### PR TITLE
ROB-983: ROB-974 R2 H5 canonical S3/S4 scorecard (CP1-CP7)

### DIFF
--- a/research/nautilus_scalping/rob974_h5_canonical.py
+++ b/research/nautilus_scalping/rob974_h5_canonical.py
@@ -1,0 +1,600 @@
+"""ROB-983 (H5, CP6) -- canonical semantic JSON and presentation-independent
+hash.
+
+JSON is the SOLE semantic source: every numeric leaf is an exact finite
+``float``/``int`` (``bool``/``Decimal``/subclass/NaN/Inf rejected, no
+string-repair casts). The one producer-approved derived-undefined field is
+per-bucket profit factor (``pf``): a zero-loss-with-profit bucket is
+mathematically ``+inf`` and a zero-loss-zero-profit bucket is ``nan`` --
+neither is valid JSON, so both are sanitized to ``null`` plus a stable
+``pf_reason`` code before they ever reach the canonical tree. Any OTHER
+non-finite float reaching the canonical validator is a bug, not a
+legitimate case, and is rejected.
+
+Every dict-shaped field sourced from CP1-CP5 (status counts, fold-keyed
+ratios, symbol/pair/exit-reason attribution, rejection histograms) is
+re-keyed into the REGISTERED domain order (``STRATEGIES``, ``FOLD_IDS``,
+``PATH_SCENARIOS``, ``S3_SYMBOLS``/``S4_PAIRS``, ``S3_EXIT_REASONS``/
+``S4_EXIT_REASONS``, ``config_ids_for``) rather than forwarded as-is --
+permuting the INPUT dict's construction order can never change the output
+bytes. ``reasons``/``incomplete_reasons`` are already alphabetically sorted
+tuples from CP1-CP5 and pass through unchanged (still a fixed, explicit
+order).
+
+Trades feeding CP6 canonicalization carry a fixture-derived chronological
+key (``fold_id``, ``config_id``, ``entry_ts``, ``exit_ts``, ``dimension``,
+``path_scenario``) -- ``actual_h4_ledger_key`` is intentionally the
+``NOT_EVALUATED`` sentinel in CP6/CP7; only CP8's actual H4 integration may
+bind it to a real ledger-derived key. A collision in the fixture
+chronological key (two trades mapping to the same key) makes ordering
+ambiguous and is rejected rather than silently tie-broken.
+
+This module never touches a clock, the filesystem, or directory iteration
+order -- it is a pure function of already-validated CP1-CP5 dataclass
+instances, so wall-clock/mtime/directory-order can never enter the hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from rob974_h5_contracts import (
+    FOLD_IDS,
+    PATH_SCENARIOS,
+    STRATEGIES,
+    CampaignEnvelope,
+    H5InputError,
+    H6AAccountingSeal,
+    MetricTrade,
+    config_ids_for,
+)
+from rob974_h5_dual_evidence import (
+    PathInvocationEvidence,
+    PboEvidence,
+    UniqueGeneratorEvidence,
+)
+from rob974_h5_gates import CommonGateResult
+from rob974_h5_s3 import S3FalsificationResult
+from rob974_h5_s4 import (
+    CampaignDecisionResult,
+    S4FalsificationResult,
+    S4PairExecutorState,
+)
+
+__all__ = [
+    "ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED",
+    "CLOSED_STATUS_ORDER",
+    "SCHEMA_VERSION",
+    "StrategyCanonicalInputs",
+    "build_canonical_scorecard",
+    "canonical_json_bytes",
+    "chronological_key",
+    "hash_canonical_bytes",
+    "sort_trades_chronologically",
+]
+
+SCHEMA_VERSION = "h5_scorecard_v1"
+ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED = "NOT_EVALUATED"
+CLOSED_STATUS_ORDER: tuple[str, ...] = ("completed", "rejected", "crashed", "timeout")
+
+_PF_REASON_INFINITE = "pf_infinite_zero_loss_with_profit"
+_PF_REASON_UNDEFINED = "pf_undefined_zero_loss_and_zero_profit"
+
+
+def _require(condition: bool, reason: str) -> None:
+    if not condition:
+        raise H5InputError(reason)
+
+
+def _exact_float(value: Any, reason: str) -> float:
+    _require(type(value) is float and math.isfinite(value), reason)
+    return value
+
+
+def _exact_int(value: Any, reason: str) -> int:
+    _require(type(value) is int, reason)
+    return value
+
+
+def _ordered_by(keys_in_order: Sequence[str], source: Mapping[str, Any]) -> dict:
+    """Rebuild ``source`` iterating ``keys_in_order`` -- a permutation of
+    ``source``'s own construction order can never change the result."""
+    return {k: source[k] for k in keys_in_order if k in source}
+
+
+def _validate_canonical_value(value: Any, path: str) -> None:
+    """Defense-in-depth recursive guard applied to raw-dict/list structures
+    this module assembles directly (attribution buckets, dual-evidence
+    entries, campaign-decision view) -- upstream CP1-CP5 dataclasses already
+    validate their own primitive fields at construction time."""
+    if value is None or type(value) is str:
+        return
+    if type(value) is bool:
+        return
+    if type(value) is int:
+        return
+    if type(value) is float:
+        _require(math.isfinite(value), f"canonical_non_finite_float_at_{path}")
+        return
+    if isinstance(value, dict):
+        for k, v in value.items():
+            _require(type(k) is str, f"canonical_non_string_key_at_{path}")
+            _validate_canonical_value(v, f"{path}.{k}")
+        return
+    if isinstance(value, list | tuple):
+        for i, v in enumerate(value):
+            _validate_canonical_value(v, f"{path}[{i}]")
+        return
+    raise H5InputError(f"canonical_unsupported_type_at_{path}:{type(value)!r}")
+
+
+def sanitize_bucket(bucket: Mapping[str, Any]) -> dict:
+    """Sanitize one attribution bucket (as produced by CP4/CP5's internal
+    ``_bucket`` helper): ``pf`` may be ``+inf``/``nan`` when a bucket has no
+    losses/no profit -- convert to ``null`` plus a stable ``pf_reason``,
+    never leaving a non-finite float in the canonical tree."""
+    trades = _exact_int(bucket["trades"], "bucket_trades_malformed")
+    e17_bps = bucket["e17_bps"]
+    e0_bps = bucket["e0_bps"]
+    pf = bucket["pf"]
+    avg_holding_minutes = bucket["avg_holding_minutes"]
+    if e17_bps is not None:
+        e17_bps = _exact_float(e17_bps, "bucket_e17_bps_malformed")
+    if e0_bps is not None:
+        e0_bps = _exact_float(e0_bps, "bucket_e0_bps_malformed")
+    if avg_holding_minutes is not None:
+        avg_holding_minutes = _exact_float(
+            avg_holding_minutes, "bucket_avg_holding_minutes_malformed"
+        )
+    pf_reason: str | None = None
+    if pf is not None:
+        _require(type(pf) is float, "bucket_pf_malformed")
+        if math.isinf(pf):
+            pf_reason = _PF_REASON_INFINITE
+            pf = None
+        elif math.isnan(pf):
+            pf_reason = _PF_REASON_UNDEFINED
+            pf = None
+    return {
+        "trades": trades,
+        "e17_bps": e17_bps,
+        "e0_bps": e0_bps,
+        "pf": pf,
+        "pf_reason": pf_reason,
+        "avg_holding_minutes": avg_holding_minutes,
+    }
+
+
+def canonicalize_by_exit_reason(
+    by_exit_reason: Mapping[str, Mapping[str, Any]], *, exit_reason_order: Sequence[str]
+) -> dict:
+    ordered = _ordered_by(exit_reason_order, by_exit_reason)
+    return {reason: sanitize_bucket(bucket) for reason, bucket in ordered.items()}
+
+
+def canonicalize_by_dimension(
+    by_dimension: Mapping[str, Mapping[str, Any]], *, dimension_order: Sequence[str]
+) -> dict:
+    ordered = _ordered_by(dimension_order, by_dimension)
+    return {dim: sanitize_bucket(bucket) for dim, bucket in ordered.items()}
+
+
+def chronological_key(trade: MetricTrade) -> tuple:
+    return (
+        trade.fold_id,
+        trade.config_id,
+        trade.entry_ts,
+        trade.exit_ts,
+        trade.dimension,
+        trade.path_scenario,
+    )
+
+
+def sort_trades_chronologically(
+    trades: tuple[MetricTrade, ...],
+) -> tuple[MetricTrade, ...]:
+    """Sort once by the fixture-derived chronological key, rejecting a
+    collision (two trades mapping to the same key) rather than silently
+    breaking the tie with an arbitrary stable-sort artifact."""
+    keys = [chronological_key(t) for t in trades]
+    _require(len(set(keys)) == len(keys), "chronological_key_collision")
+    return tuple(
+        t for _, t in sorted(zip(keys, trades, strict=True), key=lambda kt: kt[0])
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyCanonicalInputs:
+    strategy: str
+    common_gates: CommonGateResult
+    falsification: S3FalsificationResult | S4FalsificationResult
+    direct_verdict: str
+    exit_reason_order: tuple[str, ...]
+    dimension_order: tuple[str, ...]
+    unique_by_key: dict[tuple[str, str], UniqueGeneratorEvidence]
+    paths_by_key: dict[tuple[str, str, str], PathInvocationEvidence]
+    pbo: PboEvidence | None
+    pair_executor_state: S4PairExecutorState | None = None
+
+
+def _canonicalize_common_gates(gates: CommonGateResult) -> dict:
+    return {
+        "passed": gates.passed,
+        "reasons": list(gates.reasons),
+        "pooled_e17_bps": (
+            _exact_float(gates.pooled_e17_bps, "gates_pooled_e17_malformed")
+            if gates.pooled_e17_bps is not None
+            else None
+        ),
+        "pf17": (
+            None
+            if gates.pf17 is None or not math.isfinite(gates.pf17)
+            else _exact_float(gates.pf17, "gates_pf17_malformed")
+        ),
+        "pf17_reason": (
+            None
+            if gates.pf17 is None
+            else (
+                None
+                if math.isfinite(gates.pf17)
+                else (
+                    _PF_REASON_INFINITE
+                    if math.isinf(gates.pf17)
+                    else _PF_REASON_UNDEFINED
+                )
+            )
+        ),
+        "positive_fold_count": _exact_int(
+            gates.positive_fold_count, "gates_positive_fold_count_malformed"
+        ),
+        "monthly_concentration": (
+            _exact_float(gates.monthly_concentration, "gates_concentration_malformed")
+            if gates.monthly_concentration is not None
+            else None
+        ),
+        "e22_bps": (
+            _exact_float(gates.e22_bps, "gates_e22_malformed")
+            if gates.e22_bps is not None
+            else None
+        ),
+        "e0_bps": (
+            _exact_float(gates.e0_bps, "gates_e0_malformed")
+            if gates.e0_bps is not None
+            else None
+        ),
+        "observed_win_rate": (
+            _exact_float(gates.observed_win_rate, "gates_win_rate_malformed")
+            if gates.observed_win_rate is not None
+            else None
+        ),
+        "weighted_pbe": (
+            _exact_float(gates.weighted_pbe, "gates_weighted_pbe_malformed")
+            if gates.weighted_pbe is not None
+            else None
+        ),
+        "win_margin": (
+            _exact_float(gates.win_margin, "gates_win_margin_malformed")
+            if gates.win_margin is not None
+            else None
+        ),
+        "fold_trade_counts": {
+            fold_id: _exact_int(
+                gates.fold_trade_counts[fold_id], "gates_fold_trade_count_malformed"
+            )
+            for fold_id in FOLD_IDS
+            if fold_id in gates.fold_trade_counts
+        },
+    }
+
+
+def _canonicalize_s3_falsification(result: S3FalsificationResult) -> dict:
+    return {
+        "passed": result.passed,
+        "reasons": list(result.reasons),
+        "incomplete_reasons": list(result.incomplete_reasons),
+        "pooled_timeout_ratio": _exact_float(
+            result.pooled_timeout_ratio, "s3_pooled_timeout_ratio_malformed"
+        ),
+        "fold_timeout_ratios": {
+            fold_id: _exact_float(
+                result.fold_timeout_ratios[fold_id], "s3_fold_timeout_ratio_malformed"
+            )
+            for fold_id in FOLD_IDS
+            if fold_id in result.fold_timeout_ratios
+        },
+        "bullish_long_e22_bps": (
+            _exact_float(result.bullish_long_e22_bps, "s3_bullish_e22_malformed")
+            if result.bullish_long_e22_bps is not None
+            else None
+        ),
+        "first_4h_sl_dependence": (
+            _exact_float(result.first_4h_sl_dependence, "s3_sl_dependence_malformed")
+            if result.first_4h_sl_dependence is not None
+            else None
+        ),
+        "attribution": {
+            "by_exit_reason": canonicalize_by_exit_reason(
+                result.attribution["by_exit_reason"],
+                exit_reason_order=("TP", "SL", "THESIS_EXIT", "TIMEOUT"),
+            ),
+            "by_symbol": canonicalize_by_dimension(
+                result.attribution["by_symbol"],
+                dimension_order=("XRPUSDT", "DOGEUSDT", "SOLUSDT"),
+            ),
+        },
+    }
+
+
+def _canonicalize_s4_falsification(result: S4FalsificationResult) -> dict:
+    return {
+        "passed": result.passed,
+        "reasons": list(result.reasons),
+        "incomplete_reasons": list(result.incomplete_reasons),
+        "pooled_timeout_ratio": _exact_float(
+            result.pooled_timeout_ratio, "s4_pooled_timeout_ratio_malformed"
+        ),
+        "fold_timeout_ratios": {
+            fold_id: _exact_float(
+                result.fold_timeout_ratios[fold_id], "s4_fold_timeout_ratio_malformed"
+            )
+            for fold_id in FOLD_IDS
+            if fold_id in result.fold_timeout_ratios
+        },
+        "high_market_return_e22_bps": (
+            _exact_float(
+                result.high_market_return_e22_bps, "s4_high_market_return_e22_malformed"
+            )
+            if result.high_market_return_e22_bps is not None
+            else None
+        ),
+        "correlation": (
+            _exact_float(result.correlation, "s4_correlation_malformed")
+            if result.correlation is not None
+            else None
+        ),
+        "pair_concentration": (
+            _exact_float(result.pair_concentration, "s4_pair_concentration_malformed")
+            if result.pair_concentration is not None
+            else None
+        ),
+        "attribution": {
+            "by_exit_reason": canonicalize_by_exit_reason(
+                result.attribution["by_exit_reason"],
+                exit_reason_order=("TP", "SL", "MEAN_EXIT", "STALL_EXIT", "TIMEOUT"),
+            ),
+            "by_pair": canonicalize_by_dimension(
+                result.attribution["by_pair"],
+                dimension_order=("XRP-DOGE", "XRP-SOL", "DOGE-SOL"),
+            ),
+        },
+    }
+
+
+def _canonicalize_dual_evidence(
+    *,
+    strategy: str,
+    unique_by_key: Mapping[tuple[str, str], UniqueGeneratorEvidence],
+    paths_by_key: Mapping[tuple[str, str, str], PathInvocationEvidence],
+) -> list[dict]:
+    entries: list[dict] = []
+    for config_id in config_ids_for(strategy):
+        for fold_id in FOLD_IDS:
+            unique = unique_by_key.get((config_id, fold_id))
+            if unique is None:
+                continue
+            paths: list[dict] = []
+            for path_scenario in PATH_SCENARIOS:
+                path = paths_by_key.get((config_id, fold_id, path_scenario))
+                if path is None:
+                    continue
+                paths.append(
+                    {
+                        "path_scenario": path_scenario,
+                        "unique_evidence_hash": path.unique_evidence_hash,
+                        "unique_evidence_accepted_count": _exact_int(
+                            path.unique_evidence_accepted_count,
+                            "path_unique_accepted_count_malformed",
+                        ),
+                        "engine_input_hash": path.engine_input_hash,
+                        "engine_input_count": _exact_int(
+                            path.engine_input_count, "path_engine_input_count_malformed"
+                        ),
+                        "no_trade_reason_counts": {
+                            k: _exact_int(v, "path_no_trade_reason_count_malformed")
+                            for k, v in sorted(path.no_trade_reason_counts.items())
+                        },
+                        "ledger_status": path.ledger_status,
+                        "trade_count": _exact_int(
+                            path.trade_count, "path_trade_count_malformed"
+                        ),
+                        "artifact_hash": path.artifact_hash,
+                    }
+                )
+            entries.append(
+                {
+                    "config_id": config_id,
+                    "fold_id": fold_id,
+                    "accepted": _exact_int(
+                        unique.accepted, "unique_accepted_malformed"
+                    ),
+                    "rejected": _exact_int(
+                        unique.rejected, "unique_rejected_malformed"
+                    ),
+                    "accepted_input_hash": unique.accepted_input_hash,
+                    "rejection_reason_histogram": {
+                        k: _exact_int(v, "unique_rejection_histogram_value_malformed")
+                        for k, v in sorted(unique.rejection_reason_histogram.items())
+                    },
+                    "paths": paths,
+                }
+            )
+    return entries
+
+
+def _canonicalize_pbo(pbo: PboEvidence | None) -> dict | None:
+    if pbo is None:
+        return None
+    return {
+        "strategy": pbo.strategy,
+        "config_count": _exact_int(pbo.config_count, "pbo_config_count_malformed"),
+        "day_count": _exact_int(pbo.day_count, "pbo_day_count_malformed"),
+        "slices": _exact_int(pbo.slices, "pbo_slices_malformed"),
+        "scenario_name": pbo.scenario_name,
+        "value": (
+            _exact_float(pbo.value, "pbo_value_malformed")
+            if pbo.value is not None
+            else None
+        ),
+        "reason_codes": sorted(pbo.reason_codes),
+        "source_hash": pbo.source_hash,
+        "input_hash": pbo.input_hash,
+        "artifact_hash": pbo.artifact_hash,
+    }
+
+
+def _canonicalize_pair_executor_state(state: S4PairExecutorState) -> dict:
+    return {
+        "volatility_percentile": state.volatility_percentile,
+        "volatility_percentile_provenance": state.volatility_percentile_provenance,
+        "pair_executor_state": state.pair_executor_state,
+        "order_count": state.order_count,
+        "residual_count": state.residual_count,
+        "pair_exec_fail_count": state.pair_exec_fail_count,
+        "readiness": state.readiness,
+        "demo_eligible": state.demo_eligible,
+    }
+
+
+def _canonicalize_strategy(inputs: StrategyCanonicalInputs) -> dict:
+    _require(
+        inputs.strategy in STRATEGIES, "strategy_canonical_inputs_strategy_unknown"
+    )
+    if inputs.strategy == "S3":
+        falsification = _canonicalize_s3_falsification(inputs.falsification)
+    else:
+        falsification = _canonicalize_s4_falsification(inputs.falsification)
+    entry: dict[str, Any] = {
+        "common_gates": _canonicalize_common_gates(inputs.common_gates),
+        "falsification": falsification,
+        "dual_evidence": _canonicalize_dual_evidence(
+            strategy=inputs.strategy,
+            unique_by_key=inputs.unique_by_key,
+            paths_by_key=inputs.paths_by_key,
+        ),
+        "pbo": _canonicalize_pbo(inputs.pbo),
+        "direct_verdict": inputs.direct_verdict,
+    }
+    if inputs.pair_executor_state is not None:
+        entry["pair_executor_state"] = _canonicalize_pair_executor_state(
+            inputs.pair_executor_state
+        )
+    return entry
+
+
+def build_canonical_scorecard(
+    *,
+    envelope: CampaignEnvelope,
+    h6a_seal: H6AAccountingSeal,
+    envelope_ok: bool,
+    envelope_incomplete_reasons: tuple[str, ...],
+    s3_inputs: StrategyCanonicalInputs,
+    s4_inputs: StrategyCanonicalInputs,
+    campaign_decision: CampaignDecisionResult,
+) -> dict:
+    """Assemble the full canonical scorecard tree in explicit, hardcoded key
+    order. Never forwards a caller-supplied dict as-is -- every dict-shaped
+    field is rebuilt from typed sources in registered domain order, so
+    permuting how a caller constructed an upstream mapping can never change
+    the resulting bytes."""
+    lineage = {
+        "full_campaign_hash": envelope.full_campaign_hash,
+        "campaign_run_id": envelope.campaign_run_id,
+        "parent_corpus_hash": envelope.parent_corpus_hash,
+        "parent_projection_hash": envelope.parent_projection_hash,
+        "feature_contract_hash": envelope.feature_contract_hash,
+        "strategy_contract_hashes": {
+            strategy: envelope.strategy_contract_hashes[strategy]
+            for strategy in STRATEGIES
+        },
+        "h4_runner_source_hash": envelope.h4_runner_source_hash,
+        "h4_pbo_source_hash": envelope.h4_pbo_source_hash,
+        "h2_engine_source_hash": envelope.h2_engine_source_hash,
+        "h3_generator_source_hash": envelope.h3_generator_source_hash,
+        "run_schema_version": envelope.run_schema_version,
+        "generator_version": envelope.generator_version,
+        "expected_experiment_ids": list(envelope.expected_experiment_ids),
+        "h6a_trial_accounting_hash": envelope.h6a_trial_accounting_hash,
+        "actual_h4_ledger_key": ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED,
+    }
+    h6a_accounting = {
+        "expected_total": _exact_int(
+            h6a_seal.expected_total, "h6a_expected_total_malformed"
+        ),
+        "registered_total": _exact_int(
+            h6a_seal.registered_total, "h6a_registered_total_malformed"
+        ),
+        "primary_attempts": _exact_int(
+            h6a_seal.primary_attempts, "h6a_primary_attempts_malformed"
+        ),
+        "status_counts": {
+            status: _exact_int(
+                h6a_seal.status_counts[status], "h6a_status_count_malformed"
+            )
+            for status in CLOSED_STATUS_ORDER
+        },
+        "retry_attempts": _exact_int(
+            h6a_seal.retry_attempts, "h6a_retry_attempts_malformed"
+        ),
+        "accounting_complete": h6a_seal.accounting_complete,
+        "performance_usable": h6a_seal.performance_usable,
+        "trial_accounting_hash": h6a_seal.trial_accounting_hash,
+        "reason_codes": sorted(h6a_seal.reason_codes),
+    }
+    envelope_validation = {
+        "ok": envelope_ok,
+        "incomplete_reasons": sorted(envelope_incomplete_reasons),
+    }
+    strategies = {
+        "S3": _canonicalize_strategy(s3_inputs),
+        "S4": _canonicalize_strategy(s4_inputs),
+    }
+    campaign = {
+        "campaign_decision": campaign_decision.campaign_decision,
+        "s3_direct_verdict": campaign_decision.s3_direct_verdict,
+        "s4_direct_verdict": campaign_decision.s4_direct_verdict,
+        "demo_candidate": campaign_decision.demo_candidate,
+        "s4_observable_superiority": campaign_decision.s4_observable_superiority,
+    }
+    scorecard = {
+        "schema_version": SCHEMA_VERSION,
+        "lineage": lineage,
+        "h6a_accounting": h6a_accounting,
+        "envelope_validation": envelope_validation,
+        "strategies": strategies,
+        "campaign_decision": campaign,
+    }
+    _validate_canonical_value(scorecard, "scorecard")
+    return scorecard
+
+
+def canonical_json_bytes(scorecard: Mapping[str, Any]) -> bytes:
+    """Deterministic, presentation-independent byte encoding: fixed key
+    order (as already assembled by ``build_canonical_scorecard``), compact
+    separators, ``allow_nan=False`` (a raw NaN/Inf slipping through raises
+    rather than silently producing non-portable JSON)."""
+    return json.dumps(
+        scorecard,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def hash_canonical_bytes(canonical_bytes: bytes) -> str:
+    return hashlib.sha256(canonical_bytes).hexdigest()

--- a/research/nautilus_scalping/rob974_h5_canonical.py
+++ b/research/nautilus_scalping/rob974_h5_canonical.py
@@ -48,10 +48,12 @@ from rob974_h5_contracts import (
     PATH_SCENARIOS,
     STRATEGIES,
     CampaignEnvelope,
+    EnvelopeValidationResult,
     H5InputError,
     H6AAccountingSeal,
     MetricTrade,
     config_ids_for,
+    validate_envelope_and_accounting,
 )
 from rob974_h5_dual_evidence import (
     PathInvocationEvidence,
@@ -64,6 +66,8 @@ from rob974_h5_s4 import (
     CampaignDecisionResult,
     S4FalsificationResult,
     S4PairExecutorState,
+    StrategyRankMetrics,
+    compute_campaign_decision,
     compute_direct_verdict,
 )
 
@@ -71,12 +75,14 @@ __all__ = [
     "ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED",
     "CLOSED_STATUS_ORDER",
     "SCHEMA_VERSION",
+    "ScorecardConsistencyResult",
     "StrategyCanonicalInputs",
     "build_canonical_scorecard",
     "canonical_json_bytes",
     "chronological_key",
     "hash_canonical_bytes",
     "sort_trades_chronologically",
+    "validate_scorecard_consistency",
 ]
 
 SCHEMA_VERSION = "h5_scorecard_v1"
@@ -223,6 +229,224 @@ class StrategyCanonicalInputs:
     pair_executor_state: S4PairExecutorState | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class ScorecardConsistencyResult:
+    """All derived authorities recomputed at the canonical choke point."""
+
+    envelope_validation: EnvelopeValidationResult
+    s3_direct_verdict: str
+    s4_direct_verdict: str
+    campaign_decision: CampaignDecisionResult
+
+
+def _validate_reasons_and_passed(
+    *,
+    authority: str,
+    passed: Any,
+    reasons: Any,
+    incomplete_reasons: Any | None = None,
+) -> None:
+    _require(type(passed) is bool, f"canonical_{authority}_passed_not_bool")
+    _require(
+        type(reasons) is tuple and all(type(reason) is str for reason in reasons),
+        f"canonical_{authority}_reasons_malformed",
+    )
+    _require(
+        reasons == tuple(sorted(set(reasons))),
+        f"canonical_{authority}_reasons_not_canonical",
+    )
+    _require(
+        passed is (not reasons),
+        f"canonical_{authority}_passed_reasons_mismatch",
+    )
+    if incomplete_reasons is not None:
+        _require(
+            type(incomplete_reasons) is tuple
+            and all(type(reason) is str for reason in incomplete_reasons),
+            f"canonical_{authority}_incomplete_reasons_malformed",
+        )
+        _require(
+            incomplete_reasons == tuple(sorted(set(incomplete_reasons))),
+            f"canonical_{authority}_incomplete_reasons_not_canonical",
+        )
+
+
+def _rank_metrics_from_strategy_inputs(
+    inputs: StrategyCanonicalInputs,
+) -> StrategyRankMetrics:
+    gates = inputs.common_gates
+    falsification = inputs.falsification
+    _require(
+        gates.pooled_e17_bps is not None,
+        f"canonical_{inputs.strategy.lower()}_rank_pooled_e17_missing",
+    )
+    pooled_e17 = _exact_float(
+        gates.pooled_e17_bps,
+        f"canonical_{inputs.strategy.lower()}_rank_pooled_e17_malformed",
+    )
+    _require(
+        gates.monthly_concentration is not None,
+        f"canonical_{inputs.strategy.lower()}_rank_concentration_missing",
+    )
+    concentration = _exact_float(
+        gates.monthly_concentration,
+        f"canonical_{inputs.strategy.lower()}_rank_concentration_malformed",
+    )
+    _require(
+        set(gates.fold_e17_bps) == set(FOLD_IDS),
+        f"canonical_{inputs.strategy.lower()}_rank_fold_domain_mismatch",
+    )
+    fold_values: list[float] = []
+    for fold_id in FOLD_IDS:
+        value = gates.fold_e17_bps[fold_id]
+        _require(
+            value is not None,
+            f"canonical_{inputs.strategy.lower()}_rank_fold_e17_missing",
+        )
+        fold_values.append(
+            _exact_float(
+                value,
+                f"canonical_{inputs.strategy.lower()}_rank_fold_e17_malformed",
+            )
+        )
+    timeout_ratio = _exact_float(
+        falsification.pooled_timeout_ratio,
+        f"canonical_{inputs.strategy.lower()}_rank_timeout_malformed",
+    )
+    return StrategyRankMetrics(
+        min_fold_e17=min(fold_values),
+        pooled_e17=pooled_e17,
+        monthly_concentration=concentration,
+        timeout_ratio=timeout_ratio,
+    )
+
+
+def validate_scorecard_consistency(
+    *,
+    envelope: CampaignEnvelope,
+    h6a_seal: H6AAccountingSeal,
+    envelope_ok: bool,
+    envelope_incomplete_reasons: tuple[str, ...],
+    s3_inputs: StrategyCanonicalInputs,
+    s4_inputs: StrategyCanonicalInputs,
+    campaign_decision: CampaignDecisionResult,
+) -> ScorecardConsistencyResult:
+    """Recompute and cross-check every derived scorecard authority once.
+
+    This is the only gate immediately before canonical assembly.  A caller
+    may transport precomputed DTOs, but none of their derived labels is
+    trusted: seal -> envelope, reasons -> ``passed``/direct verdict, and
+    direct verdicts + rank evidence -> the complete campaign result are all
+    recomputed here.  Any contradiction raises instead of reaching JSON or
+    Markdown.
+    """
+    _require(type(envelope_ok) is bool, "canonical_envelope_validation_ok_not_bool")
+    _require(
+        type(envelope_incomplete_reasons) is tuple
+        and all(type(reason) is str for reason in envelope_incomplete_reasons),
+        "canonical_envelope_validation_reasons_malformed",
+    )
+    recomputed_envelope = validate_envelope_and_accounting(envelope, h6a_seal)
+    _require(
+        envelope_ok == recomputed_envelope.ok
+        and envelope_incomplete_reasons == recomputed_envelope.incomplete_reasons,
+        "canonical_envelope_validation_forged_or_stale",
+    )
+
+    _require(
+        type(s3_inputs) is StrategyCanonicalInputs and s3_inputs.strategy == "S3",
+        "canonical_s3_inputs_strategy_mismatch",
+    )
+    _require(
+        type(s4_inputs) is StrategyCanonicalInputs and s4_inputs.strategy == "S4",
+        "canonical_s4_inputs_strategy_mismatch",
+    )
+    _require(
+        type(s3_inputs.common_gates) is CommonGateResult,
+        "canonical_s3_common_gates_type_mismatch",
+    )
+    _require(
+        type(s4_inputs.common_gates) is CommonGateResult,
+        "canonical_s4_common_gates_type_mismatch",
+    )
+    _require(
+        type(s3_inputs.falsification) is S3FalsificationResult,
+        "canonical_s3_falsification_type_mismatch",
+    )
+    _require(
+        type(s4_inputs.falsification) is S4FalsificationResult,
+        "canonical_s4_falsification_type_mismatch",
+    )
+
+    _validate_reasons_and_passed(
+        authority="s3_common_gates",
+        passed=s3_inputs.common_gates.passed,
+        reasons=s3_inputs.common_gates.reasons,
+    )
+    _validate_reasons_and_passed(
+        authority="s4_common_gates",
+        passed=s4_inputs.common_gates.passed,
+        reasons=s4_inputs.common_gates.reasons,
+    )
+    _validate_reasons_and_passed(
+        authority="s3_falsification",
+        passed=s3_inputs.falsification.passed,
+        reasons=s3_inputs.falsification.reasons,
+        incomplete_reasons=s3_inputs.falsification.incomplete_reasons,
+    )
+    _validate_reasons_and_passed(
+        authority="s4_falsification",
+        passed=s4_inputs.falsification.passed,
+        reasons=s4_inputs.falsification.reasons,
+        incomplete_reasons=s4_inputs.falsification.incomplete_reasons,
+    )
+
+    recomputed_s3_verdict = compute_direct_verdict(
+        incomplete_reasons=s3_inputs.falsification.incomplete_reasons,
+        hard_gate_reasons=s3_inputs.common_gates.reasons
+        + s3_inputs.falsification.reasons,
+    )
+    _require(
+        recomputed_s3_verdict == s3_inputs.direct_verdict,
+        "canonical_s3_direct_verdict_forged_or_stale",
+    )
+    recomputed_s4_verdict = compute_direct_verdict(
+        incomplete_reasons=s4_inputs.falsification.incomplete_reasons,
+        hard_gate_reasons=s4_inputs.common_gates.reasons
+        + s4_inputs.falsification.reasons,
+    )
+    _require(
+        recomputed_s4_verdict == s4_inputs.direct_verdict,
+        "canonical_s4_direct_verdict_forged_or_stale",
+    )
+
+    campaign_kwargs: dict[str, Any] = {}
+    if (
+        recomputed_s3_verdict == "historical_pass"
+        and recomputed_s4_verdict == "historical_pass"
+    ):
+        campaign_kwargs = {
+            "s3_rank_metrics": _rank_metrics_from_strategy_inputs(s3_inputs),
+            "s4_rank_metrics": _rank_metrics_from_strategy_inputs(s4_inputs),
+        }
+    recomputed_campaign = compute_campaign_decision(
+        s3_direct_verdict=recomputed_s3_verdict,
+        s4_direct_verdict=recomputed_s4_verdict,
+        **campaign_kwargs,
+    )
+    _require(
+        type(campaign_decision) is CampaignDecisionResult
+        and campaign_decision == recomputed_campaign,
+        "canonical_campaign_decision_forged_or_stale",
+    )
+    return ScorecardConsistencyResult(
+        envelope_validation=recomputed_envelope,
+        s3_direct_verdict=recomputed_s3_verdict,
+        s4_direct_verdict=recomputed_s4_verdict,
+        campaign_decision=recomputed_campaign,
+    )
+
+
 def _canonicalize_common_gates(gates: CommonGateResult) -> dict:
     return {
         "passed": gates.passed,
@@ -289,6 +513,15 @@ def _canonicalize_common_gates(gates: CommonGateResult) -> dict:
             )
             for fold_id in FOLD_IDS
             if fold_id in gates.fold_trade_counts
+        },
+        "fold_e17_bps": {
+            fold_id: (
+                _exact_float(gates.fold_e17_bps[fold_id], "gates_fold_e17_malformed")
+                if gates.fold_e17_bps[fold_id] is not None
+                else None
+            )
+            for fold_id in FOLD_IDS
+            if fold_id in gates.fold_e17_bps
         },
     }
 
@@ -471,7 +704,9 @@ def _canonicalize_pair_executor_state(state: S4PairExecutorState) -> dict:
     }
 
 
-def _canonicalize_strategy(inputs: StrategyCanonicalInputs) -> dict:
+def _canonicalize_strategy(
+    inputs: StrategyCanonicalInputs, *, direct_verdict: str
+) -> dict:
     _require(
         inputs.strategy in STRATEGIES, "strategy_canonical_inputs_strategy_unknown"
     )
@@ -488,7 +723,7 @@ def _canonicalize_strategy(inputs: StrategyCanonicalInputs) -> dict:
             paths_by_key=inputs.paths_by_key,
         ),
         "pbo": _canonicalize_pbo(inputs.pbo),
-        "direct_verdict": inputs.direct_verdict,
+        "direct_verdict": direct_verdict,
     }
     if inputs.pair_executor_state is not None:
         entry["pair_executor_state"] = _canonicalize_pair_executor_state(
@@ -513,37 +748,18 @@ def build_canonical_scorecard(
     permuting how a caller constructed an upstream mapping can never change
     the resulting bytes.
 
-    D13 fix (adversarial verify R1, finding 4): each strategy's
-    ``direct_verdict`` and the campaign decision's embedded verdicts are
-    RECOMPUTED here from the actual ``common_gates``/``falsification``
-    results and compared against the caller-supplied values -- a forged or
-    stale verdict (e.g. "historical_pass" alongside a failing/incomplete
-    gate result) is rejected rather than silently canonicalized."""
-    recomputed_s3_verdict = compute_direct_verdict(
-        incomplete_reasons=s3_inputs.falsification.incomplete_reasons,
-        hard_gate_reasons=s3_inputs.common_gates.reasons
-        + s3_inputs.falsification.reasons,
-    )
-    _require(
-        recomputed_s3_verdict == s3_inputs.direct_verdict,
-        "canonical_s3_direct_verdict_forged_or_stale",
-    )
-    recomputed_s4_verdict = compute_direct_verdict(
-        incomplete_reasons=s4_inputs.falsification.incomplete_reasons,
-        hard_gate_reasons=s4_inputs.common_gates.reasons
-        + s4_inputs.falsification.reasons,
-    )
-    _require(
-        recomputed_s4_verdict == s4_inputs.direct_verdict,
-        "canonical_s4_direct_verdict_forged_or_stale",
-    )
-    _require(
-        campaign_decision.s3_direct_verdict == recomputed_s3_verdict,
-        "canonical_campaign_decision_s3_verdict_mismatch",
-    )
-    _require(
-        campaign_decision.s4_direct_verdict == recomputed_s4_verdict,
-        "canonical_campaign_decision_s4_verdict_mismatch",
+    R3 consistency authority: immediately before any canonical subtree is
+    assembled, recompute and compare seal/envelope, gate flags, direct
+    verdicts, both-pass rank/superiority, and every campaign field.  Only
+    the recomputed values returned here are written below."""
+    consistency = validate_scorecard_consistency(
+        envelope=envelope,
+        h6a_seal=h6a_seal,
+        envelope_ok=envelope_ok,
+        envelope_incomplete_reasons=envelope_incomplete_reasons,
+        s3_inputs=s3_inputs,
+        s4_inputs=s4_inputs,
+        campaign_decision=campaign_decision,
     )
 
     lineage = {
@@ -591,21 +807,26 @@ def build_canonical_scorecard(
         "reason_codes": sorted(h6a_seal.reason_codes),
     }
     envelope_validation = {
-        "ok": envelope_ok,
-        "incomplete_reasons": sorted(envelope_incomplete_reasons),
+        "ok": consistency.envelope_validation.ok,
+        "incomplete_reasons": list(consistency.envelope_validation.incomplete_reasons),
     }
     strategies = {
-        "S3": _canonicalize_strategy(s3_inputs),
-        "S4": _canonicalize_strategy(s4_inputs),
+        "S3": _canonicalize_strategy(
+            s3_inputs, direct_verdict=consistency.s3_direct_verdict
+        ),
+        "S4": _canonicalize_strategy(
+            s4_inputs, direct_verdict=consistency.s4_direct_verdict
+        ),
     }
+    canonical_campaign = consistency.campaign_decision
     campaign = {
-        "campaign_decision": campaign_decision.campaign_decision,
-        "campaign_historical_verdict": campaign_decision.campaign_historical_verdict,
-        "s3_direct_verdict": campaign_decision.s3_direct_verdict,
-        "s4_direct_verdict": campaign_decision.s4_direct_verdict,
-        "demo_candidate": campaign_decision.demo_candidate,
-        "historical_preferred": campaign_decision.historical_preferred,
-        "s4_observable_superiority": campaign_decision.s4_observable_superiority,
+        "campaign_decision": canonical_campaign.campaign_decision,
+        "campaign_historical_verdict": canonical_campaign.campaign_historical_verdict,
+        "s3_direct_verdict": canonical_campaign.s3_direct_verdict,
+        "s4_direct_verdict": canonical_campaign.s4_direct_verdict,
+        "demo_candidate": canonical_campaign.demo_candidate,
+        "historical_preferred": canonical_campaign.historical_preferred,
+        "s4_observable_superiority": canonical_campaign.s4_observable_superiority,
     }
     scorecard = {
         "schema_version": SCHEMA_VERSION,

--- a/research/nautilus_scalping/rob974_h5_canonical.py
+++ b/research/nautilus_scalping/rob974_h5_canonical.py
@@ -64,6 +64,7 @@ from rob974_h5_s4 import (
     CampaignDecisionResult,
     S4FalsificationResult,
     S4PairExecutorState,
+    compute_direct_verdict,
 )
 
 __all__ = [
@@ -510,7 +511,41 @@ def build_canonical_scorecard(
     order. Never forwards a caller-supplied dict as-is -- every dict-shaped
     field is rebuilt from typed sources in registered domain order, so
     permuting how a caller constructed an upstream mapping can never change
-    the resulting bytes."""
+    the resulting bytes.
+
+    D13 fix (adversarial verify R1, finding 4): each strategy's
+    ``direct_verdict`` and the campaign decision's embedded verdicts are
+    RECOMPUTED here from the actual ``common_gates``/``falsification``
+    results and compared against the caller-supplied values -- a forged or
+    stale verdict (e.g. "historical_pass" alongside a failing/incomplete
+    gate result) is rejected rather than silently canonicalized."""
+    recomputed_s3_verdict = compute_direct_verdict(
+        incomplete_reasons=s3_inputs.falsification.incomplete_reasons,
+        hard_gate_reasons=s3_inputs.common_gates.reasons
+        + s3_inputs.falsification.reasons,
+    )
+    _require(
+        recomputed_s3_verdict == s3_inputs.direct_verdict,
+        "canonical_s3_direct_verdict_forged_or_stale",
+    )
+    recomputed_s4_verdict = compute_direct_verdict(
+        incomplete_reasons=s4_inputs.falsification.incomplete_reasons,
+        hard_gate_reasons=s4_inputs.common_gates.reasons
+        + s4_inputs.falsification.reasons,
+    )
+    _require(
+        recomputed_s4_verdict == s4_inputs.direct_verdict,
+        "canonical_s4_direct_verdict_forged_or_stale",
+    )
+    _require(
+        campaign_decision.s3_direct_verdict == recomputed_s3_verdict,
+        "canonical_campaign_decision_s3_verdict_mismatch",
+    )
+    _require(
+        campaign_decision.s4_direct_verdict == recomputed_s4_verdict,
+        "canonical_campaign_decision_s4_verdict_mismatch",
+    )
+
     lineage = {
         "full_campaign_hash": envelope.full_campaign_hash,
         "campaign_run_id": envelope.campaign_run_id,
@@ -565,9 +600,11 @@ def build_canonical_scorecard(
     }
     campaign = {
         "campaign_decision": campaign_decision.campaign_decision,
+        "campaign_historical_verdict": campaign_decision.campaign_historical_verdict,
         "s3_direct_verdict": campaign_decision.s3_direct_verdict,
         "s4_direct_verdict": campaign_decision.s4_direct_verdict,
         "demo_candidate": campaign_decision.demo_candidate,
+        "historical_preferred": campaign_decision.historical_preferred,
         "s4_observable_superiority": campaign_decision.s4_observable_superiority,
     }
     scorecard = {

--- a/research/nautilus_scalping/rob974_h5_contracts.py
+++ b/research/nautilus_scalping/rob974_h5_contracts.py
@@ -1,0 +1,381 @@
+"""ROB-983 (H5, CP1) -- exact input domain, envelope verification, and the
+H6-A exact-48 accounting gate.
+
+H5 is a pure consumer: it never opens a DB session, never reimplements H6-A's
+trial-accounting reconstruction, and never scores a subset when H6-A's seal
+is anything less than the full, exact-48, retry-0, ``performance_usable``
+report. Any AC34 provenance violation (missing/future/lookahead bar,
+signal-close fill, unpriced gap trade, double-charged basket cost, single-leg
+notional denominator, a fabricated atomic fill/flatten price, a nonfinite or
+type-invalid required value, or missing PBO/accounting/evidence) is always
+``incomplete`` -- never ``historical_fail``, regardless of how profitable the
+reported economics look.
+
+Strategy: every constant/type here is exact and closed. ``type(x) is float``/
+``type(x) is int`` (never ``isinstance``) reject ``bool``/``Decimal``/
+subclass masquerade, mirroring the ROB-945/946 pattern (``bool`` is an
+``int`` subclass in Python -- ``isinstance(True, int)`` is ``True`` but
+``type(True) is int`` is ``False``).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "CONFIGS_PER_STRATEGY",
+    "FOLD_IDS",
+    "PATH_SCENARIOS",
+    "S3_EXIT_REASONS",
+    "S3_SYMBOLS",
+    "S4_EXIT_REASONS",
+    "S4_PAIRS",
+    "STRATEGIES",
+    "STRUCTURAL_INCOMPLETE_REASONS",
+    "CampaignEnvelope",
+    "EnvelopeValidationResult",
+    "H5InputError",
+    "H6AAccountingSeal",
+    "MetricTrade",
+    "classify_provenance_violation",
+    "config_ids_for",
+    "validate_envelope_and_accounting",
+]
+
+# ---------------------------------------------------------------------------
+# Exact, closed input domain (H5 spec AC1-3).
+# ---------------------------------------------------------------------------
+
+STRATEGIES: tuple[str, ...] = ("S3", "S4")
+CONFIGS_PER_STRATEGY = 24
+FOLD_IDS: tuple[str, ...] = tuple(f"fold-{i:02d}" for i in range(8))
+PATH_SCENARIOS: tuple[str, ...] = ("base13", "primary_stress17", "upward_stress22")
+S3_SYMBOLS: tuple[str, ...] = ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
+S4_PAIRS: tuple[str, ...] = ("XRP-DOGE", "XRP-SOL", "DOGE-SOL")
+S3_EXIT_REASONS: tuple[str, ...] = ("TP", "SL", "THESIS_EXIT", "TIMEOUT")
+S4_EXIT_REASONS: tuple[str, ...] = ("TP", "SL", "MEAN_EXIT", "STALL_EXIT", "TIMEOUT")
+
+_EXPECTED_TOTAL_EXPERIMENTS = 48
+_CLOSED_STATUSES = ("completed", "rejected", "crashed", "timeout")
+_LOWERCASE_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class H5InputError(ValueError):
+    """A sealed H5 input failed a fail-closed boundary check."""
+
+
+def _require(condition: bool, reason: str) -> None:
+    if not condition:
+        raise H5InputError(reason)
+
+
+def _require_hex64(value: Any, reason: str) -> str:
+    _require(isinstance(value, str) and bool(_LOWERCASE_HEX_64.match(value)), reason)
+    return value
+
+
+def _require_exact_int(value: Any, reason: str, *, min_value: int = 0) -> int:
+    _require(type(value) is int and value >= min_value, reason)
+    return value
+
+
+def _require_exact_float(value: Any, reason: str) -> float:
+    _require(type(value) is float and math.isfinite(value), reason)
+    return value
+
+
+def config_ids_for(strategy: str) -> tuple[str, ...]:
+    _require(strategy in STRATEGIES, "unknown_strategy")
+    return tuple(f"{strategy}-{i:02d}" for i in range(CONFIGS_PER_STRATEGY))
+
+
+_CANONICAL_EXPERIMENT_IDS: tuple[str, ...] = tuple(
+    cid for strategy in STRATEGIES for cid in config_ids_for(strategy)
+)
+
+# ---------------------------------------------------------------------------
+# AC34 structural-incomplete provenance violations. Closed set; classifying
+# an unknown code raises rather than silently accepting/ignoring it.
+# ---------------------------------------------------------------------------
+
+STRUCTURAL_INCOMPLETE_REASONS: frozenset[str] = frozenset(
+    {
+        "missing_bar",
+        "future_bar",
+        "incomplete_bar",
+        "lookahead_bar",
+        "signal_close_fill",
+        "unpriced_gap_trade",
+        "basket_cost_double_charge",
+        "single_leg_notional_denominator",
+        "fabricated_atomic_fill_price",
+        "fabricated_flatten_price",
+        "nonfinite_required_value",
+        "type_invalid_required_value",
+        "missing_pbo_evidence",
+        "missing_accounting_evidence",
+        "missing_evidence",
+    }
+)
+
+
+def classify_provenance_violation(violation: str) -> str:
+    """A pure function of the violation code alone: every registered AC34
+    violation classifies as ``"incomplete"``, never ``"historical_fail"`` --
+    no caller-supplied economics can change this."""
+    _require(violation in STRUCTURAL_INCOMPLETE_REASONS, "unknown_provenance_violation")
+    return "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# Campaign envelope (full campaign / lineage verification, AC4).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CampaignEnvelope:
+    full_campaign_hash: str
+    campaign_run_id: str
+    parent_corpus_hash: str
+    parent_projection_hash: str
+    feature_contract_hash: str
+    strategy_contract_hashes: dict[str, str]
+    h4_runner_source_hash: str
+    h4_pbo_source_hash: str
+    h2_engine_source_hash: str
+    h3_generator_source_hash: str
+    run_schema_version: str
+    generator_version: str
+    expected_experiment_ids: tuple[str, ...]
+    h6a_trial_accounting_hash: str
+
+    def __post_init__(self) -> None:
+        for hash_field in (
+            self.full_campaign_hash,
+            self.parent_corpus_hash,
+            self.parent_projection_hash,
+            self.feature_contract_hash,
+            self.h4_runner_source_hash,
+            self.h4_pbo_source_hash,
+            self.h2_engine_source_hash,
+            self.h3_generator_source_hash,
+            self.h6a_trial_accounting_hash,
+        ):
+            _require_hex64(hash_field, "envelope_hash_not_lowercase_64_hex")
+
+        _require(
+            set(self.strategy_contract_hashes.keys()) == set(STRATEGIES),
+            "envelope_strategy_contract_hash_keys_mismatch",
+        )
+        for value in self.strategy_contract_hashes.values():
+            _require_hex64(value, "envelope_strategy_contract_hash_not_hex64")
+
+        _require(
+            isinstance(self.run_schema_version, str) and self.run_schema_version != "",
+            "envelope_run_schema_version_malformed",
+        )
+        _require(
+            isinstance(self.generator_version, str) and self.generator_version != "",
+            "envelope_generator_version_malformed",
+        )
+
+        ids = self.expected_experiment_ids
+        _require(
+            isinstance(ids, tuple) and all(isinstance(i, str) for i in ids),
+            "envelope_expected_experiment_ids_malformed",
+        )
+        _require(
+            len(ids) == _EXPECTED_TOTAL_EXPERIMENTS,
+            "envelope_expected_experiment_ids_count_not_48",
+        )
+        _require(
+            len(set(ids)) == _EXPECTED_TOTAL_EXPERIMENTS,
+            "envelope_expected_experiment_ids_has_duplicate",
+        )
+        _require(
+            ids == _CANONICAL_EXPERIMENT_IDS,
+            "envelope_expected_experiment_ids_not_canonical_order",
+        )
+
+
+# ---------------------------------------------------------------------------
+# H6-A exact-48 accounting seal (AC5).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class H6AAccountingSeal:
+    expected_total: int
+    registered_total: int
+    primary_attempts: int
+    status_counts: dict[str, int]
+    retry_attempts: int
+    accounting_complete: bool
+    performance_usable: bool
+    trial_accounting_hash: str
+    reason_codes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require(
+            self.expected_total == _EXPECTED_TOTAL_EXPERIMENTS,
+            "h6a_expected_total_not_48",
+        )
+        _require_exact_int(self.registered_total, "h6a_registered_total_malformed")
+        _require_exact_int(self.primary_attempts, "h6a_primary_attempts_malformed")
+        _require_exact_int(self.retry_attempts, "h6a_retry_attempts_malformed")
+        _require(
+            set(self.status_counts.keys()) == set(_CLOSED_STATUSES),
+            "h6a_status_counts_keys_malformed",
+        )
+        for count in self.status_counts.values():
+            _require_exact_int(count, "h6a_status_count_value_malformed")
+        status_sum = sum(self.status_counts.values())
+        _require(status_sum <= _EXPECTED_TOTAL_EXPERIMENTS, "h6a_status_sum_exceeds_48")
+        # A NORMAL, accounting-complete primary run always tallies exactly
+        # 48 across the four closed statuses (a hidden/missing row can never
+        # sit "under" a status_sum of 48 while claiming completeness). A
+        # genuinely incomplete run (e.g. one config never registered/
+        # attempted at all) may report fewer than 48 -- that gap is exactly
+        # what makes it incomplete.
+        if self.accounting_complete:
+            _require(status_sum == _EXPECTED_TOTAL_EXPERIMENTS, "h6a_status_sum_not_48")
+        _require(
+            self.registered_total <= _EXPECTED_TOTAL_EXPERIMENTS
+            or not self.accounting_complete,
+            "h6a_registered_total_exceeds_48_but_claims_complete",
+        )
+        _require_hex64(
+            self.trial_accounting_hash, "h6a_trial_accounting_hash_malformed"
+        )
+        _require(
+            type(self.accounting_complete) is bool, "h6a_accounting_complete_not_bool"
+        )
+        _require(
+            type(self.performance_usable) is bool, "h6a_performance_usable_not_bool"
+        )
+        _require(
+            isinstance(self.reason_codes, tuple)
+            and all(isinstance(r, str) for r in self.reason_codes),
+            "h6a_reason_codes_malformed",
+        )
+        # performance_usable=True requires exact-48/retry-0/all-completed --
+        # a caller cannot claim usable=true while the underlying counters
+        # disagree (this alone rejects the "complete=true with usable=false
+        # allowed, but usable=true with bad counters" asymmetric mutant).
+        exact_48_all_completed = (
+            self.registered_total == _EXPECTED_TOTAL_EXPERIMENTS
+            and self.primary_attempts == _EXPECTED_TOTAL_EXPERIMENTS
+            and self.status_counts.get("completed") == _EXPECTED_TOTAL_EXPERIMENTS
+            and self.retry_attempts == 0
+            and self.accounting_complete
+        )
+        if self.performance_usable:
+            _require(exact_48_all_completed, "h6a_usable_true_with_incomplete_counters")
+
+
+@dataclass(frozen=True, slots=True)
+class EnvelopeValidationResult:
+    ok: bool
+    incomplete_reasons: tuple[str, ...]
+
+
+def validate_envelope_and_accounting(
+    envelope: CampaignEnvelope, seal: H6AAccountingSeal
+) -> EnvelopeValidationResult:
+    """Cross-check the envelope's H6-A hash pin against the sealed report and
+    gate on H6-A's ``performance_usable`` flag. Never defaults metrics or
+    scores a subset -- anything short of exact-48/retry-0/complete/usable
+    makes the campaign structurally ``incomplete``."""
+    _require(
+        envelope.h6a_trial_accounting_hash == seal.trial_accounting_hash,
+        "envelope_h6a_hash_does_not_match_sealed_report",
+    )
+    if seal.performance_usable:
+        return EnvelopeValidationResult(ok=True, incomplete_reasons=())
+    reasons = seal.reason_codes if seal.reason_codes else ("h6_accounting_incomplete",)
+    return EnvelopeValidationResult(ok=False, incomplete_reasons=tuple(sorted(reasons)))
+
+
+# ---------------------------------------------------------------------------
+# MetricTrade -- the one metric-trade unit (AC2): S3 = one global
+# single-position round trip; S4 = one two-leg pair-basket round trip. There
+# is deliberately no "leg" field anywhere on this type -- leg count can never
+# be summed into a trade/PF/expectancy/win-rate denominator because no such
+# field exists to sum.
+# ---------------------------------------------------------------------------
+
+_S3_DIMENSION_SET = frozenset(S3_SYMBOLS)
+_S4_DIMENSION_SET = frozenset(S4_PAIRS)
+
+
+@dataclass(frozen=True, slots=True)
+class MetricTrade:
+    strategy: str
+    config_id: str
+    fold_id: str
+    path_scenario: str
+    dimension: str  # S3 symbol or S4 pair label -- never a per-leg split
+    direction: str
+    entry_ts: int
+    exit_ts: int
+    holding_minutes: float
+    exit_reason: str
+    gross_bps: float
+    net_bps: float
+    tp_bps: float
+    sl_bps: float
+    gross_notional: float | None
+    market_return_4h: float | None
+    volatility_percentile: float | None
+
+    def __post_init__(self) -> None:
+        _require(self.strategy in STRATEGIES, "trade_strategy_unknown")
+        _require(
+            self.config_id in config_ids_for(self.strategy), "trade_config_id_unknown"
+        )
+        _require(self.fold_id in FOLD_IDS, "trade_fold_id_unknown")
+        _require(self.path_scenario in PATH_SCENARIOS, "trade_path_scenario_unknown")
+
+        if self.strategy == "S3":
+            _require(self.dimension in _S3_DIMENSION_SET, "trade_s3_dimension_unknown")
+            _require(
+                self.exit_reason in S3_EXIT_REASONS, "trade_s3_exit_reason_unknown"
+            )
+            _require(
+                self.gross_notional is None, "trade_s3_gross_notional_must_be_none"
+            )
+            if self.volatility_percentile is not None:
+                _require_exact_float(
+                    self.volatility_percentile, "trade_volatility_percentile_malformed"
+                )
+        else:
+            _require(self.dimension in _S4_DIMENSION_SET, "trade_s4_dimension_unknown")
+            _require(
+                self.exit_reason in S4_EXIT_REASONS, "trade_s4_exit_reason_unknown"
+            )
+            _require(
+                self.volatility_percentile is None,
+                "trade_s4_volatility_percentile_must_be_none",
+            )
+            if self.gross_notional is not None:
+                _require_exact_float(
+                    self.gross_notional, "trade_gross_notional_malformed"
+                )
+                _require(self.gross_notional > 0, "trade_gross_notional_not_positive")
+
+        _require_exact_int(self.entry_ts, "trade_entry_ts_malformed")
+        _require_exact_int(self.exit_ts, "trade_exit_ts_malformed")
+        _require(self.exit_ts >= self.entry_ts, "trade_exit_before_entry")
+        _require_exact_float(self.holding_minutes, "trade_holding_minutes_malformed")
+        _require(self.holding_minutes >= 0, "trade_holding_minutes_negative")
+        _require_exact_float(self.gross_bps, "trade_gross_bps_malformed")
+        _require_exact_float(self.net_bps, "trade_net_bps_malformed")
+        _require_exact_float(self.tp_bps, "trade_tp_bps_malformed")
+        _require_exact_float(self.sl_bps, "trade_sl_bps_malformed")
+        _require(self.tp_bps > 0, "trade_tp_bps_not_positive")
+        _require(self.sl_bps > 0, "trade_sl_bps_not_positive")
+        if self.market_return_4h is not None:
+            _require_exact_float(self.market_return_4h, "trade_market_return_malformed")

--- a/research/nautilus_scalping/rob974_h5_contracts.py
+++ b/research/nautilus_scalping/rob974_h5_contracts.py
@@ -219,6 +219,10 @@ class H6AAccountingSeal:
     reason_codes: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
+        # Fix (adversarial verify R1, finding 7): exact-int type check, not
+        # `==48` alone -- `Decimal(48)==48` and `48.0==48` are both True in
+        # Python, so equality alone let a non-int type slip past.
+        _require_exact_int(self.expected_total, "h6a_expected_total_malformed")
         _require(
             self.expected_total == _EXPECTED_TOTAL_EXPERIMENTS,
             "h6a_expected_total_not_48",
@@ -360,11 +364,15 @@ class MetricTrade:
                 self.volatility_percentile is None,
                 "trade_s4_volatility_percentile_must_be_none",
             )
-            if self.gross_notional is not None:
-                _require_exact_float(
-                    self.gross_notional, "trade_gross_notional_malformed"
-                )
-                _require(self.gross_notional > 0, "trade_gross_notional_not_positive")
+            # D12 fix (adversarial verify R1, finding 2): S4's gross basket
+            # notional G is REQUIRED (never None) -- a missing/None G must
+            # never silently fall back to S3's equal-weight (1.0)
+            # convention downstream in pBE/win-margin weighting.
+            _require(
+                self.gross_notional is not None, "trade_s4_gross_notional_required"
+            )
+            _require_exact_float(self.gross_notional, "trade_gross_notional_malformed")
+            _require(self.gross_notional > 0, "trade_gross_notional_not_positive")
 
         _require_exact_int(self.entry_ts, "trade_entry_ts_malformed")
         _require_exact_int(self.exit_ts, "trade_exit_ts_malformed")

--- a/research/nautilus_scalping/rob974_h5_dual_evidence.py
+++ b/research/nautilus_scalping/rob974_h5_dual_evidence.py
@@ -1,0 +1,249 @@
+"""ROB-983 (H5, CP2) -- selected-OOS dual evidence and PBO prerequisites.
+
+Two distinct typed evidence surfaces per H4/H6-A contract (H4 AC30-33,
+H6-A AC20-21):
+
+* ``UniqueGeneratorEvidence`` -- scenario-independent, pre-horizon/
+  pre-funding/pre-engine H3 candidate identity, keyed once per
+  strategy/config/fold. ``candidate = accepted + rejected``; the rejection
+  reason histogram subtotals exactly to ``rejected``.
+* ``PathInvocationEvidence`` -- one row per ``path_scenario``
+  (base13/primary_stress17/upward_stress22), each referencing the SAME
+  unique accepted-input hash/count and carrying its own post-horizon/funding
+  engine-input hash/count and no-trade reasons.
+
+``cross_check_dual_evidence`` is the one boundary that proves every path
+traces back to the SAME unique accepted set -- never a scenario sum,
+intersection, first-path substitute, or tripled count.
+
+PBO (``PboEvidence``) is exact independent 24-config x 365-day,
+``primary_stress17``, ``slices=4``, full-window, reference-only auxiliary
+evidence. It never enters a hard gate: ``validate_pbo_evidence`` returns only
+an ok/incomplete-reason pair, never a verdict-shaped value.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from rob974_h5_contracts import (
+    FOLD_IDS,
+    PATH_SCENARIOS,
+    STRATEGIES,
+    EnvelopeValidationResult,
+    H5InputError,
+    config_ids_for,
+)
+
+_LOWERCASE_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _require(condition: bool, reason: str) -> None:
+    if not condition:
+        raise H5InputError(reason)
+
+
+def _require_hex64(value: Any, reason: str) -> str:
+    _require(isinstance(value, str) and bool(_LOWERCASE_HEX_64.match(value)), reason)
+    return value
+
+
+def _require_exact_int(value: Any, reason: str, *, min_value: int = 0) -> int:
+    _require(type(value) is int and value >= min_value, reason)
+    return value
+
+
+__all__ = [
+    "PBO_CONFIG_COUNT",
+    "PBO_DAY_COUNT",
+    "PBO_SCENARIO_NAME",
+    "PBO_SLICES",
+    "PathInvocationEvidence",
+    "PboEvidence",
+    "UniqueGeneratorEvidence",
+    "cross_check_dual_evidence",
+    "validate_pbo_evidence",
+]
+
+PBO_CONFIG_COUNT = 24
+PBO_DAY_COUNT = 365
+PBO_SLICES = 4
+PBO_SCENARIO_NAME = "primary_stress17"
+
+
+def _require_reason_histogram(
+    value: Any, expected_total: int, reason: str
+) -> dict[str, int]:
+    _require(isinstance(value, dict), reason)
+    for k, v in value.items():
+        _require(isinstance(k, str), reason)
+        _require_exact_int(v, reason, min_value=1)
+    _require(sum(value.values()) == expected_total, reason)
+    return dict(value)
+
+
+@dataclass(frozen=True, slots=True)
+class UniqueGeneratorEvidence:
+    strategy: str
+    config_id: str
+    fold_id: str
+    accepted: int
+    rejected: int
+    accepted_input_hash: str
+    rejection_reason_histogram: dict[str, int]
+
+    def __post_init__(self) -> None:
+        _require(self.strategy in STRATEGIES, "unique_evidence_strategy_unknown")
+        _require(
+            self.config_id in config_ids_for(self.strategy),
+            "unique_evidence_config_id_unknown",
+        )
+        _require(self.fold_id in FOLD_IDS, "unique_evidence_fold_id_unknown")
+        _require_exact_int(self.accepted, "unique_evidence_accepted_malformed")
+        _require_exact_int(self.rejected, "unique_evidence_rejected_malformed")
+        _require_hex64(
+            self.accepted_input_hash, "unique_evidence_accepted_input_hash_malformed"
+        )
+        _require_reason_histogram(
+            self.rejection_reason_histogram,
+            self.rejected,
+            "unique_evidence_rejection_histogram_subtotal_mismatch",
+        )
+
+    @property
+    def candidate(self) -> int:
+        return self.accepted + self.rejected
+
+
+@dataclass(frozen=True, slots=True)
+class PathInvocationEvidence:
+    strategy: str
+    config_id: str
+    fold_id: str
+    path_scenario: str
+    unique_evidence_hash: str
+    unique_evidence_accepted_count: int
+    engine_input_hash: str
+    engine_input_count: int
+    no_trade_reason_counts: dict[str, int]
+    ledger_status: str
+    trade_count: int
+    artifact_hash: str
+
+    def __post_init__(self) -> None:
+        _require(self.strategy in STRATEGIES, "path_evidence_strategy_unknown")
+        _require(
+            self.config_id in config_ids_for(self.strategy),
+            "path_evidence_config_id_unknown",
+        )
+        _require(self.fold_id in FOLD_IDS, "path_evidence_fold_id_unknown")
+        _require(self.path_scenario in PATH_SCENARIOS, "path_evidence_scenario_unknown")
+        _require_hex64(self.unique_evidence_hash, "path_evidence_unique_hash_malformed")
+        _require_exact_int(
+            self.unique_evidence_accepted_count,
+            "path_evidence_unique_accepted_count_malformed",
+        )
+        _require_hex64(self.engine_input_hash, "path_evidence_engine_hash_malformed")
+        _require_exact_int(
+            self.engine_input_count, "path_evidence_engine_input_count_malformed"
+        )
+        for k, v in self.no_trade_reason_counts.items():
+            _require(isinstance(k, str), "path_evidence_no_trade_reason_key_malformed")
+            _require_exact_int(
+                v, "path_evidence_no_trade_reason_value_malformed", min_value=1
+            )
+        _require(
+            self.ledger_status
+            in (
+                "completed",
+                "rejected",
+                "crashed",
+                "timeout",
+                "not_selected",
+                "never_selected",
+            ),
+            "path_evidence_ledger_status_unknown",
+        )
+        _require_exact_int(self.trade_count, "path_evidence_trade_count_malformed")
+        _require_hex64(self.artifact_hash, "path_evidence_artifact_hash_malformed")
+
+
+def cross_check_dual_evidence(
+    unique: UniqueGeneratorEvidence,
+    paths: dict[str, PathInvocationEvidence],
+) -> None:
+    """The one boundary proving every path traces back to the SAME unique
+    accepted-input hash/count -- never a sum/intersection/first-path/
+    tripled reconstruction."""
+    _require(
+        set(paths.keys()) == set(PATH_SCENARIOS),
+        "dual_evidence_path_set_incomplete",
+    )
+    for name, path in paths.items():
+        _require(path.path_scenario == name, "dual_evidence_path_scenario_key_mismatch")
+        _require(
+            path.strategy == unique.strategy
+            and path.config_id == unique.config_id
+            and path.fold_id == unique.fold_id,
+            "dual_evidence_path_binding_mismatch",
+        )
+        _require(
+            path.unique_evidence_hash == unique.accepted_input_hash,
+            "dual_evidence_path_unique_hash_mismatch",
+        )
+        _require(
+            path.unique_evidence_accepted_count == unique.accepted,
+            "dual_evidence_path_unique_accepted_count_mismatch",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PboEvidence:
+    strategy: str
+    config_count: int
+    day_count: int
+    slices: int
+    scenario_name: str
+    value: float | None
+    reason_codes: tuple[str, ...]
+    source_hash: str
+    input_hash: str
+    artifact_hash: str
+
+    def __post_init__(self) -> None:
+        _require(self.strategy in STRATEGIES, "pbo_strategy_unknown")
+        _require(self.config_count == PBO_CONFIG_COUNT, "pbo_config_count_not_24")
+        _require(self.day_count == PBO_DAY_COUNT, "pbo_day_count_not_365")
+        _require(self.slices == PBO_SLICES, "pbo_slices_not_4")
+        _require(
+            self.scenario_name == PBO_SCENARIO_NAME, "pbo_scenario_not_primary_stress17"
+        )
+        if self.value is not None:
+            _require(type(self.value) is float, "pbo_value_malformed")
+        _require(
+            isinstance(self.reason_codes, tuple)
+            and all(isinstance(r, str) for r in self.reason_codes),
+            "pbo_reason_codes_malformed",
+        )
+        for h in (self.source_hash, self.input_hash, self.artifact_hash):
+            _require_hex64(h, "pbo_hash_malformed")
+
+
+def validate_pbo_evidence(pbo: PboEvidence | None) -> EnvelopeValidationResult:
+    """Missing PBO (``None``) is a legitimate producer state, never a raise
+    -- it makes the campaign structurally incomplete. An evaluator-failure
+    reason code likewise makes it incomplete. A well-formed, present
+    ``PboEvidence`` always passes here regardless of its ``value`` -- PBO can
+    never flip a hard gate/verdict, so this function never inspects
+    ``value`` for pass/fail purposes, only for presence/shape."""
+    if pbo is None:
+        return EnvelopeValidationResult(
+            ok=False, incomplete_reasons=("missing_pbo_evidence",)
+        )
+    if pbo.reason_codes:
+        return EnvelopeValidationResult(
+            ok=False, incomplete_reasons=tuple(sorted(pbo.reason_codes))
+        )
+    return EnvelopeValidationResult(ok=True, incomplete_reasons=())

--- a/research/nautilus_scalping/rob974_h5_gates.py
+++ b/research/nautilus_scalping/rob974_h5_gates.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from rob974_h5_contracts import FOLD_IDS, H5InputError, MetricTrade
@@ -36,6 +36,7 @@ __all__ = [
     "WIN_MARGIN_MIN",
     "CommonGateResult",
     "evaluate_common_gates",
+    "validate_selected_oos_membership",
 ]
 
 POOLED_E17_MIN_BPS = 5.0
@@ -71,6 +72,7 @@ class CommonGateResult:
     weighted_pbe: float | None
     win_margin: float | None
     fold_trade_counts: dict[str, int]
+    fold_e17_bps: dict[str, float | None] = field(default_factory=dict)
 
 
 def _utc_month_key(exit_ts_ms: int) -> str:
@@ -86,21 +88,51 @@ def _weight(trade: MetricTrade) -> float:
     return trade.gross_notional if trade.gross_notional is not None else 1.0
 
 
+def validate_selected_oos_membership(
+    *,
+    primary_trades: tuple[MetricTrade, ...],
+    upward_trades: tuple[MetricTrade, ...],
+    authority: str,
+    expected_strategy: str | None = None,
+) -> None:
+    """Bind every scoring consumer to one selected-OOS trade membership.
+
+    D3 has three independent domains and all three are checked here before
+    arithmetic: the registered path, one strategy, and one selected config.
+    A path label by itself cannot prevent a caller from cherry-picking the
+    best rows across the 24 configs or substituting the other strategy's
+    rows.  Empty books remain scoreable as incomplete/failing evidence; any
+    rows that do exist must share the same exact membership.
+    """
+    if any(t.path_scenario != "primary_stress17" for t in primary_trades):
+        raise H5InputError(f"{authority}_primary_path_scenario_mismatch")
+    if any(t.path_scenario != "upward_stress22" for t in upward_trades):
+        raise H5InputError(f"{authority}_upward_path_scenario_mismatch")
+
+    all_trades = primary_trades + upward_trades
+    strategies = {t.strategy for t in all_trades}
+    if expected_strategy is None:
+        if len(strategies) > 1:
+            raise H5InputError(f"{authority}_strategy_domain_mismatch")
+    elif any(t.strategy != expected_strategy for t in all_trades):
+        raise H5InputError(f"{authority}_strategy_domain_mismatch")
+
+    if len({t.config_id for t in all_trades}) > 1:
+        raise H5InputError(f"{authority}_selected_oos_membership_mismatch")
+
+
 def evaluate_common_gates(
     *,
     primary_trades: tuple[MetricTrade, ...],
     upward_trades: tuple[MetricTrade, ...],
 ) -> CommonGateResult:
-    # D3 fail-closed membership binding (adversarial verify R1, finding 1):
-    # a path-scenario swap (e.g. base13 masquerading as the primary17
-    # selected-OOS book, or the upward book carrying primary_stress17) must
-    # be rejected, never silently scored as if it were the correct
-    # membership -- there is no fourth 0bp scenario/base membership/
-    # counterfactual substitute for E0/E17/PF/win-margin/concentration.
-    if any(t.path_scenario != "primary_stress17" for t in primary_trades):
-        raise H5InputError("common_gates_primary_path_scenario_mismatch")
-    if any(t.path_scenario != "upward_stress22" for t in upward_trades):
-        raise H5InputError("common_gates_upward_path_scenario_mismatch")
+    # D3 fail-closed membership binding (adversarial verify R1/R2): path,
+    # strategy, and selected-config membership are one indivisible seal.
+    validate_selected_oos_membership(
+        primary_trades=primary_trades,
+        upward_trades=upward_trades,
+        authority="common_gates",
+    )
 
     reasons: set[str] = set()
 
@@ -162,6 +194,15 @@ def evaluate_common_gates(
     if positive_fold_count < MIN_POSITIVE_FOLDS:
         reasons.add(REASON_INSUFFICIENT_POSITIVE_FOLDS)
 
+    fold_e17_bps = {
+        fold_id: (
+            fold_net_sum[fold_id] / fold_trade_counts[fold_id]
+            if fold_trade_counts[fold_id] > 0
+            else None
+        )
+        for fold_id in FOLD_IDS
+    }
+
     monthly_net: dict[str, float] = defaultdict(float)
     for t in primary_trades:
         monthly_net[_utc_month_key(t.exit_ts)] += t.net_bps
@@ -194,4 +235,5 @@ def evaluate_common_gates(
         weighted_pbe=weighted_pbe,
         win_margin=win_margin,
         fold_trade_counts=fold_trade_counts,
+        fold_e17_bps=fold_e17_bps,
     )

--- a/research/nautilus_scalping/rob974_h5_gates.py
+++ b/research/nautilus_scalping/rob974_h5_gates.py
@@ -1,0 +1,186 @@
+"""ROB-983 (H5, CP3) -- common hard gates, E0, and win authority.
+
+All conditions must pass for a strategy ``historical_pass`` (H5 spec AC7-15);
+every stable failure reason is collected here rather than short-circuited on
+the first failing gate.
+
+E0 (AC16-17) is the mean PRICE-ONLY ``gross_bps`` over the exact
+``primary_stress17`` selected-OOS basket membership -- it excludes fixed
+scenario cost and funding, and is computed from the SAME trade set as every
+other primary gate (never a fourth 0bp scenario or a counterfactual column).
+
+Win authority (AC18-20): observed win rate is the fraction of baskets with
+``net_bps>0`` (a plain count-based fraction, not weight-adjusted). Per-trade
+``pBE=(SL_bps+17)/(TP_bps+SL_bps)`` is weighted by gross basket notional for
+S4 and equal-weight (1.0) for S3 fixed-notional trades.
+``win_margin=observed_win_rate-weighted_pBE`` must independently pass
+alongside (never instead of) PF.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from rob974_h5_contracts import FOLD_IDS, MetricTrade
+
+__all__ = [
+    "E0_MIN_BPS",
+    "MAX_MONTHLY_CONCENTRATION",
+    "MIN_POSITIVE_FOLDS",
+    "MIN_TRADES_PER_FOLD",
+    "PF17_MIN",
+    "POOLED_E17_MIN_BPS",
+    "WIN_MARGIN_MIN",
+    "CommonGateResult",
+    "evaluate_common_gates",
+]
+
+POOLED_E17_MIN_BPS = 5.0
+PF17_MIN = 1.15
+MIN_POSITIVE_FOLDS = 5
+MAX_MONTHLY_CONCENTRATION = 0.50
+E0_MIN_BPS = 25.0
+WIN_MARGIN_MIN = 0.03
+MIN_TRADES_PER_FOLD = 5
+
+REASON_POOLED_E17_BELOW = "pooled_e17_below_5bp"
+REASON_PF17_BELOW = "pf17_below_1_15"
+REASON_INSUFFICIENT_POSITIVE_FOLDS = "insufficient_positive_folds"
+REASON_NO_POSITIVE_MONTHS = "no_positive_months"
+REASON_CONCENTRATION_ABOVE = "monthly_concentration_above_50pct"
+REASON_E22_NOT_POSITIVE = "e22_not_positive"
+REASON_E0_BELOW = "e0_below_25bp"
+REASON_WIN_MARGIN_BELOW = "win_margin_below_3pp"
+REASON_INSUFFICIENT_SAMPLE = "insufficient_sample"
+
+
+@dataclass(frozen=True, slots=True)
+class CommonGateResult:
+    passed: bool
+    reasons: tuple[str, ...]
+    pooled_e17_bps: float | None
+    pf17: float | None
+    positive_fold_count: int
+    monthly_concentration: float | None
+    e22_bps: float | None
+    e0_bps: float | None
+    observed_win_rate: float | None
+    weighted_pbe: float | None
+    win_margin: float | None
+    fold_trade_counts: dict[str, int]
+
+
+def _utc_month_key(exit_ts_ms: int) -> str:
+    dt = datetime.fromtimestamp(exit_ts_ms / 1000.0, tz=UTC)
+    return f"{dt.year:04d}-{dt.month:02d}"
+
+
+def _pbe(trade: MetricTrade) -> float:
+    return (trade.sl_bps + 17.0) / (trade.tp_bps + trade.sl_bps)
+
+
+def _weight(trade: MetricTrade) -> float:
+    return trade.gross_notional if trade.gross_notional is not None else 1.0
+
+
+def evaluate_common_gates(
+    *,
+    primary_trades: tuple[MetricTrade, ...],
+    upward_trades: tuple[MetricTrade, ...],
+) -> CommonGateResult:
+    reasons: set[str] = set()
+
+    fold_trade_counts: dict[str, int] = dict.fromkeys(FOLD_IDS, 0)
+    fold_net_sum: dict[str, float] = dict.fromkeys(FOLD_IDS, 0.0)
+    for t in primary_trades:
+        fold_trade_counts[t.fold_id] += 1
+        fold_net_sum[t.fold_id] += t.net_bps
+
+    for fold_id in FOLD_IDS:
+        if fold_trade_counts[fold_id] < MIN_TRADES_PER_FOLD:
+            reasons.add(REASON_INSUFFICIENT_SAMPLE)
+
+    pooled_e17_bps: float | None = None
+    pf17: float | None = None
+    e0_bps: float | None = None
+    observed_win_rate: float | None = None
+    weighted_pbe: float | None = None
+    win_margin: float | None = None
+
+    if primary_trades:
+        net_values = [t.net_bps for t in primary_trades]
+        pooled_e17_bps = sum(net_values) / len(net_values)
+        if pooled_e17_bps < POOLED_E17_MIN_BPS:
+            reasons.add(REASON_POOLED_E17_BELOW)
+
+        gross_profit = sum(v for v in net_values if v > 0)
+        gross_loss = -sum(v for v in net_values if v < 0)
+        if gross_loss == 0.0:
+            pf17 = math.inf if gross_profit > 0 else float("nan")
+        else:
+            pf17 = gross_profit / gross_loss
+        if not (pf17 >= PF17_MIN):  # NaN-safe: NaN >= x is False
+            reasons.add(REASON_PF17_BELOW)
+
+        e0_bps = sum(t.gross_bps for t in primary_trades) / len(primary_trades)
+        if e0_bps < E0_MIN_BPS:
+            reasons.add(REASON_E0_BELOW)
+
+        wins = sum(1 for v in net_values if v > 0)
+        observed_win_rate = wins / len(net_values)
+
+        total_weight = sum(_weight(t) for t in primary_trades)
+        weighted_pbe = sum(_pbe(t) * _weight(t) for t in primary_trades) / total_weight
+        win_margin = observed_win_rate - weighted_pbe
+        if win_margin < WIN_MARGIN_MIN:
+            reasons.add(REASON_WIN_MARGIN_BELOW)
+    else:
+        reasons.add(REASON_POOLED_E17_BELOW)
+        reasons.add(REASON_PF17_BELOW)
+        reasons.add(REASON_E0_BELOW)
+        reasons.add(REASON_WIN_MARGIN_BELOW)
+
+    positive_fold_count = sum(
+        1
+        for fold_id in FOLD_IDS
+        if fold_trade_counts[fold_id] > 0 and fold_net_sum[fold_id] > 0
+    )
+    if positive_fold_count < MIN_POSITIVE_FOLDS:
+        reasons.add(REASON_INSUFFICIENT_POSITIVE_FOLDS)
+
+    monthly_net: dict[str, float] = defaultdict(float)
+    for t in primary_trades:
+        monthly_net[_utc_month_key(t.exit_ts)] += t.net_bps
+    positive_months = {k: v for k, v in monthly_net.items() if v > 0}
+    monthly_concentration: float | None = None
+    if not positive_months:
+        reasons.add(REASON_NO_POSITIVE_MONTHS)
+    else:
+        total_positive = sum(positive_months.values())
+        monthly_concentration = max(positive_months.values()) / total_positive
+        if monthly_concentration > MAX_MONTHLY_CONCENTRATION:
+            reasons.add(REASON_CONCENTRATION_ABOVE)
+
+    e22_bps: float | None = None
+    if upward_trades:
+        e22_bps = sum(t.net_bps for t in upward_trades) / len(upward_trades)
+    if e22_bps is None or not (e22_bps > 0.0):
+        reasons.add(REASON_E22_NOT_POSITIVE)
+
+    return CommonGateResult(
+        passed=not reasons,
+        reasons=tuple(sorted(reasons)),
+        pooled_e17_bps=pooled_e17_bps,
+        pf17=pf17,
+        positive_fold_count=positive_fold_count,
+        monthly_concentration=monthly_concentration,
+        e22_bps=e22_bps,
+        e0_bps=e0_bps,
+        observed_win_rate=observed_win_rate,
+        weighted_pbe=weighted_pbe,
+        win_margin=win_margin,
+        fold_trade_counts=fold_trade_counts,
+    )

--- a/research/nautilus_scalping/rob974_h5_gates.py
+++ b/research/nautilus_scalping/rob974_h5_gates.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from rob974_h5_contracts import FOLD_IDS, MetricTrade
+from rob974_h5_contracts import FOLD_IDS, H5InputError, MetricTrade
 
 __all__ = [
     "E0_MIN_BPS",
@@ -91,6 +91,17 @@ def evaluate_common_gates(
     primary_trades: tuple[MetricTrade, ...],
     upward_trades: tuple[MetricTrade, ...],
 ) -> CommonGateResult:
+    # D3 fail-closed membership binding (adversarial verify R1, finding 1):
+    # a path-scenario swap (e.g. base13 masquerading as the primary17
+    # selected-OOS book, or the upward book carrying primary_stress17) must
+    # be rejected, never silently scored as if it were the correct
+    # membership -- there is no fourth 0bp scenario/base membership/
+    # counterfactual substitute for E0/E17/PF/win-margin/concentration.
+    if any(t.path_scenario != "primary_stress17" for t in primary_trades):
+        raise H5InputError("common_gates_primary_path_scenario_mismatch")
+    if any(t.path_scenario != "upward_stress22" for t in upward_trades):
+        raise H5InputError("common_gates_upward_path_scenario_mismatch")
+
     reasons: set[str] = set()
 
     fold_trade_counts: dict[str, int] = dict.fromkeys(FOLD_IDS, 0)

--- a/research/nautilus_scalping/rob974_h5_markdown.py
+++ b/research/nautilus_scalping/rob974_h5_markdown.py
@@ -200,9 +200,13 @@ def render_markdown(canonical: Mapping[str, Any]) -> bytes:
     campaign = canonical["campaign_decision"]
     lines.append("## Campaign Decision")
     lines.append(f"- campaign_decision: {campaign['campaign_decision']}")
+    lines.append(
+        f"- campaign_historical_verdict: {campaign['campaign_historical_verdict']}"
+    )
     lines.append(f"- s3_direct_verdict: {campaign['s3_direct_verdict']}")
     lines.append(f"- s4_direct_verdict: {campaign['s4_direct_verdict']}")
     lines.append(f"- demo_candidate: {_fmt(campaign['demo_candidate'])}")
+    lines.append(f"- historical_preferred: {_fmt(campaign['historical_preferred'])}")
     lines.append(
         f"- s4_observable_superiority: {_fmt(campaign['s4_observable_superiority'])}"
     )

--- a/research/nautilus_scalping/rob974_h5_markdown.py
+++ b/research/nautilus_scalping/rob974_h5_markdown.py
@@ -1,0 +1,211 @@
+"""ROB-983 (H5, CP7) -- pure JSON-only Markdown renderer.
+
+``render_markdown`` accepts ONLY an already-``json.loads``-decoded canonical
+scorecard (as produced by ``rob974_h5_canonical.build_canonical_scorecard`` +
+``canonical_json_bytes``) -- never a raw H4/H6-A/DB object, and it never
+recomputes a metric. It is presentation only: every reason/attribution/
+verdict value is read verbatim from the canonical tree and formatted.
+
+Every dict-shaped substructure (``status_counts``, attribution buckets) is
+walked in the SAME registered domain order CP6 already canonicalized with
+(rather than trusting the input mapping's own iteration order), so a
+hypothetical differently-ordered-but-semantically-identical input dict still
+produces byte-identical Markdown. List-shaped fields (``dual_evidence``,
+``reasons``, ``incomplete_reasons``, ``expected_experiment_ids``) are
+positionally meaningful JSON arrays already in canonical order from CP6 and
+are rendered in the given order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from rob974_h5_canonical import CLOSED_STATUS_ORDER
+from rob974_h5_contracts import (
+    S3_EXIT_REASONS,
+    S3_SYMBOLS,
+    S4_EXIT_REASONS,
+    S4_PAIRS,
+    STRATEGIES,
+)
+
+__all__ = ["render_markdown"]
+
+_DIMENSION_ORDER = {"S3": S3_SYMBOLS, "S4": S4_PAIRS}
+_DIMENSION_KEY = {"S3": "by_symbol", "S4": "by_pair"}
+_EXIT_REASON_ORDER = {"S3": S3_EXIT_REASONS, "S4": S4_EXIT_REASONS}
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    return str(value)
+
+
+def _fmt_list(values: Sequence[str]) -> str:
+    return ", ".join(values) if values else "(none)"
+
+
+def _render_bucket_line(label: str, bucket: Mapping[str, Any]) -> str:
+    pf = _fmt(bucket["pf"])
+    if bucket.get("pf_reason"):
+        pf = f"{pf} ({bucket['pf_reason']})"
+    return (
+        f"- {label}: trades={bucket['trades']} e17_bps={_fmt(bucket['e17_bps'])} "
+        f"e0_bps={_fmt(bucket['e0_bps'])} pf={pf} "
+        f"avg_holding_minutes={_fmt(bucket['avg_holding_minutes'])}"
+    )
+
+
+def _render_ordered_buckets(
+    by_key: Mapping[str, Mapping[str, Any]], order: Sequence[str]
+) -> list[str]:
+    return [_render_bucket_line(key, by_key[key]) for key in order if key in by_key]
+
+
+def _render_dual_evidence(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    if not rows:
+        return []
+    lines = ["### Dual Evidence", ""]
+    for row in rows:
+        lines.append(
+            f"- {row['config_id']}/{row['fold_id']}: "
+            f"accepted={row['accepted']} rejected={row['rejected']}"
+        )
+        histogram = row["rejection_reason_histogram"]
+        if histogram:
+            # Sorted explicitly -- never trust the input mapping's own
+            # iteration order (mirrors CP6's own histogram canonicalization).
+            reasons_str = ", ".join(f"{k}={histogram[k]}" for k in sorted(histogram))
+            lines.append(f"  - rejection_reasons: {reasons_str}")
+        for path in row["paths"]:
+            lines.append(
+                f"  - path[{path['path_scenario']}]: "
+                f"ledger_status={path['ledger_status']} "
+                f"trade_count={path['trade_count']}"
+            )
+    lines.append("")
+    return lines
+
+
+def _render_pbo(pbo: Mapping[str, Any] | None) -> list[str]:
+    if pbo is None:
+        return []
+    lines = ["### PBO", ""]
+    lines.append(f"- value: {_fmt(pbo['value'])}")
+    lines.append(f"- reason_codes: {_fmt_list(pbo['reason_codes'])}")
+    lines.append("")
+    return lines
+
+
+def _render_pair_executor_state(state: Mapping[str, Any] | None) -> list[str]:
+    if state is None:
+        return []
+    lines = ["### Pair Executor State (historical)", ""]
+    lines.append(f"- pair_executor_state: {state['pair_executor_state']}")
+    lines.append(f"- readiness: {state['readiness']}")
+    lines.append(f"- demo_eligible: {_fmt(state['demo_eligible'])}")
+    lines.append("")
+    return lines
+
+
+def _render_strategy(strategy: str, entry: Mapping[str, Any]) -> list[str]:
+    lines = [f"## Strategy {strategy}", ""]
+
+    gates = entry["common_gates"]
+    lines.append("### Common Gates")
+    lines.append(f"- passed: {_fmt(gates['passed'])}")
+    lines.append(f"- reasons: {_fmt_list(gates['reasons'])}")
+    lines.append(f"- pooled_e17_bps: {_fmt(gates['pooled_e17_bps'])}")
+    pf17 = _fmt(gates["pf17"])
+    if gates.get("pf17_reason"):
+        pf17 = f"{pf17} ({gates['pf17_reason']})"
+    lines.append(f"- pf17: {pf17}")
+    lines.append(f"- win_margin: {_fmt(gates['win_margin'])}")
+    lines.append(f"- monthly_concentration: {_fmt(gates['monthly_concentration'])}")
+    lines.append("")
+
+    falsification = entry["falsification"]
+    lines.append("### Falsification")
+    lines.append(f"- reasons: {_fmt_list(falsification['reasons'])}")
+    lines.append(
+        f"- incomplete_reasons: {_fmt_list(falsification['incomplete_reasons'])}"
+    )
+    lines.append("")
+
+    lines.append("### Attribution: by_exit_reason")
+    lines.extend(
+        _render_ordered_buckets(
+            falsification["attribution"]["by_exit_reason"], _EXIT_REASON_ORDER[strategy]
+        )
+    )
+    lines.append("")
+
+    dimension_key = _DIMENSION_KEY[strategy]
+    lines.append(f"### Attribution: {dimension_key}")
+    lines.extend(
+        _render_ordered_buckets(
+            falsification["attribution"][dimension_key], _DIMENSION_ORDER[strategy]
+        )
+    )
+    lines.append("")
+
+    lines.extend(_render_dual_evidence(entry["dual_evidence"]))
+    lines.extend(_render_pbo(entry["pbo"]))
+    lines.extend(_render_pair_executor_state(entry.get("pair_executor_state")))
+
+    lines.append(f"### Direct Verdict: {entry['direct_verdict']}")
+    lines.append("")
+    return lines
+
+
+def render_markdown(canonical: Mapping[str, Any]) -> bytes:
+    lines: list[str] = [f"# H5 Scorecard ({canonical['schema_version']})", ""]
+
+    lineage = canonical["lineage"]
+    lines.append("## Lineage")
+    lines.append(f"- campaign_run_id: {lineage['campaign_run_id']}")
+    lines.append(f"- full_campaign_hash: {lineage['full_campaign_hash']}")
+    lines.append(f"- run_schema_version: {lineage['run_schema_version']}")
+    lines.append(f"- generator_version: {lineage['generator_version']}")
+    lines.append(f"- actual_h4_ledger_key: {lineage['actual_h4_ledger_key']}")
+    lines.append("")
+
+    h6a = canonical["h6a_accounting"]
+    lines.append("## H6-A Accounting")
+    lines.append(f"- expected_total: {h6a['expected_total']}")
+    lines.append(f"- registered_total: {h6a['registered_total']}")
+    lines.append(f"- accounting_complete: {_fmt(h6a['accounting_complete'])}")
+    lines.append(f"- performance_usable: {_fmt(h6a['performance_usable'])}")
+    for status in CLOSED_STATUS_ORDER:
+        if status in h6a["status_counts"]:
+            lines.append(f"  - status[{status}]: {h6a['status_counts'][status]}")
+    lines.append(f"- reason_codes: {_fmt_list(h6a['reason_codes'])}")
+    lines.append("")
+
+    env_val = canonical["envelope_validation"]
+    lines.append("## Envelope Validation")
+    lines.append(f"- ok: {_fmt(env_val['ok'])}")
+    lines.append(f"- incomplete_reasons: {_fmt_list(env_val['incomplete_reasons'])}")
+    lines.append("")
+
+    for strategy in STRATEGIES:
+        lines.extend(_render_strategy(strategy, canonical["strategies"][strategy]))
+
+    campaign = canonical["campaign_decision"]
+    lines.append("## Campaign Decision")
+    lines.append(f"- campaign_decision: {campaign['campaign_decision']}")
+    lines.append(f"- s3_direct_verdict: {campaign['s3_direct_verdict']}")
+    lines.append(f"- s4_direct_verdict: {campaign['s4_direct_verdict']}")
+    lines.append(f"- demo_candidate: {_fmt(campaign['demo_candidate'])}")
+    lines.append(
+        f"- s4_observable_superiority: {_fmt(campaign['s4_observable_superiority'])}"
+    )
+    lines.append("")
+
+    return ("\n".join(lines) + "\n").encode("utf-8")

--- a/research/nautilus_scalping/rob974_h5_s3.py
+++ b/research/nautilus_scalping/rob974_h5_s3.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-from rob974_h5_contracts import FOLD_IDS, S3_SYMBOLS, H5InputError, MetricTrade
+from rob974_h5_contracts import FOLD_IDS, S3_SYMBOLS, MetricTrade
+from rob974_h5_gates import validate_selected_oos_membership
 
 __all__ = [
     "S3_FIRST_4H_MINUTES",
@@ -95,13 +96,12 @@ def evaluate_s3_falsification(
     primary_trades: tuple[MetricTrade, ...],
     upward_trades: tuple[MetricTrade, ...],
 ) -> S3FalsificationResult:
-    # D3 fail-closed membership binding (adversarial verify R1, finding 1):
-    # reject a path-scenario swap rather than silently scoring the wrong
-    # membership.
-    if any(t.path_scenario != "primary_stress17" for t in primary_trades):
-        raise H5InputError("s3_falsification_primary_path_scenario_mismatch")
-    if any(t.path_scenario != "upward_stress22" for t in upward_trades):
-        raise H5InputError("s3_falsification_upward_path_scenario_mismatch")
+    validate_selected_oos_membership(
+        primary_trades=primary_trades,
+        upward_trades=upward_trades,
+        authority="s3_falsification",
+        expected_strategy="S3",
+    )
 
     reasons: set[str] = set()
     incomplete_reasons: set[str] = set()

--- a/research/nautilus_scalping/rob974_h5_s3.py
+++ b/research/nautilus_scalping/rob974_h5_s3.py
@@ -1,0 +1,197 @@
+"""ROB-983 (H5, CP4) -- S3 falsification gates and attribution.
+
+Pooled/per-fold timeout ceilings, all-long-entry bullish-subbook upward E22
+strict positivity, first-4h SL-dependence (undefined denominator is
+``incomplete``, never a convenient zero/pass), symbol dependence (both the
+"exactly one symbol positive" AND "other two pooled <=0" predicates
+required), and exit-reason/symbol attribution (``THESIS_EXIT`` is never
+``TIMEOUT``).
+
+First-4h SL dependence: the numerator is the absolute E17 loss confined to
+``holding_minutes<=240 AND exit_reason=="SL"``; the denominator is the
+absolute E17 loss of ALL losing trades (``net_bps<0``, any exit reason) --
+never the signed sum, which would let large losses cancel. A zero
+denominator (no losing trades at all) makes the ratio structurally
+undefined, not a free pass.
+
+Symbol dependence fails only when EXACTLY ONE of the three S3 symbols has a
+positive pooled E17 AND the other two symbols' pooled (combined) E17 is
+``<=0``. Two-or-more positive symbols never trips this gate. Missing
+evidence for any of the three symbols makes the check structurally
+incomplete rather than silently skipped.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from rob974_h5_contracts import FOLD_IDS, S3_SYMBOLS, MetricTrade
+
+__all__ = [
+    "S3_FIRST_4H_MINUTES",
+    "S3_FOLD_TIMEOUT_MAX",
+    "S3_POOLED_TIMEOUT_MAX",
+    "S3_SL_DEPENDENCE_MAX",
+    "S3FalsificationResult",
+    "evaluate_s3_falsification",
+]
+
+S3_POOLED_TIMEOUT_MAX = 0.15
+S3_FOLD_TIMEOUT_MAX = 0.25
+S3_SL_DEPENDENCE_MAX = 0.50
+S3_FIRST_4H_MINUTES = 240.0
+
+REASON_POOLED_TIMEOUT_ABOVE = "s3_pooled_timeout_above_15pct"
+REASON_FOLD_TIMEOUT_ABOVE = "s3_fold_timeout_above_25pct"
+REASON_BULLISH_LONG_E22_NOT_POSITIVE = "s3_bullish_long_e22_not_positive"
+REASON_FIRST_4H_SL_DEPENDENCE_ABOVE = "s3_first_4h_sl_dependence_above_50pct"
+REASON_SYMBOL_DEPENDENCE = "s3_symbol_dependence"
+
+INCOMPLETE_FIRST_4H_SL_DENOMINATOR_UNDEFINED = "s3_first_4h_sl_denominator_undefined"
+INCOMPLETE_SYMBOL_EVIDENCE_MISSING = "s3_symbol_evidence_missing"
+INCOMPLETE_POOLED_TIMEOUT_UNDEFINED = "s3_pooled_timeout_undefined"
+
+
+@dataclass(frozen=True, slots=True)
+class S3FalsificationResult:
+    passed: bool
+    reasons: tuple[str, ...]
+    incomplete_reasons: tuple[str, ...]
+    pooled_timeout_ratio: float
+    fold_timeout_ratios: dict[str, float]
+    bullish_long_e22_bps: float | None
+    first_4h_sl_dependence: float | None
+    attribution: dict[str, dict[str, dict[str, float | int | None]]]
+
+
+def _profit_factor(net_values: list[float]) -> float | None:
+    if not net_values:
+        return None
+    profit = sum(v for v in net_values if v > 0)
+    loss = -sum(v for v in net_values if v < 0)
+    if loss == 0.0:
+        return math.inf if profit > 0 else float("nan")
+    return profit / loss
+
+
+def _bucket(trades: tuple[MetricTrade, ...]) -> dict[str, float | int | None]:
+    net_values = [t.net_bps for t in trades]
+    gross_values = [t.gross_bps for t in trades]
+    holding_values = [t.holding_minutes for t in trades]
+    return {
+        "trades": len(trades),
+        "e17_bps": sum(net_values) / len(net_values) if net_values else None,
+        "e0_bps": sum(gross_values) / len(gross_values) if gross_values else None,
+        "pf": _profit_factor(net_values),
+        "avg_holding_minutes": (
+            sum(holding_values) / len(holding_values) if holding_values else None
+        ),
+    }
+
+
+def evaluate_s3_falsification(
+    *,
+    primary_trades: tuple[MetricTrade, ...],
+    upward_trades: tuple[MetricTrade, ...],
+) -> S3FalsificationResult:
+    reasons: set[str] = set()
+    incomplete_reasons: set[str] = set()
+
+    # -- Pooled timeout ratio (AC: pooled <=15%). --------------------------
+    total = len(primary_trades)
+    timeout_count = sum(1 for t in primary_trades if t.exit_reason == "TIMEOUT")
+    if total == 0:
+        pooled_timeout_ratio = 0.0
+        incomplete_reasons.add(INCOMPLETE_POOLED_TIMEOUT_UNDEFINED)
+    else:
+        pooled_timeout_ratio = timeout_count / total
+        if pooled_timeout_ratio > S3_POOLED_TIMEOUT_MAX:
+            reasons.add(REASON_POOLED_TIMEOUT_ABOVE)
+
+    # -- Per-fold timeout ratio (AC: every fold <=25%). --------------------
+    fold_counts: dict[str, int] = dict.fromkeys(FOLD_IDS, 0)
+    fold_timeouts: dict[str, int] = dict.fromkeys(FOLD_IDS, 0)
+    for t in primary_trades:
+        fold_counts[t.fold_id] += 1
+        if t.exit_reason == "TIMEOUT":
+            fold_timeouts[t.fold_id] += 1
+    fold_timeout_ratios: dict[str, float] = {}
+    for fold_id in FOLD_IDS:
+        if fold_counts[fold_id] == 0:
+            continue
+        ratio = fold_timeouts[fold_id] / fold_counts[fold_id]
+        fold_timeout_ratios[fold_id] = ratio
+        if ratio > S3_FOLD_TIMEOUT_MAX:
+            reasons.add(REASON_FOLD_TIMEOUT_ABOVE)
+
+    # -- Bullish all-long-entry upward E22 (AC: strict >0). ----------------
+    long_upward_net = [t.net_bps for t in upward_trades if t.direction == "long"]
+    bullish_long_e22_bps = (
+        sum(long_upward_net) / len(long_upward_net) if long_upward_net else None
+    )
+    if bullish_long_e22_bps is None or not (bullish_long_e22_bps > 0.0):
+        reasons.add(REASON_BULLISH_LONG_E22_NOT_POSITIVE)
+
+    # -- First-4h SL dependence (AC: strict >50% fails). --------------------
+    all_loss_magnitudes = [abs(t.net_bps) for t in primary_trades if t.net_bps < 0.0]
+    denominator = sum(all_loss_magnitudes)
+    first_4h_sl_dependence: float | None = None
+    if denominator == 0.0:
+        incomplete_reasons.add(INCOMPLETE_FIRST_4H_SL_DENOMINATOR_UNDEFINED)
+    else:
+        numerator = sum(
+            abs(t.net_bps)
+            for t in primary_trades
+            if t.net_bps < 0.0
+            and t.exit_reason == "SL"
+            and t.holding_minutes <= S3_FIRST_4H_MINUTES
+        )
+        first_4h_sl_dependence = numerator / denominator
+        if first_4h_sl_dependence > S3_SL_DEPENDENCE_MAX:
+            reasons.add(REASON_FIRST_4H_SL_DEPENDENCE_ABOVE)
+
+    # -- Symbol dependence (AC: exactly-one-positive AND others pooled<=0). -
+    symbol_trades: dict[str, list[MetricTrade]] = {s: [] for s in S3_SYMBOLS}
+    for t in primary_trades:
+        if t.dimension in symbol_trades:
+            symbol_trades[t.dimension].append(t)
+    missing_symbols = [s for s in S3_SYMBOLS if not symbol_trades[s]]
+    if missing_symbols:
+        incomplete_reasons.add(INCOMPLETE_SYMBOL_EVIDENCE_MISSING)
+    else:
+        symbol_e17 = {
+            s: sum(t.net_bps for t in trades) / len(trades)
+            for s, trades in symbol_trades.items()
+        }
+        positive_symbols = [s for s, v in symbol_e17.items() if v > 0.0]
+        if len(positive_symbols) == 1:
+            lone = positive_symbols[0]
+            others = [t for s in S3_SYMBOLS if s != lone for t in symbol_trades[s]]
+            others_pooled_e17 = (
+                sum(t.net_bps for t in others) / len(others) if others else 0.0
+            )
+            if others_pooled_e17 <= 0.0:
+                reasons.add(REASON_SYMBOL_DEPENDENCE)
+
+    # -- Attribution: exit-reason and symbol breakdowns. --------------------
+    exit_groups: dict[str, list[MetricTrade]] = {}
+    for t in primary_trades:
+        exit_groups.setdefault(t.exit_reason, []).append(t)
+    by_exit_reason = {
+        reason: _bucket(tuple(trades)) for reason, trades in exit_groups.items()
+    }
+    by_symbol = {
+        s: _bucket(tuple(trades)) for s, trades in symbol_trades.items() if trades
+    }
+
+    return S3FalsificationResult(
+        passed=not reasons,
+        reasons=tuple(sorted(reasons)),
+        incomplete_reasons=tuple(sorted(incomplete_reasons)),
+        pooled_timeout_ratio=pooled_timeout_ratio,
+        fold_timeout_ratios=fold_timeout_ratios,
+        bullish_long_e22_bps=bullish_long_e22_bps,
+        first_4h_sl_dependence=first_4h_sl_dependence,
+        attribution={"by_exit_reason": by_exit_reason, "by_symbol": by_symbol},
+    )

--- a/research/nautilus_scalping/rob974_h5_s3.py
+++ b/research/nautilus_scalping/rob974_h5_s3.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-from rob974_h5_contracts import FOLD_IDS, S3_SYMBOLS, MetricTrade
+from rob974_h5_contracts import FOLD_IDS, S3_SYMBOLS, H5InputError, MetricTrade
 
 __all__ = [
     "S3_FIRST_4H_MINUTES",
@@ -95,6 +95,14 @@ def evaluate_s3_falsification(
     primary_trades: tuple[MetricTrade, ...],
     upward_trades: tuple[MetricTrade, ...],
 ) -> S3FalsificationResult:
+    # D3 fail-closed membership binding (adversarial verify R1, finding 1):
+    # reject a path-scenario swap rather than silently scoring the wrong
+    # membership.
+    if any(t.path_scenario != "primary_stress17" for t in primary_trades):
+        raise H5InputError("s3_falsification_primary_path_scenario_mismatch")
+    if any(t.path_scenario != "upward_stress22" for t in upward_trades):
+        raise H5InputError("s3_falsification_upward_path_scenario_mismatch")
+
     reasons: set[str] = set()
     incomplete_reasons: set[str] = set()
 

--- a/research/nautilus_scalping/rob974_h5_s4.py
+++ b/research/nautilus_scalping/rob974_h5_s4.py
@@ -1,0 +1,473 @@
+"""ROB-983 (H5, CP5) -- S4 falsification gates, pair-executor historical
+state, direct-verdict tri-state, and campaign decision.
+
+S4-specific falsification mirrors S3's structure (CP4) with its own
+thresholds and predicates: pooled/per-fold timeout ceilings, an ``M_t>+3%``
+upward subbook (strict positivity), ``abs(Corr(pair gross return,
+M_t))<=0.15`` (pooled, price-only ``gross_bps`` against ``market_return_4h``
+-- a zero-variance denominator is structurally undefined, never a free
+pass), pair concentration (conditional -- dominant-pair share ``>0.70`` of
+the positive pool AND the other-two-pairs' pooled E17 ``<=0``, both
+predicates required), and slow-only failure (the ``[8h,32h)`` bucket
+``<=0`` AND the ``[32h,48h]`` bucket ``>0`` -- edge concentrated entirely in
+the slow tail).
+
+``S4PairExecutorState`` is a fixed literal describing S4's historical-
+screen-only nature: ``volatility_percentile``/order/residual/PAIR_EXEC_FAIL
+counts are exactly ``None`` (never a numeric zero), ``demo_eligible`` is
+exactly ``False``.
+
+Direct verdicts (``compute_direct_verdict``) are incomplete-first, then
+hard-gate-fail, then pass. The campaign decision table
+(``compute_campaign_decision``) is a separate, additive view over the two
+independently-computed direct verdicts -- it never overwrites them.
+Observable S4 superiority and both-pass ranking are report-only and never
+change the campaign decision or promote S4 to a demo candidate.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from rob974_h5_contracts import FOLD_IDS, S4_PAIRS, H5InputError, MetricTrade
+
+__all__ = [
+    "S4_CORR_MAX",
+    "S4_FOLD_TIMEOUT_MAX",
+    "S4_HISTORICAL_PAIR_EXECUTOR_STATE",
+    "S4_M_T_THRESHOLD",
+    "S4_PAIR_CONCENTRATION_MAX",
+    "S4_POOLED_TIMEOUT_MAX",
+    "S4_SLOW_BUCKET_END_MINUTES",
+    "S4_SLOW_BUCKET_MID_MINUTES",
+    "S4_SLOW_BUCKET_START_MINUTES",
+    "CampaignDecisionResult",
+    "S4FalsificationResult",
+    "S4PairExecutorState",
+    "StrategyRankMetrics",
+    "compute_campaign_decision",
+    "compute_direct_verdict",
+    "evaluate_s4_falsification",
+    "rank_both_pass",
+    "s4_shows_observable_superiority",
+]
+
+S4_POOLED_TIMEOUT_MAX = 0.20
+S4_FOLD_TIMEOUT_MAX = 0.30
+S4_M_T_THRESHOLD = 0.03
+S4_CORR_MAX = 0.15
+S4_PAIR_CONCENTRATION_MAX = 0.70
+S4_SLOW_BUCKET_START_MINUTES = 480.0  # 8h
+S4_SLOW_BUCKET_MID_MINUTES = 1920.0  # 32h
+S4_SLOW_BUCKET_END_MINUTES = 2880.0  # 48h
+
+# Correlation is a derived statistic (not a directly-supplied registered
+# constant like the CP3 thresholds); a tiny epsilon absorbs float
+# summation noise around the boundary without weakening the semantic
+# `<=0.15` rule.
+_CORR_BOUNDARY_EPSILON = 1e-9
+
+REASON_POOLED_TIMEOUT_ABOVE = "s4_pooled_timeout_above_20pct"
+REASON_FOLD_TIMEOUT_ABOVE = "s4_fold_timeout_above_30pct"
+REASON_HIGH_M_E22_NOT_POSITIVE = "s4_high_market_return_e22_not_positive"
+REASON_CORRELATION_ABOVE = "s4_correlation_above_15pct"
+REASON_PAIR_CONCENTRATION_ABOVE = "s4_pair_concentration_above_70pct"
+REASON_SLOW_ONLY_FAILURE = "s4_slow_only_failure"
+
+INCOMPLETE_POOLED_TIMEOUT_UNDEFINED = "s4_pooled_timeout_undefined"
+INCOMPLETE_CORRELATION_UNDEFINED = "s4_correlation_undefined"
+INCOMPLETE_PAIR_EVIDENCE_MISSING = "s4_pair_evidence_missing"
+INCOMPLETE_SLOW_BUCKET_EVIDENCE_MISSING = "s4_slow_bucket_evidence_missing"
+
+DIRECT_VERDICT_INCOMPLETE = "incomplete"
+DIRECT_VERDICT_PASS = "historical_pass"
+DIRECT_VERDICT_FAIL = "historical_fail"
+
+CAMPAIGN_DECISION_INCOMPLETE = "incomplete"
+CAMPAIGN_DECISION_BOTH_FAIL = "both_fail"
+CAMPAIGN_DECISION_S3_ONLY = "s3_only"
+CAMPAIGN_DECISION_S4_ONLY_NO_DEMO = "s4_only_no_demo"
+CAMPAIGN_DECISION_BOTH_PASS_S3_DEMO_CANDIDATE = "both_pass_s3_demo_candidate"
+
+_S4_SUPERIORITY_MIN_POOLED_E17_GAP_BPS = 5.0
+_S4_SUPERIORITY_MAX_TIMEOUT_GAP = 0.05
+
+
+def _require(condition: bool, reason: str) -> None:
+    if not condition:
+        raise H5InputError(reason)
+
+
+@dataclass(frozen=True, slots=True)
+class S4FalsificationResult:
+    passed: bool
+    reasons: tuple[str, ...]
+    incomplete_reasons: tuple[str, ...]
+    pooled_timeout_ratio: float
+    fold_timeout_ratios: dict[str, float]
+    high_market_return_e22_bps: float | None
+    correlation: float | None
+    pair_concentration: float | None
+    attribution: dict[str, dict[str, dict[str, float | int | None]]]
+
+
+def _profit_factor(net_values: list[float]) -> float | None:
+    if not net_values:
+        return None
+    profit = sum(v for v in net_values if v > 0)
+    loss = -sum(v for v in net_values if v < 0)
+    if loss == 0.0:
+        return math.inf if profit > 0 else float("nan")
+    return profit / loss
+
+
+def _bucket(trades: tuple[MetricTrade, ...]) -> dict[str, float | int | None]:
+    net_values = [t.net_bps for t in trades]
+    gross_values = [t.gross_bps for t in trades]
+    holding_values = [t.holding_minutes for t in trades]
+    return {
+        "trades": len(trades),
+        "e17_bps": sum(net_values) / len(net_values) if net_values else None,
+        "e0_bps": sum(gross_values) / len(gross_values) if gross_values else None,
+        "pf": _profit_factor(net_values),
+        "avg_holding_minutes": (
+            sum(holding_values) / len(holding_values) if holding_values else None
+        ),
+    }
+
+
+def _pearson_corr(xs: list[float], ys: list[float]) -> float | None:
+    n = len(xs)
+    if n == 0:
+        return None
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    var_x = sum((x - mx) ** 2 for x in xs) / n
+    var_y = sum((y - my) ** 2 for y in ys) / n
+    if var_x == 0.0 or var_y == 0.0:
+        return None
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True)) / n
+    return cov / math.sqrt(var_x * var_y)
+
+
+def evaluate_s4_falsification(
+    *,
+    primary_trades: tuple[MetricTrade, ...],
+    upward_trades: tuple[MetricTrade, ...],
+) -> S4FalsificationResult:
+    reasons: set[str] = set()
+    incomplete_reasons: set[str] = set()
+
+    # -- Pooled timeout ratio (AC: pooled <=20%). --------------------------
+    total = len(primary_trades)
+    timeout_count = sum(1 for t in primary_trades if t.exit_reason == "TIMEOUT")
+    if total == 0:
+        pooled_timeout_ratio = 0.0
+        incomplete_reasons.add(INCOMPLETE_POOLED_TIMEOUT_UNDEFINED)
+    else:
+        pooled_timeout_ratio = timeout_count / total
+        if pooled_timeout_ratio > S4_POOLED_TIMEOUT_MAX:
+            reasons.add(REASON_POOLED_TIMEOUT_ABOVE)
+
+    # -- Per-fold timeout ratio (AC: every fold <=30%). --------------------
+    fold_counts: dict[str, int] = dict.fromkeys(FOLD_IDS, 0)
+    fold_timeouts: dict[str, int] = dict.fromkeys(FOLD_IDS, 0)
+    for t in primary_trades:
+        fold_counts[t.fold_id] += 1
+        if t.exit_reason == "TIMEOUT":
+            fold_timeouts[t.fold_id] += 1
+    fold_timeout_ratios: dict[str, float] = {}
+    for fold_id in FOLD_IDS:
+        if fold_counts[fold_id] == 0:
+            continue
+        ratio = fold_timeouts[fold_id] / fold_counts[fold_id]
+        fold_timeout_ratios[fold_id] = ratio
+        if ratio > S4_FOLD_TIMEOUT_MAX:
+            reasons.add(REASON_FOLD_TIMEOUT_ABOVE)
+
+    # -- High-M_t upward subbook (AC: M_t>3% strict >0). --------------------
+    high_m_net = [
+        t.net_bps
+        for t in upward_trades
+        if t.market_return_4h is not None and t.market_return_4h > S4_M_T_THRESHOLD
+    ]
+    high_market_return_e22_bps = (
+        sum(high_m_net) / len(high_m_net) if high_m_net else None
+    )
+    if high_market_return_e22_bps is None or not (high_market_return_e22_bps > 0.0):
+        reasons.add(REASON_HIGH_M_E22_NOT_POSITIVE)
+
+    # -- Correlation (AC: abs(Corr(gross_bps, M_t))<=0.15). ------------------
+    corr_xs = [
+        t.market_return_4h for t in primary_trades if t.market_return_4h is not None
+    ]
+    corr_ys = [t.gross_bps for t in primary_trades if t.market_return_4h is not None]
+    correlation = _pearson_corr(corr_xs, corr_ys)
+    if correlation is None:
+        incomplete_reasons.add(INCOMPLETE_CORRELATION_UNDEFINED)
+    elif abs(correlation) > S4_CORR_MAX + _CORR_BOUNDARY_EPSILON:
+        reasons.add(REASON_CORRELATION_ABOVE)
+
+    # -- Pair concentration (AC: conditional >0.70 AND others pooled<=0). ---
+    pair_trades: dict[str, list[MetricTrade]] = {p: [] for p in S4_PAIRS}
+    for t in primary_trades:
+        if t.dimension in pair_trades:
+            pair_trades[t.dimension].append(t)
+    missing_pairs = [p for p in S4_PAIRS if not pair_trades[p]]
+    pair_concentration: float | None = None
+    if missing_pairs:
+        incomplete_reasons.add(INCOMPLETE_PAIR_EVIDENCE_MISSING)
+    else:
+        pair_e17 = {
+            p: sum(t.net_bps for t in trades) / len(trades)
+            for p, trades in pair_trades.items()
+        }
+        positive_pairs = {p: v for p, v in pair_e17.items() if v > 0.0}
+        if positive_pairs:
+            total_positive = sum(positive_pairs.values())
+            dominant_pair = max(positive_pairs, key=lambda p: positive_pairs[p])
+            pair_concentration = positive_pairs[dominant_pair] / total_positive
+            if pair_concentration > S4_PAIR_CONCENTRATION_MAX:
+                others = [
+                    t for p in S4_PAIRS if p != dominant_pair for t in pair_trades[p]
+                ]
+                others_pooled_e17 = (
+                    sum(t.net_bps for t in others) / len(others) if others else 0.0
+                )
+                if others_pooled_e17 <= 0.0:
+                    reasons.add(REASON_PAIR_CONCENTRATION_ABOVE)
+
+    # -- Slow-only failure ([8h,32h)<=0 AND [32h,48h]>0). --------------------
+    mid_bucket_net = [
+        t.net_bps
+        for t in primary_trades
+        if S4_SLOW_BUCKET_START_MINUTES
+        <= t.holding_minutes
+        < S4_SLOW_BUCKET_MID_MINUTES
+    ]
+    slow_bucket_net = [
+        t.net_bps
+        for t in primary_trades
+        if S4_SLOW_BUCKET_MID_MINUTES <= t.holding_minutes <= S4_SLOW_BUCKET_END_MINUTES
+    ]
+    if not mid_bucket_net or not slow_bucket_net:
+        incomplete_reasons.add(INCOMPLETE_SLOW_BUCKET_EVIDENCE_MISSING)
+    else:
+        mid_bucket_e17 = sum(mid_bucket_net) / len(mid_bucket_net)
+        slow_bucket_e17 = sum(slow_bucket_net) / len(slow_bucket_net)
+        if mid_bucket_e17 <= 0.0 and slow_bucket_e17 > 0.0:
+            reasons.add(REASON_SLOW_ONLY_FAILURE)
+
+    # -- Attribution: exit-reason and pair breakdowns. -----------------------
+    exit_groups: dict[str, list[MetricTrade]] = {}
+    for t in primary_trades:
+        exit_groups.setdefault(t.exit_reason, []).append(t)
+    by_exit_reason = {
+        reason: _bucket(tuple(trades)) for reason, trades in exit_groups.items()
+    }
+    by_pair = {p: _bucket(tuple(trades)) for p, trades in pair_trades.items() if trades}
+
+    return S4FalsificationResult(
+        passed=not reasons,
+        reasons=tuple(sorted(reasons)),
+        incomplete_reasons=tuple(sorted(incomplete_reasons)),
+        pooled_timeout_ratio=pooled_timeout_ratio,
+        fold_timeout_ratios=fold_timeout_ratios,
+        high_market_return_e22_bps=high_market_return_e22_bps,
+        correlation=correlation,
+        pair_concentration=pair_concentration,
+        attribution={"by_exit_reason": by_exit_reason, "by_pair": by_pair},
+    )
+
+
+# ---------------------------------------------------------------------------
+# S4 pair-executor historical state -- a fixed literal (AC: historical-
+# screen-only, never a live-eligible/numeric-zero masquerade).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class S4PairExecutorState:
+    volatility_percentile: None
+    volatility_percentile_provenance: str
+    pair_executor_state: str
+    order_count: None
+    residual_count: None
+    pair_exec_fail_count: None
+    readiness: str
+    demo_eligible: bool
+
+    def __post_init__(self) -> None:
+        _require(
+            self.volatility_percentile is None,
+            "s4_pair_executor_volatility_percentile_must_be_none",
+        )
+        _require(
+            self.volatility_percentile_provenance == "not_defined_for_s4",
+            "s4_pair_executor_volatility_provenance_mismatch",
+        )
+        _require(
+            self.pair_executor_state == "not_evaluated",
+            "s4_pair_executor_state_mismatch",
+        )
+        _require(self.order_count is None, "s4_pair_executor_order_count_must_be_none")
+        _require(
+            self.residual_count is None, "s4_pair_executor_residual_count_must_be_none"
+        )
+        _require(
+            self.pair_exec_fail_count is None,
+            "s4_pair_executor_fail_count_must_be_none",
+        )
+        _require(
+            self.readiness == "historical_screen_only",
+            "s4_pair_executor_readiness_mismatch",
+        )
+        _require(
+            type(self.demo_eligible) is bool and self.demo_eligible is False,
+            "s4_pair_executor_demo_eligible_must_be_false",
+        )
+
+
+S4_HISTORICAL_PAIR_EXECUTOR_STATE = S4PairExecutorState(
+    volatility_percentile=None,
+    volatility_percentile_provenance="not_defined_for_s4",
+    pair_executor_state="not_evaluated",
+    order_count=None,
+    residual_count=None,
+    pair_exec_fail_count=None,
+    readiness="historical_screen_only",
+    demo_eligible=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Direct verdict tri-state (incomplete-first, then fail, then pass).
+# ---------------------------------------------------------------------------
+
+
+def compute_direct_verdict(
+    *, incomplete_reasons: tuple[str, ...], hard_gate_reasons: tuple[str, ...]
+) -> str:
+    if incomplete_reasons:
+        return DIRECT_VERDICT_INCOMPLETE
+    if hard_gate_reasons:
+        return DIRECT_VERDICT_FAIL
+    return DIRECT_VERDICT_PASS
+
+
+# ---------------------------------------------------------------------------
+# Campaign decision -- a separate, additive view; never overwrites the
+# independently-computed direct verdicts.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CampaignDecisionResult:
+    campaign_decision: str
+    s3_direct_verdict: str
+    s4_direct_verdict: str
+    demo_candidate: str | None
+    s4_observable_superiority: bool | None
+
+
+def compute_campaign_decision(
+    *,
+    s3_direct_verdict: str,
+    s4_direct_verdict: str,
+    s4_observable_superiority: bool | None = None,
+) -> CampaignDecisionResult:
+    if (
+        s3_direct_verdict == DIRECT_VERDICT_INCOMPLETE
+        or s4_direct_verdict == DIRECT_VERDICT_INCOMPLETE
+    ):
+        return CampaignDecisionResult(
+            campaign_decision=CAMPAIGN_DECISION_INCOMPLETE,
+            s3_direct_verdict=s3_direct_verdict,
+            s4_direct_verdict=s4_direct_verdict,
+            demo_candidate=None,
+            s4_observable_superiority=None,
+        )
+    if (
+        s3_direct_verdict == DIRECT_VERDICT_PASS
+        and s4_direct_verdict == DIRECT_VERDICT_PASS
+    ):
+        return CampaignDecisionResult(
+            campaign_decision=CAMPAIGN_DECISION_BOTH_PASS_S3_DEMO_CANDIDATE,
+            s3_direct_verdict=s3_direct_verdict,
+            s4_direct_verdict=s4_direct_verdict,
+            demo_candidate="S3",
+            s4_observable_superiority=s4_observable_superiority,
+        )
+    if s3_direct_verdict == DIRECT_VERDICT_PASS:
+        return CampaignDecisionResult(
+            campaign_decision=CAMPAIGN_DECISION_S3_ONLY,
+            s3_direct_verdict=s3_direct_verdict,
+            s4_direct_verdict=s4_direct_verdict,
+            demo_candidate="S3",
+            s4_observable_superiority=None,
+        )
+    if s4_direct_verdict == DIRECT_VERDICT_PASS:
+        return CampaignDecisionResult(
+            campaign_decision=CAMPAIGN_DECISION_S4_ONLY_NO_DEMO,
+            s3_direct_verdict=s3_direct_verdict,
+            s4_direct_verdict=s4_direct_verdict,
+            demo_candidate=None,
+            s4_observable_superiority=None,
+        )
+    return CampaignDecisionResult(
+        campaign_decision=CAMPAIGN_DECISION_BOTH_FAIL,
+        s3_direct_verdict=s3_direct_verdict,
+        s4_direct_verdict=s4_direct_verdict,
+        demo_candidate=None,
+        s4_observable_superiority=None,
+    )
+
+
+def s4_shows_observable_superiority(
+    *,
+    pooled_e17_s3: float,
+    pooled_e17_s4: float,
+    min_fold_e17_s3: float,
+    min_fold_e17_s4: float,
+    pooled_timeout_s3: float,
+    pooled_timeout_s4: float,
+) -> bool:
+    """Report-only: never flips ``campaign_decision`` or promotes S4 to a
+    demo candidate -- full promotion always remains ``not_evaluated``."""
+    return (
+        pooled_e17_s4 >= pooled_e17_s3 + _S4_SUPERIORITY_MIN_POOLED_E17_GAP_BPS
+        and min_fold_e17_s4 >= min_fold_e17_s3
+        and pooled_timeout_s4 <= pooled_timeout_s3 + _S4_SUPERIORITY_MAX_TIMEOUT_GAP
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyRankMetrics:
+    min_fold_e17: float
+    pooled_e17: float
+    monthly_concentration: float
+    timeout_ratio: float
+
+
+def rank_both_pass(
+    *, s3_metrics: StrategyRankMetrics, s4_metrics: StrategyRankMetrics
+) -> str:
+    """Literal both-pass historical rank: higher minimum-fold E17, then
+    higher pooled E17, then lower monthly concentration, then lower
+    timeout, then lower operational complexity (S3's single-symbol
+    fixed-notional position is always simpler than S4's two-leg basket --
+    the final tiebreak always favors S3)."""
+    comparisons: tuple[tuple[float, float, bool], ...] = (
+        (s3_metrics.min_fold_e17, s4_metrics.min_fold_e17, True),
+        (s3_metrics.pooled_e17, s4_metrics.pooled_e17, True),
+        (s3_metrics.monthly_concentration, s4_metrics.monthly_concentration, False),
+        (s3_metrics.timeout_ratio, s4_metrics.timeout_ratio, False),
+    )
+    for s3_val, s4_val, higher_is_better in comparisons:
+        if s3_val == s4_val:
+            continue
+        if higher_is_better:
+            return "S3" if s3_val > s4_val else "S4"
+        return "S3" if s3_val < s4_val else "S4"
+    return "S3"

--- a/research/nautilus_scalping/rob974_h5_s4.py
+++ b/research/nautilus_scalping/rob974_h5_s4.py
@@ -31,6 +31,7 @@ import math
 from dataclasses import dataclass
 
 from rob974_h5_contracts import FOLD_IDS, S4_PAIRS, H5InputError, MetricTrade
+from rob974_h5_gates import validate_selected_oos_membership
 
 __all__ = [
     "S4_CORR_MAX",
@@ -156,13 +157,12 @@ def evaluate_s4_falsification(
     primary_trades: tuple[MetricTrade, ...],
     upward_trades: tuple[MetricTrade, ...],
 ) -> S4FalsificationResult:
-    # D3 fail-closed membership binding (adversarial verify R1, finding 1):
-    # reject a path-scenario swap rather than silently scoring the wrong
-    # membership.
-    if any(t.path_scenario != "primary_stress17" for t in primary_trades):
-        raise H5InputError("s4_falsification_primary_path_scenario_mismatch")
-    if any(t.path_scenario != "upward_stress22" for t in upward_trades):
-        raise H5InputError("s4_falsification_upward_path_scenario_mismatch")
+    validate_selected_oos_membership(
+        primary_trades=primary_trades,
+        upward_trades=upward_trades,
+        authority="s4_falsification",
+        expected_strategy="S4",
+    )
 
     reasons: set[str] = set()
     incomplete_reasons: set[str] = set()
@@ -379,6 +379,13 @@ _VALID_DIRECT_VERDICTS = (
     DIRECT_VERDICT_FAIL,
     DIRECT_VERDICT_PASS,
 )
+_VALID_CAMPAIGN_DECISIONS = (
+    CAMPAIGN_DECISION_INCOMPLETE,
+    CAMPAIGN_DECISION_BOTH_FAIL,
+    CAMPAIGN_DECISION_S3_ONLY,
+    CAMPAIGN_DECISION_S4_ONLY_NO_DEMO,
+    CAMPAIGN_DECISION_BOTH_PASS_S3_DEMO_CANDIDATE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -390,6 +397,49 @@ class CampaignDecisionResult:
     demo_candidate: str | None
     historical_preferred: str | None
     s4_observable_superiority: bool | None
+
+    def __post_init__(self) -> None:
+        # Primitive/enum validation belongs on the DTO boundary.  Cross-field
+        # branch consistency is deliberately enforced later by the canonical
+        # scorecard authority, which has the gates/rank evidence needed to
+        # recompute the entire result rather than trusting these labels.
+        _require(
+            type(self.campaign_decision) is str
+            and self.campaign_decision in _VALID_CAMPAIGN_DECISIONS,
+            "campaign_decision_label_unknown",
+        )
+        _require(
+            type(self.campaign_historical_verdict) is str
+            and self.campaign_historical_verdict in _VALID_DIRECT_VERDICTS,
+            "campaign_historical_verdict_unknown",
+        )
+        _require(
+            type(self.s3_direct_verdict) is str
+            and self.s3_direct_verdict in _VALID_DIRECT_VERDICTS,
+            "campaign_decision_s3_verdict_unknown",
+        )
+        _require(
+            type(self.s4_direct_verdict) is str
+            and self.s4_direct_verdict in _VALID_DIRECT_VERDICTS,
+            "campaign_decision_s4_verdict_unknown",
+        )
+        _require(
+            self.demo_candidate is None
+            or type(self.demo_candidate) is str
+            and self.demo_candidate in ("S3", "S4"),
+            "campaign_demo_candidate_unknown",
+        )
+        _require(
+            self.historical_preferred is None
+            or type(self.historical_preferred) is str
+            and self.historical_preferred in ("S3", "S4"),
+            "campaign_historical_preferred_unknown",
+        )
+        _require(
+            self.s4_observable_superiority is None
+            or type(self.s4_observable_superiority) is bool,
+            "campaign_s4_observable_superiority_malformed",
+        )
 
 
 def compute_campaign_decision(
@@ -439,6 +489,20 @@ def compute_campaign_decision(
         historical_preferred = rank_both_pass(
             s3_metrics=s3_rank_metrics, s4_metrics=s4_rank_metrics
         )
+        recomputed_superiority = s4_shows_observable_superiority(
+            pooled_e17_s3=s3_rank_metrics.pooled_e17,
+            pooled_e17_s4=s4_rank_metrics.pooled_e17,
+            min_fold_e17_s3=s3_rank_metrics.min_fold_e17,
+            min_fold_e17_s4=s4_rank_metrics.min_fold_e17,
+            pooled_timeout_s3=s3_rank_metrics.timeout_ratio,
+            pooled_timeout_s4=s4_rank_metrics.timeout_ratio,
+        )
+        if s4_observable_superiority is not None:
+            _require(
+                type(s4_observable_superiority) is bool
+                and s4_observable_superiority is recomputed_superiority,
+                "campaign_s4_observable_superiority_forged_or_stale",
+            )
         return CampaignDecisionResult(
             campaign_decision=CAMPAIGN_DECISION_BOTH_PASS_S3_DEMO_CANDIDATE,
             campaign_historical_verdict=DIRECT_VERDICT_PASS,
@@ -446,7 +510,7 @@ def compute_campaign_decision(
             s4_direct_verdict=s4_direct_verdict,
             demo_candidate="S3",
             historical_preferred=historical_preferred,
-            s4_observable_superiority=s4_observable_superiority,
+            s4_observable_superiority=recomputed_superiority,
         )
     if s3_direct_verdict == DIRECT_VERDICT_PASS:
         return CampaignDecisionResult(

--- a/research/nautilus_scalping/rob974_h5_s4.py
+++ b/research/nautilus_scalping/rob974_h5_s4.py
@@ -156,6 +156,14 @@ def evaluate_s4_falsification(
     primary_trades: tuple[MetricTrade, ...],
     upward_trades: tuple[MetricTrade, ...],
 ) -> S4FalsificationResult:
+    # D3 fail-closed membership binding (adversarial verify R1, finding 1):
+    # reject a path-scenario swap rather than silently scoring the wrong
+    # membership.
+    if any(t.path_scenario != "primary_stress17" for t in primary_trades):
+        raise H5InputError("s4_falsification_primary_path_scenario_mismatch")
+    if any(t.path_scenario != "upward_stress22" for t in upward_trades):
+        raise H5InputError("s4_falsification_upward_path_scenario_mismatch")
+
     reasons: set[str] = set()
     incomplete_reasons: set[str] = set()
 
@@ -219,11 +227,15 @@ def evaluate_s4_falsification(
     if missing_pairs:
         incomplete_reasons.add(INCOMPLETE_PAIR_EVIDENCE_MISSING)
     else:
-        pair_e17 = {
-            p: sum(t.net_bps for t in trades) / len(trades)
-            for p, trades in pair_trades.items()
+        # D12 fix (adversarial verify R1, finding 3): concentration share is
+        # the SUM of net_bps per pair, never a per-pair MEAN -- a mean-based
+        # share is skewed by unequal trade counts across pairs (the
+        # authoritative definition is "max positive pair net / sum positive
+        # pair net").
+        pair_net_sum = {
+            p: sum(t.net_bps for t in trades) for p, trades in pair_trades.items()
         }
-        positive_pairs = {p: v for p, v in pair_e17.items() if v > 0.0}
+        positive_pairs = {p: v for p, v in pair_net_sum.items() if v > 0.0}
         if positive_pairs:
             total_positive = sum(positive_pairs.values())
             dominant_pair = max(positive_pairs, key=lambda p: positive_pairs[p])
@@ -362,12 +374,21 @@ def compute_direct_verdict(
 # ---------------------------------------------------------------------------
 
 
+_VALID_DIRECT_VERDICTS = (
+    DIRECT_VERDICT_INCOMPLETE,
+    DIRECT_VERDICT_FAIL,
+    DIRECT_VERDICT_PASS,
+)
+
+
 @dataclass(frozen=True, slots=True)
 class CampaignDecisionResult:
     campaign_decision: str
+    campaign_historical_verdict: str
     s3_direct_verdict: str
     s4_direct_verdict: str
     demo_candidate: str | None
+    historical_preferred: str | None
     s4_observable_superiority: bool | None
 
 
@@ -376,50 +397,84 @@ def compute_campaign_decision(
     s3_direct_verdict: str,
     s4_direct_verdict: str,
     s4_observable_superiority: bool | None = None,
+    s3_rank_metrics: StrategyRankMetrics | None = None,
+    s4_rank_metrics: StrategyRankMetrics | None = None,
 ) -> CampaignDecisionResult:
+    # D13 fix (adversarial verify R1, finding 4): reject a non-closed-enum
+    # verdict string rather than silently falling through to a default
+    # branch.
+    _require(
+        s3_direct_verdict in _VALID_DIRECT_VERDICTS,
+        "campaign_decision_s3_verdict_unknown",
+    )
+    _require(
+        s4_direct_verdict in _VALID_DIRECT_VERDICTS,
+        "campaign_decision_s4_verdict_unknown",
+    )
+
     if (
         s3_direct_verdict == DIRECT_VERDICT_INCOMPLETE
         or s4_direct_verdict == DIRECT_VERDICT_INCOMPLETE
     ):
         return CampaignDecisionResult(
             campaign_decision=CAMPAIGN_DECISION_INCOMPLETE,
+            campaign_historical_verdict=DIRECT_VERDICT_INCOMPLETE,
             s3_direct_verdict=s3_direct_verdict,
             s4_direct_verdict=s4_direct_verdict,
             demo_candidate=None,
+            historical_preferred=None,
             s4_observable_superiority=None,
         )
     if (
         s3_direct_verdict == DIRECT_VERDICT_PASS
         and s4_direct_verdict == DIRECT_VERDICT_PASS
     ):
+        # D13 fix (finding 5, AC44): historical_preferred is the both-pass
+        # literal rank -- report-only, never changes campaign_decision or
+        # the (operationally forced) S3 demo candidate.
+        _require(
+            s3_rank_metrics is not None and s4_rank_metrics is not None,
+            "campaign_decision_both_pass_requires_rank_metrics",
+        )
+        historical_preferred = rank_both_pass(
+            s3_metrics=s3_rank_metrics, s4_metrics=s4_rank_metrics
+        )
         return CampaignDecisionResult(
             campaign_decision=CAMPAIGN_DECISION_BOTH_PASS_S3_DEMO_CANDIDATE,
+            campaign_historical_verdict=DIRECT_VERDICT_PASS,
             s3_direct_verdict=s3_direct_verdict,
             s4_direct_verdict=s4_direct_verdict,
             demo_candidate="S3",
+            historical_preferred=historical_preferred,
             s4_observable_superiority=s4_observable_superiority,
         )
     if s3_direct_verdict == DIRECT_VERDICT_PASS:
         return CampaignDecisionResult(
             campaign_decision=CAMPAIGN_DECISION_S3_ONLY,
+            campaign_historical_verdict=DIRECT_VERDICT_PASS,
             s3_direct_verdict=s3_direct_verdict,
             s4_direct_verdict=s4_direct_verdict,
             demo_candidate="S3",
+            historical_preferred="S3",
             s4_observable_superiority=None,
         )
     if s4_direct_verdict == DIRECT_VERDICT_PASS:
         return CampaignDecisionResult(
             campaign_decision=CAMPAIGN_DECISION_S4_ONLY_NO_DEMO,
+            campaign_historical_verdict=DIRECT_VERDICT_PASS,
             s3_direct_verdict=s3_direct_verdict,
             s4_direct_verdict=s4_direct_verdict,
             demo_candidate=None,
+            historical_preferred="S4",
             s4_observable_superiority=None,
         )
     return CampaignDecisionResult(
         campaign_decision=CAMPAIGN_DECISION_BOTH_FAIL,
+        campaign_historical_verdict=DIRECT_VERDICT_FAIL,
         s3_direct_verdict=s3_direct_verdict,
         s4_direct_verdict=s4_direct_verdict,
         demo_candidate=None,
+        historical_preferred=None,
         s4_observable_superiority=None,
     )
 

--- a/research/nautilus_scalping/tests/test_rob962_frozen_production_delta.py
+++ b/research/nautilus_scalping/tests/test_rob962_frozen_production_delta.py
@@ -63,6 +63,16 @@ _AUTHORIZED_PRODUCTION_CHANGES = [
     ("A", ("research/nautilus_scalping/rob974_h3_s3.py",)),
     ("A", ("research/nautilus_scalping/rob974_h3_s4.py",)),
     ("A", ("research/nautilus_scalping/rob974_h3_smoke.py",)),
+    # ROB-983 authorized additive H5 modules.  The seven literals preserve
+    # the orch-approved checkpoint-per-file layout; no wildcard/prefix can
+    # silently admit a future production module.
+    ("A", ("research/nautilus_scalping/rob974_h5_canonical.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h5_contracts.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h5_dual_evidence.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h5_gates.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h5_markdown.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h5_s3.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h5_s4.py",)),
 ]
 _FROZEN_PATHS = (
     "research/nautilus_scalping",

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp1_envelope.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp1_envelope.py
@@ -1,0 +1,428 @@
+"""ROB-983 (H5, CP1) -- strict input envelope + H6-A accounting gate.
+
+Exact strategies/configs/folds/paths/dimensions, one-metric-trade-per-round-
+trip unit (leg count never a denominator), strict envelope verification, the
+H6-A exact-48 accounting gate, and AC34 structural-incomplete provenance
+classification (never historical_fail, regardless of how good the reported
+economics look).
+"""
+
+from __future__ import annotations
+
+import pytest
+from rob974_h5_contracts import (
+    CONFIGS_PER_STRATEGY,
+    FOLD_IDS,
+    PATH_SCENARIOS,
+    S3_SYMBOLS,
+    S4_PAIRS,
+    STRATEGIES,
+    STRUCTURAL_INCOMPLETE_REASONS,
+    CampaignEnvelope,
+    H5InputError,
+    H6AAccountingSeal,
+    MetricTrade,
+    classify_provenance_violation,
+    config_ids_for,
+    validate_envelope_and_accounting,
+)
+
+
+def _envelope(**overrides) -> CampaignEnvelope:
+    base = {
+        "full_campaign_hash": "a" * 64,
+        "campaign_run_id": "run-1",
+        "parent_corpus_hash": "b" * 64,
+        "parent_projection_hash": "c" * 64,
+        "feature_contract_hash": "d" * 64,
+        "strategy_contract_hashes": {"S3": "e" * 64, "S4": "f" * 64},
+        "h4_runner_source_hash": "1" * 64,
+        "h4_pbo_source_hash": "2" * 64,
+        "h2_engine_source_hash": "3" * 64,
+        "h3_generator_source_hash": "4" * 64,
+        "run_schema_version": "rob974-h5.v1",
+        "generator_version": "rob974-h5-scorecard/1.0.0",
+        "expected_experiment_ids": (
+            tuple(config_ids_for("S3")) + tuple(config_ids_for("S4"))
+        ),
+        "h6a_trial_accounting_hash": "5" * 64,
+    }
+    base.update(overrides)
+    return CampaignEnvelope(**base)
+
+
+def _accounting_seal(**overrides) -> H6AAccountingSeal:
+    base = {
+        "expected_total": 48,
+        "registered_total": 48,
+        "primary_attempts": 48,
+        "status_counts": {"completed": 48, "rejected": 0, "crashed": 0, "timeout": 0},
+        "retry_attempts": 0,
+        "accounting_complete": True,
+        "performance_usable": True,
+        "trial_accounting_hash": "5" * 64,
+        "reason_codes": (),
+    }
+    base.update(overrides)
+    return H6AAccountingSeal(**base)
+
+
+class TestExactDomainConstants:
+    def test_strategies_are_exact(self):
+        assert STRATEGIES == ("S3", "S4")
+
+    def test_config_ids_are_exact_24_each(self):
+        assert config_ids_for("S3") == tuple(f"S3-{i:02d}" for i in range(24))
+        assert config_ids_for("S4") == tuple(f"S4-{i:02d}" for i in range(24))
+        assert CONFIGS_PER_STRATEGY == 24
+
+    def test_fold_ids_are_exact_eight(self):
+        assert FOLD_IDS == tuple(f"fold-{i:02d}" for i in range(8))
+
+    def test_path_scenarios_are_exact(self):
+        assert PATH_SCENARIOS == ("base13", "primary_stress17", "upward_stress22")
+
+    def test_s3_symbol_order(self):
+        assert S3_SYMBOLS == ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
+
+    def test_s4_pair_order(self):
+        assert S4_PAIRS == ("XRP-DOGE", "XRP-SOL", "DOGE-SOL")
+
+
+class TestMetricTradeLegCountNeverDenominator:
+    def test_s3_trade_is_one_trade_regardless_of_representation(self):
+        trade = MetricTrade(
+            strategy="S3",
+            config_id="S3-00",
+            fold_id="fold-00",
+            path_scenario="primary_stress17",
+            dimension="XRPUSDT",
+            direction="long",
+            entry_ts=1_000,
+            exit_ts=2_000,
+            holding_minutes=15.0,
+            exit_reason="TP",
+            gross_bps=50.0,
+            net_bps=44.0,
+            tp_bps=68.0,
+            sl_bps=40.0,
+            gross_notional=None,
+            market_return_4h=0.01,
+            volatility_percentile=55.0,
+        )
+        # one MetricTrade == exactly one metric-trade unit; there is no
+        # separate "leg" field/count that could ever be summed as if it
+        # were additional trades.
+        assert not hasattr(trade, "leg_count")
+        assert not hasattr(trade, "legs")
+
+    def test_s4_two_leg_basket_is_one_trade(self):
+        trade = MetricTrade(
+            strategy="S4",
+            config_id="S4-00",
+            fold_id="fold-00",
+            path_scenario="primary_stress17",
+            dimension="XRP-DOGE",
+            direction="short_a_long_b",
+            entry_ts=1_000,
+            exit_ts=2_000,
+            holding_minutes=120.0,
+            exit_reason="MEAN_EXIT",
+            gross_bps=30.0,
+            net_bps=24.0,
+            tp_bps=60.0,
+            sl_bps=35.0,
+            gross_notional=15_000.0,
+            market_return_4h=0.005,
+            volatility_percentile=None,
+        )
+        assert not hasattr(trade, "leg_count")
+        assert not hasattr(trade, "legs")
+        assert trade.gross_notional == 15_000.0
+
+    def test_s4_volatility_percentile_must_be_none(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(
+                strategy="S4",
+                config_id="S4-00",
+                fold_id="fold-00",
+                path_scenario="base13",
+                dimension="XRP-DOGE",
+                direction="short_a_long_b",
+                entry_ts=1_000,
+                exit_ts=2_000,
+                holding_minutes=120.0,
+                exit_reason="TP",
+                gross_bps=30.0,
+                net_bps=24.0,
+                tp_bps=60.0,
+                sl_bps=35.0,
+                gross_notional=15_000.0,
+                market_return_4h=0.005,
+                volatility_percentile=1.0,  # forbidden -- S4 must be None
+            )
+
+    def test_s3_gross_notional_must_be_none(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(
+                strategy="S3",
+                config_id="S3-00",
+                fold_id="fold-00",
+                path_scenario="base13",
+                dimension="XRPUSDT",
+                direction="long",
+                entry_ts=1_000,
+                exit_ts=2_000,
+                holding_minutes=15.0,
+                exit_reason="TP",
+                gross_bps=50.0,
+                net_bps=44.0,
+                tp_bps=68.0,
+                sl_bps=40.0,
+                gross_notional=100.0,  # forbidden -- S3 is equal-weight/None
+                market_return_4h=0.01,
+                volatility_percentile=55.0,
+            )
+
+
+class TestMetricTradeTypeStrictness:
+    def test_bool_net_bps_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(
+                strategy="S3",
+                config_id="S3-00",
+                fold_id="fold-00",
+                path_scenario="base13",
+                dimension="XRPUSDT",
+                direction="long",
+                entry_ts=1_000,
+                exit_ts=2_000,
+                holding_minutes=15.0,
+                exit_reason="TP",
+                gross_bps=50.0,
+                net_bps=True,  # bool masquerading as float
+                tp_bps=68.0,
+                sl_bps=40.0,
+                gross_notional=None,
+                market_return_4h=0.01,
+                volatility_percentile=55.0,
+            )
+
+    def test_int_net_bps_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(
+                strategy="S3",
+                config_id="S3-00",
+                fold_id="fold-00",
+                path_scenario="base13",
+                dimension="XRPUSDT",
+                direction="long",
+                entry_ts=1_000,
+                exit_ts=2_000,
+                holding_minutes=15.0,
+                exit_reason="TP",
+                gross_bps=50.0,
+                net_bps=44,  # int masquerading as float
+                tp_bps=68.0,
+                sl_bps=40.0,
+                gross_notional=None,
+                market_return_4h=0.01,
+                volatility_percentile=55.0,
+            )
+
+    def test_nan_net_bps_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(
+                strategy="S3",
+                config_id="S3-00",
+                fold_id="fold-00",
+                path_scenario="base13",
+                dimension="XRPUSDT",
+                direction="long",
+                entry_ts=1_000,
+                exit_ts=2_000,
+                holding_minutes=15.0,
+                exit_reason="TP",
+                gross_bps=50.0,
+                net_bps=float("nan"),
+                tp_bps=68.0,
+                sl_bps=40.0,
+                gross_notional=None,
+                market_return_4h=0.01,
+                volatility_percentile=55.0,
+            )
+
+    def test_bool_entry_ts_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(
+                strategy="S3",
+                config_id="S3-00",
+                fold_id="fold-00",
+                path_scenario="base13",
+                dimension="XRPUSDT",
+                direction="long",
+                entry_ts=True,
+                exit_ts=2_000,
+                holding_minutes=15.0,
+                exit_reason="TP",
+                gross_bps=50.0,
+                net_bps=44.0,
+                tp_bps=68.0,
+                sl_bps=40.0,
+                gross_notional=None,
+                market_return_4h=0.01,
+                volatility_percentile=55.0,
+            )
+
+
+class TestEnvelopeVerification:
+    def test_valid_envelope_and_accounting_passes(self):
+        result = validate_envelope_and_accounting(_envelope(), _accounting_seal())
+        assert result.incomplete_reasons == ()
+        assert result.ok is True
+
+    def test_missing_49th_config_id_rejected(self):
+        ids = tuple(config_ids_for("S3")) + tuple(config_ids_for("S4")) + ("S3-99",)
+        with pytest.raises(H5InputError):
+            _envelope(expected_experiment_ids=ids)
+
+    def test_missing_config_id_rejected(self):
+        ids = (tuple(config_ids_for("S3")) + tuple(config_ids_for("S4")))[:-1]
+        with pytest.raises(H5InputError):
+            _envelope(expected_experiment_ids=ids)
+
+    def test_duplicate_config_id_rejected(self):
+        ids = list(tuple(config_ids_for("S3")) + tuple(config_ids_for("S4")))
+        ids[1] = ids[0]
+        with pytest.raises(H5InputError):
+            _envelope(expected_experiment_ids=tuple(ids))
+
+    def test_reordered_config_ids_rejected(self):
+        ids = tuple(config_ids_for("S3")) + tuple(config_ids_for("S4"))
+        reordered = (ids[1], ids[0]) + ids[2:]
+        with pytest.raises(H5InputError):
+            _envelope(expected_experiment_ids=reordered)
+
+    def test_bad_hash_format_rejected(self):
+        with pytest.raises(H5InputError):
+            _envelope(full_campaign_hash="not-a-hash")
+
+
+class TestH6AAccountingGate:
+    def test_47_of_48_makes_campaign_incomplete(self):
+        seal = _accounting_seal(
+            registered_total=47,
+            primary_attempts=47,
+            status_counts={"completed": 47, "rejected": 0, "crashed": 0, "timeout": 0},
+            accounting_complete=False,
+            performance_usable=False,
+            reason_codes=("h6_accounting_incomplete",),
+        )
+        result = validate_envelope_and_accounting(_envelope(), seal)
+        assert result.ok is False
+        assert "h6_accounting_incomplete" in result.incomplete_reasons
+
+    def test_49_registered_rejected(self):
+        with pytest.raises(H5InputError):
+            _accounting_seal(registered_total=49)
+
+    def test_status_sum_not_48_rejected(self):
+        with pytest.raises(H5InputError):
+            _accounting_seal(
+                status_counts={
+                    "completed": 47,
+                    "rejected": 0,
+                    "crashed": 0,
+                    "timeout": 0,
+                }
+            )
+
+    def test_nonzero_retry_makes_campaign_incomplete(self):
+        seal = _accounting_seal(
+            retry_attempts=1,
+            performance_usable=False,
+            reason_codes=("h6_accounting_has_retries",),
+        )
+        result = validate_envelope_and_accounting(_envelope(), seal)
+        assert result.ok is False
+
+    def test_complete_true_with_usable_false_is_rejected_shape(self):
+        # accounting_complete=True but performance_usable=False (e.g. a
+        # primary that didn't complete) is a VALID, well-formed-incomplete
+        # combination -- must surface as campaign incomplete, never raise.
+        seal = _accounting_seal(
+            status_counts={"completed": 47, "rejected": 1, "crashed": 0, "timeout": 0},
+            performance_usable=False,
+            reason_codes=("h6_primary_attempt_not_completed",),
+        )
+        result = validate_envelope_and_accounting(_envelope(), seal)
+        assert result.ok is False
+        assert "h6_primary_attempt_not_completed" in result.incomplete_reasons
+
+    def test_hidden_rejected_row_under_status_sum_48_is_incomplete(self):
+        seal = _accounting_seal(
+            status_counts={"completed": 47, "rejected": 1, "crashed": 0, "timeout": 0},
+            performance_usable=False,
+            reason_codes=("h6_primary_attempt_not_completed",),
+        )
+        result = validate_envelope_and_accounting(_envelope(), seal)
+        assert result.ok is False
+        # status sum is still 48 -- this must not be mistaken for a fully
+        # usable, all-completed accounting seal.
+        assert sum(seal.status_counts.values()) == 48
+        assert result.ok is False
+
+    def test_excellent_partial_subset_is_still_incomplete(self):
+        # A caller must never be tempted to score a highly profitable
+        # 47-of-48 subset as if it were the full campaign.
+        seal = _accounting_seal(
+            registered_total=47,
+            primary_attempts=47,
+            status_counts={"completed": 47, "rejected": 0, "crashed": 0, "timeout": 0},
+            accounting_complete=False,
+            performance_usable=False,
+            reason_codes=("h6_accounting_incomplete",),
+        )
+        result = validate_envelope_and_accounting(_envelope(), seal)
+        assert result.ok is False
+
+
+class TestAC34StructuralIncompleteClassification:
+    @pytest.mark.parametrize(
+        "violation",
+        sorted(STRUCTURAL_INCOMPLETE_REASONS),
+    )
+    def test_every_ac34_violation_classifies_as_incomplete_never_fail(self, violation):
+        assert classify_provenance_violation(violation) == "incomplete"
+
+    def test_ac34_violation_set_covers_required_categories(self):
+        required_substrings = (
+            "missing_bar",
+            "future_bar",
+            "lookahead",
+            "signal_close_fill",
+            "unpriced_gap",
+            "double_charge",
+            "single_leg_notional_denominator",
+            "fabricated",
+            "nonfinite",
+            "type_invalid",
+            "missing_pbo",
+            "missing_accounting",
+            "missing_evidence",
+        )
+        for substring in required_substrings:
+            assert any(
+                substring in reason for reason in STRUCTURAL_INCOMPLETE_REASONS
+            ), f"no structural-incomplete reason covers {substring!r}"
+
+    def test_unknown_violation_code_raises_rather_than_silently_passing(self):
+        with pytest.raises(H5InputError):
+            classify_provenance_violation("not_a_real_violation_code")
+
+    def test_excellent_economics_do_not_downgrade_ac34_violation_to_fail(self):
+        # Even a caller asserting outstanding P&L cannot turn a structural
+        # provenance violation into historical_fail -- the classification is
+        # a pure function of the violation code alone.
+        for violation in STRUCTURAL_INCOMPLETE_REASONS:
+            assert classify_provenance_violation(violation) == "incomplete"

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp1_envelope.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp1_envelope.py
@@ -184,6 +184,56 @@ class TestMetricTradeLegCountNeverDenominator:
                 volatility_percentile=55.0,
             )
 
+    def _s4_trade_kwargs(self, **overrides):
+        fields = {
+            "strategy": "S4",
+            "config_id": "S4-00",
+            "fold_id": "fold-00",
+            "path_scenario": "primary_stress17",
+            "dimension": "XRP-DOGE",
+            "direction": "short_a_long_b",
+            "entry_ts": 1_000,
+            "exit_ts": 2_000,
+            "holding_minutes": 120.0,
+            "exit_reason": "MEAN_EXIT",
+            "gross_bps": 30.0,
+            "net_bps": 24.0,
+            "tp_bps": 60.0,
+            "sl_bps": 35.0,
+            "gross_notional": 15_000.0,
+            "market_return_4h": 0.005,
+            "volatility_percentile": None,
+        }
+        fields.update(overrides)
+        return fields
+
+    def test_s4_gross_notional_none_rejected(self):
+        # D12 fix (adversarial verify R1, finding 2): S4's required gross
+        # basket notional G can never be None -- a missing G must never
+        # silently fall back to S3's equal-weight (1.0) convention.
+        with pytest.raises(H5InputError):
+            MetricTrade(**self._s4_trade_kwargs(gross_notional=None))
+
+    def test_s4_gross_notional_zero_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(**self._s4_trade_kwargs(gross_notional=0.0))
+
+    def test_s4_gross_notional_negative_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(**self._s4_trade_kwargs(gross_notional=-100.0))
+
+    def test_s4_gross_notional_bool_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(**self._s4_trade_kwargs(gross_notional=True))
+
+    def test_s4_gross_notional_int_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(**self._s4_trade_kwargs(gross_notional=100))
+
+    def test_s4_gross_notional_nan_rejected(self):
+        with pytest.raises(H5InputError):
+            MetricTrade(**self._s4_trade_kwargs(gross_notional=float("nan")))
+
 
 class TestMetricTradeTypeStrictness:
     def test_bool_net_bps_rejected(self):
@@ -325,6 +375,21 @@ class TestH6AAccountingGate:
     def test_49_registered_rejected(self):
         with pytest.raises(H5InputError):
             _accounting_seal(registered_total=49)
+
+    def test_expected_total_decimal_rejected(self):
+        # Discovered gap (adversarial verify R1, finding 7): expected_total
+        # was checked via `==48` only, not exact-int type --
+        # Decimal(48)==48 is True in Python, so it silently slipped past
+        # the equality check.
+        from decimal import Decimal
+
+        with pytest.raises(H5InputError):
+            _accounting_seal(expected_total=Decimal(48))
+
+    def test_expected_total_float_rejected(self):
+        # 48.0 == 48 is True in Python -- must still be type-rejected.
+        with pytest.raises(H5InputError):
+            _accounting_seal(expected_total=48.0)
 
     def test_status_sum_not_48_rejected(self):
         with pytest.raises(H5InputError):

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp2_dual_evidence.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp2_dual_evidence.py
@@ -1,0 +1,255 @@
+"""ROB-983 (H5, CP2) -- selected-OOS dual evidence and PBO prerequisites.
+
+Unique generator evidence (scenario-independent, H3-canonical candidate
+identity) is kept strictly separate from each of the three path invocation
+evidence rows (base13/primary_stress17/upward_stress22). Every path's
+accepted-input hash/count must trace back to the SAME unique accepted set --
+never a scenario sum/intersection/first-path reconstruction, and never a
+tripled count. PBO is required, independently evaluated, 24x365/slices=4,
+reference-only (it can never flip a verdict) -- missing/placeholder/invalid
+PBO makes the campaign incomplete, never a raise-on-missing (a caller may
+legitimately not have it yet).
+"""
+
+from __future__ import annotations
+
+import pytest
+from rob974_h5_contracts import H5InputError
+from rob974_h5_dual_evidence import (
+    PBO_CONFIG_COUNT,
+    PBO_DAY_COUNT,
+    PBO_SCENARIO_NAME,
+    PBO_SLICES,
+    PathInvocationEvidence,
+    PboEvidence,
+    UniqueGeneratorEvidence,
+    cross_check_dual_evidence,
+    validate_pbo_evidence,
+)
+
+
+def _unique(**overrides) -> UniqueGeneratorEvidence:
+    base = {
+        "strategy": "S3",
+        "config_id": "S3-00",
+        "fold_id": "fold-00",
+        "accepted": 10,
+        "rejected": 5,
+        "accepted_input_hash": "a" * 64,
+        "rejection_reason_histogram": {
+            "next_bar_unavailable": 3,
+            "tp_below_r_min_sl": 2,
+        },
+    }
+    base.update(overrides)
+    return UniqueGeneratorEvidence(**base)
+
+
+def _path(
+    path_scenario: str, unique: UniqueGeneratorEvidence, **overrides
+) -> PathInvocationEvidence:
+    base = {
+        "strategy": unique.strategy,
+        "config_id": unique.config_id,
+        "fold_id": unique.fold_id,
+        "path_scenario": path_scenario,
+        "unique_evidence_hash": unique.accepted_input_hash,
+        "unique_evidence_accepted_count": unique.accepted,
+        "engine_input_hash": "b" * 64,
+        "engine_input_count": unique.accepted,
+        "no_trade_reason_counts": {"insufficient_oos_exit_horizon": 1},
+        "ledger_status": "completed",
+        "trade_count": unique.accepted - 1,
+        "artifact_hash": "c" * 64,
+    }
+    base.update(overrides)
+    return PathInvocationEvidence(**base)
+
+
+def _three_paths(unique: UniqueGeneratorEvidence) -> dict[str, PathInvocationEvidence]:
+    return {
+        name: _path(name, unique)
+        for name in ("base13", "primary_stress17", "upward_stress22")
+    }
+
+
+class TestUniqueGeneratorEvidenceInvariants:
+    def test_candidate_equals_accepted_plus_rejected(self):
+        unique = _unique()
+        assert unique.candidate == unique.accepted + unique.rejected == 15
+
+    def test_reason_histogram_subtotal_equals_rejected(self):
+        with pytest.raises(H5InputError):
+            _unique(
+                rejection_reason_histogram={"next_bar_unavailable": 1}
+            )  # sums to 1, not 5
+
+    def test_negative_accepted_rejected(self):
+        with pytest.raises(H5InputError):
+            _unique(accepted=-1)
+
+    def test_bad_hash_format_rejected(self):
+        with pytest.raises(H5InputError):
+            _unique(accepted_input_hash="not-hex")
+
+    def test_zero_rejection_with_empty_histogram_is_valid(self):
+        unique = _unique(rejected=0, rejection_reason_histogram={})
+        assert unique.rejected == 0
+        assert unique.rejection_reason_histogram == {}
+
+    def test_nonzero_rejection_cannot_be_hidden_as_empty_histogram(self):
+        with pytest.raises(H5InputError):
+            _unique(rejected=5, rejection_reason_histogram={})
+
+
+class TestPathAgreesWithUniqueSource:
+    def test_valid_three_paths_cross_check_passes(self):
+        unique = _unique()
+        paths = _three_paths(unique)
+        cross_check_dual_evidence(unique, paths)  # must not raise
+
+    def test_missing_path_rejected(self):
+        unique = _unique()
+        paths = _three_paths(unique)
+        del paths["upward_stress22"]
+        with pytest.raises(H5InputError):
+            cross_check_dual_evidence(unique, paths)
+
+    def test_path_referencing_wrong_unique_hash_rejected(self):
+        unique = _unique()
+        paths = _three_paths(unique)
+        paths["base13"] = _path("base13", unique, unique_evidence_hash="f" * 64)
+        with pytest.raises(H5InputError):
+            cross_check_dual_evidence(unique, paths)
+
+    def test_path_tripling_accepted_count_rejected(self):
+        # Simulates the "tripled unique counts" mutant: a path claims the
+        # accepted count is 3x the real unique-accepted value (as if
+        # summed across all three scenario paths).
+        unique = _unique()
+        paths = _three_paths(unique)
+        paths["primary_stress17"] = _path(
+            "primary_stress17",
+            unique,
+            unique_evidence_accepted_count=unique.accepted * 3,
+        )
+        with pytest.raises(H5InputError):
+            cross_check_dual_evidence(unique, paths)
+
+    def test_first_path_reconstruction_mutant_rejected(self):
+        # A caller must not substitute "whatever the first path happened to
+        # see" as if it were the canonical unique accepted count.
+        unique = _unique()
+        paths = _three_paths(unique)
+        wrong_first = dict(paths)
+        wrong_first["base13"] = _path(
+            "base13", unique, unique_evidence_accepted_count=unique.accepted - 1
+        )
+        with pytest.raises(H5InputError):
+            cross_check_dual_evidence(unique, wrong_first)
+
+    def test_intersection_reconstruction_mutant_rejected(self):
+        unique = _unique()
+        paths = _three_paths(unique)
+        # Pretend the caller computed an intersection-derived accepted
+        # count smaller than the true unique accepted set.
+        paths["upward_stress22"] = _path(
+            "upward_stress22",
+            unique,
+            unique_evidence_accepted_count=unique.accepted // 2,
+        )
+        with pytest.raises(H5InputError):
+            cross_check_dual_evidence(unique, paths)
+
+    def test_missing_zero_default_engine_hash_rejected(self):
+        unique = _unique()
+        with pytest.raises(H5InputError):
+            _path("base13", unique, engine_input_hash="")
+
+    def test_nonzero_path_rejection_reason_stays_nonzero(self):
+        unique = _unique()
+        paths = _three_paths(unique)
+        paths["base13"] = _path(
+            "base13",
+            unique,
+            no_trade_reason_counts={"expected_funding_cost_above_3bps": 2},
+        )
+        cross_check_dual_evidence(unique, paths)  # must not raise
+        assert paths["base13"].no_trade_reason_counts == {
+            "expected_funding_cost_above_3bps": 2
+        }
+
+    def test_wrong_strategy_or_config_binding_rejected(self):
+        unique = _unique()
+        paths = _three_paths(unique)
+        paths["base13"] = _path("base13", unique, config_id="S3-01")
+        with pytest.raises(H5InputError):
+            cross_check_dual_evidence(unique, paths)
+
+
+class TestPboPrerequisites:
+    def _pbo(self, **overrides) -> PboEvidence:
+        base = {
+            "strategy": "S3",
+            "config_count": PBO_CONFIG_COUNT,
+            "day_count": PBO_DAY_COUNT,
+            "slices": PBO_SLICES,
+            "scenario_name": PBO_SCENARIO_NAME,
+            "value": 0.42,
+            "reason_codes": (),
+            "source_hash": "a" * 64,
+            "input_hash": "b" * 64,
+            "artifact_hash": "c" * 64,
+        }
+        base.update(overrides)
+        return PboEvidence(**base)
+
+    def test_valid_pbo_evidence_passes(self):
+        result = validate_pbo_evidence(self._pbo())
+        assert result.ok is True
+
+    def test_23_configs_rejected(self):
+        with pytest.raises(H5InputError):
+            self._pbo(config_count=23)
+
+    def test_25_configs_rejected(self):
+        with pytest.raises(H5InputError):
+            self._pbo(config_count=25)
+
+    def test_364_days_rejected(self):
+        with pytest.raises(H5InputError):
+            self._pbo(day_count=364)
+
+    def test_366_days_rejected(self):
+        with pytest.raises(H5InputError):
+            self._pbo(day_count=366)
+
+    def test_wrong_slices_rejected(self):
+        with pytest.raises(H5InputError):
+            self._pbo(slices=5)
+
+    def test_wrong_scenario_rejected(self):
+        with pytest.raises(H5InputError):
+            self._pbo(scenario_name="base13")
+
+    def test_missing_pbo_evidence_is_incomplete_not_a_raise(self):
+        result = validate_pbo_evidence(None)
+        assert result.ok is False
+        assert "missing_pbo_evidence" in result.incomplete_reasons
+
+    def test_evaluator_failure_reason_code_is_incomplete(self):
+        pbo = self._pbo(value=None, reason_codes=("evaluator_failed",))
+        result = validate_pbo_evidence(pbo)
+        assert result.ok is False
+
+    def test_extreme_pbo_value_never_flips_a_verdict(self):
+        # PboEvidence exposes no verdict-shaped field at all -- there is
+        # nothing for a caller to branch a pass/fail decision on besides
+        # the (reference-only) value/reason_codes fields, and neither this
+        # module nor any gate-evaluation module ever imports the value into
+        # a hard gate.
+        overfit = self._pbo(value=0.99)
+        clean = self._pbo(value=0.01)
+        assert validate_pbo_evidence(overfit).ok == validate_pbo_evidence(clean).ok
+        assert not hasattr(overfit, "verdict")
+        assert not hasattr(clean, "verdict")

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp3_common_gates.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp3_common_gates.py
@@ -77,11 +77,20 @@ def _passing_primary_trades() -> tuple[MetricTrade, ...]:
     return tuple(trades)
 
 
-def _upward_trades(net_bps: float, count: int = 5) -> tuple[MetricTrade, ...]:
+def _upward_trades(
+    net_bps: float, count: int = 5, *, strategy: str = "S3"
+) -> tuple[MetricTrade, ...]:
+    config_id = f"{strategy}-00"
+    dimension = "XRPUSDT" if strategy == "S3" else "XRP-DOGE"
+    gross_notional = None if strategy == "S3" else 100.0
     return tuple(
         _trade(
             "fold-00",
             net_bps,
+            strategy=strategy,
+            config_id=config_id,
+            dimension=dimension,
+            gross_notional=gross_notional,
             path_scenario="upward_stress22",
             exit_ts=i * _DAY_MS,
         )
@@ -359,7 +368,8 @@ class TestWinMarginAndPbe:
             exit_ts=1,
         )
         result = evaluate_common_gates(
-            primary_trades=(big, small), upward_trades=_upward_trades(1.0)
+            primary_trades=(big, small),
+            upward_trades=_upward_trades(1.0, strategy="S4"),
         )
         big_pbe = (10.0 + 17.0) / (100.0 + 10.0)
         small_pbe = (100.0 + 17.0) / (10.0 + 100.0)
@@ -460,4 +470,62 @@ class TestPathScenarioMembershipBinding:
             evaluate_common_gates(
                 primary_trades=_passing_primary_trades(),
                 upward_trades=wrong_path_upward,
+            )
+
+
+class TestSelectedOosMembershipBinding:
+    """D3 R2 regressions: all metrics must consume one selected-OOS book.
+
+    The path label alone is insufficient: strategy and selected config are
+    equally authoritative membership domains.  Cherry-picking profitable
+    rows from the 24 configs or mixing S3/S4 rows must raise before any gate
+    arithmetic runs.
+    """
+
+    def test_cherry_pick_across_24_configs_rejected(self):
+        primary = tuple(
+            _trade(
+                FOLD_IDS[i % len(FOLD_IDS)],
+                40.0,
+                gross_bps=45.0,
+                config_id=f"S3-{i % 24:02d}",
+                exit_ts=i * _DAY_MS,
+            )
+            for i in range(48)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_common_gates(
+                primary_trades=primary, upward_trades=_upward_trades(10.0)
+            )
+
+    def test_mixed_strategy_primary_book_rejected(self):
+        s4_row = _trade(
+            "fold-00",
+            40.0,
+            strategy="S4",
+            config_id="S4-00",
+            dimension="XRP-DOGE",
+            gross_notional=100.0,
+            exit_ts=999 * _DAY_MS,
+        )
+        with pytest.raises(H5InputError):
+            evaluate_common_gates(
+                primary_trades=_passing_primary_trades() + (s4_row,),
+                upward_trades=_upward_trades(10.0),
+            )
+
+    def test_primary_and_upward_selected_config_mismatch_rejected(self):
+        upward = tuple(
+            _trade(
+                "fold-00",
+                10.0,
+                config_id="S3-01",
+                path_scenario="upward_stress22",
+                exit_ts=i * _DAY_MS,
+            )
+            for i in range(5)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_common_gates(
+                primary_trades=_passing_primary_trades(), upward_trades=upward
             )

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp3_common_gates.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp3_common_gates.py
@@ -1,0 +1,434 @@
+"""ROB-983 (H5, CP3) -- common hard gates, E0, and win authority.
+
+All conditions must pass for ``historical_pass``; every stable failure
+reason is collected -- never short-circuited. Every exact registered
+boundary passes; the immediately failing-side value (via
+``math.nextafter``) fails.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from rob974_h5_contracts import FOLD_IDS, MetricTrade
+from rob974_h5_gates import (
+    MIN_TRADES_PER_FOLD,
+    PF17_MIN,
+    WIN_MARGIN_MIN,
+    evaluate_common_gates,
+)
+
+_DAY_MS = 24 * 60 * 60 * 1000
+_MONTH_MS = 30 * _DAY_MS
+
+
+def _trade(
+    fold_id: str,
+    net_bps: float,
+    *,
+    gross_bps: float | None = None,
+    exit_ts: int = 0,
+    tp_bps: float = 68.0,
+    sl_bps: float = 40.0,
+    strategy: str = "S3",
+    config_id: str = "S3-00",
+    dimension: str = "XRPUSDT",
+    gross_notional: float | None = None,
+    exit_reason: str = "TP",
+    path_scenario: str = "primary_stress17",
+) -> MetricTrade:
+    return MetricTrade(
+        strategy=strategy,
+        config_id=config_id,
+        fold_id=fold_id,
+        path_scenario=path_scenario,
+        dimension=dimension,
+        direction="long",
+        entry_ts=exit_ts,
+        exit_ts=exit_ts + 60_000,
+        holding_minutes=1.0,
+        exit_reason=exit_reason,
+        gross_bps=gross_bps if gross_bps is not None else net_bps,
+        net_bps=net_bps,
+        tp_bps=tp_bps,
+        sl_bps=sl_bps,
+        gross_notional=gross_notional,
+        market_return_4h=0.0,
+        volatility_percentile=50.0 if strategy == "S3" else None,
+    )
+
+
+def _passing_primary_trades() -> tuple[MetricTrade, ...]:
+    """Exactly one clean pass fixture: 8 folds x 5 trades, pooled E17 well
+    above every threshold, 6/8 positive folds, single-month concentration
+    at the boundary is handled by dedicated boundary tests below."""
+    trades = []
+    for i, fold_id in enumerate(FOLD_IDS):
+        # months spread out so concentration stays low in the base fixture
+        month_ts = i * _MONTH_MS
+        net = 20.0 if i < 6 else -5.0  # 6 positive folds, 2 negative
+        for j in range(5):
+            trades.append(
+                _trade(
+                    fold_id, net, exit_ts=month_ts + j * _DAY_MS, gross_bps=net + 26.0
+                )
+            )
+    return tuple(trades)
+
+
+def _upward_trades(net_bps: float, count: int = 5) -> tuple[MetricTrade, ...]:
+    return tuple(
+        _trade(
+            "fold-00",
+            net_bps,
+            path_scenario="upward_stress22",
+            exit_ts=i * _DAY_MS,
+        )
+        for i in range(count)
+    )
+
+
+class TestCleanPass:
+    def test_all_common_gates_pass(self):
+        result = evaluate_common_gates(
+            primary_trades=_passing_primary_trades(),
+            upward_trades=_upward_trades(10.0),
+        )
+        assert result.passed is True
+        assert result.reasons == ()
+        assert result.pooled_e17_bps == pytest.approx(
+            (20.0 * 6 + -5.0 * 2) / 8, abs=1e-9
+        )
+
+
+class TestPooledExpectancyBoundary:
+    def test_exact_5bp_passes(self):
+        trades = tuple(
+            _trade(fold_id, 5.0, exit_ts=i * _DAY_MS)
+            for i, fold_id in enumerate(FOLD_IDS)
+            for _ in range(5)
+        )[:40]
+        result = evaluate_common_gates(
+            primary_trades=trades, upward_trades=_upward_trades(1.0)
+        )
+        assert "pooled_e17_below_5bp" not in result.reasons
+
+    def test_just_below_5bp_fails(self):
+        below = math.nextafter(5.0, -math.inf)
+        trades = tuple(
+            _trade(fold_id, below, exit_ts=i * _DAY_MS)
+            for i, fold_id in enumerate(FOLD_IDS)
+            for _ in range(5)
+        )
+        result = evaluate_common_gates(
+            primary_trades=trades, upward_trades=_upward_trades(1.0)
+        )
+        assert "pooled_e17_below_5bp" in result.reasons
+        assert result.passed is False
+
+
+class TestProfitFactorBoundary:
+    def _trades_for_pf(self, pf: float) -> tuple[MetricTrade, ...]:
+        # 8 wins of +10, 8 losses of -x such that PF = 80 / (8x) == pf
+        loss = 80.0 / (8.0 * pf)
+        trades = []
+        for i, fold_id in enumerate(FOLD_IDS):
+            trades.append(_trade(fold_id, 10.0, exit_ts=i * _DAY_MS))
+            trades.append(_trade(fold_id, -loss, exit_ts=i * _DAY_MS + 1))
+        return tuple(trades)
+
+    def test_exact_115_passes(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_for_pf(PF17_MIN),
+            upward_trades=_upward_trades(1.0),
+        )
+        assert "pf17_below_1_15" not in result.reasons
+
+    def test_just_below_115_fails(self):
+        below = math.nextafter(PF17_MIN, -math.inf)
+        result = evaluate_common_gates(
+            primary_trades=self._trades_for_pf(below), upward_trades=_upward_trades(1.0)
+        )
+        assert "pf17_below_1_15" in result.reasons
+
+
+class TestPositiveFoldsBoundary:
+    def _trades_with_n_positive_folds(self, n_positive: int) -> tuple[MetricTrade, ...]:
+        trades = []
+        for i, fold_id in enumerate(FOLD_IDS):
+            net = 20.0 if i < n_positive else -20.0
+            for j in range(5):
+                trades.append(_trade(fold_id, net, exit_ts=i * _MONTH_MS + j * _DAY_MS))
+        return tuple(trades)
+
+    def test_exactly_5_positive_folds_passes(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_n_positive_folds(5),
+            upward_trades=_upward_trades(1.0),
+        )
+        assert "insufficient_positive_folds" not in result.reasons
+        assert result.positive_fold_count == 5
+
+    def test_4_positive_folds_fails(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_n_positive_folds(4),
+            upward_trades=_upward_trades(1.0),
+        )
+        assert "insufficient_positive_folds" in result.reasons
+        assert result.positive_fold_count == 4
+
+
+class TestMonthlyConcentrationBoundary:
+    def test_exact_50_percent_passes(self):
+        # Two positive months with equal net (50/50 split) -> concentration
+        # == 0.50 exactly.
+        trades = []
+        for i, fold_id in enumerate(FOLD_IDS[:2]):
+            for j in range(5):
+                trades.append(
+                    _trade(fold_id, 10.0, exit_ts=i * _MONTH_MS * 2 + j * _DAY_MS)
+                )
+        for i, fold_id in enumerate(FOLD_IDS[2:8]):
+            for _j in range(5):
+                trades.append(_trade(fold_id, 5.0, exit_ts=i * _DAY_MS))
+        result = evaluate_common_gates(
+            primary_trades=tuple(trades), upward_trades=_upward_trades(1.0)
+        )
+        assert result.monthly_concentration is not None
+
+    def test_no_positive_months_fails(self):
+        trades = tuple(
+            _trade(fold_id, -5.0, exit_ts=i * _MONTH_MS)
+            for i, fold_id in enumerate(FOLD_IDS)
+            for _ in range(5)
+        )
+        result = evaluate_common_gates(
+            primary_trades=trades, upward_trades=_upward_trades(1.0)
+        )
+        assert "no_positive_months" in result.reasons
+
+
+class TestE22Strict:
+    def test_zero_fails(self):
+        result = evaluate_common_gates(
+            primary_trades=_passing_primary_trades(), upward_trades=_upward_trades(0.0)
+        )
+        assert "e22_not_positive" in result.reasons
+
+    def test_smallest_positive_passes(self):
+        smallest = math.nextafter(0.0, math.inf)
+        result = evaluate_common_gates(
+            primary_trades=_passing_primary_trades(),
+            upward_trades=_upward_trades(smallest),
+        )
+        assert "e22_not_positive" not in result.reasons
+
+
+class TestE0Boundary:
+    def _trades_with_e0(self, gross_bps: float) -> tuple[MetricTrade, ...]:
+        return tuple(
+            _trade(fold_id, 10.0, gross_bps=gross_bps, exit_ts=i * _DAY_MS)
+            for i, fold_id in enumerate(FOLD_IDS)
+            for _ in range(5)
+        )
+
+    def test_exact_25bp_passes(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_e0(25.0), upward_trades=_upward_trades(1.0)
+        )
+        assert "e0_below_25bp" not in result.reasons
+
+    def test_just_below_25bp_fails(self):
+        below = math.nextafter(25.0, -math.inf)
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_e0(below),
+            upward_trades=_upward_trades(1.0),
+        )
+        assert "e0_below_25bp" in result.reasons
+
+    def test_e0_excludes_fixed_cost_and_funding_uses_gross_bps_only(self):
+        # gross_bps (price-only) is 30, net_bps (cost/funding-adjusted) is
+        # only 10 -- E0 must reflect the GROSS figure, never net.
+        trades = tuple(
+            _trade(fold_id, 10.0, gross_bps=30.0, exit_ts=i * _DAY_MS)
+            for i, fold_id in enumerate(FOLD_IDS)
+            for _ in range(5)
+        )
+        result = evaluate_common_gates(
+            primary_trades=trades, upward_trades=_upward_trades(1.0)
+        )
+        assert result.e0_bps == pytest.approx(30.0, abs=1e-9)
+
+
+class TestWinMarginAndPbe:
+    # SL=66, TP=100 -> pBE = (66+17)/(100+66) = 83/166 = 0.5 exactly, so a
+    # discrete win-rate fraction can hit an EXACT 0.03 margin boundary
+    # (win_rate=0.53 over n=200 -> margin=0.03 exactly).
+    _PBE = 0.5
+    _N = 200
+
+    def _trades_with_n_wins(self, n_wins: int) -> tuple[MetricTrade, ...]:
+        trades = []
+        for i in range(self._N):
+            fold_id = FOLD_IDS[i % 8]
+            if i < n_wins:
+                trades.append(
+                    _trade(
+                        fold_id,
+                        30.0,
+                        tp_bps=100.0,
+                        sl_bps=66.0,
+                        exit_ts=i,
+                        exit_reason="TP",
+                    )
+                )
+            else:
+                trades.append(
+                    _trade(
+                        fold_id,
+                        -20.0,
+                        tp_bps=100.0,
+                        sl_bps=66.0,
+                        exit_ts=i,
+                        exit_reason="SL",
+                    )
+                )
+        return tuple(trades)
+
+    def test_win_margin_exact_3pp_boundary_passes(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_n_wins(106),  # 106/200 = 0.53
+            upward_trades=_upward_trades(1.0),
+        )
+        assert result.weighted_pbe == pytest.approx(self._PBE, abs=1e-12)
+        assert result.win_margin == pytest.approx(WIN_MARGIN_MIN, abs=1e-12)
+        assert "win_margin_below_3pp" not in result.reasons
+
+    def test_win_margin_one_fewer_win_fails(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_n_wins(105),  # 105/200 = 0.525
+            upward_trades=_upward_trades(1.0),
+        )
+        assert result.win_margin < WIN_MARGIN_MIN
+        assert "win_margin_below_3pp" in result.reasons
+
+    def test_win_margin_below_3pp_fails_even_with_good_pf(self):
+        # Large win magnitude keeps PF comfortably >= 1.15 while win rate
+        # alone (with SL=40/TP=68) still misses the margin gate -- proving
+        # the two gates are evaluated independently.
+        pbe = (40.0 + 17.0) / (68.0 + 40.0)
+        n = 1000
+        # win rate well below pbe + 0.03
+        n_wins = round((pbe - 0.10) * n)
+        trades = []
+        for i in range(n):
+            fold_id = FOLD_IDS[i % 8]
+            if i < n_wins:
+                trades.append(_trade(fold_id, 30.0, exit_ts=i, exit_reason="TP"))
+            else:
+                trades.append(_trade(fold_id, -5.0, exit_ts=i, exit_reason="SL"))
+        result = evaluate_common_gates(
+            primary_trades=tuple(trades), upward_trades=_upward_trades(1.0)
+        )
+        assert "win_margin_below_3pp" in result.reasons
+
+    def test_s4_pbe_weighted_by_gross_notional(self):
+        big = _trade(
+            "fold-00",
+            30.0,
+            strategy="S4",
+            config_id="S4-00",
+            dimension="XRP-DOGE",
+            gross_notional=100.0,
+            tp_bps=100.0,
+            sl_bps=10.0,
+            exit_reason="TP",
+            exit_ts=0,
+        )
+        small = _trade(
+            "fold-00",
+            30.0,
+            strategy="S4",
+            config_id="S4-00",
+            dimension="XRP-DOGE",
+            gross_notional=1.0,
+            tp_bps=10.0,
+            sl_bps=100.0,
+            exit_reason="TP",
+            exit_ts=1,
+        )
+        result = evaluate_common_gates(
+            primary_trades=(big, small), upward_trades=_upward_trades(1.0)
+        )
+        big_pbe = (10.0 + 17.0) / (100.0 + 10.0)
+        small_pbe = (100.0 + 17.0) / (10.0 + 100.0)
+        expected = (big_pbe * 100.0 + small_pbe * 1.0) / (100.0 + 1.0)
+        assert result.weighted_pbe == pytest.approx(expected, abs=1e-9)
+
+    def test_s3_pbe_is_equal_weight(self):
+        a = _trade(
+            "fold-00", 30.0, tp_bps=100.0, sl_bps=10.0, exit_ts=0, exit_reason="TP"
+        )
+        b = _trade(
+            "fold-00", 30.0, tp_bps=10.0, sl_bps=100.0, exit_ts=1, exit_reason="TP"
+        )
+        result = evaluate_common_gates(
+            primary_trades=(a, b), upward_trades=_upward_trades(1.0)
+        )
+        pbe_a = (10.0 + 17.0) / (100.0 + 10.0)
+        pbe_b = (100.0 + 17.0) / (10.0 + 100.0)
+        assert result.weighted_pbe == pytest.approx((pbe_a + pbe_b) / 2, abs=1e-9)
+
+
+class TestFoldMinimumTrades:
+    def _trades_with_fold_count(self, n_trades: int) -> tuple[MetricTrade, ...]:
+        trades = []
+        for i, fold_id in enumerate(FOLD_IDS):
+            count = n_trades if i == 0 else 10
+            for j in range(count):
+                trades.append(
+                    _trade(fold_id, 10.0, exit_ts=i * _MONTH_MS + j * _DAY_MS)
+                )
+        return tuple(trades)
+
+    def test_exact_5_trades_passes(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_fold_count(MIN_TRADES_PER_FOLD),
+            upward_trades=_upward_trades(1.0),
+        )
+        assert "insufficient_sample" not in result.reasons
+
+    def test_4_trades_fails_no_relaxation(self):
+        result = evaluate_common_gates(
+            primary_trades=self._trades_with_fold_count(4),
+            upward_trades=_upward_trades(1.0),
+        )
+        assert "insufficient_sample" in result.reasons
+
+    def test_zero_trades_in_one_fold_fails(self):
+        trades = [t for t in _passing_primary_trades() if t.fold_id != "fold-00"]
+        result = evaluate_common_gates(
+            primary_trades=tuple(trades), upward_trades=_upward_trades(1.0)
+        )
+        assert "insufficient_sample" in result.reasons
+        assert result.fold_trade_counts["fold-00"] == 0
+
+
+class TestNoShortCircuit:
+    def test_multiple_failures_all_collected(self):
+        # Deliberately fail expectancy, PF, positive folds, and E22 all at
+        # once -- every reason must be present, not just the first hit.
+        trades = tuple(
+            _trade(fold_id, -10.0, exit_ts=i * _MONTH_MS)
+            for i, fold_id in enumerate(FOLD_IDS)
+            for _ in range(5)
+        )
+        result = evaluate_common_gates(
+            primary_trades=trades, upward_trades=_upward_trades(0.0)
+        )
+        assert "pooled_e17_below_5bp" in result.reasons
+        assert "pf17_below_1_15" in result.reasons
+        assert "insufficient_positive_folds" in result.reasons
+        assert "e22_not_positive" in result.reasons
+        assert result.passed is False

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp3_common_gates.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp3_common_gates.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import math
 
 import pytest
-from rob974_h5_contracts import FOLD_IDS, MetricTrade
+from rob974_h5_contracts import FOLD_IDS, H5InputError, MetricTrade
 from rob974_h5_gates import (
     MIN_TRADES_PER_FOLD,
     PF17_MIN,
@@ -432,3 +432,32 @@ class TestNoShortCircuit:
         assert "insufficient_positive_folds" in result.reasons
         assert "e22_not_positive" in result.reasons
         assert result.passed is False
+
+
+class TestPathScenarioMembershipBinding:
+    """D3 exploit repro (adversarial verify R1, finding 1): common gates
+    must fail-closed reject a path-scenario swap (all "primary" trades
+    tagged base13, or the upward book tagged primary_stress17) instead of
+    silently computing metrics over the wrong membership."""
+
+    def test_primary_trades_wrong_path_scenario_rejected(self):
+        wrong_path_primary = tuple(
+            _trade(fold_id, 20.0, exit_ts=i * _MONTH_MS, path_scenario="base13")
+            for i, fold_id in enumerate(FOLD_IDS)
+            for _ in range(5)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_common_gates(
+                primary_trades=wrong_path_primary, upward_trades=_upward_trades(10.0)
+            )
+
+    def test_upward_trades_wrong_path_scenario_rejected(self):
+        wrong_path_upward = tuple(
+            _trade("fold-00", 10.0, exit_ts=i, path_scenario="primary_stress17")
+            for i in range(5)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_common_gates(
+                primary_trades=_passing_primary_trades(),
+                upward_trades=wrong_path_upward,
+            )

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp4_s3_falsification.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp4_s3_falsification.py
@@ -9,6 +9,8 @@ exit-reason/symbol/direction attribution (THESIS_EXIT is never TIMEOUT).
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 from rob974_h5_contracts import FOLD_IDS, H5InputError, MetricTrade
 from rob974_h5_s3 import (
@@ -209,6 +211,33 @@ class TestPathScenarioMembershipBinding:
         with pytest.raises(H5InputError):
             evaluate_s3_falsification(
                 primary_trades=_uniform_trades(40), upward_trades=wrong_path_upward
+            )
+
+
+class TestStrategyAndSelectedOosMembershipBinding:
+    def test_s3_evaluator_rejects_pure_s4_book(self):
+        def as_s4(trade: MetricTrade) -> MetricTrade:
+            return dataclasses.replace(
+                trade,
+                strategy="S4",
+                config_id="S4-00",
+                dimension="XRP-DOGE",
+                gross_notional=100.0,
+                volatility_percentile=None,
+            )
+
+        with pytest.raises(H5InputError):
+            evaluate_s3_falsification(
+                primary_trades=tuple(as_s4(t) for t in _uniform_trades(40)),
+                upward_trades=tuple(as_s4(t) for t in _upward_trades(10)),
+            )
+
+    def test_s3_evaluator_rejects_mixed_selected_configs(self):
+        primary = list(_uniform_trades(40))
+        primary[-1] = dataclasses.replace(primary[-1], config_id="S3-23")
+        with pytest.raises(H5InputError):
+            evaluate_s3_falsification(
+                primary_trades=tuple(primary), upward_trades=_upward_trades(10)
             )
 
 

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp4_s3_falsification.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp4_s3_falsification.py
@@ -10,7 +10,7 @@ exit-reason/symbol/direction attribution (THESIS_EXIT is never TIMEOUT).
 from __future__ import annotations
 
 import pytest
-from rob974_h5_contracts import FOLD_IDS, MetricTrade
+from rob974_h5_contracts import FOLD_IDS, H5InputError, MetricTrade
 from rob974_h5_s3 import (
     S3_FIRST_4H_MINUTES,
     S3_POOLED_TIMEOUT_MAX,
@@ -57,6 +57,15 @@ def _uniform_trades(n: int, exit_reason: str = "TP", net_bps: float = 10.0):
     )
 
 
+def _upward_trades(n: int, net_bps: float = 10.0):
+    # D3 fix: the upward (E22) subbook must carry path_scenario ==
+    # "upward_stress22" -- never the primary book's "primary_stress17".
+    return tuple(
+        _trade(FOLD_IDS[i % 8], net_bps, exit_ts=i, path_scenario="upward_stress22")
+        for i in range(n)
+    )
+
+
 class TestPooledTimeoutBoundary:
     def _trades_with_timeout_ratio(self, ratio: float, n: int = 1000) -> tuple:
         n_timeout = round(ratio * n)
@@ -69,14 +78,14 @@ class TestPooledTimeoutBoundary:
     def test_exact_15pct_passes(self):
         result = evaluate_s3_falsification(
             primary_trades=self._trades_with_timeout_ratio(S3_POOLED_TIMEOUT_MAX),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s3_pooled_timeout_above_15pct" not in result.reasons
 
     def test_above_15pct_fails(self):
         result = evaluate_s3_falsification(
             primary_trades=self._trades_with_timeout_ratio(0.151),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s3_pooled_timeout_above_15pct" in result.reasons
 
@@ -93,7 +102,7 @@ class TestFoldTimeoutBoundary:
             for i in range(50):
                 trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
         result = evaluate_s3_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert "s3_fold_timeout_above_25pct" in result.reasons
         assert "s3_pooled_timeout_above_15pct" not in result.reasons
@@ -107,7 +116,7 @@ class TestFoldTimeoutBoundary:
             for i in range(20):
                 trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
         result = evaluate_s3_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert "s3_fold_timeout_above_25pct" not in result.reasons
 
@@ -115,7 +124,14 @@ class TestFoldTimeoutBoundary:
 class TestBullishLongE22:
     def test_positive_bullish_subbook_passes(self):
         longs = tuple(
-            _trade("fold-00", 5.0, direction="long", exit_ts=i) for i in range(5)
+            _trade(
+                "fold-00",
+                5.0,
+                direction="long",
+                exit_ts=i,
+                path_scenario="upward_stress22",
+            )
+            for i in range(5)
         )
         result = evaluate_s3_falsification(
             primary_trades=_uniform_trades(40), upward_trades=longs
@@ -124,7 +140,14 @@ class TestBullishLongE22:
 
     def test_zero_bullish_subbook_fails(self):
         longs = tuple(
-            _trade("fold-00", 0.0, direction="long", exit_ts=i) for i in range(5)
+            _trade(
+                "fold-00",
+                0.0,
+                direction="long",
+                exit_ts=i,
+                path_scenario="upward_stress22",
+            )
+            for i in range(5)
         )
         result = evaluate_s3_falsification(
             primary_trades=_uniform_trades(40), upward_trades=longs
@@ -135,16 +158,58 @@ class TestBullishLongE22:
         # A large positive SHORT subbook must not be allowed to satisfy the
         # bullish-LONG gate -- only direction=="long" rows count.
         shorts = tuple(
-            _trade("fold-00", 500.0, direction="short", exit_ts=i) for i in range(5)
+            _trade(
+                "fold-00",
+                500.0,
+                direction="short",
+                exit_ts=i,
+                path_scenario="upward_stress22",
+            )
+            for i in range(5)
         )
         longs_losing = tuple(
-            _trade("fold-00", -1.0, direction="long", exit_ts=100 + i) for i in range(5)
+            _trade(
+                "fold-00",
+                -1.0,
+                direction="long",
+                exit_ts=100 + i,
+                path_scenario="upward_stress22",
+            )
+            for i in range(5)
         )
         result = evaluate_s3_falsification(
             primary_trades=_uniform_trades(40),
             upward_trades=shorts + longs_losing,
         )
         assert "s3_bullish_long_e22_not_positive" in result.reasons
+
+
+class TestPathScenarioMembershipBinding:
+    """D3 exploit repro (adversarial verify R1, finding 1): common gates and
+    S3/S4 falsification must fail-closed reject a path-scenario swap (all
+    "primary" trades tagged base13, or the upward book tagged
+    primary_stress17) instead of silently computing metrics over the wrong
+    membership."""
+
+    def test_primary_trades_wrong_path_scenario_rejected(self):
+        wrong_path_primary = tuple(
+            _trade(FOLD_IDS[i % 8], 20.0, exit_ts=i, path_scenario="base13")
+            for i in range(40)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_s3_falsification(
+                primary_trades=wrong_path_primary, upward_trades=_upward_trades(10)
+            )
+
+    def test_upward_trades_wrong_path_scenario_rejected(self):
+        wrong_path_upward = tuple(
+            _trade(FOLD_IDS[i % 8], 10.0, exit_ts=i, path_scenario="primary_stress17")
+            for i in range(10)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_s3_falsification(
+                primary_trades=_uniform_trades(40), upward_trades=wrong_path_upward
+            )
 
 
 class TestFirst4hSlDependence:
@@ -188,14 +253,14 @@ class TestFirst4hSlDependence:
     def test_exact_50pct_passes(self):
         result = evaluate_s3_falsification(
             primary_trades=self._trades_with_dependence(0.5),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s3_first_4h_sl_dependence_above_50pct" not in result.reasons
 
     def test_above_50pct_fails(self):
         result = evaluate_s3_falsification(
             primary_trades=self._trades_with_dependence(0.6),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s3_first_4h_sl_dependence_above_50pct" in result.reasons
 
@@ -212,7 +277,7 @@ class TestFirst4hSlDependence:
                 _trade(FOLD_IDS[i % 8], 20.0, exit_reason="TP", exit_ts=100 + i)
             )
         result = evaluate_s3_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         # numerator == denominator == 10 -> ratio 1.0 -> must FAIL (not
         # silently excluded to 0/undefined).
@@ -221,7 +286,7 @@ class TestFirst4hSlDependence:
     def test_zero_losses_denominator_is_incomplete_not_pass(self):
         trades = _uniform_trades(40, exit_reason="TP", net_bps=10.0)
         result = evaluate_s3_falsification(
-            primary_trades=trades, upward_trades=_uniform_trades(10)
+            primary_trades=trades, upward_trades=_upward_trades(10)
         )
         assert result.first_4h_sl_dependence is None
         assert "s3_first_4h_sl_denominator_undefined" in result.incomplete_reasons
@@ -243,7 +308,7 @@ class TestFirst4hSlDependence:
                 _trade(FOLD_IDS[i % 8], 20.0, exit_reason="TP", exit_ts=100 + i)
             )
         result = evaluate_s3_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         # true ratio: 800 / (800+200) = 0.8 > 0.5 -> fails
         assert result.first_4h_sl_dependence == pytest.approx(0.8, abs=1e-9)
@@ -266,7 +331,7 @@ class TestSymbolDependence:
     def test_one_positive_others_pooled_negative_fails(self):
         result = evaluate_s3_falsification(
             primary_trades=self._symbol_trades(50.0, -10.0, -10.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s3_symbol_dependence" in result.reasons
 
@@ -275,14 +340,14 @@ class TestSymbolDependence:
         # two pooled must ALSO be <=0 (second predicate).
         result = evaluate_s3_falsification(
             primary_trades=self._symbol_trades(50.0, 5.0, -1.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s3_symbol_dependence" not in result.reasons
 
     def test_two_positive_symbols_never_fails_this_gate(self):
         result = evaluate_s3_falsification(
             primary_trades=self._symbol_trades(50.0, 50.0, -10.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s3_symbol_dependence" not in result.reasons
 
@@ -295,7 +360,7 @@ class TestSymbolDependence:
             )
             # SOLUSDT has zero trades entirely
         result = evaluate_s3_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert "s3_symbol_evidence_missing" in result.incomplete_reasons
 
@@ -304,7 +369,7 @@ class TestAttributionAndExitTaxonomy:
     def test_thesis_exit_is_never_classified_as_timeout(self):
         trades = _uniform_trades(40, exit_reason="THESIS_EXIT", net_bps=10.0)
         result = evaluate_s3_falsification(
-            primary_trades=trades, upward_trades=_uniform_trades(10)
+            primary_trades=trades, upward_trades=_upward_trades(10)
         )
         by_exit = result.attribution["by_exit_reason"]
         assert "THESIS_EXIT" in by_exit
@@ -316,7 +381,7 @@ class TestAttributionAndExitTaxonomy:
     def test_attribution_by_symbol_and_exit_reason_nonempty(self):
         trades = self._mixed_trades()
         result = evaluate_s3_falsification(
-            primary_trades=trades, upward_trades=_uniform_trades(10)
+            primary_trades=trades, upward_trades=_upward_trades(10)
         )
         assert set(result.attribution["by_symbol"].keys()) >= {"XRPUSDT"}
         assert result.attribution["by_symbol"]["XRPUSDT"]["trades"] > 0

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp4_s3_falsification.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp4_s3_falsification.py
@@ -1,0 +1,349 @@
+"""ROB-983 (H5, CP4) -- S3 falsification gates and attribution.
+
+Pooled/per-fold timeout ceilings, all-long-entry bullish-subbook upward E22
+strict positivity, first-4h SL-dependence (undefined denominator is
+incomplete, never a convenient zero/pass), symbol dependence (both the
+"exactly one positive" AND "other two pooled <=0" predicates required), and
+exit-reason/symbol/direction attribution (THESIS_EXIT is never TIMEOUT).
+"""
+
+from __future__ import annotations
+
+import pytest
+from rob974_h5_contracts import FOLD_IDS, MetricTrade
+from rob974_h5_s3 import (
+    S3_FIRST_4H_MINUTES,
+    S3_POOLED_TIMEOUT_MAX,
+    evaluate_s3_falsification,
+)
+
+
+def _trade(
+    fold_id: str,
+    net_bps: float,
+    *,
+    exit_reason: str = "TP",
+    holding_minutes: float = 10.0,
+    dimension: str = "XRPUSDT",
+    direction: str = "long",
+    exit_ts: int = 0,
+    path_scenario: str = "primary_stress17",
+) -> MetricTrade:
+    return MetricTrade(
+        strategy="S3",
+        config_id="S3-00",
+        fold_id=fold_id,
+        path_scenario=path_scenario,
+        dimension=dimension,
+        direction=direction,
+        entry_ts=exit_ts,
+        exit_ts=exit_ts + 60_000,
+        holding_minutes=holding_minutes,
+        exit_reason=exit_reason,
+        gross_bps=net_bps + 5.0,
+        net_bps=net_bps,
+        tp_bps=68.0,
+        sl_bps=40.0,
+        gross_notional=None,
+        market_return_4h=0.01,
+        volatility_percentile=50.0,
+    )
+
+
+def _uniform_trades(n: int, exit_reason: str = "TP", net_bps: float = 10.0):
+    return tuple(
+        _trade(FOLD_IDS[i % 8], net_bps, exit_reason=exit_reason, exit_ts=i)
+        for i in range(n)
+    )
+
+
+class TestPooledTimeoutBoundary:
+    def _trades_with_timeout_ratio(self, ratio: float, n: int = 1000) -> tuple:
+        n_timeout = round(ratio * n)
+        trades = []
+        for i in range(n):
+            reason = "TIMEOUT" if i < n_timeout else "TP"
+            trades.append(_trade(FOLD_IDS[i % 8], 10.0, exit_reason=reason, exit_ts=i))
+        return tuple(trades)
+
+    def test_exact_15pct_passes(self):
+        result = evaluate_s3_falsification(
+            primary_trades=self._trades_with_timeout_ratio(S3_POOLED_TIMEOUT_MAX),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s3_pooled_timeout_above_15pct" not in result.reasons
+
+    def test_above_15pct_fails(self):
+        result = evaluate_s3_falsification(
+            primary_trades=self._trades_with_timeout_ratio(0.151),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s3_pooled_timeout_above_15pct" in result.reasons
+
+
+class TestFoldTimeoutBoundary:
+    def test_one_fold_above_25pct_fails_even_if_pooled_ok(self):
+        trades = []
+        # fold-00: 10 trades, 3 timeouts (30% > 25%)
+        for i in range(10):
+            reason = "TIMEOUT" if i < 3 else "TP"
+            trades.append(_trade("fold-00", 10.0, exit_reason=reason, exit_ts=i))
+        # remaining folds: all TP, plenty of trades, keeps pooled ratio low
+        for fold_id in FOLD_IDS[1:]:
+            for i in range(50):
+                trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
+        result = evaluate_s3_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert "s3_fold_timeout_above_25pct" in result.reasons
+        assert "s3_pooled_timeout_above_15pct" not in result.reasons
+
+    def test_exact_25pct_in_one_fold_passes_that_fold(self):
+        trades = []
+        for i in range(20):
+            reason = "TIMEOUT" if i < 5 else "TP"  # 5/20 = 25%
+            trades.append(_trade("fold-00", 10.0, exit_reason=reason, exit_ts=i))
+        for fold_id in FOLD_IDS[1:]:
+            for i in range(20):
+                trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
+        result = evaluate_s3_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert "s3_fold_timeout_above_25pct" not in result.reasons
+
+
+class TestBullishLongE22:
+    def test_positive_bullish_subbook_passes(self):
+        longs = tuple(
+            _trade("fold-00", 5.0, direction="long", exit_ts=i) for i in range(5)
+        )
+        result = evaluate_s3_falsification(
+            primary_trades=_uniform_trades(40), upward_trades=longs
+        )
+        assert "s3_bullish_long_e22_not_positive" not in result.reasons
+
+    def test_zero_bullish_subbook_fails(self):
+        longs = tuple(
+            _trade("fold-00", 0.0, direction="long", exit_ts=i) for i in range(5)
+        )
+        result = evaluate_s3_falsification(
+            primary_trades=_uniform_trades(40), upward_trades=longs
+        )
+        assert "s3_bullish_long_e22_not_positive" in result.reasons
+
+    def test_shorts_are_excluded_from_bullish_subbook_mutant(self):
+        # A large positive SHORT subbook must not be allowed to satisfy the
+        # bullish-LONG gate -- only direction=="long" rows count.
+        shorts = tuple(
+            _trade("fold-00", 500.0, direction="short", exit_ts=i) for i in range(5)
+        )
+        longs_losing = tuple(
+            _trade("fold-00", -1.0, direction="long", exit_ts=100 + i) for i in range(5)
+        )
+        result = evaluate_s3_falsification(
+            primary_trades=_uniform_trades(40),
+            upward_trades=shorts + longs_losing,
+        )
+        assert "s3_bullish_long_e22_not_positive" in result.reasons
+
+
+class TestFirst4hSlDependence:
+    def _trades_with_dependence(self, ratio: float) -> tuple:
+        # denominator: all losses total |net| = 1000 (10 losing trades of -100)
+        # numerator target: ratio * 1000, split evenly among first-4h SL losses
+        total_loss = 1000.0
+        n_loss_trades = 10
+        per_loss = total_loss / n_loss_trades
+        target_first4h = ratio * total_loss
+        n_first4h = round(target_first4h / per_loss)
+        trades = []
+        for i in range(n_loss_trades):
+            if i < n_first4h:
+                trades.append(
+                    _trade(
+                        "fold-00",
+                        -per_loss,
+                        exit_reason="SL",
+                        holding_minutes=S3_FIRST_4H_MINUTES,
+                        exit_ts=i,
+                    )
+                )
+            else:
+                trades.append(
+                    _trade(
+                        "fold-00",
+                        -per_loss,
+                        exit_reason="SL",
+                        holding_minutes=500.0,
+                        exit_ts=i,
+                    )
+                )
+        # plenty of winners so other gates don't interfere
+        for i in range(50):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], 20.0, exit_reason="TP", exit_ts=1000 + i)
+            )
+        return tuple(trades)
+
+    def test_exact_50pct_passes(self):
+        result = evaluate_s3_falsification(
+            primary_trades=self._trades_with_dependence(0.5),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s3_first_4h_sl_dependence_above_50pct" not in result.reasons
+
+    def test_above_50pct_fails(self):
+        result = evaluate_s3_falsification(
+            primary_trades=self._trades_with_dependence(0.6),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s3_first_4h_sl_dependence_above_50pct" in result.reasons
+
+    def test_exactly_240_minutes_is_included_not_excluded(self):
+        # A trade at EXACTLY holding_minutes=240 with exit=SL must count in
+        # the numerator (the "<=240" boundary, not "<240").
+        trades = [
+            _trade(
+                "fold-00", -10.0, exit_reason="SL", holding_minutes=240.0, exit_ts=0
+            ),
+        ]
+        for i in range(50):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], 20.0, exit_reason="TP", exit_ts=100 + i)
+            )
+        result = evaluate_s3_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        # numerator == denominator == 10 -> ratio 1.0 -> must FAIL (not
+        # silently excluded to 0/undefined).
+        assert "s3_first_4h_sl_dependence_above_50pct" in result.reasons
+
+    def test_zero_losses_denominator_is_incomplete_not_pass(self):
+        trades = _uniform_trades(40, exit_reason="TP", net_bps=10.0)
+        result = evaluate_s3_falsification(
+            primary_trades=trades, upward_trades=_uniform_trades(10)
+        )
+        assert result.first_4h_sl_dependence is None
+        assert "s3_first_4h_sl_denominator_undefined" in result.incomplete_reasons
+        assert "s3_first_4h_sl_dependence_above_50pct" not in result.reasons
+
+    def test_signed_loss_denominator_mutant_would_change_ratio(self):
+        # Sanity: denominator must be built from ABSOLUTE loss magnitude,
+        # never signed net_bps (which would let large losses cancel).
+        trades = [
+            _trade(
+                "fold-00", -800.0, exit_reason="SL", holding_minutes=100.0, exit_ts=0
+            ),
+            _trade(
+                "fold-00", -200.0, exit_reason="SL", holding_minutes=500.0, exit_ts=1
+            ),
+        ]
+        for i in range(50):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], 20.0, exit_reason="TP", exit_ts=100 + i)
+            )
+        result = evaluate_s3_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        # true ratio: 800 / (800+200) = 0.8 > 0.5 -> fails
+        assert result.first_4h_sl_dependence == pytest.approx(0.8, abs=1e-9)
+        assert "s3_first_4h_sl_dependence_above_50pct" in result.reasons
+
+
+class TestSymbolDependence:
+    def _symbol_trades(self, xrp: float, doge: float, sol: float) -> tuple:
+        trades = []
+        for i in range(10):
+            trades.append(_trade(FOLD_IDS[i % 8], xrp, dimension="XRPUSDT", exit_ts=i))
+            trades.append(
+                _trade(FOLD_IDS[i % 8], doge, dimension="DOGEUSDT", exit_ts=100 + i)
+            )
+            trades.append(
+                _trade(FOLD_IDS[i % 8], sol, dimension="SOLUSDT", exit_ts=200 + i)
+            )
+        return tuple(trades)
+
+    def test_one_positive_others_pooled_negative_fails(self):
+        result = evaluate_s3_falsification(
+            primary_trades=self._symbol_trades(50.0, -10.0, -10.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s3_symbol_dependence" in result.reasons
+
+    def test_one_positive_but_other_two_pooled_positive_passes(self):
+        # exactly one symbol positive alone isn't sufficient -- the OTHER
+        # two pooled must ALSO be <=0 (second predicate).
+        result = evaluate_s3_falsification(
+            primary_trades=self._symbol_trades(50.0, 5.0, -1.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s3_symbol_dependence" not in result.reasons
+
+    def test_two_positive_symbols_never_fails_this_gate(self):
+        result = evaluate_s3_falsification(
+            primary_trades=self._symbol_trades(50.0, 50.0, -10.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s3_symbol_dependence" not in result.reasons
+
+    def test_missing_symbol_trades_is_incomplete(self):
+        trades = []
+        for i in range(10):
+            trades.append(_trade(FOLD_IDS[i % 8], 50.0, dimension="XRPUSDT", exit_ts=i))
+            trades.append(
+                _trade(FOLD_IDS[i % 8], -10.0, dimension="DOGEUSDT", exit_ts=100 + i)
+            )
+            # SOLUSDT has zero trades entirely
+        result = evaluate_s3_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert "s3_symbol_evidence_missing" in result.incomplete_reasons
+
+
+class TestAttributionAndExitTaxonomy:
+    def test_thesis_exit_is_never_classified_as_timeout(self):
+        trades = _uniform_trades(40, exit_reason="THESIS_EXIT", net_bps=10.0)
+        result = evaluate_s3_falsification(
+            primary_trades=trades, upward_trades=_uniform_trades(10)
+        )
+        by_exit = result.attribution["by_exit_reason"]
+        assert "THESIS_EXIT" in by_exit
+        assert by_exit["THESIS_EXIT"]["trades"] == 40
+        # THESIS_EXIT trades never leak into the TIMEOUT bucket.
+        assert by_exit.get("TIMEOUT", {}).get("trades", 0) == 0
+        assert result.pooled_timeout_ratio == 0.0
+
+    def test_attribution_by_symbol_and_exit_reason_nonempty(self):
+        trades = self._mixed_trades()
+        result = evaluate_s3_falsification(
+            primary_trades=trades, upward_trades=_uniform_trades(10)
+        )
+        assert set(result.attribution["by_symbol"].keys()) >= {"XRPUSDT"}
+        assert result.attribution["by_symbol"]["XRPUSDT"]["trades"] > 0
+        assert result.attribution["by_exit_reason"]["TP"]["trades"] > 0
+        assert result.attribution["by_exit_reason"]["SL"]["trades"] > 0
+
+    @staticmethod
+    def _mixed_trades():
+        trades = []
+        for i in range(20):
+            trades.append(
+                _trade(
+                    FOLD_IDS[i % 8],
+                    10.0,
+                    exit_reason="TP",
+                    dimension="XRPUSDT",
+                    exit_ts=i,
+                )
+            )
+        for i in range(20):
+            trades.append(
+                _trade(
+                    FOLD_IDS[i % 8],
+                    -5.0,
+                    exit_reason="SL",
+                    dimension="DOGEUSDT",
+                    exit_ts=100 + i,
+                )
+            )
+        return tuple(trades)

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp5_s4_and_verdicts.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp5_s4_and_verdicts.py
@@ -47,7 +47,7 @@ def _trade(
     direction: str = "long",
     exit_ts: int = 0,
     market_return_4h: float = 0.01,
-    gross_notional: float | None = None,
+    gross_notional: float | None = 100.0,
     path_scenario: str = "primary_stress17",
 ) -> MetricTrade:
     return MetricTrade(
@@ -78,6 +78,15 @@ def _uniform_trades(n: int, exit_reason: str = "TP", net_bps: float = 10.0):
     )
 
 
+def _upward_trades(n: int, net_bps: float = 10.0):
+    # D3 fix: the upward (E22) subbook must carry path_scenario ==
+    # "upward_stress22" -- never the primary book's "primary_stress17".
+    return tuple(
+        _trade(FOLD_IDS[i % 8], net_bps, exit_ts=i, path_scenario="upward_stress22")
+        for i in range(n)
+    )
+
+
 class TestPooledTimeoutBoundary:
     def _trades_with_timeout_ratio(self, ratio: float, n: int = 1000) -> tuple:
         n_timeout = round(ratio * n)
@@ -90,14 +99,14 @@ class TestPooledTimeoutBoundary:
     def test_exact_20pct_passes(self):
         result = evaluate_s4_falsification(
             primary_trades=self._trades_with_timeout_ratio(S4_POOLED_TIMEOUT_MAX),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_pooled_timeout_above_20pct" not in result.reasons
 
     def test_above_20pct_fails(self):
         result = evaluate_s4_falsification(
             primary_trades=self._trades_with_timeout_ratio(0.201),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_pooled_timeout_above_20pct" in result.reasons
 
@@ -112,7 +121,7 @@ class TestFoldTimeoutBoundary:
             for i in range(50):
                 trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
         result = evaluate_s4_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert "s4_fold_timeout_above_30pct" in result.reasons
         assert "s4_pooled_timeout_above_20pct" not in result.reasons
@@ -126,7 +135,7 @@ class TestFoldTimeoutBoundary:
             for i in range(20):
                 trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
         result = evaluate_s4_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert "s4_fold_timeout_above_30pct" not in result.reasons
 
@@ -134,7 +143,14 @@ class TestFoldTimeoutBoundary:
 class TestHighMarketReturnE22:
     def test_positive_high_m_subbook_passes(self):
         highs = tuple(
-            _trade("fold-00", 5.0, market_return_4h=0.05, exit_ts=i) for i in range(5)
+            _trade(
+                "fold-00",
+                5.0,
+                market_return_4h=0.05,
+                exit_ts=i,
+                path_scenario="upward_stress22",
+            )
+            for i in range(5)
         )
         result = evaluate_s4_falsification(
             primary_trades=_uniform_trades(40), upward_trades=highs
@@ -143,7 +159,14 @@ class TestHighMarketReturnE22:
 
     def test_zero_high_m_subbook_fails(self):
         highs = tuple(
-            _trade("fold-00", 0.0, market_return_4h=0.05, exit_ts=i) for i in range(5)
+            _trade(
+                "fold-00",
+                0.0,
+                market_return_4h=0.05,
+                exit_ts=i,
+                path_scenario="upward_stress22",
+            )
+            for i in range(5)
         )
         result = evaluate_s4_falsification(
             primary_trades=_uniform_trades(40), upward_trades=highs
@@ -154,10 +177,23 @@ class TestHighMarketReturnE22:
         # Large winning LOW-M_t trades must not satisfy the strict M_t>3%
         # subbook gate -- only market_return_4h>0.03 rows count.
         low_m_wins = tuple(
-            _trade("fold-00", 500.0, market_return_4h=0.01, exit_ts=i) for i in range(5)
+            _trade(
+                "fold-00",
+                500.0,
+                market_return_4h=0.01,
+                exit_ts=i,
+                path_scenario="upward_stress22",
+            )
+            for i in range(5)
         )
         high_m_losses = tuple(
-            _trade("fold-00", -1.0, market_return_4h=0.05, exit_ts=100 + i)
+            _trade(
+                "fold-00",
+                -1.0,
+                market_return_4h=0.05,
+                exit_ts=100 + i,
+                path_scenario="upward_stress22",
+            )
             for i in range(5)
         )
         result = evaluate_s4_falsification(
@@ -165,6 +201,33 @@ class TestHighMarketReturnE22:
             upward_trades=low_m_wins + high_m_losses,
         )
         assert "s4_high_market_return_e22_not_positive" in result.reasons
+
+
+class TestPathScenarioMembershipBinding:
+    """D3 exploit repro (adversarial verify R1, finding 1): S4 falsification
+    must fail-closed reject a path-scenario swap (all "primary" trades
+    tagged base13, or the upward book tagged primary_stress17) instead of
+    silently computing metrics over the wrong membership."""
+
+    def test_primary_trades_wrong_path_scenario_rejected(self):
+        wrong_path_primary = tuple(
+            _trade(FOLD_IDS[i % 8], 20.0, exit_ts=i, path_scenario="base13")
+            for i in range(40)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_s4_falsification(
+                primary_trades=wrong_path_primary, upward_trades=_upward_trades(10)
+            )
+
+    def test_upward_trades_wrong_path_scenario_rejected(self):
+        wrong_path_upward = tuple(
+            _trade(FOLD_IDS[i % 8], 10.0, exit_ts=i, path_scenario="primary_stress17")
+            for i in range(10)
+        )
+        with pytest.raises(H5InputError):
+            evaluate_s4_falsification(
+                primary_trades=_uniform_trades(40), upward_trades=wrong_path_upward
+            )
 
 
 def _corr_trades(a: int, b: int, c: int, d: int) -> tuple:
@@ -196,7 +259,7 @@ class TestCorrelation:
         # (modulo float summation noise, well within tolerance).
         trades = _corr_trades(23, 17, 17, 23)
         result = evaluate_s4_falsification(
-            primary_trades=trades, upward_trades=_uniform_trades(10)
+            primary_trades=trades, upward_trades=_upward_trades(10)
         )
         assert result.correlation == pytest.approx(0.15, abs=1e-9)
         assert "s4_correlation_above_15pct" not in result.reasons
@@ -205,7 +268,7 @@ class TestCorrelation:
         # a=d=24, b=c=16, n=80 -> corr == 16/80 == 0.20
         trades = _corr_trades(24, 16, 16, 24)
         result = evaluate_s4_falsification(
-            primary_trades=trades, upward_trades=_uniform_trades(10)
+            primary_trades=trades, upward_trades=_upward_trades(10)
         )
         assert result.correlation == pytest.approx(0.20, abs=1e-9)
         assert "s4_correlation_above_15pct" in result.reasons
@@ -222,7 +285,7 @@ class TestCorrelation:
             for i in range(40)
         )
         result = evaluate_s4_falsification(
-            primary_trades=trades, upward_trades=_uniform_trades(10)
+            primary_trades=trades, upward_trades=_upward_trades(10)
         )
         assert result.correlation is None
         assert "s4_correlation_undefined" in result.incomplete_reasons
@@ -247,7 +310,7 @@ class TestPairConcentration:
     def test_dominant_pair_share_above_70pct_and_others_negative_fails(self):
         result = evaluate_s4_falsification(
             primary_trades=self._pair_trades(90.0, -5.0, -5.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_pair_concentration_above_70pct" in result.reasons
 
@@ -256,14 +319,14 @@ class TestPairConcentration:
         # pooled (combined) must ALSO be <=0 (second predicate).
         result = evaluate_s4_falsification(
             primary_trades=self._pair_trades(90.0, 20.0, -1.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_pair_concentration_above_70pct" not in result.reasons
 
     def test_two_positive_pairs_below_70pct_share_passes(self):
         result = evaluate_s4_falsification(
             primary_trades=self._pair_trades(40.0, 40.0, -5.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_pair_concentration_above_70pct" not in result.reasons
 
@@ -278,9 +341,67 @@ class TestPairConcentration:
             )
             # DOGE-SOL has zero trades entirely.
         result = evaluate_s4_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert "s4_pair_evidence_missing" in result.incomplete_reasons
+
+    def test_unequal_trade_counts_use_net_sum_share_not_per_pair_mean(self):
+        # D12 fix (adversarial verify R1, finding 3): concentration must be
+        # the SUM of net_bps per pair, never a per-pair MEAN -- a mean-based
+        # implementation is skewed by unequal trade counts. Repro: XRP-DOGE
+        # net+100 (1 trade), XRP-SOL net+100 total (100 trades of +1.0
+        # each), DOGE-SOL net-200 (1 trade). True sum-based share is
+        # 100/(100+100)=0.5 -- must NOT fail. A buggy mean-based
+        # implementation computes XRP-DOGE mean=100, XRP-SOL mean=1.0,
+        # share=100/101=0.9901 -- incorrectly fails.
+        trades = [
+            _trade(FOLD_IDS[0], 100.0, dimension="XRP-DOGE", exit_ts=0),
+            _trade(FOLD_IDS[1], -200.0, dimension="DOGE-SOL", exit_ts=1),
+        ]
+        trades.extend(
+            _trade(FOLD_IDS[i % 8], 1.0, dimension="XRP-SOL", exit_ts=100 + i)
+            for i in range(100)
+        )
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
+        )
+        assert result.pair_concentration == pytest.approx(0.5, abs=1e-9)
+        assert "s4_pair_concentration_above_70pct" not in result.reasons
+
+    def test_exact_70pct_net_sum_share_passes(self):
+        # dominant XRP-DOGE sum=70 (1 trade), second-positive XRP-SOL
+        # sum=30 (1 trade) -> share == 70/100 == 0.70 exactly -> must NOT
+        # fail (>0.70 is strict).
+        trades = [
+            _trade(FOLD_IDS[0], 70.0, dimension="XRP-DOGE", exit_ts=0),
+            _trade(FOLD_IDS[1], 30.0, dimension="XRP-SOL", exit_ts=1),
+            _trade(FOLD_IDS[2], -10.0, dimension="DOGE-SOL", exit_ts=2),
+        ]
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
+        )
+        assert result.pair_concentration == pytest.approx(0.70, abs=1e-9)
+        assert "s4_pair_concentration_above_70pct" not in result.reasons
+
+    def test_just_above_70pct_net_sum_share_with_unequal_counts_fails(self):
+        # dominant XRP-DOGE sum=71 (1 trade), second-positive XRP-SOL
+        # sum=29 (100 trades of +0.29 each -- unequal count vs dominant),
+        # DOGE-SOL sum=-50 (1 trade). Sum-based share = 71/100 = 0.71 >
+        # 0.70, and others-pooled (XRP-SOL + DOGE-SOL combined mean) is
+        # negative -> gate must fire.
+        trades = [
+            _trade(FOLD_IDS[0], 71.0, dimension="XRP-DOGE", exit_ts=0),
+            _trade(FOLD_IDS[1], -50.0, dimension="DOGE-SOL", exit_ts=1),
+        ]
+        trades.extend(
+            _trade(FOLD_IDS[i % 8], 0.29, dimension="XRP-SOL", exit_ts=100 + i)
+            for i in range(100)
+        )
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
+        )
+        assert result.pair_concentration == pytest.approx(0.71, abs=1e-6)
+        assert "s4_pair_concentration_above_70pct" in result.reasons
 
 
 class TestSlowOnlyFailure:
@@ -302,21 +423,21 @@ class TestSlowOnlyFailure:
     def test_fires_when_mid_bucket_nonpositive_and_slow_bucket_positive(self):
         result = evaluate_s4_falsification(
             primary_trades=self._bucket_trades(mid_net=-5.0, slow_net=5.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_slow_only_failure" in result.reasons
 
     def test_not_triggered_when_mid_bucket_positive(self):
         result = evaluate_s4_falsification(
             primary_trades=self._bucket_trades(mid_net=5.0, slow_net=5.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_slow_only_failure" not in result.reasons
 
     def test_not_triggered_when_slow_bucket_nonpositive(self):
         result = evaluate_s4_falsification(
             primary_trades=self._bucket_trades(mid_net=-5.0, slow_net=-1.0),
-            upward_trades=_uniform_trades(10),
+            upward_trades=_upward_trades(10),
         )
         assert "s4_slow_only_failure" not in result.reasons
 
@@ -329,7 +450,7 @@ class TestSlowOnlyFailure:
                 _trade(FOLD_IDS[i % 8], 50.0, holding_minutes=60.0, exit_ts=1000 + i)
             )
         result = evaluate_s4_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert "s4_slow_bucket_evidence_missing" in result.incomplete_reasons
         assert "s4_slow_only_failure" not in result.reasons
@@ -356,7 +477,7 @@ class TestSlowOnlyFailure:
                 _trade(FOLD_IDS[i % 8], 50.0, holding_minutes=60.0, exit_ts=1000 + i)
             )
         result = evaluate_s4_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         # mid bucket (1000min, negative) <=0, slow bucket (32h exactly,
         # positive) >0 -> gate must fire.
@@ -375,7 +496,7 @@ class TestAttributionAndExitTaxonomy:
             for i in range(40)
         )
         result = evaluate_s4_falsification(
-            primary_trades=trades, upward_trades=_uniform_trades(10)
+            primary_trades=trades, upward_trades=_upward_trades(10)
         )
         by_exit = result.attribution["by_exit_reason"]
         assert by_exit["MEAN_EXIT"]["trades"] == 20
@@ -406,7 +527,7 @@ class TestAttributionAndExitTaxonomy:
                 )
             )
         result = evaluate_s4_falsification(
-            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+            primary_trades=tuple(trades), upward_trades=_upward_trades(10)
         )
         assert set(result.attribution["by_pair"].keys()) >= {"XRP-DOGE"}
         assert result.attribution["by_pair"]["XRP-DOGE"]["trades"] > 0
@@ -486,18 +607,30 @@ class TestDirectVerdict:
         )
 
 
+_S3_RANK = StrategyRankMetrics(
+    min_fold_e17=5.0, pooled_e17=10.0, monthly_concentration=0.3, timeout_ratio=0.1
+)
+_S4_RANK = StrategyRankMetrics(
+    min_fold_e17=6.0, pooled_e17=8.0, monthly_concentration=0.4, timeout_ratio=0.2
+)
+
+
 class TestCampaignDecision:
     def test_incomplete_first_s3_incomplete(self):
         result = compute_campaign_decision(
             s3_direct_verdict="incomplete", s4_direct_verdict="historical_pass"
         )
         assert result.campaign_decision == "incomplete"
+        assert result.campaign_historical_verdict == "incomplete"
+        assert result.historical_preferred is None
 
     def test_incomplete_first_s4_incomplete(self):
         result = compute_campaign_decision(
             s3_direct_verdict="historical_pass", s4_direct_verdict="incomplete"
         )
         assert result.campaign_decision == "incomplete"
+        assert result.campaign_historical_verdict == "incomplete"
+        assert result.historical_preferred is None
 
     def test_both_fail(self):
         result = compute_campaign_decision(
@@ -505,6 +638,8 @@ class TestCampaignDecision:
         )
         assert result.campaign_decision == "both_fail"
         assert result.demo_candidate is None
+        assert result.campaign_historical_verdict == "historical_fail"
+        assert result.historical_preferred is None
 
     def test_s3_only(self):
         result = compute_campaign_decision(
@@ -512,6 +647,8 @@ class TestCampaignDecision:
         )
         assert result.campaign_decision == "s3_only"
         assert result.demo_candidate == "S3"
+        assert result.campaign_historical_verdict == "historical_pass"
+        assert result.historical_preferred == "S3"
 
     def test_s4_only_no_demo(self):
         result = compute_campaign_decision(
@@ -519,13 +656,29 @@ class TestCampaignDecision:
         )
         assert result.campaign_decision == "s4_only_no_demo"
         assert result.demo_candidate is None
+        assert result.campaign_historical_verdict == "historical_pass"
+        assert result.historical_preferred == "S4"
 
     def test_both_pass_s3_demo_candidate(self):
         result = compute_campaign_decision(
-            s3_direct_verdict="historical_pass", s4_direct_verdict="historical_pass"
+            s3_direct_verdict="historical_pass",
+            s4_direct_verdict="historical_pass",
+            s3_rank_metrics=_S3_RANK,
+            s4_rank_metrics=_S4_RANK,
         )
         assert result.campaign_decision == "both_pass_s3_demo_candidate"
         assert result.demo_candidate == "S3"
+        assert result.campaign_historical_verdict == "historical_pass"
+        # rank_both_pass(_S3_RANK, _S4_RANK): S4's higher min_fold_e17 (6>5)
+        # decides first -> "S4" is the historically-preferred strategy, even
+        # though S3 remains the (operationally forced) demo candidate.
+        assert result.historical_preferred == "S4"
+
+    def test_both_pass_requires_rank_metrics(self):
+        with pytest.raises(H5InputError):
+            compute_campaign_decision(
+                s3_direct_verdict="historical_pass", s4_direct_verdict="historical_pass"
+            )
 
     def test_campaign_decision_never_overwrites_direct_verdicts(self):
         result = compute_campaign_decision(
@@ -533,6 +686,21 @@ class TestCampaignDecision:
         )
         assert result.s3_direct_verdict == "historical_fail"
         assert result.s4_direct_verdict == "historical_pass"
+
+    def test_unknown_s3_verdict_rejected(self):
+        # D13 fix (adversarial verify R1, finding 4): compute_campaign_decision
+        # must reject a non-closed-enum verdict string rather than silently
+        # falling through to a default branch.
+        with pytest.raises(H5InputError):
+            compute_campaign_decision(
+                s3_direct_verdict="bogus", s4_direct_verdict="historical_pass"
+            )
+
+    def test_unknown_s4_verdict_rejected(self):
+        with pytest.raises(H5InputError):
+            compute_campaign_decision(
+                s3_direct_verdict="historical_pass", s4_direct_verdict="bogus"
+            )
 
 
 class TestObservableS4Superiority:
@@ -593,11 +761,15 @@ class TestObservableS4Superiority:
             s3_direct_verdict="historical_pass",
             s4_direct_verdict="historical_pass",
             s4_observable_superiority=True,
+            s3_rank_metrics=_S3_RANK,
+            s4_rank_metrics=_S4_RANK,
         )
         result_false = compute_campaign_decision(
             s3_direct_verdict="historical_pass",
             s4_direct_verdict="historical_pass",
             s4_observable_superiority=False,
+            s3_rank_metrics=_S3_RANK,
+            s4_rank_metrics=_S4_RANK,
         )
         assert (
             result_true.campaign_decision

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp5_s4_and_verdicts.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp5_s4_and_verdicts.py
@@ -1,0 +1,686 @@
+"""ROB-983 (H5, CP5) -- S4 falsification gates, pair-executor historical
+state, direct-verdict tri-state, and campaign decision.
+
+Pooled/per-fold S4 timeout ceilings, ``M_t>+3%`` upward-subbook strict
+positivity, ``abs(Corr(pair gross return, M_t))<=0.15``, pair concentration
+(conditional -- share ``>0.70`` AND other-two-pooled ``<=0``), slow-only
+failure (``[8h,32h)`` non-positive AND ``[32h,48h]`` positive), and
+exit-reason/pair attribution (``MEAN_EXIT``/``STALL_EXIT`` never leak into
+``TIMEOUT``).
+
+S4 is historical-screen-only: ``S4PairExecutorState`` is a fixed literal
+(``volatility_percentile``/counts are exactly ``None``, never ``0``;
+``demo_eligible`` is exactly ``False``).
+
+Direct verdicts (``compute_direct_verdict``) are incomplete-first, then
+hard-gate-fail, then pass -- independent of the campaign decision table
+(``compute_campaign_decision``), which never overwrites them. Observable S4
+superiority (``s4_shows_observable_superiority``) and both-pass ranking
+(``rank_both_pass``) are report-only.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rob974_h5_contracts import FOLD_IDS, H5InputError, MetricTrade
+from rob974_h5_s4 import (
+    S4_HISTORICAL_PAIR_EXECUTOR_STATE,
+    S4_POOLED_TIMEOUT_MAX,
+    S4_SLOW_BUCKET_MID_MINUTES,
+    S4PairExecutorState,
+    StrategyRankMetrics,
+    compute_campaign_decision,
+    compute_direct_verdict,
+    evaluate_s4_falsification,
+    rank_both_pass,
+    s4_shows_observable_superiority,
+)
+
+
+def _trade(
+    fold_id: str,
+    net_bps: float,
+    *,
+    exit_reason: str = "TP",
+    holding_minutes: float = 10.0,
+    dimension: str = "XRP-DOGE",
+    direction: str = "long",
+    exit_ts: int = 0,
+    market_return_4h: float = 0.01,
+    gross_notional: float | None = None,
+    path_scenario: str = "primary_stress17",
+) -> MetricTrade:
+    return MetricTrade(
+        strategy="S4",
+        config_id="S4-00",
+        fold_id=fold_id,
+        path_scenario=path_scenario,
+        dimension=dimension,
+        direction=direction,
+        entry_ts=exit_ts,
+        exit_ts=exit_ts + 60_000,
+        holding_minutes=holding_minutes,
+        exit_reason=exit_reason,
+        gross_bps=net_bps + 5.0,
+        net_bps=net_bps,
+        tp_bps=68.0,
+        sl_bps=40.0,
+        gross_notional=gross_notional,
+        market_return_4h=market_return_4h,
+        volatility_percentile=None,
+    )
+
+
+def _uniform_trades(n: int, exit_reason: str = "TP", net_bps: float = 10.0):
+    return tuple(
+        _trade(FOLD_IDS[i % 8], net_bps, exit_reason=exit_reason, exit_ts=i)
+        for i in range(n)
+    )
+
+
+class TestPooledTimeoutBoundary:
+    def _trades_with_timeout_ratio(self, ratio: float, n: int = 1000) -> tuple:
+        n_timeout = round(ratio * n)
+        trades = []
+        for i in range(n):
+            reason = "TIMEOUT" if i < n_timeout else "TP"
+            trades.append(_trade(FOLD_IDS[i % 8], 10.0, exit_reason=reason, exit_ts=i))
+        return tuple(trades)
+
+    def test_exact_20pct_passes(self):
+        result = evaluate_s4_falsification(
+            primary_trades=self._trades_with_timeout_ratio(S4_POOLED_TIMEOUT_MAX),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_pooled_timeout_above_20pct" not in result.reasons
+
+    def test_above_20pct_fails(self):
+        result = evaluate_s4_falsification(
+            primary_trades=self._trades_with_timeout_ratio(0.201),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_pooled_timeout_above_20pct" in result.reasons
+
+
+class TestFoldTimeoutBoundary:
+    def test_one_fold_above_30pct_fails_even_if_pooled_ok(self):
+        trades = []
+        for i in range(10):
+            reason = "TIMEOUT" if i < 4 else "TP"  # 4/10 = 40% > 30%
+            trades.append(_trade("fold-00", 10.0, exit_reason=reason, exit_ts=i))
+        for fold_id in FOLD_IDS[1:]:
+            for i in range(50):
+                trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert "s4_fold_timeout_above_30pct" in result.reasons
+        assert "s4_pooled_timeout_above_20pct" not in result.reasons
+
+    def test_exact_30pct_in_one_fold_passes_that_fold(self):
+        trades = []
+        for i in range(20):
+            reason = "TIMEOUT" if i < 6 else "TP"  # 6/20 = 30%
+            trades.append(_trade("fold-00", 10.0, exit_reason=reason, exit_ts=i))
+        for fold_id in FOLD_IDS[1:]:
+            for i in range(20):
+                trades.append(_trade(fold_id, 10.0, exit_reason="TP", exit_ts=i))
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert "s4_fold_timeout_above_30pct" not in result.reasons
+
+
+class TestHighMarketReturnE22:
+    def test_positive_high_m_subbook_passes(self):
+        highs = tuple(
+            _trade("fold-00", 5.0, market_return_4h=0.05, exit_ts=i) for i in range(5)
+        )
+        result = evaluate_s4_falsification(
+            primary_trades=_uniform_trades(40), upward_trades=highs
+        )
+        assert "s4_high_market_return_e22_not_positive" not in result.reasons
+
+    def test_zero_high_m_subbook_fails(self):
+        highs = tuple(
+            _trade("fold-00", 0.0, market_return_4h=0.05, exit_ts=i) for i in range(5)
+        )
+        result = evaluate_s4_falsification(
+            primary_trades=_uniform_trades(40), upward_trades=highs
+        )
+        assert "s4_high_market_return_e22_not_positive" in result.reasons
+
+    def test_low_m_trades_excluded_from_subbook_mutant(self):
+        # Large winning LOW-M_t trades must not satisfy the strict M_t>3%
+        # subbook gate -- only market_return_4h>0.03 rows count.
+        low_m_wins = tuple(
+            _trade("fold-00", 500.0, market_return_4h=0.01, exit_ts=i) for i in range(5)
+        )
+        high_m_losses = tuple(
+            _trade("fold-00", -1.0, market_return_4h=0.05, exit_ts=100 + i)
+            for i in range(5)
+        )
+        result = evaluate_s4_falsification(
+            primary_trades=_uniform_trades(40),
+            upward_trades=low_m_wins + high_m_losses,
+        )
+        assert "s4_high_market_return_e22_not_positive" in result.reasons
+
+
+def _corr_trades(a: int, b: int, c: int, d: int) -> tuple:
+    # Balanced two-value coding: X in {+0.02,-0.02}, Y (gross_bps) in
+    # {10.0,0.0} (net_bps {5.0,-5.0}). With balanced marginals
+    # (a+b==c+d==n/2, a+c==b+d==n/2) Pearson corr reduces exactly to
+    # (a+d-b-c)/n, invariant to the actual two values chosen per side.
+    trades = []
+    ts = 0
+
+    def add(n: int, m_val: float, net_val: float) -> None:
+        nonlocal ts
+        for _ in range(n):
+            trades.append(
+                _trade(FOLD_IDS[ts % 8], net_val, market_return_4h=m_val, exit_ts=ts)
+            )
+            ts += 1
+
+    add(a, 0.02, 5.0)
+    add(b, 0.02, -5.0)
+    add(c, -0.02, 5.0)
+    add(d, -0.02, -5.0)
+    return tuple(trades)
+
+
+class TestCorrelation:
+    def test_corr_at_boundary_15pct_passes(self):
+        # a=d=23, b=c=17, n=80 -> corr == (23+23-17-17)/80 == 0.15 exactly
+        # (modulo float summation noise, well within tolerance).
+        trades = _corr_trades(23, 17, 17, 23)
+        result = evaluate_s4_falsification(
+            primary_trades=trades, upward_trades=_uniform_trades(10)
+        )
+        assert result.correlation == pytest.approx(0.15, abs=1e-9)
+        assert "s4_correlation_above_15pct" not in result.reasons
+
+    def test_corr_clearly_above_15pct_fails(self):
+        # a=d=24, b=c=16, n=80 -> corr == 16/80 == 0.20
+        trades = _corr_trades(24, 16, 16, 24)
+        result = evaluate_s4_falsification(
+            primary_trades=trades, upward_trades=_uniform_trades(10)
+        )
+        assert result.correlation == pytest.approx(0.20, abs=1e-9)
+        assert "s4_correlation_above_15pct" in result.reasons
+
+    def test_corr_undefined_zero_variance_is_incomplete_not_pass(self):
+        # Every trade shares the SAME market_return_4h -> zero X-variance.
+        trades = tuple(
+            _trade(
+                FOLD_IDS[i % 8],
+                10.0 if i % 2 == 0 else -10.0,
+                market_return_4h=0.02,
+                exit_ts=i,
+            )
+            for i in range(40)
+        )
+        result = evaluate_s4_falsification(
+            primary_trades=trades, upward_trades=_uniform_trades(10)
+        )
+        assert result.correlation is None
+        assert "s4_correlation_undefined" in result.incomplete_reasons
+        assert "s4_correlation_above_15pct" not in result.reasons
+
+
+class TestPairConcentration:
+    def _pair_trades(self, xrp_doge: float, xrp_sol: float, doge_sol: float) -> tuple:
+        trades = []
+        for i in range(10):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], xrp_doge, dimension="XRP-DOGE", exit_ts=i)
+            )
+            trades.append(
+                _trade(FOLD_IDS[i % 8], xrp_sol, dimension="XRP-SOL", exit_ts=100 + i)
+            )
+            trades.append(
+                _trade(FOLD_IDS[i % 8], doge_sol, dimension="DOGE-SOL", exit_ts=200 + i)
+            )
+        return tuple(trades)
+
+    def test_dominant_pair_share_above_70pct_and_others_negative_fails(self):
+        result = evaluate_s4_falsification(
+            primary_trades=self._pair_trades(90.0, -5.0, -5.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_pair_concentration_above_70pct" in result.reasons
+
+    def test_dominant_pair_share_above_70pct_but_others_pooled_positive_passes(self):
+        # exactly-share-dominant alone isn't sufficient -- the OTHER two
+        # pooled (combined) must ALSO be <=0 (second predicate).
+        result = evaluate_s4_falsification(
+            primary_trades=self._pair_trades(90.0, 20.0, -1.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_pair_concentration_above_70pct" not in result.reasons
+
+    def test_two_positive_pairs_below_70pct_share_passes(self):
+        result = evaluate_s4_falsification(
+            primary_trades=self._pair_trades(40.0, 40.0, -5.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_pair_concentration_above_70pct" not in result.reasons
+
+    def test_missing_pair_evidence_is_incomplete(self):
+        trades = []
+        for i in range(10):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], 50.0, dimension="XRP-DOGE", exit_ts=i)
+            )
+            trades.append(
+                _trade(FOLD_IDS[i % 8], -10.0, dimension="XRP-SOL", exit_ts=100 + i)
+            )
+            # DOGE-SOL has zero trades entirely.
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert "s4_pair_evidence_missing" in result.incomplete_reasons
+
+
+class TestSlowOnlyFailure:
+    def _bucket_trades(self, mid_net: float, slow_net: float) -> tuple:
+        trades = []
+        for i in range(10):
+            trades.append(_trade("fold-00", mid_net, holding_minutes=1000.0, exit_ts=i))
+        for i in range(10):
+            trades.append(
+                _trade("fold-00", slow_net, holding_minutes=2000.0, exit_ts=100 + i)
+            )
+        # Filler winners well outside both buckets so other gates stay quiet.
+        for i in range(50):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], 50.0, holding_minutes=60.0, exit_ts=1000 + i)
+            )
+        return tuple(trades)
+
+    def test_fires_when_mid_bucket_nonpositive_and_slow_bucket_positive(self):
+        result = evaluate_s4_falsification(
+            primary_trades=self._bucket_trades(mid_net=-5.0, slow_net=5.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_slow_only_failure" in result.reasons
+
+    def test_not_triggered_when_mid_bucket_positive(self):
+        result = evaluate_s4_falsification(
+            primary_trades=self._bucket_trades(mid_net=5.0, slow_net=5.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_slow_only_failure" not in result.reasons
+
+    def test_not_triggered_when_slow_bucket_nonpositive(self):
+        result = evaluate_s4_falsification(
+            primary_trades=self._bucket_trades(mid_net=-5.0, slow_net=-1.0),
+            upward_trades=_uniform_trades(10),
+        )
+        assert "s4_slow_only_failure" not in result.reasons
+
+    def test_missing_bucket_evidence_is_incomplete(self):
+        trades = []
+        for i in range(10):
+            trades.append(_trade("fold-00", -5.0, holding_minutes=1000.0, exit_ts=i))
+        for i in range(50):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], 50.0, holding_minutes=60.0, exit_ts=1000 + i)
+            )
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert "s4_slow_bucket_evidence_missing" in result.incomplete_reasons
+        assert "s4_slow_only_failure" not in result.reasons
+
+    def test_exactly_32h_boundary_is_slow_bucket_not_mid_bucket(self):
+        # holding_minutes == S4_SLOW_BUCKET_MID_MINUTES (32h) must land in
+        # the SLOW ([32h,48h]) bucket, never the MID ([8h,32h)) bucket.
+        trades = []
+        for i in range(10):
+            trades.append(
+                _trade(
+                    "fold-00",
+                    5.0,
+                    holding_minutes=S4_SLOW_BUCKET_MID_MINUTES,
+                    exit_ts=i,
+                )
+            )
+        for i in range(10):
+            trades.append(
+                _trade("fold-00", -5.0, holding_minutes=1000.0, exit_ts=100 + i)
+            )
+        for i in range(50):
+            trades.append(
+                _trade(FOLD_IDS[i % 8], 50.0, holding_minutes=60.0, exit_ts=1000 + i)
+            )
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        # mid bucket (1000min, negative) <=0, slow bucket (32h exactly,
+        # positive) >0 -> gate must fire.
+        assert "s4_slow_only_failure" in result.reasons
+
+
+class TestAttributionAndExitTaxonomy:
+    def test_mean_and_stall_exit_never_classified_as_timeout(self):
+        trades = tuple(
+            _trade(
+                FOLD_IDS[i % 8],
+                10.0,
+                exit_reason="MEAN_EXIT" if i % 2 == 0 else "STALL_EXIT",
+                exit_ts=i,
+            )
+            for i in range(40)
+        )
+        result = evaluate_s4_falsification(
+            primary_trades=trades, upward_trades=_uniform_trades(10)
+        )
+        by_exit = result.attribution["by_exit_reason"]
+        assert by_exit["MEAN_EXIT"]["trades"] == 20
+        assert by_exit["STALL_EXIT"]["trades"] == 20
+        assert by_exit.get("TIMEOUT", {}).get("trades", 0) == 0
+        assert result.pooled_timeout_ratio == 0.0
+
+    def test_attribution_by_pair_and_exit_reason_nonempty(self):
+        trades = []
+        for i in range(20):
+            trades.append(
+                _trade(
+                    FOLD_IDS[i % 8],
+                    10.0,
+                    exit_reason="TP",
+                    dimension="XRP-DOGE",
+                    exit_ts=i,
+                )
+            )
+        for i in range(20):
+            trades.append(
+                _trade(
+                    FOLD_IDS[i % 8],
+                    -5.0,
+                    exit_reason="SL",
+                    dimension="XRP-SOL",
+                    exit_ts=100 + i,
+                )
+            )
+        result = evaluate_s4_falsification(
+            primary_trades=tuple(trades), upward_trades=_uniform_trades(10)
+        )
+        assert set(result.attribution["by_pair"].keys()) >= {"XRP-DOGE"}
+        assert result.attribution["by_pair"]["XRP-DOGE"]["trades"] > 0
+        assert result.attribution["by_exit_reason"]["TP"]["trades"] > 0
+        assert result.attribution["by_exit_reason"]["SL"]["trades"] > 0
+
+
+class TestS4PairExecutorState:
+    def test_historical_constant_matches_fixed_literal_values(self):
+        state = S4_HISTORICAL_PAIR_EXECUTOR_STATE
+        assert state.volatility_percentile is None
+        assert state.volatility_percentile_provenance == "not_defined_for_s4"
+        assert state.pair_executor_state == "not_evaluated"
+        assert state.order_count is None
+        assert state.residual_count is None
+        assert state.pair_exec_fail_count is None
+        assert state.readiness == "historical_screen_only"
+        assert state.demo_eligible is False
+
+    def test_volatility_percentile_zero_mutant_rejected(self):
+        with pytest.raises(H5InputError):
+            S4PairExecutorState(
+                volatility_percentile=0.0,
+                volatility_percentile_provenance="not_defined_for_s4",
+                pair_executor_state="not_evaluated",
+                order_count=None,
+                residual_count=None,
+                pair_exec_fail_count=None,
+                readiness="historical_screen_only",
+                demo_eligible=False,
+            )
+
+    def test_numeric_pair_exec_count_mutant_rejected(self):
+        with pytest.raises(H5InputError):
+            S4PairExecutorState(
+                volatility_percentile=None,
+                volatility_percentile_provenance="not_defined_for_s4",
+                pair_executor_state="not_evaluated",
+                order_count=0,
+                residual_count=None,
+                pair_exec_fail_count=None,
+                readiness="historical_screen_only",
+                demo_eligible=False,
+            )
+
+    def test_demo_eligible_true_mutant_rejected(self):
+        with pytest.raises(H5InputError):
+            S4PairExecutorState(
+                volatility_percentile=None,
+                volatility_percentile_provenance="not_defined_for_s4",
+                pair_executor_state="not_evaluated",
+                order_count=None,
+                residual_count=None,
+                pair_exec_fail_count=None,
+                readiness="historical_screen_only",
+                demo_eligible=True,
+            )
+
+
+class TestDirectVerdict:
+    def test_incomplete_takes_priority_over_hard_gate_fail(self):
+        assert (
+            compute_direct_verdict(incomplete_reasons=("x",), hard_gate_reasons=("y",))
+            == "incomplete"
+        )
+
+    def test_hard_gate_reason_without_incomplete_is_fail(self):
+        assert (
+            compute_direct_verdict(incomplete_reasons=(), hard_gate_reasons=("y",))
+            == "historical_fail"
+        )
+
+    def test_no_reasons_is_pass(self):
+        assert (
+            compute_direct_verdict(incomplete_reasons=(), hard_gate_reasons=())
+            == "historical_pass"
+        )
+
+
+class TestCampaignDecision:
+    def test_incomplete_first_s3_incomplete(self):
+        result = compute_campaign_decision(
+            s3_direct_verdict="incomplete", s4_direct_verdict="historical_pass"
+        )
+        assert result.campaign_decision == "incomplete"
+
+    def test_incomplete_first_s4_incomplete(self):
+        result = compute_campaign_decision(
+            s3_direct_verdict="historical_pass", s4_direct_verdict="incomplete"
+        )
+        assert result.campaign_decision == "incomplete"
+
+    def test_both_fail(self):
+        result = compute_campaign_decision(
+            s3_direct_verdict="historical_fail", s4_direct_verdict="historical_fail"
+        )
+        assert result.campaign_decision == "both_fail"
+        assert result.demo_candidate is None
+
+    def test_s3_only(self):
+        result = compute_campaign_decision(
+            s3_direct_verdict="historical_pass", s4_direct_verdict="historical_fail"
+        )
+        assert result.campaign_decision == "s3_only"
+        assert result.demo_candidate == "S3"
+
+    def test_s4_only_no_demo(self):
+        result = compute_campaign_decision(
+            s3_direct_verdict="historical_fail", s4_direct_verdict="historical_pass"
+        )
+        assert result.campaign_decision == "s4_only_no_demo"
+        assert result.demo_candidate is None
+
+    def test_both_pass_s3_demo_candidate(self):
+        result = compute_campaign_decision(
+            s3_direct_verdict="historical_pass", s4_direct_verdict="historical_pass"
+        )
+        assert result.campaign_decision == "both_pass_s3_demo_candidate"
+        assert result.demo_candidate == "S3"
+
+    def test_campaign_decision_never_overwrites_direct_verdicts(self):
+        result = compute_campaign_decision(
+            s3_direct_verdict="historical_fail", s4_direct_verdict="historical_pass"
+        )
+        assert result.s3_direct_verdict == "historical_fail"
+        assert result.s4_direct_verdict == "historical_pass"
+
+
+class TestObservableS4Superiority:
+    def test_true_when_all_three_criteria_met(self):
+        assert (
+            s4_shows_observable_superiority(
+                pooled_e17_s3=10.0,
+                pooled_e17_s4=16.0,
+                min_fold_e17_s3=2.0,
+                min_fold_e17_s4=3.0,
+                pooled_timeout_s3=0.10,
+                pooled_timeout_s4=0.12,
+            )
+            is True
+        )
+
+    def test_false_when_pooled_e17_gap_insufficient(self):
+        assert (
+            s4_shows_observable_superiority(
+                pooled_e17_s3=10.0,
+                pooled_e17_s4=14.0,
+                min_fold_e17_s3=2.0,
+                min_fold_e17_s4=3.0,
+                pooled_timeout_s3=0.10,
+                pooled_timeout_s4=0.12,
+            )
+            is False
+        )
+
+    def test_false_when_min_fold_e17_worse(self):
+        assert (
+            s4_shows_observable_superiority(
+                pooled_e17_s3=10.0,
+                pooled_e17_s4=16.0,
+                min_fold_e17_s3=2.0,
+                min_fold_e17_s4=1.0,
+                pooled_timeout_s3=0.10,
+                pooled_timeout_s4=0.12,
+            )
+            is False
+        )
+
+    def test_false_when_timeout_gap_too_wide(self):
+        assert (
+            s4_shows_observable_superiority(
+                pooled_e17_s3=10.0,
+                pooled_e17_s4=16.0,
+                min_fold_e17_s3=2.0,
+                min_fold_e17_s4=3.0,
+                pooled_timeout_s3=0.10,
+                pooled_timeout_s4=0.20,
+            )
+            is False
+        )
+
+    def test_superiority_is_report_only_never_changes_campaign_decision(self):
+        result_true = compute_campaign_decision(
+            s3_direct_verdict="historical_pass",
+            s4_direct_verdict="historical_pass",
+            s4_observable_superiority=True,
+        )
+        result_false = compute_campaign_decision(
+            s3_direct_verdict="historical_pass",
+            s4_direct_verdict="historical_pass",
+            s4_observable_superiority=False,
+        )
+        assert (
+            result_true.campaign_decision
+            == result_false.campaign_decision
+            == "both_pass_s3_demo_candidate"
+        )
+        assert result_true.demo_candidate == result_false.demo_candidate == "S3"
+        assert result_true.s4_observable_superiority is True
+        assert result_false.s4_observable_superiority is False
+
+
+class TestRankBothPass:
+    def test_prefers_higher_min_fold_e17(self):
+        s3 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.3,
+            timeout_ratio=0.1,
+        )
+        s4 = StrategyRankMetrics(
+            min_fold_e17=6.0,
+            pooled_e17=8.0,
+            monthly_concentration=0.4,
+            timeout_ratio=0.2,
+        )
+        assert rank_both_pass(s3_metrics=s3, s4_metrics=s4) == "S4"
+
+    def test_falls_back_to_pooled_e17_when_min_fold_tied(self):
+        s3 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.3,
+            timeout_ratio=0.1,
+        )
+        s4 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=12.0,
+            monthly_concentration=0.5,
+            timeout_ratio=0.3,
+        )
+        assert rank_both_pass(s3_metrics=s3, s4_metrics=s4) == "S4"
+
+    def test_falls_back_to_monthly_concentration_lower_is_better(self):
+        s3 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.5,
+            timeout_ratio=0.1,
+        )
+        s4 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.3,
+            timeout_ratio=0.3,
+        )
+        assert rank_both_pass(s3_metrics=s3, s4_metrics=s4) == "S4"
+
+    def test_falls_back_to_timeout_lower_is_better(self):
+        s3 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.3,
+            timeout_ratio=0.2,
+        )
+        s4 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.3,
+            timeout_ratio=0.1,
+        )
+        assert rank_both_pass(s3_metrics=s3, s4_metrics=s4) == "S4"
+
+    def test_operational_complexity_tiebreak_favors_s3_when_all_tied(self):
+        s3 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.3,
+            timeout_ratio=0.1,
+        )
+        s4 = StrategyRankMetrics(
+            min_fold_e17=5.0,
+            pooled_e17=10.0,
+            monthly_concentration=0.3,
+            timeout_ratio=0.1,
+        )
+        assert rank_both_pass(s3_metrics=s3, s4_metrics=s4) == "S3"

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp5_s4_and_verdicts.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp5_s4_and_verdicts.py
@@ -21,6 +21,8 @@ superiority (``s4_shows_observable_superiority``) and both-pass ranking
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 from rob974_h5_contracts import FOLD_IDS, H5InputError, MetricTrade
 from rob974_h5_s4 import (
@@ -227,6 +229,33 @@ class TestPathScenarioMembershipBinding:
         with pytest.raises(H5InputError):
             evaluate_s4_falsification(
                 primary_trades=_uniform_trades(40), upward_trades=wrong_path_upward
+            )
+
+
+class TestStrategyAndSelectedOosMembershipBinding:
+    def test_s4_evaluator_rejects_pure_s3_book(self):
+        def as_s3(trade: MetricTrade) -> MetricTrade:
+            return dataclasses.replace(
+                trade,
+                strategy="S3",
+                config_id="S3-00",
+                dimension="XRPUSDT",
+                gross_notional=None,
+                volatility_percentile=50.0,
+            )
+
+        with pytest.raises(H5InputError):
+            evaluate_s4_falsification(
+                primary_trades=tuple(as_s3(t) for t in _uniform_trades(40)),
+                upward_trades=tuple(as_s3(t) for t in _upward_trades(10)),
+            )
+
+    def test_s4_evaluator_rejects_mixed_selected_configs(self):
+        upward = list(_upward_trades(10))
+        upward[-1] = dataclasses.replace(upward[-1], config_id="S4-23")
+        with pytest.raises(H5InputError):
+            evaluate_s4_falsification(
+                primary_trades=_uniform_trades(40), upward_trades=tuple(upward)
             )
 
 
@@ -613,6 +642,12 @@ _S3_RANK = StrategyRankMetrics(
 _S4_RANK = StrategyRankMetrics(
     min_fold_e17=6.0, pooled_e17=8.0, monthly_concentration=0.4, timeout_ratio=0.2
 )
+_S4_SUPERIOR_RANK = StrategyRankMetrics(
+    min_fold_e17=6.0,
+    pooled_e17=16.0,
+    monthly_concentration=0.4,
+    timeout_ratio=0.12,
+)
 
 
 class TestCampaignDecision:
@@ -762,7 +797,7 @@ class TestObservableS4Superiority:
             s4_direct_verdict="historical_pass",
             s4_observable_superiority=True,
             s3_rank_metrics=_S3_RANK,
-            s4_rank_metrics=_S4_RANK,
+            s4_rank_metrics=_S4_SUPERIOR_RANK,
         )
         result_false = compute_campaign_decision(
             s3_direct_verdict="historical_pass",
@@ -779,6 +814,19 @@ class TestObservableS4Superiority:
         assert result_true.demo_candidate == result_false.demo_candidate == "S3"
         assert result_true.s4_observable_superiority is True
         assert result_false.s4_observable_superiority is False
+
+    def test_supplied_superiority_must_match_rank_recomputation(self):
+        with pytest.raises(
+            H5InputError,
+            match="campaign_s4_observable_superiority_forged_or_stale",
+        ):
+            compute_campaign_decision(
+                s3_direct_verdict="historical_pass",
+                s4_direct_verdict="historical_pass",
+                s4_observable_superiority=True,
+                s3_rank_metrics=_S3_RANK,
+                s4_rank_metrics=_S4_RANK,
+            )
 
 
 class TestRankBothPass:

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp6_canonical_json.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp6_canonical_json.py
@@ -38,7 +38,9 @@ from rob974_h5_gates import evaluate_common_gates
 from rob974_h5_s3 import evaluate_s3_falsification
 from rob974_h5_s4 import (
     S4_HISTORICAL_PAIR_EXECUTOR_STATE,
-    CampaignDecisionResult,
+    StrategyRankMetrics,
+    compute_campaign_decision,
+    compute_direct_verdict,
     evaluate_s4_falsification,
 )
 
@@ -86,12 +88,20 @@ def _seal(**overrides) -> H6AAccountingSeal:
     return H6AAccountingSeal(**fields)
 
 
-def _s3_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRPUSDT"):
+def _s3_trade(
+    fold_id,
+    net_bps,
+    *,
+    exit_ts=0,
+    exit_reason="TP",
+    dimension="XRPUSDT",
+    path_scenario="primary_stress17",
+):
     return MetricTrade(
         strategy="S3",
         config_id="S3-00",
         fold_id=fold_id,
-        path_scenario="primary_stress17",
+        path_scenario=path_scenario,
         dimension=dimension,
         direction="long",
         entry_ts=exit_ts,
@@ -108,12 +118,20 @@ def _s3_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRPUS
     )
 
 
-def _s4_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRP-DOGE"):
+def _s4_trade(
+    fold_id,
+    net_bps,
+    *,
+    exit_ts=0,
+    exit_reason="TP",
+    dimension="XRP-DOGE",
+    path_scenario="primary_stress17",
+):
     return MetricTrade(
         strategy="S4",
         config_id="S4-00",
         fold_id=fold_id,
-        path_scenario="primary_stress17",
+        path_scenario=path_scenario,
         dimension=dimension,
         direction="long",
         entry_ts=exit_ts,
@@ -124,7 +142,7 @@ def _s4_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRP-D
         net_bps=net_bps,
         tp_bps=68.0,
         sl_bps=40.0,
-        gross_notional=None,
+        gross_notional=100.0,
         market_return_4h=0.01,
         volatility_percentile=None,
     )
@@ -134,24 +152,48 @@ def _s3_primary_trades(n: int = 40) -> tuple:
     return tuple(_s3_trade(FOLD_IDS[i % 8], 10.0, exit_ts=i) for i in range(n))
 
 
+def _s3_upward_trades(n: int = 10) -> tuple:
+    return tuple(
+        _s3_trade(FOLD_IDS[i % 8], 10.0, exit_ts=i, path_scenario="upward_stress22")
+        for i in range(n)
+    )
+
+
 def _s4_primary_trades(n: int = 40) -> tuple:
     return tuple(_s4_trade(FOLD_IDS[i % 8], 10.0, exit_ts=i) for i in range(n))
 
 
+def _s4_upward_trades(n: int = 10) -> tuple:
+    return tuple(
+        _s4_trade(FOLD_IDS[i % 8], 10.0, exit_ts=i, path_scenario="upward_stress22")
+        for i in range(n)
+    )
+
+
 def _build_strategy_inputs(strategy: str) -> StrategyCanonicalInputs:
+    # direct_verdict is ALWAYS recomputed via compute_direct_verdict here
+    # (never hand-asserted) -- build_canonical_scorecard cross-checks this
+    # against common_gates/falsification and rejects a mismatch (D13 fix,
+    # adversarial verify R1 finding 4). This single-dimension fixture is
+    # missing symbol/pair coverage by construction, so both strategies
+    # genuinely compute "incomplete" here.
     if strategy == "S3":
         primary = _s3_primary_trades()
         common_gates = evaluate_common_gates(
-            primary_trades=primary, upward_trades=_s3_primary_trades(10)
+            primary_trades=primary, upward_trades=_s3_upward_trades(10)
         )
         falsification = evaluate_s3_falsification(
-            primary_trades=primary, upward_trades=_s3_primary_trades(10)
+            primary_trades=primary, upward_trades=_s3_upward_trades(10)
+        )
+        direct_verdict = compute_direct_verdict(
+            incomplete_reasons=falsification.incomplete_reasons,
+            hard_gate_reasons=common_gates.reasons + falsification.reasons,
         )
         return StrategyCanonicalInputs(
             strategy="S3",
             common_gates=common_gates,
             falsification=falsification,
-            direct_verdict="historical_pass",
+            direct_verdict=direct_verdict,
             exit_reason_order=("TP", "SL", "THESIS_EXIT", "TIMEOUT"),
             dimension_order=("XRPUSDT", "DOGEUSDT", "SOLUSDT"),
             unique_by_key={},
@@ -160,16 +202,20 @@ def _build_strategy_inputs(strategy: str) -> StrategyCanonicalInputs:
         )
     primary = _s4_primary_trades()
     common_gates = evaluate_common_gates(
-        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+        primary_trades=primary, upward_trades=_s4_upward_trades(10)
     )
     falsification = evaluate_s4_falsification(
-        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+        primary_trades=primary, upward_trades=_s4_upward_trades(10)
+    )
+    direct_verdict = compute_direct_verdict(
+        incomplete_reasons=falsification.incomplete_reasons,
+        hard_gate_reasons=common_gates.reasons + falsification.reasons,
     )
     return StrategyCanonicalInputs(
         strategy="S4",
         common_gates=common_gates,
         falsification=falsification,
-        direct_verdict="historical_pass",
+        direct_verdict=direct_verdict,
         exit_reason_order=("TP", "SL", "MEAN_EXIT", "STALL_EXIT", "TIMEOUT"),
         dimension_order=("XRP-DOGE", "XRP-SOL", "DOGE-SOL"),
         unique_by_key={},
@@ -180,19 +226,18 @@ def _build_strategy_inputs(strategy: str) -> StrategyCanonicalInputs:
 
 
 def _build_scorecard() -> dict:
+    s3_inputs = _build_strategy_inputs("S3")
+    s4_inputs = _build_strategy_inputs("S4")
     return build_canonical_scorecard(
         envelope=_envelope(),
         h6a_seal=_seal(),
         envelope_ok=True,
         envelope_incomplete_reasons=(),
-        s3_inputs=_build_strategy_inputs("S3"),
-        s4_inputs=_build_strategy_inputs("S4"),
-        campaign_decision=CampaignDecisionResult(
-            campaign_decision="both_pass_s3_demo_candidate",
-            s3_direct_verdict="historical_pass",
-            s4_direct_verdict="historical_pass",
-            demo_candidate="S3",
-            s4_observable_superiority=False,
+        s3_inputs=s3_inputs,
+        s4_inputs=s4_inputs,
+        campaign_decision=compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
         ),
     )
 
@@ -282,35 +327,29 @@ class TestPermutationInvariance:
         seal_b = _seal(
             status_counts={"timeout": 0, "crashed": 0, "rejected": 0, "completed": 48}
         )
+        s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
+        campaign_decision = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
         scorecard_a = build_canonical_scorecard(
             envelope=_envelope(),
             h6a_seal=seal_a,
             envelope_ok=True,
             envelope_incomplete_reasons=(),
-            s3_inputs=_build_strategy_inputs("S3"),
-            s4_inputs=_build_strategy_inputs("S4"),
-            campaign_decision=CampaignDecisionResult(
-                campaign_decision="both_pass_s3_demo_candidate",
-                s3_direct_verdict="historical_pass",
-                s4_direct_verdict="historical_pass",
-                demo_candidate="S3",
-                s4_observable_superiority=False,
-            ),
+            s3_inputs=s3_inputs,
+            s4_inputs=s4_inputs,
+            campaign_decision=campaign_decision,
         )
         scorecard_b = build_canonical_scorecard(
             envelope=_envelope(),
             h6a_seal=seal_b,
             envelope_ok=True,
             envelope_incomplete_reasons=(),
-            s3_inputs=_build_strategy_inputs("S3"),
-            s4_inputs=_build_strategy_inputs("S4"),
-            campaign_decision=CampaignDecisionResult(
-                campaign_decision="both_pass_s3_demo_candidate",
-                s3_direct_verdict="historical_pass",
-                s4_direct_verdict="historical_pass",
-                demo_candidate="S3",
-                s4_observable_superiority=False,
-            ),
+            s3_inputs=s3_inputs,
+            s4_inputs=s4_inputs,
+            campaign_decision=campaign_decision,
         )
         bytes_a = canonical_json_bytes(scorecard_a)
         bytes_b = canonical_json_bytes(scorecard_b)
@@ -322,6 +361,7 @@ class TestPermutationInvariance:
         # Rebuild S3 falsification's by_symbol attribution dict with keys
         # inserted in a DIFFERENT order -- must not move the hash.
         s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
         by_symbol = s3_inputs.falsification.attribution["by_symbol"]
         reordered = dict(reversed(list(by_symbol.items())))
         object.__setattr__(
@@ -335,13 +375,10 @@ class TestPermutationInvariance:
             envelope_ok=True,
             envelope_incomplete_reasons=(),
             s3_inputs=s3_inputs,
-            s4_inputs=_build_strategy_inputs("S4"),
-            campaign_decision=CampaignDecisionResult(
-                campaign_decision="both_pass_s3_demo_candidate",
-                s3_direct_verdict="historical_pass",
-                s4_direct_verdict="historical_pass",
-                demo_candidate="S3",
-                s4_observable_superiority=False,
+            s4_inputs=s4_inputs,
+            campaign_decision=compute_campaign_decision(
+                s3_direct_verdict=s3_inputs.direct_verdict,
+                s4_direct_verdict=s4_inputs.direct_verdict,
             ),
         )
         assert canonical_json_bytes(scorecard_a) == canonical_json_bytes(scorecard_b)
@@ -389,3 +426,86 @@ class TestHashSensitivity:
         assert hash_canonical_bytes(canonical_json_bytes(base)) != hash_canonical_bytes(
             canonical_json_bytes(mutated)
         )
+
+
+class TestCanonicalConsistencyValidation:
+    """D13 exploit repro (adversarial verify R1, finding 4):
+    ``build_canonical_scorecard`` must recompute and cross-check each
+    strategy's ``direct_verdict`` against its own ``common_gates``/
+    ``falsification`` (never trust a caller-supplied label), and must
+    cross-check the campaign decision's embedded verdicts against those
+    same recomputed values -- a forged "historical_pass" alongside
+    ``common_gates.passed=False``/nonempty ``incomplete_reasons`` must be
+    rejected, not silently canonicalized."""
+
+    def test_forged_direct_verdict_rejected(self):
+        import dataclasses
+
+        s3_inputs = _build_strategy_inputs("S3")
+        assert s3_inputs.direct_verdict == "incomplete"
+        forged = dataclasses.replace(s3_inputs, direct_verdict="historical_pass")
+        with pytest.raises(H5InputError):
+            build_canonical_scorecard(
+                envelope=_envelope(),
+                h6a_seal=_seal(),
+                envelope_ok=True,
+                envelope_incomplete_reasons=(),
+                s3_inputs=forged,
+                s4_inputs=_build_strategy_inputs("S4"),
+                campaign_decision=compute_campaign_decision(
+                    s3_direct_verdict="historical_pass", s4_direct_verdict="incomplete"
+                ),
+            )
+
+    def test_campaign_decision_verdict_mismatch_rejected(self):
+        s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
+        assert s3_inputs.direct_verdict == "incomplete"
+        # A campaign_decision computed from verdicts that do NOT match the
+        # actual strategy inputs' own (correctly-computed) direct_verdict.
+        mismatched_campaign_decision = compute_campaign_decision(
+            s3_direct_verdict="historical_pass",
+            s4_direct_verdict="historical_pass",
+            s3_rank_metrics=StrategyRankMetrics(
+                min_fold_e17=5.0,
+                pooled_e17=10.0,
+                monthly_concentration=0.3,
+                timeout_ratio=0.1,
+            ),
+            s4_rank_metrics=StrategyRankMetrics(
+                min_fold_e17=5.0,
+                pooled_e17=10.0,
+                monthly_concentration=0.3,
+                timeout_ratio=0.1,
+            ),
+        )
+        with pytest.raises(H5InputError):
+            build_canonical_scorecard(
+                envelope=_envelope(),
+                h6a_seal=_seal(),
+                envelope_ok=True,
+                envelope_incomplete_reasons=(),
+                s3_inputs=s3_inputs,
+                s4_inputs=s4_inputs,
+                campaign_decision=mismatched_campaign_decision,
+            )
+
+    def test_consistent_inputs_are_accepted(self):
+        # Sanity: the SAME cross-check must not reject genuinely consistent
+        # input (no false positives).
+        s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
+        campaign_decision = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
+        scorecard = build_canonical_scorecard(
+            envelope=_envelope(),
+            h6a_seal=_seal(),
+            envelope_ok=True,
+            envelope_incomplete_reasons=(),
+            s3_inputs=s3_inputs,
+            s4_inputs=s4_inputs,
+            campaign_decision=campaign_decision,
+        )
+        assert scorecard["campaign_decision"]["campaign_decision"] == "incomplete"

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp6_canonical_json.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp6_canonical_json.py
@@ -12,6 +12,7 @@ every semantic-subtree mutation changing the hash.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import math
 from decimal import Decimal
@@ -439,11 +440,17 @@ class TestCanonicalConsistencyValidation:
     rejected, not silently canonicalized."""
 
     def test_forged_direct_verdict_rejected(self):
-        import dataclasses
-
         s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
         assert s3_inputs.direct_verdict == "incomplete"
         forged = dataclasses.replace(s3_inputs, direct_verdict="historical_pass")
+        # Keep the campaign decision honest.  This isolates the strategy
+        # direct-verdict comparison: removing that one guard cannot be
+        # masked by the later full-campaign equality check.
+        honest_campaign = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
         with pytest.raises(H5InputError):
             build_canonical_scorecard(
                 envelope=_envelope(),
@@ -451,10 +458,28 @@ class TestCanonicalConsistencyValidation:
                 envelope_ok=True,
                 envelope_incomplete_reasons=(),
                 s3_inputs=forged,
-                s4_inputs=_build_strategy_inputs("S4"),
-                campaign_decision=compute_campaign_decision(
-                    s3_direct_verdict="historical_pass", s4_direct_verdict="incomplete"
-                ),
+                s4_inputs=s4_inputs,
+                campaign_decision=honest_campaign,
+            )
+
+    def test_forged_s4_direct_verdict_rejected_by_its_own_guard(self):
+        s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
+        assert s4_inputs.direct_verdict == "incomplete"
+        forged = dataclasses.replace(s4_inputs, direct_verdict="historical_pass")
+        honest_campaign = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
+        with pytest.raises(H5InputError):
+            build_canonical_scorecard(
+                envelope=_envelope(),
+                h6a_seal=_seal(),
+                envelope_ok=True,
+                envelope_incomplete_reasons=(),
+                s3_inputs=s3_inputs,
+                s4_inputs=forged,
+                campaign_decision=honest_campaign,
             )
 
     def test_campaign_decision_verdict_mismatch_rejected(self):
@@ -509,3 +534,106 @@ class TestCanonicalConsistencyValidation:
             campaign_decision=campaign_decision,
         )
         assert scorecard["campaign_decision"]["campaign_decision"] == "incomplete"
+
+    @pytest.mark.parametrize(
+        ("field", "forged_value"),
+        (
+            ("campaign_decision", "both_pass_s3_demo_candidate"),
+            ("campaign_historical_verdict", "historical_pass"),
+            ("s3_direct_verdict", "historical_pass"),
+            ("s4_direct_verdict", "historical_pass"),
+            ("demo_candidate", "S3"),
+            ("historical_preferred", "S3"),
+            ("s4_observable_superiority", True),
+        ),
+    )
+    def test_each_forged_campaign_field_is_independently_rejected(
+        self, field, forged_value
+    ):
+        s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
+        honest = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
+        forged = dataclasses.replace(honest, **{field: forged_value})
+        with pytest.raises(H5InputError):
+            build_canonical_scorecard(
+                envelope=_envelope(),
+                h6a_seal=_seal(),
+                envelope_ok=True,
+                envelope_incomplete_reasons=(),
+                s3_inputs=s3_inputs,
+                s4_inputs=s4_inputs,
+                campaign_decision=forged,
+            )
+
+    def test_common_gate_passed_flag_must_match_reasons(self):
+        s3_inputs = _build_strategy_inputs("S3")
+        assert s3_inputs.common_gates.reasons
+        contradictory_gates = dataclasses.replace(s3_inputs.common_gates, passed=True)
+        contradictory_s3 = dataclasses.replace(
+            s3_inputs, common_gates=contradictory_gates
+        )
+        s4_inputs = _build_strategy_inputs("S4")
+        campaign = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
+        with pytest.raises(H5InputError):
+            build_canonical_scorecard(
+                envelope=_envelope(),
+                h6a_seal=_seal(),
+                envelope_ok=True,
+                envelope_incomplete_reasons=(),
+                s3_inputs=contradictory_s3,
+                s4_inputs=s4_inputs,
+                campaign_decision=campaign,
+            )
+
+    def test_falsification_passed_flag_must_match_reasons(self):
+        s3_inputs = _build_strategy_inputs("S3")
+        assert s3_inputs.falsification.reasons == ()
+        contradictory_falsification = dataclasses.replace(
+            s3_inputs.falsification, passed=False
+        )
+        contradictory_s3 = dataclasses.replace(
+            s3_inputs, falsification=contradictory_falsification
+        )
+        s4_inputs = _build_strategy_inputs("S4")
+        campaign = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
+        with pytest.raises(H5InputError):
+            build_canonical_scorecard(
+                envelope=_envelope(),
+                h6a_seal=_seal(),
+                envelope_ok=True,
+                envelope_incomplete_reasons=(),
+                s3_inputs=contradictory_s3,
+                s4_inputs=s4_inputs,
+                campaign_decision=campaign,
+            )
+
+    def test_envelope_claim_must_match_h6a_seal_recomputation(self):
+        s3_inputs = _build_strategy_inputs("S3")
+        s4_inputs = _build_strategy_inputs("S4")
+        unusable_seal = _seal(
+            performance_usable=False,
+            reason_codes=("h6_accounting_incomplete",),
+        )
+        campaign = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+        )
+        with pytest.raises(H5InputError):
+            build_canonical_scorecard(
+                envelope=_envelope(),
+                h6a_seal=unusable_seal,
+                envelope_ok=True,
+                envelope_incomplete_reasons=(),
+                s3_inputs=s3_inputs,
+                s4_inputs=s4_inputs,
+                campaign_decision=campaign,
+            )

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp6_canonical_json.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp6_canonical_json.py
@@ -1,0 +1,391 @@
+"""ROB-983 (H5, CP6) -- canonical semantic JSON and presentation-independent
+hash.
+
+Permutation invariance (rebuilding the same semantic content via a
+differently-ordered upstream mapping produces byte-identical output),
+profit-factor sanitization (``+inf``/``nan`` -> ``null``+reason, never a raw
+non-finite float), exact-type rejection (bool-as-float, ``Decimal``,
+rounded-string re-entry), the ``NaN``/``Inf`` JSON boundary
+(``allow_nan=False``), fixture chronological-key collision detection, and
+every semantic-subtree mutation changing the hash.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from decimal import Decimal
+
+import pytest
+from rob974_h5_canonical import (
+    ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED,
+    StrategyCanonicalInputs,
+    build_canonical_scorecard,
+    canonical_json_bytes,
+    chronological_key,
+    hash_canonical_bytes,
+    sanitize_bucket,
+    sort_trades_chronologically,
+)
+from rob974_h5_contracts import (
+    FOLD_IDS,
+    CampaignEnvelope,
+    H5InputError,
+    H6AAccountingSeal,
+    MetricTrade,
+)
+from rob974_h5_gates import evaluate_common_gates
+from rob974_h5_s3 import evaluate_s3_falsification
+from rob974_h5_s4 import (
+    S4_HISTORICAL_PAIR_EXECUTOR_STATE,
+    CampaignDecisionResult,
+    evaluate_s4_falsification,
+)
+
+_HEX64_A = "a" * 64
+_HEX64_B = "b" * 64
+
+
+def _envelope(**overrides) -> CampaignEnvelope:
+    ids = tuple(f"S3-{i:02d}" for i in range(24)) + tuple(
+        f"S4-{i:02d}" for i in range(24)
+    )
+    fields = {
+        "full_campaign_hash": _HEX64_A,
+        "campaign_run_id": "run-1",
+        "parent_corpus_hash": _HEX64_A,
+        "parent_projection_hash": _HEX64_A,
+        "feature_contract_hash": _HEX64_A,
+        "strategy_contract_hashes": {"S3": _HEX64_A, "S4": _HEX64_B},
+        "h4_runner_source_hash": _HEX64_A,
+        "h4_pbo_source_hash": _HEX64_A,
+        "h2_engine_source_hash": _HEX64_A,
+        "h3_generator_source_hash": _HEX64_A,
+        "run_schema_version": "v1",
+        "generator_version": "g1",
+        "expected_experiment_ids": ids,
+        "h6a_trial_accounting_hash": _HEX64_B,
+    }
+    fields.update(overrides)
+    return CampaignEnvelope(**fields)
+
+
+def _seal(**overrides) -> H6AAccountingSeal:
+    fields = {
+        "expected_total": 48,
+        "registered_total": 48,
+        "primary_attempts": 48,
+        "status_counts": {"completed": 48, "rejected": 0, "crashed": 0, "timeout": 0},
+        "retry_attempts": 0,
+        "accounting_complete": True,
+        "performance_usable": True,
+        "trial_accounting_hash": _HEX64_B,
+        "reason_codes": (),
+    }
+    fields.update(overrides)
+    return H6AAccountingSeal(**fields)
+
+
+def _s3_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRPUSDT"):
+    return MetricTrade(
+        strategy="S3",
+        config_id="S3-00",
+        fold_id=fold_id,
+        path_scenario="primary_stress17",
+        dimension=dimension,
+        direction="long",
+        entry_ts=exit_ts,
+        exit_ts=exit_ts + 60_000,
+        holding_minutes=10.0,
+        exit_reason=exit_reason,
+        gross_bps=net_bps + 5.0,
+        net_bps=net_bps,
+        tp_bps=68.0,
+        sl_bps=40.0,
+        gross_notional=None,
+        market_return_4h=0.01,
+        volatility_percentile=50.0,
+    )
+
+
+def _s4_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRP-DOGE"):
+    return MetricTrade(
+        strategy="S4",
+        config_id="S4-00",
+        fold_id=fold_id,
+        path_scenario="primary_stress17",
+        dimension=dimension,
+        direction="long",
+        entry_ts=exit_ts,
+        exit_ts=exit_ts + 60_000,
+        holding_minutes=10.0,
+        exit_reason=exit_reason,
+        gross_bps=net_bps + 5.0,
+        net_bps=net_bps,
+        tp_bps=68.0,
+        sl_bps=40.0,
+        gross_notional=None,
+        market_return_4h=0.01,
+        volatility_percentile=None,
+    )
+
+
+def _s3_primary_trades(n: int = 40) -> tuple:
+    return tuple(_s3_trade(FOLD_IDS[i % 8], 10.0, exit_ts=i) for i in range(n))
+
+
+def _s4_primary_trades(n: int = 40) -> tuple:
+    return tuple(_s4_trade(FOLD_IDS[i % 8], 10.0, exit_ts=i) for i in range(n))
+
+
+def _build_strategy_inputs(strategy: str) -> StrategyCanonicalInputs:
+    if strategy == "S3":
+        primary = _s3_primary_trades()
+        common_gates = evaluate_common_gates(
+            primary_trades=primary, upward_trades=_s3_primary_trades(10)
+        )
+        falsification = evaluate_s3_falsification(
+            primary_trades=primary, upward_trades=_s3_primary_trades(10)
+        )
+        return StrategyCanonicalInputs(
+            strategy="S3",
+            common_gates=common_gates,
+            falsification=falsification,
+            direct_verdict="historical_pass",
+            exit_reason_order=("TP", "SL", "THESIS_EXIT", "TIMEOUT"),
+            dimension_order=("XRPUSDT", "DOGEUSDT", "SOLUSDT"),
+            unique_by_key={},
+            paths_by_key={},
+            pbo=None,
+        )
+    primary = _s4_primary_trades()
+    common_gates = evaluate_common_gates(
+        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+    )
+    falsification = evaluate_s4_falsification(
+        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+    )
+    return StrategyCanonicalInputs(
+        strategy="S4",
+        common_gates=common_gates,
+        falsification=falsification,
+        direct_verdict="historical_pass",
+        exit_reason_order=("TP", "SL", "MEAN_EXIT", "STALL_EXIT", "TIMEOUT"),
+        dimension_order=("XRP-DOGE", "XRP-SOL", "DOGE-SOL"),
+        unique_by_key={},
+        paths_by_key={},
+        pbo=None,
+        pair_executor_state=S4_HISTORICAL_PAIR_EXECUTOR_STATE,
+    )
+
+
+def _build_scorecard() -> dict:
+    return build_canonical_scorecard(
+        envelope=_envelope(),
+        h6a_seal=_seal(),
+        envelope_ok=True,
+        envelope_incomplete_reasons=(),
+        s3_inputs=_build_strategy_inputs("S3"),
+        s4_inputs=_build_strategy_inputs("S4"),
+        campaign_decision=CampaignDecisionResult(
+            campaign_decision="both_pass_s3_demo_candidate",
+            s3_direct_verdict="historical_pass",
+            s4_direct_verdict="historical_pass",
+            demo_candidate="S3",
+            s4_observable_superiority=False,
+        ),
+    )
+
+
+class TestSanitizeBucket:
+    def test_finite_pf_passes_through(self):
+        bucket = {
+            "trades": 10,
+            "e17_bps": 5.0,
+            "e0_bps": 8.0,
+            "pf": 1.5,
+            "avg_holding_minutes": 12.0,
+        }
+        result = sanitize_bucket(bucket)
+        assert result["pf"] == pytest.approx(1.5)
+        assert result["pf_reason"] is None
+
+    def test_infinite_pf_becomes_null_with_reason(self):
+        bucket = {
+            "trades": 10,
+            "e17_bps": 5.0,
+            "e0_bps": 8.0,
+            "pf": math.inf,
+            "avg_holding_minutes": 12.0,
+        }
+        result = sanitize_bucket(bucket)
+        assert result["pf"] is None
+        assert result["pf_reason"] == "pf_infinite_zero_loss_with_profit"
+
+    def test_nan_pf_becomes_null_with_reason(self):
+        bucket = {
+            "trades": 10,
+            "e17_bps": 0.0,
+            "e0_bps": 0.0,
+            "pf": float("nan"),
+            "avg_holding_minutes": 12.0,
+        }
+        result = sanitize_bucket(bucket)
+        assert result["pf"] is None
+        assert result["pf_reason"] == "pf_undefined_zero_loss_and_zero_profit"
+
+
+class TestChronologicalKeyAndSort:
+    def test_sorts_by_fold_config_entry_exit(self):
+        t1 = _s3_trade("fold-01", 1.0, exit_ts=100)
+        t2 = _s3_trade("fold-00", 2.0, exit_ts=50)
+        result = sort_trades_chronologically((t1, t2))
+        assert result == (t2, t1)
+
+    def test_collision_raises(self):
+        t1 = _s3_trade("fold-00", 1.0, exit_ts=100)
+        t2 = _s3_trade("fold-00", 2.0, exit_ts=100)
+        assert chronological_key(t1) == chronological_key(t2)
+        with pytest.raises(H5InputError):
+            sort_trades_chronologically((t1, t2))
+
+
+class TestExactTypeRejection:
+    def test_bool_as_float_rejected_in_envelope(self):
+        with pytest.raises(H5InputError):
+            _envelope(full_campaign_hash=True)
+
+    def test_decimal_rejected_in_seal(self):
+        with pytest.raises(H5InputError):
+            _seal(registered_total=Decimal(48))
+
+    def test_rounded_string_reentry_rejected(self):
+        with pytest.raises(H5InputError):
+            _seal(retry_attempts="0")
+
+    def test_nan_rejected_by_generic_canonical_validator(self):
+        with pytest.raises(H5InputError):
+            from rob974_h5_canonical import _validate_canonical_value
+
+            _validate_canonical_value({"x": float("nan")}, "root")
+
+    def test_raw_json_dumps_with_allow_nan_false_rejects_nan(self):
+        with pytest.raises(ValueError):
+            canonical_json_bytes({"x": float("nan")})
+
+
+class TestPermutationInvariance:
+    def test_status_counts_key_order_does_not_change_hash(self):
+        seal_a = _seal(
+            status_counts={"completed": 48, "rejected": 0, "crashed": 0, "timeout": 0}
+        )
+        seal_b = _seal(
+            status_counts={"timeout": 0, "crashed": 0, "rejected": 0, "completed": 48}
+        )
+        scorecard_a = build_canonical_scorecard(
+            envelope=_envelope(),
+            h6a_seal=seal_a,
+            envelope_ok=True,
+            envelope_incomplete_reasons=(),
+            s3_inputs=_build_strategy_inputs("S3"),
+            s4_inputs=_build_strategy_inputs("S4"),
+            campaign_decision=CampaignDecisionResult(
+                campaign_decision="both_pass_s3_demo_candidate",
+                s3_direct_verdict="historical_pass",
+                s4_direct_verdict="historical_pass",
+                demo_candidate="S3",
+                s4_observable_superiority=False,
+            ),
+        )
+        scorecard_b = build_canonical_scorecard(
+            envelope=_envelope(),
+            h6a_seal=seal_b,
+            envelope_ok=True,
+            envelope_incomplete_reasons=(),
+            s3_inputs=_build_strategy_inputs("S3"),
+            s4_inputs=_build_strategy_inputs("S4"),
+            campaign_decision=CampaignDecisionResult(
+                campaign_decision="both_pass_s3_demo_candidate",
+                s3_direct_verdict="historical_pass",
+                s4_direct_verdict="historical_pass",
+                demo_candidate="S3",
+                s4_observable_superiority=False,
+            ),
+        )
+        bytes_a = canonical_json_bytes(scorecard_a)
+        bytes_b = canonical_json_bytes(scorecard_b)
+        assert bytes_a == bytes_b
+        assert hash_canonical_bytes(bytes_a) == hash_canonical_bytes(bytes_b)
+
+    def test_attribution_dict_construction_order_does_not_change_hash(self):
+        scorecard_a = _build_scorecard()
+        # Rebuild S3 falsification's by_symbol attribution dict with keys
+        # inserted in a DIFFERENT order -- must not move the hash.
+        s3_inputs = _build_strategy_inputs("S3")
+        by_symbol = s3_inputs.falsification.attribution["by_symbol"]
+        reordered = dict(reversed(list(by_symbol.items())))
+        object.__setattr__(
+            s3_inputs.falsification,
+            "attribution",
+            {**s3_inputs.falsification.attribution, "by_symbol": reordered},
+        )
+        scorecard_b = build_canonical_scorecard(
+            envelope=_envelope(),
+            h6a_seal=_seal(),
+            envelope_ok=True,
+            envelope_incomplete_reasons=(),
+            s3_inputs=s3_inputs,
+            s4_inputs=_build_strategy_inputs("S4"),
+            campaign_decision=CampaignDecisionResult(
+                campaign_decision="both_pass_s3_demo_candidate",
+                s3_direct_verdict="historical_pass",
+                s4_direct_verdict="historical_pass",
+                demo_candidate="S3",
+                s4_observable_superiority=False,
+            ),
+        )
+        assert canonical_json_bytes(scorecard_a) == canonical_json_bytes(scorecard_b)
+
+
+class TestActualH4LedgerKeySentinel:
+    def test_sentinel_present_in_lineage(self):
+        scorecard = _build_scorecard()
+        assert (
+            scorecard["lineage"]["actual_h4_ledger_key"]
+            == ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED
+            == "NOT_EVALUATED"
+        )
+
+
+class TestHashSensitivity:
+    def test_hash_is_deterministic_for_identical_input(self):
+        bytes_a = canonical_json_bytes(_build_scorecard())
+        bytes_b = canonical_json_bytes(_build_scorecard())
+        assert bytes_a == bytes_b
+        assert hash_canonical_bytes(bytes_a) == hash_canonical_bytes(bytes_b)
+
+    def test_changing_campaign_decision_changes_hash(self):
+        base = _build_scorecard()
+        mutated = json.loads(canonical_json_bytes(base))
+        mutated["campaign_decision"]["campaign_decision"] = "both_fail"
+        assert hash_canonical_bytes(canonical_json_bytes(base)) != hash_canonical_bytes(
+            canonical_json_bytes(mutated)
+        )
+
+    def test_changing_a_reason_code_changes_hash(self):
+        base = _build_scorecard()
+        mutated = json.loads(canonical_json_bytes(base))
+        mutated["strategies"]["S3"]["falsification"]["reasons"] = [
+            "s3_symbol_dependence"
+        ]
+        assert hash_canonical_bytes(canonical_json_bytes(base)) != hash_canonical_bytes(
+            canonical_json_bytes(mutated)
+        )
+
+    def test_changing_lineage_hash_changes_top_hash(self):
+        base = _build_scorecard()
+        mutated = json.loads(canonical_json_bytes(base))
+        mutated["lineage"]["full_campaign_hash"] = "c" * 64
+        assert hash_canonical_bytes(canonical_json_bytes(base)) != hash_canonical_bytes(
+            canonical_json_bytes(mutated)
+        )

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
@@ -47,7 +47,7 @@ from rob974_h5_markdown import render_markdown
 from rob974_h5_s3 import evaluate_s3_falsification
 from rob974_h5_s4 import (
     S4_HISTORICAL_PAIR_EXECUTOR_STATE,
-    CampaignDecisionResult,
+    StrategyRankMetrics,
     compute_campaign_decision,
     compute_direct_verdict,
     evaluate_s4_falsification,
@@ -56,6 +56,8 @@ from rob974_h5_s4 import (
 _HEX64_A = "a" * 64
 _HEX64_B = "b" * 64
 _HEX64_C = "c" * 64
+_DAY_MS = 24 * 60 * 60 * 1000
+_MONTH_MS = 30 * _DAY_MS
 
 
 def _envelope(**overrides) -> CampaignEnvelope:
@@ -98,17 +100,26 @@ def _seal(**overrides) -> H6AAccountingSeal:
     return H6AAccountingSeal(**fields)
 
 
-def _s3_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRPUSDT"):
+def _s3_trade(
+    fold_id,
+    net_bps,
+    *,
+    exit_ts=0,
+    exit_reason="TP",
+    dimension="XRPUSDT",
+    path_scenario="primary_stress17",
+    holding_minutes=10.0,
+):
     return MetricTrade(
         strategy="S3",
         config_id="S3-00",
         fold_id=fold_id,
-        path_scenario="primary_stress17",
+        path_scenario=path_scenario,
         dimension=dimension,
         direction="long",
         entry_ts=exit_ts,
         exit_ts=exit_ts + 60_000,
-        holding_minutes=10.0,
+        holding_minutes=holding_minutes,
         exit_reason=exit_reason,
         gross_bps=net_bps + 5.0,
         net_bps=net_bps,
@@ -120,24 +131,34 @@ def _s3_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRPUS
     )
 
 
-def _s4_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRP-DOGE"):
+def _s4_trade(
+    fold_id,
+    net_bps,
+    *,
+    exit_ts=0,
+    exit_reason="TP",
+    dimension="XRP-DOGE",
+    path_scenario="primary_stress17",
+    holding_minutes=10.0,
+    market_return_4h=0.01,
+):
     return MetricTrade(
         strategy="S4",
         config_id="S4-00",
         fold_id=fold_id,
-        path_scenario="primary_stress17",
+        path_scenario=path_scenario,
         dimension=dimension,
         direction="long",
         entry_ts=exit_ts,
         exit_ts=exit_ts + 60_000,
-        holding_minutes=10.0,
+        holding_minutes=holding_minutes,
         exit_reason=exit_reason,
         gross_bps=net_bps + 5.0,
         net_bps=net_bps,
         tp_bps=68.0,
         sl_bps=40.0,
-        gross_notional=None,
-        market_return_4h=0.01,
+        gross_notional=100.0,
+        market_return_4h=market_return_4h,
         volatility_percentile=None,
     )
 
@@ -151,11 +172,25 @@ def _s3_primary_trades(
     )
 
 
+def _s3_upward_trades(n: int = 10, net_bps: float = 10.0) -> tuple:
+    return tuple(
+        _s3_trade(FOLD_IDS[i % 8], net_bps, exit_ts=i, path_scenario="upward_stress22")
+        for i in range(n)
+    )
+
+
 def _s4_primary_trades(
     n: int = 40, exit_reason: str = "TP", net_bps: float = 10.0
 ) -> tuple:
     return tuple(
         _s4_trade(FOLD_IDS[i % 8], net_bps, exit_ts=i, exit_reason=exit_reason)
+        for i in range(n)
+    )
+
+
+def _s4_upward_trades(n: int = 10, net_bps: float = 10.0) -> tuple:
+    return tuple(
+        _s4_trade(FOLD_IDS[i % 8], net_bps, exit_ts=i, path_scenario="upward_stress22")
         for i in range(n)
     )
 
@@ -207,10 +242,10 @@ def _s3_pbo() -> PboEvidence:
 def _build_s3_inputs(*, with_evidence: bool = True) -> StrategyCanonicalInputs:
     primary = _s3_primary_trades()
     common_gates = evaluate_common_gates(
-        primary_trades=primary, upward_trades=_s3_primary_trades(10)
+        primary_trades=primary, upward_trades=_s3_upward_trades(10)
     )
     falsification = evaluate_s3_falsification(
-        primary_trades=primary, upward_trades=_s3_primary_trades(10)
+        primary_trades=primary, upward_trades=_s3_upward_trades(10)
     )
     direct_verdict = compute_direct_verdict(
         incomplete_reasons=falsification.incomplete_reasons,
@@ -246,10 +281,10 @@ def _build_s3_inputs(*, with_evidence: bool = True) -> StrategyCanonicalInputs:
 def _build_s4_inputs() -> StrategyCanonicalInputs:
     primary = _s4_primary_trades()
     common_gates = evaluate_common_gates(
-        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+        primary_trades=primary, upward_trades=_s4_upward_trades(10)
     )
     falsification = evaluate_s4_falsification(
-        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+        primary_trades=primary, upward_trades=_s4_upward_trades(10)
     )
     direct_verdict = compute_direct_verdict(
         incomplete_reasons=falsification.incomplete_reasons,
@@ -266,6 +301,166 @@ def _build_s4_inputs() -> StrategyCanonicalInputs:
         paths_by_key={},
         pbo=None,
         pair_executor_state=S4_HISTORICAL_PAIR_EXECUTOR_STATE,
+    )
+
+
+def _s3_clean_primary_trades(win_net: float) -> tuple:
+    """Full 3-symbol coverage with a small first-4h-excluded loss tail --
+    complete (no incomplete_reasons) regardless of ``win_net``. At
+    ``win_net=40.0`` every common/falsification gate clears
+    (historical_pass); at ``win_net=1.0`` E17/PF/positive-folds/monthly-
+    concentration all fail while staying complete (historical_fail)."""
+    trades = []
+    for fi, fold_id in enumerate(FOLD_IDS):
+        month_ts = fi * _MONTH_MS
+        for symbol in ("XRPUSDT", "DOGEUSDT", "SOLUSDT"):
+            for j in range(5):
+                if j < 4:
+                    net, reason, holding = win_net, "TP", 10.0
+                else:
+                    net, reason, holding = -5.0, "SL", 500.0
+                trades.append(
+                    _s3_trade(
+                        fold_id,
+                        net,
+                        exit_ts=month_ts + j * _DAY_MS,
+                        exit_reason=reason,
+                        dimension=symbol,
+                        holding_minutes=holding,
+                    )
+                )
+    return tuple(trades)
+
+
+def _s3_clean_upward_trades() -> tuple:
+    return tuple(
+        _s3_trade("fold-00", 20.0, exit_ts=i, path_scenario="upward_stress22")
+        for i in range(5)
+    )
+
+
+def _s4_clean_primary_trades(win_net: float) -> tuple:
+    """Full 3-pair coverage, a decorrelated market_return_4h pattern
+    (period-2, independent of the win/loss period-5 cycle -- numerically
+    verified |corr|<<0.15), and mid/slow holding-bucket filler trades
+    (keeps the mid bucket's mean positive so slow-only-failure never
+    fires). Complete regardless of ``win_net``."""
+    trades = []
+    idx = 0
+    for fi, fold_id in enumerate(FOLD_IDS):
+        month_ts = fi * _MONTH_MS
+        for pair in ("XRP-DOGE", "XRP-SOL", "DOGE-SOL"):
+            for j in range(5):
+                if j < 4:
+                    net, reason, holding = win_net, "TP", 10.0
+                else:
+                    net, reason, holding = -5.0, "SL", 500.0
+                m = 0.01 if idx % 2 == 0 else 0.02
+                trades.append(
+                    _s4_trade(
+                        fold_id,
+                        net,
+                        exit_ts=month_ts + j * _DAY_MS,
+                        exit_reason=reason,
+                        dimension=pair,
+                        holding_minutes=holding,
+                        market_return_4h=m,
+                    )
+                )
+                idx += 1
+    for fi, fold_id in enumerate(FOLD_IDS):
+        month_ts = fi * _MONTH_MS
+        trades.append(
+            _s4_trade(
+                fold_id,
+                50.0,
+                exit_ts=month_ts,
+                dimension="XRP-DOGE",
+                holding_minutes=1000.0,
+            )
+        )
+        trades.append(
+            _s4_trade(
+                fold_id,
+                10.0,
+                exit_ts=month_ts + 1,
+                dimension="XRP-DOGE",
+                holding_minutes=2000.0,
+            )
+        )
+    return tuple(trades)
+
+
+def _s4_clean_upward_trades() -> tuple:
+    return tuple(
+        _s4_trade(
+            "fold-00",
+            20.0,
+            exit_ts=i,
+            market_return_4h=0.05,
+            path_scenario="upward_stress22",
+        )
+        for i in range(5)
+    )
+
+
+def _s3_inputs_with_verdict(*, passing: bool) -> StrategyCanonicalInputs:
+    primary = _s3_clean_primary_trades(40.0 if passing else 1.0)
+    upward = _s3_clean_upward_trades()
+    common_gates = evaluate_common_gates(primary_trades=primary, upward_trades=upward)
+    falsification = evaluate_s3_falsification(
+        primary_trades=primary, upward_trades=upward
+    )
+    direct_verdict = compute_direct_verdict(
+        incomplete_reasons=falsification.incomplete_reasons,
+        hard_gate_reasons=common_gates.reasons + falsification.reasons,
+    )
+    return StrategyCanonicalInputs(
+        strategy="S3",
+        common_gates=common_gates,
+        falsification=falsification,
+        direct_verdict=direct_verdict,
+        exit_reason_order=("TP", "SL", "THESIS_EXIT", "TIMEOUT"),
+        dimension_order=("XRPUSDT", "DOGEUSDT", "SOLUSDT"),
+        unique_by_key={},
+        paths_by_key={},
+        pbo=None,
+    )
+
+
+def _s4_inputs_with_verdict(*, passing: bool) -> StrategyCanonicalInputs:
+    primary = _s4_clean_primary_trades(40.0 if passing else 1.0)
+    upward = _s4_clean_upward_trades()
+    common_gates = evaluate_common_gates(primary_trades=primary, upward_trades=upward)
+    falsification = evaluate_s4_falsification(
+        primary_trades=primary, upward_trades=upward
+    )
+    direct_verdict = compute_direct_verdict(
+        incomplete_reasons=falsification.incomplete_reasons,
+        hard_gate_reasons=common_gates.reasons + falsification.reasons,
+    )
+    return StrategyCanonicalInputs(
+        strategy="S4",
+        common_gates=common_gates,
+        falsification=falsification,
+        direct_verdict=direct_verdict,
+        exit_reason_order=("TP", "SL", "MEAN_EXIT", "STALL_EXIT", "TIMEOUT"),
+        dimension_order=("XRP-DOGE", "XRP-SOL", "DOGE-SOL"),
+        unique_by_key={},
+        paths_by_key={},
+        pbo=None,
+        pair_executor_state=S4_HISTORICAL_PAIR_EXECUTOR_STATE,
+    )
+
+
+def _rank_metrics(common_gates, falsification) -> StrategyRankMetrics:
+    # This session's clean fixtures are fold-symmetric by construction, so
+    # min-fold E17 == pooled E17 exactly.
+    return StrategyRankMetrics(
+        min_fold_e17=common_gates.pooled_e17_bps,
+        pooled_e17=common_gates.pooled_e17_bps,
+        monthly_concentration=common_gates.monthly_concentration,
+        timeout_ratio=falsification.pooled_timeout_ratio,
     )
 
 
@@ -349,6 +544,12 @@ class TestNonzeroContentSurvivesJsonToMarkdown:
     def test_campaign_decision_survives(self):
         assert "campaign_decision: incomplete" in self.markdown
 
+    def test_campaign_historical_verdict_and_preferred_survive(self):
+        # AC44 fields (adversarial verify R1, finding 5) -- distinct from
+        # the branch-label campaign_decision/demo_candidate.
+        assert "campaign_historical_verdict: incomplete" in self.markdown
+        assert "historical_preferred: null" in self.markdown
+
 
 class TestPermutationInvarianceOfMarkdown:
     def test_reversed_attribution_dict_order_produces_identical_markdown(self):
@@ -410,16 +611,24 @@ class TestContractFixtureCampaignDecisionSmoke:
     branch -- proves the full contracts -> dual_evidence -> gates ->
     falsification -> canonical -> markdown pipeline produces sane,
     non-empty output for each, without recomputing metrics inside the
-    renderer."""
+    renderer.
 
-    def _render_with_decision(self, campaign_decision: CampaignDecisionResult) -> str:
+    Post-verify-R1 fix 4, ``build_canonical_scorecard`` recomputes and
+    cross-checks each strategy's ``direct_verdict`` (rejecting a
+    caller-supplied value that disagrees with what ``common_gates``/
+    ``falsification`` actually imply) and cross-checks the campaign
+    decision's embedded verdicts against those same recomputed values.
+    These fixtures therefore build GENUINE, gate-verified S3/S4 inputs for
+    each branch rather than asserting an arbitrary label."""
+
+    def _render(self, s3_inputs, s4_inputs, campaign_decision) -> str:
         scorecard = build_canonical_scorecard(
             envelope=_envelope(),
             h6a_seal=_seal(),
             envelope_ok=True,
             envelope_incomplete_reasons=(),
-            s3_inputs=_build_s3_inputs(with_evidence=True),
-            s4_inputs=_build_s4_inputs(),
+            s3_inputs=s3_inputs,
+            s4_inputs=s4_inputs,
             campaign_decision=campaign_decision,
         )
         return render_markdown(json.loads(canonical_json_bytes(scorecard))).decode(
@@ -427,45 +636,72 @@ class TestContractFixtureCampaignDecisionSmoke:
         )
 
     def test_both_pass_s3_demo_candidate(self):
-        md = self._render_with_decision(
-            compute_campaign_decision(
-                s3_direct_verdict="historical_pass", s4_direct_verdict="historical_pass"
-            )
+        s3_inputs = _s3_inputs_with_verdict(passing=True)
+        s4_inputs = _s4_inputs_with_verdict(passing=True)
+        assert s3_inputs.direct_verdict == "historical_pass"
+        assert s4_inputs.direct_verdict == "historical_pass"
+        campaign_decision = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+            s3_rank_metrics=_rank_metrics(
+                s3_inputs.common_gates, s3_inputs.falsification
+            ),
+            s4_rank_metrics=_rank_metrics(
+                s4_inputs.common_gates, s4_inputs.falsification
+            ),
         )
+        md = self._render(s3_inputs, s4_inputs, campaign_decision)
         assert "campaign_decision: both_pass_s3_demo_candidate" in md
         assert "demo_candidate: S3" in md
 
     def test_s3_only(self):
-        md = self._render_with_decision(
-            compute_campaign_decision(
-                s3_direct_verdict="historical_pass", s4_direct_verdict="historical_fail"
-            )
+        s3_inputs = _s3_inputs_with_verdict(passing=True)
+        s4_inputs = _s4_inputs_with_verdict(passing=False)
+        assert s3_inputs.direct_verdict == "historical_pass"
+        assert s4_inputs.direct_verdict == "historical_fail"
+        campaign_decision = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
         )
+        md = self._render(s3_inputs, s4_inputs, campaign_decision)
         assert "campaign_decision: s3_only" in md
 
     def test_s4_only_no_demo(self):
-        md = self._render_with_decision(
-            compute_campaign_decision(
-                s3_direct_verdict="historical_fail", s4_direct_verdict="historical_pass"
-            )
+        s3_inputs = _s3_inputs_with_verdict(passing=False)
+        s4_inputs = _s4_inputs_with_verdict(passing=True)
+        assert s3_inputs.direct_verdict == "historical_fail"
+        assert s4_inputs.direct_verdict == "historical_pass"
+        campaign_decision = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
         )
+        md = self._render(s3_inputs, s4_inputs, campaign_decision)
         assert "campaign_decision: s4_only_no_demo" in md
         assert "demo_candidate: null" in md
 
     def test_both_fail(self):
-        md = self._render_with_decision(
-            compute_campaign_decision(
-                s3_direct_verdict="historical_fail", s4_direct_verdict="historical_fail"
-            )
+        s3_inputs = _s3_inputs_with_verdict(passing=False)
+        s4_inputs = _s4_inputs_with_verdict(passing=False)
+        assert s3_inputs.direct_verdict == "historical_fail"
+        assert s4_inputs.direct_verdict == "historical_fail"
+        campaign_decision = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
         )
+        md = self._render(s3_inputs, s4_inputs, campaign_decision)
         assert "campaign_decision: both_fail" in md
 
     def test_incomplete(self):
-        md = self._render_with_decision(
-            compute_campaign_decision(
-                s3_direct_verdict="incomplete", s4_direct_verdict="historical_pass"
-            )
+        # The default single-dimension fixture is genuinely incomplete
+        # (missing symbol/pair coverage).
+        s3_inputs = _build_s3_inputs(with_evidence=True)
+        s4_inputs = _build_s4_inputs()
+        assert s3_inputs.direct_verdict == "incomplete"
+        campaign_decision = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
         )
+        md = self._render(s3_inputs, s4_inputs, campaign_decision)
         assert "campaign_decision: incomplete" in md
 
 
@@ -569,8 +805,10 @@ _GOLDEN_MARKDOWN_BYTES = (
     b"### Direct Verdict: incomplete\n\n"
     b"## Campaign Decision\n"
     b"- campaign_decision: incomplete\n"
+    b"- campaign_historical_verdict: incomplete\n"
     b"- s3_direct_verdict: incomplete\n"
     b"- s4_direct_verdict: incomplete\n"
     b"- demo_candidate: null\n"
+    b"- historical_preferred: null\n"
     b"- s4_observable_superiority: null\n\n"
 )

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
@@ -23,8 +23,10 @@ returns bytes.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
+import pytest
 from rob974_h5_canonical import (
     StrategyCanonicalInputs,
     build_canonical_scorecard,
@@ -34,6 +36,7 @@ from rob974_h5_canonical import (
 from rob974_h5_contracts import (
     FOLD_IDS,
     CampaignEnvelope,
+    H5InputError,
     H6AAccountingSeal,
     MetricTrade,
 )
@@ -653,6 +656,50 @@ class TestContractFixtureCampaignDecisionSmoke:
         md = self._render(s3_inputs, s4_inputs, campaign_decision)
         assert "campaign_decision: both_pass_s3_demo_candidate" in md
         assert "demo_candidate: S3" in md
+
+    @pytest.mark.parametrize(
+        "field",
+        (
+            "campaign_decision",
+            "campaign_historical_verdict",
+            "s3_direct_verdict",
+            "s4_direct_verdict",
+            "demo_candidate",
+            "historical_preferred",
+            "s4_observable_superiority",
+        ),
+    )
+    def test_each_both_pass_campaign_field_is_bound_to_ranked_recomputation(
+        self, field
+    ):
+        s3_inputs = _s3_inputs_with_verdict(passing=True)
+        s4_inputs = _s4_inputs_with_verdict(passing=True)
+        honest = compute_campaign_decision(
+            s3_direct_verdict=s3_inputs.direct_verdict,
+            s4_direct_verdict=s4_inputs.direct_verdict,
+            s3_rank_metrics=_rank_metrics(
+                s3_inputs.common_gates, s3_inputs.falsification
+            ),
+            s4_rank_metrics=_rank_metrics(
+                s4_inputs.common_gates, s4_inputs.falsification
+            ),
+        )
+        forged_values = {
+            "campaign_decision": "both_fail",
+            "campaign_historical_verdict": "historical_fail",
+            "s3_direct_verdict": "historical_fail",
+            "s4_direct_verdict": "historical_fail",
+            "demo_candidate": None,
+            "historical_preferred": (
+                "S4" if honest.historical_preferred == "S3" else "S3"
+            ),
+            "s4_observable_superiority": not honest.s4_observable_superiority,
+        }
+        forged = dataclasses.replace(honest, **{field: forged_values[field]})
+        with pytest.raises(
+            H5InputError, match="canonical_campaign_decision_forged_or_stale"
+        ):
+            self._render(s3_inputs, s4_inputs, forged)
 
     def test_s3_only(self):
         s3_inputs = _s3_inputs_with_verdict(passing=True)

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
@@ -1,0 +1,576 @@
+"""ROB-983 (H5, CP7) -- JSON-only Markdown renderer and contract-fixture
+scorecard smoke.
+
+``render_markdown`` accepts only ``json.loads(canonical_json_bytes)``,
+never raw H4/H6-A/DB objects, and never recomputes a metric. Explicit
+display order + dict-construction-order reversal produce byte-identical
+Markdown; nonzero rejections/attribution bins/exit reasons/direct verdicts/
+incomplete reasons survive the JSON->Markdown boundary; presentation
+changes can never move the semantic hash. The smoke section runs a
+deterministic, non-vacuous contract-fixture pipeline (contracts ->
+dual_evidence -> gates -> S3/S4 falsification -> canonical -> markdown)
+covering every campaign-decision branch.
+
+``contract_fixture_scorecard_smoke=PASS`` / ``actual_h4_contract=
+NOT_EVALUATED`` / ``actual_h6a_contract=NOT_EVALUATED`` /
+``db_sessions_created=0`` / ``db_queries=0`` / ``db_writes=0`` /
+``commit_calls=0`` / ``rollback_calls=0`` / ``empirical_runs=0`` /
+``corpus_campaign_runs=0`` / ``physical_stage_publish_calls=0`` -- this
+module contains no DB engine/session, no broker/network call, and never
+stages/publishes a physical file; it only builds in-memory dataclasses and
+returns bytes.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rob974_h5_canonical import (
+    StrategyCanonicalInputs,
+    build_canonical_scorecard,
+    canonical_json_bytes,
+    hash_canonical_bytes,
+)
+from rob974_h5_contracts import (
+    FOLD_IDS,
+    CampaignEnvelope,
+    H6AAccountingSeal,
+    MetricTrade,
+)
+from rob974_h5_dual_evidence import (
+    PathInvocationEvidence,
+    PboEvidence,
+    UniqueGeneratorEvidence,
+)
+from rob974_h5_gates import evaluate_common_gates
+from rob974_h5_markdown import render_markdown
+from rob974_h5_s3 import evaluate_s3_falsification
+from rob974_h5_s4 import (
+    S4_HISTORICAL_PAIR_EXECUTOR_STATE,
+    CampaignDecisionResult,
+    compute_campaign_decision,
+    compute_direct_verdict,
+    evaluate_s4_falsification,
+)
+
+_HEX64_A = "a" * 64
+_HEX64_B = "b" * 64
+_HEX64_C = "c" * 64
+
+
+def _envelope(**overrides) -> CampaignEnvelope:
+    ids = tuple(f"S3-{i:02d}" for i in range(24)) + tuple(
+        f"S4-{i:02d}" for i in range(24)
+    )
+    fields = {
+        "full_campaign_hash": _HEX64_A,
+        "campaign_run_id": "run-cp7",
+        "parent_corpus_hash": _HEX64_A,
+        "parent_projection_hash": _HEX64_A,
+        "feature_contract_hash": _HEX64_A,
+        "strategy_contract_hashes": {"S3": _HEX64_A, "S4": _HEX64_B},
+        "h4_runner_source_hash": _HEX64_A,
+        "h4_pbo_source_hash": _HEX64_A,
+        "h2_engine_source_hash": _HEX64_A,
+        "h3_generator_source_hash": _HEX64_A,
+        "run_schema_version": "v1",
+        "generator_version": "g1",
+        "expected_experiment_ids": ids,
+        "h6a_trial_accounting_hash": _HEX64_B,
+    }
+    fields.update(overrides)
+    return CampaignEnvelope(**fields)
+
+
+def _seal(**overrides) -> H6AAccountingSeal:
+    fields = {
+        "expected_total": 48,
+        "registered_total": 48,
+        "primary_attempts": 48,
+        "status_counts": {"completed": 48, "rejected": 0, "crashed": 0, "timeout": 0},
+        "retry_attempts": 0,
+        "accounting_complete": True,
+        "performance_usable": True,
+        "trial_accounting_hash": _HEX64_B,
+        "reason_codes": (),
+    }
+    fields.update(overrides)
+    return H6AAccountingSeal(**fields)
+
+
+def _s3_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRPUSDT"):
+    return MetricTrade(
+        strategy="S3",
+        config_id="S3-00",
+        fold_id=fold_id,
+        path_scenario="primary_stress17",
+        dimension=dimension,
+        direction="long",
+        entry_ts=exit_ts,
+        exit_ts=exit_ts + 60_000,
+        holding_minutes=10.0,
+        exit_reason=exit_reason,
+        gross_bps=net_bps + 5.0,
+        net_bps=net_bps,
+        tp_bps=68.0,
+        sl_bps=40.0,
+        gross_notional=None,
+        market_return_4h=0.01,
+        volatility_percentile=50.0,
+    )
+
+
+def _s4_trade(fold_id, net_bps, *, exit_ts=0, exit_reason="TP", dimension="XRP-DOGE"):
+    return MetricTrade(
+        strategy="S4",
+        config_id="S4-00",
+        fold_id=fold_id,
+        path_scenario="primary_stress17",
+        dimension=dimension,
+        direction="long",
+        entry_ts=exit_ts,
+        exit_ts=exit_ts + 60_000,
+        holding_minutes=10.0,
+        exit_reason=exit_reason,
+        gross_bps=net_bps + 5.0,
+        net_bps=net_bps,
+        tp_bps=68.0,
+        sl_bps=40.0,
+        gross_notional=None,
+        market_return_4h=0.01,
+        volatility_percentile=None,
+    )
+
+
+def _s3_primary_trades(
+    n: int = 40, exit_reason: str = "TP", net_bps: float = 10.0
+) -> tuple:
+    return tuple(
+        _s3_trade(FOLD_IDS[i % 8], net_bps, exit_ts=i, exit_reason=exit_reason)
+        for i in range(n)
+    )
+
+
+def _s4_primary_trades(
+    n: int = 40, exit_reason: str = "TP", net_bps: float = 10.0
+) -> tuple:
+    return tuple(
+        _s4_trade(FOLD_IDS[i % 8], net_bps, exit_ts=i, exit_reason=exit_reason)
+        for i in range(n)
+    )
+
+
+def _s3_unique_evidence() -> UniqueGeneratorEvidence:
+    return UniqueGeneratorEvidence(
+        strategy="S3",
+        config_id="S3-00",
+        fold_id="fold-00",
+        accepted=90,
+        rejected=10,
+        accepted_input_hash=_HEX64_A,
+        rejection_reason_histogram={"lookahead_bar": 6, "signal_close_fill": 4},
+    )
+
+
+def _s3_path_evidence(path_scenario: str) -> PathInvocationEvidence:
+    return PathInvocationEvidence(
+        strategy="S3",
+        config_id="S3-00",
+        fold_id="fold-00",
+        path_scenario=path_scenario,
+        unique_evidence_hash=_HEX64_A,
+        unique_evidence_accepted_count=90,
+        engine_input_hash=_HEX64_B,
+        engine_input_count=90,
+        no_trade_reason_counts={"unpriced_gap": 3},
+        ledger_status="completed",
+        trade_count=40,
+        artifact_hash=_HEX64_C,
+    )
+
+
+def _s3_pbo() -> PboEvidence:
+    return PboEvidence(
+        strategy="S3",
+        config_count=24,
+        day_count=365,
+        slices=4,
+        scenario_name="primary_stress17",
+        value=0.35,
+        reason_codes=(),
+        source_hash=_HEX64_A,
+        input_hash=_HEX64_B,
+        artifact_hash=_HEX64_C,
+    )
+
+
+def _build_s3_inputs(*, with_evidence: bool = True) -> StrategyCanonicalInputs:
+    primary = _s3_primary_trades()
+    common_gates = evaluate_common_gates(
+        primary_trades=primary, upward_trades=_s3_primary_trades(10)
+    )
+    falsification = evaluate_s3_falsification(
+        primary_trades=primary, upward_trades=_s3_primary_trades(10)
+    )
+    direct_verdict = compute_direct_verdict(
+        incomplete_reasons=falsification.incomplete_reasons,
+        hard_gate_reasons=common_gates.reasons + falsification.reasons,
+    )
+    if with_evidence:
+        unique_by_key = {("S3-00", "fold-00"): _s3_unique_evidence()}
+        paths_by_key = {
+            ("S3-00", "fold-00", "base13"): _s3_path_evidence("base13"),
+            ("S3-00", "fold-00", "primary_stress17"): _s3_path_evidence(
+                "primary_stress17"
+            ),
+            ("S3-00", "fold-00", "upward_stress22"): _s3_path_evidence(
+                "upward_stress22"
+            ),
+        }
+        pbo = _s3_pbo()
+    else:
+        unique_by_key, paths_by_key, pbo = {}, {}, None
+    return StrategyCanonicalInputs(
+        strategy="S3",
+        common_gates=common_gates,
+        falsification=falsification,
+        direct_verdict=direct_verdict,
+        exit_reason_order=("TP", "SL", "THESIS_EXIT", "TIMEOUT"),
+        dimension_order=("XRPUSDT", "DOGEUSDT", "SOLUSDT"),
+        unique_by_key=unique_by_key,
+        paths_by_key=paths_by_key,
+        pbo=pbo,
+    )
+
+
+def _build_s4_inputs() -> StrategyCanonicalInputs:
+    primary = _s4_primary_trades()
+    common_gates = evaluate_common_gates(
+        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+    )
+    falsification = evaluate_s4_falsification(
+        primary_trades=primary, upward_trades=_s4_primary_trades(10)
+    )
+    direct_verdict = compute_direct_verdict(
+        incomplete_reasons=falsification.incomplete_reasons,
+        hard_gate_reasons=common_gates.reasons + falsification.reasons,
+    )
+    return StrategyCanonicalInputs(
+        strategy="S4",
+        common_gates=common_gates,
+        falsification=falsification,
+        direct_verdict=direct_verdict,
+        exit_reason_order=("TP", "SL", "MEAN_EXIT", "STALL_EXIT", "TIMEOUT"),
+        dimension_order=("XRP-DOGE", "XRP-SOL", "DOGE-SOL"),
+        unique_by_key={},
+        paths_by_key={},
+        pbo=None,
+        pair_executor_state=S4_HISTORICAL_PAIR_EXECUTOR_STATE,
+    )
+
+
+def _build_full_scorecard() -> dict:
+    s3_inputs = _build_s3_inputs(with_evidence=True)
+    s4_inputs = _build_s4_inputs()
+    campaign_decision = compute_campaign_decision(
+        s3_direct_verdict=s3_inputs.direct_verdict,
+        s4_direct_verdict=s4_inputs.direct_verdict,
+    )
+    return build_canonical_scorecard(
+        envelope=_envelope(),
+        h6a_seal=_seal(),
+        envelope_ok=True,
+        envelope_incomplete_reasons=(),
+        s3_inputs=s3_inputs,
+        s4_inputs=s4_inputs,
+        campaign_decision=campaign_decision,
+    )
+
+
+class TestPureRendererBoundary:
+    def test_renderer_accepts_only_json_loads_round_trip(self):
+        scorecard = _build_full_scorecard()
+        canonical_bytes = canonical_json_bytes(scorecard)
+        decoded = json.loads(canonical_bytes)
+        # Must not raise / must not require any object beyond the plain
+        # decoded dict (no H4/H6-A/DB object is passed in).
+        markdown_bytes = render_markdown(decoded)
+        assert isinstance(markdown_bytes, bytes)
+        assert markdown_bytes
+
+    def test_rendering_never_changes_canonical_bytes_or_hash(self):
+        scorecard = _build_full_scorecard()
+        canonical_bytes_before = canonical_json_bytes(scorecard)
+        hash_before = hash_canonical_bytes(canonical_bytes_before)
+        render_markdown(json.loads(canonical_bytes_before))
+        canonical_bytes_after = canonical_json_bytes(scorecard)
+        assert canonical_bytes_after == canonical_bytes_before
+        assert hash_canonical_bytes(canonical_bytes_after) == hash_before
+
+
+class TestNonzeroContentSurvivesJsonToMarkdown:
+    def setup_method(self):
+        self.scorecard = _build_full_scorecard()
+        self.markdown = render_markdown(
+            json.loads(canonical_json_bytes(self.scorecard))
+        ).decode("utf-8")
+
+    def test_nonzero_rejections_survive(self):
+        assert "rejected=10" in self.markdown
+        assert "lookahead_bar=6" in self.markdown
+
+    def test_attribution_bins_survive(self):
+        assert "### Attribution: by_symbol" in self.markdown
+        assert "XRPUSDT: trades=" in self.markdown
+
+    def test_exit_reason_bins_survive(self):
+        assert "### Attribution: by_exit_reason" in self.markdown
+        assert "TP: trades=" in self.markdown
+
+    def test_direct_verdicts_survive(self):
+        # This fixture's single-symbol/single-pair, all-TP (no losses)
+        # trades naturally produce "incomplete" direct verdicts (missing
+        # symbol/pair evidence, undefined SL-dependence denominator) --
+        # exercised deliberately so incomplete-reasons survival (below) has
+        # real content, not a vacuous empty-list case.
+        assert self.markdown.count("Direct Verdict: incomplete") == 2
+
+    def test_incomplete_reasons_survive(self):
+        # S3's first-4h SL denominator is undefined for an all-TP fixture
+        # (zero losing trades) -- proves incomplete_reasons is not dropped.
+        assert "s3_first_4h_sl_denominator_undefined" in self.markdown
+
+    def test_pbo_and_pair_executor_state_survive(self):
+        assert "### PBO" in self.markdown
+        assert "value: 0.35" in self.markdown
+        assert "### Pair Executor State (historical)" in self.markdown
+        assert "readiness: historical_screen_only" in self.markdown
+
+    def test_campaign_decision_survives(self):
+        assert "campaign_decision: incomplete" in self.markdown
+
+
+class TestPermutationInvarianceOfMarkdown:
+    def test_reversed_attribution_dict_order_produces_identical_markdown(self):
+        scorecard = _build_full_scorecard()
+        decoded = json.loads(canonical_json_bytes(scorecard))
+        baseline = render_markdown(decoded)
+
+        reordered = json.loads(canonical_json_bytes(scorecard))
+        by_symbol = reordered["strategies"]["S3"]["falsification"]["attribution"][
+            "by_symbol"
+        ]
+        reordered["strategies"]["S3"]["falsification"]["attribution"]["by_symbol"] = (
+            dict(reversed(list(by_symbol.items())))
+        )
+        status_counts = reordered["h6a_accounting"]["status_counts"]
+        reordered["h6a_accounting"]["status_counts"] = dict(
+            reversed(list(status_counts.items()))
+        )
+
+        assert render_markdown(reordered) == baseline
+
+    def test_dict_key_reversal_alone_does_not_change_rendered_bytes(self):
+        scorecard = _build_full_scorecard()
+        canonical_bytes = canonical_json_bytes(scorecard)
+        decoded_a = json.loads(canonical_bytes)
+        decoded_b = json.loads(canonical_bytes)
+
+        # A whole-tree key-order reversal at every dict level, simulating a
+        # hypothetical alternate (still-valid) JSON encoder.
+        def _reverse_dicts(value):
+            if isinstance(value, dict):
+                return {
+                    k: _reverse_dicts(v)
+                    for k in reversed(list(value.keys()))
+                    for v in [value[k]]
+                }
+            if isinstance(value, list):
+                return [_reverse_dicts(v) for v in value]
+            return value
+
+        assert render_markdown(_reverse_dicts(decoded_b)) == render_markdown(decoded_a)
+
+
+class TestFrozenGoldenMarkdown:
+    """Frozen byte-for-byte proof (mirrors the ROB-945/960 frozen-bytes
+    pattern): ``render_markdown(json.loads(canonical_json_bytes))`` must
+    equal this exact, previously-captured Markdown -- any future change to
+    either the renderer or the canonical builder that alters presentation
+    must consciously re-freeze this constant, never drift silently."""
+
+    def test_golden_markdown_bytes_match(self):
+        scorecard = _build_full_scorecard()
+        markdown_bytes = render_markdown(json.loads(canonical_json_bytes(scorecard)))
+        assert markdown_bytes == _GOLDEN_MARKDOWN_BYTES
+
+
+class TestContractFixtureCampaignDecisionSmoke:
+    """Deterministic, non-vacuous smoke across every campaign-decision
+    branch -- proves the full contracts -> dual_evidence -> gates ->
+    falsification -> canonical -> markdown pipeline produces sane,
+    non-empty output for each, without recomputing metrics inside the
+    renderer."""
+
+    def _render_with_decision(self, campaign_decision: CampaignDecisionResult) -> str:
+        scorecard = build_canonical_scorecard(
+            envelope=_envelope(),
+            h6a_seal=_seal(),
+            envelope_ok=True,
+            envelope_incomplete_reasons=(),
+            s3_inputs=_build_s3_inputs(with_evidence=True),
+            s4_inputs=_build_s4_inputs(),
+            campaign_decision=campaign_decision,
+        )
+        return render_markdown(json.loads(canonical_json_bytes(scorecard))).decode(
+            "utf-8"
+        )
+
+    def test_both_pass_s3_demo_candidate(self):
+        md = self._render_with_decision(
+            compute_campaign_decision(
+                s3_direct_verdict="historical_pass", s4_direct_verdict="historical_pass"
+            )
+        )
+        assert "campaign_decision: both_pass_s3_demo_candidate" in md
+        assert "demo_candidate: S3" in md
+
+    def test_s3_only(self):
+        md = self._render_with_decision(
+            compute_campaign_decision(
+                s3_direct_verdict="historical_pass", s4_direct_verdict="historical_fail"
+            )
+        )
+        assert "campaign_decision: s3_only" in md
+
+    def test_s4_only_no_demo(self):
+        md = self._render_with_decision(
+            compute_campaign_decision(
+                s3_direct_verdict="historical_fail", s4_direct_verdict="historical_pass"
+            )
+        )
+        assert "campaign_decision: s4_only_no_demo" in md
+        assert "demo_candidate: null" in md
+
+    def test_both_fail(self):
+        md = self._render_with_decision(
+            compute_campaign_decision(
+                s3_direct_verdict="historical_fail", s4_direct_verdict="historical_fail"
+            )
+        )
+        assert "campaign_decision: both_fail" in md
+
+    def test_incomplete(self):
+        md = self._render_with_decision(
+            compute_campaign_decision(
+                s3_direct_verdict="incomplete", s4_direct_verdict="historical_pass"
+            )
+        )
+        assert "campaign_decision: incomplete" in md
+
+
+class TestNeverCallsWriterOrPhysicalIO:
+    """Static proof this module never imports/calls the physical scorecard
+    writer or does file/DB/network I/O (contract: 'never call or modify
+    rob960_scorecard_writer; H6-B alone owns physical canonical-JSON
+    readback, Markdown staging and publication')."""
+
+    def test_markdown_module_source_has_no_forbidden_references(self):
+        import inspect
+
+        import rob974_h5_markdown
+
+        source = inspect.getsource(rob974_h5_markdown)
+        for forbidden in (
+            "rob960_scorecard_writer",
+            "open(",
+            "Path(",
+            "requests.",
+            "httpx.",
+            "socket.",
+        ):
+            assert forbidden not in source, f"found forbidden reference: {forbidden!r}"
+
+
+# Captured once via an initial GREEN run and frozen here -- any future
+# semantic OR presentation change requires a conscious re-freeze, never a
+# silent drift.
+_GOLDEN_MARKDOWN_BYTES = (
+    b"# H5 Scorecard (h5_scorecard_v1)\n\n"
+    b"## Lineage\n"
+    b"- campaign_run_id: run-cp7\n"
+    b"- full_campaign_hash: " + b"a" * 64 + b"\n"
+    b"- run_schema_version: v1\n"
+    b"- generator_version: g1\n"
+    b"- actual_h4_ledger_key: NOT_EVALUATED\n\n"
+    b"## H6-A Accounting\n"
+    b"- expected_total: 48\n"
+    b"- registered_total: 48\n"
+    b"- accounting_complete: true\n"
+    b"- performance_usable: true\n"
+    b"  - status[completed]: 48\n"
+    b"  - status[rejected]: 0\n"
+    b"  - status[crashed]: 0\n"
+    b"  - status[timeout]: 0\n"
+    b"- reason_codes: (none)\n\n"
+    b"## Envelope Validation\n"
+    b"- ok: true\n"
+    b"- incomplete_reasons: (none)\n\n"
+    b"## Strategy S3\n\n"
+    b"### Common Gates\n"
+    b"- passed: false\n"
+    b"- reasons: e0_below_25bp, monthly_concentration_above_50pct\n"
+    b"- pooled_e17_bps: 10.0\n"
+    b"- pf17: null (pf_infinite_zero_loss_with_profit)\n"
+    b"- win_margin: 0.4722222222222222\n"
+    b"- monthly_concentration: 1.0\n\n"
+    b"### Falsification\n"
+    b"- reasons: (none)\n"
+    b"- incomplete_reasons: s3_first_4h_sl_denominator_undefined, "
+    b"s3_symbol_evidence_missing\n\n"
+    b"### Attribution: by_exit_reason\n"
+    b"- TP: trades=40 e17_bps=10.0 e0_bps=15.0 pf=null "
+    b"(pf_infinite_zero_loss_with_profit) avg_holding_minutes=10.0\n\n"
+    b"### Attribution: by_symbol\n"
+    b"- XRPUSDT: trades=40 e17_bps=10.0 e0_bps=15.0 pf=null "
+    b"(pf_infinite_zero_loss_with_profit) avg_holding_minutes=10.0\n\n"
+    b"### Dual Evidence\n\n"
+    b"- S3-00/fold-00: accepted=90 rejected=10\n"
+    b"  - rejection_reasons: lookahead_bar=6, signal_close_fill=4\n"
+    b"  - path[base13]: ledger_status=completed trade_count=40\n"
+    b"  - path[primary_stress17]: ledger_status=completed trade_count=40\n"
+    b"  - path[upward_stress22]: ledger_status=completed trade_count=40\n\n"
+    b"### PBO\n\n"
+    b"- value: 0.35\n"
+    b"- reason_codes: (none)\n\n"
+    b"### Direct Verdict: incomplete\n\n"
+    b"## Strategy S4\n\n"
+    b"### Common Gates\n"
+    b"- passed: false\n"
+    b"- reasons: e0_below_25bp, monthly_concentration_above_50pct\n"
+    b"- pooled_e17_bps: 10.0\n"
+    b"- pf17: null (pf_infinite_zero_loss_with_profit)\n"
+    b"- win_margin: 0.4722222222222222\n"
+    b"- monthly_concentration: 1.0\n\n"
+    b"### Falsification\n"
+    b"- reasons: s4_high_market_return_e22_not_positive\n"
+    b"- incomplete_reasons: s4_correlation_undefined, s4_pair_evidence_missing, "
+    b"s4_slow_bucket_evidence_missing\n\n"
+    b"### Attribution: by_exit_reason\n"
+    b"- TP: trades=40 e17_bps=10.0 e0_bps=15.0 pf=null "
+    b"(pf_infinite_zero_loss_with_profit) avg_holding_minutes=10.0\n\n"
+    b"### Attribution: by_pair\n"
+    b"- XRP-DOGE: trades=40 e17_bps=10.0 e0_bps=15.0 pf=null "
+    b"(pf_infinite_zero_loss_with_profit) avg_holding_minutes=10.0\n\n"
+    b"### Pair Executor State (historical)\n\n"
+    b"- pair_executor_state: not_evaluated\n"
+    b"- readiness: historical_screen_only\n"
+    b"- demo_eligible: false\n\n"
+    b"### Direct Verdict: incomplete\n\n"
+    b"## Campaign Decision\n"
+    b"- campaign_decision: incomplete\n"
+    b"- s3_direct_verdict: incomplete\n"
+    b"- s4_direct_verdict: incomplete\n"
+    b"- demo_candidate: null\n"
+    b"- s4_observable_superiority: null\n\n"
+)

--- a/research/nautilus_scalping/tests/test_rob974_h5_import_guard.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_import_guard.py
@@ -1,0 +1,193 @@
+"""ROB-983 (H5) -- AST/import boundary guard for all rob974_h5_* modules.
+
+Mirrors ``test_rob974_h2_import_guard.py``'s pattern: static
+``ast.Import``/``ast.ImportFrom`` scan against a forbidden-prefix list and an
+explicit allowlist, plus a ``ast.Call`` walk rejecting dynamic-import calls
+(``__import__``/``importlib.import_module``) and current-time calls
+(``.now()``/``.today()``/``.utcnow()``) -- H5 is pure: no DB/network/broker/
+scheduler/random/current-time/physical-file-IO/validated-gate import or call
+anywhere in its production surface.
+"""
+
+from __future__ import annotations
+
+import ast
+import tempfile
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _rob974_h5_modules() -> list[str]:
+    return sorted(p.name for p in _ROOT.glob("rob974_h5_*.py"))
+
+
+_FORBIDDEN_PREFIXES = (
+    "app",
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "psycopg2",
+    "alembic",
+    "redis",
+    "taskiq",
+    "celery",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib3",
+    "urllib",
+    "socket",
+    "websockets",
+    "boto3",
+    "fastapi",
+    "uvicorn",
+    "random",
+    "time",
+    "os",
+    "subprocess",
+    "pathlib",
+)
+
+# Explicit allowlist. Additive per checkpoint -- CP1-CP7 each append their own
+# new rob974_h5_* siblings and the stdlib primitives they compose (never
+# app/DB/network/broker/order/fill/scheduler/random/current-time/
+# physical-file-IO/validated-gate).
+_ALLOWED = {
+    "__future__",
+    "collections",
+    "collections.abc",
+    "dataclasses",
+    "datetime",
+    "hashlib",
+    "json",
+    "math",
+    "re",
+    "typing",
+    "rob974_h5_canonical",
+    "rob974_h5_contracts",
+    "rob974_h5_dual_evidence",
+    "rob974_h5_gates",
+    "rob974_h5_markdown",
+    "rob974_h5_s3",
+    "rob974_h5_s4",
+}
+
+_CURRENT_TIME_ATTRS = ("now", "today", "utcnow")
+
+
+def _imports(path: Path):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def _is_dynamic_import_call(call: ast.Call) -> bool:
+    func = call.func
+    if isinstance(func, ast.Name) and func.id == "__import__":
+        return True
+    return isinstance(func, ast.Attribute) and func.attr == "import_module"
+
+
+def _is_current_time_call(call: ast.Call) -> bool:
+    func = call.func
+    return isinstance(func, ast.Attribute) and func.attr in _CURRENT_TIME_ATTRS
+
+
+def _forbidden_calls(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _is_dynamic_import_call(node):
+            violations.append(f"dynamic import call at line {node.lineno}")
+        if _is_current_time_call(node):
+            violations.append(f"current-time call at line {node.lineno}")
+    return violations
+
+
+def test_no_forbidden_imports():
+    modules = _rob974_h5_modules()
+    assert modules, "expected at least one rob974_h5_*.py module to exist"
+    for mod in modules:
+        for name in _imports(_ROOT / mod):
+            top = name.split(".")[0]
+            assert top not in _FORBIDDEN_PREFIXES, (
+                f"{mod} imports forbidden module {name!r}"
+            )
+
+
+def test_only_allowlisted_modules_are_imported():
+    for mod in _rob974_h5_modules():
+        for name in _imports(_ROOT / mod):
+            assert name in _ALLOWED, f"{mod} imports non-allowlisted module {name!r}"
+
+
+def test_no_validated_gate_import():
+    for mod in _rob974_h5_modules():
+        for name in _imports(_ROOT / mod):
+            assert "validated_gate" not in name, (
+                f"{mod} imports the validated-gate module {name!r} (forbidden)"
+            )
+
+
+def test_no_scorecard_writer_import():
+    for mod in _rob974_h5_modules():
+        for name in _imports(_ROOT / mod):
+            assert "rob960_scorecard_writer" not in name, (
+                f"{mod} imports the physical scorecard writer {name!r} (forbidden)"
+            )
+
+
+def test_no_dynamic_import_or_current_time_calls():
+    for mod in _rob974_h5_modules():
+        violations = _forbidden_calls(_ROOT / mod)
+        assert violations == [], f"{mod} has forbidden call(s): {violations}"
+
+
+class TestGuardCatchesInjectedBypasses:
+    """Regression proof: inject each bypass into a SCRATCH file (never a
+    production module) and confirm the scan actually flags it."""
+
+    def test_dynamic_import_call_is_caught(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "dynamic_socket.py"
+            path.write_text("mod = __import__('socket')\n")
+            assert _forbidden_calls(path) != []
+
+    def test_importlib_import_module_call_is_caught(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "importlib_socket.py"
+            path.write_text(
+                "import importlib\nmod = importlib.import_module('socket')\n"
+            )
+            assert _forbidden_calls(path) != []
+
+    def test_datetime_now_call_is_caught(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "datetime_now.py"
+            path.write_text("from datetime import datetime\nx = datetime.now()\n")
+            assert _forbidden_calls(path) != []
+
+    def test_datetime_utcnow_and_today_are_caught(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "datetime_utcnow.py"
+            path.write_text(
+                "from datetime import datetime\n"
+                "x = datetime.utcnow()\n"
+                "y = datetime.today()\n"
+            )
+            violations = _forbidden_calls(path)
+            assert len(violations) == 2
+
+    def test_forbidden_prefix_import_is_caught(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "db_import.py"
+            path.write_text("import sqlalchemy\n")
+            imports = list(_imports(path))
+            assert any(name.split(".")[0] in _FORBIDDEN_PREFIXES for name in imports)


### PR DESCRIPTION
## Summary

Implements the additive, pure H5 scorecard (Linear ROB-983): strict H4/H6-A input verification, S3/S4 falsification gates, direct and campaign verdicts, canonical semantic JSON, and deterministic JSON-only Markdown.

**Status: CP1-CP7 complete. CP8 (actual H4/H6-A integration + literal guard re-pin) is blocked pending orch-verified ROB-981 and ROB-982 merges to `origin/main`.**

- `origin/main` currently contains a commit titled "ROB-981: ... (CP1-CP7, waiting on H2/H3) (#1618)" at its tip, but per the worker contract this branch must resume CP8 **only with an orch-supplied verified merge SHA + approved merge tree** for both ROB-981 and ROB-982 — this worker does not self-verify or poll. ROB-982 is not visible in `origin/main` history at all as of this PR.
- This is a normal, expected stop (`WAITING_H4_H6A_MERGES`), not a blocker in this PR's own scope.

## Checkpoints (RED -> GREEN -> commit each)

- **CP1** `rob974_h5_contracts.py` -- strict input envelope + H6-A exact-48 accounting gate (45 tests)
- **CP2** `rob974_h5_dual_evidence.py` -- selected-OOS dual evidence + PBO prerequisites (25 tests)
- **CP3** `rob974_h5_gates.py` -- common hard gates, E0, win authority (23 tests)
- **CP4** `rob974_h5_s3.py` -- S3 falsification gates + attribution (18 tests)
- **CP5** `rob974_h5_s4.py` -- S4 gates, historical tri-state, campaign decision (45 tests)
- **CP6** `rob974_h5_canonical.py` -- canonical semantic JSON + presentation-independent hash (17 tests)
- **CP7** `rob974_h5_markdown.py` -- JSON-only Markdown renderer + contract-fixture smoke + H5 import guard (28 tests)

201 focused tests total (all H5). Existing `test_rob960_h1_through_h5_frozen_bytes_unchanged.py` remains green/untouched.

## Scope note (disclosed in-session, user-approved)

The original packet planned exactly 3 production files (`rob974_h5_contracts.py`/`rob974_h5_scorecard.py`/`rob974_h5_markdown.py`). This worker resumed after CP1-CP3 had already established a one-file-per-checkpoint pattern instead (`contracts`/`dual_evidence`/`gates`, now also `s3`/`s4`/`canonical`/`markdown` -- 7 files). Continuing this established pattern was confirmed with the user before CP4 rather than silently reverting already-pushed checkpoints. The post-970 frozen production-delta guard re-pin (all 7 files, not the originally-planned 3) is deferred to CP8 per the packet (`frozen_repin=PREAUTHORIZED_DEFERRED_FINAL_MAIN_MERGE`), consistent with "only when these files exist, append their literal tuples" and "defer the append until CP8".

## Safety

Pure production functions only -- no DB session/query/write, no migration, no empirical `--run`, no broker/network/subprocess, no physical file I/O. Never calls or modifies `rob960_scorecard_writer`. AST/import guard (`test_rob974_h5_import_guard.py`) statically proves this for every `rob974_h5_*` module.

```
contract_fixture_scorecard_smoke=PASS
actual_h4_contract=NOT_EVALUATED
actual_h6a_contract=NOT_EVALUATED
db_sessions_created=0
db_queries=0
db_writes=0
commit_calls=0
rollback_calls=0
empirical_runs=0
corpus_campaign_runs=0
physical_stage_publish_calls=0
```

## Test plan

- [x] CP1-CP7 RED->GREEN, each committed separately with red-log SHA recorded
- [x] `uv run pytest research/nautilus_scalping/tests/test_rob974_h5_*.py research/nautilus_scalping/tests/test_rob974_h5_cp*.py -q` -- 201 passed
- [x] `test_rob960_h1_through_h5_frozen_bytes_unchanged.py` -- still green (untouched)
- [x] Ruff format/lint clean, `git diff --check` clean
- [ ] CP8: actual H4/H6-A integration + literal 7-file guard re-pin (blocked on orch-verified ROB-981/ROB-982 merge SHAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)