### PR TITLE
fix(ROB-973): recover and probe KRX sessions

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -210,6 +210,9 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `modify_order` Discord button flow example:
   - `modify_order(order_id="...", symbol="...", market="...", new_price=123.45, dry_run=false)`
 - `screen_stocks(...)` - Screen stocks across different markets (KR/US/Crypto) with various filters. **Single candidate-discovery entrypoint.**
+  - If the response has `meta.reason="krx_session_expired"`, KRX re-authentication was attempted once and did not recover the session. Use `screen_stocks_snapshot(market="kr")` for persisted-preset discovery, or `get_momentum_candidates(market="kr")` for intraday momentum candidates.
+- `get_krx_session_health()`
+  - Read-only authenticated KRX-session probe. It uses the normal KRX login/re-authentication path and reports `status`, `reason`, `retryable`, and `authenticated`; no market, broker, or order state is changed.
 - `screen_stocks_snapshot(preset=None, presets=None, market="kr", filters=None, exclude_watched=false, exclude_held=false, exclude_symbols=None, min_analyst_count=None, min_analyst_buy_count=None, min_market_cap=None, min_market_cap_eok=None, max_market_cap_eok=None, sort=None, limit=40, offset=0)`
   - Snapshot-backed discovery workflow. Pass either `preset="consecutive_gainers"` or `presets=["consecutive_gainers", "double_buy"]`; `preset` also accepts a comma-separated list for compatibility.
   - Returns symbols that matched the preset(s) from the persisted daily snapshots.
@@ -2299,6 +2302,7 @@ Allowed tools:
 - `get_indicators`
 - `screen_stocks`
 - `screen_stocks_snapshot`
+- `get_krx_session_health`
 - `get_top_stocks`
 - `get_news`
 - `get_fx_rate`

--- a/app/mcp_server/tooling/analysis_readonly_registration.py
+++ b/app/mcp_server/tooling/analysis_readonly_registration.py
@@ -73,6 +73,7 @@ ANALYSIS_READONLY_TOOL_NAMES: set[str] = {
     "get_indicators",
     "screen_stocks",
     "screen_stocks_snapshot",
+    "get_krx_session_health",
     "get_top_stocks",
     "get_news",
     "get_fx_rate",

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -25,6 +25,7 @@ from app.mcp_server.tooling.research_pipeline_read import (
 )
 from app.mcp_server.tooling.screener_snapshot_tool import screen_stocks_snapshot_impl
 from app.mcp_server.tooling.theme_events import get_theme_events_impl
+from app.services.krx import probe_krx_session_health
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -48,6 +49,7 @@ ANALYSIS_TOOL_NAMES: set[str] = {
     "get_dividends",
     "get_crypto_fear_greed",
     "get_momentum_candidates",
+    "get_krx_session_health",
     "get_theme_events",
     "research_session_get",
     "research_session_list_recent",
@@ -60,6 +62,20 @@ def register_analysis_tools(
     mcp: FastMCP,
 ) -> None:
     """Register MCP tools for analysis, screening, and ranking utilities."""
+
+    @mcp.tool(
+        name="get_krx_session_health",
+        description=(
+            "Read-only KRX authenticated-session health probe. Detects an expired "
+            "KRX session and reuses the normal KRX login path once; it never writes "
+            "market, broker, or order state. If status='unavailable' with "
+            "reason='krx_session_expired', use screen_stocks_snapshot(market='kr') "
+            "for persisted discovery and get_momentum_candidates(market='kr') for "
+            "intraday momentum candidates."
+        ),
+    )
+    async def get_krx_session_health() -> dict[str, Any]:
+        return await probe_krx_session_health()
 
     @mcp.tool(
         name="get_momentum_candidates",
@@ -316,7 +332,9 @@ def register_analysis_tools(
             "screen_stocks_snapshot for curated persisted presets, get_top_stocks "
             "for simple rankings, and get_momentum_candidates for KR intraday 급등 "
             "scoring. If this returns reason='krx_session_expired', fall back to "
-            "screen_stocks_snapshot. Screen stocks across markets (KR/US/Crypto) "
+            "screen_stocks_snapshot(market='kr') for persisted presets; use "
+            "get_momentum_candidates(market='kr') for KR intraday momentum. "
+            "Screen stocks across markets (KR/US/Crypto) "
             "with filters. "
             "KR supports kospi/kosdaq/konex/all, 30-day ADV via adv_krw_min "
             "(1B KRW conservative, 5B KRW aggressive), instrument_types, "

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -428,6 +428,7 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "get_investment_opinions",
         "get_investor_trends",
         "get_kimchi_premium",
+        "get_krx_session_health",
         "get_latest_market_brief",
         "get_market_index",
         "get_market_issues",

--- a/app/mcp_server/tooling/screening/kr.py
+++ b/app/mcp_server/tooling/screening/kr.py
@@ -640,7 +640,9 @@ def _krx_session_unavailable_response(
         market,
         warnings=[
             "KRX 세션이 만료되어 KR 스크리너를 일시적으로 사용할 수 없습니다. "
-            "잠시 후 다시 시도하세요."
+            "잠시 후 다시 시도하세요. 그동안에는 persisted preset 기반 "
+            "screen_stocks_snapshot(market='kr')를 사용하고, 장중 급등 후보는 "
+            "get_momentum_candidates(market='kr')로 확인하세요."
         ],
         meta_fields={
             "data_state": "unavailable",

--- a/app/services/krx.py
+++ b/app/services/krx.py
@@ -193,6 +193,19 @@ class KRXSessionManager:
             logger.error(f"KRX 로그인 중 오류: {e}")
             self._auth_failed = True
 
+    async def _reauthenticate(self) -> None:
+        """Reset expired state and reuse the normal KRX login flow once."""
+        self._authenticated = False
+        self._auth_failed = False
+        async with self._login_lock:
+            if not self._authenticated:
+                await self._login()
+
+    @staticmethod
+    def _is_logout_response(response: httpx.Response) -> bool:
+        """Return whether KRX explicitly rejected the current browser session."""
+        return response.status_code == 400 and "LOGOUT" in response.text
+
     async def fetch_data(
         self,
         bld: str,
@@ -227,16 +240,12 @@ class KRXSessionManager:
             response = await client.post(KRX_API_URL, data=form_data)
 
             # Handle 400 + LOGOUT body: re-authenticate once
-            if response.status_code == 400 and "LOGOUT" in response.text:
+            if self._is_logout_response(response):
                 logger.warning("KRX 세션 만료 감지 (400/LOGOUT), 재인증 시도")
-                self._authenticated = False
-                self._auth_failed = False
-                async with self._login_lock:
-                    if not self._authenticated:
-                        await self._login()
+                await self._reauthenticate()
                 client = await self._ensure_session()
                 response = await client.post(KRX_API_URL, data=form_data)
-                if response.status_code == 400 and "LOGOUT" in response.text:
+                if self._is_logout_response(response):
                     logger.error(
                         "KRX 재인증 후에도 LOGOUT 응답 (login_code=%s)",
                         self._last_login_code or "unknown",
@@ -266,6 +275,42 @@ class KRXSessionManager:
 
         return []
 
+    async def probe_health(self) -> dict[str, Any]:
+        """Read-only KRX session probe that also exercises expiry recovery.
+
+        The probe uses the same authenticated data endpoint as KR screening, but
+        never caches, persists, or mutates market data.  A LOGOUT response follows
+        ``fetch_data``'s existing re-authentication path exactly once.
+        """
+        try:
+            rows = await self.fetch_data(
+                bld="dbms/MDC/STAT/standard/MDCSTAT01501",
+                mktId="STK",
+            )
+        except KRXSessionExpiredError:
+            return {
+                "status": "unavailable",
+                "reason": "krx_session_expired",
+                "retryable": True,
+                "authenticated": False,
+            }
+        except httpx.HTTPError as exc:
+            logger.warning("KRX session health probe failed: %s", exc)
+            return {
+                "status": "unavailable",
+                "reason": "krx_session_probe_failed",
+                "retryable": True,
+                "authenticated": self._authenticated,
+            }
+
+        return {
+            "status": "ok",
+            "reason": None,
+            "retryable": False,
+            "authenticated": self._authenticated,
+            "rows_observed": len(rows),
+        }
+
     async def fetch_resource(self, url: str) -> dict[str, Any]:
         """Fetch resource data (e.g., max working date) using persistent session."""
         client = await self._ensure_session()
@@ -284,6 +329,11 @@ class KRXSessionManager:
 
 # Module-level singleton
 _krx_session = KRXSessionManager()
+
+
+async def probe_krx_session_health() -> dict[str, Any]:
+    """Run the read-only health probe against the shared KRX session."""
+    return await _krx_session.probe_health()
 
 
 async def _get_redis_client() -> Redis:

--- a/tests/mcp_server/tooling/test_screen_stocks_snapshot_docs.py
+++ b/tests/mcp_server/tooling/test_screen_stocks_snapshot_docs.py
@@ -39,6 +39,12 @@ def test_discovery_tool_descriptions_guide_selection_and_snapshot_freshness():
     screen_desc = mcp.descriptions["screen_stocks"].lower()
     assert "krx_session_expired" in screen_desc
     assert "screen_stocks_snapshot" in screen_desc
+    assert "get_momentum_candidates" in screen_desc
+
+    health_desc = mcp.descriptions["get_krx_session_health"].lower()
+    assert "read-only" in health_desc
+    assert "krx_session_expired" in health_desc
+    assert "screen_stocks_snapshot" in health_desc
 
     assert "screen_stocks_snapshot" in mcp.descriptions["get_top_stocks"].lower()
     assert (

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -387,6 +387,15 @@ async def test_fallback_stale_snapshot_returned_not_hard_zero():
     assert len(resp["results"]) == 1  # NOT hard-0
 
 
+def test_expired_krx_warning_names_snapshot_and_momentum_fallbacks():
+    response = kr_mod._krx_session_unavailable_response("kr", "volume", "desc")
+
+    warning = response["warnings"][0]
+    assert "screen_stocks_snapshot" in warning
+    assert "get_momentum_candidates" in warning
+    assert response["meta"]["reason"] == "krx_session_expired"
+
+
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_fallback_none_snapshot_goes_live():

--- a/tests/test_services_krx.py
+++ b/tests/test_services_krx.py
@@ -1446,6 +1446,41 @@ class TestKRXSessionExpired:
     """fetch_data raises a typed, classifiable error after re-auth LOGOUT."""
 
     @pytest.mark.asyncio
+    async def test_fetch_data_reauthenticates_after_logout_and_retries(
+        self, monkeypatch
+    ):
+        import httpx
+
+        from app.services.krx import KRXSessionManager
+
+        request_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            request_count += 1
+            if request_count == 1:
+                return httpx.Response(400, text="LOGOUT")
+            return httpx.Response(200, json={"OutBlock_1": [{"ISU_SRT_CD": "005930"}]})
+
+        manager = KRXSessionManager()
+        manager._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        manager._authenticated = True
+        login_count = 0
+
+        async def _existing_login_path() -> None:
+            nonlocal login_count
+            login_count += 1
+            manager._authenticated = True
+
+        monkeypatch.setattr(manager, "_login", _existing_login_path)
+
+        assert await manager.fetch_data(bld="dummy/bld") == [{"ISU_SRT_CD": "005930"}]
+        assert request_count == 2
+        assert login_count == 1
+
+        await manager.close()
+
+    @pytest.mark.asyncio
     async def test_fetch_data_raises_typed_error_after_reauth_logout(self, monkeypatch):
         import httpx
 
@@ -1475,3 +1510,27 @@ class TestKRXSessionExpired:
         from app.services.krx import KRXSessionExpiredError
 
         assert issubclass(KRXSessionExpiredError, httpx.HTTPStatusError)
+
+    @pytest.mark.asyncio
+    async def test_probe_health_reports_expired_session_without_writing(
+        self, monkeypatch
+    ):
+        from app.services.krx import KRXSessionExpiredError, KRXSessionManager
+
+        manager = KRXSessionManager()
+
+        async def _expired(**kwargs):
+            request = __import__("httpx").Request("POST", "https://example.test")
+            response = __import__("httpx").Response(400, request=request, text="LOGOUT")
+            raise KRXSessionExpiredError(
+                "KRX session expired after re-auth", request=request, response=response
+            )
+
+        monkeypatch.setattr(manager, "fetch_data", _expired)
+
+        assert await manager.probe_health() == {
+            "status": "unavailable",
+            "reason": "krx_session_expired",
+            "retryable": True,
+            "authenticated": False,
+        }


### PR DESCRIPTION
## Summary
- reuse the existing KRX login path once after a 400/LOGOUT session expiry, then retry the original read request
- add read-only `get_krx_session_health` (including `analysis_readonly`) and explicit snapshot/momentum fallback guidance
- cover recovery, exhausted-session, fallback wording, and MCP registration

## Validation
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run ty check app/services/krx.py app/mcp_server/tooling/analysis_registration.py app/mcp_server/tooling/screening/kr.py`
- `uv run pytest --no-cov tests/test_services_krx.py tests/test_mcp_screen_stocks_kr.py tests/mcp_server/tooling/test_screen_stocks_snapshot_docs.py tests/test_mcp_profiles.py -q` (195 passed)
- live KRX health probe reproduced expired-session handling; current configured KRX credentials require a password change, so recovery correctly returns `krx_session_expired` and fallback guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only KRX session health check reporting availability, authentication status, retryability, and observed data.
  * KRX session failures now automatically attempt one re-authentication and retry the request.

* **Bug Fixes**
  * Expired KRX sessions now return clear status information and actionable guidance.

* **Documentation**
  * Updated screening guidance with snapshot and momentum-based alternatives when live KRX access is unavailable.
  * Made the health check available in read-only analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->