### PR TITLE
fix(ROB-972): support cancel/replace proposals for toss_live equity_kr/us

### DIFF
--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -252,7 +252,12 @@ async def order_proposal_create(
         supersedes_proposal_id: if this proposal replaces an existing one (price/qty
                change), the original is marked superseded and lineage is linked.
         action: ``place`` (default), ``replace``, or ``cancel``. Replace/cancel
+                support the same account_mode/market combinations as place
+                (kis_live/toss_live equity_kr|equity_us, upbit crypto) and
                 perform a read-only target-order preflight before persistence.
+                An unsupported combination returns success=False with a
+                structured supported_matrix (per action) instead of a bare
+                error string.
         target_broker_order_id: required broker order ID for replace/cancel.
     """
     try:

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -35,7 +35,7 @@ from app.services.order_proposals.errors import (
     OrderProposalNotFound,
     OrderProposalUnsupportedTargetAction,
 )
-from app.services.order_proposals.service import RungInput
+from app.services.order_proposals.service import RungInput, check_action_capability
 from app.services.order_proposals.telegram_callback import _safe_edit_message
 
 if TYPE_CHECKING:
@@ -274,6 +274,9 @@ async def order_proposal_create(
         if normalized_action in {"replace", "cancel"}:
             if not target_broker_order_id:
                 raise ValueError(f"{normalized_action} requires target_broker_order_id")
+            check_action_capability(
+                action=normalized_action, account_mode=account_mode, market=market
+            )
             target_snapshot = await fetch_target_order(
                 order_id=target_broker_order_id,
                 symbol=symbol,

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -33,6 +33,7 @@ from app.services.order_proposals.dispatch import dispatch_proposal
 from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalNotFound,
+    OrderProposalUnsupportedTargetAction,
 )
 from app.services.order_proposals.service import RungInput
 from app.services.order_proposals.telegram_callback import _safe_edit_message
@@ -393,6 +394,13 @@ async def order_proposal_create(
                 )
 
         return result
+    except OrderProposalUnsupportedTargetAction as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "supported_matrix": exc.supported_matrix,
+            "requested": exc.requested,
+        }
     except (ValueError, OrderProposalError) as exc:
         return {"success": False, "error": str(exc)}
 

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -16,7 +16,6 @@ from app.services.order_proposals.approval_message import (
     _escape_markdown,
     build_callback_data,
 )
-from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
 from app.services.trading_policy_service import load_trading_policy
 
 _POLICY_MARKET = {
@@ -24,6 +23,23 @@ _POLICY_MARKET = {
     "equity_us": "us",
     "crypto": "crypto",
 }
+
+# Account/market combinations whose auto-veto Telegram button can actually
+# cancel the just-submitted order (see telegram_callback._handle_auto_veto ->
+# cancel_auto_submitted_rungs -> cancel_target_order). Deliberately NOT
+# broker_gateway.SUPPORTED_TARGET_ACTIONS: that set also gates
+# order_proposal_create's cancel/replace target-action support (ROB-972 added
+# toss_live there for that purpose only). "Can a human-created replace/cancel
+# proposal target this broker order" and "is this account mode eligible to
+# skip the Telegram click entirely via auto-approve" are different questions
+# -- widening one must never silently widen the other.
+_VETO_CAPABLE_ACCOUNT_MARKETS = frozenset(
+    {
+        ("kis_live", "equity_kr"),
+        ("kis_live", "equity_us"),
+        ("upbit", "crypto"),
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -92,7 +108,7 @@ def evaluate_auto_approve_eligibility(
     if (
         getattr(group, "account_mode", None),
         getattr(group, "market", None),
-    ) not in SUPPORTED_TARGET_ACTIONS:
+    ) not in _VETO_CAPABLE_ACCOUNT_MARKETS:
         return reject("account_not_veto_capable")
     if preview.get("success") is not True:
         return reject("preview_guard_failed")

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -17,9 +17,33 @@ SUPPORTED_TARGET_ACTIONS = frozenset(
     {
         ("kis_live", "equity_kr"),
         ("kis_live", "equity_us"),
+        ("toss_live", "equity_kr"),
+        ("toss_live", "equity_us"),
         ("upbit", "crypto"),
     }
 )
+
+# Toss broker-authoritative order status enum (see reference_toss_openapi_docs
+# memory / GET /api/v1/orders docs). OPEN-group statuses still have live,
+# actionable remaining quantity; CLOSED-group statuses are terminal. REPLACED
+# means Toss issued a new order id superseding this one (cancel/modify both
+# do this) -- for target-order confirmation purposes that is equivalent to
+# "this order id is no longer actionable", so it maps to "cancelled" the same
+# as CANCELED.
+_TOSS_OPEN_TARGET_STATUSES = {
+    "PENDING": "open",
+    "PARTIAL_FILLED": "partial",
+    "PENDING_CANCEL": "open",
+    "PENDING_REPLACE": "open",
+    "CANCEL_REJECTED": "open",
+    "REPLACE_REJECTED": "open",
+}
+_TOSS_CLOSED_TARGET_STATUSES = {
+    "FILLED": "filled",
+    "CANCELED": "cancelled",
+    "REJECTED": "rejected",
+    "REPLACED": "cancelled",
+}
 
 
 @dataclass(frozen=True)
@@ -110,6 +134,72 @@ async def _maybe_await(value: Any) -> Any:
     return await value if inspect.isawaitable(value) else value
 
 
+def _toss_target_status(raw_status: Any) -> str:
+    status = str(raw_status or "").strip().upper()
+    mapped = _TOSS_OPEN_TARGET_STATUSES.get(status) or _TOSS_CLOSED_TARGET_STATUSES.get(
+        status
+    )
+    if mapped is None:
+        raise OrderProposalError(f"unsupported toss target order status: {status!r}")
+    return mapped
+
+
+def _toss_target_remaining_quantity(order: Any) -> Decimal:
+    filled = (order.execution or {}).get("filledQuantity")
+    filled_decimal = filled if isinstance(filled, Decimal) else Decimal("0")
+    remaining = order.quantity - filled_decimal
+    return remaining if remaining > 0 else Decimal("0")
+
+
+async def _fetch_toss_target_order(
+    *,
+    order_id: str,
+    symbol: str,
+    now: datetime,
+    toss_client: Any | None,
+) -> TargetOrderSnapshot:
+    """Read-only single-order lookup for a toss_live cancel/replace target.
+
+    Uses ``GET /api/v1/orders/{orderId}`` (single order, any status) rather
+    than the paginated list scan ``fetch_operator_void_evidence`` uses -- an
+    exact order_id lookup needs no window/pagination bookkeeping.
+    """
+    from app.services.brokers.toss.client import TossReadClient
+    from app.services.brokers.toss.errors import TossApiResponseError
+
+    owns_client = toss_client is None
+    client = toss_client or TossReadClient.from_settings()
+    try:
+        order = await client.get_order(order_id)
+    except TossApiResponseError as exc:
+        if exc.status_code == 404:
+            raise OrderProposalError("target broker order not found uniquely") from exc
+        raise OrderProposalError(
+            f"target broker order lookup failed: {describe_exception(exc)}"
+        ) from exc
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    if _normalize_order_text(order.order_id) != _normalize_order_text(order_id):
+        raise OrderProposalError("target broker order not found uniquely")
+    if _normalize_order_text(order.symbol) != _normalize_order_text(symbol):
+        raise OrderProposalError("target broker order symbol mismatch")
+
+    return TargetOrderSnapshot.from_broker_order(
+        {
+            "order_id": order.order_id,
+            "symbol": order.symbol,
+            "side": order.side,
+            "order_type": order.order_type,
+            "ordered_price": order.price,
+            "remaining_qty": _toss_target_remaining_quantity(order),
+            "status": _toss_target_status(order.status),
+        },
+        observed_at=now,
+    )
+
+
 async def fetch_target_order(
     *,
     order_id: str,
@@ -118,10 +208,15 @@ async def fetch_target_order(
     account_mode: str,
     now: datetime,
     history_fn: Callable[..., Any] | None = None,
+    toss_client: Any | None = None,
 ) -> TargetOrderSnapshot:
     if (account_mode, market) not in SUPPORTED_TARGET_ACTIONS:
         raise OrderProposalError(
             f"target order lookup unsupported for {account_mode}/{market}"
+        )
+    if account_mode == "toss_live":
+        return await _fetch_toss_target_order(
+            order_id=order_id, symbol=symbol, now=now, toss_client=toss_client
         )
     if history_fn is None:
         from app.mcp_server.tooling.orders_history import get_order_history_impl
@@ -566,9 +661,29 @@ async def cancel_target_order(
     market: str,
     account_mode: str,
     cancel_fn: Callable[..., Any] | None = None,
+    toss_cancel_fn: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
     if (account_mode, market) not in SUPPORTED_TARGET_ACTIONS:
         raise OrderProposalError(f"cancel unsupported for {account_mode}/{market}")
+    if account_mode == "toss_live":
+        if toss_cancel_fn is None:
+            from app.mcp_server.tooling.orders_toss_variants import toss_cancel_order
+
+            toss_cancel_fn = toss_cancel_order
+        # toss_cancel_order is the production tool: it still enforces
+        # TOSS_LIVE_ORDER_MUTATIONS_ENABLED and records the accepted-only
+        # ledger row itself. This call site is only ever reached post-Telegram
+        # approval (revalidate_and_submit's cancel/replace execution branch),
+        # so dry_run=False/confirm=True mirrors cancel_order_impl's KIS/Upbit
+        # path below, which has no dry_run/preview concept at all.
+        return await _maybe_await(
+            toss_cancel_fn(
+                order_id=order_id,
+                dry_run=False,
+                confirm=True,
+                account_mode=account_mode,
+            )
+        )
     if cancel_fn is None:
         from app.mcp_server.tooling.orders_modify_cancel import cancel_order_impl
 

--- a/app/services/order_proposals/errors.py
+++ b/app/services/order_proposals/errors.py
@@ -38,3 +38,26 @@ class OrderProposalNotFound(OrderProposalError):
 
 class OrderProposalDuplicate(OrderProposalError):
     """A proposal with the same proposal_id already exists."""
+
+
+class OrderProposalUnsupportedTargetAction(OrderProposalError):
+    """The requested account_mode/market/action combination is unsupported.
+
+    Carries a structured ``supported_matrix`` (per-action allowed
+    account_mode x market pairs, derived from the same capability sets the
+    message text is generated from -- see ROB-972) and the rejected
+    ``requested`` combination, so callers can render an accurate,
+    action-specific rejection instead of a place-only message reused for
+    replace/cancel.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        supported_matrix: dict[str, list[dict[str, str]]],
+        requested: dict[str, str],
+    ) -> None:
+        super().__init__(message)
+        self.supported_matrix = supported_matrix
+        self.requested = requested

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -1171,7 +1171,9 @@ async def _revalidate_replace_rung(
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
 ) -> RungOutcome:
     proposal_client_order_id = (
-        _proposal_client_order_id(group.proposal_id, rung.rung_index)
+        _toss_proposal_client_order_id(group.proposal_id, rung.rung_index)
+        if group.account_mode == "toss_live"
+        else _proposal_client_order_id(group.proposal_id, rung.rung_index)
         if group.account_mode == "upbit"
         else None
     )

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -86,6 +86,7 @@ TargetCancelFn = Callable[..., Any]
 SubmitEvidenceFetchFn = Callable[..., Any]
 RetrospectiveLookupFn = Callable[[int], Any]
 EligibilityGate = Callable[..., Any]
+OppositePendingCheckFn = Callable[..., Any]
 
 _PREVIEW_REASON = "order_proposal revalidation (rung {rung})"
 _SUBMIT_REASON = "order_proposal submit after revalidation (rung {rung})"
@@ -232,6 +233,34 @@ def _invalid_toss_preview_reason(
         if price is None or not str(price).strip():
             return "limit_price_missing"
     return None
+
+
+async def _default_toss_opposite_pending_check(
+    *, account_mode: str, market: str, symbol: str, side: str
+) -> dict[str, Any] | None:
+    """Toss-only pre-cancel atomicity guard (ROB-972 R1 fix).
+
+    Toss's live place path rejects on an opposite-side pending order just
+    before POST (``orders_toss_variants._opposite_pending_error``), but that
+    scan never runs during the dry-run preview
+    ``_revalidate_replace_preview`` uses -- so a replace could cancel the
+    original resting order, then have the replacement rejected by that same
+    guard, leaving the operator with nothing resting (the original ROB-972
+    round-1 finding). Re-running the scan here, before any cancel, catches a
+    losing race while the original order is still intact. Deliberately
+    toss_live-only: kis_live/upbit replace weren't implicated by the
+    incident that reproduced this gap, and neither broker's replace path
+    shares Toss's cancel-then-place two-step.
+    """
+    if account_mode != "toss_live":
+        return None
+    from app.mcp_server.tooling.orders_toss_variants import (
+        _client_context,
+        _opposite_pending_error,
+    )
+
+    async with _client_context() as client:
+        return await _opposite_pending_error(client, symbol, side, {})
 
 
 def _adapt_toss_submit_response(
@@ -537,6 +566,7 @@ async def revalidate_and_submit(
     buying_power_claimer: BuyingPowerClaimer = default_buying_power_claimer,
     buying_power_releaser: BuyingPowerReleaser = default_buying_power_releaser,
     eligibility_gate: EligibilityGate | None = None,
+    opposite_pending_check_fn: OppositePendingCheckFn = _default_toss_opposite_pending_check,
 ) -> list[RungOutcome]:
     """Revalidate + (maybe) submit every ``pending_approval`` rung.
 
@@ -581,6 +611,8 @@ async def revalidate_and_submit(
                 cancel_target_fn=cancel_target_fn,
                 correlation_mint=correlation_mint,
                 fetch_submit_evidence_fn=fetch_submit_evidence_fn,
+                eligibility_gate=eligibility_gate,
+                opposite_pending_check_fn=opposite_pending_check_fn,
             )
         elif action == "cancel":
             outcome = await _revalidate_cancel_rung(
@@ -590,6 +622,7 @@ async def revalidate_and_submit(
                 now=now,
                 fetch_target_fn=fetch_target_fn,
                 cancel_target_fn=cancel_target_fn,
+                eligibility_gate=eligibility_gate,
             )
         else:
             outcome = await _revalidate_place_rung(
@@ -606,6 +639,75 @@ async def revalidate_and_submit(
             )
         outcomes.append(outcome)
     return outcomes
+
+
+async def _apply_eligibility_gate(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    preview: dict[str, Any],
+    now: datetime,
+    eligibility_gate: EligibilityGate | None,
+) -> RungOutcome | None:
+    """Run the auto-dispatch eligibility gate, failing closed on any error.
+
+    Returns ``None`` when the rung is eligible (or no gate is wired -- the
+    manual Telegram-click path never passes one). Otherwise reverts the rung
+    to ``pending_approval`` and returns an ``approval_required`` outcome so
+    the caller falls back to the normal human-approval message instead of
+    completing whatever broker action it was about to take.
+
+    ROB-972 round-1 finding: this used to run only from
+    ``_revalidate_place_rung``, so ``dispatch_proposal``'s auto-approve path
+    could reach a toss_live/kis_live/upbit cancel or replace's broker
+    mutation without ``evaluate_auto_approve_eligibility`` (which rejects
+    ``action_not_place`` first) ever being consulted -- a same-day resting
+    order could be auto-cancelled before the Telegram approval message was
+    even sent. ``_revalidate_cancel_rung``/``_revalidate_replace_rung`` now
+    call this too, with an empty ``preview`` (the ``action_not_place``
+    check short-circuits before ``preview`` is ever read).
+    """
+    if eligibility_gate is None:
+        return None
+    proposal_id = group.proposal_id
+    rung_index = rung.rung_index
+    try:
+        decision = await _maybe_await(
+            eligibility_gate(
+                group=group,
+                rung=rung,
+                preview=preview,
+                now=now,
+            )
+        )
+        eligible = (
+            decision.get("eligible")
+            if isinstance(decision, dict)
+            else getattr(decision, "eligible", False)
+        )
+        reason = (
+            decision.get("reason")
+            if isinstance(decision, dict)
+            else getattr(decision, "reason", "eligibility_unknown")
+        )
+        details = (
+            decision.get("details", {})
+            if isinstance(decision, dict)
+            else getattr(decision, "details", {})
+        )
+    except Exception as exc:  # noqa: BLE001 - auto path fails closed
+        eligible = False
+        reason = "eligibility_error"
+        details = {"error": str(exc)}
+    if eligible is True:
+        return None
+    await service.transition_rung(proposal_id, rung_index, new_state="pending_approval")
+    return RungOutcome(
+        rung_index,
+        "approval_required",
+        {"reason": str(reason), **dict(details or {})},
+    )
 
 
 async def _revalidate_place_rung(
@@ -722,44 +824,16 @@ async def _revalidate_place_rung(
             rung_index, "needs_reconfirm", {"before": before, "after": after}
         )
 
-    if eligibility_gate is not None:
-        try:
-            decision = await _maybe_await(
-                eligibility_gate(
-                    group=group,
-                    rung=rung,
-                    preview=preview,
-                    now=now,
-                )
-            )
-            eligible = (
-                decision.get("eligible")
-                if isinstance(decision, dict)
-                else getattr(decision, "eligible", False)
-            )
-            reason = (
-                decision.get("reason")
-                if isinstance(decision, dict)
-                else getattr(decision, "reason", "eligibility_unknown")
-            )
-            details = (
-                decision.get("details", {})
-                if isinstance(decision, dict)
-                else getattr(decision, "details", {})
-            )
-        except Exception as exc:  # noqa: BLE001 - auto path fails closed
-            eligible = False
-            reason = "eligibility_error"
-            details = {"error": str(exc)}
-        if eligible is not True:
-            await service.transition_rung(
-                proposal_id, rung_index, new_state="pending_approval"
-            )
-            return RungOutcome(
-                rung_index,
-                "approval_required",
-                {"reason": str(reason), **dict(details or {})},
-            )
+    gate_outcome = await _apply_eligibility_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        preview=preview,
+        now=now,
+        eligibility_gate=eligibility_gate,
+    )
+    if gate_outcome is not None:
+        return gate_outcome
 
     buying_power_reservation: tuple[str, Decimal, str | None] | None = None
     if rung.side == "buy" and rung.limit_price is not None:
@@ -1158,6 +1232,50 @@ async def _cancel_and_confirm_target(
     return None
 
 
+async def _check_replace_opposite_pending(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    now: datetime,
+    opposite_pending_check_fn: OppositePendingCheckFn,
+) -> RungOutcome | None:
+    """Pre-cancel guard: block a replace before it cancels the original.
+
+    ``opposite_pending_check_fn`` is a no-op (returns ``None``) for every
+    account_mode except toss_live -- see
+    ``_default_toss_opposite_pending_check``. Any exception (e.g. the Toss
+    client being unconfigured) fails closed: the rung reverts to
+    ``pending_approval`` and the original order is never touched, same as a
+    confirmed opposite-pending hit.
+    """
+    proposal_id = group.proposal_id
+    rung_index = rung.rung_index
+    try:
+        guard = await _maybe_await(
+            opposite_pending_check_fn(
+                account_mode=group.account_mode,
+                market=group.market,
+                symbol=group.symbol,
+                side=rung.side,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - fail closed: never cancel on an unknown guard state
+        await service.transition_rung(
+            proposal_id, rung_index, new_state="pending_approval"
+        )
+        return RungOutcome(
+            rung_index, "error", {"error": f"opposite_pending_check_error:{exc}"}
+        )
+    if guard is None:
+        return None
+    await service.transition_rung(proposal_id, rung_index, new_state="pending_approval")
+    error = (
+        guard.get("error") if isinstance(guard, dict) else None
+    ) or "opposite_pending_order_exists"
+    return RungOutcome(rung_index, "guard_blocked", {"error": error})
+
+
 async def _revalidate_replace_rung(
     *,
     service: OrderProposalsService,
@@ -1169,6 +1287,8 @@ async def _revalidate_replace_rung(
     cancel_target_fn: TargetCancelFn,
     correlation_mint: CorrelationMint,
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
+    eligibility_gate: EligibilityGate | None = None,
+    opposite_pending_check_fn: OppositePendingCheckFn = _default_toss_opposite_pending_check,
 ) -> RungOutcome:
     proposal_client_order_id = (
         _toss_proposal_client_order_id(group.proposal_id, rung.rung_index)
@@ -1187,6 +1307,25 @@ async def _revalidate_replace_rung(
     if target_outcome is not None:
         return target_outcome
 
+    # ROB-972 round-1 finding: an auto-dispatch eligibility gate previously
+    # only ran for `place` rungs, so a toss_live/kis_live/upbit auto-dispatch
+    # could reach the cancel below without ever consulting
+    # `evaluate_auto_approve_eligibility` (which rejects `action_not_place`
+    # first, before it would even read `preview`). Applying the same gate
+    # here means the manual Telegram-click path (`eligibility_gate=None`) is
+    # unaffected, but auto-dispatch always falls back to human approval for
+    # cancel/replace, same as it always has for `place`.
+    gate_outcome = await _apply_eligibility_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        preview={},
+        now=now,
+        eligibility_gate=eligibility_gate,
+    )
+    if gate_outcome is not None:
+        return gate_outcome
+
     preview, preview_outcome = await _revalidate_replace_preview(
         service=service,
         group=group,
@@ -1197,6 +1336,23 @@ async def _revalidate_replace_rung(
     )
     if preview_outcome is not None:
         return preview_outcome
+
+    # ROB-972 round-1 finding: Toss's live place path rejects an
+    # opposite-side pending order just before POST, but the dry-run preview
+    # above never runs that scan -- so without this check, a replace could
+    # cancel the original order below and then have the replacement
+    # rejected by that same guard, leaving the operator with nothing
+    # resting. Re-check here, before any cancel, so a losing race is caught
+    # while the original order is still intact.
+    opposite_outcome = await _check_replace_opposite_pending(
+        service=service,
+        group=group,
+        rung=rung,
+        now=now,
+        opposite_pending_check_fn=opposite_pending_check_fn,
+    )
+    if opposite_outcome is not None:
+        return opposite_outcome
 
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -1289,6 +1445,7 @@ async def _revalidate_cancel_rung(
     now: datetime,
     fetch_target_fn: TargetFetchFn,
     cancel_target_fn: TargetCancelFn,
+    eligibility_gate: EligibilityGate | None = None,
 ) -> RungOutcome:
     target_outcome = await _validate_target_action(
         service=service,
@@ -1299,6 +1456,22 @@ async def _revalidate_cancel_rung(
     )
     if target_outcome is not None:
         return target_outcome
+
+    # ROB-972 round-1 finding: see the matching comment in
+    # `_revalidate_replace_rung` -- without this, auto-dispatch could reach
+    # `BROKER_CANCEL` below for a toss_live/kis_live/upbit cancel proposal
+    # without ever consulting the eligibility gate, which rejects
+    # `action_not_place` before it reads `preview`.
+    gate_outcome = await _apply_eligibility_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        preview={},
+        now=now,
+        eligibility_gate=eligibility_gate,
+    )
+    if gate_outcome is not None:
+        return gate_outcome
 
     proposal_id = group.proposal_id
     rung_index = rung.rung_index

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -193,6 +193,7 @@ def _supported_matrix() -> dict[str, list[dict[str, str]]]:
         for action, pairs in _ACTION_CAPABILITIES.items()
     }
 
+
 _LOSS_CUT_EXIT_REASONS = frozenset({"stop_loss", "thesis_change"})
 _LOSS_CUT_TRIGGER_TYPES = frozenset({"stop_loss", "thesis_change"})
 _LOSS_CUT_MAX_AGE = timedelta(hours=72)

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -36,6 +36,7 @@ from app.services.order_proposals.defensive_ttl import (
 from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalNotFound,
+    OrderProposalUnsupportedTargetAction,
 )
 from app.services.order_proposals.payload import (
     ProposalRungSpec,
@@ -134,11 +135,63 @@ _ACTION_CAPABILITIES = {
     "cancel": SUPPORTED_TARGET_ACTIONS,
 }
 
-_ALLOWED_ACTION_CONTRACT_MESSAGE = (
-    "allowed: kis_live×equity_kr|equity_us, "
-    "toss_live×equity_kr|equity_us, upbit×crypto; "
-    "market aliases kr→equity_kr, us→equity_us"
-)
+# Display order only -- purely cosmetic grouping for the human-facing
+# "allowed: ..." message and the supported_matrix response field. Any
+# account_mode/market absent from these tuples still sorts, just after the
+# named ones.
+_ACCOUNT_MODE_DISPLAY_ORDER = ("kis_live", "toss_live", "upbit")
+_MARKET_DISPLAY_ORDER = ("equity_kr", "equity_us", "crypto")
+
+
+def _capability_sort_key(order: tuple[str, ...]) -> Callable[[str], tuple[int, str]]:
+    def key(value: str) -> tuple[int, str]:
+        try:
+            return (order.index(value), value)
+        except ValueError:
+            return (len(order), value)
+
+    return key
+
+
+def _format_action_capabilities(pairs: frozenset[tuple[str, str]]) -> str:
+    by_mode: dict[str, list[str]] = {}
+    for mode, market in pairs:
+        by_mode.setdefault(mode, []).append(market)
+    mode_key = _capability_sort_key(_ACCOUNT_MODE_DISPLAY_ORDER)
+    market_key = _capability_sort_key(_MARKET_DISPLAY_ORDER)
+    parts = [
+        f"{mode}×{'|'.join(sorted(by_mode[mode], key=market_key))}"
+        for mode in sorted(by_mode, key=mode_key)
+    ]
+    return ", ".join(parts) + "; market aliases kr→equity_kr, us→equity_us"
+
+
+def _action_contract_message(action: str) -> str:
+    """Allowed-combinations text for one action, derived from its own
+    capability set -- never a different action's set (ROB-972: cancel/replace
+    rejections previously reused place's message and falsely advertised
+    support they didn't have).
+    """
+    return f"allowed: {_format_action_capabilities(_ACTION_CAPABILITIES[action])}"
+
+
+def _supported_matrix() -> dict[str, list[dict[str, str]]]:
+    """Structured per-action allowed account_mode/market pairs.
+
+    Derived from the same ``_ACTION_CAPABILITIES`` sets ``_action_contract_message``
+    reads, so the matrix and the human-facing text can never drift apart.
+    """
+    mode_key = _capability_sort_key(_ACCOUNT_MODE_DISPLAY_ORDER)
+    market_key = _capability_sort_key(_MARKET_DISPLAY_ORDER)
+    return {
+        action: [
+            {"account_mode": mode, "market": market}
+            for mode, market in sorted(
+                pairs, key=lambda pair: (mode_key(pair[0]), market_key(pair[1]))
+            )
+        ]
+        for action, pairs in _ACTION_CAPABILITIES.items()
+    }
 
 _LOSS_CUT_EXIT_REASONS = frozenset({"stop_loss", "thesis_change"})
 _LOSS_CUT_TRIGGER_TYPES = frozenset({"stop_loss", "thesis_change"})
@@ -216,10 +269,16 @@ def _validate_action_contract(
     if normalized not in _ACTION_CAPABILITIES:
         raise OrderProposalError("action must be one of: place, replace, cancel")
     if (account_mode, market) not in _ACTION_CAPABILITIES[normalized]:
-        raise OrderProposalError(
+        raise OrderProposalUnsupportedTargetAction(
             "unsupported account_mode/market/action: "
             f"{account_mode}/{market}/{normalized} "
-            f"({_ALLOWED_ACTION_CONTRACT_MESSAGE})"
+            f"({_action_contract_message(normalized)})",
+            supported_matrix=_supported_matrix(),
+            requested={
+                "account_mode": account_mode,
+                "market": market,
+                "action": normalized,
+            },
         )
     if normalized == "place":
         if target_broker_order_id is not None or target_order_snapshot is not None:

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -253,18 +253,21 @@ def batch_member_block_reason(
     return None
 
 
-def _validate_action_contract(
-    *,
-    action: str | None,
-    account_mode: str,
-    market: str,
-    symbol: str,
-    side: str,
-    order_type: str,
-    rungs: list[RungInput],
-    target_broker_order_id: str | None,
-    target_order_snapshot: dict[str, str | None] | None,
-) -> tuple[str, TargetOrderSnapshot | None]:
+def check_action_capability(
+    *, action: str | None, account_mode: str, market: str
+) -> str:
+    """Validate (account_mode, market) is supported for ``action``.
+
+    Raises ``OrderProposalUnsupportedTargetAction`` (a structured, per-action
+    ``supported_matrix``) when unsupported. Returns the normalized action
+    ("place" default) on success.
+
+    Callers creating a replace/cancel proposal must run this check *before*
+    ``fetch_target_order`` -- that function has its own, narrower
+    ``SUPPORTED_TARGET_ACTIONS`` gate with an unstructured message, and would
+    otherwise be the first thing to reject an unsupported combination,
+    silently bypassing this structured error (ROB-972).
+    """
     normalized = action or "place"
     if normalized not in _ACTION_CAPABILITIES:
         raise OrderProposalError("action must be one of: place, replace, cancel")
@@ -280,6 +283,24 @@ def _validate_action_contract(
                 "action": normalized,
             },
         )
+    return normalized
+
+
+def _validate_action_contract(
+    *,
+    action: str | None,
+    account_mode: str,
+    market: str,
+    symbol: str,
+    side: str,
+    order_type: str,
+    rungs: list[RungInput],
+    target_broker_order_id: str | None,
+    target_order_snapshot: dict[str, str | None] | None,
+) -> tuple[str, TargetOrderSnapshot | None]:
+    normalized = check_action_capability(
+        action=action, account_mode=account_mode, market=market
+    )
     if normalized == "place":
         if target_broker_order_id is not None or target_order_snapshot is not None:
             raise OrderProposalError("place proposal cannot target a broker order")

--- a/tests/services/order_proposals/test_broker_gateway.py
+++ b/tests/services/order_proposals/test_broker_gateway.py
@@ -36,8 +36,10 @@ def _toss_order(**overrides):
         "status": "FILLED",
         "symbol": "005930",
         "side": "BUY",
+        "order_type": "LIMIT",
         "quantity": Decimal("1.00000000"),
         "price": Decimal("100.00"),
+        "execution": {},
         "ordered_at": NOW.isoformat(),
     }
     values.update(overrides)
@@ -60,11 +62,13 @@ def _toss_rung(**overrides):
 
 
 @pytest.mark.unit
-def test_supported_target_actions_are_live_kis_and_upbit_only():
+def test_supported_target_actions_are_live_kis_toss_and_upbit():
     assert SUPPORTED_TARGET_ACTIONS == frozenset(
         {
             ("kis_live", "equity_kr"),
             ("kis_live", "equity_us"),
+            ("toss_live", "equity_kr"),
+            ("toss_live", "equity_us"),
             ("upbit", "crypto"),
         }
     )
@@ -160,7 +164,12 @@ async def test_fetch_fails_closed_when_broker_history_reports_errors():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("account_mode", "market"),
-    [("kis_mock", "equity_kr"), ("kis_live", "crypto"), ("upbit", "equity_us")],
+    [
+        ("kis_mock", "equity_kr"),
+        ("kis_live", "crypto"),
+        ("upbit", "equity_us"),
+        ("toss_live", "crypto"),
+    ],
 )
 async def test_fetch_rejects_unsupported_target_tuple(account_mode, market):
     with pytest.raises(OrderProposalError, match="lookup unsupported"):
@@ -249,6 +258,199 @@ async def test_cancel_rejects_unsupported_target_tuple():
             account_mode="kis_live",
             cancel_fn=lambda **_kwargs: pytest.fail("cancel must not be called"),
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_rejects_unsupported_toss_target_tuple():
+    with pytest.raises(OrderProposalError, match="cancel unsupported"):
+        await cancel_target_order(
+            order_id="manual-1",
+            symbol="KRW-AVAX",
+            market="crypto",
+            account_mode="toss_live",
+            toss_cancel_fn=lambda **_kwargs: pytest.fail(
+                "toss cancel must not be called"
+            ),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_toss_target_order_returns_open_snapshot_for_pending():
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            assert order_id == "broker-1"
+            return _toss_order(status="PENDING", quantity=Decimal("2"))
+
+    snapshot = await fetch_target_order(
+        order_id="broker-1",
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert snapshot.status == "open"
+    assert snapshot.remaining_quantity == "2"
+    assert snapshot.broker_order_id == "broker-1"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_toss_target_order_computes_remaining_from_partial_fill():
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            return _toss_order(
+                status="PARTIAL_FILLED",
+                quantity=Decimal("5"),
+                execution={"filledQuantity": Decimal("2")},
+            )
+
+    snapshot = await fetch_target_order(
+        order_id="broker-1",
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert snapshot.status == "open"
+    assert snapshot.remaining_quantity == "3"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("broker_status", ["CANCELED", "REPLACED"])
+async def test_fetch_toss_target_order_maps_canceled_and_replaced_to_cancelled(
+    broker_status,
+):
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            return _toss_order(status=broker_status, quantity=Decimal("1"))
+
+    snapshot = await fetch_target_order(
+        order_id="broker-1",
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert snapshot.status == "cancelled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_toss_target_order_rejects_symbol_mismatch():
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            return _toss_order(symbol="000660")
+
+    with pytest.raises(OrderProposalError, match="symbol mismatch"):
+        await fetch_target_order(
+            order_id="broker-1",
+            symbol="005930",
+            market="equity_kr",
+            account_mode="toss_live",
+            now=NOW,
+            toss_client=FakeTossClient(),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_toss_target_order_maps_404_to_not_found():
+    from app.services.brokers.toss.errors import TossApiResponseError, TossErrorEnvelope
+
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            raise TossApiResponseError(
+                TossErrorEnvelope(
+                    request_id="req-1", code="order-not-found", message="", data=None
+                ),
+                status_code=404,
+            )
+
+    with pytest.raises(OrderProposalError, match="not found uniquely"):
+        await fetch_target_order(
+            order_id="broker-1",
+            symbol="005930",
+            market="equity_kr",
+            account_mode="toss_live",
+            now=NOW,
+            toss_client=FakeTossClient(),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_toss_target_order_wraps_other_broker_errors():
+    from app.services.brokers.toss.errors import TossApiResponseError, TossErrorEnvelope
+
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            raise TossApiResponseError(
+                TossErrorEnvelope(
+                    request_id="req-1", code="internal-error", message="boom", data=None
+                ),
+                status_code=500,
+            )
+
+    with pytest.raises(OrderProposalError, match="lookup failed"):
+        await fetch_target_order(
+            order_id="broker-1",
+            symbol="005930",
+            market="equity_kr",
+            account_mode="toss_live",
+            now=NOW,
+            toss_client=FakeTossClient(),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_toss_target_order_routes_live_confirm_and_returns_broker_result():
+    captured = {}
+    broker_result = {"success": True, "original_order_id": "broker-1"}
+
+    async def fake_toss_cancel(**kwargs):
+        captured.update(kwargs)
+        return broker_result
+
+    result = await cancel_target_order(
+        order_id="broker-1",
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        toss_cancel_fn=fake_toss_cancel,
+    )
+
+    assert result == broker_result
+    assert captured == {
+        "order_id": "broker-1",
+        "dry_run": False,
+        "confirm": True,
+        "account_mode": "toss_live",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_toss_target_order_returns_broker_rejection():
+    async def fake_toss_cancel(**_kwargs):
+        return {"success": False, "error": "already filled"}
+
+    assert await cancel_target_order(
+        order_id="broker-1",
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        toss_cancel_fn=fake_toss_cancel,
+    ) == {"success": False, "error": "already filled"}
 
 
 def _http_status_error(status_code: int) -> httpx.HTTPStatusError:

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -14,7 +15,7 @@ from app.services.order_proposals.dispatch import (
     dispatch_proposal,
     send_proposal_for_approval,
 )
-from app.services.order_proposals.revalidation import RungOutcome
+from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
 
 CHAT_ID = "chat-99"
@@ -509,6 +510,139 @@ async def test_dispatch_auto_ineligible_degrades_to_human_approval(
     assert rungs[0].state == "pending_approval"
     assert "auto_approved" not in (refreshed.source_asof or {})
     assert "주문 제안 승인" in notifier.sent_messages[0][0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "account_mode,market",
+    [
+        ("toss_live", "equity_kr"),
+        ("kis_live", "equity_kr"),
+        ("upbit", "crypto"),
+    ],
+)
+@pytest.mark.parametrize("action", ["cancel", "replace"])
+async def test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate(
+    monkeypatch, db_session, account_mode, market, action
+):
+    """ROB-972 round-1 regression -- the 07-20 incident.
+
+    Auto-dispatch previously reached ``_cancel_and_confirm_target`` (a real
+    broker cancel) for cancel/replace proposals without ever consulting the
+    eligibility gate, because ``revalidate_and_submit`` only threaded
+    ``eligibility_gate`` into the ``place`` branch. The gate rejects every
+    cancel/replace with ``action_not_place`` (see
+    ``evaluate_auto_approve_eligibility``), so the fix must make auto-dispatch
+    fall back to the ordinary human-approval Telegram message for ALL three
+    veto-capable account/market pairs, same as it always has for ``place``.
+
+    Deliberately exercises the REAL ``revalidate_and_submit`` (not a fake
+    ``revalidate_fn`` that calls ``eligibility_gate`` by hand, as the other
+    tests in this module do) through ``dispatch_proposal``'s real auto-
+    approve branch end to end -- only the broker/network edges
+    (``fetch_target_fn``/``cancel_target_fn``/``place_order_fn``/
+    ``opposite_pending_check_fn``) are faked. This is the shape of coverage
+    the round-1 audit found missing: a fake ``revalidate_fn`` that manually
+    invokes ``eligibility_gate`` can never catch a bug in
+    ``revalidate_and_submit`` not calling it at all for a given action.
+    """
+    from app.core.config import settings
+    from app.services.order_proposals.target_order import TargetOrderSnapshot
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    # Unique per-parametrization chat id -- batches scope by chat, and this
+    # module's tests commit real rows to the shared test DB, so a fixed
+    # CHAT_ID lets an earlier parametrization's proposal leak into this run's
+    # 10-minute batch window and add an unrelated "전체 승인" batch-summary
+    # send (see `_unique_chat` in test_mcp_order_proposal_tools.py).
+    chat_id = f"chat-gate-{account_mode}-{action}-{uuid.uuid4().hex[:8]}"
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat_id
+    )
+
+    symbol = "KRW-AVAX" if market == "crypto" else "005930"
+    side = "sell"
+    limit_price = Decimal("43000") if action == "replace" else Decimal("42000")
+    target_snapshot = TargetOrderSnapshot(
+        broker_order_id="broker-gate-1",
+        symbol=symbol,
+        side=side,
+        order_type="limit",
+        limit_price="42000",
+        remaining_quantity="3.5",
+        status="open",
+        observed_at=datetime.now(UTC).isoformat(),
+    )
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol=symbol,
+        market=market,
+        account_mode=account_mode,
+        side=side,
+        order_type="limit",
+        proposer="p",
+        broker_account_id=f"gate-{account_mode}-{action}-{uuid.uuid4()}",
+        action=action,
+        target_broker_order_id="broker-gate-1",
+        target_order_snapshot=target_snapshot.to_payload(),
+        rungs=[RungInput(0, side, Decimal("3.5"), limit_price, None)],
+    )
+    await db_session.commit()
+
+    cancel_calls: list[dict] = []
+
+    async def fetch_fn(**kwargs):
+        return target_snapshot
+
+    async def cancel_fn(**kwargs):
+        cancel_calls.append(kwargs)
+        raise AssertionError(
+            "BROKER_CANCEL must never fire before the eligibility gate runs"
+        )
+
+    async def place_fn(**kwargs):
+        if kwargs.get("dry_run"):
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": str(limit_price),
+                "quantity": "3.5",
+            }
+        raise AssertionError("live submit must never fire before the gate runs")
+
+    async def no_opposite_pending(**kwargs):
+        return None
+
+    notifier = _FakeNotifier(message_id=7700)
+    result = await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=functools.partial(
+            revalidate_and_submit,
+            fetch_target_fn=fetch_fn,
+            cancel_target_fn=cancel_fn,
+            place_order_fn=place_fn,
+            opposite_pending_check_fn=no_opposite_pending,
+        ),
+    )
+
+    assert cancel_calls == []
+    assert result is not None  # nonce minted + ordinary approval message sent
+    # Falls back to the ordinary human-approval message ("주문 제안 승인"),
+    # never the auto-approved "자동 접수됨" veto message -- TELEGRAM_APPROVAL_SEND
+    # for the human-click flow, not a post-hoc veto button on an already-sent order.
+    assert len(notifier.sent_messages) == 1
+    text, _keyboard, _chat_id = notifier.sent_messages[0]
+    assert "주문 제안 승인" in text
+    assert "자동 접수됨" not in text
+
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "pending_approval"
+    assert "auto_approved" not in (refreshed.source_asof or {})
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1,3 +1,4 @@
+import functools
 import re
 import uuid
 from datetime import UTC, datetime
@@ -1129,6 +1130,188 @@ async def test_replace_target_drift_is_rejected_without_cancel(
     _, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "rejected"
     assert rungs[0].void_reason == f"target_snapshot_mismatch:{field}"
+
+
+def _toss_broker_order(**overrides):
+    values = {
+        "order_id": "broker-1",
+        "symbol": "005930",
+        "side": "SELL",
+        "order_type": "LIMIT",
+        "price": Decimal("70000"),
+        "quantity": Decimal("10"),
+        "execution": {},
+        "status": "PENDING",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_toss_live_cancel_end_to_end_through_broker_gateway(db_session):
+    """ROB-972 AC3 -- the 07-20 incident scenario: a resting toss_live KR
+    limit order, a cancel proposal, approval, and a fake broker cancel call
+    routed through the *real* broker_gateway dispatch (fetch_target_order /
+    cancel_target_order), not a stand-in fetch_target_fn/cancel_target_fn --
+    only the actual Toss network boundary (TossReadClient.get_order,
+    toss_cancel_order) is faked.
+    """
+    from app.services.order_proposals.broker_gateway import (
+        cancel_target_order,
+        fetch_target_order,
+    )
+
+    service = OrderProposalsService(db_session)
+    approved = _target_snapshot(
+        broker_order_id="broker-1",
+        symbol="005930",
+        side="sell",
+        limit_price="70000",
+        remaining_quantity="10",
+    )
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        action="cancel",
+        target_broker_order_id="broker-1",
+        target_order_snapshot=approved.to_payload(),
+        rungs=[RungInput(0, "sell", Decimal("10"), Decimal("70000"), None)],
+    )
+    await db_session.commit()
+
+    toss_orders = iter(
+        [
+            _toss_broker_order(status="PENDING"),
+            _toss_broker_order(status="CANCELED"),
+        ]
+    )
+
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            assert order_id == "broker-1"
+            return next(toss_orders)
+
+    cancel_calls = []
+
+    async def fake_toss_cancel(**kwargs):
+        cancel_calls.append(kwargs)
+        return {"success": True, "original_order_id": kwargs["order_id"]}
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=_forbidden_submit,
+        fetch_target_fn=functools.partial(
+            fetch_target_order, toss_client=FakeTossClient()
+        ),
+        cancel_target_fn=functools.partial(
+            cancel_target_order, toss_cancel_fn=fake_toss_cancel
+        ),
+    )
+
+    assert outcomes[0].result == "cancelled"
+    assert cancel_calls == [
+        {
+            "order_id": "broker-1",
+            "dry_run": False,
+            "confirm": True,
+            "account_mode": "toss_live",
+        }
+    ]
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "cancelled"
+    assert rungs[0].broker_order_id == "broker-1"
+
+
+@pytest.mark.asyncio
+async def test_toss_live_replace_end_to_end_uses_toss_client_order_id(db_session):
+    """ROB-972 regression guard -- _revalidate_replace_rung previously only
+    generated a proposal_client_order_id for account_mode == 'upbit', so a
+    toss_live replace's live submit step would always fail with
+    invalid_toss_client_order_id. Assert the real toss-shaped id reaches
+    place_order_fn and the whole cancel-then-place pipeline converges.
+    """
+    from app.services.order_proposals.broker_gateway import (
+        cancel_target_order,
+        fetch_target_order,
+    )
+    from app.services.order_proposals.revalidation import (
+        _toss_proposal_client_order_id,
+    )
+
+    service = OrderProposalsService(db_session)
+    approved = _target_snapshot(
+        broker_order_id="broker-1",
+        symbol="005930",
+        side="sell",
+        limit_price="70000",
+        remaining_quantity="10",
+    )
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        action="replace",
+        target_broker_order_id="broker-1",
+        target_order_snapshot=approved.to_payload(),
+        rungs=[RungInput(0, "sell", Decimal("10"), Decimal("71000"), None)],
+    )
+    await db_session.commit()
+
+    toss_orders = iter(
+        [
+            _toss_broker_order(status="PENDING"),
+            _toss_broker_order(status="CANCELED"),
+        ]
+    )
+
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            return next(toss_orders)
+
+    async def fake_toss_cancel(**kwargs):
+        return {"success": True}
+
+    submit_calls = []
+
+    async def place_order_fn(**kwargs):
+        if kwargs.get("dry_run"):
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "71000",
+                "quantity": "10",
+            }
+        submit_calls.append(kwargs)
+        return {"success": True, "status": "resting", "broker_order_id": "new-1"}
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order_fn,
+        fetch_target_fn=functools.partial(
+            fetch_target_order, toss_client=FakeTossClient()
+        ),
+        cancel_target_fn=functools.partial(
+            cancel_target_order, toss_cancel_fn=fake_toss_cancel
+        ),
+    )
+
+    assert outcomes[0].result == "submitted_resting"
+    assert len(submit_calls) == 1
+    expected_client_order_id = _toss_proposal_client_order_id(group.proposal_id, 0)
+    assert submit_calls[0]["proposal_client_order_id"] == expected_client_order_id
+    assert re.fullmatch(r"[a-zA-Z0-9\-_]+", expected_client_order_id)
+    assert len(expected_client_order_id) <= 36
 
 
 def test_toss_decimal_args_are_exact_and_canonical():

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1149,12 +1149,23 @@ def _toss_broker_order(**overrides):
 
 @pytest.mark.asyncio
 async def test_toss_live_cancel_end_to_end_through_broker_gateway(db_session):
-    """ROB-972 AC3 -- the 07-20 incident scenario: a resting toss_live KR
-    limit order, a cancel proposal, approval, and a fake broker cancel call
-    routed through the *real* broker_gateway dispatch (fetch_target_order /
-    cancel_target_order), not a stand-in fetch_target_fn/cancel_target_fn --
-    only the actual Toss network boundary (TossReadClient.get_order,
-    toss_cancel_order) is faked.
+    """A resting toss_live KR limit order, a cancel proposal, and a fake
+    broker cancel call routed through the *real* broker_gateway dispatch
+    (fetch_target_order / cancel_target_order), not a stand-in
+    fetch_target_fn/cancel_target_fn -- only the actual Toss network boundary
+    (TossReadClient.get_order, toss_cancel_order) is faked.
+
+    Scope note (ROB-972 round-1): this calls `revalidate_and_submit`
+    directly, with no nonce/Telegram callback -- it is NOT an approval-
+    boundary e2e test and must not be read as covering the "did the
+    eligibility gate run before this cancel" question. That coverage lives
+    in `test_telegram_callback.py::test_toss_live_cancel_approve_click_consumes_nonce_before_broker_cancel`
+    (the real AC3 -- the 07-20 incident scenario, driven through
+    `handle_callback_update`) and in `test_dispatch.py`'s
+    `test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate`
+    (the auto-dispatch path). This test's job is narrower: broker_gateway
+    routing (fetch_target_order/cancel_target_order dispatch on
+    account_mode) actually reaches the Toss-specific functions.
     """
     from app.services.order_proposals.broker_gateway import (
         cancel_target_order,
@@ -1293,6 +1304,9 @@ async def test_toss_live_replace_end_to_end_uses_toss_client_order_id(db_session
         submit_calls.append(kwargs)
         return {"success": True, "status": "resting", "broker_order_id": "new-1"}
 
+    async def no_opposite_pending(**kwargs):
+        return None
+
     outcomes = await revalidate_and_submit(
         service=service,
         proposal_id=group.proposal_id,
@@ -1304,6 +1318,7 @@ async def test_toss_live_replace_end_to_end_uses_toss_client_order_id(db_session
         cancel_target_fn=functools.partial(
             cancel_target_order, toss_cancel_fn=fake_toss_cancel
         ),
+        opposite_pending_check_fn=no_opposite_pending,
     )
 
     assert outcomes[0].result == "submitted_resting"
@@ -1312,6 +1327,106 @@ async def test_toss_live_replace_end_to_end_uses_toss_client_order_id(db_session
     assert submit_calls[0]["proposal_client_order_id"] == expected_client_order_id
     assert re.fullmatch(r"[a-zA-Z0-9\-_]+", expected_client_order_id)
     assert len(expected_client_order_id) <= 36
+
+
+@pytest.mark.asyncio
+async def test_toss_live_replace_opposite_pending_blocks_before_cancel(db_session):
+    """ROB-972 round-1 finding -- Toss replace non-atomicity.
+
+    Toss's live place path rejects an opposite-side pending order just
+    before POST, but the dry-run preview `_revalidate_replace_preview` uses
+    never runs that scan -- so before this fix, a replace could cancel the
+    original resting order and only THEN discover the replacement is
+    rejected, leaving the operator with nothing resting. Assert the
+    opposite-pending check runs before the cancel, so a losing race leaves
+    the original order untouched and the rung retryable.
+    """
+    from app.services.order_proposals.broker_gateway import (
+        cancel_target_order,
+        fetch_target_order,
+    )
+
+    service = OrderProposalsService(db_session)
+    approved = _target_snapshot(
+        broker_order_id="broker-1",
+        symbol="005930",
+        side="sell",
+        limit_price="70000",
+        remaining_quantity="10",
+    )
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        action="replace",
+        target_broker_order_id="broker-1",
+        target_order_snapshot=approved.to_payload(),
+        rungs=[RungInput(0, "sell", Decimal("10"), Decimal("71000"), None)],
+    )
+    await db_session.commit()
+
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            assert order_id == "broker-1"
+            return _toss_broker_order(status="PENDING")
+
+    async def place_order_fn(**kwargs):
+        assert kwargs.get("dry_run") is True, (
+            "opposite-pending must block before the cancel-then-place "
+            "pipeline ever reaches a live submit"
+        )
+        return {
+            "success": True,
+            "approval_hash": "fresh",
+            "price": "71000",
+            "quantity": "10",
+        }
+
+    cancel_calls = []
+
+    async def fake_toss_cancel(**kwargs):
+        cancel_calls.append(kwargs)
+        raise AssertionError(
+            "the original order must not be cancelled when the "
+            "opposite-pending pre-check rejects the replace"
+        )
+
+    async def opposite_pending_found(**kwargs):
+        assert kwargs == {
+            "account_mode": "toss_live",
+            "market": "equity_kr",
+            "symbol": "005930",
+            "side": "sell",
+        }
+        return {
+            "success": False,
+            "error": "An opposite pending order exists for symbol 005930 (BUY).",
+        }
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order_fn,
+        fetch_target_fn=functools.partial(
+            fetch_target_order, toss_client=FakeTossClient()
+        ),
+        cancel_target_fn=functools.partial(
+            cancel_target_order, toss_cancel_fn=fake_toss_cancel
+        ),
+        opposite_pending_check_fn=opposite_pending_found,
+    )
+
+    assert cancel_calls == []
+    assert outcomes[0].result == "guard_blocked"
+    assert "opposite pending order" in outcomes[0].detail["error"].lower()
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "pending_approval"
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.target_broker_order_id == "broker-1"
 
 
 def test_toss_decimal_args_are_exact_and_canonical():

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -17,6 +17,7 @@ from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalInvalidStateTransition,
     OrderProposalNotFound,
+    OrderProposalUnsupportedTargetAction,
 )
 from app.services.order_proposals.service import ExpirySweepResult, RungInput
 
@@ -181,6 +182,84 @@ async def test_target_actions_reject_unsupported_account_market_tuple(
         await OrderProposalsService(db_session).create_proposal(
             **_target_action_create_kwargs(action, account_mode="kis_mock")
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["replace", "cancel"])
+@pytest.mark.parametrize("market", ["equity_kr", "equity_us"])
+async def test_target_actions_allow_toss_live_equities(db_session, action, market):
+    """ROB-972: toss_live x equity_kr/us must be a supported cancel/replace
+    target -- previously SUPPORTED_TARGET_ACTIONS had no toss_live entry at
+    all, so this raised 'cancel unsupported for toss_live/equity_kr' even
+    though the create-time contract message claimed it was allowed.
+    """
+    symbol = "005930" if market == "equity_kr" else "AAPL"
+    group = await OrderProposalsService(db_session).create_proposal(
+        **_target_action_create_kwargs(
+            action,
+            account_mode="toss_live",
+            market=market,
+            symbol=symbol,
+            target_order_snapshot=_target_snapshot_payload(symbol=symbol),
+        )
+    )
+    await db_session.commit()
+    assert group.account_mode == "toss_live"
+    assert group.market == market
+    assert group.action == action
+    assert group.target_broker_order_id == "manual-upbit-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["replace", "cancel"])
+async def test_target_action_rejection_message_matches_capability_set(
+    db_session, action
+):
+    """The rejection message must be derived from the same set the action
+    actually checks membership against -- not a different action's set (the
+    ROB-972 bug: cancel/replace rejections reused place's hardcoded message
+    and falsely advertised toss_live support they didn't have).
+    """
+    with pytest.raises(OrderProposalError) as exc_info:
+        await OrderProposalsService(db_session).create_proposal(
+            **_target_action_create_kwargs(action, account_mode="kis_mock")
+        )
+    assert str(exc_info.value) == (
+        f"unsupported account_mode/market/action: kis_mock/crypto/{action} "
+        "(allowed: kis_live×equity_kr|equity_us, "
+        "toss_live×equity_kr|equity_us, upbit×crypto; "
+        "market aliases kr→equity_kr, us→equity_us)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_target_action_rejection_supported_matrix_is_action_accurate(db_session):
+    with pytest.raises(OrderProposalUnsupportedTargetAction) as exc_info:
+        await OrderProposalsService(db_session).create_proposal(
+            **_target_action_create_kwargs(
+                "cancel", account_mode="toss_live", market="crypto"
+            )
+        )
+    err = exc_info.value
+    assert err.requested == {
+        "account_mode": "toss_live",
+        "market": "crypto",
+        "action": "cancel",
+    }
+    assert {"account_mode": "toss_live", "market": "equity_kr"} in (
+        err.supported_matrix["cancel"]
+    )
+    assert {"account_mode": "toss_live", "market": "equity_us"} in (
+        err.supported_matrix["cancel"]
+    )
+    assert {"account_mode": "toss_live", "market": "crypto"} not in (
+        err.supported_matrix["cancel"]
+    )
+    # replace shares cancel's capability set today but is derived
+    # independently -- assert both explicitly so a future divergence between
+    # the two actions' capability sets is caught here.
+    assert err.supported_matrix["replace"] == err.supported_matrix["cancel"]
+    assert err.supported_matrix["place"] == err.supported_matrix["cancel"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 
@@ -770,6 +772,243 @@ async def test_approve_happy_path_submits_and_edits(monkeypatch, db_session):
     assert refreshed.approval_nonce_used_at is not None
     assert refreshed.approved_by_telegram_user_id == str(USER_ID)
     assert refreshed.approved_at is not None
+
+
+def _toss_broker_order(**overrides):
+    values = {
+        "order_id": "broker-1",
+        "symbol": "005930",
+        "side": "SELL",
+        "order_type": "LIMIT",
+        "price": Decimal("70000"),
+        "quantity": Decimal("10"),
+        "execution": {},
+        "status": "PENDING",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_toss_live_cancel_approve_click_consumes_nonce_before_broker_cancel(
+    monkeypatch, db_session
+):
+    """ROB-972 AC3 -- the real 07-20 incident scenario, driven through the
+    actual Telegram approval boundary (nonce consumption via
+    `handle_callback_update`), not a direct `revalidate_and_submit` call.
+
+    ROB-972 round-1 finding: the previous "AC3" test called
+    `revalidate_and_submit` directly with no nonce/callback, so it could not
+    have caught a bug in the approval-boundary wiring itself (e.g. auto-
+    dispatch reaching a cancel before Telegram approval was ever consulted).
+    This test consumes a real approval nonce through `handle_callback_update`
+    -- exactly the human-click path -- and only then expects the broker
+    cancel to fire, with the *real* `revalidate_and_submit` (only the Toss
+    network boundary is faked, via a `revalidate_fn` partial bound onto the
+    real function, matching `test_toss_live_cancel_end_to_end_through_broker_gateway`'s
+    fakes).
+    """
+    from app.services.order_proposals.broker_gateway import (
+        cancel_target_order,
+        fetch_target_order,
+    )
+
+    _allow_chat(monkeypatch)
+    service = OrderProposalsService(db_session)
+    approved = TargetOrderSnapshot(
+        broker_order_id="broker-1",
+        symbol="005930",
+        side="sell",
+        order_type="limit",
+        limit_price="70000",
+        remaining_quantity="10",
+        status="open",
+        observed_at="2026-07-11T08:23:00+00:00",
+    )
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        action="cancel",
+        target_broker_order_id="broker-1",
+        target_order_snapshot=approved.to_payload(),
+        rungs=[RungInput(0, "sell", Decimal("10"), Decimal("70000"), None)],
+    )
+    await service.set_approval_nonce(group.proposal_id, "ac3-cancel-nonce")
+    await db_session.commit()
+
+    toss_orders = iter(
+        [
+            _toss_broker_order(status="PENDING"),
+            _toss_broker_order(status="CANCELED"),
+        ]
+    )
+
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            assert order_id == "broker-1"
+            return next(toss_orders)
+
+    cancel_calls: list[dict] = []
+
+    async def fake_toss_cancel(**kwargs):
+        cancel_calls.append(kwargs)
+        return {"success": True, "original_order_id": kwargs["order_id"]}
+
+    real_revalidate = functools.partial(
+        revalidate_and_submit,
+        fetch_target_fn=functools.partial(
+            fetch_target_order, toss_client=FakeTossClient()
+        ),
+        cancel_target_fn=functools.partial(
+            cancel_target_order, toss_cancel_fn=fake_toss_cancel
+        ),
+    )
+
+    notifier = _FakeNotifier()
+    data = f"op:{str(group.proposal_id)[:8]}:ac3-cancel-nonce"
+
+    # Before the nonce is consumed, the broker must not have been touched.
+    assert cancel_calls == []
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=real_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "approved"
+    assert result["results"] == ["cancelled"]
+    # The cancel only happened after (as a direct consequence of) this
+    # single approve click -- TELEGRAM_APPROVAL_SEND already happened
+    # earlier (dispatch.py, not under test here); this asserts the click
+    # itself, not a pre-approval leak, is what triggered BROKER_CANCEL.
+    assert len(cancel_calls) == 1
+    assert cancel_calls[0]["order_id"] == "broker-1"
+
+    refreshed, rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce_used_at is not None
+    assert refreshed.approved_by_telegram_user_id == str(USER_ID)
+    assert rungs[0].state == "cancelled"
+    assert rungs[0].broker_order_id == "broker-1"
+
+    # Nonce replay: a second click (e.g. a duplicated Telegram webhook) must
+    # not be able to re-trigger the cancel path.
+    replay = await handle_callback_update(
+        _make_update(data=data, callback_id="cbq-replay"),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=real_revalidate,
+    )
+    assert replay["handled"] is False
+    assert len(cancel_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_toss_live_replace_approve_click_opposite_pending_blocks_before_cancel(
+    monkeypatch, db_session
+):
+    """ROB-972 round-1 -- the replace-atomicity finding, through the real
+    approval boundary. An opposite-pending order discovered by the pre-cancel
+    guard must leave the original resting order untouched even when reached
+    via a real Telegram approve click, not just a direct
+    `revalidate_and_submit` call.
+    """
+    from app.services.order_proposals.broker_gateway import (
+        cancel_target_order,
+        fetch_target_order,
+    )
+
+    _allow_chat(monkeypatch)
+    service = OrderProposalsService(db_session)
+    approved = TargetOrderSnapshot(
+        broker_order_id="broker-1",
+        symbol="005930",
+        side="sell",
+        order_type="limit",
+        limit_price="70000",
+        remaining_quantity="10",
+        status="open",
+        observed_at="2026-07-11T08:23:00+00:00",
+    )
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        action="replace",
+        target_broker_order_id="broker-1",
+        target_order_snapshot=approved.to_payload(),
+        rungs=[RungInput(0, "sell", Decimal("10"), Decimal("71000"), None)],
+    )
+    await service.set_approval_nonce(group.proposal_id, "ac3-replace-nonce")
+    await db_session.commit()
+
+    class FakeTossClient:
+        async def get_order(self, order_id):
+            return _toss_broker_order(status="PENDING")
+
+    cancel_calls: list[dict] = []
+
+    async def fake_toss_cancel(**kwargs):
+        cancel_calls.append(kwargs)
+        raise AssertionError(
+            "the original order must not be cancelled when the "
+            "opposite-pending pre-check rejects the replace"
+        )
+
+    async def place_order_fn(**kwargs):
+        assert kwargs.get("dry_run") is True
+        return {
+            "success": True,
+            "approval_hash": "fresh",
+            "price": "71000",
+            "quantity": "10",
+        }
+
+    async def opposite_pending_found(**kwargs):
+        return {
+            "success": False,
+            "error": "An opposite pending order exists for symbol 005930 (BUY).",
+        }
+
+    real_revalidate = functools.partial(
+        revalidate_and_submit,
+        place_order_fn=place_order_fn,
+        fetch_target_fn=functools.partial(
+            fetch_target_order, toss_client=FakeTossClient()
+        ),
+        cancel_target_fn=functools.partial(
+            cancel_target_order, toss_cancel_fn=fake_toss_cancel
+        ),
+        opposite_pending_check_fn=opposite_pending_found,
+    )
+
+    notifier = _FakeNotifier()
+    result = await handle_callback_update(
+        _make_update(data=f"op:{str(group.proposal_id)[:8]}:ac3-replace-nonce"),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=real_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["results"] == ["guard_blocked"]
+    assert cancel_calls == []
+
+    refreshed, rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.target_broker_order_id == "broker-1"
+    assert rungs[0].state == "pending_approval"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -141,6 +141,98 @@ async def test_create_lookup_failure_returns_error_without_service_insert(monkey
     }
 
 
+def _toss_target_create_kwargs(action: str, *, market="equity_kr", **overrides):
+    symbol = "005930" if market == "equity_kr" else "AAPL"
+    return _create_kwargs(
+        symbol=symbol,
+        market=market,
+        account_mode="toss_live",
+        side="sell",
+        action=action,
+        target_broker_order_id="broker-1",
+        rungs=[
+            {
+                "rung_index": 0,
+                "side": "sell",
+                "quantity": "3.5",
+                "limit_price": "43000",
+                "notional": None,
+            }
+        ],
+        **overrides,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["replace", "cancel"])
+@pytest.mark.parametrize("market", ["equity_kr", "equity_us"])
+async def test_create_toss_live_target_action_preflights_and_creates_proposal(
+    monkeypatch, action, market
+):
+    """ROB-972: order_proposal_create(action='cancel'|'replace') must accept
+    toss_live x equity_kr/us. Only fetch_target_order (read-only preflight) is
+    ever imported/called by this tool -- broker_gateway.cancel_target_order
+    isn't imported here at all, so there is no code path for a mutation to
+    leak into proposal creation regardless of account_mode.
+    """
+    calls = []
+    symbol = "005930" if market == "equity_kr" else "AAPL"
+
+    async def fake_fetch(**kwargs):
+        calls.append(kwargs)
+        return _target_snapshot(
+            broker_order_id="broker-1",
+            symbol=symbol,
+            side="sell",
+            limit_price="43000",
+            remaining_quantity="3.5",
+        )
+
+    monkeypatch.setattr(opt, "fetch_target_order", fake_fetch)
+
+    created = await opt.order_proposal_create(
+        **_toss_target_create_kwargs(action, market=market)
+    )
+
+    assert created["success"] is True
+    assert created["action"] == action
+    assert created["target_broker_order_id"] == "broker-1"
+    assert len(calls) == 1
+    assert calls[0]["order_id"] == "broker-1"
+    assert calls[0]["symbol"] == symbol
+    assert calls[0]["market"] == market
+    assert calls[0]["account_mode"] == "toss_live"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["replace", "cancel"])
+async def test_create_rejects_toss_live_crypto_target_action_with_supported_matrix(
+    monkeypatch, action
+):
+    async def fetch_must_not_run(**kwargs):
+        raise AssertionError("unsupported combo must be rejected before any fetch")
+
+    monkeypatch.setattr(opt, "fetch_target_order", fetch_must_not_run)
+
+    result = await opt.order_proposal_create(
+        **_toss_target_create_kwargs(action, market="crypto")
+    )
+
+    assert result["success"] is False
+    assert "toss_live×equity_kr|equity_us" in result["error"]
+    assert result["requested"] == {
+        "account_mode": "toss_live",
+        "market": "crypto",
+        "action": action,
+    }
+    assert {"account_mode": "toss_live", "market": "equity_kr"} in (
+        result["supported_matrix"][action]
+    )
+    assert {"account_mode": "toss_live", "market": "crypto"} not in (
+        result["supported_matrix"][action]
+    )
+
+
 @pytest.mark.asyncio
 async def test_place_create_never_fetches_a_target(monkeypatch):
     async def fetch_must_not_run(**kwargs):

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -202,6 +203,111 @@ async def test_create_toss_live_target_action_preflights_and_creates_proposal(
     assert calls[0]["symbol"] == symbol
     assert calls[0]["market"] == market
     assert calls[0]["account_mode"] == "toss_live"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["replace", "cancel"])
+async def test_create_toss_live_cancel_replace_auto_dispatch_never_mutates_before_gate(
+    monkeypatch, action
+):
+    """ROB-972 round-1 false-green fix.
+
+    `test_create_toss_live_target_action_preflights_and_creates_proposal`'s
+    docstring claims there is "no code path for a mutation to leak into
+    proposal creation" because only the read-only `fetch_target_order`
+    preflight is imported by `order_proposal_create` -- but that test never
+    exercises `order_proposal_create`'s own best-effort `dispatch_proposal`
+    call a few lines later, which IS a real code path, and which is exactly
+    where the round-1 incident happened (auto-dispatch reaching a broker
+    cancel before the eligibility gate ran). Cover that indirect path for
+    real: enable Telegram + auto-approve, let `order_proposal_create` drive
+    its own real `dispatch_proposal` -> real `revalidate_and_submit` (only
+    the broker/network edges are faked, via a `revalidate_fn` partial bound
+    onto the real functions -- not a stub that skips the gate logic), and
+    assert the broker cancel never fires.
+    """
+    from app.services.order_proposals.dispatch import (
+        dispatch_proposal as real_dispatch_proposal,
+    )
+    from app.services.order_proposals.revalidation import revalidate_and_submit
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    chat = _unique_chat()
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+
+    fake_notifier = _FakeNotifier(message_id=9977)
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.notifier.get_trade_notifier",
+        lambda: fake_notifier,
+    )
+
+    target_snapshot = _target_snapshot(
+        broker_order_id="broker-1",
+        symbol="005930",
+        side="sell",
+        limit_price="43000",
+        remaining_quantity="3.5",
+    )
+
+    async def fake_fetch(**kwargs):
+        return target_snapshot
+
+    monkeypatch.setattr(opt, "fetch_target_order", fake_fetch)
+
+    cancel_calls = []
+
+    async def cancel_fn_must_not_run(**kwargs):
+        cancel_calls.append(kwargs)
+        raise AssertionError(
+            "order_proposal_create's own dispatch_proposal call must never "
+            "reach a broker cancel before the eligibility gate runs"
+        )
+
+    async def place_fn(**kwargs):
+        if kwargs.get("dry_run"):
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "43000",
+                "quantity": "3.5",
+            }
+        raise AssertionError("live submit must never fire before the gate runs")
+
+    async def no_opposite_pending(**kwargs):
+        return None
+
+    # Bind the fakes onto the REAL dispatch_proposal/revalidate_and_submit --
+    # not a stand-in that reimplements or skips the gate call -- so this
+    # test actually exercises the production gate-application code path.
+    monkeypatch.setattr(
+        opt,
+        "dispatch_proposal",
+        functools.partial(
+            real_dispatch_proposal,
+            revalidate_fn=functools.partial(
+                revalidate_and_submit,
+                fetch_target_fn=fake_fetch,
+                cancel_target_fn=cancel_fn_must_not_run,
+                place_order_fn=place_fn,
+                opposite_pending_check_fn=no_opposite_pending,
+            ),
+        ),
+    )
+
+    created = await opt.order_proposal_create(
+        **_toss_target_create_kwargs(action, market="equity_kr")
+    )
+
+    assert created["success"] is True
+    assert cancel_calls == []
+    assert len(fake_notifier.calls) == 1
+    text, _keyboard, _chat_id = fake_notifier.calls[0]
+    assert "주문 제안 승인" in text
+    assert "자동 접수됨" not in text
+
+    got = await opt.order_proposal_get(created["proposal_id"])
+    assert got["rungs"][0]["state"] == "pending_approval"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

07-20 incident: a session tried to cancel an approved resting toss_live×equity_kr order and hit three simultaneous blockers, burning 30 minutes with zero cancel mechanism available. This PR closes the middle one:

- `order_proposal_void` still correctly refuses resting rungs (unchanged, by design).
- `order_proposal_create(action="cancel"|"replace")` now supports `toss_live × equity_kr|equity_us` — previously `SUPPORTED_TARGET_ACTIONS` only had `kis_live` and `upbit` entries at all, so this combination was unconditionally rejected.
- Direct `toss_cancel_order` calls remain outside the approved playbook execution boundary (unchanged, by design) — this PR does not touch that gate.

**Root cause finding beyond the ticket's own diagnosis:** the rejection message (`_ALLOWED_ACTION_CONTRACT_MESSAGE`) was a single hardcoded string shared by `place`/`replace`/`cancel`. It happened to be accurate for `place` (which already supported `toss_live`) but was reused verbatim for `replace`/`cancel` rejections — so operators were told `toss_live` was "allowed" while being rejected. This is very likely what drove the 30-minute stall (a user chasing an error message that lied).

## What changed

1. **Capability wiring** (`broker_gateway.py`): `SUPPORTED_TARGET_ACTIONS` gains `(toss_live, equity_kr)` and `(toss_live, equity_us)`. Verified the lower layers did **not** already support toss before this PR:
   - `fetch_target_order`'s default `history_fn` (`get_order_history_impl`) is KIS/Upbit-only, no `account_mode` param at all — dispatches purely on market via `_fetch_kr_orders`/`_fetch_us_orders` (KIS) / `_fetch_crypto_orders` (Upbit).
   - `cancel_target_order`'s default `cancel_fn` (`cancel_order_impl`) is likewise KIS/Upbit-only.
   - So this PR adds the actual toss dispatch: a new `_fetch_toss_target_order` (read-only `GET /api/v1/orders/{orderId}` via `TossReadClient.get_order`, broker status enum -> snapshot status mapping) and a `toss_live` branch in `cancel_target_order` that delegates to the production `toss_cancel_order` tool (`dry_run=False, confirm=True`), preserving its own `TOSS_LIVE_ORDER_MUTATIONS_ENABLED` gate and ledger recording.
2. **Bug fix in `revalidation.py`**: `_revalidate_replace_rung` never generated a Toss `client_order_id` (only handled `account_mode == "upbit"`) — a toss_live replace's live submit step would always have failed `invalid_toss_client_order_id`. Fixed to match the existing `_toss_proposal_client_order_id` pattern used elsewhere in the same file. Verified as a real RED->GREEN regression (reverted the one-line fix locally, confirmed the new e2e test fails with `KeyError`, restored, confirmed green).
3. **`supported_matrix` + accurate messages** (`service.py`, `errors.py`, `order_proposal_tools.py`): extracted `check_action_capability()`, generates the "allowed: ..." text and a structured `supported_matrix` from the actual per-action capability sets (`_ACTION_CAPABILITIES`) instead of a hardcoded string, via a new `OrderProposalUnsupportedTargetAction` exception carrying `supported_matrix` + `requested`. Also had to move this check to run **before** `fetch_target_order`'s own preflight call in `order_proposal_create` — otherwise `fetch_target_order`'s narrower, unstructured `SUPPORTED_TARGET_ACTIONS` gate would fire first on an unsupported combo, and the new structured error would never be reached through the real tool.
4. **Regression guard found and fixed**: `evaluate_auto_approve_eligibility` (`auto_approve.py`) was reusing `SUPPORTED_TARGET_ACTIONS` as its "auto-veto capable" gate. Widening that set for cancel/replace support would have silently made `toss_live` eligible for auto-approve too (skipping the Telegram click entirely for live orders) — caught by an existing test (`test_ineligible_orders_fail_closed[...account_not_veto_capable]`) going from `eligible=False` to `eligible=True`. Decoupled into its own `_VETO_CAPABLE_ACCOUNT_MARKETS`, unchanged from prior behavior (`kis_live` + `upbit` only).

## Explicitly unchanged (scope boundary honored)

- No migration.
- No new MCP tool.
- Approval/nonce/Telegram two-step logic untouched.
- No real broker calls anywhere in tests (fake/stub only).
- `order_proposal_create`'s cancel/replace path performs only a read-only preflight (`fetch_target_order` / `GET /api/v1/orders/{orderId}`); the actual broker cancel only happens post-approval in `revalidate_and_submit`.

## Test plan

- [x] `uv run pytest tests/ -q -k "proposal"` — 594 passed
- [x] `uv run pytest tests/ -q -k "toss"` — 693 passed, 3 skipped
- [x] `uv run pytest tests/ -q -k "order_proposal or broker_gateway"` — 526 passed
- [x] `make lint` — ruff check / ruff format / ty all clean
- [x] `git diff --check` — clean
- [x] `uv run alembic heads` — single head, unchanged (no migration)
- [x] RED->GREEN verified locally for the two ROB-972-specific bugs (missing `toss_live` capability, missing replace `client_order_id`) by reverting the fix, confirming test failure, and restoring
- [ ] `gh pr checks` (posting once CI settles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)