### PR TITLE
ROB-983 CP8

### DIFF
--- a/research/nautilus_scalping/rob974_h5_canonical.py
+++ b/research/nautilus_scalping/rob974_h5_canonical.py
@@ -52,11 +52,13 @@ from rob974_h5_contracts import (
     EnvelopeValidationResult,
     H4AttributionContractResult,
     H5InputError,
-    H6AAccountingSeal,
+    H6AAccountingContractResult,
+    H6AAccountingInput,
     MetricTrade,
     config_ids_for,
     consume_h4_attribution,
     fixture_h4_attribution_result,
+    resolve_h6a_accounting_contract,
     validate_envelope_and_accounting,
 )
 from rob974_h5_dual_evidence import (
@@ -105,7 +107,7 @@ __all__ = [
     "validate_scorecard_consistency",
 ]
 
-SCHEMA_VERSION = "h5_scorecard_v2"
+SCHEMA_VERSION = "h5_scorecard_v3"
 ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED = "NOT_EVALUATED"
 CLOSED_STATUS_ORDER: tuple[str, ...] = ("completed", "rejected", "crashed", "timeout")
 
@@ -317,6 +319,7 @@ class ScorecardConsistencyResult:
     s4_direct_verdict: str
     campaign_decision: CampaignDecisionResult
     h4_attribution_cross_check: H4AttributionCrossCheck | None
+    h6a_contract: H6AAccountingContractResult
 
 
 def _validate_h4_campaign_binding(
@@ -495,7 +498,7 @@ def _rank_metrics_from_strategy_inputs(
 def validate_scorecard_consistency(
     *,
     envelope: CampaignEnvelope,
-    h6a_seal: H6AAccountingSeal,
+    h6a_seal: H6AAccountingInput,
     envelope_ok: bool,
     envelope_incomplete_reasons: tuple[str, ...],
     h4_attribution: H4AttributionContractResult,
@@ -534,7 +537,16 @@ def validate_scorecard_consistency(
             "canonical_h4_attribution_reprojection_mismatch",
         )
         _validate_h4_campaign_binding(envelope=envelope, h4_attribution=h4_attribution)
-    recomputed_envelope = validate_envelope_and_accounting(envelope, h6a_seal)
+    h6a_contract = resolve_h6a_accounting_contract(h6a_seal)
+    resolved_h6a_seal = h6a_contract.seal
+    if resolved_h6a_seal is None:
+        raise H5InputError("canonical_h6a_contract_not_evaluated")
+    if h6a_contract.actual_h6a_contract == "PASS":
+        _require(
+            h6a_contract.campaign_run_id == envelope.campaign_run_id,
+            "actual_h6a_campaign_run_id_mismatch",
+        )
+    recomputed_envelope = validate_envelope_and_accounting(envelope, resolved_h6a_seal)
     _require(
         envelope_ok == recomputed_envelope.ok
         and envelope_incomplete_reasons == recomputed_envelope.incomplete_reasons,
@@ -645,6 +657,7 @@ def validate_scorecard_consistency(
         s4_direct_verdict=recomputed_s4_verdict,
         campaign_decision=recomputed_campaign,
         h4_attribution_cross_check=h4_cross_check,
+        h6a_contract=h6a_contract,
     )
 
 
@@ -1209,7 +1222,7 @@ def _canonicalize_strategy(
 def build_canonical_scorecard(
     *,
     envelope: CampaignEnvelope,
-    h6a_seal: H6AAccountingSeal,
+    h6a_seal: H6AAccountingInput,
     envelope_ok: bool,
     envelope_incomplete_reasons: tuple[str, ...],
     h4_attribution: H4AttributionContractResult,
@@ -1258,29 +1271,34 @@ def build_canonical_scorecard(
         "h6a_trial_accounting_hash": envelope.h6a_trial_accounting_hash,
         "actual_h4_ledger_key": ACTUAL_H4_LEDGER_KEY_NOT_EVALUATED,
     }
+    resolved_h6a_seal = consistency.h6a_contract.seal
+    if resolved_h6a_seal is None:
+        raise H5InputError("canonical_h6a_contract_not_evaluated")
     h6a_accounting = {
+        "actual_h6a_contract": consistency.h6a_contract.actual_h6a_contract,
         "expected_total": _exact_int(
-            h6a_seal.expected_total, "h6a_expected_total_malformed"
+            resolved_h6a_seal.expected_total, "h6a_expected_total_malformed"
         ),
         "registered_total": _exact_int(
-            h6a_seal.registered_total, "h6a_registered_total_malformed"
+            resolved_h6a_seal.registered_total, "h6a_registered_total_malformed"
         ),
         "primary_attempts": _exact_int(
-            h6a_seal.primary_attempts, "h6a_primary_attempts_malformed"
+            resolved_h6a_seal.primary_attempts, "h6a_primary_attempts_malformed"
         ),
         "status_counts": {
             status: _exact_int(
-                h6a_seal.status_counts[status], "h6a_status_count_malformed"
+                resolved_h6a_seal.status_counts[status],
+                "h6a_status_count_malformed",
             )
             for status in CLOSED_STATUS_ORDER
         },
         "retry_attempts": _exact_int(
-            h6a_seal.retry_attempts, "h6a_retry_attempts_malformed"
+            resolved_h6a_seal.retry_attempts, "h6a_retry_attempts_malformed"
         ),
-        "accounting_complete": h6a_seal.accounting_complete,
-        "performance_usable": h6a_seal.performance_usable,
-        "trial_accounting_hash": h6a_seal.trial_accounting_hash,
-        "reason_codes": sorted(h6a_seal.reason_codes),
+        "accounting_complete": resolved_h6a_seal.accounting_complete,
+        "performance_usable": resolved_h6a_seal.performance_usable,
+        "trial_accounting_hash": resolved_h6a_seal.trial_accounting_hash,
+        "reason_codes": sorted(resolved_h6a_seal.reason_codes),
     }
     envelope_validation = {
         "ok": consistency.envelope_validation.ok,

--- a/research/nautilus_scalping/rob974_h5_contracts.py
+++ b/research/nautilus_scalping/rob974_h5_contracts.py
@@ -32,6 +32,7 @@ from rob974_h4_runner import (
     SelectedOOSAttributionEnvelope,
     validate_attribution_envelope,
 )
+from rob974_h6a_accounting import CombinedAccountingReport
 
 __all__ = [
     "CONFIGS_PER_STRATEGY",
@@ -47,6 +48,9 @@ __all__ = [
     "EnvelopeValidationResult",
     "H5InputError",
     "H6AAccountingSeal",
+    "H6AAccountingInput",
+    "H6AAccountingContractResult",
+    "H6A_CONTRACT_STATUSES",
     "FAKE_FREE_EMPIRICAL_CLOSURE",
     "MARKET_RETURN_SEMANTIC",
     "MetricTrade",
@@ -57,6 +61,7 @@ __all__ = [
     "config_ids_for",
     "consume_h4_attribution",
     "fixture_h4_attribution_result",
+    "resolve_h6a_accounting_contract",
     "validate_envelope_and_accounting",
 ]
 
@@ -76,6 +81,7 @@ S4_EXIT_REASONS: tuple[str, ...] = ("TP", "SL", "MEAN_EXIT", "STALL_EXIT", "TIME
 _EXPECTED_TOTAL_EXPERIMENTS = 48
 _CLOSED_STATUSES = ("completed", "rejected", "crashed", "timeout")
 _LOWERCASE_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+H6A_CONTRACT_STATUSES = ("PASS", "FIXTURE_ONLY", "NOT_EVALUATED")
 
 
 class H5InputError(ValueError):
@@ -293,6 +299,173 @@ class H6AAccountingSeal:
         )
         if self.performance_usable:
             _require(exact_48_all_completed, "h6a_usable_true_with_incomplete_counters")
+
+
+H6AAccountingInput = CombinedAccountingReport | H6AAccountingSeal | None
+
+
+@dataclass(frozen=True, slots=True)
+class H6AAccountingContractResult:
+    """Normalized H6-A provenance plus the H5 accounting projection.
+
+    ``PASS`` can only be produced from H6-A's own ``CombinedAccountingReport``
+    type.  A directly constructed H5 ``H6AAccountingSeal`` is useful for
+    hermetic predecessor tests but is always ``FIXTURE_ONLY`` even when its
+    digest happens to equal a production digest.  ``NOT_EVALUATED`` carries
+    no seal and therefore cannot reach canonical scorecard assembly.
+    """
+
+    actual_h6a_contract: str
+    seal: H6AAccountingSeal | None
+    campaign_run_id: str | None
+
+    def __post_init__(self) -> None:
+        _require(
+            self.actual_h6a_contract in H6A_CONTRACT_STATUSES,
+            "h6a_contract_status_unknown",
+        )
+        if self.actual_h6a_contract == "PASS":
+            _require(
+                type(self.seal) is H6AAccountingSeal,
+                "actual_h6a_contract_seal_missing",
+            )
+            _require(
+                type(self.campaign_run_id) is str and self.campaign_run_id != "",
+                "actual_h6a_contract_campaign_run_id_missing",
+            )
+        elif self.actual_h6a_contract == "FIXTURE_ONLY":
+            _require(
+                type(self.seal) is H6AAccountingSeal,
+                "fixture_h6a_contract_seal_missing",
+            )
+            _require(
+                self.campaign_run_id is None,
+                "fixture_h6a_contract_cannot_claim_campaign_run_id",
+            )
+        else:
+            _require(
+                self.seal is None and self.campaign_run_id is None,
+                "not_evaluated_h6a_contract_must_be_empty",
+            )
+
+
+def _seal_actual_h6a_report(report: CombinedAccountingReport) -> H6AAccountingSeal:
+    """Project H6-A's sealed report without reconstructing its trial hash."""
+    _require(
+        type(report.campaign_run_id) is str and report.campaign_run_id != "",
+        "actual_h6a_campaign_run_id_malformed",
+    )
+    for value, reason in (
+        (report.expected_total, "actual_h6a_expected_total_malformed"),
+        (report.registered_total, "actual_h6a_registered_total_malformed"),
+        (report.primary_attempts, "actual_h6a_primary_attempts_malformed"),
+        (report.total_attempts, "actual_h6a_total_attempts_malformed"),
+        (report.retry_attempts, "actual_h6a_retry_attempts_malformed"),
+    ):
+        _require_exact_int(value, reason)
+    _require(
+        report.expected_total == _EXPECTED_TOTAL_EXPERIMENTS,
+        "actual_h6a_expected_total_not_48",
+    )
+    _require(
+        type(report.status_counts) is dict,
+        "actual_h6a_status_counts_malformed",
+    )
+    status_counts = dict(report.status_counts)
+    _require(
+        set(status_counts) == set(_CLOSED_STATUSES),
+        "actual_h6a_status_counts_malformed",
+    )
+    for count in status_counts.values():
+        _require_exact_int(count, "actual_h6a_status_count_malformed")
+    _require(
+        sum(status_counts.values()) == report.total_attempts,
+        "actual_h6a_status_sum_forged_or_stale",
+    )
+    _require(
+        report.total_attempts == report.primary_attempts + report.retry_attempts,
+        "actual_h6a_attempt_totals_forged_or_stale",
+    )
+    # H5 scores only the retry-free primary surface.  A real retry report is
+    # valid H6-A evidence, but cannot be projected into H5's primary-status
+    # seal without the underlying per-attempt rows; fail closed instead.
+    _require(
+        report.retry_attempts == 0,
+        "actual_h6a_retry_report_not_h5_scoreable",
+    )
+    for values, reason in (
+        (report.missing_row_ids, "actual_h6a_missing_row_ids_malformed"),
+        (report.extra_experiment_ids, "actual_h6a_extra_ids_malformed"),
+        (report.mismatch_row_ids, "actual_h6a_mismatch_row_ids_malformed"),
+        (
+            report.duplicate_or_gap_row_ids,
+            "actual_h6a_duplicate_or_gap_row_ids_malformed",
+        ),
+    ):
+        _require(
+            type(values) is tuple and all(type(value) is str for value in values),
+            reason,
+        )
+    _require(
+        type(report.accounting_complete) is bool
+        and type(report.all_primary_completed) is bool
+        and type(report.performance_usable) is bool,
+        "actual_h6a_boolean_status_malformed",
+    )
+    structural_gaps = (
+        report.missing_row_ids
+        + report.extra_experiment_ids
+        + report.mismatch_row_ids
+        + report.duplicate_or_gap_row_ids
+    )
+    expected_complete = (
+        report.registered_total == _EXPECTED_TOTAL_EXPERIMENTS
+        and report.primary_attempts == _EXPECTED_TOTAL_EXPERIMENTS
+        and not structural_gaps
+    )
+    _require(
+        report.accounting_complete == expected_complete,
+        "actual_h6a_accounting_complete_forged_or_stale",
+    )
+    expected_all_completed = (
+        expected_complete and status_counts["completed"] == _EXPECTED_TOTAL_EXPERIMENTS
+    )
+    _require(
+        report.all_primary_completed == expected_all_completed,
+        "actual_h6a_all_primary_completed_forged_or_stale",
+    )
+    _require(
+        report.performance_usable == expected_all_completed,
+        "actual_h6a_performance_usable_forged_or_stale",
+    )
+    return H6AAccountingSeal(
+        expected_total=report.expected_total,
+        registered_total=report.registered_total,
+        primary_attempts=report.primary_attempts,
+        status_counts=status_counts,
+        retry_attempts=report.retry_attempts,
+        accounting_complete=report.accounting_complete,
+        performance_usable=report.performance_usable,
+        trial_accounting_hash=report.trial_accounting_hash,
+        reason_codes=() if report.performance_usable else ("h6_accounting_incomplete",),
+    )
+
+
+def resolve_h6a_accounting_contract(
+    value: H6AAccountingInput,
+) -> H6AAccountingContractResult:
+    """Resolve the closed H6-A provenance domain without hash heuristics."""
+    if value is None:
+        return H6AAccountingContractResult("NOT_EVALUATED", None, None)
+    if type(value) is H6AAccountingSeal:
+        return H6AAccountingContractResult("FIXTURE_ONLY", value, None)
+    if type(value) is CombinedAccountingReport:
+        return H6AAccountingContractResult(
+            "PASS",
+            _seal_actual_h6a_report(value),
+            value.campaign_run_id,
+        )
+    raise H5InputError("h6a_accounting_contract_input_type_unknown")
 
 
 @dataclass(frozen=True, slots=True)

--- a/research/nautilus_scalping/rob974_h5_markdown.py
+++ b/research/nautilus_scalping/rob974_h5_markdown.py
@@ -309,6 +309,7 @@ def render_markdown(canonical: Mapping[str, Any]) -> bytes:
 
     h6a = canonical["h6a_accounting"]
     lines.append("## H6-A Accounting")
+    lines.append(f"- actual_h6a_contract: {h6a['actual_h6a_contract']}")
     lines.append(f"- expected_total: {h6a['expected_total']}")
     lines.append(f"- registered_total: {h6a['registered_total']}")
     lines.append(f"- accounting_complete: {_fmt(h6a['accounting_complete'])}")

--- a/research/nautilus_scalping/tests/test_rob1001_h5_attribution.py
+++ b/research/nautilus_scalping/tests/test_rob1001_h5_attribution.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import replace
 
 import pytest
+import rob974_h6a_accounting as h6a_accounting
 import test_rob974_h5_cp6_canonical_json as cp6fx
 import test_rob1001_h45_attribution as h4fx
 from rob974_h4_runner import (
@@ -20,10 +22,12 @@ from rob974_h5_canonical import (
     canonical_json_bytes,
 )
 from rob974_h5_contracts import (
+    H6A_CONTRACT_STATUSES,
     CampaignEnvelope,
     H5InputError,
     consume_h4_attribution,
     fixture_h4_attribution_result,
+    resolve_h6a_accounting_contract,
 )
 from rob974_h5_dual_evidence import (
     PathInvocationEvidence,
@@ -304,6 +308,40 @@ def _campaign_envelope_for_h4(h4_envelope, **overrides) -> CampaignEnvelope:
     return cp6fx._envelope(**fields)
 
 
+def _production_h6a_report(plan):
+    """Exercise H6-A's production accounting builder against the exact H4 plan.
+
+    The attempt rows are hermetic integration evidence, not an empirical
+    campaign claim.  What is under test is the real H6-A reconstruction and
+    trial-seal type crossing the H5 boundary without an H5 fixture seal.
+    """
+    attempts = tuple(
+        h6a_accounting.AttemptAccountingRow(
+            row_id=spec.row_id,
+            experiment_id=spec.experiment_id,
+            retry_index=0,
+            status="completed",
+            reason_code=None,
+            fold_evidence_hash=hashlib.sha256(
+                f"rob983-cp8-fold:{spec.experiment_id}".encode()
+            ).hexdigest(),
+            run_identity=hashlib.sha256(
+                f"rob983-cp8-run:{plan.campaign_run_id}:{spec.experiment_id}".encode()
+            ).hexdigest(),
+        )
+        for spec in plan.row_specs
+    )
+    return h6a_accounting.build_combined_accounting(
+        campaign_run_id=plan.campaign_run_id,
+        canonical_row_ids=tuple(spec.row_id for spec in plan.row_specs),
+        row_id_to_experiment_id={
+            spec.row_id: spec.experiment_id for spec in plan.row_specs
+        },
+        registered_total=len(plan.row_specs),
+        attempts=attempts,
+    )
+
+
 def _actual_canonical_inputs(contract):
     paths_by_strategy = {"S3": {}, "S4": {}}
     for path in contract.envelope.paths:
@@ -370,8 +408,15 @@ def _actual_canonical_inputs(contract):
     return strategy_inputs["S3"], strategy_inputs["S4"]
 
 
-def _build_actual_scorecard(actual_h4_contract, **envelope_overrides):
-    _, h4_envelope, contract = actual_h4_contract
+def _build_actual_scorecard(
+    actual_h4_contract, *, h6a_input=None, **envelope_overrides
+):
+    plan, h4_envelope, contract = actual_h4_contract
+    if h6a_input is None:
+        h6a_input = _production_h6a_report(plan)
+    envelope_overrides.setdefault(
+        "h6a_trial_accounting_hash", h6a_input.trial_accounting_hash
+    )
     s3_inputs, s4_inputs = _actual_canonical_inputs(contract)
     campaign = compute_campaign_decision(
         s3_direct_verdict=s3_inputs.direct_verdict,
@@ -379,7 +424,7 @@ def _build_actual_scorecard(actual_h4_contract, **envelope_overrides):
     )
     return build_canonical_scorecard(
         envelope=_campaign_envelope_for_h4(h4_envelope, **envelope_overrides),
-        h6a_seal=cp6fx._seal(),
+        h6a_seal=h6a_input,
         envelope_ok=True,
         envelope_incomplete_reasons=(),
         h4_attribution=contract,
@@ -394,7 +439,8 @@ def test_canonical_json_seals_actual_contract_raw_rows_and_registered_bins(
 ):
     scorecard = _build_actual_scorecard(actual_h4_contract)
     contract = scorecard["h4_attribution_contract"]
-    assert scorecard["schema_version"] == "h5_scorecard_v2"
+    assert scorecard["schema_version"] == "h5_scorecard_v3"
+    assert scorecard["h6a_accounting"]["actual_h6a_contract"] == "PASS"
     assert contract["actual_h4_contract"] == "PASS"
     assert contract["contract_provenance"] == "actual"
     assert contract["market_return_semantic"] == "M_t_24h_median_log_return"
@@ -436,6 +482,7 @@ def test_canonical_json_seals_actual_contract_raw_rows_and_registered_bins(
 
 def test_markdown_renders_only_canonical_attribution_contract(actual_h4_contract):
     markdown = render_markdown(_build_actual_scorecard(actual_h4_contract)).decode()
+    assert "actual_h6a_contract: PASS" in markdown
     assert "## H4 Attribution Contract" in markdown
     assert "actual_h4_contract: PASS" in markdown
     assert "contract_provenance: actual" in markdown
@@ -462,6 +509,7 @@ def test_fixture_canonical_status_is_explicit_and_has_no_raw_rows():
         ),
     )
     assert scorecard["h4_attribution_contract"]["actual_h4_contract"] == "FIXTURE_ONLY"
+    assert scorecard["h6a_accounting"]["actual_h6a_contract"] == "FIXTURE_ONLY"
     assert scorecard["h4_attribution_contract"]["typed_path_cross_check"] == (
         "NOT_APPLICABLE"
     )
@@ -501,6 +549,52 @@ def test_deferred_canonical_status_forces_zero_paths_and_rows(actual_h4_contract
 def test_canonical_rejects_stale_campaign_source_pin(actual_h4_contract):
     with pytest.raises(H5InputError, match="runner_source_pin_mismatch"):
         _build_actual_scorecard(actual_h4_contract, h4_runner_source_hash="f" * 64)
+
+
+def test_fixture_h6a_seal_can_never_claim_actual_pass(actual_h4_contract):
+    plan, _, _ = actual_h4_contract
+    production_report = _production_h6a_report(plan)
+    literal_fixture = cp6fx._seal()
+    assert literal_fixture.trial_accounting_hash == "b" * 64
+    same_digest_fixture = cp6fx._seal(
+        trial_accounting_hash=production_report.trial_accounting_hash
+    )
+    for fixture_seal in (literal_fixture, same_digest_fixture):
+        scorecard = _build_actual_scorecard(
+            actual_h4_contract,
+            h6a_input=fixture_seal,
+        )
+        assert scorecard["h4_attribution_contract"]["actual_h4_contract"] == "PASS"
+        assert scorecard["h6a_accounting"]["actual_h6a_contract"] == "FIXTURE_ONLY"
+        assert scorecard["h6a_accounting"]["actual_h6a_contract"] != "PASS"
+
+
+def test_actual_h6a_report_must_bind_campaign_run_id(actual_h4_contract):
+    plan, _, _ = actual_h4_contract
+    forged_report = replace(
+        _production_h6a_report(plan),
+        campaign_run_id="rob974h6a-forged",
+    )
+    with pytest.raises(H5InputError, match="actual_h6a_campaign_run_id_mismatch"):
+        _build_actual_scorecard(actual_h4_contract, h6a_input=forged_report)
+
+
+def test_h6a_contract_status_domain_and_not_evaluated_sentinel_are_closed():
+    assert H6A_CONTRACT_STATUSES == ("PASS", "FIXTURE_ONLY", "NOT_EVALUATED")
+    result = resolve_h6a_accounting_contract(None)
+    assert result.actual_h6a_contract == "NOT_EVALUATED"
+    assert result.seal is None
+    assert result.campaign_run_id is None
+
+
+def test_actual_h6a_report_stale_usable_flag_is_rejected(actual_h4_contract):
+    plan, _, _ = actual_h4_contract
+    forged_report = replace(
+        _production_h6a_report(plan),
+        performance_usable=False,
+    )
+    with pytest.raises(H5InputError, match="performance_usable_forged_or_stale"):
+        resolve_h6a_accounting_contract(forged_report)
 
 
 def test_canonical_rejects_aggregate_not_derived_from_h4_rows(actual_h4_contract):

--- a/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_cp7_markdown_and_smoke.py
@@ -12,7 +12,7 @@ dual_evidence -> gates -> S3/S4 falsification -> canonical -> markdown)
 covering every campaign-decision branch.
 
 ``contract_fixture_scorecard_smoke=PASS`` / ``actual_h4_contract=
-FIXTURE_ONLY`` / ``actual_h6a_contract=NOT_EVALUATED`` /
+FIXTURE_ONLY`` / ``actual_h6a_contract=FIXTURE_ONLY`` /
 ``db_sessions_created=0`` / ``db_queries=0`` / ``db_writes=0`` /
 ``commit_calls=0`` / ``rollback_calls=0`` / ``empirical_runs=0`` /
 ``corpus_campaign_runs=0`` / ``physical_stage_publish_calls=0`` -- this
@@ -789,7 +789,7 @@ class TestNeverCallsWriterOrPhysicalIO:
 # semantic OR presentation change requires a conscious re-freeze, never a
 # silent drift.
 _GOLDEN_MARKDOWN_BYTES = (
-    b"# H5 Scorecard (h5_scorecard_v2)\n\n"
+    b"# H5 Scorecard (h5_scorecard_v3)\n\n"
     b"## Lineage\n"
     b"- campaign_run_id: run-cp7\n"
     b"- full_campaign_hash: " + b"a" * 64 + b"\n"
@@ -797,6 +797,7 @@ _GOLDEN_MARKDOWN_BYTES = (
     b"- generator_version: g1\n"
     b"- actual_h4_ledger_key: NOT_EVALUATED\n\n"
     b"## H6-A Accounting\n"
+    b"- actual_h6a_contract: FIXTURE_ONLY\n"
     b"- expected_total: 48\n"
     b"- registered_total: 48\n"
     b"- accounting_complete: true\n"

--- a/research/nautilus_scalping/tests/test_rob974_h5_import_guard.py
+++ b/research/nautilus_scalping/tests/test_rob974_h5_import_guard.py
@@ -65,6 +65,7 @@ _ALLOWED = {
     "re",
     "typing",
     "rob974_h4_runner",
+    "rob974_h6a_accounting",
     "rob974_h5_canonical",
     "rob974_h5_contracts",
     "rob974_h5_dual_evidence",


### PR DESCRIPTION
## Summary
- consume the production H6-A CombinedAccountingReport at the H5 canonical choke point
- emit the closed actual_h6a_contract status domain: PASS, FIXTURE_ONLY, NOT_EVALUATED
- bind actual H6-A campaign_run_id and trial hash to the actual H4 envelope
- keep direct H5 fixture seals fail-closed as FIXTURE_ONLY, including the bbbb digest fixture
- bump the canonical scorecard to h5_scorecard_v3 and render the new status in Markdown

## Verification
- TDD RED: 4 expected failures before implementation
- 406 passed across ROB-1001, H4, H5, H6-A accounting/smoke, and frozen guard suites
- Ruff check and format check passed
- ty checks passed
- frozen guard remains exact 45 entries: H4 8 plus H5 7, with no new production file
- full_campaign_hash remains 341a5a57ec14b7a499ea58d74de3b7d9c4b2c4e8bb514c789f6f528231a4045d

## Side effects
- empirical runs: 0
- DB, broker, order, fill, and artifact publish operations: 0