### PR TITLE
fix(ROB-1018): scope kis_mock reconciliation by market/symbol

### DIFF
--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -151,6 +151,7 @@ async def run_kis_mock_reconciliation(
     dry_run: bool = True,
     limit: int = 100,
     symbol: str | None = None,
+    market: str | None = None,
     thresholds: ReconcilerThresholds | None = None,
     kis_client: KISClient | None = None,
 ) -> dict[str, Any]:
@@ -158,11 +159,20 @@ async def run_kis_mock_reconciliation(
 
     ``symbol`` (ROB-404) restricts reconciliation to one symbol's open orders —
     the delta-budget kernel groups by (symbol, side) so a single-symbol pass is
-    self-consistent. ``None`` keeps the full-batch behavior.
+    self-consistent. ``market`` (ROB-1018) restricts to one ``instrument_type``
+    (e.g. ``equity_kr``/``equity_us``) — prevents a US-scoped run from proposing
+    transitions on KR rows (and vice versa). Both default to ``None``, which
+    keeps the full-batch behavior. Neither narrows the holdings snapshot
+    fetch (``_collect_kis_mock_holdings`` always fetches KR + US) — the
+    ROB-910 zero-synthesis fail-closed guard for out-of-scope-fetch symbols is
+    unaffected by order scoping.
     """
     thresholds = thresholds or ReconcilerThresholds()
     lifecycle_svc = KISMockLifecycleService(db)
-    open_rows = await lifecycle_svc.list_open_orders(limit=limit, symbol=symbol)
+    open_rows = await lifecycle_svc.list_open_orders(
+        limit=limit, symbol=symbol, instrument_type=market
+    )
+    scope = {"market": market, "symbol": symbol}
     if not open_rows:
         return {
             "success": True,
@@ -173,6 +183,7 @@ async def run_kis_mock_reconciliation(
             "dry_run": dry_run,
             "transitions": [],
             "events": [],
+            "scope": scope,
             "message": "No open KIS mock orders found",
         }
 
@@ -274,4 +285,5 @@ async def run_kis_mock_reconciliation(
         "dry_run": dry_run,
         "transitions": transition_logs,
         "events": events,
+        "scope": scope,
     }

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -667,6 +667,10 @@ async def _record_kis_mock_order(
 
 
 _MARKET_ALIASES = {"kr": "equity_kr", "us": "equity_us"}
+_ALLOWED_RECONCILE_MARKETS = frozenset({"equity_kr", "equity_us"})
+_ALLOWED_RECONCILE_MARKET_VALUES = sorted(_MARKET_ALIASES) + sorted(
+    _ALLOWED_RECONCILE_MARKETS
+)
 
 
 def _normalize_kis_mock_reconcile_market(market: str | None) -> str | None:
@@ -690,8 +694,28 @@ async def kis_mock_reconciliation_run_impl(
     resting orders to ``stale``). Both default to ``None``, preserving the
     prior full-scan behavior for existing callers (TaskIQ periodic task,
     unscoped MCP calls).
+
+    An unrecognized ``market`` (typo or unsupported venue) is rejected
+    explicitly rather than silently passed through — KIS mock only covers
+    KR/US equity (``equity_kr``/``equity_us``). A silent pass-through would
+    otherwise yield an ``orders_processed=0`` false-success indistinguishable
+    from "scope matched but nothing was open".
     """
     normalized_market = _normalize_kis_mock_reconcile_market(market)
+    if (
+        normalized_market is not None
+        and normalized_market not in _ALLOWED_RECONCILE_MARKETS
+    ):
+        return {
+            "success": False,
+            "error": (
+                f"unknown market '{market}' — allowed values: "
+                f"{_ALLOWED_RECONCILE_MARKET_VALUES}"
+            ),
+            "allowed_markets": _ALLOWED_RECONCILE_MARKET_VALUES,
+            "account_mode": "kis_mock",
+            "scope": {"market": market, "symbol": symbol},
+        }
     try:
         async with _order_session_factory()() as db:
             return await run_kis_mock_reconciliation(
@@ -708,6 +732,7 @@ async def kis_mock_reconciliation_run_impl(
             "error": str(exc),
             "source": "mcp",
             "account_mode": "kis_mock",
+            "scope": {"market": normalized_market, "symbol": symbol},
         }
 
 

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -673,7 +673,7 @@ _ALLOWED_RECONCILE_MARKET_VALUES = sorted(_MARKET_ALIASES) + sorted(
 )
 
 
-def _normalize_kis_mock_reconcile_market(market: str | None) -> str | None:
+def normalize_kis_mock_reconcile_market(market: str | None) -> str | None:
     if market is None:
         return None
     return _MARKET_ALIASES.get(market, market)
@@ -700,8 +700,16 @@ async def kis_mock_reconciliation_run_impl(
     KR/US equity (``equity_kr``/``equity_us``). A silent pass-through would
     otherwise yield an ``orders_processed=0`` false-success indistinguishable
     from "scope matched but nothing was open".
+
+    Response contract (ROB-1018 fix #2): every success/error path returns
+    the *effective* (canonical, alias-normalized) scope under ``scope`` —
+    e.g. a requested ``market="us"`` always echoes back as ``"equity_us"``.
+    The one exception is the unknown-market rejection below: since no valid
+    scope was ever established, it has no ``scope`` key and instead echoes
+    the verbatim, unnormalized request under ``requested_scope`` so callers
+    can't mistake it for a scope that actually ran.
     """
-    normalized_market = _normalize_kis_mock_reconcile_market(market)
+    normalized_market = normalize_kis_mock_reconcile_market(market)
     if (
         normalized_market is not None
         and normalized_market not in _ALLOWED_RECONCILE_MARKETS
@@ -714,7 +722,7 @@ async def kis_mock_reconciliation_run_impl(
             ),
             "allowed_markets": _ALLOWED_RECONCILE_MARKET_VALUES,
             "account_mode": "kis_mock",
-            "scope": {"market": market, "symbol": symbol},
+            "requested_scope": {"market": market, "symbol": symbol},
         }
     try:
         async with _order_session_factory()() as db:

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -679,6 +679,59 @@ def normalize_kis_mock_reconcile_market(market: str | None) -> str | None:
     return _MARKET_ALIASES.get(market, market)
 
 
+def resolve_kis_mock_reconcile_scope(
+    *, market: str | None, symbol: str | None
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Single front-layer point: validate, normalize, and shape the
+    reconciliation scope selector set (ROB-1018 fix #3).
+
+    This is the ONE place that (a) checks ``market`` against the allowlist
+    and (b) decides how the scope gets echoed back. Both the MCP tool
+    registration (front layer) and :func:`kis_mock_reconciliation_run_impl`
+    call this *same* function so the two layers can never shape the
+    response differently or disagree on what counts as a valid market —
+    that divergence (allowlist check only living in impl, reachable only
+    after config-error/confirm gates ran first) was the ROB-1018 round-3
+    defect. Callers must invoke this *before* any other gate (config error,
+    confirm-required) so an unknown market always short-circuits with the
+    same rejection shape regardless of what other conditions also hold.
+
+    Adding a new selector (e.g. ROB-1007's ``ledger_ids``) means adding a
+    parameter here and including it in both dicts below — no restructuring
+    of call sites or gating order.
+
+    Returns ``(scope, error)`` — exactly one is not ``None``:
+
+    - ``scope``: the effective/canonical selectors (alias-normalized
+      ``market``, e.g. ``"us"`` -> ``"equity_us"``), safe to use for the
+      rest of the request (further gating and the impl call itself).
+    - ``error``: a ready-to-return rejection dict for an unrecognized
+      ``market`` (typo or unsupported venue — KIS mock only covers
+      KR/US equity). It carries the verbatim, unnormalized request under
+      ``requested_scope`` (never ``scope``, since no valid scope was ever
+      established) so callers can't mistake it for a scope that actually
+      ran. A silent pass-through would otherwise yield an
+      ``orders_processed=0`` false-success indistinguishable from "scope
+      matched but nothing was open".
+    """
+    normalized_market = normalize_kis_mock_reconcile_market(market)
+    if (
+        normalized_market is not None
+        and normalized_market not in _ALLOWED_RECONCILE_MARKETS
+    ):
+        return None, {
+            "success": False,
+            "error": (
+                f"unknown market '{market}' — allowed values: "
+                f"{_ALLOWED_RECONCILE_MARKET_VALUES}"
+            ),
+            "allowed_markets": _ALLOWED_RECONCILE_MARKET_VALUES,
+            "account_mode": "kis_mock",
+            "requested_scope": {"market": market, "symbol": symbol},
+        }
+    return {"market": normalized_market, "symbol": symbol}, None
+
+
 async def kis_mock_reconciliation_run_impl(
     *,
     dry_run: bool = True,
@@ -695,43 +748,25 @@ async def kis_mock_reconciliation_run_impl(
     prior full-scan behavior for existing callers (TaskIQ periodic task,
     unscoped MCP calls).
 
-    An unrecognized ``market`` (typo or unsupported venue) is rejected
-    explicitly rather than silently passed through — KIS mock only covers
-    KR/US equity (``equity_kr``/``equity_us``). A silent pass-through would
-    otherwise yield an ``orders_processed=0`` false-success indistinguishable
-    from "scope matched but nothing was open".
-
-    Response contract (ROB-1018 fix #2): every success/error path returns
-    the *effective* (canonical, alias-normalized) scope under ``scope`` —
-    e.g. a requested ``market="us"`` always echoes back as ``"equity_us"``.
-    The one exception is the unknown-market rejection below: since no valid
-    scope was ever established, it has no ``scope`` key and instead echoes
-    the verbatim, unnormalized request under ``requested_scope`` so callers
-    can't mistake it for a scope that actually ran.
+    Response contract (ROB-1018 fix #2/#3): every success/error path
+    returns the *effective* (canonical, alias-normalized) scope under
+    ``scope`` — e.g. a requested ``market="us"`` always echoes back as
+    ``"equity_us"``. The one exception is the unknown-market rejection,
+    handled by :func:`resolve_kis_mock_reconcile_scope` before any other
+    work happens here: it has no ``scope`` key and instead echoes the
+    verbatim, unnormalized request under ``requested_scope``.
     """
-    normalized_market = normalize_kis_mock_reconcile_market(market)
-    if (
-        normalized_market is not None
-        and normalized_market not in _ALLOWED_RECONCILE_MARKETS
-    ):
-        return {
-            "success": False,
-            "error": (
-                f"unknown market '{market}' — allowed values: "
-                f"{_ALLOWED_RECONCILE_MARKET_VALUES}"
-            ),
-            "allowed_markets": _ALLOWED_RECONCILE_MARKET_VALUES,
-            "account_mode": "kis_mock",
-            "requested_scope": {"market": market, "symbol": symbol},
-        }
+    scope, scope_error = resolve_kis_mock_reconcile_scope(market=market, symbol=symbol)
+    if scope_error:
+        return scope_error
     try:
         async with _order_session_factory()() as db:
             return await run_kis_mock_reconciliation(
                 db,
                 dry_run=dry_run,
                 limit=limit,
-                market=normalized_market,
-                symbol=symbol,
+                market=scope["market"],
+                symbol=scope["symbol"],
             )
     except Exception as exc:
         logger.exception("Failed to run KIS mock reconciliation: %s", exc)
@@ -740,7 +775,7 @@ async def kis_mock_reconciliation_run_impl(
             "error": str(exc),
             "source": "mcp",
             "account_mode": "kis_mock",
-            "scope": {"market": normalized_market, "symbol": symbol},
+            "scope": scope,
         }
 
 

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -666,15 +666,41 @@ async def _record_kis_mock_order(
     }
 
 
+_MARKET_ALIASES = {"kr": "equity_kr", "us": "equity_us"}
+
+
+def _normalize_kis_mock_reconcile_market(market: str | None) -> str | None:
+    if market is None:
+        return None
+    return _MARKET_ALIASES.get(market, market)
+
+
 async def kis_mock_reconciliation_run_impl(
     *,
     dry_run: bool = True,
     limit: int = 100,
+    market: str | None = None,
+    symbol: str | None = None,
 ) -> dict[str, Any]:
-    """Execute KIS mock order reconciliation and return summary."""
+    """Execute KIS mock order reconciliation and return summary.
+
+    ``market``/``symbol`` (ROB-1018) narrow the open-order lookup so a
+    single-market/single-symbol reconciliation pass never proposes
+    transitions on out-of-scope rows (e.g. a US session no longer flips KR
+    resting orders to ``stale``). Both default to ``None``, preserving the
+    prior full-scan behavior for existing callers (TaskIQ periodic task,
+    unscoped MCP calls).
+    """
+    normalized_market = _normalize_kis_mock_reconcile_market(market)
     try:
         async with _order_session_factory()() as db:
-            return await run_kis_mock_reconciliation(db, dry_run=dry_run, limit=limit)
+            return await run_kis_mock_reconciliation(
+                db,
+                dry_run=dry_run,
+                limit=limit,
+                market=normalized_market,
+                symbol=symbol,
+            )
     except Exception as exc:
         logger.exception("Failed to run KIS mock reconciliation: %s", exc)
         return {

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -558,10 +558,17 @@ def register_order_tools(mcp: FastMCP) -> None:
         market: str | None = None,
         symbol: str | None = None,
     ):
-        scope = {
-            "market": kis_mock_ledger.normalize_kis_mock_reconcile_market(market),
-            "symbol": symbol,
-        }
+        # ROB-1018 fix #3: allowlist validation runs at this single
+        # front-layer point, BEFORE the config-error and confirm gates
+        # below — so an unknown market always short-circuits with the same
+        # rejection (requested_scope, no scope key) no matter what other
+        # conditions also hold. See resolve_kis_mock_reconcile_scope's
+        # docstring for why both layers must share this one function.
+        scope, scope_error = kis_mock_ledger.resolve_kis_mock_reconcile_scope(
+            market=market, symbol=symbol
+        )
+        if scope_error:
+            return scope_error
         config_error = _kis_mock_config_error()
         if config_error:
             return {**config_error, "scope": scope}
@@ -573,6 +580,12 @@ def register_order_tools(mcp: FastMCP) -> None:
                 "error": "confirm=True is required when dry_run=False",
                 "scope": scope,
             }
+        # Pass the raw request through (not the pre-normalized `scope`) —
+        # kis_mock_reconciliation_run_impl calls the same resolve helper
+        # itself and is the authoritative normalization point for the
+        # actual reconciliation call; this call can never disagree with
+        # the `scope`/`requested_scope` already validated above because
+        # both derive from the identical resolve_kis_mock_reconcile_scope.
         return await kis_mock_ledger.kis_mock_reconciliation_run_impl(
             dry_run=dry_run, limit=limit, market=market, symbol=symbol
         )

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -537,6 +537,10 @@ def register_order_tools(mcp: FastMCP) -> None:
             "holdings deltas and updates ledger lifecycle states. "
             "dry_run=True by default for safety. Applying transitions requires "
             "BOTH dry_run=False AND confirm=True. "
+            "market (kr/us or equity_kr/equity_us) and/or symbol scope the run "
+            "to matching open orders only — omit both to scan all open KIS mock "
+            "orders (unchanged default behavior). The response echoes the "
+            "applied scope. "
             "Fails closed if KIS mock config is missing."
         ),
     )
@@ -544,6 +548,8 @@ def register_order_tools(mcp: FastMCP) -> None:
         dry_run: bool = True,
         confirm: bool = False,
         limit: int = 100,
+        market: str | None = None,
+        symbol: str | None = None,
     ):
         config_error = _kis_mock_config_error()
         if config_error:
@@ -556,7 +562,7 @@ def register_order_tools(mcp: FastMCP) -> None:
                 "error": "confirm=True is required when dry_run=False",
             }
         return await kis_mock_ledger.kis_mock_reconciliation_run_impl(
-            dry_run=dry_run, limit=limit
+            dry_run=dry_run, limit=limit, market=market, symbol=symbol
         )
 
 

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -539,8 +539,10 @@ def register_order_tools(mcp: FastMCP) -> None:
             "BOTH dry_run=False AND confirm=True. "
             "market (kr/us or equity_kr/equity_us) and/or symbol scope the run "
             "to matching open orders only — omit both to scan all open KIS mock "
-            "orders (unchanged default behavior). The response echoes the "
-            "applied scope. "
+            "orders (unchanged default behavior). An unrecognized market value "
+            "is rejected (success=false + allowed_markets) rather than silently "
+            "treated as a full scan. The response always echoes the requested "
+            "scope, including on every error path. "
             "Fails closed if KIS mock config is missing."
         ),
     )

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -551,15 +551,17 @@ def register_order_tools(mcp: FastMCP) -> None:
         market: str | None = None,
         symbol: str | None = None,
     ):
+        scope = {"market": market, "symbol": symbol}
         config_error = _kis_mock_config_error()
         if config_error:
-            return config_error
+            return {**config_error, "scope": scope}
         if not dry_run and not confirm:
             return {
                 "success": False,
                 "account_mode": "kis_mock",
                 "dry_run": dry_run,
                 "error": "confirm=True is required when dry_run=False",
+                "scope": scope,
             }
         return await kis_mock_ledger.kis_mock_reconciliation_run_impl(
             dry_run=dry_run, limit=limit, market=market, symbol=symbol

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -541,8 +541,13 @@ def register_order_tools(mcp: FastMCP) -> None:
             "to matching open orders only — omit both to scan all open KIS mock "
             "orders (unchanged default behavior). An unrecognized market value "
             "is rejected (success=false + allowed_markets) rather than silently "
-            "treated as a full scan. The response always echoes the requested "
-            "scope, including on every error path. "
+            "treated as a full scan. Every path that has a valid scope (config "
+            "error, confirm-required, success, and unexpected-exception) echoes "
+            'the effective/canonical scope under `scope` (e.g. market="us" '
+            'always echoes back as "equity_us") — never the raw, pre-alias '
+            "request. The one exception is the unknown-market rejection: since "
+            "no valid scope exists there, it has no `scope` key and instead "
+            "echoes the verbatim request under `requested_scope`. "
             "Fails closed if KIS mock config is missing."
         ),
     )
@@ -553,7 +558,10 @@ def register_order_tools(mcp: FastMCP) -> None:
         market: str | None = None,
         symbol: str | None = None,
     ):
-        scope = {"market": market, "symbol": symbol}
+        scope = {
+            "market": kis_mock_ledger.normalize_kis_mock_reconcile_market(market),
+            "symbol": symbol,
+        }
         config_error = _kis_mock_config_error()
         if config_error:
             return {**config_error, "scope": scope}

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -296,6 +296,193 @@ async def test_run_passes_symbol_to_list_open_orders(db_session, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_passes_market_as_instrument_type_to_list_open_orders(
+    db_session, monkeypatch
+):
+    """ROB-1018: ``market`` must reach ``list_open_orders`` as the
+    ``instrument_type`` filter kwarg (the query-layer filter already existed;
+    only the plumbing to reach it was missing)."""
+    from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
+
+    captured: dict = {}
+
+    async def _fake_list_open_orders(
+        self, *, limit=100, symbol=None, instrument_type=None, **kw
+    ):
+        captured["symbol"] = symbol
+        captured["instrument_type"] = instrument_type
+        captured["limit"] = limit
+        return []
+
+    monkeypatch.setattr(
+        KISMockLifecycleService, "list_open_orders", _fake_list_open_orders
+    )
+    result = await run_kis_mock_reconciliation(
+        db_session, market="equity_us", symbol="AVGO", dry_run=True
+    )
+    assert captured["instrument_type"] == "equity_us"
+    assert captured["symbol"] == "AVGO"
+    assert result["orders_processed"] == 0
+    assert result["scope"] == {"market": "equity_us", "symbol": "AVGO"}
+
+
+@pytest.mark.asyncio
+async def test_market_scope_excludes_out_of_scope_rows_end_to_end(monkeypatch):
+    """ROB-1018 core repro: a US-scoped run must never see KR rows as
+    transition candidates — the query layer (not just filtering after the
+    fact) must exclude them, so a US session cannot stale-transition a
+    resting KR order it never asked about."""
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+
+    async def _list_open_orders(*, limit=100, symbol=None, instrument_type=None):
+        # Simulate the real query-layer filter: only equity_us rows come back.
+        rows = [
+            _ledger_row(
+                ledger_id=65,
+                symbol="AVGO",
+                side="buy",
+                qty=Decimal("1"),
+                state="accepted",
+                baseline=Decimal("0"),
+                instrument_type="equity_us",
+            )
+        ]
+        return [
+            r
+            for r in rows
+            if instrument_type is None or r.instrument_type == instrument_type
+        ]
+
+    mock_lifecycle_svc.list_open_orders.side_effect = _list_open_orders
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client(kr=[], us=[])
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, market="equity_us", dry_run=True, kis_client=fake_kis
+    )
+
+    assert result["orders_processed"] == 1
+    ledger_ids = {e["detail"]["ledger_id"] for e in result["events"]}
+    assert ledger_ids == {65}
+    assert result["scope"] == {"market": "equity_us", "symbol": None}
+
+
+@pytest.mark.asyncio
+async def test_scope_defaults_to_none_preserves_full_scan(monkeypatch):
+    """ROB-1018: omitting market/symbol must keep the existing full-batch
+    behavior — both reach list_open_orders as None."""
+    from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
+
+    captured: dict = {}
+
+    async def _fake_list_open_orders(
+        self, *, limit=100, symbol=None, instrument_type=None, **kw
+    ):
+        captured["symbol"] = symbol
+        captured["instrument_type"] = instrument_type
+        return []
+
+    monkeypatch.setattr(
+        KISMockLifecycleService, "list_open_orders", _fake_list_open_orders
+    )
+    mock_db = AsyncMock()
+    result = await run_kis_mock_reconciliation(mock_db, dry_run=True)
+    assert captured["symbol"] is None
+    assert captured["instrument_type"] is None
+    assert result["scope"] == {"market": None, "symbol": None}
+
+
+@pytest.mark.asyncio
+async def test_sell_to_zero_books_fill_when_scoped_by_market(monkeypatch):
+    """ROB-1018 x ROB-910 non-regression: scoping the order query by market
+    must NOT weaken holdings verification. A scoped US sell-to-zero still
+    books a fill because ``_collect_kis_mock_holdings`` always fetches BOTH
+    KR and US regardless of the order-query scope."""
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(
+            ledger_id=54,
+            symbol="F",
+            side="sell",
+            qty=Decimal("1"),
+            state="accepted",
+            baseline=Decimal("1"),
+            instrument_type="equity_us",
+        )
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    # Both fetches succeed; US returns empty (F is now zero → not listed).
+    fake_kis = _fake_kis_client(kr=[], us=[])
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, market="equity_us", dry_run=True, kis_client=fake_kis
+    )
+
+    # Both markets were still fetched — scoping orders never scopes holdings.
+    assert fake_kis.fetch_my_stocks.await_count == 2
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["ledger_id"] == 54
+    assert args["next_state"] == "fill"
+    assert args["reason_code"] == "fill_detected"
+    assert result["scope"] == {"market": "equity_us", "symbol": None}
+
+
+@pytest.mark.asyncio
+async def test_sell_to_zero_stays_anomaly_when_scoped_and_market_fetch_fails(
+    monkeypatch,
+):
+    """ROB-1018 x ROB-910 non-regression: scoping must not cause a failed
+    market fetch to be silently treated as a verified zero. Fail-closed
+    (anomaly / holdings_snapshot_missing) is preserved under scope."""
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(
+            ledger_id=54,
+            symbol="F",
+            side="sell",
+            qty=Decimal("1"),
+            state="accepted",
+            baseline=Decimal("1"),
+            instrument_type="equity_us",
+        )
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    # KR succeeds ([]), US fetch RAISES → US market unverified, even though
+    # the run is scoped to equity_us.
+    fake_kis = _fake_kis_client_seq(
+        side_effect=[[], RuntimeError("EGW00201 mock inquiry failed")]
+    )
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, market="equity_us", dry_run=True, kis_client=fake_kis
+    )
+
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["ledger_id"] == 54
+    assert args["next_state"] == "anomaly"
+    assert args["reason_code"] == "holdings_snapshot_missing"
+    assert result["scope"] == {"market": "equity_us", "symbol": None}
+
+
+@pytest.mark.asyncio
 async def test_sell_to_zero_books_fill_when_symbol_absent_but_fetch_ok(monkeypatch):
     """ROB-910 core reproduction: full sell to zero.
 

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -331,13 +331,37 @@ async def test_market_scope_excludes_out_of_scope_rows_end_to_end(monkeypatch):
     """ROB-1018 core repro: a US-scoped run must never see KR rows as
     transition candidates — the query layer (not just filtering after the
     fact) must exclude them, so a US session cannot stale-transition a
-    resting KR order it never asked about."""
+    resting KR order it never asked about.
+
+    Mirrors the actual incident shape (ledger 63/64 KR + 65 US all open at
+    once): the fake ``list_open_orders`` below returns BOTH a KR row (63) and
+    a US row (65) whenever ``instrument_type`` is None, and filters down to
+    just the matching market otherwise — exactly like the real DB query. A
+    run scoped to ``market="equity_us"`` must end up with ONLY the US row
+    in ``events``/transitions; the KR row must never surface as a candidate.
+
+    This is a load-bearing regression guard for the bug this ticket fixed: if
+    the job stops forwarding ``market`` to ``list_open_orders`` (e.g.
+    regresses to passing ``instrument_type=None``), the fake below starts
+    returning the KR row too and this test goes RED — a single-row fake
+    would have let that regression through silently (it did, pre-fix).
+    """
     mock_db = AsyncMock()
     mock_lifecycle_svc = AsyncMock()
 
     async def _list_open_orders(*, limit=100, symbol=None, instrument_type=None):
-        # Simulate the real query-layer filter: only equity_us rows come back.
+        # Simulate the real query-layer filter: instrument_type gates which
+        # rows come back. Both a KR and a US order are open simultaneously.
         rows = [
+            _ledger_row(
+                ledger_id=63,
+                symbol="005930",
+                side="buy",
+                qty=Decimal("10"),
+                state="accepted",
+                baseline=Decimal("0"),
+                instrument_type="equity_kr",
+            ),
             _ledger_row(
                 ledger_id=65,
                 symbol="AVGO",
@@ -346,7 +370,7 @@ async def test_market_scope_excludes_out_of_scope_rows_end_to_end(monkeypatch):
                 state="accepted",
                 baseline=Decimal("0"),
                 instrument_type="equity_us",
-            )
+            ),
         ]
         return [
             r
@@ -370,6 +394,14 @@ async def test_market_scope_excludes_out_of_scope_rows_end_to_end(monkeypatch):
     assert result["orders_processed"] == 1
     ledger_ids = {e["detail"]["ledger_id"] for e in result["events"]}
     assert ledger_ids == {65}
+    assert 63 not in ledger_ids  # KR row must never appear as a candidate
+
+    transitioned_ids = {
+        c.kwargs["ledger_id"]
+        for c in mock_lifecycle_svc.apply_lifecycle_transition.call_args_list
+    }
+    assert transitioned_ids == {65}
+
     assert result["scope"] == {"market": "equity_us", "symbol": None}
 
 

--- a/tests/mcp_server/test_kis_mock_reconciliation_tool.py
+++ b/tests/mcp_server/test_kis_mock_reconciliation_tool.py
@@ -202,6 +202,76 @@ async def test_kis_mock_reconciliation_tool_rejects_unknown_market_end_to_end(
 
 
 @pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_rejects_unknown_market_even_with_config_error(
+    monkeypatch,
+):
+    """ROB-1018 fix #3 (round 3), cross-condition (a).
+
+    Round 2 shipped allowlist validation only inside the impl, reachable
+    only *after* the front-layer config-error short-circuit. That meant an
+    unknown market combined with a broken KIS mock config never reached the
+    allowlist check at all — it returned the config-error response with the
+    raw, unnormalized market crammed into `scope` (contract violation: no
+    `requested_scope`, wrong-shaped `scope`). Validation must now run BEFORE
+    the config-error gate so the same unknown-market rejection always wins.
+    """
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: ["KIS_MOCK_APP_KEY"],
+    )
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](
+        market="CrYpTo-X", symbol="AVGO"
+    )
+
+    assert result["success"] is False
+    # The unknown-market rejection wins over the config error: no `scope`,
+    # the verbatim request under `requested_scope`, and an error message
+    # about the bad market (not about missing KIS mock config).
+    assert "scope" not in result
+    assert result["requested_scope"] == {"market": "CrYpTo-X", "symbol": "AVGO"}
+    assert "CrYpTo-X" in result["error"]
+    assert set(result["allowed_markets"]) == {"kr", "us", "equity_kr", "equity_us"}
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_rejects_unknown_market_even_with_apply_gate(
+    monkeypatch,
+):
+    """ROB-1018 fix #3 (round 3), cross-condition (b).
+
+    Same defect, different second condition: an unknown market combined
+    with `dry_run=False, confirm=False` must still be rejected as an
+    unknown market (not as a confirm-required error) — the allowlist check
+    must win regardless of what other gate would otherwise also fire.
+    """
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+    mock_run = AsyncMock()
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](
+        market="CrYpTo-X", symbol="AVGO", dry_run=False, confirm=False
+    )
+
+    assert result["success"] is False
+    assert "scope" not in result
+    assert result["requested_scope"] == {"market": "CrYpTo-X", "symbol": "AVGO"}
+    assert "CrYpTo-X" in result["error"]
+    assert set(result["allowed_markets"]) == {"kr", "us", "equity_kr", "equity_us"}
+    # Never reaches confirm-required (no "confirm" error text) and never
+    # calls the impl.
+    assert "confirm" not in result["error"].lower()
+    mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_scope_contract_consistent_across_all_paths_for_market_us(monkeypatch):
     """ROB-1018 fix #2 (round 2), TDD requirement #1.
 

--- a/tests/mcp_server/test_kis_mock_reconciliation_tool.py
+++ b/tests/mcp_server/test_kis_mock_reconciliation_tool.py
@@ -43,12 +43,40 @@ async def test_kis_mock_reconciliation_tool_apply_requires_confirm(monkeypatch):
 
     tools = build_tools()
     result = await tools["kis_mock_reconciliation_run"](
-        dry_run=False, confirm=False, limit=10
+        dry_run=False, confirm=False, limit=10, market="us", symbol="AVGO"
     )
 
     assert result["success"] is False
     assert "confirm" in result["error"].lower()
     mock_run.assert_not_called()
+    # ROB-1018 fix #2: the confirm=False short-circuit must still echo the
+    # scope the caller requested — callers should be able to tell what was
+    # (not) targeted from every response shape, not just the success path.
+    assert result["scope"] == {"market": "us", "symbol": "AVGO"}
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_config_error_includes_scope(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: ["KIS_MOCK_APP_KEY"],
+    )
+
+    mock_run = AsyncMock()
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](
+        market="equity_kr", symbol="005930"
+    )
+
+    assert result["success"] is False
+    mock_run.assert_not_called()
+    # ROB-1018 fix #2: a config-error short-circuit (before impl is ever
+    # reached) must still echo the requested scope.
+    assert result["scope"] == {"market": "equity_kr", "symbol": "005930"}
 
 
 @pytest.mark.asyncio
@@ -93,3 +121,72 @@ async def test_kis_mock_reconciliation_tool_passes_market_and_symbol(monkeypatch
     mock_run.assert_awaited_once_with(
         dry_run=True, limit=10, market="us", symbol="AVGO"
     )
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_run_impl_exception_includes_scope(
+    monkeypatch,
+):
+    """ROB-1018 fix #2: a raised exception inside the impl's own try/except
+    (e.g. a DB session failure) must still surface the requested scope so a
+    caller can tell what was being reconciled when it blew up."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    class _BoomDB:
+        async def __aenter__(self):
+            raise RuntimeError("db unavailable")
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        kis_mock_ledger, "_order_session_factory", lambda: lambda: _BoomDB()
+    )
+
+    result = await kis_mock_ledger.kis_mock_reconciliation_run_impl(
+        market="us", symbol="AVGO"
+    )
+
+    assert result["success"] is False
+    assert result["error"]
+    assert result["scope"] == {"market": "equity_us", "symbol": "AVGO"}
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_run_impl_rejects_unknown_market(monkeypatch):
+    """ROB-1018 fix #3: an unrecognized market must fail closed with an
+    explicit error + allowed-values list, never silently succeed as if it
+    scanned nothing on purpose (a `crypto`/typo value must not read as a
+    trustworthy 'scope matched, 0 orders' success)."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    run_spy = AsyncMock()
+    monkeypatch.setattr(kis_mock_ledger, "run_kis_mock_reconciliation", run_spy)
+
+    result = await kis_mock_ledger.kis_mock_reconciliation_run_impl(market="crypto")
+
+    assert result["success"] is False
+    assert "crypto" in result["error"]
+    assert set(result["allowed_markets"]) == {"kr", "us", "equity_kr", "equity_us"}
+    assert result["scope"] == {"market": "crypto", "symbol": None}
+    # Must fail closed BEFORE ever reaching the reconciliation query/holdings
+    # fetch — never a silent full-scan fallback for a bad market value.
+    run_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_rejects_unknown_market_end_to_end(
+    monkeypatch,
+):
+    """Same as above but through the registered MCP tool surface."""
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](market="krx")
+
+    assert result["success"] is False
+    assert set(result["allowed_markets"]) == {"kr", "us", "equity_kr", "equity_us"}
+    assert result["scope"]["market"] == "krx"

--- a/tests/mcp_server/test_kis_mock_reconciliation_tool.py
+++ b/tests/mcp_server/test_kis_mock_reconciliation_tool.py
@@ -49,10 +49,10 @@ async def test_kis_mock_reconciliation_tool_apply_requires_confirm(monkeypatch):
     assert result["success"] is False
     assert "confirm" in result["error"].lower()
     mock_run.assert_not_called()
-    # ROB-1018 fix #2: the confirm=False short-circuit must still echo the
-    # scope the caller requested — callers should be able to tell what was
-    # (not) targeted from every response shape, not just the success path.
-    assert result["scope"] == {"market": "us", "symbol": "AVGO"}
+    # ROB-1018 fix #2 (round 2): every path with a valid scope echoes the
+    # effective/canonical scope — market="us" normalizes to "equity_us" here
+    # exactly like the success path does, not the raw pre-alias request.
+    assert result["scope"] == {"market": "equity_us", "symbol": "AVGO"}
 
 
 @pytest.mark.asyncio
@@ -168,7 +168,13 @@ async def test_kis_mock_reconciliation_run_impl_rejects_unknown_market(monkeypat
     assert result["success"] is False
     assert "crypto" in result["error"]
     assert set(result["allowed_markets"]) == {"kr", "us", "equity_kr", "equity_us"}
-    assert result["scope"] == {"market": "crypto", "symbol": None}
+    # ROB-1018 fix #2 (round 2): no valid scope was ever established, so this
+    # path must NOT claim a `scope` (that key means "effective scope of what
+    # ran/would run" on every other path) — it echoes the verbatim request
+    # under `requested_scope` instead, so callers can't mistake it for a
+    # scope that actually executed.
+    assert result["requested_scope"] == {"market": "crypto", "symbol": None}
+    assert "scope" not in result
     # Must fail closed BEFORE ever reaching the reconciliation query/holdings
     # fetch — never a silent full-scan fallback for a bad market value.
     run_spy.assert_not_called()
@@ -189,4 +195,121 @@ async def test_kis_mock_reconciliation_tool_rejects_unknown_market_end_to_end(
 
     assert result["success"] is False
     assert set(result["allowed_markets"]) == {"kr", "us", "equity_kr", "equity_us"}
-    assert result["scope"]["market"] == "krx"
+    # ROB-1018 fix #2 (round 2): rejected requests have no effective scope —
+    # they echo the raw request under `requested_scope`, not `scope`.
+    assert result["requested_scope"]["market"] == "krx"
+    assert "scope" not in result
+
+
+@pytest.mark.asyncio
+async def test_scope_contract_consistent_across_all_paths_for_market_us(monkeypatch):
+    """ROB-1018 fix #2 (round 2), TDD requirement #1.
+
+    For the same input (market="us", symbol="AVGO"), every path that has a
+    valid scope — config error, confirm-required, success, and an
+    impl/DB exception — must agree on the SAME normalization rule (the
+    effective/canonical alias-resolved value, "equity_us"), never the raw
+    pre-alias request. The one path without a valid scope (unknown market)
+    is the sole, explicitly-signposted exception: it must never claim
+    `scope` and instead echoes the verbatim request under `requested_scope`.
+    """
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _BoomDB:
+        async def __aenter__(self):
+            raise RuntimeError("db unavailable")
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+    tools = build_tools()
+
+    # 1) success path — the job-level reconciliation is stubbed out, but the
+    # front-end scope contract only depends on the impl's own normalization.
+    monkeypatch.setattr(
+        kis_mock_ledger, "_order_session_factory", lambda: lambda: _FakeDB()
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "run_kis_mock_reconciliation",
+        AsyncMock(
+            return_value={
+                "success": True,
+                "scope": {"market": "equity_us", "symbol": "AVGO"},
+            }
+        ),
+    )
+    success = await tools["kis_mock_reconciliation_run"](market="us", symbol="AVGO")
+    assert success["scope"] == {"market": "equity_us", "symbol": "AVGO"}
+
+    # 2) confirm=False short-circuit — never reaches impl at all.
+    confirm_required = await tools["kis_mock_reconciliation_run"](
+        dry_run=False, confirm=False, market="us", symbol="AVGO"
+    )
+    assert confirm_required["success"] is False
+    assert confirm_required["scope"] == {"market": "equity_us", "symbol": "AVGO"}
+
+    # 3) config-error short-circuit — never reaches impl at all.
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: ["KIS_MOCK_APP_KEY"],
+    )
+    config_err = await tools["kis_mock_reconciliation_run"](market="us", symbol="AVGO")
+    assert config_err["success"] is False
+    assert config_err["scope"] == {"market": "equity_us", "symbol": "AVGO"}
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    # 4) impl/DB exception path.
+    monkeypatch.setattr(
+        kis_mock_ledger, "_order_session_factory", lambda: lambda: _BoomDB()
+    )
+    boom = await tools["kis_mock_reconciliation_run"](market="us", symbol="AVGO")
+    assert boom["success"] is False
+    assert boom["scope"] == {"market": "equity_us", "symbol": "AVGO"}
+
+    # 5) unknown-market rejection — the deliberate exception to the rule
+    # above: no `scope` key, verbatim request under `requested_scope`.
+    rejected = await tools["kis_mock_reconciliation_run"](market="crypto")
+    assert rejected["success"] is False
+    assert "scope" not in rejected
+    assert rejected["requested_scope"] == {"market": "crypto", "symbol": None}
+
+
+def test_tool_description_matches_scope_contract():
+    """ROB-1018 fix #2 (round 2), TDD requirement #2: the tool's own
+    description must describe the actual scope contract, not the stale
+    "always echoes the requested scope" claim that round 1 shipped."""
+    from app.mcp_server.tooling.orders_registration import register_order_tools
+
+    descriptions: dict[str, str] = {}
+
+    class _DescriptionCapturingMCP:
+        def tool(self, name: str, description: str):
+            def decorator(func):
+                descriptions[name] = description
+                return func
+
+            return decorator
+
+    register_order_tools(_DescriptionCapturingMCP())
+    description = descriptions["kis_mock_reconciliation_run"]
+
+    assert "effective" in description or "canonical" in description
+    assert "requested_scope" in description
+    # The stale round-1 claim ("always echoes the requested scope" as the
+    # verbatim input) must be gone now that success/error paths normalize.
+    assert "always echoes the requested" not in description.lower()

--- a/tests/mcp_server/test_kis_mock_reconciliation_tool.py
+++ b/tests/mcp_server/test_kis_mock_reconciliation_tool.py
@@ -26,7 +26,7 @@ async def test_kis_mock_reconciliation_tool_dry_run_default(monkeypatch):
 
     result = await tools["kis_mock_reconciliation_run"]()
     assert result == {"success": True, "applied": 0}
-    mock_run.assert_awaited_once_with(dry_run=True, limit=100)
+    mock_run.assert_awaited_once_with(dry_run=True, limit=100, market=None, symbol=None)
 
 
 @pytest.mark.asyncio
@@ -69,4 +69,27 @@ async def test_kis_mock_reconciliation_tool_apply_with_confirm(monkeypatch):
     )
 
     assert result == {"success": True, "applied": 3}
-    mock_run.assert_awaited_once_with(dry_run=False, limit=10)
+    mock_run.assert_awaited_once_with(dry_run=False, limit=10, market=None, symbol=None)
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_passes_market_and_symbol(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    mock_run = AsyncMock(return_value={"success": True, "applied": 0})
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](
+        market="us", symbol="AVGO", limit=10
+    )
+
+    assert result == {"success": True, "applied": 0}
+    mock_run.assert_awaited_once_with(
+        dry_run=True, limit=10, market="us", symbol="AVGO"
+    )


### PR DESCRIPTION
## Summary
- `kis_mock_reconciliation_run` had no way to scope reconciliation to a single market/symbol — a US-session dry_run flipped resting KR ledger rows to `stale`, and `_TERMINAL` makes `stale` permanent, so a later real fill on that KR order would never get booked.
- `list_open_orders(instrument_type=...)` already existed at the query layer; `run_kis_mock_reconciliation` had `symbol` (ROB-404) but no `market`, and the MCP tool exposed neither `market` nor `symbol`.
- Adds `market` (accepts `kr`/`us` aliases or canonical `equity_kr`/`equity_us`, normalized at the MCP boundary) and exposes the existing `symbol` param through the MCP tool → job → `list_open_orders` chain. Response now echoes `"scope": {"market": ..., "symbol": ...}`.
- Omitting both preserves the existing full-scan behavior (periodic TaskIQ task and unscoped MCP calls unaffected).
- `_collect_kis_mock_holdings` still always fetches both KR and US regardless of order scope, so the ROB-910 zero-synthesis fail-closed guard is unaffected by this change (verified with new regression tests).

## Out of scope (deliberately untouched — adjacent issues own these)
- `ledger_ids` selector and stale-judgment evidence (ROB-1007)
- stale-state recoverability / `_TERMINAL` set (ROB-1021)
- `lifecycle_state == "fill"` re-judgment branch (ROB-1019)

## Test plan
- [x] `uv run pytest tests/ -q -k "kis_mock"` — 403 passed
- [x] `uv run pytest tests/ -q -k "reconcil"` — 462 passed
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean
- [x] `uv run ty check` on touched files — clean
- [x] `uv run alembic heads` — single head, no migration added (column already existed)
- [x] New tests cover: market-scope excludes out-of-scope rows end-to-end, market passed as `instrument_type` to `list_open_orders`, default (no args) preserves full scan, scope echoed in response, ROB-910 sell-to-zero still books fill under scope, ROB-910 fail-closed (`holdings_snapshot_missing`) preserved under scope when a market fetch raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market and symbol filters to mock order reconciliation.
  * Added market alias normalization and validation with clear allowed-market feedback.
  * Added scope details to successful and failed reconciliation responses.
  * Unknown markets now fail safely before reconciliation begins.

* **Bug Fixes**
  * Prevented out-of-scope orders from being processed.
  * Preserved holdings verification and anomaly reporting for scoped reconciliations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->