### PR TITLE
feat(ROB-1007): ledger_ids selector, unified selector errors, mock open-order probe

### DIFF
--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -30,6 +30,7 @@ from app.services.kis_mock_holdings_reconciler import (
     classify_orders,
 )
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
+from app.services.kis_mock_reconcile_scope import resolve_kis_mock_reconcile_scope
 
 
 def _to_decimal(val: Any) -> Decimal:
@@ -152,6 +153,7 @@ async def run_kis_mock_reconciliation(
     limit: int = 100,
     symbol: str | None = None,
     market: str | None = None,
+    ledger_ids: list[int] | None = None,
     thresholds: ReconcilerThresholds | None = None,
     kis_client: KISClient | None = None,
 ) -> dict[str, Any]:
@@ -161,18 +163,52 @@ async def run_kis_mock_reconciliation(
     the delta-budget kernel groups by (symbol, side) so a single-symbol pass is
     self-consistent. ``market`` (ROB-1018) restricts to one ``instrument_type``
     (e.g. ``equity_kr``/``equity_us``) — prevents a US-scoped run from proposing
-    transitions on KR rows (and vice versa). Both default to ``None``, which
-    keeps the full-batch behavior. Neither narrows the holdings snapshot
-    fetch (``_collect_kis_mock_holdings`` always fetches KR + US) — the
-    ROB-910 zero-synthesis fail-closed guard for out-of-scope-fetch symbols is
+    transitions on KR rows (and vice versa). ``ledger_ids`` (ROB-1007) restricts
+    to an explicit set of ledger rows. All three default to ``None``, which
+    keeps the full-batch behavior. None narrow the holdings snapshot fetch
+    (``_collect_kis_mock_holdings`` always fetches KR + US) — the ROB-910
+    zero-synthesis fail-closed guard for out-of-scope-fetch symbols is
     unaffected by order scoping.
+
+    ROB-1007 R4: this function is called directly by two job-layer callers
+    that bypass the MCP tool surface (``app/tasks/kis_mock_reconciliation_tasks.py``,
+    ``kis_mock_execution_consumer.py``) and previously built ``scope`` inline
+    without ever running it through :func:`resolve_kis_mock_reconcile_scope` —
+    an unknown ``market`` at this layer silently produced a false
+    ``success=True, orders_processed=0`` rather than the ``success=False``
+    the MCP layer already guaranteed. This call re-validates through the same
+    chokepoint so both entry points share one allowlist/shape, regardless of
+    whether a caller already validated (idempotent — normalization is stable).
     """
+    scope, scope_error = resolve_kis_mock_reconcile_scope(
+        market=market, symbol=symbol, ledger_ids=ledger_ids
+    )
+    if scope_error:
+        return {**scope_error, "broker": "kis"}
+
     thresholds = thresholds or ReconcilerThresholds()
     lifecycle_svc = KISMockLifecycleService(db)
+
+    resolved_ledger_ids = scope.get("ledger_ids")
+    if resolved_ledger_ids is not None:
+        existing_ids = await lifecycle_svc.existing_ledger_ids(resolved_ledger_ids)
+        missing_ids = sorted(set(resolved_ledger_ids) - existing_ids)
+        if missing_ids:
+            return {
+                "success": False,
+                "error": f"unknown ledger_ids: {missing_ids}",
+                "selector": "ledger_ids",
+                "account_mode": "kis_mock",
+                "broker": "kis",
+                "scope": scope,
+            }
+
     open_rows = await lifecycle_svc.list_open_orders(
-        limit=limit, symbol=symbol, instrument_type=market
+        limit=limit,
+        symbol=scope["symbol"],
+        instrument_type=scope["market"],
+        ledger_ids=resolved_ledger_ids,
     )
-    scope = {"market": market, "symbol": symbol}
     if not open_rows:
         return {
             "success": True,

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -27,6 +27,10 @@ from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
 )
 from app.services.brokers.kis.order_id import normalize_broker_order_id
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
+from app.services.kis_mock_reconcile_scope import (
+    normalize_kis_mock_reconcile_market,  # noqa: F401 - re-exported for back-compat
+    resolve_kis_mock_reconcile_scope,
+)
 from app.services.live_correlation import live_correlation_id
 from app.services.live_place_provenance import publish_place_time_forecast
 
@@ -666,70 +670,13 @@ async def _record_kis_mock_order(
     }
 
 
-_MARKET_ALIASES = {"kr": "equity_kr", "us": "equity_us"}
-_ALLOWED_RECONCILE_MARKETS = frozenset({"equity_kr", "equity_us"})
-_ALLOWED_RECONCILE_MARKET_VALUES = sorted(_MARKET_ALIASES) + sorted(
-    _ALLOWED_RECONCILE_MARKETS
-)
-
-
-def normalize_kis_mock_reconcile_market(market: str | None) -> str | None:
-    if market is None:
-        return None
-    return _MARKET_ALIASES.get(market, market)
-
-
-def resolve_kis_mock_reconcile_scope(
-    *, market: str | None, symbol: str | None
-) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-    """Single front-layer point: validate, normalize, and shape the
-    reconciliation scope selector set (ROB-1018 fix #3).
-
-    This is the ONE place that (a) checks ``market`` against the allowlist
-    and (b) decides how the scope gets echoed back. Both the MCP tool
-    registration (front layer) and :func:`kis_mock_reconciliation_run_impl`
-    call this *same* function so the two layers can never shape the
-    response differently or disagree on what counts as a valid market —
-    that divergence (allowlist check only living in impl, reachable only
-    after config-error/confirm gates ran first) was the ROB-1018 round-3
-    defect. Callers must invoke this *before* any other gate (config error,
-    confirm-required) so an unknown market always short-circuits with the
-    same rejection shape regardless of what other conditions also hold.
-
-    Adding a new selector (e.g. ROB-1007's ``ledger_ids``) means adding a
-    parameter here and including it in both dicts below — no restructuring
-    of call sites or gating order.
-
-    Returns ``(scope, error)`` — exactly one is not ``None``:
-
-    - ``scope``: the effective/canonical selectors (alias-normalized
-      ``market``, e.g. ``"us"`` -> ``"equity_us"``), safe to use for the
-      rest of the request (further gating and the impl call itself).
-    - ``error``: a ready-to-return rejection dict for an unrecognized
-      ``market`` (typo or unsupported venue — KIS mock only covers
-      KR/US equity). It carries the verbatim, unnormalized request under
-      ``requested_scope`` (never ``scope``, since no valid scope was ever
-      established) so callers can't mistake it for a scope that actually
-      ran. A silent pass-through would otherwise yield an
-      ``orders_processed=0`` false-success indistinguishable from "scope
-      matched but nothing was open".
-    """
-    normalized_market = normalize_kis_mock_reconcile_market(market)
-    if (
-        normalized_market is not None
-        and normalized_market not in _ALLOWED_RECONCILE_MARKETS
-    ):
-        return None, {
-            "success": False,
-            "error": (
-                f"unknown market '{market}' — allowed values: "
-                f"{_ALLOWED_RECONCILE_MARKET_VALUES}"
-            ),
-            "allowed_markets": _ALLOWED_RECONCILE_MARKET_VALUES,
-            "account_mode": "kis_mock",
-            "requested_scope": {"market": market, "symbol": symbol},
-        }
-    return {"market": normalized_market, "symbol": symbol}, None
+# NOTE (ROB-1007): scope validation/normalization now lives in
+# app.services.kis_mock_reconcile_scope (imported above) so the job layer can
+# share the same chokepoint without a circular import (this module already
+# imports run_kis_mock_reconciliation from the job module). Both names are
+# re-exported as module attributes here for back-compat with existing
+# callers/tests that do `kis_mock_ledger.resolve_kis_mock_reconcile_scope(...)`
+# or monkeypatch it.
 
 
 async def kis_mock_reconciliation_run_impl(
@@ -738,25 +685,32 @@ async def kis_mock_reconciliation_run_impl(
     limit: int = 100,
     market: str | None = None,
     symbol: str | None = None,
+    ledger_ids: list[int] | None = None,
 ) -> dict[str, Any]:
     """Execute KIS mock order reconciliation and return summary.
 
     ``market``/``symbol`` (ROB-1018) narrow the open-order lookup so a
     single-market/single-symbol reconciliation pass never proposes
     transitions on out-of-scope rows (e.g. a US session no longer flips KR
-    resting orders to ``stale``). Both default to ``None``, preserving the
-    prior full-scan behavior for existing callers (TaskIQ periodic task,
-    unscoped MCP calls).
+    resting orders to ``stale``). ``ledger_ids`` (ROB-1007) narrows further to
+    an explicit set of ledger rows — useful for re-checking specific
+    previously-"stale" rows without a full scan. All three default to
+    ``None``, preserving the prior full-scan behavior for existing callers
+    (TaskIQ periodic task, unscoped MCP calls).
 
-    Response contract (ROB-1018 fix #2/#3): every success/error path
-    returns the *effective* (canonical, alias-normalized) scope under
-    ``scope`` — e.g. a requested ``market="us"`` always echoes back as
-    ``"equity_us"``. The one exception is the unknown-market rejection,
-    handled by :func:`resolve_kis_mock_reconcile_scope` before any other
-    work happens here: it has no ``scope`` key and instead echoes the
-    verbatim, unnormalized request under ``requested_scope``.
+    Response contract (ROB-1018 fix #2/#3, ROB-1007 fix #3): every
+    success/error path returns the *effective* (canonical, alias-normalized)
+    scope under ``scope`` — e.g. a requested ``market="us"`` always echoes
+    back as ``"equity_us"``. The one exception is an invalid-selector
+    rejection, handled by :func:`resolve_kis_mock_reconcile_scope` before any
+    other work happens here: it has no ``scope`` key and instead echoes the
+    verbatim, unnormalized request under ``requested_scope``, plus a
+    ``selector`` key naming which selector (``"market"`` or ``"ledger_ids"``)
+    was rejected.
     """
-    scope, scope_error = resolve_kis_mock_reconcile_scope(market=market, symbol=symbol)
+    scope, scope_error = resolve_kis_mock_reconcile_scope(
+        market=market, symbol=symbol, ledger_ids=ledger_ids
+    )
     if scope_error:
         return scope_error
     try:
@@ -767,6 +721,7 @@ async def kis_mock_reconciliation_run_impl(
                 limit=limit,
                 market=scope["market"],
                 symbol=scope["symbol"],
+                ledger_ids=scope.get("ledger_ids"),
             )
     except Exception as exc:
         logger.exception("Failed to run KIS mock reconciliation: %s", exc)

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -539,15 +539,20 @@ def register_order_tools(mcp: FastMCP) -> None:
             "BOTH dry_run=False AND confirm=True. "
             "market (kr/us or equity_kr/equity_us) and/or symbol scope the run "
             "to matching open orders only — omit both to scan all open KIS mock "
-            "orders (unchanged default behavior). An unrecognized market value "
-            "is rejected (success=false + allowed_markets) rather than silently "
-            "treated as a full scan. Every path that has a valid scope (config "
-            "error, confirm-required, success, and unexpected-exception) echoes "
-            'the effective/canonical scope under `scope` (e.g. market="us" '
-            'always echoes back as "equity_us") — never the raw, pre-alias '
-            "request. The one exception is the unknown-market rejection: since "
-            "no valid scope exists there, it has no `scope` key and instead "
-            "echoes the verbatim request under `requested_scope`. "
+            "orders (unchanged default behavior). ledger_ids (list of positive "
+            "ints) further narrows to an explicit set of ledger rows — useful "
+            "to re-check specific previously-'stale' rows without a full scan. "
+            "An unrecognized market value, or an invalid ledger_ids (empty "
+            "list, negative/non-integer entries, or ids that don't exist) is "
+            "rejected (success=false + `selector` naming which one) rather "
+            "than silently treated as a full scan. Every path that has a "
+            "valid scope (config error, confirm-required, success, and "
+            "unexpected-exception) echoes the effective/canonical scope under "
+            '`scope` (e.g. market="us" always echoes back as "equity_us") — '
+            "never the raw, pre-alias request. The one exception is an "
+            "invalid-selector rejection: since no valid scope exists there, "
+            "it has no `scope` key and instead echoes the verbatim request "
+            "under `requested_scope` plus `selector`. "
             "Fails closed if KIS mock config is missing."
         ),
     )
@@ -557,15 +562,17 @@ def register_order_tools(mcp: FastMCP) -> None:
         limit: int = 100,
         market: str | None = None,
         symbol: str | None = None,
+        ledger_ids: list[int] | None = None,
     ):
-        # ROB-1018 fix #3: allowlist validation runs at this single
-        # front-layer point, BEFORE the config-error and confirm gates
-        # below — so an unknown market always short-circuits with the same
-        # rejection (requested_scope, no scope key) no matter what other
-        # conditions also hold. See resolve_kis_mock_reconcile_scope's
-        # docstring for why both layers must share this one function.
+        # ROB-1018 fix #3 / ROB-1007 fix #2/#3: selector validation runs at
+        # this single front-layer point, BEFORE the config-error and confirm
+        # gates below — so an invalid market or ledger_ids always
+        # short-circuits with the same rejection (requested_scope, no scope
+        # key, `selector` naming which one) no matter what other conditions
+        # also hold. See resolve_kis_mock_reconcile_scope's docstring for why
+        # both layers must share this one function.
         scope, scope_error = kis_mock_ledger.resolve_kis_mock_reconcile_scope(
-            market=market, symbol=symbol
+            market=market, symbol=symbol, ledger_ids=ledger_ids
         )
         if scope_error:
             return scope_error
@@ -587,7 +594,11 @@ def register_order_tools(mcp: FastMCP) -> None:
         # the `scope`/`requested_scope` already validated above because
         # both derive from the identical resolve_kis_mock_reconcile_scope.
         return await kis_mock_ledger.kis_mock_reconciliation_run_impl(
-            dry_run=dry_run, limit=limit, market=market, symbol=symbol
+            dry_run=dry_run,
+            limit=limit,
+            market=market,
+            symbol=symbol,
+            ledger_ids=ledger_ids,
         )
 
 

--- a/app/services/kis_mock_lifecycle_service.py
+++ b/app/services/kis_mock_lifecycle_service.py
@@ -46,6 +46,7 @@ class KISMockLifecycleService:
         symbol: str | None = None,
         instrument_type: str | None = None,
         side: str | None = None,
+        ledger_ids: list[int] | None = None,
     ) -> list[KISMockOrderLedger]:
         if limit < 1:
             raise ValueError("limit must be >= 1")
@@ -58,12 +59,27 @@ class KISMockLifecycleService:
             stmt = stmt.where(KISMockOrderLedger.instrument_type == instrument_type)
         if side:
             stmt = stmt.where(KISMockOrderLedger.side == side)
+        if ledger_ids:
+            stmt = stmt.where(KISMockOrderLedger.id.in_(ledger_ids))
         stmt = stmt.order_by(
             KISMockOrderLedger.trade_date.asc(),
             KISMockOrderLedger.id.asc(),
         ).limit(limit)
         result = await self._db.execute(stmt)
         return list(result.scalars().all())
+
+    async def existing_ledger_ids(self, ledger_ids: list[int]) -> set[int]:
+        """Return the subset of ``ledger_ids`` that exist in the ledger at
+        all (any lifecycle state) — used to explicitly reject a
+        reconciliation scope naming a nonexistent id rather than silently
+        processing whatever subset does exist (ROB-1007)."""
+        if not ledger_ids:
+            return set()
+        stmt = select(KISMockOrderLedger.id).where(
+            KISMockOrderLedger.id.in_(ledger_ids)
+        )
+        result = await self._db.execute(stmt)
+        return set(result.scalars().all())
 
     async def get_by_order_no(self, *, order_no: str) -> KISMockOrderLedger | None:
         """Look up a single ledger row by broker order number.

--- a/app/services/kis_mock_reconcile_scope.py
+++ b/app/services/kis_mock_reconcile_scope.py
@@ -1,0 +1,128 @@
+"""KIS mock reconciliation scope selector — validate/normalize/shape (ROB-1018/ROB-1007).
+
+Single source of truth for the ``market``/``symbol``/``ledger_ids`` selector
+set accepted by ``kis_mock_reconciliation_run``. Lives in its own module (not
+``app.mcp_server.tooling.kis_mock_ledger``) so both the MCP-tool layer
+(``kis_mock_ledger``) and the job layer (``app.jobs.kis_mock_reconciliation_job``)
+can import the *same* function without a circular import — ``kis_mock_ledger``
+already imports ``run_kis_mock_reconciliation`` from the job module, so the job
+module cannot import back from ``kis_mock_ledger``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_MARKET_ALIASES = {"kr": "equity_kr", "us": "equity_us"}
+_ALLOWED_RECONCILE_MARKETS = frozenset({"equity_kr", "equity_us"})
+_ALLOWED_RECONCILE_MARKET_VALUES = sorted(_MARKET_ALIASES) + sorted(
+    _ALLOWED_RECONCILE_MARKETS
+)
+
+
+def normalize_kis_mock_reconcile_market(market: str | None) -> str | None:
+    if market is None:
+        return None
+    return _MARKET_ALIASES.get(market, market)
+
+
+def _validate_ledger_ids(ledger_ids: Any) -> str | None:
+    """Return an error message when ``ledger_ids`` is structurally invalid.
+
+    Only structural validation (type/shape) happens here — this module has
+    no DB access, so "does this id actually exist" is checked downstream by
+    the job layer once a DB session is available. Returns ``None`` when the
+    value is a well-formed non-empty list of positive integers.
+    """
+    if not isinstance(ledger_ids, list | tuple):
+        return (
+            "ledger_ids must be a non-empty list of positive integers, got "
+            f"{type(ledger_ids).__name__}"
+        )
+    if len(ledger_ids) == 0:
+        return "ledger_ids must not be empty"
+    for value in ledger_ids:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            return f"ledger_ids must contain only positive integers, got {value!r}"
+    return None
+
+
+def resolve_kis_mock_reconcile_scope(
+    *,
+    market: str | None,
+    symbol: str | None,
+    ledger_ids: list[int] | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Single front-layer point: validate, normalize, and shape the
+    reconciliation scope selector set (ROB-1018 fix #3, ROB-1007 fix #2/#3).
+
+    This is the ONE place that (a) checks ``market`` against the allowlist,
+    (b) structurally validates ``ledger_ids``, and (c) decides how the scope
+    gets echoed back. Both the MCP tool registration (front layer) and
+    :func:`app.mcp_server.tooling.kis_mock_ledger.kis_mock_reconciliation_run_impl`
+    (and, as of ROB-1007, the job layer itself,
+    :func:`app.jobs.kis_mock_reconciliation_job.run_kis_mock_reconciliation`)
+    call this *same* function so no layer can shape the response differently
+    or disagree on what counts as a valid selector — a job-layer bypass of
+    this exact function (building ``scope = {"market": market, ...}``
+    directly) was the ROB-1018 R4 follow-up defect this module closes.
+    Callers must invoke this *before* any other gate (config error,
+    confirm-required) so an invalid selector always short-circuits with the
+    same rejection shape regardless of what other conditions also hold.
+
+    Adding a new selector means adding a parameter here and including it in
+    both dicts below — no restructuring of call sites or gating order.
+
+    Returns ``(scope, error)`` — exactly one is not ``None``:
+
+    - ``scope``: the effective/canonical selectors (alias-normalized
+      ``market``, e.g. ``"us"`` -> ``"equity_us"``; ``ledger_ids`` as a
+      ``list[int]``), safe to use for the rest of the request. ``ledger_ids``
+      is present in the dict only when the caller supplied it — omitting it
+      preserves the exact pre-ROB-1007 two-key ``scope``/``requested_scope``
+      shape so existing exact-dict-equality assertions keep passing.
+    - ``error``: a ready-to-return rejection dict. It always carries
+      ``selector`` (``"market"`` or ``"ledger_ids"``) so callers can tell
+      structurally which selector was rejected and why, plus the verbatim,
+      unnormalized request under ``requested_scope`` (never ``scope``, since
+      no valid scope was ever established). A silent pass-through would
+      otherwise yield an ``orders_processed=0`` false-success indistinguishable
+      from "scope matched but nothing was open" — this is exactly the
+      ROB-1018 defect class, now generalized to a second selector.
+    """
+    requested_scope: dict[str, Any] = {"market": market, "symbol": symbol}
+    if ledger_ids is not None:
+        requested_scope["ledger_ids"] = ledger_ids
+
+    normalized_market = normalize_kis_mock_reconcile_market(market)
+    if (
+        normalized_market is not None
+        and normalized_market not in _ALLOWED_RECONCILE_MARKETS
+    ):
+        return None, {
+            "success": False,
+            "error": (
+                f"unknown market '{market}' — allowed values: "
+                f"{_ALLOWED_RECONCILE_MARKET_VALUES}"
+            ),
+            "selector": "market",
+            "allowed_markets": _ALLOWED_RECONCILE_MARKET_VALUES,
+            "account_mode": "kis_mock",
+            "requested_scope": requested_scope,
+        }
+
+    if ledger_ids is not None:
+        ledger_ids_error = _validate_ledger_ids(ledger_ids)
+        if ledger_ids_error:
+            return None, {
+                "success": False,
+                "error": ledger_ids_error,
+                "selector": "ledger_ids",
+                "account_mode": "kis_mock",
+                "requested_scope": requested_scope,
+            }
+
+    scope: dict[str, Any] = {"market": normalized_market, "symbol": symbol}
+    if ledger_ids is not None:
+        scope["ledger_ids"] = [int(value) for value in ledger_ids]
+    return scope, None

--- a/scripts/kis_mock_open_order_probe.py
+++ b/scripts/kis_mock_open_order_probe.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Read-only KIS mock open-order probe (ROB-1007).
+
+Answers one question: does KIS mock (VTTC8001R domestic / VTTS3035R
+overseas) ever return order-history rows with a non-zero remaining/unfilled
+quantity, or does mock always resolve orders to a terminal state
+immediately? This informs whether ``kis_mock_reconciliation_run``'s
+time-based "stale" demotion is even reachable from real mock broker
+behavior.
+
+This script is default-disabled and has NO order, modify, or cancel code
+path — it calls only the existing read-only
+``inquire_daily_order_domestic``/``inquire_daily_order_overseas`` client
+methods with ``is_mock=True`` (KIS TR VTTC8001R / VTTS3035R). It does not add
+new TR wiring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+PROBE_ENABLE_ENV = "KIS_MOCK_OPEN_ORDER_PROBE_ENABLED"
+REQUIRED_MOCK_ENV: tuple[str, ...] = (
+    "KIS_MOCK_APP_KEY",
+    "KIS_MOCK_APP_SECRET",
+    "KIS_MOCK_ACCOUNT_NO",
+)
+_REDACTED = "[REDACTED]"
+_SENSITIVE_TEXT = re.compile(
+    r"(?i)(authorization|bearer|access[_ -]?token|app[_ -]?(?:key|secret)|"
+    r"account(?:[_ -]?(?:no|number))?|cano)\\s*[:=]\\s*[^,\\s}]+"
+)
+
+
+def probe_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    import os
+
+    value = (environ or os.environ).get(PROBE_ENABLE_ENV, "")
+    return value.strip().lower() == "true"
+
+
+def missing_mock_credential_names(
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    import os
+
+    values = environ or os.environ
+    return [name for name in REQUIRED_MOCK_ENV if not values.get(name, "").strip()]
+
+
+def redact_row(
+    row: Mapping[str, Any], *, secret_values: tuple[str, ...]
+) -> dict[str, Any]:
+    """Redact known account-identifying keys plus any credential echoes.
+
+    Reuses the existing broker-key redaction helper (same convention as
+    ``scripts/kis_mock_us_cash_probe.py``) rather than inventing a second
+    redaction scheme.
+    """
+    from app.services.brokers.kiwoom.normalization import redact_broker_response
+
+    def scrub(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(k): scrub(v) for k, v in value.items()}
+        if isinstance(value, list | tuple):
+            return [scrub(item) for item in value]
+        if not isinstance(value, str):
+            return value
+        redacted = value
+        for secret in secret_values:
+            if secret:
+                redacted = redacted.replace(secret, _REDACTED)
+                redacted = redacted.replace(secret.replace("-", ""), _REDACTED)
+        return _SENSITIVE_TEXT.sub(_REDACTED, redacted)
+
+    return scrub(redact_broker_response(dict(row)))
+
+
+def _domestic_row_summary(row: Mapping[str, Any]) -> dict[str, Any]:
+    remaining = row.get("rmn_qty")
+    return {
+        "order_no": row.get("odno"),
+        "symbol": row.get("pdno"),
+        "order_qty": row.get("ord_qty"),
+        "filled_qty": row.get("tot_ccld_qty"),
+        "remaining_qty": remaining,
+        "rejected_qty": row.get("rjct_qty"),
+        "cancel_flag": row.get("cncl_yn"),
+        "order_status": (
+            "open_remaining" if _is_nonzero(remaining) else "no_remaining_qty"
+        ),
+    }
+
+
+def _overseas_row_summary(row: Mapping[str, Any]) -> dict[str, Any]:
+    remaining = row.get("nccs_qty") or row.get("rmn_qty")
+    return {
+        "order_no": row.get("odno"),
+        "symbol": row.get("pdno") or row.get("ovrs_pdno"),
+        "order_qty": row.get("ord_qty"),
+        "filled_qty": row.get("ft_ccld_qty") or row.get("tot_ccld_qty"),
+        "remaining_qty": remaining,
+        "cancel_flag": row.get("cncl_yn"),
+        "order_status": (
+            "open_remaining" if _is_nonzero(remaining) else "no_remaining_qty"
+        ),
+    }
+
+
+def _is_nonzero(value: Any) -> bool:
+    if value in (None, ""):
+        return False
+    try:
+        return float(value) != 0
+    except (TypeError, ValueError):
+        return False
+
+
+async def run_probe(*, market: str, start_date: str, end_date: str) -> int:
+    if not probe_enabled():
+        print(
+            f"[probe] disabled: set {PROBE_ENABLE_ENV}=true to permit read-only TR calls"
+        )
+        return 0
+
+    missing = missing_mock_credential_names()
+    if missing:
+        print(
+            f"[probe] missing KIS mock credentials: {', '.join(missing)} (names only)"
+        )
+        return 3
+
+    from app.services.brokers.kis.client import KISClient
+
+    client = KISClient(is_mock=True)
+    secret_values = tuple(
+        value
+        for value in (
+            str(client._settings.kis_account_no or ""),
+            str(client._settings.kis_app_key or ""),
+            str(client._settings.kis_app_secret or ""),
+        )
+        if value
+    )
+
+    exit_code = 0
+    markets = ("kr", "us") if market == "both" else (market,)
+    for mkt in markets:
+        try:
+            if mkt == "kr":
+                rows = await client.inquire_daily_order_domestic(
+                    start_date=start_date,
+                    end_date=end_date,
+                    is_mock=True,
+                )
+                summarize = _domestic_row_summary
+                tr_id = "VTTC8001R"
+            else:
+                rows = await client.inquire_daily_order_overseas(
+                    start_date=start_date,
+                    end_date=end_date,
+                    is_mock=True,
+                )
+                summarize = _overseas_row_summary
+                tr_id = "VTTS3035R"
+        except Exception as exc:  # noqa: BLE001 - diagnostic script, no fake success
+            print(
+                json.dumps(
+                    {
+                        "market": mkt,
+                        "tr_id": "VTTC8001R" if mkt == "kr" else "VTTS3035R",
+                        "rt_cd": None,
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                        "verdict": "request_failed",
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            exit_code = max(exit_code, 1)
+            continue
+
+        summaries = [
+            redact_row(summarize(row), secret_values=secret_values) for row in rows
+        ]
+        has_remaining = any(
+            row["order_status"] == "open_remaining" for row in summaries
+        )
+        print(
+            json.dumps(
+                {
+                    "market": mkt,
+                    "tr_id": tr_id,
+                    "rt_cd": "0",
+                    "row_count": len(summaries),
+                    "any_row_has_remaining_qty": has_remaining,
+                    "rows": summaries,
+                },
+                ensure_ascii=False,
+                default=str,
+            )
+        )
+    return exit_code
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    today = datetime.now(UTC).strftime("%Y%m%d")
+    week_ago = (datetime.now(UTC) - timedelta(days=7)).strftime("%Y%m%d")
+    parser = argparse.ArgumentParser(
+        prog="kis_mock_open_order_probe",
+        description=(
+            "ROB-1007 KIS mock open-order read-only TR probe "
+            "(default-disabled, no mutation)"
+        ),
+    )
+    parser.add_argument(
+        "--market",
+        choices=("kr", "us", "both"),
+        default="kr",
+        help="Which mock order-history TR to call (default kr)",
+    )
+    parser.add_argument(
+        "--start-date", default=week_ago, help="YYYYMMDD (default: 7 days ago)"
+    )
+    parser.add_argument("--end-date", default=today, help="YYYYMMDD (default: today)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        return asyncio.run(
+            run_probe(
+                market=args.market,
+                start_date=args.start_date,
+                end_date=args.end_date,
+            )
+        )
+    except KeyboardInterrupt:
+        print("[probe] interrupted")
+        return 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/scripts/kis_mock_open_order_probe.py
+++ b/scripts/kis_mock_open_order_probe.py
@@ -34,7 +34,7 @@ REQUIRED_MOCK_ENV: tuple[str, ...] = (
 _REDACTED = "[REDACTED]"
 _SENSITIVE_TEXT = re.compile(
     r"(?i)(authorization|bearer|access[_ -]?token|app[_ -]?(?:key|secret)|"
-    r"account(?:[_ -]?(?:no|number))?|cano)\\s*[:=]\\s*[^,\\s}]+"
+    r"account(?:[_ -]?(?:no|number))?|cano)\s*[:=]\s*[^,\s}]+"
 )
 
 

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -349,7 +349,9 @@ async def test_market_scope_excludes_out_of_scope_rows_end_to_end(monkeypatch):
     mock_db = AsyncMock()
     mock_lifecycle_svc = AsyncMock()
 
-    async def _list_open_orders(*, limit=100, symbol=None, instrument_type=None):
+    async def _list_open_orders(
+        *, limit=100, symbol=None, instrument_type=None, ledger_ids=None
+    ):
         # Simulate the real query-layer filter: instrument_type gates which
         # rows come back. Both a KR and a US order are open simultaneously.
         rows = [

--- a/tests/mcp_server/test_kis_mock_reconciliation_tool.py
+++ b/tests/mcp_server/test_kis_mock_reconciliation_tool.py
@@ -26,7 +26,9 @@ async def test_kis_mock_reconciliation_tool_dry_run_default(monkeypatch):
 
     result = await tools["kis_mock_reconciliation_run"]()
     assert result == {"success": True, "applied": 0}
-    mock_run.assert_awaited_once_with(dry_run=True, limit=100, market=None, symbol=None)
+    mock_run.assert_awaited_once_with(
+        dry_run=True, limit=100, market=None, symbol=None, ledger_ids=None
+    )
 
 
 @pytest.mark.asyncio
@@ -97,7 +99,9 @@ async def test_kis_mock_reconciliation_tool_apply_with_confirm(monkeypatch):
     )
 
     assert result == {"success": True, "applied": 3}
-    mock_run.assert_awaited_once_with(dry_run=False, limit=10, market=None, symbol=None)
+    mock_run.assert_awaited_once_with(
+        dry_run=False, limit=10, market=None, symbol=None, ledger_ids=None
+    )
 
 
 @pytest.mark.asyncio
@@ -119,7 +123,7 @@ async def test_kis_mock_reconciliation_tool_passes_market_and_symbol(monkeypatch
 
     assert result == {"success": True, "applied": 0}
     mock_run.assert_awaited_once_with(
-        dry_run=True, limit=10, market="us", symbol="AVGO"
+        dry_run=True, limit=10, market="us", symbol="AVGO", ledger_ids=None
     )
 
 
@@ -383,3 +387,125 @@ def test_tool_description_matches_scope_contract():
     # The stale round-1 claim ("always echoes the requested scope" as the
     # verbatim input) must be gone now that success/error paths normalize.
     assert "always echoes the requested" not in description.lower()
+
+
+# --- ROB-1007: ledger_ids selector + generalized selector-rejection shape ---
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_passes_ledger_ids(monkeypatch):
+    """ledger_ids flows through the MCP tool -> impl unchanged."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    mock_run = AsyncMock(return_value={"success": True, "applied": 0})
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](ledger_ids=[10, 20])
+
+    assert result == {"success": True, "applied": 0}
+    mock_run.assert_awaited_once_with(
+        dry_run=True, limit=100, market=None, symbol=None, ledger_ids=[10, 20]
+    )
+
+
+def test_resolve_scope_ledger_ids_valid_normalizes_to_int_list():
+    from app.mcp_server.tooling.kis_mock_ledger import resolve_kis_mock_reconcile_scope
+
+    scope, error = resolve_kis_mock_reconcile_scope(
+        market=None, symbol=None, ledger_ids=[3, 1, 2]
+    )
+
+    assert error is None
+    assert scope == {"market": None, "symbol": None, "ledger_ids": [3, 1, 2]}
+
+
+def test_resolve_scope_ledger_ids_omitted_unchanged_behavior():
+    """Omitting ledger_ids preserves the exact pre-ROB-1007 scope shape (no
+    extra key) so existing exact-dict-equality assertions elsewhere keep
+    passing."""
+    from app.mcp_server.tooling.kis_mock_ledger import resolve_kis_mock_reconcile_scope
+
+    scope, error = resolve_kis_mock_reconcile_scope(market="us", symbol="AVGO")
+
+    assert error is None
+    assert scope == {"market": "equity_us", "symbol": "AVGO"}
+    assert "ledger_ids" not in scope
+
+
+@pytest.mark.parametrize(
+    "bad_ledger_ids",
+    [
+        [],
+        [-1],
+        [0],
+        [1, "2"],
+        [1.5],
+        [True],
+    ],
+    ids=["empty", "negative", "zero", "non_integer_str", "float", "bool"],
+)
+def test_resolve_scope_rejects_invalid_ledger_ids_explicitly(bad_ledger_ids):
+    """Invalid ledger_ids must be rejected explicitly — never silently fall
+    through to a full scan."""
+    from app.mcp_server.tooling.kis_mock_ledger import resolve_kis_mock_reconcile_scope
+
+    scope, error = resolve_kis_mock_reconcile_scope(
+        market=None, symbol=None, ledger_ids=bad_ledger_ids
+    )
+
+    assert scope is None
+    assert error is not None
+    assert error["success"] is False
+    assert error["selector"] == "ledger_ids"
+    assert error["requested_scope"] == {
+        "market": None,
+        "symbol": None,
+        "ledger_ids": bad_ledger_ids,
+    }
+    # Must never look like a valid, effective scope.
+    assert "scope" not in error
+
+
+def test_error_shape_market_vs_ledger_ids_structurally_distinguishable():
+    """ROB-1007 fix #3: callers can tell structurally which selector was
+    rejected via the `selector` key, without string-parsing `error`."""
+    from app.mcp_server.tooling.kis_mock_ledger import resolve_kis_mock_reconcile_scope
+
+    _, market_error = resolve_kis_mock_reconcile_scope(market="crypto", symbol=None)
+    _, ledger_ids_error = resolve_kis_mock_reconcile_scope(
+        market=None, symbol=None, ledger_ids=[]
+    )
+
+    assert market_error["selector"] == "market"
+    assert "allowed_markets" in market_error
+    assert ledger_ids_error["selector"] == "ledger_ids"
+    assert "allowed_markets" not in ledger_ids_error
+    assert market_error["selector"] != ledger_ids_error["selector"]
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_rejects_invalid_ledger_ids_end_to_end(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+    mock_run = AsyncMock()
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](ledger_ids=[])
+
+    assert result["success"] is False
+    assert result["selector"] == "ledger_ids"
+    assert "scope" not in result
+    mock_run.assert_not_called()

--- a/tests/test_kis_mock_open_order_probe.py
+++ b/tests/test_kis_mock_open_order_probe.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/kis_mock_open_order_probe.py (ROB-1007).
+
+Convention mirrors tests/test_kis_mock_us_cash_probe.py: default-disabled
+gate, missing-credential-names-only reporting, and no mutation code path.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def probe_module():
+    return importlib.import_module("scripts.kis_mock_open_order_probe")
+
+
+@pytest.mark.asyncio
+async def test_disabled_gate_exits_without_calling_kis_client(
+    monkeypatch, capsys, probe_module
+):
+    monkeypatch.delenv("KIS_MOCK_OPEN_ORDER_PROBE_ENABLED", raising=False)
+
+    exit_code = await probe_module.run_probe(
+        market="kr", start_date="20260701", end_date="20260722"
+    )
+
+    assert exit_code == 0
+    assert "disabled" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_missing_mock_credentials_reports_names_not_values(
+    monkeypatch, capsys, probe_module
+):
+    monkeypatch.setenv("KIS_MOCK_OPEN_ORDER_PROBE_ENABLED", "true")
+    monkeypatch.setenv("KIS_MOCK_APP_KEY", "super-secret-app-key")
+    monkeypatch.delenv("KIS_MOCK_APP_SECRET", raising=False)
+    monkeypatch.delenv("KIS_MOCK_ACCOUNT_NO", raising=False)
+
+    exit_code = await probe_module.run_probe(
+        market="kr", start_date="20260701", end_date="20260722"
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 3
+    assert "KIS_MOCK_APP_SECRET" in out
+    assert "KIS_MOCK_ACCOUNT_NO" in out
+    assert "super-secret-app-key" not in out
+
+
+@pytest.mark.asyncio
+async def test_success_reports_rt_cd_row_count_and_remaining_qty_flag(
+    monkeypatch, capsys, probe_module
+):
+    monkeypatch.setenv("KIS_MOCK_OPEN_ORDER_PROBE_ENABLED", "true")
+    monkeypatch.setenv("KIS_MOCK_APP_KEY", "k")
+    monkeypatch.setenv("KIS_MOCK_APP_SECRET", "s")
+    monkeypatch.setenv("KIS_MOCK_ACCOUNT_NO", "12345678-01")
+
+    class FakeSettings:
+        kis_account_no = "12345678-01"
+        kis_app_key = "k"
+        kis_app_secret = "s"
+
+    class FakeClient:
+        def __init__(self, is_mock: bool) -> None:
+            self._settings = FakeSettings()
+
+        async def inquire_daily_order_domestic(self, **kwargs):
+            assert kwargs["is_mock"] is True
+            return [
+                {
+                    "odno": "0000000001",
+                    "pdno": "005930",
+                    "ord_qty": "10",
+                    "tot_ccld_qty": "3",
+                    "rmn_qty": "7",
+                    "rjct_qty": "0",
+                    "cncl_yn": "N",
+                },
+                {
+                    "odno": "0000000002",
+                    "pdno": "000660",
+                    "ord_qty": "5",
+                    "tot_ccld_qty": "5",
+                    "rmn_qty": "0",
+                    "rjct_qty": "0",
+                    "cncl_yn": "N",
+                },
+            ]
+
+    monkeypatch.setattr(
+        "app.services.brokers.kis.client.KISClient", FakeClient, raising=False
+    )
+
+    exit_code = await probe_module.run_probe(
+        market="kr", start_date="20260701", end_date="20260722"
+    )
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert '"rt_cd": "0"' in out
+    assert '"row_count": 2' in out
+    assert '"any_row_has_remaining_qty": true' in out
+    assert '"order_status": "open_remaining"' in out
+    assert '"order_status": "no_remaining_qty"' in out
+
+
+def test_redact_row_masks_account_and_secret_values(probe_module):
+    row = {
+        "odno": "0000000001",
+        "cano": "12345678",
+        "pdno": "005930",
+    }
+    result = probe_module.redact_row(row, secret_values=("12345678",))
+
+    assert result["odno"] == "0000000001"
+    assert "12345678" not in str(result)
+
+
+def test_probe_script_has_no_mutation_code_path(probe_module):
+    """Static guard: the probe source must never reference an
+    order-submit/modify/cancel client method — read-only inquiry methods
+    only."""
+    source = inspect.getsource(probe_module)
+    forbidden_tokens = (
+        "order_korea_stock",
+        "sell_korea_stock",
+        "cancel_korea_order",
+        "modify_korea_order",
+        "order_overseas_stock",
+        "buy_overseas_stock",
+        "sell_overseas_stock",
+        "cancel_overseas_order",
+        "modify_overseas_order",
+        "confirm=True",
+        "dry_run=False",
+    )
+    for token in forbidden_tokens:
+        assert token not in source, f"unexpected mutation-shaped token: {token}"
+
+    # Also confirm via AST that no attribute access even *looks* like an
+    # order-mutation call anywhere in the module.
+    tree = ast.parse(Path(probe_module.__file__).read_text())
+    mutation_attr_names = {
+        "order_korea_stock",
+        "sell_korea_stock",
+        "cancel_korea_order",
+        "modify_korea_order",
+        "order_overseas_stock",
+        "buy_overseas_stock",
+        "sell_overseas_stock",
+        "cancel_overseas_order",
+        "modify_overseas_order",
+    }
+    called_attrs = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert not (called_attrs & mutation_attr_names)

--- a/tests/test_kis_mock_open_order_probe.py
+++ b/tests/test_kis_mock_open_order_probe.py
@@ -123,6 +123,28 @@ def test_redact_row_masks_account_and_secret_values(probe_module):
     assert "12345678" not in str(result)
 
 
+def test_sensitive_text_regex_matches_secrets_with_whitespace(probe_module):
+    """The _SENSITIVE_TEXT pattern must compile as a real regex (\\s as a
+    whitespace class), not a literal backslash-s — otherwise the second-layer
+    redaction never fires on any secret-shaped text containing spaces."""
+    assert (
+        probe_module._SENSITIVE_TEXT.sub(probe_module._REDACTED, "access_token: abc123")
+        == "[REDACTED]"
+    )
+    assert (
+        probe_module._SENSITIVE_TEXT.sub(
+            probe_module._REDACTED, "authorization: Bearer xyz"
+        )
+        == "[REDACTED] xyz"
+    )
+    assert (
+        probe_module._SENSITIVE_TEXT.sub(
+            probe_module._REDACTED, "app_secret: shhh, other: 1"
+        )
+        == "[REDACTED], other: 1"
+    )
+
+
 def test_probe_script_has_no_mutation_code_path(probe_module):
     """Static guard: the probe source must never reference an
     order-submit/modify/cancel client method — read-only inquiry methods

--- a/tests/test_kis_mock_reconciliation_job_scope.py
+++ b/tests/test_kis_mock_reconciliation_job_scope.py
@@ -1,0 +1,140 @@
+"""ROB-1007 R4 follow-up: job-layer chokepoint bypass fix.
+
+``run_kis_mock_reconciliation`` (the job function) used to build
+``scope = {"market": market, "symbol": symbol}`` directly, bypassing
+``resolve_kis_mock_reconcile_scope`` / the allowlist entirely. That meant an
+invalid ``market`` at the job layer (reachable by any direct caller, not just
+the MCP tool) silently produced a false ``success=True, orders_processed=0``
+instead of failing closed — exactly the class of defect ROB-1018 fixed at the
+MCP-tool layer, reintroduced one layer down. These tests pin the RED case
+(before the fix: ``success=True``) to now be GREEN (``success=False``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
+
+
+@pytest.mark.asyncio
+async def test_job_layer_rejects_unknown_market_instead_of_false_success(monkeypatch):
+    """RED case from the task brief: calling the job function directly with
+    an unrecognized market must fail closed, not silently no-op-succeed."""
+    fake_lifecycle_svc = AsyncMock()
+    fake_lifecycle_svc.list_open_orders.return_value = []
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _db: fake_lifecycle_svc,
+    )
+
+    result = await run_kis_mock_reconciliation(db=MagicMock(), market="crypto-x")
+
+    # Before the fix this was {"success": True, "orders_processed": 0,
+    # "scope": {"market": "crypto-x"}} — a false success for an invalid
+    # market. It must now be an explicit rejection.
+    assert result["success"] is False
+    assert result["selector"] == "market"
+    assert "crypto-x" in result["error"]
+    assert "scope" not in result
+    assert result["requested_scope"] == {"market": "crypto-x", "symbol": None}
+    # Never reaches the open-orders query at all.
+    fake_lifecycle_svc.list_open_orders.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_job_layer_accepts_valid_market_unchanged(monkeypatch):
+    """Non-regression: a valid market still normalizes and runs exactly as
+    before the chokepoint was wired in."""
+    mock_ledger_row = MagicMock()
+    mock_ledger_row.id = 1
+    mock_ledger_row.symbol = "AVGO"
+    mock_ledger_row.side = "buy"
+    mock_ledger_row.quantity = Decimal("1")
+    mock_ledger_row.lifecycle_state = "accepted"
+    mock_ledger_row.holdings_baseline_qty = Decimal("0")
+    mock_ledger_row.trade_date = datetime.now(UTC) - timedelta(seconds=10)
+
+    fake_lifecycle_svc = AsyncMock()
+    fake_lifecycle_svc.list_open_orders.return_value = [mock_ledger_row]
+    fake_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": False}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _db: fake_lifecycle_svc,
+    )
+
+    fake_kis = MagicMock()
+    fake_kis.fetch_my_stocks = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISClient",
+        lambda *a, **kw: fake_kis,
+    )
+
+    result = await run_kis_mock_reconciliation(db=MagicMock(), market="us")
+
+    assert result["success"] is True
+    assert result["scope"] == {"market": "equity_us", "symbol": None}
+    fake_lifecycle_svc.list_open_orders.assert_awaited_once_with(
+        limit=100, symbol=None, instrument_type="equity_us", ledger_ids=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_job_layer_rejects_invalid_ledger_ids(monkeypatch):
+    fake_lifecycle_svc = AsyncMock()
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _db: fake_lifecycle_svc,
+    )
+
+    result = await run_kis_mock_reconciliation(db=MagicMock(), ledger_ids=[])
+
+    assert result["success"] is False
+    assert result["selector"] == "ledger_ids"
+    assert "scope" not in result
+    fake_lifecycle_svc.list_open_orders.assert_not_called()
+    fake_lifecycle_svc.existing_ledger_ids.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_job_layer_rejects_nonexistent_ledger_ids(monkeypatch):
+    """A structurally-valid but nonexistent ledger_id must be rejected
+    explicitly rather than silently processing zero rows as a success."""
+    fake_lifecycle_svc = AsyncMock()
+    fake_lifecycle_svc.existing_ledger_ids.return_value = {1}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _db: fake_lifecycle_svc,
+    )
+
+    result = await run_kis_mock_reconciliation(db=MagicMock(), ledger_ids=[1, 999])
+
+    assert result["success"] is False
+    assert result["selector"] == "ledger_ids"
+    assert "999" in result["error"]
+    assert result["scope"] == {"market": None, "symbol": None, "ledger_ids": [1, 999]}
+    fake_lifecycle_svc.existing_ledger_ids.assert_awaited_once_with([1, 999])
+    fake_lifecycle_svc.list_open_orders.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_job_layer_scopes_open_orders_to_valid_ledger_ids(monkeypatch):
+    fake_lifecycle_svc = AsyncMock()
+    fake_lifecycle_svc.existing_ledger_ids.return_value = {1, 2}
+    fake_lifecycle_svc.list_open_orders.return_value = []
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _db: fake_lifecycle_svc,
+    )
+
+    result = await run_kis_mock_reconciliation(db=MagicMock(), ledger_ids=[2, 1])
+
+    assert result["success"] is True
+    assert result["scope"] == {"market": None, "symbol": None, "ledger_ids": [2, 1]}
+    fake_lifecycle_svc.list_open_orders.assert_awaited_once_with(
+        limit=100, symbol=None, instrument_type=None, ledger_ids=[2, 1]
+    )


### PR DESCRIPTION
## Summary
- Read-only probe `scripts/kis_mock_open_order_probe.py` (default-disabled via `KIS_MOCK_OPEN_ORDER_PROBE_ENABLED`) calls the existing `inquire_daily_order_domestic`/`inquire_daily_order_overseas` client methods with `is_mock=True` (VTTC8001R/VTTS3035R) to check whether KIS mock ever returns open orders with remaining/unfilled qty > 0. No new TR wiring, no mutation code path.
- New `ledger_ids` selector on the single ROB-1018 chokepoint `resolve_kis_mock_reconcile_scope` (moved to `app/services/kis_mock_reconcile_scope.py` to avoid a circular import with the job layer). Valid ids narrow the run to those rows; omitted preserves existing full-scan behavior; invalid ids (empty list, negative, non-integer, nonexistent) are rejected explicitly, never silently full-scanned.
- Generalized the scope-rejection error shape: every rejection now carries a `selector` key (`"market"` or `"ledger_ids"`) so callers can tell structurally which selector was rejected, in addition to the existing market-only `allowed_markets`.
- Fixed the ROB-1018 R4 follow-up job-layer chokepoint bypass: `run_kis_mock_reconciliation` (job layer) now calls `resolve_kis_mock_reconcile_scope` itself instead of building `scope = {"market": market, "symbol": symbol}` inline — closes the false-success path where an invalid `market` at the job layer (bypassing the MCP tool) silently returned `success=True, orders_processed=0`.

## Test plan
- [x] `uv run pytest tests/ -q -k "kis_mock or reconcil"` — 844 passed
- [x] `make lint` — ruff check/format + ty all green
- [x] `git diff --check` — clean
- [x] `uv run alembic heads` — single head (no migration added)
- [x] New tests cover: ledger_ids selector pass-through, invalid ledger_ids rejection (empty/negative/non-int/bool/nonexistent), error-shape distinguishability (market vs ledger_ids), job-layer RED case (`market="crypto-x"` now `success=False`, was `success=True`), job-layer ledger_ids validation, probe disabled-gate/missing-creds/success/no-mutation-code-path (static + AST guard)
- [ ] Operator: run the probe manually against a live KIS mock account to answer the remaining-qty question (not run by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciliation can now target specific ledger IDs via the job and the reconciliation MCP tool.
  * Added consistent selector validation/normalization for market and ledger inputs across the reconciliation flow.
  * Added an opt-in, read-only probe to check mock open-order remaining quantities.

* **Bug Fixes**
  * Invalid or unknown selectors now fail immediately with clear, structured error details.
  * Open-order reconciliation is now restricted to the requested ledger scope when provided.

* **Tests**
  * Expanded coverage for ledger-id selector handling, MCP tool pass-through, scope rejection behavior, and probe safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->