### PR TITLE
policy(ROB-999): max_symbols_per_theme 1→2 완화 — 테마 중복을 고지 항목으로

### DIFF
--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,7 +2,7 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-17.3"
+version: "2026-07-22.1"
 captured_as_of: "2026-07-17"
 source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key"
 
@@ -57,9 +57,11 @@ thresholds:
     semantics: over-concentration cap per sector cluster (~9-10%)
   portfolio.max_symbols_per_theme:
     lanes: [buy, discovery]
-    value: 1
+    value: 2
     unit: count
-    semantics: one symbol per theme
+    semantics: max symbols per theme; theme overlap is a disclosure item, not an auto-reject
+      — strong expected-value candidates may be proposed with overlap stated in thesis
+      (operator risk direction 2026-07-22; concentration backstop = sector_concentration cap)
   order.day_expiry_kst:
     lanes: [buy, sell]
     value: "20:00"


### PR DESCRIPTION
## 배경
운영자 정책 방향(07-22): "테마당 1종목은 너무 타이트 — 돈을 잘 벌 수 있다면 모험적 투자 감당 가능."

실사례: 한전기술이 24h 내 세션별 상이 처리(테마 캡 기각 ×2 → 클러스터 캡 통과) — 이중 규칙 충돌.

## 변경
- `portfolio.max_symbols_per_theme`: 1 → **2**
- semantics: 테마 중복 = 자동 기각이 아닌 **thesis 고지 항목** (기대값 강하면 제안, 승인자 판단)
- `sector_concentration` %캡 advisory 유지 (과집중 방어선)
- version 2026-07-17.3 → **2026-07-22.1**

## 참고
ROB-999 감사 코멘트에 운영자 원문 채록. migration 0, 코드 무변경(정책 파일만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnyLNhp2ocP4u5hfqHeicJ