### PR TITLE
policy(ROB-999): 이익실현 티어·회복게이트 2-of-2·테마캡 2

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -87,6 +87,7 @@ class PolicyRecoveryGate(BaseModel):
     of: int
     missing_or_null_threshold: str
     conditions: list[PolicyRecoveryCondition]
+    advisory_context: list[PolicyRecoveryCondition] = Field(default_factory=list)
 
 
 class PolicySupportResistanceRule(BaseModel):

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-17.3"
-captured_as_of: "2026-07-17"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key"
+version: "2026-07-22.1"
+captured_as_of: "2026-07-22"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22"
 
 authority:
   scope: judgment_policy_only
@@ -48,8 +48,8 @@ thresholds:
     lanes: [buy]
     value: 2
     unit: count
-    of: 4
-    semantics: min recovery-gate conditions to deploy reserve (else support-conditional only)
+    of: 2
+    semantics: min countable recovery-gate conditions to deploy reserve (else support-conditional only)
   portfolio.sector_cluster_cap_pct:
     lanes: [buy, sell]
     value: 10
@@ -57,9 +57,11 @@ thresholds:
     semantics: over-concentration cap per sector cluster (~9-10%)
   portfolio.max_symbols_per_theme:
     lanes: [buy, discovery]
-    value: 1
+    value: 2
     unit: count
-    semantics: one symbol per theme
+    semantics: max symbols per theme; theme overlap is a disclosure item, not an auto-reject
+      — strong expected-value candidates may be proposed with overlap stated in thesis
+      (operator risk direction 2026-07-22; concentration backstop = sector_concentration cap)
   order.day_expiry_kst:
     lanes: [buy, sell]
     value: "20:00"
@@ -150,8 +152,20 @@ thresholds:
 decision_rules:
   sell.trim_preplace:
     lanes: [sell]
-    semantics: "Tie-break when resistance-near favors PLACE but upside-rich would otherwise allow WATCH: resistance proximity can pre-place only a small trim; upside richness limits size, not eligibility."
+    semantics: >-
+      Tiers are evaluated in declared priority order and the first match wins.
+      profit_realization is resistance-distance-independent; global exclusions
+      apply to every tier. When resistance-near favors PLACE but upside-rich
+      would otherwise allow WATCH, resistance proximity can pre-place only a
+      small trim; upside richness limits size, not eligibility.
     tiers:
+      - id: profit_realization
+        conditions:
+          # Fable governance advisory Q3-#4 Phase 1 seed; follow-up sell-policy
+          # research must recalibrate this initial threshold.
+          profit_pct_min: 8
+        action: preplace_small_trim_ladder
+        sizing: small_trim_only
       - id: rsi_confirmed_resistance
         conditions:
           rsi_min_policy_key: sell.rsi_place_min
@@ -172,6 +186,8 @@ decision_rules:
         action: register_watch
         sizing: no_preplaced_trim
     tie_breaks:
+      tier_priority: "profit_realization > rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
+      multiple_tiers_matched: first_matching_tier_wins
       sell.upside_place_max_pct: size_limit_only
     exclusions:
       - single_share_position
@@ -183,18 +199,14 @@ market_rules:
     recovery_gate:
       lanes: [buy]
       advisory: true
-      semantics: reserve deployment recovery frame; otherwise support-conditional only
+      semantics: >-
+        reserve deployment recovery frame; otherwise support-conditional only.
+        advisory_context is qualitative reference only, is not part of the gate
+        count, and receives thresholds in the crypto-gate redesign round.
       min_conditions_met: 2
-      of: 4
+      of: 2
       missing_or_null_threshold: do_not_infer_or_count_as_met
       conditions:
-        - id: fear_greed
-          metric: crypto_fear_greed_index
-          sources: [alternative_me]
-          operator: null
-          threshold: null
-          unit: index
-          semantics: reports cite a recovering trend but define no pass cutoff
         - id: alt_breadth_24h
           metric: upbit_alt_breadth_24h
           sources: [upbit_open_api_ticker_derived]
@@ -209,13 +221,21 @@ market_rules:
           threshold: 1.5
           unit: ratio
           semantics: both report inputs should remain at or below the threshold
+      advisory_context:
+        - id: fear_greed
+          metric: crypto_fear_greed_index
+          sources: [alternative_me]
+          operator: null
+          threshold: null
+          unit: index
+          semantics: qualitative reference only; no pass cutoff and excluded from gate count
         - id: btc_kimchi_premium
           metric: btc_kimchi_premium
           sources: [upbit_binance_fx]
           operator: null
           threshold: null
           unit: percent
-          semantics: reports interpret discount and domestic FOMO qualitatively; no pass cutoff
+          semantics: qualitative reference only; no pass cutoff and excluded from gate count
     support_resistance:
       lanes: [buy, sell, discovery]
       advisory: true

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -61,7 +61,7 @@ thresholds:
     unit: count
     semantics: max symbols per theme; theme overlap is a disclosure item, not an auto-reject
       — strong expected-value candidates may be proposed with overlap stated in thesis
-      (operator risk direction 2026-07-22; concentration backstop = sector_concentration cap)
+      (operator risk direction 2026-07-22; concentration backstop = portfolio.sector_cluster_cap_pct)
   order.day_expiry_kst:
     lanes: [buy, sell]
     value: "20:00"

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-17.3"
+    assert out["version"] == "2026-07-22.1"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,9 +23,15 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-17.3"
+    assert out["version"] == "2026-07-22.1"
     assert len(out["content_hash"]) == 12
-    assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
+    gate = out["market_rules"]["recovery_gate"]
+    assert gate["min_conditions_met"] == 2
+    assert gate["of"] == 2
+    assert [context["id"] for context in gate["advisory_context"]] == [
+        "fear_greed",
+        "btc_kimchi_premium",
+    ]
     assert out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
 
 
@@ -34,9 +40,11 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     out = await get_trading_policy(market="kr", lane="sell")
     assert out["success"] is True
     rule = out["decision_rules"]["sell.trim_preplace"]
+    assert rule["tiers"][0]["id"] == "profit_realization"
+    assert rule["tiers"][0]["conditions"]["profit_pct_min"] == 8
     assert rule["tiers"][0]["action"] == "preplace_small_trim_ladder"
-    assert rule["tiers"][1]["conditions"]["resistance_near_pct_max"] == 2
-    assert rule["tiers"][2]["action"] == "register_watch"
+    assert rule["tiers"][2]["conditions"]["resistance_near_pct_max"] == 2
+    assert rule["tiers"][3]["action"] == "register_watch"
 
 
 @pytest.mark.asyncio

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,23 +15,29 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-17.3"
+    assert doc.version == "2026-07-22.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
     assert doc.thresholds["screen.rsi_max"].value == 45
     assert doc.thresholds["buy.deep_limit_pct_range"].value == [-12, -3]
+    assert doc.thresholds["portfolio.max_symbols_per_theme"].value == 2
     assert set(doc.market_overrides.keys()) == {"kr", "us", "crypto"}
     assert "semis_memory" in doc.sector_clusters
     assert "sell.trim_preplace" in doc.decision_rules
     trim_rule = doc.decision_rules["sell.trim_preplace"]
     assert trim_rule.lanes == ["sell"]
     assert [tier.id for tier in trim_rule.tiers] == [
+        "profit_realization",
         "rsi_confirmed_resistance",
         "ultra_near_resistance",
         "watch_zone",
     ]
-    assert trim_rule.tiers[1].conditions["resistance_near_pct_max"] == 2
+    assert trim_rule.tiers[0].conditions["profit_pct_min"] == 8
+    assert trim_rule.tiers[2].conditions["resistance_near_pct_max"] == 2
+    assert trim_rule.tie_breaks["multiple_tiers_matched"] == (
+        "first_matching_tier_wins"
+    )
     assert trim_rule.tie_breaks["sell.upside_place_max_pct"] == "size_limit_only"
 
 
@@ -52,23 +58,24 @@ def test_crypto_market_rules_preserve_report_derived_and_null_thresholds():
     gate = rules.recovery_gate
 
     assert gate.min_conditions_met == 2
-    assert gate.of == 4
+    assert gate.of == 2
     assert [condition.id for condition in gate.conditions] == [
-        "fear_greed",
         "alt_breadth_24h",
         "btc_long_short_ratio",
-        "btc_kimchi_premium",
     ]
-    assert gate.conditions[0].threshold is None
-    assert (gate.conditions[1].operator, gate.conditions[1].threshold) == (
+    assert (gate.conditions[0].operator, gate.conditions[0].threshold) == (
         "gt",
         50,
     )
-    assert (gate.conditions[2].operator, gate.conditions[2].threshold) == (
+    assert (gate.conditions[1].operator, gate.conditions[1].threshold) == (
         "lte",
         1.5,
     )
-    assert gate.conditions[3].threshold is None
+    assert [context.id for context in gate.advisory_context] == [
+        "fear_greed",
+        "btc_kimchi_premium",
+    ]
+    assert all(context.threshold is None for context in gate.advisory_context)
     assert rules.no_chasing.daily_change_pct_threshold is None
     assert rules.no_chasing.min_trade_value_24h_krw is None
     assert rules.support_resistance.source_priority == [

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -438,10 +438,10 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "resting"
     assert refreshed.approved_by_telegram_user_id is None
-    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-17.3"
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-22.1"
     text, keyboard, _chat_id = notifier.sent_messages[0]
     assert "자동 접수됨" in text
-    assert "auto:policy@2026-07-17.3" in text
+    assert "auto:policy@2026-07-22.1" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
 

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -5,7 +5,7 @@ from app.services import trading_policy_service as svc
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-17.3"
+    assert stamp["version"] == "2026-07-22.1"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,13 +15,15 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-17.3"
+    assert view["version"] == "2026-07-22.1"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
     assert t["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert t["portfolio.sector_cluster_cap_pct"]["source"] == "default"
+    assert t["portfolio.max_symbols_per_theme"]["value"] == 2
     assert t["recovery_gate.min_conditions_met"]["value"] == 2
+    assert t["recovery_gate.min_conditions_met"]["of"] == 2
     assert t["sell.loss_guard_min_multiple"]["value"] == 1.01
     # sell-only threshold must NOT appear in the buy lane
     assert "sell.rsi_place_min" not in t
@@ -31,7 +33,7 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
 def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     view = svc.get_policy_for("crypto", "buy")
 
-    assert view["version"] == "2026-07-17.3"
+    assert view["version"] == "2026-07-22.1"
     assert set(view["market_rules"]) == {
         "recovery_gate",
         "support_resistance",
@@ -39,7 +41,15 @@ def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     }
     gate = view["market_rules"]["recovery_gate"]
     assert gate["min_conditions_met"] == 2
-    assert gate["of"] == 4
+    assert gate["of"] == 2
+    assert [condition["id"] for condition in gate["conditions"]] == [
+        "alt_breadth_24h",
+        "btc_long_short_ratio",
+    ]
+    assert [context["id"] for context in gate["advisory_context"]] == [
+        "fear_greed",
+        "btc_kimchi_premium",
+    ]
     assert "lanes" not in gate
     assert view["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
 
@@ -60,12 +70,13 @@ def test_get_policy_for_sell_lane_has_sell_keys():
     assert t["sell.rsi_place_min"]["value"] == 58
     assert "screen.rsi_max" not in t
     rule = view["decision_rules"]["sell.trim_preplace"]
-    assert rule["tiers"][0]["id"] == "rsi_confirmed_resistance"
-    assert rule["tiers"][0]["conditions"]["rsi_min_policy_key"] == (
+    assert rule["tiers"][0]["id"] == "profit_realization"
+    assert rule["tiers"][0]["conditions"]["profit_pct_min"] == 8
+    assert rule["tiers"][1]["conditions"]["rsi_min_policy_key"] == (
         "sell.rsi_place_min"
     )
-    assert rule["tiers"][1]["conditions"]["resistance_near_pct_max"] == 2
-    assert rule["tiers"][2]["action"] == "register_watch"
+    assert rule["tiers"][2]["conditions"]["resistance_near_pct_max"] == 2
+    assert rule["tiers"][3]["action"] == "register_watch"
     assert rule["tie_breaks"]["sell.upside_place_max_pct"] == "size_limit_only"
 
 


### PR DESCRIPTION
## 배경

Fable 거버넌스 자문 Phase 1(Q3 #4/#6)에 따라 이익 lot 매도 공백과 crypto 회복게이트의 2-of-4 착시를 정정합니다. 운영자 지시에 따라 닫힌 #1638의 테마캡 완화도 이 PR에 흡수했습니다.

## 변경

- `sell.trim_preplace` 최우선 `profit_realization` 티어 추가
  - `profit_pct_min: 8` 초기값
  - 저항 거리 비의존 소액 트림, 전역 exclusions 동일 적용
  - 선언 순서 우선·복수 매치 시 first-match tie 명시
  - 후속 리서치 보정 의무 주석
- crypto `recovery_gate`를 실효 `2 of 2`로 정정
  - countable: `alt_breadth_24h`, `btc_long_short_ratio`
  - `fear_greed`, `btc_kimchi_premium`은 `advisory_context`로 이동
  - 정성 참고·카운트 제외·임계 발명 금지·crypto 게이트 재설계 라운드 후속 명시
  - `advisory: true`, 미달 시 support-conditional 의미 유지
- #1638의 `portfolio.max_symbols_per_theme: 2` 변경 흡수
- 정책 버전 `2026-07-22.1`로 단일 bump
- `PolicyRecoveryGate.advisory_context` 최소 스키마 지원과 버전핀/응답 계약 테스트 갱신

## 검증

- YAML `safe_load` 및 `TradingPolicyDocument` 로더 검증
- policy service / `get_trading_policy` 응답 계약: 49 passed
- Ruff lint/format 통과
- [GitHub Actions 전체 검증](https://github.com/mgh3326/auto_trader/actions/runs/29894588342): pytest 4/4 shards, lint/format/ty, security, TaskIQ smoke green
- 서비스 구현 변경 0, migration 0

## 범위 메모

- #1638을 supersede하며 해당 변경을 포함합니다.
- 운영자 승인 범위에 따라 서비스 구현은 변경하지 않았습니다. 기존 `route_request_lanes.py`의 설명 문자열에 남아 있는 `of 4` 문구는 이 PR 범위 밖이며, authoritative `get_trading_policy` 응답은 `2 of 2`입니다.
