### PR TITLE
fix(kis): re-POST order on gateway per-second throttle rejection (EGW00201)

### DIFF
--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -10,8 +10,13 @@ from app.services.kr_symbol_universe_service import is_nxt_eligible
 
 from . import constants
 from .base import _log_kis_api_failure
+from .order_throttle import (
+    MAX_THROTTLE_RESUBMITS,
+    is_provider_throttle_reject,
+    throttle_backoff_seconds,
+)
 from .pre_send import PreSendHook
-from .send_outcome import OrderSendOutcomeTracker
+from .send_outcome import OrderSendDisposition, OrderSendOutcomeTracker
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -253,6 +258,7 @@ class DomesticOrderClient:
         pre_send_hook: PreSendHook | None = None,
         send_outcome: OrderSendOutcomeTracker | None = None,
         _token_retry_depth: int = 0,
+        _throttle_retry_depth: int = 0,
     ) -> dict:
         """
         국내주식 주문 (매수/매도)
@@ -331,6 +337,14 @@ class DomesticOrderClient:
             f"tr_id: {tr_id}, routing: {body['EXCG_ID_DVSN_CD']}"
         )
 
+        # ROB-BAC: always observe the send outcome, so a gateway throttle
+        # rejection (provably NOT_CREATED) can be told apart from an ambiguous
+        # one. Callers that pass their own tracker keep it — their contract is
+        # unchanged, and a locally created tracker is never returned.
+        outcome = (
+            send_outcome if send_outcome is not None else OrderSendOutcomeTracker()
+        )
+
         js = await self._parent._request_with_rate_limit(
             "POST",
             self._parent._kis_url(constants.DOMESTIC_ORDER_URL),
@@ -347,12 +361,11 @@ class DomesticOrderClient:
             # ROB-843 P1: mock-only freshness re-check fired at the actual HTTP
             # send boundary (None for live → identical behavior).
             pre_send_hook=pre_send_hook,
-            send_outcome=send_outcome,
+            send_outcome=outcome,
         )
 
         if js.get("rt_cd") != "0":
-            if send_outcome is not None:
-                send_outcome.mark_provider_rejected()
+            outcome.mark_provider_rejected()
             msg_cd = js.get("msg_cd", "")
             msg1 = js.get("msg1", "")
             _log_kis_api_failure(
@@ -397,7 +410,56 @@ class DomesticOrderClient:
                     pre_send_hook=pre_send_hook,
                     send_outcome=send_outcome,
                     _token_retry_depth=_token_retry_depth + 1,
+                    _throttle_retry_depth=_throttle_retry_depth,
                 )
+
+            # ROB-BAC: a gateway per-second throttle rejection is declined
+            # *before* the order engine — the <500 response with rt_cd != "0"
+            # and no ODNO proves no order exists, so a bounded re-POST carries
+            # no double-submit risk. ROB-645's "never re-POST" still governs
+            # every ambiguous outcome: the NOT_CREATED check below excludes the
+            # 5xx-with-body case, and timeouts never reach here at all.
+            if is_provider_throttle_reject(msg_cd, msg1):
+                if outcome.disposition is not OrderSendDisposition.NOT_CREATED:
+                    logging.error(
+                        "국내주식 주문 초당한도 거절이나 결과 불확정(http=%s) - "
+                        "fail-closed (stock_code=%s, order_type=%s)",
+                        outcome.last_http_status,
+                        stock_code,
+                        order_type,
+                    )
+                elif _throttle_retry_depth < MAX_THROTTLE_RESUBMITS:
+                    delay = throttle_backoff_seconds(_throttle_retry_depth)
+                    logging.warning(
+                        "국내주식 주문 초당 거래건수 초과(%s) - %.2fs 후 재전송(%d/%d) "
+                        "(stock_code=%s, order_type=%s)",
+                        msg_cd,
+                        delay,
+                        _throttle_retry_depth + 1,
+                        MAX_THROTTLE_RESUBMITS,
+                        stock_code,
+                        order_type,
+                    )
+                    await asyncio.sleep(delay)
+                    return await self.order_korea_stock(
+                        stock_code,
+                        order_type,
+                        quantity,
+                        price,
+                        is_mock,
+                        pre_send_hook=pre_send_hook,
+                        send_outcome=send_outcome,
+                        _token_retry_depth=_token_retry_depth,
+                        _throttle_retry_depth=_throttle_retry_depth + 1,
+                    )
+                else:
+                    logging.error(
+                        "국내주식 주문 초당한도 재전송 캡(%d) 초과 - fail-closed "
+                        "(stock_code=%s, order_type=%s)",
+                        MAX_THROTTLE_RESUBMITS,
+                        stock_code,
+                        order_type,
+                    )
 
             error_msg = f"{msg_cd} {msg1}"
             raise RuntimeError(error_msg)

--- a/app/services/brokers/kis/order_throttle.py
+++ b/app/services/brokers/kis/order_throttle.py
@@ -1,0 +1,64 @@
+"""KIS gateway throttle rejections on order POSTs (ROB-BAC).
+
+Background
+----------
+ROB-585/ROB-645 throttle order TRs to 8/s process-locally and then disable every
+re-POST (``retry_request_errors=False`` + ``max_retries_override=0``) so an order
+whose outcome is ambiguous is never sent twice. That rule is correct for
+timeouts, transport errors and 5xx bodies — none of them prove the broker did
+not create an order.
+
+It is *not* correct for a gateway throttle rejection. KIS answers
+``EGW00201 초당 거래건수를 초과하였습니다`` with a normal (<500) HTTP response
+carrying ``rt_cd != "0"`` and no ``ODNO``: the request was declined at the
+gateway, before the order engine, and provably no order exists. Treating it as a
+terminal rejection burns a live sell for the whole session even though a single
+re-POST a fraction of a second later would have been accepted.
+
+The process-local limiter cannot prevent these on its own: KIS meters per app
+key across *all* TRs, while :data:`app.core.config.DEFAULT_KIS_API_RATE_LIMITS`
+buckets per endpoint, and several processes share one key. So a throttle
+rejection is expected occasionally and must be survivable.
+
+This module holds the narrow classifier + backoff used by the order paths. The
+re-POST it enables is gated on the send outcome being provably ``NOT_CREATED``;
+see :mod:`app.services.brokers.kis.send_outcome`.
+"""
+
+from __future__ import annotations
+
+# Bounded re-POST cap for gateway throttle rejections. Mirrors the existing
+# token-expiry cap (ROB-739): a small finite number, never an unbounded loop.
+MAX_THROTTLE_RESUBMITS = 2
+
+# Documented KIS gateway throttle codes. EGW00201 is the account/app-key-wide
+# per-second limit observed on live overseas orders; EGW00215 is the ledger
+# limit ROB-585 originally paced against.
+THROTTLE_MSG_CODES = frozenset({"EGW00201", "EGW00215"})
+
+
+def is_provider_throttle_reject(msg_cd: object, msg1: object) -> bool:
+    """True when a ``rt_cd != "0"`` body is a gateway per-second throttle.
+
+    Matches the documented codes first, then falls back to the message text so
+    an undocumented sibling code still classifies. The text probe requires both
+    "초당" and "초과" so unrelated "초과" messages (e.g. 주문가능금액 초과) are
+    not misread as retryable.
+    """
+
+    code = str(msg_cd or "").strip().upper()
+    if code in THROTTLE_MSG_CODES:
+        return True
+
+    message = str(msg1 or "")
+    return "초당" in message and "초과" in message
+
+
+def throttle_backoff_seconds(depth: int) -> float:
+    """Backoff before re-POST attempt ``depth`` (0-based).
+
+    The limit is per second, so waiting out the current window is enough; the
+    delay grows so a second collision is not retried at the same cadence.
+    """
+
+    return 0.25 * (2 ** max(depth, 0))

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -8,7 +8,13 @@ from typing import TYPE_CHECKING, Any
 from app.core.symbol import to_kis_symbol
 
 from . import constants
+from .order_throttle import (
+    MAX_THROTTLE_RESUBMITS,
+    is_provider_throttle_reject,
+    throttle_backoff_seconds,
+)
 from .pre_send import PreSendHook
+from .send_outcome import OrderSendDisposition, OrderSendOutcomeTracker
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -102,7 +108,9 @@ class OverseasOrderClient:
         is_mock: bool = False,
         *,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
         _token_retry_depth: int = 0,
+        _throttle_retry_depth: int = 0,
     ) -> dict:
         """
         해외주식 주문 (매수/매도)
@@ -203,6 +211,12 @@ class OverseasOrderClient:
             body.get("OVRS_ORD_UNPR"),
         )
 
+        # ROB-BAC: see order_korea_stock — always observe the send outcome so a
+        # gateway throttle rejection can be told apart from an ambiguous one.
+        outcome = (
+            send_outcome if send_outcome is not None else OrderSendOutcomeTracker()
+        )
+
         js = await self._parent._request_with_rate_limit(
             "POST",
             self._parent._kis_url(constants.OVERSEAS_ORDER_URL),
@@ -216,9 +230,11 @@ class OverseasOrderClient:
             max_retries_override=0,
             # ROB-843 P1: mock-only freshness re-check at the HTTP send boundary.
             pre_send_hook=pre_send_hook,
+            send_outcome=outcome,
         )
 
         if js.get("rt_cd") != "0":
+            outcome.mark_provider_rejected()
             if js.get("msg_cd") in ["EGW00123", "EGW00121"]:
                 if _token_retry_depth >= _MAX_TOKEN_REFRESH_RESUBMITS:
                     # ROB-733: 캡 초과 → 재-POST 대신 fail-closed. 실 자금 다중 제출 차단.
@@ -253,8 +269,62 @@ class OverseasOrderClient:
                     price,
                     is_mock,
                     pre_send_hook=pre_send_hook,
+                    send_outcome=send_outcome,
                     _token_retry_depth=_token_retry_depth + 1,
+                    _throttle_retry_depth=_throttle_retry_depth,
                 )
+
+            # ROB-BAC: bounded re-POST on a gateway per-second throttle. The
+            # rejection is issued before the order engine, so the <500 response
+            # with rt_cd != "0" and no ODNO proves no order was created — the
+            # one rt_cd != "0" family for which ROB-645's "never re-POST" does
+            # not apply. Ambiguous outcomes (5xx-with-body, timeouts) still
+            # fail closed via the NOT_CREATED check.
+            if is_provider_throttle_reject(js.get("msg_cd"), js.get("msg1")):
+                if outcome.disposition is not OrderSendDisposition.NOT_CREATED:
+                    logging.error(
+                        "해외주식 주문 초당한도 거절이나 결과 불확정(http=%s) - "
+                        "fail-closed (symbol=%s, exchange=%s, order_type=%s)",
+                        outcome.last_http_status,
+                        symbol,
+                        exchange_code,
+                        order_type,
+                    )
+                elif _throttle_retry_depth < MAX_THROTTLE_RESUBMITS:
+                    delay = throttle_backoff_seconds(_throttle_retry_depth)
+                    logging.warning(
+                        "해외주식 주문 초당 거래건수 초과(%s) - %.2fs 후 재전송(%d/%d) "
+                        "(symbol=%s, exchange=%s, order_type=%s)",
+                        js.get("msg_cd"),
+                        delay,
+                        _throttle_retry_depth + 1,
+                        MAX_THROTTLE_RESUBMITS,
+                        symbol,
+                        exchange_code,
+                        order_type,
+                    )
+                    await asyncio.sleep(delay)
+                    return await self.order_overseas_stock(
+                        symbol,
+                        exchange_code,
+                        order_type,
+                        quantity,
+                        price,
+                        is_mock,
+                        pre_send_hook=pre_send_hook,
+                        send_outcome=send_outcome,
+                        _token_retry_depth=_token_retry_depth,
+                        _throttle_retry_depth=_throttle_retry_depth + 1,
+                    )
+                else:
+                    logging.error(
+                        "해외주식 주문 초당한도 재전송 캡(%d) 초과 - fail-closed "
+                        "(symbol=%s, exchange=%s, order_type=%s)",
+                        MAX_THROTTLE_RESUBMITS,
+                        symbol,
+                        exchange_code,
+                        order_type,
+                    )
 
             error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
             logging.error(f"해외주식 주문 실패: {error_msg}")

--- a/tests/test_kis_order_throttle_repost.py
+++ b/tests/test_kis_order_throttle_repost.py
@@ -1,0 +1,271 @@
+"""ROB-BAC: gateway per-second throttle rejections on order POSTs are retried.
+
+Live evidence (2026-07-22 us-live session): two KIS overseas sells (BAC, IVV)
+were answered ``EGW00201 초당 거래건수를 초과하였습니다`` and terminalized as
+``rejected`` while five sibling sells on the same account succeeded. The
+rejection is issued at the gateway, before the order engine — no order exists —
+so a bounded re-POST is safe and is the difference between a filled trim and a
+session-long dead proposal.
+
+These tests pin both halves of that contract: the throttle family re-POSTs
+within a hard cap, and every *ambiguous* outcome still fails closed exactly as
+ROB-645 requires.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.services.brokers.kis.order_throttle import (
+    MAX_THROTTLE_RESUBMITS,
+    is_provider_throttle_reject,
+    throttle_backoff_seconds,
+)
+from app.services.brokers.kis.send_outcome import OrderSendOutcomeTracker
+
+_THROTTLE_BODY = {
+    "rt_cd": "1",
+    "msg_cd": "EGW00201",
+    "msg1": "초당 거래건수를 초과하였습니다.",
+}
+_ACCEPTED_BODY = {
+    "rt_cd": "0",
+    "output": {"ODNO": "0030808418", "ORD_TMD": "233959"},
+    "msg1": "정상처리 되었습니다.",
+}
+
+
+def _make_parent(responses):
+    """Parent whose transport yields ``responses`` in order."""
+    parent = MagicMock()
+    parent._ensure_token = AsyncMock()
+    parent._hdr_base = {}
+    parent._kis_url = lambda path: f"https://host{path}"
+    settings = MagicMock()
+    settings.kis_account_no = "1234567890"
+    settings.kis_access_token = "test-token"
+    parent._settings = settings
+    parent._request_with_rate_limit = AsyncMock(side_effect=list(responses))
+    return parent
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Keep the backoff contract but not its wall-clock cost."""
+    slept: list[float] = []
+
+    async def _fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(
+        "app.services.brokers.kis.overseas_orders.asyncio.sleep", _fake_sleep
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.kis.domestic_orders.asyncio.sleep", _fake_sleep
+    )
+    return slept
+
+
+@pytest.fixture(autouse=True)
+def _no_nxt(monkeypatch):
+    from app.services.brokers.kis import domestic_orders
+
+    monkeypatch.setattr(
+        domestic_orders, "is_nxt_eligible", AsyncMock(return_value=False)
+    )
+
+
+def _overseas(responses):
+    from app.services.brokers.kis.overseas_orders import OverseasOrderClient
+
+    parent = _make_parent(responses)
+    return OverseasOrderClient(parent), parent
+
+
+def _domestic(responses):
+    from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+
+    parent = _make_parent(responses)
+    return DomesticOrderClient(parent), parent
+
+
+@pytest.mark.unit
+class TestThrottleClassifier:
+    def test_documented_codes_classify(self):
+        assert is_provider_throttle_reject(
+            "EGW00201", "초당 거래건수를 초과하였습니다."
+        )
+        assert is_provider_throttle_reject("EGW00215", "초당 거래건수 초과")
+
+    def test_undocumented_code_falls_back_to_message(self):
+        assert is_provider_throttle_reject(
+            "EGW99999", "초당 거래건수를 초과하였습니다."
+        )
+
+    def test_business_rejections_are_not_throttles(self):
+        # The one that must never be re-POSTed: a real order-engine rejection.
+        assert not is_provider_throttle_reject(
+            "APBK0656", "주문가능금액을 초과하였습니다."
+        )
+        assert not is_provider_throttle_reject(
+            "APBK0918", "주문가능수량을 초과하였습니다"
+        )
+        assert not is_provider_throttle_reject(None, None)
+
+    def test_backoff_grows_and_is_bounded(self):
+        delays = [throttle_backoff_seconds(d) for d in range(MAX_THROTTLE_RESUBMITS)]
+        assert delays == sorted(delays)
+        assert all(0 < d <= 2.0 for d in delays)
+
+
+@pytest.mark.unit
+class TestOverseasThrottleRepost:
+    """The BAC/IVV path."""
+
+    @pytest.mark.asyncio
+    async def test_throttled_sell_reposts_and_succeeds(self, _no_sleep):
+        instance, parent = _overseas([_THROTTLE_BODY, _ACCEPTED_BODY])
+
+        result = await instance.order_overseas_stock(
+            "BAC", "NYSE", "sell", 1, 62.15, is_mock=False
+        )
+
+        assert result["odno"] == "0030808418"
+        assert parent._request_with_rate_limit.await_count == 2
+        assert _no_sleep == [throttle_backoff_seconds(0)]
+
+    @pytest.mark.asyncio
+    async def test_repost_is_capped_then_fails_closed(self, _no_sleep):
+        instance, parent = _overseas([_THROTTLE_BODY] * (MAX_THROTTLE_RESUBMITS + 1))
+
+        with pytest.raises(RuntimeError, match="EGW00201"):
+            await instance.order_overseas_stock(
+                "BAC", "NYSE", "sell", 1, 62.15, is_mock=False
+            )
+
+        assert parent._request_with_rate_limit.await_count == MAX_THROTTLE_RESUBMITS + 1
+
+    @pytest.mark.asyncio
+    async def test_repost_preserves_order_parameters(self):
+        instance, parent = _overseas([_THROTTLE_BODY, _ACCEPTED_BODY])
+
+        await instance.order_overseas_stock(
+            "BAC", "NYSE", "sell", 1, 62.15, is_mock=False
+        )
+
+        first, second = parent._request_with_rate_limit.await_args_list
+        assert first.kwargs["json_body"] == second.kwargs["json_body"]
+        assert first.kwargs["tr_id"] == second.kwargs["tr_id"]
+
+    @pytest.mark.asyncio
+    async def test_business_rejection_is_not_reposted(self):
+        instance, parent = _overseas(
+            [
+                {
+                    "rt_cd": "1",
+                    "msg_cd": "APBK0656",
+                    "msg1": "주문가능금액을 초과하였습니다.",
+                }
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="APBK0656"):
+            await instance.order_overseas_stock(
+                "BAC", "NYSE", "sell", 1, 62.15, is_mock=False
+            )
+
+        assert parent._request_with_rate_limit.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_still_sends_exactly_once(self):
+        instance, parent = _overseas([])
+        parent._request_with_rate_limit = AsyncMock(side_effect=httpx.ReadTimeout(""))
+
+        with pytest.raises(httpx.ReadTimeout):
+            await instance.order_overseas_stock(
+                "BAC", "NYSE", "sell", 1, 62.15, is_mock=False
+            )
+
+        assert parent._request_with_rate_limit.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_throttle_body_carried_by_5xx_fails_closed(self):
+        """A 5xx never proves the order was not created — no re-POST."""
+        instance, parent = _overseas([])
+
+        async def _respond(*args, **kwargs):
+            tracker = kwargs["send_outcome"]
+            tracker.mark_dispatched()
+            tracker.mark_http_response(500)
+            return _THROTTLE_BODY
+
+        parent._request_with_rate_limit = AsyncMock(side_effect=_respond)
+
+        with pytest.raises(RuntimeError, match="EGW00201"):
+            await instance.order_overseas_stock(
+                "BAC", "NYSE", "sell", 1, 62.15, is_mock=False
+            )
+
+        assert parent._request_with_rate_limit.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_caller_tracker_is_threaded_through_the_repost(self):
+        """The re-POST re-uses the caller's tracker, not a detached copy.
+
+        Each dispatch re-marks it (``mark_dispatched`` clears the previous
+        attempt), so the caller ends up observing the *final* attempt rather
+        than the intermediate throttle rejection.
+        """
+        instance, parent = _overseas([_THROTTLE_BODY, _ACCEPTED_BODY])
+        tracker = OrderSendOutcomeTracker()
+
+        await instance.order_overseas_stock(
+            "BAC", "NYSE", "sell", 1, 62.15, is_mock=False, send_outcome=tracker
+        )
+
+        seen = [
+            call.kwargs["send_outcome"]
+            for call in parent._request_with_rate_limit.await_args_list
+        ]
+        assert seen == [tracker, tracker]
+
+
+@pytest.mark.unit
+class TestDomesticThrottleRepost:
+    @pytest.mark.asyncio
+    async def test_throttled_order_reposts_and_succeeds(self):
+        instance, parent = _domestic([_THROTTLE_BODY, _ACCEPTED_BODY])
+
+        result = await instance.order_korea_stock("005930", "sell", 1, 70000)
+
+        assert result["odno"] == "0030808418"
+        assert parent._request_with_rate_limit.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_repost_is_capped_then_fails_closed(self):
+        instance, parent = _domestic([_THROTTLE_BODY] * (MAX_THROTTLE_RESUBMITS + 1))
+
+        with pytest.raises(RuntimeError, match="EGW00201"):
+            await instance.order_korea_stock("005930", "sell", 1, 70000)
+
+        assert parent._request_with_rate_limit.await_count == MAX_THROTTLE_RESUBMITS + 1
+
+    @pytest.mark.asyncio
+    async def test_business_rejection_is_not_reposted(self):
+        instance, parent = _domestic(
+            [
+                {
+                    "rt_cd": "1",
+                    "msg_cd": "APBK0918",
+                    "msg1": "주문가능수량을 초과하였습니다",
+                }
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="APBK0918"):
+            await instance.order_korea_stock("005930", "sell", 1, 70000)
+
+        assert parent._request_with_rate_limit.await_count == 1


### PR DESCRIPTION
## 실측 (2026-07-22 us-live 세션)

운영자가 텔레그램 제안을 전건 승인했으나 **BAC 매도가 실패**했다. 원장 실측 결과 실패는 BAC 단독이 아니라 **BAC + IVV 2건**이고, 둘 다 동일한 broker 사유코드였다:

```
review.order_proposal_rungs.void_reason
  = "EGW00201 초당 거래건수를 초과하였습니다."
```

| 심볼 | 계좌 | rung state | broker_order_id |
|---|---|---|---|
| AMZN | kis_live | resting | 0030808418 |
| **BAC** | kis_live | **rejected** | **없음** |
| GOOGL | kis_live | resting | 0030808911 |
| **IVV** | kis_live | **rejected** | **없음** |
| XOM | kis_live | resting | 0030811127 |
| QQQ·QQQM·VOO·SPYM·NVDA·AVGO·ORCL | toss_live | resting | (전건 정상) |

**대조군이 원인을 좁힌다**: 같은 계좌·같은 방향(매도)·같은 수량(1주)의 KIS 주문 3건이 같은 몇 분 안에 정상 접수됐다. 따라서 잔고·손실가드·호가단위·계좌 라우팅·접수 시간창은 전부 원인이 아니다 — 매도라 현금 게이트가 걸릴 이유도 없고, 실제로 다른 매도는 통과했다. 남는 변수는 **KIS 게이트웨이 초당 한도 충돌**뿐이다.

## 원인 (확정)

`order_overseas_stock`은 ROB-645에 따라 `retry_request_errors=False` + `max_retries_override=0`으로 **모든 재-POST를 차단**한다. 그래서 transport에 이미 있는 rate-limit 재시도 휴리스틱(`"초과"` 매칭)이 주문 경로에서는 절대 발동하지 않고, `rt_cd != "0"`이 그대로 `RuntimeError`가 되어 rung이 `rejected`(terminal, 전이 없음)로 확정된다. 코멘트도 이 동작을 명시하고 있다: *"orders that still exceed it fail fast, never re-sent."*

그 규칙은 **타임아웃·전송오류·5xx**에는 옳다 — 주문이 접수됐는지 알 수 없으므로 재전송하면 이중체결 위험이 있다. 그러나 EGW00201은 다르다:

- HTTP <500 정상 응답, `rt_cd != "0"`, `ODNO` 없음
- 주문 엔진 **이전** 게이트웨이 단계에서 거절 → **주문이 생성되지 않았음이 증명됨**

즉 재-POST가 안전한 유일한 `rt_cd != "0"` 계열인데, 영구 거절과 한 덩어리로 묶여 있었다.

부수 피해: 실패해도 `review.order_send_intents` 예약(BAC `id=65`, IVV `id=66`)이 남아 해당 거래일 idempotency key가 소모된다 → 동일 주문 재시도조차 `DuplicateOrderIntent`로 차단된다.

## 수정

- `app/services/brokers/kis/order_throttle.py` 신설 — throttle 분류기 + bounded backoff. 메시지 fallback은 `"초당"`과 `"초과"`를 **둘 다** 요구하므로 `주문가능금액을 초과하였습니다` 같은 실제 업무 거절은 절대 분류되지 않는다.
- `order_overseas_stock` / `order_korea_stock` — cap 2회 bounded re-POST. `OrderSendDisposition.NOT_CREATED` 게이트로 **5xx가 실어나른 throttle body는 재전송하지 않는다**. token-refresh 재전송 예산과 별도로 카운트되며 양쪽 다 유한하다.
- `order_overseas_stock`에 optional `send_outcome` 파라미터 추가 + `mark_provider_rejected()` 호출 — 국내 경로와 동일해짐.

ROB-645 계약은 그대로다: 모호한 결과는 전부 fail-closed. 테스트로 고정했다.

## 테스트

`tests/test_kis_order_throttle_repost.py` (14건) — 재전송 성공/캡/파라미터 동일성, 업무거절 미재전송, 타임아웃 1회 전송, 5xx fail-closed, tracker 스레딩. 회귀: KIS 주문·브로커·ledger 스위트 **1252건 green**, lint/format/ty 통과. migration 0.

## 남은 것 (이 PR 범위 밖)

1. **구조적 원인** — KIS는 app key 단위로 **전 TR 합산** 초당 한도를 매기는데 `DEFAULT_KIS_API_RATE_LIMITS`는 **엔드포인트별로** 버킷을 나눈다(quote 20/s + balance 10/s + order 8/s). 게다가 limiter는 프로세스 로컬인데 여러 프로세스가 같은 키를 공유한다. 즉 로컬 limiter로는 이 충돌을 막을 수 없고, 이 PR은 발생 시 생존만 보장한다. 전역(Redis) limiter가 근본 해결.
2. **live intent 해제** — 확정적 NOT_CREATED 거절 시 `order_send_intents` 예약을 풀어주면 사후 재시도가 가능해진다. live double-send 가드를 건드리므로 별도 리뷰 필요.
3. **관측** — `kis_live_order_ledger`에 이번 세션 행이 0건이다. proposals 전송 경로가 이 원장에 기록하지 않는 것으로 보이며, 별도 확인 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary per-second gateway throttling during domestic and overseas stock orders.
  * Automatically retries eligible throttled requests with bounded backoff.
  * Prevents duplicate submissions when the request outcome is uncertain.
  * Preserves order details and tracks the final submission outcome across retries.

* **Tests**
  * Added coverage for throttle detection, retry limits, backoff behavior, request preservation, and fail-closed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->