### PR TITLE
fix(order-proposals): approval dispatch visibility + typed dispatch state (ROB-1044 P0)

### DIFF
--- a/alembic/versions/20260723_approval_dispatch_ledger.py
+++ b/alembic/versions/20260723_approval_dispatch_ledger.py
@@ -1,0 +1,285 @@
+"""Durable, caller-visible Telegram approval dispatch attempts.
+
+Revision ID: 20260723_approval_dispatch
+Revises: 20260722_rob1023_widen_runner
+Create Date: 2026-07-23
+
+This revision is additive and performs no data backfill. Existing proposals,
+including still-pending approvals, retain NULL dispatch metadata until a new
+dispatch attempt occurs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260723_approval_dispatch"
+down_revision: str = "20260722_rob1023_widen_runner"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SCHEMA = "review"
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE review.order_proposals "
+        "ADD COLUMN IF NOT EXISTS approval_dispatch_state TEXT"
+    )
+    op.execute(
+        "ALTER TABLE review.order_proposals "
+        "ADD COLUMN IF NOT EXISTS approval_dispatch_attempt_id UUID"
+    )
+    op.execute(
+        "ALTER TABLE review.order_proposals "
+        "ADD COLUMN IF NOT EXISTS approval_dispatch_attempted_at TIMESTAMPTZ"
+    )
+    op.execute(
+        "ALTER TABLE review.order_proposals "
+        "ADD COLUMN IF NOT EXISTS approval_dispatch_failure_code TEXT"
+    )
+    op.execute(
+        "ALTER TABLE review.order_proposals "
+        "ADD COLUMN IF NOT EXISTS approval_dispatch_payload_chars BIGINT"
+    )
+    for definition in (
+        "approval_dispatch_card_kind TEXT",
+        "approval_dispatch_membership_revision INTEGER",
+        "approval_dispatch_membership_digest TEXT",
+        "approval_dispatch_published_at TIMESTAMPTZ",
+    ):
+        op.execute(
+            f"ALTER TABLE review.order_proposals ADD COLUMN IF NOT EXISTS {definition}"
+        )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'order_proposals_approval_dispatch_state'
+                  AND conrelid = 'review.order_proposals'::regclass
+            ) THEN
+                ALTER TABLE review.order_proposals
+                    ADD CONSTRAINT order_proposals_approval_dispatch_state
+                    CHECK (
+                        approval_dispatch_state IS NULL
+                        OR approval_dispatch_state IN (
+                            'pending',
+                            'sent_current',
+                            'sent_superseded',
+                            'failed',
+                            'partial_failed',
+                            'failed_superseded'
+                        )
+                    );
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'order_proposals_approval_dispatch_card_kind'
+                  AND conrelid = 'review.order_proposals'::regclass
+            ) THEN
+                ALTER TABLE review.order_proposals
+                    ADD CONSTRAINT order_proposals_approval_dispatch_card_kind
+                    CHECK (
+                        approval_dispatch_card_kind IS NULL
+                        OR approval_dispatch_card_kind IN (
+                            'manual',
+                            'reconfirm',
+                            'auto_veto',
+                            'loss_cut_confirmation'
+                        )
+                    );
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS review.order_proposal_approval_dispatch_attempts (
+            id BIGSERIAL PRIMARY KEY,
+            attempt_id UUID NOT NULL,
+            proposal_pk BIGINT NOT NULL,
+            state TEXT NOT NULL,
+            attempted_at TIMESTAMPTZ NOT NULL,
+            completed_at TIMESTAMPTZ,
+            payload_chars BIGINT NOT NULL,
+            context_message_count INTEGER NOT NULL DEFAULT 0,
+            message_id BIGINT,
+            status_code INTEGER,
+            telegram_error_code INTEGER,
+            error_classification TEXT,
+            failure_code TEXT,
+            card_kind TEXT NOT NULL,
+            membership_revision INTEGER NOT NULL,
+            membership_digest TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_order_proposal_approval_dispatch_attempt_id
+                UNIQUE (attempt_id),
+            CONSTRAINT fk_order_proposal_approval_dispatch_attempt_proposal
+                FOREIGN KEY (proposal_pk)
+                REFERENCES review.order_proposals(id) ON DELETE RESTRICT,
+            CONSTRAINT order_proposal_approval_dispatch_attempt_state
+                CHECK (
+                    state IN (
+                        'pending',
+                        'sent_current',
+                        'sent_superseded',
+                        'failed',
+                        'partial_failed',
+                        'failed_superseded'
+                    )
+                ),
+            CONSTRAINT order_proposal_approval_dispatch_attempt_card_kind
+                CHECK (
+                    card_kind IN (
+                        'manual',
+                        'reconfirm',
+                        'auto_veto',
+                        'loss_cut_confirmation'
+                    )
+                )
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+            ix_order_proposal_approval_dispatch_attempts_proposal
+        ON review.order_proposal_approval_dispatch_attempts
+            (proposal_pk, attempted_at)
+        """
+    )
+    for definition in (
+        "approval_dispatch_state TEXT",
+        "approval_dispatch_attempt_id UUID",
+        "approval_dispatch_attempted_at TIMESTAMPTZ",
+        "approval_dispatch_published_at TIMESTAMPTZ",
+        "approval_dispatch_failure_code TEXT",
+        "approval_dispatch_payload_chars BIGINT",
+        "telegram_status_code INTEGER",
+        "telegram_error_code INTEGER",
+        "error_classification TEXT",
+        "membership_revision INTEGER",
+        "membership_digest TEXT",
+        "membership_frozen_at TIMESTAMPTZ",
+    ):
+        op.execute(
+            "ALTER TABLE review.order_proposal_approval_batches "
+            f"ADD COLUMN IF NOT EXISTS {definition}"
+        )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'order_proposal_approval_batches_dispatch_state'
+                  AND conrelid =
+                    'review.order_proposal_approval_batches'::regclass
+            ) THEN
+                ALTER TABLE review.order_proposal_approval_batches
+                    ADD CONSTRAINT
+                        order_proposal_approval_batches_dispatch_state
+                    CHECK (
+                        approval_dispatch_state IS NULL
+                        OR approval_dispatch_state IN (
+                            'pending',
+                            'sent_current',
+                            'sent_superseded',
+                            'failed',
+                            'partial_failed',
+                            'failed_superseded'
+                        )
+                    );
+            END IF;
+        END
+        $$;
+        """
+    )
+    for definition in (
+        "membership_revision INTEGER",
+        "approval_dispatch_attempt_id_snapshot UUID",
+        "approval_membership_revision_snapshot INTEGER",
+        "approval_membership_digest_snapshot TEXT",
+        "approval_card_kind_snapshot TEXT",
+    ):
+        op.execute(
+            "ALTER TABLE review.order_proposal_approval_batch_members "
+            f"ADD COLUMN IF NOT EXISTS {definition}"
+        )
+
+
+def downgrade() -> None:
+    for column in (
+        "approval_card_kind_snapshot",
+        "approval_membership_digest_snapshot",
+        "approval_membership_revision_snapshot",
+        "approval_dispatch_attempt_id_snapshot",
+        "membership_revision",
+    ):
+        op.execute(
+            "ALTER TABLE review.order_proposal_approval_batch_members "
+            f"DROP COLUMN IF EXISTS {column}"
+        )
+    op.execute(
+        "ALTER TABLE review.order_proposal_approval_batches "
+        "DROP CONSTRAINT IF EXISTS "
+        "order_proposal_approval_batches_dispatch_state"
+    )
+    for column in (
+        "membership_frozen_at",
+        "membership_digest",
+        "membership_revision",
+        "error_classification",
+        "telegram_error_code",
+        "telegram_status_code",
+        "approval_dispatch_payload_chars",
+        "approval_dispatch_failure_code",
+        "approval_dispatch_published_at",
+        "approval_dispatch_attempted_at",
+        "approval_dispatch_attempt_id",
+        "approval_dispatch_state",
+    ):
+        op.execute(
+            "ALTER TABLE review.order_proposal_approval_batches "
+            f"DROP COLUMN IF EXISTS {column}"
+        )
+    op.execute("DROP TABLE IF EXISTS review.order_proposal_approval_dispatch_attempts")
+    op.execute(
+        "ALTER TABLE review.order_proposals "
+        "DROP CONSTRAINT IF EXISTS order_proposals_approval_dispatch_card_kind"
+    )
+    op.execute(
+        "ALTER TABLE review.order_proposals "
+        "DROP CONSTRAINT IF EXISTS order_proposals_approval_dispatch_state"
+    )
+    for column in (
+        "approval_dispatch_payload_chars",
+        "approval_dispatch_published_at",
+        "approval_dispatch_membership_digest",
+        "approval_dispatch_membership_revision",
+        "approval_dispatch_card_kind",
+        "approval_dispatch_failure_code",
+        "approval_dispatch_attempted_at",
+        "approval_dispatch_attempt_id",
+        "approval_dispatch_state",
+    ):
+        op.execute(
+            f"ALTER TABLE {_SCHEMA}.order_proposals DROP COLUMN IF EXISTS {column}"
+        )

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -734,6 +734,39 @@ order mutation.
     Telegram approval message without being discarded. Account/market pairs
     without the existing cancel adapter and multi-rung ladders also remain
     human-gated so veto and all-or-human fallback are enforceable.
+  - The response always includes `approval_dispatch`. Proposal persistence can
+    still succeed while Telegram fails, but those outcomes are distinct:
+    `approval_dispatch.ok`, `state`, `message_id`, HTTP `status_code`, Telegram
+    numeric `error_code`, allowlisted `error_classification`, `failure_code`,
+    and conservative `payload_chars` are returned to the caller. Telegram's
+    remote `description` is discarded at the HTTP boundary and is never
+    returned, logged, or persisted; a present description that is not an exact
+    allowlisted constant is reduced to `unknown_telegram_error`.
+  - Every dispatch attempt is committed as `pending` before Telegram I/O and
+    finalized into the closed
+    `sent_current`/`sent_superseded`/`failed`/`partial_failed` state set only
+    after the current-owner fence. Caller `ok=true` is derived only from
+    `sent_current`; a physically sent stale attempt returns
+    `state="superseded"` and `failure_code="approval_dispatch_superseded"`.
+    Proposal summary fields
+    (`approval_dispatch_state`, `approval_dispatch_attempted_at`,
+    `approval_dispatch_failure_code`, `approval_dispatch_payload_chars`) and
+    the per-attempt ledger row remain durable. A failed attempt invalidates
+    its nonce; a retry mints a new nonce.
+  - Telegram `sendMessage` payloads are checked against a conservative 4,096
+    UTF-16-unit ceiling. When the full rendered card is too long, the complete
+    thesis/strategy is split losslessly into plain-text context messages. The
+    short inline-button card is sent only after every context message succeeds;
+    a context failure publishes no approval button.
+  - Callback data binds the current attempt ID, card kind, membership revision,
+    membership digest, and nonce. Manual approval/deny, batch approval,
+    auto-veto, and loss-cut confirmation all cross the same fail-closed gate;
+    only `sent_current` may consume a nonce or reach broker submit/cancel.
+  - Batch cards are immutable published snapshots. The second eligible member
+    freezes a staged batch before publication; later proposals create a new
+    batch instead of editing the published card. Batch callbacks recompute and
+    verify the exact ordered membership digest, so a row not shown on the card
+    cannot be approved.
 - `order_proposal_void(proposal_id, reason)`
   - Requires a non-blank operator reason.
   - Pre-submit rungs retain the existing local `voided` path. An `unverified`

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import logging
 import re
 import uuid
+from collections.abc import Mapping
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from app.core.config import settings
@@ -29,7 +31,15 @@ from app.services.order_proposals.buying_power import (
     currency_for_market,
     default_buying_power_reader,
 )
-from app.services.order_proposals.dispatch import dispatch_proposal
+from app.services.order_proposals.dispatch import (
+    dispatch_proposal,
+    record_approval_dispatch_failure,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalDispatchState,
+    ApprovalPublication,
+    TelegramDispatchResult,
+)
 from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalNotFound,
@@ -95,6 +105,14 @@ def _group_dict(g: Any) -> dict[str, Any]:
             str(g.superseded_by_proposal_id) if g.superseded_by_proposal_id else None
         ),
         "valid_until": g.valid_until.isoformat() if g.valid_until else None,
+        "approval_dispatch_state": g.approval_dispatch_state,
+        "approval_dispatch_attempted_at": (
+            g.approval_dispatch_attempted_at.isoformat()
+            if g.approval_dispatch_attempted_at
+            else None
+        ),
+        "approval_dispatch_failure_code": g.approval_dispatch_failure_code,
+        "approval_dispatch_payload_chars": g.approval_dispatch_payload_chars,
         "created_at": g.created_at.isoformat() if g.created_at else None,
     }
 
@@ -116,6 +134,177 @@ def _get_trade_notifier() -> Any:
     from app.monitoring.trade_notifier.notifier import get_trade_notifier
 
     return get_trade_notifier()
+
+
+def _approval_dispatch_ledger_error_result() -> TelegramDispatchResult:
+    """Return the fixed, non-sensitive fallback for post-commit ledger loss."""
+    return TelegramDispatchResult(
+        state=ApprovalDispatchState.FAILED,
+        message_id=None,
+        status_code=None,
+        error_code=None,
+        error_classification=None,
+        payload_chars=0,
+        failure_code="approval_dispatch_ledger_error",
+    )
+
+
+async def _record_post_commit_dispatch_failure(
+    proposal_id: uuid.UUID,
+    *,
+    publication: ApprovalPublication,
+    now: datetime,
+) -> TelegramDispatchResult:
+    """Record a failed dispatch without ever invalidating create success."""
+    try:
+        result = await record_approval_dispatch_failure(
+            proposal_id,
+            publication=publication,
+            now=now,
+        )
+        if not isinstance(result, TelegramDispatchResult):
+            raise TypeError("unexpected approval dispatch result")
+        return result
+    except Exception as exc:  # noqa: BLE001 - proposal commit is irreversible here
+        logger.error(
+            "order_proposal_create.approval_dispatch_ledger_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "failure_code": "approval_dispatch_ledger_error",
+                "exception_type": type(exc).__name__,
+            },
+        )
+        return _approval_dispatch_ledger_error_result()
+
+
+async def _dispatch_after_proposal_commit(
+    proposal_id: uuid.UUID,
+) -> TelegramDispatchResult:
+    """Run dispatch/attempt-ledger work behind a closed post-commit boundary."""
+    try:
+        dispatch_now = now_kst()
+        if (
+            settings.ORDER_PROPOSALS_TELEGRAM_ENABLED
+            and settings.order_proposals_telegram_chat_allowlist
+        ):
+            try:
+                from app.monitoring.trade_notifier.notifier import (
+                    get_trade_notifier,
+                )
+
+                result = await dispatch_proposal(
+                    proposal_id,
+                    notifier=get_trade_notifier(),
+                    now=dispatch_now,
+                )
+                if not isinstance(result, TelegramDispatchResult):
+                    raise TypeError("unexpected approval dispatch result")
+                return result
+            except Exception as exc:  # noqa: BLE001 - proposal is already durable
+                logger.error(
+                    "order_proposal_create.approval_dispatch_failed",
+                    extra={
+                        "proposal_id": str(proposal_id),
+                        "failure_code": "approval_dispatch_internal_error",
+                        "exception_type": type(exc).__name__,
+                    },
+                )
+                publication = ApprovalPublication.failed(
+                    payload_chars=0,
+                    failure_code="approval_dispatch_internal_error",
+                )
+                return await _record_post_commit_dispatch_failure(
+                    proposal_id,
+                    publication=publication,
+                    now=dispatch_now,
+                )
+
+        failure_code = (
+            "telegram_disabled"
+            if not settings.ORDER_PROPOSALS_TELEGRAM_ENABLED
+            else "telegram_allowlist_empty"
+        )
+        return await _record_post_commit_dispatch_failure(
+            proposal_id,
+            publication=ApprovalPublication.failed(
+                payload_chars=0,
+                failure_code=failure_code,
+            ),
+            now=dispatch_now,
+        )
+    except Exception as exc:  # noqa: BLE001 - final post-commit containment
+        logger.error(
+            "order_proposal_create.approval_dispatch_boundary_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "failure_code": "approval_dispatch_ledger_error",
+                "exception_type": type(exc).__name__,
+            },
+        )
+        return _approval_dispatch_ledger_error_result()
+
+
+async def _complete_committed_proposal_create(
+    committed_result: Mapping[str, Any],
+    *,
+    proposal_id: uuid.UUID,
+    superseded_message: tuple[Any, Any] | None,
+    normalized_action: str,
+    account_mode: str,
+    side: str,
+    broker_account_id: str | None,
+    market: str,
+) -> dict[str, Any]:
+    """Attach optional post-commit work while preserving durable create success."""
+    result = dict(committed_result)
+    try:
+        if superseded_message is not None:
+            await _edit_superseded_approval_message(
+                chat_id=superseded_message[0],
+                message_id=superseded_message[1],
+                replacement_proposal_id=proposal_id,
+            )
+
+        if (
+            normalized_action == "place"
+            and account_mode == "toss_live"
+            and side == "buy"
+        ):
+            try:
+                async with AsyncSessionLocal() as advisory_session:
+                    advisory = await build_create_advisory(
+                        advisory_session,
+                        account_mode=account_mode,
+                        broker_account_id=broker_account_id,
+                        currency=currency_for_market(market),
+                        now=now_kst(),
+                        buying_power_reader=default_buying_power_reader,
+                    )
+                result["buying_power_advisory"] = [advisory]
+                warning = advisory.get("warning")
+                if warning:
+                    result["warnings"] = [warning]
+            except Exception:  # noqa: BLE001 - advisory never blocks create
+                logger.exception(
+                    "order_proposal_create: buying-power advisory failed for "
+                    "proposal_id=%s",
+                    proposal_id,
+                )
+
+        dispatch_result = await _dispatch_after_proposal_commit(proposal_id)
+        result["approval_dispatch"] = dispatch_result.as_dict()
+        return result
+    except Exception as exc:  # noqa: BLE001 - committed create result is immutable
+        logger.error(
+            "order_proposal_create.post_commit_boundary_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "failure_code": "approval_dispatch_ledger_error",
+                "exception_type": type(exc).__name__,
+            },
+        )
+        result["approval_dispatch"] = _approval_dispatch_ledger_error_result().as_dict()
+        return result
 
 
 def _escape_telegram_markdown(value: str) -> str:
@@ -146,7 +335,7 @@ async def _edit_voided_approval_message(
             f"🗑️ 제안 무효화됨\n사유: {_escape_telegram_markdown(void_reason)}",
             reply_markup={"inline_keyboard": []},
         )
-        if edited is False:
+        if not edited.ok:
             logger.error(
                 "order_proposal_void: telegram message edit returned false "
                 "for message_id=%s",
@@ -177,7 +366,7 @@ async def _edit_expired_approval_message(
             f"⏰ 제안 만료됨\n종목: {_escape_telegram_markdown(symbol)}",
             reply_markup={"inline_keyboard": []},
         )
-        if edited is False:
+        if not edited.ok:
             logger.error(
                 "order_proposal_expire_sweep: telegram message edit returned "
                 "false for message_id=%s",
@@ -329,79 +518,36 @@ async def order_proposal_create(
                 )
             await session.commit()
             proposal_id = group.proposal_id
-            result = {
-                "success": True,
-                "proposal_id": str(proposal_id),
-                "lifecycle_state": group.lifecycle_state,
-                "action": group.action or "place",
-                "target_broker_order_id": group.target_broker_order_id,
-                "valid_until": group.valid_until.isoformat()
-                if group.valid_until
-                else None,
-                "rungs": [_rung_dict(r) for r in saved_rungs],
-            }
-
-        if superseded_message is not None:
-            await _edit_superseded_approval_message(
-                chat_id=superseded_message[0],
-                message_id=superseded_message[1],
-                replacement_proposal_id=proposal_id,
+            # Freeze the caller-visible create success at the commit boundary.
+            # Every later activity is optional post-commit work and may only
+            # attach nested status; it cannot replace this durable success.
+            committed_result = MappingProxyType(
+                {
+                    "success": True,
+                    "proposal_id": str(proposal_id),
+                    "lifecycle_state": group.lifecycle_state,
+                    "action": group.action or "place",
+                    "target_broker_order_id": group.target_broker_order_id,
+                    "valid_until": (
+                        group.valid_until.isoformat() if group.valid_until else None
+                    ),
+                    "rungs": [_rung_dict(r) for r in saved_rungs],
+                }
             )
 
-        if (
-            normalized_action == "place"
-            and account_mode == "toss_live"
-            and side == "buy"
-        ):
-            try:
-                async with AsyncSessionLocal() as advisory_session:
-                    advisory = await build_create_advisory(
-                        advisory_session,
-                        account_mode=account_mode,
-                        broker_account_id=broker_account_id,
-                        currency=currency_for_market(market),
-                        now=now_kst(),
-                        buying_power_reader=default_buying_power_reader,
-                    )
-                result["buying_power_advisory"] = [advisory]
-                warning = advisory.get("warning")
-                if warning:
-                    result["warnings"] = [warning]
-            except Exception:  # noqa: BLE001 - advisory never blocks create
-                logger.exception(
-                    "order_proposal_create: buying-power advisory failed for "
-                    "proposal_id=%s",
-                    proposal_id,
-                )
-
-        # Best-effort Telegram dispatch (ROB-816 PR 2). The proposal's own
-        # session above is already closed/committed by this point --
-        # `dispatch_proposal` opens a genuinely separate session, so
-        # this is intentional, not a nested-session bug. A dispatch failure
-        # (Telegram down, notifier misconfigured, etc.) must never fail this
-        # tool's contract -- the proposal has already persisted successfully.
-        if (
-            settings.ORDER_PROPOSALS_TELEGRAM_ENABLED
-            and settings.order_proposals_telegram_chat_allowlist
-        ):
-            try:
-                from app.monitoring.trade_notifier.notifier import (
-                    get_trade_notifier,
-                )
-
-                await dispatch_proposal(
-                    proposal_id,
-                    notifier=get_trade_notifier(),
-                    now=now_kst(),
-                )
-            except Exception:  # noqa: BLE001 - best-effort, never fail create
-                logger.exception(
-                    "order_proposal_create: telegram approval dispatch failed "
-                    "for proposal_id=%s",
-                    proposal_id,
-                )
-
-        return result
+        # Telegram dispatch and every secondary ledger path live behind a
+        # separate never-raise boundary. The proposal transaction above is
+        # already closed and its immutable success snapshot is authoritative.
+        return await _complete_committed_proposal_create(
+            committed_result,
+            proposal_id=proposal_id,
+            superseded_message=superseded_message,
+            normalized_action=normalized_action,
+            account_mode=account_mode,
+            side=side,
+            broker_account_id=broker_account_id,
+            market=market,
+        )
     except OrderProposalUnsupportedTargetAction as exc:
         return {
             "success": False,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -52,6 +52,7 @@ from .order_proposals import (
     OrderProposal,
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
+    OrderProposalApprovalDispatchAttempt,
     OrderProposalRung,
 )
 from .paper_cohort import (
@@ -225,6 +226,7 @@ __all__ = [
     "OrderProposal",
     "OrderProposalApprovalBatch",
     "OrderProposalApprovalBatchMember",
+    "OrderProposalApprovalDispatchAttempt",
     "OrderProposalRung",
     "BrokerType",
     "MarketType",

--- a/app/models/order_proposals.py
+++ b/app/models/order_proposals.py
@@ -57,6 +57,19 @@ class OrderProposal(Base):
             f"lifecycle_state IN ({_GROUP_STATES_SQL})",
             name="order_proposals_lifecycle_state",
         ),
+        CheckConstraint(
+            "approval_dispatch_state IS NULL OR "
+            "approval_dispatch_state IN "
+            "('pending','sent_current','sent_superseded','failed',"
+            "'partial_failed','failed_superseded')",
+            name="order_proposals_approval_dispatch_state",
+        ),
+        CheckConstraint(
+            "approval_dispatch_card_kind IS NULL OR "
+            "approval_dispatch_card_kind IN "
+            "('manual','reconfirm','auto_veto','loss_cut_confirmation')",
+            name="order_proposals_approval_dispatch_card_kind",
+        ),
         Index("ix_order_proposals_root", "root_proposal_id"),
         Index("ix_order_proposals_state", "lifecycle_state"),
         Index("ix_order_proposals_symbol", "symbol"),
@@ -108,6 +121,21 @@ class OrderProposal(Base):
     source_asof: Mapped[dict | None] = mapped_column(JSONB)
     approval_nonce: Mapped[str | None] = mapped_column(Text)
     approval_nonce_used_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    approval_dispatch_state: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_attempt_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True)
+    )
+    approval_dispatch_attempted_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    approval_dispatch_failure_code: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_payload_chars: Mapped[int | None] = mapped_column(BigInteger)
+    approval_dispatch_card_kind: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_membership_revision: Mapped[int | None] = mapped_column(Integer)
+    approval_dispatch_membership_digest: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_published_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True)
     )
     approved_by_telegram_user_id: Mapped[str | None] = mapped_column(Text)
@@ -176,6 +204,64 @@ class OrderProposalRung(Base):
     )
 
 
+class OrderProposalApprovalDispatchAttempt(Base):
+    __tablename__ = "order_proposal_approval_dispatch_attempts"
+    __table_args__ = (
+        UniqueConstraint(
+            "attempt_id", name="uq_order_proposal_approval_dispatch_attempt_id"
+        ),
+        CheckConstraint(
+            "state IN ('pending','sent_current','sent_superseded','failed',"
+            "'partial_failed','failed_superseded')",
+            name="order_proposal_approval_dispatch_attempt_state",
+        ),
+        CheckConstraint(
+            "card_kind IN ('manual','reconfirm','auto_veto','loss_cut_confirmation')",
+            name="order_proposal_approval_dispatch_attempt_card_kind",
+        ),
+        Index(
+            "ix_order_proposal_approval_dispatch_attempts_proposal",
+            "proposal_pk",
+            "attempted_at",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    attempt_id: Mapped[uuid.UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
+    proposal_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposals.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    state: Mapped[str] = mapped_column(Text, nullable=False)
+    attempted_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    payload_chars: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    context_message_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    message_id: Mapped[int | None] = mapped_column(BigInteger)
+    status_code: Mapped[int | None] = mapped_column(Integer)
+    telegram_error_code: Mapped[int | None] = mapped_column(Integer)
+    error_classification: Mapped[str | None] = mapped_column(Text)
+    failure_code: Mapped[str | None] = mapped_column(Text)
+    card_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    membership_revision: Mapped[int] = mapped_column(Integer, nullable=False)
+    membership_digest: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class OrderProposalApprovalBatch(Base):
     __tablename__ = "order_proposal_approval_batches"
     __table_args__ = (
@@ -185,6 +271,13 @@ class OrderProposalApprovalBatch(Base):
         CheckConstraint(
             "summary_dispatch_state IN ('idle','sending','sent')",
             name="order_proposal_approval_batches_summary_state",
+        ),
+        CheckConstraint(
+            "approval_dispatch_state IS NULL OR "
+            "approval_dispatch_state IN "
+            "('pending','sent_current','sent_superseded','failed',"
+            "'partial_failed','failed_superseded')",
+            name="order_proposal_approval_batches_dispatch_state",
         ),
         Index(
             "ix_order_proposal_approval_batches_chat_window",
@@ -217,6 +310,26 @@ class OrderProposalApprovalBatch(Base):
         Text, nullable=False, server_default="idle"
     )
     summary_dispatch_lease_until: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    approval_dispatch_state: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_attempt_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True)
+    )
+    approval_dispatch_attempted_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    approval_dispatch_published_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    approval_dispatch_failure_code: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_payload_chars: Mapped[int | None] = mapped_column(BigInteger)
+    telegram_status_code: Mapped[int | None] = mapped_column(Integer)
+    telegram_error_code: Mapped[int | None] = mapped_column(Integer)
+    error_classification: Mapped[str | None] = mapped_column(Text)
+    membership_revision: Mapped[int | None] = mapped_column(Integer)
+    membership_digest: Mapped[str | None] = mapped_column(Text)
+    membership_frozen_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True)
     )
     created_at: Mapped[datetime] = mapped_column(
@@ -258,6 +371,13 @@ class OrderProposalApprovalBatchMember(Base):
     )
     approval_nonce_snapshot: Mapped[str] = mapped_column(Text, nullable=False)
     approval_message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    membership_revision: Mapped[int | None] = mapped_column(Integer)
+    approval_dispatch_attempt_id_snapshot: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True)
+    )
+    approval_membership_revision_snapshot: Mapped[int | None] = mapped_column(Integer)
+    approval_membership_digest_snapshot: Mapped[str | None] = mapped_column(Text)
+    approval_card_kind_snapshot: Mapped[str | None] = mapped_column(Text)
     result: Mapped[str | None] = mapped_column(Text)
     result_detail: Mapped[dict | None] = mapped_column(JSONB)
     processed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))

--- a/app/monitoring/trade_notifier/__init__.py
+++ b/app/monitoring/trade_notifier/__init__.py
@@ -2,12 +2,15 @@
 
 import httpx  # noqa: F401 — needed for backward-compatible test patching
 
+from app.telegram_contract import TelegramMethodResult
+
 from .notifier import TradeNotifier, get_trade_notifier
 from .types import DiscordEmbed, DiscordField
 
 __all__ = [
     "DiscordEmbed",
     "DiscordField",
+    "TelegramMethodResult",
     "TradeNotifier",
     "get_trade_notifier",
 ]

--- a/app/monitoring/trade_notifier/notifier.py
+++ b/app/monitoring/trade_notifier/notifier.py
@@ -12,6 +12,11 @@ import httpx
 
 from app.core.timezone import format_datetime
 from app.services.fill_notification import FillEnrichment, FillOrder
+from app.telegram_contract import (
+    TelegramErrorClassification,
+    TelegramMethodResult,
+    telegram_text_length,
+)
 
 from . import formatters_discord as fmt_discord
 from . import formatters_telegram as fmt_telegram
@@ -173,18 +178,24 @@ class TradeNotifier:
     async def send_approval_message(
         self,
         text: str,
-        inline_keyboard: dict[str, Any],
+        inline_keyboard: dict[str, Any] | None,
         *,
         chat_id: str,
-    ) -> int | None:
+        parse_mode: str | None = "Markdown",
+    ) -> TelegramMethodResult:
         """Send a Telegram approval message using the singleton HTTP client."""
         if not self._http_client or not self._bot_token:
-            return None
+            return TelegramMethodResult.failed(
+                payload_chars=telegram_text_length(text),
+                failure_code="telegram_notifier_unconfigured",
+                error_classification=TelegramErrorClassification.NOT_CONFIGURED,
+            )
         return await send_telegram_message(
             http_client=self._http_client,
             bot_token=self._bot_token,
             chat_id=chat_id,
             text=text,
+            parse_mode=parse_mode,
             reply_markup=inline_keyboard,
         )
 
@@ -207,10 +218,14 @@ class TradeNotifier:
         message_id: int,
         text: str,
         reply_markup: dict[str, Any] | None = None,
-    ) -> bool:
+    ) -> TelegramMethodResult:
         """Edit a Telegram message using the singleton HTTP client."""
         if not self._http_client or not self._bot_token:
-            return False
+            return TelegramMethodResult.failed(
+                payload_chars=telegram_text_length(text),
+                failure_code="telegram_notifier_unconfigured",
+                error_classification=TelegramErrorClassification.NOT_CONFIGURED,
+            )
         return await edit_message_text(
             http_client=self._http_client,
             bot_token=self._bot_token,

--- a/app/monitoring/trade_notifier/transports.py
+++ b/app/monitoring/trade_notifier/transports.py
@@ -4,11 +4,147 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import httpx
 
+from app.telegram_contract import (
+    TELEGRAM_SEND_MESSAGE_TEXT_LIMIT,
+    TelegramErrorClassification,
+    TelegramMethodResult,
+    classify_telegram_response_error,
+    telegram_text_length,
+)
+
 logger = logging.getLogger(__name__)
+
+_TELEGRAM_BOT_URL_RE = re.compile(
+    r"(?P<prefix>https?://api\.telegram\.org/bot)[^/\s\"']+",
+    flags=re.IGNORECASE,
+)
+_TELEGRAM_BOT_PATH_RE = re.compile(
+    r"(?P<prefix>/bot)[^/\s\"']+(?P<suffix>/(?:sendMessage|editMessageText|answerCallbackQuery))",
+    flags=re.IGNORECASE,
+)
+
+
+def _redact_telegram_token(value: Any) -> Any:
+    if isinstance(value, str):
+        redacted = _TELEGRAM_BOT_URL_RE.sub(r"\g<prefix>[REDACTED]", value)
+        return _TELEGRAM_BOT_PATH_RE.sub(r"\g<prefix>[REDACTED]\g<suffix>", redacted)
+    if isinstance(value, bytes):
+        return _redact_telegram_token(value.decode("utf-8", errors="replace")).encode()
+    if isinstance(value, tuple):
+        return tuple(_redact_telegram_token(item) for item in value)
+    if isinstance(value, list):
+        return [_redact_telegram_token(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            _redact_telegram_token(key): _redact_telegram_token(item)
+            for key, item in value.items()
+        }
+    return value
+
+
+class _TelegramTokenRedactionFilter(logging.Filter):
+    """Remove Telegram bot credentials from dependency-generated URL logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            rendered = record.getMessage()
+        except Exception:  # pragma: no cover - defensive logging boundary
+            rendered = None
+        if isinstance(rendered, str):
+            redacted = _redact_telegram_token(rendered)
+            if redacted != rendered:
+                record.msg = redacted
+                record.args = ()
+                return True
+        record.msg = _redact_telegram_token(record.msg)
+        record.args = _redact_telegram_token(record.args)
+        return True
+
+
+_token_redaction_filter = _TelegramTokenRedactionFilter()
+for _dependency_logger_name in (
+    "httpx",
+    "httpcore",
+    "httpcore.connection",
+    "httpcore.http11",
+    "httpcore.http2",
+    "httpcore.proxy",
+    "httpcore.socks",
+):
+    _dependency_logger = logging.getLogger(_dependency_logger_name)
+    if not any(
+        isinstance(existing, _TelegramTokenRedactionFilter)
+        for existing in _dependency_logger.filters
+    ):
+        _dependency_logger.addFilter(_token_redaction_filter)
+
+
+def _safe_response_fields(
+    response: httpx.Response,
+) -> tuple[
+    int,
+    int | None,
+    bool,
+    int | None,
+    TelegramErrorClassification,
+]:
+    """Extract only numeric/boolean success fields; discard description."""
+    status_code = int(response.status_code)
+    try:
+        decoded = response.json()
+    except (TypeError, ValueError):
+        decoded = {}
+    body = decoded if isinstance(decoded, dict) else {}
+    raw_error_code = body.get("error_code")
+    error_code = (
+        raw_error_code
+        if isinstance(raw_error_code, int) and not isinstance(raw_error_code, bool)
+        else None
+    )
+    result_body = body.get("result")
+    message_id = (
+        result_body.get("message_id") if isinstance(result_body, dict) else None
+    )
+    safe_message_id = (
+        message_id
+        if isinstance(message_id, int) and not isinstance(message_id, bool)
+        else None
+    )
+    classification = classify_telegram_response_error(
+        status_code=status_code,
+        error_code=error_code,
+        description=body.get("description"),
+    )
+    return (
+        status_code,
+        error_code,
+        body.get("ok") is True,
+        safe_message_id,
+        classification,
+    )
+
+
+def _log_method_failure(result: TelegramMethodResult, *, telegram_method: str) -> None:
+    logger.error(
+        "telegram.method.failed",
+        extra={
+            "telegram_method": telegram_method,
+            "http_status": result.status_code,
+            "telegram_error_code": result.error_code,
+            "telegram_error_classification": (
+                result.error_classification.value
+                if result.error_classification is not None
+                else None
+            ),
+            "payload_chars": result.payload_chars,
+            "failure_code": result.failure_code,
+        },
+    )
 
 
 async def send_telegram(
@@ -24,24 +160,17 @@ async def send_telegram(
 
     Returns True if at least one chat received the message.
     """
-    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     any_success = False
     for chat_id in chat_ids:
-        try:
-            payload: dict[str, Any] = {
-                "chat_id": chat_id,
-                "text": text,
-                "parse_mode": parse_mode,
-                "disable_web_page_preview": True,
-            }
-            if reply_markup is not None:
-                payload["reply_markup"] = reply_markup
-            response = await http_client.post(url, json=payload)
-            response.raise_for_status()
-            any_success = True
-            logger.info("Telegram message sent")
-        except Exception:
-            logger.error("Failed to send Telegram message")
+        result = await send_telegram_message(
+            http_client=http_client,
+            bot_token=bot_token,
+            chat_id=chat_id,
+            text=text,
+            parse_mode=parse_mode,
+            reply_markup=reply_markup,
+        )
+        any_success = any_success or result.ok
     return any_success
 
 
@@ -51,30 +180,82 @@ async def send_telegram_message(
     bot_token: str,
     chat_id: str,
     text: str,
-    parse_mode: str = "Markdown",
+    parse_mode: str | None = "Markdown",
     reply_markup: dict[str, Any] | None = None,
-) -> int | None:
-    """Send one Telegram message and return its message ID on success."""
+) -> TelegramMethodResult:
+    """Send one message and preserve only allowlisted response metadata."""
+    payload_chars = telegram_text_length(text)
+    if payload_chars > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT:
+        result = TelegramMethodResult.failed(
+            payload_chars=payload_chars,
+            failure_code="telegram_payload_too_long",
+            error_classification=TelegramErrorClassification.PAYLOAD_TOO_LONG,
+        )
+        _log_method_failure(result, telegram_method="sendMessage")
+        return result
+
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     payload: dict[str, Any] = {
         "chat_id": chat_id,
         "text": text,
-        "parse_mode": parse_mode,
         "disable_web_page_preview": True,
     }
+    if parse_mode is not None:
+        payload["parse_mode"] = parse_mode
     if reply_markup is not None:
         payload["reply_markup"] = reply_markup
 
     try:
         response = await http_client.post(url, json=payload)
-        response.raise_for_status()
-        message_id = response.json().get("result", {}).get("message_id")
-        if isinstance(message_id, int):
-            logger.info("Telegram message sent")
-            return message_id
-    except Exception:
-        logger.error("Failed to send Telegram message")
-    return None
+    except Exception:  # noqa: BLE001 - converted to a safe typed result
+        result = TelegramMethodResult.failed(
+            payload_chars=payload_chars,
+            failure_code="telegram_transport_error",
+            error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
+        )
+        _log_method_failure(result, telegram_method="sendMessage")
+        return result
+
+    (
+        status_code,
+        error_code,
+        telegram_ok,
+        message_id,
+        classification,
+    ) = _safe_response_fields(response)
+    if 200 <= status_code < 300 and telegram_ok and message_id is not None:
+        result = TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=status_code,
+            error_code=None,
+            error_classification=None,
+            payload_chars=payload_chars,
+        )
+        logger.info(
+            "telegram.send_message.sent",
+            extra={
+                "telegram_method": "sendMessage",
+                "http_status": status_code,
+                "payload_chars": payload_chars,
+            },
+        )
+        return result
+
+    failure_code = (
+        "telegram_api_error" if error_code is not None else "telegram_invalid_response"
+    )
+    if error_code is None and 200 <= status_code < 300:
+        classification = TelegramErrorClassification.INVALID_RESPONSE
+    result = TelegramMethodResult.failed(
+        payload_chars=payload_chars,
+        failure_code=failure_code,
+        status_code=status_code,
+        error_code=error_code,
+        error_classification=classification,
+    )
+    _log_method_failure(result, telegram_method="sendMessage")
+    return result
 
 
 async def answer_callback_query(
@@ -108,8 +289,18 @@ async def edit_message_text(
     text: str,
     parse_mode: str = "Markdown",
     reply_markup: dict[str, Any] | None = None,
-) -> bool:
-    """Edit one Telegram message."""
+) -> TelegramMethodResult:
+    """Edit one message with the same UTF-16 and safe-result contract."""
+    payload_chars = telegram_text_length(text)
+    if payload_chars > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT:
+        result = TelegramMethodResult.failed(
+            payload_chars=payload_chars,
+            failure_code="telegram_payload_too_long",
+            error_classification=TelegramErrorClassification.PAYLOAD_TOO_LONG,
+        )
+        _log_method_failure(result, telegram_method="editMessageText")
+        return result
+
     url = f"https://api.telegram.org/bot{bot_token}/editMessageText"
     payload: dict[str, Any] = {
         "chat_id": chat_id,
@@ -122,11 +313,46 @@ async def edit_message_text(
 
     try:
         response = await http_client.post(url, json=payload)
-        response.raise_for_status()
-        return True
-    except Exception:
-        logger.error("Failed to edit Telegram message")
-        return False
+    except Exception:  # noqa: BLE001 - converted to a safe typed result
+        result = TelegramMethodResult.failed(
+            payload_chars=payload_chars,
+            failure_code="telegram_transport_error",
+            error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
+        )
+        _log_method_failure(result, telegram_method="editMessageText")
+        return result
+
+    (
+        status_code,
+        error_code,
+        telegram_ok,
+        _message_id,
+        classification,
+    ) = _safe_response_fields(response)
+    if 200 <= status_code < 300 and telegram_ok:
+        return TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=status_code,
+            error_code=None,
+            error_classification=None,
+            payload_chars=payload_chars,
+        )
+    if error_code is None and 200 <= status_code < 300:
+        classification = TelegramErrorClassification.INVALID_RESPONSE
+    result = TelegramMethodResult.failed(
+        payload_chars=payload_chars,
+        failure_code=(
+            "telegram_api_error"
+            if error_code is not None
+            else "telegram_invalid_response"
+        ),
+        status_code=status_code,
+        error_code=error_code,
+        error_classification=classification,
+    )
+    _log_method_failure(result, telegram_method="editMessageText")
+    return result
 
 
 async def send_discord_embed_single(

--- a/app/monitoring/trade_notifier/transports.py
+++ b/app/monitoring/trade_notifier/transports.py
@@ -160,17 +160,24 @@ async def send_telegram(
 
     Returns True if at least one chat received the message.
     """
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     any_success = False
     for chat_id in chat_ids:
-        result = await send_telegram_message(
-            http_client=http_client,
-            bot_token=bot_token,
-            chat_id=chat_id,
-            text=text,
-            parse_mode=parse_mode,
-            reply_markup=reply_markup,
-        )
-        any_success = any_success or result.ok
+        try:
+            payload: dict[str, Any] = {
+                "chat_id": chat_id,
+                "text": text,
+                "parse_mode": parse_mode,
+                "disable_web_page_preview": True,
+            }
+            if reply_markup is not None:
+                payload["reply_markup"] = reply_markup
+            response = await http_client.post(url, json=payload)
+            response.raise_for_status()
+            any_success = True
+            logger.info("Telegram message sent")
+        except Exception:
+            logger.error("Failed to send Telegram message")
     return any_success
 
 

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -2,19 +2,32 @@
 
 from __future__ import annotations
 
+import base64
 import re
 import uuid
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import ROUND_CEILING, Decimal, InvalidOperation
 from typing import Any
 
 from app.core.timezone import KST
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    CallbackEnvelope,
+    DispatchBinding,
+)
+from app.telegram_contract import (
+    TELEGRAM_SEND_MESSAGE_TEXT_LIMIT,
+    split_telegram_text,
+    telegram_text_length,
+)
 
 _ALLOWED_ACTIONS = frozenset({"op", "dn", "lc", "vc", "ba"})
 _CALLBACK_PATTERN = re.compile(
     r"^(?P<action>op|dn|lc|vc|ba):(?P<proposal_short>[0-9a-f]{8}):"
-    r"(?P<nonce>[A-Za-z0-9_-]+)$"
+    r"(?P<attempt>[A-Za-z0-9_-]{22}):(?P<revision>[0-9a-z]{1,3}):"
+    r"(?P<digest>[A-Za-z0-9_-]{12}):(?P<nonce>[A-Za-z0-9_-]+)$"
 )
 _MAX_CALLBACK_BYTES = 64
 _CASH_LABELS = (
@@ -33,6 +46,17 @@ _BATCH_RUNG_RESULT_LABELS = {
     "needs_reconfirm": "재확인 필요",
     "cancelled": "취소 확인",
 }
+_CONTEXT_HEADER_RESERVED_UNITS = 64
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDispatchMessages:
+    """Preflighted shape for context-first approval publication."""
+
+    context_messages: tuple[str, ...]
+    approval_text: str
+    inline_keyboard: dict
+    payload_chars: int
 
 
 def build_callback_data(
@@ -40,38 +64,93 @@ def build_callback_data(
     action: str,
     proposal_id: uuid.UUID,
     nonce: str,
+    binding: DispatchBinding,
 ) -> str:
-    """Build compact Telegram callback data for an approval action."""
+    """Build callback data bound to one exact published snapshot."""
     if action not in _ALLOWED_ACTIONS:
         raise ValueError("action must be one of: op, dn, lc, vc, ba")
     if not isinstance(proposal_id, uuid.UUID):
         raise ValueError("proposal_id must be a UUID")
     if not isinstance(nonce, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", nonce):
         raise ValueError("nonce must be a non-empty URL-safe token")
+    if binding.membership_revision <= 0:
+        raise ValueError("membership_revision must be positive")
+    revision = _base36_encode(binding.membership_revision)
+    if len(revision) > 3:
+        raise ValueError("membership_revision exceeds callback capacity")
+    if not re.fullmatch(r"[A-Za-z0-9_-]{12}", binding.membership_digest):
+        raise ValueError("membership_digest must be a 12-character URL-safe token")
 
-    data = f"{action}:{str(proposal_id)[:8]}:{nonce}"
+    data = (
+        f"{action}:{str(proposal_id)[:8]}:"
+        f"{_encode_uuid(binding.attempt_id)}:{revision}:"
+        f"{binding.membership_digest}:{nonce}"
+    )
     if len(data.encode("utf-8")) > _MAX_CALLBACK_BYTES:
         raise ValueError("callback data must not exceed 64 bytes")
     return data
 
 
-def build_batch_callback_data(*, batch_id: uuid.UUID, nonce: str) -> str:
+def build_batch_callback_data(
+    *, batch_id: uuid.UUID, nonce: str, binding: DispatchBinding
+) -> str:
     """Build compact callback data for a batch-only approval trigger."""
-    return build_callback_data(action="ba", proposal_id=batch_id, nonce=nonce)
+    if binding.card_kind is not ApprovalCardKind.BATCH:
+        raise ValueError("batch callback requires a batch card binding")
+    return build_callback_data(
+        action="ba", proposal_id=batch_id, nonce=nonce, binding=binding
+    )
 
 
-def parse_callback_data(data: str) -> tuple[str, str, str]:
+def parse_callback_data(data: str) -> CallbackEnvelope:
     """Parse and validate compact Telegram approval callback data."""
     if not isinstance(data, str) or len(data.encode("utf-8")) > _MAX_CALLBACK_BYTES:
         raise ValueError("malformed callback data")
     match = _CALLBACK_PATTERN.fullmatch(data)
     if match is None:
         raise ValueError("malformed callback data")
-    return (
-        match.group("action"),
-        match.group("proposal_short"),
-        match.group("nonce"),
+    try:
+        attempt_id = _decode_uuid(match.group("attempt"))
+        revision = _base36_decode(match.group("revision"))
+    except ValueError as exc:
+        raise ValueError("malformed callback data") from exc
+    return CallbackEnvelope(
+        action=match.group("action"),
+        subject_short=match.group("proposal_short"),
+        attempt_id=attempt_id,
+        membership_revision=revision,
+        membership_digest=match.group("digest"),
+        nonce=match.group("nonce"),
     )
+
+
+def _encode_uuid(value: uuid.UUID) -> str:
+    return base64.urlsafe_b64encode(value.bytes).decode().rstrip("=")
+
+
+def _decode_uuid(value: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(bytes=base64.urlsafe_b64decode(value + "=="))
+    except (ValueError, TypeError) as exc:
+        raise ValueError("invalid compact UUID") from exc
+
+
+def _base36_encode(value: int) -> str:
+    alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+    if value <= 0:
+        raise ValueError("base36 value must be positive")
+    encoded = ""
+    while value:
+        value, remainder = divmod(value, 36)
+        encoded = alphabet[remainder] + encoded
+    return encoded
+
+
+def _base36_decode(value: str) -> int:
+    decoded = int(value, 36)
+    if decoded <= 0:
+        raise ValueError("base36 value must be positive")
+    return decoded
 
 
 def build_action_diff(*, group: Any, rungs: Sequence[Any]) -> dict | None:
@@ -133,6 +212,7 @@ def build_batch_approval_message(
     *,
     batch: Any,
     proposals: Sequence[tuple[Any, Sequence[Any]]],
+    binding: DispatchBinding,
 ) -> tuple[str, dict]:
     """Render a pending manual-approval batch without exposing raw nonces."""
     if len(proposals) < 2:
@@ -215,7 +295,7 @@ def build_batch_approval_message(
                 {
                     "text": "전체 승인",
                     "callback_data": build_batch_callback_data(
-                        batch_id=batch_id, nonce=str(nonce)
+                        batch_id=batch_id, nonce=str(nonce), binding=binding
                     ),
                 }
             ]
@@ -289,8 +369,15 @@ def build_approval_message(
     rungs: Sequence[Any],
     cash_stress: dict | None = None,
     diff: dict | None = None,
+    evidence_reference: str | None = None,
+    binding: DispatchBinding,
 ) -> tuple[str, dict]:
     """Render a proposal and its Telegram inline keyboard without raw digests."""
+    if binding.card_kind not in {
+        ApprovalCardKind.MANUAL,
+        ApprovalCardKind.RECONFIRM,
+    }:
+        raise ValueError("approval message requires a manual or reconfirm binding")
     nonce = getattr(group, "approval_nonce", None)
     if not nonce:
         raise ValueError("group.approval_nonce is required")
@@ -300,11 +387,13 @@ def build_approval_message(
         action="op",
         proposal_id=proposal_id,
         nonce=nonce,
+        binding=binding,
     )
     deny_data = build_callback_data(
         action="dn",
         proposal_id=proposal_id,
         nonce=nonce,
+        binding=binding,
     )
 
     market = str(getattr(group, "market", "") or "미기재")
@@ -361,16 +450,16 @@ def build_approval_message(
     else:
         lines.append("- 없음")
 
-    thesis = getattr(group, "thesis", None) or "미기재"
-    strategy = getattr(group, "strategy", None) or "미기재"
-    lines.extend(
-        [
-            "",
-            "*근거*",
+    if evidence_reference is None:
+        thesis = getattr(group, "thesis", None) or "미기재"
+        strategy = getattr(group, "strategy", None) or "미기재"
+        evidence_lines = [
             f"- 투자 논지: {_escape_markdown(thesis)}",
             f"- 전략: {_escape_markdown(strategy)}",
         ]
-    )
+    else:
+        evidence_lines = [f"- 원문: {_escape_markdown(evidence_reference)}"]
+    lines.extend(["", "*근거*", *evidence_lines])
 
     if getattr(group, "exit_intent", None) == "loss_cut":
         lines.extend(
@@ -436,13 +525,80 @@ def build_approval_message(
     return text, inline_keyboard
 
 
+def build_approval_dispatch_messages(
+    *,
+    group: Any,
+    rungs: Sequence[Any],
+    cash_stress: dict | None = None,
+    diff: dict | None = None,
+    suffix_blocks: Sequence[str] = (),
+    binding: DispatchBinding,
+) -> ApprovalDispatchMessages:
+    """Keep short cards intact; split oversized evidence before the button card."""
+    full_text, keyboard = build_approval_message(
+        group=group,
+        rungs=rungs,
+        cash_stress=cash_stress,
+        diff=diff,
+        binding=binding,
+    )
+    if suffix_blocks:
+        full_text = f"{full_text}\n\n" + "\n\n".join(suffix_blocks)
+    payload_chars = telegram_text_length(full_text)
+    if payload_chars <= TELEGRAM_SEND_MESSAGE_TEXT_LIMIT:
+        return ApprovalDispatchMessages((), full_text, keyboard, payload_chars)
+
+    thesis = str(getattr(group, "thesis", None) or "미기재")
+    strategy = str(getattr(group, "strategy", None) or "미기재")
+    evidence_body = f"투자 논지:\n{thesis}\n\n전략:\n{strategy}"
+    body_chunks = split_telegram_text(
+        evidence_body,
+        max_units=(TELEGRAM_SEND_MESSAGE_TEXT_LIMIT - _CONTEXT_HEADER_RESERVED_UNITS),
+    )
+    total = len(body_chunks)
+    proposal_short = str(getattr(group, "proposal_id", ""))[:8] or "unknown"
+    context_messages = tuple(
+        f"주문 제안 {proposal_short} 근거 원문 ({index}/{total})\n\n{chunk}"
+        for index, chunk in enumerate(body_chunks, start=1)
+    )
+    if any(
+        telegram_text_length(message) > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+        for message in context_messages
+    ):
+        raise ValueError("approval context header exceeded reserved Telegram space")
+
+    evidence_reference = (
+        f"제안 {proposal_short}의 위 근거 메시지 {total}건 · "
+        f"투자 논지 {len(thesis)}자 / 전략 {len(strategy)}자"
+    )
+    approval_text, keyboard = build_approval_message(
+        group=group,
+        rungs=rungs,
+        cash_stress=cash_stress,
+        diff=diff,
+        evidence_reference=evidence_reference,
+        binding=binding,
+    )
+    if suffix_blocks:
+        approval_text = f"{approval_text}\n\n" + "\n\n".join(suffix_blocks)
+    return ApprovalDispatchMessages(
+        context_messages,
+        approval_text,
+        keyboard,
+        payload_chars,
+    )
+
+
 def build_loss_cut_confirmation_message(
     *,
     group: Any,
     rungs: Sequence[Any],
     evidence: Mapping[str, Any],
+    binding: DispatchBinding,
 ) -> tuple[str, dict]:
     """Render the explicit second-step loss-cut confirmation prompt."""
+    if binding.card_kind is not ApprovalCardKind.LOSS_CUT_CONFIRMATION:
+        raise ValueError("loss-cut confirmation requires its card binding")
     nonce = getattr(group, "approval_nonce", None)
     if not nonce:
         raise ValueError("group.approval_nonce is required")
@@ -508,13 +664,19 @@ def build_loss_cut_confirmation_message(
                 {
                     "text": "⚠️ 손절 확인",
                     "callback_data": build_callback_data(
-                        action="lc", proposal_id=proposal_id, nonce=nonce
+                        action="lc",
+                        proposal_id=proposal_id,
+                        nonce=nonce,
+                        binding=binding,
                     ),
                 },
                 {
                     "text": "❌ 거부",
                     "callback_data": build_callback_data(
-                        action="dn", proposal_id=proposal_id, nonce=nonce
+                        action="dn",
+                        proposal_id=proposal_id,
+                        nonce=nonce,
+                        binding=binding,
                     ),
                 },
             ]

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -16,6 +16,10 @@ from app.services.order_proposals.approval_message import (
     _escape_markdown,
     build_callback_data,
 )
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    DispatchBinding,
+)
 from app.services.trading_policy_service import load_trading_policy
 
 _POLICY_MARKET = {
@@ -183,11 +187,21 @@ def evaluate_auto_approve_eligibility(
 
 
 def build_auto_approved_message(
-    *, group: Any, rungs: list[Any], nonce: str, policy_version: str
+    *,
+    group: Any,
+    rungs: list[Any],
+    nonce: str,
+    policy_version: str,
+    binding: DispatchBinding,
 ) -> tuple[str, dict[str, Any]]:
     """Render a compact post-submit summary with a single-use veto button."""
+    if binding.card_kind is not ApprovalCardKind.AUTO_VETO:
+        raise ValueError("auto-veto message requires an auto-veto binding")
     callback = build_callback_data(
-        action="vc", proposal_id=group.proposal_id, nonce=nonce
+        action="vc",
+        proposal_id=group.proposal_id,
+        nonce=nonce,
+        binding=binding,
     )
     lines = [
         "✅ *자동 접수됨*",

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -8,10 +8,11 @@ and committed, and (b) calls the Telegram notifier, which
 ``OrderProposalsService``/``OrderProposalRepository`` never do (they only
 flush -- see ``service.py``'s module docstring).
 
-The initial individual message necessarily precedes persistence of its Telegram
-message ID. For the derived batch summary, however, membership and the summary
-claim are committed before the summary is sent or edited, so an operator never
-sees a batch button whose second member exists only in an uncommitted session.
+Each individual dispatch commits its fresh nonce and pending attempt before
+Telegram I/O, then finalizes that attempt in a separate transaction. The
+Telegram message ID necessarily arrives between those transactions. Derived
+batch membership is frozen and committed before publication. Published batches
+are immutable; later proposals always stage a new card.
 """
 
 from __future__ import annotations
@@ -29,7 +30,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.services.order_proposals.approval_message import (
-    build_approval_message,
+    ApprovalDispatchMessages,
+    build_approval_dispatch_messages,
     build_batch_approval_message,
 )
 from app.services.order_proposals.auto_approve import (
@@ -47,11 +49,25 @@ from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
     fetch_target_order,
 )
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalDispatchState,
+    ApprovalPublication,
+    DispatchBinding,
+    TelegramDispatchResult,
+    build_proposal_dispatch_binding,
+)
 from app.services.order_proposals.revalidation import (
     RungOutcome,
     revalidate_and_submit,
 )
 from app.services.order_proposals.service import OrderProposalsService
+from app.telegram_contract import (
+    TELEGRAM_SEND_MESSAGE_TEXT_LIMIT,
+    TelegramErrorClassification,
+    TelegramMethodResult,
+    telegram_text_length,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +79,23 @@ def _generate_nonce() -> str:
     # Duplicated from telegram_callback.py::_generate_nonce (2 lines) rather
     # than imported -- that name is `_`-prefixed/module-private, and this
     # module is a peer top-level caller, not a consumer of that module.
-    return secrets.token_urlsafe(12)
+    return secrets.token_urlsafe(8)
+
+
+def _proposal_binding(
+    *,
+    group: Any,
+    nonce: str | None,
+    attempt_id: uuid.UUID,
+    card_kind: ApprovalCardKind,
+) -> DispatchBinding:
+    return build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=nonce,
+        attempt_id=attempt_id,
+        card_kind=card_kind,
+        current_membership_revision=group.approval_dispatch_membership_revision,
+    )
 
 
 async def _register_and_publish_batch_summary(
@@ -76,49 +108,51 @@ async def _register_and_publish_batch_summary(
     now: datetime,
     notifier: Any,
 ) -> None:
-    """Best-effort batch registration after the individual message succeeds."""
+    """Publish a new immutable batch card after freezing its exact members."""
     registration = await service.register_approval_batch_member(
         proposal_id,
         chat_id=chat_id,
         approval_message_id=message_id,
         now=now,
     )
-    if registration is None or registration.summary_action == "none":
+    if (
+        registration is None
+        or registration.summary_action == "none"
+        or registration.binding is None
+    ):
         return
     batch, proposals = await service.get_approval_batch_display(
         registration.batch.batch_id
     )
-    text, keyboard = build_batch_approval_message(batch=batch, proposals=proposals)
-    # Make the frozen membership and summary-delivery claim visible before
-    # publishing a button that depends on both rows.
+    text, keyboard = build_batch_approval_message(
+        batch=batch,
+        proposals=proposals,
+        binding=registration.binding,
+    )
+    messages = ApprovalDispatchMessages(
+        context_messages=(),
+        approval_text=text,
+        inline_keyboard=keyboard,
+        payload_chars=telegram_text_length(text),
+    )
+    await service.record_approval_batch_payload(
+        batch.batch_id,
+        attempt_id=registration.binding.attempt_id,
+        payload_chars=messages.payload_chars,
+    )
+    # Freeze + pending owner must be durable before the external publication.
     await session.commit()
-    if registration.summary_action == "send":
-        try:
-            summary_id = await notifier.send_approval_message(
-                text, keyboard, chat_id=chat_id
-            )
-        except Exception:  # noqa: BLE001 - individual dispatch remains valid
-            logger.exception("order proposal batch summary send failed")
-            await service.release_approval_batch_summary_claim(batch.batch_id, now=now)
-            return
-        if summary_id is None:
-            await service.release_approval_batch_summary_claim(batch.batch_id, now=now)
-            return
-        await service.record_approval_batch_summary(
-            batch.batch_id, message_id=summary_id, now=now
-        )
-        return
-    if batch.summary_message_id is None:
-        return
-    try:
-        await notifier.edit_message(
-            chat_id,
-            batch.summary_message_id,
-            text,
-            reply_markup=keyboard,
-        )
-    except Exception:  # noqa: BLE001 - summary is a best-effort surface
-        logger.exception("order proposal batch summary edit failed")
+    publication = await publish_approval_messages(
+        notifier=notifier,
+        messages=messages,
+        chat_id=chat_id,
+    )
+    await service.finish_approval_batch_dispatch(
+        batch.batch_id,
+        attempt_id=registration.binding.attempt_id,
+        publication=publication,
+        now=now,
+    )
 
 
 async def send_proposal_for_approval(
@@ -127,21 +161,28 @@ async def send_proposal_for_approval(
     notifier: Any,
     now: datetime,
     service_factory: ServiceFactory = AsyncSessionLocal,
-) -> int | None:
+) -> TelegramDispatchResult:
     """Mint a fresh approval nonce, render the message, and send it.
 
     Sends to the FIRST entry in
     ``settings.order_proposals_telegram_chat_allowlist`` -- the return type
-    is a single ``int | None`` message_id, which only makes sense for a
-    single-chat send, not a broadcast. An empty allowlist is a no-op (no
-    nonce mint, no send, returns ``None``) -- callers (the MCP wiring) should
-    already gate on a non-empty allowlist before calling this, but this
-    function defends independently.
+    is a single workflow result. An empty allowlist is recorded as a durable
+    local failure without minting a nonce.
     """
     allowlist = settings.order_proposals_telegram_chat_allowlist
     if not allowlist:
-        return None
+        publication = ApprovalPublication.failed(
+            payload_chars=0,
+            failure_code="telegram_allowlist_empty",
+        )
+        return await record_approval_dispatch_failure(
+            proposal_id,
+            publication=publication,
+            now=now,
+            service_factory=service_factory,
+        )
     chat_id = allowlist[0]
+    attempt_id = uuid.uuid4()
 
     async with service_factory() as session:
         service = OrderProposalsService(session)
@@ -150,32 +191,159 @@ async def send_proposal_for_approval(
         await service.set_approval_nonce(proposal_id, fresh_nonce)
 
         group, rungs = await service.get_proposal(proposal_id)
-        text, keyboard = build_approval_message(group=group, rungs=rungs)
-
-        message_id = await notifier.send_approval_message(
-            text, keyboard, chat_id=chat_id
+        binding = _proposal_binding(
+            group=group,
+            nonce=fresh_nonce,
+            attempt_id=attempt_id,
+            card_kind=ApprovalCardKind.MANUAL,
         )
+        messages = build_approval_dispatch_messages(
+            group=group, rungs=rungs, binding=binding
+        )
+        await service.start_approval_dispatch(
+            proposal_id,
+            attempt_id=attempt_id,
+            binding=binding,
+            now=now,
+            payload_chars=messages.payload_chars,
+            context_message_count=len(messages.context_messages),
+        )
+        # The nonce and pending attempt become durable before Telegram I/O.
+        await session.commit()
 
-        if message_id is not None:
-            await service.record_approval_dispatch(
-                proposal_id, message_id=message_id, chat_id=chat_id, now=now
-            )
+    publication = await publish_approval_messages(
+        notifier=notifier,
+        messages=messages,
+        chat_id=chat_id,
+    )
+
+    async with service_factory() as session:
+        service = OrderProposalsService(session)
+        result = await service.finish_approval_dispatch(
+            proposal_id,
+            attempt_id=attempt_id,
+            publication=publication,
+            chat_id=chat_id,
+            now=now,
+        )
+        await session.commit()
+        if result.approvable and result.message_id is not None:
             await _register_and_publish_batch_summary(
                 session=session,
                 service=service,
                 proposal_id=proposal_id,
-                message_id=message_id,
+                message_id=result.message_id,
                 chat_id=chat_id,
                 now=now,
                 notifier=notifier,
             )
+            await session.commit()
+    return result
 
-        # Commit explicitly before returning -- see module docstring. The
-        # nonce mint above is committed even when message_id is None (send
-        # failed): a fresh nonce with no message sent is not a correctness
-        # problem, it just means the operator can't approve yet.
+
+async def publish_approval_messages(
+    *,
+    notifier: Any,
+    messages: ApprovalDispatchMessages,
+    chat_id: str,
+) -> ApprovalPublication:
+    """Send every context successfully before publishing the button card."""
+    all_messages = (*messages.context_messages, messages.approval_text)
+    if any(
+        telegram_text_length(text) > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+        for text in all_messages
+    ):
+        return ApprovalPublication.failed(
+            payload_chars=messages.payload_chars,
+            failure_code="approval_payload_too_long",
+        )
+
+    successful_contexts = 0
+    for context_text in messages.context_messages:
+        try:
+            context_result = await notifier.send_approval_message(
+                context_text,
+                None,
+                chat_id=chat_id,
+                parse_mode=None,
+            )
+        except Exception:  # noqa: BLE001 - converted to a closed safe result
+            context_result = TelegramMethodResult.failed(
+                payload_chars=telegram_text_length(context_text),
+                failure_code="telegram_transport_error",
+                error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
+            )
+        if not context_result.ok:
+            return ApprovalPublication.failed(
+                payload_chars=messages.payload_chars,
+                failure_code="approval_context_dispatch_failed",
+                partial=successful_contexts > 0,
+                method_result=context_result,
+            )
+        successful_contexts += 1
+
+    try:
+        card_result = await notifier.send_approval_message(
+            messages.approval_text,
+            messages.inline_keyboard,
+            chat_id=chat_id,
+        )
+    except Exception:  # noqa: BLE001 - converted to a closed safe result
+        card_result = TelegramMethodResult.failed(
+            payload_chars=telegram_text_length(messages.approval_text),
+            failure_code="telegram_transport_error",
+            error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
+        )
+    if not card_result.ok:
+        return ApprovalPublication.failed(
+            payload_chars=messages.payload_chars,
+            failure_code="approval_card_dispatch_failed",
+            partial=successful_contexts > 0,
+            method_result=card_result,
+        )
+    return ApprovalPublication.published(
+        payload_chars=messages.payload_chars,
+        method_result=card_result,
+    )
+
+
+async def record_approval_dispatch_failure(
+    proposal_id: uuid.UUID,
+    *,
+    publication: ApprovalPublication,
+    now: datetime,
+    service_factory: ServiceFactory = AsyncSessionLocal,
+) -> TelegramDispatchResult:
+    """Ledger a local/preflight dispatch failure with no Telegram I/O."""
+    if publication.card_published:
+        raise ValueError("record_approval_dispatch_failure requires a failed receipt")
+    attempt_id = uuid.uuid4()
+    async with service_factory() as session:
+        service = OrderProposalsService(session)
+        group, _rungs = await service.get_proposal(proposal_id)
+        binding = _proposal_binding(
+            group=group,
+            nonce=group.approval_nonce,
+            attempt_id=attempt_id,
+            card_kind=ApprovalCardKind.MANUAL,
+        )
+        await service.start_approval_dispatch(
+            proposal_id,
+            attempt_id=attempt_id,
+            binding=binding,
+            now=now,
+            payload_chars=publication.payload_chars,
+            context_message_count=0,
+        )
+        result = await service.finish_approval_dispatch(
+            proposal_id,
+            attempt_id=attempt_id,
+            publication=publication,
+            chat_id=None,
+            now=now,
+        )
         await session.commit()
-        return message_id
+    return result
 
 
 async def dispatch_proposal(
@@ -187,7 +355,7 @@ async def dispatch_proposal(
     revalidate_fn: RevalidateFn = revalidate_and_submit,
     cancel_target_fn: TargetCancelFn = cancel_target_order,
     fetch_target_fn: TargetFetchFn = fetch_target_order,
-) -> int | None:
+) -> TelegramDispatchResult:
     """Auto-submit an eligible resting proposal, otherwise send for approval."""
     if not settings.ORDER_PROPOSALS_AUTO_APPROVE:
         return await send_proposal_for_approval(
@@ -198,7 +366,8 @@ async def dispatch_proposal(
         )
 
     auto_submitted = False
-    message: tuple[str, dict[str, Any]] | None = None
+    messages: ApprovalDispatchMessages | None = None
+    attempt_id: uuid.UUID | None = None
     async with service_factory() as session:
         service = OrderProposalsService(session)
         await service.acquire_auto_dispatch_lock(proposal_id)
@@ -206,7 +375,15 @@ async def dispatch_proposal(
         pending_count = sum(rung.state == "pending_approval" for rung in initial_rungs)
         if pending_count == 0:
             await session.commit()
-            return None
+            return TelegramDispatchResult(
+                state=ApprovalDispatchState.FAILED,
+                message_id=None,
+                status_code=None,
+                error_code=None,
+                error_classification=None,
+                payload_chars=0,
+                failure_code="proposal_not_pending_approval",
+            )
         limits = limits_for_market(group.market)
         decisions: list[dict[str, Any]] = []
         if limits is not None:
@@ -256,16 +433,38 @@ async def dispatch_proposal(
                 veto_nonce = _generate_nonce()
                 await service.set_approval_nonce(proposal_id, veto_nonce)
                 group, rungs = await service.get_proposal(proposal_id)
-                message = build_auto_approved_message(
+                attempt_id = uuid.uuid4()
+                binding = _proposal_binding(
+                    group=group,
+                    nonce=veto_nonce,
+                    attempt_id=attempt_id,
+                    card_kind=ApprovalCardKind.AUTO_VETO,
+                )
+                text, keyboard = build_auto_approved_message(
                     group=group,
                     rungs=rungs,
                     nonce=veto_nonce,
                     policy_version=limits.policy_version,
+                    binding=binding,
+                )
+                messages = ApprovalDispatchMessages(
+                    (),
+                    text,
+                    keyboard,
+                    telegram_text_length(text),
+                )
+                await service.start_approval_dispatch(
+                    proposal_id,
+                    attempt_id=attempt_id,
+                    binding=binding,
+                    now=now,
+                    payload_chars=messages.payload_chars,
+                    context_message_count=0,
                 )
         # Persist broker outcomes and the audit/nonce before Telegram I/O.
         await session.commit()
 
-    if not auto_submitted or message is None:
+    if not auto_submitted or messages is None or attempt_id is None:
         return await send_proposal_for_approval(
             proposal_id,
             notifier=notifier,
@@ -274,24 +473,35 @@ async def dispatch_proposal(
         )
 
     allowlist = settings.order_proposals_telegram_chat_allowlist
-    text, keyboard = message
-    notify_error = "telegram_allowlist_empty"
-    message_id = None
     chat_id = allowlist[0] if allowlist else None
-    if chat_id is not None:
-        notify_error = "telegram_message_not_sent"
-        try:
-            message_id = await notifier.send_approval_message(
-                text, keyboard, chat_id=chat_id
-            )
-        except Exception as exc:  # noqa: BLE001 - compensate live order below
-            logger.exception("auto-approved proposal veto notification failed")
-            notify_error = str(exc)
-            message_id = None
-    if message_id is None:
-        async with service_factory() as session:
-            service = OrderProposalsService(session)
-            await service.acquire_auto_dispatch_lock(proposal_id)
+    publication = (
+        await publish_approval_messages(
+            notifier=notifier,
+            messages=messages,
+            chat_id=chat_id,
+        )
+        if chat_id is not None
+        else ApprovalPublication.failed(
+            payload_chars=messages.payload_chars,
+            failure_code="telegram_allowlist_empty",
+        )
+    )
+    async with service_factory() as session:
+        service = OrderProposalsService(session)
+        # Preserve the established auto-dispatch lock order: advisory lock
+        # first, then proposal/attempt row locks inside finalization.
+        await service.acquire_auto_dispatch_lock(proposal_id)
+        result = await service.finish_approval_dispatch(
+            proposal_id,
+            attempt_id=attempt_id,
+            publication=publication,
+            chat_id=chat_id,
+            now=now,
+        )
+        if result.state in {
+            ApprovalDispatchState.FAILED,
+            ApprovalDispatchState.PARTIAL_FAILED,
+        }:
             group, rungs = await service.get_proposal(proposal_id)
             await acquire_auto_veto_locks(service=service, group=group, rungs=rungs)
             outcomes = await cancel_auto_submitted_rungs(
@@ -304,21 +514,17 @@ async def dispatch_proposal(
             )
             await service.record_auto_notification_failure(
                 proposal_id,
-                error=notify_error,
+                error=result.failure_code or "telegram_dispatch_failed",
                 outcomes=outcomes,
                 now=now,
             )
-            await session.commit()
-        return None
-    if chat_id is None:
-        raise AssertionError("a sent Telegram message requires a destination chat")
-    async with service_factory() as session:
-        service = OrderProposalsService(session)
-        await service.record_approval_dispatch(
-            proposal_id, message_id=message_id, chat_id=chat_id, now=now
-        )
         await session.commit()
-    return message_id
+    return result
 
 
-__all__ = ["dispatch_proposal", "send_proposal_for_approval"]
+__all__ = [
+    "dispatch_proposal",
+    "publish_approval_messages",
+    "record_approval_dispatch_failure",
+    "send_proposal_for_approval",
+]

--- a/app/services/order_proposals/dispatch_contract.py
+++ b/app/services/order_proposals/dispatch_contract.py
@@ -1,0 +1,284 @@
+"""Authoritative approval-publication, ownership, and callback contracts."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import uuid
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any
+
+from app.telegram_contract import TelegramErrorClassification, TelegramMethodResult
+
+
+class ApprovalDispatchState(StrEnum):
+    """Closed attempt/workflow states used by every approval side effect."""
+
+    PENDING = "pending"
+    SENT_CURRENT = "sent_current"
+    SENT_SUPERSEDED = "sent_superseded"
+    FAILED = "failed"
+    PARTIAL_FAILED = "partial_failed"
+    FAILED_SUPERSEDED = "failed_superseded"
+
+    @property
+    def approvable(self) -> bool:
+        return self is ApprovalDispatchState.SENT_CURRENT
+
+    @property
+    def caller_state(self) -> str:
+        if self is ApprovalDispatchState.SENT_CURRENT:
+            return "sent"
+        if self in {
+            ApprovalDispatchState.SENT_SUPERSEDED,
+            ApprovalDispatchState.FAILED_SUPERSEDED,
+        }:
+            return "superseded"
+        return self.value
+
+
+class ApprovalCardKind(StrEnum):
+    MANUAL = "manual"
+    RECONFIRM = "reconfirm"
+    AUTO_VETO = "auto_veto"
+    LOSS_CUT_CONFIRMATION = "loss_cut_confirmation"
+    BATCH = "batch"
+
+
+_ACTIONS_BY_CARD_KIND: dict[ApprovalCardKind, frozenset[str]] = {
+    ApprovalCardKind.MANUAL: frozenset({"op", "dn"}),
+    ApprovalCardKind.RECONFIRM: frozenset({"op", "dn"}),
+    ApprovalCardKind.AUTO_VETO: frozenset({"vc"}),
+    ApprovalCardKind.LOSS_CUT_CONFIRMATION: frozenset({"lc", "dn"}),
+    ApprovalCardKind.BATCH: frozenset({"ba"}),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchBinding:
+    """Exact immutable snapshot to which a published callback is bound."""
+
+    attempt_id: uuid.UUID
+    card_kind: ApprovalCardKind
+    membership_revision: int
+    membership_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class CallbackEnvelope:
+    action: str
+    subject_short: str
+    attempt_id: uuid.UUID
+    membership_revision: int
+    membership_digest: str
+    nonce: str
+
+
+@dataclass(frozen=True, slots=True)
+class CallbackGateSnapshot:
+    subject_short: str
+    state: ApprovalDispatchState
+    attempt_id: uuid.UUID | None
+    card_kind: ApprovalCardKind | None
+    membership_revision: int | None
+    membership_digest: str | None
+    nonce: str | None
+    nonce_used: bool
+
+
+def assert_callback_gate(
+    *, snapshot: CallbackGateSnapshot, callback: CallbackEnvelope
+) -> None:
+    """Apply the one fail-closed gate shared by every nonce consumer."""
+    if snapshot.subject_short != callback.subject_short:
+        raise ValueError("approval_callback_subject_mismatch")
+    if snapshot.state is not ApprovalDispatchState.SENT_CURRENT:
+        raise ValueError(f"approval_dispatch_{snapshot.state.value}")
+    if snapshot.attempt_id != callback.attempt_id:
+        raise ValueError("approval_dispatch_attempt_mismatch")
+    if snapshot.nonce != callback.nonce:
+        raise ValueError("nonce_mismatch")
+    if snapshot.nonce_used:
+        raise ValueError("nonce_replay")
+    if snapshot.membership_revision != callback.membership_revision:
+        raise ValueError("approval_membership_revision_mismatch")
+    if snapshot.membership_digest != callback.membership_digest:
+        raise ValueError("approval_membership_digest_mismatch")
+    if (
+        snapshot.card_kind is None
+        or callback.action not in _ACTIONS_BY_CARD_KIND[snapshot.card_kind]
+    ):
+        raise ValueError("approval_card_action_mismatch")
+
+
+def build_membership_digest(
+    *,
+    card_kind: ApprovalCardKind,
+    membership_revision: int,
+    members: Sequence[dict[str, Any]],
+) -> str:
+    """Return the compact stored digest used verbatim in callback data."""
+    canonical = json.dumps(
+        {
+            "card_kind": card_kind.value,
+            "membership_revision": membership_revision,
+            "members": list(members),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    digest = hashlib.sha256(canonical).digest()[:9]
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def build_proposal_dispatch_binding(
+    *,
+    proposal_id: uuid.UUID,
+    nonce: str | None,
+    attempt_id: uuid.UUID,
+    card_kind: ApprovalCardKind,
+    current_membership_revision: int | None,
+) -> DispatchBinding:
+    """Build the next immutable single-proposal publication binding."""
+    revision = (current_membership_revision or 0) + 1
+    digest = build_membership_digest(
+        card_kind=card_kind,
+        membership_revision=revision,
+        members=[{"proposal_id": str(proposal_id), "approval_nonce": nonce}],
+    )
+    return DispatchBinding(
+        attempt_id=attempt_id,
+        card_kind=card_kind,
+        membership_revision=revision,
+        membership_digest=digest,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalPublication:
+    """Physical publication receipt that is not yet workflow success."""
+
+    card_published: bool
+    partial: bool
+    message_id: int | None
+    status_code: int | None
+    error_code: int | None
+    error_classification: TelegramErrorClassification | None
+    payload_chars: int
+    failure_code: str | None
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        payload_chars: int,
+        failure_code: str,
+        partial: bool = False,
+        method_result: TelegramMethodResult | None = None,
+    ) -> ApprovalPublication:
+        return cls(
+            card_published=False,
+            partial=partial,
+            message_id=None,
+            status_code=(
+                method_result.status_code if method_result is not None else None
+            ),
+            error_code=(
+                method_result.error_code if method_result is not None else None
+            ),
+            error_classification=(
+                method_result.error_classification
+                if method_result is not None
+                else None
+            ),
+            payload_chars=payload_chars,
+            failure_code=failure_code,
+        )
+
+    @classmethod
+    def published(
+        cls, *, payload_chars: int, method_result: TelegramMethodResult
+    ) -> ApprovalPublication:
+        if not method_result.ok or method_result.message_id is None:
+            raise ValueError("published receipt requires a successful Telegram result")
+        return cls(
+            card_published=True,
+            partial=False,
+            message_id=method_result.message_id,
+            status_code=method_result.status_code,
+            error_code=None,
+            error_classification=None,
+            payload_chars=payload_chars,
+            failure_code=None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramDispatchResult:
+    """Durable caller result derived from the final typed workflow state."""
+
+    state: ApprovalDispatchState
+    message_id: int | None
+    status_code: int | None
+    error_code: int | None
+    error_classification: TelegramErrorClassification | None
+    payload_chars: int
+    failure_code: str | None
+
+    @property
+    def ok(self) -> bool:
+        return self.state is ApprovalDispatchState.SENT_CURRENT
+
+    @property
+    def approvable(self) -> bool:
+        return self.state.approvable
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["state"] = self.state.caller_state
+        payload["ok"] = self.ok
+        if self.error_classification is not None:
+            payload["error_classification"] = self.error_classification.value
+        return payload
+
+    @classmethod
+    def from_publication(
+        cls,
+        publication: ApprovalPublication,
+        *,
+        state: ApprovalDispatchState,
+        failure_code: str | None = None,
+    ) -> TelegramDispatchResult:
+        if state is ApprovalDispatchState.SENT_CURRENT:
+            resolved_failure = None
+        elif failure_code is not None:
+            resolved_failure = failure_code
+        else:
+            resolved_failure = publication.failure_code
+        return cls(
+            state=state,
+            message_id=publication.message_id,
+            status_code=publication.status_code,
+            error_code=publication.error_code,
+            error_classification=publication.error_classification,
+            payload_chars=publication.payload_chars,
+            failure_code=resolved_failure,
+        )
+
+
+__all__ = [
+    "ApprovalCardKind",
+    "ApprovalDispatchState",
+    "ApprovalPublication",
+    "CallbackEnvelope",
+    "CallbackGateSnapshot",
+    "DispatchBinding",
+    "TelegramDispatchResult",
+    "assert_callback_gate",
+    "build_membership_digest",
+    "build_proposal_dispatch_binding",
+]

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -20,9 +20,11 @@ from app.models.order_proposals import (
     OrderProposal,
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
+    OrderProposalApprovalDispatchAttempt,
     OrderProposalRung,
 )
 from app.services.order_proposals.defensive_ttl import DEFENSIVE_EXIT_INTENTS
+from app.services.order_proposals.dispatch_contract import ApprovalDispatchState
 
 
 class OrderProposalRepository:
@@ -42,6 +44,25 @@ class OrderProposalRepository:
         await self._session.flush()
         await self._session.refresh(row)
         return row
+
+    async def insert_approval_dispatch_attempt(
+        self, **cols: Any
+    ) -> OrderProposalApprovalDispatchAttempt:
+        row = OrderProposalApprovalDispatchAttempt(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_approval_dispatch_attempt(
+        self, attempt_id: uuid.UUID, *, for_update: bool = False
+    ) -> OrderProposalApprovalDispatchAttempt | None:
+        stmt = select(OrderProposalApprovalDispatchAttempt).where(
+            OrderProposalApprovalDispatchAttempt.attempt_id == attempt_id
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self._session.execute(stmt)).scalar_one_or_none()
 
     async def get_group_by_proposal_id(
         self, proposal_id: uuid.UUID, *, for_update: bool = False
@@ -273,6 +294,14 @@ class OrderProposalRepository:
         await self._session.flush()
         return rung
 
+    async def update_approval_dispatch_attempt(
+        self, attempt: OrderProposalApprovalDispatchAttempt, **fields: Any
+    ) -> OrderProposalApprovalDispatchAttempt:
+        for key, value in fields.items():
+            setattr(attempt, key, value)
+        await self._session.flush()
+        return attempt
+
     async def acquire_approval_batch_chat_lock(self, chat_id: str) -> None:
         await self._session.execute(
             select(
@@ -292,6 +321,13 @@ class OrderProposalRepository:
             .where(
                 OrderProposalApprovalBatch.chat_id == chat_id,
                 OrderProposalApprovalBatch.approval_nonce_used_at.is_(None),
+                OrderProposalApprovalBatch.membership_frozen_at.is_(None),
+                OrderProposalApprovalBatch.approval_dispatch_state
+                == ApprovalDispatchState.PENDING.value,
+                OrderProposalApprovalBatch.summary_dispatch_state == "idle",
+                OrderProposalApprovalBatch.summary_message_id.is_(None),
+                OrderProposalApprovalBatch.approval_dispatch_attempt_id.is_(None),
+                OrderProposalApprovalBatch.membership_digest.is_(None),
                 OrderProposalApprovalBatch.window_closes_at > now,
                 OrderProposalApprovalBatch.expires_at > now,
             )

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -24,6 +24,7 @@ from app.models.order_proposals import (
     OrderProposal,
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
+    OrderProposalApprovalDispatchAttempt,
     OrderProposalRung,
 )
 from app.models.review import TossLiveOrderLedger
@@ -32,6 +33,17 @@ from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
 from app.services.order_proposals.defensive_ttl import (
     DEFENSIVE_EXIT_INTENTS,
     resolve_defensive_valid_until,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalDispatchState,
+    ApprovalPublication,
+    CallbackEnvelope,
+    CallbackGateSnapshot,
+    DispatchBinding,
+    TelegramDispatchResult,
+    assert_callback_gate,
+    build_membership_digest,
 )
 from app.services.order_proposals.errors import (
     OrderProposalError,
@@ -54,6 +66,27 @@ from app.services.trade_journal.trade_retrospective_service import (
 logger = logging.getLogger(__name__)
 
 
+def _log_dispatch_outcome(result: TelegramDispatchResult, *, surface: str) -> None:
+    logger.log(
+        logging.INFO if result.ok else logging.ERROR,
+        "order_proposals.approval_dispatch.finalized",
+        extra={
+            "approval_surface": surface,
+            "approval_dispatch_state": result.state.value,
+            "approval_dispatch_ok": result.ok,
+            "http_status": result.status_code,
+            "telegram_error_code": result.error_code,
+            "telegram_error_classification": (
+                result.error_classification.value
+                if result.error_classification is not None
+                else None
+            ),
+            "payload_chars": result.payload_chars,
+            "failure_code": result.failure_code,
+        },
+    )
+
+
 @dataclass
 class RungInput:
     rung_index: int
@@ -69,13 +102,15 @@ class BatchMemberSnapshot:
     proposal_id: uuid.UUID
     approval_nonce: str
     approval_message_id: int
+    dispatch_binding: DispatchBinding
 
 
 @dataclass(frozen=True)
 class BatchRegistration:
     batch: OrderProposalApprovalBatch
     member_count: int
-    summary_action: Literal["none", "send", "edit"]
+    summary_action: Literal["none", "send"]
+    binding: DispatchBinding | None = None
 
 
 @dataclass(frozen=True)
@@ -243,6 +278,13 @@ def batch_member_block_reason(
         return "loss_cut_excluded"
     if isinstance((group.source_asof or {}).get("auto_approved"), dict):
         return "auto_approved_excluded"
+    if group.approval_dispatch_state != ApprovalDispatchState.SENT_CURRENT.value:
+        return "approval_dispatch_not_current"
+    if group.approval_dispatch_card_kind not in {
+        ApprovalCardKind.MANUAL.value,
+        ApprovalCardKind.RECONFIRM.value,
+    }:
+        return "approval_card_kind_not_batchable"
     if group.valid_until is not None and now >= group.valid_until:
         return "proposal_expired"
     if not group.approval_nonce:
@@ -961,6 +1003,13 @@ class OrderProposalsService:
 
     # -- PR-2 helpers -------------------------------------------------------
     async def set_approval_nonce(self, proposal_id: uuid.UUID, nonce: str) -> None:
+        """Stage a nonce while fail-closing any previously published card.
+
+        Production dispatch calls this immediately before
+        ``start_approval_dispatch`` in the same transaction. Keeping the
+        intermediate state non-approvable also makes direct/legacy callers
+        unable to pair a fresh nonce with an older published binding.
+        """
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
@@ -968,48 +1017,148 @@ class OrderProposalsService:
         if block_reason is not None:
             raise OrderProposalError(block_reason)
         await self._repo.update_group(
-            group, approval_nonce=nonce, approval_nonce_used_at=None
+            group,
+            approval_nonce=nonce,
+            approval_nonce_used_at=None,
+            approval_dispatch_state=ApprovalDispatchState.FAILED.value,
+            approval_dispatch_published_at=None,
+            approval_dispatch_failure_code="approval_dispatch_snapshot_missing",
         )
 
     async def consume_approval_nonce(
         self, proposal_id: uuid.UUID, nonce: str, *, now: datetime
     ) -> OrderProposal:
-        self._require_timezone_aware(now)
-        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        """Compatibility wrapper; every consume still crosses the common gate."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
-        block_reason = proposal_approval_block_reason(group)
-        if block_reason is not None:
-            raise OrderProposalError(block_reason)
-        if isinstance((group.source_asof or {}).get("auto_approved"), dict):
-            raise OrderProposalError("auto_veto_nonce_requires_vc")
-        if group.approval_nonce != nonce:
-            raise OrderProposalError("nonce_mismatch")
-        if group.approval_nonce_used_at is not None:
-            raise OrderProposalError("nonce_replay")
-        return await self._repo.update_group(group, approval_nonce_used_at=now)
+        callback = self._current_callback_envelope(group, action="op", nonce=nonce)
+        return await self.consume_published_proposal_callback(
+            proposal_id, callback=callback, now=now
+        )
 
     async def consume_auto_veto_nonce(
         self, proposal_id: uuid.UUID, nonce: str, *, now: datetime
     ) -> OrderProposal:
-        """Consume an auto-submit veto nonce, including after a broker fill."""
+        """Compatibility wrapper for the same authoritative callback gate."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        callback = self._current_callback_envelope(group, action="vc", nonce=nonce)
+        return await self.consume_published_proposal_callback(
+            proposal_id, callback=callback, now=now
+        )
+
+    @staticmethod
+    def _current_callback_envelope(
+        group: OrderProposal, *, action: str, nonce: str
+    ) -> CallbackEnvelope:
+        attempt_id = group.approval_dispatch_attempt_id
+        revision = group.approval_dispatch_membership_revision
+        digest = group.approval_dispatch_membership_digest
+        if attempt_id is None or revision is None or digest is None:
+            raise OrderProposalError("approval_dispatch_snapshot_missing")
+        return CallbackEnvelope(
+            action=action,
+            subject_short=str(group.proposal_id)[:8],
+            attempt_id=attempt_id,
+            membership_revision=revision,
+            membership_digest=digest,
+            nonce=nonce,
+        )
+
+    @staticmethod
+    def _assert_published_proposal_binding(
+        group: OrderProposal, *, callback: CallbackEnvelope
+    ) -> ApprovalCardKind:
+        """Validate one proposal callback without consuming its nonce.
+
+        Both the read-only preflight and the row-locked consuming gate call this
+        exact function.  The second call is intentional: any owner/nonce/
+        membership change while external preview work is in flight fails
+        closed before a nonce or proposal mutation is written.
+        """
+        block_reason = proposal_approval_block_reason(group)
+        if block_reason is not None:
+            raise OrderProposalError(block_reason)
+        try:
+            state = ApprovalDispatchState(str(group.approval_dispatch_state))
+        except ValueError as exc:
+            raise OrderProposalError("approval_dispatch_state_invalid") from exc
+        try:
+            card_kind = (
+                ApprovalCardKind(str(group.approval_dispatch_card_kind))
+                if group.approval_dispatch_card_kind is not None
+                else None
+            )
+        except ValueError as exc:
+            raise OrderProposalError("approval_dispatch_card_kind_invalid") from exc
+        try:
+            assert_callback_gate(
+                snapshot=CallbackGateSnapshot(
+                    subject_short=str(group.proposal_id)[:8],
+                    state=state,
+                    attempt_id=group.approval_dispatch_attempt_id,
+                    card_kind=card_kind,
+                    membership_revision=(group.approval_dispatch_membership_revision),
+                    membership_digest=group.approval_dispatch_membership_digest,
+                    nonce=group.approval_nonce,
+                    nonce_used=group.approval_nonce_used_at is not None,
+                ),
+                callback=callback,
+            )
+        except ValueError as exc:
+            raise OrderProposalError(str(exc)) from exc
+        if card_kind is None:  # Kept explicit for the narrowed return type.
+            raise OrderProposalError("approval_dispatch_card_kind_invalid")
+
+        auto_approved = isinstance(
+            ((group.source_asof or {}).get("auto_approved")), dict
+        )
+        if card_kind is ApprovalCardKind.AUTO_VETO:
+            if not auto_approved:
+                raise OrderProposalError("auto_veto_not_available")
+        elif auto_approved:
+            raise OrderProposalError("auto_veto_nonce_requires_vc")
+        return card_kind
+
+    async def preflight_published_proposal_callback(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        callback: CallbackEnvelope,
+    ) -> OrderProposal:
+        """Read-only binding gate that must precede callback-side external I/O."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        self._assert_published_proposal_binding(group, callback=callback)
+        return group
+
+    async def consume_published_proposal_callback(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        callback: CallbackEnvelope,
+        now: datetime,
+        telegram_user_id: str | None = None,
+    ) -> OrderProposal:
+        """The single nonce-consumption gate for every proposal card kind."""
         self._require_timezone_aware(now)
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
-        if group.superseded_by_proposal_id is not None:
-            raise OrderProposalError(
-                f"proposal_superseded_by:{group.superseded_by_proposal_id}"
+        self._assert_published_proposal_binding(group, callback=callback)
+
+        fields: dict[str, Any] = {"approval_nonce_used_at": now}
+        if callback.action == "lc":
+            fields["source_asof"] = await self._validated_loss_cut_confirmation_source(
+                group,
+                nonce=callback.nonce,
+                telegram_user_id=telegram_user_id or "",
+                now=now,
             )
-        if group.lifecycle_state == "superseded":
-            raise OrderProposalError("proposal_superseded_by:unknown")
-        if not isinstance((group.source_asof or {}).get("auto_approved"), dict):
-            raise OrderProposalError("auto_veto_not_available")
-        if group.approval_nonce != nonce:
-            raise OrderProposalError("nonce_mismatch")
-        if group.approval_nonce_used_at is not None:
-            raise OrderProposalError("nonce_replay")
-        return await self._repo.update_group(group, approval_nonce_used_at=now)
+        return await self._repo.update_group(group, **fields)
 
     async def issue_loss_cut_confirmation(
         self,
@@ -1073,18 +1222,26 @@ class OrderProposalsService:
         telegram_user_id: str,
         now: datetime,
     ) -> OrderProposal:
-        """Atomically validate, audit, and consume a loss-cut second-step nonce."""
-        self._require_timezone_aware(now)
-        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        """Compatibility wrapper for the common published-callback gate."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
-        block_reason = proposal_approval_block_reason(group)
-        if block_reason is not None:
-            raise OrderProposalError(block_reason)
-        if group.approval_nonce != nonce:
-            raise OrderProposalError("nonce_mismatch")
-        if group.approval_nonce_used_at is not None:
-            raise OrderProposalError("nonce_replay")
+        callback = self._current_callback_envelope(group, action="lc", nonce=nonce)
+        return await self.consume_published_proposal_callback(
+            proposal_id,
+            callback=callback,
+            telegram_user_id=telegram_user_id,
+            now=now,
+        )
+
+    async def _validated_loss_cut_confirmation_source(
+        self,
+        group: OrderProposal,
+        *,
+        nonce: str,
+        telegram_user_id: str,
+        now: datetime,
+    ) -> dict[str, Any]:
         envelope = (group.source_asof or {}).get(_LOSS_CUT_CONFIRMATION_KEY)
         if not isinstance(envelope, dict):
             raise OrderProposalError("loss_cut_confirmation_missing")
@@ -1105,7 +1262,7 @@ class OrderProposalsService:
             if rung.state in _LOSS_CUT_CONFIRMABLE_RUNG_STATES
         ]
         if (
-            envelope.get("proposal_id") != str(proposal_id)
+            envelope.get("proposal_id") != str(group.proposal_id)
             or envelope.get("nonce") != nonce
             or envelope.get("rungs") != current_binding
         ):
@@ -1122,11 +1279,7 @@ class OrderProposalsService:
             **(group.source_asof or {}),
             _LOSS_CUT_CONFIRMATION_KEY: updated_envelope,
         }
-        return await self._repo.update_group(
-            group,
-            source_asof=source_asof,
-            approval_nonce_used_at=now,
-        )
+        return source_asof
 
     async def record_approval(
         self,
@@ -1151,15 +1304,12 @@ class OrderProposalsService:
         chat_id: str,
         now: datetime,
     ) -> OrderProposal:
-        """Record where the initial Telegram approval message was sent.
+        """Record legacy message location without creating an approvable card.
 
-        No new column exists for this (see ``dispatch.py``'s module docstring)
-        -- ``message_id``/``chat_id``/``sent_at`` are merged into the existing
-        ``source_asof`` JSONB column so a later Telegram ``edit_message`` call
-        can find them. This merges on top of whatever keys are already there
-        (e.g. ``resting_deadline``, read by
-        ``approval_message.py::_build_time_lines``) rather than overwriting
-        the column outright.
+        ``message_id``/``chat_id``/``sent_at`` stay in ``source_asof`` so later
+        Telegram edits can find them. A caller without an attempt-bound,
+        immutable snapshot cannot manufacture ``SENT_CURRENT`` through this
+        compatibility helper.
         """
         self._require_timezone_aware(now)
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
@@ -1172,7 +1322,214 @@ class OrderProposalsService:
             "approval_chat_id": chat_id,
             "approval_sent_at": now.isoformat(),
         }
-        return await self._repo.update_group(group, source_asof=merged)
+        return await self._repo.update_group(
+            group,
+            source_asof=merged,
+            approval_dispatch_state=ApprovalDispatchState.FAILED.value,
+            approval_dispatch_attempted_at=(
+                group.approval_dispatch_attempted_at or now
+            ),
+            approval_dispatch_published_at=None,
+            approval_dispatch_failure_code="approval_dispatch_snapshot_missing",
+            approval_nonce=None,
+            approval_nonce_used_at=None,
+        )
+
+    async def start_approval_dispatch(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        attempt_id: uuid.UUID,
+        binding: DispatchBinding,
+        now: datetime,
+        payload_chars: int,
+        context_message_count: int,
+    ) -> OrderProposalApprovalDispatchAttempt:
+        """Commit a pending attempt before any Telegram I/O begins."""
+        self._require_timezone_aware(now)
+        if payload_chars < 0:
+            raise ValueError("payload_chars must be non-negative")
+        if context_message_count < 0:
+            raise ValueError("context_message_count must be non-negative")
+        if binding.attempt_id != attempt_id:
+            raise ValueError("dispatch binding attempt_id mismatch")
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        expected_revision = (group.approval_dispatch_membership_revision or 0) + 1
+        if binding.membership_revision != expected_revision:
+            raise OrderProposalError("approval_membership_revision_not_next")
+        if binding.card_kind is ApprovalCardKind.BATCH:
+            raise OrderProposalError("proposal_dispatch_card_kind_invalid")
+        expected_digest = build_membership_digest(
+            card_kind=binding.card_kind,
+            membership_revision=binding.membership_revision,
+            members=[
+                {
+                    "proposal_id": str(group.proposal_id),
+                    "approval_nonce": group.approval_nonce,
+                }
+            ],
+        )
+        if binding.membership_digest != expected_digest:
+            raise OrderProposalError("approval_membership_digest_invalid")
+
+        previous_attempt_id = group.approval_dispatch_attempt_id
+        if previous_attempt_id is not None and previous_attempt_id != attempt_id:
+            previous = await self._repo.get_approval_dispatch_attempt(
+                previous_attempt_id, for_update=True
+            )
+            if (
+                previous is not None
+                and previous.state == ApprovalDispatchState.SENT_CURRENT.value
+            ):
+                await self._repo.update_approval_dispatch_attempt(
+                    previous,
+                    state=ApprovalDispatchState.SENT_SUPERSEDED.value,
+                    failure_code="approval_dispatch_superseded",
+                )
+        attempt = await self._repo.insert_approval_dispatch_attempt(
+            attempt_id=attempt_id,
+            proposal_pk=group.id,
+            state=ApprovalDispatchState.PENDING.value,
+            attempted_at=now,
+            payload_chars=payload_chars,
+            context_message_count=context_message_count,
+            card_kind=binding.card_kind.value,
+            membership_revision=binding.membership_revision,
+            membership_digest=binding.membership_digest,
+        )
+        await self._repo.update_group(
+            group,
+            approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+            approval_dispatch_attempt_id=attempt_id,
+            approval_dispatch_attempted_at=now,
+            approval_dispatch_published_at=None,
+            approval_dispatch_failure_code=None,
+            approval_dispatch_payload_chars=payload_chars,
+            approval_dispatch_card_kind=binding.card_kind.value,
+            approval_dispatch_membership_revision=binding.membership_revision,
+            approval_dispatch_membership_digest=binding.membership_digest,
+        )
+        return attempt
+
+    async def finish_approval_dispatch(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        attempt_id: uuid.UUID,
+        publication: ApprovalPublication,
+        chat_id: str | None,
+        now: datetime,
+    ) -> TelegramDispatchResult:
+        """Resolve physical publication through the current-owner fence."""
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        attempt = await self._repo.get_approval_dispatch_attempt(
+            attempt_id, for_update=True
+        )
+        if attempt is None or attempt.proposal_pk != group.id:
+            raise OrderProposalError("approval_dispatch_attempt_not_found")
+        if attempt.state != ApprovalDispatchState.PENDING.value:
+            raise OrderProposalError("approval_dispatch_attempt_already_finished")
+        if publication.card_published and (
+            publication.message_id is None or chat_id is None
+        ):
+            raise OrderProposalError(
+                "successful dispatch requires message_id and chat_id"
+            )
+
+        try:
+            attempt_card_kind = ApprovalCardKind(str(attempt.card_kind))
+        except ValueError as exc:
+            raise OrderProposalError("approval_dispatch_card_kind_invalid") from exc
+        expected_digest = build_membership_digest(
+            card_kind=attempt_card_kind,
+            membership_revision=attempt.membership_revision,
+            members=[
+                {
+                    "proposal_id": str(group.proposal_id),
+                    "approval_nonce": group.approval_nonce,
+                }
+            ],
+        )
+        is_current_owner = (
+            group.approval_dispatch_state == ApprovalDispatchState.PENDING.value
+            and group.approval_dispatch_attempt_id == attempt_id
+            and group.approval_dispatch_card_kind == attempt.card_kind
+            and group.approval_dispatch_membership_revision
+            == attempt.membership_revision
+            and group.approval_dispatch_membership_digest == attempt.membership_digest
+            and expected_digest == attempt.membership_digest
+        )
+        snapshot_missing = publication.card_published and not group.approval_nonce
+        if not is_current_owner:
+            state = (
+                ApprovalDispatchState.SENT_SUPERSEDED
+                if publication.card_published
+                else ApprovalDispatchState.FAILED_SUPERSEDED
+            )
+            failure_code = "approval_dispatch_superseded"
+        elif snapshot_missing:
+            state = ApprovalDispatchState.FAILED
+            failure_code = "approval_dispatch_snapshot_missing"
+        elif publication.card_published:
+            state = ApprovalDispatchState.SENT_CURRENT
+            failure_code = None
+        elif publication.partial:
+            state = ApprovalDispatchState.PARTIAL_FAILED
+            failure_code = publication.failure_code or "telegram_dispatch_failed"
+        else:
+            state = ApprovalDispatchState.FAILED
+            failure_code = publication.failure_code or "telegram_dispatch_failed"
+
+        await self._repo.update_approval_dispatch_attempt(
+            attempt,
+            state=state.value,
+            completed_at=now,
+            message_id=publication.message_id,
+            status_code=publication.status_code,
+            telegram_error_code=publication.error_code,
+            error_classification=(
+                publication.error_classification.value
+                if publication.error_classification is not None
+                else None
+            ),
+            failure_code=failure_code,
+        )
+
+        result = TelegramDispatchResult.from_publication(
+            publication, state=state, failure_code=failure_code
+        )
+        if not is_current_owner:
+            _log_dispatch_outcome(result, surface="proposal")
+            return result
+
+        fields: dict[str, Any] = {
+            "approval_dispatch_state": state.value,
+            "approval_dispatch_failure_code": failure_code,
+            "approval_dispatch_payload_chars": publication.payload_chars,
+        }
+        if state is ApprovalDispatchState.SENT_CURRENT:
+            existing = group.source_asof or {}
+            fields["source_asof"] = {
+                **existing,
+                "approval_message_id": publication.message_id,
+                "approval_chat_id": chat_id,
+                "approval_sent_at": now.isoformat(),
+            }
+            fields["approval_dispatch_published_at"] = now
+        else:
+            # Fail closed if Telegram accepted a message but its response was
+            # lost: an unconfirmed button cannot consume this attempt's nonce.
+            fields["approval_nonce"] = None
+            fields["approval_nonce_used_at"] = None
+            fields["approval_dispatch_published_at"] = None
+        await self._repo.update_group(group, **fields)
+        _log_dispatch_outcome(result, surface="proposal")
+        return result
 
     async def register_approval_batch_member(
         self,
@@ -1184,7 +1541,11 @@ class OrderProposalsService:
         window_seconds: int = 600,
         ttl_seconds: int = 600,
     ) -> BatchRegistration | None:
-        """Register one still-manual proposal in the chat's open batch."""
+        """Stage a member, freezing the batch before its first publication.
+
+        A frozen batch is never reopened or edited.  The next proposal starts
+        a new staged batch, so membership displayed with a button is immutable.
+        """
         self._require_timezone_aware(now)
         await self._repo.acquire_approval_batch_chat_lock(chat_id)
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
@@ -1213,8 +1574,10 @@ class OrderProposalsService:
                     ttl_seconds=ttl_seconds,
                     validity_deadlines=[group.valid_until],
                 ),
-                approval_nonce=secrets.token_urlsafe(12),
+                approval_nonce=secrets.token_urlsafe(8),
                 summary_dispatch_state="idle",
+                approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+                membership_revision=1,
             )
 
         existing_members = await self._repo.list_approval_batch_members(batch.id)
@@ -1227,6 +1590,14 @@ class OrderProposalsService:
             approval_nonce_snapshot=str(group.approval_nonce),
             approval_message_id=approval_message_id,
             added_at=now,
+            approval_dispatch_attempt_id_snapshot=(group.approval_dispatch_attempt_id),
+            approval_membership_revision_snapshot=(
+                group.approval_dispatch_membership_revision
+            ),
+            approval_membership_digest_snapshot=(
+                group.approval_dispatch_membership_digest
+            ),
+            approval_card_kind_snapshot=group.approval_dispatch_card_kind,
         )
         members = await self._repo.list_approval_batch_members(batch.id)
         validity_deadlines: list[datetime | None] = []
@@ -1235,15 +1606,30 @@ class OrderProposalsService:
         # registers into the same window as the proposal it just invalidated;
         # counting that dead member would announce an "전체 승인" batch whose
         # live membership is a single proposal.
-        live_member_count = 0
+        live_members: list[tuple[OrderProposalApprovalBatchMember, OrderProposal]] = []
         for member in members:
             member_group = await self._repo.get_group_by_pk(member.proposal_pk)
             if member_group is None:
                 continue
             validity_deadlines.append(member_group.valid_until)
             member_rungs = await self._repo.list_rungs(member_group.id)
-            if batch_member_block_reason(member_group, member_rungs, now=now) is None:
-                live_member_count += 1
+            snapshot_is_current = (
+                member_group.approval_nonce == member.approval_nonce_snapshot
+                and member_group.approval_dispatch_attempt_id
+                == member.approval_dispatch_attempt_id_snapshot
+                and member_group.approval_dispatch_membership_revision
+                == member.approval_membership_revision_snapshot
+                and member_group.approval_dispatch_membership_digest
+                == member.approval_membership_digest_snapshot
+                and member_group.approval_dispatch_card_kind
+                == member.approval_card_kind_snapshot
+            )
+            if (
+                snapshot_is_current
+                and batch_member_block_reason(member_group, member_rungs, now=now)
+                is None
+            ):
+                live_members.append((member, member_group))
         await self._repo.update_approval_batch(
             batch,
             expires_at=self._bounded_batch_expiry(
@@ -1253,26 +1639,62 @@ class OrderProposalsService:
             ),
         )
 
-        member_count = live_member_count
-        summary_action: Literal["none", "send", "edit"] = "none"
+        member_count = len(live_members)
+        summary_action: Literal["none", "send"] = "none"
+        binding: DispatchBinding | None = None
         if member_count >= 2:
-            if batch.summary_message_id is not None:
-                summary_action = "edit"
-            elif batch.summary_dispatch_state == "idle" or (
-                batch.summary_dispatch_state == "sending"
-                and batch.summary_dispatch_lease_until is not None
-                and batch.summary_dispatch_lease_until <= now
-            ):
-                await self._repo.update_approval_batch(
-                    batch,
-                    summary_dispatch_state="sending",
-                    summary_dispatch_lease_until=now + timedelta(seconds=30),
+            revision = batch.membership_revision or 1
+            attempt_id = uuid.uuid4()
+            digest_members = [
+                {
+                    "proposal_id": str(member_group.proposal_id),
+                    "approval_nonce": member.approval_nonce_snapshot,
+                    "approval_message_id": member.approval_message_id,
+                    "approval_dispatch_attempt_id": str(
+                        member.approval_dispatch_attempt_id_snapshot
+                    ),
+                    "approval_membership_revision": (
+                        member.approval_membership_revision_snapshot
+                    ),
+                    "approval_membership_digest": (
+                        member.approval_membership_digest_snapshot
+                    ),
+                }
+                for member, member_group in live_members
+            ]
+            digest = build_membership_digest(
+                card_kind=ApprovalCardKind.BATCH,
+                membership_revision=revision,
+                members=digest_members,
+            )
+            for member, _member_group in live_members:
+                await self._repo.update_approval_batch_member(
+                    member, membership_revision=revision
                 )
-                summary_action = "send"
+            await self._repo.update_approval_batch(
+                batch,
+                approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+                approval_dispatch_attempt_id=attempt_id,
+                approval_dispatch_attempted_at=now,
+                approval_dispatch_failure_code=None,
+                membership_revision=revision,
+                membership_digest=digest,
+                membership_frozen_at=now,
+                summary_dispatch_state="sending",
+                summary_dispatch_lease_until=None,
+            )
+            binding = DispatchBinding(
+                attempt_id=attempt_id,
+                card_kind=ApprovalCardKind.BATCH,
+                membership_revision=revision,
+                membership_digest=digest,
+            )
+            summary_action = "send"
         return BatchRegistration(
             batch=batch,
             member_count=member_count,
             summary_action=summary_action,
+            binding=binding,
         )
 
     @staticmethod
@@ -1291,31 +1713,140 @@ class OrderProposalsService:
     ) -> uuid.UUID | None:
         return await self._repo.resolve_approval_batch_id_prefix(batch_short)
 
+    @staticmethod
+    def _assert_published_batch_binding(
+        batch: OrderProposalApprovalBatch,
+        *,
+        callback: CallbackEnvelope,
+        chat_id: str,
+        now: datetime,
+    ) -> None:
+        if batch.chat_id != chat_id:
+            raise OrderProposalError("approval_batch_chat_mismatch")
+        if now >= batch.expires_at:
+            raise OrderProposalError("approval_batch_expired")
+        try:
+            state = ApprovalDispatchState(str(batch.approval_dispatch_state))
+        except ValueError as exc:
+            raise OrderProposalError("approval_dispatch_state_invalid") from exc
+        try:
+            assert_callback_gate(
+                snapshot=CallbackGateSnapshot(
+                    subject_short=str(batch.batch_id)[:8],
+                    state=state,
+                    attempt_id=batch.approval_dispatch_attempt_id,
+                    card_kind=ApprovalCardKind.BATCH,
+                    membership_revision=batch.membership_revision,
+                    membership_digest=batch.membership_digest,
+                    nonce=batch.approval_nonce,
+                    nonce_used=batch.approval_nonce_used_at is not None,
+                ),
+                callback=callback,
+            )
+        except ValueError as exc:
+            raise OrderProposalError(str(exc)) from exc
+
+    async def preflight_published_batch_callback(
+        self,
+        batch_id: uuid.UUID,
+        *,
+        callback: CallbackEnvelope,
+        chat_id: str,
+        now: datetime,
+    ) -> OrderProposalApprovalBatch:
+        """Read-only batch binding gate; consuming gate rechecks under lock."""
+        self._require_timezone_aware(now)
+        batch = await self._repo.get_approval_batch_by_id(batch_id)
+        if batch is None:
+            raise OrderProposalError("approval_batch_not_found")
+        self._assert_published_batch_binding(
+            batch, callback=callback, chat_id=chat_id, now=now
+        )
+        return batch
+
     async def consume_approval_batch_nonce(
         self,
         batch_id: uuid.UUID,
-        nonce: str,
         *,
+        callback: CallbackEnvelope,
         chat_id: str,
         telegram_user_id: str,
         now: datetime,
     ) -> tuple[OrderProposalApprovalBatch, list[BatchMemberSnapshot]]:
-        """Atomically consume a batch trigger and freeze its ordered members."""
+        """Consume exactly the immutable membership snapshot shown on the card."""
         self._require_timezone_aware(now)
         batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
         if batch is None:
             raise OrderProposalError("approval_batch_not_found")
-        if batch.chat_id != chat_id:
-            raise OrderProposalError("approval_batch_chat_mismatch")
-        if batch.approval_nonce != nonce:
-            raise OrderProposalError("approval_batch_nonce_mismatch")
-        if batch.approval_nonce_used_at is not None:
-            raise OrderProposalError("approval_batch_nonce_replay")
-        if now >= batch.expires_at:
-            raise OrderProposalError("approval_batch_expired")
-        members = await self._repo.list_approval_batch_members(batch.id)
+        self._assert_published_batch_binding(
+            batch, callback=callback, chat_id=chat_id, now=now
+        )
+
+        members = [
+            member
+            for member in await self._repo.list_approval_batch_members(batch.id)
+            if member.membership_revision == callback.membership_revision
+        ]
         if len(members) < 2:
             raise OrderProposalError("approval_batch_too_small")
+
+        snapshots: list[BatchMemberSnapshot] = []
+        digest_members: list[dict[str, Any]] = []
+        for member in members:
+            group = await self._repo.get_group_by_pk(member.proposal_pk)
+            if group is None:
+                raise OrderProposalError("approval_batch_member_snapshot_invalid")
+            try:
+                card_kind = ApprovalCardKind(str(member.approval_card_kind_snapshot))
+            except ValueError as exc:
+                raise OrderProposalError(
+                    "approval_batch_member_snapshot_invalid"
+                ) from exc
+            if (
+                member.approval_dispatch_attempt_id_snapshot is None
+                or member.approval_membership_revision_snapshot is None
+                or member.approval_membership_digest_snapshot is None
+            ):
+                raise OrderProposalError("approval_batch_member_snapshot_invalid")
+            digest_members.append(
+                {
+                    "proposal_id": str(group.proposal_id),
+                    "approval_nonce": member.approval_nonce_snapshot,
+                    "approval_message_id": member.approval_message_id,
+                    "approval_dispatch_attempt_id": str(
+                        member.approval_dispatch_attempt_id_snapshot
+                    ),
+                    "approval_membership_revision": (
+                        member.approval_membership_revision_snapshot
+                    ),
+                    "approval_membership_digest": (
+                        member.approval_membership_digest_snapshot
+                    ),
+                }
+            )
+            snapshots.append(
+                BatchMemberSnapshot(
+                    member_id=member.id,
+                    proposal_id=group.proposal_id,
+                    approval_nonce=member.approval_nonce_snapshot,
+                    approval_message_id=member.approval_message_id,
+                    dispatch_binding=DispatchBinding(
+                        attempt_id=member.approval_dispatch_attempt_id_snapshot,
+                        card_kind=card_kind,
+                        membership_revision=(
+                            member.approval_membership_revision_snapshot
+                        ),
+                        membership_digest=(member.approval_membership_digest_snapshot),
+                    ),
+                )
+            )
+        actual_digest = build_membership_digest(
+            card_kind=ApprovalCardKind.BATCH,
+            membership_revision=callback.membership_revision,
+            members=digest_members,
+        )
+        if actual_digest != batch.membership_digest:
+            raise OrderProposalError("approval_batch_membership_digest_mismatch")
 
         await self._repo.update_approval_batch(
             batch,
@@ -1323,20 +1854,100 @@ class OrderProposalsService:
             approved_by_telegram_user_id=telegram_user_id,
             approved_at=now,
         )
-        snapshots: list[BatchMemberSnapshot] = []
-        for member in members:
-            group = await self._repo.get_group_by_pk(member.proposal_pk)
-            if group is None:
-                continue
-            snapshots.append(
-                BatchMemberSnapshot(
-                    member_id=member.id,
-                    proposal_id=group.proposal_id,
-                    approval_nonce=member.approval_nonce_snapshot,
-                    approval_message_id=member.approval_message_id,
-                )
-            )
         return batch, snapshots
+
+    async def record_approval_batch_payload(
+        self,
+        batch_id: uuid.UUID,
+        *,
+        attempt_id: uuid.UUID,
+        payload_chars: int,
+    ) -> OrderProposalApprovalBatch:
+        batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
+        if batch is None:
+            raise OrderProposalError("approval_batch_not_found")
+        if (
+            batch.approval_dispatch_attempt_id != attempt_id
+            or batch.approval_dispatch_state != ApprovalDispatchState.PENDING.value
+        ):
+            raise OrderProposalError("approval_batch_dispatch_owner_mismatch")
+        return await self._repo.update_approval_batch(
+            batch, approval_dispatch_payload_chars=payload_chars
+        )
+
+    async def finish_approval_batch_dispatch(
+        self,
+        batch_id: uuid.UUID,
+        *,
+        attempt_id: uuid.UUID,
+        publication: ApprovalPublication,
+        now: datetime,
+    ) -> TelegramDispatchResult:
+        """Finalize one immutable batch publication through its owner fence."""
+        self._require_timezone_aware(now)
+        batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
+        if batch is None:
+            raise OrderProposalError("approval_batch_not_found")
+        is_current_owner = (
+            batch.approval_dispatch_state == ApprovalDispatchState.PENDING.value
+            and batch.approval_dispatch_attempt_id == attempt_id
+            and batch.membership_revision is not None
+            and batch.membership_digest is not None
+            and batch.membership_frozen_at is not None
+        )
+        if not is_current_owner:
+            state = (
+                ApprovalDispatchState.SENT_SUPERSEDED
+                if publication.card_published
+                else ApprovalDispatchState.FAILED_SUPERSEDED
+            )
+            result = TelegramDispatchResult.from_publication(
+                publication,
+                state=state,
+                failure_code="approval_dispatch_superseded",
+            )
+            _log_dispatch_outcome(result, surface="batch")
+            return result
+        if publication.card_published:
+            state = ApprovalDispatchState.SENT_CURRENT
+            failure_code = None
+        elif publication.partial:
+            state = ApprovalDispatchState.PARTIAL_FAILED
+            failure_code = publication.failure_code or "telegram_dispatch_failed"
+        else:
+            state = ApprovalDispatchState.FAILED
+            failure_code = publication.failure_code or "telegram_dispatch_failed"
+        await self._repo.update_approval_batch(
+            batch,
+            approval_dispatch_state=state.value,
+            approval_dispatch_published_at=(
+                now if state is ApprovalDispatchState.SENT_CURRENT else None
+            ),
+            approval_dispatch_failure_code=failure_code,
+            approval_dispatch_payload_chars=publication.payload_chars,
+            telegram_status_code=publication.status_code,
+            telegram_error_code=publication.error_code,
+            error_classification=(
+                publication.error_classification.value
+                if publication.error_classification is not None
+                else None
+            ),
+            summary_message_id=(
+                publication.message_id
+                if state is ApprovalDispatchState.SENT_CURRENT
+                else None
+            ),
+            summary_dispatch_state=(
+                "sent" if state is ApprovalDispatchState.SENT_CURRENT else "idle"
+            ),
+            summary_dispatch_lease_until=None,
+            updated_at=now,
+        )
+        result = TelegramDispatchResult.from_publication(
+            publication, state=state, failure_code=failure_code
+        )
+        _log_dispatch_outcome(result, surface="batch")
+        return result
 
     async def record_approval_batch_summary(
         self,
@@ -1345,17 +1956,14 @@ class OrderProposalsService:
         message_id: int,
         now: datetime,
     ) -> OrderProposalApprovalBatch:
+        """Reject the legacy ownerless success transition.
+
+        Batch publication must be finalized with
+        ``finish_approval_batch_dispatch`` and its exact attempt ID.
+        """
         self._require_timezone_aware(now)
-        batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
-        if batch is None:
-            raise OrderProposalError("approval_batch_not_found")
-        return await self._repo.update_approval_batch(
-            batch,
-            summary_message_id=message_id,
-            summary_dispatch_state="sent",
-            summary_dispatch_lease_until=None,
-            updated_at=now,
-        )
+        del batch_id, message_id
+        raise OrderProposalError("approval_batch_ownerless_finalize_forbidden")
 
     async def release_approval_batch_summary_claim(
         self, batch_id: uuid.UUID, *, now: datetime
@@ -1367,6 +1975,8 @@ class OrderProposalsService:
         return await self._repo.update_approval_batch(
             batch,
             summary_dispatch_state="idle",
+            approval_dispatch_state=ApprovalDispatchState.FAILED.value,
+            approval_dispatch_failure_code="approval_batch_dispatch_failed",
             summary_dispatch_lease_until=None,
             updated_at=now,
         )
@@ -1382,6 +1992,11 @@ class OrderProposalsService:
             raise OrderProposalError("approval_batch_not_found")
         proposals: list[tuple[OrderProposal, list[OrderProposalRung]]] = []
         for member in await self._repo.list_approval_batch_members(batch.id):
+            if (
+                batch.membership_frozen_at is not None
+                and member.membership_revision != batch.membership_revision
+            ):
+                continue
             group = await self._repo.get_group_by_pk(member.proposal_pk)
             if group is None:
                 continue

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -264,6 +264,16 @@ def proposal_approval_block_reason(group: OrderProposal) -> str | None:
     return None
 
 
+def _proposal_callback_block_reason(group: OrderProposal, *, nonce: str) -> str | None:
+    """Apply snapshot-independent callback blocks in stable precedence order."""
+    block_reason = proposal_approval_block_reason(group)
+    if block_reason is not None and block_reason.startswith("proposal_superseded_by:"):
+        return block_reason
+    if group.approval_nonce == nonce and group.approval_nonce_used_at is not None:
+        return "nonce_replay"
+    return block_reason
+
+
 def batch_member_block_reason(
     group: OrderProposal,
     rungs: list[OrderProposalRung],
@@ -1032,6 +1042,9 @@ class OrderProposalsService:
         group = await self._repo.get_group_by_proposal_id(proposal_id)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
+        block_reason = _proposal_callback_block_reason(group, nonce=nonce)
+        if block_reason is not None:
+            raise OrderProposalError(block_reason)
         callback = self._current_callback_envelope(group, action="op", nonce=nonce)
         return await self.consume_published_proposal_callback(
             proposal_id, callback=callback, now=now
@@ -1044,6 +1057,9 @@ class OrderProposalsService:
         group = await self._repo.get_group_by_proposal_id(proposal_id)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
+        block_reason = _proposal_callback_block_reason(group, nonce=nonce)
+        if block_reason is not None:
+            raise OrderProposalError(block_reason)
         callback = self._current_callback_envelope(group, action="vc", nonce=nonce)
         return await self.consume_published_proposal_callback(
             proposal_id, callback=callback, now=now
@@ -1078,7 +1094,7 @@ class OrderProposalsService:
         membership change while external preview work is in flight fails
         closed before a nonce or proposal mutation is written.
         """
-        block_reason = proposal_approval_block_reason(group)
+        block_reason = _proposal_callback_block_reason(group, nonce=callback.nonce)
         if block_reason is not None:
             raise OrderProposalError(block_reason)
         try:
@@ -1226,6 +1242,9 @@ class OrderProposalsService:
         group = await self._repo.get_group_by_proposal_id(proposal_id)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
+        block_reason = _proposal_callback_block_reason(group, nonce=nonce)
+        if block_reason is not None:
+            raise OrderProposalError(block_reason)
         callback = self._current_callback_envelope(group, action="lc", nonce=nonce)
         return await self.consume_published_proposal_callback(
             proposal_id,
@@ -1540,6 +1559,7 @@ class OrderProposalsService:
         now: datetime,
         window_seconds: int = 600,
         ttl_seconds: int = 600,
+        summary_member_threshold: int = 2,
     ) -> BatchRegistration | None:
         """Stage a member, freezing the batch before its first publication.
 
@@ -1547,6 +1567,8 @@ class OrderProposalsService:
         a new staged batch, so membership displayed with a button is immutable.
         """
         self._require_timezone_aware(now)
+        if summary_member_threshold < 2:
+            raise ValueError("summary_member_threshold must be at least 2")
         await self._repo.acquire_approval_batch_chat_lock(chat_id)
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
         if group is None:
@@ -1642,7 +1664,7 @@ class OrderProposalsService:
         member_count = len(live_members)
         summary_action: Literal["none", "send"] = "none"
         binding: DispatchBinding | None = None
-        if member_count >= 2:
+        if member_count >= summary_member_threshold:
             revision = batch.membership_revision or 1
             attempt_id = uuid.uuid4()
             digest_members = [
@@ -1744,7 +1766,12 @@ class OrderProposalsService:
                 callback=callback,
             )
         except ValueError as exc:
-            raise OrderProposalError(str(exc)) from exc
+            reason = str(exc)
+            if reason == "nonce_mismatch":
+                reason = "approval_batch_nonce_mismatch"
+            elif reason == "nonce_replay":
+                reason = "approval_batch_nonce_replay"
+            raise OrderProposalError(reason) from exc
 
     async def preflight_published_batch_callback(
         self,

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -27,14 +27,15 @@ Every broker/Telegram/DB dependency is injectable (``notifier``,
 ``revalidate_fn``, ``service_factory``) so tests can supply fakes; real
 broker/Telegram/httpx calls are never exercised by this module's test suite.
 
-Principle #5 (nonce replay prevention is load-bearing): ``consume_approval_nonce``
-is always called -- and its exceptions handled -- before any other mutation in
-both the approve and deny branches.
+Nonce replay prevention is load-bearing: every manual, batch, auto-veto, and
+loss-cut action crosses the shared published-snapshot gate before it can consume
+a nonce or reach submit/cancel.
 
 ``handle_callback_update`` never raises: Telegram's webhook contract expects a
-response for every update, so any unexpected exception is caught, logged, and
-turned into a failure result dict. Callback queries are answered best-effort as
-soon as their metadata is available, before validation or order processing.
+bounded result for every update, so any unexpected exception is caught, logged,
+and turned into a failure result dict. Callback queries are answered
+best-effort only after the non-consuming published-binding preflight succeeds;
+an invalid callback causes no external Telegram/provider/broker side effect.
 """
 
 from __future__ import annotations
@@ -53,7 +54,7 @@ from app.core.db import AsyncSessionLocal
 from app.mcp_server.caller_identity import caller_agent_id_var
 from app.services.order_proposals.approval_message import (
     _escape_markdown,
-    build_approval_message,
+    build_approval_dispatch_messages,
     build_batch_result_message,
     build_buying_power_shortfall_text,
     build_loss_cut_confirmation_message,
@@ -69,6 +70,13 @@ from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
     fetch_target_order,
 )
+from app.services.order_proposals.dispatch import publish_approval_messages
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalPublication,
+    CallbackEnvelope,
+    build_proposal_dispatch_binding,
+)
 from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.revalidation import (
     RungOutcome,
@@ -77,6 +85,11 @@ from app.services.order_proposals.revalidation import (
 from app.services.order_proposals.service import (
     OrderProposalsService,
     batch_member_block_reason,
+)
+from app.telegram_contract import (
+    TelegramErrorClassification,
+    TelegramMethodResult,
+    telegram_text_length,
 )
 
 logger = logging.getLogger(__name__)
@@ -142,7 +155,7 @@ def _outcome_error_summary(outcome: RungOutcome, *, limit: int = 240) -> str | N
 
 
 def _generate_nonce() -> str:
-    return secrets.token_urlsafe(12)
+    return secrets.token_urlsafe(8)
 
 
 async def _safe_answer(
@@ -150,16 +163,18 @@ async def _safe_answer(
 ) -> None:
     """Best-effort ``answer_callback`` that never raises.
 
-    Used both on the happy/known-failure paths and from the top-level
-    exception handler, where a second failure (e.g. the notifier itself
-    raising) must not crash the handler.
+    Called only after the published-binding preflight succeeds. A notifier
+    failure must not crash the handler.
     """
     if not callback_query_id:
         return
     try:
         await notifier.answer_callback(callback_query_id, text)
-    except Exception:  # noqa: BLE001 - best-effort, never propagate
-        logger.exception("order_proposals telegram answer_callback failed")
+    except Exception as exc:  # noqa: BLE001 - best-effort, never propagate
+        logger.error(
+            "order_proposals.telegram.answer_callback_failed",
+            extra={"exception_type": type(exc).__name__},
+        )
 
 
 async def _safe_edit_message(
@@ -168,7 +183,7 @@ async def _safe_edit_message(
     message_id: int,
     text: str,
     reply_markup: dict | None = None,
-) -> None:
+) -> TelegramMethodResult:
     """Best-effort ``edit_message`` that never raises.
 
     Belt-and-suspenders alongside the commit-before-notify ordering in
@@ -179,25 +194,18 @@ async def _safe_edit_message(
     action as ``"internal_error"``).
     """
     try:
-        await notifier.edit_message(
+        return await notifier.edit_message(
             chat_id, message_id, text, reply_markup=reply_markup
         )
     except Exception:  # noqa: BLE001 - best-effort, never propagate
-        logger.exception("order_proposals telegram edit_message failed")
-
-
-async def _safe_send_approval_message(
-    notifier: Any, text: str, keyboard: dict, *, chat_id: str
-) -> int | None:
-    """Best-effort ``send_approval_message`` that never raises.
-
-    See ``_safe_edit_message`` docstring for why this must never propagate.
-    """
-    try:
-        return await notifier.send_approval_message(text, keyboard, chat_id=chat_id)
-    except Exception:  # noqa: BLE001 - best-effort, never propagate
-        logger.exception("order_proposals telegram send_approval_message failed")
-        return None
+        logger.error(
+            "order_proposals.telegram.edit_message_failed",
+        )
+        return TelegramMethodResult.failed(
+            payload_chars=telegram_text_length(text),
+            failure_code="telegram_transport_error",
+            error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
+        )
 
 
 async def _resolve_proposal_id(service: Any, proposal_short: str) -> uuid.UUID | None:
@@ -210,6 +218,30 @@ async def _resolve_proposal_id(service: Any, proposal_short: str) -> uuid.UUID |
     rather than guess.
     """
     return await service.resolve_proposal_id_prefix(proposal_short)
+
+
+async def _preflight_proposal_callback(
+    *,
+    session: AsyncSession,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    callback: CallbackEnvelope,
+    notifier: Any,
+    callback_query_id: str | None,
+) -> dict[str, Any] | None:
+    """Run the shared non-consuming gate before any callback-side external I/O."""
+    try:
+        await service.preflight_published_proposal_callback(
+            proposal_id, callback=callback
+        )
+    except OrderProposalError as exc:
+        # End the read transaction without writing. Invalid bindings must not
+        # trigger even a Telegram callback answer, preview, provider fetch, or
+        # dry-run broker path.
+        await session.commit()
+        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+    await _safe_answer(notifier, callback_query_id, "처리 중")
+    return None
 
 
 def _build_result_summary(outcomes: list[RungOutcome]) -> str:
@@ -283,19 +315,31 @@ async def _handle_deny(
     session: AsyncSession,
     service: OrderProposalsService,
     proposal_id: uuid.UUID,
-    nonce: str,
+    callback: CallbackEnvelope,
     now: datetime,
     notifier: Any,
     chat_id: Any,
     message_id: int | None,
     callback_query_id: str | None,
 ) -> dict[str, Any]:
+    preflight_failure = await _preflight_proposal_callback(
+        session=session,
+        service=service,
+        proposal_id=proposal_id,
+        callback=callback,
+        notifier=notifier,
+        callback_query_id=callback_query_id,
+    )
+    if preflight_failure is not None:
+        return preflight_failure
     try:
-        await service.consume_approval_nonce(proposal_id, nonce, now=now)
+        await service.consume_published_proposal_callback(
+            proposal_id, callback=callback, now=now
+        )
     except OrderProposalError as exc:
         # No mutation happened above (mismatch/replay both raise before any
         # flush) -- commit anyway to release the row lock taken by
-        # `consume_approval_nonce`'s `for_update=True` SELECT.
+        # the common callback gate's `for_update=True` SELECT.
         await session.commit()
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
 
@@ -327,22 +371,35 @@ async def _handle_auto_veto(
     session: AsyncSession,
     service: OrderProposalsService,
     proposal_id: uuid.UUID,
-    nonce: str,
+    callback: CallbackEnvelope,
     now: datetime,
     notifier: Any,
     chat_id: Any,
     message_id: int | None,
+    callback_query_id: str | None = None,
     telegram_user_id: str,
     cancel_fn: TargetCancelFn,
     fetch_fn: TargetFetchFn,
 ) -> dict[str, Any]:
     """Cancel every still-open auto-submitted rung and converge evidence."""
+    preflight_failure = await _preflight_proposal_callback(
+        session=session,
+        service=service,
+        proposal_id=proposal_id,
+        callback=callback,
+        notifier=notifier,
+        callback_query_id=callback_query_id,
+    )
+    if preflight_failure is not None:
+        return preflight_failure
     group, rungs = await service.get_proposal(proposal_id)
     # Match replace/cancel lock ordering: broker target advisory locks before
     # the proposal-row nonce lock, with stable ordering for multi-rung groups.
     await acquire_auto_veto_locks(service=service, group=group, rungs=rungs)
     try:
-        await service.consume_auto_veto_nonce(proposal_id, nonce, now=now)
+        await service.consume_published_proposal_callback(
+            proposal_id, callback=callback, now=now
+        )
     except OrderProposalError as exc:
         await session.commit()
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
@@ -400,7 +457,7 @@ async def _handle_approve(
     session: AsyncSession,
     service: OrderProposalsService,
     proposal_id: uuid.UUID,
-    nonce: str,
+    callback: CallbackEnvelope,
     now: datetime,
     notifier: Any,
     chat_id: Any,
@@ -410,12 +467,44 @@ async def _handle_approve(
     revalidate_fn: RevalidateFn,
     loss_cut_confirmation: bool = False,
 ) -> dict[str, Any]:
+    preflight_failure = await _preflight_proposal_callback(
+        session=session,
+        service=service,
+        proposal_id=proposal_id,
+        callback=callback,
+        notifier=notifier,
+        callback_query_id=callback_query_id,
+    )
+    if preflight_failure is not None:
+        return preflight_failure
     # Lock the broker target before taking any proposal row lock. Independently
     # created proposals may point at the same manual/session order, so the
     # proposal-scoped commit lease alone cannot prevent a double mutation.
     target_group, _ = await service.get_proposal(proposal_id)
     await service.acquire_target_mutation_lock(target_group)
 
+    try:
+        if loss_cut_confirmation:
+            await service.consume_published_proposal_callback(
+                proposal_id,
+                callback=callback,
+                telegram_user_id=telegram_user_id,
+                now=now,
+            )
+        else:
+            await service.consume_published_proposal_callback(
+                proposal_id, callback=callback, now=now
+            )
+    except OrderProposalError as exc:
+        # See `_handle_deny`'s matching comment: no mutation happened above,
+        # but commit anyway to release the row lock.
+        await session.commit()
+        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+
+    # A pending/failed/superseded visible card must cross the authoritative
+    # publication gate before even a local expiry transition is allowed.
+    # For a valid SENT_CURRENT card, consuming the one-shot nonce and expiring
+    # the proposal happen in this same caller-owned transaction.
     if await service.expire_if_needed(proposal_id, now=now):
         await session.commit()
         if message_id is not None:
@@ -426,22 +515,6 @@ async def _handle_approve(
             "reason": "proposal_expired",
             "proposal_id": str(proposal_id),
         }
-
-    try:
-        if loss_cut_confirmation:
-            await service.consume_loss_cut_confirmation(
-                proposal_id,
-                nonce,
-                telegram_user_id=telegram_user_id,
-                now=now,
-            )
-        else:
-            await service.consume_approval_nonce(proposal_id, nonce, now=now)
-    except OrderProposalError as exc:
-        # See `_handle_deny`'s matching comment: no mutation happened above,
-        # but commit anyway to release the row lock.
-        await session.commit()
-        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
 
     acquired = await service.acquire_commit_lease(proposal_id, now=now)
     if not acquired:
@@ -487,15 +560,21 @@ async def _handle_approve(
         fresh_nonce = _generate_nonce()
         await service.set_approval_nonce(proposal_id, fresh_nonce)
         group, rungs = await service.get_proposal(proposal_id)
-        text, keyboard = build_approval_message(
-            group=group, rungs=rungs, diff=reconfirm_outcomes[0].detail
+        dispatch_attempt_id = uuid.uuid4()
+        binding = build_proposal_dispatch_binding(
+            proposal_id=group.proposal_id,
+            nonce=fresh_nonce,
+            attempt_id=dispatch_attempt_id,
+            card_kind=ApprovalCardKind.RECONFIRM,
+            current_membership_revision=(group.approval_dispatch_membership_revision),
         )
+        suffix_blocks: list[str] = []
         # `build_approval_message` only renders an explicit diff for the
         # first reconfirming rung -- surface every other reconfirming rung's
         # before/after here so a multi-rung reconfirm batch never silently
         # drops a rung's change (Finding 2, gap #1).
         if len(reconfirm_outcomes) > 1:
-            text = f"{text}\n\n{_build_extra_reconfirm_block(reconfirm_outcomes[1:])}"
+            suffix_blocks.append(_build_extra_reconfirm_block(reconfirm_outcomes[1:]))
         # Rungs in the same batch that did NOT come back `needs_reconfirm`
         # (e.g. one rung submitted while another needs reconfirmation) would
         # otherwise never be reported anywhere, since this branch
@@ -503,7 +582,22 @@ async def _handle_approve(
         # 2, gap #2).
         other_outcomes = [o for o in outcomes if o.result != "needs_reconfirm"]
         if other_outcomes:
-            text = f"{text}\n\n{_build_result_summary(other_outcomes)}"
+            suffix_blocks.append(_build_result_summary(other_outcomes))
+        messages = build_approval_dispatch_messages(
+            group=group,
+            rungs=rungs,
+            diff=reconfirm_outcomes[0].detail,
+            suffix_blocks=suffix_blocks,
+            binding=binding,
+        )
+        await service.start_approval_dispatch(
+            proposal_id,
+            attempt_id=dispatch_attempt_id,
+            binding=binding,
+            now=now,
+            payload_chars=messages.payload_chars,
+            context_message_count=len(messages.context_messages),
+        )
 
         # Commit the fresh nonce + record_approval + revalidate_and_submit's
         # rung-state transitions before any Telegram call -- a notify
@@ -524,29 +618,26 @@ async def _handle_approve(
                     else "⚠️ 재확인 필요 — 아래 새 메시지를 확인해 주세요."
                 ),
             )
-        new_message_id = await _safe_send_approval_message(
-            notifier, text, keyboard, chat_id=str(chat_id)
+        publication = await publish_approval_messages(
+            notifier=notifier,
+            messages=messages,
+            chat_id=str(chat_id),
         )
-        if new_message_id is not None:
-            # Mirror dispatch.py's send_proposal_for_approval: keep
-            # source_asof.approval_message_id pointing at the NEWEST
-            # outstanding Telegram message, not the original one from
-            # dispatch.py -- otherwise a later reader of source_asof would
-            # see a stale/superseded message_id for this reconfirm cycle
-            # (ROB-816 final-review Finding 4). A failed send
-            # (new_message_id is None) has nothing to persist.
-            await service.record_approval_dispatch(
-                proposal_id,
-                message_id=new_message_id,
-                chat_id=str(chat_id),
-                now=now,
-            )
-            await session.commit()
+        dispatch_result = await service.finish_approval_dispatch(
+            proposal_id,
+            attempt_id=dispatch_attempt_id,
+            publication=publication,
+            chat_id=str(chat_id),
+            now=now,
+        )
+        await session.commit()
+        new_message_id = dispatch_result.message_id if dispatch_result.ok else None
         return {
             "handled": True,
             "reason": "needs_reconfirm",
             "proposal_id": str(proposal_id),
             "new_message_id": new_message_id,
+            "approval_dispatch": dispatch_result.as_dict(),
             "results": [outcome.result for outcome in outcomes],
             "rung_results": _serialize_rung_outcomes(outcomes),
         }
@@ -573,11 +664,12 @@ async def _handle_batch_approve(
     *,
     service_factory: ServiceFactory,
     batch_short: str,
-    nonce: str,
+    callback: CallbackEnvelope,
     now: datetime,
     notifier: Any,
     chat_id: Any,
     message_id: int | None,
+    callback_query_id: str | None = None,
     telegram_user_id: str,
     revalidate_fn: RevalidateFn,
 ) -> dict[str, Any]:
@@ -589,9 +681,20 @@ async def _handle_batch_approve(
             await session.commit()
             return {"handled": False, "reason": "approval_batch_not_found"}
         try:
+            await service.preflight_published_batch_callback(
+                batch_id,
+                callback=callback,
+                chat_id=str(chat_id),
+                now=now,
+            )
+        except OrderProposalError as exc:
+            await session.commit()
+            return {"handled": False, "reason": str(exc)}
+        await _safe_answer(notifier, callback_query_id, "처리 중")
+        try:
             _batch, members = await service.consume_approval_batch_nonce(
                 batch_id,
-                nonce,
+                callback=callback,
                 chat_id=str(chat_id),
                 telegram_user_id=telegram_user_id,
                 now=now,
@@ -634,7 +737,18 @@ async def _handle_batch_approve(
                         session=member_session,
                         service=member_service,
                         proposal_id=member.proposal_id,
-                        nonce=member.approval_nonce,
+                        callback=CallbackEnvelope(
+                            action="op",
+                            subject_short=str(member.proposal_id)[:8],
+                            attempt_id=member.dispatch_binding.attempt_id,
+                            membership_revision=(
+                                member.dispatch_binding.membership_revision
+                            ),
+                            membership_digest=(
+                                member.dispatch_binding.membership_digest
+                            ),
+                            nonce=member.approval_nonce,
+                        ),
                         now=now,
                         notifier=notifier,
                         chat_id=chat_id,
@@ -663,10 +777,13 @@ async def _handle_batch_approve(
                         member_message = (
                             f"⚠️ 일괄 승인 제외 — {_escape_markdown(reason)}"
                         )
-            except Exception:  # noqa: BLE001 - isolate each batch member
-                logger.exception(
-                    "order_proposals batch member approval failed",
-                    extra={"proposal_id": str(member.proposal_id)},
+            except Exception as exc:  # noqa: BLE001 - isolate each batch member
+                logger.error(
+                    "order_proposals.batch_member.approval_failed",
+                    extra={
+                        "proposal_id": str(member.proposal_id),
+                        "exception_type": type(exc).__name__,
+                    },
                 )
                 await member_session.rollback()
                 member_result.update(status="failed", reason="internal_error")
@@ -691,10 +808,13 @@ async def _handle_batch_approve(
                     now=now,
                 )
                 await member_session.commit()
-            except Exception:  # noqa: BLE001 - observation must not stop the batch
-                logger.exception(
-                    "order_proposals batch member result audit failed",
-                    extra={"proposal_id": str(member.proposal_id)},
+            except Exception as exc:  # noqa: BLE001 - observation must not stop the batch
+                logger.error(
+                    "order_proposals.batch_member.result_record_failed",
+                    extra={
+                        "proposal_id": str(member.proposal_id),
+                        "exception_type": type(exc).__name__,
+                    },
                 )
                 await member_session.rollback()
 
@@ -733,15 +853,26 @@ async def _handle_loss_cut_first_click(
     session: AsyncSession,
     service: OrderProposalsService,
     proposal_id: uuid.UUID,
-    nonce: str,
+    callback: CallbackEnvelope,
     now: datetime,
     notifier: Any,
     chat_id: Any,
     message_id: int | None,
+    callback_query_id: str | None = None,
     telegram_user_id: str,
     loss_cut_preview_fn: RevalidateFn,
 ) -> dict[str, Any]:
     """Consume step one and edit the message into a bound confirmation."""
+    preflight_failure = await _preflight_proposal_callback(
+        session=session,
+        service=service,
+        proposal_id=proposal_id,
+        callback=callback,
+        notifier=notifier,
+        callback_query_id=callback_query_id,
+    )
+    if preflight_failure is not None:
+        return preflight_failure
     submit_agent_id = settings.ORDER_PROPOSALS_SUBMIT_AGENT_ID.strip() or None
     caller_agent_id_token = caller_agent_id_var.set(submit_agent_id)
     try:
@@ -751,7 +882,9 @@ async def _handle_loss_cut_first_click(
     finally:
         caller_agent_id_var.reset(caller_agent_id_token)
     try:
-        await service.consume_approval_nonce(proposal_id, nonce, now=now)
+        await service.consume_published_proposal_callback(
+            proposal_id, callback=callback, now=now
+        )
     except OrderProposalError as exc:
         await session.commit()
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
@@ -759,28 +892,74 @@ async def _handle_loss_cut_first_click(
     confirmation_nonce = _generate_nonce()
     await service.issue_loss_cut_confirmation(
         proposal_id,
-        first_nonce=nonce,
+        first_nonce=callback.nonce,
         confirmation_nonce=confirmation_nonce,
         telegram_user_id=telegram_user_id,
         now=now,
     )
     group, rungs = await service.get_proposal(proposal_id)
+    dispatch_attempt_id = uuid.uuid4()
+    binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=confirmation_nonce,
+        attempt_id=dispatch_attempt_id,
+        card_kind=ApprovalCardKind.LOSS_CUT_CONFIRMATION,
+        current_membership_revision=group.approval_dispatch_membership_revision,
+    )
     text, keyboard = build_loss_cut_confirmation_message(
-        group=group, rungs=rungs, evidence=evidence
+        group=group, rungs=rungs, evidence=evidence, binding=binding
+    )
+    await service.start_approval_dispatch(
+        proposal_id,
+        attempt_id=dispatch_attempt_id,
+        binding=binding,
+        now=now,
+        payload_chars=telegram_text_length(text),
+        context_message_count=0,
     )
     await session.commit()
-    if message_id is not None:
-        await _safe_edit_message(
+    if message_id is None:
+        publication = ApprovalPublication.failed(
+            payload_chars=telegram_text_length(text),
+            failure_code="approval_edit_message_missing",
+        )
+    else:
+        method_result = await _safe_edit_message(
             notifier,
             chat_id,
             message_id,
             text,
             reply_markup=keyboard,
         )
+        publication = (
+            ApprovalPublication.published(
+                payload_chars=telegram_text_length(text),
+                method_result=method_result,
+            )
+            if method_result.ok
+            else ApprovalPublication.failed(
+                payload_chars=telegram_text_length(text),
+                failure_code="approval_card_edit_failed",
+                method_result=method_result,
+            )
+        )
+    dispatch_result = await service.finish_approval_dispatch(
+        proposal_id,
+        attempt_id=dispatch_attempt_id,
+        publication=publication,
+        chat_id=str(chat_id),
+        now=now,
+    )
+    await session.commit()
     return {
-        "handled": True,
-        "reason": "loss_cut_confirmation_required",
+        "handled": dispatch_result.ok,
+        "reason": (
+            "loss_cut_confirmation_required"
+            if dispatch_result.ok
+            else "loss_cut_confirmation_dispatch_failed"
+        ),
         "proposal_id": str(proposal_id),
+        "approval_dispatch": dispatch_result.as_dict(),
     }
 
 
@@ -817,25 +996,24 @@ async def handle_callback_update(
         telegram_user_id = from_user.get("id")
         data = callback_query.get("data")
 
-        await _safe_answer(active_notifier, callback_query_id, "처리 중")
-
         if str(chat_id) not in settings.order_proposals_telegram_chat_allowlist:
             return {"handled": False, "reason": "chat_not_allowed"}
 
         try:
-            action, subject_short, nonce = parse_callback_data(data)
+            callback = parse_callback_data(data)
         except ValueError:
             return {"handled": False, "reason": "malformed_callback_data"}
 
-        if action == "ba":
+        if callback.action == "ba":
             return await _handle_batch_approve(
                 service_factory=service_factory,
-                batch_short=subject_short,
-                nonce=nonce,
+                batch_short=callback.subject_short,
+                callback=callback,
                 now=now,
                 notifier=active_notifier,
                 chat_id=chat_id,
                 message_id=message_id,
+                callback_query_id=callback_query_id,
                 telegram_user_id=(
                     str(telegram_user_id) if telegram_user_id is not None else ""
                 ),
@@ -844,40 +1022,41 @@ async def handle_callback_update(
 
         async with service_factory() as session:
             service = OrderProposalsService(session)
-            proposal_id = await _resolve_proposal_id(service, subject_short)
+            proposal_id = await _resolve_proposal_id(service, callback.subject_short)
             if proposal_id is None:
                 await session.commit()
                 return {"handled": False, "reason": "proposal_not_found"}
 
-            if action == "vc":
+            if callback.action == "vc":
                 result = await _handle_auto_veto(
                     session=session,
                     service=service,
                     proposal_id=proposal_id,
-                    nonce=nonce,
+                    callback=callback,
                     now=now,
                     notifier=active_notifier,
                     chat_id=chat_id,
                     message_id=message_id,
+                    callback_query_id=callback_query_id,
                     telegram_user_id=(
                         str(telegram_user_id) if telegram_user_id is not None else ""
                     ),
                     cancel_fn=veto_cancel_fn,
                     fetch_fn=veto_fetch_fn,
                 )
-            elif action == "dn":
+            elif callback.action == "dn":
                 result = await _handle_deny(
                     session=session,
                     service=service,
                     proposal_id=proposal_id,
-                    nonce=nonce,
+                    callback=callback,
                     now=now,
                     notifier=active_notifier,
                     chat_id=chat_id,
                     message_id=message_id,
                     callback_query_id=callback_query_id,
                 )
-            elif action == "op":
+            elif callback.action == "op":
                 group, _rungs = await service.get_proposal(proposal_id)
                 if group.exit_intent == "loss_cut":
                     if loss_cut_preview_fn is None:
@@ -890,11 +1069,12 @@ async def handle_callback_update(
                         session=session,
                         service=service,
                         proposal_id=proposal_id,
-                        nonce=nonce,
+                        callback=callback,
                         now=now,
                         notifier=active_notifier,
                         chat_id=chat_id,
                         message_id=message_id,
+                        callback_query_id=callback_query_id,
                         telegram_user_id=(
                             str(telegram_user_id)
                             if telegram_user_id is not None
@@ -907,7 +1087,7 @@ async def handle_callback_update(
                     session=session,
                     service=service,
                     proposal_id=proposal_id,
-                    nonce=nonce,
+                    callback=callback,
                     now=now,
                     notifier=active_notifier,
                     chat_id=chat_id,
@@ -923,7 +1103,7 @@ async def handle_callback_update(
                     session=session,
                     service=service,
                     proposal_id=proposal_id,
-                    nonce=nonce,
+                    callback=callback,
                     now=now,
                     notifier=active_notifier,
                     chat_id=chat_id,
@@ -940,6 +1120,9 @@ async def handle_callback_update(
             # call (see module docstring: commit-before-notify ordering) --
             # no end-of-function commit here.
             return result
-    except Exception:  # noqa: BLE001 - fail-closed webhook contract
-        logger.exception("order_proposals telegram callback handling failed")
+    except Exception as exc:  # noqa: BLE001 - fail-closed webhook contract
+        logger.error(
+            "order_proposals.telegram.callback_handling_failed",
+            extra={"exception_type": type(exc).__name__},
+        )
         return {"handled": False, "reason": "internal_error"}

--- a/app/telegram_contract.py
+++ b/app/telegram_contract.py
@@ -1,0 +1,154 @@
+"""Shared Telegram Bot API text-size and physical transport contracts.
+
+The Bot API response ``description`` is deliberately absent from every public
+type in this module.  It is untrusted remote input and must be discarded at
+the HTTP boundary rather than sanitized after it has reached logs or ledgers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+# Telegram documents 1..4096 characters after entity parsing for sendMessage.
+# Counting the raw payload in UTF-16 code units is deliberately conservative:
+# Markdown delimiters/escapes are counted even though Telegram removes them
+# while parsing, and astral characters count as two units instead of one.
+TELEGRAM_SEND_MESSAGE_TEXT_LIMIT = 4096
+
+
+def telegram_text_length(text: str) -> int:
+    """Return the conservative Telegram text length (UTF-16 code units)."""
+    return len(text.encode("utf-16-le")) // 2
+
+
+def telegram_text_within_limit(text: str) -> bool:
+    return telegram_text_length(text) <= TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+
+
+def split_telegram_text(text: str, *, max_units: int) -> tuple[str, ...]:
+    """Split text without dropping or rewriting a character."""
+    if max_units <= 0:
+        raise ValueError("max_units must be positive")
+    if not text:
+        return ("",)
+
+    chunks: list[str] = []
+    start = 0
+    used_units = 0
+    for index, character in enumerate(text):
+        character_units = telegram_text_length(character)
+        if character_units > max_units:
+            raise ValueError("one character exceeds max_units")
+        if used_units + character_units > max_units:
+            chunks.append(text[start:index])
+            start = index
+            used_units = 0
+        used_units += character_units
+    chunks.append(text[start:])
+    return tuple(chunks)
+
+
+class TelegramErrorClassification(StrEnum):
+    """Finite, non-sensitive classifications derived without response text."""
+
+    PAYLOAD_TOO_LONG = "payload_too_long"
+    BAD_REQUEST = "bad_request"
+    UNAUTHORIZED = "unauthorized"
+    FORBIDDEN = "forbidden"
+    NOT_FOUND = "not_found"
+    CONFLICT = "conflict"
+    RATE_LIMITED = "rate_limited"
+    SERVER_ERROR = "server_error"
+    TRANSPORT_ERROR = "transport_error"
+    INVALID_RESPONSE = "invalid_response"
+    NOT_CONFIGURED = "not_configured"
+    UNKNOWN_TELEGRAM_ERROR = "unknown_telegram_error"
+
+
+def classify_telegram_error(
+    *, status_code: int | None, error_code: int | None
+) -> TelegramErrorClassification:
+    """Classify a Telegram failure when no remote description was supplied."""
+    numeric = error_code if error_code is not None else status_code
+    if numeric == 400:
+        return TelegramErrorClassification.BAD_REQUEST
+    if numeric == 401:
+        return TelegramErrorClassification.UNAUTHORIZED
+    if numeric == 403:
+        return TelegramErrorClassification.FORBIDDEN
+    if numeric == 404:
+        return TelegramErrorClassification.NOT_FOUND
+    if numeric == 409:
+        return TelegramErrorClassification.CONFLICT
+    if numeric == 429:
+        return TelegramErrorClassification.RATE_LIMITED
+    if numeric is not None and 500 <= numeric <= 599:
+        return TelegramErrorClassification.SERVER_ERROR
+    return TelegramErrorClassification.UNKNOWN_TELEGRAM_ERROR
+
+
+_KNOWN_TELEGRAM_DESCRIPTIONS: dict[str, TelegramErrorClassification] = {
+    # Exact equality is intentional. Prefix/substring matching would let an
+    # upstream reflector append request secrets while still influencing a
+    # supposedly safe category.
+    "Bad Request: message is too long": TelegramErrorClassification.PAYLOAD_TOO_LONG,
+}
+
+
+def classify_telegram_response_error(
+    *,
+    status_code: int | None,
+    error_code: int | None,
+    description: object,
+) -> TelegramErrorClassification:
+    """Collapse remote text to an allowlisted constant, then discard it.
+
+    A present but unknown description is never generalized from its contents
+    or copied onward. Numeric classification remains available for responses
+    that omit ``description`` entirely.
+    """
+    if isinstance(description, str):
+        return _KNOWN_TELEGRAM_DESCRIPTIONS.get(
+            description,
+            TelegramErrorClassification.UNKNOWN_TELEGRAM_ERROR,
+        )
+    return classify_telegram_error(status_code=status_code, error_code=error_code)
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramMethodResult:
+    """Physical result for one Bot API method.
+
+    ``ok`` means only that this individual HTTP operation returned a valid
+    Telegram success response.  Approval workflow success is a separate,
+    durable state resolved after the current-attempt ownership fence.
+    """
+
+    ok: bool
+    message_id: int | None
+    status_code: int | None
+    error_code: int | None
+    error_classification: TelegramErrorClassification | None
+    payload_chars: int
+    failure_code: str | None = None
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        payload_chars: int,
+        failure_code: str,
+        status_code: int | None = None,
+        error_code: int | None = None,
+        error_classification: TelegramErrorClassification | None = None,
+    ) -> TelegramMethodResult:
+        return cls(
+            ok=False,
+            message_id=None,
+            status_code=status_code,
+            error_code=error_code,
+            error_classification=error_classification,
+            payload_chars=payload_chars,
+            failure_code=failure_code,
+        )

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -10,6 +10,7 @@ a concurrent xdist worker's test body.
 from __future__ import annotations
 
 import hashlib
+import re
 from collections.abc import Iterable
 
 from sqlalchemy import text
@@ -57,7 +58,10 @@ from sqlalchemy import text
 # v26 (ROB-954): add the dedicated terminal transition timestamp + scan index.
 # v27 (ROB-1023): widen research.backtest_runs.runner to preserve the exact
 # production execution-lineage label.
-SCHEMA_BOOTSTRAP_VERSION = 27
+# v28: durable Telegram approval-dispatch summary columns + attempt ledger.
+# v29: immutable approval publication bindings and frozen batch snapshots.
+# v30: persistent-schema typed dispatch/card constraints and attempt nullability.
+SCHEMA_BOOTSTRAP_VERSION = 30
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -106,6 +110,104 @@ def _quote_ident(identifier: str) -> str:
 def _check_constraint_sql(column_name: str, values: tuple[str, ...]) -> str:
     values_sql = ",".join(f"'{value}'" for value in values)
     return f"CHECK ({column_name} IN ({values_sql}))"
+
+
+_APPROVAL_DISPATCH_STATES = (
+    "pending",
+    "sent_current",
+    "sent_superseded",
+    "failed",
+    "partial_failed",
+    "failed_superseded",
+)
+_APPROVAL_PROPOSAL_CARD_KINDS = (
+    "manual",
+    "reconfirm",
+    "auto_veto",
+    "loss_cut_confirmation",
+)
+_APPROVAL_ATTEMPT_NOT_NULL_COLUMNS = frozenset(
+    {
+        "attempt_id",
+        "proposal_pk",
+        "state",
+        "attempted_at",
+        "payload_chars",
+        "context_message_count",
+        "card_kind",
+        "membership_revision",
+        "membership_digest",
+        "created_at",
+        "updated_at",
+    }
+)
+_APPROVAL_REQUIRED_CHECKS = {
+    (
+        "order_proposals",
+        "order_proposals_approval_dispatch_state",
+    ): ("approval_dispatch_state", frozenset(_APPROVAL_DISPATCH_STATES), True),
+    (
+        "order_proposals",
+        "order_proposals_approval_dispatch_card_kind",
+    ): (
+        "approval_dispatch_card_kind",
+        frozenset(_APPROVAL_PROPOSAL_CARD_KINDS),
+        True,
+    ),
+    (
+        "order_proposal_approval_dispatch_attempts",
+        "order_proposal_approval_dispatch_attempt_state",
+    ): ("state", frozenset(_APPROVAL_DISPATCH_STATES), False),
+    (
+        "order_proposal_approval_dispatch_attempts",
+        "order_proposal_approval_dispatch_attempt_card_kind",
+    ): ("card_kind", frozenset(_APPROVAL_PROPOSAL_CARD_KINDS), False),
+    (
+        "order_proposal_approval_batches",
+        "order_proposal_approval_batches_dispatch_state",
+    ): ("approval_dispatch_state", frozenset(_APPROVAL_DISPATCH_STATES), True),
+}
+
+
+def _approval_dispatch_catalog_errors(
+    *,
+    columns: Iterable[tuple[str, str, str]],
+    constraints: Iterable[tuple[str, str, str]],
+) -> list[str]:
+    """Return persistent-schema drift from the final typed dispatch contract."""
+    column_nullability = {
+        (table_name, column_name): is_nullable.upper()
+        for table_name, column_name, is_nullable in columns
+    }
+    errors = [
+        f"nullable_attempt_binding:{column}"
+        for column in sorted(_APPROVAL_ATTEMPT_NOT_NULL_COLUMNS)
+        if column_nullability.get(("order_proposal_approval_dispatch_attempts", column))
+        != "NO"
+    ]
+
+    definitions = {
+        (table_name, constraint_name): definition
+        for table_name, constraint_name, definition in constraints
+    }
+    for key, (
+        column,
+        allowed_values,
+        nullable_allowed,
+    ) in _APPROVAL_REQUIRED_CHECKS.items():
+        definition = definitions.get(key)
+        if definition is None:
+            errors.append(f"missing_check:{key[0]}.{key[1]}")
+            continue
+        normalized = " ".join(definition.lower().split())
+        actual_values = frozenset(re.findall(r"'([^']+)'", normalized))
+        if column not in normalized or actual_values != allowed_values:
+            errors.append(f"invalid_check:{key[0]}.{key[1]}")
+            continue
+        has_null_allowance = f"{column} is null" in normalized
+        if has_null_allowance is not nullable_allowed:
+            errors.append(f"invalid_null_contract:{key[0]}.{key[1]}")
+    return errors
 
 
 def _constraint_definitions_need_refresh(
@@ -852,6 +954,148 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ADD CONSTRAINT order_proposals_action "
     "CHECK (action IS NULL OR action IN ('place','replace','cancel')); "
     "END IF; END $$",
+    # ---- durable Telegram approval dispatch attempts ----
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_state TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_attempt_id UUID",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_attempted_at TIMESTAMPTZ",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_failure_code TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_payload_chars BIGINT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_card_kind TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_membership_revision INTEGER",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_membership_digest TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_published_at TIMESTAMPTZ",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS error_classification TEXT",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS card_kind TEXT",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS membership_revision INTEGER",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS membership_digest TEXT",
+    # Intermediate R1/R2 test schemas may contain attempts without the final
+    # immutable binding columns. Those rows cannot truthfully be repaired, so
+    # discard only invalid rows in the disposable test ledger before applying
+    # production-equivalent NOT NULL/CHECK constraints.
+    "DELETE FROM review.order_proposal_approval_dispatch_attempts "
+    "WHERE attempt_id IS NULL OR proposal_pk IS NULL OR state IS NULL "
+    "OR state NOT IN "
+    "('pending','sent_current','sent_superseded','failed',"
+    "'partial_failed','failed_superseded') "
+    "OR attempted_at IS NULL OR payload_chars IS NULL "
+    "OR context_message_count IS NULL OR card_kind IS NULL "
+    "OR card_kind NOT IN "
+    "('manual','reconfirm','auto_veto','loss_cut_confirmation') "
+    "OR membership_revision IS NULL OR membership_digest IS NULL "
+    "OR created_at IS NULL OR updated_at IS NULL",
+    *(
+        "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+        f"ALTER COLUMN {column} SET NOT NULL"
+        for column in (
+            "attempt_id",
+            "proposal_pk",
+            "state",
+            "attempted_at",
+            "payload_chars",
+            "context_message_count",
+            "card_kind",
+            "membership_revision",
+            "membership_digest",
+            "created_at",
+            "updated_at",
+        )
+    ),
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposals_approval_dispatch_state' "
+    "AND conrelid = 'review.order_proposals'::regclass) THEN "
+    "ALTER TABLE review.order_proposals "
+    "ADD CONSTRAINT order_proposals_approval_dispatch_state "
+    "CHECK (approval_dispatch_state IS NULL OR "
+    "approval_dispatch_state IN "
+    "('pending','sent_current','sent_superseded','failed',"
+    "'partial_failed','failed_superseded')); "
+    "END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposals_approval_dispatch_card_kind' "
+    "AND conrelid = 'review.order_proposals'::regclass) THEN "
+    "ALTER TABLE review.order_proposals "
+    "ADD CONSTRAINT order_proposals_approval_dispatch_card_kind "
+    "CHECK (approval_dispatch_card_kind IS NULL OR "
+    "approval_dispatch_card_kind IN "
+    "('manual','reconfirm','auto_veto','loss_cut_confirmation')); "
+    "END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposal_approval_dispatch_attempt_state' "
+    "AND conrelid = "
+    "'review.order_proposal_approval_dispatch_attempts'::regclass) THEN "
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD CONSTRAINT order_proposal_approval_dispatch_attempt_state "
+    "CHECK (state IN "
+    "('pending','sent_current','sent_superseded','failed',"
+    "'partial_failed','failed_superseded')); "
+    "END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposal_approval_dispatch_attempt_card_kind' "
+    "AND conrelid = "
+    "'review.order_proposal_approval_dispatch_attempts'::regclass) THEN "
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD CONSTRAINT order_proposal_approval_dispatch_attempt_card_kind "
+    "CHECK (card_kind IN "
+    "('manual','reconfirm','auto_veto','loss_cut_confirmation')); "
+    "END IF; END $$",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_state TEXT",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_attempt_id UUID",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_attempted_at TIMESTAMPTZ",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_published_at TIMESTAMPTZ",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_failure_code TEXT",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_payload_chars BIGINT",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS telegram_status_code INTEGER",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS telegram_error_code INTEGER",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS error_classification TEXT",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS membership_revision INTEGER",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS membership_digest TEXT",
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD COLUMN IF NOT EXISTS membership_frozen_at TIMESTAMPTZ",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposal_approval_batches_dispatch_state' "
+    "AND conrelid = "
+    "'review.order_proposal_approval_batches'::regclass) THEN "
+    "ALTER TABLE review.order_proposal_approval_batches "
+    "ADD CONSTRAINT order_proposal_approval_batches_dispatch_state "
+    "CHECK (approval_dispatch_state IS NULL OR "
+    "approval_dispatch_state IN "
+    "('pending','sent_current','sent_superseded','failed',"
+    "'partial_failed','failed_superseded')); "
+    "END IF; END $$",
+    "ALTER TABLE review.order_proposal_approval_batch_members "
+    "ADD COLUMN IF NOT EXISTS membership_revision INTEGER",
+    "ALTER TABLE review.order_proposal_approval_batch_members "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_attempt_id_snapshot UUID",
+    "ALTER TABLE review.order_proposal_approval_batch_members "
+    "ADD COLUMN IF NOT EXISTS approval_membership_revision_snapshot INTEGER",
+    "ALTER TABLE review.order_proposal_approval_batch_members "
+    "ADD COLUMN IF NOT EXISTS approval_membership_digest_snapshot TEXT",
+    "ALTER TABLE review.order_proposal_approval_batch_members "
+    "ADD COLUMN IF NOT EXISTS approval_card_kind_snapshot TEXT",
     # ---- ROB-846: append-only trial-child columns on research.backtest_runs +
     # run/config/data hash linkage on research.promotion_candidates. create_all
     # skips existing tables, so a persistent test DB needs these ALTERs (they
@@ -1407,6 +1651,55 @@ async def _ensure_alpaca_paper_ledger_lifecycle_state_constraint(conn) -> None:
     )
 
 
+async def _assert_approval_dispatch_schema_contract(conn) -> None:
+    """Fail bootstrap if a persistent table remains weaker than production."""
+    column_result = await conn.execute(
+        text(
+            "SELECT table_name, column_name, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_schema = 'review' "
+            "AND table_name = 'order_proposal_approval_dispatch_attempts'"
+        )
+    )
+    constraint_result = await conn.execute(
+        text(
+            "SELECT cls.relname AS table_name, con.conname, "
+            "pg_get_constraintdef(con.oid) AS definition "
+            "FROM pg_constraint AS con "
+            "JOIN pg_class AS cls ON cls.oid = con.conrelid "
+            "JOIN pg_namespace AS ns ON ns.oid = cls.relnamespace "
+            "WHERE ns.nspname = 'review' "
+            "AND cls.relname IN ("
+            "'order_proposals',"
+            "'order_proposal_approval_dispatch_attempts',"
+            "'order_proposal_approval_batches'"
+            ")"
+        )
+    )
+    errors = _approval_dispatch_catalog_errors(
+        columns=[
+            (
+                str(row._mapping["table_name"]),
+                str(row._mapping["column_name"]),
+                str(row._mapping["is_nullable"]),
+            )
+            for row in column_result
+        ],
+        constraints=[
+            (
+                str(row._mapping["table_name"]),
+                str(row._mapping["conname"]),
+                str(row._mapping["definition"]),
+            )
+            for row in constraint_result
+        ],
+    )
+    if errors:
+        raise RuntimeError(
+            "approval dispatch test-schema contract mismatch: " + ",".join(errors)
+        )
+
+
 def schema_content_hash() -> str:
     """SHA256 hex of the bootstrap version + the DDL tuple.
 
@@ -1514,3 +1807,4 @@ async def apply_test_schema(conn) -> None:
 
     for stmt in _DDL_STATEMENTS:
         await conn.execute(text(stmt))
+    await _assert_approval_dispatch_schema_contract(conn)

--- a/tests/mcp_server/tooling/test_order_proposal_create_post_commit.py
+++ b/tests/mcp_server/tooling/test_order_proposal_create_post_commit.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.config import settings
+from app.mcp_server.tooling import order_proposal_tools
+from app.monitoring.trade_notifier import notifier as notifier_module
+from app.services.order_proposals.errors import OrderProposalError
+
+PROPOSAL_ID = uuid.UUID("a1111111-1111-4111-8111-111111111111")
+
+
+def _create_kwargs() -> dict:
+    return {
+        "symbol": "005930",
+        "market": "equity_kr",
+        "account_mode": "kis_live",
+        "side": "buy",
+        "order_type": "limit",
+        "proposer": "post-commit-probe",
+        "rungs": [
+            {
+                "rung_index": 0,
+                "side": "buy",
+                "quantity": "1",
+                "limit_price": "70000",
+            }
+        ],
+    }
+
+
+def _committed_group() -> SimpleNamespace:
+    return SimpleNamespace(
+        proposal_id=PROPOSAL_ID,
+        lifecycle_state="proposed",
+        action="place",
+        target_broker_order_id=None,
+        valid_until=None,
+    )
+
+
+def _saved_rung() -> SimpleNamespace:
+    return SimpleNamespace(
+        rung_index=0,
+        side="buy",
+        quantity=1,
+        limit_price=70000,
+        notional=None,
+        state="pending_approval",
+        broker_order_id=None,
+        correlation_id=None,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("primary_failure", "enabled", "allowlist"),
+    [
+        ("telegram_disabled", False, "chat"),
+        ("telegram_allowlist_empty", True, ""),
+        ("telegram_transport_error", True, "chat"),
+        ("approval_card_dispatch_failed", True, "chat"),
+    ],
+)
+async def test_committed_create_survives_dispatch_and_failure_recorder_errors(
+    monkeypatch,
+    primary_failure: str,
+    enabled: bool,
+    allowlist: str,
+) -> None:
+    session = SimpleNamespace(commit=AsyncMock())
+
+    @contextlib.asynccontextmanager
+    async def session_factory():
+        yield session
+
+    service = SimpleNamespace(
+        create_proposal=AsyncMock(return_value=_committed_group()),
+        get_proposal=AsyncMock(return_value=(_committed_group(), [_saved_rung()])),
+    )
+    monkeypatch.setattr(order_proposal_tools, "AsyncSessionLocal", session_factory)
+    monkeypatch.setattr(
+        order_proposal_tools, "OrderProposalsService", lambda _session: service
+    )
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", enabled)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", allowlist
+    )
+    dispatch = AsyncMock(side_effect=OrderProposalError(primary_failure))
+    monkeypatch.setattr(order_proposal_tools, "dispatch_proposal", dispatch)
+    monkeypatch.setattr(
+        notifier_module, "get_trade_notifier", lambda: SimpleNamespace()
+    )
+    recorder = AsyncMock(side_effect=RuntimeError("attempt_ledger_unavailable"))
+    monkeypatch.setattr(
+        order_proposal_tools, "record_approval_dispatch_failure", recorder
+    )
+
+    result = await order_proposal_tools.order_proposal_create(**_create_kwargs())
+
+    assert result["success"] is True
+    assert result["proposal_id"] == str(PROPOSAL_ID)
+    assert result["approval_dispatch"] == {
+        "state": "failed",
+        "message_id": None,
+        "status_code": None,
+        "error_code": None,
+        "error_classification": None,
+        "payload_chars": 0,
+        "failure_code": "approval_dispatch_ledger_error",
+        "ok": False,
+    }
+    session.commit.assert_awaited_once()
+    service.create_proposal.assert_awaited_once()
+    recorder.assert_awaited_once()
+    if enabled and allowlist:
+        dispatch.assert_awaited_once()
+    else:
+        dispatch.assert_not_awaited()
+
+    # A caller that retries only create failures observes durable success and
+    # therefore does not create a duplicate proposal.
+    if not result["success"]:
+        await order_proposal_tools.order_proposal_create(**_create_kwargs())
+    service.create_proposal.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_pre_commit_create_error_remains_caller_visible(monkeypatch) -> None:
+    session = SimpleNamespace(commit=AsyncMock())
+
+    @contextlib.asynccontextmanager
+    async def session_factory():
+        yield session
+
+    service = SimpleNamespace(
+        create_proposal=AsyncMock(
+            side_effect=OrderProposalError("proposal_validation_failed")
+        ),
+    )
+    recorder = AsyncMock()
+    monkeypatch.setattr(order_proposal_tools, "AsyncSessionLocal", session_factory)
+    monkeypatch.setattr(
+        order_proposal_tools, "OrderProposalsService", lambda _session: service
+    )
+    monkeypatch.setattr(
+        order_proposal_tools, "record_approval_dispatch_failure", recorder
+    )
+
+    result = await order_proposal_tools.order_proposal_create(**_create_kwargs())
+
+    assert result == {"success": False, "error": "proposal_validation_failed"}
+    session.commit.assert_not_awaited()
+    recorder.assert_not_awaited()

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -762,8 +762,49 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
         approval_issue_id=None,
         now=now,
     )
-    nonce = f"nonce-{unique}"
+    nonce = unique[:11]
     await service.set_approval_nonce(group.proposal_id, nonce)
+    from app.services.order_proposals.approval_message import build_callback_data
+    from app.services.order_proposals.dispatch_contract import (
+        ApprovalCardKind,
+        ApprovalPublication,
+        build_proposal_dispatch_binding,
+    )
+    from app.telegram_contract import TelegramMethodResult, telegram_text_length
+
+    dispatch_attempt_id = uuid4()
+    dispatch_binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=nonce,
+        attempt_id=dispatch_attempt_id,
+        card_kind=ApprovalCardKind.MANUAL,
+        current_membership_revision=group.approval_dispatch_membership_revision,
+    )
+    await service.start_approval_dispatch(
+        group.proposal_id,
+        attempt_id=dispatch_attempt_id,
+        binding=dispatch_binding,
+        now=now,
+        payload_chars=100,
+        context_message_count=0,
+    )
+    await service.finish_approval_dispatch(
+        group.proposal_id,
+        attempt_id=dispatch_attempt_id,
+        publication=ApprovalPublication.published(
+            payload_chars=100,
+            method_result=TelegramMethodResult(
+                ok=True,
+                message_id=555,
+                status_code=200,
+                error_code=None,
+                error_classification=None,
+                payload_chars=100,
+            ),
+        ),
+        chat_id="42",
+        now=now,
+    )
     await db_session.commit()
 
     class _Client:
@@ -819,7 +860,14 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
 
         async def edit_message(self, chat_id, message_id, text, reply_markup=None):
             self.edited.append((chat_id, message_id, text, reply_markup))
-            return True
+            return TelegramMethodResult(
+                ok=True,
+                message_id=message_id,
+                status_code=200,
+                error_code=None,
+                error_classification=None,
+                payload_chars=telegram_text_length(text),
+            )
 
     @contextlib.asynccontextmanager
     async def service_factory():
@@ -892,7 +940,12 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
                 "id": f"callback-{unique}",
                 "from": {"id": 777},
                 "message": {"chat": {"id": 42}, "message_id": 555},
-                "data": f"op:{str(group.proposal_id)[:8]}:{nonce}",
+                "data": build_callback_data(
+                    action="op",
+                    proposal_id=group.proposal_id,
+                    nonce=nonce,
+                    binding=dispatch_binding,
+                ),
             }
         },
         now=now,

--- a/tests/monitoring/test_trade_notifier_reply_markup.py
+++ b/tests/monitoring/test_trade_notifier_reply_markup.py
@@ -1,14 +1,17 @@
 """Tests for Telegram inline-keyboard transport and notifier helpers."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app.monitoring.trade_notifier import TradeNotifier, transports
+from app.telegram_contract import TelegramErrorClassification
 
 
 def _telegram_response(*, message_id: int = 42) -> MagicMock:
     response = MagicMock()
+    response.status_code = 200
     response.raise_for_status = MagicMock()
     response.json = MagicMock(
         return_value={"ok": True, "result": {"message_id": message_id}}
@@ -76,7 +79,7 @@ async def test_send_telegram_message_returns_message_id_with_markup() -> None:
     client.post = AsyncMock(return_value=_telegram_response(message_id=42))
     keyboard = {"inline_keyboard": [[{"text": "승인", "callback_data": "op:x:y"}]]}
 
-    message_id = await transports.send_telegram_message(
+    result = await transports.send_telegram_message(
         http_client=client,
         bot_token="T",
         chat_id="1",
@@ -84,7 +87,10 @@ async def test_send_telegram_message_returns_message_id_with_markup() -> None:
         reply_markup=keyboard,
     )
 
-    assert message_id == 42
+    assert result.ok is True
+    assert result.message_id == 42
+    assert result.status_code == 200
+    assert result.payload_chars == len("approve?")
     args, kwargs = client.post.call_args
     assert args[0] == "https://api.telegram.org/botT/sendMessage"
     assert kwargs["json"] == {
@@ -98,7 +104,7 @@ async def test_send_telegram_message_returns_message_id_with_markup() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_send_telegram_message_returns_none_on_failure() -> None:
+async def test_send_telegram_message_returns_structured_transport_failure() -> None:
     client = MagicMock()
     client.post = AsyncMock(side_effect=RuntimeError("network error"))
 
@@ -109,7 +115,147 @@ async def test_send_telegram_message_returns_none_on_failure() -> None:
         text="approve?",
     )
 
-    assert result is None
+    assert result.ok is False
+    assert result.message_id is None
+    assert result.status_code is None
+    assert result.failure_code == "telegram_transport_error"
+    assert result.error_classification is TelegramErrorClassification.TRANSPORT_ERROR
+    assert not hasattr(result, "description")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_transport_exception_log_omits_all_sensitive_payload_fields(
+    caplog,
+) -> None:
+    bot_token = "123456:secret-bot-token"
+    callback_data = "op:deadbeef:secret-nonce"
+    thesis_marker = "SECRET-THESIS-CONTENT"
+    client = MagicMock()
+    client.post = AsyncMock(
+        side_effect=RuntimeError(f"https://api.telegram.org/bot{bot_token}/sendMessage")
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = await transports.send_telegram_message(
+            http_client=client,
+            bot_token=bot_token,
+            chat_id="1",
+            text=thesis_marker,
+            reply_markup={
+                "inline_keyboard": [[{"text": "승인", "callback_data": callback_data}]]
+            },
+        )
+
+    assert result.ok is False
+    assert bot_token not in caplog.text
+    assert callback_data not in caplog.text
+    assert "secret-nonce" not in caplog.text
+    assert thesis_marker not in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("length", "expected_ok", "expected_post_count"),
+    [(4095, True, 1), (4096, True, 1), (4097, False, 0)],
+)
+async def test_send_telegram_message_text_limit_boundaries(
+    length: int, expected_ok: bool, expected_post_count: int
+) -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_telegram_response(message_id=91))
+
+    result = await transports.send_telegram_message(
+        http_client=client,
+        bot_token="T",
+        chat_id="1",
+        text="x" * length,
+    )
+
+    assert result.ok is expected_ok
+    assert result.payload_chars == length
+    assert client.post.await_count == expected_post_count
+    if expected_ok:
+        assert result.message_id == 91
+    else:
+        assert result.failure_code == "telegram_payload_too_long"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("emoji_count", "expected_units", "expected_ok"),
+    [(2048, 4096, True), (2049, 4098, False)],
+)
+async def test_send_telegram_message_uses_conservative_utf16_units(
+    emoji_count: int, expected_units: int, expected_ok: bool
+) -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_telegram_response(message_id=92))
+
+    result = await transports.send_telegram_message(
+        http_client=client,
+        bot_token="T",
+        chat_id="1",
+        text="😀" * emoji_count,
+    )
+
+    assert result.payload_chars == expected_units
+    assert result.ok is expected_ok
+    assert client.post.await_count == int(expected_ok)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_telegram_message_preserves_telegram_error_fields(caplog) -> None:
+    response = MagicMock()
+    response.status_code = 400
+    response.json = MagicMock(
+        return_value={
+            "ok": False,
+            "error_code": 400,
+            "description": "Bad Request: message is too long",
+        }
+    )
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+
+    with caplog.at_level(logging.ERROR):
+        result = await transports.send_telegram_message(
+            http_client=client,
+            bot_token="secret-token",
+            chat_id="1",
+            text="safe summary",
+        )
+
+    assert result.ok is False
+    assert result.status_code == 400
+    assert result.error_code == 400
+    assert result.error_classification is (TelegramErrorClassification.PAYLOAD_TOO_LONG)
+    assert not hasattr(result, "description")
+    record = next(
+        item for item in caplog.records if item.msg == "telegram.method.failed"
+    )
+    assert record.http_status == 400
+    assert record.telegram_error_code == 400
+    assert record.telegram_error_classification == "payload_too_long"
+    assert not hasattr(record, "telegram_description")
+    assert "Bad Request: message is too long" not in caplog.text
+    assert "secret-token" not in caplog.text
+
+
+@pytest.mark.unit
+def test_httpx_telegram_bot_url_logging_is_redacted(caplog) -> None:
+    token = "123456:top-secret"
+    with caplog.at_level(logging.INFO, logger="httpx"):
+        logging.getLogger("httpx").info(
+            'HTTP Request: POST https://api.telegram.org/bot%s/sendMessage "400"',
+            token,
+        )
+
+    assert token not in caplog.text
+    assert "bot[REDACTED]/sendMessage" in caplog.text
 
 
 @pytest.mark.unit
@@ -146,7 +292,8 @@ async def test_edit_message_text_forwards_reply_markup() -> None:
         reply_markup=keyboard,
     )
 
-    assert result is True
+    assert result.ok is True
+    assert result.message_id == 42
     args, kwargs = client.post.call_args
     assert args[0] == "https://api.telegram.org/botT/editMessageText"
     assert kwargs["json"] == {
@@ -180,7 +327,13 @@ async def test_boolean_transport_helpers_return_false_on_failure(helper: str) ->
             text="approved",
         )
 
-    assert result is False
+    if helper == "answer":
+        assert result is False
+    else:
+        assert result.ok is False
+        assert result.error_classification is (
+            TelegramErrorClassification.TRANSPORT_ERROR
+        )
 
 
 @pytest.mark.unit
@@ -200,15 +353,16 @@ async def test_notifier_helpers_reuse_singleton_resources(
     notifier._bot_token = "T"
     keyboard = {"inline_keyboard": [[{"text": "승인", "callback_data": "op:x:y"}]]}
 
-    message_id = await notifier.send_approval_message("approve?", keyboard, chat_id="1")
+    dispatch = await notifier.send_approval_message("approve?", keyboard, chat_id="1")
     answered = await notifier.answer_callback("callback-1", "received")
     edited = await notifier.edit_message(
         "1", 77, "approved", reply_markup={"inline_keyboard": []}
     )
 
-    assert message_id == 77
+    assert dispatch.ok is True
+    assert dispatch.message_id == 77
     assert answered is True
-    assert edited is True
+    assert edited.ok is True
     first_call, second_call, third_call = client.post.call_args_list
     assert "botT/sendMessage" in first_call.args[0]
     assert first_call.kwargs["json"]["reply_markup"] == keyboard
@@ -232,12 +386,13 @@ async def test_notifier_helpers_fail_safely_when_resource_missing(
     notifier._http_client = None if missing == "http_client" else client
     notifier._bot_token = None if missing == "bot_token" else "T"
 
-    assert (
-        await notifier.send_approval_message(
-            "approve?", {"inline_keyboard": []}, chat_id="1"
-        )
-        is None
+    dispatch = await notifier.send_approval_message(
+        "approve?", {"inline_keyboard": []}, chat_id="1"
     )
+    assert dispatch.ok is False
+    assert dispatch.failure_code == "telegram_notifier_unconfigured"
     assert await notifier.answer_callback("callback-1") is False
-    assert await notifier.edit_message("1", 42, "approved") is False
+    edited = await notifier.edit_message("1", 42, "approved")
+    assert edited.ok is False
+    assert edited.error_classification is TelegramErrorClassification.NOT_CONFIGURED
     client.post.assert_not_awaited()

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -10,12 +10,61 @@ import pytest
 from app.services.order_proposals import approval_message as approval_messages
 from app.services.order_proposals.approval_message import (
     build_action_diff,
-    build_approval_message,
     build_buying_power_shortfall_text,
-    build_callback_data,
-    build_loss_cut_confirmation_message,
     parse_callback_data,
 )
+from app.services.order_proposals.approval_message import (
+    build_approval_dispatch_messages as _build_approval_dispatch_messages,
+)
+from app.services.order_proposals.approval_message import (
+    build_approval_message as _build_approval_message,
+)
+from app.services.order_proposals.approval_message import (
+    build_callback_data as _build_callback_data,
+)
+from app.services.order_proposals.approval_message import (
+    build_loss_cut_confirmation_message as _build_loss_cut_confirmation_message,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    DispatchBinding,
+)
+from app.telegram_contract import (
+    TELEGRAM_SEND_MESSAGE_TEXT_LIMIT,
+    telegram_text_length,
+)
+
+_ATTEMPT_ID = uuid.UUID("99999999-9999-4999-8999-999999999999")
+
+
+def _binding(
+    card_kind: ApprovalCardKind = ApprovalCardKind.MANUAL,
+) -> DispatchBinding:
+    return DispatchBinding(
+        attempt_id=_ATTEMPT_ID,
+        card_kind=card_kind,
+        membership_revision=1,
+        membership_digest="AbCdEf0123_-",
+    )
+
+
+def build_callback_data(**kwargs):
+    return _build_callback_data(binding=_binding(), **kwargs)
+
+
+def build_approval_message(**kwargs):
+    return _build_approval_message(binding=_binding(), **kwargs)
+
+
+def build_approval_dispatch_messages(**kwargs):
+    return _build_approval_dispatch_messages(binding=_binding(), **kwargs)
+
+
+def build_loss_cut_confirmation_message(**kwargs):
+    return _build_loss_cut_confirmation_message(
+        binding=_binding(ApprovalCardKind.LOSS_CUT_CONFIRMATION),
+        **kwargs,
+    )
 
 
 def _group(**overrides):
@@ -32,7 +81,7 @@ def _group(**overrides):
         "commit_lease_until": None,
         "source_asof": None,
         "payload_hash": None,
-        "approval_nonce": "abc123def4560000",
+        "approval_nonce": "abc123def45",
         "exit_intent": None,
         "exit_reason": None,
         "retrospective_id": None,
@@ -78,10 +127,19 @@ def test_batch_callback_round_trip_and_telegram_limit():
     batch_id = uuid.UUID("aaaaaaaa-1111-4111-8111-111111111111")
 
     data = approval_messages.build_batch_callback_data(
-        batch_id=batch_id, nonce="batch_nonce-1"
+        batch_id=batch_id,
+        nonce="batch_nonce",
+        binding=_binding(ApprovalCardKind.BATCH),
     )
 
-    assert parse_callback_data(data) == ("ba", "aaaaaaaa", "batch_nonce-1")
+    parsed = parse_callback_data(data)
+    assert (parsed.action, parsed.subject_short, parsed.nonce) == (
+        "ba",
+        "aaaaaaaa",
+        "batch_nonce",
+    )
+    assert parsed.attempt_id == _ATTEMPT_ID
+    assert parsed.membership_digest == "AbCdEf0123_-"
     assert len(data.encode()) <= 64
 
 
@@ -115,7 +173,9 @@ def test_batch_summary_lists_notional_and_account_subtotals():
     ]
 
     text, keyboard = approval_messages.build_batch_approval_message(
-        batch=batch, proposals=proposals
+        batch=batch,
+        proposals=proposals,
+        binding=_binding(ApprovalCardKind.BATCH),
     )
 
     assert "AAPL" in text and "MSFT" in text
@@ -153,7 +213,9 @@ def test_batch_summary_omits_market_order_notional_from_totals():
     ]
 
     text, _keyboard = approval_messages.build_batch_approval_message(
-        batch=batch, proposals=proposals
+        batch=batch,
+        proposals=proposals,
+        binding=_binding(ApprovalCardKind.BATCH),
     )
 
     assert "합계: $100" in text
@@ -219,6 +281,35 @@ def test_loss_cut_approval_message_shows_reason_and_retrospective():
 
 
 @pytest.mark.unit
+def test_4444_character_thesis_is_split_losslessly_before_short_button_card():
+    thesis = "가" * 4444
+    strategy = "분할 매도"
+    group = _group(thesis=thesis, strategy=strategy)
+    proposal_short = str(group.proposal_id)[:8]
+
+    messages = build_approval_dispatch_messages(
+        group=group,
+        rungs=[_rung()],
+    )
+
+    assert messages.payload_chars > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+    assert len(messages.context_messages) == 2
+    assert all(
+        telegram_text_length(text) <= TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+        for text in (*messages.context_messages, messages.approval_text)
+    )
+    reconstructed = "".join(
+        message.split("\n\n", 1)[1] for message in messages.context_messages
+    )
+    assert reconstructed == f"투자 논지:\n{thesis}\n\n전략:\n{strategy}"
+    assert thesis not in messages.approval_text
+    assert "투자 논지 4444자" in messages.approval_text
+    assert all(proposal_short in message for message in messages.context_messages)
+    assert proposal_short in messages.approval_text
+    assert messages.inline_keyboard["inline_keyboard"]
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("detail", "expected"),
     [
@@ -281,14 +372,15 @@ def test_callback_data_roundtrip_and_length():
     data = build_callback_data(
         action="op",
         proposal_id=proposal_id,
-        nonce="abc123def4560000",
+        nonce="abc123def45",
     )
 
     assert len(data.encode("utf-8")) <= 64
-    action, proposal_short, nonce = parse_callback_data(data)
-    assert action == "op"
-    assert proposal_short == str(proposal_id)[:8]
-    assert nonce == "abc123def4560000"
+    parsed = parse_callback_data(data)
+    assert parsed.action == "op"
+    assert parsed.subject_short == str(proposal_id)[:8]
+    assert parsed.nonce == "abc123def45"
+    assert parsed.attempt_id == _ATTEMPT_ID
 
 
 @pytest.mark.unit
@@ -298,7 +390,7 @@ def test_loss_cut_confirmation_callback_and_summary():
         exit_reason="stop_loss",
         retrospective_id=42,
         approval_issue_id="operator note: desk A",
-        approval_nonce="second-step-nonce",
+        approval_nonce="secondnonce",
     )
     text, keyboard = build_loss_cut_confirmation_message(
         group=group,
@@ -330,11 +422,11 @@ def test_loss_cut_confirmation_callback_and_summary():
     assert "98" in text
     button = keyboard["inline_keyboard"][0][0]
     assert button["text"] == "⚠️ 손절 확인"
-    action, proposal_short, nonce = parse_callback_data(button["callback_data"])
-    assert (action, proposal_short, nonce) == (
+    parsed = parse_callback_data(button["callback_data"])
+    assert (parsed.action, parsed.subject_short, parsed.nonce) == (
         "lc",
         str(group.proposal_id)[:8],
-        "second-step-nonce",
+        "secondnonce",
     )
 
 
@@ -346,7 +438,7 @@ def test_callback_builder_rejects_invalid_action_and_oversized_data():
         build_callback_data(
             action="approve",
             proposal_id=proposal_id,
-            nonce="abc123def4560000",
+            nonce="abc123def45",
         )
     with pytest.raises(ValueError, match="64 bytes"):
         build_callback_data(
@@ -381,7 +473,7 @@ def test_message_includes_times_cash_and_reconfirm_diff_without_secrets():
     proposal_id = uuid.UUID("12345678-1234-5678-9abc-123456789abc")
     payload_hash = "payload-secret-digest-0123456789"
     approval_hash = "approval-secret-digest-9876543210"
-    nonce = "abc123def4560000"
+    nonce = "abc123def45"
     group = SimpleNamespace(
         proposal_id=proposal_id,
         symbol="000660",
@@ -461,20 +553,14 @@ def test_message_includes_times_cash_and_reconfirm_diff_without_secrets():
     assert "approval_hash" not in text
     assert "nonce" not in text
     assert "digest" not in text
-    assert inline_keyboard == {
-        "inline_keyboard": [
-            [
-                {
-                    "text": "✅ 승인",
-                    "callback_data": "op:12345678:abc123def4560000",
-                },
-                {
-                    "text": "❌ 거부",
-                    "callback_data": "dn:12345678:abc123def4560000",
-                },
-            ]
-        ]
-    }
+    approve, deny = inline_keyboard["inline_keyboard"][0]
+    assert (approve["text"], deny["text"]) == ("✅ 승인", "❌ 거부")
+    approve_callback = parse_callback_data(approve["callback_data"])
+    deny_callback = parse_callback_data(deny["callback_data"])
+    assert approve_callback.action == "op"
+    assert deny_callback.action == "dn"
+    assert approve_callback.attempt_id == deny_callback.attempt_id == _ATTEMPT_ID
+    assert approve_callback.nonce == deny_callback.nonce == nonce
 
 
 @pytest.mark.unit
@@ -580,7 +666,7 @@ def test_message_omits_nested_and_non_numeric_sensitive_values():
         commit_lease_until=None,
         source_asof=None,
         payload_hash=None,
-        approval_nonce="abc123def4560000",
+        approval_nonce="abc123def45",
     )
     rung = SimpleNamespace(
         rung_index=0,
@@ -648,7 +734,7 @@ def test_message_formats_optional_market_order_fields_stably():
         commit_lease_until=None,
         source_asof=None,
         payload_hash=None,
-        approval_nonce="abc123def4560000",
+        approval_nonce="abc123def45",
     )
     rung = SimpleNamespace(
         rung_index=0,
@@ -682,7 +768,7 @@ def test_message_escapes_inline_code_delimiters():
         commit_lease_until=None,
         source_asof=None,
         payload_hash=None,
-        approval_nonce="abc123def4560000",
+        approval_nonce="abc123def45",
     )
 
     text, _ = build_approval_message(group=group, rungs=[])

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -9,39 +9,101 @@ from decimal import Decimal
 import pytest
 
 from app.core.db import AsyncSessionLocal
+from app.models.order_proposals import OrderProposal, OrderProposalRung
 from app.services.order_proposals import OrderProposalsService
-from app.services.order_proposals.approval_message import parse_callback_data
+from app.services.order_proposals.approval_message import (
+    build_approval_dispatch_messages,
+    parse_callback_data,
+)
 from app.services.order_proposals.dispatch import (
     dispatch_proposal,
+    publish_approval_messages,
     send_proposal_for_approval,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalDispatchState,
+    build_proposal_dispatch_binding,
 )
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
+from app.telegram_contract import TelegramMethodResult, telegram_text_length
 
 CHAT_ID = "chat-99"
 
 
 class _FakeNotifier:
     def __init__(self, *, message_id: int | None = 5001) -> None:
-        self.sent_messages: list[tuple[str, dict, str]] = []
+        self.sent_messages: list[tuple[str, dict | None, str]] = []
+        self.parse_modes: list[str | None] = []
         self.edited_messages: list[tuple[str, int, str, dict | None]] = []
         self._message_id = message_id
 
-    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
         self.sent_messages.append((text, inline_keyboard, chat_id))
+        self.parse_modes.append(parse_mode)
         message_id = self._message_id
         if self._message_id is not None:
             self._message_id += 1
-        return message_id
+            return TelegramMethodResult(
+                ok=True,
+                message_id=message_id,
+                status_code=200,
+                error_code=None,
+                error_classification=None,
+                payload_chars=telegram_text_length(text),
+            )
+        return TelegramMethodResult.failed(
+            payload_chars=telegram_text_length(text),
+            failure_code="telegram_error_400",
+            status_code=400,
+            error_code=400,
+        )
 
     async def edit_message(self, chat_id, message_id, text, reply_markup=None):
         self.edited_messages.append((chat_id, message_id, text, reply_markup))
-        return True
+        return TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=telegram_text_length(text),
+        )
 
 
 class _RaisingNotifier:
-    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
         raise RuntimeError("telegram down")
+
+
+class _FailAtNotifier(_FakeNotifier):
+    def __init__(self, *, fail_at: int, message_id: int = 9000) -> None:
+        super().__init__(message_id=message_id)
+        self._fail_at = fail_at
+
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
+        if len(self.sent_messages) + 1 == self._fail_at:
+            self.sent_messages.append((text, inline_keyboard, chat_id))
+            self.parse_modes.append(parse_mode)
+            return TelegramMethodResult.failed(
+                payload_chars=telegram_text_length(text),
+                failure_code="telegram_error_400",
+                status_code=400,
+                error_code=400,
+            )
+        return await super().send_approval_message(
+            text,
+            inline_keyboard,
+            chat_id=chat_id,
+            parse_mode=parse_mode,
+        )
 
 
 class _CommittedBatchNotifier(_FakeNotifier):
@@ -49,19 +111,84 @@ class _CommittedBatchNotifier(_FakeNotifier):
         super().__init__(message_id=6500)
         self.visible_member_counts: list[int] = []
 
-    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
         button = inline_keyboard["inline_keyboard"][0][0]
         if button["text"] == "전체 승인":
-            _action, batch_short, _nonce = parse_callback_data(button["callback_data"])
+            parsed = parse_callback_data(button["callback_data"])
             async with AsyncSessionLocal() as session:
                 service = OrderProposalsService(session)
-                batch_id = await service.resolve_approval_batch_id_prefix(batch_short)
+                batch_id = await service.resolve_approval_batch_id_prefix(
+                    parsed.subject_short
+                )
                 assert batch_id is not None
                 _batch, proposals = await service.get_approval_batch_display(batch_id)
                 self.visible_member_counts.append(len(proposals))
         return await super().send_approval_message(
-            text, inline_keyboard, chat_id=chat_id
+            text, inline_keyboard, chat_id=chat_id, parse_mode=parse_mode
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_publish_4444_thesis_requires_every_context_before_button() -> None:
+    group = OrderProposal(
+        proposal_id=uuid.uuid4(),
+        approval_nonce="unit-nonce1",
+        market="equity_kr",
+        symbol="259960",
+        side="buy",
+        order_type="limit",
+        action="place",
+        thesis="가" * 4444,
+        strategy="분할 매도",
+    )
+    rung = OrderProposalRung(
+        rung_index=0,
+        side="buy",
+        quantity=Decimal("1"),
+        limit_price=Decimal("100000"),
+    )
+    binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=group.approval_nonce,
+        attempt_id=uuid.uuid4(),
+        card_kind=ApprovalCardKind.MANUAL,
+        current_membership_revision=None,
+    )
+    messages = build_approval_dispatch_messages(
+        group=group, rungs=[rung], binding=binding
+    )
+    assert len(messages.context_messages) == 2
+
+    failed_notifier = _FailAtNotifier(fail_at=2)
+    failed = await publish_approval_messages(
+        notifier=failed_notifier,
+        messages=messages,
+        chat_id=CHAT_ID,
+    )
+
+    assert failed.card_published is False
+    assert failed.partial is True
+    assert failed.failure_code == "approval_context_dispatch_failed"
+    assert len(failed_notifier.sent_messages) == 2
+    assert all(keyboard is None for _, keyboard, _ in failed_notifier.sent_messages)
+
+    successful_notifier = _FakeNotifier(message_id=9200)
+    sent = await publish_approval_messages(
+        notifier=successful_notifier,
+        messages=messages,
+        chat_id=CHAT_ID,
+    )
+
+    assert sent.card_published is True
+    assert sent.message_id == 9202
+    assert len(successful_notifier.sent_messages) == 3
+    assert all(
+        keyboard is None for _, keyboard, _ in successful_notifier.sent_messages[:-1]
+    )
+    assert successful_notifier.sent_messages[-1][1]["inline_keyboard"]
 
 
 def _session_factory(db_session):
@@ -81,6 +208,8 @@ async def _seed_proposal(
     target_order_snapshot=None,
     rungs=None,
     broker_account_id=None,
+    thesis=None,
+    strategy=None,
 ):
     service = OrderProposalsService(db_session)
     group = await service.create_proposal(
@@ -90,6 +219,8 @@ async def _seed_proposal(
         side="buy",
         order_type="limit",
         proposer="p",
+        thesis=thesis,
+        strategy=strategy,
         rungs=rungs or [RungInput(0, "buy", Decimal("10"), Decimal("100"), None)],
         source_asof=source_asof,
         action=action,
@@ -114,14 +245,15 @@ async def test_send_proposal_for_approval_mints_nonce_and_sends(
     notifier = _FakeNotifier(message_id=5001)
     now = datetime(2026, 7, 10, 9, 20, tzinfo=UTC)
 
-    message_id = await send_proposal_for_approval(
+    dispatch = await send_proposal_for_approval(
         group.proposal_id,
         notifier=notifier,
         now=now,
         service_factory=_session_factory(db_session),
     )
 
-    assert message_id == 5001
+    assert dispatch.ok is True
+    assert dispatch.message_id == 5001
     assert len(notifier.sent_messages) == 1
     text, keyboard, chat_id = notifier.sent_messages[0]
     assert chat_id == CHAT_ID
@@ -137,7 +269,7 @@ async def test_send_proposal_for_approval_mints_nonce_and_sends(
 
 
 @pytest.mark.asyncio
-async def test_manual_dispatch_sends_and_updates_same_chat_batch_summary(
+async def test_manual_dispatch_freezes_published_batch_and_starts_next_card(
     monkeypatch, db_session
 ):
     from app.core.config import settings
@@ -149,41 +281,58 @@ async def test_manual_dispatch_sends_and_updates_same_chat_batch_summary(
     first = await _seed_proposal(db_session)
     second = await _seed_proposal(db_session)
     third = await _seed_proposal(db_session)
+    fourth = await _seed_proposal(db_session)
     notifier = _FakeNotifier(message_id=6000)
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
 
-    first_id = await send_proposal_for_approval(
+    first_result = await send_proposal_for_approval(
         first.proposal_id,
         notifier=notifier,
         now=now,
         service_factory=_session_factory(db_session),
     )
-    assert first_id == 6000
+    assert first_result.message_id == 6000
     assert len(notifier.sent_messages) == 1
 
-    second_id = await send_proposal_for_approval(
+    second_result = await send_proposal_for_approval(
         second.proposal_id,
         notifier=notifier,
         now=now.replace(minute=1),
         service_factory=_session_factory(db_session),
     )
-    assert second_id == 6001
+    assert second_result.message_id == 6001
     assert len(notifier.sent_messages) == 3
     summary_text, summary_keyboard, summary_chat = notifier.sent_messages[-1]
     assert summary_chat == batch_chat_id
     assert "제안: 2건" in summary_text
     assert summary_keyboard["inline_keyboard"][0][0]["text"] == "전체 승인"
 
-    third_id = await send_proposal_for_approval(
+    third_result = await send_proposal_for_approval(
         third.proposal_id,
         notifier=notifier,
         now=now.replace(minute=2),
         service_factory=_session_factory(db_session),
     )
-    assert third_id == 6003
-    assert notifier.edited_messages
-    assert notifier.edited_messages[-1][1] == 6002
-    assert "제안: 3건" in notifier.edited_messages[-1][2]
+    assert third_result.message_id == 6003
+    assert len(notifier.sent_messages) == 4
+    assert notifier.edited_messages == []
+
+    fourth_result = await send_proposal_for_approval(
+        fourth.proposal_id,
+        notifier=notifier,
+        now=now.replace(minute=3),
+        service_factory=_session_factory(db_session),
+    )
+    assert fourth_result.message_id == 6004
+    assert len(notifier.sent_messages) == 6
+    next_summary_text, next_summary_keyboard, next_summary_chat = (
+        notifier.sent_messages[-1]
+    )
+    assert next_summary_chat == batch_chat_id
+    assert "제안: 2건" in next_summary_text
+    assert next_summary_keyboard["inline_keyboard"][0][0]["text"] == "전체 승인"
+    assert next_summary_text != summary_text
+    assert notifier.edited_messages == []
 
 
 @pytest.mark.asyncio
@@ -298,23 +447,25 @@ async def test_send_proposal_for_approval_empty_allowlist_is_noop(
     notifier = _FakeNotifier()
     now = datetime(2026, 7, 10, 9, 22, tzinfo=UTC)
 
-    message_id = await send_proposal_for_approval(
+    dispatch = await send_proposal_for_approval(
         group.proposal_id,
         notifier=notifier,
         now=now,
         service_factory=_session_factory(db_session),
     )
 
-    assert message_id is None
+    assert dispatch.ok is False
+    assert dispatch.failure_code == "telegram_allowlist_empty"
     assert notifier.sent_messages == []
 
     service = OrderProposalsService(db_session)
     refreshed, _ = await service.get_proposal(group.proposal_id)
     assert refreshed.approval_nonce is None
+    assert refreshed.approval_dispatch_state == "failed"
 
 
 @pytest.mark.asyncio
-async def test_send_proposal_for_approval_send_failure_returns_none_but_nonce_committed(
+async def test_send_proposal_for_approval_send_failure_is_durable_and_invalidates_nonce(
     monkeypatch, db_session
 ):
     from app.core.config import settings
@@ -326,19 +477,89 @@ async def test_send_proposal_for_approval_send_failure_returns_none_but_nonce_co
     notifier = _FakeNotifier(message_id=None)
     now = datetime(2026, 7, 10, 9, 23, tzinfo=UTC)
 
-    message_id = await send_proposal_for_approval(
+    dispatch = await send_proposal_for_approval(
         group.proposal_id,
         notifier=notifier,
         now=now,
         service_factory=_session_factory(db_session),
     )
 
-    assert message_id is None
+    assert dispatch.ok is False
+    assert dispatch.failure_code == "approval_card_dispatch_failed"
 
     service = OrderProposalsService(db_session)
     refreshed, _ = await service.get_proposal(group.proposal_id)
-    assert refreshed.approval_nonce is not None
+    assert refreshed.approval_nonce is None
+    assert refreshed.approval_dispatch_state == "failed"
+    assert refreshed.approval_dispatch_failure_code == "approval_card_dispatch_failed"
+    assert refreshed.approval_dispatch_payload_chars == dispatch.payload_chars
     assert refreshed.source_asof is None
+
+
+@pytest.mark.asyncio
+async def test_4444_thesis_context_failure_withholds_button_and_retry_mints_new_nonce(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+    from app.services.order_proposals import dispatch as dispatch_module
+
+    chat_id = f"long-thesis-{uuid.uuid4().hex}"
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat_id
+    )
+    nonces = iter(("first-dispatch-nonce", "second-dispatch-nonce"))
+    monkeypatch.setattr(dispatch_module, "_generate_nonce", lambda: next(nonces))
+    group = await _seed_proposal(
+        db_session,
+        thesis="가" * 4444,
+        strategy="분할 매도",
+    )
+    now = datetime(2026, 7, 23, 2, 17, 50, tzinfo=UTC)
+
+    failed_notifier = _FailAtNotifier(fail_at=2)
+    failed = await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=failed_notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+    )
+
+    assert failed.ok is False
+    assert failed.failure_code == "approval_context_dispatch_failed"
+    assert failed.payload_chars > 4096
+    assert len(failed_notifier.sent_messages) == 2
+    assert all(keyboard is None for _, keyboard, _ in failed_notifier.sent_messages)
+    assert failed_notifier.parse_modes == [None, None]
+
+    service = OrderProposalsService(db_session)
+    after_failure, _ = await service.get_proposal(group.proposal_id)
+    failed_attempt_id = after_failure.approval_dispatch_attempt_id
+    assert after_failure.approval_dispatch_state == "failed"
+    assert after_failure.approval_nonce is None
+
+    successful_notifier = _FakeNotifier(message_id=9100)
+    sent = await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=successful_notifier,
+        now=now.replace(second=51),
+        service_factory=_session_factory(db_session),
+    )
+
+    assert sent.ok is True
+    assert sent.message_id == 9102
+    assert len(successful_notifier.sent_messages) == 3
+    assert all(
+        keyboard is None for _, keyboard, _ in successful_notifier.sent_messages[:-1]
+    )
+    assert successful_notifier.sent_messages[-1][1]["inline_keyboard"]
+    assert successful_notifier.parse_modes == [None, None, "Markdown"]
+    after_retry, _ = await service.get_proposal(group.proposal_id)
+    assert (
+        after_retry.approval_dispatch_state == ApprovalDispatchState.SENT_CURRENT.value
+    )
+    assert after_retry.approval_dispatch_attempt_id != failed_attempt_id
+    assert after_retry.approval_nonce == "second-dispatch-nonce"
+    assert after_retry.source_asof["approval_message_id"] == 9102
 
 
 @pytest.mark.asyncio
@@ -455,7 +676,8 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
         service_factory=_session_factory(db_session),
         revalidate_fn=duplicate_must_not_revalidate,
     )
-    assert duplicate is None
+    assert duplicate.ok is False
+    assert duplicate.failure_code == "proposal_not_pending_approval"
     assert len(notifier.sent_messages) == 1
 
 
@@ -629,7 +851,7 @@ async def test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate(
     )
 
     assert cancel_calls == []
-    assert result is not None  # nonce minted + ordinary approval message sent
+    assert result.ok is True  # nonce minted + ordinary approval message sent
     # Falls back to the ordinary human-approval message ("주문 제안 승인"),
     # never the auto-approved "자동 접수됨" veto message -- TELEGRAM_APPROVAL_SEND
     # for the human-click flow, not a post-hoc veto button on an already-sent order.
@@ -765,7 +987,7 @@ async def test_auto_notify_failure_compensates_by_cancelling_live_order(
         fetch_target_fn=fetch_fn,
     )
 
-    assert result is None
+    assert result.ok is False
     assert cancel_calls[0]["order_id"] == "broker-notify-failure"
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "cancelled"

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -507,7 +507,7 @@ async def test_4444_thesis_context_failure_withholds_button_and_retry_mints_new_
     monkeypatch.setattr(
         settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat_id
     )
-    nonces = iter(("first-dispatch-nonce", "second-dispatch-nonce"))
+    nonces = iter(("firstnonce1", "secondnonce"))
     monkeypatch.setattr(dispatch_module, "_generate_nonce", lambda: next(nonces))
     group = await _seed_proposal(
         db_session,
@@ -534,7 +534,10 @@ async def test_4444_thesis_context_failure_withholds_button_and_retry_mints_new_
     service = OrderProposalsService(db_session)
     after_failure, _ = await service.get_proposal(group.proposal_id)
     failed_attempt_id = after_failure.approval_dispatch_attempt_id
-    assert after_failure.approval_dispatch_state == "failed"
+    assert (
+        after_failure.approval_dispatch_state
+        == ApprovalDispatchState.PARTIAL_FAILED.value
+    )
     assert after_failure.approval_nonce is None
 
     successful_notifier = _FakeNotifier(message_id=9100)
@@ -558,7 +561,7 @@ async def test_4444_thesis_context_failure_withholds_button_and_retry_mints_new_
         after_retry.approval_dispatch_state == ApprovalDispatchState.SENT_CURRENT.value
     )
     assert after_retry.approval_dispatch_attempt_id != failed_attempt_id
-    assert after_retry.approval_nonce == "second-dispatch-nonce"
+    assert after_retry.approval_nonce == "secondnonce"
     assert after_retry.source_asof["approval_message_id"] == 9102
 
 

--- a/tests/services/order_proposals/test_dispatch_security_invariants.py
+++ b/tests/services/order_proposals/test_dispatch_security_invariants.py
@@ -1,0 +1,1595 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.models.order_proposals import (
+    OrderProposal,
+    OrderProposalApprovalDispatchAttempt,
+    OrderProposalRung,
+)
+from app.monitoring.trade_notifier import transports
+from app.services.order_proposals import dispatch as dispatch_module
+from app.services.order_proposals.approval_message import (
+    ApprovalDispatchMessages,
+    build_batch_approval_message,
+)
+from app.services.order_proposals.dispatch import (
+    dispatch_proposal,
+    publish_approval_messages,
+    send_proposal_for_approval,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalDispatchState,
+    ApprovalPublication,
+    CallbackEnvelope,
+    CallbackGateSnapshot,
+    DispatchBinding,
+    TelegramDispatchResult,
+    assert_callback_gate,
+    build_membership_digest,
+)
+from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.repository import OrderProposalRepository
+from app.services.order_proposals.revalidation import RungOutcome
+from app.services.order_proposals.service import OrderProposalsService
+from app.services.order_proposals.telegram_callback import (
+    _handle_approve,
+    _handle_auto_veto,
+    _handle_loss_cut_first_click,
+)
+from app.telegram_contract import (
+    TelegramErrorClassification,
+    TelegramMethodResult,
+    telegram_text_length,
+)
+
+NOW = datetime(2026, 7, 23, 9, 0, tzinfo=UTC)
+PROPOSAL_ID = uuid.UUID("11111111-1111-4111-8111-111111111111")
+ATTEMPT_ID = uuid.UUID("22222222-2222-4222-8222-222222222222")
+DIGEST = "AbCdEf0123_-"
+
+
+def _service_with_repo(repo: object, *, session: object | None = None):
+    service = object.__new__(OrderProposalsService)
+    service._repo = repo
+    service._session = session or SimpleNamespace(execute=AsyncMock())
+    return service
+
+
+def _callback(
+    *,
+    action: str = "op",
+    attempt_id: uuid.UUID = ATTEMPT_ID,
+    revision: int = 1,
+    digest: str = DIGEST,
+    nonce: str = "safe-nonce",
+    subject_short: str | None = None,
+) -> CallbackEnvelope:
+    return CallbackEnvelope(
+        action=action,
+        subject_short=subject_short or str(PROPOSAL_ID)[:8],
+        attempt_id=attempt_id,
+        membership_revision=revision,
+        membership_digest=digest,
+        nonce=nonce,
+    )
+
+
+def _proposal_digest(
+    nonce: str | None,
+    *,
+    revision: int = 1,
+    card_kind: ApprovalCardKind = ApprovalCardKind.MANUAL,
+) -> str:
+    return build_membership_digest(
+        card_kind=card_kind,
+        membership_revision=revision,
+        members=[
+            {
+                "proposal_id": str(PROPOSAL_ID),
+                "approval_nonce": nonce,
+            }
+        ],
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_raw_telegram_description_is_discarded_everywhere(caplog) -> None:
+    markers = (
+        "https://api.telegram.org/bot123:SECRET/sendMessage",
+        "chat=998877",
+        "THESIS_MARKER",
+        "callback_data=op:11111111:NONCE_MARKER",
+        "reply_markup=INLINE_MARKER",
+    )
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 400
+    response.json.return_value = {
+        "ok": False,
+        "error_code": 400,
+        "description": " | ".join(markers),
+    }
+    client = SimpleNamespace(post=AsyncMock(return_value=response))
+
+    with caplog.at_level(logging.ERROR):
+        result = await transports.send_telegram_message(
+            http_client=client,
+            bot_token="request-token",
+            chat_id="998877",
+            text="THESIS_MARKER",
+            reply_markup={"callback_data": "NONCE_MARKER"},
+        )
+
+    assert result.error_classification is (
+        TelegramErrorClassification.UNKNOWN_TELEGRAM_ERROR
+    )
+    assert not hasattr(result, "description")
+    assert "telegram_description" not in (
+        column.name for column in OrderProposalApprovalDispatchAttempt.__table__.columns
+    )
+    rendered_records = "\n".join(
+        f"{record.getMessage()} {record.__dict__}" for record in caplog.records
+    )
+    assert all(marker not in rendered_records for marker in markers)
+    caller_result = TelegramDispatchResult.from_publication(
+        ApprovalPublication.failed(
+            payload_chars=result.payload_chars,
+            failure_code="approval_card_dispatch_failed",
+            method_result=result,
+        ),
+        state=ApprovalDispatchState.FAILED,
+    ).as_dict()
+    assert all(marker not in str(caller_result) for marker in markers)
+    assert "description" not in caller_result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("units", "expected_ok", "expected_calls"),
+    [(4095, True, 1), (4096, True, 1), (4097, False, 0)],
+)
+async def test_edit_message_uses_same_utf16_preflight(
+    units: int, expected_ok: bool, expected_calls: int
+) -> None:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = {"ok": True, "result": True}
+    client = SimpleNamespace(post=AsyncMock(return_value=response))
+
+    result = await transports.edit_message_text(
+        http_client=client,
+        bot_token="token",
+        chat_id="chat",
+        message_id=1,
+        text="가" * units,
+    )
+
+    assert result.ok is expected_ok
+    assert client.post.await_count == expected_calls
+    if units == 4097:
+        assert result.failure_code == "telegram_payload_too_long"
+        assert result.error_classification is (
+            TelegramErrorClassification.PAYLOAD_TOO_LONG
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "error_code", "classification"),
+    [
+        (400, 400, TelegramErrorClassification.UNKNOWN_TELEGRAM_ERROR),
+        (429, 429, TelegramErrorClassification.UNKNOWN_TELEGRAM_ERROR),
+        (500, 500, TelegramErrorClassification.UNKNOWN_TELEGRAM_ERROR),
+        (503, 503, TelegramErrorClassification.UNKNOWN_TELEGRAM_ERROR),
+    ],
+)
+async def test_edit_failure_is_structured_without_remote_text(
+    status: int,
+    error_code: int,
+    classification: TelegramErrorClassification,
+) -> None:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status
+    response.json.return_value = {
+        "ok": False,
+        "error_code": error_code,
+        "description": "NONCE THESIS CHAT CALLBACK REPLY_MARKUP",
+    }
+    client = SimpleNamespace(post=AsyncMock(return_value=response))
+
+    result = await transports.edit_message_text(
+        http_client=client,
+        bot_token="token",
+        chat_id="chat",
+        message_id=1,
+        text="safe",
+    )
+
+    assert result.ok is False
+    assert result.status_code == status
+    assert result.error_code == error_code
+    assert result.error_classification is classification
+    assert not hasattr(result, "description")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_edit_timeout_is_structured() -> None:
+    client = SimpleNamespace(post=AsyncMock(side_effect=TimeoutError("SECRET")))
+    result = await transports.edit_message_text(
+        http_client=client,
+        bot_token="token",
+        chat_id="chat",
+        message_id=1,
+        text="safe",
+    )
+    assert result.ok is False
+    assert result.failure_code == "telegram_transport_error"
+    assert result.error_classification is TelegramErrorClassification.TRANSPORT_ERROR
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "state",
+    [
+        ApprovalDispatchState.PENDING,
+        ApprovalDispatchState.FAILED,
+        ApprovalDispatchState.PARTIAL_FAILED,
+        ApprovalDispatchState.SENT_SUPERSEDED,
+        ApprovalDispatchState.FAILED_SUPERSEDED,
+    ],
+)
+def test_common_gate_rejects_every_non_current_state(
+    state: ApprovalDispatchState,
+) -> None:
+    snapshot = CallbackGateSnapshot(
+        subject_short=str(PROPOSAL_ID)[:8],
+        state=state,
+        attempt_id=ATTEMPT_ID,
+        card_kind=ApprovalCardKind.MANUAL,
+        membership_revision=1,
+        membership_digest=DIGEST,
+        nonce="safe-nonce",
+        nonce_used=False,
+    )
+    with pytest.raises(ValueError, match=f"approval_dispatch_{state.value}"):
+        assert_callback_gate(snapshot=snapshot, callback=_callback())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("card_kind", "action"),
+    [
+        (ApprovalCardKind.MANUAL, "vc"),
+        (ApprovalCardKind.AUTO_VETO, "op"),
+        (ApprovalCardKind.LOSS_CUT_CONFIRMATION, "op"),
+        (ApprovalCardKind.BATCH, "dn"),
+    ],
+)
+def test_common_gate_rejects_action_for_wrong_card_kind(
+    card_kind: ApprovalCardKind, action: str
+) -> None:
+    snapshot = CallbackGateSnapshot(
+        subject_short=str(PROPOSAL_ID)[:8],
+        state=ApprovalDispatchState.SENT_CURRENT,
+        attempt_id=ATTEMPT_ID,
+        card_kind=card_kind,
+        membership_revision=1,
+        membership_digest=DIGEST,
+        nonce="safe-nonce",
+        nonce_used=False,
+    )
+    with pytest.raises(ValueError, match="approval_card_action_mismatch"):
+        assert_callback_gate(snapshot=snapshot, callback=_callback(action=action))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_nonce_replacement_invalidates_previous_published_snapshot() -> None:
+    old_digest = _proposal_digest("old-nonce")
+    group = OrderProposal(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        root_proposal_id=PROPOSAL_ID,
+        revision=1,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="probe",
+        lifecycle_state="proposed",
+        approval_nonce="old-nonce",
+        approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_membership_revision=1,
+        approval_dispatch_membership_digest=old_digest,
+        approval_dispatch_published_at=NOW,
+    )
+
+    class Repo:
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def update_group(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    service = _service_with_repo(Repo())
+    await service.set_approval_nonce(PROPOSAL_ID, "new-nonce")
+
+    assert group.approval_dispatch_state == ApprovalDispatchState.FAILED.value
+    assert group.approval_dispatch_published_at is None
+    assert group.approval_dispatch_failure_code == "approval_dispatch_snapshot_missing"
+    with pytest.raises(OrderProposalError, match="approval_dispatch_failed"):
+        await service.consume_published_proposal_callback(
+            PROPOSAL_ID,
+            callback=_callback(nonce="new-nonce"),
+            now=NOW,
+        )
+    assert group.approval_nonce_used_at is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_start_rejects_binding_for_different_nonce_snapshot() -> None:
+    group = OrderProposal(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        root_proposal_id=PROPOSAL_ID,
+        revision=1,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="probe",
+        lifecycle_state="proposed",
+        approval_nonce="new-nonce",
+        approval_dispatch_membership_revision=1,
+    )
+
+    class Repo:
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def insert_approval_dispatch_attempt(self, **fields):
+            raise AssertionError("invalid binding must not create an attempt")
+
+    service = _service_with_repo(Repo())
+    with pytest.raises(OrderProposalError, match="approval_membership_digest_invalid"):
+        await service.start_approval_dispatch(
+            PROPOSAL_ID,
+            attempt_id=ATTEMPT_ID,
+            binding=DispatchBinding(
+                attempt_id=ATTEMPT_ID,
+                card_kind=ApprovalCardKind.MANUAL,
+                membership_revision=2,
+                membership_digest=DIGEST,
+            ),
+            now=NOW,
+            payload_chars=10,
+            context_message_count=0,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        ApprovalDispatchState.PENDING,
+        ApprovalDispatchState.FAILED,
+        ApprovalDispatchState.PARTIAL_FAILED,
+        ApprovalDispatchState.SENT_SUPERSEDED,
+        ApprovalDispatchState.FAILED_SUPERSEDED,
+    ],
+)
+async def test_auto_veto_non_current_card_never_consumes_or_calls_cancel(
+    state: ApprovalDispatchState,
+) -> None:
+    group = OrderProposal(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        root_proposal_id=PROPOSAL_ID,
+        revision=1,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="probe",
+        lifecycle_state="submitted",
+        source_asof={"auto_approved": {"policy_version": "probe"}},
+        approval_nonce="safe-nonce",
+        approval_dispatch_state=state.value,
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        approval_dispatch_card_kind=ApprovalCardKind.AUTO_VETO.value,
+        approval_dispatch_membership_revision=1,
+        approval_dispatch_membership_digest=DIGEST,
+    )
+    rung = OrderProposalRung(
+        id=1,
+        proposal_pk=1,
+        rung_index=0,
+        side="buy",
+        quantity=1,
+        state="resting",
+        broker_order_id="broker-1",
+    )
+
+    class Repo:
+        updates = 0
+
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def list_rungs(self, proposal_pk):
+            return [rung]
+
+        async def update_group(self, target, **fields):
+            self.updates += 1
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    repo = Repo()
+    service = _service_with_repo(repo)
+    session = SimpleNamespace(commit=AsyncMock())
+    cancel_fn = AsyncMock()
+    fetch_fn = AsyncMock()
+    result = await _handle_auto_veto(
+        session=session,
+        service=service,
+        proposal_id=PROPOSAL_ID,
+        callback=_callback(action="vc"),
+        now=NOW,
+        notifier=SimpleNamespace(),
+        chat_id="chat",
+        message_id=7,
+        telegram_user_id="operator",
+        cancel_fn=cancel_fn,
+        fetch_fn=fetch_fn,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == f"approval_dispatch_{state.value}"
+    assert group.approval_nonce_used_at is None
+    assert repo.updates == 0
+    cancel_fn.assert_not_awaited()
+    fetch_fn.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_process_crash_pending_manual_card_cannot_mutate_or_revalidate() -> None:
+    group = OrderProposal(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        root_proposal_id=PROPOSAL_ID,
+        revision=1,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="probe",
+        lifecycle_state="proposed",
+        approval_nonce="safe-nonce",
+        approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_membership_revision=1,
+        approval_dispatch_membership_digest=DIGEST,
+    )
+
+    class Repo:
+        updates = 0
+
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def list_rungs(self, proposal_pk):
+            return []
+
+        async def update_group(self, target, **fields):
+            self.updates += 1
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    repo = Repo()
+    service = _service_with_repo(repo)
+    service.acquire_target_mutation_lock = AsyncMock()
+    service.expire_if_needed = AsyncMock(
+        side_effect=AssertionError("pending callback must not expire proposal")
+    )
+    revalidate_fn = AsyncMock(
+        side_effect=AssertionError("pending callback must not revalidate")
+    )
+    session = SimpleNamespace(commit=AsyncMock())
+
+    result = await _handle_approve(
+        session=session,
+        service=service,
+        proposal_id=PROPOSAL_ID,
+        callback=_callback(),
+        now=NOW,
+        notifier=SimpleNamespace(),
+        chat_id="chat",
+        message_id=7,
+        callback_query_id=None,
+        telegram_user_id="operator",
+        revalidate_fn=revalidate_fn,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == "approval_dispatch_pending"
+    assert group.approval_nonce_used_at is None
+    assert repo.updates == 0
+    service.expire_if_needed.assert_not_awaited()
+    revalidate_fn.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "attempt_id", "card_kind", "action"),
+    [
+        (ApprovalDispatchState.PENDING, ATTEMPT_ID, ApprovalCardKind.MANUAL, "op"),
+        (ApprovalDispatchState.FAILED, ATTEMPT_ID, ApprovalCardKind.MANUAL, "op"),
+        (
+            ApprovalDispatchState.PARTIAL_FAILED,
+            ATTEMPT_ID,
+            ApprovalCardKind.MANUAL,
+            "op",
+        ),
+        (
+            ApprovalDispatchState.SENT_SUPERSEDED,
+            ATTEMPT_ID,
+            ApprovalCardKind.MANUAL,
+            "op",
+        ),
+        (
+            ApprovalDispatchState.FAILED_SUPERSEDED,
+            ATTEMPT_ID,
+            ApprovalCardKind.MANUAL,
+            "op",
+        ),
+        (
+            ApprovalDispatchState.SENT_CURRENT,
+            uuid.UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+            ApprovalCardKind.MANUAL,
+            "op",
+        ),
+        (
+            ApprovalDispatchState.SENT_CURRENT,
+            ATTEMPT_ID,
+            ApprovalCardKind.AUTO_VETO,
+            "op",
+        ),
+        (
+            ApprovalDispatchState.SENT_CURRENT,
+            ATTEMPT_ID,
+            ApprovalCardKind.MANUAL,
+            "vc",
+        ),
+    ],
+)
+async def test_invalid_loss_cut_binding_has_zero_pre_gate_external_calls(
+    state: ApprovalDispatchState,
+    attempt_id: uuid.UUID,
+    card_kind: ApprovalCardKind,
+    action: str,
+) -> None:
+    nonce = "safe-nonce"
+    digest = _proposal_digest(nonce, card_kind=card_kind)
+    group = OrderProposal(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        root_proposal_id=PROPOSAL_ID,
+        revision=1,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="sell",
+        order_type="market",
+        proposer="probe",
+        lifecycle_state="proposed",
+        exit_intent="loss_cut",
+        approval_nonce=nonce,
+        approval_dispatch_state=state.value,
+        approval_dispatch_attempt_id=attempt_id,
+        approval_dispatch_card_kind=card_kind.value,
+        approval_dispatch_membership_revision=1,
+        approval_dispatch_membership_digest=digest,
+    )
+
+    class Repo:
+        updates = 0
+
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def update_group(self, target, **fields):
+            self.updates += 1
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    repo = Repo()
+    service = _service_with_repo(repo)
+    session = SimpleNamespace(commit=AsyncMock())
+    provider_read = AsyncMock()
+    dry_run = AsyncMock()
+    submit = AsyncMock()
+    cancel = AsyncMock()
+    answer_callback = AsyncMock()
+
+    async def preview(**_kwargs):
+        await provider_read()
+        await dry_run()
+        return []
+
+    preview_mock = AsyncMock(side_effect=preview)
+    result = await _handle_loss_cut_first_click(
+        session=session,
+        service=service,
+        proposal_id=PROPOSAL_ID,
+        callback=_callback(action=action),
+        now=NOW,
+        notifier=SimpleNamespace(answer_callback=answer_callback),
+        chat_id="chat",
+        message_id=7,
+        callback_query_id="callback-query",
+        telegram_user_id="operator",
+        loss_cut_preview_fn=preview_mock,
+    )
+
+    assert result["handled"] is False
+    preview_mock.assert_not_awaited()
+    provider_read.assert_not_awaited()
+    dry_run.assert_not_awaited()
+    submit.assert_not_awaited()
+    cancel.assert_not_awaited()
+    answer_callback.assert_not_awaited()
+    assert group.approval_nonce_used_at is None
+    assert repo.updates == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        (
+            "approval_dispatch_attempt_id",
+            uuid.UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+        ),
+        ("approval_nonce", "replacement-nonce"),
+        ("approval_dispatch_membership_revision", 2),
+    ],
+)
+async def test_loss_cut_preview_to_consume_toctou_fails_closed(
+    field: str, replacement: object
+) -> None:
+    nonce = "safe-nonce"
+    digest = _proposal_digest(nonce)
+    group = OrderProposal(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        root_proposal_id=PROPOSAL_ID,
+        revision=1,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="sell",
+        order_type="market",
+        proposer="probe",
+        lifecycle_state="proposed",
+        exit_intent="loss_cut",
+        approval_nonce=nonce,
+        approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_membership_revision=1,
+        approval_dispatch_membership_digest=digest,
+    )
+
+    class Repo:
+        updates = 0
+
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def update_group(self, target, **fields):
+            self.updates += 1
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    repo = Repo()
+    service = _service_with_repo(repo)
+    session = SimpleNamespace(commit=AsyncMock())
+    submit = AsyncMock()
+    cancel = AsyncMock()
+
+    async def preview(**_kwargs):
+        setattr(group, field, replacement)
+        return []
+
+    preview_mock = AsyncMock(side_effect=preview)
+    result = await _handle_loss_cut_first_click(
+        session=session,
+        service=service,
+        proposal_id=PROPOSAL_ID,
+        callback=_callback(digest=digest),
+        now=NOW,
+        notifier=SimpleNamespace(),
+        chat_id="chat",
+        message_id=7,
+        telegram_user_id="operator",
+        loss_cut_preview_fn=preview_mock,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] in {
+        "approval_dispatch_attempt_mismatch",
+        "nonce_mismatch",
+        "approval_membership_revision_mismatch",
+    }
+    preview_mock.assert_awaited_once()
+    submit.assert_not_awaited()
+    cancel.assert_not_awaited()
+    assert group.approval_nonce_used_at is None
+    assert repo.updates == 0
+
+
+def _batch_fixture(*, state: ApprovalDispatchState, extra_member_revision: int = 1):
+    batch_id = uuid.UUID("33333333-3333-4333-8333-333333333333")
+    batch = SimpleNamespace(
+        id=7,
+        batch_id=batch_id,
+        chat_id="chat",
+        approval_nonce="safe-nonce",
+        approval_nonce_used_at=None,
+        expires_at=NOW + timedelta(minutes=5),
+        approval_dispatch_state=state.value,
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        membership_revision=1,
+        membership_digest=None,
+    )
+    members = []
+    groups = {}
+    for index in range(1, 38):
+        revision = 1 if index <= 36 else extra_member_revision
+        proposal_id = uuid.UUID(int=index)
+        groups[index] = SimpleNamespace(proposal_id=proposal_id)
+        members.append(
+            SimpleNamespace(
+                id=index,
+                proposal_pk=index,
+                approval_nonce_snapshot=f"member-{index}",
+                approval_message_id=1000 + index,
+                membership_revision=revision,
+                approval_dispatch_attempt_id_snapshot=uuid.UUID(int=100 + index),
+                approval_membership_revision_snapshot=1,
+                approval_membership_digest_snapshot=DIGEST,
+                approval_card_kind_snapshot=ApprovalCardKind.MANUAL.value,
+            )
+        )
+
+    batch.membership_digest = build_membership_digest(
+        card_kind=ApprovalCardKind.BATCH,
+        membership_revision=1,
+        members=[
+            {
+                "proposal_id": str(groups[index].proposal_id),
+                "approval_nonce": members[index - 1].approval_nonce_snapshot,
+                "approval_message_id": members[index - 1].approval_message_id,
+                "approval_dispatch_attempt_id": str(
+                    members[index - 1].approval_dispatch_attempt_id_snapshot
+                ),
+                "approval_membership_revision": 1,
+                "approval_membership_digest": DIGEST,
+            }
+            for index in range(1, 37)
+        ],
+    )
+
+    class Repo:
+        async def get_approval_batch_by_id(self, requested, *, for_update=False):
+            return batch
+
+        async def list_approval_batch_members(self, batch_pk):
+            return members
+
+        async def update_approval_batch(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+        async def get_group_by_pk(self, proposal_pk):
+            return groups[proposal_pk]
+
+    return batch_id, batch, groups, _service_with_repo(Repo())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_old_36_member_button_cannot_approve_db_member_37() -> None:
+    batch_id, batch, groups, service = _batch_fixture(
+        state=ApprovalDispatchState.SENT_CURRENT
+    )
+    with pytest.raises(
+        OrderProposalError, match="approval_batch_membership_digest_mismatch"
+    ):
+        await service.consume_approval_batch_nonce(
+            batch_id,
+            callback=_callback(
+                action="ba",
+                digest=batch.membership_digest,
+                subject_short=str(batch_id)[:8],
+            ),
+            chat_id="chat",
+            telegram_user_id="operator",
+            now=NOW,
+        )
+
+    assert batch.approval_nonce_used_at is None
+    assert groups[37].proposal_id is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_exact_36_member_snapshot_processes_only_its_revision() -> None:
+    batch_id, batch, groups, service = _batch_fixture(
+        state=ApprovalDispatchState.SENT_CURRENT,
+        extra_member_revision=2,
+    )
+    _consumed, snapshots = await service.consume_approval_batch_nonce(
+        batch_id,
+        callback=_callback(
+            action="ba",
+            digest=batch.membership_digest,
+            subject_short=str(batch_id)[:8],
+        ),
+        chat_id="chat",
+        telegram_user_id="operator",
+        now=NOW,
+    )
+    assert len(snapshots) == 36
+    assert all(item.proposal_id != groups[37].proposal_id for item in snapshots)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        ApprovalDispatchState.PENDING,
+        ApprovalDispatchState.FAILED,
+        ApprovalDispatchState.PARTIAL_FAILED,
+        ApprovalDispatchState.SENT_SUPERSEDED,
+        ApprovalDispatchState.FAILED_SUPERSEDED,
+    ],
+)
+async def test_unpublished_or_failed_batch_callback_is_blocked(
+    state: ApprovalDispatchState,
+) -> None:
+    batch_id, batch, _groups, service = _batch_fixture(state=state)
+    with pytest.raises(OrderProposalError, match=f"approval_dispatch_{state.value}"):
+        await service.consume_approval_batch_nonce(
+            batch_id,
+            callback=_callback(
+                action="ba",
+                digest=batch.membership_digest,
+                subject_short=str(batch_id)[:8],
+            ),
+            chat_id="chat",
+            telegram_user_id="operator",
+            now=NOW,
+        )
+    assert batch.approval_nonce_used_at is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_frozen_batch_is_excluded_from_open_membership_query() -> None:
+    captured = []
+
+    class Result:
+        @staticmethod
+        def scalar_one_or_none():
+            return None
+
+    class Session:
+        async def execute(self, statement):
+            captured.append(statement)
+            return Result()
+
+    repository = OrderProposalRepository(Session())
+    assert (
+        await repository.get_open_approval_batch(
+            chat_id="chat", now=NOW, for_update=True
+        )
+        is None
+    )
+    statement = str(captured[0])
+    assert "membership_frozen_at IS NULL" in statement
+    assert "approval_dispatch_state" in statement
+    assert "summary_dispatch_state" in statement
+    assert "summary_message_id IS NULL" in statement
+    assert "approval_dispatch_attempt_id IS NULL" in statement
+    assert "membership_digest IS NULL" in statement
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_oversized_batch_card_is_rejected_before_any_http_call() -> None:
+    batch_id = uuid.UUID("66666666-6666-4666-8666-666666666666")
+    binding = DispatchBinding(
+        attempt_id=ATTEMPT_ID,
+        card_kind=ApprovalCardKind.BATCH,
+        membership_revision=1,
+        membership_digest=DIGEST,
+    )
+    batch = SimpleNamespace(
+        batch_id=batch_id,
+        approval_nonce="safe-nonce",
+        expires_at=NOW + timedelta(minutes=5),
+    )
+    proposals = [
+        (
+            SimpleNamespace(
+                proposal_id=uuid.UUID(int=index),
+                symbol=f"{index:02d}-" + ("매우긴종목" * 25),
+                side="buy",
+                market="equity_kr",
+                account_mode="kis_live",
+                broker_account_id=f"account-{index:04d}",
+                order_type="limit",
+            ),
+            [
+                SimpleNamespace(
+                    rung_index=0,
+                    quantity=Decimal("1"),
+                    limit_price=Decimal("100000"),
+                    notional=None,
+                )
+            ],
+        )
+        for index in range(1, 38)
+    ]
+    text, keyboard = build_batch_approval_message(
+        batch=batch, proposals=proposals, binding=binding
+    )
+    assert telegram_text_length(text) > 4096
+    notifier = SimpleNamespace(send_approval_message=AsyncMock())
+
+    publication = await publish_approval_messages(
+        notifier=notifier,
+        messages=ApprovalDispatchMessages(
+            (),
+            text,
+            keyboard,
+            telegram_text_length(text),
+        ),
+        chat_id="chat",
+    )
+
+    assert publication.card_published is False
+    assert publication.failure_code == "approval_payload_too_long"
+    notifier.send_approval_message.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "error_code", "classification"),
+    [
+        (400, 400, TelegramErrorClassification.BAD_REQUEST),
+        (429, 429, TelegramErrorClassification.RATE_LIMITED),
+        (500, 500, TelegramErrorClassification.SERVER_ERROR),
+        (503, 503, TelegramErrorClassification.SERVER_ERROR),
+        (None, None, TelegramErrorClassification.TRANSPORT_ERROR),
+    ],
+)
+async def test_failed_batch_publication_never_becomes_approvable(
+    status: int | None,
+    error_code: int | None,
+    classification: TelegramErrorClassification,
+) -> None:
+    batch_id = uuid.UUID("77777777-7777-4777-8777-777777777777")
+    batch = SimpleNamespace(
+        id=1,
+        batch_id=batch_id,
+        chat_id="chat",
+        approval_nonce="safe-nonce",
+        approval_nonce_used_at=None,
+        expires_at=NOW + timedelta(minutes=5),
+        approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        membership_revision=1,
+        membership_digest=DIGEST,
+        membership_frozen_at=NOW,
+        summary_dispatch_state="sending",
+    )
+
+    class Repo:
+        async def get_approval_batch_by_id(self, requested, *, for_update=False):
+            return batch
+
+        async def update_approval_batch(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+        async def list_approval_batch_members(self, batch_pk):
+            raise AssertionError("failed state must block before membership")
+
+    service = _service_with_repo(Repo())
+    method = TelegramMethodResult.failed(
+        payload_chars=200,
+        failure_code="telegram_transport_error",
+        status_code=status,
+        error_code=error_code,
+        error_classification=classification,
+    )
+    result = await service.finish_approval_batch_dispatch(
+        batch_id,
+        attempt_id=ATTEMPT_ID,
+        publication=ApprovalPublication.failed(
+            payload_chars=200,
+            failure_code="approval_card_dispatch_failed",
+            method_result=method,
+        ),
+        now=NOW,
+    )
+
+    assert result.ok is False
+    assert result.state is ApprovalDispatchState.FAILED
+    assert batch.approval_dispatch_state == ApprovalDispatchState.FAILED.value
+    assert batch.summary_message_id is None
+    with pytest.raises(OrderProposalError, match="approval_dispatch_failed"):
+        await service.consume_approval_batch_nonce(
+            batch_id,
+            callback=_callback(action="ba", subject_short=str(batch_id)[:8]),
+            chat_id="chat",
+            telegram_user_id="operator",
+            now=NOW,
+        )
+    assert batch.approval_nonce_used_at is None
+
+
+def _published(message_id: int) -> ApprovalPublication:
+    return ApprovalPublication.published(
+        payload_chars=100,
+        method_result=TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=100,
+        ),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_nonce_change_during_inflight_send_supersedes_same_attempt_id() -> None:
+    old_digest = _proposal_digest("old-nonce")
+    group = SimpleNamespace(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        superseded_by_proposal_id=None,
+        lifecycle_state="proposed",
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+        approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_membership_revision=1,
+        approval_dispatch_membership_digest=old_digest,
+        approval_dispatch_published_at=None,
+        approval_nonce="old-nonce",
+        approval_nonce_used_at=None,
+        source_asof={},
+    )
+    attempt = SimpleNamespace(
+        attempt_id=ATTEMPT_ID,
+        proposal_pk=1,
+        state=ApprovalDispatchState.PENDING.value,
+        card_kind=ApprovalCardKind.MANUAL.value,
+        membership_revision=1,
+        membership_digest=old_digest,
+    )
+
+    class Repo:
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def get_approval_dispatch_attempt(self, attempt_id, *, for_update=False):
+            return attempt
+
+        async def update_approval_dispatch_attempt(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+        async def update_group(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    service = _service_with_repo(Repo())
+    await service.set_approval_nonce(PROPOSAL_ID, "new-nonce")
+    result = await service.finish_approval_dispatch(
+        PROPOSAL_ID,
+        attempt_id=ATTEMPT_ID,
+        publication=_published(700),
+        chat_id="chat",
+        now=NOW,
+    )
+
+    assert result.state is ApprovalDispatchState.SENT_SUPERSEDED
+    assert result.ok is False
+    assert result.failure_code == "approval_dispatch_superseded"
+    assert attempt.state == ApprovalDispatchState.SENT_SUPERSEDED.value
+    assert group.approval_dispatch_state == ApprovalDispatchState.FAILED.value
+    assert group.approval_nonce == "new-nonce"
+    assert "approval_message_id" not in group.source_asof
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_response_loss_finalizes_failed_and_invalidates_visible_card() -> None:
+    digest = _proposal_digest("safe-nonce")
+    group = SimpleNamespace(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        superseded_by_proposal_id=None,
+        lifecycle_state="proposed",
+        approval_dispatch_attempt_id=ATTEMPT_ID,
+        approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+        approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_membership_revision=1,
+        approval_dispatch_membership_digest=digest,
+        approval_nonce="safe-nonce",
+        approval_nonce_used_at=None,
+        source_asof={},
+    )
+    attempt = SimpleNamespace(
+        attempt_id=ATTEMPT_ID,
+        proposal_pk=1,
+        state=ApprovalDispatchState.PENDING.value,
+        card_kind=ApprovalCardKind.MANUAL.value,
+        membership_revision=1,
+        membership_digest=digest,
+    )
+
+    class Repo:
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def get_approval_dispatch_attempt(self, attempt_id, *, for_update=False):
+            return attempt
+
+        async def update_approval_dispatch_attempt(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+        async def update_group(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    service = _service_with_repo(Repo())
+    method = TelegramMethodResult.failed(
+        payload_chars=100,
+        failure_code="telegram_transport_error",
+        error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
+    )
+    result = await service.finish_approval_dispatch(
+        PROPOSAL_ID,
+        attempt_id=ATTEMPT_ID,
+        publication=ApprovalPublication.failed(
+            payload_chars=100,
+            failure_code="approval_card_dispatch_failed",
+            method_result=method,
+        ),
+        chat_id="chat",
+        now=NOW,
+    )
+
+    assert result.state is ApprovalDispatchState.FAILED
+    assert result.ok is False
+    assert attempt.state == ApprovalDispatchState.FAILED.value
+    assert group.approval_dispatch_state == ApprovalDispatchState.FAILED.value
+    assert group.approval_nonce is None
+    assert "approval_message_id" not in group.source_asof
+    with pytest.raises(OrderProposalError, match="approval_dispatch_failed"):
+        await service.consume_published_proposal_callback(
+            PROPOSAL_ID,
+            callback=_callback(digest=digest),
+            now=NOW,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("new_finishes_first", [False, True])
+async def test_attempt_completion_order_preserves_current_owner_invariants(
+    new_finishes_first: bool,
+) -> None:
+    old_id = uuid.UUID("44444444-4444-4444-8444-444444444444")
+    new_id = uuid.UUID("55555555-5555-4555-8555-555555555555")
+    old_digest = _proposal_digest("old-nonce")
+    new_digest = _proposal_digest("new-nonce", revision=2)
+    group = SimpleNamespace(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        approval_dispatch_attempt_id=new_id,
+        approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+        approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_membership_revision=2,
+        approval_dispatch_membership_digest=new_digest,
+        approval_nonce="new-nonce",
+        source_asof={},
+    )
+    attempts = {
+        old_id: SimpleNamespace(
+            attempt_id=old_id,
+            proposal_pk=1,
+            state=ApprovalDispatchState.PENDING.value,
+            card_kind=ApprovalCardKind.MANUAL.value,
+            membership_revision=1,
+            membership_digest=old_digest,
+        ),
+        new_id: SimpleNamespace(
+            attempt_id=new_id,
+            proposal_pk=1,
+            state=ApprovalDispatchState.PENDING.value,
+            card_kind=ApprovalCardKind.MANUAL.value,
+            membership_revision=2,
+            membership_digest=new_digest,
+        ),
+    }
+
+    class Repo:
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def get_approval_dispatch_attempt(self, attempt_id, *, for_update=False):
+            return attempts[attempt_id]
+
+        async def update_approval_dispatch_attempt(self, attempt, **fields):
+            for key, value in fields.items():
+                setattr(attempt, key, value)
+            return attempt
+
+        async def update_group(self, target, **fields):
+            for key, value in fields.items():
+                setattr(target, key, value)
+            return target
+
+    service = _service_with_repo(Repo())
+    order = (new_id, old_id) if new_finishes_first else (old_id, new_id)
+    results = {}
+    batch_members: list[uuid.UUID] = []
+    for attempt_id in order:
+        results[attempt_id] = await service.finish_approval_dispatch(
+            PROPOSAL_ID,
+            attempt_id=attempt_id,
+            publication=_published(700 if attempt_id == old_id else 800),
+            chat_id="chat",
+            now=NOW,
+        )
+        if results[attempt_id].approvable:
+            batch_members.append(attempt_id)
+
+    assert results[old_id].ok is False
+    assert results[old_id].state is ApprovalDispatchState.SENT_SUPERSEDED
+    assert results[old_id].failure_code == "approval_dispatch_superseded"
+    assert results[new_id].ok is True
+    assert attempts[old_id].state == ApprovalDispatchState.SENT_SUPERSEDED.value
+    assert attempts[new_id].state == ApprovalDispatchState.SENT_CURRENT.value
+    assert group.approval_dispatch_attempt_id == new_id
+    assert group.approval_dispatch_state == ApprovalDispatchState.SENT_CURRENT.value
+    assert group.approval_nonce == "new-nonce"
+    assert group.source_asof["approval_message_id"] == 800
+    assert group.source_asof["approval_message_id"] != 700
+    assert batch_members == [new_id]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stale_failed_attempt_cannot_trigger_current_failure_compensation() -> (
+    None
+):
+    old_id = uuid.UUID("88888888-8888-4888-8888-888888888888")
+    new_id = uuid.UUID("99999999-9999-4999-8999-999999999999")
+    old_digest = _proposal_digest("old-nonce")
+    new_digest = _proposal_digest("new-nonce", revision=2)
+    group = SimpleNamespace(
+        id=1,
+        proposal_id=PROPOSAL_ID,
+        approval_dispatch_attempt_id=new_id,
+        approval_dispatch_state=ApprovalDispatchState.PENDING.value,
+        approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_membership_revision=2,
+        approval_dispatch_membership_digest=new_digest,
+        approval_nonce="new-nonce",
+        source_asof={},
+    )
+    old_attempt = SimpleNamespace(
+        attempt_id=old_id,
+        proposal_pk=1,
+        state=ApprovalDispatchState.PENDING.value,
+        card_kind=ApprovalCardKind.MANUAL.value,
+        membership_revision=1,
+        membership_digest=old_digest,
+    )
+
+    class Repo:
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update=False):
+            return group
+
+        async def get_approval_dispatch_attempt(self, attempt_id, *, for_update=False):
+            return old_attempt
+
+        async def update_approval_dispatch_attempt(self, attempt, **fields):
+            for key, value in fields.items():
+                setattr(attempt, key, value)
+            return attempt
+
+    service = _service_with_repo(Repo())
+    method = TelegramMethodResult.failed(
+        payload_chars=10,
+        failure_code="telegram_transport_error",
+        error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
+    )
+    result = await service.finish_approval_dispatch(
+        PROPOSAL_ID,
+        attempt_id=old_id,
+        publication=ApprovalPublication.failed(
+            payload_chars=10,
+            failure_code="approval_card_dispatch_failed",
+            method_result=method,
+        ),
+        chat_id="chat",
+        now=NOW,
+    )
+
+    assert result.state is ApprovalDispatchState.FAILED_SUPERSEDED
+    assert result.ok is False
+    assert result.failure_code == "approval_dispatch_superseded"
+    assert group.approval_dispatch_attempt_id == new_id
+    assert group.approval_nonce == "new-nonce"
+
+
+class _OrchestrationSession:
+    def __init__(self, service: object) -> None:
+        self.service = service
+        self.commit = AsyncMock()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected_batch_calls"),
+    [
+        (ApprovalDispatchState.SENT_CURRENT, 1),
+        (ApprovalDispatchState.SENT_SUPERSEDED, 0),
+    ],
+)
+async def test_send_orchestration_registers_batch_only_for_current_result(
+    monkeypatch,
+    state: ApprovalDispatchState,
+    expected_batch_calls: int,
+) -> None:
+    group = SimpleNamespace(
+        proposal_id=PROPOSAL_ID,
+        approval_dispatch_membership_revision=None,
+    )
+    first_service = SimpleNamespace(
+        set_approval_nonce=AsyncMock(),
+        get_proposal=AsyncMock(return_value=(group, [])),
+        start_approval_dispatch=AsyncMock(),
+    )
+    result = TelegramDispatchResult(
+        state=state,
+        message_id=700,
+        status_code=200,
+        error_code=None,
+        error_classification=None,
+        payload_chars=4,
+        failure_code=(
+            None
+            if state is ApprovalDispatchState.SENT_CURRENT
+            else "approval_dispatch_superseded"
+        ),
+    )
+    second_service = SimpleNamespace(
+        finish_approval_dispatch=AsyncMock(return_value=result)
+    )
+    sessions = [
+        _OrchestrationSession(first_service),
+        _OrchestrationSession(second_service),
+    ]
+
+    def service_factory():
+        return sessions.pop(0)
+
+    monkeypatch.setattr(
+        dispatch_module, "OrderProposalsService", lambda session: session.service
+    )
+    monkeypatch.setattr(
+        dispatch_module.settings,
+        "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR",
+        "chat",
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "build_approval_dispatch_messages",
+        lambda **_kwargs: ApprovalDispatchMessages(
+            context_messages=(),
+            approval_text="card",
+            inline_keyboard={"inline_keyboard": []},
+            payload_chars=4,
+        ),
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "publish_approval_messages",
+        AsyncMock(return_value=_published(700)),
+    )
+    register = AsyncMock()
+    monkeypatch.setattr(
+        dispatch_module, "_register_and_publish_batch_summary", register
+    )
+
+    returned = await send_proposal_for_approval(
+        PROPOSAL_ID,
+        notifier=SimpleNamespace(),
+        now=NOW,
+        service_factory=service_factory,
+    )
+
+    assert returned is result
+    assert register.await_count == expected_batch_calls
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected_compensation_calls"),
+    [
+        (ApprovalDispatchState.FAILED, 1),
+        (ApprovalDispatchState.PARTIAL_FAILED, 1),
+        (ApprovalDispatchState.SENT_SUPERSEDED, 0),
+        (ApprovalDispatchState.FAILED_SUPERSEDED, 0),
+    ],
+)
+async def test_auto_dispatch_compensates_only_current_failed_result(
+    monkeypatch,
+    state: ApprovalDispatchState,
+    expected_compensation_calls: int,
+) -> None:
+    group = SimpleNamespace(
+        proposal_id=PROPOSAL_ID,
+        market="equity_kr",
+        approval_dispatch_membership_revision=None,
+    )
+    rung = SimpleNamespace(state="pending_approval")
+    first_service = SimpleNamespace(
+        acquire_auto_dispatch_lock=AsyncMock(),
+        get_proposal=AsyncMock(return_value=(group, [rung])),
+        auto_approved_daily_notional=AsyncMock(return_value=Decimal("0")),
+        record_auto_approval=AsyncMock(),
+        set_approval_nonce=AsyncMock(),
+        start_approval_dispatch=AsyncMock(),
+    )
+    result = TelegramDispatchResult(
+        state=state,
+        message_id=700 if state is ApprovalDispatchState.SENT_SUPERSEDED else None,
+        status_code=200 if state is ApprovalDispatchState.SENT_SUPERSEDED else 500,
+        error_code=None,
+        error_classification=None,
+        payload_chars=4,
+        failure_code=(
+            "approval_dispatch_superseded"
+            if state
+            in {
+                ApprovalDispatchState.SENT_SUPERSEDED,
+                ApprovalDispatchState.FAILED_SUPERSEDED,
+            }
+            else "approval_card_dispatch_failed"
+        ),
+    )
+    second_service = SimpleNamespace(
+        acquire_auto_dispatch_lock=AsyncMock(),
+        finish_approval_dispatch=AsyncMock(return_value=result),
+        get_proposal=AsyncMock(return_value=(group, [rung])),
+        record_auto_notification_failure=AsyncMock(),
+    )
+    sessions = [
+        _OrchestrationSession(first_service),
+        _OrchestrationSession(second_service),
+    ]
+
+    def service_factory():
+        return sessions.pop(0)
+
+    monkeypatch.setattr(
+        dispatch_module, "OrderProposalsService", lambda session: session.service
+    )
+    monkeypatch.setattr(dispatch_module.settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        dispatch_module.settings,
+        "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR",
+        "chat",
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "limits_for_market",
+        lambda _market: SimpleNamespace(policy_version="probe"),
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "build_auto_approved_message",
+        lambda **_kwargs: ("card", {"inline_keyboard": []}),
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "publish_approval_messages",
+        AsyncMock(
+            return_value=ApprovalPublication.failed(
+                payload_chars=4,
+                failure_code="approval_card_dispatch_failed",
+            )
+        ),
+    )
+    acquire_veto_locks = AsyncMock()
+    compensate = AsyncMock(return_value=[])
+    monkeypatch.setattr(dispatch_module, "acquire_auto_veto_locks", acquire_veto_locks)
+    monkeypatch.setattr(dispatch_module, "cancel_auto_submitted_rungs", compensate)
+    revalidate = AsyncMock(
+        return_value=[RungOutcome(rung_index=0, result="submitted_acked", detail={})]
+    )
+
+    returned = await dispatch_proposal(
+        PROPOSAL_ID,
+        notifier=SimpleNamespace(),
+        now=NOW,
+        service_factory=service_factory,
+        revalidate_fn=revalidate,
+    )
+
+    assert returned is result
+    assert compensate.await_count == expected_compensation_calls
+    assert acquire_veto_locks.await_count == expected_compensation_calls
+    assert (
+        second_service.record_auto_notification_failure.await_count
+        == expected_compensation_calls
+    )

--- a/tests/services/order_proposals/test_models_smoke.py
+++ b/tests/services/order_proposals/test_models_smoke.py
@@ -1,8 +1,57 @@
+import ast
+import re
+from pathlib import Path
+
 import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 
 from app.models import order_proposals as models
 from app.models.order_proposals import OrderProposal, OrderProposalRung
 from app.services.order_proposals.state_machine import RUNG_STATES
+from tests import _schema_bootstrap as schema_bootstrap
+
+_REPO = Path(__file__).resolve().parents[3]
+_DISPATCH_MIGRATION = _REPO / "alembic/versions/20260723_approval_dispatch_ledger.py"
+
+
+def _migration_application_dml(source: str) -> list[tuple[str, str]]:
+    """Find application-table DML only inside migration operation calls."""
+    tree = ast.parse(source)
+    findings: list[tuple[str, str]] = []
+    pattern = re.compile(
+        r"\b(insert\s+into|update|delete\s+from)\s+([a-z_][a-z0-9_$.\"']*)",
+        re.IGNORECASE,
+    )
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if (
+            isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "op"
+            and node.func.attr == "bulk_insert"
+        ):
+            findings.append(("bulk_insert", "unknown"))
+            continue
+        if (
+            not isinstance(node.func.value, ast.Name)
+            or node.func.value.id != "op"
+            or node.func.attr != "execute"
+            or not node.args
+        ):
+            continue
+        sql_parts = [
+            value.value
+            for value in ast.walk(node.args[0])
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        ]
+        sql = "".join(sql_parts)
+        for match in pattern.finditer(sql):
+            verb = " ".join(match.group(1).lower().split())
+            relation = match.group(2).strip("\"'").lower()
+            if relation.rsplit(".", 1)[-1] != "alembic_version":
+                findings.append((verb, relation))
+    return findings
 
 
 @pytest.mark.unit
@@ -38,6 +87,200 @@ def test_order_proposal_has_action_columns():
 
 
 @pytest.mark.unit
+def test_approval_dispatch_models_are_durable_and_attempt_scoped():
+    proposal = OrderProposal.__table__
+    attempt = models.OrderProposalApprovalDispatchAttempt.__table__
+
+    assert {
+        "approval_dispatch_state",
+        "approval_dispatch_attempt_id",
+        "approval_dispatch_attempted_at",
+        "approval_dispatch_failure_code",
+        "approval_dispatch_payload_chars",
+        "approval_dispatch_card_kind",
+        "approval_dispatch_membership_revision",
+        "approval_dispatch_membership_digest",
+        "approval_dispatch_published_at",
+    } <= set(proposal.columns.keys())
+    assert attempt.schema == "review"
+    assert attempt.name == "order_proposal_approval_dispatch_attempts"
+    assert {
+        "attempt_id",
+        "proposal_pk",
+        "state",
+        "attempted_at",
+        "completed_at",
+        "payload_chars",
+        "context_message_count",
+        "message_id",
+        "status_code",
+        "telegram_error_code",
+        "error_classification",
+        "failure_code",
+        "card_kind",
+        "membership_revision",
+        "membership_digest",
+    } <= set(attempt.columns.keys())
+    assert "telegram_description" not in attempt.columns
+
+
+@pytest.mark.unit
+def test_approval_dispatch_model_constraints_are_closed_and_non_nullable() -> None:
+    proposal = OrderProposal.__table__
+    attempt = models.OrderProposalApprovalDispatchAttempt.__table__
+    batch = models.OrderProposalApprovalBatch.__table__
+    expected_states = set(schema_bootstrap._APPROVAL_DISPATCH_STATES)
+    expected_card_kinds = set(schema_bootstrap._APPROVAL_PROPOSAL_CARD_KINDS)
+
+    def check_values(table, column: str) -> set[str]:
+        constraint = next(
+            constraint
+            for constraint in table.constraints
+            if column in str(getattr(constraint, "sqltext", ""))
+        )
+        return set(re.findall(r"'([^']+)'", str(constraint.sqltext)))
+
+    assert check_values(proposal, "approval_dispatch_state") == expected_states
+    assert check_values(proposal, "approval_dispatch_card_kind") == expected_card_kinds
+    assert check_values(batch, "approval_dispatch_state") == expected_states
+    assert check_values(attempt, "state") == expected_states
+    assert check_values(attempt, "card_kind") == expected_card_kinds
+    assert all(
+        not attempt.columns[column].nullable
+        for column in schema_bootstrap._APPROVAL_ATTEMPT_NOT_NULL_COLUMNS
+    )
+
+
+@pytest.mark.unit
+def test_approval_dispatch_migration_is_additive_and_the_single_head():
+    source = _DISPATCH_MIGRATION.read_text(encoding="utf-8")
+    assert _migration_application_dml(source) == []
+
+    config = Config(str(_REPO / "alembic.ini"))
+    config.set_main_option("script_location", str(_REPO / "alembic"))
+    scripts = ScriptDirectory.from_config(config)
+    assert scripts.get_heads() == ["20260723_approval_dispatch"]
+    revision = scripts.get_revision("20260723_approval_dispatch")
+    assert revision is not None
+    assert revision.down_revision == "20260722_rob1023_widen_runner"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "update   review.order_proposals set lifecycle_state = 'x'",
+        "InSeRt\nINTO review.order_proposal_approval_batches(id) values (1)",
+        "DELETE \n FROM review.order_proposal_approval_dispatch_attempts",
+    ],
+)
+def test_migration_dml_detector_catches_case_and_whitespace_mutations(
+    statement: str,
+) -> None:
+    mutated_source = (
+        f"from alembic import op\ndef upgrade():\n    op.execute({statement!r})\n"
+    )
+    assert _migration_application_dml(mutated_source)
+
+
+def _valid_dispatch_catalog() -> tuple[
+    list[tuple[str, str, str]], list[tuple[str, str, str]]
+]:
+    columns = [
+        (
+            "order_proposal_approval_dispatch_attempts",
+            column,
+            "NO",
+        )
+        for column in schema_bootstrap._APPROVAL_ATTEMPT_NOT_NULL_COLUMNS
+    ]
+    constraints = []
+    for (
+        table_name,
+        constraint_name,
+    ), (
+        column,
+        allowed_values,
+        nullable_allowed,
+    ) in schema_bootstrap._APPROVAL_REQUIRED_CHECKS.items():
+        nullable_sql = f"{column} IS NULL OR " if nullable_allowed else ""
+        values_sql = ",".join(f"'{value}'" for value in sorted(allowed_values))
+        constraints.append(
+            (
+                table_name,
+                constraint_name,
+                f"CHECK ({nullable_sql}{column} IN ({values_sql}))",
+            )
+        )
+    return columns, constraints
+
+
+@pytest.mark.unit
+def test_persistent_bootstrap_catalog_matches_typed_dispatch_contract() -> None:
+    columns, constraints = _valid_dispatch_catalog()
+    assert (
+        schema_bootstrap._approval_dispatch_catalog_errors(
+            columns=columns,
+            constraints=constraints,
+        )
+        == []
+    )
+    bootstrap_sql = "\n".join(schema_bootstrap._DDL_STATEMENTS)
+    for constraint_name in (
+        "order_proposals_approval_dispatch_card_kind",
+        "order_proposal_approval_batches_dispatch_state",
+        "order_proposal_approval_dispatch_attempt_state",
+        "order_proposal_approval_dispatch_attempt_card_kind",
+    ):
+        assert constraint_name in bootstrap_sql
+    for column in schema_bootstrap._APPROVAL_ATTEMPT_NOT_NULL_COLUMNS:
+        assert f"ALTER COLUMN {column} SET NOT NULL" in bootstrap_sql
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "mutation",
+    ["invalid_state", "invalid_card_kind", "nullable_binding"],
+)
+def test_persistent_bootstrap_catalog_rejects_weakened_contract(
+    mutation: str,
+) -> None:
+    columns, constraints = _valid_dispatch_catalog()
+    if mutation == "nullable_binding":
+        columns = [
+            (
+                table,
+                column,
+                ("YES" if column == "membership_digest" else is_nullable),
+            )
+            for table, column, is_nullable in columns
+        ]
+    else:
+        target = (
+            "order_proposal_approval_dispatch_attempt_state"
+            if mutation == "invalid_state"
+            else "order_proposals_approval_dispatch_card_kind"
+        )
+        constraints = [
+            (
+                table,
+                name,
+                (
+                    definition[:-2] + ",'invalid_value'))"
+                    if name == target
+                    else definition
+                ),
+            )
+            for table, name, definition in constraints
+        ]
+
+    assert schema_bootstrap._approval_dispatch_catalog_errors(
+        columns=columns,
+        constraints=constraints,
+    )
+
+
+@pytest.mark.unit
 def test_approval_batch_models_are_durable_and_bound_to_proposals():
     batch = models.OrderProposalApprovalBatch.__table__
     member = models.OrderProposalApprovalBatchMember.__table__
@@ -58,12 +301,23 @@ def test_approval_batch_models_are_durable_and_bound_to_proposals():
         "summary_message_id",
         "summary_dispatch_state",
         "summary_dispatch_lease_until",
+        "approval_dispatch_state",
+        "approval_dispatch_attempt_id",
+        "approval_dispatch_published_at",
+        "membership_revision",
+        "membership_digest",
+        "membership_frozen_at",
     } <= set(batch.columns.keys())
     assert {
         "batch_pk",
         "proposal_pk",
         "approval_nonce_snapshot",
         "approval_message_id",
+        "membership_revision",
+        "approval_dispatch_attempt_id_snapshot",
+        "approval_membership_revision_snapshot",
+        "approval_membership_digest_snapshot",
+        "approval_card_kind_snapshot",
         "result",
         "result_detail",
         "processed_at",

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -13,6 +13,13 @@ from app.core.timezone import KST
 from app.models.review import TossLiveOrderLedger
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals import service as service_module
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalPublication,
+    CallbackEnvelope,
+    DispatchBinding,
+    build_proposal_dispatch_binding,
+)
 from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalInvalidStateTransition,
@@ -20,6 +27,74 @@ from app.services.order_proposals.errors import (
     OrderProposalUnsupportedTargetAction,
 )
 from app.services.order_proposals.service import ExpirySweepResult, RungInput
+from app.telegram_contract import TelegramMethodResult
+
+
+def _successful_publication(message_id: int) -> ApprovalPublication:
+    return ApprovalPublication.published(
+        payload_chars=100,
+        method_result=TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=100,
+        ),
+    )
+
+
+async def _publish_fixture_card(
+    service: OrderProposalsService,
+    group,
+    *,
+    nonce: str,
+    card_kind: ApprovalCardKind = ApprovalCardKind.MANUAL,
+    now: datetime | None = None,
+    message_id: int = 4242,
+) -> DispatchBinding:
+    published_at = now or datetime.now(UTC)
+    attempt_id = uuid.uuid4()
+    binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=nonce,
+        attempt_id=attempt_id,
+        card_kind=card_kind,
+        current_membership_revision=group.approval_dispatch_membership_revision,
+    )
+    await service.start_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        binding=binding,
+        now=published_at,
+        payload_chars=100,
+        context_message_count=0,
+    )
+    result = await service.finish_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        publication=_successful_publication(message_id),
+        chat_id="fixture-chat",
+        now=published_at,
+    )
+    assert result.ok
+    return binding
+
+
+def _batch_callback(
+    batch,
+    *,
+    nonce: str | None = None,
+    attempt_id: uuid.UUID | None = None,
+) -> CallbackEnvelope:
+    return CallbackEnvelope(
+        action="ba",
+        subject_short=str(batch.batch_id)[:8],
+        attempt_id=attempt_id or batch.approval_dispatch_attempt_id,
+        membership_revision=batch.membership_revision,
+        membership_digest=batch.membership_digest,
+        nonce=nonce or batch.approval_nonce,
+    )
 
 
 def _target_snapshot_payload(**overrides):
@@ -1009,6 +1084,12 @@ async def test_approval_nonce_mismatch_and_reset(db_session):
 
     result = await service.set_approval_nonce(group.proposal_id, "nonce-1")
     assert result is None
+    await _publish_fixture_card(
+        service,
+        group,
+        nonce="nonce-1",
+        now=now - timedelta(seconds=1),
+    )
     await service.consume_approval_nonce(group.proposal_id, "nonce-1", now=now)
 
     with pytest.raises(OrderProposalError, match="^nonce_mismatch$"):
@@ -1018,6 +1099,7 @@ async def test_approval_nonce_mismatch_and_reset(db_session):
     refreshed, _ = await service.get_proposal(group.proposal_id)
     assert refreshed.approval_nonce == "nonce-2"
     assert refreshed.approval_nonce_used_at is None
+    assert refreshed.approval_dispatch_state == "failed"
 
 
 @pytest.mark.asyncio
@@ -1025,6 +1107,12 @@ async def test_approval_nonce_replay_blocked(db_session):
     service, group = await _create_single_rung(db_session)
     now = datetime(2026, 7, 10, 9, 1, tzinfo=UTC)
     await service.set_approval_nonce(group.proposal_id, "nonce-1")
+    await _publish_fixture_card(
+        service,
+        group,
+        nonce="nonce-1",
+        now=now - timedelta(seconds=1),
+    )
     await db_session.commit()
 
     consumed = await service.consume_approval_nonce(
@@ -2264,6 +2352,7 @@ async def _create_batch_candidate(
         valid_until=valid_until,
     )
     await service.set_approval_nonce(group.proposal_id, nonce)
+    await _publish_fixture_card(service, group, nonce=nonce)
     await db_session.commit()
     return group
 
@@ -2300,9 +2389,14 @@ async def test_approval_batch_registration_groups_same_chat_and_window(db_sessio
     assert one.member_count == 1 and one.summary_action == "none"
     assert two.member_count == 2 and two.summary_action == "send"
 
-    await service.record_approval_batch_summary(
-        two.batch.batch_id, message_id=2001, now=now + timedelta(minutes=1)
+    assert two.binding is not None
+    finalized = await service.finish_approval_batch_dispatch(
+        two.batch.batch_id,
+        attempt_id=two.binding.attempt_id,
+        publication=_successful_publication(2001),
+        now=now + timedelta(minutes=1),
     )
+    assert finalized.ok
     three = await service.register_approval_batch_member(
         third.proposal_id,
         chat_id=chat_id,
@@ -2310,8 +2404,8 @@ async def test_approval_batch_registration_groups_same_chat_and_window(db_sessio
         now=now + timedelta(minutes=2),
     )
     assert three is not None
-    assert three.batch.batch_id == one.batch.batch_id
-    assert three.member_count == 3 and three.summary_action == "edit"
+    assert three.batch.batch_id != one.batch.batch_id
+    assert three.member_count == 1 and three.summary_action == "none"
 
 
 @pytest.mark.asyncio
@@ -2513,39 +2607,83 @@ async def test_approval_batch_nonce_rejects_wrong_chat_nonce_and_too_small(
 ):
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
     chat_id = f"batch-{uuid.uuid4().hex}"
-    group = await _create_batch_candidate(
-        db_session, symbol="AAPL", nonce="validation-member"
+    first = await _create_batch_candidate(
+        db_session, symbol="AAPL", nonce="validation-member-1"
+    )
+    second = await _create_batch_candidate(
+        db_session, symbol="MSFT", nonce="validation-member-2"
     )
     service = OrderProposalsService(db_session)
-    registration = await service.register_approval_batch_member(
-        group.proposal_id,
+    await service.register_approval_batch_member(
+        first.proposal_id,
         chat_id=chat_id,
         approval_message_id=1301,
         now=now,
     )
+    registration = await service.register_approval_batch_member(
+        second.proposal_id,
+        chat_id=chat_id,
+        approval_message_id=1302,
+        now=now + timedelta(seconds=1),
+    )
+    assert registration is not None and registration.binding is not None
+    await service.finish_approval_batch_dispatch(
+        registration.batch.batch_id,
+        attempt_id=registration.binding.attempt_id,
+        publication=_successful_publication(2301),
+        now=now + timedelta(seconds=2),
+    )
     await db_session.commit()
-    assert registration is not None
     batch_id = registration.batch.batch_id
-    batch_nonce = registration.batch.approval_nonce
-
-    for expected, supplied_chat, supplied_nonce in (
+    for expected, supplied_chat, callback in (
         (
             "approval_batch_chat_mismatch",
             "wrong-chat",
-            batch_nonce,
+            _batch_callback(registration.batch),
         ),
-        ("approval_batch_nonce_mismatch", chat_id, "wrong-nonce"),
-        ("approval_batch_too_small", chat_id, batch_nonce),
+        (
+            "nonce_mismatch",
+            chat_id,
+            _batch_callback(registration.batch, nonce="wrong-nonce"),
+        ),
     ):
         with pytest.raises(OrderProposalError, match=expected):
             await service.consume_approval_batch_nonce(
                 batch_id,
-                supplied_nonce,
+                callback=callback,
                 chat_id=supplied_chat,
                 telegram_user_id="777",
                 now=now + timedelta(minutes=1),
             )
         await db_session.rollback()
+
+    singleton_chat = f"batch-{uuid.uuid4().hex}"
+    singleton = await _create_batch_candidate(
+        db_session, symbol="NVDA", nonce="unpublished-member"
+    )
+    staged = await service.register_approval_batch_member(
+        singleton.proposal_id,
+        chat_id=singleton_chat,
+        approval_message_id=1303,
+        now=now,
+    )
+    assert staged is not None and staged.binding is None
+    await db_session.commit()
+    with pytest.raises(OrderProposalError, match="approval_dispatch_pending"):
+        await service.consume_approval_batch_nonce(
+            staged.batch.batch_id,
+            callback=CallbackEnvelope(
+                action="ba",
+                subject_short=str(staged.batch.batch_id)[:8],
+                attempt_id=uuid.uuid4(),
+                membership_revision=staged.batch.membership_revision,
+                membership_digest="AbCdEf0123_-",
+                nonce=staged.batch.approval_nonce,
+            ),
+            chat_id=singleton_chat,
+            telegram_user_id="777",
+            now=now + timedelta(minutes=1),
+        )
 
 
 @pytest.mark.asyncio
@@ -2559,22 +2697,30 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
         db_session, symbol="MSFT", nonce="consume-member-2"
     )
     service = OrderProposalsService(db_session)
-    registration = await service.register_approval_batch_member(
+    await service.register_approval_batch_member(
         first.proposal_id,
         chat_id=chat_id,
         approval_message_id=1001,
         now=now,
     )
-    await service.register_approval_batch_member(
+    registration = await service.register_approval_batch_member(
         second.proposal_id,
         chat_id=chat_id,
         approval_message_id=1002,
         now=now + timedelta(minutes=1),
     )
-    assert registration is not None
+    assert registration is not None and registration.binding is not None
+    await service.finish_approval_batch_dispatch(
+        registration.batch.batch_id,
+        attempt_id=registration.binding.attempt_id,
+        publication=_successful_publication(2001),
+        now=now + timedelta(minutes=1),
+    )
+    await db_session.commit()
+    callback = _batch_callback(registration.batch)
     batch, members = await service.consume_approval_batch_nonce(
         registration.batch.batch_id,
-        registration.batch.approval_nonce,
+        callback=callback,
         chat_id=chat_id,
         telegram_user_id="777",
         now=now + timedelta(minutes=2),
@@ -2586,10 +2732,10 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
         second.proposal_id,
     ]
 
-    with pytest.raises(OrderProposalError, match="approval_batch_nonce_replay"):
+    with pytest.raises(OrderProposalError, match="nonce_replay"):
         await service.consume_approval_batch_nonce(
             batch.batch_id,
-            batch.approval_nonce,
+            callback=callback,
             chat_id=chat_id,
             telegram_user_id="777",
             now=now + timedelta(minutes=3),
@@ -2608,26 +2754,33 @@ async def test_approval_batch_nonce_expires_without_consuming_members(db_session
         db_session, symbol="MSFT", nonce="expiry-member-2"
     )
     service = OrderProposalsService(db_session)
-    registration = await service.register_approval_batch_member(
+    await service.register_approval_batch_member(
         first.proposal_id,
         chat_id=chat_id,
         approval_message_id=1001,
         now=now,
     )
-    await service.register_approval_batch_member(
+    registration = await service.register_approval_batch_member(
         second.proposal_id,
         chat_id=chat_id,
         approval_message_id=1002,
         now=now + timedelta(minutes=1),
     )
-    assert registration is not None
+    assert registration is not None and registration.binding is not None
+    await service.finish_approval_batch_dispatch(
+        registration.batch.batch_id,
+        attempt_id=registration.binding.attempt_id,
+        publication=_successful_publication(2001),
+        now=now + timedelta(minutes=1),
+    )
+    await db_session.commit()
     first_id = first.proposal_id
     second_id = second.proposal_id
 
     with pytest.raises(OrderProposalError, match="approval_batch_expired"):
         await service.consume_approval_batch_nonce(
             registration.batch.batch_id,
-            registration.batch.approval_nonce,
+            callback=_batch_callback(registration.batch),
             chat_id=chat_id,
             telegram_user_id="777",
             now=registration.batch.expires_at,

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import hashlib
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -15,6 +16,12 @@ from app.mcp_server.caller_identity import caller_agent_id_var, get_caller_agent
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals import approval_message as approval_messages
 from app.services.order_proposals.approval_message import parse_callback_data
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalPublication,
+    DispatchBinding,
+    build_proposal_dispatch_binding,
+)
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
 from app.services.order_proposals.target_order import TargetOrderSnapshot
@@ -23,6 +30,7 @@ from app.services.order_proposals.telegram_callback import (
     _resolve_proposal_id,
     handle_callback_update,
 )
+from app.telegram_contract import TelegramMethodResult, telegram_text_length
 
 CHAT_ID = 42
 USER_ID = 777
@@ -30,15 +38,24 @@ USER_ID = 777
 
 class _FakeNotifier:
     def __init__(self) -> None:
-        self.sent_messages: list[tuple[str, dict, str]] = []
+        self.sent_messages: list[tuple[str, dict | None, str]] = []
         self.answered: list[tuple[str, str | None]] = []
         self.edited: list[tuple[str, int, str, dict | None]] = []
         self._next_message_id = 9000
 
-    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
         self._next_message_id += 1
         self.sent_messages.append((text, inline_keyboard, chat_id))
-        return self._next_message_id
+        return TelegramMethodResult(
+            ok=True,
+            message_id=self._next_message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=telegram_text_length(text),
+        )
 
     async def answer_callback(self, callback_query_id, text=None):
         self.answered.append((callback_query_id, text))
@@ -46,7 +63,14 @@ class _FakeNotifier:
 
     async def edit_message(self, chat_id, message_id, text, reply_markup=None):
         self.edited.append((chat_id, message_id, text, reply_markup))
-        return True
+        return TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=telegram_text_length(text),
+        )
 
 
 class _EventNotifier(_FakeNotifier):
@@ -82,6 +106,81 @@ def _make_update(*, data, chat_id=CHAT_ID, user_id=USER_ID, callback_id="cbq-1")
     }
 
 
+def _successful_publication(message_id: int) -> ApprovalPublication:
+    return ApprovalPublication.published(
+        payload_chars=100,
+        method_result=TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=100,
+        ),
+    )
+
+
+def _fixture_nonce(label: str) -> str:
+    """Use the production 11-character nonce shape for descriptive fixtures."""
+    if len(label) <= 11:
+        return label
+    return hashlib.sha256(label.encode()).hexdigest()[:11]
+
+
+async def _publish_fixture_card(
+    service: OrderProposalsService,
+    group,
+    *,
+    nonce: str,
+    card_kind: ApprovalCardKind,
+    message_id: int = 555,
+) -> DispatchBinding:
+    """Stage and finalize the same immutable card shape production publishes."""
+    nonce = _fixture_nonce(nonce)
+    if group.approval_nonce != nonce:
+        await service.set_approval_nonce(group.proposal_id, nonce)
+    attempt_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=nonce,
+        attempt_id=attempt_id,
+        card_kind=card_kind,
+        current_membership_revision=group.approval_dispatch_membership_revision,
+    )
+    await service.start_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        binding=binding,
+        now=now,
+        payload_chars=100,
+        context_message_count=0,
+    )
+    result = await service.finish_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        publication=_successful_publication(message_id),
+        chat_id=str(CHAT_ID),
+        now=now,
+    )
+    assert result.ok
+    return binding
+
+
+def _proposal_callback_data(group, *, action: str, nonce: str | None = None) -> str:
+    return approval_messages.build_callback_data(
+        action=action,
+        proposal_id=group.proposal_id,
+        nonce=_fixture_nonce(nonce) if nonce is not None else group.approval_nonce,
+        binding=DispatchBinding(
+            attempt_id=group.approval_dispatch_attempt_id,
+            card_kind=ApprovalCardKind(group.approval_dispatch_card_kind),
+            membership_revision=group.approval_dispatch_membership_revision,
+            membership_digest=group.approval_dispatch_membership_digest,
+        ),
+    )
+
+
 async def _seed_proposal(db_session, *, nonce="nonce-abc123", symbol="A", rungs=1):
     service = OrderProposalsService(db_session)
     rung_inputs = [
@@ -97,6 +196,12 @@ async def _seed_proposal(db_session, *, nonce="nonce-abc123", symbol="A", rungs=
         rungs=rung_inputs,
     )
     await service.set_approval_nonce(group.proposal_id, nonce)
+    await _publish_fixture_card(
+        service,
+        group,
+        nonce=nonce,
+        card_kind=ApprovalCardKind.MANUAL,
+    )
     await db_session.commit()
     return group
 
@@ -134,6 +239,12 @@ async def _seed_auto_resting(db_session, *, nonce="veto-nonce"):
         now=now,
     )
     await service.set_approval_nonce(group.proposal_id, nonce)
+    await _publish_fixture_card(
+        service,
+        group,
+        nonce=nonce,
+        card_kind=ApprovalCardKind.AUTO_VETO,
+    )
     await db_session.commit()
     return group
 
@@ -177,6 +288,12 @@ async def _seed_loss_cut_proposal(
         retrospective_id=42,
     )
     await service.set_approval_nonce(group.proposal_id, nonce)
+    await _publish_fixture_card(
+        service,
+        group,
+        nonce=nonce,
+        card_kind=ApprovalCardKind.MANUAL,
+    )
     await db_session.commit()
     return group
 
@@ -230,10 +347,20 @@ async def _seed_approval_batch(db_session, monkeypatch, *, member_count=2, rungs
         )
     await db_session.commit()
     assert registration is not None
+    assert registration.binding is not None
     batch = registration.batch
+    dispatch_result = await service.finish_approval_batch_dispatch(
+        batch.batch_id,
+        attempt_id=registration.binding.attempt_id,
+        publication=_successful_publication(7999),
+        now=now + timedelta(seconds=member_count),
+    )
+    assert dispatch_result.ok
+    await db_session.commit()
     data = approval_messages.build_batch_callback_data(
         batch_id=batch.batch_id,
         nonce=batch.approval_nonce,
+        binding=registration.binding,
     )
     return chat_id, now, groups, batch, data
 
@@ -286,7 +413,9 @@ async def test_batch_approve_consumes_each_member_nonce_and_rejects_replay(
 
 
 @pytest.mark.asyncio
-async def test_expired_batch_callback_removes_summary_button(monkeypatch, db_session):
+async def test_expired_batch_callback_has_no_preflight_external_effect(
+    monkeypatch, db_session
+):
     chat_id, _now, _groups, batch, data = await _seed_approval_batch(
         db_session, monkeypatch
     )
@@ -301,11 +430,8 @@ async def test_expired_batch_callback_removes_summary_button(monkeypatch, db_ses
     )
 
     assert result == {"handled": False, "reason": "approval_batch_expired"}
-    assert notifier.edited[-1][1:] == (
-        555,
-        "⌛ 일괄 승인 만료",
-        {"inline_keyboard": []},
-    )
+    assert notifier.answered == []
+    assert notifier.edited == []
 
 
 @pytest.mark.asyncio
@@ -580,14 +706,18 @@ async def test_auto_veto_cancels_broker_and_rung_once(monkeypatch, db_session):
             observed_at=kwargs["now"].isoformat(),
         )
 
-    update = _make_update(data=f"vc:{str(group.proposal_id)[:8]}:veto-nonce")
+    update = _make_update(
+        data=_proposal_callback_data(group, action="vc", nonce="veto-nonce")
+    )
     wrong_action = await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:veto-nonce"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="veto-nonce")
+        ),
         now=datetime.now(UTC),
         service_factory=_session_factory(db_session),
         notifier=notifier,
     )
-    assert wrong_action["reason"] == "auto_veto_nonce_requires_vc"
+    assert wrong_action["reason"] == "approval_card_action_mismatch"
 
     result = await handle_callback_update(
         update,
@@ -646,7 +776,9 @@ async def test_auto_veto_cancel_failure_that_is_filled_edits_filled(
         )
 
     result = await handle_callback_update(
-        _make_update(data=f"vc:{str(group.proposal_id)[:8]}:veto-nonce"),
+        _make_update(
+            data=_proposal_callback_data(group, action="vc", nonce="veto-nonce")
+        ),
         now=datetime.now(UTC),
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -677,7 +809,9 @@ async def test_expired_approve_never_revalidates(monkeypatch, db_session):
 
     notifier = _FakeNotifier()
     result = await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:expired-nonce"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="expired-nonce")
+        ),
         now=datetime.now(UTC),
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -707,7 +841,7 @@ async def test_chat_not_in_allowlist_rejected(monkeypatch, db_session):
     # allowlist empty -> any chat rejected; assert no revalidation invoked.
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "")
     group = await _seed_proposal(db_session)
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-abc123"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-abc123")
     notifier = _FakeNotifier()
 
     revalidate_calls = []
@@ -726,7 +860,7 @@ async def test_chat_not_in_allowlist_rejected(monkeypatch, db_session):
 
     assert result == {"handled": False, "reason": "chat_not_allowed"}
     assert revalidate_calls == []
-    assert notifier.answered == [("cbq-1", "처리 중")]
+    assert notifier.answered == []
     assert notifier.edited == []
 
 
@@ -737,7 +871,7 @@ async def test_approve_happy_path_submits_and_edits(monkeypatch, db_session):
     # nonce consumed, approved_by_telegram_user_id recorded.
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-happy1")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-happy1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-happy1")
     notifier = _FakeNotifier()
 
     async def fake_revalidate(*, service, proposal_id, now):
@@ -838,6 +972,12 @@ async def test_toss_live_cancel_approve_click_consumes_nonce_before_broker_cance
         rungs=[RungInput(0, "sell", Decimal("10"), Decimal("70000"), None)],
     )
     await service.set_approval_nonce(group.proposal_id, "ac3-cancel-nonce")
+    await _publish_fixture_card(
+        service,
+        group,
+        nonce="ac3-cancel-nonce",
+        card_kind=ApprovalCardKind.MANUAL,
+    )
     await db_session.commit()
 
     toss_orders = iter(
@@ -869,7 +1009,7 @@ async def test_toss_live_cancel_approve_click_consumes_nonce_before_broker_cance
     )
 
     notifier = _FakeNotifier()
-    data = f"op:{str(group.proposal_id)[:8]}:ac3-cancel-nonce"
+    data = _proposal_callback_data(group, action="op", nonce="ac3-cancel-nonce")
 
     # Before the nonce is consumed, the broker must not have been touched.
     assert cancel_calls == []
@@ -951,6 +1091,12 @@ async def test_toss_live_replace_approve_click_opposite_pending_blocks_before_ca
         rungs=[RungInput(0, "sell", Decimal("10"), Decimal("71000"), None)],
     )
     await service.set_approval_nonce(group.proposal_id, "ac3-replace-nonce")
+    await _publish_fixture_card(
+        service,
+        group,
+        nonce="ac3-replace-nonce",
+        card_kind=ApprovalCardKind.MANUAL,
+    )
     await db_session.commit()
 
     class FakeTossClient:
@@ -995,7 +1141,9 @@ async def test_toss_live_replace_approve_click_opposite_pending_blocks_before_ca
 
     notifier = _FakeNotifier()
     result = await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:ac3-replace-nonce"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="ac3-replace-nonce")
+        ),
         now=datetime.now(UTC),
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1030,6 +1178,12 @@ async def test_superseded_old_button_is_explicitly_blocked_and_replacement_appro
         now=datetime(2026, 7, 14, 1, 20, tzinfo=UTC),
     )
     await service.set_approval_nonce(replacement.proposal_id, "new-button-nonce")
+    await _publish_fixture_card(
+        service,
+        replacement,
+        nonce="new-button-nonce",
+        card_kind=ApprovalCardKind.MANUAL,
+    )
     await db_session.commit()
     revalidated = []
 
@@ -1039,7 +1193,9 @@ async def test_superseded_old_button_is_explicitly_blocked_and_replacement_appro
 
     notifier = _FakeNotifier()
     old_result = await handle_callback_update(
-        _make_update(data=f"op:{str(old.proposal_id)[:8]}:old-button-nonce"),
+        _make_update(
+            data=_proposal_callback_data(old, action="op", nonce="old-button-nonce")
+        ),
         now=datetime(2026, 7, 14, 1, 21, tzinfo=UTC),
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1047,7 +1203,9 @@ async def test_superseded_old_button_is_explicitly_blocked_and_replacement_appro
     )
     new_result = await handle_callback_update(
         _make_update(
-            data=f"op:{str(replacement.proposal_id)[:8]}:new-button-nonce",
+            data=_proposal_callback_data(
+                replacement, action="op", nonce="new-button-nonce"
+            ),
             callback_id="cbq-new",
         ),
         now=datetime(2026, 7, 14, 1, 22, tzinfo=UTC),
@@ -1075,7 +1233,9 @@ async def test_loss_cut_second_click_is_blocked_when_superseded(
         return [RungOutcome(0, "submitted_resting", {})]
 
     first = await handle_callback_update(
-        _make_update(data=f"op:{str(old.proposal_id)[:8]}:loss-cut-first"),
+        _make_update(
+            data=_proposal_callback_data(old, action="op", nonce="loss-cut-first")
+        ),
         now=datetime(2026, 7, 14, 1, 25, tzinfo=UTC),
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1130,7 +1290,9 @@ async def test_loss_cut_requires_second_click_before_submit(monkeypatch, db_sess
 
     issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
     first = await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="loss-cut-first")
+        ),
         now=issued,
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1143,13 +1305,14 @@ async def test_loss_cut_requires_second_click_before_submit(monkeypatch, db_sess
     text, keyboard = notifier.edited[-1][2], notifier.edited[-1][3]
     assert "손절 확인" in text
     callback_data = keyboard["inline_keyboard"][0][0]["callback_data"]
-    action, _short, second_nonce = parse_callback_data(callback_data)
-    assert action == "lc"
+    parsed = parse_callback_data(callback_data)
+    second_nonce = parsed.nonce
+    assert parsed.action == "lc"
     service = OrderProposalsService(db_session)
     refreshed, _ = await service.get_proposal(group.proposal_id)
     audit = refreshed.source_asof["loss_cut_confirmation"]
     assert audit["first_click"]["telegram_user_id"] == str(USER_ID)
-    assert audit["first_click"]["nonce"] == "loss-cut-first"
+    assert audit["first_click"]["nonce"] == _fixture_nonce("loss-cut-first")
     assert audit["rungs"] == [{"rung_index": 0, "approval_revision": 0}]
 
     second = await handle_callback_update(
@@ -1176,7 +1339,9 @@ async def test_loss_cut_second_nonce_replay_is_rejected(monkeypatch, db_session)
     notifier = _FakeNotifier()
 
     first = await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="loss-cut-first")
+        ),
         now=datetime(2026, 7, 13, 10, 0, tzinfo=UTC),
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1213,7 +1378,9 @@ async def test_loss_cut_second_nonce_expires_after_90_seconds(monkeypatch, db_se
     notifier = _FakeNotifier()
     issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
     await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="loss-cut-first")
+        ),
         now=issued,
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1243,7 +1410,9 @@ async def test_loss_cut_second_nonce_rejects_changed_rung_revision(
     notifier = _FakeNotifier()
     issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
     await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="loss-cut-first")
+        ),
         now=issued,
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1287,7 +1456,9 @@ async def test_loss_cut_second_click_revalidation_blocks_stale_retro_or_slip(
     notifier = _FakeNotifier()
     issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
     await handle_callback_update(
-        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="loss-cut-first")
+        ),
         now=issued,
         service_factory=_session_factory(db_session),
         notifier=notifier,
@@ -1337,7 +1508,7 @@ async def test_approve_acquires_target_lock_before_revalidation(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-target-lock")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-target-lock"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-target-lock")
     events: list[str] = []
 
     async def fake_target_lock(self, proposal):
@@ -1372,7 +1543,7 @@ async def test_approve_injects_configured_submit_identity(monkeypatch, db_sessio
         settings, "ORDER_PROPOSALS_SUBMIT_AGENT_ID", "  proposal-agent  "
     )
     group = await _seed_proposal(db_session, nonce="nonce-identity")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-identity"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-identity")
 
     async def fake_revalidate(*, service, proposal_id, now):
         assert get_caller_agent_id() == "proposal-agent"
@@ -1398,7 +1569,7 @@ async def test_approve_empty_submit_identity_masks_and_restores_outer_identity(
     _allow_chat(monkeypatch)
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_SUBMIT_AGENT_ID", "   ")
     group = await _seed_proposal(db_session, nonce="nonce-empty-identity")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-empty-identity"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-empty-identity")
 
     async def fake_revalidate(*, service, proposal_id, now):
         assert get_caller_agent_id() is None
@@ -1426,7 +1597,7 @@ async def test_approve_answers_before_order_processing_and_final_edit(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-answer-first")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-answer-first"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-answer-first")
     events: list[str] = []
     notifier = _EventNotifier(events)
 
@@ -1448,7 +1619,7 @@ async def test_approve_answers_before_order_processing_and_final_edit(
     )
 
     assert result["reason"] == "approved"
-    assert events == ["answer", "db", "order", "edit"]
+    assert events == ["db", "answer", "order", "edit"]
     assert notifier.answered == [("cbq-1", "처리 중")]
 
 
@@ -1456,7 +1627,7 @@ async def test_approve_answers_before_order_processing_and_final_edit(
 async def test_cancelled_approve_commits_before_telegram_edit(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-cancelled")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-cancelled"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-cancelled")
     events: list[str] = []
     notifier = _EventNotifier(events)
     original_commit = db_session.commit
@@ -1486,7 +1657,7 @@ async def test_cancelled_approve_commits_before_telegram_edit(monkeypatch, db_se
 
     assert result["reason"] == "approved"
     assert result["results"] == ["cancelled"]
-    assert events == ["answer", "db", "order", "commit", "edit"]
+    assert events == ["db", "answer", "order", "commit", "edit"]
     assert "취소 확인" in notifier.edited[0][2]
 
 
@@ -1494,7 +1665,7 @@ async def test_cancelled_approve_commits_before_telegram_edit(monkeypatch, db_se
 async def test_order_failure_final_edit_includes_reason(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-order-failure")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-order-failure"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-order-failure")
     notifier = _FakeNotifier()
 
     async def fake_revalidate(*, service, proposal_id, now):
@@ -1518,7 +1689,7 @@ async def test_replayed_nonce_does_not_resubmit(monkeypatch, db_session):
     # second identical callback -> nonce_replay -> no second revalidate call.
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-replay1")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-replay1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-replay1")
     notifier = _FakeNotifier()
 
     call_count = 0
@@ -1555,7 +1726,7 @@ async def test_replayed_nonce_does_not_resubmit(monkeypatch, db_session):
 async def test_nonce_mismatch_rejected(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-real")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-wrong1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-wrong1")
     notifier = _FakeNotifier()
 
     async def fake_revalidate(**kwargs):
@@ -1571,7 +1742,7 @@ async def test_nonce_mismatch_rejected(monkeypatch, db_session):
 
     assert result["handled"] is False
     assert result["reason"] == "nonce_mismatch"
-    assert notifier.answered
+    assert notifier.answered == []
 
 
 @pytest.mark.asyncio
@@ -1580,7 +1751,7 @@ async def test_needs_reconfirm_sends_new_diff_message(monkeypatch, db_session):
     # (fresh nonce) is sent; original edited to "재확인 필요".
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-recon1")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-recon1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-recon1")
     notifier = _FakeNotifier()
 
     diff = {
@@ -1611,14 +1782,14 @@ async def test_needs_reconfirm_sends_new_diff_message(monkeypatch, db_session):
     assert sent_chat_id == str(CHAT_ID)
     assert "재확인 변경사항" in new_text
     new_callback_data = new_keyboard["inline_keyboard"][0][0]["callback_data"]
-    new_action, new_short, new_nonce = parse_callback_data(new_callback_data)
-    assert new_action == "op"
-    assert new_short == str(group.proposal_id)[:8]
-    assert new_nonce != "nonce-recon1"
+    parsed = parse_callback_data(new_callback_data)
+    assert parsed.action == "op"
+    assert parsed.subject_short == str(group.proposal_id)[:8]
+    assert parsed.nonce != _fixture_nonce("nonce-recon1")
 
     service = OrderProposalsService(db_session)
     refreshed, _rungs = await service.get_proposal(group.proposal_id)
-    assert refreshed.approval_nonce == new_nonce
+    assert refreshed.approval_nonce == parsed.nonce
     assert refreshed.approved_by_telegram_user_id == str(USER_ID)
 
 
@@ -1628,7 +1799,7 @@ async def test_buying_power_shortfall_edits_failure_and_sends_retry_button(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-buying-power")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-buying-power"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-buying-power")
     notifier = _FakeNotifier()
     detail = {
         "reason": "insufficient_buying_power",
@@ -1658,10 +1829,10 @@ async def test_buying_power_shortfall_edits_failure_and_sends_retry_button(
     assert expected in new_text
     approve = new_keyboard["inline_keyboard"][0][0]
     assert approve["text"] == "✅ 승인"
-    action, proposal_short, nonce = parse_callback_data(approve["callback_data"])
-    assert action == "op"
-    assert proposal_short == str(group.proposal_id)[:8]
-    assert nonce != "nonce-buying-power"
+    parsed = parse_callback_data(approve["callback_data"])
+    assert parsed.action == "op"
+    assert parsed.subject_short == str(group.proposal_id)[:8]
+    assert parsed.nonce != _fixture_nonce("nonce-buying-power")
     _, rungs = await OrderProposalsService(db_session).get_proposal(group.proposal_id)
     assert rungs[0].state == "needs_reconfirm"
 
@@ -1672,7 +1843,7 @@ async def test_buying_power_multi_rung_reconfirm_shows_every_shortfall(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-buying-power-multi", rungs=2)
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-buying-power-multi"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-buying-power-multi")
     notifier = _FakeNotifier()
     details = [
         {
@@ -1717,7 +1888,7 @@ async def test_buying_power_multi_rung_reconfirm_shows_every_shortfall(
 async def test_deny_transitions_all_rungs_to_rejected(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-deny1", rungs=2)
-    data = f"dn:{str(group.proposal_id)[:8]}:nonce-deny1"
+    data = _proposal_callback_data(group, action="dn", nonce="nonce-deny1")
     notifier = _FakeNotifier()
 
     async def fake_revalidate(**kwargs):
@@ -1747,7 +1918,7 @@ async def test_deny_transitions_all_rungs_to_rejected(monkeypatch, db_session):
 async def test_lease_held_blocks_second_approval(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-lease1")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-lease1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-lease1")
     notifier = _FakeNotifier()
 
     service = OrderProposalsService(db_session)
@@ -1786,14 +1957,25 @@ async def test_malformed_callback_data_rejected(monkeypatch, db_session):
 
     assert result["handled"] is False
     assert result["reason"] == "malformed_callback_data"
-    assert notifier.answered
+    assert notifier.answered == []
 
 
 @pytest.mark.asyncio
 async def test_proposal_not_found_for_unknown_prefix(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     notifier = _FakeNotifier()
-    data = "op:deadbeef:some-nonce-1"
+    unknown_id = uuid.UUID("deadbeef-0000-4000-8000-000000000000")
+    data = approval_messages.build_callback_data(
+        action="op",
+        proposal_id=unknown_id,
+        nonce="some-nonce-1",
+        binding=DispatchBinding(
+            attempt_id=uuid.uuid4(),
+            card_kind=ApprovalCardKind.MANUAL,
+            membership_revision=1,
+            membership_digest="AbCdEf0123_-",
+        ),
+    )
 
     result = await handle_callback_update(
         _make_update(data=data),
@@ -1804,14 +1986,14 @@ async def test_proposal_not_found_for_unknown_prefix(monkeypatch, db_session):
 
     assert result["handled"] is False
     assert result["reason"] == "proposal_not_found"
-    assert notifier.answered
+    assert notifier.answered == []
 
 
 @pytest.mark.asyncio
 async def test_never_raises_on_internal_error(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-boom1")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-boom1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-boom1")
     notifier = _FakeNotifier()
 
     async def exploding_revalidate(**kwargs):
@@ -1837,7 +2019,7 @@ async def test_approve_restores_previous_identity_when_revalidation_raises(
     _allow_chat(monkeypatch)
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_SUBMIT_AGENT_ID", "proposal-agent")
     group = await _seed_proposal(db_session, nonce="nonce-identity-boom")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-identity-boom"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-identity-boom")
 
     async def exploding_revalidate(**kwargs):
         assert get_caller_agent_id() == "proposal-agent"
@@ -1877,7 +2059,7 @@ async def test_deny_survives_notify_failure_and_stays_committed(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-notifyfail-dn", rungs=2)
-    data = f"dn:{str(group.proposal_id)[:8]}:nonce-notifyfail-dn"
+    data = _proposal_callback_data(group, action="dn", nonce="nonce-notifyfail-dn")
     notifier = _EditRaisingNotifier()
 
     async def fake_revalidate(**kwargs):
@@ -1913,7 +2095,7 @@ async def test_approve_survives_notify_failure_and_stays_committed(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-notifyfail-op")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-notifyfail-op"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-notifyfail-op")
     notifier = _EditRaisingNotifier()
 
     async def fake_revalidate(*, service, proposal_id, now):
@@ -1975,7 +2157,7 @@ async def test_approve_survives_notify_failure_and_stays_committed(
 async def test_needs_reconfirm_multi_rung_shows_every_diff(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-multi-recon", rungs=2)
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-multi-recon"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-multi-recon")
     notifier = _FakeNotifier()
 
     diff0 = {
@@ -2020,7 +2202,7 @@ async def test_needs_reconfirm_mixed_batch_reports_other_outcome(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-mixed-recon", rungs=2)
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-mixed-recon"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-mixed-recon")
     notifier = _FakeNotifier()
 
     diff1 = {
@@ -2069,7 +2251,7 @@ async def test_reconfirm_click_transitions_rung_and_reenters_revalidation(
 ):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-cycle1")
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-cycle1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-cycle1")
     notifier = _FakeNotifier()
 
     diff = {
@@ -2127,8 +2309,10 @@ async def test_reconfirm_click_transitions_rung_and_reenters_revalidation(
 
     _new_text, new_keyboard, _sent_chat_id = notifier.sent_messages[0]
     new_callback_data = new_keyboard["inline_keyboard"][0][0]["callback_data"]
-    _new_action, _new_short, new_nonce = parse_callback_data(new_callback_data)
-    second_data = f"op:{str(group.proposal_id)[:8]}:{new_nonce}"
+    parsed = parse_callback_data(new_callback_data)
+    assert parsed.action == "op"
+    assert parsed.subject_short == str(group.proposal_id)[:8]
+    second_data = new_callback_data
 
     # `acquire_commit_lease`'s default 10s lease was taken by the first call
     # -- advance `now` well past it so the second click isn't spuriously
@@ -2175,7 +2359,7 @@ async def test_reconfirm_resend_refreshes_approval_message_id(monkeypatch, db_se
     )
     await db_session.commit()
 
-    data = f"op:{str(group.proposal_id)[:8]}:nonce-msgid1"
+    data = _proposal_callback_data(group, action="op", nonce="nonce-msgid1")
     notifier = _FakeNotifier()
 
     diff = {

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -344,6 +344,7 @@ async def _seed_approval_batch(db_session, monkeypatch, *, member_count=2, rungs
             chat_id=str(chat_id),
             approval_message_id=7100 + index,
             now=now + timedelta(seconds=index),
+            summary_member_threshold=member_count,
         )
     await db_session.commit()
     assert registration is not None
@@ -2351,11 +2352,12 @@ async def test_reconfirm_resend_refreshes_approval_message_id(monkeypatch, db_se
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-msgid1")
     seed_service = OrderProposalsService(db_session)
-    await seed_service.record_approval_dispatch(
-        group.proposal_id,
+    await _publish_fixture_card(
+        seed_service,
+        group,
+        nonce="nonce-msgid1",
+        card_kind=ApprovalCardKind.MANUAL,
         message_id=111,
-        chat_id=str(CHAT_ID),
-        now=datetime.now(UTC),
     )
     await db_session.commit()
 

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -56,7 +56,7 @@ def test_migration_descends_from_latest_main_head_and_is_the_single_head() -> No
     config = Config(str(REPO / "alembic.ini"))
     config.set_main_option("script_location", str(REPO / "alembic"))
     assert ScriptDirectory.from_config(config).get_heads() == [
-        "20260722_rob1023_widen_runner"
+        "20260723_approval_dispatch"
     ]
 
 
@@ -151,7 +151,7 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             assert completed.returncode == 0, completed.stdout + completed.stderr
         current = await asyncio.to_thread(alembic, "current")
         assert current.returncode == 0, current.stdout + current.stderr
-        assert "20260722_rob1023_widen_runner (head)" in current.stdout
+        assert "20260723_approval_dispatch (head)" in current.stdout
 
         async with engine.connect() as connection:
             triggers = await connection.scalar(

--- a/tests/services/research/test_rob1023_backtest_metadata_width.py
+++ b/tests/services/research/test_rob1023_backtest_metadata_width.py
@@ -69,7 +69,7 @@ def test_runner_width_contract_and_alembic_head_are_pinned() -> None:
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
     assert ScriptDirectory.from_config(config).get_heads() == [
-        "20260722_rob1023_widen_runner"
+        "20260723_approval_dispatch"
     ]
 
 

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -12,6 +12,7 @@ from app.mcp_server.tooling import order_proposal_tools as opt
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.target_order import TargetOrderSnapshot
+from app.telegram_contract import TelegramMethodResult, telegram_text_length
 
 
 def _unique_chat() -> str:
@@ -26,17 +27,42 @@ class _FakeNotifier:
         self.edited: list[tuple[str, int, str, object]] = []
         self._message_id = message_id
 
-    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
         self.calls.append((text, inline_keyboard, chat_id))
-        return self._message_id
+        if self._message_id is None:
+            return TelegramMethodResult.failed(
+                payload_chars=telegram_text_length(text),
+                failure_code="telegram_error_400",
+                status_code=400,
+                error_code=400,
+            )
+        return TelegramMethodResult(
+            ok=True,
+            message_id=self._message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=telegram_text_length(text),
+        )
 
     async def edit_message(self, chat_id, message_id, text, reply_markup=None):
         self.edited.append((chat_id, message_id, text, reply_markup))
-        return True
+        return TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=telegram_text_length(text),
+        )
 
 
 class _RaisingNotifier:
-    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
         raise RuntimeError("telegram down")
 
 
@@ -573,9 +599,36 @@ async def test_create_dispatches_telegram_when_enabled_and_allowlisted(monkeypat
     created = await opt.order_proposal_create(**_create_kwargs())
 
     assert created["success"] is True
+    assert created["approval_dispatch"]["ok"] is True
+    assert created["approval_dispatch"]["state"] == "sent"
+    assert created["approval_dispatch"]["message_id"] == 9999
     assert len(fake_notifier.calls) == 1
     _, _, chat_id = fake_notifier.calls[0]
     assert chat_id == chat
+
+
+@pytest.mark.asyncio
+async def test_create_4444_thesis_returns_visible_split_dispatch_result(monkeypatch):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    chat = _unique_chat()
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
+    fake_notifier = _FakeNotifier(message_id=10001)
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.notifier.get_trade_notifier",
+        lambda: fake_notifier,
+    )
+
+    created = await opt.order_proposal_create(
+        **_create_kwargs(thesis="가" * 4444, strategy="분할 매도")
+    )
+
+    assert created["success"] is True
+    assert created["approval_dispatch"]["ok"] is True
+    assert created["approval_dispatch"]["state"] == "sent"
+    assert created["approval_dispatch"]["payload_chars"] > 4096
+    assert len(fake_notifier.calls) == 3
+    assert all(keyboard is None for _, keyboard, _ in fake_notifier.calls[:-1])
+    assert fake_notifier.calls[-1][1]["inline_keyboard"]
 
 
 @pytest.mark.asyncio
@@ -657,6 +710,12 @@ async def test_create_does_not_dispatch_when_telegram_disabled(monkeypatch):
 
     assert created["success"] is True
     assert fake_notifier.calls == []
+    assert created["approval_dispatch"]["ok"] is False
+    assert created["approval_dispatch"]["state"] == "failed"
+    assert created["approval_dispatch"]["failure_code"] == "telegram_disabled"
+    got = await opt.order_proposal_get(created["proposal_id"])
+    assert got["proposal"]["approval_dispatch_state"] == "failed"
+    assert got["proposal"]["approval_dispatch_failure_code"] == "telegram_disabled"
 
 
 @pytest.mark.asyncio
@@ -673,6 +732,9 @@ async def test_create_does_not_dispatch_when_allowlist_empty(monkeypatch):
 
     assert created["success"] is True
     assert fake_notifier.calls == []
+    assert created["approval_dispatch"]["ok"] is False
+    assert created["approval_dispatch"]["state"] == "failed"
+    assert created["approval_dispatch"]["failure_code"] == "telegram_allowlist_empty"
 
 
 @pytest.mark.asyncio
@@ -689,6 +751,10 @@ async def test_create_succeeds_even_when_notifier_raises(monkeypatch):
 
     assert created["success"] is True
     assert "proposal_id" in created
+    assert created["approval_dispatch"]["ok"] is False
+    assert (
+        created["approval_dispatch"]["failure_code"] == "approval_card_dispatch_failed"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 배경 (ROB-1044 P0 선행 — approval 경로 contract owner)

승인 메시지 dispatch 실패 은폐 사고 수정. 오늘 크래프톤 제안이 4,444자 thesis → 4,902자 payload로 Telegram 4,096 한도를 넘겨 **400을 받았고, 전송 계층이 예외를 삼키고 `None`을 반환**해 승인 버튼·`approval_message_id`가 생성되지 않았다. 운영자가 두 번 승인했으나 **서버 원장 기준 승인이 한 번도 성립하지 않았다.** RCA: `~/work/herdr-inbox/approval-dispatch-rca.md`.

## 변경
- **payload 4,096 UTF-16 preflight** + lossless ordered context split, context 전건 성공 후에만 final button card
- **typed dispatch state** (PENDING/SENT_CURRENT/SENT_SUPERSEDED/FAILED/PARTIAL_FAILED) — 승인/callback/nonce/caller ok/batch/log 전부 이 상태에서 도출, HTTP send 성공을 workflow 성공으로 간주 안 함
- **실패 durable·caller-visible**: `TelegramDispatchResult` + attempt ledger + `approval_dispatch_state`. create 도구 결과에 `approval_dispatch` 포함(disabled/allowlist/transport/card 실패가 성공처럼 안 보임)
- **raw Telegram description 폐기** (token/nonce/thesis/chat/reply markup 비노출), `unknown_telegram_error` 분류
- **모든 nonce 소비 공통 SENT_CURRENT gate** (manual/batch/auto-veto) — 비-current 상태에서 nonce·broker submit/cancel 0
- **loss-cut pre-gate 외부 부수효과 0** (non-consuming binding preflight, preflight만으로 nonce 소비 안 함)
- **post-commit create-success 불변** — dispatch/ledger 실패가 proposal 생성 실패로 역전 안 됨(commit 전 실패는 success=false)
- **immutable published batch membership snapshot** (revision/digest, send 실패 시 approvable 안 됨)
- persistent bootstrap 제약 정합, **mutation-sensitive behavioral tests** (보호 제거·조건 반전 시 실제 실패 확인)

## Migration
additive only (`20260723_approval_dispatch_ledger.py`), 단일 head, backfill/update 없음.

## 검증
독립 적대검증 3라운드 통과 — `approval-dispatch-verify-r3-claude.md`: **APPROVE (HIGH 0 / MEDIUM 0 / LOW 2)**. 140 tests passed, ruff/format/ty/diff PASS. 반증 7종 pre-fix 재현 → post-fix 차단 실증.

## Contract ownership
🔴 이 PR이 **겹치는 order_proposal 경로 파일(dispatch/service/repository/telegram_callback/order_proposal_tools 등 10개)의 truth owner**. `fix/us-approval-window-gate`(ROB-1044 P0-4 승인창 게이트)는 **본 PR 정규 merge 후 최신 origin/main에 rebase**하여 별도 stacked PR로 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable tracking for Telegram approval-dispatch attempts and outcomes.
  * Approval messages now support securely bound callbacks, immutable batch snapshots, and long-text splitting.
  * Proposal creation now reports structured dispatch status without losing successful creation results.
  * Telegram operations provide consistent success, failure, payload-size, and error details.
* **Bug Fixes**
  * Prevented stale, replayed, mismatched, or unpublished approval callbacks from triggering actions.
  * Improved failure handling and sensitive-data redaction in Telegram logs.
* **Tests**
  * Expanded coverage for dispatch durability, callback security, batching, payload limits, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->