### PR TITLE
feat(order-proposals): market-aware approval window expiry gate (ROB-1044 P0)

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -767,6 +767,18 @@ order mutation.
   - Target-action tuples are supported only for
     `kis_live/equity_kr`, `kis_live/equity_us`, and `upbit/crypto`.
   - When `valid_until` is omitted, it defaults to the next `00:00 KST`.
+  - Before an approval card/nonce is published, dispatch enforces
+    timezone-aware `valid_until` and the proposal's broker/market submission
+    session. Missing, naive, malformed, or expired validity fails closed.
+    US DAY proposals are regular-session only and use the existing XNYS or
+    Toss broker calendar; KR keeps KRX regular plus positively confirmed,
+    fresh NXT eligibility; Upbit crypto remains 24/7. Unknown calendar or
+    capability evidence also fails closed.
+  - A dispatch block does not fail proposal persistence. The create response
+    adds `approval_dispatch={status:"blocked", code, ...}` with typed
+    `EXPIRED`, `INVALID_VALID_UNTIL`, `DEFER_SESSION_CLOSED`,
+    `CALENDAR_UNKNOWN`, or `NO_EXECUTABLE_WINDOW` evidence. No Telegram card
+    or approval nonce is published for that dispatch attempt.
   - When `supersedes_proposal_id` is present, the old group's
     `pending_approval`/`needs_reconfirm` rungs become `superseded`, its
     approval nonce is consumed, and its recorded Telegram message is edited
@@ -853,9 +865,26 @@ order mutation.
   - After a successful void, the recorded Telegram approval message is edited
     without an inline keyboard so stale approval buttons no longer remain live.
 
-Telegram approval runs fresh broker-specific checks at the submit-capable
-click. KIS/Upbit rerun their applicable ROB-800 checks through
-`_place_order_impl`.
+Telegram approval rechecks the persisted dispatch policy stamp, proposal
+validity, and authoritative market session before consuming a nonce, then
+repeats the same window policy inside revalidation and through a pre-send hook
+at the final KIS, Toss, or Upbit HTTP boundary for submit and cancel. The
+session evidence includes the allowed interval end, so a close crossed while
+an awaited check is running is rejected at the transport boundary. A missing
+or mismatched policy stamp and unknown/stale evidence fail closed. An expired
+proposal converges through the existing proposal/rung expiry transitions
+without rolling back a sibling that already has broker evidence. A still-valid
+closed-session proposal returns
+`DEFER_SESSION_CLOSED` with the next confirmed session; it is never scheduled
+or automatically resubmitted. An initial late pre-send block proves provider
+HTTP=0; a retry-time block may follow one explicit 429/auth rejection but never
+an accepted or ambiguous mutation. With that proof and no sibling mutation,
+the callback restores the rung, lease, and durable proposal nonce instead of
+stranding a consumed approval.
+Batch approval locks and verifies the exact ordered proposal/nonce-snapshot
+membership before consuming its own nonce; one missing, changed, expired, or
+closed member blocks the whole displayed batch. KIS/Upbit then rerun their
+applicable ROB-800 checks through `_place_order_impl`.
 Successful automatic submissions retain `approved_by_telegram_user_id=NULL`
 and write policy/version/eligibility evidence under
 `source_asof.auto_approved`. Their Telegram summary carries a single-use

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -773,7 +773,12 @@ order mutation.
     US DAY proposals are regular-session only and use the existing XNYS or
     Toss broker calendar; KR keeps KRX regular plus positively confirmed,
     fresh NXT eligibility; Upbit crypto remains 24/7. Unknown calendar or
-    capability evidence also fails closed.
+    capability evidence also fails closed. A proposal with a non-null
+    `exit_intent` is a protective exit and bypasses only session/calendar
+    resolution and approval-window policy-stamp binding, so calendar
+    uncertainty cannot preempt its confirmation flow. Its `valid_until`
+    remains mandatory and fail-closed; `exit_reason` alone grants no
+    exemption.
   - A dispatch block does not fail proposal persistence. The create response
     adds `approval_dispatch={status:"blocked", code, ...}` with typed
     `EXPIRED`, `INVALID_VALID_UNTIL`, `DEFER_SESSION_CLOSED`,

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -151,7 +151,13 @@ async def _execute_order(
         if is_mock:
             raise ValueError(_MOCK_CRYPTO_ERROR)
         return await _execute_crypto_order(
-            symbol, side, order_type, quantity, price, identifier=identifier
+            symbol,
+            side,
+            order_type,
+            quantity,
+            price,
+            identifier=identifier,
+            pre_send_hook=pre_send_hook,
         )
     if market_type == "equity_kr":
         return await _execute_kr_order(
@@ -176,17 +182,26 @@ async def _execute_crypto_order(
     quantity: float | None,
     price: float | None,
     identifier: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     if side == "buy":
         if order_type == "market":
             price_str = f"{price:.0f}" if price else "0"
             return await upbit_service.place_market_buy_order(
-                symbol, price_str, identifier=identifier
+                symbol,
+                price_str,
+                identifier=identifier,
+                pre_send_hook=pre_send_hook,
             )
         volume_str = f"{quantity:.8f}"
         adjusted_price = upbit_service.adjust_price_to_upbit_unit(price)
         return await upbit_service.place_buy_order(
-            symbol, adjusted_price, volume_str, "limit", identifier=identifier
+            symbol,
+            adjusted_price,
+            volume_str,
+            "limit",
+            identifier=identifier,
+            pre_send_hook=pre_send_hook,
         )
 
     holdings = await _get_holdings_for_order(symbol, "crypto")
@@ -197,12 +212,19 @@ async def _execute_crypto_order(
     volume_str = f"{volume:.8f}"
     if order_type == "market":
         return await upbit_service.place_market_sell_order(
-            symbol, volume_str, identifier=identifier
+            symbol,
+            volume_str,
+            identifier=identifier,
+            pre_send_hook=pre_send_hook,
         )
 
     adjusted_price = upbit_service.adjust_price_to_upbit_unit(price)
     return await upbit_service.place_sell_order(
-        symbol, volume_str, f"{adjusted_price}", identifier=identifier
+        symbol,
+        volume_str,
+        f"{adjusted_price}",
+        identifier=identifier,
+        pre_send_hook=pre_send_hook,
     )
 
 
@@ -819,14 +841,21 @@ async def _execute_and_record(
                     _duplicate_order_intent_message(intent_account_scope)
                 )
 
-    async def _release_reserved_mock_mirror_intent_after_send_failure(
+    async def _release_reserved_intent_after_send_failure(
         exc: BaseException,
+        *,
+        proven_not_sent: bool = False,
     ) -> bool:
         if (
             not intent_reserved
-            or intent_account_scope != "kis_mock"
             or intent_key is None
-            or mirror_cohort != "mock_counterfactual"
+            or (
+                not proven_not_sent
+                and (
+                    intent_account_scope != "kis_mock"
+                    or mirror_cohort != "mock_counterfactual"
+                )
+            )
         ):
             return False
 
@@ -861,11 +890,10 @@ async def _execute_and_record(
         return False
 
     try:
-        # ROB-843 P1: the pre_send_hook (KIS-mock-scalping only) is threaded all
-        # the way into the transport and fired immediately before EACH real HTTP
-        # mutation (including token-refresh/retry re-sends), so a book that went
-        # stale during token/limiter/client/NXT preflight blocks the POST with
-        # zero broker calls. Live callers pass no hook → identical behavior.
+        # The optional pre_send_hook is threaded to the broker transport and
+        # fired immediately before each real mutation HTTP attempt (including
+        # eligible token/rate-limit re-sends). Callers without a hook retain
+        # the existing execution behavior.
         execution_result = await _execute_order(
             symbol=normalized_symbol,
             side=side,
@@ -883,7 +911,10 @@ async def _execute_and_record(
             # result normalizer proves accepted/rejected, the outcome is unknown.
             send_outcome.mark_unknown()
     except PreSendFreshnessError as fresh_exc:
-        await _release_reserved_mock_mirror_intent_after_send_failure(fresh_exc)
+        await _release_reserved_intent_after_send_failure(
+            fresh_exc,
+            proven_not_sent=True,
+        )
         logger.info(
             "pre-send freshness block symbol=%s side=%s reasons=%s",
             normalized_symbol,
@@ -902,9 +933,7 @@ async def _execute_and_record(
         # Preserve the transport boundary's explicit state: token/client setup
         # can raise before dispatch (NOT_CREATED), while an actual send marks
         # UNKNOWN immediately before crossing the HTTP boundary.
-        retry_allowed = await _release_reserved_mock_mirror_intent_after_send_failure(
-            send_exc
-        )
+        retry_allowed = await _release_reserved_intent_after_send_failure(send_exc)
         if (
             send_outcome is not None
             and send_outcome.disposition is OrderSendDisposition.NOT_CREATED
@@ -940,7 +969,7 @@ async def _execute_and_record(
             else None,
         ) from send_exc
     except Exception as exec_exc:
-        await _release_reserved_mock_mirror_intent_after_send_failure(exec_exc)
+        await _release_reserved_intent_after_send_failure(exec_exc)
         logger.error(
             "execute_order 실패: stage=execute_order, market_type=%s, "
             "symbol=%s, side=%s, error=%s",

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -22,6 +22,7 @@ from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.approval_window import ApprovalWindowDecision
 from app.services.order_proposals.broker_gateway import (
     fetch_operator_void_evidence,
     fetch_target_order,
@@ -179,7 +180,7 @@ async def _record_post_commit_dispatch_failure(
 
 async def _dispatch_after_proposal_commit(
     proposal_id: uuid.UUID,
-) -> TelegramDispatchResult:
+) -> TelegramDispatchResult | ApprovalWindowDecision:
     """Run dispatch/attempt-ledger work behind a closed post-commit boundary."""
     try:
         dispatch_now = now_kst()
@@ -196,8 +197,11 @@ async def _dispatch_after_proposal_commit(
                     proposal_id,
                     notifier=get_trade_notifier(),
                     now=dispatch_now,
+                    now_fn=now_kst,
                 )
-                if not isinstance(result, TelegramDispatchResult):
+                if not isinstance(
+                    result, (TelegramDispatchResult, ApprovalWindowDecision)
+                ):
                     raise TypeError("unexpected approval dispatch result")
                 return result
             except Exception as exc:  # noqa: BLE001 - proposal is already durable
@@ -292,7 +296,13 @@ async def _complete_committed_proposal_create(
                 )
 
         dispatch_result = await _dispatch_after_proposal_commit(proposal_id)
-        result["approval_dispatch"] = dispatch_result.as_dict()
+        if isinstance(dispatch_result, ApprovalWindowDecision):
+            result["approval_dispatch"] = {
+                "status": "blocked",
+                **dispatch_result.to_dict(),
+            }
+        else:
+            result["approval_dispatch"] = dispatch_result.as_dict()
         return result
     except Exception as exc:  # noqa: BLE001 - committed create result is immutable
         logger.error(

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import app.services.brokers.upbit.client as upbit_service
@@ -475,9 +476,17 @@ def _validate_cancel_inputs(
     return order_id, symbol, market_type
 
 
-async def _cancel_upbit(order_id: str) -> dict[str, Any]:
+async def _cancel_upbit(
+    order_id: str,
+    *,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
+) -> dict[str, Any]:
     """Cancel an Upbit (crypto) order."""
-    results = await upbit_service.cancel_orders([order_id])
+    hook_kw = {"pre_send_hook": pre_send_hook} if pre_send_hook is not None else {}
+    results = await upbit_service.cancel_orders(
+        [order_id],
+        **hook_kw,
+    )
     if results and len(results) > 0:
         result = results[0]
         if "error" in result:
@@ -619,6 +628,7 @@ async def _cancel_kis_domestic(
     symbol: str | None,
     *,
     is_mock: bool = False,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Cancel a KIS domestic (Korean equity) order."""
     if is_mock:
@@ -718,6 +728,7 @@ async def _cancel_kis_domestic(
                 break
 
         order_type_str = "buy" if side_code == "02" else "sell"
+        hook_kw = {"pre_send_hook": pre_send_hook} if pre_send_hook is not None else {}
         result = await kis.cancel_korea_order(
             order_number=order_id,
             stock_code=symbol,
@@ -726,6 +737,7 @@ async def _cancel_kis_domestic(
             order_type=order_type_str,
             krx_fwdg_ord_orgno=krx_fwdg_ord_orgno,
             is_mock=is_mock,
+            **hook_kw,
         )
         return {
             "success": True,
@@ -747,6 +759,7 @@ async def _cancel_kis_overseas(
     symbol: str | None,
     *,
     is_mock: bool = False,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Cancel a KIS overseas (US equity) order."""
     if is_mock:
@@ -861,11 +874,13 @@ async def _cancel_kis_overseas(
             quantity,
         )
 
+        hook_kw = {"pre_send_hook": pre_send_hook} if pre_send_hook is not None else {}
         result = await kis.cancel_overseas_order(
             order_number=order_id,
             symbol=symbol,
             exchange_code=exchange_code,
             quantity=quantity,
+            **hook_kw,
         )
         return {
             "success": True,
@@ -888,14 +903,23 @@ async def cancel_order_impl(
     market: str | None = None,
     *,
     is_mock: bool = False,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     order_id, symbol, market_type = _validate_cancel_inputs(order_id, symbol, market)
 
     try:
         if market_type == "crypto":
-            return await _cancel_upbit(order_id)
+            return await _cancel_upbit(
+                order_id,
+                pre_send_hook=pre_send_hook,
+            )
         if market_type == "equity_kr":
-            result = await _cancel_kis_domestic(order_id, symbol, is_mock=is_mock)
+            result = await _cancel_kis_domestic(
+                order_id,
+                symbol,
+                is_mock=is_mock,
+                pre_send_hook=pre_send_hook,
+            )
             # ROB-395: keep the live ledger truthful — a cancelled live order must
             # not stay accepted/pending (otherwise reconcile could still act on it).
             if not is_mock and result.get("success"):
@@ -906,7 +930,12 @@ async def cancel_order_impl(
                 await _mark_ledger_cancelled(order_id)
             return result
         if market_type == "equity_us":
-            return await _cancel_kis_overseas(order_id, symbol, is_mock=is_mock)
+            return await _cancel_kis_overseas(
+                order_id,
+                symbol,
+                is_mock=is_mock,
+                pre_send_hook=pre_send_hook,
+            )
         return {
             "success": False,
             "order_id": order_id,

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -8,6 +8,7 @@ Every tool is hard-pinned to ``account_mode="toss_live"``. They:
 
 from __future__ import annotations
 
+import inspect
 import logging
 import re
 import uuid
@@ -83,6 +84,19 @@ def _bind_toss_pre_send_hook(hook: PreSendHook | None):
         yield
     finally:
         _toss_pre_send_hook.reset(token)
+
+
+def _accepts_pre_send_hook(method: Callable[..., Awaitable[Any]]) -> bool:
+    """Whether an injected Toss client exposes the current mutation protocol."""
+    try:
+        parameters = inspect.signature(method).parameters.values()
+    except (TypeError, ValueError):
+        return True
+    return any(
+        parameter.name == "pre_send_hook"
+        or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
 
 
 TOSS_LIVE_ORDER_TOOL_NAMES: set[str] = {
@@ -1405,6 +1419,13 @@ async def _toss_place_order_impl(
         res = None
         try:
             if pre_send_hook is None:
+                res = await client.place_order(payload)
+            elif not _accepts_pre_send_hook(client.place_order):
+                # Keep compatibility with injected clients implementing the
+                # original one-argument protocol. The hook still runs
+                # immediately before their mutation; the first-party client
+                # accepts the hook and rechecks it inside every HTTP attempt.
+                await pre_send_hook()
                 res = await client.place_order(payload)
             else:
                 res = await client.place_order(

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import re
 import uuid
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -46,6 +46,7 @@ from app.mcp_server.tooling.toss_live_ledger import (
     record_toss_replacement_order,
 )
 from app.services.account_routing import build_cost_profiles
+from app.services.brokers.kis.pre_send import PreSendFreshnessError
 from app.services.brokers.toss import TossReadClient
 from app.services.brokers.toss.dto import TossWarningInfo
 from app.services.brokers.toss.errors import TossApiResponseError
@@ -66,6 +67,23 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
+
+PreSendHook = Callable[[], Awaitable[None]]
+_toss_pre_send_hook: ContextVar[PreSendHook | None] = ContextVar(
+    "toss_pre_send_hook",
+    default=None,
+)
+
+
+@contextmanager
+def _bind_toss_pre_send_hook(hook: PreSendHook | None):
+    """Bind an internal transport guard without changing the MCP schema."""
+    token = _toss_pre_send_hook.set(hook)
+    try:
+        yield
+    finally:
+        _toss_pre_send_hook.reset(token)
+
 
 TOSS_LIVE_ORDER_TOOL_NAMES: set[str] = {
     "toss_preview_order",
@@ -1382,9 +1400,17 @@ async def _toss_place_order_impl(
                     verdict.reason,
                 )
 
+        pre_send_hook = _toss_pre_send_hook.get()
+
         res = None
         try:
-            res = await client.place_order(payload)
+            if pre_send_hook is None:
+                res = await client.place_order(payload)
+            else:
+                res = await client.place_order(
+                    payload,
+                    pre_send_hook=pre_send_hook,
+                )
             if side == "sell":
                 await _invalidate_sellable_after_sell_mutation(symbol)
             raw_response = {
@@ -1441,6 +1467,8 @@ async def _toss_place_order_impl(
                     "run toss_reconcile_orders to book confirmed fills."
                 ),
             }
+        except PreSendFreshnessError:
+            raise
         except Exception as exc:
             err = _toss_error_response(exc, {**base_response, "mutation_sent": True})
             # ROB-545 Major/B2 — if the POST already reached Toss (res set) the
@@ -1755,7 +1783,14 @@ async def toss_cancel_order(
                     exc, {**base_response, "original_order_id": order_id}
                 )
             mkt = _infer_market(orig_order.symbol, None)
-            res = await client.cancel_order(order_id)
+            pre_send_hook = _toss_pre_send_hook.get()
+            if pre_send_hook is None:
+                res = await client.cancel_order(order_id)
+            else:
+                res = await client.cancel_order(
+                    order_id,
+                    pre_send_hook=pre_send_hook,
+                )
             if str(orig_order.side).lower() == "sell":
                 await _invalidate_sellable_after_sell_mutation(orig_order.symbol)
             ledger = await record_toss_replacement_order(
@@ -1786,6 +1821,8 @@ async def toss_cancel_order(
                 **ledger,
                 "operation_semantics": "Toss cancel returns a newly issued orderId; it is not the original order id.",
             }
+    except PreSendFreshnessError:
+        raise
     except Exception as exc:
         err = _toss_error_response(exc, {**base_response, "mutation_sent": True})
         # ROB-545 Major — keep the order ids on the error path so the live order

--- a/app/routers/telegram_callback.py
+++ b/app/routers/telegram_callback.py
@@ -68,5 +68,5 @@ async def telegram_callback(body: dict[str, Any]) -> dict[str, Any]:
     internal result — Telegram only inspects the HTTP status.
     """
     _require_enabled()
-    await handle_callback_update(body, now=now_kst())
+    await handle_callback_update(body, now=now_kst(), now_fn=now_kst)
     return {"ok": True}

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -413,6 +413,8 @@ class KISClient(BaseKISClient):
         order_type: str,
         is_mock: bool = False,
         krx_fwdg_ord_orgno: str | None = None,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         return await self._domestic_orders.cancel_korea_order(
             order_number,
@@ -422,6 +424,7 @@ class KISClient(BaseKISClient):
             order_type,
             is_mock,
             krx_fwdg_ord_orgno,
+            pre_send_hook=pre_send_hook,
         )
 
     async def inquire_daily_order_domestic(
@@ -531,9 +534,16 @@ class KISClient(BaseKISClient):
         exchange_code: str,
         quantity: int,
         is_mock: bool = False,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         return await self._overseas_orders.cancel_overseas_order(
-            order_number, symbol, exchange_code, quantity, is_mock
+            order_number,
+            symbol,
+            exchange_code,
+            quantity,
+            is_mock,
+            pre_send_hook=pre_send_hook,
         )
 
     async def inquire_daily_order_overseas(

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -517,6 +517,7 @@ class DomesticOrderClient:
         is_mock: bool = False,
         krx_fwdg_ord_orgno: str | None = None,
         *,
+        pre_send_hook: PreSendHook | None = None,
         _token_retry_depth: int = 0,
     ) -> dict:
         """
@@ -619,6 +620,7 @@ class DomesticOrderClient:
             # but keep the no-double-submit policy uniform across order mutations.
             retry_request_errors=False,
             max_retries_override=0,
+            pre_send_hook=pre_send_hook,
         )
 
         if js.get("rt_cd") != "0":
@@ -655,6 +657,7 @@ class DomesticOrderClient:
                     order_type,
                     is_mock,
                     resolved_kis_orgno,
+                    pre_send_hook=pre_send_hook,
                     _token_retry_depth=_token_retry_depth + 1,
                 )
 

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -551,6 +551,7 @@ class OverseasOrderClient:
         quantity: int,
         is_mock: bool = False,
         *,
+        pre_send_hook: PreSendHook | None = None,
         _token_retry_depth: int = 0,
     ) -> dict:
         """
@@ -627,6 +628,7 @@ class OverseasOrderClient:
             # ROB-645: keep the no-double-submit policy uniform across mutations.
             retry_request_errors=False,
             max_retries_override=0,
+            pre_send_hook=pre_send_hook,
         )
 
         if js.get("rt_cd") != "0":
@@ -662,6 +664,7 @@ class OverseasOrderClient:
                     exchange_code,
                     quantity,
                     is_mock,
+                    pre_send_hook=pre_send_hook,
                     _token_retry_depth=_token_retry_depth + 1,
                 )
 

--- a/app/services/brokers/kis/pre_send.py
+++ b/app/services/brokers/kis/pre_send.py
@@ -1,21 +1,20 @@
-"""ROB-843 P1 — pre-send freshness abort signal.
+"""Pre-send live-mutation abort signal.
 
-Dependency-free so both the KIS transport (``base.py``) and the order
-orchestrator (``order_execution.py``) can reference it without an import cycle.
-Raised by a mock-only pre-send callback invoked immediately before each real KIS
-HTTP mutation; the orchestrator converts it into a ``pre_send_blocked`` result.
+Dependency-free so broker transports and order orchestrators can share the
+same fail-closed signal. The callback runs immediately before a real mutation
+HTTP attempt and may reject freshness, validity, or market-session policy.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 
-# A mock-only callback invoked immediately before each real KIS HTTP mutation.
+# A callback invoked immediately before each real broker mutation.
 PreSendHook = Callable[[], Awaitable[None]]
 
 
 class PreSendFreshnessError(RuntimeError):
-    """The live book is no longer tradeable at the actual HTTP send boundary."""
+    """The live mutation is no longer allowed at its HTTP send boundary."""
 
     def __init__(self, reason_codes: tuple[str, ...]) -> None:
         self.reason_codes = tuple(reason_codes)

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -37,6 +38,7 @@ from app.services.brokers.toss.transport import DEFAULT_TOSS_BASE_URL, build_tos
 
 _TOKEN_CODES = {"invalid-token", "expired-token"}
 _GET_REISSUABLE_NON_JSON_STATUSES = {403}
+PreSendHook = Callable[[], Awaitable[None]]
 
 
 def _should_retry_get_non_json_auth_error(
@@ -91,22 +93,27 @@ class TossReadClient:
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | None = None,
         account_required: bool = False,
+        pre_send_hook: PreSendHook | None = None,
     ) -> Any:
         await self._rate_limiter.acquire(group)
         token = await self._token_manager.get_access_token()
         headers = {"Authorization": f"Bearer {token}"}
         if account_required:
             headers["X-Tossinvest-Account"] = str(await self._resolve_account_seq())
-        response = await self._client.request(
-            method, path, params=params, json=json, headers=headers
-        )
+
+        async def send() -> httpx.Response:
+            if pre_send_hook is not None:
+                await pre_send_hook()
+            return await self._client.request(
+                method, path, params=params, json=json, headers=headers
+            )
+
+        response = await send()
         if response.status_code == 429:
             await asyncio.sleep(
                 retry_delay_seconds(response.headers.get("Retry-After"), attempt=0)
             )
-            response = await self._client.request(
-                method, path, params=params, json=json, headers=headers
-            )
+            response = await send()
         try:
             return parse_toss_response(response)
         except TossApiResponseError as exc:
@@ -118,9 +125,7 @@ class TossReadClient:
                     force_reissue=True, failed_token=token
                 )
                 headers["Authorization"] = f"Bearer {token}"
-                retry = await self._client.request(
-                    method, path, params=params, json=json, headers=headers
-                )
+                retry = await send()
                 return parse_toss_response(retry)
             raise
 
@@ -328,7 +333,12 @@ class TossReadClient:
             )
         )
 
-    async def place_order(self, payload: dict[str, Any]) -> TossOrderPlacementResult:
+    async def place_order(
+        self,
+        payload: dict[str, Any],
+        *,
+        pre_send_hook: PreSendHook | None = None,
+    ) -> TossOrderPlacementResult:
         return parse_order_placement_result(
             await self._request(
                 "POST",
@@ -336,6 +346,7 @@ class TossReadClient:
                 group=TossApiGroup.ORDER,
                 json=payload,
                 account_required=True,
+                pre_send_hook=pre_send_hook,
             )
         )
 
@@ -352,7 +363,12 @@ class TossReadClient:
             )
         )
 
-    async def cancel_order(self, order_id: str) -> TossOrderOperationResult:
+    async def cancel_order(
+        self,
+        order_id: str,
+        *,
+        pre_send_hook: PreSendHook | None = None,
+    ) -> TossOrderOperationResult:
         return parse_order_operation_result(
             await self._request(
                 "POST",
@@ -360,5 +376,6 @@ class TossReadClient:
                 group=TossApiGroup.ORDER,
                 json={},
                 account_required=True,
+                pre_send_hook=pre_send_hook,
             )
         )

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -4,6 +4,7 @@ import logging
 import random
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import quote, urlencode
@@ -17,6 +18,7 @@ from app.core.config import settings
 from app.services.upbit_symbol_universe_service import get_active_upbit_markets
 
 logger = logging.getLogger(__name__)
+PreSendHook = Callable[[], Awaitable[None]]
 
 UPBIT_REST = "https://api.upbit.com/v1"
 UPBIT_CANDLES_RATE_LIMIT_KEY = "GET /v1/candles/*"
@@ -101,6 +103,7 @@ async def _retry_with_backoff(
     max_retries: int | None = None,
     base_delay: float | None = None,
     retry_request_errors: bool = True,
+    pre_send_hook: PreSendHook | None = None,
 ) -> Any:
     """Common retry-with-backoff loop for Upbit API requests.
 
@@ -119,6 +122,10 @@ async def _retry_with_backoff(
         Whether to retry on ``httpx.RequestError`` (timeouts/network). ROB-645:
         order-creation POSTs pass ``False`` so a timed-out order is never re-sent
         (ROB-837 also gives order creation a zero retry budget, including 429).
+    pre_send_hook
+        Optional live-mutation policy recheck. It runs after each rate-limiter
+        admission and immediately before that attempt's HTTP send, including
+        retries.
     """
     if max_retries is None:
         max_retries = settings.api_rate_limit_retry_429_max
@@ -133,6 +140,8 @@ async def _retry_with_backoff(
         )
 
         try:
+            if pre_send_hook is not None:
+                await pre_send_hook()
             response = await send_fn()
 
             if response.status_code == 429:
@@ -840,6 +849,8 @@ async def _request_with_auth(
     url: str,
     query_params: dict[str, Any] | None = None,
     body_params: dict[str, Any] | None = None,
+    *,
+    pre_send_hook: PreSendHook | None = None,
 ) -> Any:
     import hashlib
     from urllib.parse import unquote, urlencode, urlparse
@@ -883,25 +894,26 @@ async def _request_with_auth(
             else:
                 raise ValueError(f"지원하지 않는 HTTP 메서드: {method}")
 
-    # ROB-645: order-creation POSTs (POST /v1/orders) must not retry transport
-    # errors or 429 responses — an order may have reached the broker, so a retry
-    # would double-submit. Reads (GET) and cancels (DELETE /order) keep retries.
+    # Live order mutations must not retry transport errors or 429 responses.
+    # A POST may have created an order and a DELETE may have cancelled one even
+    # when the response is lost; retrying also makes a later approval-window
+    # hook unable to distinguish HTTP=0 from an earlier ambiguous attempt.
+    # Read paths keep the existing retry behavior.
     #
-    # ROB-659 constraint note: submission is detected purely by the trailing
-    # ``/orders`` path segment (method POST + api_path suffix). This holds because
-    # Upbit's only order-creation endpoint is POST /v1/orders (singular create is
-    # /v1/orders; cancels use DELETE /v1/order, no trailing "s"). If Upbit ever adds
-    # another POST whose path ends in "/orders" that is NOT an order submission, this
-    # suffix match would over-classify it — revisit this predicate then.
-    is_order_submission = method.upper() == "POST" and api_path.rstrip("/").endswith(
-        "/orders"
-    )
+    # ROB-659 constraint note: mutation detection is deliberately limited to
+    # POST /v1/orders (create) and DELETE /v1/order (cancel). If Upbit adds
+    # another endpoint with either suffix, revisit this predicate.
+    normalized_path = api_path.rstrip("/")
+    is_order_mutation = (
+        method.upper() == "POST" and normalized_path.endswith("/orders")
+    ) or (method.upper() == "DELETE" and normalized_path.endswith("/order"))
     return await _retry_with_backoff(
         limiter,
         send,
         url=url,
-        max_retries=0 if is_order_submission else None,
-        retry_request_errors=not is_order_submission,
+        max_retries=0 if is_order_mutation else None,
+        retry_request_errors=not is_order_mutation,
+        pre_send_hook=pre_send_hook,
     )
 
 

--- a/app/services/brokers/upbit/orders.py
+++ b/app/services/brokers/upbit/orders.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import Any
 
 import app.services.brokers.upbit.client as _client
+from app.services.brokers.kis.pre_send import PreSendFreshnessError
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +52,11 @@ async def fetch_open_orders(market: str | None = None) -> list[dict[str, Any]]:
     return await _client._request_with_auth("GET", url, query_params=params)
 
 
-async def cancel_orders(order_uuids: list[str]) -> list[dict[str, Any]]:
+async def cancel_orders(
+    order_uuids: list[str],
+    *,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
+) -> list[dict[str, Any]]:
     """주문을 취소합니다.
 
     Parameters
@@ -70,10 +76,20 @@ async def cancel_orders(order_uuids: list[str]) -> list[dict[str, Any]]:
         params = {"uuid": order_uuid}
 
         try:
-            result = await _client._request_with_auth(
-                "DELETE", url, query_params=params
-            )
+            if pre_send_hook is None:
+                result = await _client._request_with_auth(
+                    "DELETE", url, query_params=params
+                )
+            else:
+                result = await _client._request_with_auth(
+                    "DELETE",
+                    url,
+                    query_params=params,
+                    pre_send_hook=pre_send_hook,
+                )
             results.append(result)
+        except PreSendFreshnessError:
+            raise
         except Exception as e:
             print(f"주문 {order_uuid} 취소 실패: {e}")
             results.append({"uuid": order_uuid, "error": str(e)})
@@ -86,6 +102,7 @@ async def place_sell_order(
     volume: str,
     price: str,
     identifier: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """지정가 매도 주문을 넣습니다.
 
@@ -116,13 +133,21 @@ async def place_sell_order(
         "identifier": identifier or _new_order_identifier(),
     }
 
-    return await _client._request_with_auth("POST", url, body_params=body_params)
+    if pre_send_hook is None:
+        return await _client._request_with_auth("POST", url, body_params=body_params)
+    return await _client._request_with_auth(
+        "POST",
+        url,
+        body_params=body_params,
+        pre_send_hook=pre_send_hook,
+    )
 
 
 async def place_market_sell_order(
     market: str,
     volume: str,
     identifier: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """시장가 전량 매도 주문을 넣습니다.
 
@@ -150,7 +175,14 @@ async def place_market_sell_order(
         "identifier": identifier or _new_order_identifier(),
     }
 
-    return await _client._request_with_auth("POST", url, body_params=body_params)
+    if pre_send_hook is None:
+        return await _client._request_with_auth("POST", url, body_params=body_params)
+    return await _client._request_with_auth(
+        "POST",
+        url,
+        body_params=body_params,
+        pre_send_hook=pre_send_hook,
+    )
 
 
 async def place_buy_order(
@@ -159,6 +191,7 @@ async def place_buy_order(
     volume: str | None = None,
     ord_type: str = "limit",
     identifier: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """매수 주문을 넣습니다.
 
@@ -201,13 +234,21 @@ async def place_buy_order(
     else:
         raise ValueError("ord_type은 'limit' 또는 'price'여야 합니다")
 
-    return await _client._request_with_auth("POST", url, body_params=body_params)
+    if pre_send_hook is None:
+        return await _client._request_with_auth("POST", url, body_params=body_params)
+    return await _client._request_with_auth(
+        "POST",
+        url,
+        body_params=body_params,
+        pre_send_hook=pre_send_hook,
+    )
 
 
 async def place_market_buy_order(
     market: str,
     price: str,
     identifier: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """시장가 매수 주문을 넣습니다 (지정 금액만큼 매수).
 
@@ -225,7 +266,13 @@ async def place_market_buy_order(
     dict
         주문 결과 정보
     """
-    return await place_buy_order(market, price, ord_type="price", identifier=identifier)
+    return await place_buy_order(
+        market,
+        price,
+        ord_type="price",
+        identifier=identifier,
+        pre_send_hook=pre_send_hook,
+    )
 
 
 def _format_upbit_time(value: datetime | str) -> str:

--- a/app/services/order_proposals/approval_window.py
+++ b/app/services/order_proposals/approval_window.py
@@ -10,6 +10,10 @@ That ordering is load-bearing. An already-expired proposal never needs a
 calendar lookup and can never degrade into a session defer. The returned
 decision is typed and side-effect free; top-level callers own expiry
 convergence and transaction boundaries.
+
+Protective exits are the deliberate exception to the second layer:
+``exit_intent`` proposals retain the validity check but bypass session,
+calendar, and approval-window policy-stamp interpretation.
 """
 
 from __future__ import annotations
@@ -155,6 +159,59 @@ def _policy_stamp(group: Any, evidence: SubmissionSessionEvidence | None = None)
     )
     digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
     return f"{POLICY_VERSION}:{digest}"
+
+
+def _exit_intent_window_exemption(
+    group: Any,
+    *,
+    now: datetime,
+) -> ApprovalWindowDecision | None:
+    """Return the validity-only decision for a protective exit proposal.
+
+    ``exit_intent`` is the discriminator. Supporting metadata such as
+    ``exit_reason`` must never grant this exemption by itself.
+    """
+    if not getattr(group, "exit_intent", None):
+        return None
+
+    market, account_mode, action, order_type = _contract_fields(group)
+    raw_valid_until = getattr(group, "valid_until", None)
+    valid_until = raw_valid_until if isinstance(raw_valid_until, datetime) else None
+    common = {
+        "observed_at": now,
+        "valid_until": valid_until,
+        "market": market,
+        "account_mode": account_mode,
+        "action": action,
+        "order_type": order_type,
+    }
+    validity_block = valid_until_block(raw_valid_until, now=now)
+    if validity_block is not None:
+        code, detail = validity_block
+        return ApprovalWindowDecision(
+            code=code,
+            policy_stamp=_policy_stamp(group),
+            detail=detail,
+            **common,
+        )
+
+    assert isinstance(raw_valid_until, datetime)
+    evidence = SubmissionSessionEvidence(
+        known=True,
+        source="proposal_exit_intent",
+        current_session="exempt",
+        allowed_sessions=("exit_intent_exempt",),
+        allowed_now=True,
+        allowed_until=raw_valid_until,
+        detail="protective_exit_session_calendar_exempt",
+    )
+    return ApprovalWindowDecision(
+        code=ApprovalWindowCode.ALLOW,
+        policy_stamp=_policy_stamp(group, evidence),
+        evidence=evidence,
+        detail="exit_intent_session_calendar_exempt",
+        **common,
+    )
 
 
 def _containing_window(
@@ -460,10 +517,14 @@ async def evaluate_approval_window(
     session_resolver: SessionResolver = resolve_submission_session,
 ) -> ApprovalWindowDecision:
     """Return the fail-closed decision for dispatch/callback/submit."""
-    market, account_mode, action, order_type = _contract_fields(group)
     if now.tzinfo is None or now.utcoffset() is None:
         raise ValueError("approval-window now must be timezone-aware")
 
+    exit_exemption = _exit_intent_window_exemption(group, now=now)
+    if exit_exemption is not None:
+        return exit_exemption
+
+    market, account_mode, action, order_type = _contract_fields(group)
     raw_valid_until = getattr(group, "valid_until", None)
     valid_until = raw_valid_until if isinstance(raw_valid_until, datetime) else None
     common = {
@@ -656,8 +717,23 @@ async def evaluate_approval_window_boundary(
     expected_policy_stamp: str | None = None,
     require_policy_stamp: bool = True,
 ) -> ApprovalWindowDecision:
-    """Evaluate and then re-sample at the exact caller boundary."""
-    decision = await window_evaluator(group, now=now_fn())
+    """Evaluate and then re-sample at the exact caller boundary.
+
+    This is the common production entry point for dispatch, callback, and
+    revalidation. It applies the exit-intent exemption before invoking even an
+    injected evaluator, so protective exits cannot touch calendar/session I/O
+    or degrade into ``CALENDAR_UNKNOWN`` through policy-stamp binding.
+    """
+    evaluation_now = now_fn()
+    exit_exemption = _exit_intent_window_exemption(group, now=evaluation_now)
+    if exit_exemption is not None:
+        return recheck_approval_window_decision(
+            group,
+            exit_exemption,
+            now=now_fn(),
+        )
+
+    decision = await window_evaluator(group, now=evaluation_now)
     if require_policy_stamp:
         decision = bind_approval_window_policy(decision, expected_policy_stamp)
     return recheck_approval_window_decision(group, decision, now=now_fn())

--- a/app/services/order_proposals/approval_window.py
+++ b/app/services/order_proposals/approval_window.py
@@ -1,0 +1,708 @@
+"""Fail-closed approval and live-submission window policy.
+
+The policy is deliberately split into two layers:
+
+* proposal validity (``valid_until``), evaluated first and without I/O;
+* broker/market submission capability, backed by the existing exchange and
+  Toss market calendars.
+
+That ordering is load-bearing. An already-expired proposal never needs a
+calendar lookup and can never degrade into a session defer. The returned
+decision is typed and side-effect free; top-level callers own expiry
+convergence and transaction boundaries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from typing import Any, Literal
+from zoneinfo import ZoneInfo
+
+from app.services.brokers.toss.market_calendar import (
+    TossKrMarketDay,
+    TossSessionWindow,
+    TossUsMarketDay,
+    get_toss_market_calendar,
+    kr_toss_session_for,
+    us_toss_session_for,
+)
+from app.services.kr_symbol_universe_service import get_kr_nxt_tradability
+from app.services.market_events.session_calendar import (
+    next_trading_session,
+    regular_session_bounds,
+)
+from app.services.order_proposals.approval_window_contract import (
+    ApprovalWindowCode,
+    valid_until_block,
+)
+
+POLICY_VERSION = "order-proposal-approval-window-v1"
+
+_KST = ZoneInfo("Asia/Seoul")
+_NEW_YORK = ZoneInfo("America/New_York")
+_NXT_SESSIONS = frozenset({"nxt_premarket", "nxt_after"})
+
+
+@dataclass(frozen=True)
+class SubmissionSessionEvidence:
+    """Authoritative session/capability evidence for one proposal."""
+
+    known: bool
+    source: str
+    current_session: str
+    allowed_sessions: tuple[str, ...]
+    allowed_now: bool
+    allowed_until: datetime | None = None
+    next_allowed_at: datetime | None = None
+    detail: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("allowed_until", self.allowed_until),
+            ("next_allowed_at", self.next_allowed_at),
+        ):
+            if value is not None and (
+                value.tzinfo is None or value.utcoffset() is None
+            ):
+                raise ValueError(f"{field_name} must be timezone-aware")
+
+
+@dataclass(frozen=True)
+class ApprovalWindowDecision:
+    code: ApprovalWindowCode
+    observed_at: datetime
+    valid_until: datetime | None
+    policy_stamp: str
+    market: str
+    account_mode: str
+    action: str
+    order_type: str
+    evidence: SubmissionSessionEvidence | None = None
+    detail: str | None = None
+
+    @property
+    def allowed(self) -> bool:
+        return self.code is ApprovalWindowCode.ALLOW
+
+    def to_dict(self) -> dict[str, Any]:
+        evidence = self.evidence
+        return {
+            "code": self.code.value,
+            "observed_at": self.observed_at.isoformat(),
+            "valid_until": (
+                self.valid_until.isoformat() if self.valid_until is not None else None
+            ),
+            "policy_stamp": self.policy_stamp,
+            "market": self.market,
+            "account_mode": self.account_mode,
+            "action": self.action,
+            "order_type": self.order_type,
+            "detail": self.detail,
+            "session_evidence": (
+                {
+                    "known": evidence.known,
+                    "source": evidence.source,
+                    "current_session": evidence.current_session,
+                    "allowed_sessions": list(evidence.allowed_sessions),
+                    "allowed_now": evidence.allowed_now,
+                    "allowed_until": (
+                        evidence.allowed_until.isoformat()
+                        if evidence.allowed_until is not None
+                        else None
+                    ),
+                    "next_allowed_at": (
+                        evidence.next_allowed_at.isoformat()
+                        if evidence.next_allowed_at is not None
+                        else None
+                    ),
+                    "detail": evidence.detail,
+                }
+                if evidence is not None
+                else None
+            ),
+        }
+
+
+SessionResolver = Callable[..., Awaitable[SubmissionSessionEvidence]]
+WindowEvaluator = Callable[..., Awaitable[ApprovalWindowDecision]]
+
+
+def _contract_fields(group: Any) -> tuple[str, str, str, str]:
+    return (
+        str(getattr(group, "market", "") or ""),
+        str(getattr(group, "account_mode", "") or ""),
+        str(getattr(group, "action", None) or "place"),
+        str(getattr(group, "order_type", "") or ""),
+    )
+
+
+def _policy_stamp(group: Any, evidence: SubmissionSessionEvidence | None = None) -> str:
+    market, account_mode, action, order_type = _contract_fields(group)
+    allowed = ",".join(evidence.allowed_sessions) if evidence is not None else "none"
+    material = "|".join(
+        (
+            POLICY_VERSION,
+            account_mode,
+            market,
+            action,
+            order_type,
+            "DAY",
+            allowed,
+        )
+    )
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"{POLICY_VERSION}:{digest}"
+
+
+def _containing_window(
+    windows: Sequence[TossSessionWindow], now: datetime
+) -> TossSessionWindow | None:
+    return next((window for window in windows if window.contains(now)), None)
+
+
+def _next_window_start(
+    windows: Sequence[TossSessionWindow],
+    *,
+    after: datetime,
+) -> datetime | None:
+    candidates = [window.start for window in windows if window.start >= after]
+    return min(candidates) if candidates else None
+
+
+def _toss_us_regular_windows(calendar: Any) -> list[TossSessionWindow]:
+    return sorted(
+        (
+            day.regular_market
+            for day in calendar.days
+            if isinstance(day, TossUsMarketDay) and day.regular_market is not None
+        ),
+        key=lambda window: window.start,
+    )
+
+
+def _toss_kr_windows(calendar: Any, *, allow_nxt: bool) -> list[TossSessionWindow]:
+    windows: list[TossSessionWindow] = []
+    for day in calendar.days:
+        if not isinstance(day, TossKrMarketDay):
+            continue
+        if allow_nxt and day.pre_market is not None:
+            windows.append(day.pre_market)
+        if day.regular_market is not None:
+            windows.append(day.regular_market)
+        if allow_nxt and day.after_market is not None:
+            windows.append(day.after_market)
+    return sorted(windows, key=lambda window: window.start)
+
+
+async def _resolve_toss_us_session(
+    group: Any, now: datetime
+) -> SubmissionSessionEvidence:
+    local = now.astimezone(_KST)
+    calendar = await get_toss_market_calendar("us", local.date())
+    if calendar is None:
+        return SubmissionSessionEvidence(
+            known=False,
+            source="toss_market_calendar:us",
+            current_session="unknown",
+            allowed_sessions=("regular",),
+            allowed_now=False,
+            detail="calendar_unavailable",
+        )
+    regular_windows = _toss_us_regular_windows(calendar)
+    session = us_toss_session_for(local, calendar=calendar) or "closed"
+    current = _containing_window(regular_windows, local)
+    next_open = _next_window_start(
+        regular_windows,
+        after=current.end if current is not None else local,
+    )
+    if not regular_windows or (session != "regular" and next_open is None):
+        return SubmissionSessionEvidence(
+            known=False,
+            source="toss_market_calendar:us",
+            current_session=session,
+            allowed_sessions=("regular",),
+            allowed_now=False,
+            detail="regular_window_unavailable",
+        )
+    return SubmissionSessionEvidence(
+        known=True,
+        source="toss_market_calendar:us",
+        current_session=session,
+        allowed_sessions=("regular",),
+        allowed_now=session == "regular",
+        allowed_until=current.end
+        if session == "regular" and current is not None
+        else None,
+        next_allowed_at=next_open,
+    )
+
+
+def _resolve_xnys_session(group: Any, now: datetime) -> SubmissionSessionEvidence:
+    local = now.astimezone(_NEW_YORK)
+    bounds = regular_session_bounds("us", local.date())
+    next_day = next_trading_session("us", local.date())
+    next_bounds = (
+        regular_session_bounds("us", next_day) if next_day is not None else None
+    )
+    next_open: datetime | None = None
+    if bounds is not None:
+        session_open, session_close = bounds
+        if session_open <= now.astimezone(UTC) < session_close:
+            return SubmissionSessionEvidence(
+                known=True,
+                source="exchange_calendars:XNYS",
+                current_session="regular",
+                allowed_sessions=("regular",),
+                allowed_now=True,
+                allowed_until=session_close,
+                next_allowed_at=next_bounds[0] if next_bounds is not None else None,
+            )
+        if now.astimezone(UTC) < session_open:
+            next_open = session_open
+    if next_open is None:
+        next_open = next_bounds[0] if next_bounds is not None else None
+    if next_open is None:
+        return SubmissionSessionEvidence(
+            known=False,
+            source="exchange_calendars:XNYS",
+            current_session="closed",
+            allowed_sessions=("regular",),
+            allowed_now=False,
+            detail="next_regular_window_unavailable",
+        )
+    return SubmissionSessionEvidence(
+        known=True,
+        source="exchange_calendars:XNYS",
+        current_session="closed",
+        allowed_sessions=("regular",),
+        allowed_now=False,
+        next_allowed_at=next_open,
+    )
+
+
+async def _resolve_kr_session(group: Any, now: datetime) -> SubmissionSessionEvidence:
+    local = now.astimezone(_KST)
+    krx_bounds = regular_session_bounds("kr", local.date())
+    in_krx_regular = (
+        krx_bounds is not None and krx_bounds[0] <= now.astimezone(UTC) < krx_bounds[1]
+    )
+    calendar = await get_toss_market_calendar("kr", local.date())
+    session = (
+        kr_toss_session_for(local, calendar=calendar) or "closed"
+        if calendar is not None
+        else "unknown"
+    )
+    nxt_known = False
+    nxt_tradable = False
+    nxt_detail = "nxt_capability_unavailable"
+    try:
+        tradability = (
+            await get_kr_nxt_tradability([str(getattr(group, "symbol", "") or "")])
+        ).get(str(getattr(group, "symbol", "") or ""))
+        if tradability is not None and not tradability.is_stale(now=local):
+            nxt_known = True
+            nxt_tradable = tradability.nxt_tradable
+            nxt_detail = (
+                "nxt_tradable"
+                if nxt_tradable
+                else (
+                    "nxt_trading_suspended"
+                    if tradability.nxt_trading_suspended is True
+                    else "not_nxt_eligible"
+                )
+            )
+        elif tradability is not None:
+            nxt_detail = "nxt_capability_stale"
+    except Exception:  # noqa: BLE001 - capability uncertainty is data, not allow
+        nxt_detail = "nxt_capability_lookup_failed"
+
+    if in_krx_regular:
+        allow_nxt = calendar is not None and nxt_known and nxt_tradable
+        windows = (
+            _toss_kr_windows(calendar, allow_nxt=allow_nxt)
+            if calendar is not None
+            else []
+        )
+        current = _containing_window(windows, local)
+        next_open = _next_window_start(
+            windows,
+            after=current.end if current is not None else krx_bounds[1],
+        )
+        if next_open is None:
+            next_day = next_trading_session("kr", local.date())
+            next_bounds = (
+                regular_session_bounds("kr", next_day) if next_day is not None else None
+            )
+            next_open = next_bounds[0] if next_bounds is not None else None
+        return SubmissionSessionEvidence(
+            known=True,
+            source="exchange_calendars:XKRX+toss_nxt_capability",
+            current_session="regular",
+            allowed_sessions=(
+                ("nxt_premarket", "regular", "nxt_after") if allow_nxt else ("regular",)
+            ),
+            allowed_now=True,
+            allowed_until=krx_bounds[1],
+            next_allowed_at=next_open,
+            detail=nxt_detail,
+        )
+
+    if calendar is None:
+        return SubmissionSessionEvidence(
+            known=False,
+            source="exchange_calendars:XKRX+toss_market_calendar:kr_integrated",
+            current_session="unknown",
+            allowed_sessions=("regular",),
+            allowed_now=False,
+            detail="integrated_calendar_unavailable",
+        )
+
+    if session == "regular":
+        return SubmissionSessionEvidence(
+            known=False,
+            source="exchange_calendars:XKRX+toss_market_calendar:kr_integrated",
+            current_session=session,
+            allowed_sessions=("regular",),
+            allowed_now=False,
+            detail="regular_calendar_disagreement",
+        )
+
+    if session in _NXT_SESSIONS and not nxt_known:
+        return SubmissionSessionEvidence(
+            known=False,
+            source="toss_market_calendar:kr_integrated+kr_symbol_universe",
+            current_session=session,
+            allowed_sessions=("regular",),
+            allowed_now=False,
+            detail=nxt_detail,
+        )
+
+    allow_nxt = nxt_known and nxt_tradable
+    allowed_sessions = (
+        ("nxt_premarket", "regular", "nxt_after") if allow_nxt else ("regular",)
+    )
+    allowed_now = session in allowed_sessions
+    windows = _toss_kr_windows(calendar, allow_nxt=allow_nxt)
+    current = _containing_window(windows, local) if allowed_now else None
+    next_open = _next_window_start(
+        windows,
+        after=current.end if current is not None else local,
+    )
+    if next_open is None:
+        next_day = next_trading_session("kr", local.date())
+        next_bounds = (
+            regular_session_bounds("kr", next_day) if next_day is not None else None
+        )
+        next_open = next_bounds[0] if next_bounds is not None else None
+    if not allowed_now and next_open is None:
+        return SubmissionSessionEvidence(
+            known=False,
+            source="toss_market_calendar:kr_integrated+kr_symbol_universe",
+            current_session=session,
+            allowed_sessions=allowed_sessions,
+            allowed_now=False,
+            detail="next_allowed_window_unavailable",
+        )
+    return SubmissionSessionEvidence(
+        known=True,
+        source="toss_market_calendar:kr_integrated+kr_symbol_universe",
+        current_session=session,
+        allowed_sessions=allowed_sessions,
+        allowed_now=allowed_now,
+        allowed_until=current.end if current is not None else None,
+        next_allowed_at=next_open,
+        detail=nxt_detail,
+    )
+
+
+async def resolve_submission_session(
+    group: Any, *, now: datetime
+) -> SubmissionSessionEvidence:
+    """Resolve broker/market-aware submission capability.
+
+    Proposal orders have DAY semantics and no persisted extended-hours
+    capability bit. US live proposals are therefore regular-session only.
+    KR retains KRX regular plus NXT carry only when the existing symbol
+    universe positively proves current NXT tradability. Crypto remains 24/7.
+    """
+    market, account_mode, _action, _order_type = _contract_fields(group)
+    if market == "crypto" and account_mode == "upbit":
+        return SubmissionSessionEvidence(
+            known=True,
+            source="crypto:24x7",
+            current_session="24x7",
+            allowed_sessions=("24x7",),
+            allowed_now=True,
+        )
+    if market == "equity_us" and account_mode == "toss_live":
+        return await _resolve_toss_us_session(group, now)
+    if market == "equity_us" and account_mode == "kis_live":
+        return _resolve_xnys_session(group, now)
+    if market == "equity_kr" and account_mode in {"kis_live", "toss_live"}:
+        return await _resolve_kr_session(group, now)
+    return SubmissionSessionEvidence(
+        known=False,
+        source="unsupported_submission_contract",
+        current_session="unknown",
+        allowed_sessions=(),
+        allowed_now=False,
+        detail=f"unsupported:{account_mode}/{market}",
+    )
+
+
+async def evaluate_approval_window(
+    group: Any,
+    *,
+    now: datetime,
+    session_resolver: SessionResolver = resolve_submission_session,
+) -> ApprovalWindowDecision:
+    """Return the fail-closed decision for dispatch/callback/submit."""
+    market, account_mode, action, order_type = _contract_fields(group)
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("approval-window now must be timezone-aware")
+
+    raw_valid_until = getattr(group, "valid_until", None)
+    valid_until = raw_valid_until if isinstance(raw_valid_until, datetime) else None
+    common = {
+        "observed_at": now,
+        "valid_until": valid_until,
+        "market": market,
+        "account_mode": account_mode,
+        "action": action,
+        "order_type": order_type,
+    }
+    validity_block = valid_until_block(raw_valid_until, now=now)
+    if validity_block is not None:
+        code, detail = validity_block
+        return ApprovalWindowDecision(
+            code=code,
+            policy_stamp=_policy_stamp(group),
+            detail=detail,
+            **common,
+        )
+    assert isinstance(raw_valid_until, datetime)
+
+    try:
+        evidence = await session_resolver(group, now=now)
+    except Exception as exc:  # noqa: BLE001 - live session uncertainty fails closed
+        evidence = SubmissionSessionEvidence(
+            known=False,
+            source="session_resolver",
+            current_session="unknown",
+            allowed_sessions=(),
+            allowed_now=False,
+            detail=f"resolver_error:{type(exc).__name__}",
+        )
+    stamp = _policy_stamp(group, evidence)
+    if not evidence.known:
+        return ApprovalWindowDecision(
+            code=ApprovalWindowCode.CALENDAR_UNKNOWN,
+            policy_stamp=stamp,
+            evidence=evidence,
+            detail=evidence.detail or "session_evidence_unknown",
+            **common,
+        )
+    if evidence.allowed_now:
+        return ApprovalWindowDecision(
+            code=ApprovalWindowCode.ALLOW,
+            policy_stamp=stamp,
+            evidence=evidence,
+            **common,
+        )
+    if (
+        evidence.next_allowed_at is not None
+        and evidence.next_allowed_at >= raw_valid_until
+    ):
+        return ApprovalWindowDecision(
+            code=ApprovalWindowCode.NO_EXECUTABLE_WINDOW,
+            policy_stamp=stamp,
+            evidence=evidence,
+            detail="valid_until_not_after_next_allowed_session",
+            **common,
+        )
+    return ApprovalWindowDecision(
+        code=ApprovalWindowCode.DEFER_SESSION_CLOSED,
+        policy_stamp=stamp,
+        evidence=evidence,
+        detail="submission_session_closed",
+        **common,
+    )
+
+
+def bind_approval_window_policy(
+    decision: ApprovalWindowDecision,
+    expected_policy_stamp: str | None,
+) -> ApprovalWindowDecision:
+    """Bind fresh evidence to the policy advertised on the approval surface.
+
+    Expiry/invalidity outrank policy metadata. Every other live decision
+    requires an exact stamp; a missing stamp is not an implicit trust path.
+    """
+    if decision.code in {
+        ApprovalWindowCode.EXPIRED,
+        ApprovalWindowCode.INVALID_VALID_UNTIL,
+    }:
+        return decision
+    if expected_policy_stamp is not None and (
+        decision.policy_stamp == expected_policy_stamp
+    ):
+        return decision
+    return replace(
+        decision,
+        code=ApprovalWindowCode.CALENDAR_UNKNOWN,
+        detail=(
+            "approval_window_policy_stamp_missing"
+            if expected_policy_stamp is None
+            else "approval_window_policy_stamp_mismatch:"
+            f"expected={expected_policy_stamp}:actual={decision.policy_stamp}"
+        ),
+    )
+
+
+def recheck_approval_window_decision(
+    group: Any,
+    decision: ApprovalWindowDecision,
+    *,
+    now: datetime,
+) -> ApprovalWindowDecision:
+    """Re-check an awaited decision at the completion/send instant.
+
+    Calendar resolution can straddle an expiry or session-close edge. The
+    evidence therefore carries the authoritative end of the currently allowed
+    interval. This function performs no I/O and never extends that interval.
+    """
+    raw_valid_until = getattr(group, "valid_until", None)
+    validity_block = valid_until_block(raw_valid_until, now=now)
+    if validity_block is not None:
+        code, detail = validity_block
+        return replace(
+            decision,
+            code=code,
+            observed_at=now,
+            valid_until=(
+                raw_valid_until if isinstance(raw_valid_until, datetime) else None
+            ),
+            detail=detail,
+        )
+    if not decision.allowed:
+        return replace(decision, observed_at=now)
+
+    evidence = decision.evidence
+    if evidence is None or not evidence.known:
+        return replace(
+            decision,
+            code=ApprovalWindowCode.CALENDAR_UNKNOWN,
+            observed_at=now,
+            detail="session_evidence_missing_at_completion",
+        )
+    if evidence.allowed_sessions == ("24x7",):
+        return replace(decision, observed_at=now)
+    if evidence.allowed_until is None:
+        return replace(
+            decision,
+            code=ApprovalWindowCode.CALENDAR_UNKNOWN,
+            observed_at=now,
+            evidence=replace(
+                evidence,
+                current_session="unknown",
+                allowed_now=False,
+            ),
+            detail="allowed_interval_end_missing",
+        )
+    if now < evidence.allowed_until:
+        return replace(decision, observed_at=now)
+
+    closed_evidence = replace(
+        evidence,
+        current_session="closed",
+        allowed_now=False,
+        allowed_until=None,
+    )
+    next_allowed_at = evidence.next_allowed_at
+    if next_allowed_at is None or next_allowed_at <= now:
+        return replace(
+            decision,
+            code=ApprovalWindowCode.CALENDAR_UNKNOWN,
+            observed_at=now,
+            evidence=closed_evidence,
+            detail="next_allowed_window_stale_or_unavailable",
+        )
+    assert isinstance(raw_valid_until, datetime)
+    if next_allowed_at >= raw_valid_until:
+        return replace(
+            decision,
+            code=ApprovalWindowCode.NO_EXECUTABLE_WINDOW,
+            observed_at=now,
+            evidence=closed_evidence,
+            detail="valid_until_not_after_next_allowed_session",
+        )
+    return replace(
+        decision,
+        code=ApprovalWindowCode.DEFER_SESSION_CLOSED,
+        observed_at=now,
+        evidence=closed_evidence,
+        detail="submission_session_closed_during_evaluation",
+    )
+
+
+async def evaluate_approval_window_boundary(
+    group: Any,
+    *,
+    window_evaluator: WindowEvaluator,
+    now_fn: Callable[[], datetime],
+    expected_policy_stamp: str | None = None,
+    require_policy_stamp: bool = True,
+) -> ApprovalWindowDecision:
+    """Evaluate and then re-sample at the exact caller boundary."""
+    decision = await window_evaluator(group, now=now_fn())
+    if require_policy_stamp:
+        decision = bind_approval_window_policy(decision, expected_policy_stamp)
+    return recheck_approval_window_decision(group, decision, now=now_fn())
+
+
+def approval_window_operator_text(decision: ApprovalWindowDecision) -> str:
+    if decision.code is ApprovalWindowCode.EXPIRED:
+        return "⌛ 제안 만료"
+    if decision.code is ApprovalWindowCode.INVALID_VALID_UNTIL:
+        return "⛔ 제안 유효기간 오류 — 승인 차단"
+    if decision.code is ApprovalWindowCode.CALENDAR_UNKNOWN:
+        return "⛔ 시장 세션 확인 불가 — 승인 차단"
+    if decision.code is ApprovalWindowCode.NO_EXECUTABLE_WINDOW:
+        prefix = "⌛ 다음 주문 가능 세션 전에 만료 —"
+    elif decision.code is ApprovalWindowCode.DEFER_SESSION_CLOSED:
+        prefix = "🌙 주문 가능 세션 아님 —"
+    else:
+        return "승인 가능"
+    if decision.code in {
+        ApprovalWindowCode.NO_EXECUTABLE_WINDOW,
+        ApprovalWindowCode.DEFER_SESSION_CLOSED,
+    }:
+        next_at = (
+            decision.evidence.next_allowed_at.isoformat()
+            if decision.evidence is not None
+            and decision.evidence.next_allowed_at is not None
+            else "확인 불가"
+        )
+        return f"{prefix} 다음 허용 세션: {next_at}"
+    return "승인 가능"
+
+
+def approval_window_rung_result(
+    decision: ApprovalWindowDecision,
+) -> Literal[
+    "expired",
+    "invalid_valid_until",
+    "defer_session_closed",
+    "calendar_unknown",
+    "no_executable_window",
+]:
+    return {
+        ApprovalWindowCode.EXPIRED: "expired",
+        ApprovalWindowCode.INVALID_VALID_UNTIL: "invalid_valid_until",
+        ApprovalWindowCode.DEFER_SESSION_CLOSED: "defer_session_closed",
+        ApprovalWindowCode.CALENDAR_UNKNOWN: "calendar_unknown",
+        ApprovalWindowCode.NO_EXECUTABLE_WINDOW: "no_executable_window",
+    }[decision.code]

--- a/app/services/order_proposals/approval_window_contract.py
+++ b/app/services/order_proposals/approval_window_contract.py
@@ -1,0 +1,40 @@
+"""Pure types and validity checks for the order-proposal approval window."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+
+class ApprovalWindowCode(StrEnum):
+    ALLOW = "ALLOW"
+    EXPIRED = "EXPIRED"
+    INVALID_VALID_UNTIL = "INVALID_VALID_UNTIL"
+    DEFER_SESSION_CLOSED = "DEFER_SESSION_CLOSED"
+    CALENDAR_UNKNOWN = "CALENDAR_UNKNOWN"
+    NO_EXECUTABLE_WINDOW = "NO_EXECUTABLE_WINDOW"
+
+
+def _aware(value: object) -> bool:
+    return (
+        isinstance(value, datetime)
+        and value.tzinfo is not None
+        and value.utcoffset() is not None
+    )
+
+
+def valid_until_block(
+    value: object, *, now: datetime
+) -> tuple[ApprovalWindowCode, str] | None:
+    """Return a typed fail-closed validity error, or ``None`` while valid."""
+    if not _aware(now):
+        raise ValueError("approval-window now must be timezone-aware")
+    if value is None:
+        return ApprovalWindowCode.INVALID_VALID_UNTIL, "valid_until_missing"
+    if not isinstance(value, datetime):
+        return ApprovalWindowCode.INVALID_VALID_UNTIL, "valid_until_invalid_type"
+    if not _aware(value):
+        return ApprovalWindowCode.INVALID_VALID_UNTIL, "valid_until_naive"
+    if now >= value:
+        return ApprovalWindowCode.EXPIRED, "now_at_or_after_valid_until"
+    return None

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
@@ -662,38 +662,49 @@ async def cancel_target_order(
     account_mode: str,
     cancel_fn: Callable[..., Any] | None = None,
     toss_cancel_fn: Callable[..., Any] | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     if (account_mode, market) not in SUPPORTED_TARGET_ACTIONS:
         raise OrderProposalError(f"cancel unsupported for {account_mode}/{market}")
     if account_mode == "toss_live":
         if toss_cancel_fn is None:
-            from app.mcp_server.tooling.orders_toss_variants import toss_cancel_order
+            from app.mcp_server.tooling.orders_toss_variants import (
+                _bind_toss_pre_send_hook,
+                toss_cancel_order,
+            )
 
             toss_cancel_fn = toss_cancel_order
+        else:
+            from app.mcp_server.tooling.orders_toss_variants import (
+                _bind_toss_pre_send_hook,
+            )
         # toss_cancel_order is the production tool: it still enforces
         # TOSS_LIVE_ORDER_MUTATIONS_ENABLED and records the accepted-only
         # ledger row itself. This call site is only ever reached post-Telegram
         # approval (revalidate_and_submit's cancel/replace execution branch),
         # so dry_run=False/confirm=True mirrors cancel_order_impl's KIS/Upbit
         # path below, which has no dry_run/preview concept at all.
-        return await _maybe_await(
-            toss_cancel_fn(
-                order_id=order_id,
-                dry_run=False,
-                confirm=True,
-                account_mode=account_mode,
+        with _bind_toss_pre_send_hook(pre_send_hook):
+            return await _maybe_await(
+                toss_cancel_fn(
+                    order_id=order_id,
+                    dry_run=False,
+                    confirm=True,
+                    account_mode=account_mode,
+                )
             )
-        )
     if cancel_fn is None:
         from app.mcp_server.tooling.orders_modify_cancel import cancel_order_impl
 
         cancel_fn = cancel_order_impl
 
+    hook_kw = {"pre_send_hook": pre_send_hook} if pre_send_hook is not None else {}
     return await _maybe_await(
         cancel_fn(
             order_id=order_id,
             symbol=symbol,
             market=market,
             is_mock=False,
+            **hook_kw,
         )
     )

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -34,6 +34,14 @@ from app.services.order_proposals.approval_message import (
     build_approval_dispatch_messages,
     build_batch_approval_message,
 )
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowCode,
+    ApprovalWindowDecision,
+    WindowEvaluator,
+    evaluate_approval_window,
+    evaluate_approval_window_boundary,
+    recheck_approval_window_decision,
+)
 from app.services.order_proposals.auto_approve import (
     build_auto_approved_message,
     evaluate_auto_approve_eligibility,
@@ -73,6 +81,7 @@ logger = logging.getLogger(__name__)
 
 ServiceFactory = Callable[[], Any]
 RevalidateFn = Callable[..., Any]
+Clock = Callable[[], datetime]
 
 
 def _generate_nonce() -> str:
@@ -107,6 +116,8 @@ async def _register_and_publish_batch_summary(
     chat_id: str,
     now: datetime,
     notifier: Any,
+    window_evaluator: WindowEvaluator,
+    now_fn: Clock,
 ) -> None:
     """Publish a new immutable batch card after freezing its exact members."""
     registration = await service.register_approval_batch_member(
@@ -121,9 +132,56 @@ async def _register_and_publish_batch_summary(
         or registration.binding is None
     ):
         return
+    # Make the frozen membership and summary-delivery claim visible before
+    # publishing a button that depends on both rows.
+    await session.commit()
     batch, proposals = await service.get_approval_batch_display(
-        registration.batch.batch_id
+        registration.batch.batch_id,
+        for_update=True,
     )
+    decisions: list[tuple[Any, ApprovalWindowDecision]] = []
+    for group, _rungs in proposals:
+        expected = (group.source_asof or {}).get("approval_window_policy_stamp")
+        decision = await evaluate_approval_window_boundary(
+            group,
+            window_evaluator=window_evaluator,
+            now_fn=now_fn,
+            expected_policy_stamp=str(expected) if expected is not None else None,
+        )
+        if not decision.allowed:
+            if decision.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(
+                    group.proposal_id,
+                    now=decision.observed_at,
+                )
+            await service.release_approval_batch_summary_claim(
+                batch.batch_id,
+                now=decision.observed_at,
+            )
+            await session.commit()
+            return
+        decisions.append((group, decision))
+
+    final_now = now_fn()
+    for group, decision in decisions:
+        final_decision = recheck_approval_window_decision(
+            group,
+            decision,
+            now=final_now,
+        )
+        if not final_decision.allowed:
+            if final_decision.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(
+                    group.proposal_id,
+                    now=final_decision.observed_at,
+                )
+            await service.release_approval_batch_summary_claim(
+                batch.batch_id,
+                now=final_decision.observed_at,
+            )
+            await session.commit()
+            return
+
     text, keyboard = build_batch_approval_message(
         batch=batch,
         proposals=proposals,
@@ -140,8 +198,30 @@ async def _register_and_publish_batch_summary(
         attempt_id=registration.binding.attempt_id,
         payload_chars=messages.payload_chars,
     )
-    # Freeze + pending owner must be durable before the external publication.
+    # The immutable member set, pending owner, and exact payload are durable
+    # before publication, matching the individual dispatch attempt contract.
     await session.commit()
+
+    publish_now = now_fn()
+    for group, decision in decisions:
+        final_decision = recheck_approval_window_decision(
+            group,
+            decision,
+            now=publish_now,
+        )
+        if not final_decision.allowed:
+            if final_decision.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(
+                    group.proposal_id,
+                    now=final_decision.observed_at,
+                )
+            await service.release_approval_batch_summary_claim(
+                batch.batch_id,
+                now=final_decision.observed_at,
+            )
+            await session.commit()
+            return
+
     publication = await publish_approval_messages(
         notifier=notifier,
         messages=messages,
@@ -151,7 +231,7 @@ async def _register_and_publish_batch_summary(
         batch.batch_id,
         attempt_id=registration.binding.attempt_id,
         publication=publication,
-        now=now,
+        now=publish_now,
     )
 
 
@@ -161,13 +241,16 @@ async def send_proposal_for_approval(
     notifier: Any,
     now: datetime,
     service_factory: ServiceFactory = AsyncSessionLocal,
-) -> TelegramDispatchResult:
+    window_evaluator: WindowEvaluator | None = None,
+    now_fn: Clock | None = None,
+) -> TelegramDispatchResult | ApprovalWindowDecision:
     """Mint a fresh approval nonce, render the message, and send it.
 
     Sends to the FIRST entry in
-    ``settings.order_proposals_telegram_chat_allowlist`` -- the return type
-    is a single workflow result. An empty allowlist is recorded as a durable
-    local failure without minting a nonce.
+    ``settings.order_proposals_telegram_chat_allowlist``. A fail-closed
+    approval-window preflight returns its typed decision without minting a
+    nonce or publishing a card. An empty allowlist is recorded as a durable
+    typed dispatch failure without minting a nonce.
     """
     allowlist = settings.order_proposals_telegram_chat_allowlist
     if not allowlist:
@@ -186,6 +269,42 @@ async def send_proposal_for_approval(
 
     async with service_factory() as session:
         service = OrderProposalsService(session)
+        group, _rungs = await service.get_proposal(proposal_id)
+        evaluate_window = window_evaluator or evaluate_approval_window
+        clock = now_fn or (lambda: now)
+        window = await evaluate_approval_window_boundary(
+            group,
+            window_evaluator=evaluate_window,
+            now_fn=clock,
+            require_policy_stamp=False,
+        )
+        observed_now = window.observed_at
+        if not window.allowed:
+            if window.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(
+                    proposal_id, now=observed_now
+                )
+            await session.commit()
+            return window
+
+        # Calendar resolution above may await broker/exchange evidence. Sample
+        # the clock and policy again at the actual nonce/card boundary so a
+        # validity or session edge crossed during that I/O cannot mint a
+        # nonce or publish an already-stale button.
+        window = await evaluate_approval_window_boundary(
+            group,
+            window_evaluator=evaluate_window,
+            now_fn=clock,
+            require_policy_stamp=False,
+        )
+        publish_now = window.observed_at
+        if not window.allowed:
+            if window.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(
+                    proposal_id, now=publish_now
+                )
+            await session.commit()
+            return window
 
         fresh_nonce = _generate_nonce()
         await service.set_approval_nonce(proposal_id, fresh_nonce)
@@ -198,13 +317,36 @@ async def send_proposal_for_approval(
             card_kind=ApprovalCardKind.MANUAL,
         )
         messages = build_approval_dispatch_messages(
-            group=group, rungs=rungs, binding=binding
+            group=group,
+            rungs=rungs,
+            binding=binding,
         )
+
+        send_window = await evaluate_approval_window_boundary(
+            group,
+            window_evaluator=evaluate_window,
+            now_fn=clock,
+            expected_policy_stamp=window.policy_stamp,
+        )
+        if not send_window.allowed:
+            if send_window.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(
+                    proposal_id,
+                    now=send_window.observed_at,
+                )
+            else:
+                await service.clear_approval_nonce(
+                    proposal_id,
+                    expected_nonce=fresh_nonce,
+                )
+            await session.commit()
+            return send_window
+
         await service.start_approval_dispatch(
             proposal_id,
             attempt_id=attempt_id,
             binding=binding,
-            now=now,
+            now=send_window.observed_at,
             payload_chars=messages.payload_chars,
             context_message_count=len(messages.context_messages),
         )
@@ -224,7 +366,8 @@ async def send_proposal_for_approval(
             attempt_id=attempt_id,
             publication=publication,
             chat_id=chat_id,
-            now=now,
+            now=send_window.observed_at,
+            approval_window_policy_stamp=send_window.policy_stamp,
         )
         await session.commit()
         if result.approvable and result.message_id is not None:
@@ -234,8 +377,10 @@ async def send_proposal_for_approval(
                 proposal_id=proposal_id,
                 message_id=result.message_id,
                 chat_id=chat_id,
-                now=now,
+                now=send_window.observed_at,
                 notifier=notifier,
+                window_evaluator=evaluate_window,
+                now_fn=clock,
             )
             await session.commit()
     return result
@@ -355,7 +500,9 @@ async def dispatch_proposal(
     revalidate_fn: RevalidateFn = revalidate_and_submit,
     cancel_target_fn: TargetCancelFn = cancel_target_order,
     fetch_target_fn: TargetFetchFn = fetch_target_order,
-) -> TelegramDispatchResult:
+    window_evaluator: WindowEvaluator | None = None,
+    now_fn: Clock | None = None,
+) -> TelegramDispatchResult | ApprovalWindowDecision:
     """Auto-submit an eligible resting proposal, otherwise send for approval."""
     if not settings.ORDER_PROPOSALS_AUTO_APPROVE:
         return await send_proposal_for_approval(
@@ -363,8 +510,11 @@ async def dispatch_proposal(
             notifier=notifier,
             now=now,
             service_factory=service_factory,
+            window_evaluator=window_evaluator,
+            now_fn=now_fn,
         )
 
+    clock = now_fn or (lambda: now)
     auto_submitted = False
     messages: ApprovalDispatchMessages | None = None
     attempt_id: uuid.UUID | None = None
@@ -372,6 +522,19 @@ async def dispatch_proposal(
         service = OrderProposalsService(session)
         await service.acquire_auto_dispatch_lock(proposal_id)
         group, initial_rungs = await service.get_proposal(proposal_id)
+        evaluate_window = window_evaluator or evaluate_approval_window
+        window = await evaluate_approval_window_boundary(
+            group,
+            window_evaluator=evaluate_window,
+            now_fn=clock,
+            require_policy_stamp=False,
+        )
+        gate_now = window.observed_at
+        if not window.allowed:
+            if window.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(proposal_id, now=gate_now)
+            await session.commit()
+            return window
         pending_count = sum(rung.state == "pending_approval" for rung in initial_rungs)
         if pending_count == 0:
             await session.commit()
@@ -410,12 +573,19 @@ async def dispatch_proposal(
                     daily_notional = Decimal(decision.details["daily_notional_after"])
                 return decision
 
-            outcomes: list[RungOutcome] = await revalidate_fn(
-                service=service,
-                proposal_id=proposal_id,
-                now=now,
-                eligibility_gate=eligibility_gate,
-            )
+            revalidate_kwargs: dict[str, Any] = {
+                "service": service,
+                "proposal_id": proposal_id,
+                "now": gate_now,
+                "eligibility_gate": eligibility_gate,
+            }
+            if revalidate_fn is revalidate_and_submit:
+                revalidate_kwargs.update(
+                    window_evaluator=evaluate_window,
+                    expected_policy_stamp=window.policy_stamp,
+                    now_fn=clock,
+                )
+            outcomes: list[RungOutcome] = await revalidate_fn(**revalidate_kwargs)
             submitted_results = {"submitted_acked", "submitted_resting"}
             auto_submitted = (
                 bool(outcomes)
@@ -470,6 +640,8 @@ async def dispatch_proposal(
             notifier=notifier,
             now=now,
             service_factory=service_factory,
+            window_evaluator=window_evaluator,
+            now_fn=clock,
         )
 
     allowlist = settings.order_proposals_telegram_chat_allowlist

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -69,7 +69,7 @@ class OrderProposalRepository:
     ) -> OrderProposal | None:
         stmt = select(OrderProposal).where(OrderProposal.proposal_id == proposal_id)
         if for_update:
-            stmt = stmt.with_for_update()
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
     async def list_groups_by_proposal_prefix(
@@ -88,6 +88,7 @@ class OrderProposalRepository:
             select(OrderProposalRung)
             .where(OrderProposalRung.proposal_pk == proposal_pk)
             .order_by(OrderProposalRung.rung_index)
+            .execution_options(populate_existing=True)
         )
         return list((await self._session.execute(stmt)).scalars().all())
 
@@ -335,7 +336,7 @@ class OrderProposalRepository:
             .limit(1)
         )
         if for_update:
-            stmt = stmt.with_for_update()
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
     async def insert_approval_batch(self, **cols: Any) -> OrderProposalApprovalBatch:
@@ -370,7 +371,7 @@ class OrderProposalRepository:
             OrderProposalApprovalBatchMember.id == member_id
         )
         if for_update:
-            stmt = stmt.with_for_update()
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
     async def list_approval_batch_members(
@@ -383,11 +384,19 @@ class OrderProposalRepository:
                 OrderProposalApprovalBatchMember.added_at,
                 OrderProposalApprovalBatchMember.id,
             )
+            .execution_options(populate_existing=True)
         )
         return list((await self._session.execute(stmt)).scalars().all())
 
-    async def get_group_by_pk(self, proposal_pk: int) -> OrderProposal | None:
+    async def get_group_by_pk(
+        self,
+        proposal_pk: int,
+        *,
+        for_update: bool = False,
+    ) -> OrderProposal | None:
         stmt = select(OrderProposal).where(OrderProposal.id == proposal_pk)
+        if for_update:
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
     async def get_approval_batch_by_id(
@@ -397,7 +406,7 @@ class OrderProposalRepository:
             OrderProposalApprovalBatch.batch_id == batch_id
         )
         if for_update:
-            stmt = stmt.with_for_update()
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
     async def resolve_approval_batch_id_prefix(

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -35,7 +35,16 @@ from typing import Any, Literal
 
 from app.core.timezone import now_kst
 from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.services.brokers.kis.pre_send import PreSendFreshnessError
 from app.services.live_correlation import live_correlation_id
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowCode,
+    ApprovalWindowDecision,
+    WindowEvaluator,
+    approval_window_rung_result,
+    evaluate_approval_window,
+    evaluate_approval_window_boundary,
+)
 from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
     fetch_submit_evidence,
@@ -69,6 +78,11 @@ RungOutcomeResult = Literal[
     "error",
     "cancelled",
     "approval_required",
+    "expired",
+    "invalid_valid_until",
+    "defer_session_closed",
+    "calendar_unknown",
+    "no_executable_window",
 ]
 
 
@@ -87,6 +101,7 @@ SubmitEvidenceFetchFn = Callable[..., Any]
 RetrospectiveLookupFn = Callable[[int], Any]
 EligibilityGate = Callable[..., Any]
 OppositePendingCheckFn = Callable[..., Any]
+Clock = Callable[[], datetime]
 
 _PREVIEW_REASON = "order_proposal revalidation (rung {rung})"
 _SUBMIT_REASON = "order_proposal submit after revalidation (rung {rung})"
@@ -107,6 +122,162 @@ _GUARD_ERROR_MARKERS = (
 _TOSS_CLIENT_ORDER_ID_MAX_LENGTH = 36
 _TOSS_CLIENT_ORDER_ID_PATTERN = re.compile(r"[a-zA-Z0-9\-_]+")
 _SUBMIT_DIAGNOSTIC_MAX_LENGTH = 240
+
+
+async def _converge_window_block(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    decision: ApprovalWindowDecision,
+    now: datetime,
+    restore_pre_send_state: bool,
+) -> RungOutcome:
+    expired = decision.code is ApprovalWindowCode.EXPIRED
+    if restore_pre_send_state and rung.state in {
+        "revalidating",
+        "approved",
+        "submitting",
+    }:
+        await service.restore_rung_after_pre_send_block(
+            group.proposal_id,
+            rung.rung_index,
+            now=now,
+            expired=expired,
+        )
+    elif expired:
+        await service.expire_rung_if_needed(
+            group.proposal_id,
+            rung.rung_index,
+            now=now,
+        )
+    return RungOutcome(
+        rung.rung_index,
+        approval_window_rung_result(decision),
+        {"approval_window": decision.to_dict(), "error": decision.code.value},
+    )
+
+
+async def _pre_mutation_window_gate(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    window_evaluator: WindowEvaluator,
+    expected_policy_stamp: str,
+    now_fn: Clock,
+) -> RungOutcome | None:
+    decision = await evaluate_approval_window_boundary(
+        group,
+        window_evaluator=window_evaluator,
+        now_fn=now_fn,
+        expected_policy_stamp=expected_policy_stamp,
+    )
+    if decision.allowed:
+        return None
+    return await _converge_window_block(
+        service=service,
+        group=group,
+        rung=rung,
+        decision=decision,
+        now=decision.observed_at,
+        restore_pre_send_state=True,
+    )
+
+
+async def _post_cancel_replace_window_gate(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    window_evaluator: WindowEvaluator,
+    expected_policy_stamp: str,
+    now_fn: Clock,
+) -> RungOutcome | None:
+    """Recheck immediately before the replacement submit.
+
+    Replace is necessarily a two-leg broker operation in the current gateway:
+    cancel the original, confirm that cancellation, then place the replacement.
+    If the approval window closes while the cancel leg is in flight, the
+    replacement must still fail closed. The original cancellation is already
+    authoritative broker evidence at that point, so preserve it as
+    ``cancelled`` instead of pretending the whole proposal can return to
+    ``pending_approval`` or ``expired``.
+    """
+    decision = await evaluate_approval_window_boundary(
+        group,
+        window_evaluator=window_evaluator,
+        now_fn=now_fn,
+        expected_policy_stamp=expected_policy_stamp,
+    )
+    if decision.allowed:
+        return None
+    return await _record_post_cancel_window_block(
+        service=service,
+        group=group,
+        rung=rung,
+        decision=decision,
+    )
+
+
+async def _record_post_cancel_window_block(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    decision: ApprovalWindowDecision,
+) -> RungOutcome:
+    target_id = group.target_broker_order_id
+    if target_id is None:
+        raise AssertionError("target id validated before replacement cancellation")
+    await service.record_cancelled(
+        group.proposal_id,
+        rung.rung_index,
+        broker_order_id=target_id,
+        now=decision.observed_at,
+    )
+    return RungOutcome(
+        rung.rung_index,
+        approval_window_rung_result(decision),
+        {
+            "approval_window": decision.to_dict(),
+            "error": (
+                f"{decision.code.value}:target_cancelled_replacement_not_submitted"
+            ),
+            "target_cancelled": True,
+            "replacement_submitted": False,
+        },
+    )
+
+
+class ApprovalWindowPreSendGate:
+    """Transport hook that aborts immediately before an HTTP mutation."""
+
+    def __init__(
+        self,
+        *,
+        group: OrderProposal,
+        window_evaluator: WindowEvaluator,
+        expected_policy_stamp: str,
+        now_fn: Clock,
+    ) -> None:
+        self._group = group
+        self._window_evaluator = window_evaluator
+        self._expected_policy_stamp = expected_policy_stamp
+        self._now_fn = now_fn
+        self.blocked_decision: ApprovalWindowDecision | None = None
+
+    async def __call__(self) -> None:
+        decision = await evaluate_approval_window_boundary(
+            self._group,
+            window_evaluator=self._window_evaluator,
+            now_fn=self._now_fn,
+            expected_policy_stamp=self._expected_policy_stamp,
+        )
+        if decision.allowed:
+            return
+        self.blocked_decision = decision
+        raise PreSendFreshnessError((f"approval_window:{decision.code.value}",))
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -362,6 +533,7 @@ async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
     if account_mode == "toss_live":
         from app.mcp_server.tooling.orders_toss_variants import (
             _bind_order_proposal_context,
+            _bind_toss_pre_send_hook,
             toss_place_order,
             toss_preview_order,
         )
@@ -401,10 +573,13 @@ async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
                     "[a-zA-Z0-9\\-_]+"
                 ),
             }
-        with _bind_order_proposal_context(
-            client_order_id=str(proposal_client_order_id),
-            correlation_id=kwargs.get("correlation_id"),
-            rung=kwargs.get("rung"),
+        with (
+            _bind_order_proposal_context(
+                client_order_id=str(proposal_client_order_id),
+                correlation_id=kwargs.get("correlation_id"),
+                rung=kwargs.get("rung"),
+            ),
+            _bind_toss_pre_send_hook(kwargs.get("pre_send_hook")),
         ):
             submit = await toss_place_order(
                 **toss_kwargs,
@@ -567,6 +742,9 @@ async def revalidate_and_submit(
     buying_power_releaser: BuyingPowerReleaser = default_buying_power_releaser,
     eligibility_gate: EligibilityGate | None = None,
     opposite_pending_check_fn: OppositePendingCheckFn = _default_toss_opposite_pending_check,
+    window_evaluator: WindowEvaluator | None = None,
+    expected_policy_stamp: str | None = None,
+    now_fn: Clock | None = None,
 ) -> list[RungOutcome]:
     """Revalidate + (maybe) submit every ``pending_approval`` rung.
 
@@ -582,6 +760,37 @@ async def revalidate_and_submit(
             for rung in rungs
         ]
     pending_rungs = [rung for rung in rungs if rung.state == "pending_approval"]
+    evaluate_window = window_evaluator or evaluate_approval_window
+    clock = now_fn or (lambda: now)
+    persisted_stamp = (group.source_asof or {}).get("approval_window_policy_stamp")
+    active_policy_stamp = (
+        expected_policy_stamp
+        if expected_policy_stamp is not None
+        else str(persisted_stamp)
+        if persisted_stamp is not None
+        else None
+    )
+    initial_window = await evaluate_approval_window_boundary(
+        group,
+        window_evaluator=evaluate_window,
+        now_fn=clock,
+        expected_policy_stamp=active_policy_stamp,
+    )
+    if not initial_window.allowed:
+        outcomes: list[RungOutcome] = []
+        for rung in pending_rungs:
+            outcomes.append(
+                await _converge_window_block(
+                    service=service,
+                    group=group,
+                    rung=rung,
+                    decision=initial_window,
+                    now=initial_window.observed_at,
+                    restore_pre_send_state=False,
+                )
+            )
+        return outcomes
+    assert active_policy_stamp is not None
     if eligibility_gate is not None and len(pending_rungs) > 1:
         # Auto-dispatch must be lossless: submitting one ladder rung before a
         # later rung fails eligibility or buying-power checks would violate
@@ -612,6 +821,9 @@ async def revalidate_and_submit(
                 correlation_mint=correlation_mint,
                 fetch_submit_evidence_fn=fetch_submit_evidence_fn,
                 eligibility_gate=eligibility_gate,
+                window_evaluator=evaluate_window,
+                expected_policy_stamp=active_policy_stamp,
+                now_fn=clock,
                 opposite_pending_check_fn=opposite_pending_check_fn,
             )
         elif action == "cancel":
@@ -623,6 +835,9 @@ async def revalidate_and_submit(
                 fetch_target_fn=fetch_target_fn,
                 cancel_target_fn=cancel_target_fn,
                 eligibility_gate=eligibility_gate,
+                window_evaluator=evaluate_window,
+                expected_policy_stamp=active_policy_stamp,
+                now_fn=clock,
             )
         else:
             outcome = await _revalidate_place_rung(
@@ -636,6 +851,9 @@ async def revalidate_and_submit(
                 buying_power_claimer=buying_power_claimer,
                 buying_power_releaser=buying_power_releaser,
                 eligibility_gate=eligibility_gate,
+                window_evaluator=evaluate_window,
+                expected_policy_stamp=active_policy_stamp,
+                now_fn=clock,
             )
         outcomes.append(outcome)
     return outcomes
@@ -722,6 +940,9 @@ async def _revalidate_place_rung(
     buying_power_claimer: BuyingPowerClaimer,
     buying_power_releaser: BuyingPowerReleaser,
     eligibility_gate: EligibilityGate | None,
+    window_evaluator: WindowEvaluator,
+    expected_policy_stamp: str,
+    now_fn: Clock,
 ) -> RungOutcome:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -732,6 +953,17 @@ async def _revalidate_place_rung(
         if group.account_mode == "upbit"
         else None
     )
+
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
 
     await service.transition_rung(proposal_id, rung_index, new_state="revalidating")
 
@@ -835,6 +1067,17 @@ async def _revalidate_place_rung(
     if gate_outcome is not None:
         return gate_outcome
 
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
+
     buying_power_reservation: tuple[str, Decimal, str | None] | None = None
     if rung.side == "buy" and rung.limit_price is not None:
         currency = currency_for_market(group.market)
@@ -889,10 +1132,32 @@ async def _revalidate_place_rung(
         if available is not None:
             buying_power_reservation = (currency, required, claim_token)
 
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        await _release_after_rejection(
+            buying_power_releaser=buying_power_releaser,
+            group=group,
+            reservation=buying_power_reservation,
+        )
+        return window_outcome
+
     await service.transition_rung(proposal_id, rung_index, new_state="approved")
     await service.transition_rung(proposal_id, rung_index, new_state="submitting")
 
     corr = await _maybe_await(correlation_mint(group=group, rung=rung, now=now))
+    transport_gate = ApprovalWindowPreSendGate(
+        group=group,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
 
     try:
         submit = await _maybe_await(
@@ -920,9 +1185,24 @@ async def _revalidate_place_rung(
                 ),
                 rung=rung_index,
                 correlation_id=corr,
+                pre_send_hook=transport_gate,
             )
         )
     except Exception as exc:  # noqa: BLE001 - broker call; ambiguous, not a void
+        if transport_gate.blocked_decision is not None:
+            await _release_after_rejection(
+                buying_power_releaser=buying_power_releaser,
+                group=group,
+                reservation=buying_power_reservation,
+            )
+            return await _converge_window_block(
+                service=service,
+                group=group,
+                rung=rung,
+                decision=transport_gate.blocked_decision,
+                now=transport_gate.blocked_decision.observed_at,
+                restore_pre_send_state=True,
+            )
         if group.account_mode == "upbit":
             outcome = await _classify_submit(
                 service=service,
@@ -948,6 +1228,21 @@ async def _revalidate_place_rung(
             )
             outcome = RungOutcome(rung_index, "unverified", {"error": str(exc)})
         return outcome
+
+    if transport_gate.blocked_decision is not None:
+        await _release_after_rejection(
+            buying_power_releaser=buying_power_releaser,
+            group=group,
+            reservation=buying_power_reservation,
+        )
+        return await _converge_window_block(
+            service=service,
+            group=group,
+            rung=rung,
+            decision=transport_gate.blocked_decision,
+            now=transport_gate.blocked_decision.observed_at,
+            restore_pre_send_state=True,
+        )
 
     outcome = await _classify_submit(
         service=service,
@@ -1155,6 +1450,9 @@ async def _cancel_and_confirm_target(
     now: datetime,
     fetch_target_fn: TargetFetchFn,
     cancel_target_fn: TargetCancelFn,
+    window_evaluator: WindowEvaluator,
+    expected_policy_stamp: str,
+    now_fn: Clock,
 ) -> RungOutcome | None:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -1167,6 +1465,12 @@ async def _cancel_and_confirm_target(
             rung_index, "error", {"error": "target_broker_order_id_missing"}
         )
 
+    transport_gate = ApprovalWindowPreSendGate(
+        group=group,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
     try:
         cancel_result = await _maybe_await(
             cancel_target_fn(
@@ -1174,13 +1478,33 @@ async def _cancel_and_confirm_target(
                 symbol=group.symbol,
                 market=group.market,
                 account_mode=group.account_mode,
+                pre_send_hook=transport_gate,
             )
         )
     except Exception as exc:
+        if transport_gate.blocked_decision is not None:
+            return await _converge_window_block(
+                service=service,
+                group=group,
+                rung=rung,
+                decision=transport_gate.blocked_decision,
+                now=transport_gate.blocked_decision.observed_at,
+                restore_pre_send_state=True,
+            )
         await service.record_unverified(
             proposal_id, rung_index, reason=f"cancel_exception:{exc}", now=now
         )
         return RungOutcome(rung_index, "unverified", {"error": str(exc)})
+
+    if transport_gate.blocked_decision is not None:
+        return await _converge_window_block(
+            service=service,
+            group=group,
+            rung=rung,
+            decision=transport_gate.blocked_decision,
+            now=transport_gate.blocked_decision.observed_at,
+            restore_pre_send_state=True,
+        )
 
     if not isinstance(cancel_result, dict) or cancel_result.get("success") is not True:
         reason = (
@@ -1288,6 +1612,9 @@ async def _revalidate_replace_rung(
     correlation_mint: CorrelationMint,
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
     eligibility_gate: EligibilityGate | None = None,
+    window_evaluator: WindowEvaluator,
+    expected_policy_stamp: str,
+    now_fn: Clock,
     opposite_pending_check_fn: OppositePendingCheckFn = _default_toss_opposite_pending_check,
 ) -> RungOutcome:
     proposal_client_order_id = (
@@ -1297,6 +1624,17 @@ async def _revalidate_replace_rung(
         if group.account_mode == "upbit"
         else None
     )
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
+
     target_outcome = await _validate_target_action(
         service=service,
         group=group,
@@ -1326,6 +1664,17 @@ async def _revalidate_replace_rung(
     if gate_outcome is not None:
         return gate_outcome
 
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
+
     preview, preview_outcome = await _revalidate_replace_preview(
         service=service,
         group=group,
@@ -1336,6 +1685,17 @@ async def _revalidate_replace_rung(
     )
     if preview_outcome is not None:
         return preview_outcome
+
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
 
     # ROB-972 round-1 finding: Toss's live place path rejects an
     # opposite-side pending order just before POST, but the dry-run preview
@@ -1354,6 +1714,17 @@ async def _revalidate_replace_rung(
     if opposite_outcome is not None:
         return opposite_outcome
 
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
+
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
     await service.transition_rung(proposal_id, rung_index, new_state="approved")
@@ -1365,11 +1736,31 @@ async def _revalidate_replace_rung(
         now=now,
         fetch_target_fn=fetch_target_fn,
         cancel_target_fn=cancel_target_fn,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
     )
     if cancel_outcome is not None:
         return cancel_outcome
 
     corr = await _maybe_await(correlation_mint(group=group, rung=rung, now=now))
+    window_outcome = await _post_cancel_replace_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
+
+    transport_gate = ApprovalWindowPreSendGate(
+        group=group,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
     try:
         submit = await _maybe_await(
             place_order_fn(
@@ -1396,9 +1787,17 @@ async def _revalidate_replace_rung(
                     if proposal_client_order_id is not None
                     else {}
                 ),
+                pre_send_hook=transport_gate,
             )
         )
     except Exception as exc:
+        if transport_gate.blocked_decision is not None:
+            return await _record_post_cancel_window_block(
+                service=service,
+                group=group,
+                rung=rung,
+                decision=transport_gate.blocked_decision,
+            )
         if group.account_mode == "upbit":
             return await _classify_submit(
                 service=service,
@@ -1422,6 +1821,13 @@ async def _revalidate_replace_rung(
             idempotency_key=preview.get("idempotency_key"),
         )
         return RungOutcome(rung_index, "unverified", {"error": str(exc)})
+    if transport_gate.blocked_decision is not None:
+        return await _record_post_cancel_window_block(
+            service=service,
+            group=group,
+            rung=rung,
+            decision=transport_gate.blocked_decision,
+        )
     return await _classify_submit(
         service=service,
         proposal_id=proposal_id,
@@ -1446,7 +1852,21 @@ async def _revalidate_cancel_rung(
     fetch_target_fn: TargetFetchFn,
     cancel_target_fn: TargetCancelFn,
     eligibility_gate: EligibilityGate | None = None,
+    window_evaluator: WindowEvaluator,
+    expected_policy_stamp: str,
+    now_fn: Clock,
 ) -> RungOutcome:
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
+
     target_outcome = await _validate_target_action(
         service=service,
         group=group,
@@ -1473,6 +1893,17 @@ async def _revalidate_cancel_rung(
     if gate_outcome is not None:
         return gate_outcome
 
+    window_outcome = await _pre_mutation_window_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
+    )
+    if window_outcome is not None:
+        return window_outcome
+
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
     await service.transition_rung(proposal_id, rung_index, new_state="approved")
@@ -1484,6 +1915,9 @@ async def _revalidate_cancel_rung(
         now=now,
         fetch_target_fn=fetch_target_fn,
         cancel_target_fn=cancel_target_fn,
+        window_evaluator=window_evaluator,
+        expected_policy_stamp=expected_policy_stamp,
+        now_fn=now_fn,
     )
     if cancel_outcome is not None:
         return cancel_outcome

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -29,6 +29,7 @@ from app.models.order_proposals import (
 )
 from app.models.review import TossLiveOrderLedger
 from app.services.order_proposals import state_machine as sm
+from app.services.order_proposals.approval_window_contract import valid_until_block
 from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
 from app.services.order_proposals.defensive_ttl import (
     DEFENSIVE_EXIT_INTENTS,
@@ -295,8 +296,10 @@ def batch_member_block_reason(
         ApprovalCardKind.RECONFIRM.value,
     }:
         return "approval_card_kind_not_batchable"
-    if group.valid_until is not None and now >= group.valid_until:
-        return "proposal_expired"
+    validity_block = valid_until_block(group.valid_until, now=now)
+    if validity_block is not None:
+        code, detail = validity_block
+        return f"approval_window:{code.value}:{detail}"
     if not group.approval_nonce:
         return "approval_nonce_missing"
     if group.approval_nonce_used_at is not None:
@@ -825,6 +828,82 @@ class OrderProposalsService:
         )
         return True
 
+    async def expire_rung_if_needed(
+        self,
+        proposal_id: uuid.UUID,
+        rung_index: int,
+        *,
+        now: datetime,
+    ) -> bool:
+        """Expire one still-local rung without erasing submitted siblings.
+
+        A ladder can cross ``valid_until`` after an earlier rung already
+        reached the broker. Whole-group expiry correctly refuses that mixed
+        state; this narrower transition preserves the authoritative broker
+        evidence while closing only the remaining mutable rung.
+        """
+        self._require_timezone_aware(now)
+        group, rung = await self._get_locked_rung(proposal_id, rung_index)
+        validity_block = valid_until_block(group.valid_until, now=now)
+        if validity_block is None or validity_block[0].value != "EXPIRED":
+            return False
+        if rung.state == "expired":
+            return True
+        if rung.state not in _VOIDABLE_RUNG_STATES:
+            raise OrderProposalError(
+                f"cannot expire proposal rung {rung_index} in state {rung.state!r}"
+            )
+        sm.assert_rung_transition(rung.state, "expired")
+        expired = await self._repo.update_rung(
+            rung,
+            state="expired",
+            updated_at=now,
+        )
+        rungs = await self._repo.list_rungs(group.id)
+        materialized = [
+            expired if item.rung_index == rung_index else item for item in rungs
+        ]
+        all_local_terminal = all(
+            item.state
+            in {
+                "expired",
+                "rejected",
+                "voided",
+                "voided_local_stale",
+                "superseded",
+            }
+            for item in materialized
+        )
+        await self._repo.update_group(
+            group,
+            lifecycle_state=self._recompute_group_state(materialized),
+            **({"approval_nonce": None} if all_local_terminal else {}),
+        )
+        return True
+
+    async def expire_mutable_rungs_if_needed(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        now: datetime,
+    ) -> int:
+        """Expire every local rung while preserving any broker-backed rung."""
+        self._require_timezone_aware(now)
+        group, rungs = await self.get_proposal(proposal_id)
+        if valid_until_block(group.valid_until, now=now) is None:
+            return 0
+        expired = 0
+        for rung in rungs:
+            if rung.state not in _VOIDABLE_RUNG_STATES:
+                continue
+            if await self.expire_rung_if_needed(
+                proposal_id,
+                rung.rung_index,
+                now=now,
+            ):
+                expired += 1
+        return expired
+
     async def void_proposal(
         self,
         proposal_id: uuid.UUID,
@@ -1035,16 +1114,99 @@ class OrderProposalsService:
             approval_dispatch_failure_code="approval_dispatch_snapshot_missing",
         )
 
+    async def clear_approval_nonce(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        expected_nonce: str | None = None,
+    ) -> OrderProposal:
+        """Remove an unpublished approval surface under the proposal lock."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        if expected_nonce is not None and group.approval_nonce != expected_nonce:
+            raise OrderProposalError("nonce_mismatch")
+        return await self._repo.update_group(
+            group,
+            approval_nonce=None,
+            approval_nonce_used_at=None,
+        )
+
+    async def restore_approval_after_window_block(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        nonce: str,
+        expired: bool,
+    ) -> OrderProposal:
+        """Undo click bookkeeping when a proven pre-send gate blocks.
+
+        This is legal only when the transport hook established that no broker
+        mutation crossed the wire. Rung state restoration is handled
+        separately at the exact blocked rung.
+        """
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        if group.approval_nonce not in {None, nonce}:
+            raise OrderProposalError("nonce_mismatch")
+        source_asof = dict(group.source_asof or {})
+        envelope = source_asof.get(_LOSS_CUT_CONFIRMATION_KEY)
+        if isinstance(envelope, dict) and envelope.get("nonce") == nonce:
+            source_asof[_LOSS_CUT_CONFIRMATION_KEY] = {
+                **envelope,
+                "second_click": None,
+            }
+        return await self._repo.update_group(
+            group,
+            source_asof=source_asof or None,
+            approval_nonce=None if expired else nonce,
+            approval_nonce_used_at=None,
+            approved_by_telegram_user_id=None,
+            approved_at=None,
+            commit_lease_until=None,
+        )
+
+    async def restore_rung_after_pre_send_block(
+        self,
+        proposal_id: uuid.UUID,
+        rung_index: int,
+        *,
+        now: datetime,
+        expired: bool,
+    ) -> OrderProposalRung:
+        """Restore a rung after a hook aborted before any HTTP mutation."""
+        self._require_timezone_aware(now)
+        group, rung = await self._get_locked_rung(proposal_id, rung_index)
+        if rung.state in {"revalidating", "approved", "submitting"}:
+            rung = await self._transition_locked_rung(
+                group,
+                rung,
+                new_state="pending_approval",
+                updated_at=now,
+            )
+        if expired:
+            await self.expire_rung_if_needed(proposal_id, rung_index, now=now)
+            _group, rung = await self._get_locked_rung(proposal_id, rung_index)
+        return rung
+
     async def consume_approval_nonce(
         self, proposal_id: uuid.UUID, nonce: str, *, now: datetime
     ) -> OrderProposal:
         """Compatibility wrapper; every consume still crosses the common gate."""
-        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        group = await self._repo.get_group_by_proposal_id(
+            proposal_id,
+            for_update=True,
+        )
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
         block_reason = _proposal_callback_block_reason(group, nonce=nonce)
         if block_reason is not None:
             raise OrderProposalError(block_reason)
+        validity_block = valid_until_block(group.valid_until, now=now)
+        if validity_block is not None:
+            code, detail = validity_block
+            raise OrderProposalError(f"approval_window:{code.value}:{detail}")
         callback = self._current_callback_envelope(group, action="op", nonce=nonce)
         return await self.consume_published_proposal_callback(
             proposal_id, callback=callback, now=now
@@ -1165,6 +1327,10 @@ class OrderProposalsService:
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
         self._assert_published_proposal_binding(group, callback=callback)
+        validity_block = valid_until_block(group.valid_until, now=now)
+        if validity_block is not None:
+            code, detail = validity_block
+            raise OrderProposalError(f"approval_window:{code.value}:{detail}")
 
         fields: dict[str, Any] = {"approval_nonce_used_at": now}
         if callback.action == "lc":
@@ -1269,7 +1435,7 @@ class OrderProposalsService:
         except (KeyError, TypeError, ValueError) as exc:
             raise OrderProposalError("loss_cut_confirmation_invalid") from exc
         self._require_timezone_aware(expires_at)
-        if now > expires_at:
+        if now >= expires_at:
             raise OrderProposalError("loss_cut_confirmation_expired")
         rungs = await self._repo.list_rungs(group.id)
         current_binding = [
@@ -1322,6 +1488,7 @@ class OrderProposalsService:
         message_id: int,
         chat_id: str,
         now: datetime,
+        approval_window_policy_stamp: str | None = None,
     ) -> OrderProposal:
         """Record legacy message location without creating an approvable card.
 
@@ -1340,6 +1507,11 @@ class OrderProposalsService:
             "approval_message_id": message_id,
             "approval_chat_id": chat_id,
             "approval_sent_at": now.isoformat(),
+            **(
+                {"approval_window_policy_stamp": approval_window_policy_stamp}
+                if approval_window_policy_stamp is not None
+                else {}
+            ),
         }
         return await self._repo.update_group(
             group,
@@ -1440,6 +1612,7 @@ class OrderProposalsService:
         publication: ApprovalPublication,
         chat_id: str | None,
         now: datetime,
+        approval_window_policy_stamp: str | None = None,
     ) -> TelegramDispatchResult:
         """Resolve physical publication through the current-owner fence."""
         self._require_timezone_aware(now)
@@ -1538,6 +1711,11 @@ class OrderProposalsService:
                 "approval_message_id": publication.message_id,
                 "approval_chat_id": chat_id,
                 "approval_sent_at": now.isoformat(),
+                **(
+                    {"approval_window_policy_stamp": approval_window_policy_stamp}
+                    if approval_window_policy_stamp is not None
+                    else {}
+                ),
             }
             fields["approval_dispatch_published_at"] = now
         else:
@@ -1742,11 +1920,10 @@ class OrderProposalsService:
         callback: CallbackEnvelope,
         chat_id: str,
         now: datetime,
+        allow_expired: bool = False,
     ) -> None:
         if batch.chat_id != chat_id:
             raise OrderProposalError("approval_batch_chat_mismatch")
-        if now >= batch.expires_at:
-            raise OrderProposalError("approval_batch_expired")
         try:
             state = ApprovalDispatchState(str(batch.approval_dispatch_state))
         except ValueError as exc:
@@ -1772,6 +1949,8 @@ class OrderProposalsService:
             elif reason == "nonce_replay":
                 reason = "approval_batch_nonce_replay"
             raise OrderProposalError(reason) from exc
+        if not allow_expired and now >= batch.expires_at:
+            raise OrderProposalError("approval_batch_expired")
 
     async def preflight_published_batch_callback(
         self,
@@ -1780,6 +1959,7 @@ class OrderProposalsService:
         callback: CallbackEnvelope,
         chat_id: str,
         now: datetime,
+        allow_expired: bool = False,
     ) -> OrderProposalApprovalBatch:
         """Read-only batch binding gate; consuming gate rechecks under lock."""
         self._require_timezone_aware(now)
@@ -1787,9 +1967,17 @@ class OrderProposalsService:
         if batch is None:
             raise OrderProposalError("approval_batch_not_found")
         self._assert_published_batch_binding(
-            batch, callback=callback, chat_id=chat_id, now=now
+            batch,
+            callback=callback,
+            chat_id=chat_id,
+            now=now,
+            allow_expired=allow_expired,
         )
         return batch
+
+    async def acquire_approval_batch_chat_lock(self, chat_id: str) -> None:
+        """Serialize batch registration and exact-membership consumption."""
+        await self._repo.acquire_approval_batch_chat_lock(chat_id)
 
     async def consume_approval_batch_nonce(
         self,
@@ -1799,8 +1987,9 @@ class OrderProposalsService:
         chat_id: str,
         telegram_user_id: str,
         now: datetime,
+        expected_members: tuple[tuple[uuid.UUID, str], ...] | None = None,
     ) -> tuple[OrderProposalApprovalBatch, list[BatchMemberSnapshot]]:
-        """Consume exactly the immutable membership snapshot shown on the card."""
+        """Atomically consume the exact immutable membership shown on the card."""
         self._require_timezone_aware(now)
         batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
         if batch is None:
@@ -1819,10 +2008,20 @@ class OrderProposalsService:
 
         snapshots: list[BatchMemberSnapshot] = []
         digest_members: list[dict[str, Any]] = []
+        actual_members: list[tuple[uuid.UUID, str]] = []
         for member in members:
-            group = await self._repo.get_group_by_pk(member.proposal_pk)
+            group = await self._repo.get_group_by_pk(
+                member.proposal_pk,
+                for_update=True,
+            )
             if group is None:
                 raise OrderProposalError("approval_batch_member_snapshot_invalid")
+            rungs = await self._repo.list_rungs(group.id)
+            block_reason = batch_member_block_reason(group, rungs, now=now)
+            if block_reason is not None:
+                raise OrderProposalError(
+                    f"approval_batch_member_stale:{group.proposal_id}:{block_reason}"
+                )
             try:
                 card_kind = ApprovalCardKind(str(member.approval_card_kind_snapshot))
             except ValueError as exc:
@@ -1835,6 +2034,18 @@ class OrderProposalsService:
                 or member.approval_membership_digest_snapshot is None
             ):
                 raise OrderProposalError("approval_batch_member_snapshot_invalid")
+            if (
+                group.approval_nonce != member.approval_nonce_snapshot
+                or group.approval_dispatch_attempt_id
+                != member.approval_dispatch_attempt_id_snapshot
+                or group.approval_dispatch_membership_revision
+                != member.approval_membership_revision_snapshot
+                or group.approval_dispatch_membership_digest
+                != member.approval_membership_digest_snapshot
+                or group.approval_dispatch_card_kind
+                != member.approval_card_kind_snapshot
+            ):
+                raise OrderProposalError("approval_batch_membership_changed")
             digest_members.append(
                 {
                     "proposal_id": str(group.proposal_id),
@@ -1851,6 +2062,7 @@ class OrderProposalsService:
                     ),
                 }
             )
+            actual_members.append((group.proposal_id, member.approval_nonce_snapshot))
             snapshots.append(
                 BatchMemberSnapshot(
                     member_id=member.id,
@@ -1874,6 +2086,8 @@ class OrderProposalsService:
         )
         if actual_digest != batch.membership_digest:
             raise OrderProposalError("approval_batch_membership_digest_mismatch")
+        if expected_members is not None and tuple(actual_members) != expected_members:
+            raise OrderProposalError("approval_batch_membership_changed")
 
         await self._repo.update_approval_batch(
             batch,
@@ -2009,12 +2223,18 @@ class OrderProposalsService:
         )
 
     async def get_approval_batch_display(
-        self, batch_id: uuid.UUID
+        self,
+        batch_id: uuid.UUID,
+        *,
+        for_update: bool = False,
     ) -> tuple[
         OrderProposalApprovalBatch,
         list[tuple[OrderProposal, list[OrderProposalRung]]],
     ]:
-        batch = await self._repo.get_approval_batch_by_id(batch_id)
+        batch = await self._repo.get_approval_batch_by_id(
+            batch_id,
+            for_update=for_update,
+        )
         if batch is None:
             raise OrderProposalError("approval_batch_not_found")
         proposals: list[tuple[OrderProposal, list[OrderProposalRung]]] = []
@@ -2024,9 +2244,12 @@ class OrderProposalsService:
                 and member.membership_revision != batch.membership_revision
             ):
                 continue
-            group = await self._repo.get_group_by_pk(member.proposal_pk)
+            group = await self._repo.get_group_by_pk(
+                member.proposal_pk,
+                for_update=for_update,
+            )
             if group is None:
-                continue
+                raise OrderProposalError("approval_batch_membership_changed")
             proposals.append((group, await self._repo.list_rungs(group.id)))
         return batch, proposals
 

--- a/app/services/order_proposals/state_machine.py
+++ b/app/services/order_proposals/state_machine.py
@@ -35,9 +35,18 @@ _ALLOWED: dict[str, frozenset[str]] = {
     "needs_reconfirm": frozenset(
         {"pending_approval", "rejected", "superseded", "expired", "voided"}
     ),
-    "approved": frozenset({"submitting", "superseded", "expired", "voided"}),
+    "approved": frozenset(
+        {"submitting", "pending_approval", "superseded", "expired", "voided"}
+    ),
     "submitting": frozenset(
-        {"acked", "resting", "rejected", "unverified", "cancelled"}
+        {
+            "pending_approval",
+            "acked",
+            "resting",
+            "rejected",
+            "unverified",
+            "cancelled",
+        }
     ),
     "acked": frozenset({"filled", "partially_filled", "cancelled", "unverified"}),
     "resting": frozenset(

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -29,7 +29,10 @@ broker/Telegram/httpx calls are never exercised by this module's test suite.
 
 Nonce replay prevention is load-bearing: every manual, batch, auto-veto, and
 loss-cut action crosses the shared published-snapshot gate before it can consume
-a nonce or reach submit/cancel.
+a nonce or reach submit/cancel. After that non-consuming snapshot gate,
+approval-window checks run before nonce consumption. An expired proposal
+converges through the authoritative expiry transition while leaving the nonce
+unconsumed. Deny retains its existing consume-before-reject ordering.
 
 ``handle_callback_update`` never raises: Telegram's webhook contract expects a
 bounded result for every update, so any unexpected exception is caught, logged,
@@ -59,6 +62,17 @@ from app.services.order_proposals.approval_message import (
     build_buying_power_shortfall_text,
     build_loss_cut_confirmation_message,
     parse_callback_data,
+)
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowCode,
+    ApprovalWindowDecision,
+    WindowEvaluator,
+    approval_window_operator_text,
+    approval_window_rung_result,
+    evaluate_approval_window,
+    evaluate_approval_window_boundary,
+    recheck_approval_window_decision,
+    valid_until_block,
 )
 from app.services.order_proposals.auto_veto import (
     TargetCancelFn,
@@ -96,6 +110,7 @@ logger = logging.getLogger(__name__)
 
 ServiceFactory = Callable[[], Any]
 RevalidateFn = Callable[..., Any]
+Clock = Callable[[], datetime]
 
 # Rung states from which a direct transition to "rejected" is legal (see
 # app/services/order_proposals/state_machine.py). A Telegram deny only ever
@@ -114,12 +129,83 @@ _RESULT_LABELS: dict[str, str] = {
     "error": "오류",
     "needs_reconfirm": "재확인 필요",
     "cancelled": "취소 확인",
+    "expired": "제안 만료",
+    "invalid_valid_until": "유효기간 오류",
+    "defer_session_closed": "주문 가능 세션 아님",
+    "calendar_unknown": "시장 세션 확인 불가",
+    "no_executable_window": "다음 가능 세션 전 만료",
 }
 
 _BATCH_SUCCESS_RESULTS = frozenset(
     {"submitted_acked", "submitted_resting", "cancelled"}
 )
 _BATCH_SKIP_RESULTS = frozenset({"guard_blocked", "approval_required"})
+_WINDOW_BLOCK_RESULTS = frozenset(
+    {
+        "expired",
+        "invalid_valid_until",
+        "defer_session_closed",
+        "calendar_unknown",
+        "no_executable_window",
+    }
+)
+_BATCH_SKIP_RESULTS = _BATCH_SKIP_RESULTS | _WINDOW_BLOCK_RESULTS
+
+
+async def _evaluate_bound_window(
+    group: Any,
+    *,
+    window_evaluator: WindowEvaluator,
+    now_fn: Clock | None = None,
+    now: datetime | None = None,
+) -> ApprovalWindowDecision:
+    if now_fn is None:
+        if now is None:
+            raise ValueError("approval-window boundary requires a clock")
+
+        def now_fn() -> datetime:
+            return now
+
+    expected = (group.source_asof or {}).get("approval_window_policy_stamp")
+    return await evaluate_approval_window_boundary(
+        group,
+        window_evaluator=window_evaluator,
+        now_fn=now_fn,
+        expected_policy_stamp=str(expected) if expected is not None else None,
+    )
+
+
+async def _reject_window_callback(
+    *,
+    session: AsyncSession,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    decision: ApprovalWindowDecision,
+    now: datetime,
+    notifier: Any,
+    chat_id: Any,
+    message_id: int | None,
+    callback_query_id: str | None,
+) -> dict[str, Any]:
+    if decision.code is ApprovalWindowCode.EXPIRED:
+        await service.expire_mutable_rungs_if_needed(proposal_id, now=now)
+    await session.commit()
+    text = approval_window_operator_text(decision)
+    if message_id is not None:
+        await _safe_edit_message(
+            notifier,
+            chat_id,
+            message_id,
+            text,
+            reply_markup={"inline_keyboard": []},
+        )
+    await _safe_answer(notifier, callback_query_id, text)
+    return {
+        "handled": False,
+        "reason": decision.code.value,
+        "proposal_id": str(proposal_id),
+        "approval_window": decision.to_dict(),
+    }
 
 
 def _serialize_rung_outcomes(outcomes: list[RungOutcome]) -> list[dict[str, Any]]:
@@ -152,6 +238,34 @@ def _outcome_error_summary(outcome: RungOutcome, *, limit: int = 240) -> str | N
     if len(compact) > limit:
         compact = compact[: limit - 1] + "…"
     return _escape_markdown(compact)
+
+
+def _window_outcome_text(outcome: RungOutcome) -> str | None:
+    payload = (outcome.detail or {}).get("approval_window")
+    if not isinstance(payload, Mapping):
+        return None
+    code = str(payload.get("code") or "")
+    if code == ApprovalWindowCode.EXPIRED.value:
+        return "제안 만료"
+    if code == ApprovalWindowCode.INVALID_VALID_UNTIL.value:
+        return "제안 유효기간 오류"
+    if code == ApprovalWindowCode.CALENDAR_UNKNOWN.value:
+        return "시장 세션 확인 불가"
+    if code in {
+        ApprovalWindowCode.NO_EXECUTABLE_WINDOW.value,
+        ApprovalWindowCode.DEFER_SESSION_CLOSED.value,
+    }:
+        evidence = payload.get("session_evidence")
+        next_at = (
+            evidence.get("next_allowed_at") if isinstance(evidence, Mapping) else None
+        )
+        prefix = (
+            "다음 주문 가능 세션 전에 만료"
+            if code == ApprovalWindowCode.NO_EXECUTABLE_WINDOW.value
+            else "주문 가능 세션 아님"
+        )
+        return f"{prefix} — 다음 허용 세션: {next_at or '확인 불가'}"
+    return None
 
 
 def _generate_nonce() -> str:
@@ -250,13 +364,25 @@ def _build_result_summary(outcomes: list[RungOutcome]) -> str:
     lines = ["*처리 결과*"]
     for outcome in outcomes:
         label = _RESULT_LABELS.get(outcome.result, outcome.result)
+        window_text = _window_outcome_text(outcome)
+        if window_text is not None:
+            label = window_text
         # Merged with main's parallel fix: PR-3a's summarizer (compacted,
         # length-capped, markdown-escaped) + main's "submit_rejected"
         # fallback for error outcomes whose detail carries no error text.
         reason = _outcome_error_summary(outcome)
         if outcome.result == "error" and not reason:
             reason = "submit\\_rejected"
-        if reason and outcome.result in {"guard_blocked", "error"}:
+        if (
+            reason
+            and window_text is None
+            and outcome.result
+            in {
+                "guard_blocked",
+                "error",
+                *_WINDOW_BLOCK_RESULTS,
+            }
+        ):
             label = f"{label} — {reason}"
         lines.append(f"- #{outcome.rung_index + 1}: {label}")
     return "\n".join(lines)
@@ -465,8 +591,12 @@ async def _handle_approve(
     callback_query_id: str | None,
     telegram_user_id: str,
     revalidate_fn: RevalidateFn,
+    window_evaluator: WindowEvaluator | None = None,
+    now_fn: Clock | None = None,
     loss_cut_confirmation: bool = False,
 ) -> dict[str, Any]:
+    window_evaluator = window_evaluator or evaluate_approval_window
+    now_fn = now_fn or (lambda: now)
     preflight_failure = await _preflight_proposal_callback(
         session=session,
         service=service,
@@ -483,17 +613,56 @@ async def _handle_approve(
     target_group, _ = await service.get_proposal(proposal_id)
     await service.acquire_target_mutation_lock(target_group)
 
+    window = await _evaluate_bound_window(
+        target_group, window_evaluator=window_evaluator, now_fn=now_fn
+    )
+    approval_now = window.observed_at
+    if not window.allowed:
+        return await _reject_window_callback(
+            session=session,
+            service=service,
+            proposal_id=proposal_id,
+            decision=window,
+            now=approval_now,
+            notifier=notifier,
+            chat_id=chat_id,
+            message_id=message_id,
+            callback_query_id=callback_query_id,
+        )
+
+    # Session resolution may await broker/calendar I/O. Re-sample and
+    # re-evaluate at the nonce boundary so an edge crossed during that lookup
+    # cannot consume the single-use approval token.
+    window = await _evaluate_bound_window(
+        target_group, window_evaluator=window_evaluator, now_fn=now_fn
+    )
+    approval_now = window.observed_at
+    if not window.allowed:
+        return await _reject_window_callback(
+            session=session,
+            service=service,
+            proposal_id=proposal_id,
+            decision=window,
+            now=approval_now,
+            notifier=notifier,
+            chat_id=chat_id,
+            message_id=message_id,
+            callback_query_id=callback_query_id,
+        )
+
     try:
         if loss_cut_confirmation:
             await service.consume_published_proposal_callback(
                 proposal_id,
                 callback=callback,
                 telegram_user_id=telegram_user_id,
-                now=now,
+                now=approval_now,
             )
         else:
             await service.consume_published_proposal_callback(
-                proposal_id, callback=callback, now=now
+                proposal_id,
+                callback=callback,
+                now=approval_now,
             )
     except OrderProposalError as exc:
         # See `_handle_deny`'s matching comment: no mutation happened above,
@@ -501,22 +670,7 @@ async def _handle_approve(
         await session.commit()
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
 
-    # A pending/failed/superseded visible card must cross the authoritative
-    # publication gate before even a local expiry transition is allowed.
-    # For a valid SENT_CURRENT card, consuming the one-shot nonce and expiring
-    # the proposal happen in this same caller-owned transaction.
-    if await service.expire_if_needed(proposal_id, now=now):
-        await session.commit()
-        if message_id is not None:
-            await _safe_edit_message(notifier, chat_id, message_id, "⌛ 제안 만료")
-        await _safe_answer(notifier, callback_query_id, "제안이 만료되었습니다")
-        return {
-            "handled": False,
-            "reason": "proposal_expired",
-            "proposal_id": str(proposal_id),
-        }
-
-    acquired = await service.acquire_commit_lease(proposal_id, now=now)
+    acquired = await service.acquire_commit_lease(proposal_id, now=approval_now)
     if not acquired:
         # Same rationale -- release the `for_update=True` lock before return.
         await session.commit()
@@ -527,7 +681,7 @@ async def _handle_approve(
         }
 
     await service.record_approval(
-        proposal_id, telegram_user_id=telegram_user_id, now=now
+        proposal_id, telegram_user_id=telegram_user_id, now=approval_now
     )
 
     # A rung that came back `needs_reconfirm` on a previous approve click is
@@ -549,14 +703,111 @@ async def _handle_approve(
     submit_agent_id = settings.ORDER_PROPOSALS_SUBMIT_AGENT_ID.strip() or None
     caller_agent_id_token = caller_agent_id_var.set(submit_agent_id)
     try:
-        outcomes: list[RungOutcome] = await revalidate_fn(
-            service=service, proposal_id=proposal_id, now=now
-        )
+        revalidate_kwargs: dict[str, Any] = {
+            "service": service,
+            "proposal_id": proposal_id,
+            "now": approval_now,
+        }
+        if revalidate_fn is revalidate_and_submit:
+            revalidate_kwargs.update(
+                window_evaluator=window_evaluator,
+                expected_policy_stamp=window.policy_stamp,
+                now_fn=now_fn,
+            )
+        outcomes: list[RungOutcome] = await revalidate_fn(**revalidate_kwargs)
     finally:
         caller_agent_id_var.reset(caller_agent_id_token)
 
+    window_blocked = [
+        outcome for outcome in outcomes if outcome.result in _WINDOW_BLOCK_RESULTS
+    ]
+    all_window_blocked = bool(outcomes) and len(window_blocked) == len(outcomes)
+    target_was_cancelled = any(
+        bool((outcome.detail or {}).get("target_cancelled"))
+        for outcome in window_blocked
+    )
+    zero_send_results = _WINDOW_BLOCK_RESULTS | {
+        "needs_reconfirm",
+        "guard_blocked",
+        "approval_required",
+    }
+    zero_send_window_block = bool(window_blocked) and all(
+        outcome.result in zero_send_results for outcome in outcomes
+    )
+    if zero_send_window_block and not target_was_cancelled:
+        expired = any(outcome.result == "expired" for outcome in window_blocked)
+        if expired:
+            await service.expire_mutable_rungs_if_needed(
+                proposal_id,
+                now=now_fn(),
+            )
+        await service.restore_approval_after_window_block(
+            proposal_id,
+            nonce=callback.nonce,
+            expired=expired,
+        )
+        summary = _build_result_summary(outcomes)
+        await session.commit()
+        if message_id is not None:
+            await _safe_edit_message(
+                notifier,
+                chat_id,
+                message_id,
+                summary,
+                reply_markup={"inline_keyboard": []},
+            )
+        first_window = window_blocked[0]
+        operator_reason = _window_outcome_text(first_window)
+        return {
+            "handled": False,
+            "reason": str(
+                (first_window.detail or {}).get("error") or "approval_window_blocked"
+            ),
+            "operator_reason": operator_reason,
+            "proposal_id": str(proposal_id),
+            "results": [outcome.result for outcome in outcomes],
+            "rung_results": _serialize_rung_outcomes(outcomes),
+        }
+
     reconfirm_outcomes = [o for o in outcomes if o.result == "needs_reconfirm"]
     if reconfirm_outcomes:
+        reconfirm_group, _ = await service.get_proposal(proposal_id)
+        reconfirm_window = await _evaluate_bound_window(
+            reconfirm_group,
+            window_evaluator=window_evaluator,
+            now_fn=now_fn,
+        )
+        reconfirm_now = reconfirm_window.observed_at
+        if not reconfirm_window.allowed:
+            return await _reject_window_callback(
+                session=session,
+                service=service,
+                proposal_id=proposal_id,
+                decision=reconfirm_window,
+                now=reconfirm_now,
+                notifier=notifier,
+                chat_id=chat_id,
+                message_id=message_id,
+                callback_query_id=callback_query_id,
+            )
+        reconfirm_window = await _evaluate_bound_window(
+            reconfirm_group,
+            window_evaluator=window_evaluator,
+            now_fn=now_fn,
+        )
+        reconfirm_now = reconfirm_window.observed_at
+        if not reconfirm_window.allowed:
+            return await _reject_window_callback(
+                session=session,
+                service=service,
+                proposal_id=proposal_id,
+                decision=reconfirm_window,
+                now=reconfirm_now,
+                notifier=notifier,
+                chat_id=chat_id,
+                message_id=message_id,
+                callback_query_id=callback_query_id,
+            )
         fresh_nonce = _generate_nonce()
         await service.set_approval_nonce(proposal_id, fresh_nonce)
         group, rungs = await service.get_proposal(proposal_id)
@@ -590,11 +841,50 @@ async def _handle_approve(
             suffix_blocks=suffix_blocks,
             binding=binding,
         )
+        send_window = await _evaluate_bound_window(
+            group,
+            window_evaluator=window_evaluator,
+            now_fn=now_fn,
+        )
+        if not send_window.allowed:
+            if send_window.code is ApprovalWindowCode.EXPIRED:
+                await service.expire_mutable_rungs_if_needed(
+                    proposal_id,
+                    now=send_window.observed_at,
+                )
+            await service.restore_approval_after_window_block(
+                proposal_id,
+                nonce=fresh_nonce,
+                expired=send_window.code is ApprovalWindowCode.EXPIRED,
+            )
+            if send_window.code is not ApprovalWindowCode.EXPIRED:
+                await service.clear_approval_nonce(
+                    proposal_id,
+                    expected_nonce=fresh_nonce,
+                )
+            await session.commit()
+            rejection_text = approval_window_operator_text(send_window)
+            if message_id is not None:
+                await _safe_edit_message(
+                    notifier,
+                    chat_id,
+                    message_id,
+                    rejection_text,
+                    reply_markup={"inline_keyboard": []},
+                )
+            return {
+                "handled": False,
+                "reason": send_window.code.value,
+                "proposal_id": str(proposal_id),
+                "approval_window": send_window.to_dict(),
+                "results": [outcome.result for outcome in outcomes],
+                "rung_results": _serialize_rung_outcomes(outcomes),
+            }
         await service.start_approval_dispatch(
             proposal_id,
             attempt_id=dispatch_attempt_id,
             binding=binding,
-            now=now,
+            now=send_window.observed_at,
             payload_chars=messages.payload_chars,
             context_message_count=len(messages.context_messages),
         )
@@ -628,7 +918,8 @@ async def _handle_approve(
             attempt_id=dispatch_attempt_id,
             publication=publication,
             chat_id=str(chat_id),
-            now=now,
+            now=send_window.observed_at,
+            approval_window_policy_stamp=send_window.policy_stamp,
         )
         await session.commit()
         new_message_id = dispatch_result.message_id if dispatch_result.ok else None
@@ -652,8 +943,17 @@ async def _handle_approve(
     if message_id is not None:
         await _safe_edit_message(notifier, chat_id, message_id, summary)
     return {
-        "handled": True,
-        "reason": "approved",
+        "handled": not all_window_blocked,
+        "reason": (
+            str(
+                (window_blocked[0].detail or {}).get("error")
+                or "approval_window_blocked"
+            )
+            if all_window_blocked
+            else "approved_with_window_block"
+            if window_blocked
+            else "approved"
+        ),
         "proposal_id": str(proposal_id),
         "results": [outcome.result for outcome in outcomes],
         "rung_results": _serialize_rung_outcomes(outcomes),
@@ -672,32 +972,181 @@ async def _handle_batch_approve(
     callback_query_id: str | None = None,
     telegram_user_id: str,
     revalidate_fn: RevalidateFn,
+    window_evaluator: WindowEvaluator,
+    now_fn: Clock,
 ) -> dict[str, Any]:
     """Consume one batch trigger and process every frozen member independently."""
     async with service_factory() as session:
         service = OrderProposalsService(session)
+        await service.acquire_approval_batch_chat_lock(str(chat_id))
         batch_id = await service.resolve_approval_batch_id_prefix(batch_short)
         if batch_id is None:
             await session.commit()
             return {"handled": False, "reason": "approval_batch_not_found"}
+
+        gate_now = now_fn()
         try:
+            # Validate the #1646 publication owner/membership/nonce snapshot
+            # before any calendar lookup or Telegram callback answer. An
+            # expired batch may proceed only far enough to converge an expired
+            # member; the consuming gate below still rejects the batch TTL.
             await service.preflight_published_batch_callback(
                 batch_id,
                 callback=callback,
                 chat_id=str(chat_id),
-                now=now,
+                now=gate_now,
+                allow_expired=True,
             )
         except OrderProposalError as exc:
             await session.commit()
             return {"handled": False, "reason": str(exc)}
+
+        batch, proposals = await service.get_approval_batch_display(
+            batch_id,
+            for_update=True,
+        )
+        gate_now = now_fn()
+        batch_expired = gate_now >= batch.expires_at
+        if len(proposals) < 2:
+            await session.commit()
+            return {"handled": False, "reason": "approval_batch_too_small"}
+        member_expired = False
+        for group, _rungs in proposals:
+            validity_block = valid_until_block(group.valid_until, now=gate_now)
+            if (
+                validity_block is not None
+                and validity_block[0] is ApprovalWindowCode.EXPIRED
+            ):
+                member_expired = True
+                break
+        if batch_expired and not member_expired:
+            # A stale batch TTL must not produce Telegram/provider side
+            # effects. Continue only when the batch deadline was bounded by a
+            # member's valid_until so that member can durably converge to
+            # expired without consuming either nonce.
+            await session.commit()
+            return {"handled": False, "reason": "approval_batch_expired"}
         await _safe_answer(notifier, callback_query_id, "처리 중")
+
+        preflight: list[tuple[Any, list[Any], str | None, ApprovalWindowDecision]] = []
+        batch_window_blocked = False
+        for group, rungs in proposals:
+            block_reason = batch_member_block_reason(group, rungs, now=gate_now)
+            decision = await _evaluate_bound_window(
+                group, window_evaluator=window_evaluator, now_fn=now_fn
+            )
+            gate_now = decision.observed_at
+            if block_reason is not None or not decision.allowed:
+                batch_window_blocked = True
+            preflight.append((group, rungs, block_reason, decision))
+
+        if not batch_window_blocked:
+            # The calendar lookups above are awaited member-by-member. Repeat
+            # the exact frozen set at the nonce boundary so an open/expiry
+            # boundary crossed while evaluating a large batch cannot consume
+            # the batch trigger on stale evidence.
+            gate_now = now_fn()
+            preflight = []
+            for group, rungs in proposals:
+                block_reason = batch_member_block_reason(
+                    group,
+                    rungs,
+                    now=gate_now,
+                )
+                decision = await _evaluate_bound_window(
+                    group, window_evaluator=window_evaluator, now_fn=now_fn
+                )
+                gate_now = decision.observed_at
+                if block_reason is not None or not decision.allowed:
+                    batch_window_blocked = True
+                preflight.append((group, rungs, block_reason, decision))
+
+        gate_now = now_fn()
+        preflight = [
+            (
+                group,
+                rungs,
+                batch_member_block_reason(group, rungs, now=gate_now),
+                recheck_approval_window_decision(group, decision, now=gate_now),
+            )
+            for group, rungs, _block_reason, decision in preflight
+        ]
+        batch_window_blocked = any(
+            block_reason is not None or not decision.allowed
+            for _group, _rungs, block_reason, decision in preflight
+        )
+
+        if batch_window_blocked:
+            blocked_results: list[dict[str, Any]] = []
+            for group, rungs, block_reason, decision in preflight:
+                if decision.code is ApprovalWindowCode.EXPIRED:
+                    await service.expire_mutable_rungs_if_needed(
+                        group.proposal_id,
+                        now=gate_now,
+                    )
+                if block_reason is not None:
+                    reason = block_reason
+                    rung_results: list[dict[str, Any]] = []
+                elif not decision.allowed:
+                    reason = approval_window_operator_text(decision)
+                    rung_result = approval_window_rung_result(decision)
+                    rung_results = [
+                        {"rung_index": rung.rung_index, "result": rung_result}
+                        for rung in rungs
+                        if rung.state in {"pending_approval", "needs_reconfirm"}
+                    ]
+                else:
+                    reason = "batch_atomic_window_block"
+                    rung_results = []
+                blocked_results.append(
+                    {
+                        "proposal_id": str(group.proposal_id),
+                        "status": "skipped",
+                        "reason": reason,
+                        "rung_results": rung_results,
+                    }
+                )
+            await session.commit()
+            if message_id is not None:
+                await _safe_edit_message(
+                    notifier,
+                    chat_id,
+                    message_id,
+                    build_batch_result_message(
+                        proposals=proposals, results=blocked_results
+                    ),
+                    reply_markup={"inline_keyboard": []},
+                )
+            return {
+                "handled": False,
+                "reason": "BATCH_WINDOW_BLOCKED",
+                "batch_id": str(batch_id),
+                "results": blocked_results,
+            }
+
+        if batch_expired:
+            await session.commit()
+            if message_id is not None:
+                await _safe_edit_message(
+                    notifier,
+                    chat_id,
+                    message_id,
+                    "⌛ 일괄 승인 만료",
+                    reply_markup={"inline_keyboard": []},
+                )
+            return {"handled": False, "reason": "approval_batch_expired"}
+
         try:
             _batch, members = await service.consume_approval_batch_nonce(
                 batch_id,
                 callback=callback,
                 chat_id=str(chat_id),
                 telegram_user_id=telegram_user_id,
-                now=now,
+                now=gate_now,
+                expected_members=tuple(
+                    (group.proposal_id, str(group.approval_nonce or ""))
+                    for group, _rungs in proposals
+                ),
             )
         except OrderProposalError as exc:
             await session.commit()
@@ -715,6 +1164,7 @@ async def _handle_batch_approve(
         # crash or Telegram retry can then never execute the frozen set twice.
         await session.commit()
 
+    now = gate_now
     results: list[dict[str, Any]] = []
     for member in members:
         member_result: dict[str, Any] = {
@@ -756,6 +1206,8 @@ async def _handle_batch_approve(
                         callback_query_id=None,
                         telegram_user_id=telegram_user_id,
                         revalidate_fn=revalidate_fn,
+                        window_evaluator=window_evaluator,
+                        now_fn=now_fn,
                     )
                     rung_results = approval_result.get("rung_results")
                     if isinstance(rung_results, list):
@@ -771,6 +1223,9 @@ async def _handle_batch_approve(
                         ]
                     status, reason = _classify_batch_approval_result(approval_result)
                     member_result["status"] = status
+                    operator_reason = approval_result.get("operator_reason")
+                    if operator_reason:
+                        reason = str(operator_reason)
                     if reason is not None:
                         member_result["reason"] = reason
                     if not approval_result.get("handled"):
@@ -861,8 +1316,12 @@ async def _handle_loss_cut_first_click(
     callback_query_id: str | None = None,
     telegram_user_id: str,
     loss_cut_preview_fn: RevalidateFn,
+    window_evaluator: WindowEvaluator | None = None,
+    now_fn: Clock | None = None,
 ) -> dict[str, Any]:
     """Consume step one and edit the message into a bound confirmation."""
+    window_evaluator = window_evaluator or evaluate_approval_window
+    now_fn = now_fn or (lambda: now)
     preflight_failure = await _preflight_proposal_callback(
         session=session,
         service=service,
@@ -873,17 +1332,105 @@ async def _handle_loss_cut_first_click(
     )
     if preflight_failure is not None:
         return preflight_failure
+
+    group = await service.preflight_published_proposal_callback(
+        proposal_id,
+        callback=callback,
+    )
+    window = await _evaluate_bound_window(
+        group, window_evaluator=window_evaluator, now_fn=now_fn
+    )
+    click_now = window.observed_at
+    if not window.allowed:
+        return await _reject_window_callback(
+            session=session,
+            service=service,
+            proposal_id=proposal_id,
+            decision=window,
+            now=click_now,
+            notifier=notifier,
+            chat_id=chat_id,
+            message_id=message_id,
+            callback_query_id=None,
+        )
+
+    # Repeat immediately before the external preview. The first calendar
+    # resolution itself may have crossed a validity/session boundary.
+    window = await _evaluate_bound_window(
+        group, window_evaluator=window_evaluator, now_fn=now_fn
+    )
+    click_now = window.observed_at
+    if not window.allowed:
+        return await _reject_window_callback(
+            session=session,
+            service=service,
+            proposal_id=proposal_id,
+            decision=window,
+            now=click_now,
+            notifier=notifier,
+            chat_id=chat_id,
+            message_id=message_id,
+            callback_query_id=None,
+        )
+
     submit_agent_id = settings.ORDER_PROPOSALS_SUBMIT_AGENT_ID.strip() or None
     caller_agent_id_token = caller_agent_id_var.set(submit_agent_id)
     try:
         evidence = await loss_cut_preview_fn(
-            service=service, proposal_id=proposal_id, now=now
+            service=service, proposal_id=proposal_id, now=click_now
         )
     finally:
         caller_agent_id_var.reset(caller_agent_id_token)
     try:
+        group = await service.preflight_published_proposal_callback(
+            proposal_id,
+            callback=callback,
+        )
+    except OrderProposalError as exc:
+        await session.commit()
+        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+    post_preview_window = await _evaluate_bound_window(
+        group,
+        window_evaluator=window_evaluator,
+        now_fn=now_fn,
+    )
+    post_preview_now = post_preview_window.observed_at
+    if not post_preview_window.allowed:
+        return await _reject_window_callback(
+            session=session,
+            service=service,
+            proposal_id=proposal_id,
+            decision=post_preview_window,
+            now=post_preview_now,
+            notifier=notifier,
+            chat_id=chat_id,
+            message_id=message_id,
+            callback_query_id=None,
+        )
+
+    post_preview_window = await _evaluate_bound_window(
+        group,
+        window_evaluator=window_evaluator,
+        now_fn=now_fn,
+    )
+    post_preview_now = post_preview_window.observed_at
+    if not post_preview_window.allowed:
+        return await _reject_window_callback(
+            session=session,
+            service=service,
+            proposal_id=proposal_id,
+            decision=post_preview_window,
+            now=post_preview_now,
+            notifier=notifier,
+            chat_id=chat_id,
+            message_id=message_id,
+            callback_query_id=None,
+        )
+    try:
         await service.consume_published_proposal_callback(
-            proposal_id, callback=callback, now=now
+            proposal_id,
+            callback=callback,
+            now=post_preview_now,
         )
     except OrderProposalError as exc:
         await session.commit()
@@ -895,7 +1442,7 @@ async def _handle_loss_cut_first_click(
         first_nonce=callback.nonce,
         confirmation_nonce=confirmation_nonce,
         telegram_user_id=telegram_user_id,
-        now=now,
+        now=post_preview_now,
     )
     group, rungs = await service.get_proposal(proposal_id)
     dispatch_attempt_id = uuid.uuid4()
@@ -909,15 +1456,54 @@ async def _handle_loss_cut_first_click(
     text, keyboard = build_loss_cut_confirmation_message(
         group=group, rungs=rungs, evidence=evidence, binding=binding
     )
+    publish_window = await _evaluate_bound_window(
+        group,
+        window_evaluator=window_evaluator,
+        now_fn=now_fn,
+    )
+    if not publish_window.allowed:
+        if publish_window.code is ApprovalWindowCode.EXPIRED:
+            await service.expire_mutable_rungs_if_needed(
+                proposal_id,
+                now=publish_window.observed_at,
+            )
+        await service.restore_approval_after_window_block(
+            proposal_id,
+            nonce=confirmation_nonce,
+            expired=publish_window.code is ApprovalWindowCode.EXPIRED,
+        )
+        if publish_window.code is not ApprovalWindowCode.EXPIRED:
+            await service.clear_approval_nonce(
+                proposal_id,
+                expected_nonce=confirmation_nonce,
+            )
+        await session.commit()
+        rejection_text = approval_window_operator_text(publish_window)
+        if message_id is not None:
+            await _safe_edit_message(
+                notifier,
+                chat_id,
+                message_id,
+                rejection_text,
+                reply_markup={"inline_keyboard": []},
+            )
+        return {
+            "handled": False,
+            "reason": publish_window.code.value,
+            "proposal_id": str(proposal_id),
+            "approval_window": publish_window.to_dict(),
+        }
+
     await service.start_approval_dispatch(
         proposal_id,
         attempt_id=dispatch_attempt_id,
         binding=binding,
-        now=now,
+        now=publish_window.observed_at,
         payload_chars=telegram_text_length(text),
         context_message_count=0,
     )
     await session.commit()
+
     if message_id is None:
         publication = ApprovalPublication.failed(
             payload_chars=telegram_text_length(text),
@@ -948,7 +1534,8 @@ async def _handle_loss_cut_first_click(
         attempt_id=dispatch_attempt_id,
         publication=publication,
         chat_id=str(chat_id),
-        now=now,
+        now=publish_window.observed_at,
+        approval_window_policy_stamp=publish_window.policy_stamp,
     )
     await session.commit()
     return {
@@ -973,10 +1560,14 @@ async def handle_callback_update(
     loss_cut_preview_fn: RevalidateFn | None = None,
     veto_cancel_fn: TargetCancelFn = cancel_target_order,
     veto_fetch_fn: TargetFetchFn = fetch_target_order,
+    window_evaluator: WindowEvaluator | None = None,
+    now_fn: Clock | None = None,
 ) -> dict[str, Any]:
     """Handle one Telegram webhook update. Never raises (fail-closed)."""
     callback_query_id: str | None = None
     active_notifier = notifier
+    evaluate_window = window_evaluator or evaluate_approval_window
+    clock = now_fn or (lambda: now)
     try:
         if active_notifier is None:
             from app.monitoring.trade_notifier.notifier import get_trade_notifier
@@ -1018,6 +1609,8 @@ async def handle_callback_update(
                     str(telegram_user_id) if telegram_user_id is not None else ""
                 ),
                 revalidate_fn=revalidate_fn,
+                window_evaluator=evaluate_window,
+                now_fn=clock,
             )
 
         async with service_factory() as session:
@@ -1081,6 +1674,8 @@ async def handle_callback_update(
                             else ""
                         ),
                         loss_cut_preview_fn=loss_cut_preview_fn,
+                        window_evaluator=evaluate_window,
+                        now_fn=clock,
                     )
                     return result
                 result = await _handle_approve(
@@ -1097,6 +1692,8 @@ async def handle_callback_update(
                         str(telegram_user_id) if telegram_user_id is not None else ""
                     ),
                     revalidate_fn=revalidate_fn,
+                    window_evaluator=evaluate_window,
+                    now_fn=clock,
                 )
             else:
                 result = await _handle_approve(
@@ -1113,6 +1710,8 @@ async def handle_callback_update(
                         str(telegram_user_id) if telegram_user_id is not None else ""
                     ),
                     revalidate_fn=revalidate_fn,
+                    window_evaluator=evaluate_window,
+                    now_fn=clock,
                     loss_cut_confirmation=True,
                 )
             # `_handle_deny`/`_handle_approve` each commit their own

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -99,7 +99,14 @@ See the full design in
   unknown/stale calendar or venue evidence fail closed. US DAY proposals use
   authoritative regular-session calendars (holiday, half-day, and DST aware);
   KR preserves KRX regular and fresh, positively confirmed NXT carry; Upbit
-  crypto is 24/7.
+  crypto is 24/7. Protective exits are deliberately validity-only at this
+  boundary: a non-null `exit_intent` (including `loss_cut` and the
+  forward-compatible `defensive_trim`) bypasses session/calendar resolution
+  and approval-window policy-stamp binding at the common evaluator entry
+  point. This keeps the confirmation and fresh broker guards reachable even
+  when calendar evidence is unavailable. Expired, missing, malformed, or
+  timezone-naive `valid_until` still fails closed, and `exit_reason` without
+  `exit_intent` does not qualify.
 - **Batch nonce is not proposal authorization.** ROB-870 atomically consumes a
   separate batch nonce only after every locked member passes the approval-
   window preflight and the exact ordered `(proposal_id, nonce snapshot)`

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -87,12 +87,27 @@ See the full design in
   callback) — so neither a stale cached message nor a duplicate callback can
   ever re-trigger approval/deny. See Troubleshooting for the two error
   strings.
+- **Approval-window defense in depth.** Dispatch checks `valid_until` and the
+  broker/market execution session before minting a nonce or publishing a
+  button. Callback handling repeats that check before nonce consumption;
+  revalidation repeats it before provider preview, and a transport hook
+  re-resolves it at the final KIS, Toss, or Upbit HTTP boundary for both
+  submit and cancel. The evidence carries the current allowed interval end,
+  so crossing the close while an awaited calendar/preview call is in flight
+  also fails closed. `now >= valid_until` is expired. Missing, malformed, or
+  timezone-naive validity, a missing/mismatched policy stamp, and
+  unknown/stale calendar or venue evidence fail closed. US DAY proposals use
+  authoritative regular-session calendars (holiday, half-day, and DST aware);
+  KR preserves KRX regular and fresh, positively confirmed NXT carry; Upbit
+  crypto is 24/7.
 - **Batch nonce is not proposal authorization.** ROB-870 atomically consumes a
-  separate batch nonce before processing its frozen member list. It then
-  consumes each member's snapshotted proposal nonce through the same single-
-  proposal approval path. Replaying the batch trigger cannot run the list
-  twice, and a stale or already-used member nonce is skipped rather than
-  bypassed.
+  separate batch nonce only after every locked member passes the approval-
+  window preflight and the exact ordered `(proposal_id, nonce snapshot)`
+  membership still matches the displayed batch. One missing, changed,
+  expired, session-closed, or calendar-unknown member blocks the exact batch
+  with zero durable batch/member nonce consumption. It then consumes each
+  member's snapshotted proposal nonce through the same single-proposal
+  approval path. Replaying the batch trigger cannot run the list twice.
 - **Chat allowlist (authz, separate from the webhook secret).**
   `handle_callback_update` rejects any callback whose `chat.id` is not in
   `settings.order_proposals_telegram_chat_allowlist`
@@ -275,6 +290,12 @@ Persists a new proposal group + its rungs. `rungs` is a list of
 "notional": str|None}`. NOT a broker mutation. Returns
 `{success, proposal_id, lifecycle_state, rungs}` on success or
 `{success: false, error}` on validation failure.
+
+When proposal persistence succeeds but approval dispatch is blocked, the
+success response additionally contains
+`approval_dispatch={status:"blocked", code, observed_at, valid_until,
+policy_stamp, session_evidence, detail}`. This is not a broker rejection:
+no Telegram approval card/nonce and no broker preview/submit/cancel occurred.
 
 If `supersedes_proposal_id` is given, the referenced proposal is marked
 `superseded` and lineage (`root_proposal_id`, `supersedes_proposal_id`) is
@@ -582,14 +603,18 @@ batch does not weaken any action-specific fresh broker checks.
 
 Clicking `전체 승인` performs these steps:
 
-1. Consume and commit the batch nonce once, freezing the ordered members.
-2. Re-read each proposal and rerun the eligibility checks at click time.
-3. Process each remaining member in its own transaction through the normal
+1. Lock and freeze the exact ordered member/nonce-snapshot set shown by the
+   batch.
+2. Re-read every proposal, rerun the approval-window checks at one common
+   instant, and fail the whole batch if a member is missing, changed, expired,
+   session-closed, or calendar-unknown.
+3. Atomically consume and commit the batch nonce only after steps 1–2 pass.
+4. Process each member in its own transaction through the normal
    single-proposal nonce, approval audit, commit lease, fresh preview, guards,
    and submit path.
-4. Continue after a skipped or failed member and edit each individual message
+5. Continue after a skipped or failed member and edit each individual message
    with its own outcome.
-5. Replace the summary with grouped `승인 완료`, `재확인 필요`,
+6. Replace the summary with grouped `승인 완료`, `재확인 필요`,
    `제외/건너뜀`, and `실패` results.
 
 The individual `✅ 승인` / `❌ 거부` messages remain available. A ROB-861
@@ -753,28 +778,38 @@ submitted blind would defeat the entire point of a human-approval gate.
    the rendered text). `_resolve_proposal_id` then matches the 8-char prefix
    against `proposed`-state candidates, failing closed (no match / multiple
    matches → unresolved) rather than guessing.
-3. **Nonce replay guard.** `consume_approval_nonce` takes a row lock
+3. **Expiry/session/policy-stamp gate.** Before any nonce is consumed, the
+   callback requires a timezone-aware, still-future `valid_until`, re-derives
+   the proposal's broker/market session capability, and compares the result
+   with the mandatory dispatch policy stamp. Expiry converges through
+   proposal- or rung-scoped expiry transitions without rewriting a sibling
+   that already has broker evidence. A still-valid closed session returns
+   `DEFER_SESSION_CLOSED` and shows the next confirmed session, without
+   scheduling or automatic resubmission. Unknown/stale evidence fails closed.
+4. **Nonce replay guard.** `consume_approval_nonce` takes a row lock
    (`for_update=True`) and marks the nonce used; a second click with the
    same already-consumed nonce raises `nonce_replay`, and a click after a
    fresh nonce has already been minted for a newer message (e.g. a
    `NEEDS_RECONFIRM` cycle) raises `nonce_mismatch` — see Troubleshooting
    for the distinction.
-4. **Loss-cut first click.** For `exit_intent="loss_cut"`, the initial `op`
+5. **Loss-cut first click.** For `exit_intent="loss_cut"`, the initial `op`
    click stops here after a fresh read-only evidence preview. It consumes and
    audits the first nonce, edits the message with order/price/loss/slip/retro
    evidence, and mints a 90-second `lc` nonce bound to proposal/rung/revision.
    It never calls `revalidate_and_submit`. A valid `lc` click consumes and
    audits the second nonce, then continues below. Non-loss-cut proposals keep
    the existing one-click flow.
-5. **Commit lease.** For a normal approve or valid loss-cut confirmation,
+6. **Commit lease.** For a normal approve or valid loss-cut confirmation,
    `acquire_commit_lease` takes a
    short-lived (`lease_seconds=10` default) in-flight lock on the group row
    — this is what prevents a double-tap on the approve button (two Telegram
    updates arriving almost simultaneously) from racing two submits. If the
    lease is already held, the second click is answered "처리 중" and does
    nothing further.
-6. **Fresh dry-run preview → broker-specific checks.** `revalidate_and_submit`
-   re-runs every `pending_approval` rung through a fresh
+7. **Fresh dry-run preview → broker-specific checks.** Before calling a
+   provider preview, `revalidate_and_submit` independently repeats the
+   expiry/session/stamp gate. It then re-runs every `pending_approval` rung
+   through a fresh
    `place_order_fn(dry_run=True, ...)` call. For `kis_live` equities and
    `upbit` crypto this delegates to `_place_order_impl`, which enforces the
    applicable ROB-800 guards and repeats final guards on live
@@ -791,27 +826,35 @@ submitted blind would defeat the entire point of a human-approval gate.
    click regardless of the create-time retrospective check. A preview guard
    rejection comes back as `guard_blocked` and the rung returns to
    `pending_approval` (retryable, not terminal).
-7. **Price/qty comparison against what the operator approved.** The fresh
+8. **Price/qty comparison against what the operator approved.** The fresh
    preview's normalized `price`/`quantity` is compared (`_norm`, which
    canonicalizes `NUMERIC(38,12)` DB values against fresh preview values so
    `Decimal("2226000.000000000000")` and `Decimal("2226000")` compare equal)
    against the rung's stored `limit_price`/`quantity`. Market-order rungs
    compare quantity only (`limit_price` is always `None` by design for
    market orders, so comparing it would always spuriously mismatch).
-8. **Unchanged → submit; changed → `NEEDS_RECONFIRM`.** If the comparison
-   matches, the rung transitions `approved → submitting` and is actually
-   submitted (`dry_run=False`) using the **freshly minted** `approval_hash`
-   from step 5's preview — never the one from the original proposal-create
-   preview. Toss receives a privately bound client ID derived only from the
-   proposal ID and rung for both preview and submit, so retries and date
-   boundaries cannot change the identity; preview must return the exact bound
-   ID or submission fails closed. The proposal correlation and rung use the
-   same private binding and are not operator-controlled MCP parameters. Toss
-   proposal numerics are converted at the adapter boundary to canonical
-   `str | int` values, never floats. After an accepted Toss send, the proposal
-   ledger records `toss_place_order`'s actual `approval_hash_digest`; it does
-   not substitute the raw approval token. If the comparison does *not* match, the
-   rung transitions to
+9. **Unchanged → submit; changed → `NEEDS_RECONFIRM`.** If the comparison
+   matches, the approval-window policy is checked before entering submission
+   and again by a pre-send hook immediately before the provider HTTP
+   submit/cancel. Only then can a mutation leave the process. An initial
+   pre-send block proves HTTP=0. A retry-time block can follow one explicit
+   429/auth rejection, but never an accepted or ambiguous mutation (Upbit
+   mutations are one-shot). On that proof the callback restores the
+   rung/lease and, when no sibling mutation occurred, the durable proposal
+   nonce to its retryable pre-click state; expiry instead converges terminally.
+   The submit uses the **freshly
+   minted** `approval_hash` from step 7's preview — never the one from the
+   original proposal-create preview. Toss receives a privately bound client
+   ID derived only from the proposal ID and rung for both preview and submit,
+   so retries and date boundaries cannot change the identity; preview must
+   return the exact bound ID or submission fails closed. The proposal
+   correlation and rung use the same private binding and are not
+   operator-controlled MCP parameters. Toss proposal numerics are converted
+   at the adapter boundary to canonical `str | int` values, never floats.
+   After an accepted Toss send, the proposal ledger records
+   `toss_place_order`'s actual `approval_hash_digest`; it does not substitute
+   the raw approval token. If the comparison does *not* match, the rung
+   transitions to
    `needs_reconfirm` and a brand-new Telegram message is sent
    (`build_approval_message(..., diff=...)`) showing an explicit
    before/after, with a freshly minted `approval_nonce` — the operator must
@@ -819,7 +862,7 @@ submitted blind would defeat the entire point of a human-approval gate.
    distinction: auto-revalidation is not the same as auto-approving a
    payload change.** The system re-checks freely; it never silently accepts
    a different price/qty on the operator's behalf.
-9. **Submit outcome classification.** `_classify_submit` records `acked`
+10. **Submit outcome classification.** `_classify_submit` records `acked`
    (market orders) or `resting` (limit orders) on explicit broker success,
    `rejected` on explicit broker/guard rejection, and `unverified` — never a
    terminal state — on anything ambiguous (submit exception, unrecognized
@@ -848,7 +891,7 @@ underneath `_default_place_order_fn` has its own `approval_hash` TTL (~300s,
 ROB-651/ROB-653) meant to bound the time between "operator saw this exact
 price/qty" and "it actually got submitted." Because `revalidate_and_submit`
 mints a **brand-new** `approval_hash` from a **fresh** preview at the moment
-of submission (step 5–7 above), that hash's age at submit time is always
+of submission (steps 7–9 above), that hash's age at submit time is always
 ~0 seconds — the underlying 300s TTL is structurally never at risk of
 tripping from a slow *human* round-trip (an operator taking 20 minutes to
 click "approve" doesn't matter; what matters is the freshness of the preview

--- a/tests/brokers/kis/mock_scalping_exec/test_pre_send_transport.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_pre_send_transport.py
@@ -18,6 +18,7 @@ import app.services.brokers.kis.circuit_breaker as cb
 from app.services.brokers.kis.base import BaseKISClient
 from app.services.brokers.kis.domestic_orders import DomesticOrderClient
 from app.services.brokers.kis.mock_scalping.contract import ReasonCode
+from app.services.brokers.kis.overseas_orders import OverseasOrderClient
 from app.services.brokers.kis.pre_send import PreSendFreshnessError
 
 _NXT = "app.services.brokers.kis.domestic_orders.is_nxt_eligible"
@@ -145,4 +146,90 @@ async def test_hook_rechecked_on_token_refresh_resend(monkeypatch) -> None:
             "005930", "buy", 1, 70000, is_mock=True, pre_send_hook=_fresh_then_stale
         )
     assert execute.await_count == 1  # first POST only; the re-send was blocked
+    assert client._parent._token_manager.clear_token.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market", ["kr", "us"])
+async def test_cancel_hook_runs_after_limiter_before_real_post(
+    monkeypatch, market
+) -> None:
+    execute = AsyncMock(return_value=_http_response({"rt_cd": "0"}))
+    domestic = _make(execute)
+    limiter = domestic._parent._get_limiter.return_value
+    admitted = False
+
+    async def acquire(**kwargs) -> None:
+        nonlocal admitted
+        admitted = True
+
+    limiter.acquire = AsyncMock(side_effect=acquire)
+
+    async def block_after_admission() -> None:
+        assert admitted is True
+        raise PreSendFreshnessError(("approval_window:EXPIRED",))
+
+    monkeypatch.setattr(_NXT, AsyncMock(return_value=False))
+    if market == "kr":
+        call = domestic.cancel_korea_order(
+            "broker-order-id",
+            "005930",
+            1,
+            70000,
+            "buy",
+            is_mock=True,
+            krx_fwdg_ord_orgno="06010",
+            pre_send_hook=block_after_admission,
+        )
+    else:
+        overseas = OverseasOrderClient(domestic._parent)
+        call = overseas.cancel_overseas_order(
+            "broker-order-id",
+            "VOO",
+            "NYSE",
+            1,
+            is_mock=True,
+            pre_send_hook=block_after_admission,
+        )
+
+    with pytest.raises(PreSendFreshnessError):
+        await call
+
+    assert limiter.acquire.await_count == 1
+    assert execute.await_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_token_refresh_resend_rechecks_transport_hook(monkeypatch) -> None:
+    execute = AsyncMock(
+        return_value=_http_response(
+            {"rt_cd": "1", "msg_cd": "EGW00123", "msg1": "token expired"}
+        )
+    )
+    client = _make(execute)
+    monkeypatch.setattr(_NXT, AsyncMock(return_value=False))
+    hook_calls = 0
+
+    async def allow_then_block() -> None:
+        nonlocal hook_calls
+        hook_calls += 1
+        if hook_calls == 2:
+            raise PreSendFreshnessError(("approval_window:DEFER_SESSION_CLOSED",))
+
+    with pytest.raises(PreSendFreshnessError):
+        await client.cancel_korea_order(
+            "broker-order-id",
+            "005930",
+            1,
+            70000,
+            "buy",
+            is_mock=True,
+            krx_fwdg_ord_orgno="06010",
+            pre_send_hook=allow_then_block,
+        )
+
+    assert hook_calls == 2
+    assert execute.await_count == 1
     assert client._parent._token_manager.clear_token.await_count == 1

--- a/tests/routers/test_telegram_callback_route.py
+++ b/tests/routers/test_telegram_callback_route.py
@@ -109,6 +109,7 @@ async def test_gate_on_valid_token_invokes_handler_and_returns_ok(
     now_arg = call_kwargs["now"]
     assert isinstance(now_arg, datetime)
     assert now_arg.tzinfo is not None  # must be timezone-aware, per Task 14
+    assert callable(call_kwargs["now_fn"])
 
 
 @pytest.mark.unit

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -726,3 +726,143 @@ async def test_warnings_fetches_and_parses() -> None:
     assert warnings[0].exchange == "KRX"
     assert warnings[0].start_date == "2026-06-12"
     assert warnings[0].end_date is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["place", "cancel"])
+async def test_mutation_hook_runs_after_limiter_token_and_account_resolution(
+    operation,
+) -> None:
+    """The final gate sees every pre-send await and blocks mutation HTTP=0."""
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+
+    paths: list[str] = []
+    limiter_groups = []
+    token_calls = 0
+
+    class TokenManager(_TokenManager):
+        async def get_access_token(
+            self, *, force_reissue: bool = False, failed_token: str | None = None
+        ) -> str:
+            nonlocal token_calls
+            del force_reissue, failed_token
+            token_calls += 1
+            return "token-1"
+
+    class Limiter:
+        async def acquire(self, group) -> None:
+            limiter_groups.append(group)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path == "/api/v1/accounts":
+            return httpx.Response(
+                200,
+                json=_json([{"accountNo": "1", "accountSeq": 7, "accountType": "B"}]),
+                request=request,
+            )
+        raise AssertionError("blocked hook must precede Toss mutation HTTP")
+
+    async def block() -> None:
+        assert token_calls == 2
+        assert paths == ["/api/v1/accounts"]
+        assert len(limiter_groups) == 2
+        raise PreSendFreshnessError(("approval_window:EXPIRED",))
+
+    client = TossReadClient(
+        token_manager=TokenManager(),
+        account_seq=None,
+        transport=httpx.MockTransport(handler),
+        rate_limiter=Limiter(),
+    )
+    try:
+        with pytest.raises(PreSendFreshnessError):
+            if operation == "place":
+                await client.place_order(
+                    {
+                        "symbol": "AAPL",
+                        "side": "BUY",
+                        "orderType": "LIMIT",
+                        "quantity": "1",
+                        "price": "150",
+                        "clientOrderId": "proposal-id",
+                    },
+                    pre_send_hook=block,
+                )
+            else:
+                await client.cancel_order(
+                    "broker-order-id",
+                    pre_send_hook=block,
+                )
+    finally:
+        await client.aclose()
+
+    assert paths == ["/api/v1/accounts"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["place", "cancel"])
+async def test_mutation_retry_rechecks_hook_before_second_http(
+    monkeypatch, operation
+) -> None:
+    """A 429-proven rejection may retry, but a closed window blocks re-send."""
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+
+    http_calls = 0
+    hook_calls = 0
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal http_calls
+        http_calls += 1
+        return httpx.Response(
+            429,
+            headers={"Retry-After": "0"},
+            json={
+                "error": {
+                    "requestId": "rate-1",
+                    "code": "too-many-requests",
+                    "message": "slow down",
+                }
+            },
+            request=request,
+        )
+
+    async def allow_then_block() -> None:
+        nonlocal hook_calls
+        hook_calls += 1
+        if hook_calls == 2:
+            raise PreSendFreshnessError(("approval_window:DEFER_SESSION_CLOSED",))
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=999,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(PreSendFreshnessError):
+            if operation == "place":
+                await client.place_order(
+                    {
+                        "symbol": "AAPL",
+                        "side": "BUY",
+                        "orderType": "LIMIT",
+                        "quantity": "1",
+                        "price": "150",
+                        "clientOrderId": "proposal-id",
+                    },
+                    pre_send_hook=allow_then_block,
+                )
+            else:
+                await client.cancel_order(
+                    "broker-order-id",
+                    pre_send_hook=allow_then_block,
+                )
+    finally:
+        await client.aclose()
+
+    assert hook_calls == 2
+    assert http_calls == 1

--- a/tests/services/order_proposals/test_approval_window.py
+++ b/tests/services/order_proposals/test_approval_window.py
@@ -21,6 +21,7 @@ from app.services.order_proposals.approval_window import (
     ApprovalWindowCode,
     SubmissionSessionEvidence,
     evaluate_approval_window,
+    evaluate_approval_window_boundary,
 )
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
@@ -42,6 +43,8 @@ def _group(
     account_mode: str = "kis_live",
     symbol: str = "VOO",
     valid_until: object,
+    exit_intent: str | None = None,
+    exit_reason: str | None = None,
 ):
     return SimpleNamespace(
         market=market,
@@ -50,6 +53,8 @@ def _group(
         valid_until=valid_until,
         action="place",
         order_type="limit",
+        exit_intent=exit_intent,
+        exit_reason=exit_reason,
     )
 
 
@@ -756,6 +761,73 @@ async def test_unknown_calendar_and_no_executable_next_window_are_distinct():
         {"approval_window": no_window.to_dict()},
     )
     assert next_allowed_at in callback_module._window_outcome_text(outcome)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_intent", ["loss_cut", "defensive_trim"])
+async def test_exit_intent_bypasses_unknown_toss_calendar_at_common_boundary(
+    monkeypatch, exit_intent
+):
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST)
+    calendar_calls = 0
+
+    async def unavailable_calendar(market, query_date):
+        nonlocal calendar_calls
+        calendar_calls += 1
+        return None
+
+    monkeypatch.setattr(policy, "get_toss_market_calendar", unavailable_calendar)
+    group = _group(
+        account_mode="toss_live",
+        valid_until=now + timedelta(days=1),
+        exit_intent=exit_intent,
+        exit_reason="stop_loss",
+    )
+
+    direct_decision = await evaluate_approval_window(group, now=now)
+    decision = await evaluate_approval_window_boundary(
+        group,
+        window_evaluator=evaluate_approval_window,
+        now_fn=lambda: now,
+        expected_policy_stamp="stale-window-policy-stamp",
+    )
+
+    assert direct_decision.code is ApprovalWindowCode.ALLOW
+    assert decision.code is ApprovalWindowCode.ALLOW
+    assert decision.detail == "exit_intent_session_calendar_exempt"
+    assert decision.evidence is not None
+    assert decision.evidence.source == "proposal_exit_intent"
+    assert calendar_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_non_exit_intent_still_fails_closed_when_toss_calendar_unknown(
+    monkeypatch,
+):
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST)
+    calendar_calls = 0
+
+    async def unavailable_calendar(market, query_date):
+        nonlocal calendar_calls
+        calendar_calls += 1
+        return None
+
+    monkeypatch.setattr(policy, "get_toss_market_calendar", unavailable_calendar)
+    group = _group(
+        account_mode="toss_live",
+        valid_until=now + timedelta(days=1),
+        exit_reason="stop_loss",
+    )
+
+    decision = await evaluate_approval_window_boundary(
+        group,
+        window_evaluator=evaluate_approval_window,
+        now_fn=lambda: now,
+        require_policy_stamp=False,
+    )
+
+    assert decision.code is ApprovalWindowCode.CALENDAR_UNKNOWN
+    assert calendar_calls == 1
 
 
 class _FakeRevalidationService:
@@ -1689,45 +1761,20 @@ async def test_batch_rechecks_frozen_members_before_global_nonce(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_loss_cut_first_click_session_block_precedes_external_preview():
+async def test_loss_cut_first_click_expiry_precedes_external_preview():
     now = datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST)
-    item = _FakeRevalidationService(valid_until=now + timedelta(days=1))
+    item = _FakeRevalidationService(valid_until=now)
+    item.group.exit_intent = "loss_cut"
 
-    async def evaluator(group, *, now):
-        async def resolver(group, *, now):
-            return SubmissionSessionEvidence(
-                known=True,
-                source="test:us-calendar",
-                current_session="closed",
-                allowed_sessions=("regular",),
-                allowed_now=False,
-                next_allowed_at=now + timedelta(hours=12),
-            )
+    async def evaluator_must_not_run(group, *, now):
+        raise AssertionError("exit-intent validity must resolve before session I/O")
 
-        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
-
-    # Bind the card to the same stable capability contract while it was open.
-    async def dispatch_resolver(group, *, now):
-        return SubmissionSessionEvidence(
-            known=True,
-            source="test:us-calendar",
-            current_session="regular",
-            allowed_sessions=("regular",),
-            allowed_now=True,
-        )
-
-    dispatched = await evaluate_approval_window(
-        item.group,
-        now=now - timedelta(hours=1),
-        session_resolver=dispatch_resolver,
-    )
-    item.group.source_asof = {"approval_window_policy_stamp": dispatched.policy_stamp}
     preview_calls = 0
 
     async def preview_must_not_run(**kwargs):
         nonlocal preview_calls
         preview_calls += 1
-        raise AssertionError("closed session must block before loss-cut preview")
+        raise AssertionError("expired loss cut must block before preview")
 
     class FakeSession:
         async def commit(self):
@@ -1744,13 +1791,13 @@ async def test_loss_cut_first_click_session_block_precedes_external_preview():
         message_id=None,
         telegram_user_id="777",
         loss_cut_preview_fn=preview_must_not_run,
-        window_evaluator=evaluator,
+        window_evaluator=evaluator_must_not_run,
         now_fn=lambda: now,
     )
 
-    assert result["reason"] == "DEFER_SESSION_CLOSED"
+    assert result["reason"] == "EXPIRED"
     assert preview_calls == 0
-    assert item.expire_calls == 0
+    assert item.expire_calls == 1
 
 
 _JULY_23_INCIDENT = (

--- a/tests/services/order_proposals/test_approval_window.py
+++ b/tests/services/order_proposals/test_approval_window.py
@@ -1,0 +1,2446 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.config import settings
+from app.services.brokers.toss.market_calendar import (
+    parse_kr_market_calendar,
+    parse_us_market_calendar,
+)
+from app.services.nxt_preflight import NxtTradability
+from app.services.order_proposals import approval_window as policy
+from app.services.order_proposals import dispatch as dispatch_module
+from app.services.order_proposals import telegram_callback as callback_module
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowCode,
+    SubmissionSessionEvidence,
+    evaluate_approval_window,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalDispatchState,
+    CallbackEnvelope,
+    DispatchBinding,
+    build_membership_digest,
+    build_proposal_dispatch_binding,
+)
+from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
+from app.services.order_proposals.service import OrderProposalsService
+from app.services.order_proposals.target_order import TargetOrderSnapshot
+
+
+def _group(
+    *,
+    market: str = "equity_us",
+    account_mode: str = "kis_live",
+    symbol: str = "VOO",
+    valid_until: object,
+):
+    return SimpleNamespace(
+        market=market,
+        account_mode=account_mode,
+        symbol=symbol,
+        valid_until=valid_until,
+        action="place",
+        order_type="limit",
+    )
+
+
+async def _allowed_session(group, *, now):
+    return SubmissionSessionEvidence(
+        known=True,
+        source="test",
+        current_session="regular",
+        allowed_sessions=("regular",),
+        allowed_now=True,
+        allowed_until=now + timedelta(hours=8),
+        next_allowed_at=now + timedelta(days=1),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("offset", "expected"),
+    [
+        (timedelta(microseconds=-1), ApprovalWindowCode.ALLOW),
+        (timedelta(0), ApprovalWindowCode.EXPIRED),
+        (timedelta(microseconds=1), ApprovalWindowCode.EXPIRED),
+    ],
+)
+async def test_valid_until_exact_microsecond_boundaries(offset, expected):
+    deadline = datetime(2026, 7, 23, 4, 55, tzinfo=policy._KST)
+    decision = await evaluate_approval_window(
+        _group(valid_until=deadline),
+        now=deadline + offset,
+        session_resolver=_allowed_session,
+    )
+    assert decision.code is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("valid_until", "detail"),
+    [
+        (None, "valid_until_missing"),
+        (datetime(2026, 7, 23, 4, 55), "valid_until_naive"),
+        ("2026-07-23T04:55:00+09:00", "valid_until_invalid_type"),
+    ],
+)
+async def test_invalid_valid_until_fails_closed_without_session_lookup(
+    valid_until, detail
+):
+    calls = 0
+
+    async def must_not_resolve(group, *, now):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("invalid validity must short-circuit session I/O")
+
+    decision = await evaluate_approval_window(
+        _group(valid_until=valid_until),
+        now=datetime(2026, 7, 23, 1, tzinfo=UTC),
+        session_resolver=must_not_resolve,
+    )
+    assert decision.code is ApprovalWindowCode.INVALID_VALID_UNTIL
+    assert decision.detail == detail
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "valid_until",
+    [None, datetime(2026, 7, 23, 4, 55), "invalid"],
+)
+async def test_invalid_valid_until_cannot_consume_approval_nonce(valid_until):
+    now = datetime(2026, 7, 23, 3, tzinfo=UTC)
+    group = SimpleNamespace(
+        proposal_id=uuid.uuid4(),
+        superseded_by_proposal_id=None,
+        lifecycle_state="proposed",
+        valid_until=valid_until,
+        source_asof={},
+        approval_nonce="nonce",
+        approval_nonce_used_at=None,
+    )
+
+    class FakeRepo:
+        def __init__(self):
+            self.updates = 0
+
+        async def get_group_by_proposal_id(self, proposal_id, *, for_update):
+            assert proposal_id == group.proposal_id
+            assert for_update is True
+            return group
+
+        async def update_group(self, group, **kwargs):
+            self.updates += 1
+            raise AssertionError("invalid validity must not consume a nonce")
+
+    service = object.__new__(OrderProposalsService)
+    service._repo = FakeRepo()
+
+    with pytest.raises(OrderProposalError, match="approval_window:INVALID_VALID_UNTIL"):
+        await service.consume_approval_nonce(group.proposal_id, "nonce", now=now)
+
+    assert service._repo.updates == 0
+    assert group.approval_nonce_used_at is None
+
+
+@pytest.mark.asyncio
+async def test_locked_callback_reads_refresh_identity_map_state() -> None:
+    """A FOR UPDATE waiter must not reuse its pre-lock nonce/rung snapshot."""
+    from app.services.order_proposals.repository import OrderProposalRepository
+
+    statements = []
+
+    class FakeScalars:
+        def all(self):
+            return []
+
+    class FakeResult:
+        def scalar_one_or_none(self):
+            return None
+
+        def scalars(self):
+            return FakeScalars()
+
+    class FakeSession:
+        async def execute(self, statement):
+            statements.append(statement)
+            return FakeResult()
+
+    repo = OrderProposalRepository(FakeSession())
+
+    await repo.get_group_by_proposal_id(uuid.uuid4(), for_update=True)
+    assert statements[-1].get_execution_options()["populate_existing"] is True
+
+    await repo.get_group_by_pk(1, for_update=True)
+    assert statements[-1].get_execution_options()["populate_existing"] is True
+
+    await repo.get_approval_batch_by_id(uuid.uuid4(), for_update=True)
+    assert statements[-1].get_execution_options()["populate_existing"] is True
+
+    await repo.list_rungs(1)
+    assert statements[-1].get_execution_options()["populate_existing"] is True
+
+    await repo.list_approval_batch_members(1)
+    assert statements[-1].get_execution_options()["populate_existing"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("known", "expected"),
+    [
+        (True, ApprovalWindowCode.DEFER_SESSION_CLOSED),
+        (False, ApprovalWindowCode.CALENDAR_UNKNOWN),
+    ],
+)
+async def test_dispatch_session_block_publishes_no_nonce_or_card(
+    monkeypatch, known, expected
+):
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST)
+    group = _group(
+        account_mode="toss_live",
+        valid_until=now + timedelta(days=1),
+    )
+    group.proposal_id = uuid.uuid4()
+    nonce_mints = 0
+    telegram_sends = 0
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            return SubmissionSessionEvidence(
+                known=known,
+                source="test:toss-us-calendar",
+                current_session="closed" if known else "unknown",
+                allowed_sessions=("regular",),
+                allowed_now=False,
+                next_allowed_at=now + timedelta(hours=12) if known else None,
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    class FakeDispatchService:
+        async def get_proposal(self, proposal_id):
+            return group, []
+
+        async def set_approval_nonce(self, proposal_id, nonce):
+            nonlocal nonce_mints
+            nonce_mints += 1
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    @contextlib.asynccontextmanager
+    async def service_factory():
+        yield FakeSession()
+
+    class NoSendNotifier:
+        async def send_approval_message(self, *args, **kwargs):
+            nonlocal telegram_sends
+            telegram_sends += 1
+            raise AssertionError("blocked dispatch must not publish Telegram")
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "test-chat"
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "OrderProposalsService",
+        lambda ignored: FakeDispatchService(),
+    )
+
+    result = await dispatch_module.send_proposal_for_approval(
+        group.proposal_id,
+        notifier=NoSendNotifier(),
+        now=now,
+        service_factory=service_factory,
+        window_evaluator=evaluator,
+    )
+
+    assert result.code is expected
+    assert nonce_mints == 0
+    assert telegram_sends == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rechecks_boundary_before_nonce_or_card(monkeypatch):
+    started = datetime(2026, 7, 23, 4, 54, 59, 999999, tzinfo=policy._KST)
+    deadline = started + timedelta(microseconds=1)
+    group = _group(account_mode="toss_live", valid_until=deadline)
+    group.proposal_id = uuid.uuid4()
+    nonce_mints = 0
+    telegram_sends = 0
+    expiry_transitions = 0
+    clock_values = iter((started, deadline))
+
+    async def evaluator(group, *, now):
+        return await evaluate_approval_window(
+            group, now=now, session_resolver=_allowed_session
+        )
+
+    class FakeDispatchService:
+        async def get_proposal(self, proposal_id):
+            return group, []
+
+        async def set_approval_nonce(self, proposal_id, nonce):
+            nonlocal nonce_mints
+            nonce_mints += 1
+
+        async def expire_mutable_rungs_if_needed(self, proposal_id, *, now):
+            nonlocal expiry_transitions
+            expiry_transitions += 1
+            return True
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    @contextlib.asynccontextmanager
+    async def service_factory():
+        yield FakeSession()
+
+    class NoSendNotifier:
+        async def send_approval_message(self, *args, **kwargs):
+            nonlocal telegram_sends
+            telegram_sends += 1
+            raise AssertionError("boundary-crossed dispatch must not publish")
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "test-chat"
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "OrderProposalsService",
+        lambda ignored: FakeDispatchService(),
+    )
+
+    result = await dispatch_module.send_proposal_for_approval(
+        group.proposal_id,
+        notifier=NoSendNotifier(),
+        now=started,
+        now_fn=lambda: next(clock_values),
+        service_factory=service_factory,
+        window_evaluator=evaluator,
+    )
+
+    assert result.code is ApprovalWindowCode.EXPIRED
+    assert nonce_mints == 0
+    assert telegram_sends == 0
+    assert expiry_transitions == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_summary_expiry_preserves_broker_backed_sibling() -> None:
+    now = datetime(2026, 7, 23, 4, 55, tzinfo=policy._KST)
+    group = _group(account_mode="toss_live", valid_until=now)
+    group.proposal_id = uuid.uuid4()
+    published = await evaluate_approval_window(
+        group,
+        now=now - timedelta(hours=1),
+        session_resolver=_allowed_session,
+    )
+    group.source_asof = {
+        "approval_window_policy_stamp": published.policy_stamp,
+    }
+    rungs = [
+        SimpleNamespace(rung_index=0, state="resting", broker_order_id="broker-1"),
+        SimpleNamespace(
+            rung_index=1,
+            state="pending_approval",
+            broker_order_id=None,
+        ),
+    ]
+    batch = SimpleNamespace(batch_id=uuid.uuid4(), summary_message_id=None)
+    registration = SimpleNamespace(
+        batch=batch,
+        summary_action="send",
+        binding=DispatchBinding(
+            attempt_id=uuid.uuid4(),
+            card_kind=ApprovalCardKind.BATCH,
+            membership_revision=1,
+            membership_digest="AbCdEf0123_-",
+        ),
+    )
+    expired_ids: list[uuid.UUID] = []
+    released_ids: list[uuid.UUID] = []
+    telegram_sends = 0
+
+    class FakeService:
+        async def register_approval_batch_member(self, *args, **kwargs):
+            return registration
+
+        async def get_approval_batch_display(self, *args, **kwargs):
+            return batch, [(group, rungs)]
+
+        async def expire_if_needed(self, *args, **kwargs):
+            raise AssertionError("whole-group expiry must not run for mixed rungs")
+
+        async def expire_mutable_rungs_if_needed(self, proposal_id, *, now):
+            expired_ids.append(proposal_id)
+            return 1
+
+        async def release_approval_batch_summary_claim(self, batch_id, *, now):
+            released_ids.append(batch_id)
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    class NoSendNotifier:
+        async def send_approval_message(self, *args, **kwargs):
+            nonlocal telegram_sends
+            telegram_sends += 1
+            raise AssertionError("expired batch summary must not publish")
+
+    async def evaluator(candidate, *, now):
+        return await evaluate_approval_window(
+            candidate,
+            now=now,
+            session_resolver=_allowed_session,
+        )
+
+    await dispatch_module._register_and_publish_batch_summary(
+        session=FakeSession(),
+        service=FakeService(),
+        proposal_id=group.proposal_id,
+        message_id=123,
+        chat_id="42",
+        now=now,
+        notifier=NoSendNotifier(),
+        window_evaluator=evaluator,
+        now_fn=lambda: now,
+    )
+
+    assert expired_ids == [group.proposal_id]
+    assert released_ids == [batch.batch_id]
+    assert rungs[0].state == "resting"
+    assert telegram_sends == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("at", "expected"),
+    [
+        (datetime(2026, 7, 22, 13, 29, 59, 999999, tzinfo=UTC), False),
+        (datetime(2026, 7, 22, 13, 30, tzinfo=UTC), True),
+        (datetime(2026, 7, 22, 19, 59, 59, 999999, tzinfo=UTC), True),
+        (datetime(2026, 7, 22, 20, 0, tzinfo=UTC), False),
+    ],
+)
+async def test_xnys_regular_open_close_exact_boundaries(at, expected):
+    evidence = policy._resolve_xnys_session(
+        _group(valid_until=at + timedelta(days=7)), at
+    )
+    assert evidence.allowed_now is expected
+    assert evidence.source == "exchange_calendars:XNYS"
+
+
+@pytest.mark.asyncio
+async def test_xnys_premarket_after_hours_and_holiday_defer():
+    group = _group(valid_until=datetime(2026, 7, 10, tzinfo=UTC))
+    pre = policy._resolve_xnys_session(group, datetime(2026, 7, 2, 12, 0, tzinfo=UTC))
+    post = policy._resolve_xnys_session(group, datetime(2026, 7, 2, 21, 0, tzinfo=UTC))
+    holiday = policy._resolve_xnys_session(
+        group, datetime(2026, 7, 3, 15, 0, tzinfo=UTC)
+    )
+    assert (pre.allowed_now, post.allowed_now, holiday.allowed_now) == (
+        False,
+        False,
+        False,
+    )
+    assert pre.next_allowed_at == datetime(2026, 7, 2, 13, 30, tzinfo=UTC)
+    assert holiday.next_allowed_at == datetime(2026, 7, 6, 13, 30, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_xnys_half_day_close_and_dst_are_calendar_derived():
+    group = _group(valid_until=datetime(2027, 1, 10, tzinfo=UTC))
+    half_day_before_close = policy._resolve_xnys_session(
+        group, datetime(2026, 11, 27, 17, 59, 59, 999999, tzinfo=UTC)
+    )
+    half_day_at_close = policy._resolve_xnys_session(
+        group, datetime(2026, 11, 27, 18, 0, tzinfo=UTC)
+    )
+    winter_open = policy._resolve_xnys_session(
+        group, datetime(2026, 1, 5, 14, 30, tzinfo=UTC)
+    )
+    summer_open = policy._resolve_xnys_session(
+        group, datetime(2026, 7, 6, 13, 30, tzinfo=UTC)
+    )
+    assert half_day_before_close.allowed_now is True
+    assert half_day_at_close.allowed_now is False
+    assert winter_open.allowed_now is True
+    assert summer_open.allowed_now is True
+
+
+def _window(start: str, end: str) -> dict[str, str]:
+    return {"startTime": start, "endTime": end}
+
+
+@pytest.mark.asyncio
+async def test_toss_us_regular_only_uses_broker_calendar(monkeypatch):
+    calendar = parse_us_market_calendar(
+        {
+            "today": {
+                "date": "2026-07-22",
+                "dayMarket": _window(
+                    "2026-07-22T09:00:00+09:00", "2026-07-22T17:00:00+09:00"
+                ),
+                "preMarket": _window(
+                    "2026-07-22T17:00:00+09:00", "2026-07-22T22:30:00+09:00"
+                ),
+                "regularMarket": _window(
+                    "2026-07-22T22:30:00+09:00", "2026-07-23T05:00:00+09:00"
+                ),
+                "afterMarket": _window(
+                    "2026-07-23T05:00:00+09:00", "2026-07-23T09:00:00+09:00"
+                ),
+            },
+            "nextBusinessDay": {
+                "date": "2026-07-23",
+                "regularMarket": _window(
+                    "2026-07-23T22:30:00+09:00", "2026-07-24T05:00:00+09:00"
+                ),
+            },
+        }
+    )
+
+    async def calendar_reader(market, query_date):
+        assert market == "us"
+        return calendar
+
+    monkeypatch.setattr(policy, "get_toss_market_calendar", calendar_reader)
+    group = _group(
+        account_mode="toss_live",
+        valid_until=datetime(2026, 7, 25, tzinfo=policy._KST),
+    )
+    pre = await policy.resolve_submission_session(
+        group, now=datetime(2026, 7, 22, 22, 29, 59, tzinfo=policy._KST)
+    )
+    opened = await policy.resolve_submission_session(
+        group, now=datetime(2026, 7, 22, 22, 30, tzinfo=policy._KST)
+    )
+    closed = await policy.resolve_submission_session(
+        group, now=datetime(2026, 7, 23, 5, 0, tzinfo=policy._KST)
+    )
+    assert pre.allowed_now is False
+    assert opened.allowed_now is True
+    assert closed.allowed_now is False
+    assert closed.next_allowed_at == datetime(2026, 7, 23, 22, 30, tzinfo=policy._KST)
+
+
+def _kr_calendar():
+    return parse_kr_market_calendar(
+        {
+            "today": {
+                "date": "2026-07-23",
+                "integrated": {
+                    "preMarket": _window(
+                        "2026-07-23T08:00:00+09:00",
+                        "2026-07-23T08:50:00+09:00",
+                    ),
+                    "regularMarket": _window(
+                        "2026-07-23T09:00:00+09:00",
+                        "2026-07-23T15:30:00+09:00",
+                    ),
+                    "afterMarket": _window(
+                        "2026-07-23T16:00:00+09:00",
+                        "2026-07-23T20:00:00+09:00",
+                    ),
+                },
+            },
+            "nextBusinessDay": {
+                "date": "2026-07-24",
+                "integrated": {
+                    "preMarket": _window(
+                        "2026-07-24T08:00:00+09:00",
+                        "2026-07-24T08:50:00+09:00",
+                    ),
+                    "regularMarket": _window(
+                        "2026-07-24T09:00:00+09:00",
+                        "2026-07-24T15:30:00+09:00",
+                    ),
+                    "afterMarket": _window(
+                        "2026-07-24T16:00:00+09:00",
+                        "2026-07-24T20:00:00+09:00",
+                    ),
+                },
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("account_mode", ["kis_live", "toss_live"])
+async def test_kr_regular_and_nxt_carry_preserved(monkeypatch, account_mode):
+    async def calendar_reader(market, query_date):
+        return _kr_calendar()
+
+    async def tradability_reader(symbols):
+        return {
+            "005930": NxtTradability(
+                nxt_eligible=True,
+                nxt_trading_suspended=False,
+                asof=datetime(2026, 7, 23, 7, tzinfo=policy._KST),
+            )
+        }
+
+    monkeypatch.setattr(policy, "get_toss_market_calendar", calendar_reader)
+    monkeypatch.setattr(policy, "get_kr_nxt_tradability", tradability_reader)
+    group = _group(
+        market="equity_kr",
+        account_mode=account_mode,
+        symbol="005930",
+        valid_until=datetime(2026, 7, 24, 20, tzinfo=policy._KST),
+    )
+    for at in (
+        datetime(2026, 7, 23, 8, 0, tzinfo=policy._KST),
+        datetime(2026, 7, 23, 9, 0, tzinfo=policy._KST),
+        datetime(2026, 7, 23, 16, 0, tzinfo=policy._KST),
+    ):
+        evidence = await policy.resolve_submission_session(group, now=at)
+        assert evidence.allowed_now is True
+        assert evidence.allowed_sessions == (
+            "nxt_premarket",
+            "regular",
+            "nxt_after",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("account_mode", ["kis_live", "toss_live"])
+async def test_krx_regular_remains_authoritative_when_nxt_calendar_is_unavailable(
+    monkeypatch, account_mode
+):
+    async def unavailable_calendar(market, query_date):
+        return None
+
+    async def unavailable_tradability(symbols):
+        raise RuntimeError("symbol universe unavailable")
+
+    monkeypatch.setattr(policy, "get_toss_market_calendar", unavailable_calendar)
+    monkeypatch.setattr(policy, "get_kr_nxt_tradability", unavailable_tradability)
+    now = datetime(2026, 7, 23, 9, 0, tzinfo=policy._KST)
+    decision = await evaluate_approval_window(
+        _group(
+            market="equity_kr",
+            account_mode=account_mode,
+            symbol="005930",
+            valid_until=now + timedelta(hours=1),
+        ),
+        now=now,
+    )
+
+    assert decision.code is ApprovalWindowCode.ALLOW
+    assert decision.evidence.source.startswith("exchange_calendars:XKRX")
+    assert decision.evidence.allowed_sessions == ("regular",)
+
+
+@pytest.mark.asyncio
+async def test_kr_nxt_unknown_or_not_tradable_fails_closed_or_defers(monkeypatch):
+    async def calendar_reader(market, query_date):
+        return _kr_calendar()
+
+    monkeypatch.setattr(policy, "get_toss_market_calendar", calendar_reader)
+    group = _group(
+        market="equity_kr",
+        account_mode="toss_live",
+        symbol="005930",
+        valid_until=datetime(2026, 7, 24, 20, tzinfo=policy._KST),
+    )
+
+    async def stale_reader(symbols):
+        return {
+            "005930": NxtTradability(
+                nxt_eligible=True,
+                nxt_trading_suspended=False,
+                asof=datetime(2026, 7, 20, tzinfo=policy._KST),
+            )
+        }
+
+    monkeypatch.setattr(policy, "get_kr_nxt_tradability", stale_reader)
+    unknown = await evaluate_approval_window(
+        group, now=datetime(2026, 7, 23, 8, 10, tzinfo=policy._KST)
+    )
+    assert unknown.code is ApprovalWindowCode.CALENDAR_UNKNOWN
+
+    async def ineligible_reader(symbols):
+        return {
+            "005930": NxtTradability(
+                nxt_eligible=False,
+                nxt_trading_suspended=False,
+                asof=datetime(2026, 7, 23, 7, tzinfo=policy._KST),
+            )
+        }
+
+    monkeypatch.setattr(policy, "get_kr_nxt_tradability", ineligible_reader)
+    deferred = await evaluate_approval_window(
+        group, now=datetime(2026, 7, 23, 8, 10, tzinfo=policy._KST)
+    )
+    assert deferred.code is ApprovalWindowCode.DEFER_SESSION_CLOSED
+    assert deferred.evidence.next_allowed_at == datetime(
+        2026, 7, 23, 9, 0, tzinfo=policy._KST
+    )
+
+
+@pytest.mark.asyncio
+async def test_crypto_is_24x7_and_does_not_use_market_calendar(monkeypatch):
+    async def must_not_read(*args, **kwargs):
+        raise AssertionError("crypto must not read equity calendars")
+
+    monkeypatch.setattr(policy, "get_toss_market_calendar", must_not_read)
+    now = datetime(2026, 7, 23, 3, tzinfo=UTC)
+    decision = await evaluate_approval_window(
+        _group(
+            market="crypto",
+            account_mode="upbit",
+            symbol="KRW-BTC",
+            valid_until=now + timedelta(hours=1),
+        ),
+        now=now,
+    )
+    assert decision.code is ApprovalWindowCode.ALLOW
+    assert decision.evidence.current_session == "24x7"
+
+
+@pytest.mark.asyncio
+async def test_unknown_calendar_and_no_executable_next_window_are_distinct():
+    now = datetime(2026, 7, 23, 1, tzinfo=UTC)
+
+    async def unknown(group, *, now):
+        return SubmissionSessionEvidence(
+            known=False,
+            source="test",
+            current_session="unknown",
+            allowed_sessions=("regular",),
+            allowed_now=False,
+        )
+
+    unknown_decision = await evaluate_approval_window(
+        _group(valid_until=now + timedelta(days=1)),
+        now=now,
+        session_resolver=unknown,
+    )
+    assert unknown_decision.code is ApprovalWindowCode.CALENDAR_UNKNOWN
+
+    async def next_after_expiry(group, *, now):
+        return SubmissionSessionEvidence(
+            known=True,
+            source="test",
+            current_session="closed",
+            allowed_sessions=("regular",),
+            allowed_now=False,
+            next_allowed_at=now + timedelta(hours=2),
+        )
+
+    no_window = await evaluate_approval_window(
+        _group(valid_until=now + timedelta(hours=1)),
+        now=now,
+        session_resolver=next_after_expiry,
+    )
+    assert no_window.code is ApprovalWindowCode.NO_EXECUTABLE_WINDOW
+    next_allowed_at = (now + timedelta(hours=2)).isoformat()
+    assert next_allowed_at in policy.approval_window_operator_text(no_window)
+    outcome = RungOutcome(
+        0,
+        "no_executable_window",
+        {"approval_window": no_window.to_dict()},
+    )
+    assert next_allowed_at in callback_module._window_outcome_text(outcome)
+
+
+class _FakeRevalidationService:
+    def __init__(self, *, action: str = "place", valid_until: datetime):
+        proposal_id = uuid.uuid4()
+        dispatch_binding = build_proposal_dispatch_binding(
+            proposal_id=proposal_id,
+            nonce="published-nonce",
+            attempt_id=uuid.uuid4(),
+            card_kind=ApprovalCardKind.MANUAL,
+            current_membership_revision=None,
+        )
+        self.group = SimpleNamespace(
+            proposal_id=proposal_id,
+            superseded_by_proposal_id=None,
+            lifecycle_state="proposed",
+            source_asof={},
+            action=action,
+            order_type="limit",
+            account_mode="kis_live",
+            market="equity_us",
+            symbol="VOO",
+            side="sell",
+            thesis=None,
+            strategy=None,
+            exit_intent=None,
+            exit_reason=None,
+            retrospective_id=None,
+            approval_issue_id=None,
+            broker_account_id=None,
+            target_broker_order_id="target-1" if action != "place" else None,
+            valid_until=valid_until,
+            approval_nonce="published-nonce",
+            approval_nonce_used_at=None,
+            approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
+            approval_dispatch_attempt_id=dispatch_binding.attempt_id,
+            approval_dispatch_card_kind=dispatch_binding.card_kind.value,
+            approval_dispatch_membership_revision=(
+                dispatch_binding.membership_revision
+            ),
+            approval_dispatch_membership_digest=dispatch_binding.membership_digest,
+            approved_by_telegram_user_id=None,
+            approved_at=None,
+            commit_lease_until=None,
+        )
+        self.rung = SimpleNamespace(
+            rung_index=0,
+            state="pending_approval",
+            side="sell",
+            quantity=Decimal("1"),
+            limit_price=Decimal("100"),
+        )
+        self.transitions: list[str] = []
+        self.expire_calls = 0
+        self.resting_calls = 0
+        self.cancelled_calls = 0
+        self.nonce_consumes = 0
+        self.allow_nonce_consume = False
+
+    async def get_proposal(self, proposal_id):
+        assert proposal_id == self.group.proposal_id
+        return self.group, [self.rung]
+
+    async def transition_rung(self, proposal_id, rung_index, *, new_state, **kwargs):
+        assert proposal_id == self.group.proposal_id
+        assert rung_index == 0
+        self.rung.state = new_state
+        self.transitions.append(new_state)
+        return self.rung
+
+    async def expire_if_needed(self, proposal_id, *, now):
+        assert proposal_id == self.group.proposal_id
+        self.expire_calls += 1
+        self.rung.state = "expired"
+        self.group.lifecycle_state = "expired"
+        return True
+
+    async def expire_rung_if_needed(self, proposal_id, rung_index, *, now):
+        assert rung_index == 0
+        return await self.expire_if_needed(proposal_id, now=now)
+
+    async def expire_mutable_rungs_if_needed(self, proposal_id, *, now):
+        await self.expire_if_needed(proposal_id, now=now)
+        return 1
+
+    async def restore_rung_after_pre_send_block(
+        self, proposal_id, rung_index, *, now, expired
+    ):
+        assert proposal_id == self.group.proposal_id
+        assert rung_index == 0
+        self.rung.state = "pending_approval"
+        if expired:
+            await self.expire_if_needed(proposal_id, now=now)
+        return self.rung
+
+    async def record_resting(self, proposal_id, rung_index, **kwargs):
+        self.resting_calls += 1
+        self.rung.state = "resting"
+        return self.rung
+
+    async def record_cancelled(self, proposal_id, rung_index, **kwargs):
+        self.cancelled_calls += 1
+        self.rung.state = "cancelled"
+        return self.rung
+
+    async def acquire_target_mutation_lock(self, group):
+        assert group is self.group
+
+    async def preflight_published_proposal_callback(self, proposal_id, *, callback):
+        assert proposal_id == self.group.proposal_id
+        OrderProposalsService._assert_published_proposal_binding(
+            self.group,
+            callback=callback,
+        )
+        return self.group
+
+    async def consume_published_proposal_callback(
+        self,
+        proposal_id,
+        *,
+        callback,
+        now,
+        telegram_user_id=None,
+    ):
+        assert proposal_id == self.group.proposal_id
+        self.nonce_consumes += 1
+        if not self.allow_nonce_consume:
+            raise AssertionError("blocked callback must not consume its nonce")
+        OrderProposalsService._assert_published_proposal_binding(
+            self.group,
+            callback=callback,
+        )
+        self.group.approval_nonce_used_at = now
+        return self.group
+
+    async def consume_approval_nonce(self, proposal_id, nonce, *, now):
+        self.nonce_consumes += 1
+        if not self.allow_nonce_consume:
+            raise AssertionError("blocked callback must not consume its nonce")
+        self.group.approval_nonce_used_at = now
+        return self.group
+
+    async def acquire_commit_lease(self, proposal_id, *, now):
+        self.group.commit_lease_until = now + timedelta(seconds=10)
+        return True
+
+    async def record_approval(self, proposal_id, *, telegram_user_id, now):
+        self.group.approved_by_telegram_user_id = telegram_user_id
+        self.group.approved_at = now
+        return self.group
+
+    async def restore_approval_after_window_block(self, proposal_id, *, nonce, expired):
+        self.group.approval_nonce = None if expired else nonce
+        self.group.approval_nonce_used_at = None
+        self.group.approved_by_telegram_user_id = None
+        self.group.approved_at = None
+        self.group.commit_lease_until = None
+        return self.group
+
+
+def _callback_for_group(
+    group: SimpleNamespace,
+    *,
+    action: str = "op",
+) -> CallbackEnvelope:
+    return CallbackEnvelope(
+        action=action,
+        subject_short=str(group.proposal_id)[:8],
+        attempt_id=group.approval_dispatch_attempt_id,
+        membership_revision=group.approval_dispatch_membership_revision,
+        membership_digest=group.approval_dispatch_membership_digest,
+        nonce=group.approval_nonce,
+    )
+
+
+def _callback_for_batch(batch: SimpleNamespace) -> CallbackEnvelope:
+    return CallbackEnvelope(
+        action="ba",
+        subject_short=str(batch.batch_id)[:8],
+        attempt_id=batch.approval_dispatch_attempt_id,
+        membership_revision=batch.membership_revision,
+        membership_digest=batch.membership_digest,
+        nonce=batch.approval_nonce,
+    )
+
+
+def _bind_batch_snapshot(
+    batch: SimpleNamespace,
+    groups: list[SimpleNamespace],
+    members: list[SimpleNamespace],
+) -> CallbackEnvelope:
+    batch.approval_dispatch_state = ApprovalDispatchState.SENT_CURRENT.value
+    batch.approval_dispatch_attempt_id = uuid.uuid4()
+    batch.membership_revision = 1
+    digest_members = []
+    for group, member in zip(groups, members, strict=True):
+        binding = build_proposal_dispatch_binding(
+            proposal_id=group.proposal_id,
+            nonce=group.approval_nonce,
+            attempt_id=uuid.uuid4(),
+            card_kind=ApprovalCardKind.MANUAL,
+            current_membership_revision=None,
+        )
+        group.approval_dispatch_state = ApprovalDispatchState.SENT_CURRENT.value
+        group.approval_dispatch_attempt_id = binding.attempt_id
+        group.approval_dispatch_card_kind = binding.card_kind.value
+        group.approval_dispatch_membership_revision = binding.membership_revision
+        group.approval_dispatch_membership_digest = binding.membership_digest
+        member.membership_revision = batch.membership_revision
+        member.approval_dispatch_attempt_id_snapshot = binding.attempt_id
+        member.approval_membership_revision_snapshot = binding.membership_revision
+        member.approval_membership_digest_snapshot = binding.membership_digest
+        member.approval_card_kind_snapshot = binding.card_kind.value
+        digest_members.append(
+            {
+                "proposal_id": str(group.proposal_id),
+                "approval_nonce": member.approval_nonce_snapshot,
+                "approval_message_id": member.approval_message_id,
+                "approval_dispatch_attempt_id": str(binding.attempt_id),
+                "approval_membership_revision": binding.membership_revision,
+                "approval_membership_digest": binding.membership_digest,
+            }
+        )
+    batch.membership_digest = build_membership_digest(
+        card_kind=ApprovalCardKind.BATCH,
+        membership_revision=batch.membership_revision,
+        members=digest_members,
+    )
+    return _callback_for_batch(batch)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["place", "replace", "cancel"])
+@pytest.mark.parametrize(
+    "block_kind",
+    ["expired", "session_closed", "calendar_unknown"],
+)
+async def test_revalidation_initial_window_block_has_zero_provider_or_broker_calls(
+    action, block_kind
+):
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST)
+    service = _FakeRevalidationService(
+        action=action,
+        valid_until=now if block_kind == "expired" else now + timedelta(days=2),
+    )
+    calls = {"preview_or_submit": 0, "fetch": 0, "cancel": 0}
+
+    async def place_must_not_run(**kwargs):
+        calls["preview_or_submit"] += 1
+        raise AssertionError("window block must precede provider preview/live submit")
+
+    async def fetch_must_not_run(**kwargs):
+        calls["fetch"] += 1
+        raise AssertionError("window block must precede target provider lookup")
+
+    async def cancel_must_not_run(**kwargs):
+        calls["cancel"] += 1
+        raise AssertionError("window block must precede broker cancel")
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            return SubmissionSessionEvidence(
+                known=block_kind != "calendar_unknown",
+                source="test:us-calendar",
+                current_session=(
+                    "unknown" if block_kind == "calendar_unknown" else "closed"
+                ),
+                allowed_sessions=("regular",),
+                allowed_now=False,
+                next_allowed_at=(
+                    now + timedelta(hours=12)
+                    if block_kind == "session_closed"
+                    else None
+                ),
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    expected_stamp = (await evaluator(service.group, now=now)).policy_stamp
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=now,
+        place_order_fn=place_must_not_run,
+        fetch_target_fn=fetch_must_not_run,
+        cancel_target_fn=cancel_must_not_run,
+        window_evaluator=evaluator,
+        expected_policy_stamp=expected_stamp,
+    )
+
+    expected = {
+        "expired": "expired",
+        "session_closed": "defer_session_closed",
+        "calendar_unknown": "calendar_unknown",
+    }[block_kind]
+    assert [outcome.result for outcome in outcomes] == [expected]
+    assert calls == {"preview_or_submit": 0, "fetch": 0, "cancel": 0}
+    assert service.expire_calls == (1 if block_kind == "expired" else 0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("close_kind", "expected"),
+    [
+        ("expiry", "expired"),
+        ("session", "defer_session_closed"),
+    ],
+)
+async def test_revalidation_toctou_after_preview_blocks_live_submit(
+    close_kind, expected
+):
+    started = datetime(2026, 7, 22, 19, 54, 59, 999999, tzinfo=UTC)
+    boundary = started + timedelta(microseconds=1)
+    valid_until = boundary if close_kind == "expiry" else started + timedelta(days=2)
+    service = _FakeRevalidationService(valid_until=valid_until)
+    calls = {"preview": 0, "submit": 0}
+
+    async def place(**kwargs):
+        if kwargs["dry_run"]:
+            calls["preview"] += 1
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "100",
+                "quantity": "1",
+            }
+        calls["submit"] += 1
+        raise AssertionError("TOCTOU window close must block live submit")
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            session_open = close_kind != "session" or now < boundary
+            return SubmissionSessionEvidence(
+                known=True,
+                source="test:us-calendar",
+                current_session="regular" if session_open else "closed",
+                allowed_sessions=("regular",),
+                allowed_now=session_open,
+                allowed_until=boundary if session_open else None,
+                next_allowed_at=boundary + timedelta(hours=17),
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    initial = await evaluator(service.group, now=started)
+    clock_values = iter((*([started] * 5), boundary))
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=started,
+        place_order_fn=place,
+        correlation_mint=lambda **kwargs: "must-not-run",
+        window_evaluator=evaluator,
+        expected_policy_stamp=initial.policy_stamp,
+        now_fn=lambda: next(clock_values),
+    )
+
+    assert [outcome.result for outcome in outcomes] == [expected]
+    assert calls == {"preview": 1, "submit": 0}
+    assert service.resting_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_replace_rechecks_after_cancel_before_replacement_submit():
+    started = datetime(2026, 7, 22, 19, 54, 59, 999999, tzinfo=UTC)
+    boundary = started + timedelta(microseconds=1)
+    service = _FakeRevalidationService(
+        action="replace", valid_until=started + timedelta(days=2)
+    )
+    approved_target = TargetOrderSnapshot(
+        broker_order_id="target-1",
+        symbol="VOO",
+        side="sell",
+        order_type="limit",
+        limit_price="100",
+        remaining_quantity="1",
+        status="open",
+        observed_at=started.isoformat(),
+    )
+    service.group.source_asof = {"target_order_snapshot": approved_target.to_payload()}
+    target_states = iter(
+        (
+            approved_target,
+            TargetOrderSnapshot(
+                broker_order_id="target-1",
+                symbol="VOO",
+                side="sell",
+                order_type="limit",
+                limit_price="100",
+                remaining_quantity="1",
+                status="cancelled",
+                observed_at=boundary.isoformat(),
+            ),
+        )
+    )
+    calls = {"preview": 0, "cancel": 0, "submit": 0}
+
+    async def place(**kwargs):
+        if kwargs["dry_run"]:
+            calls["preview"] += 1
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "100",
+                "quantity": "1",
+            }
+        calls["submit"] += 1
+        raise AssertionError("closed-window replacement must not be submitted")
+
+    async def fetch_target(**kwargs):
+        return next(target_states)
+
+    async def cancel_target(**kwargs):
+        calls["cancel"] += 1
+        return {"success": True}
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            session_open = now < boundary
+            return SubmissionSessionEvidence(
+                known=True,
+                source="test:us-calendar",
+                current_session="regular" if session_open else "closed",
+                allowed_sessions=("regular",),
+                allowed_now=session_open,
+                allowed_until=boundary if session_open else None,
+                next_allowed_at=boundary + timedelta(hours=17),
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    initial = await evaluator(service.group, now=started)
+    service.group.source_asof["approval_window_policy_stamp"] = initial.policy_stamp
+    clock_values = iter((*([started] * 11), boundary))
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=started,
+        place_order_fn=place,
+        fetch_target_fn=fetch_target,
+        cancel_target_fn=cancel_target,
+        correlation_mint=lambda **kwargs: "corr-1",
+        opposite_pending_check_fn=lambda **kwargs: None,
+        window_evaluator=evaluator,
+        expected_policy_stamp=initial.policy_stamp,
+        now_fn=lambda: next(clock_values),
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["defer_session_closed"]
+    assert outcomes[0].detail["target_cancelled"] is True
+    assert outcomes[0].detail["replacement_submitted"] is False
+    assert calls == {"preview": 1, "cancel": 1, "submit": 0}
+    assert service.cancelled_calls == 1
+    assert service.rung.state == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_card_can_expire_before_callback_without_nonce_consumption():
+    deadline = datetime(2026, 7, 23, 4, 55, tzinfo=policy._KST)
+    item = _FakeRevalidationService(valid_until=deadline)
+    dispatched = await _allowed_window_evaluator(
+        item.group, now=deadline - timedelta(microseconds=1)
+    )
+    item.group.source_asof = {"approval_window_policy_stamp": dispatched.policy_stamp}
+    revalidate_calls = 0
+
+    async def must_not_revalidate(**kwargs):
+        nonlocal revalidate_calls
+        revalidate_calls += 1
+        raise AssertionError("expired callback must not revalidate")
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    result = await callback_module._handle_approve(
+        session=FakeSession(),
+        service=item,
+        proposal_id=item.group.proposal_id,
+        callback=_callback_for_group(item.group),
+        now=deadline,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        callback_query_id=None,
+        telegram_user_id="777",
+        revalidate_fn=must_not_revalidate,
+        window_evaluator=_allowed_window_evaluator,
+        now_fn=lambda: deadline,
+    )
+
+    assert result["reason"] == "EXPIRED"
+    assert item.nonce_consumes == 0
+    assert item.expire_calls == 1
+    assert revalidate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_card_session_can_close_before_callback_without_nonce_consumption():
+    dispatched_at = datetime(2026, 7, 22, 19, 54, 59, 999999, tzinfo=UTC)
+    closed_at = dispatched_at + timedelta(microseconds=1)
+    item = _FakeRevalidationService(valid_until=closed_at + timedelta(days=2))
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            session_open = now < closed_at
+            return SubmissionSessionEvidence(
+                known=True,
+                source="test:us-calendar",
+                current_session="regular" if session_open else "closed",
+                allowed_sessions=("regular",),
+                allowed_now=session_open,
+                next_allowed_at=(
+                    None if session_open else closed_at + timedelta(hours=17)
+                ),
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    dispatched = await evaluator(item.group, now=dispatched_at)
+    item.group.source_asof = {"approval_window_policy_stamp": dispatched.policy_stamp}
+    revalidate_calls = 0
+
+    async def must_not_revalidate(**kwargs):
+        nonlocal revalidate_calls
+        revalidate_calls += 1
+        raise AssertionError("session-closed callback must not revalidate")
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    result = await callback_module._handle_approve(
+        session=FakeSession(),
+        service=item,
+        proposal_id=item.group.proposal_id,
+        callback=_callback_for_group(item.group),
+        now=closed_at,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        callback_query_id=None,
+        telegram_user_id="777",
+        revalidate_fn=must_not_revalidate,
+        window_evaluator=evaluator,
+        now_fn=lambda: closed_at,
+    )
+
+    assert result["reason"] == "DEFER_SESSION_CLOSED"
+    assert item.nonce_consumes == 0
+    assert item.expire_calls == 0
+    assert revalidate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_callback_rechecks_boundary_immediately_before_nonce_consumption():
+    started = datetime(2026, 7, 23, 4, 54, 59, 999999, tzinfo=policy._KST)
+    deadline = started + timedelta(microseconds=1)
+    item = _FakeRevalidationService(valid_until=deadline)
+    dispatched = await _allowed_window_evaluator(item.group, now=started)
+    item.group.source_asof = {"approval_window_policy_stamp": dispatched.policy_stamp}
+    clock_values = iter((started, deadline))
+    revalidate_calls = 0
+
+    async def must_not_revalidate(**kwargs):
+        nonlocal revalidate_calls
+        revalidate_calls += 1
+        raise AssertionError("nonce-boundary expiry must not revalidate")
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    result = await callback_module._handle_approve(
+        session=FakeSession(),
+        service=item,
+        proposal_id=item.group.proposal_id,
+        callback=_callback_for_group(item.group),
+        now=started,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        callback_query_id=None,
+        telegram_user_id="777",
+        revalidate_fn=must_not_revalidate,
+        window_evaluator=_allowed_window_evaluator,
+        now_fn=lambda: next(clock_values),
+    )
+
+    assert result["reason"] == "EXPIRED"
+    assert item.nonce_consumes == 0
+    assert item.expire_calls == 1
+    assert revalidate_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_callback_missing_dispatch_policy_stamp_fails_closed():
+    now = datetime(2026, 7, 22, 14, tzinfo=UTC)
+    item = _FakeRevalidationService(valid_until=now + timedelta(hours=1))
+    item.group.source_asof = {}
+
+    decision = await callback_module._evaluate_bound_window(
+        item.group,
+        now=now,
+        window_evaluator=_allowed_window_evaluator,
+    )
+
+    assert decision.code is ApprovalWindowCode.CALENDAR_UNKNOWN
+    assert decision.detail == "approval_window_policy_stamp_missing"
+
+
+@pytest.mark.asyncio
+async def test_valid_us_regular_session_preserves_preview_and_submit_path():
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    service = _FakeRevalidationService(valid_until=now + timedelta(hours=1))
+    calls = {"preview": 0, "submit": 0}
+
+    async def place(**kwargs):
+        if kwargs["dry_run"]:
+            calls["preview"] += 1
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "100",
+                "quantity": "1",
+            }
+        calls["submit"] += 1
+        return {
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "broker-1",
+            "correlation_id": "corr-1",
+            "idempotency_key": "idem-1",
+            "approval_hash_digest": "digest-1",
+        }
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=now,
+        place_order_fn=place,
+        correlation_mint=lambda **kwargs: "corr-1",
+        window_evaluator=_allowed_window_evaluator,
+        now_fn=lambda: now,
+        expected_policy_stamp=(
+            await _allowed_window_evaluator(service.group, now=now)
+        ).policy_stamp,
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["submitted_resting"]
+    assert calls == {"preview": 1, "submit": 1}
+    assert service.resting_calls == 1
+
+
+async def _allowed_window_evaluator(group, *, now):
+    return await evaluate_approval_window(
+        group, now=now, session_resolver=_allowed_session
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_window_block_preserves_exact_membership_and_all_nonces(
+    monkeypatch,
+):
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST)
+    groups = []
+    for symbol, valid_until in (
+        ("VALID", now + timedelta(days=2)),
+        ("EXPIRED", now),
+        ("CLOSED", now + timedelta(days=2)),
+    ):
+        item = _FakeRevalidationService(valid_until=valid_until)
+        item.group.symbol = symbol
+        item.group.exit_intent = None
+        item.group.approval_nonce = f"nonce-{symbol.lower()}"
+        item.group.approval_nonce_used_at = None
+        groups.append(item)
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            allowed = group.symbol != "CLOSED"
+            return SubmissionSessionEvidence(
+                known=True,
+                source="test:us-calendar",
+                current_session="regular" if allowed else "closed",
+                allowed_sessions=("regular",),
+                allowed_now=allowed,
+                allowed_until=now + timedelta(hours=8) if allowed else None,
+                next_allowed_at=None if allowed else now + timedelta(hours=12),
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    for item in groups:
+        # Published cards carry the same capability policy stamp. Current
+        # session state is evidence, not part of the stable stamp.
+        stamp_now = now - timedelta(hours=1)
+
+        async def dispatch_resolver(group, *, now):
+            return SubmissionSessionEvidence(
+                known=True,
+                source="test:us-calendar",
+                current_session="regular",
+                allowed_sessions=("regular",),
+                allowed_now=True,
+            )
+
+        decision = await evaluate_approval_window(
+            item.group, now=stamp_now, session_resolver=dispatch_resolver
+        )
+        item.group.source_asof = {"approval_window_policy_stamp": decision.policy_stamp}
+
+    batch_id = uuid.uuid4()
+    batch = SimpleNamespace(
+        batch_id=batch_id,
+        chat_id="42",
+        approval_nonce="batch-nonce",
+        approval_nonce_used_at=None,
+        # Real registration bounds the batch by the earliest member
+        # valid_until. The expired member therefore expires the batch exactly
+        # at this callback boundary; member-level typed convergence must still
+        # run before the generic batch-TTL return.
+        expires_at=now,
+        approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
+        approval_dispatch_attempt_id=uuid.uuid4(),
+        membership_revision=1,
+        membership_digest="AbCdEf0123_-",
+    )
+    proposals = [(item.group, [item.rung]) for item in groups]
+
+    class FakeBatchService:
+        def __init__(self):
+            self.batch_nonce_consumes = 0
+            self.expired_ids: list[uuid.UUID] = []
+
+        async def acquire_approval_batch_chat_lock(self, chat_id):
+            assert chat_id == "42"
+
+        async def resolve_approval_batch_id_prefix(self, batch_short):
+            return batch_id
+
+        async def preflight_published_batch_callback(
+            self,
+            requested_batch_id,
+            *,
+            callback,
+            chat_id,
+            now,
+            allow_expired=False,
+        ):
+            assert requested_batch_id == batch_id
+            OrderProposalsService._assert_published_batch_binding(
+                batch,
+                callback=callback,
+                chat_id=chat_id,
+                now=now,
+                allow_expired=allow_expired,
+            )
+            return batch
+
+        async def get_approval_batch_display(
+            self, requested_batch_id, *, for_update=False
+        ):
+            assert requested_batch_id == batch_id
+            return batch, proposals
+
+        async def expire_mutable_rungs_if_needed(self, proposal_id, *, now):
+            self.expired_ids.append(proposal_id)
+            return True
+
+        async def consume_approval_batch_nonce(self, *args, **kwargs):
+            self.batch_nonce_consumes += 1
+            raise AssertionError("mixed blocked batch must not consume its nonce")
+
+    fake_service = FakeBatchService()
+
+    class FakeSession:
+        def __init__(self):
+            self.commits = 0
+
+        async def commit(self):
+            self.commits += 1
+
+    session = FakeSession()
+
+    @contextlib.asynccontextmanager
+    async def service_factory():
+        yield session
+
+    monkeypatch.setattr(
+        callback_module, "OrderProposalsService", lambda ignored: fake_service
+    )
+
+    result = await callback_module._handle_batch_approve(
+        service_factory=service_factory,
+        batch_short=str(batch_id)[:8],
+        callback=_callback_for_batch(batch),
+        now=now,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        telegram_user_id="777",
+        revalidate_fn=lambda **kwargs: None,
+        window_evaluator=evaluator,
+        now_fn=lambda: now,
+    )
+
+    assert result["reason"] == "BATCH_WINDOW_BLOCKED"
+    assert [item["proposal_id"] for item in result["results"]] == [
+        str(item.group.proposal_id) for item in groups
+    ]
+    assert [item["reason"] for item in result["results"]] == [
+        "batch_atomic_window_block",
+        "approval_window:EXPIRED:now_at_or_after_valid_until",
+        "🌙 주문 가능 세션 아님 — 다음 허용 세션: 2026-07-23T20:50:00+09:00",
+    ]
+    assert fake_service.batch_nonce_consumes == 0
+    assert batch.approval_nonce_used_at is None
+    assert [item.group.approval_nonce_used_at for item in groups] == [None, None, None]
+    assert fake_service.expired_ids == [groups[1].group.proposal_id]
+
+
+@pytest.mark.asyncio
+async def test_batch_rechecks_frozen_members_before_global_nonce(monkeypatch):
+    started = datetime(2026, 7, 23, 4, 54, 59, 999999, tzinfo=policy._KST)
+    boundary = started + timedelta(microseconds=1)
+    groups = [
+        _FakeRevalidationService(valid_until=started + timedelta(days=1)),
+        _FakeRevalidationService(valid_until=boundary),
+    ]
+    for index, item in enumerate(groups):
+        item.group.exit_intent = None
+        item.group.approval_nonce = f"member-{index}"
+        item.group.approval_nonce_used_at = None
+        dispatched = await _allowed_window_evaluator(item.group, now=started)
+        item.group.source_asof = {
+            "approval_window_policy_stamp": dispatched.policy_stamp
+        }
+
+    batch_id = uuid.uuid4()
+    batch = SimpleNamespace(
+        batch_id=batch_id,
+        chat_id="42",
+        approval_nonce="batch-nonce",
+        approval_nonce_used_at=None,
+        expires_at=started + timedelta(minutes=5),
+        approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
+        approval_dispatch_attempt_id=uuid.uuid4(),
+        membership_revision=1,
+        membership_digest="AbCdEf0123_-",
+    )
+    proposals = [(item.group, [item.rung]) for item in groups]
+
+    class FakeBatchService:
+        def __init__(self):
+            self.batch_nonce_consumes = 0
+            self.expired_ids = []
+
+        async def acquire_approval_batch_chat_lock(self, chat_id):
+            assert chat_id == "42"
+
+        async def resolve_approval_batch_id_prefix(self, batch_short):
+            return batch_id
+
+        async def preflight_published_batch_callback(
+            self,
+            requested_batch_id,
+            *,
+            callback,
+            chat_id,
+            now,
+            allow_expired=False,
+        ):
+            assert requested_batch_id == batch_id
+            OrderProposalsService._assert_published_batch_binding(
+                batch,
+                callback=callback,
+                chat_id=chat_id,
+                now=now,
+                allow_expired=allow_expired,
+            )
+            return batch
+
+        async def get_approval_batch_display(
+            self, requested_batch_id, *, for_update=False
+        ):
+            return batch, proposals
+
+        async def expire_mutable_rungs_if_needed(self, proposal_id, *, now):
+            self.expired_ids.append(proposal_id)
+            return True
+
+        async def consume_approval_batch_nonce(self, *args, **kwargs):
+            self.batch_nonce_consumes += 1
+            raise AssertionError("second batch preflight must precede nonce")
+
+    fake_service = FakeBatchService()
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    @contextlib.asynccontextmanager
+    async def service_factory():
+        yield FakeSession()
+
+    monkeypatch.setattr(
+        callback_module, "OrderProposalsService", lambda ignored: fake_service
+    )
+    result = await callback_module._handle_batch_approve(
+        service_factory=service_factory,
+        batch_short=str(batch_id)[:8],
+        callback=_callback_for_batch(batch),
+        now=started,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        telegram_user_id="777",
+        revalidate_fn=lambda **kwargs: None,
+        window_evaluator=_allowed_window_evaluator,
+        now_fn=lambda: boundary,
+    )
+
+    assert result["reason"] == "BATCH_WINDOW_BLOCKED"
+    assert [row["proposal_id"] for row in result["results"]] == [
+        str(item.group.proposal_id) for item in groups
+    ]
+    assert fake_service.batch_nonce_consumes == 0
+    assert batch.approval_nonce_used_at is None
+    assert fake_service.expired_ids == [groups[1].group.proposal_id]
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_first_click_session_block_precedes_external_preview():
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST)
+    item = _FakeRevalidationService(valid_until=now + timedelta(days=1))
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            return SubmissionSessionEvidence(
+                known=True,
+                source="test:us-calendar",
+                current_session="closed",
+                allowed_sessions=("regular",),
+                allowed_now=False,
+                next_allowed_at=now + timedelta(hours=12),
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    # Bind the card to the same stable capability contract while it was open.
+    async def dispatch_resolver(group, *, now):
+        return SubmissionSessionEvidence(
+            known=True,
+            source="test:us-calendar",
+            current_session="regular",
+            allowed_sessions=("regular",),
+            allowed_now=True,
+        )
+
+    dispatched = await evaluate_approval_window(
+        item.group,
+        now=now - timedelta(hours=1),
+        session_resolver=dispatch_resolver,
+    )
+    item.group.source_asof = {"approval_window_policy_stamp": dispatched.policy_stamp}
+    preview_calls = 0
+
+    async def preview_must_not_run(**kwargs):
+        nonlocal preview_calls
+        preview_calls += 1
+        raise AssertionError("closed session must block before loss-cut preview")
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    result = await callback_module._handle_loss_cut_first_click(
+        session=FakeSession(),
+        service=item,
+        proposal_id=item.group.proposal_id,
+        callback=_callback_for_group(item.group),
+        now=now,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        telegram_user_id="777",
+        loss_cut_preview_fn=preview_must_not_run,
+        window_evaluator=evaluator,
+        now_fn=lambda: now,
+    )
+
+    assert result["reason"] == "DEFER_SESSION_CLOSED"
+    assert preview_calls == 0
+    assert item.expire_calls == 0
+
+
+_JULY_23_INCIDENT = (
+    ("f1e40819-e643-4abb-929c-5e049b675375", "VOO", "695.98"),
+    ("5e9e8ecc-10af-4db4-bd59-3551e473eb71", "QQQM", "295.24"),
+    ("4917e582-b57d-400e-9249-f3274e0adaf7", "ORCL", "117.21"),
+    ("f290064a-9d42-43e7-b06a-56a4047c9da2", "AVGO", "357.18"),
+    ("c8024f7e-d41a-42d3-9670-58b2606ba1f6", "QQQ", "717.15"),
+    ("bfbff3ad-e3a8-4b8c-9ff6-b216381433d9", "SPYM", "89.13"),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("proposal_id", "symbol", "price"), _JULY_23_INCIDENT)
+async def test_july_23_incident_fixture_is_typed_expired_without_calendar_lookup(
+    monkeypatch, proposal_id, symbol, price
+):
+    group = _group(
+        account_mode="toss_live",
+        symbol=symbol,
+        valid_until=datetime(2026, 7, 23, 4, 55, tzinfo=policy._KST),
+    )
+    group.proposal_id = proposal_id
+    group.limit_price = price
+
+    calls = 0
+    nonce_mints = 0
+    telegram_sends = 0
+    expiry_transitions = 0
+
+    async def must_not_resolve(group, *, now):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("expired incident fixture must not query calendar")
+
+    async def evaluator(group, *, now):
+        return await evaluate_approval_window(
+            group, now=now, session_resolver=must_not_resolve
+        )
+
+    class FakeDispatchService:
+        async def get_proposal(self, requested_id):
+            assert str(requested_id) == proposal_id
+            return group, []
+
+        async def set_approval_nonce(self, requested_id, nonce):
+            nonlocal nonce_mints
+            nonce_mints += 1
+
+        async def expire_mutable_rungs_if_needed(self, requested_id, *, now):
+            nonlocal expiry_transitions
+            expiry_transitions += 1
+            return True
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    @contextlib.asynccontextmanager
+    async def service_factory():
+        yield FakeSession()
+
+    class NoSendNotifier:
+        async def send_approval_message(self, *args, **kwargs):
+            nonlocal telegram_sends
+            telegram_sends += 1
+            raise AssertionError("expired incident fixture must not publish a card")
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "test-chat"
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "OrderProposalsService",
+        lambda ignored: FakeDispatchService(),
+    )
+
+    decision = await dispatch_module.send_proposal_for_approval(
+        uuid.UUID(proposal_id),
+        notifier=NoSendNotifier(),
+        now=datetime(2026, 7, 23, 8, 50, tzinfo=policy._KST),
+        service_factory=service_factory,
+        window_evaluator=evaluator,
+    )
+
+    assert decision.code is ApprovalWindowCode.EXPIRED
+    assert calls == 0
+    assert nonce_mints == 0
+    assert telegram_sends == 0
+    assert expiry_transitions == 1
+
+
+@pytest.mark.asyncio
+async def test_transport_hook_rechecks_after_all_preview_work_before_http():
+    started = datetime(2026, 7, 22, 19, 59, 59, 999999, tzinfo=UTC)
+    boundary = started + timedelta(microseconds=1)
+    service = _FakeRevalidationService(
+        valid_until=started + timedelta(days=2),
+    )
+    broker_http_calls = 0
+    preview_calls = 0
+
+    async def evaluator(group, *, now):
+        session_open = now < boundary
+
+        async def resolver(group, *, now):
+            return SubmissionSessionEvidence(
+                known=True,
+                source="test:transport-calendar",
+                current_session="regular" if session_open else "closed",
+                allowed_sessions=("regular",),
+                allowed_now=session_open,
+                allowed_until=boundary if session_open else None,
+                next_allowed_at=boundary + timedelta(hours=17),
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    async def place(**kwargs):
+        nonlocal broker_http_calls, preview_calls
+        if kwargs["dry_run"]:
+            preview_calls += 1
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "100",
+                "quantity": "1",
+            }
+        await kwargs["pre_send_hook"]()
+        broker_http_calls += 1
+        raise AssertionError("transport hook must abort before HTTP")
+
+    initial = await evaluator(service.group, now=started)
+    service.group.source_asof = {"approval_window_policy_stamp": initial.policy_stamp}
+    clock_values = iter((*([started] * 9), boundary))
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=started,
+        place_order_fn=place,
+        correlation_mint=lambda **kwargs: "corr-never-sent",
+        window_evaluator=evaluator,
+        expected_policy_stamp=initial.policy_stamp,
+        now_fn=lambda: next(clock_values),
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["defer_session_closed"]
+    assert preview_calls == 1
+    assert broker_http_calls == 0
+    assert service.rung.state == "pending_approval"
+    assert service.resting_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_callback_pre_send_block_leaves_nonce_unconsumed_durably():
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    service = _FakeRevalidationService(valid_until=now + timedelta(days=1))
+    service.allow_nonce_consume = True
+    dispatched = await _allowed_window_evaluator(service.group, now=now)
+    service.group.source_asof = {
+        "approval_window_policy_stamp": dispatched.policy_stamp
+    }
+    blocked = await evaluate_approval_window(
+        service.group,
+        now=now,
+        session_resolver=lambda group, *, now: _closed_session(now),
+    )
+
+    async def revalidate_block(**kwargs):
+        return [
+            RungOutcome(
+                0,
+                "defer_session_closed",
+                {
+                    "approval_window": blocked.to_dict(),
+                    "error": blocked.code.value,
+                },
+            )
+        ]
+
+    class FakeSession:
+        commits = 0
+
+        async def commit(self):
+            self.commits += 1
+
+    result = await callback_module._handle_approve(
+        session=FakeSession(),
+        service=service,
+        proposal_id=service.group.proposal_id,
+        callback=_callback_for_group(service.group),
+        now=now,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        callback_query_id=None,
+        telegram_user_id="777",
+        revalidate_fn=revalidate_block,
+        window_evaluator=_allowed_window_evaluator,
+        now_fn=lambda: now,
+    )
+
+    assert result["handled"] is False
+    assert result["results"] == ["defer_session_closed"]
+    assert service.nonce_consumes == 1
+    assert service.group.approval_nonce == "published-nonce"
+    assert service.group.approval_nonce_used_at is None
+    assert service.group.approved_at is None
+    assert service.group.commit_lease_until is None
+
+
+@pytest.mark.asyncio
+async def test_callback_mixed_zero_send_outcomes_restore_nonce_on_window_block():
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    service = _FakeRevalidationService(valid_until=now + timedelta(days=1))
+    service.allow_nonce_consume = True
+    dispatched = await _allowed_window_evaluator(service.group, now=now)
+    service.group.source_asof = {
+        "approval_window_policy_stamp": dispatched.policy_stamp
+    }
+    blocked = await evaluate_approval_window(
+        service.group,
+        now=now,
+        session_resolver=lambda group, *, now: _closed_session(now),
+    )
+
+    async def revalidate_block(**kwargs):
+        return [
+            RungOutcome(0, "guard_blocked", {"error": "preview_guard"}),
+            RungOutcome(
+                1,
+                "defer_session_closed",
+                {
+                    "approval_window": blocked.to_dict(),
+                    "error": blocked.code.value,
+                },
+            ),
+        ]
+
+    class FakeSession:
+        async def commit(self):
+            return None
+
+    result = await callback_module._handle_approve(
+        session=FakeSession(),
+        service=service,
+        proposal_id=service.group.proposal_id,
+        callback=_callback_for_group(service.group),
+        now=now,
+        notifier=SimpleNamespace(),
+        chat_id=42,
+        message_id=None,
+        callback_query_id=None,
+        telegram_user_id="777",
+        revalidate_fn=revalidate_block,
+        window_evaluator=_allowed_window_evaluator,
+        now_fn=lambda: now,
+    )
+
+    assert result["handled"] is False
+    assert result["results"] == ["guard_blocked", "defer_session_closed"]
+    assert service.group.approval_nonce == "published-nonce"
+    assert service.group.approval_nonce_used_at is None
+    assert service.group.approved_at is None
+    assert service.group.commit_lease_until is None
+
+
+async def _closed_session(now):
+    return SubmissionSessionEvidence(
+        known=True,
+        source="test:closed",
+        current_session="closed",
+        allowed_sessions=("regular",),
+        allowed_now=False,
+        next_allowed_at=now + timedelta(hours=12),
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_nonce_rejects_membership_added_after_preflight():
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    batch = SimpleNamespace(
+        id=7,
+        batch_id=uuid.uuid4(),
+        chat_id="42",
+        approval_nonce="batch-nonce",
+        approval_nonce_used_at=None,
+        expires_at=now + timedelta(minutes=5),
+    )
+    groups = [
+        SimpleNamespace(
+            id=index,
+            proposal_id=uuid.uuid4(),
+            valid_until=now + timedelta(days=1),
+            superseded_by_proposal_id=None,
+            lifecycle_state="proposed",
+            exit_intent=None,
+            source_asof={},
+            approval_nonce=f"member-{index}",
+            approval_nonce_used_at=None,
+        )
+        for index in (1, 2)
+    ]
+    members = [
+        SimpleNamespace(
+            id=index,
+            proposal_pk=group.id,
+            approval_nonce_snapshot=f"member-{index}",
+            approval_message_id=100 + index,
+        )
+        for index, group in enumerate(groups, start=1)
+    ]
+    callback = _bind_batch_snapshot(batch, groups, members)
+
+    class FakeRepo:
+        updates = 0
+
+        async def get_approval_batch_by_id(self, batch_id, *, for_update):
+            assert batch_id == batch.batch_id
+            assert for_update is True
+            return batch
+
+        async def list_approval_batch_members(self, batch_pk):
+            assert batch_pk == batch.id
+            return members
+
+        async def get_group_by_pk(self, proposal_pk, *, for_update=False):
+            assert for_update is True
+            return next(group for group in groups if group.id == proposal_pk)
+
+        async def list_rungs(self, proposal_pk):
+            return [
+                SimpleNamespace(
+                    state="pending_approval",
+                )
+            ]
+
+        async def update_approval_batch(self, *args, **kwargs):
+            self.updates += 1
+            raise AssertionError("changed membership must not consume batch nonce")
+
+    service = object.__new__(OrderProposalsService)
+    service._repo = FakeRepo()
+
+    with pytest.raises(OrderProposalError, match="approval_batch_membership_changed"):
+        await service.consume_approval_batch_nonce(
+            batch.batch_id,
+            callback=callback,
+            chat_id="42",
+            telegram_user_id="777",
+            now=now,
+            expected_members=((groups[0].proposal_id, "member-1"),),
+        )
+
+    assert service._repo.updates == 0
+    assert batch.approval_nonce_used_at is None
+
+
+@pytest.mark.asyncio
+async def test_batch_nonce_rejects_member_consumed_after_preflight():
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    batch = SimpleNamespace(
+        id=7,
+        batch_id=uuid.uuid4(),
+        chat_id="42",
+        approval_nonce="batch-nonce",
+        approval_nonce_used_at=None,
+        expires_at=now + timedelta(minutes=5),
+    )
+    groups = [
+        SimpleNamespace(
+            id=index,
+            proposal_id=uuid.uuid4(),
+            valid_until=now + timedelta(days=1),
+            superseded_by_proposal_id=None,
+            lifecycle_state="proposed",
+            exit_intent=None,
+            source_asof={},
+            approval_nonce=f"member-{index}",
+            approval_nonce_used_at=now if index == 2 else None,
+        )
+        for index in (1, 2)
+    ]
+    members = [
+        SimpleNamespace(
+            id=index,
+            proposal_pk=group.id,
+            approval_nonce_snapshot=f"member-{index}",
+            approval_message_id=100 + index,
+        )
+        for index, group in enumerate(groups, start=1)
+    ]
+    callback = _bind_batch_snapshot(batch, groups, members)
+
+    class FakeRepo:
+        updates = 0
+
+        async def get_approval_batch_by_id(self, batch_id, *, for_update):
+            assert for_update is True
+            return batch
+
+        async def list_approval_batch_members(self, batch_pk):
+            return members
+
+        async def get_group_by_pk(self, proposal_pk, *, for_update=False):
+            assert for_update is True
+            return next(group for group in groups if group.id == proposal_pk)
+
+        async def list_rungs(self, proposal_pk):
+            return [SimpleNamespace(state="pending_approval")]
+
+        async def update_approval_batch(self, *args, **kwargs):
+            self.updates += 1
+            raise AssertionError("stale member must not consume batch nonce")
+
+    service = object.__new__(OrderProposalsService)
+    service._repo = FakeRepo()
+
+    with pytest.raises(OrderProposalError, match="approval_batch_member_stale"):
+        await service.consume_approval_batch_nonce(
+            batch.batch_id,
+            callback=callback,
+            chat_id="42",
+            telegram_user_id="777",
+            now=now,
+            expected_members=tuple(
+                (group.proposal_id, str(group.approval_nonce)) for group in groups
+            ),
+        )
+
+    assert service._repo.updates == 0
+    assert batch.approval_nonce_used_at is None
+
+
+@pytest.mark.asyncio
+async def test_expired_later_rung_preserves_prior_broker_backed_rung():
+    now = datetime(2026, 7, 23, 4, 55, tzinfo=policy._KST)
+    group = _group(valid_until=now)
+    group.proposal_id = uuid.uuid4()
+    group.lifecycle_state = "partially_submitted"
+    group.superseded_by_proposal_id = None
+    group.source_asof = {}
+    rungs = [
+        SimpleNamespace(rung_index=0, state="resting"),
+        SimpleNamespace(rung_index=1, state="pending_approval"),
+    ]
+
+    class MixedRungService:
+        expired_indexes: list[int] = []
+
+        async def get_proposal(self, proposal_id):
+            return group, rungs
+
+        async def expire_rung_if_needed(self, proposal_id, rung_index, *, now):
+            assert rung_index == 1
+            self.expired_indexes.append(rung_index)
+            rungs[1].state = "expired"
+            return True
+
+    service = MixedRungService()
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=now,
+        window_evaluator=_allowed_window_evaluator,
+        now_fn=lambda: now,
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["expired"]
+    assert rungs[0].state == "resting"
+    assert rungs[1].state == "expired"
+    assert service.expired_indexes == [1]
+
+
+@pytest.mark.asyncio
+async def test_upbit_place_adapter_threads_transport_hook(monkeypatch):
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+    from app.services.brokers.upbit import orders as upbit_orders
+
+    wrapper_calls = 0
+    provider_calls = 0
+
+    async def request_with_boundary_hook(*args, pre_send_hook=None, **kwargs):
+        nonlocal wrapper_calls, provider_calls
+        wrapper_calls += 1
+        assert pre_send_hook is not None
+        await pre_send_hook()
+        provider_calls += 1
+        raise AssertionError("blocked hook must precede Upbit POST")
+
+    async def block():
+        raise PreSendFreshnessError(("approval_window:EXPIRED",))
+
+    monkeypatch.setattr(
+        upbit_orders._client,
+        "_request_with_auth",
+        request_with_boundary_hook,
+    )
+
+    with pytest.raises(PreSendFreshnessError):
+        await upbit_orders.place_sell_order(
+            "KRW-BTC",
+            "0.1",
+            "100000000",
+            identifier="proposal-id",
+            pre_send_hook=block,
+        )
+
+    assert wrapper_calls == 1
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_upbit_cancel_adapter_threads_transport_hook(monkeypatch):
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+    from app.services.brokers.upbit import orders as upbit_orders
+
+    wrapper_calls = 0
+    provider_calls = 0
+
+    async def request_with_boundary_hook(*args, pre_send_hook=None, **kwargs):
+        nonlocal wrapper_calls, provider_calls
+        wrapper_calls += 1
+        assert pre_send_hook is not None
+        await pre_send_hook()
+        provider_calls += 1
+        raise AssertionError("blocked hook must precede Upbit DELETE")
+
+    async def block():
+        raise PreSendFreshnessError(("approval_window:DEFER_SESSION_CLOSED",))
+
+    monkeypatch.setattr(
+        upbit_orders._client,
+        "_request_with_auth",
+        request_with_boundary_hook,
+    )
+
+    with pytest.raises(PreSendFreshnessError):
+        await upbit_orders.cancel_orders(
+            ["broker-order-id"],
+            pre_send_hook=block,
+        )
+
+    assert wrapper_calls == 1
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market", ["equity_kr", "equity_us"])
+async def test_kis_cancel_adapter_threads_transport_hook(monkeypatch, market):
+    from unittest.mock import AsyncMock
+
+    from app.services.brokers.kis import domestic_orders, overseas_orders
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+
+    provider_calls = 0
+
+    async def request(*args, pre_send_hook=None, **kwargs):
+        nonlocal provider_calls
+        assert pre_send_hook is not None
+        await pre_send_hook()
+        provider_calls += 1
+        raise AssertionError("blocked hook must precede KIS cancel POST")
+
+    request_mock = AsyncMock(side_effect=request)
+    parent = SimpleNamespace(
+        _settings=SimpleNamespace(
+            kis_account_no="12345678-01",
+            kis_access_token="dummy-token",
+        ),
+        _hdr_base={},
+        _ensure_token=AsyncMock(),
+        _request_with_rate_limit=request_mock,
+        _kis_url=lambda path: f"https://kis.invalid{path}",
+    )
+
+    async def block():
+        raise PreSendFreshnessError(("approval_window:DEFER_SESSION_CLOSED",))
+
+    if market == "equity_kr":
+        monkeypatch.setattr(
+            domestic_orders,
+            "is_nxt_eligible",
+            AsyncMock(return_value=False),
+        )
+        client = domestic_orders.DomesticOrderClient(parent)
+        call = client.cancel_korea_order(
+            "broker-order-id",
+            "005930",
+            1,
+            70000,
+            "sell",
+            krx_fwdg_ord_orgno="06010",
+            pre_send_hook=block,
+        )
+    else:
+        client = overseas_orders.OverseasOrderClient(parent)
+        call = client.cancel_overseas_order(
+            "broker-order-id",
+            "VOO",
+            "NYSE",
+            1,
+            pre_send_hook=block,
+        )
+
+    with pytest.raises(PreSendFreshnessError):
+        await call
+
+    request_mock.assert_awaited_once()
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_toss_place_adapter_binds_hook_at_transport_context(monkeypatch):
+    from app.mcp_server.tooling import orders_toss_variants as toss
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+    from app.services.order_proposals.revalidation import _default_place_order_fn
+
+    transport_calls = 0
+
+    async def fake_toss_place(**kwargs):
+        nonlocal transport_calls
+        hook = toss._toss_pre_send_hook.get()
+        assert hook is not None
+        await hook()
+        transport_calls += 1
+        raise AssertionError("blocked hook must precede Toss POST")
+
+    async def block():
+        raise PreSendFreshnessError(("approval_window:DEFER_SESSION_CLOSED",))
+
+    monkeypatch.setattr(toss, "toss_place_order", fake_toss_place)
+
+    with pytest.raises(PreSendFreshnessError):
+        await _default_place_order_fn(
+            account_mode="toss_live",
+            proposal_client_order_id="tosprop-123456789012345678901234",
+            dry_run=False,
+            symbol="VOO",
+            side="buy",
+            market="equity_us",
+            order_type="limit",
+            quantity=Decimal("1"),
+            price=Decimal("100"),
+            approval_hash="hash",
+            pre_send_hook=block,
+        )
+
+    assert transport_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "account_mode,market", [("kis_live", "equity_us"), ("upbit", "crypto")]
+)
+async def test_default_execution_adapter_threads_transport_hook(
+    monkeypatch,
+    account_mode,
+    market,
+):
+    from app.mcp_server.tooling import order_execution
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+    from app.services.order_proposals.revalidation import _default_place_order_fn
+
+    transport_calls = 0
+
+    async def fake_place_impl(**kwargs):
+        nonlocal transport_calls
+        await kwargs["pre_send_hook"]()
+        transport_calls += 1
+        raise AssertionError("blocked hook must precede provider HTTP")
+
+    async def block():
+        raise PreSendFreshnessError(("approval_window:CALENDAR_UNKNOWN",))
+
+    monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_impl)
+
+    with pytest.raises(PreSendFreshnessError):
+        await _default_place_order_fn(
+            account_mode=account_mode,
+            proposal_client_order_id="proposal-client-id",
+            dry_run=False,
+            symbol="VOO" if market == "equity_us" else "KRW-BTC",
+            side="buy",
+            market=market,
+            order_type="limit",
+            quantity=Decimal("1"),
+            price=Decimal("100"),
+            approval_hash="hash",
+            pre_send_hook=block,
+        )
+
+    assert transport_calls == 0

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -11,9 +11,17 @@ import pytest
 from app.core.db import AsyncSessionLocal
 from app.models.order_proposals import OrderProposal, OrderProposalRung
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals import dispatch as dispatch_module
+from app.services.order_proposals import revalidation as revalidation_module
 from app.services.order_proposals.approval_message import (
     build_approval_dispatch_messages,
     parse_callback_data,
+)
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowCode,
+    ApprovalWindowDecision,
+    SubmissionSessionEvidence,
+    evaluate_approval_window,
 )
 from app.services.order_proposals.dispatch import (
     dispatch_proposal,
@@ -28,8 +36,19 @@ from app.services.order_proposals.dispatch_contract import (
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
 from app.telegram_contract import TelegramMethodResult, telegram_text_length
+from tests.services.order_proposals.window_fakes import allow_known_session
 
 CHAT_ID = "chat-99"
+
+
+@pytest.fixture(autouse=True)
+def _known_market_session(monkeypatch):
+    monkeypatch.setattr(
+        dispatch_module, "evaluate_approval_window", allow_known_session
+    )
+    monkeypatch.setattr(
+        revalidation_module, "evaluate_approval_window", allow_known_session
+    )
 
 
 class _FakeNotifier:
@@ -238,8 +257,11 @@ async def test_send_proposal_for_approval_mints_nonce_and_sends(
 ):
     from app.core.config import settings
 
+    isolated_chat_id = f"chat-{uuid.uuid4().hex}"
     monkeypatch.setattr(
-        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR",
+        isolated_chat_id,
     )
     group = await _seed_proposal(db_session)
     notifier = _FakeNotifier(message_id=5001)
@@ -256,7 +278,7 @@ async def test_send_proposal_for_approval_mints_nonce_and_sends(
     assert dispatch.message_id == 5001
     assert len(notifier.sent_messages) == 1
     text, keyboard, chat_id = notifier.sent_messages[0]
-    assert chat_id == CHAT_ID
+    assert chat_id == isolated_chat_id
     assert "승인" in text
     assert keyboard["inline_keyboard"]
 
@@ -264,8 +286,96 @@ async def test_send_proposal_for_approval_mints_nonce_and_sends(
     refreshed, _ = await service.get_proposal(group.proposal_id)
     assert refreshed.approval_nonce is not None
     assert refreshed.source_asof["approval_message_id"] == 5001
-    assert refreshed.source_asof["approval_chat_id"] == CHAT_ID
+    assert refreshed.source_asof["approval_chat_id"] == isolated_chat_id
     assert refreshed.source_asof["approval_sent_at"] == now.isoformat()
+    assert refreshed.source_asof["approval_window_policy_stamp"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_expired_returns_typed_result_without_nonce_or_telegram(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(db_session)
+    deadline = datetime(2026, 7, 23, 4, 55, tzinfo=UTC)
+    group.valid_until = deadline
+    await db_session.commit()
+    notifier = _FakeNotifier()
+
+    result = await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=notifier,
+        now=deadline,
+        service_factory=_session_factory(db_session),
+    )
+
+    assert isinstance(result, ApprovalWindowDecision)
+    assert result.code is ApprovalWindowCode.EXPIRED
+    assert notifier.sent_messages == []
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approval_nonce is None
+    assert refreshed.lifecycle_state == "expired"
+    assert [rung.state for rung in rungs] == ["expired"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("known", "expected"),
+    [
+        (True, ApprovalWindowCode.DEFER_SESSION_CLOSED),
+        (False, ApprovalWindowCode.CALENDAR_UNKNOWN),
+    ],
+)
+async def test_dispatch_closed_or_unknown_session_has_zero_visible_side_effects(
+    monkeypatch, db_session, known, expected
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(db_session)
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=UTC)
+    group.valid_until = now + timedelta(days=2)
+    await db_session.commit()
+    notifier = _FakeNotifier()
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            return SubmissionSessionEvidence(
+                known=known,
+                source="test",
+                current_session="closed" if known else "unknown",
+                allowed_sessions=("regular",),
+                allowed_now=False,
+                next_allowed_at=now + timedelta(hours=12) if known else None,
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    result = await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+        window_evaluator=evaluator,
+    )
+
+    assert isinstance(result, ApprovalWindowDecision)
+    assert result.code is expected
+    assert notifier.sent_messages == []
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approval_nonce is None
+    assert refreshed.approval_nonce_used_at is None
+    assert [rung.state for rung in rungs] == ["pending_approval"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_dispatch_security_invariants.py
+++ b/tests/services/order_proposals/test_dispatch_security_invariants.py
@@ -51,6 +51,7 @@ from app.telegram_contract import (
     TelegramMethodResult,
     telegram_text_length,
 )
+from tests.services.order_proposals.window_fakes import allow_known_session
 
 NOW = datetime(2026, 7, 23, 9, 0, tzinfo=UTC)
 PROPOSAL_ID = uuid.UUID("11111111-1111-4111-8111-111111111111")
@@ -611,6 +612,7 @@ async def test_invalid_loss_cut_binding_has_zero_pre_gate_external_calls(
         proposer="probe",
         lifecycle_state="proposed",
         exit_intent="loss_cut",
+        valid_until=NOW + timedelta(minutes=5),
         approval_nonce=nonce,
         approval_dispatch_state=state.value,
         approval_dispatch_attempt_id=attempt_id,
@@ -618,6 +620,10 @@ async def test_invalid_loss_cut_binding_has_zero_pre_gate_external_calls(
         approval_dispatch_membership_revision=1,
         approval_dispatch_membership_digest=digest,
     )
+    dispatched = await allow_known_session(group, now=NOW)
+    group.source_asof = {
+        "approval_window_policy_stamp": dispatched.policy_stamp,
+    }
 
     class Repo:
         updates = 0
@@ -658,6 +664,8 @@ async def test_invalid_loss_cut_binding_has_zero_pre_gate_external_calls(
         callback_query_id="callback-query",
         telegram_user_id="operator",
         loss_cut_preview_fn=preview_mock,
+        window_evaluator=allow_known_session,
+        now_fn=lambda: NOW,
     )
 
     assert result["handled"] is False
@@ -702,6 +710,7 @@ async def test_loss_cut_preview_to_consume_toctou_fails_closed(
         proposer="probe",
         lifecycle_state="proposed",
         exit_intent="loss_cut",
+        valid_until=NOW + timedelta(minutes=5),
         approval_nonce=nonce,
         approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
         approval_dispatch_attempt_id=ATTEMPT_ID,
@@ -709,6 +718,10 @@ async def test_loss_cut_preview_to_consume_toctou_fails_closed(
         approval_dispatch_membership_revision=1,
         approval_dispatch_membership_digest=digest,
     )
+    dispatched = await allow_known_session(group, now=NOW)
+    group.source_asof = {
+        "approval_window_policy_stamp": dispatched.policy_stamp,
+    }
 
     class Repo:
         updates = 0
@@ -744,6 +757,8 @@ async def test_loss_cut_preview_to_consume_toctou_fails_closed(
         message_id=7,
         telegram_user_id="operator",
         loss_cut_preview_fn=preview_mock,
+        window_evaluator=allow_known_session,
+        now_fn=lambda: NOW,
     )
 
     assert result["handled"] is False
@@ -778,7 +793,22 @@ def _batch_fixture(*, state: ApprovalDispatchState, extra_member_revision: int =
     for index in range(1, 38):
         revision = 1 if index <= 36 else extra_member_revision
         proposal_id = uuid.UUID(int=index)
-        groups[index] = SimpleNamespace(proposal_id=proposal_id)
+        groups[index] = SimpleNamespace(
+            id=index,
+            proposal_id=proposal_id,
+            superseded_by_proposal_id=None,
+            lifecycle_state="proposed",
+            exit_intent=None,
+            source_asof={},
+            valid_until=NOW + timedelta(minutes=5),
+            approval_nonce=f"member-{index}",
+            approval_nonce_used_at=None,
+            approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
+            approval_dispatch_attempt_id=uuid.UUID(int=100 + index),
+            approval_dispatch_membership_revision=1,
+            approval_dispatch_membership_digest=DIGEST,
+            approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        )
         members.append(
             SimpleNamespace(
                 id=index,
@@ -823,8 +853,11 @@ def _batch_fixture(*, state: ApprovalDispatchState, extra_member_revision: int =
                 setattr(target, key, value)
             return target
 
-        async def get_group_by_pk(self, proposal_pk):
+        async def get_group_by_pk(self, proposal_pk, *, for_update=False):
             return groups[proposal_pk]
+
+        async def list_rungs(self, proposal_pk):
+            return [SimpleNamespace(state="pending_approval")]
 
     return batch_id, batch, groups, _service_with_repo(Repo())
 
@@ -1410,6 +1443,11 @@ async def test_send_orchestration_registers_batch_only_for_current_result(
 ) -> None:
     group = SimpleNamespace(
         proposal_id=PROPOSAL_ID,
+        market="equity_kr",
+        account_mode="kis_live",
+        action="place",
+        order_type="limit",
+        valid_until=NOW + timedelta(minutes=5),
         approval_dispatch_membership_revision=None,
     )
     first_service = SimpleNamespace(
@@ -1474,6 +1512,8 @@ async def test_send_orchestration_registers_batch_only_for_current_result(
         notifier=SimpleNamespace(),
         now=NOW,
         service_factory=service_factory,
+        window_evaluator=allow_known_session,
+        now_fn=lambda: NOW,
     )
 
     assert returned is result
@@ -1499,6 +1539,10 @@ async def test_auto_dispatch_compensates_only_current_failed_result(
     group = SimpleNamespace(
         proposal_id=PROPOSAL_ID,
         market="equity_kr",
+        account_mode="kis_live",
+        action="place",
+        order_type="limit",
+        valid_until=NOW + timedelta(minutes=5),
         approval_dispatch_membership_revision=None,
     )
     rung = SimpleNamespace(state="pending_approval")
@@ -1584,6 +1628,8 @@ async def test_auto_dispatch_compensates_only_current_failed_result(
         now=NOW,
         service_factory=service_factory,
         revalidate_fn=revalidate,
+        window_evaluator=allow_known_session,
+        now_fn=lambda: NOW,
     )
 
     assert returned is result

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -9,14 +9,37 @@ import httpx
 import pytest
 
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals import revalidation as revalidation_module
 from app.services.order_proposals.broker_gateway import SubmitEvidence
 from app.services.order_proposals.revalidation import (
     _adapt_live_submit_response,
     preview_loss_cut_confirmation,
-    revalidate_and_submit,
+)
+from app.services.order_proposals.revalidation import (
+    revalidate_and_submit as _production_revalidate_and_submit,
 )
 from app.services.order_proposals.service import RungInput
 from app.services.order_proposals.target_order import TargetOrderSnapshot
+from tests.services.order_proposals.window_fakes import allow_known_session
+
+
+@pytest.fixture(autouse=True)
+def _known_market_session(monkeypatch):
+    monkeypatch.setattr(
+        revalidation_module, "evaluate_approval_window", allow_known_session
+    )
+
+
+async def revalidate_and_submit(**kwargs):
+    """Bind legacy unit calls to the same policy a card/auto path persisted."""
+    if kwargs.get("expected_policy_stamp") is None:
+        group, _rungs = await kwargs["service"].get_proposal(kwargs["proposal_id"])
+        observed_at = kwargs["now"]
+        decision = await allow_known_session(group, now=observed_at)
+        kwargs["expected_policy_stamp"] = decision.policy_stamp
+        kwargs.setdefault("window_evaluator", allow_known_session)
+        kwargs.setdefault("now_fn", lambda: observed_at)
+    return await _production_revalidate_and_submit(**kwargs)
 
 
 def _bound_toss_context():

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -2654,6 +2654,7 @@ async def test_approval_batch_nonce_rejects_wrong_chat_nonce_and_too_small(
                 chat_id=supplied_chat,
                 telegram_user_id="777",
                 now=now + timedelta(minutes=1),
+                expected_members=(),
             )
         await db_session.rollback()
 
@@ -2724,6 +2725,10 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
         chat_id=chat_id,
         telegram_user_id="777",
         now=now + timedelta(minutes=2),
+        expected_members=(
+            (first.proposal_id, "consume-member-1"),
+            (second.proposal_id, "consume-member-2"),
+        ),
     )
     await db_session.commit()
     assert batch.approval_nonce_used_at == now + timedelta(minutes=2)
@@ -2739,6 +2744,10 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
             chat_id=chat_id,
             telegram_user_id="777",
             now=now + timedelta(minutes=3),
+            expected_members=(
+                (first.proposal_id, "consume-member-1"),
+                (second.proposal_id, "consume-member-2"),
+            ),
         )
     await db_session.rollback()
 
@@ -2784,6 +2793,10 @@ async def test_approval_batch_nonce_expires_without_consuming_members(db_session
             chat_id=chat_id,
             telegram_user_id="777",
             now=registration.batch.expires_at,
+            expected_members=(
+                (first.proposal_id, "expiry-member-1"),
+                (second.proposal_id, "expiry-member-2"),
+            ),
         )
     await db_session.rollback()
     first_after, _ = await service.get_proposal(first_id)

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -15,7 +15,14 @@ from app.core.db import AsyncSessionLocal
 from app.mcp_server.caller_identity import caller_agent_id_var, get_caller_agent_id
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals import approval_message as approval_messages
+from app.services.order_proposals import revalidation as revalidation_module
+from app.services.order_proposals import telegram_callback as callback_module
 from app.services.order_proposals.approval_message import parse_callback_data
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowCode,
+    SubmissionSessionEvidence,
+    evaluate_approval_window,
+)
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
     ApprovalPublication,
@@ -31,9 +38,20 @@ from app.services.order_proposals.telegram_callback import (
     handle_callback_update,
 )
 from app.telegram_contract import TelegramMethodResult, telegram_text_length
+from tests.services.order_proposals.window_fakes import allow_known_session
 
 CHAT_ID = 42
 USER_ID = 777
+
+
+@pytest.fixture(autouse=True)
+def _known_market_session(monkeypatch):
+    monkeypatch.setattr(
+        callback_module, "evaluate_approval_window", allow_known_session
+    )
+    monkeypatch.setattr(
+        revalidation_module, "evaluate_approval_window", allow_known_session
+    )
 
 
 class _FakeNotifier:
@@ -140,7 +158,11 @@ async def _publish_fixture_card(
     if group.approval_nonce != nonce:
         await service.set_approval_nonce(group.proposal_id, nonce)
     attempt_id = uuid.uuid4()
-    now = datetime.now(UTC)
+    now = min(
+        datetime.now(UTC),
+        group.valid_until - timedelta(microseconds=1),
+    )
+    window = await allow_known_session(group, now=now)
     binding = build_proposal_dispatch_binding(
         proposal_id=group.proposal_id,
         nonce=nonce,
@@ -162,6 +184,7 @@ async def _publish_fixture_card(
         publication=_successful_publication(message_id),
         chat_id=str(CHAT_ID),
         now=now,
+        approval_window_policy_stamp=window.policy_stamp,
     )
     assert result.ok
     return binding
@@ -194,6 +217,15 @@ async def _seed_proposal(db_session, *, nonce="nonce-abc123", symbol="A", rungs=
         order_type="limit",
         proposer="p",
         rungs=rung_inputs,
+    )
+    dispatched_at = datetime.now(UTC)
+    window = await allow_known_session(group, now=dispatched_at)
+    await service.record_approval_dispatch(
+        group.proposal_id,
+        message_id=555,
+        chat_id=str(CHAT_ID),
+        now=dispatched_at,
+        approval_window_policy_stamp=window.policy_stamp,
     )
     await service.set_approval_nonce(group.proposal_id, nonce)
     await _publish_fixture_card(
@@ -286,6 +318,15 @@ async def _seed_loss_cut_proposal(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
+    )
+    dispatched_at = datetime.now(UTC)
+    window = await allow_known_session(group, now=dispatched_at)
+    await service.record_approval_dispatch(
+        group.proposal_id,
+        message_id=555,
+        chat_id=str(CHAT_ID),
+        now=dispatched_at,
+        approval_window_policy_stamp=window.policy_stamp,
     )
     await service.set_approval_nonce(group.proposal_id, nonce)
     await _publish_fixture_card(
@@ -514,10 +555,10 @@ async def test_batch_approve_continues_after_member_result_audit_failure(
 
 
 @pytest.mark.asyncio
-async def test_batch_click_rechecks_loss_terminal_auto_superseded_and_used_nonce(
+async def test_batch_click_atomically_rejects_changed_frozen_membership(
     monkeypatch, db_session
 ):
-    chat_id, now, groups, _batch, data = await _seed_approval_batch(
+    chat_id, now, groups, batch, data = await _seed_approval_batch(
         db_session, monkeypatch, member_count=6
     )
     groups[0].exit_intent = "loss_cut"
@@ -544,14 +585,33 @@ async def test_batch_click_rechecks_loss_terminal_auto_superseded_and_used_nonce
         revalidate_fn=fake_revalidate,
     )
 
-    assert calls == [groups[5].proposal_id]
+    assert calls == []
+    assert result["handled"] is False
+    assert result["reason"] == "BATCH_WINDOW_BLOCKED"
     assert [item["status"] for item in result["results"]] == [
         "skipped",
         "skipped",
         "skipped",
         "skipped",
         "skipped",
-        "approved",
+        "skipped",
+    ]
+    assert [item["reason"] for item in result["results"]] == [
+        "loss_cut_excluded",
+        "proposal_terminal:terminal",
+        "auto_approved_excluded",
+        "proposal_superseded_by:unknown",
+        "approval_nonce_used",
+        "batch_atomic_window_block",
+    ]
+    assert batch.approval_nonce_used_at is None
+    assert [group.approval_nonce_used_at for group in groups] == [
+        None,
+        None,
+        None,
+        None,
+        now,
+        None,
     ]
 
 
@@ -818,10 +878,77 @@ async def test_expired_approve_never_revalidates(monkeypatch, db_session):
         notifier=notifier,
         revalidate_fn=must_not_revalidate,
     )
-    assert result["reason"] == "proposal_expired"
+    assert result["reason"] == "EXPIRED"
     assert called is False
-    assert notifier.answered[-1] == ("cbq-1", "제안이 만료되었습니다")
+    assert notifier.answered[-1] == ("cbq-1", "⌛ 제안 만료")
     assert "만료" in notifier.edited[-1][2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("known", "expected"),
+    [
+        (True, ApprovalWindowCode.DEFER_SESSION_CLOSED),
+        (False, ApprovalWindowCode.CALENDAR_UNKNOWN),
+    ],
+)
+async def test_callback_closed_or_unknown_session_consumes_no_nonce_or_broker_path(
+    monkeypatch, db_session, known, expected
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="window-blocked")
+    now = datetime(2026, 7, 23, 8, 50, tzinfo=UTC)
+    group.valid_until = now + timedelta(days=2)
+    await db_session.commit()
+    revalidate_calls = 0
+
+    async def must_not_revalidate(**kwargs):
+        nonlocal revalidate_calls
+        revalidate_calls += 1
+        raise AssertionError("window-blocked callback must not preview or submit")
+
+    async def evaluator(group, *, now):
+        async def resolver(group, *, now):
+            return SubmissionSessionEvidence(
+                known=known,
+                source="test",
+                current_session="closed" if known else "unknown",
+                allowed_sessions=("regular",),
+                allowed_now=False,
+                next_allowed_at=now + timedelta(hours=12) if known else None,
+            )
+
+        return await evaluate_approval_window(group, now=now, session_resolver=resolver)
+
+    notifier = _FakeNotifier()
+    result = await handle_callback_update(
+        _make_update(
+            data=_proposal_callback_data(
+                group,
+                action="op",
+                nonce="window-blocked",
+            )
+        ),
+        now=now,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=must_not_revalidate,
+        window_evaluator=evaluator,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == expected.value
+    assert revalidate_calls == 0
+    assert notifier.sent_messages == []
+    assert notifier.edited[-1][3] == {"inline_keyboard": []}
+    if known:
+        assert "다음 허용 세션" in notifier.edited[-1][2]
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approval_nonce_used_at is None
+    assert refreshed.approved_at is None
+    assert [rung.state for rung in rungs] == ["pending_approval"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/window_fakes.py
+++ b/tests/services/order_proposals/window_fakes.py
@@ -1,0 +1,23 @@
+from datetime import timedelta
+
+from app.services.order_proposals.approval_window import (
+    SubmissionSessionEvidence,
+    evaluate_approval_window,
+)
+
+
+async def allow_known_session(group, *, now):
+    """Keep legacy unit suites focused while retaining validity enforcement."""
+
+    async def resolver(group, *, now):
+        return SubmissionSessionEvidence(
+            known=True,
+            source="test:known-session",
+            current_session="regular",
+            allowed_sessions=("regular",),
+            allowed_now=True,
+            allowed_until=now + timedelta(hours=8),
+            next_allowed_at=now + timedelta(days=1),
+        )
+
+    return await evaluate_approval_window(group, now=now, session_resolver=resolver)

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -10,9 +10,22 @@ from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.tooling import order_proposal_tools as opt
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals import dispatch as dispatch_module
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowCode,
+    ApprovalWindowDecision,
+)
 from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.target_order import TargetOrderSnapshot
 from app.telegram_contract import TelegramMethodResult, telegram_text_length
+from tests.services.order_proposals.window_fakes import allow_known_session
+
+
+@pytest.fixture(autouse=True)
+def _known_market_session(monkeypatch):
+    monkeypatch.setattr(
+        dispatch_module, "evaluate_approval_window", allow_known_session
+    )
 
 
 def _unique_chat() -> str:
@@ -124,6 +137,42 @@ def _target_create_kwargs(**overrides):
         ],
         **overrides,
     )
+
+
+@pytest.mark.asyncio
+async def test_create_surfaces_typed_approval_dispatch_block(monkeypatch):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", _unique_chat()
+    )
+    observed_at = datetime.now(UTC)
+    deadline = observed_at - timedelta(microseconds=1)
+
+    async def blocked_dispatch(*args, **kwargs):
+        return ApprovalWindowDecision(
+            code=ApprovalWindowCode.EXPIRED,
+            observed_at=observed_at,
+            valid_until=deadline,
+            policy_stamp="order-proposal-approval-window-v1:test",
+            market="equity_kr",
+            account_mode="kis_live",
+            action="place",
+            order_type="limit",
+            detail="now_at_or_after_valid_until",
+        )
+
+    monkeypatch.setattr(opt, "dispatch_proposal", blocked_dispatch)
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.notifier.get_trade_notifier",
+        lambda: _FakeNotifier(),
+    )
+
+    result = await opt.order_proposal_create(**_create_kwargs())
+
+    assert result["success"] is True
+    assert result["approval_dispatch"]["status"] == "blocked"
+    assert result["approval_dispatch"]["code"] == "EXPIRED"
+    assert result["approval_dispatch"]["detail"] == "now_at_or_after_valid_until"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -1200,7 +1200,12 @@ class TestPlaceOrderHighAmount:
         assert result["dry_run"] is False
         assert result["preview"]["quantity"] == pytest.approx(0.1, rel=1e-6)
         mock.place_buy_order.assert_awaited_once_with(
-            "KRW-BTC", 50000000.0, "0.10000000", "limit", identifier=ANY
+            "KRW-BTC",
+            50000000.0,
+            "0.10000000",
+            "limit",
+            identifier=ANY,
+            pre_send_hook=None,
         )
 
     @pytest.mark.asyncio
@@ -1282,7 +1287,12 @@ class TestPlaceOrderHighAmount:
         assert "Daily order limit" not in str(result.get("error", ""))
         assert "Daily order limit" not in str(result.get("message", ""))
         mock.place_buy_order.assert_awaited_once_with(
-            "KRW-BTC", 50000000.0, "0.10000000", "limit", identifier=ANY
+            "KRW-BTC",
+            50000000.0,
+            "0.10000000",
+            "limit",
+            identifier=ANY,
+            pre_send_hook=None,
         )
 
 
@@ -1899,7 +1909,16 @@ async def test_place_order_crypto_sell_records_stop_loss_cooldown(monkeypatch):
         def adjust_price_to_upbit_unit(self, price):
             return price
 
-        async def place_sell_order(self, symbol, volume, price, identifier=None):
+        async def place_sell_order(
+            self,
+            symbol,
+            volume,
+            price,
+            identifier=None,
+            pre_send_hook=None,
+        ):
+            if pre_send_hook is not None:
+                await pre_send_hook()
             return {
                 "uuid": _unique_order_id("cd-sell-loss"),
                 "side": "ask",
@@ -2003,7 +2022,16 @@ async def test_place_order_crypto_profitable_sell_does_not_record_cooldown(monke
         def adjust_price_to_upbit_unit(self, price):
             return price
 
-        async def place_sell_order(self, symbol, volume, price, identifier=None):
+        async def place_sell_order(
+            self,
+            symbol,
+            volume,
+            price,
+            identifier=None,
+            pre_send_hook=None,
+        ):
+            if pre_send_hook is not None:
+                await pre_send_hook()
             return {
                 "uuid": _unique_order_id("cd-sell-profit"),
                 "side": "ask",

--- a/tests/test_upbit_retry.py
+++ b/tests/test_upbit_retry.py
@@ -196,3 +196,117 @@ async def test_get_request_keeps_request_error_retry(monkeypatch):
     await client._request_with_auth("GET", f"{client.UPBIT_REST}/accounts")
 
     assert captured.get("retry_request_errors", True) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/orders"),
+        ("DELETE", "/order"),
+    ],
+)
+async def test_order_mutation_hook_runs_after_limiter_before_http(
+    monkeypatch, method, path
+):
+    """A window crossed during limiter wait blocks with mutation HTTP=0."""
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+    from app.services.brokers.upbit import client
+
+    admitted = False
+    http_clients = 0
+
+    async def acquire(**kwargs):
+        nonlocal admitted
+        admitted = True
+
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock(side_effect=acquire)
+
+    class ForbiddenClient:
+        def __init__(self, *args, **kwargs):
+            nonlocal http_clients
+            http_clients += 1
+            raise AssertionError("blocked hook must precede HTTP client creation")
+
+    async def block():
+        assert admitted is True
+        raise PreSendFreshnessError(("approval_window:EXPIRED",))
+
+    monkeypatch.setattr(client, "get_limiter", AsyncMock(return_value=limiter))
+    monkeypatch.setattr(client.jwt, "encode", lambda *a, **k: "tok")
+    monkeypatch.setattr(client.httpx, "AsyncClient", ForbiddenClient)
+
+    kwargs = (
+        {"body_params": {"market": "KRW-BTC"}}
+        if method == "POST"
+        else {"query_params": {"uuid": "broker-order-id"}}
+    )
+    with pytest.raises(PreSendFreshnessError):
+        await client._request_with_auth(
+            method,
+            f"{client.UPBIT_REST}{path}",
+            pre_send_hook=block,
+            **kwargs,
+        )
+
+    assert limiter.acquire.await_count == 1
+    assert http_clients == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_rechecks_hook_after_each_limiter_admission():
+    """A retry gets a fresh boundary check and cannot issue a second send."""
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+    from app.services.brokers.upbit.client import _retry_with_backoff
+
+    limiter = _make_limiter()
+    response = _make_response(429, retry_after=0)
+    send = AsyncMock(return_value=response)
+    hook_calls = 0
+
+    async def allow_then_block():
+        nonlocal hook_calls
+        hook_calls += 1
+        if hook_calls == 2:
+            raise PreSendFreshnessError(("approval_window:DEFER_SESSION_CLOSED",))
+
+    with pytest.raises(PreSendFreshnessError):
+        await _retry_with_backoff(
+            limiter,
+            send,
+            url="https://test/read-retry",
+            max_retries=1,
+            base_delay=0,
+            pre_send_hook=allow_then_block,
+        )
+
+    assert limiter.acquire.await_count == 2
+    assert hook_calls == 2
+    assert send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_order_cancel_delete_uses_one_shot_transport(monkeypatch):
+    """Ambiguous DELETE outcomes are never retried across a window boundary."""
+    from app.services.brokers.upbit import client
+
+    captured: dict = {}
+
+    async def fake_retry(limiter, send_fn, *, url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return {"uuid": "x"}
+
+    monkeypatch.setattr(client, "_retry_with_backoff", fake_retry)
+    monkeypatch.setattr(client, "get_limiter", AsyncMock(return_value=MagicMock()))
+    monkeypatch.setattr(client.jwt, "encode", lambda *a, **k: "tok")
+
+    await client._request_with_auth(
+        "DELETE",
+        f"{client.UPBIT_REST}/order",
+        query_params={"uuid": "broker-order-id"},
+    )
+
+    assert captured["retry_request_errors"] is False
+    assert captured["max_retries"] == 0


### PR DESCRIPTION
## Summary

- This PR is stacked on top of the already-merged #1646 approval-dispatch visibility foundation.
- Adds double enforcement for approval-window expiry at dispatch and callback/submit boundaries.
- Enforces market-aware sessions: US regular-only, KR KRX/NXT-aware, crypto 24/7, and fail-closed behavior when calendar evidence is unknown.

## Rebase and conflict resolution

- Rebased onto origin/main at 5ae24e7c.
- Preserved #1646 typed dispatch state, immutable membership snapshots, dispatch-attempt audit rows, terminal-state checks, and nonce ownership gates.
- Layered approval-window checks after the canonical published-binding gate and immediately before nonce consumption or broker-side work.
- Kept frozen batch membership atomic: stale, terminal, superseded, auto-approved, used-nonce, or expired members block consumption without weakening the snapshot digest.
- Kept approval_window.py and approval_window_contract.py as the canonical market/session policy implementation.
- No additional approval-window migration was required; Alembic remains on the single 20260723_approval_dispatch head introduced by #1646.

## Validation

- uv run pytest tests/services/order_proposals/ tests/routers/test_telegram_callback_route.py tests/test_mcp_order_proposal_tools.py -q
- Result: 686 passed, 2 pre-existing Pydantic deprecation warnings
- Ruff check and format checks passed for all touched conflict-resolution files.
- uv run alembic heads: 20260723_approval_dispatch (head)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-closed approval-window validation for order proposals (timezone-aware validity, session/calendar evidence) and typed “blocked” Telegram dispatch reporting when submission is disallowed.
  * Extended Telegram approval flows (single + batch) to enforce boundary rechecks before nonce consumption or publishing.
  * Introduced pre-send freshness hooks for broker/crypto mutations to re-check right before each send attempt.
* **Bug Fixes**
  * Prevented publishing/cancel/submit during approval-window changes at final submission boundaries; improved retry/resend safety without unintended side effects.
* **Documentation**
  * Updated Telegram approval runbooks with the new defense-in-depth and blocked-dispatch behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->