### PR TITLE
feat(mcp): align route_request buy/sell with proposal-led approval path (ROB-1045)

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1933,23 +1933,48 @@ injects lane guidance via a hook and maps lane→role→tool indirectly. auto_tr
 exposes a **direct lane→tool advisory** tool with **no enforcement**. Blocking
 middleware (mutation tools only, reads unrestricted, caller-header-keyed because
 MCP session state resets on reconnect — ROB-469) is a separate follow-up issue.
+In particular, the contract below cannot physically prevent an enabled
+auto-approval path.
 
 Lane definitions come from the machine-readable `lanes:` blocks in
 `docs/playbooks/trading-decision-playbook.md`; `route_request_lanes.LANE_SEQUENCES`
-is kept in sync by `tests/test_route_request_registry_diff.py`. Every DEFAULT
-tool must be classified into `READ_ONLY_ADVISORY_TOOLS` or a mutation set or CI
-fails (silent-drift guard).
+is kept in exact order by `tests/test_route_request_registry_diff.py`. Every
+proposal-enabled DEFAULT tool must be classified into the read/advisory or
+explicit mutation taxonomy or CI fails.
 
-**Market-aware execution mapping (ROB-658):** the playbook lane sequences are
-KR-centric — their place steps hard-code `toss_place_order`/`kis_live_place_order`.
-On crypto/US profiles those tools are unregistered, so `route_request` substitutes
-the market's generic execution surface via `MARKET_EXECUTION_TOOLS`
-(`crypto`/`us` → `place_order`; `kr` → empty, already in the sequence). When a
-lane places orders but none of its KR place tools survive the profile
-intersection, the generic `place_order` is injected as the execution step and
-counted as the lane's own mutation — so it appears in `standard_tool_sequence` +
-`allowed_tools` instead of being misclassified into `blocked_actions`. KR output
-is unchanged.
+**Buy/sell proposal contract (ROB-1045):**
+
+- `order_proposal_create` is the only order-intent surface in buy/sell
+  `standard_tool_sequence`. Registered direct broker place/cancel/modify tools
+  are excluded from `allowed_tools` and included in `blocked_actions`.
+- The route contract requires a human Telegram approval click. Fresh broker
+  preview/revalidation and submit are owned by the proposal approval subsystem;
+  accepted/resting is not a fill, and broker-evidence reconciliation remains
+  required. Registered reconcile tools are conditional helpers rather than an
+  ordered step because `route_request` has no broker/account-mode input.
+- `route_contract` is machine-readable and carries
+  `version="proposal-led-v1"`, `state`, `execution_mode`, `execution_ready`,
+  `proposal_tool`, `approval_channel`, `human_approval_required`,
+  `preview_owner`, `reconcile_requirement`, `required_tools`, and
+  `missing_required_tools`.
+- `execution_ready=true` means only that the required route tool is present in
+  the live MCP registry. It does not assert Telegram publication, configuration,
+  or approval-window readiness. The actual `order_proposal_create`
+  `approval_dispatch` result remains authoritative; see
+  [Order proposal approval tools](#order-proposal-approval-tools-rob-816).
+- If the live registry is valid but `order_proposal_create` is absent, buy/sell
+  return `success=false`, `error="required_route_tool_unavailable"`, and
+  `execution_ready=false`, with no direct-place fallback.
+- If registry introspection is missing, raises, is malformed, or is empty, the
+  route returns `success=false`, `error="registry_introspection_unavailable"`,
+  empty sequence/allowed lists, and the static direct-mutation deny list with
+  `blocked_actions_basis="static_fail_closed"`. It never substitutes
+  `ALL_KNOWN_TOOLS`.
+
+**Discovery non-regression:** discovery is outside ROB-1045 and retains its
+existing `toss_place_order` step and ROB-658 crypto/US generic `place_order`
+injection. Aligning discovery with proposal-led approval requires a separate
+issue. Bootstrap remains read-only.
 
 
 ### User Settings Tools

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 from typing import Any
 
 from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_automated_orders import (
+    ALPACA_PAPER_AUTOMATED_TOOL_NAMES,
+)
 from app.mcp_server.tooling.alpaca_paper_orders import ALPACA_PAPER_MUTATING_TOOL_NAMES
 from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
 from app.mcp_server.tooling.market_quote_snapshot_tools import (
@@ -91,12 +94,8 @@ LANE_SEQUENCES: dict[str, list[dict[str, Any]]] = {
             "purpose": "foreign-flow gate (recovery_gate)",
         },
         {
-            "tool": "toss_place_order",
-            "purpose": "execute buy — Toss preferred (fee-free); deep limit, no chasing",
-        },
-        {
-            "tool": "kis_live_place_order",
-            "purpose": "spend down KIS deposit; dry_run preview -> live",
+            "tool": "order_proposal_create",
+            "purpose": "create place proposal; Telegram human approval is required before proposal-owned revalidation and submit",
         },
     ],
     "sell": [
@@ -109,20 +108,12 @@ LANE_SEQUENCES: dict[str, list[dict[str, Any]]] = {
             "purpose": "confirm distance to resistance, RSI, upside",
         },
         {
-            "tool": "toss_cancel_order",
-            "purpose": "clear same-symbol buy pending first (Toss two-sided constraint)",
-        },
-        {
-            "tool": "toss_place_order",
-            "purpose": "sell-into-strength split ladder just under resistance (Toss holdings)",
-        },
-        {
-            "tool": "kis_live_place_order",
-            "purpose": "sell KIS holdings from the holding account; dry_run preview -> live",
-        },
-        {
             "tool": "sell_ladder_fill_preview",
             "purpose": "ROB-477 bottom-anchor rung, fill-safety",
+        },
+        {
+            "tool": "order_proposal_create",
+            "purpose": "create place/cancel/replace proposal; Telegram human approval is required before proposal-owned revalidation and submit",
         },
     ],
     "discovery": [
@@ -150,6 +141,8 @@ HARD_CONSTRAINTS: dict[str, list[str]] = {
         "no two-sided (buy+sell) resting orders on same Toss symbol",
         "over-concentration cap: portfolio.sector_cluster_cap_pct per sector cluster",
         "portfolio.max_symbols_per_theme per theme; add-not-cut (average down, no stop-loss)",
+        "order intent: order_proposal_create only; Telegram human approval required",
+        "accepted/resting is not a fill; broker evidence reconcile is required",
         "negative class: record each reviewed-but-rejected candidate as a "
         "decision_bucket=deferred_no_action item with confidence + rejection "
         "reason, and leave a resolvable forecast_save (price_target with required "
@@ -162,8 +155,10 @@ HARD_CONSTRAINTS: dict[str, list[str]] = {
         "no two-sided (buy+sell) resting orders on same Toss symbol",
         "DAY order expiry at order.day_expiry_kst -> re-place next day",
         "preserve core lot; trim over-concentrated sectors first (portfolio.sector_cluster_cap_pct)",
-        "sell from holding account: Toss holdings -> toss_place_order, KIS holdings -> kis_live_place_order",
-        "same-symbol buy pending on Toss -> toss_cancel_order first (two-sided constraint)",
+        "order intent: order_proposal_create only; Telegram human approval required",
+        "sell from the holding account selected in the proposal",
+        "same-symbol buy pending -> separate cancel proposal and confirmed broker evidence before the sell proposal",
+        "accepted/resting is not a fill; broker evidence reconcile is required",
     ],
     "discovery": [
         "over-concentration cap: portfolio.sector_cluster_cap_pct per sector cluster",
@@ -183,8 +178,100 @@ HARD_CONSTRAINTS: dict[str, list[str]] = {
     ],
 }
 
-MUTATION_TOOLS: frozenset[str] = frozenset(
+ROUTE_CONTRACT_VERSION = "proposal-led-v1"
+PROPOSAL_TOOL = "order_proposal_create"
+PROPOSAL_LED_LANES: frozenset[str] = frozenset({"buy", "sell"})
+
+# The legacy MUTATION_TOOLS bucket intentionally remains public and broad for
+# backwards compatibility. ROB-1045 overlays explicit, disjoint action classes
+# so proposal-led lanes can fail closed on direct broker mutations without also
+# blocking pure previews, reconcile reads/writes, or read/status helpers.
+DIRECT_BROKER_MUTATION_TOOLS: frozenset[str] = frozenset(
+    {
+        "alpaca_paper_cancel_order",
+        "alpaca_paper_automated_submit_order",
+        "alpaca_paper_submit_order",
+        "binance_demo_scalping_submit_decision",
+        "cancel_order",
+        "kis_live_cancel_order",
+        "kis_live_modify_order",
+        "kis_live_place_order",
+        "kis_mock_cancel_order",
+        "kis_mock_mirror_execute_report",
+        "kis_mock_modify_order",
+        "kis_mock_place_order",
+        "kiwoom_mock_cancel_order",
+        "kiwoom_mock_modify_order",
+        "kiwoom_mock_place_order",
+        "kiwoom_mock_us_cancel_order",
+        "kiwoom_mock_us_modify_order",
+        "kiwoom_mock_us_place_order",
+        "modify_order",
+        "paper_cancel_pending_order",
+        "paper_place_limit_order",
+        "place_order",
+        "toss_cancel_order",
+        "toss_modify_order",
+        "toss_place_order",
+    }
+)
+
+PROPOSAL_LED_TOOLS: frozenset[str] = frozenset({PROPOSAL_TOOL})
+PROPOSAL_LIFECYCLE_TOOLS: frozenset[str] = frozenset(
+    {
+        "order_proposal_expire_sweep",
+        "order_proposal_void",
+    }
+)
+ORDER_PROPOSAL_READ_TOOLS: frozenset[str] = frozenset(
+    {
+        "order_proposal_get",
+        "order_proposal_list",
+        "order_proposal_list_expired_defensive",
+    }
+)
+
+PREVIEW_REVALIDATION_TOOLS: frozenset[str] = frozenset(
+    {
+        "alpaca_paper_automated_preview_order",
+        "buy_ladder_fill_preview",
+        "kiwoom_mock_preview_order",
+        "kiwoom_mock_us_preview_order",
+        "sell_ladder_fill_preview",
+        "toss_preview_order",
+    }
+)
+
+RECONCILE_TOOLS: frozenset[str] = frozenset(
+    {
+        "alpaca_paper_reconcile_orders",
+        "kis_live_reconcile_orders",
+        "kis_mock_reconciliation_run",
+        "live_reconcile_orders",
+        "paper_reconcile_orders",
+        "toss_reconcile_orders",
+    }
+)
+
+# These are read/status helpers that remain in MUTATION_TOOLS only because that
+# public legacy bucket predates the action taxonomy.
+STATUS_HELPER_TOOLS: frozenset[str] = frozenset(
+    {
+        "get_order_history",
+        "kis_live_get_order_history",
+        "kis_mock_get_order_history",
+        "kiwoom_mock_get_order_history",
+        "kiwoom_mock_get_orderable_cash",
+        "kiwoom_mock_get_positions",
+        "toss_get_order_history",
+        "toss_get_orderable_cash",
+        "toss_get_positions",
+    }
+)
+
+_LEGACY_MUTATION_TOOLS: frozenset[str] = frozenset(
     ORDER_TOOL_NAMES
+    | ALPACA_PAPER_AUTOMATED_TOOL_NAMES
     | KIS_LIVE_ORDER_TOOL_NAMES
     | KIS_MOCK_ORDER_TOOL_NAMES
     | LIVE_RECONCILE_TOOL_NAMES
@@ -197,11 +284,15 @@ MUTATION_TOOLS: frozenset[str] = frozenset(
     # lifecycle state to review.alpaca_paper_order_ledger. Flag-
     # gated in DEFAULT (settings.alpaca_paper_default_tools_enabled, default off);
     # the read/preview/us_dual/ledger surface is read-only and lives in
-    # READ_ONLY_ADVISORY_TOOLS. The automated-submit tool is not registered in
-    # DEFAULT at all (ROB-842), so it is intentionally not classified here.
+    # READ_ONLY_ADVISORY_TOOLS. The automated preview/submit pair is US_PAPER-
+    # only (ROB-842) but is classified above because route_request is present
+    # on that profile too.
     | frozenset(ALPACA_PAPER_MUTATING_TOOL_NAMES)
     | frozenset(
         {
+            # ROB-907: default-gated Binance Demo submit can place a broker
+            # round-trip when dry_run=false + confirm=true.
+            "binance_demo_scalping_submit_decision",
             # ROB-703: paper resting-limit sim mutations (paper-table writes only,
             # no live/Upbit broker mutation). paper_list_pending_orders is read-only
             # and lives in READ_ONLY_ADVISORY_TOOLS.
@@ -212,38 +303,28 @@ MUTATION_TOOLS: frozenset[str] = frozenset(
     )
 )
 
-# Market-aware execution mutation tools (ROB-658). The LANE_SEQUENCES above are
-# KR-centric (ported from the playbook, kept in sync by the registry-diff test),
-# so their execution steps hard-code toss/kis. On crypto/US profiles those tools
-# are unregistered, so without a market-aware supplement the generic place_order
-# — the real crypto/US execution surface — falls into blocked_actions and never
-# appears in the sequence/allowed list. KR needs no supplement (its execution
-# tools already live in LANE_SEQUENCES); US/crypto route execution through the
-# generic place_order, which the playbook lanes never list.
+MUTATION_TOOLS: frozenset[str] = (
+    _LEGACY_MUTATION_TOOLS | PROPOSAL_LED_TOOLS | PROPOSAL_LIFECYCLE_TOOLS
+)
+
+# ROB-658's market-aware direct execution mapping remains only for discovery,
+# which the operator explicitly excluded from ROB-1045. Buy/sell never consult
+# this mapping and never fall back to a direct place tool.
 MARKET_EXECUTION_TOOLS: dict[str, frozenset[str]] = {
     "kr": frozenset(),
     "us": frozenset({"place_order"}),
     "crypto": frozenset({"place_order"}),
 }
 
-# Order-placement tools that mark a lane as "executing" (as opposed to a
-# fill-safety/preview or reconcile helper such as sell_ladder_fill_preview, which
-# is also mutation-classified but is not the actual place step). Used to decide
-# whether a lane warrants a market-aware execution step and whether that step's
-# KR-centric tools survived the profile intersection.
+# Direct placement tools used only to preserve discovery's ROB-658 fallback.
 _PLACE_ORDER_TOOLS: frozenset[str] = frozenset(
     {"place_order", "toss_place_order", "kis_live_place_order"}
 )
 
-# ROB-659: dry-run / approval-minting precursor tools. They send no broker
-# mutation, and under TOSS_APPROVAL_HASH_MODE=required an executing lane MUST call
-# toss_preview_order to mint the approval_hash that toss_place_order then demands.
-# toss_preview_order lives in the Toss order namespace (MUTATION_TOOLS) for registry
-# partitioning, so build_route_plan otherwise put it in blocked_actions even for the
-# lane that needs it — a self-contradiction in required mode. Executing lanes now
-# surface their preview precursor as allowed (never blocked). Bootstrap has no place
-# step, so it stays unchanged. (place_order/kis_live_place_order preview via their own
-# dry_run flag, so they need no separate entry here.)
+# Discovery keeps its direct Toss preview precursor. Proposal-led buy/sell do
+# not expose broker previews: fresh preview/revalidation is owned internally by
+# the proposal approval subsystem. sell_ladder_fill_preview remains a pure
+# pre-proposal fill-safety step because it is explicitly sequenced in sell.
 PREVIEW_TOOLS: frozenset[str] = frozenset({"toss_preview_order"})
 
 # ROB-660 / ROB-666: per-lane allowed-only helper tools. The order-status tools
@@ -263,11 +344,16 @@ LANE_EXTRA_ALLOWED: dict[str, frozenset[str]] = {
     "sell": frozenset({"kis_live_get_order_history", "toss_get_order_history"}),
 }
 
-# Purpose text for the market execution step injected into the sequence when the
-# lane's KR-centric execution tools are absent from the live profile (crypto/US).
+# Registered reconcile helpers are conditional allowed helpers for proposal-led
+# lanes. They are deliberately not ordered because route_request has no broker
+# or account_mode input with which to select one.
+LANE_RECONCILE_ALLOWED: dict[str, frozenset[str]] = {
+    "buy": RECONCILE_TOOLS,
+    "sell": RECONCILE_TOOLS,
+}
+
+# Purpose text for discovery's legacy market execution injection.
 _MARKET_EXEC_PURPOSE: dict[str, str] = {
-    "buy": "execute buy via generic place_order (crypto/US limit; dry_run preview -> live)",
-    "sell": "execute sell via generic place_order (crypto/US limit)",
     "discovery": "execute buy on ranked winners via generic place_order (crypto/US limit)",
 }
 
@@ -292,6 +378,7 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         *ALPACA_PAPER_PREVIEW_TOOL_NAMES,
         *US_DUAL_PAPER_TOOL_NAMES,
         *MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
+        *ORDER_PROPOSAL_READ_TOOLS,
         "route_request",
         "analysis_artifact_get",
         "analysis_artifact_list",
@@ -417,8 +504,91 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
 ALL_KNOWN_TOOLS: frozenset[str] = READ_ONLY_ADVISORY_TOOLS | MUTATION_TOOLS
 
 
+def ordered_lane_tool_names(lane: str) -> list[str]:
+    return [step["tool"] for step in LANE_SEQUENCES[lane]]
+
+
 def lane_tool_names(lane: str) -> set[str]:
-    return {step["tool"] for step in LANE_SEQUENCES[lane]}
+    """Compatibility set view; ordered_lane_tool_names is the contract source."""
+    return set(ordered_lane_tool_names(lane))
+
+
+def _route_contract(
+    lane: str,
+    *,
+    registered_tools: set[str] | None,
+) -> dict[str, Any]:
+    proposal_led = lane in PROPOSAL_LED_LANES
+    required_tools = sorted(PROPOSAL_LED_TOOLS) if proposal_led else []
+    missing_required_tools = (
+        required_tools
+        if registered_tools is None
+        else sorted(set(required_tools) - registered_tools)
+    )
+    execution_ready = registered_tools is not None and not missing_required_tools
+
+    if proposal_led:
+        execution_mode = "proposal_led"
+        proposal_tool: str | None = PROPOSAL_TOOL
+        approval_channel = "telegram"
+        human_approval_required = True
+        preview_owner = "proposal_revalidation"
+        reconcile_requirement = "broker_evidence"
+    elif lane == "discovery":
+        execution_mode = "legacy_direct"
+        proposal_tool = None
+        approval_channel = "not_applicable"
+        human_approval_required = False
+        preview_owner = "lane_operator"
+        reconcile_requirement = "legacy_unspecified"
+    else:
+        execution_mode = "read_only"
+        proposal_tool = None
+        approval_channel = "not_applicable"
+        human_approval_required = False
+        preview_owner = "not_applicable"
+        reconcile_requirement = "not_applicable"
+
+    return {
+        "version": ROUTE_CONTRACT_VERSION,
+        "state": "ready" if execution_ready else "degraded",
+        "execution_mode": execution_mode,
+        "execution_ready": execution_ready,
+        "proposal_tool": proposal_tool,
+        "approval_channel": approval_channel,
+        "human_approval_required": human_approval_required,
+        "preview_owner": preview_owner,
+        "reconcile_requirement": reconcile_requirement,
+        "required_tools": required_tools,
+        "missing_required_tools": missing_required_tools,
+    }
+
+
+def build_registry_unavailable_plan(
+    intent: str,
+    market: str,
+    *,
+    verdict_thresholds: dict[str, Any],
+    policy_version: dict[str, str],
+) -> dict[str, Any]:
+    """Return a stable fail-closed response when live registry state is unknown."""
+    lane = INTENT_TO_LANE[intent]
+    return {
+        "success": False,
+        "error": "registry_introspection_unavailable",
+        "degraded": True,
+        "intent": intent,
+        "lane": lane,
+        "market": market,
+        "standard_tool_sequence": [],
+        "allowed_tools": [],
+        "blocked_actions": sorted(DIRECT_BROKER_MUTATION_TOOLS),
+        "blocked_actions_basis": "static_fail_closed",
+        "route_contract": _route_contract(lane, registered_tools=None),
+        "verdict_thresholds": verdict_thresholds,
+        "policy_version": policy_version,
+        "hard_constraints": list(HARD_CONSTRAINTS[lane]),
+    }
 
 
 def build_route_plan(
@@ -433,13 +603,12 @@ def build_route_plan(
     intent/market and resolves policy before calling."""
     lane = INTENT_TO_LANE[intent]
     lane_tools = lane_tool_names(lane)
-    playbook_mutation = lane_tools & MUTATION_TOOLS
-    lane_place_tools = lane_tools & _PLACE_ORDER_TOOLS
-    # Executing lanes (buy/sell/discovery place orders) get a market-aware
-    # execution supplement; bootstrap has no place step, so it stays
-    # supplement-free and every mutation tool remains blocked. For KR the
-    # supplement is empty (its place tools already live in the sequence), so
-    # behaviour is identical to the KR-centric definition (no regression).
+    proposal_led = lane in PROPOSAL_LED_LANES
+    lane_place_tools = (
+        lane_tools & _PLACE_ORDER_TOOLS if lane == "discovery" else frozenset()
+    )
+    # Only the explicitly out-of-scope discovery lane retains ROB-658's generic
+    # crypto/US direct-place fallback.
     market_exec = (
         MARKET_EXECUTION_TOOLS.get(market, frozenset())
         if lane_place_tools
@@ -447,12 +616,11 @@ def build_route_plan(
     )
 
     seq_steps = [
-        step for step in LANE_SEQUENCES[lane] if step["tool"] in registered_tools
+        step
+        for step in LANE_SEQUENCES[lane]
+        if step["tool"] in registered_tools
+        and (not proposal_led or step["tool"] not in DIRECT_BROKER_MUTATION_TOOLS)
     ]
-    # If the lane places orders but none of its playbook place tools survived the
-    # profile intersection (crypto/US), surface the market's generic execution
-    # tool so the advisory shows + allows it instead of leaving the lane
-    # execution-less with place_order misclassified as blocked (ROB-658).
     if lane_place_tools and not (lane_place_tools & registered_tools):
         for tool in sorted(market_exec & registered_tools):
             seq_steps.append({"tool": tool, "purpose": _MARKET_EXEC_PURPOSE[lane]})
@@ -461,35 +629,45 @@ def build_route_plan(
         {"step": i, "tool": step["tool"], "purpose": step["purpose"]}
         for i, step in enumerate(seq_steps, start=1)
     ]
-    lane_own_mutation = playbook_mutation | market_exec
-    # An executing lane surfaces its dry-run/approval-minting precursor (ROB-659)
-    # so the required-mode preview->place flow isn't blocked by its own advisory.
-    lane_preview = PREVIEW_TOOLS if lane_place_tools else frozenset()
-    # ROB-660: allowed-only confirmation helpers (order-status tools) — un-blocked
-    # for the lane but never added to the ordered sequence.
+    # Discovery still surfaces its direct Toss preview precursor. Proposal-led
+    # lanes leave broker preview/revalidation to the approval subsystem.
+    lane_preview = PREVIEW_TOOLS if lane == "discovery" else frozenset()
     lane_extra = LANE_EXTRA_ALLOWED.get(lane, frozenset())
-    allowed = (
-        lane_tools
+    lane_reconcile = LANE_RECONCILE_ALLOWED.get(lane, frozenset())
+    safe_lane_tools = (
+        lane_tools - DIRECT_BROKER_MUTATION_TOOLS if proposal_led else lane_tools
+    )
+    allowed_candidates = (
+        safe_lane_tools
         | market_exec
         | lane_preview
         | lane_extra
+        | lane_reconcile
         | set(READ_ONLY_ADVISORY_TOOLS)
-    ) & registered_tools
-    blocked = (
-        MUTATION_TOOLS - lane_own_mutation - lane_preview - lane_extra
-    ) & registered_tools
-    return {
-        "success": True,
+    )
+    allowed = allowed_candidates & registered_tools
+    blocked = (MUTATION_TOOLS & registered_tools) - allowed
+    route_contract = _route_contract(lane, registered_tools=registered_tools)
+    success = route_contract["execution_ready"]
+
+    result: dict[str, Any] = {
+        "success": success,
+        "degraded": not success,
         "intent": intent,
         "lane": lane,
         "market": market,
         "standard_tool_sequence": standard_tool_sequence,
         "allowed_tools": sorted(allowed),
         "blocked_actions": sorted(blocked),
+        "blocked_actions_basis": "live_registered_surface",
+        "route_contract": route_contract,
         "verdict_thresholds": verdict_thresholds,
         "policy_version": policy_version,
         "hard_constraints": list(HARD_CONSTRAINTS[lane]),
     }
+    if not success:
+        result["error"] = "required_route_tool_unavailable"
+    return result
 
 
 __all__ = [
@@ -498,12 +676,25 @@ __all__ = [
     "LANE_TO_POLICY_LANE",
     "LANE_SEQUENCES",
     "HARD_CONSTRAINTS",
+    "ROUTE_CONTRACT_VERSION",
+    "PROPOSAL_TOOL",
+    "PROPOSAL_LED_LANES",
+    "DIRECT_BROKER_MUTATION_TOOLS",
+    "PROPOSAL_LED_TOOLS",
+    "PROPOSAL_LIFECYCLE_TOOLS",
+    "ORDER_PROPOSAL_READ_TOOLS",
+    "PREVIEW_REVALIDATION_TOOLS",
+    "RECONCILE_TOOLS",
+    "STATUS_HELPER_TOOLS",
     "MARKET_EXECUTION_TOOLS",
     "PREVIEW_TOOLS",
     "LANE_EXTRA_ALLOWED",
+    "LANE_RECONCILE_ALLOWED",
     "MUTATION_TOOLS",
     "READ_ONLY_ADVISORY_TOOLS",
     "ALL_KNOWN_TOOLS",
+    "ordered_lane_tool_names",
     "lane_tool_names",
+    "build_registry_unavailable_plan",
     "build_route_plan",
 ]

--- a/app/mcp_server/tooling/route_request_registration.py
+++ b/app/mcp_server/tooling/route_request_registration.py
@@ -11,13 +11,14 @@ reconnect — ROB-469).
 from __future__ import annotations
 
 import inspect
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from app.mcp_server.tooling.route_request_lanes import (
-    ALL_KNOWN_TOOLS,
     INTENT_TO_LANE,
     LANE_TO_POLICY_LANE,
     VALID_MARKETS,
+    build_registry_unavailable_plan,
     build_route_plan,
 )
 from app.services.trading_policy_service import (
@@ -32,22 +33,31 @@ if TYPE_CHECKING:
 ROUTE_REQUEST_TOOL_NAMES: set[str] = {"route_request"}
 
 
-async def _live_registered_names(mcp: Any) -> set[str]:
-    """Best-effort live tool surface via FastMCP.list_tools(). Fail-open to the
-    full known set (no filtering) if introspection is unavailable."""
+@dataclass(frozen=True)
+class _RegistrySnapshot:
+    available: bool
+    names: frozenset[str] = frozenset()
+
+
+async def _live_registered_names(mcp: Any) -> _RegistrySnapshot:
+    """Read the live FastMCP tool surface without inventing a fallback surface."""
     lister = getattr(mcp, "list_tools", None)
-    if lister is None:
-        return set(ALL_KNOWN_TOOLS)
+    if not callable(lister):
+        return _RegistrySnapshot(available=False)
     try:
         result = lister()
         if inspect.isawaitable(result):
             result = await result
-        names = {getattr(t, "name", None) for t in result}
-        names.discard(None)
-        names_str: set[str] = {str(n) for n in names}
-        return names_str or set(ALL_KNOWN_TOOLS)
+        names: set[str] = set()
+        for tool in result:
+            name = getattr(tool, "name", None)
+            if isinstance(name, str) and name.strip():
+                names.add(name.strip())
     except Exception:
-        return set(ALL_KNOWN_TOOLS)
+        return _RegistrySnapshot(available=False)
+    if not names:
+        return _RegistrySnapshot(available=False)
+    return _RegistrySnapshot(available=True, names=frozenset(names))
 
 
 def register_route_request_tools(mcp: FastMCP) -> None:
@@ -101,11 +111,18 @@ def register_route_request_tools(mcp: FastMCP) -> None:
                     "error": "unknown_market",
                     "detail": str(exc),
                 }
-        registered = await _live_registered_names(mcp)
+        registry_snapshot = await _live_registered_names(mcp)
+        if not registry_snapshot.available:
+            return build_registry_unavailable_plan(
+                intent,
+                market,
+                verdict_thresholds=verdict_thresholds,
+                policy_version=version,
+            )
         return build_route_plan(
             intent,
             market,
-            registered_tools=registered,
+            registered_tools=set(registry_snapshot.names),
             verdict_thresholds=verdict_thresholds,
             policy_version=version,
         )
@@ -120,10 +137,14 @@ def register_route_request_tools(mcp: FastMCP) -> None:
             "{kr, us, crypto} (required). Deterministic (same input -> same "
             "output). ADVISORY ONLY — it does not block anything; it echoes "
             "get_trading_policy (ROB-646) with policy_version so a verdict can "
-            "cite the criteria. standard_tool_sequence is intersected with the "
-            "live-registered tool surface (unregistered tools are dropped); for "
-            "crypto/US the KR-centric place step is replaced by the generic "
-            "place_order execution tool (market-aware, ROB-658). "
+            "cite the criteria. Buy/sell use the proposal-led-v1 contract: "
+            "order_proposal_create is the only order-intent surface, Telegram "
+            "human approval is required, proposal revalidation owns fresh "
+            "preview/submit, and broker evidence reconciliation is required. "
+            "This route contract is advisory and cannot enforce or disable "
+            "auto-approval configuration. Discovery retains its legacy direct "
+            "execution mapping. Registry introspection failure and a missing "
+            "required proposal tool fail closed without a direct-order fallback. "
             "Missing or unknown intent/market returns a deterministic "
             "success=false envelope (error in {missing_intent, unknown_intent, "
             "missing_market, unknown_market})."

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -115,14 +115,20 @@ lanes:
    area low; place a deep limit `buy.deep_limit_pct_range` below the current
    price (pull-back catch, never chase). On crash days add a deeper rung (e.g.
    fib-50).
-5. Execute: `toss_place_order(confirm=true)` (fee-free, preferred) or
-   `kis_live_place_order(thesis + strategy, dry_run preview → live)` to spend
-   down KIS deposit. `kis_live_place_order(dry_run=true)` is the preview; there
-   is no separate KIS preview tool.
-6. Foreign-cascade names (e.g. semis): no market order until **price band
+5. Create the order intent with `order_proposal_create(action="place")`.
+   The `proposal-led-v1` route contract requires a **human Telegram approval
+   click**. The operator must not call a broker preview or place tool directly:
+   fresh preview/revalidation and broker submit belong to the proposal approval
+   subsystem. `route_request` is advisory, so it cannot override a deployment's
+   auto-approval configuration; the create response's `approval_dispatch` is
+   the runtime truth.
+6. Broker acceptance/resting is not a fill. Converge fill/cancel state through
+   the registered broker/account reconcile helper and broker evidence; the
+   route has no `account_mode`, so it does not choose one reconcile tool.
+7. Foreign-cascade names (e.g. semis): no market order until **price band
    reached AND foreign selling stops** — until both, only a small deep rung.
 
-7. **Negative-class recording (ROB-712):** every reviewed-but-rejected candidate
+8. **Negative-class recording (ROB-712):** every reviewed-but-rejected candidate
    leaves a `decision_bucket=deferred_no_action` item with `confidence` +
    rejection reason, plus a resolvable `forecast_save(kind="price_target",
    outcome_rule_version="window-touch-v1-high-gte-low-lte", …)`
@@ -143,10 +149,11 @@ lanes:
         args: {mode: quick, include_position: true, max_symbols: 10}
       - tool: get_intraday_investor_flow
         gate: recovery_gate
-      - tool: toss_place_order        # account routing: Toss preferred
-        confirm: true
-      - tool: kis_live_place_order    # KIS deposit spend-down; dry_run preview -> live
-        confirm: true
+      - tool: order_proposal_create
+        action: place
+        approval: telegram_human_click_required
+        preview_owner: proposal_revalidation
+        reconcile_requirement: broker_evidence
     gates:
       - recovery_gate     # deploy reserve only when >= recovery_gate.min_conditions_met
       - loss_guard        # sell price >= avg * sell.loss_guard_min_multiple (sell-side)
@@ -178,15 +185,23 @@ lanes:
      RSI-neutral 2-6% resistance becomes a system watch. In this conflict,
      `sell.upside_place_max_pct` limits trim size rather than blocking
      pre-placement eligibility.
-4. Execute from the **holding account**: Toss holdings via `toss_place_order`, KIS
-   holdings via `kis_live_place_order` (`dry_run` preview → live). Sell-into-strength
-   **split ladder** just under resistance;
-   [ROB-477](https://linear.app/mgh3326/issue/ROB-477) requires a bottom-anchor rung
-   (`sell_ladder_fill_preview` checks fill-safety), preserve the core lot. Trim
-   over-concentrated sectors first when in the money. If the name has a **pending buy
-   limit on Toss**, `toss_cancel_order` **first** — no two-sided (buy+sell) resting
-   orders on one symbol.
-5. WATCH items are recorded as conditional trigger text (e.g. "when in-the-money
+4. Build the sell-into-strength **split ladder** just under resistance.
+   [ROB-477](https://linear.app/mgh3326/issue/ROB-477) requires a bottom-anchor
+   rung; run the pure `sell_ladder_fill_preview` fill-safety check **before**
+   creating a proposal, preserve the core lot, and trim over-concentrated
+   sectors first when in the money.
+5. Create place/cancel/replace intent only through
+   `order_proposal_create`. The `proposal-led-v1` route contract requires a
+   **human Telegram approval click**. If the symbol has a pending buy, first
+   create a separate cancel proposal and wait for confirmed cancellation
+   evidence before creating the sell proposal; never call a direct cancel or
+   place tool from this lane.
+6. Fresh broker preview/revalidation and submit belong to the proposal approval
+   subsystem. `route_request` is advisory and cannot override auto-approval
+   configuration; `approval_dispatch` in the create response is the runtime
+   truth. Broker acceptance/resting is not a fill, so converge the result with
+   the registered broker/account reconcile helper and broker evidence.
+7. WATCH items are recorded as conditional trigger text (e.g. "when in-the-money
    AND resistance reached, place at <price>"). Today this depends on session
    memory / journal — [ROB-637](https://linear.app/mgh3326/issue/ROB-637)
    (analysis artifacts) is the durable target.
@@ -199,11 +214,12 @@ lanes:
     steps:
       - tool: toss_get_positions
       - tool: analyze_stock_batch
-      - tool: toss_cancel_order       # clear same-symbol buy pending (two-sided) before sell
-      - tool: toss_place_order        # sell-into-strength split ladder (Toss holdings)
-        confirm: true
-      - tool: kis_live_place_order    # sell KIS holdings from holding account; dry_run preview -> live
       - tool: sell_ladder_fill_preview  # ROB-477 bottom-anchor rung, fill-safety
+      - tool: order_proposal_create
+        actions: [place, cancel, replace]
+        approval: telegram_human_click_required
+        preview_owner: proposal_revalidation
+        reconcile_requirement: broker_evidence
     verdicts: [PLACE, WATCH, HOLD]
     gates:
       - loss_guard        # sell price >= avg * sell.loss_guard_min_multiple

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -785,6 +785,72 @@ class TestTradingCodexExecutionProfile:
         }
 
 
+class TestRouteProposalReadinessByProfile:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "profile",
+        [McpProfile.DEFAULT, McpProfile.TRADINGCODEX_EXECUTION],
+    )
+    async def test_proposal_gate_on_is_ready(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        profile: McpProfile,
+    ) -> None:
+        monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
+        mcp = _build_mcp(profile)
+
+        result = await mcp.tools["route_request"](
+            intent="buy_analysis",
+            market="kr",
+        )
+
+        assert "order_proposal_create" in mcp.tools
+        assert result["success"] is True
+        assert result["route_contract"]["execution_ready"] is True
+        assert result["standard_tool_sequence"][-1]["tool"] == ("order_proposal_create")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "profile",
+        [McpProfile.DEFAULT, McpProfile.TRADINGCODEX_EXECUTION],
+    )
+    async def test_proposal_gate_off_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        profile: McpProfile,
+    ) -> None:
+        monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", False)
+        mcp = _build_mcp(profile)
+
+        result = await mcp.tools["route_request"](
+            intent="profit_taking",
+            market="kr",
+        )
+
+        assert "order_proposal_create" not in mcp.tools
+        assert result["success"] is False
+        assert result["error"] == "required_route_tool_unavailable"
+        assert result["route_contract"]["execution_ready"] is False
+
+    @pytest.mark.asyncio
+    async def test_analysis_readonly_fails_closed_even_with_gate_on(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+
+        result = await mcp.tools["route_request"](
+            intent="buy_analysis",
+            market="kr",
+        )
+
+        assert "order_proposal_create" not in mcp.tools
+        assert result["success"] is False
+        assert result["error"] == "required_route_tool_unavailable"
+        assert result["route_contract"]["execution_ready"] is False
+
+
 class TestResolveMcpProfile:
     def test_none_returns_default(self) -> None:
         assert resolve_mcp_profile(None) is McpProfile.DEFAULT

--- a/tests/test_playbook_tool_names.py
+++ b/tests/test_playbook_tool_names.py
@@ -19,6 +19,7 @@ from typing import Any, cast
 
 import yaml
 
+from app.core.config import settings
 from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling.registry import register_all_tools
 from tests._mcp_tooling_support import DummyMCP
@@ -77,7 +78,10 @@ def test_playbook_yaml_blocks_are_parseable_and_nonempty() -> None:
     )
 
 
-def test_playbook_tools_exist_in_default_profile() -> None:
+def test_playbook_tools_exist_in_proposal_enabled_default_profile(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
     registry = _default_profile_tools()
     refs = set(_playbook_tool_refs())
     missing = sorted(refs - registry)
@@ -85,6 +89,20 @@ def test_playbook_tools_exist_in_default_profile() -> None:
         "playbook references tools absent from the DEFAULT MCP profile "
         f"(rename/removal drift): {missing}"
     )
+
+
+def test_buy_sell_have_one_canonical_proposal_step() -> None:
+    text = _PLAYBOOK_PATH.read_text(encoding="utf-8")
+    per_lane: dict[str, list[str]] = {}
+    for block in _YAML_BLOCK_RE.findall(text):
+        parsed = yaml.safe_load(block)
+        if isinstance(parsed, dict) and isinstance(parsed.get("lanes"), dict):
+            for lane, body in parsed["lanes"].items():
+                per_lane.setdefault(lane, []).extend(_collect_tool_refs(body))
+
+    for lane in ("buy", "sell"):
+        assert per_lane[lane].count("order_proposal_create") == 1
+        assert per_lane[lane][-1] == "order_proposal_create"
 
 
 def test_playbook_covers_core_lanes() -> None:

--- a/tests/test_route_request.py
+++ b/tests/test_route_request.py
@@ -1,12 +1,18 @@
-# tests/test_route_request.py
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
+from app.core.config import settings
 from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling.registry import register_all_tools
+from app.mcp_server.tooling.route_request_lanes import (
+    ALL_KNOWN_TOOLS,
+    DIRECT_BROKER_MUTATION_TOOLS,
+)
 from app.mcp_server.tooling.route_request_registration import (
     ROUTE_REQUEST_TOOL_NAMES,
     register_route_request_tools,
@@ -14,10 +20,26 @@ from app.mcp_server.tooling.route_request_registration import (
 from tests._mcp_tooling_support import DummyMCP, build_tools
 
 
-def _route_tool() -> Any:
+def _noop() -> None:
+    return None
+
+
+def _route_tool(registered: set[str] | None = None) -> Any:
     mcp = DummyMCP()
+    for name in set(ALL_KNOWN_TOOLS) if registered is None else registered:
+        mcp.tools[name] = _noop
     register_route_request_tools(cast(Any, mcp))
     return mcp.tools["route_request"]
+
+
+def _build_profile_mcp(profile: McpProfile) -> DummyMCP:
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=profile)
+    return mcp
+
+
+def _steps(out: dict[str, Any]) -> list[str]:
+    return [step["tool"] for step in out["standard_tool_sequence"]]
 
 
 def test_tool_name_registered():
@@ -28,124 +50,233 @@ def test_tool_name_registered():
 
 
 def test_unknown_intent_returns_error():
-    route = _route_tool()
-    out = asyncio.run(route(intent="sell_everything", market="kr"))
+    out = asyncio.run(_route_tool()(intent="sell_everything", market="kr"))
     assert out["success"] is False
     assert out["error"] == "unknown_intent"
 
 
 def test_unknown_market_returns_error():
-    route = _route_tool()
-    out = asyncio.run(route(intent="buy_analysis", market="jp"))
+    out = asyncio.run(_route_tool()(intent="buy_analysis", market="jp"))
     assert out["success"] is False
     assert out["error"] == "unknown_market"
 
 
-def test_buy_analysis_echoes_policy_version_and_thresholds():
-    route = _route_tool()
-    out = asyncio.run(route(intent="buy_analysis", market="kr"))
+def test_missing_intent_returns_deterministic_envelope():
+    out = asyncio.run(_route_tool()(market="kr"))
+    assert out["success"] is False
+    assert out["error"] == "missing_intent"
+
+
+def test_missing_market_returns_deterministic_envelope():
+    out = asyncio.run(_route_tool()(intent="buy_analysis"))
+    assert out["success"] is False
+    assert out["error"] == "missing_market"
+
+
+def test_buy_analysis_echoes_policy_and_proposal_contract():
+    out = asyncio.run(_route_tool()(intent="buy_analysis", market="kr"))
+
     assert out["success"] is True
     assert out["lane"] == "buy"
     assert set(out["policy_version"]) == {"version", "content_hash"}
-    # buy lane has policy thresholds
     assert out["verdict_thresholds"]["thresholds"]
     assert out["verdict_thresholds"]["lane"] == "buy"
+    assert out["route_contract"]["version"] == "proposal-led-v1"
+    assert out["route_contract"]["execution_ready"] is True
+    assert out["route_contract"]["human_approval_required"] is True
+    assert _steps(out)[-1] == "order_proposal_create"
 
 
 def test_market_brief_has_version_but_empty_thresholds():
-    route = _route_tool()
-    out = asyncio.run(route(intent="market_brief", market="kr"))
+    out = asyncio.run(_route_tool()(intent="market_brief", market="kr"))
+
     assert out["success"] is True
     assert out["lane"] == "bootstrap"
     assert set(out["policy_version"]) == {"version", "content_hash"}
     assert out["verdict_thresholds"]["thresholds"] == {}
+    assert out["route_contract"]["execution_mode"] == "read_only"
 
 
 @pytest.mark.parametrize(
     "intent", ["buy_analysis", "profit_taking", "discovery", "market_brief"]
 )
 @pytest.mark.parametrize("market", ["kr", "us", "crypto"])
-def test_deterministic_same_input_same_output(intent, market):
-    # ROB-659: exercise the double-call determinism assertion across all 4 intents
-    # (and all markets), not just discovery/kr.
+def test_deterministic_same_input_same_output(intent: str, market: str):
     route = _route_tool()
-    a = asyncio.run(route(intent=intent, market=market))
-    b = asyncio.run(route(intent=intent, market=market))
-    assert a == b
+    first = asyncio.run(route(intent=intent, market=market))
+    second = asyncio.run(route(intent=intent, market=market))
+    assert first == second
 
 
-def test_missing_intent_returns_deterministic_envelope():
-    # ROB-659: a missing arg returns success=false, not a schema crash.
-    route = _route_tool()
-    out = asyncio.run(route(market="kr"))
+class _MissingListToolsMCP(DummyMCP):
+    list_tools = None
+
+
+class _SyncRaisingMCP(DummyMCP):
+    def list_tools(self):
+        raise RuntimeError("sync registry failure")
+
+
+class _AsyncRaisingMCP(DummyMCP):
+    async def list_tools(self):
+        raise RuntimeError("async registry failure")
+
+
+class _EmptyRegistryMCP(DummyMCP):
+    def list_tools(self):
+        return []
+
+
+class _NoneRegistryMCP(DummyMCP):
+    def list_tools(self):
+        return None
+
+
+class _NonIterableRegistryMCP(DummyMCP):
+    def list_tools(self):
+        return 42
+
+
+class _MalformedRegistryMCP(DummyMCP):
+    def list_tools(self):
+        return [
+            object(),
+            SimpleNamespace(name=None),
+            SimpleNamespace(name=""),
+        ]
+
+
+@pytest.mark.parametrize(
+    "mcp_type",
+    [
+        _MissingListToolsMCP,
+        _SyncRaisingMCP,
+        _AsyncRaisingMCP,
+        _EmptyRegistryMCP,
+        _NoneRegistryMCP,
+        _NonIterableRegistryMCP,
+        _MalformedRegistryMCP,
+    ],
+)
+def test_registry_introspection_failure_is_static_fail_closed(mcp_type):
+    mcp = mcp_type()
+    register_route_request_tools(cast(Any, mcp))
+    out = asyncio.run(mcp.tools["route_request"](intent="buy_analysis", market="kr"))
+
     assert out["success"] is False
-    assert out["error"] == "missing_intent"
+    assert out["error"] == "registry_introspection_unavailable"
+    assert out["degraded"] is True
+    assert out["standard_tool_sequence"] == []
+    assert out["allowed_tools"] == []
+    assert set(out["blocked_actions"]) == DIRECT_BROKER_MUTATION_TOOLS
+    assert out["blocked_actions_basis"] == "static_fail_closed"
+    assert out["route_contract"]["state"] == "degraded"
+    assert out["route_contract"]["execution_ready"] is False
+    assert out["route_contract"]["missing_required_tools"] == ["order_proposal_create"]
 
 
-def test_missing_market_returns_deterministic_envelope():
-    route = _route_tool()
-    out = asyncio.run(route(intent="buy_analysis"))
+def test_registered_surface_without_proposal_tool_fails_closed():
+    registered = set(ALL_KNOWN_TOOLS) - {"order_proposal_create"}
+    out = asyncio.run(_route_tool(registered)(intent="profit_taking", market="us"))
+
     assert out["success"] is False
-    assert out["error"] == "missing_market"
+    assert out["error"] == "required_route_tool_unavailable"
+    assert out["route_contract"]["state"] == "degraded"
+    assert out["route_contract"]["execution_ready"] is False
+    assert out["route_contract"]["missing_required_tools"] == ["order_proposal_create"]
+    assert "place_order" not in _steps(out)
+    assert DIRECT_BROKER_MUTATION_TOOLS & registered <= set(out["blocked_actions"])
 
 
-def test_profile_intersection_crypto_drops_toss_place_order():
-    # DEFAULT registers toss_place_order; CRYPTO does not. route_request reads
-    # the live-registered surface via mcp.list_tools().
-    default_mcp = DummyMCP()
-    from app.mcp_server.tooling.registry import register_all_tools
+@pytest.mark.parametrize(
+    "profile",
+    [McpProfile.DEFAULT, McpProfile.TRADINGCODEX_EXECUTION],
+)
+def test_proposal_enabled_execution_profiles_are_route_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    profile: McpProfile,
+):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
+    mcp = _build_profile_mcp(profile)
+    out = asyncio.run(mcp.tools["route_request"](intent="buy_analysis", market="kr"))
 
-    register_all_tools(cast(Any, default_mcp), profile=McpProfile.DEFAULT)
-    default_route = default_mcp.tools["route_request"]
-    default_out = asyncio.run(default_route(intent="buy_analysis", market="kr"))
-    assert "toss_place_order" in [
-        s["tool"] for s in default_out["standard_tool_sequence"]
-    ]
-
-    crypto_mcp = DummyMCP()
-    register_all_tools(cast(Any, crypto_mcp), profile=McpProfile.CRYPTO)
-    crypto_route = crypto_mcp.tools["route_request"]
-    crypto_out = asyncio.run(crypto_route(intent="buy_analysis", market="crypto"))
-    assert "toss_place_order" not in [
-        s["tool"] for s in crypto_out["standard_tool_sequence"]
-    ]
-    assert "toss_place_order" not in crypto_out["allowed_tools"]
-    # ROB-658: the crypto execution tool (generic place_order) must be surfaced,
-    # not misclassified as blocked, on the CRYPTO profile.
-    assert "place_order" not in crypto_out["blocked_actions"]
-    assert "place_order" in crypto_out["allowed_tools"]
-    assert "place_order" in [s["tool"] for s in crypto_out["standard_tool_sequence"]]
+    assert "order_proposal_create" in mcp.tools
+    assert out["success"] is True
+    assert out["route_contract"]["execution_ready"] is True
+    assert _steps(out)[-1] == "order_proposal_create"
+    assert DIRECT_BROKER_MUTATION_TOOLS & mcp.tools.keys() <= set(
+        out["blocked_actions"]
+    )
 
 
-def test_executing_lane_surfaces_toss_preview_precursor():
-    # ROB-659: toss_preview_order mints the approval_hash that toss_place_order
-    # requires under TOSS_APPROVAL_HASH_MODE=required. An executing lane must NOT
-    # list its own preview precursor in blocked_actions (self-contradiction).
-    default_mcp = DummyMCP()
-    from app.mcp_server.tooling.registry import register_all_tools
+def test_proposal_flag_off_default_profile_is_not_route_ready(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", False)
+    mcp = _build_profile_mcp(McpProfile.DEFAULT)
+    out = asyncio.run(mcp.tools["route_request"](intent="buy_analysis", market="kr"))
 
-    register_all_tools(cast(Any, default_mcp), profile=McpProfile.DEFAULT)
-    route = default_mcp.tools["route_request"]
-    for intent in ("buy_analysis", "profit_taking", "discovery"):
-        out = asyncio.run(route(intent=intent, market="kr"))
-        assert "toss_preview_order" not in out["blocked_actions"], intent
-        assert "toss_preview_order" in out["allowed_tools"], intent
+    assert "order_proposal_create" not in mcp.tools
+    assert out["success"] is False
+    assert out["error"] == "required_route_tool_unavailable"
+    assert out["route_contract"]["execution_ready"] is False
 
-    # Bootstrap has no place step, so its preview precursor stays blocked (unchanged).
-    brief = asyncio.run(route(intent="market_brief", market="kr"))
-    assert brief["lane"] == "bootstrap"
-    assert "toss_preview_order" in brief["blocked_actions"]
+
+def test_analysis_readonly_stays_fail_closed_when_proposal_gate_is_on(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
+    mcp = _build_profile_mcp(McpProfile.ANALYSIS_READONLY)
+    out = asyncio.run(mcp.tools["route_request"](intent="profit_taking", market="kr"))
+
+    assert "order_proposal_create" not in mcp.tools
+    assert out["success"] is False
+    assert out["error"] == "required_route_tool_unavailable"
+    assert out["route_contract"]["execution_ready"] is False
+
+
+def test_crypto_profile_blocks_generic_direct_place_for_proposal_lane(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
+    mcp = _build_profile_mcp(McpProfile.CRYPTO)
+    out = asyncio.run(
+        mcp.tools["route_request"](intent="buy_analysis", market="crypto")
+    )
+
+    assert out["success"] is True
+    assert "place_order" in mcp.tools
+    assert "place_order" in out["blocked_actions"]
+    assert "place_order" not in out["allowed_tools"]
+    assert "place_order" not in _steps(out)
+
+
+def test_discovery_preview_and_direct_execution_non_regression(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
+    mcp = _build_profile_mcp(McpProfile.DEFAULT)
+    route = mcp.tools["route_request"]
+
+    discovery = asyncio.run(route(intent="discovery", market="kr"))
+    assert discovery["success"] is True
+    assert discovery["route_contract"]["execution_mode"] == "legacy_direct"
+    assert "toss_preview_order" in discovery["allowed_tools"]
+    assert "toss_place_order" in _steps(discovery)
+
+    for intent in ("buy_analysis", "profit_taking"):
+        proposal = asyncio.run(route(intent=intent, market="kr"))
+        assert "toss_preview_order" in proposal["blocked_actions"]
+        assert "toss_preview_order" not in proposal["allowed_tools"]
 
 
 class TestRouteRequestRegisteredEveryProfile:
-    # ROB-760: account_read is a physical account-sync allowlist and must not
-    # inherit route/advisory tools.
     @pytest.mark.parametrize(
         "profile",
         [
-            p
-            for p in McpProfile
-            if p not in (McpProfile.ACCOUNT_READ, McpProfile.PAPER_EXECUTION)
+            profile
+            for profile in McpProfile
+            if profile not in (McpProfile.ACCOUNT_READ, McpProfile.PAPER_EXECUTION)
         ],
     )
     def test_route_request_present(self, profile: McpProfile) -> None:

--- a/tests/test_route_request_lanes.py
+++ b/tests/test_route_request_lanes.py
@@ -1,5 +1,8 @@
-# tests/test_route_request_lanes.py
 from __future__ import annotations
+
+from itertools import combinations
+
+import pytest
 
 from app.mcp_server.tooling import route_request_lanes as L
 
@@ -16,102 +19,213 @@ def _fake_thresholds(market: str, lane: str, *, empty: bool = False) -> dict:
 
 _VERSION = {"version": "V", "content_hash": "H"}
 _ALL = set(L.ALL_KNOWN_TOOLS)
+_PROPOSAL_FIELDS = {
+    "version",
+    "state",
+    "execution_mode",
+    "execution_ready",
+    "proposal_tool",
+    "approval_channel",
+    "human_approval_required",
+    "preview_owner",
+    "reconcile_requirement",
+    "required_tools",
+    "missing_required_tools",
+}
+_EXPECTED_LANES = {
+    "buy_analysis": ("buy", "proposal_led"),
+    "profit_taking": ("sell", "proposal_led"),
+    "discovery": ("discovery", "legacy_direct"),
+    "market_brief": ("bootstrap", "read_only"),
+}
+
+
+def _plan(intent: str, market: str, *, registered: set[str] | None = None) -> dict:
+    lane = L.INTENT_TO_LANE[intent]
+    return L.build_route_plan(
+        intent,
+        market,
+        registered_tools=_ALL if registered is None else registered,
+        verdict_thresholds=_fake_thresholds(market, lane, empty=lane == "bootstrap"),
+        policy_version=_VERSION,
+    )
+
+
+def _step_tools(plan: dict) -> list[str]:
+    return [step["tool"] for step in plan["standard_tool_sequence"]]
 
 
 def test_intent_to_lane_covers_all_four_intents():
-    assert set(L.INTENT_TO_LANE) == {
-        "buy_analysis",
-        "profit_taking",
-        "discovery",
-        "market_brief",
+    assert L.INTENT_TO_LANE == {
+        "buy_analysis": "buy",
+        "profit_taking": "sell",
+        "discovery": "discovery",
+        "market_brief": "bootstrap",
     }
-    assert L.INTENT_TO_LANE["market_brief"] == "bootstrap"
 
 
-def test_buckets_partition_and_are_disjoint():
+def test_action_taxonomy_is_disjoint_and_total():
+    action_classes = (
+        L.DIRECT_BROKER_MUTATION_TOOLS,
+        L.PROPOSAL_LED_TOOLS,
+        L.PROPOSAL_LIFECYCLE_TOOLS,
+        L.PREVIEW_REVALIDATION_TOOLS,
+        L.RECONCILE_TOOLS,
+        L.STATUS_HELPER_TOOLS,
+    )
+    for left, right in combinations(action_classes, 2):
+        assert left.isdisjoint(right)
+    assert frozenset().union(*action_classes) == L.MUTATION_TOOLS
     assert L.READ_ONLY_ADVISORY_TOOLS.isdisjoint(L.MUTATION_TOOLS)
     assert L.ALL_KNOWN_TOOLS == L.READ_ONLY_ADVISORY_TOOLS | L.MUTATION_TOOLS
-    assert "route_request" in L.READ_ONLY_ADVISORY_TOOLS
+    assert L.ORDER_PROPOSAL_READ_TOOLS <= L.READ_ONLY_ADVISORY_TOOLS
+    assert L.PROPOSAL_LED_TOOLS == {"order_proposal_create"}
 
 
-def test_build_route_plan_buy_shape_is_deterministic():
-    plan_a = L.build_route_plan(
-        "buy_analysis",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "buy"),
-        policy_version=_VERSION,
-    )
-    plan_b = L.build_route_plan(
-        "buy_analysis",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "buy"),
-        policy_version=_VERSION,
-    )
-    assert plan_a == plan_b
-    assert plan_a["success"] is True
-    assert plan_a["lane"] == "buy"
-    assert plan_a["market"] == "kr"
-    assert plan_a["policy_version"] == _VERSION
-    steps = [s["tool"] for s in plan_a["standard_tool_sequence"]]
-    assert steps[0] == "get_operating_briefing"
-    assert "toss_place_order" in steps
-    # step numbers are contiguous 1..n
-    assert [s["step"] for s in plan_a["standard_tool_sequence"]] == list(
-        range(1, len(steps) + 1)
-    )
+@pytest.mark.parametrize(
+    ("intent", "expected_lane", "execution_mode"),
+    [
+        (intent, lane, execution_mode)
+        for intent, (lane, execution_mode) in _EXPECTED_LANES.items()
+    ],
+)
+@pytest.mark.parametrize("market", ["kr", "us", "crypto"])
+def test_route_semantic_contract_matrix(
+    intent: str,
+    expected_lane: str,
+    execution_mode: str,
+    market: str,
+):
+    plan = _plan(intent, market)
+    sequence = plan["standard_tool_sequence"]
+    steps = _step_tools(plan)
+    contract = plan["route_contract"]
+
+    assert plan["success"] is True
+    assert plan["degraded"] is False
+    assert plan["intent"] == intent
+    assert plan["lane"] == expected_lane
+    assert plan["market"] == market
+    assert plan["policy_version"] == _VERSION
+    assert set(contract) == _PROPOSAL_FIELDS
+    assert contract["version"] == "proposal-led-v1"
+    assert contract["state"] == "ready"
+    assert contract["execution_mode"] == execution_mode
+    assert contract["execution_ready"] is True
+    assert [step["step"] for step in sequence] == list(range(1, len(steps) + 1))
+    assert steps == L.ordered_lane_tool_names(expected_lane)
+    assert len(steps) == len(set(steps))
+    assert set(plan["allowed_tools"]).isdisjoint(plan["blocked_actions"])
+    assert plan["blocked_actions_basis"] == "live_registered_surface"
+
+    registered_direct = L.DIRECT_BROKER_MUTATION_TOOLS & _ALL
+    if expected_lane in {"buy", "sell"}:
+        assert contract == {
+            "version": "proposal-led-v1",
+            "state": "ready",
+            "execution_mode": "proposal_led",
+            "execution_ready": True,
+            "proposal_tool": "order_proposal_create",
+            "approval_channel": "telegram",
+            "human_approval_required": True,
+            "preview_owner": "proposal_revalidation",
+            "reconcile_requirement": "broker_evidence",
+            "required_tools": ["order_proposal_create"],
+            "missing_required_tools": [],
+        }
+        assert steps.count("order_proposal_create") == 1
+        assert steps[-1] == "order_proposal_create"
+        assert "order_proposal_create" in plan["allowed_tools"]
+        assert registered_direct <= set(plan["blocked_actions"])
+        assert registered_direct.isdisjoint(plan["allowed_tools"])
+        assert registered_direct.isdisjoint(steps)
+    elif expected_lane == "discovery":
+        assert contract["proposal_tool"] is None
+        assert contract["approval_channel"] == "not_applicable"
+        assert contract["human_approval_required"] is False
+        assert contract["preview_owner"] == "lane_operator"
+        assert contract["reconcile_requirement"] == "legacy_unspecified"
+        assert contract["required_tools"] == []
+        assert contract["missing_required_tools"] == []
+        # Operator decision: discovery is explicitly out of ROB-1045 scope.
+        assert "toss_place_order" in steps
+        assert "toss_place_order" in plan["allowed_tools"]
+        assert "toss_place_order" not in plan["blocked_actions"]
+    else:
+        assert contract["proposal_tool"] is None
+        assert contract["approval_channel"] == "not_applicable"
+        assert contract["human_approval_required"] is False
+        assert contract["preview_owner"] == "not_applicable"
+        assert contract["reconcile_requirement"] == "not_applicable"
+        assert contract["required_tools"] == []
+        assert contract["missing_required_tools"] == []
+        assert set(plan["blocked_actions"]) == (L.MUTATION_TOOLS & _ALL)
 
 
-def test_blocked_actions_excludes_lanes_own_mutation_tools():
-    plan = L.build_route_plan(
-        "buy_analysis",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "buy"),
-        policy_version=_VERSION,
-    )
-    # buy lane's own place tools are allowed, not blocked
-    assert "toss_place_order" not in plan["blocked_actions"]
-    assert "kis_live_place_order" not in plan["blocked_actions"]
-    # a non-buy mutation tool is blocked
-    assert "toss_cancel_order" in plan["blocked_actions"]
-    assert "toss_place_order" in plan["allowed_tools"]
+@pytest.mark.parametrize("intent", ["buy_analysis", "profit_taking"])
+@pytest.mark.parametrize("market", ["kr", "us", "crypto"])
+def test_proposal_tool_missing_fails_closed(
+    intent: str,
+    market: str,
+):
+    registered = _ALL - {"order_proposal_create"}
+    plan = _plan(intent, market, registered=registered)
+    steps = _step_tools(plan)
+
+    assert plan["success"] is False
+    assert plan["error"] == "required_route_tool_unavailable"
+    assert plan["degraded"] is True
+    assert plan["route_contract"]["state"] == "degraded"
+    assert plan["route_contract"]["execution_ready"] is False
+    assert plan["route_contract"]["required_tools"] == ["order_proposal_create"]
+    assert plan["route_contract"]["missing_required_tools"] == ["order_proposal_create"]
+    assert "order_proposal_create" not in steps
+    assert L.DIRECT_BROKER_MUTATION_TOOLS.isdisjoint(steps)
+    assert L.DIRECT_BROKER_MUTATION_TOOLS & registered <= set(plan["blocked_actions"])
+    assert L.DIRECT_BROKER_MUTATION_TOOLS.isdisjoint(plan["allowed_tools"])
+    assert "place_order" not in steps
+    assert plan["blocked_actions_basis"] == "live_registered_surface"
 
 
-def test_market_brief_blocks_all_mutation_and_has_empty_thresholds():
-    plan = L.build_route_plan(
-        "market_brief",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "bootstrap", empty=True),
-        policy_version=_VERSION,
-    )
-    assert plan["lane"] == "bootstrap"
-    assert plan["verdict_thresholds"]["thresholds"] == {}
-    # bootstrap sequence is all read-only -> every mutation tool is blocked
-    assert set(plan["blocked_actions"]) == (L.MUTATION_TOOLS & _ALL)
+@pytest.mark.parametrize("intent", ["buy_analysis", "profit_taking"])
+def test_proposal_lane_allows_reconcile_helpers_without_sequencing(intent: str):
+    plan = _plan(intent, "kr")
+    allowed = set(plan["allowed_tools"])
+    blocked = set(plan["blocked_actions"])
+    steps = set(_step_tools(plan))
+
+    assert L.RECONCILE_TOOLS & _ALL <= allowed
+    assert (L.RECONCILE_TOOLS & _ALL).isdisjoint(blocked)
+    assert L.RECONCILE_TOOLS.isdisjoint(steps)
 
 
-def test_profile_intersection_drops_unregistered_tools():
+def test_sell_fill_safety_preview_precedes_proposal():
+    plan = _plan("profit_taking", "kr")
+    steps = _step_tools(plan)
+
+    assert steps[-2:] == ["sell_ladder_fill_preview", "order_proposal_create"]
+    assert "sell_ladder_fill_preview" in plan["allowed_tools"]
+    assert "sell_ladder_fill_preview" not in plan["blocked_actions"]
+
+
+@pytest.mark.parametrize("intent", ["buy_analysis", "profit_taking"])
+def test_broker_preview_is_not_an_operator_step_for_proposal_lanes(intent: str):
+    plan = _plan(intent, "kr")
+
+    assert "toss_preview_order" not in _step_tools(plan)
+    assert "toss_preview_order" not in plan["allowed_tools"]
+    assert "toss_preview_order" in plan["blocked_actions"]
+
+
+def test_profile_intersection_drops_unregistered_discovery_tool():
     registered = _ALL - {"toss_place_order"}
-    plan = L.build_route_plan(
-        "discovery",
-        "kr",
-        registered_tools=registered,
-        verdict_thresholds=_fake_thresholds("kr", "discovery"),
-        policy_version=_VERSION,
-    )
-    tools = [s["tool"] for s in plan["standard_tool_sequence"]]
-    assert "toss_place_order" not in tools
+    plan = _plan("discovery", "kr", registered=registered)
+
+    assert "toss_place_order" not in _step_tools(plan)
     assert "toss_place_order" not in plan["allowed_tools"]
     assert "toss_place_order" not in plan["blocked_actions"]
 
 
-# --- ROB-658: market-aware execution tool mapping -----------------------------
-
-# crypto/US profiles register the generic place_order surface but not the
-# KR-centric toss/kis execution tools.
 _CRYPTO_MUTATION = {
     "place_order",
     "modify_order",
@@ -125,196 +239,48 @@ _CRYPTO_MUTATION = {
 _CRYPTO_REGISTERED = set(L.READ_ONLY_ADVISORY_TOOLS) | _CRYPTO_MUTATION
 
 
-def test_crypto_buy_does_not_block_generic_place_order():
-    plan = L.build_route_plan(
-        "buy_analysis",
-        "crypto",
-        registered_tools=_CRYPTO_REGISTERED,
-        verdict_thresholds=_fake_thresholds("crypto", "buy"),
-        policy_version=_VERSION,
-    )
-    # the real crypto execution tool must not be advised as blocked (ROB-658)
-    assert "place_order" not in plan["blocked_actions"]
-    # ...and it is surfaced as an allowed tool + a concrete execution step
-    assert "place_order" in plan["allowed_tools"]
-    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
+def test_crypto_discovery_keeps_legacy_generic_place_order_injection():
+    plan = _plan("discovery", "crypto", registered=_CRYPTO_REGISTERED)
+    steps = _step_tools(plan)
+
+    assert plan["success"] is True
+    assert plan["route_contract"]["execution_mode"] == "legacy_direct"
     assert "place_order" in steps
-    # KR execution tools are unregistered on crypto -> dropped, never injected
+    assert "place_order" in plan["allowed_tools"]
+    assert "place_order" not in plan["blocked_actions"]
     assert "toss_place_order" not in steps
-    assert "kis_live_place_order" not in steps
-    # other generic mutations remain blocked (only place is the sanctioned step)
-    assert "modify_order" in plan["blocked_actions"]
-    assert "cancel_order" in plan["blocked_actions"]
-    # step numbers stay contiguous after injection
-    assert [s["step"] for s in plan["standard_tool_sequence"]] == list(
-        range(1, len(steps) + 1)
-    )
 
 
-def test_crypto_sell_and_discovery_surface_generic_place_order():
-    for intent in ("profit_taking", "discovery"):
-        plan = L.build_route_plan(
-            intent,
-            "crypto",
-            registered_tools=_CRYPTO_REGISTERED,
-            verdict_thresholds=_fake_thresholds("crypto", L.INTENT_TO_LANE[intent]),
-            policy_version=_VERSION,
-        )
-        assert "place_order" not in plan["blocked_actions"]
-        assert "place_order" in plan["allowed_tools"]
-        assert "place_order" in [s["tool"] for s in plan["standard_tool_sequence"]]
+@pytest.mark.parametrize("intent", ["buy_analysis", "profit_taking"])
+def test_crypto_proposal_lanes_never_restore_generic_place_order(intent: str):
+    registered = _CRYPTO_REGISTERED | {"order_proposal_create"}
+    plan = _plan(intent, "crypto", registered=registered)
 
-
-def test_crypto_market_brief_still_blocks_all_mutation():
-    # bootstrap has no execution step -> even crypto's place_order stays blocked
-    plan = L.build_route_plan(
-        "market_brief",
-        "crypto",
-        registered_tools=_CRYPTO_REGISTERED,
-        verdict_thresholds=_fake_thresholds("crypto", "bootstrap", empty=True),
-        policy_version=_VERSION,
-    )
-    assert "place_order" in plan["blocked_actions"]
-    assert set(plan["blocked_actions"]) == (L.MUTATION_TOOLS & _CRYPTO_REGISTERED)
-
-
-def test_kr_buy_still_blocks_generic_place_order_no_regression():
-    # KR routes execution through toss/kis; the generic place_order stays blocked.
-    plan = L.build_route_plan(
-        "buy_analysis",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "buy"),
-        policy_version=_VERSION,
-    )
-    assert "place_order" in plan["blocked_actions"]
+    assert plan["success"] is True
+    assert "place_order" not in _step_tools(plan)
     assert "place_order" not in plan["allowed_tools"]
-    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
-    assert "place_order" not in steps
-    # KR execution tools are still the sanctioned, non-blocked path
-    assert "toss_place_order" not in plan["blocked_actions"]
+    assert "place_order" in plan["blocked_actions"]
 
 
-def test_hard_constraints_reference_policy_keys_not_numbers():
-    plan = L.build_route_plan(
-        "buy_analysis",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "buy"),
-        policy_version=_VERSION,
-    )
-    joined = " ".join(plan["hard_constraints"])
-    assert "sell.loss_guard_min_multiple" in joined
-    assert "1.01" not in joined
+def test_hard_constraints_reference_policy_and_proposal_contract():
+    buy = " ".join(_plan("buy_analysis", "kr")["hard_constraints"])
+    sell = " ".join(_plan("profit_taking", "kr")["hard_constraints"])
+
+    assert "sell.loss_guard_min_multiple" in buy
+    assert "1.01" not in buy
+    for joined in (buy, sell):
+        assert "order_proposal_create" in joined
+        assert "Telegram human approval" in joined
+        assert "broker evidence" in joined
+        assert "toss_place_order" not in joined
+        assert "kis_live_place_order" not in joined
+        assert "toss_cancel_order" not in joined
 
 
 def test_buy_discovery_have_negative_class_constraint():
-    # ROB-712 — buy + discovery lanes must encode the negative-class recording
-    # convention: deferred_no_action items keep confidence + a resolvable
-    # forecast so calibration isn't censored.
     for lane in ("buy", "discovery"):
         joined = " ".join(L.HARD_CONSTRAINTS[lane]).lower()
         assert "deferred_no_action" in joined
         assert "confidence" in joined
         assert "forecast" in joined
         assert "outcome_rule_version='window-touch-v1-high-gte-low-lte'" in joined
-
-
-# --- ROB-660: sell lane account routing ---------------------------------------
-
-
-def test_sell_lane_surfaces_kis_place_and_toss_cancel_as_steps():
-    plan = L.build_route_plan(
-        "profit_taking",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "sell"),
-        policy_version=_VERSION,
-    )
-    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
-    for tool in ("toss_cancel_order", "kis_live_place_order"):
-        assert tool in steps, tool
-        assert tool in plan["allowed_tools"], tool
-        assert tool not in plan["blocked_actions"], tool
-    # step numbers stay contiguous 1..n after the two inserts
-    assert [s["step"] for s in plan["standard_tool_sequence"]] == list(
-        range(1, len(steps) + 1)
-    )
-
-
-def test_sell_lane_history_helpers_allowed_but_not_sequenced():
-    plan = L.build_route_plan(
-        "profit_taking",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "sell"),
-        policy_version=_VERSION,
-    )
-    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
-    for tool in ("kis_live_get_order_history", "toss_get_order_history"):
-        assert tool in plan["allowed_tools"], tool
-        assert tool not in plan["blocked_actions"], tool
-        assert tool not in steps, tool
-
-
-def test_buy_lane_history_helpers_allowed_but_not_sequenced():
-    # ROB-666: buy lane needs the order-status helpers to confirm a buy fill and
-    # to check KIS regular-session survival after 15:30 (ROB-657 rule). Symmetric
-    # to the sell-lane allowance (ROB-660): allowed, never in the ordered sequence.
-    plan = L.build_route_plan(
-        "buy_analysis",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "buy"),
-        policy_version=_VERSION,
-    )
-    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
-    for tool in ("kis_live_get_order_history", "toss_get_order_history"):
-        assert tool in plan["allowed_tools"], tool
-        assert tool not in plan["blocked_actions"], tool
-        assert tool not in steps, tool
-
-
-def test_sell_lane_routing_does_not_leak_into_buy_lane():
-    buy = L.build_route_plan(
-        "buy_analysis",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "buy"),
-        policy_version=_VERSION,
-    )
-    # sell-lane-only execution tools remain blocked in the buy lane (no cross-lane
-    # leak). The order-history helpers are now allowed in both lanes (ROB-666), so
-    # they are asserted separately in test_buy_lane_history_helpers_allowed_*.
-    assert "toss_cancel_order" in buy["blocked_actions"]
-
-
-def test_sell_lane_new_kr_tools_dropped_when_unregistered_on_crypto():
-    plan = L.build_route_plan(
-        "profit_taking",
-        "crypto",
-        registered_tools=_CRYPTO_REGISTERED,
-        verdict_thresholds=_fake_thresholds("crypto", "sell"),
-        policy_version=_VERSION,
-    )
-    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
-    assert "toss_cancel_order" not in steps
-    assert "kis_live_place_order" not in steps
-    assert "toss_cancel_order" not in plan["allowed_tools"]
-    # ROB-658 generic execution injection still fires on crypto sell
-    assert "place_order" in steps
-    assert "place_order" not in plan["blocked_actions"]
-
-
-def test_sell_lane_hard_constraints_document_routing_and_cancel_first():
-    plan = L.build_route_plan(
-        "profit_taking",
-        "kr",
-        registered_tools=_ALL,
-        verdict_thresholds=_fake_thresholds("kr", "sell"),
-        policy_version=_VERSION,
-    )
-    joined = " ".join(plan["hard_constraints"])
-    assert "holding account" in joined
-    assert "kis_live_place_order" in joined
-    assert "toss_cancel_order" in joined

--- a/tests/test_route_request_registry_diff.py
+++ b/tests/test_route_request_registry_diff.py
@@ -1,27 +1,34 @@
-"""Registry-diff guard for route_request lane classification (ROB-649).
+"""Registry and ordered-playbook drift guards for route_request.
 
 Forces every DEFAULT-profile tool into exactly one of two disjoint buckets
 (READ_ONLY_ADVISORY_TOOLS vs MUTATION_TOOLS): a new unclassified tool makes the
 partition non-total and fails CI (the silent-drift guard the issue requires,
 motivated by the trade_profile tools that sat unregistered for months). Lane
-membership is a cross-cutting label — each lane tool is itself either read-only
-or a mutation tool — so it is validated separately against the playbook.
+membership is validated in order against the playbook. ROB-1045 also partitions
+the legacy mutation bucket into explicit action classes so a new direct broker
+mutation cannot silently become route-allowed.
 """
 
 from __future__ import annotations
 
 import re
+from itertools import combinations
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
 
+from app.core.config import settings
 from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_automated_orders import (
+    ALPACA_PAPER_AUTOMATED_TOOL_NAMES,
+)
 from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
 from app.mcp_server.tooling.market_quote_snapshot_tools import (
     MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
 )
+from app.mcp_server.tooling.order_proposal_tools import ORDER_PROPOSAL_TOOL_NAMES
 from app.mcp_server.tooling.orders_kiwoom_us_variants import (
     KIWOOM_MOCK_US_MUTATION_TOOL_NAMES,
     KIWOOM_MOCK_US_READ_TOOL_NAMES,
@@ -29,10 +36,17 @@ from app.mcp_server.tooling.orders_kiwoom_us_variants import (
 from app.mcp_server.tooling.registry import register_all_tools
 from app.mcp_server.tooling.route_request_lanes import (
     ALL_KNOWN_TOOLS,
+    DIRECT_BROKER_MUTATION_TOOLS,
     LANE_SEQUENCES,
     MUTATION_TOOLS,
+    ORDER_PROPOSAL_READ_TOOLS,
+    PREVIEW_REVALIDATION_TOOLS,
+    PROPOSAL_LED_TOOLS,
+    PROPOSAL_LIFECYCLE_TOOLS,
     READ_ONLY_ADVISORY_TOOLS,
-    lane_tool_names,
+    RECONCILE_TOOLS,
+    STATUS_HELPER_TOOLS,
+    ordered_lane_tool_names,
 )
 from app.mcp_server.tooling.us_dual_paper import US_DUAL_PAPER_TOOL_NAMES
 from tests._mcp_tooling_support import DummyMCP
@@ -66,14 +80,14 @@ def _collect_tool_refs(node: Any) -> list[str]:
     return found
 
 
-def _playbook_lane_tools() -> dict[str, set[str]]:
+def _playbook_lane_tools() -> dict[str, list[str]]:
     text = _PLAYBOOK_PATH.read_text(encoding="utf-8")
-    per_lane: dict[str, set[str]] = {}
+    per_lane: dict[str, list[str]] = {}
     for block in _YAML_BLOCK_RE.findall(text):
         parsed = yaml.safe_load(block)
         if isinstance(parsed, dict) and isinstance(parsed.get("lanes"), dict):
             for lane, body in parsed["lanes"].items():
-                per_lane.setdefault(lane, set()).update(_collect_tool_refs(body))
+                per_lane.setdefault(lane, []).extend(_collect_tool_refs(body))
     return per_lane
 
 
@@ -81,6 +95,76 @@ def test_buckets_are_disjoint():
     assert READ_ONLY_ADVISORY_TOOLS.isdisjoint(MUTATION_TOOLS)
     assert KIWOOM_MOCK_US_READ_TOOL_NAMES <= READ_ONLY_ADVISORY_TOOLS
     assert KIWOOM_MOCK_US_MUTATION_TOOL_NAMES <= MUTATION_TOOLS
+
+
+def test_mutation_action_taxonomy_is_disjoint_and_total():
+    action_classes = (
+        DIRECT_BROKER_MUTATION_TOOLS,
+        PROPOSAL_LED_TOOLS,
+        PROPOSAL_LIFECYCLE_TOOLS,
+        PREVIEW_REVALIDATION_TOOLS,
+        RECONCILE_TOOLS,
+        STATUS_HELPER_TOOLS,
+    )
+    for left, right in combinations(action_classes, 2):
+        assert left.isdisjoint(right)
+    assert frozenset().union(*action_classes) == MUTATION_TOOLS
+
+    direct_name_candidates = {
+        name
+        for name in MUTATION_TOOLS
+        if any(
+            marker in name
+            for marker in (
+                "place_order",
+                "modify_order",
+                "cancel_order",
+                "submit_order",
+                "submit_decision",
+                "execute_report",
+                "place_limit_order",
+                "cancel_pending_order",
+            )
+        )
+    }
+    assert direct_name_candidates == DIRECT_BROKER_MUTATION_TOOLS
+
+
+def test_registered_direct_surfaces_are_classified_across_route_profiles(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "alpaca_paper_default_tools_enabled", True)
+    monkeypatch.setattr(settings, "binance_demo_scalping_enabled", True)
+
+    direct_markers = (
+        "place_order",
+        "modify_order",
+        "cancel_order",
+        "submit_order",
+        "submit_decision",
+        "execute_report",
+        "place_limit_order",
+        "cancel_pending_order",
+    )
+    for profile in McpProfile:
+        mcp = DummyMCP()
+        register_all_tools(cast(Any, mcp), profile=profile)
+        if "route_request" not in mcp.tools:
+            continue
+        registered_direct = {
+            name
+            for name in mcp.tools
+            if any(marker in name for marker in direct_markers)
+        }
+        assert registered_direct <= DIRECT_BROKER_MUTATION_TOOLS, (
+            f"{profile.value} has unclassified direct mutations: "
+            f"{sorted(registered_direct - DIRECT_BROKER_MUTATION_TOOLS)}"
+        )
+
+    assert "alpaca_paper_automated_submit_order" in DIRECT_BROKER_MUTATION_TOOLS
+    assert "alpaca_paper_automated_preview_order" in PREVIEW_REVALIDATION_TOOLS
+    assert ALPACA_PAPER_AUTOMATED_TOOL_NAMES <= MUTATION_TOOLS
+    assert "binance_demo_scalping_submit_decision" in DIRECT_BROKER_MUTATION_TOOLS
 
 
 def test_every_default_tool_is_classified():
@@ -91,6 +175,21 @@ def test_every_default_tool_is_classified():
         "(add to READ_ONLY_ADVISORY_TOOLS or the appropriate mutation set): "
         f"{sorted(unclassified)}"
     )
+
+
+def test_every_proposal_enabled_default_tool_is_classified(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
+    default = _default_tools()
+
+    assert ORDER_PROPOSAL_TOOL_NAMES <= default
+    assert default <= ALL_KNOWN_TOOLS
+    assert ORDER_PROPOSAL_TOOL_NAMES == (
+        ORDER_PROPOSAL_READ_TOOLS | PROPOSAL_LED_TOOLS | PROPOSAL_LIFECYCLE_TOOLS
+    )
+    assert ORDER_PROPOSAL_READ_TOOLS <= READ_ONLY_ADVISORY_TOOLS
+    assert PROPOSAL_LED_TOOLS | PROPOSAL_LIFECYCLE_TOOLS <= MUTATION_TOOLS
 
 
 def test_read_only_bucket_has_no_phantom_tools():
@@ -109,6 +208,7 @@ def test_read_only_bucket_has_no_phantom_tools():
         *US_DUAL_PAPER_TOOL_NAMES,
         *KIWOOM_MOCK_US_READ_TOOL_NAMES,
         *MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
+        *ORDER_PROPOSAL_READ_TOOLS,
     }
     phantom = READ_ONLY_ADVISORY_TOOLS - default - _FLAG_GATED_OR_OPTIONAL
     assert not phantom, (
@@ -121,20 +221,24 @@ def test_partition_is_total_at_default_settings():
     assert default == (READ_ONLY_ADVISORY_TOOLS | MUTATION_TOOLS) & default
 
 
-def test_lane_sequences_match_playbook():
+def test_lane_sequences_match_playbook_in_exact_order():
     playbook = _playbook_lane_tools()
     for lane in LANE_SEQUENCES:
         assert lane in playbook, f"lane {lane!r} missing from playbook"
-        assert lane_tool_names(lane) == playbook[lane], (
+        assert ordered_lane_tool_names(lane) == playbook[lane], (
             f"lane {lane!r} drifted from playbook: "
-            f"code={sorted(lane_tool_names(lane))} playbook={sorted(playbook[lane])}"
+            f"code={ordered_lane_tool_names(lane)} playbook={playbook[lane]}"
+        )
+        assert len(playbook[lane]) == len(set(playbook[lane])), (
+            f"lane {lane!r} has duplicate playbook steps: {playbook[lane]}"
         )
 
 
-def test_lane_tools_registered_in_default():
+def test_lane_tools_registered_in_proposal_enabled_default(monkeypatch):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_ENABLED", True)
     default = _default_tools()
     for lane in LANE_SEQUENCES:
-        missing = lane_tool_names(lane) - default
+        missing = set(ordered_lane_tool_names(lane)) - default
         assert not missing, (
             f"lane {lane!r} references unregistered tools: {sorted(missing)}"
         )


### PR DESCRIPTION
## Decisions

1. Discovery is out of scope for ROB-1045. Its existing `toss_place_order` step and ROB-658 crypto/US generic `place_order` injection are preserved as non-regression; proposal-led discovery needs a separate issue.
2. The buy/sell `route_contract` declares that a human Telegram approval click is required after `order_proposal_create`. The route remains advisory and cannot physically prevent configured auto-approval; `approval_dispatch` remains runtime truth.
3. A buy/sell profile without `order_proposal_create` fails closed with `success=false`, `error="required_route_tool_unavailable"`, and `execution_ready=false`.
4. Registry-degraded responses retain the static direct-mutation `blocked_actions` list and add `blocked_actions_basis="static_fail_closed"`.

## Changes

- Replaced buy/sell direct place/cancel steps with `order_proposal_create` as the only order-intent surface.
- Added the `proposal-led-v1` machine-readable route contract, including required/missing tools, Telegram approval, preview ownership, and broker-evidence reconcile requirement.
- Added explicit direct/proposal/preview/reconcile/status action taxonomy and guaranteed every registered direct mutation is blocked and disjoint from buy/sell allowed tools.
- Removed the `ALL_KNOWN_TOOLS` registry fallback; missing, raising, malformed, and empty registry introspection now return a stable fail-closed envelope.
- Kept discovery direct execution unchanged.
- Synchronized the ordered playbook YAML/prose and the narrow MCP README route section.
- Added mutation-sensitive 12-cell route, registry, profile, taxonomy, and ordered playbook drift coverage.

## Verification

- Targeted route/profile suite: `184 passed`
  - `uv run pytest tests/test_route_request.py tests/test_route_request_lanes.py tests/test_route_request_registry_diff.py tests/test_playbook_tool_names.py tests/test_mcp_profiles.py -q`
- Full unit suite: `16907 passed, 9 skipped, 1178 deselected`
  - `uv run pytest tests/ -q -m "not integration and not slow"`
- `uv run ruff check app/ tests/`
- `uv run ruff format --check app/ tests/`
- `uv run ty check app/mcp_server/tooling`
- `git diff --check`

Migration: 0. Live order mutation: 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buy and sell workflows now use order proposals with required human approval before execution.
  * Proposal flows support place, cancel, and replace intents, with broker-evidence reconciliation.
  * Route details now clearly indicate execution mode, approval requirements, and readiness.

* **Bug Fixes**
  * Missing or unavailable required tools now fail safely without falling back to direct order execution.
  * Improved handling of unavailable or malformed tool information.

* **Documentation**
  * Updated trading playbooks and routing guidance to reflect proposal-led workflows and approval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->