### PR TITLE
chore: fix ruff violations in research/ and scripts/

### DIFF
--- a/research/nautilus_scalping/artifact_paths.py
+++ b/research/nautilus_scalping/artifact_paths.py
@@ -40,5 +40,9 @@ def pit_data_root() -> Path:
     ``resolve_artifact_path`` (citable discovery/gate outputs). Env if set
     (non-blank), else repo-internal ``data/`` (matched by ``.gitignore``)."""
     raw = os.environ.get(ENV_VAR)
-    base = Path(raw.strip()) if raw is not None and raw.strip() else Path(__file__).resolve().parent
+    base = (
+        Path(raw.strip())
+        if raw is not None and raw.strip()
+        else Path(__file__).resolve().parent
+    )
     return base / "data"

--- a/research/nautilus_scalping/audit_derivatives_feasibility.py
+++ b/research/nautilus_scalping/audit_derivatives_feasibility.py
@@ -130,8 +130,12 @@ def _get(url: str, timeout: int = 60) -> bytes:
 def list_data_types(granularity: str) -> list[str]:
     """CommonPrefixes (data types) under ``futures/um/<granularity>/``."""
     prefix = f"data/futures/um/{granularity}/"
-    xml = _get(S3 + "?" + urllib.parse.urlencode({"delimiter": "/", "prefix": prefix})).decode()
-    return sorted(re.findall(r"<Prefix>" + re.escape(prefix) + r"([^/<]+)/</Prefix>", xml))
+    xml = _get(
+        S3 + "?" + urllib.parse.urlencode({"delimiter": "/", "prefix": prefix})
+    ).decode()
+    return sorted(
+        re.findall(r"<Prefix>" + re.escape(prefix) + r"([^/<]+)/</Prefix>", xml)
+    )
 
 
 def list_periods(prefix: str, pat: str) -> list[str]:
@@ -222,10 +226,14 @@ def probe(symbols: tuple[tuple[str, str | None], ...] = PROBE_SYMBOLS) -> dict:
 
     # deterministic verdicts (raw_evidence flags: funding/OI raw; liquidation none here)
     fund_dead_ok = all(
-        v["survivorship_ok"] for s, v in summary["funding"].items() if dict(symbols).get(s)
+        v["survivorship_ok"]
+        for s, v in summary["funding"].items()
+        if dict(symbols).get(s)
     )
     oi_dead_ok = all(
-        v["survivorship_ok"] for s, v in summary["open_interest"].items() if dict(symbols).get(s)
+        v["survivorship_ok"]
+        for s, v in summary["open_interest"].items()
+        if dict(symbols).get(s)
     )
     summary["verdicts"] = {
         "funding_only_baseline": classify_verdict(
@@ -236,14 +244,18 @@ def probe(symbols: tuple[tuple[str, str | None], ...] = PROBE_SYMBOLS) -> dict:
         ),
         "liquidation": classify_verdict(FamilySignals(liq_present, True, False)),
         "liquidity_sweep": classify_verdict(
-            FamilySignals(True, False, False)  # trade/banded-depth present but not raw L2
+            FamilySignals(
+                True, False, False
+            )  # trade/banded-depth present but not raw L2
         ),
     }
     return summary
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="ROB-355 derivatives data feasibility probe (read-only).")
+    parser = argparse.ArgumentParser(
+        description="ROB-355 derivatives data feasibility probe (read-only)."
+    )
     parser.add_argument(
         "--out",
         action="store_true",
@@ -257,12 +269,12 @@ def main(argv: list[str] | None = None) -> int:
     print("\nfunding (monthly) / open_interest (daily metrics) coverage:")
     for sym, _ in PROBE_SYMBOLS:
         fr, oi = s["funding"][sym]["range"], s["open_interest"][sym]["range"]
-        frs = f'{fr["first"]}..{fr["last"]} ({fr["count"]}mo)' if fr else "NONE"
-        ois = f'{oi["first"]}..{oi["last"]} ({oi["count"]}d)' if oi else "NONE"
+        frs = f"{fr['first']}..{fr['last']} ({fr['count']}mo)" if fr else "NONE"
+        ois = f"{oi['first']}..{oi['last']} ({oi['count']}d)" if oi else "NONE"
         print(
-            f'  {sym:14} funding={frs:24} oi={ois:26}'
-            f' surv(f/oi)={int(s["funding"][sym]["survivorship_ok"])}/'
-            f'{int(s["open_interest"][sym]["survivorship_ok"])}'
+            f"  {sym:14} funding={frs:24} oi={ois:26}"
+            f" surv(f/oi)={int(s['funding'][sym]['survivorship_ok'])}/"
+            f"{int(s['open_interest'][sym]['survivorship_ok'])}"
         )
     print("\nsamples:", json.dumps(s["samples"]))
     print("verdicts:", json.dumps(s["verdicts"], indent=2))
@@ -270,7 +282,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.out:
         from artifact_paths import resolve_artifact_path
 
-        out = resolve_artifact_path("discovery", "rob355", "derivatives_feasibility.v1.json")
+        out = resolve_artifact_path(
+            "discovery", "rob355", "derivatives_feasibility.v1.json"
+        )
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(json.dumps(s, indent=2))
         print(f"\nsummary written (gitignored): {out}")

--- a/research/nautilus_scalping/backtest.py
+++ b/research/nautilus_scalping/backtest.py
@@ -132,20 +132,30 @@ def _report(engine, instrument, symbol: str, export_path: Path | None) -> None:
     print(f"BACKTEST RESULTS — {symbol} (spot, tick-level)")
     print("=" * 48)
     print(f"trades:            {len(rows)}")
-    print(f"win_rate:          {len(wins) / len(rows) * 100:.1f}%  ({len(wins)}/{len(rows)})")
+    print(
+        f"win_rate:          {len(wins) / len(rows) * 100:.1f}%  ({len(wins)}/{len(rows)})"
+    )
     print(f"gross_pnl_usdt:    {sum(gross):+.4f}")
     print(f"total_fees_usdt:   {sum(fees):.4f}")
     print(f"NET_pnl_usdt:      {sum(net):+.4f}")
-    print(f"profit_factor:     {(gross_win / gross_loss) if gross_loss else float('inf'):.2f}")
+    print(
+        f"profit_factor:     {(gross_win / gross_loss) if gross_loss else float('inf'):.2f}"
+    )
     print(f"avg_net_per_trade: {statistics.mean(net):+.4f} usdt")
-    print(f"avg_net_return:    {statistics.mean([r['net_return_bps'] for r in rows]):+.2f} bps")
-    print(f"avg_win / avg_loss:{(statistics.mean(wins) if wins else 0):+.4f} / "
-          f"{(statistics.mean(losses) if losses else 0):+.4f} usdt")
+    print(
+        f"avg_net_return:    {statistics.mean([r['net_return_bps'] for r in rows]):+.2f} bps"
+    )
+    print(
+        f"avg_win / avg_loss:{(statistics.mean(wins) if wins else 0):+.4f} / "
+        f"{(statistics.mean(losses) if losses else 0):+.4f} usdt"
+    )
     print(f"max_drawdown_usdt: {_max_drawdown(net):.4f}")
     print(f"avg_holding_sec:   {statistics.mean(holds):.0f}")
     print("=" * 48)
-    print("NOTE: gross vs net separated; net is after taker fees. "
-          "30/20bps TP/SL means fees dominate — read NET only.")
+    print(
+        "NOTE: gross vs net separated; net is after taker fees. "
+        "30/20bps TP/SL means fees dominate — read NET only."
+    )
 
     if export_path:
         export_path.parent.mkdir(parents=True, exist_ok=True)

--- a/research/nautilus_scalping/backtest_runner.py
+++ b/research/nautilus_scalping/backtest_runner.py
@@ -9,6 +9,7 @@ reference fee. Net at any fee is recomputed by validated_gate analytically.
 Nautilus is imported LAZILY inside the child only, so importing this module in
 the pure test layer is cheap and venv-free at import time.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -25,19 +26,29 @@ from validated_gate import Trade
 _SENTINEL = "RESULT_JSON "
 
 
-def _window_bounds_ns(window_from: str, window_to: str) -> tuple[int | None, int | None]:
+def _window_bounds_ns(
+    window_from: str, window_to: str
+) -> tuple[int | None, int | None]:
     """Parse YYYY-MM-DD window edges to epoch-ns; 'to' date inclusive ([lo, hi)).
 
     Stdlib-only (keeps this module venv-free at import) and integer-exact; matches
     discovery.data.window_bounds_ns so the Nautilus path and the discovery path
     interpret --window-from/--window-to identically.
     """
+
     def _to_ns(s: str, *, plus_one_day: bool = False) -> int:
         dt = datetime.strptime(s.strip(), "%Y-%m-%d").replace(tzinfo=UTC)
-        return int((dt + timedelta(days=1) if plus_one_day else dt).timestamp()) * 1_000_000_000
+        return (
+            int((dt + timedelta(days=1) if plus_one_day else dt).timestamp())
+            * 1_000_000_000
+        )
 
     lo = _to_ns(window_from) if window_from and window_from.strip() else None
-    hi = _to_ns(window_to, plus_one_day=True) if window_to and window_to.strip() else None
+    hi = (
+        _to_ns(window_to, plus_one_day=True)
+        if window_to and window_to.strip()
+        else None
+    )
     return lo, hi
 
 
@@ -46,13 +57,23 @@ def _filter_ticks_window(ticks, ts_from: int | None, ts_to: int | None):
     engine.add_data so the window constrains processed data, not just metadata."""
     if ts_from is None and ts_to is None:
         return ticks
-    return [t for t in ticks
-            if (ts_from is None or t.ts_event >= ts_from)
-            and (ts_to is None or t.ts_event < ts_to)]
+    return [
+        t
+        for t in ticks
+        if (ts_from is None or t.ts_event >= ts_from)
+        and (ts_to is None or t.ts_event < ts_to)
+    ]
 
 
-def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str,
-                window_from: str = "", window_to: str = "") -> None:
+def _run_single(
+    catalog: Path,
+    symbol: str,
+    strategy: str,
+    params: dict,
+    trade_size: str,
+    window_from: str = "",
+    window_to: str = "",
+) -> None:
     from nautilus_trader.backtest.engine import BacktestEngine, BacktestEngineConfig
     from nautilus_trader.config import LoggingConfig
     from nautilus_trader.model.currencies import USDT
@@ -64,7 +85,9 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
     from nautilus_trader.persistence.catalog import ParquetDataCatalog
 
     catalog_obj = ParquetDataCatalog(str(catalog))
-    instrument = next(i for i in catalog_obj.instruments() if i.id.value.startswith(symbol))
+    instrument = next(
+        i for i in catalog_obj.instruments() if i.id.value.startswith(symbol)
+    )
     ticks = catalog_obj.trade_ticks(instrument_ids=[instrument.id.value])
     lo, hi = _window_bounds_ns(window_from, window_to)
     ticks = _filter_ticks_window(ticks, lo, hi)  # real window constraint (pre-add_data)
@@ -76,51 +99,92 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
         # entry + the TP leg, taker 4bps on the SL leg). Keeps the gate-feeding net exact
         # without relying on a single Nautilus commission rate for the mixed maker/taker mix.
         instrument = CurrencyPair(
-            instrument_id=instrument.id, raw_symbol=instrument.raw_symbol,
-            base_currency=instrument.base_currency, quote_currency=instrument.quote_currency,
-            price_precision=instrument.price_precision, size_precision=instrument.size_precision,
-            price_increment=instrument.price_increment, size_increment=instrument.size_increment,
-            lot_size=instrument.lot_size, max_quantity=instrument.max_quantity,
-            min_quantity=instrument.min_quantity, max_notional=instrument.max_notional,
-            min_notional=instrument.min_notional, max_price=instrument.max_price,
-            min_price=instrument.min_price, margin_init=instrument.margin_init,
+            instrument_id=instrument.id,
+            raw_symbol=instrument.raw_symbol,
+            base_currency=instrument.base_currency,
+            quote_currency=instrument.quote_currency,
+            price_precision=instrument.price_precision,
+            size_precision=instrument.size_precision,
+            price_increment=instrument.price_increment,
+            size_increment=instrument.size_increment,
+            lot_size=instrument.lot_size,
+            max_quantity=instrument.max_quantity,
+            min_quantity=instrument.min_quantity,
+            max_notional=instrument.max_notional,
+            min_notional=instrument.min_notional,
+            max_price=instrument.max_price,
+            min_price=instrument.min_price,
+            margin_init=instrument.margin_init,
             margin_maint=instrument.margin_maint,
-            maker_fee=Decimal("0"), taker_fee=Decimal("0"),
-            ts_event=0, ts_init=0)
+            maker_fee=Decimal("0"),
+            taker_fee=Decimal("0"),
+            ts_event=0,
+            ts_init=0,
+        )
 
-    engine = BacktestEngine(config=BacktestEngineConfig(
-        trader_id="ROB320-001", logging=LoggingConfig(log_level="ERROR")))
+    engine = BacktestEngine(
+        config=BacktestEngineConfig(
+            trader_id="ROB320-001", logging=LoggingConfig(log_level="ERROR")
+        )
+    )
 
     # Both modes use ROB-320's venue: HEDGING is fine because every exit is an explicit
     # market close_all_positions (OMS-agnostic) — maker mode no longer rests a TP limit,
     # so the earlier counter-position problem is gone. Taker reproduces ROB-320 exactly
     # (789 trades, net@10bps -209.71).
-    engine.add_venue(venue=Venue("BINANCE"), oms_type=OmsType.HEDGING,
-                     account_type=AccountType.CASH, base_currency=None,
-                     starting_balances=[Money(10_000_000, USDT)])
+    engine.add_venue(
+        venue=Venue("BINANCE"),
+        oms_type=OmsType.HEDGING,
+        account_type=AccountType.CASH,
+        base_currency=None,
+        starting_balances=[Money(10_000_000, USDT)],
+    )
     engine.add_instrument(instrument)
     engine.add_data(ticks)
     bar_type = BarType.from_str(f"{instrument.id.value}-1-MINUTE-LAST-INTERNAL")
 
     if strategy == "micro_breakout":
         from strategy_breakout import BreakoutScalper, BreakoutScalperConfig
-        strat = BreakoutScalper(BreakoutScalperConfig(
-            instrument_id=instrument.id, bar_type=bar_type, trade_size=trade_size,
-            tp_bps=int(params.get("tp_bps", 30)), sl_bps=int(params.get("sl_bps", 20))))
+
+        strat = BreakoutScalper(
+            BreakoutScalperConfig(
+                instrument_id=instrument.id,
+                bar_type=bar_type,
+                trade_size=trade_size,
+                tp_bps=int(params.get("tp_bps", 30)),
+                sl_bps=int(params.get("sl_bps", 20)),
+            )
+        )
     elif strategy == "meanrev_zscore_fade":
         from strategy_meanrev import MeanRevScalper, MeanRevScalperConfig
-        strat = MeanRevScalper(MeanRevScalperConfig(
-            instrument_id=instrument.id, bar_type=bar_type, trade_size=trade_size,
-            lookback=int(params.get("lookback", 20)), z_entry=str(params.get("z_entry", "2.0")),
-            tp_bps=int(params.get("tp_bps", 30)), sl_bps=int(params.get("sl_bps", 30)),
-            require_vol=bool(params.get("require_vol", True)),
-            execution_mode=execution_mode))
+
+        strat = MeanRevScalper(
+            MeanRevScalperConfig(
+                instrument_id=instrument.id,
+                bar_type=bar_type,
+                trade_size=trade_size,
+                lookback=int(params.get("lookback", 20)),
+                z_entry=str(params.get("z_entry", "2.0")),
+                tp_bps=int(params.get("tp_bps", 30)),
+                sl_bps=int(params.get("sl_bps", 30)),
+                require_vol=bool(params.get("require_vol", True)),
+                execution_mode=execution_mode,
+            )
+        )
     elif strategy == "random_entry":
         from strategy_random import RandomScalper, RandomScalperConfig
-        strat = RandomScalper(RandomScalperConfig(
-            instrument_id=instrument.id, bar_type=bar_type, trade_size=trade_size,
-            entry_prob=float(params.get("entry_prob", 0.02)), seed=int(params.get("seed", 42)),
-            tp_bps=int(params.get("tp_bps", 30)), sl_bps=int(params.get("sl_bps", 30))))
+
+        strat = RandomScalper(
+            RandomScalperConfig(
+                instrument_id=instrument.id,
+                bar_type=bar_type,
+                trade_size=trade_size,
+                entry_prob=float(params.get("entry_prob", 0.02)),
+                seed=int(params.get("seed", 42)),
+                tp_bps=int(params.get("tp_bps", 30)),
+                sl_bps=int(params.get("sl_bps", 30)),
+            )
+        )
     else:
         raise SystemExit(f"unknown strategy {strategy}")
 
@@ -148,14 +212,36 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
     print(_SENTINEL + json.dumps({"trades": trades}))
 
 
-def run(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str = "100",
-        window_from: str = "", window_to: str = "") -> list[Trade]:
+def run(
+    catalog: Path,
+    symbol: str,
+    strategy: str,
+    params: dict,
+    trade_size: str = "100",
+    window_from: str = "",
+    window_to: str = "",
+) -> list[Trade]:
     # We must explicitly use the python interpreter inside our research .venv and pass PYTHONPATH
     venv_python = sys.executable
-    cmd = [venv_python, os.path.abspath(__file__), "--single",
-           "--catalog", str(catalog), "--symbol", symbol, "--strategy", strategy,
-           "--params", json.dumps(params), "--trade-size", trade_size,
-           "--window-from", window_from, "--window-to", window_to]
+    cmd = [
+        venv_python,
+        os.path.abspath(__file__),
+        "--single",
+        "--catalog",
+        str(catalog),
+        "--symbol",
+        symbol,
+        "--strategy",
+        strategy,
+        "--params",
+        json.dumps(params),
+        "--trade-size",
+        trade_size,
+        "--window-from",
+        window_from,
+        "--window-to",
+        window_to,
+    ]
 
     # Propagate the current PYTHONPATH so we can resolve the app package inside the child process
     env = dict(os.environ)
@@ -167,37 +253,69 @@ def run(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str
     proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
     for line in proc.stdout.splitlines():
         if line.startswith(_SENTINEL):
-            raw = json.loads(line[len(_SENTINEL):])["trades"]
-            return [Trade(net_ref_pnl=r[0], commission_ref=r[1], notional=r[2], ts_opened=r[3])
-                    for r in raw]
+            raw = json.loads(line[len(_SENTINEL) :])["trades"]
+            return [
+                Trade(
+                    net_ref_pnl=r[0], commission_ref=r[1], notional=r[2], ts_opened=r[3]
+                )
+                for r in raw
+            ]
     raise RuntimeError(f"runner {strategy} on {symbol} failed:\n{proc.stderr[-800:]}")
 
 
-def run_maker(catalog: Path, symbol: str, params: dict, trade_size: str = "100",
-              window_from: str = "", window_to: str = ""):
+def run_maker(
+    catalog: Path,
+    symbol: str,
+    params: dict,
+    trade_size: str = "100",
+    window_from: str = "",
+    window_to: str = "",
+):
     """Run the maker re-sim; return (records, attempted, filled).
 
     records are maker_fill.MakerTradeRecord; attempted-filled = missed fills."""
     from maker_fill import MakerTradeRecord
+
     p = dict(params)
     p["execution_mode"] = "maker"
     venv_python = sys.executable
-    cmd = [venv_python, os.path.abspath(__file__), "--single", "--catalog", str(catalog),
-           "--symbol", symbol, "--strategy", "meanrev_zscore_fade",
-           "--params", json.dumps(p), "--trade-size", trade_size,
-           "--window-from", window_from, "--window-to", window_to]
+    cmd = [
+        venv_python,
+        os.path.abspath(__file__),
+        "--single",
+        "--catalog",
+        str(catalog),
+        "--symbol",
+        symbol,
+        "--strategy",
+        "meanrev_zscore_fade",
+        "--params",
+        json.dumps(p),
+        "--trade-size",
+        trade_size,
+        "--window-from",
+        window_from,
+        "--window-to",
+        window_to,
+    ]
     env = dict(os.environ)
     env["PYTHONPATH"] = env.get("PYTHONPATH", "") + os.pathsep + "../.."
     proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
     for line in proc.stdout.splitlines():
         if line.startswith(_SENTINEL):
-            data = json.loads(line[len(_SENTINEL):])
-            recs = [MakerTradeRecord(
-                gross=r["gross"], entry_notional=r["entry_notional"],
-                exit_notional=r["exit_notional"], ts_opened=r["ts"],
-                filled=r["filled"], tp_hit=r["tp_hit"],
-                adverse_excursion_bps=r["adverse_bps"])
-                for r in data["records"]]
+            data = json.loads(line[len(_SENTINEL) :])
+            recs = [
+                MakerTradeRecord(
+                    gross=r["gross"],
+                    entry_notional=r["entry_notional"],
+                    exit_notional=r["exit_notional"],
+                    ts_opened=r["ts"],
+                    filled=r["filled"],
+                    tp_hit=r["tp_hit"],
+                    adverse_excursion_bps=r["adverse_bps"],
+                )
+                for r in data["records"]
+            ]
             return recs, data["entries_attempted"], data["entries_filled"]
     raise RuntimeError(f"maker runner {symbol} failed:\n{proc.stderr[-800:]}")
 
@@ -214,8 +332,15 @@ def main() -> int:
     ap.add_argument("--window-to", default="")
     args = ap.parse_args()
     if args.single:
-        _run_single(args.catalog, args.symbol, args.strategy, json.loads(args.params),
-                    args.trade_size, args.window_from, args.window_to)
+        _run_single(
+            args.catalog,
+            args.symbol,
+            args.strategy,
+            json.loads(args.params),
+            args.trade_size,
+            args.window_from,
+            args.window_to,
+        )
         return 0
     raise SystemExit("backtest_runner is a library; use run() or --single")
 

--- a/research/nautilus_scalping/build_pit_universe.py
+++ b/research/nautilus_scalping/build_pit_universe.py
@@ -91,7 +91,11 @@ def boundary_active(
         return (None, None)
     z = zipfile.ZipFile(io.BytesIO(raw))
     data = z.read(z.namelist()[0]).decode()
-    rows = [r.split(",") for r in data.splitlines() if r and not r.lower().startswith("open_time")]
+    rows = [
+        r.split(",")
+        for r in data.splitlines()
+        if r and not r.lower().startswith("open_time")
+    ]
     days: list[tuple[str, float]] = []
     for r in rows:
         try:
@@ -202,7 +206,9 @@ def write_outputs(rows: list[dict], out_json: str) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Build ROB-353 PIT Binance USD-M universe index.")
+    parser = argparse.ArgumentParser(
+        description="Build ROB-353 PIT Binance USD-M universe index."
+    )
     parser.add_argument(
         "--exchange-info",
         default="/tmp/pit_audit_exchangeinfo.json",
@@ -237,7 +243,9 @@ def main(argv: list[str] | None = None) -> int:
     cf = Counter(r["confidence"] for r in rows)
     print("status :", dict(c))
     print("conf   :", dict(cf))
-    print("with funding:", sum(1 for r in rows if r["funding_months"] > 0), "/", len(rows))
+    print(
+        "with funding:", sum(1 for r in rows if r["funding_months"] > 0), "/", len(rows)
+    )
     print(
         "freeze-tail detected:",
         sum(1 for r in rows if "delisting_freeze_tail" in r["missing_data_reason"]),
@@ -254,10 +262,10 @@ def main(argv: list[str] | None = None) -> int:
             and "BUSD" not in r["symbol"]
         ):
             print(
-                f'  {r["symbol"]:14} {r["first_seen"]}..{r["last_seen"]}'
-                f'  active {r["active_from"]}..{r["active_to"]}'
-                f'  kcov={r["kline_coverage"]} fcov={r["funding_coverage"]}'
-                f'  conf={r["confidence"]} [{r["missing_data_reason"]}]'
+                f"  {r['symbol']:14} {r['first_seen']}..{r['last_seen']}"
+                f"  active {r['active_from']}..{r['active_to']}"
+                f"  kcov={r['kline_coverage']} fcov={r['funding_coverage']}"
+                f"  conf={r['confidence']} [{r['missing_data_reason']}]"
             )
     return 0
 

--- a/research/nautilus_scalping/campaign.py
+++ b/research/nautilus_scalping/campaign.py
@@ -26,11 +26,15 @@ from frozen_config import FROZEN_CONFIG, CampaignConfig
 SCHEMA_VERSION = "rob351_campaign.v1"
 
 
-def _gate_trade(data: list, fee_bps: float, min_trades: int) -> tuple[vg.GateReport, float, float, float]:
+def _gate_trade(
+    data: list, fee_bps: float, min_trades: int
+) -> tuple[vg.GateReport, float, float, float]:
     rep = vg.evaluate_gate(
         candidate_runs={"p": data},
-        baseline_breakout=[], baseline_random=[],
-        fee_bps=fee_bps, min_trades=min_trades,
+        baseline_breakout=[],
+        baseline_random=[],
+        fee_bps=fee_bps,
+        min_trades=min_trades,
     )
     gross = rep.results.get("gross", {}).get("net_pnl", 0.0)
     net = rep.results.get("net_after_cost", {}).get("net_pnl", 0.0)
@@ -38,10 +42,14 @@ def _gate_trade(data: list, fee_bps: float, min_trades: int) -> tuple[vg.GateRep
     return rep, gross, net, breakeven
 
 
-def _gate_portfolio(data: list, fee_bps: float, min_periods: int) -> tuple[vg.GateReport, float, float, float]:
+def _gate_portfolio(
+    data: list, fee_bps: float, min_periods: int
+) -> tuple[vg.GateReport, float, float, float]:
     rep = vg.evaluate_gate_portfolio(
-        candidate_runs={"p": data}, baseline_periods=[],
-        fee_bps=fee_bps, min_periods=min_periods,
+        candidate_runs={"p": data},
+        baseline_periods=[],
+        fee_bps=fee_bps,
+        min_periods=min_periods,
     )
     gross = rep.results.get("gross", {}).get("net_pnl", 0.0)
     net = rep.results.get("net_after_cost", {}).get("net_pnl", 0.0)
@@ -64,7 +72,8 @@ def run_campaign(
         name = spec["name"]
         summary = spec["summary"]
         classified = classify(
-            summary, cost_blind=True,
+            summary,
+            cost_blind=True,
             min_samples=min(summary.sample_count, min_trades) if min_trades else 1,
             min_gross_bps=config.economic_triviality_floor_bps,
         )
@@ -82,14 +91,17 @@ def run_campaign(
             continue
 
         if spec["kind"] == "portfolio":
-            rep, gross, net, breakeven = _gate_portfolio(spec["data"], fee_bps, min_trades)
+            rep, gross, net, breakeven = _gate_portfolio(
+                spec["data"], fee_bps, min_trades
+            )
         else:
             rep, gross, net, breakeven = _gate_trade(spec["data"], fee_bps, min_trades)
         row["gate_verdict"] = rep.verdict
         oos_significant = rep.verdict != "insufficient_data"
 
         verdict = rob343_label.label_343_candidate(
-            taker_net_pnl=net, gross_pnl=gross,
+            taker_net_pnl=net,
+            gross_pnl=gross,
             maker_conservative_net=(spec.get("maker_conservative_net") or 0.0),
             oos_significant=oos_significant,
             breakeven_taker_bps=breakeven,

--- a/research/nautilus_scalping/campaign_controls.py
+++ b/research/nautilus_scalping/campaign_controls.py
@@ -5,6 +5,7 @@ max drawdown, buy&hold return, and the survivorship-/quality-aware universe filt
 (membership overlap + manifest coverage/confidence). Dollar-volume liquidity
 filtering is intentionally NOT done here (disclosed as a skipped control).
 """
+
 from __future__ import annotations
 
 from collections.abc import Sequence
@@ -26,7 +27,9 @@ def buy_hold_bps(close_series: Sequence[tuple[int, float]]) -> float:
     return (last - first) / first * 1e4 if first else 0.0
 
 
-def max_drawdown_bps(period_net_pnls: Sequence[float], notional: float = 1000.0) -> float:
+def max_drawdown_bps(
+    period_net_pnls: Sequence[float], notional: float = 1000.0
+) -> float:
     equity = notional
     peak = notional
     worst = 0.0
@@ -38,12 +41,19 @@ def max_drawdown_bps(period_net_pnls: Sequence[float], notional: float = 1000.0)
     return worst
 
 
-def filter_universe(manifest: PITManifest, lo_ts: int, hi_ts: int,
-                    min_coverage: float = 0.8, confidences=("high", "medium")) -> list[str]:
+def filter_universe(
+    manifest: PITManifest,
+    lo_ts: int,
+    hi_ts: int,
+    min_coverage: float = 0.8,
+    confidences=("high", "medium"),
+) -> list[str]:
     """Symbols whose listing overlaps [lo_ts, hi_ts] with adequate data quality."""
     kept = []
     for x in manifest.listings:
-        overlaps = x.listed_from <= hi_ts and (x.delisted_at is None or x.delisted_at > lo_ts)
+        overlaps = x.listed_from <= hi_ts and (
+            x.delisted_at is None or x.delisted_at > lo_ts
+        )
         cov_ok = (x.kline_coverage or 0.0) >= min_coverage
         conf_ok = x.confidence in confidences
         if overlaps and cov_ok and conf_ok:

--- a/research/nautilus_scalping/campaign_specs.py
+++ b/research/nautilus_scalping/campaign_specs.py
@@ -7,6 +7,7 @@ report). No market data is read here — the harness passes already-loaded bars/
 
 Round-trip reference fee: 2 * 10.0 bps (taker in + taker out at cost_model.REF_FEE_BPS).
 """
+
 from __future__ import annotations
 
 from collections.abc import Sequence
@@ -17,37 +18,51 @@ from pit_universe import PITManifest
 from validated_gate import PortfolioPeriod, Trade
 
 NOTIONAL = 1000.0
-OOS_SPLIT_TS = 1_735_689_600_000  # 2025-01-01T00:00:00Z in epoch ms (ROB-349 train/test boundary)
+OOS_SPLIT_TS = (
+    1_735_689_600_000  # 2025-01-01T00:00:00Z in epoch ms (ROB-349 train/test boundary)
+)
 
 
 def _mean(xs: list[float]) -> float:
     return sum(xs) / len(xs) if xs else 0.0
 
 
-def _summary_from_trades(name: str, trades: Sequence[Trade], oos_split_ts: int) -> HypothesisSummary:
+def _summary_from_trades(
+    name: str, trades: Sequence[Trade], oos_split_ts: int
+) -> HypothesisSummary:
     gross = [(t.net_ref_pnl + t.commission_ref) / t.notional * 1e4 for t in trades]
     net = [t.net_ref_pnl / t.notional * 1e4 for t in trades]
-    oos_g = [g for g, t in zip(gross, trades, strict=True) if t.ts_opened > oos_split_ts]
+    oos_g = [
+        g for g, t in zip(gross, trades, strict=True) if t.ts_opened > oos_split_ts
+    ]
     oos_n = [n for n, t in zip(net, trades, strict=True) if t.ts_opened > oos_split_ts]
     return HypothesisSummary(
-        name=name, conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
+        name=name,
+        conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
         sample_count=len(trades),
-        gross_expectancy_bps=_mean(gross), fee_adjusted_bps=_mean(net),
+        gross_expectancy_bps=_mean(gross),
+        fee_adjusted_bps=_mean(net),
         oos_gross_bps=(_mean(oos_g) if oos_g else None),
         oos_fee_adjusted_bps=(_mean(oos_n) if oos_n else None),
     )
 
 
-def _summary_from_periods(name: str, periods: Sequence[PortfolioPeriod], oos_split_ts: int,
-                          notional: float = NOTIONAL) -> HypothesisSummary:
+def _summary_from_periods(
+    name: str,
+    periods: Sequence[PortfolioPeriod],
+    oos_split_ts: int,
+    notional: float = NOTIONAL,
+) -> HypothesisSummary:
     gross = [(p.gross_ref_pnl + p.commission_ref) / notional * 1e4 for p in periods]
     net = [p.gross_ref_pnl / notional * 1e4 for p in periods]
     oos_g = [g for g, p in zip(gross, periods, strict=True) if p.ts > oos_split_ts]
     oos_n = [n for n, p in zip(net, periods, strict=True) if p.ts > oos_split_ts]
     return HypothesisSummary(
-        name=name, conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
+        name=name,
+        conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
         sample_count=len(periods),
-        gross_expectancy_bps=_mean(gross), fee_adjusted_bps=_mean(net),
+        gross_expectancy_bps=_mean(gross),
+        fee_adjusted_bps=_mean(net),
         oos_gross_bps=(_mean(oos_g) if oos_g else None),
         oos_fee_adjusted_bps=(_mean(oos_n) if oos_n else None),
     )
@@ -58,21 +73,41 @@ def _panel_to_bars(series: Sequence[tuple[int, float]]) -> list[families.Bar]:
     return [families.Bar(ts=ts, high=c, low=c, close=c) for ts, c in series]
 
 
-def breakout_spec(panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+def breakout_spec(
+    panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS
+) -> dict:
     pooled: list[Trade] = []
     for symbol in sorted(panel):
-        pooled.extend(families.breakout_continuation_trades(_panel_to_bars(panel[symbol]), notional=NOTIONAL))
+        pooled.extend(
+            families.breakout_continuation_trades(
+                _panel_to_bars(panel[symbol]), notional=NOTIONAL
+            )
+        )
     pooled.sort(key=lambda t: t.ts_opened)
-    return {"name": "family1_breakout_continuation",
-            "summary": _summary_from_trades("family1_breakout_continuation", pooled, oos_split_ts),
-            "kind": "trade", "data": pooled, "maker_conservative_net": None}
+    return {
+        "name": "family1_breakout_continuation",
+        "summary": _summary_from_trades(
+            "family1_breakout_continuation", pooled, oos_split_ts
+        ),
+        "kind": "trade",
+        "data": pooled,
+        "maker_conservative_net": None,
+    }
 
 
-def ts_trend_spec(panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+def ts_trend_spec(
+    panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS
+) -> dict:
     periods = families.ts_trend_basket_periods(panel, notional=NOTIONAL)
-    return {"name": "family2_ts_trend_basket",
-            "summary": _summary_from_periods("family2_ts_trend_basket", periods, oos_split_ts),
-            "kind": "portfolio", "data": periods, "maker_conservative_net": None}
+    return {
+        "name": "family2_ts_trend_basket",
+        "summary": _summary_from_periods(
+            "family2_ts_trend_basket", periods, oos_split_ts
+        ),
+        "kind": "portfolio",
+        "data": periods,
+        "maker_conservative_net": None,
+    }
 
 
 def xs_momentum_spec(
@@ -81,7 +116,13 @@ def xs_momentum_spec(
     manifest: PITManifest | None,
     oos_split_ts: int = OOS_SPLIT_TS,
 ) -> dict:
-    periods = families.xs_momentum_periods(panel, rebalances, notional=NOTIONAL, manifest=manifest)
-    return {"name": "family3_xs_momentum",
-            "summary": _summary_from_periods("family3_xs_momentum", periods, oos_split_ts),
-            "kind": "portfolio", "data": periods, "maker_conservative_net": None}
+    periods = families.xs_momentum_periods(
+        panel, rebalances, notional=NOTIONAL, manifest=manifest
+    )
+    return {
+        "name": "family3_xs_momentum",
+        "summary": _summary_from_periods("family3_xs_momentum", periods, oos_split_ts),
+        "kind": "portfolio",
+        "data": periods,
+        "maker_conservative_net": None,
+    }

--- a/research/nautilus_scalping/candidates.py
+++ b/research/nautilus_scalping/candidates.py
@@ -5,6 +5,7 @@ params, and a hypothesis label. The Nautilus Strategy factory is resolved
 LAZILY in ``backtest_runner`` (keyed by name) so this module — and the pure
 test layer — never import ``nautilus_trader``.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
@@ -53,8 +54,12 @@ def _meanrev_cfg(p: Mapping[str, Any]) -> MeanRevConfig:
 
 def _random_cfg(p: Mapping[str, Any]) -> dict[str, Any]:
     # random_entry has no pure signal; params drive the Nautilus control strategy.
-    return {"entry_prob": float(p.get("entry_prob", 0.02)), "seed": int(p.get("seed", 42)),
-            "tp_bps": int(p.get("tp_bps", 30)), "sl_bps": int(p.get("sl_bps", 30))}
+    return {
+        "entry_prob": float(p.get("entry_prob", 0.02)),
+        "seed": int(p.get("seed", 42)),
+        "tp_bps": int(p.get("tp_bps", 30)),
+        "sl_bps": int(p.get("sl_bps", 30)),
+    }
 
 
 def _random_signal(*_args: Any, **_kwargs: Any) -> None:  # no pure signal
@@ -63,18 +68,24 @@ def _random_signal(*_args: Any, **_kwargs: Any) -> None:  # no pure signal
 
 REGISTRY: dict[str, Candidate] = {
     "micro_breakout": Candidate(
-        name="micro_breakout", hypothesis="trend_breakout",
-        pure_signal=evaluate_signal, config_factory=_breakout_cfg,
+        name="micro_breakout",
+        hypothesis="trend_breakout",
+        pure_signal=evaluate_signal,
+        config_factory=_breakout_cfg,
         default_params={"tp_bps": 30, "sl_bps": 20},
     ),
     "meanrev_zscore_fade": Candidate(
-        name="meanrev_zscore_fade", hypothesis="mean_reversion",
-        pure_signal=evaluate_meanrev, config_factory=_meanrev_cfg,
+        name="meanrev_zscore_fade",
+        hypothesis="mean_reversion",
+        pure_signal=evaluate_meanrev,
+        config_factory=_meanrev_cfg,
         default_params={"lookback": 20, "z_entry": "2.0", "tp_bps": 30, "sl_bps": 30},
     ),
     "random_entry": Candidate(
-        name="random_entry", hypothesis="no_skill_control",
-        pure_signal=_random_signal, config_factory=_random_cfg,
+        name="random_entry",
+        hypothesis="no_skill_control",
+        pure_signal=_random_signal,
+        config_factory=_random_cfg,
         default_params={"entry_prob": 0.02, "seed": 42, "tp_bps": 30, "sl_bps": 30},
     ),
 }

--- a/research/nautilus_scalping/compare_strategies.py
+++ b/research/nautilus_scalping/compare_strategies.py
@@ -42,9 +42,21 @@ SPECS = [
     ("breakout 100/100", "breakout", 100, 100, {}),
     ("ict S+V+F (all)", "ict", 100, 100, {"session": True, "vol": True, "fvg": True}),
     ("ict S+V (no FVG)", "ict", 100, 100, {"session": True, "vol": True, "fvg": False}),
-    ("ict V+F (no sess)", "ict", 100, 100, {"session": False, "vol": True, "fvg": True}),
+    (
+        "ict V+F (no sess)",
+        "ict",
+        100,
+        100,
+        {"session": False, "vol": True, "fvg": True},
+    ),
     ("ict vol-only", "ict", 100, 100, {"session": False, "vol": True, "fvg": False}),
-    ("ict session-only", "ict", 100, 100, {"session": True, "vol": False, "fvg": False}),
+    (
+        "ict session-only",
+        "ict",
+        100,
+        100,
+        {"session": True, "vol": False, "fvg": False},
+    ),
 ]
 
 
@@ -68,8 +80,11 @@ def _run_single(catalog_path, symbol, strategy, tp, sl, trade_size, flags):
         )
     )
     engine.add_venue(
-        venue=Venue("BINANCE"), oms_type=OmsType.HEDGING, account_type=AccountType.CASH,
-        base_currency=None, starting_balances=[Money(1_000_000, USDT)],
+        venue=Venue("BINANCE"),
+        oms_type=OmsType.HEDGING,
+        account_type=AccountType.CASH,
+        base_currency=None,
+        starting_balances=[Money(1_000_000, USDT)],
     )
     engine.add_instrument(instrument)
     engine.add_data(ticks)
@@ -77,18 +92,32 @@ def _run_single(catalog_path, symbol, strategy, tp, sl, trade_size, flags):
 
     if strategy == "breakout":
         from strategy_breakout import BreakoutScalper, BreakoutScalperConfig
-        strat = BreakoutScalper(BreakoutScalperConfig(
-            instrument_id=instrument.id, bar_type=bar_type,
-            trade_size=trade_size, tp_bps=tp, sl_bps=sl))
+
+        strat = BreakoutScalper(
+            BreakoutScalperConfig(
+                instrument_id=instrument.id,
+                bar_type=bar_type,
+                trade_size=trade_size,
+                tp_bps=tp,
+                sl_bps=sl,
+            )
+        )
     else:
         from strategy_ict import IctScalper, IctScalperConfig
-        strat = IctScalper(IctScalperConfig(
-            instrument_id=instrument.id, bar_type=bar_type, trade_size=trade_size,
-            tp_bps=tp, sl_bps=sl,
-            require_session=flags.get("session", True),
-            require_vol=flags.get("vol", True),
-            require_fvg=flags.get("fvg", True),
-            require_sweep=flags.get("sweep", False)))
+
+        strat = IctScalper(
+            IctScalperConfig(
+                instrument_id=instrument.id,
+                bar_type=bar_type,
+                trade_size=trade_size,
+                tp_bps=tp,
+                sl_bps=sl,
+                require_session=flags.get("session", True),
+                require_vol=flags.get("vol", True),
+                require_fvg=flags.get("fvg", True),
+                require_sweep=flags.get("sweep", False),
+            )
+        )
     engine.add_strategy(strat)
     engine.run()
 
@@ -123,14 +152,29 @@ def _metrics(trades, fee_bps):
 
 
 def _worker(catalog, symbol, strategy, tp, sl, size, flags):
-    cmd = [sys.executable, os.path.abspath(__file__), "--single",
-           "--strategy", strategy, "--tp", str(tp), "--sl", str(sl),
-           "--catalog", str(catalog), "--symbol", symbol, "--trade-size", size,
-           "--flags", json.dumps(flags)]
+    cmd = [
+        sys.executable,
+        os.path.abspath(__file__),
+        "--single",
+        "--strategy",
+        strategy,
+        "--tp",
+        str(tp),
+        "--sl",
+        str(sl),
+        "--catalog",
+        str(catalog),
+        "--symbol",
+        symbol,
+        "--trade-size",
+        size,
+        "--flags",
+        json.dumps(flags),
+    ]
     proc = subprocess.run(cmd, capture_output=True, text=True, env=os.environ)
     for line in proc.stdout.splitlines():
         if line.startswith(_SENTINEL):
-            return json.loads(line[len(_SENTINEL):])["trades"]
+            return json.loads(line[len(_SENTINEL) :])["trades"]
     raise RuntimeError(f"worker {strategy} {tp}/{sl} failed:\n{proc.stderr[-700:]}")
 
 
@@ -140,8 +184,11 @@ def main() -> int:
     ap.add_argument("--symbol", default="XRPUSDT")
     ap.add_argument("--trade-size", default="100")
     ap.add_argument("--export", default="results/compare.csv", type=Path)
-    ap.add_argument("--specs", default="",
-                    help="comma-sep label substrings to include (default: all)")
+    ap.add_argument(
+        "--specs",
+        default="",
+        help="comma-sep label substrings to include (default: all)",
+    )
     ap.add_argument("--single", action="store_true")
     ap.add_argument("--strategy", choices=["breakout", "ict"])
     ap.add_argument("--tp", type=int)
@@ -150,19 +197,32 @@ def main() -> int:
     args = ap.parse_args()
 
     if args.single:
-        _run_single(args.catalog, args.symbol, args.strategy, args.tp, args.sl,
-                    args.trade_size, json.loads(args.flags))
+        _run_single(
+            args.catalog,
+            args.symbol,
+            args.strategy,
+            args.tp,
+            args.sl,
+            args.trade_size,
+            json.loads(args.flags),
+        )
         return 0
 
     print(f"compare: {args.symbol}, size={args.trade_size}, fees={FEE_GRID_BPS}")
-    print("profit judged at realistic fee (10/7.5 bps taker); 0bps = gross-edge reference only.\n")
+    print(
+        "profit judged at realistic fee (10/7.5 bps taker); 0bps = gross-edge reference only.\n"
+    )
 
-    specs = SPECS if not args.specs else [
-        s for s in SPECS if any(k.strip() in s[0] for k in args.specs.split(","))
-    ]
+    specs = (
+        SPECS
+        if not args.specs
+        else [s for s in SPECS if any(k.strip() in s[0] for k in args.specs.split(","))]
+    )
     out_rows = []
     for label, strategy, tp, sl, flags in specs:
-        trades = _worker(args.catalog, args.symbol, strategy, tp, sl, args.trade_size, flags)
+        trades = _worker(
+            args.catalog, args.symbol, strategy, tp, sl, args.trade_size, flags
+        )
         n_total = len(trades)
         flag = "  <-- LOW TRADES (overfit risk)" if n_total < OVERFIT_MIN_TRADES else ""
         print(f"### {label}   (trades={n_total}){flag}")
@@ -171,18 +231,32 @@ def main() -> int:
             n, net, win, avg_bps, mdd = _metrics(trades, fee)
             tag = "GROSS" if fee == 0.0 else f"{fee:.1f}"
             print(f"   {tag:>5} {net:>+10.1f} {win:>6.1f} {avg_bps:>+8.1f} {mdd:>9.1f}")
-            out_rows.append({
-                "strategy": label, "fee_bps_per_leg": fee, "trades": n,
-                "net_pnl_usdt": round(net, 2), "win_rate_pct": round(win, 1),
-                "avg_bps_per_trade": round(avg_bps, 2), "max_drawdown_usdt": round(mdd, 2),
-                "low_trade_overfit_flag": n_total < OVERFIT_MIN_TRADES,
-            })
+            out_rows.append(
+                {
+                    "strategy": label,
+                    "fee_bps_per_leg": fee,
+                    "trades": n,
+                    "net_pnl_usdt": round(net, 2),
+                    "win_rate_pct": round(win, 1),
+                    "avg_bps_per_trade": round(avg_bps, 2),
+                    "max_drawdown_usdt": round(mdd, 2),
+                    "low_trade_overfit_flag": n_total < OVERFIT_MIN_TRADES,
+                }
+            )
         print()
 
     print("verdict (realistic taker fees):")
     for label, *_ in [(s[0],) for s in specs]:
-        net10 = next(r["net_pnl_usdt"] for r in out_rows if r["strategy"] == label and r["fee_bps_per_leg"] == 10.0)
-        net75 = next(r["net_pnl_usdt"] for r in out_rows if r["strategy"] == label and r["fee_bps_per_leg"] == 7.5)
+        net10 = next(
+            r["net_pnl_usdt"]
+            for r in out_rows
+            if r["strategy"] == label and r["fee_bps_per_leg"] == 10.0
+        )
+        net75 = next(
+            r["net_pnl_usdt"]
+            for r in out_rows
+            if r["strategy"] == label and r["fee_bps_per_leg"] == 7.5
+        )
         print(f"  {label:>22}: 10bps={net10:+.1f}  7.5bps={net75:+.1f}")
 
     args.export.parent.mkdir(parents=True, exist_ok=True)

--- a/research/nautilus_scalping/discovery/screen.py
+++ b/research/nautilus_scalping/discovery/screen.py
@@ -79,26 +79,33 @@ def _classify_cost_blind(
     """
     if s.sample_count < min_samples:
         return ClassifiedHypothesis(
-            s, "needs_more_data",
+            s,
+            "needs_more_data",
             f"sample_count {s.sample_count} < min_samples {min_samples}",
         )
     if s.gross_expectancy_bps <= min_gross_bps:
         return ClassifiedHypothesis(
-            s, "screened_out",
+            s,
+            "screened_out",
             f"gross expectancy {s.gross_expectancy_bps:.2f}bps <= triviality floor "
             f"{min_gross_bps:.2f}bps (no economically meaningful gross edge)",
         )
     if s.oos_gross_bps is not None and s.oos_gross_bps <= 0:
         return ClassifiedHypothesis(
-            s, "screened_out",
+            s,
+            "screened_out",
             f"OOS gross expectancy {s.oos_gross_bps:.2f}bps <= 0 "
             "(in-sample gross edge does not hold out of sample)",
         )
     cost_binding = s.fee_adjusted_bps <= 0
-    note = ("positive gross, killed by fees -> cost_binding 343 signal"
-            if cost_binding else "positive gross AND net-viable after fees")
+    note = (
+        "positive gross, killed by fees -> cost_binding 343 signal"
+        if cost_binding
+        else "positive gross AND net-viable after fees"
+    )
     return ClassifiedHypothesis(
-        s, "promote_to_full_validation",
+        s,
+        "promote_to_full_validation",
         f"cost-blind: gross {s.gross_expectancy_bps:.2f}bps > floor "
         f"{min_gross_bps:.2f}bps with {s.sample_count} samples; {note}",
         in_sample_only=True,
@@ -122,7 +129,9 @@ def classify(
     """
     s = summary
     if cost_blind:
-        return _classify_cost_blind(s, min_samples=min_samples, min_gross_bps=min_gross_bps)
+        return _classify_cost_blind(
+            s, min_samples=min_samples, min_gross_bps=min_gross_bps
+        )
     if s.sample_count < min_samples:
         return ClassifiedHypothesis(
             s,

--- a/research/nautilus_scalping/families.py
+++ b/research/nautilus_scalping/families.py
@@ -45,8 +45,9 @@ def make_taker_trade(
     fee magnitude, so ``cost_model.net_at_fee(.., 0)`` recovers the gross PnL.
     """
     fee = 2.0 * ref_fee_bps / 1e4 * notional
-    return Trade(net_ref_pnl=gross_pnl - fee, commission_ref=fee,
-                 notional=notional, ts_opened=ts)
+    return Trade(
+        net_ref_pnl=gross_pnl - fee, commission_ref=fee, notional=notional, ts_opened=ts
+    )
 
 
 def _period_commission(turnover_notional: float, ref_fee_bps: float) -> float:
@@ -73,12 +74,14 @@ def breakout_continuation_trades(
     n = len(bars)
     i = lookback
     while i < n:
-        prior_high = max(b.high for b in bars[i - lookback:i])
+        prior_high = max(b.high for b in bars[i - lookback : i])
         if bars[i].close > prior_high:
             exit_idx = min(i + hold, n - 1)
             entry = bars[i].close
             ret = (bars[exit_idx].close - entry) / entry if entry else 0.0
-            trades.append(make_taker_trade(ret * notional, bars[i].ts, notional, ref_fee_bps))
+            trades.append(
+                make_taker_trade(ret * notional, bars[i].ts, notional, ref_fee_bps)
+            )
             i = exit_idx + 1  # non-overlapping
         else:
             i += 1
@@ -123,9 +126,13 @@ def ts_trend_basket_periods(
             if pos != prev_pos[s]:
                 turnover += per_symbol_notional
             prev_pos[s] = pos
-        periods.append(PortfolioPeriod(
-            ts=ts, gross_ref_pnl=gross - _period_commission(turnover, ref_fee_bps),
-            commission_ref=_period_commission(turnover, ref_fee_bps)))
+        periods.append(
+            PortfolioPeriod(
+                ts=ts,
+                gross_ref_pnl=gross - _period_commission(turnover, ref_fee_bps),
+                commission_ref=_period_commission(turnover, ref_fee_bps),
+            )
+        )
     return periods
 
 
@@ -149,8 +156,15 @@ def xs_momentum_periods(
     notional (full turnover each rebalance).
     """
     rebals = sorted(rebalances)
-    xs_by_ts = dict(_panel.iter_rebalance_cross_sections(
-        closes_by_symbol, rebals, lookback, manifest=manifest, min_seasoning=min_seasoning))
+    xs_by_ts = dict(
+        _panel.iter_rebalance_cross_sections(
+            closes_by_symbol,
+            rebals,
+            lookback,
+            manifest=manifest,
+            min_seasoning=min_seasoning,
+        )
+    )
     periods: list[PortfolioPeriod] = []
     for idx, ts in enumerate(rebals[:-1]):
         xs = xs_by_ts.get(ts, {})
@@ -166,9 +180,13 @@ def xs_momentum_periods(
         for sym in shorts:
             gross -= _realized_return(closes_by_symbol[sym], ts, next_ts) * leg_notional
         turnover = notional  # full rebalance
-        periods.append(PortfolioPeriod(
-            ts=ts, gross_ref_pnl=gross - _period_commission(turnover, ref_fee_bps),
-            commission_ref=_period_commission(turnover, ref_fee_bps)))
+        periods.append(
+            PortfolioPeriod(
+                ts=ts,
+                gross_ref_pnl=gross - _period_commission(turnover, ref_fee_bps),
+                commission_ref=_period_commission(turnover, ref_fee_bps),
+            )
+        )
     return periods
 
 

--- a/research/nautilus_scalping/fee_sweep.py
+++ b/research/nautilus_scalping/fee_sweep.py
@@ -107,14 +107,28 @@ def _net_at_fee(trades, fee_bps: float) -> tuple[float, int, int]:
 
 def _worker_trades(catalog: Path, symbol: str, tp: int, sl: int, size: str):
     proc = subprocess.run(
-        [sys.executable, os.path.abspath(__file__), "--single", "--tp", str(tp),
-         "--sl", str(sl), "--catalog", str(catalog), "--symbol", symbol,
-         "--trade-size", size],
-        capture_output=True, text=True, env=os.environ,
+        [
+            sys.executable,
+            os.path.abspath(__file__),
+            "--single",
+            "--tp",
+            str(tp),
+            "--sl",
+            str(sl),
+            "--catalog",
+            str(catalog),
+            "--symbol",
+            symbol,
+            "--trade-size",
+            size,
+        ],
+        capture_output=True,
+        text=True,
+        env=os.environ,
     )
     for line in proc.stdout.splitlines():
         if line.startswith(_SENTINEL):
-            return json.loads(line[len(_SENTINEL):])["trades"]
+            return json.loads(line[len(_SENTINEL) :])["trades"]
     raise RuntimeError(
         f"worker {tp}/{sl} produced no result.\nstderr tail:\n{proc.stderr[-600:]}"
     )
@@ -149,19 +163,29 @@ def main() -> int:
         for fee in FEE_GRID_BPS:
             net, n, wins = _net_at_fee(trades, fee)
             cells.append(f"{net:>+8.1f}")
-            rows.append({
-                "tp_bps": tp, "sl_bps": sl, "fee_bps_per_leg": fee, "trades": n,
-                "net_wins": wins,
-                "win_rate_pct": round(100 * wins / n, 1) if n else 0.0,
-                "net_pnl_usdt": round(net, 2),
-            })
+            rows.append(
+                {
+                    "tp_bps": tp,
+                    "sl_bps": sl,
+                    "fee_bps_per_leg": fee,
+                    "trades": n,
+                    "net_wins": wins,
+                    "win_rate_pct": round(100 * wins / n, 1) if n else 0.0,
+                    "net_pnl_usdt": round(net, 2),
+                }
+            )
         print(f"{f'{tp}/{sl}':>9} {len(trades):>7} " + " ".join(cells))
 
     print("\nbreak-even frontier (max per-leg fee bps with NET > 0):")
     for tp, sl in TP_SL_GRID:
-        positive = [r["fee_bps_per_leg"] for r in rows
-                    if r["tp_bps"] == tp and r["sl_bps"] == sl and r["net_pnl_usdt"] > 0]
-        verdict = f"fee <= {max(positive):.1f} bps" if positive else "NEVER net-positive"
+        positive = [
+            r["fee_bps_per_leg"]
+            for r in rows
+            if r["tp_bps"] == tp and r["sl_bps"] == sl and r["net_pnl_usdt"] > 0
+        ]
+        verdict = (
+            f"fee <= {max(positive):.1f} bps" if positive else "NEVER net-positive"
+        )
         print(f"  TP/SL {tp}/{sl}: {verdict}")
 
     args.export.parent.mkdir(parents=True, exist_ok=True)

--- a/research/nautilus_scalping/fetch_agg_trades.py
+++ b/research/nautilus_scalping/fetch_agg_trades.py
@@ -73,8 +73,7 @@ def _verify(zip_path: Path, checksum_path: Path) -> None:
     actual = _sha256(zip_path)
     if actual != expected:
         raise ValueError(
-            f"checksum mismatch for {zip_path.name}: "
-            f"expected {expected}, got {actual}"
+            f"checksum mismatch for {zip_path.name}: expected {expected}, got {actual}"
         )
 
 

--- a/research/nautilus_scalping/fetch_rob382_data.py
+++ b/research/nautilus_scalping/fetch_rob382_data.py
@@ -7,6 +7,7 @@ for the multi-timeframe informatives). No keys, no auth, no orders, no secrets. 
 under pit_data_root()/klines/<interval>/<symbol>/ (gitignored). Resumable (skips files
 already on disk). NOT committed: raw bars stay out of git.
 """
+
 from __future__ import annotations
 
 import sys
@@ -22,7 +23,9 @@ TO_MONTH = "2025-12"
 def main() -> int:
     for interval in INTERVALS:
         for sym in SYMBOLS:
-            summary = fetcher.fetch_months(sym, interval, FROM_MONTH, TO_MONTH, market="um")
+            summary = fetcher.fetch_months(
+                sym, interval, FROM_MONTH, TO_MONTH, market="um"
+            )
             print(
                 f"[{interval}] {sym}: downloaded={summary['downloaded']} "
                 f"skipped={summary['skipped']} missing={summary['missing']} -> {summary['dir']}",

--- a/research/nautilus_scalping/ict_signal.py
+++ b/research/nautilus_scalping/ict_signal.py
@@ -70,8 +70,13 @@ def required_bars(config: IctConfig) -> int:
 
 def _no_entry(reason: str) -> SignalDecision:
     return SignalDecision(
-        has_entry=False, side=None, entry_price=None, tp_price=None,
-        sl_price=None, confidence=Decimal("0"), reason_codes=(reason,),
+        has_entry=False,
+        side=None,
+        entry_price=None,
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0"),
+        reason_codes=(reason,),
     )
 
 
@@ -100,16 +105,14 @@ def atr_bps(candles: Sequence[Candle], period: int) -> Decimal:
 def has_bullish_fvg(candles: Sequence[Candle], lookback: int) -> bool:
     """Bullish fair value gap in the last ``lookback`` bars: a 3-bar imbalance
     where ``candles[i].high < candles[i+2].low`` (gap up left unfilled)."""
-    window = candles[-(lookback + 2):]
-    return any(
-        window[i].high < window[i + 2].low for i in range(len(window) - 2)
-    )
+    window = candles[-(lookback + 2) :]
+    return any(window[i].high < window[i + 2].low for i in range(len(window) - 2))
 
 
 def swept_low_reclaim(candles: Sequence[Candle], lookback: int) -> bool:
     """Sell-side liquidity sweep + reclaim: the current bar's low dips below the
     prior ``lookback``-bar min low (stops taken) but it CLOSES back above it."""
-    prior = candles[-(lookback + 1):-1]
+    prior = candles[-(lookback + 1) : -1]
     prior_min_low = min(c.low for c in prior)
     cur = candles[-1]
     return cur.low < prior_min_low and cur.close > prior_min_low
@@ -129,7 +132,10 @@ def evaluate_ict(candles: Sequence[Candle], config: IctConfig) -> SignalDecision
     prior = candles[:-1]
 
     # session filter
-    if config.require_session and _hour_utc(current.close_time_ms) not in config.killzone_hours_utc:
+    if (
+        config.require_session
+        and _hour_utc(current.close_time_ms) not in config.killzone_hours_utc
+    ):
         return _no_entry("OUT_OF_SESSION")
 
     # volatility floor
@@ -140,7 +146,7 @@ def evaluate_ict(candles: Sequence[Candle], config: IctConfig) -> SignalDecision
     # trend + breakout confirmation
     sma_fast = _sma(closes, config.sma_fast)
     sma_slow = _sma(closes, config.sma_slow)
-    prior_high = max(c.high for c in prior[-config.breakout_lookback:])
+    prior_high = max(c.high for c in prior[-config.breakout_lookback :])
     if not (sma_fast > sma_slow and current.close > prior_high):
         return _no_entry("NO_BREAKOUT")
 
@@ -154,7 +160,11 @@ def evaluate_ict(candles: Sequence[Candle], config: IctConfig) -> SignalDecision
 
     entry = current.close
     # confidence: scaled by how far ATR exceeds the floor (capped at 1).
-    conf = min(Decimal("1"), atr / (config.atr_min_bps * Decimal("4"))) if config.atr_min_bps else Decimal("0.5")
+    conf = (
+        min(Decimal("1"), atr / (config.atr_min_bps * Decimal("4")))
+        if config.atr_min_bps
+        else Decimal("0.5")
+    )
     return SignalDecision(
         has_entry=True,
         side="BUY",
@@ -162,5 +172,9 @@ def evaluate_ict(candles: Sequence[Candle], config: IctConfig) -> SignalDecision
         tp_price=entry * (Decimal("1") + config.tp_bps / _BPS),
         sl_price=entry * (Decimal("1") - config.sl_bps / _BPS),
         confidence=conf,
-        reason_codes=("ICT_LONG", "BREAKOUT", "FVG" if config.require_fvg else "NO_FVG_REQ"),
+        reason_codes=(
+            "ICT_LONG",
+            "BREAKOUT",
+            "FVG" if config.require_fvg else "NO_FVG_REQ",
+        ),
     )

--- a/research/nautilus_scalping/maker_fill.py
+++ b/research/nautilus_scalping/maker_fill.py
@@ -22,6 +22,7 @@ taker trades) — no builder needed for it.
 Missed fills (entry limit cancelled on timeout) earn nothing and are simply
 ABSENT from the record list; the re-sim reports the missed count separately.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -29,20 +30,20 @@ from hashlib import blake2b
 
 from validated_gate import Trade  # pure import (stdlib-only module)
 
-REF_FEE_BPS = 10.0          # mirrors validated_gate.REF_FEE_BPS (as-run reference point)
-TAKER_BASELINE_BPS = 4.0    # real demo taker
-MAKER_FEE_BPS = 2.0         # real demo maker
+REF_FEE_BPS = 10.0  # mirrors validated_gate.REF_FEE_BPS (as-run reference point)
+TAKER_BASELINE_BPS = 4.0  # real demo taker
+MAKER_FEE_BPS = 2.0  # real demo maker
 
 
 @dataclass(frozen=True)
 class MakerTradeRecord:
-    gross: float                 # realized price P&L on the zero-fee re-sim (fee-free)
-    entry_notional: float        # entry leg notional (price * qty)
-    exit_notional: float         # exit leg notional (price * qty)
+    gross: float  # realized price P&L on the zero-fee re-sim (fee-free)
+    entry_notional: float  # entry leg notional (price * qty)
+    exit_notional: float  # exit leg notional (price * qty)
     ts_opened: int
-    filled: bool                 # False = limit cancelled (missed fill)
-    tp_hit: bool                 # exit was the maker-limit TP (vs the taker stop SL)
-    adverse_excursion_bps: float # worst adverse move between fill and exit, bps
+    filled: bool  # False = limit cancelled (missed fill)
+    tp_hit: bool  # exit was the maker-limit TP (vs the taker stop SL)
+    adverse_excursion_bps: float  # worst adverse move between fill and exit, bps
 
 
 def _legs_fee(record: MakerTradeRecord) -> float:
@@ -63,8 +64,14 @@ def build_maker_optimistic(records: list[MakerTradeRecord]) -> list[Trade]:
         if not r.filled:
             continue
         fee = _legs_fee(r)
-        out.append(Trade(net_ref_pnl=r.gross - fee, commission_ref=fee,
-                         notional=r.entry_notional, ts_opened=r.ts_opened))
+        out.append(
+            Trade(
+                net_ref_pnl=r.gross - fee,
+                commission_ref=fee,
+                notional=r.entry_notional,
+                ts_opened=r.ts_opened,
+            )
+        )
     return out
 
 
@@ -77,7 +84,7 @@ def classify_easy_tp(record: MakerTradeRecord, excursion_eps_bps: float = 2.0) -
 def _uniform_from_ts(ts_opened: int) -> float:
     """Deterministic uniform [0,1) from the trade timestamp (reproducible, no RNG)."""
     digest = blake2b(str(ts_opened).encode(), digest_size=8).digest()
-    return int.from_bytes(digest, "big") / 2.0 ** 64
+    return int.from_bytes(digest, "big") / 2.0**64
 
 
 def build_maker_conservative(
@@ -98,10 +105,19 @@ def build_maker_conservative(
     for r in records:
         if not r.filled:
             continue
-        if classify_easy_tp(r, excursion_eps_bps) and _uniform_from_ts(r.ts_opened) < queue_loss_pct:
+        if (
+            classify_easy_tp(r, excursion_eps_bps)
+            and _uniform_from_ts(r.ts_opened) < queue_loss_pct
+        ):
             continue  # queue loss
         fee = _legs_fee(r)
         adverse_cost = adverse_bps * r.entry_notional / 10_000.0
-        out.append(Trade(net_ref_pnl=r.gross - fee - adverse_cost, commission_ref=fee,
-                         notional=r.entry_notional, ts_opened=r.ts_opened))
+        out.append(
+            Trade(
+                net_ref_pnl=r.gross - fee - adverse_cost,
+                commission_ref=fee,
+                notional=r.entry_notional,
+                ts_opened=r.ts_opened,
+            )
+        )
     return out

--- a/research/nautilus_scalping/meanrev_signal.py
+++ b/research/nautilus_scalping/meanrev_signal.py
@@ -12,6 +12,7 @@ Spot is long-only (fade oversold dips); the futures short mirror (fade
 overbought spikes) is gated on ``allow_short`` exactly like the production
 breakout signal.
 """
+
 from __future__ import annotations
 
 from collections.abc import Sequence
@@ -28,13 +29,13 @@ _BPS = Decimal("10000")
 @dataclass(frozen=True)
 class MeanRevConfig:
     lookback: int = 20
-    z_entry: Decimal = Decimal("2.0")   # enter when z crosses +/- this
-    tp_bps: Decimal = Decimal("30")     # revert target
+    z_entry: Decimal = Decimal("2.0")  # enter when z crosses +/- this
+    tp_bps: Decimal = Decimal("30")  # revert target
     sl_bps: Decimal = Decimal("30")
     atr_period: int = 14
     atr_min_bps: Decimal = Decimal("8")
     require_vol: bool = True
-    allow_short: bool = False           # spot: False; futures: True
+    allow_short: bool = False  # spot: False; futures: True
 
 
 def required_bars(config: MeanRevConfig) -> int:
@@ -62,12 +63,19 @@ def zscore(closes: Sequence[Decimal], lookback: int) -> Decimal:
 
 def _no_entry(reason: str) -> SignalDecision:
     return SignalDecision(
-        has_entry=False, side=None, entry_price=None, tp_price=None,
-        sl_price=None, confidence=Decimal("0"), reason_codes=(reason,),
+        has_entry=False,
+        side=None,
+        entry_price=None,
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0"),
+        reason_codes=(reason,),
     )
 
 
-def evaluate_meanrev(candles: Sequence[Candle], config: MeanRevConfig) -> SignalDecision:
+def evaluate_meanrev(
+    candles: Sequence[Candle], config: MeanRevConfig
+) -> SignalDecision:
     """Long-only (spot) / short-mirror (futures) z-score fade. Pure over closed candles."""
     if len(candles) < required_bars(config):
         return _no_entry("INSUFFICIENT_HISTORY")
@@ -82,7 +90,11 @@ def evaluate_meanrev(candles: Sequence[Candle], config: MeanRevConfig) -> Signal
 
     current = candles[-1]
     entry = current.close
-    conf = min(Decimal("1"), (abs(z) - config.z_entry) / config.z_entry) if config.z_entry else Decimal("0.5")
+    conf = (
+        min(Decimal("1"), (abs(z) - config.z_entry) / config.z_entry)
+        if config.z_entry
+        else Decimal("0.5")
+    )
     conf = max(Decimal("0"), conf)
 
     long_ok = z <= -config.z_entry
@@ -90,16 +102,22 @@ def evaluate_meanrev(candles: Sequence[Candle], config: MeanRevConfig) -> Signal
 
     if long_ok:
         return SignalDecision(
-            has_entry=True, side="BUY", entry_price=entry,
+            has_entry=True,
+            side="BUY",
+            entry_price=entry,
             tp_price=entry * (Decimal("1") + config.tp_bps / _BPS),
             sl_price=entry * (Decimal("1") - config.sl_bps / _BPS),
-            confidence=conf, reason_codes=("MEANREV_LONG", "OVERSOLD_FADE"),
+            confidence=conf,
+            reason_codes=("MEANREV_LONG", "OVERSOLD_FADE"),
         )
     if short_ok:
         return SignalDecision(
-            has_entry=True, side="SELL", entry_price=entry,
+            has_entry=True,
+            side="SELL",
+            entry_price=entry,
             tp_price=entry * (Decimal("1") - config.tp_bps / _BPS),
             sl_price=entry * (Decimal("1") + config.sl_bps / _BPS),
-            confidence=conf, reason_codes=("MEANREV_SHORT", "OVERBOUGHT_FADE"),
+            confidence=conf,
+            reason_codes=("MEANREV_SHORT", "OVERBOUGHT_FADE"),
         )
     return _no_entry("WITHIN_BAND")

--- a/research/nautilus_scalping/pit_bars.py
+++ b/research/nautilus_scalping/pit_bars.py
@@ -6,6 +6,7 @@ survivorship-safe ``tradeable_at`` window) with leading/trailing zero-volume bar
 Pure transformation — no network. ``load_panel`` returns per-symbol (ts, close) series for
 cross-sectional families.
 """
+
 from __future__ import annotations
 
 import csv
@@ -17,7 +18,9 @@ from artifact_paths import pit_data_root
 from pit_universe import PITManifest
 
 
-def _read_rows(symbol: str, interval: str, root: Path) -> list[tuple[int, float, float, float, float]]:
+def _read_rows(
+    symbol: str, interval: str, root: Path
+) -> list[tuple[int, float, float, float, float]]:
     """Return sorted, de-duplicated (ts, high, low, close, volume) for a symbol."""
     d = root / "klines" / interval / symbol
     seen: dict[int, tuple[int, float, float, float, float]] = {}
@@ -30,7 +33,13 @@ def _read_rows(symbol: str, interval: str, root: Path) -> list[tuple[int, float,
                 # Binance kline columns: 0=open_time(ms) 2=high 3=low 4=close 5=volume
                 try:
                     ts = int(row[0])
-                    seen[ts] = (ts, float(row[2]), float(row[3]), float(row[4]), float(row[5]))
+                    seen[ts] = (
+                        ts,
+                        float(row[2]),
+                        float(row[3]),
+                        float(row[4]),
+                        float(row[5]),
+                    )
                 except (ValueError, IndexError):
                     continue
     return [seen[k] for k in sorted(seen)]
@@ -45,7 +54,9 @@ def _trim_zero_vol_edges(rows):
     return rows[lo:hi]
 
 
-def load_bars(symbol: str, interval: str, manifest: PITManifest, root=None) -> list[families.Bar]:
+def load_bars(
+    symbol: str, interval: str, manifest: PITManifest, root=None
+) -> list[families.Bar]:
     root = Path(root) if root else pit_data_root()
     listing = next((x for x in manifest.listings if x.symbol == symbol), None)
     rows = _read_rows(symbol, interval, root)
@@ -55,7 +66,9 @@ def load_bars(symbol: str, interval: str, manifest: PITManifest, root=None) -> l
     return [families.Bar(ts=r[0], high=r[1], low=r[2], close=r[3]) for r in rows]
 
 
-def load_panel(symbols, interval: str, manifest: PITManifest, root=None) -> dict[str, list[tuple[int, float]]]:
+def load_panel(
+    symbols, interval: str, manifest: PITManifest, root=None
+) -> dict[str, list[tuple[int, float]]]:
     root = Path(root) if root else pit_data_root()
     out: dict[str, list[tuple[int, float]]] = {}
     for s in symbols:

--- a/research/nautilus_scalping/rob343_label.py
+++ b/research/nautilus_scalping/rob343_label.py
@@ -47,10 +47,14 @@ def breakeven_taker_fee_bps_from_sums(
     return max(0.0, ref_fee_bps * (1.0 + sum_net_ref / sum_comm))
 
 
-def breakeven_taker_fee_bps(trades: list[Trade], ref_fee_bps: float = cost_model.REF_FEE_BPS) -> float:
+def breakeven_taker_fee_bps(
+    trades: list[Trade], ref_fee_bps: float = cost_model.REF_FEE_BPS
+) -> float:
     """Breakeven taker fee for a ``Trade`` list (taker-only; maker decided elsewhere)."""
     return breakeven_taker_fee_bps_from_sums(
-        sum(t.net_ref_pnl for t in trades), sum(t.commission_ref for t in trades), ref_fee_bps
+        sum(t.net_ref_pnl for t in trades),
+        sum(t.commission_ref for t in trades),
+        ref_fee_bps,
     )
 
 
@@ -75,31 +79,49 @@ def label_343_candidate(
     """Classify a survivor. See module docstring for the decision table."""
     if not oos_significant:
         return Rob343Verdict(
-            "needs_more_data", False, False, breakeven_taker_bps, maker_conservative_net,
+            "needs_more_data",
+            False,
+            False,
+            breakeven_taker_bps,
+            maker_conservative_net,
             "OOS evidence insufficient (sample/CI/FDR gate not cleared)",
         )
     if taker_net_pnl > 0:
         return Rob343Verdict(
-            "promote_to_pilot", False, maker_conservative_net > 0,
-            breakeven_taker_bps, maker_conservative_net,
+            "promote_to_pilot",
+            False,
+            maker_conservative_net > 0,
+            breakeven_taker_bps,
+            maker_conservative_net,
             "already net-viable at realistic taker fees; ROB-343 not required",
         )
     cost_binding = gross_pnl > 0 and taker_net_pnl <= 0
     if not cost_binding:
         return Rob343Verdict(
-            "reject", False, False, breakeven_taker_bps, maker_conservative_net,
+            "reject",
+            False,
+            False,
+            breakeven_taker_bps,
+            maker_conservative_net,
             "no positive gross edge; not a cost problem",
         )
     closable = maker_conservative_net > 0
     if closable:
         return Rob343Verdict(
-            "cost_binding_343_candidate", True, True,
-            breakeven_taker_bps, maker_conservative_net,
+            "cost_binding_343_candidate",
+            True,
+            True,
+            breakeven_taker_bps,
+            maker_conservative_net,
             "positive gross killed by taker fees; maker-conservative scenario is "
             "net-positive => realistic maker execution plausibly closes the gap",
         )
     return Rob343Verdict(
-        "reject", True, False, breakeven_taker_bps, maker_conservative_net,
+        "reject",
+        True,
+        False,
+        breakeven_taker_bps,
+        maker_conservative_net,
         "cost-binding but maker-conservative scenario still net-negative => no "
         "realistic execution path (Codex realistic-path stop-rule)",
     )

--- a/research/nautilus_scalping/rob382_backtest.py
+++ b/research/nautilus_scalping/rob382_backtest.py
@@ -18,6 +18,7 @@ Faithfulness rules (timeframe/hold-preserving — ROB-382 §2, not short-horizon
   * SL-first within a bar (conservative): if a bar's range spans both stop and target,
     assume the stop filled first (matches strategy_meanrev's conservative exit).
 """
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/research/nautilus_scalping/rob382_bars.py
+++ b/research/nautilus_scalping/rob382_bars.py
@@ -7,6 +7,7 @@ gitignored CSVs ``pit_klines_fetcher`` writes, into a full ``OHLCVBar``.
 
 PUBLIC data only; no network here (the fetch is ``fetch_rob382_data.py``). No secrets.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/research/nautilus_scalping/rob382_baselines.py
+++ b/research/nautilus_scalping/rob382_baselines.py
@@ -10,6 +10,7 @@ so we build the baselines here and feed them to ``validated_gate.evaluate_gate``
     closed by the candidate's OWN exit model + exit signal — isolates whether the ENTRY edge
     beats random timing with identical exits ("is the signal better than a coin flip?").
 """
+
 from __future__ import annotations
 
 import random
@@ -27,7 +28,9 @@ def _to_family_bars(bars: Sequence[OHLCVBar]) -> list[families.Bar]:
 
 def breakout_baseline(bars: Sequence[OHLCVBar]) -> list[Trade]:
     """Micro-breakout control on the same bars (frozen ROB-351 family params)."""
-    return families.breakout_continuation_trades(_to_family_bars(bars), notional=bt.NOTIONAL)
+    return families.breakout_continuation_trades(
+        _to_family_bars(bars), notional=bt.NOTIONAL
+    )
 
 
 def random_baseline(

--- a/research/nautilus_scalping/rob382_candidates.py
+++ b/research/nautilus_scalping/rob382_candidates.py
@@ -13,6 +13,7 @@ not to assume they're realistic). Stats read from the strat.ninja ranking/overvi
 Each candidate's signal logic is ported (no freqtrade/talib/execution import) into the
 matching ``module`` from the PUBLIC canonical source in ``source_url``.
 """
+
 from __future__ import annotations
 
 # Ordered list of candidate descriptors. ``module`` is the ported signal module created
@@ -126,7 +127,9 @@ CANDIDATES = [
 ]
 
 # ICT family is intentionally absent: already covered by ict_signal.py / strategy_ict.py.
-EXCLUDED = {"ict": "already covered by ict_signal.py / strategy_ict.py (not a new shape)"}
+EXCLUDED = {
+    "ict": "already covered by ict_signal.py / strategy_ict.py (not a new shape)"
+}
 
 
 def by_key(key: str) -> dict:

--- a/research/nautilus_scalping/rob382_indicators.py
+++ b/research/nautilus_scalping/rob382_indicators.py
@@ -13,6 +13,7 @@ Semantics matched (good enough for a GROSS sign screen; not bit-exact to talib):
   * ichimoku — senkou spans forward-displaced (causal: span at t derives from t-displacement)
   * informative merge — last FULLY-CLOSED higher-tf bar as of base ts (lookahead-safe)
 """
+
 from __future__ import annotations
 
 import math
@@ -117,7 +118,9 @@ def rsi(xs: Sequence[float], n: int = 14) -> list[float]:
     return out
 
 
-def atr(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], n: int = 14) -> list[float]:
+def atr(
+    highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], n: int = 14
+) -> list[float]:
     m = len(closes)
     out = [NAN] * m
     if m <= n:
@@ -125,7 +128,11 @@ def atr(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], 
     tr = [NAN] * m
     tr[0] = highs[0] - lows[0]
     for i in range(1, m):
-        tr[i] = max(highs[i] - lows[i], abs(highs[i] - closes[i - 1]), abs(lows[i] - closes[i - 1]))
+        tr[i] = max(
+            highs[i] - lows[i],
+            abs(highs[i] - closes[i - 1]),
+            abs(lows[i] - closes[i - 1]),
+        )
     prev = sum(tr[1 : n + 1]) / n
     out[n] = prev
     for i in range(n + 1, m):
@@ -207,8 +214,14 @@ def bollinger(xs: Sequence[float], n: int, num_std: float, ddof: int = 1):
     """Return (mid, lower, upper). mid=SMA(n); bands = mid ± num_std*rolling_std."""
     mid = sma(xs, n)
     sd = rolling_std(xs, n, ddof=ddof)
-    lower = [m - num_std * s if (_valid(m) and _valid(s)) else NAN for m, s in zip(mid, sd, strict=True)]
-    upper = [m + num_std * s if (_valid(m) and _valid(s)) else NAN for m, s in zip(mid, sd, strict=True)]
+    lower = [
+        m - num_std * s if (_valid(m) and _valid(s)) else NAN
+        for m, s in zip(mid, sd, strict=True)
+    ]
+    upper = [
+        m + num_std * s if (_valid(m) and _valid(s)) else NAN
+        for m, s in zip(mid, sd, strict=True)
+    ]
     return mid, lower, upper
 
 
@@ -236,7 +249,9 @@ def rolling_vwap(
     return out
 
 
-def top_percent_change(opens: Sequence[float], closes: Sequence[float], length: int) -> list[float]:
+def top_percent_change(
+    opens: Sequence[float], closes: Sequence[float], length: int
+) -> list[float]:
     """(rolling-max open over `length` - close) / close. length==0 → (open-close)/close."""
     out = [NAN] * len(closes)
     for i in range(len(closes)):
@@ -278,7 +293,9 @@ def heikin_ashi(
 # --------------------------------------------------------------------------- #
 # Ichimoku (technical.indicators.ichimoku semantics, forward-displaced spans)
 # --------------------------------------------------------------------------- #
-def _midpoint_window(highs: Sequence[float], lows: Sequence[float], n: int) -> list[float]:
+def _midpoint_window(
+    highs: Sequence[float], lows: Sequence[float], n: int
+) -> list[float]:
     """(rolling-max high + rolling-min low) / 2, O(len) via monotonic deques."""
     from collections import deque
 

--- a/research/nautilus_scalping/rob382_runner.py
+++ b/research/nautilus_scalping/rob382_runner.py
@@ -19,6 +19,7 @@ net_* are reported at the FROZEN taker (4.0 bps/leg = 8 bps round trip; the gate
 at the harsher retail REF fee (10 bps/leg) so the cost-sensitivity is explicit. No market data
 is committed; raw bars stay on disk.
 """
+
 from __future__ import annotations
 
 import math
@@ -57,12 +58,18 @@ def _mean(xs: Sequence[float]) -> float:
 def _summary(name: str, trades: Sequence[Trade]) -> HypothesisSummary:
     gross = [(t.net_ref_pnl + t.commission_ref) / t.notional * 1e4 for t in trades]
     net_ref = [t.net_ref_pnl / t.notional * 1e4 for t in trades]
-    oos_g = [g for g, t in zip(gross, trades, strict=True) if t.ts_opened > OOS_SPLIT_TS]
-    oos_n = [n for n, t in zip(net_ref, trades, strict=True) if t.ts_opened > OOS_SPLIT_TS]
+    oos_g = [
+        g for g, t in zip(gross, trades, strict=True) if t.ts_opened > OOS_SPLIT_TS
+    ]
+    oos_n = [
+        n for n, t in zip(net_ref, trades, strict=True) if t.ts_opened > OOS_SPLIT_TS
+    ]
     return HypothesisSummary(
-        name=name, conditions=f"ROB-382 faithful port; OOS split {OOS_SPLIT_TS}",
+        name=name,
+        conditions=f"ROB-382 faithful port; OOS split {OOS_SPLIT_TS}",
         sample_count=len(trades),
-        gross_expectancy_bps=_mean(gross), fee_adjusted_bps=_mean(net_ref),
+        gross_expectancy_bps=_mean(gross),
+        fee_adjusted_bps=_mean(net_ref),
         oos_gross_bps=(_mean(oos_g) if oos_g else None),
         oos_fee_adjusted_bps=(_mean(oos_n) if oos_n else None),
     )
@@ -84,7 +91,12 @@ def simulate_candidate(module, symbols: Sequence[str] = DEFAULT_SYMBOLS):
             bars_1h_cache[sym] = bars_1h
         entry, exit_sig = module.signals(bars, bars_1h)
         trades = bt.simulate(bars, entry, exit_sig, module.EXIT_MODEL)
-        per_symbol[sym] = {"bars": bars, "exit_sig": exit_sig, "trades": len(trades), "trade_list": trades}
+        per_symbol[sym] = {
+            "bars": bars,
+            "exit_sig": exit_sig,
+            "trades": len(trades),
+            "trade_list": trades,
+        }
         pooled.extend(trades)
     pooled.sort(key=lambda t: t.ts_opened)
     diag = {
@@ -93,8 +105,10 @@ def simulate_candidate(module, symbols: Sequence[str] = DEFAULT_SYMBOLS):
         "needs_informative_1h": bool(getattr(module, "NEEDS_INFORMATIVE_1H", False)),
         "per_symbol_trade_counts": {s: d["trades"] for s, d in per_symbol.items()},
         "exit_model": {
-            "type": module.EXIT_MODEL.type, "hard_sl_pct": module.EXIT_MODEL.hard_sl_pct,
-            "roi_pct": module.EXIT_MODEL.roi_pct, "max_hold_bars": module.EXIT_MODEL.max_hold_bars,
+            "type": module.EXIT_MODEL.type,
+            "hard_sl_pct": module.EXIT_MODEL.hard_sl_pct,
+            "roi_pct": module.EXIT_MODEL.roi_pct,
+            "max_hold_bars": module.EXIT_MODEL.max_hold_bars,
         },
         "hold_semantics": getattr(module, "HOLD_SEMANTICS", "unspecified"),
     }
@@ -109,8 +123,15 @@ def _build_baselines(module, per_symbol: dict) -> tuple[list[Trade], list[Trade]
         if not bars:
             continue
         breakout.extend(bl.breakout_baseline(bars))
-        rnd.extend(bl.random_baseline(bars, d["exit_sig"], module.EXIT_MODEL,
-                                      n_entries=d["trades"], seed=1_000 + idx))
+        rnd.extend(
+            bl.random_baseline(
+                bars,
+                d["exit_sig"],
+                module.EXIT_MODEL,
+                n_entries=d["trades"],
+                seed=1_000 + idx,
+            )
+        )
     breakout.sort(key=lambda t: t.ts_opened)
     rnd.sort(key=lambda t: t.ts_opened)
     return breakout, rnd
@@ -128,22 +149,29 @@ def _funnel_verdict(screen_reco: str, gate_verdict: str | None) -> str:
     return "gross_edge_present_needs_full_validation"  # tested vs baselines/OOS, not validated
 
 
-def run_candidate(module, *, name: str, contrast: dict, symbols: Sequence[str] = DEFAULT_SYMBOLS,
-                  min_trades: int = 100) -> dict:
+def run_candidate(
+    module,
+    *,
+    name: str,
+    contrast: dict,
+    symbols: Sequence[str] = DEFAULT_SYMBOLS,
+    min_trades: int = 100,
+) -> dict:
     """Full per-candidate pipeline → one counts-only verdict row + contrast fields.
 
     ``contrast`` carries strat.ninja numbers (recorded FOR CONTRAST ONLY, never as evidence).
     """
     cfg = FROZEN_CONFIG
-    taker_rt_bps = 2.0 * cfg.taker_bps      # frozen taker round-trip cost (8 bps)
-    ref_rt_bps = 2.0 * REF_FEE_BPS          # retail REF round-trip cost (20 bps)
+    taker_rt_bps = 2.0 * cfg.taker_bps  # frozen taker round-trip cost (8 bps)
+    ref_rt_bps = 2.0 * REF_FEE_BPS  # retail REF round-trip cost (20 bps)
 
     trades, per_symbol, diag = simulate_candidate(module, symbols)
     summary = _summary(name, trades)
 
     # Stage 1 — cost-blind gross screen (triviality floor + OOS-gross sign).
     screened = classify(
-        summary, cost_blind=True,
+        summary,
+        cost_blind=True,
         min_samples=min(summary.sample_count, min_trades) if min_trades else 1,
         min_gross_bps=cfg.economic_triviality_floor_bps,
     )
@@ -155,9 +183,14 @@ def run_candidate(module, *, name: str, contrast: dict, symbols: Sequence[str] =
     if screened.recommendation == "promote_to_full_validation":
         breakout, rnd = _build_baselines(module, per_symbol)
         rep = vg.evaluate_gate(
-            candidate_runs={"p": trades}, baseline_breakout=breakout, baseline_random=rnd,
-            fee_bps=cfg.taker_bps, min_trades=min_trades, candidate_name=name,
-            symbols=list(symbols), window={"oos_split_ts": OOS_SPLIT_TS},
+            candidate_runs={"p": trades},
+            baseline_breakout=breakout,
+            baseline_random=rnd,
+            fee_bps=cfg.taker_bps,
+            min_trades=min_trades,
+            candidate_name=name,
+            symbols=list(symbols),
+            window={"oos_split_ts": OOS_SPLIT_TS},
         )
         gate_verdict = rep.verdict
         gate_reasons = rep.verdict_reasons
@@ -168,7 +201,9 @@ def run_candidate(module, *, name: str, contrast: dict, symbols: Sequence[str] =
         beats_random = oos_net.get("net_pnl", 0.0) > rd.get("net_after_cost", 0.0)
 
     gross_bps = [(t.net_ref_pnl + t.commission_ref) / t.notional * 1e4 for t in trades]
-    oos_gross = [g for g, t in zip(gross_bps, trades, strict=True) if t.ts_opened > OOS_SPLIT_TS]
+    oos_gross = [
+        g for g, t in zip(gross_bps, trades, strict=True) if t.ts_opened > OOS_SPLIT_TS
+    ]
 
     g_full = summary.gross_expectancy_bps
     g_oos = summary.oos_gross_bps
@@ -179,8 +214,10 @@ def run_candidate(module, *, name: str, contrast: dict, symbols: Sequence[str] =
     meets_survivor = bool(
         gate_verdict == "validated"
         and t_oos_gross >= cfg.target_t
-        and oos_net_taker is not None and oos_net_taker > 0
-        and beats_breakout and beats_random
+        and oos_net_taker is not None
+        and oos_net_taker > 0
+        and beats_breakout
+        and beats_random
     )
 
     return {
@@ -198,10 +235,14 @@ def run_candidate(module, *, name: str, contrast: dict, symbols: Sequence[str] =
         "our_oos_gross_bps": (round(g_oos, 4) if g_oos is not None else None),
         # net at OUR frozen taker (8 bps RT) vs retail REF (20 bps RT) — cost sensitivity explicit
         "our_net_bps_frozen_taker": round(g_full - taker_rt_bps, 4),
-        "our_oos_net_bps_frozen_taker": (round(g_oos - taker_rt_bps, 4) if g_oos is not None else None),
+        "our_oos_net_bps_frozen_taker": (
+            round(g_oos - taker_rt_bps, 4) if g_oos is not None else None
+        ),
         "our_net_bps_retail_ref": round(summary.fee_adjusted_bps, 4),
         "our_oos_net_bps_retail_ref": (
-            round(summary.oos_fee_adjusted_bps, 4) if summary.oos_fee_adjusted_bps is not None else None
+            round(summary.oos_fee_adjusted_bps, 4)
+            if summary.oos_fee_adjusted_bps is not None
+            else None
         ),
         "frozen_taker_rt_bps": taker_rt_bps,
         "retail_ref_rt_bps": ref_rt_bps,

--- a/research/nautilus_scalping/rob382_signal_cluc.py
+++ b/research/nautilus_scalping/rob382_signal_cluc.py
@@ -28,6 +28,7 @@ by the published hard stop (pHSL = -0.32) + a 24h (1440 x 1m) max-hold cap. The 
 timeframe and the 1h informative are preserved; only the exit MECHANISM is approximated, so
 ``horizon_changed_during_port`` is True.
 """
+
 from __future__ import annotations
 
 import rob382_backtest
@@ -57,7 +58,9 @@ NEEDS_INFORMATIVE_1H = True
 
 # Published pHSL = -0.32 (hard stop). Custom trailing-stop + minimal_roi {"70": 0} time-exit
 # NOT modeled -> approximated by hard stop + 24h (1440 x 1m) max-hold cap.
-EXIT_MODEL = rob382_backtest.ExitModel(type="signal", hard_sl_pct=0.32, max_hold_bars=1440)
+EXIT_MODEL = rob382_backtest.ExitModel(
+    type="signal", hard_sl_pct=0.32, max_hold_bars=1440
+)
 
 HOLD_SEMANTICS = (
     "signal exit (fisher cluster) preserved; published hard stop -32%; custom trailing-stop "
@@ -103,7 +106,9 @@ def signals(bars, bars_1h=None):
     ema_fast = I.ema(ha_close, EMA_FAST)
     ema_slow = I.ema(ha_close, EMA_SLOW)
 
-    rsi = I.rsi(closes, RSI_LEN)  # RSI on REAL close (source: ta.RSI(dataframe) -> default close,14)
+    rsi = I.rsi(
+        closes, RSI_LEN
+    )  # RSI on REAL close (source: ta.RSI(dataframe) -> default close,14)
     fisher = I.fisher_from_rsi(rsi)
 
     # --- 1h informative rocr_1h (lookahead-safe merge) ------------------------------------- #

--- a/research/nautilus_scalping/rob382_signal_elliot.py
+++ b/research/nautilus_scalping/rob382_signal_elliot.py
@@ -20,6 +20,7 @@ Causality: ElliotV7 uses NO ``.shift(k)`` in either populate_*_trend — every g
 SAME bar's columns, so signals[i] depends only on bars[0..i]. The 1h merge is the lookahead-
 safe ``merge_informative`` (last FULLY-CLOSED 1h bar as of the 5m bar's open time).
 """
+
 from __future__ import annotations
 
 import rob382_backtest

--- a/research/nautilus_scalping/rob382_signal_ichi.py
+++ b/research/nautilus_scalping/rob382_signal_ichi.py
@@ -19,6 +19,7 @@ source is a PAST shift (``fan.shift(k)[i] == fan[i-k]``). The ichimoku senkou sp
 forward-displaced (span at i derives from i-displacement), so ``close > senkou_a`` is
 causal (no lookahead). ``crossed_below`` uses only i and i-1.
 """
+
 from __future__ import annotations
 
 import rob382_backtest as bt
@@ -84,7 +85,9 @@ def signals(bars, bars_1h=None) -> tuple[list[bool], list[bool]]:
 
     # fan_magnitude = trend_close_1h / trend_close_8h; gain = fan[i]/fan[i-1]
     fan = [
-        (tc_1h[i] / tc_8h[i]) if (_v(tc_1h[i]) and _v(tc_8h[i]) and tc_8h[i] != 0) else float("nan")
+        (tc_1h[i] / tc_8h[i])
+        if (_v(tc_1h[i]) and _v(tc_8h[i]) and tc_8h[i] != 0)
+        else float("nan")
         for i in range(n)
     ]
     fan_gain = [float("nan")] * n

--- a/research/nautilus_scalping/rob382_signal_vwap.py
+++ b/research/nautilus_scalping/rob382_signal_vwap.py
@@ -30,6 +30,7 @@ Causality: every value at index i derives only from bars[0..i]. The indicator li
 already causal; the VWAP band uses rolling_std OF the vwap series (a causal transform of
 a causal series), and all RSI/CTI/tcp are backward-looking windows.
 """
+
 from __future__ import annotations
 
 import rob382_backtest as bt
@@ -96,7 +97,9 @@ def signals(bars, bars_1h=None):  # noqa: ARG001 (bars_1h unused; NEEDS_INFORMAT
     vwap = I.rolling_vwap(highs, lows, closes, volumes, _VWAP_WINDOW)
     vwap_sd = I.rolling_std(vwap, _VWAP_WINDOW)  # df['vwap'].rolling(20).std()
     vwap_low = [
-        vwap[i] - _VWAP_NUM_STD * vwap_sd[i] if (_valid(vwap[i]) and _valid(vwap_sd[i])) else float("nan")
+        vwap[i] - _VWAP_NUM_STD * vwap_sd[i]
+        if (_valid(vwap[i]) and _valid(vwap_sd[i]))
+        else float("nan")
         for i in range(n)
     ]
 

--- a/research/nautilus_scalping/run_rob351_campaign.py
+++ b/research/nautilus_scalping/run_rob351_campaign.py
@@ -34,26 +34,50 @@ def _self_test() -> dict:
     from frozen_config import FROZEN_CONFIG
 
     def trades(gross_each, n):
-        return [families.make_taker_trade(gross_each, ts=i, notional=1000.0) for i in range(n)]
+        return [
+            families.make_taker_trade(gross_each, ts=i, notional=1000.0)
+            for i in range(n)
+        ]
 
     specs = [
-        {"name": "family1_breakout_continuation",
-         "summary": HypothesisSummary("f1", "demo", 40, 8.0, 4.0, oos_gross_bps=8.0),
-         "kind": "trade", "data": trades(5.0, 40), "maker_conservative_net": None},
-        {"name": "family2_trend_basket(seed-style cost-binding)",
-         "summary": HypothesisSummary("f2", "demo", 40, 6.0, -2.0, oos_gross_bps=6.0),
-         "kind": "trade", "data": trades(0.5, 40), "maker_conservative_net": 1.5},
-        {"name": "family3_xs_momentum(no gross edge)",
-         "summary": HypothesisSummary("f3", "demo", 40, -1.0, -3.0, oos_gross_bps=-1.0),
-         "kind": "trade", "data": trades(-2.0, 40), "maker_conservative_net": None},
+        {
+            "name": "family1_breakout_continuation",
+            "summary": HypothesisSummary("f1", "demo", 40, 8.0, 4.0, oos_gross_bps=8.0),
+            "kind": "trade",
+            "data": trades(5.0, 40),
+            "maker_conservative_net": None,
+        },
+        {
+            "name": "family2_trend_basket(seed-style cost-binding)",
+            "summary": HypothesisSummary(
+                "f2", "demo", 40, 6.0, -2.0, oos_gross_bps=6.0
+            ),
+            "kind": "trade",
+            "data": trades(0.5, 40),
+            "maker_conservative_net": 1.5,
+        },
+        {
+            "name": "family3_xs_momentum(no gross edge)",
+            "summary": HypothesisSummary(
+                "f3", "demo", 40, -1.0, -3.0, oos_gross_bps=-1.0
+            ),
+            "kind": "trade",
+            "data": trades(-2.0, 40),
+            "maker_conservative_net": None,
+        },
     ]
     return campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description="ROB-351 cost-blind funnel (research only)")
-    ap.add_argument("--self-test", action="store_true",
-                    help="run the funnel on synthetic fixtures and print the verdict table")
+    ap = argparse.ArgumentParser(
+        description="ROB-351 cost-blind funnel (research only)"
+    )
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the funnel on synthetic fixtures and print the verdict table",
+    )
     args = ap.parse_args(argv)
 
     if args.self_test:

--- a/research/nautilus_scalping/run_rob353_campaign.py
+++ b/research/nautilus_scalping/run_rob353_campaign.py
@@ -13,6 +13,7 @@ Two modes:
 Safety: research/backtest only. No live, no Demo confirm, no broker/order/scheduler/DB,
 no /invest. ROB-343 is RECOMMENDED by the verdict, never run here. No raw data committed.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -45,22 +46,37 @@ def _self_test() -> dict:
 
 
 def main(argv=None) -> int:
-    ap = argparse.ArgumentParser(description="ROB-353 bounded empirical RUN (research only)")
-    ap.add_argument("--self-test", action="store_true",
-                    help="synthetic wiring proof (no network); prints the verdict table")
+    ap = argparse.ArgumentParser(
+        description="ROB-353 bounded empirical RUN (research only)"
+    )
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="synthetic wiring proof (no network); prints the verdict table",
+    )
     ap.add_argument("--from-month", default="2023-01")
     ap.add_argument("--to-month", default="2026-04")
-    ap.add_argument("--max-symbols", type=int, default=None,
-                    help="operator bound on universe size (default: all qualifying)")
-    ap.add_argument("--skip-fetch", action="store_true",
-                    help="use already-downloaded klines; do not hit the network")
+    ap.add_argument(
+        "--max-symbols",
+        type=int,
+        default=None,
+        help="operator bound on universe size (default: all qualifying)",
+    )
+    ap.add_argument(
+        "--skip-fetch",
+        action="store_true",
+        help="use already-downloaded klines; do not hit the network",
+    )
     args = ap.parse_args(argv)
 
     if args.self_test:
         result = _self_test()
         print(json.dumps(result, indent=2))
         from frozen_config import FROZEN_CONFIG
-        assert result["config_hash"] == FROZEN_CONFIG.config_hash(), "frozen config drift!"
+
+        assert result["config_hash"] == FROZEN_CONFIG.config_hash(), (
+            "frozen config drift!"
+        )
         return 0
 
     return _real_run(args)
@@ -77,7 +93,9 @@ def _real_run(args) -> int:  # pragma: no cover - network/operator-gated
     import pit_universe
     from frozen_config import FROZEN_CONFIG
 
-    manifest = pit_universe.PITManifest.load("data_manifests/pit_universe.v1.json").strict_usdt_perp()
+    manifest = pit_universe.PITManifest.load(
+        "data_manifests/pit_universe.v1.json"
+    ).strict_usdt_perp()
     lo = pit_universe._date_to_epoch_ms(f"{args.from_month}-01")
     hi = pit_universe._date_to_epoch_ms(f"{args.to_month}-28")
     symbols = cc.filter_universe(manifest, lo, hi)
@@ -87,9 +105,13 @@ def _real_run(args) -> int:  # pragma: no cover - network/operator-gated
 
     if not args.skip_fetch:
         for i, sym in enumerate(symbols, 1):
-            summary = pit_klines_fetcher.fetch_months(sym, "1d", args.from_month, args.to_month)
+            summary = pit_klines_fetcher.fetch_months(
+                sym, "1d", args.from_month, args.to_month
+            )
             if i % 25 == 0:
-                print(f"  fetched {i}/{len(symbols)} (last {sym}: {summary['downloaded']} dl)")
+                print(
+                    f"  fetched {i}/{len(symbols)} (last {sym}: {summary['downloaded']} dl)"
+                )
 
     panel = pit_bars.load_panel(symbols, "1d", manifest)
     panel = {s: v for s, v in panel.items() if len(v) >= 30}
@@ -113,23 +135,31 @@ def _real_run(args) -> int:  # pragma: no cover - network/operator-gated
         "family_drawdown_bps": {},
         "skipped_controls": [
             "dollar-volume liquidity filter (used manifest coverage/confidence instead)",
-            "parameter-neighborhood sweep", "BTC regime split", "symbol-concentration analysis",
+            "parameter-neighborhood sweep",
+            "BTC regime split",
+            "symbol-concentration analysis",
             "1h interval (deferred)",
         ],
     }
     for spec in specs:
         if spec["kind"] == "portfolio":
             controls["family_drawdown_bps"][spec["name"]] = cc.max_drawdown_bps(
-                [p.gross_ref_pnl for p in spec["data"]], notional=cs.NOTIONAL)
+                [p.gross_ref_pnl for p in spec["data"]], notional=cs.NOTIONAL
+            )
 
     os.makedirs("results/rob353", exist_ok=True)
-    out = {"verdict_table": result, "controls": controls,
-           "spec_sample_counts": {s["name"]: s["summary"].sample_count for s in specs}}
+    out = {
+        "verdict_table": result,
+        "controls": controls,
+        "spec_sample_counts": {s["name"]: s["summary"].sample_count for s in specs},
+    }
     with open("results/rob353/rob351_campaign.v1.json", "w") as fh:
         json.dump(out, fh, indent=2, default=str)
     print(json.dumps(out, indent=2, default=str))
-    print("\nwrote results/rob353/rob351_campaign.v1.json (gitignored). "
-          "Author docs/runbooks/rob-353-pr2-empirical-verdict.md from this output.")
+    print(
+        "\nwrote results/rob353/rob351_campaign.v1.json (gitignored). "
+        "Author docs/runbooks/rob-353-pr2-empirical-verdict.md from this output."
+    )
     return 0
 
 

--- a/research/nautilus_scalping/run_rob382_falsification.py
+++ b/research/nautilus_scalping/run_rob382_falsification.py
@@ -19,6 +19,7 @@ Safety: research/backtest only. No freqtrade/talib runtime import; no broker/ord
 order-intent/approval/trade-journal mutation; no scheduler/TaskIQ/Prefect/cron; no prod DB
 write; no secrets; no raw bars or leaderboard dumps committed (counts-only).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -44,9 +45,17 @@ def _self_test() -> dict:
     minute = 60_000
     for i in range(400):
         price *= 1.001 if i % 10 else 0.98  # drift up, dip every 10 bars
-        bars.append(OHLCVBar(ts=i * minute, open=price, high=price * 1.002,
-                             low=price * 0.998, close=price, volume=1000.0,
-                             close_ts=i * minute + minute - 1))
+        bars.append(
+            OHLCVBar(
+                ts=i * minute,
+                open=price,
+                high=price * 1.002,
+                low=price * 0.998,
+                close=price,
+                volume=1000.0,
+                close_ts=i * minute + minute - 1,
+            )
+        )
 
     def signals(bs, bars_1h=None):
         # trivial: buy the dip (close < prior close), exit never (roi/sl/max-hold governs)
@@ -54,19 +63,28 @@ def _self_test() -> dict:
         return entry, [False] * len(bs)
 
     module = SimpleNamespace(
-        NATIVE_INTERVAL="1m", NEEDS_INFORMATIVE_1H=False,
-        EXIT_MODEL=bt.ExitModel(type="roi_sl", roi_pct=0.02, hard_sl_pct=0.15, max_hold_bars=20),
-        HOLD_SEMANTICS="self-test trivial", signals=signals,
+        NATIVE_INTERVAL="1m",
+        NEEDS_INFORMATIVE_1H=False,
+        EXIT_MODEL=bt.ExitModel(
+            type="roi_sl", roi_pct=0.02, hard_sl_pct=0.15, max_hold_bars=20
+        ),
+        HOLD_SEMANTICS="self-test trivial",
+        signals=signals,
     )
     trades = bt.simulate(bars, *module.signals(bars), module.EXIT_MODEL)
     spec = {
-        "name": "selftest_dip", "kind": "trade", "data": trades,
+        "name": "selftest_dip",
+        "kind": "trade",
+        "data": trades,
         "summary": cs._summary_from_trades("selftest_dip", trades, cs.OOS_SPLIT_TS),
         "maker_conservative_net": None,
     }
     table = campaign.run_campaign([spec], config=FROZEN_CONFIG, min_trades=5)
-    return {"trade_count": len(trades), "verdict_table": table,
-            "config_hash": table["config_hash"]}
+    return {
+        "trade_count": len(trades),
+        "verdict_table": table,
+        "config_hash": table["config_hash"],
+    }
 
 
 def _real_run(args) -> int:
@@ -81,13 +99,25 @@ def _real_run(args) -> int:
         try:
             module = importlib.import_module(cand["module"])
         except ModuleNotFoundError:
-            skipped.append({"key": cand["key"], "module": cand["module"],
-                            "reason": "ported signal module not present yet"})
-            print(f"  SKIP {cand['key']}: module {cand['module']} not found", flush=True)
+            skipped.append(
+                {
+                    "key": cand["key"],
+                    "module": cand["module"],
+                    "reason": "ported signal module not present yet",
+                }
+            )
+            print(
+                f"  SKIP {cand['key']}: module {cand['module']} not found", flush=True
+            )
             continue
         print(f"  running {cand['key']} ({cand['display_name']}) ...", flush=True)
-        row = runner.run_candidate(module, name=cand["key"], contrast=cand["contrast"],
-                                   symbols=symbols, min_trades=args.min_trades)
+        row = runner.run_candidate(
+            module,
+            name=cand["key"],
+            contrast=cand["contrast"],
+            symbols=symbols,
+            min_trades=args.min_trades,
+        )
         row["display_name"] = cand["display_name"]
         row["strat_ninja_name"] = cand["strat_ninja_name"]
         row["family_shape"] = cand["family_shape"]
@@ -95,10 +125,13 @@ def _real_run(args) -> int:
         row["source_url"] = cand["source_url"]
         row["source_note"] = cand["source_note"]
         rows.append(row)
-        print(f"    -> verdict={row['our_verdict']} gross={row['our_gross_bps']}bps "
-              f"oos_gross={row['our_oos_gross_bps']}bps oos_net@taker={row['our_oos_net_bps_frozen_taker']}bps "
-              f"t_oos={row['our_t_stat_oos_gross']} gate={row['gate_verdict']} "
-              f"survivor={row['meets_decisive_survivor_bar']} trades={row['trade_count']}", flush=True)
+        print(
+            f"    -> verdict={row['our_verdict']} gross={row['our_gross_bps']}bps "
+            f"oos_gross={row['our_oos_gross_bps']}bps oos_net@taker={row['our_oos_net_bps_frozen_taker']}bps "
+            f"t_oos={row['our_t_stat_oos_gross']} gate={row['gate_verdict']} "
+            f"survivor={row['meets_decisive_survivor_bar']} trades={row['trade_count']}",
+            flush=True,
+        )
 
     verdicts = {r["our_verdict"] for r in rows}
     decisive = [r["name"] for r in rows if r.get("meets_decisive_survivor_bar")]
@@ -111,7 +144,9 @@ def _real_run(args) -> int:
             "separate bounded backtest issue (explicit later decision, not auto-created)"
         )
     elif verdicts <= {"screened_out", "needs_more_data"}:
-        overall = "all_screened_out_or_insufficient — close line, open NO backtest issue"
+        overall = (
+            "all_screened_out_or_insufficient — close line, open NO backtest issue"
+        )
     else:
         overall = (
             "no_decisive_survivor — some candidates show positive GROSS at their native timeframe "
@@ -125,7 +160,11 @@ def _real_run(args) -> int:
         "schema_version": SCHEMA_VERSION,
         "config_hash": FROZEN_CONFIG.config_hash(),
         "config": FROZEN_CONFIG.to_dict(),
-        "data": {"symbols": list(symbols), "window": f"{args.window}", "venue": "binance_usdm_futures"},
+        "data": {
+            "symbols": list(symbols),
+            "window": f"{args.window}",
+            "venue": "binance_usdm_futures",
+        },
         "candidates": rows,
         "skipped": skipped,
         "overall_verdict": overall,
@@ -144,7 +183,9 @@ def _real_run(args) -> int:
             "leaderboard_access": "read-only via gstack /browse + read-only WebFetch",
         },
     }
-    assert artifact["config_hash"] == FROZEN_CONFIG.config_hash(), "frozen config drift!"
+    assert artifact["config_hash"] == FROZEN_CONFIG.config_hash(), (
+        "frozen config drift!"
+    )
 
     out_dir = "results/rob382"
     os.makedirs(out_dir, exist_ok=True)
@@ -153,16 +194,27 @@ def _real_run(args) -> int:
         json.dump(artifact, fh, indent=2, default=str)
     print(json.dumps(artifact, indent=2, default=str))
     print(f"\noverall: {overall}")
-    print(f"wrote {out_path} (gitignored). Author docs/runbooks/rob-382-strat-ninja-falsification.md from this.")
+    print(
+        f"wrote {out_path} (gitignored). Author docs/runbooks/rob-382-strat-ninja-falsification.md from this."
+    )
     return 0
 
 
 def main(argv=None) -> int:
-    ap = argparse.ArgumentParser(description="ROB-382 strat.ninja falsification spike (research only)")
-    ap.add_argument("--self-test", action="store_true",
-                    help="synthetic wiring proof (no network/data/modules); prints verdict table")
+    ap = argparse.ArgumentParser(
+        description="ROB-382 strat.ninja falsification spike (research only)"
+    )
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="synthetic wiring proof (no network/data/modules); prints verdict table",
+    )
     ap.add_argument("--symbols", default="BTCUSDT,ETHUSDT,XRPUSDT,SOLUSDT")
-    ap.add_argument("--window", default="2024-01..2025-12", help="recorded in artifact (fetch is separate)")
+    ap.add_argument(
+        "--window",
+        default="2024-01..2025-12",
+        help="recorded in artifact (fetch is separate)",
+    )
     ap.add_argument("--min-trades", type=int, default=100)
     args = ap.parse_args(argv)
 
@@ -170,7 +222,10 @@ def main(argv=None) -> int:
         result = _self_test()
         print(json.dumps(result, indent=2, default=str))
         from frozen_config import FROZEN_CONFIG
-        assert result["config_hash"] == FROZEN_CONFIG.config_hash(), "frozen config drift!"
+
+        assert result["config_hash"] == FROZEN_CONFIG.config_hash(), (
+            "frozen config drift!"
+        )
         return 0
     return _real_run(args)
 

--- a/research/nautilus_scalping/strategy_meanrev.py
+++ b/research/nautilus_scalping/strategy_meanrev.py
@@ -12,6 +12,7 @@ under-fills); the maker/taker per-leg fees are NOT charged here — the re-sim r
 on a ZERO-FEE instrument and ``maker_fill`` applies real fees to the gross P&L
 (maker on entry + the TP leg, taker on the SL leg) plus the conservative overlay.
 """
+
 from __future__ import annotations
 
 from collections import deque
@@ -30,16 +31,16 @@ class MeanRevScalperConfig(StrategyConfig, frozen=True):
     bar_type: BarType
     trade_size: str = "100"
     lookback: int = 20
-    z_entry: str = "2.0"           # Decimal-as-string (msgspec-safe)
+    z_entry: str = "2.0"  # Decimal-as-string (msgspec-safe)
     tp_bps: int = 30
     sl_bps: int = 30
     atr_period: int = 14
     atr_min_bps: int = 8
     require_vol: bool = True
     allow_short: bool = False
-    execution_mode: str = "taker"   # "taker" (default, unchanged) | "maker"
-    entry_offset_bps: int = 5       # maker: passive entry distance below/above close
-    fill_timeout_bars: int = 1      # maker: cancel an unfilled entry after N closed bars
+    execution_mode: str = "taker"  # "taker" (default, unchanged) | "maker"
+    entry_offset_bps: int = 5  # maker: passive entry distance below/above close
+    fill_timeout_bars: int = 1  # maker: cancel an unfilled entry after N closed bars
 
 
 class MeanRevScalper(Strategy):
@@ -67,10 +68,12 @@ class MeanRevScalper(Strategy):
         self._entry_submitted_bar: int | None = None
         self._bar_count = 0
         self._entry_px: Decimal | None = None
-        self._adverse_px: Decimal | None = None    # worst price vs entry while in position
-        self._exit_px: Decimal | None = None       # price that triggered the exit
-        self._tp_hit = False                       # last exit was the TP leg (vs SL)
-        self.records: list[dict] = []              # maker: completed trade records
+        self._adverse_px: Decimal | None = (
+            None  # worst price vs entry while in position
+        )
+        self._exit_px: Decimal | None = None  # price that triggered the exit
+        self._tp_hit = False  # last exit was the TP leg (vs SL)
+        self.records: list[dict] = []  # maker: completed trade records
         self.entries_attempted = 0
         self.entries_filled = 0
 
@@ -84,9 +87,13 @@ class MeanRevScalper(Strategy):
         self._candles.append(bar_to_candle(bar))
 
         # maker: cancel a stale unfilled entry limit (missed fill)
-        if (self.config.execution_mode == "maker" and self._entry_order is not None
-                and self._entry_submitted_bar is not None
-                and self._bar_count - self._entry_submitted_bar >= self.config.fill_timeout_bars):
+        if (
+            self.config.execution_mode == "maker"
+            and self._entry_order is not None
+            and self._entry_submitted_bar is not None
+            and self._bar_count - self._entry_submitted_bar
+            >= self.config.fill_timeout_bars
+        ):
             self.cancel_order(self._entry_order)
             self._entry_order = None
             self._entry_submitted_bar = None
@@ -95,7 +102,7 @@ class MeanRevScalper(Strategy):
             return
         if not self.portfolio.is_flat(self.config.instrument_id):
             return
-        if self._entry_order is not None:   # maker: a limit is still working
+        if self._entry_order is not None:  # maker: a limit is still working
             return
         d = evaluate_meanrev(list(self._candles), self._cfg)
         if d.has_entry and d.side == "BUY":
@@ -103,23 +110,33 @@ class MeanRevScalper(Strategy):
         elif d.has_entry and d.side == "SELL":
             self._enter(OrderSide.SELL, d.entry_price, d.tp_price, d.sl_price)
 
-    def _enter(self, side: OrderSide, entry: Decimal, tp: Decimal | None, sl: Decimal | None) -> None:
+    def _enter(
+        self, side: OrderSide, entry: Decimal, tp: Decimal | None, sl: Decimal | None
+    ) -> None:
         self._tp, self._sl, self._side = tp, sl, side
         if self.config.execution_mode == "taker":
             order = self.order_factory.market(
-                instrument_id=self.config.instrument_id, order_side=side,
-                quantity=self._instrument.make_qty(Decimal(self.config.trade_size)))
+                instrument_id=self.config.instrument_id,
+                order_side=side,
+                quantity=self._instrument.make_qty(Decimal(self.config.trade_size)),
+            )
             self.submit_order(order)
             return
         # maker: passive limit OFFSET from the close (below for BUY, above for SELL) so
         # immediate reversions are missed and continued moves fill (entry adverse selection).
         self.entries_attempted += 1
         off = Decimal(self.config.entry_offset_bps) / Decimal("10000")
-        limit_px = entry * (Decimal("1") - off) if side == OrderSide.BUY else entry * (Decimal("1") + off)
+        limit_px = (
+            entry * (Decimal("1") - off)
+            if side == OrderSide.BUY
+            else entry * (Decimal("1") + off)
+        )
         order = self.order_factory.limit(
-            instrument_id=self.config.instrument_id, order_side=side,
+            instrument_id=self.config.instrument_id,
+            order_side=side,
             quantity=self._instrument.make_qty(Decimal(self.config.trade_size)),
-            price=self._instrument.make_price(limit_px))
+            price=self._instrument.make_price(limit_px),
+        )
         self._entry_order = order
         self._entry_submitted_bar = self._bar_count
         self.submit_order(order)
@@ -183,23 +200,33 @@ class MeanRevScalper(Strategy):
         if self.config.execution_mode != "maker":
             return
         pos = self.cache.position(event.position_id)
-        entry = self._entry_px if self._entry_px is not None else Decimal(str(pos.avg_px_open))
-        exit_px = self._exit_px if self._exit_px is not None else Decimal(str(pos.avg_px_open))
+        entry = (
+            self._entry_px
+            if self._entry_px is not None
+            else Decimal(str(pos.avg_px_open))
+        )
+        exit_px = (
+            self._exit_px
+            if self._exit_px is not None
+            else Decimal(str(pos.avg_px_open))
+        )
         qty = float(pos.peak_qty)
         if self._side == OrderSide.SELL:
             adverse = ((self._adverse_px or entry) - entry) / entry * Decimal("10000")
         else:
             adverse = (entry - (self._adverse_px or entry)) / entry * Decimal("10000")
-        self.records.append({
-            "gross": pos.realized_pnl.as_double(),       # zero-fee instrument => pure price P&L
-            "entry_notional": float(entry) * qty,
-            "exit_notional": float(exit_px) * qty,
-            "ts": int(pos.ts_opened),
-            "ts_closed": int(pos.ts_closed),
-            "filled": True,
-            "tp_hit": bool(self._tp_hit),
-            "adverse_bps": float(max(Decimal("0"), adverse)),
-        })
+        self.records.append(
+            {
+                "gross": pos.realized_pnl.as_double(),  # zero-fee instrument => pure price P&L
+                "entry_notional": float(entry) * qty,
+                "exit_notional": float(exit_px) * qty,
+                "ts": int(pos.ts_opened),
+                "ts_closed": int(pos.ts_closed),
+                "filled": True,
+                "tp_hit": bool(self._tp_hit),
+                "adverse_bps": float(max(Decimal("0"), adverse)),
+            }
+        )
         self._entry_px = self._adverse_px = self._exit_px = None
         self._tp = self._sl = self._side = None
         self._tp_hit = False

--- a/research/nautilus_scalping/strategy_random.py
+++ b/research/nautilus_scalping/strategy_random.py
@@ -5,6 +5,7 @@ Enters long with fixed probability per warmed bar using a DETERMINISTIC
 as the real strategies. This isolates "does the candidate beat coin-flip entries
 with identical exits/costs?" — a required ROB-320 baseline.
 """
+
 from __future__ import annotations
 
 import random
@@ -50,10 +51,15 @@ class RandomScalper(Strategy):
         if self._rng.random() >= self.config.entry_prob:
             return
         entry = bar.close.as_decimal()
-        self._tp = entry * (Decimal("1") + Decimal(self.config.tp_bps) / Decimal("10000"))
-        self._sl = entry * (Decimal("1") - Decimal(self.config.sl_bps) / Decimal("10000"))
+        self._tp = entry * (
+            Decimal("1") + Decimal(self.config.tp_bps) / Decimal("10000")
+        )
+        self._sl = entry * (
+            Decimal("1") - Decimal(self.config.sl_bps) / Decimal("10000")
+        )
         order = self.order_factory.market(
-            instrument_id=self.config.instrument_id, order_side=OrderSide.BUY,
+            instrument_id=self.config.instrument_id,
+            order_side=OrderSide.BUY,
             quantity=self._instrument.make_qty(Decimal(self.config.trade_size)),
         )
         self.submit_order(order)
@@ -62,7 +68,9 @@ class RandomScalper(Strategy):
         if self.portfolio.is_flat(self.config.instrument_id):
             return
         price = tick.price.as_decimal()
-        if (self._sl is not None and price <= self._sl) or (self._tp is not None and price >= self._tp):
+        if (self._sl is not None and price <= self._sl) or (
+            self._tp is not None and price >= self._tp
+        ):
             self._tp = self._sl = None
             self.close_all_positions(self.config.instrument_id)
 

--- a/research/nautilus_scalping/tests/test_campaign.py
+++ b/research/nautilus_scalping/tests/test_campaign.py
@@ -13,27 +13,59 @@ from frozen_config import FROZEN_CONFIG
 
 
 def _trades(gross_each, n, notional=1000.0):
-    return [families.make_taker_trade(gross_each, ts=i, notional=notional) for i in range(n)]
+    return [
+        families.make_taker_trade(gross_each, ts=i, notional=notional) for i in range(n)
+    ]
 
 
 def test_campaign_produces_verdict_table_with_three_outcomes():
     specs = [
         # net-viable: big gross, survives taker fees -> promote_to_pilot
-        {"name": "A_net_viable",
-         "summary": HypothesisSummary("A", "c", 40, gross_expectancy_bps=8.0,
-                                      fee_adjusted_bps=4.0, oos_gross_bps=8.0),
-         "kind": "trade", "data": _trades(5.0, 40), "maker_conservative_net": None},
+        {
+            "name": "A_net_viable",
+            "summary": HypothesisSummary(
+                "A",
+                "c",
+                40,
+                gross_expectancy_bps=8.0,
+                fee_adjusted_bps=4.0,
+                oos_gross_bps=8.0,
+            ),
+            "kind": "trade",
+            "data": _trades(5.0, 40),
+            "maker_conservative_net": None,
+        },
         # cost-binding + closable: gross>0, taker-net<0, maker-conservative>0 -> 343 candidate
-        {"name": "B_cost_binding",
-         "summary": HypothesisSummary("B", "c", 40, gross_expectancy_bps=6.0,
-                                      fee_adjusted_bps=-2.0, oos_gross_bps=6.0),
-         # gross +0.5/trade but taker fee (~0.8/trade) pushes net negative
-         "kind": "trade", "data": _trades(0.5, 40), "maker_conservative_net": 1.5},
+        {
+            "name": "B_cost_binding",
+            "summary": HypothesisSummary(
+                "B",
+                "c",
+                40,
+                gross_expectancy_bps=6.0,
+                fee_adjusted_bps=-2.0,
+                oos_gross_bps=6.0,
+            ),
+            # gross +0.5/trade but taker fee (~0.8/trade) pushes net negative
+            "kind": "trade",
+            "data": _trades(0.5, 40),
+            "maker_conservative_net": 1.5,
+        },
         # no gross edge -> screened_out at Stage 1, never reaches the gate
-        {"name": "C_screened",
-         "summary": HypothesisSummary("C", "c", 40, gross_expectancy_bps=-1.0,
-                                      fee_adjusted_bps=-3.0, oos_gross_bps=-1.0),
-         "kind": "trade", "data": _trades(-2.0, 40), "maker_conservative_net": None},
+        {
+            "name": "C_screened",
+            "summary": HypothesisSummary(
+                "C",
+                "c",
+                40,
+                gross_expectancy_bps=-1.0,
+                fee_adjusted_bps=-3.0,
+                oos_gross_bps=-1.0,
+            ),
+            "kind": "trade",
+            "data": _trades(-2.0, 40),
+            "maker_conservative_net": None,
+        },
     ]
     rep = campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
 

--- a/research/nautilus_scalping/tests/test_campaign_controls.py
+++ b/research/nautilus_scalping/tests/test_campaign_controls.py
@@ -21,13 +21,33 @@ def test_max_drawdown_bps_on_cumulative_pnl():
 
 
 def test_filter_universe_uses_membership_and_quality():
-    m = pit_universe.PITManifest.from_records([
-        {"symbol": "GOOD", "listed_from": 0, "delisted_at": None, "status": "live",
-         "kline_coverage": 1.0, "confidence": "high"},
-        {"symbol": "LOWCOV", "listed_from": 0, "delisted_at": None, "status": "live",
-         "kline_coverage": 0.5, "confidence": "low"},
-        {"symbol": "OUTWINDOW", "listed_from": 100 * DAY, "delisted_at": None, "status": "live",
-         "kline_coverage": 1.0, "confidence": "high"},
-    ])
+    m = pit_universe.PITManifest.from_records(
+        [
+            {
+                "symbol": "GOOD",
+                "listed_from": 0,
+                "delisted_at": None,
+                "status": "live",
+                "kline_coverage": 1.0,
+                "confidence": "high",
+            },
+            {
+                "symbol": "LOWCOV",
+                "listed_from": 0,
+                "delisted_at": None,
+                "status": "live",
+                "kline_coverage": 0.5,
+                "confidence": "low",
+            },
+            {
+                "symbol": "OUTWINDOW",
+                "listed_from": 100 * DAY,
+                "delisted_at": None,
+                "status": "live",
+                "kline_coverage": 1.0,
+                "confidence": "high",
+            },
+        ]
+    )
     kept = campaign_controls.filter_universe(m, lo_ts=0, hi_ts=10 * DAY)
     assert kept == ["GOOD"]

--- a/research/nautilus_scalping/tests/test_campaign_specs.py
+++ b/research/nautilus_scalping/tests/test_campaign_specs.py
@@ -15,7 +15,9 @@ def test_summary_from_trades_gross_net_and_oos_split():
     s = campaign_specs._summary_from_trades("f1", trades, split)
     assert s.sample_count == 3
     assert round(s.gross_expectancy_bps, 6) == round((100 + 50 - 20) / 3, 6)
-    assert round(s.fee_adjusted_bps, 6) == round(((100 - 20) + (50 - 20) + (-20 - 20)) / 3, 6)
+    assert round(s.fee_adjusted_bps, 6) == round(
+        ((100 - 20) + (50 - 20) + (-20 - 20)) / 3, 6
+    )
     assert round(s.oos_gross_bps, 6) == -20.0
     assert round(s.oos_fee_adjusted_bps, 6) == -40.0
 
@@ -63,10 +65,18 @@ def test_ts_trend_spec_is_portfolio():
 
 
 def test_xs_momentum_spec_is_portfolio_pit_aware():
-    panel = {s: _ramp(0, 40, base=b) for s, b in [("AUSDT", 100), ("BUSDT", 50), ("CUSDT", 75)]}
+    panel = {
+        s: _ramp(0, 40, base=b)
+        for s, b in [("AUSDT", 100), ("BUSDT", 50), ("CUSDT", 75)]
+    }
     import pit_universe
-    m = pit_universe.PITManifest.from_records([{"symbol": s, "listed_from": 0} for s in panel])
+
+    m = pit_universe.PITManifest.from_records(
+        [{"symbol": s, "listed_from": 0} for s in panel]
+    )
     rebals = [10 * DAY, 17 * DAY, 24 * DAY, 31 * DAY]
-    spec = campaign_specs.xs_momentum_spec(panel, rebals, m, oos_split_ts=campaign_specs.OOS_SPLIT_TS)
+    spec = campaign_specs.xs_momentum_spec(
+        panel, rebals, m, oos_split_ts=campaign_specs.OOS_SPLIT_TS
+    )
     assert spec["name"] == "family3_xs_momentum"
     assert spec["kind"] == "portfolio"

--- a/research/nautilus_scalping/tests/test_candidates.py
+++ b/research/nautilus_scalping/tests/test_candidates.py
@@ -7,9 +7,9 @@ from candidates import REGISTRY, get_candidate
 
 
 def test_registry_has_required_members() -> None:
-    assert "micro_breakout" in REGISTRY        # baseline, not silently treated as viable
-    assert "meanrev_zscore_fade" in REGISTRY    # the new non-breakout candidate
-    assert "random_entry" in REGISTRY           # honest control
+    assert "micro_breakout" in REGISTRY  # baseline, not silently treated as viable
+    assert "meanrev_zscore_fade" in REGISTRY  # the new non-breakout candidate
+    assert "random_entry" in REGISTRY  # honest control
 
 
 def test_candidate_metadata_shape() -> None:
@@ -21,18 +21,34 @@ def test_candidate_metadata_shape() -> None:
 
 def test_pure_signal_is_deterministic_via_registry() -> None:
     from app.services.brokers.binance.demo_scalping.signal import Candle
+
     c = get_candidate("meanrev_zscore_fade")
     candles = [
-        Candle(open_time_ms=i * 60_000, open=Decimal("100"), high=Decimal("100.5"),
-               low=Decimal("99.5"), close=Decimal("100"), close_time_ms=i * 60_000)
+        Candle(
+            open_time_ms=i * 60_000,
+            open=Decimal("100"),
+            high=Decimal("100.5"),
+            low=Decimal("99.5"),
+            close=Decimal("100"),
+            close_time_ms=i * 60_000,
+        )
         for i in range(19)
-    ] + [Candle(open_time_ms=19 * 60_000, open=Decimal("97"), high=Decimal("100"),
-                low=Decimal("96.5"), close=Decimal("97"), close_time_ms=19 * 60_000)]
+    ] + [
+        Candle(
+            open_time_ms=19 * 60_000,
+            open=Decimal("97"),
+            high=Decimal("100"),
+            low=Decimal("96.5"),
+            close=Decimal("97"),
+            close_time_ms=19 * 60_000,
+        )
+    ]
     cfg = c.config_factory(c.default_params)
     assert c.pure_signal(candles, cfg) == c.pure_signal(candles, cfg)
 
 
 def test_unknown_candidate_raises() -> None:
     import pytest
+
     with pytest.raises(KeyError):
         get_candidate("does_not_exist")

--- a/research/nautilus_scalping/tests/test_discovery_cost_blind.py
+++ b/research/nautilus_scalping/tests/test_discovery_cost_blind.py
@@ -11,8 +11,12 @@ from discovery.screen import HypothesisSummary, classify
 
 def _summary(gross, fee_adj, *, oos=None, oos_gross=None, samples=300, name="h"):
     return HypothesisSummary(
-        name=name, conditions="c", sample_count=samples,
-        gross_expectancy_bps=gross, fee_adjusted_bps=fee_adj, oos_fee_adjusted_bps=oos,
+        name=name,
+        conditions="c",
+        sample_count=samples,
+        gross_expectancy_bps=gross,
+        fee_adjusted_bps=fee_adj,
+        oos_fee_adjusted_bps=oos,
         oos_gross_bps=oos_gross,
     )
 

--- a/research/nautilus_scalping/tests/test_families.py
+++ b/research/nautilus_scalping/tests/test_families.py
@@ -12,7 +12,9 @@ from validated_gate import PortfolioPeriod, Trade, portfolio_metrics_at_fee
 
 
 def test_make_taker_trade_gross_and_commission():
-    t = families.make_taker_trade(gross_pnl=5.0, ts=1, notional=1000.0, ref_fee_bps=10.0)
+    t = families.make_taker_trade(
+        gross_pnl=5.0, ts=1, notional=1000.0, ref_fee_bps=10.0
+    )
     assert isinstance(t, Trade)
     # zero-fee net == gross; commission is the 2-leg ref fee on notional
     assert abs(cost_model.net_at_fee(t.net_ref_pnl, t.commission_ref, 0.0) - 5.0) < 1e-9
@@ -22,9 +24,11 @@ def test_make_taker_trade_gross_and_commission():
 def test_breakout_continuation_enters_on_breakout():
     # flat then a clean breakout + continuation
     bars = [families.Bar(ts=i, high=100.0, low=99.0, close=100.0) for i in range(20)]
-    bars += [families.Bar(ts=20, high=105.0, low=100.0, close=105.0),
-             families.Bar(ts=21, high=107.0, low=104.0, close=107.0),
-             families.Bar(ts=22, high=109.0, low=106.0, close=109.0)]
+    bars += [
+        families.Bar(ts=20, high=105.0, low=100.0, close=105.0),
+        families.Bar(ts=21, high=107.0, low=104.0, close=107.0),
+        families.Bar(ts=22, high=109.0, low=106.0, close=109.0),
+    ]
     trades = families.breakout_continuation_trades(bars, lookback=20, hold=2)
     assert len(trades) >= 1
     assert all(isinstance(t, Trade) for t in trades)
@@ -41,16 +45,20 @@ def test_ts_trend_basket_longs_up_shorts_down():
     down = [(i, 100.0 - i) for i in range(40)]
     periods = families.ts_trend_basket_periods({"AAA": up, "BBB": down}, lookback=10)
     assert all(isinstance(p, PortfolioPeriod) for p in periods)
-    assert portfolio_metrics_at_fee(periods, 0.0).net_pnl > 0  # gross edge on the fixture
+    assert (
+        portfolio_metrics_at_fee(periods, 0.0).net_pnl > 0
+    )  # gross edge on the fixture
 
 
 def test_xs_momentum_periods_emit_and_respect_lookback():
     closes = {
-        "AAA": [(i, 100.0 + 2 * i) for i in range(40)],   # strongest momentum
+        "AAA": [(i, 100.0 + 2 * i) for i in range(40)],  # strongest momentum
         "BBB": [(i, 100.0 + i) for i in range(40)],
-        "CCC": [(i, 100.0 - i) for i in range(40)],       # weakest
+        "CCC": [(i, 100.0 - i) for i in range(40)],  # weakest
     }
     rebalances = [20, 25, 30]
-    periods = families.xs_momentum_periods(closes, rebalances=rebalances, lookback=10, top_k=1)
+    periods = families.xs_momentum_periods(
+        closes, rebalances=rebalances, lookback=10, top_k=1
+    )
     assert all(isinstance(p, PortfolioPeriod) for p in periods)
     assert len(periods) >= 1

--- a/research/nautilus_scalping/tests/test_gate_stats_hardening.py
+++ b/research/nautilus_scalping/tests/test_gate_stats_hardening.py
@@ -18,13 +18,19 @@ def test_block_bootstrap_is_deterministic_and_well_formed():
     a = vg.block_bootstrap_sharpe_ci(pnls, block_size=5, n_bootstrap=200, seed=7)
     b = vg.block_bootstrap_sharpe_ci(pnls, block_size=5, n_bootstrap=200, seed=7)
     assert a == b  # reproducible
-    assert a["ci_lower"] <= a["observed_sharpe"] <= a["ci_upper"] or a["ci_lower"] <= a["ci_upper"]
+    assert (
+        a["ci_lower"] <= a["observed_sharpe"] <= a["ci_upper"]
+        or a["ci_lower"] <= a["ci_upper"]
+    )
     assert a["block_size"] == 5
     assert 0.0 <= a["prob_positive"] <= 1.0
 
 
 def test_block_bootstrap_insufficient_data():
-    assert vg.block_bootstrap_sharpe_ci([1.0], block_size=5)["error"] == "insufficient_data"
+    assert (
+        vg.block_bootstrap_sharpe_ci([1.0], block_size=5)["error"]
+        == "insufficient_data"
+    )
 
 
 def test_benjamini_hochberg_controls_fdr():
@@ -43,13 +49,16 @@ def test_effect_size_aware_min_trades_monotonic():
     n1 = vg.effect_size_aware_min_trades(observed_sharpe=0.1, n_configs_tried=1)
     n10 = vg.effect_size_aware_min_trades(observed_sharpe=0.1, n_configs_tried=10)
     big = vg.effect_size_aware_min_trades(observed_sharpe=0.3, n_configs_tried=1)
-    assert n10 > n1            # more shots tried -> need more evidence
-    assert big < n1            # bigger effect -> need fewer trades
-    assert n1 == 400           # (2.0 / 0.1)^2 at m=1
+    assert n10 > n1  # more shots tried -> need more evidence
+    assert big < n1  # bigger effect -> need fewer trades
+    assert n1 == 400  # (2.0 / 0.1)^2 at m=1
 
 
 def test_effect_size_aware_min_trades_zero_effect_is_infinite():
-    assert vg.effect_size_aware_min_trades(observed_sharpe=0.0, n_configs_tried=1) == math.inf
+    assert (
+        vg.effect_size_aware_min_trades(observed_sharpe=0.0, n_configs_tried=1)
+        == math.inf
+    )
 
 
 def test_turnover_matched_random_baseline_matches_count_and_is_deterministic():

--- a/research/nautilus_scalping/tests/test_ict_signal.py
+++ b/research/nautilus_scalping/tests/test_ict_signal.py
@@ -25,8 +25,12 @@ _HOUR_MS = 3_600_000
 def _c(close, high, low, *, ts=0) -> Candle:
     d = lambda x: Decimal(str(x))  # noqa: E731
     return Candle(
-        open_time_ms=ts, open=d(close), high=d(high), low=d(low),
-        close=d(close), close_time_ms=ts,
+        open_time_ms=ts,
+        open=d(close),
+        high=d(high),
+        low=d(low),
+        close=d(close),
+        close_time_ms=ts,
     )
 
 
@@ -49,7 +53,9 @@ def test_bullish_fvg_detected() -> None:
 
 
 def test_bullish_fvg_absent_in_steady_rise() -> None:
-    candles = [_c(100 + 0.1 * i, 100 + 0.1 * i + 0.3, 100 + 0.1 * i - 0.3) for i in range(5)]
+    candles = [
+        _c(100 + 0.1 * i, 100 + 0.1 * i + 0.3, 100 + 0.1 * i - 0.3) for i in range(5)
+    ]
     assert not has_bullish_fvg(candles, lookback=3)
 
 

--- a/research/nautilus_scalping/tests/test_maker_fill.py
+++ b/research/nautilus_scalping/tests/test_maker_fill.py
@@ -4,6 +4,7 @@
 Records (zero-fee gross + notionals) in, validated_gate.Trade lists out. No
 nautilus; fully deterministic. Fees applied per leg: maker 2bps on entry + the TP
 leg, taker 4bps on the SL leg."""
+
 from __future__ import annotations
 
 from maker_fill import (
@@ -17,10 +18,17 @@ from maker_fill import (
 from validated_gate import Trade, evaluate_gate, metrics_at_fee
 
 
-def _rec(gross, notional, ts, *, filled=True, tp_hit=True, adverse=0.0) -> MakerTradeRecord:
+def _rec(
+    gross, notional, ts, *, filled=True, tp_hit=True, adverse=0.0
+) -> MakerTradeRecord:
     return MakerTradeRecord(
-        gross=gross, entry_notional=notional, exit_notional=notional,
-        ts_opened=ts, filled=filled, tp_hit=tp_hit, adverse_excursion_bps=adverse,
+        gross=gross,
+        entry_notional=notional,
+        exit_notional=notional,
+        ts_opened=ts,
+        filled=filled,
+        tp_hit=tp_hit,
+        adverse_excursion_bps=adverse,
     )
 
 
@@ -38,18 +46,18 @@ def test_optimistic_excludes_missed_fills_and_applies_maker_fees() -> None:
     # tp_hit => exit leg is maker (2bps); fee = 2bps*100/1e4 (entry) + 2bps*100/1e4 (TP) = 0.04
     recs = [
         _rec(0.50, 100.0, 1, filled=True, tp_hit=True),
-        _rec(0.00, 100.0, 2, filled=False),              # missed fill -> dropped
+        _rec(0.00, 100.0, 2, filled=False),  # missed fill -> dropped
         _rec(-0.30, 100.0, 3, filled=True, tp_hit=True),
     ]
     trades = build_maker_optimistic(recs)
-    assert len(trades) == 2                              # missed fill excluded
+    assert len(trades) == 2  # missed fill excluded
     assert all(isinstance(t, Trade) for t in trades)
     # net_after_cost at the gate reference point == as-run true net (gross - fees)
     m = metrics_at_fee(trades, fee_bps=10.0, fold="net_after_cost")
-    assert round(m.net_pnl, 4) == round((0.50 - 0.04) + (-0.30 - 0.04), 4)   # 0.12
+    assert round(m.net_pnl, 4) == round((0.50 - 0.04) + (-0.30 - 0.04), 4)  # 0.12
     # gross column (fee=0) adds the fee back -> recovers the fee-free gross sum
     g = metrics_at_fee(trades, fee_bps=0.0, fold="gross")
-    assert round(g.net_pnl, 4) == round(0.50 + (-0.30), 4)                   # 0.20
+    assert round(g.net_pnl, 4) == round(0.50 + (-0.30), 4)  # 0.20
 
 
 def test_sl_exit_charges_taker_fee_on_exit_leg() -> None:
@@ -70,16 +78,18 @@ def test_conservative_applies_adverse_cost_to_survivors() -> None:
     recs = [_rec(0.50, 100.0, 1, tp_hit=True, adverse=9.0)]
     t = build_maker_conservative(recs, queue_loss_pct=0.25, adverse_bps=1.0)[0]
     # fee 0.04 (maker entry + maker TP) + adverse 1bps*100/1e4 = 0.01
-    assert round(t.net_ref_pnl, 4) == round(0.50 - 0.04 - 0.01, 4)           # 0.45
+    assert round(t.net_ref_pnl, 4) == round(0.50 - 0.04 - 0.01, 4)  # 0.45
 
 
 def test_conservative_drops_about_quarter_of_easy_tp_fills_deterministically() -> None:
     easy = [_rec(0.50, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(2000)]
     first = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
     second = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
-    assert [t.ts_opened for t in first] == [t.ts_opened for t in second]     # deterministic
+    assert [t.ts_opened for t in first] == [
+        t.ts_opened for t in second
+    ]  # deterministic
     dropped = 2000 - len(first)
-    assert 400 <= dropped <= 600                                            # ~25%
+    assert 400 <= dropped <= 600  # ~25%
 
 
 def test_conservative_excludes_missed_fills() -> None:
@@ -90,19 +100,28 @@ def test_conservative_is_strictly_worse_than_optimistic() -> None:
     recs = [_rec(0.50, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(500)]
     opt = metrics_at_fee(build_maker_optimistic(recs), 10.0).net_pnl
     con = metrics_at_fee(build_maker_conservative(recs), 10.0).net_pnl
-    assert con < opt                                                        # haircuts only hurt
+    assert con < opt  # haircuts only hurt
 
 
 def test_maker_scenario_verdict_stays_in_vocabulary() -> None:
-    recs = [_rec(0.20, 100.0, ts, tp_hit=(ts % 2 == 0), adverse=float(ts % 5))
-            for ts in range(400)]
-    losers = [Trade(net_ref_pnl=-0.5, commission_ref=0.04, notional=100.0, ts_opened=ts)
-              for ts in range(400)]
+    recs = [
+        _rec(0.20, 100.0, ts, tp_hit=(ts % 2 == 0), adverse=float(ts % 5))
+        for ts in range(400)
+    ]
+    losers = [
+        Trade(net_ref_pnl=-0.5, commission_ref=0.04, notional=100.0, ts_opened=ts)
+        for ts in range(400)
+    ]
     for builder in (build_maker_optimistic, build_maker_conservative):
         trades = builder(recs)
         report = evaluate_gate(
             candidate_runs={"maker_fill": trades},
-            baseline_breakout=losers, baseline_random=losers,
-            fee_bps=10.0, min_trades=100,
-            candidate_name="t", hypothesis="mean_reversion", symbols=["XRPUSDT"])
+            baseline_breakout=losers,
+            baseline_random=losers,
+            fee_bps=10.0,
+            min_trades=100,
+            candidate_name="t",
+            hypothesis="mean_reversion",
+            symbols=["XRPUSDT"],
+        )
         assert report.verdict in {"validated", "not_validated", "insufficient_data"}

--- a/research/nautilus_scalping/tests/test_meanrev_parity.py
+++ b/research/nautilus_scalping/tests/test_meanrev_parity.py
@@ -7,6 +7,7 @@ handling. The Nautilus bar-adaptation parity reuses ``bar_to_candle`` and is
 skipped if the research venv (nautilus_trader) is unavailable — documented as a
 parity limitation per the ROB-320 acceptance criterion.
 """
+
 from __future__ import annotations
 
 from decimal import Decimal
@@ -25,8 +26,16 @@ _BAR_TYPE = BarType.from_str("XRPUSDT.BINANCE-1-MINUTE-LAST-INTERNAL")
 
 
 def _bar(close: float, high: float, low: float, ts_ns: int) -> Bar:
-    return Bar(_BAR_TYPE, Price(close, 4), Price(high, 4), Price(low, 4),
-               Price(close, 4), Quantity(100, 1), ts_event=ts_ns, ts_init=ts_ns)
+    return Bar(
+        _BAR_TYPE,
+        Price(close, 4),
+        Price(high, 4),
+        Price(low, 4),
+        Price(close, 4),
+        Quantity(100, 1),
+        ts_event=ts_ns,
+        ts_init=ts_ns,
+    )
 
 
 def test_bar_adaptation_feeds_same_decision() -> None:
@@ -35,13 +44,29 @@ def test_bar_adaptation_feeds_same_decision() -> None:
     bars.append(_bar(97.0, 100.0, 96.5, 19 * 60_000_000_000))
     candles_from_bars = [bar_to_candle(b) for b in bars]
     candles_direct = [
-        Candle(open_time_ms=i * 60_000, open=Decimal("100"), high=Decimal("100.5"),
-               low=Decimal("99.5"), close=Decimal("100"), close_time_ms=i * 60_000)
+        Candle(
+            open_time_ms=i * 60_000,
+            open=Decimal("100"),
+            high=Decimal("100.5"),
+            low=Decimal("99.5"),
+            close=Decimal("100"),
+            close_time_ms=i * 60_000,
+        )
         for i in range(19)
-    ] + [Candle(open_time_ms=19 * 60_000, open=Decimal("97"), high=Decimal("100"),
-                low=Decimal("96.5"), close=Decimal("97"), close_time_ms=19 * 60_000)]
+    ] + [
+        Candle(
+            open_time_ms=19 * 60_000,
+            open=Decimal("97"),
+            high=Decimal("100"),
+            low=Decimal("96.5"),
+            close=Decimal("97"),
+            close_time_ms=19 * 60_000,
+        )
+    ]
     cfg = MeanRevConfig(require_vol=False)
-    assert evaluate_meanrev(candles_from_bars, cfg) == evaluate_meanrev(candles_direct, cfg)
+    assert evaluate_meanrev(candles_from_bars, cfg) == evaluate_meanrev(
+        candles_direct, cfg
+    )
 
 
 def test_required_bars_matches_config() -> None:

--- a/research/nautilus_scalping/tests/test_meanrev_signal.py
+++ b/research/nautilus_scalping/tests/test_meanrev_signal.py
@@ -4,6 +4,7 @@
 Each rule is a pure function; these pin entry logic, the no-entry reasons,
 determinism, and no-lookahead (truncation invariance).
 """
+
 from __future__ import annotations
 
 from decimal import Decimal
@@ -17,10 +18,12 @@ def _c(close, high=None, low=None, *, ts=0) -> Candle:
     d = lambda x: Decimal(str(x))  # noqa: E731
     cv = d(close)
     return Candle(
-        open_time_ms=ts, open=cv,
+        open_time_ms=ts,
+        open=cv,
         high=d(high) if high is not None else cv,
         low=d(low) if low is not None else cv,
-        close=cv, close_time_ms=ts,
+        close=cv,
+        close_time_ms=ts,
     )
 
 
@@ -56,7 +59,9 @@ def test_within_band_with_dispersion_no_entry() -> None:
     # slight fluctuation so sd > 0, but no extreme dip or spike -> within band
     candles = [_c(100 + (i % 2), 101, 99, ts=i * 60_000) for i in range(19)]
     candles.append(_c(100, 101, 99, ts=19 * 60_000))
-    d = evaluate_meanrev(candles, MeanRevConfig(require_vol=False, z_entry=Decimal("2.0")))
+    d = evaluate_meanrev(
+        candles, MeanRevConfig(require_vol=False, z_entry=Decimal("2.0"))
+    )
     assert not d.has_entry and d.reason_codes == ("WITHIN_BAND",)
 
 

--- a/research/nautilus_scalping/tests/test_panel.py
+++ b/research/nautilus_scalping/tests/test_panel.py
@@ -21,12 +21,15 @@ def _closes():
 
 def test_iter_is_lazy_generator():
     import types
+
     g = panel.iter_rebalance_cross_sections(_closes(), rebalances=[20, 30], lookback=10)
     assert isinstance(g, types.GeneratorType)
 
 
 def test_cross_section_lookback_return():
-    out = dict(panel.iter_rebalance_cross_sections(_closes(), rebalances=[20], lookback=10))
+    out = dict(
+        panel.iter_rebalance_cross_sections(_closes(), rebalances=[20], lookback=10)
+    )
     # at ts=20, lookback 10: AAA 121/110-1=0.10, BBB 48/49-1<0
     xs = out[20]
     assert abs(xs["AAA"] - (121.0 / 110.0 - 1.0)) < 1e-9
@@ -34,18 +37,29 @@ def test_cross_section_lookback_return():
 
 
 def test_pit_excludes_unlisted_symbol():
-    m = PITManifest.from_records([
-        {"symbol": "AAA", "listed_from": 0, "delisted_at": None},
-        {"symbol": "BBB", "listed_from": 0, "delisted_at": None},
-        {"symbol": "CCC", "listed_from": 25, "delisted_at": None},  # lists after ts=20
-    ])
-    out = dict(panel.iter_rebalance_cross_sections(
-        _closes(), rebalances=[20], lookback=10, manifest=m))
-    assert "CCC" not in out[20]   # unlisted as-of ts=20 -> leak guard
+    m = PITManifest.from_records(
+        [
+            {"symbol": "AAA", "listed_from": 0, "delisted_at": None},
+            {"symbol": "BBB", "listed_from": 0, "delisted_at": None},
+            {
+                "symbol": "CCC",
+                "listed_from": 25,
+                "delisted_at": None,
+            },  # lists after ts=20
+        ]
+    )
+    out = dict(
+        panel.iter_rebalance_cross_sections(
+            _closes(), rebalances=[20], lookback=10, manifest=m
+        )
+    )
+    assert "CCC" not in out[20]  # unlisted as-of ts=20 -> leak guard
     assert "AAA" in out[20]
 
 
 def test_symbol_without_enough_lookback_history_skipped():
     # CCC has no bar at ts<=10, so a lookback-10 return at ts=20 is impossible
-    out = dict(panel.iter_rebalance_cross_sections(_closes(), rebalances=[20], lookback=10))
+    out = dict(
+        panel.iter_rebalance_cross_sections(_closes(), rebalances=[20], lookback=10)
+    )
     assert "CCC" not in out[20]

--- a/research/nautilus_scalping/tests/test_pit_bars.py
+++ b/research/nautilus_scalping/tests/test_pit_bars.py
@@ -36,15 +36,32 @@ def test_load_bars_unknown_symbol_returns_empty(tmp_path):
 
 
 def test_load_panel_aligns_close_series(tmp_path):
-    _write_csv(tmp_path, "AUSDT", "1d", "1970-01",
-               [[1 * DAY, 1, 1, 1, 100, 5, 0, 0, 0, 0, 0, 0],
-                [2 * DAY, 1, 1, 1, 110, 5, 0, 0, 0, 0, 0, 0]])
-    _write_csv(tmp_path, "BUSDT", "1d", "1970-01",
-               [[1 * DAY, 1, 1, 1, 200, 5, 0, 0, 0, 0, 0, 0],
-                [2 * DAY, 1, 1, 1, 220, 5, 0, 0, 0, 0, 0, 0]])
-    m = pit_universe.PITManifest.from_records([
-        {"symbol": "AUSDT", "listed_from": 0}, {"symbol": "BUSDT", "listed_from": 0},
-    ])
+    _write_csv(
+        tmp_path,
+        "AUSDT",
+        "1d",
+        "1970-01",
+        [
+            [1 * DAY, 1, 1, 1, 100, 5, 0, 0, 0, 0, 0, 0],
+            [2 * DAY, 1, 1, 1, 110, 5, 0, 0, 0, 0, 0, 0],
+        ],
+    )
+    _write_csv(
+        tmp_path,
+        "BUSDT",
+        "1d",
+        "1970-01",
+        [
+            [1 * DAY, 1, 1, 1, 200, 5, 0, 0, 0, 0, 0, 0],
+            [2 * DAY, 1, 1, 1, 220, 5, 0, 0, 0, 0, 0, 0],
+        ],
+    )
+    m = pit_universe.PITManifest.from_records(
+        [
+            {"symbol": "AUSDT", "listed_from": 0},
+            {"symbol": "BUSDT", "listed_from": 0},
+        ]
+    )
     panel = pit_bars.load_panel(["AUSDT", "BUSDT"], "1d", m, root=tmp_path)
     assert panel["AUSDT"] == [(1 * DAY, 100.0), (2 * DAY, 110.0)]
     assert panel["BUSDT"] == [(1 * DAY, 200.0), (2 * DAY, 220.0)]

--- a/research/nautilus_scalping/tests/test_portfolio_gate.py
+++ b/research/nautilus_scalping/tests/test_portfolio_gate.py
@@ -44,21 +44,25 @@ def test_portfolio_drawdown_beats_serial_trade_drawdown():
         PortfolioPeriod(ts=4, gross_ref_pnl=11.0, commission_ref=0.0),
     ]
     pf = validated_gate.portfolio_metrics_at_fee(periods, 0.0)
-    assert pf.max_drawdown == -30.0          # correct, severe
-    assert pf.net_pnl == 3.0                 # same total as the flat trades
+    assert pf.max_drawdown == -30.0  # correct, severe
+    assert pf.net_pnl == 3.0  # same total as the flat trades
     assert pf.max_drawdown < serial.max_drawdown  # portfolio path is the honest one
 
 
 def test_evaluate_gate_portfolio_returns_report_with_portfolio_dd():
     # enough periods to split walk-forward and exceed a small min_trades
     periods = [
-        PortfolioPeriod(ts=i, gross_ref_pnl=(1.0 if i % 2 else -0.5), commission_ref=0.1)
+        PortfolioPeriod(
+            ts=i, gross_ref_pnl=(1.0 if i % 2 else -0.5), commission_ref=0.1
+        )
         for i in range(1, 41)
     ]
     rep = validated_gate.evaluate_gate_portfolio(
         candidate_runs={"p": periods},
-        baseline_periods=[PortfolioPeriod(ts=i, gross_ref_pnl=0.0, commission_ref=0.1)
-                          for i in range(1, 41)],
+        baseline_periods=[
+            PortfolioPeriod(ts=i, gross_ref_pnl=0.0, commission_ref=0.1)
+            for i in range(1, 41)
+        ],
         fee_bps=2.0,
         min_periods=5,
         candidate_name="basket-test",

--- a/research/nautilus_scalping/tests/test_rob343_label.py
+++ b/research/nautilus_scalping/tests/test_rob343_label.py
@@ -25,17 +25,25 @@ def test_breakeven_no_commission_dependence():
 
 
 def test_already_net_viable_is_promote_to_pilot():
-    v = r.label_343_candidate(taker_net_pnl=4.0, gross_pnl=6.0,
-                              maker_conservative_net=5.0, oos_significant=True,
-                              breakeven_taker_bps=8.0)
+    v = r.label_343_candidate(
+        taker_net_pnl=4.0,
+        gross_pnl=6.0,
+        maker_conservative_net=5.0,
+        oos_significant=True,
+        breakeven_taker_bps=8.0,
+    )
     assert v.label == "promote_to_pilot"
     assert v.cost_binding is False
 
 
 def test_cost_binding_and_closable_is_343_candidate():
-    v = r.label_343_candidate(taker_net_pnl=-2.0, gross_pnl=6.0,
-                              maker_conservative_net=1.5, oos_significant=True,
-                              breakeven_taker_bps=3.0)
+    v = r.label_343_candidate(
+        taker_net_pnl=-2.0,
+        gross_pnl=6.0,
+        maker_conservative_net=1.5,
+        oos_significant=True,
+        breakeven_taker_bps=3.0,
+    )
     assert v.label == "cost_binding_343_candidate"
     assert v.cost_binding is True
     assert v.closable is True
@@ -43,24 +51,36 @@ def test_cost_binding_and_closable_is_343_candidate():
 
 def test_cost_binding_but_not_closable_is_reject():
     # gross positive, killed by taker fees, but maker-conservative STILL negative
-    v = r.label_343_candidate(taker_net_pnl=-2.0, gross_pnl=6.0,
-                              maker_conservative_net=-0.5, oos_significant=True,
-                              breakeven_taker_bps=3.0)
+    v = r.label_343_candidate(
+        taker_net_pnl=-2.0,
+        gross_pnl=6.0,
+        maker_conservative_net=-0.5,
+        oos_significant=True,
+        breakeven_taker_bps=3.0,
+    )
     assert v.label == "reject"
     assert v.cost_binding is True
     assert v.closable is False
 
 
 def test_no_gross_edge_is_reject():
-    v = r.label_343_candidate(taker_net_pnl=-3.0, gross_pnl=-1.0,
-                              maker_conservative_net=-2.0, oos_significant=True,
-                              breakeven_taker_bps=0.0)
+    v = r.label_343_candidate(
+        taker_net_pnl=-3.0,
+        gross_pnl=-1.0,
+        maker_conservative_net=-2.0,
+        oos_significant=True,
+        breakeven_taker_bps=0.0,
+    )
     assert v.label == "reject"
     assert v.cost_binding is False
 
 
 def test_not_significant_is_needs_more_data():
-    v = r.label_343_candidate(taker_net_pnl=-2.0, gross_pnl=6.0,
-                              maker_conservative_net=1.5, oos_significant=False,
-                              breakeven_taker_bps=3.0)
+    v = r.label_343_candidate(
+        taker_net_pnl=-2.0,
+        gross_pnl=6.0,
+        maker_conservative_net=1.5,
+        oos_significant=False,
+        breakeven_taker_bps=3.0,
+    )
     assert v.label == "needs_more_data"

--- a/research/nautilus_scalping/tests/test_rob382_cluc.py
+++ b/research/nautilus_scalping/tests/test_rob382_cluc.py
@@ -10,6 +10,7 @@ Covers:
 Pure: no freqtrade / talib / pandas. Run from research/nautilus_scalping:
     uv run --no-project pytest tests/test_rob382_cluc.py -q
 """
+
 from __future__ import annotations
 
 import rob382_bars as rb
@@ -17,8 +18,10 @@ import rob382_indicators as I
 import rob382_signal_cluc as m
 
 
-def _bar(ts, o, h, l, c, v=10.0, interval_ms=60_000):
-    return rb.OHLCVBar(ts=ts, open=o, high=h, low=l, close=c, volume=v, close_ts=ts + interval_ms - 1)
+def _bar(ts, o, h, l, c, v=10.0, interval_ms=60_000):  # noqa: E741
+    return rb.OHLCVBar(
+        ts=ts, open=o, high=h, low=l, close=c, volume=v, close_ts=ts + interval_ms - 1
+    )
 
 
 # Anchor the base (1m) series AFTER 200 fully-closed 1h bars so the merged ROCR(168) is valid.
@@ -31,7 +34,9 @@ def _flat_1h(n=300, price=100.0):
     bars_1h = []
     t1 = 0
     for _ in range(n):
-        bars_1h.append(_bar(t1, price, price + 0.5, price - 0.5, price, v=1000.0, interval_ms=_H))
+        bars_1h.append(
+            _bar(t1, price, price + 0.5, price - 0.5, price, v=1000.0, interval_ms=_H)
+        )
         t1 += _H
     return bars_1h
 
@@ -76,20 +81,27 @@ def test_entry_fires_on_documented_case():
     last = len(bars) - 1
 
     # Re-derive the documented cond_a sub-conditions to prove the case is genuinely satisfied.
-    opens = [b.open for b in bars]; highs = [b.high for b in bars]
-    lows = [b.low for b in bars]; closes = [b.close for b in bars]
+    opens = [b.open for b in bars]
+    highs = [b.high for b in bars]
+    lows = [b.low for b in bars]
+    closes = [b.close for b in bars]
     _ho, hh, hl, hc = I.heikin_ashi(opens, highs, lows, closes)
     ha_typ = [(hh[i] + hl[i] + hc[i]) / 3.0 for i in range(len(bars))]
     mr, lr, _u = I.bollinger(ha_typ, m.BB_WINDOW, m.BB_NUM_STD, ddof=1)
-    mid = [v if v == v else 0.0 for v in mr]; lower = [v if v == v else 0.0 for v in lr]
-    bbd = abs(mid[last] - lower[last]); cd = abs(hc[last] - hc[last - 1]); tail = abs(hc[last] - hl[last])
+    mid = [v if v == v else 0.0 for v in mr]
+    lower = [v if v == v else 0.0 for v in lr]
+    bbd = abs(mid[last] - lower[last])
+    cd = abs(hc[last] - hc[last - 1])
+    tail = abs(hc[last] - hl[last])
     assert lower[last - 1] > 0
     assert bbd > hc[last] * m.BBDELTA_CLOSE
     assert cd > hc[last] * m.CLOSEDELTA_CLOSE
     assert tail < bbd * m.BBDELTA_TAIL
     assert hc[last] < lower[last - 1]
     assert hc[last] <= hc[last - 1]
-    assert entry[last] is True, "cond_a squeeze-dip entry should fire when all conditions + rocr gate hold"
+    assert entry[last] is True, (
+        "cond_a squeeze-dip entry should fire when all conditions + rocr gate hold"
+    )
 
 
 def test_entry_blocked_when_rocr_gate_broken():
@@ -107,11 +119,15 @@ def test_entry_blocked_when_rocr_gate_broken():
     entry, _exit = m.signals(bars, bars_1h)
     last = len(bars) - 1
     # Sanity: the rocr at the last bar must indeed be below the gate (the broken condition).
-    o1h = [b.open for b in bars_1h]; h1h = [b.high for b in bars_1h]
-    l1h = [b.low for b in bars_1h]; c1h = [b.close for b in bars_1h]
+    o1h = [b.open for b in bars_1h]
+    h1h = [b.high for b in bars_1h]
+    l1h = [b.low for b in bars_1h]
+    c1h = [b.close for b in bars_1h]
     ha_c_1h = I.heikin_ashi(o1h, h1h, l1h, c1h)[3]
     rocr_v = I.rocr(ha_c_1h, m.ROCR_1H_LEN)
-    rocr_b = I.merge_informative([b.ts for b in bars], [b.close_ts for b in bars_1h], rocr_v)
+    rocr_b = I.merge_informative(
+        [b.ts for b in bars], [b.close_ts for b in bars_1h], rocr_v
+    )
     assert rocr_b[last] < m.ROCR_1H, "test setup: rocr gate must actually be broken"
     assert entry[last] is False, "entry must NOT fire when the rocr_1h gate is broken"
 
@@ -132,7 +148,9 @@ def test_no_lookahead_truncation_invariance():
     trunc_entry, trunc_exit = m.signals(bars[:k], bars_1h)
 
     WARMUP = 250  # past ema_slow(50)/bollinger(40)/rsi(14) warmup
-    WARMUP_TAIL = 0  # truncation re-seeds nothing here (all indicators are running-window/causal)
+    WARMUP_TAIL = (
+        0  # truncation re-seeds nothing here (all indicators are running-window/causal)
+    )
     lo, hi = WARMUP, k - WARMUP_TAIL
     mism_entry = [i for i in range(lo, hi) if full_entry[i] != trunc_entry[i]]
     mism_exit = [i for i in range(lo, hi) if full_exit[i] != trunc_exit[i]]

--- a/research/nautilus_scalping/tests/test_rob382_elliot.py
+++ b/research/nautilus_scalping/tests/test_rob382_elliot.py
@@ -7,6 +7,7 @@
     signals(bars)[:k] outside the warmup tail;
 (c) the module runs on a small real slice without error.
 """
+
 from __future__ import annotations
 
 import rob382_bars as rb
@@ -19,14 +20,20 @@ _1H_MS = 60 * 60 * 1000
 _5M_OFFSET_MS = 48 * _1H_MS
 
 
-def _bar(i: int, o: float, h: float, low: float, c: float, vol: float = 100.0) -> rb.OHLCVBar:
+def _bar(
+    i: int, o: float, h: float, low: float, c: float, vol: float = 100.0
+) -> rb.OHLCVBar:
     ts = _5M_OFFSET_MS + i * _5M_MS
-    return rb.OHLCVBar(ts=ts, open=o, high=h, low=low, close=c, volume=vol, close_ts=ts + _5M_MS - 1)
+    return rb.OHLCVBar(
+        ts=ts, open=o, high=h, low=low, close=c, volume=vol, close_ts=ts + _5M_MS - 1
+    )
 
 
 def _bar_1h(i: int, c: float, vol: float = 1000.0) -> rb.OHLCVBar:
     ts = i * _1H_MS
-    return rb.OHLCVBar(ts=ts, open=c, high=c, low=c, close=c, volume=vol, close_ts=ts + _1H_MS - 1)
+    return rb.OHLCVBar(
+        ts=ts, open=c, high=c, low=c, close=c, volume=vol, close_ts=ts + _1H_MS - 1
+    )
 
 
 def _build_5m_series() -> list[rb.OHLCVBar]:
@@ -75,7 +82,9 @@ def test_entry_fires_on_documented_condB() -> None:
     entry, _exit = m.signals(bars, bars_1h)
     assert len(entry) == len(bars)
     # The crash region (last ~25 bars) must produce at least one entry via condB.
-    assert any(entry[260:]), "expected condB entry during the EWO-deep-negative crash dip"
+    assert any(entry[260:]), (
+        "expected condB entry during the EWO-deep-negative crash dip"
+    )
 
 
 def test_entry_blocked_when_uptrend_broken() -> None:

--- a/research/nautilus_scalping/tests/test_rob382_ichi.py
+++ b/research/nautilus_scalping/tests/test_rob382_ichi.py
@@ -7,14 +7,17 @@ Covers:
       the non-warmup region (small warmup-tail tolerance);
   (c) the module runs on a small real slice without error.
 """
+
 from __future__ import annotations
 
 import rob382_bars as rb
 import rob382_signal_ichi as m
 
 
-def _bar(ts, o, h, l, c, v=100.0):
-    return rb.OHLCVBar(ts=ts, open=o, high=h, low=l, close=c, volume=v, close_ts=ts + 299_999)
+def _bar(ts, o, h, l, c, v=100.0):  # noqa: E741
+    return rb.OHLCVBar(
+        ts=ts, open=o, high=h, low=l, close=c, volume=v, close_ts=ts + 299_999
+    )
 
 
 def _uptrend_bars(n, start=100.0, base=0.003, accel=0.0002):
@@ -41,9 +44,13 @@ def test_entry_fires_on_documented_uptrend():
     entry, exit_sig = m.signals(bars)
     assert len(entry) == len(bars) == len(exit_sig)
     # On a clean sustained uptrend, the entry must fire somewhere in the mature region.
-    assert any(entry[200:]), "expected entry to fire in the mature region of a clean uptrend"
+    assert any(entry[200:]), (
+        "expected entry to fire in the mature region of a clean uptrend"
+    )
     # The exit signal (close x-under EMA24) must NOT fire on a strictly rising series.
-    assert not any(exit_sig), "exit (cross-below) should never fire on a monotone uptrend"
+    assert not any(exit_sig), (
+        "exit (cross-below) should never fire on a monotone uptrend"
+    )
 
 
 def test_entry_blocked_when_below_cloud():
@@ -62,7 +69,9 @@ def test_entry_blocked_when_below_cloud():
         price = c
     entry, _ = m.signals(bars)
     # In the downtrend tail, every above-cloud + fan-rising condition is broken.
-    assert not any(entry[300:]), "entry must not fire while price is in a downtrend below the cloud"
+    assert not any(entry[300:]), (
+        "entry must not fire while price is in a downtrend below the cloud"
+    )
 
 
 def test_entry_blocked_when_fan_not_rising():
@@ -92,8 +101,12 @@ def test_no_lookahead_truncation_invariance():
     warmup = 256
     tail_tol = 3
     hi = k - tail_tol
-    assert full_entry[warmup:hi] == pre_entry[warmup:hi], "entry differs under truncation (lookahead?)"
-    assert full_exit[warmup:hi] == pre_exit[warmup:hi], "exit differs under truncation (lookahead?)"
+    assert full_entry[warmup:hi] == pre_entry[warmup:hi], (
+        "entry differs under truncation (lookahead?)"
+    )
+    assert full_exit[warmup:hi] == pre_exit[warmup:hi], (
+        "exit differs under truncation (lookahead?)"
+    )
 
 
 def test_runs_on_real_slice():

--- a/research/nautilus_scalping/tests/test_rob382_vwap.py
+++ b/research/nautilus_scalping/tests/test_rob382_vwap.py
@@ -9,6 +9,7 @@ Covers:
 
 Pure (stdlib + harness modules only); no network, no freqtrade/talib/pandas.
 """
+
 from __future__ import annotations
 
 import rob382_bars as rb
@@ -16,8 +17,12 @@ import rob382_signal_vwap as m
 from rob382_bars import OHLCVBar
 
 
-def _bar(ts: int, o: float, h: float, lo: float, c: float, v: float = 100.0) -> OHLCVBar:
-    return OHLCVBar(ts=ts, open=o, high=h, low=lo, close=c, volume=v, close_ts=ts + 299_999)
+def _bar(
+    ts: int, o: float, h: float, lo: float, c: float, v: float = 100.0
+) -> OHLCVBar:
+    return OHLCVBar(
+        ts=ts, open=o, high=h, low=lo, close=c, volume=v, close_ts=ts + 299_999
+    )
 
 
 def _build_decline(n_pre: int = 130) -> list[OHLCVBar]:
@@ -73,13 +78,16 @@ def test_entry_does_not_fire_when_rsi_condition_broken():
         open=last.open,
         high=last.open * 1.06,
         low=last.open * 0.999,
-        close=last.open * 1.05,  # rally → RSI-14 lifts, close above vwap_low, tcp gap gone
+        close=last.open
+        * 1.05,  # rally → RSI-14 lifts, close above vwap_low, tcp gap gone
         volume=last.volume,
         close_ts=last.close_ts,
     )
     bars = bars[:-1] + [up]
     entry, _ = m.signals(bars)
-    assert entry[-1] is False, "entry must NOT fire when the RSI/dip condition is broken"
+    assert entry[-1] is False, (
+        "entry must NOT fire when the RSI/dip condition is broken"
+    )
 
 
 def test_no_lookahead_truncation_invariance():

--- a/research/nautilus_scalping/tests/test_rob974_h1.py
+++ b/research/nautilus_scalping/tests/test_rob974_h1.py
@@ -129,7 +129,11 @@ def test_cp4_typed_deterministic_lineage_seal_is_order_invariant_and_sensitive()
     assert parent.content_hash() == PARENT_CONTENT_SHA256
     selected = {symbol: tuple(rows(1)) for symbol in ("XRPUSDT", "DOGEUSDT", "SOLUSDT")}
     actual = feature_input_hash(selected)
-    permuted = {"SOLUSDT": selected["SOLUSDT"], "XRPUSDT": selected["XRPUSDT"], "DOGEUSDT": selected["DOGEUSDT"]}
+    permuted = {
+        "SOLUSDT": selected["SOLUSDT"],
+        "XRPUSDT": selected["XRPUSDT"],
+        "DOGEUSDT": selected["DOGEUSDT"],
+    }
     assert feature_input_hash(permuted) == actual
     from_rows = DerivedManifest.create(
         rows=selected, context_start=0, context_end=240 * MIN

--- a/research/nautilus_scalping/tests/test_validated_gate.py
+++ b/research/nautilus_scalping/tests/test_validated_gate.py
@@ -3,6 +3,7 @@
 
 Trades are (net_ref_pnl, commission_ref, notional, ts_opened) tuples at the
 reference fee; net at any fee is recomputed analytically (mirrors fee_sweep)."""
+
 from __future__ import annotations
 
 from validated_gate import (
@@ -23,23 +24,29 @@ def test_walk_forward_split_is_chronological() -> None:
     assert len(folds["train"]) == 50
     assert len(folds["val"]) == 25
     assert len(folds["oos"]) == 25
-    assert max(t.ts_opened for t in folds["train"]) < min(t.ts_opened for t in folds["oos"])
+    assert max(t.ts_opened for t in folds["train"]) < min(
+        t.ts_opened for t in folds["oos"]
+    )
 
 
 def test_metrics_profit_factor_and_expectancy() -> None:
     trades = [_trade(2.0, 0.2, 100, 0), _trade(-1.0, 0.2, 100, 1)]
     m = metrics_at_fee(trades, fee_bps=0.0)  # gross (scale removes commission)
     assert m.trades == 2
-    assert round(m.profit_factor, 2) == 2.75     # 2.2 / 0.8
-    assert round(m.expectancy, 2) == 0.7        # (2.2 - 0.8) / 2
+    assert round(m.profit_factor, 2) == 2.75  # 2.2 / 0.8
+    assert round(m.expectancy, 2) == 0.7  # (2.2 - 0.8) / 2
 
 
 def test_insufficient_data_when_oos_thin() -> None:
     # 120 train, 0 oos -> insufficient
     cand = {"z2.0/tp30/sl30": [_trade(0.5, -0.1, 100, ts) for ts in range(120)]}
     report = evaluate_gate(
-        candidate_runs=cand, baseline_breakout=[], baseline_random=[],
-        fee_bps=10.0, min_trades=100, fractions=(1.0, 0.0, 0.0),
+        candidate_runs=cand,
+        baseline_breakout=[],
+        baseline_random=[],
+        fee_bps=10.0,
+        min_trades=100,
+        fractions=(1.0, 0.0, 0.0),
     )
     assert report.verdict == "insufficient_data"
     assert report.overfit_flags["low_trades"] is True
@@ -50,8 +57,12 @@ def test_not_validated_when_oos_negative() -> None:
     losing = [_trade(-0.5, -0.1, 100, ts) for ts in range(400)]
     cand = {"z2.0/tp30/sl30": losing}
     report = evaluate_gate(
-        candidate_runs=cand, baseline_breakout=losing, baseline_random=losing,
-        fee_bps=10.0, min_trades=100, fractions=(0.5, 0.25, 0.25),
+        candidate_runs=cand,
+        baseline_breakout=losing,
+        baseline_random=losing,
+        fee_bps=10.0,
+        min_trades=100,
+        fractions=(0.5, 0.25, 0.25),
     )
     assert report.verdict == "not_validated"
 
@@ -60,12 +71,16 @@ def test_validated_when_oos_positive_and_beats_baselines_and_stable() -> None:
     winners = [_trade(1.0, -0.1, 100, ts) for ts in range(400)]
     losers = [_trade(-0.5, -0.1, 100, ts) for ts in range(400)]
     cand = {
-        "z2.0/tp30/sl30": winners,            # val-best and oos-best
-        "z2.5/tp40/sl40": winners,            # stable across params
+        "z2.0/tp30/sl30": winners,  # val-best and oos-best
+        "z2.5/tp40/sl40": winners,  # stable across params
     }
     report = evaluate_gate(
-        candidate_runs=cand, baseline_breakout=losers, baseline_random=losers,
-        fee_bps=10.0, min_trades=100, fractions=(0.5, 0.25, 0.25),
+        candidate_runs=cand,
+        baseline_breakout=losers,
+        baseline_random=losers,
+        fee_bps=10.0,
+        min_trades=100,
+        fractions=(0.5, 0.25, 0.25),
     )
     assert report.verdict == "validated"
     assert report.overfit_flags["single_fold_edge"] is False

--- a/research/nautilus_scalping/tests/test_validated_gate_stats.py
+++ b/research/nautilus_scalping/tests/test_validated_gate_stats.py
@@ -8,6 +8,7 @@ pure-stdlib (no numpy), seeded for reproducibility. The framing is *not* "find
 an edge" but "prove the net-after-fee result is statistically robust" — see
 ROB-316/320 (fees kill the scalper).
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -47,7 +48,7 @@ def test_bootstrap_all_positive_ci_strictly_positive() -> None:
     out = bootstrap_sharpe_ci(pnls, n_bootstrap=500, seed=7)
     assert out["observed_sharpe"] > 0
     assert out["ci_lower"] <= out["ci_upper"]
-    assert out["ci_lower"] > 0           # every resample of positives is positive
+    assert out["ci_lower"] > 0  # every resample of positives is positive
     assert out["prob_positive"] == 1.0
 
 
@@ -55,7 +56,7 @@ def test_bootstrap_all_negative_ci_upper_below_zero() -> None:
     pnls = [-1.0, -2.0, -1.5, -2.5, -1.0, -2.0, -3.0, -1.5] * 8
     out = bootstrap_sharpe_ci(pnls, n_bootstrap=500, seed=7)
     assert out["observed_sharpe"] < 0
-    assert out["ci_upper"] < 0           # net edge statistically <= 0
+    assert out["ci_upper"] < 0  # net edge statistically <= 0
     assert out["prob_positive"] == 0.0
 
 
@@ -141,9 +142,13 @@ def _losing_report() -> GateReport:
     losing = [Trade(-0.5, -0.1, 100, ts) for ts in range(400)]
     return evaluate_gate(
         candidate_runs={"z2.0/tp30/sl30": losing},
-        baseline_breakout=losing, baseline_random=losing,
-        fee_bps=10.0, min_trades=100, fractions=(0.5, 0.25, 0.25),
-        candidate_name="meanrev_demo", hypothesis="mean_reversion",
+        baseline_breakout=losing,
+        baseline_random=losing,
+        fee_bps=10.0,
+        min_trades=100,
+        fractions=(0.5, 0.25, 0.25),
+        candidate_name="meanrev_demo",
+        hypothesis="mean_reversion",
     )
 
 
@@ -151,8 +156,11 @@ def test_write_run_card_emits_json_and_md(tmp_path: Path) -> None:
     report = _losing_report()
     bs = bootstrap_sharpe_ci([-0.5] * 400, n_bootstrap=200, seed=3)
     paths = write_run_card(
-        report, tmp_path, config={"fee_bps": 10.0},
-        data_sources=["binance_demo"], bootstrap=bs,
+        report,
+        tmp_path,
+        config={"fee_bps": 10.0},
+        data_sources=["binance_demo"],
+        bootstrap=bs,
     )
     assert paths["json"].exists() and paths["md"].exists()
 
@@ -164,7 +172,7 @@ def test_write_run_card_emits_json_and_md(tmp_path: Path) -> None:
 
     md = paths["md"].read_text()
     assert "net-after-fee" in md.lower()
-    assert "ROB-316" in md          # fee-kill framing is explicit in the card
+    assert "ROB-316" in md  # fee-kill framing is explicit in the card
     assert report.verdict in md
 
 
@@ -184,7 +192,7 @@ def test_negative_ci_downgrades_a_validated_verdict() -> None:
     report = GateReport(verdict="validated", verdict_reasons=["passed gate"])
     bs = bootstrap_sharpe_ci([-1.0, -2.0, -1.5, -0.5] * 50, n_bootstrap=200, seed=5)
     apply_statistical_evidence(report, bs)
-    assert report.verdict == "not_validated"   # statistical guard overrides
+    assert report.verdict == "not_validated"  # statistical guard overrides
     assert any("statistic" in r.lower() for r in report.verdict_reasons)
 
 
@@ -192,4 +200,4 @@ def test_positive_ci_does_not_upgrade_not_validated() -> None:
     report = GateReport(verdict="not_validated", verdict_reasons=["thin oos"])
     bs = bootstrap_sharpe_ci([1.0, 2.0, 1.5, 0.5] * 50, n_bootstrap=200, seed=5)
     apply_statistical_evidence(report, bs)
-    assert report.verdict == "not_validated"    # never flips up; gate owns that
+    assert report.verdict == "not_validated"  # never flips up; gate owns that

--- a/research/nautilus_scalping/validate_candidate.py
+++ b/research/nautilus_scalping/validate_candidate.py
@@ -15,6 +15,7 @@ Usage (research venv):
         --window-from 2026-03-01 --window-to 2026-05-14 \
         --export results/rob320/meanrev.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -36,8 +37,14 @@ from validated_gate import (
 # small, fixed param grid (param-stability check, not optimization)
 _GRID = {
     "meanrev_zscore_fade": [
-        ("z2.0/tp30/sl30", {"lookback": 20, "z_entry": "2.0", "tp_bps": 30, "sl_bps": 30}),
-        ("z2.5/tp40/sl40", {"lookback": 20, "z_entry": "2.5", "tp_bps": 40, "sl_bps": 40}),
+        (
+            "z2.0/tp30/sl30",
+            {"lookback": 20, "z_entry": "2.0", "tp_bps": 30, "sl_bps": 30},
+        ),
+        (
+            "z2.5/tp40/sl40",
+            {"lookback": 20, "z_entry": "2.5", "tp_bps": 40, "sl_bps": 40},
+        ),
     ],
 }
 
@@ -57,8 +64,12 @@ def main() -> int:
     ap.add_argument("--window-from", default="")
     ap.add_argument("--window-to", default="")
     ap.add_argument("--export", type=Path, default="results/rob320/gate.json")
-    ap.add_argument("--seed", type=int, default=42,
-                    help="seed for bootstrap / Monte-Carlo permutation")
+    ap.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="seed for bootstrap / Monte-Carlo permutation",
+    )
     ap.add_argument("--bootstrap-n", type=int, default=1000)
     ap.add_argument("--mc-n", type=int, default=1000)
     args = ap.parse_args()
@@ -81,8 +92,17 @@ def main() -> int:
         per_symbol = []
         for sym in symbols:
             size = "0.002" if sym == "BTCUSDT" else args.trade_size
-            per_symbol.append(run(args.catalog, sym, args.candidate, params, size,
-                                   args.window_from, args.window_to))
+            per_symbol.append(
+                run(
+                    args.catalog,
+                    sym,
+                    args.candidate,
+                    params,
+                    size,
+                    args.window_from,
+                    args.window_to,
+                )
+            )
         candidate_runs[label] = _merge(per_symbol)
         print(f"  -> Total trades across all symbols: {len(candidate_runs[label])}")
 
@@ -91,9 +111,17 @@ def main() -> int:
     breakout_runs = []
     for sym in symbols:
         size = "0.002" if sym == "BTCUSDT" else args.trade_size
-        breakout_runs.append(run(args.catalog, sym, "micro_breakout",
-                                 get_candidate("micro_breakout").default_params, size,
-                                 args.window_from, args.window_to))
+        breakout_runs.append(
+            run(
+                args.catalog,
+                sym,
+                "micro_breakout",
+                get_candidate("micro_breakout").default_params,
+                size,
+                args.window_from,
+                args.window_to,
+            )
+        )
     breakout = _merge(breakout_runs)
     print(f"  -> Total trades: {len(breakout)}")
 
@@ -101,19 +129,35 @@ def main() -> int:
     random_runs = []
     for sym in symbols:
         size = "0.002" if sym == "BTCUSDT" else args.trade_size
-        random_runs.append(run(args.catalog, sym, "random_entry",
-                               get_candidate("random_entry").default_params, size,
-                               args.window_from, args.window_to))
+        random_runs.append(
+            run(
+                args.catalog,
+                sym,
+                "random_entry",
+                get_candidate("random_entry").default_params,
+                size,
+                args.window_from,
+                args.window_to,
+            )
+        )
     random_ctrl = _merge(random_runs)
     print(f"  -> Total trades: {len(random_ctrl)}")
 
     print("Evaluating walk-forward gate report...")
     report = evaluate_gate(
-        candidate_runs=candidate_runs, baseline_breakout=breakout, baseline_random=random_ctrl,
-        fee_bps=args.fee_bps, min_trades=args.min_trades,
-        candidate_name=cand.name, hypothesis=cand.hypothesis, symbols=symbols,
-        window={"from": args.window_from, "to": args.window_to,
-                "folds": {"train": 0.5, "val": 0.25, "oos": 0.25}},
+        candidate_runs=candidate_runs,
+        baseline_breakout=breakout,
+        baseline_random=random_ctrl,
+        fee_bps=args.fee_bps,
+        min_trades=args.min_trades,
+        candidate_name=cand.name,
+        hypothesis=cand.hypothesis,
+        symbols=symbols,
+        window={
+            "from": args.window_from,
+            "to": args.window_to,
+            "folds": {"train": 0.5, "val": 0.25, "oos": 0.25},
+        },
     )
 
     # ROB-328 (ROB-327 F1) — statistical robustness of the net-after-fee result.
@@ -124,7 +168,9 @@ def main() -> int:
     bootstrap = monte_carlo = None
     if val_best in candidate_runs:
         net_pnls = net_pnls_at_fee(candidate_runs[val_best], args.fee_bps)
-        bootstrap = bootstrap_sharpe_ci(net_pnls, n_bootstrap=args.bootstrap_n, seed=args.seed)
+        bootstrap = bootstrap_sharpe_ci(
+            net_pnls, n_bootstrap=args.bootstrap_n, seed=args.seed
+        )
         monte_carlo = monte_carlo_permutation(net_pnls, n_sim=args.mc_n, seed=args.seed)
         apply_statistical_evidence(report, bootstrap)  # folds CI evidence into verdict
 
@@ -132,16 +178,23 @@ def main() -> int:
     args.export.write_text(json.dumps(report.to_dict(), indent=2))
 
     run_card_config = {
-        "candidate": args.candidate, "symbols": symbols, "fee_bps": args.fee_bps,
-        "min_trades": args.min_trades, "grid": dict(grid),
+        "candidate": args.candidate,
+        "symbols": symbols,
+        "fee_bps": args.fee_bps,
+        "min_trades": args.min_trades,
+        "grid": dict(grid),
         "window": {"from": args.window_from, "to": args.window_to},
-        "seed": args.seed, "bootstrap_n": args.bootstrap_n, "mc_n": args.mc_n,
+        "seed": args.seed,
+        "bootstrap_n": args.bootstrap_n,
+        "mc_n": args.mc_n,
     }
     card_paths = write_run_card(
-        report, args.export.parent,
+        report,
+        args.export.parent,
         config=run_card_config,
         data_sources=[f"binance_demo_backtest:{','.join(symbols)}"],
-        bootstrap=bootstrap, monte_carlo=monte_carlo,
+        bootstrap=bootstrap,
+        monte_carlo=monte_carlo,
     )
 
     print("\n=============================================================")

--- a/research/nautilus_scalping/validate_maker_fill.py
+++ b/research/nautilus_scalping/validate_maker_fill.py
@@ -15,6 +15,7 @@ Usage (rob-320 venv):
         --symbols XRPUSDT,BTCUSDT --window-from 2026-03-01 --window-to 2026-05-14 \
         --export results/rob324/maker_fill.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -63,13 +64,19 @@ def _merge_recs(runs):
     return sorted((rec for r in runs for rec in r), key=lambda rec: rec.ts_opened)
 
 
-def _gate(candidate_runs, breakout, random_ctrl, fee_bps, symbols, window, name, seed=42):
+def _gate(
+    candidate_runs, breakout, random_ctrl, fee_bps, symbols, window, name, seed=42
+):
     report = evaluate_gate(
         candidate_runs=candidate_runs,
-        baseline_breakout=breakout, baseline_random=random_ctrl,
-        fee_bps=fee_bps, min_trades=100,
-        candidate_name=name, hypothesis="mean_reversion",
-        symbols=symbols, window=window,
+        baseline_breakout=breakout,
+        baseline_random=random_ctrl,
+        fee_bps=fee_bps,
+        min_trades=100,
+        candidate_name=name,
+        hypothesis="mean_reversion",
+        symbols=symbols,
+        window=window,
     )
     # ROB-328 statistical robustness on the val-best config's net-after-fee per-trade PnL:
     # bootstrap Sharpe CI + Monte-Carlo permutation. apply_statistical_evidence only
@@ -81,7 +88,10 @@ def _gate(candidate_runs, breakout, random_ctrl, fee_bps, symbols, window, name,
         bootstrap = bootstrap_sharpe_ci(net_pnls, n_bootstrap=1000, seed=seed)
         monte_carlo = monte_carlo_permutation(net_pnls, n_sim=1000, seed=seed)
         apply_statistical_evidence(report, bootstrap)
-        stats = {"bootstrap_sharpe_ci": bootstrap, "monte_carlo_permutation": monte_carlo}
+        stats = {
+            "bootstrap_sharpe_ci": bootstrap,
+            "monte_carlo_permutation": monte_carlo,
+        }
     out = report.to_dict()
     out.update(stats)
     return out
@@ -96,28 +106,71 @@ def main() -> int:
     ap.add_argument("--export", type=Path, default="results/rob324/maker_fill.json")
     args = ap.parse_args()
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
-    window = {"from": args.window_from, "to": args.window_to,
-              "folds": {"train": 0.5, "val": 0.25, "oos": 0.25}}
+    window = {
+        "from": args.window_from,
+        "to": args.window_to,
+        "folds": {"train": 0.5, "val": 0.25, "oos": 0.25},
+    }
 
     # --- baselines (taker, single config each), merged across symbols ---
     print("Running taker baselines (breakout, random)...")
-    breakout = _merge([run(args.catalog, s, "micro_breakout",
-                           get_candidate("micro_breakout").default_params,
-                           _SIZE.get(s, "100"), args.window_from, args.window_to)
-                       for s in symbols])
-    random_ctrl = _merge([run(args.catalog, s, "random_entry",
-                              get_candidate("random_entry").default_params,
-                              _SIZE.get(s, "100"), args.window_from, args.window_to)
-                          for s in symbols])
+    breakout = _merge(
+        [
+            run(
+                args.catalog,
+                s,
+                "micro_breakout",
+                get_candidate("micro_breakout").default_params,
+                _SIZE.get(s, "100"),
+                args.window_from,
+                args.window_to,
+            )
+            for s in symbols
+        ]
+    )
+    random_ctrl = _merge(
+        [
+            run(
+                args.catalog,
+                s,
+                "random_entry",
+                get_candidate("random_entry").default_params,
+                _SIZE.get(s, "100"),
+                args.window_from,
+                args.window_to,
+            )
+            for s in symbols
+        ]
+    )
 
     # --- scenario 1: taker baseline candidate over the param grid (grid rescales 10->4) ---
     print("Scenario 1: taker baseline @ 4 bps (grid)...")
-    taker_runs = {label: _merge([run(args.catalog, s, "meanrev_zscore_fade",
-                                     dict(params), _SIZE.get(s, "100"),
-                                     args.window_from, args.window_to) for s in symbols])
-                  for label, params in _GRID}
-    taker_report = _gate(taker_runs, breakout, random_ctrl, TAKER_BASELINE_BPS,
-                         symbols, window, "meanrev_taker_baseline")
+    taker_runs = {
+        label: _merge(
+            [
+                run(
+                    args.catalog,
+                    s,
+                    "meanrev_zscore_fade",
+                    dict(params),
+                    _SIZE.get(s, "100"),
+                    args.window_from,
+                    args.window_to,
+                )
+                for s in symbols
+            ]
+        )
+        for label, params in _GRID
+    }
+    taker_report = _gate(
+        taker_runs,
+        breakout,
+        random_ctrl,
+        TAKER_BASELINE_BPS,
+        symbols,
+        window,
+        "meanrev_taker_baseline",
+    )
 
     # --- scenarios 2 & 3: maker re-sim over the SAME grid (param-stability preserved) ---
     print("Scenarios 2 & 3: maker re-sim (grid)...")
@@ -126,25 +179,51 @@ def main() -> int:
     for label, params in _GRID:
         per_symbol = []
         for s in symbols:
-            recs, att, fil = run_maker(args.catalog, s, dict(params), _SIZE.get(s, "100"),
-                                       args.window_from, args.window_to)
+            recs, att, fil = run_maker(
+                args.catalog,
+                s,
+                dict(params),
+                _SIZE.get(s, "100"),
+                args.window_from,
+                args.window_to,
+            )
             per_symbol.append(recs)
             attempted += att
             filled += fil
         maker_recs[label] = _merge_recs(per_symbol)
 
-    opt_runs = {label: build_maker_optimistic(recs) for label, recs in maker_recs.items()}
-    con_runs = {label: build_maker_conservative(
-                    recs, queue_loss_pct=_FILL_MODEL["queue_loss_pct"],
-                    adverse_bps=_FILL_MODEL["adverse_bps"],
-                    excursion_eps_bps=_FILL_MODEL["excursion_eps_bps"])
-                for label, recs in maker_recs.items()}
+    opt_runs = {
+        label: build_maker_optimistic(recs) for label, recs in maker_recs.items()
+    }
+    con_runs = {
+        label: build_maker_conservative(
+            recs,
+            queue_loss_pct=_FILL_MODEL["queue_loss_pct"],
+            adverse_bps=_FILL_MODEL["adverse_bps"],
+            excursion_eps_bps=_FILL_MODEL["excursion_eps_bps"],
+        )
+        for label, recs in maker_recs.items()
+    }
 
     # maker scenarios: net already at real fees -> evaluate at REF (as-run)
-    opt_report = _gate(opt_runs, breakout, random_ctrl, REF_FEE_BPS,
-                       symbols, window, "meanrev_maker_optimistic")
-    con_report = _gate(con_runs, breakout, random_ctrl, REF_FEE_BPS,
-                       symbols, window, "meanrev_maker_conservative")
+    opt_report = _gate(
+        opt_runs,
+        breakout,
+        random_ctrl,
+        REF_FEE_BPS,
+        symbols,
+        window,
+        "meanrev_maker_optimistic",
+    )
+    con_report = _gate(
+        con_runs,
+        breakout,
+        random_ctrl,
+        REF_FEE_BPS,
+        symbols,
+        window,
+        "meanrev_maker_conservative",
+    )
 
     artifact = {
         "schema_version": "validated_signal_gate.v2",
@@ -153,21 +232,27 @@ def main() -> int:
         "symbols": symbols,
         "window": window,
         "cost_model": {
-            "maker_fee_bps": MAKER_FEE_BPS, "taker_fee_bps": TAKER_BASELINE_BPS,
+            "maker_fee_bps": MAKER_FEE_BPS,
+            "taker_fee_bps": TAKER_BASELINE_BPS,
             "commission_source": "results/rob324/binance_usdm_commission_rates.json",
-            "note": ("maker scenarios bake real per-leg fees into net; gate evaluated "
-                     "at its reference point (as-run). taker baseline uses the gate's "
-                     "native single-rate rescale to 4.0 bps."),
+            "note": (
+                "maker scenarios bake real per-leg fees into net; gate evaluated "
+                "at its reference point (as-run). taker baseline uses the gate's "
+                "native single-rate rescale to 4.0 bps."
+            ),
         },
         "fill_model": _FILL_MODEL,
-        "fill_stats": {"entries_attempted": attempted, "entries_filled": filled,
-                       "missed_fills": attempted - filled},
+        "fill_stats": {
+            "entries_attempted": attempted,
+            "entries_filled": filled,
+            "missed_fills": attempted - filled,
+        },
         "scenarios": {
             "taker_baseline": taker_report,
             "maker_optimistic": opt_report,
             "maker_conservative": con_report,
         },
-        "verdict": con_report["verdict"],            # headline = conservative (honest bound)
+        "verdict": con_report["verdict"],  # headline = conservative (honest bound)
         "verdict_reasons": con_report["verdict_reasons"],
         "verdict_source": "maker_conservative",
     }
@@ -188,4 +273,5 @@ def main() -> int:
 
 if __name__ == "__main__":
     import sys
+
     sys.exit(main())

--- a/research/nautilus_scalping/validated_gate.py
+++ b/research/nautilus_scalping/validated_gate.py
@@ -6,6 +6,7 @@ fold metrics, gross/zero-fee/net-after-cost separation, baseline comparison, and
 concrete overfit flags. Net at any fee is recomputed analytically from the
 reference-fee run (same method as fee_sweep / compare_strategies).
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -26,8 +27,8 @@ Verdict = Literal["validated", "not_validated", "insufficient_data"]
 
 @dataclass(frozen=True)
 class Trade:
-    net_ref_pnl: float      # realized pnl at REF_FEE_BPS
-    commission_ref: float   # commission paid at REF_FEE_BPS (negative)
+    net_ref_pnl: float  # realized pnl at REF_FEE_BPS
+    commission_ref: float  # commission paid at REF_FEE_BPS (negative)
     notional: float
     ts_opened: int
 
@@ -119,9 +120,13 @@ def _fold_metrics_from_nets(nets: list[float], fold: str) -> FoldMetrics:
     gross_loss = abs(sum(losses))
     pf = gross_win / gross_loss if gross_loss else (float("inf") if gross_win else 0.0)
     return FoldMetrics(
-        fold=fold, trades=n, net_pnl=sum(nets),
+        fold=fold,
+        trades=n,
+        net_pnl=sum(nets),
         win_rate_pct=100.0 * len(wins) / n,
-        max_drawdown=_equity_drawdown(nets), profit_factor=pf, expectancy=sum(nets) / n,
+        max_drawdown=_equity_drawdown(nets),
+        profit_factor=pf,
+        expectancy=sum(nets) / n,
     )
 
 
@@ -136,8 +141,10 @@ def portfolio_net_pnls_at_fee(
 ) -> list[float]:
     """Per-period net portfolio PnLs (chronological) at ``fee_bps`` per leg."""
     rows = sorted(periods, key=lambda p: p.ts)
-    return [cost_model.net_at_fee(p.gross_ref_pnl, p.commission_ref, fee_bps, REF_FEE_BPS)
-            for p in rows]
+    return [
+        cost_model.net_at_fee(p.gross_ref_pnl, p.commission_ref, fee_bps, REF_FEE_BPS)
+        for p in rows
+    ]
 
 
 def portfolio_metrics_at_fee(
@@ -156,8 +163,8 @@ def _chrono_split(rows: list, fractions: tuple[float, float, float]) -> dict[str
     n_val = int(n * fractions[1])
     return {
         "train": rows[:n_train],
-        "val": rows[n_train:n_train + n_val],
-        "oos": rows[n_train + n_val:],
+        "val": rows[n_train : n_train + n_val],
+        "oos": rows[n_train + n_val :],
     }
 
 
@@ -168,14 +175,15 @@ def walk_forward_split(
 
 
 def walk_forward_split_periods(
-    periods: list[PortfolioPeriod], fractions: tuple[float, float, float] = (0.5, 0.25, 0.25)
+    periods: list[PortfolioPeriod],
+    fractions: tuple[float, float, float] = (0.5, 0.25, 0.25),
 ) -> dict[str, list[PortfolioPeriod]]:
     return _chrono_split(sorted(periods, key=lambda p: p.ts), fractions)
 
 
 def evaluate_gate(
     *,
-    candidate_runs: dict[str, list[Trade]],   # param_label -> trades
+    candidate_runs: dict[str, list[Trade]],  # param_label -> trades
     baseline_breakout: list[Trade],
     baseline_random: list[Trade],
     fee_bps: float,
@@ -187,9 +195,14 @@ def evaluate_gate(
     window: dict | None = None,
 ) -> GateReport:
     report = GateReport(
-        candidate=candidate_name, hypothesis=hypothesis, symbols=symbols or [],
-        window=window or {}, cost_model={"fee_bps_per_leg": fee_bps,
-                                         "fee_grid_bps": [10.0, 7.5, 5.0, 2.0, 0.0]},
+        candidate=candidate_name,
+        hypothesis=hypothesis,
+        symbols=symbols or [],
+        window=window or {},
+        cost_model={
+            "fee_bps_per_leg": fee_bps,
+            "fee_grid_bps": [10.0, 7.5, 5.0, 2.0, 0.0],
+        },
     )
 
     # Rank params by validation-fold net; pick the val-best param.
@@ -213,8 +226,10 @@ def evaluate_gate(
     folds = folds_by_param[val_best]
 
     # per-fold metrics (net-after-cost) for the val-best param
-    fold_metrics = {name: metrics_at_fee(folds[name], fee_bps, name)
-                    for name in ("train", "val", "oos")}
+    fold_metrics = {
+        name: metrics_at_fee(folds[name], fee_bps, name)
+        for name in ("train", "val", "oos")
+    }
     report.per_fold = [asdict(fold_metrics[n]) for n in ("train", "val", "oos")]
 
     # gross / zero-fee / net-after-cost over ALL candidate trades (val-best)
@@ -235,33 +250,49 @@ def evaluate_gate(
     }
 
     # overfit flags
-    oos_rank = sorted(by_param_oos, key=by_param_oos.get, reverse=True).index(val_best) + 1
+    oos_rank = (
+        sorted(by_param_oos, key=by_param_oos.get, reverse=True).index(val_best) + 1
+    )
     half = max(1, (len(by_param_oos) + 1) // 2)
     param_island = oos_rank > half
     fold_nets = [fold_metrics[n].net_pnl for n in ("train", "val", "oos")]
     single_fold_edge = sum(1 for x in fold_nets if x > 0) == 1
-    low_trades = any(fold_metrics[n].trades < min_trades for n in ("train", "val", "oos"))
+    low_trades = any(
+        fold_metrics[n].trades < min_trades for n in ("train", "val", "oos")
+    )
     report.param_stability = {
-        "grid": list(candidate_runs), "val_best_param": val_best,
+        "grid": list(candidate_runs),
+        "val_best_param": val_best,
         "oos_rank_of_val_best": oos_rank,
-        "single_fold_edge": single_fold_edge, "param_island": param_island,
+        "single_fold_edge": single_fold_edge,
+        "param_island": param_island,
     }
-    report.overfit_flags = {"low_trades": low_trades,
-                            "single_fold_edge": single_fold_edge,
-                            "param_island": param_island}
+    report.overfit_flags = {
+        "low_trades": low_trades,
+        "single_fold_edge": single_fold_edge,
+        "param_island": param_island,
+    }
 
     # verdict
     oos = fold_metrics["oos"]
     reasons: list[str] = []
     if low_trades:
         report.verdict = "insufficient_data"
-        thin = [f"{n}={fold_metrics[n].trades}" for n in ("train", "val", "oos")
-                if fold_metrics[n].trades < min_trades]
+        thin = [
+            f"{n}={fold_metrics[n].trades}"
+            for n in ("train", "val", "oos")
+            if fold_metrics[n].trades < min_trades
+        ]
         reasons.append(f"folds below min_trades={min_trades}: {', '.join(thin)}")
     else:
         beats_baselines = oos.net_pnl > bk.net_pnl and oos.net_pnl > rnd.net_pnl
-        ok = (oos.net_pnl > 0 and oos.profit_factor > 1.0 and beats_baselines
-              and not single_fold_edge and not param_island)
+        ok = (
+            oos.net_pnl > 0
+            and oos.profit_factor > 1.0
+            and beats_baselines
+            and not single_fold_edge
+            and not param_island
+        )
         report.verdict = "validated" if ok else "not_validated"
         if not ok:
             if oos.net_pnl <= 0:
@@ -282,7 +313,7 @@ def evaluate_gate(
 
 def evaluate_gate_portfolio(
     *,
-    candidate_runs: dict[str, list[PortfolioPeriod]],   # param_label -> period series
+    candidate_runs: dict[str, list[PortfolioPeriod]],  # param_label -> period series
     baseline_periods: list[PortfolioPeriod],
     fee_bps: float,
     min_periods: int = 30,
@@ -300,10 +331,15 @@ def evaluate_gate_portfolio(
     portfolio drawdown, not a per-trade serial sum.
     """
     report = GateReport(
-        candidate=candidate_name, hypothesis=hypothesis, symbols=symbols or [],
+        candidate=candidate_name,
+        hypothesis=hypothesis,
+        symbols=symbols or [],
         window=window or {},
-        cost_model={"fee_bps_per_leg": fee_bps, "fee_grid_bps": [10.0, 7.5, 5.0, 2.0, 0.0],
-                    "unit": "portfolio_period"},
+        cost_model={
+            "fee_bps_per_leg": fee_bps,
+            "fee_grid_bps": [10.0, 7.5, 5.0, 2.0, 0.0],
+            "unit": "portfolio_period",
+        },
     )
     if not candidate_runs:
         report.verdict = "insufficient_data"
@@ -316,52 +352,79 @@ def evaluate_gate_portfolio(
     for label, periods in candidate_runs.items():
         folds = walk_forward_split_periods(periods, fractions)
         folds_by_param[label] = folds
-        by_param_val[label] = portfolio_metrics_at_fee(folds["val"], fee_bps, "val").net_pnl
-        by_param_oos[label] = portfolio_metrics_at_fee(folds["oos"], fee_bps, "oos").net_pnl
+        by_param_val[label] = portfolio_metrics_at_fee(
+            folds["val"], fee_bps, "val"
+        ).net_pnl
+        by_param_oos[label] = portfolio_metrics_at_fee(
+            folds["oos"], fee_bps, "oos"
+        ).net_pnl
 
     val_best = max(by_param_val, key=by_param_val.get)
     folds = folds_by_param[val_best]
-    fold_metrics = {name: portfolio_metrics_at_fee(folds[name], fee_bps, name)
-                    for name in ("train", "val", "oos")}
+    fold_metrics = {
+        name: portfolio_metrics_at_fee(folds[name], fee_bps, name)
+        for name in ("train", "val", "oos")
+    }
     report.per_fold = [asdict(fold_metrics[n]) for n in ("train", "val", "oos")]
 
     all_best = candidate_runs[val_best]
     report.results = {
         "gross": asdict(portfolio_metrics_at_fee(all_best, 0.0, "gross")),
         "zero_fee": asdict(portfolio_metrics_at_fee(all_best, 0.0, "zero_fee")),
-        "net_after_cost": asdict(portfolio_metrics_at_fee(all_best, fee_bps, "net_after_cost")),
+        "net_after_cost": asdict(
+            portfolio_metrics_at_fee(all_best, fee_bps, "net_after_cost")
+        ),
     }
     report.trade_count = len(all_best)
 
     base = portfolio_metrics_at_fee(baseline_periods, fee_bps, "baseline")
-    report.baselines = {"baseline": {"net_after_cost": base.net_pnl, "trades": base.trades}}
+    report.baselines = {
+        "baseline": {"net_after_cost": base.net_pnl, "trades": base.trades}
+    }
 
-    oos_rank = sorted(by_param_oos, key=by_param_oos.get, reverse=True).index(val_best) + 1
+    oos_rank = (
+        sorted(by_param_oos, key=by_param_oos.get, reverse=True).index(val_best) + 1
+    )
     half = max(1, (len(by_param_oos) + 1) // 2)
     param_island = oos_rank > half
     fold_nets = [fold_metrics[n].net_pnl for n in ("train", "val", "oos")]
     single_fold_edge = sum(1 for x in fold_nets if x > 0) == 1
-    low_periods = any(fold_metrics[n].trades < min_periods for n in ("train", "val", "oos"))
+    low_periods = any(
+        fold_metrics[n].trades < min_periods for n in ("train", "val", "oos")
+    )
     report.param_stability = {
-        "grid": list(candidate_runs), "val_best_param": val_best,
+        "grid": list(candidate_runs),
+        "val_best_param": val_best,
         "oos_rank_of_val_best": oos_rank,
-        "single_fold_edge": single_fold_edge, "param_island": param_island,
+        "single_fold_edge": single_fold_edge,
+        "param_island": param_island,
         "unit": "portfolio_period",
     }
-    report.overfit_flags = {"low_trades": low_periods, "single_fold_edge": single_fold_edge,
-                            "param_island": param_island}
+    report.overfit_flags = {
+        "low_trades": low_periods,
+        "single_fold_edge": single_fold_edge,
+        "param_island": param_island,
+    }
 
     oos = fold_metrics["oos"]
     reasons: list[str] = []
     if low_periods:
         report.verdict = "insufficient_data"
-        thin = [f"{n}={fold_metrics[n].trades}" for n in ("train", "val", "oos")
-                if fold_metrics[n].trades < min_periods]
+        thin = [
+            f"{n}={fold_metrics[n].trades}"
+            for n in ("train", "val", "oos")
+            if fold_metrics[n].trades < min_periods
+        ]
         reasons.append(f"folds below min_periods={min_periods}: {', '.join(thin)}")
     else:
         beats_baseline = oos.net_pnl > base.net_pnl
-        ok = (oos.net_pnl > 0 and oos.profit_factor > 1.0 and beats_baseline
-              and not single_fold_edge and not param_island)
+        ok = (
+            oos.net_pnl > 0
+            and oos.profit_factor > 1.0
+            and beats_baseline
+            and not single_fold_edge
+            and not param_island
+        )
         report.verdict = "validated" if ok else "not_validated"
         if not ok:
             if oos.net_pnl <= 0:
@@ -458,8 +521,13 @@ def bootstrap_sharpe_ci(
     """
     n = len(net_pnls)
     if n < 2:
-        return {"error": "insufficient_data", "n": n,
-                "n_bootstrap": n_bootstrap, "confidence": confidence, "seed": seed}
+        return {
+            "error": "insufficient_data",
+            "n": n,
+            "n_bootstrap": n_bootstrap,
+            "confidence": confidence,
+            "seed": seed,
+        }
     rng = random.Random(seed)
     observed = _sharpe(net_pnls)
     sharpes: list[float] = []
@@ -565,8 +633,14 @@ def block_bootstrap_sharpe_ci(
     """
     n = len(net_pnls)
     if n < 2:
-        return {"error": "insufficient_data", "n": n, "block_size": block_size,
-                "n_bootstrap": n_bootstrap, "confidence": confidence, "seed": seed}
+        return {
+            "error": "insufficient_data",
+            "n": n,
+            "block_size": block_size,
+            "n_bootstrap": n_bootstrap,
+            "confidence": confidence,
+            "seed": seed,
+        }
     block_size = max(1, min(block_size, n))
     n_blocks = math.ceil(n / block_size)
     max_start = n - block_size
@@ -577,7 +651,7 @@ def block_bootstrap_sharpe_ci(
         sample: list[float] = []
         for _ in range(n_blocks):
             start = rng.randint(0, max_start) if max_start > 0 else 0
-            sample.extend(net_pnls[start:start + block_size])
+            sample.extend(net_pnls[start : start + block_size])
         sharpes.append(_sharpe(sample[:n]))
     sharpes.sort()
     alpha = (1.0 - confidence) / 2.0
@@ -587,8 +661,11 @@ def block_bootstrap_sharpe_ci(
         "ci_upper": _percentile(sharpes, 1.0 - alpha),
         "median_sharpe": _percentile(sharpes, 0.5),
         "prob_positive": sum(1 for s in sharpes if s > 0) / n_bootstrap,
-        "confidence": confidence, "n_bootstrap": n_bootstrap, "seed": seed,
-        "block_size": block_size, "method": "moving_block",
+        "confidence": confidence,
+        "n_bootstrap": n_bootstrap,
+        "seed": seed,
+        "block_size": block_size,
+        "method": "moving_block",
     }
 
 
@@ -667,8 +744,11 @@ def run_card_hashes(
             artifacts.append(
                 {"path": str(p), "sha256": hashlib.sha256(p.read_bytes()).hexdigest()}
             )
-    return {"config_hash": config_hash, "strategy_hash": strategy_hash,
-            "artifacts": artifacts}
+    return {
+        "config_hash": config_hash,
+        "strategy_hash": strategy_hash,
+        "artifacts": artifacts,
+    }
 
 
 def apply_statistical_evidence(report: GateReport, bootstrap: dict) -> GateReport:

--- a/scripts/binance_public_smoke.py
+++ b/scripts/binance_public_smoke.py
@@ -121,9 +121,7 @@ async def _run(args: argparse.Namespace) -> int:
         log.error(f"WS FAIL: {exc}")
         return 4
 
-    log.info(
-        f"smoke OK (dry_run={args.dry_run}; received {received} WS events)"
-    )
+    log.info(f"smoke OK (dry_run={args.dry_run}; received {received} WS events)")
     return 0
 
 

--- a/scripts/build_invest_crypto_screener_snapshots.py
+++ b/scripts/build_invest_crypto_screener_snapshots.py
@@ -49,7 +49,9 @@ async def run(args: argparse.Namespace) -> int:
     )
     print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
     if not args.commit:
-        print("\n--dry-run: no rows written. Pass --commit only with operator approval.")
+        print(
+            "\n--dry-run: no rows written. Pass --commit only with operator approval."
+        )
     return 0
 
 

--- a/scripts/build_investor_flow_snapshots.py
+++ b/scripts/build_investor_flow_snapshots.py
@@ -58,7 +58,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=100,
         help="Symbols per processing batch when --all is set (default 100).",
     )
-    parser.add_argument("--concurrency", type=int, default=4, help="Per-symbol fetch concurrency.")
+    parser.add_argument(
+        "--concurrency", type=int, default=4, help="Per-symbol fetch concurrency."
+    )
     parser.add_argument(
         "--commit",
         action="store_true",

--- a/scripts/build_market_valuation_snapshots.py
+++ b/scripts/build_market_valuation_snapshots.py
@@ -95,7 +95,9 @@ def _print_result(result) -> None:
     )
     if result.market == "us" and result.symbols_resolved > 0:
         coverage_pct = (result.snapshots_built / result.symbols_resolved) * 100
-        print(f"US Universe Coverage: {result.snapshots_built}/{result.symbols_resolved} ({coverage_pct:.2f}%)")
+        print(
+            f"US Universe Coverage: {result.snapshots_built}/{result.symbols_resolved} ({coverage_pct:.2f}%)"
+        )
     print("idempotency:")
     for key in ("wouldInsert", "wouldUpdate", "duplicatePayloadKeys"):
         print(f"  {key}: {result.idempotency.get(key, 0)}")

--- a/scripts/debug_economic_calendar.py
+++ b/scripts/debug_economic_calendar.py
@@ -56,7 +56,9 @@ async def main() -> None:
             countries = {str(e.get("country", "?")) for e in events[:50]}
             print(f"Countries in response: {countries}")
             if events:
-                print(f"\nFirst event sample: {json.dumps(events[0], indent=2, default=str)}")
+                print(
+                    f"\nFirst event sample: {json.dumps(events[0], indent=2, default=str)}"
+                )
     else:
         print(f"Unexpected response: {raw_response}")
 

--- a/scripts/diagnose_invest_screener_snapshots.py
+++ b/scripts/diagnose_invest_screener_snapshots.py
@@ -8,6 +8,7 @@ Examples:
     uv run python -m scripts.diagnose_invest_screener_snapshots --market kr
     uv run python -m scripts.diagnose_invest_screener_snapshots --market us
 """
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/diagnose_research_reports.py
+++ b/scripts/diagnose_research_reports.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """ROB-207 diagnose CLI — print research_reports freshness, read-only."""
+
 from __future__ import annotations
 
 import argparse
@@ -15,7 +16,9 @@ from app.services.research_reports.freshness import (
 
 
 def parse_args(argv=None):
-    p = argparse.ArgumentParser(description="Diagnose research_reports freshness (ROB-207).")
+    p = argparse.ArgumentParser(
+        description="Diagnose research_reports freshness (ROB-207)."
+    )
     p.add_argument("--source", default=None)
     p.add_argument("--max-age-hours", type=int, default=None)
     return p.parse_args(argv)
@@ -30,7 +33,9 @@ async def main_async(argv=None) -> int:
     budget = ns.max_age_hours or settings.RESEARCH_REPORTS_FRESHNESS_MAX_AGE_HOURS
     async with AsyncSessionLocal() as db:
         out = await compute_research_reports_readiness(
-            db, source=ns.source, max_age_hours=budget,
+            db,
+            source=ns.source,
+            max_age_hours=budget,
         )
     print(json.dumps(out.model_dump(mode="json"), default=str))
     return 0

--- a/scripts/kis_overseas_price_smoke.py
+++ b/scripts/kis_overseas_price_smoke.py
@@ -64,9 +64,7 @@ def missing_kis_cred_names() -> list[str]:
 
 def evaluate_field_presence(output: Mapping[str, Any]) -> dict[str, bool]:
     """Map each expected HHDFS00000300 field to present-and-non-blank."""
-    return {
-        field: output.get(field) not in (None, "") for field in EXPECTED_FIELDS
-    }
+    return {field: output.get(field) not in (None, "") for field in EXPECTED_FIELDS}
 
 
 def decide_exit_code(price: float | None) -> int:
@@ -186,8 +184,10 @@ async def run_smoke(
             print(f"[smoke] get_quote(US) 예외({type(exc).__name__}): {exc}")
 
     code = decide_exit_code(price)
-    verdict = "OK (KIS-primary 라이브 현재가 확인)" if code == 0 else (
-        "현재가 없음/0 — raw output 필드명/세션 확인 필요"
+    verdict = (
+        "OK (KIS-primary 라이브 현재가 확인)"
+        if code == 0
+        else ("현재가 없음/0 — raw output 필드명/세션 확인 필요")
     )
     print(f"[smoke] verdict: exit={code} — {verdict}")
     return code

--- a/scripts/kis_websocket_mock_smoke.py
+++ b/scripts/kis_websocket_mock_smoke.py
@@ -47,9 +47,7 @@ async def run_smoke() -> int:
     Returns exit code (see module docstring).
     """
     if not str(settings.kis_ws_hts_id or "").strip():
-        logger.error(
-            "KIS_WS_HTS_ID is not configured; cannot run mock smoke handshake"
-        )
+        logger.error("KIS_WS_HTS_ID is not configured; cannot run mock smoke handshake")
         return 4
 
     client = KISExecutionWebSocket(
@@ -88,9 +86,7 @@ async def run_smoke() -> int:
         except Exception:
             logger.exception("Failed to stop KIS mock smoke client cleanly")
 
-    logger.info(
-        "KIS mock smoke OK: handshake complete (no orders, no callback wiring)"
-    )
+    logger.info("KIS mock smoke OK: handshake complete (no orders, no callback wiring)")
     return 0
 
 

--- a/scripts/measure_calendar_endpoint.py
+++ b/scripts/measure_calendar_endpoint.py
@@ -233,8 +233,10 @@ def _summary_dict(row: ScenarioRow) -> dict[str, object]:
 
 
 def _print_scenario(name: str, summary: dict[str, object]) -> None:
-    print(f"[{name}] from={summary['from_date']} to={summary['to_date']} "
-          f"days_requested={summary['days_requested']}")
+    print(
+        f"[{name}] from={summary['from_date']} to={summary['to_date']} "
+        f"days_requested={summary['days_requested']}"
+    )
     print(f"  status_counts={summary['status_counts']}")
 
     def _fmt(label: str, block: dict[str, float | int]) -> str:
@@ -250,7 +252,7 @@ def _print_scenario(name: str, summary: dict[str, object]) -> None:
 
     print(_fmt("cold", summary["cold"]))
     print(_fmt("warm", summary["warm"]))
-    print(_fmt("all",  summary["all"]))
+    print(_fmt("all", summary["all"]))
 
     counts = summary.get("counts")
     if counts:
@@ -392,18 +394,14 @@ def main() -> int:
         return 2
 
     anchor = (
-        date.fromisoformat(args.selected)
-        if args.selected
-        else datetime.now(KST).date()
+        date.fromisoformat(args.selected) if args.selected else datetime.now(KST).date()
     )
     grid_start, grid_end = _grid_range(anchor)
 
     scenarios: list[Scenario] = [
         Scenario("42d_grid (current)", grid_start, grid_end),
         Scenario("7d (±3)", anchor - timedelta(days=3), anchor + timedelta(days=3)),
-        Scenario(
-            "15d (±7)", anchor - timedelta(days=7), anchor + timedelta(days=7)
-        ),
+        Scenario("15d (±7)", anchor - timedelta(days=7), anchor + timedelta(days=7)),
         Scenario("single_day", anchor, anchor),
     ]
     repeated = Scenario(
@@ -441,19 +439,15 @@ def main() -> int:
     overhead = _fixed_overhead_block(rows)
     if overhead:
         print("Fixed-overhead estimation (warm-mean anchors):")
-        print(
-            f"  per_day_marginal ≈ {overhead['per_day_marginal_ms']:.1f} ms/day"
-        )
-        print(
-            f"  fixed_overhead   ≈ {overhead['fixed_overhead_ms']:.1f} ms"
-        )
+        print(f"  per_day_marginal ≈ {overhead['per_day_marginal_ms']:.1f} ms/day")
+        print(f"  fixed_overhead   ≈ {overhead['fixed_overhead_ms']:.1f} ms")
         print()
         for proj in overhead["fanout_projection"]:
             W = proj["visible_days"]
             print(
                 f"  cold view of ~{W} visible days: "
                 f"single-day fanout ≈ {proj['single_day_fanout_total_ms']:.0f} ms "
-                f"vs ±{(W-1)//2} range single call ≈ "
+                f"vs ±{(W - 1) // 2} range single call ≈ "
                 f"{proj['range_single_call_total_ms']:.0f} ms"
             )
 

--- a/scripts/news_feed_readonly_smoke.py
+++ b/scripts/news_feed_readonly_smoke.py
@@ -51,7 +51,9 @@ class SmokeResult:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="ROB-155 GET-only news feed smoke")
-    parser.add_argument("--base-url", required=True, help="API base URL, e.g. https://example")
+    parser.add_argument(
+        "--base-url", required=True, help="API base URL, e.g. https://example"
+    )
     parser.add_argument("--timeout", type=float, default=10.0)
     parser.add_argument(
         "--auth-header-env",
@@ -80,7 +82,9 @@ def validate_feed_payload(path: str, payload: Any) -> SmokeResult:
 
     if not isinstance(payload, dict):
         errors.append("payload_not_object")
-    if "items" not in payload and not (isinstance(payload.get("data"), dict) and "items" in payload["data"]):
+    if "items" not in payload and not (
+        isinstance(payload.get("data"), dict) and "items" in payload["data"]
+    ):
         errors.append("missing_items")
 
     crypto_category_count = 0
@@ -95,7 +99,9 @@ def validate_feed_payload(path: str, payload: Any) -> SmokeResult:
         for field in _OPTIONAL_ADDITIVE_FIELDS_WARN:
             if field not in item:
                 source_market_missing_count += 1
-            elif field == "sourceMarket" and item.get("sourceMarket") != item.get("market"):
+            elif field == "sourceMarket" and item.get("sourceMarket") != item.get(
+                "market"
+            ):
                 source_market_divergent_count += 1
         scope = item.get("scope")
         if scope not in _ALLOWED_SCOPES:
@@ -116,7 +122,9 @@ def validate_feed_payload(path: str, payload: Any) -> SmokeResult:
     if source_market_missing_count:
         warnings.append(f"source_market_missing_on_{source_market_missing_count}_items")
     if source_market_divergent_count:
-        warnings.append(f"source_market_diverges_from_market_on_{source_market_divergent_count}_items")
+        warnings.append(
+            f"source_market_diverges_from_market_on_{source_market_divergent_count}_items"
+        )
 
     return SmokeResult(
         path=path,
@@ -127,7 +135,9 @@ def validate_feed_payload(path: str, payload: Any) -> SmokeResult:
     )
 
 
-def _fetch_json(base_url: str, path: str, timeout: float, auth_header: str | None) -> Any:
+def _fetch_json(
+    base_url: str, path: str, timeout: float, auth_header: str | None
+) -> Any:
     url = urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
     headers = {"Accept": "application/json"}
     if auth_header:
@@ -138,7 +148,9 @@ def _fetch_json(base_url: str, path: str, timeout: float, auth_header: str | Non
     return json.loads(body)
 
 
-def run_smoke(base_url: str, timeout: float = 10.0, auth_header: str | None = None) -> list[SmokeResult]:
+def run_smoke(
+    base_url: str, timeout: float = 10.0, auth_header: str | None = None
+) -> list[SmokeResult]:
     results: list[SmokeResult] = []
     for path in _DEFAULT_PATHS:
         try:

--- a/scripts/news_issue_lab_quality_eval.py
+++ b/scripts/news_issue_lab_quality_eval.py
@@ -173,6 +173,7 @@ def _worst_status(statuses: list[str]) -> str:
 # ROB-155 tag-precision mode
 # ---------------------------------------------------------------------------
 
+
 def _load_jsonl(path: str) -> list[dict[str, Any]]:
     """Load newline-delimited JSON fixtures; return empty list if file missing."""
     p = Path(path)
@@ -236,18 +237,28 @@ def _run_us_tag_precision(fixtures: list[dict[str, Any]]) -> dict[str, Any]:
         else:
             if expected_scope == "market_wide" and predicted_scope == "symbol_specific":
                 fn += 1
-                fn_examples.append({"title": title[:100], "expected": expected_scope, "got": predicted_scope})
+                fn_examples.append(
+                    {
+                        "title": title[:100],
+                        "expected": expected_scope,
+                        "got": predicted_scope,
+                    }
+                )
             else:
                 fp += 1
-                fp_examples.append({"title": title[:100], "expected": expected_scope, "got": predicted_scope})
+                fp_examples.append(
+                    {
+                        "title": title[:100],
+                        "expected": expected_scope,
+                        "got": predicted_scope,
+                    }
+                )
 
     total = len(fixtures)
     precision = tp / (tp + fp) if (tp + fp) else 0.0
     recall = tp / (tp + fn) if (tp + fn) else 0.0
 
-    demotion_accuracy = (
-        demotion_correct / demotion_labeled if demotion_labeled else 0.0
-    )
+    demotion_accuracy = demotion_correct / demotion_labeled if demotion_labeled else 0.0
 
     return {
         "sample_count": total,
@@ -286,18 +297,22 @@ def _run_crypto_tag_precision(fixtures: list[dict[str, Any]]) -> dict[str, Any]:
             tp += 1
         elif expected_include and not predicted_include:
             fn += 1
-            fn_examples.append({
-                "title": (row.get("title") or "")[:100],
-                "score": relevance.score,
-                "noise_reason": relevance.noise_reason,
-            })
+            fn_examples.append(
+                {
+                    "title": (row.get("title") or "")[:100],
+                    "score": relevance.score,
+                    "noise_reason": relevance.noise_reason,
+                }
+            )
         elif not expected_include and predicted_include:
             fp += 1
-            fp_examples.append({
-                "title": (row.get("title") or "")[:100],
-                "score": relevance.score,
-                "category": user_cat,
-            })
+            fp_examples.append(
+                {
+                    "title": (row.get("title") or "")[:100],
+                    "score": relevance.score,
+                    "category": user_cat,
+                }
+            )
         else:
             tn += 1
 
@@ -337,9 +352,14 @@ def _tag_precision_markdown(summary: dict[str, Any]) -> str:
         f"- tp/fp/fn: {us.get('tp')}/{us.get('fp')}/{us.get('fn')}",
     ]
     if us.get("fp_examples"):
-        lines += ["", "**FP examples (classified market_wide, expected symbol_specific):**"]
+        lines += [
+            "",
+            "**FP examples (classified market_wide, expected symbol_specific):**",
+        ]
         for ex in us["fp_examples"]:
-            lines.append(f"- `{ex.get('title', '')}` → got `{ex.get('got')}`, expected `{ex.get('expected')}`")
+            lines.append(
+                f"- `{ex.get('title', '')}` → got `{ex.get('got')}`, expected `{ex.get('expected')}`"
+            )
     lines += ["", "## Crypto relevance precision"]
     cr = summary.get("crypto", {})
     lines += [
@@ -383,7 +403,9 @@ async def _run_tag_precision_mode(args: argparse.Namespace) -> int:
 
     summary_json = output_dir / "summary.json"
     summary_md = output_dir / "summary.md"
-    summary_json.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    summary_json.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
     summary_md.write_text(_tag_precision_markdown(summary), encoding="utf-8")
 
     print(f"output_dir: {output_dir}")

--- a/scripts/news_quality_baseline.py
+++ b/scripts/news_quality_baseline.py
@@ -91,7 +91,9 @@ def _analyze_us_articles(articles: list[Any]) -> dict[str, Any]:
     big_tech_fp_rate = (
         len(big_tech_fp_candidates) / sample_count if sample_count else 0.0
     )
-    broad_market_flag_rate = broad_market_flag_count / sample_count if sample_count else 0.0
+    broad_market_flag_rate = (
+        broad_market_flag_count / sample_count if sample_count else 0.0
+    )
 
     return {
         "sample_count": sample_count,
@@ -176,7 +178,9 @@ async def _load_articles_from_db(
         from app.models.news import NewsArticle
 
         async with AsyncSessionLocal() as db:
-            cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=window_hours)
+            cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+                hours=window_hours
+            )
             stmt = (
                 select(NewsArticle)
                 .where(NewsArticle.market == market)
@@ -221,9 +225,7 @@ def run_baseline_on_articles(
 async def async_main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    output_dir = Path(
-        args.output_dir or f"/tmp/rob155_news_quality_{timestamp}"
-    )
+    output_dir = Path(args.output_dir or f"/tmp/rob155_news_quality_{timestamp}")
     output_dir.mkdir(parents=True, exist_ok=True)
 
     report: dict[str, Any] = {
@@ -245,7 +247,9 @@ async def async_main(argv: list[str] | None = None) -> int:
         report[market] = metrics
 
     report_path = output_dir / "baseline_report.json"
-    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    report_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     print(f"output_dir: {output_dir}")
     print(f"report: {report_path}")

--- a/scripts/quote_parity_shadow_probe.py
+++ b/scripts/quote_parity_shadow_probe.py
@@ -120,12 +120,12 @@ async def enumerate_db_universe(
     holdings = await ManualHoldingsService(session).get_holdings_by_user(
         user_id, broker_type="toss"
     )
-    kr = [
-        to_db_symbol(h.ticker) for h in holdings if h.market_type == MarketType.KR
-    ][:limit]
-    us = [
-        to_db_symbol(h.ticker) for h in holdings if h.market_type == MarketType.US
-    ][:limit]
+    kr = [to_db_symbol(h.ticker) for h in holdings if h.market_type == MarketType.KR][
+        :limit
+    ]
+    us = [to_db_symbol(h.ticker) for h in holdings if h.market_type == MarketType.US][
+        :limit
+    ]
     return kr, us
 
 
@@ -175,7 +175,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Arm real Toss/KIS network reads. Without this flag: dry-run only.",
     )
     parser.add_argument(
-        "--json", action="store_true", default=False, help="(reserved) force JSON output."
+        "--json",
+        action="store_true",
+        default=False,
+        help="(reserved) force JSON output.",
     )
     return parser.parse_args(argv)
 
@@ -212,9 +215,7 @@ async def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         kr_symbols, us_symbols = await _resolve_universe(args)
-        allowlist = frozenset(
-            s.strip() for s in args.allowlist.split(",") if s.strip()
-        )
+        allowlist = frozenset(s.strip() for s in args.allowlist.split(",") if s.strip())
 
         if not args.confirm_live:
             # Dry-run: enumerate + print the plan. ZERO network calls.

--- a/scripts/run_research_run_refresh.py
+++ b/scripts/run_research_run_refresh.py
@@ -5,6 +5,7 @@ Read-only by default (dry-run). Examples:
   uv run python scripts/run_research_run_refresh.py --stage preopen
   uv run python scripts/run_research_run_refresh.py --stage nxt_aftermarket --no-dry-run
 """
+
 from __future__ import annotations
 
 import argparse
@@ -38,7 +39,11 @@ async def _dry_run(*, stage: str, market_scope: str) -> dict:
                 ),
             )
         except research_run_decision_session_service.ResearchRunNotFound:
-            return {"status": "dry_run", "reason": "no_research_run", "would_create": False}
+            return {
+                "status": "dry_run",
+                "reason": "no_research_run",
+                "would_create": False,
+            }
         snapshot = await research_run_live_refresh_service.build_live_refresh_snapshot(
             db, run=run
         )
@@ -54,7 +59,9 @@ async def _dry_run(*, stage: str, market_scope: str) -> dict:
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="run_research_run_refresh")
-    parser.add_argument("--stage", choices=["preopen", "nxt_aftermarket"], required=True)
+    parser.add_argument(
+        "--stage", choices=["preopen", "nxt_aftermarket"], required=True
+    )
     parser.add_argument("--market-scope", default="kr", choices=["kr"])
     parser.add_argument(
         "--dry-run", dest="dry_run", default=True, action=argparse.BooleanOptionalAction
@@ -62,14 +69,10 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.dry_run:
-        result = asyncio.run(
-            _dry_run(stage=args.stage, market_scope=args.market_scope)
-        )
+        result = asyncio.run(_dry_run(stage=args.stage, market_scope=args.market_scope))
     else:
         result = asyncio.run(
-            run_research_run_refresh(
-                stage=args.stage, market_scope=args.market_scope
-            )
+            run_research_run_refresh(stage=args.stage, market_scope=args.market_scope)
         )
     print(json.dumps(result, indent=2, ensure_ascii=False))
 

--- a/scripts/test_discord_webhook_e2e.py
+++ b/scripts/test_discord_webhook_e2e.py
@@ -35,8 +35,11 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from app.core.config import settings
-from app.monitoring.trade_notifier import TradeNotifier, get_trade_notifier
+from app.core.config import settings  # noqa: E402
+from app.monitoring.trade_notifier import (  # noqa: E402
+    TradeNotifier,
+    get_trade_notifier,
+)
 
 
 def print_section(title: str) -> None:
@@ -66,7 +69,9 @@ def print_warning(message: str) -> None:
     print(f"⚠️  {message}")
 
 
-async def test_buy_notification(notifier: TradeNotifier, market_type: str, webhook_name: str) -> bool:
+async def test_buy_notification(
+    notifier: TradeNotifier, market_type: str, webhook_name: str
+) -> bool:
     """Test buy order notification."""
     print_info(f"Testing buy notification for {webhook_name}...")
 
@@ -101,7 +106,9 @@ async def test_buy_notification(notifier: TradeNotifier, market_type: str, webho
         return False
 
 
-async def test_sell_notification(notifier: TradeNotifier, market_type: str, webhook_name: str) -> bool:
+async def test_sell_notification(
+    notifier: TradeNotifier, market_type: str, webhook_name: str
+) -> bool:
     """Test sell order notification."""
     print_info(f"Testing sell notification for {webhook_name}...")
 
@@ -137,7 +144,9 @@ async def test_sell_notification(notifier: TradeNotifier, market_type: str, webh
         return False
 
 
-async def test_analysis_notification(notifier: TradeNotifier, market_type: str, webhook_name: str) -> bool:
+async def test_analysis_notification(
+    notifier: TradeNotifier, market_type: str, webhook_name: str
+) -> bool:
     """Test AI analysis notification."""
     print_info(f"Testing analysis notification for {webhook_name}...")
 
@@ -256,7 +265,9 @@ async def run_tests(
     # Configure with webhooks from settings
     notifier.configure(
         bot_token=getattr(settings, "telegram_token", "") or "",
-        chat_ids=[getattr(settings, "telegram_chat_id", "")] if getattr(settings, "telegram_chat_id", None) else [],
+        chat_ids=[getattr(settings, "telegram_chat_id", "")]
+        if getattr(settings, "telegram_chat_id", None)
+        else [],
         enabled=True,
         discord_webhook_us=config["us"],
         discord_webhook_kr=config["kr"],
@@ -316,13 +327,19 @@ async def run_tests(
                 test_results.append(result)
             else:
                 # Test buy, sell, and analysis notifications
-                result1 = await test_buy_notification(notifier, webhook_type, webhook_name)
+                result1 = await test_buy_notification(
+                    notifier, webhook_type, webhook_name
+                )
                 test_results.append(result1)
 
-                result2 = await test_sell_notification(notifier, webhook_type, webhook_name)
+                result2 = await test_sell_notification(
+                    notifier, webhook_type, webhook_name
+                )
                 test_results.append(result2)
 
-                result3 = await test_analysis_notification(notifier, webhook_type, webhook_name)
+                result3 = await test_analysis_notification(
+                    notifier, webhook_type, webhook_name
+                )
                 test_results.append(result3)
 
         results[webhook_name] = test_results
@@ -351,9 +368,13 @@ def display_summary(results: dict[str, list[bool]], verbose: bool) -> int:
         passed_tests += webhook_passed
 
         if webhook_passed == webhook_total:
-            print_success(f"{webhook_name}: {webhook_passed}/{webhook_total} tests passed")
+            print_success(
+                f"{webhook_name}: {webhook_passed}/{webhook_total} tests passed"
+            )
         else:
-            print_warning(f"{webhook_name}: {webhook_passed}/{webhook_total} tests passed")
+            print_warning(
+                f"{webhook_name}: {webhook_passed}/{webhook_total} tests passed"
+            )
 
         if verbose:
             for i, result in enumerate(test_results, 1):
@@ -364,10 +385,14 @@ def display_summary(results: dict[str, list[bool]], verbose: bool) -> int:
     print(f"Overall: {passed_tests}/{total_tests} tests passed")
 
     if passed_tests == total_tests:
-        print_success("\n🎉 All tests passed! Discord webhook integration is working correctly.")
+        print_success(
+            "\n🎉 All tests passed! Discord webhook integration is working correctly."
+        )
         return 0
     else:
-        print_error(f"\n❌ {total_tests - passed_tests} test(s) failed. Please check your Discord webhook configuration.")
+        print_error(
+            f"\n❌ {total_tests - passed_tests} test(s) failed. Please check your Discord webhook configuration."
+        )
         return 1
 
 
@@ -387,7 +412,8 @@ def main() -> int:
         help="Show what would be sent without actually sending",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Enable verbose output",
     )
@@ -396,11 +422,13 @@ def main() -> int:
 
     try:
         # Run async tests
-        results = asyncio.run(run_tests(
-            market_type=args.market_type,
-            dry_run=args.dry_run,
-            verbose=args.verbose,
-        ))
+        results = asyncio.run(
+            run_tests(
+                market_type=args.market_type,
+                dry_run=args.dry_run,
+                verbose=args.verbose,
+            )
+        )
 
         # Display summary
         exit_code = display_summary(results, args.verbose)
@@ -414,6 +442,7 @@ def main() -> int:
         print_error(f"Unexpected error: {e}")
         if args.verbose:
             import traceback
+
             traceback.print_exc()
         return 1
 


### PR DESCRIPTION
## Summary
CI lint only covers `app/` and `tests/`, allowing ruff violations to accumulate in `research/` and `scripts/`. This PR fixes all remaining ruff violations in `research/` and `scripts/` without any business logic changes.

## Fix Details
- **I001 (Unsorted imports)**: 1 fix (in `scripts/test_discord_webhook_e2e.py`) automatically sorted via `ruff check --fix`.
- **E402 (Module level import not at top of file)**: 2 occurrences in `scripts/test_discord_webhook_e2e.py` marked with `# noqa: E402` because `sys.path` modification must precede these imports.
- **E741 (Ambiguous variable name)**: 2 occurrences in `research/nautilus_scalping/tests/test_rob382_cluc.py` and `test_rob382_ichi.py` marked with `# noqa: E741`.
- **E702 & Formatting**: 7 occurrences of multi-statement lines formatted using `ruff format`.

## Verification
- `uv run ruff check research/ scripts/` -> `All checks passed!`
- `uv run ruff format --check research/ scripts/` -> Passed
- `uv run python -m py_compile` -> Clean compilation
- **Logic Changes**: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code readability and consistency across research, backtesting, trading strategy, data-processing, and utility workflows.
  * Reformatted command-line output and configuration handling without changing results or user-facing behavior.

* **Tests**
  * Clarified test structure and strengthened statistical validation coverage while preserving existing expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->