### PR TITLE
chore: widen ruff lint scope to research/ and scripts/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,10 +73,10 @@ jobs:
       - setup-deps
       - run:
           name: Run Ruff linter
-          command: uv run ruff check app/ tests/
+          command: uv run ruff check app/ tests/ research/ scripts/
       - run:
           name: Run Ruff formatter check
-          command: uv run ruff format --check app/ tests/
+          command: uv run ruff format --check app/ tests/ research/ scripts/
       - run:
           name: Run ty type checker
           command: uv run ty check app/ --error-on-warning

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,10 @@ jobs:
       run: uv sync --group dev
 
     - name: Run Ruff linter
-      run: uv run ruff check app/ tests/
+      run: uv run ruff check app/ tests/ research/ scripts/
 
     - name: Run Ruff formatter check
-      run: uv run ruff format --check app/ tests/
+      run: uv run ruff format --check app/ tests/ research/ scripts/
 
     - name: Run ty
       run: uv run ty check app/ --error-on-warning

--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,13 @@ test-watch: ## Run tests in watch mode (excludes live)
 test-live: ## Run live API tests only (requires external network)
 	uv run pytest tests/ -v -m "integration and live" --run-live --no-cov
 lint: ## Run linting checks (Ruff + ty)
-	uv run ruff check app/ tests/
-	uv run ruff format --check app/ tests/
+	uv run ruff check app/ tests/ research/ scripts/
+	uv run ruff format --check app/ tests/ research/ scripts/
 	uv run ty check app/ --error-on-warning
 
 format: ## Format code with Ruff
-	uv run ruff format app/ tests/
-	uv run ruff check --fix app/ tests/
+	uv run ruff format app/ tests/ research/ scripts/
+	uv run ruff check --fix app/ tests/ research/ scripts/
 
 typecheck: ## Run ty type checking
 	uv run ty check app/ --error-on-warning


### PR DESCRIPTION
## 개요
PR #1651에서 `research/` 및 `scripts/` 디렉터리의 ruff 위반 사항을 모두 정리했으나, CI 및 Makefile의 ruff 검사 범위가 `app/`과 `tests/`에 한정되어 있어 향후 오류가 재발하는 것을 방지하고자 검사 범위를 넓혔습니다.

## 수정한 위치
- `Makefile` (L45, L46, L50, L51): ruff check/format 대상에 `research/ scripts/` 추가
- `.github/workflows/test.yml` (L41, L44): ruff check/format 대상에 `research/ scripts/` 추가
- `.circleci/config.yml` (L76, L79): ruff check/format 대상에 `research/ scripts/` 추가

## 검증 결과
1. `uv run ruff check app/ tests/ research/ scripts/`: `All checks passed!`
2. `uv run ruff format --check app/ tests/ research/ scripts/`: `3253 files already formatted`
3. `make lint`: 성공 (`ruff check`, `ruff format --check`, `ty check` 모두 통과)

PR #1651의 후속 작업입니다.