### PR TITLE
fix(crypto): resolve venue mismatch blocking crypto forecast scoring (ROB-1010)

### DIFF
--- a/alembic/versions/20260725_rob1010_normalize_crypto_instrument_venue.py
+++ b/alembic/versions/20260725_rob1010_normalize_crypto_instrument_venue.py
@@ -1,0 +1,57 @@
+"""ROB-1010: Normalize crypto_instruments.venue from 'KRW' to 'upbit'
+
+Revision ID: 20260725_rob1010_crypto_venue
+Revises: 20260723_approval_dispatch
+Create Date: 2026-07-25 15:50:00.000000
+
+ROB-1010 root cause:
+  Backfill migration 181f946296ff seeded crypto_instruments using:
+    CASE WHEN c.market = 'upbit_krw' THEN 'upbit' ELSE c.market END AS venue
+  Because legacy crypto_candles_1d.market contained 'KRW' rather than
+  'upbit_krw', 261 rows were inserted into crypto_instruments with
+  venue='KRW' instead of venue='upbit'.
+
+  This caused _resolve_instrument_id() in daily_candles/repository.py
+  to fail (as it queries venue='upbit' for partition='upbit_krw'), leading
+  to empty candle ranges during forecast resolution (unresolved_no_data).
+
+This migration normalizes venue='KRW' -> venue='upbit' in crypto_instruments.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260725_rob1010_crypto_venue"
+down_revision: Union[str, Sequence[str], None] = "20260723_approval_dispatch"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Normalize legacy venue='KRW' rows to venue='upbit'."""
+    op.execute(
+        """
+        UPDATE crypto_instruments
+        SET venue = 'upbit', updated_at = NOW()
+        WHERE venue = 'KRW'
+          AND NOT EXISTS (
+            SELECT 1 FROM crypto_instruments target
+            WHERE target.venue = 'upbit'
+              AND target.product = crypto_instruments.product
+              AND target.venue_symbol = crypto_instruments.venue_symbol
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Revert venue='upbit' rows back to venue='KRW'."""
+    op.execute(
+        """
+        UPDATE crypto_instruments
+        SET venue = 'KRW', updated_at = NOW()
+        WHERE venue = 'upbit'
+        """
+    )

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -6,6 +6,7 @@ This module knows about the database. It does NOT call external APIs.
 from __future__ import annotations
 
 import enum
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import cast
@@ -15,6 +16,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import TextClause
 
 from app.services.candles_sync_common import SyncTableConfig
+
+logger = logging.getLogger(__name__)
 
 
 class MarketKey(enum.StrEnum):
@@ -191,6 +194,7 @@ class DailyCandlesRepository:
         )
         if not normalized:
             return {}
+        venue = _crypto_venue_for_partition(partition)
         sql = text(
             "SELECT venue_symbol, id FROM crypto_instruments "
             "WHERE venue = :venue AND product = 'spot' "
@@ -199,11 +203,26 @@ class DailyCandlesRepository:
         result = await self._session.execute(
             sql,
             {
-                "venue": _crypto_venue_for_partition(partition),
+                "venue": venue,
                 "symbols": normalized,
             },
         )
-        return {str(row.venue_symbol): int(row.id) for row in result}
+        resolved_map = {str(row.venue_symbol): int(row.id) for row in result}
+        missing = [s for s in normalized if s not in resolved_map]
+        if missing:
+            logger.warning(
+                "Crypto instrument lookup returned incomplete results for venue=%r (partition=%r): "
+                "requested %d symbols, found %d, missing %d symbol(s) (e.g. %s). "
+                "Verify crypto_instruments table is seeded with venue=%r.",
+                venue,
+                partition,
+                len(normalized),
+                len(resolved_map),
+                len(missing),
+                missing[:5],
+                venue,
+            )
+        return resolved_map
 
     async def _resolve_instrument_id(self, *, symbol: str, partition: str) -> int:
         """Single-symbol identity resolver. Raises ``LookupError`` if not seeded."""
@@ -388,7 +407,13 @@ class DailyCandlesRepository:
                 iid = await self._resolve_instrument_id(
                     symbol=symbol, partition=partition
                 )
-            except LookupError:
+            except LookupError as exc:
+                logger.warning(
+                    "latest_time_utc(market=CRYPTO) failed to resolve instrument_id for symbol=%r partition=%r: %s",
+                    symbol,
+                    partition,
+                    exc,
+                )
                 return None
             sql = text(
                 "SELECT MAX(time) AS latest FROM public.crypto_candles_1d "
@@ -438,7 +463,13 @@ class DailyCandlesRepository:
                 iid = await self._resolve_instrument_id(
                     symbol=symbol, partition=partition
                 )
-            except LookupError:
+            except LookupError as exc:
+                logger.warning(
+                    "fetch_range(market=CRYPTO) failed to resolve instrument_id for symbol=%r partition=%r: %s",
+                    symbol,
+                    partition,
+                    exc,
+                )
                 return []
             sql = text(
                 """

--- a/tests/services/daily_candles/test_crypto_candles_1m.py
+++ b/tests/services/daily_candles/test_crypto_candles_1m.py
@@ -64,12 +64,12 @@ async def test_ohlc_check_rejects_inconsistent(db_session: AsyncSession) -> None
         text(
             "INSERT INTO crypto_instruments "
             "(venue, product, venue_symbol, base_asset, quote_asset, status) "
-            "VALUES ('upbit', 'spot', 'KRW-BTC', 'BTC', 'KRW', 'active')"
+            "VALUES ('upbit', 'spot', 'KRW-BTC-OHLC', 'BTC', 'KRW', 'active')"
         )
     )
     inst_id = (
         await db_session.execute(
-            text("SELECT id FROM crypto_instruments WHERE venue_symbol='KRW-BTC'")
+            text("SELECT id FROM crypto_instruments WHERE venue_symbol='KRW-BTC-OHLC'")
         )
     ).scalar_one()
     with pytest.raises(IntegrityError):
@@ -142,7 +142,7 @@ async def test_cross_venue_same_bucket_coexistence(db_session: AsyncSession) -> 
     )
 
     instruments = [
-        ("upbit", "spot", "KRW-BTC", "BTC", "KRW"),
+        ("upbit", "spot", "KRW-BTC-COEXIST", "BTC", "KRW"),
         ("binance", "spot", "BTCUSDT", "BTC", "USDT"),
         ("binance", "usdm_futures", "BTCUSDT", "BTC", "USDT"),
         ("alpaca", "paper", "BTC/USD", "BTC", "USD"),

--- a/tests/services/daily_candles/test_crypto_instruments.py
+++ b/tests/services/daily_candles/test_crypto_instruments.py
@@ -45,7 +45,7 @@ async def test_crypto_instruments_unique_constraint(db_session: AsyncSession) ->
         text(
             "INSERT INTO crypto_instruments "
             "(venue, product, venue_symbol, base_asset, quote_asset, status) "
-            "VALUES ('upbit', 'spot', 'KRW-BTC', 'BTC', 'KRW', 'active')"
+            "VALUES ('upbit', 'spot', 'KRW-BTC-UNIQ', 'BTC', 'KRW', 'active')"
         )
     )
     await db_session.flush()
@@ -54,7 +54,7 @@ async def test_crypto_instruments_unique_constraint(db_session: AsyncSession) ->
             text(
                 "INSERT INTO crypto_instruments "
                 "(venue, product, venue_symbol, base_asset, quote_asset, status) "
-                "VALUES ('upbit', 'spot', 'KRW-BTC', 'BTC', 'KRW', 'active')"
+                "VALUES ('upbit', 'spot', 'KRW-BTC-UNIQ', 'BTC', 'KRW', 'active')"
             )
         )
         await db_session.flush()

--- a/tests/services/daily_candles/test_crypto_venue_resolution.py
+++ b/tests/services/daily_candles/test_crypto_venue_resolution.py
@@ -1,0 +1,183 @@
+"""ROB-1010 — Tests for crypto venue normalization, resolution, and forecast scoring."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.crypto_instruments import CryptoInstrument
+from app.services.daily_candles.repository import (
+    DailyCandleRow,
+    DailyCandlesRepository,
+    MarketKey,
+)
+from app.services.trade_journal import forecast_service as svc
+
+
+@pytest.mark.asyncio
+async def test_crypto_instrument_id_resolution_with_upbit_venue(
+    db_session: AsyncSession,
+) -> None:
+    """Verify resolve_crypto_instrument_ids resolves venue='upbit' for partition='upbit_krw'."""
+    inst = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="KRW-ROBDOGE",
+        base_asset="ROBDOGE",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = DailyCandlesRepository(session=db_session)
+    resolved = await repo.resolve_crypto_instrument_ids(
+        symbols=["KRW-ROBDOGE"], partition="upbit_krw"
+    )
+    assert resolved == {"KRW-ROBDOGE": inst.id}
+
+    rows = await repo.fetch_range(
+        market=MarketKey.CRYPTO,
+        symbol="KRW-ROBDOGE",
+        partition="upbit_krw",
+        start=dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+        end=dt.datetime(2026, 6, 5, tzinfo=dt.UTC),
+    )
+    # Instrument resolved, no candles yet -> []
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_crypto_instrument_id_resolution_warning_when_venue_is_krw(
+    db_session: AsyncSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify legacy venue='KRW' returns empty map and logs diagnostic warning."""
+    inst = CryptoInstrument(
+        venue="KRW",
+        product="spot",
+        venue_symbol="KRW-ROBADA",
+        base_asset="ROBADA",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = DailyCandlesRepository(session=db_session)
+    resolved = await repo.resolve_crypto_instrument_ids(
+        symbols=["KRW-ROBADA"], partition="upbit_krw"
+    )
+    assert resolved == {}
+    assert any(
+        "incomplete results for venue='upbit'" in r.message for r in caplog.records
+    )
+
+    rows = await repo.fetch_range(
+        market=MarketKey.CRYPTO,
+        symbol="KRW-ROBADA",
+        partition="upbit_krw",
+        start=dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+        end=dt.datetime(2026, 6, 5, tzinfo=dt.UTC),
+    )
+    assert rows == []
+    assert any(
+        "fetch_range(market=CRYPTO) failed to resolve instrument_id" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_crypto_forecast_resolution_exits_unresolved_no_data(
+    db_session: AsyncSession,
+) -> None:
+    """Fixture-based test verifying crypto forecast resolution succeeds when venue='upbit'."""
+    inst = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="KRW-ROBBTC",
+        base_asset="ROBBTC",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = DailyCandlesRepository(session=db_session)
+    candle = DailyCandleRow(
+        time_utc=dt.datetime(2026, 6, 2, 0, 0, tzinfo=dt.UTC),
+        symbol="KRW-ROBBTC",
+        partition="upbit_krw",
+        open=90000000.0,
+        high=105000000.0,
+        low=89000000.0,
+        close=100000000.0,
+        adj_close=None,
+        volume=10.0,
+        value=1000000000.0,
+        source="upbit",
+    )
+    await repo.upsert_rows(market=MarketKey.CRYPTO, rows=[candle])
+    await db_session.commit()
+
+    target = {
+        "kind": "price_target",
+        "target": 100000000.0,
+        "direction": "at_or_above",
+    }
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="KRW-ROBBTC",
+        instrument_type="crypto",
+        forecast_target=target,
+        probability=0.7,
+        forecast_start_date="2026-06-01",
+        review_date="2026-06-05",
+    )
+    await db_session.commit()
+
+    result = await svc.resolve_forecast(
+        db_session, forecast_id=str(row.forecast_id), persist=True
+    )
+    assert result["status"] == "closed_hit"
+    assert result["changed"] is True
+
+
+@pytest.mark.asyncio
+async def test_normalize_crypto_venue_migration_sql(
+    db_session: AsyncSession,
+) -> None:
+    """Simulate Alembic migration SQL updating venue='KRW' -> venue='upbit'."""
+    inst = CryptoInstrument(
+        venue="KRW",
+        product="spot",
+        venue_symbol="KRW-ROBSOL",
+        base_asset="ROBSOL",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    await db_session.execute(
+        text(
+            """
+            UPDATE crypto_instruments
+            SET venue = 'upbit', updated_at = NOW()
+            WHERE venue = 'KRW'
+              AND NOT EXISTS (
+                SELECT 1 FROM crypto_instruments target
+                WHERE target.venue = 'upbit'
+                  AND target.product = crypto_instruments.product
+                  AND target.venue_symbol = crypto_instruments.venue_symbol
+              )
+            """
+        )
+    )
+    await db_session.flush()
+    await db_session.refresh(inst)
+
+    assert inst.venue == "upbit"

--- a/tests/services/daily_candles/test_crypto_venue_resolution.py
+++ b/tests/services/daily_candles/test_crypto_venue_resolution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import uuid
 
 import pytest
 from sqlalchemy import text
@@ -93,22 +94,23 @@ async def test_crypto_instrument_id_resolution_warning_when_venue_is_krw(
 async def test_crypto_forecast_resolution_exits_unresolved_no_data(
     db_session: AsyncSession,
 ) -> None:
-    """Fixture-based test verifying crypto forecast resolution succeeds when venue='upbit'."""
+    """Verify forecast resolution yields unresolved_no_data on venue='KRW' and resolves cleanly when normalized to venue='upbit'."""
+    unique_symbol = f"KRW-ROBFORECAST-{uuid.uuid4().hex[:8].upper()}"
     inst = CryptoInstrument(
         venue="upbit",
         product="spot",
-        venue_symbol="KRW-ROBBTC",
-        base_asset="ROBBTC",
+        venue_symbol=unique_symbol,
+        base_asset=unique_symbol.replace("KRW-", ""),
         quote_asset="KRW",
         status="active",
     )
     db_session.add(inst)
-    await db_session.flush()
+    await db_session.commit()
 
     repo = DailyCandlesRepository(session=db_session)
     candle = DailyCandleRow(
         time_utc=dt.datetime(2026, 6, 2, 0, 0, tzinfo=dt.UTC),
-        symbol="KRW-ROBBTC",
+        symbol=unique_symbol,
         partition="upbit_krw",
         open=90000000.0,
         high=105000000.0,
@@ -124,13 +126,14 @@ async def test_crypto_forecast_resolution_exits_unresolved_no_data(
 
     target = {
         "kind": "price_target",
-        "target": 100000000.0,
+        "target_price": 100000000.0,
         "direction": "at_or_above",
+        "outcome_rule_version": "window-touch-v1-high-gte-low-lte",
     }
     _, row = await svc.save_forecast(
         db_session,
         created_by="claude",
-        symbol="KRW-ROBBTC",
+        symbol=unique_symbol,
         instrument_type="crypto",
         forecast_target=target,
         probability=0.7,
@@ -139,11 +142,25 @@ async def test_crypto_forecast_resolution_exits_unresolved_no_data(
     )
     await db_session.commit()
 
-    result = await svc.resolve_forecast(
+    # 1. Mutate venue to legacy mis-normalized 'KRW' -> DailyCandlesRepository fails to map instrument -> unresolved_no_data
+    inst.venue = "KRW"
+    await db_session.commit()
+
+    unresolved_result = await svc.resolve_forecast(
         db_session, forecast_id=str(row.forecast_id), persist=True
     )
-    assert result["status"] == "closed_hit"
-    assert result["changed"] is True
+    assert unresolved_result["status"] == "unresolved_no_data"
+
+    # 2. Normalize venue to "upbit" -> resolution succeeds with resolved status and closed_hit forecast status
+    inst.venue = "upbit"
+    await db_session.commit()
+
+    resolved_result = await svc.resolve_forecast(
+        db_session, forecast_id=str(row.forecast_id), persist=True
+    )
+    assert resolved_result["status"] == "resolved"
+    assert resolved_result["changed"] is True
+    assert resolved_result["forecast"]["status"] == "closed"
 
 
 @pytest.mark.asyncio

--- a/tests/services/daily_candles/test_repository_crypto_path.py
+++ b/tests/services/daily_candles/test_repository_crypto_path.py
@@ -213,7 +213,12 @@ async def test_resolve_crypto_instrument_ids_batches_symbols_in_one_select(
         resolved = await DailyCandlesRepository(
             session=db_session
         ).resolve_crypto_instrument_ids(
-            symbols=["KRW-XRP-BATCH", "KRW-BTC-BATCH", "KRW-ETH-BATCH", "KRW-BTC-BATCH"],
+            symbols=[
+                "KRW-XRP-BATCH",
+                "KRW-BTC-BATCH",
+                "KRW-ETH-BATCH",
+                "KRW-BTC-BATCH",
+            ],
             partition="upbit_krw",
         )
     finally:

--- a/tests/services/daily_candles/test_repository_crypto_path.py
+++ b/tests/services/daily_candles/test_repository_crypto_path.py
@@ -213,7 +213,7 @@ async def test_resolve_crypto_instrument_ids_batches_symbols_in_one_select(
         resolved = await DailyCandlesRepository(
             session=db_session
         ).resolve_crypto_instrument_ids(
-            symbols=["KRW-XRP", "KRW-BTC", "KRW-ETH", "KRW-BTC"],
+            symbols=["KRW-XRP-BATCH", "KRW-BTC-BATCH", "KRW-ETH-BATCH", "KRW-BTC-BATCH"],
             partition="upbit_krw",
         )
     finally:

--- a/tests/services/daily_candles/test_repository_crypto_path.py
+++ b/tests/services/daily_candles/test_repository_crypto_path.py
@@ -194,7 +194,7 @@ async def test_resolve_crypto_instrument_ids_batches_symbols_in_one_select(
             quote_asset="KRW",
             status="active",
         )
-        for symbol in ("KRW-BTC", "KRW-ETH", "KRW-XRP")
+        for symbol in ("KRW-BTC-BATCH", "KRW-ETH-BATCH", "KRW-XRP-BATCH")
     ]
     db_session.add_all(instruments)
     await db_session.flush()

--- a/tests/services/order_proposals/test_models_smoke.py
+++ b/tests/services/order_proposals/test_models_smoke.py
@@ -159,10 +159,13 @@ def test_approval_dispatch_migration_is_additive_and_the_single_head():
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
     scripts = ScriptDirectory.from_config(config)
-    assert scripts.get_heads() == ["20260723_approval_dispatch"]
-    revision = scripts.get_revision("20260723_approval_dispatch")
+    # Note: This test explicitly asserts the latest migration revision head ID to enforce
+    # single-head linear history across all Alembic migrations (preventing unintentional head splits).
+    # Each new Alembic migration must update this target head revision.
+    assert scripts.get_heads() == ["20260725_rob1010_crypto_venue"]
+    revision = scripts.get_revision("20260725_rob1010_crypto_venue")
     assert revision is not None
-    assert revision.down_revision == "20260722_rob1023_widen_runner"
+    assert revision.down_revision == "20260723_approval_dispatch"
 
 
 @pytest.mark.unit

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -151,7 +151,7 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             assert completed.returncode == 0, completed.stdout + completed.stderr
         current = await asyncio.to_thread(alembic, "current")
         assert current.returncode == 0, current.stdout + current.stderr
-        assert "20260723_approval_dispatch (head)" in current.stdout
+        assert "20260725_rob1010_crypto_venue (head)" in current.stdout
 
         async with engine.connect() as connection:
             triggers = await connection.scalar(

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -56,7 +56,7 @@ def test_migration_descends_from_latest_main_head_and_is_the_single_head() -> No
     config = Config(str(REPO / "alembic.ini"))
     config.set_main_option("script_location", str(REPO / "alembic"))
     assert ScriptDirectory.from_config(config).get_heads() == [
-        "20260723_approval_dispatch"
+        "20260725_rob1010_crypto_venue"
     ]
 
 

--- a/tests/services/research/test_rob1023_backtest_metadata_width.py
+++ b/tests/services/research/test_rob1023_backtest_metadata_width.py
@@ -68,6 +68,7 @@ def test_runner_width_contract_and_alembic_head_are_pinned() -> None:
 
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
+    # Note: Enforce single-head linear Alembic migration history.
     assert ScriptDirectory.from_config(config).get_heads() == [
         "20260725_rob1010_crypto_venue"
     ]

--- a/tests/services/research/test_rob1023_backtest_metadata_width.py
+++ b/tests/services/research/test_rob1023_backtest_metadata_width.py
@@ -69,7 +69,7 @@ def test_runner_width_contract_and_alembic_head_are_pinned() -> None:
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
     assert ScriptDirectory.from_config(config).get_heads() == [
-        "20260723_approval_dispatch"
+        "20260725_rob1010_crypto_venue"
     ]
 
 


### PR DESCRIPTION
## Root Cause
`forecast_resolve` evaluated all crypto forecasts as `unresolved_no_data` because `DailyCandlesRepository._crypto_venue_for_partition("upbit_krw")` queried `crypto_instruments` for `venue = 'upbit'`, but in production 261 rows in `crypto_instruments` were seeded with `venue = 'KRW'` (and 0 with `venue = 'upbit'`).
This happened because backfill migration `181f946296ff` assumed legacy `crypto_candles_1d.market` was `'upbit_krw'`, whereas in production it contained `'KRW'`, hitting the `ELSE` fallback branch during insertion.

## Chosen Option & Rationale
**Option 2 (DB Normalization)**: Normalize 261 rows in `crypto_instruments` from `venue = 'KRW'` to `venue = 'upbit'`.

### Rationale:
1. **Domain Semantics**: `venue` represents exchange/platform identity (`'upbit'`, `'binance'`), whereas `'KRW'` is a quote asset currency. Calling venue `'KRW'` creates confusing technical debt and prevents multi-currency/multi-market support on Upbit.
2. **Codebase Alignment**: Existing code (`_crypto_venue_for_partition`), migration intent (`181f946296ff`), test assertions, and ROB-284 design specs already expect `venue = 'upbit'`.
3. **Options 1 & 3 Rejection**: Option 1 (changing code to return `'KRW'`) locks in incorrect domain semantics. Option 3 (querying both) is an ad-hoc band-aid.

## Exhaustive Consumer Verification
- `app/services/daily_candles/repository.py`: Queries `venue = 'upbit'` via `_crypto_venue_for_partition`.
- `app/services/brokers/binance/ingest.py`: Queries `venue = 'binance'`.
- `app/services/brokers/binance/demo/ledger/repository.py`: Queries `venue` (for Binance demo).
- `app/jobs/binance_demo_root_reservation_reconciliation.py`: Queries `venue_symbol`.
- `crypto_instruments` unique constraint is `(venue, product, venue_symbol)`. With 0 `venue = 'upbit'` rows in DB, updating `venue = 'KRW'` -> `venue = 'upbit'` does not conflict with any existing rows.

## Migration & Rollback
- New migration: `alembic/versions/20260725_rob1010_normalize_crypto_instrument_venue.py` (Revision: `20260725_rob1010_crypto_venue`, Revises: `20260723_approval_dispatch`).
- **Upgrade**: `UPDATE crypto_instruments SET venue = 'upbit', updated_at = NOW() WHERE venue = 'KRW' AND NOT EXISTS (...);`.
- **Downgrade**: `UPDATE crypto_instruments SET venue = 'KRW', updated_at = NOW() WHERE venue = 'upbit';`.
- Explains the erroneous assumption of `181f946296ff` in docstring without modifying `181f946296ff`.
- **CRITICAL**: This migration has **NOT been executed on the production DB**.

## Recurrence Prevention & Observability
- Added diagnostic `logger.warning` calls to `DailyCandlesRepository.resolve_crypto_instrument_ids`, `fetch_range`, and `latest_time_utc` when requested symbols/venues are missing or resolution fails.
- Read paths continue to fail open gracefully without raising unhandled exceptions.

## Test Verification
- Target unit tests (`test_crypto_venue_resolution.py`): 4/4 PASSED.
- Daily candles & forecast service suite: 72/72 PASSED.
- Full unit test suite (`uv run pytest tests/ -q -m "not integration and not slow"`): **3332 passed, 0 failed**.
- Ruff lint & format checks: PASSED.