### PR TITLE
feat(ROB-1052): KR single-share full-exit shadow lane

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1932,6 +1932,13 @@ Response shape:
     permits only a small pre-placed trim ladder; RSI-neutral 2-6% resistance is
     a watch; `sell.upside_place_max_pct` limits size rather than blocking
     pre-placement eligibility.
+    `decision_rules["sell.single_share_exit"]` is intentionally visible only
+    for KR sell, but remains shadow metadata: `activation_state=shadow` and
+    `proposal_enabled=false` mean that neither `get_trading_policy` nor
+    `route_request` may interpret its candidate action as permission to create,
+    approve, or execute a proposal. Capability labels in its snapshot API are
+    descriptive, not authentication; any future live composition must pin the
+    trusted read-adapter provenance separately.
   - **Version-stamping contract**: consumers cite `{version, content_hash}` (from `get_trading_policy` or the `policy_version` field of `get_operating_briefing`) in `report_item.evidence_snapshot`, `trade_retrospectives`, and forecast records so the judging criteria are recoverable.
   - The buy-preview `sector_concentration` field is **fail-open** advisory (never blocks).
 

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -8,10 +8,18 @@ fails loudly instead of silently dropping a key.
 
 from __future__ import annotations
 
-from datetime import date
-from typing import Literal
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 Lane = Literal["buy", "sell", "discovery"]
 Market = Literal["kr", "us", "crypto"]
@@ -19,6 +27,9 @@ Market = Literal["kr", "us", "crypto"]
 ThresholdValue = int | float | str | list[int | float]
 RuleConditionValue = int | float | str | bool | list[int | float | str | bool]
 PolicyComparison = Literal["gt", "gte", "lt", "lte", "eq"]
+KrBroker = Literal["kis", "toss"]
+KrSymbol = Annotated[str, StringConstraints(pattern=r"^\d{6}$")]
+ResistanceStrength = Literal["weak", "moderate", "strong"]
 
 
 class OneShareExceptionPolicy(BaseModel):
@@ -69,27 +80,65 @@ class SingleShareExitScope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     markets: list[Literal["kr"]]
-    brokers: list[Literal["kis", "toss"]]
+    brokers: list[KrBroker]
+    required_broker_inventory: list[KrBroker]
     order_routable_required: Literal[True]
+
+    @model_validator(mode="after")
+    def validate_kis_toss_scope(self) -> SingleShareExitScope:
+        required = {"kis", "toss"}
+        if set(self.brokers) != required or len(self.brokers) != len(required):
+            raise ValueError("brokers must contain exactly kis and toss")
+        if set(self.required_broker_inventory) != required or len(
+            self.required_broker_inventory
+        ) != len(required):
+            raise ValueError(
+                "required_broker_inventory must contain exactly kis and toss"
+            )
+        return self
+
+
+class SingleShareResistanceSourceFamilies(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    volume_profile_exact: list[str]
+    fibonacci_prefixes: list[str]
+    bollinger_prefixes: list[str]
 
 
 class SingleShareExitConditions(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    quantity_eq: Literal[1]
+    symbol_routable_sellable_quantity_eq: Literal[1]
     profit_pct_min: float = Field(ge=0)
     resistance_reference_required: Literal[True]
-    resistance_near_pct_max: float = Field(ge=0, le=100)
+    resistance_distance_pct_min_exclusive: float = Field(ge=0, le=100)
+    resistance_distance_pct_max: float = Field(ge=0, le=100)
+    resistance_source_family_min: int = Field(ge=2)
+    resistance_source_families: SingleShareResistanceSourceFamilies
+    quote_max_age_seconds: int = Field(gt=0)
+    snapshot_max_skew_seconds: int = Field(gt=0)
+    required_completed_bar_market: Literal["XKRX"]
     min_sell_price_multiple_policy_key: Literal["sell.loss_guard_min_multiple"]
+    same_symbol_open_orders_max: Literal[0]
     unresolved_open_actions_max: Literal[0]
     loss_state_uses_existing_path: Literal["loss_cut_only"]
+
+    @model_validator(mode="after")
+    def validate_resistance_band(self) -> SingleShareExitConditions:
+        if (
+            self.resistance_distance_pct_max
+            <= self.resistance_distance_pct_min_exclusive
+        ):
+            raise ValueError("resistance distance max must exceed exclusive min")
+        return self
 
 
 class SingleShareExitProposal(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    action: Literal["propose_full_exit"]
-    sizing: Literal["full_position"]
+    action: Literal["propose_full_account_lot_exit"]
+    sizing: Literal["full_account_lot_exit"]
     approval: Literal["telegram_manual"]
     auto_approve: Literal[False]
     execution: Literal["proposal_only"]
@@ -107,12 +156,106 @@ class SingleShareExitDecisionRule(BaseModel):
 
     lanes: list[Literal["sell"]]
     semantics: str
+    activation_state: Literal["shadow"]
+    proposal_enabled: Literal[False]
     scope: SingleShareExitScope
     conditions: SingleShareExitConditions
     proposal: SingleShareExitProposal
     threshold_status: Literal["provisional"]
     operator_approval_required: Literal[True]
     recalibration_note: str
+
+
+class SingleShareExitTargetIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: KrSymbol
+    broker: KrBroker
+    broker_account_id: str = Field(min_length=1)
+    lot_id: str = Field(min_length=1)
+
+
+class SingleShareExitAccountLot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: KrSymbol
+    lot_id: str = Field(min_length=1)
+    order_routable: bool
+    sellable_quantity: Decimal = Field(ge=0)
+    average_cost: Decimal = Field(gt=0)
+
+
+class SingleShareExitOpenOrder(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    order_id: str = Field(min_length=1)
+    symbol: KrSymbol
+    side: Literal["buy", "sell"]
+
+
+class SingleShareExitBrokerAccountSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_id: str = Field(min_length=1)
+    broker: KrBroker
+    broker_account_id: str = Field(min_length=1)
+    observed_at: datetime
+    holdings_complete: Literal[True]
+    lots: list[SingleShareExitAccountLot]
+    open_orders_checked_at: datetime
+    open_orders_complete: Literal[True]
+    open_orders: list[SingleShareExitOpenOrder]
+
+
+class SingleShareExitQuoteEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_id: str = Field(min_length=1)
+    symbol: KrSymbol
+    price: Decimal = Field(gt=0)
+    observed_at: datetime
+    source: str = Field(min_length=1)
+
+
+class SingleShareExitResistanceEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_id: str = Field(min_length=1)
+    symbol: KrSymbol
+    price: Decimal = Field(gt=0)
+    sources: list[str] = Field(min_length=1)
+    strength: ResistanceStrength
+    computed_at: datetime
+    ohlcv_through_date: date
+
+
+class SingleShareExitOpenAction(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action_id: str = Field(min_length=1)
+    symbol: KrSymbol
+    side: Literal["buy", "sell"]
+    broker_account_id: str = Field(min_length=1)
+    status: Literal["open", "in_progress"]
+
+
+class SingleShareExitEvidenceSnapshot(BaseModel):
+    """Read-only evidence contract for shadow single-account-lot exit review."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_id: str = Field(min_length=1)
+    market: Literal["kr"]
+    captured_at: datetime
+    target: SingleShareExitTargetIdentity
+    broker_account_scope_complete: Literal[True]
+    accounts: list[SingleShareExitBrokerAccountSnapshot] = Field(min_length=2)
+    quote: SingleShareExitQuoteEvidence
+    resistance: SingleShareExitResistanceEvidence
+    open_actions_snapshot_id: str = Field(min_length=1)
+    open_actions_checked_at: datetime
+    open_actions_complete: Literal[True]
+    open_actions: list[SingleShareExitOpenAction]
 
 
 class PolicyRecoveryCondition(BaseModel):

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -145,11 +145,13 @@ class SingleShareExitProposal(BaseModel):
 
 
 class SingleShareExitDecisionRule(BaseModel):
-    """Additive KR one-share profit-exit proposal policy.
+    """Additive KR one-share profit-exit shadow policy.
 
     This rule intentionally has a distinct shape from the tiered trim rule:
     ``sell.trim_preplace`` excludes one-share positions globally, while this
-    path can only produce a manually approved proposal and never an order.
+    path can only classify shadow eligibility while ``proposal_enabled`` is
+    false. Its candidate metadata is manual-approval-only for a separately
+    authorized future activation; this schema never enables an order.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -65,6 +65,56 @@ class PolicyDecisionRule(BaseModel):
     exclusions: list[str] = Field(default_factory=list)
 
 
+class SingleShareExitScope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    markets: list[Literal["kr"]]
+    brokers: list[Literal["kis", "toss"]]
+    order_routable_required: Literal[True]
+
+
+class SingleShareExitConditions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    quantity_eq: Literal[1]
+    profit_pct_min: float = Field(ge=0)
+    resistance_reference_required: Literal[True]
+    resistance_near_pct_max: float = Field(ge=0, le=100)
+    min_sell_price_multiple_policy_key: Literal["sell.loss_guard_min_multiple"]
+    unresolved_open_actions_max: Literal[0]
+    loss_state_uses_existing_path: Literal["loss_cut_only"]
+
+
+class SingleShareExitProposal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    action: Literal["propose_full_exit"]
+    sizing: Literal["full_position"]
+    approval: Literal["telegram_manual"]
+    auto_approve: Literal[False]
+    execution: Literal["proposal_only"]
+
+
+class SingleShareExitDecisionRule(BaseModel):
+    """Additive KR one-share profit-exit proposal policy.
+
+    This rule intentionally has a distinct shape from the tiered trim rule:
+    ``sell.trim_preplace`` excludes one-share positions globally, while this
+    path can only produce a manually approved proposal and never an order.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Literal["sell"]]
+    semantics: str
+    scope: SingleShareExitScope
+    conditions: SingleShareExitConditions
+    proposal: SingleShareExitProposal
+    threshold_status: Literal["provisional"]
+    operator_approval_required: Literal[True]
+    recalibration_note: str
+
+
 class PolicyRecoveryCondition(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -235,7 +285,9 @@ class TradingPolicyDocument(BaseModel):
     order_proposals: OrderProposalsPolicy
     sector_clusters: dict[str, list[str]]
     thresholds: dict[str, PolicyThreshold]
-    decision_rules: dict[str, PolicyDecisionRule] = Field(default_factory=dict)
+    decision_rules: dict[str, PolicyDecisionRule | SingleShareExitDecisionRule] = Field(
+        default_factory=dict
+    )
     market_rules: dict[Literal["crypto"], CryptoMarketRules]
     market_overrides: dict[Market, dict[str, ThresholdValue]]
     crash_day: CrashDayPolicy

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -108,6 +108,7 @@ class SingleShareExitConditions(BaseModel):
     symbol_routable_sellable_quantity_eq: Literal[1]
     profit_pct_min: float = Field(ge=0)
     resistance_reference_required: Literal[True]
+    resistance_strength_min: Literal["strong"]
     resistance_distance_pct_min_exclusive: float = Field(ge=0, le=100)
     resistance_distance_pct_max: float = Field(ge=0, le=100)
     resistance_source_family_min: int = Field(ge=2)
@@ -138,7 +139,7 @@ class SingleShareExitConditions(BaseModel):
 class SingleShareExitProposal(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    action: Literal["propose_full_account_lot_exit"]
+    action: Literal["full_exit_at_far_resistance"]
     sizing: Literal["full_account_lot_exit"]
     approval: Literal["telegram_manual"]
     auto_approve: Literal[False]

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -8,15 +8,13 @@ fails loudly instead of silently dropping a key.
 
 from __future__ import annotations
 
-from datetime import date, datetime
-from decimal import Decimal
-from typing import Annotated, Literal
+from datetime import date
+from typing import Literal
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    StringConstraints,
     field_validator,
     model_validator,
 )
@@ -28,8 +26,6 @@ ThresholdValue = int | float | str | list[int | float]
 RuleConditionValue = int | float | str | bool | list[int | float | str | bool]
 PolicyComparison = Literal["gt", "gte", "lt", "lte", "eq"]
 KrBroker = Literal["kis", "toss"]
-KrSymbol = Annotated[str, StringConstraints(pattern=r"^\d{6}$")]
-ResistanceStrength = Literal["weak", "moderate", "strong"]
 
 
 class OneShareExceptionPolicy(BaseModel):
@@ -117,6 +113,11 @@ class SingleShareExitConditions(BaseModel):
     resistance_source_family_min: int = Field(ge=2)
     resistance_source_families: SingleShareResistanceSourceFamilies
     quote_max_age_seconds: int = Field(gt=0)
+    resistance_max_age_seconds: int = Field(gt=0)
+    holdings_max_age_seconds: int = Field(gt=0)
+    open_orders_max_age_seconds: int = Field(gt=0)
+    open_actions_max_age_seconds: int = Field(gt=0)
+    captured_at_max_age_seconds: int = Field(gt=0)
     snapshot_max_skew_seconds: int = Field(gt=0)
     required_completed_bar_market: Literal["XKRX"]
     min_sell_price_multiple_policy_key: Literal["sell.loss_guard_min_multiple"]
@@ -166,98 +167,6 @@ class SingleShareExitDecisionRule(BaseModel):
     threshold_status: Literal["provisional"]
     operator_approval_required: Literal[True]
     recalibration_note: str
-
-
-class SingleShareExitTargetIdentity(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    symbol: KrSymbol
-    broker: KrBroker
-    broker_account_id: str = Field(min_length=1)
-    lot_id: str = Field(min_length=1)
-
-
-class SingleShareExitAccountLot(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    symbol: KrSymbol
-    lot_id: str = Field(min_length=1)
-    order_routable: bool
-    sellable_quantity: Decimal = Field(ge=0)
-    average_cost: Decimal = Field(gt=0)
-
-
-class SingleShareExitOpenOrder(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    order_id: str = Field(min_length=1)
-    symbol: KrSymbol
-    side: Literal["buy", "sell"]
-
-
-class SingleShareExitBrokerAccountSnapshot(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    snapshot_id: str = Field(min_length=1)
-    broker: KrBroker
-    broker_account_id: str = Field(min_length=1)
-    observed_at: datetime
-    holdings_complete: Literal[True]
-    lots: list[SingleShareExitAccountLot]
-    open_orders_checked_at: datetime
-    open_orders_complete: Literal[True]
-    open_orders: list[SingleShareExitOpenOrder]
-
-
-class SingleShareExitQuoteEvidence(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    snapshot_id: str = Field(min_length=1)
-    symbol: KrSymbol
-    price: Decimal = Field(gt=0)
-    observed_at: datetime
-    source: str = Field(min_length=1)
-
-
-class SingleShareExitResistanceEvidence(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    snapshot_id: str = Field(min_length=1)
-    symbol: KrSymbol
-    price: Decimal = Field(gt=0)
-    sources: list[str] = Field(min_length=1)
-    strength: ResistanceStrength
-    computed_at: datetime
-    ohlcv_through_date: date
-
-
-class SingleShareExitOpenAction(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    action_id: str = Field(min_length=1)
-    symbol: KrSymbol
-    side: Literal["buy", "sell"]
-    broker_account_id: str = Field(min_length=1)
-    status: Literal["open", "in_progress"]
-
-
-class SingleShareExitEvidenceSnapshot(BaseModel):
-    """Read-only evidence contract for shadow single-account-lot exit review."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    snapshot_id: str = Field(min_length=1)
-    market: Literal["kr"]
-    captured_at: datetime
-    target: SingleShareExitTargetIdentity
-    broker_account_scope_complete: Literal[True]
-    accounts: list[SingleShareExitBrokerAccountSnapshot] = Field(min_length=2)
-    quote: SingleShareExitQuoteEvidence
-    resistance: SingleShareExitResistanceEvidence
-    open_actions_snapshot_id: str = Field(min_length=1)
-    open_actions_checked_at: datetime
-    open_actions_complete: Literal[True]
-    open_actions: list[SingleShareExitOpenAction]
 
 
 class PolicyRecoveryCondition(BaseModel):

--- a/app/services/single_share_exit_snapshot_service.py
+++ b/app/services/single_share_exit_snapshot_service.py
@@ -1,0 +1,752 @@
+"""Authoritative, read-only evidence assembly for the KR single-share exit lane.
+
+Raw account rows and caller-supplied completeness booleans are deliberately not
+an evaluator input.  A producer enumerates the configured account roster first,
+asks each read port for evidence over that exact roster, and issues a sealed
+context.  The trading-policy evaluator accepts only that context.
+
+The ports are read-only capability boundaries.  Live broker adapters are not
+constructed here; offline tests use fakes, and any future live composition must
+provide all four authoritative capabilities explicitly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import StrEnum
+from typing import Protocol
+
+PRODUCER_IDENTITY = "kr_single_share_exit_snapshot_producer/v2"
+PRODUCER_CAPABILITY = "validated_exhaustive_kis_toss_snapshot/v2"
+ROSTER_CAPABILITY = "configured_kr_account_roster_read/v1"
+BROKER_EVIDENCE_CAPABILITY = "exhaustive_broker_account_evidence_read/v1"
+OPEN_ACTION_CAPABILITY = "scoped_open_action_evidence_read/v1"
+MARKET_EVIDENCE_CAPABILITY = "typed_executable_market_evidence_read/v1"
+
+_REQUIRED_READER_CAPABILITIES = (
+    ROSTER_CAPABILITY,
+    BROKER_EVIDENCE_CAPABILITY,
+    OPEN_ACTION_CAPABILITY,
+    MARKET_EVIDENCE_CAPABILITY,
+)
+
+
+class KrBroker(StrEnum):
+    KIS = "kis"
+    TOSS = "toss"
+
+
+class AccountKind(StrEnum):
+    TAXABLE = "taxable"
+    ISA = "isa"
+    RETIREMENT = "retirement"
+
+
+class ResistanceStrength(StrEnum):
+    WEAK = "weak"
+    MODERATE = "moderate"
+    STRONG = "strong"
+
+
+class QuoteVenue(StrEnum):
+    KRX = "krx"
+    NXT = "nxt"
+
+
+class QuoteKind(StrEnum):
+    BROKER_LAST_TRADE = "broker_last_trade"
+    LIVE_ORDERBOOK_MID = "live_orderbook_mid"
+    NXT_EXPECTED_PRICE = "nxt_expected_price"
+    PREVIOUS_CLOSE_ECHO = "previous_close_echo"
+    INDICATIVE_ONLY = "indicative_only"
+
+
+class QuoteSource(StrEnum):
+    KIS_BROKER = "kis_broker"
+    TOSS_BROKER = "toss_broker"
+    NXT_EXPECTED_MODEL = "nxt_expected_model"
+    PREVIOUS_CLOSE = "previous_close"
+    INDICATIVE_MODEL = "indicative_model"
+
+
+class QuoteProvenance(StrEnum):
+    VENUE_LAST_TRADE = "venue_last_trade"
+    VENUE_BEST_BID = "venue_best_bid"
+    VENUE_BEST_ASK = "venue_best_ask"
+    PREVIOUS_CLOSE = "previous_close"
+    INDICATIVE_MODEL = "indicative_model"
+
+
+class ContextMode(StrEnum):
+    LIVE = "live"
+    REPLAY = "replay"
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not value or not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+
+
+def _require_kr_symbol(value: str) -> None:
+    if len(value) != 6 or not value.isascii() or not value.isdigit():
+        raise ValueError("symbol must be a six-digit KR code")
+
+
+def _require_aware(value: dt.datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class AccountIdentity:
+    broker: KrBroker
+    broker_account_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.broker, KrBroker):
+            raise ValueError("broker must be a typed KrBroker")
+        _require_text(self.broker_account_id, "broker_account_id")
+
+
+@dataclass(frozen=True, slots=True)
+class ConfiguredAccount:
+    identity: AccountIdentity
+    account_kind: AccountKind
+    order_routable: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.account_kind, AccountKind):
+            raise ValueError("account_kind must be typed")
+
+
+@dataclass(frozen=True, slots=True)
+class AuthoritativeAccountRoster:
+    roster_id: str
+    roster_version: str
+    roster_hash: str
+    read_model_identity: str
+    read_model_capability: str
+    accounts: tuple[ConfiguredAccount, ...]
+
+    def __post_init__(self) -> None:
+        _require_text(self.roster_id, "roster_id")
+        _require_text(self.roster_version, "roster_version")
+        _require_text(self.roster_hash, "roster_hash")
+        _require_text(self.read_model_identity, "read_model_identity")
+        _require_text(self.read_model_capability, "read_model_capability")
+
+
+@dataclass(frozen=True, slots=True)
+class SingleShareExitTarget:
+    symbol: str
+    broker: KrBroker
+    broker_account_id: str
+    lot_id: str
+
+    def __post_init__(self) -> None:
+        _require_kr_symbol(self.symbol)
+        if not isinstance(self.broker, KrBroker):
+            raise ValueError("broker must be a typed KrBroker")
+        _require_text(self.broker_account_id, "broker_account_id")
+        _require_text(self.lot_id, "lot_id")
+
+    @property
+    def account_identity(self) -> AccountIdentity:
+        return AccountIdentity(self.broker, self.broker_account_id)
+
+
+@dataclass(frozen=True, slots=True)
+class AccountLotEvidence:
+    symbol: str
+    lot_id: str
+    sellable_quantity: Decimal
+    average_cost: Decimal
+
+    def __post_init__(self) -> None:
+        _require_kr_symbol(self.symbol)
+        _require_text(self.lot_id, "lot_id")
+        if self.sellable_quantity < 0:
+            raise ValueError("sellable_quantity must be non-negative")
+        if self.average_cost <= 0:
+            raise ValueError("average_cost must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerOpenOrderEvidence:
+    order_id: str
+    symbol: str
+    side: str
+
+    def __post_init__(self) -> None:
+        _require_text(self.order_id, "order_id")
+        _require_kr_symbol(self.symbol)
+        if self.side not in {"buy", "sell"}:
+            raise ValueError("side must be buy or sell")
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerAccountEvidence:
+    identity: AccountIdentity
+    holdings_observed_at: dt.datetime
+    lots: tuple[AccountLotEvidence, ...]
+    open_orders_observed_at: dt.datetime
+    open_orders: tuple[BrokerOpenOrderEvidence, ...]
+
+    def __post_init__(self) -> None:
+        _require_aware(self.holdings_observed_at, "holdings_observed_at")
+        _require_aware(self.open_orders_observed_at, "open_orders_observed_at")
+
+
+@dataclass(frozen=True, slots=True)
+class OpenActionEvidence:
+    action_id: str
+    symbol: str
+    side: str
+    broker_account_id: str
+    status: str
+
+    def __post_init__(self) -> None:
+        _require_text(self.action_id, "action_id")
+        _require_kr_symbol(self.symbol)
+        if self.side not in {"buy", "sell"}:
+            raise ValueError("side must be buy or sell")
+        _require_text(self.broker_account_id, "broker_account_id")
+        if self.status not in {"open", "in_progress"}:
+            raise ValueError("status must be unresolved")
+
+
+@dataclass(frozen=True, slots=True)
+class ScopedOpenActionsEvidence:
+    observed_at: dt.datetime
+    actions: tuple[OpenActionEvidence, ...]
+
+    def __post_init__(self) -> None:
+        _require_aware(self.observed_at, "open_actions observed_at")
+
+
+@dataclass(frozen=True, slots=True)
+class TypedQuoteEvidence:
+    symbol: str
+    venue: QuoteVenue
+    quote_kind: QuoteKind
+    source: QuoteSource
+    observed_at: dt.datetime
+    executable: bool
+    firm: bool
+    last_price: Decimal | None = None
+    bid_price: Decimal | None = None
+    ask_price: Decimal | None = None
+    last_provenance: QuoteProvenance | None = None
+    bid_provenance: QuoteProvenance | None = None
+    ask_provenance: QuoteProvenance | None = None
+
+    def __post_init__(self) -> None:
+        _require_kr_symbol(self.symbol)
+        _require_aware(self.observed_at, "quote observed_at")
+        if not isinstance(self.venue, QuoteVenue):
+            raise ValueError("venue must be typed")
+        if not isinstance(self.quote_kind, QuoteKind):
+            raise ValueError("quote_kind must be typed")
+        if not isinstance(self.source, QuoteSource):
+            raise ValueError("quote source must be typed")
+        prices = (self.last_price, self.bid_price, self.ask_price)
+        if any(price is not None and price <= 0 for price in prices):
+            raise ValueError("quote prices must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class ResistanceEvidence:
+    symbol: str
+    price: Decimal
+    sources: tuple[str, ...]
+    strength: ResistanceStrength
+    computed_at: dt.datetime
+    ohlcv_through_date: dt.date
+
+    def __post_init__(self) -> None:
+        _require_kr_symbol(self.symbol)
+        if self.price <= 0:
+            raise ValueError("resistance price must be positive")
+        if not self.sources or any(not source.strip() for source in self.sources):
+            raise ValueError("resistance sources must be non-empty")
+        if not isinstance(self.strength, ResistanceStrength):
+            raise ValueError("resistance strength must be typed")
+        _require_aware(self.computed_at, "resistance computed_at")
+
+
+@dataclass(frozen=True, slots=True)
+class MarketEvidence:
+    quote: TypedQuoteEvidence
+    resistance: ResistanceEvidence | None
+
+
+class ConfiguredAccountRosterReadModel(Protocol):
+    identity: str
+    capability: str
+
+    async def read_configured_kr_accounts(self) -> AuthoritativeAccountRoster: ...
+
+
+class BrokerAccountEvidenceReadModel(Protocol):
+    identity: str
+    capability: str
+
+    async def read_accounts(
+        self,
+        *,
+        symbol: str,
+        expected_accounts: tuple[ConfiguredAccount, ...],
+    ) -> tuple[BrokerAccountEvidence, ...]: ...
+
+
+class ScopedOpenActionReadModel(Protocol):
+    identity: str
+    capability: str
+
+    async def read_open_actions(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        broker_account_id: str,
+    ) -> ScopedOpenActionsEvidence: ...
+
+
+class TypedMarketEvidenceReadModel(Protocol):
+    identity: str
+    capability: str
+
+    async def read_market_evidence(self, *, symbol: str) -> MarketEvidence: ...
+
+
+class ReplayClock(Protocol):
+    def now(self) -> dt.datetime: ...
+
+
+class ValidatedSingleShareExitContext(Protocol):
+    """Read-only interface implemented only by an identity-registered context."""
+
+    snapshot_id: str
+    market: str
+    captured_at: dt.datetime
+    produced_at: dt.datetime
+    mode: ContextMode
+    target: SingleShareExitTarget
+    roster_id: str
+    roster_version: str
+    roster_hash: str
+    derived_roster_hash: str
+    roster_read_model_identity: str
+    roster_read_model_capability: str
+    expected_account_identities: tuple[AccountIdentity, ...]
+    observed_account_identities: tuple[AccountIdentity, ...]
+    configured_accounts: tuple[ConfiguredAccount, ...]
+    accounts: tuple[BrokerAccountEvidence, ...]
+    quote: TypedQuoteEvidence
+    resistance: ResistanceEvidence | None
+    open_actions: ScopedOpenActionsEvidence
+    producer_identity: str
+    producer_capability: str
+    reader_identities: tuple[str, ...]
+    reader_capabilities: tuple[str, ...]
+
+    @property
+    def roster_is_exact(self) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _ContextState:
+    """Producer-collected data, never itself accepted by the evaluator."""
+
+    snapshot_id: str
+    market: str
+    captured_at: dt.datetime
+    produced_at: dt.datetime
+    mode: ContextMode
+    target: SingleShareExitTarget
+    roster_id: str
+    roster_version: str
+    roster_hash: str
+    derived_roster_hash: str
+    roster_read_model_identity: str
+    roster_read_model_capability: str
+    expected_account_identities: tuple[AccountIdentity, ...]
+    observed_account_identities: tuple[AccountIdentity, ...]
+    configured_accounts: tuple[ConfiguredAccount, ...]
+    accounts: tuple[BrokerAccountEvidence, ...]
+    quote: TypedQuoteEvidence
+    resistance: ResistanceEvidence | None
+    open_actions: ScopedOpenActionsEvidence
+    producer_identity: str
+    producer_capability: str
+    reader_identities: tuple[str, ...]
+    reader_capabilities: tuple[str, ...]
+
+
+class ProducerContextIntegrityError(RuntimeError):
+    """The object is not the exact context issued by its producer authority."""
+
+
+def compute_account_roster_hash(
+    *,
+    roster_id: str,
+    roster_version: str,
+    read_model_identity: str,
+    accounts: tuple[ConfiguredAccount, ...],
+) -> str:
+    ordered = sorted(
+        accounts,
+        key=lambda account: (
+            account.identity.broker.value,
+            account.identity.broker_account_id,
+        ),
+    )
+    payload = {
+        "roster_id": roster_id,
+        "roster_version": roster_version,
+        "read_model_identity": read_model_identity,
+        "accounts": [
+            {
+                "broker": account.identity.broker.value,
+                "broker_account_id": account.identity.broker_account_id,
+                "account_kind": account.account_kind.value,
+                "order_routable": account.order_routable,
+            }
+            for account in ordered
+        ],
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def executable_quote_price(quote: TypedQuoteEvidence) -> Decimal | None:
+    broker_sources = {QuoteSource.KIS_BROKER, QuoteSource.TOSS_BROKER}
+    if (
+        not quote.executable
+        or not quote.firm
+        or quote.source not in broker_sources
+        or quote.venue not in {QuoteVenue.KRX, QuoteVenue.NXT}
+    ):
+        return None
+    if quote.quote_kind is QuoteKind.BROKER_LAST_TRADE:
+        if (
+            quote.last_price is None
+            or quote.last_provenance is not QuoteProvenance.VENUE_LAST_TRADE
+        ):
+            return None
+        return quote.last_price
+    if quote.quote_kind is QuoteKind.LIVE_ORDERBOOK_MID:
+        if (
+            quote.bid_price is None
+            or quote.ask_price is None
+            or quote.bid_price > quote.ask_price
+            or quote.bid_provenance is not QuoteProvenance.VENUE_BEST_BID
+            or quote.ask_provenance is not QuoteProvenance.VENUE_BEST_ASK
+        ):
+            return None
+        return (quote.bid_price + quote.ask_price) / Decimal("2")
+    return None
+
+
+class _SystemClock:
+    def now(self) -> dt.datetime:
+        return dt.datetime.now(dt.UTC)
+
+
+class _Producer:
+    def __init__(
+        self,
+        *,
+        roster_reader: ConfiguredAccountRosterReadModel,
+        broker_reader: BrokerAccountEvidenceReadModel,
+        open_action_reader: ScopedOpenActionReadModel,
+        market_reader: TypedMarketEvidenceReadModel,
+    ) -> None:
+        self._roster_reader = roster_reader
+        self._broker_reader = broker_reader
+        self._open_action_reader = open_action_reader
+        self._market_reader = market_reader
+
+    async def _collect_state(
+        self,
+        *,
+        target: SingleShareExitTarget,
+        mode: ContextMode,
+        clock: ReplayClock,
+    ) -> _ContextState:
+        roster = await self._roster_reader.read_configured_kr_accounts()
+        accounts, open_actions, market = await asyncio.gather(
+            self._broker_reader.read_accounts(
+                symbol=target.symbol,
+                expected_accounts=roster.accounts,
+            ),
+            self._open_action_reader.read_open_actions(
+                symbol=target.symbol,
+                side="sell",
+                broker_account_id=target.broker_account_id,
+            ),
+            self._market_reader.read_market_evidence(symbol=target.symbol),
+        )
+        now = clock.now()
+        _require_aware(now, "producer clock")
+        captured_at = now.astimezone(dt.UTC)
+        expected = tuple(
+            sorted(
+                (account.identity for account in roster.accounts),
+                key=lambda identity: (
+                    identity.broker.value,
+                    identity.broker_account_id,
+                ),
+            )
+        )
+        observed = tuple(
+            sorted(
+                (account.identity for account in accounts),
+                key=lambda identity: (
+                    identity.broker.value,
+                    identity.broker_account_id,
+                ),
+            )
+        )
+        derived_hash = compute_account_roster_hash(
+            roster_id=roster.roster_id,
+            roster_version=roster.roster_version,
+            read_model_identity=roster.read_model_identity,
+            accounts=roster.accounts,
+        )
+        snapshot_seed = "|".join(
+            (
+                roster.roster_hash,
+                captured_at.isoformat(),
+                target.symbol,
+                target.broker.value,
+                target.broker_account_id,
+                target.lot_id,
+                mode.value,
+            )
+        )
+        snapshot_id = hashlib.sha256(snapshot_seed.encode()).hexdigest()[:24]
+        reader_identities = (
+            self._roster_reader.identity,
+            self._broker_reader.identity,
+            self._open_action_reader.identity,
+            self._market_reader.identity,
+        )
+        reader_capabilities = (
+            self._roster_reader.capability,
+            self._broker_reader.capability,
+            self._open_action_reader.capability,
+            self._market_reader.capability,
+        )
+        return _ContextState(
+            snapshot_id=snapshot_id,
+            market="kr",
+            captured_at=captured_at,
+            produced_at=captured_at,
+            mode=mode,
+            target=target,
+            roster_id=roster.roster_id,
+            roster_version=roster.roster_version,
+            roster_hash=roster.roster_hash,
+            derived_roster_hash=derived_hash,
+            roster_read_model_identity=roster.read_model_identity,
+            roster_read_model_capability=roster.read_model_capability,
+            expected_account_identities=expected,
+            observed_account_identities=observed,
+            configured_accounts=roster.accounts,
+            accounts=accounts,
+            quote=market.quote,
+            resistance=market.resistance,
+            open_actions=open_actions,
+            producer_identity=PRODUCER_IDENTITY,
+            producer_capability=PRODUCER_CAPABILITY,
+            reader_identities=reader_identities,
+            reader_capabilities=reader_capabilities,
+        )
+
+
+def _build_context_authority():
+    """Build the only issuance authority without exporting issuance material."""
+
+    issued_records: tuple[tuple[_Producer, object, _ContextState, bytes], ...] = ()
+    state_field_names = frozenset(
+        item.name for item in dataclasses.fields(_ContextState)
+    )
+
+    def canonical(value: object) -> object:
+        if dataclasses.is_dataclass(value):
+            return {
+                item.name: canonical(getattr(value, item.name))
+                for item in dataclasses.fields(value)
+            }
+        if isinstance(value, StrEnum):
+            return value.value
+        if isinstance(value, dt.datetime):
+            return value.astimezone(dt.UTC).isoformat()
+        if isinstance(value, dt.date):
+            return value.isoformat()
+        if isinstance(value, Decimal):
+            return str(value)
+        if isinstance(value, tuple):
+            return [canonical(item) for item in value]
+        return value
+
+    def state_snapshot(state: _ContextState) -> bytes:
+        return json.dumps(
+            canonical(state),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+
+    def registered_state(candidate: object) -> _ContextState:
+        for _issuer, issued_context, state, issued_snapshot in issued_records:
+            if candidate is issued_context:
+                if state_snapshot(state) != issued_snapshot:
+                    raise ProducerContextIntegrityError(
+                        "producer-issued context state changed after issuance"
+                    )
+                return state
+        raise ProducerContextIntegrityError(
+            "context was not issued by the producer authority"
+        )
+
+    def issue(
+        issuer: _Producer,
+        state: _ContextState,
+    ) -> ValidatedSingleShareExitContext:
+        nonlocal issued_records
+        constructor_capability = object()
+
+        class _IssuedContext:
+            __slots__ = ()
+
+            def __init__(self, capability: object) -> None:
+                if capability is not constructor_capability:
+                    raise ProducerContextIntegrityError(
+                        "context construction is producer-only"
+                    )
+
+            def __getattribute__(self, name: str) -> object:
+                current_state = registered_state(self)
+                if name in state_field_names:
+                    return getattr(current_state, name)
+                if name == "roster_is_exact":
+                    return (
+                        current_state.expected_account_identities
+                        == current_state.observed_account_identities
+                    )
+                return object.__getattribute__(self, name)
+
+            def __repr__(self) -> str:
+                current_state = registered_state(self)
+                return (
+                    "<ValidatedSingleShareExitContext "
+                    f"snapshot_id={current_state.snapshot_id!r}>"
+                )
+
+            def __eq__(self, other: object) -> bool:
+                registered_state(self)
+                return self is other
+
+            def __hash__(self) -> int:
+                registered_state(self)
+                return object.__hash__(self)
+
+            def __copy__(self):
+                registered_state(self)
+                raise TypeError("producer-issued contexts cannot be copied")
+
+            def __deepcopy__(self, _memo):
+                registered_state(self)
+                raise TypeError("producer-issued contexts cannot be deep-copied")
+
+            def __reduce__(self):
+                registered_state(self)
+                raise TypeError("producer-issued contexts cannot be pickled")
+
+            def __reduce_ex__(self, _protocol):
+                registered_state(self)
+                raise TypeError("producer-issued contexts cannot be pickled")
+
+            @classmethod
+            def __init_subclass__(cls, **_kwargs) -> None:
+                raise TypeError("producer-issued context types cannot be subclassed")
+
+        context = _IssuedContext(constructor_capability)
+        issued_records += ((issuer, context, state, state_snapshot(state)),)
+        return context
+
+    def validate(candidate: object) -> bool:
+        try:
+            registered_state(candidate)
+        except ProducerContextIntegrityError:
+            return False
+        return True
+
+    class SnapshotProducer(_Producer):
+        """Live producer. Its clock is internal and cannot be caller-supplied."""
+
+        async def produce(
+            self,
+            *,
+            target: SingleShareExitTarget,
+        ) -> ValidatedSingleShareExitContext:
+            state = await self._collect_state(
+                target=target,
+                mode=ContextMode.LIVE,
+                clock=_SystemClock(),
+            )
+            return issue(self, state)
+
+    class ReplayProducer(_Producer):
+        """Replay-only producer; its contexts can never be live-eligible."""
+
+        def __init__(
+            self,
+            *,
+            roster_reader: ConfiguredAccountRosterReadModel,
+            broker_reader: BrokerAccountEvidenceReadModel,
+            open_action_reader: ScopedOpenActionReadModel,
+            market_reader: TypedMarketEvidenceReadModel,
+            replay_clock: ReplayClock,
+        ) -> None:
+            super().__init__(
+                roster_reader=roster_reader,
+                broker_reader=broker_reader,
+                open_action_reader=open_action_reader,
+                market_reader=market_reader,
+            )
+            self._replay_clock = replay_clock
+
+        async def produce(
+            self,
+            *,
+            target: SingleShareExitTarget,
+        ) -> ValidatedSingleShareExitContext:
+            state = await self._collect_state(
+                target=target,
+                mode=ContextMode.REPLAY,
+                clock=self._replay_clock,
+            )
+            return issue(self, state)
+
+    return SnapshotProducer, ReplayProducer, validate
+
+
+(
+    SingleShareExitSnapshotProducer,
+    SingleShareExitReplayProducer,
+    is_validated_context,
+) = _build_context_authority()
+del _build_context_authority
+
+
+def required_reader_capabilities() -> tuple[str, ...]:
+    return _REQUIRED_READER_CAPABILITIES

--- a/app/services/single_share_exit_snapshot_service.py
+++ b/app/services/single_share_exit_snapshot_service.py
@@ -395,7 +395,7 @@ class _ValidatedSingleShareExitContextBase:
 
     @property
     def derived_roster_hash(self) -> str:
-        """Recompute the roster digest; never trust a second caller-carried hash."""
+        """Recompute the roster digest from configured accounts rather than relying on a secondary hash field."""
 
         return compute_account_roster_hash(
             roster_id=self.roster_id,
@@ -412,9 +412,10 @@ class _ValidatedSingleShareExitContextBase:
 class _ValidatedLiveSingleShareExitContext(_ValidatedSingleShareExitContextBase):
     """Private live context; mode is derived from this exact concrete type."""
 
-    # Different layouts prevent ``object.__setattr__(replay, "__class__", live)``
-    # from turning a replay object into a live object without storing a mutable
-    # or caller-copyable mode field.
+    # Standard copy, serialization, and subclassing paths do not promote a replay
+    # context into a live context. This layout distinction can be bypassed via matching
+    # slot layouts or reflection (equivalent to arbitrary in-process execution),
+    # so this layout distinction is an API structure boundary rather than a security boundary.
     __slots__ = ("_live_context_layout",)
 
     @property
@@ -626,7 +627,7 @@ class _Producer:
 
 
 class SingleShareExitSnapshotProducer(_Producer):
-    """Live producer. Its clock is internal and cannot be caller-supplied."""
+    """Live producer using an internal _SystemClock."""
 
     async def produce(
         self,

--- a/app/services/single_share_exit_snapshot_service.py
+++ b/app/services/single_share_exit_snapshot_service.py
@@ -1,19 +1,20 @@
-"""Authoritative, read-only evidence assembly for the KR single-share exit lane.
+"""Read-only evidence assembly for the KR single-share exit shadow lane.
 
-Raw account rows and caller-supplied completeness booleans are deliberately not
-an evaluator input.  A producer enumerates the configured account roster first,
-asks each read port for evidence over that exact roster, and issues a sealed
-context.  The trading-policy evaluator accepts only that context.
+Raw account rows and caller-supplied completeness booleans are not evaluator
+inputs. A producer enumerates the configured account roster, asks each read port
+for evidence over that roster, derives the roster hash, and returns a private
+concrete context type that the evaluator recognizes with ``isinstance``.
 
-The ports are read-only capability boundaries.  Live broker adapters are not
-constructed here; offline tests use fakes, and any future live composition must
-provide all four authoritative capabilities explicitly.
+This type check is an API boundary, not an evidence-authenticity or security
+boundary. Capability values are descriptive labels, and callers supply the read
+ports; future live composition must therefore pin trusted adapter provenance
+outside this module. In-process Python code must not treat this module as
+protection from forged or mutated evidence.
 """
 
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import datetime as dt
 import hashlib
 import json
@@ -330,7 +331,7 @@ class ReplayClock(Protocol):
 
 
 class ValidatedSingleShareExitContext(Protocol):
-    """Read-only interface implemented only by an identity-registered context."""
+    """Read-only interface returned by the producer API."""
 
     snapshot_id: str
     market: str
@@ -361,8 +362,8 @@ class ValidatedSingleShareExitContext(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
-class _ContextState:
-    """Producer-collected data, never itself accepted by the evaluator."""
+class _ValidatedSingleShareExitContext:
+    """Private concrete context produced after roster-first evidence reads."""
 
     snapshot_id: str
     market: str
@@ -388,9 +389,9 @@ class _ContextState:
     reader_identities: tuple[str, ...]
     reader_capabilities: tuple[str, ...]
 
-
-class ProducerContextIntegrityError(RuntimeError):
-    """The object is not the exact context issued by its producer authority."""
+    @property
+    def roster_is_exact(self) -> bool:
+        return self.expected_account_identities == self.observed_account_identities
 
 
 def compute_account_roster_hash(
@@ -480,7 +481,7 @@ class _Producer:
         target: SingleShareExitTarget,
         mode: ContextMode,
         clock: ReplayClock,
-    ) -> _ContextState:
+    ) -> _ValidatedSingleShareExitContext:
         roster = await self._roster_reader.read_configured_kr_accounts()
         accounts, open_actions, market = await asyncio.gather(
             self._broker_reader.read_accounts(
@@ -545,7 +546,7 @@ class _Producer:
             self._open_action_reader.capability,
             self._market_reader.capability,
         )
-        return _ContextState(
+        return _ValidatedSingleShareExitContext(
             snapshot_id=snapshot_id,
             market="kr",
             captured_at=captured_at,
@@ -572,180 +573,57 @@ class _Producer:
         )
 
 
-def _build_context_authority():
-    """Build the only issuance authority without exporting issuance material."""
+class SingleShareExitSnapshotProducer(_Producer):
+    """Live producer. Its clock is internal and cannot be caller-supplied."""
 
-    issued_records: tuple[tuple[_Producer, object, _ContextState, bytes], ...] = ()
-    state_field_names = frozenset(
-        item.name for item in dataclasses.fields(_ContextState)
-    )
-
-    def canonical(value: object) -> object:
-        if dataclasses.is_dataclass(value):
-            return {
-                item.name: canonical(getattr(value, item.name))
-                for item in dataclasses.fields(value)
-            }
-        if isinstance(value, StrEnum):
-            return value.value
-        if isinstance(value, dt.datetime):
-            return value.astimezone(dt.UTC).isoformat()
-        if isinstance(value, dt.date):
-            return value.isoformat()
-        if isinstance(value, Decimal):
-            return str(value)
-        if isinstance(value, tuple):
-            return [canonical(item) for item in value]
-        return value
-
-    def state_snapshot(state: _ContextState) -> bytes:
-        return json.dumps(
-            canonical(state),
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode()
-
-    def registered_state(candidate: object) -> _ContextState:
-        for _issuer, issued_context, state, issued_snapshot in issued_records:
-            if candidate is issued_context:
-                if state_snapshot(state) != issued_snapshot:
-                    raise ProducerContextIntegrityError(
-                        "producer-issued context state changed after issuance"
-                    )
-                return state
-        raise ProducerContextIntegrityError(
-            "context was not issued by the producer authority"
+    async def produce(
+        self,
+        *,
+        target: SingleShareExitTarget,
+    ) -> ValidatedSingleShareExitContext:
+        return await self._collect_state(
+            target=target,
+            mode=ContextMode.LIVE,
+            clock=_SystemClock(),
         )
 
-    def issue(
-        issuer: _Producer,
-        state: _ContextState,
+
+class SingleShareExitReplayProducer(_Producer):
+    """Replay-only producer; its contexts can never be live-eligible."""
+
+    def __init__(
+        self,
+        *,
+        roster_reader: ConfiguredAccountRosterReadModel,
+        broker_reader: BrokerAccountEvidenceReadModel,
+        open_action_reader: ScopedOpenActionReadModel,
+        market_reader: TypedMarketEvidenceReadModel,
+        replay_clock: ReplayClock,
+    ) -> None:
+        super().__init__(
+            roster_reader=roster_reader,
+            broker_reader=broker_reader,
+            open_action_reader=open_action_reader,
+            market_reader=market_reader,
+        )
+        self._replay_clock = replay_clock
+
+    async def produce(
+        self,
+        *,
+        target: SingleShareExitTarget,
     ) -> ValidatedSingleShareExitContext:
-        nonlocal issued_records
-        constructor_capability = object()
-
-        class _IssuedContext:
-            __slots__ = ()
-
-            def __init__(self, capability: object) -> None:
-                if capability is not constructor_capability:
-                    raise ProducerContextIntegrityError(
-                        "context construction is producer-only"
-                    )
-
-            def __getattribute__(self, name: str) -> object:
-                current_state = registered_state(self)
-                if name in state_field_names:
-                    return getattr(current_state, name)
-                if name == "roster_is_exact":
-                    return (
-                        current_state.expected_account_identities
-                        == current_state.observed_account_identities
-                    )
-                return object.__getattribute__(self, name)
-
-            def __repr__(self) -> str:
-                current_state = registered_state(self)
-                return (
-                    "<ValidatedSingleShareExitContext "
-                    f"snapshot_id={current_state.snapshot_id!r}>"
-                )
-
-            def __eq__(self, other: object) -> bool:
-                registered_state(self)
-                return self is other
-
-            def __hash__(self) -> int:
-                registered_state(self)
-                return object.__hash__(self)
-
-            def __copy__(self):
-                registered_state(self)
-                raise TypeError("producer-issued contexts cannot be copied")
-
-            def __deepcopy__(self, _memo):
-                registered_state(self)
-                raise TypeError("producer-issued contexts cannot be deep-copied")
-
-            def __reduce__(self):
-                registered_state(self)
-                raise TypeError("producer-issued contexts cannot be pickled")
-
-            def __reduce_ex__(self, _protocol):
-                registered_state(self)
-                raise TypeError("producer-issued contexts cannot be pickled")
-
-            @classmethod
-            def __init_subclass__(cls, **_kwargs) -> None:
-                raise TypeError("producer-issued context types cannot be subclassed")
-
-        context = _IssuedContext(constructor_capability)
-        issued_records += ((issuer, context, state, state_snapshot(state)),)
-        return context
-
-    def validate(candidate: object) -> bool:
-        try:
-            registered_state(candidate)
-        except ProducerContextIntegrityError:
-            return False
-        return True
-
-    class SnapshotProducer(_Producer):
-        """Live producer. Its clock is internal and cannot be caller-supplied."""
-
-        async def produce(
-            self,
-            *,
-            target: SingleShareExitTarget,
-        ) -> ValidatedSingleShareExitContext:
-            state = await self._collect_state(
-                target=target,
-                mode=ContextMode.LIVE,
-                clock=_SystemClock(),
-            )
-            return issue(self, state)
-
-    class ReplayProducer(_Producer):
-        """Replay-only producer; its contexts can never be live-eligible."""
-
-        def __init__(
-            self,
-            *,
-            roster_reader: ConfiguredAccountRosterReadModel,
-            broker_reader: BrokerAccountEvidenceReadModel,
-            open_action_reader: ScopedOpenActionReadModel,
-            market_reader: TypedMarketEvidenceReadModel,
-            replay_clock: ReplayClock,
-        ) -> None:
-            super().__init__(
-                roster_reader=roster_reader,
-                broker_reader=broker_reader,
-                open_action_reader=open_action_reader,
-                market_reader=market_reader,
-            )
-            self._replay_clock = replay_clock
-
-        async def produce(
-            self,
-            *,
-            target: SingleShareExitTarget,
-        ) -> ValidatedSingleShareExitContext:
-            state = await self._collect_state(
-                target=target,
-                mode=ContextMode.REPLAY,
-                clock=self._replay_clock,
-            )
-            return issue(self, state)
-
-    return SnapshotProducer, ReplayProducer, validate
+        return await self._collect_state(
+            target=target,
+            mode=ContextMode.REPLAY,
+            clock=self._replay_clock,
+        )
 
 
-(
-    SingleShareExitSnapshotProducer,
-    SingleShareExitReplayProducer,
-    is_validated_context,
-) = _build_context_authority()
-del _build_context_authority
+def is_validated_context(candidate: object) -> bool:
+    """Return whether the producer API's private concrete type was supplied."""
+
+    return isinstance(candidate, _ValidatedSingleShareExitContext)
 
 
 def required_reader_capabilities() -> tuple[str, ...]:

--- a/app/services/single_share_exit_snapshot_service.py
+++ b/app/services/single_share_exit_snapshot_service.py
@@ -3,7 +3,8 @@
 Raw account rows and caller-supplied completeness booleans are not evaluator
 inputs. A producer enumerates the configured account roster, asks each read port
 for evidence over that roster, derives the roster hash, and returns a private
-concrete context type that the evaluator recognizes with ``isinstance``.
+live or replay concrete context type that the matching evaluator recognizes by
+exact type.
 
 This type check is an API boundary, not an evidence-authenticity or security
 boundary. Capability values are descriptive labels, and callers supply the read
@@ -17,10 +18,11 @@ from __future__ import annotations
 import asyncio
 import datetime as dt
 import hashlib
-import json
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from decimal import Decimal
 from enum import StrEnum
+from json.encoder import encode_basestring_ascii
+from operator import attrgetter
 from typing import Protocol
 
 PRODUCER_IDENTITY = "kr_single_share_exit_snapshot_producer/v2"
@@ -337,12 +339,10 @@ class ValidatedSingleShareExitContext(Protocol):
     market: str
     captured_at: dt.datetime
     produced_at: dt.datetime
-    mode: ContextMode
     target: SingleShareExitTarget
     roster_id: str
     roster_version: str
     roster_hash: str
-    derived_roster_hash: str
     roster_read_model_identity: str
     roster_read_model_capability: str
     expected_account_identities: tuple[AccountIdentity, ...]
@@ -356,25 +356,29 @@ class ValidatedSingleShareExitContext(Protocol):
     producer_capability: str
     reader_identities: tuple[str, ...]
     reader_capabilities: tuple[str, ...]
+
+    @property
+    def mode(self) -> ContextMode: ...
+
+    @property
+    def derived_roster_hash(self) -> str: ...
 
     @property
     def roster_is_exact(self) -> bool: ...
 
 
 @dataclass(frozen=True, slots=True)
-class _ValidatedSingleShareExitContext:
-    """Private concrete context produced after roster-first evidence reads."""
+class _ValidatedSingleShareExitContextBase:
+    """Shared immutable payload for the two private evaluator context types."""
 
     snapshot_id: str
     market: str
     captured_at: dt.datetime
     produced_at: dt.datetime
-    mode: ContextMode
     target: SingleShareExitTarget
     roster_id: str
     roster_version: str
     roster_hash: str
-    derived_roster_hash: str
     roster_read_model_identity: str
     roster_read_model_capability: str
     expected_account_identities: tuple[AccountIdentity, ...]
@@ -390,8 +394,48 @@ class _ValidatedSingleShareExitContext:
     reader_capabilities: tuple[str, ...]
 
     @property
+    def derived_roster_hash(self) -> str:
+        """Recompute the roster digest; never trust a second caller-carried hash."""
+
+        return compute_account_roster_hash(
+            roster_id=self.roster_id,
+            roster_version=self.roster_version,
+            read_model_identity=self.roster_read_model_identity,
+            accounts=self.configured_accounts,
+        )
+
+    @property
     def roster_is_exact(self) -> bool:
         return self.expected_account_identities == self.observed_account_identities
+
+
+class _ValidatedLiveSingleShareExitContext(_ValidatedSingleShareExitContextBase):
+    """Private live context; mode is derived from this exact concrete type."""
+
+    # Different layouts prevent ``object.__setattr__(replay, "__class__", live)``
+    # from turning a replay object into a live object without storing a mutable
+    # or caller-copyable mode field.
+    __slots__ = ("_live_context_layout",)
+
+    @property
+    def mode(self) -> ContextMode:
+        return ContextMode.LIVE
+
+
+class _ValidatedReplaySingleShareExitContext(_ValidatedSingleShareExitContextBase):
+    """Private replay context; mode is derived from this exact concrete type."""
+
+    __slots__ = ("_replay_context_layout_a", "_replay_context_layout_b")
+
+    @property
+    def mode(self) -> ContextMode:
+        return ContextMode.REPLAY
+
+
+_CONTEXT_FIELD_NAMES = tuple(
+    field.name for field in fields(_ValidatedSingleShareExitContextBase)
+)
+_CONTEXT_FIELDS_GETTER = attrgetter(*_CONTEXT_FIELD_NAMES)
 
 
 def compute_account_roster_hash(
@@ -408,23 +452,31 @@ def compute_account_roster_hash(
             account.identity.broker_account_id,
         ),
     )
-    payload = {
-        "roster_id": roster_id,
-        "roster_version": roster_version,
-        "read_model_identity": read_model_identity,
-        "accounts": [
-            {
-                "broker": account.identity.broker.value,
-                "broker_account_id": account.identity.broker_account_id,
-                "account_kind": account.account_kind.value,
-                "order_routable": account.order_routable,
-            }
-            for account in ordered
-        ],
-    }
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    ).hexdigest()
+    # Preserve the byte-for-byte canonical JSON contract without rebuilding and
+    # sorting a nested dict on every evaluation. ``encode_basestring_ascii`` is
+    # the string encoder used by the stdlib JSON encoder, so quotes, control
+    # characters, and non-ASCII account IDs retain the prior representation.
+    encoded_accounts = ",".join(
+        (
+            '{"account_kind":'
+            f"{encode_basestring_ascii(account.account_kind.value)},"
+            '"broker":'
+            f"{encode_basestring_ascii(account.identity.broker.value)},"
+            '"broker_account_id":'
+            f"{encode_basestring_ascii(account.identity.broker_account_id)},"
+            '"order_routable":'
+            f"{'true' if account.order_routable else 'false'}"
+            "}"
+        )
+        for account in ordered
+    )
+    payload = (
+        f'{{"accounts":[{encoded_accounts}],"read_model_identity":'
+        f"{encode_basestring_ascii(read_model_identity)},"
+        f'"roster_id":{encode_basestring_ascii(roster_id)},'
+        f'"roster_version":{encode_basestring_ascii(roster_version)}}}'
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def executable_quote_price(quote: TypedQuoteEvidence) -> Decimal | None:
@@ -481,7 +533,8 @@ class _Producer:
         target: SingleShareExitTarget,
         mode: ContextMode,
         clock: ReplayClock,
-    ) -> _ValidatedSingleShareExitContext:
+        context_type: type[_ValidatedSingleShareExitContextBase],
+    ) -> _ValidatedSingleShareExitContextBase:
         roster = await self._roster_reader.read_configured_kr_accounts()
         accounts, open_actions, market = await asyncio.gather(
             self._broker_reader.read_accounts(
@@ -531,6 +584,7 @@ class _Producer:
                 target.broker_account_id,
                 target.lot_id,
                 mode.value,
+                derived_hash,
             )
         )
         snapshot_id = hashlib.sha256(snapshot_seed.encode()).hexdigest()[:24]
@@ -546,17 +600,15 @@ class _Producer:
             self._open_action_reader.capability,
             self._market_reader.capability,
         )
-        return _ValidatedSingleShareExitContext(
+        return context_type(
             snapshot_id=snapshot_id,
             market="kr",
             captured_at=captured_at,
             produced_at=captured_at,
-            mode=mode,
             target=target,
             roster_id=roster.roster_id,
             roster_version=roster.roster_version,
             roster_hash=roster.roster_hash,
-            derived_roster_hash=derived_hash,
             roster_read_model_identity=roster.read_model_identity,
             roster_read_model_capability=roster.read_model_capability,
             expected_account_identities=expected,
@@ -585,11 +637,12 @@ class SingleShareExitSnapshotProducer(_Producer):
             target=target,
             mode=ContextMode.LIVE,
             clock=_SystemClock(),
+            context_type=_ValidatedLiveSingleShareExitContext,
         )
 
 
 class SingleShareExitReplayProducer(_Producer):
-    """Replay-only producer; its contexts can never be live-eligible."""
+    """Replay producer whose exact context type is rejected by the live wrapper."""
 
     def __init__(
         self,
@@ -617,13 +670,45 @@ class SingleShareExitReplayProducer(_Producer):
             target=target,
             mode=ContextMode.REPLAY,
             clock=self._replay_clock,
+            context_type=_ValidatedReplaySingleShareExitContext,
         )
 
 
-def is_validated_context(candidate: object) -> bool:
-    """Return whether the producer API's private concrete type was supplied."""
+def _is_initialized_exact_context(
+    candidate: object,
+    expected_type: type[_ValidatedSingleShareExitContextBase],
+) -> bool:
+    if type(candidate) is not expected_type:
+        return False
+    try:
+        _CONTEXT_FIELDS_GETTER(candidate)
+    except AttributeError:
+        return False
+    return True
 
-    return isinstance(candidate, _ValidatedSingleShareExitContext)
+
+def is_validated_live_context(candidate: object) -> bool:
+    """Return whether an initialized exact live context was supplied."""
+
+    return _is_initialized_exact_context(
+        candidate, _ValidatedLiveSingleShareExitContext
+    )
+
+
+def is_validated_replay_context(candidate: object) -> bool:
+    """Return whether an initialized exact replay context was supplied."""
+
+    return _is_initialized_exact_context(
+        candidate, _ValidatedReplaySingleShareExitContext
+    )
+
+
+def is_validated_context(candidate: object) -> bool:
+    """Return whether either initialized exact producer context was supplied."""
+
+    return is_validated_live_context(candidate) or is_validated_replay_context(
+        candidate
+    )
 
 
 def required_reader_capabilities() -> tuple[str, ...]:

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -4,12 +4,17 @@ of trading judgment thresholds (ROB-646). Read-only; operator edits via PR."""
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 
-from app.schemas.trading_policy import TradingPolicyDocument
+from app.schemas.trading_policy import (
+    SingleShareExitDecisionRule,
+    TradingPolicyDocument,
+)
 
 _POLICY_PATH: Path = (
     Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
@@ -20,6 +25,19 @@ _cache: dict[str, Any] = {"key": None, "doc": None, "hash": None}
 
 class TradingPolicyKeyError(ValueError):
     """Unknown market or lane requested from the trading policy."""
+
+
+@dataclass(frozen=True, slots=True)
+class SingleShareExitEvaluation:
+    """Pure policy result; it neither persists nor dispatches a proposal."""
+
+    outcome: Literal["PROPOSE", "DEFER", "INELIGIBLE"]
+    reason: str
+    action: Literal["propose_full_exit"] | None = None
+    sizing: Literal["full_position"] | None = None
+    approval: Literal["telegram_manual"] | None = None
+    auto_approve: bool = False
+    execution: Literal["proposal_only"] | None = None
 
 
 def _reset_cache_for_tests() -> None:
@@ -131,6 +149,75 @@ def sector_cluster_for(label: str | None) -> str | None:
             if m and m in needle:
                 return cluster
     return None
+
+
+def evaluate_single_share_exit(
+    *,
+    market: str,
+    broker: str,
+    quantity: int,
+    order_routable: bool,
+    average_cost: int | float,
+    proposed_sell_price: int | float,
+    profit_pct: int | float,
+    resistance_near_pct: int | float | None,
+    unresolved_open_actions: int,
+) -> SingleShareExitEvaluation:
+    """Evaluate the additive one-share full-exit *proposal* path.
+
+    Scope and quantity are checked before the unresolved-action DEFER gate so
+    unrelated positions do not get classified by a rule that does not apply to
+    them. No broker, database, scheduler, or order-proposal mutation occurs.
+    """
+
+    doc = load_trading_policy()
+    rule = doc.decision_rules.get("sell.single_share_exit")
+    if not isinstance(rule, SingleShareExitDecisionRule):
+        return SingleShareExitEvaluation("INELIGIBLE", "policy_rule_unavailable")
+
+    if market not in rule.scope.markets:
+        return SingleShareExitEvaluation("INELIGIBLE", "market_out_of_scope")
+    if broker not in rule.scope.brokers:
+        return SingleShareExitEvaluation("INELIGIBLE", "broker_out_of_scope")
+    if rule.scope.order_routable_required and not order_routable:
+        return SingleShareExitEvaluation("INELIGIBLE", "order_routable_false")
+    if quantity != rule.conditions.quantity_eq:
+        return SingleShareExitEvaluation("INELIGIBLE", "not_single_share_position")
+    if unresolved_open_actions > rule.conditions.unresolved_open_actions_max:
+        return SingleShareExitEvaluation("DEFER", "unresolved_open_action")
+    if rule.conditions.resistance_reference_required and resistance_near_pct is None:
+        return SingleShareExitEvaluation("INELIGIBLE", "no_resistance_reference")
+    if resistance_near_pct is None or not (
+        0 <= resistance_near_pct <= rule.conditions.resistance_near_pct_max
+    ):
+        return SingleShareExitEvaluation("INELIGIBLE", "resistance_not_ultra_near")
+    if profit_pct < rule.conditions.profit_pct_min:
+        return SingleShareExitEvaluation(
+            "INELIGIBLE", "profit_below_provisional_minimum"
+        )
+
+    guard_spec = doc.thresholds.get(rule.conditions.min_sell_price_multiple_policy_key)
+    try:
+        avg = Decimal(str(average_cost))
+        sell_price = Decimal(str(proposed_sell_price))
+        guard_multiple = Decimal(str(guard_spec.value)) if guard_spec else Decimal(0)
+    except (InvalidOperation, ValueError):
+        return SingleShareExitEvaluation("INELIGIBLE", "invalid_price_evidence")
+    if avg <= 0 or sell_price <= 0 or guard_multiple <= 0:
+        return SingleShareExitEvaluation("INELIGIBLE", "invalid_price_evidence")
+    if sell_price < avg * guard_multiple:
+        return SingleShareExitEvaluation("INELIGIBLE", "loss_guard_not_met")
+
+    proposal = rule.proposal
+    return SingleShareExitEvaluation(
+        outcome="PROPOSE",
+        reason="single_share_profit_exit_eligible",
+        action=proposal.action,
+        sizing=proposal.sizing,
+        approval=proposal.approval,
+        auto_approve=proposal.auto_approve,
+        execution=proposal.execution,
+    )
 
 
 _LOSS_CUT_MAX_SLIP_KEY = "sell.loss_cut_max_slip"

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -3,6 +3,7 @@ of trading judgment thresholds (ROB-646). Read-only; operator edits via PR."""
 
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
@@ -13,6 +14,7 @@ import yaml
 
 from app.schemas.trading_policy import (
     SingleShareExitDecisionRule,
+    SingleShareExitEvidenceSnapshot,
     TradingPolicyDocument,
 )
 
@@ -29,15 +31,37 @@ class TradingPolicyKeyError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class SingleShareExitEvaluation:
-    """Pure policy result; it neither persists nor dispatches a proposal."""
+    """Pure shadow-policy result; it neither persists nor proposes an order."""
 
-    outcome: Literal["PROPOSE", "DEFER", "INELIGIBLE"]
+    outcome: Literal["SHADOW_ELIGIBLE", "DEFER", "INELIGIBLE"]
     reason: str
-    action: Literal["propose_full_exit"] | None = None
-    sizing: Literal["full_position"] | None = None
+    snapshot_id: str
+    symbol: str
+    broker: Literal["kis", "toss"]
+    broker_account_id: str
+    lot_id: str
+    activation_state: Literal["shadow"] = "shadow"
+    proposal_enabled: Literal[False] = False
+    candidate_action: Literal["propose_full_account_lot_exit"] | None = None
+    sizing: Literal["full_account_lot_exit"] | None = None
     approval: Literal["telegram_manual"] | None = None
-    auto_approve: bool = False
+    auto_approve: Literal[False] = False
     execution: Literal["proposal_only"] | None = None
+    average_cost: Decimal | None = None
+    symbol_routable_sellable_quantity: Decimal | None = None
+    current_quote: Decimal | None = None
+    quote_source: str | None = None
+    quote_age_seconds: Decimal | None = None
+    resistance_price: Decimal | None = None
+    profit_pct: Decimal | None = None
+    resistance_distance_pct: Decimal | None = None
+    normalized_source_families: tuple[str, ...] = ()
+    resistance_sources: tuple[str, ...] = ()
+    resistance_strength: str | None = None
+    quote_observed_at: dt.datetime | None = None
+    resistance_computed_at: dt.datetime | None = None
+    ohlcv_through_date: dt.date | None = None
+    expected_completed_krx_bar_date: dt.date | None = None
 
 
 def _reset_cache_for_tests() -> None:
@@ -151,72 +175,405 @@ def sector_cluster_for(label: str | None) -> str | None:
     return None
 
 
-def evaluate_single_share_exit(
+def _single_share_result(
+    evidence: SingleShareExitEvidenceSnapshot,
     *,
-    market: str,
-    broker: str,
-    quantity: int,
-    order_routable: bool,
-    average_cost: int | float,
-    proposed_sell_price: int | float,
-    profit_pct: int | float,
-    resistance_near_pct: int | float | None,
-    unresolved_open_actions: int,
+    outcome: Literal["SHADOW_ELIGIBLE", "DEFER", "INELIGIBLE"],
+    reason: str,
+    rule: SingleShareExitDecisionRule | None = None,
+    average_cost: Decimal | None = None,
+    profit_pct: Decimal | None = None,
+    resistance_distance_pct: Decimal | None = None,
+    normalized_source_families: tuple[str, ...] = (),
+    expected_completed_krx_bar_date: dt.date | None = None,
+    symbol_routable_sellable_quantity: Decimal | None = None,
+    quote_age_seconds: Decimal | None = None,
 ) -> SingleShareExitEvaluation:
-    """Evaluate the additive one-share full-exit *proposal* path.
+    proposal = rule.proposal if outcome == "SHADOW_ELIGIBLE" and rule else None
+    return SingleShareExitEvaluation(
+        outcome=outcome,
+        reason=reason,
+        snapshot_id=evidence.snapshot_id,
+        symbol=evidence.target.symbol,
+        broker=evidence.target.broker,
+        broker_account_id=evidence.target.broker_account_id,
+        lot_id=evidence.target.lot_id,
+        candidate_action=proposal.action if proposal else None,
+        sizing=proposal.sizing if proposal else None,
+        approval=proposal.approval if proposal else None,
+        auto_approve=proposal.auto_approve if proposal else False,
+        execution=proposal.execution if proposal else None,
+        average_cost=average_cost,
+        symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
+        current_quote=evidence.quote.price,
+        quote_source=evidence.quote.source,
+        quote_age_seconds=quote_age_seconds,
+        resistance_price=evidence.resistance.price,
+        profit_pct=profit_pct,
+        resistance_distance_pct=resistance_distance_pct,
+        normalized_source_families=normalized_source_families,
+        resistance_sources=tuple(evidence.resistance.sources),
+        resistance_strength=evidence.resistance.strength,
+        quote_observed_at=evidence.quote.observed_at,
+        resistance_computed_at=evidence.resistance.computed_at,
+        ohlcv_through_date=evidence.resistance.ohlcv_through_date,
+        expected_completed_krx_bar_date=expected_completed_krx_bar_date,
+    )
 
-    Scope and quantity are checked before the unresolved-action DEFER gate so
-    unrelated positions do not get classified by a rule that does not apply to
-    them. No broker, database, scheduler, or order-proposal mutation occurs.
+
+def _as_aware_utc(value: dt.datetime) -> dt.datetime | None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        return None
+    return value.astimezone(dt.UTC)
+
+
+def _normalized_resistance_families(
+    sources: list[str], rule: SingleShareExitDecisionRule
+) -> tuple[str, ...]:
+    normalization = rule.conditions.resistance_source_families
+    volume_exact = {source.casefold() for source in normalization.volume_profile_exact}
+    fib_prefixes = tuple(
+        prefix.casefold() for prefix in normalization.fibonacci_prefixes
+    )
+    bollinger_prefixes = tuple(
+        prefix.casefold() for prefix in normalization.bollinger_prefixes
+    )
+    families: set[str] = set()
+    for raw_source in sources:
+        source = raw_source.strip().casefold()
+        if source in volume_exact:
+            families.add("VOLUME_PROFILE")
+        elif source.startswith(fib_prefixes):
+            families.add("FIBONACCI")
+        elif source.startswith(bollinger_prefixes):
+            families.add("BOLLINGER")
+    return tuple(sorted(families))
+
+
+def _expected_completed_krx_bar(now: dt.datetime) -> dt.date | None:
+    """Resolve the authoritative finalized KRX session without import side effects."""
+    from app.services.daily_candles.read_service import last_final_session_kr
+
+    return last_final_session_kr(now)
+
+
+def evaluate_single_share_exit(
+    evidence: SingleShareExitEvidenceSnapshot,
+    *,
+    evaluated_at: dt.datetime | None = None,
+) -> SingleShareExitEvaluation:
+    """Evaluate one bounded evidence snapshot in shadow mode only.
+
+    Profit and resistance distance are recomputed from Decimal prices in the
+    snapshot. KIS/Toss inventory and open-order evidence are caller-supplied
+    read models, but completeness, identity, scope, timestamps, and aggregate
+    quantities are checked here. This function has no broker, DB, scheduler,
+    Telegram, proposal, or order side effects.
     """
 
     doc = load_trading_policy()
     rule = doc.decision_rules.get("sell.single_share_exit")
     if not isinstance(rule, SingleShareExitDecisionRule):
-        return SingleShareExitEvaluation("INELIGIBLE", "policy_rule_unavailable")
-
-    if market not in rule.scope.markets:
-        return SingleShareExitEvaluation("INELIGIBLE", "market_out_of_scope")
-    if broker not in rule.scope.brokers:
-        return SingleShareExitEvaluation("INELIGIBLE", "broker_out_of_scope")
-    if rule.scope.order_routable_required and not order_routable:
-        return SingleShareExitEvaluation("INELIGIBLE", "order_routable_false")
-    if quantity != rule.conditions.quantity_eq:
-        return SingleShareExitEvaluation("INELIGIBLE", "not_single_share_position")
-    if unresolved_open_actions > rule.conditions.unresolved_open_actions_max:
-        return SingleShareExitEvaluation("DEFER", "unresolved_open_action")
-    if rule.conditions.resistance_reference_required and resistance_near_pct is None:
-        return SingleShareExitEvaluation("INELIGIBLE", "no_resistance_reference")
-    if resistance_near_pct is None or not (
-        0 <= resistance_near_pct <= rule.conditions.resistance_near_pct_max
-    ):
-        return SingleShareExitEvaluation("INELIGIBLE", "resistance_not_ultra_near")
-    if profit_pct < rule.conditions.profit_pct_min:
-        return SingleShareExitEvaluation(
-            "INELIGIBLE", "profit_below_provisional_minimum"
+        return _single_share_result(
+            evidence, outcome="INELIGIBLE", reason="policy_rule_unavailable"
+        )
+    if rule.activation_state != "shadow" or rule.proposal_enabled:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="policy_not_shadow_off",
+            rule=rule,
+        )
+    if evidence.market not in rule.scope.markets:
+        return _single_share_result(
+            evidence, outcome="INELIGIBLE", reason="market_out_of_scope", rule=rule
+        )
+    if evidence.target.broker not in rule.scope.brokers:
+        return _single_share_result(
+            evidence, outcome="INELIGIBLE", reason="broker_out_of_scope", rule=rule
         )
 
+    now = _as_aware_utc(evaluated_at or dt.datetime.now(dt.UTC))
+    captured_at = _as_aware_utc(evidence.captured_at)
+    if now is None or captured_at is None:
+        return _single_share_result(
+            evidence, outcome="INELIGIBLE", reason="naive_evidence_timestamp", rule=rule
+        )
+
+    nested_snapshot_ids = {
+        evidence.quote.snapshot_id,
+        evidence.resistance.snapshot_id,
+        evidence.open_actions_snapshot_id,
+        *(account.snapshot_id for account in evidence.accounts),
+    }
+    if nested_snapshot_ids != {evidence.snapshot_id}:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="inconsistent_snapshot_id",
+            rule=rule,
+        )
+    if (
+        evidence.quote.symbol != evidence.target.symbol
+        or evidence.resistance.symbol != evidence.target.symbol
+    ):
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="inconsistent_snapshot_symbol",
+            rule=rule,
+        )
+
+    required_brokers = set(rule.scope.required_broker_inventory)
+    observed_brokers = {account.broker for account in evidence.accounts}
+    if not required_brokers.issubset(observed_brokers):
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="incomplete_kis_toss_inventory",
+            rule=rule,
+        )
+    account_identities = [
+        (account.broker, account.broker_account_id) for account in evidence.accounts
+    ]
+    if len(set(account_identities)) != len(account_identities):
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="duplicate_broker_account_snapshot",
+            rule=rule,
+        )
+
+    timestamp_values = [
+        evidence.quote.observed_at,
+        evidence.resistance.computed_at,
+        evidence.open_actions_checked_at,
+        *(
+            timestamp
+            for account in evidence.accounts
+            for timestamp in (account.observed_at, account.open_orders_checked_at)
+        ),
+    ]
+    timestamp_values_utc = [_as_aware_utc(value) for value in timestamp_values]
+    if any(value is None for value in timestamp_values_utc):
+        return _single_share_result(
+            evidence, outcome="INELIGIBLE", reason="naive_evidence_timestamp", rule=rule
+        )
+    max_skew = dt.timedelta(seconds=rule.conditions.snapshot_max_skew_seconds)
+    if captured_at > now or any(
+        value is None or value > now or abs(value - captured_at) > max_skew
+        for value in timestamp_values_utc
+    ):
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="stale_or_inconsistent_evidence",
+            rule=rule,
+        )
+    quote_observed_at = _as_aware_utc(evidence.quote.observed_at)
+    quote_age_seconds = (
+        Decimal(str((now - quote_observed_at).total_seconds()))
+        if quote_observed_at is not None
+        else None
+    )
+    if quote_observed_at is None or now - quote_observed_at > dt.timedelta(
+        seconds=rule.conditions.quote_max_age_seconds
+    ):
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="stale_quote",
+            rule=rule,
+            quote_age_seconds=quote_age_seconds,
+        )
+
+    expected_bar_date = _expected_completed_krx_bar(now)
+    if expected_bar_date is None:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="expected_completed_krx_bar_unavailable",
+            rule=rule,
+        )
+    if evidence.resistance.ohlcv_through_date != expected_bar_date:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="ohlcv_not_through_expected_completed_krx_bar",
+            rule=rule,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
+
+    target_matches = [
+        lot
+        for account in evidence.accounts
+        if account.broker == evidence.target.broker
+        and account.broker_account_id == evidence.target.broker_account_id
+        for lot in account.lots
+        if lot.symbol == evidence.target.symbol and lot.lot_id == evidence.target.lot_id
+    ]
+    if len(target_matches) != 1:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="target_lot_identity_not_unique",
+            rule=rule,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
+    target_lot = target_matches[0]
+    required_quantity = Decimal(rule.conditions.symbol_routable_sellable_quantity_eq)
+    target_is_routable = (
+        not rule.scope.order_routable_required or target_lot.order_routable
+    )
+    target_is_single_sellable = target_lot.sellable_quantity == required_quantity
+    if not target_is_routable or not target_is_single_sellable:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="target_account_lot_not_single_routable_sellable",
+            rule=rule,
+            average_cost=target_lot.average_cost,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
+    symbol_routable_sellable_quantity = sum(
+        (
+            lot.sellable_quantity
+            for account in evidence.accounts
+            for lot in account.lots
+            if lot.symbol == evidence.target.symbol and lot.order_routable
+        ),
+        start=Decimal(0),
+    )
+    if symbol_routable_sellable_quantity != required_quantity:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="symbol_routable_sellable_quantity_not_one",
+            rule=rule,
+            average_cost=target_lot.average_cost,
+            symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
+            quote_age_seconds=quote_age_seconds,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
+
+    same_symbol_open_orders = [
+        order
+        for account in evidence.accounts
+        for order in account.open_orders
+        if order.symbol == evidence.target.symbol
+    ]
+    if len(same_symbol_open_orders) > rule.conditions.same_symbol_open_orders_max:
+        return _single_share_result(
+            evidence,
+            outcome="DEFER",
+            reason="same_symbol_broker_open_order",
+            rule=rule,
+            average_cost=target_lot.average_cost,
+            symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
+            quote_age_seconds=quote_age_seconds,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
+
+    scoped_open_actions = [
+        action
+        for action in evidence.open_actions
+        if action.symbol == evidence.target.symbol
+        and action.side == "sell"
+        and action.broker_account_id == evidence.target.broker_account_id
+    ]
+    if len(scoped_open_actions) > rule.conditions.unresolved_open_actions_max:
+        return _single_share_result(
+            evidence,
+            outcome="DEFER",
+            reason="unresolved_scoped_open_action",
+            rule=rule,
+            average_cost=target_lot.average_cost,
+            symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
+            quote_age_seconds=quote_age_seconds,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
+
+    average_cost = target_lot.average_cost
+    quote = evidence.quote.price
+    resistance = evidence.resistance.price
     guard_spec = doc.thresholds.get(rule.conditions.min_sell_price_multiple_policy_key)
     try:
-        avg = Decimal(str(average_cost))
-        sell_price = Decimal(str(proposed_sell_price))
         guard_multiple = Decimal(str(guard_spec.value)) if guard_spec else Decimal(0)
     except (InvalidOperation, ValueError):
-        return SingleShareExitEvaluation("INELIGIBLE", "invalid_price_evidence")
-    if avg <= 0 or sell_price <= 0 or guard_multiple <= 0:
-        return SingleShareExitEvaluation("INELIGIBLE", "invalid_price_evidence")
-    if sell_price < avg * guard_multiple:
-        return SingleShareExitEvaluation("INELIGIBLE", "loss_guard_not_met")
+        guard_multiple = Decimal(0)
+    if guard_multiple <= 0:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="invalid_loss_guard_policy",
+            rule=rule,
+            average_cost=average_cost,
+            symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
+            quote_age_seconds=quote_age_seconds,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
+    if quote < average_cost * guard_multiple:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="loss_guard_not_met",
+            rule=rule,
+            average_cost=average_cost,
+            symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
+            quote_age_seconds=quote_age_seconds,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
 
-    proposal = rule.proposal
-    return SingleShareExitEvaluation(
-        outcome="PROPOSE",
-        reason="single_share_profit_exit_eligible",
-        action=proposal.action,
-        sizing=proposal.sizing,
-        approval=proposal.approval,
-        auto_approve=proposal.auto_approve,
-        execution=proposal.execution,
+    hundred = Decimal(100)
+    raw_profit_pct = (quote - average_cost) / average_cost * hundred
+    raw_resistance_distance_pct = (resistance - quote) / quote * hundred
+    profit_pct = raw_profit_pct.quantize(Decimal("0.0001"))
+    resistance_distance_pct = raw_resistance_distance_pct.quantize(Decimal("0.0001"))
+    normalized_families = _normalized_resistance_families(
+        evidence.resistance.sources, rule
+    )
+    result_kwargs: dict[str, Any] = {
+        "rule": rule,
+        "average_cost": average_cost,
+        "profit_pct": profit_pct,
+        "resistance_distance_pct": resistance_distance_pct,
+        "normalized_source_families": normalized_families,
+        "symbol_routable_sellable_quantity": symbol_routable_sellable_quantity,
+        "quote_age_seconds": quote_age_seconds,
+        "expected_completed_krx_bar_date": expected_bar_date,
+    }
+    if raw_profit_pct < Decimal(str(rule.conditions.profit_pct_min)):
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="profit_below_provisional_minimum",
+            **result_kwargs,
+        )
+    if not (
+        raw_resistance_distance_pct
+        > Decimal(str(rule.conditions.resistance_distance_pct_min_exclusive))
+        and raw_resistance_distance_pct
+        <= Decimal(str(rule.conditions.resistance_distance_pct_max))
+    ):
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="resistance_outside_far_band",
+            **result_kwargs,
+        )
+    if len(normalized_families) < rule.conditions.resistance_source_family_min:
+        return _single_share_result(
+            evidence,
+            outcome="INELIGIBLE",
+            reason="insufficient_independent_resistance_families",
+            **result_kwargs,
+        )
+
+    return _single_share_result(
+        evidence,
+        outcome="SHADOW_ELIGIBLE",
+        reason="proposal_disabled_shadow_candidate",
+        **result_kwargs,
     )
 
 

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -21,6 +21,7 @@ from app.services.single_share_exit_snapshot_service import (
     PRODUCER_IDENTITY,
     ROSTER_CAPABILITY,
     ContextMode,
+    ResistanceStrength,
     ValidatedSingleShareExitContext,
     executable_quote_price,
     is_validated_context,
@@ -51,7 +52,7 @@ class SingleShareExitEvaluation:
     lot_id: str
     activation_state: Literal["shadow"] = "shadow"
     proposal_enabled: Literal[False] = False
-    candidate_action: Literal["propose_full_account_lot_exit"] | None = None
+    candidate_action: Literal["full_exit_at_far_resistance"] | None = None
     sizing: Literal["full_account_lot_exit"] | None = None
     approval: Literal["telegram_manual"] | None = None
     auto_approve: Literal[False] = False
@@ -284,11 +285,11 @@ def _invalid_context_result(reason: str) -> SingleShareExitEvaluation:
     return SingleShareExitEvaluation(
         outcome="INELIGIBLE",
         reason=reason,
-        snapshot_id="invalid",
-        symbol="000000",
+        snapshot_id="<invalid>",
+        symbol="<invalid>",
         broker="kis",
-        broker_account_id="invalid",
-        lot_id="invalid",
+        broker_account_id="<invalid>",
+        lot_id="<invalid>",
     )
 
 
@@ -405,6 +406,14 @@ def _evaluate_single_share_exit(
             context,
             outcome="INELIGIBLE",
             reason="no_resistance_reference",
+            rule=rule,
+        )
+    required_strength = ResistanceStrength(rule.conditions.resistance_strength_min)
+    if context.resistance.strength is not required_strength:
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="resistance_strength_below_required",
             rule=rule,
         )
     if (

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -20,11 +20,12 @@ from app.services.single_share_exit_snapshot_service import (
     PRODUCER_CAPABILITY,
     PRODUCER_IDENTITY,
     ROSTER_CAPABILITY,
-    ContextMode,
     ResistanceStrength,
     ValidatedSingleShareExitContext,
+    compute_account_roster_hash,
     executable_quote_price,
-    is_validated_context,
+    is_validated_live_context,
+    is_validated_replay_context,
     required_reader_capabilities,
 )
 
@@ -33,6 +34,15 @@ _POLICY_PATH: Path = (
 )
 
 _cache: dict[str, Any] = {"key": None, "doc": None, "hash": None}
+
+_SINGLE_SHARE_EXIT_ACTION: Literal["full_exit_at_far_resistance"] = (
+    "full_exit_at_far_resistance"
+)
+_SINGLE_SHARE_EXIT_SIZING: Literal["full_account_lot_exit"] = "full_account_lot_exit"
+_SINGLE_SHARE_EXIT_APPROVAL: Literal["telegram_manual"] = "telegram_manual"
+_SINGLE_SHARE_EXIT_EXECUTION: Literal["proposal_only"] = "proposal_only"
+_SINGLE_SHARE_EXIT_LOSS_GUARD_KEY = "sell.loss_guard_min_multiple"
+_SINGLE_SHARE_EXIT_CODE_LOSS_FLOOR = Decimal("1.01")
 
 
 class TradingPolicyKeyError(ValueError):
@@ -104,6 +114,14 @@ def _load() -> tuple[TradingPolicyDocument, str]:
 
 
 def load_trading_policy() -> TradingPolicyDocument:
+    """Return a detached policy model, never the mutable cached singleton."""
+
+    return _load()[0].model_copy(deep=True)
+
+
+def _single_share_policy_document() -> TradingPolicyDocument:
+    """Internal read-only view used by the hot evaluator path."""
+
     return _load()[0]
 
 
@@ -201,6 +219,43 @@ def sector_cluster_for(label: str | None) -> str | None:
     return None
 
 
+def _single_share_policy_contract_is_safe(
+    rule: SingleShareExitDecisionRule,
+) -> bool:
+    """Pin the non-judgment safety projection before any eligible result."""
+
+    if type(rule) is not SingleShareExitDecisionRule:
+        return False
+    proposal = rule.proposal
+    conditions = rule.conditions
+    scope = rule.scope
+    return (
+        rule.lanes == ["sell"]
+        and rule.activation_state == "shadow"
+        and rule.proposal_enabled is False
+        and scope.markets == ["kr"]
+        and scope.brokers == ["kis", "toss"]
+        and scope.required_broker_inventory == ["kis", "toss"]
+        and scope.order_routable_required is True
+        and conditions.symbol_routable_sellable_quantity_eq == 1
+        and conditions.resistance_reference_required is True
+        and conditions.resistance_strength_min == "strong"
+        and conditions.required_completed_bar_market == "XKRX"
+        and conditions.min_sell_price_multiple_policy_key
+        == _SINGLE_SHARE_EXIT_LOSS_GUARD_KEY
+        and conditions.same_symbol_open_orders_max == 0
+        and conditions.unresolved_open_actions_max == 0
+        and conditions.loss_state_uses_existing_path == "loss_cut_only"
+        and proposal.action == _SINGLE_SHARE_EXIT_ACTION
+        and proposal.sizing == _SINGLE_SHARE_EXIT_SIZING
+        and proposal.approval == _SINGLE_SHARE_EXIT_APPROVAL
+        and proposal.auto_approve is False
+        and proposal.execution == _SINGLE_SHARE_EXIT_EXECUTION
+        and rule.threshold_status == "provisional"
+        and rule.operator_approval_required is True
+    )
+
+
 def _single_share_result(
     context: ValidatedSingleShareExitContext,
     *,
@@ -216,7 +271,7 @@ def _single_share_result(
     symbol_routable_sellable_quantity: Decimal | None = None,
     quote_age_seconds: Decimal | None = None,
 ) -> SingleShareExitEvaluation:
-    proposal = rule.proposal if outcome == "SHADOW_ELIGIBLE" and rule else None
+    include_candidate_metadata = outcome == "SHADOW_ELIGIBLE" and rule is not None
     expected_identities = tuple(
         f"{identity.broker.value}:{identity.broker_account_id}"
         for identity in context.expected_account_identities
@@ -233,11 +288,15 @@ def _single_share_result(
         broker=context.target.broker.value,
         broker_account_id=context.target.broker_account_id,
         lot_id=context.target.lot_id,
-        candidate_action=proposal.action if proposal else None,
-        sizing=proposal.sizing if proposal else None,
-        approval=proposal.approval if proposal else None,
-        auto_approve=proposal.auto_approve if proposal else False,
-        execution=proposal.execution if proposal else None,
+        candidate_action=(
+            _SINGLE_SHARE_EXIT_ACTION if include_candidate_metadata else None
+        ),
+        sizing=_SINGLE_SHARE_EXIT_SIZING if include_candidate_metadata else None,
+        approval=_SINGLE_SHARE_EXIT_APPROVAL if include_candidate_metadata else None,
+        auto_approve=False,
+        execution=(
+            _SINGLE_SHARE_EXIT_EXECUTION if include_candidate_metadata else None
+        ),
         average_cost=average_cost,
         symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
         current_quote=current_quote,
@@ -329,9 +388,9 @@ def _evaluate_single_share_exit(
     now: dt.datetime,
     eligible_outcome: Literal["SHADOW_ELIGIBLE", "REPLAY_ELIGIBLE"],
 ) -> SingleShareExitEvaluation:
-    doc = load_trading_policy()
+    doc = _single_share_policy_document()
     rule = doc.decision_rules.get("sell.single_share_exit")
-    if not isinstance(rule, SingleShareExitDecisionRule):
+    if type(rule) is not SingleShareExitDecisionRule:
         return _single_share_result(
             context, outcome="INELIGIBLE", reason="policy_rule_unavailable"
         )
@@ -340,6 +399,13 @@ def _evaluate_single_share_exit(
             context,
             outcome="INELIGIBLE",
             reason="policy_not_shadow_off",
+            rule=rule,
+        )
+    if not _single_share_policy_contract_is_safe(rule):
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="policy_safe_projection_mismatch",
             rule=rule,
         )
     if context.market not in rule.scope.markets:
@@ -362,7 +428,21 @@ def _evaluate_single_share_exit(
             reason="authoritative_producer_capability_mismatch",
             rule=rule,
         )
-    if context.roster_hash != context.derived_roster_hash:
+    try:
+        derived_roster_hash = compute_account_roster_hash(
+            roster_id=context.roster_id,
+            roster_version=context.roster_version,
+            read_model_identity=context.roster_read_model_identity,
+            accounts=context.configured_accounts,
+        )
+    except (AttributeError, TypeError, ValueError):
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="invalid_account_roster_context",
+            rule=rule,
+        )
+    if context.roster_hash != derived_roster_hash:
         return _single_share_result(
             context,
             outcome="INELIGIBLE",
@@ -647,12 +727,14 @@ def _evaluate_single_share_exit(
 
     average_cost = target_lot.average_cost
     resistance = context.resistance.price
-    guard_spec = doc.thresholds.get(rule.conditions.min_sell_price_multiple_policy_key)
+    guard_spec = doc.thresholds.get(_SINGLE_SHARE_EXIT_LOSS_GUARD_KEY)
     try:
-        guard_multiple = Decimal(str(guard_spec.value)) if guard_spec else Decimal(0)
+        configured_guard_multiple = (
+            Decimal(str(guard_spec.value)) if guard_spec else Decimal(0)
+        )
     except (InvalidOperation, ValueError):
-        guard_multiple = Decimal(0)
-    if guard_multiple <= 0:
+        configured_guard_multiple = Decimal(0)
+    if not configured_guard_multiple.is_finite() or configured_guard_multiple <= 0:
         return _single_share_result(
             context,
             outcome="INELIGIBLE",
@@ -664,6 +746,10 @@ def _evaluate_single_share_exit(
             quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
         )
+    guard_multiple = max(
+        configured_guard_multiple,
+        _SINGLE_SHARE_EXIT_CODE_LOSS_FLOOR,
+    )
     if quote < average_cost * guard_multiple:
         return _single_share_result(
             context,
@@ -738,16 +824,16 @@ def _evaluate_single_share_exit(
 def evaluate_single_share_exit(
     context: ValidatedSingleShareExitContext,
 ) -> SingleShareExitEvaluation:
-    """Evaluate only a live producer-issued context using the internal clock."""
+    """Evaluate only the initialized exact live context type."""
 
-    if not is_validated_context(context):
-        return _invalid_context_result("unvalidated_producer_context")
-    if context.mode is not ContextMode.LIVE:
+    if is_validated_replay_context(context):
         return _single_share_result(
             context,
             outcome="INELIGIBLE",
             reason="replay_context_not_live",
         )
+    if not is_validated_live_context(context):
+        return _invalid_context_result("unvalidated_producer_context")
     return _evaluate_single_share_exit(
         context,
         now=dt.datetime.now(dt.UTC),
@@ -758,16 +844,16 @@ def evaluate_single_share_exit(
 def evaluate_single_share_exit_replay(
     context: ValidatedSingleShareExitContext,
 ) -> SingleShareExitEvaluation:
-    """Deterministic offline seam; never returns live ``SHADOW_ELIGIBLE``."""
+    """Deterministic seam accepting only the initialized exact replay type."""
 
-    if not is_validated_context(context):
-        return _invalid_context_result("unvalidated_producer_context")
-    if context.mode is not ContextMode.REPLAY:
+    if is_validated_live_context(context):
         return _single_share_result(
             context,
             outcome="INELIGIBLE",
             reason="live_context_not_replay",
         )
+    if not is_validated_replay_context(context):
+        return _invalid_context_result("unvalidated_producer_context")
     return _evaluate_single_share_exit(
         context,
         now=context.produced_at,

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -14,8 +14,17 @@ import yaml
 
 from app.schemas.trading_policy import (
     SingleShareExitDecisionRule,
-    SingleShareExitEvidenceSnapshot,
     TradingPolicyDocument,
+)
+from app.services.single_share_exit_snapshot_service import (
+    PRODUCER_CAPABILITY,
+    PRODUCER_IDENTITY,
+    ROSTER_CAPABILITY,
+    ContextMode,
+    ValidatedSingleShareExitContext,
+    executable_quote_price,
+    is_validated_context,
+    required_reader_capabilities,
 )
 
 _POLICY_PATH: Path = (
@@ -33,7 +42,7 @@ class TradingPolicyKeyError(ValueError):
 class SingleShareExitEvaluation:
     """Pure shadow-policy result; it neither persists nor proposes an order."""
 
-    outcome: Literal["SHADOW_ELIGIBLE", "DEFER", "INELIGIBLE"]
+    outcome: Literal["SHADOW_ELIGIBLE", "REPLAY_ELIGIBLE", "DEFER", "INELIGIBLE"]
     reason: str
     snapshot_id: str
     symbol: str
@@ -62,6 +71,17 @@ class SingleShareExitEvaluation:
     resistance_computed_at: dt.datetime | None = None
     ohlcv_through_date: dt.date | None = None
     expected_completed_krx_bar_date: dt.date | None = None
+    roster_id: str | None = None
+    roster_version: str | None = None
+    roster_hash: str | None = None
+    expected_account_identities: tuple[str, ...] = ()
+    observed_account_identities: tuple[str, ...] = ()
+    producer_identity: str | None = None
+    producer_capability: str | None = None
+    quote_kind: str | None = None
+    quote_venue: str | None = None
+    quote_executable: bool | None = None
+    quote_firm: bool | None = None
 
 
 def _reset_cache_for_tests() -> None:
@@ -129,11 +149,16 @@ def get_policy_for(market: str, lane: str) -> dict[str, Any]:
             ),
             "source": source,
         }
-    decision_rules = {
-        key: spec.model_dump(exclude={"lanes"})
-        for key, spec in doc.decision_rules.items()
-        if lane in spec.lanes
-    }
+    decision_rules: dict[str, Any] = {}
+    for key, spec in doc.decision_rules.items():
+        if lane not in spec.lanes:
+            continue
+        if (
+            isinstance(spec, SingleShareExitDecisionRule)
+            and market not in spec.scope.markets
+        ):
+            continue
+        decision_rules[key] = spec.model_dump(exclude={"lanes"})
     market_rules: dict[str, Any] = {}
     rules = doc.market_rules.get("crypto") if market == "crypto" else None
     if rules is not None:
@@ -176,12 +201,13 @@ def sector_cluster_for(label: str | None) -> str | None:
 
 
 def _single_share_result(
-    evidence: SingleShareExitEvidenceSnapshot,
+    context: ValidatedSingleShareExitContext,
     *,
-    outcome: Literal["SHADOW_ELIGIBLE", "DEFER", "INELIGIBLE"],
+    outcome: Literal["SHADOW_ELIGIBLE", "REPLAY_ELIGIBLE", "DEFER", "INELIGIBLE"],
     reason: str,
     rule: SingleShareExitDecisionRule | None = None,
     average_cost: Decimal | None = None,
+    current_quote: Decimal | None = None,
     profit_pct: Decimal | None = None,
     resistance_distance_pct: Decimal | None = None,
     normalized_source_families: tuple[str, ...] = (),
@@ -190,14 +216,22 @@ def _single_share_result(
     quote_age_seconds: Decimal | None = None,
 ) -> SingleShareExitEvaluation:
     proposal = rule.proposal if outcome == "SHADOW_ELIGIBLE" and rule else None
+    expected_identities = tuple(
+        f"{identity.broker.value}:{identity.broker_account_id}"
+        for identity in context.expected_account_identities
+    )
+    observed_identities = tuple(
+        f"{identity.broker.value}:{identity.broker_account_id}"
+        for identity in context.observed_account_identities
+    )
     return SingleShareExitEvaluation(
         outcome=outcome,
         reason=reason,
-        snapshot_id=evidence.snapshot_id,
-        symbol=evidence.target.symbol,
-        broker=evidence.target.broker,
-        broker_account_id=evidence.target.broker_account_id,
-        lot_id=evidence.target.lot_id,
+        snapshot_id=context.snapshot_id,
+        symbol=context.target.symbol,
+        broker=context.target.broker.value,
+        broker_account_id=context.target.broker_account_id,
+        lot_id=context.target.lot_id,
         candidate_action=proposal.action if proposal else None,
         sizing=proposal.sizing if proposal else None,
         approval=proposal.approval if proposal else None,
@@ -205,30 +239,61 @@ def _single_share_result(
         execution=proposal.execution if proposal else None,
         average_cost=average_cost,
         symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
-        current_quote=evidence.quote.price,
-        quote_source=evidence.quote.source,
+        current_quote=current_quote,
+        quote_source=context.quote.source.value,
         quote_age_seconds=quote_age_seconds,
-        resistance_price=evidence.resistance.price,
+        resistance_price=(
+            context.resistance.price if context.resistance is not None else None
+        ),
         profit_pct=profit_pct,
         resistance_distance_pct=resistance_distance_pct,
         normalized_source_families=normalized_source_families,
-        resistance_sources=tuple(evidence.resistance.sources),
-        resistance_strength=evidence.resistance.strength,
-        quote_observed_at=evidence.quote.observed_at,
-        resistance_computed_at=evidence.resistance.computed_at,
-        ohlcv_through_date=evidence.resistance.ohlcv_through_date,
+        resistance_sources=(
+            context.resistance.sources if context.resistance is not None else ()
+        ),
+        resistance_strength=(
+            context.resistance.strength.value
+            if context.resistance is not None
+            else None
+        ),
+        quote_observed_at=context.quote.observed_at,
+        resistance_computed_at=(
+            context.resistance.computed_at if context.resistance is not None else None
+        ),
+        ohlcv_through_date=(
+            context.resistance.ohlcv_through_date
+            if context.resistance is not None
+            else None
+        ),
         expected_completed_krx_bar_date=expected_completed_krx_bar_date,
+        roster_id=context.roster_id,
+        roster_version=context.roster_version,
+        roster_hash=context.roster_hash,
+        expected_account_identities=expected_identities,
+        observed_account_identities=observed_identities,
+        producer_identity=context.producer_identity,
+        producer_capability=context.producer_capability,
+        quote_kind=context.quote.quote_kind.value,
+        quote_venue=context.quote.venue.value,
+        quote_executable=context.quote.executable,
+        quote_firm=context.quote.firm,
     )
 
 
-def _as_aware_utc(value: dt.datetime) -> dt.datetime | None:
-    if value.tzinfo is None or value.utcoffset() is None:
-        return None
-    return value.astimezone(dt.UTC)
+def _invalid_context_result(reason: str) -> SingleShareExitEvaluation:
+    return SingleShareExitEvaluation(
+        outcome="INELIGIBLE",
+        reason=reason,
+        snapshot_id="invalid",
+        symbol="000000",
+        broker="kis",
+        broker_account_id="invalid",
+        lot_id="invalid",
+    )
 
 
 def _normalized_resistance_families(
-    sources: list[str], rule: SingleShareExitDecisionRule
+    sources: tuple[str, ...], rule: SingleShareExitDecisionRule
 ) -> tuple[str, ...]:
     normalization = rule.conditions.resistance_source_families
     volume_exact = {source.casefold() for source in normalization.volume_profile_exact}
@@ -257,200 +322,276 @@ def _expected_completed_krx_bar(now: dt.datetime) -> dt.date | None:
     return last_final_session_kr(now)
 
 
-def evaluate_single_share_exit(
-    evidence: SingleShareExitEvidenceSnapshot,
+def _evaluate_single_share_exit(
+    context: ValidatedSingleShareExitContext,
     *,
-    evaluated_at: dt.datetime | None = None,
+    now: dt.datetime,
+    eligible_outcome: Literal["SHADOW_ELIGIBLE", "REPLAY_ELIGIBLE"],
 ) -> SingleShareExitEvaluation:
-    """Evaluate one bounded evidence snapshot in shadow mode only.
-
-    Profit and resistance distance are recomputed from Decimal prices in the
-    snapshot. KIS/Toss inventory and open-order evidence are caller-supplied
-    read models, but completeness, identity, scope, timestamps, and aggregate
-    quantities are checked here. This function has no broker, DB, scheduler,
-    Telegram, proposal, or order side effects.
-    """
-
     doc = load_trading_policy()
     rule = doc.decision_rules.get("sell.single_share_exit")
     if not isinstance(rule, SingleShareExitDecisionRule):
         return _single_share_result(
-            evidence, outcome="INELIGIBLE", reason="policy_rule_unavailable"
+            context, outcome="INELIGIBLE", reason="policy_rule_unavailable"
         )
     if rule.activation_state != "shadow" or rule.proposal_enabled:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="policy_not_shadow_off",
             rule=rule,
         )
-    if evidence.market not in rule.scope.markets:
+    if context.market not in rule.scope.markets:
         return _single_share_result(
-            evidence, outcome="INELIGIBLE", reason="market_out_of_scope", rule=rule
+            context, outcome="INELIGIBLE", reason="market_out_of_scope", rule=rule
         )
-    if evidence.target.broker not in rule.scope.brokers:
+    if context.target.broker.value not in rule.scope.brokers:
         return _single_share_result(
-            evidence, outcome="INELIGIBLE", reason="broker_out_of_scope", rule=rule
+            context, outcome="INELIGIBLE", reason="broker_out_of_scope", rule=rule
         )
-
-    now = _as_aware_utc(evaluated_at or dt.datetime.now(dt.UTC))
-    captured_at = _as_aware_utc(evidence.captured_at)
-    if now is None or captured_at is None:
+    if (
+        context.producer_identity != PRODUCER_IDENTITY
+        or context.producer_capability != PRODUCER_CAPABILITY
+        or context.roster_read_model_capability != ROSTER_CAPABILITY
+        or context.reader_capabilities != required_reader_capabilities()
+    ):
         return _single_share_result(
-            evidence, outcome="INELIGIBLE", reason="naive_evidence_timestamp", rule=rule
-        )
-
-    nested_snapshot_ids = {
-        evidence.quote.snapshot_id,
-        evidence.resistance.snapshot_id,
-        evidence.open_actions_snapshot_id,
-        *(account.snapshot_id for account in evidence.accounts),
-    }
-    if nested_snapshot_ids != {evidence.snapshot_id}:
-        return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
-            reason="inconsistent_snapshot_id",
+            reason="authoritative_producer_capability_mismatch",
+            rule=rule,
+        )
+    if context.roster_hash != context.derived_roster_hash:
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="account_roster_hash_mismatch",
+            rule=rule,
+        )
+    configured_identities = tuple(
+        sorted(
+            (account.identity for account in context.configured_accounts),
+            key=lambda identity: (
+                identity.broker.value,
+                identity.broker_account_id,
+            ),
+        )
+    )
+    if (
+        configured_identities != context.expected_account_identities
+        or len(set(configured_identities)) != len(configured_identities)
+        or not context.roster_is_exact
+    ):
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="expected_observed_account_roster_mismatch",
+            rule=rule,
+        )
+    routable_brokers = {
+        account.identity.broker.value
+        for account in context.configured_accounts
+        if account.order_routable
+    }
+    if not set(rule.scope.required_broker_inventory).issubset(routable_brokers):
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="incomplete_kis_toss_routable_roster",
+            rule=rule,
+        )
+    if context.resistance is None:
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="no_resistance_reference",
             rule=rule,
         )
     if (
-        evidence.quote.symbol != evidence.target.symbol
-        or evidence.resistance.symbol != evidence.target.symbol
+        context.quote.symbol != context.target.symbol
+        or context.resistance.symbol != context.target.symbol
     ):
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="inconsistent_snapshot_symbol",
             rule=rule,
         )
-
-    required_brokers = set(rule.scope.required_broker_inventory)
-    observed_brokers = {account.broker for account in evidence.accounts}
-    if not required_brokers.issubset(observed_brokers):
+    quote = executable_quote_price(context.quote)
+    if quote is None:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
-            reason="incomplete_kis_toss_inventory",
-            rule=rule,
-        )
-    account_identities = [
-        (account.broker, account.broker_account_id) for account in evidence.accounts
-    ]
-    if len(set(account_identities)) != len(account_identities):
-        return _single_share_result(
-            evidence,
-            outcome="INELIGIBLE",
-            reason="duplicate_broker_account_snapshot",
+            reason="quote_quality_not_executable",
             rule=rule,
         )
 
-    timestamp_values = [
-        evidence.quote.observed_at,
-        evidence.resistance.computed_at,
-        evidence.open_actions_checked_at,
-        *(
-            timestamp
-            for account in evidence.accounts
-            for timestamp in (account.observed_at, account.open_orders_checked_at)
-        ),
+    timestamps_by_kind: dict[str, list[dt.datetime]] = {
+        "quote": [context.quote.observed_at],
+        "resistance": [context.resistance.computed_at],
+        "holdings": [account.holdings_observed_at for account in context.accounts],
+        "open_orders": [
+            account.open_orders_observed_at for account in context.accounts
+        ],
+        "open_actions": [context.open_actions.observed_at],
+        "captured_at": [context.captured_at],
+    }
+    all_timestamps = [
+        timestamp
+        for timestamps in timestamps_by_kind.values()
+        for timestamp in timestamps
     ]
-    timestamp_values_utc = [_as_aware_utc(value) for value in timestamp_values]
-    if any(value is None for value in timestamp_values_utc):
-        return _single_share_result(
-            evidence, outcome="INELIGIBLE", reason="naive_evidence_timestamp", rule=rule
-        )
-    max_skew = dt.timedelta(seconds=rule.conditions.snapshot_max_skew_seconds)
-    if captured_at > now or any(
-        value is None or value > now or abs(value - captured_at) > max_skew
-        for value in timestamp_values_utc
+    if any(
+        timestamp.tzinfo is None or timestamp.utcoffset() is None
+        for timestamp in all_timestamps
     ):
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
-            reason="stale_or_inconsistent_evidence",
+            reason="naive_evidence_timestamp",
             rule=rule,
+            current_quote=quote,
         )
-    quote_observed_at = _as_aware_utc(evidence.quote.observed_at)
-    quote_age_seconds = (
-        Decimal(str((now - quote_observed_at).total_seconds()))
-        if quote_observed_at is not None
-        else None
+    timestamps_utc = [timestamp.astimezone(dt.UTC) for timestamp in all_timestamps]
+    now_utc = now.astimezone(dt.UTC)
+    if any(timestamp > now_utc for timestamp in timestamps_utc):
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="future_evidence_timestamp",
+            rule=rule,
+            current_quote=quote,
+        )
+    pairwise_skew = max(timestamps_utc) - min(timestamps_utc)
+    if pairwise_skew > dt.timedelta(seconds=rule.conditions.snapshot_max_skew_seconds):
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="snapshot_pairwise_skew_exceeded",
+            rule=rule,
+            current_quote=quote,
+        )
+    age_limits = {
+        "quote": rule.conditions.quote_max_age_seconds,
+        "resistance": rule.conditions.resistance_max_age_seconds,
+        "holdings": rule.conditions.holdings_max_age_seconds,
+        "open_orders": rule.conditions.open_orders_max_age_seconds,
+        "open_actions": rule.conditions.open_actions_max_age_seconds,
+        "captured_at": rule.conditions.captured_at_max_age_seconds,
+    }
+    for kind, timestamps in timestamps_by_kind.items():
+        oldest = min(timestamp.astimezone(dt.UTC) for timestamp in timestamps)
+        if now_utc - oldest > dt.timedelta(seconds=age_limits[kind]):
+            return _single_share_result(
+                context,
+                outcome="INELIGIBLE",
+                reason=f"stale_{kind}",
+                rule=rule,
+                current_quote=quote,
+                quote_age_seconds=Decimal(
+                    str(
+                        (
+                            now_utc - context.quote.observed_at.astimezone(dt.UTC)
+                        ).total_seconds()
+                    )
+                ),
+            )
+    quote_age_seconds = Decimal(
+        str((now_utc - context.quote.observed_at.astimezone(dt.UTC)).total_seconds())
     )
-    if quote_observed_at is None or now - quote_observed_at > dt.timedelta(
-        seconds=rule.conditions.quote_max_age_seconds
-    ):
-        return _single_share_result(
-            evidence,
-            outcome="INELIGIBLE",
-            reason="stale_quote",
-            rule=rule,
-            quote_age_seconds=quote_age_seconds,
-        )
 
-    expected_bar_date = _expected_completed_krx_bar(now)
+    expected_bar_date = _expected_completed_krx_bar(now_utc)
     if expected_bar_date is None:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="expected_completed_krx_bar_unavailable",
             rule=rule,
+            current_quote=quote,
+            quote_age_seconds=quote_age_seconds,
         )
-    if evidence.resistance.ohlcv_through_date != expected_bar_date:
+    if context.resistance.ohlcv_through_date != expected_bar_date:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="ohlcv_not_through_expected_completed_krx_bar",
             rule=rule,
+            current_quote=quote,
+            quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
         )
 
+    target_accounts = [
+        account
+        for account in context.configured_accounts
+        if account.identity == context.target.account_identity
+    ]
+    if len(target_accounts) != 1 or (
+        rule.scope.order_routable_required and not target_accounts[0].order_routable
+    ):
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="target_account_not_routable",
+            rule=rule,
+            current_quote=quote,
+            quote_age_seconds=quote_age_seconds,
+            expected_completed_krx_bar_date=expected_bar_date,
+        )
     target_matches = [
         lot
-        for account in evidence.accounts
-        if account.broker == evidence.target.broker
-        and account.broker_account_id == evidence.target.broker_account_id
+        for account in context.accounts
+        if account.identity == context.target.account_identity
         for lot in account.lots
-        if lot.symbol == evidence.target.symbol and lot.lot_id == evidence.target.lot_id
+        if lot.symbol == context.target.symbol and lot.lot_id == context.target.lot_id
     ]
     if len(target_matches) != 1:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="target_lot_identity_not_unique",
             rule=rule,
+            current_quote=quote,
+            quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
         )
     target_lot = target_matches[0]
     required_quantity = Decimal(rule.conditions.symbol_routable_sellable_quantity_eq)
-    target_is_routable = (
-        not rule.scope.order_routable_required or target_lot.order_routable
-    )
     target_is_single_sellable = target_lot.sellable_quantity == required_quantity
-    if not target_is_routable or not target_is_single_sellable:
+    if not target_is_single_sellable:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="target_account_lot_not_single_routable_sellable",
             rule=rule,
             average_cost=target_lot.average_cost,
+            current_quote=quote,
+            quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
         )
+    routable_identities = {
+        account.identity
+        for account in context.configured_accounts
+        if account.order_routable
+    }
     symbol_routable_sellable_quantity = sum(
         (
             lot.sellable_quantity
-            for account in evidence.accounts
+            for account in context.accounts
+            if account.identity in routable_identities
             for lot in account.lots
-            if lot.symbol == evidence.target.symbol and lot.order_routable
+            if lot.symbol == context.target.symbol
         ),
         start=Decimal(0),
     )
     if symbol_routable_sellable_quantity != required_quantity:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="symbol_routable_sellable_quantity_not_one",
             rule=rule,
             average_cost=target_lot.average_cost,
+            current_quote=quote,
             symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
             quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
@@ -458,17 +599,18 @@ def evaluate_single_share_exit(
 
     same_symbol_open_orders = [
         order
-        for account in evidence.accounts
+        for account in context.accounts
         for order in account.open_orders
-        if order.symbol == evidence.target.symbol
+        if order.symbol == context.target.symbol
     ]
     if len(same_symbol_open_orders) > rule.conditions.same_symbol_open_orders_max:
         return _single_share_result(
-            evidence,
+            context,
             outcome="DEFER",
             reason="same_symbol_broker_open_order",
             rule=rule,
             average_cost=target_lot.average_cost,
+            current_quote=quote,
             symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
             quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
@@ -476,26 +618,26 @@ def evaluate_single_share_exit(
 
     scoped_open_actions = [
         action
-        for action in evidence.open_actions
-        if action.symbol == evidence.target.symbol
+        for action in context.open_actions.actions
+        if action.symbol == context.target.symbol
         and action.side == "sell"
-        and action.broker_account_id == evidence.target.broker_account_id
+        and action.broker_account_id == context.target.broker_account_id
     ]
     if len(scoped_open_actions) > rule.conditions.unresolved_open_actions_max:
         return _single_share_result(
-            evidence,
+            context,
             outcome="DEFER",
             reason="unresolved_scoped_open_action",
             rule=rule,
             average_cost=target_lot.average_cost,
+            current_quote=quote,
             symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
             quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
         )
 
     average_cost = target_lot.average_cost
-    quote = evidence.quote.price
-    resistance = evidence.resistance.price
+    resistance = context.resistance.price
     guard_spec = doc.thresholds.get(rule.conditions.min_sell_price_multiple_policy_key)
     try:
         guard_multiple = Decimal(str(guard_spec.value)) if guard_spec else Decimal(0)
@@ -503,22 +645,24 @@ def evaluate_single_share_exit(
         guard_multiple = Decimal(0)
     if guard_multiple <= 0:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="invalid_loss_guard_policy",
             rule=rule,
             average_cost=average_cost,
+            current_quote=quote,
             symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
             quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
         )
     if quote < average_cost * guard_multiple:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="loss_guard_not_met",
             rule=rule,
             average_cost=average_cost,
+            current_quote=quote,
             symbol_routable_sellable_quantity=symbol_routable_sellable_quantity,
             quote_age_seconds=quote_age_seconds,
             expected_completed_krx_bar_date=expected_bar_date,
@@ -530,11 +674,12 @@ def evaluate_single_share_exit(
     profit_pct = raw_profit_pct.quantize(Decimal("0.0001"))
     resistance_distance_pct = raw_resistance_distance_pct.quantize(Decimal("0.0001"))
     normalized_families = _normalized_resistance_families(
-        evidence.resistance.sources, rule
+        context.resistance.sources, rule
     )
     result_kwargs: dict[str, Any] = {
         "rule": rule,
         "average_cost": average_cost,
+        "current_quote": quote,
         "profit_pct": profit_pct,
         "resistance_distance_pct": resistance_distance_pct,
         "normalized_source_families": normalized_families,
@@ -544,7 +689,7 @@ def evaluate_single_share_exit(
     }
     if raw_profit_pct < Decimal(str(rule.conditions.profit_pct_min)):
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="profit_below_provisional_minimum",
             **result_kwargs,
@@ -556,24 +701,68 @@ def evaluate_single_share_exit(
         <= Decimal(str(rule.conditions.resistance_distance_pct_max))
     ):
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="resistance_outside_far_band",
             **result_kwargs,
         )
     if len(normalized_families) < rule.conditions.resistance_source_family_min:
         return _single_share_result(
-            evidence,
+            context,
             outcome="INELIGIBLE",
             reason="insufficient_independent_resistance_families",
             **result_kwargs,
         )
 
     return _single_share_result(
-        evidence,
-        outcome="SHADOW_ELIGIBLE",
-        reason="proposal_disabled_shadow_candidate",
+        context,
+        outcome=eligible_outcome,
+        reason=(
+            "proposal_disabled_shadow_candidate"
+            if eligible_outcome == "SHADOW_ELIGIBLE"
+            else "replay_candidate_no_live_eligibility"
+        ),
         **result_kwargs,
+    )
+
+
+def evaluate_single_share_exit(
+    context: ValidatedSingleShareExitContext,
+) -> SingleShareExitEvaluation:
+    """Evaluate only a live producer-issued context using the internal clock."""
+
+    if not is_validated_context(context):
+        return _invalid_context_result("unvalidated_producer_context")
+    if context.mode is not ContextMode.LIVE:
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="replay_context_not_live",
+        )
+    return _evaluate_single_share_exit(
+        context,
+        now=dt.datetime.now(dt.UTC),
+        eligible_outcome="SHADOW_ELIGIBLE",
+    )
+
+
+def evaluate_single_share_exit_replay(
+    context: ValidatedSingleShareExitContext,
+) -> SingleShareExitEvaluation:
+    """Deterministic offline seam; never returns live ``SHADOW_ELIGIBLE``."""
+
+    if not is_validated_context(context):
+        return _invalid_context_result("unvalidated_producer_context")
+    if context.mode is not ContextMode.REPLAY:
+        return _single_share_result(
+            context,
+            outcome="INELIGIBLE",
+            reason="live_context_not_replay",
+        )
+    return _evaluate_single_share_exit(
+        context,
+        now=context.produced_at,
+        eligible_outcome="REPLAY_ELIGIBLE",
     )
 
 

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -114,7 +114,7 @@ def _load() -> tuple[TradingPolicyDocument, str]:
 
 
 def load_trading_policy() -> TradingPolicyDocument:
-    """Return a detached policy model, never the mutable cached singleton."""
+    """Return a detached policy copy rather than the internal cached instance."""
 
     return _load()[0].model_copy(deep=True)
 

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-22.1"
-captured_as_of: "2026-07-22"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22"
+version: "2026-07-23.1"
+captured_as_of: "2026-07-23"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit proposal seed 2026-07-23"
 
 authority:
   scope: judgment_policy_only
@@ -193,6 +193,43 @@ decision_rules:
       - single_share_position
       - no_resistance_reference
       - composite_gates
+  sell.single_share_exit:
+    lanes: [sell]
+    semantics: >-
+      Additive fallback for a profitable KR holding whose one-share quantity
+      makes a partial trim physically impossible. This rule is evaluated
+      separately from sell.trim_preplace and can create a full-exit proposal
+      only; it cannot approve or execute an order. A loss state remains
+      ineligible here and belongs exclusively to the existing loss_cut path.
+    scope:
+      markets: [kr]
+      brokers: [kis, toss]
+      order_routable_required: true
+    conditions:
+      quantity_eq: 1
+      # Provisional: aligned with profit_realization so this fallback closes
+      # only the single-share sizing gap instead of changing profit eligibility.
+      profit_pct_min: 8
+      resistance_reference_required: true
+      # Provisional: full liquidation requires the stronger existing ultra-near
+      # evidence (2%), not the broader sell.resistance_near_pct PLACE band (6%).
+      resistance_near_pct_max: 2
+      min_sell_price_multiple_policy_key: sell.loss_guard_min_multiple
+      unresolved_open_actions_max: 0
+      loss_state_uses_existing_path: loss_cut_only
+    proposal:
+      action: propose_full_exit
+      sizing: full_position
+      approval: telegram_manual
+      auto_approve: false
+      execution: proposal_only
+    threshold_status: provisional
+    operator_approval_required: true
+    recalibration_note: >-
+      Fable governance advisory Q3-#4 Phase 1 seed; follow-up sell-policy
+      research must recalibrate this initial threshold. The single-share
+      profit and resistance thresholds inherit that provisional status and
+      require operator approval before final adoption.
 
 market_rules:
   crypto:

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-23.1"
+version: "2026-07-23.2"
 captured_as_of: "2026-07-23"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit proposal seed 2026-07-23"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23"
 
 authority:
   scope: judgment_policy_only
@@ -196,30 +196,46 @@ decision_rules:
   sell.single_share_exit:
     lanes: [sell]
     semantics: >-
-      Additive fallback for a profitable KR holding whose one-share quantity
-      makes a partial trim physically impossible. This rule is evaluated
-      separately from sell.trim_preplace and can create a full-exit proposal
-      only; it cannot approve or execute an order. A loss state remains
-      ineligible here and belongs exclusively to the existing loss_cut path.
+      Additive shadow-only fallback review for a profitable KR account lot when
+      complete KIS+Toss evidence proves the symbol-wide routable sellable
+      quantity is exactly one. This rule is evaluated separately from
+      sell.trim_preplace. It cannot create, approve, or execute a proposal while
+      proposal_enabled is false. A loss state remains ineligible here and
+      belongs exclusively to the existing loss_cut path.
+    activation_state: shadow
+    proposal_enabled: false
     scope:
       markets: [kr]
       brokers: [kis, toss]
+      required_broker_inventory: [kis, toss]
       order_routable_required: true
     conditions:
-      quantity_eq: 1
+      symbol_routable_sellable_quantity_eq: 1
       # Provisional: aligned with profit_realization so this fallback closes
       # only the single-share sizing gap instead of changing profit eligibility.
       profit_pct_min: 8
       resistance_reference_required: true
-      # Provisional: full liquidation requires the stronger existing ultra-near
-      # evidence (2%), not the broader sell.resistance_near_pct PLACE band (6%).
-      resistance_near_pct_max: 2
+      # Provisional ROB-1037-aligned far lane. The 6% boundary is exclusive;
+      # a resistance exactly at +6% remains outside this path.
+      resistance_distance_pct_min_exclusive: 6
+      resistance_distance_pct_max: 15
+      resistance_source_family_min: 2
+      resistance_source_families:
+        volume_profile_exact: [poc, vah, val, volume_poc, volume_value_area_high, volume_value_area_low]
+        fibonacci_prefixes: [fib]
+        bollinger_prefixes: [bb_, bollinger]
+      # Reuses the server-side submit-ready quote snapshot freshness contract
+      # (age <= 300 seconds); all evidence must also belong to one bounded snapshot.
+      quote_max_age_seconds: 300
+      snapshot_max_skew_seconds: 300
+      required_completed_bar_market: XKRX
       min_sell_price_multiple_policy_key: sell.loss_guard_min_multiple
+      same_symbol_open_orders_max: 0
       unresolved_open_actions_max: 0
       loss_state_uses_existing_path: loss_cut_only
     proposal:
-      action: propose_full_exit
-      sizing: full_position
+      action: propose_full_account_lot_exit
+      sizing: full_account_lot_exit
       approval: telegram_manual
       auto_approve: false
       execution: proposal_only
@@ -228,8 +244,9 @@ decision_rules:
     recalibration_note: >-
       Fable governance advisory Q3-#4 Phase 1 seed; follow-up sell-policy
       research must recalibrate this initial threshold. The single-share
-      profit and resistance thresholds inherit that provisional status and
-      require operator approval before final adoption.
+      profit and far-resistance thresholds inherit that provisional status.
+      Shadow evidence must be adversarially validated before proposal_enabled
+      can be considered separately by the operator.
 
 market_rules:
   crypto:

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,7 +2,7 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-23.2"
+version: "2026-07-23.3"
 captured_as_of: "2026-07-23"
 source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23"
 
@@ -224,9 +224,14 @@ decision_rules:
         volume_profile_exact: [poc, vah, val, volume_poc, volume_value_area_high, volume_value_area_low]
         fibonacci_prefixes: [fib]
         bollinger_prefixes: [bb_, bollinger]
-      # Reuses the server-side submit-ready quote snapshot freshness contract
-      # (age <= 300 seconds); all evidence must also belong to one bounded snapshot.
+      # Every evidence class has its own wall-clock age bound, and all endpoints
+      # (including captured_at) must also fit one pairwise-bounded snapshot.
       quote_max_age_seconds: 300
+      resistance_max_age_seconds: 300
+      holdings_max_age_seconds: 300
+      open_orders_max_age_seconds: 300
+      open_actions_max_age_seconds: 300
+      captured_at_max_age_seconds: 300
       snapshot_max_skew_seconds: 300
       required_completed_bar_market: XKRX
       min_sell_price_multiple_policy_key: sell.loss_guard_min_multiple

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -215,6 +215,7 @@ decision_rules:
       # only the single-share sizing gap instead of changing profit eligibility.
       profit_pct_min: 8
       resistance_reference_required: true
+      resistance_strength_min: strong
       # Provisional ROB-1037-aligned far lane. The 6% boundary is exclusive;
       # a resistance exactly at +6% remains outside this path.
       resistance_distance_pct_min_exclusive: 6
@@ -239,7 +240,7 @@ decision_rules:
       unresolved_open_actions_max: 0
       loss_state_uses_existing_path: loss_cut_only
     proposal:
-      action: propose_full_account_lot_exit
+      action: full_exit_at_far_resistance
       sizing: full_account_lot_exit
       approval: telegram_manual
       auto_approve: false

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-22.1"
+    assert out["version"] == "2026-07-23.1"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,7 +23,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-22.1"
+    assert out["version"] == "2026-07-23.1"
     assert len(out["content_hash"]) == 12
     gate = out["market_rules"]["recovery_gate"]
     assert gate["min_conditions_met"] == 2
@@ -45,6 +45,16 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     assert rule["tiers"][0]["action"] == "preplace_small_trim_ladder"
     assert rule["tiers"][2]["conditions"]["resistance_near_pct_max"] == 2
     assert rule["tiers"][3]["action"] == "register_watch"
+    single_share = out["decision_rules"]["sell.single_share_exit"]
+    assert single_share["conditions"]["profit_pct_min"] == 8
+    assert single_share["conditions"]["resistance_near_pct_max"] == 2
+    assert single_share["proposal"] == {
+        "action": "propose_full_exit",
+        "sizing": "full_position",
+        "approval": "telegram_manual",
+        "auto_approve": False,
+        "execution": "proposal_only",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-23.1"
+    assert out["version"] == "2026-07-23.2"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,7 +23,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-23.1"
+    assert out["version"] == "2026-07-23.2"
     assert len(out["content_hash"]) == 12
     gate = out["market_rules"]["recovery_gate"]
     assert gate["min_conditions_met"] == 2
@@ -46,11 +46,15 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     assert rule["tiers"][2]["conditions"]["resistance_near_pct_max"] == 2
     assert rule["tiers"][3]["action"] == "register_watch"
     single_share = out["decision_rules"]["sell.single_share_exit"]
+    assert single_share["activation_state"] == "shadow"
+    assert single_share["proposal_enabled"] is False
     assert single_share["conditions"]["profit_pct_min"] == 8
-    assert single_share["conditions"]["resistance_near_pct_max"] == 2
+    assert single_share["conditions"]["resistance_distance_pct_min_exclusive"] == 6
+    assert single_share["conditions"]["resistance_distance_pct_max"] == 15
+    assert single_share["conditions"]["resistance_source_family_min"] == 2
     assert single_share["proposal"] == {
-        "action": "propose_full_exit",
-        "sizing": "full_position",
+        "action": "propose_full_account_lot_exit",
+        "sizing": "full_account_lot_exit",
         "approval": "telegram_manual",
         "auto_approve": False,
         "execution": "proposal_only",

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-23.2"
+    assert out["version"] == "2026-07-23.3"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,7 +23,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-23.2"
+    assert out["version"] == "2026-07-23.3"
     assert len(out["content_hash"]) == 12
     gate = out["market_rules"]["recovery_gate"]
     assert gate["min_conditions_met"] == 2
@@ -59,6 +59,16 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
         "auto_approve": False,
         "execution": "proposal_only",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market", ["us", "crypto"])
+async def test_get_trading_policy_hides_kr_single_share_exit_from_other_markets(
+    market,
+):
+    out = await get_trading_policy(market=market, lane="sell")
+    assert out["success"] is True
+    assert "sell.single_share_exit" not in out["decision_rules"]
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -49,11 +49,12 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     assert single_share["activation_state"] == "shadow"
     assert single_share["proposal_enabled"] is False
     assert single_share["conditions"]["profit_pct_min"] == 8
+    assert single_share["conditions"]["resistance_strength_min"] == "strong"
     assert single_share["conditions"]["resistance_distance_pct_min_exclusive"] == 6
     assert single_share["conditions"]["resistance_distance_pct_max"] == 15
     assert single_share["conditions"]["resistance_source_family_min"] == 2
     assert single_share["proposal"] == {
-        "action": "propose_full_account_lot_exit",
+        "action": "full_exit_at_far_resistance",
         "sizing": "full_account_lot_exit",
         "approval": "telegram_manual",
         "auto_approve": False,

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,7 +15,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-22.1"
+    assert doc.version == "2026-07-23.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -39,6 +39,43 @@ def test_shipped_config_validates():
         "first_matching_tier_wins"
     )
     assert trim_rule.tie_breaks["sell.upside_place_max_pct"] == "size_limit_only"
+
+
+def test_single_share_exit_rule_is_provisional_manual_proposal_only():
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "sell.single_share_exit"
+    ]
+
+    assert rule.scope.markets == ["kr"]
+    assert rule.scope.brokers == ["kis", "toss"]
+    assert rule.scope.order_routable_required is True
+    assert rule.conditions.quantity_eq == 1
+    assert rule.conditions.profit_pct_min == 8
+    assert rule.conditions.resistance_reference_required is True
+    assert rule.conditions.resistance_near_pct_max == 2
+    assert (
+        rule.conditions.min_sell_price_multiple_policy_key
+        == "sell.loss_guard_min_multiple"
+    )
+    assert rule.conditions.unresolved_open_actions_max == 0
+    assert rule.conditions.loss_state_uses_existing_path == "loss_cut_only"
+    assert rule.proposal.action == "propose_full_exit"
+    assert rule.proposal.approval == "telegram_manual"
+    assert rule.proposal.auto_approve is False
+    assert rule.proposal.execution == "proposal_only"
+    assert rule.threshold_status == "provisional"
+    assert rule.operator_approval_required is True
+    assert "research must recalibrate this initial threshold" in (
+        rule.recalibration_note
+    )
+
+
+def test_single_share_exit_rule_rejects_automatic_approval():
+    raw = _raw()
+    raw["decision_rules"]["sell.single_share_exit"]["proposal"]["auto_approve"] = True
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
 
 
 def test_auto_approve_policy_has_conservative_market_caps():

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -1,10 +1,15 @@
 from pathlib import Path
+from typing import Literal
 
 import pytest
 import yaml
 from pydantic import ValidationError
 
-from app.schemas.trading_policy import TradingPolicyDocument
+from app.schemas.trading_policy import (
+    SingleShareExitEvidenceSnapshot,
+    SingleShareExitTargetIdentity,
+    TradingPolicyDocument,
+)
 
 _CONFIG = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
 
@@ -15,7 +20,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-23.1"
+    assert doc.version == "2026-07-23.2"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -41,25 +46,35 @@ def test_shipped_config_validates():
     assert trim_rule.tie_breaks["sell.upside_place_max_pct"] == "size_limit_only"
 
 
-def test_single_share_exit_rule_is_provisional_manual_proposal_only():
+def test_single_share_exit_rule_is_provisional_shadow_only():
     rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
         "sell.single_share_exit"
     ]
 
+    assert rule.activation_state == "shadow"
+    assert rule.proposal_enabled is False
     assert rule.scope.markets == ["kr"]
     assert rule.scope.brokers == ["kis", "toss"]
+    assert rule.scope.required_broker_inventory == ["kis", "toss"]
     assert rule.scope.order_routable_required is True
-    assert rule.conditions.quantity_eq == 1
+    assert rule.conditions.symbol_routable_sellable_quantity_eq == 1
     assert rule.conditions.profit_pct_min == 8
     assert rule.conditions.resistance_reference_required is True
-    assert rule.conditions.resistance_near_pct_max == 2
+    assert rule.conditions.resistance_distance_pct_min_exclusive == 6
+    assert rule.conditions.resistance_distance_pct_max == 15
+    assert rule.conditions.resistance_source_family_min == 2
+    assert rule.conditions.quote_max_age_seconds == 300
+    assert rule.conditions.snapshot_max_skew_seconds == 300
+    assert rule.conditions.required_completed_bar_market == "XKRX"
     assert (
         rule.conditions.min_sell_price_multiple_policy_key
         == "sell.loss_guard_min_multiple"
     )
+    assert rule.conditions.same_symbol_open_orders_max == 0
     assert rule.conditions.unresolved_open_actions_max == 0
     assert rule.conditions.loss_state_uses_existing_path == "loss_cut_only"
-    assert rule.proposal.action == "propose_full_exit"
+    assert rule.proposal.action == "propose_full_account_lot_exit"
+    assert rule.proposal.sizing == "full_account_lot_exit"
     assert rule.proposal.approval == "telegram_manual"
     assert rule.proposal.auto_approve is False
     assert rule.proposal.execution == "proposal_only"
@@ -76,6 +91,52 @@ def test_single_share_exit_rule_rejects_automatic_approval():
 
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)
+
+
+def test_single_share_exit_rule_rejects_live_activation_or_enabled_proposal():
+    activation = _raw()
+    activation["decision_rules"]["sell.single_share_exit"]["activation_state"] = "live"
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(activation)
+
+    enabled = _raw()
+    enabled["decision_rules"]["sell.single_share_exit"]["proposal_enabled"] = True
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(enabled)
+
+
+def test_single_share_exit_rule_requires_both_kis_and_toss_inventory():
+    raw = _raw()
+    raw["decision_rules"]["sell.single_share_exit"]["scope"][
+        "required_broker_inventory"
+    ] = ["kis"]
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_single_share_exit_input_contract_requires_target_and_complete_account_scope():
+    identity_fields = SingleShareExitTargetIdentity.model_fields
+    assert set(identity_fields) == {
+        "symbol",
+        "broker",
+        "broker_account_id",
+        "lot_id",
+    }
+    assert all(field.is_required() for field in identity_fields.values())
+    assert (
+        SingleShareExitEvidenceSnapshot.model_fields[
+            "broker_account_scope_complete"
+        ].annotation
+        == Literal[True]
+    )
+    with pytest.raises(ValidationError):
+        SingleShareExitTargetIdentity(
+            symbol="NAVER",
+            broker="toss",
+            broker_account_id="toss-main",
+            lot_id="lot-1",
+        )
 
 
 def test_auto_approve_policy_has_conservative_market_caps():

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -56,6 +56,7 @@ def test_single_share_exit_rule_is_provisional_shadow_only():
     assert rule.conditions.symbol_routable_sellable_quantity_eq == 1
     assert rule.conditions.profit_pct_min == 8
     assert rule.conditions.resistance_reference_required is True
+    assert rule.conditions.resistance_strength_min == "strong"
     assert rule.conditions.resistance_distance_pct_min_exclusive == 6
     assert rule.conditions.resistance_distance_pct_max == 15
     assert rule.conditions.resistance_source_family_min == 2
@@ -74,7 +75,7 @@ def test_single_share_exit_rule_is_provisional_shadow_only():
     assert rule.conditions.same_symbol_open_orders_max == 0
     assert rule.conditions.unresolved_open_actions_max == 0
     assert rule.conditions.loss_state_uses_existing_path == "loss_cut_only"
-    assert rule.proposal.action == "propose_full_account_lot_exit"
+    assert rule.proposal.action == "full_exit_at_far_resistance"
     assert rule.proposal.sizing == "full_account_lot_exit"
     assert rule.proposal.approval == "telegram_manual"
     assert rule.proposal.auto_approve is False
@@ -111,6 +112,16 @@ def test_single_share_exit_rule_requires_both_kis_and_toss_inventory():
     raw["decision_rules"]["sell.single_share_exit"]["scope"][
         "required_broker_inventory"
     ] = ["kis"]
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_single_share_exit_rule_requires_strong_resistance():
+    raw = _raw()
+    raw["decision_rules"]["sell.single_share_exit"]["conditions"][
+        "resistance_strength_min"
+    ] = "moderate"
 
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -1,15 +1,11 @@
 from pathlib import Path
-from typing import Literal
 
 import pytest
 import yaml
 from pydantic import ValidationError
 
-from app.schemas.trading_policy import (
-    SingleShareExitEvidenceSnapshot,
-    SingleShareExitTargetIdentity,
-    TradingPolicyDocument,
-)
+import app.schemas.trading_policy as policy_schema
+from app.schemas.trading_policy import TradingPolicyDocument
 
 _CONFIG = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
 
@@ -20,7 +16,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-23.2"
+    assert doc.version == "2026-07-23.3"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -64,6 +60,11 @@ def test_single_share_exit_rule_is_provisional_shadow_only():
     assert rule.conditions.resistance_distance_pct_max == 15
     assert rule.conditions.resistance_source_family_min == 2
     assert rule.conditions.quote_max_age_seconds == 300
+    assert rule.conditions.resistance_max_age_seconds == 300
+    assert rule.conditions.holdings_max_age_seconds == 300
+    assert rule.conditions.open_orders_max_age_seconds == 300
+    assert rule.conditions.open_actions_max_age_seconds == 300
+    assert rule.conditions.captured_at_max_age_seconds == 300
     assert rule.conditions.snapshot_max_skew_seconds == 300
     assert rule.conditions.required_completed_bar_market == "XKRX"
     assert (
@@ -115,28 +116,10 @@ def test_single_share_exit_rule_requires_both_kis_and_toss_inventory():
         TradingPolicyDocument.model_validate(raw)
 
 
-def test_single_share_exit_input_contract_requires_target_and_complete_account_scope():
-    identity_fields = SingleShareExitTargetIdentity.model_fields
-    assert set(identity_fields) == {
-        "symbol",
-        "broker",
-        "broker_account_id",
-        "lot_id",
-    }
-    assert all(field.is_required() for field in identity_fields.values())
-    assert (
-        SingleShareExitEvidenceSnapshot.model_fields[
-            "broker_account_scope_complete"
-        ].annotation
-        == Literal[True]
-    )
-    with pytest.raises(ValidationError):
-        SingleShareExitTargetIdentity(
-            symbol="NAVER",
-            broker="toss",
-            broker_account_id="toss-main",
-            lot_id="lot-1",
-        )
+def test_raw_evidence_and_caller_completeness_contract_is_not_public():
+    assert not hasattr(policy_schema, "SingleShareExitEvidenceSnapshot")
+    assert not hasattr(policy_schema, "SingleShareExitBrokerAccountSnapshot")
+    assert not hasattr(policy_schema, "SingleShareExitTargetIdentity")
 
 
 def test_auto_approve_policy_has_conservative_market_caps():

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -772,10 +772,10 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "resting"
     assert refreshed.approved_by_telegram_user_id is None
-    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-23.1"
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-23.2"
     text, keyboard, _chat_id = notifier.sent_messages[0]
     assert "자동 접수됨" in text
-    assert "auto:policy@2026-07-23.1" in text
+    assert "auto:policy@2026-07-23.2" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
 

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -772,10 +772,10 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "resting"
     assert refreshed.approved_by_telegram_user_id is None
-    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-22.1"
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-23.1"
     text, keyboard, _chat_id = notifier.sent_messages[0]
     assert "자동 접수됨" in text
-    assert "auto:policy@2026-07-22.1" in text
+    assert "auto:policy@2026-07-23.1" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
 

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -772,10 +772,10 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "resting"
     assert refreshed.approved_by_telegram_user_id is None
-    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-23.2"
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-23.3"
     text, keyboard, _chat_id = notifier.sent_messages[0]
     assert "자동 접수됨" in text
-    assert "auto:policy@2026-07-23.2" in text
+    assert "auto:policy@2026-07-23.3" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
 

--- a/tests/services/test_single_share_exit_snapshot_service.py
+++ b/tests/services/test_single_share_exit_snapshot_service.py
@@ -423,7 +423,7 @@ def test_context_uses_private_exact_replay_type_with_derived_mode():
     assert not hasattr(context, "model_copy")
 
 
-def test_functional_copy_cannot_promote_replay_or_redeclare_derived_roster_hash():
+def test_functional_copy_does_not_promote_replay_or_redeclare_derived_roster_hash():
     replay = _make_context()
 
     with pytest.raises(TypeError):
@@ -450,7 +450,7 @@ def test_functional_copy_cannot_promote_replay_or_redeclare_derived_roster_hash(
     )
 
 
-def test_exact_type_boundary_rejects_subclass_and_blocks_class_swap():
+def test_exact_type_boundary_rejects_subclass_and_direct_differing_layout_swap():
     replay = _make_context()
     live = _make_context(live=True)
     replay_type = type(replay)
@@ -598,7 +598,7 @@ def test_snapshot_service_has_no_app_or_broker_import_reachability():
     assert not relative_imports
 
 
-def test_declared_roster_hash_forgery_is_rejected():
+def test_mismatched_declared_roster_hash_is_rejected():
     result = _replay_result(declared_roster_hash="0" * 64)
     assert (result.outcome, result.reason) == (
         "INELIGIBLE",
@@ -627,7 +627,7 @@ def test_roster_hash_canonical_compatibility_vector_is_unchanged():
     )
 
 
-def test_replay_clock_can_never_create_live_eligibility():
+def test_replay_clock_does_not_create_live_eligibility():
     old_clock = _CLOCK_AT - timedelta(days=1)
     old_evidence = _EVIDENCE_AT - timedelta(days=1)
     accounts = (
@@ -785,7 +785,7 @@ def test_non_executable_quote_kinds_fail_closed(kind, source):
     )
 
 
-def test_unknown_string_quote_source_cannot_form_typed_evidence():
+def test_unknown_string_quote_source_does_not_form_typed_evidence():
     with pytest.raises(ValueError, match="quote source must be typed"):
         TypedQuoteEvidence(
             symbol="257720",
@@ -937,7 +937,7 @@ def test_secondary_non_routable_retirement_lot_is_excluded_from_aggregate():
     assert result.symbol_routable_sellable_quantity == Decimal("1")
 
 
-def test_actual_total_quantity_over_one_cannot_pass_with_one_account_lot():
+def test_actual_total_quantity_over_one_fails_with_one_account_lot():
     roster = (
         _configured(KrBroker.KIS, "kis-main"),
         _configured(KrBroker.KIS, "kis-secondary"),
@@ -1335,7 +1335,7 @@ def test_far_band_exact_boundaries(resistance_price, expected):
     assert result.outcome == expected
 
 
-def test_public_policy_loader_never_returns_mutable_cached_singleton():
+def test_public_policy_loader_returns_detached_policy_copy():
     detached = policy.load_trading_policy()
     detached_rule = detached.decision_rules["sell.single_share_exit"]
     detached_rule.proposal.auto_approve = True
@@ -1398,7 +1398,7 @@ def test_exact_policy_safety_projection_is_rechecked(
     assert result.execution is None
 
 
-def test_unsafe_nested_proposal_never_leaks_auto_approval_metadata(
+def test_unsafe_nested_proposal_does_not_leak_auto_approval_metadata(
     monkeypatch,
 ):
     now = datetime.now(UTC)

--- a/tests/services/test_single_share_exit_snapshot_service.py
+++ b/tests/services/test_single_share_exit_snapshot_service.py
@@ -1,0 +1,1304 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import dataclasses
+import inspect
+import pickle
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+import app.schemas.trading_policy as policy_schema
+import app.services.single_share_exit_snapshot_service as snapshot_service
+from app.services import trading_policy_service as policy
+from app.services.single_share_exit_snapshot_service import (
+    BROKER_EVIDENCE_CAPABILITY,
+    MARKET_EVIDENCE_CAPABILITY,
+    OPEN_ACTION_CAPABILITY,
+    ROSTER_CAPABILITY,
+    AccountIdentity,
+    AccountKind,
+    AccountLotEvidence,
+    AuthoritativeAccountRoster,
+    BrokerAccountEvidence,
+    BrokerOpenOrderEvidence,
+    ConfiguredAccount,
+    KrBroker,
+    MarketEvidence,
+    OpenActionEvidence,
+    ProducerContextIntegrityError,
+    QuoteKind,
+    QuoteProvenance,
+    QuoteSource,
+    QuoteVenue,
+    ResistanceEvidence,
+    ResistanceStrength,
+    ScopedOpenActionsEvidence,
+    SingleShareExitReplayProducer,
+    SingleShareExitSnapshotProducer,
+    SingleShareExitTarget,
+    TypedQuoteEvidence,
+    ValidatedSingleShareExitContext,
+    compute_account_roster_hash,
+)
+
+_CLOCK_AT = datetime(2026, 7, 23, 6, 50, 30, tzinfo=UTC)  # 15:50:30 KST
+_EVIDENCE_AT = datetime(2026, 7, 23, 6, 50, 0, tzinfo=UTC)  # 15:50 KST
+_EXPECTED_KRX_BAR = date(2026, 7, 23)
+
+
+@pytest.fixture(autouse=True)
+def _stub_expected_completed_krx_bar(monkeypatch):
+    monkeypatch.setattr(
+        policy, "_expected_completed_krx_bar", lambda _now: _EXPECTED_KRX_BAR
+    )
+
+
+class _FixedClock:
+    def __init__(self, value: datetime):
+        self.value = value
+
+    def now(self) -> datetime:
+        return self.value
+
+
+class _RosterReader:
+    identity = "offline.authoritative_roster"
+    capability = ROSTER_CAPABILITY
+
+    def __init__(
+        self,
+        accounts: tuple[ConfiguredAccount, ...],
+        *,
+        declared_hash: str | None = None,
+    ):
+        self.accounts = accounts
+        self.declared_hash = declared_hash
+
+    async def read_configured_kr_accounts(self) -> AuthoritativeAccountRoster:
+        roster_id = "kr-live-routable-accounts"
+        roster_version = "2026-07-23T15:50:00+09:00"
+        roster_hash = self.declared_hash or compute_account_roster_hash(
+            roster_id=roster_id,
+            roster_version=roster_version,
+            read_model_identity=self.identity,
+            accounts=self.accounts,
+        )
+        return AuthoritativeAccountRoster(
+            roster_id=roster_id,
+            roster_version=roster_version,
+            roster_hash=roster_hash,
+            read_model_identity=self.identity,
+            read_model_capability=self.capability,
+            accounts=self.accounts,
+        )
+
+
+class _BrokerReader:
+    identity = "offline.exhaustive_broker_evidence"
+    capability = BROKER_EVIDENCE_CAPABILITY
+
+    def __init__(self, accounts: tuple[BrokerAccountEvidence, ...]):
+        self.accounts = accounts
+        self.requested_accounts: tuple[ConfiguredAccount, ...] | None = None
+
+    async def read_accounts(self, *, symbol, expected_accounts):
+        self.requested_accounts = expected_accounts
+        return self.accounts
+
+
+class _OpenActionReader:
+    identity = "offline.scoped_open_actions"
+    capability = OPEN_ACTION_CAPABILITY
+
+    def __init__(self, evidence: ScopedOpenActionsEvidence):
+        self.evidence = evidence
+        self.scope = None
+
+    async def read_open_actions(self, *, symbol, side, broker_account_id):
+        self.scope = (symbol, side, broker_account_id)
+        return self.evidence
+
+
+class _MarketReader:
+    identity = "offline.typed_market_evidence"
+    capability = MARKET_EVIDENCE_CAPABILITY
+
+    def __init__(self, evidence: MarketEvidence):
+        self.evidence = evidence
+
+    async def read_market_evidence(self, *, symbol):
+        assert self.evidence.quote.symbol == symbol
+        return self.evidence
+
+
+def _identity(broker: KrBroker, account_id: str) -> AccountIdentity:
+    return AccountIdentity(broker, account_id)
+
+
+def _configured(
+    broker: KrBroker,
+    account_id: str,
+    *,
+    routable: bool = True,
+    kind: AccountKind = AccountKind.TAXABLE,
+) -> ConfiguredAccount:
+    return ConfiguredAccount(
+        identity=_identity(broker, account_id),
+        account_kind=kind,
+        order_routable=routable,
+    )
+
+
+def _lot(
+    *,
+    symbol: str = "257720",
+    lot_id: str = "target-lot",
+    quantity: str = "1",
+    average_cost: str = "31800",
+) -> AccountLotEvidence:
+    return AccountLotEvidence(
+        symbol=symbol,
+        lot_id=lot_id,
+        sellable_quantity=Decimal(quantity),
+        average_cost=Decimal(average_cost),
+    )
+
+
+def _account(
+    broker: KrBroker,
+    account_id: str,
+    *,
+    lots: tuple[AccountLotEvidence, ...] = (),
+    orders: tuple[BrokerOpenOrderEvidence, ...] = (),
+    holdings_at: datetime = _EVIDENCE_AT,
+    orders_at: datetime = _EVIDENCE_AT,
+) -> BrokerAccountEvidence:
+    return BrokerAccountEvidence(
+        identity=_identity(broker, account_id),
+        holdings_observed_at=holdings_at,
+        lots=lots,
+        open_orders_observed_at=orders_at,
+        open_orders=orders,
+    )
+
+
+def _firm_quote(
+    *,
+    symbol: str = "257720",
+    price: str = "36450",
+    observed_at: datetime = _EVIDENCE_AT,
+    venue: QuoteVenue = QuoteVenue.NXT,
+) -> TypedQuoteEvidence:
+    return TypedQuoteEvidence(
+        symbol=symbol,
+        venue=venue,
+        quote_kind=QuoteKind.BROKER_LAST_TRADE,
+        source=QuoteSource.KIS_BROKER,
+        observed_at=observed_at,
+        executable=True,
+        firm=True,
+        last_price=Decimal(price),
+        last_provenance=QuoteProvenance.VENUE_LAST_TRADE,
+    )
+
+
+def _resistance(
+    *,
+    symbol: str = "257720",
+    price: str = "39946.31",
+    sources: tuple[str, ...] = ("bb_upper", "fib_50"),
+    computed_at: datetime = _EVIDENCE_AT,
+) -> ResistanceEvidence:
+    return ResistanceEvidence(
+        symbol=symbol,
+        price=Decimal(price),
+        sources=sources,
+        strength=ResistanceStrength.WEAK,
+        computed_at=computed_at,
+        ohlcv_through_date=_EXPECTED_KRX_BAR,
+    )
+
+
+def _default_roster() -> tuple[ConfiguredAccount, ...]:
+    return (
+        _configured(KrBroker.KIS, "kis-main"),
+        _configured(KrBroker.TOSS, "toss-main"),
+    )
+
+
+def _default_accounts(
+    *,
+    target_broker: KrBroker = KrBroker.TOSS,
+    target_account_id: str = "toss-main",
+    symbol: str = "257720",
+    average_cost: str = "31800",
+) -> tuple[BrokerAccountEvidence, ...]:
+    target_lot = _lot(symbol=symbol, average_cost=average_cost)
+    return (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            lots=(target_lot,) if target_broker is KrBroker.KIS else (),
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(target_lot,) if target_broker is KrBroker.TOSS else (),
+        ),
+    )
+
+
+def _make_context(
+    *,
+    symbol: str = "257720",
+    target_broker: KrBroker = KrBroker.TOSS,
+    target_account_id: str = "toss-main",
+    target_lot_id: str = "target-lot",
+    roster: tuple[ConfiguredAccount, ...] | None = None,
+    accounts: tuple[BrokerAccountEvidence, ...] | None = None,
+    quote: TypedQuoteEvidence | None = None,
+    resistance: ResistanceEvidence | None | object = ...,
+    actions: tuple[OpenActionEvidence, ...] = (),
+    actions_at: datetime = _EVIDENCE_AT,
+    clock_at: datetime = _CLOCK_AT,
+    declared_roster_hash: str | None = None,
+    live: bool = False,
+) -> ValidatedSingleShareExitContext:
+    configured_accounts = roster or _default_roster()
+    broker_accounts = accounts or _default_accounts(
+        target_broker=target_broker,
+        target_account_id=target_account_id,
+        symbol=symbol,
+    )
+    quote_evidence = quote or _firm_quote(symbol=symbol)
+    resistance_evidence = (
+        _resistance(symbol=symbol) if resistance is ... else resistance
+    )
+    roster_reader = _RosterReader(
+        configured_accounts,
+        declared_hash=declared_roster_hash,
+    )
+    broker_reader = _BrokerReader(broker_accounts)
+    open_action_reader = _OpenActionReader(
+        ScopedOpenActionsEvidence(observed_at=actions_at, actions=actions)
+    )
+    market_reader = _MarketReader(
+        MarketEvidence(
+            quote=quote_evidence,
+            resistance=resistance_evidence,
+        )
+    )
+    producer_args = {
+        "roster_reader": roster_reader,
+        "broker_reader": broker_reader,
+        "open_action_reader": open_action_reader,
+        "market_reader": market_reader,
+    }
+    if live:
+        producer = SingleShareExitSnapshotProducer(**producer_args)
+    else:
+        producer = SingleShareExitReplayProducer(
+            **producer_args,
+            replay_clock=_FixedClock(clock_at),
+        )
+    target = SingleShareExitTarget(
+        symbol=symbol,
+        broker=target_broker,
+        broker_account_id=target_account_id,
+        lot_id=target_lot_id,
+    )
+    return asyncio.run(producer.produce(target=target))
+
+
+def _replay_result(**kwargs):
+    return policy.evaluate_single_share_exit_replay(_make_context(**kwargs))
+
+
+def test_raw_public_construction_and_completeness_flags_are_removed():
+    assert not hasattr(policy_schema, "SingleShareExitEvidenceSnapshot")
+    assert (
+        "evaluated_at"
+        not in inspect.signature(policy.evaluate_single_share_exit).parameters
+    )
+    assert (
+        "evaluated_at"
+        not in inspect.signature(policy.evaluate_single_share_exit_replay).parameters
+    )
+
+
+def test_producer_enumerates_exact_roster_and_scopes_open_actions():
+    roster = (
+        _configured(KrBroker.KIS, "kis-main"),
+        _configured(KrBroker.KIS, "kis-secondary"),
+        _configured(KrBroker.TOSS, "toss-main"),
+    )
+    broker_reader = _BrokerReader(
+        (
+            _account(KrBroker.KIS, "kis-main"),
+            _account(KrBroker.KIS, "kis-secondary"),
+            _account(KrBroker.TOSS, "toss-main", lots=(_lot(),)),
+        )
+    )
+    open_reader = _OpenActionReader(
+        ScopedOpenActionsEvidence(observed_at=_EVIDENCE_AT, actions=())
+    )
+    roster_reader = _RosterReader(roster)
+    producer = SingleShareExitReplayProducer(
+        roster_reader=roster_reader,
+        broker_reader=broker_reader,
+        open_action_reader=open_reader,
+        market_reader=_MarketReader(
+            MarketEvidence(quote=_firm_quote(), resistance=_resistance())
+        ),
+        replay_clock=_FixedClock(_CLOCK_AT),
+    )
+    context = asyncio.run(
+        producer.produce(
+            target=SingleShareExitTarget(
+                "257720", KrBroker.TOSS, "toss-main", "target-lot"
+            )
+        )
+    )
+
+    assert broker_reader.requested_accounts == roster
+    assert open_reader.scope == ("257720", "sell", "toss-main")
+    assert context.expected_account_identities == (
+        _identity(KrBroker.KIS, "kis-main"),
+        _identity(KrBroker.KIS, "kis-secondary"),
+        _identity(KrBroker.TOSS, "toss-main"),
+    )
+    assert context.expected_account_identities == context.observed_account_identities
+    assert context.roster_hash == context.derived_roster_hash
+    assert context.producer_capability
+
+
+def test_omitted_account_cannot_claim_complete():
+    roster = (
+        _configured(KrBroker.KIS, "kis-main"),
+        _configured(KrBroker.KIS, "kis-secondary"),
+        _configured(KrBroker.TOSS, "toss-main"),
+    )
+    observed = (
+        _account(KrBroker.KIS, "kis-main"),
+        _account(KrBroker.TOSS, "toss-main", lots=(_lot(),)),
+    )
+    result = _replay_result(roster=roster, accounts=observed)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "expected_observed_account_roster_mismatch",
+    )
+    assert result.expected_account_identities == (
+        "kis:kis-main",
+        "kis:kis-secondary",
+        "toss:toss-main",
+    )
+    assert result.observed_account_identities == ("kis:kis-main", "toss:toss-main")
+
+
+def test_model_copy_or_dataclass_replace_cannot_forge_roster():
+    context = _make_context()
+    assert not hasattr(context, "model_copy")
+    with pytest.raises(TypeError, match="dataclass instances"):
+        dataclasses.replace(
+            context,
+            expected_account_identities=context.expected_account_identities[:-1],
+        )
+
+
+def test_claude_public_seal_recalculation_poc_has_no_issuance_material():
+    for removed_name in (
+        "_CONTEXT_CAPABILITY",
+        "_CONTEXT_SEAL_KEY",
+        "_context_seal",
+    ):
+        assert not hasattr(snapshot_service, removed_name)
+
+    configured_accounts = _default_roster()
+    identities = tuple(account.identity for account in configured_accounts)
+    roster_hash = compute_account_roster_hash(
+        roster_id="caller-forged-roster",
+        roster_version="caller-forged-v1",
+        read_model_identity="caller.forged_roster",
+        accounts=configured_accounts,
+    )
+    public_values = {
+        "snapshot_id": "caller-forged-without-producer",
+        "market": "kr",
+        "captured_at": _CLOCK_AT,
+        "produced_at": _CLOCK_AT,
+        "mode": snapshot_service.ContextMode.REPLAY,
+        "target": SingleShareExitTarget(
+            "257720", KrBroker.TOSS, "toss-main", "target-lot"
+        ),
+        "roster_id": "caller-forged-roster",
+        "roster_version": "caller-forged-v1",
+        "roster_hash": roster_hash,
+        "derived_roster_hash": roster_hash,
+        "roster_read_model_identity": "caller.forged_roster",
+        "roster_read_model_capability": ROSTER_CAPABILITY,
+        "expected_account_identities": identities,
+        "observed_account_identities": identities,
+        "configured_accounts": configured_accounts,
+        "accounts": _default_accounts(),
+        "quote": _firm_quote(),
+        "resistance": _resistance(),
+        "open_actions": ScopedOpenActionsEvidence(_EVIDENCE_AT, ()),
+        "producer_identity": snapshot_service.PRODUCER_IDENTITY,
+        "producer_capability": snapshot_service.PRODUCER_CAPABILITY,
+        "reader_identities": (
+            "caller.forged_roster",
+            "caller.forged_broker",
+            "caller.forged_actions",
+            "caller.forged_market",
+        ),
+        "reader_capabilities": (
+            ROSTER_CAPABILITY,
+            BROKER_EVIDENCE_CAPABILITY,
+            OPEN_ACTION_CAPABILITY,
+            MARKET_EVIDENCE_CAPABILITY,
+        ),
+    }
+
+    with pytest.raises(TypeError, match="Protocols cannot be instantiated"):
+        ValidatedSingleShareExitContext(
+            **public_values,
+            _issuer_capability=object(),
+            _seal="caller-self-computed",
+        )
+    forged_namespace = SimpleNamespace(**public_values)
+    result = policy.evaluate_single_share_exit_replay(forged_namespace)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "unvalidated_producer_context",
+    )
+
+
+def test_only_exact_producer_issued_object_identity_is_accepted():
+    context = _make_context()
+    context_type = type(context)
+
+    with pytest.raises(ProducerContextIntegrityError, match="producer-only"):
+        context_type(object())
+
+    forged_by_object_new = object.__new__(context_type)
+    result = policy.evaluate_single_share_exit_replay(forged_by_object_new)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "unvalidated_producer_context",
+    )
+
+    with pytest.raises(TypeError, match="cannot be subclassed"):
+
+        class _ForgedSubclass(context_type):
+            pass
+
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.copy(context)
+    with pytest.raises(TypeError, match="cannot be deep-copied"):
+        copy.deepcopy(context)
+    with pytest.raises(TypeError, match="cannot be pickled"):
+        pickle.dumps(context)
+
+
+def test_every_exposed_context_property_revalidates_issued_state():
+    public_properties = (
+        *ValidatedSingleShareExitContext.__annotations__,
+        "roster_is_exact",
+    )
+    for property_name in public_properties:
+        context = _make_context()
+        issued_target = context.target
+        object.__setattr__(issued_target, "symbol", "000000")
+
+        with pytest.raises(
+            ProducerContextIntegrityError,
+            match="state changed after issuance",
+        ):
+            getattr(context, property_name)
+        assert snapshot_service.is_validated_context(context) is False
+
+
+def test_declared_roster_hash_forgery_is_rejected():
+    result = _replay_result(declared_roster_hash="0" * 64)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "account_roster_hash_mismatch",
+    )
+
+
+def test_replay_clock_can_never_create_live_eligibility():
+    old_clock = _CLOCK_AT - timedelta(days=1)
+    old_evidence = _EVIDENCE_AT - timedelta(days=1)
+    accounts = (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            holdings_at=old_evidence,
+            orders_at=old_evidence,
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(_lot(),),
+            holdings_at=old_evidence,
+            orders_at=old_evidence,
+        ),
+    )
+    context = _make_context(
+        accounts=accounts,
+        quote=_firm_quote(observed_at=old_evidence),
+        resistance=_resistance(computed_at=old_evidence),
+        actions_at=old_evidence,
+        clock_at=old_clock,
+    )
+    assert policy.evaluate_single_share_exit_replay(context).outcome == (
+        "REPLAY_ELIGIBLE"
+    )
+    live_result = policy.evaluate_single_share_exit(context)
+    assert (live_result.outcome, live_result.reason) == (
+        "INELIGIBLE",
+        "replay_context_not_live",
+    )
+    with pytest.raises(TypeError):
+        policy.evaluate_single_share_exit(context, evaluated_at=old_clock)  # type: ignore[call-arg]
+
+
+def test_pairwise_600_second_endpoint_skew_is_rejected():
+    oldest = _CLOCK_AT - timedelta(seconds=600)
+    accounts = (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            holdings_at=oldest,
+            orders_at=oldest,
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(_lot(),),
+            holdings_at=oldest,
+            orders_at=oldest,
+        ),
+    )
+    result = _replay_result(
+        accounts=accounts,
+        quote=_firm_quote(observed_at=_CLOCK_AT),
+        resistance=_resistance(computed_at=_CLOCK_AT),
+        actions_at=_CLOCK_AT - timedelta(seconds=300),
+    )
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "snapshot_pairwise_skew_exceeded",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_reason"),
+    [
+        ("quote", "stale_quote"),
+        ("resistance", "stale_resistance"),
+        ("holdings", "stale_holdings"),
+        ("open_orders", "stale_open_orders"),
+        ("open_actions", "stale_open_actions"),
+    ],
+)
+def test_each_evidence_kind_has_wall_clock_age_limit(
+    field,
+    expected_reason,
+    monkeypatch,
+):
+    doc = policy.load_trading_policy()
+    rule = doc.decision_rules["sell.single_share_exit"]
+    widened_conditions = rule.conditions.model_copy(
+        update={"snapshot_max_skew_seconds": 600}
+    )
+    widened_rule = rule.model_copy(update={"conditions": widened_conditions})
+    monkeypatch.setattr(
+        policy,
+        "load_trading_policy",
+        lambda: doc.model_copy(
+            update={
+                "decision_rules": {
+                    **doc.decision_rules,
+                    "sell.single_share_exit": widened_rule,
+                }
+            }
+        ),
+    )
+    stale = _CLOCK_AT - timedelta(seconds=301)
+    fresh = _CLOCK_AT - timedelta(seconds=1)
+    quote = _firm_quote(observed_at=stale if field == "quote" else fresh)
+    resistance = _resistance(computed_at=stale if field == "resistance" else fresh)
+    accounts = (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            holdings_at=stale if field == "holdings" else fresh,
+            orders_at=stale if field == "open_orders" else fresh,
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(_lot(),),
+            holdings_at=stale if field == "holdings" else fresh,
+            orders_at=stale if field == "open_orders" else fresh,
+        ),
+    )
+    result = _replay_result(
+        accounts=accounts,
+        quote=quote,
+        resistance=resistance,
+        actions_at=stale if field == "open_actions" else fresh,
+    )
+    assert (result.outcome, result.reason) == ("INELIGIBLE", expected_reason)
+
+
+@pytest.mark.parametrize(
+    ("kind", "source"),
+    [
+        (QuoteKind.NXT_EXPECTED_PRICE, QuoteSource.NXT_EXPECTED_MODEL),
+        (QuoteKind.PREVIOUS_CLOSE_ECHO, QuoteSource.PREVIOUS_CLOSE),
+        (QuoteKind.INDICATIVE_ONLY, QuoteSource.INDICATIVE_MODEL),
+    ],
+)
+def test_non_executable_quote_kinds_fail_closed(kind, source):
+    quote = TypedQuoteEvidence(
+        symbol="257720",
+        venue=QuoteVenue.NXT,
+        quote_kind=kind,
+        source=source,
+        observed_at=_EVIDENCE_AT,
+        executable=False,
+        firm=False,
+        last_price=Decimal("36450"),
+        last_provenance=(
+            QuoteProvenance.PREVIOUS_CLOSE
+            if kind is QuoteKind.PREVIOUS_CLOSE_ECHO
+            else QuoteProvenance.INDICATIVE_MODEL
+        ),
+    )
+    result = _replay_result(quote=quote)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "quote_quality_not_executable",
+    )
+
+
+def test_unknown_string_quote_source_cannot_form_typed_evidence():
+    with pytest.raises(ValueError, match="quote source must be typed"):
+        TypedQuoteEvidence(
+            symbol="257720",
+            venue=QuoteVenue.NXT,
+            quote_kind=QuoteKind.BROKER_LAST_TRADE,
+            source="unknown",  # type: ignore[arg-type]
+            observed_at=_EVIDENCE_AT,
+            executable=True,
+            firm=True,
+            last_price=Decimal("36450"),
+            last_provenance=QuoteProvenance.VENUE_LAST_TRADE,
+        )
+
+
+def test_two_sided_live_orderbook_mid_is_executable():
+    quote = TypedQuoteEvidence(
+        symbol="257720",
+        venue=QuoteVenue.NXT,
+        quote_kind=QuoteKind.LIVE_ORDERBOOK_MID,
+        source=QuoteSource.TOSS_BROKER,
+        observed_at=_EVIDENCE_AT,
+        executable=True,
+        firm=True,
+        bid_price=Decimal("36400"),
+        ask_price=Decimal("36500"),
+        bid_provenance=QuoteProvenance.VENUE_BEST_BID,
+        ask_provenance=QuoteProvenance.VENUE_BEST_ASK,
+    )
+    result = _replay_result(quote=quote)
+    assert result.outcome == "REPLAY_ELIGIBLE"
+    assert result.current_quote == Decimal("36450")
+
+
+def test_no_resistance_reference_is_ineligible():
+    result = _replay_result(resistance=None)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "no_resistance_reference",
+    )
+
+
+def test_resistance_must_cover_expected_completed_krx_bar():
+    resistance = ResistanceEvidence(
+        symbol="257720",
+        price=Decimal("39946.31"),
+        sources=("bb_upper", "fib_50"),
+        strength=ResistanceStrength.WEAK,
+        computed_at=_EVIDENCE_AT,
+        ohlcv_through_date=date(2026, 7, 22),
+    )
+    result = _replay_result(resistance=resistance)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "ohlcv_not_through_expected_completed_krx_bar",
+    )
+    assert result.expected_completed_krx_bar_date == _EXPECTED_KRX_BAR
+
+
+def test_same_symbol_broker_open_order_defers():
+    pending = BrokerOpenOrderEvidence("pending-1", "257720", "buy")
+    accounts = (
+        _account(KrBroker.KIS, "kis-main", orders=(pending,)),
+        _account(KrBroker.TOSS, "toss-main", lots=(_lot(),)),
+    )
+    result = _replay_result(accounts=accounts)
+    assert (result.outcome, result.reason) == (
+        "DEFER",
+        "same_symbol_broker_open_order",
+    )
+
+
+def test_scoped_open_action_defers_and_scope_is_exact():
+    action = OpenActionEvidence(
+        "2fd4fa42",
+        "257720",
+        "sell",
+        "toss-main",
+        "open",
+    )
+    result = _replay_result(actions=(action,))
+    assert (result.outcome, result.reason) == (
+        "DEFER",
+        "unresolved_scoped_open_action",
+    )
+
+
+def test_target_non_routable_is_ineligible():
+    roster = (
+        _configured(KrBroker.KIS, "kis-main"),
+        _configured(KrBroker.TOSS, "toss-main"),
+        _configured(
+            KrBroker.TOSS,
+            "toss-isa",
+            routable=False,
+            kind=AccountKind.ISA,
+        ),
+    )
+    accounts = (
+        _account(KrBroker.KIS, "kis-main"),
+        _account(KrBroker.TOSS, "toss-main"),
+        _account(KrBroker.TOSS, "toss-isa", lots=(_lot(),)),
+    )
+    result = _replay_result(
+        target_account_id="toss-isa",
+        roster=roster,
+        accounts=accounts,
+    )
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "target_account_not_routable",
+    )
+
+
+def test_secondary_non_routable_retirement_lot_is_excluded_from_aggregate():
+    roster = (
+        _configured(KrBroker.KIS, "kis-main"),
+        _configured(KrBroker.TOSS, "toss-main"),
+        _configured(
+            KrBroker.KIS,
+            "kis-retirement",
+            routable=False,
+            kind=AccountKind.RETIREMENT,
+        ),
+    )
+    accounts = (
+        _account(KrBroker.KIS, "kis-main"),
+        _account(KrBroker.TOSS, "toss-main", lots=(_lot(),)),
+        _account(
+            KrBroker.KIS,
+            "kis-retirement",
+            lots=(_lot(lot_id="retirement-lot", quantity="99"),),
+        ),
+    )
+    result = _replay_result(roster=roster, accounts=accounts)
+    assert result.outcome == "REPLAY_ELIGIBLE"
+    assert result.symbol_routable_sellable_quantity == Decimal("1")
+
+
+def test_actual_total_quantity_over_one_cannot_pass_with_one_account_lot():
+    roster = (
+        _configured(KrBroker.KIS, "kis-main"),
+        _configured(KrBroker.KIS, "kis-secondary"),
+        _configured(KrBroker.TOSS, "toss-main"),
+    )
+    omitted_secondary = (
+        _account(KrBroker.KIS, "kis-main"),
+        _account(KrBroker.TOSS, "toss-main", lots=(_lot(),)),
+    )
+    omitted_result = _replay_result(roster=roster, accounts=omitted_secondary)
+    assert omitted_result.reason == "expected_observed_account_roster_mismatch"
+
+    exhaustive = (
+        _account(KrBroker.KIS, "kis-main"),
+        _account(
+            KrBroker.KIS,
+            "kis-secondary",
+            lots=(_lot(lot_id="secondary", quantity="3"),),
+        ),
+        _account(KrBroker.TOSS, "toss-main", lots=(_lot(),)),
+    )
+    exhaustive_result = _replay_result(roster=roster, accounts=exhaustive)
+    assert (exhaustive_result.outcome, exhaustive_result.reason) == (
+        "INELIGIBLE",
+        "symbol_routable_sellable_quantity_not_one",
+    )
+    assert exhaustive_result.symbol_routable_sellable_quantity == Decimal("4")
+
+
+@pytest.mark.parametrize(
+    (
+        "symbol",
+        "average_cost",
+        "quote_price",
+        "resistance_price",
+        "sources",
+        "expected_profit",
+        "expected_distance",
+        "expected_outcome",
+        "expected_reason",
+    ),
+    [
+        (
+            "257720",
+            "31800",
+            "36450",
+            "39946.31",
+            ("bb_upper", "fib_50"),
+            "14.6226",
+            "9.5921",
+            "REPLAY_ELIGIBLE",
+            "replay_candidate_no_live_eligibility",
+        ),
+        (
+            "042660",
+            "78800",
+            "89400",
+            "100548.9",
+            ("fib_38.2", "volume_value_area_low"),
+            "13.4518",
+            "12.4708",
+            "REPLAY_ELIGIBLE",
+            "replay_candidate_no_live_eligibility",
+        ),
+        (
+            "086790",
+            "117000",
+            "130500",
+            "142264.52",
+            ("bb_upper", "fib_0"),
+            "11.5385",
+            "9.0150",
+            "REPLAY_ELIGIBLE",
+            "replay_candidate_no_live_eligibility",
+        ),
+        (
+            "035420",
+            "197900",
+            "220000",
+            "242550",
+            ("fib_50",),
+            "11.1673",
+            "10.2500",
+            "INELIGIBLE",
+            "insufficient_independent_resistance_families",
+        ),
+    ],
+)
+def test_synthetic_firm_quotes_exact_decimal_far_band_and_family_normalization(
+    symbol,
+    average_cost,
+    quote_price,
+    resistance_price,
+    sources,
+    expected_profit,
+    expected_distance,
+    expected_outcome,
+    expected_reason,
+):
+    accounts = _default_accounts(symbol=symbol, average_cost=average_cost)
+    result = _replay_result(
+        symbol=symbol,
+        accounts=accounts,
+        quote=_firm_quote(symbol=symbol, price=quote_price),
+        resistance=_resistance(
+            symbol=symbol,
+            price=resistance_price,
+            sources=sources,
+        ),
+    )
+    assert (result.outcome, result.reason) == (expected_outcome, expected_reason)
+    assert result.average_cost == Decimal(average_cost)
+    assert result.current_quote == Decimal(quote_price)
+    assert result.symbol_routable_sellable_quantity == Decimal("1")
+    assert result.profit_pct == Decimal(expected_profit)
+    assert result.resistance_distance_pct == Decimal(expected_distance)
+
+
+def test_operational_1550_nxt_evidence_is_quote_quality_rejected_exactly():
+    fixtures = (
+        (
+            "257720",
+            KrBroker.TOSS,
+            "31800",
+            "36450",
+            "39946.31",
+            ("bb_upper", "fib_50"),
+            (
+                _account(
+                    KrBroker.KIS,
+                    "kis-main",
+                    lots=(
+                        _lot(
+                            lot_id="kis-lot",
+                            quantity="5",
+                            average_cost="35000",
+                        ),
+                    ),
+                ),
+                _account(
+                    KrBroker.TOSS,
+                    "toss-main",
+                    lots=(_lot(quantity="1", average_cost="31800"),),
+                ),
+            ),
+            (),
+        ),
+        (
+            "042660",
+            KrBroker.TOSS,
+            "78800",
+            "89400",
+            "100548.9",
+            ("fib_38.2", "volume_value_area_low"),
+            (
+                _account(KrBroker.KIS, "kis-main"),
+                _account(
+                    KrBroker.TOSS,
+                    "toss-main",
+                    lots=(
+                        _lot(
+                            symbol="042660",
+                            quantity="1",
+                            average_cost="78800",
+                        ),
+                    ),
+                ),
+            ),
+            (),
+        ),
+        (
+            "086790",
+            KrBroker.KIS,
+            "117000",
+            "130500",
+            "142264.52",
+            ("bb_upper", "fib_0"),
+            (
+                _account(
+                    KrBroker.KIS,
+                    "kis-main",
+                    lots=(
+                        _lot(
+                            symbol="086790",
+                            quantity="1",
+                            average_cost="117000",
+                        ),
+                    ),
+                ),
+                _account(KrBroker.TOSS, "toss-main"),
+            ),
+            (
+                OpenActionEvidence(
+                    "2fd4fa42",
+                    "086790",
+                    "sell",
+                    "kis-main",
+                    "open",
+                ),
+            ),
+        ),
+        (
+            "035420",
+            KrBroker.TOSS,
+            "197900",
+            "220000",
+            "242550",
+            ("fib_50",),
+            (
+                _account(
+                    KrBroker.KIS,
+                    "kis-main",
+                    lots=(
+                        _lot(
+                            symbol="035420",
+                            lot_id="kis-lot",
+                            quantity="3",
+                            average_cost="241500",
+                        ),
+                    ),
+                ),
+                _account(
+                    KrBroker.TOSS,
+                    "toss-main",
+                    lots=(
+                        _lot(
+                            symbol="035420",
+                            quantity="1",
+                            average_cost="197900",
+                        ),
+                    ),
+                ),
+            ),
+            (),
+        ),
+    )
+    for (
+        symbol,
+        target_broker,
+        average_cost,
+        quote_price,
+        resistance_price,
+        sources,
+        accounts,
+        actions,
+    ) in fixtures:
+        quote = TypedQuoteEvidence(
+            symbol=symbol,
+            venue=QuoteVenue.NXT,
+            quote_kind=QuoteKind.NXT_EXPECTED_PRICE,
+            source=QuoteSource.NXT_EXPECTED_MODEL,
+            observed_at=_EVIDENCE_AT,
+            executable=False,
+            firm=False,
+            last_price=Decimal(quote_price),
+            last_provenance=QuoteProvenance.INDICATIVE_MODEL,
+        )
+        context = _make_context(
+            symbol=symbol,
+            target_broker=target_broker,
+            target_account_id=(
+                "kis-main" if target_broker is KrBroker.KIS else "toss-main"
+            ),
+            accounts=accounts,
+            quote=quote,
+            resistance=_resistance(
+                symbol=symbol,
+                price=resistance_price,
+                sources=sources,
+            ),
+            actions=actions,
+        )
+        result = policy.evaluate_single_share_exit_replay(context)
+        assert (result.outcome, result.reason) == (
+            "INELIGIBLE",
+            "quote_quality_not_executable",
+        )
+        target_account = next(
+            account
+            for account in context.accounts
+            if account.identity == context.target.account_identity
+        )
+        target_lot = next(
+            lot for lot in target_account.lots if lot.lot_id == "target-lot"
+        )
+        assert target_lot.average_cost == Decimal(average_cost)
+        assert target_lot.sellable_quantity == Decimal("1")
+        assert result.quote_kind == "nxt_expected_price"
+        assert result.quote_source == "nxt_expected_model"
+        assert result.quote_observed_at == _EVIDENCE_AT
+        assert result.profit_pct is None
+        assert result.resistance_distance_pct is None
+
+
+def test_257720_authoritative_toss_one_plus_kis_five_is_quantity_six():
+    accounts = (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            lots=(_lot(lot_id="kis-lot", quantity="5", average_cost="35000"),),
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(_lot(quantity="1", average_cost="31800"),),
+        ),
+    )
+    result = _replay_result(accounts=accounts)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "symbol_routable_sellable_quantity_not_one",
+    )
+    assert result.symbol_routable_sellable_quantity == Decimal("6")
+
+
+def test_naver_authoritative_toss_one_plus_kis_three_is_quantity_four():
+    accounts = (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            lots=(
+                _lot(
+                    symbol="035420",
+                    lot_id="kis-lot",
+                    quantity="3",
+                    average_cost="241500",
+                ),
+            ),
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(
+                _lot(
+                    symbol="035420",
+                    quantity="1",
+                    average_cost="197900",
+                ),
+            ),
+        ),
+    )
+    result = _replay_result(
+        symbol="035420",
+        accounts=accounts,
+        quote=_firm_quote(symbol="035420", price="220000"),
+        resistance=_resistance(
+            symbol="035420",
+            price="242550",
+            sources=("fib_50",),
+        ),
+    )
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "symbol_routable_sellable_quantity_not_one",
+    )
+    assert result.symbol_routable_sellable_quantity == Decimal("4")
+
+
+def test_loss_guard_is_decimal_and_separate():
+    accounts = _default_accounts(average_cost="100000")
+    result = _replay_result(
+        accounts=accounts,
+        quote=_firm_quote(price="100999.9999"),
+        resistance=_resistance(price="112000"),
+    )
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "loss_guard_not_met",
+    )
+    assert result.average_cost == Decimal("100000")
+    assert result.current_quote == Decimal("100999.9999")
+
+
+def test_multiple_fibonacci_sources_normalize_to_one_independent_family():
+    result = _replay_result(
+        resistance=_resistance(sources=("fib_0", "fib_38.2", "fib_50"))
+    )
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "insufficient_independent_resistance_families",
+    )
+    assert result.normalized_source_families == ("FIBONACCI",)
+
+
+@pytest.mark.parametrize(
+    ("resistance_price", "expected"),
+    [
+        ("38637", "INELIGIBLE"),  # exactly +6%, exclusive
+        ("41917.5", "REPLAY_ELIGIBLE"),  # exactly +15%, inclusive
+        ("41917.5001", "INELIGIBLE"),
+    ],
+)
+def test_far_band_exact_boundaries(resistance_price, expected):
+    result = _replay_result(resistance=_resistance(price=resistance_price))
+    assert result.outcome == expected
+
+
+def test_activation_and_proposal_off_are_rechecked(monkeypatch):
+    context = _make_context()
+    doc = policy.load_trading_policy()
+    rule = doc.decision_rules["sell.single_share_exit"]
+    bypassed = rule.model_copy(update={"proposal_enabled": True})
+    monkeypatch.setattr(
+        policy,
+        "load_trading_policy",
+        lambda: doc.model_copy(
+            update={
+                "decision_rules": {
+                    **doc.decision_rules,
+                    "sell.single_share_exit": bypassed,
+                }
+            }
+        ),
+    )
+    result = policy.evaluate_single_share_exit_replay(context)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "policy_not_shadow_off",
+    )
+    assert result.candidate_action is None
+
+
+def test_live_producer_uses_internal_clock_and_remains_shadow_off(monkeypatch):
+    now = datetime.now(UTC)
+    expected_date = now.date()
+    monkeypatch.setattr(
+        policy, "_expected_completed_krx_bar", lambda _now: expected_date
+    )
+    accounts = (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            holdings_at=now,
+            orders_at=now,
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(_lot(),),
+            holdings_at=now,
+            orders_at=now,
+        ),
+    )
+    context = _make_context(
+        accounts=accounts,
+        quote=_firm_quote(observed_at=now),
+        resistance=ResistanceEvidence(
+            symbol="257720",
+            price=Decimal("39946.31"),
+            sources=("bb_upper", "fib_50"),
+            strength=ResistanceStrength.WEAK,
+            computed_at=now,
+            ohlcv_through_date=expected_date,
+        ),
+        actions_at=now,
+        live=True,
+    )
+    result = policy.evaluate_single_share_exit(context)
+    assert result.outcome == "SHADOW_ELIGIBLE"
+    assert result.outcome != "PROPOSE"
+    assert result.proposal_enabled is False
+    assert result.candidate_action == "propose_full_account_lot_exit"
+    assert result.sizing == "full_account_lot_exit"
+    assert result.approval == "telegram_manual"
+    assert result.auto_approve is False
+    assert result.execution == "proposal_only"
+
+
+def test_unsealed_raw_context_construction_is_fail_closed():
+    result = policy.evaluate_single_share_exit(SimpleNamespace())
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "unvalidated_producer_context",
+    )

--- a/tests/services/test_single_share_exit_snapshot_service.py
+++ b/tests/services/test_single_share_exit_snapshot_service.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import copy
 import inspect
+from dataclasses import fields, replace
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -12,6 +14,7 @@ import pytest
 
 import app.schemas.trading_policy as policy_schema
 import app.services.single_share_exit_snapshot_service as snapshot_service
+from app.schemas.trading_policy import TradingPolicyDocument
 from app.services import trading_policy_service as policy
 from app.services.single_share_exit_snapshot_service import (
     BROKER_EVIDENCE_CAPABILITY,
@@ -317,6 +320,17 @@ def _replay_result(**kwargs):
     return policy.evaluate_single_share_exit_replay(_make_context(**kwargs))
 
 
+def _with_single_share_rule(doc, rule):
+    return doc.model_copy(
+        update={
+            "decision_rules": {
+                **doc.decision_rules,
+                "sell.single_share_exit": rule,
+            }
+        }
+    )
+
+
 def test_raw_public_construction_and_completeness_flags_are_removed():
     assert not hasattr(policy_schema, "SingleShareExitEvidenceSnapshot")
     assert (
@@ -398,11 +412,111 @@ def test_omitted_account_cannot_claim_complete():
     assert result.observed_account_identities == ("kis:kis-main", "toss:toss-main")
 
 
-def test_context_uses_private_concrete_type_and_isinstance_boundary():
+def test_context_uses_private_exact_replay_type_with_derived_mode():
     context = _make_context()
-    assert type(context).__name__ == "_ValidatedSingleShareExitContext"
+    assert type(context).__name__ == "_ValidatedReplaySingleShareExitContext"
     assert snapshot_service.is_validated_context(context) is True
+    assert snapshot_service.is_validated_replay_context(context) is True
+    assert snapshot_service.is_validated_live_context(context) is False
+    assert context.mode is snapshot_service.ContextMode.REPLAY
+    assert "mode" not in {field.name for field in fields(context)}
     assert not hasattr(context, "model_copy")
+
+
+def test_functional_copy_cannot_promote_replay_or_redeclare_derived_roster_hash():
+    replay = _make_context()
+
+    with pytest.raises(TypeError):
+        replace(replay, mode=snapshot_service.ContextMode.LIVE)
+    with pytest.raises(TypeError):
+        copy.replace(replay, mode=snapshot_service.ContextMode.LIVE)
+    with pytest.raises(AttributeError):
+        replay.model_copy(update={"mode": snapshot_service.ContextMode.LIVE})  # type: ignore[attr-defined]
+
+    for copied in (replace(replay), copy.replace(replay)):
+        assert type(copied) is type(replay)
+        result = policy.evaluate_single_share_exit(copied)
+        assert (result.outcome, result.reason) == (
+            "INELIGIBLE",
+            "replay_context_not_live",
+        )
+
+    forged_hash = replace(replay, roster_hash="caller-claims-complete")
+    assert forged_hash.derived_roster_hash != forged_hash.roster_hash
+    result = policy.evaluate_single_share_exit_replay(forged_hash)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "account_roster_hash_mismatch",
+    )
+
+
+def test_exact_type_boundary_rejects_subclass_and_blocks_class_swap():
+    replay = _make_context()
+    live = _make_context(live=True)
+    replay_type = type(replay)
+
+    class ReplaySubclass(replay_type):
+        pass
+
+    values = {field.name: getattr(replay, field.name) for field in fields(replay)}
+    subclass = ReplaySubclass(**values)
+    assert snapshot_service.is_validated_context(subclass) is False
+    result = policy.evaluate_single_share_exit_replay(subclass)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "unvalidated_producer_context",
+    )
+
+    with pytest.raises(TypeError, match="object layout differs"):
+        object.__setattr__(replay, "__class__", type(live))
+    assert replay.mode is snapshot_service.ContextMode.REPLAY
+
+
+def test_live_wrapper_ignores_class_level_replay_mode_spoof(monkeypatch):
+    replay = _make_context()
+    monkeypatch.setattr(
+        type(replay),
+        "mode",
+        property(lambda _context: snapshot_service.ContextMode.LIVE),
+    )
+
+    assert replay.mode is snapshot_service.ContextMode.LIVE
+    result = policy.evaluate_single_share_exit(replay)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "replay_context_not_live",
+    )
+
+
+@pytest.mark.parametrize("live", [False, True], ids=["replay", "live"])
+def test_uninitialized_exact_context_is_structured_ineligible(live):
+    context_type = type(_make_context(live=live))
+    uninitialized = object.__new__(context_type)
+
+    assert snapshot_service.is_validated_context(uninitialized) is False
+    evaluator = (
+        policy.evaluate_single_share_exit
+        if live
+        else policy.evaluate_single_share_exit_replay
+    )
+    result = evaluator(uninitialized)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "unvalidated_producer_context",
+    )
+
+
+def test_slotted_context_has_no_dict_mutation_path():
+    context = _make_context()
+
+    with pytest.raises(AttributeError):
+        _ = context.__dict__
+    with pytest.raises(AttributeError):
+        object.__setattr__(
+            context,
+            "mode",
+            snapshot_service.ContextMode.LIVE,
+        )
 
 
 def test_raw_context_shaped_object_is_rejected():
@@ -474,8 +588,14 @@ def test_snapshot_service_has_no_app_or_broker_import_reachability():
         for node in ast.walk(tree)
         if isinstance(node, ast.ImportFrom) and node.module is not None
     }
+    relative_imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.level
+    ]
 
     assert not {module for module in imported_modules if module.startswith("app")}
+    assert not relative_imports
 
 
 def test_declared_roster_hash_forgery_is_rejected():
@@ -483,6 +603,27 @@ def test_declared_roster_hash_forgery_is_rejected():
     assert (result.outcome, result.reason) == (
         "INELIGIBLE",
         "account_roster_hash_mismatch",
+    )
+
+
+def test_roster_hash_canonical_compatibility_vector_is_unchanged():
+    assert (
+        compute_account_roster_hash(
+            roster_id="kr-live-routable-accounts",
+            roster_version="2026-07-23T15:50:00+09:00",
+            read_model_identity="offline.authoritative_roster",
+            accounts=_default_roster(),
+        )
+        == "34f9275b3b4c153af15f39200da470ad7f4e9acbf26795bc1a5ae94fed26c4a9"
+    )
+    assert (
+        compute_account_roster_hash(
+            roster_id='명부"A',
+            roster_version="v1\\n",
+            read_model_identity="reader/한글",
+            accounts=(_configured(KrBroker.KIS, '계좌"\\n'),),
+        )
+        == "f4d927823d5cba703695fe9e7a642eedd751d1ecff92579e0dac3c6fe69089c2"
     )
 
 
@@ -575,7 +716,7 @@ def test_each_evidence_kind_has_wall_clock_age_limit(
     widened_rule = rule.model_copy(update={"conditions": widened_conditions})
     monkeypatch.setattr(
         policy,
-        "load_trading_policy",
+        "_single_share_policy_document",
         lambda: doc.model_copy(
             update={
                 "decision_rules": {
@@ -1194,6 +1335,172 @@ def test_far_band_exact_boundaries(resistance_price, expected):
     assert result.outcome == expected
 
 
+def test_public_policy_loader_never_returns_mutable_cached_singleton():
+    detached = policy.load_trading_policy()
+    detached_rule = detached.decision_rules["sell.single_share_exit"]
+    detached_rule.proposal.auto_approve = True
+    detached.thresholds["sell.loss_guard_min_multiple"].value = 0.01
+
+    fresh = policy.load_trading_policy()
+    cached = policy._single_share_policy_document()
+    for document in (fresh, cached):
+        rule = document.decision_rules["sell.single_share_exit"]
+        assert rule.proposal.auto_approve is False
+        assert document.thresholds["sell.loss_guard_min_multiple"].value == 1.01
+    assert detached is not fresh
+
+
+@pytest.mark.parametrize(
+    ("component", "field", "unsafe_value"),
+    [
+        ("proposal", "action", "order_proposal_create"),
+        ("proposal", "sizing", "partial_lot"),
+        ("proposal", "approval", "none"),
+        ("proposal", "auto_approve", True),
+        ("proposal", "execution", "direct_broker_submit"),
+        ("rule", "operator_approval_required", False),
+        ("conditions", "min_sell_price_multiple_policy_key", "other.key"),
+    ],
+)
+def test_exact_policy_safety_projection_is_rechecked(
+    monkeypatch,
+    component,
+    field,
+    unsafe_value,
+):
+    doc = policy.load_trading_policy()
+    rule = doc.decision_rules["sell.single_share_exit"]
+    if component == "proposal":
+        mutated = rule.model_copy(
+            update={"proposal": rule.proposal.model_copy(update={field: unsafe_value})}
+        )
+    elif component == "conditions":
+        mutated = rule.model_copy(
+            update={
+                "conditions": rule.conditions.model_copy(update={field: unsafe_value})
+            }
+        )
+    else:
+        mutated = rule.model_copy(update={field: unsafe_value})
+    monkeypatch.setattr(
+        policy,
+        "_single_share_policy_document",
+        lambda: _with_single_share_rule(doc, mutated),
+    )
+
+    result = _replay_result()
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "policy_safe_projection_mismatch",
+    )
+    assert result.candidate_action is None
+    assert result.auto_approve is False
+    assert result.execution is None
+
+
+def test_unsafe_nested_proposal_never_leaks_auto_approval_metadata(
+    monkeypatch,
+):
+    now = datetime.now(UTC)
+    expected_date = now.date()
+    monkeypatch.setattr(
+        policy, "_expected_completed_krx_bar", lambda _now: expected_date
+    )
+    doc = policy.load_trading_policy()
+    rule = doc.decision_rules["sell.single_share_exit"]
+    rule.proposal.auto_approve = True
+    rule.proposal.execution = "direct_broker_submit"
+    monkeypatch.setattr(policy, "_single_share_policy_document", lambda: doc)
+    accounts = (
+        _account(
+            KrBroker.KIS,
+            "kis-main",
+            holdings_at=now,
+            orders_at=now,
+        ),
+        _account(
+            KrBroker.TOSS,
+            "toss-main",
+            lots=(_lot(),),
+            holdings_at=now,
+            orders_at=now,
+        ),
+    )
+    context = _make_context(
+        accounts=accounts,
+        quote=_firm_quote(observed_at=now),
+        resistance=ResistanceEvidence(
+            symbol="257720",
+            price=Decimal("39946.31"),
+            sources=("bb_upper", "fib_50"),
+            strength=ResistanceStrength.STRONG,
+            computed_at=now,
+            ohlcv_through_date=expected_date,
+        ),
+        actions_at=now,
+        live=True,
+    )
+
+    result = policy.evaluate_single_share_exit(context)
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "policy_safe_projection_mismatch",
+    )
+    assert result.proposal_enabled is False
+    assert result.candidate_action is None
+    assert result.auto_approve is False
+    assert result.execution is None
+
+
+def test_schema_valid_policy_below_code_loss_floor_stays_ineligible(
+    monkeypatch,
+):
+    raw = policy.load_trading_policy().model_dump(mode="python")
+    raw["thresholds"]["sell.loss_guard_min_multiple"]["value"] = 0.01
+    raw["decision_rules"]["sell.single_share_exit"]["conditions"]["profit_pct_min"] = 0
+    schema_valid = TradingPolicyDocument.model_validate(raw)
+    monkeypatch.setattr(
+        policy,
+        "_single_share_policy_document",
+        lambda: schema_valid,
+    )
+
+    result = _replay_result(
+        accounts=_default_accounts(average_cost="100000"),
+        quote=_firm_quote(price="100000"),
+        resistance=_resistance(price="112000"),
+    )
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "loss_guard_not_met",
+    )
+    assert result.average_cost == Decimal("100000")
+    assert result.current_quote == Decimal("100000")
+
+
+@pytest.mark.parametrize(
+    "configured_value", [float("nan"), float("inf"), float("-inf")]
+)
+def test_schema_valid_non_finite_loss_guard_fails_closed(
+    monkeypatch,
+    configured_value,
+):
+    raw = policy.load_trading_policy().model_dump(mode="python")
+    raw["thresholds"]["sell.loss_guard_min_multiple"]["value"] = configured_value
+    schema_valid = TradingPolicyDocument.model_validate(raw)
+    monkeypatch.setattr(
+        policy,
+        "_single_share_policy_document",
+        lambda: schema_valid,
+    )
+
+    result = _replay_result()
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "invalid_loss_guard_policy",
+    )
+
+
 @pytest.mark.parametrize(
     "gate_mutation",
     [
@@ -1209,7 +1516,7 @@ def test_activation_and_proposal_off_are_rechecked(monkeypatch, gate_mutation):
     bypassed = rule.model_copy(update=gate_mutation)
     monkeypatch.setattr(
         policy,
-        "load_trading_policy",
+        "_single_share_policy_document",
         lambda: doc.model_copy(
             update={
                 "decision_rules": {

--- a/tests/services/test_single_share_exit_snapshot_service.py
+++ b/tests/services/test_single_share_exit_snapshot_service.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+import ast
 import asyncio
-import copy
-import dataclasses
 import inspect
-import pickle
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -29,7 +28,6 @@ from app.services.single_share_exit_snapshot_service import (
     KrBroker,
     MarketEvidence,
     OpenActionEvidence,
-    ProducerContextIntegrityError,
     QuoteKind,
     QuoteProvenance,
     QuoteSource,
@@ -211,13 +209,14 @@ def _resistance(
     symbol: str = "257720",
     price: str = "39946.31",
     sources: tuple[str, ...] = ("bb_upper", "fib_50"),
+    strength: ResistanceStrength = ResistanceStrength.STRONG,
     computed_at: datetime = _EVIDENCE_AT,
 ) -> ResistanceEvidence:
     return ResistanceEvidence(
         symbol=symbol,
         price=Decimal(price),
         sources=sources,
-        strength=ResistanceStrength.WEAK,
+        strength=strength,
         computed_at=computed_at,
         ohlcv_through_date=_EXPECTED_KRX_BAR,
     )
@@ -399,24 +398,14 @@ def test_omitted_account_cannot_claim_complete():
     assert result.observed_account_identities == ("kis:kis-main", "toss:toss-main")
 
 
-def test_model_copy_or_dataclass_replace_cannot_forge_roster():
+def test_context_uses_private_concrete_type_and_isinstance_boundary():
     context = _make_context()
+    assert type(context).__name__ == "_ValidatedSingleShareExitContext"
+    assert snapshot_service.is_validated_context(context) is True
     assert not hasattr(context, "model_copy")
-    with pytest.raises(TypeError, match="dataclass instances"):
-        dataclasses.replace(
-            context,
-            expected_account_identities=context.expected_account_identities[:-1],
-        )
 
 
-def test_claude_public_seal_recalculation_poc_has_no_issuance_material():
-    for removed_name in (
-        "_CONTEXT_CAPABILITY",
-        "_CONTEXT_SEAL_KEY",
-        "_context_seal",
-    ):
-        assert not hasattr(snapshot_service, removed_name)
-
+def test_raw_context_shaped_object_is_rejected():
     configured_accounts = _default_roster()
     identities = tuple(account.identity for account in configured_accounts)
     roster_hash = compute_account_roster_hash(
@@ -463,13 +452,8 @@ def test_claude_public_seal_recalculation_poc_has_no_issuance_material():
         ),
     }
 
-    with pytest.raises(TypeError, match="Protocols cannot be instantiated"):
-        ValidatedSingleShareExitContext(
-            **public_values,
-            _issuer_capability=object(),
-            _seal="caller-self-computed",
-        )
     forged_namespace = SimpleNamespace(**public_values)
+    assert snapshot_service.is_validated_context(forged_namespace) is False
     result = policy.evaluate_single_share_exit_replay(forged_namespace)
     assert (result.outcome, result.reason) == (
         "INELIGIBLE",
@@ -477,49 +461,21 @@ def test_claude_public_seal_recalculation_poc_has_no_issuance_material():
     )
 
 
-def test_only_exact_producer_issued_object_identity_is_accepted():
-    context = _make_context()
-    context_type = type(context)
+def test_snapshot_service_has_no_app_or_broker_import_reachability():
+    source = Path(snapshot_service.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
 
-    with pytest.raises(ProducerContextIntegrityError, match="producer-only"):
-        context_type(object())
-
-    forged_by_object_new = object.__new__(context_type)
-    result = policy.evaluate_single_share_exit_replay(forged_by_object_new)
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "unvalidated_producer_context",
-    )
-
-    with pytest.raises(TypeError, match="cannot be subclassed"):
-
-        class _ForgedSubclass(context_type):
-            pass
-
-    with pytest.raises(TypeError, match="cannot be copied"):
-        copy.copy(context)
-    with pytest.raises(TypeError, match="cannot be deep-copied"):
-        copy.deepcopy(context)
-    with pytest.raises(TypeError, match="cannot be pickled"):
-        pickle.dumps(context)
-
-
-def test_every_exposed_context_property_revalidates_issued_state():
-    public_properties = (
-        *ValidatedSingleShareExitContext.__annotations__,
-        "roster_is_exact",
-    )
-    for property_name in public_properties:
-        context = _make_context()
-        issued_target = context.target
-        object.__setattr__(issued_target, "symbol", "000000")
-
-        with pytest.raises(
-            ProducerContextIntegrityError,
-            match="state changed after issuance",
-        ):
-            getattr(context, property_name)
-        assert snapshot_service.is_validated_context(context) is False
+    assert not {module for module in imported_modules if module.startswith("app")}
 
 
 def test_declared_roster_hash_forgery_is_rejected():
@@ -730,12 +686,25 @@ def test_no_resistance_reference_is_ineligible():
     )
 
 
+@pytest.mark.parametrize(
+    "strength",
+    [ResistanceStrength.WEAK, ResistanceStrength.MODERATE],
+)
+def test_resistance_must_be_strong(strength):
+    result = _replay_result(resistance=_resistance(strength=strength))
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "resistance_strength_below_required",
+    )
+    assert result.resistance_strength == strength.value
+
+
 def test_resistance_must_cover_expected_completed_krx_bar():
     resistance = ResistanceEvidence(
         symbol="257720",
         price=Decimal("39946.31"),
         sources=("bb_upper", "fib_50"),
-        strength=ResistanceStrength.WEAK,
+        strength=ResistanceStrength.STRONG,
         computed_at=_EVIDENCE_AT,
         ohlcv_through_date=date(2026, 7, 22),
     )
@@ -1225,11 +1194,19 @@ def test_far_band_exact_boundaries(resistance_price, expected):
     assert result.outcome == expected
 
 
-def test_activation_and_proposal_off_are_rechecked(monkeypatch):
+@pytest.mark.parametrize(
+    "gate_mutation",
+    [
+        {"activation_state": "live"},
+        {"proposal_enabled": True},
+    ],
+    ids=["activation-live", "proposal-enabled"],
+)
+def test_activation_and_proposal_off_are_rechecked(monkeypatch, gate_mutation):
     context = _make_context()
     doc = policy.load_trading_policy()
     rule = doc.decision_rules["sell.single_share_exit"]
-    bypassed = rule.model_copy(update={"proposal_enabled": True})
+    bypassed = rule.model_copy(update=gate_mutation)
     monkeypatch.setattr(
         policy,
         "load_trading_policy",
@@ -1278,7 +1255,7 @@ def test_live_producer_uses_internal_clock_and_remains_shadow_off(monkeypatch):
             symbol="257720",
             price=Decimal("39946.31"),
             sources=("bb_upper", "fib_50"),
-            strength=ResistanceStrength.WEAK,
+            strength=ResistanceStrength.STRONG,
             computed_at=now,
             ohlcv_through_date=expected_date,
         ),
@@ -1289,7 +1266,7 @@ def test_live_producer_uses_internal_clock_and_remains_shadow_off(monkeypatch):
     assert result.outcome == "SHADOW_ELIGIBLE"
     assert result.outcome != "PROPOSE"
     assert result.proposal_enabled is False
-    assert result.candidate_action == "propose_full_account_lot_exit"
+    assert result.candidate_action == "full_exit_at_far_resistance"
     assert result.sizing == "full_account_lot_exit"
     assert result.approval == "telegram_manual"
     assert result.auto_approve is False

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -5,7 +5,7 @@ from app.services import trading_policy_service as svc
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-22.1"
+    assert stamp["version"] == "2026-07-23.1"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,7 +15,7 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-22.1"
+    assert view["version"] == "2026-07-23.1"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
@@ -33,7 +33,7 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
 def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     view = svc.get_policy_for("crypto", "buy")
 
-    assert view["version"] == "2026-07-22.1"
+    assert view["version"] == "2026-07-23.1"
     assert set(view["market_rules"]) == {
         "recovery_gate",
         "support_resistance",
@@ -78,6 +78,144 @@ def test_get_policy_for_sell_lane_has_sell_keys():
     assert rule["tiers"][2]["conditions"]["resistance_near_pct_max"] == 2
     assert rule["tiers"][3]["action"] == "register_watch"
     assert rule["tie_breaks"]["sell.upside_place_max_pct"] == "size_limit_only"
+
+
+def _single_share_candidate(**overrides):
+    candidate = {
+        "market": "kr",
+        "broker": "kis",
+        "quantity": 1,
+        "order_routable": True,
+        "average_cost": 100_000,
+        "proposed_sell_price": 108_000,
+        "profit_pct": 8,
+        "resistance_near_pct": 2,
+        "unresolved_open_actions": 0,
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+@pytest.mark.parametrize("broker", ["kis", "toss"])
+def test_single_share_exit_proposes_manual_full_exit_only(broker):
+    result = svc.evaluate_single_share_exit(**_single_share_candidate(broker=broker))
+
+    assert result.outcome == "PROPOSE"
+    assert result.action == "propose_full_exit"
+    assert result.sizing == "full_position"
+    assert result.approval == "telegram_manual"
+    assert result.auto_approve is False
+    assert result.execution == "proposal_only"
+
+
+def test_single_share_exit_is_ineligible_below_loss_guard():
+    result = svc.evaluate_single_share_exit(
+        **_single_share_candidate(proposed_sell_price=100_999)
+    )
+
+    assert (result.outcome, result.reason) == ("INELIGIBLE", "loss_guard_not_met")
+
+
+def test_single_share_exit_is_ineligible_without_resistance_reference():
+    result = svc.evaluate_single_share_exit(
+        **_single_share_candidate(resistance_near_pct=None)
+    )
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "no_resistance_reference",
+    )
+
+
+def test_single_share_exit_defers_for_unresolved_open_action():
+    result = svc.evaluate_single_share_exit(
+        **_single_share_candidate(unresolved_open_actions=1)
+    )
+
+    assert (result.outcome, result.reason) == ("DEFER", "unresolved_open_action")
+
+
+def test_single_share_exit_does_not_apply_to_multi_share_position():
+    result = svc.evaluate_single_share_exit(**_single_share_candidate(quantity=2))
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "not_single_share_position",
+    )
+
+
+def test_single_share_exit_excludes_non_routable_account():
+    result = svc.evaluate_single_share_exit(
+        **_single_share_candidate(order_routable=False)
+    )
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "order_routable_false",
+    )
+
+
+def test_existing_trim_preplace_rule_is_exactly_unchanged():
+    rule = svc.get_policy_for("kr", "sell")["decision_rules"]["sell.trim_preplace"]
+
+    assert rule == {
+        "semantics": (
+            "Tiers are evaluated in declared priority order and the first match wins. "
+            "profit_realization is resistance-distance-independent; global exclusions "
+            "apply to every tier. When resistance-near favors PLACE but upside-rich "
+            "would otherwise allow WATCH, resistance proximity can pre-place only a "
+            "small trim; upside richness limits size, not eligibility."
+        ),
+        "tiers": [
+            {
+                "id": "profit_realization",
+                "conditions": {"profit_pct_min": 8},
+                "action": "preplace_small_trim_ladder",
+                "sizing": "small_trim_only",
+            },
+            {
+                "id": "rsi_confirmed_resistance",
+                "conditions": {
+                    "rsi_min_policy_key": "sell.rsi_place_min",
+                    "resistance_near_pct_max_policy_key": ("sell.resistance_near_pct"),
+                },
+                "action": "preplace_small_trim_ladder",
+                "sizing": "small_trim_only",
+            },
+            {
+                "id": "ultra_near_resistance",
+                "conditions": {
+                    "rsi_below_policy_key": "sell.rsi_place_min",
+                    "resistance_near_pct_max": 2,
+                },
+                "action": "preplace_small_trim_ladder",
+                "sizing": "small_trim_only",
+            },
+            {
+                "id": "watch_zone",
+                "conditions": {
+                    "rsi_below_policy_key": "sell.rsi_place_min",
+                    "resistance_near_pct_min_exclusive": 2,
+                    "resistance_near_pct_max_policy_key": ("sell.resistance_near_pct"),
+                },
+                "action": "register_watch",
+                "sizing": "no_preplaced_trim",
+            },
+        ],
+        "tie_breaks": {
+            "tier_priority": (
+                "profit_realization > rsi_confirmed_resistance > "
+                "ultra_near_resistance > watch_zone"
+            ),
+            "multiple_tiers_matched": "first_matching_tier_wins",
+            "sell.upside_place_max_pct": "size_limit_only",
+        },
+        "exclusions": [
+            "single_share_position",
+            "no_resistance_reference",
+            "composite_gates",
+        ],
+    }
 
 
 def test_unknown_market_raises():

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -1,11 +1,25 @@
+import inspect
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
 import pytest
 
+from app.schemas.trading_policy import (
+    SingleShareExitAccountLot,
+    SingleShareExitBrokerAccountSnapshot,
+    SingleShareExitEvidenceSnapshot,
+    SingleShareExitOpenAction,
+    SingleShareExitOpenOrder,
+    SingleShareExitQuoteEvidence,
+    SingleShareExitResistanceEvidence,
+    SingleShareExitTargetIdentity,
+)
 from app.services import trading_policy_service as svc
 
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-23.1"
+    assert stamp["version"] == "2026-07-23.2"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,7 +29,7 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-23.1"
+    assert view["version"] == "2026-07-23.2"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
@@ -33,7 +47,7 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
 def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     view = svc.get_policy_for("crypto", "buy")
 
-    assert view["version"] == "2026-07-23.1"
+    assert view["version"] == "2026-07-23.2"
     assert set(view["market_rules"]) == {
         "recovery_gate",
         "support_resistance",
@@ -80,79 +94,520 @@ def test_get_policy_for_sell_lane_has_sell_keys():
     assert rule["tie_breaks"]["sell.upside_place_max_pct"] == "size_limit_only"
 
 
-def _single_share_candidate(**overrides):
-    candidate = {
-        "market": "kr",
-        "broker": "kis",
-        "quantity": 1,
-        "order_routable": True,
-        "average_cost": 100_000,
-        "proposed_sell_price": 108_000,
-        "profit_pct": 8,
-        "resistance_near_pct": 2,
-        "unresolved_open_actions": 0,
-    }
-    candidate.update(overrides)
-    return candidate
+_NOW = datetime(2026, 7, 23, 7, 0, tzinfo=UTC)
+_SNAPSHOT_AT = _NOW - timedelta(seconds=60)
+_EXPECTED_KRX_BAR = date(2026, 7, 23)
 
 
-@pytest.mark.parametrize("broker", ["kis", "toss"])
-def test_single_share_exit_proposes_manual_full_exit_only(broker):
-    result = svc.evaluate_single_share_exit(**_single_share_candidate(broker=broker))
+@pytest.fixture(autouse=True)
+def _stub_expected_completed_krx_bar(monkeypatch):
+    monkeypatch.setattr(
+        svc, "_expected_completed_krx_bar", lambda _now: _EXPECTED_KRX_BAR
+    )
 
-    assert result.outcome == "PROPOSE"
-    assert result.action == "propose_full_exit"
-    assert result.sizing == "full_position"
+
+def _lot(
+    *,
+    symbol="257720",
+    lot_id="lot-1",
+    quantity="1",
+    average_cost="100000",
+    order_routable=True,
+):
+    return SingleShareExitAccountLot(
+        symbol=symbol,
+        lot_id=lot_id,
+        order_routable=order_routable,
+        sellable_quantity=Decimal(quantity),
+        average_cost=Decimal(average_cost),
+    )
+
+
+def _account(
+    *,
+    broker,
+    account_id,
+    lots=None,
+    orders=None,
+    snapshot_id="snapshot-1",
+    observed_at=_SNAPSHOT_AT,
+):
+    return SingleShareExitBrokerAccountSnapshot(
+        snapshot_id=snapshot_id,
+        broker=broker,
+        broker_account_id=account_id,
+        observed_at=observed_at,
+        holdings_complete=True,
+        lots=lots or [],
+        open_orders_checked_at=observed_at,
+        open_orders_complete=True,
+        open_orders=orders or [],
+    )
+
+
+def _single_share_evidence(
+    *,
+    symbol="257720",
+    target_broker="kis",
+    target_account_id="kis-main",
+    target_lot_id="lot-1",
+    accounts=None,
+    average_cost="100000",
+    quote_price="108000",
+    resistance_price="119000",
+    resistance_sources=None,
+    resistance_strength="strong",
+    snapshot_id="snapshot-1",
+    quote_snapshot_id=None,
+    quote_observed_at=_SNAPSHOT_AT,
+    resistance_computed_at=_SNAPSHOT_AT,
+    ohlcv_through_date=_EXPECTED_KRX_BAR,
+    captured_at=_SNAPSHOT_AT,
+    open_actions=None,
+):
+    if accounts is None:
+        target_lot = _lot(
+            symbol=symbol,
+            lot_id=target_lot_id,
+            average_cost=average_cost,
+        )
+        if target_broker == "kis":
+            accounts = [
+                _account(broker="kis", account_id=target_account_id, lots=[target_lot]),
+                _account(broker="toss", account_id="toss-main"),
+            ]
+        else:
+            accounts = [
+                _account(broker="kis", account_id="kis-main"),
+                _account(
+                    broker="toss", account_id=target_account_id, lots=[target_lot]
+                ),
+            ]
+    return SingleShareExitEvidenceSnapshot(
+        snapshot_id=snapshot_id,
+        market="kr",
+        captured_at=captured_at,
+        target=SingleShareExitTargetIdentity(
+            symbol=symbol,
+            broker=target_broker,
+            broker_account_id=target_account_id,
+            lot_id=target_lot_id,
+        ),
+        broker_account_scope_complete=True,
+        accounts=accounts,
+        quote=SingleShareExitQuoteEvidence(
+            snapshot_id=quote_snapshot_id or snapshot_id,
+            symbol=symbol,
+            price=Decimal(quote_price),
+            observed_at=quote_observed_at,
+            source="kis_quote",
+        ),
+        resistance=SingleShareExitResistanceEvidence(
+            snapshot_id=snapshot_id,
+            symbol=symbol,
+            price=Decimal(resistance_price),
+            sources=resistance_sources or ["bb_upper", "fib_50"],
+            strength=resistance_strength,
+            computed_at=resistance_computed_at,
+            ohlcv_through_date=ohlcv_through_date,
+        ),
+        open_actions_snapshot_id=snapshot_id,
+        open_actions_checked_at=captured_at,
+        open_actions_complete=True,
+        open_actions=open_actions or [],
+    )
+
+
+@pytest.mark.parametrize(
+    ("broker", "account_id"),
+    [("kis", "kis-main"), ("toss", "toss-main")],
+)
+def test_single_share_exit_is_shadow_only_for_kis_and_toss(broker, account_id):
+    evidence = _single_share_evidence(
+        target_broker=broker,
+        target_account_id=account_id,
+    )
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert result.outcome == "SHADOW_ELIGIBLE"
+    assert result.outcome != "PROPOSE"
+    assert result.activation_state == "shadow"
+    assert result.proposal_enabled is False
+    assert result.candidate_action == "propose_full_account_lot_exit"
+    assert result.sizing == "full_account_lot_exit"
     assert result.approval == "telegram_manual"
     assert result.auto_approve is False
     assert result.execution == "proposal_only"
 
 
-def test_single_share_exit_is_ineligible_below_loss_guard():
+def test_evaluator_rejects_even_bypassed_proposal_enabled_policy(monkeypatch):
+    doc = svc.load_trading_policy()
+    rule = doc.decision_rules["sell.single_share_exit"]
+    bypassed_rule = rule.model_copy(update={"proposal_enabled": True})
+    bypassed_doc = doc.model_copy(
+        update={
+            "decision_rules": {
+                **doc.decision_rules,
+                "sell.single_share_exit": bypassed_rule,
+            }
+        }
+    )
+    monkeypatch.setattr(svc, "load_trading_policy", lambda: bypassed_doc)
+
+    result = svc.evaluate_single_share_exit(_single_share_evidence(), evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "policy_not_shadow_off",
+    )
+    assert result.candidate_action is None
+
+
+@pytest.mark.parametrize(
+    ("symbol", "quote", "resistance", "sources"),
+    [
+        ("257720", "36450", "39946.31", ["bb_upper", "fib_50"]),
+        (
+            "042660",
+            "89400",
+            "100548.9",
+            ["fib_38.2", "volume_value_area_low"],
+        ),
+        ("086790", "130500", "142264.52", ["bb_upper", "fib_0"]),
+    ],
+)
+def test_measured_far_lane_two_family_cases_are_shadow_eligible(
+    symbol, quote, resistance, sources
+):
+    # All measured lots were comfortably above 8%; avoid manufacturing an
+    # exactly-8% repeating Decimal at the boundary in this evidence test.
+    average_cost = Decimal(quote) / Decimal("1.10")
+    evidence = _single_share_evidence(
+        symbol=symbol,
+        average_cost=str(average_cost),
+        quote_price=quote,
+        resistance_price=resistance,
+        resistance_sources=sources,
+    )
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert result.outcome == "SHADOW_ELIGIBLE"
+    assert len(result.normalized_source_families) == 2
+
+
+def test_naver_one_family_is_ineligible_even_if_symbol_total_were_one():
+    evidence = _single_share_evidence(
+        symbol="035420",
+        average_cost="196428.5714285714",
+        quote_price="220000",
+        resistance_price="242550",
+        resistance_sources=["fib_50"],
+    )
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "insufficient_independent_resistance_families",
+    )
+    assert result.normalized_source_families == ("FIBONACCI",)
+
+
+def test_naver_toss_one_plus_kis_three_is_not_single_symbol_quantity():
+    accounts = [
+        _account(
+            broker="kis",
+            account_id="kis-main",
+            lots=[
+                _lot(
+                    symbol="035420",
+                    lot_id="kis-lot",
+                    quantity="3",
+                    average_cost="200000",
+                )
+            ],
+        ),
+        _account(
+            broker="toss",
+            account_id="toss-main",
+            lots=[
+                _lot(
+                    symbol="035420",
+                    lot_id="toss-lot",
+                    quantity="1",
+                    average_cost="196428.5714285714",
+                )
+            ],
+        ),
+    ]
+    evidence = _single_share_evidence(
+        symbol="035420",
+        target_broker="toss",
+        target_account_id="toss-main",
+        target_lot_id="toss-lot",
+        accounts=accounts,
+        quote_price="220000",
+        resistance_price="242550",
+    )
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "symbol_routable_sellable_quantity_not_one",
+    )
+    assert result.symbol_routable_sellable_quantity == Decimal("4")
+
+
+def test_missing_kis_or_toss_inventory_is_ineligible():
+    evidence = _single_share_evidence(
+        accounts=[
+            _account(
+                broker="kis",
+                account_id="kis-main",
+                lots=[_lot()],
+            ),
+            _account(broker="kis", account_id="kis-secondary"),
+        ]
+    )
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "incomplete_kis_toss_inventory",
+    )
+
+
+def test_duplicate_broker_account_snapshot_is_ineligible():
+    evidence = _single_share_evidence(
+        accounts=[
+            _account(
+                broker="kis",
+                account_id="kis-main",
+                lots=[_lot()],
+            ),
+            _account(broker="kis", account_id="kis-main"),
+            _account(broker="toss", account_id="toss-main"),
+        ]
+    )
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "duplicate_broker_account_snapshot",
+    )
+
+
+def test_same_symbol_broker_open_order_defers():
+    order = SingleShareExitOpenOrder(order_id="order-1", symbol="257720", side="buy")
+    accounts = [
+        _account(broker="kis", account_id="kis-main", lots=[_lot()]),
+        _account(
+            broker="toss",
+            account_id="toss-main",
+            orders=[order],
+        ),
+    ]
+
     result = svc.evaluate_single_share_exit(
-        **_single_share_candidate(proposed_sell_price=100_999)
+        _single_share_evidence(accounts=accounts),
+        evaluated_at=_NOW,
+    )
+
+    assert (result.outcome, result.reason) == (
+        "DEFER",
+        "same_symbol_broker_open_order",
+    )
+
+
+def test_open_action_is_scoped_by_symbol_side_and_account():
+    unrelated = [
+        SingleShareExitOpenAction(
+            action_id="wrong-symbol",
+            symbol="035420",
+            side="sell",
+            broker_account_id="kis-main",
+            status="open",
+        ),
+        SingleShareExitOpenAction(
+            action_id="wrong-side",
+            symbol="257720",
+            side="buy",
+            broker_account_id="kis-main",
+            status="open",
+        ),
+        SingleShareExitOpenAction(
+            action_id="wrong-account",
+            symbol="257720",
+            side="sell",
+            broker_account_id="toss-main",
+            status="in_progress",
+        ),
+    ]
+    unrelated_result = svc.evaluate_single_share_exit(
+        _single_share_evidence(open_actions=unrelated),
+        evaluated_at=_NOW,
+    )
+    assert unrelated_result.outcome == "SHADOW_ELIGIBLE"
+
+    scoped = [
+        *unrelated,
+        SingleShareExitOpenAction(
+            action_id="scoped",
+            symbol="257720",
+            side="sell",
+            broker_account_id="kis-main",
+            status="open",
+        ),
+    ]
+    scoped_result = svc.evaluate_single_share_exit(
+        _single_share_evidence(open_actions=scoped),
+        evaluated_at=_NOW,
+    )
+    assert (scoped_result.outcome, scoped_result.reason) == (
+        "DEFER",
+        "unresolved_scoped_open_action",
+    )
+
+
+def test_stale_quote_is_ineligible():
+    stale_at = _NOW - timedelta(seconds=301)
+    evidence = _single_share_evidence(
+        captured_at=stale_at,
+        quote_observed_at=stale_at,
+        resistance_computed_at=stale_at,
+        accounts=[
+            _account(
+                broker="kis",
+                account_id="kis-main",
+                lots=[_lot()],
+                observed_at=stale_at,
+            ),
+            _account(
+                broker="toss",
+                account_id="toss-main",
+                observed_at=stale_at,
+            ),
+        ],
+    )
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == ("INELIGIBLE", "stale_quote")
+
+
+def test_inconsistent_snapshot_id_is_ineligible():
+    evidence = _single_share_evidence(quote_snapshot_id="other-snapshot")
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "inconsistent_snapshot_id",
+    )
+
+
+def test_ohlcv_must_cover_expected_completed_krx_bar():
+    evidence = _single_share_evidence(ohlcv_through_date=date(2026, 7, 22))
+
+    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "ohlcv_not_through_expected_completed_krx_bar",
+    )
+    assert result.expected_completed_krx_bar_date == _EXPECTED_KRX_BAR
+
+
+def test_profit_and_distance_are_recomputed_from_decimal_snapshot():
+    parameters = inspect.signature(svc.evaluate_single_share_exit).parameters
+    assert "profit_pct" not in parameters
+    assert "resistance_distance_pct" not in parameters
+
+    result = svc.evaluate_single_share_exit(
+        _single_share_evidence(
+            average_cost="100000",
+            quote_price="108000",
+            resistance_price="118800",
+        ),
+        evaluated_at=_NOW,
+    )
+
+    assert result.profit_pct == Decimal("8.0000")
+    assert result.resistance_distance_pct == Decimal("10.0000")
+    assert result.average_cost == Decimal("100000")
+    assert result.current_quote == Decimal("108000")
+    assert result.resistance_price == Decimal("118800")
+
+
+@pytest.mark.parametrize(
+    ("resistance_price", "expected_outcome"),
+    [
+        ("114480", "INELIGIBLE"),  # exactly +6%, exclusive
+        ("124200", "SHADOW_ELIGIBLE"),  # exactly +15%, inclusive
+        ("124200.01", "INELIGIBLE"),  # above +15%
+    ],
+)
+def test_far_resistance_band_boundaries(resistance_price, expected_outcome):
+    result = svc.evaluate_single_share_exit(
+        _single_share_evidence(resistance_price=resistance_price),
+        evaluated_at=_NOW,
+    )
+
+    assert result.outcome == expected_outcome
+
+
+def test_multiple_fibonacci_sources_count_as_one_family():
+    result = svc.evaluate_single_share_exit(
+        _single_share_evidence(resistance_sources=["fib_0", "fib_38.2", "fib_50"]),
+        evaluated_at=_NOW,
+    )
+
+    assert (result.outcome, result.reason) == (
+        "INELIGIBLE",
+        "insufficient_independent_resistance_families",
+    )
+    assert result.normalized_source_families == ("FIBONACCI",)
+
+
+def test_loss_guard_is_decimal_and_checked_separately():
+    result = svc.evaluate_single_share_exit(
+        _single_share_evidence(
+            average_cost="100000",
+            quote_price="100999.9999",
+            resistance_price="112000",
+        ),
+        evaluated_at=_NOW,
     )
 
     assert (result.outcome, result.reason) == ("INELIGIBLE", "loss_guard_not_met")
 
 
-def test_single_share_exit_is_ineligible_without_resistance_reference():
+def test_resistance_provenance_and_freshness_fields_are_preserved():
     result = svc.evaluate_single_share_exit(
-        **_single_share_candidate(resistance_near_pct=None)
+        _single_share_evidence(
+            resistance_sources=["volume_poc", "bb_upper"],
+            resistance_strength="moderate",
+        ),
+        evaluated_at=_NOW,
     )
 
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "no_resistance_reference",
+    assert result.outcome == "SHADOW_ELIGIBLE"
+    assert result.resistance_sources == ("volume_poc", "bb_upper")
+    assert result.normalized_source_families == (
+        "BOLLINGER",
+        "VOLUME_PROFILE",
     )
-
-
-def test_single_share_exit_defers_for_unresolved_open_action():
-    result = svc.evaluate_single_share_exit(
-        **_single_share_candidate(unresolved_open_actions=1)
-    )
-
-    assert (result.outcome, result.reason) == ("DEFER", "unresolved_open_action")
-
-
-def test_single_share_exit_does_not_apply_to_multi_share_position():
-    result = svc.evaluate_single_share_exit(**_single_share_candidate(quantity=2))
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "not_single_share_position",
-    )
-
-
-def test_single_share_exit_excludes_non_routable_account():
-    result = svc.evaluate_single_share_exit(
-        **_single_share_candidate(order_routable=False)
-    )
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "order_routable_false",
-    )
+    assert result.resistance_strength == "moderate"
+    assert result.quote_source == "kis_quote"
+    assert result.quote_age_seconds == Decimal("60.0")
+    assert result.quote_observed_at == _SNAPSHOT_AT
+    assert result.resistance_computed_at == _SNAPSHOT_AT
+    assert result.ohlcv_through_date == _EXPECTED_KRX_BAR
 
 
 def test_existing_trim_preplace_rule_is_exactly_unchanged():

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -1,613 +1,53 @@
-import inspect
-from datetime import UTC, date, datetime, timedelta
-from decimal import Decimal
+from pathlib import Path
 
 import pytest
+import yaml
 
-from app.schemas.trading_policy import (
-    SingleShareExitAccountLot,
-    SingleShareExitBrokerAccountSnapshot,
-    SingleShareExitEvidenceSnapshot,
-    SingleShareExitOpenAction,
-    SingleShareExitOpenOrder,
-    SingleShareExitQuoteEvidence,
-    SingleShareExitResistanceEvidence,
-    SingleShareExitTargetIdentity,
-)
 from app.services import trading_policy_service as svc
 
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-23.2"
+    assert stamp["version"] == "2026-07-23.3"
     assert len(stamp["content_hash"]) == 12
-
-
-def test_content_hash_stable_across_calls():
     assert svc.policy_content_hash() == svc.policy_content_hash()
 
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-23.2"
-    assert view["content_hash"]
-    t = view["thresholds"]
-    # buy lane references these (playbook lane tags)
-    assert t["portfolio.sector_cluster_cap_pct"]["value"] == 10
-    assert t["portfolio.sector_cluster_cap_pct"]["source"] == "default"
-    assert t["portfolio.max_symbols_per_theme"]["value"] == 2
-    assert t["recovery_gate.min_conditions_met"]["value"] == 2
-    assert t["recovery_gate.min_conditions_met"]["of"] == 2
-    assert t["sell.loss_guard_min_multiple"]["value"] == 1.01
-    # sell-only threshold must NOT appear in the buy lane
-    assert "sell.rsi_place_min" not in t
+    assert view["version"] == "2026-07-23.3"
+    assert view["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
+    assert view["thresholds"]["portfolio.max_symbols_per_theme"]["value"] == 2
+    assert view["thresholds"]["sell.loss_guard_min_multiple"]["value"] == 1.01
+    assert "sell.rsi_place_min" not in view["thresholds"]
     assert view["decision_rules"] == {}
 
 
-def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
-    view = svc.get_policy_for("crypto", "buy")
-
-    assert view["version"] == "2026-07-23.2"
-    assert set(view["market_rules"]) == {
-        "recovery_gate",
-        "support_resistance",
-        "no_chasing",
-    }
-    gate = view["market_rules"]["recovery_gate"]
-    assert gate["min_conditions_met"] == 2
-    assert gate["of"] == 2
-    assert [condition["id"] for condition in gate["conditions"]] == [
-        "alt_breadth_24h",
-        "btc_long_short_ratio",
-    ]
-    assert [context["id"] for context in gate["advisory_context"]] == [
-        "fear_greed",
-        "btc_kimchi_premium",
-    ]
-    assert "lanes" not in gate
-    assert view["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
-
-
 def test_get_policy_for_filters_crypto_market_rules_by_lane():
+    buy = svc.get_policy_for("crypto", "buy")["market_rules"]
+    assert set(buy) == {"recovery_gate", "support_resistance", "no_chasing"}
     discovery = svc.get_policy_for("crypto", "discovery")["market_rules"]
     assert set(discovery) == {"support_resistance", "no_chasing"}
-
     sell = svc.get_policy_for("crypto", "sell")["market_rules"]
     assert set(sell) == {"support_resistance"}
-
     assert svc.get_policy_for("kr", "buy")["market_rules"] == {}
 
 
-def test_get_policy_for_sell_lane_has_sell_keys():
-    view = svc.get_policy_for("kr", "sell")
-    t = view["thresholds"]
-    assert t["sell.rsi_place_min"]["value"] == 58
-    assert "screen.rsi_max" not in t
-    rule = view["decision_rules"]["sell.trim_preplace"]
-    assert rule["tiers"][0]["id"] == "profit_realization"
-    assert rule["tiers"][0]["conditions"]["profit_pct_min"] == 8
-    assert rule["tiers"][1]["conditions"]["rsi_min_policy_key"] == (
-        "sell.rsi_place_min"
+def test_single_share_exit_is_exposed_only_for_kr_sell():
+    kr_sell = svc.get_policy_for("kr", "sell")["decision_rules"]
+    assert "sell.single_share_exit" in kr_sell
+    assert (
+        "sell.single_share_exit"
+        not in svc.get_policy_for("us", "sell")["decision_rules"]
     )
-    assert rule["tiers"][2]["conditions"]["resistance_near_pct_max"] == 2
-    assert rule["tiers"][3]["action"] == "register_watch"
-    assert rule["tie_breaks"]["sell.upside_place_max_pct"] == "size_limit_only"
-
-
-_NOW = datetime(2026, 7, 23, 7, 0, tzinfo=UTC)
-_SNAPSHOT_AT = _NOW - timedelta(seconds=60)
-_EXPECTED_KRX_BAR = date(2026, 7, 23)
-
-
-@pytest.fixture(autouse=True)
-def _stub_expected_completed_krx_bar(monkeypatch):
-    monkeypatch.setattr(
-        svc, "_expected_completed_krx_bar", lambda _now: _EXPECTED_KRX_BAR
+    assert (
+        "sell.single_share_exit"
+        not in svc.get_policy_for("crypto", "sell")["decision_rules"]
     )
-
-
-def _lot(
-    *,
-    symbol="257720",
-    lot_id="lot-1",
-    quantity="1",
-    average_cost="100000",
-    order_routable=True,
-):
-    return SingleShareExitAccountLot(
-        symbol=symbol,
-        lot_id=lot_id,
-        order_routable=order_routable,
-        sellable_quantity=Decimal(quantity),
-        average_cost=Decimal(average_cost),
+    assert (
+        "sell.single_share_exit"
+        not in svc.get_policy_for("kr", "buy")["decision_rules"]
     )
-
-
-def _account(
-    *,
-    broker,
-    account_id,
-    lots=None,
-    orders=None,
-    snapshot_id="snapshot-1",
-    observed_at=_SNAPSHOT_AT,
-):
-    return SingleShareExitBrokerAccountSnapshot(
-        snapshot_id=snapshot_id,
-        broker=broker,
-        broker_account_id=account_id,
-        observed_at=observed_at,
-        holdings_complete=True,
-        lots=lots or [],
-        open_orders_checked_at=observed_at,
-        open_orders_complete=True,
-        open_orders=orders or [],
-    )
-
-
-def _single_share_evidence(
-    *,
-    symbol="257720",
-    target_broker="kis",
-    target_account_id="kis-main",
-    target_lot_id="lot-1",
-    accounts=None,
-    average_cost="100000",
-    quote_price="108000",
-    resistance_price="119000",
-    resistance_sources=None,
-    resistance_strength="strong",
-    snapshot_id="snapshot-1",
-    quote_snapshot_id=None,
-    quote_observed_at=_SNAPSHOT_AT,
-    resistance_computed_at=_SNAPSHOT_AT,
-    ohlcv_through_date=_EXPECTED_KRX_BAR,
-    captured_at=_SNAPSHOT_AT,
-    open_actions=None,
-):
-    if accounts is None:
-        target_lot = _lot(
-            symbol=symbol,
-            lot_id=target_lot_id,
-            average_cost=average_cost,
-        )
-        if target_broker == "kis":
-            accounts = [
-                _account(broker="kis", account_id=target_account_id, lots=[target_lot]),
-                _account(broker="toss", account_id="toss-main"),
-            ]
-        else:
-            accounts = [
-                _account(broker="kis", account_id="kis-main"),
-                _account(
-                    broker="toss", account_id=target_account_id, lots=[target_lot]
-                ),
-            ]
-    return SingleShareExitEvidenceSnapshot(
-        snapshot_id=snapshot_id,
-        market="kr",
-        captured_at=captured_at,
-        target=SingleShareExitTargetIdentity(
-            symbol=symbol,
-            broker=target_broker,
-            broker_account_id=target_account_id,
-            lot_id=target_lot_id,
-        ),
-        broker_account_scope_complete=True,
-        accounts=accounts,
-        quote=SingleShareExitQuoteEvidence(
-            snapshot_id=quote_snapshot_id or snapshot_id,
-            symbol=symbol,
-            price=Decimal(quote_price),
-            observed_at=quote_observed_at,
-            source="kis_quote",
-        ),
-        resistance=SingleShareExitResistanceEvidence(
-            snapshot_id=snapshot_id,
-            symbol=symbol,
-            price=Decimal(resistance_price),
-            sources=resistance_sources or ["bb_upper", "fib_50"],
-            strength=resistance_strength,
-            computed_at=resistance_computed_at,
-            ohlcv_through_date=ohlcv_through_date,
-        ),
-        open_actions_snapshot_id=snapshot_id,
-        open_actions_checked_at=captured_at,
-        open_actions_complete=True,
-        open_actions=open_actions or [],
-    )
-
-
-@pytest.mark.parametrize(
-    ("broker", "account_id"),
-    [("kis", "kis-main"), ("toss", "toss-main")],
-)
-def test_single_share_exit_is_shadow_only_for_kis_and_toss(broker, account_id):
-    evidence = _single_share_evidence(
-        target_broker=broker,
-        target_account_id=account_id,
-    )
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert result.outcome == "SHADOW_ELIGIBLE"
-    assert result.outcome != "PROPOSE"
-    assert result.activation_state == "shadow"
-    assert result.proposal_enabled is False
-    assert result.candidate_action == "propose_full_account_lot_exit"
-    assert result.sizing == "full_account_lot_exit"
-    assert result.approval == "telegram_manual"
-    assert result.auto_approve is False
-    assert result.execution == "proposal_only"
-
-
-def test_evaluator_rejects_even_bypassed_proposal_enabled_policy(monkeypatch):
-    doc = svc.load_trading_policy()
-    rule = doc.decision_rules["sell.single_share_exit"]
-    bypassed_rule = rule.model_copy(update={"proposal_enabled": True})
-    bypassed_doc = doc.model_copy(
-        update={
-            "decision_rules": {
-                **doc.decision_rules,
-                "sell.single_share_exit": bypassed_rule,
-            }
-        }
-    )
-    monkeypatch.setattr(svc, "load_trading_policy", lambda: bypassed_doc)
-
-    result = svc.evaluate_single_share_exit(_single_share_evidence(), evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "policy_not_shadow_off",
-    )
-    assert result.candidate_action is None
-
-
-@pytest.mark.parametrize(
-    ("symbol", "quote", "resistance", "sources"),
-    [
-        ("257720", "36450", "39946.31", ["bb_upper", "fib_50"]),
-        (
-            "042660",
-            "89400",
-            "100548.9",
-            ["fib_38.2", "volume_value_area_low"],
-        ),
-        ("086790", "130500", "142264.52", ["bb_upper", "fib_0"]),
-    ],
-)
-def test_measured_far_lane_two_family_cases_are_shadow_eligible(
-    symbol, quote, resistance, sources
-):
-    # All measured lots were comfortably above 8%; avoid manufacturing an
-    # exactly-8% repeating Decimal at the boundary in this evidence test.
-    average_cost = Decimal(quote) / Decimal("1.10")
-    evidence = _single_share_evidence(
-        symbol=symbol,
-        average_cost=str(average_cost),
-        quote_price=quote,
-        resistance_price=resistance,
-        resistance_sources=sources,
-    )
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert result.outcome == "SHADOW_ELIGIBLE"
-    assert len(result.normalized_source_families) == 2
-
-
-def test_naver_one_family_is_ineligible_even_if_symbol_total_were_one():
-    evidence = _single_share_evidence(
-        symbol="035420",
-        average_cost="196428.5714285714",
-        quote_price="220000",
-        resistance_price="242550",
-        resistance_sources=["fib_50"],
-    )
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "insufficient_independent_resistance_families",
-    )
-    assert result.normalized_source_families == ("FIBONACCI",)
-
-
-def test_naver_toss_one_plus_kis_three_is_not_single_symbol_quantity():
-    accounts = [
-        _account(
-            broker="kis",
-            account_id="kis-main",
-            lots=[
-                _lot(
-                    symbol="035420",
-                    lot_id="kis-lot",
-                    quantity="3",
-                    average_cost="200000",
-                )
-            ],
-        ),
-        _account(
-            broker="toss",
-            account_id="toss-main",
-            lots=[
-                _lot(
-                    symbol="035420",
-                    lot_id="toss-lot",
-                    quantity="1",
-                    average_cost="196428.5714285714",
-                )
-            ],
-        ),
-    ]
-    evidence = _single_share_evidence(
-        symbol="035420",
-        target_broker="toss",
-        target_account_id="toss-main",
-        target_lot_id="toss-lot",
-        accounts=accounts,
-        quote_price="220000",
-        resistance_price="242550",
-    )
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "symbol_routable_sellable_quantity_not_one",
-    )
-    assert result.symbol_routable_sellable_quantity == Decimal("4")
-
-
-def test_missing_kis_or_toss_inventory_is_ineligible():
-    evidence = _single_share_evidence(
-        accounts=[
-            _account(
-                broker="kis",
-                account_id="kis-main",
-                lots=[_lot()],
-            ),
-            _account(broker="kis", account_id="kis-secondary"),
-        ]
-    )
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "incomplete_kis_toss_inventory",
-    )
-
-
-def test_duplicate_broker_account_snapshot_is_ineligible():
-    evidence = _single_share_evidence(
-        accounts=[
-            _account(
-                broker="kis",
-                account_id="kis-main",
-                lots=[_lot()],
-            ),
-            _account(broker="kis", account_id="kis-main"),
-            _account(broker="toss", account_id="toss-main"),
-        ]
-    )
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "duplicate_broker_account_snapshot",
-    )
-
-
-def test_same_symbol_broker_open_order_defers():
-    order = SingleShareExitOpenOrder(order_id="order-1", symbol="257720", side="buy")
-    accounts = [
-        _account(broker="kis", account_id="kis-main", lots=[_lot()]),
-        _account(
-            broker="toss",
-            account_id="toss-main",
-            orders=[order],
-        ),
-    ]
-
-    result = svc.evaluate_single_share_exit(
-        _single_share_evidence(accounts=accounts),
-        evaluated_at=_NOW,
-    )
-
-    assert (result.outcome, result.reason) == (
-        "DEFER",
-        "same_symbol_broker_open_order",
-    )
-
-
-def test_open_action_is_scoped_by_symbol_side_and_account():
-    unrelated = [
-        SingleShareExitOpenAction(
-            action_id="wrong-symbol",
-            symbol="035420",
-            side="sell",
-            broker_account_id="kis-main",
-            status="open",
-        ),
-        SingleShareExitOpenAction(
-            action_id="wrong-side",
-            symbol="257720",
-            side="buy",
-            broker_account_id="kis-main",
-            status="open",
-        ),
-        SingleShareExitOpenAction(
-            action_id="wrong-account",
-            symbol="257720",
-            side="sell",
-            broker_account_id="toss-main",
-            status="in_progress",
-        ),
-    ]
-    unrelated_result = svc.evaluate_single_share_exit(
-        _single_share_evidence(open_actions=unrelated),
-        evaluated_at=_NOW,
-    )
-    assert unrelated_result.outcome == "SHADOW_ELIGIBLE"
-
-    scoped = [
-        *unrelated,
-        SingleShareExitOpenAction(
-            action_id="scoped",
-            symbol="257720",
-            side="sell",
-            broker_account_id="kis-main",
-            status="open",
-        ),
-    ]
-    scoped_result = svc.evaluate_single_share_exit(
-        _single_share_evidence(open_actions=scoped),
-        evaluated_at=_NOW,
-    )
-    assert (scoped_result.outcome, scoped_result.reason) == (
-        "DEFER",
-        "unresolved_scoped_open_action",
-    )
-
-
-def test_stale_quote_is_ineligible():
-    stale_at = _NOW - timedelta(seconds=301)
-    evidence = _single_share_evidence(
-        captured_at=stale_at,
-        quote_observed_at=stale_at,
-        resistance_computed_at=stale_at,
-        accounts=[
-            _account(
-                broker="kis",
-                account_id="kis-main",
-                lots=[_lot()],
-                observed_at=stale_at,
-            ),
-            _account(
-                broker="toss",
-                account_id="toss-main",
-                observed_at=stale_at,
-            ),
-        ],
-    )
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == ("INELIGIBLE", "stale_quote")
-
-
-def test_inconsistent_snapshot_id_is_ineligible():
-    evidence = _single_share_evidence(quote_snapshot_id="other-snapshot")
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "inconsistent_snapshot_id",
-    )
-
-
-def test_ohlcv_must_cover_expected_completed_krx_bar():
-    evidence = _single_share_evidence(ohlcv_through_date=date(2026, 7, 22))
-
-    result = svc.evaluate_single_share_exit(evidence, evaluated_at=_NOW)
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "ohlcv_not_through_expected_completed_krx_bar",
-    )
-    assert result.expected_completed_krx_bar_date == _EXPECTED_KRX_BAR
-
-
-def test_profit_and_distance_are_recomputed_from_decimal_snapshot():
-    parameters = inspect.signature(svc.evaluate_single_share_exit).parameters
-    assert "profit_pct" not in parameters
-    assert "resistance_distance_pct" not in parameters
-
-    result = svc.evaluate_single_share_exit(
-        _single_share_evidence(
-            average_cost="100000",
-            quote_price="108000",
-            resistance_price="118800",
-        ),
-        evaluated_at=_NOW,
-    )
-
-    assert result.profit_pct == Decimal("8.0000")
-    assert result.resistance_distance_pct == Decimal("10.0000")
-    assert result.average_cost == Decimal("100000")
-    assert result.current_quote == Decimal("108000")
-    assert result.resistance_price == Decimal("118800")
-
-
-@pytest.mark.parametrize(
-    ("resistance_price", "expected_outcome"),
-    [
-        ("114480", "INELIGIBLE"),  # exactly +6%, exclusive
-        ("124200", "SHADOW_ELIGIBLE"),  # exactly +15%, inclusive
-        ("124200.01", "INELIGIBLE"),  # above +15%
-    ],
-)
-def test_far_resistance_band_boundaries(resistance_price, expected_outcome):
-    result = svc.evaluate_single_share_exit(
-        _single_share_evidence(resistance_price=resistance_price),
-        evaluated_at=_NOW,
-    )
-
-    assert result.outcome == expected_outcome
-
-
-def test_multiple_fibonacci_sources_count_as_one_family():
-    result = svc.evaluate_single_share_exit(
-        _single_share_evidence(resistance_sources=["fib_0", "fib_38.2", "fib_50"]),
-        evaluated_at=_NOW,
-    )
-
-    assert (result.outcome, result.reason) == (
-        "INELIGIBLE",
-        "insufficient_independent_resistance_families",
-    )
-    assert result.normalized_source_families == ("FIBONACCI",)
-
-
-def test_loss_guard_is_decimal_and_checked_separately():
-    result = svc.evaluate_single_share_exit(
-        _single_share_evidence(
-            average_cost="100000",
-            quote_price="100999.9999",
-            resistance_price="112000",
-        ),
-        evaluated_at=_NOW,
-    )
-
-    assert (result.outcome, result.reason) == ("INELIGIBLE", "loss_guard_not_met")
-
-
-def test_resistance_provenance_and_freshness_fields_are_preserved():
-    result = svc.evaluate_single_share_exit(
-        _single_share_evidence(
-            resistance_sources=["volume_poc", "bb_upper"],
-            resistance_strength="moderate",
-        ),
-        evaluated_at=_NOW,
-    )
-
-    assert result.outcome == "SHADOW_ELIGIBLE"
-    assert result.resistance_sources == ("volume_poc", "bb_upper")
-    assert result.normalized_source_families == (
-        "BOLLINGER",
-        "VOLUME_PROFILE",
-    )
-    assert result.resistance_strength == "moderate"
-    assert result.quote_source == "kis_quote"
-    assert result.quote_age_seconds == Decimal("60.0")
-    assert result.quote_observed_at == _SNAPSHOT_AT
-    assert result.resistance_computed_at == _SNAPSHOT_AT
-    assert result.ohlcv_through_date == _EXPECTED_KRX_BAR
 
 
 def test_existing_trim_preplace_rule_is_exactly_unchanged():
@@ -632,7 +72,7 @@ def test_existing_trim_preplace_rule_is_exactly_unchanged():
                 "id": "rsi_confirmed_resistance",
                 "conditions": {
                     "rsi_min_policy_key": "sell.rsi_place_min",
-                    "resistance_near_pct_max_policy_key": ("sell.resistance_near_pct"),
+                    "resistance_near_pct_max_policy_key": "sell.resistance_near_pct",
                 },
                 "action": "preplace_small_trim_ladder",
                 "sizing": "small_trim_only",
@@ -651,7 +91,7 @@ def test_existing_trim_preplace_rule_is_exactly_unchanged():
                 "conditions": {
                     "rsi_below_policy_key": "sell.rsi_place_min",
                     "resistance_near_pct_min_exclusive": 2,
-                    "resistance_near_pct_max_policy_key": ("sell.resistance_near_pct"),
+                    "resistance_near_pct_max_policy_key": "sell.resistance_near_pct",
                 },
                 "action": "register_watch",
                 "sizing": "no_preplaced_trim",
@@ -673,9 +113,35 @@ def test_existing_trim_preplace_rule_is_exactly_unchanged():
     }
 
 
-def test_unknown_market_raises():
+def test_market_override_applied(monkeypatch, tmp_path):
+    raw = yaml.safe_load(svc._POLICY_PATH.read_text(encoding="utf-8"))
+    raw["market_overrides"]["us"]["screen.rsi_max"] = 55
+    policy_path = tmp_path / "trading_policy.yaml"
+    policy_path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    monkeypatch.setattr(svc, "_POLICY_PATH", Path(policy_path))
+    svc._reset_cache_for_tests()
+    threshold = svc.get_policy_for("us", "discovery")["thresholds"]["screen.rsi_max"]
+    assert threshold["value"] == 55
+    assert threshold["source"] == "override"
+
+
+@pytest.mark.parametrize(
+    ("market", "lane"),
+    [("us", "sell"), ("crypto", "discovery")],
+)
+def test_global_advisories_remain_market_lane_independent(market, lane):
+    view = svc.get_policy_for(market, lane)
+    assert view["crash_day"]["trigger"]["index_symbol"] == "069500"
+    assert any(
+        stance["id"] == "ai-demand-real-value-selective"
+        for stance in view["user_stances"]
+    )
+
+
+@pytest.mark.parametrize("market", ["jp", "KR"])
+def test_unknown_market_raises(market):
     with pytest.raises(svc.TradingPolicyKeyError):
-        svc.get_policy_for("jp", "buy")
+        svc.get_policy_for(market, "buy")
 
 
 def test_unknown_lane_raises():
@@ -683,104 +149,17 @@ def test_unknown_lane_raises():
         svc.get_policy_for("kr", "scalp")
 
 
-def test_market_override_applied(monkeypatch, tmp_path):
-    from pathlib import Path
-
-    import yaml
-
-    raw = yaml.safe_load(svc._POLICY_PATH.read_text(encoding="utf-8"))
-    raw["market_overrides"]["us"]["screen.rsi_max"] = 55
-    p = tmp_path / "trading_policy.yaml"
-    p.write_text(yaml.safe_dump(raw), encoding="utf-8")
-    monkeypatch.setattr(svc, "_POLICY_PATH", Path(p))
-    svc.load_trading_policy.cache_clear() if hasattr(
-        svc.load_trading_policy, "cache_clear"
-    ) else None
-    svc._reset_cache_for_tests()
-    t = svc.get_policy_for("us", "discovery")["thresholds"]
-    assert t["screen.rsi_max"]["value"] == 55
-    assert t["screen.rsi_max"]["source"] == "override"
-
-
-def test_get_policy_for_includes_crash_day_advisory_with_version_stamp():
-    view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == svc.policy_version_stamp()["version"]
-    assert view["content_hash"] == svc.policy_content_hash()
-    crash_day = view["crash_day"]
-    assert crash_day["trigger"]["index_symbol"] == "069500"
-    assert crash_day["trigger"]["index_gap_pct_max"] == -3.0
-    assert crash_day["actions"]["new_entry_hold"] is True
-
-
-def test_get_policy_for_crash_day_present_regardless_of_market_lane():
-    # crash_day is a single global advisory trigger, not market/lane-scoped.
-    us_sell = svc.get_policy_for("us", "sell")["crash_day"]
-    crypto_discovery = svc.get_policy_for("crypto", "discovery")["crash_day"]
-    assert us_sell == crypto_discovery
-
-
-def test_get_policy_for_includes_user_stances_advisory():
-    view = svc.get_policy_for("kr", "buy")
-    stances = {s["id"]: s for s in view["user_stances"]}
-    stance = stances["ai-demand-real-value-selective"]
-    assert stance["review_date"] == "2026-10-17"
-    assert stance["risk_scenario"].startswith("효율 충격")
-
-
-def test_get_policy_for_user_stances_present_regardless_of_market_lane():
-    # user_stances is global advisory context, not market/lane-scoped.
-    us_sell = svc.get_policy_for("us", "sell")["user_stances"]
-    crypto_discovery = svc.get_policy_for("crypto", "discovery")["user_stances"]
-    assert us_sell == crypto_discovery
-
-
-def test_get_policy_for_includes_us_notional_usd_range_with_one_share_exception():
-    view = svc.get_policy_for("us", "buy")
-    t = view["thresholds"]
-    us_range = t["buy.per_symbol_notional_usd_range"]
-
-    assert us_range["value"] == [150, 450]
-    assert us_range["unit"] == "usd"
-    assert us_range["one_share_exception"] == {
-        "enabled": True,
-        "absolute_ceiling_usd": 700,
-        "max_deep_rungs": 1,
-    }
-
-
-def test_get_policy_for_kr_notional_krw_range_has_no_one_share_exception():
-    view = svc.get_policy_for("kr", "buy")
-    kr_range = view["thresholds"]["buy.per_symbol_notional_krw_range"]
-
-    assert kr_range["value"] == [200000, 400000]
-    assert kr_range["one_share_exception"] is None
-
-
-def test_sector_cluster_for():
-    assert svc.sector_cluster_for("반도체") == "semis_memory"
-    assert svc.sector_cluster_for("Financial Services") == "financials"
-    assert svc.sector_cluster_for("정체불명업종") is None
-    assert svc.sector_cluster_for(None) is None
-
-
-def test_sector_cluster_for_no_cjk_substring_false_positive():
-    # ROB-646 Finding 3: "의료" must not spill into unrelated 업종 like
-    # "의료정밀" (medical *precision instruments*). Member "의료" removed +
-    # matcher is one-directional (member is a substring of the label, not the
-    # reverse), so "의료정밀" resolves to no cluster.
-    assert svc.sector_cluster_for("의료정밀") is None
-
-
-def test_sector_cluster_for_broad_healthcare_not_bio():
-    # ROB-646 Finding 3: a generic "Healthcare" sector (e.g. managed-care /
-    # health insurers) must not be bucketed as bio.
-    assert svc.sector_cluster_for("Healthcare") is None
-    assert svc.sector_cluster_for("Healthcare Plans") is None
-
-
-def test_sector_cluster_for_prefix_coverage_preserved():
-    # One-directional match still gives real KR coverage: the Naver 업종
-    # "반도체와반도체장비" contains the member "반도체".
-    assert svc.sector_cluster_for("반도체와반도체장비") == "semis_memory"
-    # yfinance em-dash variants still map (member is a substring of the label).
-    assert svc.sector_cluster_for("Drug Manufacturers—General") == "bio"
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("반도체", "semis_memory"),
+        ("반도체와반도체장비", "semis_memory"),
+        ("Financial Services", "financials"),
+        ("Drug Manufacturers—General", "bio"),
+        ("의료정밀", None),
+        ("Healthcare Plans", None),
+        (None, None),
+    ],
+)
+def test_sector_cluster_mapping(label, expected):
+    assert svc.sector_cluster_for(label) == expected

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -16,11 +16,20 @@ def test_version_stamp_has_version_and_hash():
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
     assert view["version"] == "2026-07-23.3"
+    assert view["version"] == svc.policy_version_stamp()["version"]
+    assert view["content_hash"] == svc.policy_content_hash()
     assert view["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert view["thresholds"]["portfolio.max_symbols_per_theme"]["value"] == 2
     assert view["thresholds"]["sell.loss_guard_min_multiple"]["value"] == 1.01
     assert "sell.rsi_place_min" not in view["thresholds"]
     assert view["decision_rules"] == {}
+
+
+def test_get_policy_for_sell_lane_filters_thresholds():
+    thresholds = svc.get_policy_for("kr", "sell")["thresholds"]
+
+    assert thresholds["sell.rsi_place_min"]["value"] == 58
+    assert "screen.rsi_max" not in thresholds
 
 
 def test_get_policy_for_filters_crypto_market_rules_by_lane():
@@ -138,6 +147,14 @@ def test_global_advisories_remain_market_lane_independent(market, lane):
     )
 
 
+def test_global_advisories_are_identical_across_market_and_lane():
+    us_sell = svc.get_policy_for("us", "sell")
+    crypto_discovery = svc.get_policy_for("crypto", "discovery")
+
+    assert us_sell["crash_day"] == crypto_discovery["crash_day"]
+    assert us_sell["user_stances"] == crypto_discovery["user_stances"]
+
+
 @pytest.mark.parametrize("market", ["jp", "KR"])
 def test_unknown_market_raises(market):
     with pytest.raises(svc.TradingPolicyKeyError):
@@ -157,7 +174,9 @@ def test_unknown_lane_raises():
         ("Financial Services", "financials"),
         ("Drug Manufacturers—General", "bio"),
         ("의료정밀", None),
+        ("Healthcare", None),
         ("Healthcare Plans", None),
+        ("정체불명업종", None),
         (None, None),
     ],
 )

--- a/tests/test_route_request.py
+++ b/tests/test_route_request.py
@@ -87,16 +87,24 @@ def test_buy_analysis_echoes_policy_and_proposal_contract():
     assert _steps(out)[-1] == "order_proposal_create"
 
 
-@pytest.mark.parametrize(
-    ("market", "expected"),
-    [("kr", True), ("us", False), ("crypto", False)],
-)
-def test_profit_taking_policy_surface_is_market_scoped(market, expected):
+@pytest.mark.parametrize("market", ["us", "crypto"])
+def test_profit_taking_hides_kr_shadow_rule_from_other_markets(market):
     route = _route_tool()
     out = asyncio.run(route(intent="profit_taking", market=market))
     assert out["success"] is True
     rules = out["verdict_thresholds"]["decision_rules"]
-    assert ("sell.single_share_exit" in rules) is expected
+    assert "sell.single_share_exit" not in rules
+
+
+def test_profit_taking_labels_kr_single_share_rule_as_shadow_only():
+    out = asyncio.run(_route_tool()(intent="profit_taking", market="kr"))
+    rule = out["verdict_thresholds"]["decision_rules"]["sell.single_share_exit"]
+
+    assert rule["activation_state"] == "shadow"
+    assert rule["proposal_enabled"] is False
+    assert rule["operator_approval_required"] is True
+    assert rule["proposal"]["execution"] == "proposal_only"
+    assert rule["proposal"]["auto_approve"] is False
 
 
 def test_market_brief_has_version_but_empty_thresholds():

--- a/tests/test_route_request.py
+++ b/tests/test_route_request.py
@@ -87,6 +87,18 @@ def test_buy_analysis_echoes_policy_and_proposal_contract():
     assert _steps(out)[-1] == "order_proposal_create"
 
 
+@pytest.mark.parametrize(
+    ("market", "expected"),
+    [("kr", True), ("us", False), ("crypto", False)],
+)
+def test_profit_taking_policy_surface_is_market_scoped(market, expected):
+    route = _route_tool()
+    out = asyncio.run(route(intent="profit_taking", market=market))
+    assert out["success"] is True
+    rules = out["verdict_thresholds"]["decision_rules"]
+    assert ("sell.single_share_exit" in rules) is expected
+
+
 def test_market_brief_has_version_but_empty_thresholds():
     out = asyncio.run(_route_tool()(intent="market_brief", market="kr"))
 


### PR DESCRIPTION
## Summary

Adds a **provisional, shadow-only** KR single-share exit review lane (`sell.single_share_exit`) to the trading-policy decision surface, for the narrow case where complete KIS+Toss evidence proves a symbol's account-wide routable sellable quantity is exactly 1 (a size the existing `sell.trim_preplace` ladder logic can't act on sensibly).

- New rule `sell.single_share_exit` in `config/trading_policy.yaml`: profit ≥ 8%, resistance strictly between +6% and +15% (far band), ≥2 independent resistance source families, loss guard (avg cost × 1.01) enforced, per-evidence-class staleness bounds (quote/resistance/holdings/open_orders/open_actions/captured_at, all ≤300s + pairwise skew ≤300s).
- `app/services/single_share_exit_snapshot_service.py`: a capability-sealed producer/context architecture (`ValidatedSingleShareExitContext`) that replaces a plain pydantic evidence-snapshot model. The evaluator only accepts a context object issued by a registered producer authority — raw dicts/dataclasses/copies/pickles cannot be handed in to fake evidence completeness (enforced via `__getattribute__` interception + identity-registered state, not just type hints).
- `app/services/trading_policy_service.py`: `evaluate_single_share_exit` (live) / `evaluate_single_share_exit_replay` (offline replay, capped to `REPLAY_ELIGIBLE` — can never claim live eligibility) — both fail-closed on any missing/stale/inconsistent evidence, in particular **no resistance reference → `INELIGIBLE`, never a fabricated price**.
- `route_request`'s `verdict_thresholds` now scopes `sell.single_share_exit` to `market="kr"` only (previously an empty-scope rule leaked into US/crypto responses).

## Shadow-only contract

This is evaluation-only. There is no wiring into any proposal-creation or broker-mutation path — `evaluate_single_share_exit`/`_replay` have no production callers outside tests. The gate is also mutation-sensitive: `test_activation_and_proposal_off_are_rechecked` monkeypatches `proposal_enabled=True` on the loaded policy doc and asserts the evaluator still returns `INELIGIBLE` / `policy_not_shadow_off` — flipping the config alone cannot make this path live-eligible.

## Relationship to ROB-1037

The `rob-1037` worktree was independently editing the same three files (`app/schemas/trading_policy.py`, `app/services/trading_policy_service.py`, `config/trading_policy.yaml`). Per operator direction, this track (which has test coverage) goes first; `rob-1037` is sealed at `05e78a064` and will rebase onto this once merged. **This PR should not be merged without a second pass — do not merge yet.**

## Test plan

- [x] `uv run pytest tests/services/test_trading_policy_service.py tests/schemas/test_trading_policy_schema.py tests/mcp_server/test_trading_policy_tool.py tests/services/order_proposals/test_dispatch.py tests/test_route_request.py tests/services/test_single_share_exit_snapshot_service.py -q` → 150 passed
- [x] Full unit suite: `uv run pytest tests/ -q -m "not integration and not slow"` → 16995 passed, 9 skipped, 1178 deselected, 0 failed (an earlier run in this session hit mass transient errors from shared-DB contention with other concurrent sessions on this box; a clean rerun confirmed green)
- [x] `ruff check` / `ruff format --check` on all changed files — clean
- [x] Rebased cleanly onto `origin/main` (no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `sell.single_share_exit` as a provisional, shadow-only fallback for KR sells; it’s hidden from other markets when requesting lane/market routing.
  - Introduced single-share exit evaluation for live and deterministic replay modes, returning eligibility/deferral results.
- **Bug Fixes**
  - Expanded trading-policy schema to support the new single-share decision-rule shape with stricter broker-inventory and resistance-band boundary validation.
  - Strengthened fail-closed snapshot/context validation and tightened evidence staleness/timestamp and quantity/executable-quote requirements.
- **Documentation**
  - Clarified that the shadow rule is metadata only and does not authorize proposal creation/approval/execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->