### PR TITLE
feat(ROB-1040): CRS-24 refreeze launcher + real-corpus input binding

### DIFF
--- a/research/nautilus_scalping/rob1040_crs24_evidence.py
+++ b/research/nautilus_scalping/rob1040_crs24_evidence.py
@@ -617,11 +617,172 @@ class ValidatedCampaignContext(Protocol):
     ) -> FeasibilityEvidence: ...
 
 
-def _validated_campaign_factory() -> ValidatedCampaignContext:
+@dataclass(frozen=True, slots=True)
+class CampaignInputBinding:
+    """Caller-constructed ``generator``/``references`` pair, pinned once.
+
+    Exactly two postures exist:
+
+    * ``"frozen_synthetic_fixture"`` — built ONLY by this module's
+      zero-argument default path (:func:`_validated_campaign_factory` called
+      with no binding). Every pin must equal this module's compile-time
+      frozen ``SYNTHETIC_*`` constant, so this posture stays byte-identical
+      to the pre-existing behavior; a caller can never construct one.
+    * ``"refrozen_real_corpus"`` — built by an external caller (the ROB-1040
+      refreeze launcher) from real 1-minute corpus data via
+      :meth:`for_real_corpus`. No compile-time literal can exist for
+      un-emitted real-corpus content, so every pin is instead captured once
+      from the bound ``generator``/``references`` objects themselves at
+      construction time and reverified against that same captured value on
+      every later use — the same anti-substitution identity discipline as
+      the synthetic path, without a value known in advance.
+
+    Nothing downstream of this binding (``evaluate_cell`` and everything it
+    calls) branches on posture; only the pin *source* differs.
+    """
+
+    posture: str
+    version: str
+    generator: CRSFeatureGenerator
+    references: ReferenceSurface
+    snapshot_sha256_pin: str
+    entry_source_sha256_pin: str
+    exit_presence_source_sha256_pin: str
+    fixture_content_sha256_pin: str
+    extra_authority: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        if self.posture not in {"frozen_synthetic_fixture", "refrozen_real_corpus"}:
+            raise ValueError("campaign input binding posture is unknown")
+        if type(self.version) is not str or not self.version:
+            raise TypeError("campaign input binding version must be a non-empty str")
+        if type(self.generator) is not CRSFeatureGenerator:
+            raise TypeError(
+                "campaign input binding generator must be exact CRSFeatureGenerator"
+            )
+        if type(self.references) is not ReferenceSurface:
+            raise TypeError(
+                "campaign input binding references must be exact ReferenceSurface"
+            )
+        for name in (
+            "snapshot_sha256_pin",
+            "entry_source_sha256_pin",
+            "exit_presence_source_sha256_pin",
+            "fixture_content_sha256_pin",
+        ):
+            _sha256(getattr(self, name), name)
+        if type(self.extra_authority) is not tuple or any(
+            type(item) is not tuple
+            or len(item) != 2
+            or type(item[0]) is not str
+            or type(item[1]) is not str
+            for item in self.extra_authority
+        ):
+            raise TypeError(
+                "extra_authority must be an exact tuple of (str, str) pairs"
+            )
+        if self.posture == "frozen_synthetic_fixture":
+            if (
+                self.version != SYNTHETIC_FIXTURE_VERSION
+                or self.snapshot_sha256_pin != SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256
+                or self.entry_source_sha256_pin
+                != SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256
+                or self.exit_presence_source_sha256_pin
+                != SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
+                or self.fixture_content_sha256_pin != SYNTHETIC_FIXTURE_CONTENT_SHA256
+                or self.extra_authority != ()
+            ):
+                raise ValueError(
+                    "synthetic posture must reuse only the frozen synthetic pins"
+                )
+        else:
+            if (
+                self.version == SYNTHETIC_FIXTURE_VERSION
+                or self.snapshot_sha256_pin == SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256
+                or self.entry_source_sha256_pin
+                == SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256
+                or self.exit_presence_source_sha256_pin
+                == SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
+                or self.fixture_content_sha256_pin == SYNTHETIC_FIXTURE_CONTENT_SHA256
+            ):
+                raise ValueError(
+                    "real-corpus posture must not reuse any frozen synthetic pin"
+                )
+        if self.snapshot_sha256_pin != self.generator.snapshot_sha256:
+            raise ValueError("snapshot pin does not match the bound generator")
+        if self.entry_source_sha256_pin != self.references.entry_source_sha256:
+            raise ValueError("entry-source pin does not match the bound references")
+        if (
+            self.exit_presence_source_sha256_pin
+            != self.references.exit_presence_source_sha256
+        ):
+            raise ValueError("exit-presence pin does not match the bound references")
+        if self.fixture_content_sha256_pin != fixture_content_sha256(
+            self.generator, self.references
+        ):
+            raise ValueError(
+                "full-input pin does not match the bound generator/references"
+            )
+
+    @classmethod
+    def for_real_corpus(
+        cls,
+        *,
+        version: str,
+        generator: CRSFeatureGenerator,
+        references: ReferenceSurface,
+        corpus_manifest_content_sha256: str,
+    ) -> CampaignInputBinding:
+        """Build a ``refrozen_real_corpus`` binding; every pin is self-captured.
+
+        The caller supplies only the generator/references objects and the
+        corpus manifest content hash for evidence-trail purposes — every pin
+        value is read back from ``generator``/``references`` themselves
+        (never accepted as a bare caller-supplied string), so a mismatched or
+        forged pin cannot be constructed this way.
+        """
+        _sha256(corpus_manifest_content_sha256, "corpus_manifest_content_sha256")
+        return cls(
+            posture="refrozen_real_corpus",
+            version=version,
+            generator=generator,
+            references=references,
+            snapshot_sha256_pin=generator.snapshot_sha256,
+            entry_source_sha256_pin=references.entry_source_sha256,
+            exit_presence_source_sha256_pin=references.exit_presence_source_sha256,
+            fixture_content_sha256_pin=fixture_content_sha256(generator, references),
+            extra_authority=(
+                (
+                    "corpus_manifest_content_sha256",
+                    corpus_manifest_content_sha256,
+                ),
+            ),
+        )
+
+
+def _validated_campaign_factory(
+    binding: CampaignInputBinding | None = None,
+) -> ValidatedCampaignContext:
     """Build the sole computation context after checking every frozen input pin."""
-    fixture = build_synthetic_fixture()
-    generator = validate_frozen_synthetic_fixture(fixture)
-    references = fixture.references
+    if binding is None:
+        fixture = build_synthetic_fixture()
+        generator = validate_frozen_synthetic_fixture(fixture)
+        binding = CampaignInputBinding(
+            posture="frozen_synthetic_fixture",
+            version=fixture.version,
+            generator=generator,
+            references=fixture.references,
+            snapshot_sha256_pin=SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256,
+            entry_source_sha256_pin=SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256,
+            exit_presence_source_sha256_pin=SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256,
+            fixture_content_sha256_pin=SYNTHETIC_FIXTURE_CONTENT_SHA256,
+            extra_authority=(),
+        )
+    if type(binding) is not CampaignInputBinding:
+        raise TypeError("campaign input binding must be exact CampaignInputBinding")
+
+    generator = binding.generator
+    references = binding.references
     registered_configs = ACTIVE_CONFIGS
     registered_folds = exact_h4_folds()
     registered_config_snapshots = copy.deepcopy(registered_configs)
@@ -630,8 +791,11 @@ def _validated_campaign_factory() -> ValidatedCampaignContext:
     references_identity = id(references)
 
     def verify_live_inputs() -> None:
-        if fixture.version != SYNTHETIC_FIXTURE_VERSION:
-            raise RunAuthorityClosedError("campaign fixture version changed at use")
+        if (
+            binding.posture == "frozen_synthetic_fixture"
+            and binding.version != SYNTHETIC_FIXTURE_VERSION
+        ):
+            raise RunAuthorityClosedError("campaign binding version changed at use")
         if registered_configs != registered_config_snapshots:
             raise RunAuthorityClosedError("campaign config state changed at use")
         if registered_folds != registered_fold_snapshots:
@@ -644,18 +808,18 @@ def _validated_campaign_factory() -> ValidatedCampaignContext:
             references_identity
         ):
             raise RunAuthorityClosedError("campaign reference identity changed")
-        if generator.snapshot_sha256 != SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256:
+        if generator.snapshot_sha256 != binding.snapshot_sha256_pin:
             raise RunAuthorityClosedError("campaign snapshot pin changed at use")
-        if references.entry_source_sha256 != SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256:
+        if references.entry_source_sha256 != binding.entry_source_sha256_pin:
             raise RunAuthorityClosedError("campaign entry-source pin changed at use")
         if (
             references.exit_presence_source_sha256
-            != SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
+            != binding.exit_presence_source_sha256_pin
         ):
             raise RunAuthorityClosedError("campaign exit-presence pin changed at use")
         if (
             fixture_content_sha256(generator, references)
-            != SYNTHETIC_FIXTURE_CONTENT_SHA256
+            != binding.fixture_content_sha256_pin
         ):
             raise RunAuthorityClosedError("campaign full-input identity changed at use")
 
@@ -668,17 +832,20 @@ def _validated_campaign_factory() -> ValidatedCampaignContext:
     issued_evidence_digest: str | None = None
     issued_evidence_totals_snapshot: CampaignTotals | None = None
 
-    def live_input_identity() -> dict[str, str]:
+    def live_input_identity() -> dict[str, object]:
         verify_live_inputs()
-        return {
-            "posture": "frozen_synthetic_fixture",
-            "fixture_version": fixture.version,
+        payload: dict[str, object] = {
+            "posture": binding.posture,
+            "fixture_version": binding.version,
             "complete_bar_snapshot_sha256": generator.snapshot_sha256,
             "entry_reference_source_sha256": references.entry_source_sha256,
             "exit_presence_source_sha256": references.exit_presence_source_sha256,
             "fixture_content_sha256": fixture_content_sha256(generator, references),
             "binding": "validated_campaign_context_object_identity",
         }
+        if binding.extra_authority:
+            payload["real_corpus_authority"] = dict(binding.extra_authority)
+        return payload
 
     def evaluate_cell(config: object, fold: object) -> CellFeasibility:
         verify_live_inputs()
@@ -928,7 +1095,10 @@ def _validated_campaign_factory() -> ValidatedCampaignContext:
         digest = canonical_sha256(core)
         if issued_evidence_digest is None or digest != issued_evidence_digest:
             raise RunAuthorityClosedError("evidence payload identity changed")
-        if digest != FROZEN_SYNTHETIC_EVIDENCE_SHA256:
+        if (
+            binding.posture == "frozen_synthetic_fixture"
+            and digest != FROZEN_SYNTHETIC_EVIDENCE_SHA256
+        ):
             raise RunAuthorityClosedError("frozen synthetic evidence pin changed")
         return cells, totals, digest, core
 
@@ -1027,6 +1197,41 @@ def build_frozen_synthetic_evidence() -> FeasibilityEvidence:
     return context.seal_cells(cells)
 
 
+def open_real_corpus_campaign_context(
+    binding: CampaignInputBinding,
+) -> ValidatedCampaignContext:
+    """Open a validated context from a caller-supplied real-corpus binding.
+
+    Only an exact ``posture="refrozen_real_corpus"`` binding is accepted —
+    a synthetic-posture binding can only ever be constructed by this
+    module's own zero-argument default path
+    (:func:`open_frozen_synthetic_test_seam`/
+    :func:`build_frozen_synthetic_evidence`), never by a caller, so every
+    synthetic invocation stays on the byte-identical frozen path and no
+    caller can claim the synthetic posture for substituted content.
+    """
+    if type(binding) is not CampaignInputBinding or binding.posture != (
+        "refrozen_real_corpus"
+    ):
+        raise RunAuthorityClosedError(
+            "real-corpus campaign context requires an exact refrozen_real_corpus"
+            " binding"
+        )
+    return _validated_campaign_factory(binding)
+
+
+def build_real_corpus_evidence(
+    binding: CampaignInputBinding,
+) -> FeasibilityEvidence:
+    """Issue evidence for cells computed from a caller-supplied real-corpus
+    binding. The decision logic invoked is identical to the synthetic path
+    (same ``evaluate_cell``/``evaluate_all``/``evidence_core`` closures);
+    only the bound ``generator``/``references`` differ."""
+    context = open_real_corpus_campaign_context(binding)
+    cells = context.cells()
+    return context.seal_cells(cells)
+
+
 def build_evidence(*_args: object, **_kwargs: object) -> None:
     raise RunAuthorityClosedError(
         "caller-supplied evidence issuance is closed pending merge/refreeze/approval"
@@ -1055,6 +1260,7 @@ def render_evidence_bytes() -> bytes:
 
 
 __all__ = [
+    "CampaignInputBinding",
     "CampaignTotals",
     "EVIDENCE_SCHEMA_VERSION",
     "FROZEN_SYNTHETIC_EVIDENCE_SHA256",
@@ -1062,8 +1268,10 @@ __all__ = [
     "ValidatedCampaignContext",
     "build_evidence",
     "build_frozen_synthetic_evidence",
+    "build_real_corpus_evidence",
     "cell_payload",
     "open_frozen_synthetic_test_seam",
+    "open_real_corpus_campaign_context",
     "render_evidence_bytes",
     "run_frozen_synthetic_cells",
 ]

--- a/research/nautilus_scalping/rob1040_crs24_evidence.py
+++ b/research/nautilus_scalping/rob1040_crs24_evidence.py
@@ -59,6 +59,10 @@ EVIDENCE_SCHEMA_VERSION = "rob1040.crs24.corr1.feasibility_evidence.v3"
 FROZEN_SYNTHETIC_EVIDENCE_SHA256 = (
     "ef9b0b819bef5e4cb0a63a9f88b5df0a7a65832d103d4ed379ba460fa3232bab"
 )
+# Mandatory `extra_authority` key for the `refrozen_real_corpus` posture: the
+# real corpus has no compile-time content pin, so its provenance trail must at
+# minimum name the frozen corpus manifest it was loaded from.
+REAL_CORPUS_MANIFEST_AUTHORITY_KEY = "corpus_manifest_content_sha256"
 
 
 def _exact_int(value: object, name: str) -> int:
@@ -623,11 +627,16 @@ class CampaignInputBinding:
 
     Exactly two postures exist:
 
-    * ``"frozen_synthetic_fixture"`` — built ONLY by this module's
-      zero-argument default path (:func:`_validated_campaign_factory` called
-      with no binding). Every pin must equal this module's compile-time
-      frozen ``SYNTHETIC_*`` constant, so this posture stays byte-identical
-      to the pre-existing behavior; a caller can never construct one.
+    * ``"frozen_synthetic_fixture"`` — the posture this module's
+      zero-argument default path builds (:func:`_validated_campaign_factory`
+      called with no binding). Every pin must equal this module's
+      compile-time frozen ``SYNTHETIC_*`` constant. An external caller *can*
+      construct such a binding, but only by supplying a generator/reference
+      pair whose self-computed digests equal those frozen constants — i.e.
+      only by supplying byte-identical frozen content — so this posture stays
+      byte-identical to the pre-existing behavior regardless of who builds
+      it. (It is separately barred from the real-corpus entry points by
+      :func:`open_real_corpus_campaign_context`'s posture check.)
     * ``"refrozen_real_corpus"`` — built by an external caller (the ROB-1040
       refreeze launcher) from real 1-minute corpus data via
       :meth:`for_real_corpus`. No compile-time literal can exist for
@@ -696,17 +705,49 @@ class CampaignInputBinding:
                     "synthetic posture must reuse only the frozen synthetic pins"
                 )
         else:
+            # Anti-substitution: a real-corpus binding must not be a relabelled
+            # frozen synthetic fixture. The decisive discriminator is the JOINT
+            # identity `fixture_content_sha256_pin` (generator + references
+            # together) -- differing there is by itself sufficient proof that
+            # this binding is not the synthetic fixture. `version`, the
+            # complete-bar `snapshot_sha256_pin` and the value-bearing
+            # `entry_source_sha256_pin` add independent content-bearing
+            # evidence and are also required to differ.
+            #
+            # `exit_presence_source_sha256_pin` is DELIBERATELY EXCLUDED from
+            # the must-differ set. `ReferenceSurface.exit_presence_source_sha256`
+            # hashes only the {symbol, timestamp_ms} of the rows whose
+            # `present` flag is True, over a FROZEN key domain (1296 keys,
+            # fixed order) -- it is a presence bitmap and carries no content.
+            # Consequently ANY two datasets with complete exit coverage produce
+            # the identical digest by construction: the all-signal synthetic
+            # calendar (1296/1296 present) and a gapless real corpus
+            # (1296/1296 present) necessarily collide. Requiring that pin to
+            # differ would amount to requiring the real corpus to be MISSING
+            # exit bars -- the exact opposite of the desired property, and a
+            # false positive on every healthy corpus. The pin is still captured
+            # at construction and still reverified against the bound references
+            # below and on every later use (`verify_live_inputs`), so exit
+            # presence remains tamper-evident; it simply is not a posture
+            # discriminator.
             if (
                 self.version == SYNTHETIC_FIXTURE_VERSION
                 or self.snapshot_sha256_pin == SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256
                 or self.entry_source_sha256_pin
                 == SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256
-                or self.exit_presence_source_sha256_pin
-                == SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
                 or self.fixture_content_sha256_pin == SYNTHETIC_FIXTURE_CONTENT_SHA256
             ):
                 raise ValueError(
                     "real-corpus posture must not reuse any frozen synthetic pin"
+                )
+            # Provenance is mandatory for the real posture: without it the
+            # emitted evidence would carry no corpus authority at all.
+            if not any(
+                name == REAL_CORPUS_MANIFEST_AUTHORITY_KEY
+                for name, _ in self.extra_authority
+            ):
+                raise ValueError(
+                    "real-corpus posture requires corpus-manifest provenance authority"
                 )
         if self.snapshot_sha256_pin != self.generator.snapshot_sha256:
             raise ValueError("snapshot pin does not match the bound generator")
@@ -753,7 +794,7 @@ class CampaignInputBinding:
             fixture_content_sha256_pin=fixture_content_sha256(generator, references),
             extra_authority=(
                 (
-                    "corpus_manifest_content_sha256",
+                    REAL_CORPUS_MANIFEST_AUTHORITY_KEY,
                     corpus_manifest_content_sha256,
                 ),
             ),

--- a/research/nautilus_scalping/tests/test_rob1040_crs24_evidence_real_corpus_binding.py
+++ b/research/nautilus_scalping/tests/test_rob1040_crs24_evidence_real_corpus_binding.py
@@ -1,0 +1,256 @@
+"""ROB-1040 CRS-24 CORR-1 real-corpus input-binding seam.
+
+Covers the ONLY intentional opening of the sealed CRS-24 evidence module:
+``CampaignInputBinding``/``open_real_corpus_campaign_context``/
+``build_real_corpus_evidence``. Every fixture here is synthetic-in-shape
+(small, locally constructed) -- none of it touches the real ROB-941 corpus.
+
+The frozen synthetic path (``build_frozen_synthetic_evidence`` and friends)
+is exercised elsewhere (``test_rob1040_crs24_evidence_cli.py``); this file's
+job is to prove the new real-corpus posture is (a) reachable only through
+its own dedicated entry points, (b) unable to reuse any frozen synthetic pin,
+and (c) produces a structurally well-formed, reconciled evidence payload
+whose posture/authority differ from the synthetic one -- all without a
+single OOS incidence number being asserted against a "real" value (there is
+no real corpus here at all).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+import rob1040_crs24_evidence as evidence_module
+from rob1040_crs24_evidence import (
+    FROZEN_SYNTHETIC_EVIDENCE_SHA256,
+    CampaignInputBinding,
+    build_real_corpus_evidence,
+    open_real_corpus_campaign_context,
+)
+from rob1040_crs24_feasibility import (
+    EntryReference,
+    ExitPresence,
+    ReferenceSurface,
+    RunAuthorityClosedError,
+    expected_entry_reference_keys,
+    expected_exit_presence_keys,
+)
+from rob1040_crs24_features import CRSFeatureGenerator
+from rob1040_crs24_synthetic import (
+    SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256,
+    SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256,
+    SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256,
+    SYNTHETIC_FIXTURE_CONTENT_SHA256,
+    SYNTHETIC_FIXTURE_VERSION,
+    build_synthetic_fixture,
+)
+
+_FAKE_MANIFEST_SHA256 = "1" * 64
+
+
+def _empty_binding(
+    *, version: str = "rob1040.crs24.corr1.real_corpus.v1"
+) -> CampaignInputBinding:
+    """The smallest possible valid ``refrozen_real_corpus`` binding: an empty
+    complete-bar snapshot and an all-absent reference surface.  This is not a
+    real corpus and is not shaped like one -- it exists purely to exercise
+    the plumbing (context open -> full campaign evaluation -> evidence seal)
+    cheaply and without any incidence-bearing content."""
+    generator = CRSFeatureGenerator({"XRPUSDT": (), "DOGEUSDT": (), "SOLUSDT": ()})
+    entries = tuple(
+        EntryReference(key, None) for key in expected_entry_reference_keys()
+    )
+    exit_presence = tuple(
+        ExitPresence(key, False) for key in expected_exit_presence_keys()
+    )
+    references = ReferenceSurface(entries, exit_presence)
+    return CampaignInputBinding.for_real_corpus(
+        version=version,
+        generator=generator,
+        references=references,
+        corpus_manifest_content_sha256=_FAKE_MANIFEST_SHA256,
+    )
+
+
+def test_empty_real_corpus_binding_round_trips_through_for_real_corpus() -> None:
+    binding = _empty_binding()
+    assert binding.posture == "refrozen_real_corpus"
+    assert (
+        binding.snapshot_sha256_pin
+        == CRSFeatureGenerator(
+            {"XRPUSDT": (), "DOGEUSDT": (), "SOLUSDT": ()}
+        ).snapshot_sha256
+    )
+    assert binding.extra_authority == (
+        ("corpus_manifest_content_sha256", _FAKE_MANIFEST_SHA256),
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "snapshot_sha256_pin",
+        "entry_source_sha256_pin",
+        "exit_presence_source_sha256_pin",
+        "fixture_content_sha256_pin",
+    ),
+)
+def test_real_corpus_binding_cannot_reuse_any_synthetic_pin(field: str) -> None:
+    generator = CRSFeatureGenerator({"XRPUSDT": (), "DOGEUSDT": (), "SOLUSDT": ()})
+    entries = tuple(
+        EntryReference(key, None) for key in expected_entry_reference_keys()
+    )
+    exit_presence = tuple(
+        ExitPresence(key, False) for key in expected_exit_presence_keys()
+    )
+    references = ReferenceSurface(entries, exit_presence)
+    kwargs = {
+        "posture": "refrozen_real_corpus",
+        "version": "rob1040.crs24.corr1.real_corpus.v1",
+        "generator": generator,
+        "references": references,
+        "snapshot_sha256_pin": generator.snapshot_sha256,
+        "entry_source_sha256_pin": references.entry_source_sha256,
+        "exit_presence_source_sha256_pin": references.exit_presence_source_sha256,
+        "fixture_content_sha256_pin": evidence_module.fixture_content_sha256(
+            generator, references
+        ),
+        "extra_authority": (),
+    }
+    synthetic_pin_by_field = {
+        "snapshot_sha256_pin": SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256,
+        "entry_source_sha256_pin": SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256,
+        "exit_presence_source_sha256_pin": SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256,
+        "fixture_content_sha256_pin": SYNTHETIC_FIXTURE_CONTENT_SHA256,
+    }
+    kwargs[field] = synthetic_pin_by_field[field]
+    with pytest.raises(ValueError, match="must not reuse"):
+        CampaignInputBinding(**kwargs)
+
+
+def test_synthetic_posture_binding_must_reuse_the_exact_frozen_pins() -> None:
+    fixture = build_synthetic_fixture()
+    generator = CRSFeatureGenerator(fixture.bars_by_symbol())
+    with pytest.raises(ValueError, match="synthetic posture must reuse"):
+        CampaignInputBinding(
+            posture="frozen_synthetic_fixture",
+            version=SYNTHETIC_FIXTURE_VERSION,
+            generator=generator,
+            references=fixture.references,
+            snapshot_sha256_pin=generator.snapshot_sha256,
+            entry_source_sha256_pin=fixture.references.entry_source_sha256,
+            exit_presence_source_sha256_pin=(
+                fixture.references.exit_presence_source_sha256
+            ),
+            fixture_content_sha256_pin=evidence_module.fixture_content_sha256(
+                generator, fixture.references
+            ),
+            extra_authority=(("stray", "value"),),  # non-empty: forbidden for synthetic
+        )
+
+
+def test_open_real_corpus_context_rejects_a_synthetic_postured_binding() -> None:
+    """Even a LEGITIMATELY pinned synthetic-posture binding (built from the
+    real frozen fixture, matching every real SYNTHETIC_* constant) is refused
+    by the real-corpus entry point -- the posture gate is enforced
+    independently of pin correctness, so a synthetic binding can never reach
+    ``build_real_corpus_evidence``."""
+    fixture = build_synthetic_fixture()
+    generator = CRSFeatureGenerator(fixture.bars_by_symbol())
+    binding = CampaignInputBinding(
+        posture="frozen_synthetic_fixture",
+        version=SYNTHETIC_FIXTURE_VERSION,
+        generator=generator,
+        references=fixture.references,
+        snapshot_sha256_pin=SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256,
+        entry_source_sha256_pin=SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256,
+        exit_presence_source_sha256_pin=SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256,
+        fixture_content_sha256_pin=SYNTHETIC_FIXTURE_CONTENT_SHA256,
+        extra_authority=(),
+    )
+    with pytest.raises(RunAuthorityClosedError, match="refrozen_real_corpus"):
+        open_real_corpus_campaign_context(binding)
+    with pytest.raises(RunAuthorityClosedError, match="refrozen_real_corpus"):
+        build_real_corpus_evidence(binding)
+
+
+def test_open_real_corpus_context_rejects_non_binding_objects() -> None:
+    with pytest.raises(RunAuthorityClosedError, match="refrozen_real_corpus"):
+        open_real_corpus_campaign_context(object())  # type: ignore[arg-type]
+
+
+def test_empty_real_corpus_evidence_reconciles_with_zero_planned() -> None:
+    binding = _empty_binding()
+    evidence = build_real_corpus_evidence(binding)
+    assert evidence.totals.scheduled == 24 * 56 == 1_344
+    assert evidence.totals.planned == 0
+    assert evidence.totals.occupied == 0
+    payload = evidence.to_payload()
+    assert payload["authorities"]["input"]["posture"] == "refrozen_real_corpus"
+    assert payload["authorities"]["input"]["fixture_version"] == binding.version
+    assert payload["authorities"]["input"]["real_corpus_authority"] == {
+        "corpus_manifest_content_sha256": _FAKE_MANIFEST_SHA256,
+    }
+    assert evidence.evidence_sha256 != FROZEN_SYNTHETIC_EVIDENCE_SHA256
+
+
+def test_two_real_corpus_bindings_cannot_mix_contexts() -> None:
+    first_binding = _empty_binding()
+    second_binding = _empty_binding(version="rob1040.crs24.corr1.real_corpus.v2")
+    first_context = open_real_corpus_campaign_context(first_binding)
+    second_context = open_real_corpus_campaign_context(second_binding)
+    first_cells = first_context.cells()
+    second_cells = second_context.cells()
+    mixed = (first_cells[0], *second_cells[1:])
+    with pytest.raises(RunAuthorityClosedError, match="not issued by this"):
+        first_context.seal_cells(mixed)
+
+
+def test_real_corpus_binding_generator_and_references_are_rechecked_at_use() -> None:
+    binding = _empty_binding()
+    context = open_real_corpus_campaign_context(binding)
+    # The empty fixture has every exit_presence row `present=False`; flipping
+    # one to `True` changes `exit_presence_source_sha256` away from the pin
+    # captured at `for_real_corpus` construction time, so the next use must
+    # be refused even though object identity is unchanged.
+    exit_rows = binding.references.exit_presence
+    object.__setattr__(
+        binding.references,
+        "exit_presence",
+        (dataclasses.replace(exit_rows[0], present=True), *exit_rows[1:]),
+    )
+    with pytest.raises(
+        RunAuthorityClosedError, match="exit-presence pin changed at use"
+    ):
+        context.cells()
+
+
+def test_for_real_corpus_captures_pins_from_the_generator_and_references() -> None:
+    """``for_real_corpus`` never accepts a bare caller-supplied pin string --
+    every pin is read back from the bound objects, so a caller cannot forge a
+    mismatched pin through this constructor."""
+    binding = _empty_binding()
+    assert binding.snapshot_sha256_pin == binding.generator.snapshot_sha256
+    assert binding.entry_source_sha256_pin == binding.references.entry_source_sha256
+    assert (
+        binding.exit_presence_source_sha256_pin
+        == binding.references.exit_presence_source_sha256
+    )
+
+
+def test_for_real_corpus_rejects_a_malformed_manifest_hash() -> None:
+    generator = CRSFeatureGenerator({"XRPUSDT": (), "DOGEUSDT": (), "SOLUSDT": ()})
+    entries = tuple(
+        EntryReference(key, None) for key in expected_entry_reference_keys()
+    )
+    exit_presence = tuple(
+        ExitPresence(key, False) for key in expected_exit_presence_keys()
+    )
+    references = ReferenceSurface(entries, exit_presence)
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        CampaignInputBinding.for_real_corpus(
+            version="rob1040.crs24.corr1.real_corpus.v1",
+            generator=generator,
+            references=references,
+            corpus_manifest_content_sha256="not-a-hash",
+        )

--- a/research/nautilus_scalping/tests/test_rob1040_crs24_evidence_real_corpus_binding.py
+++ b/research/nautilus_scalping/tests/test_rob1040_crs24_evidence_real_corpus_binding.py
@@ -18,6 +18,7 @@ no real corpus here at all).
 from __future__ import annotations
 
 import dataclasses
+from decimal import Decimal
 
 import pytest
 import rob1040_crs24_evidence as evidence_module
@@ -86,25 +87,16 @@ def test_empty_real_corpus_binding_round_trips_through_for_real_corpus() -> None
     )
 
 
-@pytest.mark.parametrize(
-    "field",
-    (
-        "snapshot_sha256_pin",
-        "entry_source_sha256_pin",
-        "exit_presence_source_sha256_pin",
-        "fixture_content_sha256_pin",
-    ),
-)
-def test_real_corpus_binding_cannot_reuse_any_synthetic_pin(field: str) -> None:
+def _real_posture_kwargs(*, all_exits_present: bool = False) -> dict[str, object]:
     generator = CRSFeatureGenerator({"XRPUSDT": (), "DOGEUSDT": (), "SOLUSDT": ()})
     entries = tuple(
         EntryReference(key, None) for key in expected_entry_reference_keys()
     )
     exit_presence = tuple(
-        ExitPresence(key, False) for key in expected_exit_presence_keys()
+        ExitPresence(key, all_exits_present) for key in expected_exit_presence_keys()
     )
     references = ReferenceSurface(entries, exit_presence)
-    kwargs = {
+    return {
         "posture": "refrozen_real_corpus",
         "version": "rob1040.crs24.corr1.real_corpus.v1",
         "generator": generator,
@@ -115,16 +107,131 @@ def test_real_corpus_binding_cannot_reuse_any_synthetic_pin(field: str) -> None:
         "fixture_content_sha256_pin": evidence_module.fixture_content_sha256(
             generator, references
         ),
-        "extra_authority": (),
+        "extra_authority": (
+            (
+                evidence_module.REAL_CORPUS_MANIFEST_AUTHORITY_KEY,
+                _FAKE_MANIFEST_SHA256,
+            ),
+        ),
     }
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "snapshot_sha256_pin",
+        "entry_source_sha256_pin",
+        "fixture_content_sha256_pin",
+    ),
+)
+def test_real_corpus_binding_cannot_reuse_any_content_bearing_synthetic_pin(
+    field: str,
+) -> None:
+    """`exit_presence_source_sha256_pin` is intentionally NOT in this set --
+    see :func:`test_a_full_exit_coverage_real_binding_collides_on_the_exit_pin`
+    for why a presence-only bitmap over a frozen key domain cannot serve as a
+    posture discriminator."""
+    kwargs = _real_posture_kwargs()
     synthetic_pin_by_field = {
         "snapshot_sha256_pin": SYNTHETIC_COMPLETE_BAR_SNAPSHOT_SHA256,
         "entry_source_sha256_pin": SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256,
-        "exit_presence_source_sha256_pin": SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256,
         "fixture_content_sha256_pin": SYNTHETIC_FIXTURE_CONTENT_SHA256,
     }
     kwargs[field] = synthetic_pin_by_field[field]
     with pytest.raises(ValueError, match="must not reuse"):
+        CampaignInputBinding(**kwargs)
+
+
+def test_exit_presence_pin_is_still_reverified_against_the_bound_references() -> None:
+    """Dropping the exit pin from the must-differ set does NOT drop it from the
+    identity discipline: a substituted exit pin still cannot be bound, it is
+    just refused by the pin-vs-references check instead of the posture check."""
+    kwargs = _real_posture_kwargs()  # all-absent -> pin != the synthetic one
+    kwargs["exit_presence_source_sha256_pin"] = SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
+    with pytest.raises(ValueError, match="exit-presence pin does not match"):
+        CampaignInputBinding(**kwargs)
+
+
+def test_a_full_exit_coverage_real_binding_collides_on_the_exit_pin() -> None:
+    """REGRESSION (adversarial verification 2026-07-26, blocking defect).
+
+    ``ReferenceSurface.exit_presence_source_sha256`` hashes only the
+    ``present=True`` rows of a FROZEN 1296-key domain, so it is a presence
+    bitmap with no content. Any dataset with COMPLETE exit coverage therefore
+    produces exactly the synthetic all-signal calendar's digest -- including a
+    healthy, gapless real corpus. This test first pins that structural fact,
+    then asserts that such a binding is nonetheless accepted.
+
+    Before the fix, ``__post_init__`` required every one of the four pins to
+    differ from its ``SYNTHETIC_*`` constant, so this test's
+    ``for_real_corpus`` call raised ``ValueError: real-corpus posture must not
+    reuse any frozen synthetic pin`` -- i.e. the launcher could never load ANY
+    corpus without exit gaps. Every pre-existing test used an all-absent
+    (``present=False``) or 1-row surface, which is why 97 green tests missed
+    it.
+    """
+    kwargs = _real_posture_kwargs(all_exits_present=True)
+    references = kwargs["references"]
+    # The collision is structural, not incidental -- assert it explicitly so a
+    # future reader cannot mistake the relaxed guard for an oversight.
+    assert (
+        references.exit_presence_source_sha256 == SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
+    )
+    assert all(item.present for item in references.exit_presence)
+    assert len(references.exit_presence) == 1_296
+
+    binding = CampaignInputBinding.for_real_corpus(
+        version="rob1040.crs24.corr1.real_corpus.v1",
+        generator=kwargs["generator"],
+        references=references,
+        corpus_manifest_content_sha256=_FAKE_MANIFEST_SHA256,
+    )
+    assert binding.posture == "refrozen_real_corpus"
+    assert binding.exit_presence_source_sha256_pin == (
+        SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
+    )
+    # ...and the binding is actually usable end to end.
+    evidence = build_real_corpus_evidence(binding)
+    assert evidence.evidence_sha256 != FROZEN_SYNTHETIC_EVIDENCE_SHA256
+    assert evidence.totals.scheduled == 1_344
+
+
+def test_a_full_exit_coverage_real_binding_with_entry_values_is_accepted() -> None:
+    """Same as above but with real-shaped (non-None) entry values, i.e. the
+    exact shape the launcher builds from the ROB-941 corpus: every entry
+    resolves AND every exit is present."""
+    generator = CRSFeatureGenerator({"XRPUSDT": (), "DOGEUSDT": (), "SOLUSDT": ()})
+    entries = tuple(
+        EntryReference(key, Decimal("1.25")) for key in expected_entry_reference_keys()
+    )
+    exit_presence = tuple(
+        ExitPresence(key, True) for key in expected_exit_presence_keys()
+    )
+    references = ReferenceSurface(entries, exit_presence)
+    binding = CampaignInputBinding.for_real_corpus(
+        version="rob1040.crs24.corr1.real_corpus.v1",
+        generator=generator,
+        references=references,
+        corpus_manifest_content_sha256=_FAKE_MANIFEST_SHA256,
+    )
+    assert binding.posture == "refrozen_real_corpus"
+    assert binding.exit_presence_source_sha256_pin == (
+        SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256
+    )
+    assert binding.entry_source_sha256_pin != SYNTHETIC_ENTRY_REFERENCE_SOURCE_SHA256
+    assert binding.fixture_content_sha256_pin != SYNTHETIC_FIXTURE_CONTENT_SHA256
+
+
+def test_real_corpus_posture_requires_corpus_manifest_provenance() -> None:
+    """A ``refrozen_real_corpus`` binding with no provenance would emit
+    evidence whose `authorities.input` names no corpus at all."""
+    kwargs = _real_posture_kwargs()
+    kwargs["extra_authority"] = ()
+    with pytest.raises(ValueError, match="corpus-manifest provenance"):
+        CampaignInputBinding(**kwargs)
+
+    kwargs["extra_authority"] = (("some_other_key", "0" * 64),)
+    with pytest.raises(ValueError, match="corpus-manifest provenance"):
         CampaignInputBinding(**kwargs)
 
 

--- a/scripts/run_rob1040_crs24_refreeze.py
+++ b/scripts/run_rob1040_crs24_refreeze.py
@@ -15,13 +15,18 @@ Two gated modes exist beyond that:
     re-run any number of times; it never writes the one-shot marker.
 
 ``--run-one-shot``
-    Everything ``--preflight`` does, plus the explicit literal one-shot
-    confirmation phrase, plus the full CRS-24 campaign evaluation via the
+    Everything ``--preflight`` does, plus three gates preflight is exempt
+    from — ``HEAD == origin/main`` (Linear ROB-1040 실행순서 step 3: the seal
+    must be taken on the *merged exact main tree*, not merely on a descendant
+    of the refreeze head), a clean worktree, and the exact literal one-shot
+    confirmation phrase — plus the full CRS-24 campaign evaluation via the
     sealed ``rob1040_crs24_evidence`` decision closure (unmodified by this
     launcher — this file only supplies the input binding), plus writing the
-    evidence/metadata artifacts and a one-shot exhaustion marker. A second
-    invocation against the same ``--output-root`` refuses fail-closed once
-    that marker exists.
+    evidence/metadata artifacts and a one-shot exhaustion marker. The marker
+    is written ``ARMED`` *before* the evaluation and promoted to ``CONSUMED``
+    only after every artifact write, so an interrupted run cannot silently
+    re-arm. A second invocation against the same ``--output-root`` refuses
+    fail-closed in either state.
 
 This launcher performs no PnL/forward-return computation; the sealed CRS-24
 decision logic already accepts no realized-outcome columns and emits none
@@ -36,6 +41,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
@@ -96,7 +102,29 @@ CRS24_CHANGED_FILES: frozenset[str] = frozenset({"rob1040_crs24_evidence.py"})
 CRS24_CURRENT_REFREEZE_FILE_DIGESTS: dict[str, str] = {
     **CRS24_FILE_DIGESTS_AT_MERGE_COMMIT,
     "rob1040_crs24_evidence.py": (
-        "96d1e6b8b3bd08dd2baf4084bcdea1a56b7028659dfbf19d0ab205d4723a7c32"
+        "93bbee16960858cb79beabf821cd9a0d04835cd555066b2ca6ed82473c0916ea"
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Defence-in-depth beyond the preregistration's seven-file table: the CRS-24
+# fold/calendar authority modules the campaign REUSES (Linear "구현 경계":
+# `rob944_folds.generate_frozen_fold_schedule` /
+# `rob974_h4_contracts.exact_h4_folds`). They are outside the sealed seven, so
+# the seven-file table alone would let a drifted calendar authority through
+# while the *stale* fold-schedule digest still got stamped into all 24 cells.
+# `_require_contract_authority` re-verifies these digests AND calls
+# `rob1040_crs24_contracts.validate_contract()`, which recomputes the fold /
+# filter / contract digests from the live authorities at run time. Kept in a
+# separate table from the seven-file seal so a reviewer never confuses the
+# preregistered seal with this additional guard.
+# ---------------------------------------------------------------------------
+CRS24_AUTHORITY_FILE_DIGESTS: dict[str, str] = {
+    "rob944_folds.py": (
+        "97a646b96647aca40f953701e04aa2d081fcf5b9bc50a654981a01feed40add0"
+    ),
+    "rob974_h4_contracts.py": (
+        "db68351c04321fa8e92054af930ebe78d1082a7c9f0862a1d9e7eb72b1d3499a"
     ),
 }
 
@@ -134,7 +162,15 @@ EXPECTED_OUTPUT_ROOT = Path(
 
 SELECTED_SYMBOLS = ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
 REAL_CORPUS_BINDING_VERSION = "rob1040.crs24.corr1.real_corpus.v1"
+# Single durable one-shot marker file with an explicit lifecycle state.
+# `ARMED` is written (exclusive-create) BEFORE the sealed evaluation begins, so
+# a crash/interrupt/disk error after the counts were computed still leaves a
+# durable record; it is promoted to `CONSUMED` only after every artifact write
+# succeeds. Either state refuses a later `--run-one-shot`, with distinct reason
+# codes, so an operator can tell "completed" from "must be investigated".
 ONE_SHOT_MARKER_NAME = "ONE_SHOT_CONSUMED.json"
+ONE_SHOT_STATE_ARMED = "ARMED"
+ONE_SHOT_STATE_CONSUMED = "CONSUMED"
 EVIDENCE_ARTIFACT_NAME = "crs24_corr1_evidence.json"
 METADATA_ARTIFACT_NAME = "crs24_corr1_launch_metadata.json"
 
@@ -180,15 +216,16 @@ _COMMON_REQUIRED = ("manifest", "corpus_root", "output_root", "launcher_sha256")
 
 def _dry_run_payload() -> dict[str, object]:
     return {
-        "schema_version": "rob1040_crs24_refreeze_launcher_dry_run.v1",
+        "schema_version": "rob1040_crs24_refreeze_launcher_dry_run.v2",
         "run_requested": False,
         "default_state": "DISABLED",
         "description": (
             "No arguments perform no corpus load, artifact write, or broker "
             "call. --preflight verifies gates and builds the real-corpus "
             "input binding without evaluating any feature/gate/count. "
-            "--run-one-shot additionally requires the exact literal "
-            "confirmation phrase and performs the one-shot evaluation."
+            "--run-one-shot additionally requires HEAD == origin/main (the "
+            "merged exact main tree), a clean worktree, and the exact literal "
+            "confirmation phrase, and performs the one-shot evaluation."
         ),
         "refreeze_head": CRS24_MERGE_REFREEZE_HEAD,
         "seven_file_seal": {
@@ -196,6 +233,12 @@ def _dry_run_payload() -> dict[str, object]:
             "current_refreeze": CRS24_CURRENT_REFREEZE_FILE_DIGESTS,
             "changed_files": sorted(CRS24_CHANGED_FILES),
         },
+        "authority_file_seal": dict(CRS24_AUTHORITY_FILE_DIGESTS),
+        "one_shot_only_gates": [
+            "head_is_origin_main",
+            "clean_worktree",
+            "confirm_phrase",
+        ],
         "corpus": {
             "manifest": str(EXPECTED_MANIFEST),
             "corpus_root": str(EXPECTED_CORPUS_ROOT),
@@ -271,6 +314,96 @@ def _require_refreeze_head_ancestor() -> None:
         raise LaunchRefused("REFREEZE_HEAD_NOT_ANCESTOR") from None
 
 
+def _require_head_is_origin_main() -> None:
+    """`--run-one-shot` may only run on the exact merged `main` tree.
+
+    Linear ROB-1040 실행순서 step 3 requires the final hash-seal/launcher gate
+    to be taken "머지된 exact main tree에서". The ancestry check alone is not
+    sufficient: it also passes on an unmerged feature branch that merely
+    descends from the refreeze head. This gate compares LOCAL refs only (no
+    network, no fetch) -- the operator is responsible for having fetched
+    `origin/main` before arming the one-shot.
+
+    `--preflight` is exempt (it must stay auditable while the PR is under
+    review); the preflight output says so explicitly.
+    """
+    try:
+        head = _git("rev-parse", "HEAD")
+        origin_main = _git("rev-parse", "origin/main")
+    except (OSError, subprocess.CalledProcessError):
+        raise LaunchRefused("GIT_STATE_UNAVAILABLE") from None
+    if not head or head != origin_main:
+        raise LaunchRefused("HEAD_IS_NOT_ORIGIN_MAIN")
+
+
+def _measured_head_sha() -> str:
+    """The physical `git rev-parse HEAD` at run time.
+
+    The preregistration's stage-3 procedure requires recording "the merge
+    commit SHA on `main` that carries this implementation". That SHA cannot be
+    known before the merge, so it is not a compile-time constant here; the
+    one-shot instead measures it and stamps it into the run metadata, where
+    `_require_head_is_origin_main` has already proven it equals `origin/main`.
+    """
+    try:
+        return _git("rev-parse", "HEAD")
+    except (OSError, subprocess.CalledProcessError):
+        raise LaunchRefused("GIT_STATE_UNAVAILABLE") from None
+
+
+def _require_contract_authority() -> None:
+    """Run-time re-verification of the fold/filter/contract authorities.
+
+    Two independent layers:
+
+    1. The physical digests of the two reused calendar/fold authority modules
+       (outside the preregistered seven-file seal).
+    2. ``rob1040_crs24_contracts.validate_contract()``, which recomputes
+       `fold_schedule_payload()` / `filter_manifest_payload()` /
+       `contract_payload()` from the LIVE authorities and compares them to the
+       frozen `FOLD_SCHEDULE_SHA256` / `FILTER_MANIFEST_SHA256` /
+       `CONTRACT_SHA256`, plus the exact 8-fold and config-roster assertions.
+
+    Without (2) a drifted calendar authority would be used silently while the
+    stale digest was still stamped into all 24 cells.
+    """
+    for name, expected_digest in CRS24_AUTHORITY_FILE_DIGESTS.items():
+        actual = _physical_sha256(RESEARCH_ROOT / name)
+        if actual != expected_digest:
+            raise LaunchRefused(f"AUTHORITY_FILE_DIGEST_MISMATCH:{name}")
+    from rob1040_crs24_contracts import validate_contract
+
+    try:
+        validate_contract()
+    except (ValueError, TypeError):
+        raise LaunchRefused("CONTRACT_AUTHORITY_DRIFTED") from None
+
+
+def _require_preregistration_artifact() -> None:
+    """Physically verify the preregistration `.md` against its frozen pins.
+
+    The sealed CRS-24 modules cannot do this (the static guard forbids
+    `open`/`pathlib` inside them) even though they stamp
+    `PREREGISTRATION_SHA256` into every cell's `hashes` block. The launcher
+    can, so it does -- reading the expected size/digest from
+    `rob1040_crs24_contracts` rather than hardcoding a second copy.
+    """
+    from rob1040_crs24_contracts import (
+        PREREGISTRATION_RELATIVE_PATH,
+        canonical_preregistration_bytes,
+    )
+
+    path = REPO_ROOT / PREREGISTRATION_RELATIVE_PATH
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        raise LaunchRefused("PREREGISTRATION_ARTIFACT_MISSING") from None
+    try:
+        canonical_preregistration_bytes(raw)
+    except (ValueError, TypeError):
+        raise LaunchRefused("PREREGISTRATION_ARTIFACT_MISMATCH") from None
+
+
 def _require_clean_worktree() -> None:
     try:
         dirty = _git("status", "--porcelain", "--untracked-files=all")
@@ -326,19 +459,36 @@ def _require_pit_lookback_coverage(manifest) -> None:  # noqa: ANN001
     """Metadata-only PIT sufficiency check: the first scheduled cutoff's PIT
     lookback (60 calendar days) plus the widest configured formation window
     (CRS-A2, 84 complete 4h returns) must not require history before the
-    corpus's declared minimum open_time_ms. Uses ONLY the manifest's declared
-    `min_open_time_ms` per symbol -- no row data is read, no statistic is
-    computed."""
+    corpus's declared minimum open_time_ms.
+
+    Two-sided. The upper bound matters just as much: a corpus truncated on the
+    RIGHT would not be refused by a lower-bound-only gate -- every missing
+    entry/exit reference past the truncation would simply be counted as
+    `entry_reference_missing` / `exit_reference_missing` and the run would look
+    "valid" while silently under-counting. So the last exit-presence key in the
+    frozen domain (last cutoff + 24h + 60s) must also be inside the corpus's
+    declared `max_open_time_ms`.
+
+    Uses ONLY the manifest's declared `min_open_time_ms`/`max_open_time_ms`
+    per symbol -- no row data is read, no statistic is computed."""
     from rob974_h4_contracts import exact_h4_folds
     from rob1040_crs24_contracts import ACTIVE_CONFIGS, FOUR_HOUR_MS, PIT_LOOKBACK_MS
-    from rob1040_crs24_feasibility import scheduled_cutoffs
+    from rob1040_crs24_feasibility import (
+        expected_exit_presence_keys,
+        scheduled_cutoffs,
+    )
 
     first_cutoff = scheduled_cutoffs(exact_h4_folds()[0])[0]
     widest_formation = max(config.formation_return_count for config in ACTIVE_CONFIGS)
     floor_ms = first_cutoff - PIT_LOOKBACK_MS - widest_formation * FOUR_HOUR_MS
+    ceiling_ms = max(key.timestamp_ms for key in expected_exit_presence_keys())
     for kline in manifest.klines:
-        if kline.symbol in SELECTED_SYMBOLS and kline.min_open_time_ms > floor_ms:
+        if kline.symbol not in SELECTED_SYMBOLS:
+            continue
+        if kline.min_open_time_ms > floor_ms:
             raise LaunchRefused("PIT_LOOKBACK_COVERAGE_INSUFFICIENT")
+        if kline.max_open_time_ms < ceiling_ms:
+            raise LaunchRefused("PIT_HORIZON_COVERAGE_INSUFFICIENT")
 
 
 def _build_reference_surface(minute_rows: Mapping[str, tuple]):  # noqa: ANN001, ANN201
@@ -417,9 +567,66 @@ def _load_real_corpus_binding(manifest, corpus_root: Path):  # noqa: ANN001, ANN
 
 
 def _require_one_shot_not_consumed(output_root: Path) -> None:
+    """Refuse if the one-shot has been armed or consumed, with distinct codes.
+
+    ``ARMED`` means a previous invocation reached the sealed evaluation but did
+    not finish writing its artifacts -- the one-shot may in fact have been
+    consumed (the counts computed) with no complete record. That state is NOT
+    self-clearing: a human must investigate the output root and explicitly
+    resolve it before any further run.
+    """
     marker = output_root / ONE_SHOT_MARKER_NAME
-    if marker.exists():
+    if not marker.exists():
+        return
+    try:
+        state = json.loads(marker.read_text(encoding="utf-8")).get("state")
+    except (OSError, ValueError, AttributeError):
+        raise LaunchRefused("ONE_SHOT_MARKER_UNREADABLE") from None
+    if state == ONE_SHOT_STATE_ARMED:
+        raise LaunchRefused("ONE_SHOT_ARMED_NOT_RECONCILED")
+    if state == ONE_SHOT_STATE_CONSUMED:
         raise LaunchRefused("ONE_SHOT_ALREADY_CONSUMED")
+    raise LaunchRefused("ONE_SHOT_MARKER_UNREADABLE")
+
+
+def _arm_one_shot_marker(output_root: Path, *, armed_at_utc: str) -> None:
+    """Durably record ARMED before the sealed evaluation can compute anything.
+
+    Exclusive-create (``O_CREAT | O_EXCL``) so a concurrent invocation cannot
+    both pass the pre-check and both arm; ``fsync`` before returning so a
+    crash immediately after arming still leaves the record on disk.
+    """
+    output_root.mkdir(parents=True, exist_ok=True)
+    marker = output_root / ONE_SHOT_MARKER_NAME
+    body = (
+        json.dumps(
+            {
+                "state": ONE_SHOT_STATE_ARMED,
+                "armed_at_utc": armed_at_utc,
+                "note": (
+                    "Sealed CRS-24 evaluation was about to begin. If this state "
+                    "persists the one-shot may have been consumed without a "
+                    "complete artifact set; investigate before any re-run."
+                ),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    )
+    try:
+        descriptor = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        raise LaunchRefused("ONE_SHOT_ALREADY_CONSUMED") from None
+    except OSError:
+        raise LaunchRefused("ONE_SHOT_MARKER_UNWRITABLE") from None
+    try:
+        os.write(descriptor, body.encode("utf-8"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _preflight_payload(binding) -> dict[str, object]:  # noqa: ANN001
@@ -434,10 +641,19 @@ def _preflight_payload(binding) -> dict[str, object]:  # noqa: ANN001
     if binding.extra_authority:
         identity["real_corpus_authority"] = dict(binding.extra_authority)
     return {
-        "schema_version": "rob1040_crs24_refreeze_launcher_preflight.v1",
+        "schema_version": "rob1040_crs24_refreeze_launcher_preflight.v2",
         "mode": "preflight",
         "refreeze_head": CRS24_MERGE_REFREEZE_HEAD,
         "seven_file_seal_verified": True,
+        "authority_file_seal_verified": True,
+        "contract_authority_revalidated": True,
+        "preregistration_artifact_verified": True,
+        "head_is_origin_main_enforced": False,
+        "head_is_origin_main_note": (
+            "HEAD == origin/main is enforced ONLY by --run-one-shot; "
+            "--preflight is deliberately exempt so it stays auditable while "
+            "this PR is under review."
+        ),
         "binding_identity": identity,
         "counts_computed": False,
         "effects": {"artifact_writes": 0, "one_shot_consumed": False},
@@ -467,17 +683,28 @@ def _run_one_shot_payload(
     evidence,  # noqa: ANN001
     output_root: Path,
     run_started_at_utc: str,
+    measured_head_sha: str,
 ) -> tuple[dict[str, object], dict[str, object]]:
     evidence_payload = evidence.to_payload()
     metadata_payload: dict[str, object] = {
-        "schema_version": "rob1040_crs24_refreeze_launcher_metadata.v1",
+        "schema_version": "rob1040_crs24_refreeze_launcher_metadata.v2",
         "run_started_at_utc": run_started_at_utc,
         "refreeze_head": CRS24_MERGE_REFREEZE_HEAD,
+        # Stage-3 procedure item 1 ("the merge commit SHA on main that carries
+        # this implementation"). It cannot be a compile-time constant -- the
+        # merge SHA is unknowable before the merge -- so it is MEASURED here,
+        # after `_require_head_is_origin_main` proved HEAD == origin/main.
+        "head_sha_at_run": measured_head_sha,
+        "head_is_origin_main_verified": True,
         "seven_file_seal": {
             "at_merge_commit": CRS24_FILE_DIGESTS_AT_MERGE_COMMIT,
             "current_refreeze": CRS24_CURRENT_REFREEZE_FILE_DIGESTS,
             "changed_files": sorted(CRS24_CHANGED_FILES),
         },
+        # Separate from the preregistered seven-file seal on purpose.
+        "authority_file_seal": dict(CRS24_AUTHORITY_FILE_DIGESTS),
+        "contract_authority_revalidated": True,
+        "preregistration_artifact_verified": True,
         "corpus": {
             "manifest": str(EXPECTED_MANIFEST),
             "corpus_root": str(EXPECTED_CORPUS_ROOT),
@@ -512,6 +739,14 @@ def _execute_preflight(
     stderr.write("REFREEZE_PREFLIGHT seven_file_seal=PASS\n")
     manifest_path, corpus_root, _output_root = _require_paths(arguments)
     _install_runtime_paths()
+    _require_contract_authority()
+    stderr.write("REFREEZE_PREFLIGHT contract_authority=PASS\n")
+    _require_preregistration_artifact()
+    stderr.write("REFREEZE_PREFLIGHT preregistration_artifact=PASS\n")
+    stderr.write(
+        "REFREEZE_PREFLIGHT head_is_origin_main=EXEMPT_IN_PREFLIGHT "
+        "(enforced only in --run-one-shot)\n"
+    )
     manifest = _verify_manifest(manifest_path)
     stderr.write("REFREEZE_PREFLIGHT manifest_lineage=PASS\n")
     _require_pit_lookback_coverage(manifest)
@@ -539,13 +774,17 @@ def _execute_run_one_shot(
         raise LaunchRefused("CONFIRM_PHRASE_MISMATCH")
     _require_launcher_self_sha256(arguments.launcher_sha256)
     _require_refreeze_head_ancestor()
+    _require_head_is_origin_main()
     _require_clean_worktree()
     _require_seven_file_seal(CRS24_CURRENT_REFREEZE_FILE_DIGESTS)
     manifest_path, corpus_root, output_root = _require_paths(arguments)
+    _install_runtime_paths()
+    _require_contract_authority()
+    _require_preregistration_artifact()
     _require_one_shot_not_consumed(output_root)
+    measured_head_sha = _measured_head_sha()
     stderr.write("REFREEZE_ONE_SHOT static_gates=PASS\n")
 
-    _install_runtime_paths()
     manifest = _verify_manifest(manifest_path)
     _require_pit_lookback_coverage(manifest)
     binding = _load_real_corpus_binding(manifest, corpus_root)
@@ -558,6 +797,11 @@ def _execute_run_one_shot(
     from rob1040_crs24_evidence import build_real_corpus_evidence
 
     run_started_at_utc = datetime.now(UTC).isoformat()
+    # Durably ARM the one-shot BEFORE any count can be computed: after this
+    # point a crash, interrupt or write failure still leaves a record, so the
+    # "exactly once" contract no longer depends on the happy path.
+    _arm_one_shot_marker(output_root, armed_at_utc=run_started_at_utc)
+    stderr.write("REFREEZE_ONE_SHOT one_shot_marker=ARMED\n")
     stderr.write("REFREEZE_ONE_SHOT evaluating_sealed_campaign starting\n")
     evidence = build_real_corpus_evidence(binding)
     stderr.write("REFREEZE_ONE_SHOT evaluating_sealed_campaign PASS\n")
@@ -568,19 +812,22 @@ def _execute_run_one_shot(
         evidence=evidence,
         output_root=output_root,
         run_started_at_utc=run_started_at_utc,
+        measured_head_sha=measured_head_sha,
     )
 
-    output_root.mkdir(parents=True, exist_ok=True)
-    _require_one_shot_not_consumed(output_root)
     _atomic_write_json(output_root / EVIDENCE_ARTIFACT_NAME, evidence_payload)
     _atomic_write_json(output_root / METADATA_ARTIFACT_NAME, metadata_payload)
     _atomic_write_json(
         output_root / ONE_SHOT_MARKER_NAME,
         {
+            "state": ONE_SHOT_STATE_CONSUMED,
+            "armed_at_utc": run_started_at_utc,
             "consumed_at_utc": run_started_at_utc,
+            "head_sha_at_run": measured_head_sha,
             "evidence_sha256": evidence.evidence_sha256,
         },
     )
+    stderr.write("REFREEZE_ONE_SHOT one_shot_marker=CONSUMED\n")
 
     _write_json(
         stdout,

--- a/scripts/run_rob1040_crs24_refreeze.py
+++ b/scripts/run_rob1040_crs24_refreeze.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""Default-disabled ROB-1040 CRS-24 CORR-1 real-corpus refreeze launcher.
+
+With no arguments this command performs no corpus load, no file read beyond
+its own source, and no artifact write — it only prints its dry-run contract.
+Two gated modes exist beyond that:
+
+``--preflight``
+    Verifies every static gate (refreeze head ancestry, the seven-file CRS-24
+    code seal, the frozen corpus/manifest pins, and PIT lookback coverage
+    from manifest metadata only), loads the real corpus fully offline, and
+    builds the ``CampaignInputBinding`` + validated campaign context — but
+    stops BEFORE any feature/gate/candidate/occupancy evaluation, so it never
+    computes or prints an OOS incidence count. It is idempotent and may be
+    re-run any number of times; it never writes the one-shot marker.
+
+``--run-one-shot``
+    Everything ``--preflight`` does, plus the explicit literal one-shot
+    confirmation phrase, plus the full CRS-24 campaign evaluation via the
+    sealed ``rob1040_crs24_evidence`` decision closure (unmodified by this
+    launcher — this file only supplies the input binding), plus writing the
+    evidence/metadata artifacts and a one-shot exhaustion marker. A second
+    invocation against the same ``--output-root`` refuses fail-closed once
+    that marker exists.
+
+This launcher performs no PnL/forward-return computation; the sealed CRS-24
+decision logic already accepts no realized-outcome columns and emits none
+(exit is timestamp-presence-only). This file only builds the two inputs the
+sealed module accepts as a caller-supplied binding: a ``CRSFeatureGenerator``
+built from real 1-minute corpus bars, and a ``ReferenceSurface`` built from
+the same real 1-minute bars' open (entry) / presence (exit).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from io import TextIOBase
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESEARCH_ROOT = REPO_ROOT / "research" / "nautilus_scalping"
+
+# ---------------------------------------------------------------------------
+# Stage-3 code-seal procedure (preregistration.md): the merge commit SHA on
+# main that carries the CRS-24 implementation, plus a `shasum -a 256` table
+# for each of the seven CRS-24 implementation files AT THAT MERGE COMMIT.
+# This launcher's own PR changes exactly one of the seven files
+# (`rob1040_crs24_evidence.py`, to open one caller-supplied input-binding
+# seam; the decision logic body is untouched) — the "current" table below
+# records that single expected change explicitly rather than silently
+# re-pinning it, so a reviewer can diff the two tables and see exactly one
+# entry differ.
+# ---------------------------------------------------------------------------
+CRS24_MERGE_REFREEZE_HEAD = "0534db071b7b3820f7e0681f66da408a8ae0cc35"
+
+CRS24_FILE_DIGESTS_AT_MERGE_COMMIT: dict[str, str] = {
+    "rob1040_crs24_contracts.py": (
+        "1f26ebec4809f3fa45705e4f9115087eeda762c7055a8f2381128874e016b15c"
+    ),
+    "rob1040_crs24_features.py": (
+        "9fa529b878f4b454ee1968d65909ff7b8b43a04daf0de87cf060642175688684"
+    ),
+    "rob1040_crs24_feasibility.py": (
+        "618a5775653f298c055f9785687ab14ed4ba572ab5c8403697d509d509cb31ba"
+    ),
+    "rob1040_crs24_evidence.py": (
+        "e5549b146268bc48cc3f190529cd5a51e6874e863f58858af2a6cf9f01084ae8"
+    ),
+    "rob1040_crs24_synthetic.py": (
+        "ccc5bf16e67189d2c824996a934326ef469ad4c2ddbe5af6bb9cf78c30fa8500"
+    ),
+    "rob1040_crs24_cli.py": (
+        "7169799f2f04532c914804d129f5e02faa776818152aa3c047f5bdd4a779a806"
+    ),
+    "run_rob1040_crs24.py": (
+        "f994aecd3537cae3a9653b06c6793007f511ad16151d777dd807655e84765e62"
+    ),
+}
+
+# Expected digests IN THIS WORKTREE (post-refreeze-launcher-PR). Six entries
+# are byte-identical to the merge-commit table; only `rob1040_crs24_evidence.py`
+# differs (the one intentional, minimal, behavior-neutral-for-synthetic seam
+# opening described in the PR). `CRS24_CHANGED_FILES` names exactly which
+# entries are expected to differ, so the launcher can assert both "the six
+# untouched files are byte-identical to the merge commit" and "the changed
+# file is byte-identical to what THIS PR actually shipped" without silently
+# hiding the diff.
+CRS24_CHANGED_FILES: frozenset[str] = frozenset({"rob1040_crs24_evidence.py"})
+
+CRS24_CURRENT_REFREEZE_FILE_DIGESTS: dict[str, str] = {
+    **CRS24_FILE_DIGESTS_AT_MERGE_COMMIT,
+    "rob1040_crs24_evidence.py": (
+        "96d1e6b8b3bd08dd2baf4084bcdea1a56b7028659dfbf19d0ab205d4723a7c32"
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Frozen corpus/manifest identity. This is the SAME rob941 corpus and the
+# SAME committed manifest file `scripts/run_rob974_r2_campaign.py` already
+# pins (`PARENT_CONTENT_SHA256`/`PARENT_MANIFEST_SHA256`) — CRS-24 shares the
+# exact same frozen window/universe authority (`rob974_h4_contracts`). The
+# manifest JSON itself (row counts, archive checksums, shard paths) is
+# committed, non-sensitive provenance metadata; the corpus PARQUET DATA under
+# `EXPECTED_CORPUS_ROOT` is what must never be read/loaded/summarized outside
+# a `--run-one-shot`/`--preflight` invocation of this launcher.
+# ---------------------------------------------------------------------------
+EXPECTED_MANIFEST = RESEARCH_ROOT / "data_manifests" / "rob941_corpus_manifest.v1.json"
+EXPECTED_CORPUS_ROOT = Path(
+    "/Users/mgh3326/work/herdr-artifacts/"
+    "rob941-4bcc2da979b47caa45b5f90a09c326aefff91fa605e110d55ef316d53c9a9351/"
+    "data"
+)
+EXPECTED_PARENT_CONTENT_SHA256 = (
+    "4bcc2da979b47caa45b5f90a09c326aefff91fa605e110d55ef316d53c9a9351"
+)
+EXPECTED_PARENT_MANIFEST_SHA256 = (
+    "0767b44f976bf717cdc26bbcb0d01da1800418668f9f153461ce62486de10721"
+)
+
+# Dedicated one-shot output root for THIS campaign (distinct from the
+# ROB-974 R2 output roots). Not previously assigned by an orch packet for
+# ROB-1040 -- picked here following the same `herdr-artifacts/<slug>` naming
+# convention as `scripts/run_rob974_r2_campaign.py`; flagged in the PR/report
+# as a point an approver may want to override before the real one-shot run.
+EXPECTED_OUTPUT_ROOT = Path(
+    "/Users/mgh3326/work/herdr-artifacts/rob1040-crs24-corr1-refreeze-v1"
+)
+
+SELECTED_SYMBOLS = ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
+REAL_CORPUS_BINDING_VERSION = "rob1040.crs24.corr1.real_corpus.v1"
+ONE_SHOT_MARKER_NAME = "ONE_SHOT_CONSUMED.json"
+EVIDENCE_ARTIFACT_NAME = "crs24_corr1_evidence.json"
+METADATA_ARTIFACT_NAME = "crs24_corr1_launch_metadata.json"
+
+# The literal one-shot confirmation phrase (ROB-974 R2's
+# `--confirm-full-corpus-pit` pattern): a caller must echo this back exactly
+# to reach `--run-one-shot`'s empirical path. Prevents a copy-pasted/stale
+# command line from ever silently reaching the one-shot write path.
+ONE_SHOT_CONFIRMATION = "ROB-1040/CRS-24-CORR-1/REAL-CORPUS/OOS-DRY-COUNT-ONE-SHOT"
+
+CLI_USAGE_OR_PLAN_ERROR = 2
+LAUNCH_REFUSED = 4
+
+
+class LaunchRefused(RuntimeError):
+    """Safe pre-mutation refusal with a stable, non-secret reason code."""
+
+    def __init__(self, reason_code: str) -> None:
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        del message
+        raise ValueError("closed CLI parse failure")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = _Parser(prog="run_rob1040_crs24_refreeze")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--preflight", action="store_true")
+    mode.add_argument("--run-one-shot", action="store_true")
+    parser.add_argument("--manifest")
+    parser.add_argument("--corpus-root")
+    parser.add_argument("--output-root")
+    parser.add_argument("--launcher-sha256")
+    parser.add_argument("--confirm-one-shot-oos-dry-count")
+    return parser
+
+
+_COMMON_REQUIRED = ("manifest", "corpus_root", "output_root", "launcher_sha256")
+
+
+def _dry_run_payload() -> dict[str, object]:
+    return {
+        "schema_version": "rob1040_crs24_refreeze_launcher_dry_run.v1",
+        "run_requested": False,
+        "default_state": "DISABLED",
+        "description": (
+            "No arguments perform no corpus load, artifact write, or broker "
+            "call. --preflight verifies gates and builds the real-corpus "
+            "input binding without evaluating any feature/gate/count. "
+            "--run-one-shot additionally requires the exact literal "
+            "confirmation phrase and performs the one-shot evaluation."
+        ),
+        "refreeze_head": CRS24_MERGE_REFREEZE_HEAD,
+        "seven_file_seal": {
+            "at_merge_commit": CRS24_FILE_DIGESTS_AT_MERGE_COMMIT,
+            "current_refreeze": CRS24_CURRENT_REFREEZE_FILE_DIGESTS,
+            "changed_files": sorted(CRS24_CHANGED_FILES),
+        },
+        "corpus": {
+            "manifest": str(EXPECTED_MANIFEST),
+            "corpus_root": str(EXPECTED_CORPUS_ROOT),
+            "selected_symbols": list(SELECTED_SYMBOLS),
+        },
+        "output_root": str(EXPECTED_OUTPUT_ROOT),
+        "effects": {
+            "corpus_reads": 0,
+            "artifact_writes": 0,
+            "one_shot_consumed": False,
+            "broker_calls": 0,
+        },
+    }
+
+
+def _write_json(stream: TextIOBase, payload: Mapping[str, object]) -> None:
+    stream.write(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    )
+
+
+def _git(*arguments: str) -> str:
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _physical_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        raise LaunchRefused("SEALED_FILE_MISSING_OR_UNSAFE") from None
+    return digest.hexdigest()
+
+
+def _require_seven_file_seal(expected: Mapping[str, str]) -> None:
+    for name, expected_digest in expected.items():
+        actual = _physical_sha256(RESEARCH_ROOT / name)
+        if actual != expected_digest:
+            raise LaunchRefused(f"SEVEN_FILE_DIGEST_MISMATCH:{name}")
+
+
+def _require_launcher_self_sha256(claimed: str) -> None:
+    actual = _physical_sha256(Path(__file__))
+    if actual != claimed:
+        raise LaunchRefused("LAUNCHER_PHYSICAL_SHA256_MISMATCH")
+
+
+def _require_refreeze_head_ancestor() -> None:
+    try:
+        subprocess.run(
+            ("git", "merge-base", "--is-ancestor", CRS24_MERGE_REFREEZE_HEAD, "HEAD"),
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        raise LaunchRefused("REFREEZE_HEAD_NOT_ANCESTOR") from None
+
+
+def _require_clean_worktree() -> None:
+    try:
+        dirty = _git("status", "--porcelain", "--untracked-files=all")
+    except (OSError, subprocess.CalledProcessError):
+        raise LaunchRefused("GIT_STATE_UNAVAILABLE") from None
+    if dirty:
+        raise LaunchRefused("WORKTREE_NOT_CLEAN")
+
+
+def _require_paths(arguments: argparse.Namespace) -> tuple[Path, Path, Path]:
+    try:
+        manifest = Path(arguments.manifest).resolve(strict=True)
+        corpus_root = Path(arguments.corpus_root).resolve(strict=True)
+        output_root = Path(arguments.output_root)
+    except (OSError, RuntimeError, TypeError):
+        raise LaunchRefused("APPROVED_PATH_RESOLUTION_FAILED") from None
+    if manifest != EXPECTED_MANIFEST.resolve(strict=True):
+        raise LaunchRefused("MANIFEST_PATH_MISMATCH")
+    if corpus_root != EXPECTED_CORPUS_ROOT.resolve(strict=True):
+        raise LaunchRefused("CORPUS_ROOT_PATH_MISMATCH")
+    if not output_root.is_absolute() or output_root != EXPECTED_OUTPUT_ROOT:
+        raise LaunchRefused("OUTPUT_ROOT_PATH_MISMATCH")
+    return manifest, corpus_root, output_root
+
+
+def _install_runtime_paths() -> None:
+    for path in (str(RESEARCH_ROOT),):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def _verify_manifest(manifest_path: Path):  # noqa: ANN201 - CorpusManifest, dynamic import
+    """Load+verify the frozen parent manifest via the existing ROB-974 lineage
+    seal (`rob974_lineage.verify_parent`) -- reused unmodified, not
+    reimplemented. Only reads the small committed JSON manifest, never the
+    corpus parquet shards."""
+    import rob974_lineage
+
+    if (
+        rob974_lineage.PARENT_CONTENT_SHA256 != EXPECTED_PARENT_CONTENT_SHA256
+        or rob974_lineage.PARENT_MANIFEST_SHA256 != EXPECTED_PARENT_MANIFEST_SHA256
+        or rob974_lineage.SELECTED_UNIVERSE != SELECTED_SYMBOLS
+    ):
+        raise LaunchRefused("LINEAGE_AUTHORITY_DRIFTED")
+    try:
+        manifest = rob974_lineage.verify_parent(manifest_path)
+    except ValueError:
+        raise LaunchRefused("MANIFEST_LINEAGE_MISMATCH") from None
+    return manifest
+
+
+def _require_pit_lookback_coverage(manifest) -> None:  # noqa: ANN001
+    """Metadata-only PIT sufficiency check: the first scheduled cutoff's PIT
+    lookback (60 calendar days) plus the widest configured formation window
+    (CRS-A2, 84 complete 4h returns) must not require history before the
+    corpus's declared minimum open_time_ms. Uses ONLY the manifest's declared
+    `min_open_time_ms` per symbol -- no row data is read, no statistic is
+    computed."""
+    from rob974_h4_contracts import exact_h4_folds
+    from rob1040_crs24_contracts import ACTIVE_CONFIGS, FOUR_HOUR_MS, PIT_LOOKBACK_MS
+    from rob1040_crs24_feasibility import scheduled_cutoffs
+
+    first_cutoff = scheduled_cutoffs(exact_h4_folds()[0])[0]
+    widest_formation = max(config.formation_return_count for config in ACTIVE_CONFIGS)
+    floor_ms = first_cutoff - PIT_LOOKBACK_MS - widest_formation * FOUR_HOUR_MS
+    for kline in manifest.klines:
+        if kline.symbol in SELECTED_SYMBOLS and kline.min_open_time_ms > floor_ms:
+            raise LaunchRefused("PIT_LOOKBACK_COVERAGE_INSUFFICIENT")
+
+
+def _build_reference_surface(minute_rows: Mapping[str, tuple]):  # noqa: ANN001, ANN201
+    from rob1040_crs24_feasibility import (
+        EntryReference,
+        ExitPresence,
+        ReferenceSurface,
+        expected_entry_reference_keys,
+        expected_exit_presence_keys,
+    )
+
+    by_symbol_ts = {
+        symbol: {bar.ts: bar for bar in bars} for symbol, bars in minute_rows.items()
+    }
+    entries = tuple(
+        EntryReference(
+            key,
+            None
+            if by_symbol_ts[key.symbol].get(key.timestamp_ms) is None
+            else Decimal(str(by_symbol_ts[key.symbol][key.timestamp_ms].open)),
+        )
+        for key in expected_entry_reference_keys()
+    )
+    exit_presence = tuple(
+        ExitPresence(key, key.timestamp_ms in by_symbol_ts[key.symbol])
+        for key in expected_exit_presence_keys()
+    )
+    return ReferenceSurface(entries, exit_presence)
+
+
+def _load_real_corpus_binding(manifest, corpus_root: Path):  # noqa: ANN001, ANN201
+    """Fully offline (`rob941_offline_loader`, network-0) real-corpus load.
+
+    Builds the exact two objects the sealed CRS-24 evidence module accepts
+    as a caller-supplied binding: a `CRSFeatureGenerator` over real
+    complete-4h bars (reusing `rob1040_crs24_features.complete_bars_from_minutes`,
+    itself a thin wrapper over the ROB-974 H1 `build_complete_4h` semantics)
+    and a `ReferenceSurface` over the same real 1-minute bars' open
+    (entry)/presence (exit). No feature/gate/candidate/occupancy evaluation
+    happens in this function -- that only happens inside the sealed module's
+    `evaluate_cell`, reached only via `.cells()`.
+    """
+    import rob941_offline_loader
+    from rob974_features import MinuteBar
+    from rob1040_crs24_evidence import CampaignInputBinding
+    from rob1040_crs24_features import CRSFeatureGenerator, complete_bars_from_minutes
+
+    loaded = rob941_offline_loader.load_corpus(manifest, corpus_root)
+    klines = loaded["klines"]
+    minute_rows: dict[str, tuple] = {}
+    for symbol in SELECTED_SYMBOLS:
+        rows = klines.get(symbol)
+        if rows is None:
+            raise LaunchRefused("SELECTED_CORPUS_SYMBOL_MISSING")
+        minute_rows[symbol] = tuple(
+            MinuteBar(
+                row.open_time_ms,
+                row.open,
+                row.high,
+                row.low,
+                row.close,
+                row.base_volume,
+            )
+            for row in rows
+        )
+
+    bars_4h = complete_bars_from_minutes(minute_rows)
+    generator = CRSFeatureGenerator(bars_4h)
+    references = _build_reference_surface(minute_rows)
+    return CampaignInputBinding.for_real_corpus(
+        version=REAL_CORPUS_BINDING_VERSION,
+        generator=generator,
+        references=references,
+        corpus_manifest_content_sha256=manifest.content_hash(),
+    )
+
+
+def _require_one_shot_not_consumed(output_root: Path) -> None:
+    marker = output_root / ONE_SHOT_MARKER_NAME
+    if marker.exists():
+        raise LaunchRefused("ONE_SHOT_ALREADY_CONSUMED")
+
+
+def _preflight_payload(binding) -> dict[str, object]:  # noqa: ANN001
+    identity: dict[str, object] = {
+        "posture": binding.posture,
+        "version": binding.version,
+        "complete_bar_snapshot_sha256": binding.snapshot_sha256_pin,
+        "entry_reference_source_sha256": binding.entry_source_sha256_pin,
+        "exit_presence_source_sha256": binding.exit_presence_source_sha256_pin,
+        "fixture_content_sha256": binding.fixture_content_sha256_pin,
+    }
+    if binding.extra_authority:
+        identity["real_corpus_authority"] = dict(binding.extra_authority)
+    return {
+        "schema_version": "rob1040_crs24_refreeze_launcher_preflight.v1",
+        "mode": "preflight",
+        "refreeze_head": CRS24_MERGE_REFREEZE_HEAD,
+        "seven_file_seal_verified": True,
+        "binding_identity": identity,
+        "counts_computed": False,
+        "effects": {"artifact_writes": 0, "one_shot_consumed": False},
+    }
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, object]) -> None:
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def _run_one_shot_payload(
+    *,
+    arguments: argparse.Namespace,
+    binding,  # noqa: ANN001
+    evidence,  # noqa: ANN001
+    output_root: Path,
+    run_started_at_utc: str,
+) -> tuple[dict[str, object], dict[str, object]]:
+    evidence_payload = evidence.to_payload()
+    metadata_payload: dict[str, object] = {
+        "schema_version": "rob1040_crs24_refreeze_launcher_metadata.v1",
+        "run_started_at_utc": run_started_at_utc,
+        "refreeze_head": CRS24_MERGE_REFREEZE_HEAD,
+        "seven_file_seal": {
+            "at_merge_commit": CRS24_FILE_DIGESTS_AT_MERGE_COMMIT,
+            "current_refreeze": CRS24_CURRENT_REFREEZE_FILE_DIGESTS,
+            "changed_files": sorted(CRS24_CHANGED_FILES),
+        },
+        "corpus": {
+            "manifest": str(EXPECTED_MANIFEST),
+            "corpus_root": str(EXPECTED_CORPUS_ROOT),
+            "manifest_content_sha256": EXPECTED_PARENT_CONTENT_SHA256,
+        },
+        "binding_posture": binding.posture,
+        "binding_version": binding.version,
+        "evidence_sha256": evidence.evidence_sha256,
+        "launcher_argv": {
+            "manifest": arguments.manifest,
+            "corpus_root": arguments.corpus_root,
+            "output_root": arguments.output_root,
+            "launcher_sha256": arguments.launcher_sha256,
+        },
+        "artifacts": {
+            "evidence": str(output_root / EVIDENCE_ARTIFACT_NAME),
+            "metadata": str(output_root / METADATA_ARTIFACT_NAME),
+            "one_shot_marker": str(output_root / ONE_SHOT_MARKER_NAME),
+        },
+    }
+    return evidence_payload, metadata_payload
+
+
+def _execute_preflight(
+    arguments: argparse.Namespace, *, stdout: TextIOBase, stderr: TextIOBase
+) -> int:
+    _require_launcher_self_sha256(arguments.launcher_sha256)
+    stderr.write("REFREEZE_PREFLIGHT launcher_self_sha256=PASS\n")
+    _require_refreeze_head_ancestor()
+    stderr.write("REFREEZE_PREFLIGHT refreeze_head_ancestor=PASS\n")
+    _require_seven_file_seal(CRS24_CURRENT_REFREEZE_FILE_DIGESTS)
+    stderr.write("REFREEZE_PREFLIGHT seven_file_seal=PASS\n")
+    manifest_path, corpus_root, _output_root = _require_paths(arguments)
+    _install_runtime_paths()
+    manifest = _verify_manifest(manifest_path)
+    stderr.write("REFREEZE_PREFLIGHT manifest_lineage=PASS\n")
+    _require_pit_lookback_coverage(manifest)
+    stderr.write("REFREEZE_PREFLIGHT pit_lookback_coverage=PASS\n")
+    binding = _load_real_corpus_binding(manifest, corpus_root)
+    stderr.write("REFREEZE_PREFLIGHT real_corpus_binding_built=PASS\n")
+
+    from rob1040_crs24_evidence import open_real_corpus_campaign_context
+
+    # Opens+identity-checks the sealed context but never calls `.cells()` --
+    # no feature/gate/candidate/occupancy evaluation, no OOS incidence count.
+    open_real_corpus_campaign_context(binding)
+    stderr.write("REFREEZE_PREFLIGHT validated_context_opened=PASS\n")
+
+    _write_json(stdout, _preflight_payload(binding))
+    return 0
+
+
+def _execute_run_one_shot(
+    arguments: argparse.Namespace, *, stdout: TextIOBase, stderr: TextIOBase
+) -> int:
+    from datetime import UTC, datetime
+
+    if arguments.confirm_one_shot_oos_dry_count != ONE_SHOT_CONFIRMATION:
+        raise LaunchRefused("CONFIRM_PHRASE_MISMATCH")
+    _require_launcher_self_sha256(arguments.launcher_sha256)
+    _require_refreeze_head_ancestor()
+    _require_clean_worktree()
+    _require_seven_file_seal(CRS24_CURRENT_REFREEZE_FILE_DIGESTS)
+    manifest_path, corpus_root, output_root = _require_paths(arguments)
+    _require_one_shot_not_consumed(output_root)
+    stderr.write("REFREEZE_ONE_SHOT static_gates=PASS\n")
+
+    _install_runtime_paths()
+    manifest = _verify_manifest(manifest_path)
+    _require_pit_lookback_coverage(manifest)
+    binding = _load_real_corpus_binding(manifest, corpus_root)
+    stderr.write("REFREEZE_ONE_SHOT real_corpus_binding_built=PASS\n")
+
+    # Re-check the marker immediately before the empirical evaluation too --
+    # narrows (never eliminates) a TOCTOU window against a concurrent run.
+    _require_one_shot_not_consumed(output_root)
+
+    from rob1040_crs24_evidence import build_real_corpus_evidence
+
+    run_started_at_utc = datetime.now(UTC).isoformat()
+    stderr.write("REFREEZE_ONE_SHOT evaluating_sealed_campaign starting\n")
+    evidence = build_real_corpus_evidence(binding)
+    stderr.write("REFREEZE_ONE_SHOT evaluating_sealed_campaign PASS\n")
+
+    evidence_payload, metadata_payload = _run_one_shot_payload(
+        arguments=arguments,
+        binding=binding,
+        evidence=evidence,
+        output_root=output_root,
+        run_started_at_utc=run_started_at_utc,
+    )
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    _require_one_shot_not_consumed(output_root)
+    _atomic_write_json(output_root / EVIDENCE_ARTIFACT_NAME, evidence_payload)
+    _atomic_write_json(output_root / METADATA_ARTIFACT_NAME, metadata_payload)
+    _atomic_write_json(
+        output_root / ONE_SHOT_MARKER_NAME,
+        {
+            "consumed_at_utc": run_started_at_utc,
+            "evidence_sha256": evidence.evidence_sha256,
+        },
+    )
+
+    _write_json(
+        stdout,
+        {
+            "schema_version": "rob1040_crs24_refreeze_launcher_result.v1",
+            "mode": "run_one_shot",
+            "evidence_sha256": evidence.evidence_sha256,
+            "artifacts": metadata_payload["artifacts"],
+        },
+    )
+    return 0
+
+
+def run_cli(
+    argv: Sequence[str],
+    *,
+    stdout: TextIOBase,
+    stderr: TextIOBase,
+) -> int:
+    """Run the closed launcher without calling ``sys.exit``."""
+    if isinstance(argv, str | bytes) or not isinstance(argv, Sequence):
+        stderr.write("CLI_USAGE_OR_PLAN_ERROR\n")
+        return CLI_USAGE_OR_PLAN_ERROR
+    if not argv:
+        _write_json(stdout, _dry_run_payload())
+        return 0
+    try:
+        arguments = _parser().parse_args(list(argv))
+    except (TypeError, ValueError):
+        stderr.write("CLI_USAGE_OR_PLAN_ERROR\n")
+        return CLI_USAGE_OR_PLAN_ERROR
+
+    if arguments.preflight:
+        if any(getattr(arguments, name) is None for name in _COMMON_REQUIRED):
+            stderr.write("CLI_USAGE_OR_PLAN_ERROR\n")
+            return CLI_USAGE_OR_PLAN_ERROR
+        executor = _execute_preflight
+    elif arguments.run_one_shot:
+        required = (*_COMMON_REQUIRED, "confirm_one_shot_oos_dry_count")
+        if any(getattr(arguments, name) is None for name in required):
+            stderr.write("CLI_USAGE_OR_PLAN_ERROR\n")
+            return CLI_USAGE_OR_PLAN_ERROR
+        executor = _execute_run_one_shot
+    else:
+        stderr.write("CLI_USAGE_OR_PLAN_ERROR\n")
+        return CLI_USAGE_OR_PLAN_ERROR
+
+    try:
+        return executor(arguments, stdout=stdout, stderr=stderr)
+    except LaunchRefused as exc:
+        stderr.write("LAUNCH_REFUSED " + exc.reason_code + "\n")
+        return LAUNCH_REFUSED
+    except KeyboardInterrupt:
+        stderr.write("INTERRUPTED audit_state_before_retry\n")
+        return 130
+    except Exception as exc:
+        stderr.write(f"LAUNCH_REFUSED UNEXPECTED_{type(exc).__name__}\n")
+        return LAUNCH_REFUSED
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return run_cli(
+        tuple(sys.argv[1:] if argv is None else argv),
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_run_rob1040_crs24_refreeze.py
+++ b/tests/scripts/test_run_rob1040_crs24_refreeze.py
@@ -219,11 +219,46 @@ def test_require_paths_rejects_a_mismatched_path(
         launcher._require_paths(_Args())
 
 
-def test_one_shot_marker_gate(tmp_path: Path) -> None:
+def test_one_shot_marker_gate_refuses_a_consumed_marker(tmp_path: Path) -> None:
     launcher._require_one_shot_not_consumed(tmp_path)
-    (tmp_path / launcher.ONE_SHOT_MARKER_NAME).write_text("{}")
+    (tmp_path / launcher.ONE_SHOT_MARKER_NAME).write_text(
+        json.dumps({"state": launcher.ONE_SHOT_STATE_CONSUMED})
+    )
     with pytest.raises(launcher.LaunchRefused, match="ONE_SHOT_ALREADY_CONSUMED"):
         launcher._require_one_shot_not_consumed(tmp_path)
+
+
+def test_one_shot_marker_gate_refuses_an_armed_marker_with_its_own_code(
+    tmp_path: Path,
+) -> None:
+    """An ARMED marker means a previous run reached the sealed evaluation but
+    never finished writing -- the one-shot may already be consumed with no
+    complete record, so it must NOT be silently re-runnable."""
+    (tmp_path / launcher.ONE_SHOT_MARKER_NAME).write_text(
+        json.dumps({"state": launcher.ONE_SHOT_STATE_ARMED})
+    )
+    with pytest.raises(launcher.LaunchRefused, match="ONE_SHOT_ARMED_NOT_RECONCILED"):
+        launcher._require_one_shot_not_consumed(tmp_path)
+
+
+@pytest.mark.parametrize("body", ("{}", "not json at all", '{"state":"WHATEVER"}'))
+def test_one_shot_marker_gate_refuses_an_unreadable_marker(
+    tmp_path: Path, body: str
+) -> None:
+    (tmp_path / launcher.ONE_SHOT_MARKER_NAME).write_text(body)
+    with pytest.raises(launcher.LaunchRefused, match="ONE_SHOT_MARKER_UNREADABLE"):
+        launcher._require_one_shot_not_consumed(tmp_path)
+
+
+def test_arm_one_shot_marker_is_exclusive_create(tmp_path: Path) -> None:
+    output_root = tmp_path / "out"
+    launcher._arm_one_shot_marker(output_root, armed_at_utc="2026-07-26T00:00:00+00:00")
+    payload = json.loads((output_root / launcher.ONE_SHOT_MARKER_NAME).read_text())
+    assert payload["state"] == launcher.ONE_SHOT_STATE_ARMED
+    with pytest.raises(launcher.LaunchRefused, match="ONE_SHOT_ALREADY_CONSUMED"):
+        launcher._arm_one_shot_marker(
+            output_root, armed_at_utc="2026-07-26T00:00:01+00:00"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -231,10 +266,14 @@ def test_one_shot_marker_gate(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+_AMPLE_MAX_OPEN_TIME_MS = 1 << 62
+
+
 @dataclass(frozen=True)
 class _FakeKlineManifestRow:
     symbol: str
     min_open_time_ms: int
+    max_open_time_ms: int = _AMPLE_MAX_OPEN_TIME_MS
 
 
 @dataclass(frozen=True)
@@ -275,6 +314,159 @@ def test_pit_lookback_coverage_gate_refuses_insufficient_history() -> None:
         launcher.LaunchRefused, match="PIT_LOOKBACK_COVERAGE_INSUFFICIENT"
     ):
         launcher._require_pit_lookback_coverage(manifest)
+
+
+def test_pit_coverage_gate_refuses_a_right_truncated_corpus() -> None:
+    """Upper-bound half of the two-sided gate: a corpus that stops before the
+    last exit-presence key would otherwise silently report every truncated
+    reference as `exit_reference_missing` and still look 'valid'."""
+    from rob974_h4_contracts import exact_h4_folds
+    from rob1040_crs24_feasibility import expected_exit_presence_keys, scheduled_cutoffs
+
+    first_cutoff = scheduled_cutoffs(exact_h4_folds()[0])[0]
+    last_exit_ts = max(key.timestamp_ms for key in expected_exit_presence_keys())
+    manifest = _FakeManifest(
+        (
+            _FakeKlineManifestRow("XRPUSDT", first_cutoff - 200 * 86_400_000),
+            _FakeKlineManifestRow(
+                "DOGEUSDT",
+                first_cutoff - 200 * 86_400_000,
+                last_exit_ts - 60_000,  # one minute short of the last exit key
+            ),
+            _FakeKlineManifestRow("SOLUSDT", first_cutoff - 200 * 86_400_000),
+        )
+    )
+    with pytest.raises(
+        launcher.LaunchRefused, match="PIT_HORIZON_COVERAGE_INSUFFICIENT"
+    ):
+        launcher._require_pit_lookback_coverage(manifest)
+
+
+def test_pit_coverage_gate_accepts_a_corpus_ending_exactly_on_the_last_exit_key() -> (
+    None
+):
+    from rob974_h4_contracts import exact_h4_folds
+    from rob1040_crs24_feasibility import expected_exit_presence_keys, scheduled_cutoffs
+
+    first_cutoff = scheduled_cutoffs(exact_h4_folds()[0])[0]
+    last_exit_ts = max(key.timestamp_ms for key in expected_exit_presence_keys())
+    manifest = _FakeManifest(
+        tuple(
+            _FakeKlineManifestRow(symbol, first_cutoff - 200 * 86_400_000, last_exit_ts)
+            for symbol in launcher.SELECTED_SYMBOLS
+        )
+    )
+    launcher._require_pit_lookback_coverage(manifest)
+
+
+# ---------------------------------------------------------------------------
+# Contract-authority re-verification / preregistration artifact / origin-main
+# ---------------------------------------------------------------------------
+
+
+def test_contract_authority_gate_passes_against_the_real_worktree() -> None:
+    launcher._install_runtime_paths()
+    launcher._require_contract_authority()
+
+
+def test_contract_authority_gate_rejects_a_drifted_authority_file_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        launcher.CRS24_AUTHORITY_FILE_DIGESTS, "rob944_folds.py", "0" * 64
+    )
+    with pytest.raises(
+        launcher.LaunchRefused, match="AUTHORITY_FILE_DIGEST_MISMATCH:rob944_folds.py"
+    ):
+        launcher._require_contract_authority()
+
+
+def test_contract_authority_gate_actually_calls_validate_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point of gate (4): the fold/filter/contract digests stamped
+    into all 24 cells must be re-derived from the LIVE authorities at run
+    time, not merely echoed."""
+    launcher._install_runtime_paths()
+    import rob1040_crs24_contracts
+
+    calls: list[int] = []
+
+    def _drifted() -> None:
+        calls.append(1)
+        raise ValueError("fold schedule digest drifted")
+
+    monkeypatch.setattr(rob1040_crs24_contracts, "validate_contract", _drifted)
+    with pytest.raises(launcher.LaunchRefused, match="CONTRACT_AUTHORITY_DRIFTED"):
+        launcher._require_contract_authority()
+    assert calls == [1]
+
+
+def test_preregistration_artifact_gate_passes_against_the_real_file() -> None:
+    launcher._install_runtime_paths()
+    launcher._require_preregistration_artifact()
+
+
+def test_preregistration_artifact_gate_refuses_a_missing_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    launcher._install_runtime_paths()
+    monkeypatch.setattr(launcher, "REPO_ROOT", tmp_path)
+    with pytest.raises(
+        launcher.LaunchRefused, match="PREREGISTRATION_ARTIFACT_MISSING"
+    ):
+        launcher._require_preregistration_artifact()
+
+
+def test_preregistration_artifact_gate_refuses_tampered_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    launcher._install_runtime_paths()
+    from rob1040_crs24_contracts import PREREGISTRATION_RELATIVE_PATH
+
+    forged = tmp_path / PREREGISTRATION_RELATIVE_PATH
+    forged.parent.mkdir(parents=True)
+    forged.write_bytes(b"not the preregistration\n")
+    monkeypatch.setattr(launcher, "REPO_ROOT", tmp_path)
+    with pytest.raises(
+        launcher.LaunchRefused, match="PREREGISTRATION_ARTIFACT_MISMATCH"
+    ):
+        launcher._require_preregistration_artifact()
+
+
+def test_head_is_origin_main_gate_reflects_actual_git_state() -> None:
+    head = launcher._git("rev-parse", "HEAD")
+    origin_main = launcher._git("rev-parse", "origin/main")
+    if head == origin_main:
+        launcher._require_head_is_origin_main()
+    else:
+        with pytest.raises(launcher.LaunchRefused, match="HEAD_IS_NOT_ORIGIN_MAIN"):
+            launcher._require_head_is_origin_main()
+
+
+def test_head_is_origin_main_gate_refuses_a_descendant_feature_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defect this gate closes: `merge-base --is-ancestor` alone passes on
+    an unmerged feature branch that merely descends from the refreeze head."""
+    real_git = launcher._git
+
+    def _fake_git(*arguments: str) -> str:
+        if arguments == ("rev-parse", "HEAD"):
+            return "a" * 40
+        if arguments == ("rev-parse", "origin/main"):
+            return "b" * 40
+        return real_git(*arguments)
+
+    monkeypatch.setattr(launcher, "_git", _fake_git)
+    with pytest.raises(launcher.LaunchRefused, match="HEAD_IS_NOT_ORIGIN_MAIN"):
+        launcher._require_head_is_origin_main()
+    # ...and the ancestry check on its own is NOT sufficient: it still passes.
+    launcher._require_refreeze_head_ancestor()
+
+
+def test_measured_head_sha_is_the_physical_head() -> None:
+    assert launcher._measured_head_sha() == launcher._git("rev-parse", "HEAD")
 
 
 # ---------------------------------------------------------------------------
@@ -429,6 +621,15 @@ def _wire_common_fakes(
     return manifest, corpus_root, output_root
 
 
+def _wire_one_shot_only_fakes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize the two one-shot-only environment gates that cannot hold in a
+    feature-branch test run: the worktree is dirty (this PR) and HEAD is not
+    `origin/main` (unmerged). Both are exercised for real by their own tests
+    above; here they would only mask the CLI wiring under test."""
+    monkeypatch.setattr(launcher, "_require_clean_worktree", lambda: None)
+    monkeypatch.setattr(launcher, "_require_head_is_origin_main", lambda: None)
+
+
 def test_preflight_never_computes_or_prints_any_count(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -483,7 +684,7 @@ def test_run_one_shot_writes_artifacts_and_marker_then_refuses_a_second_run(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
-    monkeypatch.setattr(launcher, "_require_clean_worktree", lambda: None)
+    _wire_one_shot_only_fakes(monkeypatch)
     argv = (
         "--run-one-shot",
         "--manifest",
@@ -517,11 +718,167 @@ def test_run_one_shot_writes_artifacts_and_marker_then_refuses_a_second_run(
     assert "ONE_SHOT_ALREADY_CONSUMED" in stderr2.getvalue()
 
 
-def test_run_one_shot_rejects_a_wrong_confirmation_phrase(
+def test_a_crash_during_evaluation_leaves_an_armed_marker_and_blocks_a_rerun(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The marker-ordering defect: before the fix the marker was written LAST,
+    so a crash after the sealed evaluation consumed the one-shot with ZERO
+    durable record and a second run was permitted. Now ARMED is durable before
+    any count can exist, and it is not self-clearing."""
+    launcher._install_runtime_paths()
+    import rob1040_crs24_evidence
+
+    manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
+    _wire_one_shot_only_fakes(monkeypatch)
+
+    real_build = rob1040_crs24_evidence.build_real_corpus_evidence
+    crash_next = [True]
+
+    def _maybe_explode(binding: object):  # noqa: ANN202
+        if crash_next[0]:
+            crash_next[0] = False
+            raise RuntimeError("simulated crash mid-evaluation")
+        return real_build(binding)
+
+    monkeypatch.setattr(
+        rob1040_crs24_evidence, "build_real_corpus_evidence", _maybe_explode
+    )
+    argv = (
+        "--run-one-shot",
+        "--manifest",
+        str(manifest),
+        "--corpus-root",
+        str(corpus_root),
+        "--output-root",
+        str(output_root),
+        "--launcher-sha256",
+        _LAUNCHER_SHA256,
+        "--confirm-one-shot-oos-dry-count",
+        launcher.ONE_SHOT_CONFIRMATION,
+    )
+    stdout, stderr = _stdio()
+    assert (
+        launcher.run_cli(argv, stdout=stdout, stderr=stderr) == launcher.LAUNCH_REFUSED
+    )
+    marker = output_root / launcher.ONE_SHOT_MARKER_NAME
+    assert marker.is_file(), "the one-shot must be durably armed before evaluation"
+    assert json.loads(marker.read_text())["state"] == launcher.ONE_SHOT_STATE_ARMED
+    assert not (output_root / launcher.EVIDENCE_ARTIFACT_NAME).exists()
+
+    # Second run: the evaluation would now succeed, but the ARMED marker must
+    # still refuse it -- the one-shot may already have been consumed.
+    stdout2, stderr2 = _stdio()
+    assert launcher.run_cli(argv, stdout=stdout2, stderr=stderr2) == (
+        launcher.LAUNCH_REFUSED
+    )
+    assert "ONE_SHOT_ARMED_NOT_RECONCILED" in stderr2.getvalue()
+
+
+def test_run_one_shot_refuses_when_head_is_not_origin_main(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
     monkeypatch.setattr(launcher, "_require_clean_worktree", lambda: None)
+
+    def _refuse() -> None:
+        raise launcher.LaunchRefused("HEAD_IS_NOT_ORIGIN_MAIN")
+
+    monkeypatch.setattr(launcher, "_require_head_is_origin_main", _refuse)
+    stdout, stderr = _stdio()
+    exit_code = launcher.run_cli(
+        (
+            "--run-one-shot",
+            "--manifest",
+            str(manifest),
+            "--corpus-root",
+            str(corpus_root),
+            "--output-root",
+            str(output_root),
+            "--launcher-sha256",
+            _LAUNCHER_SHA256,
+            "--confirm-one-shot-oos-dry-count",
+            launcher.ONE_SHOT_CONFIRMATION,
+        ),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert exit_code == launcher.LAUNCH_REFUSED
+    assert "HEAD_IS_NOT_ORIGIN_MAIN" in stderr.getvalue()
+    assert not output_root.exists()
+
+
+def test_preflight_is_exempt_from_the_origin_main_gate_and_says_so(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
+
+    def _explode() -> None:  # pragma: no cover - must never be called
+        raise AssertionError("preflight must not consult the origin/main gate")
+
+    monkeypatch.setattr(launcher, "_require_head_is_origin_main", _explode)
+    stdout, stderr = _stdio()
+    exit_code = launcher.run_cli(
+        (
+            "--preflight",
+            "--manifest",
+            str(manifest),
+            "--corpus-root",
+            str(corpus_root),
+            "--output-root",
+            str(output_root),
+            "--launcher-sha256",
+            _LAUNCHER_SHA256,
+        ),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert exit_code == 0, stderr.getvalue()
+    payload = json.loads(stdout.getvalue())
+    assert payload["head_is_origin_main_enforced"] is False
+    assert "--run-one-shot" in payload["head_is_origin_main_note"]
+    assert "head_is_origin_main=EXEMPT_IN_PREFLIGHT" in stderr.getvalue()
+    assert payload["contract_authority_revalidated"] is True
+    assert payload["preregistration_artifact_verified"] is True
+
+
+def test_run_one_shot_metadata_records_the_measured_head_sha(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
+    _wire_one_shot_only_fakes(monkeypatch)
+    stdout, stderr = _stdio()
+    exit_code = launcher.run_cli(
+        (
+            "--run-one-shot",
+            "--manifest",
+            str(manifest),
+            "--corpus-root",
+            str(corpus_root),
+            "--output-root",
+            str(output_root),
+            "--launcher-sha256",
+            _LAUNCHER_SHA256,
+            "--confirm-one-shot-oos-dry-count",
+            launcher.ONE_SHOT_CONFIRMATION,
+        ),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert exit_code == 0, stderr.getvalue()
+    metadata = json.loads((output_root / launcher.METADATA_ARTIFACT_NAME).read_text())
+    assert metadata["head_sha_at_run"] == launcher._git("rev-parse", "HEAD")
+    assert metadata["head_is_origin_main_verified"] is True
+    assert metadata["authority_file_seal"] == launcher.CRS24_AUTHORITY_FILE_DIGESTS
+    marker = json.loads((output_root / launcher.ONE_SHOT_MARKER_NAME).read_text())
+    assert marker["state"] == launcher.ONE_SHOT_STATE_CONSUMED
+    assert marker["head_sha_at_run"] == metadata["head_sha_at_run"]
+
+
+def test_run_one_shot_rejects_a_wrong_confirmation_phrase(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
+    _wire_one_shot_only_fakes(monkeypatch)
     stdout, stderr = _stdio()
     exit_code = launcher.run_cli(
         (

--- a/tests/scripts/test_run_rob1040_crs24_refreeze.py
+++ b/tests/scripts/test_run_rob1040_crs24_refreeze.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -32,6 +34,69 @@ launcher._install_runtime_paths()
 
 def _stdio() -> tuple[io.StringIO, io.StringIO]:
     return io.StringIO(), io.StringIO()
+
+
+# ---------------------------------------------------------------------------
+# Hermetic git-repo fixtures for the ancestor / origin-main gates
+#
+# These two gates (`_require_refreeze_head_ancestor`, `_require_head_is_origin_
+# main`) shell out to the real `git` binary against `launcher.REPO_ROOT`. A
+# naive test that just calls them against the ambient checkout is coupled to
+# how deep/wide that checkout happens to be: a local clone has full history
+# and a fetched `origin/main`, but a CI runner's checkout is commonly shallow
+# (the CRS-24 merge commit may not be reachable at all) and has no
+# `origin/main` ref unless a prior step fetched one. Building a tiny, private
+# git repo per test and pointing `launcher.REPO_ROOT` at it removes that
+# coupling entirely -- the gate logic itself is still exercised for real
+# (real `git` subprocess calls), just against a repo whose shape the test
+# fully controls.
+# ---------------------------------------------------------------------------
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "rob1040-test",
+    "GIT_AUTHOR_EMAIL": "rob1040-test@example.invalid",
+    "GIT_COMMITTER_NAME": "rob1040-test",
+    "GIT_COMMITTER_EMAIL": "rob1040-test@example.invalid",
+}
+
+
+def _run_git(repo_dir: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_GIT_ENV,
+    )
+    return result.stdout.strip()
+
+
+def _init_hermetic_git_repo(repo_dir: Path) -> tuple[str, str]:
+    """Build a tiny, fully self-contained git repo with two commits.
+
+    Returns ``(first_commit_sha, head_sha)`` where ``head_sha`` is a direct
+    child of ``first_commit_sha`` -- i.e. exactly the ancestor/descendant
+    shape the CRS-24 refreeze-head gate checks for, without depending on the
+    ambient checkout at all.
+    """
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    _run_git(repo_dir, "init", "-q", "-b", "main")
+    seed = repo_dir / "seed.txt"
+    seed.write_text("seed\n")
+    _run_git(repo_dir, "add", "seed.txt")
+    _run_git(repo_dir, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "first")
+    first_sha = _run_git(repo_dir, "rev-parse", "HEAD")
+    seed.write_text("seed 2\n")
+    _run_git(repo_dir, "add", "seed.txt")
+    _run_git(repo_dir, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "second")
+    head_sha = _run_git(repo_dir, "rev-parse", "HEAD")
+    return first_sha, head_sha
+
+
+def _set_origin_main_ref(repo_dir: Path, sha: str) -> None:
+    _run_git(repo_dir, "update-ref", "refs/remotes/origin/main", sha)
 
 
 # ---------------------------------------------------------------------------
@@ -105,9 +170,17 @@ def test_launcher_self_sha256_gate() -> None:
         launcher._require_launcher_self_sha256("0" * 64)
 
 
-def test_refreeze_head_ancestor_gate_passes_on_this_worktree() -> None:
-    # The worktree this test runs in was branched from a commit descending
-    # from the CRS-24 merge commit, so this must pass without a monkeypatch.
+def test_refreeze_head_ancestor_gate_passes_when_head_descends_from_the_refreeze_commit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Hermetic stand-in for "the worktree was branched from a commit
+    # descending from the CRS-24 merge commit" -- does not depend on the
+    # ambient checkout's history depth (a CI shallow clone may not contain
+    # the real CRS24_MERGE_REFREEZE_HEAD commit at all).
+    repo_dir = tmp_path / "repo"
+    merge_sha, _head_sha = _init_hermetic_git_repo(repo_dir)
+    monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
+    monkeypatch.setattr(launcher, "CRS24_MERGE_REFREEZE_HEAD", merge_sha)
     launcher._require_refreeze_head_ancestor()
 
 
@@ -434,21 +507,53 @@ def test_preregistration_artifact_gate_refuses_tampered_bytes(
         launcher._require_preregistration_artifact()
 
 
-def test_head_is_origin_main_gate_reflects_actual_git_state() -> None:
-    head = launcher._git("rev-parse", "HEAD")
-    origin_main = launcher._git("rev-parse", "origin/main")
-    if head == origin_main:
+def test_head_is_origin_main_gate_passes_when_head_equals_origin_main(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo_dir = tmp_path / "repo"
+    _first_sha, head_sha = _init_hermetic_git_repo(repo_dir)
+    _set_origin_main_ref(repo_dir, head_sha)
+    monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
+    launcher._require_head_is_origin_main()
+
+
+def test_head_is_origin_main_gate_refuses_when_head_diverges_from_origin_main(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo_dir = tmp_path / "repo"
+    first_sha, _head_sha = _init_hermetic_git_repo(repo_dir)
+    # origin/main points at the earlier commit -- HEAD (the second commit) has
+    # moved on without being merged/fetched back.
+    _set_origin_main_ref(repo_dir, first_sha)
+    monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
+    with pytest.raises(launcher.LaunchRefused, match="HEAD_IS_NOT_ORIGIN_MAIN"):
         launcher._require_head_is_origin_main()
-    else:
-        with pytest.raises(launcher.LaunchRefused, match="HEAD_IS_NOT_ORIGIN_MAIN"):
-            launcher._require_head_is_origin_main()
+
+
+def test_head_is_origin_main_gate_refuses_when_origin_main_ref_is_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reproduces the CI checkout shape directly: a shallow/partial checkout
+    commonly has no `origin/main` ref at all (`git rev-parse origin/main`
+    exits 128) unless a prior step explicitly fetched one. The gate must fail
+    closed with a typed refusal, not let the subprocess error propagate."""
+    repo_dir = tmp_path / "repo"
+    _init_hermetic_git_repo(repo_dir)  # no origin/main ref created
+    monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
+    with pytest.raises(launcher.LaunchRefused, match="GIT_STATE_UNAVAILABLE"):
+        launcher._require_head_is_origin_main()
 
 
 def test_head_is_origin_main_gate_refuses_a_descendant_feature_branch(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """The defect this gate closes: `merge-base --is-ancestor` alone passes on
     an unmerged feature branch that merely descends from the refreeze head."""
+    repo_dir = tmp_path / "repo"
+    merge_sha, _head_sha = _init_hermetic_git_repo(repo_dir)
+    monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
+    monkeypatch.setattr(launcher, "CRS24_MERGE_REFREEZE_HEAD", merge_sha)
+
     real_git = launcher._git
 
     def _fake_git(*arguments: str) -> str:
@@ -461,7 +566,9 @@ def test_head_is_origin_main_gate_refuses_a_descendant_feature_branch(
     monkeypatch.setattr(launcher, "_git", _fake_git)
     with pytest.raises(launcher.LaunchRefused, match="HEAD_IS_NOT_ORIGIN_MAIN"):
         launcher._require_head_is_origin_main()
-    # ...and the ancestry check on its own is NOT sufficient: it still passes.
+    # ...and the ancestry check on its own is NOT sufficient: it still passes
+    # (real `git merge-base --is-ancestor` against the hermetic repo, not the
+    # faked `_git`).
     launcher._require_refreeze_head_ancestor()
 
 
@@ -609,6 +716,12 @@ def _wire_common_fakes(
     monkeypatch.setattr(launcher, "EXPECTED_MANIFEST", manifest)
     monkeypatch.setattr(launcher, "EXPECTED_CORPUS_ROOT", corpus_root)
     monkeypatch.setattr(launcher, "EXPECTED_OUTPUT_ROOT", output_root)
+    # `_require_refreeze_head_ancestor` is another environment gate that
+    # cannot reliably hold against the ambient checkout in every runner (a CI
+    # shallow clone may not contain the real CRS24_MERGE_REFREEZE_HEAD
+    # commit). It is exercised for real, hermetically, by its own dedicated
+    # tests above; here it would only mask the CLI wiring under test.
+    monkeypatch.setattr(launcher, "_require_refreeze_head_ancestor", lambda: None)
     monkeypatch.setattr(launcher, "_verify_manifest", lambda path: _FakeManifest(()))
     monkeypatch.setattr(
         launcher, "_require_pit_lookback_coverage", lambda manifest: None

--- a/tests/scripts/test_run_rob1040_crs24_refreeze.py
+++ b/tests/scripts/test_run_rob1040_crs24_refreeze.py
@@ -1,0 +1,545 @@
+"""ROB-1040 CRS-24 CORR-1 real-corpus refreeze launcher.
+
+Every gate rejection path is exercised with fakes/tmp_path fixtures -- this
+suite never reads, loads, or summarizes anything under the real frozen
+ROB-941 corpus root (``~/work/herdr-artifacts/rob941-4bcc2da9.../``). The one
+end-to-end smoke test that exercises the real-corpus loading pipeline
+(``_load_real_corpus_binding``) uses a hand-built, tiny, entirely synthetic
+in-memory kline dict -- never the real corpus.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from scripts import run_rob1040_crs24_refreeze as launcher
+
+_SCRIPT = Path(launcher.__file__).resolve()
+_LAUNCHER_SHA256 = hashlib.sha256(_SCRIPT.read_bytes()).hexdigest()
+
+# Several tests import CRS-24 research modules directly (to build fixtures,
+# e.g. the exact expected reference-key domain); the launcher only adds
+# `research/nautilus_scalping` to `sys.path` lazily inside its own gated
+# functions, so tests need the same idempotent installation up front.
+launcher._install_runtime_paths()
+
+
+def _stdio() -> tuple[io.StringIO, io.StringIO]:
+    return io.StringIO(), io.StringIO()
+
+
+# ---------------------------------------------------------------------------
+# Dry-run / usage
+# ---------------------------------------------------------------------------
+
+
+def test_no_arguments_are_dry_run_only_and_effectless() -> None:
+    stdout, stderr = _stdio()
+    assert launcher.run_cli((), stdout=stdout, stderr=stderr) == 0
+    payload = json.loads(stdout.getvalue())
+    assert payload["default_state"] == "DISABLED"
+    assert payload["run_requested"] is False
+    assert all(value in (0, False) for value in payload["effects"].values())
+    assert payload["refreeze_head"] == launcher.CRS24_MERGE_REFREEZE_HEAD
+    assert payload["seven_file_seal"]["changed_files"] == ["rob1040_crs24_evidence.py"]
+    assert stderr.getvalue() == ""
+
+
+def test_no_mode_flag_is_a_usage_error() -> None:
+    stdout, stderr = _stdio()
+    assert (
+        launcher.run_cli(
+            ("--manifest", "x", "--corpus-root", "y"), stdout=stdout, stderr=stderr
+        )
+        == launcher.CLI_USAGE_OR_PLAN_ERROR
+    )
+    assert stdout.getvalue() == ""
+
+
+def test_preflight_missing_required_argument_is_a_usage_error() -> None:
+    stdout, stderr = _stdio()
+    assert (
+        launcher.run_cli(("--preflight",), stdout=stdout, stderr=stderr)
+        == launcher.CLI_USAGE_OR_PLAN_ERROR
+    )
+
+
+def test_run_one_shot_without_confirm_phrase_is_a_usage_error() -> None:
+    stdout, stderr = _stdio()
+    assert (
+        launcher.run_cli(
+            (
+                "--run-one-shot",
+                "--manifest",
+                "x",
+                "--corpus-root",
+                "y",
+                "--output-root",
+                "z",
+                "--launcher-sha256",
+                _LAUNCHER_SHA256,
+            ),
+            stdout=stdout,
+            stderr=stderr,
+        )
+        == launcher.CLI_USAGE_OR_PLAN_ERROR
+    )
+
+
+# ---------------------------------------------------------------------------
+# Individual gate functions
+# ---------------------------------------------------------------------------
+
+
+def test_launcher_self_sha256_gate() -> None:
+    launcher._require_launcher_self_sha256(_LAUNCHER_SHA256)
+    with pytest.raises(
+        launcher.LaunchRefused, match="LAUNCHER_PHYSICAL_SHA256_MISMATCH"
+    ):
+        launcher._require_launcher_self_sha256("0" * 64)
+
+
+def test_refreeze_head_ancestor_gate_passes_on_this_worktree() -> None:
+    # The worktree this test runs in was branched from a commit descending
+    # from the CRS-24 merge commit, so this must pass without a monkeypatch.
+    launcher._require_refreeze_head_ancestor()
+
+
+def test_refreeze_head_ancestor_gate_rejects_an_unknown_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(launcher, "CRS24_MERGE_REFREEZE_HEAD", "f" * 40)
+    with pytest.raises(launcher.LaunchRefused, match="REFREEZE_HEAD_NOT_ANCESTOR"):
+        launcher._require_refreeze_head_ancestor()
+
+
+def test_clean_worktree_gate_reflects_actual_git_status() -> None:
+    # This branch has new untracked/modified files at test time (the PR this
+    # suite ships in), so the real worktree is NOT clean -- assert the gate
+    # actually observes that rather than asserting a fixed outcome.
+    dirty = launcher._git("status", "--porcelain", "--untracked-files=all")
+    if dirty:
+        with pytest.raises(launcher.LaunchRefused, match="WORKTREE_NOT_CLEAN"):
+            launcher._require_clean_worktree()
+    else:
+        launcher._require_clean_worktree()
+
+
+def test_seven_file_seal_gate_passes_against_the_real_worktree() -> None:
+    launcher._require_seven_file_seal(launcher.CRS24_CURRENT_REFREEZE_FILE_DIGESTS)
+
+
+def test_seven_file_seal_gate_rejects_a_tampered_expectation() -> None:
+    tampered = dict(launcher.CRS24_CURRENT_REFREEZE_FILE_DIGESTS)
+    tampered["rob1040_crs24_contracts.py"] = "0" * 64
+    with pytest.raises(
+        launcher.LaunchRefused,
+        match="SEVEN_FILE_DIGEST_MISMATCH:rob1040_crs24_contracts.py",
+    ):
+        launcher._require_seven_file_seal(tampered)
+
+
+def test_seven_file_seal_gate_rejects_a_missing_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(launcher, "RESEARCH_ROOT", tmp_path)
+    with pytest.raises(launcher.LaunchRefused, match="SEALED_FILE_MISSING_OR_UNSAFE"):
+        launcher._require_seven_file_seal(launcher.CRS24_CURRENT_REFREEZE_FILE_DIGESTS)
+
+
+def test_require_paths_accepts_the_exact_expected_triple(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text("{}")
+    corpus_root_path = tmp_path / "corpus"
+    corpus_root_path.mkdir()
+    output_root_path = tmp_path / "out"
+    monkeypatch.setattr(launcher, "EXPECTED_MANIFEST", manifest_path)
+    monkeypatch.setattr(launcher, "EXPECTED_CORPUS_ROOT", corpus_root_path)
+    monkeypatch.setattr(launcher, "EXPECTED_OUTPUT_ROOT", output_root_path)
+
+    class _Args:
+        manifest = str(manifest_path)
+        corpus_root = str(corpus_root_path)
+        output_root = str(output_root_path)
+
+    resolved_manifest, resolved_corpus, resolved_output = launcher._require_paths(
+        _Args()
+    )
+    assert resolved_manifest == manifest_path.resolve()
+    assert resolved_corpus == corpus_root_path.resolve()
+    assert resolved_output == output_root_path
+
+
+@pytest.mark.parametrize(
+    "field,reason",
+    (
+        ("manifest", "MANIFEST_PATH_MISMATCH"),
+        ("corpus_root", "CORPUS_ROOT_PATH_MISMATCH"),
+        ("output_root", "OUTPUT_ROOT_PATH_MISMATCH"),
+    ),
+)
+def test_require_paths_rejects_a_mismatched_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, field: str, reason: str
+) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}")
+    corpus_root = tmp_path / "corpus"
+    corpus_root.mkdir()
+    output_root = tmp_path / "out"
+    monkeypatch.setattr(launcher, "EXPECTED_MANIFEST", manifest)
+    monkeypatch.setattr(launcher, "EXPECTED_CORPUS_ROOT", corpus_root)
+    monkeypatch.setattr(launcher, "EXPECTED_OUTPUT_ROOT", output_root)
+
+    values = {
+        "manifest": str(manifest),
+        "corpus_root": str(corpus_root),
+        "output_root": str(output_root),
+    }
+    other = tmp_path / "other"
+    if field == "output_root":
+        values[field] = str(other)
+    else:
+        other.mkdir()
+        values[field] = str(other)
+
+    class _Args:
+        manifest = values["manifest"]
+        corpus_root = values["corpus_root"]
+        output_root = values["output_root"]
+
+    with pytest.raises(launcher.LaunchRefused, match=reason):
+        launcher._require_paths(_Args())
+
+
+def test_one_shot_marker_gate(tmp_path: Path) -> None:
+    launcher._require_one_shot_not_consumed(tmp_path)
+    (tmp_path / launcher.ONE_SHOT_MARKER_NAME).write_text("{}")
+    with pytest.raises(launcher.LaunchRefused, match="ONE_SHOT_ALREADY_CONSUMED"):
+        launcher._require_one_shot_not_consumed(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# PIT lookback coverage (metadata-only)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeKlineManifestRow:
+    symbol: str
+    min_open_time_ms: int
+
+
+@dataclass(frozen=True)
+class _FakeManifest:
+    klines: tuple[_FakeKlineManifestRow, ...]
+
+    def content_hash(self) -> str:
+        return "2" * 64
+
+
+def test_pit_lookback_coverage_gate_passes_with_ample_history() -> None:
+    from rob974_h4_contracts import exact_h4_folds
+    from rob1040_crs24_feasibility import scheduled_cutoffs
+
+    first_cutoff = scheduled_cutoffs(exact_h4_folds()[0])[0]
+    manifest = _FakeManifest(
+        tuple(
+            _FakeKlineManifestRow(symbol, first_cutoff - 200 * 86_400_000)
+            for symbol in launcher.SELECTED_SYMBOLS
+        )
+    )
+    launcher._require_pit_lookback_coverage(manifest)
+
+
+def test_pit_lookback_coverage_gate_refuses_insufficient_history() -> None:
+    from rob974_h4_contracts import exact_h4_folds
+    from rob1040_crs24_feasibility import scheduled_cutoffs
+
+    first_cutoff = scheduled_cutoffs(exact_h4_folds()[0])[0]
+    manifest = _FakeManifest(
+        (
+            _FakeKlineManifestRow("XRPUSDT", first_cutoff - 200 * 86_400_000),
+            _FakeKlineManifestRow("DOGEUSDT", first_cutoff),  # far too little history
+            _FakeKlineManifestRow("SOLUSDT", first_cutoff - 200 * 86_400_000),
+        )
+    )
+    with pytest.raises(
+        launcher.LaunchRefused, match="PIT_LOOKBACK_COVERAGE_INSUFFICIENT"
+    ):
+        launcher._require_pit_lookback_coverage(manifest)
+
+
+# ---------------------------------------------------------------------------
+# Reference-surface construction (pure, no corpus loader involved)
+# ---------------------------------------------------------------------------
+
+
+def test_build_reference_surface_from_a_tiny_hand_built_minute_series() -> None:
+    from decimal import Decimal
+
+    from rob974_features import MinuteBar
+    from rob1040_crs24_feasibility import expected_entry_reference_keys
+
+    first_entry_key = expected_entry_reference_keys()[0]
+    bar = MinuteBar(first_entry_key.timestamp_ms, 1.25, 1.26, 1.24, 1.255, 10.0)
+    minute_rows = {
+        "XRPUSDT": (bar,) if first_entry_key.symbol == "XRPUSDT" else (),
+        "DOGEUSDT": (bar,) if first_entry_key.symbol == "DOGEUSDT" else (),
+        "SOLUSDT": (bar,) if first_entry_key.symbol == "SOLUSDT" else (),
+    }
+    surface = launcher._build_reference_surface(minute_rows)
+    matched = surface.entry_observation(first_entry_key)
+    assert matched.value == Decimal(str(bar.open))
+    # every other key in the domain is untouched -> None/absent sentinel
+    other_entry = next(
+        key for key in expected_entry_reference_keys() if key != first_entry_key
+    )
+    assert surface.entry_observation(other_entry).value is None
+
+
+# ---------------------------------------------------------------------------
+# Small fake corpus, full launcher-wiring smoke (never touches real corpus)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeCorpusRow:
+    open_time_ms: int
+    open: float
+    high: float
+    low: float
+    close: float
+    base_volume: float
+
+
+def test_load_real_corpus_binding_with_a_tiny_fake_corpus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercises the launcher's own corpus->binding wiring end-to-end against
+    a hand-built, 1-row-per-symbol fake kline dict -- proves MinuteBar
+    construction, 4h aggregation, generator/reference-surface wiring, and
+    ``CampaignInputBinding.for_real_corpus`` all connect correctly, without
+    reading a single byte from the real ROB-941 corpus."""
+    launcher._install_runtime_paths()
+    import rob941_offline_loader
+    from rob1040_crs24_feasibility import expected_entry_reference_keys
+
+    first_entry_key = expected_entry_reference_keys()[0]
+    fake_row = _FakeCorpusRow(first_entry_key.timestamp_ms, 2.0, 2.1, 1.9, 2.05, 5.0)
+    fake_loaded = {
+        "klines": {
+            symbol: [fake_row] if symbol == first_entry_key.symbol else []
+            for symbol in launcher.SELECTED_SYMBOLS
+        },
+        "funding": {symbol: [] for symbol in launcher.SELECTED_SYMBOLS},
+    }
+    monkeypatch.setattr(
+        rob941_offline_loader,
+        "load_corpus",
+        lambda manifest, corpus_root: fake_loaded,
+    )
+    manifest = _FakeManifest(())
+    binding = launcher._load_real_corpus_binding(manifest, Path("/does/not/matter"))
+    assert binding.posture == "refrozen_real_corpus"
+    assert binding.extra_authority == (
+        ("corpus_manifest_content_sha256", manifest.content_hash()),
+    )
+
+
+def test_load_real_corpus_binding_refuses_a_missing_selected_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launcher._install_runtime_paths()
+    import rob941_offline_loader
+
+    fake_loaded = {
+        "klines": {"XRPUSDT": [], "DOGEUSDT": []},  # SOLUSDT missing
+        "funding": {},
+    }
+    monkeypatch.setattr(
+        rob941_offline_loader,
+        "load_corpus",
+        lambda manifest, corpus_root: fake_loaded,
+    )
+    manifest = _FakeManifest(())
+    with pytest.raises(launcher.LaunchRefused, match="SELECTED_CORPUS_SYMBOL_MISSING"):
+        launcher._load_real_corpus_binding(manifest, Path("/does/not/matter"))
+
+
+# ---------------------------------------------------------------------------
+# Full CLI wiring: preflight computes no counts; run-one-shot writes once
+# ---------------------------------------------------------------------------
+
+
+def _empty_fake_binding(version: str = "rob1040.crs24.corr1.real_corpus.v1"):
+    from rob1040_crs24_evidence import CampaignInputBinding
+    from rob1040_crs24_feasibility import (
+        EntryReference,
+        ExitPresence,
+        ReferenceSurface,
+        expected_entry_reference_keys,
+        expected_exit_presence_keys,
+    )
+    from rob1040_crs24_features import CRSFeatureGenerator
+
+    generator = CRSFeatureGenerator({"XRPUSDT": (), "DOGEUSDT": (), "SOLUSDT": ()})
+    entries = tuple(
+        EntryReference(key, None) for key in expected_entry_reference_keys()
+    )
+    exit_presence = tuple(
+        ExitPresence(key, False) for key in expected_exit_presence_keys()
+    )
+    references = ReferenceSurface(entries, exit_presence)
+    return CampaignInputBinding.for_real_corpus(
+        version=version,
+        generator=generator,
+        references=references,
+        corpus_manifest_content_sha256="3" * 64,
+    )
+
+
+def _wire_common_fakes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[Path, Path, Path]:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}")
+    corpus_root = tmp_path / "corpus"
+    corpus_root.mkdir()
+    output_root = tmp_path / "out"
+    monkeypatch.setattr(launcher, "EXPECTED_MANIFEST", manifest)
+    monkeypatch.setattr(launcher, "EXPECTED_CORPUS_ROOT", corpus_root)
+    monkeypatch.setattr(launcher, "EXPECTED_OUTPUT_ROOT", output_root)
+    monkeypatch.setattr(launcher, "_verify_manifest", lambda path: _FakeManifest(()))
+    monkeypatch.setattr(
+        launcher, "_require_pit_lookback_coverage", lambda manifest: None
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_load_real_corpus_binding",
+        lambda manifest, root: _empty_fake_binding(),
+    )
+    return manifest, corpus_root, output_root
+
+
+def test_preflight_never_computes_or_prints_any_count(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
+    stdout, stderr = _stdio()
+    exit_code = launcher.run_cli(
+        (
+            "--preflight",
+            "--manifest",
+            str(manifest),
+            "--corpus-root",
+            str(corpus_root),
+            "--output-root",
+            str(output_root),
+            "--launcher-sha256",
+            _LAUNCHER_SHA256,
+        ),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert exit_code == 0, stderr.getvalue()
+    payload = json.loads(stdout.getvalue())
+    assert payload["mode"] == "preflight"
+    assert payload["counts_computed"] is False
+    assert "planned" not in json.dumps(payload)
+    assert not output_root.exists()
+
+    # Idempotent: running it again does not fail and still writes nothing.
+    stdout2, stderr2 = _stdio()
+    assert (
+        launcher.run_cli(
+            (
+                "--preflight",
+                "--manifest",
+                str(manifest),
+                "--corpus-root",
+                str(corpus_root),
+                "--output-root",
+                str(output_root),
+                "--launcher-sha256",
+                _LAUNCHER_SHA256,
+            ),
+            stdout=stdout2,
+            stderr=stderr2,
+        )
+        == 0
+    )
+    assert not output_root.exists()
+
+
+def test_run_one_shot_writes_artifacts_and_marker_then_refuses_a_second_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_require_clean_worktree", lambda: None)
+    argv = (
+        "--run-one-shot",
+        "--manifest",
+        str(manifest),
+        "--corpus-root",
+        str(corpus_root),
+        "--output-root",
+        str(output_root),
+        "--launcher-sha256",
+        _LAUNCHER_SHA256,
+        "--confirm-one-shot-oos-dry-count",
+        launcher.ONE_SHOT_CONFIRMATION,
+    )
+    stdout, stderr = _stdio()
+    exit_code = launcher.run_cli(argv, stdout=stdout, stderr=stderr)
+    assert exit_code == 0, stderr.getvalue()
+    result = json.loads(stdout.getvalue())
+    assert result["mode"] == "run_one_shot"
+    assert (output_root / launcher.EVIDENCE_ARTIFACT_NAME).is_file()
+    assert (output_root / launcher.METADATA_ARTIFACT_NAME).is_file()
+    assert (output_root / launcher.ONE_SHOT_MARKER_NAME).is_file()
+    evidence_payload = json.loads(
+        (output_root / launcher.EVIDENCE_ARTIFACT_NAME).read_text()
+    )
+    assert evidence_payload["authorities"]["input"]["posture"] == "refrozen_real_corpus"
+    assert evidence_payload["campaign"]["planned"] == 0
+
+    stdout2, stderr2 = _stdio()
+    second_exit_code = launcher.run_cli(argv, stdout=stdout2, stderr=stderr2)
+    assert second_exit_code == launcher.LAUNCH_REFUSED
+    assert "ONE_SHOT_ALREADY_CONSUMED" in stderr2.getvalue()
+
+
+def test_run_one_shot_rejects_a_wrong_confirmation_phrase(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest, corpus_root, output_root = _wire_common_fakes(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_require_clean_worktree", lambda: None)
+    stdout, stderr = _stdio()
+    exit_code = launcher.run_cli(
+        (
+            "--run-one-shot",
+            "--manifest",
+            str(manifest),
+            "--corpus-root",
+            str(corpus_root),
+            "--output-root",
+            str(output_root),
+            "--launcher-sha256",
+            _LAUNCHER_SHA256,
+            "--confirm-one-shot-oos-dry-count",
+            "not the phrase",
+        ),
+        stdout=stdout,
+        stderr=stderr,
+    )
+    assert exit_code == launcher.LAUNCH_REFUSED
+    assert "CONFIRM_PHRASE_MISMATCH" in stderr.getvalue()
+    assert not output_root.exists()


### PR DESCRIPTION
## Summary

Stage-3 refreeze launcher for ROB-1040 CRS-24 CORR-1, per the preregistration's "Stage-3 code-seal procedure" (merge → exact-main source refreeze → separate one-shot approval → empirical open). Adds a default-disabled, offline, read-only launcher (`scripts/run_rob1040_crs24_refreeze.py`) that evaluates the sealed CRS-24 feasibility surface against the real, frozen ROB-941 corpus, plus the single minimal seam in the sealed evidence module required to make that possible.

**No threshold/config/cadence/hold-period/formula/order in the CRS-24 preregistration or sealed modules was changed.** No PnL/forward-return is computed or emitted anywhere in this diff — exit remains timestamp-presence-only.

## (a) Why the sealed module was opened at all

The merged implementation (PR #1656, merge commit `0534db071b7b3820f7e0681f66da408a8ae0cc35`) has every real-data seam closed: `run_cell`/`run_all_cells`/`build_evidence`/`cell_payload` are permanent `RunAuthorityClosedError` stubs, and `_validated_campaign_factory()` took **zero arguments**, hard-coding a call to `build_synthetic_fixture()` internally. Critically, **the entire CRS-24 decision loop (gate → arbitrate → occupancy → entry-reference → exit-presence → order-filter → planned) lives only inside that factory's private closure (`evaluate_cell`)** — there is no public, reusable entry point for it.

A fully-additive launcher therefore cannot reach real-corpus evaluation, and reimplementing the decision loop in the launcher would risk silently diverging from the sealed logic — unacceptable for a one-shot pre-registered judgment. The only safe option is a minimal **input-binding seam**: parameterize `_validated_campaign_factory()` on a caller-supplied `CampaignInputBinding` (defaulting to `None`, which reproduces the exact original synthetic construction), while leaving `evaluate_cell`/`evaluate_all`/`require_registered_cells`/`evidence_core`/`_Evidence`/`_Context`/`issue_evidence` **byte-for-byte untouched**.

`CampaignInputBinding` has exactly two postures:
- `"frozen_synthetic_fixture"` — constructible only by the module's own zero-arg default path; every pin must equal the frozen `SYNTHETIC_*` module constants (or construction raises).
- `"refrozen_real_corpus"` — built via `CampaignInputBinding.for_real_corpus(...)`; every pin is **captured from the bound `generator`/`references` objects themselves** (never a bare caller-supplied string), and a real-posture binding is structurally forbidden from equaling any `SYNTHETIC_*` literal (checked in `__post_init__`). `open_real_corpus_campaign_context`/`build_real_corpus_evidence` additionally reject any binding whose posture isn't exactly `"refrozen_real_corpus"` — even a *correctly*-pinned synthetic-posture binding is refused there (tested).

`run_cell`/`run_all_cells`/`build_evidence`/`cell_payload` remain closed exactly as before.

## (b) Evidence the diff is decision-logic-neutral for the synthetic path

- `git diff --numstat` on `rob1040_crs24_evidence.py`: **+223 / -15** lines. The diff hunks touch only: the new `CampaignInputBinding` class, `_validated_campaign_factory`'s setup section + `verify_live_inputs`/`live_input_identity` (generalized from literal `SYNTHETIC_*` comparisons to `binding.*_pin` comparisons — same checks, different source), one conditional line in `sealed_evidence_state` (the `FROZEN_SYNTHETIC_EVIDENCE_SHA256` pin check is now skipped only for `posture != "frozen_synthetic_fixture"`), two new public functions, and `__all__`. **Zero lines changed inside `evaluate_cell`, `evaluate_all`, `require_registered_cells`, `evidence_core`, `_Evidence`, `_Context`, or `issue_evidence`.**
- All 5 pre-existing CRS-24 test suites (60 tests, 24-cell full campaign evaluations) pass unmodified against the new code, **including** `test_synthetic_evidence_hash_is_byte_stable_and_tamper_evident`, which asserts `evidence.evidence_sha256 == "ef9b0b819bef5e4cb0a63a9f88b5df0a7a65832d103d4ed379ba460fa3232bab"` (`FROZEN_SYNTHETIC_EVIDENCE_SHA256`) — i.e. the synthetic path is byte-identical post-diff.
- `tests/.../test_rob1040_crs24_static_guard.py`'s exact import-allowlist test still passes with **zero new imports** in `rob1040_crs24_evidence.py` (only already-imported `dataclasses`/`copy`/`math`/`typing` symbols are used).

## (c) Launcher gates (all fail-closed)

1. **Default-disabled**: no args → dry-run description JSON only, zero corpus reads/writes.
2. **Refreeze-head ancestry**: `git merge-base --is-ancestor 0534db071b7b3820f7e0681f66da408a8ae0cc35 HEAD`.
3. **Seven-file code seal**: `shasum -a 256` re-verification of all 7 CRS-24 implementation files against a pinned table; the one expected-changed file (`rob1040_crs24_evidence.py`) is named explicitly in `CRS24_CHANGED_FILES`, not silently re-pinned.
4. **Launcher physical self-sha256** (anti-stale-copy).
5. **Explicit literal one-shot confirmation phrase** (`--confirm-one-shot-oos-dry-count`), required only for `--run-one-shot`.
6. **Corpus/manifest pins**: exact `--manifest`/`--corpus-root`/`--output-root` path match; manifest lineage reused unmodified via `rob974_lineage.verify_parent` (physical + canonical-content hash, same pins `scripts/run_rob974_r2_campaign.py` already uses for the identical corpus).
7. **PIT lookback coverage** (metadata-only: manifest-declared `min_open_time_ms` vs. `first_cutoff - 60d - 84*4h`; no row data read, no statistic computed).
8. **One-shot exhaustion marker**: `--run-one-shot` refuses if `ONE_SHOT_CONSUMED.json` already exists in the output root; re-checked immediately before the empirical evaluation too (narrows, doesn't eliminate, a TOCTOU window).
9. **Worktree cleanliness** required for `--run-one-shot` only (not `--preflight`, which must stay repeatable for reviewers).
10. **Mode separation**: `--preflight` builds the real-corpus `CampaignInputBinding` and opens the validated context (`open_real_corpus_campaign_context`) but **never calls `.cells()`** — no feature/gate/candidate/occupancy evaluation, no OOS incidence count, ever. `--run-one-shot` additionally calls `build_real_corpus_evidence` and atomically writes the evidence/metadata artifacts + marker.

## (d) Seven-file refreeze digest table (before → after this PR)

| File | At merge commit `0534db07` | Current refreeze (this PR) |
|---|---|---|
| `rob1040_crs24_contracts.py` | `1f26ebec...5c` | *(unchanged)* |
| `rob1040_crs24_features.py` | `9fa529b8...84` | *(unchanged)* |
| `rob1040_crs24_feasibility.py` | `618a5775...ba` | *(unchanged)* |
| `rob1040_crs24_evidence.py` | `e5549b14...e8` | **`96d1e6b8...32`** (changed — this PR) |
| `rob1040_crs24_synthetic.py` | `ccc5bf16...00` | *(unchanged)* |
| `rob1040_crs24_cli.py` | `7169799f...06` | *(unchanged)* |
| `run_rob1040_crs24.py` | `f994aecd...62` | *(unchanged)* |

(Full digests are in `scripts/run_rob1040_crs24_refreeze.py`'s `CRS24_FILE_DIGESTS_AT_MERGE_COMMIT` / `CRS24_CURRENT_REFREEZE_FILE_DIGESTS`.)

## Test plan

- [x] `research/nautilus_scalping/tests/test_rob1040_crs24_{contracts,features,feasibility,evidence_cli,static_guard}.py` — 60 passed (fresh run, `519.15s`)
- [x] `research/nautilus_scalping/tests/test_rob1040_crs24_evidence_real_corpus_binding.py` (new) — 13 passed
- [x] `tests/scripts/test_run_rob1040_crs24_refreeze.py` (new) — 24 passed
- [x] `uv run ruff check app/ tests/ research/ scripts/` — all checks passed
- [x] `uv run ruff format --check app/ tests/ research/ scripts/` — all formatted
- [x] `uv run ty check app/ --error-on-warning` — all checks passed
- [ ] Real `--preflight`/`--run-one-shot` invocation against the actual frozen corpus (deliberately **not** run in this PR — that's the separate one-shot operator action this launcher exists to gate)

**Not merged** — awaiting adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# UPDATE 2026-07-26 — adversarial-verification BLOCK addressed (commit `af6544b8e`)

The verification report (`herdr-inbox/rob1040-launcher-verify-2026-07-26.md`) returned **BLOCK**: the
launcher **refused `--preflight` against the real ROB-941 corpus** and had four further seal/marker
defects. All nine required items are fixed in `af6544b8e`.

## The blocking defect (§ fix 1)

`CampaignInputBinding.__post_init__` required **all four** real-corpus pins to differ from the frozen
`SYNTHETIC_*` constants. But `ReferenceSurface.exit_presence_source_sha256` hashes only the
`present=True` rows of a **frozen 1296-key domain** — a presence bitmap carrying no content — so
**any two datasets with complete exit coverage produce the identical digest by construction**. The
all-signal synthetic calendar (1296/1296 present) and a gapless real corpus (1296/1296 present)
therefore necessarily collide. The guard effectively demanded *the real corpus be missing exit bars*
and fired as a false positive on every healthy corpus.

**Fix:** `exit_presence_source_sha256_pin` is removed from the must-differ set, with the reasoning
spelled out in a code comment. The three remaining must-differ pins are content-bearing and each
independently sufficient for anti-substitution — the joint `fixture_content_sha256_pin`
(generator + references), the complete-bar `snapshot_sha256_pin`, and the value-bearing
`entry_source_sha256_pin`, plus `version`. The exit pin is **still captured at construction and
still reverified** against the bound references in `__post_init__` and in `verify_live_inputs()` on
every use — it simply is not a posture discriminator. The synthetic-posture guard (all pins must
equal the frozen constants) is unchanged.

## All nine fixes

| # | Fix | Where |
|---|---|---|
| 1 | exit-presence pin removed from the real-posture must-differ set (blocking) | `rob1040_crs24_evidence.py` |
| 2 | regression tests for a **full-presence** real-corpus binding (the gap that hid the bug) | `test_..._real_corpus_binding.py` |
| 3 | `--run-one-shot` requires `HEAD == origin/main`; measured HEAD stamped into metadata | launcher |
| 4 | `validate_contract()` called in **both** modes + `rob944_folds.py`/`rob974_h4_contracts.py` digests | launcher |
| 5 | preregistration `.md` physically verified against `PREREGISTRATION_SIZE`/`SHA256` (imported) | launcher |
| 6 | two-stage marker: `ARMED` (O_EXCL + fsync) **before** evaluation → `CONSUMED` after writes | launcher |
| 7 | PIT gate made two-sided (right-truncated corpus now refused) | launcher |
| 8 | real posture requires corpus-manifest provenance; false docstring claim corrected | `rob1040_crs24_evidence.py` |
| 9 | **real-corpus `--preflight` actually executed** — output below | — |

### Notes on 3 and 6

- **(3)** The self merge SHA cannot be a compile-time constant. `--run-one-shot` now requires
  `git rev-parse HEAD == git rev-parse origin/main` (local refs only, no network) in addition to the
  existing ancestry check, and **measures** `git rev-parse HEAD` into
  `crs24_corr1_launch_metadata.json` as `head_sha_at_run` — this satisfies stage-3 procedure item 1
  ("the merge commit SHA on `main` that carries this implementation"). `--preflight` is deliberately
  **exempt** (it must stay auditable during review) and says so on both stderr and stdout.
- **(6)** `ARMED` is written exclusive-create + `fsync` immediately before `build_real_corpus_evidence`
  and promoted to `CONSUMED` only after both artifact writes. `ARMED` is **not self-clearing**: a
  later `--run-one-shot` refuses with `ONE_SHOT_ARMED_NOT_RECONCILED` (distinct from
  `ONE_SHOT_ALREADY_CONSUMED`) so a human must investigate. A test simulates a mid-evaluation crash
  and asserts the marker is durable and the re-run is refused.

## Synthetic-path neutrality re-proven

```
evidence_sha256      = ef9b0b819bef5e4cb0a63a9f88b5df0a7a65832d103d4ed379ba460fa3232bab
FROZEN_SYNTHETIC     = ef9b0b819bef5e4cb0a63a9f88b5df0a7a65832d103d4ed379ba460fa3232bab
EQUAL                = True
full payload sha256  = 15fa6b5095561b21ad55c8f6860a26148e787cde8eb53e68cde45986615ac002
```

Both values match the verifier's independently measured figures. `rob1040_crs24_evidence.py`'s
digest changed → `CRS24_CURRENT_REFREEZE_FILE_DIGESTS` re-pinned:

| File | At merge commit `0534db07` | Current refreeze (this PR) |
|---|---|---|
| `rob1040_crs24_evidence.py` | `e5549b146268bc48cc3f190529cd5a51e6874e863f58858af2a6cf9f01084ae8` | **`93bbee16960858cb79beabf821cd9a0d04835cd555066b2ca6ed82473c0916ea`** |

The other six entries are unchanged. New launcher self-sha256:
`6710f479cfd29303dc462503c0141c9ac7f96666c260503ac3b305f5fafabb7a`.
New separate authority table (`CRS24_AUTHORITY_FILE_DIGESTS`, deliberately kept apart from the
preregistered seven-file seal):

| File | sha256 |
|---|---|
| `rob944_folds.py` | `97a646b96647aca40f953701e04aa2d081fcf5b9bc50a654981a01feed40add0` |
| `rob974_h4_contracts.py` | `db68351c04321fa8e92054af930ebe78d1082a7c9f0862a1d9e7eb72b1d3499a` |

## ✅ Real-corpus `--preflight` — actually executed, exit 0

```
$ LSHA=$(shasum -a 256 scripts/run_rob1040_crs24_refreeze.py | cut -d' ' -f1)
$ uv run python scripts/run_rob1040_crs24_refreeze.py --preflight \
    --manifest  research/nautilus_scalping/data_manifests/rob941_corpus_manifest.v1.json \
    --corpus-root /Users/mgh3326/work/herdr-artifacts/rob941-4bcc2da9…/data \
    --output-root /Users/mgh3326/work/herdr-artifacts/rob1040-crs24-corr1-refreeze-v1 \
    --launcher-sha256 "$LSHA"
```

stderr (gate lines):

```
REFREEZE_PREFLIGHT launcher_self_sha256=PASS
REFREEZE_PREFLIGHT refreeze_head_ancestor=PASS
REFREEZE_PREFLIGHT seven_file_seal=PASS
REFREEZE_PREFLIGHT contract_authority=PASS
REFREEZE_PREFLIGHT preregistration_artifact=PASS
REFREEZE_PREFLIGHT head_is_origin_main=EXEMPT_IN_PREFLIGHT (enforced only in --run-one-shot)
REFREEZE_PREFLIGHT manifest_lineage=PASS
REFREEZE_PREFLIGHT pit_lookback_coverage=PASS
REFREEZE_PREFLIGHT real_corpus_binding_built=PASS
REFREEZE_PREFLIGHT validated_context_opened=PASS
```

stdout (payload):

```json
{"authority_file_seal_verified":true,"binding_identity":{"complete_bar_snapshot_sha256":"a22fbac56b800718bcb2536b552da7e654b644fec9800f4bc8fd24ad4fdaa2cc","entry_reference_source_sha256":"abc7410113037127ff4a72926c5ad5f065d38456f00946081f84be25521a6a6e","exit_presence_source_sha256":"14a217e426ef8c6f4c02661f6bfbd128a467263e1121665b983223d6a306bf43","fixture_content_sha256":"4bc89f4a0d886bb5c6b1cbb3b51ffe1bd71ece4d4fec81e88be7aad6223e55b6","posture":"refrozen_real_corpus","real_corpus_authority":{"corpus_manifest_content_sha256":"4bcc2da979b47caa45b5f90a09c326aefff91fa605e110d55ef316d53c9a9351"},"version":"rob1040.crs24.corr1.real_corpus.v1"},"contract_authority_revalidated":true,"counts_computed":false,"effects":{"artifact_writes":0,"one_shot_consumed":false},"head_is_origin_main_enforced":false,"head_is_origin_main_note":"HEAD == origin/main is enforced ONLY by --run-one-shot; --preflight is deliberately exempt so it stays auditable while this PR is under review.","mode":"preflight","preregistration_artifact_verified":true,"refreeze_head":"0534db071b7b3820f7e0681f66da408a8ae0cc35","schema_version":"rob1040_crs24_refreeze_launcher_preflight.v2","seven_file_seal_verified":true}
```

```
EXIT=0
```

Side-effect check afterwards: `EXPECTED_OUTPUT_ROOT` **does not exist** (`ls` → No such file or
directory) — no directory, no marker, no artifact. **No incidence count of any kind appears on
stdout, stderr, or disk**; `counts_computed` is `false`. The four measured pins are byte-identical to
those the verifier independently measured, including
`exit_presence_source_sha256 = 14a217e426ef8c6f4c02661f6bfbd128a467263e1121665b983223d6a306bf43`
— the structural collision with `SYNTHETIC_EXIT_PRESENCE_SOURCE_SHA256` that is now (correctly)
permitted.

**`--run-one-shot` was NOT run, in any form.**

## Test plan (re-run)

- [x] Full CRS-24 suite, `-p no:randomly`: **120 passed, 2 warnings in 660.25s** (was 97 → +23 new tests)
      across `test_rob1040_crs24_{contracts,evidence_cli,evidence_real_corpus_binding,feasibility,features,static_guard}.py`
      and `tests/scripts/test_run_rob1040_crs24_refreeze.py`
- [x] The fix-2 regression tests were confirmed to **fail against the pre-fix `evidence.py`**
      (`ValueError: real-corpus posture must not reuse any frozen synthetic pin`) before the fix was applied
- [x] `make lint` — ruff check / ruff format --check (3326 files) / `ty check app/ --error-on-warning`: all passed
- [x] **Real-corpus `--preflight`: exit 0** (output above)
- [ ] `--run-one-shot` — still the separate operator action this launcher exists to gate

**Still not merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for issuing CRS-24 synthetic feasibility evidence from validated real-corpus inputs.
  - Introduced a controlled real-corpus “refreeze” launcher with `dry-run`, `--preflight`, and `--run-one-shot` modes.
  - Enforced stronger input/provenance verification and repeat-run safety via a one-shot marker workflow.
- **Tests**
  - Expanded end-to-end coverage for real-corpus bindings/context sealing and the refreeze launcher gates, artifact writing, and refusal/error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
