### PR TITLE
fix(ROB-1040): close CRS-24 R3 low findings

### DIFF
--- a/docs/rob1040_crs24_closeout_runbook.md
+++ b/docs/rob1040_crs24_closeout_runbook.md
@@ -1,0 +1,45 @@
+# ROB-1040 CRS-24 closeout runbook
+
+Status: **TERMINATE_RESEARCH** as of 2026-07-26. The CRS-24 one-shot is
+consumed. This document records the launcher boundary for audit and
+maintenance; it does not authorize another empirical run.
+
+## Threat model and provenance boundary
+
+The launcher guards against operator error and accidental source or artifact
+drift. Arbitrary code execution inside the same Python process is outside its
+threat model: such code could replace the evaluator itself, so adding more
+in-process object guards would not provide a meaningful security boundary.
+
+The real-posture must-differ pins are a **negative test** only: they establish
+that a `CampaignInputBinding` is not the frozen synthetic fixture. They do not
+affirmatively establish that the binding came from the frozen ROB-941 corpus.
+
+Affirmative corpus provenance is provided entirely by the launcher's
+manifest-lineage chain:
+
+- `rob974_lineage.verify_parent` checks the pinned physical manifest digest
+  and canonical manifest-content digest.
+- `EXPECTED_PARENT_CONTENT_SHA256` independently binds the launcher to that
+  canonical parent identity.
+- `rob941_offline_loader` verifies every shard's raw-archive checksum chain,
+  derived shard bytes, schema, canonical row content, and declared bounds.
+
+The negative pins and affirmative lineage chain are complementary. A
+must-differ PASS alone must never be reported as proof of ROB-941 provenance.
+
+## Git gate behavior
+
+The exact-main gate performs `git fetch --prune origin` itself and refuses if
+the fetch fails, so it cannot pass from only a stale or locally forged
+`origin/main` ref. The refreeze-ancestor gate detects a shallow checkout and
+unshallows it before making the final ancestry decision.
+
+## Preserved one-shot evidence
+
+The completed evidence remains under
+`herdr-artifacts/rob1040-oneshot-56bdb1f6/`. Its canonical digest is
+`56bdb1f6aa425ed42c4137fb494946171d3634d0fb4a8dbb4a3231ecb79c2731`.
+The judgment report's reproduction procedure reads the launcher and sealed
+files from commit `c9b4658b`; closeout maintenance must not rewrite that
+commit or reinterpret the terminated result.

--- a/research/nautilus_scalping/rob1040_crs24_evidence.py
+++ b/research/nautilus_scalping/rob1040_crs24_evidence.py
@@ -706,13 +706,13 @@ class CampaignInputBinding:
                 )
         else:
             # Anti-substitution: a real-corpus binding must not be a relabelled
-            # frozen synthetic fixture. The decisive discriminator is the JOINT
-            # identity `fixture_content_sha256_pin` (generator + references
-            # together) -- differing there is by itself sufficient proof that
-            # this binding is not the synthetic fixture. `version`, the
-            # complete-bar `snapshot_sha256_pin` and the value-bearing
-            # `entry_source_sha256_pin` add independent content-bearing
-            # evidence and are also required to differ.
+            # frozen synthetic fixture. The complete-bar
+            # `snapshot_sha256_pin` and value-bearing `entry_source_sha256_pin`
+            # are the two content-bearing discriminators. The
+            # `fixture_content_sha256_pin` is a derived join of its component
+            # digests, so it cannot detect anything those inputs miss; `version`
+            # is a caller-supplied assertion. Both are still required to differ
+            # as redundant posture checks, not as independent corpus evidence.
             #
             # `exit_presence_source_sha256_pin` is DELIBERATELY EXCLUDED from
             # the must-differ set. `ReferenceSurface.exit_presence_source_sha256`

--- a/scripts/run_rob1040_crs24_refreeze.py
+++ b/scripts/run_rob1040_crs24_refreeze.py
@@ -102,7 +102,7 @@ CRS24_CHANGED_FILES: frozenset[str] = frozenset({"rob1040_crs24_evidence.py"})
 CRS24_CURRENT_REFREEZE_FILE_DIGESTS: dict[str, str] = {
     **CRS24_FILE_DIGESTS_AT_MERGE_COMMIT,
     "rob1040_crs24_evidence.py": (
-        "93bbee16960858cb79beabf821cd9a0d04835cd555066b2ca6ed82473c0916ea"
+        "08550a03bd0e8517efe004cbd2eb9ea7b3d0367b9acddcf7dfd898e3c993ab74"
     ),
 }
 
@@ -303,13 +303,35 @@ def _require_launcher_self_sha256(claimed: str) -> None:
 
 
 def _require_refreeze_head_ancestor() -> None:
-    try:
-        subprocess.run(
+    def _is_ancestor() -> bool:
+        result = subprocess.run(
             ("git", "merge-base", "--is-ancestor", CRS24_MERGE_REFREEZE_HEAD, "HEAD"),
             cwd=REPO_ROOT,
-            check=True,
+            check=False,
             capture_output=True,
         )
+        return result.returncode == 0
+
+    try:
+        if _is_ancestor():
+            return
+        if _git("rev-parse", "--is-shallow-repository") != "true":
+            raise LaunchRefused("REFREEZE_HEAD_NOT_ANCESTOR")
+        # A depth-limited checkout cannot distinguish "not an ancestor" from
+        # "the ancestor exists upstream but is outside the local boundary".
+        # Complete the history, then make the ancestry decision from the full
+        # graph. A failed unshallow or a still-false result remains fail-closed.
+        _git(
+            "fetch",
+            "--prune",
+            "--unshallow",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        )
+        if not _is_ancestor():
+            raise LaunchRefused("REFREEZE_HEAD_NOT_ANCESTOR")
+    except LaunchRefused:
+        raise
     except (OSError, subprocess.CalledProcessError):
         raise LaunchRefused("REFREEZE_HEAD_NOT_ANCESTOR") from None
 
@@ -320,13 +342,22 @@ def _require_head_is_origin_main() -> None:
     Linear ROB-1040 실행순서 step 3 requires the final hash-seal/launcher gate
     to be taken "머지된 exact main tree에서". The ancestry check alone is not
     sufficient: it also passes on an unmerged feature branch that merely
-    descends from the refreeze head. This gate compares LOCAL refs only (no
-    network, no fetch) -- the operator is responsible for having fetched
-    `origin/main` before arming the one-shot.
+    descends from the refreeze head. A successful ``git fetch --prune origin``
+    is mandatory inside this gate, so a stale or locally forged
+    ``origin/main`` ref cannot make the comparison pass.
 
     `--preflight` is exempt (it must stay auditable while the PR is under
     review); the preflight output says so explicitly.
     """
+    try:
+        _git(
+            "fetch",
+            "--prune",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+        )
+    except (OSError, subprocess.CalledProcessError):
+        raise LaunchRefused("ORIGIN_FETCH_FAILED") from None
     try:
         head = _git("rev-parse", "HEAD")
         origin_main = _git("rev-parse", "origin/main")
@@ -596,7 +627,6 @@ def _arm_one_shot_marker(output_root: Path, *, armed_at_utc: str) -> None:
     both pass the pre-check and both arm; ``fsync`` before returning so a
     crash immediately after arming still leaves the record on disk.
     """
-    output_root.mkdir(parents=True, exist_ok=True)
     marker = output_root / ONE_SHOT_MARKER_NAME
     body = (
         json.dumps(
@@ -617,6 +647,7 @@ def _arm_one_shot_marker(output_root: Path, *, armed_at_utc: str) -> None:
         + "\n"
     )
     try:
+        output_root.mkdir(parents=True, exist_ok=True)
         descriptor = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
     except FileExistsError:
         raise LaunchRefused("ONE_SHOT_ALREADY_CONSUMED") from None

--- a/tests/scripts/test_run_rob1040_crs24_refreeze.py
+++ b/tests/scripts/test_run_rob1040_crs24_refreeze.py
@@ -95,8 +95,21 @@ def _init_hermetic_git_repo(repo_dir: Path) -> tuple[str, str]:
     return first_sha, head_sha
 
 
-def _set_origin_main_ref(repo_dir: Path, sha: str) -> None:
-    _run_git(repo_dir, "update-ref", "refs/remotes/origin/main", sha)
+def _set_origin_main_ref(repo_dir: Path, sha: str) -> Path:
+    """Publish ``sha`` as main on a local bare origin and fetch it."""
+    remote_dir = repo_dir.with_name(f"{repo_dir.name}-origin.git")
+    if not remote_dir.exists():
+        subprocess.run(
+            ("git", "init", "--bare", "-q", str(remote_dir)),
+            cwd=repo_dir.parent,
+            check=True,
+            capture_output=True,
+            env=_GIT_ENV,
+        )
+        _run_git(repo_dir, "remote", "add", "origin", str(remote_dir))
+    _run_git(repo_dir, "push", "--force", "-q", "origin", f"{sha}:refs/heads/main")
+    _run_git(repo_dir, "fetch", "--prune", "-q", "origin")
+    return remote_dir
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +203,46 @@ def test_refreeze_head_ancestor_gate_rejects_an_unknown_sha(
     monkeypatch.setattr(launcher, "CRS24_MERGE_REFREEZE_HEAD", "f" * 40)
     with pytest.raises(launcher.LaunchRefused, match="REFREEZE_HEAD_NOT_ANCESTOR"):
         launcher._require_refreeze_head_ancestor()
+
+
+def test_refreeze_head_ancestor_gate_unshallows_before_deciding(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A depth-1 clone cannot initially see the pinned ancestor.
+
+    The old gate reported REFREEZE_HEAD_NOT_ANCESTOR from that incomplete graph.
+    The hardened gate completes the history and then makes the real decision.
+    """
+    source_dir = tmp_path / "source"
+    merge_sha, head_sha = _init_hermetic_git_repo(source_dir)
+    remote_dir = _set_origin_main_ref(source_dir, head_sha)
+    shallow_dir = tmp_path / "shallow"
+    subprocess.run(
+        (
+            "git",
+            "clone",
+            "-q",
+            "--depth",
+            "1",
+            "--branch",
+            "main",
+            f"file://{remote_dir}",
+            str(shallow_dir),
+        ),
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    assert _run_git(shallow_dir, "rev-parse", "--is-shallow-repository") == "true"
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_git(shallow_dir, "cat-file", "-e", f"{merge_sha}^{{commit}}")
+
+    monkeypatch.setattr(launcher, "REPO_ROOT", shallow_dir)
+    monkeypatch.setattr(launcher, "CRS24_MERGE_REFREEZE_HEAD", merge_sha)
+    launcher._require_refreeze_head_ancestor()
+
+    assert _run_git(shallow_dir, "rev-parse", "--is-shallow-repository") == "false"
 
 
 def test_clean_worktree_gate_reflects_actual_git_status() -> None:
@@ -332,6 +385,26 @@ def test_arm_one_shot_marker_is_exclusive_create(tmp_path: Path) -> None:
         launcher._arm_one_shot_marker(
             output_root, armed_at_utc="2026-07-26T00:00:01+00:00"
         )
+
+
+def test_arm_one_shot_marker_classifies_mkdir_permission_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    output_root = tmp_path / "unwritable" / "out"
+    real_mkdir = Path.mkdir
+
+    def _permission_denied(path: Path, *args: object, **kwargs: object) -> None:
+        if path == output_root:
+            raise PermissionError("simulated unwritable output parent")
+        real_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _permission_denied)
+    with pytest.raises(launcher.LaunchRefused) as refusal:
+        launcher._arm_one_shot_marker(
+            output_root, armed_at_utc="2026-07-26T00:00:00+00:00"
+        )
+    assert refusal.value.reason_code == "ONE_SHOT_MARKER_UNWRITABLE"
+    assert not output_root.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -530,17 +603,34 @@ def test_head_is_origin_main_gate_refuses_when_head_diverges_from_origin_main(
         launcher._require_head_is_origin_main()
 
 
-def test_head_is_origin_main_gate_refuses_when_origin_main_ref_is_absent(
+def test_head_is_origin_main_gate_fetches_before_trusting_a_forged_local_ref(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Reproduces the CI checkout shape directly: a shallow/partial checkout
-    commonly has no `origin/main` ref at all (`git rev-parse origin/main`
-    exits 128) unless a prior step explicitly fetched one. The gate must fail
-    closed with a typed refusal, not let the subprocess error propagate."""
     repo_dir = tmp_path / "repo"
-    _init_hermetic_git_repo(repo_dir)  # no origin/main ref created
+    origin_sha, head_sha = _init_hermetic_git_repo(repo_dir)
+    _set_origin_main_ref(repo_dir, origin_sha)
+    # Forge the local remote-tracking ref so the old local-only comparison
+    # would pass even though the origin's main still points at origin_sha.
+    _run_git(repo_dir, "update-ref", "refs/remotes/origin/main", head_sha)
+    assert _run_git(repo_dir, "rev-parse", "HEAD") == _run_git(
+        repo_dir, "rev-parse", "origin/main"
+    )
+
     monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
-    with pytest.raises(launcher.LaunchRefused, match="GIT_STATE_UNAVAILABLE"):
+    with pytest.raises(launcher.LaunchRefused, match="HEAD_IS_NOT_ORIGIN_MAIN"):
+        launcher._require_head_is_origin_main()
+
+    assert _run_git(repo_dir, "rev-parse", "origin/main") == origin_sha
+
+
+def test_head_is_origin_main_gate_refuses_when_origin_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The exact-main decision cannot pass without a successful fresh fetch."""
+    repo_dir = tmp_path / "repo"
+    _init_hermetic_git_repo(repo_dir)  # no origin remote configured
+    monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
+    with pytest.raises(launcher.LaunchRefused, match="ORIGIN_FETCH_FAILED"):
         launcher._require_head_is_origin_main()
 
 
@@ -551,6 +641,7 @@ def test_head_is_origin_main_gate_refuses_a_descendant_feature_branch(
     an unmerged feature branch that merely descends from the refreeze head."""
     repo_dir = tmp_path / "repo"
     merge_sha, _head_sha = _init_hermetic_git_repo(repo_dir)
+    _set_origin_main_ref(repo_dir, merge_sha)
     monkeypatch.setattr(launcher, "REPO_ROOT", repo_dir)
     monkeypatch.setattr(launcher, "CRS24_MERGE_REFREEZE_HEAD", merge_sha)
 


### PR DESCRIPTION
## Summary

- document the CRS-24 threat-model boundary and clarify that must-differ pins are negative tests while the launcher lineage chain provides affirmative corpus provenance
- correct the two overstated must-differ comments without changing executable evidence logic
- require an explicit fresh origin/main fetch, classify marker mkdir failures, and recover ancestry checks in shallow clones
- add hermetic regressions for forged local refs, mkdir permission failure, and depth-1 ancestry

The CRS-24 one-shot remains consumed and was not rerun. No threshold, cadence, holding, configuration, decision/count logic, or four sealed authority constants changed.

## Verification

- `uv run --group test pytest --no-cov -q tests/scripts/test_run_rob1040_crs24_refreeze.py research/nautilus_scalping/tests/test_rob1040_crs24_contracts.py research/nautilus_scalping/tests/test_rob1040_crs24_evidence_cli.py research/nautilus_scalping/tests/test_rob1040_crs24_evidence_real_corpus_binding.py research/nautilus_scalping/tests/test_rob1040_crs24_feasibility.py research/nautilus_scalping/tests/test_rob1040_crs24_features.py research/nautilus_scalping/tests/test_rob1040_crs24_static_guard.py`
  - 125 passed, 2 pre-existing Pydantic deprecation warnings
- `uv run --group dev ruff check ...`
  - All checks passed
- `uv run --group dev ruff format --check ...`
  - 3 files already formatted
- executable AST of `rob1040_crs24_evidence.py` is unchanged from `origin/main`

## Judgment reproduction

- artifact directory recursive diff: identical (exit 0, no output)
- canonical evidence digest:
  `56bdb1f6aa425ed42c4137fb494946171d3634d0fb4a8dbb4a3231ecb79c2731`
- synthetic occupancy: `[(18, 36)] * 8`
- all seven `git show c9b4658b:...` seal hashes match the judgment report


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a closeout runbook documenting CRS-24 termination status, evidence preservation, provenance verification, and maintenance procedures.

* **Bug Fixes**
  * Improved refreeze validation for shallow repositories by completing history before checking ancestry.
  * Ensured branch-state checks refresh remote information before validation, preventing stale or misleading results.
  * Added clear failure handling when output markers cannot be written or remote verification fails.

* **Tests**
  * Expanded coverage for repository validation, marker creation failures, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->