### PR TITLE
T2: add R4 P0 no-regret PIT collector

### DIFF
--- a/app/services/binance_r4_p0_collector.py
+++ b/app/services/binance_r4_p0_collector.py
@@ -1,0 +1,873 @@
+"""R4 P0 point-in-time collector for Binance USD-M public market data.
+
+This module is deliberately isolated from every Binance execution adapter.  It
+can issue only unsigned GET requests to a small production-public allowlist and
+can connect only to the public USD-M websocket host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import logging
+import random
+import sqlite3
+import urllib.parse
+import uuid
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+import httpx
+import websockets
+
+REST_BASE_URL: Final = "https://fapi.binance.com"
+WS_PUBLIC_BASE_URL: Final = "wss://fstream.binance.com/public"
+WS_MARKET_BASE_URL: Final = "wss://fstream.binance.com/market"
+REST_PATH_ALLOWLIST: Final = frozenset(
+    {
+        "/fapi/v1/openInterest",
+        "/fapi/v1/premiumIndex",
+        "/fapi/v1/premiumIndexKlines",
+        "/futures/data/basis",
+        "/futures/data/takerlongshortRatio",
+    }
+)
+SYMBOLS: Final = ("XRPUSDT", "DOGEUSDT", "SOLUSDT", "BTCUSDT")
+SIGNAL_SYMBOLS: Final = frozenset({"XRPUSDT", "DOGEUSDT", "SOLUSDT"})
+PREDICTOR_ONLY_SYMBOLS: Final = frozenset({"BTCUSDT"})
+PIT_COLUMNS: Final = (
+    "source",
+    "symbol",
+    "event_time",
+    "transaction_time",
+    "local_receive_time",
+    "request_started_at",
+    "request_completed_at",
+    "sequence_or_trade_id",
+    "raw_payload_sha256",
+    "collector_version",
+    "partition_sha256",
+    "gap_detected",
+    "reconnect_id",
+)
+COLLECTOR_VERSION: Final = "r4-p0-collector.v1"
+EXPECTED_SOURCES: Final = frozenset(
+    {
+        "binance_usdm.aggTrade",
+        "binance_usdm.forceOrder",
+        "binance_usdm.bookTicker",
+        "binance_usdm.depth5",
+        "binance_usdm.openInterest",
+        "binance_usdm.basis",
+        "binance_usdm.takerLongShortRatio",
+        "binance_usdm.premiumIndex",
+        "binance_usdm.premiumIndexKline1m",
+        "binance_usdm.predictedFunding",
+    }
+)
+SPARSE_SOURCES: Final = frozenset({"binance_usdm.forceOrder"})
+REQUIRED_ACTIVE_SOURCES: Final = EXPECTED_SOURCES - SPARSE_SOURCES
+
+log = logging.getLogger("r4_p0_collector")
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+def iso_utc(value: dt.datetime | None) -> str | None:
+    if value is None:
+        return None
+    return (
+        value.astimezone(dt.UTC)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def epoch_ms(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return iso_utc(dt.datetime.fromtimestamp(int(value) / 1000, tz=dt.UTC))
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def assert_rest_target(path: str) -> None:
+    parsed = urllib.parse.urlparse(f"{REST_BASE_URL}{path}")
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "fapi.binance.com"
+        or parsed.path not in REST_PATH_ALLOWLIST
+    ):
+        raise ValueError(
+            f"blocked Binance REST target: {parsed.scheme}://{parsed.netloc}{parsed.path}"
+        )
+
+
+def assert_ws_target(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    path = parsed.path.rstrip("/")
+    if (
+        parsed.scheme != "wss"
+        or parsed.hostname != "fstream.binance.com"
+        or not (path.startswith("/public/") or path.startswith("/market/"))
+    ):
+        raise ValueError(
+            f"blocked Binance websocket target: {parsed.scheme}://{parsed.netloc}"
+        )
+
+
+def build_ws_urls(symbols: Sequence[str] = SYMBOLS) -> dict[str, str]:
+    public_streams = [
+        f"{symbol.lower()}@{stream}"
+        for symbol in symbols
+        for stream in ("bookTicker", "depth5@100ms")
+    ]
+    market_streams = [
+        f"{symbol.lower()}@{stream}"
+        for symbol in symbols
+        for stream in ("aggTrade", "forceOrder")
+    ]
+    # The all-market snapshot is retained alongside symbol streams as required
+    # by the R4 source contract. Semantic record ids deduplicate overlap.
+    market_streams.append("!forceOrder@arr")
+    urls = {
+        "public": (f"{WS_PUBLIC_BASE_URL}/stream?streams={'/'.join(public_streams)}"),
+        "market": (f"{WS_MARKET_BASE_URL}/stream?streams={'/'.join(market_streams)}"),
+    }
+    for url in urls.values():
+        assert_ws_target(url)
+    return urls
+
+
+@dataclass(frozen=True, slots=True)
+class CollectorConfig:
+    artifact_root: Path
+    duration_seconds: float | None = None
+    oi_poll_seconds: float = 60.0
+    premium_poll_seconds: float = 60.0
+    basis_poll_seconds: float = 300.0
+    taker_poll_seconds: float = 300.0
+    status_seconds: float = 30.0
+    symbols: tuple[str, ...] = SYMBOLS
+
+
+class AppendOnlyPITStore:
+    """Crash-safe local research artifact with immutable rows and deduplication."""
+
+    def __init__(
+        self, root: Path, *, collector_version: str = COLLECTOR_VERSION
+    ) -> None:
+        self.root = root.expanduser().resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.path = self.root / "r4_p0_collector.sqlite3"
+        self.collector_version = collector_version
+        self._lock_file = (self.root / ".collector.lock").open("a+")
+        try:
+            fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            self._lock_file.close()
+            raise RuntimeError(
+                f"collector artifact is already locked: {self.root}"
+            ) from exc
+        self._db = sqlite3.connect(self.path)
+        self._db.row_factory = sqlite3.Row
+        self._configure()
+
+    def _configure(self) -> None:
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA synchronous=FULL")
+        self._db.execute("PRAGMA foreign_keys=ON")
+        self._db.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS pit_records (
+                append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                record_id TEXT NOT NULL UNIQUE,
+                partition_key TEXT NOT NULL,
+                source TEXT NOT NULL,
+                symbol TEXT NOT NULL,
+                event_time TEXT,
+                transaction_time TEXT,
+                local_receive_time TEXT NOT NULL,
+                request_started_at TEXT,
+                request_completed_at TEXT,
+                sequence_or_trade_id TEXT,
+                raw_payload_sha256 TEXT NOT NULL,
+                collector_version TEXT NOT NULL,
+                partition_sha256 TEXT NOT NULL,
+                gap_detected INTEGER NOT NULL CHECK (gap_detected IN (0, 1)),
+                reconnect_id TEXT,
+                previous_partition_sha256 TEXT,
+                run_id TEXT NOT NULL,
+                raw_payload TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS ix_pit_partition
+                ON pit_records(partition_key, append_id);
+            CREATE INDEX IF NOT EXISTS ix_pit_source_symbol
+                ON pit_records(source, symbol, append_id);
+            CREATE TRIGGER IF NOT EXISTS pit_records_no_update
+            BEFORE UPDATE ON pit_records
+            BEGIN
+                SELECT RAISE(ABORT, 'pit_records is append-only');
+            END;
+            CREATE TRIGGER IF NOT EXISTS pit_records_no_delete
+            BEFORE DELETE ON pit_records
+            BEGIN
+                SELECT RAISE(ABORT, 'pit_records is append-only');
+            END;
+            """
+        )
+        self._db.commit()
+
+    def close(self) -> None:
+        self._db.close()
+        fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_UN)
+        self._lock_file.close()
+
+    def __enter__(self) -> AppendOnlyPITStore:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def has_source_symbol(self, source: str, symbol: str) -> bool:
+        row = self._db.execute(
+            "SELECT 1 FROM pit_records WHERE source = ? AND symbol = ? LIMIT 1",
+            (source, symbol),
+        ).fetchone()
+        return row is not None
+
+    def append(
+        self,
+        *,
+        source: str,
+        symbol: str,
+        raw_payload: Any,
+        local_receive_time: dt.datetime,
+        run_id: str,
+        event_time: str | None,
+        transaction_time: str | None,
+        request_started_at: str | None,
+        request_completed_at: str | None,
+        sequence_or_trade_id: str | None,
+        gap_detected: bool,
+        reconnect_id: str | None,
+    ) -> bool:
+        raw_text = canonical_json(raw_payload)
+        raw_hash = sha256_text(raw_text)
+        local_iso = iso_utc(local_receive_time)
+        assert local_iso is not None
+        record_identity = {
+            "source": source,
+            "symbol": symbol,
+            "event_time": event_time,
+            "transaction_time": transaction_time,
+            "sequence_or_trade_id": sequence_or_trade_id,
+            "raw_payload_sha256": raw_hash,
+        }
+        record_id = sha256_text(canonical_json(record_identity))
+        day = local_iso[:10]
+        partition_key = f"{source}/{symbol}/{day}"
+
+        self._db.execute("BEGIN IMMEDIATE")
+        try:
+            if self._db.execute(
+                "SELECT 1 FROM pit_records WHERE record_id = ?", (record_id,)
+            ).fetchone():
+                self._db.rollback()
+                return False
+            previous_row = self._db.execute(
+                """
+                SELECT partition_sha256 FROM pit_records
+                WHERE partition_key = ? ORDER BY append_id DESC LIMIT 1
+                """,
+                (partition_key,),
+            ).fetchone()
+            previous_hash = previous_row["partition_sha256"] if previous_row else None
+            chain_payload = {
+                **record_identity,
+                "local_receive_time": local_iso,
+                "request_started_at": request_started_at,
+                "request_completed_at": request_completed_at,
+                "collector_version": self.collector_version,
+                "gap_detected": gap_detected,
+                "reconnect_id": reconnect_id,
+                "previous_partition_sha256": previous_hash,
+                "run_id": run_id,
+            }
+            partition_hash = sha256_text(
+                f"{previous_hash or ''}\n{canonical_json(chain_payload)}"
+            )
+            self._db.execute(
+                """
+                INSERT INTO pit_records (
+                    record_id, partition_key, source, symbol, event_time,
+                    transaction_time, local_receive_time, request_started_at,
+                    request_completed_at, sequence_or_trade_id,
+                    raw_payload_sha256, collector_version, partition_sha256,
+                    gap_detected, reconnect_id, previous_partition_sha256,
+                    run_id, raw_payload
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record_id,
+                    partition_key,
+                    source,
+                    symbol,
+                    event_time,
+                    transaction_time,
+                    local_iso,
+                    request_started_at,
+                    request_completed_at,
+                    sequence_or_trade_id,
+                    raw_hash,
+                    self.collector_version,
+                    partition_hash,
+                    int(gap_detected),
+                    reconnect_id,
+                    previous_hash,
+                    run_id,
+                    raw_text,
+                ),
+            )
+            self._db.commit()
+            return True
+        except BaseException:
+            self._db.rollback()
+            raise
+
+    def audit(self) -> dict[str, Any]:
+        missing = []
+        bad_raw_hash = 0
+        bad_chain = 0
+        previous_by_partition: dict[str, str | None] = {}
+        count = 0
+        rows = self._db.execute("SELECT * FROM pit_records ORDER BY append_id")
+        for row in rows:
+            count += 1
+            record = dict(row)
+            missing.extend(column for column in PIT_COLUMNS if column not in record)
+            if sha256_text(record["raw_payload"]) != record["raw_payload_sha256"]:
+                bad_raw_hash += 1
+            previous = previous_by_partition.get(record["partition_key"])
+            if record["previous_partition_sha256"] != previous:
+                bad_chain += 1
+            chain_payload = {
+                "source": record["source"],
+                "symbol": record["symbol"],
+                "event_time": record["event_time"],
+                "transaction_time": record["transaction_time"],
+                "sequence_or_trade_id": record["sequence_or_trade_id"],
+                "raw_payload_sha256": record["raw_payload_sha256"],
+                "local_receive_time": record["local_receive_time"],
+                "request_started_at": record["request_started_at"],
+                "request_completed_at": record["request_completed_at"],
+                "collector_version": record["collector_version"],
+                "gap_detected": bool(record["gap_detected"]),
+                "reconnect_id": record["reconnect_id"],
+                "previous_partition_sha256": record["previous_partition_sha256"],
+                "run_id": record["run_id"],
+            }
+            expected = sha256_text(f"{previous or ''}\n{canonical_json(chain_payload)}")
+            if expected != record["partition_sha256"]:
+                bad_chain += 1
+            previous_by_partition[record["partition_key"]] = record["partition_sha256"]
+        return {
+            "rows": count,
+            "pit_columns": list(PIT_COLUMNS),
+            "missing_pit_columns": sorted(set(missing)),
+            "bad_raw_payload_hashes": bad_raw_hash,
+            "bad_partition_chain_links": bad_chain,
+            "ok": not missing and bad_raw_hash == 0 and bad_chain == 0,
+        }
+
+    def sample_by_source(self) -> list[dict[str, Any]]:
+        rows = self._db.execute(
+            """
+            SELECT p.* FROM pit_records p
+            INNER JOIN (
+                SELECT source, MIN(append_id) AS append_id
+                FROM pit_records GROUP BY source
+            ) firsts ON firsts.append_id = p.append_id
+            ORDER BY p.source
+            """
+        )
+        return [dict(row) for row in rows]
+
+    def counts(self) -> dict[str, int]:
+        return {
+            row["source"]: row["count"]
+            for row in self._db.execute(
+                "SELECT source, COUNT(*) AS count FROM pit_records GROUP BY source"
+            )
+        }
+
+
+class BinanceR4P0Collector:
+    def __init__(self, config: CollectorConfig, store: AppendOnlyPITStore) -> None:
+        self.config = config
+        self.store = store
+        self.run_id = uuid.uuid4().hex
+        self.stop = asyncio.Event()
+        self.session_counts: Counter[str] = Counter()
+        self.duplicate_counts: Counter[str] = Counter()
+        self.failure_counts: Counter[str] = Counter()
+        self._previous_sequence: dict[tuple[str, str], int] = {}
+        self._seen_on_connection: set[tuple[str, str, str]] = set()
+        self._last_book_snapshot: dict[str, dt.datetime] = {}
+
+    async def run(self) -> None:
+        log.info(
+            "collector.start run_id=%s symbols=%s artifact=%s",
+            self.run_id,
+            ",".join(self.config.symbols),
+            self.store.path,
+        )
+        tasks = [
+            asyncio.create_task(self._ws_supervisor("public"), name="r4-p0-ws-public"),
+            asyncio.create_task(self._ws_supervisor("market"), name="r4-p0-ws-market"),
+            asyncio.create_task(
+                self._poll_loop("open_interest", self.config.oi_poll_seconds),
+                name="r4-p0-open-interest",
+            ),
+            asyncio.create_task(
+                self._poll_loop("premium", self.config.premium_poll_seconds),
+                name="r4-p0-premium",
+            ),
+            asyncio.create_task(
+                self._poll_loop("basis", self.config.basis_poll_seconds),
+                name="r4-p0-basis",
+            ),
+            asyncio.create_task(
+                self._poll_loop("taker", self.config.taker_poll_seconds),
+                name="r4-p0-taker",
+            ),
+            asyncio.create_task(self._status_loop(), name="r4-p0-status"),
+        ]
+        timer = None
+        if self.config.duration_seconds is not None:
+            timer = asyncio.create_task(self._duration_timer(), name="r4-p0-duration")
+            tasks.append(timer)
+        try:
+            await self.stop.wait()
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            log.info(
+                "collector.stop run_id=%s session_counts=%s duplicates=%s failures=%s",
+                self.run_id,
+                dict(self.session_counts),
+                dict(self.duplicate_counts),
+                dict(self.failure_counts),
+            )
+
+    def health(self) -> dict[str, Any]:
+        active = set(self.session_counts) | set(self.duplicate_counts)
+        missing_required = sorted(REQUIRED_ACTIVE_SOURCES - active)
+        missing_sparse = sorted(SPARSE_SOURCES - active)
+        return {
+            "ok": not missing_required and not self.failure_counts,
+            "missing_required_sources": missing_required,
+            "missing_sparse_sources": missing_sparse,
+            "failures": dict(self.failure_counts),
+            "session_counts": dict(self.session_counts),
+            "duplicate_counts": dict(self.duplicate_counts),
+        }
+
+    async def _duration_timer(self) -> None:
+        assert self.config.duration_seconds is not None
+        await asyncio.sleep(self.config.duration_seconds)
+        self.stop.set()
+
+    async def _status_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self.config.status_seconds)
+            log.info(
+                "collector.status run_id=%s session_counts=%s duplicates=%s failures=%s total=%s",
+                self.run_id,
+                dict(self.session_counts),
+                dict(self.duplicate_counts),
+                dict(self.failure_counts),
+                self.store.counts(),
+            )
+
+    async def _ws_supervisor(self, lane: str) -> None:
+        failure_attempt = 0
+        reconnect_number = 0
+        url = build_ws_urls(self.config.symbols)[lane]
+        while not self.stop.is_set():
+            reconnect_number += 1
+            reconnect_id = f"{self.run_id}:ws:{lane}:{reconnect_number}"
+            request_started = utc_now()
+            try:
+                assert_ws_target(url)
+                async with websockets.connect(
+                    url,
+                    ping_interval=20,
+                    ping_timeout=20,
+                    close_timeout=10,
+                    max_queue=4096,
+                ) as ws:
+                    request_completed = utc_now()
+                    log.info(
+                        "collector.ws.connected lane=%s reconnect_id=%s",
+                        lane,
+                        reconnect_id,
+                    )
+                    failure_attempt = 0
+                    async for raw in ws:
+                        received = utc_now()
+                        self._handle_ws_raw(
+                            raw,
+                            received=received,
+                            request_started=request_started,
+                            request_completed=request_completed,
+                            reconnect_id=reconnect_id,
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self.failure_counts["websocket"] += 1
+                delay = min(60.0, 1.0 * (2 ** min(failure_attempt, 6)))
+                delay *= random.uniform(0.8, 1.2)
+                failure_attempt += 1
+                log.error(
+                    "collector.ws.disconnected reconnect_id=%s error=%s backoff_s=%.2f",
+                    reconnect_id,
+                    type(exc).__name__,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+    def _handle_ws_raw(
+        self,
+        raw: str | bytes,
+        *,
+        received: dt.datetime,
+        request_started: dt.datetime,
+        request_completed: dt.datetime,
+        reconnect_id: str,
+    ) -> None:
+        try:
+            message = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+            self.failure_counts["websocket_malformed"] += 1
+            log.error("collector.ws.malformed reconnect_id=%s", reconnect_id)
+            return
+        stream = message.get("stream", "") if isinstance(message, dict) else ""
+        data = message.get("data") if isinstance(message, dict) else None
+        events = data if isinstance(data, list) else [data]
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            normalized = self._normalize_ws_event(stream, event)
+            if normalized is None:
+                continue
+            source, symbol, event_time, transaction_time, sequence = normalized
+            if symbol not in self.config.symbols:
+                continue
+            if source == "binance_usdm.bookTicker":
+                previous_snapshot = self._last_book_snapshot.get(symbol)
+                if (
+                    previous_snapshot is not None
+                    and (received - previous_snapshot).total_seconds() < 1.0
+                ):
+                    continue
+                self._last_book_snapshot[symbol] = received
+            gap = self._ws_gap(
+                source=source,
+                symbol=symbol,
+                sequence=sequence,
+                payload=event,
+                reconnect_id=reconnect_id,
+            )
+            inserted = self.store.append(
+                source=source,
+                symbol=symbol,
+                raw_payload=event,
+                local_receive_time=received,
+                run_id=self.run_id,
+                event_time=event_time,
+                transaction_time=transaction_time,
+                request_started_at=iso_utc(request_started),
+                request_completed_at=iso_utc(request_completed),
+                sequence_or_trade_id=str(sequence) if sequence is not None else None,
+                gap_detected=gap,
+                reconnect_id=reconnect_id,
+            )
+            self._count_result(source, inserted)
+
+    @staticmethod
+    def _normalize_ws_event(
+        stream: str, event: Mapping[str, Any]
+    ) -> tuple[str, str, str | None, str | None, int | None] | None:
+        event_type = event.get("e")
+        symbol = str(event.get("s") or event.get("o", {}).get("s") or "").upper()
+        if event_type == "aggTrade" or "@aggTrade" in stream:
+            return (
+                "binance_usdm.aggTrade",
+                symbol,
+                epoch_ms(event.get("E")),
+                epoch_ms(event.get("T")),
+                int(event["a"]),
+            )
+        if event_type == "forceOrder" or "forceOrder" in stream:
+            order = event.get("o", {})
+            sequence = order.get("T") or event.get("E")
+            return (
+                "binance_usdm.forceOrder",
+                symbol,
+                epoch_ms(event.get("E")),
+                epoch_ms(order.get("T")),
+                int(sequence) if sequence is not None else None,
+            )
+        if event_type == "bookTicker" or "@bookTicker" in stream:
+            return (
+                "binance_usdm.bookTicker",
+                symbol,
+                epoch_ms(event.get("E")),
+                epoch_ms(event.get("T")),
+                int(event["u"]),
+            )
+        if event_type == "depthUpdate" or "@depth" in stream:
+            return (
+                "binance_usdm.depth5",
+                symbol,
+                epoch_ms(event.get("E")),
+                epoch_ms(event.get("T")),
+                int(event["u"]),
+            )
+        return None
+
+    def _ws_gap(
+        self,
+        *,
+        source: str,
+        symbol: str,
+        sequence: int | None,
+        payload: Mapping[str, Any],
+        reconnect_id: str,
+    ) -> bool:
+        key = (source, symbol)
+        connection_key = (source, symbol, reconnect_id)
+        first_on_connection = connection_key not in self._seen_on_connection
+        if first_on_connection:
+            self._seen_on_connection.add(connection_key)
+        gap = first_on_connection and self.store.has_source_symbol(source, symbol)
+        previous = self._previous_sequence.get(key)
+        if previous is not None and sequence is not None:
+            if source == "binance_usdm.depth5" and payload.get("pu") is not None:
+                gap = gap or int(payload["pu"]) != previous
+            elif source == "binance_usdm.aggTrade":
+                gap = gap or sequence != previous + 1
+            elif source == "binance_usdm.bookTicker":
+                gap = gap or sequence <= previous
+        if sequence is not None:
+            self._previous_sequence[key] = sequence
+        if gap:
+            log.warning(
+                "collector.gap source=%s symbol=%s previous=%s current=%s reconnect_id=%s",
+                source,
+                symbol,
+                previous,
+                sequence,
+                reconnect_id,
+            )
+        return gap
+
+    async def _poll_loop(self, family: str, interval: float) -> None:
+        failure_attempt = 0
+        async with httpx.AsyncClient(
+            base_url=REST_BASE_URL,
+            timeout=httpx.Timeout(10.0),
+            follow_redirects=False,
+            headers={"User-Agent": f"auto-trader/{COLLECTOR_VERSION}"},
+        ) as client:
+            while not self.stop.is_set():
+                try:
+                    await self._poll_family(client, family)
+                    failure_attempt = 0
+                    await asyncio.sleep(interval)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    self.failure_counts[family] += 1
+                    delay = min(interval, 2.0 * (2 ** min(failure_attempt, 5)))
+                    delay *= random.uniform(0.8, 1.2)
+                    failure_attempt += 1
+                    log.error(
+                        "collector.poll.failed family=%s error=%s backoff_s=%.2f",
+                        family,
+                        type(exc).__name__,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+
+    async def _poll_family(self, client: httpx.AsyncClient, family: str) -> None:
+        for symbol in self.config.symbols:
+            if family == "open_interest":
+                await self._rest_get(
+                    client,
+                    path="/fapi/v1/openInterest",
+                    params={"symbol": symbol},
+                    symbol=symbol,
+                    outputs=(("binance_usdm.openInterest", None),),
+                )
+            elif family == "premium":
+                await self._rest_get(
+                    client,
+                    path="/fapi/v1/premiumIndex",
+                    params={"symbol": symbol},
+                    symbol=symbol,
+                    outputs=(
+                        ("binance_usdm.premiumIndex", None),
+                        ("binance_usdm.predictedFunding", "lastFundingRate"),
+                    ),
+                )
+                await self._rest_premium_kline(client, symbol=symbol)
+            elif family == "basis":
+                await self._rest_get(
+                    client,
+                    path="/futures/data/basis",
+                    params={
+                        "pair": symbol,
+                        "contractType": "PERPETUAL",
+                        "period": "5m",
+                        "limit": 1,
+                    },
+                    symbol=symbol,
+                    outputs=(("binance_usdm.basis", None),),
+                )
+            elif family == "taker":
+                await self._rest_get(
+                    client,
+                    path="/futures/data/takerlongshortRatio",
+                    params={"symbol": symbol, "period": "5m", "limit": 1},
+                    symbol=symbol,
+                    outputs=(("binance_usdm.takerLongShortRatio", None),),
+                )
+            else:
+                raise ValueError(f"unknown poll family: {family}")
+
+    async def _rest_premium_kline(
+        self, client: httpx.AsyncClient, *, symbol: str
+    ) -> None:
+        path = "/fapi/v1/premiumIndexKlines"
+        assert_rest_target(path)
+        started = utc_now()
+        response = await client.get(
+            path,
+            params={"symbol": symbol, "interval": "1m", "limit": 2},
+        )
+        completed = utc_now()
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise ValueError(f"invalid JSON shape from allowlisted path {path}")
+        completed_ms = int(completed.timestamp() * 1000)
+        complete_rows = [
+            row
+            for row in payload
+            if isinstance(row, list) and len(row) >= 7 and int(row[6]) <= completed_ms
+        ]
+        if not complete_rows:
+            raise ValueError(f"no completed 1m row from allowlisted path {path}")
+        item = complete_rows[-1]
+        source = "binance_usdm.premiumIndexKline1m"
+        inserted = self.store.append(
+            source=source,
+            symbol=symbol,
+            raw_payload=item,
+            local_receive_time=completed,
+            run_id=self.run_id,
+            event_time=epoch_ms(item[6]),
+            transaction_time=epoch_ms(item[6]),
+            request_started_at=iso_utc(started),
+            request_completed_at=iso_utc(completed),
+            sequence_or_trade_id=str(item[0]),
+            gap_detected=False,
+            reconnect_id=f"{self.run_id}:rest:{path}",
+        )
+        self._count_result(source, inserted)
+
+    async def _rest_get(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        path: str,
+        params: Mapping[str, Any],
+        symbol: str,
+        outputs: Sequence[tuple[str, str | None]],
+    ) -> None:
+        assert_rest_target(path)
+        started = utc_now()
+        response = await client.get(path, params=params)
+        completed = utc_now()
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, str) or not isinstance(payload, (dict, list)):
+            raise ValueError(f"invalid JSON shape from allowlisted path {path}")
+        item = payload[-1] if isinstance(payload, list) and payload else payload
+        if not isinstance(item, dict):
+            raise ValueError(f"empty/invalid payload from allowlisted path {path}")
+        event_time = epoch_ms(item.get("time") or item.get("timestamp"))
+        if event_time is None:
+            # A response with no exchange timestamp cannot satisfy the PIT
+            # contract and must never be silently persisted.
+            raise ValueError(f"missing exchange timestamp from allowlisted path {path}")
+        sequence = item.get("timestamp") or item.get("time")
+        reconnect_id = f"{self.run_id}:rest:{path}"
+        for source, semantic_field in outputs:
+            semantic_payload = (
+                {**item, "_semantic_field": semantic_field}
+                if semantic_field is not None
+                else item
+            )
+            inserted = self.store.append(
+                source=source,
+                symbol=symbol,
+                raw_payload=semantic_payload,
+                local_receive_time=completed,
+                run_id=self.run_id,
+                event_time=event_time,
+                transaction_time=None,
+                request_started_at=iso_utc(started),
+                request_completed_at=iso_utc(completed),
+                sequence_or_trade_id=str(sequence) if sequence is not None else None,
+                gap_detected=False,
+                reconnect_id=reconnect_id,
+            )
+            self._count_result(source, inserted)
+
+    def _count_result(self, source: str, inserted: bool) -> None:
+        if inserted:
+            self.session_counts[source] += 1
+        else:
+            self.duplicate_counts[source] += 1
+
+
+def redact_sample(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a compact, secret-free proof row with every PIT contract column."""
+    return {column: row.get(column) for column in PIT_COLUMNS}

--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -35,6 +35,7 @@ REST_PATH_ALLOWLIST: Final = frozenset(
         "/fapi/v1/premiumIndex",
         "/fapi/v1/premiumIndexKlines",
         "/futures/data/basis",
+        "/futures/data/openInterestHist",
         "/futures/data/takerlongshortRatio",
     }
 )
@@ -56,7 +57,7 @@ PIT_COLUMNS: Final = (
     "gap_detected",
     "reconnect_id",
 )
-COLLECTOR_VERSION: Final = "r4-p0-collector.v1"
+COLLECTOR_VERSION: Final = "r4-p0-collector.v2"
 EXPECTED_SOURCES: Final = frozenset(
     {
         "binance_usdm.aggTrade",
@@ -64,6 +65,7 @@ EXPECTED_SOURCES: Final = frozenset(
         "binance_usdm.bookTicker",
         "binance_usdm.depth5",
         "binance_usdm.openInterest",
+        "binance_usdm.openInterestHist",
         "binance_usdm.basis",
         "binance_usdm.takerLongShortRatio",
         "binance_usdm.premiumIndex",
@@ -734,6 +736,13 @@ class BinanceR4P0Collector:
                     params={"symbol": symbol},
                     symbol=symbol,
                     outputs=(("binance_usdm.openInterest", None),),
+                )
+                await self._rest_get(
+                    client,
+                    path="/futures/data/openInterestHist",
+                    params={"symbol": symbol, "period": "5m", "limit": 1},
+                    symbol=symbol,
+                    outputs=(("binance_usdm.openInterestHist", None),),
                 )
             elif family == "premium":
                 await self._rest_get(

--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -1,4 +1,4 @@
-"""R4 P0 point-in-time collector for Binance USD-M public market data.
+"""Binance USD-M R4 P0 point-in-time public market-data collector.
 
 This module is deliberately isolated from every Binance execution adapter.  It
 can issue only unsigned GET requests to a small production-public allowlist and

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -1,0 +1,87 @@
+# R4 P0 no-regret collector
+
+This is a manual, research-artifact-only point-in-time collector. It never
+writes the production database and is not registered with TaskIQ, cron, or
+Prefect.
+
+## Hard boundary
+
+- Public unsigned market data only.
+- REST: HTTPS `GET` only, host `fapi.binance.com`, exact paths:
+  `/fapi/v1/openInterest`, `/fapi/v1/premiumIndex`,
+  `/fapi/v1/premiumIndexKlines`,
+  `/futures/data/basis`, `/futures/data/takerlongshortRatio`.
+- Websocket: `wss://fstream.binance.com/public` for book/depth and
+  `wss://fstream.binance.com/market` for aggTrade/forceOrder. The split is
+  required by Binance's post-2026-04-23 routed websocket contract.
+- No API key, signing, account endpoint, order endpoint, or broker mutation.
+- XRP/DOGE/SOL are signal symbols. BTC is collected only as a predictor.
+
+## Modes
+
+With no mode flag the command prints its contract and makes no network or disk
+write:
+
+```bash
+uv run python -m scripts.r4_p0_collector
+```
+
+The bounded validation mode is explicit and capped at 180 seconds:
+
+```bash
+uv run python -m scripts.r4_p0_collector \
+  --probe --duration 60 \
+  --artifact-root /tmp/r4-p0-validation
+```
+
+The long-running operational arm requires both an environment gate and a CLI
+flag:
+
+```bash
+export R4_P0_COLLECTOR_ENABLED=true
+export R4_P0_ARTIFACT_ROOT="$HOME/work/herdr-artifacts/r4-p0-collector"
+uv run python -m scripts.r4_p0_collector --run
+```
+
+Do not put these values in a committed `.env` file. Stop with SIGTERM or
+Ctrl-C. A single-instance file lock prevents two writers sharing an artifact.
+
+## Storage and restart contract
+
+The artifact is `r4_p0_collector.sqlite3` in WAL mode with `synchronous=FULL`.
+All persistence uses INSERT; database triggers reject UPDATE and DELETE.
+`record_id` is a semantic unique key, so replayed websocket events and
+unchanged REST periods are ignored after restart.
+
+`bookTicker` is stored as one snapshot per symbol per second (the P0 contract
+allows either every change or 1s snapshots); raw aggTrade, forceOrder snapshots,
+and top-5 depth updates are not sampled.
+
+The premium poll stores the live mark/index/predicted-funding snapshot and the
+latest completed 1-minute premium-index kline. An in-progress kline whose close
+time is after `request_completed_at` is rejected, so downstream PIT consumers
+cannot accidentally use its future close.
+
+Each source/symbol/UTC-day partition is an ordered SHA-256 chain:
+`partition_sha256` covers the previous chain head plus the current PIT
+envelope. `raw_payload_sha256` independently covers canonical raw JSON.
+A restart/reconnect marks the first subsequent stream record per source/symbol
+with `gap_detected=true`; sequence discontinuities are also surfaced. The
+`forceOrder` stream remains Binance's throttled snapshot, not a complete
+liquidation tape.
+
+Run the offline audit (no network) at any time:
+
+```bash
+uv run python -m scripts.r4_p0_collector \
+  --audit --artifact-root "$R4_P0_ARTIFACT_ROOT"
+```
+
+It verifies raw hashes, partition-chain links, the 13 PIT column names, and
+prints one secret-free sample per collected source. The collector also logs
+session insert, duplicate, failure, and cumulative source counts every 30
+seconds so a zero-row/partial-source run is visible. On graceful exit, the
+process returns nonzero if any required source had neither an insert nor a
+deduplicated response. `forceOrder` is reported separately as a sparse,
+event-driven source and is not treated as failed merely because no liquidation
+occurred during a short run.

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -10,12 +10,35 @@ Prefect.
 - REST: HTTPS `GET` only, host `fapi.binance.com`, exact paths:
   `/fapi/v1/openInterest`, `/fapi/v1/premiumIndex`,
   `/fapi/v1/premiumIndexKlines`,
-  `/futures/data/basis`, `/futures/data/takerlongshortRatio`.
+  `/futures/data/openInterestHist`, `/futures/data/basis`,
+  `/futures/data/takerlongshortRatio`.
 - Websocket: `wss://fstream.binance.com/public` for book/depth and
   `wss://fstream.binance.com/market` for aggTrade/forceOrder. The split is
   required by Binance's post-2026-04-23 routed websocket contract.
 - No API key, signing, account endpoint, order endpoint, or broker mutation.
 - XRP/DOGE/SOL are signal symbols. BTC is collected only as a predictor.
+
+## Collection priority and backfill boundary
+
+Operational attention follows this order without dropping any P0 source:
+
+1. The four websocket sources: aggTrade, forceOrder, 1-second bookTicker
+   snapshots, and top-5 depth. Their local receive time is not recoverable
+   later; book snapshots and forceOrder observations are likewise not
+   reconstructable from a later REST backfill. Although aggTrade content was
+   observed to be REST-backfillable through roughly 390 days, that does not
+   recreate the original PIT receive-time observation.
+2. `openInterestHist` at 5-minute resolution. Production probing confirmed
+   that this endpoint has the actual short retrospective boundary (under 30
+   days), so it is collected on every open-interest poll. The instantaneous
+   `/fapi/v1/openInterest` snapshot remains as a separate additive source.
+3. Basis, taker ratio, and premium/funding polls. They remain in scope, but are
+   lower urgency because their exchange-time content can be backfilled. In
+   particular, production basis rows were observed beyond 1,000 days; the
+   earlier 30-day basis assumption is not used by this collector.
+
+Backfill reach and PIT observation are separate properties. A later REST row
+must not be treated as if it had the `local_receive_time` of the live collector.
 
 ## Modes
 

--- a/scripts/r4_p0_collector.py
+++ b/scripts/r4_p0_collector.py
@@ -1,0 +1,139 @@
+"""Manual R4 P0 Binance USD-M point-in-time collector.
+
+Default invocation is a no-network dry-run.  Long-running collection requires
+both ``R4_P0_COLLECTOR_ENABLED=true`` and ``--run``.  ``--probe`` is an
+explicit, bounded (<=180 seconds) production-public validation mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import signal
+from pathlib import Path
+
+from app.services.binance_r4_p0_collector import (
+    COLLECTOR_VERSION,
+    PIT_COLUMNS,
+    REST_PATH_ALLOWLIST,
+    SYMBOLS,
+    AppendOnlyPITStore,
+    BinanceR4P0Collector,
+    CollectorConfig,
+    redact_sample,
+)
+
+ENABLED_ENV = "R4_P0_COLLECTOR_ENABLED"
+ARTIFACT_ENV = "R4_P0_ARTIFACT_ROOT"
+DEFAULT_ARTIFACT_ROOT = "~/work/herdr-artifacts/r4-p0-collector"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--run", action="store_true", help="run until stopped (env-gated)"
+    )
+    mode.add_argument(
+        "--probe",
+        action="store_true",
+        help="bounded public-network validation; does not require the operational env gate",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="stop after N seconds; required for --probe and capped at 180",
+    )
+    parser.add_argument(
+        "--artifact-root",
+        default=os.getenv(ARTIFACT_ENV, DEFAULT_ARTIFACT_ROOT),
+    )
+    parser.add_argument("--status-seconds", type=float, default=30.0)
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="offline integrity audit and one sample per source; no network",
+    )
+    return parser.parse_args()
+
+
+def _enabled() -> bool:
+    return os.getenv(ENABLED_ENV, "").strip().lower() == "true"
+
+
+def _dry_run_payload(args: argparse.Namespace) -> dict[str, object]:
+    return {
+        "mode": "dry_run",
+        "network": False,
+        "database_write": False,
+        "broker_mutation": False,
+        "collector_version": COLLECTOR_VERSION,
+        "symbols": list(SYMBOLS),
+        "signal_symbols": ["XRPUSDT", "DOGEUSDT", "SOLUSDT"],
+        "predictor_only_symbols": ["BTCUSDT"],
+        "rest_method": "GET",
+        "rest_paths": sorted(REST_PATH_ALLOWLIST),
+        "pit_columns": list(PIT_COLUMNS),
+        "artifact_root_if_armed": str(Path(args.artifact_root).expanduser()),
+        "arm": f"{ENABLED_ENV}=true plus --run",
+    }
+
+
+def _offline_audit(root: Path) -> int:
+    with AppendOnlyPITStore(root) as store:
+        result = store.audit()
+        result["samples"] = [redact_sample(row) for row in store.sample_by_source()]
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["ok"] else 1
+
+
+async def _run_collector(args: argparse.Namespace) -> int:
+    root = Path(args.artifact_root)
+    config = CollectorConfig(
+        artifact_root=root,
+        duration_seconds=args.duration,
+        status_seconds=args.status_seconds,
+    )
+    with AppendOnlyPITStore(root) as store:
+        collector = BinanceR4P0Collector(config, store)
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, collector.stop.set)
+        await collector.run()
+        audit = store.audit()
+        logging.info("collector.audit %s", json.dumps(audit, sort_keys=True))
+        health = collector.health()
+        logging.info("collector.health %s", json.dumps(health, sort_keys=True))
+        return 0 if audit["ok"] and health["ok"] else 1
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)sZ %(levelname)s %(message)s",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    if args.audit:
+        if args.run or args.probe:
+            raise SystemExit("--audit cannot be combined with network modes")
+        return _offline_audit(Path(args.artifact_root))
+    if not args.run and not args.probe:
+        print(json.dumps(_dry_run_payload(args), ensure_ascii=False, indent=2))
+        return 0
+    if args.probe:
+        if args.duration is None or not 1 <= args.duration <= 180:
+            raise SystemExit("--probe requires --duration between 1 and 180 seconds")
+    elif not _enabled():
+        raise SystemExit(f"refusing --run: set {ENABLED_ENV}=true explicitly")
+    if args.duration is not None and args.duration <= 0:
+        raise SystemExit("--duration must be positive")
+    return asyncio.run(_run_collector(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/r4_p0_collector.py
+++ b/scripts/r4_p0_collector.py
@@ -15,7 +15,7 @@ import os
 import signal
 from pathlib import Path
 
-from app.services.binance_r4_p0_collector import (
+from app.services.brokers.binance.r4_p0_collector import (
     COLLECTOR_VERSION,
     PIT_COLUMNS,
     REST_PATH_ALLOWLIST,

--- a/tests/test_binance_r4_p0_collector.py
+++ b/tests/test_binance_r4_p0_collector.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sqlite3
+
+import httpx
+import pytest
+
+from app.services.binance_r4_p0_collector import (
+    PIT_COLUMNS,
+    AppendOnlyPITStore,
+    BinanceR4P0Collector,
+    CollectorConfig,
+    assert_rest_target,
+    assert_ws_target,
+    build_ws_urls,
+)
+
+
+@pytest.mark.unit
+def test_allowlists_are_read_only_and_exact() -> None:
+    for path in (
+        "/fapi/v1/openInterest",
+        "/fapi/v1/premiumIndex",
+        "/fapi/v1/premiumIndexKlines",
+        "/futures/data/basis",
+        "/futures/data/takerlongshortRatio",
+    ):
+        assert_rest_target(path)
+    with pytest.raises(ValueError):
+        assert_rest_target("/fapi/v1/order")
+    with pytest.raises(ValueError):
+        assert_rest_target("/fapi/v2/account")
+    with pytest.raises(ValueError):
+        assert_ws_target("wss://demo-fapi.binance.com/ws")
+    urls = build_ws_urls()
+    assert set(urls) == {"public", "market"}
+    assert "/public/stream?" in urls["public"]
+    assert "aggTrade" not in urls["public"]
+    assert "/market/stream?" in urls["market"]
+    assert "aggTrade" in urls["market"]
+    assert "forceOrder" in urls["market"]
+
+
+@pytest.mark.unit
+def test_store_is_append_only_deduplicated_and_auditable(tmp_path) -> None:
+    now = dt.datetime(2026, 7, 26, 1, 2, 3, tzinfo=dt.UTC)
+    kwargs = {
+        "source": "binance_usdm.aggTrade",
+        "symbol": "XRPUSDT",
+        "raw_payload": {"a": 123, "E": 1785027723000},
+        "local_receive_time": now,
+        "run_id": "run-1",
+        "event_time": "2026-07-26T01:02:03.000000Z",
+        "transaction_time": "2026-07-26T01:02:03.000000Z",
+        "request_started_at": "2026-07-26T01:02:02.000000Z",
+        "request_completed_at": "2026-07-26T01:02:02.500000Z",
+        "sequence_or_trade_id": "123",
+        "gap_detected": False,
+        "reconnect_id": "run-1:ws:1",
+    }
+    with AppendOnlyPITStore(tmp_path) as store:
+        assert store.append(**kwargs)
+        assert not store.append(**{**kwargs, "run_id": "run-2"})
+        result = store.audit()
+        assert result["ok"]
+        assert result["rows"] == 1
+        row = store.sample_by_source()[0]
+        assert set(PIT_COLUMNS).issubset(row)
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            store._db.execute("UPDATE pit_records SET symbol = 'DOGEUSDT'")  # noqa: SLF001
+        store._db.rollback()  # noqa: SLF001
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            store._db.execute("DELETE FROM pit_records")  # noqa: SLF001
+
+    # Reopening proves restart-safe deduplication against persisted identity.
+    with AppendOnlyPITStore(tmp_path) as reopened:
+        assert not reopened.append(**{**kwargs, "run_id": "run-3"})
+        assert reopened.audit()["rows"] == 1
+
+
+@pytest.mark.unit
+def test_websocket_payloads_keep_exchange_and_receive_times(tmp_path) -> None:
+    config = CollectorConfig(artifact_root=tmp_path)
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(config, store)
+        collector._handle_ws_raw(  # noqa: SLF001
+            json.dumps(
+                {
+                    "stream": "xrpusdt@aggTrade",
+                    "data": {
+                        "e": "aggTrade",
+                        "E": 1785027723001,
+                        "s": "XRPUSDT",
+                        "a": 42,
+                        "p": "1.23",
+                        "q": "2",
+                        "T": 1785027723000,
+                        "m": True,
+                    },
+                }
+            ),
+            received=dt.datetime(2026, 7, 26, 1, 2, 4, tzinfo=dt.UTC),
+            request_started=dt.datetime(2026, 7, 26, 1, 2, 0, tzinfo=dt.UTC),
+            request_completed=dt.datetime(2026, 7, 26, 1, 2, 1, tzinfo=dt.UTC),
+            reconnect_id="run:ws:1",
+        )
+        row = store.sample_by_source()[0]
+        assert row["event_time"] == "2026-07-26T01:02:03.001000Z"
+        assert row["transaction_time"] == "2026-07-26T01:02:03.000000Z"
+        assert row["local_receive_time"] == "2026-07-26T01:02:04.000000Z"
+        assert json.loads(row["raw_payload"])["a"] == 42
+
+
+@pytest.mark.unit
+def test_restart_marks_first_new_connection_record_as_gap(tmp_path) -> None:
+    config = CollectorConfig(artifact_root=tmp_path)
+    received = dt.datetime(2026, 7, 26, 1, 2, 4, tzinfo=dt.UTC)
+    with AppendOnlyPITStore(tmp_path) as store:
+        first = BinanceR4P0Collector(config, store)
+        first._handle_ws_raw(  # noqa: SLF001
+            json.dumps(
+                {
+                    "stream": "xrpusdt@bookTicker",
+                    "data": {
+                        "e": "bookTicker",
+                        "E": 1785027723001,
+                        "T": 1785027723000,
+                        "s": "XRPUSDT",
+                        "u": 9,
+                    },
+                }
+            ),
+            received=received,
+            request_started=received,
+            request_completed=received,
+            reconnect_id="run-1:ws:1",
+        )
+    with AppendOnlyPITStore(tmp_path) as store:
+        second = BinanceR4P0Collector(config, store)
+        second._handle_ws_raw(  # noqa: SLF001
+            json.dumps(
+                {
+                    "stream": "xrpusdt@bookTicker",
+                    "data": {
+                        "e": "bookTicker",
+                        "E": 1785027724001,
+                        "T": 1785027724000,
+                        "s": "XRPUSDT",
+                        "u": 10,
+                    },
+                }
+            ),
+            received=received + dt.timedelta(seconds=1),
+            request_started=received,
+            request_completed=received,
+            reconnect_id="run-2:ws:1",
+        )
+        rows = list(
+            store._db.execute(  # noqa: SLF001
+                "SELECT gap_detected FROM pit_records ORDER BY append_id"
+            )
+        )
+        assert [row["gap_detected"] for row in rows] == [0, 1]
+
+
+@pytest.mark.unit
+def test_health_fails_closed_for_zero_row_required_sources(tmp_path) -> None:
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(CollectorConfig(artifact_root=tmp_path), store)
+        health = collector.health()
+        assert not health["ok"]
+        assert "binance_usdm.aggTrade" in health["missing_required_sources"]
+        assert health["missing_sparse_sources"] == ["binance_usdm.forceOrder"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_premium_kline_persists_only_a_completed_period(tmp_path) -> None:
+    now_ms = int(dt.datetime.now(tz=dt.UTC).timestamp() * 1000)
+    closed = [
+        now_ms - 120_000,
+        "0.1",
+        "0.2",
+        "0.0",
+        "0.1",
+        "0",
+        now_ms - 60_000,
+    ]
+    active = [
+        now_ms,
+        "0.2",
+        "0.3",
+        "0.1",
+        "0.2",
+        "0",
+        now_ms + 60_000,
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/fapi/v1/premiumIndexKlines"
+        return httpx.Response(200, json=[closed, active])
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(CollectorConfig(artifact_root=tmp_path), store)
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._rest_premium_kline(  # noqa: SLF001
+                client, symbol="XRPUSDT"
+            )
+        row = store.sample_by_source()[0]
+        assert row["source"] == "binance_usdm.premiumIndexKline1m"
+        assert json.loads(row["raw_payload"]) == closed
+        assert row["event_time"] == row["transaction_time"]

--- a/tests/test_binance_r4_p0_collector.py
+++ b/tests/test_binance_r4_p0_collector.py
@@ -25,6 +25,7 @@ def test_allowlists_are_read_only_and_exact() -> None:
         "/fapi/v1/premiumIndex",
         "/fapi/v1/premiumIndexKlines",
         "/futures/data/basis",
+        "/futures/data/openInterestHist",
         "/futures/data/takerlongshortRatio",
     ):
         assert_rest_target(path)
@@ -215,3 +216,59 @@ async def test_premium_kline_persists_only_a_completed_period(tmp_path) -> None:
         assert row["source"] == "binance_usdm.premiumIndexKline1m"
         assert json.loads(row["raw_payload"]) == closed
         assert row["event_time"] == row["transaction_time"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_open_interest_family_keeps_current_and_bounded_history(tmp_path) -> None:
+    timestamp = 1785027600000
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/fapi/v1/openInterest":
+            assert request.url.params["symbol"] == "XRPUSDT"
+            return httpx.Response(
+                200,
+                json={
+                    "symbol": "XRPUSDT",
+                    "openInterest": "335606096.1",
+                    "time": timestamp,
+                },
+            )
+        assert request.url.path == "/futures/data/openInterestHist"
+        assert dict(request.url.params) == {
+            "symbol": "XRPUSDT",
+            "period": "5m",
+            "limit": "1",
+        }
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "symbol": "XRPUSDT",
+                    "sumOpenInterest": "335602101.0",
+                    "sumOpenInterestValue": "368798010.1",
+                    "CMCCirculatingSupply": "59985132502",
+                    "timestamp": timestamp,
+                }
+            ],
+        )
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(artifact_root=tmp_path, symbols=("XRPUSDT",)),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._poll_family(client, "open_interest")  # noqa: SLF001
+        samples = {row["source"]: row for row in store.sample_by_source()}
+        assert set(samples) == {
+            "binance_usdm.openInterest",
+            "binance_usdm.openInterestHist",
+        }
+        assert samples["binance_usdm.openInterestHist"]["event_time"] == (
+            "2026-07-26T01:00:00.000000Z"
+        )
+        assert set(PIT_COLUMNS).issubset(samples["binance_usdm.openInterestHist"])

--- a/tests/test_binance_r4_p0_collector.py
+++ b/tests/test_binance_r4_p0_collector.py
@@ -7,7 +7,7 @@ import sqlite3
 import httpx
 import pytest
 
-from app.services.binance_r4_p0_collector import (
+from app.services.brokers.binance.r4_p0_collector import (
     PIT_COLUMNS,
     AppendOnlyPITStore,
     BinanceR4P0Collector,


### PR DESCRIPTION
## Summary

- add a default-off, dry-run-by-default manual Binance USD-M P0 collector
- collect routed websocket aggTrade, forceOrder, 1s bookTicker snapshots, and top-5 depth as the first operational priority
- poll current OI plus 5m openInterestHist as separate sources; retain basis, taker ratio, premium/index, completed premium klines, and predicted funding
- persist only to a local append-only SQLite research artifact with immutable-row triggers, semantic deduplication, raw hashes, and partition hash chains
- preserve the canonical 13 PIT columns and surface reconnect/gap, duplicate, failure, and periodic source counts

## Priority and corrected backfill boundary

1. Websocket streams remain first because local receive timestamps cannot be backfilled; book snapshots and forceOrder observations cannot be reconstructed later. Production probing showed aggTrade content is REST-backfillable through roughly 390 days, but a backfill does not recreate the original live PIT observation.
2. openInterestHist is second. Production probing confirmed the actual short retrospective boundary is under 30 days. The collector now treats it as its own required source and fails closed if it returns no row.
3. Basis, taker, and premium/funding polls remain in scope at lower urgency. Production basis rows were observed beyond 1,000 days, so the earlier 30-day basis assumption is not used.

## Safety boundary

- unsigned public GET data only; no credentials
- exact REST allowlist on `fapi.binance.com`, including `/futures/data/openInterestHist`
- routed public/market streams only on `fstream.binance.com`
- no account, signed, order, broker-mutation, production-DB, scheduler, TaskIQ, cron, or Prefect wiring
- XRP/DOGE/SOL remain signal symbols; BTC is predictor-only
- operational mode requires `R4_P0_COLLECTOR_ENABLED=true` plus `--run`; bounded `--probe` is capped at 180 seconds

## Production empirical validation (2026-07-26)

The original bounded capture at `~/work/herdr-artifacts/r4-p0-collector/t2-validation-20260726-v2` contains 14,712 audited rows across the original 10 sources, including actual DOGEUSDT forceOrder observations. SIGKILL/restart retained a valid 5,677-row chain, marked restart boundaries, and surfaced replay duplicates.

After the priority correction, a fresh v2 bounded probe at `~/work/herdr-artifacts/r4-p0-collector/t2-correction-20260726` captured 1,040 rows with all required sources present, including one openInterestHist row for each of four symbols. A second run against the same artifact rejected all four openInterestHist rows as semantic duplicates and marked 12 websocket source/symbol restart boundaries. Final audit: 1,462 rows, all 13 PIT columns present, zero bad raw hashes, zero bad partition links.

Representative new row:
- openInterestHist XRPUSDT: exchange timestamp `2026-07-26T08:55:00.000000Z`, local receive `2026-07-26T08:57:15.680685Z`, sum OI `335718746.00000000`, collector `r4-p0-collector.v2`

The optional demo contrast was reproduced earlier: demo openInterestHist and taker ratio returned the JSON string `ok`; demo XRP current OI was about 11.67 trillion versus production about 335.6 million.

## Verification

- `make lint`
- `uv run pytest -q tests/services/brokers/binance/test_audit_no_signed_endpoints.py tests/test_binance_r4_p0_collector.py` (10 passed; 2 pre-existing Pydantic warnings)
- bounded production probes, offline audit, restart duplicate and gap validation

## Operator arm

```bash
export R4_P0_COLLECTOR_ENABLED=true
export R4_P0_ARTIFACT_ROOT="$HOME/work/herdr-artifacts/r4-p0-collector"
uv run python -m scripts.r4_p0_collector --run
```

## Not verified

- no 24-hour soak, disk-growth/retention benchmark, or host reboot test
- no scheduler/service registration, intentionally out of scope
- no downstream feature consumer or PIT join validation
- no exchange-clock/NTP offset collection, P1 scope
- no signed/private/account/order endpoint was tested or accessed
