### PR TITLE
fix(ROB-1071): repair silent DART disclosure no-op

### DIFF
--- a/app/services/market_events/dart_helpers.py
+++ b/app/services/market_events/dart_helpers.py
@@ -1,7 +1,7 @@
-"""Thin wrapper around OpenDartReader.list_date for per-day market-wide DART fetch (ROB-128).
+"""Thin wrapper around OpenDartReader.list_date_ex for market-wide DART fetches.
 
-This is the only DART-side new code; for per-symbol filings the existing
-`app/services/disclosures/dart.py::list_filings` is reused elsewhere.
+``list_date_ex`` scrapes ``dart.fss.or.kr`` rather than using the official API,
+so its response shape is validated before any result can be treated as usable.
 """
 
 from __future__ import annotations
@@ -15,9 +15,25 @@ from app.services.disclosures.dart import _get_client
 
 logger = logging.getLogger(__name__)
 
+DART_LIST_DATE_EX_REQUIRED_COLUMNS = frozenset(
+    {
+        "rcept_dt",
+        "corp_cls",
+        "corp_name",
+        "rcept_no",
+        "report_nm",
+        "flr_nm",
+        "rm",
+    }
+)
+
+
+class DartResponseSchemaError(RuntimeError):
+    """The DART scraping response no longer matches the expected table shape."""
+
 
 async def fetch_dart_filings_for_date(target_date: date) -> list[dict[str, Any]]:
-    """Return DART filings for one day. Empty list if DART is unavailable.
+    """Return validated DART filings for one day.
 
     The OpenDartReader client is loaded lazily and reused across calls.
     """
@@ -29,9 +45,26 @@ async def fetch_dart_filings_for_date(target_date: date) -> list[dict[str, Any]]
     iso = target_date.isoformat()
 
     def fetch_sync() -> list[dict[str, Any]]:
-        df = client.list_date(iso)
-        if df is None or df.empty:
+        df = client.list_date_ex(iso)
+        columns = getattr(df, "columns", None)
+        if columns is None:
+            raise DartResponseSchemaError(
+                "DART list_date_ex returned a non-DataFrame response"
+            )
+        missing = DART_LIST_DATE_EX_REQUIRED_COLUMNS.difference(columns)
+        if missing:
+            raise DartResponseSchemaError(
+                "DART list_date_ex response missing required columns: "
+                + ", ".join(sorted(missing))
+            )
+        if df.empty:
             return []
-        return df.to_dict(orient="records")
+        records = df.to_dict(orient="records")
+        for record in records:
+            receipt_at = record.get("rcept_dt")
+            isoformat = getattr(receipt_at, "isoformat", None)
+            if callable(isoformat):
+                record["rcept_dt"] = isoformat()
+        return records
 
     return await asyncio.to_thread(fetch_sync)

--- a/app/services/market_events/ingestion.py
+++ b/app/services/market_events/ingestion.py
@@ -26,8 +26,33 @@ from app.services.market_events.normalizers import (
     normalize_finnhub_earnings_row,
 )
 from app.services.market_events.repository import MarketEventsRepository
+from app.services.market_events.session_calendar import trading_session_status
 
 logger = logging.getLogger(__name__)
+
+
+def _require_legitimate_dart_zero(target_date: date, event_count: int) -> None:
+    """Reject an empty DART result unless XKRX confirms the date was closed."""
+    if event_count > 0:
+        return
+
+    session_status = trading_session_status("kr", target_date)
+    if session_status == "closed":
+        logger.info(
+            "DART returned zero filings on confirmed XKRX non-session %s",
+            target_date,
+        )
+        return
+    if session_status == "open":
+        raise RuntimeError(
+            f"DART returned zero filings on confirmed XKRX trading session "
+            f"{target_date}"
+        )
+    raise RuntimeError(
+        f"DART returned zero filings for {target_date}, but XKRX calendar "
+        "classification is unknown; cannot distinguish a legitimate empty day "
+        "from a broken DART scraper"
+    )
 
 
 async def _mark_failed_after_exception(
@@ -281,6 +306,7 @@ async def ingest_kr_disclosures_for_date(
             await repo.upsert_event_with_values(event_dict, value_dicts)
             upserted += 1
 
+        _require_legitimate_dart_zero(target_date, upserted)
         await repo.mark_partition_succeeded(partition, event_count=upserted)
         return IngestionRunResult(
             source=source,

--- a/app/services/market_events/normalizers.py
+++ b/app/services/market_events/normalizers.py
@@ -131,11 +131,11 @@ def classify_dart_category(report_nm: str) -> str:
 def normalize_dart_disclosure_row(
     row: dict[str, Any],
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    """Normalize one DART `list_date` row to a MarketEvent.
+    """Normalize one DART ``list_date_ex`` row to a MarketEvent.
 
-    DART rows expose at minimum: rcept_no, rcept_dt, corp_name, corp_code, report_nm.
-    Prefer stock_code for symbol matching; corp_code stays in raw_payload_json.
-    URL builds from rcept_no.
+    The scraper exposes receipt time, class, company name, receipt number, report
+    name, filer name, and remarks. It does not expose ``stock_code``; keep support
+    for that field for injected/legacy rows, but never substitute ``corp_code``.
     """
     rcept_no = (row.get("rcept_no") or row.get("rcp_no") or "").strip()
     rcept_dt = (row.get("rcept_dt") or row.get("date") or "").strip()
@@ -150,7 +150,7 @@ def normalize_dart_disclosure_row(
     if len(rcept_dt) >= 8 and rcept_dt[:8].isdigit():
         event_date = date(int(rcept_dt[:4]), int(rcept_dt[4:6]), int(rcept_dt[6:8]))
     else:
-        event_date = date.fromisoformat(rcept_dt)
+        event_date = date.fromisoformat(rcept_dt[:10])
 
     category = classify_dart_category(report_nm)
 

--- a/app/services/market_events/session_calendar.py
+++ b/app/services/market_events/session_calendar.py
@@ -21,6 +21,7 @@ from typing import Literal
 logger = logging.getLogger(__name__)
 
 Market = Literal["us", "kr"]
+SessionStatus = Literal["open", "closed", "unknown"]
 
 _CALENDAR_NAME: dict[str, str] = {"us": "XNYS", "kr": "XKRX"}
 
@@ -41,8 +42,33 @@ def _calendar(market: Market):
         raise ValueError(f"unsupported market {market!r}") from exc
 
 
+def trading_session_status(market: Market, day: date) -> SessionStatus:
+    """Classify ``day`` as an open, closed, or unresolvable exchange session.
+
+    ``unknown`` deliberately differs from ``closed``. Callers deciding whether an
+    empty provider response is legitimate must fail closed when the calendar cannot
+    classify the date instead of silently treating an infrastructure error as a
+    holiday.
+    """
+    import pandas as pd
+
+    try:
+        cal = _calendar(market)
+        return "open" if bool(cal.is_session(pd.Timestamp(day))) else "closed"
+    except (ValueError, KeyError):
+        return "unknown"
+    except Exception:  # noqa: BLE001 - expose uncertainty without claiming open/closed
+        logger.warning(
+            "session_calendar: unexpected error classifying %s %s; status unknown",
+            market,
+            day,
+            exc_info=True,
+        )
+        return "unknown"
+
+
 def is_trading_session(market: Market, day: date) -> bool:
-    """True iff ``day`` is a trading session on the market's exchange.
+    """True iff ``day`` is a confirmed trading session on the market's exchange.
 
     Fail-closed: ANY error from the calendar load or query path returns
     ``False`` (never raises). Expected out-of-range / unrepresentable-date
@@ -50,22 +76,7 @@ def is_trading_session(market: Market, day: date) -> bool:
     unexpected errors are logged (so library/data bugs aren't hidden) but still
     fail closed — the contract is that we never claim a session we can't confirm.
     """
-    import pandas as pd
-
-    try:
-        cal = _calendar(market)
-        return bool(cal.is_session(pd.Timestamp(day)))
-    except (ValueError, KeyError):
-        return False
-    except Exception:  # noqa: BLE001 - fail-closed on any calendar/library error
-        logger.warning(
-            "session_calendar: unexpected error classifying %s %s; treating as "
-            "closed (fail-closed)",
-            market,
-            day,
-            exc_info=True,
-        )
-        return False
+    return trading_session_status(market, day) == "open"
 
 
 def regular_session_bounds(

--- a/docs/runbooks/calendar-source-coverage.md
+++ b/docs/runbooks/calendar-source-coverage.md
@@ -10,7 +10,7 @@
 | Source | Category | Market | Ingest entry point | Notes |
 | --- | --- | --- | --- | --- |
 | Finnhub | earnings | us | `app/services/market_events/finnhub_helpers.py::fetch_earnings_calendar_finnhub` | Per-day partition. EPS / revenue / fiscal period. `time_hint` = bmo/amc/dmh. |
-| DART | disclosure (and `earnings` when title matches) | kr | `app/services/market_events/dart_helpers.py::fetch_dart_filings_for_date` | Uses `OpenDartReader.list_date`. Symbol from `stock_code`. Title-classified into earnings vs. disclosure via `normalize_dart_disclosure_row`. |
+| DART | disclosure (and `earnings` when title matches) | kr | `app/services/market_events/dart_helpers.py::fetch_dart_filings_for_date` | Uses scraping-backed `OpenDartReader.list_date_ex` with an explicit response-column contract. A zero result succeeds only on a confirmed XKRX non-session; trading-session or calendar-unknown zeroes fail closed. `list_date_ex` does not expose `stock_code`, so symbol is empty. Title-classified into earnings vs. disclosure via `normalize_dart_disclosure_row`. |
 | ForexFactory | economic | global | `app/services/market_events/forexfactory_helpers.py::fetch_forexfactory_events_for_date` | This-week + next-week XML. Times converted ET → UTC. |
 
 `scripts/ingest_market_events.py::SUPPORTED` is the canonical list of supported triples.

--- a/tests/services/market_events/test_session_calendar.py
+++ b/tests/services/market_events/test_session_calendar.py
@@ -11,6 +11,7 @@ from app.services.market_events.session_calendar import (
     next_trading_session,
     previous_trading_session,
     regular_session_bounds,
+    trading_session_status,
     trading_sessions_in_range,
 )
 
@@ -38,6 +39,13 @@ def test_us_regular_weekday_is_a_session():
 def test_kr_holiday_is_not_a_session():
     # 2025-01-01 New Year — XKRX closed.
     assert is_trading_session("kr", date(2025, 1, 1)) is False
+
+
+@pytest.mark.unit
+def test_session_status_distinguishes_closed_from_unknown():
+    assert trading_session_status("kr", date(2025, 1, 1)) == "closed"
+    assert trading_session_status("kr", date(2025, 1, 2)) == "open"
+    assert trading_session_status("kr", date(2100, 1, 4)) == "unknown"
 
 
 @pytest.mark.unit

--- a/tests/services/test_market_events_dart_helpers.py
+++ b/tests/services/test_market_events_dart_helpers.py
@@ -1,0 +1,73 @@
+"""Unit tests for the scraping-backed DART daily filing helper (ROB-1071)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+from app.services.market_events import dart_helpers
+from app.services.market_events.normalizers import normalize_dart_disclosure_row
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_uses_list_date_ex_and_returns_json_safe_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = pd.DataFrame(
+        [
+            {
+                "rcept_dt": pd.Timestamp("2026-07-24 07:31:00"),
+                "corp_cls": "Y",
+                "corp_name": "테스트",
+                "rcept_no": "20260724000001",
+                "report_nm": "주요사항보고서",
+                "flr_nm": "테스트",
+                "rm": "",
+            }
+        ]
+    )
+    client = MagicMock()
+    client.list_date_ex.return_value = frame
+    monkeypatch.setattr(dart_helpers, "_get_client", AsyncMock(return_value=client))
+
+    rows = await dart_helpers.fetch_dart_filings_for_date(date(2026, 7, 24))
+
+    client.list_date_ex.assert_called_once_with("2026-07-24")
+    assert rows == [
+        {
+            "rcept_dt": "2026-07-24T07:31:00",
+            "corp_cls": "Y",
+            "corp_name": "테스트",
+            "rcept_no": "20260724000001",
+            "report_nm": "주요사항보고서",
+            "flr_nm": "테스트",
+            "rm": "",
+        }
+    ]
+    event, _ = normalize_dart_disclosure_row(rows[0])
+    assert event["event_date"] == date(2026, 7, 24)
+    json.dumps(event["raw_payload_json"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_fails_closed_when_list_date_ex_column_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = pd.DataFrame(
+        columns=sorted(dart_helpers.DART_LIST_DATE_EX_REQUIRED_COLUMNS - {"rcept_no"})
+    )
+    client = MagicMock()
+    client.list_date_ex.return_value = frame
+    monkeypatch.setattr(dart_helpers, "_get_client", AsyncMock(return_value=client))
+
+    with pytest.raises(
+        dart_helpers.DartResponseSchemaError,
+        match=r"missing required columns: rcept_no",
+    ):
+        await dart_helpers.fetch_dart_filings_for_date(date(2026, 7, 24))

--- a/tests/services/test_market_events_ingestion.py
+++ b/tests/services/test_market_events_ingestion.py
@@ -275,6 +275,138 @@ async def test_ingest_kr_disclosures_for_date_with_injected_fetcher(db_session):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+async def test_ingest_kr_disclosures_accepts_zero_on_confirmed_xkrx_holiday(
+    db_session,
+):
+    from app.models.market_events import MarketEventIngestionPartition
+    from app.services.market_events import ingestion
+
+    holiday = date(2025, 1, 1)
+    result = await ingestion.ingest_kr_disclosures_for_date(
+        db_session,
+        holiday,
+        fetch_rows=AsyncMock(return_value=[]),
+    )
+    await db_session.commit()
+
+    assert result.status == "succeeded"
+    assert result.event_count == 0
+    parts = await _load_partitions(
+        db_session,
+        MarketEventIngestionPartition,
+        source="dart",
+        category="disclosure",
+        market="kr",
+        partition_date=holiday,
+    )
+    assert len(parts) == 1
+    assert parts[0].status == "succeeded"
+    assert parts[0].event_count == 0
+    assert parts[0].last_error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_kr_disclosures_fails_zero_on_xkrx_trading_session(
+    db_session,
+):
+    from app.models.market_events import MarketEventIngestionPartition
+    from app.services.market_events import ingestion
+
+    trading_day = date(2026, 5, 7)
+    result = await ingestion.ingest_kr_disclosures_for_date(
+        db_session,
+        trading_day,
+        fetch_rows=AsyncMock(return_value=[]),
+    )
+    await db_session.commit()
+
+    assert result.status == "failed"
+    assert result.event_count == 0
+    assert "confirmed XKRX trading session" in (result.error or "")
+    parts = await _load_partitions(
+        db_session,
+        MarketEventIngestionPartition,
+        source="dart",
+        category="disclosure",
+        market="kr",
+        partition_date=trading_day,
+    )
+    assert len(parts) == 1
+    assert parts[0].status == "failed"
+    assert "confirmed XKRX trading session" in (parts[0].last_error or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_kr_disclosures_fails_zero_when_calendar_is_unknown(
+    db_session,
+    monkeypatch,
+):
+    from app.models.market_events import MarketEventIngestionPartition
+    from app.services.market_events import ingestion
+
+    target_date = date(2026, 5, 7)
+    monkeypatch.setattr(ingestion, "trading_session_status", lambda *_: "unknown")
+
+    result = await ingestion.ingest_kr_disclosures_for_date(
+        db_session,
+        target_date,
+        fetch_rows=AsyncMock(return_value=[]),
+    )
+    await db_session.commit()
+
+    assert result.status == "failed"
+    assert "calendar classification is unknown" in (result.error or "")
+    parts = await _load_partitions(
+        db_session,
+        MarketEventIngestionPartition,
+        source="dart",
+        category="disclosure",
+        market="kr",
+        partition_date=target_date,
+    )
+    assert len(parts) == 1
+    assert parts[0].status == "failed"
+    assert "calendar classification is unknown" in (parts[0].last_error or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_kr_disclosures_records_scraper_schema_failure(db_session):
+    from app.models.market_events import MarketEventIngestionPartition
+    from app.services.market_events import ingestion
+    from app.services.market_events.dart_helpers import DartResponseSchemaError
+
+    target_date = date(2026, 5, 7)
+    result = await ingestion.ingest_kr_disclosures_for_date(
+        db_session,
+        target_date,
+        fetch_rows=AsyncMock(
+            side_effect=DartResponseSchemaError(
+                "DART list_date_ex response missing required columns: rcept_no"
+            )
+        ),
+    )
+    await db_session.commit()
+
+    assert result.status == "failed"
+    assert "missing required columns: rcept_no" in (result.error or "")
+    parts = await _load_partitions(
+        db_session,
+        MarketEventIngestionPartition,
+        source="dart",
+        category="disclosure",
+        market="kr",
+        partition_date=target_date,
+    )
+    assert len(parts) == 1
+    assert parts[0].status == "failed"
+    assert "missing required columns: rcept_no" in (parts[0].last_error or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
 async def test_ingest_us_earnings_records_failure_when_upsert_fails(
     db_session, monkeypatch
 ):

--- a/tests/test_market_events_cli.py
+++ b/tests/test_market_events_cli.py
@@ -97,6 +97,41 @@ async def test_run_ingest_dispatches_per_day(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+async def test_run_ingest_returns_nonzero_when_dart_partition_fails(
+    db_session, monkeypatch
+):
+    from scripts import ingest_market_events as cli
+
+    fake = AsyncMock(
+        return_value=type(
+            "R",
+            (),
+            {
+                "status": "failed",
+                "event_count": 0,
+                "error": "DART returned zero filings on confirmed XKRX trading session",
+            },
+        )()
+    )
+    monkeypatch.setitem(cli.SUPPORTED, ("dart", "disclosure", "kr"), fake)
+
+    rc = await cli.run_ingest(
+        db=db_session,
+        source="dart",
+        category="disclosure",
+        market="kr",
+        from_date=date(2026, 5, 7),
+        to_date=date(2026, 5, 7),
+        dry_run=False,
+        force=False,
+    )
+
+    assert rc == 2
+    fake.assert_awaited_once_with(db_session, date(2026, 5, 7))
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
 async def test_run_ingest_rejects_reversed_range_before_dispatch(
     db_session, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- replace deprecated `OpenDartReader.list_date` with scraping-backed `list_date_ex`
- validate the full observed `list_date_ex` column contract and fail the partition when it changes
- distinguish XKRX open / closed / calendar-unknown dates so a DART zero succeeds only on a confirmed non-session
- preserve `rcept_dt` as a JSON-safe ISO timestamp for normalization and JSONB persistence
- make a failed DART partition propagate through the CLI as exit code 2

## Why

OpenDartReader 0.2.3's deprecated `list_date()` has no body and implicitly returns `None`. The helper converted that into `[]`, and all 66 production DART partitions were recorded as `succeeded`, `event_count=0`, `last_error=null`.

`list_date_ex()` scrapes `dart.fss.or.kr`, so this change also converts scraper schema drift and unresolvable empty-day classification into explicit failures instead of another silent zero.

## Live/read-only evidence

- patched helper, 2026-07-24 (recent XKRX session): 786 rows; normalized date min/max both 2026-07-24
- direct scraper, 2026-07-25 (Saturday): 0 rows with the expected seven columns
- API key: present in deployed env; value was not printed
- production DB: SELECT only; 66 zero/succeeded partitions from 2026-05-01 through 2026-07-05, all without errors; zero DART disclosure events
- no production DB writes or backfill were performed

## ROB-1070 PR #25 relationship

PR https://github.com/mgh3326/robin-prefect-automations/pull/25 already owns runner-level `inserted` / `updated` / `processed` and before/after rowcount observability. This PR does not duplicate that. It fixes the source contract and partition status in auto_trader; a trading-session/schema failure becomes CLI `failed=1`, exit code 2, which the merged Prefect runner then surfaces alongside its existing rowcount summary.

## Tests

- `uv run pytest tests/services/test_market_events*.py tests/services/market_events tests/test_market_events_cli.py tests/test_market_events_coverage_router.py -q` — 229 passed
- `make lint` — Ruff, format, and ty passed

## Backfill handoff (not executed)

```bash
ENV_FILE=/Users/mgh3326/services/auto_trader/shared/.env.prod.native \
uv run python -m scripts.ingest_market_events \
  --source dart --category disclosure --market kr \
  --from-date 2026-05-01 --to-date 2026-07-05 --force
```

Backfill remains an orchestrator/operator action after deploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DART filing retrieval with response validation and date normalization.
  - Prevented empty ingestion results from being accepted on trading days or when the market calendar is unknown.
  - Preserved successful zero-result ingestion for confirmed non-trading days.
  - Improved handling and reporting of malformed DART responses.

- **Documentation**
  - Updated DART ingestion coverage and zero-result handling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->