### PR TITLE
fix(ROB-1062): H4 적대검증 BLOCK 치명 결함 수정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -426,9 +426,62 @@ jobs:
         # path -- a nonzero exit fails this step, so this job cannot pass
         # silently on zero collected tests.
 
+  alpaca-track-walkforward-tests:
+    # ROB-1062 H4 -- exactly mirrors the alpaca-track-tests (H1) /
+    # alpaca-track-seal-tests (H2) / alpaca-track-signals-tests (H3) jobs
+    # above: additive-only, own conftest.py sys.path wiring onto its three
+    # producer siblings (research/alpaca_track, research/alpaca_track_seal,
+    # research/alpaca_track_signals), network-0, no DB/Redis. The main
+    # `test` job's `testpaths` and pytest invocation remain UNCHANGED.
+    #
+    # Runtime note: this suite includes a handful of `@pytest.mark.slow`
+    # tests exercising the full walk-forward runner across all 8 sealed
+    # AP-A2 configs on one fold (~1 minute each) -- H3's own engine reloads
+    # and re-hashes the entire H2 seal from disk on every decision
+    # (NO_THRESHOLD_RELAXATION enforcement H4 does not, and must not,
+    # bypass), so this is a genuine, disclosed cost inherited from H3, not
+    # an H4 inefficiency. `timeout-minutes` is set higher than the sibling
+    # H1/H2/H3 jobs to give this comfortable headroom.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      PYTHON_VERSION: "3.13"
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install UV
+      run: pip install uv
+
+    - name: Load cached venv
+      id: cached-uv-dependencies
+      uses: actions/cache@v5
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}
+
+    - name: Install dependencies
+      run: uv sync --group test
+
+    - name: Run ROB-1062 alpaca_track_walkforward H4 walk-forward-runner tests (network-0, no DB/Redis)
+      run: |
+        uv run pytest research/alpaca_track_walkforward/tests/ -v --strict-markers -ra
+        # pytest exits 5 ("no tests collected") on an empty/misconfigured
+        # path -- a nonzero exit fails this step, so this job cannot pass
+        # silently on zero collected tests.
+
   notify:
     if: failure()
-    needs: [lint, test, taskiq-smoke, security, alpaca-track-tests, alpaca-track-seal-tests, alpaca-track-signals-tests]
+    needs: [lint, test, taskiq-smoke, security, alpaca-track-tests, alpaca-track-seal-tests, alpaca-track-signals-tests, alpaca-track-walkforward-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Discord failure notification

--- a/docs/reviews/ROB-1062-h4-audit-implementation.md
+++ b/docs/reviews/ROB-1062-h4-audit-implementation.md
@@ -1,0 +1,58 @@
+# ROB-1062 H4 audit implementation contract
+
+Authority:
+
+- `alpaca-h4-audit-contract-freeze-2026-07-26.md`, SHA-256
+  `cffc68f839296a75278bc5b7c8a66537fd394e1a0e96ef8ea0a1927baf48ffa1`
+- `gptpro-alpaca-h4-adjudication-result-2026-07-26.md`, SHA-256
+  `e1d8caad6877e9f0acaa29e9bb4af692468d7deccfed0f681654b22bdf3fe812`
+
+This is an implementation-level PIT and accounting rule. It does not modify
+the sealed preregistration or any threshold.
+
+## Event-time attribution
+
+For a half-open window `W=[start,end)`:
+
+| Lifecycle | Modeled-entry dry count | C120 cost | Closed/E120 |
+| --- | --- | --- | --- |
+| Entry fill and exit fill both in W | Include | Once at entry | Include |
+| Entry fill in W, exit fill outside W | Include | Once at entry | Exclude |
+| Entry fill outside W, exit fill in W | Exclude | Exclude | Exclude |
+| Timestamp exactly at `end` | Outside W | Attribute by its own timestamp | Exclude |
+
+Positions continue across boundaries. H4 never resets a carried position,
+force-closes it, or fabricates an exit. Consequently, an OOS exit price cannot
+enter a TRAIN closed-trade or E120 statistic.
+
+## AC9 stress-cost accounting
+
+H4 computes:
+
+```text
+100 × (365 / window_days) ×
+Σ[(filled_qty × entry_fill_price) / 2000 × 0.012]
+```
+
+The population is every entry fill in the window, including entries still
+open at the window end. The denominator is sealed fixed initial NAV `$2,000`,
+and the cost rate is C120 only. The calculation uses full precision.
+AP-A2's `[20.8%, 28.9%]` turnover band remains a separate gate.
+
+The historical model fixes quantity before observing the later fill:
+`filled_qty = target_notional / signal_reference_close`. The numerator then
+uses the actual modeled entry fill price. This preserves vol scaling and cash
+constraints while preventing substitution of a family base slot or a raw
+entry count.
+
+Every phase result exposes immutable modeled-entry evidence with
+`entry_fill_ts_ms`, `filled_qty`, `entry_fill_price`, and the derived
+`entry_filled_notional`, so the cap can be independently reproduced.
+
+The enforced selection order is:
+
+1. TRAIN closed count
+2. annualized C120 stress-cost cap
+3. TRAIN E120
+
+`SEAL_CHANGE=NO` and `THRESHOLD_REDECISION=NO`.

--- a/research/alpaca_track_walkforward/blind_counts.py
+++ b/research/alpaca_track_walkforward/blind_counts.py
@@ -59,6 +59,7 @@ def compute_blind_counts(
     closed_trades: Sequence[Trade] = (),
     open_positions_count: int = 0,
     fill_attempts: Sequence[FillAttempt] = (),
+    modeled_entries_count: int | None = None,
 ) -> BlindCounts:
     """``records``/``closed_trades``/``fill_attempts`` must already be
     scoped to the phase (TRAIN or OOS) the caller wants counted — this
@@ -70,7 +71,10 @@ def compute_blind_counts(
     phase-sliced record subsequence can orphan a EXIT whose paired ENTER
     fell in the other phase)."""
     closed_trades_count = len(closed_trades)
-    modeled_entries_count = closed_trades_count + open_positions_count
+    if modeled_entries_count is None:
+        modeled_entries_count = closed_trades_count + open_positions_count
+    if type(modeled_entries_count) is not int or modeled_entries_count < 0:
+        raise ValueError("modeled_entries_count must be a non-negative built-in int")
     holding_days = tuple(t.holding_days for t in closed_trades)
     histogram = rc.reconcile_histogram([r.reason_code for r in records])
     entry_unfilled = sum(
@@ -100,15 +104,30 @@ def compute_blind_counts(
 
 
 def annualized_stress_cost_pct(
-    *, modeled_entries_count: int, window_days: int, cost_bp: float
+    *,
+    entry_filled_notionals: Sequence[float],
+    window_days: int,
+    nav_usd: float,
+    cost_bp: float,
 ) -> float:
-    """PnL-blind annualized turnover-cost drag, as a percentage of NAV
-    (Run A SS5/SS11.6/SS12.6's "stress 드래그 연 X%"): entries-per-year times
-    the (stress) cost scenario's bp, expressed as a percent. Uses ONLY
-    entry counts and the sealed cost scenario bp — never a PnL figure —
-    which is exactly what lets AC9's cost cap reject a config "PnL-blind,
-    before any gross edge is even looked at"."""
+    """Annualized notional-weighted drag as percentage of fixed NAV.
+
+    Audit freeze 2026-07-26:
+      100 * (365 / D_W) * sum((entry_filled_notional / NAV0) * cost_rate)
+    """
     if window_days <= 0:
         raise ValueError("window_days must be positive")
-    entries_per_year = modeled_entries_count / window_days * 365.0
-    return entries_per_year * (cost_bp / 10_000.0) * 100.0
+    if type(nav_usd) is not float or nav_usd <= 0.0:
+        raise ValueError("nav_usd must be a positive built-in float")
+    if type(cost_bp) is not float or cost_bp <= 0.0:
+        raise ValueError("cost_bp must be a positive built-in float")
+    for notional in entry_filled_notionals:
+        if type(notional) is not float or notional <= 0.0:
+            raise ValueError(
+                "entry_filled_notionals must contain positive built-in floats"
+            )
+    cost_rate = cost_bp / 10_000.0
+    window_drag = sum(
+        (notional / nav_usd) * cost_rate for notional in entry_filled_notionals
+    )
+    return 100.0 * (365.0 / window_days) * window_drag

--- a/research/alpaca_track_walkforward/blind_counts.py
+++ b/research/alpaca_track_walkforward/blind_counts.py
@@ -1,0 +1,114 @@
+"""ROB-1062 H4 (AC25, AC28) — the PnL-blind counts: entries, turnover,
+holding-period distribution, and the rejection-reason histogram. These are
+ALWAYS exposed, mask or no mask (never wrapped by ``oos_mask.Masked`` — see
+that module's own docstring and ``tests/test_oos_mask.py``'s "opposite of
+masked" documentation test) — this is H5's dry-count gate's entire input
+surface.
+
+AC28: an all-zero-trades fold is a normal, legitimate outcome and must never
+be hidden — but a rejection histogram with ZERO entries when records exist
+is ``incomplete`` (the ROB-1025 lesson: an empty reason histogram alongside
+real decisions means the histogram-plumbing itself is broken, not that the
+strategy chose not to trade). ``BlindCounts.is_incomplete`` makes this
+distinction explicit and queryable rather than left for a caller to notice.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import reason_codes as rc
+from output_schema import SignalRecord
+from trade_ledger import FillAttempt, Trade
+
+__all__ = [
+    "BlindCounts",
+    "annualized_stress_cost_pct",
+    "compute_blind_counts",
+]
+
+
+@dataclass(frozen=True)
+class BlindCounts:
+    total_decision_records: int
+    modeled_entries_count: int
+    closed_trades_count: int
+    open_positions_count: int
+    entry_unfilled_count: int
+    exit_unfilled_count: int
+    fill_window_incomplete_count: int
+    holding_days: tuple[int, ...]
+    reason_code_histogram: dict[str, int]
+
+    @property
+    def is_incomplete(self) -> bool:
+        """ROB-1025 lesson: real decision records with an EMPTY reason
+        histogram means the histogram plumbing broke, not that nothing
+        happened — never silently collapse this into a clean zero-trade
+        result."""
+        return (
+            self.total_decision_records > 0
+            and sum(self.reason_code_histogram.values()) == 0
+        )
+
+
+def compute_blind_counts(
+    records: Sequence[SignalRecord],
+    *,
+    closed_trades: Sequence[Trade] = (),
+    open_positions_count: int = 0,
+    fill_attempts: Sequence[FillAttempt] = (),
+) -> BlindCounts:
+    """``records``/``closed_trades``/``fill_attempts`` must already be
+    scoped to the phase (TRAIN or OOS) the caller wants counted — this
+    function does no phase attribution itself (that is the walk-forward
+    runner's job, by ``entry_decision_ts_ms``/``decision_ts_ms`` membership;
+    see ``runner.py``'s module docstring for why a SINGLE canonical ledger
+    run over the full continuous stream, filtered afterward by timestamp,
+    is the only safe way to do this — re-running the ledger on a
+    phase-sliced record subsequence can orphan a EXIT whose paired ENTER
+    fell in the other phase)."""
+    closed_trades_count = len(closed_trades)
+    modeled_entries_count = closed_trades_count + open_positions_count
+    holding_days = tuple(t.holding_days for t in closed_trades)
+    histogram = rc.reconcile_histogram([r.reason_code for r in records])
+    entry_unfilled = sum(
+        1
+        for a in fill_attempts
+        if a.leg == "ENTRY" and a.outcome.reason == "ENTRY_UNFILLED"
+    )
+    exit_unfilled = sum(
+        1
+        for a in fill_attempts
+        if a.leg == "EXIT" and a.outcome.reason == "EXIT_UNFILLED"
+    )
+    incomplete = sum(
+        1 for a in fill_attempts if a.outcome.reason == "FILL_WINDOW_INCOMPLETE"
+    )
+    return BlindCounts(
+        total_decision_records=len(records),
+        modeled_entries_count=modeled_entries_count,
+        closed_trades_count=closed_trades_count,
+        open_positions_count=open_positions_count,
+        entry_unfilled_count=entry_unfilled,
+        exit_unfilled_count=exit_unfilled,
+        fill_window_incomplete_count=incomplete,
+        holding_days=holding_days,
+        reason_code_histogram=histogram,
+    )
+
+
+def annualized_stress_cost_pct(
+    *, modeled_entries_count: int, window_days: int, cost_bp: float
+) -> float:
+    """PnL-blind annualized turnover-cost drag, as a percentage of NAV
+    (Run A SS5/SS11.6/SS12.6's "stress 드래그 연 X%"): entries-per-year times
+    the (stress) cost scenario's bp, expressed as a percent. Uses ONLY
+    entry counts and the sealed cost scenario bp — never a PnL figure —
+    which is exactly what lets AC9's cost cap reject a config "PnL-blind,
+    before any gross edge is even looked at"."""
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+    entries_per_year = modeled_entries_count / window_days * 365.0
+    return entries_per_year * (cost_bp / 10_000.0) * 100.0

--- a/research/alpaca_track_walkforward/blind_counts.py
+++ b/research/alpaca_track_walkforward/blind_counts.py
@@ -15,8 +15,9 @@ distinction explicit and queryable rather than left for a caller to notice.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 
 import reason_codes as rc
 from output_schema import SignalRecord
@@ -39,17 +40,54 @@ class BlindCounts:
     exit_unfilled_count: int
     fill_window_incomplete_count: int
     holding_days: tuple[int, ...]
-    reason_code_histogram: dict[str, int]
+    reason_code_histogram: Mapping[str, int]
+
+    def __post_init__(self) -> None:
+        count_fields = (
+            "total_decision_records",
+            "modeled_entries_count",
+            "closed_trades_count",
+            "open_positions_count",
+            "entry_unfilled_count",
+            "exit_unfilled_count",
+            "fill_window_incomplete_count",
+        )
+        for name in count_fields:
+            value = getattr(self, name)
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} must be a non-negative built-in int")
+        for value in self.holding_days:
+            if type(value) is not int or value < 0:
+                raise ValueError("holding_days must contain non-negative built-in ints")
+        histogram = dict(self.reason_code_histogram)
+        for reason, count in histogram.items():
+            if type(reason) is not str or type(count) is not int or count < 0:
+                raise ValueError(
+                    "reason_code_histogram must map built-in str to "
+                    "non-negative built-in int"
+                )
+        object.__setattr__(
+            self,
+            "reason_code_histogram",
+            MappingProxyType(dict(sorted(histogram.items()))),
+        )
 
     @property
     def is_incomplete(self) -> bool:
-        """ROB-1025 lesson: real decision records with an EMPTY reason
-        histogram means the histogram plumbing broke, not that nothing
-        happened — never silently collapse this into a clean zero-trade
-        result."""
+        """Fail closed on any structural incompleteness signal.
+
+        A valid zero-trade fold still has scheduled decision records and one
+        reconciled reason per record.  No-record phases, partial histograms,
+        incomplete fill windows, or internally inconsistent lifecycle counts
+        can therefore never be promoted into dry-count PASS evidence.
+        """
         return (
-            self.total_decision_records > 0
-            and sum(self.reason_code_histogram.values()) == 0
+            self.total_decision_records == 0
+            or sum(self.reason_code_histogram.values()) != self.total_decision_records
+            or self.fill_window_incomplete_count > 0
+            or self.modeled_entries_count
+            != self.closed_trades_count + self.open_positions_count
+            or len(self.holding_days) != self.closed_trades_count
         )
 
 

--- a/research/alpaca_track_walkforward/config_selection.py
+++ b/research/alpaca_track_walkforward/config_selection.py
@@ -1,0 +1,114 @@
+"""ROB-1062 H4 (Run A SS15, AC7-AC10) — TRAIN-only config selection.
+
+Selection rule, applied IN ORDER, exactly as SS15 states it:
+
+    TRAIN closed >= 30
+    AND TRAIN E120 > 0
+    AND passes the PnL-blind annualized stress cost cap
+    -> max median-trade E120
+    -> tie: lower turnover
+    -> tie: canonical config_id ascending (AP-A1-00..07 / AP-A2-00..07 sort
+       lexicographically in their own canonical nested-loop order, per
+       ``alpaca_track_seal.configs``)
+
+No config passing -> ``NO_SELECTED_CONFIG`` — never an arbitrary fallback
+(AC10).
+
+AC8 ("selection uses TRAIN data only; OOS information reaching selection is
+a terminal error") is enforced structurally here, not merely by caller
+discipline: ``select_config`` requires an explicit ``data_window`` argument
+that must be the literal string ``"TRAIN"`` — there is no other window value
+this function will accept, so a caller that tried to feed it OOS-derived
+metrics under an ``"OOS"`` (or any other) label fails closed immediately,
+before any metric is even inspected.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = [
+    "OOSDataReachedSelectionError",
+    "ConfigSelectionResult",
+    "ConfigTrainMetrics",
+    "MIN_TRAIN_CLOSED_TRADES",
+    "select_config",
+]
+
+MIN_TRAIN_CLOSED_TRADES = 30
+
+SelectionStatus = Literal["SELECTED", "NO_SELECTED_CONFIG"]
+
+
+class OOSDataReachedSelectionError(ValueError):
+    """``select_config`` was called with anything other than
+    ``data_window="TRAIN"`` — AC8's terminal-error enforcement point."""
+
+
+@dataclass(frozen=True)
+class ConfigTrainMetrics:
+    """One config's TRAIN-window-only metrics — the only shape
+    ``select_config`` ever looks at."""
+
+    config_id: str
+    closed_trades_count: int
+    median_trade_e120_bp: float | None  # None iff closed_trades_count == 0
+    turnover_p: float
+    annualized_stress_cost_pct: float
+
+    def __post_init__(self) -> None:
+        if self.closed_trades_count < 0:
+            raise ValueError("closed_trades_count must be non-negative")
+        if self.closed_trades_count == 0 and self.median_trade_e120_bp is not None:
+            raise ValueError("zero closed trades cannot carry a median E120")
+        if self.closed_trades_count > 0 and self.median_trade_e120_bp is None:
+            raise ValueError("a config with closed trades must carry a median E120")
+
+
+@dataclass(frozen=True)
+class ConfigSelectionResult:
+    status: SelectionStatus
+    selected_config_id: str | None
+
+    def __post_init__(self) -> None:
+        if self.status == "SELECTED" and self.selected_config_id is None:
+            raise ValueError("a SELECTED result must carry a selected_config_id")
+        if self.status == "NO_SELECTED_CONFIG" and self.selected_config_id is not None:
+            raise ValueError("NO_SELECTED_CONFIG must not carry a selected_config_id")
+
+
+def select_config(
+    metrics: Sequence[ConfigTrainMetrics],
+    *,
+    data_window: str,
+    stress_cost_cap_pct: float,
+) -> ConfigSelectionResult:
+    if data_window != "TRAIN":
+        raise OOSDataReachedSelectionError(
+            f"select_config only ever accepts data_window='TRAIN', got "
+            f"{data_window!r} — OOS information must never reach config "
+            "selection (Run A SS15/AC8)"
+        )
+    eligible = [
+        m
+        for m in metrics
+        if m.closed_trades_count >= MIN_TRAIN_CLOSED_TRADES
+        and m.median_trade_e120_bp is not None
+        and m.median_trade_e120_bp > 0.0
+        and m.annualized_stress_cost_pct <= stress_cost_cap_pct
+    ]
+    if not eligible:
+        return ConfigSelectionResult(
+            status="NO_SELECTED_CONFIG", selected_config_id=None
+        )
+    best = min(
+        eligible,
+        key=lambda m: (
+            -m.median_trade_e120_bp,  # type: ignore[operator]  # narrowed non-None above
+            m.turnover_p,
+            m.config_id,
+        ),
+    )
+    return ConfigSelectionResult(status="SELECTED", selected_config_id=best.config_id)

--- a/research/alpaca_track_walkforward/config_selection.py
+++ b/research/alpaca_track_walkforward/config_selection.py
@@ -3,8 +3,9 @@
 Selection rule, applied IN ORDER, exactly as SS15 states it:
 
     TRAIN closed >= 30
-    AND TRAIN E120 > 0
     AND passes the PnL-blind annualized stress cost cap
+    AND, for AP-A2, sealed replacement p is inside its turnover band
+    AND TRAIN E120 > 0
     -> max median-trade E120
     -> tie: lower turnover
     -> tie: canonical config_id ascending (AP-A1-00..07 / AP-A2-00..07 sort
@@ -65,6 +66,8 @@ class ConfigTrainMetrics:
             raise ValueError("zero closed trades cannot carry a median E120")
         if self.closed_trades_count > 0 and self.median_trade_e120_bp is None:
             raise ValueError("a config with closed trades must carry a median E120")
+        if type(self.turnover_p) is not float or not 0.0 <= self.turnover_p <= 1.0:
+            raise ValueError("turnover_p must be a built-in float in [0, 1]")
 
 
 @dataclass(frozen=True)
@@ -84,6 +87,7 @@ def select_config(
     *,
     data_window: str,
     stress_cost_cap_pct: float,
+    turnover_band: tuple[float, float] | None = None,
 ) -> ConfigSelectionResult:
     if data_window != "TRAIN":
         raise OOSDataReachedSelectionError(
@@ -101,9 +105,25 @@ def select_config(
         for m in structurally_eligible
         if m.annualized_stress_cost_pct <= stress_cost_cap_pct
     ]
+    contains_ap_a2 = any(m.config_id.startswith("AP-A2-") for m in metrics)
+    if contains_ap_a2 and turnover_band is None:
+        raise ValueError("AP-A2 selection requires the sealed turnover band")
+    if turnover_band is not None:
+        lower, upper = turnover_band
+        if (
+            type(lower) is not float
+            or type(upper) is not float
+            or not 0.0 <= lower <= upper <= 1.0
+        ):
+            raise ValueError("turnover_band must contain two ordered floats in [0, 1]")
+        turnover_eligible = [
+            m for m in cost_eligible if m.turnover_p >= lower and m.turnover_p <= upper
+        ]
+    else:
+        turnover_eligible = cost_eligible
     eligible = [
         m
-        for m in cost_eligible
+        for m in turnover_eligible
         if m.median_trade_e120_bp is not None and m.median_trade_e120_bp > 0.0
     ]
     if not eligible:

--- a/research/alpaca_track_walkforward/config_selection.py
+++ b/research/alpaca_track_walkforward/config_selection.py
@@ -2,6 +2,7 @@
 
 Selection rule, applied IN ORDER, exactly as SS15 states it:
 
+    TRAIN dry counts must be complete
     TRAIN closed >= 30
     AND passes the PnL-blind annualized stress cost cap
     AND, for AP-A2, sealed replacement p is inside its turnover band
@@ -54,12 +55,15 @@ class ConfigTrainMetrics:
     ``select_config`` ever looks at."""
 
     config_id: str
+    is_incomplete: bool
     closed_trades_count: int
     median_trade_e120_bp: float | None  # None iff closed_trades_count == 0
     turnover_p: float
     annualized_stress_cost_pct: float
 
     def __post_init__(self) -> None:
+        if type(self.is_incomplete) is not bool:
+            raise TypeError("is_incomplete must be a built-in bool")
         if self.closed_trades_count < 0:
             raise ValueError("closed_trades_count must be non-negative")
         if self.closed_trades_count == 0 and self.median_trade_e120_bp is not None:
@@ -97,8 +101,9 @@ def select_config(
         )
     # AC9 is procedural, not merely a final-result predicate: the
     # PnL-blind cost cap must run before *any* E120 value is inspected.
+    complete = [m for m in metrics if not m.is_incomplete]
     structurally_eligible = [
-        m for m in metrics if m.closed_trades_count >= MIN_TRAIN_CLOSED_TRADES
+        m for m in complete if m.closed_trades_count >= MIN_TRAIN_CLOSED_TRADES
     ]
     cost_eligible = [
         m

--- a/research/alpaca_track_walkforward/config_selection.py
+++ b/research/alpaca_track_walkforward/config_selection.py
@@ -91,13 +91,20 @@ def select_config(
             f"{data_window!r} — OOS information must never reach config "
             "selection (Run A SS15/AC8)"
         )
+    # AC9 is procedural, not merely a final-result predicate: the
+    # PnL-blind cost cap must run before *any* E120 value is inspected.
+    structurally_eligible = [
+        m for m in metrics if m.closed_trades_count >= MIN_TRAIN_CLOSED_TRADES
+    ]
+    cost_eligible = [
+        m
+        for m in structurally_eligible
+        if m.annualized_stress_cost_pct <= stress_cost_cap_pct
+    ]
     eligible = [
         m
-        for m in metrics
-        if m.closed_trades_count >= MIN_TRAIN_CLOSED_TRADES
-        and m.median_trade_e120_bp is not None
-        and m.median_trade_e120_bp > 0.0
-        and m.annualized_stress_cost_pct <= stress_cost_cap_pct
+        for m in cost_eligible
+        if m.median_trade_e120_bp is not None and m.median_trade_e120_bp > 0.0
     ]
     if not eligible:
         return ConfigSelectionResult(

--- a/research/alpaca_track_walkforward/conftest.py
+++ b/research/alpaca_track_walkforward/conftest.py
@@ -1,0 +1,44 @@
+"""ROB-1062 H4 — make the alpaca_track_walkforward package, its three
+producer siblings (``research/alpaca_track`` H1 data-layer, ``research/
+alpaca_track_seal`` H2 registry seal, ``research/alpaca_track_signals`` H3
+signal engines — all consumed by import, never edited), the sibling
+``research/nautilus_scalping`` package (whose pure ``canonical_hash`` shim we
+reuse — the SAME typed canonical AST authority H1/H2/H3 use), and the repo
+root (for ``research_contracts``) importable in tests.
+
+This package is a deliberate SIBLING of H1/H2/H3, not a subpackage of any of
+them — mirrors H3's own conftest rationale for being a sibling of H1/H2: H4's
+static OOS-mask/no-bypass guard and PnL-surface guards recursively scan
+everything under ``research/alpaca_track_walkforward/`` only; they must never
+scan (or be scanned as part of) H1/H2/H3's own trees, and H1/H2/H3's own
+guards must never have to account for H4's modules.
+"""
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent  # .../auto_trader.<worktree>
+_NAUTILUS_SCALPING = _REPO_ROOT / "research" / "nautilus_scalping"
+_ALPACA_TRACK = _REPO_ROOT / "research" / "alpaca_track"
+_ALPACA_TRACK_SEAL = _REPO_ROOT / "research" / "alpaca_track_seal"
+_ALPACA_TRACK_SIGNALS = _REPO_ROOT / "research" / "alpaca_track_signals"
+
+assert _NAUTILUS_SCALPING.is_dir(), (
+    f"conftest path arithmetic is broken: {_NAUTILUS_SCALPING} does not exist "
+    f"(computed repo root: {_REPO_ROOT})"
+)
+assert _ALPACA_TRACK.is_dir(), f"{_ALPACA_TRACK} does not exist"
+assert _ALPACA_TRACK_SEAL.is_dir(), f"{_ALPACA_TRACK_SEAL} does not exist"
+assert _ALPACA_TRACK_SIGNALS.is_dir(), f"{_ALPACA_TRACK_SIGNALS} does not exist"
+
+for _p in (
+    str(_HERE),
+    str(_ALPACA_TRACK),
+    str(_ALPACA_TRACK_SEAL),
+    str(_ALPACA_TRACK_SIGNALS),
+    str(_NAUTILUS_SCALPING),
+    str(_REPO_ROOT),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)

--- a/research/alpaca_track_walkforward/context_binding.py
+++ b/research/alpaca_track_walkforward/context_binding.py
@@ -1,0 +1,94 @@
+"""ROB-1062 H4 (Run A SS15, AC4, AC5) — warm-up context provenance binding.
+
+Embargo-window data may be consumed ONLY as warm-up context for the first
+OOS decisions (indicator lookback continuity) — it may never itself
+generate a signal/entry/trade/PnL/selection metric (AC4: no decision is ever
+dated inside an embargo window; the walk-forward runner enforces that by
+construction, simply never calling an engine at an embargo-window
+timestamp). This module's job is AC5's evidence requirement: bind the EXACT
+context range/bytes consumed by each decision to a hash, so that (a) an
+OOS-only mutation can be PROVEN never to change a TRAIN decision's
+consumed-context hash, and (b) a silent, invisible context substitution
+(different bars reaching the same decision without changing anything
+else) is structurally impossible — the hash IS the evidence.
+
+Reuses H3's own ``indicators.trailing_valid_segment`` (a pure function, not
+a re-declaration of a sealed value) to compute EXACTLY the same trailing
+run of bars an engine decision would itself consume for a given
+``window_end_ms`` — this module does not reimplement segment-restart logic,
+it calls the same one H3 calls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import canonical_hash
+import indicators as ind
+from daily_bars import DailyBar
+
+__all__ = [
+    "WarmupContextBinding",
+    "compute_warmup_context_binding",
+]
+
+
+def _bar_tuple(bar: DailyBar) -> tuple:
+    return (
+        bar.day_start_ms,
+        bar.day_end_ms,
+        bar.open,
+        bar.high,
+        bar.low,
+        bar.close,
+        bar.volume,
+        bar.is_valid,
+        bar.is_segment_start,
+    )
+
+
+class WarmupContextBinding:
+    """Immutable evidence record: exactly which bars (as a content hash,
+    not merely a count/range) a decision's indicators were computed
+    from."""
+
+    __slots__ = ("window_end_ms", "per_symbol_segment_hash", "combined_context_hash")
+
+    def __init__(
+        self, *, window_end_ms: int, per_symbol_segment_hash: dict[str, str]
+    ) -> None:
+        object.__setattr__(self, "window_end_ms", window_end_ms)
+        object.__setattr__(
+            self, "per_symbol_segment_hash", dict(per_symbol_segment_hash)
+        )
+        object.__setattr__(
+            self,
+            "combined_context_hash",
+            canonical_hash.canonical_sha256(
+                {
+                    "window_end_ms": window_end_ms,
+                    "per_symbol": dict(per_symbol_segment_hash),
+                }
+            ),
+        )
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("WarmupContextBinding is immutable")
+
+
+def compute_warmup_context_binding(
+    bars_by_symbol: Mapping[str, Sequence[DailyBar]], *, window_end_ms: int
+) -> WarmupContextBinding:
+    """The EXACT per-symbol trailing valid segment (the same one an engine
+    decision at this ``window_end_ms`` would consume), content-hashed."""
+    per_symbol_hash: dict[str, str] = {}
+    for symbol in sorted(bars_by_symbol):
+        raw_bars = bars_by_symbol[symbol]
+        usable = tuple(b for b in raw_bars if b.day_end_ms <= window_end_ms)
+        segment = ind.trailing_valid_segment(usable)
+        per_symbol_hash[symbol] = canonical_hash.canonical_sha256(
+            {"segment": [_bar_tuple(b) for b in segment]}
+        )
+    return WarmupContextBinding(
+        window_end_ms=window_end_ms, per_symbol_segment_hash=per_symbol_hash
+    )

--- a/research/alpaca_track_walkforward/context_binding.py
+++ b/research/alpaca_track_walkforward/context_binding.py
@@ -22,6 +22,7 @@ it calls the same one H3 calls.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from types import MappingProxyType
 
 import canonical_hash
 import indicators as ind
@@ -42,6 +43,10 @@ def _bar_tuple(bar: DailyBar) -> tuple:
         bar.low,
         bar.close,
         bar.volume,
+        bar.minute_count_observed,
+        bar.imputed_minutes,
+        bar.max_gap_minutes,
+        bar.gap_in_last_60min,
         bar.is_valid,
         bar.is_segment_start,
     )
@@ -52,22 +57,53 @@ class WarmupContextBinding:
     not merely a count/range) a decision's indicators were computed
     from."""
 
-    __slots__ = ("window_end_ms", "per_symbol_segment_hash", "combined_context_hash")
+    __slots__ = (
+        "window_end_ms",
+        "per_symbol_segment_hash",
+        "per_symbol_segment_range",
+        "source_corpus_hash",
+        "feature_input_hash",
+        "combined_context_hash",
+    )
 
     def __init__(
-        self, *, window_end_ms: int, per_symbol_segment_hash: dict[str, str]
+        self,
+        *,
+        window_end_ms: int,
+        per_symbol_segment_hash: Mapping[str, str],
+        per_symbol_segment_range: Mapping[str, tuple[int | None, int | None]],
+        source_corpus_hash: str,
     ) -> None:
+        ordered_hashes = dict(sorted(per_symbol_segment_hash.items()))
+        ordered_ranges = dict(sorted(per_symbol_segment_range.items()))
         object.__setattr__(self, "window_end_ms", window_end_ms)
         object.__setattr__(
-            self, "per_symbol_segment_hash", dict(per_symbol_segment_hash)
+            self,
+            "per_symbol_segment_hash",
+            MappingProxyType(ordered_hashes),
         )
+        object.__setattr__(
+            self,
+            "per_symbol_segment_range",
+            MappingProxyType(ordered_ranges),
+        )
+        object.__setattr__(self, "source_corpus_hash", source_corpus_hash)
+        feature_input_hash = canonical_hash.canonical_sha256(
+            {
+                "window_end_ms": window_end_ms,
+                "per_symbol_segment_hash": ordered_hashes,
+                "per_symbol_segment_range": ordered_ranges,
+            }
+        )
+        object.__setattr__(self, "feature_input_hash", feature_input_hash)
         object.__setattr__(
             self,
             "combined_context_hash",
             canonical_hash.canonical_sha256(
                 {
                     "window_end_ms": window_end_ms,
-                    "per_symbol": dict(per_symbol_segment_hash),
+                    "source_corpus_hash": source_corpus_hash,
+                    "feature_input_hash": feature_input_hash,
                 }
             ),
         )
@@ -82,13 +118,25 @@ def compute_warmup_context_binding(
     """The EXACT per-symbol trailing valid segment (the same one an engine
     decision at this ``window_end_ms`` would consume), content-hashed."""
     per_symbol_hash: dict[str, str] = {}
+    per_symbol_range: dict[str, tuple[int | None, int | None]] = {}
+    source_payload: dict[str, list[tuple]] = {}
     for symbol in sorted(bars_by_symbol):
         raw_bars = bars_by_symbol[symbol]
         usable = tuple(b for b in raw_bars if b.day_end_ms <= window_end_ms)
+        source_payload[symbol] = [_bar_tuple(b) for b in usable]
         segment = ind.trailing_valid_segment(usable)
         per_symbol_hash[symbol] = canonical_hash.canonical_sha256(
             {"segment": [_bar_tuple(b) for b in segment]}
         )
+        per_symbol_range[symbol] = (
+            segment[0].day_start_ms if segment else None,
+            segment[-1].day_end_ms if segment else None,
+        )
     return WarmupContextBinding(
-        window_end_ms=window_end_ms, per_symbol_segment_hash=per_symbol_hash
+        window_end_ms=window_end_ms,
+        per_symbol_segment_hash=per_symbol_hash,
+        per_symbol_segment_range=per_symbol_range,
+        source_corpus_hash=canonical_hash.canonical_sha256(
+            {"bars_by_symbol": source_payload}
+        ),
     )

--- a/research/alpaca_track_walkforward/fill_model.py
+++ b/research/alpaca_track_walkforward/fill_model.py
@@ -1,0 +1,198 @@
+"""ROB-1062 H4 (Run A SS14.5, AC11-AC16) — the historical fill model: a
+conservative proxy for BBO-based fills, built only from Binance public-spot
+1-minute bars (``daily_bars.SpotMinute`` — H1's own raw-minute type, reused
+here rather than re-declared).
+
+    entry: reference = signal-time Binance close (C_t); limit_cap =
+        ref * 1.005. If either of the next 2 one-minute bars' OPEN is
+        <= limit_cap, fill at the FIRST such bar's open. Otherwise
+        ENTRY_UNFILLED.
+    exit: symmetric — limit_floor = ref * 0.995; fill at the first
+        qualifying bar's open (open >= limit_floor). Otherwise EXIT_UNFILLED.
+
+Spread/fee/venue-mismatch are NEVER mixed into the fill price (AC13) — they
+are deducted separately, per cost scenario, in ``pnl_views.py``. The fill
+price is ALWAYS a later bar's ``open`` (AC14: same-close fill is
+structurally impossible here — there is no code path that returns
+``reference_close`` itself as a fill price; every returned ``fill_price`` is
+traceable to one of the two window bars via ``fill_bar_offset``).
+
+Documented, explicit implementation choice (SS14.5 specifies the 2-bar
+window and both multipliers but does not pin an exact clock anchor for
+"이후" / "after" the signal): the window's first bar is the one-minute bar
+whose ``open_time_ms`` equals the DECISION timestamp itself (the instant the
+order actually reaches the book), and the second is the immediately
+following minute. This is flagged here (and in the H4 completion report),
+mirroring H3's own precedent for genuinely open implementation choices not
+pinned by the authority doc (EMA seed rule, sigma20 annualization,
+greedy-continue cash allocation) — it is a documented choice, not a
+reinterpretation of a specified VALUE (the ``1.005``/``0.995`` multipliers
+and the "2 bars" window count themselves are taken verbatim and are never
+altered here).
+
+A missing expected minute bar (data gap) is NEVER treated as an unfilled
+attempt — that would fabricate a market outcome from absent data (AC15).
+It is reported as ``FILL_WINDOW_INCOMPLETE``, a distinct, structural,
+"incomplete" classification the caller must never fold into a performance
+verdict.
+
+Partial fills are not modeled (AC16) — every fill is all-or-nothing at the
+qualifying bar's open. This simplification is recorded on every
+``FillOutcome`` via ``partial_fill_modeled=False`` (a literal constant, not a
+per-call decision) so no downstream consumer can mistake this backtest proxy
+for a partial-fill-aware simulation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from daily_bars import SpotMinute
+
+__all__ = [
+    "ENTRY_LIMIT_CAP_MULTIPLIER",
+    "EXIT_LIMIT_FLOOR_MULTIPLIER",
+    "FILL_WINDOW_MINUTE_COUNT",
+    "MINUTE_MS",
+    "FillOutcome",
+    "FillReason",
+    "model_entry_fill",
+    "model_exit_fill",
+]
+
+MINUTE_MS = 60_000
+FILL_WINDOW_MINUTE_COUNT = 2
+
+# Run A SS14.5 — verbatim, never altered.
+ENTRY_LIMIT_CAP_MULTIPLIER = 1.005
+EXIT_LIMIT_FLOOR_MULTIPLIER = 0.995
+
+FillReason = Literal[
+    "FILLED", "ENTRY_UNFILLED", "EXIT_UNFILLED", "FILL_WINDOW_INCOMPLETE"
+]
+
+_PARTIAL_FILL_MODELED = False  # AC16 — literal, never a per-call parameter.
+
+
+def _float(value: object, name: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{name} must be built-in float")
+    return value
+
+
+def _int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be built-in int")
+    return value
+
+
+@dataclass(frozen=True)
+class FillOutcome:
+    filled: bool
+    fill_price: float | None
+    fill_bar_offset: int | None  # 1 or 2 -- which window bar filled it
+    reason: FillReason
+    partial_fill_modeled: bool = _PARTIAL_FILL_MODELED
+
+    def __post_init__(self) -> None:
+        if self.partial_fill_modeled is not _PARTIAL_FILL_MODELED:
+            raise ValueError(
+                "partial_fill_modeled is a fixed literal, never overridden"
+            )
+        if self.filled:
+            if self.reason != "FILLED":
+                raise ValueError("a filled outcome must carry reason='FILLED'")
+            if self.fill_price is None or self.fill_bar_offset is None:
+                raise ValueError(
+                    "a filled outcome must carry fill_price and fill_bar_offset"
+                )
+            _float(self.fill_price, "fill_price")
+            if self.fill_bar_offset not in (1, 2):
+                raise ValueError("fill_bar_offset must be 1 or 2")
+        else:
+            if self.reason == "FILLED":
+                raise ValueError("reason='FILLED' requires filled=True")
+            if self.fill_price is not None or self.fill_bar_offset is not None:
+                raise ValueError(
+                    "an unfilled outcome must carry fill_price=None and "
+                    "fill_bar_offset=None"
+                )
+
+
+def _window_bars(
+    decision_ts_ms: int, minute_bars_after_signal: Sequence[SpotMinute]
+) -> list[SpotMinute | None]:
+    _int(decision_ts_ms, "decision_ts_ms")
+    for bar in minute_bars_after_signal:
+        if type(bar) is not SpotMinute:
+            raise TypeError("minute_bars_after_signal must contain SpotMinute")
+    by_ts = {b.open_time_ms: b for b in minute_bars_after_signal}
+    expected = [decision_ts_ms + i * MINUTE_MS for i in range(FILL_WINDOW_MINUTE_COUNT)]
+    return [by_ts.get(ts) for ts in expected]
+
+
+def model_entry_fill(
+    *,
+    decision_ts_ms: int,
+    reference_close: float,
+    minute_bars_after_signal: Sequence[SpotMinute],
+) -> FillOutcome:
+    """Entry side: fill at the first qualifying bar's open where
+    ``open <= reference_close * ENTRY_LIMIT_CAP_MULTIPLIER``, scanning the
+    2-bar window in order (never bar 3+, AC14/AC16 boundary discipline)."""
+    _float(reference_close, "reference_close")
+    limit_cap = reference_close * ENTRY_LIMIT_CAP_MULTIPLIER
+    window = _window_bars(decision_ts_ms, minute_bars_after_signal)
+    if any(bar is None for bar in window):
+        return FillOutcome(
+            filled=False,
+            fill_price=None,
+            fill_bar_offset=None,
+            reason="FILL_WINDOW_INCOMPLETE",
+        )
+    for offset, bar in enumerate(window, start=1):
+        assert bar is not None  # narrowed by the `any(... is None)` check above
+        if bar.open <= limit_cap:
+            return FillOutcome(
+                filled=True,
+                fill_price=bar.open,
+                fill_bar_offset=offset,
+                reason="FILLED",
+            )
+    return FillOutcome(
+        filled=False, fill_price=None, fill_bar_offset=None, reason="ENTRY_UNFILLED"
+    )
+
+
+def model_exit_fill(
+    *,
+    decision_ts_ms: int,
+    reference_close: float,
+    minute_bars_after_signal: Sequence[SpotMinute],
+) -> FillOutcome:
+    """Exit side, symmetric to entry: fill at the first qualifying bar's
+    open where ``open >= reference_close * EXIT_LIMIT_FLOOR_MULTIPLIER``."""
+    _float(reference_close, "reference_close")
+    limit_floor = reference_close * EXIT_LIMIT_FLOOR_MULTIPLIER
+    window = _window_bars(decision_ts_ms, minute_bars_after_signal)
+    if any(bar is None for bar in window):
+        return FillOutcome(
+            filled=False,
+            fill_price=None,
+            fill_bar_offset=None,
+            reason="FILL_WINDOW_INCOMPLETE",
+        )
+    for offset, bar in enumerate(window, start=1):
+        assert bar is not None
+        if bar.open >= limit_floor:
+            return FillOutcome(
+                filled=True,
+                fill_price=bar.open,
+                fill_bar_offset=offset,
+                reason="FILLED",
+            )
+    return FillOutcome(
+        filled=False, fill_price=None, fill_bar_offset=None, reason="EXIT_UNFILLED"
+    )

--- a/research/alpaca_track_walkforward/fill_model.py
+++ b/research/alpaca_track_walkforward/fill_model.py
@@ -17,18 +17,11 @@ structurally impossible here — there is no code path that returns
 ``reference_close`` itself as a fill price; every returned ``fill_price`` is
 traceable to one of the two window bars via ``fill_bar_offset``).
 
-Documented, explicit implementation choice (SS14.5 specifies the 2-bar
-window and both multipliers but does not pin an exact clock anchor for
-"이후" / "after" the signal): the window's first bar is the one-minute bar
-whose ``open_time_ms`` equals the DECISION timestamp itself (the instant the
-order actually reaches the book), and the second is the immediately
-following minute. This is flagged here (and in the H4 completion report),
-mirroring H3's own precedent for genuinely open implementation choices not
-pinned by the authority doc (EMA seed rule, sigma20 annualization,
-greedy-continue cash allocation) — it is a documented choice, not a
-reinterpretation of a specified VALUE (the ``1.005``/``0.995`` multipliers
-and the "2 bars" window count themselves are taken verbatim and are never
-altered here).
+The Korean authority word ``이후`` is enforced strictly: the first eligible
+bar opens one full minute AFTER ``decision_ts_ms`` and the second opens two
+minutes after it. A bar whose open equals the signal/decision timestamp is
+already observable when the decision is formed and is therefore rejected
+from the fill window rather than treated as an optimistic instantaneous fill.
 
 A missing expected minute bar (data gap) is NEVER treated as an unfilled
 attempt — that would fabricate a market outcome from absent data (AC15).
@@ -128,8 +121,18 @@ def _window_bars(
     for bar in minute_bars_after_signal:
         if type(bar) is not SpotMinute:
             raise TypeError("minute_bars_after_signal must contain SpotMinute")
+    timestamps = [b.open_time_ms for b in minute_bars_after_signal]
+    if len(timestamps) != len(set(timestamps)):
+        raise ValueError("minute_bars_after_signal contains duplicate open_time_ms")
+    if any(timestamp <= decision_ts_ms for timestamp in timestamps):
+        raise ValueError(
+            "minute fill bars must open strictly after the signal timestamp"
+        )
     by_ts = {b.open_time_ms: b for b in minute_bars_after_signal}
-    expected = [decision_ts_ms + i * MINUTE_MS for i in range(FILL_WINDOW_MINUTE_COUNT)]
+    expected = [
+        decision_ts_ms + offset * MINUTE_MS
+        for offset in range(1, FILL_WINDOW_MINUTE_COUNT + 1)
+    ]
     return [by_ts.get(ts) for ts in expected]
 
 

--- a/research/alpaca_track_walkforward/fold_schedule.py
+++ b/research/alpaca_track_walkforward/fold_schedule.py
@@ -25,6 +25,7 @@ argument alone.
 
 from __future__ import annotations
 
+import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -36,6 +37,8 @@ __all__ = [
     "ROLL_DAYS",
     "TRAIN_DAYS",
     "Fold",
+    "FoldBindingError",
+    "assert_registered_fold_binding",
     "build_fold_schedule",
 ]
 
@@ -54,13 +57,22 @@ OOS_DAYS = 28
 ROLL_DAYS = 28
 
 
+class FoldBindingError(ValueError):
+    """A fold was not issued by ``build_fold_schedule`` or its public id
+    does not match the issued fold index."""
+
+
+_FOLD_CONSTRUCTION_TOKEN = object()
+_ISSUED_FOLDS: dict[int, weakref.ReferenceType[Fold]] = {}
+
+
 def _int(value: object, name: str) -> int:
     if type(value) is not int:
         raise TypeError(f"{name} must be built-in int")
     return value
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True, init=False)
 class Fold:
     """One walk-forward fold. Every boundary is UTC-half-open ``[start,
     end)``; ``embargo_start_ms == train_end_ms`` and ``oos_start_ms ==
@@ -74,8 +86,40 @@ class Fold:
     oos_start_ms: int
     oos_end_ms: int
 
-    def __post_init__(self) -> None:
+    def __init__(
+        self,
+        fold_index: int,
+        train_start_ms: int,
+        train_end_ms: int,
+        embargo_start_ms: int,
+        embargo_end_ms: int,
+        oos_start_ms: int,
+        oos_end_ms: int,
+        *,
+        _construction_token: object | None = None,
+    ) -> None:
+        if _construction_token is not _FOLD_CONSTRUCTION_TOKEN:
+            raise FoldBindingError(
+                "Fold objects are issued only by build_fold_schedule(); "
+                "direct construction/reconstruction is forbidden"
+            )
+        values = {
+            "fold_index": fold_index,
+            "train_start_ms": train_start_ms,
+            "train_end_ms": train_end_ms,
+            "embargo_start_ms": embargo_start_ms,
+            "embargo_end_ms": embargo_end_ms,
+            "oos_start_ms": oos_start_ms,
+            "oos_end_ms": oos_end_ms,
+        }
+        for name, value in values.items():
+            object.__setattr__(self, name, value)
+        self._validate()
+
+    def _validate(self) -> None:
         _int(self.fold_index, "fold_index")
+        if not 0 <= self.fold_index < OOS_FOLDS:
+            raise ValueError(f"fold_index must be in [0, {OOS_FOLDS})")
         for name in (
             "train_start_ms",
             "train_end_ms",
@@ -95,6 +139,33 @@ class Fold:
             raise ValueError("embargo must start exactly where TRAIN ends (no gap)")
         if self.oos_start_ms != self.embargo_end_ms:
             raise ValueError("OOS must start exactly where embargo ends (no gap)")
+        _assert_utc_monday_midnight(self.oos_start_ms, label="oos_start_ms")
+
+
+def _register_fold(fold: Fold) -> Fold:
+    fold_id = id(fold)
+
+    def _discard(_ref: weakref.ReferenceType[Fold]) -> None:
+        _ISSUED_FOLDS.pop(fold_id, None)
+
+    _ISSUED_FOLDS[fold_id] = weakref.ref(fold, _discard)
+    return fold
+
+
+def assert_registered_fold_binding(*, fold_id: str, fold: Fold) -> None:
+    """Fail closed on direct copies/reconstruction and fold-id swapping."""
+    if type(fold) is not Fold:
+        raise FoldBindingError("fold must be an exact Fold instance")
+    issued_ref = _ISSUED_FOLDS.get(id(fold))
+    if issued_ref is None or issued_ref() is not fold:
+        raise FoldBindingError(
+            "fold was not issued by build_fold_schedule() in this process"
+        )
+    expected_fold_id = f"fold-{fold.fold_index}"
+    if fold_id != expected_fold_id:
+        raise FoldBindingError(
+            f"fold_id {fold_id!r} does not match issued {expected_fold_id!r}"
+        )
 
 
 def _assert_utc_monday_midnight(ts_ms: int, *, label: str) -> None:
@@ -128,14 +199,17 @@ def build_fold_schedule(anchor_oos_start_ms: int) -> tuple[Fold, ...]:
         train_end = embargo_start
         train_start = train_end - TRAIN_DAYS * DAY_MS
         folds.append(
-            Fold(
-                fold_index=i,
-                train_start_ms=train_start,
-                train_end_ms=train_end,
-                embargo_start_ms=embargo_start,
-                embargo_end_ms=embargo_end,
-                oos_start_ms=oos_start,
-                oos_end_ms=oos_end,
+            _register_fold(
+                Fold(
+                    fold_index=i,
+                    train_start_ms=train_start,
+                    train_end_ms=train_end,
+                    embargo_start_ms=embargo_start,
+                    embargo_end_ms=embargo_end,
+                    oos_start_ms=oos_start,
+                    oos_end_ms=oos_end,
+                    _construction_token=_FOLD_CONSTRUCTION_TOKEN,
+                )
             )
         )
     return tuple(folds)

--- a/research/alpaca_track_walkforward/fold_schedule.py
+++ b/research/alpaca_track_walkforward/fold_schedule.py
@@ -6,11 +6,11 @@ exactly 28 days (== the OOS length) fold-to-fold, so consecutive folds' OOS
 windows are back-to-back and non-overlapping.
 
 ``build_fold_schedule`` takes exactly ONE parameter — the first fold's OOS
-start timestamp — and returns ALL 8 folds computed purely from it. There is
-no caller-reachable way to substitute, add, or re-split an individual fold
-(AC6: "fold 교체·추가·재분할은 금지다"): the only way to get a different
-fold 3 is to pass a different anchor, which changes every fold, never one
-in isolation.
+start timestamp — and returns ALL 8 folds computed purely from it. The first
+valid call establishes the process's immutable run identity; later calls may
+repeat that exact anchor but cannot register a second valid Monday anchor.
+There is no caller-reachable way to substitute, add, or re-split an
+individual fold (AC6: "fold 교체·추가·재분할은 금지다").
 
 The anchor is required to be UTC-midnight-aligned AND a Monday. Given
 ``roll_days == oos_days == 28 == 4*7``, adding any whole multiple of 28 days
@@ -25,6 +25,7 @@ argument alone.
 
 from __future__ import annotations
 
+import threading
 import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -64,6 +65,8 @@ class FoldBindingError(ValueError):
 
 _FOLD_CONSTRUCTION_TOKEN = object()
 _ISSUED_FOLDS: dict[int, weakref.ReferenceType[Fold]] = {}
+_SCHEDULE_LOCK = threading.RLock()
+_CANONICAL_ANCHOR_OOS_START_MS: int | None = None
 
 
 def _int(value: object, name: str) -> int:
@@ -166,6 +169,11 @@ def assert_registered_fold_binding(*, fold_id: str, fold: Fold) -> None:
         raise FoldBindingError(
             f"fold_id {fold_id!r} does not match issued {expected_fold_id!r}"
         )
+    fold_anchor = fold.oos_start_ms - fold.fold_index * ROLL_DAYS * DAY_MS
+    if fold_anchor != _CANONICAL_ANCHOR_OOS_START_MS:
+        raise FoldBindingError(
+            "fold does not belong to this process's canonical schedule identity"
+        )
 
 
 def _assert_utc_monday_midnight(ts_ms: int, *, label: str) -> None:
@@ -185,31 +193,43 @@ def build_fold_schedule(anchor_oos_start_ms: int) -> tuple[Fold, ...]:
     ``anchor_oos_start_ms`` must be UTC-midnight-aligned and a Monday (see
     module docstring for why this one constraint is sufficient for AC2).
     Fails closed (raises) otherwise — never silently rounds/shifts the
-    anchor to the nearest valid instant.
+    anchor to the nearest valid instant. The first accepted anchor becomes
+    the sole process-level schedule identity; a different otherwise-valid
+    anchor is rejected rather than issuing another object called ``fold-0``.
     """
     _int(anchor_oos_start_ms, "anchor_oos_start_ms")
     _assert_utc_monday_midnight(anchor_oos_start_ms, label="anchor_oos_start_ms")
 
-    folds: list[Fold] = []
-    for i in range(OOS_FOLDS):
-        oos_start = anchor_oos_start_ms + i * ROLL_DAYS * DAY_MS
-        oos_end = oos_start + OOS_DAYS * DAY_MS
-        embargo_end = oos_start
-        embargo_start = embargo_end - EMBARGO_DAYS * DAY_MS
-        train_end = embargo_start
-        train_start = train_end - TRAIN_DAYS * DAY_MS
-        folds.append(
-            _register_fold(
-                Fold(
-                    fold_index=i,
-                    train_start_ms=train_start,
-                    train_end_ms=train_end,
-                    embargo_start_ms=embargo_start,
-                    embargo_end_ms=embargo_end,
-                    oos_start_ms=oos_start,
-                    oos_end_ms=oos_end,
-                    _construction_token=_FOLD_CONSTRUCTION_TOKEN,
+    global _CANONICAL_ANCHOR_OOS_START_MS
+    with _SCHEDULE_LOCK:
+        if _CANONICAL_ANCHOR_OOS_START_MS is None:
+            _CANONICAL_ANCHOR_OOS_START_MS = anchor_oos_start_ms
+        elif anchor_oos_start_ms != _CANONICAL_ANCHOR_OOS_START_MS:
+            raise FoldBindingError(
+                "a different walk-forward anchor cannot be registered after "
+                "the canonical schedule identity has been established"
+            )
+
+        folds: list[Fold] = []
+        for i in range(OOS_FOLDS):
+            oos_start = anchor_oos_start_ms + i * ROLL_DAYS * DAY_MS
+            oos_end = oos_start + OOS_DAYS * DAY_MS
+            embargo_end = oos_start
+            embargo_start = embargo_end - EMBARGO_DAYS * DAY_MS
+            train_end = embargo_start
+            train_start = train_end - TRAIN_DAYS * DAY_MS
+            folds.append(
+                _register_fold(
+                    Fold(
+                        fold_index=i,
+                        train_start_ms=train_start,
+                        train_end_ms=train_end,
+                        embargo_start_ms=embargo_start,
+                        embargo_end_ms=embargo_end,
+                        oos_start_ms=oos_start,
+                        oos_end_ms=oos_end,
+                        _construction_token=_FOLD_CONSTRUCTION_TOKEN,
+                    )
                 )
             )
-        )
-    return tuple(folds)
+        return tuple(folds)

--- a/research/alpaca_track_walkforward/fold_schedule.py
+++ b/research/alpaca_track_walkforward/fold_schedule.py
@@ -1,0 +1,141 @@
+"""ROB-1062 H4 (Run A SS15, AC1-AC6) — the 8-fold walk-forward schedule.
+
+Each fold is TRAIN(365 days) -> embargo(7 days) -> OOS(28 days), contiguous,
+UTC half-open ``[start, end)`` throughout, and the schedule rolls forward by
+exactly 28 days (== the OOS length) fold-to-fold, so consecutive folds' OOS
+windows are back-to-back and non-overlapping.
+
+``build_fold_schedule`` takes exactly ONE parameter — the first fold's OOS
+start timestamp — and returns ALL 8 folds computed purely from it. There is
+no caller-reachable way to substitute, add, or re-split an individual fold
+(AC6: "fold 교체·추가·재분할은 금지다"): the only way to get a different
+fold 3 is to pass a different anchor, which changes every fold, never one
+in isolation.
+
+The anchor is required to be UTC-midnight-aligned AND a Monday. Given
+``roll_days == oos_days == 28 == 4*7``, adding any whole multiple of 28 days
+to a Monday-midnight timestamp always yields another Monday-midnight
+timestamp — so this ONE constraint on the anchor is sufficient to guarantee,
+for every one of the 8 OOS windows, that AP-A2's weekly Monday-00:05-UTC
+decision lands exactly 4 times (AC2) without re-deriving the constraint
+per-fold. ``tests/test_fold_schedule.py`` proves this by literal calendar
+walk (a real per-minute assertion), never by trusting this arithmetic
+argument alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+__all__ = [
+    "DAY_MS",
+    "EMBARGO_DAYS",
+    "OOS_DAYS",
+    "OOS_FOLDS",
+    "ROLL_DAYS",
+    "TRAIN_DAYS",
+    "Fold",
+    "build_fold_schedule",
+]
+
+DAY_MS = 86_400_000
+
+# Run A SS15 — literal, sealed schedule shape. These are schedule-STRUCTURE
+# constants (fold count/window lengths), not gate thresholds or cost
+# assumptions, so they are NOT read through the H2 seal (H2's `policy`
+# identity component independently carries the SAME literals for the
+# ROB-846 identity hash — see `seal_consumption.assert_policy_matches_
+# schedule_constants`, which fails closed if the two ever diverge).
+OOS_FOLDS = 8
+TRAIN_DAYS = 365
+EMBARGO_DAYS = 7
+OOS_DAYS = 28
+ROLL_DAYS = 28
+
+
+def _int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be built-in int")
+    return value
+
+
+@dataclass(frozen=True)
+class Fold:
+    """One walk-forward fold. Every boundary is UTC-half-open ``[start,
+    end)``; ``embargo_start_ms == train_end_ms`` and ``oos_start_ms ==
+    embargo_end_ms`` always hold (contiguous, no gap, no overlap)."""
+
+    fold_index: int
+    train_start_ms: int
+    train_end_ms: int
+    embargo_start_ms: int
+    embargo_end_ms: int
+    oos_start_ms: int
+    oos_end_ms: int
+
+    def __post_init__(self) -> None:
+        _int(self.fold_index, "fold_index")
+        for name in (
+            "train_start_ms",
+            "train_end_ms",
+            "embargo_start_ms",
+            "embargo_end_ms",
+            "oos_start_ms",
+            "oos_end_ms",
+        ):
+            _int(getattr(self, name), name)
+        if self.train_end_ms - self.train_start_ms != TRAIN_DAYS * DAY_MS:
+            raise ValueError("train window must be exactly TRAIN_DAYS long")
+        if self.embargo_end_ms - self.embargo_start_ms != EMBARGO_DAYS * DAY_MS:
+            raise ValueError("embargo window must be exactly EMBARGO_DAYS long")
+        if self.oos_end_ms - self.oos_start_ms != OOS_DAYS * DAY_MS:
+            raise ValueError("OOS window must be exactly OOS_DAYS long")
+        if self.embargo_start_ms != self.train_end_ms:
+            raise ValueError("embargo must start exactly where TRAIN ends (no gap)")
+        if self.oos_start_ms != self.embargo_end_ms:
+            raise ValueError("OOS must start exactly where embargo ends (no gap)")
+
+
+def _assert_utc_monday_midnight(ts_ms: int, *, label: str) -> None:
+    if ts_ms % DAY_MS != 0:
+        raise ValueError(f"{label} must be UTC midnight aligned, got {ts_ms}")
+    dt = datetime.fromtimestamp(ts_ms / 1000, tz=UTC)
+    if dt.weekday() != 0:
+        raise ValueError(
+            f"{label} must fall on a Monday (weekday()==0), got weekday="
+            f"{dt.weekday()} for {ts_ms}"
+        )
+
+
+def build_fold_schedule(anchor_oos_start_ms: int) -> tuple[Fold, ...]:
+    """Build all 8 folds from a single anchor: the FIRST fold's OOS start.
+
+    ``anchor_oos_start_ms`` must be UTC-midnight-aligned and a Monday (see
+    module docstring for why this one constraint is sufficient for AC2).
+    Fails closed (raises) otherwise — never silently rounds/shifts the
+    anchor to the nearest valid instant.
+    """
+    _int(anchor_oos_start_ms, "anchor_oos_start_ms")
+    _assert_utc_monday_midnight(anchor_oos_start_ms, label="anchor_oos_start_ms")
+
+    folds: list[Fold] = []
+    for i in range(OOS_FOLDS):
+        oos_start = anchor_oos_start_ms + i * ROLL_DAYS * DAY_MS
+        oos_end = oos_start + OOS_DAYS * DAY_MS
+        embargo_end = oos_start
+        embargo_start = embargo_end - EMBARGO_DAYS * DAY_MS
+        train_end = embargo_start
+        train_start = train_end - TRAIN_DAYS * DAY_MS
+        folds.append(
+            Fold(
+                fold_index=i,
+                train_start_ms=train_start,
+                train_end_ms=train_end,
+                embargo_start_ms=embargo_start,
+                embargo_end_ms=embargo_end,
+                oos_start_ms=oos_start,
+                oos_end_ms=oos_end,
+            )
+        )
+    return tuple(folds)

--- a/research/alpaca_track_walkforward/fold_schedule.py
+++ b/research/alpaca_track_walkforward/fold_schedule.py
@@ -6,9 +6,9 @@ exactly 28 days (== the OOS length) fold-to-fold, so consecutive folds' OOS
 windows are back-to-back and non-overlapping.
 
 ``build_fold_schedule`` takes exactly ONE parameter — the first fold's OOS
-start timestamp — and returns ALL 8 folds computed purely from it. The first
-valid call establishes the process's immutable run identity; later calls may
-repeat that exact anchor but cannot register a second valid Monday anchor.
+start timestamp — and returns ALL 8 folds computed purely from it. The anchor
+is read from the immutable canonical run manifest, not learned from a
+caller's first invocation, so the same identity survives process restarts.
 There is no caller-reachable way to substitute, add, or re-split an
 individual fold (AC6: "fold 교체·추가·재분할은 금지다").
 
@@ -25,10 +25,11 @@ argument alone.
 
 from __future__ import annotations
 
-import threading
 import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
+
+import run_manifest as rm
 
 __all__ = [
     "DAY_MS",
@@ -65,8 +66,6 @@ class FoldBindingError(ValueError):
 
 _FOLD_CONSTRUCTION_TOKEN = object()
 _ISSUED_FOLDS: dict[int, weakref.ReferenceType[Fold]] = {}
-_SCHEDULE_LOCK = threading.RLock()
-_CANONICAL_ANCHOR_OOS_START_MS: int | None = None
 
 
 def _int(value: object, name: str) -> int:
@@ -170,9 +169,9 @@ def assert_registered_fold_binding(*, fold_id: str, fold: Fold) -> None:
             f"fold_id {fold_id!r} does not match issued {expected_fold_id!r}"
         )
     fold_anchor = fold.oos_start_ms - fold.fold_index * ROLL_DAYS * DAY_MS
-    if fold_anchor != _CANONICAL_ANCHOR_OOS_START_MS:
+    if fold_anchor != rm.canonical_run_manifest().anchor_oos_start_ms:
         raise FoldBindingError(
-            "fold does not belong to this process's canonical schedule identity"
+            "fold does not belong to the immutable canonical run manifest"
         )
 
 
@@ -193,43 +192,37 @@ def build_fold_schedule(anchor_oos_start_ms: int) -> tuple[Fold, ...]:
     ``anchor_oos_start_ms`` must be UTC-midnight-aligned and a Monday (see
     module docstring for why this one constraint is sufficient for AC2).
     Fails closed (raises) otherwise — never silently rounds/shifts the
-    anchor to the nearest valid instant. The first accepted anchor becomes
-    the sole process-level schedule identity; a different otherwise-valid
-    anchor is rejected rather than issuing another object called ``fold-0``.
+    anchor to the nearest valid instant. A different otherwise-valid anchor
+    is rejected before any fold is issued.
     """
     _int(anchor_oos_start_ms, "anchor_oos_start_ms")
     _assert_utc_monday_midnight(anchor_oos_start_ms, label="anchor_oos_start_ms")
 
-    global _CANONICAL_ANCHOR_OOS_START_MS
-    with _SCHEDULE_LOCK:
-        if _CANONICAL_ANCHOR_OOS_START_MS is None:
-            _CANONICAL_ANCHOR_OOS_START_MS = anchor_oos_start_ms
-        elif anchor_oos_start_ms != _CANONICAL_ANCHOR_OOS_START_MS:
-            raise FoldBindingError(
-                "a different walk-forward anchor cannot be registered after "
-                "the canonical schedule identity has been established"
-            )
+    if anchor_oos_start_ms != rm.canonical_run_manifest().anchor_oos_start_ms:
+        raise FoldBindingError(
+            "anchor does not match the immutable canonical run manifest"
+        )
 
-        folds: list[Fold] = []
-        for i in range(OOS_FOLDS):
-            oos_start = anchor_oos_start_ms + i * ROLL_DAYS * DAY_MS
-            oos_end = oos_start + OOS_DAYS * DAY_MS
-            embargo_end = oos_start
-            embargo_start = embargo_end - EMBARGO_DAYS * DAY_MS
-            train_end = embargo_start
-            train_start = train_end - TRAIN_DAYS * DAY_MS
-            folds.append(
-                _register_fold(
-                    Fold(
-                        fold_index=i,
-                        train_start_ms=train_start,
-                        train_end_ms=train_end,
-                        embargo_start_ms=embargo_start,
-                        embargo_end_ms=embargo_end,
-                        oos_start_ms=oos_start,
-                        oos_end_ms=oos_end,
-                        _construction_token=_FOLD_CONSTRUCTION_TOKEN,
-                    )
+    folds: list[Fold] = []
+    for i in range(OOS_FOLDS):
+        oos_start = anchor_oos_start_ms + i * ROLL_DAYS * DAY_MS
+        oos_end = oos_start + OOS_DAYS * DAY_MS
+        embargo_end = oos_start
+        embargo_start = embargo_end - EMBARGO_DAYS * DAY_MS
+        train_end = embargo_start
+        train_start = train_end - TRAIN_DAYS * DAY_MS
+        folds.append(
+            _register_fold(
+                Fold(
+                    fold_index=i,
+                    train_start_ms=train_start,
+                    train_end_ms=train_end,
+                    embargo_start_ms=embargo_start,
+                    embargo_end_ms=embargo_end,
+                    oos_start_ms=oos_start,
+                    oos_end_ms=oos_end,
+                    _construction_token=_FOLD_CONSTRUCTION_TOKEN,
                 )
             )
-        return tuple(folds)
+        )
+    return tuple(folds)

--- a/research/alpaca_track_walkforward/oos_mask.py
+++ b/research/alpaca_track_walkforward/oos_mask.py
@@ -462,6 +462,12 @@ def issue_dry_count_pass(
     if fingerprint != record.counts_fingerprint:
         raise OOSMaskBypassError("bound dry counts changed after mask issuance")
     sealed_minimum = wf_seal.min_modeled_entries_per_fold()
+    if dry_counts.is_incomplete:
+        raise OOSMaskBypassError("incomplete dry counts can never issue PASS")
+    if dry_counts.modeled_entries_count < sealed_minimum:
+        raise OOSMaskBypassError(
+            "bound dry count is below the sealed minimum modeled entries"
+        )
     vault_token = _vault().call(("ISSUE", record.vault_handle, fingerprint))
 
     evidence = object.__new__(DryCountPassEvidence)

--- a/research/alpaca_track_walkforward/oos_mask.py
+++ b/research/alpaca_track_walkforward/oos_mask.py
@@ -1,162 +1,103 @@
-"""ROB-1062 H4 (Run A SS15, AC22-AC25) — the OOS PnL masking guarantee.
+"""ROB-1062 H4 (AC22-AC25) — fail-closed OOS PnL masking.
 
-This is the single most consequential module in H4: H5's entire PnL-blind
-dry-count gate rests on the property that an OOS PnL value produced by this
-package CANNOT be read by any caller — API, report, log line, ``__repr__``,
-debug helper, pickle/JSON round-trip, or exception message — until an
-explicit ``unmask()`` call is presented with a genuine, matching
-``DryCountPassEvidence`` (which only H5 is positioned to construct, since
-only H5 owns the dry-count gate itself).
+``Masked`` never retains the source object, a closure over it, plaintext
+pickle bytes, ciphertext, or a caller-reachable reveal callable. ``mask``
+serializes the value immediately and transfers it into an isolated local
+vault process. The public object contains binding metadata only.
 
-Design (why this resists the concrete bypass routes AC24 names):
+Unmask authority is not a public dataclass constructor. H5 must call
+``issue_dry_count_pass`` with the exact ``BlindCounts`` object that H4 bound
+to the masked value at creation. Issuance rechecks that object's fingerprint,
+the sealed minimum-entry threshold, and incomplete status inside both the
+caller and the isolated vault. Evidence reconstructed with ``object.__new__``,
+copied, subclassed, or mutated is absent from the issuance registry and is
+rejected.
 
-1. **The raw value is never stored as a readable attribute at all.** It
-   lives ONLY inside a closure cell captured by a per-instance gated
-   callable (``_reveal``). ``Masked`` has NO slot/attribute whose value IS
-   the raw PnL — so even direct, no-holds-barred attribute access
-   (``masked._reveal``, or ``object.__getattribute__(masked, "_reveal")``,
-   which would trivially defeat a ``__getattribute__``-override-based
-   design) only ever recovers a FUNCTION, which itself still demands the
-   correct, non-exported sentinel token before it will return anything. A
-   slot/attribute-based "private" field (name-mangled or not) would NOT
-   have this property: a slot descriptor just returns its stored value to
-   ANY attribute-access route, override or no override — that design was
-   considered and rejected in favor of the closure (see
-   ``tests/test_oos_mask.py::test_direct_attribute_access_to_the_closure_
-   itself_never_yields_the_raw_value``, which is the regression test for
-   exactly that near-miss).
-2. ``__repr__``/``__str__`` never format the raw value — only the public,
-   non-sensitive binding (``fold_id``/``family``/``config_id``).
-3. ``__reduce__``/``__getstate__`` raise — a ``Masked`` value can never be
-   pickled (and therefore never persisted to disk, logged via a pickling
-   logger, or survive a ``copy.deepcopy``, which falls back to the same
-   protocol).
-4. ``__eq__``/``__hash__`` raise — comparison is blocked so a caller cannot
-   use repeated equality probes as an oracle to binary-search the hidden
-   value.
-5. ``unmask()`` additionally verifies the supplied evidence's
-   ``(fold_id, family, config_id)`` binding matches the masked value's own
-   — a genuine PASS evidence for a DIFFERENT fold/config can never unmask
-   THIS value (closing the "reuse someone else's passing evidence" route).
-
-Scope honesty: this is a research-backtest guarantee against the concrete,
-named bypass classes in AC24 (direct field access, debug/repr output,
-pickle/JSON round-trip, exception-message leakage, evidence reuse across
-folds/configs) — it is not a defense against a caller willing to import this
-module's own private, non-exported sentinel object and hand it to the
-closure directly (``from oos_mask import _AUTHORIZED_UNMASK_TOKEN`` reaches
-past every public surface this module exposes). That residual gap is
-recorded here explicitly rather than silently, per the same "flag it, don't
-hide it" discipline H3 used for its own documented open choices.
+Native debuggers able to read another process's address space are outside the
+threat model. Ordinary Python reflection, closure inspection, object graph
+walking, private-name imports, copying, and serialization stay in the caller
+process and cannot recover the vault payload.
 """
 
 from __future__ import annotations
 
+import atexit
+import hashlib
+import multiprocessing
+import os
+import pickle
+import threading
+import weakref
 from dataclasses import dataclass
 from typing import Any
+
+import blind_counts as bc
+import wf_seal_consumption as wf_seal
 
 __all__ = [
     "DryCountPassEvidence",
     "Masked",
     "OOSMaskBypassError",
+    "issue_dry_count_pass",
     "mask",
     "unmask",
 ]
 
 
 class OOSMaskBypassError(RuntimeError):
-    """Raised whenever code attempts to read a masked OOS PnL value without
-    a matching, genuine dry-count PASS evidence."""
+    """A masked value or PASS authority failed an integrity check."""
 
 
-# Not exported (absent from __all__, single leading underscore only as a
-# naming convention — see the module docstring's "scope honesty" note for
-# what this does and does not defend against).
-_AUTHORIZED_UNMASK_TOKEN = object()
+def _binding_tuple(
+    *, fold_id: str, family: str, config_id: str
+) -> tuple[str, str, str]:
+    if (
+        type(fold_id) is not str
+        or type(family) is not str
+        or type(config_id) is not str
+    ):
+        raise TypeError("mask binding values must be built-in str")
+    return (fold_id, family, config_id)
 
 
-def _int(value: object, name: str) -> int:
-    if type(value) is not int:
-        raise TypeError(f"{name} must be built-in int")
-    return value
-
-
-@dataclass(frozen=True)
-class DryCountPassEvidence:
-    """H5's dry-count PASS evidence, scoped to exactly ONE
-    ``(fold_id, family, config_id)``. This type can only ever represent a
-    genuine PASS — ``__post_init__`` refuses to construct a "fail" instance,
-    so there is no way to build a plausible-looking-but-fake unmask key by
-    accident; H5's own (out-of-H4-scope) dry-count report type is where a
-    FAIL outcome is recorded."""
-
-    fold_id: str
-    family: str
-    config_id: str
-    modeled_entries: int
-    min_modeled_entries_per_fold: int
-    passed: bool
-
-    def __post_init__(self) -> None:
-        _int(self.modeled_entries, "modeled_entries")
-        _int(self.min_modeled_entries_per_fold, "min_modeled_entries_per_fold")
-        if type(self.passed) is not bool:
-            raise TypeError("passed must be built-in bool")
-        if not self.passed:
-            raise ValueError(
-                "DryCountPassEvidence can only represent a genuine PASS — "
-                "never construct one to represent a fail/insufficient-sample "
-                "outcome"
-            )
-        if self.modeled_entries < self.min_modeled_entries_per_fold:
-            raise ValueError(
-                f"modeled_entries={self.modeled_entries} is below "
-                f"min_modeled_entries_per_fold={self.min_modeled_entries_per_fold} "
-                "— this cannot be a genuine PASS"
-            )
-
-    def binding_key(self) -> tuple[str, str, str]:
-        return (self.fold_id, self.family, self.config_id)
+def _counts_fingerprint(counts: bc.BlindCounts) -> str:
+    payload = (
+        counts.total_decision_records,
+        counts.modeled_entries_count,
+        counts.closed_trades_count,
+        counts.open_positions_count,
+        counts.entry_unfilled_count,
+        counts.exit_unfilled_count,
+        counts.fill_window_incomplete_count,
+        counts.holding_days,
+        tuple(sorted(counts.reason_code_histogram.items())),
+        counts.is_incomplete,
+    )
+    return hashlib.sha256(pickle.dumps(payload, protocol=5)).hexdigest()
 
 
 class Masked:
-    """An opaque, unreadable wrapper around one OOS PnL value. See module
-    docstring for the full bypass-resistance rationale."""
+    """Opaque public handle. No payload, vault id, key, or reveal slot."""
 
-    __slots__ = ("_fold_id", "_family", "_config_id", "_reveal")
+    __slots__ = ("_fold_id", "_family", "_config_id", "__weakref__")
 
-    def __init__(
-        self, raw_value: Any, *, fold_id: str, family: str, config_id: str
-    ) -> None:
-        def _reveal(token: object) -> Any:
-            if token is not _AUTHORIZED_UNMASK_TOKEN:
-                raise OOSMaskBypassError(
-                    "direct access to a masked OOS PnL value is forbidden — "
-                    "call oos_mask.unmask(masked, evidence) with H5's "
-                    "dry-count PASS evidence"
-                )
-            return raw_value
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise OOSMaskBypassError("Masked instances can only be issued by mask()")
 
-        object.__setattr__(self, "_fold_id", fold_id)
-        object.__setattr__(self, "_family", family)
-        object.__setattr__(self, "_config_id", config_id)
-        object.__setattr__(self, "_reveal", _reveal)
-
-    # ---- metadata (safe, non-sensitive) -------------------------------- #
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        raise TypeError("Masked cannot be subclassed")
 
     @property
     def fold_id(self) -> str:
-        return self._fold_id
+        return object.__getattribute__(self, "_fold_id")
 
     @property
     def family(self) -> str:
-        return self._family
+        return object.__getattribute__(self, "_family")
 
     @property
     def config_id(self) -> str:
-        return self._config_id
-
-    # ---- bypass-resistance surface ------------------------------------- #
+        return object.__getattribute__(self, "_config_id")
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise OOSMaskBypassError("Masked values are immutable")
@@ -166,58 +107,405 @@ class Masked:
 
     def __repr__(self) -> str:
         return (
-            f"Masked(fold_id={self._fold_id!r}, family={self._family!r}, "
-            f"config_id={self._config_id!r}, value=<masked>)"
+            f"Masked(fold_id={self.fold_id!r}, family={self.family!r}, "
+            f"config_id={self.config_id!r}, value=<masked>)"
         )
 
     __str__ = __repr__
 
     def __reduce__(self) -> Any:
-        raise OOSMaskBypassError(
-            "Masked values must never be pickled (would persist raw OOS PnL "
-            "to disk unmasked)"
-        )
+        raise OOSMaskBypassError("Masked values cannot be copied or pickled")
+
+    def __reduce_ex__(self, protocol: int) -> Any:
+        raise OOSMaskBypassError("Masked values cannot be copied or pickled")
 
     def __getstate__(self) -> Any:
-        raise OOSMaskBypassError(
-            "Masked values must never be pickled/deepcopy-serialized"
-        )
+        raise OOSMaskBypassError("Masked values cannot be serialized")
+
+    def __copy__(self) -> Any:
+        raise OOSMaskBypassError("Masked values cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, object]) -> Any:
+        raise OOSMaskBypassError("Masked values cannot be deep-copied")
 
     def __eq__(self, other: object) -> bool:
-        raise OOSMaskBypassError(
-            "Masked values cannot be compared — repeated equality probes "
-            "could be used as an oracle to infer the raw value"
-        )
+        raise OOSMaskBypassError("Masked values cannot be compared")
 
     __hash__ = None  # type: ignore[assignment]
 
 
-def mask(raw_value: Any, *, fold_id: str, family: str, config_id: str) -> Masked:
-    """Wrap ``raw_value`` (an OOS ``pnl_views.ThreeViewPnL``, a bare float,
-    or any other OOS-PnL-shaped value) as masked-by-default, bound to
-    exactly one ``(fold_id, family, config_id)``."""
-    return Masked(raw_value, fold_id=fold_id, family=family, config_id=config_id)
+class DryCountPassEvidence:
+    """Registry-backed evidence issued only for an actual bound dry count."""
+
+    __slots__ = (
+        "_fold_id",
+        "_family",
+        "_config_id",
+        "_modeled_entries",
+        "_min_modeled_entries_per_fold",
+        "__weakref__",
+    )
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise OOSMaskBypassError(
+            "DryCountPassEvidence cannot be constructed externally; "
+            "call issue_dry_count_pass(masked, actual_blind_counts)"
+        )
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        raise TypeError("DryCountPassEvidence cannot be subclassed")
+
+    @property
+    def fold_id(self) -> str:
+        return object.__getattribute__(self, "_fold_id")
+
+    @property
+    def family(self) -> str:
+        return object.__getattribute__(self, "_family")
+
+    @property
+    def config_id(self) -> str:
+        return object.__getattribute__(self, "_config_id")
+
+    @property
+    def modeled_entries(self) -> int:
+        return object.__getattribute__(self, "_modeled_entries")
+
+    @property
+    def min_modeled_entries_per_fold(self) -> int:
+        return object.__getattribute__(self, "_min_modeled_entries_per_fold")
+
+    @property
+    def passed(self) -> bool:
+        return True
+
+    def binding_key(self) -> tuple[str, str, str]:
+        return (self.fold_id, self.family, self.config_id)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise OOSMaskBypassError("DryCountPassEvidence is immutable")
+
+    def __delattr__(self, name: str) -> None:
+        raise OOSMaskBypassError("DryCountPassEvidence is immutable")
+
+    def __repr__(self) -> str:
+        return (
+            "DryCountPassEvidence("
+            f"fold_id={self.fold_id!r}, family={self.family!r}, "
+            f"config_id={self.config_id!r}, modeled_entries={self.modeled_entries}, "
+            f"min_modeled_entries_per_fold={self.min_modeled_entries_per_fold}, "
+            "passed=True)"
+        )
+
+    def __reduce__(self) -> Any:
+        raise OOSMaskBypassError("PASS evidence cannot be copied or serialized")
+
+    def __reduce_ex__(self, protocol: int) -> Any:
+        raise OOSMaskBypassError("PASS evidence cannot be copied or serialized")
+
+    def __copy__(self) -> Any:
+        raise OOSMaskBypassError("PASS evidence cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, object]) -> Any:
+        raise OOSMaskBypassError("PASS evidence cannot be deep-copied")
+
+
+def _vault_worker(connection: Any) -> None:
+    """Own plaintext payloads and PASS tokens outside the caller process."""
+    masks: dict[int, dict[str, Any]] = {}
+    passes: dict[bytes, int] = {}
+    next_handle = 1
+    while True:
+        try:
+            request = connection.recv()
+        except EOFError:
+            return
+        operation = request[0]
+        try:
+            if operation == "CREATE":
+                (
+                    _operation,
+                    payload,
+                    binding,
+                    counts_fingerprint,
+                    modeled_entries,
+                    is_incomplete,
+                    sealed_minimum,
+                ) = request
+                handle = next_handle
+                next_handle += 1
+                masks[handle] = {
+                    "payload": payload,
+                    "binding": binding,
+                    "counts_fingerprint": counts_fingerprint,
+                    "modeled_entries": modeled_entries,
+                    "is_incomplete": is_incomplete,
+                    "sealed_minimum": sealed_minimum,
+                    "consumed": False,
+                }
+                connection.send(("OK", handle))
+            elif operation == "ISSUE":
+                _operation, handle, counts_fingerprint = request
+                record = masks.get(handle)
+                if record is None:
+                    raise OOSMaskBypassError("unknown masked handle")
+                if counts_fingerprint != record["counts_fingerprint"]:
+                    raise OOSMaskBypassError("dry-count fingerprint mismatch")
+                if record["is_incomplete"]:
+                    raise OOSMaskBypassError(
+                        "incomplete dry counts can never issue PASS"
+                    )
+                if record["modeled_entries"] < record["sealed_minimum"]:
+                    raise OOSMaskBypassError(
+                        "bound dry count is below the sealed minimum modeled entries"
+                    )
+                token = os.urandom(32)
+                passes[token] = handle
+                connection.send(("OK", token))
+            elif operation == "REVEAL":
+                _operation, handle, token = request
+                record = masks.get(handle)
+                if record is not None and record["consumed"]:
+                    raise OOSMaskBypassError(
+                        "masked OOS PnL has already been unmasked once"
+                    )
+                if record is None or passes.get(token) != handle:
+                    raise OOSMaskBypassError("PASS token is not valid for this mask")
+                record["consumed"] = True
+                passes.pop(token, None)
+                payload = record["payload"]
+                record["payload"] = None
+                connection.send(("OK", payload))
+            elif operation == "DROP":
+                _operation, handle = request
+                masks.pop(handle, None)
+                for token, token_handle in tuple(passes.items()):
+                    if token_handle == handle:
+                        passes.pop(token, None)
+                connection.send(("OK", None))
+            elif operation == "STOP":
+                connection.send(("OK", None))
+                return
+            else:
+                raise OOSMaskBypassError("unknown vault operation")
+        except Exception as exc:
+            connection.send(("ERROR", type(exc).__name__, str(exc)))
+
+
+class _VaultClient:
+    __slots__ = ("_connection", "_lock", "_process")
+
+    def __init__(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        parent, child = context.Pipe()
+        process = context.Process(
+            target=_vault_worker,
+            args=(child,),
+            name="rob1062-oos-mask-vault",
+            daemon=True,
+        )
+        process.start()
+        child.close()
+        self._connection = parent
+        self._lock = threading.RLock()
+        self._process = process
+
+    def call(self, request: tuple[Any, ...]) -> Any:
+        with self._lock:
+            self._connection.send(request)
+            response = self._connection.recv()
+        if response[0] == "OK":
+            return response[1]
+        raise OOSMaskBypassError(response[2])
+
+    def stop(self) -> None:
+        if self._process.is_alive():
+            try:
+                self.call(("STOP",))
+            except (EOFError, OSError, OOSMaskBypassError):
+                pass
+            self._process.join(timeout=1.0)
+        self._connection.close()
+
+
+@dataclass(slots=True)
+class _MaskRecord:
+    masked_ref: weakref.ReferenceType[Masked]
+    binding: tuple[str, str, str]
+    vault_handle: int
+    counts: bc.BlindCounts
+    counts_fingerprint: str
+
+
+@dataclass(slots=True)
+class _EvidenceRecord:
+    evidence_ref: weakref.ReferenceType[DryCountPassEvidence]
+    masked_id: int
+    binding: tuple[str, str, str]
+    counts_fingerprint: str
+    vault_token: bytes
+
+
+_VAULT: _VaultClient | None = None
+_VAULT_LOCK = threading.RLock()
+_MASKS: dict[int, _MaskRecord] = {}
+_EVIDENCES: dict[int, _EvidenceRecord] = {}
+
+
+def _vault() -> _VaultClient:
+    global _VAULT
+    with _VAULT_LOCK:
+        if _VAULT is None:
+            _VAULT = _VaultClient()
+        return _VAULT
+
+
+def _stop_vault() -> None:
+    global _VAULT
+    with _VAULT_LOCK:
+        if _VAULT is not None:
+            _VAULT.stop()
+            _VAULT = None
+
+
+atexit.register(_stop_vault)
+
+
+def _drop_mask(masked_id: int, vault_handle: int):
+    def discard(_ref: weakref.ReferenceType[Masked]) -> None:
+        _MASKS.pop(masked_id, None)
+        if _VAULT is None:
+            return
+        try:
+            _VAULT.call(("DROP", vault_handle))
+        except (EOFError, OSError, OOSMaskBypassError):
+            pass
+
+    return discard
+
+
+def _drop_evidence(evidence_id: int):
+    def discard(_ref: weakref.ReferenceType[DryCountPassEvidence]) -> None:
+        _EVIDENCES.pop(evidence_id, None)
+
+    return discard
+
+
+def _record_for(masked: Masked) -> _MaskRecord:
+    if type(masked) is not Masked:
+        raise TypeError("expected an exact Masked instance")
+    record = _MASKS.get(id(masked))
+    if record is None or record.masked_ref() is not masked:
+        raise OOSMaskBypassError("masked handle is reconstructed or not issued")
+    if (masked.fold_id, masked.family, masked.config_id) != record.binding:
+        raise OOSMaskBypassError("masked binding integrity check failed")
+    return record
+
+
+def mask(
+    raw_value: Any,
+    *,
+    fold_id: str,
+    family: str,
+    config_id: str,
+    dry_counts: bc.BlindCounts,
+) -> Masked:
+    """Transfer one OOS value to the vault and bind its actual dry counts."""
+    if type(dry_counts) is not bc.BlindCounts:
+        raise TypeError("dry_counts must be an exact BlindCounts instance")
+    binding = _binding_tuple(fold_id=fold_id, family=family, config_id=config_id)
+    counts_fingerprint = _counts_fingerprint(dry_counts)
+    payload = pickle.dumps(raw_value, protocol=5)
+    try:
+        vault_handle = _vault().call(
+            (
+                "CREATE",
+                payload,
+                binding,
+                counts_fingerprint,
+                dry_counts.modeled_entries_count,
+                dry_counts.is_incomplete,
+                wf_seal.min_modeled_entries_per_fold(),
+            )
+        )
+    finally:
+        del payload
+
+    masked = object.__new__(Masked)
+    object.__setattr__(masked, "_fold_id", fold_id)
+    object.__setattr__(masked, "_family", family)
+    object.__setattr__(masked, "_config_id", config_id)
+    masked_id = id(masked)
+    masked_ref = weakref.ref(masked, _drop_mask(masked_id, vault_handle))
+    _MASKS[masked_id] = _MaskRecord(
+        masked_ref=masked_ref,
+        binding=binding,
+        vault_handle=vault_handle,
+        counts=dry_counts,
+        counts_fingerprint=counts_fingerprint,
+    )
+    return masked
+
+
+def issue_dry_count_pass(
+    masked: Masked, dry_counts: bc.BlindCounts
+) -> DryCountPassEvidence:
+    """Issue PASS only for the exact bound counts and sealed threshold."""
+    record = _record_for(masked)
+    if type(dry_counts) is not bc.BlindCounts:
+        raise TypeError("dry_counts must be an exact BlindCounts instance")
+    if record.counts is not dry_counts:
+        raise OOSMaskBypassError(
+            "dry counts are not the actual object bound by H4 to this mask"
+        )
+    fingerprint = _counts_fingerprint(dry_counts)
+    if fingerprint != record.counts_fingerprint:
+        raise OOSMaskBypassError("bound dry counts changed after mask issuance")
+    sealed_minimum = wf_seal.min_modeled_entries_per_fold()
+    vault_token = _vault().call(("ISSUE", record.vault_handle, fingerprint))
+
+    evidence = object.__new__(DryCountPassEvidence)
+    for name, value in (
+        ("_fold_id", record.binding[0]),
+        ("_family", record.binding[1]),
+        ("_config_id", record.binding[2]),
+        ("_modeled_entries", dry_counts.modeled_entries_count),
+        ("_min_modeled_entries_per_fold", sealed_minimum),
+    ):
+        object.__setattr__(evidence, name, value)
+    evidence_id = id(evidence)
+    evidence_ref = weakref.ref(evidence, _drop_evidence(evidence_id))
+    _EVIDENCES[evidence_id] = _EvidenceRecord(
+        evidence_ref=evidence_ref,
+        masked_id=id(masked),
+        binding=record.binding,
+        counts_fingerprint=fingerprint,
+        vault_token=vault_token,
+    )
+    return evidence
 
 
 def unmask(masked: Masked, evidence: DryCountPassEvidence) -> Any:
-    """The ONLY sanctioned way to read a masked OOS PnL value: requires a
-    genuine ``DryCountPassEvidence`` whose ``(fold_id, family, config_id)``
-    binding matches ``masked`` exactly."""
-    if type(masked) is not Masked:
-        raise TypeError(f"expected a Masked value, got {type(masked)!r}")
+    """One-shot reveal with registry-issued, matching PASS evidence."""
+    record = _record_for(masked)
     if type(evidence) is not DryCountPassEvidence:
-        raise TypeError(f"expected a DryCountPassEvidence, got {type(evidence)!r}")
-    if not evidence.passed:
-        # Unreachable given DryCountPassEvidence.__post_init__, kept as an
-        # explicit, independently-checkable identity (mirrors reason_codes.
-        # reconcile_histogram's own belt-and-suspenders re-check).
-        raise OOSMaskBypassError("evidence does not represent a PASS")
-    masked_binding = (masked.fold_id, masked.family, masked.config_id)
-    if masked_binding != evidence.binding_key():
+        raise TypeError("expected an exact DryCountPassEvidence instance")
+    evidence_record = _EVIDENCES.get(id(evidence))
+    if (
+        evidence_record is None
+        or evidence_record.evidence_ref() is not evidence
+        or evidence_record.masked_id != id(masked)
+        or evidence_record.binding != record.binding
+        or evidence.binding_key() != record.binding
+        or evidence_record.counts_fingerprint != record.counts_fingerprint
+    ):
         raise OOSMaskBypassError(
-            f"evidence binding {evidence.binding_key()!r} does not match "
-            f"this masked value's binding {masked_binding!r} — a PASS "
-            "evidence from a different fold/family/config can never unmask "
-            "this value"
+            "PASS evidence was reconstructed, mutated, or issued for another mask"
         )
-    return object.__getattribute__(masked, "_reveal")(_AUTHORIZED_UNMASK_TOKEN)
+    payload = _vault().call(
+        ("REVEAL", record.vault_handle, evidence_record.vault_token)
+    )
+    try:
+        return pickle.loads(payload)
+    finally:
+        del payload

--- a/research/alpaca_track_walkforward/oos_mask.py
+++ b/research/alpaca_track_walkforward/oos_mask.py
@@ -6,12 +6,11 @@ serializes the value immediately and transfers it into an isolated local
 vault process. The public object contains binding metadata only.
 
 Unmask authority is not a public dataclass constructor. H5 must call
-``issue_dry_count_pass`` with the exact ``BlindCounts`` object that H4 bound
-to the masked value at creation. Issuance rechecks that object's fingerprint,
-the sealed minimum-entry threshold, and incomplete status inside both the
-caller and the isolated vault. Evidence reconstructed with ``object.__new__``,
-copied, subclassed, or mutated is absent from the issuance registry and is
-rejected.
+``issue_all_folds_dry_count_pass`` with all 8 folds' exact ``BlindCounts``
+objects and masked handles for one family/config. No vault token is issued
+until every fold is complete and meets the sealed minimum. Evidence
+reconstructed with ``object.__new__``, copied, subclassed, or mutated is
+absent from the issuance registry and is rejected.
 
 Native debuggers able to read another process's address space are outside the
 threat model. Ordinary Python reflection, closure inspection, object graph
@@ -28,6 +27,7 @@ import os
 import pickle
 import threading
 import weakref
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -38,6 +38,7 @@ __all__ = [
     "DryCountPassEvidence",
     "Masked",
     "OOSMaskBypassError",
+    "issue_all_folds_dry_count_pass",
     "issue_dry_count_pass",
     "mask",
     "unmask",
@@ -135,13 +136,13 @@ class Masked:
 
 
 class DryCountPassEvidence:
-    """Registry-backed evidence issued only for an actual bound dry count."""
+    """Registry-backed evidence issued only after all 8 folds pass."""
 
     __slots__ = (
-        "_fold_id",
         "_family",
         "_config_id",
-        "_modeled_entries",
+        "_fold_ids",
+        "_modeled_entries_by_fold",
         "_min_modeled_entries_per_fold",
         "__weakref__",
     )
@@ -149,15 +150,15 @@ class DryCountPassEvidence:
     def __init__(self, *args: object, **kwargs: object) -> None:
         raise OOSMaskBypassError(
             "DryCountPassEvidence cannot be constructed externally; "
-            "call issue_dry_count_pass(masked, actual_blind_counts)"
+            "call issue_all_folds_dry_count_pass(...)"
         )
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         raise TypeError("DryCountPassEvidence cannot be subclassed")
 
     @property
-    def fold_id(self) -> str:
-        return object.__getattribute__(self, "_fold_id")
+    def fold_ids(self) -> tuple[str, ...]:
+        return object.__getattribute__(self, "_fold_ids")
 
     @property
     def family(self) -> str:
@@ -168,8 +169,8 @@ class DryCountPassEvidence:
         return object.__getattribute__(self, "_config_id")
 
     @property
-    def modeled_entries(self) -> int:
-        return object.__getattribute__(self, "_modeled_entries")
+    def modeled_entries_by_fold(self) -> tuple[tuple[str, int], ...]:
+        return object.__getattribute__(self, "_modeled_entries_by_fold")
 
     @property
     def min_modeled_entries_per_fold(self) -> int:
@@ -179,8 +180,8 @@ class DryCountPassEvidence:
     def passed(self) -> bool:
         return True
 
-    def binding_key(self) -> tuple[str, str, str]:
-        return (self.fold_id, self.family, self.config_id)
+    def binding_key(self) -> tuple[str, str, tuple[str, ...]]:
+        return (self.family, self.config_id, self.fold_ids)
 
     def __setattr__(self, name: str, value: Any) -> None:
         raise OOSMaskBypassError("DryCountPassEvidence is immutable")
@@ -191,8 +192,9 @@ class DryCountPassEvidence:
     def __repr__(self) -> str:
         return (
             "DryCountPassEvidence("
-            f"fold_id={self.fold_id!r}, family={self.family!r}, "
-            f"config_id={self.config_id!r}, modeled_entries={self.modeled_entries}, "
+            f"fold_ids={self.fold_ids!r}, family={self.family!r}, "
+            f"config_id={self.config_id!r}, "
+            f"modeled_entries_by_fold={self.modeled_entries_by_fold!r}, "
             f"min_modeled_entries_per_fold={self.min_modeled_entries_per_fold}, "
             "passed=True)"
         )
@@ -340,10 +342,12 @@ class _MaskRecord:
 @dataclass(slots=True)
 class _EvidenceRecord:
     evidence_ref: weakref.ReferenceType[DryCountPassEvidence]
-    masked_id: int
-    binding: tuple[str, str, str]
-    counts_fingerprint: str
-    vault_token: bytes
+    family: str
+    config_id: str
+    fold_ids: tuple[str, ...]
+    binding_by_masked_id: Mapping[int, tuple[str, str, str]]
+    counts_fingerprint_by_masked_id: Mapping[int, str]
+    vault_token_by_masked_id: Mapping[int, bytes]
 
 
 _VAULT: _VaultClient | None = None
@@ -450,32 +454,97 @@ def mask(
 def issue_dry_count_pass(
     masked: Masked, dry_counts: bc.BlindCounts
 ) -> DryCountPassEvidence:
-    """Issue PASS only for the exact bound counts and sealed threshold."""
-    record = _record_for(masked)
+    """The former fold-local authority is deliberately disabled."""
+    _record_for(masked)
     if type(dry_counts) is not bc.BlindCounts:
         raise TypeError("dry_counts must be an exact BlindCounts instance")
-    if record.counts is not dry_counts:
-        raise OOSMaskBypassError(
-            "dry counts are not the actual object bound by H4 to this mask"
-        )
-    fingerprint = _counts_fingerprint(dry_counts)
-    if fingerprint != record.counts_fingerprint:
-        raise OOSMaskBypassError("bound dry counts changed after mask issuance")
-    sealed_minimum = wf_seal.min_modeled_entries_per_fold()
-    if dry_counts.is_incomplete:
-        raise OOSMaskBypassError("incomplete dry counts can never issue PASS")
-    if dry_counts.modeled_entries_count < sealed_minimum:
-        raise OOSMaskBypassError(
-            "bound dry count is below the sealed minimum modeled entries"
-        )
-    vault_token = _vault().call(("ISSUE", record.vault_handle, fingerprint))
+    raise OOSMaskBypassError(
+        "fold-local PASS is forbidden; all 8 folds must pass together"
+    )
 
+
+def issue_all_folds_dry_count_pass(
+    *,
+    masked_by_fold: Mapping[str, Sequence[Masked]],
+    dry_counts_by_fold: Mapping[str, bc.BlindCounts],
+) -> DryCountPassEvidence:
+    """Issue one authority only after the exact 8-fold dry gate passes."""
+    expected_fold_ids = tuple(f"fold-{index}" for index in range(wf_seal.oos_folds()))
+    if tuple(sorted(masked_by_fold)) != expected_fold_ids:
+        raise OOSMaskBypassError("masked_by_fold must cover exactly fold-0..fold-7")
+    if tuple(sorted(dry_counts_by_fold)) != expected_fold_ids:
+        raise OOSMaskBypassError("dry_counts_by_fold must cover exactly fold-0..fold-7")
+
+    sealed_minimum = wf_seal.min_modeled_entries_per_fold()
+    family: str | None = None
+    config_id: str | None = None
+    records_by_masked_id: dict[int, _MaskRecord] = {}
+    fingerprints_by_masked_id: dict[int, str] = {}
+
+    # Validate every fold before asking the vault to issue any token.
+    for fold_id in expected_fold_ids:
+        counts = dry_counts_by_fold[fold_id]
+        if type(counts) is not bc.BlindCounts:
+            raise TypeError("every dry count must be an exact BlindCounts instance")
+        if counts.is_incomplete:
+            raise OOSMaskBypassError(
+                f"{fold_id} is incomplete; aggregate PASS cannot issue"
+            )
+        if counts.modeled_entries_count < sealed_minimum:
+            raise OOSMaskBypassError(
+                f"{fold_id} is below the sealed minimum modeled entries"
+            )
+        if not masked_by_fold[fold_id]:
+            raise OOSMaskBypassError(
+                f"{fold_id} has no H4-issued dry-count gate handle"
+            )
+        for masked in masked_by_fold[fold_id]:
+            record = _record_for(masked)
+            if record.binding[0] != fold_id:
+                raise OOSMaskBypassError("masked handle is filed under the wrong fold")
+            if record.counts is not counts:
+                raise OOSMaskBypassError(
+                    "dry counts are not the actual object bound by H4 to this mask"
+                )
+            fingerprint = _counts_fingerprint(counts)
+            if fingerprint != record.counts_fingerprint:
+                raise OOSMaskBypassError("bound dry counts changed after mask issuance")
+            if family is None:
+                family, config_id = record.binding[1], record.binding[2]
+            elif (record.binding[1], record.binding[2]) != (family, config_id):
+                raise OOSMaskBypassError(
+                    "aggregate PASS cannot mix family/config identities"
+                )
+            records_by_masked_id[id(masked)] = record
+            fingerprints_by_masked_id[id(masked)] = fingerprint
+
+    if family is None or config_id is None:
+        raise OOSMaskBypassError(
+            "aggregate PASS requires at least one actual masked H4 value"
+        )
+
+    tokens_by_masked_id = {
+        masked_id: _vault().call(
+            (
+                "ISSUE",
+                record.vault_handle,
+                fingerprints_by_masked_id[masked_id],
+            )
+        )
+        for masked_id, record in records_by_masked_id.items()
+    }
     evidence = object.__new__(DryCountPassEvidence)
     for name, value in (
-        ("_fold_id", record.binding[0]),
-        ("_family", record.binding[1]),
-        ("_config_id", record.binding[2]),
-        ("_modeled_entries", dry_counts.modeled_entries_count),
+        ("_family", family),
+        ("_config_id", config_id),
+        ("_fold_ids", expected_fold_ids),
+        (
+            "_modeled_entries_by_fold",
+            tuple(
+                (fold_id, dry_counts_by_fold[fold_id].modeled_entries_count)
+                for fold_id in expected_fold_ids
+            ),
+        ),
         ("_min_modeled_entries_per_fold", sealed_minimum),
     ):
         object.__setattr__(evidence, name, value)
@@ -483,10 +552,15 @@ def issue_dry_count_pass(
     evidence_ref = weakref.ref(evidence, _drop_evidence(evidence_id))
     _EVIDENCES[evidence_id] = _EvidenceRecord(
         evidence_ref=evidence_ref,
-        masked_id=id(masked),
-        binding=record.binding,
-        counts_fingerprint=fingerprint,
-        vault_token=vault_token,
+        family=family,
+        config_id=config_id,
+        fold_ids=expected_fold_ids,
+        binding_by_masked_id={
+            masked_id: record.binding
+            for masked_id, record in records_by_masked_id.items()
+        },
+        counts_fingerprint_by_masked_id=dict(fingerprints_by_masked_id),
+        vault_token_by_masked_id=tokens_by_masked_id,
     )
     return evidence
 
@@ -497,19 +571,29 @@ def unmask(masked: Masked, evidence: DryCountPassEvidence) -> Any:
     if type(evidence) is not DryCountPassEvidence:
         raise TypeError("expected an exact DryCountPassEvidence instance")
     evidence_record = _EVIDENCES.get(id(evidence))
+    masked_id = id(masked)
     if (
         evidence_record is None
         or evidence_record.evidence_ref() is not evidence
-        or evidence_record.masked_id != id(masked)
-        or evidence_record.binding != record.binding
-        or evidence.binding_key() != record.binding
-        or evidence_record.counts_fingerprint != record.counts_fingerprint
+        or evidence_record.binding_by_masked_id.get(masked_id) != record.binding
+        or evidence.binding_key()
+        != (
+            evidence_record.family,
+            evidence_record.config_id,
+            evidence_record.fold_ids,
+        )
+        or evidence_record.counts_fingerprint_by_masked_id.get(masked_id)
+        != record.counts_fingerprint
     ):
         raise OOSMaskBypassError(
             "PASS evidence was reconstructed, mutated, or issued for another mask"
         )
     payload = _vault().call(
-        ("REVEAL", record.vault_handle, evidence_record.vault_token)
+        (
+            "REVEAL",
+            record.vault_handle,
+            evidence_record.vault_token_by_masked_id[masked_id],
+        )
     )
     try:
         return pickle.loads(payload)

--- a/research/alpaca_track_walkforward/oos_mask.py
+++ b/research/alpaca_track_walkforward/oos_mask.py
@@ -1,9 +1,9 @@
 """ROB-1062 H4 (AC22-AC25) — fail-closed OOS PnL masking.
 
 ``Masked`` never retains the source object, a closure over it, plaintext
-pickle bytes, ciphertext, or a caller-reachable reveal callable. ``mask``
-serializes the value immediately and transfers it into an isolated local
-vault process. The public object contains binding metadata only.
+payload bytes, ciphertext, or a caller-reachable reveal callable. ``mask``
+encodes the value with a closed typed codec and transfers it into an isolated
+local vault process. The public object contains binding metadata only.
 
 Unmask authority is not a public dataclass constructor. H5 must call
 ``issue_all_folds_dry_count_pass`` with all 8 folds' exact ``BlindCounts``
@@ -21,10 +21,10 @@ process and cannot recover the vault payload.
 from __future__ import annotations
 
 import atexit
-import hashlib
+import json
+import math
 import multiprocessing
 import os
-import pickle
 import threading
 import weakref
 from collections.abc import Mapping, Sequence
@@ -32,6 +32,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import blind_counts as bc
+import canonical_hash
+import pnl_views as pv
 import wf_seal_consumption as wf_seal
 
 __all__ = [
@@ -74,7 +76,159 @@ def _counts_fingerprint(counts: bc.BlindCounts) -> str:
         tuple(sorted(counts.reason_code_histogram.items())),
         counts.is_incomplete,
     )
-    return hashlib.sha256(pickle.dumps(payload, protocol=5)).hexdigest()
+    return canonical_hash.canonical_sha256(payload)
+
+
+def _finite_float(value: object, label: str) -> float:
+    if type(value) is not float:
+        raise OOSMaskBypassError(f"{label} must be an exact float")
+    if not math.isfinite(value):
+        raise OOSMaskBypassError(f"{label} must be finite")
+    return value
+
+
+def _encode_node(value: object) -> list:
+    """Encode only the closed set of OOS result value types."""
+    if value is None:
+        return ["none", None]
+    if type(value) is bool:
+        return ["bool", value]
+    if type(value) is int:
+        return ["int", value]
+    if type(value) is float:
+        return ["float", _finite_float(value, "masked float").hex()]
+    if type(value) is str:
+        return ["str", value]
+    if type(value) is list:
+        return ["list", [_encode_node(item) for item in value]]
+    if type(value) is tuple:
+        return ["tuple", [_encode_node(item) for item in value]]
+    if type(value) is dict:
+        entries: list[list] = []
+        for key, item in value.items():
+            if type(key) is not str:
+                raise OOSMaskBypassError("masked dict keys must be exact strings")
+            entries.append([key, _encode_node(item)])
+        return ["dict", sorted(entries, key=lambda pair: pair[0])]
+    if type(value) is pv.ThreeViewPnL:
+        scenarios: list[list[str]] = []
+        for key, scenario_value in value.shadow_net_bp_by_scenario.items():
+            if type(key) is not str:
+                raise OOSMaskBypassError(
+                    "ThreeViewPnL scenario keys must be exact strings"
+                )
+            scenarios.append(
+                [
+                    key,
+                    _finite_float(
+                        scenario_value, f"ThreeViewPnL scenario {key!r}"
+                    ).hex(),
+                ]
+            )
+        return [
+            "three_view_pnl",
+            {
+                "gross_bp": _finite_float(
+                    value.gross_bp, "ThreeViewPnL.gross_bp"
+                ).hex(),
+                "actual_fill_bp": _finite_float(
+                    value.actual_fill_bp, "ThreeViewPnL.actual_fill_bp"
+                ).hex(),
+                "shadow_net_bp_by_scenario": sorted(
+                    scenarios, key=lambda pair: pair[0]
+                ),
+            },
+        ]
+    raise OOSMaskBypassError(f"unsupported masked value type {type(value).__name__!r}")
+
+
+def _decode_node(node: object) -> object:
+    """Decode the closed wire schema and reject every malformed shape."""
+    if type(node) is not list or len(node) != 2 or type(node[0]) is not str:
+        raise OOSMaskBypassError("masked payload has an invalid typed node")
+    tag, payload = node
+    if tag == "none" and payload is None:
+        return None
+    if tag == "bool" and type(payload) is bool:
+        return payload
+    if tag == "int" and type(payload) is int:
+        return payload
+    if tag == "float" and type(payload) is str:
+        try:
+            return _finite_float(float.fromhex(payload), "decoded float")
+        except ValueError as exc:
+            raise OOSMaskBypassError("masked float payload is invalid") from exc
+    if tag == "str" and type(payload) is str:
+        return payload
+    if tag in {"list", "tuple"} and type(payload) is list:
+        values = [_decode_node(item) for item in payload]
+        return values if tag == "list" else tuple(values)
+    if tag == "dict" and type(payload) is list:
+        result: dict[str, object] = {}
+        for pair in payload:
+            if (
+                type(pair) is not list
+                or len(pair) != 2
+                or type(pair[0]) is not str
+                or pair[0] in result
+            ):
+                raise OOSMaskBypassError("masked dict payload is invalid")
+            result[pair[0]] = _decode_node(pair[1])
+        return result
+    if tag == "three_view_pnl" and type(payload) is dict:
+        if set(payload) != {
+            "gross_bp",
+            "actual_fill_bp",
+            "shadow_net_bp_by_scenario",
+        }:
+            raise OOSMaskBypassError("ThreeViewPnL payload fields are invalid")
+        gross_bp = _decode_node(["float", payload["gross_bp"]])
+        actual_fill_bp = _decode_node(["float", payload["actual_fill_bp"]])
+        scenarios_payload = payload["shadow_net_bp_by_scenario"]
+        if type(scenarios_payload) is not list:
+            raise OOSMaskBypassError("ThreeViewPnL scenario payload is invalid")
+        scenarios: dict[str, float] = {}
+        for pair in scenarios_payload:
+            if (
+                type(pair) is not list
+                or len(pair) != 2
+                or type(pair[0]) is not str
+                or pair[0] in scenarios
+                or type(pair[1]) is not str
+            ):
+                raise OOSMaskBypassError("ThreeViewPnL scenario entry is invalid")
+            scenario_value = _decode_node(["float", pair[1]])
+            if type(scenario_value) is not float:
+                raise OOSMaskBypassError("ThreeViewPnL scenario value is invalid")
+            scenarios[pair[0]] = scenario_value
+        if type(gross_bp) is not float or type(actual_fill_bp) is not float:
+            raise OOSMaskBypassError("ThreeViewPnL scalar payload is invalid")
+        return pv.ThreeViewPnL(
+            gross_bp=gross_bp,
+            actual_fill_bp=actual_fill_bp,
+            shadow_net_bp_by_scenario=scenarios,
+        )
+    raise OOSMaskBypassError("masked payload uses an unknown or malformed type")
+
+
+def _encode_masked_value(value: object) -> bytes:
+    return json.dumps(
+        _encode_node(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _decode_masked_value(payload: object) -> object:
+    if type(payload) is not bytes:
+        raise OOSMaskBypassError("vault returned a non-bytes masked payload")
+    try:
+        node = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise OOSMaskBypassError("vault returned an invalid masked payload") from exc
+    return _decode_node(node)
 
 
 class Masked:
@@ -419,7 +573,7 @@ def mask(
         raise TypeError("dry_counts must be an exact BlindCounts instance")
     binding = _binding_tuple(fold_id=fold_id, family=family, config_id=config_id)
     counts_fingerprint = _counts_fingerprint(dry_counts)
-    payload = pickle.dumps(raw_value, protocol=5)
+    payload = _encode_masked_value(raw_value)
     try:
         vault_handle = _vault().call(
             (
@@ -596,6 +750,6 @@ def unmask(masked: Masked, evidence: DryCountPassEvidence) -> Any:
         )
     )
     try:
-        return pickle.loads(payload)
+        return _decode_masked_value(payload)
     finally:
         del payload

--- a/research/alpaca_track_walkforward/oos_mask.py
+++ b/research/alpaca_track_walkforward/oos_mask.py
@@ -1,0 +1,223 @@
+"""ROB-1062 H4 (Run A SS15, AC22-AC25) — the OOS PnL masking guarantee.
+
+This is the single most consequential module in H4: H5's entire PnL-blind
+dry-count gate rests on the property that an OOS PnL value produced by this
+package CANNOT be read by any caller — API, report, log line, ``__repr__``,
+debug helper, pickle/JSON round-trip, or exception message — until an
+explicit ``unmask()`` call is presented with a genuine, matching
+``DryCountPassEvidence`` (which only H5 is positioned to construct, since
+only H5 owns the dry-count gate itself).
+
+Design (why this resists the concrete bypass routes AC24 names):
+
+1. **The raw value is never stored as a readable attribute at all.** It
+   lives ONLY inside a closure cell captured by a per-instance gated
+   callable (``_reveal``). ``Masked`` has NO slot/attribute whose value IS
+   the raw PnL — so even direct, no-holds-barred attribute access
+   (``masked._reveal``, or ``object.__getattribute__(masked, "_reveal")``,
+   which would trivially defeat a ``__getattribute__``-override-based
+   design) only ever recovers a FUNCTION, which itself still demands the
+   correct, non-exported sentinel token before it will return anything. A
+   slot/attribute-based "private" field (name-mangled or not) would NOT
+   have this property: a slot descriptor just returns its stored value to
+   ANY attribute-access route, override or no override — that design was
+   considered and rejected in favor of the closure (see
+   ``tests/test_oos_mask.py::test_direct_attribute_access_to_the_closure_
+   itself_never_yields_the_raw_value``, which is the regression test for
+   exactly that near-miss).
+2. ``__repr__``/``__str__`` never format the raw value — only the public,
+   non-sensitive binding (``fold_id``/``family``/``config_id``).
+3. ``__reduce__``/``__getstate__`` raise — a ``Masked`` value can never be
+   pickled (and therefore never persisted to disk, logged via a pickling
+   logger, or survive a ``copy.deepcopy``, which falls back to the same
+   protocol).
+4. ``__eq__``/``__hash__`` raise — comparison is blocked so a caller cannot
+   use repeated equality probes as an oracle to binary-search the hidden
+   value.
+5. ``unmask()`` additionally verifies the supplied evidence's
+   ``(fold_id, family, config_id)`` binding matches the masked value's own
+   — a genuine PASS evidence for a DIFFERENT fold/config can never unmask
+   THIS value (closing the "reuse someone else's passing evidence" route).
+
+Scope honesty: this is a research-backtest guarantee against the concrete,
+named bypass classes in AC24 (direct field access, debug/repr output,
+pickle/JSON round-trip, exception-message leakage, evidence reuse across
+folds/configs) — it is not a defense against a caller willing to import this
+module's own private, non-exported sentinel object and hand it to the
+closure directly (``from oos_mask import _AUTHORIZED_UNMASK_TOKEN`` reaches
+past every public surface this module exposes). That residual gap is
+recorded here explicitly rather than silently, per the same "flag it, don't
+hide it" discipline H3 used for its own documented open choices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "DryCountPassEvidence",
+    "Masked",
+    "OOSMaskBypassError",
+    "mask",
+    "unmask",
+]
+
+
+class OOSMaskBypassError(RuntimeError):
+    """Raised whenever code attempts to read a masked OOS PnL value without
+    a matching, genuine dry-count PASS evidence."""
+
+
+# Not exported (absent from __all__, single leading underscore only as a
+# naming convention — see the module docstring's "scope honesty" note for
+# what this does and does not defend against).
+_AUTHORIZED_UNMASK_TOKEN = object()
+
+
+def _int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be built-in int")
+    return value
+
+
+@dataclass(frozen=True)
+class DryCountPassEvidence:
+    """H5's dry-count PASS evidence, scoped to exactly ONE
+    ``(fold_id, family, config_id)``. This type can only ever represent a
+    genuine PASS — ``__post_init__`` refuses to construct a "fail" instance,
+    so there is no way to build a plausible-looking-but-fake unmask key by
+    accident; H5's own (out-of-H4-scope) dry-count report type is where a
+    FAIL outcome is recorded."""
+
+    fold_id: str
+    family: str
+    config_id: str
+    modeled_entries: int
+    min_modeled_entries_per_fold: int
+    passed: bool
+
+    def __post_init__(self) -> None:
+        _int(self.modeled_entries, "modeled_entries")
+        _int(self.min_modeled_entries_per_fold, "min_modeled_entries_per_fold")
+        if type(self.passed) is not bool:
+            raise TypeError("passed must be built-in bool")
+        if not self.passed:
+            raise ValueError(
+                "DryCountPassEvidence can only represent a genuine PASS — "
+                "never construct one to represent a fail/insufficient-sample "
+                "outcome"
+            )
+        if self.modeled_entries < self.min_modeled_entries_per_fold:
+            raise ValueError(
+                f"modeled_entries={self.modeled_entries} is below "
+                f"min_modeled_entries_per_fold={self.min_modeled_entries_per_fold} "
+                "— this cannot be a genuine PASS"
+            )
+
+    def binding_key(self) -> tuple[str, str, str]:
+        return (self.fold_id, self.family, self.config_id)
+
+
+class Masked:
+    """An opaque, unreadable wrapper around one OOS PnL value. See module
+    docstring for the full bypass-resistance rationale."""
+
+    __slots__ = ("_fold_id", "_family", "_config_id", "_reveal")
+
+    def __init__(
+        self, raw_value: Any, *, fold_id: str, family: str, config_id: str
+    ) -> None:
+        def _reveal(token: object) -> Any:
+            if token is not _AUTHORIZED_UNMASK_TOKEN:
+                raise OOSMaskBypassError(
+                    "direct access to a masked OOS PnL value is forbidden — "
+                    "call oos_mask.unmask(masked, evidence) with H5's "
+                    "dry-count PASS evidence"
+                )
+            return raw_value
+
+        object.__setattr__(self, "_fold_id", fold_id)
+        object.__setattr__(self, "_family", family)
+        object.__setattr__(self, "_config_id", config_id)
+        object.__setattr__(self, "_reveal", _reveal)
+
+    # ---- metadata (safe, non-sensitive) -------------------------------- #
+
+    @property
+    def fold_id(self) -> str:
+        return self._fold_id
+
+    @property
+    def family(self) -> str:
+        return self._family
+
+    @property
+    def config_id(self) -> str:
+        return self._config_id
+
+    # ---- bypass-resistance surface ------------------------------------- #
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise OOSMaskBypassError("Masked values are immutable")
+
+    def __delattr__(self, name: str) -> None:
+        raise OOSMaskBypassError("Masked values are immutable")
+
+    def __repr__(self) -> str:
+        return (
+            f"Masked(fold_id={self._fold_id!r}, family={self._family!r}, "
+            f"config_id={self._config_id!r}, value=<masked>)"
+        )
+
+    __str__ = __repr__
+
+    def __reduce__(self) -> Any:
+        raise OOSMaskBypassError(
+            "Masked values must never be pickled (would persist raw OOS PnL "
+            "to disk unmasked)"
+        )
+
+    def __getstate__(self) -> Any:
+        raise OOSMaskBypassError(
+            "Masked values must never be pickled/deepcopy-serialized"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        raise OOSMaskBypassError(
+            "Masked values cannot be compared — repeated equality probes "
+            "could be used as an oracle to infer the raw value"
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+def mask(raw_value: Any, *, fold_id: str, family: str, config_id: str) -> Masked:
+    """Wrap ``raw_value`` (an OOS ``pnl_views.ThreeViewPnL``, a bare float,
+    or any other OOS-PnL-shaped value) as masked-by-default, bound to
+    exactly one ``(fold_id, family, config_id)``."""
+    return Masked(raw_value, fold_id=fold_id, family=family, config_id=config_id)
+
+
+def unmask(masked: Masked, evidence: DryCountPassEvidence) -> Any:
+    """The ONLY sanctioned way to read a masked OOS PnL value: requires a
+    genuine ``DryCountPassEvidence`` whose ``(fold_id, family, config_id)``
+    binding matches ``masked`` exactly."""
+    if type(masked) is not Masked:
+        raise TypeError(f"expected a Masked value, got {type(masked)!r}")
+    if type(evidence) is not DryCountPassEvidence:
+        raise TypeError(f"expected a DryCountPassEvidence, got {type(evidence)!r}")
+    if not evidence.passed:
+        # Unreachable given DryCountPassEvidence.__post_init__, kept as an
+        # explicit, independently-checkable identity (mirrors reason_codes.
+        # reconcile_histogram's own belt-and-suspenders re-check).
+        raise OOSMaskBypassError("evidence does not represent a PASS")
+    masked_binding = (masked.fold_id, masked.family, masked.config_id)
+    if masked_binding != evidence.binding_key():
+        raise OOSMaskBypassError(
+            f"evidence binding {evidence.binding_key()!r} does not match "
+            f"this masked value's binding {masked_binding!r} — a PASS "
+            "evidence from a different fold/family/config can never unmask "
+            "this value"
+        )
+    return object.__getattribute__(masked, "_reveal")(_AUTHORIZED_UNMASK_TOKEN)

--- a/research/alpaca_track_walkforward/pnl_views.py
+++ b/research/alpaca_track_walkforward/pnl_views.py
@@ -1,0 +1,141 @@
+"""ROB-1062 H4 (Run A SS3, SS16, AC17-AC21) — the 3 independent PnL views
+for one CLOSED trade (one entry-fill + one exit-fill round trip; a trade
+that never exits is not a closed trade and never reaches this module).
+
+    gross        = Binance reference-close-to-close move only (no
+                   execution friction of any kind — the theoretical
+                   best case).
+    actual_fill  = this backtest's MODELED fill prices
+                   (``fill_model.FillOutcome.fill_price`` on both legs) —
+                   captures the fill model's own price slippage (paying up
+                   to +0.5% on entry / down to -0.5% on exit), but still no
+                   spread/fee/venue-mismatch deduction.
+    shadow_net   = actual_fill MINUS exactly one cost-scenario bp value
+                   (C50/C100/C120/C150 — Run A SS3's own table already
+                   bakes the 50bp round-trip paper fee INTO every one of
+                   those bp figures, e.g. C100 = "50 fee + ~36 spread + 14
+                   buffer"). This is the ONLY place a cost scenario is
+                   deducted; ``shadow_net`` is the promotion-canonical view
+                   (SS16).
+
+AC19 (no double fee deduction) is enforced STRUCTURALLY, not by convention:
+no function in this module accepts a separate fee parameter, and this
+module never imports ``wf_seal_consumption.paper_fee_bp`` — there is no
+second deduction path to accidentally wire in.
+``tests/test_pnl_views.py::test_module_never_imports_or_references_a_
+separate_paper_fee_bp_deduction`` statically proves this by AST scan.
+
+AC17 (scenarios never derive from one another): every scenario's
+``shadow_net`` is computed as ``actual_fill_pnl_bp - scenario_bp[name]``
+directly from the caller-supplied ``cost_scenarios_bp`` mapping — never as
+an offset/interpolation from another scenario's own result. Because the
+implementation reads the mapping by KEY rather than by relative position,
+scenario bp values need not even be monotonic for this property to hold
+(``tests/test_pnl_views.py`` proves this with a deliberately non-monotonic,
+non-evenly-spaced fake scenario table).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+__all__ = [
+    "ThreeViewPnL",
+    "TradeFill",
+    "actual_fill_pnl_bp",
+    "gross_pnl_bp",
+    "shadow_net_pnl_bp",
+    "three_view_pnl_bp",
+]
+
+
+def _float(value: object, name: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{name} must be built-in float")
+    return value
+
+
+@dataclass(frozen=True)
+class TradeFill:
+    """One CLOSED round trip's price evidence — both the pure Binance
+    reference closes (for ``gross``) and this backtest's modeled fill
+    prices (for ``actual_fill``/``shadow_net``). Never a per-leg record:
+    one ``TradeFill`` == one trade, always (AC21)."""
+
+    entry_reference_close: float
+    entry_fill_price: float
+    exit_reference_close: float
+    exit_fill_price: float
+
+    def __post_init__(self) -> None:
+        for name in (
+            "entry_reference_close",
+            "entry_fill_price",
+            "exit_reference_close",
+            "exit_fill_price",
+        ):
+            value = _float(getattr(self, name), name)
+            if value <= 0.0:
+                raise ValueError(f"{name} must be positive, got {value!r}")
+
+
+@dataclass(frozen=True)
+class ThreeViewPnL:
+    gross_bp: float
+    actual_fill_bp: float
+    shadow_net_bp_by_scenario: Mapping[str, float]
+
+
+def gross_pnl_bp(trade: TradeFill) -> float:
+    """Binance reference-close-to-close move, in bp. No execution friction
+    of any kind mixed in (AC18)."""
+    return (
+        (trade.exit_reference_close - trade.entry_reference_close)
+        / trade.entry_reference_close
+        * 10_000.0
+    )
+
+
+def actual_fill_pnl_bp(trade: TradeFill) -> float:
+    """This backtest's modeled-fill-price move, in bp. Still no spread/fee/
+    venue-mismatch deduction (AC13/AC18) — those arrive only in
+    ``shadow_net_pnl_bp``."""
+    return (
+        (trade.exit_fill_price - trade.entry_fill_price)
+        / trade.entry_fill_price
+        * 10_000.0
+    )
+
+
+def shadow_net_pnl_bp(
+    trade: TradeFill, *, scenario: str, cost_scenarios_bp: Mapping[str, int]
+) -> float:
+    """``actual_fill_pnl_bp(trade) - cost_scenarios_bp[scenario]`` — exactly
+    ONE deduction, looked up directly by scenario NAME (never derived from
+    another scenario's value or position in the table)."""
+    if scenario not in cost_scenarios_bp:
+        raise KeyError(
+            f"unknown cost scenario {scenario!r}: {sorted(cost_scenarios_bp)}"
+        )
+    return actual_fill_pnl_bp(trade) - float(cost_scenarios_bp[scenario])
+
+
+def three_view_pnl_bp(
+    trade: TradeFill, *, cost_scenarios_bp: Mapping[str, int]
+) -> ThreeViewPnL:
+    """Bundle all 3 views for one closed trade — every scenario's
+    ``shadow_net`` computed independently (AC17), from a single shared
+    ``actual_fill_pnl_bp`` base (never from ``gross``, and never from each
+    other)."""
+    by_scenario = {
+        name: shadow_net_pnl_bp(
+            trade, scenario=name, cost_scenarios_bp=cost_scenarios_bp
+        )
+        for name in cost_scenarios_bp
+    }
+    return ThreeViewPnL(
+        gross_bp=gross_pnl_bp(trade),
+        actual_fill_bp=actual_fill_pnl_bp(trade),
+        shadow_net_bp_by_scenario=by_scenario,
+    )

--- a/research/alpaca_track_walkforward/provider_evidence.py
+++ b/research/alpaca_track_walkforward/provider_evidence.py
@@ -31,8 +31,12 @@ class ProviderEvidenceError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class RunProviderEvidenceBinding:
-    """Immutable aggregate of every provider artifact consumed by one run."""
+    """Immutable aggregate bound to the code-pinned canonical run manifest."""
 
+    run_manifest_hash: str
+    daily_bars_artifact_hash: str
+    universe_grid_hash: str
+    minute_grid_hash: str
     universe_artifacts: tuple[tuple[int, int, str], ...]
     minute_artifacts: tuple[tuple[str, int, int, str], ...]
     combined_hash: str = field(init=False)
@@ -43,6 +47,10 @@ class RunProviderEvidenceBinding:
             "combined_hash",
             canonical_hash.canonical_sha256(
                 {
+                    "run_manifest_hash": self.run_manifest_hash,
+                    "daily_bars_artifact_hash": self.daily_bars_artifact_hash,
+                    "universe_grid_hash": self.universe_grid_hash,
+                    "minute_grid_hash": self.minute_grid_hash,
                     "universe_artifacts": [
                         list(item) for item in self.universe_artifacts
                     ],

--- a/research/alpaca_track_walkforward/provider_evidence.py
+++ b/research/alpaca_track_walkforward/provider_evidence.py
@@ -1,0 +1,213 @@
+"""Typed, immutable provenance envelopes for H4 data providers.
+
+Provider values are not trusted merely because their public timestamp was
+rewritten to the requested instant.  Each response binds its content to the
+source artifact's own as-of timestamp and a canonical content hash.  Runner
+code validates both on every consumption.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import canonical_hash
+import pit_universe_alpaca as pu
+from daily_bars import SpotMinute
+
+__all__ = [
+    "MinuteBarsEvidence",
+    "ProviderEvidenceError",
+    "RunProviderEvidenceBinding",
+    "UniverseSnapshotEvidence",
+    "bind_minute_bars",
+    "bind_universe_snapshot",
+]
+
+
+class ProviderEvidenceError(ValueError):
+    """Provider evidence is stale, relabeled, reconstructed, or mutated."""
+
+
+@dataclass(frozen=True, slots=True)
+class RunProviderEvidenceBinding:
+    """Immutable aggregate of every provider artifact consumed by one run."""
+
+    universe_artifacts: tuple[tuple[int, int, str], ...]
+    minute_artifacts: tuple[tuple[str, int, int, str], ...]
+    combined_hash: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "combined_hash",
+            canonical_hash.canonical_sha256(
+                {
+                    "universe_artifacts": [
+                        list(item) for item in self.universe_artifacts
+                    ],
+                    "minute_artifacts": [list(item) for item in self.minute_artifacts],
+                }
+            ),
+        )
+
+
+def _universe_payload(
+    snapshot: pu.UniverseSnapshot, *, source_as_of_ts_ms: int
+) -> dict:
+    return {
+        "source_as_of_ts_ms": source_as_of_ts_ms,
+        "snapshot": {
+            "decision_ts_ms": snapshot.decision_ts_ms,
+            "eligible_symbols": list(snapshot.eligible_symbols),
+            "per_symbol": [item.to_dict() for item in snapshot.per_symbol],
+            "n_t": snapshot.n_t,
+            "meets_min_universe_size": snapshot.meets_min_universe_size,
+        },
+    }
+
+
+def _minute_payload(
+    *,
+    symbol: str,
+    signal_ts_ms: int,
+    source_as_of_ts_ms: int,
+    bars: Sequence[SpotMinute],
+) -> dict:
+    return {
+        "symbol": symbol,
+        "signal_ts_ms": signal_ts_ms,
+        "source_as_of_ts_ms": source_as_of_ts_ms,
+        "bars": [
+            {
+                "open_time_ms": bar.open_time_ms,
+                "open": bar.open,
+                "high": bar.high,
+                "low": bar.low,
+                "close": bar.close,
+                "volume": bar.volume,
+            }
+            for bar in bars
+        ],
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class UniverseSnapshotEvidence:
+    snapshot: pu.UniverseSnapshot
+    source_as_of_ts_ms: int
+    source_artifact_hash: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if type(self.snapshot) is not pu.UniverseSnapshot:
+            raise TypeError("snapshot must be an exact UniverseSnapshot")
+        if type(self.source_as_of_ts_ms) is not int:
+            raise TypeError("source_as_of_ts_ms must be a built-in int")
+        object.__setattr__(
+            self,
+            "source_artifact_hash",
+            canonical_hash.canonical_sha256(
+                _universe_payload(
+                    self.snapshot, source_as_of_ts_ms=self.source_as_of_ts_ms
+                )
+            ),
+        )
+
+    def assert_integrity(self, *, requested_ts_ms: int) -> None:
+        expected = canonical_hash.canonical_sha256(
+            _universe_payload(self.snapshot, source_as_of_ts_ms=self.source_as_of_ts_ms)
+        )
+        if expected != self.source_artifact_hash:
+            raise ProviderEvidenceError("universe source artifact hash mismatch")
+        if self.source_as_of_ts_ms != requested_ts_ms:
+            raise ProviderEvidenceError(
+                "universe source as-of timestamp does not equal the requested "
+                "decision timestamp"
+            )
+        if self.snapshot.decision_ts_ms != requested_ts_ms:
+            raise ProviderEvidenceError(
+                "universe snapshot timestamp does not equal the requested "
+                "decision timestamp"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class MinuteBarsEvidence:
+    symbol: str
+    signal_ts_ms: int
+    bars: tuple[SpotMinute, ...]
+    source_as_of_ts_ms: int
+    source_artifact_hash: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if type(self.symbol) is not str or not self.symbol:
+            raise TypeError("symbol must be a non-empty built-in str")
+        if type(self.signal_ts_ms) is not int:
+            raise TypeError("signal_ts_ms must be a built-in int")
+        if type(self.source_as_of_ts_ms) is not int:
+            raise TypeError("source_as_of_ts_ms must be a built-in int")
+        if type(self.bars) is not tuple or any(
+            type(bar) is not SpotMinute for bar in self.bars
+        ):
+            raise TypeError("bars must be a tuple of exact SpotMinute values")
+        object.__setattr__(
+            self,
+            "source_artifact_hash",
+            canonical_hash.canonical_sha256(
+                _minute_payload(
+                    symbol=self.symbol,
+                    signal_ts_ms=self.signal_ts_ms,
+                    source_as_of_ts_ms=self.source_as_of_ts_ms,
+                    bars=self.bars,
+                )
+            ),
+        )
+
+    def assert_integrity(self, *, symbol: str, signal_ts_ms: int) -> None:
+        expected = canonical_hash.canonical_sha256(
+            _minute_payload(
+                symbol=self.symbol,
+                signal_ts_ms=self.signal_ts_ms,
+                source_as_of_ts_ms=self.source_as_of_ts_ms,
+                bars=self.bars,
+            )
+        )
+        if expected != self.source_artifact_hash:
+            raise ProviderEvidenceError("minute source artifact hash mismatch")
+        if self.symbol != symbol or self.signal_ts_ms != signal_ts_ms:
+            raise ProviderEvidenceError(
+                "minute evidence binding does not match the requested symbol/signal"
+            )
+        latest_content_ts = max(
+            (bar.open_time_ms for bar in self.bars), default=signal_ts_ms
+        )
+        if self.source_as_of_ts_ms != latest_content_ts:
+            raise ProviderEvidenceError(
+                "minute source as-of timestamp does not match its actual content"
+            )
+
+
+def bind_universe_snapshot(
+    snapshot: pu.UniverseSnapshot, *, source_as_of_ts_ms: int
+) -> UniverseSnapshotEvidence:
+    return UniverseSnapshotEvidence(
+        snapshot=snapshot, source_as_of_ts_ms=source_as_of_ts_ms
+    )
+
+
+def bind_minute_bars(
+    *,
+    symbol: str,
+    signal_ts_ms: int,
+    bars: Sequence[SpotMinute],
+) -> MinuteBarsEvidence:
+    bound_bars = tuple(bars)
+    source_as_of_ts_ms = max(
+        (bar.open_time_ms for bar in bound_bars), default=signal_ts_ms
+    )
+    return MinuteBarsEvidence(
+        symbol=symbol,
+        signal_ts_ms=signal_ts_ms,
+        bars=bound_bars,
+        source_as_of_ts_ms=source_as_of_ts_ms,
+    )

--- a/research/alpaca_track_walkforward/run_manifest.py
+++ b/research/alpaca_track_walkforward/run_manifest.py
@@ -1,0 +1,274 @@
+"""Immutable run identity for ROB-1062 H4.
+
+H2 deliberately carries no fabricated H1 dataset-manifest hash: the real,
+operator-approved H1 archive corpus has not been collected.  H4 therefore
+has exactly one runnable identity today, the committed synthetic AC27
+fixture.  This module pins that fixture's anchor and every input-artifact
+digest used by each fold/family.  A future real run must add an
+operator-approved manifest whose H1 ``CorpusManifest.content_hash()`` is
+fixed here; callers cannot nominate an authority at runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import canonical_hash
+from daily_bars import DailyBar
+from pit_universe_alpaca import UniverseSnapshot
+
+__all__ = [
+    "CanonicalRunManifest",
+    "RunManifestError",
+    "canonical_daily_bars_hash",
+    "canonical_minute_grid_hash",
+    "canonical_run_manifest",
+    "canonical_universe_grid_hash",
+]
+
+DAY_MS = 86_400_000
+CANONICAL_ANCHOR_OOS_START_MS = 1_704_067_200_000  # 2024-01-01T00:00:00Z
+CANONICAL_RUN_ID = "rob1062-h4-synthetic-ac27-v1"
+CANONICAL_SOURCE_KIND = "synthetic_fixture"
+CANONICAL_SYMBOLS = tuple(f"SYM{index:02d}/USD" for index in range(20))
+
+
+class RunManifestError(ValueError):
+    """A runtime input differs from the immutable run authority."""
+
+
+def _bar_payload(bar: DailyBar) -> list:
+    if type(bar) is not DailyBar:
+        raise TypeError("daily corpus must contain exact DailyBar values")
+    return [
+        bar.day_start_ms,
+        bar.day_end_ms,
+        bar.open,
+        bar.high,
+        bar.low,
+        bar.close,
+        bar.volume,
+        bar.minute_count_observed,
+        bar.imputed_minutes,
+        bar.max_gap_minutes,
+        bar.gap_in_last_60min,
+        bar.is_valid,
+        bar.is_segment_start,
+    ]
+
+
+def canonical_daily_bars_hash(
+    bars_by_symbol: Mapping[str, Sequence[DailyBar]],
+) -> str:
+    return canonical_hash.canonical_sha256(
+        {
+            "bars_by_symbol": {
+                symbol: [_bar_payload(bar) for bar in bars_by_symbol[symbol]]
+                for symbol in sorted(bars_by_symbol)
+            }
+        }
+    )
+
+
+def _universe_payload(snapshot: UniverseSnapshot) -> dict:
+    if type(snapshot) is not UniverseSnapshot:
+        raise TypeError("universe grid must contain exact UniverseSnapshot values")
+    return {
+        "decision_ts_ms": snapshot.decision_ts_ms,
+        "eligible_symbols": list(snapshot.eligible_symbols),
+        "per_symbol": [item.to_dict() for item in snapshot.per_symbol],
+        "n_t": snapshot.n_t,
+        "meets_min_universe_size": snapshot.meets_min_universe_size,
+    }
+
+
+def canonical_universe_grid_hash(
+    snapshots_by_ts: Mapping[int, UniverseSnapshot],
+) -> str:
+    return canonical_hash.canonical_sha256(
+        {
+            "universe_by_ts": [
+                [timestamp, _universe_payload(snapshots_by_ts[timestamp])]
+                for timestamp in sorted(snapshots_by_ts)
+            ]
+        }
+    )
+
+
+def canonical_minute_grid_hash(
+    bars_by_key: Mapping[tuple[str, int], Sequence],
+) -> str:
+    payload: list[list] = []
+    for symbol, signal_ts_ms in sorted(bars_by_key):
+        bars = bars_by_key[(symbol, signal_ts_ms)]
+        payload.append(
+            [
+                symbol,
+                signal_ts_ms,
+                [
+                    [
+                        bar.open_time_ms,
+                        bar.open,
+                        bar.high,
+                        bar.low,
+                        bar.close,
+                        bar.volume,
+                    ]
+                    for bar in bars
+                ],
+            ]
+        )
+    return canonical_hash.canonical_sha256({"minute_bars_by_key": payload})
+
+
+_CONSTRUCTION_TOKEN = object()
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalRunManifest:
+    run_id: str
+    source_kind: str
+    anchor_oos_start_ms: int
+    symbols: tuple[str, ...]
+    daily_bars_hash_by_fold: Mapping[str, str]
+    universe_grid_hash_by_fold_family: Mapping[str, str]
+    minute_grid_hash_by_fold_family: Mapping[str, str]
+    manifest_hash: str
+    _construction_token: object
+
+    def __post_init__(self) -> None:
+        if self._construction_token is not _CONSTRUCTION_TOKEN:
+            raise TypeError("CanonicalRunManifest is issued only by this module")
+        object.__setattr__(self, "symbols", tuple(self.symbols))
+        for mapping_name in (
+            "daily_bars_hash_by_fold",
+            "universe_grid_hash_by_fold_family",
+            "minute_grid_hash_by_fold_family",
+        ):
+            mapping = dict(getattr(self, mapping_name))
+            object.__setattr__(
+                self,
+                mapping_name,
+                MappingProxyType(dict(sorted(mapping.items()))),
+            )
+
+    def assert_daily_bars(self, *, fold_id: str, actual_hash: str) -> None:
+        expected = self.daily_bars_hash_by_fold.get(fold_id)
+        if expected is None or actual_hash != expected:
+            raise RunManifestError(
+                f"daily corpus hash does not match canonical {fold_id} artifact"
+            )
+
+    def assert_provider_grids(
+        self,
+        *,
+        fold_id: str,
+        family: str,
+        universe_grid_hash: str,
+        minute_grid_hash: str,
+    ) -> None:
+        self.assert_universe_grid(
+            fold_id=fold_id,
+            family=family,
+            actual_hash=universe_grid_hash,
+        )
+        self.assert_minute_grid(
+            fold_id=fold_id,
+            family=family,
+            actual_hash=minute_grid_hash,
+        )
+
+    def assert_universe_grid(
+        self, *, fold_id: str, family: str, actual_hash: str
+    ) -> None:
+        key = f"{fold_id}:{family}"
+        if self.universe_grid_hash_by_fold_family.get(key) != actual_hash:
+            raise RunManifestError(
+                f"universe grid hash does not match canonical {key} artifact"
+            )
+
+    def assert_minute_grid(
+        self, *, fold_id: str, family: str, actual_hash: str
+    ) -> None:
+        key = f"{fold_id}:{family}"
+        if self.minute_grid_hash_by_fold_family.get(key) != actual_hash:
+            raise RunManifestError(
+                f"minute grid hash does not match canonical {key} artifact"
+            )
+
+
+# Generated from the deterministic synthetic fixture and reviewed as part of
+# the implementation commit. These are source-input identities, not strategy
+# thresholds.
+_DAILY_HASHES = {
+    "fold-0": "553a05325c38edb4f2744956c10a8ab398df431d6d9ff91d3f3046690b261f96",
+    "fold-1": "756c051d0b8a85b4c4b10f5255e5bf537496313405eb9d14520d39158f620bd2",
+    "fold-2": "eef6a24886063bbbb582c71ec222e645f559c45122655491fabe615c8c8582e1",
+    "fold-3": "5349e5ae3a9e8951115c86e5fff195abd2d03479a79b34c4ffeba3c71a99256c",
+    "fold-4": "b788911bf968ee95208b404e434d75922436fa960f2255f5293898620b2a9984",
+    "fold-5": "8ba808a848b578be0309335909c0e63df343139c0af993fcde85af2f35b6b150",
+    "fold-6": "d37ff902e9ac8a329814211904ef6dbdf7a6044b4fa49bf8661e98bf0f0fae0f",
+    "fold-7": "b31253c8bfbc63aadf2b9ae3d7a82edb4d332e062e07574de66fed4a4b48a8ee",
+}
+_UNIVERSE_HASHES = {
+    "fold-0:AP-A1": "3811ac111ceb1dd796710003f206881a5ffd1b80b9c4832622e2b3cdcc41fa11",
+    "fold-0:AP-A2": "7db0083ab034e459f045052c8bad42be77a2ccf5df0c7828de4f1eb6557b22f7",
+    "fold-1:AP-A1": "2192bb777b84d7b9ae793771089e79bc900e2ed38411e6606fc5378b6de73eaf",
+    "fold-1:AP-A2": "3ef1f5e4cbee65b1c041d23b14391123683acdcd4a72831a91da8aa02fc5df00",
+    "fold-2:AP-A1": "56ab91764161c36ef734d3d9179ae6e7dbff3cc2fe00d50bdb47d208e3105248",
+    "fold-2:AP-A2": "6a7e635f68ce3a7d9fbeae9332924b2c9908e52174071c2f73693bdb0d31d684",
+    "fold-3:AP-A1": "733b360f89821e45d61ceab0a279e5318fc3db74918a15d037d5b740870f1941",
+    "fold-3:AP-A2": "e8618c35df6b017cd84dca47a4607baa9986090ca90b6c9924138970a35f8e40",
+    "fold-4:AP-A1": "45a3145da0494c12135a3c559060d1febbc2446f95f8761fe7e58d9f1b1305be",
+    "fold-4:AP-A2": "d2d028c9803092498d5fa7850591f6d945bf9611a624b3665e68be6bc000964a",
+    "fold-5:AP-A1": "3114608742ef9ff19551ab3d4668922f699a9398f45c56366239bfc38494e1df",
+    "fold-5:AP-A2": "dee3b48ced1516013481dad9aaa7f3a0ea5c6f6fa0b6d11407c06ddb19a72e67",
+    "fold-6:AP-A1": "cf5c5a7d4817695b4f9bc2555269b8a1809dd76c4ddefcc956ed7662fc7b82d8",
+    "fold-6:AP-A2": "1064e20936edc6c638ebbe5364482b0073f150e5892e28265ed2a5a4d57af627",
+    "fold-7:AP-A1": "c331085948ab44667e615619770b1720a96700adf48f15ed27c7ea4562b47d29",
+    "fold-7:AP-A2": "ebb3994ad7022776f0a736df0fa8e201e82002f8070dccd1008adbcf2644dc59",
+}
+_MINUTE_HASHES = {
+    "fold-0:AP-A1": "b74732a30da4de5fe4970c45555911c1019d8cc6bdfe2276eb3bcac5bbb1b5d8",
+    "fold-0:AP-A2": "a687e88607bdfb2247110e4a0f244d7e17963b383290072afa78006c8b31bc96",
+    "fold-1:AP-A1": "2e292e4b50cc7308a4ac333e86a3cc208c5c4e8a09268188a7a5f5660c6d10fd",
+    "fold-1:AP-A2": "11dac9610dae09292fda1f2c6706dfb2ec3ce5770a2429ec58eeb21f2817b1df",
+    "fold-2:AP-A1": "76c758fd69287e6a2c324001f71a01c04c3499ace8fffbafa4a09c58934a3484",
+    "fold-2:AP-A2": "d3e579f270829959b34ac749a721718632676a489232e754a1ea0a7b69c2cc05",
+    "fold-3:AP-A1": "cd722aaab16add4a3e6d4597434dd7ff0de32a64ededd851b3d4dbc096681058",
+    "fold-3:AP-A2": "b3b0c406dccf2bc9590ab70e5e7d9f05caa93a8126bd7e21483bc74fcb25bc67",
+    "fold-4:AP-A1": "1daf8e6fe553620084926d139b60f0d79f04a2f78763e832c4283b513965cc72",
+    "fold-4:AP-A2": "9c8662eeea4636aba239410184b5844053b6932fa957d08aa252358f9efc2881",
+    "fold-5:AP-A1": "84691f4678e58f15bff55e8869c97bbe37b90406a9ae2f82e443484dae4d3143",
+    "fold-5:AP-A2": "b594b7f2b0fe6586b76038b8a82fa4b055af9e71d775cfcb48f1ec2223f4487e",
+    "fold-6:AP-A1": "52a6c1be58ad63bc0080a6c63cab71a9932fa709d429deb4b455167e09bcb6a7",
+    "fold-6:AP-A2": "7b0a2651603279997cd3056bab6d8653551ba936b5c0e5281c88d407ff9f458a",
+    "fold-7:AP-A1": "dba362f3e2490017bd037d5ceb14d7874a6d38ef14eb36b1a9b7d0b8d0750399",
+    "fold-7:AP-A2": "bc1a46a526c8c8d82f2105b612ae942143b87c1ce8521d7287e247a96dd165f2",
+}
+
+
+def _manifest_payload() -> dict:
+    return {
+        "run_id": CANONICAL_RUN_ID,
+        "source_kind": CANONICAL_SOURCE_KIND,
+        "anchor_oos_start_ms": CANONICAL_ANCHOR_OOS_START_MS,
+        "symbols": list(CANONICAL_SYMBOLS),
+        "daily_bars_hash_by_fold": _DAILY_HASHES,
+        "universe_grid_hash_by_fold_family": _UNIVERSE_HASHES,
+        "minute_grid_hash_by_fold_family": _MINUTE_HASHES,
+    }
+
+
+_CANONICAL_MANIFEST = CanonicalRunManifest(
+    **_manifest_payload(),
+    manifest_hash=canonical_hash.canonical_sha256(_manifest_payload()),
+    _construction_token=_CONSTRUCTION_TOKEN,
+)
+
+
+def canonical_run_manifest() -> CanonicalRunManifest:
+    """Return the sole code-pinned run authority; no caller-selected path."""
+    return _CANONICAL_MANIFEST

--- a/research/alpaca_track_walkforward/runner.py
+++ b/research/alpaca_track_walkforward/runner.py
@@ -1,0 +1,455 @@
+"""ROB-1062 H4 — the walk-forward runner: wires fold_schedule + H3's two
+signal engines + fill_model + trade_ledger + pnl_views + config_selection +
+blind_counts + oos_mask into one continuous, per-fold, per-family,
+per-config simulation.
+
+Continuity contract (AC3, Run A SS11.2 "OOS 경계 포지션 리셋 없음"): for one
+(fold, family, config), decisions run in ONE unbroken chronological loop
+from ``fold.train_start_ms`` through ``fold.oos_end_ms``, skipping the
+embargo window entirely (no decision is ever dated inside it — AC4). State
+(``prior_state``/``prior_held``) is threaded through this single loop; there
+is no reset anywhere between TRAIN and OOS. A fresh, flat state is used only
+at the very START of each fold's own TRAIN window (folds do not share state
+with each other — each fold is its own independent walk-forward instance,
+per the fold_schedule module's own docstring on why TRAIN windows mostly
+overlap fold-to-fold rather than continuing a single simulation across
+folds).
+
+Trade attribution (a documented, flagged implementation choice — Run A SS15
+does not itself resolve what happens to a trade whose ENTRY and EXIT
+straddle the TRAIN/OOS boundary): a trade (closed or still-open) is
+attributed to whichever phase its ENTRY decision timestamp falls in. A
+TRAIN-entered trade that has not yet closed by ``train_end_ms`` is simply
+carried forward (never force-closed, never reset) and, if it later closes
+during OOS, its REALIZED PnL naturally uses OOS-period price bytes for the
+EXIT leg only — this is an unavoidable consequence of multi-day holding
+periods in ANY walk-forward design and is NOT the same thing as OOS SIGNAL
+information influencing the TRAIN entry decision itself (AC8's concern).
+Symmetrically, an OOS-entered trade's ``modeled_entries`` count (H5's own
+dry-count input) counts ONLY entries whose OWN decision timestamp is inside
+the OOS window — a carried-forward TRAIN position that happens to still be
+open during OOS is not itself a new OOS entry and is never counted as one.
+
+Fill-aware state feedback (a real structural finding, not a simplification):
+H3's own engines assume every ``ENTER``/``EXIT`` signal they accept executes
+INSTANTLY (their ``new_state``/``new_held`` bookkeeping has no concept of a
+fill failing) — exactly correct for H3's own PnL-blind scope, but WRONG once
+H4's historical fill model is layered on top: an ``ENTRY_UNFILLED`` candidate
+never actually became a position, and an ``EXIT_UNFILLED`` position never
+actually closed. Feeding the engine's naive state straight into the next
+decision would let it emit an EXIT for a symbol that was never really
+entered (an unrecoverable "orphan EXIT" — this was caught and fixed during
+this module's own development, see ``tests/test_runner.py``'s dedicated
+regression test). This runner therefore PATCHES engine state immediately
+after every decision, before the next one runs: an unfilled/incomplete ENTER
+is corrected back to flat/unheld; an unfilled/incomplete EXIT is corrected
+back to the SAME long/held state the symbol had going into that decision.
+``trade_ledger.process_entry_signal``/``process_exit_signal`` are the single
+source of truth for "did this leg actually fill" — shared with
+``trade_ledger.build_trades_for_symbol_config`` (a standalone, tested,
+already-consistent-stream batch function) so the fill-outcome logic itself
+is never duplicated, only the state-feedback wiring around it.
+
+Known, documented simplification: a within-decision fill failure does NOT
+retroactively free the cash/rank-slot capacity it naively consumed for
+OTHER candidates evaluated in that SAME decision (H3's engine already
+finalized its own allocation before this runner ever learns which legs
+filled) — it only affects state CARRIED FORWARD into future decisions. This
+mirrors AC16's own "partial fill not modeled" simplification in spirit and
+is flagged here rather than silently accepted.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+import blind_counts as bc
+import config_selection as cs
+import context_binding as ctxb
+import dats_engine as dats_eng
+import decision_calendar as dc
+import oos_mask as om
+import pit_universe_alpaca as pu
+import pnl_views as pv
+import seal_consumption as h3_seal
+import trade_ledger as tl
+import wcmb_engine as wcmb_eng
+import wf_seal_consumption as wf_seal
+from daily_bars import DailyBar, SpotMinute
+from fold_schedule import Fold
+from output_schema import SignalRecord
+
+__all__ = [
+    "ConfigFoldRun",
+    "FamilyFoldResult",
+    "MinuteBarsProvider",
+    "PhaseTradeMetrics",
+    "UniverseSnapshotProvider",
+    "run_family_fold",
+]
+
+UniverseSnapshotProvider = Callable[[int], pu.UniverseSnapshot]
+MinuteBarsProvider = Callable[[str, int], Sequence[SpotMinute]]
+
+_PRIMARY_SCENARIO = "C120"
+
+
+@dataclass(frozen=True)
+class PhaseTradeMetrics:
+    closed_trades_count: int
+    median_trade_e120_bp: float | None
+    modeled_entries_count: int
+    turnover_p: float
+    blind_counts: bc.BlindCounts
+
+
+@dataclass(frozen=True)
+class ConfigFoldRun:
+    config_id: str
+    family: str
+    train_metrics: PhaseTradeMetrics
+    oos_blind_counts: bc.BlindCounts
+    oos_masked_pnl_by_trade: tuple[om.Masked, ...]
+    context_binding_at_oos_start: ctxb.WarmupContextBinding
+
+
+@dataclass(frozen=True)
+class FamilyFoldResult:
+    family: str
+    fold_id: str
+    config_runs: tuple[ConfigFoldRun, ...]
+    selection: cs.ConfigSelectionResult
+
+
+def _decision_timestamps(
+    *, family: str, window_start_ms: int, window_end_ms: int
+) -> list[int]:
+    day_ms = 86_400_000
+    check_fn = dc.is_ap_a1_decision_ts if family == "AP-A1" else dc.is_ap_a2_decision_ts
+    result = []
+    day = window_start_ms
+    while day < window_end_ms:
+        ts = day + dc.DECISION_MINUTE_UTC * 60_000
+        if ts < window_end_ms and check_fn(ts):
+            result.append(ts)
+        day += day_ms
+    return result
+
+
+@dataclass(frozen=True)
+class _ContinuousRunResult:
+    all_records: tuple[SignalRecord, ...]
+    closed_trades: tuple[tl.Trade, ...]
+    open_legs_by_symbol: Mapping[str, tl.OpenLeg]
+    fill_attempts: tuple[tl.FillAttempt, ...]
+
+
+class _RunnerInternalInvariantError(RuntimeError):
+    """The engine emitted an EXIT for a symbol this runner has no tracked
+    open leg for — this would mean engine state and this runner's own
+    fill-aware state patching have desynced. Structurally unreachable given
+    the patching this module performs (see module docstring); kept as an
+    explicit, fail-closed check rather than a silent ``KeyError``."""
+
+
+def _reference_close(
+    bars_by_symbol: Mapping[str, Sequence[DailyBar]], symbol: str, decision_ts_ms: int
+) -> float:
+    _start, window_end = dc.prior_completed_day_window(decision_ts_ms)
+    for bar in bars_by_symbol.get(symbol, ()):
+        if bar.day_end_ms == window_end:
+            return bar.close
+    raise ValueError(
+        f"no reference-close bar for {symbol} at decision {decision_ts_ms} "
+        "(window_end has no matching DailyBar.day_end_ms) — the engine "
+        "should never have fired ENTER/EXIT without one"
+    )
+
+
+def _phase_of(
+    ts: int, *, train_start: int, train_end: int, oos_start: int, oos_end: int
+) -> str:
+    if train_start <= ts < train_end:
+        return "TRAIN"
+    if oos_start <= ts < oos_end:
+        return "OOS"
+    raise ValueError(f"decision_ts {ts} is outside both TRAIN and OOS windows")
+
+
+def _run_continuous_decisions(
+    *,
+    config,
+    family: str,
+    fold: Fold,
+    bars_by_symbol: Mapping[str, Sequence[DailyBar]],
+    universe_snapshot_provider: UniverseSnapshotProvider,
+    minute_bars_provider: MinuteBarsProvider,
+) -> _ContinuousRunResult:
+    timestamps = sorted(
+        _decision_timestamps(
+            family=family,
+            window_start_ms=fold.train_start_ms,
+            window_end_ms=fold.train_end_ms,
+        )
+        + _decision_timestamps(
+            family=family,
+            window_start_ms=fold.oos_start_ms,
+            window_end_ms=fold.oos_end_ms,
+        )
+    )
+    state: dict = {}
+    all_records: list[SignalRecord] = []
+    closed_trades: list[tl.Trade] = []
+    open_legs: dict[str, tl.OpenLeg] = {}
+    fill_attempts: list[tl.FillAttempt] = []
+
+    for ts in timestamps:
+        universe = universe_snapshot_provider(ts)
+        prior_state = state
+        if family == "AP-A1":
+            result = dats_eng.run_ap_a1_decision(
+                decision_ts_ms=ts,
+                config=config,
+                universe=universe,
+                bars_by_symbol=bars_by_symbol,
+                prior_state=prior_state,
+            )
+            naive_new_state: dict = dict(result.new_state)
+        else:
+            result = wcmb_eng.run_ap_a2_decision(
+                decision_ts_ms=ts,
+                config=config,
+                universe=universe,
+                bars_by_symbol=bars_by_symbol,
+                prior_held=prior_state,
+            )
+            naive_new_state = dict(result.new_held)
+
+        all_records.extend(result.records)
+        patched_state = dict(naive_new_state)
+
+        for record in result.records:
+            symbol = record.symbol
+            if record.action == "ENTER":
+                ref = _reference_close(bars_by_symbol, symbol, ts)
+                bars = minute_bars_provider(symbol, ts)
+                attempt, maybe_open_leg = tl.process_entry_signal(
+                    record, reference_close=ref, minute_bars=bars
+                )
+                fill_attempts.append(attempt)
+                if maybe_open_leg is not None:
+                    open_legs[symbol] = maybe_open_leg
+                    # naive_new_state already reflects long/held -- keep it.
+                elif family == "AP-A1":
+                    patched_state[symbol] = dats_eng.AP_A1_PositionState(state="flat")
+                else:
+                    patched_state.pop(symbol, None)
+            elif record.action == "EXIT":
+                open_leg = open_legs.get(symbol)
+                if open_leg is None:
+                    raise _RunnerInternalInvariantError(
+                        f"EXIT for {symbol} at {ts} with no tracked open leg"
+                    )
+                ref = _reference_close(bars_by_symbol, symbol, ts)
+                bars = minute_bars_provider(symbol, ts)
+                attempt, maybe_trade = tl.process_exit_signal(
+                    record, open_leg, reference_close=ref, minute_bars=bars
+                )
+                fill_attempts.append(attempt)
+                if maybe_trade is not None:
+                    closed_trades.append(maybe_trade)
+                    del open_legs[symbol]
+                    # naive_new_state already reflects flat/unheld -- keep it.
+                else:
+                    # Exit did not actually fill -- restore the position
+                    # exactly as it was going into this decision.
+                    patched_state[symbol] = prior_state[symbol]
+        state = patched_state
+
+    return _ContinuousRunResult(
+        all_records=tuple(all_records),
+        closed_trades=tuple(closed_trades),
+        open_legs_by_symbol=dict(open_legs),
+        fill_attempts=tuple(fill_attempts),
+    )
+
+
+def _build_phase_metrics(
+    *,
+    phase: str,
+    run_result: _ContinuousRunResult,
+    fold: Fold,
+    cost_scenarios_bp: Mapping[str, int],
+) -> tuple[PhaseTradeMetrics, tuple[tl.Trade, ...]]:
+    """Derive this phase's metrics from the ALREADY-COMPUTED continuous run
+    result (``_run_continuous_decisions``), by filtering trades/open-legs/
+    fill-attempts by timestamp membership in this phase."""
+
+    def _in_phase(ts: int) -> bool:
+        return (
+            _phase_of(
+                ts,
+                train_start=fold.train_start_ms,
+                train_end=fold.train_end_ms,
+                oos_start=fold.oos_start_ms,
+                oos_end=fold.oos_end_ms,
+            )
+            == phase
+        )
+
+    phase_records = tuple(
+        r for r in run_result.all_records if _in_phase(r.decision_ts_ms)
+    )
+
+    phase_closed_trades = [
+        t for t in run_result.closed_trades if _in_phase(t.entry_decision_ts_ms)
+    ]
+    phase_open_count = sum(
+        1
+        for open_leg in run_result.open_legs_by_symbol.values()
+        if _in_phase(open_leg.entry_decision_ts_ms)
+    )
+    phase_fill_attempts = [
+        a for a in run_result.fill_attempts if _in_phase(a.decision_ts_ms)
+    ]
+
+    modeled_entries_count = len(phase_closed_trades) + phase_open_count
+    turnover_p = modeled_entries_count / len(phase_records) if phase_records else 0.0
+
+    trade_fills = [
+        pv.TradeFill(
+            entry_reference_close=t.entry_reference_close,
+            entry_fill_price=t.entry_fill.fill_price,
+            exit_reference_close=t.exit_reference_close,
+            exit_fill_price=t.exit_fill.fill_price,
+        )
+        for t in phase_closed_trades
+    ]
+    e120_values = [
+        pv.shadow_net_pnl_bp(
+            tf, scenario=_PRIMARY_SCENARIO, cost_scenarios_bp=cost_scenarios_bp
+        )
+        for tf in trade_fills
+    ]
+    median_e120 = statistics.median(e120_values) if e120_values else None
+
+    blind = bc.compute_blind_counts(
+        phase_records,
+        closed_trades=phase_closed_trades,
+        open_positions_count=phase_open_count,
+        fill_attempts=phase_fill_attempts,
+    )
+
+    metrics = PhaseTradeMetrics(
+        closed_trades_count=len(phase_closed_trades),
+        median_trade_e120_bp=median_e120,
+        modeled_entries_count=modeled_entries_count,
+        turnover_p=turnover_p,
+        blind_counts=blind,
+    )
+    return metrics, tuple(phase_closed_trades)
+
+
+def run_family_fold(
+    *,
+    family: str,
+    fold_id: str,
+    fold: Fold,
+    bars_by_symbol: Mapping[str, Sequence[DailyBar]],
+    universe_snapshot_provider: UniverseSnapshotProvider,
+    minute_bars_provider: MinuteBarsProvider,
+) -> FamilyFoldResult:
+    """Run all 8 sealed configs of ``family`` continuously across
+    ``fold``'s TRAIN+OOS windows, select the winning config from TRAIN-only
+    metrics, and return every config's run with OOS PnL masked-by-default."""
+    if family not in ("AP-A1", "AP-A2"):
+        raise ValueError(f"unknown family {family!r}")
+
+    bundle = h3_seal.load_sealed_configs_and_params()
+    family_configs = [c for c in bundle.configs if c.family == family]
+    cost_scenarios_bp = wf_seal.cost_scenarios_bp()
+    stress_cap_pct = wf_seal.stress_annual_cost_cap_pct(family)
+
+    config_runs: list[ConfigFoldRun] = []
+    train_metrics_by_config: dict[str, cs.ConfigTrainMetrics] = {}
+
+    context_binding = ctxb.compute_warmup_context_binding(
+        bars_by_symbol, window_end_ms=fold.oos_start_ms
+    )
+
+    for config in family_configs:
+        run_result = _run_continuous_decisions(
+            config=config,
+            family=family,
+            fold=fold,
+            bars_by_symbol=bars_by_symbol,
+            universe_snapshot_provider=universe_snapshot_provider,
+            minute_bars_provider=minute_bars_provider,
+        )
+        train_metrics, _train_trades = _build_phase_metrics(
+            phase="TRAIN",
+            run_result=run_result,
+            fold=fold,
+            cost_scenarios_bp=cost_scenarios_bp,
+        )
+        oos_metrics, oos_trades = _build_phase_metrics(
+            phase="OOS",
+            run_result=run_result,
+            fold=fold,
+            cost_scenarios_bp=cost_scenarios_bp,
+        )
+
+        train_metrics_by_config[config.config_id] = cs.ConfigTrainMetrics(
+            config_id=config.config_id,
+            closed_trades_count=train_metrics.closed_trades_count,
+            median_trade_e120_bp=train_metrics.median_trade_e120_bp,
+            turnover_p=train_metrics.turnover_p,
+            annualized_stress_cost_pct=bc.annualized_stress_cost_pct(
+                modeled_entries_count=train_metrics.modeled_entries_count,
+                window_days=(fold.train_end_ms - fold.train_start_ms) // 86_400_000,
+                cost_bp=cost_scenarios_bp[wf_seal.primary_cost_scenario()],
+            ),
+        )
+
+        oos_masked = tuple(
+            om.mask(
+                pv.three_view_pnl_bp(
+                    pv.TradeFill(
+                        entry_reference_close=t.entry_reference_close,
+                        entry_fill_price=t.entry_fill.fill_price,
+                        exit_reference_close=t.exit_reference_close,
+                        exit_fill_price=t.exit_fill.fill_price,
+                    ),
+                    cost_scenarios_bp=cost_scenarios_bp,
+                ),
+                fold_id=fold_id,
+                family=family,
+                config_id=config.config_id,
+            )
+            for t in oos_trades
+        )
+
+        config_runs.append(
+            ConfigFoldRun(
+                config_id=config.config_id,
+                family=family,
+                train_metrics=train_metrics,
+                oos_blind_counts=oos_metrics.blind_counts,
+                oos_masked_pnl_by_trade=oos_masked,
+                context_binding_at_oos_start=context_binding,
+            )
+        )
+
+    selection = cs.select_config(
+        [train_metrics_by_config[c.config_id] for c in family_configs],
+        data_window="TRAIN",
+        stress_cost_cap_pct=stress_cap_pct,
+    )
+    return FamilyFoldResult(
+        family=family,
+        fold_id=fold_id,
+        config_runs=tuple(config_runs),
+        selection=selection,
+    )

--- a/research/alpaca_track_walkforward/runner.py
+++ b/research/alpaca_track_walkforward/runner.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 import statistics
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 
 import blind_counts as bc
 import config_selection as cs
@@ -67,6 +68,7 @@ import fold_schedule as fs
 import oos_mask as om
 import pnl_views as pv
 import provider_evidence as pe
+import run_manifest as rm
 import seal_consumption as h3_seal
 import trade_ledger as tl
 import wcmb_engine as wcmb_eng
@@ -107,7 +109,9 @@ class ConfigFoldRun:
     family: str
     train_metrics: PhaseTradeMetrics
     oos_blind_counts: bc.BlindCounts
+    oos_turnover_p: float
     oos_modeled_entry_evidence: tuple[tl.ModeledEntryEvidence, ...]
+    oos_dry_count_gate_handle: om.Masked
     oos_masked_pnl_by_trade: tuple[om.Masked, ...]
     context_binding_at_oos_start: ctxb.WarmupContextBinding
     provider_evidence_binding: pe.RunProviderEvidenceBinding
@@ -146,6 +150,15 @@ class _ContinuousRunResult:
     provider_evidence_binding: pe.RunProviderEvidenceBinding
 
 
+@dataclass(frozen=True)
+class _ProviderSnapshot:
+    """One immutable input snapshot shared by every sealed config."""
+
+    universe_by_ts: Mapping[int, pe.UniverseSnapshotEvidence]
+    minute_by_key: Mapping[tuple[str, int], pe.MinuteBarsEvidence]
+    binding: pe.RunProviderEvidenceBinding
+
+
 class _RunnerInternalInvariantError(RuntimeError):
     """The engine emitted an EXIT for a symbol this runner has no tracked
     open leg for — this would mean engine state and this runner's own
@@ -172,6 +185,209 @@ def _reference_close(
     )
 
 
+def _all_decision_timestamps(*, family: str, fold: Fold) -> tuple[int, ...]:
+    return tuple(
+        sorted(
+            _decision_timestamps(
+                family=family,
+                window_start_ms=fold.train_start_ms,
+                window_end_ms=fold.train_end_ms,
+            )
+            + _decision_timestamps(
+                family=family,
+                window_start_ms=fold.oos_start_ms,
+                window_end_ms=fold.oos_end_ms,
+            )
+        )
+    )
+
+
+def _materialize_provider_snapshot(
+    *,
+    family: str,
+    fold: Fold,
+    fold_id: str,
+    bars_by_symbol: Mapping[str, Sequence[DailyBar]],
+    universe_snapshot_provider: UniverseSnapshotProvider,
+    minute_bars_provider: MinuteBarsProvider,
+) -> _ProviderSnapshot:
+    """Materialize and authenticate every possible provider input once.
+
+    No config can call a stateful provider after another config has entered
+    OOS.  The complete grids are compared to the immutable run manifest, so
+    a caller cannot re-sign changed content with a rewritten timestamp.
+    """
+    manifest = rm.canonical_run_manifest()
+    if tuple(sorted(bars_by_symbol)) != manifest.symbols:
+        raise rm.RunManifestError(
+            "daily corpus symbols do not match the canonical run manifest"
+        )
+    daily_hash = rm.canonical_daily_bars_hash(bars_by_symbol)
+    manifest.assert_daily_bars(fold_id=fold_id, actual_hash=daily_hash)
+
+    timestamps = _all_decision_timestamps(family=family, fold=fold)
+    universe_by_ts: dict[int, pe.UniverseSnapshotEvidence] = {}
+    minute_by_key: dict[tuple[str, int], pe.MinuteBarsEvidence] = {}
+
+    for timestamp in timestamps:
+        evidence = universe_snapshot_provider(timestamp)
+        if type(evidence) is not pe.UniverseSnapshotEvidence:
+            raise TypeError(
+                "universe_snapshot_provider must return UniverseSnapshotEvidence"
+            )
+        try:
+            evidence.assert_integrity(requested_ts_ms=timestamp)
+        except pe.ProviderEvidenceError as exc:
+            raise ProviderTimeBindingError(str(exc)) from exc
+        universe_by_ts[timestamp] = evidence
+
+    universe_grid_hash = rm.canonical_universe_grid_hash(
+        {timestamp: evidence.snapshot for timestamp, evidence in universe_by_ts.items()}
+    )
+    manifest.assert_universe_grid(
+        fold_id=fold_id,
+        family=family,
+        actual_hash=universe_grid_hash,
+    )
+
+    for timestamp in timestamps:
+        for symbol in manifest.symbols:
+            evidence = minute_bars_provider(symbol, timestamp)
+            if type(evidence) is not pe.MinuteBarsEvidence:
+                raise TypeError("minute_bars_provider must return MinuteBarsEvidence")
+            try:
+                evidence.assert_integrity(symbol=symbol, signal_ts_ms=timestamp)
+            except pe.ProviderEvidenceError as exc:
+                raise ProviderTimeBindingError(str(exc)) from exc
+            minute_by_key[(symbol, timestamp)] = evidence
+
+    minute_grid_hash = rm.canonical_minute_grid_hash(
+        {key: evidence.bars for key, evidence in minute_by_key.items()}
+    )
+    manifest.assert_minute_grid(
+        fold_id=fold_id,
+        family=family,
+        actual_hash=minute_grid_hash,
+    )
+    binding = pe.RunProviderEvidenceBinding(
+        run_manifest_hash=manifest.manifest_hash,
+        daily_bars_artifact_hash=daily_hash,
+        universe_grid_hash=universe_grid_hash,
+        minute_grid_hash=minute_grid_hash,
+        universe_artifacts=tuple(
+            (
+                timestamp,
+                evidence.source_as_of_ts_ms,
+                evidence.source_artifact_hash,
+            )
+            for timestamp, evidence in sorted(universe_by_ts.items())
+        ),
+        minute_artifacts=tuple(
+            (
+                symbol,
+                timestamp,
+                evidence.source_as_of_ts_ms,
+                evidence.source_artifact_hash,
+            )
+            for (symbol, timestamp), evidence in sorted(minute_by_key.items())
+        ),
+    )
+    return _ProviderSnapshot(
+        universe_by_ts=MappingProxyType(dict(universe_by_ts)),
+        minute_by_key=MappingProxyType(dict(minute_by_key)),
+        binding=binding,
+    )
+
+
+def _assert_provider_snapshot(
+    *,
+    snapshot: _ProviderSnapshot,
+    family: str,
+    fold: Fold,
+    fold_id: str,
+    bars_by_symbol: Mapping[str, Sequence[DailyBar]],
+) -> None:
+    """Re-authenticate a supplied cache; private arguments are not authority."""
+    if type(snapshot) is not _ProviderSnapshot:
+        raise TypeError("provider_snapshot must be an exact _ProviderSnapshot")
+    manifest = rm.canonical_run_manifest()
+    timestamps = _all_decision_timestamps(family=family, fold=fold)
+    expected_universe_keys = set(timestamps)
+    expected_minute_keys = {
+        (symbol, timestamp) for timestamp in timestamps for symbol in manifest.symbols
+    }
+    if set(snapshot.universe_by_ts) != expected_universe_keys:
+        raise rm.RunManifestError("provider snapshot universe coverage is incomplete")
+    if set(snapshot.minute_by_key) != expected_minute_keys:
+        raise rm.RunManifestError("provider snapshot minute coverage is incomplete")
+
+    for timestamp, evidence in snapshot.universe_by_ts.items():
+        if type(evidence) is not pe.UniverseSnapshotEvidence:
+            raise TypeError("cached universe evidence must use the typed envelope")
+        try:
+            evidence.assert_integrity(requested_ts_ms=timestamp)
+        except pe.ProviderEvidenceError as exc:
+            raise ProviderTimeBindingError(str(exc)) from exc
+    for (symbol, timestamp), evidence in snapshot.minute_by_key.items():
+        if type(evidence) is not pe.MinuteBarsEvidence:
+            raise TypeError("cached minute evidence must use the typed envelope")
+        try:
+            evidence.assert_integrity(symbol=symbol, signal_ts_ms=timestamp)
+        except pe.ProviderEvidenceError as exc:
+            raise ProviderTimeBindingError(str(exc)) from exc
+
+    daily_hash = rm.canonical_daily_bars_hash(bars_by_symbol)
+    universe_hash = rm.canonical_universe_grid_hash(
+        {
+            timestamp: evidence.snapshot
+            for timestamp, evidence in snapshot.universe_by_ts.items()
+        }
+    )
+    minute_hash = rm.canonical_minute_grid_hash(
+        {key: evidence.bars for key, evidence in snapshot.minute_by_key.items()}
+    )
+    manifest.assert_daily_bars(fold_id=fold_id, actual_hash=daily_hash)
+    manifest.assert_provider_grids(
+        fold_id=fold_id,
+        family=family,
+        universe_grid_hash=universe_hash,
+        minute_grid_hash=minute_hash,
+    )
+    binding = snapshot.binding
+    expected_universe_artifacts = tuple(
+        (
+            timestamp,
+            evidence.source_as_of_ts_ms,
+            evidence.source_artifact_hash,
+        )
+        for timestamp, evidence in sorted(snapshot.universe_by_ts.items())
+    )
+    expected_minute_artifacts = tuple(
+        (
+            symbol,
+            timestamp,
+            evidence.source_as_of_ts_ms,
+            evidence.source_artifact_hash,
+        )
+        for (symbol, timestamp), evidence in sorted(snapshot.minute_by_key.items())
+    )
+    expected_binding = pe.RunProviderEvidenceBinding(
+        run_manifest_hash=manifest.manifest_hash,
+        daily_bars_artifact_hash=daily_hash,
+        universe_grid_hash=universe_hash,
+        minute_grid_hash=minute_hash,
+        universe_artifacts=expected_universe_artifacts,
+        minute_artifacts=expected_minute_artifacts,
+    )
+    if (
+        type(binding) is not pe.RunProviderEvidenceBinding
+        or binding != expected_binding
+    ):
+        raise rm.RunManifestError(
+            "provider evidence binding does not match canonical materialized inputs"
+        )
+
+
 def _run_continuous_decisions(
     *,
     config,
@@ -180,47 +396,37 @@ def _run_continuous_decisions(
     bars_by_symbol: Mapping[str, Sequence[DailyBar]],
     universe_snapshot_provider: UniverseSnapshotProvider,
     minute_bars_provider: MinuteBarsProvider,
+    provider_snapshot: _ProviderSnapshot | None = None,
 ) -> _ContinuousRunResult:
     fs.assert_registered_fold_binding(fold_id=f"fold-{fold.fold_index}", fold=fold)
-    timestamps = sorted(
-        _decision_timestamps(
+    fold_id = f"fold-{fold.fold_index}"
+    if provider_snapshot is None:
+        provider_snapshot = _materialize_provider_snapshot(
             family=family,
-            window_start_ms=fold.train_start_ms,
-            window_end_ms=fold.train_end_ms,
+            fold=fold,
+            fold_id=fold_id,
+            bars_by_symbol=bars_by_symbol,
+            universe_snapshot_provider=universe_snapshot_provider,
+            minute_bars_provider=minute_bars_provider,
         )
-        + _decision_timestamps(
-            family=family,
-            window_start_ms=fold.oos_start_ms,
-            window_end_ms=fold.oos_end_ms,
-        )
+    _assert_provider_snapshot(
+        snapshot=provider_snapshot,
+        family=family,
+        fold=fold,
+        fold_id=fold_id,
+        bars_by_symbol=bars_by_symbol,
     )
+    timestamps = _all_decision_timestamps(family=family, fold=fold)
     state: dict = {}
     all_records: list[SignalRecord] = []
     closed_trades: list[tl.Trade] = []
     open_legs: dict[str, tl.OpenLeg] = {}
     fill_attempts: list[tl.FillAttempt] = []
     modeled_entry_evidence: list[tl.ModeledEntryEvidence] = []
-    universe_artifacts: list[tuple[int, int, str]] = []
-    minute_artifacts: list[tuple[str, int, int, str]] = []
 
     for ts in timestamps:
-        universe_evidence = universe_snapshot_provider(ts)
-        if type(universe_evidence) is not pe.UniverseSnapshotEvidence:
-            raise TypeError(
-                "universe_snapshot_provider must return UniverseSnapshotEvidence"
-            )
-        try:
-            universe_evidence.assert_integrity(requested_ts_ms=ts)
-        except pe.ProviderEvidenceError as exc:
-            raise ProviderTimeBindingError(str(exc)) from exc
+        universe_evidence = provider_snapshot.universe_by_ts[ts]
         universe = universe_evidence.snapshot
-        universe_artifacts.append(
-            (
-                ts,
-                universe_evidence.source_as_of_ts_ms,
-                universe_evidence.source_artifact_hash,
-            )
-        )
         prior_state = state
         if family == "AP-A1":
             result = dats_eng.run_ap_a1_decision(
@@ -248,23 +454,7 @@ def _run_continuous_decisions(
             symbol = record.symbol
             if record.action == "ENTER":
                 ref = _reference_close(bars_by_symbol, symbol, ts)
-                minute_evidence = minute_bars_provider(symbol, ts)
-                if type(minute_evidence) is not pe.MinuteBarsEvidence:
-                    raise TypeError(
-                        "minute_bars_provider must return MinuteBarsEvidence"
-                    )
-                try:
-                    minute_evidence.assert_integrity(symbol=symbol, signal_ts_ms=ts)
-                except pe.ProviderEvidenceError as exc:
-                    raise ProviderTimeBindingError(str(exc)) from exc
-                minute_artifacts.append(
-                    (
-                        symbol,
-                        ts,
-                        minute_evidence.source_as_of_ts_ms,
-                        minute_evidence.source_artifact_hash,
-                    )
-                )
+                minute_evidence = provider_snapshot.minute_by_key[(symbol, ts)]
                 attempt, maybe_open_leg = tl.process_entry_signal(
                     record,
                     reference_close=ref,
@@ -286,23 +476,7 @@ def _run_continuous_decisions(
                         f"EXIT for {symbol} at {ts} with no tracked open leg"
                     )
                 ref = _reference_close(bars_by_symbol, symbol, ts)
-                minute_evidence = minute_bars_provider(symbol, ts)
-                if type(minute_evidence) is not pe.MinuteBarsEvidence:
-                    raise TypeError(
-                        "minute_bars_provider must return MinuteBarsEvidence"
-                    )
-                try:
-                    minute_evidence.assert_integrity(symbol=symbol, signal_ts_ms=ts)
-                except pe.ProviderEvidenceError as exc:
-                    raise ProviderTimeBindingError(str(exc)) from exc
-                minute_artifacts.append(
-                    (
-                        symbol,
-                        ts,
-                        minute_evidence.source_as_of_ts_ms,
-                        minute_evidence.source_artifact_hash,
-                    )
-                )
+                minute_evidence = provider_snapshot.minute_by_key[(symbol, ts)]
                 attempt, maybe_trade = tl.process_exit_signal(
                     record,
                     open_leg,
@@ -326,10 +500,7 @@ def _run_continuous_decisions(
         open_legs_by_symbol=dict(open_legs),
         fill_attempts=tuple(fill_attempts),
         modeled_entry_evidence=tuple(modeled_entry_evidence),
-        provider_evidence_binding=pe.RunProviderEvidenceBinding(
-            universe_artifacts=tuple(universe_artifacts),
-            minute_artifacts=tuple(minute_artifacts),
-        ),
+        provider_evidence_binding=provider_snapshot.binding,
     )
 
 
@@ -475,6 +646,14 @@ def run_family_fold(
     bars_snapshot = {
         symbol: tuple(bars_by_symbol[symbol]) for symbol in sorted(bars_by_symbol)
     }
+    provider_snapshot = _materialize_provider_snapshot(
+        family=family,
+        fold=fold,
+        fold_id=fold_id,
+        bars_by_symbol=bars_snapshot,
+        universe_snapshot_provider=universe_snapshot_provider,
+        minute_bars_provider=minute_bars_provider,
+    )
     context_binding = ctxb.compute_warmup_context_binding(
         bars_snapshot, window_end_ms=fold.oos_start_ms
     )
@@ -487,6 +666,7 @@ def run_family_fold(
             bars_by_symbol=bars_snapshot,
             universe_snapshot_provider=universe_snapshot_provider,
             minute_bars_provider=minute_bars_provider,
+            provider_snapshot=provider_snapshot,
         )
         train_metrics, _train_trades = _build_phase_metrics(
             phase="TRAIN",
@@ -509,6 +689,7 @@ def run_family_fold(
 
         train_metrics_by_config[config.config_id] = cs.ConfigTrainMetrics(
             config_id=config.config_id,
+            is_incomplete=train_metrics.blind_counts.is_incomplete,
             closed_trades_count=train_metrics.closed_trades_count,
             median_trade_e120_bp=train_metrics.median_trade_e120_bp,
             turnover_p=train_metrics.turnover_p,
@@ -541,6 +722,13 @@ def run_family_fold(
             )
             for t in oos_trades
         )
+        oos_gate_handle = om.mask(
+            True,
+            fold_id=fold_id,
+            family=family,
+            config_id=config.config_id,
+            dry_counts=oos_metrics.blind_counts,
+        )
 
         config_runs.append(
             ConfigFoldRun(
@@ -548,7 +736,9 @@ def run_family_fold(
                 family=family,
                 train_metrics=train_metrics,
                 oos_blind_counts=oos_metrics.blind_counts,
+                oos_turnover_p=oos_metrics.turnover_p,
                 oos_modeled_entry_evidence=oos_metrics.modeled_entry_evidence,
+                oos_dry_count_gate_handle=oos_gate_handle,
                 oos_masked_pnl_by_trade=oos_masked,
                 context_binding_at_oos_start=context_binding,
                 provider_evidence_binding=run_result.provider_evidence_binding,

--- a/research/alpaca_track_walkforward/runner.py
+++ b/research/alpaca_track_walkforward/runner.py
@@ -65,13 +65,13 @@ import dats_engine as dats_eng
 import decision_calendar as dc
 import fold_schedule as fs
 import oos_mask as om
-import pit_universe_alpaca as pu
 import pnl_views as pv
+import provider_evidence as pe
 import seal_consumption as h3_seal
 import trade_ledger as tl
 import wcmb_engine as wcmb_eng
 import wf_seal_consumption as wf_seal
-from daily_bars import DailyBar, SpotMinute
+from daily_bars import DailyBar
 from fold_schedule import Fold
 from output_schema import SignalRecord
 
@@ -85,8 +85,8 @@ __all__ = [
     "run_family_fold",
 ]
 
-UniverseSnapshotProvider = Callable[[int], pu.UniverseSnapshot]
-MinuteBarsProvider = Callable[[str, int], Sequence[SpotMinute]]
+UniverseSnapshotProvider = Callable[[int], pe.UniverseSnapshotEvidence]
+MinuteBarsProvider = Callable[[str, int], pe.MinuteBarsEvidence]
 
 _PRIMARY_SCENARIO = "C120"
 
@@ -110,6 +110,7 @@ class ConfigFoldRun:
     oos_modeled_entry_evidence: tuple[tl.ModeledEntryEvidence, ...]
     oos_masked_pnl_by_trade: tuple[om.Masked, ...]
     context_binding_at_oos_start: ctxb.WarmupContextBinding
+    provider_evidence_binding: pe.RunProviderEvidenceBinding
 
 
 @dataclass(frozen=True)
@@ -142,6 +143,7 @@ class _ContinuousRunResult:
     open_legs_by_symbol: Mapping[str, tl.OpenLeg]
     fill_attempts: tuple[tl.FillAttempt, ...]
     modeled_entry_evidence: tuple[tl.ModeledEntryEvidence, ...]
+    provider_evidence_binding: pe.RunProviderEvidenceBinding
 
 
 class _RunnerInternalInvariantError(RuntimeError):
@@ -198,16 +200,27 @@ def _run_continuous_decisions(
     open_legs: dict[str, tl.OpenLeg] = {}
     fill_attempts: list[tl.FillAttempt] = []
     modeled_entry_evidence: list[tl.ModeledEntryEvidence] = []
+    universe_artifacts: list[tuple[int, int, str]] = []
+    minute_artifacts: list[tuple[str, int, int, str]] = []
 
     for ts in timestamps:
-        universe = universe_snapshot_provider(ts)
-        if type(universe) is not pu.UniverseSnapshot:
-            raise TypeError("universe_snapshot_provider must return UniverseSnapshot")
-        if universe.decision_ts_ms != ts:
-            raise ProviderTimeBindingError(
-                "universe snapshot timestamp does not equal the requested "
-                "decision timestamp"
+        universe_evidence = universe_snapshot_provider(ts)
+        if type(universe_evidence) is not pe.UniverseSnapshotEvidence:
+            raise TypeError(
+                "universe_snapshot_provider must return UniverseSnapshotEvidence"
             )
+        try:
+            universe_evidence.assert_integrity(requested_ts_ms=ts)
+        except pe.ProviderEvidenceError as exc:
+            raise ProviderTimeBindingError(str(exc)) from exc
+        universe = universe_evidence.snapshot
+        universe_artifacts.append(
+            (
+                ts,
+                universe_evidence.source_as_of_ts_ms,
+                universe_evidence.source_artifact_hash,
+            )
+        )
         prior_state = state
         if family == "AP-A1":
             result = dats_eng.run_ap_a1_decision(
@@ -235,9 +248,27 @@ def _run_continuous_decisions(
             symbol = record.symbol
             if record.action == "ENTER":
                 ref = _reference_close(bars_by_symbol, symbol, ts)
-                bars = minute_bars_provider(symbol, ts)
+                minute_evidence = minute_bars_provider(symbol, ts)
+                if type(minute_evidence) is not pe.MinuteBarsEvidence:
+                    raise TypeError(
+                        "minute_bars_provider must return MinuteBarsEvidence"
+                    )
+                try:
+                    minute_evidence.assert_integrity(symbol=symbol, signal_ts_ms=ts)
+                except pe.ProviderEvidenceError as exc:
+                    raise ProviderTimeBindingError(str(exc)) from exc
+                minute_artifacts.append(
+                    (
+                        symbol,
+                        ts,
+                        minute_evidence.source_as_of_ts_ms,
+                        minute_evidence.source_artifact_hash,
+                    )
+                )
                 attempt, maybe_open_leg = tl.process_entry_signal(
-                    record, reference_close=ref, minute_bars=bars
+                    record,
+                    reference_close=ref,
+                    minute_bars=minute_evidence.bars,
                 )
                 fill_attempts.append(attempt)
                 if maybe_open_leg is not None:
@@ -255,9 +286,28 @@ def _run_continuous_decisions(
                         f"EXIT for {symbol} at {ts} with no tracked open leg"
                     )
                 ref = _reference_close(bars_by_symbol, symbol, ts)
-                bars = minute_bars_provider(symbol, ts)
+                minute_evidence = minute_bars_provider(symbol, ts)
+                if type(minute_evidence) is not pe.MinuteBarsEvidence:
+                    raise TypeError(
+                        "minute_bars_provider must return MinuteBarsEvidence"
+                    )
+                try:
+                    minute_evidence.assert_integrity(symbol=symbol, signal_ts_ms=ts)
+                except pe.ProviderEvidenceError as exc:
+                    raise ProviderTimeBindingError(str(exc)) from exc
+                minute_artifacts.append(
+                    (
+                        symbol,
+                        ts,
+                        minute_evidence.source_as_of_ts_ms,
+                        minute_evidence.source_artifact_hash,
+                    )
+                )
                 attempt, maybe_trade = tl.process_exit_signal(
-                    record, open_leg, reference_close=ref, minute_bars=bars
+                    record,
+                    open_leg,
+                    reference_close=ref,
+                    minute_bars=minute_evidence.bars,
                 )
                 fill_attempts.append(attempt)
                 if maybe_trade is not None:
@@ -276,6 +326,10 @@ def _run_continuous_decisions(
         open_legs_by_symbol=dict(open_legs),
         fill_attempts=tuple(fill_attempts),
         modeled_entry_evidence=tuple(modeled_entry_evidence),
+        provider_evidence_binding=pe.RunProviderEvidenceBinding(
+            universe_artifacts=tuple(universe_artifacts),
+            minute_artifacts=tuple(minute_artifacts),
+        ),
     )
 
 
@@ -285,6 +339,7 @@ def _build_phase_metrics(
     run_result: _ContinuousRunResult,
     fold: Fold,
     cost_scenarios_bp: Mapping[str, int],
+    turnover_capacity_k: int | None,
 ) -> tuple[PhaseTradeMetrics, tuple[tl.Trade, ...]]:
     """Derive this phase's metrics from the ALREADY-COMPUTED continuous run
     result (``_run_continuous_decisions``), by filtering trades/open-legs/
@@ -321,7 +376,26 @@ def _build_phase_metrics(
     ]
 
     modeled_entries_count = len(phase_modeled_entries)
-    turnover_p = modeled_entries_count / len(phase_records) if phase_records else 0.0
+    if turnover_capacity_k is None:
+        turnover_p = (
+            modeled_entries_count / len(phase_records) if phase_records else 0.0
+        )
+    else:
+        if type(turnover_capacity_k) is not int or turnover_capacity_k <= 0:
+            raise ValueError("turnover_capacity_k must be a positive built-in int")
+        weekly_evaluations = len(
+            _decision_timestamps(
+                family="AP-A2",
+                window_start_ms=phase_start_ms,
+                window_end_ms=phase_end_ms,
+            )
+        )
+        if weekly_evaluations <= 0:
+            raise ValueError("AP-A2 phase must contain scheduled weekly evaluations")
+        # Run A §7/§12.6: E[entries/fold] = evaluations * k * p.
+        # Therefore p is replacement incidence per available top-k slot,
+        # not entries divided by every symbol decision record.
+        turnover_p = modeled_entries_count / (weekly_evaluations * turnover_capacity_k)
 
     trade_fills = [
         pv.TradeFill(
@@ -419,12 +493,18 @@ def run_family_fold(
             run_result=run_result,
             fold=fold,
             cost_scenarios_bp=cost_scenarios_bp,
+            turnover_capacity_k=(
+                int(config.params["k"]) if family == "AP-A2" else None
+            ),
         )
         oos_metrics, oos_trades = _build_phase_metrics(
             phase="OOS",
             run_result=run_result,
             fold=fold,
             cost_scenarios_bp=cost_scenarios_bp,
+            turnover_capacity_k=(
+                int(config.params["k"]) if family == "AP-A2" else None
+            ),
         )
 
         train_metrics_by_config[config.config_id] = cs.ConfigTrainMetrics(
@@ -471,6 +551,7 @@ def run_family_fold(
                 oos_modeled_entry_evidence=oos_metrics.modeled_entry_evidence,
                 oos_masked_pnl_by_trade=oos_masked,
                 context_binding_at_oos_start=context_binding,
+                provider_evidence_binding=run_result.provider_evidence_binding,
             )
         )
 
@@ -478,6 +559,7 @@ def run_family_fold(
         [train_metrics_by_config[c.config_id] for c in family_configs],
         data_window="TRAIN",
         stress_cost_cap_pct=stress_cap_pct,
+        turnover_band=(wf_seal.ap_a2_turnover_band() if family == "AP-A2" else None),
     )
     return FamilyFoldResult(
         family=family,

--- a/research/alpaca_track_walkforward/runner.py
+++ b/research/alpaca_track_walkforward/runner.py
@@ -15,20 +15,13 @@ per the fold_schedule module's own docstring on why TRAIN windows mostly
 overlap fold-to-fold rather than continuing a single simulation across
 folds).
 
-Trade attribution (a documented, flagged implementation choice — Run A SS15
-does not itself resolve what happens to a trade whose ENTRY and EXIT
-straddle the TRAIN/OOS boundary): a trade (closed or still-open) is
-attributed to whichever phase its ENTRY decision timestamp falls in. A
-TRAIN-entered trade that has not yet closed by ``train_end_ms`` is simply
-carried forward (never force-closed, never reset) and, if it later closes
-during OOS, its REALIZED PnL naturally uses OOS-period price bytes for the
-EXIT leg only — this is an unavoidable consequence of multi-day holding
-periods in ANY walk-forward design and is NOT the same thing as OOS SIGNAL
-information influencing the TRAIN entry decision itself (AC8's concern).
-Symmetrically, an OOS-entered trade's ``modeled_entries`` count (H5's own
-dry-count input) counts ONLY entries whose OWN decision timestamp is inside
-the OOS window — a carried-forward TRAIN position that happens to still be
-open during OOS is not itself a new OOS entry and is never counted as one.
+Event-time attribution (2026-07-26 audit-contract freeze): an actual ENTRY
+fill belongs to the half-open window containing ``entry_fill_ts_ms`` for
+modeled-entry dry count and C120 cost, regardless of whether it later closes.
+A closed trade/E120 belongs to a window only when BOTH its entry-fill and
+exit-fill timestamps are inside that same window. Cross-boundary positions
+remain carried without reset or synthetic exit, but their later exit price
+cannot enter an earlier window's closed/E120 statistic.
 
 Fill-aware state feedback (a real structural finding, not a simplification):
 H3's own engines assume every ``ENTER``/``EXIT`` signal they accept executes
@@ -70,6 +63,7 @@ import config_selection as cs
 import context_binding as ctxb
 import dats_engine as dats_eng
 import decision_calendar as dc
+import fold_schedule as fs
 import oos_mask as om
 import pit_universe_alpaca as pu
 import pnl_views as pv
@@ -86,6 +80,7 @@ __all__ = [
     "FamilyFoldResult",
     "MinuteBarsProvider",
     "PhaseTradeMetrics",
+    "ProviderTimeBindingError",
     "UniverseSnapshotProvider",
     "run_family_fold",
 ]
@@ -102,6 +97,7 @@ class PhaseTradeMetrics:
     median_trade_e120_bp: float | None
     modeled_entries_count: int
     turnover_p: float
+    modeled_entry_evidence: tuple[tl.ModeledEntryEvidence, ...]
     blind_counts: bc.BlindCounts
 
 
@@ -111,6 +107,7 @@ class ConfigFoldRun:
     family: str
     train_metrics: PhaseTradeMetrics
     oos_blind_counts: bc.BlindCounts
+    oos_modeled_entry_evidence: tuple[tl.ModeledEntryEvidence, ...]
     oos_masked_pnl_by_trade: tuple[om.Masked, ...]
     context_binding_at_oos_start: ctxb.WarmupContextBinding
 
@@ -144,6 +141,7 @@ class _ContinuousRunResult:
     closed_trades: tuple[tl.Trade, ...]
     open_legs_by_symbol: Mapping[str, tl.OpenLeg]
     fill_attempts: tuple[tl.FillAttempt, ...]
+    modeled_entry_evidence: tuple[tl.ModeledEntryEvidence, ...]
 
 
 class _RunnerInternalInvariantError(RuntimeError):
@@ -152,6 +150,10 @@ class _RunnerInternalInvariantError(RuntimeError):
     fill-aware state patching have desynced. Structurally unreachable given
     the patching this module performs (see module docstring); kept as an
     explicit, fail-closed check rather than a silent ``KeyError``."""
+
+
+class ProviderTimeBindingError(ValueError):
+    """A provider returned evidence for a timestamp other than requested."""
 
 
 def _reference_close(
@@ -168,16 +170,6 @@ def _reference_close(
     )
 
 
-def _phase_of(
-    ts: int, *, train_start: int, train_end: int, oos_start: int, oos_end: int
-) -> str:
-    if train_start <= ts < train_end:
-        return "TRAIN"
-    if oos_start <= ts < oos_end:
-        return "OOS"
-    raise ValueError(f"decision_ts {ts} is outside both TRAIN and OOS windows")
-
-
 def _run_continuous_decisions(
     *,
     config,
@@ -187,6 +179,7 @@ def _run_continuous_decisions(
     universe_snapshot_provider: UniverseSnapshotProvider,
     minute_bars_provider: MinuteBarsProvider,
 ) -> _ContinuousRunResult:
+    fs.assert_registered_fold_binding(fold_id=f"fold-{fold.fold_index}", fold=fold)
     timestamps = sorted(
         _decision_timestamps(
             family=family,
@@ -204,9 +197,17 @@ def _run_continuous_decisions(
     closed_trades: list[tl.Trade] = []
     open_legs: dict[str, tl.OpenLeg] = {}
     fill_attempts: list[tl.FillAttempt] = []
+    modeled_entry_evidence: list[tl.ModeledEntryEvidence] = []
 
     for ts in timestamps:
         universe = universe_snapshot_provider(ts)
+        if type(universe) is not pu.UniverseSnapshot:
+            raise TypeError("universe_snapshot_provider must return UniverseSnapshot")
+        if universe.decision_ts_ms != ts:
+            raise ProviderTimeBindingError(
+                "universe snapshot timestamp does not equal the requested "
+                "decision timestamp"
+            )
         prior_state = state
         if family == "AP-A1":
             result = dats_eng.run_ap_a1_decision(
@@ -241,6 +242,7 @@ def _run_continuous_decisions(
                 fill_attempts.append(attempt)
                 if maybe_open_leg is not None:
                     open_legs[symbol] = maybe_open_leg
+                    modeled_entry_evidence.append(maybe_open_leg.entry_evidence)
                     # naive_new_state already reflects long/held -- keep it.
                 elif family == "AP-A1":
                     patched_state[symbol] = dats_eng.AP_A1_PositionState(state="flat")
@@ -273,6 +275,7 @@ def _run_continuous_decisions(
         closed_trades=tuple(closed_trades),
         open_legs_by_symbol=dict(open_legs),
         fill_attempts=tuple(fill_attempts),
+        modeled_entry_evidence=tuple(modeled_entry_evidence),
     )
 
 
@@ -286,36 +289,38 @@ def _build_phase_metrics(
     """Derive this phase's metrics from the ALREADY-COMPUTED continuous run
     result (``_run_continuous_decisions``), by filtering trades/open-legs/
     fill-attempts by timestamp membership in this phase."""
+    if phase == "TRAIN":
+        phase_start_ms, phase_end_ms = fold.train_start_ms, fold.train_end_ms
+    elif phase == "OOS":
+        phase_start_ms, phase_end_ms = fold.oos_start_ms, fold.oos_end_ms
+    else:
+        raise ValueError(f"unknown phase {phase!r}")
 
     def _in_phase(ts: int) -> bool:
-        return (
-            _phase_of(
-                ts,
-                train_start=fold.train_start_ms,
-                train_end=fold.train_end_ms,
-                oos_start=fold.oos_start_ms,
-                oos_end=fold.oos_end_ms,
-            )
-            == phase
-        )
+        return phase_start_ms <= ts < phase_end_ms
 
     phase_records = tuple(
         r for r in run_result.all_records if _in_phase(r.decision_ts_ms)
     )
 
-    phase_closed_trades = [
-        t for t in run_result.closed_trades if _in_phase(t.entry_decision_ts_ms)
-    ]
-    phase_open_count = sum(
-        1
-        for open_leg in run_result.open_legs_by_symbol.values()
-        if _in_phase(open_leg.entry_decision_ts_ms)
+    phase_modeled_entries = tuple(
+        entry
+        for entry in run_result.modeled_entry_evidence
+        if _in_phase(entry.entry_fill_ts_ms)
     )
+    phase_closed_trades = [
+        trade
+        for trade in run_result.closed_trades
+        if _in_phase(trade.entry_fill_ts_ms) and _in_phase(trade.exit_fill_ts_ms)
+    ]
+    # Entries that close outside the phase remain open at this phase's end
+    # for phase accounting, even if the continuous lifecycle later closes.
+    phase_open_count = len(phase_modeled_entries) - len(phase_closed_trades)
     phase_fill_attempts = [
         a for a in run_result.fill_attempts if _in_phase(a.decision_ts_ms)
     ]
 
-    modeled_entries_count = len(phase_closed_trades) + phase_open_count
+    modeled_entries_count = len(phase_modeled_entries)
     turnover_p = modeled_entries_count / len(phase_records) if phase_records else 0.0
 
     trade_fills = [
@@ -340,6 +345,7 @@ def _build_phase_metrics(
         closed_trades=phase_closed_trades,
         open_positions_count=phase_open_count,
         fill_attempts=phase_fill_attempts,
+        modeled_entries_count=modeled_entries_count,
     )
 
     metrics = PhaseTradeMetrics(
@@ -347,6 +353,7 @@ def _build_phase_metrics(
         median_trade_e120_bp=median_e120,
         modeled_entries_count=modeled_entries_count,
         turnover_p=turnover_p,
+        modeled_entry_evidence=phase_modeled_entries,
         blind_counts=blind,
     )
     return metrics, tuple(phase_closed_trades)
@@ -366,6 +373,19 @@ def run_family_fold(
     metrics, and return every config's run with OOS PnL masked-by-default."""
     if family not in ("AP-A1", "AP-A2"):
         raise ValueError(f"unknown family {family!r}")
+    fs.assert_registered_fold_binding(fold_id=fold_id, fold=fold)
+    wf_seal.assert_policy_matches_schedule_constants(
+        oos_folds_const=fs.OOS_FOLDS,
+        oos_days_const=fs.OOS_DAYS,
+        train_days_const=fs.TRAIN_DAYS,
+        embargo_days_const=fs.EMBARGO_DAYS,
+        roll_days_const=fs.ROLL_DAYS,
+    )
+    train_window_days = (fold.train_end_ms - fold.train_start_ms) // fs.DAY_MS
+    if train_window_days != wf_seal.train_days():
+        raise wf_seal.SealDriftError(
+            "canonical TRAIN window must equal the sealed day count"
+        )
 
     bundle = h3_seal.load_sealed_configs_and_params()
     family_configs = [c for c in bundle.configs if c.family == family]
@@ -375,8 +395,14 @@ def run_family_fold(
     config_runs: list[ConfigFoldRun] = []
     train_metrics_by_config: dict[str, cs.ConfigTrainMetrics] = {}
 
+    # Snapshot caller-owned buffers once. Engines and context evidence read
+    # these same tuples, so an in-run caller mutation cannot silently
+    # substitute bytes after the binding was computed.
+    bars_snapshot = {
+        symbol: tuple(bars_by_symbol[symbol]) for symbol in sorted(bars_by_symbol)
+    }
     context_binding = ctxb.compute_warmup_context_binding(
-        bars_by_symbol, window_end_ms=fold.oos_start_ms
+        bars_snapshot, window_end_ms=fold.oos_start_ms
     )
 
     for config in family_configs:
@@ -384,7 +410,7 @@ def run_family_fold(
             config=config,
             family=family,
             fold=fold,
-            bars_by_symbol=bars_by_symbol,
+            bars_by_symbol=bars_snapshot,
             universe_snapshot_provider=universe_snapshot_provider,
             minute_bars_provider=minute_bars_provider,
         )
@@ -407,9 +433,13 @@ def run_family_fold(
             median_trade_e120_bp=train_metrics.median_trade_e120_bp,
             turnover_p=train_metrics.turnover_p,
             annualized_stress_cost_pct=bc.annualized_stress_cost_pct(
-                modeled_entries_count=train_metrics.modeled_entries_count,
-                window_days=(fold.train_end_ms - fold.train_start_ms) // 86_400_000,
-                cost_bp=cost_scenarios_bp[wf_seal.primary_cost_scenario()],
+                entry_filled_notionals=tuple(
+                    entry.entry_filled_notional
+                    for entry in train_metrics.modeled_entry_evidence
+                ),
+                window_days=train_window_days,
+                nav_usd=h3_seal.initial_equity_usd(),
+                cost_bp=float(cost_scenarios_bp[wf_seal.primary_cost_scenario()]),
             ),
         )
 
@@ -427,6 +457,7 @@ def run_family_fold(
                 fold_id=fold_id,
                 family=family,
                 config_id=config.config_id,
+                dry_counts=oos_metrics.blind_counts,
             )
             for t in oos_trades
         )
@@ -437,6 +468,7 @@ def run_family_fold(
                 family=family,
                 train_metrics=train_metrics,
                 oos_blind_counts=oos_metrics.blind_counts,
+                oos_modeled_entry_evidence=oos_metrics.modeled_entry_evidence,
                 oos_masked_pnl_by_trade=oos_masked,
                 context_binding_at_oos_start=context_binding,
             )

--- a/research/alpaca_track_walkforward/tests/conftest.py
+++ b/research/alpaca_track_walkforward/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Make the alpaca_track_walkforward package, its H1/H2/H3 producer
+siblings, the sibling nautilus_scalping package, and the repo root
+importable in tests — mirrors ``research/alpaca_track_signals/tests/
+conftest.py``. See the package-level ``conftest.py`` (one directory
+shallower) for the full rationale.
+"""
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = (
+    _HERE.parent.parent.parent
+)  # tests -> alpaca_track_walkforward -> research -> repo root
+_NAUTILUS_SCALPING = _REPO_ROOT / "research" / "nautilus_scalping"
+_ALPACA_TRACK = _REPO_ROOT / "research" / "alpaca_track"
+_ALPACA_TRACK_SEAL = _REPO_ROOT / "research" / "alpaca_track_seal"
+_ALPACA_TRACK_SIGNALS = _REPO_ROOT / "research" / "alpaca_track_signals"
+
+assert _NAUTILUS_SCALPING.is_dir(), (
+    f"conftest path arithmetic is broken: {_NAUTILUS_SCALPING} does not exist "
+    f"(computed repo root: {_REPO_ROOT})"
+)
+assert _ALPACA_TRACK.is_dir(), f"{_ALPACA_TRACK} does not exist"
+assert _ALPACA_TRACK_SEAL.is_dir(), f"{_ALPACA_TRACK_SEAL} does not exist"
+assert _ALPACA_TRACK_SIGNALS.is_dir(), f"{_ALPACA_TRACK_SIGNALS} does not exist"
+
+for _p in (
+    str(_HERE),
+    str(_ALPACA_TRACK),
+    str(_ALPACA_TRACK_SEAL),
+    str(_ALPACA_TRACK_SIGNALS),
+    str(_NAUTILUS_SCALPING),
+    str(_REPO_ROOT),
+):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)

--- a/research/alpaca_track_walkforward/tests/synthetic_fixture.py
+++ b/research/alpaca_track_walkforward/tests/synthetic_fixture.py
@@ -14,8 +14,9 @@ symbols, and AP-A2 WCM-B sees genuine cross-sectional rank variation.
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping
 
+import provider_evidence as pe
 from daily_bars import DailyBar, SpotMinute
 from pit_universe_alpaca import SymbolEligibility, UniverseSnapshot
 
@@ -82,10 +83,10 @@ def build_bars_by_symbol(
 
 def make_universe_snapshot_provider(
     n_symbols: int = N_SYMBOLS,
-) -> callable:
+) -> Callable[[int], pe.UniverseSnapshotEvidence]:
     names = tuple(sorted(symbol_names(n_symbols)))
 
-    def provider(decision_ts_ms: int) -> UniverseSnapshot:
+    def provider(decision_ts_ms: int) -> pe.UniverseSnapshotEvidence:
         per_symbol = tuple(
             SymbolEligibility(
                 symbol=s,
@@ -96,31 +97,32 @@ def make_universe_snapshot_provider(
             )
             for s in names
         )
-        return UniverseSnapshot(
+        snapshot = UniverseSnapshot(
             decision_ts_ms=decision_ts_ms,
             eligible_symbols=names,
             per_symbol=per_symbol,
             n_t=len(names),
             meets_min_universe_size=True,
         )
+        return pe.bind_universe_snapshot(snapshot, source_as_of_ts_ms=decision_ts_ms)
 
     return provider
 
 
 def make_minute_bars_provider(
     *, window_start_ms: int, n_symbols: int = N_SYMBOLS
-) -> callable:
+) -> Callable[[str, int], pe.MinuteBarsEvidence]:
     idx_by_symbol: Mapping[str, int] = {
         s: i for i, s in enumerate(symbol_names(n_symbols))
     }
 
-    def provider(symbol: str, decision_ts_ms: int) -> Sequence[SpotMinute]:
+    def provider(symbol: str, decision_ts_ms: int) -> pe.MinuteBarsEvidence:
         idx = idx_by_symbol[symbol]
         day_index = (decision_ts_ms - window_start_ms) // DAY_MS
         price = close_for(idx, day_index)
         m1 = decision_ts_ms + 60_000
         m2 = decision_ts_ms + 120_000
-        return [
+        bars = [
             SpotMinute(
                 open_time_ms=m1,
                 open=price,
@@ -138,5 +140,10 @@ def make_minute_bars_provider(
                 volume=1.0,
             ),
         ]
+        return pe.bind_minute_bars(
+            symbol=symbol,
+            signal_ts_ms=decision_ts_ms,
+            bars=bars,
+        )
 
     return provider

--- a/research/alpaca_track_walkforward/tests/synthetic_fixture.py
+++ b/research/alpaca_track_walkforward/tests/synthetic_fixture.py
@@ -111,8 +111,8 @@ def make_minute_bars_provider(
         idx = idx_by_symbol[symbol]
         day_index = (decision_ts_ms - window_start_ms) // DAY_MS
         price = close_for(idx, day_index)
-        m1 = decision_ts_ms
-        m2 = decision_ts_ms + 60_000
+        m1 = decision_ts_ms + 60_000
+        m2 = decision_ts_ms + 120_000
         return [
             SpotMinute(
                 open_time_ms=m1,

--- a/research/alpaca_track_walkforward/tests/synthetic_fixture.py
+++ b/research/alpaca_track_walkforward/tests/synthetic_fixture.py
@@ -1,0 +1,135 @@
+"""ROB-1062 H4 — a deterministic, closed-form SYNTHETIC corpus fixture for
+runner integration tests and the golden digest. NEVER real Binance archive
+data (H1 AC25's real one-time collection has not happened and is not this
+module's concern) — every price is a pure function of a symbol index and a
+day index, no randomness, no wall clock, byte-identical across repeated
+calls.
+
+20 symbols (matching H2's sealed_effective_n) with varying sinusoidal
+amplitude/period/phase so AP-A1 DATS sees both persistent-uptrend (never
+exits within the window) and up-then-down (closes within the window)
+symbols, and AP-A2 WCM-B sees genuine cross-sectional rank variation.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+
+from daily_bars import DailyBar, SpotMinute
+from pit_universe_alpaca import SymbolEligibility, UniverseSnapshot
+
+DAY_MS = 86_400_000
+N_SYMBOLS = 20
+
+
+def symbol_names(n: int = N_SYMBOLS) -> list[str]:
+    return [f"SYM{idx:02d}/USD" for idx in range(n)]
+
+
+def close_for(symbol_idx: int, day_index: int) -> float:
+    """Deterministic sinusoidal close price, always positive."""
+    amplitude = 0.15 + 0.02 * (symbol_idx % 5)
+    period = 80 + 15 * (symbol_idx % 6)
+    phase = (symbol_idx * 0.7) % (2 * math.pi)
+    return 100.0 * (
+        1.0 + amplitude * math.sin(2 * math.pi * day_index / period + phase)
+    )
+
+
+def build_bars_by_symbol(
+    *, window_start_ms: int, num_days: int, n_symbols: int = N_SYMBOLS
+) -> dict[str, tuple[DailyBar, ...]]:
+    """One complete, gap-free, all-valid ``DailyBar`` series per symbol
+    spanning ``num_days`` whole UTC days starting at ``window_start_ms``
+    (which must be UTC-midnight aligned)."""
+    if window_start_ms % DAY_MS:
+        raise ValueError("window_start_ms must be UTC midnight aligned")
+    result: dict[str, tuple[DailyBar, ...]] = {}
+    names = symbol_names(n_symbols)
+    for idx, symbol in enumerate(names):
+        bars = []
+        for day_index in range(num_days):
+            close = close_for(idx, day_index)
+            day_start = window_start_ms + day_index * DAY_MS
+            bars.append(
+                DailyBar(
+                    day_start_ms=day_start,
+                    day_end_ms=day_start + DAY_MS,
+                    open=close,
+                    high=close * 1.001,
+                    low=close * 0.999,
+                    close=close,
+                    volume=1_000.0,
+                    minute_count_observed=1440,
+                    imputed_minutes=0,
+                    max_gap_minutes=0,
+                    gap_in_last_60min=False,
+                    is_valid=True,
+                    is_segment_start=(day_index == 0),
+                )
+            )
+        result[symbol] = tuple(bars)
+    return result
+
+
+def make_universe_snapshot_provider(
+    n_symbols: int = N_SYMBOLS,
+) -> callable:
+    names = tuple(sorted(symbol_names(n_symbols)))
+
+    def provider(decision_ts_ms: int) -> UniverseSnapshot:
+        per_symbol = tuple(
+            SymbolEligibility(
+                symbol=s,
+                eligible=True,
+                fail_reason=None,
+                pit_history_days=999,
+                listing_proxy_source="alpaca_first_daily_proxy",
+            )
+            for s in names
+        )
+        return UniverseSnapshot(
+            decision_ts_ms=decision_ts_ms,
+            eligible_symbols=names,
+            per_symbol=per_symbol,
+            n_t=len(names),
+            meets_min_universe_size=True,
+        )
+
+    return provider
+
+
+def make_minute_bars_provider(
+    *, window_start_ms: int, n_symbols: int = N_SYMBOLS
+) -> callable:
+    idx_by_symbol: Mapping[str, int] = {
+        s: i for i, s in enumerate(symbol_names(n_symbols))
+    }
+
+    def provider(symbol: str, decision_ts_ms: int) -> Sequence[SpotMinute]:
+        idx = idx_by_symbol[symbol]
+        day_index = (decision_ts_ms - window_start_ms) // DAY_MS
+        price = close_for(idx, day_index)
+        m1 = decision_ts_ms
+        m2 = decision_ts_ms + 60_000
+        return [
+            SpotMinute(
+                open_time_ms=m1,
+                open=price,
+                high=price * 1.001,
+                low=price * 0.999,
+                close=price,
+                volume=1.0,
+            ),
+            SpotMinute(
+                open_time_ms=m2,
+                open=price,
+                high=price * 1.001,
+                low=price * 0.999,
+                close=price,
+                volume=1.0,
+            ),
+        ]
+
+    return provider

--- a/research/alpaca_track_walkforward/tests/synthetic_fixture.py
+++ b/research/alpaca_track_walkforward/tests/synthetic_fixture.py
@@ -28,12 +28,19 @@ def symbol_names(n: int = N_SYMBOLS) -> list[str]:
 
 
 def close_for(symbol_idx: int, day_index: int) -> float:
-    """Deterministic sinusoidal close price, always positive."""
+    """Deterministic sinusoidal close price, always positive.
+
+    The test corpus is quantized at generation so CPython/libm last-bit
+    differences cannot turn the same semantic fixture into different source
+    corpus hashes on macOS and Linux. This affects this synthetic fixture
+    only; runner calculations and gate comparisons retain full precision.
+    """
     amplitude = 0.15 + 0.02 * (symbol_idx % 5)
     period = 80 + 15 * (symbol_idx % 6)
     phase = (symbol_idx * 0.7) % (2 * math.pi)
-    return 100.0 * (
-        1.0 + amplitude * math.sin(2 * math.pi * day_index / period + phase)
+    return round(
+        100.0 * (1.0 + amplitude * math.sin(2 * math.pi * day_index / period + phase)),
+        10,
     )
 
 

--- a/research/alpaca_track_walkforward/tests/test_blind_counts.py
+++ b/research/alpaca_track_walkforward/tests/test_blind_counts.py
@@ -22,17 +22,93 @@ def _rec(ts, action, reason):
     )
 
 
-def test_annualized_stress_cost_pct_matches_direct_arithmetic():
+def test_annualized_stress_cost_pct_matches_frozen_notional_formula():
     result = bc.annualized_stress_cost_pct(
-        modeled_entries_count=10, window_days=365, cost_bp=120
+        entry_filled_notionals=(62.5,) * 10,
+        window_days=365,
+        nav_usd=2000.0,
+        cost_bp=120.0,
     )
-    assert result == pytest.approx(10 * (120 / 10_000.0) * 100.0)
+    assert result == pytest.approx(10 * (62.5 / 2000.0) * 0.012 * 100.0)
 
 
 def test_annualized_stress_cost_pct_rejects_non_positive_window():
     with pytest.raises(ValueError, match="window_days"):
         bc.annualized_stress_cost_pct(
-            modeled_entries_count=1, window_days=0, cost_bp=100
+            entry_filled_notionals=(62.5,),
+            window_days=0,
+            nav_usd=2000.0,
+            cost_bp=120.0,
+        )
+
+
+def _fractional_entry_notionals(
+    entry_count: float, full_size_notional: float
+) -> tuple[float, ...]:
+    whole = int(entry_count)
+    fraction = entry_count - whole
+    notionals = [full_size_notional] * whole
+    if fraction:
+        notionals.append(full_size_notional * fraction)
+    return tuple(notionals)
+
+
+@pytest.mark.parametrize(
+    ("entry_count", "full_size_notional", "expected_pct"),
+    [
+        (365 * 24 * 0.008, 2000.0 / 32, 2.628),
+        (365 * 24 * 0.015, 2000.0 / 32, 4.9275),
+        (52 * 5 * 0.21, 2000.0 / 5, 13.104),
+        (52 * 5 * 0.29, 2000.0 / 5, 18.096),
+    ],
+)
+def test_frozen_formula_reproduces_preregistered_drag_ranges(
+    entry_count, full_size_notional, expected_pct
+):
+    result = bc.annualized_stress_cost_pct(
+        entry_filled_notionals=_fractional_entry_notionals(
+            entry_count, full_size_notional
+        ),
+        window_days=365,
+        nav_usd=2000.0,
+        cost_bp=120.0,
+    )
+    assert result == pytest.approx(expected_pct)
+
+
+@pytest.mark.parametrize(
+    ("full_size_notional", "expected_pct"),
+    [
+        (2000.0 / 32, 1.125),
+        (2000.0 / 5, 7.2),
+        (2000.0 / 6, 6.0),
+    ],
+)
+def test_thirty_full_size_entries_are_compatible_with_frozen_caps(
+    full_size_notional, expected_pct
+):
+    result = bc.annualized_stress_cost_pct(
+        entry_filled_notionals=(full_size_notional,) * 30,
+        window_days=365,
+        nav_usd=2000.0,
+        cost_bp=120.0,
+    )
+    assert result == pytest.approx(expected_pct)
+
+
+def test_full_nav_per_entry_misread_is_rejected_not_used_by_the_api():
+    full_nav_drag = bc.annualized_stress_cost_pct(
+        entry_filled_notionals=(2000.0,) * 30,
+        window_days=365,
+        nav_usd=2000.0,
+        cost_bp=120.0,
+    )
+    assert full_nav_drag == pytest.approx(36.0)
+    with pytest.raises(TypeError):
+        bc.annualized_stress_cost_pct(
+            modeled_entries_count=30,  # type: ignore[call-arg]
+            window_days=365,
+            cost_bp=120.0,
         )
 
 

--- a/research/alpaca_track_walkforward/tests/test_blind_counts.py
+++ b/research/alpaca_track_walkforward/tests/test_blind_counts.py
@@ -161,7 +161,7 @@ def test_empty_histogram_alongside_real_records_is_incomplete_rob_1025_lesson():
     assert counts.is_incomplete is True
 
 
-def test_no_records_at_all_is_not_incomplete_there_is_nothing_to_summarize():
+def test_no_records_at_all_is_incomplete_for_a_scheduled_fold():
     counts = bc.BlindCounts(
         total_decision_records=0,
         modeled_entries_count=0,
@@ -173,4 +173,52 @@ def test_no_records_at_all_is_not_incomplete_there_is_nothing_to_summarize():
         holding_days=(),
         reason_code_histogram={},
     )
-    assert counts.is_incomplete is False
+    assert counts.is_incomplete is True
+
+
+def test_fill_window_incomplete_is_always_structurally_incomplete():
+    counts = bc.BlindCounts(
+        total_decision_records=5,
+        modeled_entries_count=5,
+        closed_trades_count=5,
+        open_positions_count=0,
+        entry_unfilled_count=0,
+        exit_unfilled_count=0,
+        fill_window_incomplete_count=1,
+        holding_days=(3, 3, 3, 3, 3),
+        reason_code_histogram={"ENTRY_ACCEPTED": 5},
+    )
+    assert counts.is_incomplete is True
+
+
+def test_partial_histogram_and_lifecycle_count_mismatch_are_incomplete():
+    partial_histogram = bc.BlindCounts(
+        total_decision_records=5,
+        modeled_entries_count=5,
+        closed_trades_count=5,
+        open_positions_count=0,
+        entry_unfilled_count=0,
+        exit_unfilled_count=0,
+        fill_window_incomplete_count=0,
+        holding_days=(3, 3, 3, 3, 3),
+        reason_code_histogram={"ENTRY_ACCEPTED": 4},
+    )
+    lifecycle_mismatch = bc.BlindCounts(
+        total_decision_records=5,
+        modeled_entries_count=5,
+        closed_trades_count=4,
+        open_positions_count=0,
+        entry_unfilled_count=0,
+        exit_unfilled_count=0,
+        fill_window_incomplete_count=0,
+        holding_days=(3, 3, 3, 3),
+        reason_code_histogram={"ENTRY_ACCEPTED": 5},
+    )
+    assert partial_histogram.is_incomplete is True
+    assert lifecycle_mismatch.is_incomplete is True
+
+
+def test_reason_histogram_is_immutable_after_completeness_is_bound():
+    counts = bc.compute_blind_counts([_rec(1, "NO_ACTION", "NO_ENTRY_SIGNAL")])
+    with pytest.raises(TypeError):
+        counts.reason_code_histogram["ENTRY_ACCEPTED"] = 99  # type: ignore[index]

--- a/research/alpaca_track_walkforward/tests/test_blind_counts.py
+++ b/research/alpaca_track_walkforward/tests/test_blind_counts.py
@@ -1,0 +1,100 @@
+"""ROB-1062 H4 (AC25, AC28) — PnL-blind counts."""
+
+from __future__ import annotations
+
+import blind_counts as bc
+import fill_model as fm
+import pytest
+import trade_ledger as tl
+from output_schema import SignalRecord, evidence_hash
+
+
+def _rec(ts, action, reason):
+    return SignalRecord(
+        decision_ts_ms=ts,
+        strategy="AP-A1",
+        config_id="AP-A1-00",
+        symbol="BTC/USD",
+        action=action,
+        target_notional=0.0,
+        reason_code=reason,
+        evidence_hash=evidence_hash({}),
+    )
+
+
+def test_annualized_stress_cost_pct_matches_direct_arithmetic():
+    result = bc.annualized_stress_cost_pct(
+        modeled_entries_count=10, window_days=365, cost_bp=120
+    )
+    assert result == pytest.approx(10 * (120 / 10_000.0) * 100.0)
+
+
+def test_annualized_stress_cost_pct_rejects_non_positive_window():
+    with pytest.raises(ValueError, match="window_days"):
+        bc.annualized_stress_cost_pct(
+            modeled_entries_count=1, window_days=0, cost_bp=100
+        )
+
+
+def _fill_attempt(ts, *, symbol="BTC/USD", leg, reason):
+    outcome = fm.FillOutcome(
+        filled=False, fill_price=None, fill_bar_offset=None, reason=reason
+    )
+    return tl.FillAttempt(decision_ts_ms=ts, symbol=symbol, leg=leg, outcome=outcome)
+
+
+def test_compute_blind_counts_aggregates_across_fill_attempts():
+    records = [
+        _rec(1, "NO_ACTION", "NO_ENTRY_SIGNAL"),
+        _rec(2, "NO_ACTION", "UNIVERSE_INELIGIBLE"),
+    ]
+    attempts = [_fill_attempt(1, leg="ENTRY", reason="ENTRY_UNFILLED")]
+    counts = bc.compute_blind_counts(records, fill_attempts=attempts)
+    assert counts.total_decision_records == 2
+    assert counts.entry_unfilled_count == 1
+    assert counts.reason_code_histogram == {
+        "NO_ENTRY_SIGNAL": 1,
+        "UNIVERSE_INELIGIBLE": 1,
+    }
+    assert counts.is_incomplete is False
+
+
+def test_zero_trades_with_real_records_and_a_populated_histogram_is_not_incomplete():
+    records = [_rec(1, "NO_ACTION", "NO_ENTRY_SIGNAL")]
+    counts = bc.compute_blind_counts(records)
+    assert counts.modeled_entries_count == 0
+    assert counts.is_incomplete is False  # legitimate all-NO_ACTION fold
+
+
+def test_empty_histogram_alongside_real_records_is_incomplete_rob_1025_lesson():
+    """The exact ROB-1025 failure mode: real decision records exist, but the
+    histogram plumbing produced nothing — must be flagged, never mistaken
+    for a clean zero-trade result."""
+    records = [_rec(1, "NO_ACTION", "NO_ENTRY_SIGNAL")]
+    counts = bc.BlindCounts(
+        total_decision_records=len(records),
+        modeled_entries_count=0,
+        closed_trades_count=0,
+        open_positions_count=0,
+        entry_unfilled_count=0,
+        exit_unfilled_count=0,
+        fill_window_incomplete_count=0,
+        holding_days=(),
+        reason_code_histogram={},  # broken plumbing -- empty despite real records
+    )
+    assert counts.is_incomplete is True
+
+
+def test_no_records_at_all_is_not_incomplete_there_is_nothing_to_summarize():
+    counts = bc.BlindCounts(
+        total_decision_records=0,
+        modeled_entries_count=0,
+        closed_trades_count=0,
+        open_positions_count=0,
+        entry_unfilled_count=0,
+        exit_unfilled_count=0,
+        fill_window_incomplete_count=0,
+        holding_days=(),
+        reason_code_histogram={},
+    )
+    assert counts.is_incomplete is False

--- a/research/alpaca_track_walkforward/tests/test_config_selection.py
+++ b/research/alpaca_track_walkforward/tests/test_config_selection.py
@@ -7,9 +7,18 @@ import config_selection as cs
 import pytest
 
 
-def _metric(config_id, *, closed=40, median_e120=50.0, turnover=0.2, cost_pct=3.0):
+def _metric(
+    config_id,
+    *,
+    incomplete=False,
+    closed=40,
+    median_e120=50.0,
+    turnover=0.2,
+    cost_pct=3.0,
+):
     return cs.ConfigTrainMetrics(
         config_id=config_id,
+        is_incomplete=incomplete,
         closed_trades_count=closed,
         median_trade_e120_bp=median_e120,
         turnover_p=turnover,
@@ -108,6 +117,41 @@ def test_cost_gate_is_compared_before_pnl_and_stops_pnl_access_on_cost_failure()
     assert events == ["COST<="]
 
 
+def test_incomplete_train_is_rejected_before_closed_cost_or_pnl_gates():
+    events: list[str] = []
+
+    class CountSpy(int):
+        def __ge__(self, other):
+            events.append("CLOSED>=")
+            return True
+
+    class CostSpy(float):
+        def __le__(self, other):
+            events.append("COST<=")
+            return True
+
+    class PnLSpy(float):
+        def __gt__(self, other):
+            events.append("PNL>")
+            return True
+
+    result = cs.select_config(
+        [
+            _metric(
+                "AP-A1-00",
+                incomplete=True,
+                closed=CountSpy(30),
+                cost_pct=CostSpy(1.0),
+                median_e120=PnLSpy(1.0),
+            )
+        ],
+        data_window="TRAIN",
+        stress_cost_cap_pct=6.0,
+    )
+    assert result.status == "NO_SELECTED_CONFIG"
+    assert events == []
+
+
 def test_ap_a2_turnover_band_is_pnl_blind_and_rejects_90pct_before_e120():
     events: list[str] = []
 
@@ -181,6 +225,7 @@ def test_zero_closed_trades_metric_construction_requires_none_median():
     with pytest.raises(ValueError, match="zero closed trades"):
         cs.ConfigTrainMetrics(
             config_id="x",
+            is_incomplete=False,
             closed_trades_count=0,
             median_trade_e120_bp=1.0,
             turnover_p=0.1,
@@ -192,6 +237,7 @@ def test_nonzero_closed_trades_metric_construction_requires_a_median():
     with pytest.raises(ValueError, match="must carry a median E120"):
         cs.ConfigTrainMetrics(
             config_id="x",
+            is_incomplete=False,
             closed_trades_count=5,
             median_trade_e120_bp=None,
             turnover_p=0.1,

--- a/research/alpaca_track_walkforward/tests/test_config_selection.py
+++ b/research/alpaca_track_walkforward/tests/test_config_selection.py
@@ -1,0 +1,118 @@
+"""ROB-1062 H4 (AC7-AC10) — TRAIN-only config selection rule."""
+
+from __future__ import annotations
+
+import config_selection as cs
+import pytest
+
+
+def _metric(config_id, *, closed=40, median_e120=50.0, turnover=0.2, cost_pct=3.0):
+    return cs.ConfigTrainMetrics(
+        config_id=config_id,
+        closed_trades_count=closed,
+        median_trade_e120_bp=median_e120,
+        turnover_p=turnover,
+        annualized_stress_cost_pct=cost_pct,
+    )
+
+
+def test_select_config_rejects_anything_other_than_train_literal():
+    with pytest.raises(cs.OOSDataReachedSelectionError, match="OOS"):
+        cs.select_config([], data_window="OOS", stress_cost_cap_pct=6.0)
+    with pytest.raises(cs.OOSDataReachedSelectionError):
+        cs.select_config(
+            [], data_window="train", stress_cost_cap_pct=6.0
+        )  # case-sensitive
+
+
+def test_picks_max_median_e120_among_passing_configs():
+    metrics = [
+        _metric("AP-A1-00", median_e120=40.0),
+        _metric("AP-A1-01", median_e120=90.0),
+        _metric("AP-A1-02", median_e120=10.0),
+    ]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "SELECTED"
+    assert result.selected_config_id == "AP-A1-01"
+
+
+def test_tie_break_1_lower_turnover_wins():
+    metrics = [
+        _metric("AP-A1-00", median_e120=50.0, turnover=0.25),
+        _metric("AP-A1-01", median_e120=50.0, turnover=0.10),
+    ]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.selected_config_id == "AP-A1-01"
+
+
+def test_tie_break_2_canonical_config_id_ascending():
+    metrics = [
+        _metric("AP-A1-05", median_e120=50.0, turnover=0.10),
+        _metric("AP-A1-02", median_e120=50.0, turnover=0.10),
+    ]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.selected_config_id == "AP-A1-02"
+
+
+def test_below_min_closed_trades_excluded():
+    metrics = [_metric("AP-A1-00", closed=29, median_e120=999.0)]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "NO_SELECTED_CONFIG"
+    assert result.selected_config_id is None
+
+
+def test_exactly_30_closed_trades_is_the_inclusive_boundary():
+    metrics = [_metric("AP-A1-00", closed=30, median_e120=1.0)]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "SELECTED"
+
+
+def test_non_positive_median_e120_excluded():
+    metrics = [
+        _metric("AP-A1-00", median_e120=0.0),
+        _metric("AP-A1-01", median_e120=-5.0),
+    ]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "NO_SELECTED_CONFIG"
+
+
+def test_cost_cap_exceeded_excluded_pnl_blind_even_with_great_median_e120():
+    metrics = [_metric("AP-A1-00", median_e120=1000.0, cost_pct=6.01)]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "NO_SELECTED_CONFIG"
+
+
+def test_no_config_passes_yields_no_selected_config_never_a_fallback():
+    metrics = [_metric("AP-A1-00", closed=0, median_e120=None)]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "NO_SELECTED_CONFIG"
+    assert result.selected_config_id is None
+
+
+def test_zero_closed_trades_metric_construction_requires_none_median():
+    with pytest.raises(ValueError, match="zero closed trades"):
+        cs.ConfigTrainMetrics(
+            config_id="x",
+            closed_trades_count=0,
+            median_trade_e120_bp=1.0,
+            turnover_p=0.1,
+            annualized_stress_cost_pct=1.0,
+        )
+
+
+def test_nonzero_closed_trades_metric_construction_requires_a_median():
+    with pytest.raises(ValueError, match="must carry a median E120"):
+        cs.ConfigTrainMetrics(
+            config_id="x",
+            closed_trades_count=5,
+            median_trade_e120_bp=None,
+            turnover_p=0.1,
+            annualized_stress_cost_pct=1.0,
+        )
+
+
+def test_selection_result_construction_invariants():
+    with pytest.raises(ValueError, match="must carry a selected_config_id"):
+        cs.ConfigSelectionResult(status="SELECTED", selected_config_id=None)
+    with pytest.raises(ValueError, match="must not carry"):
+        cs.ConfigSelectionResult(status="NO_SELECTED_CONFIG", selected_config_id="x")

--- a/research/alpaca_track_walkforward/tests/test_config_selection.py
+++ b/research/alpaca_track_walkforward/tests/test_config_selection.py
@@ -108,6 +108,52 @@ def test_cost_gate_is_compared_before_pnl_and_stops_pnl_access_on_cost_failure()
     assert events == ["COST<="]
 
 
+def test_ap_a2_turnover_band_is_pnl_blind_and_rejects_90pct_before_e120():
+    events: list[str] = []
+
+    class PnLSpy(float):
+        def __gt__(self, other):
+            events.append("PNL>")
+            return True
+
+    result = cs.select_config(
+        [
+            _metric(
+                "AP-A2-00",
+                closed=30,
+                median_e120=PnLSpy(1.0),
+                turnover=0.90,
+                cost_pct=1.0,
+            )
+        ],
+        data_window="TRAIN",
+        stress_cost_cap_pct=18.0,
+        turnover_band=(0.2083, 0.2885),
+    )
+    assert result.status == "NO_SELECTED_CONFIG"
+    assert events == []
+
+
+def test_ap_a2_selection_cannot_omit_the_sealed_turnover_band():
+    with pytest.raises(ValueError, match="requires the sealed turnover band"):
+        cs.select_config(
+            [_metric("AP-A2-00", turnover=0.25)],
+            data_window="TRAIN",
+            stress_cost_cap_pct=18.0,
+        )
+
+
+@pytest.mark.parametrize("turnover", [0.2083, 0.2885])
+def test_ap_a2_turnover_band_boundaries_are_inclusive(turnover):
+    result = cs.select_config(
+        [_metric("AP-A2-00", closed=30, median_e120=1.0, turnover=turnover)],
+        data_window="TRAIN",
+        stress_cost_cap_pct=18.0,
+        turnover_band=(0.2083, 0.2885),
+    )
+    assert result.selected_config_id == "AP-A2-00"
+
+
 def test_full_nav_per_trade_36pct_misread_is_rejected_by_unchanged_caps():
     full_nav_drag = bc.annualized_stress_cost_pct(
         entry_filled_notionals=(2000.0,) * 30,

--- a/research/alpaca_track_walkforward/tests/test_config_selection.py
+++ b/research/alpaca_track_walkforward/tests/test_config_selection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import blind_counts as bc
 import config_selection as cs
 import pytest
 
@@ -79,6 +80,47 @@ def test_non_positive_median_e120_excluded():
 def test_cost_cap_exceeded_excluded_pnl_blind_even_with_great_median_e120():
     metrics = [_metric("AP-A1-00", median_e120=1000.0, cost_pct=6.01)]
     result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "NO_SELECTED_CONFIG"
+
+
+def test_cost_gate_is_compared_before_pnl_and_stops_pnl_access_on_cost_failure():
+    events: list[str] = []
+
+    class CostSpy(float):
+        def __le__(self, other):
+            events.append("COST<=")
+            return False
+
+    class PnLSpy(float):
+        def __gt__(self, other):
+            events.append("PNL>")
+            return True
+
+    metrics = [
+        _metric(
+            "AP-A1-00",
+            median_e120=PnLSpy(1000.0),
+            cost_pct=CostSpy(99.0),
+        )
+    ]
+    result = cs.select_config(metrics, data_window="TRAIN", stress_cost_cap_pct=6.0)
+    assert result.status == "NO_SELECTED_CONFIG"
+    assert events == ["COST<="]
+
+
+def test_full_nav_per_trade_36pct_misread_is_rejected_by_unchanged_caps():
+    full_nav_drag = bc.annualized_stress_cost_pct(
+        entry_filled_notionals=(2000.0,) * 30,
+        window_days=365,
+        nav_usd=2000.0,
+        cost_bp=120.0,
+    )
+    assert full_nav_drag == pytest.approx(36.0)
+    result = cs.select_config(
+        [_metric("AP-A1-00", closed=30, median_e120=999.0, cost_pct=full_nav_drag)],
+        data_window="TRAIN",
+        stress_cost_cap_pct=6.0,
+    )
     assert result.status == "NO_SELECTED_CONFIG"
 
 

--- a/research/alpaca_track_walkforward/tests/test_context_binding.py
+++ b/research/alpaca_track_walkforward/tests/test_context_binding.py
@@ -1,0 +1,92 @@
+"""ROB-1062 H4 (AC4, AC5) — warm-up context provenance binding: an OOS-only
+mutation must never change a TRAIN decision's consumed-context hash, and a
+mutation INSIDE the consumed window must."""
+
+from __future__ import annotations
+
+import context_binding as cb
+from daily_bars import DailyBar
+
+_DAY_MS = 86_400_000
+
+
+def _bar(day_index, *, close, is_valid=True, is_segment_start=False):
+    start = day_index * _DAY_MS
+    return DailyBar(
+        day_start_ms=start,
+        day_end_ms=start + _DAY_MS,
+        open=close,
+        high=close + 1.0,
+        low=close - 1.0 if close > 1.0 else close / 2,
+        close=close,
+        volume=100.0,
+        minute_count_observed=1440,
+        imputed_minutes=0,
+        max_gap_minutes=0,
+        gap_in_last_60min=False,
+        is_valid=is_valid,
+        is_segment_start=is_segment_start,
+    )
+
+
+def test_context_hash_is_deterministic_for_identical_input():
+    bars = {
+        "BTC/USD": [_bar(0, close=100.0, is_segment_start=True), _bar(1, close=101.0)]
+    }
+    a = cb.compute_warmup_context_binding(bars, window_end_ms=2 * _DAY_MS)
+    b = cb.compute_warmup_context_binding(bars, window_end_ms=2 * _DAY_MS)
+    assert a.combined_context_hash == b.combined_context_hash
+
+
+def test_mutating_an_oos_only_bar_never_changes_the_train_decisions_context_hash():
+    """AC5 — the central guarantee: an OOS-only variant must never move a
+    TRAIN decision's consumed-context hash."""
+    train_window_end = 2 * _DAY_MS  # TRAIN decision consumes days 0-1 only
+    bars_v1 = {
+        "BTC/USD": [
+            _bar(0, close=100.0, is_segment_start=True),
+            _bar(1, close=101.0),
+            _bar(2, close=999.0),  # OOS-only day, far beyond train_window_end
+        ]
+    }
+    bars_v2 = {
+        "BTC/USD": [
+            _bar(0, close=100.0, is_segment_start=True),
+            _bar(1, close=101.0),
+            _bar(2, close=1.0),  # mutated OOS-only day
+        ]
+    }
+    hash_v1 = cb.compute_warmup_context_binding(
+        bars_v1, window_end_ms=train_window_end
+    ).combined_context_hash
+    hash_v2 = cb.compute_warmup_context_binding(
+        bars_v2, window_end_ms=train_window_end
+    ).combined_context_hash
+    assert hash_v1 == hash_v2
+
+
+def test_mutating_a_bar_inside_the_consumed_window_does_change_the_hash():
+    train_window_end = 2 * _DAY_MS
+    bars_v1 = {
+        "BTC/USD": [_bar(0, close=100.0, is_segment_start=True), _bar(1, close=101.0)]
+    }
+    bars_v2 = {
+        "BTC/USD": [_bar(0, close=100.0, is_segment_start=True), _bar(1, close=555.0)]
+    }
+    hash_v1 = cb.compute_warmup_context_binding(
+        bars_v1, window_end_ms=train_window_end
+    ).combined_context_hash
+    hash_v2 = cb.compute_warmup_context_binding(
+        bars_v2, window_end_ms=train_window_end
+    ).combined_context_hash
+    assert hash_v1 != hash_v2
+
+
+def test_binding_is_immutable():
+    binding = cb.compute_warmup_context_binding({}, window_end_ms=_DAY_MS)
+    try:
+        binding.window_end_ms = 999
+        raised = False
+    except AttributeError:
+        raised = True
+    assert raised is True

--- a/research/alpaca_track_walkforward/tests/test_context_binding.py
+++ b/research/alpaca_track_walkforward/tests/test_context_binding.py
@@ -90,3 +90,19 @@ def test_binding_is_immutable():
     except AttributeError:
         raised = True
     assert raised is True
+
+
+def test_inner_context_mappings_are_immutable_and_hashes_cover_source_and_features():
+    bars = {
+        "BTC/USD": [_bar(0, close=100.0, is_segment_start=True), _bar(1, close=101.0)]
+    }
+    binding = cb.compute_warmup_context_binding(bars, window_end_ms=2 * _DAY_MS)
+    try:
+        binding.per_symbol_segment_hash["FUTURE/USD"] = "attacker-mutated"
+        raised = False
+    except TypeError:
+        raised = True
+    assert raised is True
+    assert len(binding.source_corpus_hash) == 64
+    assert len(binding.feature_input_hash) == 64
+    assert binding.per_symbol_segment_range["BTC/USD"] == (0, 2 * _DAY_MS)

--- a/research/alpaca_track_walkforward/tests/test_fake_free_smoke.py
+++ b/research/alpaca_track_walkforward/tests/test_fake_free_smoke.py
@@ -1,0 +1,205 @@
+"""ROB-1062 H4 (AC29/AC30 spirit — first RED/first real run must be
+synthetic) — fake-free smoke test.
+
+Real synthetic daily bars -> the REAL H1 ``pit_universe_alpaca.
+evaluate_universe`` -> the REAL H3 ``dats_engine.run_ap_a1_decision`` -> the
+REAL H4 ``fill_model``/``trade_ledger``/``pnl_views``/``oos_mask``, chained
+end to end for TWO real decisions (an entry, then an exit) hand-picked from
+the synthetic price path — mirrors ``alpaca_track_signals/tests/
+test_fake_free_smoke.py``'s own discipline (every processing stage is the
+REAL named function; only the raw price content is fake). Deliberately does
+NOT go through the full ``runner.run_family_fold`` continuous loop (that is
+covered, expensively, by ``test_runner.py``/``test_golden_digest.py``) — this
+test exists to be FAST and to prove the wiring is real, not mocked.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import daily_bars as db
+import dats_engine
+import oos_mask as om
+import pit_universe_alpaca as pu
+import pnl_views as pv
+import trade_ledger as tl
+import wf_seal_consumption as wf_seal
+
+MIN_MS = 60_000
+DAY_MS = db.DAY_MS
+N_DAYS = 200
+
+
+def _ms(y, m, d, hh=0, mm=0, ss=0) -> int:
+    return int(datetime(y, m, d, hh, mm, ss, tzinfo=UTC).timestamp() * 1000)
+
+
+def _minute_rows(window_start_ms: int, closes: list[float]) -> list[db.SpotMinute]:
+    rows = []
+    for day, price in enumerate(closes):
+        day_start = window_start_ms + day * DAY_MS
+        for minute in range(1440):
+            rows.append(
+                db.SpotMinute(
+                    open_time_ms=day_start + minute * MIN_MS,
+                    open=price,
+                    high=price,
+                    low=price,
+                    close=price,
+                    volume=1.0,
+                )
+            )
+    return rows
+
+
+def _candidate(symbol: str, bars, window_start_ms: int) -> pu.SymbolCandidate:
+    return pu.SymbolCandidate(
+        symbol=symbol,
+        base=symbol.split("/")[0],
+        alpaca_active=True,
+        alpaca_tradable=True,
+        is_usd_pair=True,
+        binance_quote_mode="USDC",
+        alpaca_first_daily_ms=window_start_ms - 400 * DAY_MS,
+        all_valid_daily_bars_in_lookback=all(b.is_valid for b in bars),
+        no_gap_in_last_60min=not bars[-1].gap_in_last_60min,
+    )
+
+
+def test_fake_free_entry_then_exit_through_the_full_h4_pipeline():
+    entry_decision_day = _ms(2026, 7, 20, 0, 0, 0)  # a Monday
+    window_start = entry_decision_day - N_DAYS * DAY_MS
+
+    # Uptrend for N_DAYS-ish, then a sharp reversal in the last ~10 days so
+    # AP-A1's D flips negative and an EXIT fires within a short horizon.
+    closes = [100.0 * (1.0006**i) for i in range(N_DAYS)]
+    peak = closes[-1]
+    for i in range(10):
+        closes.append(peak * (0.985 ** (i + 1)))
+
+    strong_rows = _minute_rows(window_start, closes)
+    strong_bars = db.build_daily_series(
+        strong_rows,
+        window_start_ms=window_start,
+        window_end_ms=window_start + len(closes) * DAY_MS,
+    )
+    padding_bars = {
+        f"PAD{i}/USD": db.build_daily_series(
+            _minute_rows(window_start, [50.0 + i] * len(closes)),
+            window_start_ms=window_start,
+            window_end_ms=window_start + len(closes) * DAY_MS,
+        )
+        for i in range(19)
+    }
+    all_bars = {"STRONG/USD": strong_bars, **padding_bars}
+    candidates = [_candidate(s, b, window_start) for s, b in all_bars.items()]
+
+    import seal_consumption as h3_seal
+
+    bundle = h3_seal.load_sealed_configs_and_params()
+    config = next(c for c in bundle.configs if c.family == "AP-A1")
+
+    universe = pu.evaluate_universe(entry_decision_day + 5 * MIN_MS, candidates)
+    assert universe.meets_min_universe_size
+
+    entry_result = dats_engine.run_ap_a1_decision(
+        decision_ts_ms=entry_decision_day + 5 * MIN_MS,
+        config=config,
+        universe=universe,
+        bars_by_symbol=all_bars,
+        prior_state={},
+    )
+    entry_record = next(r for r in entry_result.records if r.symbol == "STRONG/USD")
+    assert entry_record.action == "ENTER"
+    assert entry_record.reason_code == "ENTRY_ACCEPTED"
+
+    exit_decision_day = window_start + (N_DAYS + 8) * DAY_MS
+    universe_2 = pu.evaluate_universe(exit_decision_day + 5 * MIN_MS, candidates)
+    exit_result = dats_engine.run_ap_a1_decision(
+        decision_ts_ms=exit_decision_day + 5 * MIN_MS,
+        config=config,
+        universe=universe_2,
+        bars_by_symbol=all_bars,
+        prior_state=entry_result.new_state,
+    )
+    exit_record = next(r for r in exit_result.records if r.symbol == "STRONG/USD")
+    assert exit_record.action == "EXIT"
+    assert exit_record.reason_code == "EXIT_TRIGGERED"
+
+    # Real fill_model, on both legs.
+    entry_ref = strong_bars[N_DAYS - 1].close
+    exit_ref = [b for b in strong_bars if b.day_end_ms == exit_decision_day][0].close
+    entry_minutes = [
+        db.SpotMinute(
+            open_time_ms=entry_record.decision_ts_ms,
+            open=entry_ref,
+            high=entry_ref + 1,
+            low=entry_ref - 1,
+            close=entry_ref,
+            volume=1.0,
+        ),
+        db.SpotMinute(
+            open_time_ms=entry_record.decision_ts_ms + 60_000,
+            open=entry_ref,
+            high=entry_ref + 1,
+            low=entry_ref - 1,
+            close=entry_ref,
+            volume=1.0,
+        ),
+    ]
+    exit_minutes = [
+        db.SpotMinute(
+            open_time_ms=exit_record.decision_ts_ms,
+            open=exit_ref,
+            high=exit_ref + 1,
+            low=max(exit_ref - 1, 0.01),
+            close=exit_ref,
+            volume=1.0,
+        ),
+        db.SpotMinute(
+            open_time_ms=exit_record.decision_ts_ms + 60_000,
+            open=exit_ref,
+            high=exit_ref + 1,
+            low=max(exit_ref - 1, 0.01),
+            close=exit_ref,
+            volume=1.0,
+        ),
+    ]
+
+    entry_attempt, open_leg = tl.process_entry_signal(
+        entry_record, reference_close=entry_ref, minute_bars=entry_minutes
+    )
+    assert entry_attempt.outcome.filled is True
+    assert open_leg is not None
+
+    exit_attempt, trade = tl.process_exit_signal(
+        exit_record, open_leg, reference_close=exit_ref, minute_bars=exit_minutes
+    )
+    assert exit_attempt.outcome.filled is True
+    assert trade is not None
+
+    # Real pnl_views, real sealed cost scenarios (via H4's own seal gateway).
+    trade_fill = pv.TradeFill(
+        entry_reference_close=trade.entry_reference_close,
+        entry_fill_price=trade.entry_fill.fill_price,
+        exit_reference_close=trade.exit_reference_close,
+        exit_fill_price=trade.exit_fill.fill_price,
+    )
+    real_scenarios = wf_seal.cost_scenarios_bp()
+    three_view = pv.three_view_pnl_bp(trade_fill, cost_scenarios_bp=real_scenarios)
+    assert three_view.shadow_net_bp_by_scenario["C120"] < three_view.actual_fill_bp
+
+    # Real oos_mask -- masked by default, unmaskable only with matching PASS evidence.
+    masked = om.mask(
+        three_view, fold_id="smoke-fold", family="AP-A1", config_id=config.config_id
+    )
+    evidence = om.DryCountPassEvidence(
+        fold_id="smoke-fold",
+        family="AP-A1",
+        config_id=config.config_id,
+        modeled_entries=5,
+        min_modeled_entries_per_fold=5,
+        passed=True,
+    )
+    unmasked = om.unmask(masked, evidence)
+    assert unmasked is three_view

--- a/research/alpaca_track_walkforward/tests/test_fake_free_smoke.py
+++ b/research/alpaca_track_walkforward/tests/test_fake_free_smoke.py
@@ -190,25 +190,37 @@ def test_fake_free_entry_then_exit_through_the_full_h4_pipeline():
     three_view = pv.three_view_pnl_bp(trade_fill, cost_scenarios_bp=real_scenarios)
     assert three_view.shadow_net_bp_by_scenario["C120"] < three_view.actual_fill_bp
 
-    # Real oos_mask -- masked by default, unmaskable only with matching PASS evidence.
-    dry_counts = bc.BlindCounts(
-        total_decision_records=5,
-        modeled_entries_count=5,
-        closed_trades_count=5,
-        open_positions_count=0,
-        entry_unfilled_count=0,
-        exit_unfilled_count=0,
-        fill_window_incomplete_count=0,
-        holding_days=(3, 3, 3, 3, 3),
-        reason_code_histogram={"ENTRY_ACCEPTED": 5},
+    # Real oos_mask -- no fold-local reveal exists. One aggregate authority
+    # is issued only after exact, complete dry counts for all 8 folds pass.
+    counts_by_fold = {
+        f"fold-{index}": bc.BlindCounts(
+            total_decision_records=5,
+            modeled_entries_count=5,
+            closed_trades_count=5,
+            open_positions_count=0,
+            entry_unfilled_count=0,
+            exit_unfilled_count=0,
+            fill_window_incomplete_count=0,
+            holding_days=(3, 3, 3, 3, 3),
+            reason_code_histogram={"ENTRY_ACCEPTED": 5},
+        )
+        for index in range(8)
+    }
+    masked_by_fold = {
+        fold_id: (
+            om.mask(
+                three_view if fold_id == "fold-0" else None,
+                fold_id=fold_id,
+                family="AP-A1",
+                config_id=config.config_id,
+                dry_counts=counts,
+            ),
+        )
+        for fold_id, counts in counts_by_fold.items()
+    }
+    evidence = om.issue_all_folds_dry_count_pass(
+        masked_by_fold=masked_by_fold,
+        dry_counts_by_fold=counts_by_fold,
     )
-    masked = om.mask(
-        three_view,
-        fold_id="smoke-fold",
-        family="AP-A1",
-        config_id=config.config_id,
-        dry_counts=dry_counts,
-    )
-    evidence = om.issue_dry_count_pass(masked, dry_counts)
-    unmasked = om.unmask(masked, evidence)
+    unmasked = om.unmask(masked_by_fold["fold-0"][0], evidence)
     assert unmasked == three_view

--- a/research/alpaca_track_walkforward/tests/test_fake_free_smoke.py
+++ b/research/alpaca_track_walkforward/tests/test_fake_free_smoke.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import blind_counts as bc
 import daily_bars as db
 import dats_engine
 import oos_mask as om
@@ -131,7 +132,7 @@ def test_fake_free_entry_then_exit_through_the_full_h4_pipeline():
     exit_ref = [b for b in strong_bars if b.day_end_ms == exit_decision_day][0].close
     entry_minutes = [
         db.SpotMinute(
-            open_time_ms=entry_record.decision_ts_ms,
+            open_time_ms=entry_record.decision_ts_ms + 60_000,
             open=entry_ref,
             high=entry_ref + 1,
             low=entry_ref - 1,
@@ -139,7 +140,7 @@ def test_fake_free_entry_then_exit_through_the_full_h4_pipeline():
             volume=1.0,
         ),
         db.SpotMinute(
-            open_time_ms=entry_record.decision_ts_ms + 60_000,
+            open_time_ms=entry_record.decision_ts_ms + 120_000,
             open=entry_ref,
             high=entry_ref + 1,
             low=entry_ref - 1,
@@ -149,7 +150,7 @@ def test_fake_free_entry_then_exit_through_the_full_h4_pipeline():
     ]
     exit_minutes = [
         db.SpotMinute(
-            open_time_ms=exit_record.decision_ts_ms,
+            open_time_ms=exit_record.decision_ts_ms + 60_000,
             open=exit_ref,
             high=exit_ref + 1,
             low=max(exit_ref - 1, 0.01),
@@ -157,7 +158,7 @@ def test_fake_free_entry_then_exit_through_the_full_h4_pipeline():
             volume=1.0,
         ),
         db.SpotMinute(
-            open_time_ms=exit_record.decision_ts_ms + 60_000,
+            open_time_ms=exit_record.decision_ts_ms + 120_000,
             open=exit_ref,
             high=exit_ref + 1,
             low=max(exit_ref - 1, 0.01),
@@ -190,16 +191,24 @@ def test_fake_free_entry_then_exit_through_the_full_h4_pipeline():
     assert three_view.shadow_net_bp_by_scenario["C120"] < three_view.actual_fill_bp
 
     # Real oos_mask -- masked by default, unmaskable only with matching PASS evidence.
-    masked = om.mask(
-        three_view, fold_id="smoke-fold", family="AP-A1", config_id=config.config_id
+    dry_counts = bc.BlindCounts(
+        total_decision_records=5,
+        modeled_entries_count=5,
+        closed_trades_count=5,
+        open_positions_count=0,
+        entry_unfilled_count=0,
+        exit_unfilled_count=0,
+        fill_window_incomplete_count=0,
+        holding_days=(3, 3, 3, 3, 3),
+        reason_code_histogram={"ENTRY_ACCEPTED": 5},
     )
-    evidence = om.DryCountPassEvidence(
+    masked = om.mask(
+        three_view,
         fold_id="smoke-fold",
         family="AP-A1",
         config_id=config.config_id,
-        modeled_entries=5,
-        min_modeled_entries_per_fold=5,
-        passed=True,
+        dry_counts=dry_counts,
     )
+    evidence = om.issue_dry_count_pass(masked, dry_counts)
     unmasked = om.unmask(masked, evidence)
-    assert unmasked is three_view
+    assert unmasked == three_view

--- a/research/alpaca_track_walkforward/tests/test_fill_model.py
+++ b/research/alpaca_track_walkforward/tests/test_fill_model.py
@@ -1,0 +1,166 @@
+"""ROB-1062 H4 (AC11-AC16) — historical fill model boundary tests."""
+
+from __future__ import annotations
+
+import fill_model as fm
+import pytest
+from daily_bars import SpotMinute
+
+_DECISION_TS = 1_700_000_100_000  # arbitrary minute-aligned ms, unrelated to wall clock
+_MIN = fm.MINUTE_MS
+
+
+def _minute(offset_minutes: int, *, open_: float) -> SpotMinute:
+    ts = _DECISION_TS + offset_minutes * _MIN
+    low = open_ / 2.0
+    return SpotMinute(
+        open_time_ms=ts, open=open_, high=open_ + 1.0, low=low, close=open_, volume=1.0
+    )
+
+
+def test_entry_fills_at_first_bar_open_when_at_the_exact_limit_cap_boundary():
+    ref = 100.0
+    limit_cap = ref * 1.005  # == 100.5
+    bars = [_minute(0, open_=limit_cap), _minute(1, open_=999.0)]
+    outcome = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is True
+    assert outcome.fill_price == limit_cap
+    assert outcome.fill_bar_offset == 1
+    assert outcome.reason == "FILLED"
+
+
+def test_entry_rejects_first_bar_one_cent_above_cap_but_fills_second_bar():
+    ref = 100.0
+    limit_cap = ref * 1.005
+    bars = [_minute(0, open_=limit_cap + 0.01), _minute(1, open_=limit_cap)]
+    outcome = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is True
+    assert outcome.fill_bar_offset == 2
+    assert outcome.fill_price == limit_cap
+
+
+def test_entry_unfilled_when_both_window_bars_exceed_cap():
+    ref = 100.0
+    bars = [_minute(0, open_=200.0), _minute(1, open_=200.0)]
+    outcome = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is False
+    assert outcome.reason == "ENTRY_UNFILLED"
+    assert outcome.fill_price is None
+
+
+def test_entry_never_considers_a_third_bar_even_if_it_would_fill():
+    """AC16 2-bar window boundary — a widened window is a required mutation
+    to kill; this test is the kill mechanism."""
+    ref = 100.0
+    bars = [
+        _minute(0, open_=200.0),
+        _minute(1, open_=200.0),
+        _minute(2, open_=100.0),  # would fill if the window were widened to 3
+    ]
+    outcome = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is False
+    assert outcome.reason == "ENTRY_UNFILLED"
+
+
+def test_entry_incomplete_when_a_window_minute_bar_is_missing_not_unfilled():
+    """AC15 — a data gap must never be reported as ENTRY_UNFILLED (a real
+    market outcome); it is a distinct structural classification."""
+    ref = 100.0
+    bars = [_minute(0, open_=200.0)]  # bar at offset 1 is missing (gap)
+    outcome = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is False
+    assert outcome.reason == "FILL_WINDOW_INCOMPLETE"
+
+
+def test_entry_incomplete_when_both_window_bars_are_missing():
+    outcome = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=100.0, minute_bars_after_signal=()
+    )
+    assert outcome.reason == "FILL_WINDOW_INCOMPLETE"
+
+
+def test_exit_fills_at_first_bar_open_when_at_the_exact_limit_floor_boundary():
+    ref = 100.0
+    limit_floor = ref * 0.995  # == 99.5
+    bars = [_minute(0, open_=limit_floor), _minute(1, open_=1.0)]
+    outcome = fm.model_exit_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is True
+    assert outcome.fill_price == limit_floor
+    assert outcome.fill_bar_offset == 1
+
+
+def test_exit_unfilled_when_both_window_bars_below_floor():
+    ref = 100.0
+    bars = [_minute(0, open_=1.0), _minute(1, open_=1.0)]
+    outcome = fm.model_exit_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is False
+    assert outcome.reason == "EXIT_UNFILLED"
+
+
+def test_fill_price_is_never_the_reference_close_itself_same_close_fill_banned():
+    """AC14 — even when a window bar's open happens to numerically equal
+    reference_close, the fill is still sourced from that bar's open (a real
+    later-bar observation), never a same-close shortcut. This proves the
+    VALUE can coincide without the SOURCE being the banned shortcut: the
+    returned fill_bar_offset is always 1 or 2, never absent/None/0, which a
+    same-close-fill shortcut (returning reference_close with no offset)
+    could never produce."""
+    ref = 100.0
+    bars = [_minute(0, open_=ref), _minute(1, open_=ref)]
+    outcome = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
+    )
+    assert outcome.filled is True
+    assert outcome.fill_price == ref
+    assert outcome.fill_bar_offset == 1  # traceable to a real bar, not a shortcut
+
+
+def test_partial_fill_is_never_modeled_literal_flag_on_every_outcome():
+    filled = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS,
+        reference_close=100.0,
+        minute_bars_after_signal=[_minute(0, open_=100.0), _minute(1, open_=100.0)],
+    )
+    unfilled = fm.model_entry_fill(
+        decision_ts_ms=_DECISION_TS,
+        reference_close=100.0,
+        minute_bars_after_signal=[_minute(0, open_=999.0), _minute(1, open_=999.0)],
+    )
+    assert filled.partial_fill_modeled is False
+    assert unfilled.partial_fill_modeled is False
+
+
+def test_fill_outcome_construction_rejects_inconsistent_filled_and_price():
+    with pytest.raises(ValueError, match="fill_price and fill_bar_offset"):
+        fm.FillOutcome(
+            filled=True, fill_price=None, fill_bar_offset=None, reason="FILLED"
+        )
+    with pytest.raises(ValueError, match="fill_price=None and fill_bar_offset=None"):
+        fm.FillOutcome(
+            filled=False, fill_price=1.0, fill_bar_offset=1, reason="ENTRY_UNFILLED"
+        )
+
+
+def test_fill_outcome_construction_rejects_reason_action_mismatch():
+    with pytest.raises(ValueError, match="reason='FILLED' requires filled=True"):
+        fm.FillOutcome(
+            filled=False, fill_price=None, fill_bar_offset=None, reason="FILLED"
+        )
+    with pytest.raises(ValueError, match="filled outcome must carry reason='FILLED'"):
+        fm.FillOutcome(
+            filled=True, fill_price=1.0, fill_bar_offset=1, reason="ENTRY_UNFILLED"
+        )

--- a/research/alpaca_track_walkforward/tests/test_fill_model.py
+++ b/research/alpaca_track_walkforward/tests/test_fill_model.py
@@ -21,7 +21,7 @@ def _minute(offset_minutes: int, *, open_: float) -> SpotMinute:
 def test_entry_fills_at_first_bar_open_when_at_the_exact_limit_cap_boundary():
     ref = 100.0
     limit_cap = ref * 1.005  # == 100.5
-    bars = [_minute(0, open_=limit_cap), _minute(1, open_=999.0)]
+    bars = [_minute(1, open_=limit_cap), _minute(2, open_=999.0)]
     outcome = fm.model_entry_fill(
         decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
     )
@@ -34,7 +34,7 @@ def test_entry_fills_at_first_bar_open_when_at_the_exact_limit_cap_boundary():
 def test_entry_rejects_first_bar_one_cent_above_cap_but_fills_second_bar():
     ref = 100.0
     limit_cap = ref * 1.005
-    bars = [_minute(0, open_=limit_cap + 0.01), _minute(1, open_=limit_cap)]
+    bars = [_minute(1, open_=limit_cap + 0.01), _minute(2, open_=limit_cap)]
     outcome = fm.model_entry_fill(
         decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
     )
@@ -45,7 +45,7 @@ def test_entry_rejects_first_bar_one_cent_above_cap_but_fills_second_bar():
 
 def test_entry_unfilled_when_both_window_bars_exceed_cap():
     ref = 100.0
-    bars = [_minute(0, open_=200.0), _minute(1, open_=200.0)]
+    bars = [_minute(1, open_=200.0), _minute(2, open_=200.0)]
     outcome = fm.model_entry_fill(
         decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
     )
@@ -59,9 +59,9 @@ def test_entry_never_considers_a_third_bar_even_if_it_would_fill():
     to kill; this test is the kill mechanism."""
     ref = 100.0
     bars = [
-        _minute(0, open_=200.0),
         _minute(1, open_=200.0),
-        _minute(2, open_=100.0),  # would fill if the window were widened to 3
+        _minute(2, open_=200.0),
+        _minute(3, open_=100.0),  # would fill if the window were widened to 3
     ]
     outcome = fm.model_entry_fill(
         decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
@@ -74,7 +74,7 @@ def test_entry_incomplete_when_a_window_minute_bar_is_missing_not_unfilled():
     """AC15 — a data gap must never be reported as ENTRY_UNFILLED (a real
     market outcome); it is a distinct structural classification."""
     ref = 100.0
-    bars = [_minute(0, open_=200.0)]  # bar at offset 1 is missing (gap)
+    bars = [_minute(1, open_=200.0)]  # bar at offset 2 is missing (gap)
     outcome = fm.model_entry_fill(
         decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
     )
@@ -92,7 +92,7 @@ def test_entry_incomplete_when_both_window_bars_are_missing():
 def test_exit_fills_at_first_bar_open_when_at_the_exact_limit_floor_boundary():
     ref = 100.0
     limit_floor = ref * 0.995  # == 99.5
-    bars = [_minute(0, open_=limit_floor), _minute(1, open_=1.0)]
+    bars = [_minute(1, open_=limit_floor), _minute(2, open_=1.0)]
     outcome = fm.model_exit_fill(
         decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
     )
@@ -103,7 +103,7 @@ def test_exit_fills_at_first_bar_open_when_at_the_exact_limit_floor_boundary():
 
 def test_exit_unfilled_when_both_window_bars_below_floor():
     ref = 100.0
-    bars = [_minute(0, open_=1.0), _minute(1, open_=1.0)]
+    bars = [_minute(1, open_=1.0), _minute(2, open_=1.0)]
     outcome = fm.model_exit_fill(
         decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
     )
@@ -111,34 +111,32 @@ def test_exit_unfilled_when_both_window_bars_below_floor():
     assert outcome.reason == "EXIT_UNFILLED"
 
 
-def test_fill_price_is_never_the_reference_close_itself_same_close_fill_banned():
-    """AC14 — even when a window bar's open happens to numerically equal
-    reference_close, the fill is still sourced from that bar's open (a real
-    later-bar observation), never a same-close shortcut. This proves the
-    VALUE can coincide without the SOURCE being the banned shortcut: the
-    returned fill_bar_offset is always 1 or 2, never absent/None/0, which a
-    same-close-fill shortcut (returning reference_close with no offset)
-    could never produce."""
+def test_signal_timestamp_bar_open_is_rejected_fail_closed():
+    """Verifier reproduction: the same-minute open must never fill."""
     ref = 100.0
-    bars = [_minute(0, open_=ref), _minute(1, open_=ref)]
-    outcome = fm.model_entry_fill(
-        decision_ts_ms=_DECISION_TS, reference_close=ref, minute_bars_after_signal=bars
-    )
-    assert outcome.filled is True
-    assert outcome.fill_price == ref
-    assert outcome.fill_bar_offset == 1  # traceable to a real bar, not a shortcut
+    bars = [
+        _minute(0, open_=ref),  # forbidden same-timestamp open
+        _minute(1, open_=200.0),
+        _minute(2, open_=ref),
+    ]
+    with pytest.raises(ValueError, match="strictly after"):
+        fm.model_entry_fill(
+            decision_ts_ms=_DECISION_TS,
+            reference_close=ref,
+            minute_bars_after_signal=bars,
+        )
 
 
 def test_partial_fill_is_never_modeled_literal_flag_on_every_outcome():
     filled = fm.model_entry_fill(
         decision_ts_ms=_DECISION_TS,
         reference_close=100.0,
-        minute_bars_after_signal=[_minute(0, open_=100.0), _minute(1, open_=100.0)],
+        minute_bars_after_signal=[_minute(1, open_=100.0), _minute(2, open_=100.0)],
     )
     unfilled = fm.model_entry_fill(
         decision_ts_ms=_DECISION_TS,
         reference_close=100.0,
-        minute_bars_after_signal=[_minute(0, open_=999.0), _minute(1, open_=999.0)],
+        minute_bars_after_signal=[_minute(1, open_=999.0), _minute(2, open_=999.0)],
     )
     assert filled.partial_fill_modeled is False
     assert unfilled.partial_fill_modeled is False

--- a/research/alpaca_track_walkforward/tests/test_fold_boundary_invariants.py
+++ b/research/alpaca_track_walkforward/tests/test_fold_boundary_invariants.py
@@ -1,0 +1,154 @@
+"""ROB-1062 H4 (AC3, AC4, AC20, AC27) — targeted invariant tests identified
+during the AC-by-AC audit as needing their OWN dedicated coverage, beyond
+what the integration/golden-digest tests exercise incidentally.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import fold_schedule as fs
+import pytest
+import runner
+import synthetic_fixture as sfx
+import wf_seal_consumption as wf_seal
+
+_ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
+_FOLD = fs.build_fold_schedule(_ANCHOR_MS)[0]
+
+
+def test_decision_timestamps_never_land_inside_the_embargo_window_ap_a1():
+    """AC4 — embargo data may only ever be consumed as warm-up CONTEXT; no
+    decision is EVER dated inside the embargo window. This is a structural
+    property of ``_decision_timestamps`` (it is only ever called with the
+    TRAIN and OOS window bounds, never the embargo one) — proven directly
+    against the real fold boundaries rather than trusting that by
+    inspection alone."""
+    timestamps = runner._decision_timestamps(
+        family="AP-A1",
+        window_start_ms=_FOLD.train_start_ms,
+        window_end_ms=_FOLD.train_end_ms,
+    ) + runner._decision_timestamps(
+        family="AP-A1",
+        window_start_ms=_FOLD.oos_start_ms,
+        window_end_ms=_FOLD.oos_end_ms,
+    )
+    for ts in timestamps:
+        assert not (_FOLD.embargo_start_ms <= ts < _FOLD.embargo_end_ms), (
+            f"decision {ts} falls inside the embargo window "
+            f"[{_FOLD.embargo_start_ms}, {_FOLD.embargo_end_ms})"
+        )
+    # And the embargo window is non-empty -- this is a real exclusion, not
+    # a vacuous one over an empty range.
+    assert _FOLD.embargo_end_ms > _FOLD.embargo_start_ms
+
+
+def test_decision_timestamps_never_land_inside_the_embargo_window_ap_a2():
+    timestamps = runner._decision_timestamps(
+        family="AP-A2",
+        window_start_ms=_FOLD.train_start_ms,
+        window_end_ms=_FOLD.train_end_ms,
+    ) + runner._decision_timestamps(
+        family="AP-A2",
+        window_start_ms=_FOLD.oos_start_ms,
+        window_end_ms=_FOLD.oos_end_ms,
+    )
+    for ts in timestamps:
+        assert not (_FOLD.embargo_start_ms <= ts < _FOLD.embargo_end_ms)
+
+
+def test_economic_execution_is_taker_taker_never_a_maker_assumption():
+    """AC20 — no maker-optimistic cost assumption anywhere: the sealed
+    execution model is TAKER_TAKER, and H4's own cost scenario table is
+    EXACTLY the sealed 4 (no lower, maker-implying 5th scenario could ever
+    be introduced through this gateway)."""
+    import seal_consumption as h3_seal
+
+    bundle = h3_seal.load_sealed_configs_and_params()
+    assert bundle.params.run_status.economic_execution == "TAKER_TAKER"
+    scenarios = wf_seal.cost_scenarios_bp()
+    assert set(scenarios) == {"C50", "C100", "C120", "C150"}
+    assert min(scenarios.values()) == 50  # the cheapest scenario is still fee-inclusive
+
+
+@pytest.mark.slow
+def test_two_different_configs_never_share_or_alias_mutable_state_rob_1012_guard():
+    """AC27 (ROB-1012 regression guard) — running two DIFFERENT AP-A2
+    configs must produce independent results with no shared/aliased
+    mutable buffer: mutating one config's run result must never affect the
+    other's, and their internal per-decision `state` dicts must be
+    distinct objects at every point (proven here by running both and
+    diffing which symbols are held -- distinct configs with distinct
+    L/k/b almost certainly diverge in held membership at some point across
+    ~56 weekly decisions)."""
+    import seal_consumption as h3_seal
+
+    bundle = h3_seal.load_sealed_configs_and_params()
+    config_a = next(c for c in bundle.configs if c.config_id == "AP-A2-00")
+    config_b = next(c for c in bundle.configs if c.config_id == "AP-A2-07")
+
+    bars = sfx.build_bars_by_symbol(
+        window_start_ms=_FOLD.train_start_ms,
+        num_days=(_FOLD.oos_end_ms - _FOLD.train_start_ms) // 86_400_000,
+        n_symbols=20,
+    )
+    universe_provider = sfx.make_universe_snapshot_provider(20)
+    minute_provider = sfx.make_minute_bars_provider(
+        window_start_ms=_FOLD.train_start_ms, n_symbols=20
+    )
+
+    result_a = runner._run_continuous_decisions(
+        config=config_a,
+        family="AP-A2",
+        fold=_FOLD,
+        bars_by_symbol=bars,
+        universe_snapshot_provider=universe_provider,
+        minute_bars_provider=minute_provider,
+    )
+    result_b = runner._run_continuous_decisions(
+        config=config_b,
+        family="AP-A2",
+        fold=_FOLD,
+        bars_by_symbol=bars,
+        universe_snapshot_provider=universe_provider,
+        minute_bars_provider=minute_provider,
+    )
+
+    # Different objects, never the same list/dict instance leaking across
+    # configs (the literal ROB-1012 failure shape: a shared candidate
+    # buffer aliased between two configs' runs).
+    assert result_a.all_records is not result_b.all_records
+    assert result_a.open_legs_by_symbol is not result_b.open_legs_by_symbol
+    assert result_a.closed_trades is not result_b.closed_trades
+
+    # Mutating one's records must never be visible in the other's (proves
+    # they are not views over the same underlying storage).
+    records_a_before = len(result_a.all_records)
+    _ = list(result_a.all_records) + [None]  # a copy, not a mutation -- but
+    # the real proof is object identity above; this sanity-checks lengths
+    # are independently meaningful (differing config params -> differing
+    # record counts is NOT required, but the objects must be independent).
+    assert len(result_a.all_records) == records_a_before  # unchanged by the above
+    assert len(result_b.all_records) > 0
+
+    # AC3, reusing this same (expensive) run rather than paying for a
+    # third one: a position opened during TRAIN that survives to (or past)
+    # the OOS boundary is the direct, observable signature of "no reset at
+    # the OOS boundary" -- if state WERE reset at train_end, no TRAIN-
+    # entered position could ever still be open/closing during OOS.
+    for result in (result_a, result_b):
+        train_entered_carrying_into_oos = [
+            t
+            for t in result.closed_trades
+            if t.entry_decision_ts_ms < _FOLD.train_end_ms
+            and t.exit_decision_ts_ms >= _FOLD.oos_start_ms
+        ] + [
+            leg
+            for leg in result.open_legs_by_symbol.values()
+            if leg.entry_decision_ts_ms < _FOLD.train_end_ms
+        ]
+        assert len(train_entered_carrying_into_oos) > 0, (
+            "expected at least one TRAIN-entered position to still be open "
+            "or closing during OOS in this fixture -- otherwise this run "
+            "cannot demonstrate AC3's no-reset-at-OOS-boundary property"
+        )

--- a/research/alpaca_track_walkforward/tests/test_fold_schedule.py
+++ b/research/alpaca_track_walkforward/tests/test_fold_schedule.py
@@ -117,9 +117,8 @@ def test_fold_id_must_match_builder_issued_fold_index():
         fs.assert_registered_fold_binding(fold_id="fold-7", fold=fold)
 
 
-def test_second_valid_monday_anchor_cannot_register_another_fold_zero():
-    """Verifier reproduction: fold-0 has one process-level run identity."""
-    fs.build_fold_schedule(_ANCHOR_MS)
+def test_other_valid_monday_anchor_is_rejected_against_manifest_not_first_call():
+    """Verifier reproduction: process restart cannot choose another fold-0."""
     second_monday_anchor = _ANCHOR_MS + 28 * 86_400_000
-    with pytest.raises(fs.FoldBindingError, match="different walk-forward anchor"):
+    with pytest.raises(fs.FoldBindingError, match="canonical run manifest"):
         fs.build_fold_schedule(second_monday_anchor)

--- a/research/alpaca_track_walkforward/tests/test_fold_schedule.py
+++ b/research/alpaca_track_walkforward/tests/test_fold_schedule.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import fold_schedule as fs
+import pytest
 
 # A Monday 00:00:00 UTC anchor (first OOS start) — 2024-01-01 is a Monday.
 _ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
@@ -93,3 +94,24 @@ def test_build_fold_schedule_takes_no_fold_list_parameter():
 
     sig = inspect.signature(fs.build_fold_schedule)
     assert list(sig.parameters) == ["anchor_oos_start_ms"]
+
+
+def test_report_reproduction_direct_arbitrary_fold_construction_is_rejected():
+    real = fs.build_fold_schedule(_ANCHOR_MS)[0]
+    with pytest.raises(fs.FoldBindingError, match="direct construction"):
+        fs.Fold(
+            fold_index=99,
+            train_start_ms=real.train_start_ms,
+            train_end_ms=real.train_end_ms,
+            embargo_start_ms=real.embargo_start_ms,
+            embargo_end_ms=real.embargo_end_ms,
+            oos_start_ms=real.oos_start_ms,
+            oos_end_ms=real.oos_end_ms,
+        )
+
+
+def test_fold_id_must_match_builder_issued_fold_index():
+    fold = fs.build_fold_schedule(_ANCHOR_MS)[0]
+    fs.assert_registered_fold_binding(fold_id="fold-0", fold=fold)
+    with pytest.raises(fs.FoldBindingError, match="does not match"):
+        fs.assert_registered_fold_binding(fold_id="fold-7", fold=fold)

--- a/research/alpaca_track_walkforward/tests/test_fold_schedule.py
+++ b/research/alpaca_track_walkforward/tests/test_fold_schedule.py
@@ -115,3 +115,11 @@ def test_fold_id_must_match_builder_issued_fold_index():
     fs.assert_registered_fold_binding(fold_id="fold-0", fold=fold)
     with pytest.raises(fs.FoldBindingError, match="does not match"):
         fs.assert_registered_fold_binding(fold_id="fold-7", fold=fold)
+
+
+def test_second_valid_monday_anchor_cannot_register_another_fold_zero():
+    """Verifier reproduction: fold-0 has one process-level run identity."""
+    fs.build_fold_schedule(_ANCHOR_MS)
+    second_monday_anchor = _ANCHOR_MS + 28 * 86_400_000
+    with pytest.raises(fs.FoldBindingError, match="different walk-forward anchor"):
+        fs.build_fold_schedule(second_monday_anchor)

--- a/research/alpaca_track_walkforward/tests/test_fold_schedule.py
+++ b/research/alpaca_track_walkforward/tests/test_fold_schedule.py
@@ -1,0 +1,95 @@
+"""ROB-1062 H4 (AC1, AC2, AC6) — RED-first: the 8-fold walk-forward
+schedule generator does not exist yet. This test module is written and run
+BEFORE ``fold_schedule.py`` is created, to capture the failing (RED) state
+verbatim before any implementation exists.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import fold_schedule as fs
+
+# A Monday 00:00:00 UTC anchor (first OOS start) — 2024-01-01 is a Monday.
+_ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
+
+
+def test_build_fold_schedule_returns_exactly_8_folds():
+    folds = fs.build_fold_schedule(_ANCHOR_MS)
+    assert len(folds) == 8
+
+
+def test_every_fold_has_train_365_embargo_7_oos_28_and_half_open_utc_boundaries():
+    folds = fs.build_fold_schedule(_ANCHOR_MS)
+    day_ms = 86_400_000
+    for fold in folds:
+        assert fold.oos_end_ms - fold.oos_start_ms == 28 * day_ms
+        assert fold.embargo_end_ms - fold.embargo_start_ms == 7 * day_ms
+        assert fold.train_end_ms - fold.train_start_ms == 365 * day_ms
+        # contiguous, half-open, end exclusive
+        assert fold.embargo_start_ms == fold.train_end_ms
+        assert fold.oos_start_ms == fold.embargo_end_ms
+
+
+def test_folds_roll_forward_by_28_days_each():
+    folds = fs.build_fold_schedule(_ANCHOR_MS)
+    day_ms = 86_400_000
+    for earlier, later in zip(folds, folds[1:], strict=False):
+        assert later.oos_start_ms - earlier.oos_start_ms == 28 * day_ms
+
+
+def test_each_oos_window_has_exactly_4_monday_0005_utc_decisions_calendar_assertion():
+    """AC2 — a calendar assertion, not a trusted arithmetic identity: walk
+    every minute-boundary in each OOS window and count real Monday 00:05:00
+    UTC timestamps landing inside it."""
+    folds = fs.build_fold_schedule(_ANCHOR_MS)
+    for fold in folds:
+        mondays_0005 = 0
+        t = fold.oos_start_ms
+        minute_ms = 60_000
+        while t < fold.oos_end_ms:
+            dt = datetime.fromtimestamp(t / 1000, tz=UTC)
+            if dt.weekday() == 0 and dt.hour == 0 and dt.minute == 5 and dt.second == 0:
+                mondays_0005 += 1
+            t += minute_ms
+        assert mondays_0005 == 4
+
+
+def test_each_oos_window_has_exactly_28_daily_0005_utc_decisions():
+    """AC2 second sentence — AP-A1 daily eval count == OOS day count."""
+    folds = fs.build_fold_schedule(_ANCHOR_MS)
+    for fold in folds:
+        daily_0005 = 0
+        t = fold.oos_start_ms
+        minute_ms = 60_000
+        while t < fold.oos_end_ms:
+            dt = datetime.fromtimestamp(t / 1000, tz=UTC)
+            if dt.hour == 0 and dt.minute == 5 and dt.second == 0:
+                daily_0005 += 1
+            t += minute_ms
+        assert daily_0005 == 28
+
+
+def test_anchor_not_utc_midnight_rejected():
+    bad_anchor = _ANCHOR_MS + 3_600_000
+    import pytest
+
+    with pytest.raises(ValueError, match="UTC midnight"):
+        fs.build_fold_schedule(bad_anchor)
+
+
+def test_anchor_not_a_monday_rejected():
+    not_monday = _ANCHOR_MS + 86_400_000  # Tuesday
+    import pytest
+
+    with pytest.raises(ValueError, match="Monday"):
+        fs.build_fold_schedule(not_monday)
+
+
+def test_build_fold_schedule_takes_no_fold_list_parameter():
+    """AC6 — no caller-reachable way to substitute/add/re-split individual
+    folds: the function's only parameter is the anchor timestamp."""
+    import inspect
+
+    sig = inspect.signature(fs.build_fold_schedule)
+    assert list(sig.parameters) == ["anchor_oos_start_ms"]

--- a/research/alpaca_track_walkforward/tests/test_golden_digest.py
+++ b/research/alpaca_track_walkforward/tests/test_golden_digest.py
@@ -39,9 +39,13 @@ _NUM_DAYS = (_FOLD.oos_end_ms - _FOLD.train_start_ms) // 86_400_000
 # context/evidence fields were added. Synthetic prices and this hash
 # projection are quantized only to remove CPython/libm last-bit differences
 # between macOS and Linux; runner gates still compare full-precision values.
-# Any later change remains a deliberate re-seal: STOP and inspect the
-# human-readable diagnostic before touching this constant.
-GOLDEN_DIGEST = "d8a78ac0a9ebe38169ff9e4abd887e4a81e4b8fe3db11308bb71323b00bac922"
+# Re-pinned 2026-07-27 after verify2: AP-A2 turnover now uses
+# entries/(weekly evaluations*k), the unchanged sealed band is enforced
+# before E120, and immutable per-call universe/minute provenance hashes are
+# part of the regression projection. Selection and every TRAIN/OOS lifecycle
+# count remain unchanged. Any later change remains a deliberate re-seal:
+# STOP and inspect the human-readable diagnostic before touching this value.
+GOLDEN_DIGEST = "f80a016ad1be1af5883e5c13e793bb2f9209c12c328c67131456ea9029613867"
 
 
 def _golden_float(value: float) -> float:
@@ -146,6 +150,7 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
                     for m in cr.oos_masked_pnl_by_trade
                 ],
                 "context_binding_hash": cr.context_binding_at_oos_start.combined_context_hash,
+                "provider_evidence_hash": cr.provider_evidence_binding.combined_hash,
             }
             for cr in result.config_runs
         },
@@ -171,6 +176,7 @@ def _digest_diagnostics(result: runner.FamilyFoldResult) -> dict:
                     "median_e120_bp": run.train_metrics.median_trade_e120_bp,
                     "modeled_entries": run.train_metrics.modeled_entries_count,
                     "open": run.train_metrics.blind_counts.open_positions_count,
+                    "turnover_p": run.train_metrics.turnover_p,
                     "annualized_c120_pct": bc.annualized_stress_cost_pct(
                         entry_filled_notionals=tuple(
                             entry.entry_filled_notional
@@ -194,6 +200,7 @@ def _digest_diagnostics(result: runner.FamilyFoldResult) -> dict:
                 "context_binding_hash": (
                     run.context_binding_at_oos_start.combined_context_hash
                 ),
+                "provider_evidence_hash": run.provider_evidence_binding.combined_hash,
             }
             for run in result.config_runs
         },

--- a/research/alpaca_track_walkforward/tests/test_golden_digest.py
+++ b/research/alpaca_track_walkforward/tests/test_golden_digest.py
@@ -31,12 +31,22 @@ _ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
 _FOLD = fs.build_fold_schedule(_ANCHOR_MS)[0]
 _NUM_DAYS = (_FOLD.oos_end_ms - _FOLD.train_start_ms) // 86_400_000
 
-# Pinned 2026-07-26. Changing this constant is a deliberate re-seal of the
-# golden fixture (a real behavioral change to fold_schedule/fill_model/
-# pnl_views/config_selection/blind_counts/oos_mask/runner) -- never a
-# routine edit to make a failing test pass. If this test fails, STOP and
-# determine WHY the digest moved before touching this constant.
-GOLDEN_DIGEST = "91b5d47e2abcc2b23c07dcff3303f5b2113139a443779b10a8d8725012a06850"
+# Pinned 2026-07-27 after the audit-contract change. The moved summary was
+# decomposed before re-pinning: event-time attribution removed only
+# cross-boundary trades from TRAIN closed/E120 (entry counts stayed fixed),
+# actual-filled-notional C120 replaced the count-as-full-NAV formula, OOS
+# blind counts and NO_SELECTED_CONFIG stayed unchanged, and the strengthened
+# context/evidence fields were added. Synthetic prices and this hash
+# projection are quantized only to remove CPython/libm last-bit differences
+# between macOS and Linux; runner gates still compare full-precision values.
+# Any later change remains a deliberate re-seal: STOP and inspect the
+# human-readable diagnostic before touching this constant.
+GOLDEN_DIGEST = "d8a78ac0a9ebe38169ff9e4abd887e4a81e4b8fe3db11308bb71323b00bac922"
+
+
+def _golden_float(value: float) -> float:
+    """Cross-platform golden projection only, never a gate input."""
+    return round(value, 10)
 
 
 def _digest_summary(result: runner.FamilyFoldResult) -> dict:
@@ -53,15 +63,21 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
             cr.config_id: {
                 "train_metrics": {
                     "closed_trades_count": cr.train_metrics.closed_trades_count,
-                    "median_trade_e120_bp": cr.train_metrics.median_trade_e120_bp,
+                    "median_trade_e120_bp": (
+                        _golden_float(cr.train_metrics.median_trade_e120_bp)
+                        if cr.train_metrics.median_trade_e120_bp is not None
+                        else None
+                    ),
                     "modeled_entries_count": cr.train_metrics.modeled_entries_count,
-                    "turnover_p": cr.train_metrics.turnover_p,
+                    "turnover_p": _golden_float(cr.train_metrics.turnover_p),
                     "modeled_entry_evidence": [
                         {
                             "entry_fill_ts_ms": entry.entry_fill_ts_ms,
-                            "filled_qty": entry.filled_qty,
-                            "entry_fill_price": entry.entry_fill_price,
-                            "entry_filled_notional": entry.entry_filled_notional,
+                            "filled_qty": _golden_float(entry.filled_qty),
+                            "entry_fill_price": _golden_float(entry.entry_fill_price),
+                            "entry_filled_notional": _golden_float(
+                                entry.entry_filled_notional
+                            ),
                         }
                         for entry in cr.train_metrics.modeled_entry_evidence
                     ],
@@ -113,9 +129,11 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
                 "oos_modeled_entry_evidence": [
                     {
                         "entry_fill_ts_ms": entry.entry_fill_ts_ms,
-                        "filled_qty": entry.filled_qty,
-                        "entry_fill_price": entry.entry_fill_price,
-                        "entry_filled_notional": entry.entry_filled_notional,
+                        "filled_qty": _golden_float(entry.filled_qty),
+                        "entry_fill_price": _golden_float(entry.entry_fill_price),
+                        "entry_filled_notional": _golden_float(
+                            entry.entry_filled_notional
+                        ),
                     }
                     for entry in cr.oos_modeled_entry_evidence
                 ],
@@ -227,6 +245,38 @@ def test_golden_digest_matches_the_pinned_value(baseline_digest, baseline_result
             sort_keys=True,
             indent=2,
         )
+
+
+@pytest.mark.slow
+def test_golden_runner_costs_match_the_frozen_full_precision_formula(
+    baseline_result,
+):
+    """Cross-check the golden run against the same frozen equation whose
+    range/30-entry cases are pinned in ``test_blind_counts.py``.
+
+    Golden float normalization is presentation-only: both sides here use
+    the immutable raw fill evidence and compare the production calculation
+    before any rounding.
+    """
+    for run in baseline_result.config_runs:
+        evidence = run.train_metrics.modeled_entry_evidence
+        production = bc.annualized_stress_cost_pct(
+            entry_filled_notionals=tuple(
+                entry.entry_filled_notional for entry in evidence
+            ),
+            window_days=365,
+            nav_usd=2000.0,
+            cost_bp=120.0,
+        )
+        direct = (
+            100.0
+            * (365.0 / 365)
+            * sum(
+                ((entry.filled_qty * entry.entry_fill_price) / 2000.0) * 0.012
+                for entry in evidence
+            )
+        )
+        assert production == direct
 
 
 @pytest.mark.slow

--- a/research/alpaca_track_walkforward/tests/test_golden_digest.py
+++ b/research/alpaca_track_walkforward/tests/test_golden_digest.py
@@ -1,0 +1,185 @@
+"""ROB-1062 H4 — golden digest over the runner's full output on a fixed
+synthetic fixture.
+
+Scope note: the digest covers the FULL ``FamilyFoldResult`` for AP-A2 (all 8
+sealed configs, one fold) — AP-A2's weekly cadence is used rather than
+AP-A1's daily one purely for CI runtime (see ``test_runner.py``'s module
+docstring: H3's per-decision seal reload makes AP-A1 ~7x more expensive for
+the same config count; AP-A1's own code path is separately exercised by
+``test_runner.py``'s dedicated regression test).
+
+The digest NEVER unmasks OOS PnL (that would defeat the entire point of
+AC22-25) — it is computed over ``TRAIN`` metrics (numbers), OOS blind counts
+(numbers), the COUNT and (fold_id, family, config_id) BINDING metadata of
+each masked OOS entry (never the underlying value), the context-binding
+hash, and the selection result.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import canonical_hash
+import fold_schedule as fs
+import pytest
+import runner
+import synthetic_fixture as sfx
+
+_ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
+_FOLD = fs.build_fold_schedule(_ANCHOR_MS)[0]
+_NUM_DAYS = (_FOLD.oos_end_ms - _FOLD.train_start_ms) // 86_400_000
+
+# Pinned 2026-07-26. Changing this constant is a deliberate re-seal of the
+# golden fixture (a real behavioral change to fold_schedule/fill_model/
+# pnl_views/config_selection/blind_counts/oos_mask/runner) -- never a
+# routine edit to make a failing test pass. If this test fails, STOP and
+# determine WHY the digest moved before touching this constant.
+GOLDEN_DIGEST = "f787c3baa866b654e786437fe78bd7ed15445671dd914de1e568bd9665c94bf8"
+
+
+def _digest_summary(result: runner.FamilyFoldResult) -> dict:
+    """A JSON-safe summary of the FULL run — never touches a masked raw
+    value (no ``unmask`` call anywhere in this function)."""
+    return {
+        "family": result.family,
+        "fold_id": result.fold_id,
+        "selection": {
+            "status": result.selection.status,
+            "selected_config_id": result.selection.selected_config_id,
+        },
+        "configs": {
+            cr.config_id: {
+                "train_metrics": {
+                    "closed_trades_count": cr.train_metrics.closed_trades_count,
+                    "median_trade_e120_bp": cr.train_metrics.median_trade_e120_bp,
+                    "modeled_entries_count": cr.train_metrics.modeled_entries_count,
+                    "turnover_p": cr.train_metrics.turnover_p,
+                    "blind_counts": {
+                        "total_decision_records": (
+                            cr.train_metrics.blind_counts.total_decision_records
+                        ),
+                        "modeled_entries_count": (
+                            cr.train_metrics.blind_counts.modeled_entries_count
+                        ),
+                        "closed_trades_count": (
+                            cr.train_metrics.blind_counts.closed_trades_count
+                        ),
+                        "open_positions_count": (
+                            cr.train_metrics.blind_counts.open_positions_count
+                        ),
+                        "entry_unfilled_count": (
+                            cr.train_metrics.blind_counts.entry_unfilled_count
+                        ),
+                        "exit_unfilled_count": (
+                            cr.train_metrics.blind_counts.exit_unfilled_count
+                        ),
+                        "fill_window_incomplete_count": (
+                            cr.train_metrics.blind_counts.fill_window_incomplete_count
+                        ),
+                        "holding_days": list(
+                            cr.train_metrics.blind_counts.holding_days
+                        ),
+                        "reason_code_histogram": dict(
+                            cr.train_metrics.blind_counts.reason_code_histogram
+                        ),
+                    },
+                },
+                "oos_blind_counts": {
+                    "total_decision_records": cr.oos_blind_counts.total_decision_records,
+                    "modeled_entries_count": cr.oos_blind_counts.modeled_entries_count,
+                    "closed_trades_count": cr.oos_blind_counts.closed_trades_count,
+                    "open_positions_count": cr.oos_blind_counts.open_positions_count,
+                    "entry_unfilled_count": cr.oos_blind_counts.entry_unfilled_count,
+                    "exit_unfilled_count": cr.oos_blind_counts.exit_unfilled_count,
+                    "fill_window_incomplete_count": (
+                        cr.oos_blind_counts.fill_window_incomplete_count
+                    ),
+                    "holding_days": list(cr.oos_blind_counts.holding_days),
+                    "reason_code_histogram": dict(
+                        cr.oos_blind_counts.reason_code_histogram
+                    ),
+                },
+                "oos_masked_pnl_bindings": [
+                    {
+                        "fold_id": m.fold_id,
+                        "family": m.family,
+                        "config_id": m.config_id,
+                    }
+                    for m in cr.oos_masked_pnl_by_trade
+                ],
+                "context_binding_hash": cr.context_binding_at_oos_start.combined_context_hash,
+            }
+            for cr in result.config_runs
+        },
+    }
+
+
+def _run() -> runner.FamilyFoldResult:
+    bars = sfx.build_bars_by_symbol(
+        window_start_ms=_FOLD.train_start_ms, num_days=_NUM_DAYS, n_symbols=20
+    )
+    universe_provider = sfx.make_universe_snapshot_provider(20)
+    minute_provider = sfx.make_minute_bars_provider(
+        window_start_ms=_FOLD.train_start_ms, n_symbols=20
+    )
+    return runner.run_family_fold(
+        family="AP-A2",
+        fold_id="fold-0",
+        fold=_FOLD,
+        bars_by_symbol=bars,
+        universe_snapshot_provider=universe_provider,
+        minute_bars_provider=minute_provider,
+    )
+
+
+# Module-scoped: the full 8-config AP-A2 run is expensive (H3's own
+# per-decision seal reload, see test_runner.py's module docstring) -- every
+# test in this file that only needs the BASELINE result reuses this ONE
+# computation rather than re-running it, to keep total CI time bounded.
+# The "moves on a real change" and "reproducible across repeated calls"
+# tests below each still perform their OWN independent second `_run()` call
+# (unavoidable -- that is the entire point of what they prove).
+@pytest.fixture(scope="module")
+def baseline_result() -> runner.FamilyFoldResult:
+    return _run()
+
+
+@pytest.fixture(scope="module")
+def baseline_digest(baseline_result) -> str:
+    return canonical_hash.canonical_sha256(_digest_summary(baseline_result))
+
+
+@pytest.mark.slow
+def test_golden_digest_matches_the_pinned_value(baseline_digest):
+    # First-run bootstrap: print the real digest so it can be pinned above.
+    print(f"\nCOMPUTED GOLDEN DIGEST: {baseline_digest}")
+    if GOLDEN_DIGEST != "pending":
+        assert baseline_digest == GOLDEN_DIGEST
+
+
+@pytest.mark.slow
+def test_golden_digest_moves_on_a_real_behavioral_change(baseline_digest):
+    """Proof the pinned digest is non-vacuous: a genuine behavioral change
+    (widening the entry fill window from 2 minutes to 3) moves it. This is
+    NOT the `r1 == r2` determinism check H3 was sent back for lacking —
+    this specifically proves the digest is SENSITIVE to real behavior."""
+    import fill_model as fm
+
+    original = fm.FILL_WINDOW_MINUTE_COUNT
+    try:
+        fm.FILL_WINDOW_MINUTE_COUNT = 3
+        mutated_summary = _digest_summary(_run())
+    finally:
+        fm.FILL_WINDOW_MINUTE_COUNT = original
+    mutated = canonical_hash.canonical_sha256(mutated_summary)
+
+    assert mutated != baseline_digest
+
+
+@pytest.mark.slow
+def test_golden_digest_is_reproducible_across_a_second_independent_run(baseline_digest):
+    """A lighter-weight, same-process determinism check (r1 == r2) --
+    useful but NOT a substitute for the "moves on a real change" proof
+    above (H3 was sent back precisely for stopping at this check alone)."""
+    second_digest = canonical_hash.canonical_sha256(_digest_summary(_run()))
+    assert second_digest == baseline_digest

--- a/research/alpaca_track_walkforward/tests/test_golden_digest.py
+++ b/research/alpaca_track_walkforward/tests/test_golden_digest.py
@@ -34,7 +34,7 @@ _NUM_DAYS = (_FOLD.oos_end_ms - _FOLD.train_start_ms) // 86_400_000
 # pnl_views/config_selection/blind_counts/oos_mask/runner) -- never a
 # routine edit to make a failing test pass. If this test fails, STOP and
 # determine WHY the digest moved before touching this constant.
-GOLDEN_DIGEST = "f787c3baa866b654e786437fe78bd7ed15445671dd914de1e568bd9665c94bf8"
+GOLDEN_DIGEST = "91b5d47e2abcc2b23c07dcff3303f5b2113139a443779b10a8d8725012a06850"
 
 
 def _digest_summary(result: runner.FamilyFoldResult) -> dict:
@@ -54,6 +54,15 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
                     "median_trade_e120_bp": cr.train_metrics.median_trade_e120_bp,
                     "modeled_entries_count": cr.train_metrics.modeled_entries_count,
                     "turnover_p": cr.train_metrics.turnover_p,
+                    "modeled_entry_evidence": [
+                        {
+                            "entry_fill_ts_ms": entry.entry_fill_ts_ms,
+                            "filled_qty": entry.filled_qty,
+                            "entry_fill_price": entry.entry_fill_price,
+                            "entry_filled_notional": entry.entry_filled_notional,
+                        }
+                        for entry in cr.train_metrics.modeled_entry_evidence
+                    ],
                     "blind_counts": {
                         "total_decision_records": (
                             cr.train_metrics.blind_counts.total_decision_records
@@ -99,6 +108,15 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
                         cr.oos_blind_counts.reason_code_histogram
                     ),
                 },
+                "oos_modeled_entry_evidence": [
+                    {
+                        "entry_fill_ts_ms": entry.entry_fill_ts_ms,
+                        "filled_qty": entry.filled_qty,
+                        "entry_fill_price": entry.entry_fill_price,
+                        "entry_filled_notional": entry.entry_filled_notional,
+                    }
+                    for entry in cr.oos_modeled_entry_evidence
+                ],
                 "oos_masked_pnl_bindings": [
                     {
                         "fold_id": m.fold_id,

--- a/research/alpaca_track_walkforward/tests/test_golden_digest.py
+++ b/research/alpaca_track_walkforward/tests/test_golden_digest.py
@@ -43,9 +43,16 @@ _NUM_DAYS = (_FOLD.oos_end_ms - _FOLD.train_start_ms) // 86_400_000
 # entries/(weekly evaluations*k), the unchanged sealed band is enforced
 # before E120, and immutable per-call universe/minute provenance hashes are
 # part of the regression projection. Selection and every TRAIN/OOS lifecycle
-# count remain unchanged. Any later change remains a deliberate re-seal:
+# count remain unchanged.
+# Re-pinned 2026-07-27 after verify4: the synthetic runner now compares its
+# complete daily/universe/minute inputs to one immutable run-manifest identity,
+# shares that pre-materialized snapshot across all configs, exposes OOS
+# turnover and an aggregate-dry-gate handle, and records those binding fields
+# here. The human-readable diagnostic confirmed selection, every TRAIN metric,
+# and every OOS blind count are unchanged; only provenance/gate metadata moved.
+# Any later change remains a deliberate re-seal:
 # STOP and inspect the human-readable diagnostic before touching this value.
-GOLDEN_DIGEST = "f80a016ad1be1af5883e5c13e793bb2f9209c12c328c67131456ea9029613867"
+GOLDEN_DIGEST = "35756b6d90aa9fc1190cc0c6dcd6b6c2503b8dd57966917058baccf28bcbd8c5"
 
 
 def _golden_float(value: float) -> float:
@@ -130,6 +137,7 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
                         cr.oos_blind_counts.reason_code_histogram
                     ),
                 },
+                "oos_turnover_p": _golden_float(cr.oos_turnover_p),
                 "oos_modeled_entry_evidence": [
                     {
                         "entry_fill_ts_ms": entry.entry_fill_ts_ms,
@@ -149,8 +157,25 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
                     }
                     for m in cr.oos_masked_pnl_by_trade
                 ],
+                "oos_dry_count_gate_binding": {
+                    "fold_id": cr.oos_dry_count_gate_handle.fold_id,
+                    "family": cr.oos_dry_count_gate_handle.family,
+                    "config_id": cr.oos_dry_count_gate_handle.config_id,
+                },
                 "context_binding_hash": cr.context_binding_at_oos_start.combined_context_hash,
-                "provider_evidence_hash": cr.provider_evidence_binding.combined_hash,
+                "provider_evidence": {
+                    "run_manifest_hash": (
+                        cr.provider_evidence_binding.run_manifest_hash
+                    ),
+                    "daily_bars_artifact_hash": (
+                        cr.provider_evidence_binding.daily_bars_artifact_hash
+                    ),
+                    "universe_grid_hash": (
+                        cr.provider_evidence_binding.universe_grid_hash
+                    ),
+                    "minute_grid_hash": cr.provider_evidence_binding.minute_grid_hash,
+                    "combined_hash": cr.provider_evidence_binding.combined_hash,
+                },
             }
             for cr in result.config_runs
         },

--- a/research/alpaca_track_walkforward/tests/test_golden_digest.py
+++ b/research/alpaca_track_walkforward/tests/test_golden_digest.py
@@ -17,8 +17,10 @@ hash, and the selection result.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
+import blind_counts as bc
 import canonical_hash
 import fold_schedule as fs
 import pytest
@@ -132,6 +134,54 @@ def _digest_summary(result: runner.FamilyFoldResult) -> dict:
     }
 
 
+def _digest_diagnostics(result: runner.FamilyFoldResult) -> dict:
+    """Human-readable semantic projection for a moved golden hash.
+
+    This intentionally uses the production C120 accounting function so a
+    digest failure exposes whether the full runner and the frozen-formula
+    unit tests are still exercising the same calculation.
+    """
+    return {
+        "selection": {
+            "status": result.selection.status,
+            "selected_config_id": result.selection.selected_config_id,
+        },
+        "configs": {
+            run.config_id: {
+                "train": {
+                    "closed": run.train_metrics.closed_trades_count,
+                    "median_e120_bp": run.train_metrics.median_trade_e120_bp,
+                    "modeled_entries": run.train_metrics.modeled_entries_count,
+                    "open": run.train_metrics.blind_counts.open_positions_count,
+                    "annualized_c120_pct": bc.annualized_stress_cost_pct(
+                        entry_filled_notionals=tuple(
+                            entry.entry_filled_notional
+                            for entry in run.train_metrics.modeled_entry_evidence
+                        ),
+                        window_days=365,
+                        nav_usd=2000.0,
+                        cost_bp=120.0,
+                    ),
+                },
+                "oos_blind_counts": {
+                    "modeled_entries": run.oos_blind_counts.modeled_entries_count,
+                    "closed": run.oos_blind_counts.closed_trades_count,
+                    "open": run.oos_blind_counts.open_positions_count,
+                    "entry_unfilled": run.oos_blind_counts.entry_unfilled_count,
+                    "exit_unfilled": run.oos_blind_counts.exit_unfilled_count,
+                    "incomplete": run.oos_blind_counts.fill_window_incomplete_count,
+                    "holding_days": list(run.oos_blind_counts.holding_days),
+                    "histogram": dict(run.oos_blind_counts.reason_code_histogram),
+                },
+                "context_binding_hash": (
+                    run.context_binding_at_oos_start.combined_context_hash
+                ),
+            }
+            for run in result.config_runs
+        },
+    }
+
+
 def _run() -> runner.FamilyFoldResult:
     bars = sfx.build_bars_by_symbol(
         window_start_ms=_FOLD.train_start_ms, num_days=_NUM_DAYS, n_symbols=20
@@ -168,11 +218,15 @@ def baseline_digest(baseline_result) -> str:
 
 
 @pytest.mark.slow
-def test_golden_digest_matches_the_pinned_value(baseline_digest):
+def test_golden_digest_matches_the_pinned_value(baseline_digest, baseline_result):
     # First-run bootstrap: print the real digest so it can be pinned above.
     print(f"\nCOMPUTED GOLDEN DIGEST: {baseline_digest}")
     if GOLDEN_DIGEST != "pending":
-        assert baseline_digest == GOLDEN_DIGEST
+        assert baseline_digest == GOLDEN_DIGEST, json.dumps(
+            _digest_diagnostics(baseline_result),
+            sort_keys=True,
+            indent=2,
+        )
 
 
 @pytest.mark.slow

--- a/research/alpaca_track_walkforward/tests/test_import_and_boundary_guards.py
+++ b/research/alpaca_track_walkforward/tests/test_import_and_boundary_guards.py
@@ -205,6 +205,7 @@ def test_all_h4_source_modules_are_accounted_for():
         "fold_schedule.py",
         "oos_mask.py",
         "pnl_views.py",
+        "provider_evidence.py",
         "runner.py",
         "trade_ledger.py",
         "wf_seal_consumption.py",

--- a/research/alpaca_track_walkforward/tests/test_import_and_boundary_guards.py
+++ b/research/alpaca_track_walkforward/tests/test_import_and_boundary_guards.py
@@ -1,0 +1,215 @@
+"""ROB-1062 H4 (AC26, AC31) — structural guards over the whole
+``research/alpaca_track_walkforward/`` surface (recursive, excluding
+``tests/``): no app/DB/broker/scheduler/random/time/alpaca import, no
+wall-clock call, no broker mutation/scheduler token referenced lexically.
+
+Closes a gap H1/H2/H3 all carried forward (their own closing reports flag
+it explicitly, most recently H3's: "AST 가드가 importlib/__import__/os.times
+3종 회피를 놓친다") in THIS package's own tree — H1/H2/H3 cannot be modified
+(out of scope), so this is the one place that gap can actually be closed for
+new code.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_EXCLUDED_DIR_NAMES = {"tests", "__pycache__"}
+
+
+def _iter_source_modules(root: Path) -> list[Path]:
+    out = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(root)
+        if any(part in _EXCLUDED_DIR_NAMES for part in rel.parts[:-1]):
+            continue
+        if rel.name == "conftest.py":
+            continue
+        out.append(path)
+    return out
+
+
+_MODULES = [str(p.relative_to(_ROOT)) for p in _iter_source_modules(_ROOT)]
+
+_FORBIDDEN_IMPORT_ROOTS = {
+    "app",
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "psycopg2",
+    "alembic",
+    "redis",
+    "taskiq",
+    "celery",
+    "prefect",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib3",
+    "urllib",
+    "socket",
+    "websockets",
+    "boto3",
+    "fastapi",
+    "uvicorn",
+    "random",
+    "time",
+    "alpaca",
+    "alpaca_trade_api",
+    # ROB-1062's own gap-closure: H1/H2/H3's guards only ban `import time` /
+    # `import random` by root name -- `importlib.import_module("time")`,
+    # `__import__("time")`, and `os.times()` (a real stdlib wall-clock-
+    # adjacent call, easily confused with the banned `time` module by a
+    # naive substring scan) all slipped past every prior phase's guard.
+    "importlib",
+}
+
+_FORBIDDEN_NOW_ATTRS = {"now", "utcnow", "today"}
+_FORBIDDEN_OS_ATTRS = {
+    "times"
+}  # os.times() -- wall-clock-adjacent, HR-1062 gap closure
+_FORBIDDEN_TOKENS = (
+    "submit_order",
+    "place_order",
+    "cancel_order",
+    "TaskiqScheduler",
+    "@broker.task",
+    "prefect.flow",
+    "__import__",
+)
+
+
+def _imports(tree: ast.AST):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def _forbidden_import_violations(mod: str, tree: ast.AST) -> list[tuple[str, str]]:
+    violations = []
+    for name in _imports(tree):
+        root = name.split(".")[0]
+        if root in _FORBIDDEN_IMPORT_ROOTS:
+            violations.append((mod, name))
+    return violations
+
+
+def _wall_clock_hit(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr in _FORBIDDEN_NOW_ATTRS:
+                return True
+    return False
+
+
+def _os_times_hit(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr in _FORBIDDEN_OS_ATTRS
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "os"
+            ):
+                return True
+    return False
+
+
+def _forbidden_token_violations(mod: str, text: str) -> list[tuple[str, str]]:
+    violations = []
+    for token in _FORBIDDEN_TOKENS:
+        if token in text:
+            violations.append((mod, token))
+    return violations
+
+
+def test_no_forbidden_imports_anywhere_in_h4():
+    violations = []
+    for mod in _MODULES:
+        tree = ast.parse((_ROOT / mod).read_text())
+        violations.extend(_forbidden_import_violations(mod, tree))
+    assert violations == [], f"forbidden imports found: {violations}"
+
+
+def test_no_wall_clock_now_calls_anywhere_in_h4():
+    for mod in _MODULES:
+        tree = ast.parse((_ROOT / mod).read_text())
+        assert not _wall_clock_hit(tree), (
+            f"{mod}: forbidden wall-clock .now()-style call"
+        )
+
+
+def test_no_os_times_call_anywhere_in_h4():
+    for mod in _MODULES:
+        tree = ast.parse((_ROOT / mod).read_text())
+        assert not _os_times_hit(tree), f"{mod}: forbidden os.times() call"
+
+
+def test_no_broker_order_fill_or_scheduler_symbols_referenced():
+    violations = []
+    for mod in _MODULES:
+        text = (_ROOT / mod).read_text()
+        violations.extend(_forbidden_token_violations(mod, text))
+    assert violations == [], (
+        f"forbidden broker/scheduler/dunder-import tokens: {violations}"
+    )
+
+
+def test_forbidden_import_scanner_actually_catches_a_synthetic_violation(tmp_path):
+    (tmp_path / "bad.py").write_text("import sqlalchemy\n")
+    tree = ast.parse((tmp_path / "bad.py").read_text())
+    assert _forbidden_import_violations("bad.py", tree) == [("bad.py", "sqlalchemy")]
+
+
+def test_forbidden_import_scanner_catches_importlib_the_h1_h3_gap():
+    text = "import importlib\nimportlib.import_module('time')\n"
+    tree = ast.parse(text)
+    assert _forbidden_import_violations("bad.py", tree) == [("bad.py", "importlib")]
+
+
+def test_wall_clock_scanner_catches_a_synthetic_violation():
+    tree = ast.parse("import datetime\ndatetime.datetime.now()\n")
+    assert _wall_clock_hit(tree) is True
+
+
+def test_os_times_scanner_catches_a_synthetic_violation():
+    tree = ast.parse("import os\nos.times()\n")
+    assert _os_times_hit(tree) is True
+
+
+def test_os_times_scanner_does_not_false_positive_on_unrelated_dot_times():
+    tree = ast.parse("class X:\n    def times(self):\n        pass\nX().times()\n")
+    assert _os_times_hit(tree) is False
+
+
+def test_forbidden_token_scanner_catches_dunder_import():
+    text = "def f():\n    return __import__('time')\n"
+    assert _forbidden_token_violations("bad.py", text) == [("bad.py", "__import__")]
+
+
+def test_all_h4_source_modules_are_accounted_for():
+    """Drift guard: a new module added anywhere under
+    research/alpaca_track_walkforward/ must be added here."""
+    expected = {
+        "blind_counts.py",
+        "config_selection.py",
+        "context_binding.py",
+        "fill_model.py",
+        "fold_schedule.py",
+        "oos_mask.py",
+        "pnl_views.py",
+        "runner.py",
+        "trade_ledger.py",
+        "wf_seal_consumption.py",
+    }
+    discovered = {str(p.relative_to(_ROOT)) for p in _iter_source_modules(_ROOT)}
+    assert discovered == expected, (
+        f"module list drift: discovered {sorted(discovered)}, expected {sorted(expected)}"
+    )

--- a/research/alpaca_track_walkforward/tests/test_import_and_boundary_guards.py
+++ b/research/alpaca_track_walkforward/tests/test_import_and_boundary_guards.py
@@ -206,6 +206,7 @@ def test_all_h4_source_modules_are_accounted_for():
         "oos_mask.py",
         "pnl_views.py",
         "provider_evidence.py",
+        "run_manifest.py",
         "runner.py",
         "trade_ledger.py",
         "wf_seal_consumption.py",

--- a/research/alpaca_track_walkforward/tests/test_oos_mask.py
+++ b/research/alpaca_track_walkforward/tests/test_oos_mask.py
@@ -107,6 +107,77 @@ def test_below_sealed_minimum_cannot_issue_pass():
         om.issue_dry_count_pass(masked, counts)
 
 
+@pytest.mark.parametrize(
+    "counts",
+    [
+        # Verifier reproduction: five modeled entries plus one incomplete
+        # fill window must not become PASS.
+        bc.BlindCounts(
+            total_decision_records=5,
+            modeled_entries_count=5,
+            closed_trades_count=5,
+            open_positions_count=0,
+            entry_unfilled_count=0,
+            exit_unfilled_count=0,
+            fill_window_incomplete_count=1,
+            holding_days=(3, 3, 3, 3, 3),
+            reason_code_histogram={"ENTRY_ACCEPTED": 5},
+        ),
+        # Self-devised bypass 1: modeled entries with no scheduled records.
+        bc.BlindCounts(
+            total_decision_records=0,
+            modeled_entries_count=5,
+            closed_trades_count=5,
+            open_positions_count=0,
+            entry_unfilled_count=0,
+            exit_unfilled_count=0,
+            fill_window_incomplete_count=0,
+            holding_days=(3, 3, 3, 3, 3),
+            reason_code_histogram={},
+        ),
+        # Self-devised bypass 2: a non-empty but under-counted histogram.
+        bc.BlindCounts(
+            total_decision_records=5,
+            modeled_entries_count=5,
+            closed_trades_count=5,
+            open_positions_count=0,
+            entry_unfilled_count=0,
+            exit_unfilled_count=0,
+            fill_window_incomplete_count=0,
+            holding_days=(3, 3, 3, 3, 3),
+            reason_code_histogram={"ENTRY_ACCEPTED": 4},
+        ),
+        # Self-devised bypass 3: entries do not reconcile to closed + open.
+        bc.BlindCounts(
+            total_decision_records=5,
+            modeled_entries_count=5,
+            closed_trades_count=4,
+            open_positions_count=0,
+            entry_unfilled_count=0,
+            exit_unfilled_count=0,
+            fill_window_incomplete_count=0,
+            holding_days=(3, 3, 3, 3),
+            reason_code_histogram={"ENTRY_ACCEPTED": 5},
+        ),
+    ],
+)
+def test_any_structurally_incomplete_counts_cannot_issue_or_unmask(counts):
+    masked, actual_counts = _masked(counts=counts)
+    with pytest.raises(om.OOSMaskBypassError, match="incomplete"):
+        om.issue_dry_count_pass(masked, actual_counts)
+    forged = object.__new__(om.DryCountPassEvidence)
+    for name, value in (
+        ("_fold_id", "fold-0"),
+        ("_family", "AP-A1"),
+        ("_config_id", "AP-A1-00"),
+        ("_modeled_entries", 5),
+        ("_min_modeled_entries_per_fold", 5),
+    ):
+        object.__setattr__(forged, name, value)
+    with pytest.raises(om.OOSMaskBypassError, match="reconstructed"):
+        om.unmask(masked, forged)
+
+
 def test_reconstructed_evidence_object_is_not_authority():
     masked, counts = _masked()
     forged = object.__new__(om.DryCountPassEvidence)

--- a/research/alpaca_track_walkforward/tests/test_oos_mask.py
+++ b/research/alpaca_track_walkforward/tests/test_oos_mask.py
@@ -1,0 +1,250 @@
+"""ROB-1062 H4 (AC22-AC25) — the OOS PnL masking guarantee: every named
+bypass route in AC24 (direct field access, debug/repr output, pickle/JSON
+round-trip, exception-message leakage) is attempted here and proven blocked.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import pickle
+
+import oos_mask as om
+import pytest
+
+_SECRET_PNL_VALUE = -12345.6789  # an OOS PnL value that must never leak
+
+
+def _masked(**overrides):
+    kwargs = {"fold_id": "fold-0", "family": "AP-A1", "config_id": "AP-A1-00"}
+    kwargs.update(overrides)
+    return om.mask(_SECRET_PNL_VALUE, **kwargs)
+
+
+def _pass_evidence(**overrides):
+    kwargs = {
+        "fold_id": "fold-0",
+        "family": "AP-A1",
+        "config_id": "AP-A1-00",
+        "modeled_entries": 7,
+        "min_modeled_entries_per_fold": 5,
+        "passed": True,
+    }
+    kwargs.update(overrides)
+    return om.DryCountPassEvidence(**kwargs)
+
+
+# --------------------------------------------------------------------- #
+# The mask must be transparent when the evidence genuinely matches.
+# --------------------------------------------------------------------- #
+
+
+def test_unmask_with_matching_evidence_returns_the_raw_value():
+    masked = _masked()
+    evidence = _pass_evidence()
+    assert om.unmask(masked, evidence) == _SECRET_PNL_VALUE
+
+
+# --------------------------------------------------------------------- #
+# AC24 bypass route 1: direct field/attribute access.
+# --------------------------------------------------------------------- #
+
+
+def test_direct_attribute_access_to_the_closure_itself_never_yields_the_raw_value():
+    masked = _masked()
+    reveal = masked._reveal  # the closure itself, not the value
+    assert callable(reveal)
+    with pytest.raises(om.OOSMaskBypassError, match="direct access"):
+        reveal(None)
+    with pytest.raises(om.OOSMaskBypassError, match="direct access"):
+        reveal(object())  # a fresh, wrong sentinel object
+
+
+def test_object_getattribute_direct_bypass_of_any_override_still_fails():
+    """The most aggressive attribute-access bypass attempt: calling
+    object.__getattribute__ directly, which would defeat a
+    __getattribute__-override-based design outright."""
+    masked = _masked()
+    reveal = object.__getattribute__(masked, "_reveal")
+    with pytest.raises(om.OOSMaskBypassError):
+        reveal(object())
+
+
+def test_vars_and_dict_introspection_blocked_by_slots():
+    masked = _masked()
+    with pytest.raises(TypeError):
+        vars(masked)
+    assert not hasattr(masked, "__dict__")
+
+
+def test_setattr_and_delattr_are_blocked():
+    masked = _masked()
+    with pytest.raises(om.OOSMaskBypassError):
+        masked.new_attr = 1
+    with pytest.raises(om.OOSMaskBypassError):
+        del masked._fold_id
+
+
+# --------------------------------------------------------------------- #
+# AC24 bypass route 2: debug/repr/str output.
+# --------------------------------------------------------------------- #
+
+
+def test_repr_never_contains_the_raw_value():
+    masked = _masked()
+    text = repr(masked)
+    assert str(_SECRET_PNL_VALUE) not in text
+    assert "<masked>" in text
+
+
+def test_str_never_contains_the_raw_value():
+    masked = _masked()
+    text = str(masked)
+    assert str(_SECRET_PNL_VALUE) not in text
+
+
+def test_f_string_formatting_never_leaks_the_raw_value():
+    masked = _masked()
+    text = f"debug: {masked}"
+    assert str(_SECRET_PNL_VALUE) not in text
+
+
+# --------------------------------------------------------------------- #
+# AC24 bypass route 3: pickle / JSON round-trip / deepcopy.
+# --------------------------------------------------------------------- #
+
+
+def test_pickle_dumps_is_blocked():
+    masked = _masked()
+    with pytest.raises((om.OOSMaskBypassError, TypeError, pickle.PicklingError)):
+        pickle.dumps(masked)
+
+
+def test_deepcopy_is_blocked():
+    masked = _masked()
+    with pytest.raises((om.OOSMaskBypassError, TypeError)):
+        copy.deepcopy(masked)
+
+
+def test_json_dumps_cannot_serialize_a_masked_value():
+    masked = _masked()
+    with pytest.raises(TypeError):
+        json.dumps(masked)
+    # Even a caller-supplied default= hook that naively formats via str()
+    # must not leak the value (repr/str are already redacted above, but
+    # this proves the composition holds end-to-end through json.dumps).
+    text = json.dumps({"pnl": None}, default=lambda o: str(o))
+    assert str(_SECRET_PNL_VALUE) not in text
+
+
+# --------------------------------------------------------------------- #
+# AC24 bypass route 4: exception-message leakage.
+# --------------------------------------------------------------------- #
+
+
+def test_wrong_evidence_binding_error_message_never_contains_the_raw_value():
+    masked = _masked()
+    wrong_fold_evidence = _pass_evidence(fold_id="fold-1")
+    with pytest.raises(om.OOSMaskBypassError) as exc_info:
+        om.unmask(masked, wrong_fold_evidence)
+    assert str(_SECRET_PNL_VALUE) not in str(exc_info.value)
+
+
+def test_type_error_on_bad_evidence_type_never_contains_the_raw_value():
+    masked = _masked()
+    with pytest.raises(TypeError) as exc_info:
+        om.unmask(masked, "not evidence")
+    assert str(_SECRET_PNL_VALUE) not in str(exc_info.value)
+
+
+# --------------------------------------------------------------------- #
+# Binding: a PASS evidence for a DIFFERENT fold/family/config must never
+# unmask THIS value (no evidence reuse across scope).
+# --------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"fold_id": "fold-1"},
+        {"family": "AP-A2"},
+        {"config_id": "AP-A1-01"},
+    ],
+)
+def test_evidence_from_a_different_scope_cannot_unmask(override):
+    masked = _masked()
+    wrong_evidence = _pass_evidence(**override)
+    with pytest.raises(om.OOSMaskBypassError, match="does not match"):
+        om.unmask(masked, wrong_evidence)
+
+
+def test_unmask_rejects_non_masked_first_argument():
+    evidence = _pass_evidence()
+    with pytest.raises(TypeError, match="expected a Masked value"):
+        om.unmask(_SECRET_PNL_VALUE, evidence)
+
+
+# --------------------------------------------------------------------- #
+# Equality/hash cannot be used as an oracle.
+# --------------------------------------------------------------------- #
+
+
+def test_equality_comparison_is_blocked_not_a_silent_false():
+    masked_a = _masked()
+    masked_b = _masked()
+    with pytest.raises(om.OOSMaskBypassError):
+        _ = masked_a == masked_b
+
+
+def test_masked_is_unhashable():
+    masked = _masked()
+    with pytest.raises(TypeError):
+        hash(masked)
+
+
+# --------------------------------------------------------------------- #
+# DryCountPassEvidence itself can never represent a fail — closing off a
+# whole class of "construct a fake-looking pass to smuggle through" bug.
+# --------------------------------------------------------------------- #
+
+
+def test_dry_count_pass_evidence_cannot_be_constructed_as_a_fail():
+    with pytest.raises(ValueError, match="genuine PASS"):
+        om.DryCountPassEvidence(
+            fold_id="fold-0",
+            family="AP-A1",
+            config_id="AP-A1-00",
+            modeled_entries=2,
+            min_modeled_entries_per_fold=5,
+            passed=False,
+        )
+
+
+def test_dry_count_pass_evidence_rejects_entries_below_threshold_even_if_flagged_passed():
+    with pytest.raises(ValueError, match="below"):
+        om.DryCountPassEvidence(
+            fold_id="fold-0",
+            family="AP-A1",
+            config_id="AP-A1-00",
+            modeled_entries=2,
+            min_modeled_entries_per_fold=5,
+            passed=True,
+        )
+
+
+# --------------------------------------------------------------------- #
+# PnL-blind counts (AC25) are the exact OPPOSITE of masked: they must be
+# always-visible plain data, never wrapped. This test documents that
+# `mask`/`unmask` are the ONLY functions this module offers to wrap
+# anything — a caller cannot accidentally end up masking a blind count.
+# --------------------------------------------------------------------- #
+
+
+def test_module_public_api_is_exactly_mask_unmask_and_the_two_types():
+    assert set(om.__all__) == {
+        "DryCountPassEvidence",
+        "Masked",
+        "OOSMaskBypassError",
+        "mask",
+        "unmask",
+    }

--- a/research/alpaca_track_walkforward/tests/test_oos_mask.py
+++ b/research/alpaca_track_walkforward/tests/test_oos_mask.py
@@ -49,13 +49,53 @@ def _masked(
     )
 
 
-def _issued_pass(masked: om.Masked, counts: bc.BlindCounts) -> om.DryCountPassEvidence:
-    return om.issue_dry_count_pass(masked, counts)
+def _aggregate_pass(
+    *,
+    secret: object = _SECRET_PNL_VALUE,
+    target_counts: bc.BlindCounts | None = None,
+) -> tuple[om.Masked, bc.BlindCounts, om.DryCountPassEvidence]:
+    masked_by_fold: dict[str, tuple[om.Masked, ...]] = {}
+    counts_by_fold: dict[str, bc.BlindCounts] = {}
+    target_masked: om.Masked | None = None
+    target_actual_counts: bc.BlindCounts | None = None
+    for index in range(8):
+        fold_id = f"fold-{index}"
+        counts = (
+            target_counts if index == 0 and target_counts is not None else _counts()
+        )
+        masked, actual_counts = _masked(
+            secret=secret if index == 0 else 0.0,
+            counts=counts,
+            fold_id=fold_id,
+        )
+        masked_by_fold[fold_id] = (masked,)
+        counts_by_fold[fold_id] = actual_counts
+        if index == 0:
+            target_masked = masked
+            target_actual_counts = actual_counts
+    assert target_masked is not None
+    assert target_actual_counts is not None
+    evidence = om.issue_all_folds_dry_count_pass(
+        masked_by_fold=masked_by_fold,
+        dry_counts_by_fold=counts_by_fold,
+    )
+    return target_masked, target_actual_counts, evidence
+
+
+def _aggregate_inputs(
+    *,
+    counts_by_fold: dict[str, bc.BlindCounts] | None = None,
+) -> tuple[dict[str, tuple[om.Masked, ...]], dict[str, bc.BlindCounts]]:
+    actual_counts = counts_by_fold or {f"fold-{index}": _counts() for index in range(8)}
+    masked_by_fold = {
+        fold_id: (_masked(counts=actual_counts[fold_id], fold_id=fold_id)[0],)
+        for fold_id in (f"fold-{index}" for index in range(8))
+    }
+    return masked_by_fold, actual_counts
 
 
 def test_matching_real_dry_count_pass_unmasks_once():
-    masked, counts = _masked()
-    evidence = _issued_pass(masked, counts)
+    masked, _counts_value, evidence = _aggregate_pass()
     assert om.unmask(masked, evidence) == _SECRET_PNL_VALUE
     with pytest.raises(om.OOSMaskBypassError, match="already"):
         om.unmask(masked, evidence)
@@ -93,18 +133,35 @@ def test_private_token_import_bypass_no_longer_exists():
 
 
 def test_fake_counts_cannot_issue_pass_for_an_existing_mask():
-    masked, actual_counts = _masked()
-    fake_counts = _counts(modeled_entries=999)
-    assert fake_counts is not actual_counts
+    masked_by_fold, counts_by_fold = _aggregate_inputs()
+    fake_counts = dict(counts_by_fold)
+    fake_counts["fold-0"] = _counts(modeled_entries=999)
+    assert fake_counts["fold-0"] is not counts_by_fold["fold-0"]
     with pytest.raises(om.OOSMaskBypassError, match="actual object"):
-        om.issue_dry_count_pass(masked, fake_counts)
+        om.issue_all_folds_dry_count_pass(
+            masked_by_fold=masked_by_fold,
+            dry_counts_by_fold=fake_counts,
+        )
 
 
-def test_below_sealed_minimum_cannot_issue_pass():
-    counts = _counts(modeled_entries=4)
-    masked, counts = _masked(counts=counts)
-    with pytest.raises(om.OOSMaskBypassError, match="sealed minimum"):
+def test_verifier_reproduction_fold_local_pass_is_forbidden():
+    masked, counts = _masked()
+    with pytest.raises(om.OOSMaskBypassError, match="all 8 folds"):
         om.issue_dry_count_pass(masked, counts)
+
+
+def test_one_below_minimum_fold_blocks_every_fold_and_issues_no_pass():
+    counts_by_fold = {f"fold-{index}": _counts() for index in range(8)}
+    counts_by_fold["fold-1"] = _counts(modeled_entries=4)
+    masked_by_fold, counts_by_fold = _aggregate_inputs(counts_by_fold=counts_by_fold)
+    with pytest.raises(om.OOSMaskBypassError, match="fold-1.*sealed minimum"):
+        om.issue_all_folds_dry_count_pass(
+            masked_by_fold=masked_by_fold,
+            dry_counts_by_fold=counts_by_fold,
+        )
+    forged = object.__new__(om.DryCountPassEvidence)
+    with pytest.raises(om.OOSMaskBypassError, match="reconstructed"):
+        om.unmask(masked_by_fold["fold-0"][0], forged)
 
 
 @pytest.mark.parametrize(
@@ -162,30 +219,41 @@ def test_below_sealed_minimum_cannot_issue_pass():
     ],
 )
 def test_any_structurally_incomplete_counts_cannot_issue_or_unmask(counts):
-    masked, actual_counts = _masked(counts=counts)
-    with pytest.raises(om.OOSMaskBypassError, match="incomplete"):
-        om.issue_dry_count_pass(masked, actual_counts)
+    counts_by_fold = {f"fold-{index}": _counts() for index in range(8)}
+    counts_by_fold["fold-3"] = counts
+    masked_by_fold, counts_by_fold = _aggregate_inputs(counts_by_fold=counts_by_fold)
+    with pytest.raises(om.OOSMaskBypassError, match="fold-3.*incomplete"):
+        om.issue_all_folds_dry_count_pass(
+            masked_by_fold=masked_by_fold,
+            dry_counts_by_fold=counts_by_fold,
+        )
     forged = object.__new__(om.DryCountPassEvidence)
     for name, value in (
-        ("_fold_id", "fold-0"),
         ("_family", "AP-A1"),
         ("_config_id", "AP-A1-00"),
-        ("_modeled_entries", 5),
+        ("_fold_ids", tuple(f"fold-{index}" for index in range(8))),
+        (
+            "_modeled_entries_by_fold",
+            tuple((f"fold-{index}", 5) for index in range(8)),
+        ),
         ("_min_modeled_entries_per_fold", 5),
     ):
         object.__setattr__(forged, name, value)
     with pytest.raises(om.OOSMaskBypassError, match="reconstructed"):
-        om.unmask(masked, forged)
+        om.unmask(masked_by_fold["fold-0"][0], forged)
 
 
 def test_reconstructed_evidence_object_is_not_authority():
-    masked, counts = _masked()
+    masked, _counts_value = _masked()
     forged = object.__new__(om.DryCountPassEvidence)
     for name, value in (
-        ("_fold_id", "fold-0"),
         ("_family", "AP-A1"),
         ("_config_id", "AP-A1-00"),
-        ("_modeled_entries", 999),
+        ("_fold_ids", tuple(f"fold-{index}" for index in range(8))),
+        (
+            "_modeled_entries_by_fold",
+            tuple((f"fold-{index}", 999) for index in range(8)),
+        ),
         ("_min_modeled_entries_per_fold", 0),
     ):
         object.__setattr__(forged, name, value)
@@ -203,10 +271,14 @@ def test_reconstructed_mask_handle_is_not_in_the_issuance_registry():
 
 
 def test_object_setattr_tampering_fails_integrity_check():
-    masked, counts = _masked()
+    masked_by_fold, counts_by_fold = _aggregate_inputs()
+    masked = masked_by_fold["fold-0"][0]
     object.__setattr__(masked, "_config_id", "AP-A1-07")
     with pytest.raises(om.OOSMaskBypassError, match="integrity"):
-        om.issue_dry_count_pass(masked, counts)
+        om.issue_all_folds_dry_count_pass(
+            masked_by_fold=masked_by_fold,
+            dry_counts_by_fold=counts_by_fold,
+        )
 
 
 def test_masked_and_evidence_subclassing_is_blocked():
@@ -222,8 +294,7 @@ def test_masked_and_evidence_subclassing_is_blocked():
 
 
 def test_copy_reconstruction_pickle_and_deepcopy_are_blocked():
-    masked, counts = _masked()
-    evidence = _issued_pass(masked, counts)
+    masked, _counts_value, evidence = _aggregate_pass()
     for value in (masked, evidence):
         with pytest.raises((om.OOSMaskBypassError, TypeError, pickle.PicklingError)):
             copy.copy(value)
@@ -248,17 +319,15 @@ def test_nested_raw_values_are_not_object_referents_or_string_representations():
 def test_source_object_is_not_retained_in_the_caller_process_object_graph():
     secret = _SecretBox()
     secret_ref = weakref.ref(secret)
-    masked, counts = _masked(secret=secret)
+    masked, _counts_value, evidence = _aggregate_pass(secret=secret)
     del secret
     gc.collect()
     assert secret_ref() is None
-    evidence = _issued_pass(masked, counts)
     assert isinstance(om.unmask(masked, evidence), _SecretBox)
 
 
 def test_exception_messages_never_contain_raw_value():
-    masked, counts = _masked()
-    evidence = _issued_pass(masked, counts)
+    _masked_value, _counts_value, evidence = _aggregate_pass()
     other_masked, _other_counts = _masked(config_id="AP-A1-01")
     with pytest.raises(om.OOSMaskBypassError) as exc_info:
         om.unmask(other_masked, evidence)
@@ -279,6 +348,7 @@ def test_public_api_requires_issuance_not_public_evidence_construction():
         "DryCountPassEvidence",
         "Masked",
         "OOSMaskBypassError",
+        "issue_all_folds_dry_count_pass",
         "issue_dry_count_pass",
         "mask",
         "unmask",

--- a/research/alpaca_track_walkforward/tests/test_oos_mask.py
+++ b/research/alpaca_track_walkforward/tests/test_oos_mask.py
@@ -11,6 +11,7 @@ import weakref
 
 import blind_counts as bc
 import oos_mask as om
+import pnl_views as pv
 import pytest
 
 _SECRET_PNL_VALUE = -12345.6789
@@ -317,13 +318,26 @@ def test_nested_raw_values_are_not_object_referents_or_string_representations():
 
 
 def test_source_object_is_not_retained_in_the_caller_process_object_graph():
-    secret = _SecretBox()
+    secret = pv.ThreeViewPnL(
+        gross_bp=12.5,
+        actual_fill_bp=10.0,
+        shadow_net_bp_by_scenario={"C120": -110.0},
+    )
     secret_ref = weakref.ref(secret)
     masked, _counts_value, evidence = _aggregate_pass(secret=secret)
     del secret
     gc.collect()
     assert secret_ref() is None
-    assert isinstance(om.unmask(masked, evidence), _SecretBox)
+    assert om.unmask(masked, evidence) == pv.ThreeViewPnL(
+        gross_bp=12.5,
+        actual_fill_bp=10.0,
+        shadow_net_bp_by_scenario={"C120": -110.0},
+    )
+
+
+def test_typed_codec_rejects_arbitrary_python_objects():
+    with pytest.raises(om.OOSMaskBypassError, match="unsupported masked value type"):
+        _masked(secret=_SecretBox())
 
 
 def test_exception_messages_never_contain_raw_value():

--- a/research/alpaca_track_walkforward/tests/test_oos_mask.py
+++ b/research/alpaca_track_walkforward/tests/test_oos_mask.py
@@ -1,250 +1,214 @@
-"""ROB-1062 H4 (AC22-AC25) — the OOS PnL masking guarantee: every named
-bypass route in AC24 (direct field access, debug/repr output, pickle/JSON
-round-trip, exception-message leakage) is attempted here and proven blocked.
-"""
+"""Adversarial tests for the OOS PnL mask and dry-count authority."""
 
 from __future__ import annotations
 
 import copy
+import gc
+import inspect
 import json
 import pickle
+import weakref
 
+import blind_counts as bc
 import oos_mask as om
 import pytest
 
-_SECRET_PNL_VALUE = -12345.6789  # an OOS PnL value that must never leak
+_SECRET_PNL_VALUE = -12345.6789
 
 
-def _masked(**overrides):
+class _SecretBox:
+    pass
+
+
+def _counts(*, modeled_entries: int = 7) -> bc.BlindCounts:
+    return bc.BlindCounts(
+        total_decision_records=modeled_entries,
+        modeled_entries_count=modeled_entries,
+        closed_trades_count=modeled_entries,
+        open_positions_count=0,
+        entry_unfilled_count=0,
+        exit_unfilled_count=0,
+        fill_window_incomplete_count=0,
+        holding_days=tuple(3 for _ in range(modeled_entries)),
+        reason_code_histogram={"ENTRY_ACCEPTED": modeled_entries},
+    )
+
+
+def _masked(
+    *,
+    secret: object = _SECRET_PNL_VALUE,
+    counts: bc.BlindCounts | None = None,
+    **overrides: str,
+) -> tuple[om.Masked, bc.BlindCounts]:
+    actual_counts = counts or _counts()
     kwargs = {"fold_id": "fold-0", "family": "AP-A1", "config_id": "AP-A1-00"}
     kwargs.update(overrides)
-    return om.mask(_SECRET_PNL_VALUE, **kwargs)
+    return (
+        om.mask(secret, dry_counts=actual_counts, **kwargs),
+        actual_counts,
+    )
 
 
-def _pass_evidence(**overrides):
-    kwargs = {
-        "fold_id": "fold-0",
-        "family": "AP-A1",
-        "config_id": "AP-A1-00",
-        "modeled_entries": 7,
-        "min_modeled_entries_per_fold": 5,
-        "passed": True,
-    }
-    kwargs.update(overrides)
-    return om.DryCountPassEvidence(**kwargs)
+def _issued_pass(masked: om.Masked, counts: bc.BlindCounts) -> om.DryCountPassEvidence:
+    return om.issue_dry_count_pass(masked, counts)
 
 
-# --------------------------------------------------------------------- #
-# The mask must be transparent when the evidence genuinely matches.
-# --------------------------------------------------------------------- #
-
-
-def test_unmask_with_matching_evidence_returns_the_raw_value():
-    masked = _masked()
-    evidence = _pass_evidence()
+def test_matching_real_dry_count_pass_unmasks_once():
+    masked, counts = _masked()
+    evidence = _issued_pass(masked, counts)
     assert om.unmask(masked, evidence) == _SECRET_PNL_VALUE
+    with pytest.raises(om.OOSMaskBypassError, match="already"):
+        om.unmask(masked, evidence)
 
 
-# --------------------------------------------------------------------- #
-# AC24 bypass route 1: direct field/attribute access.
-# --------------------------------------------------------------------- #
+def test_report_reproduction_closure_and_inspect_paths_have_no_raw_value():
+    masked, _counts_value = _masked()
+    with pytest.raises(AttributeError):
+        object.__getattribute__(masked, "_reveal")
+    closure_vars = inspect.getclosurevars(om.mask)
+    assert "raw_value" not in closure_vars.nonlocals
+    assert "raw_value" not in closure_vars.globals
+    assert all(value is not _SECRET_PNL_VALUE for value in gc.get_referents(masked))
 
 
-def test_direct_attribute_access_to_the_closure_itself_never_yields_the_raw_value():
-    masked = _masked()
-    reveal = masked._reveal  # the closure itself, not the value
-    assert callable(reveal)
-    with pytest.raises(om.OOSMaskBypassError, match="direct access"):
-        reveal(None)
-    with pytest.raises(om.OOSMaskBypassError, match="direct access"):
-        reveal(object())  # a fresh, wrong sentinel object
-
-
-def test_object_getattribute_direct_bypass_of_any_override_still_fails():
-    """The most aggressive attribute-access bypass attempt: calling
-    object.__getattribute__ directly, which would defeat a
-    __getattribute__-override-based design outright."""
-    masked = _masked()
-    reveal = object.__getattribute__(masked, "_reveal")
-    with pytest.raises(om.OOSMaskBypassError):
-        reveal(object())
-
-
-def test_vars_and_dict_introspection_blocked_by_slots():
-    masked = _masked()
-    with pytest.raises(TypeError):
-        vars(masked)
-    assert not hasattr(masked, "__dict__")
-
-
-def test_setattr_and_delattr_are_blocked():
-    masked = _masked()
-    with pytest.raises(om.OOSMaskBypassError):
-        masked.new_attr = 1
-    with pytest.raises(om.OOSMaskBypassError):
-        del masked._fold_id
-
-
-# --------------------------------------------------------------------- #
-# AC24 bypass route 2: debug/repr/str output.
-# --------------------------------------------------------------------- #
-
-
-def test_repr_never_contains_the_raw_value():
-    masked = _masked()
-    text = repr(masked)
-    assert str(_SECRET_PNL_VALUE) not in text
-    assert "<masked>" in text
-
-
-def test_str_never_contains_the_raw_value():
-    masked = _masked()
-    text = str(masked)
-    assert str(_SECRET_PNL_VALUE) not in text
-
-
-def test_f_string_formatting_never_leaks_the_raw_value():
-    masked = _masked()
-    text = f"debug: {masked}"
-    assert str(_SECRET_PNL_VALUE) not in text
-
-
-# --------------------------------------------------------------------- #
-# AC24 bypass route 3: pickle / JSON round-trip / deepcopy.
-# --------------------------------------------------------------------- #
-
-
-def test_pickle_dumps_is_blocked():
-    masked = _masked()
-    with pytest.raises((om.OOSMaskBypassError, TypeError, pickle.PicklingError)):
-        pickle.dumps(masked)
-
-
-def test_deepcopy_is_blocked():
-    masked = _masked()
-    with pytest.raises((om.OOSMaskBypassError, TypeError)):
-        copy.deepcopy(masked)
-
-
-def test_json_dumps_cannot_serialize_a_masked_value():
-    masked = _masked()
-    with pytest.raises(TypeError):
-        json.dumps(masked)
-    # Even a caller-supplied default= hook that naively formats via str()
-    # must not leak the value (repr/str are already redacted above, but
-    # this proves the composition holds end-to-end through json.dumps).
-    text = json.dumps({"pnl": None}, default=lambda o: str(o))
-    assert str(_SECRET_PNL_VALUE) not in text
-
-
-# --------------------------------------------------------------------- #
-# AC24 bypass route 4: exception-message leakage.
-# --------------------------------------------------------------------- #
-
-
-def test_wrong_evidence_binding_error_message_never_contains_the_raw_value():
-    masked = _masked()
-    wrong_fold_evidence = _pass_evidence(fold_id="fold-1")
-    with pytest.raises(om.OOSMaskBypassError) as exc_info:
-        om.unmask(masked, wrong_fold_evidence)
-    assert str(_SECRET_PNL_VALUE) not in str(exc_info.value)
-
-
-def test_type_error_on_bad_evidence_type_never_contains_the_raw_value():
-    masked = _masked()
-    with pytest.raises(TypeError) as exc_info:
-        om.unmask(masked, "not evidence")
-    assert str(_SECRET_PNL_VALUE) not in str(exc_info.value)
-
-
-# --------------------------------------------------------------------- #
-# Binding: a PASS evidence for a DIFFERENT fold/family/config must never
-# unmask THIS value (no evidence reuse across scope).
-# --------------------------------------------------------------------- #
-
-
-@pytest.mark.parametrize(
-    "override",
-    [
-        {"fold_id": "fold-1"},
-        {"family": "AP-A2"},
-        {"config_id": "AP-A1-01"},
-    ],
-)
-def test_evidence_from_a_different_scope_cannot_unmask(override):
-    masked = _masked()
-    wrong_evidence = _pass_evidence(**override)
-    with pytest.raises(om.OOSMaskBypassError, match="does not match"):
-        om.unmask(masked, wrong_evidence)
-
-
-def test_unmask_rejects_non_masked_first_argument():
-    evidence = _pass_evidence()
-    with pytest.raises(TypeError, match="expected a Masked value"):
-        om.unmask(_SECRET_PNL_VALUE, evidence)
-
-
-# --------------------------------------------------------------------- #
-# Equality/hash cannot be used as an oracle.
-# --------------------------------------------------------------------- #
-
-
-def test_equality_comparison_is_blocked_not_a_silent_false():
-    masked_a = _masked()
-    masked_b = _masked()
-    with pytest.raises(om.OOSMaskBypassError):
-        _ = masked_a == masked_b
-
-
-def test_masked_is_unhashable():
-    masked = _masked()
-    with pytest.raises(TypeError):
-        hash(masked)
-
-
-# --------------------------------------------------------------------- #
-# DryCountPassEvidence itself can never represent a fail — closing off a
-# whole class of "construct a fake-looking pass to smuggle through" bug.
-# --------------------------------------------------------------------- #
-
-
-def test_dry_count_pass_evidence_cannot_be_constructed_as_a_fail():
-    with pytest.raises(ValueError, match="genuine PASS"):
+def test_report_reproduction_external_pass_constructor_is_blocked():
+    masked, _counts_value = _masked()
+    with pytest.raises(om.OOSMaskBypassError, match="cannot be constructed"):
         om.DryCountPassEvidence(
             fold_id="fold-0",
             family="AP-A1",
             config_id="AP-A1-00",
-            modeled_entries=2,
-            min_modeled_entries_per_fold=5,
-            passed=False,
-        )
-
-
-def test_dry_count_pass_evidence_rejects_entries_below_threshold_even_if_flagged_passed():
-    with pytest.raises(ValueError, match="below"):
-        om.DryCountPassEvidence(
-            fold_id="fold-0",
-            family="AP-A1",
-            config_id="AP-A1-00",
-            modeled_entries=2,
-            min_modeled_entries_per_fold=5,
+            modeled_entries=0,
+            min_modeled_entries_per_fold=0,
             passed=True,
         )
+    with pytest.raises(TypeError):
+        om.unmask(masked, object())
 
 
-# --------------------------------------------------------------------- #
-# PnL-blind counts (AC25) are the exact OPPOSITE of masked: they must be
-# always-visible plain data, never wrapped. This test documents that
-# `mask`/`unmask` are the ONLY functions this module offers to wrap
-# anything — a caller cannot accidentally end up masking a blind count.
-# --------------------------------------------------------------------- #
+def test_private_token_import_bypass_no_longer_exists():
+    assert not hasattr(om, "_AUTHORIZED_UNMASK_TOKEN")
+    masked, _counts_value = _masked()
+    assert not hasattr(masked, "_reveal")
 
 
-def test_module_public_api_is_exactly_mask_unmask_and_the_two_types():
+def test_fake_counts_cannot_issue_pass_for_an_existing_mask():
+    masked, actual_counts = _masked()
+    fake_counts = _counts(modeled_entries=999)
+    assert fake_counts is not actual_counts
+    with pytest.raises(om.OOSMaskBypassError, match="actual object"):
+        om.issue_dry_count_pass(masked, fake_counts)
+
+
+def test_below_sealed_minimum_cannot_issue_pass():
+    counts = _counts(modeled_entries=4)
+    masked, counts = _masked(counts=counts)
+    with pytest.raises(om.OOSMaskBypassError, match="sealed minimum"):
+        om.issue_dry_count_pass(masked, counts)
+
+
+def test_reconstructed_evidence_object_is_not_authority():
+    masked, counts = _masked()
+    forged = object.__new__(om.DryCountPassEvidence)
+    for name, value in (
+        ("_fold_id", "fold-0"),
+        ("_family", "AP-A1"),
+        ("_config_id", "AP-A1-00"),
+        ("_modeled_entries", 999),
+        ("_min_modeled_entries_per_fold", 0),
+    ):
+        object.__setattr__(forged, name, value)
+    with pytest.raises(om.OOSMaskBypassError, match="reconstructed"):
+        om.unmask(masked, forged)
+
+
+def test_reconstructed_mask_handle_is_not_in_the_issuance_registry():
+    forged = object.__new__(om.Masked)
+    object.__setattr__(forged, "_fold_id", "fold-0")
+    object.__setattr__(forged, "_family", "AP-A1")
+    object.__setattr__(forged, "_config_id", "AP-A1-00")
+    with pytest.raises(om.OOSMaskBypassError, match="reconstructed"):
+        om.issue_dry_count_pass(forged, _counts())
+
+
+def test_object_setattr_tampering_fails_integrity_check():
+    masked, counts = _masked()
+    object.__setattr__(masked, "_config_id", "AP-A1-07")
+    with pytest.raises(om.OOSMaskBypassError, match="integrity"):
+        om.issue_dry_count_pass(masked, counts)
+
+
+def test_masked_and_evidence_subclassing_is_blocked():
+    with pytest.raises(TypeError, match="cannot be subclassed"):
+
+        class EvilMasked(om.Masked):
+            pass
+
+    with pytest.raises(TypeError, match="cannot be subclassed"):
+
+        class EvilEvidence(om.DryCountPassEvidence):
+            pass
+
+
+def test_copy_reconstruction_pickle_and_deepcopy_are_blocked():
+    masked, counts = _masked()
+    evidence = _issued_pass(masked, counts)
+    for value in (masked, evidence):
+        with pytest.raises((om.OOSMaskBypassError, TypeError, pickle.PicklingError)):
+            copy.copy(value)
+        with pytest.raises((om.OOSMaskBypassError, TypeError, pickle.PicklingError)):
+            copy.deepcopy(value)
+        with pytest.raises((om.OOSMaskBypassError, TypeError, pickle.PicklingError)):
+            pickle.dumps(value)
+
+
+def test_nested_raw_values_are_not_object_referents_or_string_representations():
+    secret = {"outer": [{"pnl": _SECRET_PNL_VALUE}], "other": ("x", 3)}
+    masked, _counts_value = _masked(secret=secret)
+    assert secret not in gc.get_referents(masked)
+    assert str(_SECRET_PNL_VALUE) not in repr(masked)
+    assert str(_SECRET_PNL_VALUE) not in str(masked)
+    with pytest.raises(TypeError):
+        json.dumps(masked)
+    redacted_json = json.dumps({"pnl": masked}, default=str)
+    assert str(_SECRET_PNL_VALUE) not in redacted_json
+
+
+def test_source_object_is_not_retained_in_the_caller_process_object_graph():
+    secret = _SecretBox()
+    secret_ref = weakref.ref(secret)
+    masked, counts = _masked(secret=secret)
+    del secret
+    gc.collect()
+    assert secret_ref() is None
+    evidence = _issued_pass(masked, counts)
+    assert isinstance(om.unmask(masked, evidence), _SecretBox)
+
+
+def test_exception_messages_never_contain_raw_value():
+    masked, counts = _masked()
+    evidence = _issued_pass(masked, counts)
+    other_masked, _other_counts = _masked(config_id="AP-A1-01")
+    with pytest.raises(om.OOSMaskBypassError) as exc_info:
+        om.unmask(other_masked, evidence)
+    assert str(_SECRET_PNL_VALUE) not in str(exc_info.value)
+
+
+def test_equality_and_hash_oracles_are_blocked():
+    masked_a, _counts_a = _masked()
+    masked_b, _counts_b = _masked()
+    with pytest.raises(om.OOSMaskBypassError):
+        _ = masked_a == masked_b
+    with pytest.raises(TypeError):
+        hash(masked_a)
+
+
+def test_public_api_requires_issuance_not_public_evidence_construction():
     assert set(om.__all__) == {
         "DryCountPassEvidence",
         "Masked",
         "OOSMaskBypassError",
+        "issue_dry_count_pass",
         "mask",
         "unmask",
     }

--- a/research/alpaca_track_walkforward/tests/test_pnl_views.py
+++ b/research/alpaca_track_walkforward/tests/test_pnl_views.py
@@ -1,0 +1,124 @@
+"""ROB-1062 H4 (AC17-AC21) — 3-view PnL independence and no-double-fee
+guarantees."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pnl_views as pv
+import pytest
+import wf_seal_consumption as sc
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _trade(*, entry_ref=100.0, entry_fill=100.5, exit_ref=110.0, exit_fill=109.45):
+    return pv.TradeFill(
+        entry_reference_close=entry_ref,
+        entry_fill_price=entry_fill,
+        exit_reference_close=exit_ref,
+        exit_fill_price=exit_fill,
+    )
+
+
+def test_gross_uses_reference_closes_only():
+    trade = _trade()
+    expected = (110.0 - 100.0) / 100.0 * 10_000.0
+    assert pv.gross_pnl_bp(trade) == pytest.approx(expected)
+
+
+def test_actual_fill_uses_modeled_fill_prices_only_and_differs_from_gross():
+    trade = _trade()
+    expected = (109.45 - 100.5) / 100.5 * 10_000.0
+    assert pv.actual_fill_pnl_bp(trade) == pytest.approx(expected)
+    assert pv.actual_fill_pnl_bp(trade) != pv.gross_pnl_bp(trade)
+
+
+def test_shadow_net_deducts_exactly_the_named_scenario_bp_once():
+    trade = _trade()
+    base = pv.actual_fill_pnl_bp(trade)
+    scenarios = {"C50": 50, "C100": 100, "C120": 120, "C150": 150}
+    for name, bp in scenarios.items():
+        assert pv.shadow_net_pnl_bp(
+            trade, scenario=name, cost_scenarios_bp=scenarios
+        ) == pytest.approx(base - bp)
+
+
+def test_shadow_net_rejects_unknown_scenario_name():
+    trade = _trade()
+    with pytest.raises(KeyError, match="unknown cost scenario"):
+        pv.shadow_net_pnl_bp(trade, scenario="C999", cost_scenarios_bp={"C50": 50})
+
+
+def test_scenarios_are_computed_independently_never_derived_from_each_other():
+    """AC17 — deliberately non-monotonic, unevenly-spaced fake scenario
+    table. Any implementation that derives one scenario from another
+    (interpolates, assumes even spacing, assumes ordering) fails this."""
+    trade = _trade()
+    fake_scenarios = {"C50": 7, "C100": 999, "C120": 3, "C150": 12_345}
+    base = pv.actual_fill_pnl_bp(trade)
+    result = pv.three_view_pnl_bp(trade, cost_scenarios_bp=fake_scenarios)
+    for name, bp in fake_scenarios.items():
+        assert result.shadow_net_bp_by_scenario[name] == pytest.approx(base - bp)
+
+
+def test_mutating_one_scenario_bp_moves_only_that_scenarios_output():
+    trade = _trade()
+    scenarios = {"C50": 50, "C100": 100, "C120": 120, "C150": 150}
+    before = pv.three_view_pnl_bp(trade, cost_scenarios_bp=scenarios)
+    mutated = dict(scenarios)
+    mutated["C120"] = 121  # bump only C120
+    after = pv.three_view_pnl_bp(trade, cost_scenarios_bp=mutated)
+    assert (
+        after.shadow_net_bp_by_scenario["C120"]
+        != before.shadow_net_bp_by_scenario["C120"]
+    )
+    for name in ("C50", "C100", "C150"):
+        assert (
+            after.shadow_net_bp_by_scenario[name]
+            == before.shadow_net_bp_by_scenario[name]
+        )
+
+
+def test_three_view_pnl_using_the_real_sealed_scenarios_matches_seal():
+    trade = _trade()
+    real_scenarios = sc.cost_scenarios_bp()
+    result = pv.three_view_pnl_bp(trade, cost_scenarios_bp=real_scenarios)
+    base = pv.actual_fill_pnl_bp(trade)
+    assert result.shadow_net_bp_by_scenario["C120"] == pytest.approx(base - 120)
+    assert result.gross_bp == pytest.approx(pv.gross_pnl_bp(trade))
+
+
+def test_trade_fill_rejects_non_positive_prices():
+    with pytest.raises(ValueError, match="must be positive"):
+        pv.TradeFill(
+            entry_reference_close=0.0,
+            entry_fill_price=1.0,
+            exit_reference_close=1.0,
+            exit_fill_price=1.0,
+        )
+
+
+def test_module_never_imports_or_references_a_separate_paper_fee_bp_deduction():
+    """AC19 (fee applied exactly once) enforced structurally: this module
+    must never import wf_seal_consumption.paper_fee_bp — the cost scenario
+    bp values already include the fee once; a second deduction would double
+    -charge it."""
+    text = (_ROOT / "pnl_views.py").read_text()
+    tree = ast.parse(text)
+    # Scan only executable code (calls/attribute access), not prose in
+    # docstrings — the module docstring legitimately DISCUSSES why no
+    # `paper_fee_bp` deduction exists, which would otherwise self-trip a
+    # naive substring scan of the raw file text.
+    referenced_names = {
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+    } | {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+    assert "paper_fee_bp" not in referenced_names
+    imported_names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_names.update(n.name for n in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported_names.add(node.module or "")
+    assert "wf_seal_consumption" not in imported_names

--- a/research/alpaca_track_walkforward/tests/test_run_manifest.py
+++ b/research/alpaca_track_walkforward/tests/test_run_manifest.py
@@ -1,0 +1,77 @@
+"""Canonical run-manifest authority and synthetic input identity regressions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import fold_schedule as fs
+import pytest
+import run_manifest as rm
+import runner
+import synthetic_fixture as sfx
+
+_ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
+_FOLD = fs.build_fold_schedule(_ANCHOR_MS)[0]
+_NUM_DAYS = (_FOLD.oos_end_ms - _FOLD.train_start_ms) // rm.DAY_MS
+
+
+def test_manifest_is_singleton_code_authority_not_caller_constructible():
+    manifest = rm.canonical_run_manifest()
+    assert manifest is rm.canonical_run_manifest()
+    assert manifest.anchor_oos_start_ms == _ANCHOR_MS
+    assert manifest.source_kind == "synthetic_fixture"
+    assert len(manifest.manifest_hash) == 64
+    with pytest.raises(TypeError, match="issued only"):
+        rm.CanonicalRunManifest(
+            run_id=manifest.run_id,
+            source_kind=manifest.source_kind,
+            anchor_oos_start_ms=manifest.anchor_oos_start_ms,
+            symbols=manifest.symbols,
+            daily_bars_hash_by_fold=manifest.daily_bars_hash_by_fold,
+            universe_grid_hash_by_fold_family=(
+                manifest.universe_grid_hash_by_fold_family
+            ),
+            minute_grid_hash_by_fold_family=manifest.minute_grid_hash_by_fold_family,
+            manifest_hash=manifest.manifest_hash,
+            _construction_token=object(),
+        )
+    with pytest.raises(TypeError):
+        manifest.daily_bars_hash_by_fold["fold-0"] = "0" * 64
+
+
+@pytest.mark.parametrize("family", ["AP-A1", "AP-A2"])
+def test_fold0_fixture_recomputes_exact_pinned_input_lineage(family):
+    manifest = rm.canonical_run_manifest()
+    bars = sfx.build_bars_by_symbol(
+        window_start_ms=_FOLD.train_start_ms,
+        num_days=_NUM_DAYS,
+        n_symbols=20,
+    )
+    universe_provider = sfx.make_universe_snapshot_provider(20)
+    minute_provider = sfx.make_minute_bars_provider(
+        window_start_ms=_FOLD.train_start_ms,
+        n_symbols=20,
+    )
+    timestamps = runner._all_decision_timestamps(family=family, fold=_FOLD)
+    universe_grid = {
+        timestamp: universe_provider(timestamp).snapshot for timestamp in timestamps
+    }
+    minute_grid = {
+        (symbol, timestamp): minute_provider(symbol, timestamp).bars
+        for timestamp in timestamps
+        for symbol in manifest.symbols
+    }
+    key = f"fold-0:{family}"
+
+    assert (
+        rm.canonical_daily_bars_hash(bars)
+        == (manifest.daily_bars_hash_by_fold["fold-0"])
+    )
+    assert (
+        rm.canonical_universe_grid_hash(universe_grid)
+        == (manifest.universe_grid_hash_by_fold_family[key])
+    )
+    assert (
+        rm.canonical_minute_grid_hash(minute_grid)
+        == (manifest.minute_grid_hash_by_fold_family[key])
+    )

--- a/research/alpaca_track_walkforward/tests/test_runner.py
+++ b/research/alpaca_track_walkforward/tests/test_runner.py
@@ -14,12 +14,14 @@ module's own development surfaced (see
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
 
 import fill_model as fm
 import fold_schedule as fs
 import oos_mask as om
+import provider_evidence as pe
 import pytest
 import runner
 import synthetic_fixture as sfx
@@ -99,9 +101,13 @@ def test_future_universe_snapshot_is_rejected_fail_closed(
 
     def future_provider(decision_ts_ms):
         current = universe_provider_20(decision_ts_ms)
-        return replace(
-            current,
+        future_snapshot = replace(
+            current.snapshot,
             decision_ts_ms=decision_ts_ms + 999 * 86_400_000,
+        )
+        return pe.bind_universe_snapshot(
+            future_snapshot,
+            source_as_of_ts_ms=decision_ts_ms + 999 * 86_400_000,
         )
 
     with pytest.raises(runner.ProviderTimeBindingError, match="does not equal"):
@@ -112,6 +118,98 @@ def test_future_universe_snapshot_is_rejected_fail_closed(
             bars_by_symbol=bars_20,
             universe_snapshot_provider=future_provider,
             minute_bars_provider=minute_provider_20,
+        )
+
+
+def test_future_universe_content_relabelled_to_current_timestamp_is_rejected(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    """Verifier reproduction: content keeps its source artifact as-of."""
+    import seal_consumption as h3_seal
+
+    config = next(
+        c
+        for c in h3_seal.load_sealed_configs_and_params().configs
+        if c.family == "AP-A1"
+    )
+
+    def relabelled_provider(decision_ts_ms):
+        future = universe_provider_20(decision_ts_ms + 28 * 86_400_000)
+        relabelled = replace(future.snapshot, decision_ts_ms=decision_ts_ms)
+        return pe.bind_universe_snapshot(
+            relabelled,
+            source_as_of_ts_ms=future.source_as_of_ts_ms,
+        )
+
+    with pytest.raises(runner.ProviderTimeBindingError, match="source as-of"):
+        runner._run_continuous_decisions(
+            config=config,
+            family="AP-A1",
+            fold=_FOLD,
+            bars_by_symbol=bars_20,
+            universe_snapshot_provider=relabelled_provider,
+            minute_bars_provider=minute_provider_20,
+        )
+
+
+def test_mutated_universe_content_is_rejected_by_source_artifact_hash(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    """A frozen envelope cannot be relabelled after its source hash is bound."""
+    import seal_consumption as h3_seal
+
+    config = next(
+        c
+        for c in h3_seal.load_sealed_configs_and_params().configs
+        if c.family == "AP-A1"
+    )
+
+    def tampered_provider(decision_ts_ms):
+        evidence = universe_provider_20(decision_ts_ms)
+        object.__setattr__(
+            evidence.snapshot,
+            "decision_ts_ms",
+            decision_ts_ms + 28 * 86_400_000,
+        )
+        return evidence
+
+    with pytest.raises(runner.ProviderTimeBindingError, match="hash mismatch"):
+        runner._run_continuous_decisions(
+            config=config,
+            family="AP-A1",
+            fold=_FOLD,
+            bars_by_symbol=bars_20,
+            universe_snapshot_provider=tampered_provider,
+            minute_bars_provider=minute_provider_20,
+        )
+
+
+def test_mutated_minute_evidence_hash_is_rejected_fail_closed(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    import seal_consumption as h3_seal
+
+    config = next(
+        c
+        for c in h3_seal.load_sealed_configs_and_params().configs
+        if c.family == "AP-A1"
+    )
+
+    def tampered_minute_provider(symbol, decision_ts_ms):
+        evidence = minute_provider_20(symbol, decision_ts_ms)
+        object.__setattr__(
+            evidence, "source_as_of_ts_ms", evidence.source_as_of_ts_ms + 60_000
+        )
+        return evidence
+
+    with pytest.raises(runner.ProviderTimeBindingError, match="hash mismatch"):
+        runner._run_continuous_decisions(
+            config=config,
+            family="AP-A1",
+            fold=_FOLD,
+            bars_by_symbol=bars_20,
+            universe_snapshot_provider=universe_provider_20,
+            minute_bars_provider=tampered_minute_provider,
         )
 
 
@@ -168,6 +266,10 @@ def _run_result_for_trade(trade: tl.Trade) -> runner._ContinuousRunResult:
         open_legs_by_symbol={},
         fill_attempts=(),
         modeled_entry_evidence=(trade.entry_evidence,),
+        provider_evidence_binding=pe.RunProviderEvidenceBinding(
+            universe_artifacts=(),
+            minute_artifacts=(),
+        ),
     )
 
 
@@ -186,12 +288,14 @@ def test_train_entry_oos_exit_counts_entry_cost_but_never_train_closed_or_e120()
         run_result=run_result,
         fold=_FOLD,
         cost_scenarios_bp=scenarios,
+        turnover_capacity_k=None,
     )
     oos, oos_trades = runner._build_phase_metrics(
         phase="OOS",
         run_result=run_result,
         fold=_FOLD,
         cost_scenarios_bp=scenarios,
+        turnover_capacity_k=None,
     )
 
     assert train.modeled_entries_count == 1
@@ -219,6 +323,7 @@ def test_oos_exit_price_mutation_cannot_move_train_e120_verifier_reproduction():
             run_result=_run_result_for_trade(trade),
             fold=_FOLD,
             cost_scenarios_bp=scenarios,
+            turnover_capacity_k=None,
         )
         observed.append(
             (
@@ -241,6 +346,7 @@ def test_complete_lifecycle_inside_train_is_included_in_closed_and_e120():
         run_result=_run_result_for_trade(trade),
         fold=_FOLD,
         cost_scenarios_bp=wf_seal.cost_scenarios_bp(),
+        turnover_capacity_k=None,
     )
     assert train.modeled_entries_count == 1
     assert train.closed_trades_count == 1
@@ -259,6 +365,7 @@ def test_entry_fill_exactly_at_train_end_is_outside_half_open_train():
         run_result=_run_result_for_trade(trade),
         fold=_FOLD,
         cost_scenarios_bp=wf_seal.cost_scenarios_bp(),
+        turnover_capacity_k=None,
     )
     assert train.modeled_entries_count == 0
     assert train.closed_trades_count == 0
@@ -293,7 +400,7 @@ def test_run_family_fold_ap_a2_full_8_configs_end_to_end(ap_a2_full_result):
         # PnL-blind counts are ALWAYS visible (AC25) -- plain ints/dicts,
         # never wrapped.
         assert isinstance(cr.oos_blind_counts.modeled_entries_count, int)
-        assert isinstance(cr.oos_blind_counts.reason_code_histogram, dict)
+        assert isinstance(cr.oos_blind_counts.reason_code_histogram, Mapping)
         # OOS PnL is masked by default (AC22) -- every entry is a real
         # Masked instance bound to this exact fold/family/config, and
         # cannot be read without evidence.
@@ -315,6 +422,35 @@ def test_run_family_fold_ap_a2_full_8_configs_end_to_end(ap_a2_full_result):
         # float or None, never masked.
         assert cr.train_metrics.median_trade_e120_bp is None or isinstance(
             cr.train_metrics.median_trade_e120_bp, float
+        )
+        assert len(cr.provider_evidence_binding.universe_artifacts) > 0
+        assert len(cr.provider_evidence_binding.combined_hash) == 64
+
+
+@pytest.mark.slow
+def test_ap_a2_turnover_is_entries_over_weekly_evaluations_times_k(
+    ap_a2_full_result,
+):
+    """Run A §7/§12.6 p-unit, not entries/all-symbol decision records."""
+    import seal_consumption as h3_seal
+
+    configs = {
+        config.config_id: config
+        for config in h3_seal.load_sealed_configs_and_params().configs
+        if config.family == "AP-A2"
+    }
+    weekly_evaluations = len(
+        runner._decision_timestamps(
+            family="AP-A2",
+            window_start_ms=_FOLD.train_start_ms,
+            window_end_ms=_FOLD.train_end_ms,
+        )
+    )
+    assert weekly_evaluations == 52
+    for run in ap_a2_full_result.config_runs:
+        k = int(configs[run.config_id].params["k"])
+        assert run.train_metrics.turnover_p == (
+            run.train_metrics.modeled_entries_count / (weekly_evaluations * k)
         )
 
 

--- a/research/alpaca_track_walkforward/tests/test_runner.py
+++ b/research/alpaca_track_walkforward/tests/test_runner.py
@@ -14,13 +14,17 @@ module's own development surfaced (see
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 
+import fill_model as fm
 import fold_schedule as fs
 import oos_mask as om
 import pytest
 import runner
 import synthetic_fixture as sfx
+import trade_ledger as tl
+import wf_seal_consumption as wf_seal
 
 _ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
 _FOLD = fs.build_fold_schedule(_ANCHOR_MS)[0]
@@ -81,6 +85,186 @@ def test_unfilled_entry_never_produces_an_orphan_exit_ap_a1(
     assert len(unfilled_or_incomplete) > 0
 
 
+def test_future_universe_snapshot_is_rejected_fail_closed(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    """Verifier reproduction: a provider cannot return a future U_t."""
+    import seal_consumption as h3_seal
+
+    config = next(
+        c
+        for c in h3_seal.load_sealed_configs_and_params().configs
+        if c.family == "AP-A1"
+    )
+
+    def future_provider(decision_ts_ms):
+        current = universe_provider_20(decision_ts_ms)
+        return replace(
+            current,
+            decision_ts_ms=decision_ts_ms + 999 * 86_400_000,
+        )
+
+    with pytest.raises(runner.ProviderTimeBindingError, match="does not equal"):
+        runner._run_continuous_decisions(
+            config=config,
+            family="AP-A1",
+            fold=_FOLD,
+            bars_by_symbol=bars_20,
+            universe_snapshot_provider=future_provider,
+            minute_bars_provider=minute_provider_20,
+        )
+
+
+def test_runner_rejects_fold_id_not_bound_to_issued_fold(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    with pytest.raises(fs.FoldBindingError, match="does not match"):
+        runner.run_family_fold(
+            family="AP-A2",
+            fold_id="fold-99",
+            fold=_FOLD,
+            bars_by_symbol=bars_20,
+            universe_snapshot_provider=universe_provider_20,
+            minute_bars_provider=minute_provider_20,
+        )
+
+
+def _filled(price: float) -> fm.FillOutcome:
+    return fm.FillOutcome(
+        filled=True,
+        fill_price=price,
+        fill_bar_offset=1,
+        reason="FILLED",
+    )
+
+
+def _boundary_trade(
+    *,
+    entry_fill_ts_ms: int,
+    exit_fill_ts_ms: int,
+    exit_price: float,
+) -> tl.Trade:
+    entry_fill = _filled(100.0)
+    exit_fill = _filled(exit_price)
+    return tl.Trade(
+        symbol="BTC/USD",
+        config_id="AP-A1-00",
+        entry_decision_ts_ms=entry_fill_ts_ms - fm.MINUTE_MS,
+        entry_fill_ts_ms=entry_fill_ts_ms,
+        exit_decision_ts_ms=exit_fill_ts_ms - fm.MINUTE_MS,
+        exit_fill_ts_ms=exit_fill_ts_ms,
+        entry_reference_close=100.0,
+        exit_reference_close=exit_price,
+        filled_qty=0.625,
+        entry_fill=entry_fill,
+        exit_fill=exit_fill,
+    )
+
+
+def _run_result_for_trade(trade: tl.Trade) -> runner._ContinuousRunResult:
+    return runner._ContinuousRunResult(
+        all_records=(),
+        closed_trades=(trade,),
+        open_legs_by_symbol={},
+        fill_attempts=(),
+        modeled_entry_evidence=(trade.entry_evidence,),
+    )
+
+
+def test_train_entry_oos_exit_counts_entry_cost_but_never_train_closed_or_e120():
+    """Frozen event-time table rows 2/3 in one lifecycle."""
+    trade = _boundary_trade(
+        entry_fill_ts_ms=_FOLD.train_end_ms - 60_000,
+        exit_fill_ts_ms=_FOLD.oos_start_ms + 60_000,
+        exit_price=120.0,
+    )
+    run_result = _run_result_for_trade(trade)
+    scenarios = wf_seal.cost_scenarios_bp()
+
+    train, train_trades = runner._build_phase_metrics(
+        phase="TRAIN",
+        run_result=run_result,
+        fold=_FOLD,
+        cost_scenarios_bp=scenarios,
+    )
+    oos, oos_trades = runner._build_phase_metrics(
+        phase="OOS",
+        run_result=run_result,
+        fold=_FOLD,
+        cost_scenarios_bp=scenarios,
+    )
+
+    assert train.modeled_entries_count == 1
+    assert len(train.modeled_entry_evidence) == 1
+    assert train.closed_trades_count == 0
+    assert train.median_trade_e120_bp is None
+    assert train_trades == ()
+    assert oos.modeled_entries_count == 0
+    assert oos.closed_trades_count == 0
+    assert oos.median_trade_e120_bp is None
+    assert oos_trades == ()
+
+
+def test_oos_exit_price_mutation_cannot_move_train_e120_verifier_reproduction():
+    scenarios = wf_seal.cost_scenarios_bp()
+    observed = []
+    for exit_price in (120.0, 80.0):
+        trade = _boundary_trade(
+            entry_fill_ts_ms=_FOLD.train_end_ms - 60_000,
+            exit_fill_ts_ms=_FOLD.oos_start_ms + 60_000,
+            exit_price=exit_price,
+        )
+        train, _trades = runner._build_phase_metrics(
+            phase="TRAIN",
+            run_result=_run_result_for_trade(trade),
+            fold=_FOLD,
+            cost_scenarios_bp=scenarios,
+        )
+        observed.append(
+            (
+                train.closed_trades_count,
+                train.median_trade_e120_bp,
+                train.modeled_entries_count,
+            )
+        )
+    assert observed == [(0, None, 1), (0, None, 1)]
+
+
+def test_complete_lifecycle_inside_train_is_included_in_closed_and_e120():
+    trade = _boundary_trade(
+        entry_fill_ts_ms=_FOLD.train_end_ms - 2 * 86_400_000,
+        exit_fill_ts_ms=_FOLD.train_end_ms - 86_400_000,
+        exit_price=120.0,
+    )
+    train, train_trades = runner._build_phase_metrics(
+        phase="TRAIN",
+        run_result=_run_result_for_trade(trade),
+        fold=_FOLD,
+        cost_scenarios_bp=wf_seal.cost_scenarios_bp(),
+    )
+    assert train.modeled_entries_count == 1
+    assert train.closed_trades_count == 1
+    assert train.median_trade_e120_bp == pytest.approx(1880.0)
+    assert train_trades == (trade,)
+
+
+def test_entry_fill_exactly_at_train_end_is_outside_half_open_train():
+    trade = _boundary_trade(
+        entry_fill_ts_ms=_FOLD.train_end_ms,
+        exit_fill_ts_ms=_FOLD.oos_start_ms + 60_000,
+        exit_price=120.0,
+    )
+    train, train_trades = runner._build_phase_metrics(
+        phase="TRAIN",
+        run_result=_run_result_for_trade(trade),
+        fold=_FOLD,
+        cost_scenarios_bp=wf_seal.cost_scenarios_bp(),
+    )
+    assert train.modeled_entries_count == 0
+    assert train.closed_trades_count == 0
+    assert train_trades == ()
+
+
 @pytest.fixture(scope="module")
 def ap_a2_full_result(bars_20, universe_provider_20, minute_provider_20):
     # Expensive (~1 minute, all 8 configs) -- module-scoped so the two
@@ -118,17 +302,14 @@ def test_run_family_fold_ap_a2_full_8_configs_end_to_end(ap_a2_full_result):
             assert masked.fold_id == "fold-0"
             assert masked.family == "AP-A2"
             assert masked.config_id == cr.config_id
-            with pytest.raises(om.OOSMaskBypassError):
-                om.unmask(
-                    masked,
-                    om.DryCountPassEvidence(
-                        fold_id="WRONG-fold",
-                        family="AP-A2",
-                        config_id=cr.config_id,
-                        modeled_entries=999,
-                        min_modeled_entries_per_fold=5,
-                        passed=True,
-                    ),
+            with pytest.raises(om.OOSMaskBypassError, match="cannot be constructed"):
+                om.DryCountPassEvidence(
+                    fold_id="WRONG-fold",
+                    family="AP-A2",
+                    config_id=cr.config_id,
+                    modeled_entries=999,
+                    min_modeled_entries_per_fold=5,
+                    passed=True,
                 )
         # TRAIN PnL (median E120) IS directly readable (AC23) -- plain
         # float or None, never masked.

--- a/research/alpaca_track_walkforward/tests/test_runner.py
+++ b/research/alpaca_track_walkforward/tests/test_runner.py
@@ -23,6 +23,7 @@ import fold_schedule as fs
 import oos_mask as om
 import provider_evidence as pe
 import pytest
+import run_manifest as rm
 import runner
 import synthetic_fixture as sfx
 import trade_ledger as tl
@@ -152,6 +153,110 @@ def test_future_universe_content_relabelled_to_current_timestamp_is_rejected(
         )
 
 
+def test_changed_universe_content_self_signed_at_current_timestamp_is_rejected(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    """Verifier reproduction: caller-controlled labels and hashes are not authority."""
+    import seal_consumption as h3_seal
+
+    config = next(
+        c
+        for c in h3_seal.load_sealed_configs_and_params().configs
+        if c.family == "AP-A1"
+    )
+
+    def self_signed_changed_provider(decision_ts_ms):
+        current = universe_provider_20(decision_ts_ms)
+        first = current.snapshot.per_symbol[0]
+        changed_first = replace(
+            first,
+            eligible=False,
+            fail_reason="gap_in_last_60min",
+        )
+        changed = replace(
+            current.snapshot,
+            eligible_symbols=current.snapshot.eligible_symbols[1:],
+            per_symbol=(changed_first, *current.snapshot.per_symbol[1:]),
+            n_t=current.snapshot.n_t - 1,
+        )
+        # Both public labels are rewritten to "now", and the public binder
+        # happily hashes those caller-selected values. The immutable complete
+        # grid in run_manifest remains different and must reject the run.
+        return pe.bind_universe_snapshot(
+            changed,
+            source_as_of_ts_ms=decision_ts_ms,
+        )
+
+    with pytest.raises(rm.RunManifestError, match="universe grid hash"):
+        runner._run_continuous_decisions(
+            config=config,
+            family="AP-A1",
+            fold=_FOLD,
+            bars_by_symbol=bars_20,
+            universe_snapshot_provider=self_signed_changed_provider,
+            minute_bars_provider=minute_provider_20,
+        )
+
+
+def test_daily_feature_mutation_is_rejected_against_complete_corpus_identity(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    mutated = dict(bars_20)
+    symbol = sorted(mutated)[0]
+    bars = list(mutated[symbol])
+    bars[-1] = replace(bars[-1], volume=bars[-1].volume + 1.0)
+    mutated[symbol] = tuple(bars)
+
+    with pytest.raises(rm.RunManifestError, match="daily corpus hash"):
+        runner.run_family_fold(
+            family="AP-A2",
+            fold_id="fold-0",
+            fold=_FOLD,
+            bars_by_symbol=mutated,
+            universe_snapshot_provider=universe_provider_20,
+            minute_bars_provider=minute_provider_20,
+        )
+
+
+def test_oos_provider_state_cannot_rewrite_later_config_train_inputs(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    """Verifier reproduction: all provider inputs bind before any config runs."""
+
+    def changes_after_train_provider(decision_ts_ms):
+        current = universe_provider_20(decision_ts_ms)
+        if decision_ts_ms < _FOLD.oos_start_ms:
+            return current
+        first = current.snapshot.per_symbol[0]
+        changed = replace(
+            current.snapshot,
+            eligible_symbols=current.snapshot.eligible_symbols[1:],
+            per_symbol=(
+                replace(
+                    first,
+                    eligible=False,
+                    fail_reason="gap_in_last_60min",
+                ),
+                *current.snapshot.per_symbol[1:],
+            ),
+            n_t=current.snapshot.n_t - 1,
+        )
+        return pe.bind_universe_snapshot(
+            changed,
+            source_as_of_ts_ms=decision_ts_ms,
+        )
+
+    with pytest.raises(rm.RunManifestError, match="universe grid hash"):
+        runner.run_family_fold(
+            family="AP-A2",
+            fold_id="fold-0",
+            fold=_FOLD,
+            bars_by_symbol=bars_20,
+            universe_snapshot_provider=changes_after_train_provider,
+            minute_bars_provider=minute_provider_20,
+        )
+
+
 def test_mutated_universe_content_is_rejected_by_source_artifact_hash(
     bars_20, universe_provider_20, minute_provider_20
 ):
@@ -267,6 +372,10 @@ def _run_result_for_trade(trade: tl.Trade) -> runner._ContinuousRunResult:
         fill_attempts=(),
         modeled_entry_evidence=(trade.entry_evidence,),
         provider_evidence_binding=pe.RunProviderEvidenceBinding(
+            run_manifest_hash="0" * 64,
+            daily_bars_artifact_hash="1" * 64,
+            universe_grid_hash="2" * 64,
+            minute_grid_hash="3" * 64,
             universe_artifacts=(),
             minute_artifacts=(),
         ),
@@ -395,6 +504,7 @@ def test_run_family_fold_ap_a2_full_8_configs_end_to_end(ap_a2_full_result):
         f"AP-A2-{i:02d}" for i in range(8)
     }
     assert result.selection.status in ("SELECTED", "NO_SELECTED_CONFIG")
+    assert len({id(run.provider_evidence_binding) for run in result.config_runs}) == 1
 
     for cr in result.config_runs:
         # PnL-blind counts are ALWAYS visible (AC25) -- plain ints/dicts,

--- a/research/alpaca_track_walkforward/tests/test_runner.py
+++ b/research/alpaca_track_walkforward/tests/test_runner.py
@@ -1,0 +1,157 @@
+"""ROB-1062 H4 — runner integration tests against the synthetic fixture.
+
+Runtime note: H3's ``seal_consumption.assert_sealed_config`` rebuilds and
+re-hashes the ENTIRE H2 seal from disk on every single engine decision (by
+design — this is H3's own NO_THRESHOLD_RELAXATION enforcement point, not
+something H4 may cache around, since caching it here could mask a mutation
+that breaks that very check). AP-A1's daily cadence means 393 decisions per
+config across one fold; AP-A2's weekly cadence means ~56 — roughly 7x
+cheaper. The full-8-config tests below therefore use AP-A2. A dedicated,
+single-config AP-A1 slice covers the one AP-A1-specific regression this
+module's own development surfaced (see
+``test_unfilled_entry_never_produces_an_orphan_exit_ap_a1``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import fold_schedule as fs
+import oos_mask as om
+import pytest
+import runner
+import synthetic_fixture as sfx
+
+_ANCHOR_MS = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
+_FOLD = fs.build_fold_schedule(_ANCHOR_MS)[0]
+_NUM_DAYS = (_FOLD.oos_end_ms - _FOLD.train_start_ms) // 86_400_000
+
+
+@pytest.fixture(scope="module")
+def bars_20():
+    return sfx.build_bars_by_symbol(
+        window_start_ms=_FOLD.train_start_ms, num_days=_NUM_DAYS, n_symbols=20
+    )
+
+
+@pytest.fixture(scope="module")
+def universe_provider_20():
+    return sfx.make_universe_snapshot_provider(20)
+
+
+@pytest.fixture(scope="module")
+def minute_provider_20():
+    return sfx.make_minute_bars_provider(
+        window_start_ms=_FOLD.train_start_ms, n_symbols=20
+    )
+
+
+def test_unfilled_entry_never_produces_an_orphan_exit_ap_a1(
+    bars_20, universe_provider_20, minute_provider_20
+):
+    """Regression test for the real bug this module's own development
+    caught: without fill-aware state patching, H3's engine's naive
+    bookkeeping later emits an EXIT for a symbol whose ENTRY never actually
+    filled, which the trade ledger cannot pair (a crash, not a silent
+    wrong-answer). Running to completion without raising IS the proof."""
+    import seal_consumption as h3_seal
+
+    bundle = h3_seal.load_sealed_configs_and_params()
+    config = next(c for c in bundle.configs if c.family == "AP-A1")
+    result = runner._run_continuous_decisions(
+        config=config,
+        family="AP-A1",
+        fold=_FOLD,
+        bars_by_symbol=bars_20,
+        universe_snapshot_provider=universe_provider_20,
+        minute_bars_provider=minute_provider_20,
+    )
+    # Reaching here without a _RunnerInternalInvariantError IS the proof.
+    assert isinstance(result.all_records, tuple)
+    # This fixture's fill model DOES produce genuine unfilled attempts
+    # (sinusoidal day-over-day moves sometimes exceed the +-0.5% band) --
+    # confirm the scenario this regression test exists for actually occurs,
+    # not merely that nothing crashed on an empty no-op.
+    unfilled_or_incomplete = [
+        a
+        for a in result.fill_attempts
+        if a.outcome.reason
+        in ("ENTRY_UNFILLED", "EXIT_UNFILLED", "FILL_WINDOW_INCOMPLETE")
+    ]
+    assert len(unfilled_or_incomplete) > 0
+
+
+@pytest.fixture(scope="module")
+def ap_a2_full_result(bars_20, universe_provider_20, minute_provider_20):
+    # Expensive (~1 minute, all 8 configs) -- module-scoped so the two
+    # tests below share ONE computation instead of re-running it.
+    return runner.run_family_fold(
+        family="AP-A2",
+        fold_id="fold-0",
+        fold=_FOLD,
+        bars_by_symbol=bars_20,
+        universe_snapshot_provider=universe_provider_20,
+        minute_bars_provider=minute_provider_20,
+    )
+
+
+@pytest.mark.slow
+def test_run_family_fold_ap_a2_full_8_configs_end_to_end(ap_a2_full_result):
+    result = ap_a2_full_result
+    assert result.family == "AP-A2"
+    assert len(result.config_runs) == 8
+    assert {cr.config_id for cr in result.config_runs} == {
+        f"AP-A2-{i:02d}" for i in range(8)
+    }
+    assert result.selection.status in ("SELECTED", "NO_SELECTED_CONFIG")
+
+    for cr in result.config_runs:
+        # PnL-blind counts are ALWAYS visible (AC25) -- plain ints/dicts,
+        # never wrapped.
+        assert isinstance(cr.oos_blind_counts.modeled_entries_count, int)
+        assert isinstance(cr.oos_blind_counts.reason_code_histogram, dict)
+        # OOS PnL is masked by default (AC22) -- every entry is a real
+        # Masked instance bound to this exact fold/family/config, and
+        # cannot be read without evidence.
+        for masked in cr.oos_masked_pnl_by_trade:
+            assert isinstance(masked, om.Masked)
+            assert masked.fold_id == "fold-0"
+            assert masked.family == "AP-A2"
+            assert masked.config_id == cr.config_id
+            with pytest.raises(om.OOSMaskBypassError):
+                om.unmask(
+                    masked,
+                    om.DryCountPassEvidence(
+                        fold_id="WRONG-fold",
+                        family="AP-A2",
+                        config_id=cr.config_id,
+                        modeled_entries=999,
+                        min_modeled_entries_per_fold=5,
+                        passed=True,
+                    ),
+                )
+        # TRAIN PnL (median E120) IS directly readable (AC23) -- plain
+        # float or None, never masked.
+        assert cr.train_metrics.median_trade_e120_bp is None or isinstance(
+            cr.train_metrics.median_trade_e120_bp, float
+        )
+
+
+@pytest.mark.slow
+def test_selection_uses_only_train_metrics_never_oos(ap_a2_full_result):
+    """Structural proof mirroring AC8: selection is computed purely from
+    ConfigTrainMetrics built out of TRAIN-phase trades; the selected
+    config_id is one of the 8 real AP-A2 config ids or NO_SELECTED_CONFIG,
+    and the winning config (if any) is byte-traceable to a config whose
+    TRAIN metrics alone satisfy config_selection's rule."""
+    import config_selection as cs
+
+    result = ap_a2_full_result
+    if result.selection.status == "SELECTED":
+        winner = next(
+            cr
+            for cr in result.config_runs
+            if cr.config_id == result.selection.selected_config_id
+        )
+        assert winner.train_metrics.closed_trades_count >= cs.MIN_TRAIN_CLOSED_TRADES
+        assert winner.train_metrics.median_trade_e120_bp > 0.0

--- a/research/alpaca_track_walkforward/tests/test_trade_ledger.py
+++ b/research/alpaca_track_walkforward/tests/test_trade_ledger.py
@@ -29,7 +29,7 @@ def _rec(ts, action, reason, notional=0.0):
 def _bars(ts, *, open_price):
     return [
         SpotMinute(
-            open_time_ms=ts,
+            open_time_ms=ts + _MIN,
             open=open_price,
             high=open_price + 1,
             low=open_price / 2,
@@ -37,7 +37,7 @@ def _bars(ts, *, open_price):
             volume=1.0,
         ),
         SpotMinute(
-            open_time_ms=ts + _MIN,
+            open_time_ms=ts + 2 * _MIN,
             open=open_price,
             high=open_price + 1,
             low=open_price / 2,
@@ -69,6 +69,13 @@ def test_enter_then_exit_produces_one_closed_trade():
     trade = result.closed_trades[0]
     assert trade.both_legs_filled is True
     assert trade.holding_days == 3
+    assert trade.entry_fill_ts_ms == t_entry + _MIN
+    assert trade.exit_fill_ts_ms == t_exit + _MIN
+    assert trade.filled_qty == pytest.approx(62.5 / 100.0)
+    assert trade.entry_evidence.entry_fill_price == pytest.approx(100.2)
+    assert trade.entry_evidence.entry_filled_notional == pytest.approx(
+        (62.5 / 100.0) * 100.2
+    )
     assert result.open_position is None
 
 
@@ -85,6 +92,18 @@ def test_enter_with_no_exit_is_reported_as_open_not_closed():
     assert result.closed_trades == ()
     assert result.open_position is not None
     assert result.open_position.entry_decision_ts_ms == t_entry
+
+
+def test_modeled_entry_evidence_is_immutable():
+    t_entry = _T0
+    result = tl.build_trades_for_symbol_config(
+        [_rec(t_entry, "ENTER", "ENTRY_ACCEPTED", notional=62.5)],
+        reference_close_by_decision_ts={t_entry: 100.0},
+        minute_bars_by_decision_ts={t_entry: _bars(t_entry, open_price=100.2)},
+    )
+    evidence = result.open_position.entry_evidence
+    with pytest.raises(AttributeError):
+        evidence.filled_qty = 999.0
 
 
 def test_entry_unfilled_never_opens_a_position():

--- a/research/alpaca_track_walkforward/tests/test_trade_ledger.py
+++ b/research/alpaca_track_walkforward/tests/test_trade_ledger.py
@@ -1,0 +1,166 @@
+"""ROB-1062 H4 — trade_ledger: SignalRecord stream -> closed trades."""
+
+from __future__ import annotations
+
+import pytest
+import trade_ledger as tl
+from daily_bars import SpotMinute
+from output_schema import SignalRecord, evidence_hash
+
+_DAY_MS = 86_400_000
+_MIN = 60_000
+_RAW_T0 = 1_700_000_000_000
+_T0 = _RAW_T0 - (_RAW_T0 % _MIN)  # minute-aligned anchor
+
+
+def _rec(ts, action, reason, notional=0.0):
+    return SignalRecord(
+        decision_ts_ms=ts,
+        strategy="AP-A1",
+        config_id="AP-A1-00",
+        symbol="BTC/USD",
+        action=action,
+        target_notional=notional,
+        reason_code=reason,
+        evidence_hash=evidence_hash({"x": 1}),
+    )
+
+
+def _bars(ts, *, open_price):
+    return [
+        SpotMinute(
+            open_time_ms=ts,
+            open=open_price,
+            high=open_price + 1,
+            low=open_price / 2,
+            close=open_price,
+            volume=1.0,
+        ),
+        SpotMinute(
+            open_time_ms=ts + _MIN,
+            open=open_price,
+            high=open_price + 1,
+            low=open_price / 2,
+            close=open_price,
+            volume=1.0,
+        ),
+    ]
+
+
+def test_enter_then_exit_produces_one_closed_trade():
+    t_entry = _T0
+    t_exit = t_entry + 3 * _DAY_MS
+    records = [
+        _rec(t_entry, "ENTER", "ENTRY_ACCEPTED", notional=62.5),
+        _rec(t_entry + _DAY_MS, "HOLD", "TREND_INTACT_HOLD"),
+        _rec(t_exit, "EXIT", "EXIT_TRIGGERED"),
+    ]
+    ref_prices = {t_entry: 100.0, t_exit: 110.0}
+    minute_bars = {
+        t_entry: _bars(t_entry, open_price=100.2),
+        t_exit: _bars(t_exit, open_price=109.9),
+    }
+    result = tl.build_trades_for_symbol_config(
+        records,
+        reference_close_by_decision_ts=ref_prices,
+        minute_bars_by_decision_ts=minute_bars,
+    )
+    assert len(result.closed_trades) == 1
+    trade = result.closed_trades[0]
+    assert trade.both_legs_filled is True
+    assert trade.holding_days == 3
+    assert result.open_position is None
+
+
+def test_enter_with_no_exit_is_reported_as_open_not_closed():
+    t_entry = _T0
+    records = [_rec(t_entry, "ENTER", "ENTRY_ACCEPTED", notional=62.5)]
+    ref_prices = {t_entry: 100.0}
+    minute_bars = {t_entry: _bars(t_entry, open_price=100.0)}
+    result = tl.build_trades_for_symbol_config(
+        records,
+        reference_close_by_decision_ts=ref_prices,
+        minute_bars_by_decision_ts=minute_bars,
+    )
+    assert result.closed_trades == ()
+    assert result.open_position is not None
+    assert result.open_position.entry_decision_ts_ms == t_entry
+
+
+def test_entry_unfilled_never_opens_a_position():
+    t_entry = _T0
+    records = [_rec(t_entry, "ENTER", "ENTRY_ACCEPTED", notional=62.5)]
+    ref_prices = {t_entry: 100.0}
+    minute_bars = {t_entry: _bars(t_entry, open_price=999.0)}  # far above cap
+    result = tl.build_trades_for_symbol_config(
+        records,
+        reference_close_by_decision_ts=ref_prices,
+        minute_bars_by_decision_ts=minute_bars,
+    )
+    assert result.open_position is None
+    assert result.closed_trades == ()
+    assert result.entry_unfilled_count == 1
+
+
+def test_exit_unfilled_keeps_position_open():
+    t_entry = _T0
+    t_exit = t_entry + _DAY_MS
+    records = [
+        _rec(t_entry, "ENTER", "ENTRY_ACCEPTED", notional=62.5),
+        _rec(t_exit, "EXIT", "EXIT_TRIGGERED"),
+    ]
+    ref_prices = {t_entry: 100.0, t_exit: 100.0}
+    minute_bars = {
+        t_entry: _bars(t_entry, open_price=100.0),
+        t_exit: _bars(t_exit, open_price=1.0),  # far below floor -> unfilled
+    }
+    result = tl.build_trades_for_symbol_config(
+        records,
+        reference_close_by_decision_ts=ref_prices,
+        minute_bars_by_decision_ts=minute_bars,
+    )
+    assert result.closed_trades == ()
+    assert result.exit_unfilled_count == 1
+    assert result.open_position is not None
+
+
+def test_exit_with_no_open_leg_raises():
+    t_exit = _T0
+    records = [_rec(t_exit, "EXIT", "EXIT_TRIGGERED")]
+    with pytest.raises(ValueError, match="no matching open ENTER"):
+        tl.build_trades_for_symbol_config(
+            records,
+            reference_close_by_decision_ts={t_exit: 1.0},
+            minute_bars_by_decision_ts={},
+        )
+
+
+def test_records_must_share_one_symbol_and_config():
+    ts = 1_700_000_000_000
+    other = SignalRecord(
+        decision_ts_ms=ts + _DAY_MS,
+        strategy="AP-A1",
+        config_id="AP-A1-01",
+        symbol="ETH/USD",
+        action="NO_ACTION",
+        target_notional=0.0,
+        reason_code="NO_ENTRY_SIGNAL",
+        evidence_hash=evidence_hash({}),
+    )
+    records = [_rec(ts, "NO_ACTION", "NO_ENTRY_SIGNAL"), other]
+    with pytest.raises(ValueError, match="same \\(symbol, config_id\\)"):
+        tl.build_trades_for_symbol_config(
+            records, reference_close_by_decision_ts={}, minute_bars_by_decision_ts={}
+        )
+
+
+def test_records_must_be_strictly_increasing_by_decision_ts():
+    ts = 1_700_000_000_000
+    records = [
+        _rec(ts, "NO_ACTION", "NO_ENTRY_SIGNAL"),
+        _rec(ts, "NO_ACTION", "NO_ENTRY_SIGNAL"),
+    ]
+    with pytest.raises(ValueError, match="strictly increasing"):
+        tl.build_trades_for_symbol_config(
+            records, reference_close_by_decision_ts={}, minute_bars_by_decision_ts={}
+        )

--- a/research/alpaca_track_walkforward/tests/test_wf_seal_consumption.py
+++ b/research/alpaca_track_walkforward/tests/test_wf_seal_consumption.py
@@ -1,0 +1,69 @@
+"""ROB-1062 H4 — seal_consumption reads H2's seal, never re-declares it.
+
+The critical property under test: ``fold_schedule.py``'s module-level
+constants (``OOS_FOLDS``/``OOS_DAYS``/``TRAIN_DAYS``/``EMBARGO_DAYS``/
+``ROLL_DAYS``) are a SEPARATE, hardcoded copy for a documented reason (the
+schedule generator must have zero runtime H2 dependency — it is pure
+calendar arithmetic used inside the fill model's hot path). Because they are
+a copy, not a read, ``assert_policy_matches_schedule_constants`` exists
+SPECIFICALLY to catch the two copies drifting apart — this test proves that
+cross-check actually fires.
+"""
+
+from __future__ import annotations
+
+import fold_schedule as fs
+import pytest
+import wf_seal_consumption as sc
+
+
+def test_sealed_walk_forward_shape_matches_run_a_literal_values():
+    assert sc.oos_folds() == 8
+    assert sc.oos_days() == 28
+    assert sc.train_days() == 365
+    assert sc.embargo_days() == 7
+    assert sc.roll_days() == 28
+    assert sc.min_modeled_entries_per_fold() == 5
+
+
+def test_cost_scenarios_bp_are_exactly_the_sealed_four():
+    assert sc.cost_scenarios_bp() == {"C50": 50, "C100": 100, "C120": 120, "C150": 150}
+    assert sc.primary_cost_scenario() == "C120"
+    assert sc.upward_cost_scenario() == "C150"
+
+
+def test_ap_a2_turnover_band_matches_seal():
+    assert sc.ap_a2_turnover_band() == (0.2083, 0.2885)
+
+
+def test_stress_annual_cost_cap_pct_per_family():
+    assert sc.stress_annual_cost_cap_pct("AP-A1") == 6
+    assert sc.stress_annual_cost_cap_pct("AP-A2") == 18
+
+
+def test_stress_annual_cost_cap_pct_rejects_unknown_family():
+    with pytest.raises(ValueError, match="unknown family"):
+        sc.stress_annual_cost_cap_pct("AP-A3")
+
+
+def test_assert_policy_matches_schedule_constants_passes_for_the_real_constants():
+    sc.assert_policy_matches_schedule_constants(
+        oos_folds_const=fs.OOS_FOLDS,
+        oos_days_const=fs.OOS_DAYS,
+        train_days_const=fs.TRAIN_DAYS,
+        embargo_days_const=fs.EMBARGO_DAYS,
+        roll_days_const=fs.ROLL_DAYS,
+    )
+
+
+def test_assert_policy_matches_schedule_constants_fails_closed_on_drift():
+    """Proves the cross-check is a REAL guard, not vacuous: a fold_schedule
+    copy that silently drifted (e.g. embargo shortened 7->0) is caught."""
+    with pytest.raises(sc.SealDriftError, match="embargo_days"):
+        sc.assert_policy_matches_schedule_constants(
+            oos_folds_const=fs.OOS_FOLDS,
+            oos_days_const=fs.OOS_DAYS,
+            train_days_const=fs.TRAIN_DAYS,
+            embargo_days_const=0,
+            roll_days_const=fs.ROLL_DAYS,
+        )

--- a/research/alpaca_track_walkforward/trade_ledger.py
+++ b/research/alpaca_track_walkforward/trade_ledger.py
@@ -29,6 +29,7 @@ from output_schema import SignalRecord
 
 __all__ = [
     "FillAttempt",
+    "ModeledEntryEvidence",
     "OpenLeg",
     "Trade",
     "TradeLedgerResult",
@@ -55,6 +56,29 @@ class FillAttempt:
     outcome: fm.FillOutcome
 
 
+@dataclass(frozen=True, slots=True)
+class ModeledEntryEvidence:
+    """Immutable AC9 evidence for one actual all-or-none entry fill."""
+
+    symbol: str
+    config_id: str
+    entry_fill_ts_ms: int
+    filled_qty: float
+    entry_fill_price: float
+
+    def __post_init__(self) -> None:
+        if type(self.entry_fill_ts_ms) is not int:
+            raise TypeError("entry_fill_ts_ms must be built-in int")
+        for name in ("filled_qty", "entry_fill_price"):
+            value = getattr(self, name)
+            if type(value) is not float or value <= 0.0:
+                raise ValueError(f"{name} must be a positive built-in float")
+
+    @property
+    def entry_filled_notional(self) -> float:
+        return self.filled_qty * self.entry_fill_price
+
+
 @dataclass(frozen=True)
 class OpenLeg:
     """An ENTER with no matching EXIT yet inside the supplied record
@@ -63,8 +87,21 @@ class OpenLeg:
     symbol: str
     config_id: str
     entry_decision_ts_ms: int
+    entry_fill_ts_ms: int
     entry_reference_close: float
+    filled_qty: float
     entry_fill: fm.FillOutcome
+
+    @property
+    def entry_evidence(self) -> ModeledEntryEvidence:
+        assert self.entry_fill.fill_price is not None
+        return ModeledEntryEvidence(
+            symbol=self.symbol,
+            config_id=self.config_id,
+            entry_fill_ts_ms=self.entry_fill_ts_ms,
+            filled_qty=self.filled_qty,
+            entry_fill_price=self.entry_fill.fill_price,
+        )
 
 
 @dataclass(frozen=True)
@@ -75,9 +112,12 @@ class Trade:
     symbol: str
     config_id: str
     entry_decision_ts_ms: int
+    entry_fill_ts_ms: int
     exit_decision_ts_ms: int
+    exit_fill_ts_ms: int
     entry_reference_close: float
     exit_reference_close: float
+    filled_qty: float
     entry_fill: fm.FillOutcome
     exit_fill: fm.FillOutcome
 
@@ -92,6 +132,23 @@ class Trade:
     @property
     def holding_days(self) -> int:
         return (self.exit_decision_ts_ms - self.entry_decision_ts_ms) // 86_400_000
+
+    @property
+    def entry_evidence(self) -> ModeledEntryEvidence:
+        assert self.entry_fill.fill_price is not None
+        return ModeledEntryEvidence(
+            symbol=self.symbol,
+            config_id=self.config_id,
+            entry_fill_ts_ms=self.entry_fill_ts_ms,
+            filled_qty=self.filled_qty,
+            entry_fill_price=self.entry_fill.fill_price,
+        )
+
+
+def _fill_ts_ms(decision_ts_ms: int, fill: fm.FillOutcome) -> int:
+    if not fill.filled or fill.fill_bar_offset is None:
+        raise ValueError("fill timestamp requires a filled FillOutcome")
+    return decision_ts_ms + fill.fill_bar_offset * fm.MINUTE_MS
 
 
 @dataclass(frozen=True)
@@ -129,11 +186,20 @@ def process_entry_signal(
     )
     if not fill.filled:
         return attempt, None
+    assert fill.fill_price is not None
+    # H3 commits target_notional at the signal/reference price before H4 can
+    # observe a later fill. The quantity is therefore fixed pre-fill; using
+    # the actual fill price below preserves the audit contract's
+    # filled_qty*entry_fill_price numerator rather than substituting target
+    # notional or a family base slot.
+    filled_qty = record.target_notional / reference_close
     return attempt, OpenLeg(
         symbol=record.symbol,
         config_id=record.config_id,
         entry_decision_ts_ms=ts,
+        entry_fill_ts_ms=_fill_ts_ms(ts, fill),
         entry_reference_close=reference_close,
+        filled_qty=filled_qty,
         entry_fill=fill,
     )
 
@@ -164,9 +230,12 @@ def process_exit_signal(
         symbol=open_leg.symbol,
         config_id=open_leg.config_id,
         entry_decision_ts_ms=open_leg.entry_decision_ts_ms,
+        entry_fill_ts_ms=open_leg.entry_fill_ts_ms,
         exit_decision_ts_ms=ts,
+        exit_fill_ts_ms=_fill_ts_ms(ts, fill),
         entry_reference_close=open_leg.entry_reference_close,
         exit_reference_close=reference_close,
+        filled_qty=open_leg.filled_qty,
         entry_fill=open_leg.entry_fill,
         exit_fill=fill,
     )

--- a/research/alpaca_track_walkforward/trade_ledger.py
+++ b/research/alpaca_track_walkforward/trade_ledger.py
@@ -1,0 +1,265 @@
+"""ROB-1062 H4 — turn one (symbol, config_id) chronological stream of H3
+``output_schema.SignalRecord``s into CLOSED trades, applying the historical
+fill model (``fill_model.py``) to both legs.
+
+``SignalRecord`` itself carries no price (H3 is PnL-blind by construction,
+AC20/AC21 of ROB-1061) — only ``action``/``reason_code``/``evidence_hash``.
+This module is the FIRST point in the pipeline where a price ever touches a
+record, and it does so from data the CALLER supplies independently (the
+reference close at each decision, and the minute bars following it) — never
+by reaching back into a signal record's evidence_hash (which is an opaque
+digest, not a reversible price).
+
+AP-A1/AP-A2 are both single-position-per-symbol (never pyramided, AC9/H3):
+an ``ENTER`` record is matched with the NEXT ``EXIT`` record for the same
+``(symbol, config_id)`` that follows it — there is never more than one open
+leg per symbol/config at a time. An ``ENTER`` with no following ``EXIT`` by
+the end of the supplied stream is an OPEN position (not a closed trade) and
+is reported separately, never silently counted as closed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import fill_model as fm
+from daily_bars import SpotMinute
+from output_schema import SignalRecord
+
+__all__ = [
+    "FillAttempt",
+    "OpenLeg",
+    "Trade",
+    "TradeLedgerResult",
+    "build_trades_for_symbol_config",
+    "process_entry_signal",
+    "process_exit_signal",
+]
+
+
+@dataclass(frozen=True)
+class FillAttempt:
+    """One ENTRY or EXIT fill attempt, with its own decision timestamp —
+    exists so a caller can attribute an unfilled/incomplete attempt to a
+    walk-forward PHASE (TRAIN vs OOS) by timestamp, without needing to
+    re-run the ledger over a phase-sliced (and therefore potentially
+    ENTER/EXIT-orphaning) record subsequence. A single canonical ledger run
+    over the FULL continuous stream is the only ledger run that ever
+    happens; every consumer downstream (blind counts, trade attribution)
+    filters THIS list by timestamp instead."""
+
+    decision_ts_ms: int
+    symbol: str
+    leg: str  # "ENTRY" or "EXIT"
+    outcome: fm.FillOutcome
+
+
+@dataclass(frozen=True)
+class OpenLeg:
+    """An ENTER with no matching EXIT yet inside the supplied record
+    stream — genuinely open, never counted as a closed trade."""
+
+    symbol: str
+    config_id: str
+    entry_decision_ts_ms: int
+    entry_reference_close: float
+    entry_fill: fm.FillOutcome
+
+
+@dataclass(frozen=True)
+class Trade:
+    """One CLOSED round trip: an ENTER matched with the following EXIT for
+    the same symbol/config, both legs run through the fill model."""
+
+    symbol: str
+    config_id: str
+    entry_decision_ts_ms: int
+    exit_decision_ts_ms: int
+    entry_reference_close: float
+    exit_reference_close: float
+    entry_fill: fm.FillOutcome
+    exit_fill: fm.FillOutcome
+
+    def __post_init__(self) -> None:
+        if self.exit_decision_ts_ms <= self.entry_decision_ts_ms:
+            raise ValueError("exit must come strictly after entry")
+
+    @property
+    def both_legs_filled(self) -> bool:
+        return self.entry_fill.filled and self.exit_fill.filled
+
+    @property
+    def holding_days(self) -> int:
+        return (self.exit_decision_ts_ms - self.entry_decision_ts_ms) // 86_400_000
+
+
+@dataclass(frozen=True)
+class TradeLedgerResult:
+    closed_trades: tuple[Trade, ...]
+    open_position: OpenLeg | None
+    entry_unfilled_count: int
+    exit_unfilled_count: int
+    fill_window_incomplete_count: int
+    fill_attempts: tuple[FillAttempt, ...] = ()
+
+
+def process_entry_signal(
+    record: SignalRecord,
+    *,
+    reference_close: float,
+    minute_bars: Sequence[SpotMinute],
+) -> tuple[FillAttempt, OpenLeg | None]:
+    """The single source of truth for turning one ENTER record into a fill
+    attempt + (maybe) a new open leg. Shared by ``build_trades_for_symbol_
+    config`` (a standalone, already-consistent-stream batch pass) and the
+    walk-forward runner's interleaved per-decision loop (which additionally
+    needs to know THIS RESULT immediately, in order to patch H3's engine
+    state before the next decision — see ``runner.py`` module docstring for
+    why: H3's own position bookkeeping assumes every accepted signal
+    executes instantly, which the fill model can contradict)."""
+    ts = record.decision_ts_ms
+    fill = fm.model_entry_fill(
+        decision_ts_ms=ts,
+        reference_close=reference_close,
+        minute_bars_after_signal=minute_bars,
+    )
+    attempt = FillAttempt(
+        decision_ts_ms=ts, symbol=record.symbol, leg="ENTRY", outcome=fill
+    )
+    if not fill.filled:
+        return attempt, None
+    return attempt, OpenLeg(
+        symbol=record.symbol,
+        config_id=record.config_id,
+        entry_decision_ts_ms=ts,
+        entry_reference_close=reference_close,
+        entry_fill=fill,
+    )
+
+
+def process_exit_signal(
+    record: SignalRecord,
+    open_leg: OpenLeg,
+    *,
+    reference_close: float,
+    minute_bars: Sequence[SpotMinute],
+) -> tuple[FillAttempt, Trade | None]:
+    """The single source of truth for turning one EXIT record + its known
+    open leg into a fill attempt + (maybe) a closed Trade. Returns
+    ``(attempt, None)`` if the exit did not fill (unfilled or incomplete) —
+    the caller keeps treating ``open_leg`` as still open."""
+    ts = record.decision_ts_ms
+    fill = fm.model_exit_fill(
+        decision_ts_ms=ts,
+        reference_close=reference_close,
+        minute_bars_after_signal=minute_bars,
+    )
+    attempt = FillAttempt(
+        decision_ts_ms=ts, symbol=record.symbol, leg="EXIT", outcome=fill
+    )
+    if not fill.filled:
+        return attempt, None
+    trade = Trade(
+        symbol=open_leg.symbol,
+        config_id=open_leg.config_id,
+        entry_decision_ts_ms=open_leg.entry_decision_ts_ms,
+        exit_decision_ts_ms=ts,
+        entry_reference_close=open_leg.entry_reference_close,
+        exit_reference_close=reference_close,
+        entry_fill=open_leg.entry_fill,
+        exit_fill=fill,
+    )
+    return attempt, trade
+
+
+def build_trades_for_symbol_config(
+    records: Sequence[SignalRecord],
+    *,
+    reference_close_by_decision_ts: Mapping[int, float],
+    minute_bars_by_decision_ts: Mapping[int, Sequence[SpotMinute]],
+) -> TradeLedgerResult:
+    """``records`` must already be the chronological, single-(symbol,
+    config_id) slice (the caller is the walk-forward runner, which knows
+    the symbol/config grouping — this function does not re-derive it, to
+    stay a small, directly testable unit)."""
+    if records:
+        symbol = records[0].symbol
+        config_id = records[0].config_id
+        for r in records:
+            if r.symbol != symbol or r.config_id != config_id:
+                raise ValueError(
+                    "records must all share the same (symbol, config_id) — "
+                    f"got {(r.symbol, r.config_id)!r} mixed with "
+                    f"{(symbol, config_id)!r}"
+                )
+        for earlier, later in zip(records, records[1:], strict=False):
+            if later.decision_ts_ms <= earlier.decision_ts_ms:
+                raise ValueError(
+                    "records must be strictly increasing by decision_ts_ms"
+                )
+
+    closed: list[Trade] = []
+    open_leg: OpenLeg | None = None
+    entry_unfilled = 0
+    exit_unfilled = 0
+    incomplete = 0
+    attempts: list[FillAttempt] = []
+
+    for record in records:
+        ts = record.decision_ts_ms
+        if record.action == "ENTER":
+            ref = reference_close_by_decision_ts[ts]
+            bars = minute_bars_by_decision_ts.get(ts, ())
+            attempt, maybe_open_leg = process_entry_signal(
+                record, reference_close=ref, minute_bars=bars
+            )
+            attempts.append(attempt)
+            if attempt.outcome.reason == "FILL_WINDOW_INCOMPLETE":
+                incomplete += 1
+                continue
+            if maybe_open_leg is None:
+                entry_unfilled += 1
+                continue
+            open_leg = maybe_open_leg
+        elif record.action == "EXIT":
+            if open_leg is None:
+                # H3 never emits an EXIT for a symbol it did not itself
+                # carry as long (state is caller-owned and continuous) —
+                # an EXIT with no open leg here means the caller fed a
+                # stream that does not start from a flat/known state.
+                raise ValueError(
+                    f"EXIT at {ts} for {record.symbol}/{record.config_id} with "
+                    "no matching open ENTER in this record stream"
+                )
+            ref = reference_close_by_decision_ts[ts]
+            bars = minute_bars_by_decision_ts.get(ts, ())
+            attempt, maybe_trade = process_exit_signal(
+                record, open_leg, reference_close=ref, minute_bars=bars
+            )
+            attempts.append(attempt)
+            if attempt.outcome.reason == "FILL_WINDOW_INCOMPLETE":
+                incomplete += 1
+                # The open leg survives — an incomplete OOS fill attempt on
+                # the exit leg is a structural data gap, not an exit event;
+                # the position is still open from this ledger's perspective.
+                continue
+            if maybe_trade is None:
+                exit_unfilled += 1
+                # EXIT_UNFILLED: the position remains open (SS13.2-style
+                # retry-until-filled economics are the live loop's scope;
+                # this backtest ledger simply keeps the leg open for the
+                # next EXIT-shaped record to attempt again).
+                continue
+            closed.append(maybe_trade)
+            open_leg = None
+        # HOLD/NO_ACTION records do not affect the ledger.
+
+    return TradeLedgerResult(
+        closed_trades=tuple(closed),
+        open_position=open_leg,
+        entry_unfilled_count=entry_unfilled,
+        exit_unfilled_count=exit_unfilled,
+        fill_window_incomplete_count=incomplete,
+        fill_attempts=tuple(attempts),
+    )

--- a/research/alpaca_track_walkforward/wf_seal_consumption.py
+++ b/research/alpaca_track_walkforward/wf_seal_consumption.py
@@ -1,0 +1,184 @@
+"""ROB-1062 H4 — the ONLY module in this package allowed to import
+``alpaca_track_seal`` (H2) directly. Every other H4 module reaches sealed
+values (cost scenarios, the AP-A2 turnover band, the walk-forward policy
+shape, per-family annual stress cost caps, the sealed 16 configs) through the
+accessors here — never by importing ``configs``/``params``/``artifact``/
+``identity`` directly, and never by re-typing a sealed literal (the SAME
+AC18-style discipline ``alpaca_track_signals.seal_consumption`` documents and
+enforces for H3).
+
+Config access (the sealed 16 ``ConfigSpec`` rows) and the $2,000/$62.50
+equity/base-slot literals are already exposed read-only by H3's OWN
+``seal_consumption`` module — this module does not re-expose those (importing
+``alpaca_track_signals.seal_consumption`` from elsewhere in H4 for that
+purpose is normal H3-consumption, not a violation of the "one gateway" rule,
+which is specifically about NOT importing ``alpaca_track_seal.*`` a second
+way). This module exposes ONLY the walk-forward-policy-shaped sealed values
+H3 has no reason to expose: fold/window day-counts, cost scenario bp values,
+the AP-A2 turnover band, the paper fee bp (kept for evidence/provenance
+binding ONLY — never as a second, additional deduction; see
+``pnl_views.py``'s explicit no-double-fee test), and the per-family annual
+stress cost cap percentage.
+"""
+
+from __future__ import annotations
+
+import artifact as art
+import configs as cfg
+import identity as ident
+import params as prm
+
+__all__ = [
+    "SealDriftError",
+    "ap_a2_turnover_band",
+    "assert_policy_matches_schedule_constants",
+    "cost_scenarios_bp",
+    "embargo_days",
+    "min_modeled_entries_per_fold",
+    "oos_days",
+    "oos_folds",
+    "paper_fee_bp",
+    "primary_cost_scenario",
+    "roll_days",
+    "stress_annual_cost_cap_pct",
+    "train_days",
+    "upward_cost_scenario",
+]
+
+
+class SealDriftError(RuntimeError):
+    """The freshly-rebuilt H2 seal no longer matches the pinned semantic
+    hash — refuse to consume a drifted seal (mirrors
+    ``alpaca_track_signals.seal_consumption.SealDriftError``)."""
+
+
+def _load() -> prm.SealedParams:
+    sealed = art.build_sealed_artifact()
+    actual = sealed.semantic_hash()
+    if actual != art.SEALED_ARTIFACT_SEMANTIC_HASH:
+        raise SealDriftError(
+            f"H2 seal semantic hash {actual!r} does not match the pinned "
+            f"{art.SEALED_ARTIFACT_SEMANTIC_HASH!r} — refusing to consume a "
+            "drifted seal"
+        )
+    return sealed.params
+
+
+def _policy_component(family: str) -> dict:
+    """The ``policy`` ROB-846 identity component for the first sealed config
+    of ``family`` — carries the walk-forward window shape
+    (``oos_folds``/``oos_days``/``train_days``/``embargo_days``/
+    ``roll_days``) and ``min_modeled_entries_per_fold``. Identical across
+    both families by ``identity.validate_same_family_components_are_
+    identical`` (H2-lock invariant); this reads AP-A1's row only, since both
+    are guaranteed equal."""
+    params = _load()
+    for config in cfg.build_ap_a1_configs():
+        return ident.build_components_for_config(config, params)["policy"]
+    raise AssertionError("build_ap_a1_configs() must never be empty")
+
+
+def _frozen_config_component(family: str) -> dict:
+    params = _load()
+    configs = (
+        cfg.build_ap_a1_configs() if family == "AP-A1" else cfg.build_ap_a2_configs()
+    )
+    for config in configs:
+        return ident.build_components_for_config(config, params)["frozen_config"]
+    raise AssertionError(f"no sealed config with family={family!r}")
+
+
+def oos_folds() -> int:
+    return int(_policy_component("AP-A1")["walk_forward"]["oos_folds"])
+
+
+def oos_days() -> int:
+    return int(_policy_component("AP-A1")["walk_forward"]["oos_days"])
+
+
+def train_days() -> int:
+    return int(_policy_component("AP-A1")["walk_forward"]["train_days"])
+
+
+def embargo_days() -> int:
+    return int(_policy_component("AP-A1")["walk_forward"]["embargo_days"])
+
+
+def roll_days() -> int:
+    return int(_policy_component("AP-A1")["walk_forward"]["roll_days"])
+
+
+def min_modeled_entries_per_fold() -> int:
+    return int(_policy_component("AP-A1")["min_modeled_entries_per_fold"])
+
+
+def cost_scenarios_bp() -> dict[str, int]:
+    """``{"C50": 50, "C100": 100, "C120": 120, "C150": 150}`` — the FULL,
+    already-round-trip-inclusive cost scenario bp values (never re-typed;
+    read fresh from the H2 seal every call)."""
+    params = _load()
+    return dict(params.cost_scenarios.scenarios_bp)
+
+
+def primary_cost_scenario() -> str:
+    return _load().cost_scenarios.primary
+
+
+def upward_cost_scenario() -> str:
+    return _load().cost_scenarios.upward
+
+
+def ap_a2_turnover_band() -> tuple[float, float]:
+    return tuple(_load().gate_thresholds.ap_a2_turnover_band)  # type: ignore[return-value]
+
+
+def paper_fee_bp() -> float:
+    """The sealed measured coin-side round-trip paper fee (25.0bp coin-side;
+    ~50bp round trip per the Run A ``50 fee`` component baked into every
+    cost scenario bp value). Exposed ONLY for evidence/provenance binding —
+    never subtracted a second time from a trade's PnL (the cost scenario bp
+    values already include it; see ``pnl_views.py``)."""
+    return float(_load().paper_fee.paper_fee_bp)
+
+
+def stress_annual_cost_cap_pct(family: str) -> float:
+    """AP-A1 = 6% NAV, AP-A2 = 18% NAV (Run A SS5/SS11.7/SS12.7), read from
+    the sealed ``frozen_config`` identity component — never re-typed."""
+    if family not in ("AP-A1", "AP-A2"):
+        raise ValueError(f"unknown family {family!r}")
+    return float(_frozen_config_component(family)["annual_stress_cost_cap_pct"])
+
+
+def assert_policy_matches_schedule_constants(
+    *,
+    oos_folds_const: int,
+    oos_days_const: int,
+    train_days_const: int,
+    embargo_days_const: int,
+    roll_days_const: int,
+) -> None:
+    """Fail closed unless ``fold_schedule.py``'s own module-level constants
+    (duplicated there so the schedule generator has no runtime H2 dependency)
+    are byte-identical to the SAME shape as sealed in H2's ``policy``
+    identity component. Run once at import/test time — a caller mutating
+    either side without the other now surfaces immediately instead of the
+    two silently drifting apart."""
+    sealed = {
+        "oos_folds": oos_folds(),
+        "oos_days": oos_days(),
+        "train_days": train_days(),
+        "embargo_days": embargo_days(),
+        "roll_days": roll_days(),
+    }
+    provided = {
+        "oos_folds": oos_folds_const,
+        "oos_days": oos_days_const,
+        "train_days": train_days_const,
+        "embargo_days": embargo_days_const,
+        "roll_days": roll_days_const,
+    }
+    if sealed != provided:
+        raise SealDriftError(
+            f"fold_schedule constants {provided} diverge from the sealed "
+            f"policy component {sealed}"
+        )


### PR DESCRIPTION
## 요약

ROB-1062 H4 적대검증 BLOCK과 후속 verify2/verify4 결함을 수정합니다. 치명 2·3은 GPT Pro 심판 완료 후 운영자 승인 동결 감사 계약을 정본으로 구현했습니다.

- OOS PnL 원본을 별도 프로세스 vault로 이전하고 실제 bound BlindCounts의 sealed dry-count PASS만 1회 unmask 가능하도록 강화
- fill-window incomplete, zero-record, histogram/lifecycle 불일치를 모두 incomplete로 승격하고 PASS 발급 지점에서 재검사
- event-time attribution으로 entry-fill count/C120 비용과 complete lifecycle closed/E120 모집단을 분리해 OOS exit의 TRAIN E120 유입 차단
- actual-filled notional, 고정 NAV 2000, C120, full precision 기준 동결 비용 산식 구현 및 immutable entry-fill 증거 노출
- AP-A2 turnover를 entries/(weekly evaluations × k)로 계산하고 봉인 band [0.2083, 0.2885]를 selection에 적용
- gate 순서를 completeness → closed count → stress-cost cap → turnover band → E120으로 강제

## verify4: 정본 권한 결속

- fold anchor는 프로세스 첫 호출값이 아니라 immutable canonical run manifest의 고정 anchor와 대조
- universe/minute의 개별 caller 서명은 권한으로 인정하지 않고, fold/family 전체 grid와 daily corpus의 pinned digest를 exact-match
- TRAIN+OOS provider 입력을 config 실행 전에 한 번 materialize하고 모든 8 configs가 동일 immutable snapshot/binding을 공유
- OOS 이후 daily feature input까지 포함한 전체 daily corpus digest를 결속
- fold-local PASS를 폐기하고 fold-0..fold-7 전부의 실제 H4-bound BlindCounts가 complete/minimum을 만족해야 aggregate PASS 발급
- TRAIN incomplete는 selection의 첫 gate에서 탈락하여 closed/cost/turnover/E120을 읽지 않음
- OOS turnover와 all-fold dry-count gate handle을 결과에 명시적으로 노출
- generic pickle을 제거하고 폐쇄형 typed JSON codec으로 교체하여 허용되지 않은 masked 값 타입을 fail-closed 거부

현재 H2 seal은 H1 dataset-manifest hash를 `None`으로 정직하게 기록하고 있으며 운영자 승인 실 H1 archive corpus는 아직 수집되지 않았습니다. 따라서 현 H4의 유일한 runnable identity인 deterministic synthetic AC27 corpus의 anchor와 모든 fold/family daily/universe/minute digest를 코드의 immutable run manifest에 고정했습니다. 향후 실 corpus는 운영자 승인 `CorpusManifest.content_hash()`가 manifest에 추가되기 전까지 fail-closed입니다.

## 동결 계약

- `docs/reviews/ROB-1062-h4-audit-implementation.md`에 event-time 4사례와 비용 산식/사유 문서화
- `SEAL_CHANGE=NO` / `THRESHOLD_REDECISION=NO`
- 30-closed, 6%/18% cap, turnover band, 16 configs, `MIN_MODELED_ENTRIES_PER_FOLD=5` 및 하드 인바리언트 변경 없음

## 검증

- verify4 집중 회귀: 74 passed
- H4 전체: 149 passed
- 전체 저장소: 18,259 passed, 15 skipped, 7 deselected
- Ruff format/check 및 ty 통과
- 동결 계약 역산/30-entry 회귀와 golden digest 통과
- 모든 8 folds × 2 families의 pinned provider grids 독립 재계산 일치
- `git diff --check` 통과

로컬 `make security`의 Bandit은 기존 app-only baseline 145건(Low 126/Medium 17/High 2)으로 종료했으며 이 PR의 `research/alpaca_track_walkforward` 파일은 해당 scan 대상이 아닙니다.

실 corpus 전량 실행, 실제 아카이브 수집, paper/broker/prod mutation은 수행하지 않았습니다. 봉인 문서·봉인 임계·하드 인바리언트는 수정하지 않았고 merge도 수행하지 않습니다.
