### PR TITLE
fix: fail closed on Telegram mirror delivery errors

### DIFF
--- a/app/monitoring/trade_notifier/notifier.py
+++ b/app/monitoring/trade_notifier/notifier.py
@@ -162,7 +162,7 @@ class TradeNotifier:
     # ── transport wrappers (delegate to transports module) ──
 
     async def _send_to_telegram(
-        self, message: str, parse_mode: str = "Markdown"
+        self, message: str, parse_mode: str | None = "Markdown"
     ) -> bool:
         """Send message to all configured Telegram chats."""
         if not self._http_client or not self._bot_token or not self._chat_ids:
@@ -712,7 +712,7 @@ class TradeNotifier:
     async def notify_agent_message(
         self,
         message: str,
-        parse_mode: str = "Markdown",
+        parse_mode: str | None = "Markdown",
         *,
         correlation_id: str | None = None,
         market_type: str | None = None,
@@ -766,24 +766,69 @@ class TradeNotifier:
             # Fall back to Telegram
             if not self._has_telegram_delivery_config():
                 telegram_result = "skipped(no_telegram_config)"
+                if (
+                    mirror_telegram
+                    and discord_result == "success"
+                    and webhook_url is not None
+                ):
+                    escalation = (
+                        "⚠️ 텔레그램 미러 실패\n"
+                        f"correlation_id: {correlation_id or 'unknown'}\n"
+                        "Discord 원문은 전송됐지만 Telegram 설정이 없어 "
+                        "미러를 완료하지 못했습니다."
+                    )
+                    escalated = await self._send_to_discord_content_single(
+                        escalation, webhook_url
+                    )
+                    logger.error(
+                        "Agent gateway Telegram mirror escalation: "
+                        "correlation_id=%s reason=%s discord_escalation=%s",
+                        correlation_id,
+                        "no_telegram_config",
+                        "success" if escalated else "failed",
+                    )
                 logger.info(
                     "Agent gateway mirror result: correlation_id=%s discord=%s telegram=%s",
                     correlation_id,
                     discord_result,
                     telegram_result,
                 )
-                return discord_result == "success"
+                return discord_result == "success" and not mirror_telegram
 
             telegram_success = await self._send_to_telegram(
                 message, parse_mode=parse_mode
             )
             telegram_result = "success" if telegram_success else "failed"
+            if (
+                mirror_telegram
+                and not telegram_success
+                and discord_result == "success"
+                and webhook_url is not None
+            ):
+                escalation = (
+                    "⚠️ 텔레그램 미러 실패\n"
+                    f"correlation_id: {correlation_id or 'unknown'}\n"
+                    "Discord 원문은 전송됐지만 Telegram 미러가 재시도 후 "
+                    "최종 실패했습니다."
+                )
+                escalated = await self._send_to_discord_content_single(
+                    escalation, webhook_url
+                )
+                logger.error(
+                    "Agent gateway Telegram mirror escalation: "
+                    "correlation_id=%s reason=%s discord_escalation=%s",
+                    correlation_id,
+                    "delivery_failed",
+                    "success" if escalated else "failed",
+                )
             logger.info(
                 "Agent gateway mirror result: correlation_id=%s discord=%s telegram=%s",
                 correlation_id,
                 discord_result,
                 telegram_result,
             )
+            if mirror_telegram:
+                return telegram_success
             return telegram_success or discord_result == "success"
         except Exception as e:
             logger.error(f"Failed to forward agent-gateway message: {e}")

--- a/app/monitoring/trade_notifier/transports.py
+++ b/app/monitoring/trade_notifier/transports.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import logging
 import re
 from typing import Any
@@ -14,13 +16,25 @@ from app.telegram_contract import (
     TelegramErrorClassification,
     TelegramMethodResult,
     classify_telegram_response_error,
+    split_telegram_text,
     telegram_text_length,
 )
 
 logger = logging.getLogger(__name__)
 
+_TELEGRAM_MAX_ATTEMPTS = 3
+_TELEGRAM_RETRY_BASE_SECONDS = 0.25
+_TELEGRAM_RETRY_MAX_SECONDS = 5.0
 _TELEGRAM_BOT_URL_RE = re.compile(
     r"(?P<prefix>https?://api\.telegram\.org/bot)[^/\s\"']+",
+    flags=re.IGNORECASE,
+)
+_TELEGRAM_PARSE_OFFSET_RE = re.compile(
+    r"^Bad Request: can't parse entities:.*byte offset (?P<offset>\d+)$",
+    flags=re.IGNORECASE,
+)
+_TELEGRAM_RETRY_DESCRIPTION_RE = re.compile(
+    r"^Too Many Requests: retry after (?P<seconds>\d+)$",
     flags=re.IGNORECASE,
 )
 _TELEGRAM_BOT_PATH_RE = re.compile(
@@ -147,38 +161,266 @@ def _log_method_failure(result: TelegramMethodResult, *, telegram_method: str) -
     )
 
 
+def _telegram_chat_ref(chat_id: str) -> str:
+    """Return a stable, non-reversible identifier for one configured chat."""
+    digest = hashlib.sha256(chat_id.encode("utf-8")).hexdigest()[:12]
+    return f"sha256:{digest}"
+
+
+def _telegram_response_body_for_log(response: httpx.Response) -> dict[str, Any]:
+    """Return diagnostic Telegram fields without propagating remote free text."""
+    try:
+        decoded = response.json()
+    except (TypeError, ValueError):
+        return {"body": "[non-json response redacted]"}
+    if not isinstance(decoded, dict):
+        return {"body": "[non-object response redacted]"}
+
+    safe_body: dict[str, Any] = {}
+    if isinstance(decoded.get("ok"), bool):
+        safe_body["ok"] = decoded["ok"]
+    error_code = decoded.get("error_code")
+    if isinstance(error_code, int) and not isinstance(error_code, bool):
+        safe_body["error_code"] = error_code
+
+    description = decoded.get("description")
+    if description == "Bad Request: message is too long":
+        safe_body["description"] = description
+    elif isinstance(description, str):
+        parse_match = _TELEGRAM_PARSE_OFFSET_RE.fullmatch(description)
+        retry_match = _TELEGRAM_RETRY_DESCRIPTION_RE.fullmatch(description)
+        if parse_match:
+            safe_body["description"] = (
+                "Bad Request: can't parse entities "
+                f"(byte_offset={parse_match.group('offset')})"
+            )
+        elif retry_match:
+            safe_body["description"] = (
+                f"Too Many Requests: retry after {retry_match.group('seconds')}"
+            )
+        else:
+            safe_body["description"] = "[untrusted description redacted]"
+    return safe_body
+
+
+def _telegram_status_code(response: Any) -> int | None:
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int) and not isinstance(status_code, bool):
+        return status_code
+    return None
+
+
+def _telegram_retry_delay(response: httpx.Response, *, attempt: int) -> float:
+    retry_after: float | None = None
+    try:
+        header_value = response.headers.get("Retry-After")
+        if header_value is not None:
+            retry_after = float(header_value)
+    except (AttributeError, TypeError, ValueError):
+        retry_after = None
+
+    if retry_after is None:
+        try:
+            decoded = response.json()
+        except (TypeError, ValueError):
+            decoded = {}
+        parameters = decoded.get("parameters") if isinstance(decoded, dict) else None
+        raw_retry_after = (
+            parameters.get("retry_after") if isinstance(parameters, dict) else None
+        )
+        if isinstance(raw_retry_after, (int, float)) and not isinstance(
+            raw_retry_after, bool
+        ):
+            retry_after = float(raw_retry_after)
+
+    if retry_after is None or retry_after < 0:
+        retry_after = _TELEGRAM_RETRY_BASE_SECONDS * (2 ** (attempt - 1))
+    return min(retry_after, _TELEGRAM_RETRY_MAX_SECONDS)
+
+
+def _safe_exception_message(
+    error: Exception,
+    *,
+    bot_token: str,
+    chat_id: str,
+) -> str:
+    message = str(_redact_telegram_token(str(error)))
+    if bot_token:
+        message = message.replace(bot_token, "[REDACTED]")
+    if chat_id:
+        message = message.replace(chat_id, "[REDACTED_CHAT_ID]")
+    return message
+
+
+def _log_telegram_send_failure(
+    *,
+    chat_id: str,
+    text: str,
+    attempt: int,
+    error: Exception,
+    bot_token: str,
+    response: httpx.Response | None,
+    retryable: bool,
+) -> None:
+    chat_ref = _telegram_chat_ref(chat_id)
+    exception_message = _safe_exception_message(
+        error,
+        bot_token=bot_token,
+        chat_id=chat_id,
+    )
+    http_status = _telegram_status_code(response) if response is not None else None
+    response_body = (
+        _telegram_response_body_for_log(response) if response is not None else None
+    )
+    payload_chars = telegram_text_length(text)
+    logger.error(
+        "telegram.send.failed chat_ref=%s attempt=%d/%d exception_type=%s "
+        "exception_message=%r http_status=%s response_body=%s retryable=%s "
+        "payload_chars=%d",
+        chat_ref,
+        attempt,
+        _TELEGRAM_MAX_ATTEMPTS,
+        type(error).__name__,
+        exception_message,
+        http_status,
+        response_body,
+        retryable,
+        payload_chars,
+        extra={
+            "chat_ref": chat_ref,
+            "attempt": attempt,
+            "max_attempts": _TELEGRAM_MAX_ATTEMPTS,
+            "exception_type": type(error).__name__,
+            "exception_message": exception_message,
+            "http_status": http_status,
+            "response_body": response_body,
+            "retryable": retryable,
+            "payload_chars": payload_chars,
+        },
+    )
+
+
+async def _send_telegram_payload(
+    *,
+    http_client: httpx.AsyncClient,
+    url: str,
+    bot_token: str,
+    chat_id: str,
+    payload: dict[str, Any],
+) -> bool:
+    for attempt in range(1, _TELEGRAM_MAX_ATTEMPTS + 1):
+        response: httpx.Response | None = None
+        try:
+            response = await http_client.post(url, json=payload)
+            status_code = _telegram_status_code(response)
+            if status_code is None:
+                response.raise_for_status()
+                return True
+            if 200 <= status_code < 300:
+                response.raise_for_status()
+                return True
+            try:
+                response.raise_for_status()
+            except Exception as error:  # noqa: BLE001 - logged and classified below
+                failure = error
+            else:
+                failure = RuntimeError(f"Telegram API returned HTTP {status_code}")
+        except Exception as error:  # noqa: BLE001 - bounded transport boundary
+            failure = error
+            if isinstance(error, httpx.HTTPStatusError):
+                response = error.response
+
+        status_code = _telegram_status_code(response) if response is not None else None
+        retryable = isinstance(failure, httpx.TransportError) or (
+            status_code == 429
+            or (status_code is not None and 500 <= status_code <= 599)
+        )
+        if retryable and attempt < _TELEGRAM_MAX_ATTEMPTS:
+            delay = (
+                _telegram_retry_delay(response, attempt=attempt)
+                if response is not None
+                else min(
+                    _TELEGRAM_RETRY_BASE_SECONDS * (2 ** (attempt - 1)),
+                    _TELEGRAM_RETRY_MAX_SECONDS,
+                )
+            )
+            logger.warning(
+                "telegram.send.retrying",
+                extra={
+                    "chat_ref": _telegram_chat_ref(chat_id),
+                    "attempt": attempt,
+                    "max_attempts": _TELEGRAM_MAX_ATTEMPTS,
+                    "exception_type": type(failure).__name__,
+                    "http_status": status_code,
+                    "retry_delay_seconds": delay,
+                },
+            )
+            await asyncio.sleep(delay)
+            continue
+
+        _log_telegram_send_failure(
+            chat_id=chat_id,
+            text=payload["text"],
+            attempt=attempt,
+            error=failure,
+            bot_token=bot_token,
+            response=response,
+            retryable=retryable,
+        )
+        return False
+    return False  # pragma: no cover - loop always returns
+
+
 async def send_telegram(
     *,
     http_client: httpx.AsyncClient,
     bot_token: str,
     chat_ids: list[str],
     text: str,
-    parse_mode: str = "Markdown",
+    parse_mode: str | None = "Markdown",
     reply_markup: dict[str, Any] | None = None,
 ) -> bool:
     """Send a message to multiple Telegram chat IDs.
 
-    Returns True if at least one chat received the message.
+    Long messages are split at Telegram's conservative UTF-16 limit. Returns
+    True only when every chunk reaches every configured chat.
     """
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
-    any_success = False
+    chunks = split_telegram_text(text, max_units=TELEGRAM_SEND_MESSAGE_TEXT_LIMIT)
+    all_success = bool(chat_ids)
     for chat_id in chat_ids:
-        try:
+        chat_success = True
+        for chunk_index, chunk in enumerate(chunks, start=1):
             payload: dict[str, Any] = {
                 "chat_id": chat_id,
-                "text": text,
-                "parse_mode": parse_mode,
+                "text": chunk,
                 "disable_web_page_preview": True,
             }
+            if parse_mode is not None:
+                payload["parse_mode"] = parse_mode
             if reply_markup is not None:
                 payload["reply_markup"] = reply_markup
-            response = await http_client.post(url, json=payload)
-            response.raise_for_status()
-            any_success = True
-            logger.info("Telegram message sent")
-        except Exception:
-            logger.error("Failed to send Telegram message")
-    return any_success
+            sent = await _send_telegram_payload(
+                http_client=http_client,
+                url=url,
+                bot_token=bot_token,
+                chat_id=chat_id,
+                payload=payload,
+            )
+            if not sent:
+                chat_success = False
+                break
+            logger.info(
+                "telegram.send.sent",
+                extra={
+                    "chat_ref": _telegram_chat_ref(chat_id),
+                    "chunk_index": chunk_index,
+                    "chunk_count": len(chunks),
+                    "payload_chars": telegram_text_length(chunk),
+                },
+            )
+        all_success = all_success and chat_success
+    return all_success
 
 
 async def send_telegram_message(

--- a/scripts/post_watch_triage_reply.py
+++ b/scripts/post_watch_triage_reply.py
@@ -65,6 +65,7 @@ async def send_reply(
     try:
         return await get_trade_notifier().notify_agent_message(
             message,
+            parse_mode=None,
             correlation_id=event_uuid,
             market_type=market,
             mirror_telegram=True,

--- a/tests/scripts/test_post_watch_triage_reply.py
+++ b/tests/scripts/test_post_watch_triage_reply.py
@@ -59,6 +59,7 @@ async def test_send_reply_uses_trade_notifier_mirror(monkeypatch) -> None:
     assert kwargs["correlation_id"] == "event-1"
     assert kwargs["market_type"] == "crypto"
     assert kwargs["mirror_telegram"] is True
+    assert kwargs["parse_mode"] is None
 
 
 def test_main_reads_stdin_and_returns_zero(monkeypatch, capsys) -> None:

--- a/tests/test_trade_notifier.py
+++ b/tests/test_trade_notifier.py
@@ -1070,7 +1070,7 @@ async def test_notify_agent_message_mirror_telegram_sends_both_on_discord_succes
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_notify_agent_message_mirror_returns_true_when_telegram_unconfigured(
+async def test_notify_agent_message_mirror_returns_false_and_escalates_when_unconfigured(
     trade_notifier,
 ):
     trade_notifier.configure(
@@ -1083,7 +1083,7 @@ async def test_notify_agent_message_mirror_returns_true_when_telegram_unconfigur
     with patch.object(
         trade_notifier,
         "_send_to_discord_content_single",
-        new=AsyncMock(return_value=True),
+        new=AsyncMock(side_effect=[True, True]),
     ) as md:
         ok = await trade_notifier.notify_agent_message(
             "triage text",
@@ -1092,8 +1092,52 @@ async def test_notify_agent_message_mirror_returns_true_when_telegram_unconfigur
             mirror_telegram=True,
         )
 
-    assert ok is True
-    md.assert_awaited_once()
+    assert ok is False
+    assert md.await_count == 2
+    escalation = md.await_args_list[1].args[0]
+    assert "텔레그램 미러 실패" in escalation
+    assert "event-2" in escalation
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_agent_message_mirror_failure_is_escalated_and_not_success(
+    trade_notifier,
+):
+    webhook = "https://discord.com/api/webhooks/crypto"
+    trade_notifier.configure(
+        bot_token="t",
+        chat_ids=["1"],
+        enabled=True,
+        discord_webhook_crypto=webhook,
+    )
+
+    with (
+        patch.object(
+            trade_notifier,
+            "_send_to_discord_content_single",
+            new=AsyncMock(side_effect=[True, True]),
+        ) as mock_discord,
+        patch.object(
+            trade_notifier,
+            "_send_to_telegram",
+            new=AsyncMock(return_value=False),
+        ) as mock_telegram,
+    ):
+        ok = await trade_notifier.notify_agent_message(
+            "triage text",
+            parse_mode=None,
+            correlation_id="event-3",
+            market_type="crypto",
+            mirror_telegram=True,
+        )
+
+    assert ok is False
+    mock_telegram.assert_awaited_once_with("triage text", parse_mode=None)
+    assert mock_discord.await_count == 2
+    assert mock_discord.await_args_list[0].args == ("triage text", webhook)
+    assert "텔레그램 미러 실패" in mock_discord.await_args_list[1].args[0]
+    assert mock_discord.await_args_list[1].args[1] == webhook
 
 
 @pytest.mark.unit

--- a/tests/test_trade_notifier_transports.py
+++ b/tests/test_trade_notifier_transports.py
@@ -1,8 +1,10 @@
 # tests/test_trade_notifier_transports.py
 """Tests for trade notifier transport functions."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from app.monitoring.trade_notifier.transports import (
@@ -10,6 +12,7 @@ from app.monitoring.trade_notifier.transports import (
     send_discord_embed_single,
     send_telegram,
 )
+from app.telegram_contract import TELEGRAM_SEND_MESSAGE_TEXT_LIMIT, telegram_text_length
 
 
 @pytest.fixture
@@ -59,8 +62,8 @@ class TestSendTelegram:
         assert payload["text"] == "msg"
         assert payload["parse_mode"] == "Markdown"
 
-    async def test_returns_true_if_at_least_one_succeeds(self, mock_http_client):
-        """Partial success: first chat fails, second succeeds."""
+    async def test_returns_false_if_only_some_chats_succeed(self, mock_http_client):
+        """A configured mirror is incomplete unless every chat receives it."""
         mock_http_client.post.side_effect = [
             Exception("fail"),
             MagicMock(raise_for_status=MagicMock()),
@@ -71,7 +74,208 @@ class TestSendTelegram:
             chat_ids=["a", "b"],
             text="msg",
         )
+        assert result is False
+
+    async def test_plain_text_avoids_triage_markdown_parse_failure(self):
+        triage = "\n".join(
+            [
+                "[watch triage] 214150",
+                "market: kr",
+                "## 알림 요약",
+                "- price_breakout_* 후보 [원문](https://example.invalid)",
+                "## 제안 verdict",
+                "- verdict=`wait` because risk_score_under_limit",
+            ]
+        )
+
+        async def telegram_api(_url, *, json):
+            request = httpx.Request("POST", "https://api.telegram.org/sendMessage")
+            if json.get("parse_mode") == "Markdown":
+                return httpx.Response(
+                    400,
+                    request=request,
+                    json={
+                        "ok": False,
+                        "error_code": 400,
+                        "description": (
+                            "Bad Request: can't parse entities: "
+                            "Can't find end of the entity starting at byte offset 91"
+                        ),
+                    },
+                )
+            return httpx.Response(200, request=request, json={"ok": True})
+
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=telegram_api)
+
+        markdown_result = await send_telegram(
+            http_client=client,
+            bot_token="request-token",
+            chat_ids=["998877"],
+            text=triage,
+            parse_mode="Markdown",
+        )
+        plain_result = await send_telegram(
+            http_client=client,
+            bot_token="request-token",
+            chat_ids=["998877"],
+            text=triage,
+            parse_mode=None,
+        )
+
+        assert markdown_result is False
+        assert plain_result is True
+        assert "parse_mode" not in client.post.await_args.kwargs["json"]
+
+    async def test_splits_long_plain_triage_without_losing_text(self):
+        triage = "\n".join(
+            [
+                "[watch triage] 214150",
+                "## 알림 요약",
+                ("risk_score_under_limit * [source] `wait` _ " * 140),
+                "## 제안 verdict",
+                ("- verdict=`wait`; 신규 주문 없음\n" * 80),
+            ]
+        )
+        assert telegram_text_length(triage) > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+
+        result = await send_telegram(
+            http_client=client,
+            bot_token="request-token",
+            chat_ids=["998877"],
+            text=triage,
+            parse_mode=None,
+        )
+
         assert result is True
+        payloads = [call.kwargs["json"] for call in client.post.await_args_list]
+        assert len(payloads) > 1
+        assert "".join(payload["text"] for payload in payloads) == triage
+        assert all(
+            telegram_text_length(payload["text"]) <= TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+            for payload in payloads
+        )
+        assert all("parse_mode" not in payload for payload in payloads)
+
+    async def test_retries_rate_limit_with_a_hard_attempt_cap(self, monkeypatch):
+        request = httpx.Request("POST", "https://api.telegram.org/sendMessage")
+        rate_limited = httpx.Response(
+            429,
+            request=request,
+            headers={"Retry-After": "0"},
+            json={
+                "ok": False,
+                "error_code": 429,
+                "description": "Too Many Requests: retry after 0",
+            },
+        )
+        success = httpx.Response(200, request=request, json={"ok": True})
+        client = MagicMock()
+        client.post = AsyncMock(
+            side_effect=[rate_limited, rate_limited, rate_limited, success]
+        )
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "app.monitoring.trade_notifier.transports.asyncio.sleep", sleep
+        )
+
+        result = await send_telegram(
+            http_client=client,
+            bot_token="request-token",
+            chat_ids=["998877"],
+            text="triage",
+            parse_mode=None,
+        )
+
+        assert result is False
+        assert client.post.await_count == 3
+        assert sleep.await_count == 2
+
+    async def test_retries_network_errors_then_succeeds_without_secret_logs(
+        self, monkeypatch, caplog
+    ):
+        token = "123456:top-secret"
+        chat_id = "998877"
+        request = httpx.Request(
+            "POST", f"https://api.telegram.org/bot{token}/sendMessage"
+        )
+        client = MagicMock()
+        client.post = AsyncMock(
+            side_effect=[
+                httpx.ConnectError(
+                    f"network down for chat={chat_id} via {request.url}",
+                    request=request,
+                ),
+                MagicMock(raise_for_status=MagicMock()),
+            ]
+        )
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "app.monitoring.trade_notifier.transports.asyncio.sleep", sleep
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = await send_telegram(
+                http_client=client,
+                bot_token=token,
+                chat_ids=[chat_id],
+                text="triage",
+                parse_mode=None,
+            )
+
+        assert result is True
+        assert client.post.await_count == 2
+        sleep.assert_awaited_once()
+        assert token not in caplog.text
+        assert chat_id not in caplog.text
+
+    async def test_logs_safe_response_reason_and_chat_fingerprint(self, caplog):
+        request = httpx.Request("POST", "https://api.telegram.org/sendMessage")
+        response = httpx.Response(
+            400,
+            request=request,
+            json={
+                "ok": False,
+                "error_code": 400,
+                "description": (
+                    "Bad Request: can't parse entities: "
+                    "Can't find end of the entity starting at byte offset 91"
+                ),
+            },
+        )
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+
+        with caplog.at_level(logging.ERROR):
+            result = await send_telegram(
+                http_client=client,
+                bot_token="123456:top-secret",
+                chat_ids=["998877"],
+                text="triage",
+            )
+
+        assert result is False
+        record = next(
+            item
+            for item in caplog.records
+            if item.msg.startswith("telegram.send.failed")
+        )
+        assert record.exception_type == "HTTPStatusError"
+        assert "400 Bad Request" in record.exception_message
+        assert record.response_body == {
+            "ok": False,
+            "error_code": 400,
+            "description": "Bad Request: can't parse entities (byte_offset=91)",
+        }
+        assert record.chat_ref.startswith("sha256:")
+        assert "can't parse entities" in caplog.text
+        assert "response_body=" in caplog.text
+        assert "123456:top-secret" not in caplog.text
+        assert "998877" not in caplog.text
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- send watch-triage mirrors as plain text so untrusted triage Markdown cannot trigger Telegram entity parsing failures; existing formatted notification defaults stay unchanged
- split messages at the conservative 4096 UTF-16-unit limit and retry transport errors, HTTP 429, and HTTP 5xx up to three attempts
- log safe failure diagnostics with exception type/message, HTTP status, normalized Telegram response reason, and hashed chat reference without exposing bot tokens or raw chat IDs
- treat partial Telegram delivery as failure; when Discord succeeded but the requested Telegram mirror did not, post a Discord escalation and return false so the poller retries

## Root-cause evidence
The watch-triage path passed raw Claude output through legacy parse_mode=Markdown. Telegram legacy Markdown requires escaping special characters such as underscore, asterisk, backtick, and opening bracket. A Telegram API spy reproduces the prior 400 can't parse entities response for a 214150-style verdict body and verifies the same body succeeds when parse_mode is omitted. The historical Telegram response for the July 27 incident was swallowed by the old code, so its exact server description cannot be recovered. Message length is a separate covered risk, not proven as the historical trigger.

## Validation
- uv run pytest tests/test_trade_notifier_transports.py tests/monitoring/test_trade_notifier_reply_markup.py tests/services/order_proposals/test_dispatch_security_invariants.py tests/test_trade_notifier.py tests/scripts/test_post_watch_triage_reply.py -q (168 passed)
- uv run ruff check on all changed Python files
- uv run ruff format --check on all changed Python files
- uv run ty check app/monitoring/trade_notifier/transports.py app/monitoring/trade_notifier/notifier.py scripts/post_watch_triage_reply.py

No live Telegram or Discord messages were sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram delivery reliability with retries for rate limits, server errors, and network failures.
  * Long messages are now split safely before delivery.
  * Delivery reports failure when any configured destination cannot receive the message.
  * Added clearer Discord escalation when Telegram mirroring is unavailable or fails.
  * Plain-text messages can now be sent without Markdown formatting.
* **Security**
  * Improved diagnostic logging to avoid exposing sensitive tokens and chat identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->