### PR TITLE
fix: make KR NXT freshness operations dry-run first

### DIFF
--- a/app/jobs/kr_symbol_universe.py
+++ b/app/jobs/kr_symbol_universe.py
@@ -7,16 +7,23 @@ from app.services.kr_symbol_universe_service import sync_kr_symbol_universe
 logger = logging.getLogger(__name__)
 
 
-async def run_kr_symbol_universe_sync() -> dict[str, int | str]:
+async def run_kr_symbol_universe_sync(
+    *,
+    dry_run: bool = False,
+) -> dict[str, int | str | bool]:
     try:
-        result = await sync_kr_symbol_universe()
-        return {
+        result = await sync_kr_symbol_universe(dry_run=dry_run)
+        payload: dict[str, int | str | bool] = {
             "status": "completed",
             **result,
         }
+        if dry_run:
+            payload["dry_run"] = True
+        return payload
     except Exception as exc:
         logger.error("KR symbol universe sync failed: %s", exc, exc_info=True)
         return {
             "status": "failed",
             "error": str(exc),
+            **({"dry_run": True} if dry_run else {}),
         }

--- a/app/services/kr_symbol_universe_service.py
+++ b/app/services/kr_symbol_universe_service.py
@@ -297,6 +297,41 @@ async def _apply_snapshot(
     }
 
 
+async def _plan_snapshot(
+    db: AsyncSession,
+    snapshot: dict[str, _UniverseRow],
+) -> dict[str, int]:
+    """Return the apply counts without mutating ORM rows or flushing."""
+    existing_result = await db.execute(select(KRSymbolUniverse))
+    existing_rows = {row.symbol: row for row in list(existing_result.scalars().all())}
+
+    inserted = sum(symbol not in existing_rows for symbol in snapshot)
+    updated = 0
+    for symbol, row in snapshot.items():
+        existing = existing_rows.get(symbol)
+        if existing is None:
+            continue
+        if (
+            existing.name != row.name
+            or existing.exchange != row.exchange
+            or existing.nxt_eligible != row.nxt_eligible
+            or not existing.is_active
+        ):
+            updated += 1
+
+    snapshot_symbols = set(snapshot)
+    deactivated = sum(
+        existing.is_active and symbol not in snapshot_symbols
+        for symbol, existing in existing_rows.items()
+    )
+    return {
+        "total": len(snapshot),
+        "inserted": inserted,
+        "updated": updated,
+        "deactivated": deactivated,
+    }
+
+
 async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
     normalized_name = normalize_name(name)
     if not normalized_name:
@@ -499,19 +534,31 @@ async def search_kr_symbols(
         await session.close()
 
 
-async def sync_kr_symbol_universe(db: AsyncSession | None = None) -> dict[str, int]:
+async def sync_kr_symbol_universe(
+    db: AsyncSession | None = None,
+    *,
+    dry_run: bool = False,
+) -> dict[str, int]:
     snapshot = await build_kr_symbol_universe_snapshot()
     if db is not None:
-        return await _apply_snapshot(db, snapshot)
+        return (
+            await _plan_snapshot(db, snapshot)
+            if dry_run
+            else await _apply_snapshot(db, snapshot)
+        )
 
     session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
     try:
-        async with session.begin():
-            result = await _apply_snapshot(session, snapshot)
+        if dry_run:
+            result = await _plan_snapshot(session, snapshot)
+        else:
+            async with session.begin():
+                result = await _apply_snapshot(session, snapshot)
     finally:
         await session.close()
     logger.info(
-        "KR symbol universe synced total=%d inserted=%d updated=%d deactivated=%d",
+        "KR symbol universe %s total=%d inserted=%d updated=%d deactivated=%d",
+        "dry-run" if dry_run else "synced",
         result["total"],
         result["inserted"],
         result["updated"],

--- a/docs/runbooks/kr-nxt-tradable-freshness.md
+++ b/docs/runbooks/kr-nxt-tradable-freshness.md
@@ -1,0 +1,279 @@
+# KR NXT Tradability Freshness Runbook
+
+This runbook keeps the data behind the fail-closed approval-window gate fresh.
+It does not relax that gate, send approval cards, or place orders.
+
+## Why there are two syncs
+
+`nxt_tradable` is derived rather than stored:
+
+```text
+nxt_tradable = nxt_eligible AND nxt_trading_suspended IS NOT TRUE
+asof = COALESCE(toss_master_updated_at, updated_at)
+stale = now - asof > 2 days
+```
+
+The inputs have different owners:
+
+| Input | Source | Operator entrypoint | What it changes |
+|---|---|---|---|
+| `nxt_eligible` | Korea Investment & Securities DWS static master (`new.real.download.dws.co.kr`) | `scripts/sync_kr_symbol_universe.py` | universe membership, name, exchange, `nxt_eligible`, active flag |
+| `nxt_trading_suspended`, `toss_master_updated_at` | authenticated Toss Open API `/api/v1/stocks` | `scripts/sync_toss_symbol_master.py` | Toss master metadata, including NXT suspension and the freshness timestamp |
+
+Running only `sync_kr_symbol_universe.py` does **not** refresh
+`toss_master_updated_at`. Once that column is non-null, the gate prefers it to
+`updated_at`, so the KR universe sync cannot clear `nxt_capability_stale`.
+
+## 2026-07-27 incident measurement
+
+Measurements were taken from the local production `auto_trader` database in a
+read-only transaction at `2026-07-27 09:35:54+09:00`. The PostgreSQL session
+timezone was `Asia/Seoul`; all timestamp columns below are `TIMESTAMPTZ`.
+
+| Measurement | Result |
+|---|---:|
+| total / active rows | 3,976 / 3,919 |
+| active `nxt_eligible=true` | 606 |
+| active rows stale by the gate's effective as-of | 3,918 |
+| stale active NXT-eligible rows | 606 |
+| active rows with a stale Toss timestamp | 3,919 |
+| missing effective as-of | 0 |
+
+For `052690` (한전기술):
+
+- `nxt_eligible=true`, `nxt_trading_suspended=false`, `is_active=true`
+- `toss_master_updated_at=2026-06-15 08:00:04.772008+09:00`
+  (`2026-06-14 23:00:04.772008Z`)
+- `updated_at=2026-07-21 11:49:05.410071+09:00`, but it is ignored because the
+  Toss timestamp is non-null
+- age when proposal `0f17e182-f3f1-44a0-b2ad-6dd2199d4764` was created:
+  `42 days 00:15:56.825973`
+
+The proposal row has no dispatch attempt/state. The initial dispatch boundary
+returned before minting a nonce or starting the Telegram dispatch ledger.
+
+## Manual operation
+
+### Ownership and cadence
+
+- Primary: the KR trading operator; backup: the trading on-call.
+- During the manual-validation phase, run before `07:30 Asia/Seoul` on every KR
+  trading day, including the first trading day after a weekend or long holiday.
+- Do not wait for the 48-hour gate threshold. Treat a successful refresh older
+  than 24 hours as a warning and older than 36 hours as an escalation.
+- Record the dry-run and commit packets in the operator log. A command exit
+  code alone is not sufficient evidence.
+
+Use only this worktree:
+
+```bash
+cd /Users/mgh3326/work/auto_trader.nxtfresh
+export ENV_FILE=/Users/mgh3326/services/auto_trader/shared/.env.prod.native
+```
+
+### 1. Read-only preflight
+
+```bash
+psql -X -v ON_ERROR_STOP=1 -P pager=off -d auto_trader -c "
+BEGIN TRANSACTION READ ONLY;
+SELECT clock_timestamp() AS checked_at,
+       count(*) FILTER (WHERE is_active) AS active_rows,
+       count(*) FILTER (
+         WHERE is_active
+           AND (
+             COALESCE(toss_master_updated_at, updated_at) IS NULL
+             OR clock_timestamp()
+                - COALESCE(toss_master_updated_at, updated_at)
+                > interval '2 days'
+           )
+       ) AS gate_stale_rows,
+       min(COALESCE(toss_master_updated_at, updated_at))
+         FILTER (WHERE is_active) AS oldest_effective_asof,
+       max(COALESCE(toss_master_updated_at, updated_at))
+         FILTER (WHERE is_active) AS newest_effective_asof
+FROM kr_symbol_universe;
+ROLLBACK;"
+```
+
+The subtraction stays inside PostgreSQL between timezone-aware values. Do not
+strip timezone information or reinterpret a naive timestamp as UTC.
+
+### 2. Validate the KIS eligibility universe
+
+```bash
+uv run python scripts/sync_kr_symbol_universe.py --dry-run
+```
+
+On `2026-07-27 09:41+09:00`, all four downloads returned HTTP 200:
+
+- KOSPI base: 2,096 valid rows
+- KOSDAQ base: 1,823 valid rows
+- NXT KOSPI: 336 symbols
+- NXT KOSDAQ: 270 symbols
+- merged snapshot: 3,919 rows, 606 NXT-eligible
+- database diff: inserted 0, updated 0, deactivated 0
+
+Reject the run if any download or parse fails, either NXT file unexpectedly has
+zero valid rows, totals move materially without a reviewed exchange event, or
+the diff is not understood. This dry-run performs SELECTs only and never
+mutates or flushes ORM rows.
+
+If a reviewed KIS universe change must be applied, the operator hands this
+exact command to the orchestrator:
+
+```bash
+uv run python scripts/sync_kr_symbol_universe.py
+```
+
+That command is **not** the freshness repair.
+
+### 3. Validate the Toss NXT capability data
+
+```bash
+uv run python -m scripts.sync_toss_symbol_master \
+  --market kr --all --no-market-cap
+```
+
+The 2026-07-27 dry-run result was:
+
+```text
+requested=3919
+stocks_matched=3919
+stocks_missing=0
+master_updates=3919
+market_cap_payloads=0
+```
+
+An additional read-only coverage check found
+`nxtTradingSuspended` present for all 3,919 responses: 3,918 false and 1 true.
+Thirty-one stored suspension values differ from the source, but none changes
+derived NXT tradability because all 31 symbols are currently ineligible. There
+are 1,198 non-timestamp Toss metadata differences. The commit therefore
+updates all 3,919 rows (at minimum their Toss timestamp and ORM `updated_at`);
+`--no-market-cap` prevents valuation snapshot writes.
+
+Accept only `requested == stocks_matched == active_rows` and
+`stocks_missing == 0`. Any partial result requires investigation and a new
+full dry-run.
+
+### 4. Freshness commit (orchestrator only)
+
+After the accepted dry-run, the exact command is:
+
+```bash
+uv run python -m scripts.sync_toss_symbol_master \
+  --market kr --all --no-market-cap --commit
+```
+
+This is the command that refreshes the approval gate's as-of. The trading
+operator must not substitute the KR universe command.
+
+### 5. Post-commit proof
+
+Re-run the read-only preflight, then verify the incident symbol:
+
+```bash
+psql -X -v ON_ERROR_STOP=1 -P pager=off -d auto_trader -c "
+BEGIN TRANSACTION READ ONLY;
+SELECT symbol, nxt_eligible, nxt_trading_suspended,
+       toss_master_updated_at, updated_at,
+       clock_timestamp() - toss_master_updated_at AS toss_age
+FROM kr_symbol_universe
+WHERE symbol = '052690';
+ROLLBACK;"
+```
+
+Success requires:
+
+- `gate_stale_rows=0`
+- all active rows have a recent effective as-of
+- `052690.toss_master_updated_at` is from the just-completed run
+- no missing Toss stocks were reported
+
+Do not create a live proposal or send an order merely to test freshness.
+
+## Failure modes
+
+### KR universe sync
+
+- HTTP error, timeout, invalid ZIP/member, CP949 decode error, malformed row,
+  empty base universe, or an NXT symbol absent from the base snapshot raises
+  before database application. The normal sync transaction is atomic.
+- A syntactically valid but incomplete base snapshot can deactivate omitted
+  active symbols.
+- Syntactically valid empty or incomplete NXT files are not protected by a
+  minimum-coverage guard and can flip many/all `nxt_eligible` values to false.
+- It never changes `nxt_trading_suspended` or `toss_master_updated_at`, so
+  successful execution can still leave the approval gate stale.
+
+### Toss master sync
+
+- Authentication, transport, or parsing exceptions abort the transaction; an
+  ordinary source failure does not commit partial ORM changes.
+- A 200 response that omits individual stocks is reported as
+  `stocks_missing`; matched rows can still be committed while omitted rows
+  preserve their old values. The manual equality check is therefore mandatory.
+- A missing `nxtTradingSuspended` field maps to `NULL`. Because derived
+  tradability treats suspension as blocking only when it is explicitly true,
+  field coverage must be reviewed before commit.
+- `--all --commit` refreshes more Toss master metadata than NXT alone. The
+  measured non-timestamp impact was 1,198 rows; `--no-market-cap` removes the
+  separate valuation write path.
+
+## Automation recommendation (not activated here)
+
+Choose **TaskIQ** for the future write job:
+
+- the provider clients, transaction boundary, models, production credentials,
+  and KST scheduler already live in this application runtime;
+- `symbols.kr.universe.sync` already runs at `07:10 Asia/Seoul`, proving the
+  worker/scheduler path is deployed;
+- Prefect would add cross-repository release/version coupling to a write path;
+- launchd would add another singleton process/plist with weaker application
+  result and retry semantics.
+
+The existing `07:10` task only runs the KIS universe sync and therefore does
+not solve Toss freshness. A follow-up automation change should add a separate
+TaskIQ unit for the Toss NXT refresh (or explicitly orchestrate both sources),
+default its schedule and commit gates off, require full response and suspension
+field coverage, raise on failure so TaskIQ/Sentry sees a failed run, and enable
+it only after a reviewed manual baseline. Do not silently return
+`{"status": "failed"}` from an automated task.
+
+## Freshness monitoring recommendation (not implemented here)
+
+The existing 15-minute Prefect `Pipeline Result Freshness Monitor` can carry
+this check. It already has:
+
+- a read-only asyncpg transaction and statement timeout;
+- stable `problem_keys`, alert deduplication/repeat, recovery notification, and
+  Discord delivery;
+- the production Auto Trader database URL resolution.
+
+Add a database-side query that returns, at minimum:
+
+- active row count;
+- stale count using the exact gate expression
+  `COALESCE(toss_master_updated_at, updated_at)`;
+- missing effective as-of count;
+- active/NXT-eligible stale counts;
+- oldest/newest effective as-of and age;
+- Toss timestamp coverage separately, so unrelated `updated_at` changes cannot
+  mask a missing Toss refresh.
+
+Use PostgreSQL `clock_timestamp() - TIMESTAMPTZ` (or epoch seconds computed in
+SQL) and return timezone-aware ISO values. Do not pass a database-naive value
+through the monitor's current `_as_utc`, which labels naive datetimes as UTC
+and can create the known +9-hour skew.
+
+Suggested alerting:
+
+- warning at 24 hours since the last complete refresh;
+- critical at 36 hours, leaving 12 hours before the 48-hour gate;
+- immediate critical when any row is already gate-stale, coverage is
+  incomplete, or the query fails;
+- stable keys such as `nxt-tradable:freshness`,
+  `nxt-tradable:coverage`, and `nxt-tradable:read-failed`.
+
+Prefect is recommended for this read-only cross-pipeline observer, not for the
+application-owned write job.

--- a/scripts/sync_kr_symbol_universe.py
+++ b/scripts/sync_kr_symbol_universe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 
@@ -11,19 +12,34 @@ from app.jobs.kr_symbol_universe import run_kr_symbol_universe_sync
 logger = logging.getLogger(__name__)
 
 
-async def main() -> int:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync the KR symbol universe.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Download and diff the source snapshot without writing database rows.",
+    )
+    return parser.parse_args(argv)
+
+
+async def main(*, dry_run: bool = False) -> int:
     setup_logging_and_sentry(service_name="kr-symbol-universe-sync")
 
     async def _job() -> int:
-        result = await run_kr_symbol_universe_sync()
+        result = await run_kr_symbol_universe_sync(dry_run=dry_run)
         if result.get("status") != "completed":
             logger.error("KR symbol universe sync failed: %s", result)
             return 1
-        logger.info("KR symbol universe sync completed: %s", result)
+        logger.info(
+            "KR symbol universe %s completed: %s",
+            "dry-run" if dry_run else "sync",
+            result,
+        )
         return 0
 
     return await run_async_job(_job, process="sync_kr_symbol_universe")
 
 
 if __name__ == "__main__":
-    raise SystemExit(asyncio.run(main()))
+    args = parse_args()
+    raise SystemExit(asyncio.run(main(dry_run=args.dry_run)))

--- a/tests/test_kr_symbol_universe_sync.py
+++ b/tests/test_kr_symbol_universe_sync.py
@@ -264,6 +264,65 @@ async def test_sync_service_upsert_deactivate_and_idempotent(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_sync_service_dry_run_reports_diff_without_mutation(monkeypatch):
+    snapshot = {
+        "005930": kr_symbol_universe_service._UniverseRow(
+            symbol="005930",
+            name="삼성전자",
+            exchange="KOSPI",
+            nxt_eligible=True,
+        ),
+        "035420": kr_symbol_universe_service._UniverseRow(
+            symbol="035420",
+            name="NAVER",
+            exchange="KOSDAQ",
+            nxt_eligible=False,
+        ),
+    }
+    monkeypatch.setattr(
+        kr_symbol_universe_service,
+        "build_kr_symbol_universe_snapshot",
+        AsyncMock(return_value=snapshot),
+    )
+    db = _FakeSession(
+        [
+            KRSymbolUniverse(
+                symbol="005930",
+                name="OLD",
+                exchange="KOSPI",
+                nxt_eligible=False,
+                is_active=False,
+            ),
+            KRSymbolUniverse(
+                symbol="000001",
+                name="LEGACY",
+                exchange="KOSPI",
+                nxt_eligible=False,
+                is_active=True,
+            ),
+        ]
+    )
+
+    result = await kr_symbol_universe_service.sync_kr_symbol_universe(
+        db=db,
+        dry_run=True,
+    )
+
+    assert result == {
+        "total": 2,
+        "inserted": 1,
+        "updated": 1,
+        "deactivated": 1,
+    }
+    assert db.flushed is False
+    assert db.added == []
+    assert db.rows["005930"].name == "OLD"
+    assert db.rows["005930"].is_active is False
+    assert db.rows["005930"].nxt_eligible is False
+    assert db.rows["000001"].is_active is True
+
+
+@pytest.mark.asyncio
 async def test_sync_service_hard_fails_before_db_changes_on_snapshot_error(monkeypatch):
     db = _FakeSession([])
     monkeypatch.setattr(
@@ -508,6 +567,32 @@ async def test_script_main_returns_zero_on_success(monkeypatch):
     code = await sync_kr_symbol_universe.main()
 
     assert code == 0
+
+
+def test_script_parse_args_supports_read_only_dry_run() -> None:
+    args = sync_kr_symbol_universe.parse_args(["--dry-run"])
+
+    assert args.dry_run is True
+
+
+@pytest.mark.asyncio
+async def test_script_main_forwards_dry_run(monkeypatch):
+    import app.core.cli as _cli
+
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
+    runner = AsyncMock(
+        return_value={"status": "completed", "dry_run": True, "total": 1}
+    )
+    monkeypatch.setattr(
+        sync_kr_symbol_universe,
+        "run_kr_symbol_universe_sync",
+        runner,
+    )
+
+    code = await sync_kr_symbol_universe.main(dry_run=True)
+
+    assert code == 0
+    runner.assert_awaited_once_with(dry_run=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a SELECT-only --dry-run mode to the KR symbol-universe sync
- document the measured 2026-07-27 NXT freshness incident and source split
- provide the manual Toss freshness recovery command, failure gates, and post-commit proof
- recommend TaskIQ for the future write job and the existing Prefect monitor for read-only freshness alerts

## Key finding
scripts/sync_kr_symbol_universe.py refreshes KIS nxt_eligible data but does not update toss_master_updated_at or nxt_trading_suspended. The actual gate-freshness repair is the existing Toss symbol-master sync with --market kr --all --no-market-cap --commit, after an accepted dry-run.

## Verification
- live read-only KR universe dry-run: total=3919, inserted=0, updated=0, deactivated=0
- live Toss dry-run: requested=3919, matched=3919, missing=0
- pytest tests/test_kr_symbol_universe_sync.py: 27 passed
- NXT accessor/preflight/approval-window regression: 82 passed
- Ruff check and format check passed
- ty check passed
- production DB was queried only through read-only transactions; no sync commit was run

## Not included
- no production DB write
- no scheduler or plist change
- no approval-window policy change
- no broker or order mutation