### PR TITLE
policy: 급등 예외·single-share 전량판정·실익 하한

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -147,13 +147,14 @@ class SingleShareExitProposal(BaseModel):
 
 
 class SingleShareExitDecisionRule(BaseModel):
-    """Additive KR one-share profit-exit shadow policy.
+    """Deprecated general fallback retained as a KR shadow/replay policy.
 
     This rule intentionally has a distinct shape from the tiered trim rule:
-    ``sell.trim_preplace`` excludes one-share positions globally, while this
-    path can only classify shadow eligibility while ``proposal_enabled`` is
-    false. Its candidate metadata is manual-approval-only for a separately
-    authorized future activation; this schema never enables an order.
+    ``sell.trim_preplace`` now includes one-share positions for a full-exit
+    advisory review, while this legacy path can only classify the narrower KR
+    far-resistance shadow cohort while ``proposal_enabled`` is false. Its
+    candidate metadata is manual-approval-only for a separately authorized
+    future activation; this schema never enables an order.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/backtest/benchmarks/buy_and_hold.py
+++ b/backtest/benchmarks/buy_and_hold.py
@@ -41,12 +41,14 @@ class BuyAndHold:
         weight = 1.0 / len(symbols)
 
         for symbol in symbols:
-            signals.append(prepare.Signal(
-                symbol=symbol,
-                action="buy",
-                weight=weight,
-                reason="Buy and hold initial allocation",
-            ))
+            signals.append(
+                prepare.Signal(
+                    symbol=symbol,
+                    action="buy",
+                    weight=weight,
+                    reason="Buy and hold initial allocation",
+                )
+            )
 
         self._has_bought = True
         return signals

--- a/backtest/benchmarks/random_baseline.py
+++ b/backtest/benchmarks/random_baseline.py
@@ -57,20 +57,24 @@ class RandomBaseline:
         if can_buy and (not can_sell or self._rng.random() < 0.5):
             # Buy a random symbol
             symbol = self._rng.choice(can_buy)
-            signals.append(prepare.Signal(
-                symbol=symbol,
-                action="buy",
-                weight=0.15,  # Fixed position size
-                reason="Random buy signal",
-            ))
+            signals.append(
+                prepare.Signal(
+                    symbol=symbol,
+                    action="buy",
+                    weight=0.15,  # Fixed position size
+                    reason="Random buy signal",
+                )
+            )
         elif can_sell:
             # Sell a random held symbol
             symbol = self._rng.choice(can_sell)
-            signals.append(prepare.Signal(
-                symbol=symbol,
-                action="sell",
-                weight=1.0,  # Full sell
-                reason="Random sell signal",
-            ))
+            signals.append(
+                prepare.Signal(
+                    symbol=symbol,
+                    action="sell",
+                    weight=1.0,  # Full sell
+                    reason="Random sell signal",
+                )
+            )
 
         return signals

--- a/backtest/rsi/data_loader.py
+++ b/backtest/rsi/data_loader.py
@@ -80,18 +80,22 @@ def normalize_candles(raw: list[dict]) -> pd.DataFrame:
     datetime is KST ISO string "YYYY-MM-DDTHH:MM:SS".
     """
     if not raw:
-        return pd.DataFrame(columns=["datetime", "open", "high", "low", "close", "volume", "value"])
+        return pd.DataFrame(
+            columns=["datetime", "open", "high", "low", "close", "volume", "value"]
+        )
 
     df = pd.DataFrame(raw)
-    df = df.rename(columns={
-        "candle_date_time_kst": "datetime",
-        "opening_price": "open",
-        "high_price": "high",
-        "low_price": "low",
-        "trade_price": "close",
-        "candle_acc_trade_volume": "volume",
-        "candle_acc_trade_price": "value",
-    })
+    df = df.rename(
+        columns={
+            "candle_date_time_kst": "datetime",
+            "opening_price": "open",
+            "high_price": "high",
+            "low_price": "low",
+            "trade_price": "close",
+            "candle_acc_trade_volume": "volume",
+            "candle_acc_trade_price": "value",
+        }
+    )
     df = df[["datetime", "open", "high", "low", "close", "volume", "value"]]
     df = df.sort_values("datetime").reset_index(drop=True)
     return df
@@ -197,7 +201,9 @@ def fetch_all_universe(
     """
     # Get current top markets by 24h volume
     with httpx.Client(timeout=10) as client:
-        resp = client.get(f"{UPBIT_API_URL}/ticker/all", params={"quoteCurrencies": "KRW"})
+        resp = client.get(
+            f"{UPBIT_API_URL}/ticker/all", params={"quoteCurrencies": "KRW"}
+        )
         resp.raise_for_status()
         tickers = resp.json()
 

--- a/backtest/rsi/report.py
+++ b/backtest/rsi/report.py
@@ -18,7 +18,9 @@ def print_summary(metrics: Metrics, result: BacktestResult) -> None:
     print("  Strategy Parameters:")
     print(f"    Period:           {cfg.start} ~ {cfg.end}")
     print(f"    Universe:         top {cfg.top_n} by 24h trade value")
-    print(f"    Selection:        RSI-{cfg.rsi_period} ascending, max_rsi={cfg.max_rsi}")
+    print(
+        f"    Selection:        RSI-{cfg.rsi_period} ascending, max_rsi={cfg.max_rsi}"
+    )
     print(f"    Portfolio:        equal-weight top {cfg.pick_k}")
     print(f"    Rebalance:        every {cfg.rebalance_hours}h")
     print(f"    Fee:              {cfg.fee_rate * 100:.3f}%")
@@ -76,7 +78,9 @@ def export_monthly_returns(result: BacktestResult, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
     # Group equity by month
-    monthly: dict[str, tuple[float, float]] = {}  # "YYYY-MM" -> (first_equity, last_equity)
+    monthly: dict[
+        str, tuple[float, float]
+    ] = {}  # "YYYY-MM" -> (first_equity, last_equity)
     for ts, eq in zip(result.timestamps, result.equity_curve, strict=False):
         month = ts[:7]  # "YYYY-MM"
         if month not in monthly:

--- a/backtest/rsi/simulator.py
+++ b/backtest/rsi/simulator.py
@@ -42,7 +42,9 @@ def _build_price_index(all_data: dict[str, pd.DataFrame]) -> PriceIndex:
     """Pre-build a price lookup dict for O(1) access per (market, timestamp)."""
     index: PriceIndex = {}
     for market, df in all_data.items():
-        index[market] = dict(zip(df["datetime"], df["close"].astype(float), strict=False))
+        index[market] = dict(
+            zip(df["datetime"], df["close"].astype(float), strict=False)
+        )
     return index
 
 
@@ -97,14 +99,16 @@ def _execute_rebalance(
                 proceeds = qty * sell_price
                 fee = proceeds * config.fee_rate
                 portfolio.cash += proceeds - fee
-                trades.append({
-                    "datetime": timestamp,
-                    "market": market,
-                    "action": "sell",
-                    "quantity": qty,
-                    "price": sell_price,
-                    "fee": fee,
-                })
+                trades.append(
+                    {
+                        "datetime": timestamp,
+                        "market": market,
+                        "action": "sell",
+                        "quantity": qty,
+                        "price": sell_price,
+                        "fee": fee,
+                    }
+                )
             portfolio.positions.pop(market, None)
 
     # Phase 2: Rebalance existing + buy new
@@ -137,14 +141,16 @@ def _execute_rebalance(
             fee = cost * config.fee_rate
             portfolio.cash -= cost + fee
             portfolio.positions[market] = current_qty + qty
-            trades.append({
-                "datetime": timestamp,
-                "market": market,
-                "action": "buy",
-                "quantity": qty,
-                "price": buy_price,
-                "fee": fee,
-            })
+            trades.append(
+                {
+                    "datetime": timestamp,
+                    "market": market,
+                    "action": "buy",
+                    "quantity": qty,
+                    "price": buy_price,
+                    "fee": fee,
+                }
+            )
         elif diff_value < 0:
             # Sell excess
             sell_price = price * (1 - slippage_mult)
@@ -157,14 +163,16 @@ def _execute_rebalance(
             portfolio.positions[market] = current_qty - sell_qty
             if portfolio.positions[market] <= 0:
                 portfolio.positions.pop(market, None)
-            trades.append({
-                "datetime": timestamp,
-                "market": market,
-                "action": "sell",
-                "quantity": sell_qty,
-                "price": sell_price,
-                "fee": fee,
-            })
+            trades.append(
+                {
+                    "datetime": timestamp,
+                    "market": market,
+                    "action": "sell",
+                    "quantity": sell_qty,
+                    "price": sell_price,
+                    "fee": fee,
+                }
+            )
 
     return trades
 

--- a/backtest/rsi_backtest.py
+++ b/backtest/rsi_backtest.py
@@ -33,15 +33,42 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
     parser.add_argument("--end", required=True, help="End date YYYY-MM-DD")
-    parser.add_argument("--top-n", type=int, default=30, help="Universe size by 거래대금 (default: 30)")
-    parser.add_argument("--pick-k", type=int, default=5, help="Number of coins to hold (default: 5)")
-    parser.add_argument("--max-rsi", type=float, default=45.0, help="Max RSI for entry (default: 45)")
-    parser.add_argument("--rebalance-hours", type=int, default=24, help="Rebalance interval in hours (default: 24)")
-    parser.add_argument("--rsi-period", type=int, default=14, help="RSI lookback period (default: 14)")
-    parser.add_argument("--initial-capital", type=float, default=10_000_000, help="Initial capital in KRW (default: 10M)")
-    parser.add_argument("--prefetch", type=int, default=100, help="Number of markets to pre-fetch (default: 100)")
-    parser.add_argument("--export-dir", type=str, default=None, help="Directory for CSV exports")
-    parser.add_argument("--skip-fetch", action="store_true", help="Skip API fetch, use cached data only")
+    parser.add_argument(
+        "--top-n", type=int, default=30, help="Universe size by 거래대금 (default: 30)"
+    )
+    parser.add_argument(
+        "--pick-k", type=int, default=5, help="Number of coins to hold (default: 5)"
+    )
+    parser.add_argument(
+        "--max-rsi", type=float, default=45.0, help="Max RSI for entry (default: 45)"
+    )
+    parser.add_argument(
+        "--rebalance-hours",
+        type=int,
+        default=24,
+        help="Rebalance interval in hours (default: 24)",
+    )
+    parser.add_argument(
+        "--rsi-period", type=int, default=14, help="RSI lookback period (default: 14)"
+    )
+    parser.add_argument(
+        "--initial-capital",
+        type=float,
+        default=10_000_000,
+        help="Initial capital in KRW (default: 10M)",
+    )
+    parser.add_argument(
+        "--prefetch",
+        type=int,
+        default=100,
+        help="Number of markets to pre-fetch (default: 100)",
+    )
+    parser.add_argument(
+        "--export-dir", type=str, default=None, help="Directory for CSV exports"
+    )
+    parser.add_argument(
+        "--skip-fetch", action="store_true", help="Skip API fetch, use cached data only"
+    )
     return parser
 
 

--- a/blog/tests/test_candlestick.py
+++ b/blog/tests/test_candlestick.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+
 def make_large_ohlcv(count: int = 80) -> list[dict[str, int | str]]:
     return [
         {
@@ -21,16 +22,86 @@ def make_large_ohlcv(count: int = 80) -> list[dict[str, int | str]]:
 
 # Sample OHLCV data with varied bullish, bearish, and doji-like candles
 SAMPLE_OHLCV = [
-    {"date": "2026-03-01", "open": 50000, "high": 52000, "low": 49000, "close": 51500, "volume": 1_000_000},
-    {"date": "2026-03-02", "open": 51500, "high": 52500, "low": 51000, "close": 51200, "volume": 1_200_000},
-    {"date": "2026-03-03", "open": 51200, "high": 51800, "low": 50500, "close": 51700, "volume": 900_000},
-    {"date": "2026-03-04", "open": 51700, "high": 51750, "low": 50800, "close": 50800, "volume": 1_100_000},
-    {"date": "2026-03-05", "open": 50800, "high": 52000, "low": 50600, "close": 51900, "volume": 800_000},
-    {"date": "2026-03-06", "open": 51900, "high": 52200, "low": 51500, "close": 51550, "volume": 950_000},
-    {"date": "2026-03-07", "open": 51550, "high": 51600, "low": 50800, "close": 51000, "volume": 1_050_000},
-    {"date": "2026-03-08", "open": 51000, "high": 51400, "low": 50500, "close": 51400, "volume": 700_000},
-    {"date": "2026-03-09", "open": 51400, "high": 51500, "low": 50900, "close": 51400, "volume": 600_000},  # Doji-like
-    {"date": "2026-03-10", "open": 51400, "high": 52500, "low": 51200, "close": 52400, "volume": 1_500_000},
+    {
+        "date": "2026-03-01",
+        "open": 50000,
+        "high": 52000,
+        "low": 49000,
+        "close": 51500,
+        "volume": 1_000_000,
+    },
+    {
+        "date": "2026-03-02",
+        "open": 51500,
+        "high": 52500,
+        "low": 51000,
+        "close": 51200,
+        "volume": 1_200_000,
+    },
+    {
+        "date": "2026-03-03",
+        "open": 51200,
+        "high": 51800,
+        "low": 50500,
+        "close": 51700,
+        "volume": 900_000,
+    },
+    {
+        "date": "2026-03-04",
+        "open": 51700,
+        "high": 51750,
+        "low": 50800,
+        "close": 50800,
+        "volume": 1_100_000,
+    },
+    {
+        "date": "2026-03-05",
+        "open": 50800,
+        "high": 52000,
+        "low": 50600,
+        "close": 51900,
+        "volume": 800_000,
+    },
+    {
+        "date": "2026-03-06",
+        "open": 51900,
+        "high": 52200,
+        "low": 51500,
+        "close": 51550,
+        "volume": 950_000,
+    },
+    {
+        "date": "2026-03-07",
+        "open": 51550,
+        "high": 51600,
+        "low": 50800,
+        "close": 51000,
+        "volume": 1_050_000,
+    },
+    {
+        "date": "2026-03-08",
+        "open": 51000,
+        "high": 51400,
+        "low": 50500,
+        "close": 51400,
+        "volume": 700_000,
+    },
+    {
+        "date": "2026-03-09",
+        "open": 51400,
+        "high": 51500,
+        "low": 50900,
+        "close": 51400,
+        "volume": 600_000,
+    },  # Doji-like
+    {
+        "date": "2026-03-10",
+        "open": 51400,
+        "high": 52500,
+        "low": 51200,
+        "close": 52400,
+        "volume": 1_500_000,
+    },
 ]
 
 
@@ -38,34 +109,44 @@ class TestCandlestickChart:
     def test_basic_render(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV)
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV
+        )
         assert "<rect" in svg
         assert "<line" in svg
 
     def test_bullish_candle_uses_korean_red(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV)
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV
+        )
         # Korean bullish color: #ef5350
         assert "#ef5350" in svg
 
     def test_bearish_candle_uses_korean_blue(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV)
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV
+        )
         # Korean bearish color: #1565c0
         assert "#1565c0" in svg
 
     def test_volume_true_renders_volume_bars(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, volume=True)
-        assert "opacity=" in svg or "opacity=\"0.4\"" in svg
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, volume=True
+        )
+        assert "opacity=" in svg or 'opacity="0.4"' in svg
 
     def test_volume_false_omits_volume(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, volume=False)
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, volume=False
+        )
         # Should not have volume-specific opacity markers
         # Volume bars use opacity="0.4" so check we don't have that pattern
         # Just verify it renders without error
@@ -84,14 +165,18 @@ class TestCandlestickChart:
     def test_dark_theme_swaps_colors(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, theme="dark")
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, theme="dark"
+        )
         # Dark theme grid color
         assert "#333" in svg or "#aaa" in svg
 
     def test_light_theme_grid(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, theme="light")
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, theme="light"
+        )
         # Light theme grid color
         assert "#e0e0e0" in svg
 
@@ -105,7 +190,9 @@ class TestCandlestickChart:
     def test_max_candles_truncates_input(self) -> None:
         from blog.tools.stock.candlestick_chart import CandlestickChart
 
-        svg = CandlestickChart.create(x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, max_candles=5)
+        svg = CandlestickChart.create(
+            x=0, y=0, width=800, height=400, ohlcv=SAMPLE_OHLCV, max_candles=5
+        )
         assert isinstance(svg, str)
         # Should render without error with truncated data
 
@@ -217,4 +304,9 @@ class TestVolumeProfile:
             current_price=51000,
         )
         # Check for some kind of marker indicator
-        assert "marker" in svg.lower() or "arrow" in svg.lower() or "triangle" in svg.lower() or "<polygon" in svg
+        assert (
+            "marker" in svg.lower()
+            or "arrow" in svg.lower()
+            or "triangle" in svg.lower()
+            or "<polygon" in svg
+        )

--- a/blog/tests/test_screenshot.py
+++ b/blog/tests/test_screenshot.py
@@ -27,29 +27,84 @@ class TestImageComposer:
         # Create a small valid PNG file
         png_path = tmp_path / "test.png"
         # Minimal valid PNG: 1x1 pixel, transparent
-        png_data = bytes([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,  # PNG signature
-            0x00, 0x00, 0x00, 0x0D,  # IHDR length
-            0x49, 0x48, 0x44, 0x52,  # IHDR
-            0x00, 0x00, 0x00, 0x01,  # width: 1
-            0x00, 0x00, 0x00, 0x01,  # height: 1
-            0x08, 0x06, 0x00, 0x00, 0x00,  # 8-bit RGBA
-            0x1F, 0x15, 0xC4, 0x89,  # IHDR CRC
-            0x00, 0x00, 0x00, 0x0A,  # IDAT length
-            0x49, 0x44, 0x41, 0x54,  # IDAT
-            0x78, 0x9C, 0x63, 0x60, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01,
-            0x73, 0x75, 0x01, 0x18,  # IDAT data + CRC
-            0x00, 0x00, 0x00, 0x00,  # IEND length
-            0x49, 0x45, 0x4E, 0x44,  # IEND
-            0xAE, 0x42, 0x60, 0x82,  # IEND CRC
-        ])
+        png_data = bytes(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,  # PNG signature
+                0x00,
+                0x00,
+                0x00,
+                0x0D,  # IHDR length
+                0x49,
+                0x48,
+                0x44,
+                0x52,  # IHDR
+                0x00,
+                0x00,
+                0x00,
+                0x01,  # width: 1
+                0x00,
+                0x00,
+                0x00,
+                0x01,  # height: 1
+                0x08,
+                0x06,
+                0x00,
+                0x00,
+                0x00,  # 8-bit RGBA
+                0x1F,
+                0x15,
+                0xC4,
+                0x89,  # IHDR CRC
+                0x00,
+                0x00,
+                0x00,
+                0x0A,  # IDAT length
+                0x49,
+                0x44,
+                0x41,
+                0x54,  # IDAT
+                0x78,
+                0x9C,
+                0x63,
+                0x60,
+                0x00,
+                0x00,
+                0x00,
+                0x02,
+                0x00,
+                0x01,
+                0x73,
+                0x75,
+                0x01,
+                0x18,  # IDAT data + CRC
+                0x00,
+                0x00,
+                0x00,
+                0x00,  # IEND length
+                0x49,
+                0x45,
+                0x4E,
+                0x44,  # IEND
+                0xAE,
+                0x42,
+                0x60,
+                0x82,  # IEND CRC
+            ]
+        )
         png_path.write_bytes(png_data)
 
         result = ImageComposer.embed_png(png_path, x=10, y=20, width=100, height=100)
 
-        assert 'data:image/png;base64,' in result
+        assert "data:image/png;base64," in result
         # Verify it's valid base64
-        encoded = result.split('data:image/png;base64,')[1].split('"')[0]
+        encoded = result.split("data:image/png;base64,")[1].split('"')[0]
         decoded = base64.b64decode(encoded)
         assert decoded == png_data
 
@@ -109,7 +164,9 @@ class TestImageComposer:
 
         missing_path = tmp_path / "nonexistent.png"
 
-        result = ImageComposer.embed_png(missing_path, x=10, y=20, width=100, height=100)
+        result = ImageComposer.embed_png(
+            missing_path, x=10, y=20, width=100, height=100
+        )
 
         assert result.startswith("<!--")
         assert "not found" in result.lower() or "missing" in result.lower()
@@ -121,8 +178,12 @@ class TestImageComposer:
         screenshot_path = tmp_path / "screenshot.png"
         screenshot_path.write_bytes(b"\x89PNG\r\n\x1a\n")
 
-        indicator_fragment = '<rect x="880" y="95" width="480" height="350" fill="blue"/>'
-        support_resistance_fragment = '<rect x="60" y="480" width="1300" height="280" fill="green"/>'
+        indicator_fragment = (
+            '<rect x="880" y="95" width="480" height="350" fill="blue"/>'
+        )
+        support_resistance_fragment = (
+            '<rect x="60" y="480" width="1300" height="280" fill="green"/>'
+        )
 
         result = ImageComposer.create_hybrid_technical(
             screenshot_path=screenshot_path,
@@ -179,7 +240,9 @@ class TestScreenshotCaptureUnit:
             )
 
             capture = ScreenshotCapture()
-            capture._mcporter_call("playwright.browser_navigate", {"url": "https://example.com"})
+            capture._mcporter_call(
+                "playwright.browser_navigate", {"url": "https://example.com"}
+            )
 
             mock_run.assert_called_once()
             cmd = mock_run.call_args[0][0]
@@ -193,6 +256,7 @@ class TestScreenshotCaptureUnit:
             # Find --args index and verify JSON follows
             args_idx = cmd.index("--args")
             import json
+
             params = json.loads(cmd[args_idx + 1])
             assert params["url"] == "https://example.com"
 
@@ -237,7 +301,10 @@ class TestScreenshotCaptureUnit:
                 capture._mcporter_call("stealth_browser.spawn_browser")
 
             assert "stealth_browser.spawn_browser" in str(exc_info.value)
-            assert "unknown server" in str(exc_info.value).lower() or "unavailable" in str(exc_info.value).lower()
+            assert (
+                "unknown server" in str(exc_info.value).lower()
+                or "unavailable" in str(exc_info.value).lower()
+            )
 
     def test_ensure_browser_marks_session_ready_once(self) -> None:
         """_ensure_browser should only initialize the session once."""
@@ -302,7 +369,9 @@ class TestScreenshotCaptureUnit:
 
         assert result == png_data
 
-    def test_capture_tradingview_uses_playwright_schema_calls(self, tmp_path: Path) -> None:
+    def test_capture_tradingview_uses_playwright_schema_calls(
+        self, tmp_path: Path
+    ) -> None:
         """capture_tradingview should use browser_navigate/resize/wait/take_screenshot."""
         from blog.tools.screenshot_capture import ScreenshotCapture
 
@@ -360,7 +429,9 @@ class TestScreenshotCaptureIntegration:
         capture = ScreenshotCapture(output_dir=tmp_path)
 
         try:
-            path = capture.capture_tradingview("BINANCE:BTCUSDT", interval="D", theme="dark")
+            path = capture.capture_tradingview(
+                "BINANCE:BTCUSDT", interval="D", theme="dark"
+            )
 
             assert path.exists()
             assert path.stat().st_size > 1000  # Should be a real PNG, not empty

--- a/blog/tests/test_stock_preset.py
+++ b/blog/tests/test_stock_preset.py
@@ -112,17 +112,77 @@ class TestStockAnalysisPresetHybridMode:
         from blog.tools.presets.stock_analysis import StockAnalysisPreset
 
         # Create a minimal valid PNG file
-        png_data = bytes([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
-            0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
-            0x54, 0x78, 0x9C, 0x63, 0x60, 0x00, 0x00, 0x00,
-            0x02, 0x00, 0x01, 0x73, 0x75, 0x01, 0x18, 0x00,
-            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
-            0x42, 0x60, 0x82,
-        ])
+        png_data = bytes(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+                0x00,
+                0x00,
+                0x00,
+                0x0D,
+                0x49,
+                0x48,
+                0x44,
+                0x52,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x08,
+                0x06,
+                0x00,
+                0x00,
+                0x00,
+                0x1F,
+                0x15,
+                0xC4,
+                0x89,
+                0x00,
+                0x00,
+                0x00,
+                0x0A,
+                0x49,
+                0x44,
+                0x41,
+                0x54,
+                0x78,
+                0x9C,
+                0x63,
+                0x60,
+                0x00,
+                0x00,
+                0x00,
+                0x02,
+                0x00,
+                0x01,
+                0x73,
+                0x75,
+                0x01,
+                0x18,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x49,
+                0x45,
+                0x4E,
+                0x44,
+                0xAE,
+                0x42,
+                0x60,
+                0x82,
+            ]
+        )
         screenshot_path = tmp_path / "test_screenshot.png"
         screenshot_path.write_bytes(png_data)
 
@@ -130,7 +190,10 @@ class TestStockAnalysisPresetHybridMode:
         output_dir.mkdir()
 
         preset = StockAnalysisPreset(
-            "005930", SAMPLE_DATA, output_dir=output_dir, screenshot_path=screenshot_path
+            "005930",
+            SAMPLE_DATA,
+            output_dir=output_dir,
+            screenshot_path=screenshot_path,
         )
         paths = preset.generate_svgs()
         tech = next(p for p in paths if "technical" in p.stem)
@@ -141,23 +204,85 @@ class TestStockAnalysisPresetHybridMode:
         # Should still contain indicator dashboard
         assert "RSI" in content
         # Should still contain support/resistance
-        assert "지지선" in content or "저항선" in content or "support" in content.lower()
+        assert (
+            "지지선" in content or "저항선" in content or "support" in content.lower()
+        )
 
     def test_hybrid_mode_keeps_indicator_and_sr_fragments(self, tmp_path: Path) -> None:
         """Hybrid mode should include both indicator and support/resistance fragments."""
         from blog.tools.presets.stock_analysis import StockAnalysisPreset
 
-        png_data = bytes([
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
-            0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
-            0x54, 0x78, 0x9C, 0x63, 0x60, 0x00, 0x00, 0x00,
-            0x02, 0x00, 0x01, 0x73, 0x75, 0x01, 0x18, 0x00,
-            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
-            0x42, 0x60, 0x82,
-        ])
+        png_data = bytes(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+                0x00,
+                0x00,
+                0x00,
+                0x0D,
+                0x49,
+                0x48,
+                0x44,
+                0x52,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x08,
+                0x06,
+                0x00,
+                0x00,
+                0x00,
+                0x1F,
+                0x15,
+                0xC4,
+                0x89,
+                0x00,
+                0x00,
+                0x00,
+                0x0A,
+                0x49,
+                0x44,
+                0x41,
+                0x54,
+                0x78,
+                0x9C,
+                0x63,
+                0x60,
+                0x00,
+                0x00,
+                0x00,
+                0x02,
+                0x00,
+                0x01,
+                0x73,
+                0x75,
+                0x01,
+                0x18,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x49,
+                0x45,
+                0x4E,
+                0x44,
+                0xAE,
+                0x42,
+                0x60,
+                0x82,
+            ]
+        )
         screenshot_path = tmp_path / "test_screenshot.png"
         screenshot_path.write_bytes(png_data)
 
@@ -165,7 +290,10 @@ class TestStockAnalysisPresetHybridMode:
         output_dir.mkdir()
 
         preset = StockAnalysisPreset(
-            "005930", SAMPLE_DATA, output_dir=output_dir, screenshot_path=screenshot_path
+            "005930",
+            SAMPLE_DATA,
+            output_dir=output_dir,
+            screenshot_path=screenshot_path,
         )
         paths = preset.generate_svgs()
         tech = next(p for p in paths if "technical" in p.stem)

--- a/blog/tests/test_visual_polish.py
+++ b/blog/tests/test_visual_polish.py
@@ -199,7 +199,9 @@ class TestThumbnailWithThemes:
         from blog.tools.components.base import THEMES
         from blog.tools.components.thumbnail import ThumbnailTemplate
 
-        svg = ThumbnailTemplate.create(title_line1="Test", title_line2="Accent", theme="terminal")
+        svg = ThumbnailTemplate.create(
+            title_line1="Test", title_line2="Accent", theme="terminal"
+        )
         assert THEMES["terminal"].accent in svg
 
     def test_thumbnail_explicit_accent_overrides_theme_accent(self) -> None:

--- a/blog/tools/components/icons.py
+++ b/blog/tools/components/icons.py
@@ -93,12 +93,8 @@ ICON_PATHS: dict[str, tuple[str, ...]] = {
         "M21 12V7H5a2 2 0 0 1-2-2 2 2 0 0 1 2-2h14v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7",
     ),
     # Shield/Security icons
-    "shield": (
-        "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",
-    ),
-    "zap": (
-        "M13 2 3 14h9l-1 8 10-12h-9l1-8z",
-    ),
+    "shield": ("M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",),
+    "zap": ("M13 2 3 14h9l-1 8 10-12h-9l1-8z",),
     # Alert/Status icons
     "alert-triangle": (
         "M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z",
@@ -194,11 +190,7 @@ class Icon:
 
         paths_svg = "\n".join(path_elements)
 
-        return (
-            f'<g transform="translate({x}, {y}) scale({scale})">'
-            f'{paths_svg}'
-            f'</g>'
-        )
+        return f'<g transform="translate({x}, {y}) scale({scale})">{paths_svg}</g>'
 
     @staticmethod
     def exists(name: str) -> bool:

--- a/blog/tools/components/thumbnail.py
+++ b/blog/tools/components/thumbnail.py
@@ -14,7 +14,9 @@ class ThumbnailTemplate:
     """Blog thumbnail template — 1200×630 standard layout."""
 
     @staticmethod
-    def _render_icon_cell(icon_name_or_emoji: str, label: str, color: str, x: int) -> str:
+    def _render_icon_cell(
+        icon_name_or_emoji: str, label: str, color: str, x: int
+    ) -> str:
         """Render a single icon cell with Lucide icon or emoji.
 
         Args:
@@ -33,7 +35,9 @@ class ThumbnailTemplate:
         # Check if it's a Lucide icon or emoji/text
         if Icon.exists(icon_name_or_emoji):
             # Lucide icon - render as path
-            icon_svg = Icon.render(icon_name_or_emoji, x + 26, y=26, size=48, color="#ffffff")
+            icon_svg = Icon.render(
+                icon_name_or_emoji, x + 26, y=26, size=48, color="#ffffff"
+            )
             parts.append(f"        {icon_svg}")
         else:
             # Emoji or text
@@ -134,7 +138,12 @@ class ThumbnailTemplate:
 
             for i, (icon_name_or_emoji, label, color) in enumerate(icons):
                 x = i * 130
-                svg += ThumbnailTemplate._render_icon_cell(icon_name_or_emoji, label, color, x) + "\n"
+                svg += (
+                    ThumbnailTemplate._render_icon_cell(
+                        icon_name_or_emoji, label, color, x
+                    )
+                    + "\n"
+                )
             svg += "    </g>\n"
 
         if tech_stack:
@@ -174,7 +183,7 @@ class ThumbnailTemplate:
         """Candlestick chart pattern."""
         # Fixed positions for candlesticks (deterministic, not random)
         candles = [
-            (100, 50, 30, 80, "#ff5252"),   # bearish
+            (100, 50, 30, 80, "#ff5252"),  # bearish
             (200, 100, 25, 60, "#4CAF50"),  # bullish
             (300, 80, 35, 70, "#ff5252"),
             (400, 120, 20, 50, "#4CAF50"),
@@ -187,7 +196,7 @@ class ThumbnailTemplate:
             (1100, 75, 30, 70, "#4CAF50"),
         ]
 
-        parts = ['    <!-- Background pattern: candlesticks -->']
+        parts = ["    <!-- Background pattern: candlesticks -->"]
         for x, y, w, h, color in candles:
             parts.append(
                 f'    <rect x="{x}" y="{y}" width="{w}" height="{h}" '
@@ -199,7 +208,7 @@ class ThumbnailTemplate:
     @staticmethod
     def _pattern_grid(width: int, height: int) -> str:
         """Grid pattern."""
-        parts = ['    <!-- Background pattern: grid -->']
+        parts = ["    <!-- Background pattern: grid -->"]
         # Vertical lines
         for x in range(100, width, 100):
             parts.append(
@@ -218,7 +227,7 @@ class ThumbnailTemplate:
     @staticmethod
     def _pattern_dots(width: int, height: int) -> str:
         """Dots pattern."""
-        parts = ['    <!-- Background pattern: dots -->']
+        parts = ["    <!-- Background pattern: dots -->"]
         # Fixed grid of dots
         for x in range(50, width, 80):
             for y in range(50, height, 80):
@@ -232,12 +241,12 @@ class ThumbnailTemplate:
     @staticmethod
     def _pattern_wave(width: int, height: int) -> str:
         """Wave pattern."""
-        parts = ['    <!-- Background pattern: wave -->']
+        parts = ["    <!-- Background pattern: wave -->"]
         # Simple wave lines
         for offset in range(0, 200, 40):
             parts.append(
-                f'    <path d="M0,{150 + offset} Q{width//4},{100 + offset} '
-                f'{width//2},{150 + offset} T{width},{150 + offset}" '
+                f'    <path d="M0,{150 + offset} Q{width // 4},{100 + offset} '
+                f'{width // 2},{150 + offset} T{width},{150 + offset}" '
                 f'fill="none" stroke="#ffffff" stroke-width="2" opacity="0.06"/>'
             )
         parts.append("")

--- a/blog/tools/image_composer.py
+++ b/blog/tools/image_composer.py
@@ -65,21 +65,23 @@ class ImageComposer:
         ]
 
         if shadow:
-            svg_parts.extend([
-                '    <defs>',
-                '        <filter id="dropShadow" x="-20%" y="-20%" width="140%" height="140%">',
-                '            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>',
-                '            <feOffset dx="2" dy="2" result="offsetblur"/>',
-                '            <feComponentTransfer>',
-                '                <feFuncA type="linear" slope="0.3"/>',
-                '            </feComponentTransfer>',
-                '            <feMerge>',
-                '                <feMergeNode/>',
-                '                <feMergeNode in="SourceGraphic"/>',
-                '            </feMerge>',
-                '        </filter>',
-                '    </defs>',
-            ])
+            svg_parts.extend(
+                [
+                    "    <defs>",
+                    '        <filter id="dropShadow" x="-20%" y="-20%" width="140%" height="140%">',
+                    '            <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>',
+                    '            <feOffset dx="2" dy="2" result="offsetblur"/>',
+                    "            <feComponentTransfer>",
+                    '                <feFuncA type="linear" slope="0.3"/>',
+                    "            </feComponentTransfer>",
+                    "            <feMerge>",
+                    "                <feMergeNode/>",
+                    '                <feMergeNode in="SourceGraphic"/>',
+                    "            </feMerge>",
+                    "        </filter>",
+                    "    </defs>",
+                ]
+            )
 
         svg_parts.append(
             f'    <image x="{x}" y="{y}" width="{width}" height="{height}" '
@@ -132,7 +134,9 @@ class ImageComposer:
 
         svg = SVGComponent.header(width, height)
         svg += SVGComponent.background(width, height, theme=theme)
-        svg += SVGComponent.title(width, f"{company_name} — 기술적 분석", fill="#e0e1dd")
+        svg += SVGComponent.title(
+            width, f"{company_name} — 기술적 분석", fill="#e0e1dd"
+        )
 
         # Embed the screenshot
         svg += ImageComposer.embed_png(

--- a/blog/tools/screenshot_capture.py
+++ b/blog/tools/screenshot_capture.py
@@ -172,7 +172,9 @@ class ScreenshotCapture:
         theme: str = "dark",
     ) -> Path:
         """Capture an Upbit chart screenshot."""
-        del theme  # Current Playwright capture path does not theme Upbit pages directly.
+        del (
+            theme
+        )  # Current Playwright capture path does not theme Upbit pages directly.
 
         url = f"https://upbit.com/exchange?code=CRIX.UPBIT.{market}"
         output_path = (

--- a/blog/tools/stock/candlestick_chart.py
+++ b/blog/tools/stock/candlestick_chart.py
@@ -120,18 +120,33 @@ class CandlestickChart:
         if bollinger and "upper" in bollinger and "lower" in bollinger:
             upper = bollinger["upper"]
             lower = bollinger["lower"]
-            visible_upper = upper[-visible_count:] if len(upper) >= visible_count else upper
-            visible_lower = lower[-visible_count:] if len(lower) >= visible_count else lower
-            if len(visible_upper) == visible_count and len(visible_lower) == visible_count:
+            visible_upper = (
+                upper[-visible_count:] if len(upper) >= visible_count else upper
+            )
+            visible_lower = (
+                lower[-visible_count:] if len(lower) >= visible_count else lower
+            )
+            if (
+                len(visible_upper) == visible_count
+                and len(visible_lower) == visible_count
+            ):
                 points = []
                 # Upper band (left to right)
                 for i, val in enumerate(visible_upper):
-                    px = x + (i / (visible_count - 1)) * width if visible_count > 1 else x
+                    px = (
+                        x + (i / (visible_count - 1)) * width
+                        if visible_count > 1
+                        else x
+                    )
                     py = price_to_y(val)
                     points.append(f"{px},{py}")
                 # Lower band (right to left)
                 for i in range(len(visible_lower) - 1, -1, -1):
-                    px = x + (i / (visible_count - 1)) * width if visible_count > 1 else x
+                    px = (
+                        x + (i / (visible_count - 1)) * width
+                        if visible_count > 1
+                        else x
+                    )
                     py = price_to_y(visible_lower[i])
                     points.append(f"{px},{py}")
 
@@ -144,11 +159,19 @@ class CandlestickChart:
                 # Middle band (dashed line)
                 if "middle" in bollinger:
                     middle = bollinger["middle"]
-                    visible_middle = middle[-visible_count:] if len(middle) >= visible_count else middle
+                    visible_middle = (
+                        middle[-visible_count:]
+                        if len(middle) >= visible_count
+                        else middle
+                    )
                     if len(visible_middle) == visible_count:
                         middle_points = []
                         for i, val in enumerate(visible_middle):
-                            px = x + (i / (visible_count - 1)) * width if visible_count > 1 else x
+                            px = (
+                                x + (i / (visible_count - 1)) * width
+                                if visible_count > 1
+                                else x
+                            )
                             py = price_to_y(val)
                             middle_points.append(f"{px},{py}")
                         parts.append(
@@ -205,7 +228,10 @@ class CandlestickChart:
             wick_y1 = price_to_y(high_p)
             wick_y2 = price_to_y(low_p)
             candle_svg_elements.append(
-                (0, f'    <line x1="{cx}" y1="{wick_y1}" x2="{cx}" y2="{wick_y2}" stroke="{color}" stroke-width="1"/>')
+                (
+                    0,
+                    f'    <line x1="{cx}" y1="{wick_y1}" x2="{cx}" y2="{wick_y2}" stroke="{color}" stroke-width="1"/>',
+                )
             )
 
             # Body
@@ -216,7 +242,10 @@ class CandlestickChart:
 
             candle_x = cx - candle_width / 2
             candle_svg_elements.append(
-                (1, f'    <rect x="{candle_x}" y="{body_top}" width="{candle_width}" height="{body_height}" fill="{color}"/>')
+                (
+                    1,
+                    f'    <rect x="{candle_x}" y="{body_top}" width="{candle_width}" height="{body_height}" fill="{color}"/>',
+                )
             )
 
             # Volume bar
@@ -224,7 +253,10 @@ class CandlestickChart:
                 vol_h = volume_to_h(vol)
                 vol_y = y + height - vol_h
                 candle_svg_elements.append(
-                    (0, f'    <rect x="{candle_x}" y="{vol_y}" width="{candle_width}" height="{vol_h}" fill="{color}" opacity="0.4"/>')
+                    (
+                        0,
+                        f'    <rect x="{candle_x}" y="{vol_y}" width="{candle_width}" height="{vol_h}" fill="{color}" opacity="0.4"/>',
+                    )
                 )
 
         # Sort by z-index and add to parts
@@ -235,11 +267,17 @@ class CandlestickChart:
         # Draw EMA lines (over candles)
         if ema_values:
             for idx, (_name, values) in enumerate(ema_values.items()):
-                visible_values = values[-visible_count:] if len(values) >= visible_count else values
+                visible_values = (
+                    values[-visible_count:] if len(values) >= visible_count else values
+                )
                 if len(visible_values) == visible_count:
                     ema_points = []
                     for i, val in enumerate(visible_values):
-                        px = x + (i / (visible_count - 1)) * width if visible_count > 1 else x
+                        px = (
+                            x + (i / (visible_count - 1)) * width
+                            if visible_count > 1
+                            else x
+                        )
                         py = price_to_y(val)
                         ema_points.append(f"{px},{py}")
 

--- a/blog/tools/stock/volume_profile.py
+++ b/blog/tools/stock/volume_profile.py
@@ -35,14 +35,14 @@ class VolumeProfile:
             SVG fragment string (no <svg> wrapper).
         """
         if not ohlcv:
-            return f'    <!-- Empty volume profile at ({x}, {y}) -->\n'
+            return f"    <!-- Empty volume profile at ({x}, {y}) -->\n"
 
         # Filter rows with required keys
         required_keys = {"open", "high", "low", "close", "volume"}
         rows = [row for row in ohlcv if required_keys <= row.keys()]
 
         if not rows:
-            return '    <!-- No valid OHLCV data for volume profile -->\n'
+            return "    <!-- No valid OHLCV data for volume profile -->\n"
 
         # Calculate price range from all rows
         global_min = min(row["low"] for row in rows)
@@ -96,7 +96,9 @@ class VolumeProfile:
 
         # Draw current price marker (arrow/triangle)
         if current_price is not None and global_min <= current_price <= global_max:
-            marker_y = y + height - ((current_price - global_min) / price_range * height)
+            marker_y = (
+                y + height - ((current_price - global_min) / price_range * height)
+            )
             marker_size = 6
 
             # Triangle pointing right
@@ -107,8 +109,7 @@ class VolumeProfile:
             ]
 
             parts.append(
-                f'    <polygon points="{" ".join(triangle_points)}" '
-                f'fill="#FF5722"/>'
+                f'    <polygon points="{" ".join(triangle_points)}" fill="#FF5722"/>'
             )
 
             # Price label

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-25.1"
-captured_as_of: "2026-07-25"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25"
+version: "2026-07-27.1"
+captured_as_of: "2026-07-27"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27"
 
 authority:
   scope: judgment_policy_only
@@ -133,6 +133,29 @@ thresholds:
     value: 50
     unit: percent
     semantics: upside at/above which WATCH (let-it-run) is allowed
+  sell.momentum_spike_change_pct_min:
+    lanes: [sell]
+    value: 10
+    unit: percent
+    semantics: >-
+      D2 advisory threshold for a KR/US equity momentum-spike day or premarket
+      session; applicability and evidence requirements are defined by the
+      momentum_spike_profit_ladder tier
+  sell.single_share_profit_pct_min:
+    lanes: [sell]
+    value: 8
+    unit: percent
+    semantics: >-
+      D5 advisory profit threshold at which a one-share KR/US equity position
+      may be reviewed for a full-position resistance exit; never a partial trim
+  sell.trim_min_expected_net_realized_gain_krw:
+    lanes: [sell]
+    value: 5000
+    unit: krw_equivalent
+    semantics: >-
+      D7 advisory minimum expected net realized gain after estimated fees and
+      taxes for a trim; US gains use the decision snapshot FX rate, and a trim
+      below this threshold becomes WATCH instead of inventing a session-local gate
   screen.rsi_max:
     lanes: [discovery]
     value: 45
@@ -154,11 +177,44 @@ decision_rules:
     lanes: [sell]
     semantics: >-
       Tiers are evaluated in declared priority order and the first match wins.
-      profit_realization is resistance-distance-independent; global exclusions
-      apply to every tier. When resistance-near favors PLACE but upside-rich
-      would otherwise allow WATCH, resistance proximity can pre-place only a
-      small trim; upside richness limits size, not eligibility.
+      ADVISORY ONLY. de_minimis_trim_watch prevents session-local benefit gates.
+      A one-share equity position is assessed for a full exit, never a
+      pseudo-partial trim. momentum_spike_profit_ladder exempts only its matched
+      spike candidate from the RSI gate and remains profit-zone-only.
+      profit_realization is resistance-distance-independent. When
+      resistance-near favors PLACE but upside-rich would otherwise allow WATCH,
+      resistance proximity can pre-place only a small trim; upside richness
+      limits size, not eligibility.
     tiers:
+      - id: de_minimis_trim_watch
+        conditions:
+          markets: [kr, us, crypto]
+          trim_candidate: true
+          expected_net_realized_gain_krw_below_policy_key: sell.trim_min_expected_net_realized_gain_krw
+        action: register_watch_instead_of_trim
+        sizing: no_preplaced_trim
+      - id: single_share_full_exit_review
+        conditions:
+          markets: [kr, us]
+          total_quantity_eq: 1
+          profit_pct_min_policy_key: sell.single_share_profit_pct_min
+          resistance_reference_required: true
+          disposition_policy_key: phase25.10_single_share_exit_choice
+        action: advise_full_quantity_resistance_exit_or_trailing_verdict
+        sizing: full_position
+      - id: momentum_spike_profit_ladder
+        conditions:
+          markets: [kr, us]
+          position_quantity_min: 2
+          session_change_basis: [regular_day, premarket]
+          session_change_pct_min_policy_key: sell.momentum_spike_change_pct_min
+          rsi_gate_exempt: true
+          required_thesis_evidence: [catalyst_basis, flow_basis]
+          resistance_levels_required: [resistance_1, resistance_2]
+          average_cost_multiple_min_exclusive: 1.0
+          ladder_total_position_pct_max: 33.3333
+        action: preplace_resistance_1_2_small_trim_ladder
+        sizing: at_most_one_third_position
       - id: profit_realization
         conditions:
           # Fable governance advisory Q3-#4 Phase 1 seed; follow-up sell-policy
@@ -186,22 +242,28 @@ decision_rules:
         action: register_watch
         sizing: no_preplaced_trim
     tie_breaks:
-      tier_priority: "profit_realization > rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
+      tier_priority: "de_minimis_trim_watch > single_share_full_exit_review > momentum_spike_profit_ladder > profit_realization > rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
       multiple_tiers_matched: first_matching_tier_wins
       sell.upside_place_max_pct: size_limit_only
+      momentum_spike_rsi_exception: matched_tier_only
+      momentum_spike_profit_zone: average_cost_multiple_strictly_above_1
+      momentum_spike_integer_rounding: floor_without_exceeding_one_third_or_watch
+      single_share_disposition: full_static_target_or_full_trailing_verdict_never_partial
+      minimum_benefit_boundary: at_or_above_threshold_may_trim_below_threshold_watch
     exclusions:
-      - single_share_position
       - no_resistance_reference
       - composite_gates
   sell.single_share_exit:
     lanes: [sell]
     semantics: >-
-      Additive shadow-only fallback review for a profitable KR account lot when
-      complete KIS+Toss evidence proves the symbol-wide routable sellable
-      quantity is exactly one. This rule is evaluated separately from
-      sell.trim_preplace. It cannot create, approve, or execute a proposal while
-      proposal_enabled is false. A loss state remains ineligible here and
-      belongs exclusively to the existing loss_cut path.
+      DEPRECATED AS THE GENERAL SINGLE-SHARE EXCLUSION/FALLBACK. Retained without
+      key deletion or activation change for historical KR KIS+Toss shadow and
+      replay evidence only. The replacement advisory path is
+      sell.trim_preplace.single_share_full_exit_review, with disposition by
+      phase25.10_single_share_exit_choice. This shadow rule cannot narrow that
+      general advisory eligibility and cannot create, approve, or execute a
+      proposal while proposal_enabled is false. A loss state remains ineligible
+      here and belongs exclusively to the existing loss_cut path.
     activation_state: shadow
     proposal_enabled: false
     scope:
@@ -249,10 +311,15 @@ decision_rules:
     operator_approval_required: true
     recalibration_note: >-
       Fable governance advisory Q3-#4 Phase 1 seed; follow-up sell-policy
-      research must recalibrate this initial threshold. The single-share
-      profit and far-resistance thresholds inherit that provisional status.
-      Shadow evidence must be adversarially validated before proposal_enabled
-      can be considered separately by the operator.
+      research must recalibrate this initial threshold. Deprecated as a general
+      fallback by D5 on 2026-07-27 and retained only for the existing KR
+      far-resistance shadow/replay cohort. General one-share advisory eligibility
+      is replaced by
+      sell.trim_preplace.single_share_full_exit_review and its 8% threshold
+      sell.single_share_profit_pct_min; phase25.10_single_share_exit_choice owns
+      the full-static-target versus full-trailing verdict. Shadow evidence must
+      still be adversarially validated before proposal_enabled can be considered
+      separately by the operator.
 
   # GPT Pro trading retrospective Phase 2.5 (received 2026-07-25).
   # Rules 01-14 are advisory policy data only. They do not activate proposals,
@@ -608,9 +675,21 @@ decision_rules:
     semantics: >-
       ADVISORY ONLY. An equity position of exactly one share cannot use a
       pseudo-partial exit: choose a full static target or a full trailing
-      verdict. Crypto is excluded because the recommendation is share-specific.
-      Existing loss-cut and approval guards remain unchanged.
+      verdict. This rule owns disposition after
+      sell.trim_preplace.single_share_full_exit_review includes the position in
+      the funnel. At or above sell.single_share_profit_pct_min, a full-position
+      resistance exit may be preplaced or proposed; this does not force an exit.
+      Crypto is excluded because the recommendation is share-specific. Existing
+      loss-cut and approval guards remain unchanged.
     tiers:
+      - id: one_share_profitable_resistance_exit
+        conditions:
+          markets: [kr, us]
+          total_quantity_eq: 1
+          profit_pct_min_policy_key: sell.single_share_profit_pct_min
+          resistance_reference_required: true
+        action: advise_full_quantity_resistance_exit_or_proposal
+        sizing: full_position
       - id: one_share_hard_exit
         conditions:
           markets: [kr, us]
@@ -648,6 +727,7 @@ decision_rules:
         action: advise_static_trim_then_trail_remainder
         sizing: reserved_quantity_without_overlap
     tie_breaks:
+      profitable_resistance_priority: full_exit_review_before_role_or_trail_choice
       one_share_choice: hard_target_or_trail_not_both
       collision_sequence: cancel_terminal_before_replacement_submit
     exclusions: [crypto_fractional_quantity, loss_state_uses_existing_loss_cut_path]

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -4,7 +4,7 @@
 # Repo is public; exposing these values is an accepted decision.
 version: "2026-07-27.1"
 captured_as_of: "2026-07-27"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27"
 
 authority:
   scope: judgment_policy_only
@@ -140,14 +140,23 @@ thresholds:
     semantics: >-
       D2 advisory threshold for a KR/US equity momentum-spike day or premarket
       session; applicability and evidence requirements are defined by the
-      momentum_spike_profit_ladder tier
+      momentum_spike_profit_ladder tier. TRANSITIONAL PATCH: posture-v1
+      (ROB-1090) §11 retires the RSI hard gate in favor of continuous signal
+      multipliers, so this tier is absorbed after posture shadow completion.
+      Parameter status: 측정으로 확정할 가설; frozen at 10 for this policy
+      version, not adjustable by a runtime session, and changeable only by an
+      operator-reviewed policy PR after measurement
   sell.single_share_profit_pct_min:
     lanes: [sell]
     value: 8
     unit: percent
     semantics: >-
       D5 advisory profit threshold at which a one-share KR/US equity position
-      may be reviewed for a full-position resistance exit; never a partial trim
+      may be reviewed for a full-position resistance exit; never a partial trim.
+      posture-v1 (ROB-1090) carries this full-position verdict forward.
+      Parameter status: 측정으로 확정할 가설; frozen at 8 for this policy
+      version, not adjustable by a runtime session, and changeable only by an
+      operator-reviewed policy PR after measurement
   sell.trim_min_expected_net_realized_gain_krw:
     lanes: [sell]
     value: 5000
@@ -155,7 +164,12 @@ thresholds:
     semantics: >-
       D7 advisory minimum expected net realized gain after estimated fees and
       taxes for a trim; US gains use the decision snapshot FX rate, and a trim
-      below this threshold becomes WATCH instead of inventing a session-local gate
+      below this threshold becomes WATCH instead of inventing a session-local
+      gate. posture-v1 (ROB-1090) carries this forward as
+      sell.net_realization_floor. Parameter status: 측정으로 확정할 가설;
+      frozen at 5000 KRW equivalent for this policy version, not adjustable by
+      a runtime session, and changeable only by an operator-reviewed policy PR
+      after measurement
   screen.rsi_max:
     lanes: [discovery]
     value: 45

--- a/kis_websocket_monitor.py
+++ b/kis_websocket_monitor.py
@@ -75,8 +75,7 @@ class KISWebSocketMonitor:
         account_mode = "kis_mock" if is_mock else "kis_live"
 
         logger.info(
-            "Initializing KIS WebSocket: account_mode=%s mock_mode=%s "
-            "ws_url=%s",
+            "Initializing KIS WebSocket: account_mode=%s mock_mode=%s ws_url=%s",
             account_mode,
             is_mock,
             "ws://ops.koreainvestment.com:31000/tryitout"

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -44,11 +44,18 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     out = await get_trading_policy(market="kr", lane="sell")
     assert out["success"] is True
     rule = out["decision_rules"]["sell.trim_preplace"]
-    assert rule["tiers"][0]["id"] == "profit_realization"
-    assert rule["tiers"][0]["conditions"]["profit_pct_min"] == 8
-    assert rule["tiers"][0]["action"] == "preplace_small_trim_ladder"
-    assert rule["tiers"][2]["conditions"]["resistance_near_pct_max"] == 2
-    assert rule["tiers"][3]["action"] == "register_watch"
+    tiers = {tier["id"]: tier for tier in rule["tiers"]}
+    assert tiers["de_minimis_trim_watch"]["action"] == "register_watch_instead_of_trim"
+    assert tiers["single_share_full_exit_review"]["sizing"] == "full_position"
+    assert tiers["momentum_spike_profit_ladder"]["conditions"]["rsi_gate_exempt"] is True
+    assert tiers["momentum_spike_profit_ladder"]["conditions"][
+        "ladder_total_position_pct_max"
+    ] == 33.3333
+    assert tiers["profit_realization"]["conditions"]["profit_pct_min"] == 8
+    assert tiers["profit_realization"]["action"] == "preplace_small_trim_ladder"
+    assert tiers["ultra_near_resistance"]["conditions"]["resistance_near_pct_max"] == 2
+    assert tiers["watch_zone"]["action"] == "register_watch"
+    assert "single_share_position" not in rule["exclusions"]
     single_share = out["decision_rules"]["sell.single_share_exit"]
     assert single_share["activation_state"] == "shadow"
     assert single_share["proposal_enabled"] is False

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -47,10 +47,15 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     tiers = {tier["id"]: tier for tier in rule["tiers"]}
     assert tiers["de_minimis_trim_watch"]["action"] == "register_watch_instead_of_trim"
     assert tiers["single_share_full_exit_review"]["sizing"] == "full_position"
-    assert tiers["momentum_spike_profit_ladder"]["conditions"]["rsi_gate_exempt"] is True
-    assert tiers["momentum_spike_profit_ladder"]["conditions"][
-        "ladder_total_position_pct_max"
-    ] == 33.3333
+    assert (
+        tiers["momentum_spike_profit_ladder"]["conditions"]["rsi_gate_exempt"] is True
+    )
+    assert (
+        tiers["momentum_spike_profit_ladder"]["conditions"][
+            "ladder_total_position_pct_max"
+        ]
+        == 33.3333
+    )
     assert tiers["profit_realization"]["conditions"]["profit_pct_min"] == 8
     assert tiers["profit_realization"]["action"] == "preplace_small_trim_ladder"
     assert tiers["ultra_near_resistance"]["conditions"]["resistance_near_pct_max"] == 2

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -26,9 +26,7 @@ def test_shipped_config_validates():
     assert doc.thresholds["portfolio.max_symbols_per_theme"].value == 2
     assert doc.thresholds["sell.momentum_spike_change_pct_min"].value == 10
     assert doc.thresholds["sell.single_share_profit_pct_min"].value == 8
-    assert (
-        doc.thresholds["sell.trim_min_expected_net_realized_gain_krw"].value == 5000
-    )
+    assert doc.thresholds["sell.trim_min_expected_net_realized_gain_krw"].value == 5000
     for key in (
         "sell.momentum_spike_change_pct_min",
         "sell.single_share_profit_pct_min",
@@ -37,9 +35,10 @@ def test_shipped_config_validates():
         semantics = doc.thresholds[key].semantics
         assert "측정으로 확정할 가설" in semantics
         assert "not adjustable by a runtime session" in semantics
-    assert "posture shadow completion" in doc.thresholds[
-        "sell.momentum_spike_change_pct_min"
-    ].semantics
+    assert (
+        "posture shadow completion"
+        in doc.thresholds["sell.momentum_spike_change_pct_min"].semantics
+    )
     assert set(doc.market_overrides.keys()) == {"kr", "us", "crypto"}
     assert "semis_memory" in doc.sector_clusters
     assert "sell.trim_preplace" in doc.decision_rules

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -29,6 +29,17 @@ def test_shipped_config_validates():
     assert (
         doc.thresholds["sell.trim_min_expected_net_realized_gain_krw"].value == 5000
     )
+    for key in (
+        "sell.momentum_spike_change_pct_min",
+        "sell.single_share_profit_pct_min",
+        "sell.trim_min_expected_net_realized_gain_krw",
+    ):
+        semantics = doc.thresholds[key].semantics
+        assert "측정으로 확정할 가설" in semantics
+        assert "not adjustable by a runtime session" in semantics
+    assert "posture shadow completion" in doc.thresholds[
+        "sell.momentum_spike_change_pct_min"
+    ].semantics
     assert set(doc.market_overrides.keys()) == {"kr", "us", "crypto"}
     assert "semis_memory" in doc.sector_clusters
     assert "sell.trim_preplace" in doc.decision_rules

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -24,23 +24,36 @@ def test_shipped_config_validates():
     assert doc.thresholds["screen.rsi_max"].value == 45
     assert doc.thresholds["buy.deep_limit_pct_range"].value == [-12, -3]
     assert doc.thresholds["portfolio.max_symbols_per_theme"].value == 2
+    assert doc.thresholds["sell.momentum_spike_change_pct_min"].value == 10
+    assert doc.thresholds["sell.single_share_profit_pct_min"].value == 8
+    assert (
+        doc.thresholds["sell.trim_min_expected_net_realized_gain_krw"].value == 5000
+    )
     assert set(doc.market_overrides.keys()) == {"kr", "us", "crypto"}
     assert "semis_memory" in doc.sector_clusters
     assert "sell.trim_preplace" in doc.decision_rules
     trim_rule = doc.decision_rules["sell.trim_preplace"]
     assert trim_rule.lanes == ["sell"]
     assert [tier.id for tier in trim_rule.tiers] == [
+        "de_minimis_trim_watch",
+        "single_share_full_exit_review",
+        "momentum_spike_profit_ladder",
         "profit_realization",
         "rsi_confirmed_resistance",
         "ultra_near_resistance",
         "watch_zone",
     ]
-    assert trim_rule.tiers[0].conditions["profit_pct_min"] == 8
-    assert trim_rule.tiers[2].conditions["resistance_near_pct_max"] == 2
+    assert trim_rule.tiers[0].action == "register_watch_instead_of_trim"
+    assert trim_rule.tiers[1].sizing == "full_position"
+    assert trim_rule.tiers[2].conditions["rsi_gate_exempt"] is True
+    assert trim_rule.tiers[2].conditions["ladder_total_position_pct_max"] == 33.3333
+    assert trim_rule.tiers[3].conditions["profit_pct_min"] == 8
+    assert trim_rule.tiers[5].conditions["resistance_near_pct_max"] == 2
     assert trim_rule.tie_breaks["multiple_tiers_matched"] == (
         "first_matching_tier_wins"
     )
     assert trim_rule.tie_breaks["sell.upside_place_max_pct"] == "size_limit_only"
+    assert "single_share_position" not in trim_rule.exclusions
 
 
 def test_single_share_exit_rule_is_provisional_shadow_only():

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -62,67 +62,56 @@ def test_single_share_exit_is_exposed_only_for_kr_sell():
     )
 
 
-def test_existing_trim_preplace_rule_is_exactly_unchanged():
+def test_trim_preplace_exposes_d2_d5_d7_advisory_contracts():
     rule = svc.get_policy_for("kr", "sell")["decision_rules"]["sell.trim_preplace"]
+    tiers = {tier["id"]: tier for tier in rule["tiers"]}
 
-    assert rule == {
-        "semantics": (
-            "Tiers are evaluated in declared priority order and the first match wins. "
-            "profit_realization is resistance-distance-independent; global exclusions "
-            "apply to every tier. When resistance-near favors PLACE but upside-rich "
-            "would otherwise allow WATCH, resistance proximity can pre-place only a "
-            "small trim; upside richness limits size, not eligibility."
+    assert list(tiers) == [
+        "de_minimis_trim_watch",
+        "single_share_full_exit_review",
+        "momentum_spike_profit_ladder",
+        "profit_realization",
+        "rsi_confirmed_resistance",
+        "ultra_near_resistance",
+        "watch_zone",
+    ]
+    assert tiers["de_minimis_trim_watch"]["conditions"] == {
+        "markets": ["kr", "us", "crypto"],
+        "trim_candidate": True,
+        "expected_net_realized_gain_krw_below_policy_key": (
+            "sell.trim_min_expected_net_realized_gain_krw"
         ),
-        "tiers": [
-            {
-                "id": "profit_realization",
-                "conditions": {"profit_pct_min": 8},
-                "action": "preplace_small_trim_ladder",
-                "sizing": "small_trim_only",
-            },
-            {
-                "id": "rsi_confirmed_resistance",
-                "conditions": {
-                    "rsi_min_policy_key": "sell.rsi_place_min",
-                    "resistance_near_pct_max_policy_key": "sell.resistance_near_pct",
-                },
-                "action": "preplace_small_trim_ladder",
-                "sizing": "small_trim_only",
-            },
-            {
-                "id": "ultra_near_resistance",
-                "conditions": {
-                    "rsi_below_policy_key": "sell.rsi_place_min",
-                    "resistance_near_pct_max": 2,
-                },
-                "action": "preplace_small_trim_ladder",
-                "sizing": "small_trim_only",
-            },
-            {
-                "id": "watch_zone",
-                "conditions": {
-                    "rsi_below_policy_key": "sell.rsi_place_min",
-                    "resistance_near_pct_min_exclusive": 2,
-                    "resistance_near_pct_max_policy_key": "sell.resistance_near_pct",
-                },
-                "action": "register_watch",
-                "sizing": "no_preplaced_trim",
-            },
-        ],
-        "tie_breaks": {
-            "tier_priority": (
-                "profit_realization > rsi_confirmed_resistance > "
-                "ultra_near_resistance > watch_zone"
-            ),
-            "multiple_tiers_matched": "first_matching_tier_wins",
-            "sell.upside_place_max_pct": "size_limit_only",
-        },
-        "exclusions": [
-            "single_share_position",
-            "no_resistance_reference",
-            "composite_gates",
-        ],
     }
+    assert tiers["de_minimis_trim_watch"]["action"] == (
+        "register_watch_instead_of_trim"
+    )
+    assert tiers["single_share_full_exit_review"]["conditions"][
+        "profit_pct_min_policy_key"
+    ] == "sell.single_share_profit_pct_min"
+    assert tiers["single_share_full_exit_review"]["sizing"] == "full_position"
+    spike = tiers["momentum_spike_profit_ladder"]
+    assert spike["conditions"]["session_change_pct_min_policy_key"] == (
+        "sell.momentum_spike_change_pct_min"
+    )
+    assert spike["conditions"]["rsi_gate_exempt"] is True
+    assert spike["conditions"]["required_thesis_evidence"] == [
+        "catalyst_basis",
+        "flow_basis",
+    ]
+    assert spike["conditions"]["resistance_levels_required"] == [
+        "resistance_1",
+        "resistance_2",
+    ]
+    assert spike["conditions"]["ladder_total_position_pct_max"] == 33.3333
+    assert spike["sizing"] == "at_most_one_third_position"
+    assert rule["tie_breaks"]["multiple_tiers_matched"] == (
+        "first_matching_tier_wins"
+    )
+    assert rule["tie_breaks"]["momentum_spike_integer_rounding"] == (
+        "floor_without_exceeding_one_third_or_watch"
+    )
+    assert "single_share_position" not in rule["exclusions"]
+    assert rule["exclusions"] == ["no_resistance_reference", "composite_gates"]
 
 
 def test_market_override_applied(monkeypatch, tmp_path):

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -85,9 +85,12 @@ def test_trim_preplace_exposes_d2_d5_d7_advisory_contracts():
     assert tiers["de_minimis_trim_watch"]["action"] == (
         "register_watch_instead_of_trim"
     )
-    assert tiers["single_share_full_exit_review"]["conditions"][
-        "profit_pct_min_policy_key"
-    ] == "sell.single_share_profit_pct_min"
+    assert (
+        tiers["single_share_full_exit_review"]["conditions"][
+            "profit_pct_min_policy_key"
+        ]
+        == "sell.single_share_profit_pct_min"
+    )
     assert tiers["single_share_full_exit_review"]["sizing"] == "full_position"
     spike = tiers["momentum_spike_profit_ladder"]
     assert spike["conditions"]["session_change_pct_min_policy_key"] == (
@@ -104,9 +107,7 @@ def test_trim_preplace_exposes_d2_d5_d7_advisory_contracts():
     ]
     assert spike["conditions"]["ladder_total_position_pct_max"] == 33.3333
     assert spike["sizing"] == "at_most_one_third_position"
-    assert rule["tie_breaks"]["multiple_tiers_matched"] == (
-        "first_matching_tier_wins"
-    )
+    assert rule["tie_breaks"]["multiple_tiers_matched"] == ("first_matching_tier_wins")
     assert rule["tie_breaks"]["momentum_spike_integer_rounding"] == (
         "floor_without_exceeding_one_third_or_watch"
     )


### PR DESCRIPTION
## 운영자 승인 필수

`config/trading_policy.yaml`은 매매 판단 임계값/decision rule의 단일 소스입니다. 이 PR은 **operator 승인 전 머지하면 안 됩니다.** Codex는 PR 생성·갱신까지만 수행했으며 머지, 주문, watch/journal, broker mutation은 수행하지 않았습니다.

## 요약

2026-07-27 NXT 프리마켓 실측에 따른 운영자 확정 결정 D2·D5·D7을 advisory policy로 반영합니다.

- policy version: `2026-07-25.1` → `2026-07-27.1`
- `captured_as_of`: `2026-07-27`
- loader-computed content hash: `3bf9adb70881`
- migration 없음, 주문/브로커 mutation 없음
- runtime 강제 범위 확대 없음. 모든 신규 판단은 advisory이며 기존 fail-open/guard 계약은 그대로
- runtime 변경은 없고, stale schema docstring 1곳과 정책 계약 테스트만 갱신

## posture-v1(ROB-1090) 관계 — 중복 구현 방지

posture-v1 에픽은 2026-07-27 승인·등록됐으며, 정본 §11은 RSI·모멘텀·수급 AND gate를 폐기하고 연속 multiplier로 전환합니다.

> 본 티어는 과도기 패치다. posture-v1(ROB-1090) §11 에서 RSI 게이트 자체가 폐기될 예정이며, 본 티어는 posture shadow 완료 시 흡수된다.

- D2 `momentum_spike_profit_ladder`만 posture 전환까지의 과도기 예외입니다.
- D5의 one-share full-position verdict와 D7의 net realization floor는 posture-v1이 그대로 채택했습니다. posture로 이어지는 입력이므로 중복 투자가 아닙니다.
- §11에 따라 `sell.trim_preplace`는 legacy classifier로 존치합니다. posture generator가 authoritative가 되는 시점은 sell pilot 1 이후이므로, 이 PR의 현재 `trim_preplace` 변경은 그때까지 유효합니다.
- 세 임계값은 모두 semantics에 `측정으로 확정할 가설`로 표시하고 이 policy version에서 동결했습니다. 런타임 세션은 값을 바꿀 수 없고, 측정 후 operator-reviewed policy PR로만 변경할 수 있습니다.

## D2·D5·D7 매핑

| 결정 | threshold 키 | decision rule 경로 | 반영 내용 |
|---|---|---|---|
| D2 급등 예외 | `thresholds.sell.momentum_spike_change_pct_min` = `10%` | `decision_rules.sell.trim_preplace.tiers[id=momentum_spike_profit_ladder]` | KR/US 당일·프리마켓 급등 후보만 RSI≥58 면제. catalyst/flow thesis 근거 필수, 저항1·2 래더, 평단 초과 이익구간 전용, 합계 `≤33.3333%`(정수 수량은 floor, 0이면 WATCH). posture shadow 완료 시 흡수되는 과도기 티어 |
| D5 single_share 폐지 | `thresholds.sell.single_share_profit_pct_min` = `8%` | `sell.trim_preplace.tiers[id=single_share_full_exit_review]` + `phase25.10_single_share_exit_choice` | 기존 `single_share_position` global exclusion 삭제. 1주는 partial trim 없이 저항 전량청산 또는 전량 trail 판정 대상으로 포함. posture full-position verdict로 승계 |
| D7 실익 하한 | `thresholds.sell.trim_min_expected_net_realized_gain_krw` = `5,000 KRW equivalent` | `sell.trim_preplace.tiers[id=de_minimis_trim_watch]` | 예상 순실현이익(수수료·세금 추정 후)이 임계 미만인 trim 후보는 trim 대신 WATCH. US는 판정 snapshot FX로 KRW 환산. posture `sell.net_realization_floor`로 승계 |

## single_share 기존 3곳 정합 처리

1. 기존 `sell.trim_preplace.exclusions`의 `single_share_position`을 제거했습니다. 대신 `single_share_full_exit_review`를 첫 실익 게이트 다음 우선순위에 두어 1주를 매도 깔때기 안에서 판정합니다.
2. 기존 `sell.single_share_exit` 키는 삭제·개명하지 않았습니다. strict schema와 기존 replay 계약을 보존한 채 **general fallback으로서는 deprecated**라고 semantics/recalibration note에 표시했습니다. 이 규칙은 기존 KR KIS+Toss far-resistance shadow/replay cohort만 유지하고 `activation_state=shadow`, `proposal_enabled=false`, manual/proposal-only 계약도 그대로입니다. 일반 advisory eligibility를 좁힐 수 없습니다.
3. `phase25.10_single_share_exit_choice`가 일반 1주 disposition의 소유자입니다. `one_share_profitable_resistance_exit` 티어를 추가해 +8% 이상에서 전량 저항 exit 선배치/제안을 허용하되 강제하지 않으며, 기존 hard target 또는 full trail 중 하나만 선택하는 계약을 유지합니다.

따라서 중복 역할은 “legacy shadow evidence”와 “general advisory disposition”으로 분리되고, pseudo-partial exit는 어느 경로에서도 허용하지 않습니다.

## 제안 임계값과 운영자 리뷰 근거

세 값 모두 **측정으로 확정할 가설**이며 현재 policy version에서 동결됩니다. 세션이 런타임에 조정할 수 없고 운영자 리뷰 PR만 변경할 수 있습니다.

- **급등 +10%**: 오늘 실측에서 대웅제약 +10.6%, NAVER +23.9%처럼 두 자릿수 급등을 기존 RSI 게이트가 놓친 문제를 직접 겨냥합니다. 일반 상승일보다 명확한 regime-change 후보를 좁혀 catalyst/수급 근거가 있을 때만 예외를 허용합니다.
- **single_share 이익 +8%**: 기존 `profit_realization`과 legacy KR shadow rule이 이미 쓰는 8%와 정렬해 같은 정책 안에서 상충하는 이익 기준을 만들지 않습니다.
- **실익 하한 5,000원**: SOOP·실리콘투에서 약 1,000원 실익을 이유로 세션이 임의 보류한 사례를 정책 기준으로 대체합니다. 이 PR은 “실익”을 **예상 순실현이익**으로 해석했습니다. 5,000원 수준과 gross proceeds가 아닌 net gain 기준이 맞는지는 운영자 리뷰 지점입니다.

## market × lane 전수 확인

| market | buy | sell | discovery |
|---|---|---|---|
| KR | 적용 불가 — exit 정책 | D2 + D5 + D7 | 적용 불가 — exit 정책 |
| US | 적용 불가 — exit 정책 | D2 + D5 + D7 | 적용 불가 — exit 정책 |
| crypto | 적용 불가 — exit 정책 | D7만 적용 | 적용 불가 — exit 정책 |

- D2 crypto 제외: 24×7 연속시장은 프리마켓이 없고 “당일” 기준시각 및 +10% calibration이 이번 결정에 제공되지 않아 추정하지 않았습니다.
- D5 crypto 제외: Phase 2.5 원계약처럼 fractional quantity 자산이라 “정확히 1주” 규칙이 적용되지 않습니다.
- generic decision-rule schema/loader는 lane만 필터링하고 market은 자동 필터링하지 않습니다. 따라서 crypto sell view에도 새 threshold 이름과 `sell.trim_preplace` rule은 노출되지만, tier의 `conditions.markets`가 적용 계약입니다. market-aware 자동 필터링은 schema/loader 변경이 필요하므로 금지 범위에 따라 수행하지 않았습니다.

## 로더 파싱 검증 원문

`app/services/trading_policy_service.py`를 실제 호출했습니다.

```text
parsed version=2026-07-27.1 captured_as_of=2026-07-27
{'version': '2026-07-27.1', 'content_hash': '3bf9adb70881'}
sell.momentum_spike_change_pct_min=10; hypothesis_frozen=true
sell.single_share_profit_pct_min=8; hypothesis_frozen=true
sell.trim_min_expected_net_realized_gain_krw=5000; hypothesis_frozen=true
posture_transition_contract=passed
```

원본 대비 키 보존 및 single-share 계약 감사:

```text
removed_thresholds=[]
removed_decision_rules=[]
single_share_contract=trim_included; legacy_shadow_deprecated; phase25_full_exit_choice
policy_contract_checks=passed
```

## 테스트

정책/loader/MCP/route/single-share replay/dispatch 관련 기존 테스트 전량:

```text
297 passed, 2 warnings in 12.21s
```

정적 검사:

```text
All checks passed!
```

경고 2개는 기존 `app/auth/schemas.py`의 Pydantic class-based config deprecation 경고입니다.

## 확인하지 못한 것 / 판단이 갈린 것

- 전체 repository test suite는 실행하지 않았고, `trading_policy`, single-share, route, dispatch를 직접 참조하는 관련 테스트 10개 파일(297개)을 실행했습니다.
- 실제 NXT/KIS/Toss/US/crypto 시장 데이터로 advisory 소비 동작을 실행하지 않았고 실주문도 하지 않았습니다.
- D2를 crypto에 확대하지 않은 판단, D7을 순실현이익·KRW equivalent로 정의한 판단, generic rule의 `conditions.markets` 계약이 충분한지는 운영자 확인이 필요합니다.
- posture-v1의 시장별 `net_realization_floor` 초기값(KR 5,000원·US $5·crypto 3,000원)과 이 과도기 PR의 단일 5,000 KRW-equivalent 값은 후속 posture 정책화 시 조정 대상입니다. 이 PR에서는 D7 확정 범위를 변경하지 않았습니다.
- `sell.single_share_exit`의 strict schema/runtime shadow evaluator를 제거하거나 구조 변경하지 않았습니다. 완전 제거는 별도 schema/service 변경이 필요하므로 이 정책 PR 범위에서는 deprecated 보존으로 처리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sell-side decision guidance for momentum spikes, profit realization, and resistance-based exits.
  * Added specialized handling for profitable one-share positions, including full-exit review recommendations.
  * Added minimum-benefit checks to distinguish trim recommendations from watch-only outcomes.
  * Introduced momentum-spike trim ladders with updated evaluation priorities and safeguards.

* **Documentation**
  * Clarified that the legacy single-share fallback remains available only for historical shadow and replay analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->