### PR TITLE
feat(alpaca): add isolated directional-lab paper profile

### DIFF
--- a/alembic/versions/20260727_alpaca_paper_lab_account_mode.py
+++ b/alembic/versions/20260727_alpaca_paper_lab_account_mode.py
@@ -1,0 +1,126 @@
+"""Add the dedicated Alpaca paper lab account mode to existing CHECKs.
+
+Revision ID: 20260727_alpaca_paper_lab
+Revises: 20260725_rob1010_crypto_venue
+Create Date: 2026-07-27 00:00:00.000000
+
+This reuses the existing Alpaca ledger and retrospective table/columns. It
+does not add or change any unique index. Downgrade refuses to narrow the
+constraints while lab rows still exist.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260727_alpaca_paper_lab"
+down_revision: str | Sequence[str] | None = "20260725_rob1010_crypto_venue"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_LEDGER_TABLE = "review.alpaca_paper_order_ledger"
+_LEDGER_CHECK = (
+    "ck_alpaca_paper_order_ledger_alpaca_paper_ledger_account_mode"
+)
+_LEDGER_TEMP_CHECK = "ck_alpaca_paper_ledger_account_mode_next"
+_RETROSPECTIVE_TABLE = "review.trade_retrospectives"
+_RETROSPECTIVE_CHECK = (
+    "ck_trade_retrospectives_ck_trade_retrospectives_account_mode"
+)
+_RETROSPECTIVE_TEMP_CHECK = "ck_trade_retrospectives_account_mode_next"
+
+_LEDGER_NEW = "account_mode IN ('alpaca_paper','alpaca_paper_lab')"
+_LEDGER_OLD = "account_mode = 'alpaca_paper'"
+_RETROSPECTIVE_NEW = (
+    "account_mode IN ("
+    "'kis_mock','kiwoom_mock','kis_live','toss_live','alpaca_paper',"
+    "'alpaca_paper_lab','upbit_live','paper'"
+    ")"
+)
+_RETROSPECTIVE_OLD = (
+    "account_mode IN ("
+    "'kis_mock','kiwoom_mock','kis_live','toss_live','alpaca_paper',"
+    "'upbit_live','paper'"
+    ")"
+)
+
+
+def _swap_check(
+    table: str,
+    current_name: str,
+    temporary_name: str,
+    expression: str,
+) -> None:
+    op.execute(
+        f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{temporary_name}"'
+    )
+    op.execute(
+        f'ALTER TABLE {table} ADD CONSTRAINT "{temporary_name}" '
+        f"CHECK ({expression}) NOT VALID"
+    )
+    op.execute(
+        f'ALTER TABLE {table} VALIDATE CONSTRAINT "{temporary_name}"'
+    )
+    op.execute(
+        f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{current_name}"'
+    )
+    op.execute(
+        f'ALTER TABLE {table} RENAME CONSTRAINT "{temporary_name}" '
+        f'TO "{current_name}"'
+    )
+
+
+def upgrade() -> None:
+    _swap_check(
+        _LEDGER_TABLE,
+        _LEDGER_CHECK,
+        _LEDGER_TEMP_CHECK,
+        _LEDGER_NEW,
+    )
+    _swap_check(
+        _RETROSPECTIVE_TABLE,
+        _RETROSPECTIVE_CHECK,
+        _RETROSPECTIVE_TEMP_CHECK,
+        _RETROSPECTIVE_NEW,
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM review.alpaca_paper_order_ledger
+                WHERE account_mode = 'alpaca_paper_lab'
+            ) THEN
+                RAISE EXCEPTION
+                    'cannot downgrade: alpaca_paper_lab ledger rows exist';
+            END IF;
+            IF EXISTS (
+                SELECT 1
+                FROM review.trade_retrospectives
+                WHERE account_mode = 'alpaca_paper_lab'
+            ) THEN
+                RAISE EXCEPTION
+                    'cannot downgrade: alpaca_paper_lab retrospective rows exist';
+            END IF;
+        END
+        $$;
+        """
+    )
+    _swap_check(
+        _RETROSPECTIVE_TABLE,
+        _RETROSPECTIVE_CHECK,
+        _RETROSPECTIVE_TEMP_CHECK,
+        _RETROSPECTIVE_OLD,
+    )
+    _swap_check(
+        _LEDGER_TABLE,
+        _LEDGER_CHECK,
+        _LEDGER_TEMP_CHECK,
+        _LEDGER_OLD,
+    )

--- a/alembic/versions/20260727_alpaca_paper_lab_account_mode.py
+++ b/alembic/versions/20260727_alpaca_paper_lab_account_mode.py
@@ -21,14 +21,10 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 _LEDGER_TABLE = "review.alpaca_paper_order_ledger"
-_LEDGER_CHECK = (
-    "ck_alpaca_paper_order_ledger_alpaca_paper_ledger_account_mode"
-)
+_LEDGER_CHECK = "ck_alpaca_paper_order_ledger_alpaca_paper_ledger_account_mode"
 _LEDGER_TEMP_CHECK = "ck_alpaca_paper_ledger_account_mode_next"
 _RETROSPECTIVE_TABLE = "review.trade_retrospectives"
-_RETROSPECTIVE_CHECK = (
-    "ck_trade_retrospectives_ck_trade_retrospectives_account_mode"
-)
+_RETROSPECTIVE_CHECK = "ck_trade_retrospectives_ck_trade_retrospectives_account_mode"
 _RETROSPECTIVE_TEMP_CHECK = "ck_trade_retrospectives_account_mode_next"
 
 _LEDGER_NEW = "account_mode IN ('alpaca_paper','alpaca_paper_lab')"
@@ -53,22 +49,15 @@ def _swap_check(
     temporary_name: str,
     expression: str,
 ) -> None:
-    op.execute(
-        f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{temporary_name}"'
-    )
+    op.execute(f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{temporary_name}"')
     op.execute(
         f'ALTER TABLE {table} ADD CONSTRAINT "{temporary_name}" '
         f"CHECK ({expression}) NOT VALID"
     )
+    op.execute(f'ALTER TABLE {table} VALIDATE CONSTRAINT "{temporary_name}"')
+    op.execute(f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{current_name}"')
     op.execute(
-        f'ALTER TABLE {table} VALIDATE CONSTRAINT "{temporary_name}"'
-    )
-    op.execute(
-        f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{current_name}"'
-    )
-    op.execute(
-        f'ALTER TABLE {table} RENAME CONSTRAINT "{temporary_name}" '
-        f'TO "{current_name}"'
+        f'ALTER TABLE {table} RENAME CONSTRAINT "{temporary_name}" TO "{current_name}"'
     )
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -860,6 +860,10 @@ class Settings(BaseSettings):
     # Only paper credentials/endpoint — no live trading support.
     alpaca_paper_api_key: str | None = None
     alpaca_paper_api_secret: SecretStr | None = None
+    # directional-lab uses a distinct Alpaca paper account. The endpoint is
+    # intentionally shared; credentials are not allowed to fall back.
+    alpaca_paper_lab_api_key: str | None = None
+    alpaca_paper_lab_api_secret: SecretStr | None = None
     alpaca_paper_base_url: str = "https://paper-api.alpaca.markets"
     alpaca_paper_data_base_url: str = "https://data.alpaca.markets"
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -494,21 +494,33 @@ ROB-69 exposes Alpaca paper broker inspection via explicit read-only MCP tool
 names only. These tools are registered under `MCP_PROFILE=us-paper`; they are
 not part of the default or `hermes-paper-kis` surfaces.
 
-- `alpaca_paper_get_account()`
-- `alpaca_paper_get_cash()`
-- `alpaca_paper_list_positions()`
-- `alpaca_paper_list_orders(status="open", limit=50)`
-- `alpaca_paper_get_order(order_id)`
-- `alpaca_paper_list_assets(status="active", asset_class="us_equity")`
-- `alpaca_paper_list_fills(after=None, until=None, limit=50)`
-- `alpaca_paper_ledger_list_recent(limit=50, lifecycle_state=None)`
-- `alpaca_paper_ledger_get(client_order_id)`
+- `alpaca_paper_get_account(account_mode="alpaca_paper")`
+- `alpaca_paper_get_cash(account_mode="alpaca_paper")`
+- `alpaca_paper_list_positions(account_mode="alpaca_paper")`
+- `alpaca_paper_list_orders(status="open", limit=50, account_mode="alpaca_paper")`
+- `alpaca_paper_get_order(order_id, account_mode="alpaca_paper")`
+- `alpaca_paper_list_assets(status="active", asset_class="us_equity", account_mode="alpaca_paper")`
+- `alpaca_paper_list_fills(after=None, until=None, limit=50, account_mode="alpaca_paper")`
+- `alpaca_paper_ledger_list_recent(limit=50, lifecycle_state=None, account_mode="alpaca_paper")`
+- `alpaca_paper_ledger_get(client_order_id, account_mode="alpaca_paper")`
 - `alpaca_paper_execution_preflight_check(...)`
+
+All existing calls keep `account_mode="alpaca_paper"` by default. The
+directional-lab lane selects its isolated paper account with
+`account_mode="alpaca_paper_lab"`. That mode reads
+`ALPACA_PAPER_LAB_API_KEY` and `ALPACA_PAPER_LAB_API_SECRET`, while reusing
+`ALPACA_PAPER_BASE_URL`. Both lab credentials are mandatory: missing or
+incomplete lab credentials raise a configuration error and never fall back to
+the existing Alpaca paper credentials. Lab order preview/submit is restricted
+to `asset_class="us_equity"`; Alpaca crypto paper remains on the existing
+account only. Ledger, preflight, roundtrip, cancel status sync, and reconcile
+lookups are scoped to the selected account mode.
 
 ### Alpaca paper fill reconcile (DB-writing mutation, ROB-953)
 
 `alpaca_paper_reconcile_orders(symbol=None, client_order_id=None, dry_run=True,
-confirm=False, limit=100)` is **not** part of the read-only surface above. It is
+confirm=False, limit=100, account_mode="alpaca_paper")` is **not** part of the
+read-only surface above. It is
 a **DB-writing mutation** classified in `MUTATION_TOOLS`, denied by the
 read-only settings profile, and exposed on the **DEFAULT** profile behind
 `settings.alpaca_paper_default_tools_enabled` (default off) — not `us-paper`
@@ -695,6 +707,7 @@ alpaca_paper_preview_order(
     stop_price=None,       # always rejected (deferred)
     client_order_id=None,  # optional, 1-48 chars
     asset_class="us_equity",  # "us_equity" or ROB-74 "crypto"
+    account_mode="alpaca_paper",  # or isolated US-equity-only "alpaca_paper_lab"
 )
 ```
 

--- a/app/mcp_server/tooling/alpaca_paper.py
+++ b/app/mcp_server/tooling/alpaca_paper.py
@@ -13,6 +13,11 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
+from app.services.alpaca_paper_account_modes import (
+    ALPACA_PAPER_ACCOUNT_MODE,
+    normalize_alpaca_paper_account_mode,
+    profile_for_account_mode,
+)
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
 
 if TYPE_CHECKING:
@@ -61,6 +66,14 @@ def reset_alpaca_paper_service_factory() -> None:
     _service_factory = _default_service_factory
 
 
+def _service_for_account_mode(account_mode: str) -> AlpacaPaperBrokerService:
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    profile = profile_for_account_mode(selected)
+    if profile is None or _service_factory is not _default_service_factory:
+        return _service_factory()
+    return AlpacaPaperBrokerService(profile=profile)
+
+
 def _model_to_jsonable(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return value.model_dump(mode="json", by_alias=True)
@@ -91,37 +104,46 @@ def _normalize_optional_limit(limit: int | None, *, max_limit: int = 500) -> int
     return min(limit, max_limit)
 
 
-async def alpaca_paper_get_account() -> dict[str, Any]:
+async def alpaca_paper_get_account(
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+) -> dict[str, Any]:
     """Return the Alpaca paper account snapshot using the paper-only service."""
 
-    account = await _service_factory().get_account()
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    account = await _service_for_account_mode(selected).get_account()
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "account": _model_to_jsonable(account),
     }
 
 
-async def alpaca_paper_get_cash() -> dict[str, Any]:
+async def alpaca_paper_get_cash(
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+) -> dict[str, Any]:
     """Return paper cash and buying power."""
 
-    cash = await _service_factory().get_cash()
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    cash = await _service_for_account_mode(selected).get_cash()
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "cash": _model_to_jsonable(cash),
     }
 
 
-async def alpaca_paper_list_positions() -> dict[str, Any]:
+async def alpaca_paper_list_positions(
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+) -> dict[str, Any]:
     """List current Alpaca paper positions."""
 
-    positions = await _service_factory().list_positions()
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    positions = await _service_for_account_mode(selected).list_positions()
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "count": len(positions),
         "positions": _model_to_jsonable(positions),
@@ -131,14 +153,18 @@ async def alpaca_paper_list_positions() -> dict[str, Any]:
 async def alpaca_paper_list_orders(
     status: str | None = "open",
     limit: int | None = 50,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """List Alpaca paper orders without mutating broker state."""
 
     normalized_limit = _normalize_optional_limit(limit)
-    orders = await _service_factory().list_orders(status=status, limit=normalized_limit)
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    orders = await _service_for_account_mode(selected).list_orders(
+        status=status, limit=normalized_limit
+    )
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "status": status,
         "limit": normalized_limit,
@@ -147,15 +173,19 @@ async def alpaca_paper_list_orders(
     }
 
 
-async def alpaca_paper_get_order(order_id: str) -> dict[str, Any]:
+async def alpaca_paper_get_order(
+    order_id: str,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+) -> dict[str, Any]:
     """Fetch one Alpaca paper order by id without modifying it."""
 
     if not order_id.strip():
         raise ValueError("order_id is required")
-    order = await _service_factory().get_order(order_id.strip())
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    order = await _service_for_account_mode(selected).get_order(order_id.strip())
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "order": _model_to_jsonable(order),
     }
@@ -164,15 +194,17 @@ async def alpaca_paper_get_order(order_id: str) -> dict[str, Any]:
 async def alpaca_paper_list_assets(
     status: str | None = "active",
     asset_class: str | None = "us_equity",
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """List Alpaca paper-visible assets with optional status/class filters."""
 
-    assets = await _service_factory().list_assets(
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    assets = await _service_for_account_mode(selected).list_assets(
         status=status, asset_class=asset_class
     )
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "status": status,
         "asset_class": asset_class,
@@ -185,20 +217,22 @@ async def alpaca_paper_list_fills(
     after: str | None = None,
     until: str | None = None,
     limit: int | None = 50,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """List Alpaca paper fill activities without placing/cancelling orders."""
 
     parsed_after = _parse_optional_datetime(after, field_name="after")
     parsed_until = _parse_optional_datetime(until, field_name="until")
     normalized_limit = _normalize_optional_limit(limit)
-    fills = await _service_factory().list_fills(
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    fills = await _service_for_account_mode(selected).list_fills(
         after=parsed_after,
         until=parsed_until,
         limit=normalized_limit,
     )
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "after": after,
         "until": until,

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -11,6 +11,10 @@ from typing import TYPE_CHECKING, Any, cast
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
+from app.services.alpaca_paper_account_modes import (
+    ALPACA_PAPER_ACCOUNT_MODE,
+    normalize_alpaca_paper_account_mode,
+)
 from app.services.alpaca_paper_anomaly_checks import (
     build_paper_execution_preflight_report,
 )
@@ -25,6 +29,24 @@ if TYPE_CHECKING:
 
 def _session_factory() -> async_sessionmaker[AsyncSession]:
     return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _ledger_service(
+    db: AsyncSession,
+    account_mode: str,
+) -> AlpacaPaperLedgerService:
+    if account_mode == ALPACA_PAPER_ACCOUNT_MODE:
+        return AlpacaPaperLedgerService(db)
+    return AlpacaPaperLedgerService(db, account_mode=account_mode)
+
+
+def _roundtrip_service(
+    db: AsyncSession,
+    account_mode: str,
+) -> AlpacaPaperRoundtripReportService:
+    if account_mode == ALPACA_PAPER_ACCOUNT_MODE:
+        return AlpacaPaperRoundtripReportService(db)
+    return AlpacaPaperRoundtripReportService(db, account_mode=account_mode)
 
 
 def _clean_scope_value(value: Any) -> str | None:
@@ -57,6 +79,7 @@ def _row_to_dict(row: Any) -> dict[str, Any]:
 async def alpaca_paper_ledger_list_recent(
     limit: int = 50,
     lifecycle_state: str | None = None,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """List recent Alpaca Paper order ledger entries (read-only).
 
@@ -66,18 +89,19 @@ async def alpaca_paper_ledger_list_recent(
             planned, previewed, validated, submitted, filled,
             position_reconciled, sell_validated, closed, final_reconciled, anomaly, canceled.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
     if limit < 1:
         raise ValueError("limit must be >= 1")
     limit = min(limit, 200)
 
     async with _session_factory()() as db:
-        svc = AlpacaPaperLedgerService(db)
+        svc = _ledger_service(db, selected_account_mode)
         rows = await svc.list_recent(limit=limit, lifecycle_state=lifecycle_state)
 
     items = [_row_to_dict(r) for r in rows]
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected_account_mode,
         "source": "alpaca_paper_ledger",
         "lifecycle_state_filter": lifecycle_state,
         "limit": limit,
@@ -88,22 +112,24 @@ async def alpaca_paper_ledger_list_recent(
 
 async def alpaca_paper_ledger_get(
     client_order_id: str,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any] | None:
     """Fetch one Alpaca Paper ledger entry by client_order_id (read-only).
 
     Returns None if not found.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
     if not client_order_id or not client_order_id.strip():
         raise ValueError("client_order_id is required")
 
     async with _session_factory()() as db:
-        svc = AlpacaPaperLedgerService(db)
+        svc = _ledger_service(db, selected_account_mode)
         row = await svc.get_by_client_order_id(client_order_id.strip())
 
     if row is None:
         return {
             "success": False,
-            "account_mode": "alpaca_paper",
+            "account_mode": selected_account_mode,
             "source": "alpaca_paper_ledger",
             "client_order_id": client_order_id,
             "found": False,
@@ -111,7 +137,7 @@ async def alpaca_paper_ledger_get(
         }
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected_account_mode,
         "source": "alpaca_paper_ledger",
         "client_order_id": client_order_id,
         "found": True,
@@ -133,6 +159,7 @@ async def alpaca_paper_execution_preflight_check(
     candidate_uuid: str | None = None,
     briefing_artifact_run_uuid: str | None = None,
     session_uuid: str | None = None,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """Run read-only Alpaca Paper execution anomaly checks.
 
@@ -152,6 +179,7 @@ async def alpaca_paper_execution_preflight_check(
     warnings, while open-order conflicts, duplicate IDs, ledger/fill anomalies,
     symbol mismatches, and other execution-safety findings remain blockers.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
     if limit < 1:
         raise ValueError("limit must be >= 1")
     limit = min(limit, 200)
@@ -175,7 +203,7 @@ async def alpaca_paper_execution_preflight_check(
     scoped_by: dict[str, str] | None = None
 
     async with _session_factory()() as db:
-        svc = AlpacaPaperLedgerService(db)
+        svc = _ledger_service(db, selected_account_mode)
         if scope["lifecycle_correlation_id"]:
             scoped_by = {
                 "kind": "lifecycle_correlation_id",
@@ -214,7 +242,7 @@ async def alpaca_paper_execution_preflight_check(
     data.update(
         {
             "success": True,
-            "account_mode": "alpaca_paper",
+            "account_mode": selected_account_mode,
             "source": "alpaca_paper_execution_preflight",
             "read_only": True,
             "limit": limit,
@@ -228,23 +256,25 @@ async def alpaca_paper_execution_preflight_check(
 
 async def alpaca_paper_ledger_get_by_correlation(
     lifecycle_correlation_id: str,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """Fetch all Alpaca Paper ledger rows sharing a lifecycle_correlation_id (read-only).
 
     Returns the buy/sell roundtrip records in chronological order.
     lifecycle_correlation_id links buy and sell legs of the same paper roundtrip.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
     if not lifecycle_correlation_id or not lifecycle_correlation_id.strip():
         raise ValueError("lifecycle_correlation_id is required")
 
     async with _session_factory()() as db:
-        svc = AlpacaPaperLedgerService(db)
+        svc = _ledger_service(db, selected_account_mode)
         rows = await svc.list_by_correlation_id(lifecycle_correlation_id.strip())
 
     items = [_row_to_dict(r) for r in rows]
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected_account_mode,
         "source": "alpaca_paper_ledger",
         "lifecycle_correlation_id": lifecycle_correlation_id,
         "count": len(items),
@@ -261,6 +291,7 @@ async def alpaca_paper_roundtrip_report(
     positions: list[dict[str, Any]] | None = None,
     stale_after_minutes: int = 30,
     include_ledger_rows: bool = True,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """Build a read-only Alpaca Paper roundtrip audit report.
 
@@ -269,6 +300,7 @@ async def alpaca_paper_roundtrip_report(
     optional caller-supplied read-only snapshots; this tool never fetches broker
     state itself.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
     supplied = [
         lifecycle_correlation_id is not None,
         client_order_id is not None,
@@ -288,7 +320,7 @@ async def alpaca_paper_roundtrip_report(
     )
 
     async with _session_factory()() as db:
-        svc = AlpacaPaperRoundtripReportService(db)
+        svc = _roundtrip_service(db, selected_account_mode)
         if candidate_lookup is not None:
             response = await svc.build_reports_for_candidate_uuid(
                 candidate_lookup,
@@ -319,7 +351,7 @@ async def alpaca_paper_roundtrip_report(
 
     return {
         "success": success,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected_account_mode,
         "source": "alpaca_paper_roundtrip_report",
         "read_only": True,
         "report": payload,

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -26,6 +26,12 @@ from app.mcp_server.tooling.alpaca_paper_preview import (
     ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD,
     PreviewOrderInput,
 )
+from app.services.alpaca_paper_account_modes import (
+    ALPACA_PAPER_ACCOUNT_MODE,
+    ALPACA_PAPER_LAB_ACCOUNT_MODE,
+    normalize_alpaca_paper_account_mode,
+    profile_for_account_mode,
+)
 from app.services.alpaca_paper_ledger_service import (
     KNOWN_OPEN_BROKER_STATUSES,
     AlpacaPaperLedgerService,
@@ -100,6 +106,14 @@ def reset_alpaca_paper_orders_service_factory() -> None:
     _service_factory = _default_service_factory
 
 
+def _service_for_account_mode(account_mode: str) -> AlpacaPaperBrokerService:
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    profile = profile_for_account_mode(selected)
+    if profile is None or _service_factory is not _default_service_factory:
+        return _service_factory()
+    return AlpacaPaperBrokerService(profile=profile)
+
+
 def _model_to_jsonable(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return value.model_dump(mode="json", by_alias=True)
@@ -124,9 +138,13 @@ def _canonical_payload(validated: PreviewOrderInput) -> dict[str, Any]:
     )
 
 
-def _derive_client_order_id(payload: dict[str, Any]) -> str:
+def _derive_client_order_id(
+    payload: dict[str, Any],
+    *,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+) -> str:
     """Server-derived deterministic client_order_id (shared, single source)."""
-    return derive_client_order_id(payload)
+    return derive_client_order_id(payload, account_mode=account_mode)
 
 
 def _validate_exact_order_id(order_id: str) -> str:
@@ -169,6 +187,8 @@ def _build_manual_packet(
     canonical: dict[str, Any],
     coid: str,
     evidence: MarketEvidence,
+    *,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> PaperApprovalPacket:
     """Server-built manual operator packet (origin='manual', server-derived key).
 
@@ -197,7 +217,7 @@ def _build_manual_packet(
         lifecycle_correlation_id=coid,
         client_order_id=coid,
         expires_at=datetime.now(UTC) + timedelta(seconds=_MANUAL_PACKET_TTL_SECONDS),
-        account_mode="alpaca_paper",
+        account_mode=account_mode,
         origin="manual",
         market_data_asof=evidence.market_data_asof,
         market_data_source=evidence.market_data_source,
@@ -219,6 +239,7 @@ async def alpaca_paper_submit_order(
     limit_price: Decimal | None = None,
     asset_class: str = "us_equity",
     confirm: bool = False,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """Submit a single Alpaca PAPER order (us_equity or narrow crypto).
 
@@ -235,6 +256,7 @@ async def alpaca_paper_submit_order(
     uncertain outcome is reconciled — never re-POSTed. There is no direct-POST
     fallback and this behaviour does not depend on the automated feature flag.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
     validated = PreviewOrderInput(
         symbol=symbol,
         side=side,
@@ -247,6 +269,16 @@ async def alpaca_paper_submit_order(
         client_order_id=None,
         asset_class=asset_class,
     )
+    if (
+        selected_account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE
+        and validated.asset_class != "us_equity"
+    ):
+        raise ValueError("alpaca_paper_lab supports us_equity orders only")
+    if selected_account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE:
+        # Resolve the dedicated profile before returning even a confirmation
+        # preview. Missing/incomplete lab credentials must never be mistaken for
+        # a valid request that could later route through the shared account.
+        _service_for_account_mode(selected_account_mode)
 
     submit_notional_cap = (
         ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
@@ -274,12 +306,15 @@ async def alpaca_paper_submit_order(
         )
 
     canonical = _canonical_payload(validated)
-    coid = _derive_client_order_id(canonical)
+    coid = _derive_client_order_id(
+        canonical,
+        account_mode=selected_account_mode,
+    )
 
     if confirm is not True:
         return {
             "success": True,
-            "account_mode": "alpaca_paper",
+            "account_mode": selected_account_mode,
             "source": "alpaca_paper",
             "submitted": False,
             "blocked_reason": "confirmation_required",
@@ -293,7 +328,7 @@ async def alpaca_paper_submit_order(
     if quote_snapshot_id is None:
         return {
             "success": False,
-            "account_mode": "alpaca_paper",
+            "account_mode": selected_account_mode,
             "source": "alpaca_paper",
             "submitted": False,
             "status": "rejected",
@@ -316,7 +351,7 @@ async def alpaca_paper_submit_order(
         except MarketEvidenceError as exc:
             return {
                 "success": False,
-                "account_mode": "alpaca_paper",
+                "account_mode": selected_account_mode,
                 "source": "alpaca_paper",
                 "submitted": False,
                 "status": "rejected",
@@ -324,14 +359,24 @@ async def alpaca_paper_submit_order(
                 "client_order_id": coid,
                 "message": str(exc),
             }
-        packet = _build_manual_packet(validated, canonical, coid, evidence)
-        ledger = AlpacaPaperLedgerService(db)
-        coordinator = AlpacaPaperSubmitCoordinator(ledger, _service_factory)
+        packet = _build_manual_packet(
+            validated,
+            canonical,
+            coid,
+            evidence,
+            account_mode=selected_account_mode,
+        )
+        ledger = AlpacaPaperLedgerService(db, account_mode=selected_account_mode)
+        coordinator = AlpacaPaperSubmitCoordinator(
+            ledger,
+            lambda: _service_for_account_mode(selected_account_mode),
+            expected_account_mode=selected_account_mode,
+        )
         outcome = await coordinator.submit(packet, submit_canonical=canonical)
 
     return {
         "success": outcome.success,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected_account_mode,
         "source": "alpaca_paper",
         "submitted": outcome.submitted,
         "status": outcome.status,
@@ -345,21 +390,25 @@ async def alpaca_paper_submit_order(
 async def alpaca_paper_cancel_order(
     order_id: str,
     confirm: bool = False,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """Cancel exactly one Alpaca PAPER order by id."""
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
+    if selected_account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE:
+        _service_for_account_mode(selected_account_mode)
     stripped = _validate_exact_order_id(order_id)
 
     if confirm is not True:
         return {
             "success": True,
-            "account_mode": "alpaca_paper",
+            "account_mode": selected_account_mode,
             "source": "alpaca_paper",
             "cancelled": False,
             "blocked_reason": "confirmation_required",
             "target_order_id": stripped,
         }
 
-    service = _service_factory()
+    service = _service_for_account_mode(selected_account_mode)
     await service.cancel_order(stripped)
 
     # A DELETE 204 only ACCEPTS the cancel request; it is not a terminal
@@ -390,7 +439,10 @@ async def alpaca_paper_cancel_order(
     if client_order_id and read_back_status == "ok" and status_should_sync:
         try:
             async with _session_factory()() as db:
-                ledger = AlpacaPaperLedgerService(db)
+                ledger = AlpacaPaperLedgerService(
+                    db,
+                    account_mode=selected_account_mode,
+                )
                 normalized_payload = dict(order_payload)
                 normalized_payload["status"] = normalized_status
                 await ledger.record_status(
@@ -414,7 +466,7 @@ async def alpaca_paper_cancel_order(
 
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected_account_mode,
         "source": "alpaca_paper",
         # honest: cancel_requested was accepted; cancelled is True only once the
         # broker confirms the terminal `canceled` status.
@@ -436,12 +488,16 @@ async def alpaca_paper_reconcile_orders(
     dry_run: bool = True,
     confirm: bool = False,
     limit: int = 100,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """Book broker-confirmed Alpaca paper fills into non-terminal ledger rows.
 
     This only performs read-only broker evidence lookups plus existing ledger
     writes. It never submits, replaces, or cancels a broker order.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
+    if selected_account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE:
+        _service_for_account_mode(selected_account_mode)
     if limit < 1:
         raise ValueError("limit must be >= 1")
     if not dry_run and not confirm:
@@ -456,7 +512,8 @@ async def alpaca_paper_reconcile_orders(
     )
     async with _session_factory()() as db:
         reconcile = AlpacaPaperReconcileService(
-            AlpacaPaperLedgerService(db), _service_factory()
+            AlpacaPaperLedgerService(db, account_mode=selected_account_mode),
+            _service_for_account_mode(selected_account_mode),
         )
         result = await reconcile.reconcile(
             symbol=clean_symbol,
@@ -465,7 +522,7 @@ async def alpaca_paper_reconcile_orders(
             limit=min(limit, 200),
         )
     return {
-        "account_mode": "alpaca_paper",
+        "account_mode": selected_account_mode,
         "source": "alpaca_paper_reconcile_orders",
         "symbol": clean_symbol,
         "client_order_id": clean_order_id,

--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -14,6 +14,12 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, field_validator, model_validator
 
+from app.services.alpaca_paper_account_modes import (
+    ALPACA_PAPER_ACCOUNT_MODE,
+    ALPACA_PAPER_LAB_ACCOUNT_MODE,
+    normalize_alpaca_paper_account_mode,
+    profile_for_account_mode,
+)
 from app.services.brokers.alpaca.exceptions import (
     AlpacaPaperConfigurationError,
     AlpacaPaperEndpointError,
@@ -62,6 +68,17 @@ def reset_alpaca_paper_preview_service_factory() -> None:
     """Restore the default preview service factory after tests."""
     global _preview_service_factory
     _preview_service_factory = _default_preview_service_factory
+
+
+def _preview_service_for_account_mode(account_mode: str) -> AlpacaPaperBrokerService:
+    selected = normalize_alpaca_paper_account_mode(account_mode)
+    profile = profile_for_account_mode(selected)
+    if (
+        profile is None
+        or _preview_service_factory is not _default_preview_service_factory
+    ):
+        return _preview_service_factory()
+    return AlpacaPaperBrokerService(profile=profile)
 
 
 class PreviewOrderInput(BaseModel):
@@ -260,6 +277,7 @@ async def alpaca_paper_preview_order(
     stop_price: Decimal | None = None,
     client_order_id: str | None = None,
     asset_class: str = "us_equity",
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> dict[str, Any]:
     """Preview and validate an Alpaca paper US equity or narrow crypto order without submitting it.
 
@@ -270,6 +288,7 @@ async def alpaca_paper_preview_order(
     place_order, replace_order, modify_order, bulk-cancel, or generic order
     tools.
     """
+    selected = normalize_alpaca_paper_account_mode(account_mode)
     validated = PreviewOrderInput(
         symbol=symbol,
         side=side,
@@ -282,6 +301,11 @@ async def alpaca_paper_preview_order(
         client_order_id=client_order_id,
         asset_class=asset_class,
     )
+    if (
+        selected == ALPACA_PAPER_LAB_ACCOUNT_MODE
+        and validated.asset_class != "us_equity"
+    ):
+        raise ValueError("alpaca_paper_lab supports us_equity orders only")
 
     order_request: dict[str, Any] = {
         "symbol": validated.symbol,
@@ -304,7 +328,7 @@ async def alpaca_paper_preview_order(
     would_exceed_buying_power: bool | None = None
 
     try:
-        service = _preview_service_factory()
+        service = _preview_service_for_account_mode(selected)
         cash = await service.get_cash()
         account_context = {
             "cash": str(cash.cash),
@@ -312,7 +336,11 @@ async def alpaca_paper_preview_order(
         }
     except AlpacaPaperEndpointError:
         raise  # fail closed — live endpoint is never allowed
-    except (AlpacaPaperConfigurationError, AlpacaPaperRequestError):
+    except AlpacaPaperConfigurationError:
+        if selected == ALPACA_PAPER_LAB_ACCOUNT_MODE:
+            raise
+        warnings.append("context_unavailable")
+    except AlpacaPaperRequestError:
         warnings.append("context_unavailable")
 
     if validated.qty is not None and validated.limit_price is not None:
@@ -333,7 +361,7 @@ async def alpaca_paper_preview_order(
 
     return {
         "success": True,
-        "account_mode": "alpaca_paper",
+        "account_mode": selected,
         "source": "alpaca_paper",
         "preview": True,
         "submitted": False,

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -706,7 +706,8 @@ class AlpacaPaperOrderLedger(Base):
         ),
         CheckConstraint("broker = 'alpaca'", name="alpaca_paper_ledger_broker"),
         CheckConstraint(
-            "account_mode = 'alpaca_paper'", name="alpaca_paper_ledger_account_mode"
+            "account_mode IN ('alpaca_paper','alpaca_paper_lab')",
+            name="alpaca_paper_ledger_account_mode",
         ),
         CheckConstraint(
             "lifecycle_state IN ("
@@ -1048,7 +1049,8 @@ class TradeRetrospective(Base):
             name="uq_trade_retrospectives_correlation_account",
         ),
         CheckConstraint(
-            "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live','alpaca_paper','upbit_live','paper')",
+            "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
+            "'alpaca_paper','alpaca_paper_lab','upbit_live','paper')",
             name="account_mode",
         ),
         CheckConstraint(

--- a/app/services/alpaca_paper_account_modes.py
+++ b/app/services/alpaca_paper_account_modes.py
@@ -1,0 +1,54 @@
+"""Supported Alpaca paper account identities and profile routing."""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+ALPACA_PAPER_ACCOUNT_MODE = "alpaca_paper"
+ALPACA_PAPER_LAB_ACCOUNT_MODE = "alpaca_paper_lab"
+AlpacaPaperAccountMode = Literal["alpaca_paper", "alpaca_paper_lab"]
+
+ALPACA_PAPER_ACCOUNT_MODES = frozenset(
+    {ALPACA_PAPER_ACCOUNT_MODE, ALPACA_PAPER_LAB_ACCOUNT_MODE}
+)
+
+
+def normalize_alpaca_paper_account_mode(
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+) -> AlpacaPaperAccountMode:
+    normalized = str(account_mode or "").strip().lower()
+    if normalized not in ALPACA_PAPER_ACCOUNT_MODES:
+        allowed = ", ".join(sorted(ALPACA_PAPER_ACCOUNT_MODES))
+        raise ValueError(f"account_mode must be one of: {allowed}")
+    return cast(AlpacaPaperAccountMode, normalized)
+
+
+def profile_for_account_mode(account_mode: str) -> str | None:
+    normalized = normalize_alpaca_paper_account_mode(account_mode)
+    if normalized == ALPACA_PAPER_LAB_ACCOUNT_MODE:
+        return "lab"
+    return None
+
+
+def account_mode_for_profile(profile: str | None) -> AlpacaPaperAccountMode:
+    from app.services.brokers.alpaca.exceptions import AlpacaPaperConfigurationError
+
+    normalized = str(profile or "").strip().lower()
+    if normalized in {"", "default"}:
+        return ALPACA_PAPER_ACCOUNT_MODE
+    if normalized == "lab":
+        return ALPACA_PAPER_LAB_ACCOUNT_MODE
+    raise AlpacaPaperConfigurationError(
+        "Alpaca paper profile must be one of: default, lab"
+    )
+
+
+__all__ = [
+    "ALPACA_PAPER_ACCOUNT_MODE",
+    "ALPACA_PAPER_ACCOUNT_MODES",
+    "ALPACA_PAPER_LAB_ACCOUNT_MODE",
+    "AlpacaPaperAccountMode",
+    "account_mode_for_profile",
+    "normalize_alpaca_paper_account_mode",
+    "profile_for_account_mode",
+]

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -25,6 +25,10 @@ from app.schemas.preopen import (
     PreopenPaperApprovalBridge,
     PreopenPaperApprovalCandidate,
 )
+from app.services.alpaca_paper_account_modes import (
+    ALPACA_PAPER_ACCOUNT_MODE,
+    normalize_alpaca_paper_account_mode,
+)
 
 # ---------------------------------------------------------------------------
 # ROB-90 canonical lifecycle state constants
@@ -429,8 +433,13 @@ class AlpacaPaperLedgerService:
     All sensitive keys in JSONB payloads are redacted before persistence.
     """
 
-    def __init__(self, db: AsyncSession) -> None:
+    def __init__(
+        self,
+        db: AsyncSession,
+        account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+    ) -> None:
         self._db = db
+        self._account_mode = normalize_alpaca_paper_account_mode(account_mode)
 
     @property
     def session(self) -> AsyncSession:
@@ -446,7 +455,10 @@ class AlpacaPaperLedgerService:
     ) -> AlpacaPaperOrderLedger | None:
         stmt = (
             select(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
+            .where(
+                AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.account_mode == self._account_mode,
+            )
             .order_by(
                 AlpacaPaperOrderLedger.created_at.desc(),
                 AlpacaPaperOrderLedger.id.desc(),
@@ -458,7 +470,8 @@ class AlpacaPaperLedgerService:
 
     async def get_by_id(self, ledger_id: int) -> AlpacaPaperOrderLedger | None:
         stmt = select(AlpacaPaperOrderLedger).where(
-            AlpacaPaperOrderLedger.id == ledger_id
+            AlpacaPaperOrderLedger.id == ledger_id,
+            AlpacaPaperOrderLedger.account_mode == self._account_mode,
         )
         result = await self._db.execute(stmt)
         return result.scalar_one_or_none()
@@ -468,8 +481,10 @@ class AlpacaPaperLedgerService:
         limit: int = 50,
         lifecycle_state: str | None = None,
     ) -> list[AlpacaPaperOrderLedger]:
-        stmt = select(AlpacaPaperOrderLedger).order_by(
-            AlpacaPaperOrderLedger.created_at.desc()
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(AlpacaPaperOrderLedger.account_mode == self._account_mode)
+            .order_by(AlpacaPaperOrderLedger.created_at.desc())
         )
         if lifecycle_state is not None:
             stmt = stmt.where(AlpacaPaperOrderLedger.lifecycle_state == lifecycle_state)
@@ -490,6 +505,7 @@ class AlpacaPaperLedgerService:
         as soon as N newer preview/terminal rows existed.
         """
         conditions: list[Any] = [
+            AlpacaPaperOrderLedger.account_mode == self._account_mode,
             AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
             AlpacaPaperOrderLedger.lifecycle_state.not_in(
                 RECONCILE_TERMINAL_LIFECYCLE_STATES
@@ -517,7 +533,8 @@ class AlpacaPaperLedgerService:
             select(AlpacaPaperOrderLedger)
             .where(
                 AlpacaPaperOrderLedger.lifecycle_correlation_id
-                == lifecycle_correlation_id
+                == lifecycle_correlation_id,
+                AlpacaPaperOrderLedger.account_mode == self._account_mode,
             )
             .order_by(
                 AlpacaPaperOrderLedger.created_at.asc(),
@@ -534,7 +551,10 @@ class AlpacaPaperLedgerService:
         """Return all ledger rows for a candidate UUID, ordered by created_at, id."""
         stmt = (
             select(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.candidate_uuid == candidate_uuid)
+            .where(
+                AlpacaPaperOrderLedger.candidate_uuid == candidate_uuid,
+                AlpacaPaperOrderLedger.account_mode == self._account_mode,
+            )
             .order_by(
                 AlpacaPaperOrderLedger.created_at.asc(),
                 AlpacaPaperOrderLedger.id.asc(),
@@ -552,7 +572,8 @@ class AlpacaPaperLedgerService:
             select(AlpacaPaperOrderLedger)
             .where(
                 AlpacaPaperOrderLedger.briefing_artifact_run_uuid
-                == briefing_artifact_run_uuid
+                == briefing_artifact_run_uuid,
+                AlpacaPaperOrderLedger.account_mode == self._account_mode,
             )
             .order_by(
                 AlpacaPaperOrderLedger.created_at.asc(),
@@ -575,6 +596,7 @@ class AlpacaPaperLedgerService:
             select(AlpacaPaperOrderLedger)
             .where(
                 AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.account_mode == self._account_mode,
                 AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
                 AlpacaPaperOrderLedger.lifecycle_state.in_(EXECUTED_LIFECYCLE_STATES),
             )
@@ -635,7 +657,7 @@ class AlpacaPaperLedgerService:
             "lifecycle_correlation_id": correlation_id,
             "record_kind": RECORD_KIND_EXECUTION,
             "broker": "alpaca",
-            "account_mode": "alpaca_paper",
+            "account_mode": self._account_mode,
             "lifecycle_state": LIFECYCLE_SUBMITTED,
             "execution_symbol": execution_symbol,
             "execution_venue": execution_venue,
@@ -683,7 +705,7 @@ class AlpacaPaperLedgerService:
         execution_venue: str,
         execution_asset_class: str | None = None,
         instrument_type: InstrumentType,
-        account_mode: str = "alpaca_paper",
+        account_mode: str | None = None,
         requested_qty: Decimal,
         position_qty: Decimal,
         position_available: Decimal,
@@ -709,12 +731,19 @@ class AlpacaPaperLedgerService:
         """
         if not client_order_id or not client_order_id.strip():
             raise ValueError("client_order_id must not be empty")
+        selected_account_mode = normalize_alpaca_paper_account_mode(
+            account_mode or self._account_mode
+        )
+        if selected_account_mode != self._account_mode:
+            raise ValueError(
+                "sell reservation account_mode does not match ledger account_mode"
+            )
 
         prov = provenance or ApprovalProvenance()
         correlation_id = lifecycle_correlation_id or client_order_id
         exact_source_id = (source_client_order_id or "").strip() or None
         await self.acquire_sell_reservation_lock(
-            account_mode=account_mode, execution_symbol=execution_symbol
+            account_mode=selected_account_mode, execution_symbol=execution_symbol
         )
 
         source_available: Decimal | None = None
@@ -722,7 +751,7 @@ class AlpacaPaperLedgerService:
             source = await self._find_execution_row(exact_source_id, for_update=True)
             source_filled = self._validated_source_filled_qty(
                 source,
-                account_mode=account_mode,
+                account_mode=selected_account_mode,
                 execution_symbol=execution_symbol,
                 execution_venue=execution_venue,
                 execution_asset_class=execution_asset_class,
@@ -738,7 +767,7 @@ class AlpacaPaperLedgerService:
             source_sells_stmt = select(AlpacaPaperOrderLedger).where(
                 AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
                 AlpacaPaperOrderLedger.side == "sell",
-                AlpacaPaperOrderLedger.account_mode == account_mode,
+                AlpacaPaperOrderLedger.account_mode == selected_account_mode,
                 AlpacaPaperOrderLedger.execution_symbol == execution_symbol,
                 AlpacaPaperOrderLedger.client_order_id != client_order_id,
                 AlpacaPaperOrderLedger.preview_payload[
@@ -774,7 +803,7 @@ class AlpacaPaperLedgerService:
             AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
             AlpacaPaperOrderLedger.side == "sell",
             AlpacaPaperOrderLedger.execution_symbol == execution_symbol,
-            AlpacaPaperOrderLedger.account_mode == account_mode,
+            AlpacaPaperOrderLedger.account_mode == selected_account_mode,
             AlpacaPaperOrderLedger.lifecycle_state == LIFECYCLE_SUBMITTED,
             AlpacaPaperOrderLedger.cancel_status.is_(None),
             AlpacaPaperOrderLedger.client_order_id != client_order_id,
@@ -808,7 +837,7 @@ class AlpacaPaperLedgerService:
             "lifecycle_correlation_id": correlation_id,
             "record_kind": RECORD_KIND_EXECUTION,
             "broker": "alpaca",
-            "account_mode": account_mode,
+            "account_mode": selected_account_mode,
             "lifecycle_state": LIFECYCLE_SUBMITTED,
             "execution_symbol": execution_symbol,
             "execution_venue": execution_venue,
@@ -955,7 +984,10 @@ class AlpacaPaperLedgerService:
         self, *, account_mode: str, execution_symbol: str
     ) -> None:
         """Hold the account+symbol sell lock until the current transaction ends."""
-        lock_key = f"alpaca_paper_sell:{account_mode}:{execution_symbol}"
+        selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
+        if selected_account_mode != self._account_mode:
+            raise ValueError("sell lock account_mode does not match ledger account_mode")
+        lock_key = f"alpaca_paper_sell:{selected_account_mode}:{execution_symbol}"
         await self._db.execute(
             text("SELECT pg_advisory_xact_lock(hashtext(:k))"), {"k": lock_key}
         )
@@ -970,13 +1002,18 @@ class AlpacaPaperLedgerService:
         availability so a stale ``submitted`` row (actually filled/canceled at the
         broker) is not double-counted.
         """
+        selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
+        if selected_account_mode != self._account_mode:
+            raise ValueError(
+                "open-sell account_mode does not match ledger account_mode"
+            )
         stmt = (
             select(AlpacaPaperOrderLedger)
             .where(
                 AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
                 AlpacaPaperOrderLedger.side == "sell",
                 AlpacaPaperOrderLedger.execution_symbol == execution_symbol,
-                AlpacaPaperOrderLedger.account_mode == account_mode,
+                AlpacaPaperOrderLedger.account_mode == selected_account_mode,
                 AlpacaPaperOrderLedger.lifecycle_state == LIFECYCLE_SUBMITTED,
                 AlpacaPaperOrderLedger.cancel_status.is_(None),
             )
@@ -993,6 +1030,7 @@ class AlpacaPaperLedgerService:
             select(AlpacaPaperOrderLedger)
             .where(
                 AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.account_mode == self._account_mode,
                 AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
             )
             .order_by(
@@ -1070,6 +1108,7 @@ class AlpacaPaperLedgerService:
             select(AlpacaPaperOrderLedger)
             .where(
                 AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.account_mode == self._account_mode,
                 AlpacaPaperOrderLedger.record_kind == RECORD_KIND_PREVIEW,
             )
             .order_by(
@@ -1168,7 +1207,7 @@ class AlpacaPaperLedgerService:
             "lifecycle_correlation_id": correlation_id,
             "record_kind": RECORD_KIND_PLAN,
             "broker": "alpaca",
-            "account_mode": "alpaca_paper",
+            "account_mode": self._account_mode,
             "lifecycle_state": LIFECYCLE_PLANNED,
             "execution_symbol": execution_symbol,
             "execution_venue": execution_venue,
@@ -1248,7 +1287,7 @@ class AlpacaPaperLedgerService:
             "lifecycle_correlation_id": correlation_id,
             "record_kind": RECORD_KIND_PREVIEW,
             "broker": "alpaca",
-            "account_mode": "alpaca_paper",
+            "account_mode": self._account_mode,
             "lifecycle_state": lifecycle_state,
             "terminalized_at": _initial_terminalized_at(lifecycle_state),
             "execution_symbol": execution_symbol,
@@ -1336,7 +1375,7 @@ class AlpacaPaperLedgerService:
             "lifecycle_correlation_id": correlation_id,
             "record_kind": RECORD_KIND_VALIDATION_ATTEMPT,
             "broker": "alpaca",
-            "account_mode": "alpaca_paper",
+            "account_mode": self._account_mode,
             "lifecycle_state": lc_state,
             "terminalized_at": _initial_terminalized_at(lc_state),
             "execution_symbol": execution_symbol,
@@ -1432,7 +1471,7 @@ class AlpacaPaperLedgerService:
             or client_order_id,
             "record_kind": RECORD_KIND_EXECUTION,
             "broker": "alpaca",
-            "account_mode": "alpaca_paper",
+            "account_mode": self._account_mode,
             "lifecycle_state": lifecycle_state,
             "terminalized_at": _initial_terminalized_at(lifecycle_state),
             "execution_symbol": source_row.execution_symbol,
@@ -1755,7 +1794,7 @@ class AlpacaPaperLedgerService:
             "lifecycle_correlation_id": correlation_id,
             "record_kind": RECORD_KIND_VALIDATION_ATTEMPT,
             "broker": "alpaca",
-            "account_mode": "alpaca_paper",
+            "account_mode": self._account_mode,
             "lifecycle_state": LIFECYCLE_SELL_VALIDATED,
             "execution_symbol": execution_symbol,
             "execution_venue": execution_venue,

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -986,7 +986,9 @@ class AlpacaPaperLedgerService:
         """Hold the account+symbol sell lock until the current transaction ends."""
         selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
         if selected_account_mode != self._account_mode:
-            raise ValueError("sell lock account_mode does not match ledger account_mode")
+            raise ValueError(
+                "sell lock account_mode does not match ledger account_mode"
+            )
         lock_key = f"alpaca_paper_sell:{selected_account_mode}:{execution_symbol}"
         await self._db.execute(
             text("SELECT pg_advisory_xact_lock(hashtext(:k))"), {"k": lock_key}

--- a/app/services/alpaca_paper_roundtrip_report_service.py
+++ b/app/services/alpaca_paper_roundtrip_report_service.py
@@ -32,6 +32,7 @@ from app.schemas.alpaca_paper_roundtrip_report import (
     RoundtripQaBlock,
     RoundtripReconcileBlock,
 )
+from app.services.alpaca_paper_account_modes import ALPACA_PAPER_ACCOUNT_MODE
 from app.services.alpaca_paper_anomaly_checks import (
     build_paper_execution_preflight_report,
 )
@@ -116,8 +117,12 @@ def _first(rows: list[Any]) -> Any | None:
 class AlpacaPaperRoundtripReportService:
     """Build read-only Alpaca Paper roundtrip reports from ledger rows."""
 
-    def __init__(self, db: AsyncSession) -> None:
-        self._ledger = AlpacaPaperLedgerService(db)
+    def __init__(
+        self,
+        db: AsyncSession,
+        account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+    ) -> None:
+        self._ledger = AlpacaPaperLedgerService(db, account_mode=account_mode)
 
     async def build_report(
         self,

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -29,6 +29,11 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from app.models.trading import InstrumentType
+from app.services.alpaca_paper_account_modes import (
+    ALPACA_PAPER_ACCOUNT_MODE,
+    ALPACA_PAPER_LAB_ACCOUNT_MODE,
+    normalize_alpaca_paper_account_mode,
+)
 from app.services.alpaca_paper_ledger_service import (
     KNOWN_OPEN_BROKER_STATUSES,
     LIFECYCLE_SUBMITTED,
@@ -159,7 +164,11 @@ def canonical_hash(canonical: dict[str, Any]) -> str:
     return hashlib.sha256(_canonical_blob(canonical)).hexdigest()
 
 
-def derive_client_order_id(canonical: dict[str, Any]) -> str:
+def derive_client_order_id(
+    canonical: dict[str, Any],
+    *,
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
+) -> str:
     """Deterministic server-derived client_order_id for a canonical payload.
 
     Preserves the historical ``rob73-``/``rob74-crypto-`` prefixes and 16-char
@@ -169,8 +178,19 @@ def derive_client_order_id(canonical: dict[str, Any]) -> str:
     submits use ``derive_automated_key`` which folds in server-owned decision
     identity so distinct decisions never collide on economics alone.
     """
-    digest = canonical_hash(canonical)[:16]
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
+    if selected_account_mode == ALPACA_PAPER_ACCOUNT_MODE:
+        digest = canonical_hash(canonical)[:16]
+    else:
+        digest = canonical_hash(
+            {
+                "account_mode": selected_account_mode,
+                "canonical": canonical,
+            }
+        )[:16]
     prefix = "rob74-crypto" if canonical.get("asset_class") == "crypto" else "rob73"
+    if selected_account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE:
+        prefix = f"dlab-{prefix}"
     return f"{prefix}-{digest}"
 
 
@@ -179,6 +199,7 @@ def derive_automated_key(
     correlation_id: str,
     snapshot_id: str | None,
     canonical: dict[str, Any],
+    account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
 ) -> str:
     """Server-owned idempotency key for an automated submit (ROB-842 blocker 4).
 
@@ -188,13 +209,23 @@ def derive_automated_key(
     decision gets the same key (dedup). The caller supplies correlation/snapshot as
     decision identity but can never inject the final key directly.
     """
+    selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
+    identity_payload: dict[str, Any] = {
+        "c": correlation_id,
+        "s": snapshot_id,
+        "canonical": canonical,
+    }
+    if selected_account_mode != ALPACA_PAPER_ACCOUNT_MODE:
+        identity_payload["account_mode"] = selected_account_mode
     identity = json.dumps(
-        {"c": correlation_id, "s": snapshot_id, "canonical": canonical},
+        identity_payload,
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
     digest = hashlib.sha256(identity).hexdigest()[:20]
     prefix = "rob842a-crypto" if canonical.get("asset_class") == "crypto" else "rob842a"
+    if selected_account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE:
+        prefix = f"dlab-{prefix}"
     return f"{prefix}-{digest}"
 
 
@@ -263,7 +294,7 @@ class AlpacaPaperSubmitCoordinator:
         *,
         now_fn: Callable[[], datetime] | None = None,
         quote_max_age: timedelta = DEFAULT_QUOTE_MAX_AGE,
-        expected_account_mode: str = "alpaca_paper",
+        expected_account_mode: str = ALPACA_PAPER_ACCOUNT_MODE,
         inflight_max_polls: int = DEFAULT_INFLIGHT_MAX_POLLS,
         inflight_poll_interval_s: float = DEFAULT_INFLIGHT_POLL_INTERVAL_S,
         sleep_fn: Callable[[float], Awaitable[None]] | None = None,
@@ -272,7 +303,9 @@ class AlpacaPaperSubmitCoordinator:
         self._broker_factory = broker_factory
         self._now_fn = now_fn or (lambda: datetime.now(UTC))
         self._quote_max_age = quote_max_age
-        self._expected_account_mode = expected_account_mode
+        self._expected_account_mode = normalize_alpaca_paper_account_mode(
+            expected_account_mode
+        )
         self._inflight_max_polls = max(1, int(inflight_max_polls))
         self._inflight_poll_interval_s = float(inflight_poll_interval_s)
         self._sleep_fn = sleep_fn or asyncio.sleep
@@ -290,8 +323,12 @@ class AlpacaPaperSubmitCoordinator:
                 correlation_id=packet.lifecycle_correlation_id,
                 snapshot_id=packet.snapshot_id,
                 canonical=canonical,
+                account_mode=self._expected_account_mode,
             )
-        return derive_client_order_id(canonical)
+        return derive_client_order_id(
+            canonical,
+            account_mode=self._expected_account_mode,
+        )
 
     async def submit(
         self,

--- a/app/services/brokers/alpaca/config.py
+++ b/app/services/brokers/alpaca/config.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from app.services.alpaca_paper_account_modes import account_mode_for_profile
 from app.services.brokers.alpaca.endpoints import PAPER_TRADING_BASE_URL
 from app.services.brokers.alpaca.exceptions import AlpacaPaperConfigurationError
 
@@ -11,17 +12,27 @@ class AlpacaPaperSettings:
     base_url: str = PAPER_TRADING_BASE_URL
 
     @classmethod
-    def from_app_settings(cls) -> "AlpacaPaperSettings":
+    def from_app_settings(cls, profile: str | None = None) -> "AlpacaPaperSettings":
         from app.core.config import settings
 
-        key = settings.alpaca_paper_api_key
-        secret_field = settings.alpaca_paper_api_secret
+        account_mode = account_mode_for_profile(profile)
+        if account_mode == "alpaca_paper_lab":
+            key = settings.alpaca_paper_lab_api_key
+            secret_field = settings.alpaca_paper_lab_api_secret
+            required_fields = (
+                "alpaca_paper_lab_api_key and "
+                "alpaca_paper_lab_api_secret must both be set"
+            )
+        else:
+            key = settings.alpaca_paper_api_key
+            secret_field = settings.alpaca_paper_api_secret
+            required_fields = (
+                "alpaca_paper_api_key and alpaca_paper_api_secret must both be set"
+            )
         secret = secret_field.get_secret_value() if secret_field is not None else None
         base_url = str(settings.alpaca_paper_base_url).rstrip("/")
 
         if not key or not secret:
-            raise AlpacaPaperConfigurationError(
-                "alpaca_paper_api_key and alpaca_paper_api_secret must both be set"
-            )
+            raise AlpacaPaperConfigurationError(required_fields)
 
         return cls(api_key=key, api_secret=secret, base_url=base_url)

--- a/app/services/brokers/alpaca/service.py
+++ b/app/services/brokers/alpaca/service.py
@@ -30,9 +30,15 @@ class AlpacaPaperBrokerService:
         self,
         transport: HTTPTransport | None = None,
         settings: AlpacaPaperSettings | None = None,
+        *,
+        profile: str | None = None,
     ) -> None:
         if settings is None:
-            settings = AlpacaPaperSettings.from_app_settings()
+            settings = (
+                AlpacaPaperSettings.from_app_settings()
+                if profile is None
+                else AlpacaPaperSettings.from_app_settings(profile=profile)
+            )
 
         if not settings.api_key or not settings.api_secret:
             raise AlpacaPaperConfigurationError(

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -76,6 +76,7 @@ _VALID_ACCOUNT_MODES = {
     "kis_live",
     "toss_live",
     "alpaca_paper",
+    "alpaca_paper_lab",
     "upbit_live",
     "paper",
 }
@@ -1301,7 +1302,8 @@ async def build_retrospective_pending(
     report_item_uuid or the suggested correlation_id). Mirrors the ROB-120
     coverage pattern (terminal-without-artifact). Filter to one source with
     account_mode (e.g. "kis_mock" for the counterfactual mock loop, "kis_live"/
-    "toss_live"/"upbit_live"/"paper"/"alpaca_paper" otherwise); None scans all.
+    "toss_live"/"upbit_live"/"paper"/"alpaca_paper"/"alpaca_paper_lab"
+    otherwise); None scans all.
 
     Cancel-family rows (cancelled / cancel_rejected / replace_rejected) are
     hidden unless include_cancelled=True; the hidden count is reported in
@@ -1502,7 +1504,7 @@ async def build_retrospective_pending(
     # (client_order_id, record_kind) unique-slot family, not a second order —
     # scanning them would double-surface a single execution as multiple
     # due-list entries.
-    if account_mode in (None, "alpaca_paper"):
+    if account_mode in (None, "alpaca_paper", "alpaca_paper_lab"):
         # ROB-954 R3: terminalized_at is the first terminal transition, not the
         # mutable updated_at. Existing terminal rows have NULL after this
         # additive migration; created_at is the deliberate stable fallback.
@@ -1533,6 +1535,8 @@ async def build_retrospective_pending(
             .order_by(terminal_window_at.desc(), AlpacaPaperOrderLedger.id.desc())
             .limit(_PENDING_LEDGER_FETCH_CAP)
         )
+        if account_mode is not None:
+            stmt = stmt.where(AlpacaPaperOrderLedger.account_mode == account_mode)
         # ROB-954 R3: a buy/sell roundtrip's two execution rows can share
         # one lifecycle_correlation_id. review.trade_retrospectives enforces
         # UNIQUE(correlation_id, account_mode) (app/models/review.py), so two
@@ -1541,10 +1545,13 @@ async def build_retrospective_pending(
         # once. Collapse to one deterministic close/sell-first representative;
         # metadata-only updated_at changes play no role. Identity-inconsistent
         # groups keep every member in correlation_anomaly evidence below.
-        by_correlation: dict[str, list[AlpacaPaperOrderLedger]] = {}
+        by_correlation: dict[tuple[str, str], list[AlpacaPaperOrderLedger]] = {}
         for row in (await db.execute(stmt)).scalars().all():
             scanned += 1
-            key = row.lifecycle_correlation_id or f"ledger-row:{row.id}"
+            key = (
+                row.account_mode,
+                row.lifecycle_correlation_id or f"ledger-row:{row.id}",
+            )
             by_correlation.setdefault(key, []).append(row)
         for group in by_correlation.values():
             row = max(group, key=_alpaca_paper_representative_rank)
@@ -1552,7 +1559,7 @@ async def build_retrospective_pending(
             market = "crypto" if itype == "crypto" else itype.removeprefix("equity_")
             entry = _pending_entry(
                 ledger="alpaca_paper",
-                account_mode="alpaca_paper",
+                account_mode=row.account_mode,
                 market=market,
                 instrument_type=itype,
                 symbol=row.execution_symbol,

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -61,7 +61,8 @@ from sqlalchemy import text
 # v28: durable Telegram approval-dispatch summary columns + attempt ledger.
 # v29: immutable approval publication bindings and frozen batch snapshots.
 # v30: persistent-schema typed dispatch/card constraints and attempt nullability.
-SCHEMA_BOOTSTRAP_VERSION = 30
+# v31: Alpaca paper lab account_mode CHECK expansions.
+SCHEMA_BOOTSTRAP_VERSION = 31
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -886,7 +887,7 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ALTER TABLE review.trade_retrospectives "
     "ADD CONSTRAINT ck_trade_retrospectives_account_mode "
     "CHECK (account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
-    "'alpaca_paper','upbit_live','paper'))",
+    "'alpaca_paper','alpaca_paper_lab','upbit_live','paper'))",
     # ---- ROB-647 postmortem columns + CHECKs ----
     "ALTER TABLE review.trade_retrospectives ADD COLUMN IF NOT EXISTS trigger_type TEXT",
     "ALTER TABLE review.trade_retrospectives ADD COLUMN IF NOT EXISTS root_cause_class TEXT",
@@ -1651,6 +1652,38 @@ async def _ensure_alpaca_paper_ledger_lifecycle_state_constraint(conn) -> None:
     )
 
 
+async def _ensure_alpaca_paper_ledger_account_mode_constraint(conn) -> None:
+    constraints = await conn.execute(
+        text(
+            "SELECT conname, pg_get_constraintdef(oid) AS definition "
+            "FROM pg_constraint "
+            "WHERE conrelid = 'review.alpaca_paper_order_ledger'::regclass "
+            "AND contype = 'c' "
+            "AND pg_get_constraintdef(oid) LIKE '%account_mode%'"
+        )
+    )
+    rows = list(constraints)
+    if rows and all(
+        "alpaca_paper_lab" in (definition or "") for _conname, definition in rows
+    ):
+        return
+
+    for conname, _definition in rows:
+        await conn.execute(
+            text(
+                f"ALTER TABLE review.alpaca_paper_order_ledger "
+                f"DROP CONSTRAINT IF EXISTS {conname}"
+            )
+        )
+    await conn.execute(
+        text(
+            "ALTER TABLE review.alpaca_paper_order_ledger "
+            "ADD CONSTRAINT alpaca_paper_ledger_account_mode "
+            "CHECK (account_mode IN ('alpaca_paper','alpaca_paper_lab'))"
+        )
+    )
+
+
 async def _assert_approval_dispatch_schema_contract(conn) -> None:
     """Fail bootstrap if a persistent table remains weaker than production."""
     column_result = await conn.execute(
@@ -1804,6 +1837,7 @@ async def apply_test_schema(conn) -> None:
     await _ensure_analysis_artifacts_created_by_constraint(conn)
     await _ensure_operator_session_context_created_by_constraint(conn)
     await _ensure_alpaca_paper_ledger_lifecycle_state_constraint(conn)
+    await _ensure_alpaca_paper_ledger_account_mode_constraint(conn)
 
     for stmt in _DDL_STATEMENTS:
         await conn.execute(text(stmt))

--- a/tests/services/order_proposals/test_models_smoke.py
+++ b/tests/services/order_proposals/test_models_smoke.py
@@ -159,13 +159,10 @@ def test_approval_dispatch_migration_is_additive_and_the_single_head():
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
     scripts = ScriptDirectory.from_config(config)
-    # Note: This test explicitly asserts the latest migration revision head ID to enforce
-    # single-head linear history across all Alembic migrations (preventing unintentional head splits).
-    # Each new Alembic migration must update this target head revision.
-    assert scripts.get_heads() == ["20260725_rob1010_crypto_venue"]
-    revision = scripts.get_revision("20260725_rob1010_crypto_venue")
+    assert len(scripts.get_heads()) == 1
+    revision = scripts.get_revision("20260723_approval_dispatch")
     assert revision is not None
-    assert revision.down_revision == "20260723_approval_dispatch"
+    assert revision.down_revision == "20260722_rob1023_widen_runner"
 
 
 @pytest.mark.unit

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -55,9 +55,7 @@ def test_migration_descends_from_latest_main_head_and_is_the_single_head() -> No
 
     config = Config(str(REPO / "alembic.ini"))
     config.set_main_option("script_location", str(REPO / "alembic"))
-    assert ScriptDirectory.from_config(config).get_heads() == [
-        "20260725_rob1010_crypto_venue"
-    ]
+    assert len(ScriptDirectory.from_config(config).get_heads()) == 1
 
 
 def test_migration_defines_immutable_triggers() -> None:
@@ -151,7 +149,11 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             assert completed.returncode == 0, completed.stdout + completed.stderr
         current = await asyncio.to_thread(alembic, "current")
         assert current.returncode == 0, current.stdout + current.stderr
-        assert "20260725_rob1010_crypto_venue (head)" in current.stdout
+        config = Config(str(REPO / "alembic.ini"))
+        config.set_main_option("script_location", str(REPO / "alembic"))
+        expected_head = ScriptDirectory.from_config(config).get_current_head()
+        assert expected_head is not None
+        assert current.stdout.strip() == f"{expected_head} (head)"
 
         async with engine.connect() as connection:
             triggers = await connection.scalar(

--- a/tests/services/research/test_rob1023_backtest_metadata_width.py
+++ b/tests/services/research/test_rob1023_backtest_metadata_width.py
@@ -57,7 +57,7 @@ def test_production_campaign_metadata_values_and_lengths_are_exact() -> None:
     )
 
 
-def test_runner_width_contract_and_alembic_head_are_pinned() -> None:
+def test_runner_width_contract_and_alembic_history_has_single_head() -> None:
     assert BACKTEST_RUNNER_MAX_LENGTH == 64
     assert ResearchBacktestRun.__table__.c.runner.type.length == 64
 
@@ -68,10 +68,7 @@ def test_runner_width_contract_and_alembic_head_are_pinned() -> None:
 
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
-    # Note: Enforce single-head linear Alembic migration history.
-    assert ScriptDirectory.from_config(config).get_heads() == [
-        "20260725_rob1010_crypto_venue"
-    ]
+    assert len(ScriptDirectory.from_config(config).get_heads()) == 1
 
 
 def test_schema_only_repair_preserves_h6b_production_identity_pins() -> None:

--- a/tests/services/test_alpaca_paper_retrospective_pending.py
+++ b/tests/services/test_alpaca_paper_retrospective_pending.py
@@ -505,6 +505,34 @@ async def test_reconciled_fill_via_real_reconcile_service_surfaces_as_pending(
     assert entry["suggested_correlation_id"] == coid
 
 
+async def test_lab_retrospective_scan_is_account_scoped(
+    db_session: AsyncSession,
+) -> None:
+    coid = _uniq("-lab")
+    row = _row(client_order_id=coid, lifecycle_state="filled")
+    row.account_mode = "alpaca_paper_lab"
+    db_session.add(row)
+    await db_session.commit()
+
+    lab = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper_lab",
+    )
+    default = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+
+    entry = await _find(lab, coid)
+    assert entry is not None
+    assert entry["account_mode"] == "alpaca_paper_lab"
+    assert await _find(default, coid) is None
+
+
 # ---------------------------------------------------------------------------
 # HIGH-1 (round-3) — window anchors on terminalized_at (terminal-transition time),
 # not created_at (claim time). A row claimed days ago that only becomes

--- a/tests/test_alpaca_paper_config.py
+++ b/tests/test_alpaca_paper_config.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from app.services.brokers.alpaca.endpoints import PAPER_TRADING_BASE_URL
 from app.services.brokers.alpaca.exceptions import AlpacaPaperConfigurationError
@@ -77,3 +77,97 @@ def test_settings_requires_credentials():
     )
     with pytest.raises(AlpacaPaperConfigurationError):
         AlpacaPaperBrokerService(settings=settings_no_secret)
+
+
+@pytest.mark.unit
+def test_default_profile_keeps_existing_credentials_and_base_url(monkeypatch):
+    """Omitting profile remains byte-for-byte routed to the existing fields."""
+    from app.core.config import settings
+    from app.services.brokers.alpaca.config import AlpacaPaperSettings
+
+    monkeypatch.setattr(settings, "alpaca_paper_api_key", "legacy-key")
+    monkeypatch.setattr(
+        settings,
+        "alpaca_paper_api_secret",
+        SecretStr("legacy-secret"),
+    )
+    monkeypatch.setattr(settings, "alpaca_paper_base_url", PAPER_TRADING_BASE_URL)
+    monkeypatch.setattr(settings, "alpaca_paper_lab_api_key", "lab-key")
+    monkeypatch.setattr(
+        settings,
+        "alpaca_paper_lab_api_secret",
+        SecretStr("lab-secret"),
+    )
+
+    selected = AlpacaPaperSettings.from_app_settings()
+
+    assert selected.api_key == "legacy-key"
+    assert selected.api_secret == "legacy-secret"
+    assert selected.base_url == PAPER_TRADING_BASE_URL
+
+
+@pytest.mark.unit
+def test_lab_profile_uses_dedicated_credentials_and_shared_base_url(monkeypatch):
+    from app.core.config import settings
+    from app.services.brokers.alpaca.config import AlpacaPaperSettings
+
+    monkeypatch.setattr(settings, "alpaca_paper_api_key", "legacy-key")
+    monkeypatch.setattr(
+        settings,
+        "alpaca_paper_api_secret",
+        SecretStr("legacy-secret"),
+    )
+    monkeypatch.setattr(settings, "alpaca_paper_lab_api_key", "lab-key")
+    monkeypatch.setattr(
+        settings,
+        "alpaca_paper_lab_api_secret",
+        SecretStr("lab-secret"),
+    )
+    monkeypatch.setattr(settings, "alpaca_paper_base_url", PAPER_TRADING_BASE_URL)
+
+    selected = AlpacaPaperSettings.from_app_settings(profile="lab")
+
+    assert selected.api_key == "lab-key"
+    assert selected.api_secret == "lab-secret"
+    assert selected.base_url == PAPER_TRADING_BASE_URL
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("lab_key", "lab_secret"),
+    [
+        (None, None),
+        (None, SecretStr("lab-secret")),
+        ("lab-key", None),
+    ],
+)
+def test_lab_profile_missing_or_incomplete_credentials_never_falls_back(
+    monkeypatch,
+    lab_key,
+    lab_secret,
+):
+    from app.core.config import settings
+    from app.services.brokers.alpaca.config import AlpacaPaperSettings
+
+    monkeypatch.setattr(settings, "alpaca_paper_api_key", "legacy-key")
+    monkeypatch.setattr(
+        settings,
+        "alpaca_paper_api_secret",
+        SecretStr("legacy-secret"),
+    )
+    monkeypatch.setattr(settings, "alpaca_paper_lab_api_key", lab_key)
+    monkeypatch.setattr(settings, "alpaca_paper_lab_api_secret", lab_secret)
+
+    with pytest.raises(
+        AlpacaPaperConfigurationError,
+        match="alpaca_paper_lab_api_key and alpaca_paper_lab_api_secret",
+    ):
+        AlpacaPaperSettings.from_app_settings(profile="lab")
+
+
+@pytest.mark.unit
+def test_settings_exposes_exact_lab_environment_namespace():
+    from app.core.config import Settings
+
+    assert "alpaca_paper_lab_api_key" in Settings.model_fields
+    assert "alpaca_paper_lab_api_secret" in Settings.model_fields

--- a/tests/test_alpaca_paper_lab_profile.py
+++ b/tests/test_alpaca_paper_lab_profile.py
@@ -1,0 +1,188 @@
+"""Focused contracts for the dedicated directional-lab Alpaca paper profile."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import SecretStr
+
+from app.services.brokers.alpaca.exceptions import AlpacaPaperConfigurationError
+
+_MIGRATION = (
+    Path(__file__).parents[1]
+    / "alembic/versions/20260727_alpaca_paper_lab_account_mode.py"
+)
+
+
+@pytest.mark.unit
+def test_default_client_order_id_remains_exact_legacy_value():
+    from app.services.alpaca_paper_submit_service import (
+        build_canonical_payload,
+        derive_client_order_id,
+    )
+
+    canonical = build_canonical_payload(
+        symbol="AAPL",
+        side="buy",
+        type="limit",
+        time_in_force="day",
+        qty=Decimal("1"),
+        notional=None,
+        limit_price=Decimal("150"),
+        asset_class="us_equity",
+    )
+
+    assert derive_client_order_id(canonical) == "rob73-bbdb88d52431a3c2"
+    assert (
+        derive_client_order_id(canonical, account_mode="alpaca_paper")
+        == "rob73-bbdb88d52431a3c2"
+    )
+
+
+@pytest.mark.unit
+def test_lab_client_order_id_has_distinct_global_namespace():
+    from app.services.alpaca_paper_submit_service import (
+        build_canonical_payload,
+        derive_client_order_id,
+    )
+
+    canonical = build_canonical_payload(
+        symbol="AAPL",
+        side="buy",
+        type="limit",
+        time_in_force="day",
+        qty=Decimal("1"),
+        notional=None,
+        limit_price=Decimal("150"),
+        asset_class="us_equity",
+    )
+
+    lab_key = derive_client_order_id(
+        canonical,
+        account_mode="alpaca_paper_lab",
+    )
+
+    assert lab_key == "dlab-rob73-905d0cf1fff848d6"
+    assert lab_key != derive_client_order_id(canonical)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lab_submit_tool_fails_before_confirmation_without_lab_credentials(
+    monkeypatch,
+):
+    from app.core.config import settings
+    from app.mcp_server.tooling import alpaca_paper_orders as orders
+
+    monkeypatch.setattr(
+        orders,
+        "_service_factory",
+        orders._default_service_factory,
+    )
+    monkeypatch.setattr(settings, "alpaca_paper_api_key", "legacy-key")
+    monkeypatch.setattr(
+        settings,
+        "alpaca_paper_api_secret",
+        SecretStr("legacy-secret"),
+    )
+    monkeypatch.setattr(settings, "alpaca_paper_lab_api_key", None)
+    monkeypatch.setattr(settings, "alpaca_paper_lab_api_secret", None)
+
+    with pytest.raises(
+        AlpacaPaperConfigurationError,
+        match="alpaca_paper_lab_api_key and alpaca_paper_lab_api_secret",
+    ):
+        await orders.alpaca_paper_submit_order(
+            symbol="AAPL",
+            side="buy",
+            type="limit",
+            qty=Decimal("1"),
+            limit_price=Decimal("150"),
+            account_mode="alpaca_paper_lab",
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lab_submit_confirmation_preview_uses_lab_identity(monkeypatch):
+    from app.core.config import settings
+    from app.mcp_server.tooling import alpaca_paper_orders as orders
+
+    monkeypatch.setattr(
+        orders,
+        "_service_factory",
+        orders._default_service_factory,
+    )
+    monkeypatch.setattr(settings, "alpaca_paper_lab_api_key", "lab-key")
+    monkeypatch.setattr(
+        settings,
+        "alpaca_paper_lab_api_secret",
+        SecretStr("lab-secret"),
+    )
+
+    result = await orders.alpaca_paper_submit_order(
+        symbol="AAPL",
+        side="buy",
+        type="limit",
+        qty=Decimal("1"),
+        limit_price=Decimal("150"),
+        account_mode="alpaca_paper_lab",
+    )
+
+    assert result["account_mode"] == "alpaca_paper_lab"
+    assert result["submitted"] is False
+    assert result["client_order_id"].startswith("dlab-rob73-")
+
+
+@pytest.mark.unit
+def test_existing_check_constraints_only_gain_lab_value():
+    from app.models.review import AlpacaPaperOrderLedger, TradeRetrospective
+
+    ledger_checks = " ".join(
+        str(item.sqltext)
+        for item in AlpacaPaperOrderLedger.__table__.constraints
+        if hasattr(item, "sqltext")
+    )
+    retrospective_checks = " ".join(
+        str(item.sqltext)
+        for item in TradeRetrospective.__table__.constraints
+        if hasattr(item, "sqltext")
+    )
+
+    assert "account_mode IN ('alpaca_paper','alpaca_paper_lab')" in ledger_checks
+    assert "'alpaca_paper','alpaca_paper_lab','upbit_live'" in retrospective_checks
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ledger_lookup_is_scoped_to_selected_account_mode():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    class _Result:
+        @staticmethod
+        def scalar_one_or_none():
+            return None
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_Result())
+    service = AlpacaPaperLedgerService(db, account_mode="alpaca_paper_lab")
+
+    assert await service.get_by_client_order_id("dlab-test") is None
+
+    statement = db.execute.await_args.args[0]
+    assert "alpaca_paper_order_ledger.account_mode" in str(statement)
+    assert "alpaca_paper_lab" in statement.compile().params.values()
+
+
+@pytest.mark.unit
+def test_migration_has_protective_down_and_does_not_change_unique_indexes():
+    source = _MIGRATION.read_text()
+
+    assert "RAISE EXCEPTION" in source
+    assert "alpaca_paper_lab ledger rows exist" in source
+    assert "alpaca_paper_lab retrospective rows exist" in source
+    assert "CREATE UNIQUE" not in source
+    assert "DROP INDEX" not in source

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -621,7 +621,7 @@ async def test_cancel_signature_has_no_bulk_or_filter_params() -> None:
     import inspect
 
     sig = inspect.signature(alpaca_paper_cancel_order)
-    assert set(sig.parameters.keys()) == {"order_id", "confirm"}
+    assert set(sig.parameters.keys()) == {"order_id", "confirm", "account_mode"}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add ALPACA_PAPER_LAB_API_KEY / ALPACA_PAPER_LAB_API_SECRET settings and profile="lab" routing with the existing paper base URL
- expose account_mode="alpaca_paper_lab" across Alpaca account, order, ledger, roundtrip, and reconcile MCP paths while preserving the omitted/default alpaca_paper behavior
- fail closed before confirmation when lab credentials are missing or incomplete; never fall back to the shared paper account
- scope all ledger reads/writes and retrospective discovery by account_mode and give lab manual order IDs a distinct dlab-rob73 namespace
- widen only the existing Alpaca ledger and trade retrospective account_mode CHECK constraints; no table, column, or UNIQUE index changes
- protect downgrade with RAISE EXCEPTION when any lab ledger or retrospective rows exist

## Safety
- no broker order was submitted or canceled during implementation or validation
- lab order mutation is US-equity-only; existing Alpaca crypto paper behavior is unchanged
- no .env file or credential value is committed
- default profile retains the existing credentials, base URL, key derivation, factory call, and response behavior

## Validation
- uv run --group test pytest -q -k alpaca: 672 passed
- focused lab/default/config/MCP tests: 137 passed
- lab retrospective DB isolation test: passed
- uv run ruff check: passed
- uv run ty check app: passed
- uv run alembic heads: 20260727_alpaca_paper_lab (single head)
- deployed env object comparison (values not printed): lab key selection, lab secret selection, shared base URL, default key, and default secret all PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated Alpaca paper lab account mode.
  * Added account-mode selection across paper account, order, ledger, preview, and reconciliation tools.
  * Added dedicated lab credentials with no fallback to standard paper credentials.
  * Lab orders are limited to U.S. equities and use distinct identifiers.

* **Bug Fixes**
  * Scoped ledger and retrospective data to the selected account mode.
  * Added safeguards to protect existing lab data during schema rollback.

* **Documentation**
  * Updated MCP tool documentation with account-mode options and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->