### PR TITLE
fix(order-proposals): alert and safely redispatch blocked approvals

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -786,7 +786,15 @@ order mutation.
     adds `approval_dispatch={status:"blocked", code, ...}` with typed
     `EXPIRED`, `INVALID_VALID_UNTIL`, `DEFER_SESSION_CLOSED`,
     `CALENDAR_UNKNOWN`, or `NO_EXECUTABLE_WINDOW` evidence. No Telegram card
-    or approval nonce is published for that dispatch attempt.
+    or approval nonce is published for that dispatch attempt. The blocked
+    attempt is nevertheless finalized durably with
+    `approval_dispatch_state="failed"` and a `CODE/detail` failure code.
+    Every create-time non-sent dispatch also sends a Discord-first operational
+    alert through `discord_webhook_alerts`; callback-generated reconfirm and
+    loss-cut confirmation dispatches use the same alert boundary. The alert
+    includes proposal ID, symbol, side, failure code, and the safe next action.
+    Alert delivery failure is logged at error level and retained in
+    `source_asof.approval_dispatch_alert` instead of being reported as success.
   - When `supersedes_proposal_id` is present, the old group's
     `pending_approval`/`needs_reconfirm` rungs become `superseded`, its
     approval nonce is consumed, and its recorded Telegram message is edited
@@ -849,6 +857,21 @@ order mutation.
     batch instead of editing the published card. Batch callbacks recompute and
     verify the exact ordered membership digest, so a row not shown on the card
     cannot be approved.
+- `order_proposal_redispatch(proposal_id, dry_run=true)`
+  - This is a single-proposal manual lever; there is no automatic redispatch
+    sweep. `dry_run=true` is read-only and must be reviewed before execution.
+  - Only active `limit` + `place` proposals whose prior dispatch is failed (or
+    absent for proposals blocked before the dispatch ledger existed) are
+    eligible. A pending/current dispatch, published card, active or consumed
+    nonce, terminal/approved/cancelled rung, expired/closed/unknown approval
+    window, unsupported action, or market order fails closed.
+  - Every rung receives a fresh broker-safe dry-run preview. The normalized
+    executable price and quantity must exactly match the stored proposal, and a
+    limit that crossed the current market is rejected as a price departure.
+  - `dry_run=false` repeats the checks and sends only a fresh Telegram approval
+    card. It never approves or submits an order. A DB-row-locked nonce guard
+    rejects concurrent redispatch after the first attempt becomes pending or
+    current, so two live approval cards cannot be minted for one proposal.
 - `order_proposal_void(proposal_id, reason)`
   - Requires a non-blank operator reason.
   - Pre-submit rungs retain the existing local `voided` path. An `unverified`

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -22,6 +22,7 @@ from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.alerts import send_approval_dispatch_alert
 from app.services.order_proposals.approval_window import ApprovalWindowDecision
 from app.services.order_proposals.broker_gateway import (
     fetch_operator_void_evidence,
@@ -33,8 +34,10 @@ from app.services.order_proposals.buying_power import (
     default_buying_power_reader,
 )
 from app.services.order_proposals.dispatch import (
+    approval_window_failure_code,
     dispatch_proposal,
     record_approval_dispatch_failure,
+    send_proposal_for_approval,
 )
 from app.services.order_proposals.dispatch_contract import (
     ApprovalDispatchState,
@@ -46,6 +49,7 @@ from app.services.order_proposals.errors import (
     OrderProposalNotFound,
     OrderProposalUnsupportedTargetAction,
 )
+from app.services.order_proposals.redispatch import validate_proposal_redispatch
 from app.services.order_proposals.service import RungInput, check_action_capability
 from app.services.order_proposals.telegram_callback import _safe_edit_message
 
@@ -61,6 +65,7 @@ ORDER_PROPOSAL_TOOL_NAMES: set[str] = {
     "order_proposal_void",
     "order_proposal_expire_sweep",
     "order_proposal_list_expired_defensive",
+    "order_proposal_redispatch",
 }
 
 _MARKET_ALIASES = {"kr": "equity_kr", "us": "equity_us"}
@@ -114,6 +119,7 @@ def _group_dict(g: Any) -> dict[str, Any]:
         ),
         "approval_dispatch_failure_code": g.approval_dispatch_failure_code,
         "approval_dispatch_payload_chars": g.approval_dispatch_payload_chars,
+        "approval_dispatch_alert": (g.source_asof or {}).get("approval_dispatch_alert"),
         "created_at": g.created_at.isoformat() if g.created_at else None,
     }
 
@@ -176,6 +182,40 @@ async def _record_post_commit_dispatch_failure(
             },
         )
         return _approval_dispatch_ledger_error_result()
+
+
+async def _alert_non_sent_dispatch(
+    proposal_id: uuid.UUID,
+    *,
+    dispatch_state: str,
+    dispatch_failure_code: str,
+) -> dict[str, Any]:
+    """Keep alert failure observable without replacing committed create success."""
+    try:
+        alert = await send_approval_dispatch_alert(
+            proposal_id,
+            dispatch_state=dispatch_state,
+            dispatch_failure_code=dispatch_failure_code,
+            now=now_kst(),
+        )
+        return alert.as_dict()
+    except Exception as exc:  # noqa: BLE001 - alerting is secondary to durable dispatch
+        logger.error(
+            "order_proposals.approval_dispatch_alert_boundary_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "dispatch_state": dispatch_state,
+                "dispatch_failure_code": dispatch_failure_code,
+                "alert_failure_code": "approval_dispatch_alert_internal_error",
+                "exception_type": type(exc).__name__,
+            },
+        )
+        return {
+            "state": "failed",
+            "channel": "discord",
+            "failure_code": "approval_dispatch_alert_internal_error",
+            "recorded": False,
+        }
 
 
 async def _dispatch_after_proposal_commit(
@@ -297,12 +337,28 @@ async def _complete_committed_proposal_create(
 
         dispatch_result = await _dispatch_after_proposal_commit(proposal_id)
         if isinstance(dispatch_result, ApprovalWindowDecision):
+            operator_alert = await _alert_non_sent_dispatch(
+                proposal_id,
+                dispatch_state="blocked",
+                dispatch_failure_code=approval_window_failure_code(dispatch_result),
+            )
             result["approval_dispatch"] = {
                 "status": "blocked",
                 **dispatch_result.to_dict(),
+                "operator_alert": operator_alert,
             }
         else:
-            result["approval_dispatch"] = dispatch_result.as_dict()
+            dispatch_payload = dispatch_result.as_dict()
+            if not dispatch_result.ok:
+                operator_alert = await _alert_non_sent_dispatch(
+                    proposal_id,
+                    dispatch_state=dispatch_result.state.value,
+                    dispatch_failure_code=(
+                        dispatch_result.failure_code or dispatch_result.state.value
+                    ),
+                )
+                dispatch_payload["operator_alert"] = operator_alert
+            result["approval_dispatch"] = dispatch_payload
         return result
     except Exception as exc:  # noqa: BLE001 - committed create result is immutable
         logger.error(
@@ -763,6 +819,136 @@ async def order_proposal_list_expired_defensive(
         return {"success": False, "error": str(exc)}
 
 
+async def order_proposal_redispatch(
+    proposal_id: str,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Revalidate and optionally re-send one failed approval card.
+
+    ``dry_run=True`` is read-only and is the required first step. Execution
+    sends only a fresh Telegram approval card; it never approves or submits an
+    order. Only active limit/place proposals with failed-or-missing dispatch,
+    unused/no active nonce, eligible rungs, a live approval window, and exact
+    fresh preview price/quantity are eligible.
+    """
+    try:
+        pid = uuid.UUID(proposal_id)
+    except ValueError:
+        return {"success": False, "error": f"invalid proposal_id {proposal_id!r}"}
+
+    try:
+        now = now_kst()
+        async with AsyncSessionLocal() as session:
+            service = OrderProposalsService(session)
+            group, rungs = await service.get_proposal(pid)
+            validation = await validate_proposal_redispatch(
+                group=group,
+                rungs=rungs,
+                now=now,
+                now_fn=now_kst,
+            )
+        validation_payload = validation.as_dict()
+        base = {
+            "proposal_id": str(pid),
+            "symbol": group.symbol,
+            "side": group.side,
+            "dry_run": bool(dry_run),
+            "validation": validation_payload,
+        }
+        if dry_run:
+            return {
+                "success": True,
+                **base,
+            }
+        if not validation.eligible:
+            return {
+                "success": False,
+                **base,
+                "error": validation.failure_code,
+            }
+        if not settings.ORDER_PROPOSALS_TELEGRAM_ENABLED:
+            return {
+                "success": False,
+                **base,
+                "error": "telegram_disabled",
+            }
+
+        try:
+            dispatch_result = await send_proposal_for_approval(
+                pid,
+                notifier=_get_trade_notifier(),
+                now=now_kst(),
+                now_fn=now_kst,
+                redispatch=True,
+            )
+        except OrderProposalError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - preserve any uncertain pending card
+            logger.error(
+                "order_proposal_redispatch.approval_dispatch_failed",
+                extra={
+                    "proposal_id": str(pid),
+                    "failure_code": "approval_redispatch_internal_error",
+                    "exception_type": type(exc).__name__,
+                },
+            )
+            operator_alert = await _alert_non_sent_dispatch(
+                pid,
+                dispatch_state="unknown",
+                dispatch_failure_code="approval_redispatch_internal_error",
+            )
+            return {
+                "success": False,
+                **base,
+                "error": "approval_redispatch_internal_error",
+                "operator_alert": operator_alert,
+            }
+        if isinstance(dispatch_result, ApprovalWindowDecision):
+            failure_code = approval_window_failure_code(dispatch_result)
+            operator_alert = await _alert_non_sent_dispatch(
+                pid,
+                dispatch_state="blocked",
+                dispatch_failure_code=failure_code,
+            )
+            return {
+                "success": False,
+                **base,
+                "approval_dispatch": {
+                    "status": "blocked",
+                    **dispatch_result.to_dict(),
+                    "operator_alert": operator_alert,
+                },
+                "error": failure_code,
+            }
+
+        dispatch_payload = dispatch_result.as_dict()
+        if not dispatch_result.ok:
+            operator_alert = await _alert_non_sent_dispatch(
+                pid,
+                dispatch_state=dispatch_result.state.value,
+                dispatch_failure_code=(
+                    dispatch_result.failure_code or dispatch_result.state.value
+                ),
+            )
+            dispatch_payload["operator_alert"] = operator_alert
+        return {
+            "success": dispatch_result.ok,
+            **base,
+            "approval_dispatch": dispatch_payload,
+            **(
+                {}
+                if dispatch_result.ok
+                else {
+                    "error": dispatch_result.failure_code or dispatch_result.state.value
+                }
+            ),
+        }
+    except OrderProposalNotFound:
+        return {"success": False, "error": "not_found"}
+    except (ValueError, OrderProposalError) as exc:
+        return {"success": False, "error": str(exc)}
+
+
 def register_order_proposal_tools(mcp: FastMCP) -> None:
     """Register the order_proposals read/create/void MCP tools.
 
@@ -821,6 +1007,16 @@ def register_order_proposal_tools(mcp: FastMCP) -> None:
             "re-judgment (needs_reassessment=true) -- NOT a broker mutation."
         ),
     )(order_proposal_list_expired_defensive)
+    _ = mcp.tool(
+        name="order_proposal_redispatch",
+        description=(
+            "Revalidate and optionally re-send one failed/missing Telegram approval "
+            "card. dry_run=True is the default and performs only fresh session, "
+            "validity, state, nonce, holdings/guard, price, and quantity checks. "
+            "dry_run=False sends a new Telegram approval card only; it never approves "
+            "or submits an order. Active/current/pending/acted proposals fail closed."
+        ),
+    )(order_proposal_redispatch)
 
 
 __all__ = [
@@ -830,6 +1026,7 @@ __all__ = [
     "order_proposal_get",
     "order_proposal_list",
     "order_proposal_list_expired_defensive",
+    "order_proposal_redispatch",
     "order_proposal_void",
     "register_order_proposal_tools",
     "run_order_proposal_expire_sweep",

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -220,6 +220,7 @@ PROPOSAL_LED_TOOLS: frozenset[str] = frozenset({PROPOSAL_TOOL})
 PROPOSAL_LIFECYCLE_TOOLS: frozenset[str] = frozenset(
     {
         "order_proposal_expire_sweep",
+        "order_proposal_redispatch",
         "order_proposal_void",
     }
 )

--- a/app/services/order_proposals/alerts.py
+++ b/app/services/order_proposals/alerts.py
@@ -1,0 +1,213 @@
+"""Discord-first operational alerts for non-sent approval dispatches."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+import httpx
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.monitoring.trade_notifier.transports import send_discord_embed_single
+from app.services.order_proposals.service import OrderProposalsService
+
+logger = logging.getLogger(__name__)
+
+ServiceFactory = Callable[[], Any]
+AlertState = Literal["sent", "failed"]
+
+_FAILURE_COLOR = 0xE74C3C
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDispatchAlertResult:
+    state: AlertState
+    channel: str
+    failure_code: str | None
+    recorded: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _recommended_action(failure_code: str) -> str:
+    upper = failure_code.upper()
+    if "EXPIRED" in upper or "INVALID_VALID_UNTIL" in upper:
+        return "재발송 금지. 제안을 재평가한 뒤 void + 새 제안을 생성하세요."
+    if "CALENDAR_UNKNOWN" in upper or "NXT_CAPABILITY_STALE" in upper:
+        return (
+            "세션/NXT 데이터를 신선화한 뒤 order_proposal_redispatch(dry_run=true)로 "
+            "확인하고, 통과 시 dry_run=false로 재발송하세요. 또는 정규장에서 재시도하세요."
+        )
+    if "DEFER_SESSION_CLOSED" in upper or "NO_EXECUTABLE_WINDOW" in upper:
+        return (
+            "다음 주문 가능 세션에서 order_proposal_redispatch(dry_run=true)로 "
+            "재검증한 뒤 재발송하세요."
+        )
+    if "TELEGRAM" in upper or "APPROVAL_" in upper:
+        return (
+            "Telegram 설정/전송 상태를 복구한 뒤 order_proposal_redispatch"
+            "(dry_run=true → false)로 재발송하세요."
+        )
+    return (
+        "원인을 확인한 뒤 order_proposal_redispatch(dry_run=true)로 재검증하고, "
+        "통과한 경우에만 dry_run=false로 재발송하세요."
+    )
+
+
+async def _record_alert_outcome(
+    proposal_id: uuid.UUID,
+    *,
+    state: AlertState,
+    alert_failure_code: str | None,
+    dispatch_failure_code: str,
+    now: datetime,
+    service_factory: ServiceFactory,
+) -> bool:
+    try:
+        async with service_factory() as session:
+            service = OrderProposalsService(session)
+            await service.record_approval_dispatch_alert(
+                proposal_id,
+                state=state,
+                alert_failure_code=alert_failure_code,
+                dispatch_failure_code=dispatch_failure_code,
+                now=now,
+            )
+            await session.commit()
+        return True
+    except Exception:  # noqa: BLE001 - the primary dispatch outcome is already durable
+        logger.exception(
+            "order_proposals.approval_dispatch_alert_record_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "dispatch_failure_code": dispatch_failure_code,
+                "alert_failure_code": alert_failure_code,
+            },
+        )
+        return False
+
+
+async def send_approval_dispatch_alert(
+    proposal_id: uuid.UUID,
+    *,
+    dispatch_state: str,
+    dispatch_failure_code: str,
+    now: datetime,
+    service_factory: ServiceFactory = AsyncSessionLocal,
+) -> ApprovalDispatchAlertResult:
+    """Alert Discord and durably record delivery success/failure.
+
+    This boundary never changes the already-committed proposal or dispatch
+    outcome. Alert delivery failures are returned, logged at error level, and
+    written to ``source_asof.approval_dispatch_alert`` when the DB is available.
+    """
+    symbol = "unknown"
+    side = "unknown"
+    attempt_id: str | None = None
+    try:
+        async with service_factory() as session:
+            service = OrderProposalsService(session)
+            group, _rungs = await service.get_proposal(proposal_id)
+            symbol = group.symbol
+            side = group.side
+            attempt_id = (
+                str(group.approval_dispatch_attempt_id)
+                if group.approval_dispatch_attempt_id is not None
+                else None
+            )
+    except Exception:  # noqa: BLE001 - still try the operator channel
+        logger.exception(
+            "order_proposals.approval_dispatch_alert_context_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "dispatch_failure_code": dispatch_failure_code,
+            },
+        )
+
+    embed: dict[str, Any] = {
+        "title": "🚨 approval_dispatch가 승인창 없이 종료됨",
+        "color": _FAILURE_COLOR,
+        "fields": [
+            {"name": "proposal_id", "value": str(proposal_id), "inline": False},
+            {"name": "symbol", "value": symbol, "inline": True},
+            {"name": "side", "value": side, "inline": True},
+            {"name": "dispatch_state", "value": dispatch_state, "inline": True},
+            {
+                "name": "failure_code",
+                "value": dispatch_failure_code,
+                "inline": False,
+            },
+            {
+                "name": "operator_action",
+                "value": _recommended_action(dispatch_failure_code),
+                "inline": False,
+            },
+        ],
+    }
+    if attempt_id is not None:
+        embed["fields"].append(
+            {"name": "dispatch_attempt_id", "value": attempt_id, "inline": False}
+        )
+
+    webhook = settings.discord_webhook_alerts
+    alert_failure_code: str | None = None
+    delivered = False
+    if not webhook:
+        alert_failure_code = "discord_webhook_unconfigured"
+    else:
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                delivered = await send_discord_embed_single(
+                    http_client=client,
+                    webhook_url=webhook,
+                    embed=embed,
+                )
+            if not delivered:
+                alert_failure_code = "discord_delivery_failed"
+        except Exception:  # noqa: BLE001 - convert to observable failure
+            alert_failure_code = "discord_alert_exception"
+            logger.exception(
+                "order_proposals.approval_dispatch_alert_exception",
+                extra={
+                    "proposal_id": str(proposal_id),
+                    "dispatch_failure_code": dispatch_failure_code,
+                },
+            )
+
+    state: AlertState = "sent" if delivered else "failed"
+    if not delivered:
+        logger.error(
+            "order_proposals.approval_dispatch_alert_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "dispatch_state": dispatch_state,
+                "dispatch_failure_code": dispatch_failure_code,
+                "alert_failure_code": alert_failure_code,
+            },
+        )
+    recorded = await _record_alert_outcome(
+        proposal_id,
+        state=state,
+        alert_failure_code=alert_failure_code,
+        dispatch_failure_code=dispatch_failure_code,
+        now=now,
+        service_factory=service_factory,
+    )
+    return ApprovalDispatchAlertResult(
+        state=state,
+        channel="discord",
+        failure_code=alert_failure_code,
+        recorded=recorded,
+    )
+
+
+__all__ = [
+    "ApprovalDispatchAlertResult",
+    "send_approval_dispatch_alert",
+]

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -91,6 +91,15 @@ def _generate_nonce() -> str:
     return secrets.token_urlsafe(8)
 
 
+def approval_window_failure_code(decision: ApprovalWindowDecision) -> str:
+    """Return the stable dispatch-ledger code for a blocked approval window."""
+    evidence_detail = (
+        decision.evidence.detail if decision.evidence is not None else None
+    )
+    detail = evidence_detail or decision.detail
+    return f"{decision.code.value}/{detail or 'unspecified'}"
+
+
 def _proposal_binding(
     *,
     group: Any,
@@ -104,6 +113,43 @@ def _proposal_binding(
         attempt_id=attempt_id,
         card_kind=card_kind,
         current_membership_revision=group.approval_dispatch_membership_revision,
+    )
+
+
+async def _record_approval_window_block(
+    *,
+    service: OrderProposalsService,
+    group: Any,
+    decision: ApprovalWindowDecision,
+    attempt_id: uuid.UUID,
+    binding: DispatchBinding | None = None,
+) -> TelegramDispatchResult:
+    """Ledger a fail-closed window decision before returning it to the caller."""
+    resolved_binding = binding or _proposal_binding(
+        group=group,
+        nonce=group.approval_nonce,
+        attempt_id=attempt_id,
+        card_kind=ApprovalCardKind.MANUAL,
+    )
+    publication = ApprovalPublication.failed(
+        payload_chars=0,
+        failure_code=approval_window_failure_code(decision),
+    )
+    await service.start_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        binding=resolved_binding,
+        now=decision.observed_at,
+        payload_chars=0,
+        context_message_count=0,
+    )
+    return await service.finish_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        publication=publication,
+        chat_id=None,
+        now=decision.observed_at,
+        approval_window_policy_stamp=decision.policy_stamp,
     )
 
 
@@ -243,6 +289,7 @@ async def send_proposal_for_approval(
     service_factory: ServiceFactory = AsyncSessionLocal,
     window_evaluator: WindowEvaluator | None = None,
     now_fn: Clock | None = None,
+    redispatch: bool = False,
 ) -> TelegramDispatchResult | ApprovalWindowDecision:
     """Mint a fresh approval nonce, render the message, and send it.
 
@@ -280,6 +327,12 @@ async def send_proposal_for_approval(
         )
         observed_now = window.observed_at
         if not window.allowed:
+            await _record_approval_window_block(
+                service=service,
+                group=group,
+                decision=window,
+                attempt_id=attempt_id,
+            )
             if window.code is ApprovalWindowCode.EXPIRED:
                 await service.expire_mutable_rungs_if_needed(
                     proposal_id, now=observed_now
@@ -299,6 +352,12 @@ async def send_proposal_for_approval(
         )
         publish_now = window.observed_at
         if not window.allowed:
+            await _record_approval_window_block(
+                service=service,
+                group=group,
+                decision=window,
+                attempt_id=attempt_id,
+            )
             if window.code is ApprovalWindowCode.EXPIRED:
                 await service.expire_mutable_rungs_if_needed(
                     proposal_id, now=publish_now
@@ -307,7 +366,14 @@ async def send_proposal_for_approval(
             return window
 
         fresh_nonce = _generate_nonce()
-        await service.set_approval_nonce(proposal_id, fresh_nonce)
+        if redispatch:
+            await service.set_approval_nonce(
+                proposal_id,
+                fresh_nonce,
+                require_redispatchable=True,
+            )
+        else:
+            await service.set_approval_nonce(proposal_id, fresh_nonce)
 
         group, rungs = await service.get_proposal(proposal_id)
         binding = _proposal_binding(
@@ -329,15 +395,17 @@ async def send_proposal_for_approval(
             expected_policy_stamp=window.policy_stamp,
         )
         if not send_window.allowed:
+            await _record_approval_window_block(
+                service=service,
+                group=group,
+                decision=send_window,
+                attempt_id=attempt_id,
+                binding=binding,
+            )
             if send_window.code is ApprovalWindowCode.EXPIRED:
                 await service.expire_mutable_rungs_if_needed(
                     proposal_id,
                     now=send_window.observed_at,
-                )
-            else:
-                await service.clear_approval_nonce(
-                    proposal_id,
-                    expected_nonce=fresh_nonce,
                 )
             await session.commit()
             return send_window

--- a/app/services/order_proposals/redispatch.py
+++ b/app/services/order_proposals/redispatch.py
@@ -1,0 +1,241 @@
+"""Read-only fail-closed eligibility checks for manual approval redispatch."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowDecision,
+    WindowEvaluator,
+    evaluate_approval_window,
+    evaluate_approval_window_boundary,
+)
+from app.services.order_proposals.dispatch import approval_window_failure_code
+from app.services.order_proposals.dispatch_contract import ApprovalDispatchState
+from app.services.order_proposals.revalidation import (
+    PlaceOrderFn,
+    _default_place_order_fn,
+    _norm,
+    _proposal_client_order_id,
+    _toss_proposal_client_order_id,
+)
+
+Clock = Callable[[], datetime]
+
+_ELIGIBLE_RUNG_STATES = frozenset({"pending_approval", "needs_reconfirm"})
+_REDISPATCHABLE_STATES = frozenset(
+    {
+        None,
+        ApprovalDispatchState.FAILED.value,
+        ApprovalDispatchState.PARTIAL_FAILED.value,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RedispatchValidation:
+    eligible: bool
+    failure_code: str | None
+    detail: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "eligible": self.eligible,
+            "failure_code": self.failure_code,
+            "detail": self.detail,
+        }
+
+
+def _blocked(failure_code: str, **detail: Any) -> RedispatchValidation:
+    return RedispatchValidation(False, failure_code, detail)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
+
+
+async def validate_proposal_redispatch(
+    *,
+    group: Any,
+    rungs: list[Any],
+    now: datetime,
+    place_order_fn: PlaceOrderFn = _default_place_order_fn,
+    window_evaluator: WindowEvaluator = evaluate_approval_window,
+    now_fn: Clock | None = None,
+) -> RedispatchValidation:
+    """Re-check one proposal without DB or broker mutation.
+
+    A redispatch is intentionally narrower than create: only unbounded-free
+    limit ``place`` proposals can be re-sent. Fresh order previews rerun current
+    holdings/price guards and must preserve the exact normalized price and
+    quantity stored on every rung.
+    """
+    if group.lifecycle_state != "proposed":
+        return _blocked(
+            "redispatch_proposal_not_active",
+            lifecycle_state=group.lifecycle_state,
+        )
+    if (group.action or "place") != "place":
+        return _blocked(
+            "redispatch_action_not_supported",
+            action=group.action or "place",
+        )
+    if group.order_type != "limit":
+        return _blocked(
+            "redispatch_market_order_unbounded",
+            order_type=group.order_type,
+        )
+    if group.approval_nonce_used_at is not None:
+        return _blocked("redispatch_approval_already_acted")
+    if group.approval_dispatch_state == ApprovalDispatchState.PENDING.value:
+        return _blocked("redispatch_dispatch_pending")
+    if group.approval_dispatch_state == ApprovalDispatchState.SENT_CURRENT.value:
+        return _blocked("redispatch_already_sent")
+    if group.approval_dispatch_state not in _REDISPATCHABLE_STATES:
+        return _blocked(
+            "redispatch_dispatch_state_not_eligible",
+            approval_dispatch_state=group.approval_dispatch_state,
+        )
+    if group.approval_dispatch_published_at is not None:
+        return _blocked(
+            "redispatch_publication_already_recorded",
+            approval_dispatch_published_at=group.approval_dispatch_published_at.isoformat(),
+        )
+    if group.approval_nonce is not None:
+        return _blocked("redispatch_active_nonce_present")
+    if not rungs or any(rung.state not in _ELIGIBLE_RUNG_STATES for rung in rungs):
+        return _blocked(
+            "redispatch_rung_state_not_eligible",
+            rung_states=[rung.state for rung in rungs],
+        )
+
+    clock = now_fn or (lambda: now)
+    window: ApprovalWindowDecision = await evaluate_approval_window_boundary(
+        group,
+        window_evaluator=window_evaluator,
+        now_fn=clock,
+        require_policy_stamp=False,
+    )
+    if not window.allowed:
+        return _blocked(
+            approval_window_failure_code(window),
+            approval_window=window.to_dict(),
+        )
+
+    previews: list[dict[str, Any]] = []
+    for rung in rungs:
+        proposal_client_order_id = (
+            _toss_proposal_client_order_id(group.proposal_id, rung.rung_index)
+            if group.account_mode == "toss_live"
+            else _proposal_client_order_id(group.proposal_id, rung.rung_index)
+            if group.account_mode == "upbit"
+            else None
+        )
+        try:
+            preview = await place_order_fn(
+                dry_run=True,
+                account_mode=group.account_mode,
+                symbol=group.symbol,
+                side=rung.side,
+                market=group.market,
+                order_type=group.order_type,
+                quantity=rung.quantity,
+                price=rung.limit_price,
+                thesis=group.thesis,
+                strategy=group.strategy,
+                exit_intent=group.exit_intent,
+                exit_reason=group.exit_reason,
+                retrospective_id=group.retrospective_id,
+                approval_issue_id=group.approval_issue_id,
+                reason=f"order_proposal redispatch validation (rung {rung.rung_index})",
+                rung=rung.rung_index,
+                **(
+                    {"proposal_client_order_id": proposal_client_order_id}
+                    if proposal_client_order_id is not None
+                    else {}
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 - preview is read-only
+            return _blocked(
+                "redispatch_preview_exception",
+                rung_index=rung.rung_index,
+                exception_type=type(exc).__name__,
+            )
+        if not isinstance(preview, dict) or preview.get("success") is not True:
+            return _blocked(
+                "redispatch_preview_blocked",
+                rung_index=rung.rung_index,
+                error=(preview.get("error") if isinstance(preview, dict) else None),
+                error_code=(
+                    preview.get("error_code") if isinstance(preview, dict) else None
+                ),
+            )
+
+        expected_price = _norm(rung.limit_price)
+        preview_price = _norm(preview.get("price"))
+        if preview_price != expected_price:
+            return _blocked(
+                "redispatch_price_changed",
+                rung_index=rung.rung_index,
+                expected_price=expected_price,
+                preview_price=preview_price,
+            )
+        expected_quantity = _norm(rung.quantity)
+        preview_quantity = _norm(preview.get("quantity"))
+        if preview_quantity != expected_quantity:
+            return _blocked(
+                "redispatch_quantity_changed",
+                rung_index=rung.rung_index,
+                expected_quantity=expected_quantity,
+                preview_quantity=preview_quantity,
+            )
+
+        current_price = _decimal(preview.get("current_price"))
+        limit_price = _decimal(rung.limit_price)
+        if current_price is None or current_price <= 0 or limit_price is None:
+            return _blocked(
+                "redispatch_current_price_missing",
+                rung_index=rung.rung_index,
+            )
+        crossed_market = (rung.side == "buy" and limit_price > current_price) or (
+            rung.side == "sell" and limit_price < current_price
+        )
+        if crossed_market:
+            return _blocked(
+                "redispatch_price_crossed_market",
+                rung_index=rung.rung_index,
+                side=rung.side,
+                limit_price=_norm(limit_price),
+                current_price=_norm(current_price),
+            )
+        previews.append(
+            {
+                "rung_index": rung.rung_index,
+                "limit_price": expected_price,
+                "quantity": expected_quantity,
+                "current_price": _norm(current_price),
+            }
+        )
+
+    return RedispatchValidation(
+        True,
+        None,
+        {
+            "approval_window": window.to_dict(),
+            "rungs": previews,
+        },
+    )
+
+
+__all__ = [
+    "RedispatchValidation",
+    "validate_proposal_redispatch",
+]

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1091,7 +1091,13 @@ class OrderProposalsService:
         return voided_rungs
 
     # -- PR-2 helpers -------------------------------------------------------
-    async def set_approval_nonce(self, proposal_id: uuid.UUID, nonce: str) -> None:
+    async def set_approval_nonce(
+        self,
+        proposal_id: uuid.UUID,
+        nonce: str,
+        *,
+        require_redispatchable: bool = False,
+    ) -> None:
         """Stage a nonce while fail-closing any previously published card.
 
         Production dispatch calls this immediately before
@@ -1105,6 +1111,15 @@ class OrderProposalsService:
         block_reason = proposal_approval_block_reason(group)
         if block_reason is not None:
             raise OrderProposalError(block_reason)
+        if require_redispatchable:
+            if group.approval_dispatch_state == ApprovalDispatchState.PENDING.value:
+                raise OrderProposalError("approval_dispatch_already_pending")
+            if (
+                group.approval_dispatch_state
+                == ApprovalDispatchState.SENT_CURRENT.value
+                and group.approval_nonce_used_at is None
+            ):
+                raise OrderProposalError("approval_dispatch_already_current")
         await self._repo.update_group(
             group,
             approval_nonce=nonce,
@@ -1113,6 +1128,37 @@ class OrderProposalsService:
             approval_dispatch_published_at=None,
             approval_dispatch_failure_code="approval_dispatch_snapshot_missing",
         )
+
+    async def record_approval_dispatch_alert(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        state: str,
+        alert_failure_code: str | None,
+        dispatch_failure_code: str,
+        now: datetime,
+    ) -> OrderProposal:
+        """Persist the latest Discord ops-alert result without hiding root failure."""
+        self._require_timezone_aware(now)
+        if state not in {"sent", "failed"}:
+            raise ValueError("approval dispatch alert state must be sent or failed")
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        source_asof = dict(group.source_asof or {})
+        source_asof["approval_dispatch_alert"] = {
+            "state": state,
+            "channel": "discord",
+            "attempted_at": now.isoformat(),
+            "failure_code": alert_failure_code,
+            "dispatch_failure_code": dispatch_failure_code,
+            "dispatch_attempt_id": (
+                str(group.approval_dispatch_attempt_id)
+                if group.approval_dispatch_attempt_id is not None
+                else None
+            ),
+        }
+        return await self._repo.update_group(group, source_asof=source_asof)
 
     async def clear_approval_nonce(
         self,

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -55,6 +55,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.caller_identity import caller_agent_id_var
+from app.services.order_proposals.alerts import send_approval_dispatch_alert
 from app.services.order_proposals.approval_message import (
     _escape_markdown,
     build_approval_dispatch_messages,
@@ -320,6 +321,44 @@ async def _safe_edit_message(
             failure_code="telegram_transport_error",
             error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
         )
+
+
+async def _alert_non_sent_callback_dispatch(
+    proposal_id: uuid.UUID,
+    *,
+    dispatch_state: str,
+    dispatch_failure_code: str,
+    now: datetime,
+    service_factory: ServiceFactory,
+) -> dict[str, Any]:
+    """Alert without hiding an already-committed callback dispatch result."""
+    try:
+        return (
+            await send_approval_dispatch_alert(
+                proposal_id,
+                dispatch_state=dispatch_state,
+                dispatch_failure_code=dispatch_failure_code,
+                now=now,
+                service_factory=service_factory,
+            )
+        ).as_dict()
+    except Exception as exc:  # noqa: BLE001 - preserve the durable dispatch outcome
+        logger.error(
+            "order_proposals.approval_dispatch_alert_boundary_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "dispatch_state": dispatch_state,
+                "dispatch_failure_code": dispatch_failure_code,
+                "alert_failure_code": "approval_dispatch_alert_internal_error",
+                "exception_type": type(exc).__name__,
+            },
+        )
+        return {
+            "state": "failed",
+            "channel": "discord",
+            "failure_code": "approval_dispatch_alert_internal_error",
+            "recorded": False,
+        }
 
 
 async def _resolve_proposal_id(service: Any, proposal_short: str) -> uuid.UUID | None:
@@ -594,6 +633,7 @@ async def _handle_approve(
     window_evaluator: WindowEvaluator | None = None,
     now_fn: Clock | None = None,
     loss_cut_confirmation: bool = False,
+    service_factory: ServiceFactory = AsyncSessionLocal,
 ) -> dict[str, Any]:
     window_evaluator = window_evaluator or evaluate_approval_window
     now_fn = now_fn or (lambda: now)
@@ -922,6 +962,17 @@ async def _handle_approve(
             approval_window_policy_stamp=send_window.policy_stamp,
         )
         await session.commit()
+        operator_alert = None
+        if not dispatch_result.ok:
+            operator_alert = await _alert_non_sent_callback_dispatch(
+                proposal_id,
+                dispatch_state=dispatch_result.state.value,
+                dispatch_failure_code=(
+                    dispatch_result.failure_code or "approval_dispatch_failed"
+                ),
+                now=send_window.observed_at,
+                service_factory=service_factory,
+            )
         new_message_id = dispatch_result.message_id if dispatch_result.ok else None
         return {
             "handled": True,
@@ -929,6 +980,7 @@ async def _handle_approve(
             "proposal_id": str(proposal_id),
             "new_message_id": new_message_id,
             "approval_dispatch": dispatch_result.as_dict(),
+            "operator_alert": operator_alert,
             "results": [outcome.result for outcome in outcomes],
             "rung_results": _serialize_rung_outcomes(outcomes),
         }
@@ -1208,6 +1260,7 @@ async def _handle_batch_approve(
                         revalidate_fn=revalidate_fn,
                         window_evaluator=window_evaluator,
                         now_fn=now_fn,
+                        service_factory=service_factory,
                     )
                     rung_results = approval_result.get("rung_results")
                     if isinstance(rung_results, list):
@@ -1318,6 +1371,7 @@ async def _handle_loss_cut_first_click(
     loss_cut_preview_fn: RevalidateFn,
     window_evaluator: WindowEvaluator | None = None,
     now_fn: Clock | None = None,
+    service_factory: ServiceFactory = AsyncSessionLocal,
 ) -> dict[str, Any]:
     """Consume step one and edit the message into a bound confirmation."""
     window_evaluator = window_evaluator or evaluate_approval_window
@@ -1538,6 +1592,17 @@ async def _handle_loss_cut_first_click(
         approval_window_policy_stamp=publish_window.policy_stamp,
     )
     await session.commit()
+    operator_alert = None
+    if not dispatch_result.ok:
+        operator_alert = await _alert_non_sent_callback_dispatch(
+            proposal_id,
+            dispatch_state=dispatch_result.state.value,
+            dispatch_failure_code=(
+                dispatch_result.failure_code or "approval_dispatch_failed"
+            ),
+            now=publish_window.observed_at,
+            service_factory=service_factory,
+        )
     return {
         "handled": dispatch_result.ok,
         "reason": (
@@ -1547,6 +1612,7 @@ async def _handle_loss_cut_first_click(
         ),
         "proposal_id": str(proposal_id),
         "approval_dispatch": dispatch_result.as_dict(),
+        "operator_alert": operator_alert,
     }
 
 
@@ -1676,6 +1742,7 @@ async def handle_callback_update(
                         loss_cut_preview_fn=loss_cut_preview_fn,
                         window_evaluator=evaluate_window,
                         now_fn=clock,
+                        service_factory=service_factory,
                     )
                     return result
                 result = await _handle_approve(
@@ -1694,6 +1761,7 @@ async def handle_callback_update(
                     revalidate_fn=revalidate_fn,
                     window_evaluator=evaluate_window,
                     now_fn=clock,
+                    service_factory=service_factory,
                 )
             else:
                 result = await _handle_approve(
@@ -1713,6 +1781,7 @@ async def handle_callback_update(
                     window_evaluator=evaluate_window,
                     now_fn=clock,
                     loss_cut_confirmation=True,
+                    service_factory=service_factory,
                 )
             # `_handle_deny`/`_handle_approve` each commit their own
             # mutating work internally before making any Telegram notify

--- a/tests/mcp_server/tooling/test_order_proposal_create_post_commit.py
+++ b/tests/mcp_server/tooling/test_order_proposal_create_post_commit.py
@@ -101,6 +101,18 @@ async def test_committed_create_survives_dispatch_and_failure_recorder_errors(
     monkeypatch.setattr(
         order_proposal_tools, "record_approval_dispatch_failure", recorder
     )
+    operator_alert = {
+        "state": "failed",
+        "channel": "discord",
+        "failure_code": "discord_delivery_failed",
+        "recorded": True,
+    }
+    alert = AsyncMock(return_value=operator_alert)
+    monkeypatch.setattr(
+        order_proposal_tools,
+        "_alert_non_sent_dispatch",
+        alert,
+    )
 
     result = await order_proposal_tools.order_proposal_create(**_create_kwargs())
 
@@ -115,10 +127,12 @@ async def test_committed_create_survives_dispatch_and_failure_recorder_errors(
         "payload_chars": 0,
         "failure_code": "approval_dispatch_ledger_error",
         "ok": False,
+        "operator_alert": operator_alert,
     }
     session.commit.assert_awaited_once()
     service.create_proposal.assert_awaited_once()
     recorder.assert_awaited_once()
+    alert.assert_awaited_once()
     if enabled and allowlist:
         dispatch.assert_awaited_once()
     else:

--- a/tests/services/order_proposals/test_alerts.py
+++ b/tests/services/order_proposals/test_alerts.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.config import settings
+from app.services.order_proposals import alerts
+
+
+@contextlib.asynccontextmanager
+async def _session_factory():
+    yield SimpleNamespace(commit=AsyncMock())
+
+
+def _service(record: AsyncMock) -> SimpleNamespace:
+    return SimpleNamespace(
+        get_proposal=AsyncMock(
+            return_value=(
+                SimpleNamespace(
+                    symbol="052690",
+                    side="sell",
+                    approval_dispatch_attempt_id=uuid.UUID(
+                        "a1111111-1111-4111-8111-111111111111"
+                    ),
+                ),
+                [],
+            )
+        ),
+        record_approval_dispatch_alert=record,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_blocked_dispatch_alert_sends_required_discord_fields(
+    monkeypatch,
+) -> None:
+    proposal_id = uuid.UUID("b2222222-2222-4222-8222-222222222222")
+    record = AsyncMock()
+    service = _service(record)
+    sender = AsyncMock(return_value=True)
+    monkeypatch.setattr(alerts, "OrderProposalsService", lambda _session: service)
+    monkeypatch.setattr(alerts, "send_discord_embed_single", sender)
+    monkeypatch.setattr(
+        settings,
+        "discord_webhook_alerts",
+        "https://discord.example/ops-alerts",
+    )
+
+    result = await alerts.send_approval_dispatch_alert(
+        proposal_id,
+        dispatch_state="blocked",
+        dispatch_failure_code="CALENDAR_UNKNOWN/nxt_capability_stale",
+        now=datetime(2026, 7, 27, 8, 16, tzinfo=UTC),
+        service_factory=_session_factory,
+    )
+
+    assert result.state == "sent"
+    assert result.recorded is True
+    sender.assert_awaited_once()
+    embed = sender.await_args.kwargs["embed"]
+    fields = {field["name"]: field["value"] for field in embed["fields"]}
+    assert fields["proposal_id"] == str(proposal_id)
+    assert fields["symbol"] == "052690"
+    assert fields["side"] == "sell"
+    assert fields["failure_code"] == "CALENDAR_UNKNOWN/nxt_capability_stale"
+    assert "order_proposal_redispatch(dry_run=true)" in fields["operator_action"]
+    assert "정규장" in fields["operator_action"]
+    record.assert_awaited_once()
+    assert record.await_args.kwargs["state"] == "sent"
+    assert record.await_args.kwargs["alert_failure_code"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_alert_transport_failure_is_logged_and_durably_recorded(
+    monkeypatch,
+    caplog,
+) -> None:
+    proposal_id = uuid.UUID("c3333333-3333-4333-8333-333333333333")
+    record = AsyncMock()
+    service = _service(record)
+    monkeypatch.setattr(alerts, "OrderProposalsService", lambda _session: service)
+    monkeypatch.setattr(
+        alerts,
+        "send_discord_embed_single",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        settings,
+        "discord_webhook_alerts",
+        "https://discord.example/ops-alerts",
+    )
+
+    result = await alerts.send_approval_dispatch_alert(
+        proposal_id,
+        dispatch_state="failed",
+        dispatch_failure_code="approval_card_dispatch_failed",
+        now=datetime(2026, 7, 27, 8, 17, tzinfo=UTC),
+        service_factory=_session_factory,
+    )
+
+    assert result.state == "failed"
+    assert result.failure_code == "discord_delivery_failed"
+    assert "order_proposals.approval_dispatch_alert_failed" in caplog.text
+    record.assert_awaited_once()
+    assert record.await_args.kwargs["state"] == "failed"
+    assert record.await_args.kwargs["alert_failure_code"] == "discord_delivery_failed"

--- a/tests/services/order_proposals/test_approval_window.py
+++ b/tests/services/order_proposals/test_approval_window.py
@@ -55,6 +55,8 @@ def _group(
         order_type="limit",
         exit_intent=exit_intent,
         exit_reason=exit_reason,
+        approval_nonce=None,
+        approval_dispatch_membership_revision=None,
     )
 
 
@@ -240,6 +242,12 @@ async def test_dispatch_session_block_publishes_no_nonce_or_card(
             nonlocal nonce_mints
             nonce_mints += 1
 
+        async def start_approval_dispatch(self, *args, **kwargs):
+            return None
+
+        async def finish_approval_dispatch(self, *args, **kwargs):
+            return None
+
     class FakeSession:
         async def commit(self):
             return None
@@ -304,6 +312,12 @@ async def test_dispatch_rechecks_boundary_before_nonce_or_card(monkeypatch):
             nonlocal expiry_transitions
             expiry_transitions += 1
             return True
+
+        async def start_approval_dispatch(self, *args, **kwargs):
+            return None
+
+        async def finish_approval_dispatch(self, *args, **kwargs):
+            return None
 
     class FakeSession:
         async def commit(self):
@@ -1851,6 +1865,12 @@ async def test_july_23_incident_fixture_is_typed_expired_without_calendar_lookup
             nonlocal expiry_transitions
             expiry_transitions += 1
             return True
+
+        async def start_approval_dispatch(self, *args, **kwargs):
+            return None
+
+        async def finish_approval_dispatch(self, *args, **kwargs):
+            return None
 
     class FakeSession:
         async def commit(self):

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -322,19 +322,34 @@ async def test_dispatch_expired_returns_typed_result_without_nonce_or_telegram(
     )
     assert refreshed.approval_nonce is None
     assert refreshed.lifecycle_state == "expired"
+    assert refreshed.approval_dispatch_state == "failed"
+    assert (
+        refreshed.approval_dispatch_failure_code
+        == "EXPIRED/now_at_or_after_valid_until"
+    )
+    assert refreshed.approval_dispatch_attempted_at == deadline
+    assert refreshed.approval_dispatch_published_at is None
     assert [rung.state for rung in rungs] == ["expired"]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("known", "expected"),
+    ("known", "expected", "expected_failure"),
     [
-        (True, ApprovalWindowCode.DEFER_SESSION_CLOSED),
-        (False, ApprovalWindowCode.CALENDAR_UNKNOWN),
+        (
+            True,
+            ApprovalWindowCode.DEFER_SESSION_CLOSED,
+            "DEFER_SESSION_CLOSED/submission_session_closed",
+        ),
+        (
+            False,
+            ApprovalWindowCode.CALENDAR_UNKNOWN,
+            "CALENDAR_UNKNOWN/nxt_capability_stale",
+        ),
     ],
 )
-async def test_dispatch_closed_or_unknown_session_has_zero_visible_side_effects(
-    monkeypatch, db_session, known, expected
+async def test_dispatch_closed_or_unknown_session_is_durably_blocked_without_telegram(
+    monkeypatch, db_session, known, expected, expected_failure
 ):
     from app.core.config import settings
 
@@ -356,6 +371,7 @@ async def test_dispatch_closed_or_unknown_session_has_zero_visible_side_effects(
                 allowed_sessions=("regular",),
                 allowed_now=False,
                 next_allowed_at=now + timedelta(hours=12) if known else None,
+                detail=None if known else "nxt_capability_stale",
             )
 
         return await evaluate_approval_window(group, now=now, session_resolver=resolver)
@@ -376,6 +392,10 @@ async def test_dispatch_closed_or_unknown_session_has_zero_visible_side_effects(
     )
     assert refreshed.approval_nonce is None
     assert refreshed.approval_nonce_used_at is None
+    assert refreshed.approval_dispatch_state == "failed"
+    assert refreshed.approval_dispatch_failure_code == expected_failure
+    assert refreshed.approval_dispatch_attempted_at == now
+    assert refreshed.approval_dispatch_published_at is None
     assert [rung.state for rung in rungs] == ["pending_approval"]
 
 

--- a/tests/services/order_proposals/test_redispatch.py
+++ b/tests/services/order_proposals/test_redispatch.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.order_proposals.approval_window import (
+    ApprovalWindowDecision,
+    SubmissionSessionEvidence,
+)
+from app.services.order_proposals.approval_window_contract import ApprovalWindowCode
+from app.services.order_proposals.redispatch import validate_proposal_redispatch
+
+NOW = datetime(2026, 7, 27, 9, 0, tzinfo=UTC)
+
+
+def _group(**overrides):
+    values = {
+        "proposal_id": uuid.UUID("d4444444-4444-4444-8444-444444444444"),
+        "lifecycle_state": "proposed",
+        "action": "place",
+        "order_type": "limit",
+        "approval_nonce": None,
+        "approval_nonce_used_at": None,
+        "approval_dispatch_state": "failed",
+        "approval_dispatch_published_at": None,
+        "valid_until": NOW + timedelta(hours=1),
+        "market": "equity_kr",
+        "account_mode": "kis_live",
+        "symbol": "052690",
+        "side": "sell",
+        "thesis": "premarket exit",
+        "strategy": "manual",
+        "exit_intent": None,
+        "exit_reason": None,
+        "retrospective_id": None,
+        "approval_issue_id": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _rung(**overrides):
+    values = {
+        "rung_index": 0,
+        "side": "sell",
+        "quantity": Decimal("1"),
+        "limit_price": Decimal("70000"),
+        "state": "pending_approval",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+async def _allow(group, *, now):
+    return ApprovalWindowDecision(
+        code=ApprovalWindowCode.ALLOW,
+        observed_at=now,
+        valid_until=group.valid_until,
+        policy_stamp="order-proposal-approval-window-v1:test",
+        market=group.market,
+        account_mode=group.account_mode,
+        action=group.action,
+        order_type=group.order_type,
+        evidence=SubmissionSessionEvidence(
+            known=True,
+            source="test",
+            current_session="regular",
+            allowed_sessions=("regular",),
+            allowed_now=True,
+            allowed_until=group.valid_until,
+        ),
+    )
+
+
+def _preview(**overrides):
+    values = {
+        "success": True,
+        "price": "70000",
+        "quantity": "1",
+        "current_price": "69000",
+    }
+    values.update(overrides)
+    return values
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_validation_accepts_exact_fresh_limit_terms() -> None:
+    place = AsyncMock(return_value=_preview())
+
+    result = await validate_proposal_redispatch(
+        group=_group(),
+        rungs=[_rung()],
+        now=NOW,
+        now_fn=lambda: NOW,
+        window_evaluator=_allow,
+        place_order_fn=place,
+    )
+
+    assert result.eligible is True
+    assert result.failure_code is None
+    place.assert_awaited_once()
+    assert place.await_args.kwargs["dry_run"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_rejects_expired_without_preview() -> None:
+    place = AsyncMock(return_value=_preview())
+    group = _group(valid_until=NOW)
+
+    result = await validate_proposal_redispatch(
+        group=group,
+        rungs=[_rung()],
+        now=NOW,
+        now_fn=lambda: NOW,
+        window_evaluator=_allow,
+        place_order_fn=place,
+    )
+
+    assert result.eligible is False
+    assert result.failure_code == "EXPIRED/now_at_or_after_valid_until"
+    place.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_rejects_fresh_preview_price_change() -> None:
+    result = await validate_proposal_redispatch(
+        group=_group(),
+        rungs=[_rung()],
+        now=NOW,
+        now_fn=lambda: NOW,
+        window_evaluator=_allow,
+        place_order_fn=AsyncMock(return_value=_preview(price="69500")),
+    )
+
+    assert result.eligible is False
+    assert result.failure_code == "redispatch_price_changed"
+    assert result.detail["expected_price"] == "70000"
+    assert result.detail["preview_price"] == "69500"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_rejects_already_approved_or_cancelled_rungs() -> None:
+    for group, rung in (
+        (_group(lifecycle_state="approved"), _rung(state="approved")),
+        (_group(lifecycle_state="terminal"), _rung(state="cancelled")),
+    ):
+        result = await validate_proposal_redispatch(
+            group=group,
+            rungs=[rung],
+            now=NOW,
+            now_fn=lambda: NOW,
+            window_evaluator=_allow,
+            place_order_fn=AsyncMock(return_value=_preview()),
+        )
+        assert result.eligible is False
+        assert result.failure_code == "redispatch_proposal_not_active"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_rejects_current_dispatch_without_preview() -> None:
+    place = AsyncMock(return_value=_preview())
+
+    result = await validate_proposal_redispatch(
+        group=_group(approval_dispatch_state="sent_current"),
+        rungs=[_rung()],
+        now=NOW,
+        now_fn=lambda: NOW,
+        window_evaluator=_allow,
+        place_order_fn=place,
+    )
+
+    assert result.eligible is False
+    assert result.failure_code == "redispatch_already_sent"
+    place.assert_not_awaited()

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -1103,6 +1103,83 @@ async def test_approval_nonce_mismatch_and_reset(db_session):
 
 
 @pytest.mark.asyncio
+async def test_set_approval_nonce_rejects_pending_or_live_current_card(db_session):
+    service, pending_group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 0, tzinfo=UTC)
+    await service.set_approval_nonce(pending_group.proposal_id, "pending-nonce")
+    pending_group, _ = await service.get_proposal(pending_group.proposal_id)
+    attempt_id = uuid.uuid4()
+    binding = build_proposal_dispatch_binding(
+        proposal_id=pending_group.proposal_id,
+        nonce="pending-nonce",
+        attempt_id=attempt_id,
+        card_kind=ApprovalCardKind.MANUAL,
+        current_membership_revision=pending_group.approval_dispatch_membership_revision,
+    )
+    await service.start_approval_dispatch(
+        pending_group.proposal_id,
+        attempt_id=attempt_id,
+        binding=binding,
+        now=now,
+        payload_chars=10,
+        context_message_count=0,
+    )
+    with pytest.raises(OrderProposalError, match="^approval_dispatch_already_pending$"):
+        await service.set_approval_nonce(
+            pending_group.proposal_id,
+            "duplicate-nonce",
+            require_redispatchable=True,
+        )
+
+    service, current_group = await _create_single_rung(db_session)
+    await service.set_approval_nonce(current_group.proposal_id, "current-nonce")
+    await _publish_fixture_card(
+        service,
+        current_group,
+        nonce="current-nonce",
+        now=now,
+    )
+    with pytest.raises(OrderProposalError, match="^approval_dispatch_already_current$"):
+        await service.set_approval_nonce(
+            current_group.proposal_id,
+            "duplicate-nonce",
+            require_redispatchable=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_approval_dispatch_alert_failure_is_queryable_without_overwriting_root(
+    db_session,
+):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 27, 0, 17, tzinfo=UTC)
+    group.approval_dispatch_failure_code = "CALENDAR_UNKNOWN/nxt_capability_stale"
+
+    await service.record_approval_dispatch_alert(
+        group.proposal_id,
+        state="failed",
+        alert_failure_code="discord_delivery_failed",
+        dispatch_failure_code="CALENDAR_UNKNOWN/nxt_capability_stale",
+        now=now,
+    )
+    await db_session.commit()
+
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert (
+        refreshed.approval_dispatch_failure_code
+        == "CALENDAR_UNKNOWN/nxt_capability_stale"
+    )
+    assert refreshed.source_asof["approval_dispatch_alert"] == {
+        "state": "failed",
+        "channel": "discord",
+        "attempted_at": now.isoformat(),
+        "failure_code": "discord_delivery_failed",
+        "dispatch_failure_code": "CALENDAR_UNKNOWN/nxt_capability_stale",
+        "dispatch_attempt_id": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_approval_nonce_replay_blocked(db_session):
     service, group = await _create_single_rung(db_session)
     now = datetime(2026, 7, 10, 9, 1, tzinfo=UTC)

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -105,6 +105,17 @@ class _EventNotifier(_FakeNotifier):
         return await super().edit_message(chat_id, message_id, text, reply_markup)
 
 
+class _FailedSendNotifier(_FakeNotifier):
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
+        self.sent_messages.append((text, inline_keyboard, chat_id))
+        return TelegramMethodResult.failed(
+            payload_chars=telegram_text_length(text),
+            failure_code="telegram_transport_error",
+        )
+
+
 def _session_factory(db_session):
     @contextlib.asynccontextmanager
     async def _factory():
@@ -1919,6 +1930,59 @@ async def test_needs_reconfirm_sends_new_diff_message(monkeypatch, db_session):
     refreshed, _rungs = await service.get_proposal(group.proposal_id)
     assert refreshed.approval_nonce == parsed.nonce
     assert refreshed.approved_by_telegram_user_id == str(USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_needs_reconfirm_dispatch_failure_alerts_operator(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-alert1")
+    data = _proposal_callback_data(group, action="op", nonce="nonce-alert1")
+    notifier = _FailedSendNotifier()
+    alert_calls = []
+
+    async def fake_alert(proposal_id, **kwargs):
+        alert_calls.append((proposal_id, kwargs))
+        return SimpleNamespace(
+            as_dict=lambda: {
+                "state": "sent",
+                "channel": "discord",
+                "failure_code": None,
+                "recorded": True,
+            }
+        )
+
+    monkeypatch.setattr(callback_module, "send_approval_dispatch_alert", fake_alert)
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        return [
+            RungOutcome(
+                0,
+                "needs_reconfirm",
+                {
+                    "before": {"limit_price": "100", "quantity": "10"},
+                    "after": {"limit_price": "105", "quantity": "10"},
+                },
+            )
+        ]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["approval_dispatch"]["state"] == "failed"
+    assert result["operator_alert"]["state"] == "sent"
+    assert len(alert_calls) == 1
+    alert_proposal_id, alert_kwargs = alert_calls[0]
+    assert alert_proposal_id == group.proposal_id
+    assert alert_kwargs["dispatch_state"] == "failed"
+    assert alert_kwargs["dispatch_failure_code"] == "approval_card_dispatch_failed"
+    assert alert_kwargs["service_factory"] is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,8 +1,10 @@
+import contextlib
 import functools
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -16,6 +18,7 @@ from app.services.order_proposals.approval_window import (
     ApprovalWindowDecision,
 )
 from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.redispatch import RedispatchValidation
 from app.services.order_proposals.target_order import TargetOrderSnapshot
 from app.telegram_contract import TelegramMethodResult, telegram_text_length
 from tests.services.order_proposals.window_fakes import allow_known_session
@@ -166,6 +169,16 @@ async def test_create_surfaces_typed_approval_dispatch_block(monkeypatch):
         "app.monitoring.trade_notifier.notifier.get_trade_notifier",
         lambda: _FakeNotifier(),
     )
+    alert_result = SimpleNamespace(
+        as_dict=lambda: {
+            "state": "sent",
+            "channel": "discord",
+            "failure_code": None,
+            "recorded": True,
+        }
+    )
+    alert = AsyncMock(return_value=alert_result)
+    monkeypatch.setattr(opt, "send_approval_dispatch_alert", alert)
 
     result = await opt.order_proposal_create(**_create_kwargs())
 
@@ -173,6 +186,12 @@ async def test_create_surfaces_typed_approval_dispatch_block(monkeypatch):
     assert result["approval_dispatch"]["status"] == "blocked"
     assert result["approval_dispatch"]["code"] == "EXPIRED"
     assert result["approval_dispatch"]["detail"] == "now_at_or_after_valid_until"
+    assert result["approval_dispatch"]["operator_alert"]["state"] == "sent"
+    alert.assert_awaited_once()
+    assert (
+        alert.await_args.kwargs["dispatch_failure_code"]
+        == "EXPIRED/now_at_or_after_valid_until"
+    )
 
 
 @pytest.mark.asyncio
@@ -1008,7 +1027,170 @@ def test_tools_registered_and_names_exported():
         "order_proposal_void",
         "order_proposal_expire_sweep",
         "order_proposal_list_expired_defensive",
+        "order_proposal_redispatch",
     }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_defaults_to_dry_run_and_never_loads_notifier(monkeypatch):
+    group = SimpleNamespace(symbol="052690", side="sell")
+    service = SimpleNamespace(get_proposal=AsyncMock(return_value=(group, [])))
+
+    @contextlib.asynccontextmanager
+    async def session_factory():
+        yield SimpleNamespace()
+
+    validation = RedispatchValidation(
+        False,
+        "redispatch_price_changed",
+        {"rung_index": 0},
+    )
+    validator = AsyncMock(return_value=validation)
+    monkeypatch.setattr(opt, "AsyncSessionLocal", session_factory)
+    monkeypatch.setattr(opt, "OrderProposalsService", lambda _session: service)
+    monkeypatch.setattr(opt, "validate_proposal_redispatch", validator)
+    monkeypatch.setattr(
+        opt,
+        "_get_trade_notifier",
+        lambda: (_ for _ in ()).throw(AssertionError("notifier must not load")),
+    )
+
+    result = await opt.order_proposal_redispatch(str(uuid.uuid4()))
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["validation"]["eligible"] is False
+    validator.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_execute_refuses_invalid_proposal_without_telegram(
+    monkeypatch,
+):
+    group = SimpleNamespace(symbol="052690", side="sell")
+    service = SimpleNamespace(get_proposal=AsyncMock(return_value=(group, [])))
+
+    @contextlib.asynccontextmanager
+    async def session_factory():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr(opt, "AsyncSessionLocal", session_factory)
+    monkeypatch.setattr(opt, "OrderProposalsService", lambda _session: service)
+    monkeypatch.setattr(
+        opt,
+        "validate_proposal_redispatch",
+        AsyncMock(
+            return_value=RedispatchValidation(
+                False,
+                "redispatch_approval_already_acted",
+                {},
+            )
+        ),
+    )
+    sender = AsyncMock()
+    monkeypatch.setattr(opt, "send_proposal_for_approval", sender)
+
+    result = await opt.order_proposal_redispatch(str(uuid.uuid4()), dry_run=False)
+
+    assert result["success"] is False
+    assert result["error"] == "redispatch_approval_already_acted"
+    sender.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_execute_sends_only_fresh_telegram_card(monkeypatch):
+    proposal_id = uuid.uuid4()
+    group = SimpleNamespace(symbol="052690", side="sell")
+    service = SimpleNamespace(get_proposal=AsyncMock(return_value=(group, [])))
+
+    @contextlib.asynccontextmanager
+    async def session_factory():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr(opt, "AsyncSessionLocal", session_factory)
+    monkeypatch.setattr(opt, "OrderProposalsService", lambda _session: service)
+    monkeypatch.setattr(
+        opt,
+        "validate_proposal_redispatch",
+        AsyncMock(return_value=RedispatchValidation(True, None, {"rungs": []})),
+    )
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    notifier = SimpleNamespace()
+    monkeypatch.setattr(opt, "_get_trade_notifier", lambda: notifier)
+    sender = AsyncMock(
+        return_value=opt.TelegramDispatchResult(
+            state=opt.ApprovalDispatchState.SENT_CURRENT,
+            message_id=4242,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=120,
+            failure_code=None,
+        )
+    )
+    monkeypatch.setattr(opt, "send_proposal_for_approval", sender)
+
+    result = await opt.order_proposal_redispatch(str(proposal_id), dry_run=False)
+
+    assert result["success"] is True
+    assert result["approval_dispatch"]["state"] == "sent"
+    sender.assert_awaited_once()
+    assert sender.await_args.kwargs["notifier"] is notifier
+    assert sender.await_args.kwargs["redispatch"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redispatch_uncertain_send_failure_alerts_without_replacing_attempt(
+    monkeypatch,
+):
+    proposal_id = uuid.uuid4()
+    group = SimpleNamespace(symbol="052690", side="sell")
+    service = SimpleNamespace(get_proposal=AsyncMock(return_value=(group, [])))
+
+    @contextlib.asynccontextmanager
+    async def session_factory():
+        yield SimpleNamespace()
+
+    monkeypatch.setattr(opt, "AsyncSessionLocal", session_factory)
+    monkeypatch.setattr(opt, "OrderProposalsService", lambda _session: service)
+    monkeypatch.setattr(
+        opt,
+        "validate_proposal_redispatch",
+        AsyncMock(return_value=RedispatchValidation(True, None, {"rungs": []})),
+    )
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    monkeypatch.setattr(opt, "_get_trade_notifier", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        opt,
+        "send_proposal_for_approval",
+        AsyncMock(side_effect=RuntimeError("uncertain publication boundary")),
+    )
+    alert = AsyncMock(return_value={"state": "sent", "channel": "discord"})
+    monkeypatch.setattr(opt, "_alert_non_sent_dispatch", alert)
+    replacement_ledger = AsyncMock()
+    monkeypatch.setattr(
+        opt,
+        "_record_post_commit_dispatch_failure",
+        replacement_ledger,
+    )
+
+    result = await opt.order_proposal_redispatch(
+        str(proposal_id),
+        dry_run=False,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "approval_redispatch_internal_error"
+    alert.assert_awaited_once_with(
+        proposal_id,
+        dispatch_state="unknown",
+        dispatch_failure_code="approval_redispatch_internal_error",
+    )
+    replacement_ledger.assert_not_awaited()
 
 
 # -- ROB-897 cause (1): order_proposal_expire_sweep MCP tool ----------------


### PR DESCRIPTION
## Summary

- ledger fail-closed approval-window blocks and send Discord-first operator alerts for every non-sent create dispatch, plus callback reconfirm/loss-cut card failures
- persist alert delivery success/failure under `source_asof.approval_dispatch_alert` without replacing the root dispatch failure code
- add manual `order_proposal_redispatch(proposal_id, dry_run=true)` with fresh approval-window and broker-safe preview validation
- prevent duplicate approval cards with the existing nonce plus row-locked pending/current dispatch guard

## Redispatch safety boundary

Execution is limited to active `place` + `limit` proposals with failed/missing dispatch state, no published card, no active/consumed nonce, and only `pending_approval`/`needs_reconfirm` rungs. It rejects expired/closed/unknown windows, approved/cancelled/terminal proposals, price or quantity drift, missing current price, and limit prices that crossed the current market. Execution sends only a Telegram approval card; it cannot approve or submit an order. An uncertain publication exception preserves any pending attempt/nonce instead of replacing it.

## Verification

- `make lint`
- 410 focused order-proposal/MCP tests passed
- blocked dispatch alert verified with Discord mock/spy; no live ops channel used
- alert delivery failure verified as error-logged and durably queryable
- invalid redispatch, duplicate/current dispatch, and normal dispatch regressions covered

## Flash delegation trial

Attempted the requested read-only inventory with `herdr-spawn -m agy`; it exited before spawning because the agy quota probe returned HTTP 401. No delegated output was used.