### PR TITLE
fix(ROB-496): fail closed on missing fill evidence

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -2286,6 +2286,12 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: existing account/advisory/learning/execution tools plus the seven mock-pinned typed `kiwoom_mock_*` tools. Requires a dedicated auth token and required approval-hash modes; no Kiwoom live or generic unscoped Kiwoom order surface is registered. |
 | Canonical paper execution | `paper_execution` | ROB-845 façade + ROB-848 validation + ROB-849 operator kill switch. Default-off and auth-required; no generic, venue-native, or live tools. |
 
+Generic `live_reconcile_orders` is evidence-first: `none` returns
+`noop_no_evidence` with `requires_manual_review=true` and leaves the ledger open.
+Only explicit broker cancellation evidence returns `cancelled`; its dry-run
+action is `would_mark_cancelled`, while an applied reconcile reports
+`marked_cancelled`.
+
 ### Profile: `paper_execution` (ROB-845)
 
 This isolated profile is the canonical experiment-to-paper-broker boundary. It

--- a/app/mcp_server/tooling/live_order_evidence.py
+++ b/app/mcp_server/tooling/live_order_evidence.py
@@ -18,6 +18,7 @@ from app.mcp_server.tooling.orders_modify_cancel import (
     _normalize_kis_overseas_order,
 )
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+    EvidenceCategory,
     FillEvidence,
     FillVerdict,
     classify_fill_evidence,
@@ -93,7 +94,7 @@ class UsOverseasEvidenceAdapter:
                 )
             if normalized_status == "cancelled":
                 return FillEvidence(
-                    FillVerdict.NONE,
+                    FillVerdict.CANCELLED,
                     Decimal("0"),
                     None,
                     None,
@@ -150,6 +151,15 @@ class UpbitEvidenceAdapter:
                 verdict.value,
                 f"upbit {row.order_no} {verdict.value} {executed}@{avg}",
             )
+        if executed > 0:
+            return FillEvidence(
+                FillVerdict.NONE,
+                executed,
+                None,
+                EvidenceCategory.CODE,
+                "missing_fill_price",
+                f"upbit {row.order_no} has executed volume without a fill price",
+            )
         if state == "wait":
             return FillEvidence(
                 FillVerdict.PENDING,
@@ -159,14 +169,22 @@ class UpbitEvidenceAdapter:
                 "pending",
                 f"upbit {row.order_no} waiting",
             )
-        # done/cancel with zero executed → 미체결 종료
+        if state == "cancel":
+            return FillEvidence(
+                FillVerdict.CANCELLED,
+                Decimal("0"),
+                None,
+                None,
+                "cancelled",
+                f"upbit {row.order_no} cancelled unfilled",
+            )
         return FillEvidence(
             FillVerdict.NONE,
             Decimal("0"),
             None,
-            None,
-            "cancelled",
-            f"upbit {row.order_no} ended unfilled",
+            EvidenceCategory.DATA_PRECONDITION,
+            "unexpected_order_state",
+            f"upbit {row.order_no} returned unexpected state={state!r}",
         )
 
 

--- a/app/mcp_server/tooling/live_order_ledger.py
+++ b/app/mcp_server/tooling/live_order_ledger.py
@@ -312,8 +312,8 @@ async def _reconcile_one_live_row(
                 base["proposal_rung"] = converged
         return base
 
-    if evidence.verdict == FillVerdict.NONE:
-        base["action"] = "marked_cancelled"
+    if evidence.verdict == FillVerdict.CANCELLED:
+        base["action"] = "would_mark_cancelled" if dry_run else "marked_cancelled"
         if not dry_run:
             await _update_live_ledger_outcome(ledger_id=row.id, status="cancelled")
             converged = await _converge_proposal_rung(
@@ -321,6 +321,15 @@ async def _reconcile_one_live_row(
             )
             if converged is not None:
                 base["proposal_rung"] = converged
+        return base
+
+    if evidence.verdict == FillVerdict.NONE:
+        base["action"] = "noop_no_evidence"
+        base["requires_manual_review"] = True
+        base["reason_code"] = evidence.reason_code
+        base["reason"] = evidence.detail or (
+            "no broker fill evidence; ledger left open instead of marking cancelled"
+        )
         return base
 
     # FILLED / PARTIAL — broker 확정값. 델타 멱등 booking.

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -720,8 +720,11 @@ def register_live_reconcile_tools(mcp: FastMCP) -> None:
         description=(
             "Reconcile accepted/pending US/overseas + crypto live (real-money) orders "
             "against broker fill evidence (overseas daily-order / Upbit order-state). "
-            "Books fills/journals/realized_pnl ONLY from confirmed fills (delta-idempotent); "
-            "marks unfilled/cancelled without journal side-effects. dry_run=True by default. "
+            "Books fills/journals/realized_pnl ONLY from confirmed fills (delta-idempotent). "
+            "Evidence-first: explicit broker cancellation returns cancelled "
+            "(dry: would_mark_cancelled, real: marked_cancelled); missing evidence (NONE) "
+            "returns noop_no_evidence with requires_manual_review=true and leaves ledger open "
+            "without ledger/proposal rung mutation. dry_run=True by default. "
             "ROB-568: Surfaces US FX PnL split (security_pnl_krw, fx_pnl_krw) "
             "for overseas equity fills. "
             "realized_pnl_pct (alias journal_pnl_pct, labeled "

--- a/app/services/brokers/kis/mock_scalping_exec/fill_evidence.py
+++ b/app/services/brokers/kis/mock_scalping_exec/fill_evidence.py
@@ -24,6 +24,7 @@ class FillVerdict(StrEnum):
     PARTIAL = "partial"
     PENDING = "pending"
     EXPIRED = "expired"
+    CANCELLED = "cancelled"
     NONE = "none"
     UNSUPPORTED = "unsupported"
 

--- a/docs/runbooks/live-order-periodic-reconcile.md
+++ b/docs/runbooks/live-order-periodic-reconcile.md
@@ -42,7 +42,7 @@ uv run python scripts/live_reconcile_backfill_report.py --market all
 LIVE_AUTO_RECONCILE_ENABLED=true LIVE_AUTO_RECONCILE_DRY_RUN=true \
   uv run python -c "import asyncio; from app.tasks.live_reconcile_tasks import live_reconcile_us_periodic; print(asyncio.run(live_reconcile_us_periodic()))"
 ```
-- **목적:** 브로커 API 조회를 통해 `would_book_filled`, `would_mark_expired`, `would_mark_cancelled`, `noop_pending` 분류 결과를 미리 확인 (DB Mutation 0).
+- **목적:** 브로커 API 조회를 통해 `would_book_filled`, `would_mark_expired`, `would_mark_cancelled`, `noop_pending`, `noop_no_evidence` 분류 결과를 미리 확인 (DB Mutation 0). `noop_no_evidence`는 ledger를 open으로 유지하고 `requires_manual_review=true`를 반환한다.
 
 ### ③ 3단계: 백필 실행 (Non-Dry Reconcile)
 운영자 확정 후 수동 실행 또는 MCP `live_reconcile_orders` 도구를 통해 `dry_run=False`로 실행.

--- a/tests/mcp_server/tooling/test_live_order_evidence_upbit.py
+++ b/tests/mcp_server/tooling/test_live_order_evidence_upbit.py
@@ -70,7 +70,7 @@ async def test_upbit_adapter_partial():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_upbit_adapter_cancelled_zero_fill_is_none():
+async def test_upbit_adapter_cancelled_zero_fill_is_cancelled():
     from app.mcp_server.tooling import live_order_evidence as ev
     from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
 
@@ -82,4 +82,22 @@ async def test_upbit_adapter_cancelled_zero_fill_is_none():
     )
     with patch.object(ev, "fetch_order_detail", new=AsyncMock(return_value=detail)):
         e = await ev.UpbitEvidenceAdapter().fetch_evidence(_Row())
+    assert e.verdict == FillVerdict.CANCELLED
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upbit_adapter_unknown_state_is_fail_closed_none():
+    from app.mcp_server.tooling import live_order_evidence as ev
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
+
+    class _Row:
+        order_no = "U-UNKNOWN"
+
+    detail = _detail(
+        state="unknown", executed_volume="0", remaining_volume="0", avg_price=None
+    )
+    with patch.object(ev, "fetch_order_detail", new=AsyncMock(return_value=detail)):
+        e = await ev.UpbitEvidenceAdapter().fetch_evidence(_Row())
     assert e.verdict == FillVerdict.NONE
+    assert e.reason_code == "unexpected_order_state"

--- a/tests/mcp_server/tooling/test_live_order_evidence_us.py
+++ b/tests/mcp_server/tooling/test_live_order_evidence_us.py
@@ -143,6 +143,41 @@ async def test_us_adapter_classifies_expired_day_order_from_broker_terminal_shap
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_us_adapter_classifies_explicit_cancel_evidence_as_cancelled() -> None:
+    from app.mcp_server.tooling import live_order_evidence as ev
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
+
+    class _Row:
+        symbol = "AAPL"
+        exchange = "NASD"
+        order_no = "US-CANCELLED-1"
+
+    broker_order = _row(
+        odno="US-CANCELLED-1",
+        ft_ord_qty="1",
+        ft_ccld_qty="0",
+        nccs_qty="0",
+        rvse_cncl_dvsn_name="취소",
+    )
+    with (
+        patch.object(ev, "_create_live_kis_client", return_value=object()),
+        patch.object(
+            ev, "_build_us_exchange_candidates", new=AsyncMock(return_value=["NASD"])
+        ),
+        patch.object(
+            ev,
+            "_find_us_order_in_recent_history",
+            new=AsyncMock(return_value=(broker_order, "NASD")),
+        ),
+    ):
+        evidence = await ev.UsOverseasEvidenceAdapter().fetch_evidence(_Row())
+
+    assert evidence.verdict == FillVerdict.CANCELLED
+    assert evidence.reason_code == "cancelled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_us_adapter_keeps_actual_open_order_pending() -> None:
     from app.mcp_server.tooling import live_order_evidence as ev
     from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -214,25 +214,83 @@ async def test_reconcile_cancelled_no_journal():
         indicators_snapshot=None,
     )
     row = await ll._load_live_ledger_row(lid)
-    none_ev = FillEvidence(FillVerdict.NONE, Decimal("0"), None, None, "cancelled", "")
+    cancelled = FillEvidence(
+        FillVerdict.CANCELLED, Decimal("0"), None, None, "cancelled", ""
+    )
 
     class _Adapter:
         broker = "kis"
-        fetch_evidence = AsyncMock(return_value=none_ev)
+        fetch_evidence = AsyncMock(return_value=cancelled)
 
     with (
         patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
         patch.object(ll, "_save_order_fill", new=AsyncMock()) as m_fill,
         patch.object(ll, "_create_trade_journal_for_buy", new=AsyncMock()) as m_buy,
     ):
+        preview = await ll._reconcile_one_live_row(row, dry_run=True)
+        before = await ll._load_live_ledger_row(lid)
         out = await ll._reconcile_one_live_row(row, dry_run=False)
 
-    assert out["verdict"] == "none"
+    assert preview["verdict"] == "cancelled"
+    assert preview["action"] == "would_mark_cancelled"
+    assert before.status == "accepted"
+    assert out["verdict"] == "cancelled"
+    assert out["action"] == "marked_cancelled"
     m_fill.assert_not_awaited()
     m_buy.assert_not_awaited()
     after = await ll._load_live_ledger_row(lid)
     assert after.status == "cancelled"
     assert after.journal_id is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dry_run", [True, False])
+async def test_reconcile_none_is_fail_closed_and_keeps_ledger_open(dry_run):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        EvidenceCategory,
+        FillEvidence,
+        FillVerdict,
+    )
+
+    row = SimpleNamespace(
+        id=496,
+        order_no="US-NO-EVIDENCE",
+        broker="kis",
+        market="us",
+        symbol="AAPL",
+    )
+    no_evidence = FillEvidence(
+        FillVerdict.NONE,
+        None,
+        None,
+        EvidenceCategory.DATA_PRECONDITION,
+        "no_matching_order",
+        "no daily-execution row for odno=US-NO-EVIDENCE",
+    )
+
+    class _Adapter:
+        broker = "kis"
+        fetch_evidence = AsyncMock(return_value=no_evidence)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(ll, "_update_live_ledger_outcome", new=AsyncMock()) as update,
+        patch.object(ll, "_converge_proposal_rung", new=AsyncMock()) as converge,
+    ):
+        out = await ll._reconcile_one_live_row(row, dry_run=dry_run)
+
+    assert out["verdict"] == "none"
+    assert out["action"] == "noop_no_evidence"
+    assert out["requires_manual_review"] is True
+    assert out["reason_code"] == "no_matching_order"
+    assert "no daily-execution row" in out["reason"]
+    update.assert_not_awaited()
+    converge.assert_not_awaited()
 
 
 @pytest.mark.unit
@@ -1325,16 +1383,19 @@ async def test_reconcile_cancel_converges_proposal_rung(db_session):
     pid = await _seed_resting_proposal(order_no=order_no, correlation_id=corr)
     lid = await _save_crypto_ledger(order_no=order_no, correlation_id=corr)
     row = await ll._load_live_ledger_row(lid)
-    none_ev = FillEvidence(FillVerdict.NONE, Decimal("0"), None, None, "cancelled", "")
+    cancelled = FillEvidence(
+        FillVerdict.CANCELLED, Decimal("0"), None, None, "cancelled", ""
+    )
 
     class _Adapter:
         broker = "upbit"
-        fetch_evidence = AsyncMock(return_value=none_ev)
+        fetch_evidence = AsyncMock(return_value=cancelled)
 
     with patch.object(ll, "get_evidence_adapter", return_value=_Adapter()):
         out = await ll._reconcile_one_live_row(row, dry_run=False)
 
-    assert out["verdict"] == "none"
+    assert out["verdict"] == "cancelled"
+    assert out["action"] == "marked_cancelled"
     assert await _read_rung_state(pid) == "cancelled"
 
 


### PR DESCRIPTION
## Summary
- split explicit broker cancellation into `FillVerdict.CANCELLED`
- keep `FillVerdict.NONE` open as `noop_no_evidence` with manual-review context
- report explicit cancellation as `would_mark_cancelled` in dry-run and `marked_cancelled` only when applied
- preserve the existing proposal-rung convergence contract for proven cancellations

## Evidence analysis
- the shared classifier returns `NONE` for missing order numbers, no matching row, unparseable quantities, and missing fill prices
- KIS mock diagnostics also map inquiry errors/exceptions to `NONE`; US live history lookup currently maps both not-found and swallowed per-exchange lookup failures to non-terminal `PENDING`
- KR live reconciliation already handles `NONE` as fail-closed `noop_no_evidence` and does not mark cancellation

## Retry posture
`NONE` leaves accepted/pending/partial rows eligible for a later reconcile. This patch adds no retry counter or terminal timeout because that would require a broader persistence/operations policy. The existing oldest-first `limit=100` scan can starve newer rows if unresolved backlog exceeds the limit; track that separately rather than inferring a terminal state here.

## Verification
- `make lint`
- targeted evidence/ledger tests: 45 passed
- KR fail-closed regression: 1 passed
- `make test`: 18,329 passed, 15 skipped, 7 deselected, 53 warnings

No deployment, broker mutation, production DB write, scheduler activation, or merge was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reconciliation now distinguishes confirmed broker cancellations from missing evidence.
  * Confirmed cancellations can mark orders as cancelled, with clear dry-run previews.
  * Orders without sufficient evidence remain open and are flagged for manual review.
  * Improved classification of cancellation, missing fill prices, and unexpected order states.

* **Documentation**
  * Updated reconciliation guidance and tool documentation to describe the new outcomes and manual-review behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->