### PR TITLE
fix(ROB-1095): refresh KIS US holdings prices

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1894,8 +1894,15 @@ Filtering rules:
 - If `include_current_price=False`, `minimum_value` filtering is skipped
 - When `minimum_value=None`, per-currency thresholds are automatically applied based on `instrument_type`: `equity_kr` and `crypto` use 5000, `equity_us` uses 10
 - When `minimum_value` is a number, that uniform threshold is applied to all positions
-- KIS US holdings keep KIS-provided snapshot values when the KIS snapshot is numerically valid: `current_price > 0`, `evaluation_amount > 0`, and `profit_loss` / `profit_rate` are parseable numbers
-- KIS US holdings fall back to Yahoo only when that KIS snapshot is missing or invalid; Yahoo is a fallback refresh path, not the default for valid KIS US holdings
+- KIS US balance snapshots are not treated as current-price truth even when
+  `current_price > 0`, `evaluation_amount > 0`, and `profit_loss` /
+  `profit_rate` are parseable: the balance response has no trustworthy
+  per-symbol as-of and can lag the live quote materially.
+- With `include_current_price=True`, every US position is refreshed through the
+  same venue-aware KIS overseas current-price path as `get_quote`, with Yahoo as
+  fallback. `evaluation_amount`, `profit_loss`, and `profit_rate` are
+  recalculated from that refreshed price. KIS KR holdings retain their complete
+  bulk balance snapshot to avoid the domestic per-symbol N+1.
 - Upbit crypto current prices are fetched via batch ticker request (`/v1/ticker?markets=...`)
 - During Upbit holdings collection, coins that raise `UpbitSymbolNotRegisteredError` or `UpbitSymbolInactiveError` on name lookup are silently skipped (not added to `errors`).
 - Before batch ticker request, tradable markets are loaded from `upbit_symbol_universe` and only valid holdings symbols are included in the batch
@@ -1907,6 +1914,13 @@ Response contract additions:
 - `filtered_count`: number of positions excluded by `minimum_value` filter
 - `filter_reason`: filter status string, e.g. `minimum_value < 1000` or `equity_kr < 5000, equity_us < 10, crypto < 5000`
 - `errors`: includes per-symbol price lookup failures for holdings price refresh (example fields: `source`, `market`, `symbol`, `stage`, `error`)
+- Refreshed US positions expose `price_source`, nullable `price_asof`,
+  `data_state`, and `profit_rate_price_source`; provider metadata such as
+  `session`, `venue`, and `delayed` is included when available. If both live
+  quote sources fail, the retained KIS balance snapshot is marked
+  `data_state="stale"` with
+  `data_state_reason="live_price_refresh_failed"` rather than silently reading
+  as current.
 - `filters.minimum_value`: when `minimum_value=None` in the request, this field contains the per-currency threshold dict that was applied
 - When `TOSS_API_ENABLED=true`, Toss Open API holdings are emitted with `broker="toss"`, `source="toss_api"`. `order_routable` (and `get_cash_balance` `orderable`, `/invest` home `isTradeable`/`sellableQuantity`) are gated on `TOSS_LIVE_ORDER_MUTATIONS_ENABLED` (ROB-549): reference-only (`order_routable=false`, `orderable=0`, `isTradeable=false`, `sellableQuantity=0`) while disabled, and routable with the API-provided `sellable_quantity` (Toss `/api/v1/sellable-quantity`) once the operator arms live mutations.
 - Toss sellable quantities use a successful-values-only Redis cache shared by `/invest` home and MCP processes (600-second default, controlled by `TOSS_SELLABLE_CACHE_TTL_SECONDS`; `TOSS_SELLABLE_CACHE_ENABLED=false` disables it). Reads use one batched `MGET`; confirmed fills and successful sell place/cancel/modify mutations delete only the affected symbol. `fresh_sellable=true` bypasses the cache, while `need_sellable=false` paths skip Redis and Toss sellable reads entirely.

--- a/app/mcp_server/tooling/portfolio_helpers.py
+++ b/app/mcp_server/tooling/portfolio_helpers.py
@@ -39,6 +39,20 @@ def position_to_output(position: dict[str, Any]) -> dict[str, Any]:
         output["sellable_quantity"] = position["sellable_quantity"]
     if "source" in position:
         output["source"] = position["source"]
+    # ROB-1095: expose the quote freshness/provenance used by US holdings and
+    # make the derivation source of profit_rate explicit.
+    for key in (
+        "price_source",
+        "price_asof",
+        "data_state",
+        "data_state_reason",
+        "profit_rate_price_source",
+        "session",
+        "venue",
+        "delayed",
+    ):
+        if key in position:
+            output[key] = position[key]
     # ROB-541: surface per-position sellability + provenance so consumers that
     # only read positions[] (not just the account GROUP) still get the
     # authoritative order_routable flag and the ROB-357 account_mode label.

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -10,7 +10,6 @@ import pandas as pd
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings, validate_kis_mock_config
 from app.core.db import AsyncSessionLocal
-from app.core.symbol import to_kis_symbol
 from app.mcp_server.env_utils import _env_int
 from app.mcp_server.tooling.account_modes import (
     apply_account_routing_metadata,
@@ -417,6 +416,14 @@ async def _collect_kis_positions(
                         "evaluation_amount": evaluation_amount,
                         "profit_loss": profit_loss,
                         "profit_rate": profit_rate,
+                        # KIS overseas balance rows do not carry a trustworthy
+                        # per-symbol quote timestamp.  This snapshot provenance
+                        # is replaced by the live quote refresh below when
+                        # include_current_price=True.
+                        "price_source": "kis_holdings_snapshot",
+                        "price_asof": None,
+                        "data_state": "unverified",
+                        "profit_rate_price_source": "kis_holdings_snapshot",
                     }
                 )
         except Exception as exc:
@@ -620,25 +627,27 @@ async def _collect_toss_api_positions(
     return positions, snapshot.errors, True
 
 
-def _has_valid_kis_equity_snapshot(position: dict[str, Any]) -> bool:
-    """KIS-account equity (KR or US) whose broker balance snapshot is complete.
+def _has_valid_kis_kr_snapshot(position: dict[str, Any]) -> bool:
+    """KIS-account KR equity whose broker balance snapshot is complete.
 
     When True, get_holdings keeps the KIS-provided snapshot values
     (``current_price`` / ``evaluation_amount`` / ``profit_loss`` /
     ``profit_rate``) and skips the per-symbol live current-price refresh.
 
-    PR #288 (ROB-365) established this for ``equity_us`` — the Yahoo/KIS live
-    refresh is a *fallback*, not the default for a valid KIS US snapshot.
-    ROB-902 extends the identical rule to ``equity_kr``: the KIS domestic
-    balance (``fetch_my_stocks``) already returns 현재가(``prpr``) / 평가금액 /
-    평가손익 for every holding in ONE bulk call, so the per-symbol
+    ROB-902 established this for ``equity_kr``: the KIS domestic balance
+    (``fetch_my_stocks``) already returns 현재가(``prpr``) / 평가금액 / 평가손익
+    for every holding in ONE bulk call, so the per-symbol
     ``inquire-daily-itemchartprice`` refresh was a redundant N+1 (~41 KR HTTP
     calls per get_holdings invocation).
+
+    ROB-1095 deliberately excludes ``equity_us``. KIS overseas balance rows
+    have no usable per-symbol as-of timestamp, and production measurement found
+    a numerically complete WDC snapshot lagging the live quote by 3.13%.
     """
     if position.get("source") != "kis_api":
         return False
 
-    if str(position.get("instrument_type") or "") not in {"equity_kr", "equity_us"}:
+    if str(position.get("instrument_type") or "") != "equity_kr":
         return False
 
     current_price = _to_optional_float(position.get("current_price"))
@@ -658,20 +667,53 @@ def _has_valid_kis_equity_snapshot(position: dict[str, Any]) -> bool:
 
 def _position_needs_current_price_refresh(position: dict[str, Any]) -> bool:
     instrument_type = str(position.get("instrument_type") or "")
-    if _has_valid_kis_equity_snapshot(position):
+    if _has_valid_kis_kr_snapshot(position):
         return False
 
     return instrument_type in {"equity_kr", "equity_us", "crypto"}
 
 
+def _apply_price_refresh(
+    position: dict[str, Any],
+    price: float,
+    metadata: dict[str, Any] | None,
+) -> None:
+    """Apply an authoritative price and keep its PnL provenance together."""
+    position["current_price"] = price
+    _recalculate_profit_fields(position)
+    if metadata is None:
+        return
+
+    position.update(metadata)
+    position["profit_rate_price_source"] = metadata.get("price_source")
+
+
+def _mark_price_refresh_failed(position: dict[str, Any], error: str) -> None:
+    """Surface that a retained KIS US balance snapshot could not be verified."""
+    position["price_error"] = error
+    if (
+        position.get("source") == "kis_api"
+        and position.get("instrument_type") == "equity_us"
+    ):
+        position["price_source"] = "kis_holdings_snapshot"
+        position["price_asof"] = None
+        position["data_state"] = "stale"
+        position["data_state_reason"] = "live_price_refresh_failed"
+        position["profit_rate_price_source"] = "kis_holdings_snapshot"
+
+
 async def _fetch_price_map_for_positions(
     positions: list[dict[str, Any]],
 ) -> tuple[
-    dict[tuple[str, str], float], list[dict[str, Any]], dict[tuple[str, str], str]
+    dict[tuple[str, str], float],
+    list[dict[str, Any]],
+    dict[tuple[str, str], str],
+    dict[tuple[str, str], dict[str, Any]],
 ]:
     price_map: dict[tuple[str, str], float] = {}
     price_errors: list[dict[str, Any]] = []
     error_map: dict[tuple[str, str], str] = {}
+    metadata_map: dict[tuple[str, str], dict[str, Any]] = {}
 
     crypto_symbols = sorted(
         {
@@ -757,7 +799,14 @@ async def _fetch_price_map_for_positions(
 
     async def fetch_equity_price(
         instrument_type: str, symbol: str
-    ) -> tuple[str, str, float | None, str | None, str | None]:
+    ) -> tuple[
+        str,
+        str,
+        float | None,
+        str | None,
+        str | None,
+        dict[str, Any] | None,
+    ]:
         if instrument_type == "equity_kr":
             try:
                 cached = await cache_first_kr(symbol, 2)
@@ -774,6 +823,7 @@ async def _fetch_price_map_for_positions(
                             cached_price,
                             None,
                             "db",
+                            None,
                         )
             except Exception:
                 logger.debug(
@@ -790,43 +840,54 @@ async def _fetch_price_map_for_positions(
                     float(price) if price is not None else None,
                     None,
                     "kis",
+                    None,
                 )
             except Exception as exc:
                 error_msg = str(exc)
                 logger.debug(
                     "Failed to fetch equity price for %s: %s", symbol, error_msg
                 )
-                return instrument_type, symbol, None, error_msg, "kis"
+                return instrument_type, symbol, None, error_msg, "kis", None
 
-        # equity_us (ROB-365 bug 2): KIS overseas daily close is the PRIMARY refresh
-        # source (reliable, no Yahoo fast_info session flakiness); Yahoo fast_info is
-        # the secondary live source; fail-closed (no fabricated price) if both miss.
-        kis_error: str | None = None
-        try:
-            kis = KISClient()
-            frame = await kis.inquire_overseas_daily_price(to_kis_symbol(symbol), n=2)
-            if frame is not None and not frame.empty and "close" in frame.columns:
-                last_close = float(frame["close"].iloc[-1])
-                if last_close > 0:
-                    return (instrument_type, symbol, last_close, None, "kis")
-            kis_error = "KIS overseas daily price unavailable"
-        except Exception as exc:
-            kis_error = str(exc)
-            logger.debug("KIS US daily price failed for %s: %s", symbol, kis_error)
-
-        yahoo_error: str
+        # ROB-1095: overseas balance ``now_pric2`` has no per-symbol as-of and
+        # can lag the regular-session quote by several percent while remaining
+        # numerically valid. Use the same venue-aware KIS-current -> Yahoo
+        # fallback path as get_quote, then recalculate every price-derived field.
         try:
             quote = await _fetch_quote_equity_us(symbol)
-            price = quote.get("price")
-            if price is not None:
-                return (instrument_type, symbol, float(price), None, "yahoo")
-            yahoo_error = "Yahoo quote returned no price"
-        except Exception as exc:
-            yahoo_error = str(exc)
-            logger.debug("Failed to fetch equity price for %s: %s", symbol, yahoo_error)
+            price = _to_optional_float(quote.get("price"))
+            if price is None or price <= 0:
+                raise RuntimeError("US live quote returned no price")
 
-        combined = "; ".join(part for part in (kis_error, yahoo_error) if part)
-        return instrument_type, symbol, None, combined, "kis+yahoo"
+            metadata = {
+                "price_source": (
+                    quote.get("price_source") or quote.get("source") or "us_live_quote"
+                ),
+                "price_asof": quote.get("quote_asof"),
+                "data_state": quote.get("data_state") or "unknown",
+            }
+            for key in ("data_state_reason", "session", "venue", "delayed"):
+                if key in quote:
+                    metadata[key] = quote[key]
+            return (
+                instrument_type,
+                symbol,
+                price,
+                None,
+                str(quote.get("source") or "kis+yahoo"),
+                metadata,
+            )
+        except Exception as exc:
+            error_msg = str(exc)
+            logger.debug("Failed to fetch US live quote for %s: %s", symbol, error_msg)
+            return (
+                instrument_type,
+                symbol,
+                None,
+                error_msg,
+                "kis+yahoo",
+                None,
+            )
 
     equity_pairs = sorted(
         {
@@ -845,9 +906,12 @@ async def _fetch_price_map_for_positions(
                 for it, sym in equity_pairs
             ],
         )
-        for instrument_type, symbol, price, error, source in results:
+        for instrument_type, symbol, price, error, source, metadata in results:
             if price is not None:
-                price_map[(instrument_type, symbol)] = price
+                key = (instrument_type, symbol)
+                price_map[key] = price
+                if metadata is not None:
+                    metadata_map[key] = metadata
             elif error is not None:
                 error_map[(instrument_type, symbol)] = error
                 price_errors.append(
@@ -861,7 +925,7 @@ async def _fetch_price_map_for_positions(
                     }
                 )
 
-    return price_map, price_errors, error_map
+    return price_map, price_errors, error_map, metadata_map
 
 
 async def _collect_portfolio_positions(
@@ -911,25 +975,38 @@ async def _collect_portfolio_positions(
             ]
 
         if include_current_price and positions:
-            price_map, price_errors, error_map = await _fetch_price_map_for_positions(
-                positions
-            )
+            (
+                price_map,
+                price_errors,
+                error_map,
+                metadata_map,
+            ) = await _fetch_price_map_for_positions(positions)
             errors.extend(price_errors)
             for position in positions:
                 key = (position["instrument_type"], position["symbol"])
                 needs_refresh = _position_needs_current_price_refresh(position)
                 price = price_map.get(key)
                 if price is not None and needs_refresh:
-                    position["current_price"] = price
-                    _recalculate_profit_fields(position)
+                    _apply_price_refresh(position, price, metadata_map.get(key))
                 elif (error := error_map.get(key)) is not None and needs_refresh:
-                    position["price_error"] = error
+                    _mark_price_refresh_failed(position, error)
         else:
             for position in positions:
                 position["current_price"] = None
                 position["evaluation_amount"] = None
                 position["profit_loss"] = None
                 position["profit_rate"] = None
+                for key in (
+                    "price_source",
+                    "price_asof",
+                    "data_state",
+                    "data_state_reason",
+                    "profit_rate_price_source",
+                    "session",
+                    "venue",
+                    "delayed",
+                ):
+                    position.pop(key, None)
 
         positions.sort(key=lambda p: (p["account"], p["market"], p["symbol"]))
         return positions, errors, market_filter, account
@@ -1015,27 +1092,40 @@ async def _collect_portfolio_positions(
         ]
 
     if include_current_price and positions:
-        price_map, price_errors, error_map = await _fetch_price_map_for_positions(
-            positions
-        )
+        (
+            price_map,
+            price_errors,
+            error_map,
+            metadata_map,
+        ) = await _fetch_price_map_for_positions(positions)
         errors.extend(price_errors)
         for position in positions:
             key = (position["instrument_type"], position["symbol"])
             needs_price_refresh = _position_needs_current_price_refresh(position)
             price = price_map.get(key)
             if price is not None and needs_price_refresh:
-                position["current_price"] = price
-                _recalculate_profit_fields(position)
+                _apply_price_refresh(position, price, metadata_map.get(key))
             else:
                 error = error_map.get(key)
                 if error is not None and needs_price_refresh:
-                    position["price_error"] = error
+                    _mark_price_refresh_failed(position, error)
     else:
         for position in positions:
             position["current_price"] = None
             position["evaluation_amount"] = None
             position["profit_loss"] = None
             position["profit_rate"] = None
+            for key in (
+                "price_source",
+                "price_asof",
+                "data_state",
+                "data_state_reason",
+                "profit_rate_price_source",
+                "session",
+                "venue",
+                "delayed",
+            ):
+                position.pop(key, None)
 
     positions.sort(
         key=lambda position: (

--- a/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
+++ b/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
@@ -209,6 +209,7 @@ async def test_kr_price_enrichment_db_hit_matches_legacy_result_and_skips_kis(
         {("equity_kr", "005930"): 62_000.0},
         [],
         {},
+        {},
     )
     db_read.assert_awaited_once_with("005930", 2)
     kis_quote.assert_not_awaited()
@@ -232,7 +233,7 @@ async def test_kr_price_enrichment_db_miss_falls_back_to_legacy_kis_result(
         [_kr_refresh_position()]
     )
 
-    assert actual == ({("equity_kr", "005930"): 62_000.0}, [], {})
+    assert actual == ({("equity_kr", "005930"): 62_000.0}, [], {}, {})
     kis_quote.assert_awaited_once_with("005930")
 
 
@@ -241,8 +242,8 @@ def _kr_kis_snapshot_position(symbol: str = "005930") -> dict[str, object]:
 
     ``_collect_kis_positions`` fills these four fields in one bulk balance call
     (``prpr`` / ``evlu_amt`` / ``evlu_pfls_amt`` / ``evlu_pfls_rt``). ROB-902:
-    such a holding must NOT trigger the per-symbol itemchartprice refresh —
-    mirroring the pre-existing US snapshot exemption (PR #288 / ROB-365).
+    such a KR holding must NOT trigger the per-symbol itemchartprice refresh.
+    ROB-1095 intentionally removed the corresponding US snapshot exemption.
     """
     return {
         "instrument_type": "equity_kr",
@@ -270,7 +271,7 @@ async def test_kr_kis_snapshot_skips_price_refresh_and_makes_zero_kis_http(
     )
 
     # No equity pair enqueued -> empty price map, no errors.
-    assert actual == ({}, [], {})
+    assert actual == ({}, [], {}, {})
     db_read.assert_not_awaited()
     kis_quote.assert_not_awaited()
 
@@ -299,8 +300,8 @@ def test_kr_non_kis_snapshot_still_refreshes() -> None:
     assert portfolio_holdings._position_needs_current_price_refresh(manual) is True
 
 
-def test_us_kis_snapshot_remains_exempt() -> None:
-    """Regression: the pre-existing US snapshot exemption is preserved."""
+def test_us_kis_snapshot_always_refreshes() -> None:
+    """ROB-1095: a complete US balance snapshot still needs a live quote."""
     us = _kr_kis_snapshot_position("AAPL")
     us["instrument_type"] = "equity_us"
-    assert portfolio_holdings._position_needs_current_price_refresh(us) is False
+    assert portfolio_holdings._position_needs_current_price_refresh(us) is True

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -923,7 +923,15 @@ async def test_get_holdings_groups_by_account_and_calculates_pnl(monkeypatch):
         "_fetch_quote_equity_kr",
         AsyncMock(return_value={"price": 71000.0}),
     )
-    us_quote_mock = AsyncMock(return_value={"price": 220.0})
+    us_quote_mock = AsyncMock(
+        return_value={
+            "price": 220.0,
+            "source": "kis_overseas",
+            "price_source": "kis_overseas_last",
+            "data_state": "fresh",
+            "venue": "NASD",
+        }
+    )
     _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_us", us_quote_mock)
     monkeypatch.setattr(
         upbit_service,
@@ -954,20 +962,22 @@ async def test_get_holdings_groups_by_account_and_calculates_pnl(monkeypatch):
     )
     # ROB-902: a KIS-account KR holding keeps its bulk balance snapshot
     # (prpr / evlu_amt / evlu_pfls_amt / evlu_pfls_rt) instead of firing the
-    # per-symbol itemchartprice refresh — mirroring the US snapshot exemption
-    # asserted below. The 71000 KR refresh mock only serves the manual/Toss
-    # 005930 holding (source != kis_api), not this KIS-account one.
+    # per-symbol itemchartprice refresh. The 71000 KR refresh mock only serves
+    # the manual/Toss 005930 holding (source != kis_api), not this KIS-account
+    # one. US positions below intentionally do refresh (ROB-1095).
     assert kis_kr["current_price"] == pytest.approx(70500.0)
     assert kis_kr["evaluation_amount"] == pytest.approx(141000.0)
     assert kis_kr["profit_loss"] == pytest.approx(1000.0)
     assert kis_kr["profit_rate"] == pytest.approx(0.71)
 
     kis_us = next(item for item in kis_account["positions"] if item["symbol"] == "AAPL")
-    assert kis_us["current_price"] == pytest.approx(210.0)
-    assert kis_us["evaluation_amount"] == pytest.approx(210.0)
-    assert kis_us["profit_loss"] == pytest.approx(10.0)
-    assert kis_us["profit_rate"] == pytest.approx(5.0)
-    us_quote_mock.assert_not_awaited()
+    assert kis_us["current_price"] == pytest.approx(220.0)
+    assert kis_us["evaluation_amount"] == pytest.approx(220.0)
+    assert kis_us["profit_loss"] == pytest.approx(20.0)
+    assert kis_us["profit_rate"] == pytest.approx(10.0)
+    assert kis_us["price_source"] == "kis_overseas_last"
+    assert kis_us["profit_rate_price_source"] == "kis_overseas_last"
+    us_quote_mock.assert_awaited_once_with("AAPL")
 
     upbit_account = next(
         item for item in result["accounts"] if item["account"] == "upbit"
@@ -1858,8 +1868,8 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
         async def inquire_overseas_daily_price(
             self, symbol, exchange_code="NASD", n=200, period="D"
         ):
-            # ROB-365 bug 2: KIS daily close is the primary refresh source; here it
-            # is also unavailable, so the position must fall back / fail-closed.
+            # Legacy method retained on the stub; ROB-1095 no longer uses a
+            # daily bar as a US holdings current-price refresh.
             return pd.DataFrame()
 
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
@@ -1909,7 +1919,7 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
     assert "AMZN" in error_symbols
     assert "AAPL" in error_symbols
     for error in result["errors"]:
-        # KIS daily close is tried first, then Yahoo; both unavailable here.
+        # The shared KIS-current/Yahoo quote path failed.
         assert error["source"] == "kis+yahoo"
         assert error["market"] == "us"
         assert error["stage"] == "current_price"
@@ -1918,8 +1928,9 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_collect_portfolio_positions_skips_yahoo_for_kis_us_with_valid_numeric_snapshot(
-    monkeypatch,
+@pytest.mark.parametrize("is_mock", [False, True])
+async def test_collect_portfolio_positions_refreshes_kis_us_valid_numeric_snapshot(
+    monkeypatch, is_mock
 ):
     from app.mcp_server.tooling import portfolio_holdings
 
@@ -1942,11 +1953,24 @@ async def test_collect_portfolio_positions_skips_yahoo_for_kis_us_with_valid_num
         }
     ]
 
-    async def fake_collect_kis_positions(market_filter):
+    async def fake_collect_kis_positions(market_filter, *, is_mock=False):
         assert market_filter == "equity_us"
+        assert is_mock is is_mock_mode
         return positions, []
 
-    quote_mock = AsyncMock(return_value={"price": 220.0})
+    is_mock_mode = is_mock
+    quote_mock = AsyncMock(
+        return_value={
+            "price": 220.0,
+            "source": "kis_overseas",
+            "price_source": "kis_overseas_last",
+            "quote_asof": "2026-07-27T10:03:00-04:00",
+            "data_state": "fresh",
+            "session": "regular",
+            "venue": "NASD",
+            "delayed": True,
+        }
+    )
 
     monkeypatch.setattr(
         portfolio_holdings, "_collect_kis_positions", fake_collect_kis_positions
@@ -1972,20 +1996,109 @@ async def test_collect_portfolio_positions_skips_yahoo_for_kis_us_with_valid_num
         account="kis",
         market="us",
         include_current_price=True,
+        is_mock=is_mock,
     )
 
     assert result_errors == []
-    assert result_positions == positions
-    assert result_positions[0]["current_price"] == pytest.approx(210.0)
-    assert result_positions[0]["evaluation_amount"] == pytest.approx(210.0)
-    assert result_positions[0]["profit_loss"] == pytest.approx(0.0)
-    assert result_positions[0]["profit_rate"] == pytest.approx(0.0)
-    quote_mock.assert_not_awaited()
+    assert result_positions[0]["current_price"] == pytest.approx(220.0)
+    assert result_positions[0]["evaluation_amount"] == pytest.approx(220.0)
+    assert result_positions[0]["profit_loss"] == pytest.approx(20.0)
+    assert result_positions[0]["profit_rate"] == pytest.approx(10.0)
+    assert result_positions[0]["price_source"] == "kis_overseas_last"
+    assert result_positions[0]["price_asof"] == "2026-07-27T10:03:00-04:00"
+    assert result_positions[0]["data_state"] == "fresh"
+    assert result_positions[0]["profit_rate_price_source"] == "kis_overseas_last"
+    quote_mock.assert_awaited_once_with("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_rob1095_wdc_and_uber_refresh_live_price_and_derived_pnl(monkeypatch):
+    """ROB-1095 production reproduction: both valid snapshots use live quotes."""
+    tools = build_tools()
+
+    class DummyKISClient:
+        def __init__(self, is_mock=False):
+            self.is_mock = is_mock
+
+        async def fetch_my_stocks(self, is_mock=False):
+            return []
+
+        async def fetch_my_us_stocks(self, is_mock=False):
+            return [
+                {
+                    "ovrs_pdno": "WDC",
+                    "ovrs_item_name": "Western Digital",
+                    "ovrs_cblc_qty": "1",
+                    "pchs_avg_pric": "532",
+                    "now_pric2": "513.99",
+                    "ovrs_stck_evlu_amt": "513.99",
+                    "frcr_evlu_pfls_amt": "-18.01",
+                    "evlu_pfls_rt": "-3.39",
+                },
+                {
+                    "ovrs_pdno": "UBER",
+                    "ovrs_item_name": "Uber",
+                    "ovrs_cblc_qty": "4",
+                    "pchs_avg_pric": "68.6",
+                    "now_pric2": "66.49",
+                    "ovrs_stck_evlu_amt": "265.96",
+                    "frcr_evlu_pfls_amt": "-8.44",
+                    "evlu_pfls_rt": "-3.08",
+                },
+            ]
+
+    async def fetch_quote(symbol: str) -> dict[str, object]:
+        return {
+            "price": {"WDC": 498.39, "UBER": 66.56}[symbol],
+            "source": "kis_overseas",
+            "price_source": "kis_overseas_last",
+            "data_state": "fresh",
+            "session": "regular",
+            "venue": {"WDC": "NASD", "UBER": "NYSE"}[symbol],
+            "delayed": True,
+        }
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    _patch_runtime_attr(
+        monkeypatch,
+        "_collect_manual_positions",
+        AsyncMock(return_value=([], [])),
+    )
+    _patch_runtime_attr(monkeypatch, "validate_kis_mock_config", lambda: [])
+    quote_mock = AsyncMock(side_effect=fetch_quote)
+    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_us", quote_mock)
+
+    result = await tools["get_holdings"](
+        account="kis",
+        account_mode="kis_mock",
+        market="us",
+        minimum_value=0,
+    )
+    positions = {
+        position["symbol"]: position for position in result["accounts"][0]["positions"]
+    }
+
+    assert positions["WDC"]["current_price"] == pytest.approx(498.39)
+    assert positions["WDC"]["evaluation_amount"] == pytest.approx(498.39)
+    assert positions["WDC"]["profit_loss"] == pytest.approx(-33.61)
+    assert positions["WDC"]["profit_rate"] == pytest.approx(-6.32)
+    assert positions["WDC"]["venue"] == "NASD"
+
+    assert positions["UBER"]["current_price"] == pytest.approx(66.56)
+    assert positions["UBER"]["evaluation_amount"] == pytest.approx(266.24)
+    assert positions["UBER"]["profit_loss"] == pytest.approx(-8.16)
+    assert positions["UBER"]["profit_rate"] == pytest.approx(-2.97)
+    assert positions["UBER"]["venue"] == "NYSE"
+
+    assert result["summary"]["total_evaluation"] == pytest.approx(764.63)
+    assert result["summary"]["total_profit_loss"] == pytest.approx(-41.77)
+    assert result["summary"]["total_profit_rate"] == pytest.approx(-5.18)
+    assert {call.args[0] for call in quote_mock.await_args_list} == {"WDC", "UBER"}
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("kis_price_value", ["", "0"])
-async def test_get_holdings_fetches_yahoo_only_for_kis_us_missing_price_and_recalculates(
+async def test_get_holdings_refreshes_all_kis_us_positions_and_recalculates(
     monkeypatch, kis_price_value
 ):
     tools = build_tools()
@@ -2024,7 +2137,16 @@ async def test_get_holdings_fetches_yahoo_only_for_kis_us_missing_price_and_reca
         "_collect_manual_positions",
         AsyncMock(return_value=([], [])),
     )
-    quote_mock = AsyncMock(return_value={"price": 165.0})
+
+    async def fetch_quote(symbol: str) -> dict[str, object]:
+        return {
+            "price": {"AAPL": 220.0, "AMZN": 165.0}[symbol],
+            "source": "kis_overseas",
+            "price_source": "kis_overseas_last",
+            "data_state": "fresh",
+        }
+
+    quote_mock = AsyncMock(side_effect=fetch_quote)
     _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_us", quote_mock)
 
     result = await tools["get_holdings"](account="kis", market="us")
@@ -2038,10 +2160,11 @@ async def test_get_holdings_fetches_yahoo_only_for_kis_us_missing_price_and_reca
     }
 
     aapl = positions_by_symbol["AAPL"]
-    assert aapl["current_price"] == pytest.approx(210.0)
-    assert aapl["evaluation_amount"] == pytest.approx(210.0)
-    assert aapl["profit_loss"] == pytest.approx(10.0)
-    assert aapl["profit_rate"] == pytest.approx(5.0)
+    assert aapl["current_price"] == pytest.approx(220.0)
+    assert aapl["evaluation_amount"] == pytest.approx(220.0)
+    assert aapl["profit_loss"] == pytest.approx(20.0)
+    assert aapl["profit_rate"] == pytest.approx(10.0)
+    assert aapl["profit_rate_price_source"] == "kis_overseas_last"
     assert "price_error" not in aapl
 
     amzn = positions_by_symbol["AMZN"]
@@ -2051,7 +2174,7 @@ async def test_get_holdings_fetches_yahoo_only_for_kis_us_missing_price_and_reca
     assert amzn["profit_rate"] == pytest.approx(10.0)
     assert "price_error" not in amzn
 
-    quote_mock.assert_awaited_once_with("AMZN")
+    assert {call.args[0] for call in quote_mock.await_args_list} == {"AAPL", "AMZN"}
 
 
 @pytest.mark.asyncio
@@ -2213,7 +2336,7 @@ async def test_get_holdings_fetches_yahoo_for_kis_us_with_invalid_profit_metrics
 
 
 @pytest.mark.asyncio
-async def test_get_holdings_keeps_kis_us_price_when_manual_same_symbol_uses_yahoo(
+async def test_get_holdings_shares_us_live_price_for_same_symbol_across_accounts(
     monkeypatch,
 ):
     tools = build_tools()
@@ -2276,10 +2399,10 @@ async def test_get_holdings_keeps_kis_us_price_when_manual_same_symbol_uses_yaho
     kis_aapl = accounts_by_id["kis"]["positions"][0]
     manual_aapl = accounts_by_id["toss"]["positions"][0]
 
-    assert kis_aapl["current_price"] == pytest.approx(210.0)
-    assert kis_aapl["evaluation_amount"] == pytest.approx(210.0)
-    assert kis_aapl["profit_loss"] == pytest.approx(10.0)
-    assert kis_aapl["profit_rate"] == pytest.approx(5.0)
+    assert kis_aapl["current_price"] == pytest.approx(225.0)
+    assert kis_aapl["evaluation_amount"] == pytest.approx(225.0)
+    assert kis_aapl["profit_loss"] == pytest.approx(25.0)
+    assert kis_aapl["profit_rate"] == pytest.approx(12.5)
     assert "price_error" not in kis_aapl
 
     assert manual_aapl["current_price"] == pytest.approx(225.0)
@@ -2318,7 +2441,8 @@ async def test_get_holdings_only_records_yahoo_error_for_same_symbol_manual_fall
         async def inquire_overseas_daily_price(
             self, symbol, exchange_code="NASD", n=200, period="D"
         ):
-            # KIS daily close (primary refresh source) also unavailable here.
+            # Legacy method retained on the stub; ROB-1095 uses the shared
+            # KIS-current/Yahoo quote path instead.
             return pd.DataFrame()
 
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
@@ -2365,7 +2489,12 @@ async def test_get_holdings_only_records_yahoo_error_for_same_symbol_manual_fall
     assert kis_aapl["evaluation_amount"] == pytest.approx(210.0)
     assert kis_aapl["profit_loss"] == pytest.approx(10.0)
     assert kis_aapl["profit_rate"] == pytest.approx(5.0)
-    assert "price_error" not in kis_aapl
+    assert "not found" in kis_aapl["price_error"]
+    assert kis_aapl["price_source"] == "kis_holdings_snapshot"
+    assert kis_aapl["price_asof"] is None
+    assert kis_aapl["data_state"] == "stale"
+    assert kis_aapl["data_state_reason"] == "live_price_refresh_failed"
+    assert kis_aapl["profit_rate_price_source"] == "kis_holdings_snapshot"
 
     assert manual_aapl["current_price"] is None
     assert manual_aapl["evaluation_amount"] is None
@@ -2373,8 +2502,7 @@ async def test_get_holdings_only_records_yahoo_error_for_same_symbol_manual_fall
     assert manual_aapl["profit_rate"] is None
     assert "not found" in manual_aapl["price_error"]
 
-    # A single deduped error for the symbol; KIS daily close is tried before Yahoo,
-    # both unavailable here, so the source reflects both providers (ROB-365 bug 2).
+    # One shared live-quote attempt/error serves both same-symbol positions.
     assert len(result["errors"]) == 1
     error = result["errors"][0]
     assert error["source"] == "kis+yahoo"
@@ -3312,15 +3440,12 @@ async def test_get_available_capital_paper(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# ROB-365 bug 2: get_holdings US current-price refresh — KIS-primary, fail-closed
+# ROB-1095: get_holdings US current-price refresh + provenance
 # ---------------------------------------------------------------------------
 
 
 def _us_refresh_position(symbol: str = "AAPL") -> dict:
-    """A US position whose KIS snapshot is incomplete, so the refresh path fires.
-
-    source != "kis_api" makes _has_valid_kis_equity_snapshot() return False.
-    """
+    """A US position; every US position takes the live quote refresh path."""
     return {
         "instrument_type": "equity_us",
         "symbol": symbol,
@@ -3332,86 +3457,84 @@ def _us_refresh_position(symbol: str = "AAPL") -> dict:
     }
 
 
-def _kis_daily_frame(last_close: float) -> pd.DataFrame:
-    return pd.DataFrame(
-        {
-            "date": pd.date_range("2024-01-01", periods=2, freq="D"),
-            "open": [last_close - 2, last_close - 1],
-            "high": [last_close + 2, last_close + 2],
-            "low": [last_close - 3, last_close - 2],
-            "close": [last_close - 1, last_close],
-            "volume": [1000, 1100],
+@pytest.mark.asyncio
+async def test_fetch_price_map_us_uses_live_quote_and_preserves_provenance(monkeypatch):
+    """ROB-1095: refresh through get_quote's venue-aware KIS current-price arm."""
+    us_quote_mock = AsyncMock(
+        return_value={
+            "price": 208.0,
+            "source": "kis_overseas",
+            "price_source": "kis_overseas_last",
+            "quote_asof": "2026-07-27T10:03:00-04:00",
+            "data_state": "fresh",
+            "session": "regular",
+            "venue": "NYSE",
+            "delayed": True,
         }
     )
-
-
-@pytest.mark.asyncio
-async def test_fetch_price_map_us_uses_kis_daily_close_primary(monkeypatch):
-    """US current-price refresh resolves from KIS daily close first; Yahoo not called (ROB-365 bug 2)."""
-
-    class DummyKISClient:
-        async def inquire_overseas_daily_price(
-            self, symbol, exchange_code="NASD", n=200, period="D"
-        ):
-            return _kis_daily_frame(208.0)
-
-    monkeypatch.setattr(portfolio_holdings, "KISClient", DummyKISClient)
-    us_quote_mock = AsyncMock(return_value={"price": 220.0})
     monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
 
     (
         price_map,
         price_errors,
         error_map,
+        metadata_map,
     ) = await portfolio_holdings._fetch_price_map_for_positions(
         [_us_refresh_position()]
     )
 
     assert price_map[("equity_us", "AAPL")] == pytest.approx(208.0)
+    assert price_errors == []
     assert ("equity_us", "AAPL") not in error_map
-    us_quote_mock.assert_not_awaited()
+    assert metadata_map[("equity_us", "AAPL")] == {
+        "price_source": "kis_overseas_last",
+        "price_asof": "2026-07-27T10:03:00-04:00",
+        "data_state": "fresh",
+        "session": "regular",
+        "venue": "NYSE",
+        "delayed": True,
+    }
+    us_quote_mock.assert_awaited_once_with("AAPL")
 
 
 @pytest.mark.asyncio
-async def test_fetch_price_map_us_falls_back_to_yahoo_when_kis_empty(monkeypatch):
-    """When KIS daily close is unavailable, fall back to the Yahoo live quote (ROB-365 bug 2)."""
-
-    class DummyKISClient:
-        async def inquire_overseas_daily_price(
-            self, symbol, exchange_code="NASD", n=200, period="D"
-        ):
-            return pd.DataFrame()  # no data (e.g. a NYSE/AMEX symbol under NASD)
-
-    monkeypatch.setattr(portfolio_holdings, "KISClient", DummyKISClient)
-    us_quote_mock = AsyncMock(return_value={"price": 215.0})
+async def test_fetch_price_map_us_preserves_yahoo_fallback_provenance(monkeypatch):
+    """The shared quote path can fall back to Yahoo without losing provenance."""
+    us_quote_mock = AsyncMock(
+        return_value={
+            "price": 215.0,
+            "source": "yahoo",
+            "price_source": "yahoo_fast_info_close",
+            "data_state": "fresh",
+            "session": "regular",
+            "delayed": True,
+        }
+    )
     monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
 
     (
         price_map,
         price_errors,
         error_map,
+        metadata_map,
     ) = await portfolio_holdings._fetch_price_map_for_positions(
         [_us_refresh_position()]
     )
 
     assert price_map[("equity_us", "AAPL")] == pytest.approx(215.0)
+    assert price_errors == []
+    assert error_map == {}
+    assert metadata_map[("equity_us", "AAPL")]["price_source"] == (
+        "yahoo_fast_info_close"
+    )
     us_quote_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_fetch_price_map_us_fail_closed_when_all_sources_fail(monkeypatch):
-    """When both KIS and Yahoo fail, no price is fabricated and the error records the
-    actual source (not the previously hardcoded 'yahoo') (ROB-365 bug 2)."""
-
-    class DummyKISClient:
-        async def inquire_overseas_daily_price(
-            self, symbol, exchange_code="NASD", n=200, period="D"
-        ):
-            raise RuntimeError("KIS overseas daily unavailable")
-
-    monkeypatch.setattr(portfolio_holdings, "KISClient", DummyKISClient)
+    """When the shared KIS/Yahoo quote path fails, no price is fabricated."""
     us_quote_mock = AsyncMock(
-        side_effect=RuntimeError("'NoneType' object is not subscriptable")
+        side_effect=RuntimeError("US quote temporarily unavailable")
     )
     monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
 
@@ -3419,12 +3542,14 @@ async def test_fetch_price_map_us_fail_closed_when_all_sources_fail(monkeypatch)
         price_map,
         price_errors,
         error_map,
+        metadata_map,
     ) = await portfolio_holdings._fetch_price_map_for_positions(
         [_us_refresh_position()]
     )
 
     assert ("equity_us", "AAPL") not in price_map  # no fabricated price
     assert ("equity_us", "AAPL") in error_map
+    assert metadata_map == {}
     us_error = next(e for e in price_errors if e.get("symbol") == "AAPL")
     assert us_error["source"] == "kis+yahoo"
     assert us_error["market"] == "us"


### PR DESCRIPTION
## Summary

- Treat every US holding as needing a current-price refresh when `include_current_price=True`; a numerically complete KIS overseas balance snapshot is no longer assumed fresh.
- Reuse the venue-aware `get_quote` path (KIS overseas current quote, Yahoo fallback), then recalculate evaluation/P&L fields from the refreshed price.
- Expose `price_source`, nullable `price_asof`, `data_state`, and `profit_rate_price_source`; retain-and-tag the KIS balance snapshot as stale if both live quote arms fail.
- Preserve ROB-902's complete KIS KR snapshot exemption, so the domestic N+1 does not return.

## Root cause / scope

The KIS US balance response has no usable per-symbol quote timestamp. The old validity gate checked only positive/parseable numbers, so WDC's lagging `513.99` passed and skipped refresh. UBER followed the same snapshot path; its KIS snapshot happened to be close to live, rather than taking a separate Yahoo fallback.

Venue is not a holdings-path discriminator: NASD and NYSE rows pass through the same snapshot gate. The old invalid-snapshot refresh did use a default NASD daily-bar attempt, but the new path resolves the symbol's actual venue through the shared current-quote implementation.

`kis_mock` and `kis_live` share this collection/refresh policy. The fix intentionally covers both because stale `kis_live` P&L can directly affect live trading judgment; it does not add or modify any order path.

A ROB-731-style age threshold cannot be applied honestly to the balance snapshot because it has no as-of. Refreshing US positions through the timestamp/provenance-aware quote path is the smallest fail-safe correction.

ROB-1095 is canonical; ROB-1099 is the duplicate investigation record.

## Tests

- `uv run pytest tests/test_mcp_portfolio_tools.py tests/mcp_server/tooling/test_get_holdings_n1_residuals.py tests/mcp_server/test_portfolio_helpers.py -q` — 113 passed
- Account-mode / quote / KIS market-data related suite — 167 passed
- `make lint` — Ruff check, Ruff format check, and ty passed
- Full non-live suite sampled to 11,422 passed / 0 failed before manual interruption in an unrelated slow report-integration section

No deployment, broker mutation, production DB write, or order action was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * US holdings now refresh with live, venue-aware quotes, with Yahoo used as a fallback.
  * Quote freshness and provenance are shown through price source, timestamp, session, venue, and data-state details.
  * Failed live-price refreshes are clearly marked as stale instead of appearing current.
  * Korean holdings continue using efficient bulk snapshot pricing.
* **Bug Fixes**
  * Shared US symbols now use a single refreshed quote across accounts.
  * Profit and loss calculations now reflect refreshed prices and their source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->