### PR TITLE
ROB-1069: wire alpaca-track H3 code supersession guard

### DIFF
--- a/app/services/research_canonical_hash.py
+++ b/app/services/research_canonical_hash.py
@@ -5,6 +5,11 @@ The stdlib-only implementation lives in the small wheel-packaged
 drift to different hashes.
 """
 
+import math
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
 from research_contracts.canonical_hash import (
     IDENTITY_COMPONENTS,
     canonical_ast_json,
@@ -25,8 +30,110 @@ __all__ = [
     "canonical_sha256",
     "compute_identity_hashes",
     "compute_identity_hashes_from_ast",
+    "decode_canonical",
+    "decode_manifest",
     "derive_experiment_id",
     "encode_canonical",
     "encode_manifest",
     "hash_canonical_ast",
 ]
+
+
+def decode_canonical(ast: Any) -> Any:
+    """Strictly decode one closed typed AST node from persisted JSONB."""
+    if type(ast) is not list or len(ast) != 2:
+        raise ValueError("canonical AST node must be an exact 2-element list")
+    tag, payload = ast
+    if type(tag) is not str:
+        raise ValueError("canonical AST tag must be a built-in str")
+
+    try:
+        if tag == "null":
+            if payload is not None:
+                raise ValueError("null payload must be None")
+            decoded: Any = None
+        elif tag == "bool":
+            if type(payload) is not bool:
+                raise ValueError("bool payload must be a built-in bool")
+            decoded = payload
+        elif tag == "int":
+            if type(payload) is not int:
+                raise ValueError("int payload must be a built-in int")
+            decoded = payload
+        elif tag == "float":
+            if type(payload) is not str:
+                raise ValueError("float payload must be an exact hex string")
+            decoded = float.fromhex(payload)
+            if not math.isfinite(decoded):
+                raise ValueError("float payload must be finite")
+        elif tag == "decimal":
+            if type(payload) is not str:
+                raise ValueError("decimal payload must be a built-in str")
+            decoded = Decimal(payload)
+            if not decoded.is_finite():
+                raise ValueError("decimal payload must be finite")
+        elif tag == "datetime":
+            if type(payload) is not str:
+                raise ValueError("datetime payload must be a built-in str")
+            decoded = datetime.fromisoformat(payload)
+        elif tag == "date":
+            if type(payload) is not str:
+                raise ValueError("date payload must be a built-in str")
+            decoded = date.fromisoformat(payload)
+        elif tag == "str":
+            if type(payload) is not str:
+                raise ValueError("str payload must be a built-in str")
+            decoded = payload
+        elif tag == "dict":
+            if type(payload) is not list:
+                raise ValueError("dict payload must be a built-in list")
+            decoded = {}
+            prior_key: str | None = None
+            for entry in payload:
+                if type(entry) is not list or len(entry) != 2:
+                    raise ValueError("dict entry must be an exact [key, node] list")
+                key, child = entry
+                if type(key) is not str:
+                    raise ValueError("dict key must be a built-in str")
+                if prior_key is not None and key <= prior_key:
+                    raise ValueError("dict keys must be unique and strictly sorted")
+                decoded[key] = decode_canonical(child)
+                prior_key = key
+        elif tag in {"list", "tuple", "set"}:
+            if type(payload) is not list:
+                raise ValueError(f"{tag} payload must be a built-in list")
+            values = [decode_canonical(child) for child in payload]
+            if tag == "list":
+                decoded = values
+            elif tag == "tuple":
+                decoded = tuple(values)
+            else:
+                try:
+                    decoded = frozenset(values)
+                except TypeError as exc:
+                    raise ValueError(
+                        "set payload contains an unhashable member"
+                    ) from exc
+        else:
+            raise ValueError(f"unknown canonical AST tag {tag!r}")
+    except (InvalidOperation, OverflowError) as exc:
+        raise ValueError(f"invalid {tag!r} canonical AST payload") from exc
+
+    if canonical_ast_json(encode_canonical(decoded)) != canonical_ast_json(ast):
+        raise ValueError(f"{tag!r} canonical AST node is not in canonical form")
+    return decoded
+
+
+def decode_manifest(manifest: Any) -> dict[str, Any]:
+    """Decode an exact persisted identity manifest (all 11 components)."""
+    if type(manifest) is not dict:
+        raise ValueError("canonical identity manifest must be a built-in dict")
+    expected = set(IDENTITY_COMPONENTS)
+    actual = set(manifest)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(
+            f"canonical identity manifest keys differ (missing={missing}, extra={extra})"
+        )
+    return {name: decode_canonical(manifest[name]) for name in IDENTITY_COMPONENTS}

--- a/app/services/strategy_experiment_registry.py
+++ b/app/services/strategy_experiment_registry.py
@@ -36,6 +36,8 @@ from app.services.research_canonical_hash import (
     IDENTITY_COMPONENTS,
     canonical_ast_json,
     compute_identity_hashes,
+    compute_identity_hashes_from_ast,
+    decode_manifest,
     derive_experiment_id,
     encode_canonical,
     encode_manifest,
@@ -77,6 +79,10 @@ class CanonicalIdentityCollision(StrategyExperimentRegistryError):
     refuses to replay the stored immutable row under a different identity."""
 
 
+class StoredManifestInvalid(StrategyExperimentRegistryError):
+    """A stored experiment manifest is malformed or disagrees with its hashes."""
+
+
 async def _get_experiment(
     session: AsyncSession, experiment_id: str
 ) -> ResearchStrategyExperiment | None:
@@ -85,6 +91,45 @@ async def _get_experiment(
             ResearchStrategyExperiment.experiment_id == experiment_id
         )
     )
+
+
+async def get_experiment_identity_components(
+    session: AsyncSession,
+    experiment_id: str,
+) -> dict[str, object]:
+    """Fetch, integrity-check, and decode one persisted identity manifest.
+
+    The registry persists the already-encoded closed typed AST. Supersession
+    callers need raw components for policy checks, so this read boundary first
+    proves all 11 AST hashes still match their immutable columns and only then
+    decodes the exact manifest.
+    """
+    stored = await _get_experiment(session, experiment_id)
+    if stored is None:
+        raise ExperimentNotFound(f"experiment_id {experiment_id!r} is not registered")
+    if type(stored.manifest) is not dict:
+        raise StoredManifestInvalid(
+            f"experiment_id {experiment_id!r} has no canonical identity manifest"
+        )
+
+    ast_hashes = compute_identity_hashes_from_ast(stored.manifest)
+    mismatches = [
+        column
+        for column, actual in ast_hashes.items()
+        if getattr(stored, column) != actual
+    ]
+    if mismatches:
+        raise StoredManifestInvalid(
+            f"experiment_id {experiment_id!r} stored manifest disagrees with "
+            f"immutable component hash column(s): {', '.join(mismatches)}"
+        )
+    try:
+        return decode_manifest(stored.manifest)
+    except (TypeError, ValueError) as exc:
+        raise StoredManifestInvalid(
+            f"experiment_id {experiment_id!r} has an invalid canonical identity "
+            f"manifest: {exc}"
+        ) from exc
 
 
 def _assert_same_identity(

--- a/research/alpaca_track_seal/identity.py
+++ b/research/alpaca_track_seal/identity.py
@@ -7,16 +7,11 @@ app-side registration CLI (``registry_cli.py``) is the only place that
 constructs the real Pydantic identity, using this module's output as pure
 input.
 
-Design note on the ``code`` component (open question, see H2 completion
-report): H3 (the actual DATS state-machine / WCM-B ranking signal engine,
-ROB-1061) does not exist yet — there is no real implementation source to
-hash. ``default_formula_provenance`` seals the FORMULA SPECIFICATION text
-verbatim from the Run A preregistration (SS11.3 / SS12.2-12.3) as the ``code``
-identity for now. This is deliberately NOT a stand-in for H3's eventual
-implementation hash — once H3 merges, registering with its real source text
-derives a DIFFERENT ``code_hash`` and therefore a different experiment_id,
-which must be registered as a NEW experiment superseding this one (same
-strategy_key, ROB-846 lineage), never an in-place edit.
+The H2 builders remain immutable: ``default_formula_provenance`` still seals
+the Run A formula specification as the original ``code`` identity. ROB-1069
+adds a separate byte-derived H3 implementation component. Registration copies
+the H2 identity, replaces only ``code``, and creates a new experiment linked by
+``supersedes_experiment_id``; the H2 record is never edited in place.
 
 Pure stdlib + ``canonical_hash``/``research_contracts``. No app/DB/network
 import.
@@ -26,12 +21,13 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import configs as cfg
 import params as prm
 
-from research_contracts.canonical_hash import IDENTITY_COMPONENTS
+from research_contracts.canonical_hash import IDENTITY_COMPONENTS, canonical_sha256
 
 __all__ = [
     "SourceMismatchError",
@@ -39,6 +35,7 @@ __all__ = [
     "SupersessionSealedComponentDivergenceError",
     "assert_supersession_preserves_sealed_components",
     "build_components_for_config",
+    "build_h3_implementation_code_component",
     "default_formula_provenance",
     "validate_same_family_components_are_identical",
 ]
@@ -74,6 +71,34 @@ _AP_A2_FORMULA_SPEC = (
     "restoration of existing holdings' weight (rank buffer suppresses "
     "turnover)."
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_H3_SOURCE_COMMIT = "5c09c2e7a"
+_H3_SOURCE_BUNDLE_SCHEMA = "alpaca_track_h3_source_bundle.v1"
+_H3_COMMON_SOURCE_PATHS = (
+    "research/alpaca_track_signals/decision_calendar.py",
+    "research/alpaca_track_signals/indicators.py",
+    "research/alpaca_track_signals/output_schema.py",
+    "research/alpaca_track_signals/reason_codes.py",
+    "research/alpaca_track_signals/seal_consumption.py",
+    "research/alpaca_track_signals/sizing.py",
+)
+_H3_SOURCE_PATHS_BY_FAMILY = {
+    "AP-A1": (
+        "research/alpaca_track_signals/dats_engine.py",
+        "research/alpaca_track_signals/dats_state.py",
+        *_H3_COMMON_SOURCE_PATHS,
+    ),
+    "AP-A2": (
+        *_H3_COMMON_SOURCE_PATHS,
+        "research/alpaca_track_signals/wcmb_engine.py",
+        "research/alpaca_track_signals/wcmb_ranking.py",
+    ),
+}
+_H3_EXPECTED_SOURCE_SHA256 = {
+    "AP-A1": "321e532fc9c70d40451caf37a2e2e84b5c76ad0f3cdf93d8fd77813580079c68",
+    "AP-A2": "c233333e988d41d7aa90ef2ff31b4ff97b7d61be427367f4f02b780acc44cc65",
+}
 
 
 class SourceMismatchError(ValueError):
@@ -136,6 +161,82 @@ def _build_code_component(source: StrategySourceProvenance) -> dict[str, Any]:
     return {
         "kind": "formula_specification_not_implementation",
         "source_sha256": source.verified_source_sha256(),
+    }
+
+
+def build_h3_implementation_code_component(
+    family: str,
+    *,
+    source_files: tuple[tuple[str, Path], ...] | None = None,
+) -> dict[str, Any]:
+    """Build a byte-derived H3 implementation provenance component.
+
+    Each strategy family binds its two family-specific engine modules plus the
+    six shared H3 signal modules.  The bundle hashes an ordered inventory of
+    normalized repo-relative logical paths and each file's raw SHA-256 through
+    the ROB-846 canonical authority.  The expected digest is pinned to merged
+    H3 commit ``5c09c2e7a`` so a later source edit cannot be mislabeled as that
+    implementation.
+    """
+    try:
+        expected_sha256 = _H3_EXPECTED_SOURCE_SHA256[family]
+        logical_paths = _H3_SOURCE_PATHS_BY_FAMILY[family]
+    except KeyError as exc:
+        raise ValueError(f"unknown family {family!r}") from exc
+
+    resolved = source_files
+    if resolved is None:
+        resolved = tuple((logical, _REPO_ROOT / logical) for logical in logical_paths)
+    if not resolved:
+        raise SourceMismatchError(f"{family}: H3 source bundle is empty")
+
+    rows: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for logical_path, path in resolved:
+        logical = PurePosixPath(logical_path)
+        if (
+            not logical_path
+            or logical.is_absolute()
+            or ".." in logical.parts
+            or str(logical) != logical_path
+            or logical_path in seen
+        ):
+            raise SourceMismatchError(
+                f"{family}: invalid or duplicate H3 logical source path {logical_path!r}"
+            )
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:
+            raise SourceMismatchError(
+                f"{family}: cannot read H3 source {logical_path!r}"
+            ) from exc
+        if not path.is_file():
+            raise SourceMismatchError(
+                f"{family}: H3 source is not a regular file: {logical_path!r}"
+            )
+        rows.append(
+            {
+                "logical_path": logical_path,
+                "raw_sha256": hashlib.sha256(raw).hexdigest(),
+            }
+        )
+        seen.add(logical_path)
+
+    source_sha256 = canonical_sha256(
+        {"schema_version": _H3_SOURCE_BUNDLE_SCHEMA, "files": rows}
+    )
+    if source_sha256 != expected_sha256:
+        raise SourceMismatchError(
+            f"{family}: H3 source bundle SHA-256 mismatch (expected "
+            f"{expected_sha256}, actual {source_sha256}) — checked-out source "
+            f"does not match merged H3 commit {_H3_SOURCE_COMMIT}"
+        )
+    return {
+        "kind": "real_implementation",
+        "source_commit": _H3_SOURCE_COMMIT,
+        "source_bundle_schema": _H3_SOURCE_BUNDLE_SCHEMA,
+        "source_sha256": source_sha256,
+        "files": rows,
     }
 
 
@@ -316,36 +417,12 @@ def assert_supersession_preserves_sealed_components(
     membership, or cost assumptions under that cover -- exactly the post-hoc
     relaxation this seal exists to prevent.
 
-    ROB-1060 H2-lock adversarial-verification Finding 5 (2026-07-26,
-    DETERMINATION -- genuinely blocked, NOT wired): this function is pure
-    and DB-agnostic by design (plain ``dict`` in, plain ``dict`` out), and
-    ``registry_cli.build_registration_plan()`` already proves the
-    "pure sibling-component comparison, zero DB" pattern works
-    (``validate_same_family_components_are_identical`` runs purely over the
-    in-process per-config components list). But THIS package's own
-    ``_cmd_register`` never declares a supersession at all -- it registers
-    16 fresh identities with no ``supersedes_experiment_id`` -- so there is
-    no in-process "parent" for this specific registration to compare
-    against. Once a REAL supersession exists (H3's real-implementation
-    ``code`` superseding one of these 16 rows), the parent's components live
-    only as a persisted row in ``research.strategy_experiments``
-    (``app.models.research_backtest.ResearchStrategyExperiment``): the table
-    stores an AST-ENCODED ``manifest`` (via
-    ``research_canonical_hash.encode_manifest``), not the raw components
-    this function compares with plain ``==``, and the app-side registry
-    (``app.services.strategy_experiment_registry.register_experiment``)
-    fetches that row via ``_get_experiment`` -- an ``app.*``/DB read. Wiring
-    this guard into a genuine supersession therefore requires either an
-    ``app.*`` DB fetch (out of scope for this pure package and forbidden by
-    the ROB-1060 remediation constraints) or a new AST-vs-AST comparison
-    path that does not exist today. Recorded here as a HARD PREREQUISITE for
-    H3: before H3 registers a superseding experiment, it (or a follow-up
-    ROB-846 registry read helper) must fetch and reconstruct the parent H2
-    identity's components -- from the DB row, or from re-running THIS
-    package's own ``build_components_for_config`` if the parent is exactly
-    this H2 seal (deterministic and reproducible) -- before calling this
-    guard. Left UNWIRED in ``registry_cli.py`` until that prerequisite is
-    met; see the matching note in ``registry_cli._cmd_register``."""
+    ROB-1069 closes ROB-1060 Finding 5 by wiring this pure authority into
+    ``registry_cli._register_supersession_plan``. The app-side registry helper
+    fetches the parent through ``_get_experiment``, verifies all 11 persisted
+    AST hashes, decodes the closed typed manifest, and supplies the reconstructed
+    raw components here before ``register_experiment`` is allowed to run.
+    """
     for name in IDENTITY_COMPONENTS:
         if name == "code":
             continue

--- a/research/alpaca_track_seal/registry_cli.py
+++ b/research/alpaca_track_seal/registry_cli.py
@@ -18,7 +18,9 @@ Mirrors ``research/nautilus_scalping/run_rob944_campaign.py``'s ``--plan`` /
        (``app.services.research_db_write_guard``) must positively authorize
        the resolved (host, database) target — never "not production", never
        a bare database-name check;
-    4. only then: register all 16 configs via
+    4. only then: fetch each H2 parent's stored typed-AST manifest, decode and
+       integrity-check it, assert every sealed component except ``code`` is
+       preserved, and register all 16 H3-code supersessions via
        ``app.services.strategy_experiment_registry.register_experiment``
        (idempotent by canonical identity — re-running ``register`` is safe).
 
@@ -37,6 +39,7 @@ No broker mutation, no scheduler/TaskIQ registration anywhere in this file.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import os
 import sys
@@ -44,6 +47,11 @@ from typing import Any
 
 import artifact as art
 import identity as ident
+
+from research_contracts.canonical_hash import (
+    compute_identity_hashes,
+    derive_experiment_id,
+)
 
 __all__ = [
     "PlanComponentDivergenceError",
@@ -97,8 +105,14 @@ class PlanComponentDivergenceError(RuntimeError):
 
 
 def build_registration_plan() -> dict[str, Any]:
-    """The full, PURE registration plan: semantic hash + per-config identity
-    components, ready to feed an app-side ``StrategyExperimentIdentity``.
+    """Build the pure H3-code supersession plan for all 16 H2 identities.
+
+    The pinned H2 artifact is reconstructed and verified first.  Its exact
+    canonical identity derives each immutable parent experiment ID.  A child
+    copy then replaces only ``code`` with the byte-derived H3 implementation
+    component and is checked by the same preservation authority used later
+    against the parent's stored DB manifest.
+
     Never touches DB/network — safe to call from ``plan`` or from tests.
 
     Fails closed (``SemanticHashDriftError``) if the freshly-built artifact's
@@ -161,10 +175,38 @@ def build_registration_plan() -> dict[str, Any]:
             "digest check"
         )
 
+    h3_code_by_family = {
+        family: ident.build_h3_implementation_code_component(family)
+        for family in ("AP-A1", "AP-A2")
+    }
+    supersession_specs = []
+    for spec in specs:
+        parent_components = spec["components"]
+        child_components = copy.deepcopy(parent_components)
+        child_components["code"] = copy.deepcopy(h3_code_by_family[spec["family"]])
+        ident.assert_supersession_preserves_sealed_components(
+            child_components=child_components,
+            parent_components=parent_components,
+        )
+        parent_experiment_id = derive_experiment_id(
+            spec["strategy_key"],
+            spec["strategy_version"],
+            compute_identity_hashes(parent_components),
+        )
+        supersession_specs.append(
+            {
+                **spec,
+                "supersedes_experiment_id": parent_experiment_id,
+                "components": child_components,
+            }
+        )
+
     return {
         "semantic_hash": semantic_hash,
         "config_count": len(sealed.configs),
-        "specs": specs,
+        "plan_kind": "h3_real_implementation_supersession",
+        "h3_source_commit": "5c09c2e7a",
+        "specs": supersession_specs,
     }
 
 
@@ -175,34 +217,27 @@ def _cmd_plan(_args: argparse.Namespace) -> int:
 
 
 class SupersessionGuardUnwiredError(RuntimeError):
-    """``_cmd_register`` was about to register a superseding experiment
-    (``supersedes_experiment_id`` is not ``None``) without first wiring
-    ``identity.assert_supersession_preserves_sealed_components`` (ROB-1060
-    H2-lock adversarial-verification NEW-2, 2026-07-26).
+    """A supersession was requested without both comparable component sets.
 
-    Finding 5 (below, and in ``identity.assert_supersession_preserves_
-    sealed_components``'s own docstring) DETERMINED, correctly, that wiring
-    that guard is blocked on an ``app.*``/DB read this pure H2 package is not
-    allowed to add -- and left it documented-but-unwired via a code comment.
-    A code comment is not fail-closed: a developer who later adds
-    ``supersedes_experiment_id=...`` here (wiring a real H3 supersession)
-    without ALSO wiring the component-preservation guard would get a silent
-    pass, exactly the post-hoc relaxation this whole seal exists to prevent.
-    This guard converts "documented-but-unwired" into "fail-closed-unwired":
-    it does not (and cannot, per the Finding-5 determination) perform the
-    comparison itself, but it refuses to proceed at all until that
-    prerequisite is met."""
+    ROB-1069 wires the guard for the H3 path. This error remains the fail-closed
+    boundary for any future call site that supplies a parent ID without also
+    fetching and decoding that parent's stored manifest.
+    """
 
 
 def _assert_supersession_guard_wired_before_use(
     supersedes_experiment_id: str | None,
+    *,
+    child_components: dict[str, Any] | None = None,
+    parent_components: dict[str, Any] | None = None,
 ) -> None:
-    """Fail closed if a future edit ever sets ``supersedes_experiment_id`` to
-    non-``None`` in ``_cmd_register`` -- see ``SupersessionGuardUnwiredError``
-    and the Finding-5 note below for the full rationale. No-op (returns
-    silently) for this H2 seal's actual behavior today: every registered
-    identity is a fresh registration with no parent."""
-    if supersedes_experiment_id is not None:
+    """Call the preservation authority, or fail closed when inputs are unwired.
+
+    ``None`` remains a no-op for legitimate fresh-registration consumers.
+    """
+    if supersedes_experiment_id is None:
+        return
+    if child_components is None or parent_components is None:
         raise SupersessionGuardUnwiredError(
             f"supersedes_experiment_id={supersedes_experiment_id!r} was about "
             "to be registered, but "
@@ -214,29 +249,52 @@ def _assert_supersession_guard_wired_before_use(
             "own docstring); refusing to register a superseding experiment "
             "without it"
         )
+    ident.assert_supersession_preserves_sealed_components(
+        child_components=child_components,
+        parent_components=parent_components,
+    )
+
+
+async def _register_supersession_plan(
+    *,
+    session: Any,
+    plan: dict[str, Any],
+    registry: Any,
+    identity_type: Any,
+) -> list[dict[str, str]]:
+    """Execute the guarded per-spec portion of ``_cmd_register``.
+
+    Dependencies stay injected so this exact production subpath can be tested
+    against both in-memory no-write ports and the disposable integration DB.
+    """
+    registered = []
+    for spec in plan["specs"]:
+        supersedes_experiment_id = spec["supersedes_experiment_id"]
+        parent_components = await registry.get_experiment_identity_components(
+            session, supersedes_experiment_id
+        )
+        _assert_supersession_guard_wired_before_use(
+            supersedes_experiment_id,
+            child_components=spec["components"],
+            parent_components=parent_components,
+        )
+        identity = identity_type(
+            strategy_key=spec["strategy_key"],
+            strategy_version=spec["strategy_version"],
+            hypothesis=(
+                f"ROB-1069 H3 implementation supersession: {spec['config_id']}"
+            ),
+            supersedes_experiment_id=supersedes_experiment_id,
+            **spec["components"],
+        )
+        row = await registry.register_experiment(session, identity)
+        registered.append(
+            {"config_id": spec["config_id"], "experiment_id": row.experiment_id}
+        )
+    return registered
 
 
 def _cmd_register(args: argparse.Namespace) -> int:
-    # ROB-1060 H2-lock adversarial-verification Finding 5 (2026-07-26,
-    # DETERMINATION -- genuinely blocked, left UNWIRED): every identity built
-    # below has `supersedes_experiment_id` unset -- this command registers
-    # 16 FRESH identities, never a supersession, so
-    # `identity.assert_supersession_preserves_sealed_components` has no
-    # in-process parent to compare against here. Wiring it for a REAL future
-    # supersession (H3's real-implementation `code` superseding one of these
-    # rows) would require fetching the parent's stored `manifest` from
-    # `research.strategy_experiments` (an `app.*`/DB read) and reconstructing
-    # comparable raw components from its AST encoding -- both out of scope
-    # for this pure H2 package under the ROB-1060 remediation constraints.
-    # See `identity.assert_supersession_preserves_sealed_components`'s
-    # docstring for the full determination; this is a recorded HARD
-    # PREREQUISITE for H3, not an oversight. `_assert_supersession_guard_
-    # wired_before_use` below (NEW-2) makes that prerequisite fail-closed
-    # rather than merely documented: a future edit that sets
-    # `supersedes_experiment_id` to non-`None` without also wiring the
-    # component-preservation guard raises `SupersessionGuardUnwiredError`
-    # instead of silently registering.
-    #
     # Deliberate two-stage deferred import (stricter than a single deferred
     # block): `app.services.research_db_write_guard` imports nothing but the
     # stdlib itself, so importing ONLY it first is safe even with no .env
@@ -285,27 +343,12 @@ def _cmd_register(args: argparse.Namespace) -> int:
                 print(f"registration refused: {exc}", file=sys.stderr)
                 return 3
 
-            registered = []
-            for spec in plan["specs"]:
-                # ROB-1060 H2-lock NEW-2: this H2 seal never supersedes an
-                # existing experiment -- see the Finding-5 note above. The
-                # explicit `None` here is the ONLY value this call site may
-                # pass without also wiring the component-preservation guard;
-                # `_assert_supersession_guard_wired_before_use` fails closed
-                # if that ever changes.
-                supersedes_experiment_id: str | None = None
-                _assert_supersession_guard_wired_before_use(supersedes_experiment_id)
-                identity = StrategyExperimentIdentity(
-                    strategy_key=spec["strategy_key"],
-                    strategy_version=spec["strategy_version"],
-                    hypothesis=f"ROB-1060 H2 seal: {spec['config_id']}",
-                    supersedes_experiment_id=supersedes_experiment_id,
-                    **spec["components"],
-                )
-                row = await registry.register_experiment(session, identity)
-                registered.append(
-                    {"config_id": spec["config_id"], "experiment_id": row.experiment_id}
-                )
+            registered = await _register_supersession_plan(
+                session=session,
+                plan=plan,
+                registry=registry,
+                identity_type=StrategyExperimentIdentity,
+            )
             await session.commit()
             print(json.dumps({"registered": registered}, indent=2, sort_keys=True))
             return 0

--- a/research/alpaca_track_seal/tests/test_identity.py
+++ b/research/alpaca_track_seal/tests/test_identity.py
@@ -213,6 +213,38 @@ def test_code_component_kind_is_pinned_as_formula_specification_not_implementati
     )
 
 
+@pytest.mark.parametrize(
+    ("family", "expected_sha256"),
+    [
+        ("AP-A1", "321e532fc9c70d40451caf37a2e2e84b5c76ad0f3cdf93d8fd77813580079c68"),
+        ("AP-A2", "c233333e988d41d7aa90ef2ff31b4ff97b7d61be427367f4f02b780acc44cc65"),
+    ],
+)
+def test_h3_real_implementation_code_hashes_exact_merged_source_bytes(
+    family, expected_sha256
+):
+    import identity as m
+
+    code = m.build_h3_implementation_code_component(family)
+    assert code["kind"] == "real_implementation"
+    assert code["source_commit"] == "5c09c2e7a"
+    assert code["source_sha256"] == expected_sha256
+    assert code["source_bundle_schema"] == "alpaca_track_h3_source_bundle.v1"
+    assert code["files"]
+
+
+def test_h3_real_implementation_source_hash_rejects_a_changed_source_file(tmp_path):
+    import identity as m
+
+    source = tmp_path / "dats_engine.py"
+    source.write_text("changed implementation\n")
+    with pytest.raises(m.SourceMismatchError, match="source bundle SHA-256 mismatch"):
+        m.build_h3_implementation_code_component(
+            "AP-A1",
+            source_files=(("research/alpaca_track_signals/dats_engine.py", source),),
+        )
+
+
 # --------------------------------------------------------------------------- #
 # ROB-1060 H2-lock item 3/4: literal content assertions.                      #
 # `assert components[name] is not None` cannot fail for a dict -- emptying    #

--- a/research/alpaca_track_seal/tests/test_registry_cli_plan_component_divergence_gate.py
+++ b/research/alpaca_track_seal/tests/test_registry_cli_plan_component_divergence_gate.py
@@ -45,6 +45,10 @@ def test_build_registration_plan_succeeds_when_undrifted_new1_baseline():
     assert len(plan["semantic_hash"]) == 64
     assert plan["config_count"] == 16
     assert len(plan["specs"]) == 16
+    assert plan["plan_kind"] == "h3_real_implementation_supersession"
+    for spec in plan["specs"]:
+        assert spec["supersedes_experiment_id"]
+        assert spec["components"]["code"]["kind"] == "real_implementation"
 
 
 def test_build_registration_plan_fails_closed_when_a_fresh_recomputation_diverges(
@@ -110,3 +114,22 @@ def test_supersession_guard_wired_before_use_fails_closed_on_any_non_none_value(
         m.SupersessionGuardUnwiredError, match="has not been wired into _cmd_register"
     ):
         m._assert_supersession_guard_wired_before_use("some-parent-experiment-id")
+
+
+def test_supersession_guard_calls_the_component_preservation_authority(monkeypatch):
+    import registry_cli as m
+
+    calls = []
+
+    def spy(*, child_components, parent_components):
+        calls.append((child_components, parent_components))
+
+    monkeypatch.setattr(m.ident, "assert_supersession_preserves_sealed_components", spy)
+    child = {"code": {"kind": "real_implementation"}}
+    parent = {"code": {"kind": "formula_specification_not_implementation"}}
+    m._assert_supersession_guard_wired_before_use(
+        "parent-id",
+        child_components=child,
+        parent_components=parent,
+    )
+    assert calls == [(child, parent)]

--- a/research/alpaca_track_seal/tests/test_registry_cli_supersession_wiring.py
+++ b/research/alpaca_track_seal/tests/test_registry_cli_supersession_wiring.py
@@ -1,0 +1,143 @@
+"""ROB-1069 — executable proof of the register-path supersession wiring."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+import types
+
+
+def test_cmd_register_fetches_parent_calls_guard_then_registers(
+    monkeypatch,
+    capsys,
+):
+    """Exercise the real ``_cmd_register`` loop without a DB or any write.
+
+    Deferred app modules are replaced with in-memory ports.  The emitted proof
+    lines come from a spy around the actual preservation authority and occur
+    only after the fake stored-parent fetch, immediately before the fake
+    ``register_experiment`` call.
+    """
+    import artifact as art
+    import identity as ident
+    import registry_cli as cli
+
+    import app.core
+    import app.schemas
+    import app.services
+    from research_contracts.canonical_hash import (
+        compute_identity_hashes,
+        derive_experiment_id,
+    )
+
+    sealed = art.build_sealed_artifact()
+    parent_by_id = {}
+    for config in sealed.configs:
+        components = ident.build_components_for_config(config, sealed.params)
+        parent_id = derive_experiment_id(
+            components["strategy"]["strategy_key"],
+            components["strategy"]["strategy_version"],
+            compute_identity_hashes(components),
+        )
+        parent_by_id[parent_id] = components
+
+    events = []
+    pending_parent = {"id": None}
+    real_guard = ident.assert_supersession_preserves_sealed_components
+
+    def guard_spy(*, child_components, parent_components):
+        parent_id = pending_parent["id"]
+        if parent_id is not None:
+            print(f"ROB-1069_GUARD_CALLED parent={parent_id}")
+            events.append(("guard", parent_id))
+            pending_parent["id"] = None
+        real_guard(
+            child_components=child_components,
+            parent_components=parent_components,
+        )
+
+    monkeypatch.setattr(
+        cli.ident, "assert_supersession_preserves_sealed_components", guard_spy
+    )
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def commit(self):
+            events.append(("commit", None))
+
+    class FakeIdentity:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeRow:
+        def __init__(self, experiment_id):
+            self.experiment_id = experiment_id
+
+    fake_registry = types.ModuleType("app.services.strategy_experiment_registry")
+
+    async def get_experiment_identity_components(_session, experiment_id):
+        events.append(("fetch", experiment_id))
+        pending_parent["id"] = experiment_id
+        return copy.deepcopy(parent_by_id[experiment_id])
+
+    async def register_experiment(_session, identity):
+        parent_id = identity.kwargs["supersedes_experiment_id"]
+        events.append(("register", parent_id))
+        return FakeRow(f"child-{parent_id}")
+
+    fake_registry.get_experiment_identity_components = (
+        get_experiment_identity_components
+    )
+    fake_registry.register_experiment = register_experiment
+
+    fake_db = types.ModuleType("app.core.db")
+    fake_db.AsyncSessionLocal = FakeSession
+    fake_schema = types.ModuleType("app.schemas.research_backtest")
+    fake_schema.StrategyExperimentIdentity = FakeIdentity
+    fake_write_guard = types.ModuleType("app.services.research_db_write_guard")
+    fake_write_guard.research_write_opt_in_enabled = lambda _value: True
+    fake_write_guard.resolve_research_db_target = lambda _session: object()
+    fake_write_guard.default_research_db_policy = object
+    fake_write_guard.assert_research_write_authorized = lambda **_kwargs: None
+
+    monkeypatch.setitem(sys.modules, "app.core.db", fake_db)
+    monkeypatch.setitem(sys.modules, "app.schemas.research_backtest", fake_schema)
+    monkeypatch.setitem(
+        sys.modules, "app.services.strategy_experiment_registry", fake_registry
+    )
+    monkeypatch.setitem(
+        sys.modules, "app.services.research_db_write_guard", fake_write_guard
+    )
+    monkeypatch.setattr(app.core, "db", fake_db, raising=False)
+    monkeypatch.setattr(app.schemas, "research_backtest", fake_schema, raising=False)
+    monkeypatch.setattr(
+        app.services, "strategy_experiment_registry", fake_registry, raising=False
+    )
+    monkeypatch.setattr(
+        app.services, "research_db_write_guard", fake_write_guard, raising=False
+    )
+    monkeypatch.setenv(cli.ENV_WRITE_OPT_IN, "true")
+
+    assert cli._cmd_register(argparse.Namespace(confirm=True)) == 0
+
+    proof = capsys.readouterr().out
+    assert proof.count("ROB-1069_GUARD_CALLED parent=") == 16
+    path_events = [event for event in events if event[0] != "commit"]
+    assert len(path_events) == 48
+    for offset in range(0, len(path_events), 3):
+        fetch, guard, register = path_events[offset : offset + 3]
+        assert fetch[0] == "fetch"
+        assert guard == ("guard", fetch[1])
+        assert register == ("register", fetch[1])
+    assert events[-1] == ("commit", None)
+    with capsys.disabled():
+        print(
+            "ROB-1069_GUARD_CALL_PROOF "
+            "count=16 order=fetch_parent_ast->guard->register_experiment"
+        )

--- a/tests/services/research/test_alpaca_track_seal_registration.py
+++ b/tests/services/research/test_alpaca_track_seal_registration.py
@@ -24,6 +24,7 @@ real subprocess invocations.
 
 from __future__ import annotations
 
+import copy
 import sys
 import uuid
 from pathlib import Path
@@ -43,6 +44,10 @@ for _p in (str(_SEAL_PKG), str(_NAUTILUS_SCALPING), str(_REPO_ROOT)):
 
 from app.schemas.research_backtest import StrategyExperimentIdentity  # noqa: E402
 from app.services import strategy_experiment_registry as reg  # noqa: E402
+from app.services.research_canonical_hash import (  # noqa: E402
+    compute_identity_hashes,
+    derive_experiment_id,
+)
 
 
 @pytest_asyncio.fixture
@@ -67,6 +72,30 @@ def _unique_plan():
     for spec in plan["specs"]:
         spec["strategy_version"] = f"{spec['strategy_version']}-{suffix}"
     return plan
+
+
+def _unique_supersession_pair():
+    """One exact H2 parent plus its H3-code-only child, namespaced per test."""
+    import artifact as art
+    import registry_cli as cli
+
+    plan = cli.build_registration_plan()
+    spec = copy.deepcopy(plan["specs"][0])
+    config_id = spec["config_id"]
+    parent_components = copy.deepcopy(
+        art.build_sealed_artifact().to_dict()["identity_components"][config_id]
+    )
+    suffix = uuid.uuid4().hex[:8]
+    version = f"{spec['strategy_version']}-{suffix}"
+    spec["strategy_version"] = version
+    spec["components"]["strategy"]["strategy_version"] = version
+    parent_components["strategy"]["strategy_version"] = version
+    spec["supersedes_experiment_id"] = derive_experiment_id(
+        spec["strategy_key"],
+        version,
+        compute_identity_hashes(parent_components),
+    )
+    return {"specs": [spec]}, parent_components
 
 
 @pytest.mark.integration
@@ -143,3 +172,116 @@ async def test_ap_a1_config_cannot_supersede_an_ap_a2_experiment(
     )
     with pytest.raises(reg.SupersedesStrategyMismatch):
         await reg.register_experiment(session, a2_identity)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_h3_code_only_supersession_path_calls_guard_and_creates_new_row(
+    registry_tables,
+    monkeypatch,
+) -> None:
+    import registry_cli as cli
+
+    session = registry_tables
+    plan, parent_components = _unique_supersession_pair()
+    spec = plan["specs"][0]
+    parent_identity = StrategyExperimentIdentity(
+        strategy_key=spec["strategy_key"],
+        strategy_version=spec["strategy_version"],
+        hypothesis=f"ROB-1060 H2 seal: {spec['config_id']}",
+        **parent_components,
+    )
+    parent = await reg.register_experiment(session, parent_identity)
+    await session.flush()
+    assert parent.experiment_id == spec["supersedes_experiment_id"]
+
+    guard_calls = []
+    real_guard = cli.ident.assert_supersession_preserves_sealed_components
+
+    def guard_spy(*, child_components, parent_components):
+        guard_calls.append((child_components, parent_components))
+        real_guard(
+            child_components=child_components,
+            parent_components=parent_components,
+        )
+
+    monkeypatch.setattr(
+        cli.ident, "assert_supersession_preserves_sealed_components", guard_spy
+    )
+    registered = await cli._register_supersession_plan(
+        session=session,
+        plan=plan,
+        registry=reg,
+        identity_type=StrategyExperimentIdentity,
+    )
+    await session.flush()
+
+    child = await reg._get_experiment(session, registered[0]["experiment_id"])
+    assert child is not None
+    assert child.supersedes_experiment_id == parent.experiment_id
+    assert child.experiment_id != parent.experiment_id
+    assert len(guard_calls) == 1
+    assert child.code_hash != parent.code_hash
+    for name in (
+        "strategy",
+        "params",
+        "dataset_manifest",
+        "universe",
+        "pit",
+        "frozen_config",
+        "policy",
+        "benchmark",
+        "cost",
+        "mdd",
+    ):
+        assert getattr(child, f"{name}_hash") == getattr(parent, f"{name}_hash")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_supersession_path_rejects_changed_sealed_component_before_register(
+    registry_tables,
+    monkeypatch,
+) -> None:
+    import identity as identity_module
+    import registry_cli as cli
+
+    session = registry_tables
+    plan, parent_components = _unique_supersession_pair()
+    spec = plan["specs"][0]
+    parent = await reg.register_experiment(
+        session,
+        StrategyExperimentIdentity(
+            strategy_key=spec["strategy_key"],
+            strategy_version=spec["strategy_version"],
+            hypothesis=f"ROB-1060 H2 seal: {spec['config_id']}",
+            **parent_components,
+        ),
+    )
+    await session.flush()
+    assert parent.experiment_id == spec["supersedes_experiment_id"]
+    spec["components"]["cost"] = {
+        **spec["components"]["cost"],
+        "primary": "C50",
+    }
+
+    register_calls = 0
+    real_register = reg.register_experiment
+
+    async def register_spy(session, identity):
+        nonlocal register_calls
+        register_calls += 1
+        return await real_register(session, identity)
+
+    monkeypatch.setattr(reg, "register_experiment", register_spy)
+    with pytest.raises(
+        identity_module.SupersessionSealedComponentDivergenceError,
+        match="cost",
+    ):
+        await cli._register_supersession_plan(
+            session=session,
+            plan=plan,
+            registry=reg,
+            identity_type=StrategyExperimentIdentity,
+        )
+    assert register_calls == 0

--- a/tests/services/research/test_research_canonical_hash.py
+++ b/tests/services/research/test_research_canonical_hash.py
@@ -20,6 +20,8 @@ from app.services.research_canonical_hash import (
     canonical_sha256,
     compute_identity_hashes,
     compute_identity_hashes_from_ast,
+    decode_canonical,
+    decode_manifest,
     derive_experiment_id,
     encode_canonical,
     encode_manifest,
@@ -238,6 +240,28 @@ def test_ast_manifest_rehashes_to_same_component_hashes() -> None:
     roundtripped = json.loads(json.dumps(manifest))
     ast_hashes = compute_identity_hashes_from_ast(roundtripped)
     assert ast_hashes == raw_hashes
+
+
+def test_closed_typed_ast_decodes_back_to_raw_components() -> None:
+    components = _identity_components()
+    manifest = json.loads(json.dumps(encode_manifest(components)))
+    decoded = decode_manifest(manifest)
+    assert decoded == components
+    assert encode_manifest(decoded) == manifest
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        ["unknown", None],
+        ["dict", [["duplicate", ["int", 1]], ["duplicate", ["int", 2]]]],
+        ["float", "nan"],
+        ["int", True],
+    ],
+)
+def test_decode_canonical_rejects_noncanonical_or_malformed_ast(malformed) -> None:
+    with pytest.raises(ValueError):
+        decode_canonical(malformed)
 
 
 def test_hash_canonical_ast_does_not_re_encode() -> None:

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -15,6 +15,7 @@ import asyncio
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -299,6 +300,50 @@ async def test_correction_creates_new_lineage_without_changing_old_hashes(
         )
     ).one()
     assert tuple(persisted) == base_hashes
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_experiment_identity_components_decodes_stored_ast(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    identity = _identity()
+    row = await reg.register_experiment(session, identity)
+    await session.flush()
+
+    components = await reg.get_experiment_identity_components(
+        session, row.experiment_id
+    )
+
+    assert components == identity.components()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_experiment_identity_components_rejects_manifest_hash_mismatch(
+    registry_tables,
+    monkeypatch,
+) -> None:
+    session = registry_tables
+    identity = _identity()
+    row = await reg.register_experiment(session, identity)
+    await session.flush()
+    tampered = SimpleNamespace(
+        manifest={**row.manifest, "cost": ["str", "tampered"]},
+        **{
+            f"{name}_hash": getattr(row, f"{name}_hash")
+            for name in reg.IDENTITY_COMPONENTS
+        },
+    )
+
+    async def get_tampered(_session, _experiment_id):
+        return tampered
+
+    monkeypatch.setattr(reg, "_get_experiment", get_tampered)
+
+    with pytest.raises(reg.StoredManifestInvalid, match="cost_hash"):
+        await reg.get_experiment_identity_components(session, row.experiment_id)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- replace only the H2 `code` identity component with pinned H3 implementation source bundles for AP-A1/AP-A2
- decode and integrity-check the persisted parent typed-AST manifest before applying `assert_supersession_preserves_sealed_components`
- wire the guard into `_cmd_register -> build_registration_plan -> _register_supersession_plan -> register_experiment`
- preserve the default-off environment and explicit confirmation gates; this change does not execute registration

## H3 source bundles

- AP-A1: `321e532fc9c70d40451caf37a2e2e84b5c76ad0f3cdf93d8fd77813580079c68`
- AP-A2: `c233333e988d41d7aa90ef2ff31b4ff97b7d61be427367f4f02b780acc44cc65`
- source commit: `5c09c2e7a`
- derivation: raw SHA-256 per ordered repo-relative source file, then ROB-846 canonical SHA-256 over the schema/versioned ordered file inventory

## Verification

- `make lint`
- `make test`: 18334 passed, 15 skipped, 7 deselected
- research alpaca-track suites: 269 passed
- actual command-path proof: `ROB-1069_GUARD_CALL_PROOF count=16 order=fetch_parent_ast->guard->register_experiment`
- positive and mutated sealed-component rejection integration cases: 2 passed

No deployment, production DB write, broker mutation, scheduler activation, or actual experiment registration was performed.