### PR TITLE
fix(ROB-1019): stop roundtrip closes from reviving completed mock fills

### DIFF
--- a/app/services/kis_mock_lifecycle_service.py
+++ b/app/services/kis_mock_lifecycle_service.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.review import KISMockOrderLedger
@@ -24,9 +24,12 @@ from app.schemas.execution_contracts import (
     OrderLifecycleState,
 )
 
-# These are the lifecycle states the reconciler reads from. anything
-# else is excluded from `list_open_orders`.
+# These are the lifecycle states the reconciler may read from. A ``fill`` with
+# durable full-fill evidence is excluded separately in ``list_open_orders``:
+# current holdings can later fall after an opposite-side close, so they cannot
+# safely re-prove or invalidate that completed leg (ROB-1019).
 OPEN_LIFECYCLE_STATES: frozenset[str] = frozenset({"accepted", "pending", "fill"})
+_CONCLUDED_FILL_REASON_CODES: frozenset[str] = frozenset({"fill_detected"})
 
 
 class LedgerNotFoundError(Exception):
@@ -50,8 +53,20 @@ class KISMockLifecycleService:
     ) -> list[KISMockOrderLedger]:
         if limit < 1:
             raise ValueError("limit must be >= 1")
+        fill_reason = KISMockOrderLedger.last_reconcile_detail["reason_code"].astext
         stmt = select(KISMockOrderLedger).where(
-            KISMockOrderLedger.lifecycle_state.in_(OPEN_LIFECYCLE_STATES)
+            or_(
+                KISMockOrderLedger.lifecycle_state.in_(
+                    OPEN_LIFECYCLE_STATES - {"fill"}
+                ),
+                and_(
+                    KISMockOrderLedger.lifecycle_state == "fill",
+                    or_(
+                        fill_reason.is_(None),
+                        fill_reason.notin_(_CONCLUDED_FILL_REASON_CODES),
+                    ),
+                ),
+            )
         )
         if symbol:
             stmt = stmt.where(KISMockOrderLedger.symbol == symbol)

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
 
@@ -51,6 +52,69 @@ def _fake_kis_client_seq(*, side_effect):
     client = MagicMock()
     client.fetch_my_stocks = AsyncMock(side_effect=side_effect)
     return client
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_close_does_not_retransition_concluded_buy_fill(
+    db_session,
+):
+    """ROB-1019 production shape: a later sell-to-zero must not revive the buy."""
+    symbol = f"RT-{uuid4().hex}"
+    common = {
+        "instrument_type": "equity_kr",
+        "order_type": "limit",
+        "quantity": Decimal("1"),
+        "price": Decimal("70000"),
+        "amount": Decimal("70000"),
+        "currency": "KRW",
+        "account_mode": "kis_mock",
+        "broker": "kis",
+        "status": "accepted",
+    }
+    concluded_buy = KISMockOrderLedger(
+        **common,
+        trade_date=datetime.now(UTC) - timedelta(minutes=2),
+        symbol=symbol,
+        side="buy",
+        order_no=f"MOCK-{uuid4()}",
+        lifecycle_state="fill",
+        holdings_baseline_qty=Decimal("0"),
+        last_reconcile_detail={
+            "reason_code": "fill_detected",
+            "observed_holdings_qty": "1",
+            "observed_delta": "1",
+            "attributed_fill_qty": "1",
+        },
+    )
+    closing_sell = KISMockOrderLedger(
+        **common,
+        trade_date=datetime.now(UTC) - timedelta(minutes=1),
+        symbol=symbol,
+        side="sell",
+        order_no=f"MOCK-{uuid4()}",
+        lifecycle_state="accepted",
+        holdings_baseline_qty=Decimal("1"),
+    )
+    db_session.add_all([concluded_buy, closing_sell])
+    await db_session.commit()
+
+    result = await run_kis_mock_reconciliation(
+        db_session,
+        dry_run=True,
+        market="equity_kr",
+        symbol=symbol,
+        kis_client=_fake_kis_client(kr=[], us=[]),
+    )
+
+    assert result["orders_processed"] == 1
+    assert [event["detail"]["ledger_id"] for event in result["events"]] == [
+        closing_sell.id
+    ]
+    assert result["events"][0]["detail"]["reason_code"] == "fill_detected"
+    assert result["events"][0]["detail"]["observed_holdings_qty"] == "0"
+    assert concluded_buy.id not in {
+        transition["ledger_id"] for transition in result["transitions"]
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_kis_mock_lifecycle_service.py
+++ b/tests/services/test_kis_mock_lifecycle_service.py
@@ -167,6 +167,62 @@ async def test_list_open_orders_returns_only_inflight_and_fill(
     assert terminal.id not in ids
 
 
+@pytest.mark.asyncio
+async def test_list_open_orders_excludes_concluded_full_fill_but_keeps_partial_and_legacy(
+    db_session: AsyncSession,
+):
+    """ROB-1019: a proven full fill must not be rejudged from later holdings.
+
+    Partial fills still need another pass, and legacy fill rows without durable
+    reconcile evidence retain the previous fail-closed behavior.
+    """
+    symbol = f"TEST-{uuid4().hex}"
+
+    def _fill_row(*, reason_code: str | None) -> KISMockOrderLedger:
+        detail = None
+        if reason_code is not None:
+            detail = {
+                "reason_code": reason_code,
+                "observed_holdings_qty": "10",
+                "attributed_fill_qty": (
+                    "10" if reason_code == "fill_detected" else "4"
+                ),
+            }
+        return KISMockOrderLedger(
+            trade_date=datetime(2026, 7, 28, 9, 0, tzinfo=UTC),
+            symbol=symbol,
+            instrument_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            quantity=Decimal("10"),
+            price=Decimal("70000"),
+            amount=Decimal("700000"),
+            currency="KRW",
+            order_no=f"MOCK-{uuid4()}",
+            account_mode="kis_mock",
+            broker="kis",
+            status="accepted",
+            lifecycle_state="fill",
+            holdings_baseline_qty=Decimal("0"),
+            last_reconcile_detail=detail,
+        )
+
+    concluded = _fill_row(reason_code="fill_detected")
+    partial = _fill_row(reason_code="partial_fill_detected")
+    legacy = _fill_row(reason_code=None)
+    db_session.add_all([concluded, partial, legacy])
+    await db_session.commit()
+
+    rows = await KISMockLifecycleService(db_session).list_open_orders(
+        limit=50, symbol=symbol
+    )
+    ids = {row.id for row in rows}
+
+    assert concluded.id not in ids
+    assert partial.id in ids
+    assert legacy.id in ids
+
+
 def test_service_does_not_call_broker_or_live_paths():
     """Service must remain record-keeping only. No broker / live imports."""
     src = SERVICE_PATH.read_text()


### PR DESCRIPTION
## Summary
- Exclude KIS mock `fill` rows with durable `fill_detected` evidence from reconciliation candidates.
- Keep partial fills (`partial_fill_detected`) and legacy `fill` rows without durable detail eligible for later reconciliation.
- Add a DB-backed roundtrip regression proving a later sell-to-zero is processed without retransitioning the concluded buy.

## Root cause
The holdings reconciler groups candidates by `(symbol, side)` and compares the current absolute holding against each order baseline. `fill` was intentionally included in the open candidate set so partial fills could advance. After a later opposite-side close, however, the completed buy saw zero current holdings, received no attributed buy budget, and `_proposal_for` emitted `anomaly / holdings_mismatch`.

The event-driven mock execution consumer, the periodic TaskIQ task, and the MCP manual run all share `run_kis_mock_reconciliation`, so they all reached the same candidate query.

## Fix rationale
Pairing the two legs is not reliable for the affected production rows: F and ISRG entry/exit legs have different `correlation_id` values and blank `scalping_role`. Falling back to symbol, opposite side, quantity, and time order would be ambiguous in the presence of concurrent or manual positions. A prior `fill_detected` result is durable per-leg proof that the full order was already observed, so later absolute holdings must not invalidate it.

This change is scoped to `KISMockLifecycleService.list_open_orders`. KIS live reconciliation uses the separate `KISLiveOrderLedger` and order-id-keyed broker fill evidence; no live path or shared pure delta kernel was changed.

## Read-only production verification
- Opened an explicit transaction with `SET TRANSACTION READ ONLY`; `transaction_read_only` reported `on`.
- Confirmed the affected F ledger 61/62 and ISRG ledger 77/78 roundtrips and their per-leg correlation mismatch.
- Ran the updated candidate query against those real rows: completed F/ISRG buys were excluded.
- The 2026-07-28 `005930` auto-execute event existed, but no matching `kis_mock_order_ledger` row had arrived at verification time, so it was not yet usable as a fresh roundtrip fixture.
- No production writes, broker mutations, orders, or deployments were performed.

## Tests
- `96 passed`: focused lifecycle, holdings classifier, job/scope, MCP, acceptance, and retrospective-pending suites.
- `make lint`: passed, including Ruff and ty.
- `make test`: `18,327 passed, 15 skipped, 7 deselected`, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved open-order detection by excluding concluded full fills while retaining partial and legacy fill records.
  * Prevented concluded buy orders from being transitioned again during sell-to-zero reconciliation.
* **Tests**
  * Added coverage for concluded, partial, and legacy fill handling.
  * Added regression coverage for reconciliation behavior involving already-concluded orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->