### PR TITLE
fix(ROB-1111): kiwoom get_order_status(kt00009)에 필수 mrkt_tp 추가

### DIFF
--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -66,6 +66,7 @@ TOKEN_REFRESH_LEEWAY_SECONDS = 30  # refresh slightly before expires_dt
 ACCOUNT_BALANCE_QRY_TP_DEFAULT = "1"  # kt00018 조회구분
 ACCOUNT_DEPOSIT_QRY_TP_DEFAULT = "2"  # ROB-891 — kt00001 일반조회 (orderable cash)
 ACCOUNT_ORDER_STK_BOND_TP_DEFAULT = "0"  # kt00009 주식채권구분(전체)
+ACCOUNT_ORDER_MRKT_TP_DEFAULT = "0"  # ROB-1111 — kt00009 시장구분(전체)
 
 # ROB-460 — Kiwoom REST account-cash reads also require dmst_stex_tp (국내거래소구분).
 # 2026-06-09 live: get_positions(kt00018)·get_orderable_cash returned return_code 2

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -131,9 +131,13 @@ class KiwoomDomesticAccountClient:
             api_id=constants.ACCOUNT_ORDER_STATUS_API_ID,
             path=ACCOUNT_PATH,
             # ROB-418 — kt00009 requires stk_bond_tp; omitting it returns
-            # return_code 2 (필수입력 파라미터=stk_bond_tp). Convention-default,
-            # smoke-confirmed.
-            body={"stk_bond_tp": constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT},
+            # return_code 2 (필수입력 파라미터=stk_bond_tp).
+            # ROB-1111 — kt00009 ALSO requires mrkt_tp; omitting it returns
+            # return_code 2 (필수입력 파라미터=mrkt_tp).
+            body={
+                "stk_bond_tp": constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,
+                "mrkt_tp": constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT,
+            },
             cont_yn=cont_yn,
             next_key=next_key,
         )

--- a/scripts/kiwoom_mock_smoke.py
+++ b/scripts/kiwoom_mock_smoke.py
@@ -137,6 +137,7 @@ _TRUSTED_CONTRACT_OUTPUT_KEYS: frozenset[str] = frozenset(
         "trde_tp",
         "uv",
         "stk_bond_tp",
+        "mrkt_tp",
     }
 )
 
@@ -684,7 +685,7 @@ _CONTRACT_STEPS_SPEC: list[dict[str, Any]] = [
         "evidence_kind": "order_history",
         "tool_args": {},
         "contract_fields": {
-            "request_body": {"stk_bond_tp": "0"},
+            "request_body": {"stk_bond_tp": "0", "mrkt_tp": "0"},
             "response_array": "acnt_ord_cntr_prst_array",
         },
     },

--- a/tests/scripts/test_kiwoom_mock_smoke_contract.py
+++ b/tests/scripts/test_kiwoom_mock_smoke_contract.py
@@ -227,6 +227,7 @@ async def test_request_body_captured_via_mocktransport(
     }
     assert captured[kw_constants.ACCOUNT_ORDER_STATUS_API_ID] == {
         "stk_bond_tp": kw_constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,
+        "mrkt_tp": kw_constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT,
     }
 
 

--- a/tests/test_kiwoom_constants.py
+++ b/tests/test_kiwoom_constants.py
@@ -34,6 +34,12 @@ def test_account_api_ids():
     assert k.ACCOUNT_BALANCE_API_ID == "kt00018"
 
 
+def test_kt00009_order_status_defaults():
+    # ROB-418 & ROB-1111 — kt00009 required parameters: stk_bond_tp and mrkt_tp
+    assert k.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT == "0"
+    assert k.ACCOUNT_ORDER_MRKT_TP_DEFAULT == "0"
+
+
 def test_kt00001_deposit_qry_tp_is_general_query_two():
     # ROB-891 — Official kt00001 (예수금상세현황) body is exactly {"qry_tp": "2"}.
     # "2" is 일반조회, used for current orderable cash. Must NOT reuse

--- a/tests/test_kiwoom_domestic_account.py
+++ b/tests/test_kiwoom_domestic_account.py
@@ -165,7 +165,7 @@ async def test_get_balance_uses_kt00018_with_qry_tp_and_dmst_stex_tp():
 
 
 @pytest.mark.asyncio
-async def test_get_order_status_uses_kt00009_with_stk_bond_tp_and_continuation():
+async def test_get_order_status_uses_kt00009_with_required_params_and_continuation():
     fake = FakeClient()
     acct = KiwoomDomesticAccountClient(fake)
     await acct.get_order_status(cont_yn="Y", next_key="page-2")
@@ -173,10 +173,10 @@ async def test_get_order_status_uses_kt00009_with_stk_bond_tp_and_continuation()
     assert call["api_id"] == constants.ACCOUNT_ORDER_STATUS_API_ID
     # ROB-418 — kt00009 requires stk_bond_tp (operator return_code 2 without it).
     assert call["body"]["stk_bond_tp"] == constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT
+    # ROB-1111 — kt00009 ALSO requires mrkt_tp (operator return_code 2 without it).
+    assert call["body"]["mrkt_tp"] == constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT
     # ROB-460 boundary — kt00009 is an order-history read (different tool,
-    # get_order_history), already recovered by ROB-418, and NOT proven to need
-    # dmst_stex_tp. Do not speculatively add it to a working endpoint; scope is
-    # operator-smoke-validated (see kiwoom-mock-smoke runbook).
+    # get_order_history), and NOT proven to need dmst_stex_tp.
     assert "dmst_stex_tp" not in call["body"]
     assert call["cont_yn"] == "Y"
     assert call["next_key"] == "page-2"


### PR DESCRIPTION
## Summary
ROB-1111: Kiwoom domestic account order status query (`kt00009` TR) missing required parameter `mrkt_tp`.

## Changes
- `app/services/brokers/kiwoom/constants.py`: Added `ACCOUNT_ORDER_MRKT_TP_DEFAULT = "0"` (시장구분: 전체).
- `app/services/brokers/kiwoom/domestic_account.py`: Updated `get_order_status` to pass both required parameters `stk_bond_tp` and `mrkt_tp` in request body.
- `scripts/kiwoom_mock_smoke.py`: Updated contract sweep expectations to include `mrkt_tp`.
- Unit tests added and updated in `tests/test_kiwoom_constants.py`, `tests/test_kiwoom_domestic_account.py`, and `tests/scripts/test_kiwoom_mock_smoke_contract.py`.

## Verification
- `make test-unit` passed (934 tests passed).