### PR TITLE
fix(ROB-1103): repair watch source report links

### DIFF
--- a/alembic/versions/20260728_rob1103_watch_source_links.py
+++ b/alembic/versions/20260728_rob1103_watch_source_links.py
@@ -1,0 +1,99 @@
+"""ROB-1103 make direct-watch source links honest and protect real links.
+
+Revision ID: 20260728_rob1103_watch_links
+Revises: 20260727_alpaca_paper_lab
+Create Date: 2026-07-28 12:00:00.000000
+
+Direct watches do not own an investment report/item. ROB-768 filled the
+non-null source columns with deterministic UUIDv5 placeholders, which looked
+like report links but could never match the UUIDv4 report table. Make those
+links nullable for direct watches and add NOT VALID foreign keys to the alert
+projection. NOT VALID preserves the legacy UUIDv5 rows and the ROB-413 smoke
+orphan while enforcing referential integrity for every new non-null link.
+
+Legacy formula (kept here for audit, not reused):
+namespace ``7d85169b-7e5d-4d53-87eb-1bb7ba8ecf60`` with names
+``report:<idempotency_key>`` and ``item:<idempotency_key>``.
+
+Event rows deliberately keep nullable, non-FK audit links: their immutable
+snapshot must survive deletion of the alert/report/item.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260728_rob1103_watch_links"
+down_revision: str | Sequence[str] | None = "20260727_alpaca_paper_lab"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SCHEMA = "review"
+_ALERTS = "investment_watch_alerts"
+_EVENTS = "investment_watch_events"
+_REPORT_FK = "fk_investment_watch_alerts_source_report_uuid"
+_ITEM_FK = "fk_investment_watch_alerts_source_item_uuid"
+
+
+def upgrade() -> None:
+    for table in (_ALERTS, _EVENTS):
+        op.alter_column(
+            table,
+            "source_report_uuid",
+            existing_type=sa.Uuid(),
+            nullable=True,
+            schema=_SCHEMA,
+        )
+        op.alter_column(
+            table,
+            "source_item_uuid",
+            existing_type=sa.Uuid(),
+            nullable=True,
+            schema=_SCHEMA,
+        )
+
+    op.execute(
+        f"""
+        ALTER TABLE {_SCHEMA}.{_ALERTS}
+        ADD CONSTRAINT {_REPORT_FK}
+        FOREIGN KEY (source_report_uuid)
+        REFERENCES {_SCHEMA}.investment_reports (report_uuid)
+        ON DELETE SET NULL
+        NOT VALID
+        """
+    )
+    op.execute(
+        f"""
+        ALTER TABLE {_SCHEMA}.{_ALERTS}
+        ADD CONSTRAINT {_ITEM_FK}
+        FOREIGN KEY (source_item_uuid)
+        REFERENCES {_SCHEMA}.investment_report_items (item_uuid)
+        ON DELETE SET NULL
+        NOT VALID
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_ITEM_FK, _ALERTS, schema=_SCHEMA, type_="foreignkey")
+    op.drop_constraint(_REPORT_FK, _ALERTS, schema=_SCHEMA, type_="foreignkey")
+
+    for table in (_EVENTS, _ALERTS):
+        op.alter_column(
+            table,
+            "source_item_uuid",
+            existing_type=sa.Uuid(),
+            nullable=False,
+            schema=_SCHEMA,
+        )
+        op.alter_column(
+            table,
+            "source_report_uuid",
+            existing_type=sa.Uuid(),
+            nullable=False,
+            schema=_SCHEMA,
+        )

--- a/alembic/versions/20260728_rob1103_watch_source_links.py
+++ b/alembic/versions/20260728_rob1103_watch_source_links.py
@@ -39,6 +39,46 @@ _REPORT_FK = "fk_investment_watch_alerts_source_report_uuid"
 _ITEM_FK = "fk_investment_watch_alerts_source_item_uuid"
 
 
+def _add_foreign_key_if_missing(
+    name: str,
+    column: str,
+    referred_table: str,
+    referred_column: str,
+) -> None:
+    """Add a source-link FK unless the current schema already materialized it."""
+
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conrelid = '{_SCHEMA}.{_ALERTS}'::regclass
+                  AND conname = '{name}'
+            ) THEN
+                ALTER TABLE {_SCHEMA}.{_ALERTS}
+                ADD CONSTRAINT {name}
+                FOREIGN KEY ({column})
+                REFERENCES {_SCHEMA}.{referred_table} ({referred_column})
+                ON DELETE SET NULL
+                NOT VALID;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def _drop_foreign_key_if_exists(name: str) -> None:
+    op.execute(
+        f"""
+        ALTER TABLE {_SCHEMA}.{_ALERTS}
+        DROP CONSTRAINT IF EXISTS "{name}"
+        """
+    )
+
+
 def upgrade() -> None:
     for table in (_ALERTS, _EVENTS):
         op.alter_column(
@@ -56,31 +96,23 @@ def upgrade() -> None:
             schema=_SCHEMA,
         )
 
-    op.execute(
-        f"""
-        ALTER TABLE {_SCHEMA}.{_ALERTS}
-        ADD CONSTRAINT {_REPORT_FK}
-        FOREIGN KEY (source_report_uuid)
-        REFERENCES {_SCHEMA}.investment_reports (report_uuid)
-        ON DELETE SET NULL
-        NOT VALID
-        """
+    _add_foreign_key_if_missing(
+        _REPORT_FK,
+        "source_report_uuid",
+        "investment_reports",
+        "report_uuid",
     )
-    op.execute(
-        f"""
-        ALTER TABLE {_SCHEMA}.{_ALERTS}
-        ADD CONSTRAINT {_ITEM_FK}
-        FOREIGN KEY (source_item_uuid)
-        REFERENCES {_SCHEMA}.investment_report_items (item_uuid)
-        ON DELETE SET NULL
-        NOT VALID
-        """
+    _add_foreign_key_if_missing(
+        _ITEM_FK,
+        "source_item_uuid",
+        "investment_report_items",
+        "item_uuid",
     )
 
 
 def downgrade() -> None:
-    op.drop_constraint(_ITEM_FK, _ALERTS, schema=_SCHEMA, type_="foreignkey")
-    op.drop_constraint(_REPORT_FK, _ALERTS, schema=_SCHEMA, type_="foreignkey")
+    _drop_foreign_key_if_exists(_ITEM_FK)
+    _drop_foreign_key_if_exists(_REPORT_FK)
 
     for table in (_EVENTS, _ALERTS):
         op.alter_column(

--- a/app/jobs/investment_watch_scanner.py
+++ b/app/jobs/investment_watch_scanner.py
@@ -323,7 +323,11 @@ class InvestmentWatchScanner:
         # never block the trigger notification itself.
         price_guidance = None
         try:
-            item = await repo.get_item_by_uuid(event.source_item_uuid)
+            item = (
+                await repo.get_item_by_uuid(event.source_item_uuid)
+                if event.source_item_uuid is not None
+                else None
+            )
             price_guidance = price_guidance_from_watch_recommendation(
                 item.watch_recommendation if item is not None else None
             )

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1402,6 +1402,11 @@ Response includes `active_watches[]` with `symbol`, `operator`, `threshold`, `va
 Creates an active row in `review.investment_watch_alerts` without creating an
 investment report or report item.
 
+Because a direct watch has no report/item source, its `source_report_uuid` and
+`source_item_uuid` are `null`. Do not synthesize or look up a report for these
+rows; use the alert's immutable rationale, checklist, max-action, and condition
+snapshot. Report-activated watches continue to carry real source UUIDs.
+
 Parameters:
 - `created_by`: required provenance label. Use `tradingcodex` from the
   `tradingcodex_execution` profile.

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -508,11 +508,23 @@ class InvestmentWatchAlert(Base):
     )
     idempotency_key: Mapped[str] = mapped_column(Text, nullable=False)
 
-    source_report_uuid: Mapped[uuid.UUID] = mapped_column(
-        PG_UUID(as_uuid=True), nullable=False
+    source_report_uuid: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey(
+            "review.investment_reports.report_uuid",
+            name="fk_investment_watch_alerts_source_report_uuid",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
     )
-    source_item_uuid: Mapped[uuid.UUID] = mapped_column(
-        PG_UUID(as_uuid=True), nullable=False
+    source_item_uuid: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey(
+            "review.investment_report_items.item_uuid",
+            name="fk_investment_watch_alerts_source_item_uuid",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
     )
 
     market: Mapped[str] = mapped_column(Text, nullable=False)
@@ -589,10 +601,10 @@ class InvestmentWatchEvent(Base):
     ``action_mode``) so it remains audit-useful after the source alert
     is removed.
 
-    ``source_report_uuid`` / ``source_item_uuid`` are logical audit links
-    (no FK on purpose) — the snapshot fields above are the canonical
-    record. Plan 2's service layer validates source existence/consistency
-    at write time.
+    ``source_report_uuid`` / ``source_item_uuid`` are nullable logical audit
+    links (no FK on purpose) — direct watches have no report/item, and event
+    snapshots must survive deletion of a linked report. The snapshot fields
+    above are the canonical record.
     """
 
     __tablename__ = "investment_watch_events"
@@ -667,12 +679,8 @@ class InvestmentWatchEvent(Base):
     alert_id: Mapped[int | None] = mapped_column(
         ForeignKey("review.investment_watch_alerts.id", ondelete="SET NULL")
     )
-    source_report_uuid: Mapped[uuid.UUID] = mapped_column(
-        PG_UUID(as_uuid=True), nullable=False
-    )
-    source_item_uuid: Mapped[uuid.UUID] = mapped_column(
-        PG_UUID(as_uuid=True), nullable=False
-    )
+    source_report_uuid: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    source_item_uuid: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
 
     # Immutable trigger-identity snapshot copied from the source alert at
     # event creation. Must survive alert deletion.

--- a/app/schemas/invest_watches.py
+++ b/app/schemas/invest_watches.py
@@ -35,7 +35,7 @@ class WatchAlertRow(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     alert_uuid: UUID
-    source_report_uuid: UUID
+    source_report_uuid: UUID | None
     market: Literal["kr", "us", "crypto"]
     symbol: str = Field(min_length=1)
     symbol_name: str | None = None

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -942,8 +942,8 @@ class InvestmentWatchAlertResponse(BaseModel):
     """Single ``investment_watch_alerts`` row."""
 
     alert_uuid: UUID
-    source_report_uuid: UUID
-    source_item_uuid: UUID
+    source_report_uuid: UUID | None
+    source_item_uuid: UUID | None
     market: MarketLiteral
     target_kind: TargetKindLiteral
     symbol: str
@@ -982,8 +982,8 @@ class InvestmentWatchEventResponse(BaseModel):
 
     event_uuid: UUID
     alert_id: int | None
-    source_report_uuid: UUID
-    source_item_uuid: UUID
+    source_report_uuid: UUID | None
+    source_item_uuid: UUID | None
     market: MarketLiteral
     target_kind: TargetKindLiteral
     symbol: str

--- a/app/services/hermes_client.py
+++ b/app/services/hermes_client.py
@@ -55,7 +55,7 @@ class InvestLinks(BaseModel):
     Hermes prepends its configured Invest base URL when rendering.
     """
 
-    report_path: str
+    report_path: str | None
     stock_path: str
     event_anchor: str | None = None
     alert_anchor: str | None = None
@@ -153,7 +153,11 @@ def build_invest_links(
     event_uuid: Any | None = None,
     alert_uuid: Any | None = None,
 ) -> InvestLinks:
-    report_path = f"/invest/reports/{source_report_uuid}"
+    report_path = (
+        f"/invest/reports/{source_report_uuid}"
+        if source_report_uuid is not None
+        else None
+    )
     stock_path = (
         f"/invest/stocks/{quote(str(market).lower(), safe='')}"
         f"/{quote(str(symbol), safe='')}"
@@ -163,12 +167,12 @@ def build_invest_links(
         stock_path=stock_path,
         event_anchor=(
             f"{report_path}#watch-event-{event_uuid}"
-            if event_uuid is not None
+            if report_path is not None and event_uuid is not None
             else None
         ),
         alert_anchor=(
             f"{report_path}#watch-alert-{alert_uuid}"
-            if alert_uuid is not None
+            if report_path is not None and alert_uuid is not None
             else None
         ),
     )
@@ -263,8 +267,8 @@ class ReviewTriggerPayload(BaseModel):
 
     event_uuid: UUID
     alert_uuid: UUID
-    source_report_uuid: UUID
-    source_item_uuid: UUID
+    source_report_uuid: UUID | None
+    source_item_uuid: UUID | None
     correlation_id: str
     kst_date: str
     market: MarketLiteral

--- a/app/services/investment_reports/watch_create.py
+++ b/app/services/investment_reports/watch_create.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from decimal import Decimal
 from typing import Any
 
@@ -13,8 +12,6 @@ from app.models.investment_reports import InvestmentWatchAlert
 from app.schemas.investment_reports import CreateInvestmentWatchRequest
 from app.services.investment_reports.idempotency import direct_watch_key
 from app.services.investment_reports.repository import InvestmentReportsRepository
-
-_DIRECT_WATCH_NAMESPACE = uuid.UUID("7d85169b-7e5d-4d53-87eb-1bb7ba8ecf60")
 
 
 class DirectWatchCreateService:
@@ -87,13 +84,16 @@ def _alert_fields(
         {
             "created_by": request.created_by,
             "source_tool": "investment_watch_create",
+            "source_link": "direct_without_report",
         }
     )
 
     return {
         "idempotency_key": idempotency_key,
-        "source_report_uuid": _source_uuid(idempotency_key, "report"),
-        "source_item_uuid": _source_uuid(idempotency_key, "item"),
+        # Direct watches have no report/item source. UUIDv5 placeholders used
+        # before ROB-1103 looked like valid links but could never resolve.
+        "source_report_uuid": None,
+        "source_item_uuid": None,
         "market": request.market,
         "target_kind": condition.get("target_kind", "asset"),
         "symbol": symbol,
@@ -153,10 +153,6 @@ def _assert_same_identity(
             f"idempotency_key {existing.idempotency_key!r} already used for "
             "a different watch identity"
         )
-
-
-def _source_uuid(idempotency_key: str, slot: str) -> uuid.UUID:
-    return uuid.uuid5(_DIRECT_WATCH_NAMESPACE, f"{slot}:{idempotency_key}")
 
 
 def _to_decimal(value: Any) -> Decimal:

--- a/app/services/investment_reports/watch_validity_review.py
+++ b/app/services/investment_reports/watch_validity_review.py
@@ -127,7 +127,11 @@ class WatchValidityReviewService:
             alerts = await repo.list_active_alerts(market=market, valid_at=now_utc)
             for alert in alerts:
                 stats.alerts_seen += 1
-                item = await repo.get_item_by_uuid(alert.source_item_uuid)
+                item = (
+                    await repo.get_item_by_uuid(alert.source_item_uuid)
+                    if alert.source_item_uuid is not None
+                    else None
+                )
                 stored = item.watch_recommendation if item is not None else None
 
                 current_price = await self._current_price(alert)

--- a/docs/runbooks/watch-alert-claude-triage.md
+++ b/docs/runbooks/watch-alert-claude-triage.md
@@ -116,7 +116,7 @@ echo "$events" | jq -c '.[]' | while read -r ev; do
   # uuid가 seen에 있으면(exit 0) continue; 없으면(exit 1) && 단락→계속 진행 (set -e 미발동)
   grep -qxF "$uuid" "$SEEN" && continue   # 이미 처리
 
-  payload="$(jq -r '"event_uuid=\(.event_uuid) symbol=\(.symbol) market=\(.market) source_report_uuid=\(.source_report_uuid) metric=\(.metric) operator=\(.operator) threshold=\(.threshold) current_value=\(.current_value)"' <<<"$ev")"
+  payload="$(jq -r '"event_uuid=\(.event_uuid) symbol=\(.symbol) market=\(.market) source_report_uuid=\(.source_report_uuid) source_report_link_state=\(.source_report_link_state) metric=\(.metric) operator=\(.operator) threshold=\(.threshold) current_value=\(.current_value)"' <<<"$ev")"
 
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "[dry-run] claude -p \"/crypto-alert-triage $payload\" --permission-mode bypassPermissions --settings $SETTINGS --output-format json"
@@ -158,6 +158,27 @@ chmod +x ~/ops/watch-alert-triage/poller.sh
 - `seen_event_uuids` — 같은 초에 여러 이벤트가 동일 `delivered_at`를 갖는 경우 중복 처리 방지. 최대 500행 유지.
 - `validation.jsonl` — Q3 검증용 메타 로그 (§6 참조).
 - `DRY_RUN=1` — claude/Discord/Telegram 미호출. 안전하게 명령 미리보기.
+
+### Source report link 판정 (ROB-1103)
+
+`list_recent_watch_events.py`의 `source_report_link_state`를 먼저 확인한다.
+
+- `report_lookup_required`: UUIDv4 리포트 기반 watch. `investment_report_get`
+  조회를 수행한다. v4인데 `not_found`면 실제 무결성 이상으로 에스컬레이션한다.
+- `not_applicable_direct_watch`: ROB-1103 이후 직접 생성 watch. 애초에
+  report/item이 없으므로 `source_report_uuid=null`이 정상이다. report 조회를
+  시도하지 말고 이벤트/알림의 `rationale`, `trigger_checklist`, `max_action`,
+  `watch_condition` 스냅샷으로 트리아지한다.
+- `legacy_direct_watch_placeholder`: ROB-768 직접 생성 경로가 남긴 UUIDv5
+  placeholder. 이는 삭제된 리포트가 아니며, 대응 리포트/item은 처음부터
+  존재하지 않았다. UUIDv5를 "유실"로 기록하거나 report 백필 대상으로
+  분류하지 말고 직접 watch 스냅샷으로 트리아지한다.
+
+UUIDv5는 고정 namespace와 저장된 idempotency key로 같은 값을 재계산할 수
+있지만 SHA-1 preimage를 역산할 수 없고, 무엇보다 원본 report/item 행이 생성된
+적이 없다. 따라서 기존 UUIDv5 행의 **리포트 맥락 복원은 불가**하다.
+레거시 공식은 namespace `7d85169b-7e5d-4d53-87eb-1bb7ba8ecf60`, name
+`report:<idempotency_key>` / `item:<idempotency_key>`다.
 
 ---
 
@@ -269,6 +290,7 @@ uv run python -m scripts.list_recent_watch_events --market crypto --limit 5 | jq
       "symbol": "KRW-BTC",
       "market": "crypto",
       "source_report_uuid": "...",
+      "source_report_link_state": "report_lookup_required",
       "metric": "price",
       "operator": "above",
       "threshold": "...",
@@ -312,7 +334,7 @@ DRY_RUN=1 AUTO_TRADER_REPO="$AUTO_TRADER_REPO" \
 예상 결과: 새 이벤트(워터마크 이후)마다 다음 형태의 출력:
 
 ```
-[dry-run] claude -p "/crypto-alert-triage event_uuid=f912d55f-... symbol=KRW-BTC market=crypto source_report_uuid=... metric=price operator=above threshold=1.00000000 current_value=92000000.00000000" --permission-mode bypassPermissions --settings /Users/.../auto_trader/.claude/settings.readonly.json --output-format json
+[dry-run] claude -p "/crypto-alert-triage event_uuid=f912d55f-... symbol=KRW-BTC market=crypto source_report_uuid=... source_report_link_state=report_lookup_required metric=price operator=above threshold=1.00000000 current_value=92000000.00000000" --permission-mode bypassPermissions --settings /Users/.../auto_trader/.claude/settings.readonly.json --output-format json
 ```
 
 2회 실행 시: 동일 uuid가 `seen_event_uuids`에 기록되어 두 번째 실행에서는 출력 없음 (디듀프 동작).

--- a/scripts/list_recent_watch_events.py
+++ b/scripts/list_recent_watch_events.py
@@ -14,9 +14,18 @@ import asyncio
 import json
 import sys
 from datetime import datetime
+from uuid import UUID
 
 from app.core.db import AsyncSessionLocal
 from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+def _source_report_link_state(source_report_uuid: UUID | None) -> str:
+    if source_report_uuid is None:
+        return "not_applicable_direct_watch"
+    if source_report_uuid.version == 5:
+        return "legacy_direct_watch_placeholder"
+    return "report_lookup_required"
 
 
 def _parse_since(value: str | None) -> datetime | None:
@@ -48,6 +57,9 @@ async def collect(
                 "source_report_uuid": str(e.source_report_uuid)
                 if e.source_report_uuid
                 else None,
+                "source_report_link_state": _source_report_link_state(
+                    e.source_report_uuid
+                ),
                 "metric": e.metric,
                 "operator": e.operator,
                 "threshold": str(e.threshold),

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -62,7 +62,8 @@ from sqlalchemy import text
 # v29: immutable approval publication bindings and frozen batch snapshots.
 # v30: persistent-schema typed dispatch/card constraints and attempt nullability.
 # v31: Alpaca paper lab account_mode CHECK expansions.
-SCHEMA_BOOTSTRAP_VERSION = 31
+# v32 (ROB-1103): nullable direct-watch source links + future-write FKs.
+SCHEMA_BOOTSTRAP_VERSION = 32
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -831,6 +832,31 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ADD CONSTRAINT ck_investment_watch_events_outcome "
     "CHECK (outcome IN ('notified','review_required','preview_attached',"
     "'executed','expired','ignored','failed'))",
+    # ---- watch source-link semantics (ROB-1103) ----
+    "ALTER TABLE review.investment_watch_alerts "
+    "ALTER COLUMN source_report_uuid DROP NOT NULL",
+    "ALTER TABLE review.investment_watch_alerts "
+    "ALTER COLUMN source_item_uuid DROP NOT NULL",
+    "ALTER TABLE review.investment_watch_events "
+    "ALTER COLUMN source_report_uuid DROP NOT NULL",
+    "ALTER TABLE review.investment_watch_events "
+    "ALTER COLUMN source_item_uuid DROP NOT NULL",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conrelid = 'review.investment_watch_alerts'::regclass "
+    "AND conname = 'fk_investment_watch_alerts_source_report_uuid') THEN "
+    "ALTER TABLE review.investment_watch_alerts "
+    "ADD CONSTRAINT fk_investment_watch_alerts_source_report_uuid "
+    "FOREIGN KEY (source_report_uuid) "
+    "REFERENCES review.investment_reports (report_uuid) "
+    "ON DELETE SET NULL NOT VALID; END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conrelid = 'review.investment_watch_alerts'::regclass "
+    "AND conname = 'fk_investment_watch_alerts_source_item_uuid') THEN "
+    "ALTER TABLE review.investment_watch_alerts "
+    "ADD CONSTRAINT fk_investment_watch_alerts_source_item_uuid "
+    "FOREIGN KEY (source_item_uuid) "
+    "REFERENCES review.investment_report_items (item_uuid) "
+    "ON DELETE SET NULL NOT VALID; END IF; END $$",
     # ---- trade_journals (ROB-405 / ROB-568) ----
     "ALTER TABLE review.trade_journals ADD COLUMN IF NOT EXISTS correlation_id TEXT",
     "ALTER TABLE review.trade_journals DROP CONSTRAINT IF EXISTS trade_journals_account_type",

--- a/tests/_watch_events_helpers.py
+++ b/tests/_watch_events_helpers.py
@@ -45,10 +45,8 @@ async def mk_watch_event(
         kst_date=kst_date,
         correlation_id=f"corr-{symbol}-{delivery_status}-{delivered_at}",
         idempotency_key=f"event:{symbol}:{kst_date}:{symbol}:price:below:100:{uuid.uuid4()}",
-        source_report_uuid=source_report_uuid
-        if source_report_uuid is not None
-        else uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=source_report_uuid,
+        source_item_uuid=None,
         delivery_status=delivery_status,
         delivered_at=delivered_at if delivery_status == "delivered" else None,
     )

--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -72,8 +72,8 @@ async def test_list_active_watches_impl_returns_rationale_and_filters(
     db_session.add(
         InvestmentWatchAlert(
             idempotency_key=f"rob517:list-active:{uuid.uuid4()}",
-            source_report_uuid=uuid.uuid4(),
-            source_item_uuid=uuid.uuid4(),
+            source_report_uuid=None,
+            source_item_uuid=None,
             market="kr",
             target_kind="asset",
             symbol="005930",
@@ -102,7 +102,7 @@ async def test_list_active_watches_impl_returns_rationale_and_filters(
     ]
     assert len(matching) >= 1
     assert matching[0]["symbol"] == "005930"
-    assert matching[0]["source_item_uuid"]
+    assert matching[0]["source_item_uuid"] is None
 
 
 @pytest.mark.asyncio
@@ -554,8 +554,8 @@ async def test_get_operating_briefing_reads_active_watch_and_session_context(
     db_session.add(
         InvestmentWatchAlert(
             idempotency_key=f"rob517:briefing-active:{uuid.uuid4()}",
-            source_report_uuid=uuid.uuid4(),
-            source_item_uuid=uuid.uuid4(),
+            source_report_uuid=None,
+            source_item_uuid=None,
             market="us",
             target_kind="asset",
             symbol="AAPL",

--- a/tests/scripts/test_list_recent_watch_events_cli.py
+++ b/tests/scripts/test_list_recent_watch_events_cli.py
@@ -1,9 +1,10 @@
 import json
+import uuid
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from scripts.list_recent_watch_events import collect, main
+from scripts.list_recent_watch_events import _source_report_link_state, collect, main
 from tests._watch_events_helpers import mk_watch_event, utc_at
 
 
@@ -24,6 +25,7 @@ async def test_collect_returns_serializable_delivered_events(session: AsyncSessi
         "symbol",
         "market",
         "source_report_uuid",
+        "source_report_link_state",
         "metric",
         "operator",
         "threshold",
@@ -31,6 +33,7 @@ async def test_collect_returns_serializable_delivered_events(session: AsyncSessi
         "delivered_at",
         "kst_date",
     }
+    assert ev["source_report_link_state"] == "not_applicable_direct_watch"
 
 
 def test_main_bad_since_emits_error_json_and_nonzero(capsys):
@@ -40,3 +43,8 @@ def test_main_bad_since_emits_error_json_and_nonzero(capsys):
     payload = json.loads(out)
     assert payload["success"] is False
     assert "error" in payload
+
+
+def test_uuid5_source_is_classified_as_legacy_placeholder() -> None:
+    source_uuid = uuid.uuid5(uuid.NAMESPACE_URL, "legacy-direct-watch")
+    assert _source_report_link_state(source_uuid) == "legacy_direct_watch_placeholder"

--- a/tests/services/invest_view_model/test_watch_panel_service.py
+++ b/tests/services/invest_view_model/test_watch_panel_service.py
@@ -38,8 +38,8 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
     alert1 = InvestmentWatchAlert(
         alert_uuid=uuid.uuid4(),
         idempotency_key="key-1",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="kr",
         target_kind="asset",
         symbol="005930",
@@ -61,8 +61,8 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
     alert2 = InvestmentWatchAlert(
         alert_uuid=uuid.uuid4(),
         idempotency_key="key-2",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="us",
         target_kind="asset",
         # Test-unique ticker: this alert must stay price-less to drive the
@@ -85,8 +85,8 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
     alert3 = InvestmentWatchAlert(
         alert_uuid=uuid.uuid4(),
         idempotency_key="key-3",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="crypto",
         target_kind="asset",
         symbol="BTC",
@@ -196,8 +196,8 @@ async def test_watch_panel_service_us_symbol_normalization(
     alert = InvestmentWatchAlert(
         alert_uuid=uuid.uuid4(),
         idempotency_key="key-brk",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="us",
         target_kind="asset",
         symbol="BRK.B",  # alert table stores the dot form
@@ -239,8 +239,8 @@ async def test_watch_panel_service_skips_unbuildable_row(
         return InvestmentWatchAlert(
             alert_uuid=uuid.uuid4(),
             idempotency_key=idem,
-            source_report_uuid=uuid.uuid4(),
-            source_item_uuid=uuid.uuid4(),
+            source_report_uuid=None,
+            source_item_uuid=None,
             market="us",
             target_kind="asset",
             symbol=symbol,

--- a/tests/services/investment_reports/test_watch_create.py
+++ b/tests/services/investment_reports/test_watch_create.py
@@ -57,7 +57,10 @@ async def test_direct_watch_create_persists_alert_without_report_rows(
     assert alert.max_action == {"side": "buy", "cash_fraction": 0.1}
     assert alert.alert_metadata["created_by"] == "tradingcodex"
     assert alert.alert_metadata["source_tool"] == "investment_watch_create"
+    assert alert.alert_metadata["source_link"] == "direct_without_report"
     assert alert.alert_metadata["ticket_hint"] == "support-reclaim"
+    assert alert.source_report_uuid is None
+    assert alert.source_item_uuid is None
 
     report_count = await session.scalar(
         sa.select(sa.func.count()).select_from(InvestmentReport)

--- a/tests/test_hermes_client.py
+++ b/tests/test_hermes_client.py
@@ -202,6 +202,20 @@ def test_build_invest_links_without_event_uuid_omits_event_anchor() -> None:
     assert links.stock_path == "/invest/stocks/kr/005930"
 
 
+def test_build_invest_links_without_report_omits_report_anchors() -> None:
+    links = build_invest_links(
+        market="us",
+        symbol="NVDA",
+        source_report_uuid=None,
+        event_uuid=_EVENT_UUID,
+        alert_uuid=_ALERT_UUID,
+    )
+    assert links.report_path is None
+    assert links.event_anchor is None
+    assert links.alert_anchor is None
+    assert links.stock_path == "/invest/stocks/us/NVDA"
+
+
 def test_build_invest_links_quotes_symbol() -> None:
     links = build_invest_links(
         market="us", symbol="BRK.B", source_report_uuid=_REPORT_UUID

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -173,7 +173,10 @@ async def test_investment_watch_create_direct_persists_active_alert(
     assert response["alert"]["symbol"] == "005930"
     assert response["alert"]["metadata"]["created_by"] == "tradingcodex"
     assert response["alert"]["metadata"]["source_tool"] == "investment_watch_create"
+    assert response["alert"]["metadata"]["source_link"] == "direct_without_report"
     assert response["alert"]["metadata"]["source"] == "tcx-smoke"
+    assert response["alert"]["source_report_uuid"] is None
+    assert response["alert"]["source_item_uuid"] is None
 
 
 @pytest.mark.asyncio
@@ -545,7 +548,6 @@ async def test_activate_watch_rejects_condition_override(
 async def test_list_active_watches_filters_market_symbol_and_expiry(
     session: AsyncSession,
 ) -> None:
-    import uuid
     from datetime import UTC, datetime, timedelta
 
     from app.core.db import AsyncSessionLocal
@@ -555,8 +557,8 @@ async def test_list_active_watches_filters_market_symbol_and_expiry(
     now = datetime(2026, 6, 11, 3, 0, tzinfo=UTC)
     active_future = InvestmentWatchAlert(
         idempotency_key="rob517:active:005930",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="kr",
         target_kind="asset",
         symbol="005930",
@@ -574,8 +576,8 @@ async def test_list_active_watches_filters_market_symbol_and_expiry(
     )
     active_expired = InvestmentWatchAlert(
         idempotency_key="rob517:expired:005930",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="kr",
         target_kind="asset",
         symbol="005930",
@@ -593,8 +595,8 @@ async def test_list_active_watches_filters_market_symbol_and_expiry(
     )
     inactive = InvestmentWatchAlert(
         idempotency_key="rob517:triggered:005930",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="kr",
         target_kind="asset",
         symbol="005930",

--- a/tests/test_investment_reports_model.py
+++ b/tests/test_investment_reports_model.py
@@ -475,6 +475,16 @@ async def test_alert_target_kind_index_allowed(session: AsyncSession) -> None:
     assert alert.target_kind == "index"
 
 
+@pytest.mark.asyncio
+async def test_alert_rejects_nonexistent_non_null_source_links(
+    session: AsyncSession,
+) -> None:
+    await assert_integrity_error(
+        session,
+        InvestmentWatchAlert(**_base_alert_payload(uuid.uuid4(), uuid.uuid4())),
+    )
+
+
 # ---------------------------------------------------------------------------
 # InvestmentWatchEvent
 # ---------------------------------------------------------------------------

--- a/tests/test_investment_reports_watch_activation.py
+++ b/tests/test_investment_reports_watch_activation.py
@@ -273,8 +273,8 @@ async def test_alert_accepts_between_operator_and_conditions(
     alert = InvestmentWatchAlert(
         alert_uuid=uuid.uuid4(),
         idempotency_key=f"k-{uuid.uuid4()}",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="kr",
         target_kind="asset",
         symbol="005930",

--- a/tests/test_investment_watch_scanner.py
+++ b/tests/test_investment_watch_scanner.py
@@ -20,6 +20,7 @@ from app.jobs import investment_watch_scanner as scanner_module
 from app.jobs.investment_watch_scanner import InvestmentWatchScanner
 from app.schemas.investment_reports import (
     ActivateWatchRequest,
+    CreateInvestmentWatchRequest,
     IngestReportItem,
     IngestReportRequest,
     RecordDecisionRequest,
@@ -35,6 +36,7 @@ from app.services.investment_reports.ingestion import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
+from app.services.investment_reports.watch_create import DirectWatchCreateService
 from tests._investment_reports_helpers import future_datetime
 
 
@@ -220,6 +222,47 @@ async def test_scan_market_triggered_notify_only_emits_event_and_hermes_call(
     assert delivered_at is not None
     assert delivery_attempts == 1
     assert delivery_reason is None
+
+
+@pytest.mark.asyncio
+async def test_scan_direct_watch_uses_null_source_links(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    alert, _ = await DirectWatchCreateService(session).create(
+        CreateInvestmentWatchRequest(
+            created_by="test",
+            market="kr",
+            symbol="005930",
+            intent="trend_recovery_review",
+            rationale="direct watch without a report",
+            watch_condition=WatchConditionPayload(
+                metric="rsi",
+                operator="below",
+                threshold=Decimal("30"),
+            ),
+            valid_until=future_datetime(days=30),
+        )
+    )
+    await session.commit()
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    summary = await InvestmentWatchScanner(hermes_client=stub).scan_market("kr")
+
+    assert summary["triggered"] == 1
+    assert len(stub.calls) == 1
+    payload = stub.calls[0]
+    assert payload.alert_uuid == alert.alert_uuid
+    assert payload.source_report_uuid is None
+    assert payload.source_item_uuid is None
+    assert payload.invest_links is not None
+    assert payload.invest_links.report_path is None
+    assert payload.invest_links.stock_path == "/invest/stocks/kr/005930"
 
 
 @pytest.mark.asyncio

--- a/tests/test_watch_auto_execute.py
+++ b/tests/test_watch_auto_execute.py
@@ -19,8 +19,8 @@ def _alert(max_action: dict | None, action_mode="auto_execute_mock"):
     return InvestmentWatchAlert(
         alert_uuid=uuid.uuid4(),
         idempotency_key=f"k-{uuid.uuid4()}",
-        source_report_uuid=uuid.uuid4(),
-        source_item_uuid=uuid.uuid4(),
+        source_report_uuid=None,
+        source_item_uuid=None,
         market="kr",
         target_kind="asset",
         symbol="005930",


### PR DESCRIPTION
## Summary

- stop generating UUIDv5 placeholders for direct watches; direct watches now store null source report/item links with explicit direct-watch metadata
- allow nullable source links through alert/event schemas and Hermes payloads, while preserving stock links and omitting nonexistent report links
- enforce real non-null alert links for new writes with NOT VALID, ON DELETE SET NULL foreign keys; legacy UUIDv5 rows and the ROB-413 smoke orphan remain untouched
- classify poller events as report_lookup_required, not_applicable_direct_watch, or legacy_direct_watch_placeholder and document the triage behavior

## Production read-only findings

All queries ran inside SET TRANSACTION READ ONLY.

At the ROB-1103 issue timestamp (2026-07-27T14:40:20.275Z):

- alerts: UUIDv4 54 (53 report/item matches, 1 unmatched ROB-413 postmerge smoke)
- alerts: UUIDv5 157 (0 report/item matches)
- reports: UUIDv4 67, no other versions
- all 157 UUIDv5 alert report/item IDs reproduce the ROB-768 formula:
  - namespace 7d85169b-7e5d-4d53-87eb-1bb7ba8ecf60
  - names report:<idempotency_key> and item:<idempotency_key>
- UUIDv5 rows are all investment_watch_create direct watches; UUIDv4 rows are report activation rows apart from the ROB-413 smoke orphan

The UUIDv5 value is reproducible when the stored idempotency key is known, but no source report/item row ever existed, so report context cannot be restored or backfilled.

## FK decision

Alert rows are current projections, so nullable source links can use foreign keys. The constraints are added NOT VALID to preserve existing invalid rows while enforcing every future non-null insert. Event rows remain without source FKs because their immutable audit snapshot must survive alert/report/item deletion.

## Verification

- 162 focused tests passed
- make lint passed (Ruff check, Ruff format check, ty)
- Alembic offline PostgreSQL SQL generation passed
- no production writes, broker mutation, deletion, or deployment

Linear: ROB-1103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct investment watches can now be created without report or item source links.
  * Watch alerts and events preserve optional source references and safely clear links when source records are removed.
  * Notifications and event listings now distinguish direct watches from report-linked watches.

* **Bug Fixes**
  * Improved handling of direct watches during scanning, validation, and notification generation.
  * Prevented missing source references from causing lookup failures.

* **Documentation**
  * Updated watch creation guidance and triage runbooks for direct-watch source-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->