### PR TITLE
fix(r4): recover transient basis gaps

### DIFF
--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -58,6 +58,7 @@ PIT_COLUMNS: Final = (
     "reconnect_id",
 )
 COLLECTOR_VERSION: Final = "r4-p0-collector.v2"
+BASIS_RECOVERY_LIMIT: Final = 100
 EXPECTED_SOURCES: Final = frozenset(
     {
         "binance_usdm.aggTrade",
@@ -77,6 +78,14 @@ SPARSE_SOURCES: Final = frozenset({"binance_usdm.forceOrder"})
 REQUIRED_ACTIVE_SOURCES: Final = EXPECTED_SOURCES - SPARSE_SOURCES
 
 log = logging.getLogger("r4_p0_collector")
+
+
+class MissingBasisDataError(ValueError):
+    """The venue returned no usable basis observation for a requested symbol."""
+
+
+class BasisPollError(RuntimeError):
+    """One or more symbols failed without starving the remaining basis polls."""
 
 
 def utc_now() -> dt.datetime:
@@ -264,6 +273,17 @@ class AppendOnlyPITStore:
             (source, symbol),
         ).fetchone()
         return row is not None
+
+    def first_event_time(self, source: str, symbol: str) -> str | None:
+        row = self._db.execute(
+            """
+            SELECT MIN(event_time) AS event_time
+            FROM pit_records
+            WHERE source = ? AND symbol = ?
+            """,
+            (source, symbol),
+        ).fetchone()
+        return row["event_time"] if row is not None else None
 
     def append(
         self,
@@ -725,14 +745,18 @@ class BinanceR4P0Collector:
                     delay *= random.uniform(0.8, 1.2)
                     failure_attempt += 1
                     log.error(
-                        "collector.poll.failed family=%s error=%s backoff_s=%.2f",
+                        "collector.poll.failed family=%s error=%s detail=%r backoff_s=%.2f",
                         family,
                         type(exc).__name__,
+                        str(exc),
                         delay,
                     )
                     await asyncio.sleep(delay)
 
     async def _poll_family(self, client: httpx.AsyncClient, family: str) -> None:
+        if family == "basis":
+            await self._poll_basis_family(client)
+            return
         for symbol in self.config.symbols:
             if family == "open_interest":
                 await self._rest_get(
@@ -761,19 +785,6 @@ class BinanceR4P0Collector:
                     ),
                 )
                 await self._rest_premium_kline(client, symbol=symbol)
-            elif family == "basis":
-                await self._rest_get(
-                    client,
-                    path="/futures/data/basis",
-                    params={
-                        "pair": symbol,
-                        "contractType": "PERPETUAL",
-                        "period": "5m",
-                        "limit": 1,
-                    },
-                    symbol=symbol,
-                    outputs=(("binance_usdm.basis", None),),
-                )
             elif family == "taker":
                 await self._rest_get(
                     client,
@@ -784,6 +795,93 @@ class BinanceR4P0Collector:
                 )
             else:
                 raise ValueError(f"unknown poll family: {family}")
+
+    async def _poll_basis_family(self, client: httpx.AsyncClient) -> None:
+        failures: list[tuple[str, Exception]] = []
+        for symbol in self.config.symbols:
+            try:
+                await self._rest_basis(client, symbol=symbol)
+            except asyncio.CancelledError:
+                raise
+            except MissingBasisDataError as exc:
+                failures.append((symbol, exc))
+        if failures:
+            detail = "; ".join(
+                f"{symbol}={type(exc).__name__}({exc})" for symbol, exc in failures
+            )
+            raise BasisPollError(f"basis poll incomplete: {detail}")
+
+    async def _rest_basis(self, client: httpx.AsyncClient, *, symbol: str) -> None:
+        path = "/futures/data/basis"
+        assert_rest_target(path)
+        started = utc_now()
+        response = await client.get(
+            path,
+            params={
+                "pair": symbol,
+                "contractType": "PERPETUAL",
+                "period": "5m",
+                # Re-read a bounded 8h20m window so a later successful request
+                # can repair transient holes before epoch finalization.
+                "limit": BASIS_RECOVERY_LIMIT,
+            },
+        )
+        completed = utc_now()
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise ValueError(
+                f"invalid JSON shape from allowlisted path {path} symbol={symbol}"
+            )
+        if not payload:
+            raise MissingBasisDataError(
+                f"no basis observations from allowlisted path {path} symbol={symbol}"
+            )
+
+        rows: list[tuple[int, Mapping[str, Any], str]] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"invalid basis row from allowlisted path {path} symbol={symbol}"
+                )
+            pair = str(item.get("pair") or "").upper()
+            contract_type = str(item.get("contractType") or "").upper()
+            timestamp = item.get("timestamp")
+            event_time = epoch_ms(timestamp)
+            if pair != symbol or contract_type != "PERPETUAL" or event_time is None:
+                raise ValueError(
+                    f"invalid basis identity from allowlisted path {path} "
+                    f"symbol={symbol} pair={pair!r} contractType={contract_type!r} "
+                    f"timestamp={timestamp!r}"
+                )
+            rows.append((int(timestamp), item, event_time))
+
+        collection_floor = self.store.first_event_time("binance_usdm.basis", symbol)
+        if collection_floor is None:
+            # This collector is not the seed-backfill lane. On first sight of a
+            # symbol, retain only the latest venue row and establish the live
+            # collection floor.
+            rows = [max(rows, key=lambda row: row[0])]
+        else:
+            rows = [row for row in rows if row[2] >= collection_floor]
+
+        reconnect_id = f"{self.run_id}:rest:{path}"
+        for timestamp, item, event_time in sorted(rows, key=lambda row: row[0]):
+            inserted = self.store.append(
+                source="binance_usdm.basis",
+                symbol=symbol,
+                raw_payload=item,
+                local_receive_time=completed,
+                run_id=self.run_id,
+                event_time=event_time,
+                transaction_time=None,
+                request_started_at=iso_utc(started),
+                request_completed_at=iso_utc(completed),
+                sequence_or_trade_id=str(timestamp),
+                gap_detected=False,
+                reconnect_id=reconnect_id,
+            )
+            self._count_result("binance_usdm.basis", inserted)
 
     async def _rest_premium_kline(
         self, client: httpx.AsyncClient, *, symbol: str

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -40,6 +40,16 @@ Operational attention follows this order without dropping any P0 source:
 Backfill reach and PIT observation are separate properties. A later REST row
 must not be treated as if it had the `local_receive_time` of the live collector.
 
+The basis endpoint can transiently return HTTP 200 with an empty JSON list.
+That is **missing source data**, not a successful zero-observation state. The
+collector continues polling the other symbols, reports the failed symbol, and
+re-reads a bounded 100-period (8h20m) window on the next attempt. Deduplication
+keeps replays idempotent, while the original collection floor prevents this
+recovery path from acting as seed backfill. Any absence still unresolved at
+epoch finalization is `FINAL_MISSING`; two different canonical payloads for the
+same source identity are `FINAL_CONFLICT`, never last-write-wins
+`FINAL_COMPLETE`.
+
 ## Modes
 
 With no mode flag the command prints its contract and makes no network or disk

--- a/tests/test_binance_r4_p0_collector.py
+++ b/tests/test_binance_r4_p0_collector.py
@@ -8,8 +8,10 @@ import httpx
 import pytest
 
 from app.services.brokers.binance.r4_p0_collector import (
+    BASIS_RECOVERY_LIMIT,
     PIT_COLUMNS,
     AppendOnlyPITStore,
+    BasisPollError,
     BinanceR4P0Collector,
     CollectorConfig,
     assert_rest_target,
@@ -272,3 +274,172 @@ async def test_open_interest_family_keeps_current_and_bounded_history(tmp_path) 
             "2026-07-26T01:00:00.000000Z"
         )
         assert set(PIT_COLUMNS).issubset(samples["binance_usdm.openInterestHist"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_basis_empty_response_is_missing_without_starving_other_symbols(
+    tmp_path,
+) -> None:
+    timestamp = 1785027600000
+    requested: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        symbol = request.url.params["pair"]
+        requested.append(symbol)
+        assert request.url.params["limit"] == str(BASIS_RECOVERY_LIMIT)
+        if symbol == "DOGEUSDT":
+            return httpx.Response(200, json=[])
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "pair": symbol,
+                    "contractType": "PERPETUAL",
+                    "timestamp": timestamp,
+                    "basis": "0.1",
+                }
+            ],
+        )
+
+    symbols = ("XRPUSDT", "DOGEUSDT", "SOLUSDT", "BTCUSDT")
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(artifact_root=tmp_path, symbols=symbols),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with pytest.raises(
+                BasisPollError,
+                match=r"DOGEUSDT=MissingBasisDataError",
+            ):
+                await collector._poll_family(client, "basis")  # noqa: SLF001
+
+        assert requested == list(symbols)
+        rows = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT symbol, event_time
+                FROM pit_records
+                WHERE source = 'binance_usdm.basis'
+                ORDER BY symbol
+                """
+            )
+        )
+        assert [row["symbol"] for row in rows] == [
+            "BTCUSDT",
+            "SOLUSDT",
+            "XRPUSDT",
+        ]
+        assert {row["event_time"] for row in rows} == {"2026-07-26T01:00:00.000000Z"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_basis_replays_recent_rows_to_repair_transient_gap(tmp_path) -> None:
+    initial_timestamp = 1785027000000
+    recovery_timestamps = (
+        1785026700000,
+        initial_timestamp,
+        1785027300000,
+        1785027600000,
+    )
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        timestamps = (initial_timestamp,) if calls == 1 else recovery_timestamps
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "pair": "XRPUSDT",
+                    "contractType": "PERPETUAL",
+                    "timestamp": timestamp,
+                    "basis": str(timestamp),
+                }
+                for timestamp in timestamps
+            ],
+        )
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(artifact_root=tmp_path, symbols=("XRPUSDT",)),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._poll_family(client, "basis")  # noqa: SLF001
+            await collector._poll_family(client, "basis")  # noqa: SLF001
+
+        rows = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT event_time
+                FROM pit_records
+                WHERE source = 'binance_usdm.basis'
+                ORDER BY event_time
+                """
+            )
+        )
+        assert [row["event_time"] for row in rows] == [
+            "2026-07-26T00:50:00.000000Z",
+            "2026-07-26T00:55:00.000000Z",
+            "2026-07-26T01:00:00.000000Z",
+        ]
+        assert collector.session_counts["binance_usdm.basis"] == 3
+        assert collector.duplicate_counts["binance_usdm.basis"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_basis_conflicting_replay_preserves_both_payloads(tmp_path) -> None:
+    timestamp = 1785027600000
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "pair": "XRPUSDT",
+                    "contractType": "PERPETUAL",
+                    "timestamp": timestamp,
+                    "basis": str(calls),
+                }
+            ],
+        )
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(artifact_root=tmp_path, symbols=("XRPUSDT",)),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._poll_family(client, "basis")  # noqa: SLF001
+            await collector._poll_family(client, "basis")  # noqa: SLF001
+
+        rows = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT event_time, raw_payload_sha256
+                FROM pit_records
+                WHERE source = 'binance_usdm.basis'
+                ORDER BY append_id
+                """
+            )
+        )
+        assert len(rows) == 2
+        assert rows[0]["event_time"] == rows[1]["event_time"]
+        assert rows[0]["raw_payload_sha256"] != rows[1]["raw_payload_sha256"]


### PR DESCRIPTION
## Summary
- classify Binance basis HTTP 200 `[]` as explicit missing source data instead of a successful empty observation
- keep polling remaining symbols when one symbol is transiently empty, then raise a visible aggregate failure
- replay a bounded 100-period basis window after the live collection floor so the next successful poll repairs transient 5-minute holes without becoming seed backfill
- retain conflicting canonical payloads for downstream `FINAL_CONFLICT` classification and include exception details in failure logs

## Evidence
The existing logger retained only `ValueError`, but replaying the observed response shape reproduces:

`ValueError: empty/invalid payload from allowlisted path /futures/data/basis`

The live artifact already contains 9/11/19/24 missing 5-minute basis points for XRP/DOGE/SOL/BTC respectively. Historical Binance reads now return those rows, proving they were transient collection holes rather than a normal no-basis state.

## Contract
- unresolved empty response at epoch finalization: `FINAL_MISSING`
- distinct canonical payloads for the same source identity: `FINAL_CONFLICT`
- only present, finite, schema-valid, non-conflicting data may become `FINAL_COMPLETE`

This PR does not change epoch finalization, retry orchestration, redundancy, forceOrder polling, deployment, or scheduler behavior; those remain in ROB-1108's track.

## Tests
- `uv run pytest tests/test_binance_r4_p0_collector.py -q` (10 passed)
- `uv run ruff check app/services/brokers/binance/r4_p0_collector.py tests/test_binance_r4_p0_collector.py`
- `uv run ruff format --check app/services/brokers/binance/r4_p0_collector.py tests/test_binance_r4_p0_collector.py`
- `uv run ty check app/services/brokers/binance/r4_p0_collector.py`
- bounded live public probe: first observation stores one latest row (no implicit seed backfill)
