### PR TITLE
fix(ROB-1110): isolate watch-scan alerts from mid-loop session resets

### DIFF
--- a/app/jobs/investment_watch_scanner.py
+++ b/app/jobs/investment_watch_scanner.py
@@ -21,10 +21,32 @@ Locked semantics:
 * ``investment_watch_events.idempotency_key`` is unique on
   ``event:{alert_uuid}:{kst_date}:{threshold_key}`` — same-day collisions
   trigger the retry path (NOT a silent no-op).
+
+ROB-1110 — per-alert isolation. The scan loop writes to the DB while it
+is still iterating, so a single alert used to be able to take out every
+alert behind it in the same cycle:
+
+* The rows returned by ``list_active_alerts`` are ORM objects owned by
+  the scan session. ``AsyncSession.rollback()`` **always** expires the
+  identity map (unlike ``commit()``, which this app configures with
+  ``expire_on_commit=False``), so after the very first rollback — e.g.
+  the routine same-day ``IntegrityError`` retry path in ``_upsert_event``
+  — the next ``alert.conditions`` read became an implicit lazy refresh
+  and raised ``MissingGreenlet`` under asyncio.
+* A DB error inside one alert's handling left the transaction in an
+  aborted state, so every later alert's ``commit()`` failed too.
+
+The fix is structural rather than a targeted eager-load: every alert row
+is materialized into an immutable ``_AlertSnapshot`` *before* the first
+write, so the loop holds no ORM state at all, and each alert is processed
+inside its own try/rollback boundary. A failure is counted
+(``failed_alerts``) and described in ``details`` — never silently
+swallowed — and the cycle carries on to the remaining alerts.
 """
 
 from __future__ import annotations
 
+import copy
 import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
@@ -74,6 +96,68 @@ _OUTCOME_BY_ACTION_MODE: dict[str, str] = {
 }
 
 
+@dataclass(frozen=True)
+class _AlertSnapshot:
+    """Plain-Python copy of one ``investment_watch_alerts`` row.
+
+    ROB-1110: the scan loop commits and rolls back while iterating, and a
+    rollback expires the whole identity map. Reading any attribute off a
+    live ORM row after that point is an implicit lazy refresh, which
+    raises ``MissingGreenlet`` under asyncio. Materializing every field
+    the scan needs — once, before the first write — removes the
+    lazy-load surface entirely instead of eager-loading one column at a
+    time and hoping no future field is added.
+
+    Attribute names deliberately mirror ``InvestmentWatchAlert`` so this
+    is a drop-in for the collaborators that take an ``alert`` (notably
+    ``maybe_auto_execute``).
+    """
+
+    id: int
+    alert_uuid: Any
+    source_report_uuid: Any
+    source_item_uuid: Any
+    market: str
+    target_kind: str
+    symbol: str
+    metric: str
+    operator: str
+    threshold: Any
+    threshold_key: str
+    threshold_high: Any
+    intent: str
+    action_mode: str
+    combine: str
+    conditions: list[Any]
+    max_action: dict[str, Any]
+    trigger_checklist: list[Any]
+
+    @classmethod
+    def from_row(cls, row: Any) -> _AlertSnapshot:
+        # deepcopy the mutable JSON containers so the snapshot cannot be
+        # aliased to (or invalidated with) the ORM row's attribute state.
+        return cls(
+            id=row.id,
+            alert_uuid=row.alert_uuid,
+            source_report_uuid=row.source_report_uuid,
+            source_item_uuid=row.source_item_uuid,
+            market=row.market,
+            target_kind=row.target_kind,
+            symbol=row.symbol,
+            metric=row.metric,
+            operator=row.operator,
+            threshold=row.threshold,
+            threshold_key=row.threshold_key,
+            threshold_high=row.threshold_high,
+            intent=row.intent,
+            action_mode=row.action_mode,
+            combine=row.combine,
+            conditions=copy.deepcopy(row.conditions or []),
+            max_action=copy.deepcopy(row.max_action or {}),
+            trigger_checklist=copy.deepcopy(row.trigger_checklist or []),
+        )
+
+
 @dataclass
 class _ScanStats:
     alerts_seen: int = 0
@@ -84,6 +168,12 @@ class _ScanStats:
     failed_delivery: int = 0
     skipped_delivery: int = 0
     skipped_closed: int = 0
+    # ROB-1110: alerts whose handling raised and was isolated, and alerts
+    # the cycle never reached. Both are "not evaluated" — kept separate
+    # from the zero-trigger case so a quiet scan can't be mistaken for a
+    # clean one.
+    failed_alerts: int = 0
+    not_evaluated: int = 0
     details: list[dict[str, Any]] = field(default_factory=list)
 
     def summary(self, market: str, *, market_open: bool) -> dict[str, Any]:
@@ -98,6 +188,8 @@ class _ScanStats:
             "failed_delivery": self.failed_delivery,
             "skipped_delivery": self.skipped_delivery,
             "skipped_closed": self.skipped_closed,
+            "failed_alerts": self.failed_alerts,
+            "not_evaluated": self.not_evaluated,
             "details": self.details,
         }
 
@@ -125,117 +217,195 @@ class InvestmentWatchScanner:
         async with self._session_factory() as db:
             repo = InvestmentReportsRepository(db)
             now_utc = datetime.now(UTC)
-            alerts = await repo.list_active_alerts(
+            rows = await repo.list_active_alerts(
                 market=normalized_market, valid_at=now_utc
             )
+            # ROB-1110: detach from the ORM *before* the first write. From
+            # here on the loop touches nothing that a commit/rollback can
+            # invalidate.
+            alerts = [_AlertSnapshot.from_row(row) for row in rows]
+            del rows
             stats.alerts_seen = len(alerts)
 
             if not alerts:
                 return stats.summary(normalized_market, market_open=market_open)
 
-            for alert in alerts:
+            for index, alert in enumerate(alerts):
                 # FX watches keep firing while regular markets are closed.
                 if not market_open and alert.target_kind != "fx":
                     stats.skipped_closed += 1
                     continue
 
                 try:
-                    if alert.conditions:
-                        triggered, current_value = await evaluate_alert_conditions(
-                            target_kind=alert.target_kind,
-                            symbol=alert.symbol,
-                            market=alert.market,
-                            conditions=alert.conditions,
-                            combine=alert.combine,
-                            get_value_fn=get_current_value,
-                        )
-                    else:
-                        current_value = await get_current_value(
-                            target_kind=alert.target_kind,
-                            metric=alert.metric,
-                            symbol=alert.symbol,
-                            market=alert.market,
-                        )
-                        triggered = is_triggered(
-                            current_value, alert.operator, float(alert.threshold)
-                        )
-                except Exception as exc:
-                    logger.warning(
-                        "investment-watch lookup failed: "
-                        "alert_uuid=%s market=%s symbol=%s metric=%s error=%s",
+                    await self._process_alert(
+                        db=db, repo=repo, alert=alert, stats=stats
+                    )
+                except Exception as exc:  # noqa: BLE001 - isolate, don't swallow
+                    # ROB-1110: one alert's failure must not reach the next
+                    # one. Record it loudly, then reset the session so the
+                    # rest of the cycle still has a usable transaction.
+                    stats.failed_alerts += 1
+                    stats.details.append(
+                        {
+                            "alert_uuid": str(alert.alert_uuid),
+                            "symbol": alert.symbol,
+                            "status": "alert_failed",
+                            "error": f"{type(exc).__name__}: {exc}"[:300],
+                        }
+                    )
+                    logger.exception(
+                        "investment-watch alert processing failed — "
+                        "isolated, scan continues: alert_uuid=%s market=%s symbol=%s",
                         alert.alert_uuid,
                         alert.market,
                         alert.symbol,
-                        alert.metric,
-                        exc,
                     )
-                    stats.failed_lookups += 1
-                    continue
-
-                if not triggered:
-                    continue
-
-                # Insert (or look up existing) event row with delivery_status='pending'.
-                emission = await self._upsert_event(
-                    db=db,
-                    repo=repo,
-                    alert=alert,
-                    current_value=current_value,
-                )
-                if emission is None:
-                    # Same-day collision and existing event is already delivered;
-                    # nothing left to do for this loop iteration.
-                    stats.duplicates += 1
-                    continue
-
-                is_first_attempt = emission["is_first_attempt"]
-
-                if is_first_attempt:
-                    stats.triggered += 1
-                    stats.details.append(emission["detail"])
-                    if alert.action_mode == "auto_execute_mock":
-                        payload = emission["payload"]
-                        try:
-                            await maybe_auto_execute(
-                                db,
-                                alert=alert,
-                                correlation_id=payload.correlation_id,
-                                kst_date=payload.kst_date,
-                            )
-                        except Exception:  # noqa: BLE001 - never kill the scan loop
-                            logger.exception(
-                                "auto_execute_mock failed for alert %s",
-                                emission["alert_uuid"],
-                            )
-                else:
-                    # No new event row this iteration — we found an
-                    # existing pending/failed/skipped row from earlier
-                    # in the day and are re-attempting delivery against
-                    # it. Count as a duplicate so the scan summary
-                    # reflects "row reused, not created".
-                    stats.duplicates += 1
-
-                # Attempt Hermes delivery and gate the alert transition on it.
-                delivery = await self._hermes.send_review_trigger(emission["payload"])
-                await self._record_delivery_outcome(
-                    db=db,
-                    repo=repo,
-                    alert_id=emission["alert_id"],
-                    alert_uuid=emission["alert_uuid"],
-                    event_id=emission["event_id"],
-                    event_uuid=emission["event_uuid"],
-                    delivery=delivery,
-                    stats=stats,
-                )
+                    if not await self._reset_session(db):
+                        # The session itself is unusable; every remaining
+                        # alert would fail identically. Stop and report
+                        # exactly how many were never evaluated rather
+                        # than emitting a wall of identical failures.
+                        stats.not_evaluated = len(alerts) - index - 1
+                        stats.details.append(
+                            {
+                                "status": "scan_aborted",
+                                "reason": "session_unusable",
+                                "not_evaluated": stats.not_evaluated,
+                            }
+                        )
+                        break
 
             return stats.summary(normalized_market, market_open=market_open)
+
+    @staticmethod
+    async def _reset_session(db: AsyncSession) -> bool:
+        """Roll the scan session back to a clean state. ROB-1110.
+
+        Returns ``False`` when the rollback itself fails, which means the
+        session can no longer be reused for the remaining alerts.
+        """
+        try:
+            await db.rollback()
+        except Exception:  # noqa: BLE001 - reported by the caller
+            logger.exception(
+                "investment-watch: scan session rollback failed — "
+                "remaining alerts in this market cannot be evaluated"
+            )
+            return False
+        return True
+
+    async def _process_alert(
+        self,
+        *,
+        db: AsyncSession,
+        repo: InvestmentReportsRepository,
+        alert: _AlertSnapshot,
+        stats: _ScanStats,
+    ) -> None:
+        """Evaluate one alert and, if triggered, emit + deliver it.
+
+        Raises on unexpected failure; ``scan_market`` isolates and records
+        it so the remaining alerts still get evaluated (ROB-1110).
+        """
+        try:
+            if alert.conditions:
+                triggered, current_value = await evaluate_alert_conditions(
+                    target_kind=alert.target_kind,
+                    symbol=alert.symbol,
+                    market=alert.market,
+                    conditions=alert.conditions,
+                    combine=alert.combine,
+                    get_value_fn=get_current_value,
+                )
+            else:
+                current_value = await get_current_value(
+                    target_kind=alert.target_kind,
+                    metric=alert.metric,
+                    symbol=alert.symbol,
+                    market=alert.market,
+                )
+                triggered = is_triggered(
+                    current_value, alert.operator, float(alert.threshold)
+                )
+        except Exception as exc:
+            logger.warning(
+                "investment-watch lookup failed: "
+                "alert_uuid=%s market=%s symbol=%s metric=%s error=%s",
+                alert.alert_uuid,
+                alert.market,
+                alert.symbol,
+                alert.metric,
+                exc,
+            )
+            stats.failed_lookups += 1
+            return
+
+        if not triggered:
+            return
+
+        # Insert (or look up existing) event row with delivery_status='pending'.
+        emission = await self._upsert_event(
+            db=db,
+            repo=repo,
+            alert=alert,
+            current_value=current_value,
+        )
+        if emission is None:
+            # Same-day collision and existing event is already delivered;
+            # nothing left to do for this loop iteration.
+            stats.duplicates += 1
+            return
+
+        is_first_attempt = emission["is_first_attempt"]
+
+        if is_first_attempt:
+            stats.triggered += 1
+            stats.details.append(emission["detail"])
+            if alert.action_mode == "auto_execute_mock":
+                payload = emission["payload"]
+                try:
+                    await maybe_auto_execute(
+                        db,
+                        alert=alert,
+                        correlation_id=payload.correlation_id,
+                        kst_date=payload.kst_date,
+                    )
+                except Exception:  # noqa: BLE001 - never kill the scan loop
+                    logger.exception(
+                        "auto_execute_mock failed for alert %s",
+                        emission["alert_uuid"],
+                    )
+                    # ROB-1110: the event row is already committed, but a
+                    # failed statement leaves the transaction aborted — roll
+                    # back so this alert's own delivery bookkeeping (and
+                    # every alert after it) can still commit.
+                    await self._reset_session(db)
+        else:
+            # No new event row this iteration — we found an existing
+            # pending/failed/skipped row from earlier in the day and are
+            # re-attempting delivery against it. Count as a duplicate so
+            # the scan summary reflects "row reused, not created".
+            stats.duplicates += 1
+
+        # Attempt Hermes delivery and gate the alert transition on it.
+        delivery = await self._hermes.send_review_trigger(emission["payload"])
+        await self._record_delivery_outcome(
+            db=db,
+            repo=repo,
+            alert_id=emission["alert_id"],
+            alert_uuid=emission["alert_uuid"],
+            event_id=emission["event_id"],
+            event_uuid=emission["event_uuid"],
+            delivery=delivery,
+            stats=stats,
+        )
 
     async def _upsert_event(
         self,
         *,
         db: AsyncSession,
         repo: InvestmentReportsRepository,
-        alert: Any,
+        alert: _AlertSnapshot,
         current_value: float,
     ) -> dict[str, Any] | None:
         """Insert a fresh event row, or load the existing one for retry.
@@ -243,11 +413,12 @@ class InvestmentWatchScanner:
         Returns ``None`` if a same-day event already exists and was
         already delivered (nothing to do). Otherwise returns the event
         row + payload + ``is_first_attempt`` flag.
+
+        ``alert`` is an :class:`_AlertSnapshot`, i.e. already detached
+        plain data — the ``db.rollback()`` on the same-day collision path
+        below expires the ORM identity map, so nothing read here may be a
+        live ORM attribute (ROB-1110).
         """
-        # Snapshot the alert into plain locals before any commit/rollback —
-        # a rolled-back transaction expires SQLAlchemy attribute state, and
-        # later reads of ``alert.xxx`` would trigger a lazy refresh from
-        # the wrong session context (MissingGreenlet).
         alert_id = alert.id
         alert_uuid_value = alert.alert_uuid
         alert_source_report_uuid = alert.source_report_uuid
@@ -262,8 +433,8 @@ class InvestmentWatchScanner:
         alert_threshold_high = alert.threshold_high
         alert_intent = alert.intent
         alert_action_mode = alert.action_mode
-        alert_max_action = dict(alert.max_action or {})
-        alert_trigger_checklist = list(alert.trigger_checklist or [])
+        alert_max_action = alert.max_action
+        alert_trigger_checklist = alert.trigger_checklist
 
         outcome = _OUTCOME_BY_ACTION_MODE.get(alert_action_mode, "notified")
         correlation_id = uuid4().hex

--- a/tests/test_investment_watch_scanner.py
+++ b/tests/test_investment_watch_scanner.py
@@ -711,3 +711,224 @@ async def test_trigger_payload_price_guidance_none_without_recommendation(
     assert len(stub.calls) == 1
     assert stub.calls[0].price_guidance is None
     assert stub.calls[0].invest_links is not None  # 링크는 항상 채움
+
+
+# ---------------------------------------------------------------------------
+# ROB-1110 — per-alert isolation.
+#
+# The scan loop writes to the DB while still iterating. Before the fix the
+# alerts were live ORM rows owned by that same session, so the first
+# ``rollback()`` (the routine same-day idempotency-collision retry path)
+# expired the identity map and every later ``alert.conditions`` read raised
+# ``MissingGreenlet`` — taking out the whole remainder of the cycle.
+# Live ``notify_only`` alerts share this exact loop, so these cover the live
+# notify lane too.
+# ---------------------------------------------------------------------------
+
+
+_ROB1110_SYMBOLS = ("005930", "000660", "035420", "051910")
+
+
+async def _seed_kr_alert_fleet(
+    session: AsyncSession,
+    *,
+    action_mode: str = "notify_only",
+    symbols: tuple[str, ...] = _ROB1110_SYMBOLS,
+) -> list[Any]:
+    """Seed several independently-activated active KR alerts."""
+    alerts = []
+    for index, symbol in enumerate(symbols):
+        alerts.append(
+            await _seed_active_kr_alert(
+                session,
+                action_mode=action_mode,
+                symbol=symbol,
+                # A distinct report per alert: report ingestion is idempotent
+                # per (report_type, kst_date), and the helper activates
+                # ``items[0]``, so same-day seeds would all resolve to the
+                # very same watch item.
+                kst_date=f"2026-05-{18 + index:02d}",
+                client_item_key=f"rob1110-watch-{index}",
+            )
+        )
+    return alerts
+
+
+@pytest.mark.asyncio
+async def test_multiple_triggers_in_one_cycle_all_emit(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ROB-1110 — a cycle with many simultaneous triggers emits all of them."""
+    await _seed_kr_alert_fleet(session)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0  # below 30 → every alert triggers
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    summary = await InvestmentWatchScanner(hermes_client=stub).scan_market("kr")
+
+    assert summary["alerts_seen"] == len(_ROB1110_SYMBOLS)
+    assert summary["triggered"] == len(_ROB1110_SYMBOLS)
+    assert summary["notified"] == len(_ROB1110_SYMBOLS)
+    assert summary["failed_lookups"] == 0
+    assert summary["failed_alerts"] == 0
+    assert summary["not_evaluated"] == 0
+    assert {call.symbol for call in stub.calls} == set(_ROB1110_SYMBOLS)
+
+
+@pytest.mark.asyncio
+async def test_rollback_on_first_alert_does_not_kill_the_rest(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ROB-1110 regression — the ``MissingGreenlet`` cascade.
+
+    Scan 1 emits an event row per alert but Hermes is disabled, so every
+    alert stays ``active``. Scan 2 therefore hits the same-day
+    ``IntegrityError`` → ``db.rollback()`` path on the *first* alert, which
+    expires the ORM identity map. Before the fix the second alert's
+    ``alert.conditions`` read became a lazy refresh and raised
+    ``MissingGreenlet``, so scan 2 reported ``duplicates=1`` and silently
+    booked the other three as ``failed_lookups``. All of them must be
+    evaluated.
+    """
+    await _seed_kr_alert_fleet(session)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    # Scan 1 — Hermes disabled → events written, alerts remain 'active'.
+    skipped = _StubHermesClient(
+        delivery=HermesDeliveryResult(
+            status="skipped", http_status=None, reason="hermes_disabled"
+        )
+    )
+    first = await InvestmentWatchScanner(hermes_client=skipped).scan_market("kr")
+    assert first["triggered"] == len(_ROB1110_SYMBOLS)
+    assert first["skipped_delivery"] == len(_ROB1110_SYMBOLS)
+
+    # Scan 2 — every alert now collides on idempotency_key and rolls back.
+    retry = _StubHermesClient()
+    second = await InvestmentWatchScanner(hermes_client=retry).scan_market("kr")
+
+    assert second["alerts_seen"] == len(_ROB1110_SYMBOLS)
+    # Rolled-back insert → retry against the existing row, for *every* alert.
+    assert second["duplicates"] == len(_ROB1110_SYMBOLS)
+    assert second["notified"] == len(_ROB1110_SYMBOLS)
+    assert second["failed_lookups"] == 0, second
+    assert second["failed_alerts"] == 0, second
+    assert second["not_evaluated"] == 0, second
+    assert {call.symbol for call in retry.calls} == set(_ROB1110_SYMBOLS)
+
+
+@pytest.mark.asyncio
+async def test_failing_alert_is_isolated_recorded_and_cycle_completes(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ROB-1110 — one alert blowing up must not cost the others, and the
+    failure must be visible in the summary rather than swallowed."""
+    await _seed_kr_alert_fleet(session)
+    poisoned = _ROB1110_SYMBOLS[1]
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    @dataclass
+    class _ExplodingHermesClient(_StubHermesClient):
+        async def send_review_trigger(
+            self, payload: ReviewTriggerPayload
+        ) -> HermesDeliveryResult:
+            if payload.symbol == poisoned:
+                raise RuntimeError("hermes transport exploded")
+            return await super().send_review_trigger(payload)
+
+    stub = _ExplodingHermesClient()
+    summary = await InvestmentWatchScanner(hermes_client=stub).scan_market("kr")
+
+    assert summary["alerts_seen"] == len(_ROB1110_SYMBOLS)
+    assert summary["failed_alerts"] == 1
+    assert summary["not_evaluated"] == 0
+    # The other three completed end-to-end.
+    assert summary["notified"] == len(_ROB1110_SYMBOLS) - 1
+    assert {call.symbol for call in stub.calls} == set(_ROB1110_SYMBOLS) - {poisoned}
+
+    # The failure is recorded, not swallowed.
+    failures = [d for d in summary["details"] if d.get("status") == "alert_failed"]
+    assert len(failures) == 1
+    assert failures[0]["symbol"] == poisoned
+    assert "hermes transport exploded" in failures[0]["error"]
+
+    # The failed alert keeps its retryable state: event row still pending and
+    # the alert is still active, so the next cycle picks it back up.
+    await session.commit()
+    row = await session.execute(
+        sa.text(
+            "SELECT e.delivery_status, a.status "
+            "FROM review.investment_watch_events e "
+            "JOIN review.investment_watch_alerts a ON a.id = e.alert_id "
+            "WHERE e.symbol = :symbol"
+        ),
+        {"symbol": poisoned},
+    )
+    delivery_status, alert_status = row.one()
+    assert delivery_status == "pending"
+    assert alert_status == "active"
+
+
+@pytest.mark.asyncio
+async def test_db_error_in_auto_execute_does_not_poison_later_alerts(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ROB-1110 / ROB-1109 shape — an aborted transaction must not cascade.
+
+    ``maybe_auto_execute`` failing on a missing table (the original ROB-1109
+    observation) leaves the transaction in an aborted state. Without the
+    rollback the alert's own delivery bookkeeping — and every commit after
+    it — fails too. The alert that broke still has to record its delivery,
+    and the alerts behind it must be untouched.
+    """
+    await _seed_kr_alert_fleet(session, action_mode="auto_execute_mock")
+    poisoned = _ROB1110_SYMBOLS[0]
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    async def _exploding_auto_execute(db, *, alert, **_kwargs):
+        if alert.symbol == poisoned:
+            # A real aborted-transaction failure, not a bare raise.
+            await db.execute(sa.text("SELECT * FROM review.__rob1110_missing__"))
+        return {"executed": False, "skipped": "test"}
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+    monkeypatch.setattr(scanner_module, "maybe_auto_execute", _exploding_auto_execute)
+
+    stub = _StubHermesClient()
+    summary = await InvestmentWatchScanner(hermes_client=stub).scan_market("kr")
+
+    assert summary["alerts_seen"] == len(_ROB1110_SYMBOLS)
+    assert summary["triggered"] == len(_ROB1110_SYMBOLS)
+    # Including the alert whose auto-execute blew up: the event row was
+    # already committed, so its delivery is still booked.
+    assert summary["notified"] == len(_ROB1110_SYMBOLS)
+    assert summary["failed_alerts"] == 0, summary
+    assert summary["not_evaluated"] == 0, summary
+    assert {call.symbol for call in stub.calls} == set(_ROB1110_SYMBOLS)
+
+    await session.commit()
+    delivered = await session.scalar(
+        sa.text(
+            "SELECT COUNT(*) FROM review.investment_watch_events "
+            "WHERE symbol = ANY(:symbols) AND delivery_status = 'delivered'"
+        ),
+        {"symbols": list(_ROB1110_SYMBOLS)},
+    )
+    assert delivered == len(_ROB1110_SYMBOLS)


### PR DESCRIPTION
Fixes ROB-1110. **This also fixes the live notify lane** — see below.

## Root cause

`InvestmentWatchScanner.scan_market` writes to the DB while still iterating its alert list, so one alert could take out every alert behind it in the same cycle.

`repo.list_active_alerts` returns live ORM rows owned by the scan session. `AsyncSession.rollback()` **always** expires the identity map — even though this app builds its sessionmaker with `expire_on_commit=False` (`app/core/db.py:77`). So the routine same-day `IntegrityError` retry path in `_upsert_event` (`await db.rollback()`) expired every remaining alert, and the next `alert.conditions` read became an implicit lazy refresh → `MissingGreenlet` under asyncio. The rest of the cycle was booked as `failed_lookups` and never evaluated (measured: KR 48 alerts × 2 cycles).

A DB error inside one alert's handling had the same blast radius by a second route: it left the transaction aborted, so every later `commit()` failed with `InFailedSQLTransactionError`. That is how ROB-1109 (missing `review.watch_order_intent_ledger`) surfaced this.

Note the ignition is **`rollback`, not plain `commit`** — the issue body's "commit → expire" reading would have pointed at a fix that doesn't hold, since `expire_on_commit` is already off.

## Live-lane exposure — yes, shared

`app/tasks/watch_scan_tasks.py` registers a single task, `scan.investment_watch_alerts` (`*/5 * * * *`), which calls `run()` → `scan_market()` for crypto/kr/us. That one loop handles **every** `action_mode`, including live `notify_only`. There is no separate live scanner. So this is a pre-existing live-notify defect that `auto_execute_mock` merely made visible, and a triggered watch on any market silently killed the remaining watches in that cycle — indistinguishable from "condition not met".

## Fix

- **`_AlertSnapshot`** — each alert row is materialized into an immutable plain-Python snapshot *before* the first write. The loop then holds no ORM state at all. Chosen over a targeted `selectinload(conditions)` because the loop reads ~14 other attributes that are equally expirable; snapshotting removes the whole lazy-load surface instead of fixing one column and hoping no future field is added. Attribute names mirror the model, so `maybe_auto_execute` is unchanged.
- **Per-alert try/rollback boundary** (`_process_alert` + `_reset_session`). A failure increments `failed_alerts` and appends a `status="alert_failed"` entry to `details` with the alert uuid, symbol and error — recorded, never silently swallowed — and the cycle carries on. If the rollback itself fails, the session is unusable, so the scan stops and reports exactly how many alerts were `not_evaluated` rather than emitting a wall of identical failures.
- **Rollback after a failed `maybe_auto_execute`**, so the alert's own delivery bookkeeping and every commit after it still succeed.
- Two new summary counters: `failed_alerts`, `not_evaluated`. A quiet scan can no longer be mistaken for a clean one.

## Verification

4 new tests, all confirmed to **fail on the unfixed code** with the originally reported errors:

| test | failure without the fix |
|---|---|
| `test_rollback_on_first_alert_does_not_kill_the_rest` | `MissingGreenlet` at `if alert.conditions:` — the exact reported bug, reproduced via the routine same-day retry path |
| `test_db_error_in_auto_execute_does_not_poison_later_alerts` | `InFailedSQLTransactionError` cascade — the ROB-1109 shape |
| `test_failing_alert_is_isolated_recorded_and_cycle_completes` | the exception escapes `scan_market` entirely |
| `test_multiple_triggers_in_one_cycle_all_emit` | multi-trigger contract (`KeyError: 'failed_alerts'`) |

All use 4 seeded alerts, not 1, so multi-trigger cycles are covered. The isolation test also asserts the failed alert stays retryable (event row `pending`, alert `active`) while the other three deliver.

`tests/test_investment_watch_scanner.py` + `test_watch_scan_tasks.py` + `test_nxt_advisory_only_pilot.py` + `test_import_contracts.py`: **25 passed**. Broader watch suites: 41 passed, 1 failure — `test_investment_reports_watch_activation.py::test_alert_accepts_between_operator_and_conditions`, a `ForeignKeyViolationError` **confirmed pre-existing** (reproduced with both changed files reverted to `origin/main`; that test does not import the scanner).

No migration. No broker/order/production-DB mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)