### PR TITLE
feat(ROB-1108): harden R4 collector epochs

### DIFF
--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -26,6 +26,21 @@ from typing import Any, Final
 import httpx
 import websockets
 
+from app.services.brokers.binance.r4_p0_hardening import (
+    FINAL_COMPLETE,
+    AlertDispatcher,
+    DeterministicEpochFinalizer,
+    EpochLedger,
+    EpochPolicy,
+    FinalizationInvariantError,
+    RawPITReader,
+    availability_report,
+    decision_epoch_for_event,
+    finalize_at,
+    scheduled_epochs,
+    sha256_bytes,
+)
+
 REST_BASE_URL: Final = "https://fapi.binance.com"
 WS_PUBLIC_BASE_URL: Final = "wss://fstream.binance.com/public"
 WS_MARKET_BASE_URL: Final = "wss://fstream.binance.com/market"
@@ -57,7 +72,7 @@ PIT_COLUMNS: Final = (
     "gap_detected",
     "reconnect_id",
 )
-COLLECTOR_VERSION: Final = "r4-p0-collector.v2"
+COLLECTOR_VERSION: Final = "r4-p0-collector.v3"
 BASIS_RECOVERY_LIMIT: Final = 100
 EXPECTED_SOURCES: Final = frozenset(
     {
@@ -182,6 +197,14 @@ class CollectorConfig:
     taker_poll_seconds: float = 300.0
     status_seconds: float = 30.0
     symbols: tuple[str, ...] = SYMBOLS
+    collector_instance_id: str = "r4-p0-local"
+    replica_artifacts: tuple[Path, ...] = ()
+    alert_webhook_urls: tuple[str, ...] = ()
+    epoch_tick_seconds: float = 5.0
+    epoch_retry_seconds: float = 30.0
+    deadline_risk_seconds: float = 60.0 * 60.0
+    heartbeat_stale_seconds: float = 120.0
+    minimum_healthy_replicas: int = 1
 
 
 class AppendOnlyPITStore:
@@ -463,6 +486,26 @@ class BinanceR4P0Collector:
         self._previous_sequence: dict[tuple[str, str], int] = {}
         self._seen_on_connection: set[tuple[str, str, str]] = set()
         self._last_book_snapshot: dict[str, dt.datetime] = {}
+        policy_symbols = tuple(sorted(set(config.symbols).intersection(SIGNAL_SYMBOLS)))
+        self.epoch_policy = EpochPolicy(
+            required_sources=tuple(sorted(REQUIRED_ACTIVE_SOURCES)),
+            symbols=policy_symbols,
+        )
+        self.epoch_ledger = EpochLedger(store._db, self.epoch_policy)
+        self.raw_reader = RawPITReader(
+            store._db,
+            store.path,
+            config.replica_artifacts,
+        )
+        self.epoch_finalizer = DeterministicEpochFinalizer(
+            self.epoch_ledger, self.raw_reader
+        )
+        self.alert_dispatcher = AlertDispatcher(
+            self.epoch_ledger, config.alert_webhook_urls
+        )
+        self._opened_epochs: set[str] = set()
+        self._finalized_epochs: set[tuple[str, str]] = set()
+        self._last_epoch_retry: dt.datetime | None = None
 
     async def run(self) -> None:
         log.info(
@@ -489,6 +532,9 @@ class BinanceR4P0Collector:
             asyncio.create_task(
                 self._poll_loop("taker", self.config.taker_poll_seconds),
                 name="r4-p0-taker",
+            ),
+            asyncio.create_task(
+                self._epoch_supervisor(), name="r4-p0-epoch-supervisor"
             ),
             asyncio.create_task(self._status_loop(), name="r4-p0-status"),
         ]
@@ -531,6 +577,14 @@ class BinanceR4P0Collector:
     async def _status_loop(self) -> None:
         while True:
             await asyncio.sleep(self.config.status_seconds)
+            observed_at = utc_now()
+            health = self.health()
+            self.epoch_ledger.append_heartbeat(
+                collector_instance_id=self.config.collector_instance_id,
+                run_id=self.run_id,
+                observed_at=observed_at,
+                health=health,
+            )
             log.info(
                 "collector.status run_id=%s session_counts=%s duplicates=%s failures=%s total=%s",
                 self.run_id,
@@ -539,6 +593,219 @@ class BinanceR4P0Collector:
                 dict(self.failure_counts),
                 self.store.counts(),
             )
+            artifact_paths = (self.store.path, *self.config.replica_artifacts)
+            availability = availability_report(
+                artifact_paths,
+                self.epoch_policy,
+                observed_at=observed_at,
+                stale_after_seconds=self.config.heartbeat_stale_seconds,
+            )
+            if (
+                availability["healthy_replica_count"]
+                < self.config.minimum_healthy_replicas
+            ):
+                await self.alert_dispatcher.emit(
+                    alert_key=(
+                        "COLLECTOR_REDUNDANCY_LOST:"
+                        f"{self.epoch_policy.study_id}:"
+                        f"{self.epoch_policy.policy_hash}:"
+                        f"{int(observed_at.timestamp()) // 900}"
+                    ),
+                    severity="CRITICAL",
+                    payload={
+                        "alert_type": "COLLECTOR_REDUNDANCY_LOST",
+                        "minimum_healthy_replicas": (
+                            self.config.minimum_healthy_replicas
+                        ),
+                        **availability,
+                    },
+                    now=observed_at,
+                )
+
+    async def _epoch_supervisor(self) -> None:
+        async with httpx.AsyncClient(
+            base_url=REST_BASE_URL,
+            timeout=httpx.Timeout(10.0),
+            follow_redirects=False,
+            headers={"User-Agent": f"auto-trader/{COLLECTOR_VERSION}"},
+        ) as client:
+            while not self.stop.is_set():
+                now = utc_now()
+                for epoch in scheduled_epochs(self.epoch_policy.t0, now):
+                    epoch_text = iso_utc(epoch)
+                    assert epoch_text is not None
+                    if epoch_text not in self._opened_epochs:
+                        self.epoch_ledger.ensure_open_rows(
+                            epoch,
+                            self.config.collector_instance_id,
+                            now,
+                        )
+                        self._opened_epochs.add(epoch_text)
+                    if now >= finalize_at(epoch):
+                        await self._finalize_epoch(epoch, now)
+
+                retry_epoch = decision_epoch_for_event(now) - dt.timedelta(hours=4)
+                retry_deadline = finalize_at(retry_epoch)
+                if (
+                    retry_epoch >= self.epoch_policy.t0
+                    and retry_epoch <= now < retry_deadline
+                ):
+                    due = (
+                        self._last_epoch_retry is None
+                        or (now - self._last_epoch_retry).total_seconds()
+                        >= self.config.epoch_retry_seconds
+                    )
+                    if due:
+                        await self._retry_incomplete_epoch(client, retry_epoch, now)
+                        self._last_epoch_retry = now
+                    if (
+                        retry_deadline - now
+                    ).total_seconds() <= self.config.deadline_risk_seconds:
+                        await self._alert_deadline_risk(retry_epoch, now)
+                await asyncio.sleep(self.config.epoch_tick_seconds)
+
+    async def _finalize_epoch(
+        self, epoch: dt.datetime, observed_at: dt.datetime
+    ) -> None:
+        epoch_text = iso_utc(epoch) or ""
+        if all(
+            (symbol, epoch_text) in self._finalized_epochs
+            for symbol in self.epoch_policy.symbols
+        ):
+            return
+        for symbol in self.epoch_policy.symbols:
+            cache_key = (symbol, epoch_text)
+            if cache_key in self._finalized_epochs:
+                continue
+            try:
+                result = self.epoch_finalizer.finalize(
+                    symbol, epoch, observed_at=observed_at
+                )
+            except FinalizationInvariantError as exc:
+                self.failure_counts["finalizer_invariant"] += 1
+                await self.alert_dispatcher.emit(
+                    alert_key=(
+                        "LEDGER_REPRODUCTION_FAIL:"
+                        f"{self.epoch_policy.study_id}:"
+                        f"{self.epoch_policy.policy_hash}:"
+                        f"{symbol}:{epoch_text}"
+                    ),
+                    severity="CRITICAL",
+                    payload={
+                        "alert_type": "LEDGER_REPRODUCTION_FAIL",
+                        "decision_epoch_utc": epoch_text,
+                        "error_type": type(exc).__name__,
+                        "policy_hash": self.epoch_policy.policy_hash,
+                        "study_id": self.epoch_policy.study_id,
+                        "symbol": symbol,
+                    },
+                    now=observed_at,
+                )
+                self.stop.set()
+                return
+            self._finalized_epochs.add(cache_key)
+            self.epoch_finalizer.append_late_only(
+                symbol, epoch, recorded_at=observed_at
+            )
+            if result.final_status != FINAL_COMPLETE:
+                await self.alert_dispatcher.emit(
+                    alert_key=(
+                        "DATA_INTEGRITY_FAIL:"
+                        f"{result.study_id}:{result.policy_hash}:"
+                        f"{result.symbol}:{result.decision_epoch_utc}:"
+                        f"{result.final_status}"
+                    ),
+                    severity="CRITICAL",
+                    payload={
+                        "alert_type": "DATA_INTEGRITY_FAIL",
+                        "conflict_sources": result.conflict_sources,
+                        "decision_epoch_utc": result.decision_epoch_utc,
+                        "evaluation_hash": result.evaluation_hash,
+                        "final_status": result.final_status,
+                        "finalize_at": result.finalize_at,
+                        "invalid_sources": result.invalid_sources,
+                        "missing_sources": result.missing_sources,
+                        "policy_hash": result.policy_hash,
+                        "study_id": result.study_id,
+                        "symbol": result.symbol,
+                    },
+                    now=observed_at,
+                )
+
+    async def _alert_deadline_risk(
+        self, epoch: dt.datetime, observed_at: dt.datetime
+    ) -> None:
+        for symbol in self.epoch_policy.symbols:
+            preview = self.epoch_finalizer.preview(symbol, epoch)
+            if preview.final_status == FINAL_COMPLETE:
+                continue
+            await self.alert_dispatcher.emit(
+                alert_key=(
+                    "EPOCH_DEADLINE_RISK:"
+                    f"{preview.study_id}:{preview.policy_hash}:"
+                    f"{symbol}:{preview.decision_epoch_utc}"
+                ),
+                severity="WARNING",
+                payload={
+                    "alert_type": "EPOCH_DEADLINE_RISK",
+                    "conflict_sources": preview.conflict_sources,
+                    "decision_epoch_utc": preview.decision_epoch_utc,
+                    "finalize_at": preview.finalize_at,
+                    "invalid_sources": preview.invalid_sources,
+                    "missing_sources": preview.missing_sources,
+                    "policy_hash": preview.policy_hash,
+                    "study_id": preview.study_id,
+                    "symbol": symbol,
+                },
+                now=observed_at,
+            )
+
+    async def _retry_incomplete_epoch(
+        self,
+        client: httpx.AsyncClient,
+        epoch: dt.datetime,
+        observed_at: dt.datetime,
+    ) -> None:
+        recoverable = {
+            "binance_usdm.basis",
+            "binance_usdm.openInterestHist",
+            "binance_usdm.premiumIndexKline1m",
+            "binance_usdm.takerLongShortRatio",
+        }
+        for symbol in self.epoch_policy.symbols:
+            preview = self.epoch_finalizer.preview(symbol, epoch)
+            retry_sources = sorted(
+                (set(preview.missing_sources) | set(preview.invalid_sources))
+                & recoverable
+            )
+            for source in retry_sources:
+                if observed_at >= finalize_at(epoch):
+                    self.epoch_ledger.append_attempt(
+                        collector_instance_id=self.config.collector_instance_id,
+                        decision_epoch=epoch,
+                        attempted_at=observed_at,
+                        completed_at=observed_at,
+                        request_identity={
+                            "method": "GET",
+                            "source_name": source,
+                            "symbol": symbol,
+                            "target": "deadline-recovery",
+                        },
+                        response_sha256=None,
+                        terminal_status="DEADLINE_EXPIRED",
+                    )
+                    continue
+                try:
+                    await self._rest_epoch_history(
+                        client,
+                        source=source,
+                        symbol=symbol,
+                        decision_epoch=epoch,
+                    )
+                except Exception:
+                    # The request-level immutable attempt row already contains
+                    # the terminal failure. Other missing sources still retry.
+                    continue
 
     async def _ws_supervisor(self, lane: str) -> None:
         failure_attempt = 0
@@ -548,6 +815,18 @@ class BinanceR4P0Collector:
             reconnect_number += 1
             reconnect_id = f"{self.run_id}:ws:{lane}:{reconnect_number}"
             request_started = utc_now()
+            request_identity = {
+                "lane": lane,
+                "method": "WEBSOCKET_CONNECT",
+                "target": url,
+            }
+            connect_attempt_id = self.epoch_ledger.begin_attempt(
+                collector_instance_id=self.config.collector_instance_id,
+                decision_epoch=decision_epoch_for_event(request_started),
+                attempted_at=request_started,
+                request_identity=request_identity,
+            )
+            connected_at: dt.datetime | None = None
             try:
                 assert_ws_target(url)
                 async with websockets.connect(
@@ -558,10 +837,21 @@ class BinanceR4P0Collector:
                     max_queue=4096,
                 ) as ws:
                     request_completed = utc_now()
+                    connected_at = request_completed
                     log.info(
                         "collector.ws.connected lane=%s reconnect_id=%s",
                         lane,
                         reconnect_id,
+                    )
+                    self.epoch_ledger.append_attempt(
+                        collector_instance_id=self.config.collector_instance_id,
+                        decision_epoch=decision_epoch_for_event(request_started),
+                        attempted_at=request_started,
+                        completed_at=request_completed,
+                        request_identity=request_identity,
+                        response_sha256=None,
+                        terminal_status="SUCCESS",
+                        attempt_id=connect_attempt_id,
                     )
                     failure_attempt = 0
                     async for raw in ws:
@@ -576,6 +866,32 @@ class BinanceR4P0Collector:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                failed_at = utc_now()
+                failure_identity = (
+                    {
+                        "lane": lane,
+                        "method": "WEBSOCKET_SESSION",
+                        "reconnect_id": reconnect_id,
+                        "target": url,
+                    }
+                    if connected_at is not None
+                    else request_identity
+                )
+                self.epoch_ledger.append_attempt(
+                    collector_instance_id=self.config.collector_instance_id,
+                    decision_epoch=decision_epoch_for_event(
+                        connected_at or request_started
+                    ),
+                    attempted_at=connected_at or request_started,
+                    completed_at=failed_at,
+                    request_identity=failure_identity,
+                    response_sha256=None,
+                    terminal_status="TRANSPORT_ERROR",
+                    error_type=type(exc).__name__,
+                    attempt_id=(
+                        None if connected_at is not None else connect_attempt_id
+                    ),
+                )
                 self.failure_counts["websocket"] += 1
                 delay = min(60.0, 1.0 * (2 ** min(failure_attempt, 6)))
                 delay *= random.uniform(0.8, 1.2)
@@ -884,45 +1200,89 @@ class BinanceR4P0Collector:
             self._count_result("binance_usdm.basis", inserted)
 
     async def _rest_premium_kline(
-        self, client: httpx.AsyncClient, *, symbol: str
+        self,
+        client: httpx.AsyncClient,
+        *,
+        symbol: str,
+        decision_epoch: dt.datetime | None = None,
     ) -> None:
         path = "/fapi/v1/premiumIndexKlines"
         assert_rest_target(path)
         started = utc_now()
-        response = await client.get(
-            path,
-            params={"symbol": symbol, "interval": "1m", "limit": 2},
-        )
-        completed = utc_now()
-        response.raise_for_status()
-        payload = response.json()
-        if not isinstance(payload, list):
-            raise ValueError(f"invalid JSON shape from allowlisted path {path}")
-        completed_ms = int(completed.timestamp() * 1000)
-        complete_rows = [
-            row
-            for row in payload
-            if isinstance(row, list) and len(row) >= 7 and int(row[6]) <= completed_ms
-        ]
-        if not complete_rows:
-            raise ValueError(f"no completed 1m row from allowlisted path {path}")
-        item = complete_rows[-1]
-        source = "binance_usdm.premiumIndexKline1m"
-        inserted = self.store.append(
-            source=source,
+        params = {"symbol": symbol, "interval": "1m", "limit": 2}
+        target_epoch = decision_epoch or decision_epoch_for_event(started)
+        attempt_id = self._begin_rest_attempt(
+            decision_epoch=target_epoch,
+            attempted_at=started,
+            path=path,
+            params=params,
             symbol=symbol,
-            raw_payload=item,
-            local_receive_time=completed,
-            run_id=self.run_id,
-            event_time=epoch_ms(item[6]),
-            transaction_time=epoch_ms(item[6]),
-            request_started_at=iso_utc(started),
-            request_completed_at=iso_utc(completed),
-            sequence_or_trade_id=str(item[0]),
-            gap_detected=False,
-            reconnect_id=f"{self.run_id}:rest:{path}",
+            sources=("binance_usdm.premiumIndexKline1m",),
         )
-        self._count_result(source, inserted)
+        response_hash: str | None = None
+        completed = started
+        try:
+            response = await client.get(path, params=params)
+            completed = utc_now()
+            response_hash = sha256_bytes(response.content)
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
+                raise ValueError(f"invalid JSON shape from allowlisted path {path}")
+            completed_ms = int(completed.timestamp() * 1000)
+            complete_rows = [
+                row
+                for row in payload
+                if isinstance(row, list)
+                and len(row) >= 7
+                and int(row[6]) <= completed_ms
+            ]
+            if not complete_rows:
+                raise ValueError(f"no completed 1m row from allowlisted path {path}")
+            item = complete_rows[-1]
+            source = "binance_usdm.premiumIndexKline1m"
+            inserted = self.store.append(
+                source=source,
+                symbol=symbol,
+                raw_payload=item,
+                local_receive_time=completed,
+                run_id=self.run_id,
+                event_time=epoch_ms(item[6]),
+                transaction_time=epoch_ms(item[6]),
+                request_started_at=iso_utc(started),
+                request_completed_at=iso_utc(completed),
+                sequence_or_trade_id=str(item[0]),
+                gap_detected=False,
+                reconnect_id=f"{self.run_id}:rest:{path}",
+            )
+            self._count_result(source, inserted)
+        except Exception as exc:
+            self._append_rest_attempt(
+                decision_epoch=target_epoch,
+                attempted_at=started,
+                completed_at=completed,
+                path=path,
+                params=params,
+                symbol=symbol,
+                sources=("binance_usdm.premiumIndexKline1m",),
+                response_hash=response_hash,
+                terminal_status=self._attempt_failure_status(exc),
+                error_type=type(exc).__name__,
+                attempt_id=attempt_id,
+            )
+            raise
+        self._append_rest_attempt(
+            decision_epoch=target_epoch,
+            attempted_at=started,
+            completed_at=completed,
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=("binance_usdm.premiumIndexKline1m",),
+            response_hash=response_hash,
+            terminal_status="SUCCESS" if inserted else "EXACT_DUPLICATE",
+            attempt_id=attempt_id,
+        )
 
     async def _rest_get(
         self,
@@ -932,46 +1292,324 @@ class BinanceR4P0Collector:
         params: Mapping[str, Any],
         symbol: str,
         outputs: Sequence[tuple[str, str | None]],
+        decision_epoch: dt.datetime | None = None,
     ) -> None:
         assert_rest_target(path)
         started = utc_now()
-        response = await client.get(path, params=params)
-        completed = utc_now()
-        response.raise_for_status()
-        payload = response.json()
-        if isinstance(payload, str) or not isinstance(payload, (dict, list)):
-            raise ValueError(f"invalid JSON shape from allowlisted path {path}")
-        item = payload[-1] if isinstance(payload, list) and payload else payload
-        if not isinstance(item, dict):
-            raise ValueError(f"empty/invalid payload from allowlisted path {path}")
-        event_time = epoch_ms(item.get("time") or item.get("timestamp"))
-        if event_time is None:
-            # A response with no exchange timestamp cannot satisfy the PIT
-            # contract and must never be silently persisted.
-            raise ValueError(f"missing exchange timestamp from allowlisted path {path}")
-        sequence = item.get("timestamp") or item.get("time")
-        reconnect_id = f"{self.run_id}:rest:{path}"
-        for source, semantic_field in outputs:
-            semantic_payload = (
-                {**item, "_semantic_field": semantic_field}
-                if semantic_field is not None
-                else item
-            )
-            inserted = self.store.append(
-                source=source,
+        target_epoch = decision_epoch or decision_epoch_for_event(started)
+        output_sources = tuple(source for source, _ in outputs)
+        attempt_id = self._begin_rest_attempt(
+            decision_epoch=target_epoch,
+            attempted_at=started,
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=output_sources,
+        )
+        response_hash: str | None = None
+        completed = started
+        inserted_any = False
+        all_duplicates = True
+        try:
+            response = await client.get(path, params=params)
+            completed = utc_now()
+            response_hash = sha256_bytes(response.content)
+            response.raise_for_status()
+            payload = response.json()
+            if isinstance(payload, str) or not isinstance(payload, (dict, list)):
+                raise ValueError(f"invalid JSON shape from allowlisted path {path}")
+            item = payload[-1] if isinstance(payload, list) and payload else payload
+            if not isinstance(item, dict):
+                raise ValueError(f"empty/invalid payload from allowlisted path {path}")
+            event_time = epoch_ms(item.get("time") or item.get("timestamp"))
+            if event_time is None:
+                # A response with no exchange timestamp cannot satisfy the PIT
+                # contract and must never be silently persisted.
+                raise ValueError(
+                    f"missing exchange timestamp from allowlisted path {path}"
+                )
+            sequence = item.get("timestamp") or item.get("time")
+            reconnect_id = f"{self.run_id}:rest:{path}"
+            for source, semantic_field in outputs:
+                semantic_payload = (
+                    {**item, "_semantic_field": semantic_field}
+                    if semantic_field is not None
+                    else item
+                )
+                inserted = self.store.append(
+                    source=source,
+                    symbol=symbol,
+                    raw_payload=semantic_payload,
+                    local_receive_time=completed,
+                    run_id=self.run_id,
+                    event_time=event_time,
+                    transaction_time=None,
+                    request_started_at=iso_utc(started),
+                    request_completed_at=iso_utc(completed),
+                    sequence_or_trade_id=(
+                        str(sequence) if sequence is not None else None
+                    ),
+                    gap_detected=False,
+                    reconnect_id=reconnect_id,
+                )
+                self._count_result(source, inserted)
+                inserted_any = inserted_any or inserted
+                all_duplicates = all_duplicates and not inserted
+        except Exception as exc:
+            self._append_rest_attempt(
+                decision_epoch=target_epoch,
+                attempted_at=started,
+                completed_at=completed,
+                path=path,
+                params=params,
                 symbol=symbol,
-                raw_payload=semantic_payload,
-                local_receive_time=completed,
-                run_id=self.run_id,
-                event_time=event_time,
-                transaction_time=None,
-                request_started_at=iso_utc(started),
-                request_completed_at=iso_utc(completed),
-                sequence_or_trade_id=str(sequence) if sequence is not None else None,
-                gap_detected=False,
-                reconnect_id=reconnect_id,
+                sources=output_sources,
+                response_hash=response_hash,
+                terminal_status=self._attempt_failure_status(exc),
+                error_type=type(exc).__name__,
+                attempt_id=attempt_id,
             )
-            self._count_result(source, inserted)
+            raise
+        self._append_rest_attempt(
+            decision_epoch=target_epoch,
+            attempted_at=started,
+            completed_at=completed,
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=output_sources,
+            response_hash=response_hash,
+            terminal_status=(
+                "EXACT_DUPLICATE" if all_duplicates and not inserted_any else "SUCCESS"
+            ),
+            attempt_id=attempt_id,
+        )
+
+    async def _rest_epoch_history(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        source: str,
+        symbol: str,
+        decision_epoch: dt.datetime,
+    ) -> None:
+        interval_start = decision_epoch - dt.timedelta(hours=4)
+        start_ms = int(interval_start.timestamp() * 1000)
+        end_ms = int(decision_epoch.timestamp() * 1000) - 1
+        request_by_source: dict[str, tuple[str, dict[str, Any]]] = {
+            "binance_usdm.openInterestHist": (
+                "/futures/data/openInterestHist",
+                {
+                    "symbol": symbol,
+                    "period": "5m",
+                    "startTime": start_ms,
+                    "endTime": end_ms,
+                    "limit": 500,
+                },
+            ),
+            "binance_usdm.basis": (
+                "/futures/data/basis",
+                {
+                    "pair": symbol,
+                    "contractType": "PERPETUAL",
+                    "period": "5m",
+                    "startTime": start_ms,
+                    "endTime": end_ms,
+                    "limit": 500,
+                },
+            ),
+            "binance_usdm.takerLongShortRatio": (
+                "/futures/data/takerlongshortRatio",
+                {
+                    "symbol": symbol,
+                    "period": "5m",
+                    "startTime": start_ms,
+                    "endTime": end_ms,
+                    "limit": 500,
+                },
+            ),
+            "binance_usdm.premiumIndexKline1m": (
+                "/fapi/v1/premiumIndexKlines",
+                {
+                    "symbol": symbol,
+                    "interval": "1m",
+                    "startTime": start_ms,
+                    "endTime": end_ms,
+                    "limit": 500,
+                },
+            ),
+        }
+        path, params = request_by_source[source]
+        assert_rest_target(path)
+        started = utc_now()
+        attempt_id = self._begin_rest_attempt(
+            decision_epoch=decision_epoch,
+            attempted_at=started,
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=(source,),
+        )
+        response_hash: str | None = None
+        completed = started
+        inserted_count = 0
+        try:
+            response = await client.get(path, params=params)
+            completed = utc_now()
+            response_hash = sha256_bytes(response.content)
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
+                raise ValueError(f"invalid historical JSON shape from {path}")
+            reconnect_id = f"{self.run_id}:retry:{path}"
+            for item in payload:
+                if source == "binance_usdm.premiumIndexKline1m":
+                    if not isinstance(item, list) or len(item) < 7:
+                        raise ValueError(f"invalid historical kline row from {path}")
+                    event_time = epoch_ms(item[6])
+                    sequence = str(item[0])
+                else:
+                    if not isinstance(item, dict):
+                        raise ValueError(f"invalid historical data row from {path}")
+                    timestamp = item.get("timestamp") or item.get("time")
+                    event_time = epoch_ms(timestamp)
+                    sequence = str(timestamp) if timestamp is not None else None
+                if event_time is None:
+                    raise ValueError(
+                        f"missing historical exchange timestamp from {path}"
+                    )
+                event_dt = dt.datetime.fromisoformat(event_time.replace("Z", "+00:00"))
+                if not interval_start <= event_dt < decision_epoch:
+                    continue
+                inserted = self.store.append(
+                    source=source,
+                    symbol=symbol,
+                    raw_payload=item,
+                    local_receive_time=completed,
+                    run_id=self.run_id,
+                    event_time=event_time,
+                    transaction_time=(
+                        event_time
+                        if source == "binance_usdm.premiumIndexKline1m"
+                        else None
+                    ),
+                    request_started_at=iso_utc(started),
+                    request_completed_at=iso_utc(completed),
+                    sequence_or_trade_id=sequence,
+                    gap_detected=False,
+                    reconnect_id=reconnect_id,
+                )
+                self._count_result(source, inserted)
+                inserted_count += int(inserted)
+            if not payload:
+                raise ValueError(f"empty historical response from {path}")
+        except Exception as exc:
+            self._append_rest_attempt(
+                decision_epoch=decision_epoch,
+                attempted_at=started,
+                completed_at=completed,
+                path=path,
+                params=params,
+                symbol=symbol,
+                sources=(source,),
+                response_hash=response_hash,
+                terminal_status=self._attempt_failure_status(exc),
+                error_type=type(exc).__name__,
+                attempt_id=attempt_id,
+            )
+            raise
+        self._append_rest_attempt(
+            decision_epoch=decision_epoch,
+            attempted_at=started,
+            completed_at=completed,
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=(source,),
+            response_hash=response_hash,
+            terminal_status=("SUCCESS" if inserted_count else "EXACT_DUPLICATE"),
+            attempt_id=attempt_id,
+        )
+
+    @staticmethod
+    def _attempt_failure_status(exc: Exception) -> str:
+        if isinstance(exc, httpx.HTTPStatusError):
+            return "HTTP_ERROR"
+        if isinstance(exc, httpx.HTTPError):
+            return "TRANSPORT_ERROR"
+        return "INVALID_RESPONSE"
+
+    def _append_rest_attempt(
+        self,
+        *,
+        decision_epoch: dt.datetime,
+        attempted_at: dt.datetime,
+        completed_at: dt.datetime,
+        path: str,
+        params: Mapping[str, Any],
+        symbol: str,
+        sources: Sequence[str],
+        response_hash: str | None,
+        terminal_status: str,
+        error_type: str | None = None,
+        attempt_id: str | None = None,
+    ) -> None:
+        request_identity = self._rest_request_identity(
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=sources,
+        )
+        self.epoch_ledger.append_attempt(
+            collector_instance_id=self.config.collector_instance_id,
+            decision_epoch=decision_epoch,
+            attempted_at=attempted_at,
+            completed_at=completed_at,
+            request_identity=request_identity,
+            response_sha256=response_hash,
+            terminal_status=terminal_status,
+            error_type=error_type,
+            attempt_id=attempt_id,
+        )
+
+    def _begin_rest_attempt(
+        self,
+        *,
+        decision_epoch: dt.datetime,
+        attempted_at: dt.datetime,
+        path: str,
+        params: Mapping[str, Any],
+        symbol: str,
+        sources: Sequence[str],
+    ) -> str:
+        return self.epoch_ledger.begin_attempt(
+            collector_instance_id=self.config.collector_instance_id,
+            decision_epoch=decision_epoch,
+            attempted_at=attempted_at,
+            request_identity=self._rest_request_identity(
+                path=path,
+                params=params,
+                symbol=symbol,
+                sources=sources,
+            ),
+        )
+
+    @staticmethod
+    def _rest_request_identity(
+        *,
+        path: str,
+        params: Mapping[str, Any],
+        symbol: str,
+        sources: Sequence[str],
+    ) -> dict[str, Any]:
+        return {
+            "base_url": REST_BASE_URL,
+            "method": "GET",
+            "params": dict(sorted(params.items())),
+            "path": path,
+            "sources": sorted(sources),
+            "symbol": symbol,
+        }
 
     def _count_result(self, source: str, inserted: bool) -> None:
         if inserted:

--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -15,6 +15,7 @@ import json
 import logging
 import random
 import sqlite3
+import traceback
 import urllib.parse
 import uuid
 from collections import Counter
@@ -575,6 +576,21 @@ class BinanceR4P0Collector:
         self.stop.set()
 
     async def _status_loop(self) -> None:
+        try:
+            await self._status_loop_body()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.failure_counts["status_supervisor"] += 1
+            log.exception(
+                "collector.supervisor.failed lane=status error=%s detail=%r",
+                type(exc).__name__,
+                str(exc),
+            )
+            self.stop.set()
+            raise
+
+    async def _status_loop_body(self) -> None:
         while True:
             await asyncio.sleep(self.config.status_seconds)
             observed_at = utc_now()
@@ -623,6 +639,21 @@ class BinanceR4P0Collector:
                 )
 
     async def _epoch_supervisor(self) -> None:
+        try:
+            await self._epoch_supervisor_body()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.failure_counts["epoch_supervisor"] += 1
+            log.exception(
+                "collector.supervisor.failed lane=epoch error=%s detail=%r",
+                type(exc).__name__,
+                str(exc),
+            )
+            self.stop.set()
+            raise
+
+    async def _epoch_supervisor_body(self) -> None:
         async with httpx.AsyncClient(
             base_url=REST_BASE_URL,
             timeout=httpx.Timeout(10.0),
@@ -802,9 +833,19 @@ class BinanceR4P0Collector:
                         symbol=symbol,
                         decision_epoch=epoch,
                     )
-                except Exception:
+                except Exception as exc:
                     # The request-level immutable attempt row already contains
                     # the terminal failure. Other missing sources still retry.
+                    self.failure_counts["epoch_retry"] += 1
+                    log.exception(
+                        "collector.epoch_retry.failed source=%s symbol=%s "
+                        "decision_epoch=%s error=%s detail=%r",
+                        source,
+                        symbol,
+                        iso_utc(epoch),
+                        type(exc).__name__,
+                        str(exc),
+                    )
                     continue
 
     async def _ws_supervisor(self, lane: str) -> None:
@@ -888,6 +929,8 @@ class BinanceR4P0Collector:
                     response_sha256=None,
                     terminal_status="TRANSPORT_ERROR",
                     error_type=type(exc).__name__,
+                    error_message=str(exc),
+                    error_traceback=traceback.format_exc(),
                     attempt_id=(
                         None if connected_at is not None else connect_attempt_id
                     ),
@@ -896,10 +939,12 @@ class BinanceR4P0Collector:
                 delay = min(60.0, 1.0 * (2 ** min(failure_attempt, 6)))
                 delay *= random.uniform(0.8, 1.2)
                 failure_attempt += 1
-                log.error(
-                    "collector.ws.disconnected reconnect_id=%s error=%s backoff_s=%.2f",
+                log.exception(
+                    "collector.ws.disconnected reconnect_id=%s error=%s "
+                    "detail=%r backoff_s=%.2f",
                     reconnect_id,
                     type(exc).__name__,
+                    str(exc),
                     delay,
                 )
                 await asyncio.sleep(delay)
@@ -1060,7 +1105,7 @@ class BinanceR4P0Collector:
                     delay = min(interval, 2.0 * (2 ** min(failure_attempt, 5)))
                     delay *= random.uniform(0.8, 1.2)
                     failure_attempt += 1
-                    log.error(
+                    log.exception(
                         "collector.poll.failed family=%s error=%s detail=%r backoff_s=%.2f",
                         family,
                         type(exc).__name__,
@@ -1131,73 +1176,118 @@ class BinanceR4P0Collector:
         path = "/futures/data/basis"
         assert_rest_target(path)
         started = utc_now()
-        response = await client.get(
-            path,
-            params={
-                "pair": symbol,
-                "contractType": "PERPETUAL",
-                "period": "5m",
-                # Re-read a bounded 8h20m window so a later successful request
-                # can repair transient holes before epoch finalization.
-                "limit": BASIS_RECOVERY_LIMIT,
-            },
+        params = {
+            "pair": symbol,
+            "contractType": "PERPETUAL",
+            "period": "5m",
+            # Re-read a bounded 8h20m window so a later successful request
+            # can repair transient holes before epoch finalization.
+            "limit": BASIS_RECOVERY_LIMIT,
+        }
+        target_epoch = decision_epoch_for_event(started)
+        attempt_id = self._begin_rest_attempt(
+            decision_epoch=target_epoch,
+            attempted_at=started,
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=("binance_usdm.basis",),
         )
-        completed = utc_now()
-        response.raise_for_status()
-        payload = response.json()
-        if not isinstance(payload, list):
-            raise ValueError(
-                f"invalid JSON shape from allowlisted path {path} symbol={symbol}"
-            )
-        if not payload:
-            raise MissingBasisDataError(
-                f"no basis observations from allowlisted path {path} symbol={symbol}"
-            )
-
-        rows: list[tuple[int, Mapping[str, Any], str]] = []
-        for item in payload:
-            if not isinstance(item, dict):
+        response_hash: str | None = None
+        response_body_summary: str | None = None
+        completed = started
+        inserted_count = 0
+        try:
+            response = await client.get(path, params=params)
+            completed = utc_now()
+            response_hash = sha256_bytes(response.content)
+            response_body_summary = self._response_body_summary(response.content)
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
                 raise ValueError(
-                    f"invalid basis row from allowlisted path {path} symbol={symbol}"
+                    f"invalid JSON shape from allowlisted path {path} symbol={symbol}"
                 )
-            pair = str(item.get("pair") or "").upper()
-            contract_type = str(item.get("contractType") or "").upper()
-            timestamp = item.get("timestamp")
-            event_time = epoch_ms(timestamp)
-            if pair != symbol or contract_type != "PERPETUAL" or event_time is None:
-                raise ValueError(
-                    f"invalid basis identity from allowlisted path {path} "
-                    f"symbol={symbol} pair={pair!r} contractType={contract_type!r} "
-                    f"timestamp={timestamp!r}"
+            if not payload:
+                raise MissingBasisDataError(
+                    f"no basis observations from allowlisted path {path} symbol={symbol}"
                 )
-            rows.append((int(timestamp), item, event_time))
 
-        collection_floor = self.store.first_event_time("binance_usdm.basis", symbol)
-        if collection_floor is None:
-            # This collector is not the seed-backfill lane. On first sight of a
-            # symbol, retain only the latest venue row and establish the live
-            # collection floor.
-            rows = [max(rows, key=lambda row: row[0])]
-        else:
-            rows = [row for row in rows if row[2] >= collection_floor]
+            rows: list[tuple[int, Mapping[str, Any], str]] = []
+            for item in payload:
+                if not isinstance(item, dict):
+                    raise ValueError(
+                        f"invalid basis row from allowlisted path {path} symbol={symbol}"
+                    )
+                pair = str(item.get("pair") or "").upper()
+                contract_type = str(item.get("contractType") or "").upper()
+                timestamp = item.get("timestamp")
+                event_time = epoch_ms(timestamp)
+                if pair != symbol or contract_type != "PERPETUAL" or event_time is None:
+                    raise ValueError(
+                        f"invalid basis identity from allowlisted path {path} "
+                        f"symbol={symbol} pair={pair!r} "
+                        f"contractType={contract_type!r} timestamp={timestamp!r}"
+                    )
+                rows.append((int(timestamp), item, event_time))
 
-        reconnect_id = f"{self.run_id}:rest:{path}"
-        for timestamp, item, event_time in sorted(rows, key=lambda row: row[0]):
-            inserted = self.store.append(
-                source="binance_usdm.basis",
+            collection_floor = self.store.first_event_time("binance_usdm.basis", symbol)
+            if collection_floor is None:
+                # This collector is not the seed-backfill lane. On first sight
+                # of a symbol, retain only the latest venue row and establish
+                # the live collection floor.
+                rows = [max(rows, key=lambda row: row[0])]
+            else:
+                rows = [row for row in rows if row[2] >= collection_floor]
+
+            reconnect_id = f"{self.run_id}:rest:{path}"
+            for timestamp, item, event_time in sorted(rows, key=lambda row: row[0]):
+                inserted = self.store.append(
+                    source="binance_usdm.basis",
+                    symbol=symbol,
+                    raw_payload=item,
+                    local_receive_time=completed,
+                    run_id=self.run_id,
+                    event_time=event_time,
+                    transaction_time=None,
+                    request_started_at=iso_utc(started),
+                    request_completed_at=iso_utc(completed),
+                    sequence_or_trade_id=str(timestamp),
+                    gap_detected=False,
+                    reconnect_id=reconnect_id,
+                )
+                self._count_result("binance_usdm.basis", inserted)
+                inserted_count += int(inserted)
+        except Exception as exc:
+            self._append_rest_attempt(
+                decision_epoch=target_epoch,
+                attempted_at=started,
+                completed_at=completed,
+                path=path,
+                params=params,
                 symbol=symbol,
-                raw_payload=item,
-                local_receive_time=completed,
-                run_id=self.run_id,
-                event_time=event_time,
-                transaction_time=None,
-                request_started_at=iso_utc(started),
-                request_completed_at=iso_utc(completed),
-                sequence_or_trade_id=str(timestamp),
-                gap_detected=False,
-                reconnect_id=reconnect_id,
+                sources=("binance_usdm.basis",),
+                response_hash=response_hash,
+                terminal_status=self._attempt_failure_status(exc),
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+                error_traceback=traceback.format_exc(),
+                response_body_summary=response_body_summary,
+                attempt_id=attempt_id,
             )
-            self._count_result("binance_usdm.basis", inserted)
+            raise
+        self._append_rest_attempt(
+            decision_epoch=target_epoch,
+            attempted_at=started,
+            completed_at=completed,
+            path=path,
+            params=params,
+            symbol=symbol,
+            sources=("binance_usdm.basis",),
+            response_hash=response_hash,
+            terminal_status=("SUCCESS" if inserted_count else "EXACT_DUPLICATE"),
+            attempt_id=attempt_id,
+        )
 
     async def _rest_premium_kline(
         self,
@@ -1220,11 +1310,13 @@ class BinanceR4P0Collector:
             sources=("binance_usdm.premiumIndexKline1m",),
         )
         response_hash: str | None = None
+        response_body_summary: str | None = None
         completed = started
         try:
             response = await client.get(path, params=params)
             completed = utc_now()
             response_hash = sha256_bytes(response.content)
+            response_body_summary = self._response_body_summary(response.content)
             response.raise_for_status()
             payload = response.json()
             if not isinstance(payload, list):
@@ -1268,6 +1360,9 @@ class BinanceR4P0Collector:
                 response_hash=response_hash,
                 terminal_status=self._attempt_failure_status(exc),
                 error_type=type(exc).__name__,
+                error_message=str(exc),
+                error_traceback=traceback.format_exc(),
+                response_body_summary=response_body_summary,
                 attempt_id=attempt_id,
             )
             raise
@@ -1307,6 +1402,7 @@ class BinanceR4P0Collector:
             sources=output_sources,
         )
         response_hash: str | None = None
+        response_body_summary: str | None = None
         completed = started
         inserted_any = False
         all_duplicates = True
@@ -1314,6 +1410,7 @@ class BinanceR4P0Collector:
             response = await client.get(path, params=params)
             completed = utc_now()
             response_hash = sha256_bytes(response.content)
+            response_body_summary = self._response_body_summary(response.content)
             response.raise_for_status()
             payload = response.json()
             if isinstance(payload, str) or not isinstance(payload, (dict, list)):
@@ -1367,6 +1464,9 @@ class BinanceR4P0Collector:
                 response_hash=response_hash,
                 terminal_status=self._attempt_failure_status(exc),
                 error_type=type(exc).__name__,
+                error_message=str(exc),
+                error_traceback=traceback.format_exc(),
+                response_body_summary=response_body_summary,
                 attempt_id=attempt_id,
             )
             raise
@@ -1451,12 +1551,14 @@ class BinanceR4P0Collector:
             sources=(source,),
         )
         response_hash: str | None = None
+        response_body_summary: str | None = None
         completed = started
         inserted_count = 0
         try:
             response = await client.get(path, params=params)
             completed = utc_now()
             response_hash = sha256_bytes(response.content)
+            response_body_summary = self._response_body_summary(response.content)
             response.raise_for_status()
             payload = response.json()
             if not isinstance(payload, list):
@@ -1515,6 +1617,9 @@ class BinanceR4P0Collector:
                 response_hash=response_hash,
                 terminal_status=self._attempt_failure_status(exc),
                 error_type=type(exc).__name__,
+                error_message=str(exc),
+                error_traceback=traceback.format_exc(),
+                response_body_summary=response_body_summary,
                 attempt_id=attempt_id,
             )
             raise
@@ -1539,6 +1644,13 @@ class BinanceR4P0Collector:
             return "TRANSPORT_ERROR"
         return "INVALID_RESPONSE"
 
+    @staticmethod
+    def _response_body_summary(content: bytes, *, limit: int = 4096) -> str:
+        decoded = content[:limit].decode("utf-8", errors="replace")
+        if len(content) > limit:
+            return f"{decoded}…[truncated {len(content) - limit} bytes]"
+        return decoded
+
     def _append_rest_attempt(
         self,
         *,
@@ -1552,6 +1664,9 @@ class BinanceR4P0Collector:
         response_hash: str | None,
         terminal_status: str,
         error_type: str | None = None,
+        error_message: str | None = None,
+        error_traceback: str | None = None,
+        response_body_summary: str | None = None,
         attempt_id: str | None = None,
     ) -> None:
         request_identity = self._rest_request_identity(
@@ -1569,6 +1684,9 @@ class BinanceR4P0Collector:
             response_sha256=response_hash,
             terminal_status=terminal_status,
             error_type=error_type,
+            error_message=error_message,
+            error_traceback=error_traceback,
+            response_body_summary=response_body_summary,
             attempt_id=attempt_id,
         )
 

--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -75,6 +75,16 @@ PIT_COLUMNS: Final = (
 )
 COLLECTOR_VERSION: Final = "r4-p0-collector.v3"
 BASIS_RECOVERY_LIMIT: Final = 100
+# Binance's taker ratio endpoint maps requested boundaries to the preceding
+# 5-minute buckets ([S-5m, E-5m]); the other epoch-history endpoints use their
+# requested boundaries directly. Keep these source-specific vendor semantics
+# explicit so their recovery windows are not incorrectly normalized.
+EPOCH_HISTORY_REQUEST_OFFSET_MS: Final[dict[str, int]] = {
+    "binance_usdm.openInterestHist": 0,
+    "binance_usdm.basis": 0,
+    "binance_usdm.takerLongShortRatio": 5 * 60 * 1000,
+    "binance_usdm.premiumIndexKline1m": 0,
+}
 EXPECTED_SOURCES: Final = frozenset(
     {
         "binance_usdm.aggTrade",
@@ -1496,14 +1506,17 @@ class BinanceR4P0Collector:
         interval_start = decision_epoch - dt.timedelta(hours=4)
         start_ms = int(interval_start.timestamp() * 1000)
         end_ms = int(decision_epoch.timestamp() * 1000) - 1
+        request_offset_ms = EPOCH_HISTORY_REQUEST_OFFSET_MS[source]
+        request_start_ms = start_ms + request_offset_ms
+        request_end_ms = end_ms + request_offset_ms
         request_by_source: dict[str, tuple[str, dict[str, Any]]] = {
             "binance_usdm.openInterestHist": (
                 "/futures/data/openInterestHist",
                 {
                     "symbol": symbol,
                     "period": "5m",
-                    "startTime": start_ms,
-                    "endTime": end_ms,
+                    "startTime": request_start_ms,
+                    "endTime": request_end_ms,
                     "limit": 500,
                 },
             ),
@@ -1513,8 +1526,8 @@ class BinanceR4P0Collector:
                     "pair": symbol,
                     "contractType": "PERPETUAL",
                     "period": "5m",
-                    "startTime": start_ms,
-                    "endTime": end_ms,
+                    "startTime": request_start_ms,
+                    "endTime": request_end_ms,
                     "limit": 500,
                 },
             ),
@@ -1523,8 +1536,8 @@ class BinanceR4P0Collector:
                 {
                     "symbol": symbol,
                     "period": "5m",
-                    "startTime": start_ms,
-                    "endTime": end_ms,
+                    "startTime": request_start_ms,
+                    "endTime": request_end_ms,
                     "limit": 500,
                 },
             ),
@@ -1533,8 +1546,8 @@ class BinanceR4P0Collector:
                 {
                     "symbol": symbol,
                     "interval": "1m",
-                    "startTime": start_ms,
-                    "endTime": end_ms,
+                    "startTime": request_start_ms,
+                    "endTime": request_end_ms,
                     "limit": 500,
                 },
             ),

--- a/app/services/brokers/binance/r4_p0_hardening.py
+++ b/app/services/brokers/binance/r4_p0_hardening.py
@@ -31,7 +31,7 @@ DEFAULT_POLICY_HASH: Final = (
     "b3ee7db2f4cd8f76522a9c66ca8201177a01c24bbbd3876f53da4fb2f7c14a94"
 )
 DEFAULT_T0: Final = dt.datetime(2026, 7, 27, tzinfo=dt.UTC)
-FINALIZER_VERSION: Final = "r4-p0-epoch-finalizer.v1"
+FINALIZER_VERSION: Final = "r4-p0-epoch-finalizer.v2"
 
 FINAL_COMPLETE: Final = "FINAL_COMPLETE"
 FINAL_MISSING: Final = "FINAL_MISSING"
@@ -64,6 +64,12 @@ SOURCE_SCHEMA_FIELDS: Final[dict[str, tuple[str, ...]]] = {
     "binance_usdm.premiumIndex": ("markPrice", "indexPrice"),
     "binance_usdm.premiumIndexKline1m": (),
     "binance_usdm.predictedFunding": ("lastFundingRate",),
+}
+SOURCE_CADENCE_SECONDS: Final[dict[str, int]] = {
+    "binance_usdm.basis": 5 * 60,
+    "binance_usdm.openInterestHist": 5 * 60,
+    "binance_usdm.premiumIndexKline1m": 60,
+    "binance_usdm.takerLongShortRatio": 5 * 60,
 }
 
 
@@ -173,6 +179,11 @@ class EpochPolicy:
                         source: SOURCE_SCHEMA_FIELDS.get(source, ())
                         for source in self.required_sources
                     },
+                    "source_cadence_seconds": {
+                        source: SOURCE_CADENCE_SECONDS[source]
+                        for source in self.required_sources
+                        if source in SOURCE_CADENCE_SECONDS
+                    },
                     "symbols": self.symbols,
                 }
             )
@@ -267,7 +278,10 @@ class EpochLedger:
                     'DEADLINE_EXPIRED'
                 )
             ),
-            error_type TEXT
+            error_type TEXT,
+            error_message TEXT,
+            error_traceback TEXT,
+            response_body_summary TEXT
         );
         CREATE INDEX IF NOT EXISTS ix_collector_attempt_epoch
             ON collector_attempts (
@@ -365,6 +379,19 @@ class EpochLedger:
             + _trigger_sql("collector_heartbeats")
             + _trigger_sql("collector_alert_events")
         )
+        attempt_columns = {
+            row["name"]
+            for row in self.db.execute("PRAGMA table_info(collector_attempts)")
+        }
+        for column in (
+            "error_message",
+            "error_traceback",
+            "response_body_summary",
+        ):
+            if column not in attempt_columns:
+                self.db.execute(
+                    f"ALTER TABLE collector_attempts ADD COLUMN {column} TEXT"
+                )
         self.db.commit()
 
     def ensure_open_rows(
@@ -467,6 +494,9 @@ class EpochLedger:
         response_sha256: str | None,
         terminal_status: str,
         error_type: str | None = None,
+        error_message: str | None = None,
+        error_traceback: str | None = None,
+        response_body_summary: str | None = None,
         attempt_id: str | None = None,
     ) -> str:
         if terminal_status not in TERMINAL_STATUSES:
@@ -496,8 +526,9 @@ class EpochLedger:
                 attempt_id, study_id, policy_hash, collector_instance_id,
                 decision_epoch_utc, finalize_at, attempted_at, completed_at,
                 request_identity_sha256, request_identity_json,
-                response_sha256, terminal_status, error_type
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                response_sha256, terminal_status, error_type, error_message,
+                error_traceback, response_body_summary
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 attempt_id,
@@ -513,6 +544,9 @@ class EpochLedger:
                 response_sha256,
                 terminal_status,
                 error_type,
+                error_message,
+                error_traceback,
+                response_body_summary,
             ),
         )
         self.db.commit()
@@ -666,6 +700,10 @@ class EpochLedger:
         self.db.commit()
 
 
+class RawPITReadError(RuntimeError):
+    """A required local or replica PIT artifact could not be read."""
+
+
 class RawPITReader:
     """Deterministically merge the local raw ledger and read-only replicas."""
 
@@ -727,27 +765,37 @@ class RawPITReader:
         interval_start = iso_utc(decision_epoch - dt.timedelta(hours=EPOCH_HOURS))
         interval_end = iso_utc(decision_epoch)
         deadline = iso_utc(received_by) if received_by is not None else None
-        rows = self._query(
-            self.local_connection,
-            symbol=symbol,
-            interval_start=interval_start,
-            interval_end=interval_end,
-            deadline=deadline,
-        )
+        try:
+            rows = self._query(
+                self.local_connection,
+                symbol=symbol,
+                interval_start=interval_start,
+                interval_end=interval_end,
+                deadline=deadline,
+            )
+        except sqlite3.Error as exc:
+            raise RawPITReadError(
+                f"failed to read local PIT artifact {self.local_path}: {exc}"
+            ) from exc
         for path in self.replica_paths:
             if not path.is_file():
                 continue
             uri = f"file:{urllib.parse.quote(str(path))}?mode=ro"
-            with sqlite3.connect(uri, uri=True) as replica:
-                rows.extend(
-                    self._query(
-                        replica,
-                        symbol=symbol,
-                        interval_start=interval_start,
-                        interval_end=interval_end,
-                        deadline=deadline,
+            try:
+                with sqlite3.connect(uri, uri=True) as replica:
+                    rows.extend(
+                        self._query(
+                            replica,
+                            symbol=symbol,
+                            interval_start=interval_start,
+                            interval_end=interval_end,
+                            deadline=deadline,
+                        )
                     )
-                )
+            except sqlite3.Error as exc:
+                raise RawPITReadError(
+                    f"failed to read replica PIT artifact {path}: {exc}"
+                ) from exc
         return rows
 
 
@@ -816,6 +864,24 @@ def _source_identity(row: Mapping[str, Any]) -> str:
     return sha256_text(canonical_json(identity))
 
 
+def _observation_slot(
+    event_time: Any,
+    *,
+    interval_start: dt.datetime,
+    cadence_seconds: int,
+) -> int | None:
+    if not isinstance(event_time, str):
+        return None
+    try:
+        observed_at = parse_utc(event_time)
+    except ValueError:
+        return None
+    offset_seconds = (observed_at - interval_start).total_seconds()
+    if not 0 <= offset_seconds < EPOCH_SECONDS:
+        return None
+    return int(offset_seconds // cadence_seconds)
+
+
 class DeterministicEpochFinalizer:
     def __init__(self, ledger: EpochLedger, raw_reader: RawPITReader) -> None:
         self.ledger = ledger
@@ -832,6 +898,7 @@ class DeterministicEpochFinalizer:
         str,
     ]:
         deadline = finalize_at(decision_epoch)
+        interval_start = decision_epoch - dt.timedelta(hours=EPOCH_HOURS)
         rows = self.raw_reader.rows_for_epoch(
             symbol=symbol,
             decision_epoch=decision_epoch,
@@ -853,6 +920,7 @@ class DeterministicEpochFinalizer:
             valid_evidence: set[tuple[str, str]] = set()
             invalid_evidence: set[tuple[str, str]] = set()
             gap_flags: dict[tuple[str, str], set[bool]] = defaultdict(set)
+            evidence_slots: dict[tuple[str, str], int] = {}
             for row in source_rows:
                 identity = _source_identity(row)
                 payload_hash = str(row["raw_payload_sha256"])
@@ -871,6 +939,15 @@ class DeterministicEpochFinalizer:
                     invalid_evidence.add(evidence_key)
                 else:
                     valid_evidence.add(evidence_key)
+                    cadence_seconds = SOURCE_CADENCE_SECONDS.get(source)
+                    if cadence_seconds is not None:
+                        slot = _observation_slot(
+                            row.get("event_time"),
+                            interval_start=interval_start,
+                            cadence_seconds=cadence_seconds,
+                        )
+                        if slot is not None:
+                            evidence_slots[evidence_key] = slot
             uncovered_gaps = sorted(
                 [identity, payload_hash]
                 for (identity, payload_hash), flags in gap_flags.items()
@@ -879,23 +956,59 @@ class DeterministicEpochFinalizer:
             conflicting_ids = sorted(
                 identity for identity, hashes in identities.items() if len(hashes) > 1
             )
+            cadence_seconds = SOURCE_CADENCE_SECONDS.get(source)
+            expected_observations = (
+                EPOCH_SECONDS // cadence_seconds
+                if cadence_seconds is not None
+                else None
+            )
+            covered_slots = sorted(
+                {
+                    slot
+                    for evidence_key, slot in evidence_slots.items()
+                    if evidence_key in valid_evidence
+                    and gap_flags[evidence_key] != {True}
+                }
+            )
+            missing_slots = (
+                sorted(set(range(expected_observations)) - set(covered_slots))
+                if expected_observations is not None
+                else []
+            )
             if conflicting_ids:
                 conflicts.append(source)
                 state = "CONFLICT"
             elif not source_rows:
                 missing.append(source)
                 state = "MISSING"
-            elif invalid_evidence or uncovered_gaps or not valid_evidence:
+            elif (
+                invalid_evidence
+                or uncovered_gaps
+                or not valid_evidence
+                or missing_slots
+            ):
                 invalid.append(source)
                 state = "INVALID"
             else:
                 state = "COMPLETE"
             source_evidence[source] = {
                 "conflicting_source_identities": conflicting_ids,
+                "covered_observation_count": (
+                    len(covered_slots) if expected_observations is not None else None
+                ),
+                "expected_observation_count": expected_observations,
                 "invalid_source_identity_payload_hashes": [
                     [identity, payload_hash]
                     for identity, payload_hash in sorted(invalid_evidence)
                 ],
+                "missing_observation_slots": [
+                    iso_utc(
+                        interval_start + dt.timedelta(seconds=slot * cadence_seconds)
+                    )
+                    for slot in missing_slots
+                ]
+                if cadence_seconds is not None
+                else [],
                 "source_identity_payload_hashes": [
                     [identity, payload_hash]
                     for identity, payload_hash in sorted(evidence_rows)

--- a/app/services/brokers/binance/r4_p0_hardening.py
+++ b/app/services/brokers/binance/r4_p0_hardening.py
@@ -1,0 +1,1270 @@
+"""Immutable epoch ledger and deterministic finalizer for the R4 P0 collector.
+
+This module contains infrastructure only.  It does not calculate research
+features, scores, candidates, or stage decisions.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import logging
+import math
+import sqlite3
+import urllib.parse
+import uuid
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Literal
+
+import httpx
+
+log = logging.getLogger("r4_p0_collector")
+
+EPOCH_HOURS: Final = 4
+EPOCH_SECONDS: Final = EPOCH_HOURS * 60 * 60
+DEFAULT_STUDY_ID: Final = "R4.1-DFC-4H"
+DEFAULT_POLICY_HASH: Final = (
+    "b3ee7db2f4cd8f76522a9c66ca8201177a01c24bbbd3876f53da4fb2f7c14a94"
+)
+DEFAULT_T0: Final = dt.datetime(2026, 7, 27, tzinfo=dt.UTC)
+FINALIZER_VERSION: Final = "r4-p0-epoch-finalizer.v1"
+
+FINAL_COMPLETE: Final = "FINAL_COMPLETE"
+FINAL_MISSING: Final = "FINAL_MISSING"
+FINAL_CONFLICT: Final = "FINAL_CONFLICT"
+FinalStatus = Literal["FINAL_COMPLETE", "FINAL_MISSING", "FINAL_CONFLICT"]
+
+TERMINAL_STATUSES: Final = frozenset(
+    {
+        "SUCCESS",
+        "EXACT_DUPLICATE",
+        "HTTP_ERROR",
+        "TRANSPORT_ERROR",
+        "INVALID_RESPONSE",
+        "DEADLINE_EXPIRED",
+    }
+)
+
+SOURCE_SCHEMA_FIELDS: Final[dict[str, tuple[str, ...]]] = {
+    "binance_usdm.aggTrade": ("p", "q"),
+    "binance_usdm.bookTicker": ("b", "B", "a", "A"),
+    "binance_usdm.depth5": ("b", "a"),
+    "binance_usdm.openInterest": ("openInterest",),
+    "binance_usdm.openInterestHist": ("sumOpenInterest",),
+    "binance_usdm.basis": ("basis",),
+    "binance_usdm.takerLongShortRatio": (
+        "buySellRatio",
+        "buyVol",
+        "sellVol",
+    ),
+    "binance_usdm.premiumIndex": ("markPrice", "indexPrice"),
+    "binance_usdm.premiumIndexKline1m": (),
+    "binance_usdm.predictedFunding": ("lastFundingRate",),
+}
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def iso_utc(value: dt.datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("naive datetime is forbidden")
+    return (
+        value.astimezone(dt.UTC)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def parse_utc(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("naive timestamp is forbidden")
+    return parsed.astimezone(dt.UTC)
+
+
+def floor_epoch(value: dt.datetime) -> dt.datetime:
+    value = value.astimezone(dt.UTC)
+    hour = value.hour - (value.hour % EPOCH_HOURS)
+    return value.replace(hour=hour, minute=0, second=0, microsecond=0)
+
+
+def decision_epoch_for_event(value: dt.datetime) -> dt.datetime:
+    """Return e for the half-open source interval [e-4h, e).
+
+    An event exactly on a four-hour boundary belongs to the next epoch.
+    """
+
+    return floor_epoch(value) + dt.timedelta(hours=EPOCH_HOURS)
+
+
+def finalize_at(decision_epoch: dt.datetime) -> dt.datetime:
+    return decision_epoch.astimezone(dt.UTC) + dt.timedelta(hours=EPOCH_HOURS)
+
+
+def scheduled_epochs(
+    start: dt.datetime, end_inclusive: dt.datetime
+) -> Iterable[dt.datetime]:
+    current = floor_epoch(start)
+    end = floor_epoch(end_inclusive)
+    while current <= end:
+        yield current
+        current += dt.timedelta(hours=EPOCH_HOURS)
+
+
+def _trigger_sql(table: str) -> str:
+    return f"""
+    CREATE TRIGGER IF NOT EXISTS {table}_no_update
+    BEFORE UPDATE ON {table}
+    BEGIN
+        SELECT RAISE(ABORT, '{table} is append-only');
+    END;
+    CREATE TRIGGER IF NOT EXISTS {table}_no_delete
+    BEFORE DELETE ON {table}
+    BEGIN
+        SELECT RAISE(ABORT, '{table} is append-only');
+    END;
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class EpochPolicy:
+    required_sources: tuple[str, ...]
+    symbols: tuple[str, ...]
+    study_id: str = DEFAULT_STUDY_ID
+    policy_hash: str = DEFAULT_POLICY_HASH
+    t0: dt.datetime = DEFAULT_T0
+
+    def __post_init__(self) -> None:
+        if not self.required_sources or not self.symbols:
+            raise ValueError("epoch policy requires sources and symbols")
+        if tuple(sorted(set(self.required_sources))) != self.required_sources:
+            raise ValueError("required_sources must be unique and sorted")
+        if tuple(sorted(set(self.symbols))) != self.symbols:
+            raise ValueError("symbols must be unique and sorted")
+        if self.t0.tzinfo is None or floor_epoch(self.t0) != self.t0:
+            raise ValueError("t0 must be an aware UTC four-hour boundary")
+
+    @property
+    def source_manifest_hash(self) -> str:
+        return sha256_text(
+            canonical_json(
+                {
+                    "required_sources": self.required_sources,
+                    "source_schema_fields": {
+                        source: SOURCE_SCHEMA_FIELDS.get(source, ())
+                        for source in self.required_sources
+                    },
+                    "symbols": self.symbols,
+                }
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizationResult:
+    study_id: str
+    policy_hash: str
+    symbol: str
+    decision_epoch_utc: str
+    finalize_at: str
+    final_status: FinalStatus
+    evaluation_hash: str
+    missing_sources: tuple[str, ...]
+    conflict_sources: tuple[str, ...]
+    invalid_sources: tuple[str, ...]
+    inserted: bool
+
+
+class FinalizationInvariantError(RuntimeError):
+    """Raised when immutable finalization disagrees with reconstructed input."""
+
+
+class EpochLedger:
+    """Append-only operational ledger sharing the raw collector connection."""
+
+    def __init__(self, connection: sqlite3.Connection, policy: EpochPolicy) -> None:
+        self.db = connection
+        self.db.row_factory = sqlite3.Row
+        self.policy = policy
+        self._configure()
+
+    def _configure(self) -> None:
+        tables = """
+        CREATE TABLE IF NOT EXISTS epoch_source_events (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            source_name TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            decision_epoch_utc TEXT NOT NULL,
+            finalize_at TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            collector_instance_id TEXT NOT NULL,
+            details_sha256 TEXT NOT NULL,
+            details_json TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_epoch_source_open
+            ON epoch_source_events (
+                study_id, policy_hash, source_name, symbol,
+                decision_epoch_utc, event_type
+            ) WHERE event_type = 'OPEN';
+
+        CREATE TABLE IF NOT EXISTS collector_attempt_starts (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            attempt_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            collector_instance_id TEXT NOT NULL,
+            decision_epoch_utc TEXT NOT NULL,
+            finalize_at TEXT NOT NULL,
+            attempted_at TEXT NOT NULL,
+            request_identity_sha256 TEXT NOT NULL,
+            request_identity_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS ix_collector_attempt_start_epoch
+            ON collector_attempt_starts (
+                study_id, policy_hash, decision_epoch_utc, append_id
+            );
+
+        CREATE TABLE IF NOT EXISTS collector_attempts (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            attempt_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            collector_instance_id TEXT NOT NULL,
+            decision_epoch_utc TEXT NOT NULL,
+            finalize_at TEXT NOT NULL,
+            attempted_at TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            request_identity_sha256 TEXT NOT NULL,
+            request_identity_json TEXT NOT NULL,
+            response_sha256 TEXT,
+            terminal_status TEXT NOT NULL CHECK (
+                terminal_status IN (
+                    'SUCCESS', 'EXACT_DUPLICATE', 'HTTP_ERROR',
+                    'TRANSPORT_ERROR', 'INVALID_RESPONSE',
+                    'DEADLINE_EXPIRED'
+                )
+            ),
+            error_type TEXT
+        );
+        CREATE INDEX IF NOT EXISTS ix_collector_attempt_epoch
+            ON collector_attempts (
+                study_id, policy_hash, decision_epoch_utc, append_id
+            );
+
+        CREATE TABLE IF NOT EXISTS symbol_epoch_finalizations (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            finalization_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            source_manifest_hash TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            decision_epoch_utc TEXT NOT NULL,
+            finalize_at TEXT NOT NULL,
+            finalized_at TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            final_status TEXT NOT NULL CHECK (
+                final_status IN (
+                    'FINAL_COMPLETE', 'FINAL_MISSING', 'FINAL_CONFLICT'
+                )
+            ),
+            missing_sources_json TEXT NOT NULL,
+            conflict_sources_json TEXT NOT NULL,
+            invalid_sources_json TEXT NOT NULL,
+            evaluation_hash TEXT NOT NULL,
+            evaluation_json TEXT NOT NULL,
+            finalizer_version TEXT NOT NULL,
+            UNIQUE (study_id, policy_hash, symbol, decision_epoch_utc)
+        );
+        CREATE INDEX IF NOT EXISTS ix_symbol_epoch_status
+            ON symbol_epoch_finalizations (
+                study_id, policy_hash, final_status, decision_epoch_utc
+            );
+
+        CREATE TABLE IF NOT EXISTS late_only_corrections (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            correction_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            decision_epoch_utc TEXT NOT NULL,
+            source_name TEXT NOT NULL,
+            raw_record_id TEXT NOT NULL,
+            raw_payload_sha256 TEXT NOT NULL,
+            received_at TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            correction_status TEXT NOT NULL CHECK (
+                correction_status = 'LATE_ONLY'
+            ),
+            UNIQUE (
+                study_id, policy_hash, symbol, decision_epoch_utc,
+                raw_record_id
+            )
+        );
+
+        CREATE TABLE IF NOT EXISTS collector_heartbeats (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            heartbeat_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            collector_instance_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            observed_at TEXT NOT NULL,
+            health_sha256 TEXT NOT NULL,
+            health_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS ix_collector_heartbeat_latest
+            ON collector_heartbeats (
+                study_id, policy_hash, collector_instance_id, append_id
+            );
+
+        CREATE TABLE IF NOT EXISTS collector_alert_events (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            alert_event_id TEXT NOT NULL UNIQUE,
+            alert_key TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            delivery_status TEXT,
+            error_type TEXT
+        );
+        CREATE INDEX IF NOT EXISTS ix_collector_alert_key
+            ON collector_alert_events (alert_key, append_id);
+        """
+        self.db.executescript(
+            tables
+            + _trigger_sql("epoch_source_events")
+            + _trigger_sql("collector_attempt_starts")
+            + _trigger_sql("collector_attempts")
+            + _trigger_sql("symbol_epoch_finalizations")
+            + _trigger_sql("late_only_corrections")
+            + _trigger_sql("collector_heartbeats")
+            + _trigger_sql("collector_alert_events")
+        )
+        self.db.commit()
+
+    def ensure_open_rows(
+        self, decision_epoch: dt.datetime, collector_instance_id: str, now: dt.datetime
+    ) -> None:
+        epoch_text = iso_utc(decision_epoch)
+        deadline_text = iso_utc(finalize_at(decision_epoch))
+        recorded_at = iso_utc(now)
+        self.db.execute("BEGIN IMMEDIATE")
+        try:
+            for symbol in self.policy.symbols:
+                for source in self.policy.required_sources:
+                    details = canonical_json(
+                        {
+                            "source_interval_end": epoch_text,
+                            "source_interval_start": iso_utc(
+                                decision_epoch - dt.timedelta(hours=EPOCH_HOURS)
+                            ),
+                        }
+                    )
+                    identity = canonical_json(
+                        {
+                            "decision_epoch_utc": epoch_text,
+                            "event_type": "OPEN",
+                            "policy_hash": self.policy.policy_hash,
+                            "source_name": source,
+                            "study_id": self.policy.study_id,
+                            "symbol": symbol,
+                        }
+                    )
+                    self.db.execute(
+                        """
+                        INSERT OR IGNORE INTO epoch_source_events (
+                            event_id, study_id, policy_hash, source_name,
+                            symbol, decision_epoch_utc, finalize_at, event_type,
+                            recorded_at, collector_instance_id,
+                            details_sha256, details_json
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'OPEN', ?, ?, ?, ?)
+                        """,
+                        (
+                            sha256_text(identity),
+                            self.policy.study_id,
+                            self.policy.policy_hash,
+                            source,
+                            symbol,
+                            epoch_text,
+                            deadline_text,
+                            recorded_at,
+                            collector_instance_id,
+                            sha256_text(details),
+                            details,
+                        ),
+                    )
+            self.db.commit()
+        except BaseException:
+            self.db.rollback()
+            raise
+
+    def begin_attempt(
+        self,
+        *,
+        collector_instance_id: str,
+        decision_epoch: dt.datetime,
+        attempted_at: dt.datetime,
+        request_identity: Mapping[str, Any],
+    ) -> str:
+        request_json = canonical_json(request_identity)
+        attempt_id = uuid.uuid4().hex
+        self.db.execute(
+            """
+            INSERT INTO collector_attempt_starts (
+                attempt_id, study_id, policy_hash, collector_instance_id,
+                decision_epoch_utc, finalize_at, attempted_at,
+                request_identity_sha256, request_identity_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                attempt_id,
+                self.policy.study_id,
+                self.policy.policy_hash,
+                collector_instance_id,
+                iso_utc(decision_epoch),
+                iso_utc(finalize_at(decision_epoch)),
+                iso_utc(attempted_at),
+                sha256_text(request_json),
+                request_json,
+            ),
+        )
+        self.db.commit()
+        return attempt_id
+
+    def append_attempt(
+        self,
+        *,
+        collector_instance_id: str,
+        decision_epoch: dt.datetime,
+        attempted_at: dt.datetime,
+        completed_at: dt.datetime,
+        request_identity: Mapping[str, Any],
+        response_sha256: str | None,
+        terminal_status: str,
+        error_type: str | None = None,
+        attempt_id: str | None = None,
+    ) -> str:
+        if terminal_status not in TERMINAL_STATUSES:
+            raise ValueError(f"invalid terminal status: {terminal_status}")
+        request_json = canonical_json(request_identity)
+        if attempt_id is None:
+            attempt_id = self.begin_attempt(
+                collector_instance_id=collector_instance_id,
+                decision_epoch=decision_epoch,
+                attempted_at=attempted_at,
+                request_identity=request_identity,
+            )
+        start = self.db.execute(
+            """
+            SELECT request_identity_sha256 FROM collector_attempt_starts
+            WHERE attempt_id = ?
+            """,
+            (attempt_id,),
+        ).fetchone()
+        if start is None or start["request_identity_sha256"] != sha256_text(
+            request_json
+        ):
+            raise ValueError("attempt terminal identity does not match start")
+        self.db.execute(
+            """
+            INSERT INTO collector_attempts (
+                attempt_id, study_id, policy_hash, collector_instance_id,
+                decision_epoch_utc, finalize_at, attempted_at, completed_at,
+                request_identity_sha256, request_identity_json,
+                response_sha256, terminal_status, error_type
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                attempt_id,
+                self.policy.study_id,
+                self.policy.policy_hash,
+                collector_instance_id,
+                iso_utc(decision_epoch),
+                iso_utc(finalize_at(decision_epoch)),
+                iso_utc(attempted_at),
+                iso_utc(completed_at),
+                sha256_text(request_json),
+                request_json,
+                response_sha256,
+                terminal_status,
+                error_type,
+            ),
+        )
+        self.db.commit()
+        return attempt_id
+
+    def append_heartbeat(
+        self,
+        *,
+        collector_instance_id: str,
+        run_id: str,
+        observed_at: dt.datetime,
+        health: Mapping[str, Any],
+    ) -> None:
+        health_json = canonical_json(health)
+        self.db.execute(
+            """
+            INSERT INTO collector_heartbeats (
+                heartbeat_id, study_id, policy_hash, collector_instance_id,
+                run_id, observed_at, health_sha256, health_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                uuid.uuid4().hex,
+                self.policy.study_id,
+                self.policy.policy_hash,
+                collector_instance_id,
+                run_id,
+                iso_utc(observed_at),
+                sha256_text(health_json),
+                health_json,
+            ),
+        )
+        self.db.commit()
+
+    def finalization_row(
+        self, symbol: str, decision_epoch: dt.datetime
+    ) -> sqlite3.Row | None:
+        return self.db.execute(
+            """
+            SELECT * FROM symbol_epoch_finalizations
+            WHERE study_id = ? AND policy_hash = ? AND symbol = ?
+              AND decision_epoch_utc = ?
+            """,
+            (
+                self.policy.study_id,
+                self.policy.policy_hash,
+                symbol,
+                iso_utc(decision_epoch),
+            ),
+        ).fetchone()
+
+    def append_finalization(
+        self,
+        *,
+        symbol: str,
+        decision_epoch: dt.datetime,
+        recorded_at: dt.datetime,
+        final_status: FinalStatus,
+        missing_sources: Sequence[str],
+        conflict_sources: Sequence[str],
+        invalid_sources: Sequence[str],
+        evaluation_hash: str,
+        evaluation_json: str,
+    ) -> None:
+        identity = canonical_json(
+            {
+                "decision_epoch_utc": iso_utc(decision_epoch),
+                "policy_hash": self.policy.policy_hash,
+                "study_id": self.policy.study_id,
+                "symbol": symbol,
+            }
+        )
+        deadline = finalize_at(decision_epoch)
+        self.db.execute(
+            """
+            INSERT INTO symbol_epoch_finalizations (
+                finalization_id, study_id, policy_hash,
+                source_manifest_hash, symbol, decision_epoch_utc,
+                finalize_at, finalized_at, recorded_at, final_status,
+                missing_sources_json, conflict_sources_json,
+                invalid_sources_json, evaluation_hash, evaluation_json,
+                finalizer_version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                sha256_text(identity),
+                self.policy.study_id,
+                self.policy.policy_hash,
+                self.policy.source_manifest_hash,
+                symbol,
+                iso_utc(decision_epoch),
+                iso_utc(deadline),
+                iso_utc(deadline),
+                iso_utc(recorded_at),
+                final_status,
+                canonical_json(list(missing_sources)),
+                canonical_json(list(conflict_sources)),
+                canonical_json(list(invalid_sources)),
+                evaluation_hash,
+                evaluation_json,
+                FINALIZER_VERSION,
+            ),
+        )
+        self.db.commit()
+
+    def alert_event_exists(
+        self, alert_key: str, event_type: str, delivery_status: str | None = None
+    ) -> bool:
+        sql = """
+            SELECT 1 FROM collector_alert_events
+            WHERE alert_key = ? AND event_type = ?
+        """
+        params: list[str] = [alert_key, event_type]
+        if delivery_status is not None:
+            sql += " AND delivery_status = ?"
+            params.append(delivery_status)
+        sql += " LIMIT 1"
+        return self.db.execute(sql, params).fetchone() is not None
+
+    def append_alert_event(
+        self,
+        *,
+        alert_key: str,
+        event_type: str,
+        severity: str,
+        recorded_at: dt.datetime,
+        payload: Mapping[str, Any],
+        delivery_status: str | None = None,
+        error_type: str | None = None,
+    ) -> None:
+        payload_json = canonical_json(payload)
+        self.db.execute(
+            """
+            INSERT INTO collector_alert_events (
+                alert_event_id, alert_key, event_type, severity, recorded_at,
+                payload_sha256, payload_json, delivery_status, error_type
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                uuid.uuid4().hex,
+                alert_key,
+                event_type,
+                severity,
+                iso_utc(recorded_at),
+                sha256_text(payload_json),
+                payload_json,
+                delivery_status,
+                error_type,
+            ),
+        )
+        self.db.commit()
+
+
+class RawPITReader:
+    """Deterministically merge the local raw ledger and read-only replicas."""
+
+    def __init__(
+        self,
+        local_connection: sqlite3.Connection,
+        local_path: Path,
+        replica_paths: Sequence[Path] = (),
+    ) -> None:
+        self.local_connection = local_connection
+        self.local_path = local_path.resolve()
+        self.replica_paths = tuple(
+            sorted(
+                {
+                    path.expanduser().resolve()
+                    for path in replica_paths
+                    if path.expanduser().resolve() != self.local_path
+                },
+                key=str,
+            )
+        )
+
+    @staticmethod
+    def _query(
+        connection: sqlite3.Connection,
+        *,
+        symbol: str,
+        interval_start: str,
+        interval_end: str,
+        deadline: str | None,
+    ) -> list[dict[str, Any]]:
+        connection.row_factory = sqlite3.Row
+        deadline_clause = "AND local_receive_time <= ?" if deadline is not None else ""
+        params: list[str] = [symbol, interval_start, interval_end]
+        if deadline is not None:
+            params.append(deadline)
+        rows = connection.execute(
+            f"""
+            SELECT record_id, source, symbol, event_time, transaction_time,
+                   local_receive_time, sequence_or_trade_id,
+                   raw_payload_sha256, gap_detected, run_id, raw_payload
+            FROM pit_records
+            WHERE symbol = ?
+              AND event_time >= ?
+              AND event_time < ?
+              {deadline_clause}
+            """,
+            params,
+        )
+        return [dict(row) for row in rows]
+
+    def rows_for_epoch(
+        self,
+        *,
+        symbol: str,
+        decision_epoch: dt.datetime,
+        received_by: dt.datetime | None,
+    ) -> list[dict[str, Any]]:
+        interval_start = iso_utc(decision_epoch - dt.timedelta(hours=EPOCH_HOURS))
+        interval_end = iso_utc(decision_epoch)
+        deadline = iso_utc(received_by) if received_by is not None else None
+        rows = self._query(
+            self.local_connection,
+            symbol=symbol,
+            interval_start=interval_start,
+            interval_end=interval_end,
+            deadline=deadline,
+        )
+        for path in self.replica_paths:
+            if not path.is_file():
+                continue
+            uri = f"file:{urllib.parse.quote(str(path))}?mode=ro"
+            with sqlite3.connect(uri, uri=True) as replica:
+                rows.extend(
+                    self._query(
+                        replica,
+                        symbol=symbol,
+                        interval_start=interval_start,
+                        interval_end=interval_end,
+                        deadline=deadline,
+                    )
+                )
+        return rows
+
+
+def _finite_number(value: Any) -> bool:
+    if isinstance(value, bool) or value is None:
+        return False
+    try:
+        return math.isfinite(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
+def _finite_depth(value: Any) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    for level in value:
+        if (
+            not isinstance(level, list)
+            or len(level) < 2
+            or not _finite_number(level[0])
+            or not _finite_number(level[1])
+        ):
+            return False
+    return True
+
+
+def _payload_valid(source: str, payload: Any) -> bool:
+    if source == "binance_usdm.premiumIndexKline1m":
+        return (
+            isinstance(payload, list)
+            and len(payload) >= 7
+            and all(_finite_number(payload[index]) for index in range(1, 6))
+        )
+    if not isinstance(payload, dict):
+        return False
+    fields = SOURCE_SCHEMA_FIELDS.get(source)
+    if fields is None:
+        return False
+    for field in fields:
+        value = payload.get(field)
+        if source == "binance_usdm.depth5" and field in {"a", "b"}:
+            if not _finite_depth(value):
+                return False
+        elif not _finite_number(value):
+            return False
+    return True
+
+
+def _source_identity(row: Mapping[str, Any]) -> str:
+    source_event_id = row.get("sequence_or_trade_id")
+    if source_event_id is not None:
+        identity = {
+            "source_event_id": str(source_event_id),
+            "source_name": row["source"],
+            "symbol": row["symbol"],
+        }
+    else:
+        identity = {
+            "record_type": "PIT_OBSERVATION",
+            "source_event_time": row.get("event_time"),
+            "source_interval_end": row.get("event_time"),
+            "source_interval_start": row.get("event_time"),
+            "source_name": row["source"],
+            "symbol": row["symbol"],
+        }
+    return sha256_text(canonical_json(identity))
+
+
+class DeterministicEpochFinalizer:
+    def __init__(self, ledger: EpochLedger, raw_reader: RawPITReader) -> None:
+        self.ledger = ledger
+        self.raw_reader = raw_reader
+
+    def _evaluate(
+        self, symbol: str, decision_epoch: dt.datetime
+    ) -> tuple[
+        FinalStatus,
+        tuple[str, ...],
+        tuple[str, ...],
+        tuple[str, ...],
+        str,
+        str,
+    ]:
+        deadline = finalize_at(decision_epoch)
+        rows = self.raw_reader.rows_for_epoch(
+            symbol=symbol,
+            decision_epoch=decision_epoch,
+            received_by=deadline,
+        )
+        by_source: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            if row["source"] in self.ledger.policy.required_sources:
+                by_source[row["source"]].append(row)
+
+        missing: list[str] = []
+        conflicts: list[str] = []
+        invalid: list[str] = []
+        source_evidence: dict[str, Any] = {}
+        for source in self.ledger.policy.required_sources:
+            source_rows = by_source.get(source, [])
+            identities: dict[str, set[str]] = defaultdict(set)
+            evidence_rows: set[tuple[str, str]] = set()
+            valid_evidence: set[tuple[str, str]] = set()
+            invalid_evidence: set[tuple[str, str]] = set()
+            gap_flags: dict[tuple[str, str], set[bool]] = defaultdict(set)
+            for row in source_rows:
+                identity = _source_identity(row)
+                payload_hash = str(row["raw_payload_sha256"])
+                evidence_key = (identity, payload_hash)
+                identities[identity].add(payload_hash)
+                evidence_rows.add(evidence_key)
+                gap_flags[evidence_key].add(bool(row["gap_detected"]))
+                try:
+                    payload = json.loads(row["raw_payload"])
+                except (json.JSONDecodeError, TypeError):
+                    invalid_evidence.add(evidence_key)
+                    continue
+                if sha256_text(
+                    canonical_json(payload)
+                ) != payload_hash or not _payload_valid(source, payload):
+                    invalid_evidence.add(evidence_key)
+                else:
+                    valid_evidence.add(evidence_key)
+            uncovered_gaps = sorted(
+                [identity, payload_hash]
+                for (identity, payload_hash), flags in gap_flags.items()
+                if flags == {True}
+            )
+            conflicting_ids = sorted(
+                identity for identity, hashes in identities.items() if len(hashes) > 1
+            )
+            if conflicting_ids:
+                conflicts.append(source)
+                state = "CONFLICT"
+            elif not source_rows:
+                missing.append(source)
+                state = "MISSING"
+            elif invalid_evidence or uncovered_gaps or not valid_evidence:
+                invalid.append(source)
+                state = "INVALID"
+            else:
+                state = "COMPLETE"
+            source_evidence[source] = {
+                "conflicting_source_identities": conflicting_ids,
+                "invalid_source_identity_payload_hashes": [
+                    [identity, payload_hash]
+                    for identity, payload_hash in sorted(invalid_evidence)
+                ],
+                "source_identity_payload_hashes": [
+                    [identity, payload_hash]
+                    for identity, payload_hash in sorted(evidence_rows)
+                ],
+                "state": state,
+                "uncovered_gap_identity_payload_hashes": uncovered_gaps,
+                "valid_source_identity_payload_hashes": [
+                    [identity, payload_hash]
+                    for identity, payload_hash in sorted(valid_evidence)
+                ],
+            }
+
+        if conflicts:
+            status: FinalStatus = FINAL_CONFLICT
+        elif missing or invalid:
+            status = FINAL_MISSING
+        else:
+            status = FINAL_COMPLETE
+        evaluation = {
+            "decision_epoch_utc": iso_utc(decision_epoch),
+            "final_status": status,
+            "finalize_at": iso_utc(deadline),
+            "finalizer_version": FINALIZER_VERSION,
+            "policy_hash": self.ledger.policy.policy_hash,
+            "source_evidence": source_evidence,
+            "source_manifest_hash": self.ledger.policy.source_manifest_hash,
+            "study_id": self.ledger.policy.study_id,
+            "symbol": symbol,
+        }
+        evaluation_json = canonical_json(evaluation)
+        return (
+            status,
+            tuple(missing),
+            tuple(conflicts),
+            tuple(invalid),
+            sha256_text(evaluation_json),
+            evaluation_json,
+        )
+
+    def preview(self, symbol: str, decision_epoch: dt.datetime) -> FinalizationResult:
+        status, missing, conflicts, invalid, digest, _ = self._evaluate(
+            symbol, decision_epoch
+        )
+        return FinalizationResult(
+            study_id=self.ledger.policy.study_id,
+            policy_hash=self.ledger.policy.policy_hash,
+            symbol=symbol,
+            decision_epoch_utc=iso_utc(decision_epoch),
+            finalize_at=iso_utc(finalize_at(decision_epoch)),
+            final_status=status,
+            evaluation_hash=digest,
+            missing_sources=missing,
+            conflict_sources=conflicts,
+            invalid_sources=invalid,
+            inserted=False,
+        )
+
+    def finalize(
+        self,
+        symbol: str,
+        decision_epoch: dt.datetime,
+        *,
+        observed_at: dt.datetime,
+    ) -> FinalizationResult:
+        deadline = finalize_at(decision_epoch)
+        if observed_at < deadline:
+            raise ValueError(f"cannot finalize before {iso_utc(deadline)}")
+        status, missing, conflicts, invalid, digest, evaluation_json = self._evaluate(
+            symbol, decision_epoch
+        )
+        existing = self.ledger.finalization_row(symbol, decision_epoch)
+        if existing is not None:
+            if (
+                existing["evaluation_hash"] != digest
+                or existing["final_status"] != status
+            ):
+                raise FinalizationInvariantError(
+                    "reconstructed input disagrees with immutable finalization "
+                    f"for {symbol} {iso_utc(decision_epoch)}"
+                )
+            return FinalizationResult(
+                study_id=self.ledger.policy.study_id,
+                policy_hash=self.ledger.policy.policy_hash,
+                symbol=symbol,
+                decision_epoch_utc=iso_utc(decision_epoch),
+                finalize_at=iso_utc(deadline),
+                final_status=status,
+                evaluation_hash=digest,
+                missing_sources=missing,
+                conflict_sources=conflicts,
+                invalid_sources=invalid,
+                inserted=False,
+            )
+        self.ledger.append_finalization(
+            symbol=symbol,
+            decision_epoch=decision_epoch,
+            recorded_at=observed_at,
+            final_status=status,
+            missing_sources=missing,
+            conflict_sources=conflicts,
+            invalid_sources=invalid,
+            evaluation_hash=digest,
+            evaluation_json=evaluation_json,
+        )
+        return FinalizationResult(
+            study_id=self.ledger.policy.study_id,
+            policy_hash=self.ledger.policy.policy_hash,
+            symbol=symbol,
+            decision_epoch_utc=iso_utc(decision_epoch),
+            finalize_at=iso_utc(deadline),
+            final_status=status,
+            evaluation_hash=digest,
+            missing_sources=missing,
+            conflict_sources=conflicts,
+            invalid_sources=invalid,
+            inserted=True,
+        )
+
+    def append_late_only(
+        self, symbol: str, decision_epoch: dt.datetime, *, recorded_at: dt.datetime
+    ) -> int:
+        if self.ledger.finalization_row(symbol, decision_epoch) is None:
+            return 0
+        deadline = finalize_at(decision_epoch)
+        rows = self.raw_reader.rows_for_epoch(
+            symbol=symbol,
+            decision_epoch=decision_epoch,
+            received_by=None,
+        )
+        inserted = 0
+        for row in sorted(rows, key=lambda item: str(item["record_id"])):
+            if parse_utc(row["local_receive_time"]) <= deadline:
+                continue
+            correction_identity = canonical_json(
+                {
+                    "decision_epoch_utc": iso_utc(decision_epoch),
+                    "policy_hash": self.ledger.policy.policy_hash,
+                    "raw_record_id": row["record_id"],
+                    "study_id": self.ledger.policy.study_id,
+                    "symbol": symbol,
+                }
+            )
+            cursor = self.ledger.db.execute(
+                """
+                INSERT OR IGNORE INTO late_only_corrections (
+                    correction_id, study_id, policy_hash, symbol,
+                    decision_epoch_utc, source_name, raw_record_id,
+                    raw_payload_sha256, received_at, recorded_at,
+                    correction_status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'LATE_ONLY')
+                """,
+                (
+                    sha256_text(correction_identity),
+                    self.ledger.policy.study_id,
+                    self.ledger.policy.policy_hash,
+                    symbol,
+                    iso_utc(decision_epoch),
+                    row["source"],
+                    row["record_id"],
+                    row["raw_payload_sha256"],
+                    row["local_receive_time"],
+                    iso_utc(recorded_at),
+                ),
+            )
+            inserted += cursor.rowcount
+        self.ledger.db.commit()
+        return inserted
+
+
+class AlertDispatcher:
+    """Durably log alerts and optionally deliver them to an HTTPS webhook."""
+
+    def __init__(self, ledger: EpochLedger, webhook_urls: Sequence[str] = ()) -> None:
+        self.ledger = ledger
+        self.webhook_urls = tuple(webhook_urls)
+        for url in self.webhook_urls:
+            parsed = urllib.parse.urlparse(url)
+            if parsed.scheme != "https" or not parsed.hostname:
+                raise ValueError("alert webhooks must use HTTPS")
+
+    async def emit(
+        self,
+        *,
+        alert_key: str,
+        severity: str,
+        payload: Mapping[str, Any],
+        now: dt.datetime,
+    ) -> None:
+        if not self.ledger.alert_event_exists(alert_key, "ALERT_RAISED"):
+            self.ledger.append_alert_event(
+                alert_key=alert_key,
+                event_type="ALERT_RAISED",
+                severity=severity,
+                recorded_at=now,
+                payload=payload,
+                delivery_status="PERSISTED",
+            )
+        if not self.ledger.alert_event_exists(alert_key, "LOG_DELIVERY", "SUCCEEDED"):
+            log.critical(
+                "collector.alert key=%s severity=%s payload=%s",
+                alert_key,
+                severity,
+                canonical_json(payload),
+            )
+            self.ledger.append_alert_event(
+                alert_key=alert_key,
+                event_type="LOG_DELIVERY",
+                severity=severity,
+                recorded_at=now,
+                payload=payload,
+                delivery_status="SUCCEEDED",
+            )
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0), follow_redirects=False
+        ) as client:
+            for index, url in enumerate(self.webhook_urls):
+                delivery_type = f"WEBHOOK_{index}"
+                if self.ledger.alert_event_exists(
+                    alert_key, delivery_type, "SUCCEEDED"
+                ):
+                    continue
+                try:
+                    response = await client.post(url, json=dict(payload))
+                    response.raise_for_status()
+                except Exception as exc:
+                    self.ledger.append_alert_event(
+                        alert_key=alert_key,
+                        event_type=delivery_type,
+                        severity=severity,
+                        recorded_at=now,
+                        payload=payload,
+                        delivery_status="FAILED",
+                        error_type=type(exc).__name__,
+                    )
+                else:
+                    self.ledger.append_alert_event(
+                        alert_key=alert_key,
+                        event_type=delivery_type,
+                        severity=severity,
+                        recorded_at=now,
+                        payload=payload,
+                        delivery_status="SUCCEEDED",
+                    )
+
+
+def latest_heartbeat(path: Path, policy: EpochPolicy) -> dict[str, Any] | None:
+    path = path.expanduser().resolve()
+    if not path.is_file():
+        return None
+    uri = f"file:{urllib.parse.quote(str(path))}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            connection.row_factory = sqlite3.Row
+            row = connection.execute(
+                """
+                SELECT * FROM collector_heartbeats
+                WHERE study_id = ? AND policy_hash = ?
+                ORDER BY append_id DESC LIMIT 1
+                """,
+                (policy.study_id, policy.policy_hash),
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+    return dict(row) if row is not None else None
+
+
+def availability_report(
+    artifact_paths: Sequence[Path],
+    policy: EpochPolicy,
+    *,
+    observed_at: dt.datetime,
+    stale_after_seconds: float,
+) -> dict[str, Any]:
+    replicas: list[dict[str, Any]] = []
+    fresh_instance_ids: set[str] = set()
+    instance_path_counts: dict[str, int] = defaultdict(int)
+    for path in sorted(
+        {item.expanduser().resolve() for item in artifact_paths}, key=str
+    ):
+        heartbeat = latest_heartbeat(path, policy)
+        if heartbeat is None:
+            replicas.append({"artifact": str(path), "status": "UNAVAILABLE"})
+            continue
+        age = (observed_at - parse_utc(heartbeat["observed_at"])).total_seconds()
+        status = "HEALTHY" if 0 <= age <= stale_after_seconds else "STALE"
+        if status == "HEALTHY":
+            fresh_instance_ids.add(heartbeat["collector_instance_id"])
+            instance_path_counts[heartbeat["collector_instance_id"]] += 1
+        replicas.append(
+            {
+                "age_seconds": age,
+                "artifact": str(path),
+                "collector_instance_id": heartbeat["collector_instance_id"],
+                "observed_at": heartbeat["observed_at"],
+                "status": status,
+            }
+        )
+    return {
+        "duplicate_collector_instance_ids": sorted(
+            instance_id
+            for instance_id, count in instance_path_counts.items()
+            if count > 1
+        ),
+        "healthy_replica_count": len(fresh_instance_ids),
+        "observed_at": iso_utc(observed_at),
+        "replicas": replicas,
+    }
+
+
+def finalization_report(
+    artifact_paths: Sequence[Path],
+    policy: EpochPolicy,
+    *,
+    decision_epoch: dt.datetime,
+) -> dict[str, Any]:
+    """Read finalization rows from replicas without mutating any collector DB."""
+
+    rows_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    unavailable_artifacts: list[str] = []
+    for path in sorted(
+        {item.expanduser().resolve() for item in artifact_paths}, key=str
+    ):
+        if not path.is_file():
+            unavailable_artifacts.append(str(path))
+            continue
+        uri = f"file:{urllib.parse.quote(str(path))}?mode=ro"
+        try:
+            with sqlite3.connect(uri, uri=True) as connection:
+                connection.row_factory = sqlite3.Row
+                rows = connection.execute(
+                    """
+                    SELECT symbol, final_status, evaluation_hash, recorded_at
+                    FROM symbol_epoch_finalizations
+                    WHERE study_id = ? AND policy_hash = ?
+                      AND decision_epoch_utc = ?
+                    """,
+                    (
+                        policy.study_id,
+                        policy.policy_hash,
+                        iso_utc(decision_epoch),
+                    ),
+                )
+                for row in rows:
+                    key = (row["symbol"], row["evaluation_hash"])
+                    rows_by_key[key] = {
+                        "evaluation_hash": row["evaluation_hash"],
+                        "final_status": row["final_status"],
+                        "recorded_at": row["recorded_at"],
+                        "symbol": row["symbol"],
+                    }
+        except sqlite3.Error:
+            unavailable_artifacts.append(str(path))
+    rows = sorted(
+        rows_by_key.values(),
+        key=lambda item: (
+            item["symbol"],
+            item["evaluation_hash"],
+        ),
+    )
+    symbols_present = {row["symbol"] for row in rows}
+    divergent_symbols = sorted(
+        symbol
+        for symbol in policy.symbols
+        if len({row["evaluation_hash"] for row in rows if row["symbol"] == symbol}) > 1
+    )
+    return {
+        "decision_epoch_utc": iso_utc(decision_epoch),
+        "divergent_symbols": divergent_symbols,
+        "finalizations": rows,
+        "missing_symbols": sorted(set(policy.symbols) - symbols_present),
+        "unavailable_artifacts": unavailable_artifacts,
+    }

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -109,7 +109,8 @@ UPDATE/DELETE rejection triggers:
 - `collector_attempts`: the matching terminal row for each completed REST
   request or websocket connection attempt, including `attempted_at`, canonical
   request identity and its hash, response SHA-256 when a response exists, and
-  terminal status.
+  terminal status. Failures also retain the exception class, message, formatted
+  traceback, and a bounded response-body summary.
 - `symbol_epoch_finalizations`: the one-shot three-way result and canonical
   evaluator input/hash.
 - `late_only_corrections`: observations received after the deadline. These
@@ -119,9 +120,9 @@ UPDATE/DELETE rejection triggers:
   delivery attempts are not overwritten.
 
 The `source_manifest_hash` is computed from the sorted required-source matrix,
-source schema requirements, and the three sealed signal symbols. The policy
-hash is the R4.1 combined seal hash. A mismatch therefore cannot silently
-reuse another finalization key.
+source schema and cadence requirements, and the three sealed signal symbols.
+The policy hash is the R4.1 combined seal hash. A mismatch therefore cannot
+silently reuse another finalization key.
 
 `bookTicker` is stored as one snapshot per symbol per second (the P0 contract
 allows either every change or 1s snapshots); raw aggTrade, forceOrder snapshots,
@@ -176,7 +177,11 @@ The precedence is fixed:
 1. Any same-source-identity/different-payload conflict produces
    `FINAL_CONFLICT`.
 2. Otherwise any absent, non-finite, schema-invalid, hash-invalid, or
-   PIT-invalid required source produces `FINAL_MISSING`.
+   PIT-invalid required source produces `FINAL_MISSING`. The bounded-history
+   periodic sources must also cover every expected interval slot: 48 rows for
+   each 5-minute source and 240 completed rows for the 1-minute premium-index
+   kline source. A source with only partial slot coverage is invalid, even when
+   it has one or more valid rows.
 3. Otherwise the result is `FINAL_COMPLETE`.
 
 `finalized_at` is the logical deadline, while `recorded_at` preserves actual
@@ -201,13 +206,16 @@ history:
 Websocket PIT receive time, book/depth continuity, instantaneous OI, and live
 premium/funding snapshots cannot be recreated honestly after the fact. The
 supervisor therefore does not relabel a later snapshot as an earlier one.
-Those sources rely on independent live replicas. Missing/invalid recoverable
-sources are retried only while `now < finalize_at`; the finalizer never waits
-past the deadline.
+Those sources rely on independent live replicas. Missing, invalid, and
+partial-coverage recoverable sources are retried only while
+`now < finalize_at`; the finalizer never waits past the deadline.
 
 Each request, including invalid responses and transport/HTTP failures, appends
 a terminal attempt row. The raw response body SHA-256 is retained even when
-JSON/schema validation fails.
+JSON/schema validation fails. Retry failures increment collector health failure
+counts and emit an ERROR record with message and traceback. An unexpected
+epoch/status supervisor exception is fail-stop: it is counted, logged with a
+traceback, sets the collector stop event, and is re-raised.
 
 ## Two collectors and an independent watchdog
 

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -2,7 +2,9 @@
 
 This is a manual, research-artifact-only point-in-time collector. It never
 writes the production database and is not registered with TaskIQ, cron, or
-Prefect.
+Prefect. ROB-1108 adds epoch finalization, deadline recovery, independent
+replica awareness, and fail-fast alerting without changing feature, score,
+candidate, or stage-decision logic.
 
 ## Hard boundary
 
@@ -73,11 +75,22 @@ flag:
 ```bash
 export R4_P0_COLLECTOR_ENABLED=true
 export R4_P0_ARTIFACT_ROOT="$HOME/work/herdr-artifacts/r4-p0-collector"
-uv run python -m scripts.r4_p0_collector --run
+export R4_P0_COLLECTOR_ID="r4-p0-host-a"
+export R4_P0_ALERT_WEBHOOK_URLS="https://alerts.example.invalid/r4"
+uv run python -m scripts.r4_p0_collector --run \
+  --replica-artifact /path/to/host-b/r4_p0_collector.sqlite3 \
+  --minimum-healthy-replicas 2
 ```
 
 Do not put these values in a committed `.env` file. Stop with SIGTERM or
 Ctrl-C. A single-instance file lock prevents two writers sharing an artifact.
+`--run` refuses to arm unless two distinct artifact paths are configured and
+the minimum healthy replica count is at least two. It also requires an HTTPS
+webhook unless the operator explicitly chooses `--allow-log-only-alerts` for a
+manual validation. Webhook values are read from the environment, not command
+arguments, so they are not exposed in the process list.
+
+`--probe` remains a bounded single-replica validation and does not claim HA.
 
 ## Storage and restart contract
 
@@ -85,6 +98,30 @@ The artifact is `r4_p0_collector.sqlite3` in WAL mode with `synchronous=FULL`.
 All persistence uses INSERT; database triggers reject UPDATE and DELETE.
 `record_id` is a semantic unique key, so replayed websocket events and
 unchanged REST periods are ignored after restart.
+
+ROB-1108 adds seven tables to the same local artifact. Every table has
+UPDATE/DELETE rejection triggers:
+
+- `epoch_source_events`: one immutable `OPEN` event per
+  `(study, policy, source, symbol, decision_epoch)`.
+- `collector_attempt_starts`: a pre-request row committed before network I/O;
+  an unmatched start proves the process/host died mid-attempt.
+- `collector_attempts`: the matching terminal row for each completed REST
+  request or websocket connection attempt, including `attempted_at`, canonical
+  request identity and its hash, response SHA-256 when a response exists, and
+  terminal status.
+- `symbol_epoch_finalizations`: the one-shot three-way result and canonical
+  evaluator input/hash.
+- `late_only_corrections`: observations received after the deadline. These
+  never rewrite a finalization.
+- `collector_heartbeats`: append-only replica liveness evidence.
+- `collector_alert_events`: alert creation and each delivery result; failed
+  delivery attempts are not overwritten.
+
+The `source_manifest_hash` is computed from the sorted required-source matrix,
+source schema requirements, and the three sealed signal symbols. The policy
+hash is the R4.1 combined seal hash. A mismatch therefore cannot silently
+reuse another finalization key.
 
 `bookTicker` is stored as one snapshot per symbol per second (the P0 contract
 allows either every change or 1s snapshots); raw aggTrade, forceOrder snapshots,
@@ -118,3 +155,118 @@ process returns nonzero if any required source had neither an insert nor a
 deduplicated response. `forceOrder` is reported separately as a sparse,
 event-driven source and is not treated as failed merely because no liquidation
 occurred during a short run.
+
+## Deterministic epoch finalizer
+
+Decision epochs are the six UTC four-hour boundaries. For decision epoch `e`,
+the current source interval is `[e-4h,e)` and the immutable deadline is:
+
+```text
+finalize_at(e) = e + 4h
+```
+
+At or after that deadline, the evaluator reads only raw rows whose event time
+is in the source interval and whose local receive time is no later than the
+deadline. It sorts source identities and payload hashes before canonical JSON
+serialization. Runtime clock time, database append order, replica path order,
+run ID, and retry count are not evaluator inputs.
+
+The precedence is fixed:
+
+1. Any same-source-identity/different-payload conflict produces
+   `FINAL_CONFLICT`.
+2. Otherwise any absent, non-finite, schema-invalid, hash-invalid, or
+   PIT-invalid required source produces `FINAL_MISSING`.
+3. Otherwise the result is `FINAL_COMPLETE`.
+
+`finalized_at` is the logical deadline, while `recorded_at` preserves actual
+write time. Re-running the evaluator checks the stored `evaluation_hash`; it
+cannot insert or mutate another result. A row received after the deadline is
+excluded by the fixed receive-time cutoff and appended as `LATE_ONLY`.
+
+## Deadline-aware recovery
+
+Normal polling/reconnect remains in place. In addition, the epoch supervisor
+checks the just-closed interval every 30 seconds until its deadline. It retries
+only provider endpoints that can faithfully return an event-time-bounded
+history:
+
+| source | bounded retry |
+|---|---|
+| `openInterestHist` | 5-minute rows with `startTime`/`endTime` |
+| `basis` | 5-minute rows with `startTime`/`endTime` |
+| `takerLongShortRatio` | 5-minute rows with `startTime`/`endTime` |
+| `premiumIndexKline1m` | completed 1-minute rows with `startTime`/`endTime` |
+
+Websocket PIT receive time, book/depth continuity, instantaneous OI, and live
+premium/funding snapshots cannot be recreated honestly after the fact. The
+supervisor therefore does not relabel a later snapshot as an earlier one.
+Those sources rely on independent live replicas. Missing/invalid recoverable
+sources are retried only while `now < finalize_at`; the finalizer never waits
+past the deadline.
+
+Each request, including invalid responses and transport/HTTP failures, appends
+a terminal attempt row. The raw response body SHA-256 is retained even when
+JSON/schema validation fails.
+
+## Two collectors and an independent watchdog
+
+The operational topology is two collectors on distinct hosts/network paths,
+each with its own local SQLite artifact and stable collector ID. They must not
+share a writable SQLite file. Each process reads the other artifact through a
+read-only replicated/mounted path; deterministic source-identity merge removes
+byte-identical duplicates and exposes conflicting payloads.
+
+A third process on an independent host watches both heartbeat/finalization
+ledgers. It pages when fewer than two replicas are fresh or when a due epoch
+has no matching finalization within the configured grace:
+
+```bash
+export R4_P0_WATCHDOG_ENABLED=true
+export R4_P0_ALERT_WEBHOOK_URLS="https://alerts.example.invalid/r4"
+uv run python -m scripts.r4_p0_watchdog --run \
+  --artifact /path/to/host-a/r4_p0_collector.sqlite3 \
+  --artifact /path/to/host-b/r4_p0_collector.sqlite3 \
+  --minimum-healthy-replicas 2
+```
+
+The alert path is:
+
+```text
+epoch deadline risk (last hour) -> append-only alert ledger -> CRITICAL/WARNING log
+                                                     \-> HTTPS webhook(s)
+final MISSING/CONFLICT --------> DATA_INTEGRITY_FAIL through the same path
+stale replica/finalizer --------> independent watchdog through the same path
+```
+
+Logging is formatted in real UTC before adding the `Z` suffix. Webhook delivery
+success/failure is appended separately, so an outage cannot erase its own
+alert history.
+
+No scheduler or service registration is part of this change. After manual
+fault injection, operators may install the example `KeepAlive` launchd
+templates in `ops/native/plists/examples/`; merely committing those templates
+does not load or deploy them.
+
+## Manual pre-arm verification
+
+These checks write only temporary local artifacts and use public market data:
+
+```bash
+uv run pytest \
+  tests/test_binance_r4_p0_collector.py \
+  tests/test_binance_r4_p0_hardening.py -q
+
+uv run python -m scripts.r4_p0_collector \
+  --probe --duration 60 \
+  --artifact-root /tmp/r4-p0-host-a
+
+uv run python -m scripts.r4_p0_watchdog \
+  --artifact /tmp/r4-p0-host-a/r4_p0_collector.sqlite3 \
+  --artifact /tmp/r4-p0-host-b/r4_p0_collector.sqlite3
+```
+
+Before T_WEEK0, the operator-owned one-week rehearsal must use the same source
+manifest, two-host topology, finalizer, and alert route. Acceptance is 100%
+`FINAL_COMPLETE`, zero `FINAL_MISSING`, zero `FINAL_CONFLICT`, zero stalled
+finalizers, and demonstrated page delivery under injected process/host loss.

--- a/ops/native/plists/examples/com.robinco.auto-trader.r4-p0-collector.plist.example
+++ b/ops/native/plists/examples/com.robinco.auto-trader.r4-p0-collector.plist.example
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Example only. ROB-1108 does not load or register this service. -->
+  <key>Label</key>
+  <string>com.robinco.auto-trader.r4-p0-collector</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__UV_PATH__</string>
+    <string>run</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>scripts.r4_p0_collector</string>
+    <string>--run</string>
+    <string>--collector-id</string>
+    <string>__UNIQUE_HOST_COLLECTOR_ID__</string>
+    <string>--artifact-root</string>
+    <string>__LOCAL_ARTIFACT_ROOT__</string>
+    <string>--replica-artifact</string>
+    <string>__READ_ONLY_PEER_ARTIFACT__</string>
+    <string>--minimum-healthy-replicas</string>
+    <string>2</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>__REPO_ROOT__</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>R4_P0_COLLECTOR_ENABLED</key>
+    <string>true</string>
+    <key>R4_P0_ALERT_WEBHOOK_URLS</key>
+    <string>__PRIVATE_HTTPS_WEBHOOK_RENDER_VALUE__</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>__LOG_ROOT__/r4-p0-collector.log</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_ROOT__/r4-p0-collector.error.log</string>
+</dict>
+</plist>

--- a/ops/native/plists/examples/com.robinco.auto-trader.r4-p0-watchdog.plist.example
+++ b/ops/native/plists/examples/com.robinco.auto-trader.r4-p0-watchdog.plist.example
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Example only. Install on an independent host after manual validation. -->
+  <key>Label</key>
+  <string>com.robinco.auto-trader.r4-p0-watchdog</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__UV_PATH__</string>
+    <string>run</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>scripts.r4_p0_watchdog</string>
+    <string>--run</string>
+    <string>--artifact</string>
+    <string>__READ_ONLY_HOST_A_ARTIFACT__</string>
+    <string>--artifact</string>
+    <string>__READ_ONLY_HOST_B_ARTIFACT__</string>
+    <string>--minimum-healthy-replicas</string>
+    <string>2</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>__REPO_ROOT__</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>R4_P0_WATCHDOG_ENABLED</key>
+    <string>true</string>
+    <key>R4_P0_ALERT_WEBHOOK_URLS</key>
+    <string>__PRIVATE_HTTPS_WEBHOOK_RENDER_VALUE__</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>__LOG_ROOT__/r4-p0-watchdog.log</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_ROOT__/r4-p0-watchdog.error.log</string>
+</dict>
+</plist>

--- a/scripts/r4_p0_collector.py
+++ b/scripts/r4_p0_collector.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import signal
+import time
 from pathlib import Path
 
 from app.services.brokers.binance.r4_p0_collector import (
@@ -28,6 +29,8 @@ from app.services.brokers.binance.r4_p0_collector import (
 
 ENABLED_ENV = "R4_P0_COLLECTOR_ENABLED"
 ARTIFACT_ENV = "R4_P0_ARTIFACT_ROOT"
+COLLECTOR_ID_ENV = "R4_P0_COLLECTOR_ID"
+ALERT_WEBHOOKS_ENV = "R4_P0_ALERT_WEBHOOK_URLS"
 DEFAULT_ARTIFACT_ROOT = "~/work/herdr-artifacts/r4-p0-collector"
 
 
@@ -54,6 +57,31 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--status-seconds", type=float, default=30.0)
     parser.add_argument(
+        "--collector-id",
+        default=os.getenv(COLLECTOR_ID_ENV, "r4-p0-local"),
+        help="stable identity unique to this host/collector replica",
+    )
+    parser.add_argument(
+        "--replica-artifact",
+        action="append",
+        default=[],
+        help=(
+            "read-only peer r4_p0_collector.sqlite3 path; repeat for "
+            "independent replicas"
+        ),
+    )
+    parser.add_argument(
+        "--minimum-healthy-replicas",
+        type=int,
+        default=2,
+        help="required fresh collector heartbeats (operational default: 2)",
+    )
+    parser.add_argument(
+        "--allow-log-only-alerts",
+        action="store_true",
+        help="explicitly permit no HTTPS webhook (probe/manual validation only)",
+    )
+    parser.add_argument(
         "--audit",
         action="store_true",
         help="offline integrity audit and one sample per source; no network",
@@ -63,6 +91,16 @@ def parse_args() -> argparse.Namespace:
 
 def _enabled() -> bool:
     return os.getenv(ENABLED_ENV, "").strip().lower() == "true"
+
+
+def _alert_webhook_urls() -> tuple[str, ...]:
+    raw = os.getenv(ALERT_WEBHOOKS_ENV, "")
+    return tuple(
+        item.strip()
+        for chunk in raw.splitlines()
+        for item in chunk.split(",")
+        if item.strip()
+    )
 
 
 def _dry_run_payload(args: argparse.Namespace) -> dict[str, object]:
@@ -79,6 +117,12 @@ def _dry_run_payload(args: argparse.Namespace) -> dict[str, object]:
         "rest_paths": sorted(REST_PATH_ALLOWLIST),
         "pit_columns": list(PIT_COLUMNS),
         "artifact_root_if_armed": str(Path(args.artifact_root).expanduser()),
+        "collector_instance_id": args.collector_id,
+        "replica_artifacts": [
+            str(Path(path).expanduser()) for path in args.replica_artifact
+        ],
+        "minimum_healthy_replicas": args.minimum_healthy_replicas,
+        "alert_webhook_count": len(_alert_webhook_urls()),
         "arm": f"{ENABLED_ENV}=true plus --run",
     }
 
@@ -97,6 +141,10 @@ async def _run_collector(args: argparse.Namespace) -> int:
         artifact_root=root,
         duration_seconds=args.duration,
         status_seconds=args.status_seconds,
+        collector_instance_id=args.collector_id,
+        replica_artifacts=tuple(Path(path) for path in args.replica_artifact),
+        alert_webhook_urls=_alert_webhook_urls(),
+        minimum_healthy_replicas=(1 if args.probe else args.minimum_healthy_replicas),
     )
     with AppendOnlyPITStore(root) as store:
         collector = BinanceR4P0Collector(config, store)
@@ -113,9 +161,13 @@ async def _run_collector(args: argparse.Namespace) -> int:
 
 def main() -> int:
     args = parse_args()
+    formatter = logging.Formatter(fmt="%(asctime)sZ %(levelname)s %(message)s")
+    formatter.converter = time.gmtime
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)sZ %(levelname)s %(message)s",
+        handlers=[handler],
     )
     logging.getLogger("httpx").setLevel(logging.WARNING)
     if args.audit:
@@ -130,6 +182,28 @@ def main() -> int:
             raise SystemExit("--probe requires --duration between 1 and 180 seconds")
     elif not _enabled():
         raise SystemExit(f"refusing --run: set {ENABLED_ENV}=true explicitly")
+    if args.run:
+        if args.collector_id == "r4-p0-local":
+            raise SystemExit(
+                "--run requires an explicit host-unique --collector-id "
+                f"or {COLLECTOR_ID_ENV}"
+            )
+        configured_replicas = 1 + len(
+            {str(Path(path).expanduser().resolve()) for path in args.replica_artifact}
+        )
+        if (
+            args.minimum_healthy_replicas < 2
+            or configured_replicas < args.minimum_healthy_replicas
+        ):
+            raise SystemExit(
+                "--run requires at least two independently configured "
+                "artifacts and --minimum-healthy-replicas >= 2"
+            )
+        if not _alert_webhook_urls() and not args.allow_log_only_alerts:
+            raise SystemExit(
+                f"--run requires {ALERT_WEBHOOKS_ENV}; "
+                "use --allow-log-only-alerts only for explicit validation"
+            )
     if args.duration is not None and args.duration <= 0:
         raise SystemExit("--duration must be positive")
     return asyncio.run(_run_collector(args))

--- a/scripts/r4_p0_watchdog.py
+++ b/scripts/r4_p0_watchdog.py
@@ -1,0 +1,198 @@
+"""Independent availability/finalization watchdog for R4 P0 collectors.
+
+The watchdog is intentionally a manual operator entrypoint.  This module does
+not register cron, TaskIQ, launchd, or any other scheduler.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import logging
+import os
+import signal
+import time
+from pathlib import Path
+
+from app.services.brokers.binance.r4_p0_collector import (
+    REQUIRED_ACTIVE_SOURCES,
+    SIGNAL_SYMBOLS,
+    AppendOnlyPITStore,
+    utc_now,
+)
+from app.services.brokers.binance.r4_p0_hardening import (
+    AlertDispatcher,
+    EpochLedger,
+    EpochPolicy,
+    availability_report,
+    finalization_report,
+    floor_epoch,
+)
+
+ENABLED_ENV = "R4_P0_WATCHDOG_ENABLED"
+ALERT_WEBHOOKS_ENV = "R4_P0_ALERT_WEBHOOK_URLS"
+DEFAULT_STATE_ROOT = "~/work/herdr-artifacts/r4-p0-watchdog"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help=f"run until stopped; requires {ENABLED_ENV}=true",
+    )
+    parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        help="collector SQLite artifact path; repeat for each independent replica",
+    )
+    parser.add_argument(
+        "--state-root",
+        default=DEFAULT_STATE_ROOT,
+        help="local append-only watchdog alert ledger",
+    )
+    parser.add_argument("--interval-seconds", type=float, default=15.0)
+    parser.add_argument("--stale-after-seconds", type=float, default=120.0)
+    parser.add_argument("--finalizer-grace-seconds", type=float, default=30.0)
+    parser.add_argument("--minimum-healthy-replicas", type=int, default=2)
+    parser.add_argument(
+        "--allow-log-only-alerts",
+        action="store_true",
+        help="explicitly allow no HTTPS webhook during manual validation",
+    )
+    return parser.parse_args()
+
+
+def _alert_webhook_urls() -> tuple[str, ...]:
+    raw = os.getenv(ALERT_WEBHOOKS_ENV, "")
+    return tuple(
+        item.strip()
+        for chunk in raw.splitlines()
+        for item in chunk.split(",")
+        if item.strip()
+    )
+
+
+def _policy() -> EpochPolicy:
+    return EpochPolicy(
+        required_sources=tuple(sorted(REQUIRED_ACTIVE_SOURCES)),
+        symbols=tuple(sorted(SIGNAL_SYMBOLS)),
+    )
+
+
+async def _watch(args: argparse.Namespace) -> int:
+    policy = _policy()
+    artifact_paths = tuple(Path(path) for path in args.artifact)
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+
+    with AppendOnlyPITStore(
+        Path(args.state_root),
+        artifact_filename="r4_p0_watchdog.sqlite3",
+        lock_filename=".watchdog.lock",
+    ) as store:
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+        dispatcher = AlertDispatcher(ledger, _alert_webhook_urls())
+        while not stop.is_set():
+            now = utc_now()
+            availability = availability_report(
+                artifact_paths,
+                policy,
+                observed_at=now,
+                stale_after_seconds=args.stale_after_seconds,
+            )
+            if availability["healthy_replica_count"] < args.minimum_healthy_replicas:
+                await dispatcher.emit(
+                    alert_key=(
+                        "COLLECTOR_REDUNDANCY_LOST:"
+                        f"{policy.study_id}:{policy.policy_hash}:"
+                        f"{int(now.timestamp()) // 900}"
+                    ),
+                    severity="CRITICAL",
+                    payload={
+                        "alert_type": "COLLECTOR_REDUNDANCY_LOST",
+                        "minimum_healthy_replicas": (args.minimum_healthy_replicas),
+                        **availability,
+                    },
+                    now=now,
+                )
+
+            latest_due = floor_epoch(now) - dt.timedelta(hours=4)
+            due_at = latest_due + dt.timedelta(
+                hours=4,
+                seconds=args.finalizer_grace_seconds,
+            )
+            if latest_due >= policy.t0 and now >= due_at:
+                report = finalization_report(
+                    artifact_paths,
+                    policy,
+                    decision_epoch=latest_due,
+                )
+                if report["missing_symbols"] or report["divergent_symbols"]:
+                    await dispatcher.emit(
+                        alert_key=(
+                            "FINALIZER_STALLED:"
+                            f"{policy.study_id}:{policy.policy_hash}:"
+                            f"{report['decision_epoch_utc']}"
+                        ),
+                        severity="CRITICAL",
+                        payload={
+                            "alert_type": "FINALIZER_STALLED",
+                            "finalizer_grace_seconds": (args.finalizer_grace_seconds),
+                            "policy_hash": policy.policy_hash,
+                            "study_id": policy.study_id,
+                            **report,
+                        },
+                        now=now,
+                    )
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=args.interval_seconds)
+            except TimeoutError:
+                pass
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    formatter = logging.Formatter(fmt="%(asctime)sZ %(levelname)s %(message)s")
+    formatter.converter = time.gmtime
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    payload = {
+        "alert_webhook_count": len(_alert_webhook_urls()),
+        "artifacts": [str(Path(path).expanduser()) for path in args.artifact],
+        "broker_mutation": False,
+        "database_write": bool(args.run),
+        "minimum_healthy_replicas": args.minimum_healthy_replicas,
+        "mode": "run" if args.run else "dry_run",
+        "network": bool(args.run and _alert_webhook_urls()),
+        "scheduler_registration": False,
+        "state_root": str(Path(args.state_root).expanduser()),
+    }
+    if not args.run:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+    if os.getenv(ENABLED_ENV, "").strip().lower() != "true":
+        raise SystemExit(f"refusing --run: set {ENABLED_ENV}=true explicitly")
+    artifacts = {str(Path(path).expanduser().resolve()) for path in args.artifact}
+    if args.minimum_healthy_replicas < 2 or len(artifacts) < 2:
+        raise SystemExit("--run requires at least two distinct collector artifacts")
+    if args.interval_seconds <= 0 or args.stale_after_seconds <= 0:
+        raise SystemExit("watchdog intervals must be positive")
+    if not _alert_webhook_urls() and not args.allow_log_only_alerts:
+        raise SystemExit(
+            f"--run requires {ALERT_WEBHOOKS_ENV}; "
+            "use --allow-log-only-alerts only for explicit validation"
+        )
+    return asyncio.run(_watch(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_binance_r4_p0_collector.py
+++ b/tests/test_binance_r4_p0_collector.py
@@ -335,6 +335,27 @@ async def test_basis_empty_response_is_missing_without_starving_other_symbols(
             "XRPUSDT",
         ]
         assert {row["event_time"] for row in rows} == {"2026-07-26T01:00:00.000000Z"}
+        attempts = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT request_identity_json, terminal_status, error_type,
+                       error_message, error_traceback, response_body_summary
+                FROM collector_attempts ORDER BY append_id
+                """
+            )
+        )
+        assert len(attempts) == len(symbols)
+        failed = [row for row in attempts if row["terminal_status"] != "SUCCESS"]
+        assert len(failed) == 1
+        assert failed[0]["terminal_status"] == "INVALID_RESPONSE"
+        assert failed[0]["error_type"] == "MissingBasisDataError"
+        assert "DOGEUSDT" in failed[0]["error_message"]
+        assert "MissingBasisDataError" in failed[0]["error_traceback"]
+        assert failed[0]["response_body_summary"] == "[]"
+        identities = [json.loads(row["request_identity_json"]) for row in attempts]
+        assert all(
+            identity["sources"] == ["binance_usdm.basis"] for identity in identities
+        )
 
 
 @pytest.mark.unit
@@ -395,6 +416,23 @@ async def test_basis_replays_recent_rows_to_repair_transient_gap(tmp_path) -> No
         ]
         assert collector.session_counts["binance_usdm.basis"] == 3
         assert collector.duplicate_counts["binance_usdm.basis"] == 1
+        attempts = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT terminal_status, request_identity_json
+                FROM collector_attempts ORDER BY append_id
+                """
+            )
+        )
+        assert [row["terminal_status"] for row in attempts] == [
+            "SUCCESS",
+            "SUCCESS",
+        ]
+        assert all(
+            json.loads(row["request_identity_json"])["sources"]
+            == ["binance_usdm.basis"]
+            for row in attempts
+        )
 
 
 @pytest.mark.unit

--- a/tests/test_binance_r4_p0_hardening.py
+++ b/tests/test_binance_r4_p0_hardening.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sqlite3
+
+import httpx
+import pytest
+
+from app.services.brokers.binance.r4_p0_collector import (
+    AppendOnlyPITStore,
+    BinanceR4P0Collector,
+    CollectorConfig,
+)
+from app.services.brokers.binance.r4_p0_hardening import (
+    FINAL_COMPLETE,
+    FINAL_CONFLICT,
+    FINAL_MISSING,
+    AlertDispatcher,
+    DeterministicEpochFinalizer,
+    EpochLedger,
+    EpochPolicy,
+    RawPITReader,
+    availability_report,
+    decision_epoch_for_event,
+    finalization_report,
+    finalize_at,
+)
+
+EPOCH = dt.datetime(2026, 7, 28, 8, tzinfo=dt.UTC)
+RECEIVED = dt.datetime(2026, 7, 28, 7, 1, tzinfo=dt.UTC)
+POLICY = EpochPolicy(
+    required_sources=(
+        "binance_usdm.openInterestHist",
+        "binance_usdm.takerLongShortRatio",
+    ),
+    symbols=("XRPUSDT",),
+)
+
+
+def _payload(source: str, value: str = "10") -> dict[str, str]:
+    if source == "binance_usdm.openInterestHist":
+        return {
+            "sumOpenInterest": value,
+            "symbol": "XRPUSDT",
+            "timestamp": "1785222000000",
+        }
+    return {
+        "buySellRatio": value,
+        "buyVol": "20",
+        "sellVol": "2",
+        "symbol": "XRPUSDT",
+        "timestamp": "1785222000000",
+    }
+
+
+def _append(
+    store: AppendOnlyPITStore,
+    source: str,
+    *,
+    value: str = "10",
+    received: dt.datetime = RECEIVED,
+    sequence: str = "1785222000000",
+) -> None:
+    assert store.append(
+        source=source,
+        symbol="XRPUSDT",
+        raw_payload=_payload(source, value),
+        local_receive_time=received,
+        run_id="replica:test",
+        event_time="2026-07-28T07:00:00.000000Z",
+        transaction_time=None,
+        request_started_at="2026-07-28T07:00:59.000000Z",
+        request_completed_at="2026-07-28T07:01:00.000000Z",
+        sequence_or_trade_id=sequence,
+        gap_detected=False,
+        reconnect_id="replica:test:rest",
+    )
+
+
+def _append_agg(store: AppendOnlyPITStore, *, gap: bool) -> None:
+    assert store.append(
+        source="binance_usdm.aggTrade",
+        symbol="XRPUSDT",
+        raw_payload={
+            "E": 1785222000000,
+            "T": 1785222000000,
+            "a": 42,
+            "p": "1.25",
+            "q": "3",
+            "s": "XRPUSDT",
+        },
+        local_receive_time=RECEIVED,
+        run_id=f"replica:gap:{gap}",
+        event_time="2026-07-28T07:00:00.000000Z",
+        transaction_time="2026-07-28T07:00:00.000000Z",
+        request_started_at="2026-07-28T06:59:59.000000Z",
+        request_completed_at="2026-07-28T07:00:00.000000Z",
+        sequence_or_trade_id="42",
+        gap_detected=gap,
+        reconnect_id=f"replica:gap:{gap}:ws",
+    )
+
+
+def _finalizer(
+    store: AppendOnlyPITStore,
+    *,
+    policy: EpochPolicy = POLICY,
+    replicas: tuple = (),
+) -> tuple[EpochLedger, DeterministicEpochFinalizer]:
+    ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+    reader = RawPITReader(store._db, store.path, replicas)  # noqa: SLF001
+    return ledger, DeterministicEpochFinalizer(ledger, reader)
+
+
+@pytest.mark.unit
+def test_decision_epoch_uses_half_open_boundary() -> None:
+    assert (
+        decision_epoch_for_event(dt.datetime(2026, 7, 28, 7, 59, 59, tzinfo=dt.UTC))
+        == EPOCH
+    )
+    assert decision_epoch_for_event(EPOCH) == EPOCH + dt.timedelta(hours=4)
+    assert finalize_at(EPOCH) == dt.datetime(2026, 7, 28, 12, tzinfo=dt.UTC)
+
+
+@pytest.mark.unit
+def test_finalizer_is_deterministic_across_input_order(tmp_path) -> None:
+    hashes: list[str] = []
+    for index, sources in enumerate(
+        (
+            POLICY.required_sources,
+            tuple(reversed(POLICY.required_sources)),
+        )
+    ):
+        root = tmp_path / str(index)
+        with AppendOnlyPITStore(root) as store:
+            for source in sources:
+                _append(store, source)
+            _, finalizer = _finalizer(store)
+            preview = finalizer.preview("XRPUSDT", EPOCH)
+            result = finalizer.finalize(
+                "XRPUSDT",
+                EPOCH,
+                observed_at=finalize_at(EPOCH),
+            )
+            repeated = finalizer.finalize(
+                "XRPUSDT",
+                EPOCH,
+                observed_at=finalize_at(EPOCH) + dt.timedelta(minutes=1),
+            )
+            assert preview.final_status == FINAL_COMPLETE
+            assert result.inserted
+            assert not repeated.inserted
+            assert result.evaluation_hash == repeated.evaluation_hash
+            hashes.append(result.evaluation_hash)
+    assert hashes[0] == hashes[1]
+
+
+@pytest.mark.unit
+def test_finalizer_missing_and_conflict_are_fail_closed(tmp_path) -> None:
+    missing_root = tmp_path / "missing"
+    with AppendOnlyPITStore(missing_root) as store:
+        _append(store, POLICY.required_sources[0])
+        _, finalizer = _finalizer(store)
+        result = finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
+        assert result.final_status == FINAL_MISSING
+        assert result.missing_sources == (POLICY.required_sources[1],)
+
+    conflict_root = tmp_path / "conflict"
+    with AppendOnlyPITStore(conflict_root) as store:
+        for source in POLICY.required_sources:
+            _append(store, source)
+        _append(
+            store,
+            POLICY.required_sources[0],
+            value="11",
+            sequence="1785222000000",
+        )
+        _, finalizer = _finalizer(store)
+        result = finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
+        assert result.final_status == FINAL_CONFLICT
+        assert result.conflict_sources == (POLICY.required_sources[0],)
+
+
+@pytest.mark.unit
+def test_independent_replica_covers_same_identity_gap(tmp_path) -> None:
+    gap_policy = EpochPolicy(
+        required_sources=("binance_usdm.aggTrade",),
+        symbols=("XRPUSDT",),
+    )
+    with (
+        AppendOnlyPITStore(tmp_path / "gap") as gap_store,
+        AppendOnlyPITStore(tmp_path / "continuous") as continuous_store,
+    ):
+        _append_agg(gap_store, gap=True)
+        _append_agg(continuous_store, gap=False)
+        _, local = _finalizer(gap_store, policy=gap_policy)
+        assert local.preview("XRPUSDT", EPOCH).final_status == FINAL_MISSING
+        _, merged = _finalizer(
+            gap_store,
+            policy=gap_policy,
+            replicas=(continuous_store.path,),
+        )
+        assert merged.preview("XRPUSDT", EPOCH).final_status == FINAL_COMPLETE
+
+
+@pytest.mark.unit
+def test_finalization_ignores_late_payload_and_records_late_only(tmp_path) -> None:
+    with AppendOnlyPITStore(tmp_path) as store:
+        for source in POLICY.required_sources:
+            _append(store, source)
+        ledger, finalizer = _finalizer(store)
+        original = finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
+        _append(
+            store,
+            POLICY.required_sources[0],
+            value="999",
+            received=finalize_at(EPOCH) + dt.timedelta(seconds=1),
+            sequence="1785222000000",
+        )
+        repeated = finalizer.finalize(
+            "XRPUSDT",
+            EPOCH,
+            observed_at=finalize_at(EPOCH) + dt.timedelta(minutes=1),
+        )
+        assert repeated.final_status == FINAL_COMPLETE
+        assert repeated.evaluation_hash == original.evaluation_hash
+        assert (
+            finalizer.append_late_only(
+                "XRPUSDT",
+                EPOCH,
+                recorded_at=finalize_at(EPOCH) + dt.timedelta(minutes=1),
+            )
+            == 1
+        )
+        row = ledger.db.execute(
+            "SELECT correction_status FROM late_only_corrections"
+        ).fetchone()
+        assert row["correction_status"] == "LATE_ONLY"
+
+
+@pytest.mark.unit
+def test_attempt_and_finalization_tables_reject_update_delete(tmp_path) -> None:
+    with AppendOnlyPITStore(tmp_path) as store:
+        for source in POLICY.required_sources:
+            _append(store, source)
+        ledger, finalizer = _finalizer(store)
+        ledger.ensure_open_rows(EPOCH, "replica-a", RECEIVED)
+        ledger.append_attempt(
+            collector_instance_id="replica-a",
+            decision_epoch=EPOCH,
+            attempted_at=RECEIVED,
+            completed_at=RECEIVED + dt.timedelta(seconds=1),
+            request_identity={
+                "method": "GET",
+                "path": "/futures/data/openInterestHist",
+            },
+            response_sha256="a" * 64,
+            terminal_status="SUCCESS",
+        )
+        finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
+        assert (
+            ledger.db.execute("SELECT count(*) FROM epoch_source_events").fetchone()[0]
+            == 2
+        )
+        for table in (
+            "epoch_source_events",
+            "collector_attempt_starts",
+            "collector_attempts",
+            "symbol_epoch_finalizations",
+        ):
+            with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+                ledger.db.execute(f"DELETE FROM {table}")  # noqa: S608
+            ledger.db.rollback()
+            with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+                ledger.db.execute(
+                    f"UPDATE {table} SET append_id = append_id"  # noqa: S608
+                )
+            ledger.db.rollback()
+
+
+@pytest.mark.unit
+def test_replica_finalizations_are_deduplicated_and_divergence_is_visible(
+    tmp_path,
+) -> None:
+    paths = []
+    stores = []
+    try:
+        for name in ("a", "b"):
+            store = AppendOnlyPITStore(tmp_path / name)
+            stores.append(store)
+            for source in POLICY.required_sources:
+                _append(store, source)
+            _, finalizer = _finalizer(store)
+            finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
+            paths.append(store.path)
+        _, local_only = _finalizer(stores[0])
+        _, with_exact_replica = _finalizer(stores[0], replicas=(stores[1].path,))
+        assert (
+            local_only.preview("XRPUSDT", EPOCH).evaluation_hash
+            == with_exact_replica.preview("XRPUSDT", EPOCH).evaluation_hash
+        )
+        report = finalization_report(paths, POLICY, decision_epoch=EPOCH)
+        assert report["missing_symbols"] == []
+        assert report["divergent_symbols"] == []
+        assert len(report["finalizations"]) == 1
+    finally:
+        for store in stores:
+            store.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_historical_retry_appends_terminal_attempt(tmp_path) -> None:
+    timestamp = int(dt.datetime(2026, 7, 28, 7, tzinfo=dt.UTC).timestamp() * 1000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/futures/data/openInterestHist"
+        assert request.url.params["startTime"] == str(
+            int((EPOCH - dt.timedelta(hours=4)).timestamp() * 1000)
+        )
+        assert request.url.params["endTime"] == str(int(EPOCH.timestamp() * 1000) - 1)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "sumOpenInterest": "10",
+                    "symbol": "XRPUSDT",
+                    "timestamp": timestamp,
+                }
+            ],
+        )
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._rest_epoch_history(  # noqa: SLF001
+                client,
+                source="binance_usdm.openInterestHist",
+                symbol="XRPUSDT",
+                decision_epoch=EPOCH,
+            )
+        attempt = store._db.execute(  # noqa: SLF001
+            "SELECT * FROM collector_attempts"
+        ).fetchone()
+        start = store._db.execute(  # noqa: SLF001
+            "SELECT * FROM collector_attempt_starts"
+        ).fetchone()
+        assert start["attempt_id"] == attempt["attempt_id"]
+        assert attempt["terminal_status"] == "SUCCESS"
+        assert attempt["response_sha256"]
+        identity = json.loads(attempt["request_identity_json"])
+        assert identity["method"] == "GET"
+        assert identity["sources"] == ["binance_usdm.openInterestHist"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_invalid_retry_response_keeps_hash_and_terminal_failure(
+    tmp_path,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with pytest.raises(ValueError, match="empty historical"):
+                await collector._rest_epoch_history(  # noqa: SLF001
+                    client,
+                    source="binance_usdm.openInterestHist",
+                    symbol="XRPUSDT",
+                    decision_epoch=EPOCH,
+                )
+        attempt = store._db.execute(  # noqa: SLF001
+            "SELECT * FROM collector_attempts"
+        ).fetchone()
+        assert attempt["terminal_status"] == "INVALID_RESPONSE"
+        assert attempt["response_sha256"]
+        assert attempt["error_type"] == "ValueError"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_alert_log_path_and_two_replica_health(tmp_path) -> None:
+    paths = []
+    stores = []
+    try:
+        for name in ("a", "b"):
+            root = tmp_path / name
+            store = AppendOnlyPITStore(root)
+            stores.append(store)
+            ledger = EpochLedger(store._db, POLICY)  # noqa: SLF001
+            ledger.append_heartbeat(
+                collector_instance_id=f"replica-{name}",
+                run_id=f"run-{name}",
+                observed_at=RECEIVED,
+                health={"ok": True},
+            )
+            paths.append(store.path)
+        report = availability_report(
+            paths,
+            POLICY,
+            observed_at=RECEIVED + dt.timedelta(seconds=30),
+            stale_after_seconds=60,
+        )
+        assert report["healthy_replica_count"] == 2
+
+        ledger = EpochLedger(stores[0]._db, POLICY)  # noqa: SLF001
+        dispatcher = AlertDispatcher(ledger)
+        await dispatcher.emit(
+            alert_key="DATA_INTEGRITY_FAIL:test",
+            severity="CRITICAL",
+            payload={"alert_type": "DATA_INTEGRITY_FAIL"},
+            now=RECEIVED,
+        )
+        await dispatcher.emit(
+            alert_key="DATA_INTEGRITY_FAIL:test",
+            severity="CRITICAL",
+            payload={"alert_type": "DATA_INTEGRITY_FAIL"},
+            now=RECEIVED,
+        )
+        events = list(
+            ledger.db.execute(
+                "SELECT event_type, delivery_status "
+                "FROM collector_alert_events ORDER BY append_id"
+            )
+        )
+        assert [tuple(row) for row in events] == [
+            ("ALERT_RAISED", "PERSISTED"),
+            ("LOG_DELIVERY", "SUCCEEDED"),
+        ]
+    finally:
+        for store in stores:
+            store.close()

--- a/tests/test_binance_r4_p0_hardening.py
+++ b/tests/test_binance_r4_p0_hardening.py
@@ -474,6 +474,69 @@ async def test_historical_retry_appends_terminal_attempt(tmp_path) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_taker_history_shift_restores_full_epoch_coverage(tmp_path) -> None:
+    cadence = dt.timedelta(minutes=5)
+    interval_start = EPOCH - dt.timedelta(hours=4)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/futures/data/takerlongshortRatio"
+        request_start = int(request.url.params["startTime"])
+        assert request_start == int((interval_start + cadence).timestamp() * 1000)
+        assert request.url.params["endTime"] == str(
+            int((EPOCH + cadence).timestamp() * 1000) - 1
+        )
+        # This endpoint returns the bucket preceding each requested boundary.
+        first_bucket = request_start - int(cadence.total_seconds() * 1000)
+        return httpx.Response(
+            200,
+            json=[
+                _payload(
+                    "binance_usdm.takerLongShortRatio",
+                    timestamp=first_bucket
+                    + index * int(cadence.total_seconds() * 1000),
+                )
+                for index in range(48)
+            ],
+        )
+
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.takerLongShortRatio",),
+        symbols=("XRPUSDT",),
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._rest_epoch_history(  # noqa: SLF001
+                client,
+                source="binance_usdm.takerLongShortRatio",
+                symbol="XRPUSDT",
+                decision_epoch=EPOCH,
+            )
+
+        stored_rows = store._db.execute(  # noqa: SLF001
+            "SELECT COUNT(*) FROM pit_records "
+            "WHERE source = 'binance_usdm.takerLongShortRatio'"
+        ).fetchone()[0]
+        _, finalizer = _finalizer(store, policy=policy)
+        preview = finalizer.preview("XRPUSDT", EPOCH)
+
+        assert stored_rows == 48
+        assert preview.final_status == FINAL_COMPLETE
+        assert preview.invalid_sources == ()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_invalid_retry_response_keeps_hash_and_terminal_failure(
     tmp_path,
 ) -> None:

--- a/tests/test_binance_r4_p0_hardening.py
+++ b/tests/test_binance_r4_p0_hardening.py
@@ -7,6 +7,7 @@ import sqlite3
 import httpx
 import pytest
 
+from app.services.brokers.binance import r4_p0_collector as collector_module
 from app.services.brokers.binance.r4_p0_collector import (
     AppendOnlyPITStore,
     BinanceR4P0Collector,
@@ -21,6 +22,7 @@ from app.services.brokers.binance.r4_p0_hardening import (
     EpochLedger,
     EpochPolicy,
     RawPITReader,
+    RawPITReadError,
     availability_report,
     decision_epoch_for_event,
     finalization_report,
@@ -38,19 +40,31 @@ POLICY = EpochPolicy(
 )
 
 
-def _payload(source: str, value: str = "10") -> dict[str, str]:
+def _payload(
+    source: str,
+    value: str = "10",
+    *,
+    timestamp: int = 1785222000000,
+) -> dict[str, str]:
     if source == "binance_usdm.openInterestHist":
         return {
             "sumOpenInterest": value,
             "symbol": "XRPUSDT",
-            "timestamp": "1785222000000",
+            "timestamp": str(timestamp),
+        }
+    if source == "binance_usdm.basis":
+        return {
+            "basis": value,
+            "contractType": "PERPETUAL",
+            "pair": "XRPUSDT",
+            "timestamp": str(timestamp),
         }
     return {
         "buySellRatio": value,
         "buyVol": "20",
         "sellVol": "2",
         "symbol": "XRPUSDT",
-        "timestamp": "1785222000000",
+        "timestamp": str(timestamp),
     }
 
 
@@ -61,14 +75,16 @@ def _append(
     value: str = "10",
     received: dt.datetime = RECEIVED,
     sequence: str = "1785222000000",
+    event_time: dt.datetime = dt.datetime(2026, 7, 28, 7, tzinfo=dt.UTC),
 ) -> None:
+    timestamp = int(event_time.timestamp() * 1000)
     assert store.append(
         source=source,
         symbol="XRPUSDT",
-        raw_payload=_payload(source, value),
+        raw_payload=_payload(source, value, timestamp=timestamp),
         local_receive_time=received,
         run_id="replica:test",
-        event_time="2026-07-28T07:00:00.000000Z",
+        event_time=event_time.isoformat().replace("+00:00", "Z"),
         transaction_time=None,
         request_started_at="2026-07-28T07:00:59.000000Z",
         request_completed_at="2026-07-28T07:01:00.000000Z",
@@ -76,6 +92,23 @@ def _append(
         gap_detected=False,
         reconnect_id="replica:test:rest",
     )
+
+
+def _append_complete_periodic_source(
+    store: AppendOnlyPITStore,
+    source: str,
+    *,
+    observations: int = 48,
+) -> None:
+    interval_start = EPOCH - dt.timedelta(hours=4)
+    for index in range(observations):
+        event_time = interval_start + dt.timedelta(minutes=5 * index)
+        _append(
+            store,
+            source,
+            sequence=str(int(event_time.timestamp() * 1000)),
+            event_time=event_time,
+        )
 
 
 def _append_agg(store: AppendOnlyPITStore, *, gap: bool) -> None:
@@ -135,7 +168,7 @@ def test_finalizer_is_deterministic_across_input_order(tmp_path) -> None:
         root = tmp_path / str(index)
         with AppendOnlyPITStore(root) as store:
             for source in sources:
-                _append(store, source)
+                _append_complete_periodic_source(store, source)
             _, finalizer = _finalizer(store)
             preview = finalizer.preview("XRPUSDT", EPOCH)
             result = finalizer.finalize(
@@ -160,7 +193,7 @@ def test_finalizer_is_deterministic_across_input_order(tmp_path) -> None:
 def test_finalizer_missing_and_conflict_are_fail_closed(tmp_path) -> None:
     missing_root = tmp_path / "missing"
     with AppendOnlyPITStore(missing_root) as store:
-        _append(store, POLICY.required_sources[0])
+        _append_complete_periodic_source(store, POLICY.required_sources[0])
         _, finalizer = _finalizer(store)
         result = finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
         assert result.final_status == FINAL_MISSING
@@ -169,7 +202,7 @@ def test_finalizer_missing_and_conflict_are_fail_closed(tmp_path) -> None:
     conflict_root = tmp_path / "conflict"
     with AppendOnlyPITStore(conflict_root) as store:
         for source in POLICY.required_sources:
-            _append(store, source)
+            _append_complete_periodic_source(store, source)
         _append(
             store,
             POLICY.required_sources[0],
@@ -180,6 +213,81 @@ def test_finalizer_missing_and_conflict_are_fail_closed(tmp_path) -> None:
         result = finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
         assert result.final_status == FINAL_CONFLICT
         assert result.conflict_sources == (POLICY.required_sources[0],)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("observations", [1, 24, 47, 48])
+def test_periodic_source_requires_full_epoch_coverage(tmp_path, observations) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+    )
+    with AppendOnlyPITStore(tmp_path / str(observations)) as store:
+        _append_complete_periodic_source(
+            store,
+            "binance_usdm.basis",
+            observations=observations,
+        )
+        _, finalizer = _finalizer(store, policy=policy)
+        preview = finalizer.preview("XRPUSDT", EPOCH)
+
+        if observations == 48:
+            assert preview.final_status == FINAL_COMPLETE
+            assert preview.invalid_sources == ()
+        else:
+            assert preview.final_status == FINAL_MISSING
+            assert preview.missing_sources == ()
+            assert preview.invalid_sources == ("binance_usdm.basis",)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_partial_periodic_coverage_triggers_historical_retry(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        _append_complete_periodic_source(
+            store,
+            "binance_usdm.basis",
+            observations=24,
+        )
+        _, finalizer = _finalizer(store, policy=policy)
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        collector.epoch_policy = policy
+        collector.epoch_finalizer = finalizer
+        calls: list[tuple[str, str]] = []
+
+        async def retry_history(
+            _client,
+            *,
+            source: str,
+            symbol: str,
+            decision_epoch: dt.datetime,
+        ) -> None:
+            assert decision_epoch == EPOCH
+            calls.append((source, symbol))
+
+        monkeypatch.setattr(collector, "_rest_epoch_history", retry_history)
+        async with httpx.AsyncClient() as client:
+            await collector._retry_incomplete_epoch(  # noqa: SLF001
+                client,
+                EPOCH,
+                EPOCH + dt.timedelta(hours=1),
+            )
+
+        assert calls == [("binance_usdm.basis", "XRPUSDT")]
 
 
 @pytest.mark.unit
@@ -208,7 +316,7 @@ def test_independent_replica_covers_same_identity_gap(tmp_path) -> None:
 def test_finalization_ignores_late_payload_and_records_late_only(tmp_path) -> None:
     with AppendOnlyPITStore(tmp_path) as store:
         for source in POLICY.required_sources:
-            _append(store, source)
+            _append_complete_periodic_source(store, source)
         ledger, finalizer = _finalizer(store)
         original = finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
         _append(
@@ -243,7 +351,7 @@ def test_finalization_ignores_late_payload_and_records_late_only(tmp_path) -> No
 def test_attempt_and_finalization_tables_reject_update_delete(tmp_path) -> None:
     with AppendOnlyPITStore(tmp_path) as store:
         for source in POLICY.required_sources:
-            _append(store, source)
+            _append_complete_periodic_source(store, source)
         ledger, finalizer = _finalizer(store)
         ledger.ensure_open_rows(EPOCH, "replica-a", RECEIVED)
         ledger.append_attempt(
@@ -290,7 +398,7 @@ def test_replica_finalizations_are_deduplicated_and_divergence_is_visible(
             store = AppendOnlyPITStore(tmp_path / name)
             stores.append(store)
             for source in POLICY.required_sources:
-                _append(store, source)
+                _append_complete_periodic_source(store, source)
             _, finalizer = _finalizer(store)
             finalizer.finalize("XRPUSDT", EPOCH, observed_at=finalize_at(EPOCH))
             paths.append(store.path)
@@ -398,6 +506,131 @@ async def test_invalid_retry_response_keeps_hash_and_terminal_failure(
         assert attempt["terminal_status"] == "INVALID_RESPONSE"
         assert attempt["response_sha256"]
         assert attempt["error_type"] == "ValueError"
+        assert attempt["error_message"] == (
+            "empty historical response from /futures/data/openInterestHist"
+        )
+        assert "ValueError: empty historical response" in attempt["error_traceback"]
+        assert attempt["response_body_summary"] == "[]"
+
+
+@pytest.mark.unit
+def test_rows_for_epoch_surfaces_unreadable_replica(tmp_path) -> None:
+    with AppendOnlyPITStore(tmp_path / "local") as store:
+        replica = tmp_path / "replica.sqlite3"
+        replica.write_text("copy still in progress", encoding="utf-8")
+        reader = RawPITReader(store._db, store.path, (replica,))  # noqa: SLF001
+
+        with pytest.raises(
+            RawPITReadError,
+            match="failed to read replica PIT artifact.*file is not a database",
+        ):
+            reader.rows_for_epoch(
+                symbol="XRPUSDT",
+                decision_epoch=EPOCH,
+                received_by=finalize_at(EPOCH),
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_epoch_supervisor_failure_is_logged_counted_and_stops(
+    tmp_path,
+    monkeypatch,
+    caplog,
+) -> None:
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        now = finalize_at(EPOCH)
+        monkeypatch.setattr(collector_module, "utc_now", lambda: now)
+        monkeypatch.setattr(
+            collector_module,
+            "scheduled_epochs",
+            lambda _start, _end: (EPOCH,),
+        )
+
+        async def fail_finalize(
+            _epoch: dt.datetime,
+            _observed_at: dt.datetime,
+        ) -> None:
+            raise RuntimeError("injected finalizer failure")
+
+        monkeypatch.setattr(collector, "_finalize_epoch", fail_finalize)
+        with (
+            caplog.at_level("ERROR", logger="r4_p0_collector"),
+            pytest.raises(RuntimeError, match="injected finalizer failure"),
+        ):
+            await collector._epoch_supervisor()  # noqa: SLF001
+
+        assert collector.stop.is_set()
+        assert collector.failure_counts == {"epoch_supervisor": 1}
+        record = caplog.records[-1]
+        assert "detail='injected finalizer failure'" in record.getMessage()
+        assert record.exc_info is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_retry_failures_are_logged_counted_and_preserve_diagnostics(
+    tmp_path,
+    caplog,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="provider failed: incident-247")
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with caplog.at_level("ERROR", logger="r4_p0_collector"):
+                await collector._retry_incomplete_epoch(  # noqa: SLF001
+                    client,
+                    EPOCH,
+                    EPOCH + dt.timedelta(hours=1),
+                )
+
+        attempts = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT terminal_status, error_type, error_message,
+                       error_traceback, response_body_summary
+                FROM collector_attempts ORDER BY append_id
+                """
+            )
+        )
+        assert len(attempts) == 4
+        assert collector.failure_counts == {"epoch_retry": 4}
+        assert (
+            len(
+                [
+                    record
+                    for record in caplog.records
+                    if "collector.epoch_retry.failed" in record.getMessage()
+                ]
+            )
+            == 4
+        )
+        for attempt in attempts:
+            assert attempt["terminal_status"] == "HTTP_ERROR"
+            assert attempt["error_type"] == "HTTPStatusError"
+            assert "500 Internal Server Error" in attempt["error_message"]
+            assert "httpx.HTTPStatusError" in attempt["error_traceback"]
+            assert attempt["response_body_summary"] == "provider failed: incident-247"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- add an immutable epoch source/attempt/finalization ledger for R4.1 §3.2
- deterministically finalize each signal-symbol epoch as `FINAL_COMPLETE`, `FINAL_MISSING`, or `FINAL_CONFLICT` at `e + 4h`
- retry only event-time-bounded historical sources before the fixed deadline, preserving pre-request and terminal attempt rows
- merge two independent read-only collector artifacts by canonical source identity
- add deadline/integrity/redundancy alerts plus an independent two-replica watchdog
- add inactive launchd `KeepAlive` examples and an operator runbook; no scheduler registration or deployment

## Existing behavior retained

- unsigned public Binance GET/websocket allowlists
- websocket reconnect and normal REST polling backoff
- raw PIT append-only SQLite rows, semantic deduplication, and partition hash chains
- signal/candidate/score/stage logic is untouched

## Determinism and immutability

The evaluator uses only the sealed policy/source manifest, the fixed `[e-4h,e)` interval, rows received by `finalize_at(e)`, and sorted unique source-identity/payload-hash evidence. Append order, replica path order, retry count, run ID, and wall-clock recording time are excluded from the evaluation hash. All new ledger tables reject UPDATE and DELETE. Re-evaluation must match the immutable hash; late rows are `LATE_ONLY` and cannot change the result.

## Availability and alert path

- operational `--run` requires two configured artifacts, two distinct fresh collector IDs, and an HTTPS webhook unless log-only validation is explicitly selected
- each collector writes append-only heartbeats and watches peer freshness
- independent watchdog pages on lost redundancy or missing/divergent due finalizations
- final missing/conflict emits `DATA_INTEGRITY_FAIL`; alert creation and delivery attempts are append-only

## Validation

- `uv run pytest tests/test_binance_r4_p0_collector.py tests/test_binance_r4_p0_hardening.py tests/test_binance_r4_p0_backfill.py -q --no-cov` — 23 passed
- `make lint` — Ruff, format check, and ty passed across app/tests/research/scripts
- both example plists pass `plutil -lint`
- collector/watchdog dry-run paths perform no network, DB, broker, scheduler, or deployment mutation

## Related

- ROB-1108
- basis empty-response root cause/fix is intentionally separate in #1695. This PR treats unresolved basis data as retryable before deadline and `FINAL_MISSING` at deadline; it does not absorb that out-of-scope fix.

## Not done

- no production deployment or process restart
- no scheduler/cron/launchd registration
- no production DB or broker mutation
- no one-week rehearsal (operator-owned item 4)
- do not merge before operator review and manual fault injection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic four-hour epoch finalization with completeness, conflict, and integrity checks.
  * Added replica health monitoring, redundancy alerts, and optional HTTPS webhook notifications.
  * Added deadline-aware recovery for missing historical data and late-arriving corrections.
  * Added a watchdog for stalled finalization and reduced collector redundancy.
  * Added deployment templates and expanded runbook guidance for supervised operation.

* **Bug Fixes**
  * Improved request validation, duplicate handling, failure diagnostics, and retry behavior.
  * Corrected vendor-specific historical data offsets to restore complete coverage.

* **Tests**
  * Expanded coverage for finalization, retries, replicas, alerts, failures, and append-only data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->