### PR TITLE
fix(ROB-1109): restore watch intent ledger and truthful outcomes

### DIFF
--- a/alembic/versions/20260728_rob1109_restore_watch_intent_ledger.py
+++ b/alembic/versions/20260728_rob1109_restore_watch_intent_ledger.py
@@ -26,7 +26,7 @@ from sqlalchemy.sql import text
 from alembic import op
 
 revision: str = "20260728_rob1109_watch_intent"
-down_revision: str | Sequence[str] | None = "20260728_rob1103_watch_links"
+down_revision: str | Sequence[str] | None = "20260728_rob1115_learning"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/20260728_rob1109_restore_watch_intent_ledger.py
+++ b/alembic/versions/20260728_rob1109_restore_watch_intent_ledger.py
@@ -1,0 +1,232 @@
+"""ROB-1109 restore the active watch intent ledger.
+
+Revision ID: 20260728_rob1109_watch_intent
+Revises: 20260728_rob1103_watch_links
+Create Date: 2026-07-28 00:00:00.000000
+
+ROB-265 Plan 5 misclassified ``review.watch_order_intent_ledger`` as a
+legacy action-center table.  The model and ROB-402 auto-execution path remain
+active, so this migration corrects that classification; it does not roll back
+the other ROB-265 removals.
+
+The table definition mirrors both ``daf4130b13ce`` and
+``WatchOrderIntentLedger``.  The watch-event outcome constraint also gains a
+``pending`` state so auto-execution cannot be recorded as successful before
+the executor returns evidence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import text
+
+from alembic import op
+
+revision: str = "20260728_rob1109_watch_intent"
+down_revision: str | Sequence[str] | None = "20260728_rob1103_watch_links"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SCHEMA = "review"
+_EVENT_TABLE = "investment_watch_events"
+_EVENT_OUTCOME_CONSTRAINT = "ck_investment_watch_events_outcome"
+_EVENT_OUTCOME_LEGACY_CONSTRAINT = (
+    "ck_investment_watch_events_ck_investment_watch_events_outcome"
+)
+_OUTCOME_WITH_PENDING = (
+    "outcome IN ('notified','review_required','preview_attached','pending',"
+    "'executed','expired','ignored','failed')"
+)
+_OUTCOME_WITHOUT_PENDING = (
+    "outcome IN ('notified','review_required','preview_attached',"
+    "'executed','expired','ignored','failed')"
+)
+
+
+def _replace_event_outcome_constraint(expression: str) -> None:
+    # Older migrations ran through the metadata naming convention and could
+    # persist the doubled name. Raw DDL avoids applying that convention again
+    # while accepting both deployed variants.
+    op.execute(
+        f"ALTER TABLE {_SCHEMA}.{_EVENT_TABLE} "
+        f'DROP CONSTRAINT IF EXISTS "{_EVENT_OUTCOME_CONSTRAINT}"'
+    )
+    op.execute(
+        f"ALTER TABLE {_SCHEMA}.{_EVENT_TABLE} "
+        f'DROP CONSTRAINT IF EXISTS "{_EVENT_OUTCOME_LEGACY_CONSTRAINT}"'
+    )
+    op.execute(
+        f"ALTER TABLE {_SCHEMA}.{_EVENT_TABLE} "
+        f'ADD CONSTRAINT "{_EVENT_OUTCOME_CONSTRAINT}" CHECK ({expression})'
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "watch_order_intent_ledger",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("correlation_id", sa.Text(), nullable=False),
+        sa.Column("idempotency_key", sa.Text(), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("target_kind", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("condition_type", sa.Text(), nullable=False),
+        sa.Column("threshold", sa.Numeric(18, 8), nullable=False),
+        sa.Column("threshold_key", sa.Text(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("side", sa.Text(), nullable=False),
+        sa.Column("account_mode", sa.Text(), nullable=False),
+        sa.Column("execution_source", sa.Text(), nullable=False),
+        sa.Column("lifecycle_state", sa.Text(), nullable=False),
+        sa.Column("quantity", sa.Numeric(18, 8), nullable=True),
+        sa.Column("limit_price", sa.Numeric(18, 8), nullable=True),
+        sa.Column("notional", sa.Numeric(18, 8), nullable=True),
+        sa.Column("currency", sa.Text(), nullable=True),
+        sa.Column("notional_krw_input", sa.Numeric(18, 2), nullable=True),
+        sa.Column("max_notional_krw", sa.Numeric(18, 2), nullable=True),
+        sa.Column("notional_krw_evaluated", sa.Numeric(18, 2), nullable=True),
+        sa.Column("fx_usd_krw_used", sa.Numeric(18, 4), nullable=True),
+        sa.Column(
+            "approval_required",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "execution_allowed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "blocking_reasons",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("blocked_by", sa.Text(), nullable=True),
+        sa.Column(
+            "detail",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "preview_line",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("triggered_value", sa.Numeric(18, 8), nullable=True),
+        sa.Column("kst_date", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "correlation_id",
+            name="uq_watch_intent_correlation_id",
+        ),
+        sa.CheckConstraint(
+            "lifecycle_state IN ('previewed','failed')",
+            name="watch_intent_ledger_lifecycle_state",
+        ),
+        sa.CheckConstraint(
+            "side IN ('buy','sell')",
+            name="watch_intent_ledger_side",
+        ),
+        sa.CheckConstraint(
+            "account_mode = 'kis_mock'",
+            name="watch_intent_ledger_account_mode",
+        ),
+        sa.CheckConstraint(
+            "execution_source = 'watch'",
+            name="watch_intent_ledger_execution_source",
+        ),
+        sa.CheckConstraint(
+            "currency IS NULL OR currency IN ('KRW','USD')",
+            name="watch_intent_ledger_currency",
+        ),
+        schema=_SCHEMA,
+    )
+
+    op.create_index(
+        "ix_watch_intent_kst_date",
+        "watch_order_intent_ledger",
+        ["kst_date"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_watch_intent_market_symbol",
+        "watch_order_intent_ledger",
+        ["market", "symbol"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_watch_intent_state_created_at",
+        "watch_order_intent_ledger",
+        ["lifecycle_state", "created_at"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "uq_watch_intent_previewed_idempotency",
+        "watch_order_intent_ledger",
+        ["idempotency_key"],
+        unique=True,
+        schema=_SCHEMA,
+        postgresql_where=text("lifecycle_state = 'previewed'"),
+    )
+
+    _replace_event_outcome_constraint(_OUTCOME_WITH_PENDING)
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM review.watch_order_intent_ledger
+            ) THEN
+                RAISE EXCEPTION
+                    'cannot downgrade: watch_order_intent_ledger contains audit rows';
+            END IF;
+            IF EXISTS (
+                SELECT 1
+                FROM review.investment_watch_events
+                WHERE outcome = 'pending'
+            ) THEN
+                RAISE EXCEPTION
+                    'cannot downgrade: investment_watch_events contains pending outcomes';
+            END IF;
+        END
+        $$;
+        """
+    )
+
+    _replace_event_outcome_constraint(_OUTCOME_WITHOUT_PENDING)
+    op.drop_index(
+        "uq_watch_intent_previewed_idempotency",
+        table_name="watch_order_intent_ledger",
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "ix_watch_intent_state_created_at",
+        table_name="watch_order_intent_ledger",
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "ix_watch_intent_market_symbol",
+        table_name="watch_order_intent_ledger",
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "ix_watch_intent_kst_date",
+        table_name="watch_order_intent_ledger",
+        schema=_SCHEMA,
+    )
+    op.drop_table("watch_order_intent_ledger", schema=_SCHEMA)

--- a/app/jobs/investment_watch_scanner.py
+++ b/app/jobs/investment_watch_scanner.py
@@ -7,7 +7,8 @@ snapshot, transitions the alert to ``triggered``, and emits Hermes
 review-trigger notifications.
 
 Locked semantics:
-* Watch is a **review trigger**, never an automatic order instruction.
+* Watch is a **review trigger** unless the report activation explicitly uses
+  ``auto_execute_mock``; that mode is permanently limited to ``kis_mock``.
 * No broker / live order mutation from this path.
 * Notification target is **Hermes**, never the agent gateway (the legacy
   agent-gateway watch-alert path has been removed).
@@ -87,12 +88,13 @@ logger = logging.getLogger(__name__)
 # success/failure is tracked separately via the delivery_status /
 # delivery_reason / delivered_at / delivery_attempts columns; the
 # original ``outcome`` is the operator-facing classification of what
-# the watch represented (notified / review_required / preview_attached).
+# the watch represented. Auto-execution starts pending and is finalized
+# only after maybe_auto_execute returns evidence (ROB-843 / ROB-1109).
 _OUTCOME_BY_ACTION_MODE: dict[str, str] = {
     "notify_only": "notified",
     "preview_only": "preview_attached",
     "approval_required": "review_required",
-    "auto_execute_mock": "executed",
+    "auto_execute_mock": "pending",
 }
 
 
@@ -363,13 +365,16 @@ class InvestmentWatchScanner:
             stats.details.append(emission["detail"])
             if alert.action_mode == "auto_execute_mock":
                 payload = emission["payload"]
+                execution_outcome = "failed"
                 try:
-                    await maybe_auto_execute(
+                    execution_result = await maybe_auto_execute(
                         db,
                         alert=alert,
                         correlation_id=payload.correlation_id,
                         kst_date=payload.kst_date,
                     )
+                    if execution_result.get("executed") is True:
+                        execution_outcome = "executed"
                 except Exception:  # noqa: BLE001 - never kill the scan loop
                     logger.exception(
                         "auto_execute_mock failed for alert %s",
@@ -380,6 +385,13 @@ class InvestmentWatchScanner:
                     # back so this alert's own delivery bookkeeping (and
                     # every alert after it) can still commit.
                     await self._reset_session(db)
+                await repo.update_event_outcome(
+                    emission["event_id"],
+                    outcome=execution_outcome,
+                )
+                await db.commit()
+                payload.outcome = execution_outcome
+                emission["detail"]["outcome"] = execution_outcome
         else:
             # No new event row this iteration — we found an existing
             # pending/failed/skipped row from earlier in the day and are

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1374,15 +1374,19 @@ Watch execution context fields:
 ### `manage_watch_alerts` — removed (ROB-265)
 
 The legacy Redis-backed `manage_watch_alerts` MCP tool was removed by
-ROB-265 along with the `watch_alerts` / `watch_order_intent_ledger` /
-`watch_scanner` Redis surface. Report-scoped watches now flow through
+ROB-265 along with the `watch_alerts` / `watch_scanner` Redis surface.
+`review.watch_order_intent_ledger` is not part of that legacy surface: ROB-1109
+restored it as the active audit ledger for the mock-only auto-execution path.
+Report-scoped watches now flow through
 `investment_report_activate_watch` (which copies an approved watch
 item into `investment_watch_alerts` as an immutable activation
 snapshot) and the `investment_watch_scanner` job (which evaluates
 those alerts, writes `investment_watch_events` with the full trigger
 identity snapshot, and emits Hermes review-trigger notifications).
-Watches are review triggers, not automatic order instructions —
-delivery state is auditable per event row (`delivery_status` /
+Watches are review triggers by default. The explicit `auto_execute_mock` mode
+is permanently restricted to `kis_mock`; its event starts with
+`outcome='pending'` and becomes `executed` only after positive executor
+evidence. Delivery state is auditable per event row (`delivery_status` /
 `delivery_reason` / `delivered_at` / `delivery_attempts`).
 
 ### `list_active_watches`

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -589,10 +589,11 @@ class InvestmentWatchAlert(Base):
 class InvestmentWatchEvent(Base):
     """Scanner-emitted trigger event linked back to source report/item.
 
-    Replaces every legacy write path that went through
-    ``watch_order_intent_ledger``. ``idempotency_key`` is
-    ``alert_uuid:kst_date:threshold_key`` so a single watch can only
-    fire once per day per threshold cross.
+    Replaces the legacy watch-notification write path.
+    ``watch_order_intent_ledger`` remains a separate, active audit ledger for
+    the explicitly mock-only auto-execution decision. ``idempotency_key`` is
+    ``alert_uuid:kst_date:threshold_key`` so a single watch can only fire once
+    per day per threshold cross.
 
     **Audit identity is self-contained.** Because ``alert_id`` is
     ``ON DELETE SET NULL``, the event row must carry the full immutable
@@ -615,7 +616,7 @@ class InvestmentWatchEvent(Base):
         ),
         CheckConstraint(
             "outcome IN ('notified','review_required','preview_attached',"
-            "'executed','expired','ignored','failed')",
+            "'pending','executed','expired','ignored','failed')",
             name="ck_investment_watch_events_outcome",
         ),
         CheckConstraint(

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -999,6 +999,8 @@ class InvestmentWatchEventResponse(BaseModel):
         "notified",
         "review_required",
         "preview_attached",
+        "pending",
+        "executed",
         "expired",
         "ignored",
         "failed",

--- a/app/services/hermes_client.py
+++ b/app/services/hermes_client.py
@@ -42,6 +42,7 @@ WatchEventOutcomeLiteral = Literal[
     "notified",
     "review_required",
     "preview_attached",
+    "pending",
     "executed",
     "expired",
     "ignored",

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -475,6 +475,14 @@ class InvestmentReportsRepository:
             .values(follow_up_report_item_id=follow_up_report_item_id)
         )
 
+    async def update_event_outcome(self, event_id: int, *, outcome: str) -> None:
+        """Persist the evidence-backed execution outcome for a watch event."""
+        await self._session.execute(
+            sa.update(InvestmentWatchEvent)
+            .where(InvestmentWatchEvent.id == event_id)
+            .values(outcome=outcome)
+        )
+
     async def update_event_delivery(
         self,
         event_id: int,

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -832,7 +832,7 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ALTER TABLE review.investment_watch_events "
     "ADD CONSTRAINT ck_investment_watch_events_outcome "
     "CHECK (outcome IN ('notified','review_required','preview_attached',"
-    "'executed','expired','ignored','failed'))",
+    "'pending','executed','expired','ignored','failed'))",
     # ---- watch source-link semantics (ROB-1103) ----
     "ALTER TABLE review.investment_watch_alerts "
     "ALTER COLUMN source_report_uuid DROP NOT NULL",

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -141,6 +141,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             await connection.execute(
                 text("DROP TABLE review.trade_retrospective_actions")
             )
+            # ROB-1109 is later than this reconstructed boundary. Current
+            # metadata already contains its restored table, so remove it before
+            # upgrading the post-ROB-849 chain.
+            await connection.execute(
+                text("DROP TABLE review.watch_order_intent_ledger")
+            )
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -129,6 +129,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             await connection.execute(
                 text("DROP TABLE research.strategy_learning_events")
             )
+            # ROB-1109 is later than this reconstructed boundary. Current
+            # metadata already contains its restored table, so remove it before
+            # upgrading the post-ROB-850 chain.
+            await connection.execute(
+                text("DROP TABLE review.watch_order_intent_ledger")
+            )
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/test_investment_watch_scanner.py
+++ b/tests/test_investment_watch_scanner.py
@@ -624,7 +624,7 @@ async def test_scan_market_triggers_on_zone_inside(
 async def test_scan_calls_auto_execute_for_auto_execute_mock(
     session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    await _seed_active_kr_alert(session, action_mode="auto_execute_mock")
+    alert = await _seed_active_kr_alert(session, action_mode="auto_execute_mock")
 
     async def _fake_current_value(**_kwargs) -> float:
         return 25.0  # below 30 → triggered
@@ -635,7 +635,20 @@ async def test_scan_calls_auto_execute_for_auto_execute_mock(
     captured: list = []
 
     async def _fake_maybe_auto_execute(db, *, alert, correlation_id, kst_date, **kw):
-        captured.append({"symbol": alert.symbol, "cid": correlation_id})
+        outcome_before_execution = await db.scalar(
+            sa.text(
+                "SELECT outcome FROM review.investment_watch_events "
+                "WHERE correlation_id = :correlation_id"
+            ),
+            {"correlation_id": correlation_id},
+        )
+        captured.append(
+            {
+                "symbol": alert.symbol,
+                "cid": correlation_id,
+                "outcome_before_execution": outcome_before_execution,
+            }
+        )
         return {"executed": False, "skipped": "stubbed"}
 
     monkeypatch.setattr(scanner_module, "maybe_auto_execute", _fake_maybe_auto_execute)
@@ -647,6 +660,65 @@ async def test_scan_calls_auto_execute_for_auto_execute_mock(
     assert summary["triggered"] == 1, summary
     assert len(captured) == 1, captured
     assert captured[0]["symbol"] == "005930"
+    assert captured[0]["outcome_before_execution"] == "pending"
+
+    event_outcome = await session.scalar(
+        sa.text(
+            "SELECT outcome FROM review.investment_watch_events "
+            "WHERE alert_id = :alert_id"
+        ),
+        {"alert_id": alert.id},
+    )
+    assert event_outcome == "failed"
+    assert stub.calls[0].outcome == "failed"
+
+
+@pytest.mark.asyncio
+async def test_scan_records_executed_only_after_positive_execution_evidence(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    alert = await _seed_active_kr_alert(
+        session,
+        action_mode="auto_execute_mock",
+        client_item_key="watch-executed-evidence",
+    )
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    outcomes_seen_by_executor: list[str | None] = []
+
+    async def _fake_maybe_auto_execute(db, *, correlation_id, **_kwargs):
+        outcomes_seen_by_executor.append(
+            await db.scalar(
+                sa.text(
+                    "SELECT outcome FROM review.investment_watch_events "
+                    "WHERE correlation_id = :correlation_id"
+                ),
+                {"correlation_id": correlation_id},
+            )
+        )
+        return {"executed": True, "correlation_id": correlation_id}
+
+    monkeypatch.setattr(scanner_module, "maybe_auto_execute", _fake_maybe_auto_execute)
+
+    stub = _StubHermesClient()
+    summary = await InvestmentWatchScanner(hermes_client=stub).scan_market("kr")
+
+    assert summary["triggered"] == 1
+    assert outcomes_seen_by_executor == ["pending"]
+    event_outcome = await session.scalar(
+        sa.text(
+            "SELECT outcome FROM review.investment_watch_events "
+            "WHERE alert_id = :alert_id"
+        ),
+        {"alert_id": alert.id},
+    )
+    assert event_outcome == "executed"
+    assert stub.calls[0].outcome == "executed"
 
 
 # --- ROB-500 Tests ---

--- a/tests/test_watch_order_intent_ledger.py
+++ b/tests/test_watch_order_intent_ledger.py
@@ -49,3 +49,36 @@ async def test_intent_account_mode_check_blocks_live(db_session: AsyncSession):
     with pytest.raises(IntegrityError):
         await db_session.commit()
     await db_session.rollback()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "constraint"),
+    [
+        ({"side": "hold"}, "side"),
+        ({"lifecycle_state": "executed"}, "lifecycle_state"),
+    ],
+)
+async def test_intent_domain_checks_reject_invalid_values(
+    db_session: AsyncSession,
+    overrides: dict,
+    constraint: str,
+):
+    db_session.add(_row(**overrides))
+    with pytest.raises(IntegrityError, match=constraint):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_intent_correlation_id_is_unique(db_session: AsyncSession):
+    correlation_id = f"corr-{uuid4().hex}"
+    db_session.add_all(
+        [
+            _row(correlation_id=correlation_id),
+            _row(correlation_id=correlation_id),
+        ]
+    )
+    with pytest.raises(IntegrityError, match="uq_watch_intent_correlation_id"):
+        await db_session.commit()
+    await db_session.rollback()


### PR DESCRIPTION
## Summary
- restore `review.watch_order_intent_ledger` after its ROB-265 Plan 5 legacy misclassification, without reverting any other ROB-265 migration
- match the original `daf4130b13ce` table definition and the live `WatchOrderIntentLedger` model, including correlation, lifecycle-state, and side constraints
- record `auto_execute_mock` watch events as `pending` before execution, then persist `executed` only when the executor returns explicit `executed=true`; otherwise persist `failed`
- propagate the new `pending` event outcome through the model, schema bootstrap, Hermes contract, repository, and MCP documentation

## Migration safety
- remains a single Alembic head (`20260728_rob1109_watch_intent`)
- local PostgreSQL upgrade, downgrade, and re-upgrade verified
- downgrade refuses to drop a non-empty audit ledger or remove `pending` while pending events exist
- no production migration was applied

## Verification
- `make lint`
- targeted ROB-1109 tests: 29 passed
- migration acceptance tests for paper cohort/evaluation passed
- full suite: 18,342 passed, 15 skipped, 7 deselected

## Safety
- no broker mutation or live order
- do not merge before adversarial validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored an audit ledger for mock-only automatic execution decisions.
  * Added a `pending` event status that transitions to `executed` or `failed` based on execution evidence.
  * Updated watch scanning and notifications to report final execution outcomes.
  * Restricted automatic execution to the mock environment.

* **Bug Fixes**
  * Prevented events from being marked as executed before execution evidence is available.

* **Documentation**
  * Updated watch workflow and audit behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->