### PR TITLE
feat(ROB-1106): add default-off posture-v1 shadow coverage

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -21,6 +21,13 @@ from pydantic import (
 
 Lane = Literal["buy", "sell", "discovery"]
 Market = Literal["kr", "us", "crypto"]
+PostureStateName = Literal[
+    "RESTING",
+    "CONDITIONAL",
+    "ARMED_DEFERRED",
+    "DISARMED",
+    "EXPIRED_REARMABLE",
+]
 
 ThresholdValue = int | float | str | list[int | float]
 RuleConditionValue = int | float | str | bool | list[int | float | str | bool]
@@ -235,6 +242,40 @@ class PolicyAuthority(BaseModel):
     does_not_govern: list[str]
 
 
+class PosturePolicy(BaseModel):
+    """ROB-1106 stage-1 feature gate and five-state shadow contract.
+
+    Only ``shadow`` is accepted in this stage. Later pilot/live modes need
+    separate authorization and implementation rather than silently widening
+    this schema.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    mode: Literal["shadow"]
+    states: list[PostureStateName]
+    policy_stamp_required: Literal[True]
+
+    @field_validator("states")
+    @classmethod
+    def validate_exact_five_states(
+        cls, value: list[PostureStateName]
+    ) -> list[PostureStateName]:
+        required = {
+            "RESTING",
+            "CONDITIONAL",
+            "ARMED_DEFERRED",
+            "DISARMED",
+            "EXPIRED_REARMABLE",
+        }
+        if len(value) != len(required) or set(value) != required:
+            raise ValueError(
+                "posture.states must contain exactly the five posture-v1 states"
+            )
+        return value
+
+
 class OrderProposalAutoApprovePolicy(BaseModel):
     """Default-off resting-order auto-approval thresholds (ROB-871).
 
@@ -338,6 +379,7 @@ class TradingPolicyDocument(BaseModel):
     captured_as_of: str
     source: str
     authority: PolicyAuthority
+    posture: PosturePolicy
     order_proposals: OrderProposalsPolicy
     sector_clusters: dict[str, list[str]]
     thresholds: dict[str, PolicyThreshold]

--- a/app/services/posture_generator.py
+++ b/app/services/posture_generator.py
@@ -1,0 +1,414 @@
+"""Pure posture-v1 stage-1 generator and coverage accounting (ROB-1106).
+
+The generator consumes a captured holdings/quotes/policy-context snapshot and
+returns declarative posture rows. It has no database, proposal, notification,
+broker, or order dependency. Unknown policy combinations are intentionally
+reported as unmapped instead of being forced into DISARMED: finding those holes
+is the purpose of the first shadow stage.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.trading_policy import PosturePolicy
+
+
+class PostureState(StrEnum):
+    RESTING = "RESTING"
+    CONDITIONAL = "CONDITIONAL"
+    ARMED_DEFERRED = "ARMED_DEFERRED"
+    DISARMED = "DISARMED"
+    EXPIRED_REARMABLE = "EXPIRED_REARMABLE"
+
+
+POSTURE_STATES: tuple[PostureState, ...] = tuple(PostureState)
+
+Market = Literal["kr", "us", "crypto"]
+Intent = Literal["buy", "sell"]
+LevelStatus = Literal["fresh", "stale", "expired", "missing"]
+LevelStrength = Literal["strong", "moderate", "weak", "unknown"]
+
+_MAX_LIVE_DISTANCE_PCT: dict[str, Decimal] = {
+    "kr": Decimal("15"),
+    "us": Decimal("15"),
+    "crypto": Decimal("20"),
+}
+
+
+class PostureDisabledError(RuntimeError):
+    """Raised when a caller tries to bypass the default-off posture gate."""
+
+
+class PostureHolding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    holding_id: str = Field(min_length=1)
+    account_id: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    market: Market
+    quantity: Decimal
+    average_cost: Decimal | None = None
+
+
+class PostureQuote(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str = Field(min_length=1)
+    market: Market
+    price: Decimal
+    observed_at: dt.datetime
+
+
+class PosturePolicyContext(BaseModel):
+    """Policy facts already resolved for one holding.
+
+    ``level_role`` remains an open string on purpose. A new/unknown role must
+    appear in ``unmapped_holdings`` until the five-state definition explicitly
+    covers it; validation must not erase that measurement opportunity.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    holding_id: str = Field(min_length=1)
+    intent: Intent
+    level_role: str | None = None
+    level_price: Decimal | None = None
+    level_status: LevelStatus = "missing"
+    level_strength: LevelStrength = "unknown"
+    price_touch_sufficient: bool | None = None
+    evidence_ready: bool | None = None
+    intent_approved: bool | None = None
+    risk_eligible: bool | None = None
+    economic_floor_met: bool | None = None
+    rearm_allowed: bool = False
+    block_reasons: list[str] = Field(default_factory=list)
+    review_at: dt.datetime | None = None
+
+
+class PostureGeneratorInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    captured_at: dt.datetime
+    holdings: list[PostureHolding]
+    quotes: list[PostureQuote]
+    policy_contexts: list[PosturePolicyContext]
+
+    @model_validator(mode="after")
+    def validate_unique_input_keys(self) -> PostureGeneratorInput:
+        holding_ids = [row.holding_id for row in self.holdings]
+        if len(holding_ids) != len(set(holding_ids)):
+            raise ValueError("holding_id must be unique")
+
+        context_ids = [row.holding_id for row in self.policy_contexts]
+        if len(context_ids) != len(set(context_ids)):
+            raise ValueError("policy context holding_id must be unique")
+
+        quote_keys = [(row.market, row.symbol.upper()) for row in self.quotes]
+        if len(quote_keys) != len(set(quote_keys)):
+            raise ValueError("quote market/symbol must be unique")
+        return self
+
+
+class PostureAssignment(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    holding_id: str
+    account_id: str
+    symbol: str
+    market: Market
+    state: PostureState
+    reason: str
+    intent: Intent
+    level_role: str | None
+    quantity: Decimal
+    current_price: Decimal | None
+    level_price: Decimal | None
+    target_distance_pct: Decimal | None
+    review_at: dt.datetime | None
+    policy_version: str
+    policy_content_hash: str
+
+
+class UnmappedHolding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    holding_id: str
+    account_id: str
+    symbol: str
+    market: Market
+    reason: str
+    level_role: str | None = None
+
+
+class PostureCoverage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input_holding_count: int
+    mapped_holding_count: int
+    unmapped_holding_count: int
+    coverage_ratio: float
+    state_counts: dict[PostureState, int]
+    state_symbol_counts: dict[PostureState, int]
+
+    @model_validator(mode="after")
+    def validate_totals_and_five_states(self) -> PostureCoverage:
+        expected = set(POSTURE_STATES)
+        if set(self.state_counts) != expected:
+            raise ValueError("state_counts must include exactly all five states")
+        if set(self.state_symbol_counts) != expected:
+            raise ValueError("state_symbol_counts must include exactly all five states")
+        if sum(self.state_counts.values()) != self.mapped_holding_count:
+            raise ValueError("state_counts total must equal mapped_holding_count")
+        if (
+            self.mapped_holding_count + self.unmapped_holding_count
+            != self.input_holding_count
+        ):
+            raise ValueError("mapped + unmapped must equal input holding count")
+        return self
+
+
+class ShadowSafetyCounters(BaseModel):
+    """Explicit zero-mutation evidence carried by every shadow artifact."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    orders_created: Literal[0] = 0
+    proposals_created: Literal[0] = 0
+    broker_mutations: Literal[0] = 0
+
+
+class PostureGenerationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    captured_at: dt.datetime
+    generated_at: dt.datetime
+    policy_version: str
+    policy_content_hash: str
+    mode: Literal["shadow"] = "shadow"
+    assignments: list[PostureAssignment]
+    unmapped_holdings: list[UnmappedHolding]
+    coverage: PostureCoverage
+    safety: ShadowSafetyCounters = Field(default_factory=ShadowSafetyCounters)
+
+
+def _distance_pct(level_price: Decimal, quote_price: Decimal) -> Decimal:
+    return ((level_price / quote_price) - Decimal("1")) * Decimal("100")
+
+
+def _unmapped_reason(
+    *,
+    holding: PostureHolding,
+    context: PosturePolicyContext | None,
+) -> str | None:
+    if context is None:
+        return "missing_policy_context"
+    if context.level_role is None:
+        return "missing_level_role"
+    if context.level_role not in {
+        "HARD_EXIT",
+        "CONDITIONAL_EXIT",
+        "HARD_INVALIDATION",
+        "BUY_SUPPORT",
+        "REFERENCE_ONLY",
+    }:
+        return f"state_definition_gap:unknown_level_role:{context.level_role}"
+    if context.intent == "sell" and context.level_role == "BUY_SUPPORT":
+        return "state_definition_gap:sell_intent_with_buy_support"
+    if context.intent == "buy" and context.level_role in {
+        "HARD_EXIT",
+        "CONDITIONAL_EXIT",
+        "HARD_INVALIDATION",
+    }:
+        return "state_definition_gap:buy_intent_with_exit_role"
+    if (
+        context.level_role == "HARD_EXIT"
+        and context.level_status == "fresh"
+        and context.price_touch_sufficient is None
+    ):
+        return "state_definition_gap:hard_exit_touch_policy_missing"
+    if (
+        context.level_role == "BUY_SUPPORT"
+        and context.level_status == "fresh"
+        and context.evidence_ready is not False
+        and context.intent_approved is None
+    ):
+        return "state_definition_gap:buy_intent_approval_missing"
+    if holding.market not in _MAX_LIVE_DISTANCE_PCT:
+        return f"state_definition_gap:unsupported_market:{holding.market}"
+    return None
+
+
+def _classify(
+    *,
+    holding: PostureHolding,
+    quote: PostureQuote | None,
+    context: PosturePolicyContext,
+) -> tuple[PostureState, str, Decimal | None]:
+    if holding.quantity <= 0:
+        return PostureState.DISARMED, "position_zero", None
+    if context.block_reasons:
+        return (
+            PostureState.DISARMED,
+            "policy_block:" + ",".join(sorted(set(context.block_reasons))),
+            None,
+        )
+    if context.risk_eligible is False:
+        return PostureState.DISARMED, "risk_ineligible", None
+    if context.economic_floor_met is False:
+        return PostureState.DISARMED, "economic_floor_not_met", None
+    if context.level_status == "stale":
+        return PostureState.DISARMED, "stale_level", None
+    if context.level_status == "missing":
+        return PostureState.DISARMED, "invalid_level_data", None
+    if context.level_status == "expired":
+        if context.rearm_allowed:
+            return PostureState.EXPIRED_REARMABLE, "expired_level_rearmable", None
+        return PostureState.DISARMED, "expired_level_not_rearmable", None
+    if context.level_role == "REFERENCE_ONLY":
+        return PostureState.DISARMED, "reference_only", None
+    if context.evidence_ready is False:
+        return PostureState.ARMED_DEFERRED, "pending_evidence", None
+    if context.level_price is None or context.level_price <= 0:
+        return PostureState.DISARMED, "invalid_level_data", None
+    if quote is None or quote.price <= 0:
+        return PostureState.DISARMED, "invalid_quote_data", None
+
+    distance_pct = _distance_pct(context.level_price, quote.price)
+    max_live_distance = _MAX_LIVE_DISTANCE_PCT[holding.market]
+
+    if context.level_role == "CONDITIONAL_EXIT":
+        return PostureState.CONDITIONAL, "conditional_exit", distance_pct
+    if context.level_role == "HARD_INVALIDATION":
+        return PostureState.CONDITIONAL, "hard_invalidation_review", distance_pct
+    if context.level_role == "HARD_EXIT":
+        if context.price_touch_sufficient is False:
+            return (
+                PostureState.CONDITIONAL,
+                "hard_exit_requires_more_information",
+                distance_pct,
+            )
+        if context.level_strength == "weak":
+            return PostureState.CONDITIONAL, "weak_level", distance_pct
+        if distance_pct > max_live_distance:
+            return PostureState.CONDITIONAL, "target_beyond_live_band", distance_pct
+        return PostureState.RESTING, "hard_exit_touch_sufficient", distance_pct
+    if context.level_role == "BUY_SUPPORT":
+        if context.intent_approved is False:
+            return (
+                PostureState.ARMED_DEFERRED,
+                "buy_intent_not_approved",
+                distance_pct,
+            )
+        return PostureState.RESTING, "approved_buy_support", distance_pct
+
+    raise AssertionError("unmapped level role reached classifier")
+
+
+def generate_posture(
+    snapshot: PostureGeneratorInput,
+    *,
+    posture_policy: PosturePolicy,
+    policy_version: str,
+    policy_content_hash: str,
+    generated_at: dt.datetime | None = None,
+) -> PostureGenerationResult:
+    """Generate a declarative five-state posture without side effects."""
+
+    if not posture_policy.enabled:
+        raise PostureDisabledError("posture.enabled=false")
+    if posture_policy.mode != "shadow":
+        raise ValueError("ROB-1106 generator supports shadow mode only")
+    if not posture_policy.policy_stamp_required:
+        raise ValueError("policy stamp is required")
+    if not policy_version.strip() or not policy_content_hash.strip():
+        raise ValueError("non-empty policy version/content hash are required")
+    if set(posture_policy.states) != {state.value for state in POSTURE_STATES}:
+        raise ValueError("policy state machine must contain exactly five states")
+
+    quotes = {(row.market, row.symbol.upper()): row for row in snapshot.quotes}
+    contexts = {row.holding_id: row for row in snapshot.policy_contexts}
+    assignments: list[PostureAssignment] = []
+    unmapped: list[UnmappedHolding] = []
+
+    for holding in snapshot.holdings:
+        context = contexts.get(holding.holding_id)
+        gap = _unmapped_reason(holding=holding, context=context)
+        if gap is not None:
+            unmapped.append(
+                UnmappedHolding(
+                    holding_id=holding.holding_id,
+                    account_id=holding.account_id,
+                    symbol=holding.symbol,
+                    market=holding.market,
+                    reason=gap,
+                    level_role=context.level_role if context is not None else None,
+                )
+            )
+            continue
+
+        assert context is not None
+        quote = quotes.get((holding.market, holding.symbol.upper()))
+        state, reason, distance_pct = _classify(
+            holding=holding,
+            quote=quote,
+            context=context,
+        )
+        assignments.append(
+            PostureAssignment(
+                holding_id=holding.holding_id,
+                account_id=holding.account_id,
+                symbol=holding.symbol,
+                market=holding.market,
+                state=state,
+                reason=reason,
+                intent=context.intent,
+                level_role=context.level_role,
+                quantity=holding.quantity,
+                current_price=quote.price if quote is not None else None,
+                level_price=context.level_price,
+                target_distance_pct=distance_pct,
+                review_at=context.review_at,
+                policy_version=policy_version,
+                policy_content_hash=policy_content_hash,
+            )
+        )
+
+    state_counts = {
+        state: sum(row.state is state for row in assignments)
+        for state in POSTURE_STATES
+    }
+    state_symbol_counts = {
+        state: len(
+            {
+                (row.market, row.symbol.upper())
+                for row in assignments
+                if row.state is state
+            }
+        )
+        for state in POSTURE_STATES
+    }
+    input_count = len(snapshot.holdings)
+    mapped_count = len(assignments)
+    coverage = PostureCoverage(
+        input_holding_count=input_count,
+        mapped_holding_count=mapped_count,
+        unmapped_holding_count=len(unmapped),
+        coverage_ratio=(mapped_count / input_count) if input_count else 1.0,
+        state_counts=state_counts,
+        state_symbol_counts=state_symbol_counts,
+    )
+    return PostureGenerationResult(
+        captured_at=snapshot.captured_at,
+        generated_at=generated_at or dt.datetime.now(dt.UTC),
+        policy_version=policy_version,
+        policy_content_hash=policy_content_hash,
+        assignments=assignments,
+        unmapped_holdings=unmapped,
+        coverage=coverage,
+    )

--- a/app/services/posture_shadow_service.py
+++ b/app/services/posture_shadow_service.py
@@ -1,0 +1,75 @@
+"""Manual, record-only posture-v1 shadow orchestration (ROB-1106).
+
+The default-off branch returns before loading holdings/quotes and before opening
+an artifact. The enabled branch can only call the pure generator and an
+injected/local JSONL recorder; it has no order/proposal/broker integration.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.trading_policy import PosturePolicy
+from app.services.posture_generator import (
+    PostureGenerationResult,
+    PostureGeneratorInput,
+    generate_posture,
+)
+
+SnapshotLoader = Callable[[], PostureGeneratorInput]
+ShadowRecorder = Callable[[PostureGenerationResult], None]
+
+
+class PostureShadowRunOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["disabled", "recorded"]
+    reason: str
+    result: PostureGenerationResult | None = None
+
+
+def append_shadow_jsonl(path: Path, result: PostureGenerationResult) -> None:
+    """Append one immutable coverage record to an operator-selected local path."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = result.model_dump(mode="json")
+    with path.open("a", encoding="utf-8") as artifact:
+        artifact.write(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        artifact.write("\n")
+
+
+def run_posture_shadow(
+    *,
+    posture_policy: PosturePolicy,
+    policy_version: str,
+    policy_content_hash: str,
+    snapshot_loader: SnapshotLoader,
+    recorder: ShadowRecorder,
+) -> PostureShadowRunOutcome:
+    """Run one manual shadow rep, or perform a side-effect-free disabled no-op."""
+
+    if not posture_policy.enabled:
+        return PostureShadowRunOutcome(
+            status="disabled",
+            reason="posture.enabled=false",
+        )
+    if posture_policy.mode != "shadow":
+        raise ValueError("ROB-1106 runner supports shadow mode only")
+
+    result = generate_posture(
+        snapshot_loader(),
+        posture_policy=posture_policy,
+        policy_version=policy_version,
+        policy_content_hash=policy_content_hash,
+    )
+    recorder(result)
+    return PostureShadowRunOutcome(
+        status="recorded",
+        reason="shadow_coverage_recorded",
+        result=result,
+    )

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-27.1"
-captured_as_of: "2026-07-27"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27"
+version: "2026-07-28.1"
+captured_as_of: "2026-07-28"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28"
 
 authority:
   scope: judgment_policy_only
@@ -16,6 +16,21 @@ authority:
     - "symbol_trade_settings — live per-symbol sizing (separate authority)"
     - "sell_conditions — dormant/test-only (not authoritative)"
     - "trade_profile — dead since ROB-488 (not revived)"
+
+# ROB-1106 posture-v1 stage 1. This block is deliberately default-off and
+# shadow-only. It is consumed only by the manual posture shadow entrypoint;
+# existing signal/gate, proposal, broker, worker, and scheduler paths do not
+# import or consult it.
+posture:
+  enabled: false
+  mode: shadow
+  states:
+    - RESTING
+    - CONDITIONAL
+    - ARMED_DEFERRED
+    - DISARMED
+    - EXPIRED_REARMABLE
+  policy_stamp_required: true
 
 # ROB-871 — master-gated by ORDER_PROPOSALS_AUTO_APPROVE=false. Caps use the
 # settlement currency for each market (KRW for kr/crypto, USD for us).

--- a/scripts/run_posture_shadow.py
+++ b/scripts/run_posture_shadow.py
@@ -1,0 +1,99 @@
+"""Run one posture-v1 shadow rep from a read-only captured JSON snapshot.
+
+Examples:
+    # Shipped policy is default-off: prints disabled and reads/writes nothing.
+    uv run python -m scripts.run_posture_shadow \
+      --input snapshot.json --output posture-coverage.jsonl
+
+    # After an operator-approved policy PR sets posture.enabled=true, the same
+    # command appends one coverage-only JSONL record.
+
+There is no proposal, notification, scheduler, or broker client in this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+from app.schemas.trading_policy import TradingPolicyDocument
+from app.services.posture_generator import PostureGeneratorInput
+from app.services.posture_shadow_service import (
+    append_shadow_jsonl,
+    run_posture_shadow,
+)
+
+_DEFAULT_POLICY_PATH = (
+    Path(__file__).resolve().parents[1] / "config" / "trading_policy.yaml"
+)
+
+
+def _load_policy(path: Path) -> tuple[TradingPolicyDocument, str]:
+    import hashlib
+
+    raw = path.read_bytes()
+    policy = TradingPolicyDocument.model_validate(yaml.safe_load(raw))
+    return policy, hashlib.sha256(raw).hexdigest()[:12]
+
+
+def _load_snapshot(path: Path) -> PostureGeneratorInput:
+    return PostureGeneratorInput.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="ROB-1106 manual posture-v1 shadow coverage recorder"
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Captured holdings/quotes/policy_contexts JSON (read-only).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Append-only local JSONL coverage artifact.",
+    )
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=_DEFAULT_POLICY_PATH,
+        help="Operator-approved trading policy YAML.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    policy, content_hash = _load_policy(args.policy)
+    outcome = run_posture_shadow(
+        posture_policy=policy.posture,
+        policy_version=policy.version,
+        policy_content_hash=content_hash,
+        snapshot_loader=lambda: _load_snapshot(args.input),
+        recorder=lambda result: append_shadow_jsonl(args.output, result),
+    )
+
+    summary: dict[str, object] = {
+        "status": outcome.status,
+        "reason": outcome.reason,
+        "policy_version": policy.version,
+        "policy_content_hash": content_hash,
+    }
+    if outcome.result is not None:
+        summary["coverage"] = outcome.result.coverage.model_dump(mode="json")
+        summary["unmapped_holdings"] = [
+            row.model_dump(mode="json") for row in outcome.result.unmapped_holdings
+        ]
+        summary["safety"] = outcome.result.safety.model_dump(mode="json")
+    print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/posture/rob1106_20260727_replay.json
+++ b/tests/fixtures/posture/rob1106_20260727_replay.json
@@ -1,0 +1,52 @@
+{
+  "captured_at": "2026-07-27T00:30:00+09:00",
+  "holdings": [
+    {"holding_id": "toss-052690", "account_id": "toss", "symbol": "052690", "market": "kr", "quantity": "2", "average_cost": "90400"},
+    {"holding_id": "toss-259960", "account_id": "toss", "symbol": "259960", "market": "kr", "quantity": "1", "average_cost": "228286"},
+    {"holding_id": "toss-214450", "account_id": "toss", "symbol": "214450", "market": "kr", "quantity": "9", "average_cost": "382777.78"},
+    {"holding_id": "kis-035420", "account_id": "kis", "symbol": "035420", "market": "kr", "quantity": "4", "average_cost": "220000"},
+    {"holding_id": "toss-035420", "account_id": "toss", "symbol": "035420", "market": "kr", "quantity": "2", "average_cost": "225000"},
+    {"holding_id": "toss-069620", "account_id": "toss", "symbol": "069620", "market": "kr", "quantity": "3", "average_cost": "120000"},
+    {"holding_id": "toss-298040", "account_id": "toss", "symbol": "298040", "market": "kr", "quantity": "2", "average_cost": "430000"},
+    {"holding_id": "toss-000270", "account_id": "toss", "symbol": "000270", "market": "kr", "quantity": "2", "average_cost": "150000"},
+    {"holding_id": "toss-067160", "account_id": "toss", "symbol": "067160", "market": "kr", "quantity": "2", "average_cost": "90000"},
+    {"holding_id": "kis-257720", "account_id": "kis", "symbol": "257720", "market": "kr", "quantity": "4", "average_cost": "45000"},
+    {"holding_id": "toss-214150", "account_id": "toss", "symbol": "214150", "market": "kr", "quantity": "2", "average_cost": "60000"},
+    {"holding_id": "toss-257720", "account_id": "toss", "symbol": "257720", "market": "kr", "quantity": "3", "average_cost": "46000"},
+    {"holding_id": "toss-011210", "account_id": "toss", "symbol": "011210", "market": "kr", "quantity": "4", "average_cost": "53900"},
+    {"holding_id": "toss-138040", "account_id": "toss", "symbol": "138040", "market": "kr", "quantity": "3", "average_cost": "109000"},
+    {"holding_id": "toss-036460", "account_id": "toss", "symbol": "036460", "market": "kr", "quantity": "5", "average_cost": "34000"}
+  ],
+  "quotes": [
+    {"symbol": "052690", "market": "kr", "price": "101300", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "259960", "market": "kr", "price": "244750", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "214450", "market": "kr", "price": "361750", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "035420", "market": "kr", "price": "250000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "069620", "market": "kr", "price": "130000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "298040", "market": "kr", "price": "450000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "000270", "market": "kr", "price": "160000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "067160", "market": "kr", "price": "100000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "257720", "market": "kr", "price": "50000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "214150", "market": "kr", "price": "65000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "011210", "market": "kr", "price": "56000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "138040", "market": "kr", "price": "115000", "observed_at": "2026-07-27T00:25:00+09:00"},
+    {"symbol": "036460", "market": "kr", "price": "36000", "observed_at": "2026-07-27T00:25:00+09:00"}
+  ],
+  "policy_contexts": [
+    {"holding_id": "toss-052690", "intent": "sell", "level_role": "HARD_EXIT", "level_price": "111200", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": true, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "toss-259960", "intent": "sell", "level_role": "HARD_EXIT", "level_price": "253000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": true, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "toss-214450", "intent": "sell", "level_role": "CONDITIONAL_EXIT", "level_price": "386700", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": false, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "kis-035420", "intent": "sell", "level_role": "CONDITIONAL_EXIT", "level_price": "270000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": false, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "toss-035420", "intent": "sell", "level_role": "CONDITIONAL_EXIT", "level_price": "270000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": false, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "toss-069620", "intent": "sell", "level_role": "CONDITIONAL_EXIT", "level_price": "140000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": false, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "toss-298040", "intent": "sell", "level_role": "CONDITIONAL_EXIT", "level_price": "480000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": false, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "toss-000270", "intent": "sell", "level_role": "CONDITIONAL_EXIT", "level_price": "175000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": false, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true},
+    {"holding_id": "toss-067160", "intent": "sell", "level_role": "HARD_EXIT", "level_price": "108000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": true, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": false},
+    {"holding_id": "kis-257720", "intent": "sell", "level_role": "HARD_EXIT", "level_price": "54000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": true, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": false},
+    {"holding_id": "toss-214150", "intent": "sell", "level_role": "HARD_EXIT", "level_price": "70000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": true, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": false},
+    {"holding_id": "toss-257720", "intent": "sell", "level_role": "HARD_EXIT", "level_price": "54000", "level_status": "fresh", "level_strength": "moderate", "price_touch_sufficient": true, "evidence_ready": true, "risk_eligible": true, "economic_floor_met": true, "block_reasons": ["single_share_verdict_pending"]},
+    {"holding_id": "toss-011210", "intent": "buy", "level_role": "BUY_SUPPORT", "level_price": "53900", "level_status": "fresh", "level_strength": "moderate", "evidence_ready": false, "intent_approved": false, "risk_eligible": true, "economic_floor_met": true, "review_at": "2026-07-28T09:00:00+09:00"},
+    {"holding_id": "toss-138040", "intent": "buy", "level_role": "BUY_SUPPORT", "level_price": "110900", "level_status": "fresh", "level_strength": "moderate", "evidence_ready": true, "intent_approved": false, "risk_eligible": false, "economic_floor_met": true, "block_reasons": ["outside_band", "financials_concentration"]},
+    {"holding_id": "toss-036460", "intent": "buy", "level_role": "BUY_SUPPORT", "level_price": "33950", "level_status": "stale", "level_strength": "moderate", "evidence_ready": true, "intent_approved": true, "risk_eligible": true, "economic_floor_met": true}
+  ]
+}

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -42,6 +42,16 @@ def test_shipped_config_validates():
     assert set(doc.market_overrides.keys()) == {"kr", "us", "crypto"}
     assert "semis_memory" in doc.sector_clusters
     assert "sell.trim_preplace" in doc.decision_rules
+    assert doc.posture.enabled is False
+    assert doc.posture.mode == "shadow"
+    assert doc.posture.states == [
+        "RESTING",
+        "CONDITIONAL",
+        "ARMED_DEFERRED",
+        "DISARMED",
+        "EXPIRED_REARMABLE",
+    ]
+    assert doc.posture.policy_stamp_required is True
     trim_rule = doc.decision_rules["sell.trim_preplace"]
     assert trim_rule.lanes == ["sell"]
     assert [tier.id for tier in trim_rule.tiers] == [
@@ -237,6 +247,25 @@ def test_decision_rule_schema_accepts_sell_trim_preplace_block():
 def test_extra_key_rejected():
     raw = _raw()
     raw["unexpected_top_level"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_posture_rejects_sixth_or_missing_state():
+    extra = _raw()
+    extra["posture"]["states"].append("CATALYST_GAP_CAPTURE_V1")
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(extra)
+
+    missing = _raw()
+    missing["posture"]["states"].remove("EXPIRED_REARMABLE")
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(missing)
+
+
+def test_posture_stage_one_rejects_non_shadow_mode():
+    raw = _raw()
+    raw["posture"]["mode"] = "sell_pilot"
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)
 

--- a/tests/services/test_posture_generator.py
+++ b/tests/services/test_posture_generator.py
@@ -1,0 +1,171 @@
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from app.services.posture_generator import (
+    POSTURE_STATES,
+    PostureDisabledError,
+    PostureGeneratorInput,
+    PostureState,
+    generate_posture,
+)
+from app.services.trading_policy_service import (
+    load_trading_policy,
+    policy_content_hash,
+)
+
+_REPLAY = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "posture"
+    / "rob1106_20260727_replay.json"
+)
+
+
+def _replay() -> PostureGeneratorInput:
+    return PostureGeneratorInput.model_validate_json(
+        _REPLAY.read_text(encoding="utf-8")
+    )
+
+
+def _enabled_policy():
+    return load_trading_policy().posture.model_copy(update={"enabled": True})
+
+
+def test_posture_state_machine_has_exactly_five_states():
+    assert [state.value for state in POSTURE_STATES] == [
+        "RESTING",
+        "CONDITIONAL",
+        "ARMED_DEFERRED",
+        "DISARMED",
+        "EXPIRED_REARMABLE",
+    ]
+
+
+def test_generator_cannot_bypass_default_off_gate():
+    policy = load_trading_policy()
+
+    with pytest.raises(PostureDisabledError, match="posture.enabled=false"):
+        generate_posture(
+            _replay(),
+            posture_policy=policy.posture,
+            policy_version=policy.version,
+            policy_content_hash=policy_content_hash(),
+        )
+
+
+def test_rob1106_20260727_replay_matches_canonical_coverage():
+    policy = load_trading_policy()
+
+    result = generate_posture(
+        _replay(),
+        posture_policy=_enabled_policy(),
+        policy_version=policy.version,
+        policy_content_hash=policy_content_hash(),
+        generated_at=dt.datetime(2026, 7, 28, tzinfo=dt.UTC),
+    )
+
+    assert result.coverage.input_holding_count == 15
+    assert result.coverage.mapped_holding_count == 15
+    assert result.coverage.unmapped_holding_count == 0
+    assert result.coverage.coverage_ratio == 1.0
+    assert result.coverage.state_counts == {
+        PostureState.RESTING: 2,
+        PostureState.CONDITIONAL: 6,
+        PostureState.ARMED_DEFERRED: 1,
+        PostureState.DISARMED: 6,
+        PostureState.EXPIRED_REARMABLE: 0,
+    }
+    assert result.unmapped_holdings == []
+    assert result.safety.orders_created == 0
+    assert result.safety.proposals_created == 0
+    assert result.safety.broker_mutations == 0
+
+
+def test_unmapped_holding_is_exposed_instead_of_forced_into_a_state():
+    policy = load_trading_policy()
+    snapshot = _replay().model_copy(deep=True)
+    snapshot.policy_contexts = [
+        row for row in snapshot.policy_contexts if row.holding_id != "toss-036460"
+    ]
+
+    result = generate_posture(
+        snapshot,
+        posture_policy=_enabled_policy(),
+        policy_version=policy.version,
+        policy_content_hash=policy_content_hash(),
+    )
+
+    assert result.coverage.input_holding_count == 15
+    assert result.coverage.mapped_holding_count == 14
+    assert result.coverage.unmapped_holding_count == 1
+    assert result.coverage.coverage_ratio == 14 / 15
+    assert sum(result.coverage.state_counts.values()) == 14
+    assert [row.holding_id for row in result.unmapped_holdings] == ["toss-036460"]
+    assert result.unmapped_holdings[0].reason == "missing_policy_context"
+
+
+def test_expired_rearmable_is_a_state_not_a_sixth_overlay_state():
+    policy = load_trading_policy()
+    snapshot = _replay().model_copy(deep=True)
+    context = next(
+        row for row in snapshot.policy_contexts if row.holding_id == "toss-052690"
+    )
+    context.level_status = "expired"
+    context.rearm_allowed = True
+
+    result = generate_posture(
+        snapshot,
+        posture_policy=_enabled_policy(),
+        policy_version=policy.version,
+        policy_content_hash=policy_content_hash(),
+    )
+
+    assigned = next(
+        row for row in result.assignments if row.holding_id == "toss-052690"
+    )
+    assert assigned.state is PostureState.EXPIRED_REARMABLE
+    assert set(result.coverage.state_counts) == set(POSTURE_STATES)
+
+
+def test_unknown_overlay_role_surfaces_as_state_definition_gap():
+    policy = load_trading_policy()
+    snapshot = _replay().model_copy(deep=True)
+    context = next(
+        row for row in snapshot.policy_contexts if row.holding_id == "toss-052690"
+    )
+    context.level_role = "CATALYST_GAP_CAPTURE_V1"
+
+    result = generate_posture(
+        snapshot,
+        posture_policy=_enabled_policy(),
+        policy_version=policy.version,
+        policy_content_hash=policy_content_hash(),
+    )
+
+    gap = next(
+        row for row in result.unmapped_holdings if row.holding_id == "toss-052690"
+    )
+    assert gap.reason == (
+        "state_definition_gap:unknown_level_role:CATALYST_GAP_CAPTURE_V1"
+    )
+    assert "CATALYST_GAP_CAPTURE_V1" not in {state.value for state in POSTURE_STATES}
+
+
+def test_generator_output_has_no_order_or_proposal_surface():
+    policy = load_trading_policy()
+    result = generate_posture(
+        _replay(),
+        posture_policy=_enabled_policy(),
+        policy_version=policy.version,
+        policy_content_hash=policy_content_hash(),
+    )
+
+    fields = set(type(result.assignments[0]).model_fields)
+    assert not any("order" in field or "proposal" in field for field in fields)
+    assert result.safety.model_dump() == {
+        "orders_created": 0,
+        "proposals_created": 0,
+        "broker_mutations": 0,
+    }

--- a/tests/services/test_posture_shadow_service.py
+++ b/tests/services/test_posture_shadow_service.py
@@ -1,0 +1,121 @@
+import json
+from pathlib import Path
+
+from app.services.posture_generator import PostureGeneratorInput
+from app.services.posture_shadow_service import (
+    append_shadow_jsonl,
+    run_posture_shadow,
+)
+from app.services.trading_policy_service import (
+    get_policy_for,
+    load_trading_policy,
+    policy_content_hash,
+)
+from scripts.run_posture_shadow import main
+
+_REPLAY = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "posture"
+    / "rob1106_20260727_replay.json"
+)
+
+
+def _replay() -> PostureGeneratorInput:
+    return PostureGeneratorInput.model_validate_json(
+        _REPLAY.read_text(encoding="utf-8")
+    )
+
+
+def test_shipped_policy_is_default_off_and_projection_shape_is_unchanged():
+    policy = load_trading_policy()
+    assert policy.posture.enabled is False
+    assert policy.posture.mode == "shadow"
+
+    existing_view = get_policy_for("kr", "sell")
+    assert set(existing_view) == {
+        "market",
+        "lane",
+        "version",
+        "content_hash",
+        "thresholds",
+        "decision_rules",
+        "market_rules",
+        "crash_day",
+        "user_stances",
+    }
+    assert "posture" not in existing_view
+
+
+def test_default_off_returns_before_snapshot_load_and_record():
+    policy = load_trading_policy()
+    calls = {"load": 0, "record": 0}
+
+    def loader() -> PostureGeneratorInput:
+        calls["load"] += 1
+        raise AssertionError("default-off must not load holdings or quotes")
+
+    def recorder(_result) -> None:
+        calls["record"] += 1
+        raise AssertionError("default-off must not record an artifact")
+
+    outcome = run_posture_shadow(
+        posture_policy=policy.posture,
+        policy_version=policy.version,
+        policy_content_hash=policy_content_hash(),
+        snapshot_loader=loader,
+        recorder=recorder,
+    )
+
+    assert outcome.status == "disabled"
+    assert outcome.reason == "posture.enabled=false"
+    assert outcome.result is None
+    assert calls == {"load": 0, "record": 0}
+
+
+def test_default_off_cli_does_not_read_input_or_create_output(tmp_path: Path, capsys):
+    missing_input = tmp_path / "does-not-exist.json"
+    output = tmp_path / "must-not-exist.jsonl"
+
+    assert main(["--input", str(missing_input), "--output", str(output)]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "disabled"
+    assert payload["reason"] == "posture.enabled=false"
+    assert not output.exists()
+
+
+def test_enabled_shadow_records_all_five_counts_and_unmapped_rows(tmp_path: Path):
+    policy = load_trading_policy()
+    enabled = policy.posture.model_copy(update={"enabled": True})
+    snapshot = _replay()
+    snapshot.policy_contexts = [
+        row for row in snapshot.policy_contexts if row.holding_id != "toss-036460"
+    ]
+    output = tmp_path / "posture-coverage.jsonl"
+
+    outcome = run_posture_shadow(
+        posture_policy=enabled,
+        policy_version=policy.version,
+        policy_content_hash=policy_content_hash(),
+        snapshot_loader=lambda: snapshot,
+        recorder=lambda result: append_shadow_jsonl(output, result),
+    )
+
+    assert outcome.status == "recorded"
+    assert outcome.result is not None
+    recorded = json.loads(output.read_text(encoding="utf-8"))
+    assert set(recorded["coverage"]["state_counts"]) == {
+        "RESTING",
+        "CONDITIONAL",
+        "ARMED_DEFERRED",
+        "DISARMED",
+        "EXPIRED_REARMABLE",
+    }
+    assert recorded["coverage"]["unmapped_holding_count"] == 1
+    assert recorded["unmapped_holdings"][0]["holding_id"] == "toss-036460"
+    assert recorded["safety"] == {
+        "orders_created": 0,
+        "proposals_created": 0,
+        "broker_mutations": 0,
+    }


### PR DESCRIPTION
## Summary

- add the posture.enabled=false, shadow-only, exact five-state policy contract
- add a pure holdings + quotes + policy-context posture generator
- record per-state holding and unique-symbol coverage to a manual local JSONL artifact
- expose unmapped holdings as state-definition gaps instead of forcing DISARMED
- add the 2026-07-27 canonical 15-position replay fixture

## Safety / invariants

- no API, worker, scheduler, cron, MCP, proposal, notification, or broker wiring
- generator and runner both fail closed while posture.enabled=false
- disabled CLI returns before reading the snapshot and before creating the output artifact
- every shadow result carries orders_created=0, proposals_created=0, broker_mutations=0
- CATALYST_GAP_CAPTURE_V1 is verified not to become a sixth state
- existing get_policy_for projection does not expose or activate posture

## Shadow evidence

Canonical 2026-07-27 replay:

- input holdings: 15
- mapped holdings: 15
- RESTING: 2
- CONDITIONAL: 6
- ARMED_DEFERRED: 1
- DISARMED: 6
- EXPIRED_REARMABLE: 0
- unmapped holdings: 0
- unique-symbol counts: RESTING 2 / CONDITIONAL 5 / ARMED_DEFERRED 1 / DISARMED 5 / EXPIRED_REARMABLE 0
- orders / proposals / broker mutations: 0 / 0 / 0

An adversarial missing-policy-context case records coverage 14/15 and one explicit unmapped holding.

## Verification

- 62 related tests passed
- Ruff check passed across app/tests/research/scripts
- Ruff format check passed across 3,403 files
- ty --error-on-warning passed for the changed app modules
- full unit attempt reached 991 passed before an unrelated existing watch-alert FK fixture failure (investment_watch_alerts.source_report_uuid -> investment_reports); no ROB-1106 file overlaps the concurrent ROB-1109 change set

Linear: ROB-1106 (epic ROB-1090)
