### PR TITLE
fix(ROB-1118): bound native worker logs

### DIFF
--- a/app/core/cli.py
+++ b/app/core/cli.py
@@ -11,6 +11,7 @@ import logging
 from collections.abc import Awaitable, Callable
 
 from app.core.config import settings
+from app.core.logging_config import configure_dependency_log_levels
 from app.monitoring.sentry import capture_exception, init_sentry
 
 __all__ = ["run_async_job", "setup_logging_and_sentry"]
@@ -27,6 +28,7 @@ def setup_logging_and_sentry(service_name: str) -> None:
         level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+    configure_dependency_log_levels()
     init_sentry(service_name=service_name)
 
 

--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -1,0 +1,12 @@
+"""Shared logging policy for noisy third-party libraries."""
+
+from __future__ import annotations
+
+import logging
+
+HTTPX_LOG_LEVEL = logging.WARNING
+
+
+def configure_dependency_log_levels() -> None:
+    """Keep transport diagnostics while suppressing per-request access lines."""
+    logging.getLogger("httpx").setLevel(HTTPX_LOG_LEVEL)

--- a/app/core/taskiq_broker.py
+++ b/app/core/taskiq_broker.py
@@ -9,8 +9,11 @@ from taskiq_redis import (
 )
 
 from app.core.config import settings
+from app.core.logging_config import configure_dependency_log_levels
 from app.monitoring.sentry import init_sentry
 from app.monitoring.trade_notifier.runtime import configure_trade_notifier_from_settings
+
+configure_dependency_log_levels()
 
 logger = logging.getLogger(__name__)
 

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from app.auth.router import router as auth_router
 from app.auth.web_router import limiter
 from app.auth.web_router import router as web_auth_router
 from app.core.config import settings
+from app.core.logging_config import configure_dependency_log_levels
 from app.core.taskiq_broker import broker
 from app.middleware.auth import AuthMiddleware
 from app.middleware.csrf import TemplateFormCSRFMiddleware
@@ -95,6 +96,7 @@ def configure_logging() -> None:
         level=log_level,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+    configure_dependency_log_levels()
     # uvicorn 로거도 동일 레벨로 설정
     logging.getLogger("uvicorn").setLevel(log_level)
     logging.getLogger("uvicorn.access").setLevel(log_level)

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -1,6 +1,7 @@
 import logging
 
 from app.core.config import settings, validate_kiwoom_mock_config
+from app.core.logging_config import configure_dependency_log_levels
 from app.mcp_server.env_utils import (
     _env,
     _env_int,
@@ -180,6 +181,7 @@ def main() -> None:
         format="%(asctime)s [%(levelname)s] %(message)s",
         datefmt="%H:%M:%S",
     )
+    configure_dependency_log_levels()
 
     mcp_type = _env("MCP_TYPE", "streamable-http")
     mcp_host = _env("MCP_HOST", "0.0.0.0")

--- a/docs/runbooks/worker-log-rotation.md
+++ b/docs/runbooks/worker-log-rotation.md
@@ -1,0 +1,154 @@
+# Worker launchd 로그 회전 및 25GB 기존 파일 처리
+
+ROB-1118은 TaskIQ worker의 launchd stderr가 무제한 증가한 사고를 다룬다.
+애플리케이션은 `httpx`를 `WARNING` 이상으로 유지해 요청별 INFO 라인을
+제거하고, launchd 작업은 60초마다 worker stdout/stderr의 크기를 확인한다.
+
+## 정상 운영 상한
+
+- 현재 파일별 회전 기준: 128MiB (`AUTO_TRADER_LOG_MAX_BYTES=134217728`)
+- 보관: 파일별 gzip archive 4개
+- 검사 주기: 60초
+- 정상 상태의 명목상 파일별 최대 보관량: 현재 128MiB + archive 4×128MiB
+  = 640MiB
+- 실제 현재 파일은 검사 사이 최대 60초 동안의 유입량만큼 128MiB를
+  초과할 수 있다. `httpx` INFO 억제가 1차 방어이고, 회전기가 2차 상한이다.
+
+회전기는 `launchd`가 열어 둔 FD 문제를 피하기 위해 worker를 bootout하고,
+`lsof`로 writer가 0인지 확인한 후 `newsyslog`를 실행한다. 그 다음 worker를
+bootstrap/kickstart해 새 inode에 stdout/stderr를 연결한다. archive 개수와
+새 현재 파일의 크기를 실행 후 다시 검사하며, 검증 실패는 non-zero로 남긴다.
+
+## 기존 25GB 파일: 운영자 승인 절차
+
+이 절차는 운영자가 maintenance window와 삭제/보관 승인을 받은 뒤 수행한다.
+코드 배포나 자동 회전 작업이 기존 파일을 직접 삭제하거나 truncate하지
+않도록 arming marker는 배포에서 만들지 않는다.
+
+1. 전체 파일을 읽지 말고 메타데이터와 제한 샘플만 확인한다.
+
+   ```bash
+   log="$HOME/services/auto_trader/logs/com.robinco.auto-trader.worker.err.log"
+   stat -f 'size=%z inode=%i modified=%Sm' "$log"
+   /usr/sbin/lsof "$log"
+   tail -n 200000 "$log" | awk '...운영 승인된 제한 집계...'
+   ```
+
+   25GB 파일에 `grep`, `rg`, `cat`, `wc -l`을 실행하지 않는다.
+
+2. worker를 중지하고 모든 writer FD가 닫혔는지 확인한다.
+
+   ```bash
+   uid_num="$(id -u)"
+   label="com.robinco.auto-trader.worker"
+   launchctl bootout "gui/$uid_num/$label"
+   /usr/sbin/lsof "$log"
+   ```
+
+   `lsof` 출력이 남아 있으면 진행하지 않는다. launchd 부모와 TaskIQ 자식이
+   이전 inode를 계속 잡은 채 path만 rename/unlink하면 디스크 공간은
+   반환되지 않는다. 열린 FD가 남은 상태의 truncate 역시 안전한 회전이나
+   공간 반환 절차로 인정하지 않는다. writer는 이전 offset/inode를 계속
+   사용할 수 있고 sparse 재증가·로그 유실을 만들 수 있으므로 금지한다.
+
+3. 현재 파일을 같은 파일시스템의 명시적인 incident archive 이름으로
+   rename하고 새 파일을 만든다. 이 단계는 보존만 하며 공간을 반환하지 않는다.
+
+   ```bash
+   stamp="$(date '+%Y%m%d-%H%M%S')"
+   archive="$log.pre-rob1118.$stamp"
+   mv "$log" "$archive"
+   install -m 0640 /dev/null "$log"
+   ```
+
+4. worker를 다시 올리고 새 파일 inode를 잡았는지 확인한다.
+
+   ```bash
+   plist="$HOME/Library/LaunchAgents/$label.plist"
+   launchctl bootstrap "gui/$uid_num" "$plist"
+   launchctl enable "gui/$uid_num/$label"
+   launchctl kickstart -k "gui/$uid_num/$label"
+   /usr/sbin/lsof "$log"
+   ```
+
+   `lsof`의 inode와 `stat`의 새 inode가 같아야 한다. 새 로그에는 애플리케이션
+   WARNING/ERROR가 남고 `[httpx][INFO] HTTP Request:`가 더 이상 쌓이지 않는지
+   제한된 `tail`로 확인한다.
+
+5. 25GB incident archive는 승인된 보존 정책에 따라 처리한다.
+
+   - 보존 필요: 여유 공간이 있는 별도 볼륨으로 복사하고 checksum을 대조한
+     후, 원본 archive 제거를 별도 승인한다.
+   - 로컬 압축: 압축 중 추가 공간이 필요하므로 사전 free-space 계산과 승인을
+     거친다.
+   - 삭제 승인: 현재 로그가 아닌 `pre-rob1118` archive의 정확한 경로와
+     checksum을 재확인한 후 운영자가 제거한다.
+
+   어떤 경우에도 실행 중인 현재 파일을 `rm` 또는 `truncate`하지 않는다.
+
+## 회전기 설치와 arming
+
+기존 25GB archive 처리와 새 inode 검증이 끝난 뒤에만 실행한다. 프로덕션
+배포와 launchd 등록은 별도 운영 절차다.
+
+```bash
+label="com.robinco.auto-trader.worker-log-rotation"
+source_plist="$HOME/services/auto_trader/plists/$label.plist"
+target_plist="$HOME/Library/LaunchAgents/$label.plist"
+install -m 0644 "$source_plist" "$target_plist"
+touch "$HOME/services/auto_trader/shared/log-rotation.enabled"
+launchctl bootstrap "gui/$(id -u)" "$target_plist"
+launchctl enable "gui/$(id -u)/$label"
+```
+
+배포 스크립트는 이 label을 자동 시작하지 않으며 marker도 만들지 않는다.
+
+## 상한 검증
+
+운영 파일에는 강제 회전을 실행하지 않는다. 임시 디렉터리에서 기준을 1KiB,
+archive 2개로 낮춰 실제 `newsyslog`를 반복 실행하는 테스트가 상한을 검증한다.
+
+```bash
+uv run pytest -q tests/scripts/test_worker_log_rotation.py
+```
+
+운영 arming 뒤에는 read-only로 다음을 확인한다.
+
+```bash
+log_dir="$HOME/services/auto_trader/logs"
+ls -lh "$log_dir"/com.robinco.auto-trader.worker.{err,out}.log*
+launchctl print "gui/$(id -u)/com.robinco.auto-trader.worker-log-rotation"
+```
+
+archive는 각 current 파일당 최대 4개여야 하고, current가 128MiB를 넘은 채
+다음 검사 주기 이후에도 유지되면 회전기 stderr와 launchd 상태를 조사한다.
+
+## 2026-07-28 제한 샘플 조사
+
+25GB 전체를 읽지 않고 마지막 200,000줄만 조사했다. 샘플 범위는
+2026-07-23 01:30:00~2026-07-28 12:20:29 KST였으며, 그 안에서 최근 24시간
+(2026-07-27 12:20:29~2026-07-28 12:20:29 KST)을 별도로 집계했다.
+
+| 지표 | 최근 24시간 |
+|---|---:|
+| 전체 샘플 줄 | 50,882 |
+| httpx HTTP 요청 INFO | 39,950 |
+| HTTP 5xx | 811 (전부 HTTP 500, HTTP 요청의 2.03%) |
+| KIS rate-limit heuristic 경고 | 809 |
+| ConnectTimeout 요청 sequence | 10 |
+| 기록된 ConnectTimeout retry attempt | 20 |
+
+HTTP 500 endpoint는 `inquire-daily-itemchartprice` 445,
+overseas `dailyprice` 158, `inquire-time-dailychartprice` 115,
+overseas `inquire-time-itemchartprice` 82, 기타 11건이었다. 811건 중 최소
+808건(99.63%)은 뒤 10줄 안의 `EGW00201 초당 거래건수를 초과` rate-limit
+경고와 짝지어졌고, 같은 구간의 rate-limit 경고 총수는 809건이었다. 따라서
+일반적인 upstream 5xx와 분리해 해석해야 한다.
+
+ConnectTimeout 10 sequence는 모두 KIS `inquire_daily_itemchartprice`였다.
+각 sequence가 5초 ConnectTimeout을 1/3, 2/3으로 기록했고 호출 간격은 약
+15~16초였다. 이는 ROB-1116의 최악 trace가 기록한 같은 KIS endpoint,
+`5.003s + 5.002s + 5.002s` 직렬 retry와 동일한 코드 경로·시간 형태다.
+따라서 ROB-1118 로그의 이 부분은 별건이 아니라 ROB-1116 B 트랙의 현장
+증거로 합쳐야 한다. 반면 HTTP 500 대부분은 ConnectTimeout이 아니라 KIS가
+HTTP 500 body로 반환한 rate-limit 응답이다.

--- a/kis_websocket_monitor.py
+++ b/kis_websocket_monitor.py
@@ -17,6 +17,7 @@ import sys
 from typing import Any
 
 from app.core.config import settings
+from app.core.logging_config import configure_dependency_log_levels
 from app.monitoring.sentry import capture_exception, init_sentry
 from app.services.execution_event import (
     close_redis as close_execution_redis,
@@ -158,6 +159,7 @@ async def main():
         level=getattr(logging, settings.LOG_LEVEL, logging.INFO),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+    configure_dependency_log_levels()
     init_sentry(service_name="auto-trader-kis-ws")
 
     monitor = KISWebSocketMonitor()

--- a/ops/native/plists/com.robinco.auto-trader.worker-log-rotation.plist
+++ b/ops/native/plists/com.robinco.auto-trader.worker-log-rotation.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.robinco.auto-trader.worker-log-rotation</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/mgh3326/services/auto_trader/scripts/rotate-worker-logs.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>/Users/mgh3326</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>AUTO_TRADER_BASE</key>
+    <string>/Users/mgh3326/services/auto_trader</string>
+  </dict>
+  <key>StartInterval</key>
+  <integer>60</integer>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>/Users/mgh3326/services/auto_trader/logs/com.robinco.auto-trader.worker-log-rotation.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/mgh3326/services/auto_trader/logs/com.robinco.auto-trader.worker-log-rotation.err.log</string>
+</dict>
+</plist>

--- a/ops/native/scripts/rotate-worker-logs.sh
+++ b/ops/native/scripts/rotate-worker-logs.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ROB-1118: bounded launchd stdout/stderr rotation for the TaskIQ worker.
+#
+# launchd gives the worker an open descriptor for StandardOutPath and
+# StandardErrorPath. Renaming the path while the worker is running leaves that
+# descriptor attached to the old inode, so this script stops the launchd job,
+# verifies that all descriptors are closed, rotates with newsyslog, and then
+# restores the job.
+
+BASE="${AUTO_TRADER_BASE:-$HOME/services/auto_trader}"
+LOG_DIR="${AUTO_TRADER_LOG_DIR:-$BASE/logs}"
+ARM_FILE="${AUTO_TRADER_LOG_ROTATION_ARM_FILE:-$BASE/shared/log-rotation.enabled}"
+MAX_BYTES="${AUTO_TRADER_LOG_MAX_BYTES:-134217728}"
+ARCHIVE_COUNT="${AUTO_TRADER_LOG_ARCHIVE_COUNT:-4}"
+WORKER_LABEL="${AUTO_TRADER_WORKER_LABEL:-com.robinco.auto-trader.worker}"
+WORKER_PLIST="${AUTO_TRADER_WORKER_PLIST:-$HOME/Library/LaunchAgents/$WORKER_LABEL.plist}"
+LAUNCHCTL_BIN="${AUTO_TRADER_LAUNCHCTL_BIN:-/bin/launchctl}"
+NEWSYSLOG_BIN="${AUTO_TRADER_NEWSYSLOG_BIN:-/usr/sbin/newsyslog}"
+LSOF_BIN="${AUTO_TRADER_LSOF_BIN:-/usr/sbin/lsof}"
+FD_WAIT_ATTEMPTS="${AUTO_TRADER_LOG_FD_WAIT_ATTEMPTS:-40}"
+FD_WAIT_SECONDS="${AUTO_TRADER_LOG_FD_WAIT_SECONDS:-0.25}"
+
+case "$MAX_BYTES" in
+  *[!0-9]*|"")
+    echo "AUTO_TRADER_LOG_MAX_BYTES must be a positive integer" >&2
+    exit 64
+    ;;
+esac
+if (( MAX_BYTES < 1024 )); then
+  echo "AUTO_TRADER_LOG_MAX_BYTES must be at least 1024" >&2
+  exit 64
+fi
+
+case "$ARCHIVE_COUNT" in
+  *[!0-9]*|"")
+    echo "AUTO_TRADER_LOG_ARCHIVE_COUNT must be a positive integer" >&2
+    exit 64
+    ;;
+esac
+if (( ARCHIVE_COUNT < 1 )); then
+  echo "AUTO_TRADER_LOG_ARCHIVE_COUNT must be at least 1" >&2
+  exit 64
+fi
+
+case "$FD_WAIT_ATTEMPTS" in
+  *[!0-9]*|"")
+    echo "AUTO_TRADER_LOG_FD_WAIT_ATTEMPTS must be a positive integer" >&2
+    exit 64
+    ;;
+esac
+if (( FD_WAIT_ATTEMPTS < 1 )); then
+  echo "AUTO_TRADER_LOG_FD_WAIT_ATTEMPTS must be at least 1" >&2
+  exit 64
+fi
+
+# Deployment deliberately does not create this marker. The operator must first
+# complete the legacy 25GB-file runbook and then arm future rotations.
+if [[ ! -f "$ARM_FILE" ]]; then
+  exit 0
+fi
+
+logs=(
+  "$LOG_DIR/com.robinco.auto-trader.worker.err.log"
+  "$LOG_DIR/com.robinco.auto-trader.worker.out.log"
+)
+rotate_logs=()
+
+file_size() {
+  local path="$1"
+  if stat -f '%z' "$path" >/dev/null 2>&1; then
+    stat -f '%z' "$path"
+  else
+    stat -c '%s' "$path"
+  fi
+}
+
+for log_path in "${logs[@]}"; do
+  if [[ -f "$log_path" ]] && (( $(file_size "$log_path") >= MAX_BYTES )); then
+    rotate_logs+=("$log_path")
+  fi
+done
+
+if (( ${#rotate_logs[@]} == 0 )); then
+  exit 0
+fi
+
+for required in "$LAUNCHCTL_BIN" "$NEWSYSLOG_BIN" "$LSOF_BIN"; do
+  if [[ ! -x "$required" ]]; then
+    echo "required executable is missing: $required" >&2
+    exit 69
+  fi
+done
+
+uid_num="$(id -u)"
+domain="gui/$uid_num"
+service="$domain/$WORKER_LABEL"
+worker_was_loaded=0
+worker_stopped=0
+config_file=""
+
+restart_worker() {
+  if (( worker_was_loaded == 0 || worker_stopped == 0 )); then
+    return 0
+  fi
+  if [[ ! -f "$WORKER_PLIST" ]]; then
+    echo "worker plist is missing; cannot restore service: $WORKER_PLIST" >&2
+    return 78
+  fi
+  "$LAUNCHCTL_BIN" bootstrap "$domain" "$WORKER_PLIST" || return $?
+  "$LAUNCHCTL_BIN" enable "$service" || return $?
+  "$LAUNCHCTL_BIN" kickstart -k "$service" || return $?
+  worker_stopped=0
+}
+
+cleanup() {
+  local rc=$?
+  local restart_rc=0
+  set +e
+  if [[ -n "$config_file" ]]; then
+    rm -f "$config_file"
+  fi
+  restart_worker
+  restart_rc=$?
+  if (( rc == 0 && restart_rc != 0 )); then
+    rc=$restart_rc
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+if "$LAUNCHCTL_BIN" print "$service" >/dev/null 2>&1; then
+  worker_was_loaded=1
+  "$LAUNCHCTL_BIN" bootout "$service"
+  worker_stopped=1
+fi
+
+# bootout is synchronous for the launchd job, but descendants can take a
+# moment to close. Never rotate until every writer has released the old inode.
+for log_path in "${rotate_logs[@]}"; do
+  holders=""
+  for (( attempt = 1; attempt <= FD_WAIT_ATTEMPTS; attempt++ )); do
+    holders="$("$LSOF_BIN" -t "$log_path" 2>/dev/null || true)"
+    [[ -z "$holders" ]] && break
+    sleep "$FD_WAIT_SECONDS"
+  done
+  if [[ -n "$holders" ]]; then
+    echo "refusing rotation; open file descriptors remain for $log_path: $holders" >&2
+    exit 75
+  fi
+done
+
+mkdir -p "$BASE/run"
+config_file="$(mktemp "$BASE/run/worker-newsyslog.XXXXXX")"
+chmod 600 "$config_file"
+owner="$(id -un)"
+group="$(id -gn)"
+max_kib=$(( (MAX_BYTES + 1023) / 1024 ))
+# macOS newsyslog retains .0 plus the configured count (.1 .. .count).
+# Convert the operator-facing maximum archive count to that field.
+newsyslog_count=$(( ARCHIVE_COUNT - 1 ))
+
+for log_path in "${rotate_logs[@]}"; do
+  printf '%s %s:%s 640 %s %s * NZ\n' \
+    "$log_path" "$owner" "$group" "$newsyslog_count" "$max_kib" >>"$config_file"
+done
+
+"$NEWSYSLOG_BIN" -r -s -f "$config_file" -R ROB-1118 "${rotate_logs[@]}"
+
+shopt -s nullglob
+for log_path in "${rotate_logs[@]}"; do
+  new_size="$(file_size "$log_path")"
+  if (( new_size >= MAX_BYTES )); then
+    echo "rotation verification failed; current file is still oversized: $log_path ($new_size bytes)" >&2
+    exit 70
+  fi
+  archives=("$log_path".[0-9]*)
+  if (( ${#archives[@]} > ARCHIVE_COUNT )); then
+    echo "rotation verification failed; archive count exceeds $ARCHIVE_COUNT for $log_path" >&2
+    exit 70
+  fi
+done
+
+restart_worker

--- a/tests/core/test_logging_config.py
+++ b/tests/core/test_logging_config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.core.logging_config import configure_dependency_log_levels
+
+
+@pytest.mark.unit
+def test_httpx_request_info_is_suppressed_but_warning_is_retained() -> None:
+    httpx_logger = logging.getLogger("httpx")
+    original_level = httpx_logger.level
+
+    try:
+        httpx_logger.setLevel(logging.NOTSET)
+        configure_dependency_log_levels()
+
+        assert httpx_logger.level == logging.WARNING
+        assert not httpx_logger.isEnabledFor(logging.INFO)
+        assert httpx_logger.isEnabledFor(logging.WARNING)
+    finally:
+        httpx_logger.setLevel(original_level)

--- a/tests/scripts/test_native_plists.py
+++ b/tests/scripts/test_native_plists.py
@@ -21,6 +21,7 @@ PLISTS = [
     "com.robinco.auto-trader.mcp-account-read.plist",
     "com.robinco.auto-trader.mcp-tradingcodex-execution.plist",
     "com.robinco.auto-trader.worker.plist",
+    "com.robinco.auto-trader.worker-log-rotation.plist",
     "com.robinco.auto-trader.scheduler.plist",
     "com.robinco.auto-trader.kis-websocket.plist",
     "com.robinco.auto-trader.upbit-websocket.plist",
@@ -52,6 +53,13 @@ def test_haproxy_plist_label() -> None:
     # Silicon Homebrew). The plist must NOT hardcode /opt/homebrew/bin/haproxy.
     assert "scripts/run-haproxy.sh" in body
     assert "/opt/homebrew/bin/haproxy" not in body
+
+
+def test_worker_log_rotation_is_bounded_and_not_auto_armed() -> None:
+    body = (PLIST_DIR / "com.robinco.auto-trader.worker-log-rotation.plist").read_text()
+    assert "scripts/rotate-worker-logs.sh" in body
+    assert "<key>StartInterval</key>\n  <integer>60</integer>" in body
+    assert "<key>RunAtLoad</key>" not in body
 
 
 def test_api_blue_plist_port() -> None:

--- a/tests/scripts/test_worker_log_rotation.py
+++ b/tests/scripts/test_worker_log_rotation.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROTATE_SCRIPT = REPO_ROOT / "ops" / "native" / "scripts" / "rotate-worker-logs.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _rotation_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
+    base = tmp_path / "service"
+    log_dir = base / "logs"
+    shared_dir = base / "shared"
+    run_dir = base / "run"
+    bin_dir = tmp_path / "bin"
+    launch_agents = tmp_path / "Library" / "LaunchAgents"
+    for directory in (log_dir, shared_dir, run_dir, bin_dir, launch_agents):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    arm_file = shared_dir / "log-rotation.enabled"
+    worker_plist = launch_agents / "com.robinco.auto-trader.worker.plist"
+    worker_plist.write_text("<plist/>")
+    launchctl_log = tmp_path / "launchctl.log"
+
+    launchctl = bin_dir / "launchctl"
+    _write_executable(
+        launchctl,
+        """#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >>"$AUTO_TRADER_TEST_LAUNCHCTL_LOG"
+exit 0
+""",
+    )
+    lsof = bin_dir / "lsof"
+    _write_executable(lsof, "#!/usr/bin/env bash\nexit 1\n")
+
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "AUTO_TRADER_BASE": str(base),
+        "AUTO_TRADER_LOG_DIR": str(log_dir),
+        "AUTO_TRADER_LOG_ROTATION_ARM_FILE": str(arm_file),
+        "AUTO_TRADER_LOG_MAX_BYTES": "1024",
+        "AUTO_TRADER_LOG_ARCHIVE_COUNT": "2",
+        "AUTO_TRADER_WORKER_PLIST": str(worker_plist),
+        "AUTO_TRADER_LAUNCHCTL_BIN": str(launchctl),
+        "AUTO_TRADER_LSOF_BIN": str(lsof),
+        "AUTO_TRADER_TEST_LAUNCHCTL_LOG": str(launchctl_log),
+    }
+    return env, log_dir, arm_file
+
+
+def test_rotation_is_inert_until_operator_arms_it(tmp_path: Path) -> None:
+    env, log_dir, _ = _rotation_env(tmp_path)
+    err_log = log_dir / "com.robinco.auto-trader.worker.err.log"
+    err_log.write_bytes(b"x" * 2048)
+    env["AUTO_TRADER_NEWSYSLOG_BIN"] = str(tmp_path / "not-used-newsyslog")
+
+    proc = subprocess.run(
+        ["bash", str(ROTATE_SCRIPT)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert err_log.stat().st_size == 2048
+    assert not list(log_dir.glob("*.0*"))
+
+
+def test_open_descriptors_block_rotation_and_worker_is_restored(
+    tmp_path: Path,
+) -> None:
+    env, log_dir, arm_file = _rotation_env(tmp_path)
+    arm_file.touch()
+    err_log = log_dir / "com.robinco.auto-trader.worker.err.log"
+    err_log.write_bytes(b"x" * 2048)
+
+    lsof = Path(env["AUTO_TRADER_LSOF_BIN"])
+    _write_executable(lsof, "#!/usr/bin/env bash\nprintf '4242\\n'\n")
+    newsyslog = tmp_path / "bin" / "newsyslog"
+    called = tmp_path / "newsyslog.called"
+    _write_executable(
+        newsyslog,
+        f"#!/usr/bin/env bash\ntouch {called}\n",
+    )
+    env["AUTO_TRADER_NEWSYSLOG_BIN"] = str(newsyslog)
+    env["AUTO_TRADER_LOG_FD_WAIT_ATTEMPTS"] = "1"
+    env["AUTO_TRADER_LOG_FD_WAIT_SECONDS"] = "0"
+
+    proc = subprocess.run(
+        ["bash", str(ROTATE_SCRIPT)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == 75
+    assert "open file descriptors remain" in proc.stderr
+    assert err_log.stat().st_size == 2048
+    assert not called.exists()
+
+    launchctl_calls = (tmp_path / "launchctl.log").read_text()
+    assert "bootout" in launchctl_calls
+    assert "bootstrap" in launchctl_calls
+    assert "kickstart -k" in launchctl_calls
+
+
+@pytest.mark.skipif(
+    shutil.which("newsyslog") is None,
+    reason="newsyslog is only available on macOS/BSD",
+)
+def test_real_newsyslog_enforces_size_and_archive_count(tmp_path: Path) -> None:
+    env, log_dir, arm_file = _rotation_env(tmp_path)
+    arm_file.touch()
+    env["AUTO_TRADER_NEWSYSLOG_BIN"] = shutil.which("newsyslog") or ""
+    err_log = log_dir / "com.robinco.auto-trader.worker.err.log"
+
+    for index in range(4):
+        err_log.write_bytes(bytes([65 + index]) * 2048)
+        proc = subprocess.run(
+            ["bash", str(ROTATE_SCRIPT)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert err_log.stat().st_size < 1024
+
+    archives = list(log_dir.glob(f"{err_log.name}.[0-9]*"))
+    assert len(archives) == 2
+
+    launchctl_calls = (tmp_path / "launchctl.log").read_text()
+    assert "bootout" in launchctl_calls
+    assert "bootstrap" in launchctl_calls
+    assert "kickstart -k" in launchctl_calls

--- a/upbit_websocket_monitor.py
+++ b/upbit_websocket_monitor.py
@@ -9,6 +9,7 @@ OpenClaw-based analysis will be implemented in the future.
 import asyncio
 import logging
 
+from app.core.logging_config import configure_dependency_log_levels
 from app.monitoring.sentry import capture_exception, init_sentry
 from app.services.upbit_websocket import UpbitOrderAnalysisService
 
@@ -16,6 +17,7 @@ from app.services.upbit_websocket import UpbitOrderAnalysisService
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
+configure_dependency_log_levels()
 logger = logging.getLogger(__name__)
 
 

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
+from app.core.logging_config import configure_dependency_log_levels
 from app.monitoring.sentry import capture_exception, init_sentry
 from app.monitoring.trade_notifier import get_trade_notifier
 from app.schemas.execution_ledger import ExecutionLedgerUpsert
@@ -966,6 +967,7 @@ async def main(mode: str = "both") -> None:
         level=getattr(logging, settings.LOG_LEVEL, logging.INFO),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+    configure_dependency_log_levels()
     service_name = {
         "upbit": "auto-trader-upbit-ws",
         "kis": "auto-trader-kis-ws",


### PR DESCRIPTION
## Summary
- suppress per-request `httpx` INFO lines across runtime entrypoints while retaining WARNING/ERROR diagnostics
- add an operator-armed 60s launchd guard that stops the TaskIQ worker, verifies log FDs are closed, rotates at 128MiB with macOS `newsyslog`, retains at most 4 gzip archives, and restores the worker
- document the operator-only procedure for the existing 25GB file; this PR does not delete/truncate it and does not deploy or arm rotation
- record bounded-tail ConnectTimeout/HTTP 5xx evidence and correlate `inquire_daily_itemchartprice` 3×5s behavior with ROB-1116

## Log sample (bounded; no full-file scan)
Window: 2026-07-27 12:20:29–2026-07-28 12:20:29 KST, derived from the last 200,000 lines.

- `httpx` HTTP request INFO: 39,950
- HTTP 5xx: 811 (all 500; 2.03% of HTTP request lines)
- KIS rate-limit heuristic warnings: 809; 808/811 500 lines paired with a rate-limit warning within 10 following lines
- ConnectTimeout: 10 request sequences / 20 logged retry attempts, all `inquire_daily_itemchartprice`
- ROB-1116: same endpoint and same ~15–16s 3-attempt timing; treat as the same B-track evidence

## Safety
- production deployment: not performed
- existing 25GB log: not deleted, truncated, renamed, or rotated
- rotation remains inert until the operator creates `shared/log-rotation.enabled` after following the runbook
- deploy does not auto-start the new rotation label

## Verification
- 118 focused logging/ops/runtime tests passed
- 91 tests covering the pre-rebase watch-FK failure set passed after rebasing onto current main
- real macOS `newsyslog` test repeatedly enforced a 1KiB current-file threshold and a 2-archive hard count in a temp directory
- open-FD refusal/restoration test passed
- `make lint` passed (Ruff, format, ty)
- `bash -n`, `plutil -lint`, and `git diff --check` passed

Runbook: `docs/runbooks/worker-log-rotation.md`

Linear: ROB-1118
