### PR TITLE
feat(research): prepare KR-B1 P0 session artifacts

### DIFF
--- a/app/services/krb1_p0_journal.py
+++ b/app/services/krb1_p0_journal.py
@@ -16,10 +16,13 @@ from pathlib import Path
 from typing import Any
 
 GENESIS_HASH = "0" * 64
-SEALED_INITIAL_ROW_HASH = (
-    "48335298149e92cdfbbb83f7f604b488074d33122f9c5ad15fe8d42b3925d8b8"
-)
-SEALED_INITIAL_HEAD = "be117294febe0c8280949a37e35baf95246f527049484b2c20ee890591408229"
+_SEALED_INITIAL_ROW = {
+    "next_stage": "P0_10_KRX_SESSIONS",
+    "p0_state": "NOT_STARTED",
+    "record_type": "SEAL_INITIALIZED",
+    "recorded_date": "2026-07-28",
+    "study_id": "KRB1-CSM60-H5-v1",
+}
 _ENTRY_KEYS = frozenset({"chain_hash", "index", "row", "row_hash"})
 _HEX_DIGITS = frozenset("0123456789abcdef")
 
@@ -67,6 +70,14 @@ def canonical_json_bytes(value: Any) -> bytes:
     except (TypeError, ValueError) as exc:
         raise JournalError(f"value is not canonical-JSON encodable: {exc}") from exc
     return encoded.encode("utf-8")
+
+
+SEALED_INITIAL_ROW_HASH = hashlib.sha256(
+    canonical_json_bytes(_SEALED_INITIAL_ROW)
+).hexdigest()
+SEALED_INITIAL_HEAD = hashlib.sha256(
+    bytes.fromhex(GENESIS_HASH) + bytes.fromhex(SEALED_INITIAL_ROW_HASH)
+).hexdigest()
 
 
 def compute_row_hash(row: Mapping[str, Any]) -> str:

--- a/app/services/krb1_p0_journal.py
+++ b/app/services/krb1_p0_journal.py
@@ -1,0 +1,268 @@
+"""Append-only JSONL hash-chain for the KR-B1 P0 campaign.
+
+This module is deliberately file-only.  It does not import a database, broker,
+order, fill, scheduler, or deployment surface.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+GENESIS_HASH = "0" * 64
+SEALED_INITIAL_ROW_HASH = (
+    "48335298149e92cdfbbb83f7f604b488074d33122f9c5ad15fe8d42b3925d8b8"
+)
+SEALED_INITIAL_HEAD = "be117294febe0c8280949a37e35baf95246f527049484b2c20ee890591408229"
+_ENTRY_KEYS = frozenset({"chain_hash", "index", "row", "row_hash"})
+_HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+class JournalError(ValueError):
+    """The journal is malformed or violates the append-only chain contract."""
+
+
+@dataclass(frozen=True)
+class JournalEntry:
+    """One verified JSONL envelope."""
+
+    index: int
+    row: dict[str, Any]
+    row_hash: str
+    chain_hash: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "chain_hash": self.chain_hash,
+            "index": self.index,
+            "row": self.row,
+            "row_hash": self.row_hash,
+        }
+
+
+@dataclass(frozen=True)
+class JournalHead:
+    """Verified append position."""
+
+    row_count: int
+    chain_hash: str
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Return the sealed-policy JSON encoding or fail closed."""
+    try:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise JournalError(f"value is not canonical-JSON encodable: {exc}") from exc
+    return encoded.encode("utf-8")
+
+
+def compute_row_hash(row: Mapping[str, Any]) -> str:
+    """SHA-256 of one canonical row."""
+    return hashlib.sha256(canonical_json_bytes(dict(row))).hexdigest()
+
+
+def compute_chain_hash(previous_chain_hash: str, row_hash: str) -> str:
+    """SHA-256(raw previous chain hash || raw row hash)."""
+    _require_hash(previous_chain_hash, field="previous_chain_hash")
+    _require_hash(row_hash, field="row_hash")
+    material = bytes.fromhex(previous_chain_hash) + bytes.fromhex(row_hash)
+    return hashlib.sha256(material).hexdigest()
+
+
+def build_entry(
+    *, index: int, row: Mapping[str, Any], previous_chain_hash: str
+) -> JournalEntry:
+    """Build the next immutable envelope without writing it."""
+    if type(index) is not int or index < 1:
+        raise JournalError("index must be a positive built-in int")
+    normalized_row = _normalize_row(row)
+    row_hash = compute_row_hash(normalized_row)
+    return JournalEntry(
+        index=index,
+        row=normalized_row,
+        row_hash=row_hash,
+        chain_hash=compute_chain_hash(previous_chain_hash, row_hash),
+    )
+
+
+def verify_journal(path: Path) -> JournalHead:
+    """Verify canonical bytes, every row hash, and the complete chain."""
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise JournalError(f"cannot read journal {path}: {exc}") from exc
+    return _verify_bytes(data)
+
+
+def append_journal_row(path: Path, row: Mapping[str, Any]) -> JournalEntry:
+    """Atomically append one canonical line after verifying the current chain.
+
+    The exclusive advisory lock serializes writers.  Existing bytes are never
+    rewritten or truncated.
+    """
+    normalized_row = _normalize_row(row)
+    try:
+        with path.open("r+b") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            handle.seek(0)
+            existing = handle.read()
+            head = _verify_bytes(existing)
+            if head.row_count == 0:
+                raise JournalError(
+                    "journal has no sealed initial row; initialize it before append"
+                )
+            entry = build_entry(
+                index=head.row_count + 1,
+                row=normalized_row,
+                previous_chain_hash=head.chain_hash,
+            )
+            line = canonical_json_bytes(entry.as_dict()) + b"\n"
+            handle.seek(0, os.SEEK_END)
+            handle.write(line)
+            handle.flush()
+            os.fsync(handle.fileno())
+            return entry
+    except OSError as exc:
+        raise JournalError(f"cannot append journal {path}: {exc}") from exc
+
+
+def create_journal(path: Path, initial_row: Mapping[str, Any]) -> JournalEntry:
+    """Create a new journal exclusively; refuse to replace any existing path."""
+    entry = build_entry(
+        index=1,
+        row=initial_row,
+        previous_chain_hash=GENESIS_HASH,
+    )
+    if (
+        entry.row_hash != SEALED_INITIAL_ROW_HASH
+        or entry.chain_hash != SEALED_INITIAL_HEAD
+    ):
+        raise JournalError("initial row does not match the sealed KR-B1 anchor")
+    line = canonical_json_bytes(entry.as_dict()) + b"\n"
+    try:
+        with path.open("xb") as handle:
+            handle.write(line)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError as exc:
+        raise JournalError(f"cannot create new journal {path}: {exc}") from exc
+    return entry
+
+
+def _verify_bytes(data: bytes) -> JournalHead:
+    if not data:
+        return JournalHead(row_count=0, chain_hash=GENESIS_HASH)
+    if not data.endswith(b"\n"):
+        raise JournalError("journal must end with a newline before another append")
+
+    previous = GENESIS_HASH
+    row_count = 0
+    for expected_index, raw_line in enumerate(data.splitlines(), start=1):
+        if not raw_line:
+            raise JournalError(f"line {expected_index} is blank")
+        value = _strict_json_loads(raw_line, line=expected_index)
+        if type(value) is not dict or set(value) != _ENTRY_KEYS:
+            raise JournalError(
+                f"line {expected_index} must have exactly {sorted(_ENTRY_KEYS)}"
+            )
+        if canonical_json_bytes(value) != raw_line:
+            raise JournalError(f"line {expected_index} is not canonical JSON")
+
+        index = value["index"]
+        if type(index) is not int or index != expected_index:
+            raise JournalError(
+                f"line {expected_index} has non-contiguous index {index!r}"
+            )
+        row = value["row"]
+        if type(row) is not dict:
+            raise JournalError(f"line {expected_index} row must be an object")
+        row_hash = value["row_hash"]
+        chain_hash = value["chain_hash"]
+        _require_hash(row_hash, field=f"line {expected_index} row_hash")
+        _require_hash(chain_hash, field=f"line {expected_index} chain_hash")
+
+        expected_row_hash = compute_row_hash(row)
+        if row_hash != expected_row_hash:
+            raise JournalError(f"line {expected_index} row_hash mismatch")
+        expected_chain_hash = compute_chain_hash(previous, row_hash)
+        if chain_hash != expected_chain_hash:
+            raise JournalError(f"line {expected_index} chain_hash mismatch")
+        if expected_index == 1 and (
+            row_hash != SEALED_INITIAL_ROW_HASH or chain_hash != SEALED_INITIAL_HEAD
+        ):
+            raise JournalError("line 1 does not match the sealed KR-B1 anchor")
+
+        previous = chain_hash
+        row_count = expected_index
+    return JournalHead(row_count=row_count, chain_hash=previous)
+
+
+def _strict_json_loads(raw: bytes, *, line: int) -> Any:
+    def pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, child in pairs:
+            if key in value:
+                raise JournalError(f"line {line} contains duplicate key {key!r}")
+            value[key] = child
+        return value
+
+    def reject_constant(value: str) -> None:
+        raise JournalError(f"line {line} contains non-finite number {value}")
+
+    try:
+        return json.loads(
+            raw,
+            object_pairs_hook=pairs_hook,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise JournalError(f"line {line} is not valid UTF-8 JSON: {exc}") from exc
+
+
+def _normalize_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(row, Mapping):
+        raise JournalError("row must be a mapping")
+    normalized = dict(row)
+    if any(type(key) is not str for key in normalized):
+        raise JournalError("row keys must be built-in strings")
+    canonical_json_bytes(normalized)
+    return normalized
+
+
+def _require_hash(value: Any, *, field: str) -> None:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or not set(value).issubset(_HEX_DIGITS)
+    ):
+        raise JournalError(f"{field} must be lowercase 64-hex SHA-256")
+
+
+__all__ = [
+    "GENESIS_HASH",
+    "SEALED_INITIAL_HEAD",
+    "SEALED_INITIAL_ROW_HASH",
+    "JournalEntry",
+    "JournalError",
+    "JournalHead",
+    "append_journal_row",
+    "build_entry",
+    "canonical_json_bytes",
+    "compute_chain_hash",
+    "compute_row_hash",
+    "create_journal",
+    "verify_journal",
+]

--- a/docs/research/krb1/README.md
+++ b/docs/research/krb1/README.md
@@ -1,0 +1,92 @@
+# KR-B1 P0 준비물
+
+이 디렉터리는 봉인 정본
+`KRB1-CSM60-H5-v1`(`d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1`)
+을 수정하지 않고 P0 시작에 필요한 파일만 고정한다.
+
+## P0-4 journal
+
+`p0-anchor-ledger.initial.jsonl`은 봉인 JSON의 초기 row/index/row hash/chain head를
+바이트 그대로 옮긴 한 줄짜리 read-only scaffold다. P0 시작 시 `init`으로 gitignored
+runtime journal을 독점 생성한다. 다음 쓰기는 기존 줄을 바꾸지 않고
+`scripts/krb1_p0_journal.py append --row-file ...`로만 추가한다. 서비스는 매 append
+전에 전체 prefix의 canonical JSON, row hash, chain hash를 검증하고 advisory lock,
+단일 append, `fsync`를 수행한다.
+
+`p0-retrospective-row.schema.json`은 §6의 필드를 다음처럼 일대일로 보존한다.
+
+| 정본 표기 | JSON field |
+|---|---|
+| rank | `rank` |
+| M60 | `M60` |
+| DV20 pct | `DV20_pct` |
+| planned limit | `planned_limit` |
+| 실체결가 | `actual_execution_price` |
+| 수량 | `quantity` |
+| 예정·실제 청산일 | `planned_exit_date`, `actual_exit_date` |
+| gross·base·stress net | `gross`, `base_net`, `stress_net` |
+| 틱 bp | `tick_bp` |
+| 수수료·세금 | `fees`, `taxes` |
+| 지연 | `delay` |
+| hash | `hash` |
+| correlation_id | `correlation_id` |
+
+§7.4가 DB 원장을 요구하지 않으므로 새 DB 테이블이나 migration은 만들지 않았다.
+
+## ROB-1115 / PR #1700 판단
+
+PR #1700의 `research.strategy_learning_events`는 UPDATE/DELETE/TRUNCATE를 DB
+trigger로 거부하고 idempotent INSERT를 제공한다. 그러나 그 테이블은 학습결과
+메모리(`stage`, `verdict`, `failure_class`, `learning_payload` 등)이고, KR-B1이
+요구한 CSV/JSON row hash-chain 및 §6 retrospective 필드가 없다. 또한 PR은 아직
+open이며 main에 없다.
+
+따라서 PR #1700 테이블을 복제하거나 P0 journal로 오용하지 않는다. ROB-1115가
+재사용한 ROB-846 hash helper도 raw row를 typed AST로 바꾸므로, 봉인 ledger의
+plain-JSON row hash와 바이트가 달라 직접 재사용할 수 없다. 파일 원장은 정본의
+`sort_keys=True`, `separators=(",",":")`, `ensure_ascii=False`,
+`allow_nan=False`를 그대로 구현하고 봉인 초기 row hash/head 재현 테스트로 잠근다.
+PR #1700이 merge된 뒤 P0 결과를 학습 메모리로 요약하는 것은 가능하지만, 그 row가
+이 hash-chain journal을 대체하지 않는다.
+
+## Calendar
+
+`krx-calendar-2026-07-30-p0.json` 자체가 판정 권위다. XKRX 4.13.2 결과를 KRX 공식
+휴장/정규장 규칙과 대조한 뒤 10개 날짜와 운영 시각을 파일에 고정했다. 이후
+`exchange_calendars` 결과가 바뀌어도 동적 재계산으로 날짜를 바꾸지 않는다.
+
+세션은 `2026-07-30`, `07-31`, `08-03`, `08-04`, `08-05`, `08-06`, `08-07`,
+`08-10`, `08-11`, `08-12`다. 범위 안 제외일은 주말 `08-01`, `08-02`, `08-08`,
+`08-09`이며 반차는 없다.
+
+## 운영
+
+P0 시작 전 read-only smoke:
+
+```bash
+uv run python scripts/krb1_p0_smoke.py \
+  --sealed-json ~/work/herdr-inbox/krb1-combined-canonical-2026-07-28.json
+```
+
+journal 단독 검증:
+
+```bash
+uv run python scripts/krb1_p0_journal.py init
+uv run python scripts/krb1_p0_journal.py verify
+```
+
+P0 시작 시에는 별도 JSON object 파일에 start anchor/manifest를 작성한 뒤 append한다.
+봉인 문서가 지정하지 않은 start-anchor 세부 필드는 이 준비물에서 임의로 고정하지
+않는다. 비용 probe는 `cost-probe-plan.md` 순서로 P0에서만 수행한다.
+
+## 정본 모호성
+
+- §6의 `hash`가 어느 단일 artifact hash인지 이름을 특정하지 않는다. 스키마는 키를
+  `hash` 그대로 두었다.
+- §6의 `tick bp` 계산 분모·반올림, `delay` 단위가 특정되지 않는다. 필드만 고정하고
+  계산식을 추가하지 않았다.
+- 비용 실측값을 `C_stress_cap`으로 축약하는 reducer/반올림 식이 없다.
+- tick band별 표와 상·하한가 산식의 반올림 세부가 없다. P0-1/P0-2 증거로
+  닫히지 않으면 fail-closed 한다.
+- next append가 P0 시작 anchor/manifest라고만 되어 있고 그 payload 필드는 없다.
+  따라서 start row의 세부 스키마는 만들지 않았다.

--- a/docs/research/krb1/cost-probe-plan.md
+++ b/docs/research/krb1/cost-probe-plan.md
@@ -1,0 +1,83 @@
+# KR-B1 P0 비용 probe 계획
+
+상태: `PLAN_ONLY / NOT_EXECUTED`
+
+정본: `KRB1-CSM60-H5-v1`, 봉인 JSON SHA-256
+`d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1`.
+이 문서는 봉인 조문의 수치·임계·절차를 바꾸지 않으며 현재 probe를 실행하지 않는다.
+
+## 금지 경계
+
+- P0 probe는 `kiwoom_mock` / `KRX_ONLY`에서만 한다.
+- 실계좌·실주문·production DB write·배포는 하지 않는다.
+- broker mock이 개장 전 접수, closing auction 생존, 정규장 종료 후 DAY 자동 만료 중
+  하나라도 지원하지 않으면 대체 절차를 만들지 않고 P0 실패 +
+  `NOT_DISCRIMINABLE`로 끝낸다.
+- P0 전에 `C_stress_cap`, 비용표, tick 함수, 상·하한가 산식의 값을 확정하거나
+  canonical hash에 넣지 않는다.
+
+## P0 표본과 원증거
+
+10개 동결 KRX 세션 동안 KOSPI와 KOSDAQ을 포함해 1주 왕복 probe를 합계 20건 이상
+수집한다. 두 시장이 모두 포함되어야 하며, 봉인 조문에 없는 시장별 할당 수는 새로
+만들지 않는다. 각 probe는 다음 원증거를 같은 correlation 단위로 보존한다.
+
+- 시장·종목·상품유형, KRX 거래일, broker order/execution ID
+- 매수·매도 요청/접수/체결 시각, 가격, 수량, venue, validity
+- 매수 전·reserve 후·체결 후·매도 체결 후 cash와 그 delta
+- broker가 보고한 매수 수수료, 매도 수수료, 매도세, 평균단가
+- 요청가·체결가에서 broker가 수용한 호가단위
+- 취소 probe의 취소 전/후 reserved cash와 해제 시각
+- 모든 broker 응답 원문은 별도 immutable evidence 파일로 보존하고 SHA-256만
+  journal row에 넣는다.
+
+왕복 1주 표본마다 `cash delta = 매도대금 - 매수대금 - 수수료 - 매도세`와 broker
+평단을 정수 KRW 원장으로 대사한다. 불일치, 결손, 중복 correlation, venue 이탈은
+임의 보정하지 않고 결함으로 기록한다.
+
+## tick_floor / tick_ceil와 상·하한가
+
+P0-1에서 KOSPI·KOSDAQ 각각에 대해 가격 band 경계의 바로 아래/경계/바로 위를
+포함하는 표를 만든다. 각 가격에서 broker preview/acceptance가 수용하는 호가단위를
+원증거로 기록하고 다음 두 연산을 그 표에 대조한다.
+
+- 진입: `L_i = tick_floor(1.01 × C_t)`
+- forecast target: `T_i = tick_ceil(L × (1 + C_stress_cap))`
+
+상·하한가는 동일 종목·세션의 broker 기준가, broker 표시 상한가·하한가, 주문
+preview 수용가격을 함께 저장해 산식을 검증한다. 청산 주문은 5번째 세션 15:10의
+당일 유효 하한가 지정가라는 정본 절차를 그대로 사용한다. 정본은 호가 band별 표와
+상·하한가의 반올림 세부식을 명시하지 않으므로 P0 실측 전에는 구현 하나를 정답으로
+선언하지 않는다. P0 증거가 단일 산식을 확정하지 못하면 fail-closed 한다.
+
+## 비용표와 C_stress_cap 동결
+
+20건 이상을 모두 대사한 뒤 시장/상품/side별 관측 수수료·세금·cash delta 표를 만든다.
+모의 비용이 실제 적용 비용과 다르면 정본 지시대로 실제 비용표로 재계산한다.
+`stress_pnl_num_krw_i`에는 동결 비용정책·반올림 뒤의 정수 KRW로 실청산대금,
+실진입대금, 매수/매도 수수료, 매도세, 진입 1틱과 청산 1틱 adverse shortfall을
+execution 합산한다.
+
+정본에는 비용 실측값을 `C_stress_cap` 하나로 축약하는 reducer/반올림 식이 없다.
+따라서 probe 표를 보기 전에 reducer를 추가하지 않는다. P0 증거와 별도의 승인된
+정본이 그 식을 닫은 뒤에만 `C_stress_cap`을 계산하고, 닫히지 않으면 canonical
+hash를 만들지 않고 모호성으로 보고한다.
+
+## P0 → canonical hash 순서
+
+순서는 다음과 같이 고정한다.
+
+1. 봉인 정책 JSON과 코드, P0 calendar, journal schema를 입력 권위로 고정한다.
+2. P0 10세션에서 비용·tick·상하한가 증거를 수집한다.
+3. 20건 이상 왕복 원장을 대사하고 mock 비용과 실제 비용표 차이를 판정한다.
+4. tick_floor/ceil 및 상·하한가 산식을 증거로 확정한다.
+5. 승인된 reducer가 있을 때만 `C_stress_cap`을 확정한다.
+6. 비용표·반올림·tick 함수·상하한가 산식·`C_stress_cap`과 각 원증거 SHA-256을
+   P0 비용계약 JSON에 기록한다.
+7. 그 P0 비용계약 JSON을 포함한 실행정책 manifest를 canonical 직렬화하고
+   SHA-256을 계산한다. 기존 봉인 JSON 해시는 바꾸지 않는다.
+8. 이 hash를 journal P0 완료 anchor와 이후 forecast의
+   `policy_version=v1:<canonical_sha256>`에 사용한다.
+9. 그 다음에만 20세션 PnL-blind dry-count를 시작한다.
+
+즉 비용값은 P0의 입력이 아니라 P0 산출물이며, P0 산출물 확정 뒤 hash가 만들어진다.

--- a/docs/research/krb1/krx-calendar-2026-07-30-p0.json
+++ b/docs/research/krb1/krx-calendar-2026-07-30-p0.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": "krb1-p0-krx-calendar.v1",
+  "study_id": "KRB1-CSM60-H5-v1",
+  "timezone": "Asia/Seoul",
+  "authority": "THIS_FROZEN_SNAPSHOT",
+  "canonical_policy_sha256": "d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1",
+  "calendar_source": {
+    "calendar": "XKRX",
+    "exchange_calendars_version": "4.13.2",
+    "uv_lock_wheel_sha256": "fc5a2ad0d61b5c3a6539a3061cd4cbb55c59f4a903455cec7926e4b798919996",
+    "official_krx_rules_url": "https://global.krx.co.kr/contents/GLB/06/0602/0602010201/GLB0602010201T1.jsp",
+    "official_rule": "Monday-Friday except government holidays, Labor Day, Saturdays, year-end closing, and KRX-designated closures; regular session 09:00-15:30"
+  },
+  "frozen_on": "2026-07-28",
+  "first_session": "2026-07-30",
+  "last_session": "2026-08-12",
+  "session_count": 10,
+  "excluded_dates_within_span": [
+    {
+      "date": "2026-08-01",
+      "reason": "SATURDAY"
+    },
+    {
+      "date": "2026-08-02",
+      "reason": "SUNDAY"
+    },
+    {
+      "date": "2026-08-08",
+      "reason": "SATURDAY"
+    },
+    {
+      "date": "2026-08-09",
+      "reason": "SUNDAY"
+    }
+  ],
+  "half_days_within_span": [],
+  "sessions": [
+    {
+      "p0_session": 1,
+      "trade_date": "2026-07-30",
+      "decision_at": "2026-07-29T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-07-30T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-07-30T08:55:00+09:00",
+      "official_open": "2026-07-30T09:00:00+09:00",
+      "exit_submit_at": "2026-07-30T15:10:00+09:00",
+      "official_close": "2026-07-30T15:30:00+09:00",
+      "reconcile_at": "2026-07-30T15:35:00+09:00"
+    },
+    {
+      "p0_session": 2,
+      "trade_date": "2026-07-31",
+      "decision_at": "2026-07-30T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-07-31T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-07-31T08:55:00+09:00",
+      "official_open": "2026-07-31T09:00:00+09:00",
+      "exit_submit_at": "2026-07-31T15:10:00+09:00",
+      "official_close": "2026-07-31T15:30:00+09:00",
+      "reconcile_at": "2026-07-31T15:35:00+09:00"
+    },
+    {
+      "p0_session": 3,
+      "trade_date": "2026-08-03",
+      "decision_at": "2026-07-31T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-03T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-03T08:55:00+09:00",
+      "official_open": "2026-08-03T09:00:00+09:00",
+      "exit_submit_at": "2026-08-03T15:10:00+09:00",
+      "official_close": "2026-08-03T15:30:00+09:00",
+      "reconcile_at": "2026-08-03T15:35:00+09:00"
+    },
+    {
+      "p0_session": 4,
+      "trade_date": "2026-08-04",
+      "decision_at": "2026-08-03T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-04T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-04T08:55:00+09:00",
+      "official_open": "2026-08-04T09:00:00+09:00",
+      "exit_submit_at": "2026-08-04T15:10:00+09:00",
+      "official_close": "2026-08-04T15:30:00+09:00",
+      "reconcile_at": "2026-08-04T15:35:00+09:00"
+    },
+    {
+      "p0_session": 5,
+      "trade_date": "2026-08-05",
+      "decision_at": "2026-08-04T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-05T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-05T08:55:00+09:00",
+      "official_open": "2026-08-05T09:00:00+09:00",
+      "exit_submit_at": "2026-08-05T15:10:00+09:00",
+      "official_close": "2026-08-05T15:30:00+09:00",
+      "reconcile_at": "2026-08-05T15:35:00+09:00"
+    },
+    {
+      "p0_session": 6,
+      "trade_date": "2026-08-06",
+      "decision_at": "2026-08-05T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-06T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-06T08:55:00+09:00",
+      "official_open": "2026-08-06T09:00:00+09:00",
+      "exit_submit_at": "2026-08-06T15:10:00+09:00",
+      "official_close": "2026-08-06T15:30:00+09:00",
+      "reconcile_at": "2026-08-06T15:35:00+09:00"
+    },
+    {
+      "p0_session": 7,
+      "trade_date": "2026-08-07",
+      "decision_at": "2026-08-06T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-07T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-07T08:55:00+09:00",
+      "official_open": "2026-08-07T09:00:00+09:00",
+      "exit_submit_at": "2026-08-07T15:10:00+09:00",
+      "official_close": "2026-08-07T15:30:00+09:00",
+      "reconcile_at": "2026-08-07T15:35:00+09:00"
+    },
+    {
+      "p0_session": 8,
+      "trade_date": "2026-08-10",
+      "decision_at": "2026-08-07T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-10T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-10T08:55:00+09:00",
+      "official_open": "2026-08-10T09:00:00+09:00",
+      "exit_submit_at": "2026-08-10T15:10:00+09:00",
+      "official_close": "2026-08-10T15:30:00+09:00",
+      "reconcile_at": "2026-08-10T15:35:00+09:00"
+    },
+    {
+      "p0_session": 9,
+      "trade_date": "2026-08-11",
+      "decision_at": "2026-08-10T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-11T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-11T08:55:00+09:00",
+      "official_open": "2026-08-11T09:00:00+09:00",
+      "exit_submit_at": "2026-08-11T15:10:00+09:00",
+      "official_close": "2026-08-11T15:30:00+09:00",
+      "reconcile_at": "2026-08-11T15:35:00+09:00"
+    },
+    {
+      "p0_session": 10,
+      "trade_date": "2026-08-12",
+      "decision_at": "2026-08-11T18:00:00+09:00",
+      "entry_submit_start_inclusive": "2026-08-12T08:50:00+09:00",
+      "entry_submit_end_exclusive": "2026-08-12T08:55:00+09:00",
+      "official_open": "2026-08-12T09:00:00+09:00",
+      "exit_submit_at": "2026-08-12T15:10:00+09:00",
+      "official_close": "2026-08-12T15:30:00+09:00",
+      "reconcile_at": "2026-08-12T15:35:00+09:00"
+    }
+  ]
+}

--- a/docs/research/krb1/p0-anchor-ledger.initial.jsonl
+++ b/docs/research/krb1/p0-anchor-ledger.initial.jsonl
@@ -1,0 +1,1 @@
+{"chain_hash":"be117294febe0c8280949a37e35baf95246f527049484b2c20ee890591408229","index":1,"row":{"next_stage":"P0_10_KRX_SESSIONS","p0_state":"NOT_STARTED","record_type":"SEAL_INITIALIZED","recorded_date":"2026-07-28","study_id":"KRB1-CSM60-H5-v1"},"row_hash":"48335298149e92cdfbbb83f7f604b488074d33122f9c5ad15fe8d42b3925d8b8"}

--- a/docs/research/krb1/p0-prep-artifact-manifest.json
+++ b/docs/research/krb1/p0-prep-artifact-manifest.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "krb1-p0-prep-artifact-manifest.v1",
+  "study_id": "KRB1-CSM60-H5-v1",
+  "sealed_canonical_sha256": "d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1",
+  "artifacts": {
+    "cost-probe-plan.md": "47fba3b51027dad170f4ee104adf8b566a39669a29a2a473c1ead9de9ef6e800",
+    "krx-calendar-2026-07-30-p0.json": "b8933e4b02ed29b5e40b96a77fa0091f70c25394cfc854657064cda99eca84da",
+    "p0-anchor-ledger.initial.jsonl": "d76ff46f9f38c205ccfab16d541fbddf8c439e08a0cbb1b4f90c16be7b0d7af9",
+    "p0-retrospective-row.schema.json": "39752e133b3a9f5b6ca4e18e7a5cc765833a0e7c287eda21d4bb08b42c105239"
+  },
+  "calendar_authority": {
+    "artifact": "krx-calendar-2026-07-30-p0.json",
+    "first_session": "2026-07-30",
+    "last_session": "2026-08-12",
+    "session_count": 10,
+    "runtime_recalculation": "PROHIBITED"
+  },
+  "rob_1115_review": {
+    "pr": 1700,
+    "head_sha": "54876480be03eb7996717e6949f9207695bc44d7",
+    "state_at_review": "OPEN",
+    "decision": "DO_NOT_DUPLICATE_OR_USE_AS_P0_HASH_CHAIN"
+  },
+  "cost_probe_state": "NOT_EXECUTED",
+  "p0_state": "NOT_STARTED"
+}

--- a/docs/research/krb1/p0-retrospective-row.schema.json
+++ b/docs/research/krb1/p0-retrospective-row.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:auto-trader:krb1:p0-retrospective-row:v1",
+  "title": "KR-B1 P0 append-only journal retrospective row",
+  "description": "The §6 retrospective fields, retained with the canonical clause's field labels. Hash-chain metadata is the surrounding JSONL envelope.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "record_type": {
+      "const": "RETROSPECTIVE"
+    },
+    "study_id": {
+      "const": "KRB1-CSM60-H5-v1"
+    },
+    "rank": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "M60": {
+      "type": "number"
+    },
+    "DV20_pct": {
+      "type": "number"
+    },
+    "planned_limit": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "actual_execution_price": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "quantity": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "planned_exit_date": {
+      "type": "string",
+      "format": "date"
+    },
+    "actual_exit_date": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date"
+    },
+    "gross": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "base_net": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "stress_net": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "tick_bp": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "fees": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "taxes": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "delay": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "correlation_id": {
+      "type": "string",
+      "pattern": "^krb1:csm60-h5:v1:[0-9]{8}:[^:]+:[0-9]+$"
+    }
+  },
+  "required": [
+    "record_type",
+    "study_id",
+    "rank",
+    "M60",
+    "DV20_pct",
+    "planned_limit",
+    "actual_execution_price",
+    "quantity",
+    "planned_exit_date",
+    "actual_exit_date",
+    "gross",
+    "base_net",
+    "stress_net",
+    "tick_bp",
+    "fees",
+    "taxes",
+    "delay",
+    "hash",
+    "correlation_id"
+  ]
+}

--- a/scripts/krb1_p0_journal.py
+++ b/scripts/krb1_p0_journal.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify or append the local KR-B1 P0 JSONL journal."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from app.services.krb1_p0_journal import (
+    JournalError,
+    append_journal_row,
+    create_journal,
+    verify_journal,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAFFOLD_JOURNAL = REPO_ROOT / "docs/research/krb1/p0-anchor-ledger.initial.jsonl"
+DEFAULT_JOURNAL = REPO_ROOT / "var/research/krb1/p0-anchor-ledger.jsonl"
+
+
+def _object_file(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise JournalError(f"cannot load row file {path}: {exc}") from exc
+    if type(value) is not dict:
+        raise JournalError("row file must contain one JSON object")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Append-only KR-B1 P0 journal operator utility"
+    )
+    parser.add_argument(
+        "--journal",
+        type=Path,
+        default=DEFAULT_JOURNAL,
+        help="runtime JSONL journal path (default: var/research/krb1/...)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser(
+        "init",
+        help="exclusively create the runtime journal from the sealed scaffold",
+    )
+    subparsers.add_parser("verify", help="verify the complete hash-chain")
+    append_parser = subparsers.add_parser("append", help="append one JSON row")
+    append_parser.add_argument("--row-file", type=Path, required=True)
+    args = parser.parse_args()
+
+    try:
+        if args.command == "init":
+            scaffold_head = verify_journal(SCAFFOLD_JOURNAL)
+            if scaffold_head.row_count != 1:
+                raise JournalError("sealed scaffold must contain exactly one row")
+            initial_entry = json.loads(SCAFFOLD_JOURNAL.read_text(encoding="utf-8"))
+            args.journal.parent.mkdir(parents=True, exist_ok=True)
+            created = create_journal(args.journal, initial_entry["row"])
+            if created.as_dict() != initial_entry:
+                raise JournalError("runtime initial row differs from sealed scaffold")
+            print(
+                json.dumps(
+                    {
+                        "chain_hash": created.chain_hash,
+                        "journal": str(args.journal),
+                        "row_count": 1,
+                        "status": "INITIALIZED",
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+
+        if args.command == "verify":
+            head = verify_journal(args.journal)
+            print(
+                json.dumps(
+                    {
+                        "chain_hash": head.chain_hash,
+                        "journal": str(args.journal),
+                        "row_count": head.row_count,
+                        "status": "PASS",
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+
+        row = _object_file(args.row_file)
+        entry = append_journal_row(args.journal, row)
+        print(json.dumps(entry.as_dict(), sort_keys=True, ensure_ascii=False))
+        return 0
+    except JournalError as exc:
+        parser.exit(1, f"FAIL: {exc}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/krb1_p0_smoke.py
+++ b/scripts/krb1_p0_smoke.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Read-only KR-B1 P0 preparation smoke.
+
+This validates frozen local artifacts only.  It does not call a broker,
+database, network, scheduler, or deployment surface and does not execute a
+cost probe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from app.services.krb1_p0_journal import (
+    SEALED_INITIAL_HEAD,
+    JournalError,
+    verify_journal,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ROOT = REPO_ROOT / "docs/research/krb1"
+MANIFEST_PATH = ARTIFACT_ROOT / "p0-prep-artifact-manifest.json"
+EXPECTED_SEALED_SHA256 = (
+    "d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1"
+)
+EXPECTED_DATES = [
+    "2026-07-30",
+    "2026-07-31",
+    "2026-08-03",
+    "2026-08-04",
+    "2026-08-05",
+    "2026-08-06",
+    "2026-08-07",
+    "2026-08-10",
+    "2026-08-11",
+    "2026-08-12",
+]
+EXPECTED_RETROSPECTIVE_FIELDS = {
+    "DV20_pct",
+    "M60",
+    "actual_execution_price",
+    "actual_exit_date",
+    "base_net",
+    "correlation_id",
+    "delay",
+    "fees",
+    "gross",
+    "hash",
+    "planned_exit_date",
+    "planned_limit",
+    "quantity",
+    "rank",
+    "record_type",
+    "stress_net",
+    "study_id",
+    "taxes",
+    "tick_bp",
+}
+
+
+class SmokeError(ValueError):
+    """One preparation artifact failed closed."""
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SmokeError(f"cannot load {path}: {exc}") from exc
+    if type(value) is not dict:
+        raise SmokeError(f"{path} must contain one JSON object")
+    return value
+
+
+def _sha256(path: Path) -> str:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise SmokeError(f"cannot hash {path}: {exc}") from exc
+
+
+def _verify_artifact_hashes(manifest: dict[str, Any]) -> None:
+    artifacts = manifest.get("artifacts")
+    if type(artifacts) is not dict or not artifacts:
+        raise SmokeError("artifact manifest has no artifacts")
+    for relative_name, expected in artifacts.items():
+        if type(relative_name) is not str or type(expected) is not str:
+            raise SmokeError("artifact manifest names and hashes must be strings")
+        actual = _sha256(ARTIFACT_ROOT / relative_name)
+        if actual != expected:
+            raise SmokeError(
+                f"artifact hash mismatch for {relative_name}: {actual} != {expected}"
+            )
+
+
+def _verify_seal_and_scaffold(sealed_path: Path) -> None:
+    actual_seal_hash = _sha256(sealed_path)
+    if actual_seal_hash != EXPECTED_SEALED_SHA256:
+        raise SmokeError(
+            f"sealed canonical hash mismatch: {actual_seal_hash} "
+            f"!= {EXPECTED_SEALED_SHA256}"
+        )
+    sealed = _load_object(sealed_path)
+    initial_rows = sealed.get("anchor_ledger", {}).get("initial_rows")
+    if type(initial_rows) is not list or len(initial_rows) != 1:
+        raise SmokeError("sealed canonical must contain exactly one initial row")
+
+    scaffold_path = ARTIFACT_ROOT / "p0-anchor-ledger.initial.jsonl"
+    try:
+        scaffold = json.loads(scaffold_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SmokeError(f"cannot load journal scaffold: {exc}") from exc
+    if scaffold != initial_rows[0]:
+        raise SmokeError("journal scaffold differs from sealed initial row")
+    try:
+        head = verify_journal(scaffold_path)
+    except JournalError as exc:
+        raise SmokeError(f"journal scaffold failed verification: {exc}") from exc
+    if head.row_count != 1 or head.chain_hash != SEALED_INITIAL_HEAD:
+        raise SmokeError("journal scaffold initial head/count mismatch")
+
+
+def _parse(value: Any, *, field: str) -> datetime:
+    if type(value) is not str:
+        raise SmokeError(f"{field} must be an ISO timestamp")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SmokeError(f"{field} is not an ISO timestamp") from exc
+    if parsed.utcoffset() != timedelta(hours=9):
+        raise SmokeError(f"{field} must use +09:00")
+    return parsed
+
+
+def _verify_calendar() -> None:
+    calendar = _load_object(ARTIFACT_ROOT / "krx-calendar-2026-07-30-p0.json")
+    if calendar.get("authority") != "THIS_FROZEN_SNAPSHOT":
+        raise SmokeError("calendar snapshot is not the declared authority")
+    if calendar.get("half_days_within_span") != []:
+        raise SmokeError("frozen P0 window must have no half-days")
+    sessions = calendar.get("sessions")
+    if type(sessions) is not list or len(sessions) != 10:
+        raise SmokeError("calendar must contain exactly 10 sessions")
+    dates = [session.get("trade_date") for session in sessions]
+    if dates != EXPECTED_DATES:
+        raise SmokeError(f"calendar session dates changed: {dates!r}")
+
+    for expected_index, session in enumerate(sessions, start=1):
+        if type(session) is not dict:
+            raise SmokeError(f"calendar session {expected_index} must be an object")
+        if session.get("p0_session") != expected_index:
+            raise SmokeError(f"calendar session index {expected_index} changed")
+        opened = _parse(session.get("official_open"), field="official_open")
+        closed = _parse(session.get("official_close"), field="official_close")
+        start = _parse(
+            session.get("entry_submit_start_inclusive"),
+            field="entry_submit_start_inclusive",
+        )
+        end = _parse(
+            session.get("entry_submit_end_exclusive"),
+            field="entry_submit_end_exclusive",
+        )
+        exit_at = _parse(session.get("exit_submit_at"), field="exit_submit_at")
+        reconcile = _parse(session.get("reconcile_at"), field="reconcile_at")
+        if opened.date().isoformat() != session["trade_date"]:
+            raise SmokeError(f"calendar session {expected_index} date/open mismatch")
+        if (
+            start != opened - timedelta(minutes=10)
+            or end != opened - timedelta(minutes=5)
+            or closed - opened != timedelta(hours=6, minutes=30)
+            or exit_at != closed - timedelta(minutes=20)
+            or reconcile != closed + timedelta(minutes=5)
+        ):
+            raise SmokeError(f"calendar session {expected_index} timing changed")
+
+
+def _verify_retrospective_schema() -> None:
+    schema = _load_object(ARTIFACT_ROOT / "p0-retrospective-row.schema.json")
+    required = schema.get("required")
+    properties = schema.get("properties")
+    if type(required) is not list or set(required) != EXPECTED_RETROSPECTIVE_FIELDS:
+        raise SmokeError("retrospective required fields differ from §6 mapping")
+    if type(properties) is not dict or set(properties) != EXPECTED_RETROSPECTIVE_FIELDS:
+        raise SmokeError("retrospective properties differ from §6 mapping")
+    if schema.get("additionalProperties") is not False:
+        raise SmokeError("retrospective schema must reject undeclared fields")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only KR-B1 P0 preparation smoke")
+    parser.add_argument(
+        "--sealed-json",
+        type=Path,
+        required=True,
+        help="path to krb1-combined-canonical-2026-07-28.json",
+    )
+    args = parser.parse_args()
+
+    try:
+        manifest = _load_object(MANIFEST_PATH)
+        if manifest.get("sealed_canonical_sha256") != EXPECTED_SEALED_SHA256:
+            raise SmokeError("artifact manifest seal hash changed")
+        if manifest.get("cost_probe_state") != "NOT_EXECUTED":
+            raise SmokeError("cost probe must remain NOT_EXECUTED before P0")
+        if manifest.get("p0_state") != "NOT_STARTED":
+            raise SmokeError("preparation manifest must remain NOT_STARTED")
+        _verify_artifact_hashes(manifest)
+        _verify_seal_and_scaffold(args.sealed_json.expanduser())
+        _verify_calendar()
+        _verify_retrospective_schema()
+    except SmokeError as exc:
+        parser.exit(1, f"KR-B1 P0 PREP SMOKE FAIL: {exc}\n")
+
+    print(
+        json.dumps(
+            {
+                "calendar_first_session": EXPECTED_DATES[0],
+                "calendar_last_session": EXPECTED_DATES[-1],
+                "calendar_sessions": len(EXPECTED_DATES),
+                "canonical_sha256": EXPECTED_SEALED_SHA256,
+                "cost_probe_state": "NOT_EXECUTED",
+                "journal_initial_head": SEALED_INITIAL_HEAD,
+                "status": "PASS",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/services/test_krb1_p0_journal.py
+++ b/tests/services/test_krb1_p0_journal.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.krb1_p0_journal import (
+    GENESIS_HASH,
+    JournalError,
+    append_journal_row,
+    build_entry,
+    compute_row_hash,
+    create_journal,
+    verify_journal,
+)
+
+pytestmark = pytest.mark.unit
+
+_INITIAL_ROW = {
+    "next_stage": "P0_10_KRX_SESSIONS",
+    "p0_state": "NOT_STARTED",
+    "record_type": "SEAL_INITIALIZED",
+    "recorded_date": "2026-07-28",
+    "study_id": "KRB1-CSM60-H5-v1",
+}
+_INITIAL_ROW_HASH = "48335298149e92cdfbbb83f7f604b488074d33122f9c5ad15fe8d42b3925d8b8"
+_INITIAL_HEAD = "be117294febe0c8280949a37e35baf95246f527049484b2c20ee890591408229"
+
+
+def test_initial_row_reproduces_sealed_hashes() -> None:
+    entry = build_entry(
+        index=1,
+        row=_INITIAL_ROW,
+        previous_chain_hash=GENESIS_HASH,
+    )
+    assert compute_row_hash(_INITIAL_ROW) == _INITIAL_ROW_HASH
+    assert entry.row_hash == _INITIAL_ROW_HASH
+    assert entry.chain_hash == _INITIAL_HEAD
+
+
+def test_create_verify_and_append_without_rewriting_prefix(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    initial = create_journal(path, _INITIAL_ROW)
+    prefix = path.read_bytes()
+
+    appended = append_journal_row(
+        path,
+        {
+            "p0_state": "IN_PROGRESS",
+            "record_type": "P0_START_ANCHOR",
+            "study_id": "KRB1-CSM60-H5-v1",
+        },
+    )
+
+    assert initial.index == 1
+    assert appended.index == 2
+    assert path.read_bytes().startswith(prefix)
+    head = verify_journal(path)
+    assert head.row_count == 2
+    assert head.chain_hash == appended.chain_hash
+
+
+def test_create_refuses_to_replace_existing_journal(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    path.write_text("operator-owned", encoding="utf-8")
+    with pytest.raises(JournalError, match="cannot create new journal"):
+        create_journal(path, _INITIAL_ROW)
+    assert path.read_text(encoding="utf-8") == "operator-owned"
+
+
+def test_create_rejects_a_different_genesis_row(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    with pytest.raises(JournalError, match="does not match the sealed"):
+        create_journal(path, {"record_type": "OTHER"})
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("field", ["row_hash", "chain_hash"])
+def test_verify_rejects_hash_tampering(tmp_path: Path, field: str) -> None:
+    path = tmp_path / "journal.jsonl"
+    entry = create_journal(path, _INITIAL_ROW).as_dict()
+    entry[field] = "0" * 64
+    path.write_text(
+        json.dumps(
+            entry,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(JournalError, match=f"{field} mismatch"):
+        verify_journal(path)
+
+
+def test_verify_rejects_noncanonical_or_truncated_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    entry = build_entry(
+        index=1,
+        row=_INITIAL_ROW,
+        previous_chain_hash=GENESIS_HASH,
+    ).as_dict()
+    path.write_text(json.dumps(entry), encoding="utf-8")
+    with pytest.raises(JournalError, match="end with a newline"):
+        verify_journal(path)
+
+
+def test_append_rejects_nonfinite_values_without_touching_file(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    create_journal(path, _INITIAL_ROW)
+    before = path.read_bytes()
+    with pytest.raises(JournalError, match="not canonical-JSON encodable"):
+        append_journal_row(path, {"bad": float("nan")})
+    assert path.read_bytes() == before
+
+
+def test_append_requires_an_initialized_existing_journal(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.jsonl"
+    with pytest.raises(JournalError, match="cannot append journal"):
+        append_journal_row(missing, {"record_type": "P0_START_ANCHOR"})
+    assert not missing.exists()
+
+    empty = tmp_path / "empty.jsonl"
+    empty.touch()
+    with pytest.raises(JournalError, match="no sealed initial row"):
+        append_journal_row(empty, {"record_type": "P0_START_ANCHOR"})
+    assert empty.read_bytes() == b""


### PR DESCRIPTION
## Summary
- add a file-only append-only JSONL hash-chain journal scaffold that reproduces the sealed KR-B1 initial row hash and head
- freeze the 10 P0 XKRX sessions from 2026-07-30 through 2026-08-12, including entry window/open/exit/close/reconcile timestamps
- add a PLAN_ONLY cost probe runbook with the required P0 -> cost contract -> canonical hash -> dry-count order
- add a read-only smoke that validates the sealed canonical hash, frozen artifact hashes, calendar, journal chain, and retrospective field set

## ROB-1115 / PR #1700 reuse decision
PR #1700 was reviewed at head 54876480be03eb7996717e6949f9207695bc44d7. Its research.strategy_learning_events table is append-only learning memory, but it does not provide the KR-B1 CSV/JSON row hash-chain or the sealed retrospective fields. P0-4 explicitly does not require a DB ledger. This PR therefore does not duplicate or misuse that table. The ROB-846 typed-AST hash helper used by #1700 is also byte-incompatible with the sealed plain-JSON initial row, so this scaffold implements the sealed JSON serialization directly and locks it with the known initial row/hash/head fixture.

## Frozen calendar
- sessions: 2026-07-30, 07-31, 08-03, 08-04, 08-05, 08-06, 08-07, 08-10, 08-11, 08-12
- all sessions: 09:00-15:30 Asia/Seoul; no half-days in the window
- excluded in-window dates: weekends 08-01, 08-02, 08-08, 08-09
- calendar artifact SHA-256: b8933e4b02ed29b5e40b96a77fa0091f70c25394cfc854657064cda99eca84da
- preparation manifest SHA-256: 9597d8bf2852547d68d01804bc7b331cc4b4482ec5b6b6db73b27fae50382878

## Closed safety boundary
- cost probe state remains NOT_EXECUTED
- no real order, broker mutation, production DB write, deployment, or migration
- runtime journal is created under gitignored var/research/krb1 and only appended after full chain verification

## Canonical ambiguities surfaced without adding policy
- the §6 hash target is unnamed
- tick-bp denominator/rounding and delay unit are unspecified
- the reducer from measured costs to C_stress_cap is unspecified
- tick-band and upper/lower-limit rounding details are unspecified
- the next P0 start anchor/manifest payload fields are unspecified

These remain fail-closed in the runbook and are not invented here.

## Verification
- make lint
- uv run pytest tests/services/test_krb1_p0_journal.py -q (9 passed)
- uv run python scripts/krb1_p0_smoke.py --sealed-json ~/work/herdr-inbox/krb1-combined-canonical-2026-07-28.json (PASS)
- runtime journal init + verify smoke (PASS)

Do not merge until reviewed. Cost probe was not executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to initialize, verify, and append to a protected KR-B1 P0 research journal.
  * Added validation for journal integrity, canonical records, and tamper detection.
  * Added a read-only smoke check for preparation artifacts and frozen session schedules.

* **Documentation**
  * Documented P0 preparation procedures, evidence requirements, calendar controls, and cost-probe boundaries.
  * Added a retrospective record schema and preparation manifest.

* **Tests**
  * Added coverage for journal creation, verification, appending, and invalid or tampered data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->