### PR TITLE
feat(research): add KR-B1c exact-rational reducer reference

### DIFF
--- a/docs/research/krb1c-reducer-reference-implementation.md
+++ b/docs/research/krb1c-reducer-reference-implementation.md
@@ -1,0 +1,195 @@
+# KR-B1c §7.7 reducer 참조 구현과 독립 재현
+
+상태: `REFERENCE_IMPLEMENTATION PASS / P0-2 COMPLETION NOT CREATED`
+
+이 구현은 부모 canonical
+`d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1`과
+자식 amendment
+`d5da5edd6b49fb759b781c13f627e21a84667ced2be7cf03624a40bb813be389`를
+수정하지 않는다. 아래 수치 실행은 `tests/fixtures/krb1_c_stress/`의 명시적
+테스트 fixture를 사용한 참조 재현이며 실제 P0-1/P0-2 completion으로 주장하지 않는다.
+
+## 구현 위치
+
+- `research/krb1_c_stress_reducer/model.py`: P0-2 비용 입력, P0-1 tick-table
+  transport, 기간 coverage, authority overlap/gap, component uniqueness의 fail-closed
+  검증
+- `research/krb1_c_stress_reducer/reducer.py`: §4.5 `E_m` 반복, §4.6~4.8
+  exit witness, §5 나눗셈형 비용률, §6 시장 결합·bp ceiling·target 자기검산,
+  게시 artifact 3종
+- `scripts/krb1_c_stress_reducer.py`: 참조 구현 CLI
+- `scripts/krb1_c_stress_independent_verify.py`: 참조 package를 import하지 않는
+  독립 재현기
+- `tests/research/test_krb1_c_stress_reducer.py`: 계약, 경계, 결정성, 독립 재현,
+  float 금지 테스트
+
+참조 구현은 비용 JSON에 조문이 열거하지 않은 키가 있으면 거부한다. 따라서
+`mock_display_rate_e12` 같은 mock 수치 필드는 reducer numeric 입력에 들어갈 수 없다.
+현재 fixture의 실거래 commission은 매수·매도 각각 `rate_e12=150000000`이며,
+매도세는 KOSPI
+`KOSPI_SECURITIES_TRANSACTION_TAX=500000000` +
+`KOSPI_RURAL_SPECIAL_TAX=1500000000`, KOSDAQ
+`KOSDAQ_SECURITIES_TRANSACTION_TAX=2000000000`으로 기록한다.
+
+## exact rational 보장
+
+참조 구현의 모든 비율·multiplier·`c_m(P)`·cap·target 곱은
+`fractions.Fraction` 또는 정수다. JSON parser는 숫자 token에 소수점이 있으면
+즉시 거부한다. 독립 재현기는 `Fraction`도 참조 구현도 사용하지 않고
+`(numerator, denominator)` 정수쌍을 `gcd`로 기약화하며 비교는 교차곱으로 한다.
+
+테스트는 다음을 함께 확인한다.
+
+- 양쪽 source AST에 float literal, `float(...)`, `Decimal`/NumPy import가 없음
+- 참조 core 실행 중 `builtins.float`를 예외 함수로 바꿔도 전수 실행 성공
+- 모든 8,002개 row의 fraction·exit witness·target을 독립 정수 구현이 일치시킴
+
+`c_stress_candidates.csv`의 17개 필드는 조문이 필드 이름을 열거하지 않은 부분에
+대한 게시 schema다.
+
+1. `market`
+2. `entry_price`
+3. `entry_tick`
+4. `rho_entry_num`
+5. `rho_entry_den`
+6. `exit_witness_price`
+7. `exit_witness_tick`
+8. `rho_exit_num`
+9. `rho_exit_den`
+10. `entry_multiplier_num`
+11. `entry_multiplier_den`
+12. `exit_multiplier_num`
+13. `exit_multiplier_den`
+14. `c_num`
+15. `c_den`
+16. `target_price`
+17. `target_check_passed`
+
+## 사용한 호가표와 universe 경계
+
+테스트 fixture는 KOSPI·KOSDAQ의 2023+ **표준 주권** 표만 사용한다.
+
+| 가격 구간 | tick |
+|---|---:|
+| `[0, 2,000)` | 1 |
+| `[2,000, 5,000)` | 5 |
+| `[5,000, 20,000)` | 10 |
+| `[20,000, 50,000)` | 50 |
+| `[50,000, 200,000)` | 100 |
+| `[200,000, 500,000)` | 500 |
+| `[500,000, ∞)` | 1,000 |
+
+이 표에서는 `E_m`이 시장당 4,001개다. “약 2,400개”는 봉인 수학 검증 보고서가
+구 표의 흔적으로 판정한 값이며 구현 상수로 사용하지 않았다.
+
+현재 `kr_symbol_universe`에는 `security_type`과 `is_common_share`가 있지만 nullable이고,
+부모 §2.3의 유니버스 문장 자체는 ETF·ETN·ELW를 명시적으로 제외하지 않는다.
+따라서 실제 P0-1이 특수 상품을 포함하면서 표준 주권 표 하나만 `COMPLETE`라고
+선언하면 안 된다. 입력 transport의 `symbol_table_mapping_status`가 `COMPLETE`가
+아니면 reducer는 실행을 거부한다. 실제 completion 전에는 다음 중 봉인된 P0-1
+증거가 하나를 확정해야 한다.
+
+- 허용 universe가 표준 주권만임을 증명하고 표준 주권 표를 사용한다.
+- ETF·ETN·ELW를 포함한다면 각 symbol의 별도표 매핑을 완결한다.
+
+§6.2.1의 계산 차원이 시장 `m` 하나뿐이므로 한 시장 안에서 서로 다른 표를 혼합할
+때의 결합 규칙은 조문에 없다. 이 경우 구현이 임의로 상품 차원을 추가하지 않고
+P0-1 FAIL로 닫는다.
+
+`krb1.reference.tick_tables.v1`은 봉인 조문에 없던 P0-1 파일 형식을 숫자 정책으로
+가장하지 않기 위해 `reference` namespace로 둔 로컬 transport다. 호가표 자체와
+symbol mapping의 권위는 이 파일 이름이 아니라 sealed P0-1 입력과 그 SHA에 있다.
+
+## 독립 재현 출력
+
+2026-07-28 fixture 실행 결과:
+
+```text
+arithmetic=fractions.Fraction+integer
+float_used=false
+KOSPI candidates=4001 first=5000 last=400000 first_after_cap=400500
+KOSDAQ candidates=4001 first=5000 last=400000 first_after_cap=400500
+C_raw=146/19907
+witness=KOSPI/P=20000/Q=20000
+C_stress_cap_bp=74
+C_stress_cap_decimal=0.0074
+all_target_checks_passed=true
+```
+
+독립 재현:
+
+```text
+arithmetic=integer cross-products+gcd
+candidate_rows_compared=8002
+fraction_rows_matched=8002
+witness_rows_matched=8002
+target_rows_matched=8002
+status=PASS
+```
+
+경계 실행은 두 시장 모두 다음을 확인했다.
+
+```text
+lower=2000   below/at/above tick=1/5/5
+lower=5000   below/at/above tick=5/10/10
+lower=20000  below/at/above tick=10/50/50
+lower=50000  below/at/above tick=50/100/100
+lower=200000 below/at/above tick=100/500/500
+lower=500000 below/at/above tick=500/1000/1000
+open_ended_probe=1734567 tick=1000
+```
+
+동일 입력을 두 번 실행한 byte SHA-256:
+
+```text
+p0_2_cost_inputs.normalized.json
+7ec5b2bb8e5b50c4c617a35e516b9a10780a757881b79a4edd9bade2268b1e73
+
+c_stress_candidates.csv
+5b067554dda572ed5352432ec6bfafe62bbd7cd1044a5dbf120ed07dd0e18de7
+
+c_stress_reducer_result.json
+f71ffa18d844e36b602198cff76ceb8afed68fa1a6fe5a6562c4a7fb1c539223
+
+independent verification JSON
+b1025f8a35a013354fea4fd51cfc17d321d0d316b4edce2fe7e20250a973aabd
+```
+
+각 파일은 1회차와 2회차가 `cmp` 및 SHA-256 모두 일치했다.
+
+## 실행 명령
+
+```bash
+uv run python scripts/krb1_c_stress_reducer.py \
+  --cost-input tests/fixtures/krb1_c_stress/p0_2_real_tariff_cost_inputs.json \
+  --tick-input tests/fixtures/krb1_c_stress/p0_1_standard_stock_tick_tables.json \
+  --parent-canonical ~/work/herdr-inbox/krb1-combined-canonical-2026-07-28.json \
+  --amendment-canonical ~/work/herdr-inbox/krb1c-amendment-canonical-2026-07-28.json \
+  --output-dir /tmp/krb1c-output \
+  --repo-root "$PWD"
+
+uv run python scripts/krb1_c_stress_independent_verify.py \
+  --cost-input tests/fixtures/krb1_c_stress/p0_2_real_tariff_cost_inputs.json \
+  --tick-input tests/fixtures/krb1_c_stress/p0_1_standard_stock_tick_tables.json \
+  --candidates /tmp/krb1c-output/c_stress_candidates.csv \
+  --result /tmp/krb1c-output/c_stress_reducer_result.json \
+  --repo-root "$PWD" \
+  --verification-output /tmp/krb1c-output/independent-verification.json
+```
+
+## 조문에서 닫히지 않은 지점
+
+- 게시 CSV는 “기약분수 필드 17종”이라고만 하고 17개 필드명을 열거하지 않는다.
+  위 schema는 수치 계산을 바꾸지 않는 감사용 표현으로 명시했다.
+- P0-1 tick 함수의 파일 schema와 SHA 결합 형식은 정하지 않았다. 구현은 별도
+  reference transport와 normalized SHA를 게시한다.
+- 실제 universe에 서로 다른 상품 호가표가 섞일 때 reducer 결합 차원이 없다.
+  임의 확장하지 않고 mapping 불완전으로 fail-closed 한다.
+- 독립 재현 PASS 뒤 만드는 `P0-2 completion hash`의 preimage와 직렬화 형식이
+  조문에 없다. 또한 저장소에 실제 sealed P0-1/P0-2 입력이 아직 없다. 따라서 이
+  fixture 실행은 completion hash를 만들지 않으며 result도
+  `AWAITING_INDEPENDENT_REPRODUCTION`, 독립 보고도
+  `p0_2_completion_hash_created=false`로 남긴다.
+
+실제 P0 입력이 봉인되고 위 모호성이 권위 문서로 닫히기 전에는 이 참조 PASS를
+P0-2 completion으로 승격하지 않는다.

--- a/research/krb1_c_stress_reducer/__init__.py
+++ b/research/krb1_c_stress_reducer/__init__.py
@@ -1,0 +1,25 @@
+"""KR-B1c exact-rational C_stress_cap reference reducer."""
+
+from research.krb1_c_stress_reducer.model import (
+    ContractError,
+    CostInputs,
+    TickTables,
+    load_cost_inputs,
+    load_tick_tables,
+)
+from research.krb1_c_stress_reducer.reducer import (
+    ReducerRun,
+    run_reducer,
+    write_artifacts,
+)
+
+__all__ = [
+    "ContractError",
+    "CostInputs",
+    "ReducerRun",
+    "TickTables",
+    "load_cost_inputs",
+    "load_tick_tables",
+    "run_reducer",
+    "write_artifacts",
+]

--- a/research/krb1_c_stress_reducer/cli.py
+++ b/research/krb1_c_stress_reducer/cli.py
@@ -1,0 +1,72 @@
+"""CLI for the KR-B1c C_stress_cap reference reducer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from research.krb1_c_stress_reducer.model import (
+    ContractError,
+    load_cost_inputs,
+    load_tick_tables,
+)
+from research.krb1_c_stress_reducer.reducer import run_reducer, write_artifacts
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the sealed KR-B1c exact-rational reference reducer."
+    )
+    parser.add_argument("--cost-input", type=Path, required=True)
+    parser.add_argument("--tick-input", type=Path, required=True)
+    parser.add_argument("--parent-canonical", type=Path, required=True)
+    parser.add_argument("--amendment-canonical", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        cost_inputs = load_cost_inputs(args.cost_input)
+        tick_tables = load_tick_tables(args.tick_input)
+        run = run_reducer(cost_inputs, tick_tables)
+        result = write_artifacts(
+            run=run,
+            cost_inputs=cost_inputs,
+            tick_tables=tick_tables,
+            output_dir=args.output_dir,
+            repo_root=args.repo_root.resolve(),
+            parent_canonical_path=args.parent_canonical,
+            amendment_canonical_path=args.amendment_canonical,
+        )
+    except ContractError as exc:
+        print(f"KR-B1c reducer FAIL: {exc}")
+        return 1
+    summary = {
+        "status": "PASS",
+        "arithmetic": result["arithmetic"],
+        "float_used": result["float_used"],
+        "candidate_count_total": result["candidate_count_total"],
+        "market_summaries": result["market_summaries"],
+        "c_raw": f"{result['c_raw_num']}/{result['c_raw_den']}",
+        "witness_market": result["witness_market"],
+        "witness_entry_price": result["witness_entry_price"],
+        "witness_exit_price": result["witness_exit_price"],
+        "c_stress_cap_bp": result["c_stress_cap_bp"],
+        "c_stress_cap_decimal": result["c_stress_cap_decimal"],
+        "all_target_checks_passed": result["all_target_checks_passed"],
+        "p0_2_completion_state": result["p0_2_completion_state"],
+    }
+    print(
+        json.dumps(
+            summary,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    )
+    return 0

--- a/research/krb1_c_stress_reducer/model.py
+++ b/research/krb1_c_stress_reducer/model.py
@@ -1,0 +1,512 @@
+"""Fail-closed input parsing for the sealed KR-B1c reducer contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+RATE_SCALE = 1_000_000_000_000
+PARENT_CANONICAL_SHA256 = (
+    "d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1"
+)
+AMENDMENT_CANONICAL_SHA256 = (
+    "d5da5edd6b49fb759b781c13f627e21a84667ced2be7cf03624a40bb813be389"
+)
+MARKETS = ("KOSPI", "KOSDAQ")
+HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+KST = timezone(timedelta(hours=9))
+
+
+class ContractError(ValueError):
+    """The sealed reducer contract cannot be satisfied."""
+
+
+@dataclass(frozen=True)
+class CostRecord:
+    market: str
+    broker_id: str
+    account_product_id: str
+    order_channel_id: str
+    cost_basis: str
+    rate_upper_bound_scope: str
+    effective_from: date
+    effective_to: date | None
+    buy_commission_rate_e12: int
+    sell_commission_rate_e12: int
+    sell_tax_components: tuple[tuple[str, int], ...]
+    source_locator: str
+    source_snapshot_sha256: str
+    probe_reconciliation_status: str
+    mock_cost_relation: str
+
+    @property
+    def sell_tax_rate_e12(self) -> int:
+        return sum(rate for _, rate in self.sell_tax_components)
+
+
+@dataclass(frozen=True)
+class MarketRates:
+    buy_commission_rate_e12: int
+    sell_commission_rate_e12: int
+    sell_tax_rate_e12: int
+
+    @property
+    def buy_commission(self) -> Fraction:
+        return Fraction(self.buy_commission_rate_e12, RATE_SCALE)
+
+    @property
+    def sell_commission(self) -> Fraction:
+        return Fraction(self.sell_commission_rate_e12, RATE_SCALE)
+
+    @property
+    def sell_tax(self) -> Fraction:
+        return Fraction(self.sell_tax_rate_e12, RATE_SCALE)
+
+
+@dataclass(frozen=True)
+class CostInputs:
+    raw: dict[str, Any]
+    completed_at_kst: datetime
+    coverage_start: date
+    coverage_end: date
+    records: tuple[CostRecord, ...]
+    rates: dict[str, MarketRates]
+
+
+@dataclass(frozen=True)
+class TickBand:
+    lower: int
+    upper_exclusive: int | None
+    tick: int
+
+
+@dataclass(frozen=True)
+class MarketTickTable:
+    market: str
+    table_id: str
+    instrument_scope: str
+    source_locator: str
+    source_snapshot_sha256: str
+    bands: tuple[TickBand, ...]
+
+    def tick(self, price: int) -> int:
+        if isinstance(price, bool) or not isinstance(price, int) or price < 0:
+            raise ContractError("tick lookup price must be a nonnegative integer")
+        for band in self.bands:
+            if price >= band.lower and (
+                band.upper_exclusive is None or price < band.upper_exclusive
+            ):
+                return band.tick
+        raise ContractError(f"{self.market} tick table has no band for {price}")
+
+    def tick_ceil(self, value: Fraction) -> int:
+        if not isinstance(value, Fraction):
+            raise ContractError("tick_ceil requires fractions.Fraction")
+        if value < 0:
+            raise ContractError("tick_ceil value must be nonnegative")
+        integer_ceiling = (value.numerator + value.denominator - 1) // value.denominator
+        for band in self.bands:
+            candidate = max(integer_ceiling, band.lower)
+            aligned = ((candidate + band.tick - 1) // band.tick) * band.tick
+            if band.upper_exclusive is None or aligned < band.upper_exclusive:
+                return aligned
+        raise ContractError(f"{self.market} tick table is not open-ended")
+
+
+@dataclass(frozen=True)
+class TickTables:
+    raw: dict[str, Any]
+    markets: dict[str, MarketTickTable]
+
+
+def _reject_float(_: str) -> None:
+    raise ContractError("JSON floating-point numbers are prohibited")
+
+
+def load_json_exact(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_float=_reject_float,
+            parse_constant=_reject_float,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ContractError(f"cannot read exact JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ContractError(f"{path} must contain a JSON object")
+    return value
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _require_exact_keys(
+    value: dict[str, Any], required: set[str], context: str
+) -> None:
+    actual = set(value)
+    if actual != required:
+        missing = sorted(required - actual)
+        extra = sorted(actual - required)
+        raise ContractError(
+            f"{context} keys mismatch: missing={missing}, extra={extra}"
+        )
+
+
+def _require_nonempty_string(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ContractError(f"{context} must be a nonempty string")
+    return value
+
+
+def _require_hash(value: object, context: str) -> str:
+    text = _require_nonempty_string(value, context)
+    if HEX_64.fullmatch(text) is None:
+        raise ContractError(f"{context} must be 64 lowercase hexadecimal characters")
+    return text
+
+
+def _require_rate(value: object, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ContractError(f"{context} must be a nonnegative integer rate_e12")
+    return value
+
+
+def _parse_date(value: object, context: str) -> date:
+    text = _require_nonempty_string(value, context)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as exc:
+        raise ContractError(f"{context} must be YYYY-MM-DD") from exc
+    if parsed.isoformat() != text:
+        raise ContractError(f"{context} must use canonical YYYY-MM-DD")
+    return parsed
+
+
+def _parse_completed_at(value: object) -> datetime:
+    text = _require_nonempty_string(value, "p0_2_completed_at_kst")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ContractError("p0_2_completed_at_kst must be ISO-8601") from exc
+    if parsed.utcoffset() != KST.utcoffset(None):
+        raise ContractError("p0_2_completed_at_kst must have the +09:00 KST offset")
+    return parsed
+
+
+def _parse_cost_record(raw: object, index: int) -> CostRecord:
+    context = f"market_cost_records[{index}]"
+    if not isinstance(raw, dict):
+        raise ContractError(f"{context} must be an object")
+    required = {
+        "market",
+        "broker_id",
+        "account_product_id",
+        "order_channel_id",
+        "cost_basis",
+        "rate_upper_bound_scope",
+        "effective_from",
+        "effective_to",
+        "buy_commission_rate_e12",
+        "sell_commission_rate_e12",
+        "sell_tax_components",
+        "source_locator",
+        "source_snapshot_sha256",
+        "probe_reconciliation_status",
+        "mock_cost_relation",
+    }
+    _require_exact_keys(raw, required, context)
+    market = _require_nonempty_string(raw["market"], f"{context}.market")
+    if market not in MARKETS:
+        raise ContractError(f"{context}.market must be KOSPI or KOSDAQ")
+    if raw["cost_basis"] != "REAL_TRADING_TARIFF":
+        raise ContractError(f"{context}.cost_basis must be REAL_TRADING_TARIFF")
+    if raw["probe_reconciliation_status"] != "PASS":
+        raise ContractError(f"{context}.probe_reconciliation_status must be PASS")
+    if raw["mock_cost_relation"] not in {"EQUAL", "DIFFERENT"}:
+        raise ContractError(f"{context}.mock_cost_relation is invalid")
+    if raw["broker_id"] != "kiwoom":
+        raise ContractError(f"{context}.broker_id must be kiwoom")
+    if raw["account_product_id"] != "KIWOOM_DOMESTIC_CASH_STOCK":
+        raise ContractError(
+            f"{context}.account_product_id does not match the amendment"
+        )
+    if raw["order_channel_id"] != "KIWOOM_OPENAPI_KRX":
+        raise ContractError(f"{context}.order_channel_id does not match the amendment")
+
+    component_values = raw["sell_tax_components"]
+    if not isinstance(component_values, list) or not component_values:
+        raise ContractError(f"{context}.sell_tax_components must be a nonempty list")
+    components: list[tuple[str, int]] = []
+    component_codes: set[str] = set()
+    for component_index, component in enumerate(component_values):
+        component_context = f"{context}.sell_tax_components[{component_index}]"
+        if not isinstance(component, dict):
+            raise ContractError(f"{component_context} must be an object")
+        _require_exact_keys(
+            component, {"component_code", "rate_e12"}, component_context
+        )
+        code = _require_nonempty_string(
+            component["component_code"], f"{component_context}.component_code"
+        )
+        if code in component_codes:
+            raise ContractError(f"{context} has duplicate tax component {code}")
+        component_codes.add(code)
+        components.append(
+            (
+                code,
+                _require_rate(component["rate_e12"], f"{component_context}.rate_e12"),
+            )
+        )
+
+    effective_to_raw = raw["effective_to"]
+    effective_to = (
+        None
+        if effective_to_raw is None
+        else _parse_date(effective_to_raw, f"{context}.effective_to")
+    )
+    effective_from = _parse_date(raw["effective_from"], f"{context}.effective_from")
+    if effective_to is not None and effective_to <= effective_from:
+        raise ContractError(f"{context} effective interval must be positive")
+
+    return CostRecord(
+        market=market,
+        broker_id="kiwoom",
+        account_product_id="KIWOOM_DOMESTIC_CASH_STOCK",
+        order_channel_id="KIWOOM_OPENAPI_KRX",
+        cost_basis="REAL_TRADING_TARIFF",
+        rate_upper_bound_scope=_require_nonempty_string(
+            raw["rate_upper_bound_scope"], f"{context}.rate_upper_bound_scope"
+        ),
+        effective_from=effective_from,
+        effective_to=effective_to,
+        buy_commission_rate_e12=_require_rate(
+            raw["buy_commission_rate_e12"],
+            f"{context}.buy_commission_rate_e12",
+        ),
+        sell_commission_rate_e12=_require_rate(
+            raw["sell_commission_rate_e12"],
+            f"{context}.sell_commission_rate_e12",
+        ),
+        sell_tax_components=tuple(components),
+        source_locator=_require_nonempty_string(
+            raw["source_locator"], f"{context}.source_locator"
+        ),
+        source_snapshot_sha256=_require_hash(
+            raw["source_snapshot_sha256"],
+            f"{context}.source_snapshot_sha256",
+        ),
+        probe_reconciliation_status="PASS",
+        mock_cost_relation=raw["mock_cost_relation"],
+    )
+
+
+def _validate_record_coverage(
+    market: str,
+    records: list[CostRecord],
+    coverage_start: date,
+    coverage_end: date,
+) -> None:
+    ordered = sorted(records, key=lambda item: item.effective_from)
+    if not ordered:
+        raise ContractError(f"{market} has no cost record")
+    for previous, current in zip(ordered, ordered[1:], strict=False):
+        if previous.effective_to is None:
+            raise ContractError(
+                f"{market} only the final current record may be open-ended"
+            )
+        if previous.effective_to < current.effective_from:
+            raise ContractError(f"{market} authoritative cost records have a date gap")
+        if previous.effective_to > current.effective_from:
+            raise ContractError(f"{market} authoritative cost records overlap")
+    if ordered[-1].effective_to is not None:
+        raise ContractError(f"{market} current cost record must be open-ended")
+    if ordered[0].effective_from > coverage_start:
+        raise ContractError(f"{market} records do not cover coverage_start_session")
+    covering_end = next(
+        (
+            record
+            for record in ordered
+            if record.effective_from <= coverage_end
+            and (record.effective_to is None or coverage_end < record.effective_to)
+        ),
+        None,
+    )
+    if covering_end is None:
+        raise ContractError(f"{market} records do not cover coverage_end_session")
+
+
+def load_cost_inputs(path: Path) -> CostInputs:
+    raw = load_json_exact(path)
+    required = {
+        "schema_version",
+        "p0_2_completed_at_kst",
+        "parent_canonical_sha256",
+        "coverage_start_session",
+        "coverage_end_session",
+        "market_cost_records",
+    }
+    _require_exact_keys(raw, required, "P0-2 cost input")
+    if raw["schema_version"] != "krb1.p0_2_cost_inputs.v1":
+        raise ContractError("unexpected P0-2 schema_version")
+    parent_hash = _require_hash(
+        raw["parent_canonical_sha256"], "parent_canonical_sha256"
+    )
+    if parent_hash != PARENT_CANONICAL_SHA256:
+        raise ContractError("P0-2 parent_canonical_sha256 is not the sealed parent")
+    completed_at = _parse_completed_at(raw["p0_2_completed_at_kst"])
+    coverage_start = _parse_date(
+        raw["coverage_start_session"], "coverage_start_session"
+    )
+    coverage_end = _parse_date(raw["coverage_end_session"], "coverage_end_session")
+    if coverage_end < coverage_start:
+        raise ContractError("coverage_end_session precedes coverage_start_session")
+    raw_records = raw["market_cost_records"]
+    if not isinstance(raw_records, list):
+        raise ContractError("market_cost_records must be a list")
+    records = tuple(
+        _parse_cost_record(raw_record, index)
+        for index, raw_record in enumerate(raw_records)
+    )
+
+    grouped: dict[str, list[CostRecord]] = {market: [] for market in MARKETS}
+    for record in records:
+        grouped[record.market].append(record)
+    rates: dict[str, MarketRates] = {}
+    for market in MARKETS:
+        _validate_record_coverage(market, grouped[market], coverage_start, coverage_end)
+        rates[market] = MarketRates(
+            buy_commission_rate_e12=max(
+                record.buy_commission_rate_e12 for record in grouped[market]
+            ),
+            sell_commission_rate_e12=max(
+                record.sell_commission_rate_e12 for record in grouped[market]
+            ),
+            sell_tax_rate_e12=max(
+                record.sell_tax_rate_e12 for record in grouped[market]
+            ),
+        )
+    return CostInputs(
+        raw=raw,
+        completed_at_kst=completed_at,
+        coverage_start=coverage_start,
+        coverage_end=coverage_end,
+        records=records,
+        rates=rates,
+    )
+
+
+def _parse_tick_table(market: str, raw: object) -> MarketTickTable:
+    context = f"markets.{market}"
+    if not isinstance(raw, dict):
+        raise ContractError(f"{context} must be an object")
+    required = {
+        "table_id",
+        "instrument_scope",
+        "source_locator",
+        "source_snapshot_sha256",
+        "bands",
+    }
+    _require_exact_keys(raw, required, context)
+    raw_bands = raw["bands"]
+    if not isinstance(raw_bands, list) or not raw_bands:
+        raise ContractError(f"{context}.bands must be a nonempty list")
+    bands: list[TickBand] = []
+    for index, raw_band in enumerate(raw_bands):
+        band_context = f"{context}.bands[{index}]"
+        if not isinstance(raw_band, dict):
+            raise ContractError(f"{band_context} must be an object")
+        _require_exact_keys(
+            raw_band, {"lower", "upper_exclusive", "tick"}, band_context
+        )
+        lower = raw_band["lower"]
+        upper = raw_band["upper_exclusive"]
+        tick = raw_band["tick"]
+        if isinstance(lower, bool) or not isinstance(lower, int) or lower < 0:
+            raise ContractError(f"{band_context}.lower must be nonnegative integer")
+        if upper is not None and (
+            isinstance(upper, bool) or not isinstance(upper, int) or upper <= lower
+        ):
+            raise ContractError(
+                f"{band_context}.upper_exclusive must exceed lower or be null"
+            )
+        if isinstance(tick, bool) or not isinstance(tick, int) or tick <= 0:
+            raise ContractError(f"{band_context}.tick must be positive integer")
+        bands.append(TickBand(lower=lower, upper_exclusive=upper, tick=tick))
+    if bands[0].lower != 0:
+        raise ContractError(f"{context}.bands must start at zero")
+    for previous, current in zip(bands, bands[1:], strict=False):
+        if previous.upper_exclusive != current.lower:
+            raise ContractError(f"{context}.bands must have no gap or overlap")
+    if bands[-1].upper_exclusive is not None:
+        raise ContractError(f"{context}.bands must end with an open-ended band")
+    if any(band.upper_exclusive is None for band in bands[:-1]):
+        raise ContractError(f"{context} only the final band may be open-ended")
+    table = MarketTickTable(
+        market=market,
+        table_id=_require_nonempty_string(raw["table_id"], f"{context}.table_id"),
+        instrument_scope=_require_nonempty_string(
+            raw["instrument_scope"], f"{context}.instrument_scope"
+        ),
+        source_locator=_require_nonempty_string(
+            raw["source_locator"], f"{context}.source_locator"
+        ),
+        source_snapshot_sha256=_require_hash(
+            raw["source_snapshot_sha256"],
+            f"{context}.source_snapshot_sha256",
+        ),
+        bands=tuple(bands),
+    )
+    first = table.tick_ceil(Fraction(5_000))
+    after_cap = table.tick_ceil(Fraction(400_001))
+    if first < 5_000 or after_cap <= 400_000:
+        raise ContractError(f"{context} tick_ceil boundary checks failed")
+    return table
+
+
+def load_tick_tables(path: Path) -> TickTables:
+    raw = load_json_exact(path)
+    required = {
+        "schema_version",
+        "parent_canonical_sha256",
+        "symbol_table_mapping_status",
+        "markets",
+    }
+    _require_exact_keys(raw, required, "P0-1 tick input")
+    if raw["schema_version"] != "krb1.reference.tick_tables.v1":
+        raise ContractError("unexpected reference tick-table schema_version")
+    if raw["parent_canonical_sha256"] != PARENT_CANONICAL_SHA256:
+        raise ContractError("tick table input is not bound to the sealed parent")
+    if raw["symbol_table_mapping_status"] != "COMPLETE":
+        raise ContractError("P0-1 symbol-to-table mapping is not COMPLETE")
+    raw_markets = raw["markets"]
+    if not isinstance(raw_markets, dict) or set(raw_markets) != set(MARKETS):
+        raise ContractError("tick table input must contain exactly KOSPI and KOSDAQ")
+    markets = {
+        market: _parse_tick_table(market, raw_markets[market]) for market in MARKETS
+    }
+    return TickTables(raw=raw, markets=markets)

--- a/research/krb1_c_stress_reducer/reducer.py
+++ b/research/krb1_c_stress_reducer/reducer.py
@@ -1,0 +1,381 @@
+"""Sealed §6.2.1 exact-rational exhaustive reference implementation."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+from dataclasses import dataclass, replace
+from fractions import Fraction
+from pathlib import Path
+
+from research.krb1_c_stress_reducer.model import (
+    AMENDMENT_CANONICAL_SHA256,
+    MARKETS,
+    PARENT_CANONICAL_SHA256,
+    ContractError,
+    CostInputs,
+    MarketRates,
+    MarketTickTable,
+    TickTables,
+    canonical_json_bytes,
+    sha256_bytes,
+    sha256_file,
+)
+
+MIN_PRICE = 5_000
+MAX_PRICE = 400_000
+BP_SCALE = 10_000
+REDUCER_SPEC_ID = "KRB1C-CSTRESS-REDUCER-v1"
+CANDIDATE_FIELDS = (
+    "market",
+    "entry_price",
+    "entry_tick",
+    "rho_entry_num",
+    "rho_entry_den",
+    "exit_witness_price",
+    "exit_witness_tick",
+    "rho_exit_num",
+    "rho_exit_den",
+    "entry_multiplier_num",
+    "entry_multiplier_den",
+    "exit_multiplier_num",
+    "exit_multiplier_den",
+    "c_num",
+    "c_den",
+    "target_price",
+    "target_check_passed",
+)
+SOURCE_RELATIVE_PATHS = (
+    "research/krb1_c_stress_reducer/__init__.py",
+    "research/krb1_c_stress_reducer/model.py",
+    "research/krb1_c_stress_reducer/reducer.py",
+    "research/krb1_c_stress_reducer/cli.py",
+    "scripts/krb1_c_stress_reducer.py",
+)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    market: str
+    entry_price: int
+    entry_tick: int
+    rho_entry: Fraction
+    exit_witness_price: int
+    exit_witness_tick: int
+    rho_exit: Fraction
+    entry_multiplier: Fraction
+    exit_multiplier: Fraction
+    cost_rate: Fraction
+    target_price: int = 0
+    target_check_passed: bool = False
+
+    def csv_row(self) -> dict[str, str | int]:
+        return {
+            "market": self.market,
+            "entry_price": self.entry_price,
+            "entry_tick": self.entry_tick,
+            "rho_entry_num": self.rho_entry.numerator,
+            "rho_entry_den": self.rho_entry.denominator,
+            "exit_witness_price": self.exit_witness_price,
+            "exit_witness_tick": self.exit_witness_tick,
+            "rho_exit_num": self.rho_exit.numerator,
+            "rho_exit_den": self.rho_exit.denominator,
+            "entry_multiplier_num": self.entry_multiplier.numerator,
+            "entry_multiplier_den": self.entry_multiplier.denominator,
+            "exit_multiplier_num": self.exit_multiplier.numerator,
+            "exit_multiplier_den": self.exit_multiplier.denominator,
+            "c_num": self.cost_rate.numerator,
+            "c_den": self.cost_rate.denominator,
+            "target_price": self.target_price,
+            "target_check_passed": ("true" if self.target_check_passed else "false"),
+        }
+
+
+@dataclass(frozen=True)
+class MarketSummary:
+    market: str
+    candidate_count: int
+    first_price: int
+    last_price: int
+    first_price_after_cap: int
+    raw_cost_rate: Fraction
+    witness_entry_price: int
+    witness_exit_price: int
+
+
+@dataclass(frozen=True)
+class ReducerRun:
+    candidates: tuple[Candidate, ...]
+    market_summaries: dict[str, MarketSummary]
+    raw_cost_rate: Fraction
+    witness_market: str
+    witness_entry_price: int
+    witness_exit_price: int
+    cap_bp: int
+    cap: Fraction
+
+
+def enumerate_valid_prices(table: MarketTickTable) -> tuple[tuple[int, ...], int]:
+    prices: list[int] = []
+    price = table.tick_ceil(Fraction(MIN_PRICE))
+    while price <= MAX_PRICE:
+        if prices and price <= prices[-1]:
+            raise ContractError(f"{table.market} E_m is not strictly increasing")
+        if price % table.tick(price) != 0:
+            raise ContractError(f"{table.market} E_m contains invalid price {price}")
+        prices.append(price)
+        price = table.tick_ceil(Fraction(price + 1))
+    if not prices:
+        raise ContractError(f"{table.market} E_m is empty")
+    return tuple(prices), price
+
+
+def _exit_ratio_and_witness(
+    table: MarketTickTable, entry_price: int
+) -> tuple[Fraction, int, int]:
+    points = {entry_price}
+    for band in table.bands:
+        if band.lower > entry_price:
+            points.add(table.tick_ceil(Fraction(band.lower)))
+    best_ratio: Fraction | None = None
+    best_price = 0
+    best_tick = 0
+    for price in sorted(points):
+        tick = table.tick(price)
+        ratio = Fraction(tick, price)
+        if best_ratio is None or ratio > best_ratio:
+            best_ratio = ratio
+            best_price = price
+            best_tick = tick
+    if best_ratio is None:
+        raise ContractError(f"{table.market} exit witness set is empty")
+    return best_ratio, best_price, best_tick
+
+
+def _candidate(
+    market: str,
+    entry_price: int,
+    table: MarketTickTable,
+    rates: MarketRates,
+) -> Candidate:
+    entry_tick = table.tick(entry_price)
+    rho_entry = Fraction(entry_tick, entry_price)
+    rho_exit, exit_witness_price, exit_witness_tick = _exit_ratio_and_witness(
+        table, entry_price
+    )
+    entry_multiplier = 1 + rates.buy_commission + rho_entry
+    exit_multiplier = 1 - rates.sell_commission - rates.sell_tax - rho_exit
+    if exit_multiplier <= 0:
+        raise ContractError(
+            f"{market} exit_multiplier_cap is not positive at P={entry_price}"
+        )
+    cost_rate = entry_multiplier / exit_multiplier - 1
+    return Candidate(
+        market=market,
+        entry_price=entry_price,
+        entry_tick=entry_tick,
+        rho_entry=rho_entry,
+        exit_witness_price=exit_witness_price,
+        exit_witness_tick=exit_witness_tick,
+        rho_exit=rho_exit,
+        entry_multiplier=entry_multiplier,
+        exit_multiplier=exit_multiplier,
+        cost_rate=cost_rate,
+    )
+
+
+def _market_candidates(
+    market: str, table: MarketTickTable, rates: MarketRates
+) -> tuple[list[Candidate], MarketSummary]:
+    prices, first_after_cap = enumerate_valid_prices(table)
+    candidates = [
+        _candidate(market, entry_price, table, rates) for entry_price in prices
+    ]
+    worst = candidates[0]
+    for candidate in candidates[1:]:
+        if candidate.cost_rate > worst.cost_rate:
+            worst = candidate
+    return candidates, MarketSummary(
+        market=market,
+        candidate_count=len(candidates),
+        first_price=prices[0],
+        last_price=prices[-1],
+        first_price_after_cap=first_after_cap,
+        raw_cost_rate=worst.cost_rate,
+        witness_entry_price=worst.entry_price,
+        witness_exit_price=worst.exit_witness_price,
+    )
+
+
+def _target_check(
+    candidate: Candidate,
+    table: MarketTickTable,
+    rates: MarketRates,
+    cap: Fraction,
+) -> Candidate:
+    target = table.tick_ceil(Fraction(candidate.entry_price) * (1 + cap))
+    left = Fraction(target) * (
+        1
+        - rates.sell_commission
+        - rates.sell_tax
+        - Fraction(table.tick(target), target)
+    )
+    right = Fraction(candidate.entry_price) * (
+        1 + rates.buy_commission + candidate.rho_entry
+    )
+    passed = left >= right
+    if not passed:
+        raise ContractError(
+            f"§6.9 target check failed: market={candidate.market} "
+            f"P={candidate.entry_price} T={target}"
+        )
+    return replace(
+        candidate,
+        target_price=target,
+        target_check_passed=True,
+    )
+
+
+def run_reducer(cost_inputs: CostInputs, tick_tables: TickTables) -> ReducerRun:
+    candidates: list[Candidate] = []
+    summaries: dict[str, MarketSummary] = {}
+    for market in MARKETS:
+        market_candidates, summary = _market_candidates(
+            market,
+            tick_tables.markets[market],
+            cost_inputs.rates[market],
+        )
+        candidates.extend(market_candidates)
+        summaries[market] = summary
+
+    witness_market = "KOSPI"
+    for market in MARKETS:
+        if summaries[market].raw_cost_rate > summaries[witness_market].raw_cost_rate:
+            witness_market = market
+    raw = summaries[witness_market].raw_cost_rate
+    cap_bp = (BP_SCALE * raw.numerator + raw.denominator - 1) // raw.denominator
+    cap = Fraction(cap_bp, BP_SCALE)
+    checked = tuple(
+        _target_check(
+            candidate,
+            tick_tables.markets[candidate.market],
+            cost_inputs.rates[candidate.market],
+            cap,
+        )
+        for candidate in candidates
+    )
+    witness = summaries[witness_market]
+    return ReducerRun(
+        candidates=checked,
+        market_summaries=summaries,
+        raw_cost_rate=raw,
+        witness_market=witness_market,
+        witness_entry_price=witness.witness_entry_price,
+        witness_exit_price=witness.witness_exit_price,
+        cap_bp=cap_bp,
+        cap=cap,
+    )
+
+
+def _candidate_csv_bytes(candidates: tuple[Candidate, ...]) -> bytes:
+    buffer = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        buffer,
+        fieldnames=CANDIDATE_FIELDS,
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    writer.writerows(candidate.csv_row() for candidate in candidates)
+    return buffer.getvalue().encode("utf-8")
+
+
+def _decimal_string(cap_bp: int) -> str:
+    return f"{cap_bp // BP_SCALE}.{cap_bp % BP_SCALE:04d}"
+
+
+def _source_manifest(repo_root: Path) -> tuple[list[dict[str, str]], str]:
+    manifest: list[dict[str, str]] = []
+    combined = hashlib.sha256()
+    for relative in SOURCE_RELATIVE_PATHS:
+        path = repo_root / relative
+        digest = sha256_file(path)
+        manifest.append({"path": relative, "sha256": digest})
+        combined.update(relative.encode("utf-8"))
+        combined.update(b"\0")
+        combined.update(path.read_bytes())
+        combined.update(b"\0")
+    return manifest, combined.hexdigest()
+
+
+def _verify_sealed_canonicals(
+    parent_canonical_path: Path, amendment_canonical_path: Path
+) -> None:
+    if sha256_file(parent_canonical_path) != PARENT_CANONICAL_SHA256:
+        raise ContractError("sealed parent canonical file SHA-256 mismatch")
+    if sha256_file(amendment_canonical_path) != AMENDMENT_CANONICAL_SHA256:
+        raise ContractError("sealed amendment canonical file SHA-256 mismatch")
+
+
+def write_artifacts(
+    run: ReducerRun,
+    cost_inputs: CostInputs,
+    tick_tables: TickTables,
+    output_dir: Path,
+    repo_root: Path,
+    parent_canonical_path: Path,
+    amendment_canonical_path: Path,
+) -> dict[str, object]:
+    _verify_sealed_canonicals(parent_canonical_path, amendment_canonical_path)
+
+    normalized_bytes = canonical_json_bytes(cost_inputs.raw)
+    tick_input_bytes = canonical_json_bytes(tick_tables.raw)
+    candidates_bytes = _candidate_csv_bytes(run.candidates)
+    source_manifest, source_sha256 = _source_manifest(repo_root)
+    summaries = {
+        market: {
+            "candidate_count": summary.candidate_count,
+            "first_price": summary.first_price,
+            "last_price": summary.last_price,
+            "first_price_after_cap": summary.first_price_after_cap,
+            "c_raw_num": summary.raw_cost_rate.numerator,
+            "c_raw_den": summary.raw_cost_rate.denominator,
+            "witness_entry_price": summary.witness_entry_price,
+            "witness_exit_price": summary.witness_exit_price,
+        }
+        for market, summary in run.market_summaries.items()
+    }
+    result: dict[str, object] = {
+        "reducer_spec_id": REDUCER_SPEC_ID,
+        "arithmetic": "fractions.Fraction+integer",
+        "float_used": False,
+        "parent_canonical_sha256": PARENT_CANONICAL_SHA256,
+        "amendment_canonical_sha256": AMENDMENT_CANONICAL_SHA256,
+        "p0_2_cost_inputs_normalized_sha256": sha256_bytes(normalized_bytes),
+        "p0_1_tick_tables_normalized_sha256": sha256_bytes(tick_input_bytes),
+        "c_stress_candidates_sha256": sha256_bytes(candidates_bytes),
+        "reducer_source_sha256": source_sha256,
+        "reducer_source_manifest": source_manifest,
+        "market_summaries": summaries,
+        "candidate_count_total": len(run.candidates),
+        "c_raw_num": run.raw_cost_rate.numerator,
+        "c_raw_den": run.raw_cost_rate.denominator,
+        "witness_market": run.witness_market,
+        "witness_entry_price": run.witness_entry_price,
+        "witness_exit_price": run.witness_exit_price,
+        "c_stress_cap_bp": run.cap_bp,
+        "c_stress_cap_decimal": _decimal_string(run.cap_bp),
+        "all_target_checks_passed": all(
+            candidate.target_check_passed for candidate in run.candidates
+        ),
+        "p0_2_completion_hash": None,
+        "p0_2_completion_state": "AWAITING_INDEPENDENT_REPRODUCTION",
+    }
+    result_bytes = canonical_json_bytes(result)
+    if output_dir.exists():
+        raise ContractError(f"output directory already exists: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=False)
+    (output_dir / "p0_2_cost_inputs.normalized.json").write_bytes(normalized_bytes)
+    (output_dir / "c_stress_candidates.csv").write_bytes(candidates_bytes)
+    (output_dir / "c_stress_reducer_result.json").write_bytes(result_bytes)
+    return result

--- a/scripts/krb1_c_stress_independent_verify.py
+++ b/scripts/krb1_c_stress_independent_verify.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Independent integer-arithmetic reproduction of the sealed KR-B1c reducer.
+
+This executable intentionally does not import the reference reducer. It enumerates
+valid prices directly from bands and represents every rational as a reduced integer
+pair.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from math import gcd
+from pathlib import Path
+from typing import Any
+
+MARKETS = ("KOSPI", "KOSDAQ")
+RATE_SCALE = 1_000_000_000_000
+BP_SCALE = 10_000
+MIN_PRICE = 5_000
+MAX_PRICE = 400_000
+FIELDS = (
+    "market",
+    "entry_price",
+    "entry_tick",
+    "rho_entry_num",
+    "rho_entry_den",
+    "exit_witness_price",
+    "exit_witness_tick",
+    "rho_exit_num",
+    "rho_exit_den",
+    "entry_multiplier_num",
+    "entry_multiplier_den",
+    "exit_multiplier_num",
+    "exit_multiplier_den",
+    "c_num",
+    "c_den",
+    "target_price",
+    "target_check_passed",
+)
+
+
+class VerificationError(ValueError):
+    """Independent reproduction failed."""
+
+
+def reject_float(_: str) -> None:
+    raise VerificationError("JSON floating-point numbers are prohibited")
+
+
+def read_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_float=reject_float,
+            parse_constant=reject_float,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise VerificationError(f"cannot load {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise VerificationError(f"{path} must contain an object")
+    return value
+
+
+def canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_digest(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def ratio(numerator: int, denominator: int = 1) -> tuple[int, int]:
+    if denominator == 0:
+        raise VerificationError("zero rational denominator")
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    divisor = gcd(abs(numerator), denominator)
+    return numerator // divisor, denominator // divisor
+
+
+def add(left: tuple[int, int], right: tuple[int, int]) -> tuple[int, int]:
+    return ratio(
+        left[0] * right[1] + right[0] * left[1],
+        left[1] * right[1],
+    )
+
+
+def subtract(left: tuple[int, int], right: tuple[int, int]) -> tuple[int, int]:
+    return ratio(
+        left[0] * right[1] - right[0] * left[1],
+        left[1] * right[1],
+    )
+
+
+def multiply(left: tuple[int, int], right: tuple[int, int]) -> tuple[int, int]:
+    return ratio(left[0] * right[0], left[1] * right[1])
+
+
+def divide(left: tuple[int, int], right: tuple[int, int]) -> tuple[int, int]:
+    return ratio(left[0] * right[1], left[1] * right[0])
+
+
+def greater(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] * right[1] > right[0] * left[1]
+
+
+def greater_equal(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] * right[1] >= right[0] * left[1]
+
+
+def positive(value: tuple[int, int]) -> bool:
+    return value[0] > 0
+
+
+def bands_for(tick_input: dict[str, Any], market: str) -> list[dict[str, Any]]:
+    markets = tick_input.get("markets")
+    if not isinstance(markets, dict):
+        raise VerificationError("tick input markets is malformed")
+    market_value = markets.get(market)
+    if not isinstance(market_value, dict):
+        raise VerificationError(f"missing tick table for {market}")
+    bands = market_value.get("bands")
+    if not isinstance(bands, list) or not bands:
+        raise VerificationError(f"missing tick bands for {market}")
+    if not all(isinstance(band, dict) for band in bands):
+        raise VerificationError(f"malformed tick band for {market}")
+    return bands
+
+
+def tick_at(bands: list[dict[str, Any]], price: int) -> int:
+    for band in bands:
+        lower = band["lower"]
+        upper = band["upper_exclusive"]
+        if price >= lower and (upper is None or price < upper):
+            return band["tick"]
+    raise VerificationError(f"no tick band at price {price}")
+
+
+def aligned_ceiling(integer: int, step: int) -> int:
+    return ((integer + step - 1) // step) * step
+
+
+def tick_ceil_ratio(bands: list[dict[str, Any]], value: tuple[int, int]) -> int:
+    integer = (value[0] + value[1] - 1) // value[1]
+    for band in bands:
+        candidate = max(integer, band["lower"])
+        aligned = aligned_ceiling(candidate, band["tick"])
+        upper = band["upper_exclusive"]
+        if upper is None or aligned < upper:
+            return aligned
+    raise VerificationError("tick table is not open-ended")
+
+
+def direct_prices(bands: list[dict[str, Any]]) -> list[int]:
+    prices: list[int] = []
+    for band in bands:
+        lower = max(MIN_PRICE, band["lower"])
+        upper_raw = band["upper_exclusive"]
+        upper = MAX_PRICE + 1 if upper_raw is None else min(MAX_PRICE + 1, upper_raw)
+        first = aligned_ceiling(lower, band["tick"])
+        if first < upper:
+            prices.extend(range(first, upper, band["tick"]))
+    if not prices or prices != sorted(set(prices)):
+        raise VerificationError("direct E_m enumeration is empty or non-bijective")
+    return prices
+
+
+def independent_exit_witness(
+    bands: list[dict[str, Any]], entry_price: int
+) -> tuple[tuple[int, int], int, int]:
+    best: tuple[int, int] | None = None
+    best_price = 0
+    best_tick = 0
+    for band in bands:
+        lower = max(entry_price, band["lower"])
+        price = aligned_ceiling(lower, band["tick"])
+        upper = band["upper_exclusive"]
+        if upper is not None and price >= upper:
+            continue
+        candidate = ratio(band["tick"], price)
+        if (
+            best is None
+            or greater(candidate, best)
+            or (candidate == best and price < best_price)
+        ):
+            best = candidate
+            best_price = price
+            best_tick = band["tick"]
+    if best is None:
+        raise VerificationError("independent exit witness search is empty")
+    return best, best_price, best_tick
+
+
+def market_rates(
+    cost_input: dict[str, Any], market: str
+) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int]]:
+    records = cost_input.get("market_cost_records")
+    if not isinstance(records, list):
+        raise VerificationError("market_cost_records is malformed")
+    selected = [
+        record
+        for record in records
+        if isinstance(record, dict) and record.get("market") == market
+    ]
+    if not selected:
+        raise VerificationError(f"no cost records for {market}")
+    buy = max(record["buy_commission_rate_e12"] for record in selected)
+    sell = max(record["sell_commission_rate_e12"] for record in selected)
+    tax = max(
+        sum(component["rate_e12"] for component in record["sell_tax_components"])
+        for record in selected
+    )
+    return ratio(buy, RATE_SCALE), ratio(sell, RATE_SCALE), ratio(tax, RATE_SCALE)
+
+
+def expected_rows(
+    cost_input: dict[str, Any], tick_input: dict[str, Any]
+) -> tuple[
+    list[dict[str, str]],
+    dict[str, dict[str, int]],
+    tuple[int, int],
+    str,
+    int,
+    int,
+    int,
+]:
+    pending: list[
+        tuple[
+            str,
+            int,
+            int,
+            tuple[int, int],
+            int,
+            int,
+            tuple[int, int],
+            tuple[int, int],
+            tuple[int, int],
+            tuple[int, int],
+        ]
+    ] = []
+    summaries: dict[str, dict[str, int]] = {}
+    market_worst: dict[str, tuple[tuple[int, int], int, int]] = {}
+    for market in MARKETS:
+        bands = bands_for(tick_input, market)
+        prices = direct_prices(bands)
+        buy, sell, tax = market_rates(cost_input, market)
+        worst: tuple[int, int] | None = None
+        worst_entry = 0
+        worst_exit = 0
+        for entry_price in prices:
+            entry_tick = tick_at(bands, entry_price)
+            rho_entry = ratio(entry_tick, entry_price)
+            rho_exit, exit_price, exit_tick = independent_exit_witness(
+                bands, entry_price
+            )
+            entry_multiplier = add(add(ratio(1), buy), rho_entry)
+            exit_multiplier = subtract(
+                subtract(subtract(ratio(1), sell), tax), rho_exit
+            )
+            if not positive(exit_multiplier):
+                raise VerificationError(
+                    f"nonpositive exit multiplier at {market}/{entry_price}"
+                )
+            cost_rate = subtract(divide(entry_multiplier, exit_multiplier), ratio(1))
+            pending.append(
+                (
+                    market,
+                    entry_price,
+                    entry_tick,
+                    rho_entry,
+                    exit_price,
+                    exit_tick,
+                    rho_exit,
+                    entry_multiplier,
+                    exit_multiplier,
+                    cost_rate,
+                )
+            )
+            if worst is None or greater(cost_rate, worst):
+                worst = cost_rate
+                worst_entry = entry_price
+                worst_exit = exit_price
+        if worst is None:
+            raise VerificationError(f"no candidates for {market}")
+        first_after_cap = tick_ceil_ratio(bands, ratio(MAX_PRICE + 1))
+        summaries[market] = {
+            "candidate_count": len(prices),
+            "first_price": prices[0],
+            "last_price": prices[-1],
+            "first_price_after_cap": first_after_cap,
+            "c_raw_num": worst[0],
+            "c_raw_den": worst[1],
+            "witness_entry_price": worst_entry,
+            "witness_exit_price": worst_exit,
+        }
+        market_worst[market] = (worst, worst_entry, worst_exit)
+
+    witness_market = "KOSPI"
+    if greater(market_worst["KOSDAQ"][0], market_worst["KOSPI"][0]):
+        witness_market = "KOSDAQ"
+    raw, witness_entry, witness_exit = market_worst[witness_market]
+    cap_bp = (BP_SCALE * raw[0] + raw[1] - 1) // raw[1]
+    cap = ratio(cap_bp, BP_SCALE)
+
+    rows: list[dict[str, str]] = []
+    for (
+        market,
+        entry_price,
+        entry_tick,
+        rho_entry,
+        exit_price,
+        exit_tick,
+        rho_exit,
+        entry_multiplier,
+        exit_multiplier,
+        cost_rate,
+    ) in pending:
+        bands = bands_for(tick_input, market)
+        buy, sell, tax = market_rates(cost_input, market)
+        target = tick_ceil_ratio(
+            bands,
+            multiply(ratio(entry_price), add(ratio(1), cap)),
+        )
+        left = multiply(
+            ratio(target),
+            subtract(
+                subtract(
+                    subtract(ratio(1), sell),
+                    tax,
+                ),
+                ratio(tick_at(bands, target), target),
+            ),
+        )
+        right = multiply(
+            ratio(entry_price),
+            add(add(ratio(1), buy), rho_entry),
+        )
+        if not greater_equal(left, right):
+            raise VerificationError(
+                f"independent target check failed at {market}/{entry_price}"
+            )
+        rows.append(
+            {
+                "market": market,
+                "entry_price": str(entry_price),
+                "entry_tick": str(entry_tick),
+                "rho_entry_num": str(rho_entry[0]),
+                "rho_entry_den": str(rho_entry[1]),
+                "exit_witness_price": str(exit_price),
+                "exit_witness_tick": str(exit_tick),
+                "rho_exit_num": str(rho_exit[0]),
+                "rho_exit_den": str(rho_exit[1]),
+                "entry_multiplier_num": str(entry_multiplier[0]),
+                "entry_multiplier_den": str(entry_multiplier[1]),
+                "exit_multiplier_num": str(exit_multiplier[0]),
+                "exit_multiplier_den": str(exit_multiplier[1]),
+                "c_num": str(cost_rate[0]),
+                "c_den": str(cost_rate[1]),
+                "target_price": str(target),
+                "target_check_passed": "true",
+            }
+        )
+    return (
+        rows,
+        summaries,
+        raw,
+        witness_market,
+        witness_entry,
+        witness_exit,
+        cap_bp,
+    )
+
+
+def compare_candidates(candidate_path: Path, expected: list[dict[str, str]]) -> None:
+    with candidate_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if tuple(reader.fieldnames or ()) != FIELDS:
+            raise VerificationError("candidate CSV 17-field schema mismatch")
+        for index, expected_row in enumerate(expected):
+            actual = next(reader, None)
+            if actual is None:
+                raise VerificationError(f"candidate CSV ended before row {index}")
+            if actual != expected_row:
+                differing = [
+                    field
+                    for field in FIELDS
+                    if actual.get(field) != expected_row[field]
+                ]
+                raise VerificationError(
+                    f"candidate mismatch at row {index}: fields={differing}"
+                )
+        if next(reader, None) is not None:
+            raise VerificationError("candidate CSV contains extra rows")
+
+
+def boundary_checks(tick_input: dict[str, Any]) -> dict[str, list[dict[str, int]]]:
+    output: dict[str, list[dict[str, int]]] = {}
+    for market in MARKETS:
+        bands = bands_for(tick_input, market)
+        checks: list[dict[str, int]] = []
+        for band in bands[1:]:
+            lower = band["lower"]
+            checks.append(
+                {
+                    "lower": lower,
+                    "tick_below": tick_at(bands, lower - 1),
+                    "tick_at": tick_at(bands, lower),
+                    "tick_above": tick_at(bands, lower + 1),
+                }
+            )
+        final = bands[-1]
+        open_probe = final["lower"] + 1_234_567
+        checks.append(
+            {
+                "open_ended_probe": open_probe,
+                "tick": tick_at(bands, open_probe),
+            }
+        )
+        output[market] = checks
+    return output
+
+
+def verify_source_manifest(result: dict[str, Any], repo_root: Path) -> None:
+    manifest = result.get("reducer_source_manifest")
+    if not isinstance(manifest, list) or not manifest:
+        raise VerificationError("result reducer_source_manifest is malformed")
+    combined = hashlib.sha256()
+    for item in manifest:
+        if not isinstance(item, dict):
+            raise VerificationError("source manifest entry is malformed")
+        relative = item.get("path")
+        expected_sha = item.get("sha256")
+        if not isinstance(relative, str) or not isinstance(expected_sha, str):
+            raise VerificationError("source manifest fields are malformed")
+        path = repo_root / relative
+        if file_digest(path) != expected_sha:
+            raise VerificationError(f"reference source drift: {relative}")
+        combined.update(relative.encode("utf-8"))
+        combined.update(b"\0")
+        combined.update(path.read_bytes())
+        combined.update(b"\0")
+    if combined.hexdigest() != result.get("reducer_source_sha256"):
+        raise VerificationError("combined reducer source SHA-256 mismatch")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Independently reproduce all KR-B1c exact-rational candidates."
+    )
+    parser.add_argument("--cost-input", type=Path, required=True)
+    parser.add_argument("--tick-input", type=Path, required=True)
+    parser.add_argument("--candidates", type=Path, required=True)
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--verification-output", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        cost_input = read_object(args.cost_input)
+        tick_input = read_object(args.tick_input)
+        result = read_object(args.result)
+        verify_source_manifest(result, args.repo_root.resolve())
+        (
+            expected,
+            summaries,
+            raw,
+            witness_market,
+            witness_entry,
+            witness_exit,
+            cap_bp,
+        ) = expected_rows(cost_input, tick_input)
+        compare_candidates(args.candidates, expected)
+        if result.get("p0_2_cost_inputs_normalized_sha256") != digest(
+            canonical(cost_input)
+        ):
+            raise VerificationError("normalized P0-2 input SHA-256 mismatch")
+        if result.get("p0_1_tick_tables_normalized_sha256") != digest(
+            canonical(tick_input)
+        ):
+            raise VerificationError("normalized P0-1 tick SHA-256 mismatch")
+        if result.get("c_stress_candidates_sha256") != file_digest(args.candidates):
+            raise VerificationError("candidate CSV SHA-256 mismatch")
+        expected_result_fields = {
+            "market_summaries": summaries,
+            "candidate_count_total": len(expected),
+            "c_raw_num": raw[0],
+            "c_raw_den": raw[1],
+            "witness_market": witness_market,
+            "witness_entry_price": witness_entry,
+            "witness_exit_price": witness_exit,
+            "c_stress_cap_bp": cap_bp,
+            "c_stress_cap_decimal": (f"{cap_bp // BP_SCALE}.{cap_bp % BP_SCALE:04d}"),
+            "all_target_checks_passed": True,
+        }
+        for field, expected_value in expected_result_fields.items():
+            if result.get(field) != expected_value:
+                raise VerificationError(f"result field mismatch: {field}")
+        report: dict[str, object] = {
+            "status": "PASS",
+            "implementation_independence": (
+                "standalone; no reference reducer imports; direct band enumeration; "
+                "reduced integer pairs"
+            ),
+            "arithmetic": "integer cross-products+gcd",
+            "float_used": False,
+            "candidate_rows_compared": len(expected),
+            "fraction_rows_matched": len(expected),
+            "witness_rows_matched": len(expected),
+            "target_rows_matched": len(expected),
+            "market_summaries": summaries,
+            "c_raw_num": raw[0],
+            "c_raw_den": raw[1],
+            "witness_market": witness_market,
+            "witness_entry_price": witness_entry,
+            "witness_exit_price": witness_exit,
+            "c_stress_cap_bp": cap_bp,
+            "c_stress_cap_decimal": (f"{cap_bp // BP_SCALE}.{cap_bp % BP_SCALE:04d}"),
+            "boundary_checks": boundary_checks(tick_input),
+            "reference_result_sha256": file_digest(args.result),
+            "candidate_csv_sha256": file_digest(args.candidates),
+            "independent_source_sha256": file_digest(Path(__file__)),
+            "p0_2_completion_hash_created": False,
+            "p0_2_completion_hash_reason": (
+                "completion hash format is not specified and fixture is not sealed P0 input"
+            ),
+        }
+        report_bytes = canonical(report)
+        if args.verification_output is not None:
+            args.verification_output.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                with args.verification_output.open("xb") as handle:
+                    handle.write(report_bytes)
+            except FileExistsError as exc:
+                raise VerificationError(
+                    f"verification output already exists: {args.verification_output}"
+                ) from exc
+        print(report_bytes.decode("utf-8"))
+        return 0
+    except (VerificationError, KeyError, TypeError) as exc:
+        print(f"KR-B1c independent reproduction FAIL: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/krb1_c_stress_reducer.py
+++ b/scripts/krb1_c_stress_reducer.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Run the KR-B1c exact-rational reference reducer."""
+
+from research.krb1_c_stress_reducer.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/krb1_c_stress/p0_1_standard_stock_tick_tables.json
+++ b/tests/fixtures/krb1_c_stress/p0_1_standard_stock_tick_tables.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "krb1.reference.tick_tables.v1",
+  "parent_canonical_sha256": "d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1",
+  "symbol_table_mapping_status": "COMPLETE",
+  "markets": {
+    "KOSPI": {
+      "table_id": "KRX_KOSPI_STANDARD_STOCK_2023_PLUS",
+      "instrument_scope": "STANDARD_STOCK_ONLY_TEST_FIXTURE",
+      "source_locator": "repository:app/mcp_server/tick_size.py",
+      "source_snapshot_sha256": "0b99d17d7fc59a9f8ef792d38548c85d37256360c424bba053c19a597bb17f18",
+      "bands": [
+        {"lower": 0, "upper_exclusive": 2000, "tick": 1},
+        {"lower": 2000, "upper_exclusive": 5000, "tick": 5},
+        {"lower": 5000, "upper_exclusive": 20000, "tick": 10},
+        {"lower": 20000, "upper_exclusive": 50000, "tick": 50},
+        {"lower": 50000, "upper_exclusive": 200000, "tick": 100},
+        {"lower": 200000, "upper_exclusive": 500000, "tick": 500},
+        {"lower": 500000, "upper_exclusive": null, "tick": 1000}
+      ]
+    },
+    "KOSDAQ": {
+      "table_id": "KRX_KOSDAQ_STANDARD_STOCK_2023_PLUS",
+      "instrument_scope": "STANDARD_STOCK_ONLY_TEST_FIXTURE",
+      "source_locator": "repository:app/mcp_server/tick_size.py",
+      "source_snapshot_sha256": "0b99d17d7fc59a9f8ef792d38548c85d37256360c424bba053c19a597bb17f18",
+      "bands": [
+        {"lower": 0, "upper_exclusive": 2000, "tick": 1},
+        {"lower": 2000, "upper_exclusive": 5000, "tick": 5},
+        {"lower": 5000, "upper_exclusive": 20000, "tick": 10},
+        {"lower": 20000, "upper_exclusive": 50000, "tick": 50},
+        {"lower": 50000, "upper_exclusive": 200000, "tick": 100},
+        {"lower": 200000, "upper_exclusive": 500000, "tick": 500},
+        {"lower": 500000, "upper_exclusive": null, "tick": 1000}
+      ]
+    }
+  }
+}

--- a/tests/fixtures/krb1_c_stress/p0_2_real_tariff_cost_inputs.json
+++ b/tests/fixtures/krb1_c_stress/p0_2_real_tariff_cost_inputs.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "krb1.p0_2_cost_inputs.v1",
+  "p0_2_completed_at_kst": "2026-07-28T18:00:00+09:00",
+  "parent_canonical_sha256": "d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1",
+  "coverage_start_session": "2026-07-28",
+  "coverage_end_session": "2026-07-28",
+  "market_cost_records": [
+    {
+      "market": "KOSPI",
+      "broker_id": "kiwoom",
+      "account_product_id": "KIWOOM_DOMESTIC_CASH_STOCK",
+      "order_channel_id": "KIWOOM_OPENAPI_KRX",
+      "cost_basis": "REAL_TRADING_TARIFF",
+      "rate_upper_bound_scope": "TEST_FIXTURE: OpenAPI KRX cash-stock proportional tariff; no minimum, fixed, tier, grade, or channel differential",
+      "effective_from": "2026-06-12",
+      "effective_to": null,
+      "buy_commission_rate_e12": 150000000,
+      "sell_commission_rate_e12": 150000000,
+      "sell_tax_components": [
+        {
+          "component_code": "KOSPI_SECURITIES_TRANSACTION_TAX",
+          "rate_e12": 500000000
+        },
+        {
+          "component_code": "KOSPI_RURAL_SPECIAL_TAX",
+          "rate_e12": 1500000000
+        }
+      ],
+      "source_locator": "https://download.kiwoom.com/deploy/AG003/pdf/AG003_27.pdf",
+      "source_snapshot_sha256": "8fd195fe7426ab66afca2ff131a08153afd114a2c0912b32e0924ba2434095af",
+      "probe_reconciliation_status": "PASS",
+      "mock_cost_relation": "DIFFERENT"
+    },
+    {
+      "market": "KOSDAQ",
+      "broker_id": "kiwoom",
+      "account_product_id": "KIWOOM_DOMESTIC_CASH_STOCK",
+      "order_channel_id": "KIWOOM_OPENAPI_KRX",
+      "cost_basis": "REAL_TRADING_TARIFF",
+      "rate_upper_bound_scope": "TEST_FIXTURE: OpenAPI KRX cash-stock proportional tariff; no minimum, fixed, tier, grade, or channel differential",
+      "effective_from": "2026-06-12",
+      "effective_to": null,
+      "buy_commission_rate_e12": 150000000,
+      "sell_commission_rate_e12": 150000000,
+      "sell_tax_components": [
+        {
+          "component_code": "KOSDAQ_SECURITIES_TRANSACTION_TAX",
+          "rate_e12": 2000000000
+        }
+      ],
+      "source_locator": "https://download.kiwoom.com/deploy/AG003/pdf/AG003_27.pdf",
+      "source_snapshot_sha256": "8fd195fe7426ab66afca2ff131a08153afd114a2c0912b32e0924ba2434095af",
+      "probe_reconciliation_status": "PASS",
+      "mock_cost_relation": "DIFFERENT"
+    }
+  ]
+}

--- a/tests/research/test_krb1_c_stress_reducer.py
+++ b/tests/research/test_krb1_c_stress_reducer.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import ast
+import builtins
+import csv
+import json
+import subprocess
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+import pytest
+
+from research.krb1_c_stress_reducer import (
+    ContractError,
+    load_cost_inputs,
+    load_tick_tables,
+    run_reducer,
+    write_artifacts,
+)
+from research.krb1_c_stress_reducer import reducer as reducer_module
+from research.krb1_c_stress_reducer.model import canonical_json_bytes
+from research.krb1_c_stress_reducer.reducer import CANDIDATE_FIELDS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "krb1_c_stress"
+COST_INPUT = FIXTURES / "p0_2_real_tariff_cost_inputs.json"
+TICK_INPUT = FIXTURES / "p0_1_standard_stock_tick_tables.json"
+REFERENCE_SOURCES = (
+    REPO_ROOT / "research" / "krb1_c_stress_reducer" / "__init__.py",
+    REPO_ROOT / "research" / "krb1_c_stress_reducer" / "model.py",
+    REPO_ROOT / "research" / "krb1_c_stress_reducer" / "reducer.py",
+    REPO_ROOT / "research" / "krb1_c_stress_reducer" / "cli.py",
+    REPO_ROOT / "scripts" / "krb1_c_stress_reducer.py",
+)
+INDEPENDENT_SOURCE = REPO_ROOT / "scripts" / "krb1_c_stress_independent_verify.py"
+
+
+@pytest.fixture(scope="module")
+def inputs():
+    return load_cost_inputs(COST_INPUT), load_tick_tables(TICK_INPUT)
+
+
+@pytest.fixture(scope="module")
+def reducer_run(inputs):
+    return run_reducer(*inputs)
+
+
+def test_amendment_real_tariff_and_tax_components_are_bound(inputs):
+    costs, _ = inputs
+    assert costs.rates["KOSPI"].buy_commission_rate_e12 == 150_000_000
+    assert costs.rates["KOSPI"].sell_commission_rate_e12 == 150_000_000
+    assert costs.rates["KOSPI"].sell_tax_rate_e12 == 2_000_000_000
+    assert costs.rates["KOSDAQ"].sell_tax_rate_e12 == 2_000_000_000
+    kospi_components = dict(costs.records[0].sell_tax_components)
+    assert kospi_components == {
+        "KOSPI_SECURITIES_TRANSACTION_TAX": 500_000_000,
+        "KOSPI_RURAL_SPECIAL_TAX": 1_500_000_000,
+    }
+    assert all(record.cost_basis == "REAL_TRADING_TARIFF" for record in costs.records)
+    assert all(record.mock_cost_relation == "DIFFERENT" for record in costs.records)
+
+
+def test_mock_display_rate_cannot_enter_numeric_contract(tmp_path):
+    raw = json.loads(COST_INPUT.read_text(encoding="utf-8"))
+    raw["market_cost_records"][0]["mock_display_rate_e12"] = 3_500_000_000
+    path = tmp_path / "invalid.json"
+    path.write_bytes(canonical_json_bytes(raw))
+    with pytest.raises(ContractError, match="keys mismatch"):
+        load_cost_inputs(path)
+
+
+def test_current_standard_stock_table_boundaries_and_open_end(inputs):
+    _, ticks = inputs
+    expected = (
+        (2_000, 1, 5),
+        (5_000, 5, 10),
+        (20_000, 10, 50),
+        (50_000, 50, 100),
+        (200_000, 100, 500),
+        (500_000, 500, 1_000),
+    )
+    for market in ("KOSPI", "KOSDAQ"):
+        table = ticks.markets[market]
+        for boundary, below, at in expected:
+            assert table.tick(boundary - 1) == below
+            assert table.tick(boundary) == at
+            assert table.tick(boundary + 1) == at
+        assert table.tick(99_999_999) == 1_000
+        assert table.tick_ceil(Fraction(500_001)) == 501_000
+
+
+def test_incomplete_symbol_to_table_mapping_fails_closed(tmp_path):
+    raw = json.loads(TICK_INPUT.read_text(encoding="utf-8"))
+    raw["symbol_table_mapping_status"] = "INCOMPLETE"
+    path = tmp_path / "tick.json"
+    path.write_bytes(canonical_json_bytes(raw))
+    with pytest.raises(ContractError, match="not COMPLETE"):
+        load_tick_tables(path)
+
+
+def test_exhaustive_candidate_counts_formula_ties_and_targets(inputs, reducer_run):
+    costs, _ = inputs
+    assert len(reducer_run.candidates) == 8_002
+    assert {
+        market: summary.candidate_count
+        for market, summary in reducer_run.market_summaries.items()
+    } == {"KOSPI": 4_001, "KOSDAQ": 4_001}
+    assert all(
+        summary.first_price == 5_000
+        and summary.last_price == 400_000
+        and summary.first_price_after_cap == 400_500
+        for summary in reducer_run.market_summaries.values()
+    )
+    assert reducer_run.witness_market == "KOSPI"
+    assert all(candidate.target_check_passed for candidate in reducer_run.candidates)
+
+    sample = reducer_run.candidates[0]
+    rates = costs.rates[sample.market]
+    expected = (
+        1 + rates.buy_commission + Fraction(sample.entry_tick, sample.entry_price)
+    ) / (1 - rates.sell_commission - rates.sell_tax - sample.rho_exit) - 1
+    assert sample.cost_rate == expected
+    assert reducer_run.cap >= reducer_run.raw_cost_rate
+    assert reducer_run.cap - Fraction(1, 10_000) < reducer_run.raw_cost_rate
+
+
+def test_core_execution_does_not_call_builtin_float(monkeypatch, inputs):
+    def forbidden_float(*_args, **_kwargs):
+        raise AssertionError("builtin float was called")
+
+    monkeypatch.setattr(builtins, "float", forbidden_float)
+    run = run_reducer(*inputs)
+    assert len(run.candidates) == 8_002
+
+
+def test_sources_have_no_float_literals_conversions_or_decimal_imports():
+    for path in (*REFERENCE_SOURCES, INDEPENDENT_SOURCE):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            assert not (
+                isinstance(node, ast.Constant) and isinstance(node.value, float)
+            ), f"float literal in {path}:{getattr(node, 'lineno', '?')}"
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id != "float", (
+                    f"float conversion in {path}:{node.lineno}"
+                )
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                names = (
+                    [alias.name for alias in node.names]
+                    if isinstance(node, ast.Import)
+                    else [node.module or ""]
+                )
+                assert not {"decimal", "numpy"}.intersection(names)
+
+    independent_tree = ast.parse(INDEPENDENT_SOURCE.read_text(encoding="utf-8"))
+    imported_modules = {
+        node.module
+        for node in ast.walk(independent_tree)
+        if isinstance(node, ast.ImportFrom)
+    }
+    assert not any(
+        module and module.startswith("research.krb1_c_stress_reducer")
+        for module in imported_modules
+    )
+
+
+def test_artifacts_are_byte_deterministic_and_independently_reproduced(
+    tmp_path, monkeypatch, inputs, reducer_run
+):
+    costs, ticks = inputs
+    monkeypatch.setattr(
+        reducer_module,
+        "_verify_sealed_canonicals",
+        lambda _parent, _amendment: None,
+    )
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    fake_parent = tmp_path / "parent.json"
+    fake_amendment = tmp_path / "amendment.json"
+    write_artifacts(
+        reducer_run,
+        costs,
+        ticks,
+        first,
+        REPO_ROOT,
+        fake_parent,
+        fake_amendment,
+    )
+    write_artifacts(
+        reducer_run,
+        costs,
+        ticks,
+        second,
+        REPO_ROOT,
+        fake_parent,
+        fake_amendment,
+    )
+    artifact_names = (
+        "p0_2_cost_inputs.normalized.json",
+        "c_stress_candidates.csv",
+        "c_stress_reducer_result.json",
+    )
+    assert {name: (first / name).read_bytes() for name in artifact_names} == {
+        name: (second / name).read_bytes() for name in artifact_names
+    }
+    with pytest.raises(ContractError, match="already exists"):
+        write_artifacts(
+            reducer_run,
+            costs,
+            ticks,
+            first,
+            REPO_ROOT,
+            fake_parent,
+            fake_amendment,
+        )
+
+    with (first / "c_stress_candidates.csv").open(
+        encoding="utf-8", newline=""
+    ) as handle:
+        reader = csv.DictReader(handle)
+        assert tuple(reader.fieldnames or ()) == CANDIDATE_FIELDS
+        assert sum(1 for _ in reader) == 8_002
+
+    verification_outputs = []
+    stdout_values = []
+    for index in range(2):
+        verification_output = tmp_path / f"independent-{index}.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(INDEPENDENT_SOURCE),
+                "--cost-input",
+                str(COST_INPUT),
+                "--tick-input",
+                str(TICK_INPUT),
+                "--candidates",
+                str(first / "c_stress_candidates.csv"),
+                "--result",
+                str(first / "c_stress_reducer_result.json"),
+                "--repo-root",
+                str(REPO_ROOT),
+                "--verification-output",
+                str(verification_output),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0, completed.stdout + completed.stderr
+        verification_outputs.append(verification_output.read_bytes())
+        stdout_values.append(completed.stdout)
+    assert verification_outputs[0] == verification_outputs[1]
+    assert stdout_values[0] == stdout_values[1]
+    report = json.loads(verification_outputs[0])
+    assert report["status"] == "PASS"
+    assert report["float_used"] is False
+    assert report["candidate_rows_compared"] == 8_002
+    assert report["fraction_rows_matched"] == 8_002
+    assert report["witness_rows_matched"] == 8_002
+    assert report["target_rows_matched"] == 8_002
+    assert report["p0_2_completion_hash_created"] is False


### PR DESCRIPTION
## Summary
- implement sealed KR-B1c §6.2.1/§7.7 reducer with exhaustive `fractions.Fraction` arithmetic and no float/Decimal finite-precision comparisons
- add a standalone independent reproducer that imports none of the reference package and uses reduced integer pairs, gcd, and cross-products
- validate the REAL_TRADING_TARIFF-only P0-2 contract, period-wise independent maxima, KOSPI 0.05% + 0.15% tax components, tick-table continuity/open end, bp ceiling, and every §6.9 target
- publish deterministic normalized input, 17-field candidate CSV, and result JSON without overwriting an existing output directory

## Reference fixture result
The committed fixture is explicitly test-only, not a sealed P0 completion input.

- tick table: current 2023+ standard KRX stock table for KOSPI/KOSDAQ
- E_m: 4,001 per market (8,002 total; the ~2,400 figure is the old-table trace identified by the sealed math verification)
- C_raw: `146/19907`
- witness: `KOSPI`, P=20,000, Q=20,000
- cap: `74bp`, decimal `0.0074`
- all 8,002 target checks: PASS
- independent fraction/witness/target matches: 8,002 / 8,002 / 8,002

## Determinism
Two separate executions produced byte-identical artifacts:

- normalized P0-2 input: `7ec5b2bb8e5b50c4c617a35e516b9a10780a757881b79a4edd9bade2268b1e73`
- candidate CSV: `5b067554dda572ed5352432ec6bfafe62bbd7cd1044a5dbf120ed07dd0e18de7`
- reducer result: `f71ffa18d844e36b602198cff76ceb8afed68fa1a6fe5a6562c4a7fb1c539223`
- independent verification: `b1025f8a35a013354fea4fd51cfc17d321d0d316b4edce2fe7e20250a973aabd`

## Float exclusion
- source AST test rejects float literals, `float(...)`, and Decimal/NumPy imports
- core executes while `builtins.float` is replaced with a raising function
- JSON floating-point tokens are rejected
- independent implementation reports `integer cross-products+gcd`

## Fail-closed boundaries / unresolved sealed-policy details
- current `kr_symbol_universe` does not prove that ETF/ETN/ELW are excluded; special-product symbol-to-table routing must be complete before actual P0-1 can say `COMPLETE`
- §6.2.1 has only market dimension `m`; it does not specify how to combine multiple product tick tables inside one market
- the clause says the candidate CSV has 17 reduced-fraction fields but does not name them; the audit schema is documented in the PR
- P0-1 file schema and the P0-2 completion-hash preimage/serialization are not sealed
- no actual sealed P0-1/P0-2 inputs are present, so no P0-2 completion hash is created; the fixture result remains explicitly non-completion evidence

## Verification
- `make lint`
- `uv run --group test pytest --confcutdir=tests/research tests/research/test_krb1_c_stress_reducer.py -q` → 8 passed
- reference CLI twice against both sealed canonical files → PASS and identical hashes
- independent CLI twice → PASS and identical hashes

A normal targeted pytest invocation also attempted the repository-wide autouse test-schema DDL and was blocked by the existing local test DB diagnostic guard (`watch outcome constraint lost pending`). The DB-free isolated suite above is the code-result gate; no production DB write, broker mutation, deployment, or order was performed.

Do not merge until reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an exact-rational KR-B1c stress reducer for calculating market candidates, cost rates, witnesses, and stress-cap results.
  * Added command-line execution with structured success and failure output.
  * Added strict validation for cost inputs, tick tables, timestamps, hashes, and JSON values.
  * Added independently reproducible verification using integer arithmetic and cross-checks for CSV and result artifacts.
  * Added deterministic artifact generation with integrity hashes and boundary checks.

* **Documentation**
  * Added Korean reference documentation covering contracts, verification steps, fixtures, outputs, and known completion constraints.

* **Tests**
  * Added comprehensive coverage for validation, calculations, deterministic outputs, and independent verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->