### PR TITLE
test(ci): isolate pytest workers and speed up the test suite

### DIFF
--- a/.github/workflows/test-durations-refresh.yml
+++ b/.github/workflows/test-durations-refresh.yml
@@ -1,17 +1,14 @@
 name: Refresh test durations
 
-# Weekly self-healing refresh of .test_durations (ROB-963).
-#
-# .test_durations feeds pytest-split's 4-shard balance in test.yml. As tests are
-# added, unrecorded entries fall back to an even-split assumption and the shards
-# drift out of balance (worst shard decides the whole test job's wall-clock).
-# This job re-runs the full suite with --store-durations and opens an auto-PR
-# with the diff so the file never goes stale without manual intervention.
+# Weekly deterministic refresh of .test_durations (ROB-963 / ROB-1051).
+# Each matrix shard owns a PostgreSQL service; xdist workers are further
+# isolated by tests/conftest.py. Shards emit clean JSON maps and identical
+# collection manifests. The merge job drops stale entries and refuses partial,
+# duplicate, or collection-inconsistent results.
 
 on:
   schedule:
-    # Mondays 18:10 UTC (~03:10 KST Tue) — off-peak, once a week.
-    - cron: '10 18 * * 1'
+    - cron: "10 18 * * 1"
   workflow_dispatch: {}
 
 concurrency:
@@ -23,13 +20,17 @@ permissions:
   pull-requests: write
 
 jobs:
-  refresh-durations:
+  measure:
+    name: Measure shard ${{ matrix.group }}/4
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
     env:
       PYTHON_VERSION: "3.13"
 
-    # Same service container + env-setup pattern as the `test` job in test.yml.
     services:
       postgres:
         image: postgres:15-alpine
@@ -38,7 +39,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_db
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres -d test_db"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -57,8 +58,6 @@ jobs:
       run: pip install uv
 
     - name: Install redis-server (ROB-892 real-Redis acceptance)
-      # ROB-892: the gate-acceptance suite spawns its own disposable redis-server
-      # on a random port. The binary must exist in CI or that fixture fails loudly.
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq redis-server redis-tools
@@ -66,7 +65,6 @@ jobs:
         redis-cli --version
 
     - name: Load cached venv
-      id: cached-uv-dependencies
       uses: actions/cache@v5
       with:
         path: .venv
@@ -75,51 +73,82 @@ jobs:
     - name: Install dependencies
       run: uv sync --group test
 
-    - name: Wait for PostgreSQL to be ready
+    - name: Wait for PostgreSQL
       run: |
         for i in {1..30}; do
-          if pg_isready -h localhost -p 5432 -U postgres; then
-            echo "PostgreSQL is ready!"
+          if pg_isready -h localhost -p 5432 -U postgres -d test_db; then
             exit 0
           fi
-          echo "Waiting for PostgreSQL... ($i/30)"
           sleep 1
         done
-        echo "PostgreSQL failed to start"
         exit 1
 
-    - name: Set environment variables from env.example
-      run: |
-        chmod +x scripts/setup-test-env.sh
-        bash scripts/setup-test-env.sh
+    - name: Set test environment
+      run: bash scripts/setup-test-env.sh
 
-    - name: Regenerate .test_durations (full suite, unsharded)
-      env:
-        COVERAGE_CORE: sysmon
-      # Unsharded on purpose: --store-durations must observe EVERY test so the
-      # single committed .test_durations covers the whole suite. Running with
-      # --splits/--group would only record that shard's subset. No --cov here
-      # (durations only). Mirrors the command documented in test.yml.
-      #
-      # Exit code 1 (test failures) is tolerated: unsharded, every test file
-      # shares ONE postgres, so files that the 4-shard split normally isolates
-      # into separate jobs collide here (advisory-lock deadlocks, cross-file
-      # row contamination — observed in runs 29641342852 / 29642419871 with a
-      # different flaky set each time). Correctness gating belongs to test.yml;
-      # this job only needs per-test durations, which pytest-split records for
-      # failed tests too. Exit codes >= 2 (interrupted / internal error /
-      # collection error) still fail the job so a partial run never ships.
+    - name: Record authoritative collection manifest
       run: |
-        set +e
-        uv run pytest tests/ -m "not live" --store-durations -n 4 --dist=loadfile \
-          -o faulthandler_timeout=120 -ra
-        status=$?
-        if [ "$status" -eq 1 ]; then
-          echo "::warning title=durations refresh::test failures tolerated (exit 1); durations were still recorded"
-        elif [ "$status" -ne 0 ]; then
-          echo "pytest exited with $status (interrupted/internal/collection error) — aborting refresh"
-          exit "$status"
-        fi
+        set -euo pipefail
+        uv run pytest tests/ --collect-only -q --no-cov -m "not live" \
+          2>/dev/null | grep '^tests/.*::' | LC_ALL=C sort -u \
+          > "collected-shard-${{ matrix.group }}.txt"
+        test -s "collected-shard-${{ matrix.group }}.txt"
+
+    - name: Measure shard
+      run: |
+        cp .test_durations "durations-shard-${{ matrix.group }}.json"
+        uv run pytest tests/ -q -ra -m "not live" \
+          --splits 4 --group "${{ matrix.group }}" \
+          --durations-path "durations-shard-${{ matrix.group }}.json" \
+          --store-durations --clean-durations \
+          -n 4 --dist=loadfile \
+          -o faulthandler_timeout=120
+
+    - name: Upload shard measurements
+      uses: actions/upload-artifact@v6
+      with:
+        name: durations-shard-${{ matrix.group }}
+        path: |
+          durations-shard-${{ matrix.group }}.json
+          collected-shard-${{ matrix.group }}.txt
+        if-no-files-found: error
+
+  merge:
+    name: Merge duration shards
+    needs: measure
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PYTHON_VERSION: "3.13"
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Download shard measurements
+      uses: actions/download-artifact@v6
+      with:
+        pattern: durations-shard-*
+        path: duration-artifacts
+        merge-multiple: true
+
+    - name: Merge complete current duration set
+      run: |
+        python scripts/merge_test_durations.py \
+          --baseline .test_durations \
+          --shard duration-artifacts/durations-shard-1.json \
+          --shard duration-artifacts/durations-shard-2.json \
+          --shard duration-artifacts/durations-shard-3.json \
+          --shard duration-artifacts/durations-shard-4.json \
+          --collected duration-artifacts/collected-shard-1.txt \
+          --collected duration-artifacts/collected-shard-2.txt \
+          --collected duration-artifacts/collected-shard-3.txt \
+          --collected duration-artifacts/collected-shard-4.txt \
+          --output .test_durations
 
     - name: Detect .test_durations changes
       id: diff
@@ -134,39 +163,26 @@ jobs:
           echo "before_entries=$before" >> "$GITHUB_OUTPUT"
           echo "after_entries=$after" >> "$GITHUB_OUTPUT"
           echo "Recorded duration entries: $before -> $after"
-          # A large entry-count drop means the run recorded only part of the
-          # suite (legit test removals shrink it far less) — never PR that.
-          if [ "$after" -lt $(( before * 9 / 10 )) ]; then
-            echo "Entry count dropped >10% ($before -> $after) — refusing to open a PR with partial durations."
-            exit 1
-          fi
         fi
 
     - name: Open auto-PR with refreshed durations
       if: steps.diff.outputs.changed == 'true'
       uses: peter-evans/create-pull-request@v7
       with:
-        # Falls back to the default GITHUB_TOKEN when no PAT is configured. NOTE:
-        # PRs opened with GITHUB_TOKEN do NOT trigger the Test workflow. Set a
-        # repo secret DURATIONS_REFRESH_TOKEN (a PAT/bot token with repo scope)
-        # if you want CI to run automatically on the refresh PR.
-        token: ${{ secrets.DURATIONS_REFRESH_TOKEN || secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.DURATIONS_REFRESH_TOKEN || github.token }}
         commit-message: "chore(ci): refresh .test_durations (pytest-split shard balance)"
-        # The suite mutates tracked files as a side effect (.smoke-out/*.json);
-        # commit ONLY the durations file so the auto-PR never picks them up.
         add-paths: .test_durations
         branch: ci/test-durations-refresh
         delete-branch: true
         base: main
         title: "chore(ci): refresh .test_durations"
         body: |
-          Automated weekly refresh of `.test_durations` (ROB-963).
+          Automated weekly refresh of `.test_durations` (ROB-963 / ROB-1051).
 
-          `.test_durations` feeds pytest-split's 4-shard balance in `test.yml`. As
-          tests are added, unrecorded entries fall back to an even-split assumption
-          and the shards drift out of balance (the slowest shard decides the whole
-          test job's wall-clock). This PR re-runs the full suite with
-          `--store-durations` and commits the result.
+          Four CI-equivalent shards measured the full non-live suite using
+          independent PostgreSQL services and worker-isolated databases. The
+          merge rejected missing/duplicate measurements, dropped stale entries,
+          and wrote a deterministic node-id-sorted map.
 
           - recorded duration entries: `${{ steps.diff.outputs.before_entries }}` → `${{ steps.diff.outputs.after_entries }}`
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ on:
     branches: [ main, develop ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -53,9 +53,8 @@ jobs:
       matrix:
         python-version: ["3.13"]
         # Duration-based shards via pytest-split (.test_durations is committed;
-        # refresh it periodically with: uv run pytest tests/ -m "not live"
-        # --store-durations -n 4 --dist=loadfile). Unrecorded new tests fall
-        # back to an even-split assumption until the next refresh.
+        # refresh it with test-durations-refresh.yml). Unrecorded new tests
+        # fall back to an even-split assumption until the next refresh.
         group: [1, 2, 3, 4]
 
     services:
@@ -66,7 +65,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_db
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres -d test_db"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -108,7 +107,7 @@ jobs:
     - name: Wait for PostgreSQL to be ready
       run: |
         for i in {1..30}; do
-          if pg_isready -h localhost -p 5432 -U postgres; then
+          if pg_isready -h localhost -p 5432 -U postgres -d test_db; then
             echo "PostgreSQL is ready!"
             exit 0
           fi
@@ -141,7 +140,7 @@ jobs:
       # per commit).
       run: |
         set +e
-        uv run pytest tests/ -m "not live" --splits 4 --group ${{ matrix.group }} --durations-path .test_durations -n auto --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml 2>&1 | tee pytest-output.log
+        uv run pytest tests/ -m "not live" --splits 4 --group ${{ matrix.group }} --durations-path .test_durations -n 4 --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml 2>&1 | tee pytest-output.log
         status=${PIPESTATUS[0]}
         if [ "$status" -ne 0 ]; then
           {
@@ -209,34 +208,52 @@ jobs:
     - name: TaskIQ worker smoke test
       run: |
         set -euo pipefail
-        status=0
-        timeout --signal=TERM --kill-after=5s 30s uv run taskiq worker app.core.taskiq_broker:broker app.tasks > taskiq-worker.log 2>&1 || status=$?
-        if [[ "$status" -ne 124 && "$status" -ne 137 ]]; then
-          echo "TaskIQ worker smoke test failed: unexpected exit code $status."
-          tail -n 200 taskiq-worker.log || true
-          exit 1
-        fi
-        if ! grep -Fq "Listening started." taskiq-worker.log; then
-          echo "TaskIQ worker smoke test failed: startup marker not found."
-          tail -n 200 taskiq-worker.log || true
-          exit 1
-        fi
+        uv run taskiq worker app.core.taskiq_broker:broker app.tasks > taskiq-worker.log 2>&1 &
+        process_id=$!
+        for _ in {1..60}; do
+          if grep -Fq "Listening started." taskiq-worker.log; then
+            kill -TERM "$process_id"
+            wait "$process_id" || true
+            exit 0
+          fi
+          if ! kill -0 "$process_id" 2>/dev/null; then
+            wait "$process_id" || status=$?
+            echo "TaskIQ worker smoke test exited before readiness (status ${status:-0})."
+            tail -n 200 taskiq-worker.log || true
+            exit 1
+          fi
+          sleep 0.5
+        done
+        kill -TERM "$process_id" 2>/dev/null || true
+        wait "$process_id" || true
+        echo "TaskIQ worker smoke test did not become ready within 30 seconds."
+        tail -n 200 taskiq-worker.log || true
+        exit 1
 
     - name: TaskIQ scheduler smoke test
       run: |
         set -euo pipefail
-        status=0
-        timeout --signal=TERM --kill-after=5s 30s uv run taskiq scheduler app.core.scheduler:sched app.tasks --skip-first-run > taskiq-scheduler.log 2>&1 || status=$?
-        if [[ "$status" -ne 124 && "$status" -ne 137 ]]; then
-          echo "TaskIQ scheduler smoke test failed: unexpected exit code $status."
-          tail -n 200 taskiq-scheduler.log || true
-          exit 1
-        fi
-        if ! grep -Fq "Startup completed." taskiq-scheduler.log; then
-          echo "TaskIQ scheduler smoke test failed: startup marker not found."
-          tail -n 200 taskiq-scheduler.log || true
-          exit 1
-        fi
+        uv run taskiq scheduler app.core.scheduler:sched app.tasks --skip-first-run > taskiq-scheduler.log 2>&1 &
+        process_id=$!
+        for _ in {1..60}; do
+          if grep -Fq "Startup completed." taskiq-scheduler.log; then
+            kill -TERM "$process_id"
+            wait "$process_id" || true
+            exit 0
+          fi
+          if ! kill -0 "$process_id" 2>/dev/null; then
+            wait "$process_id" || status=$?
+            echo "TaskIQ scheduler smoke test exited before readiness (status ${status:-0})."
+            tail -n 200 taskiq-scheduler.log || true
+            exit 1
+          fi
+          sleep 0.5
+        done
+        kill -TERM "$process_id" 2>/dev/null || true
+        wait "$process_id" || true
+        echo "TaskIQ scheduler smoke test did not become ready within 30 seconds."
+        tail -n 200 taskiq-scheduler.log || true
+        exit 1
 
     - name: Upload TaskIQ smoke logs
       if: always()
@@ -287,14 +304,10 @@ jobs:
           bandit-report.json
           safety-report.json
 
-  alpaca-track-tests:
-    # ROB-1059 S9: additive-only job -- the main `test` job's `testpaths`
-    # (pyproject.toml: ["tests"]) and its own pytest invocation are UNCHANGED.
-    # research/alpaca_track/tests/ is a fully separate, network-0, no-DB/no-
-    # Redis suite (own conftest.py sys.path wiring), so it gets its own
-    # lightweight job rather than being folded into the sharded `test` job's
-    # DB-backed run. This does not attempt to fix the pre-existing, separately
-    # out-of-scope research/nautilus_scalping CI gap.
+  alpaca-track-fast-tests:
+    # H1/H2/H3 are separate pytest invocations because they contain duplicate
+    # test module basenames under prepend import mode. They share one job so
+    # checkout/Python/uv/dependency setup is paid once instead of three times.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -325,111 +338,21 @@ jobs:
     - name: Install dependencies
       run: uv sync --group test
 
-    - name: Run ROB-1059 alpaca_track H1 data-layer tests (network-0, no DB/Redis)
+    - name: Run H1 data-layer tests
       run: |
-        uv run pytest research/alpaca_track/tests/ -v
+        uv run pytest research/alpaca_track/tests/ -q -ra --strict-markers
 
-  alpaca-track-seal-tests:
-    # ROB-1060 H2-lock adversarial-verification Finding 1: the H2 seal (94+
-    # tests pinning the ROB-846 registration domain/params/identity/semantic
-    # digest) previously ran ONLY on a developer's machine -- `pyproject.toml`
-    # `testpaths` collects only `tests/` (the DB-backed app suite), and no CI
-    # job referenced `alpaca_track_seal`. Additive-only job, exactly mirroring
-    # the `alpaca-track-tests` job above (H1): the main `test` job's
-    # `testpaths` and pytest invocation are UNCHANGED, and this does not
-    # attempt to fix the pre-existing, separately out-of-scope
-    # research/nautilus_scalping CI gap. research/alpaca_track_seal/tests/ is
-    # a fully separate, network-0, no-DB/no-Redis suite (own conftest.py
-    # sys.path wiring), so it gets its own lightweight job rather than being
-    # folded into the sharded `test` job's DB-backed run.
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    env:
-      PYTHON_VERSION: "3.13"
-
-    steps:
-    - uses: actions/checkout@v5
-      with:
-        persist-credentials: false
-
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-
-    - name: Install UV
-      run: pip install uv
-
-    - name: Load cached venv
-      id: cached-uv-dependencies
-      uses: actions/cache@v5
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}
-
-    - name: Install dependencies
-      run: uv sync --group test
-
-    - name: Run ROB-1060 alpaca_track_seal H2 registry-seal tests (network-0, no DB/Redis)
+    - name: Run H2 registry-seal tests
       run: |
-        uv run pytest research/alpaca_track_seal/tests/ -v
+        uv run pytest research/alpaca_track_seal/tests/ -q -ra --strict-markers
 
-  alpaca-track-signals-tests:
-    # ROB-1061 H3 -- exactly mirrors the alpaca-track-tests (H1) /
-    # alpaca-track-seal-tests (H2) jobs above: H1 and H2 both shipped a full
-    # suite that ran in NO CI job at all (each phase's own closing report
-    # calls this out as a completion-criteria failure caught only by
-    # adversarial re-verification, not by "tests passed locally"). This job
-    # exists so that mistake is not repeated a third time.
-    # research/alpaca_track_signals/tests/ is a fully separate, network-0,
-    # no-DB/no-Redis suite (own conftest.py sys.path wiring onto its two
-    # producer siblings, research/alpaca_track and research/alpaca_track_seal),
-    # so it gets its own lightweight job rather than being folded into the
-    # sharded `test` job's DB-backed run. The main `test` job's `testpaths`
-    # and pytest invocation remain UNCHANGED.
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    env:
-      PYTHON_VERSION: "3.13"
-
-    steps:
-    - uses: actions/checkout@v5
-      with:
-        persist-credentials: false
-
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-
-    - name: Install UV
-      run: pip install uv
-
-    - name: Load cached venv
-      id: cached-uv-dependencies
-      uses: actions/cache@v5
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}
-
-    - name: Install dependencies
-      run: uv sync --group test
-
-    - name: Run ROB-1061 alpaca_track_signals H3 signal-engine tests (network-0, no DB/Redis)
+    - name: Run H3 signal-engine tests
       run: |
-        uv run pytest research/alpaca_track_signals/tests/ -v --strict-markers -ra
-        # pytest exits 5 ("no tests collected") on an empty/misconfigured
-        # path -- a nonzero exit fails this step, so this job cannot pass
-        # silently on zero collected tests.
+        uv run pytest research/alpaca_track_signals/tests/ -q -ra --strict-markers
 
   alpaca-track-walkforward-tests:
-    # ROB-1062 H4 -- exactly mirrors the alpaca-track-tests (H1) /
-    # alpaca-track-seal-tests (H2) / alpaca-track-signals-tests (H3) jobs
-    # above: additive-only, own conftest.py sys.path wiring onto its three
+    # ROB-1062 H4 remains a separate gate from the consolidated H1/H2/H3 job:
+    # it has its own conftest.py sys.path wiring onto its three
     # producer siblings (research/alpaca_track, research/alpaca_track_seal,
     # research/alpaca_track_signals), network-0, no DB/Redis. The main
     # `test` job's `testpaths` and pytest invocation remain UNCHANGED.
@@ -481,7 +404,7 @@ jobs:
 
   notify:
     if: failure()
-    needs: [lint, test, taskiq-smoke, security, alpaca-track-tests, alpaca-track-seal-tests, alpaca-track-signals-tests, alpaca-track-walkforward-tests]
+    needs: [lint, test, taskiq-smoke, security, alpaca-track-fast-tests, alpaca-track-walkforward-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Discord failure notification

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ install-dev: ## Install development dependencies
 	uv sync --all-groups
 
 test: ## Run all tests (excludes live)
-	uv run pytest tests/ -v -m "not live"
+	uv run pytest tests/ -q -ra -m "not live"
 
-test-unit: ## Run unit tests only (excludes integration and live)
-	uv run pytest tests/ -v -m "not integration and not live"
+test-unit: ## Run positively marked unit tests (excludes slow and live)
+	uv run pytest tests/ -q -ra -m "unit and not integration and not slow and not live"
 
 test-integration: ## Run integration tests only (excludes live)
-	uv run pytest tests/ -v -m "integration and not live"
+	uv run pytest tests/ -q -ra -m "integration and not live"
 
 test-services-split: ## Run split service tests for former test_services.py scope
 	uv run pytest --no-cov -q \
@@ -25,22 +25,21 @@ test-services-split: ## Run split service tests for former test_services.py scop
 		tests/test_services_kis_client.py \
 		tests/test_services_kis_market_data.py \
 		tests/test_services_kis_logging.py \
-		tests/test_services_stock_info.py \
-		tests/test_services_gemini.py \
 		tests/test_services_dart.py \
 		tests/test_services_yahoo.py
 
 test-cov: ## Run tests with coverage report (excludes live)
-	uv run pytest tests/ -v -m "not live" --cov=app --cov-report=html --cov-report=term-missing
+	uv run pytest tests/ -q -ra -m "not live" --cov=app --cov-report=html --cov-report=term-missing
 
-test-fast: ## Run tests without coverage (faster, excludes live)
-	uv run pytest tests/ -v -m "not live" --no-cov
+test-fast: ## Run the bounded parallel unit development loop
+	uv run pytest tests/ -q -ra -m "unit and not integration and not slow and not live" \
+		--no-cov --maxfail=1 -n 4 --dist=loadfile
 
 test-watch: ## Run tests in watch mode (excludes live)
-	uv run pytest tests/ -v -m "not live" -f
+	uv run pytest tests/ -q -ra -m "not live" -f
 
 test-live: ## Run live API tests only (requires external network)
-	uv run pytest tests/ -v -m "integration and live" --run-live --no-cov
+	uv run pytest tests/ -q -ra -m "integration and live" --run-live --no-cov
 lint: ## Run linting checks (Ruff + ty)
 	uv run ruff check app/ tests/ research/ scripts/
 	uv run ruff format --check app/ tests/ research/ scripts/

--- a/scripts/merge_test_durations.py
+++ b/scripts/merge_test_durations.py
@@ -1,0 +1,125 @@
+"""Deterministically merge pytest-split duration shards.
+
+The current collected-node manifests are authoritative:
+
+* baseline entries absent from collection are stale and are dropped;
+* every currently collected test must have a measured shard duration;
+* duplicate measurements across shards are rejected;
+* all shard manifests must describe the same collection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+def _load_durations(path: Path) -> dict[str, float]:
+    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+
+    durations: dict[str, float] = {}
+    for node_id, duration in raw.items():
+        if (
+            not isinstance(node_id, str)
+            or isinstance(duration, bool)
+            or not isinstance(duration, int | float)
+        ):
+            raise ValueError(f"{path}: invalid duration entry {node_id!r}")
+        value = float(duration)
+        if value < 0 or not math.isfinite(value):
+            raise ValueError(f"{path}: invalid duration for {node_id}: {duration!r}")
+        durations[node_id] = value
+    return durations
+
+
+def _load_collected_nodes(paths: list[Path]) -> set[str]:
+    manifests = [
+        {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+        for path in paths
+    ]
+    if not manifests or not manifests[0]:
+        raise ValueError("collected-node manifests must not be empty")
+    expected = manifests[0]
+    for path, manifest in zip(paths[1:], manifests[1:], strict=True):
+        if manifest != expected:
+            missing = sorted(expected - manifest)[:10]
+            extra = sorted(manifest - expected)[:10]
+            raise ValueError(
+                f"{path}: collection differs from first manifest; "
+                f"missing={missing!r}, extra={extra!r}"
+            )
+    return expected
+
+
+def merge_duration_shards(
+    *,
+    baseline_path: Path,
+    shard_paths: list[Path],
+    collected_paths: list[Path],
+) -> tuple[dict[str, float], int]:
+    """Return the complete current duration map and number of stale entries."""
+    baseline = _load_durations(baseline_path)
+    collected = _load_collected_nodes(collected_paths)
+    measured: dict[str, float] = {}
+
+    for shard_path in shard_paths:
+        shard = _load_durations(shard_path)
+        unexpected = sorted(set(shard) - collected)
+        if unexpected:
+            raise ValueError(
+                f"{shard_path}: durations contain uncollected tests: {unexpected[:10]!r}"
+            )
+        duplicates = sorted(set(shard) & set(measured))
+        if duplicates:
+            raise ValueError(
+                f"{shard_path}: duplicate tests across shards: {duplicates[:10]!r}"
+            )
+        measured.update(shard)
+
+    missing = sorted(collected - set(measured))
+    if missing:
+        raise ValueError(
+            "duration shards are incomplete; "
+            f"{len(missing)} collected tests have no measurement: {missing[:20]!r}"
+        )
+
+    stale_count = len(set(baseline) - collected)
+    return {node_id: measured[node_id] for node_id in sorted(collected)}, stale_count
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--shard", type=Path, action="append", required=True)
+    parser.add_argument("--collected", type=Path, action="append", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    merged, stale_count = merge_duration_shards(
+        baseline_path=args.baseline,
+        shard_paths=args.shard,
+        collected_paths=args.collected,
+    )
+    args.output.write_text(
+        json.dumps(merged, sort_keys=True, indent=4) + "\n", encoding="utf-8"
+    )
+    print(
+        f"merged {len(args.shard)} shards into {len(merged)} entries; "
+        f"dropped {stale_count} stale baseline entries"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -42,8 +42,8 @@ INVESTMENT_REPORTS_TEST_LOCK_ID = 265_202_605
 
 
 @pytest_asyncio.fixture
-async def session() -> AsyncSession:
-    """Per-test AsyncSession against the real PostgreSQL test_db.
+async def session(_bootstrap_test_schema) -> AsyncSession:
+    """Per-test AsyncSession against the current PostgreSQL test database.
 
     Schema is owned by the session-scoped ``_bootstrap_test_schema`` barrier
     (ROB-723) — this fixture performs no DDL. Between tests it TRUNCATEs the

--- a/tests/_mcp_tooling_support.py
+++ b/tests/_mcp_tooling_support.py
@@ -351,7 +351,7 @@ def mock_upbit_coins() -> list[dict[str, Any]]:
     ]
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _mock_crypto_external_sources(monkeypatch: pytest.MonkeyPatch):
     async def mock_get_upbit_warning_markets(
         db=None,

--- a/tests/brokers/kis/mock_scalping_exec/test_adapters.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_adapters.py
@@ -45,6 +45,8 @@ async def test_submit_exit_sell_uses_scalping_exit(mocker) -> None:
     place = mocker.patch.object(
         mod, "_place_order_impl", new=AsyncMock(return_value={})
     )
+    reserve = mocker.patch.object(mod, "reserve_entry", new=AsyncMock())
+    release = mocker.patch.object(mod, "release_entry", new=AsyncMock())
     broker = KisMockBroker(get_state=lambda s: None)
     mocker.patch.object(
         broker, "_read_snapshot", new=AsyncMock(return_value=(Decimal("1"), None))
@@ -65,6 +67,10 @@ async def test_submit_exit_sell_uses_scalping_exit(mocker) -> None:
     assert kw["scalping_exit"] is True
     assert kw["scalping_exit_reason"] == "stop_loss"
     assert kw["scalping_strategy_id"] == "kis-mock-v1"
+    reserve.assert_awaited_once_with(
+        correlation_id="cid1", symbol="005930", side="sell"
+    )
+    release.assert_awaited_once_with(correlation_id="cid1", side="sell")
 
 
 @pytest.mark.unit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Pytest configuration and common fixtures for auto-trader tests.
 import asyncio
 import contextlib
 import os
+import re
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -22,6 +23,22 @@ import pytest_asyncio
 # dependency — and no-ops on the rare non-posix host.
 _ALPACA_PAPER_DB_LOCK_PATH = (
     Path(tempfile.gettempdir()) / "auto_trader_alpaca_paper_db_suite.lock"
+)
+_DEFAULT_TEST_DATABASE_URL = (
+    "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+)
+_XDIST_DATABASE_NAME_ENV = "AUTO_TRADER_XDIST_DATABASE_NAME"
+_XDIST_BASE_DATABASE_URL_ENV = "AUTO_TRADER_XDIST_BASE_DATABASE_URL"
+_DATABASE_FIXTURE_NAMES = frozenset(
+    {
+        "db_session",
+        "session",
+        "investment_reports_cleanup_lock",
+        "retrospective_action_control_lock",
+        "toss_ledger_cleanup_lock",
+        "binance_demo_reservation_lock",
+        "binance_demo_smoke_ledger_isolation",
+    }
 )
 
 
@@ -86,7 +103,7 @@ def _ensure_test_env() -> None:
         "TOP_N": "30",
         "DROP_PCT": "-3.0",
         "CRON": "0 * * * *",
-        "DATABASE_URL": "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db",
+        "DATABASE_URL": _DEFAULT_TEST_DATABASE_URL,
         "REDIS_URL": "redis://localhost:6379/0",
         "REDIS_MAX_CONNECTIONS": "10",
         "REDIS_SOCKET_TIMEOUT": "5",
@@ -106,9 +123,23 @@ def _ensure_test_env() -> None:
 
     # Force overwrite DATABASE_URL to ensure tests use the correct test database
     # regardless of what's in env.example (which may contain placeholder values)
-    os.environ["DATABASE_URL"] = (
-        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
-    )
+    os.environ["DATABASE_URL"] = _DEFAULT_TEST_DATABASE_URL
+
+    # Each xdist worker gets its own PostgreSQL database. File-based distribution
+    # prevents two workers from running one file, but it does not isolate table
+    # rows: broad cleanup and fixed-key fixtures in different files can still
+    # delete or duplicate one another's data. A run-unique database removes that
+    # race while leaving ordinary serial pytest runs on the conventional test_db.
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id and worker_id != "master":
+        run_uid = os.environ.get("PYTEST_XDIST_TESTRUNUID", "local")
+        safe_suffix = re.sub(r"[^a-zA-Z0-9_]", "_", f"{run_uid}_{worker_id}")
+        database_name = f"test_db_{safe_suffix[:55]}"
+        os.environ[_XDIST_DATABASE_NAME_ENV] = database_name
+        os.environ[_XDIST_BASE_DATABASE_URL_ENV] = _DEFAULT_TEST_DATABASE_URL
+        os.environ["DATABASE_URL"] = (
+            _DEFAULT_TEST_DATABASE_URL.rsplit("/", 1)[0] + f"/{database_name}"
+        )
 
     # ROB-469 PR2: force tests onto NullPool. Production defaults to the async queue
     # pool (DB_POOL_CLASS=queue), but pytest-asyncio uses a fresh event loop PER TEST,
@@ -434,8 +465,9 @@ def auth_mock_session():
 
 
 @pytest.fixture
-def auth_test_client(auth_mock_session):
+def auth_test_client(auth_mock_session, reset_auth_mock_db):
     """FastAPI test client with mocked database for auth tests."""
+    assert reset_auth_mock_db is auth_mock_session
     from fastapi.testclient import TestClient
 
     from app.core.db import get_db
@@ -449,7 +481,7 @@ def auth_test_client(auth_mock_session):
     del api.dependency_overrides[get_db]
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def reset_auth_mock_db(auth_mock_session):
     """Reset auth mock database before each test."""
     auth_mock_session.reset_mock()
@@ -561,26 +593,97 @@ def pytest_collection_modifyitems(config, items):
     - `pytest --collect-only -m "not live"` shows what fast gate will run
     - `pytest --collect-only -m "live" --run-live` shows live test set
     """
-    if not config.getoption("--run-live"):
-        # Skip live tests by default (mark as skip, not deselect)
-        # This makes the skip visible in test output
-        skip_live = pytest.mark.skip(reason="Live test: use --run-live to execute")
-        for item in items:
-            if item.get_closest_marker("live"):
-                item.add_marker(skip_live)
+    skip_live = pytest.mark.skip(reason="Live test: use --run-live to execute")
+    for item in items:
+        # A test requesting a real database fixture is integration by
+        # construction. Keep that invariant centralized so legacy file-level
+        # ``unit`` marks cannot accidentally put DB tests in the fast loop.
+        if _DATABASE_FIXTURE_NAMES.intersection(item.fixturenames):
+            item.add_marker(pytest.mark.integration)
+
+        if not config.getoption("--run-live") and item.get_closest_marker("live"):
+            item.add_marker(skip_live)
+
+
+async def _ensure_xdist_test_database() -> None:
+    """Create the current worker's isolated database before its first DB test."""
+    database_name = os.environ.get(_XDIST_DATABASE_NAME_ENV)
+    if not database_name:
+        return
+    if not re.fullmatch(r"[A-Za-z0-9_]+", database_name):
+        raise RuntimeError("refusing unsafe xdist database name")
+
+    import asyncpg
+    from sqlalchemy.engine import make_url
+
+    base_url = make_url(os.environ[_XDIST_BASE_DATABASE_URL_ENV])
+    admin = await asyncpg.connect(
+        user=base_url.username,
+        password=base_url.password,
+        host=base_url.host,
+        port=base_url.port,
+        database="postgres",
+    )
+    try:
+        exists = await admin.fetchval(
+            "SELECT 1 FROM pg_database WHERE datname = $1", database_name
+        )
+        if not exists:
+            await admin.execute(f'CREATE DATABASE "{database_name}"')
+    finally:
+        await admin.close()
+
+
+async def _drop_xdist_test_database() -> None:
+    """Drop only the validated, run-owned xdist database."""
+    database_name = os.environ.get(_XDIST_DATABASE_NAME_ENV)
+    if not database_name:
+        return
+    if not re.fullmatch(r"test_db_[A-Za-z0-9_]+", database_name):
+        raise RuntimeError("refusing to drop an unowned xdist database")
+
+    import asyncpg
+    from sqlalchemy.engine import make_url
+
+    base_url = make_url(os.environ[_XDIST_BASE_DATABASE_URL_ENV])
+    admin = await asyncpg.connect(
+        user=base_url.username,
+        password=base_url.password,
+        host=base_url.host,
+        port=base_url.port,
+        database="postgres",
+    )
+    try:
+        await admin.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
+    finally:
+        await admin.close()
 
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
-async def _bootstrap_test_schema():
-    """ROB-723: apply the test schema exactly once, before any test body.
+async def _bootstrap_test_schema(request: pytest.FixtureRequest):
+    """Apply the test schema once, before the first database-backed test.
 
-    Under xdist ``--dist=loadfile`` every worker enters this session-scoped
-    autouse fixture before running its first test. The first worker to win the
-    advisory lock runs the full DDL while all other workers block on the lock
-    (barrier); subsequent workers see the content-hash sentinel and skip all
-    DDL. Result: schema DDL (AccessExclusive) never overlaps another worker's
-    test-body SELECT, closing the deadlock window.
+    ROB-723's advisory-lock + sentinel DDL barrier remains intact. The fixture
+    is now an explicit dependency of database fixtures, so pure unit/static
+    tests do not connect to PostgreSQL. Under xdist each worker first creates
+    its own run-owned database, which also isolates test rows and broad cleanup.
     """
+    selected_items = request.session.items
+    requires_database = any(
+        item.get_closest_marker("integration")
+        or _DATABASE_FIXTURE_NAMES.intersection(item.fixturenames)
+        for item in selected_items
+    )
+    if not requires_database:
+        # Pure unit/static selections are a DB-free contract. Legacy direct-DB
+        # files remain covered by their integration marker, while explicit DB
+        # fixtures also force this barrier even if a marker is accidentally
+        # omitted.
+        yield
+        return
+
+    await _ensure_xdist_test_database()
+
     from sqlalchemy import text
 
     from app.core.db import engine
@@ -631,20 +734,24 @@ async def _bootstrap_test_schema():
                     {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
                 )
 
-    await run_with_deadlock_retry(_bootstrap_once)
-    yield
+    try:
+        await run_with_deadlock_retry(_bootstrap_once)
+        yield
+    finally:
+        if os.environ.get(_XDIST_DATABASE_NAME_ENV):
+            await engine.dispose()
+            await _drop_xdist_test_database()
 
 
 # Database fixtures for integration tests
 
 
 @pytest_asyncio.fixture
-async def db_session():
-    """Async session against the shared test_db.
+async def db_session(_bootstrap_test_schema):
+    """Async session against the current test database.
 
-    Schema is owned by the session-scoped ``_bootstrap_test_schema`` barrier
-    (ROB-723); this fixture performs no DDL — that is what previously overlapped
-    other xdist workers' test bodies and deadlocked.
+    Schema is owned by the explicit session-scoped bootstrap dependency; this
+    fixture performs no DDL. Xdist workers use isolated databases.
     """
     from app.core.db import AsyncSessionLocal
 
@@ -718,7 +825,7 @@ async def investment_reports_cleanup_lock(db_session):
 
 
 @pytest_asyncio.fixture
-async def retrospective_action_control_lock():
+async def retrospective_action_control_lock(_bootstrap_test_schema):
     """Serialize tests that mutate the global retrospective-action authority.
 
     The ROB-878/880 migration and cutover contracts intentionally change the
@@ -999,7 +1106,7 @@ async def seed_summary_sell_005930(db_session):
 
 
 @pytest_asyncio.fixture
-async def toss_ledger_cleanup_lock():
+async def toss_ledger_cleanup_lock(_bootstrap_test_schema):
     """Serialize tests that globally delete/scan ``review.toss_live_order_ledger``.
 
     Several toss-ledger test files run an autouse pre-clean that issues a
@@ -1033,7 +1140,7 @@ async def toss_ledger_cleanup_lock():
 
 
 @pytest_asyncio.fixture
-async def binance_demo_reservation_lock():
+async def binance_demo_reservation_lock(_bootstrap_test_schema):
     """Serialize files that COMMIT open-root rows to ``binance_demo_order_ledger``.
 
     ROB-844 makes ``reserve_root_planned`` commit the planned root so the claim

--- a/tests/infra/test_schema_barrier.py
+++ b/tests/infra/test_schema_barrier.py
@@ -206,7 +206,7 @@ def test_schema_content_hash_is_stable_and_hex():
 # Task 3: the bootstrap barrier must record the current schema hash.          #
 # --------------------------------------------------------------------------- #
 @pytest.mark.asyncio
-async def test_bootstrap_sentinel_present_after_session():
+async def test_bootstrap_sentinel_present_after_session(_bootstrap_test_schema):
     """The barrier must have recorded the current schema hash exactly once."""
     from sqlalchemy import text
 

--- a/tests/mcp_server/test_market_quote_snapshot_tools.py
+++ b/tests/mcp_server/test_market_quote_snapshot_tools.py
@@ -22,7 +22,13 @@ pytestmark = [pytest.mark.asyncio]
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_db():
+async def _clean_db(request: pytest.FixtureRequest):
+    if request.node.get_closest_marker("unit") and not request.node.get_closest_marker(
+        "integration"
+    ):
+        yield
+        return
+
     stmt = delete(MarketQuoteSnapshot).where(
         MarketQuoteSnapshot.symbol.in_(["MOCKSNAP", "KRW-BTC"])
     )

--- a/tests/mcp_server/tooling/test_kis_live_ledger.py
+++ b/tests/mcp_server/tooling/test_kis_live_ledger.py
@@ -4,6 +4,8 @@ import pytest_asyncio
 
 from app.models.review import KISLiveOrderLedger
 
+pytestmark = pytest.mark.integration
+
 
 @pytest_asyncio.fixture(autouse=True)
 async def clean_kis_live_ledger(db_session):

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -2,6 +2,8 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import delete
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.unit
 def test_live_order_ledger_model_shape():

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -15,7 +15,7 @@ from app.models.execution_ledger import ExecutionLedger
 from app.models.review import TossLiveOrderLedger
 from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
 
-pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 pytestmark.append(pytest.mark.usefixtures("toss_ledger_cleanup_lock"))
 
 

--- a/tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py
+++ b/tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py
@@ -49,6 +49,8 @@ FORBIDDEN_RUNTIME_FILES: tuple[pathlib.Path, ...] = (
     REPO_ROOT / "app" / "services" / "ai_providers" / "openai_provider.py",
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _iter_python_files(roots: Iterable[pathlib.Path]) -> list[pathlib.Path]:
     files: list[pathlib.Path] = []
@@ -101,26 +103,29 @@ def _forbidden_import_matches(imports: set[str]) -> set[str]:
     return matches
 
 
-@pytest.mark.parametrize("path", _iter_python_files(GUARDED_PATHS))
-def test_no_runtime_in_process_llm_imports(path: pathlib.Path) -> None:
-    source = path.read_text(encoding="utf-8")
-    tree = ast.parse(source, filename=str(path))
-    imports = _imports_in(tree)
-    definitions = _defined_names(tree)
-    accesses = _attribute_accesses(tree)
+def test_no_runtime_in_process_llm_imports() -> None:
+    violations: list[str] = []
+    for path in _iter_python_files(GUARDED_PATHS):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        imports = _imports_in(tree)
+        definitions = _defined_names(tree)
+        accesses = _attribute_accesses(tree)
 
-    offending_imports = _forbidden_import_matches(imports)
-    offending_definitions = definitions & FORBIDDEN_DEFINED_NAMES
-    offending_accesses = {
-        access
-        for access in accesses
-        if access.endswith(".ask")
-        and any(
-            access.startswith(f"{forbidden}.") for forbidden in FORBIDDEN_DEFINED_NAMES
-        )
-    }
+        offending_imports = _forbidden_import_matches(imports)
+        offending_definitions = definitions & FORBIDDEN_DEFINED_NAMES
+        offending_accesses = {
+            access
+            for access in accesses
+            if access.endswith(".ask")
+            and any(
+                access.startswith(f"{forbidden}.")
+                for forbidden in FORBIDDEN_DEFINED_NAMES
+            )
+        }
+        if not (offending_imports or offending_definitions or offending_accesses):
+            continue
 
-    if offending_imports or offending_definitions or offending_accesses:
         rel = path.relative_to(REPO_ROOT)
         messages: list[str] = []
         if offending_imports:
@@ -131,11 +136,12 @@ def test_no_runtime_in_process_llm_imports(path: pathlib.Path) -> None:
             )
         if offending_accesses:
             messages.append(f"calls forbidden .ask: {sorted(offending_accesses)!r}")
-        pytest.fail(
-            "ROB-501 guard violated — "
-            f"{rel} re-introduced an in-process LLM runtime surface: "
-            + "; ".join(messages)
-        )
+        violations.append(f"{rel}: " + "; ".join(messages))
+
+    assert not violations, (
+        "ROB-501 guard violated — in-process LLM runtime surfaces found:\n"
+        + "\n".join(f"- {violation}" for violation in violations)
+    )
 
 
 def test_forbidden_runtime_llm_files_are_absent() -> None:

--- a/tests/services/research/_db_guard_test_policy.py
+++ b/tests/services/research/_db_guard_test_policy.py
@@ -1,0 +1,47 @@
+"""Exact research-write policy for the pytest-owned PostgreSQL target.
+
+This helper is test-only. It does not change the production guard or teach it
+to accept a prefix: it builds a one-target policy from the DATABASE_URL that
+tests/conftest.py has already forced to localhost and, under xdist, to the
+exact run-owned worker database.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from sqlalchemy.engine import make_url
+
+from app.services.research_db_write_guard import ResearchDbPolicy, ResearchDbTarget
+
+_BASE_TEST_DATABASE_NAME = "test_db"
+_LOCAL_TEST_DATABASE_HOST = "localhost"
+_XDIST_DATABASE_NAME_ENV = "AUTO_TRADER_XDIST_DATABASE_NAME"
+_XDIST_DATABASE_PATTERN = re.compile(r"test_db_[A-Za-z0-9_]+")
+
+
+def current_research_test_db_policy() -> ResearchDbPolicy:
+    """Authorize exactly the local pytest database selected by conftest."""
+    raw_url = os.environ.get("DATABASE_URL")
+    if not raw_url:
+        raise RuntimeError("pytest research DB policy requires DATABASE_URL")
+
+    url = make_url(raw_url)
+    host = (url.host or "").strip().lower()
+    database_name = (url.database or "").strip()
+    worker_database_name = os.environ.get(_XDIST_DATABASE_NAME_ENV)
+    expected_database_name = worker_database_name or _BASE_TEST_DATABASE_NAME
+
+    if host != _LOCAL_TEST_DATABASE_HOST:
+        raise RuntimeError("pytest research DB policy requires the localhost target")
+    if database_name != expected_database_name:
+        raise RuntimeError("pytest research DB policy target does not match conftest")
+    if worker_database_name and not _XDIST_DATABASE_PATTERN.fullmatch(
+        worker_database_name
+    ):
+        raise RuntimeError(
+            "pytest research DB policy rejected the worker database name"
+        )
+
+    return ResearchDbPolicy.of(ResearchDbTarget(host=host, database_name=database_name))

--- a/tests/services/research/test_research_campaign_bridge_observer_effect.py
+++ b/tests/services/research/test_research_campaign_bridge_observer_effect.py
@@ -82,12 +82,12 @@ from app.services.research_campaign_bridge import (
     record_attempt,
     register_campaign_experiments,
 )
-from app.services.research_db_write_guard import ResearchDbPolicy, ResearchDbTarget
 from research_contracts.canonical_hash import canonical_json, canonical_sha256
-
-_POLICY = ResearchDbPolicy.of(
-    ResearchDbTarget(host="localhost", database_name="test_db")
+from tests.services.research._db_guard_test_policy import (
+    current_research_test_db_policy,
 )
+
+_POLICY = current_research_test_db_policy()
 _SYMBOLS = ("BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT")
 
 # -- REAL frozen production campaign identity (never fabricated) ----------

--- a/tests/services/research/test_research_campaign_bridge_registration.py
+++ b/tests/services/research/test_research_campaign_bridge_registration.py
@@ -28,10 +28,11 @@ from app.services.research_db_write_guard import (
     ResearchDbTargetRejected,
     ResearchWriteDisabled,
 )
-
-_POLICY = ResearchDbPolicy.of(
-    ResearchDbTarget(host="localhost", database_name="test_db")
+from tests.services.research._db_guard_test_policy import (
+    current_research_test_db_policy,
 )
+
+_POLICY = current_research_test_db_policy()
 _DENYING_POLICY = ResearchDbPolicy.of(
     ResearchDbTarget(host="some-other-host", database_name="some_other_db")
 )

--- a/tests/services/research/test_research_campaign_bridge_trials.py
+++ b/tests/services/research/test_research_campaign_bridge_trials.py
@@ -73,16 +73,13 @@ from app.services.research_campaign_bridge import (
     record_attempt,
     terminal_evidence_fingerprint,
 )
-from app.services.research_db_write_guard import (
-    ResearchDbPolicy,
-    ResearchDbTarget,
-    ResearchWriteDisabled,
-)
+from app.services.research_db_write_guard import ResearchWriteDisabled
 from research_contracts.canonical_hash import canonical_json
-
-_POLICY = ResearchDbPolicy.of(
-    ResearchDbTarget(host="localhost", database_name="test_db")
+from tests.services.research._db_guard_test_policy import (
+    current_research_test_db_policy,
 )
+
+_POLICY = current_research_test_db_policy()
 
 _ATTEMPT_BOUNDARY_PUBLIC_TEXT = (
     "attempt evidence rejected at the diagnostic persistence boundary"

--- a/tests/services/research/test_research_db_write_guard.py
+++ b/tests/services/research/test_research_db_write_guard.py
@@ -29,6 +29,9 @@ from app.services.research_db_write_guard import (
     research_write_opt_in_enabled,
     resolve_research_db_target,
 )
+from tests.services.research._db_guard_test_policy import (
+    current_research_test_db_policy,
+)
 
 _DISPOSABLE_TARGET = ResearchDbTarget(host="localhost", database_name="test_db")
 _POLICY = ResearchDbPolicy.of(_DISPOSABLE_TARGET)
@@ -135,6 +138,64 @@ def test_default_research_db_policy_only_authorizes_the_one_known_local_target()
     assert not policy.authorizes(
         ResearchDbTarget(host="prod-primary.internal.example", database_name="test_db")
     )
+
+
+def test_pytest_worker_policy_authorizes_only_the_exact_run_owned_target(monkeypatch):
+    worker_database = "test_db_run_123_gw2"
+    monkeypatch.setenv("AUTO_TRADER_XDIST_DATABASE_NAME", worker_database)
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        f"postgresql+asyncpg://postgres:postgres@localhost:5432/{worker_database}",
+    )
+
+    policy = current_research_test_db_policy()
+
+    assert policy.authorizes(
+        ResearchDbTarget(host="localhost", database_name=worker_database)
+    )
+    assert not policy.authorizes(
+        ResearchDbTarget(host="localhost", database_name="test_db")
+    )
+    assert not policy.authorizes(
+        ResearchDbTarget(host="localhost", database_name="test_db_run_123_gw3")
+    )
+    assert not policy.authorizes(
+        ResearchDbTarget(
+            host="prod-primary.internal.example", database_name=worker_database
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("database_url", "worker_database"),
+    [
+        (
+            "postgresql+asyncpg://postgres:postgres@prod.example:5432/"
+            "test_db_run_123_gw2",
+            "test_db_run_123_gw2",
+        ),
+        (
+            "postgresql+asyncpg://postgres:postgres@localhost:5432/production",
+            "production",
+        ),
+        (
+            "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db_run_123_gw2",
+            "test_db_run_123_gw3",
+        ),
+        (
+            "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db-unsafe",
+            "test_db-unsafe",
+        ),
+    ],
+)
+def test_pytest_worker_policy_rejects_non_owned_targets(
+    monkeypatch, database_url, worker_database
+):
+    monkeypatch.setenv("AUTO_TRADER_XDIST_DATABASE_NAME", worker_database)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    with pytest.raises(RuntimeError):
+        current_research_test_db_policy()
 
 
 @pytest.mark.parametrize("raw", ["1", "true", "True", "TRUE", "yes", "on"])

--- a/tests/services/research/test_rob944_campaign_controller.py
+++ b/tests/services/research/test_rob944_campaign_controller.py
@@ -30,7 +30,6 @@ from app.services.research_campaign_bridge import (
     CampaignSpecCountError,
     campaign_completeness_report,
 )
-from app.services.research_db_write_guard import ResearchDbPolicy, ResearchDbTarget
 from app.services.rob944_campaign_controller import (
     AttemptKeyExperimentMismatchError,
     CampaignBatchValidationError,
@@ -43,10 +42,11 @@ from app.services.rob944_campaign_controller import (
     _run_preflight_and_register,
     run_full_campaign,
 )
-
-_POLICY = ResearchDbPolicy.of(
-    ResearchDbTarget(host="localhost", database_name="test_db")
+from tests.services.research._db_guard_test_policy import (
+    current_research_test_db_policy,
 )
+
+_POLICY = current_research_test_db_policy()
 
 
 def _hex64(label: str) -> str:

--- a/tests/test_admin_router.py
+++ b/tests/test_admin_router.py
@@ -16,9 +16,11 @@ def _user(uid=1, role=UserRole.admin, is_active=True):
 
 
 @pytest.fixture(autouse=True)
-def override_refresh_side_effect(auth_mock_session):
+def override_refresh_side_effect(auth_mock_session, reset_auth_mock_db):
     # Override the module-level refresh side-effect from conftest.py
     # to preserve user IDs instead of forcing them to 1.
+    assert reset_auth_mock_db is auth_mock_session
+
     def custom_refresh(instance):
         if not getattr(instance, "id", None):
             instance.id = 1

--- a/tests/test_alpaca_paper_dev_smoke_safety.py
+++ b/tests/test_alpaca_paper_dev_smoke_safety.py
@@ -20,6 +20,8 @@ from app.mcp_server.tooling.alpaca_paper_orders import (
     set_alpaca_paper_orders_service_factory,
 )
 
+pytestmark = pytest.mark.integration
+
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_smoke_rows():

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -28,6 +28,8 @@ from app.services.brokers.alpaca.schemas import Order
 from tests._mcp_tooling_support import DummyMCP
 from tests.test_mcp_alpaca_paper_tools import FakeAlpacaPaperService
 
+pytestmark = pytest.mark.integration
+
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_manual_ledger_rows():

--- a/tests/test_crypto_composite_score.py
+++ b/tests/test_crypto_composite_score.py
@@ -32,6 +32,7 @@ from app.mcp_server.tooling.screening import crypto as screening_crypto
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
+pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -65,6 +65,22 @@ class _StubScreening:
         return self._payload
 
 
+class _EmptyRelationResult:
+    def scalars(self) -> _EmptyRelationResult:
+        return self
+
+    def all(self) -> list[Any]:
+        return []
+
+
+class _EmptyRelationSession:
+    async def execute(self, stmt: Any) -> _EmptyRelationResult:  # noqa: ARG002
+        return _EmptyRelationResult()
+
+    async def rollback(self) -> None:
+        return None
+
+
 def _build_app(stub_screening: _StubScreening | None = None) -> FastAPI:
     app = FastAPI()
     app.include_router(invest_api_router)
@@ -74,6 +90,11 @@ def _build_app(stub_screening: _StubScreening | None = None) -> FastAPI:
     app.dependency_overrides[get_invest_home_service] = lambda: _StubHomeService()
     if stub_screening is not None:
         app.dependency_overrides[get_screener_service_dep] = lambda: stub_screening
+
+    async def _override_get_db():
+        yield _EmptyRelationSession()
+
+    app.dependency_overrides[get_db] = _override_get_db
     return app
 
 

--- a/tests/test_investment_report_item_evidence.py
+++ b/tests/test_investment_report_item_evidence.py
@@ -62,6 +62,7 @@ def test_evidence_payload_forbids_unknown_keys():
         ItemEvidencePayload(source="s", bogus_field="x")
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_structured_evidence_round_trips_through_ingestion(session) -> None:
     """create→저장→read에서 structured_evidence/item_freshness가 노출된다."""
@@ -105,6 +106,7 @@ async def test_structured_evidence_round_trips_through_ingestion(session) -> Non
     assert snap["item_freshness"] == "fresh"
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_no_evidence_leaves_snapshot_keys_absent(session) -> None:
     """evidence 미지정 시 reserved key를 추가하지 않는다(기존 동작 무변화)."""
@@ -257,6 +259,7 @@ def test_item_rejects_caller_supplied_trade_setup_reserved_key():
     assert "reserved evidence_snapshot keys" in str(exc.value)
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_trade_plan_fields_round_trip_through_evidence_snapshot(session) -> None:
     from app.schemas.investment_reports import IngestReportRequest
@@ -348,6 +351,7 @@ async def _ingest_single_item_report(
     return items[0].evidence_snapshot or {}
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_trade_setup_attached_for_long_buy(session) -> None:
     snap = await _ingest_single_item_report(
@@ -368,6 +372,7 @@ async def test_trade_setup_attached_for_long_buy(session) -> None:
     assert snap["trade_setup"]["headline"]["rr_ratio"] == "1.60"
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_trade_setup_skipped_for_sell_exit(session) -> None:
     """Pure long sell-exit — R:R is not the right frame (ROB-691 realized P/L)."""
@@ -388,6 +393,7 @@ async def test_trade_setup_skipped_for_sell_exit(session) -> None:
     assert "trade_setup" not in snap
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_trade_setup_skipped_on_fail_closed_price_mismatch(session) -> None:
     """Long direction but stop above entry — inconsistent triangle, fail-closed
@@ -409,6 +415,7 @@ async def test_trade_setup_skipped_on_fail_closed_price_mismatch(session) -> Non
     assert "trade_setup" not in snap
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_trade_setup_explicit_short_direction(session) -> None:
     snap = await _ingest_single_item_report(
@@ -496,6 +503,7 @@ def test_evidence_snapshot_invalidation_triggers_key_alone_is_not_a_conflict():
     assert item.evidence_snapshot["invalidation_triggers"] == ["raw only"]
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_trade_setup_skipped_when_target_price_missing(session) -> None:
     snap = await _ingest_single_item_report(

--- a/tests/test_kis_order_history_pagination_rob903.py
+++ b/tests/test_kis_order_history_pagination_rob903.py
@@ -127,12 +127,18 @@ class TestOverseasDisplayPaginationRob903:
         sleep_mock.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_default_paginates_exhaustively_reconcile_invariant(self):
+    async def test_default_paginates_exhaustively_reconcile_invariant(
+        self, monkeypatch
+    ):
         """RECONCILE LOCK: defaults must keep exhaustive pagination — a duplicate
         cursor still runs to max_pages and raises, exactly as today."""
         instance, parent = _make_overseas_client()
         parent._request_with_rate_limit = AsyncMock(
             side_effect=[_dup_cursor_page(f"NK{i}") for i in range(500)]
+        )
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr(
+            "app.services.brokers.kis.overseas_orders.asyncio.sleep", sleep_mock
         )
 
         with pytest.raises(RuntimeError, match="truncated"):
@@ -140,6 +146,8 @@ class TestOverseasDisplayPaginationRob903:
                 start_date="20260317", end_date="20260317", max_pages=100
             )
         assert parent._request_with_rate_limit.call_count == 100
+        assert sleep_mock.await_count == 99
+        assert all(call.args == (0.1,) for call in sleep_mock.await_args_list)
 
     @pytest.mark.asyncio
     async def test_default_delay_still_sleeps_between_pages(self, monkeypatch):
@@ -199,7 +207,9 @@ class TestDomesticDisplayPaginationRob903:
         assert result == [{"odno": "001", "pdno": "005930"}]
 
     @pytest.mark.asyncio
-    async def test_default_paginates_exhaustively_reconcile_invariant(self):
+    async def test_default_paginates_exhaustively_reconcile_invariant(
+        self, monkeypatch
+    ):
         instance, parent = _make_domestic_client()
         parent._request_with_rate_limit = AsyncMock(
             side_effect=[
@@ -212,12 +222,18 @@ class TestDomesticDisplayPaginationRob903:
                 for i in range(500)
             ]
         )
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr(
+            "app.services.brokers.kis.domestic_orders.asyncio.sleep", sleep_mock
+        )
 
         with pytest.raises(RuntimeError, match="truncated"):
             await instance.inquire_daily_order_domestic(
                 start_date="20260317", end_date="20260317", max_pages=100
             )
         assert parent._request_with_rate_limit.call_count == 100
+        assert sleep_mock.await_count == 99
+        assert all(call.args == (0.1,) for call in sleep_mock.await_args_list)
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_recommend_flow.py
+++ b/tests/test_mcp_recommend_flow.py
@@ -17,6 +17,7 @@ from tests._mcp_recommend_support import _mock_empty_holdings, _mock_kr_sources
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
+pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 
 def _mock_crypto_screen(

--- a/tests/test_mcp_screen_stocks_crypto.py
+++ b/tests/test_mcp_screen_stocks_crypto.py
@@ -10,6 +10,7 @@ from app.mcp_server.tooling.screening import crypto as screening_crypto
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
+pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 
 class TestScreenStocksCrypto:

--- a/tests/test_mcp_screen_stocks_filters_and_rsi.py
+++ b/tests/test_mcp_screen_stocks_filters_and_rsi.py
@@ -10,6 +10,7 @@ from app.mcp_server.tooling.screening import us as screening_us
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
+pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 
 class TestScreenStocksRsiLogging:

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -25,6 +25,7 @@ from tests._mcp_screen_stocks_support import (
 )
 
 pytest_plugins = ("tests._mcp_screen_stocks_support",)
+pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 __all__ = [
     "TestScreenStocksKR",

--- a/tests/test_mcp_screen_stocks_tvscreener_contract.py
+++ b/tests/test_mcp_screen_stocks_tvscreener_contract.py
@@ -13,6 +13,7 @@ from app.services.tvscreener_service import (
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
+pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_merge_test_durations.py
+++ b/tests/test_merge_test_durations.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.merge_test_durations import merge_duration_shards
+
+pytestmark = pytest.mark.unit
+
+
+def _write_json(path: Path, value: object) -> Path:
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def _write_manifest(path: Path, *node_ids: str) -> Path:
+    path.write_text("\n".join(node_ids) + "\n", encoding="utf-8")
+    return path
+
+
+def test_merge_replaces_measurements_and_drops_stale_entries(tmp_path: Path) -> None:
+    first = "tests/test_a.py::test_a"
+    second = "tests/test_b.py::test_b"
+    stale = "tests/test_removed.py::test_removed"
+    baseline = _write_json(
+        tmp_path / "baseline.json", {first: 99.0, second: 88.0, stale: 77.0}
+    )
+    shards = [
+        _write_json(tmp_path / "shard-1.json", {first: 1.25}),
+        _write_json(tmp_path / "shard-2.json", {second: 2.5}),
+    ]
+    manifests = [
+        _write_manifest(tmp_path / "collected-1.txt", first, second),
+        _write_manifest(tmp_path / "collected-2.txt", second, first),
+    ]
+
+    merged, stale_count = merge_duration_shards(
+        baseline_path=baseline,
+        shard_paths=shards,
+        collected_paths=manifests,
+    )
+
+    assert merged == {first: 1.25, second: 2.5}
+    assert stale_count == 1
+
+
+def test_merge_fails_when_collected_test_has_no_measurement(tmp_path: Path) -> None:
+    first = "tests/test_a.py::test_a"
+    second = "tests/test_b.py::test_b"
+    baseline = _write_json(tmp_path / "baseline.json", {first: 1.0, second: 2.0})
+    manifest = _write_manifest(tmp_path / "collected.txt", first, second)
+
+    with pytest.raises(ValueError, match="1 collected tests have no measurement"):
+        merge_duration_shards(
+            baseline_path=baseline,
+            shard_paths=[_write_json(tmp_path / "shard.json", {first: 1.5})],
+            collected_paths=[manifest],
+        )
+
+
+def test_merge_rejects_duplicate_shard_entries(tmp_path: Path) -> None:
+    node_id = "tests/test_a.py::test_a"
+    baseline = _write_json(tmp_path / "baseline.json", {node_id: 1.0})
+    manifest = _write_manifest(tmp_path / "collected.txt", node_id)
+
+    with pytest.raises(ValueError, match="duplicate tests across shards"):
+        merge_duration_shards(
+            baseline_path=baseline,
+            shard_paths=[
+                _write_json(tmp_path / "shard-1.json", {node_id: 1.5}),
+                _write_json(tmp_path / "shard-2.json", {node_id: 1.6}),
+            ],
+            collected_paths=[manifest],
+        )
+
+
+def test_merge_rejects_different_collection_manifests(tmp_path: Path) -> None:
+    first = "tests/test_a.py::test_a"
+    second = "tests/test_b.py::test_b"
+    baseline = _write_json(tmp_path / "baseline.json", {first: 1.0})
+
+    with pytest.raises(ValueError, match="collection differs"):
+        merge_duration_shards(
+            baseline_path=baseline,
+            shard_paths=[_write_json(tmp_path / "shard.json", {first: 1.5})],
+            collected_paths=[
+                _write_manifest(tmp_path / "collected-1.txt", first),
+                _write_manifest(tmp_path / "collected-2.txt", first, second),
+            ],
+        )

--- a/tests/test_news_stage_fallback.py
+++ b/tests/test_news_stage_fallback.py
@@ -62,6 +62,16 @@ def _related_symbol_session_factory(rows: list[SimpleNamespace]):
     return lambda: _RelatedRowsSession()
 
 
+@pytest.fixture(autouse=True)
+def _fake_related_symbol_database(monkeypatch):
+    """Keep unit fallback tests off PostgreSQL unless rows are injected."""
+    monkeypatch.setattr(
+        llm_news_service,
+        "AsyncSessionLocal",
+        _related_symbol_session_factory([]),
+    )
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_fallback_exact_symbol_match_returned_first(monkeypatch):
@@ -76,6 +86,11 @@ async def test_fallback_exact_symbol_match_returned_first(monkeypatch):
         llm_news_service,
         "get_news_articles",
         AsyncMock(side_effect=fake_get_news_articles),
+    )
+    monkeypatch.setattr(
+        llm_news_service,
+        "AsyncSessionLocal",
+        _related_symbol_session_factory([]),
     )
 
     result = await llm_news_service.get_news_articles_with_fallback(

--- a/tests/test_rob878_transition_core.py
+++ b/tests/test_rob878_transition_core.py
@@ -1042,10 +1042,10 @@ async def test_save_and_transition_share_lock_order_and_keep_projection(
             )
             await session.commit()
 
-    outcomes = await asyncio.wait_for(
-        asyncio.gather(save(), transition(), return_exceptions=True), timeout=8
-    )
-    assert not any(isinstance(outcome, BaseException) for outcome in outcomes)
+    # Let gather propagate the original exception and traceback. Returning
+    # exceptions here previously reduced a useful DB/lock failure to a boolean
+    # assertion with no indication of which concurrent path failed.
+    await asyncio.wait_for(asyncio.gather(save(), transition()), timeout=8)
     row = await _load_action(db_session, action_id)
     assert row.status == "in_progress" and row.version == 2
     projection = await _projection(db_session, parent_id)

--- a/tests/test_rob878_transition_core.py
+++ b/tests/test_rob878_transition_core.py
@@ -995,8 +995,10 @@ async def test_sibling_transitions_preserve_both_projection_updates(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("first_operation", ["save", "transition"])
 async def test_save_and_transition_share_lock_order_and_keep_projection(
     db_session: AsyncSession,
+    first_operation: str,
 ) -> None:
     from app.services.trade_journal.retrospective_action_repository import (
         RetrospectiveActionRepository,
@@ -1006,6 +1008,8 @@ async def test_save_and_transition_share_lock_order_and_keep_projection(
     )
 
     parent_id, action_id = await _seed_action(db_session, position=0)
+    first_holds_lock = asyncio.Event()
+    release_first = asyncio.Event()
 
     async def save() -> None:
         async with AsyncSessionLocal() as session:
@@ -1018,7 +1022,8 @@ async def test_save_and_transition_share_lock_order_and_keep_projection(
                         "action": "action-0",
                         "owner": None,
                         "issue_id": None,
-                        "status": "open",
+                        # Save must preserve a status concurrently owned by the
+                        # transition API, not replay a stale open snapshot.
                         "due_kst_date": None,
                         "custom": "preserve-0",
                     }
@@ -1026,6 +1031,9 @@ async def test_save_and_transition_share_lock_order_and_keep_projection(
                 "user:save",
                 control_mode="canonical",
             )
+            if first_operation == "save":
+                first_holds_lock.set()
+                await release_first.wait()
             await session.commit()
 
     async def transition() -> None:
@@ -1040,12 +1048,22 @@ async def test_save_and_transition_share_lock_order_and_keep_projection(
                 reason=None,
                 evidence=None,
             )
+            if first_operation == "transition":
+                first_holds_lock.set()
+                await release_first.wait()
             await session.commit()
 
     # Let gather propagate the original exception and traceback. Returning
     # exceptions here previously reduced a useful DB/lock failure to a boolean
     # assertion with no indication of which concurrent path failed.
-    await asyncio.wait_for(asyncio.gather(save(), transition()), timeout=8)
+    operations = {"save": save, "transition": transition}
+    second_operation = "transition" if first_operation == "save" else "save"
+    first_task = asyncio.create_task(operations[first_operation]())
+    await asyncio.wait_for(first_holds_lock.wait(), timeout=3)
+    second_task = asyncio.create_task(operations[second_operation]())
+    await asyncio.sleep(0.1)
+    release_first.set()
+    await asyncio.wait_for(asyncio.gather(first_task, second_task), timeout=8)
     row = await _load_action(db_session, action_id)
     assert row.status == "in_progress" and row.version == 2
     projection = await _projection(db_session, parent_id)

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -27,6 +27,49 @@ class _FakeCM:
         return False
 
 
+@pytest.fixture(autouse=True)
+def _fake_external_boundaries_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep ordinary unit paths hermetic; focused tests override these fakes."""
+
+    async def _empty_positions(
+        market_filter: str | None, *, is_mock: bool = False
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        del market_filter, is_mock
+        return [], []
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings._collect_kis_positions",
+        _empty_positions,
+    )
+
+    async def _no_redis():
+        return None
+
+    async def _identity_enrichment(
+        *,
+        rows: list[dict[str, Any]],
+        market: str,
+        session_factory,
+        opinion_provider=None,
+    ) -> dict[str, Any]:
+        del market, session_factory, opinion_provider
+        return {
+            "results": rows,
+            "summary": {
+                "attempted": len(rows),
+                "consensusSucceeded": 0,
+                "rsiSucceeded": 0,
+                "warnings": [],
+            },
+        }
+
+    monkeypatch.setattr("app.core.analyze_cache._get_redis_client", _no_redis)
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_analysis_enrichment.enrich_snapshot_page",
+        _identity_enrichment,
+    )
+
+
 @pytest.fixture
 def patched(monkeypatch):
     """Patch the session factory, ScreenerService, and build_screener_results."""


### PR DESCRIPTION
## Summary

This addresses the ROB-1051 failure mode observed in CI: xdist workers shared one PostgreSQL database, so broad cleanup and fixed-key fixtures could overwrite one another even though the ROB-723 schema-DDL barrier prevented deadlocks.

- give every xdist worker a run-owned PostgreSQL database and remove it at teardown
- keep pure unit/static selections off PostgreSQL and classify real DB fixture users as integration tests
- make hidden KIS/Redis/DB boundaries deterministic and replace real pagination sleeps with verified fake sleeps
- expose the original ROB878 concurrent exception instead of hiding it behind a boolean assertion
- replace the shared-DB duration refresh with four independent shards plus deterministic completeness-checked merge
- keep the serial correctness gate, add a bounded `-n4 --dist=loadfile` fast loop, cancel superseded branch runs, consolidate H1/H2/H3 setup, and poll TaskIQ readiness

## Measured results

| Scope | Before | After |
|---|---:|---:|
| non-live collection | 18,384 tests / 66.37s | 17,116 tests / 18.58s |
| screener snapshot tests | 70.38s recorded worker-time sum | 28 tests / 2.29s pytest elapsed |
| KIS pagination tests | 19.93s recorded worker-time sum | 8 tests / 1.99s pytest elapsed |
| ROB878 transition file | 116.77s recorded worker-time sum | 76 tests / 52.23s pytest elapsed |
| positive unit loop | 4,675 tests / 106.12s serial wall | 4,675 tests / 57.59s bounded n4 wall |
| TaskIQ worker smoke | fixed 30s timeout wait | readiness observed in 7.76s |
| TaskIQ scheduler smoke | fixed 30s timeout wait | readiness observed in 4.58s |

The net collection reduction is 1,268 nodes: the static LLM guard collapses roughly 1,273 per-file parametrized nodes into one aggregate scan, while four duration-merge tests were added.

Current marker collection:

- non-live: 17,116
- fast unit (`unit and not integration and not slow and not live`): 4,675
- integration: 3,030
- slow: 2
- live: 7

## Validation performed

- `make test-fast`: 4,675 passed in 54.54s pytest / 57.59s wall
- same positive-unit set serially: 4,675 passed in 100.14s pytest / 106.12s wall
- changed unit/static test bundle: 84 passed
- representative worker-isolated DB subset: 6 passed under `-n4 --dist=loadfile`; 0 `test_db_*` databases remained
- ROB878 concurrent test: repeated with fresh xdist worker databases; 10/10 passed
- duration refresh simulation: four shards measured and deterministically merged 43/43 nodes with 0 missing/duplicate nodes
- H1/H2/H3: 203 / 114 / 155 passed in 7.03s / 1.04s / 25.77s
- auth fixture-scope regression: 38 passed
- `ruff check app/ tests/ research/ scripts/`
- `ruff format --check app/ tests/ research/ scripts/` (3,405 files)
- `ty check app/ --error-on-warning`
- both workflow YAML files parsed successfully
- all 38 workflow `run:` blocks passed `bash -n` after expression substitution
- `git diff --check`

## Not executed

These are intentionally reported as unverified rather than implied to have passed:

- the full 17,116-test serial non-live correctness suite
- the approximately four-minute H4 walk-forward suite
- `actionlint` (not installed locally); YAML parsing, `bash -n`, and local four-shard simulation were used instead
- the actual GitHub-hosted duration refresh workflow

## Deliberately not changed

- **H4 path filtering:** retained the unconditional main/PR gate because a path-filtered required check can be bypassed or remain pending depending on branch protection wiring.
- **Redis installation in each shard:** retained because the acceptance suite starts and verifies a real disposable Redis server.
- **transaction/SAVEPOINT conversion:** broad TRUNCATE/advisory-lock cleanup remains inside worker-private databases. Converting cleanup semantics should be a separate incremental PR with domain-specific proof.
- **H4 parallelization:** left unchanged pending dedicated validation of its import and state-isolation assumptions.

## Operator action required

The refresh workflow declares `contents: write` and `pull-requests: write`, but repository/organization Actions policy must also permit write access and enable **Allow GitHub Actions to create and approve pull requests** for the `github.token` fallback to open its PR.

A PR created by `GITHUB_TOKEN` does not normally trigger another workflow run. Configure `DURATIONS_REFRESH_TOKEN` with a PAT/bot token that can write contents and pull requests if the refresh PR should automatically trigger the Test workflow.

## Remaining warnings / follow-up

The fast suite still reports existing warnings, including `AsyncMock` coroutines that were never awaited in research-run/news-related tests. They did not fail this change, but should be fixed next so warnings remain useful as a regression signal.

Other follow-ups: run the duration refresh manually once in GitHub, observe all four production shards under worker DB isolation, then evaluate transaction/SAVEPOINT cleanup per domain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Test execution is now more consistent and reliable across parallel runs.
  - Database-backed checks use isolated test environments to reduce interference.
  - Service readiness checks provide clearer handling of startup and timeout failures.
  - Faster test commands include bounded parallel execution and improved result summaries.
  - Live and integration checks are categorized more accurately for predictable execution.

- **Chores**
  - Automated test-duration updates now use deterministic sharding and validated merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->