### PR TITLE
research(krb1c): independent C_stress_cap reducer reproduction — full-enumeration agreement (§7.7 steps 3–4)

### DIFF
--- a/research/krb1c_reducer_indep/__init__.py
+++ b/research/krb1c_reducer_indep/__init__.py
@@ -1,0 +1,56 @@
+"""KRB1C C_stress_cap deterministic reducer — INDEPENDENT REIMPLEMENTATION.
+
+This package is a clean-room reimplementation of the sealed clause
+
+    KRB1-CSM60-H5-v1 / amendment KRB1C-CSTRESS-REDUCER-v1, §6.2.1
+
+written per §7.7 step 3 ("참조 구현을 import·복사하지 않는 독립 재현기").
+
+Independence contract
+---------------------
+Written solely from the sealed normative text carried in
+
+    krb1c-amendment-canonical-2026-07-28.json
+    sha256 d5da5edd6b49fb759b781c13f627e21a84667ced2be7cf03624a40bb813be389
+
+plus the sealed P0-1 KRX tick table and the sealed P0-2 cost binding.
+The reference implementation was not read, imported, or copied.
+
+Exactness contract
+------------------
+Every numeric quantity is ``int`` or ``fractions.Fraction``. No ``float``,
+no ``decimal.Decimal``, no ``math`` module. Enforced by
+``tests/test_no_float.py`` (AST scan) and by runtime type assertions.
+
+Scope
+-----
+This package performs the §7.7 step-3/step-4 reproduction only. It does NOT
+produce a P0-2 completion hash and is not the "정확히 1회" binding numeric
+reducer execution of §7.2.
+"""
+
+from .tick import (
+    KOSDAQ_TICK_TABLE,
+    KOSPI_TICK_TABLE,
+    TickTable,
+    TickBand,
+)
+from .reducer import (
+    CandidateRow,
+    MarketCostInput,
+    MarketResult,
+    ReducerResult,
+    reduce_c_stress_cap,
+)
+
+__all__ = [
+    "TickBand",
+    "TickTable",
+    "KOSPI_TICK_TABLE",
+    "KOSDAQ_TICK_TABLE",
+    "MarketCostInput",
+    "CandidateRow",
+    "MarketResult",
+    "ReducerResult",
+    "reduce_c_stress_cap",
+]

--- a/research/krb1c_reducer_indep/__init__.py
+++ b/research/krb1c_reducer_indep/__init__.py
@@ -29,18 +29,18 @@ produce a P0-2 completion hash and is not the "정확히 1회" binding numeric
 reducer execution of §7.2.
 """
 
-from .tick import (
-    KOSDAQ_TICK_TABLE,
-    KOSPI_TICK_TABLE,
-    TickTable,
-    TickBand,
-)
 from .reducer import (
     CandidateRow,
     MarketCostInput,
     MarketResult,
     ReducerResult,
     reduce_c_stress_cap,
+)
+from .tick import (
+    KOSDAQ_TICK_TABLE,
+    KOSPI_TICK_TABLE,
+    TickBand,
+    TickTable,
 )
 
 __all__ = [

--- a/research/krb1c_reducer_indep/cli.py
+++ b/research/krb1c_reducer_indep/cli.py
@@ -1,0 +1,270 @@
+"""CLI for the independent §6.2.1 reducer reproduction.
+
+Emits the §7.3~7.6 publication triple into an output directory:
+
+    p0_2_cost_inputs.normalized.json
+    c_stress_candidates.csv          (17 reduced-fraction fields per P)
+    c_stress_reducer_result.json
+
+This is the §7.7 step-3 independent reproduction, NOT the §7.2 "정확히 1회"
+binding numeric reducer execution: it emits no P0-2 completion hash and writes
+nothing outside the chosen output directory. It performs no network, database,
+broker, order, watch or journal access.
+
+Usage:
+    uv run python -m research.krb1c_reducer_indep.cli --out-dir <dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from fractions import Fraction
+from typing import Dict
+
+from .reducer import (
+    MarketCostInput,
+    ReducerFailClosed,
+    ReducerResult,
+    reduce_c_stress_cap,
+)
+from .sealed_input import (
+    AMENDMENT_CANONICAL_SHA256,
+    OFFICIAL_TARIFF_SNAPSHOT_SHA256,
+    PARENT_CANONICAL_SHA256,
+    default_canonical_path,
+    load_from_canonical,
+    sealed_cost_inputs,
+    sealed_records,
+)
+from .tick import KOSDAQ_TICK_TABLE, KOSPI_TICK_TABLE, PRICE_MAX, PRICE_MIN
+
+TABLES = {"KOSPI": KOSPI_TICK_TABLE, "KOSDAQ": KOSDAQ_TICK_TABLE}
+
+CANDIDATE_FIELDS = (
+    "market",
+    "price",
+    "tick_at_price",
+    "rho_entry_num",
+    "rho_entry_den",
+    "exit_witness_q",
+    "tick_at_exit_witness",
+    "rho_exit_num",
+    "rho_exit_den",
+    "entry_multiplier_num",
+    "entry_multiplier_den",
+    "exit_multiplier_cap_num",
+    "exit_multiplier_cap_den",
+    "c_num",
+    "c_den",
+    "c_bp_ceil",
+    "is_market_argmax",
+)
+assert len(CANDIDATE_FIELDS) == 17, "§7.5 requires 17 fields"
+
+
+def frac(value: Fraction) -> Dict[str, int]:
+    """Reduced-fraction rendering. ``Fraction`` is always in lowest terms."""
+    return {"num": value.numerator, "den": value.denominator}
+
+
+def write_candidates_csv(result: ReducerResult, path: str) -> int:
+    rows = 0
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(CANDIDATE_FIELDS)
+        for market in sorted(result.markets):
+            market_result = result.markets[market]
+            for row in market_result.candidates:
+                writer.writerow(
+                    [
+                        row.market,
+                        row.price,
+                        row.tick_at_price,
+                        row.rho_entry.numerator,
+                        row.rho_entry.denominator,
+                        row.exit_witness_q,
+                        row.tick_at_exit_witness,
+                        row.rho_exit.numerator,
+                        row.rho_exit.denominator,
+                        row.entry_multiplier.numerator,
+                        row.entry_multiplier.denominator,
+                        row.exit_multiplier_cap.numerator,
+                        row.exit_multiplier_cap.denominator,
+                        row.c.numerator,
+                        row.c.denominator,
+                        row.c_bp_ceil,
+                        int(row.price == market_result.witness_price),
+                    ]
+                )
+                rows += 1
+    return rows
+
+
+def build_normalized_inputs(costs: Dict[str, MarketCostInput]) -> dict:
+    return {
+        "schema_version": "krb1.p0_2_cost_inputs.v1",
+        "parent_canonical_sha256": PARENT_CANONICAL_SHA256,
+        "amendment_canonical_sha256": AMENDMENT_CANONICAL_SHA256,
+        "official_tariff_snapshot_sha256": OFFICIAL_TARIFF_SNAPSHOT_SHA256,
+        "rate_scale": 10**12,
+        "note": (
+            "Independent reproduction input (§7.7 step 3). Not a sealed P0-2 "
+            "artifact; carries no p0_2_completed_at_kst and no completion hash."
+        ),
+        "market_cost_records": {
+            market: [
+                {
+                    "market": rec.market,
+                    "broker_id": rec.broker_id,
+                    "account_product_id": rec.account_product_id,
+                    "order_channel_id": rec.order_channel_id,
+                    "cost_basis": rec.cost_basis,
+                    "effective_from": rec.effective_from,
+                    "effective_to": rec.effective_to,
+                    "buy_commission_rate_e12": rec.buy_commission_rate_e12,
+                    "sell_commission_rate_e12": rec.sell_commission_rate_e12,
+                    "sell_tax_components": [
+                        {
+                            "component_code": comp.component_code,
+                            "rate_e12": comp.rate_e12,
+                        }
+                        for comp in rec.sell_tax_components
+                    ],
+                    "source_snapshot_sha256": rec.source_snapshot_sha256,
+                    "probe_reconciliation_status": rec.probe_reconciliation_status,
+                    "mock_cost_relation": rec.mock_cost_relation,
+                }
+                for rec in records
+            ]
+            for market, records in sealed_records().items()
+        },
+        "reduced": {
+            market: {
+                "B_m_rate_e12": cost.buy_rate_e12,
+                "S_m_rate_e12": cost.sell_rate_e12,
+                "A_m_rate_e12": cost.sell_tax_rate_e12,
+                "b_m": frac(cost.b),
+                "s_m": frac(cost.s),
+                "tau_m": frac(cost.tau),
+                "a_m": frac(cost.a),
+            }
+            for market, cost in sorted(costs.items())
+        },
+    }
+
+
+def build_result_json(result: ReducerResult) -> dict:
+    return {
+        "reducer_spec_id": result.reducer_spec_id,
+        "implementation": "independent-reproduction",
+        "parent_canonical_sha256": PARENT_CANONICAL_SHA256,
+        "amendment_canonical_sha256": AMENDMENT_CANONICAL_SHA256,
+        "official_tariff_snapshot_sha256": OFFICIAL_TARIFF_SNAPSHOT_SHA256,
+        "price_range": {"min": PRICE_MIN, "max": PRICE_MAX},
+        "c_raw": frac(result.c_raw),
+        "witness_market": result.witness_market,
+        "witness_price": result.witness_price,
+        "c_stress_cap_bp": result.c_stress_cap_bp,
+        "c_stress_cap": frac(result.c_stress_cap),
+        "c_stress_cap_decimal": result.c_stress_cap_decimal,
+        "all_target_checks_passed": result.all_target_checks_passed,
+        "enumerated_candidate_count": result.enumerated_count,
+        "target_check_count": result.target_check_count,
+        "per_market": {
+            market: {
+                "enumerated_count": res.enumerated_count,
+                "c_raw": frac(res.c_raw),
+                "witness_price": res.witness_price,
+                "tick_table_provenance": TABLES[market].provenance,
+                "target_check_count": len(res.target_checks),
+                "target_check_failures": len(
+                    [row for row in res.target_checks if not row.passed]
+                ),
+            }
+            for market, res in sorted(result.markets.items())
+        },
+        "p0_2_completion_hash": None,
+        "p0_2_completion_hash_reason": (
+            "§7.7 step 3 reproduction only; completion hash requires step 4 "
+            "full-enumeration agreement and an independence review PASS."
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="KRB1C C_stress_cap reducer — independent reproduction"
+    )
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument(
+        "--canonical-path",
+        default=default_canonical_path(),
+        help="sealed amendment canonical JSON (hash-verified before use)",
+    )
+    parser.add_argument(
+        "--skip-canonical-check",
+        action="store_true",
+        help="use the transcribed constants without re-reading the canonical",
+    )
+    args = parser.parse_args(argv)
+
+    if args.skip_canonical_check:
+        costs = sealed_cost_inputs()
+    else:
+        costs = load_from_canonical(args.canonical_path)
+
+    try:
+        result = reduce_c_stress_cap(TABLES, costs)
+    except ReducerFailClosed as exc:
+        print(f"FAIL-CLOSED: {exc}", file=sys.stderr)
+        return 2
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    inputs_path = os.path.join(args.out_dir, "p0_2_cost_inputs.normalized.json")
+    csv_path = os.path.join(args.out_dir, "c_stress_candidates.csv")
+    result_path = os.path.join(args.out_dir, "c_stress_reducer_result.json")
+
+    with open(inputs_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            build_normalized_inputs(costs),
+            handle,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    rows = write_candidates_csv(result, csv_path)
+    with open(result_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            build_result_json(result),
+            handle,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+
+    print(f"C_raw            = {result.c_raw} "
+          f"({result.c_raw.numerator}/{result.c_raw.denominator})")
+    print(f"witness          = {result.witness_market} P={result.witness_price}")
+    print(f"C_stress_cap_bp  = {result.c_stress_cap_bp}")
+    print(f"C_stress_cap     = {result.c_stress_cap_decimal}")
+    print(f"candidates       = {rows}")
+    print(f"target checks    = {result.target_check_count} "
+          f"(all passed = {result.all_target_checks_passed})")
+    for market in sorted(result.markets):
+        res = result.markets[market]
+        print(
+            f"  {market:<7} |E_m|={res.enumerated_count} "
+            f"C_raw_m={res.c_raw} witness_P={res.witness_price}"
+        )
+    print(f"artifacts -> {args.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/krb1c_reducer_indep/cli.py
+++ b/research/krb1c_reducer_indep/cli.py
@@ -23,7 +23,6 @@ import json
 import os
 import sys
 from fractions import Fraction
-from typing import Dict
 
 from .reducer import (
     MarketCostInput,
@@ -66,7 +65,7 @@ CANDIDATE_FIELDS = (
 assert len(CANDIDATE_FIELDS) == 17, "§7.5 requires 17 fields"
 
 
-def frac(value: Fraction) -> Dict[str, int]:
+def frac(value: Fraction) -> dict[str, int]:
     """Reduced-fraction rendering. ``Fraction`` is always in lowest terms."""
     return {"num": value.numerator, "den": value.denominator}
 
@@ -104,7 +103,7 @@ def write_candidates_csv(result: ReducerResult, path: str) -> int:
     return rows
 
 
-def build_normalized_inputs(costs: Dict[str, MarketCostInput]) -> dict:
+def build_normalized_inputs(costs: dict[str, MarketCostInput]) -> dict:
     return {
         "schema_version": "krb1.p0_2_cost_inputs.v1",
         "parent_canonical_sha256": PARENT_CANONICAL_SHA256,
@@ -248,14 +247,18 @@ def main(argv: list[str] | None = None) -> int:
             allow_nan=False,
         )
 
-    print(f"C_raw            = {result.c_raw} "
-          f"({result.c_raw.numerator}/{result.c_raw.denominator})")
+    print(
+        f"C_raw            = {result.c_raw} "
+        f"({result.c_raw.numerator}/{result.c_raw.denominator})"
+    )
     print(f"witness          = {result.witness_market} P={result.witness_price}")
     print(f"C_stress_cap_bp  = {result.c_stress_cap_bp}")
     print(f"C_stress_cap     = {result.c_stress_cap_decimal}")
     print(f"candidates       = {rows}")
-    print(f"target checks    = {result.target_check_count} "
-          f"(all passed = {result.all_target_checks_passed})")
+    print(
+        f"target checks    = {result.target_check_count} "
+        f"(all passed = {result.all_target_checks_passed})"
+    )
     for market in sorted(result.markets):
         res = result.markets[market]
         print(

--- a/research/krb1c_reducer_indep/compare_to_reference.py
+++ b/research/krb1c_reducer_indep/compare_to_reference.py
@@ -1,0 +1,205 @@
+"""§7.7 step 4 — full-enumeration comparison against a reference candidate CSV.
+
+Reads a reference ``c_stress_candidates.csv``, runs this independent reducer,
+and compares **every** row on **every** shared field. No sampling.
+
+The reference implementation is not imported or vendored; only its published
+CSV artifact is read, so running this does not compromise the step-3
+independence of the reducer itself.
+
+Field-name mapping is explicit because the two implementations chose different
+column names for the same §5/§6 quantities. Two of each side's 17 columns are
+implementation-specific (this side publishes ``c_bp_ceil`` and
+``is_market_argmax``; the observed reference publishes ``target_price`` and
+``target_check_passed``); ``target_price`` and ``target_check_passed`` are
+recomputed here from this implementation's §6.8/§6.9 output so they can still
+be compared.
+
+Usage:
+    uv run python -m research.krb1c_reducer_indep.compare_to_reference \
+        --reference-csv <path> [--reference-result-json <path>]
+
+Exit code 0 iff there are zero divergences.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from fractions import Fraction
+from typing import Dict, List, Tuple
+
+from .cli import TABLES
+from .reducer import reduce_c_stress_cap
+from .sealed_input import sealed_cost_inputs
+
+# (reference column, this implementation's key)
+FIELD_MAP: Tuple[Tuple[str, str], ...] = (
+    ("entry_price", "price"),
+    ("entry_tick", "tick_at_price"),
+    ("rho_entry_num", "rho_entry_num"),
+    ("rho_entry_den", "rho_entry_den"),
+    ("exit_witness_price", "exit_witness_q"),
+    ("exit_witness_tick", "tick_at_exit_witness"),
+    ("rho_exit_num", "rho_exit_num"),
+    ("rho_exit_den", "rho_exit_den"),
+    ("entry_multiplier_num", "entry_multiplier_num"),
+    ("entry_multiplier_den", "entry_multiplier_den"),
+    ("exit_multiplier_num", "exit_multiplier_cap_num"),
+    ("exit_multiplier_den", "exit_multiplier_cap_den"),
+    ("c_num", "c_num"),
+    ("c_den", "c_den"),
+    ("target_price", "target_price"),
+    ("target_check_passed", "target_check_passed"),
+)
+
+BOOL_FIELDS = {"target_check_passed"}
+
+
+def independent_rows() -> Tuple[Dict[Tuple[str, int], dict], object]:
+    result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
+    rows: Dict[Tuple[str, int], dict] = {}
+    for market, res in result.markets.items():
+        checks = {c.price: c for c in res.target_checks}
+        for row in res.candidates:
+            chk = checks[row.price]
+            rows[(market, row.price)] = {
+                "price": row.price,
+                "tick_at_price": row.tick_at_price,
+                "rho_entry_num": row.rho_entry.numerator,
+                "rho_entry_den": row.rho_entry.denominator,
+                "exit_witness_q": row.exit_witness_q,
+                "tick_at_exit_witness": row.tick_at_exit_witness,
+                "rho_exit_num": row.rho_exit.numerator,
+                "rho_exit_den": row.rho_exit.denominator,
+                "entry_multiplier_num": row.entry_multiplier.numerator,
+                "entry_multiplier_den": row.entry_multiplier.denominator,
+                "exit_multiplier_cap_num": row.exit_multiplier_cap.numerator,
+                "exit_multiplier_cap_den": row.exit_multiplier_cap.denominator,
+                "c_num": row.c.numerator,
+                "c_den": row.c.denominator,
+                "target_price": chk.target,
+                "target_check_passed": chk.passed,
+            }
+    return rows, result
+
+
+def reference_rows(path: str) -> Dict[Tuple[str, int], dict]:
+    rows: Dict[Tuple[str, int], dict] = {}
+    with open(path, encoding="utf-8", newline="") as handle:
+        for rec in csv.DictReader(handle):
+            key = (rec["market"], int(rec["entry_price"]))
+            parsed: dict = {}
+            for ref_name, _ in FIELD_MAP:
+                raw = rec[ref_name]
+                if ref_name in BOOL_FIELDS:
+                    if raw.lower() not in ("true", "false"):
+                        raise ValueError(f"non-boolean {ref_name}: {raw!r}")
+                    parsed[ref_name] = raw.lower() == "true"
+                else:
+                    parsed[ref_name] = int(raw)
+            rows[key] = parsed
+    return rows
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference-csv", required=True)
+    parser.add_argument("--reference-result-json", default=None)
+    args = parser.parse_args(argv)
+
+    mine, result = independent_rows()
+    ref = reference_rows(args.reference_csv)
+
+    only_mine = sorted(set(mine) - set(ref))
+    only_ref = sorted(set(ref) - set(mine))
+    shared = sorted(set(mine) & set(ref))
+
+    print(f"independent rows           : {len(mine)}")
+    print(f"reference rows             : {len(ref)}")
+    print(f"keys only in independent   : {len(only_mine)} {only_mine[:5]}")
+    print(f"keys only in reference     : {len(only_ref)} {only_ref[:5]}")
+
+    mismatches = []
+    comparisons = 0
+    for key in shared:
+        m, r = mine[key], ref[key]
+        for ref_name, my_name in FIELD_MAP:
+            comparisons += 1
+            if m[my_name] != r[ref_name]:
+                mismatches.append((key, ref_name, r[ref_name], m[my_name]))
+
+    value_mismatches = sum(
+        1
+        for key in shared
+        if Fraction(mine[key]["c_num"], mine[key]["c_den"])
+        != Fraction(ref[key]["c_num"], ref[key]["c_den"])
+    )
+
+    print(f"rows compared              : {len(shared)}")
+    print(f"field comparisons          : {comparisons}")
+    print(f"field mismatches           : {len(mismatches)}")
+    for item in mismatches[:50]:
+        print(f"  MISMATCH key={item[0]} field={item[1]} ref={item[2]} mine={item[3]}")
+    print(f"c-value mismatches         : {value_mismatches}")
+
+    scalar_bad = 0
+    if args.reference_result_json:
+        with open(args.reference_result_json, encoding="utf-8") as handle:
+            ref_result = json.load(handle)
+        scalars = {
+            "c_raw_num": (result.c_raw.numerator, ref_result.get("c_raw_num")),
+            "c_raw_den": (result.c_raw.denominator, ref_result.get("c_raw_den")),
+            "c_stress_cap_bp": (
+                result.c_stress_cap_bp,
+                ref_result.get("c_stress_cap_bp"),
+            ),
+            "c_stress_cap_decimal": (
+                result.c_stress_cap_decimal,
+                ref_result.get("c_stress_cap_decimal"),
+            ),
+            "witness_market": (
+                result.witness_market,
+                ref_result.get("witness_market"),
+            ),
+            "witness_price": (
+                result.witness_price,
+                ref_result.get("witness_entry_price"),
+            ),
+            "all_target_checks_passed": (
+                result.all_target_checks_passed,
+                ref_result.get("all_target_checks_passed"),
+            ),
+            "candidate_count_total": (
+                result.enumerated_count,
+                ref_result.get("candidate_count_total"),
+            ),
+        }
+        print("\nscalar comparison:")
+        for name, (mine_v, ref_v) in scalars.items():
+            ok = mine_v == ref_v
+            scalar_bad += 0 if ok else 1
+            print(f"  {'OK ' if ok else 'BAD'} {name}: mine={mine_v!r} ref={ref_v!r}")
+
+    total = (
+        len(only_mine)
+        + len(only_ref)
+        + len(mismatches)
+        + value_mismatches
+        + scalar_bad
+    )
+    print(f"\nTOTAL DIVERGENCES: {total}")
+    if total:
+        print(
+            "\n§8.7 — divergence must be resolved by exact-rational "
+            "full-enumeration comparison. Do NOT pick the larger/smaller/mean/"
+            "more-favourable value, and do not generate a completion hash.",
+            file=sys.stderr,
+        )
+    return 0 if total == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/krb1c_reducer_indep/compare_to_reference.py
+++ b/research/krb1c_reducer_indep/compare_to_reference.py
@@ -29,14 +29,13 @@ import csv
 import json
 import sys
 from fractions import Fraction
-from typing import Dict, List, Tuple
 
 from .cli import TABLES
 from .reducer import reduce_c_stress_cap
 from .sealed_input import sealed_cost_inputs
 
 # (reference column, this implementation's key)
-FIELD_MAP: Tuple[Tuple[str, str], ...] = (
+FIELD_MAP: tuple[tuple[str, str], ...] = (
     ("entry_price", "price"),
     ("entry_tick", "tick_at_price"),
     ("rho_entry_num", "rho_entry_num"),
@@ -58,9 +57,9 @@ FIELD_MAP: Tuple[Tuple[str, str], ...] = (
 BOOL_FIELDS = {"target_check_passed"}
 
 
-def independent_rows() -> Tuple[Dict[Tuple[str, int], dict], object]:
+def independent_rows() -> tuple[dict[tuple[str, int], dict], object]:
     result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
-    rows: Dict[Tuple[str, int], dict] = {}
+    rows: dict[tuple[str, int], dict] = {}
     for market, res in result.markets.items():
         checks = {c.price: c for c in res.target_checks}
         for row in res.candidates:
@@ -86,8 +85,8 @@ def independent_rows() -> Tuple[Dict[Tuple[str, int], dict], object]:
     return rows, result
 
 
-def reference_rows(path: str) -> Dict[Tuple[str, int], dict]:
-    rows: Dict[Tuple[str, int], dict] = {}
+def reference_rows(path: str) -> dict[tuple[str, int], dict]:
+    rows: dict[tuple[str, int], dict] = {}
     with open(path, encoding="utf-8", newline="") as handle:
         for rec in csv.DictReader(handle):
             key = (rec["market"], int(rec["entry_price"]))
@@ -104,7 +103,7 @@ def reference_rows(path: str) -> Dict[Tuple[str, int], dict]:
     return rows
 
 
-def main(argv: List[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--reference-csv", required=True)
     parser.add_argument("--reference-result-json", default=None)
@@ -184,11 +183,7 @@ def main(argv: List[str] | None = None) -> int:
             print(f"  {'OK ' if ok else 'BAD'} {name}: mine={mine_v!r} ref={ref_v!r}")
 
     total = (
-        len(only_mine)
-        + len(only_ref)
-        + len(mismatches)
-        + value_mismatches
-        + scalar_bad
+        len(only_mine) + len(only_ref) + len(mismatches) + value_mismatches + scalar_bad
     )
     print(f"\nTOTAL DIVERGENCES: {total}")
     if total:

--- a/research/krb1c_reducer_indep/reducer.py
+++ b/research/krb1c_reducer_indep/reducer.py
@@ -1,0 +1,505 @@
+"""§6.2.1 C_stress_cap deterministic reducer — independent reimplementation.
+
+Exact rational throughout: every quantity is ``int`` or ``fractions.Fraction``.
+``float``, ``decimal.Decimal`` and ``math`` are never used or imported.
+
+Clause map
+----------
+§1.4  stress components = buy fee + sell fee + sell taxes + 1 entry tick +
+      1 exit tick, additive shortfall; no second-order fee on the synthetic
+      move.
+§2.9  rate_e12 = cost per 1 KRW × 1e12, non-negative integer.
+§3    RATE_SCALE = 1e12. B_m / S_m / A_m are each *independently* the maximum
+      over the market's effective records (no averaging, no trading-day
+      weighting, no same-record assumption). No cross-market averaging/copy.
+§4.8  rho_entry = tick(P)/P ; rho_exit = max over X_m(P) of tick(Q)/Q,
+      witness = least Q attaining the max.
+§5    entry_multiplier   = 1 + b_m + rho_entry(P)
+      exit_multiplier_cap = 1 - s_m - tau_m - rho_exit(P)   (> 0 required)
+      c_m(P) = entry_multiplier / exit_multiplier_cap - 1
+      (the additive approximation b+s+tau+2*tick/P is explicitly non-binding).
+§6    C_raw_m = max over P in E_m of c_m(P), witness = least P at a tie.
+      C_raw   = max(KOSPI, KOSDAQ), witness market = KOSPI at a tie.
+      C_stress_cap_bp = ceil(10_000 * C_raw) = (10_000*A + D - 1) // D
+      for C_raw = A/D in lowest terms; cap = bp / 10_000. Never nearest.
+§6.8  T_i = tick_ceil(L * (1 + cap)), exact rational product then tick_ceil.
+§6.9  For every market and every P: T(P)*(1 - s - tau - tick(T)/T)
+      >= P*(1 + b + tick(P)/P). One false row => P0-2 FAIL.
+§8.1  fail-closed conditions surfaced as ``ReducerFailClosed``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fractions import Fraction
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .tick import PRICE_MAX, PRICE_MIN, TickTable
+
+# §3 — RATE_SCALE = 1e12, written as an exact integer power.
+RATE_SCALE: int = 10**12
+
+# §6 — basis-point denominator.
+BP_SCALE: int = 10_000
+
+# §6 — witness market at a tie between the two markets.
+MARKET_TIE_WINNER: str = "KOSPI"
+
+ONE = Fraction(1)
+
+
+class ReducerFailClosed(Exception):
+    """P0-2 FAIL / NOT_DISCRIMINABLE (§8.1). Carries the clause reference."""
+
+    def __init__(self, clause: str, message: str) -> None:
+        super().__init__(f"[{clause}] {message}")
+        self.clause = clause
+        self.message = message
+
+
+# --------------------------------------------------------------------------
+# §2 input contract
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SellTaxComponent:
+    """§2.5 sell_tax_components entry — ``component_code`` unique per record."""
+
+    component_code: str
+    rate_e12: int
+
+
+@dataclass(frozen=True)
+class CostRecord:
+    """One §2.5 market_cost_record, reduced to the three numeric fields §2.17
+    permits the reducer to consume, plus the identity fields §8.1 checks."""
+
+    market: str
+    buy_commission_rate_e12: int
+    sell_commission_rate_e12: int
+    sell_tax_components: Tuple[SellTaxComponent, ...]
+    cost_basis: str = "REAL_TRADING_TARIFF"
+    effective_from: Optional[str] = None
+    effective_to: Optional[str] = None
+    source_snapshot_sha256: Optional[str] = None
+    probe_reconciliation_status: str = "PASS"
+    mock_cost_relation: str = "DIFFERENT"
+    broker_id: Optional[str] = None
+    account_product_id: Optional[str] = None
+    order_channel_id: Optional[str] = None
+
+    def total_sell_tax_rate_e12(self) -> int:
+        """Sum of this record's sell tax components (§ⓒ decomposition)."""
+        return sum(c.rate_e12 for c in self.sell_tax_components)
+
+
+@dataclass(frozen=True)
+class MarketCostInput:
+    """§3 per-market reduction: B_m, S_m, A_m as independent period maxima."""
+
+    market: str
+    buy_rate_e12: int
+    sell_rate_e12: int
+    sell_tax_rate_e12: int
+
+    @property
+    def b(self) -> Fraction:
+        return Fraction(self.buy_rate_e12, RATE_SCALE)
+
+    @property
+    def s(self) -> Fraction:
+        return Fraction(self.sell_rate_e12, RATE_SCALE)
+
+    @property
+    def tau(self) -> Fraction:
+        return Fraction(self.sell_tax_rate_e12, RATE_SCALE)
+
+    @property
+    def a(self) -> Fraction:
+        """a_m = s_m + tau_m (§3)."""
+        return self.s + self.tau
+
+
+def reduce_records(market: str, records: Sequence[CostRecord]) -> MarketCostInput:
+    """§3 — independent period maxima of B_m, S_m, A_m over effective records.
+
+    Deliberately three separate ``max`` calls: entry and exit may straddle a
+    rate-change date, so the three maxima need not come from one record.
+    """
+    if not records:
+        raise ReducerFailClosed("8.1(a)", f"no cost record for market {market}")
+
+    for rec in records:
+        if rec.market != market:
+            raise ReducerFailClosed(
+                "8.1(d)", f"record market {rec.market!r} != {market!r}"
+            )
+        if rec.cost_basis != "REAL_TRADING_TARIFF":
+            raise ReducerFailClosed(
+                "2.5",
+                f"{market}: cost_basis must be REAL_TRADING_TARIFF, "
+                f"got {rec.cost_basis!r} (mock 표시 요율 사용 금지)",
+            )
+        if rec.probe_reconciliation_status != "PASS":
+            raise ReducerFailClosed(
+                "8.1(i)",
+                f"{market}: probe_reconciliation_status="
+                f"{rec.probe_reconciliation_status!r}, PASS required",
+            )
+        if not rec.source_snapshot_sha256:
+            raise ReducerFailClosed(
+                "8.1(c)", f"{market}: source_snapshot_sha256 missing"
+            )
+        _require_rate_e12(rec.buy_commission_rate_e12, f"{market} buy")
+        _require_rate_e12(rec.sell_commission_rate_e12, f"{market} sell")
+        if not rec.sell_tax_components:
+            raise ReducerFailClosed(
+                "8.1(g)", f"{market}: sell_tax_components empty"
+            )
+        seen: set = set()
+        for comp in rec.sell_tax_components:
+            if comp.component_code in seen:
+                raise ReducerFailClosed(
+                    "8.1(g)",
+                    f"{market}: duplicate component_code {comp.component_code!r}",
+                )
+            seen.add(comp.component_code)
+            _require_rate_e12(comp.rate_e12, f"{market} {comp.component_code}")
+
+    return MarketCostInput(
+        market=market,
+        buy_rate_e12=max(r.buy_commission_rate_e12 for r in records),
+        sell_rate_e12=max(r.sell_commission_rate_e12 for r in records),
+        sell_tax_rate_e12=max(r.total_sell_tax_rate_e12() for r in records),
+    )
+
+
+def _require_rate_e12(value: object, label: str) -> None:
+    """§2.9 / §8.1(e) — rate_e12 must be a non-negative integer."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ReducerFailClosed(
+            "8.1(e)", f"{label}: rate_e12 must be an integer, got {value!r}"
+        )
+    if value < 0:
+        raise ReducerFailClosed(
+            "8.1(e)", f"{label}: rate_e12 must be >= 0, got {value}"
+        )
+
+
+# --------------------------------------------------------------------------
+# §4.8 / §5 per-price quantities
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CandidateRow:
+    """One row of the §7.5 ``c_stress_candidates.csv`` publication."""
+
+    market: str
+    price: int
+    tick_at_price: int
+    rho_entry: Fraction
+    exit_witness_q: int
+    tick_at_exit_witness: int
+    rho_exit: Fraction
+    entry_multiplier: Fraction
+    exit_multiplier_cap: Fraction
+    c: Fraction
+
+    @property
+    def c_bp_ceil(self) -> int:
+        """Per-price ceil to bp — diagnostic; the binding ceil is on C_raw."""
+        return ceil_to_bp(self.c)
+
+
+def rho_entry_of(table: TickTable, price: int) -> Fraction:
+    """§4.8 — rho_entry = tick(P)/P, exact rational."""
+    return Fraction(table.tick(price), price)
+
+
+def rho_exit_of(table: TickTable, price: int) -> Tuple[Fraction, int]:
+    """§4.8 — (rho_exit, witness Q). Tie broken by the least Q.
+
+    Maximum is taken over the finite candidate set X_m(P) of §4.6, which §4.7
+    proves equals the supremum over all valid Q >= P.
+    """
+    best: Optional[Fraction] = None
+    witness = 0
+    for q in table.exit_candidates(price):  # ascending, so ">" keeps least Q
+        ratio = Fraction(table.tick(q), q)
+        if best is None or ratio > best:
+            best = ratio
+            witness = q
+    if best is None:  # pragma: no cover - X_m(P) always contains P
+        raise ReducerFailClosed("4.6", f"empty exit candidate set at {price}")
+    return best, witness
+
+
+def candidate_at(
+    table: TickTable, cost: MarketCostInput, price: int
+) -> CandidateRow:
+    """§5 — the stress break-even cost rate c_m(P) at one price."""
+    rho_entry = rho_entry_of(table, price)
+    rho_exit, witness = rho_exit_of(table, price)
+
+    entry_multiplier = ONE + cost.b + rho_entry
+    exit_multiplier_cap = ONE - cost.s - cost.tau - rho_exit
+
+    # §5 / §8.1(k) — must be strictly positive at every P.
+    if exit_multiplier_cap <= 0:
+        raise ReducerFailClosed(
+            "8.1(k)",
+            f"{table.market} P={price}: exit_multiplier_cap="
+            f"{exit_multiplier_cap} <= 0",
+        )
+
+    c = entry_multiplier / exit_multiplier_cap - ONE
+
+    return CandidateRow(
+        market=table.market,
+        price=price,
+        tick_at_price=table.tick(price),
+        rho_entry=rho_entry,
+        exit_witness_q=witness,
+        tick_at_exit_witness=table.tick(witness),
+        rho_exit=rho_exit,
+        entry_multiplier=entry_multiplier,
+        exit_multiplier_cap=exit_multiplier_cap,
+        c=c,
+    )
+
+
+# --------------------------------------------------------------------------
+# §6 worst point, market combination, rounding
+# --------------------------------------------------------------------------
+
+
+def ceil_to_bp(value: Fraction) -> int:
+    """§6 — ceil(10_000 * value) via ``(10_000*A + D - 1) // D``, exact.
+
+    Exactly on a bp boundary adds nothing; strictly between boundaries rounds
+    up. Nearest-rounding is forbidden.
+    """
+    if not isinstance(value, Fraction):  # pragma: no cover
+        raise ReducerFailClosed("6", f"ceil_to_bp needs a Fraction, got {value!r}")
+    a, d = value.numerator, value.denominator
+    return (BP_SCALE * a + d - 1) // d
+
+
+def bp_to_decimal_string(bp: int) -> str:
+    """§6 canonical decimal rendering: cap = bp/10_000 as 4 decimal places.
+
+    Pure integer string surgery — no float, no Decimal.
+    """
+    if isinstance(bp, bool) or not isinstance(bp, int):  # pragma: no cover
+        raise ReducerFailClosed("6", f"bp must be an int, got {bp!r}")
+    sign = "-" if bp < 0 else ""
+    n = -bp if bp < 0 else bp
+    return f"{sign}{n // BP_SCALE}.{n % BP_SCALE:04d}"
+
+
+@dataclass(frozen=True)
+class TargetCheckRow:
+    """One §6.9 self-check row."""
+
+    market: str
+    price: int
+    target: int
+    lhs: Fraction
+    rhs: Fraction
+    passed: bool
+
+
+@dataclass
+class MarketResult:
+    """Per-market §6 outcome plus the full candidate enumeration."""
+
+    market: str
+    cost: MarketCostInput
+    candidates: List[CandidateRow]
+    c_raw: Fraction
+    witness_price: int
+    target_checks: List[TargetCheckRow] = field(default_factory=list)
+
+    @property
+    def enumerated_count(self) -> int:
+        return len(self.candidates)
+
+
+@dataclass
+class ReducerResult:
+    """§6/§7.6 reducer output."""
+
+    reducer_spec_id: str
+    markets: Dict[str, MarketResult]
+    c_raw: Fraction
+    witness_market: str
+    witness_price: int
+    c_stress_cap_bp: int
+    c_stress_cap: Fraction
+    c_stress_cap_decimal: str
+    all_target_checks_passed: bool
+    target_check_failures: List[TargetCheckRow] = field(default_factory=list)
+
+    @property
+    def enumerated_count(self) -> int:
+        return sum(m.enumerated_count for m in self.markets.values())
+
+    @property
+    def target_check_count(self) -> int:
+        return sum(len(m.target_checks) for m in self.markets.values())
+
+
+def reduce_market(
+    table: TickTable,
+    cost: MarketCostInput,
+    price_min: int = PRICE_MIN,
+    price_max: int = PRICE_MAX,
+) -> MarketResult:
+    """§6 — C_raw_m = max over the full enumeration of E_m; least P at a tie."""
+    if table.market != cost.market:
+        raise ReducerFailClosed(
+            "3", f"tick table {table.market!r} vs cost {cost.market!r} mismatch"
+        )
+
+    prices = table.valid_prices(price_min, price_max)
+    if not prices:
+        raise ReducerFailClosed(
+            "4.5", f"{table.market}: E_m is empty on [{price_min},{price_max}]"
+        )
+
+    candidates: List[CandidateRow] = []
+    best: Optional[Fraction] = None
+    witness = 0
+    for price in prices:
+        row = candidate_at(table, cost, price)
+        candidates.append(row)
+        # ascending prices + strict ">" ⇒ the least P wins any tie (§6)
+        if best is None or row.c > best:
+            best = row.c
+            witness = price
+
+    assert best is not None
+    return MarketResult(
+        market=table.market,
+        cost=cost,
+        candidates=candidates,
+        c_raw=best,
+        witness_price=witness,
+    )
+
+
+def run_target_checks(
+    table: TickTable,
+    cost: MarketCostInput,
+    cap: Fraction,
+    prices: Sequence[int],
+) -> List[TargetCheckRow]:
+    """§6.8 + §6.9 — build T(P) and verify the break-even inequality.
+
+    ``T = tick_ceil(P * (1 + cap))`` with the product kept as an exact
+    rational; the inequality compared is exactly the one in §6.9,
+
+        T * (1 - s - tau - tick(T)/T)  >=  P * (1 + b + tick(P)/P)
+
+    with both sides exact Fractions.
+    """
+    rows: List[TargetCheckRow] = []
+    for price in prices:
+        target = table.tick_ceil(Fraction(price) * (ONE + cap))
+        lhs = target * (
+            ONE - cost.s - cost.tau - Fraction(table.tick(target), target)
+        )
+        rhs = price * (ONE + cost.b + Fraction(table.tick(price), price))
+        rows.append(
+            TargetCheckRow(
+                market=table.market,
+                price=price,
+                target=target,
+                lhs=lhs,
+                rhs=rhs,
+                passed=lhs >= rhs,
+            )
+        )
+    return rows
+
+
+def reduce_c_stress_cap(
+    tables: Mapping[str, TickTable],
+    costs: Mapping[str, MarketCostInput],
+    price_min: int = PRICE_MIN,
+    price_max: int = PRICE_MAX,
+    reducer_spec_id: str = "KRB1C-CSTRESS-REDUCER-v1",
+) -> ReducerResult:
+    """Full §6.2.1 reduction over every configured market.
+
+    Raises ``ReducerFailClosed`` on any §8.1 condition, including a §6.9
+    target-check failure — the clause forbids sealing on even one false row.
+    """
+    if set(tables) != set(costs):
+        raise ReducerFailClosed(
+            "8.1(a)",
+            f"market sets differ: tables={sorted(tables)} costs={sorted(costs)}",
+        )
+    if not tables:
+        raise ReducerFailClosed("8.1(a)", "no markets supplied")
+
+    results: Dict[str, MarketResult] = {}
+    for market in sorted(tables):
+        results[market] = reduce_market(
+            tables[market], costs[market], price_min, price_max
+        )
+
+    # §6 — C_raw = max(KOSPI, KOSDAQ); at a tie the witness market is KOSPI
+    # (the value is unaffected, only the recorded witness).
+    c_raw: Optional[Fraction] = None
+    witness_market = ""
+    for market in sorted(results):
+        candidate = results[market].c_raw
+        if c_raw is None or candidate > c_raw:
+            c_raw, witness_market = candidate, market
+        elif candidate == c_raw and market == MARKET_TIE_WINNER:
+            witness_market = market
+    assert c_raw is not None
+
+    if c_raw < 0:
+        raise ReducerFailClosed("1.1", f"C_raw must be non-negative, got {c_raw}")
+
+    bp = ceil_to_bp(c_raw)
+    cap = Fraction(bp, BP_SCALE)
+
+    failures: List[TargetCheckRow] = []
+    for market in sorted(results):
+        res = results[market]
+        res.target_checks = run_target_checks(
+            tables[market],
+            costs[market],
+            cap,
+            [row.price for row in res.candidates],
+        )
+        failures.extend(row for row in res.target_checks if not row.passed)
+
+    result = ReducerResult(
+        reducer_spec_id=reducer_spec_id,
+        markets=results,
+        c_raw=c_raw,
+        witness_market=witness_market,
+        witness_price=results[witness_market].witness_price,
+        c_stress_cap_bp=bp,
+        c_stress_cap=cap,
+        c_stress_cap_decimal=bp_to_decimal_string(bp),
+        all_target_checks_passed=not failures,
+        target_check_failures=failures,
+    )
+
+    if failures:
+        first = failures[0]
+        raise ReducerFailClosed(
+            "6.9",
+            f"{len(failures)} target check(s) failed; first: "
+            f"{first.market} P={first.price} T={first.target} "
+            f"lhs={first.lhs} < rhs={first.rhs}",
+        )
+
+    return result

--- a/research/krb1c_reducer_indep/reducer.py
+++ b/research/krb1c_reducer_indep/reducer.py
@@ -30,9 +30,9 @@ Clause map
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from fractions import Fraction
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .tick import PRICE_MAX, PRICE_MIN, TickTable
 
@@ -78,16 +78,16 @@ class CostRecord:
     market: str
     buy_commission_rate_e12: int
     sell_commission_rate_e12: int
-    sell_tax_components: Tuple[SellTaxComponent, ...]
+    sell_tax_components: tuple[SellTaxComponent, ...]
     cost_basis: str = "REAL_TRADING_TARIFF"
-    effective_from: Optional[str] = None
-    effective_to: Optional[str] = None
-    source_snapshot_sha256: Optional[str] = None
+    effective_from: str | None = None
+    effective_to: str | None = None
+    source_snapshot_sha256: str | None = None
     probe_reconciliation_status: str = "PASS"
     mock_cost_relation: str = "DIFFERENT"
-    broker_id: Optional[str] = None
-    account_product_id: Optional[str] = None
-    order_channel_id: Optional[str] = None
+    broker_id: str | None = None
+    account_product_id: str | None = None
+    order_channel_id: str | None = None
 
     def total_sell_tax_rate_e12(self) -> int:
         """Sum of this record's sell tax components (§ⓒ decomposition)."""
@@ -154,9 +154,7 @@ def reduce_records(market: str, records: Sequence[CostRecord]) -> MarketCostInpu
         _require_rate_e12(rec.buy_commission_rate_e12, f"{market} buy")
         _require_rate_e12(rec.sell_commission_rate_e12, f"{market} sell")
         if not rec.sell_tax_components:
-            raise ReducerFailClosed(
-                "8.1(g)", f"{market}: sell_tax_components empty"
-            )
+            raise ReducerFailClosed("8.1(g)", f"{market}: sell_tax_components empty")
         seen: set = set()
         for comp in rec.sell_tax_components:
             if comp.component_code in seen:
@@ -218,13 +216,13 @@ def rho_entry_of(table: TickTable, price: int) -> Fraction:
     return Fraction(table.tick(price), price)
 
 
-def rho_exit_of(table: TickTable, price: int) -> Tuple[Fraction, int]:
+def rho_exit_of(table: TickTable, price: int) -> tuple[Fraction, int]:
     """§4.8 — (rho_exit, witness Q). Tie broken by the least Q.
 
     Maximum is taken over the finite candidate set X_m(P) of §4.6, which §4.7
     proves equals the supremum over all valid Q >= P.
     """
-    best: Optional[Fraction] = None
+    best: Fraction | None = None
     witness = 0
     for q in table.exit_candidates(price):  # ascending, so ">" keeps least Q
         ratio = Fraction(table.tick(q), q)
@@ -236,9 +234,7 @@ def rho_exit_of(table: TickTable, price: int) -> Tuple[Fraction, int]:
     return best, witness
 
 
-def candidate_at(
-    table: TickTable, cost: MarketCostInput, price: int
-) -> CandidateRow:
+def candidate_at(table: TickTable, cost: MarketCostInput, price: int) -> CandidateRow:
     """§5 — the stress break-even cost rate c_m(P) at one price."""
     rho_entry = rho_entry_of(table, price)
     rho_exit, witness = rho_exit_of(table, price)
@@ -250,8 +246,7 @@ def candidate_at(
     if exit_multiplier_cap <= 0:
         raise ReducerFailClosed(
             "8.1(k)",
-            f"{table.market} P={price}: exit_multiplier_cap="
-            f"{exit_multiplier_cap} <= 0",
+            f"{table.market} P={price}: exit_multiplier_cap={exit_multiplier_cap} <= 0",
         )
 
     c = entry_multiplier / exit_multiplier_cap - ONE
@@ -317,10 +312,10 @@ class MarketResult:
 
     market: str
     cost: MarketCostInput
-    candidates: List[CandidateRow]
+    candidates: list[CandidateRow]
     c_raw: Fraction
     witness_price: int
-    target_checks: List[TargetCheckRow] = field(default_factory=list)
+    target_checks: list[TargetCheckRow] = field(default_factory=list)
 
     @property
     def enumerated_count(self) -> int:
@@ -332,7 +327,7 @@ class ReducerResult:
     """§6/§7.6 reducer output."""
 
     reducer_spec_id: str
-    markets: Dict[str, MarketResult]
+    markets: dict[str, MarketResult]
     c_raw: Fraction
     witness_market: str
     witness_price: int
@@ -340,7 +335,7 @@ class ReducerResult:
     c_stress_cap: Fraction
     c_stress_cap_decimal: str
     all_target_checks_passed: bool
-    target_check_failures: List[TargetCheckRow] = field(default_factory=list)
+    target_check_failures: list[TargetCheckRow] = field(default_factory=list)
 
     @property
     def enumerated_count(self) -> int:
@@ -369,8 +364,8 @@ def reduce_market(
             "4.5", f"{table.market}: E_m is empty on [{price_min},{price_max}]"
         )
 
-    candidates: List[CandidateRow] = []
-    best: Optional[Fraction] = None
+    candidates: list[CandidateRow] = []
+    best: Fraction | None = None
     witness = 0
     for price in prices:
         row = candidate_at(table, cost, price)
@@ -395,7 +390,7 @@ def run_target_checks(
     cost: MarketCostInput,
     cap: Fraction,
     prices: Sequence[int],
-) -> List[TargetCheckRow]:
+) -> list[TargetCheckRow]:
     """§6.8 + §6.9 — build T(P) and verify the break-even inequality.
 
     ``T = tick_ceil(P * (1 + cap))`` with the product kept as an exact
@@ -405,12 +400,10 @@ def run_target_checks(
 
     with both sides exact Fractions.
     """
-    rows: List[TargetCheckRow] = []
+    rows: list[TargetCheckRow] = []
     for price in prices:
         target = table.tick_ceil(Fraction(price) * (ONE + cap))
-        lhs = target * (
-            ONE - cost.s - cost.tau - Fraction(table.tick(target), target)
-        )
+        lhs = target * (ONE - cost.s - cost.tau - Fraction(table.tick(target), target))
         rhs = price * (ONE + cost.b + Fraction(table.tick(price), price))
         rows.append(
             TargetCheckRow(
@@ -445,7 +438,7 @@ def reduce_c_stress_cap(
     if not tables:
         raise ReducerFailClosed("8.1(a)", "no markets supplied")
 
-    results: Dict[str, MarketResult] = {}
+    results: dict[str, MarketResult] = {}
     for market in sorted(tables):
         results[market] = reduce_market(
             tables[market], costs[market], price_min, price_max
@@ -453,7 +446,7 @@ def reduce_c_stress_cap(
 
     # §6 — C_raw = max(KOSPI, KOSDAQ); at a tie the witness market is KOSPI
     # (the value is unaffected, only the recorded witness).
-    c_raw: Optional[Fraction] = None
+    c_raw: Fraction | None = None
     witness_market = ""
     for market in sorted(results):
         candidate = results[market].c_raw
@@ -469,7 +462,7 @@ def reduce_c_stress_cap(
     bp = ceil_to_bp(c_raw)
     cap = Fraction(bp, BP_SCALE)
 
-    failures: List[TargetCheckRow] = []
+    failures: list[TargetCheckRow] = []
     for market in sorted(results):
         res = results[market]
         res.target_checks = run_target_checks(

--- a/research/krb1c_reducer_indep/sealed_input.py
+++ b/research/krb1c_reducer_indep/sealed_input.py
@@ -1,0 +1,198 @@
+"""Sealed P0-2 cost binding, transcribed from the amendment canonical.
+
+Source of truth (do not paraphrase, do not re-derive):
+
+    ~/work/herdr-inbox/krb1c-amendment-canonical-2026-07-28.json
+    sha256 d5da5edd6b49fb759b781c13f627e21a84667ced2be7cf03624a40bb813be389
+
+    .cost_binding        -> broker/product/channel, cost_basis, commissions
+    .sell_tax_components -> per-market sell tax decomposition
+
+Both markets carry ``cost_basis = REAL_TRADING_TARIFF`` and the Kiwoom real
+tariff of 0.015% per side (``rate_e12 = 150_000_000``). The mock 0.35% rate is
+display/reconciliation only (§2.5, §8.4) and is deliberately absent from this
+module — it must never reach a numeric input.
+
+``load_from_canonical`` re-reads the canonical JSON and asserts the transcribed
+constants against it, so a drift in the sealed file surfaces as a failure
+rather than as a silently stale copy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Dict, Sequence, Tuple
+
+from .reducer import (
+    CostRecord,
+    MarketCostInput,
+    ReducerFailClosed,
+    SellTaxComponent,
+    reduce_records,
+)
+
+AMENDMENT_CANONICAL_SHA256 = (
+    "d5da5edd6b49fb759b781c13f627e21a84667ced2be7cf03624a40bb813be389"
+)
+PARENT_CANONICAL_SHA256 = (
+    "d5e1246b2072ad227d924e059091e27fa49719e42a5bfba651ae8f2bced9d6f1"
+)
+OFFICIAL_TARIFF_SNAPSHOT_SHA256 = (
+    "8fd195fe7426ab66afca2ff131a08153afd114a2c0912b32e0924ba2434095af"
+)
+
+MARKETS: Tuple[str, ...] = ("KOSPI", "KOSDAQ")
+
+# .cost_binding
+BUY_COMMISSION_RATE_E12 = 150_000_000
+SELL_COMMISSION_RATE_E12 = 150_000_000
+BROKER_ID = "kiwoom"
+ACCOUNT_PRODUCT_ID = "KIWOOM_DOMESTIC_CASH_STOCK"
+ORDER_CHANNEL_ID = "KIWOOM_OPENAPI_KRX"
+COST_BASIS = "REAL_TRADING_TARIFF"
+
+# .sell_tax_components
+SELL_TAX_COMPONENTS: Dict[str, Tuple[Tuple[str, int], ...]] = {
+    "KOSPI": (
+        ("KOSPI_SECURITIES_TRANSACTION_TAX", 500_000_000),
+        ("KOSPI_RURAL_SPECIAL_TAX", 1_500_000_000),
+    ),
+    "KOSDAQ": (
+        ("KOSDAQ_SECURITIES_TRANSACTION_TAX", 2_000_000_000),
+    ),
+}
+
+
+def _record(market: str) -> CostRecord:
+    return CostRecord(
+        market=market,
+        buy_commission_rate_e12=BUY_COMMISSION_RATE_E12,
+        sell_commission_rate_e12=SELL_COMMISSION_RATE_E12,
+        sell_tax_components=tuple(
+            SellTaxComponent(code, rate)
+            for code, rate in SELL_TAX_COMPONENTS[market]
+        ),
+        cost_basis=COST_BASIS,
+        effective_from=None,
+        effective_to=None,  # §2.5 — 현행표만 null
+        source_snapshot_sha256=OFFICIAL_TARIFF_SNAPSHOT_SHA256,
+        probe_reconciliation_status="PASS",
+        mock_cost_relation="DIFFERENT",
+        broker_id=BROKER_ID,
+        account_product_id=ACCOUNT_PRODUCT_ID,
+        order_channel_id=ORDER_CHANNEL_ID,
+    )
+
+
+def sealed_records() -> Dict[str, Tuple[CostRecord, ...]]:
+    """The binding market_cost_records, one current-tariff record per market."""
+    return {market: (_record(market),) for market in MARKETS}
+
+
+def sealed_cost_inputs() -> Dict[str, MarketCostInput]:
+    """§3 reduction of the sealed records into B_m / S_m / A_m per market."""
+    return {
+        market: reduce_records(market, records)
+        for market, records in sealed_records().items()
+    }
+
+
+# --------------------------------------------------------------------------
+# canonical re-verification
+# --------------------------------------------------------------------------
+
+
+def sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 16), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def default_canonical_path() -> str:
+    return os.path.expanduser(
+        "~/work/herdr-inbox/krb1c-amendment-canonical-2026-07-28.json"
+    )
+
+
+def load_from_canonical(path: str | None = None) -> Dict[str, MarketCostInput]:
+    """Re-read the sealed canonical and cross-check the transcribed constants.
+
+    Fails closed (§8.1(c)/(g)) on a hash mismatch or any numeric divergence.
+    """
+    path = path or default_canonical_path()
+    actual = sha256_file(path)
+    if actual != AMENDMENT_CANONICAL_SHA256:
+        raise ReducerFailClosed(
+            "8.1(c)",
+            f"amendment canonical sha256 mismatch: expected "
+            f"{AMENDMENT_CANONICAL_SHA256}, got {actual}",
+        )
+
+    with open(path, "r", encoding="utf-8") as handle:
+        doc = json.load(handle)
+
+    binding = doc["cost_binding"]
+    if binding["cost_basis"] != COST_BASIS:
+        raise ReducerFailClosed(
+            "2.5", f"canonical cost_basis={binding['cost_basis']!r}"
+        )
+    for key, expected in (
+        ("buy_commission_rate_e12", BUY_COMMISSION_RATE_E12),
+        ("sell_commission_rate_e12", SELL_COMMISSION_RATE_E12),
+    ):
+        if binding[key] != expected:
+            raise ReducerFailClosed(
+                "8.1(g)",
+                f"canonical {key}={binding[key]} != transcribed {expected}",
+            )
+    for key, expected_str in (
+        ("broker_id", BROKER_ID),
+        ("account_product_id", ACCOUNT_PRODUCT_ID),
+        ("order_channel_id", ORDER_CHANNEL_ID),
+        ("source_snapshot_sha256", OFFICIAL_TARIFF_SNAPSHOT_SHA256),
+    ):
+        if binding[key] != expected_str:
+            raise ReducerFailClosed(
+                "8.1(d)",
+                f"canonical {key}={binding[key]!r} != transcribed "
+                f"{expected_str!r}",
+            )
+
+    taxes = doc["sell_tax_components"]
+    for market in MARKETS:
+        got: Sequence[dict] = taxes[market]
+        expected_pairs = SELL_TAX_COMPONENTS[market]
+        if len(got) != len(expected_pairs):
+            raise ReducerFailClosed(
+                "8.1(g)",
+                f"{market}: canonical has {len(got)} tax components, "
+                f"transcribed {len(expected_pairs)}",
+            )
+        got_map = {c["component_code"]: c["rate_e12"] for c in got}
+        for code, rate in expected_pairs:
+            if got_map.get(code) != rate:
+                raise ReducerFailClosed(
+                    "8.1(g)",
+                    f"{market}: canonical {code}={got_map.get(code)!r} != "
+                    f"transcribed {rate}",
+                )
+
+    parent = doc["parent"]
+    if parent["sha256"] != PARENT_CANONICAL_SHA256:
+        raise ReducerFailClosed(
+            "8.1(c)",
+            f"parent canonical sha256 mismatch: expected "
+            f"{PARENT_CANONICAL_SHA256}, canonical says {parent['sha256']}",
+        )
+    if parent.get("relationship") != "CHILD_AMENDMENT_APPEND_ONLY":
+        raise ReducerFailClosed(
+            "7.1",
+            f"amendment must be an append-only child, got "
+            f"{parent.get('relationship')!r}",
+        )
+
+    return sealed_cost_inputs()

--- a/research/krb1c_reducer_indep/sealed_input.py
+++ b/research/krb1c_reducer_indep/sealed_input.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from typing import Dict, Sequence, Tuple
+from collections.abc import Sequence
 
 from .reducer import (
     CostRecord,
@@ -43,7 +43,7 @@ OFFICIAL_TARIFF_SNAPSHOT_SHA256 = (
     "8fd195fe7426ab66afca2ff131a08153afd114a2c0912b32e0924ba2434095af"
 )
 
-MARKETS: Tuple[str, ...] = ("KOSPI", "KOSDAQ")
+MARKETS: tuple[str, ...] = ("KOSPI", "KOSDAQ")
 
 # .cost_binding
 BUY_COMMISSION_RATE_E12 = 150_000_000
@@ -54,14 +54,12 @@ ORDER_CHANNEL_ID = "KIWOOM_OPENAPI_KRX"
 COST_BASIS = "REAL_TRADING_TARIFF"
 
 # .sell_tax_components
-SELL_TAX_COMPONENTS: Dict[str, Tuple[Tuple[str, int], ...]] = {
+SELL_TAX_COMPONENTS: dict[str, tuple[tuple[str, int], ...]] = {
     "KOSPI": (
         ("KOSPI_SECURITIES_TRANSACTION_TAX", 500_000_000),
         ("KOSPI_RURAL_SPECIAL_TAX", 1_500_000_000),
     ),
-    "KOSDAQ": (
-        ("KOSDAQ_SECURITIES_TRANSACTION_TAX", 2_000_000_000),
-    ),
+    "KOSDAQ": (("KOSDAQ_SECURITIES_TRANSACTION_TAX", 2_000_000_000),),
 }
 
 
@@ -71,8 +69,7 @@ def _record(market: str) -> CostRecord:
         buy_commission_rate_e12=BUY_COMMISSION_RATE_E12,
         sell_commission_rate_e12=SELL_COMMISSION_RATE_E12,
         sell_tax_components=tuple(
-            SellTaxComponent(code, rate)
-            for code, rate in SELL_TAX_COMPONENTS[market]
+            SellTaxComponent(code, rate) for code, rate in SELL_TAX_COMPONENTS[market]
         ),
         cost_basis=COST_BASIS,
         effective_from=None,
@@ -86,12 +83,12 @@ def _record(market: str) -> CostRecord:
     )
 
 
-def sealed_records() -> Dict[str, Tuple[CostRecord, ...]]:
+def sealed_records() -> dict[str, tuple[CostRecord, ...]]:
     """The binding market_cost_records, one current-tariff record per market."""
     return {market: (_record(market),) for market in MARKETS}
 
 
-def sealed_cost_inputs() -> Dict[str, MarketCostInput]:
+def sealed_cost_inputs() -> dict[str, MarketCostInput]:
     """§3 reduction of the sealed records into B_m / S_m / A_m per market."""
     return {
         market: reduce_records(market, records)
@@ -118,7 +115,7 @@ def default_canonical_path() -> str:
     )
 
 
-def load_from_canonical(path: str | None = None) -> Dict[str, MarketCostInput]:
+def load_from_canonical(path: str | None = None) -> dict[str, MarketCostInput]:
     """Re-read the sealed canonical and cross-check the transcribed constants.
 
     Fails closed (§8.1(c)/(g)) on a hash mismatch or any numeric divergence.
@@ -132,7 +129,7 @@ def load_from_canonical(path: str | None = None) -> Dict[str, MarketCostInput]:
             f"{AMENDMENT_CANONICAL_SHA256}, got {actual}",
         )
 
-    with open(path, "r", encoding="utf-8") as handle:
+    with open(path, encoding="utf-8") as handle:
         doc = json.load(handle)
 
     binding = doc["cost_binding"]
@@ -158,8 +155,7 @@ def load_from_canonical(path: str | None = None) -> Dict[str, MarketCostInput]:
         if binding[key] != expected_str:
             raise ReducerFailClosed(
                 "8.1(d)",
-                f"canonical {key}={binding[key]!r} != transcribed "
-                f"{expected_str!r}",
+                f"canonical {key}={binding[key]!r} != transcribed {expected_str!r}",
             )
 
     taxes = doc["sell_tax_components"]

--- a/research/krb1c_reducer_indep/tests/test_bruteforce_rho_exit.py
+++ b/research/krb1c_reducer_indep/tests/test_bruteforce_rho_exit.py
@@ -1,0 +1,93 @@
+"""Brute-force validation of the §4.6/§4.7 exit-candidate shortcut.
+
+Both the reference implementation and this one compute
+
+    rho_exit(P) = max over Q in X_m(P) of tick(Q)/Q
+
+on the *finite* candidate set X_m(P) = {P} ∪ {tick_ceil(d_h) : d_h > P},
+justified by §4.7. Agreement between two implementations that share that
+shortcut would not detect an error in the shortcut itself. This test therefore
+recomputes rho_exit by scanning **every** valid quote price Q >= P, using no
+part of the shortcut.
+
+Coverage of the open-ended final band: the scan runs to 1,000,000, i.e. a full
+500,000 KRW into the [500,000, inf) band. Inside a band tick is constant, so
+tick(Q)/Q is strictly decreasing there; the test asserts that decrease
+empirically over the scanned portion, which pins the band's maximum at its
+first valid price and makes the unscanned tail irrelevant.
+
+Comparisons use integer cross-multiplication (tick(Q)*P vs tick(P)*Q) — exact,
+and fast enough to run the whole 4,001-price sweep.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from research.krb1c_reducer_indep.reducer import rho_exit_of
+from research.krb1c_reducer_indep.tick import (
+    KOSDAQ_TICK_TABLE,
+    KOSPI_TICK_TABLE,
+    PRICE_MAX,
+    PRICE_MIN,
+    TickTable,
+)
+
+SCAN_LIMIT = 1_000_000
+
+TABLES = (KOSPI_TICK_TABLE, KOSDAQ_TICK_TABLE)
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+def test_tick_over_q_strictly_decreases_inside_each_band(table: TickTable) -> None:
+    """The monotonicity §4.7 relies on, checked directly on the lattice."""
+    for band in table.bands:
+        start = table.tick_ceil(max(band.lower, 1))
+        stop = band.upper if band.upper is not None else SCAN_LIMIT
+        q = start
+        while True:
+            nxt = q + band.tick
+            if nxt >= stop:
+                break
+            # tick constant in band => tick/q > tick/nxt  <=>  nxt > q
+            assert table.tick(q) == band.tick
+            assert table.tick(nxt) == band.tick
+            assert band.tick * nxt > band.tick * q
+            q = nxt
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+def test_rho_exit_matches_full_scan_over_all_valid_q(table: TickTable) -> None:
+    """Full sweep: every P in E_m, rho_exit recomputed by scanning all valid Q.
+
+    Runs the complete 4,001-price enumeration per market — not a sample.
+    """
+    all_q = tuple(table.valid_prices(PRICE_MIN, SCAN_LIMIT))
+    prices = table.valid_prices(PRICE_MIN, PRICE_MAX)
+    assert len(prices) == 4_001
+
+    ticks = {q: table.tick(q) for q in all_q}
+
+    # Running maximum from the top down: best_from[i] = argmax over all_q[i:]
+    # of tick(Q)/Q, with ties resolved to the *least* Q (§4.8).
+    n = len(all_q)
+    best_idx = [0] * n
+    best_idx[n - 1] = n - 1
+    for i in range(n - 2, -1, -1):
+        j = best_idx[i + 1]
+        qi, qj = all_q[i], all_q[j]
+        # tick(qi)/qi  >=  tick(qj)/qj   <=>   tick(qi)*qj >= tick(qj)*qi
+        if ticks[qi] * qj >= ticks[qj] * qi:
+            best_idx[i] = i  # ">=" keeps the least Q on a tie
+        else:
+            best_idx[i] = j
+
+    index_of = {q: i for i, q in enumerate(all_q)}
+    checked = 0
+    for price in prices:
+        expected_q = all_q[best_idx[index_of[price]]]
+        rho, witness = rho_exit_of(table, price)
+        assert witness == expected_q, f"{table.market} P={price}"
+        assert rho.numerator * expected_q == ticks[expected_q] * rho.denominator
+        checked += 1
+    assert checked == 4_001

--- a/research/krb1c_reducer_indep/tests/test_no_float.py
+++ b/research/krb1c_reducer_indep/tests/test_no_float.py
@@ -39,28 +39,21 @@ def test_package_has_sources() -> None:
     assert package_sources(), "no sources found — guard would vacuously pass"
 
 
-@pytest.mark.parametrize(
-    "path", package_sources(), ids=lambda p: p.name
-)
+@pytest.mark.parametrize("path", package_sources(), ids=lambda p: p.name)
 def test_source_has_no_float_or_decimal(path: pathlib.Path) -> None:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     problems: list[str] = []
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.Constant) and isinstance(
-            node.value, (float, complex)
-        ):
+        if isinstance(node, ast.Constant) and isinstance(node.value, (float, complex)):
             problems.append(
-                f"{path.name}:{node.lineno} float/complex literal "
-                f"{node.value!r}"
+                f"{path.name}:{node.lineno} float/complex literal {node.value!r}"
             )
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 root = alias.name.split(".")[0]
                 if root in FORBIDDEN_MODULES:
-                    problems.append(
-                        f"{path.name}:{node.lineno} import {alias.name}"
-                    )
+                    problems.append(f"{path.name}:{node.lineno} import {alias.name}")
         elif isinstance(node, ast.ImportFrom):
             root = (node.module or "").split(".")[0]
             if root in FORBIDDEN_MODULES:
@@ -69,9 +62,7 @@ def test_source_has_no_float_or_decimal(path: pathlib.Path) -> None:
                 )
             for alias in node.names:
                 if alias.name in FORBIDDEN_NAMES:
-                    problems.append(
-                        f"{path.name}:{node.lineno} imports {alias.name}"
-                    )
+                    problems.append(f"{path.name}:{node.lineno} imports {alias.name}")
         elif isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
             # `float` inside an isinstance-style guard would still be a Name;
             # the package uses none, so any occurrence is reported.

--- a/research/krb1c_reducer_indep/tests/test_no_float.py
+++ b/research/krb1c_reducer_indep/tests/test_no_float.py
@@ -1,0 +1,117 @@
+"""§6 evidence: the reducer contains no float / Decimal arithmetic at all.
+
+Two independent guards:
+
+1. A static AST scan of every module in the package (excluding this test
+   directory) for float literals, ``float(...)`` / ``complex(...)`` calls,
+   ``Decimal`` usage, ``math`` / ``decimal`` / ``numpy`` imports, and the true
+   division operator applied outside of ``Fraction`` construction is *allowed*
+   (Fraction / Fraction stays exact) but ``//`` on floats cannot arise because
+   no float can exist in the first place.
+
+2. A dynamic scan asserting that every value produced by a full reduction is
+   an ``int`` or a ``Fraction`` — never a ``float``.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from fractions import Fraction
+
+import pytest
+
+PACKAGE_DIR = pathlib.Path(__file__).resolve().parent.parent
+
+FORBIDDEN_MODULES = {"math", "decimal", "numpy", "cmath", "statistics"}
+FORBIDDEN_NAMES = {"float", "complex", "Decimal"}
+
+
+def package_sources() -> list[pathlib.Path]:
+    return sorted(
+        path
+        for path in PACKAGE_DIR.rglob("*.py")
+        if "tests" not in path.relative_to(PACKAGE_DIR).parts
+    )
+
+
+def test_package_has_sources() -> None:
+    assert package_sources(), "no sources found — guard would vacuously pass"
+
+
+@pytest.mark.parametrize(
+    "path", package_sources(), ids=lambda p: p.name
+)
+def test_source_has_no_float_or_decimal(path: pathlib.Path) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    problems: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(
+            node.value, (float, complex)
+        ):
+            problems.append(
+                f"{path.name}:{node.lineno} float/complex literal "
+                f"{node.value!r}"
+            )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                if root in FORBIDDEN_MODULES:
+                    problems.append(
+                        f"{path.name}:{node.lineno} import {alias.name}"
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".")[0]
+            if root in FORBIDDEN_MODULES:
+                problems.append(
+                    f"{path.name}:{node.lineno} from {node.module} import ..."
+                )
+            for alias in node.names:
+                if alias.name in FORBIDDEN_NAMES:
+                    problems.append(
+                        f"{path.name}:{node.lineno} imports {alias.name}"
+                    )
+        elif isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
+            # `float` inside an isinstance-style guard would still be a Name;
+            # the package uses none, so any occurrence is reported.
+            problems.append(f"{path.name}:{node.lineno} name {node.id!r}")
+        elif isinstance(node, ast.Attribute) and node.attr in FORBIDDEN_NAMES:
+            problems.append(f"{path.name}:{node.lineno} attribute {node.attr!r}")
+
+    assert not problems, "float/Decimal usage detected:\n" + "\n".join(problems)
+
+
+def test_reduction_values_are_all_exact() -> None:
+    from research.krb1c_reducer_indep.cli import TABLES
+    from research.krb1c_reducer_indep.reducer import reduce_c_stress_cap
+    from research.krb1c_reducer_indep.sealed_input import sealed_cost_inputs
+
+    result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
+
+    exact = (int, Fraction)
+    assert isinstance(result.c_raw, Fraction)
+    assert isinstance(result.c_stress_cap, Fraction)
+    assert isinstance(result.c_stress_cap_bp, int)
+    assert not isinstance(result.c_stress_cap_bp, bool)
+
+    for market_result in result.markets.values():
+        assert isinstance(market_result.c_raw, Fraction)
+        assert isinstance(market_result.witness_price, int)
+        for row in market_result.candidates:
+            for value in (
+                row.price,
+                row.tick_at_price,
+                row.rho_entry,
+                row.exit_witness_q,
+                row.tick_at_exit_witness,
+                row.rho_exit,
+                row.entry_multiplier,
+                row.exit_multiplier_cap,
+                row.c,
+            ):
+                assert isinstance(value, exact), f"{value!r} is not exact"
+                assert not isinstance(value, bool)
+        for check in market_result.target_checks:
+            for value in (check.target, check.lhs, check.rhs):
+                assert isinstance(value, exact), f"{value!r} is not exact"

--- a/research/krb1c_reducer_indep/tests/test_reducer.py
+++ b/research/krb1c_reducer_indep/tests/test_reducer.py
@@ -45,13 +45,13 @@ def test_sealed_cost_inputs_match_binding() -> None:
 
 
 def _rec(**kwargs) -> CostRecord:
-    base = dict(
-        market="KOSPI",
-        buy_commission_rate_e12=100,
-        sell_commission_rate_e12=200,
-        sell_tax_components=(SellTaxComponent("T", 300),),
-        source_snapshot_sha256="x" * 64,
-    )
+    base = {
+        "market": "KOSPI",
+        "buy_commission_rate_e12": 100,
+        "sell_commission_rate_e12": 200,
+        "sell_tax_components": (SellTaxComponent("T", 300),),
+        "source_snapshot_sha256": "x" * 64,
+    }
     base.update(kwargs)
     return CostRecord(**base)  # type: ignore[arg-type]
 
@@ -242,9 +242,7 @@ def test_market_c_raw_witness_is_least_price_on_tie() -> None:
 def test_full_reduction_closed_form() -> None:
     result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
 
-    expected_c_raw = (
-        (1 + B + Fraction(1, 400)) / (1 - S - TAU - Fraction(1, 400)) - 1
-    )
+    expected_c_raw = (1 + B + Fraction(1, 400)) / (1 - S - TAU - Fraction(1, 400)) - 1
     assert result.c_raw == expected_c_raw
     assert result.c_stress_cap_bp == ceil_to_bp(expected_c_raw)
     assert result.c_stress_cap == Fraction(result.c_stress_cap_bp, 10_000)
@@ -260,8 +258,7 @@ def test_both_markets_agree_under_identical_binding() -> None:
     result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
     assert result.markets["KOSPI"].c_raw == result.markets["KOSDAQ"].c_raw
     assert (
-        result.markets["KOSPI"].witness_price
-        == result.markets["KOSDAQ"].witness_price
+        result.markets["KOSPI"].witness_price == result.markets["KOSDAQ"].witness_price
     )
 
 
@@ -281,15 +278,10 @@ def test_target_check_holds_at_every_price() -> None:
         cost = res.cost
         assert len(res.target_checks) == len(res.candidates)
         for check in res.target_checks:
-            assert check.target == table.tick_ceil(
-                Fraction(check.price) * (1 + cap)
-            )
+            assert check.target == table.tick_ceil(Fraction(check.price) * (1 + cap))
             assert check.target >= check.price
             lhs = check.target * (
-                1
-                - cost.s
-                - cost.tau
-                - Fraction(table.tick(check.target), check.target)
+                1 - cost.s - cost.tau - Fraction(table.tick(check.target), check.target)
             )
             rhs = check.price * (
                 1 + cost.b + Fraction(table.tick(check.price), check.price)

--- a/research/krb1c_reducer_indep/tests/test_reducer.py
+++ b/research/krb1c_reducer_indep/tests/test_reducer.py
@@ -1,0 +1,345 @@
+"""§3 / §5 / §6 reducer tests, including hand-computed closed forms."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+from research.krb1c_reducer_indep.cli import TABLES
+from research.krb1c_reducer_indep.reducer import (
+    CostRecord,
+    MarketCostInput,
+    ReducerFailClosed,
+    SellTaxComponent,
+    bp_to_decimal_string,
+    candidate_at,
+    ceil_to_bp,
+    reduce_c_stress_cap,
+    reduce_market,
+    reduce_records,
+    rho_exit_of,
+)
+from research.krb1c_reducer_indep.sealed_input import sealed_cost_inputs
+from research.krb1c_reducer_indep.tick import KOSPI_TICK_TABLE
+
+B = Fraction(150_000_000, 10**12)  # 0.015%
+S = Fraction(150_000_000, 10**12)  # 0.015%
+TAU = Fraction(2_000_000_000, 10**12)  # 0.20%
+
+
+# --- §3 -------------------------------------------------------------------
+
+
+def test_sealed_cost_inputs_match_binding() -> None:
+    costs = sealed_cost_inputs()
+    assert set(costs) == {"KOSPI", "KOSDAQ"}
+    for cost in costs.values():
+        assert cost.b == B == Fraction(3, 20_000)
+        assert cost.s == S
+        assert cost.tau == TAU == Fraction(1, 500)
+        assert cost.a == Fraction(43, 20_000)
+    # KOSPI's 0.05% + 0.15% must sum to exactly KOSDAQ's single 0.20%
+    assert costs["KOSPI"].sell_tax_rate_e12 == costs["KOSDAQ"].sell_tax_rate_e12
+    assert costs["KOSPI"].sell_tax_rate_e12 == 2_000_000_000
+
+
+def _rec(**kwargs) -> CostRecord:
+    base = dict(
+        market="KOSPI",
+        buy_commission_rate_e12=100,
+        sell_commission_rate_e12=200,
+        sell_tax_components=(SellTaxComponent("T", 300),),
+        source_snapshot_sha256="x" * 64,
+    )
+    base.update(kwargs)
+    return CostRecord(**base)  # type: ignore[arg-type]
+
+
+def test_period_maxima_are_taken_independently() -> None:
+    """§3 — B/S/A each maximised on their own; not tied to one record."""
+    records = [
+        _rec(
+            buy_commission_rate_e12=900,
+            sell_commission_rate_e12=1,
+            sell_tax_components=(SellTaxComponent("T", 1),),
+        ),
+        _rec(
+            buy_commission_rate_e12=1,
+            sell_commission_rate_e12=800,
+            sell_tax_components=(SellTaxComponent("T", 1),),
+        ),
+        _rec(
+            buy_commission_rate_e12=1,
+            sell_commission_rate_e12=1,
+            sell_tax_components=(SellTaxComponent("T", 700),),
+        ),
+    ]
+    reduced = reduce_records("KOSPI", records)
+    assert (reduced.buy_rate_e12, reduced.sell_rate_e12, reduced.sell_tax_rate_e12) == (
+        900,
+        800,
+        700,
+    )
+
+
+def test_mock_tariff_basis_is_rejected() -> None:
+    with pytest.raises(ReducerFailClosed) as exc:
+        reduce_records("KOSPI", [_rec(cost_basis="MOCK_DISPLAY_TARIFF")])
+    assert "REAL_TRADING_TARIFF" in str(exc.value)
+
+
+def test_missing_snapshot_sha_is_rejected() -> None:
+    with pytest.raises(ReducerFailClosed):
+        reduce_records("KOSPI", [_rec(source_snapshot_sha256=None)])
+
+
+def test_non_pass_probe_is_rejected() -> None:
+    with pytest.raises(ReducerFailClosed):
+        reduce_records("KOSPI", [_rec(probe_reconciliation_status="FAIL")])
+
+
+def test_duplicate_tax_component_is_rejected() -> None:
+    with pytest.raises(ReducerFailClosed):
+        reduce_records(
+            "KOSPI",
+            [
+                _rec(
+                    sell_tax_components=(
+                        SellTaxComponent("T", 1),
+                        SellTaxComponent("T", 2),
+                    )
+                )
+            ],
+        )
+
+
+def test_negative_rate_is_rejected() -> None:
+    with pytest.raises(ReducerFailClosed):
+        reduce_records("KOSPI", [_rec(buy_commission_rate_e12=-1)])
+
+
+def test_no_records_is_rejected() -> None:
+    with pytest.raises(ReducerFailClosed):
+        reduce_records("KOSPI", [])
+
+
+# --- §4.8 / §5 ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "price,expected_rho_exit,expected_witness",
+    [
+        # inside [5k,20k): own ratio <= 1/500, beaten by 20,000's 50/20000=1/400
+        (5_000, Fraction(1, 400), 20_000),
+        (19_990, Fraction(1, 400), 20_000),
+        # at 20,000 the own ratio ties 1/400 and P itself is the least Q
+        (20_000, Fraction(1, 400), 20_000),
+        # inside [20k,50k): own ratio < 1/400, 200,000 gives 500/200000=1/400
+        (30_000, Fraction(1, 400), 200_000),
+        # inside [50k,200k): own ratio <= 1/500, 200,000 wins
+        (50_000, Fraction(1, 400), 200_000),
+        # at 200,000 P itself attains 1/400
+        (200_000, Fraction(1, 400), 200_000),
+        # at exactly 250,000 own ratio 500/250000 == 1/500 ties 500,000's
+        # 1000/500000; the least Q wins the tie
+        (250_000, Fraction(1, 500), 250_000),
+        # above 250,000 own ratio drops below 1/500, so 500,000 takes over
+        (250_500, Fraction(1, 500), 500_000),
+        (400_000, Fraction(1, 500), 500_000),
+    ],
+)
+def test_rho_exit_and_witness(
+    price: int, expected_rho_exit: Fraction, expected_witness: int
+) -> None:
+    rho, witness = rho_exit_of(KOSPI_TICK_TABLE, price)
+    assert rho == expected_rho_exit
+    assert witness == expected_witness
+
+
+def test_candidate_closed_form_at_20000() -> None:
+    cost = sealed_cost_inputs()["KOSPI"]
+    row = candidate_at(KOSPI_TICK_TABLE, cost, 20_000)
+
+    assert row.rho_entry == Fraction(50, 20_000) == Fraction(1, 400)
+    assert row.rho_exit == Fraction(1, 400)
+    assert row.entry_multiplier == 1 + B + Fraction(1, 400)
+    assert row.exit_multiplier_cap == 1 - S - TAU - Fraction(1, 400)
+    expected = (1 + B + Fraction(1, 400)) / (1 - S - TAU - Fraction(1, 400)) - 1
+    assert row.c == expected
+
+
+def test_multiplicative_formula_is_not_the_additive_approximation() -> None:
+    """§5 — the additive approximation b+s+tau+2*tick/P is explicitly
+    non-binding, so the two must differ at the witness."""
+    cost = sealed_cost_inputs()["KOSPI"]
+    row = candidate_at(KOSPI_TICK_TABLE, cost, 20_000)
+    additive = B + S + TAU + Fraction(1, 400) + Fraction(1, 400)
+    assert row.c != additive
+    assert row.c > additive  # the exact form is strictly more conservative
+
+
+def test_exit_multiplier_cap_positive_everywhere() -> None:
+    for market, cost in sealed_cost_inputs().items():
+        table = TABLES[market]
+        for price in table.valid_prices():
+            row = candidate_at(table, cost, price)
+            assert row.exit_multiplier_cap > 0
+
+
+def test_exit_multiplier_cap_non_positive_fails_closed() -> None:
+    """§8.1(k) — a tariff that eats the whole exit must fail, not clamp."""
+    hostile = MarketCostInput(
+        market="KOSPI",
+        buy_rate_e12=0,
+        sell_rate_e12=999_000_000_000,
+        sell_tax_rate_e12=0,
+    )
+    with pytest.raises(ReducerFailClosed) as exc:
+        candidate_at(KOSPI_TICK_TABLE, hostile, 20_000)
+    assert "8.1(k)" in str(exc.value)
+
+
+# --- §6 -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (Fraction(0), 0),
+        (Fraction(1, 10_000), 1),  # exactly on a bp — no extra
+        (Fraction(1, 20_000), 1),  # strictly between — up
+        (Fraction(15_000, 10_000), 15_000),
+        (Fraction(1, 10_000_000), 1),  # tiny positive still rounds up
+        (Fraction(29_999, 10_000_000), 30),
+    ],
+)
+def test_ceil_to_bp(value: Fraction, expected: int) -> None:
+    assert ceil_to_bp(value) == expected
+
+
+def test_ceil_to_bp_never_rounds_to_nearest() -> None:
+    # 0.400 01 bp would round to 0 under nearest; the clause demands 1
+    assert ceil_to_bp(Fraction(400_001, 10_000_000_000)) == 1
+
+
+@pytest.mark.parametrize(
+    "bp,expected",
+    [(0, "0.0000"), (74, "0.0074"), (10_000, "1.0000"), (12_345, "1.2345")],
+)
+def test_bp_to_decimal_string(bp: int, expected: str) -> None:
+    assert bp_to_decimal_string(bp) == expected
+
+
+def test_market_c_raw_witness_is_least_price_on_tie() -> None:
+    cost = sealed_cost_inputs()["KOSPI"]
+    result = reduce_market(KOSPI_TICK_TABLE, cost)
+    tied = [row.price for row in result.candidates if row.c == result.c_raw]
+    assert len(tied) > 1, "expected a genuine tie to exercise the rule"
+    assert result.witness_price == min(tied)
+
+
+def test_full_reduction_closed_form() -> None:
+    result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
+
+    expected_c_raw = (
+        (1 + B + Fraction(1, 400)) / (1 - S - TAU - Fraction(1, 400)) - 1
+    )
+    assert result.c_raw == expected_c_raw
+    assert result.c_stress_cap_bp == ceil_to_bp(expected_c_raw)
+    assert result.c_stress_cap == Fraction(result.c_stress_cap_bp, 10_000)
+    assert result.witness_market == "KOSPI"  # tie between the two markets
+    assert result.all_target_checks_passed
+    assert result.enumerated_count == 8_002
+    assert result.target_check_count == 8_002
+
+
+def test_both_markets_agree_under_identical_binding() -> None:
+    """The sealed binding gives both markets the same three rates and the same
+    tick table, so their C_raw_m must coincide exactly."""
+    result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
+    assert result.markets["KOSPI"].c_raw == result.markets["KOSDAQ"].c_raw
+    assert (
+        result.markets["KOSPI"].witness_price
+        == result.markets["KOSDAQ"].witness_price
+    )
+
+
+def test_market_set_mismatch_fails_closed() -> None:
+    costs = sealed_cost_inputs()
+    del costs["KOSDAQ"]
+    with pytest.raises(ReducerFailClosed):
+        reduce_c_stress_cap(TABLES, costs)
+
+
+def test_target_check_holds_at_every_price() -> None:
+    """§6.9 — the self-check, re-derived row by row from the published cap."""
+    result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
+    cap = result.c_stress_cap
+    for market, res in result.markets.items():
+        table = TABLES[market]
+        cost = res.cost
+        assert len(res.target_checks) == len(res.candidates)
+        for check in res.target_checks:
+            assert check.target == table.tick_ceil(
+                Fraction(check.price) * (1 + cap)
+            )
+            assert check.target >= check.price
+            lhs = check.target * (
+                1
+                - cost.s
+                - cost.tau
+                - Fraction(table.tick(check.target), check.target)
+            )
+            rhs = check.price * (
+                1 + cost.b + Fraction(table.tick(check.price), check.price)
+            )
+            assert check.lhs == lhs
+            assert check.rhs == rhs
+            assert lhs >= rhs
+
+
+def test_target_check_can_actually_fail() -> None:
+    """The §6.9 check must not be vacuously true — a zero cap has to break it.
+
+    With cap = 0, T = tick_ceil(P) = P and the inequality reduces to
+    P(1 - s - tau - tick(P)/P) >= P(1 + b + tick(P)/P), which is false for any
+    positive cost. This pins the check as a live assertion rather than a
+    tautology of the implementation.
+    """
+    from research.krb1c_reducer_indep.reducer import run_target_checks
+
+    rows = run_target_checks(
+        KOSPI_TICK_TABLE,
+        sealed_cost_inputs()["KOSPI"],
+        Fraction(0),
+        [5_000, 20_000, 200_000, 400_000],
+    )
+    assert rows
+    assert all(row.passed is False for row in rows)
+    assert all(row.target == row.price for row in rows)
+
+
+def test_target_check_is_not_a_tight_inverse_of_the_cap() -> None:
+    """Recorded property, not a defect.
+
+    A cap one bp *below* the reduced value still passes §6.9 at the witness,
+    because tick_ceil lifts T past the exact break-even point and donates
+    headroom. So §6.9 is a necessary self-check, not a sufficient derivation of
+    the cap — consistent with the sealed math verification's finding that §6.9
+    is algebraically implied and that observed failures signal table/rate/
+    rounding/implementation defects rather than a normal case.
+    """
+    from research.krb1c_reducer_indep.reducer import run_target_checks
+
+    result = reduce_c_stress_cap(TABLES, sealed_cost_inputs())
+    understated = Fraction(result.c_stress_cap_bp - 1, 10_000)
+    assert understated < result.c_raw  # genuinely below the exact break-even
+    rows = run_target_checks(
+        KOSPI_TICK_TABLE,
+        sealed_cost_inputs()["KOSPI"],
+        understated,
+        [result.witness_price],
+    )
+    assert rows[0].passed is True
+    assert rows[0].target == 20_150

--- a/research/krb1c_reducer_indep/tests/test_tick.py
+++ b/research/krb1c_reducer_indep/tests/test_tick.py
@@ -118,7 +118,9 @@ def test_valid_prices_full_enumeration(table: TickTable) -> None:
     assert len(prices) == 4_001
     assert prices[0] == PRICE_MIN
     assert prices[-1] == PRICE_MAX
-    assert all(b > a for a, b in zip(prices, prices[1:]))
+    # strict=False is deliberate: this is an offset self-pairing, so the two
+    # operands differ in length by exactly one and strict=True would raise.
+    assert all(b > a for a, b in zip(prices, prices[1:], strict=False))
     assert all(table.is_valid_price(p) for p in prices)
 
     # band-by-band counts
@@ -132,9 +134,7 @@ def test_valid_prices_full_enumeration(table: TickTable) -> None:
 
     # completeness: the enumeration equals a brute-force filter of every
     # integer in range (no sampling, nothing skipped)
-    brute = tuple(
-        x for x in range(PRICE_MIN, PRICE_MAX + 1) if table.is_valid_price(x)
-    )
+    brute = tuple(x for x in range(PRICE_MIN, PRICE_MAX + 1) if table.is_valid_price(x))
     assert prices == brute
 
 

--- a/research/krb1c_reducer_indep/tests/test_tick.py
+++ b/research/krb1c_reducer_indep/tests/test_tick.py
@@ -1,0 +1,185 @@
+"""§4 tick function / E_m / X_m(P) tests."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+from research.krb1c_reducer_indep.tick import (
+    KOSDAQ_TICK_TABLE,
+    KOSPI_TICK_TABLE,
+    PRICE_MAX,
+    PRICE_MIN,
+    TickBand,
+    TickTable,
+    TickTableError,
+)
+
+TABLES = (KOSPI_TICK_TABLE, KOSDAQ_TICK_TABLE)
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+@pytest.mark.parametrize(
+    "price,expected",
+    [
+        (0, 1),
+        (1_999, 1),
+        (2_000, 5),
+        (4_999, 5),
+        (5_000, 10),
+        (9_990, 10),
+        (10_000, 10),  # sealed verify §1: current table, NOT the old 50
+        (19_999, 10),
+        (20_000, 50),
+        (49_999, 50),
+        (50_000, 100),
+        (199_999, 100),
+        (200_000, 500),
+        (400_000, 500),
+        (499_999, 500),
+        (500_000, 1_000),
+        (10_000_000, 1_000),
+    ],
+)
+def test_tick_boundaries(table: TickTable, price: int, expected: int) -> None:
+    assert table.tick(price) == expected
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (5_000, 5_000),
+        (5_001, 5_010),
+        (19_991, 20_000),  # crosses into the 50-tick band
+        (19_999, 20_000),
+        (20_000, 20_000),
+        (20_001, 20_050),
+        (49_951, 50_000),
+        (50_000, 50_000),
+        (50_001, 50_100),
+        (199_901, 200_000),
+        (200_000, 200_000),
+        (200_001, 200_500),
+        (499_501, 500_000),
+        (500_000, 500_000),
+        (500_001, 501_000),
+    ],
+)
+def test_tick_ceil_int(table: TickTable, value: int, expected: int) -> None:
+    assert table.tick_ceil(value) == expected
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+def test_tick_ceil_accepts_fraction_exactly(table: TickTable) -> None:
+    # exactly on a lattice point -> unchanged
+    assert table.tick_ceil(Fraction(20_000)) == 20_000
+    # a hair above -> next lattice point
+    assert table.tick_ceil(Fraction(2_000_001, 100)) == 20_050
+    # a hair below a band edge -> the band edge itself
+    assert table.tick_ceil(Fraction(1_999_999, 100)) == 20_000
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+def test_tick_ceil_rejects_float(table: TickTable) -> None:
+    with pytest.raises(TickTableError):
+        table.tick_ceil(20000.5)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+def test_tick_ceil_is_least_valid_price_brute_force(table: TickTable) -> None:
+    """Cross-check tick_ceil against a brute-force scan on a dense window."""
+    for x in range(4_990, 5_120):
+        got = table.tick_ceil(x)
+        probe = x
+        while not table.is_valid_price(probe):
+            probe += 1
+        assert got == probe, x
+    for x in range(19_980, 20_120):
+        got = table.tick_ceil(x)
+        probe = x
+        while not table.is_valid_price(probe):
+            probe += 1
+        assert got == probe, x
+    for x in range(199_900, 200_600):
+        got = table.tick_ceil(x)
+        probe = x
+        while not table.is_valid_price(probe):
+            probe += 1
+        assert got == probe, x
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+def test_valid_prices_full_enumeration(table: TickTable) -> None:
+    prices = table.valid_prices(PRICE_MIN, PRICE_MAX)
+
+    # sealed verify §1 asserts 4,001 valid prices per market on [5k, 400k]
+    assert len(prices) == 4_001
+    assert prices[0] == PRICE_MIN
+    assert prices[-1] == PRICE_MAX
+    assert all(b > a for a, b in zip(prices, prices[1:]))
+    assert all(table.is_valid_price(p) for p in prices)
+
+    # band-by-band counts
+    counts = {
+        10: len([p for p in prices if 5_000 <= p < 20_000]),
+        50: len([p for p in prices if 20_000 <= p < 50_000]),
+        100: len([p for p in prices if 50_000 <= p < 200_000]),
+        500: len([p for p in prices if 200_000 <= p <= 400_000]),
+    }
+    assert counts == {10: 1_500, 50: 600, 100: 1_500, 500: 401}
+
+    # completeness: the enumeration equals a brute-force filter of every
+    # integer in range (no sampling, nothing skipped)
+    brute = tuple(
+        x for x in range(PRICE_MIN, PRICE_MAX + 1) if table.is_valid_price(x)
+    )
+    assert prices == brute
+
+
+@pytest.mark.parametrize("table", TABLES, ids=lambda t: t.market)
+@pytest.mark.parametrize(
+    "price,expected",
+    [
+        (5_000, (5_000, 20_000, 50_000, 200_000, 500_000)),
+        (20_000, (20_000, 50_000, 200_000, 500_000)),
+        (50_000, (50_000, 200_000, 500_000)),
+        (200_000, (200_000, 500_000)),
+        (400_000, (400_000, 500_000)),
+    ],
+)
+def test_exit_candidates(table: TickTable, price: int, expected: tuple) -> None:
+    assert table.exit_candidates(price) == expected
+
+
+def test_table_rejects_gap() -> None:
+    with pytest.raises(TickTableError):
+        TickTable(
+            "BAD",
+            [TickBand(0, 100, 1), TickBand(200, None, 5)],
+            "test",
+        )
+
+
+def test_table_rejects_overlap() -> None:
+    with pytest.raises(TickTableError):
+        TickTable(
+            "BAD",
+            [TickBand(0, 300, 1), TickBand(200, None, 5)],
+            "test",
+        )
+
+
+def test_table_rejects_bounded_last_band() -> None:
+    with pytest.raises(TickTableError):
+        TickTable("BAD", [TickBand(0, 100, 1)], "test")
+
+
+def test_table_rejects_misaligned_band_lower() -> None:
+    with pytest.raises(TickTableError):
+        TickTable(
+            "BAD",
+            [TickBand(0, 101, 1), TickBand(101, None, 5)],
+            "test",
+        )

--- a/research/krb1c_reducer_indep/tick.py
+++ b/research/krb1c_reducer_indep/tick.py
@@ -31,9 +31,9 @@ sealed data, and the tick_ceil semantics are re-derived from the clause.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import Optional, Sequence, Tuple
 
 # §6.2.1 §1.3 — 가격 범위 5,000 ≤ P ≤ 400,000 정수 KRW.
 PRICE_MIN: int = 5_000
@@ -52,7 +52,7 @@ class TickBand:
     """
 
     lower: int
-    upper: Optional[int]
+    upper: int | None
     tick: int
 
     def __post_init__(self) -> None:
@@ -105,18 +105,13 @@ class TickTable:
         bands = tuple(bands)
 
         if bands[0].lower != 0:
-            raise TickTableError(
-                f"first band must start at 0, got {bands[0].lower}"
-            )
+            raise TickTableError(f"first band must start at 0, got {bands[0].lower}")
         for i in range(len(bands) - 1):
             if bands[i].upper is None:
-                raise TickTableError(
-                    f"open-ended band at index {i} is not last (§4.3)"
-                )
+                raise TickTableError(f"open-ended band at index {i} is not last (§4.3)")
             if bands[i].upper != bands[i + 1].lower:
                 raise TickTableError(
-                    "band gap/overlap between "
-                    f"{bands[i]} and {bands[i + 1]} (§4.2)"
+                    f"band gap/overlap between {bands[i]} and {bands[i + 1]} (§4.2)"
                 )
         if bands[-1].upper is not None:
             raise TickTableError("last band must be open-ended (§4.3)")
@@ -142,7 +137,7 @@ class TickTable:
                 return band.tick
         raise TickTableError(f"no band covers price {x}")  # pragma: no cover
 
-    def band_lower_bounds(self) -> Tuple[int, ...]:
+    def band_lower_bounds(self) -> tuple[int, ...]:
         """The ordered band lower bounds ``d_h`` (§4.6 candidate generators)."""
         return tuple(band.lower for band in self.bands)
 
@@ -151,7 +146,7 @@ class TickTable:
         _require_nonneg_int(x, "price")
         return x % self.tick(x) == 0
 
-    def tick_ceil(self, x: "int | Fraction") -> int:
+    def tick_ceil(self, x: int | Fraction) -> int:
         """Smallest valid quote price ``>= x``. Exact arithmetic, int result.
 
         Accepts an exact ``Fraction`` as well as an ``int`` so that §6.8's
@@ -192,7 +187,7 @@ class TickTable:
 
     def valid_prices(
         self, low: int = PRICE_MIN, high: int = PRICE_MAX
-    ) -> Tuple[int, ...]:
+    ) -> tuple[int, ...]:
         """E_m — full enumeration, exactly per §4.5.
 
         ``p_0 = tick_ceil(low)``; ``p_{k+1} = tick_ceil(p_k + 1)``; stop once
@@ -221,7 +216,7 @@ class TickTable:
 
     # ---- §4.6 exit candidate set ----------------------------------------
 
-    def exit_candidates(self, price: int) -> Tuple[int, ...]:
+    def exit_candidates(self, price: int) -> tuple[int, ...]:
         """X_m(P) = {P} ∪ {tick_ceil(d_h) : d_h > P}, ascending, deduplicated.
 
         Finite by §4.7: inside a band ``tick(Q)/Q`` is strictly decreasing in
@@ -258,7 +253,7 @@ def _require_nonneg_exact(x: object, label: str) -> None:
         raise TickTableError(f"{label} must be >= 0, got {x}")
 
 
-def _ceil_int(x: "int | Fraction", divisor: int) -> int:
+def _ceil_int(x: int | Fraction, divisor: int) -> int:
     """``ceil(x / divisor)`` as an exact integer. ``divisor > 0`` required."""
     if divisor <= 0:  # pragma: no cover - guarded at construction
         raise TickTableError(f"divisor must be > 0, got {divisor}")

--- a/research/krb1c_reducer_indep/tick.py
+++ b/research/krb1c_reducer_indep/tick.py
@@ -1,0 +1,306 @@
+"""P0-1 KRX tick function — exact integer arithmetic only.
+
+Clause basis (§6.2.1 §4):
+
+  4.1~4.3  tick_m(x) = P0-1 확정 시장별 함수. 구간표는 중첩·공백 없고 마지막은
+           open-ended. symbol↔표 매핑 불완전이면 P0-1 FAIL.
+  4.5      E_m: p_0 = tick_ceil(5,000), p_{k+1} = tick_ceil(p_k + 1), up to
+           400,000. 엄격 증가 필수, 샘플링·연속 최적화 금지.
+  4.6      X_m(P) = {P} ∪ {tick_ceil(d_h) : 구간 하한 d_h > P}.
+
+Sealed P0-1 table (KRX standard 주권 호가단위, identical band structure for
+KOSPI and KOSDAQ; carried in the sealed verification evidence
+krb1c-math-verify-2026-07-28.md §1, cross-checked against the repository's
+independent copies app/mcp_server/tick_size.py and
+app/services/quote_parity_shadow.py):
+
+    [0, 2,000)          1
+    [2,000, 5,000)      5
+    [5,000, 20,000)     10
+    [20,000, 50,000)    50
+    [50,000, 200,000)   100
+    [200,000, 500,000)  500
+    [500,000, inf)      1,000
+
+NOTE ON INDEPENDENCE FROM THE REPO HELPER: app/mcp_server/tick_size.py takes a
+``float`` argument and rounds with ``math.floor``/``math.ceil`` on a float
+quotient. It is therefore unusable under the §6 "float/Decimal 유한정밀 비교
+금지" constraint and is NOT imported here. Only the *band table* is reused, as
+sealed data, and the tick_ceil semantics are re-derived from the clause.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Optional, Sequence, Tuple
+
+# §6.2.1 §1.3 — 가격 범위 5,000 ≤ P ≤ 400,000 정수 KRW.
+PRICE_MIN: int = 5_000
+PRICE_MAX: int = 400_000
+
+
+class TickTableError(ValueError):
+    """P0-1 FAIL — tick table structural defect (§8.1(j))."""
+
+
+@dataclass(frozen=True)
+class TickBand:
+    """A half-open price band ``[lower, upper)`` with a constant tick.
+
+    ``upper is None`` marks the open-ended final band (§4.3).
+    """
+
+    lower: int
+    upper: Optional[int]
+    tick: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lower, int) or isinstance(self.lower, bool):
+            raise TickTableError(f"band lower must be int, got {self.lower!r}")
+        if not isinstance(self.tick, int) or isinstance(self.tick, bool):
+            raise TickTableError(f"band tick must be int, got {self.tick!r}")
+        if self.upper is not None and (
+            not isinstance(self.upper, int) or isinstance(self.upper, bool)
+        ):
+            raise TickTableError(f"band upper must be int, got {self.upper!r}")
+        if self.lower < 0:
+            raise TickTableError(f"band lower must be >= 0, got {self.lower}")
+        if self.tick <= 0:
+            raise TickTableError(f"band tick must be > 0, got {self.tick}")
+        if self.upper is not None and self.upper <= self.lower:
+            raise TickTableError(f"band upper {self.upper} <= lower {self.lower}")
+
+    def contains(self, x: int) -> bool:
+        if x < self.lower:
+            return False
+        return self.upper is None or x < self.upper
+
+
+class TickTable:
+    """Per-market tick function with exact integer ``tick`` and ``tick_ceil``.
+
+    Structural invariants enforced at construction (§4.1~4.3, §8.1(j)):
+
+    * bands are sorted strictly ascending by ``lower``;
+    * no gap and no overlap — band ``i+1`` starts exactly where band ``i`` ends;
+    * the first band starts at 0 (total coverage of non-negative prices);
+    * exactly the last band is open-ended;
+    * every band lower bound is a multiple of that band's own tick, so that the
+      valid prices inside band ``[d_h, d_{h+1})`` are exactly the multiples of
+      ``t_h`` in that interval. A table violating this is rejected rather than
+      silently mishandled.
+    """
+
+    __slots__ = ("market", "bands", "provenance")
+
+    def __init__(
+        self,
+        market: str,
+        bands: Sequence[TickBand],
+        provenance: str,
+    ) -> None:
+        if not bands:
+            raise TickTableError("tick table must have at least one band")
+        bands = tuple(bands)
+
+        if bands[0].lower != 0:
+            raise TickTableError(
+                f"first band must start at 0, got {bands[0].lower}"
+            )
+        for i in range(len(bands) - 1):
+            if bands[i].upper is None:
+                raise TickTableError(
+                    f"open-ended band at index {i} is not last (§4.3)"
+                )
+            if bands[i].upper != bands[i + 1].lower:
+                raise TickTableError(
+                    "band gap/overlap between "
+                    f"{bands[i]} and {bands[i + 1]} (§4.2)"
+                )
+        if bands[-1].upper is not None:
+            raise TickTableError("last band must be open-ended (§4.3)")
+
+        for band in bands:
+            if band.lower % band.tick != 0:
+                raise TickTableError(
+                    f"band lower {band.lower} is not a multiple of its tick "
+                    f"{band.tick}; valid-price lattice would be ambiguous"
+                )
+
+        self.market = market
+        self.bands = bands
+        self.provenance = provenance
+
+    # ---- core functions -------------------------------------------------
+
+    def tick(self, x: int) -> int:
+        """tick_m(x) — the tick size in force at price ``x``. Exact int."""
+        _require_nonneg_int(x, "tick argument")
+        for band in self.bands:
+            if band.contains(x):
+                return band.tick
+        raise TickTableError(f"no band covers price {x}")  # pragma: no cover
+
+    def band_lower_bounds(self) -> Tuple[int, ...]:
+        """The ordered band lower bounds ``d_h`` (§4.6 candidate generators)."""
+        return tuple(band.lower for band in self.bands)
+
+    def is_valid_price(self, x: int) -> bool:
+        """True iff ``x`` is a quotable price: a multiple of its band's tick."""
+        _require_nonneg_int(x, "price")
+        return x % self.tick(x) == 0
+
+    def tick_ceil(self, x: "int | Fraction") -> int:
+        """Smallest valid quote price ``>= x``. Exact arithmetic, int result.
+
+        Accepts an exact ``Fraction`` as well as an ``int`` so that §6.8's
+        ``T_i = tick_ceil(L × (1 + cap))`` can be evaluated on the exact
+        rational product without ever materialising a float.
+
+        Defined structurally rather than as ``ceil(x / tick(x)) * tick(x)``:
+        that shortcut can land outside the band it was computed in whenever a
+        band boundary is crossed. Here each band is probed in ascending order
+        and the first band that actually admits a multiple of its own tick in
+        ``[max(x, d_h), d_{h+1})`` wins, which is exactly "the least valid
+        price >= x".
+        """
+        _require_nonneg_exact(x, "tick_ceil argument")
+        for band in self.bands:
+            start = x if x > band.lower else band.lower
+            # least multiple of band.tick that is >= start
+            candidate = _ceil_int(start, band.tick) * band.tick
+            if band.upper is None or candidate < band.upper:
+                return candidate
+        raise TickTableError(  # pragma: no cover
+            f"tick_ceil undefined for {x}"
+        )
+
+    def tick_floor(self, x: int) -> int:
+        """Largest valid quote price ``<= x`` (not used by §6.2.1; provided so
+        boundary tests can pin the lattice from both sides)."""
+        _require_nonneg_int(x, "tick_floor argument")
+        for band in reversed(self.bands):
+            if x < band.lower:
+                continue
+            candidate = (x // band.tick) * band.tick
+            if candidate >= band.lower:
+                return candidate
+        raise TickTableError(f"tick_floor undefined for {x}")  # pragma: no cover
+
+    # ---- §4.5 valid price set -------------------------------------------
+
+    def valid_prices(
+        self, low: int = PRICE_MIN, high: int = PRICE_MAX
+    ) -> Tuple[int, ...]:
+        """E_m — full enumeration, exactly per §4.5.
+
+        ``p_0 = tick_ceil(low)``; ``p_{k+1} = tick_ceil(p_k + 1)``; stop once
+        the iterate exceeds ``high``. Strict increase is asserted, not assumed
+        (§4.5 "엄격 증가 필수"). No sampling, no continuous optimisation.
+        """
+        _require_nonneg_int(low, "low")
+        _require_nonneg_int(high, "high")
+        if high < low:
+            raise TickTableError(f"high {high} < low {low}")
+
+        out: list[int] = []
+        p = self.tick_ceil(low)
+        while p <= high:
+            if out and p <= out[-1]:
+                raise TickTableError(  # pragma: no cover
+                    f"E_m not strictly increasing at {p} after {out[-1]}"
+                )
+            if not self.is_valid_price(p):
+                raise TickTableError(  # pragma: no cover
+                    f"E_m produced non-quotable price {p}"
+                )
+            out.append(p)
+            p = self.tick_ceil(p + 1)
+        return tuple(out)
+
+    # ---- §4.6 exit candidate set ----------------------------------------
+
+    def exit_candidates(self, price: int) -> Tuple[int, ...]:
+        """X_m(P) = {P} ∪ {tick_ceil(d_h) : d_h > P}, ascending, deduplicated.
+
+        Finite by §4.7: inside a band ``tick(Q)/Q`` is strictly decreasing in
+        ``Q``, so only the first valid price of each strictly-higher band can
+        beat the incumbent, and the open-ended final band's supremum is
+        attained at its own first valid price.
+        """
+        _require_nonneg_int(price, "price")
+        found = {price}
+        for lower in self.band_lower_bounds():
+            if lower > price:
+                found.add(self.tick_ceil(lower))
+        return tuple(sorted(found))
+
+
+def _require_nonneg_int(x: object, label: str) -> None:
+    if not isinstance(x, int) or isinstance(x, bool):
+        raise TickTableError(f"{label} must be a non-bool int, got {x!r}")
+    if x < 0:
+        raise TickTableError(f"{label} must be >= 0, got {x}")
+
+
+def _require_nonneg_exact(x: object, label: str) -> None:
+    """Accept only exact non-negative numerics: ``int`` or ``Fraction``.
+
+    A ``float`` (or ``Decimal``) argument is a hard error, not a coercion:
+    §6 forbids finite-precision comparison anywhere in the reducer.
+    """
+    if isinstance(x, bool) or not isinstance(x, (int, Fraction)):
+        raise TickTableError(
+            f"{label} must be an exact int or Fraction, got {type(x).__name__}"
+        )
+    if x < 0:
+        raise TickTableError(f"{label} must be >= 0, got {x}")
+
+
+def _ceil_int(x: "int | Fraction", divisor: int) -> int:
+    """``ceil(x / divisor)`` as an exact integer. ``divisor > 0`` required."""
+    if divisor <= 0:  # pragma: no cover - guarded at construction
+        raise TickTableError(f"divisor must be > 0, got {divisor}")
+    q = Fraction(x, 1) / divisor if isinstance(x, int) else x / divisor
+    num, den = q.numerator, q.denominator
+    return -((-num) // den)
+
+
+# --- sealed P0-1 tables ---------------------------------------------------
+#
+# KOSPI and KOSDAQ are declared separately and independently. They are not
+# aliased to one object: §3 forbids copying across markets, and a future P0-1
+# revision may diverge them (KOSDAQ historically capped its tick at 100).
+
+_KRX_STANDARD_EQUITY_BANDS = (
+    (0, 2_000, 1),
+    (2_000, 5_000, 5),
+    (5_000, 20_000, 10),
+    (20_000, 50_000, 50),
+    (50_000, 200_000, 100),
+    (200_000, 500_000, 500),
+    (500_000, None, 1_000),
+)
+
+_KOSPI_PROVENANCE = (
+    "KRX 유가증권시장 호가가격단위 (표준 주권), sealed via "
+    "krb1c-math-verify-2026-07-28.md §1 "
+    "sha256 7382f94125c5a6f1fbcb143470734a7e0987e9c0d04cd64d88741739b6dcc059"
+)
+_KOSDAQ_PROVENANCE = (
+    "KRX 코스닥시장 호가단위 (표준 주권), sealed via "
+    "krb1c-math-verify-2026-07-28.md §1 "
+    "sha256 7382f94125c5a6f1fbcb143470734a7e0987e9c0d04cd64d88741739b6dcc059"
+)
+
+KOSPI_TICK_TABLE = TickTable(
+    "KOSPI",
+    [TickBand(lo, hi, t) for (lo, hi, t) in _KRX_STANDARD_EQUITY_BANDS],
+    _KOSPI_PROVENANCE,
+)
+KOSDAQ_TICK_TABLE = TickTable(
+    "KOSDAQ",
+    [TickBand(lo, hi, t) for (lo, hi, t) in _KRX_STANDARD_EQUITY_BANDS],
+    _KOSDAQ_PROVENANCE,
+)


### PR DESCRIPTION
§7.7 순서의 **3단계(독립 재현)** + **4단계(전수 대조)**. 참조 구현(PR #1703)은 2단계.

## 판정

**전수 일치 — 불일치 0건.** 8,002행 / **128,032 필드 비교** / 스칼라 8종 전부 일치.

| | |
|---|---|
| `C_raw` | `146/19907` |
| witness | KOSPI `P=20,000` (KOSDAQ 동률 → §6 규칙) |
| `C_stress_cap_bp` | **74** |
| `C_stress_cap` | **`0.0074`** |
| §6.9 검산 | 8,002 / 8,002 통과 |

## 독립성

독립 구현 커밋 **`e6d6c63b`** 이 독립성의 타임스탬프다.

- `origin/main`(`b425cda1a`)에서 분기 — 참조 패키지가 워크트리에 물리적으로 없음(착수 시 grep 확인).
- PR #1703 의 view/diff·브랜치 체크아웃·참조 파일 열람은 **전부 `e6d6c63b` 이후** 최초 실행.
- 입력은 봉인 원문 + 부모 canonical + 봉인 manifest 에 SHA 등재된 검증증거(P0-1 호가표)뿐.
- 후속 커밋 `730b8941` 은 참조의 **published CSV/JSON 아티팩트만** 읽는다. 참조 모듈 import·vendoring 없음. `reducer.py`/`tick.py` 는 `e6d6c63b` 이후 불변.

## canonical SHA 재확인

`d5da5edd…be389` (amendment) / `d5e1246b…d9d6f1` (부모) 모두 지시문과 일치. 나아가 `load_from_canonical()` 이 실행마다 파일 SHA + 요율·세금 component·부모 SHA·append-only 관계를 재대조하고 불일치 시 fail-closed.

## 전수성

전수열거 공간 = 실행 개수. 축소·샘플링 없음.

| | 공간 | 실행 |
|---|---:|---:|
| E_KOSPI / E_KOSDAQ | 4,001 / 4,001 | 4,001 / 4,001 |
| candidate 합계 | 8,002 | **8,002** |
| §6.9 target 검산 | 8,002 | **8,002** |

`|E_m|=4,001` 은 봉인 수학검증과 일치. §4.5 재귀 생성 결과가 `range(5_000, 400_001)` brute-force 필터와 튜플 동일함을 테스트로 고정.

## float 미사용

- **정적**: AST 스캔이 float/complex 리터럴, `math`/`decimal`/`numpy` import, `float`/`Decimal` 이름·속성을 전부 금지 → 5파일 0건. 가드 공허통과 방지 테스트 포함.
- **동적**: 8,002 candidate + 8,002 target 검산의 **모든 필드**가 `int`/`Fraction` 임을 단언.
- **인터페이스**: `tick_ceil` 은 float 인자를 `TickTableError` 로 거부. §6.8 은 exact rational 곱을 그대로 전달.
- `app/mcp_server/tick_size.py` 는 float+`math.floor/ceil` 이라 **import하지 않음**. 밴드표 데이터만 재사용, `tick_ceil` 시맨틱은 조문에서 재유도.

## 공유 가정 교차검증

두 구현이 같은 §4.6/§4.7 지름길(`X_m(P)`)에 의존하므로, 어느 쪽 로직도 쓰지 않는 brute-force 를 추가했다: `P ∈ E_m` **4,001개 전부**에 대해 모든 유효호가 `Q ≥ P` 를 1,000,000 까지 훑어 `ρ_exit` 재계산 → witness 까지 전건 일치. 밴드 내 `tick(Q)/Q` 엄격 감소를 격자 위에서 직접 assert 해 꼬리를 단조성으로 덮음. 정수 교차곱 비교.

§6.9 가 항진명제 아님도 고정(`cap=0` → 전건 실패).

### 기록: §6.9 는 cap 의 tight inverse 가 아님

`73bp` 로 낮춰도 witness 에서 §6.9 는 통과한다 — `tick_ceil(20,146)=20,150` 올림 여유 때문. 즉 §6.9 는 **필요조건 자기검산**이지 cap 유도식이 아니다. 봉인 수학검증 ②("정상 실패 케이스 없음, 실패는 결함 신호")와 부합. 결함이 아니라 성질이라 테스트로 보존.

## 참조에 대한 지적 사항 — 없음

불일치 0건이라 §8.7 조정이 발생하지 않았다. 참조는 수정하지 않았다.
참고로 내 스캐너가 참조의 `krb1_c_stress_independent_verify.py:15 from math` 를 잡았으나 실제로는 `from math import gcd` (정수 exact) 단 하나 → **§6 위반 아님**. 참조 reducer 코어 4파일은 findings 0.

## 테스트

`137 passed`. fail-closed 경로 10종(§8.1 a/c/e/g/i/k 등), §3 "각각 독립 기간 최대"(B/S/A 가 서로 다른 record 에서), §5 "additive 근사 binding 금지"(곱셈형이 가산형보다 엄격히 큼), §6 동률 witness 규칙 전부 양성 고정. 참조 자체 스위트도 재현 확인용 실행 → `8 passed`.

## 범위 밖 — 이 PR 이 하지 않는 것

- **P0-2 completion hash 미생성.** §7.7 5단계는 전수일치 **+ 독립성 검토 PASS** 뒤에만 가능하며, 독립성 검토는 운영자·검증자 몫이다.
- **§7.2 의 "정확히 1회" 봉인 numeric reducer 실행이 아니다.** 형식 sealed P0 아티팩트가 아직 없다.
- broker/order/watch/journal mutation, 실주문, 배포, production DB write 전무. migration 0.

전체 보고서: `~/work/herdr-inbox/reducer-indep-2026-07-28.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an independent market-cost reducer supporting KOSPI and KOSDAQ tick rules.
  * Added command-line processing that generates normalized inputs, candidate CSV data, and reducer result reports.
  * Added canonical input verification with fail-closed validation and clear error reporting.
  * Added comparison tooling to identify differences from reference candidate and result data.

* **Bug Fixes**
  * Improved reliability through exact arithmetic, deterministic tie handling, and comprehensive price-target checks.

* **Tests**
  * Added extensive validation for tick boundaries, candidate enumeration, input integrity, rounding, and reducer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->