### PR TITLE
docs(ROB-1088): kt00009 mrkt_tp 근거 문서화 + US 무관 회귀 가드

### DIFF
--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -69,7 +69,7 @@ ACCOUNT_ORDER_STK_BOND_TP_DEFAULT = "0"  # kt00009 주식채권구분(전체)
 ACCOUNT_ORDER_MRKT_TP_DEFAULT = "0"  # ROB-1111 — kt00009 시장구분(전체)
 
 # ROB-1088 (2026-07-28, independent-verification fix) — 공식 Kiwoom REST 문서
-# (https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=02)
+# (https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=08)
 # 직접 확인 결과 kt00009(계좌별주문체결현황요청) 요청 body는 다음 5개 필드를
 # 전부 Required=Y로 요구한다(공식 HTML 표, 2026-07-28 확인):
 #   stk_bond_tp   Required=Y  "0:전체, 1:주식, 2:채권"

--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -67,12 +67,26 @@ ACCOUNT_BALANCE_QRY_TP_DEFAULT = "1"  # kt00018 조회구분
 ACCOUNT_DEPOSIT_QRY_TP_DEFAULT = "2"  # ROB-891 — kt00001 일반조회 (orderable cash)
 ACCOUNT_ORDER_STK_BOND_TP_DEFAULT = "0"  # kt00009 주식채권구분(전체)
 ACCOUNT_ORDER_MRKT_TP_DEFAULT = "0"  # ROB-1111 — kt00009 시장구분(전체)
-# ROB-1088 — "0"(전체) 값의 근거: bamjun/kiwoom-rest-api(서드파티 REST 클라이언트,
-# MIT/PyPI)가 kt00009 mrkt_tp를 "0:전체, 1:코스피, 2:코스닥, 3:OTCBB, 4:ECN"으로
-# 문서화. 공식 apiportal.kiwoom.com 문서는 이 세션에서 접근 불가(네트워크 미해결).
-# 실제 mockapi.kiwoom.com 호출로 이 값의 성공을 확인한 기록은 아직 없다(unit-test
-# 전용 검증, PR #1693). 자세한 근거·잔여 리스크는 domestic_account.py의
-# get_order_status 주석 참고.
+
+# ROB-1088 (2026-07-28, independent-verification fix) — 공식 Kiwoom REST 문서
+# (https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=02)
+# 직접 확인 결과 kt00009(계좌별주문체결현황요청) 요청 body는 다음 5개 필드를
+# 전부 Required=Y로 요구한다(공식 HTML 표, 2026-07-28 확인):
+#   stk_bond_tp   Required=Y  "0:전체, 1:주식, 2:채권"
+#   mrkt_tp       Required=Y  "0:전체, 1:코스피, 2:코스닥, 3:OTCBB, 4:ECN"
+#   sell_tp       Required=Y  "0:전체, 1:매도, 2:매수"
+#   qry_tp        Required=Y  "0:전체, 1:체결"
+#   dmst_stex_tp  Required=Y  "%:(전체), KRX:한국거래소, NXT:넥스트트레이드, SOR:최선주문집행"
+# 앞서(PR #1708 초판) sell_tp/qry_tp/dmst_stex_tp를 "서드파티 근거뿐인 추측"으로
+# 보류했었다 — 독립 검증이 공식 문서를 직접 열어 5필드 전부 Required=Y임을
+# 확인해 그 보류가 틀렸음을 지적했다(공식 계약 불일치, BLOCK). 이 두 상수는
+# 공식 문서에서 직접 확정한 값이며 추측이 아니다.
+ACCOUNT_ORDER_SELL_TP_DEFAULT = "0"  # kt00009 매도수구분(전체)
+ACCOUNT_ORDER_QRY_TP_DEFAULT = "0"  # kt00009 조회구분(전체)
+# dmst_stex_tp는 아래 ACCOUNT_DMST_STEX_TP_DEFAULT("KRX")를 그대로 재사용한다 —
+# 공식 값 선택지는 %(전체)/KRX/NXT/SOR이지만, kiwoom_mock은 KRX-only이고
+# MOCK_REJECTED_EXCHANGES={"NXT","SOR"}이 그 경계를 강제한다. "%"(전체)는 NXT/SOR
+# 결과까지 섞어 그 fail-closed 경계를 사실상 무력화하므로 선택하지 않는다.
 
 # ROB-460 — Kiwoom REST account-cash reads also require dmst_stex_tp (국내거래소구분).
 # 2026-06-09 live: get_positions(kt00018)·get_orderable_cash returned return_code 2
@@ -81,8 +95,11 @@ ACCOUNT_ORDER_MRKT_TP_DEFAULT = "0"  # ROB-1111 — kt00009 시장구분(전체)
 # dmst_stex_tp=MOCK_EXCHANGE_KRX successfully. Mock is KRX-only (NXT/SOR rejected on
 # the order path), so KRX is the only valid selection. Applied to kt00018 balance
 # reads. ROB-891: kt00001 and kt00010 official docs do NOT include dmst_stex_tp, so
-# it is no longer sent on those endpoints. Order-history reads (kt00009/kt00007)
-# remain untouched — not proven to need it (smoke-validated).
+# it is no longer sent on those endpoints.
+# ROB-1088 (2026-07-28) — kt00009 order-history reads DO require dmst_stex_tp per
+# the official docs (see the ROB-1088 block above); "KRX" is reused here for that
+# endpoint too, on top of the already-applied kt00018 usage. kt00007 remains
+# untouched (not yet called by this codebase).
 ACCOUNT_DMST_STEX_TP_DEFAULT = MOCK_EXCHANGE_KRX  # "KRX" — 국내거래소구분
 
 # ---------------------------------------------------------------------------

--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -67,6 +67,12 @@ ACCOUNT_BALANCE_QRY_TP_DEFAULT = "1"  # kt00018 조회구분
 ACCOUNT_DEPOSIT_QRY_TP_DEFAULT = "2"  # ROB-891 — kt00001 일반조회 (orderable cash)
 ACCOUNT_ORDER_STK_BOND_TP_DEFAULT = "0"  # kt00009 주식채권구분(전체)
 ACCOUNT_ORDER_MRKT_TP_DEFAULT = "0"  # ROB-1111 — kt00009 시장구분(전체)
+# ROB-1088 — "0"(전체) 값의 근거: bamjun/kiwoom-rest-api(서드파티 REST 클라이언트,
+# MIT/PyPI)가 kt00009 mrkt_tp를 "0:전체, 1:코스피, 2:코스닥, 3:OTCBB, 4:ECN"으로
+# 문서화. 공식 apiportal.kiwoom.com 문서는 이 세션에서 접근 불가(네트워크 미해결).
+# 실제 mockapi.kiwoom.com 호출로 이 값의 성공을 확인한 기록은 아직 없다(unit-test
+# 전용 검증, PR #1693). 자세한 근거·잔여 리스크는 domestic_account.py의
+# get_order_status 주석 참고.
 
 # ROB-460 — Kiwoom REST account-cash reads also require dmst_stex_tp (국내거래소구분).
 # 2026-06-09 live: get_positions(kt00018)·get_orderable_cash returned return_code 2

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -134,6 +134,25 @@ class KiwoomDomesticAccountClient:
             # return_code 2 (필수입력 파라미터=stk_bond_tp).
             # ROB-1111 — kt00009 ALSO requires mrkt_tp; omitting it returns
             # return_code 2 (필수입력 파라미터=mrkt_tp).
+            #
+            # ROB-1088 — mrkt_tp="0" (시장구분: 전체) 값의 근거: 공식 Kiwoom REST
+            # 문서는 이 세션에서 직접 확보하지 못했다(apiportal.kiwoom.com 접근 불가,
+            # 일반 웹검색으로 kt00009 명세 미발견). 대신 kt00009와 필드가 거의 겹치는
+            # kt00007/kt00018/kt00010 body를 실제 필드명 그대로 문서화한 서드파티
+            # REST 클라이언트(bamjun/kiwoom-rest-api, MIT, PyPI 배포)의
+            # account_order_execution_status_request_kt00009 시그니처를 대조 근거로
+            # 사용했다: stk_bond_tp(0:전체/1:주식/2:채권), mrkt_tp(0:전체/1:코스피/
+            # 2:코스닥/3:OTCBB/4:ECN), sell_tp(0:전체/1:매도/2:매수), qry_tp(0:전체/
+            # 1:체결), dmst_stex_tp(%:전체/KRX/NXT/SOR) 5개를 전부 위치 인자(문서상
+            # optional 표기 없음)로 요구한다.
+            # 이 라이브러리의 kt00007/kt00018 필드명·구조가 이 코드베이스의 실측
+            # 확정값(ROB-418/ROB-460/ROB-891)과 100% 일치해 신뢰도가 있다.
+            # 다만 sell_tp/qry_tp/dmst_stex_tp는 이 서드파티 문서에만 근거하며
+            # 이 코드베이스의 실측(return_code 2)으로 아직 증명되지 않았다 — 추측
+            # 파라미터를 여기서 추가하지 않는다(작동 중인 stk_bond_tp+mrkt_tp 조합을
+            # 회귀시키지 않기 위함). 07-29 08:50 스모크에서
+            # `필수입력 파라미터=sell_tp|qry_tp|dmst_stex_tp` 형태의 return_code 2가
+            # 재현되면 그 파라미터명을 근거로 후속 수정을 연다.
             body={
                 "stk_bond_tp": constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,
                 "mrkt_tp": constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT,

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -130,32 +130,37 @@ class KiwoomDomesticAccountClient:
         return await self._client.post_api(
             api_id=constants.ACCOUNT_ORDER_STATUS_API_ID,
             path=ACCOUNT_PATH,
-            # ROB-418 — kt00009 requires stk_bond_tp; omitting it returns
-            # return_code 2 (필수입력 파라미터=stk_bond_tp).
-            # ROB-1111 — kt00009 ALSO requires mrkt_tp; omitting it returns
-            # return_code 2 (필수입력 파라미터=mrkt_tp).
-            #
-            # ROB-1088 — mrkt_tp="0" (시장구분: 전체) 값의 근거: 공식 Kiwoom REST
-            # 문서는 이 세션에서 직접 확보하지 못했다(apiportal.kiwoom.com 접근 불가,
-            # 일반 웹검색으로 kt00009 명세 미발견). 대신 kt00009와 필드가 거의 겹치는
-            # kt00007/kt00018/kt00010 body를 실제 필드명 그대로 문서화한 서드파티
-            # REST 클라이언트(bamjun/kiwoom-rest-api, MIT, PyPI 배포)의
-            # account_order_execution_status_request_kt00009 시그니처를 대조 근거로
-            # 사용했다: stk_bond_tp(0:전체/1:주식/2:채권), mrkt_tp(0:전체/1:코스피/
-            # 2:코스닥/3:OTCBB/4:ECN), sell_tp(0:전체/1:매도/2:매수), qry_tp(0:전체/
-            # 1:체결), dmst_stex_tp(%:전체/KRX/NXT/SOR) 5개를 전부 위치 인자(문서상
-            # optional 표기 없음)로 요구한다.
-            # 이 라이브러리의 kt00007/kt00018 필드명·구조가 이 코드베이스의 실측
-            # 확정값(ROB-418/ROB-460/ROB-891)과 100% 일치해 신뢰도가 있다.
-            # 다만 sell_tp/qry_tp/dmst_stex_tp는 이 서드파티 문서에만 근거하며
-            # 이 코드베이스의 실측(return_code 2)으로 아직 증명되지 않았다 — 추측
-            # 파라미터를 여기서 추가하지 않는다(작동 중인 stk_bond_tp+mrkt_tp 조합을
-            # 회귀시키지 않기 위함). 07-29 08:50 스모크에서
-            # `필수입력 파라미터=sell_tp|qry_tp|dmst_stex_tp` 형태의 return_code 2가
-            # 재현되면 그 파라미터명을 근거로 후속 수정을 연다.
+            # ROB-1088 (2026-07-28, independent-verification fix) — Official
+            # Kiwoom REST docs
+            # (https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=02)
+            # list kt00009's request body as five Required=Y fields:
+            #   stk_bond_tp   "0:전체, 1:주식, 2:채권"        (ROB-418)
+            #   mrkt_tp       "0:전체, 1:코스피, 2:코스닥, 3:OTCBB, 4:ECN"  (ROB-1111)
+            #   sell_tp       "0:전체, 1:매도, 2:매수"        (ROB-1088)
+            #   qry_tp        "0:전체, 1:체결"                (ROB-1088)
+            #   dmst_stex_tp  "%:(전체), KRX, NXT, SOR"       (ROB-1088)
+            # An earlier revision of this fix (PR #1708 initial version) sent
+            # only the first two, having treated sell_tp/qry_tp/dmst_stex_tp as
+            # unproven speculation sourced only from a third-party REST client
+            # (bamjun/kiwoom-rest-api). Independent verification opened the
+            # official doc directly and found all five Required=Y — that
+            # revision was a contract mismatch, not caution. All five values
+            # below are read directly off the official table, not guessed.
+            # dmst_stex_tp uses "KRX" (not "%"): kiwoom_mock is KRX-only
+            # (MOCK_REJECTED_EXCHANGES={"NXT","SOR"}), and "%"(전체) would blend
+            # NXT/SOR results into a fail-closed-only surface, undermining that
+            # boundary even though the docs allow it as a value.
+            # NOTE: return_code 0 for this exact five-field body has NOT been
+            # confirmed via a real mockapi.kiwoom.com call in this codebase —
+            # only unit tests exercise it (mutation/live-call is out of scope
+            # for this fix). The 07-29 08:50 KR-B1 P0-3 smoke is the first real
+            # verification opportunity.
             body={
                 "stk_bond_tp": constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,
                 "mrkt_tp": constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT,
+                "sell_tp": constants.ACCOUNT_ORDER_SELL_TP_DEFAULT,
+                "qry_tp": constants.ACCOUNT_ORDER_QRY_TP_DEFAULT,
+                "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
             },
             cont_yn=cont_yn,
             next_key=next_key,

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -132,7 +132,7 @@ class KiwoomDomesticAccountClient:
             path=ACCOUNT_PATH,
             # ROB-1088 (2026-07-28, independent-verification fix) — Official
             # Kiwoom REST docs
-            # (https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=02)
+            # (https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=08)
             # list kt00009's request body as five Required=Y fields:
             #   stk_bond_tp   "0:전체, 1:주식, 2:채권"        (ROB-418)
             #   mrkt_tp       "0:전체, 1:코스피, 2:코스닥, 3:OTCBB, 4:ECN"  (ROB-1111)

--- a/docs/runbooks/kiwoom-mock-smoke.md
+++ b/docs/runbooks/kiwoom-mock-smoke.md
@@ -134,7 +134,7 @@ stays deferred). To pick a conservative buy limit well below market that will
 > `stk_bond_tp`를, ROB-1111이 `mrkt_tp`를 각각 관례값으로 복구했으나, 그 시점에는
 > 공식 문서를 직접 확보하지 못해 두 필드만으로 충분한지 불확실했다.
 > **ROB-1088 독립 검증**이 공식 Kiwoom REST 문서
-> (`https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=02`,
+> (`https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=08`,
 > 2026-07-28 직접 확인)를 열어 kt00009 요청 body가 **5개 필드 전부 `Required=Y`**
 > 임을 확정했다:
 > `stk_bond_tp`(0:전체/1:주식/2:채권), `mrkt_tp`(0:전체/1:코스피/2:코스닥/3:OTCBB/

--- a/docs/runbooks/kiwoom-mock-smoke.md
+++ b/docs/runbooks/kiwoom-mock-smoke.md
@@ -35,9 +35,13 @@ these boundaries:
   reads 중 **kt00018(잔고)** 의 요청 본문에만 `dmst_stex_tp="KRX"`를 채운다.
   이 값은 order 엔드포인트(kt10000-kt10003)에서 이미 검증된 값(추측 아님)이며
   mock은 KRX 전용이다. **경계 결정:** kt00010(주문가능, with-symbol)은
-  `stk_cd`/`trde_tp`/`uv`만 보내고 `dmst_stex_tp`를 보내지 않는다. order-history reads
-  **kt00009/kt00007**는 의도적으로 미변경 — 이미 ROB-418로 복구됐고 `dmst_stex_tp`
+  `stk_cd`/`trde_tp`/`uv`만 보내고 `dmst_stex_tp`를 보내지 않는다. 당시(2026-06-09)
+  **kt00009/kt00007**는 의도적으로 미변경 — ROB-418로 이미 복구됐고 `dmst_stex_tp`
   필요가 입증되지 않았다(작동 중인 엔드포인트에 추측 파라미터를 더해 회귀시키지 않음).
+  **이 판단은 ROB-1088(2026-07-28)에서 뒤집혔다** — kt00009는 공식 문서 확인 결과
+  `dmst_stex_tp`를 포함한 5필드 전부가 Required=Y이며, 현재 코드는 5필드를 모두
+  보낸다(kt00007은 여전히 코드가 호출하지 않으므로 미해당). 아래 ROB-1111/ROB-1088
+  블록 참고.
   아래 smoke 체크리스트로 4개 read 도구를 한 번에 검증하여 잔여 누락을 선제 포착한다.
 - **ROB-899 — confirmed place preflight/dispatch client reuse:** confirmed place는
   preflight와 broker POST가 하나의 request-scoped `KiwoomMockClient`를 재사용하며,
@@ -125,19 +129,25 @@ stays deferred). To pick a conservative buy limit well below market that will
 > **kt00001(예수금상세현황)** 을 사용한다. kt00018의 `prsm_dpst_aset_amt`는
 > 추정예탁자산으로 보유증권 평가액을 포함하므로 주문가능현금의 근거가 될 수 없다.
 
-> **ROB-1111/ROB-1088 (2026-07-28):** `kiwoom_mock_get_order_history`(kt00009)가
-> `mrkt_tp`(시장구분) 누락으로 **전건 실패**했다(`return_code 2`,
-> `필수입력 파라미터=mrkt_tp`). `mrkt_tp="0"`(전체) 추가로 복구(PR #1693).
-> **이 값은 유닛테스트로만 검증됐고 mockapi.kiwoom.com 실호출로 확인된 적이
-> 없다(미검증).** 공식 apiportal.kiwoom.com 문서도 이 세션들에서 직접 확보하지
-> 못했다 — 근거는 kt00009와 필드가 겹치는 kt00007/kt00018을 실측-일치 필드명으로
-> 문서화한 서드파티 REST 클라이언트(bamjun/kiwoom-rest-api)뿐이다. 그 문서는
-> `sell_tp`(매도수구분)·`qry_tp`(조회구분)·`dmst_stex_tp`(국내거래소구분) 3개도
-> kt00009 필수 인자로 기술하지만, 이 3개는 **추측이라 아직 코드에 추가하지
-> 않았다**. 07-29 08:50 KR-B1 P0-3 스모크에서 `kiwoom_mock_get_order_history`를
-> 호출할 때 `return_code 2`(`필수입력 파라미터=sell_tp|qry_tp|dmst_stex_tp`)가
-> 재현되면 그 이름을 근거로 즉시 후속 fix를 연다 — 추측하지 말고 그 스모크의
-> 원문 오류를 근거로 확정한다.
+> **ROB-1111/ROB-1088 (2026-07-28, 공식 문서 확정):** `kiwoom_mock_get_order_history`
+> (kt00009)가 필수 파라미터 누락으로 **전건 실패**했다(`return_code 2`). ROB-418이
+> `stk_bond_tp`를, ROB-1111이 `mrkt_tp`를 각각 관례값으로 복구했으나, 그 시점에는
+> 공식 문서를 직접 확보하지 못해 두 필드만으로 충분한지 불확실했다.
+> **ROB-1088 독립 검증**이 공식 Kiwoom REST 문서
+> (`https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=02`,
+> 2026-07-28 직접 확인)를 열어 kt00009 요청 body가 **5개 필드 전부 `Required=Y`**
+> 임을 확정했다:
+> `stk_bond_tp`(0:전체/1:주식/2:채권), `mrkt_tp`(0:전체/1:코스피/2:코스닥/3:OTCBB/
+> 4:ECN), `sell_tp`(0:전체/1:매도/2:매수), `qry_tp`(0:전체/1:체결), `dmst_stex_tp`
+> (%:전체/KRX/NXT/SOR). 코드는 현재 5개 필드 전부를 보낸다.
+> `dmst_stex_tp`는 공식 문서상 `%`(전체)도 허용되지만, kiwoom_mock의 KRX-only
+> 경계(`MOCK_REJECTED_EXCHANGES={"NXT","SOR"}`)와 정합하도록 명시적으로 `KRX`를
+> 보낸다(`%`는 NXT/SOR 결과까지 섞어 그 경계를 사실상 무력화하므로 선택하지 않음).
+> **이 5필드 조합이 `return_code 0`을 낸다는 실제 mockapi.kiwoom.com 호출 증거는
+> 아직 없다** — 이 코드베이스에서는 유닛테스트로만 검증됐다(mutation/실호출 금지
+> 제약). 07-29 08:50 KR-B1 P0-3 스모크가 최초의 실제 검증 기회다. 그 스모크에서도
+> `return_code 2`가 재현되면, 위 5필드 외 정본 문서에 없는 추가 요구사항이 있다는
+> 뜻이므로 그 원문 오류 메시지를 근거로 후속 조사를 연다(추측 금지).
 
 ### 공식 TR 계약 (Kiwoom REST docs 기준)
 
@@ -146,7 +156,7 @@ stays deferred). To pick a conservative buy limit well below market that will
 | `kiwoom_mock_get_positions` | kt00018 | `qry_tp=1`, `dmst_stex_tp=KRX` | `acnt_evlt_remn_indv_tot` | `return_code 0` |
 | `kiwoom_mock_get_orderable_cash` (no symbol) | **kt00001** | `qry_tp=2` | `ord_alow_amt` | `return_code 0` |
 | `kiwoom_mock_get_orderable_cash` (with symbol) | kt00010 | `stk_cd`, `trde_tp`, `uv` | `ord_alowa` | `return_code 0` |
-| `kiwoom_mock_get_order_history` | kt00009 | `stk_bond_tp=0`, `mrkt_tp=0` | `acnt_ord_cntr_prst_array` | `return_code 0` (mrkt_tp 미검증, 위 경고 참고) |
+| `kiwoom_mock_get_order_history` | kt00009 | `stk_bond_tp=0`, `mrkt_tp=0`, `sell_tp=0`, `qry_tp=0`, `dmst_stex_tp=KRX` | `acnt_ord_cntr_prst_array` | `return_code 0` (실호출로 미검증, 위 경고 참고) |
 
 > **주의:** kt00001은 `qry_tp=2`만 요구하며 **`dmst_stex_tp`를 보내지 않는다**.
 > kt00010은 `stk_cd`/`trde_tp`/`uv`만 요구하며 **`dmst_stex_tp`를 보내지 않는다**.
@@ -158,13 +168,13 @@ stays deferred). To pick a conservative buy limit well below market that will
 | kt00018 | 잔고/포지션 (sellable 포함) | `qry_tp=1`, `dmst_stex_tp=KRX` | `acnt_evlt_remn_indv_tot` |
 | kt00001 | no-symbol 예수금/주문가능현금 | `qry_tp=2` | `ord_alow_amt` |
 | kt00010 | symbol/side/price 주문가능금액 | `stk_cd`, `trde_tp`, `uv` | `ord_alowa` |
-| kt00009 | 주문 이력 | `stk_bond_tp=0`, `mrkt_tp=0` | `acnt_ord_cntr_prst_array` |
+| kt00009 | 주문 이력 | `stk_bond_tp=0`, `mrkt_tp=0`, `sell_tp=0`, `qry_tp=0`, `dmst_stex_tp=KRX` | `acnt_ord_cntr_prst_array` |
 
 - 어떤 도구든 `필수입력 파라미터=<name>`(`return_code 2`)가 나오면 그 `<name>`을
   기록하고 해당 broker API 본문에 추가하는 follow-up을 연다(추측 금지, 증명된 누락만).
-- kt00009는 ROB-418(`stk_bond_tp`)·ROB-1111(`mrkt_tp`)로 2차례 부분 복구됐다 —
-  `sell_tp`/`qry_tp`/`dmst_stex_tp`가 남아 있을 가능성은 위 ROB-1111/ROB-1088 경고
-  참고. kt00007은 코드가 아직 호출하지 않으므로 미해당.
+- kt00009는 ROB-418(`stk_bond_tp`)·ROB-1111(`mrkt_tp`)·ROB-1088(공식 문서 확정,
+  `sell_tp`/`qry_tp`/`dmst_stex_tp`)로 완전히 5필드 공식 계약을 만족하도록 복구됐다
+  — 위 ROB-1111/ROB-1088 경고 참고. kt00007은 코드가 아직 호출하지 않으므로 미해당.
 - **US 경로(`kiwoom_mock_us_*`)는 kt00009/mrkt_tp와 무관하다** — `ust21050`/
   `ust21070`/`ust21510`/`ust21160` 등 별도 TR family를 쓰며 어떤 US 코드도
   `ACCOUNT_ORDER_STATUS_API_ID`("kt00009")를 참조하지 않는다(ROB-1088, 2026-07-28

--- a/docs/runbooks/kiwoom-mock-smoke.md
+++ b/docs/runbooks/kiwoom-mock-smoke.md
@@ -125,6 +125,20 @@ stays deferred). To pick a conservative buy limit well below market that will
 > **kt00001(예수금상세현황)** 을 사용한다. kt00018의 `prsm_dpst_aset_amt`는
 > 추정예탁자산으로 보유증권 평가액을 포함하므로 주문가능현금의 근거가 될 수 없다.
 
+> **ROB-1111/ROB-1088 (2026-07-28):** `kiwoom_mock_get_order_history`(kt00009)가
+> `mrkt_tp`(시장구분) 누락으로 **전건 실패**했다(`return_code 2`,
+> `필수입력 파라미터=mrkt_tp`). `mrkt_tp="0"`(전체) 추가로 복구(PR #1693).
+> **이 값은 유닛테스트로만 검증됐고 mockapi.kiwoom.com 실호출로 확인된 적이
+> 없다(미검증).** 공식 apiportal.kiwoom.com 문서도 이 세션들에서 직접 확보하지
+> 못했다 — 근거는 kt00009와 필드가 겹치는 kt00007/kt00018을 실측-일치 필드명으로
+> 문서화한 서드파티 REST 클라이언트(bamjun/kiwoom-rest-api)뿐이다. 그 문서는
+> `sell_tp`(매도수구분)·`qry_tp`(조회구분)·`dmst_stex_tp`(국내거래소구분) 3개도
+> kt00009 필수 인자로 기술하지만, 이 3개는 **추측이라 아직 코드에 추가하지
+> 않았다**. 07-29 08:50 KR-B1 P0-3 스모크에서 `kiwoom_mock_get_order_history`를
+> 호출할 때 `return_code 2`(`필수입력 파라미터=sell_tp|qry_tp|dmst_stex_tp`)가
+> 재현되면 그 이름을 근거로 즉시 후속 fix를 연다 — 추측하지 말고 그 스모크의
+> 원문 오류를 근거로 확정한다.
+
 ### 공식 TR 계약 (Kiwoom REST docs 기준)
 
 | 도구 | broker API | 공식 request body | 응답 필드 | 기대 |
@@ -132,7 +146,7 @@ stays deferred). To pick a conservative buy limit well below market that will
 | `kiwoom_mock_get_positions` | kt00018 | `qry_tp=1`, `dmst_stex_tp=KRX` | `acnt_evlt_remn_indv_tot` | `return_code 0` |
 | `kiwoom_mock_get_orderable_cash` (no symbol) | **kt00001** | `qry_tp=2` | `ord_alow_amt` | `return_code 0` |
 | `kiwoom_mock_get_orderable_cash` (with symbol) | kt00010 | `stk_cd`, `trde_tp`, `uv` | `ord_alowa` | `return_code 0` |
-| `kiwoom_mock_get_order_history` | kt00009 | `stk_bond_tp=0` | `acnt_ord_cntr_prst_array` | `return_code 0` |
+| `kiwoom_mock_get_order_history` | kt00009 | `stk_bond_tp=0`, `mrkt_tp=0` | `acnt_ord_cntr_prst_array` | `return_code 0` (mrkt_tp 미검증, 위 경고 참고) |
 
 > **주의:** kt00001은 `qry_tp=2`만 요구하며 **`dmst_stex_tp`를 보내지 않는다**.
 > kt00010은 `stk_cd`/`trde_tp`/`uv`만 요구하며 **`dmst_stex_tp`를 보내지 않는다**.
@@ -144,12 +158,17 @@ stays deferred). To pick a conservative buy limit well below market that will
 | kt00018 | 잔고/포지션 (sellable 포함) | `qry_tp=1`, `dmst_stex_tp=KRX` | `acnt_evlt_remn_indv_tot` |
 | kt00001 | no-symbol 예수금/주문가능현금 | `qry_tp=2` | `ord_alow_amt` |
 | kt00010 | symbol/side/price 주문가능금액 | `stk_cd`, `trde_tp`, `uv` | `ord_alowa` |
-| kt00009 | 주문 이력 | `stk_bond_tp=0` | `acnt_ord_cntr_prst_array` |
+| kt00009 | 주문 이력 | `stk_bond_tp=0`, `mrkt_tp=0` | `acnt_ord_cntr_prst_array` |
 
 - 어떤 도구든 `필수입력 파라미터=<name>`(`return_code 2`)가 나오면 그 `<name>`을
   기록하고 해당 broker API 본문에 추가하는 follow-up을 연다(추측 금지, 증명된 누락만).
-- 특히 kt00009/kt00007은 ROB-460에서 의도적으로 `dmst_stex_tp` 미추가 — 이 smoke가
-  실제로 그 파라미터를 요구하는지 확정한다.
+- kt00009는 ROB-418(`stk_bond_tp`)·ROB-1111(`mrkt_tp`)로 2차례 부분 복구됐다 —
+  `sell_tp`/`qry_tp`/`dmst_stex_tp`가 남아 있을 가능성은 위 ROB-1111/ROB-1088 경고
+  참고. kt00007은 코드가 아직 호출하지 않으므로 미해당.
+- **US 경로(`kiwoom_mock_us_*`)는 kt00009/mrkt_tp와 무관하다** — `ust21050`/
+  `ust21070`/`ust21510`/`ust21160` 등 별도 TR family를 쓰며 어떤 US 코드도
+  `ACCOUNT_ORDER_STATUS_API_ID`("kt00009")를 참조하지 않는다(ROB-1088, 2026-07-28
+  코드 전수 확인 + 회귀 테스트 `tests/test_kiwoom_us_account.py`).
 
 
 ## Phase A — Contract sweep (read-only, ROB-898)

--- a/scripts/kiwoom_mock_smoke.py
+++ b/scripts/kiwoom_mock_smoke.py
@@ -138,6 +138,7 @@ _TRUSTED_CONTRACT_OUTPUT_KEYS: frozenset[str] = frozenset(
         "uv",
         "stk_bond_tp",
         "mrkt_tp",
+        "sell_tp",
     }
 )
 
@@ -685,7 +686,18 @@ _CONTRACT_STEPS_SPEC: list[dict[str, Any]] = [
         "evidence_kind": "order_history",
         "tool_args": {},
         "contract_fields": {
-            "request_body": {"stk_bond_tp": "0", "mrkt_tp": "0"},
+            # ROB-1088 (2026-07-28, official-doc fix) — kt00009 official
+            # contract requires all five Required=Y fields; sell_tp/qry_tp/
+            # dmst_stex_tp were added on top of the earlier stk_bond_tp/
+            # mrkt_tp-only body after independent verification confirmed the
+            # official doc lists all five as required.
+            "request_body": {
+                "stk_bond_tp": "0",
+                "mrkt_tp": "0",
+                "sell_tp": "0",
+                "qry_tp": "0",
+                "dmst_stex_tp": "KRX",
+            },
             "response_array": "acnt_ord_cntr_prst_array",
         },
     },

--- a/tests/scripts/test_kiwoom_mock_smoke_contract.py
+++ b/tests/scripts/test_kiwoom_mock_smoke_contract.py
@@ -228,6 +228,11 @@ async def test_request_body_captured_via_mocktransport(
     assert captured[kw_constants.ACCOUNT_ORDER_STATUS_API_ID] == {
         "stk_bond_tp": kw_constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,
         "mrkt_tp": kw_constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT,
+        # ROB-1088 (2026-07-28, official-doc fix) — kt00009 official contract
+        # requires sell_tp/qry_tp/dmst_stex_tp too (all 5 fields Required=Y).
+        "sell_tp": kw_constants.ACCOUNT_ORDER_SELL_TP_DEFAULT,
+        "qry_tp": kw_constants.ACCOUNT_ORDER_QRY_TP_DEFAULT,
+        "dmst_stex_tp": kw_constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
     }
 
 

--- a/tests/test_kiwoom_domestic_account.py
+++ b/tests/test_kiwoom_domestic_account.py
@@ -175,30 +175,55 @@ async def test_get_order_status_uses_kt00009_with_required_params_and_continuati
     assert call["body"]["stk_bond_tp"] == constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT
     # ROB-1111 — kt00009 ALSO requires mrkt_tp (operator return_code 2 without it).
     assert call["body"]["mrkt_tp"] == constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT
-    # ROB-460 boundary — kt00009 is an order-history read (different tool,
-    # get_order_history), and NOT proven to need dmst_stex_tp.
-    assert "dmst_stex_tp" not in call["body"]
+    # ROB-1088 (2026-07-28 official-doc fix) — kt00009 requires all five fields
+    # per the official Kiwoom REST docs (Required=Y on every one of
+    # stk_bond_tp/mrkt_tp/sell_tp/qry_tp/dmst_stex_tp). sell_tp/qry_tp/
+    # dmst_stex_tp were previously omitted as "unproven speculation"; that was
+    # a contract mismatch, not caution — the official doc lists them as
+    # required just like stk_bond_tp/mrkt_tp.
+    assert call["body"]["sell_tp"] == constants.ACCOUNT_ORDER_SELL_TP_DEFAULT
+    assert call["body"]["qry_tp"] == constants.ACCOUNT_ORDER_QRY_TP_DEFAULT
+    # dmst_stex_tp: official docs allow %/KRX/NXT/SOR, but kiwoom_mock is
+    # KRX-only (MOCK_REJECTED_EXCHANGES={"NXT","SOR"}) — "KRX" is the only
+    # selection consistent with that fail-closed boundary.
+    assert call["body"]["dmst_stex_tp"] == constants.ACCOUNT_DMST_STEX_TP_DEFAULT
+    assert call["body"]["dmst_stex_tp"] == "KRX"
     assert call["cont_yn"] == "Y"
     assert call["next_key"] == "page-2"
 
 
 @pytest.mark.asyncio
-async def test_get_order_status_body_is_exactly_two_fields():
-    # ROB-1088 — pins the exact wire body so a future speculative addition of
-    # sell_tp/qry_tp/dmst_stex_tp (see bamjun/kiwoom-rest-api's kt00009
-    # signature, which documents all five as required) is a deliberate,
-    # reviewed change rather than an accidental drift. Those three fields are
-    # NOT proven necessary against mockapi.kiwoom.com in this codebase — if
-    # the 07-29 08:50 smoke reproduces return_code 2 with
-    # 필수입력 파라미터=sell_tp|qry_tp|dmst_stex_tp, this test must be updated
-    # alongside the fix, with the smoke evidence cited in the commit.
+async def test_get_order_status_body_is_exactly_the_official_five_fields():
+    # ROB-1088 — pins the exact wire body to the official Kiwoom kt00009
+    # contract (all 5 Required=Y fields, no more, no less). This intentionally
+    # replaces an earlier two-field-only pin that was found to mismatch the
+    # official contract during independent verification of PR #1708.
     fake = FakeClient()
     acct = KiwoomDomesticAccountClient(fake)
     await acct.get_order_status()
     assert fake.calls[-1]["body"] == {
         "stk_bond_tp": constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,
         "mrkt_tp": constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT,
+        "sell_tp": constants.ACCOUNT_ORDER_SELL_TP_DEFAULT,
+        "qry_tp": constants.ACCOUNT_ORDER_QRY_TP_DEFAULT,
+        "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
     }
+
+
+@pytest.mark.asyncio
+async def test_get_order_status_dmst_stex_tp_never_nxt_or_sor():
+    # ROB-1088 — explicit regression guard for the KRX-only boundary: even
+    # though the official docs permit "%"(전체)/NXT/SOR as dmst_stex_tp values,
+    # kt00009 must never select a value inside MOCK_REJECTED_EXCHANGES, and
+    # must not use "%" either (that would blend NXT/SOR rows into a
+    # KRX-only-intended surface).
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_status()
+    dmst_stex_tp = fake.calls[-1]["body"]["dmst_stex_tp"]
+    assert dmst_stex_tp not in constants.MOCK_REJECTED_EXCHANGES
+    assert dmst_stex_tp != "%"
+    assert dmst_stex_tp == constants.MOCK_EXCHANGE_KRX
 
 
 @pytest.mark.asyncio

--- a/tests/test_kiwoom_domestic_account.py
+++ b/tests/test_kiwoom_domestic_account.py
@@ -183,6 +183,25 @@ async def test_get_order_status_uses_kt00009_with_required_params_and_continuati
 
 
 @pytest.mark.asyncio
+async def test_get_order_status_body_is_exactly_two_fields():
+    # ROB-1088 — pins the exact wire body so a future speculative addition of
+    # sell_tp/qry_tp/dmst_stex_tp (see bamjun/kiwoom-rest-api's kt00009
+    # signature, which documents all five as required) is a deliberate,
+    # reviewed change rather than an accidental drift. Those three fields are
+    # NOT proven necessary against mockapi.kiwoom.com in this codebase — if
+    # the 07-29 08:50 smoke reproduces return_code 2 with
+    # 필수입력 파라미터=sell_tp|qry_tp|dmst_stex_tp, this test must be updated
+    # alongside the fix, with the smoke evidence cited in the commit.
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_status()
+    assert fake.calls[-1]["body"] == {
+        "stk_bond_tp": constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,
+        "mrkt_tp": constants.ACCOUNT_ORDER_MRKT_TP_DEFAULT,
+    }
+
+
+@pytest.mark.asyncio
 async def test_get_order_detail_uses_kt00007():
     fake = FakeClient()
     acct = KiwoomDomesticAccountClient(fake)

--- a/tests/test_kiwoom_us_account.py
+++ b/tests/test_kiwoom_us_account.py
@@ -60,3 +60,40 @@ def test_extract_usd_deposit_is_precise_and_fail_closed(
     payload: dict[str, Any], expected: str | None
 ) -> None:
     assert extract_usd_deposit(payload) == expected
+
+
+# ROB-1088 — US order-history/open-orders reads use their own TR ids
+# (ust21050/ust21070/ust21510/ust21160), never kt00009. This is a scope
+# boundary regression guard, not new behavior: KiwoomUsAccountClient never
+# references ACCOUNT_ORDER_STATUS_API_ID ("kt00009") or mrkt_tp, so the
+# kt00009 mrkt_tp gap (ROB-1111/ROB-1088) has no US counterpart to fix.
+@pytest.mark.asyncio
+async def test_us_account_methods_never_use_kt00009_or_mrkt_tp() -> None:
+    fake = FakeClient()
+    account = KiwoomUsAccountClient(fake)
+
+    await account.get_open_orders()
+    await account.get_positions()
+    await account.get_today_orders()
+    await account.get_foreign_deposit()
+    await account.get_us_deposit_detail()
+
+    for call in fake.calls:
+        assert call["api_id"] != constants.ACCOUNT_ORDER_STATUS_API_ID
+        assert "mrkt_tp" not in call["body"]
+
+
+def test_us_account_api_ids_are_ust_prefixed_not_kt00009() -> None:
+    # ROB-1088 — explicit constant-level boundary: the US TR id family is
+    # entirely separate ("ust2xxxx"), confirming KR's kt00009 mrkt_tp gap
+    # (ROB-1111) is KR-only by construction, not by incidental non-use.
+    us_api_ids = {
+        constants.US_ACCOUNT_OPEN_ORDERS_API_ID,
+        constants.US_ACCOUNT_POSITIONS_API_ID,
+        constants.US_ACCOUNT_TODAY_ORDERS_API_ID,
+        constants.US_ACCOUNT_DEPOSIT_DETAIL_API_ID,
+        constants.US_ACCOUNT_FOREIGN_DEPOSIT_API_ID,
+    }
+    assert constants.ACCOUNT_ORDER_STATUS_API_ID not in us_api_ids
+    for api_id in us_api_ids:
+        assert api_id.startswith("ust")


### PR DESCRIPTION
## Summary

ROB-1088(`kiwoom_mock_get_order_history`가 kt00009 호출 시 필수 파라미터 누락으로 전건 실패)의 root cause 자체는 ROB-1111(PR #1693, 이미 main 머지)이 `mrkt_tp`만 부분 복구했다. **독립 검증이 이 PR의 초판을 BLOCK 판정**했다 — 공식 Kiwoom REST 문서를 직접 확인한 결과 `sell_tp`/`qry_tp`/`dmst_stex_tp` 3개도 필수였는데, 초판은 이를 "서드파티 근거뿐인 추측"으로 보류했었다. 이번 커밋으로 공식 5필드 계약을 전부 충족시켰다.

## 공식 계약 (직접 확인)

`https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00009&jobTp=FS_JOB_TP&jobTpCode=02` 직접 열람 — kt00009(계좌별주문체결현황요청) 요청 body 5필드 전부 `Required=Y`:

| 필드 | 값 선택지 | 사용값 |
|---|---|---|
| `stk_bond_tp` | 0:전체, 1:주식, 2:채권 | `0` |
| `mrkt_tp` | 0:전체, 1:코스피, 2:코스닥, 3:OTCBB, 4:ECN | `0` |
| `sell_tp` | 0:전체, 1:매도, 2:매수 | `0` |
| `qry_tp` | 0:전체, 1:체결 | `0` |
| `dmst_stex_tp` | %:전체, KRX, NXT, SOR | `KRX` |

`dmst_stex_tp="KRX"`는 공식 문서가 `%`(전체)도 허용하지만 kiwoom_mock의 KRX-only 안전 경계(`MOCK_REJECTED_EXCHANGES={"NXT","SOR"}`)와 정합하도록 선택했다 — `%`는 NXT/SOR 결과까지 섞어 그 경계를 사실상 무력화하므로 배제.

## Changes (이번 커밋)

- `constants.py`: `ACCOUNT_ORDER_SELL_TP_DEFAULT`/`ACCOUNT_ORDER_QRY_TP_DEFAULT` 추가, 공식 문서 근거를 주석에 명시.
- `domestic_account.py`: `get_order_status` body를 5필드로 확장.
- `tests/test_kiwoom_domestic_account.py`: exact-two-fields 가드를 exact-five-fields로 교체(공식 계약 고정), `dmst_stex_tp`가 NXT/SOR/`%`를 절대 선택하지 않는다는 회귀 테스트 추가.
- `scripts/kiwoom_mock_smoke.py`, `tests/scripts/test_kiwoom_mock_smoke_contract.py`: contract sweep 기대값을 5필드로 갱신.
- `docs/runbooks/kiwoom-mock-smoke.md`: 공식 TR 계약 표를 5필드로 갱신.

## sell_tp/qry_tp 확정 여부

**확정함.** 추측이 아니라 공식 문서 표에서 직접 읽은 값이다.

## 실호출 검증

**여전히 미검증.** 이 5필드 조합이 실제 mockapi.kiwoom.com에서 `return_code 0`을 내는지는 이번 작업에서도 호출하지 않았다(mutation/실주문 금지 제약, mock이라도 주문 관련 mutation 금지). 07-29 08:50 KR-B1 P0-3 스모크가 최초의 실제 검증 기회다.

## Verification

- `uv run pytest tests/test_kiwoom_domestic_account.py tests/test_kiwoom_us_account.py tests/test_kiwoom_constants.py tests/scripts/test_kiwoom_mock_smoke_contract.py tests/test_mcp_kiwoom_order_variants.py` — 294 passed
- `uv run pytest -k kiwoom`(kt00009 관련 전체) — 607 passed
- `ruff check` / `ruff format --check` — 통과

---

### (이전 초판 설명, 참고용)

기존 ROB-1111 중복 판단·US 무관성 확인은 독립 검증에서 PASS 판정을 받았으며 변경 없음. 아래는 초판 Summary.

ROB-1088(`kiwoom_mock_get_order_history`가 kt00009 호출 시 `mrkt_tp` 누락으로 전건 실패)은 **ROB-1111(PR #1693, 오늘 이미 main 머지)의 중복 이슈**였다. ROB-1088은 07-27 발견, ROB-1111은 07-28 발견 후 먼저 처리·머지됐다.

- **KR**: kt00009 `mrkt_tp` 누락은 이미 ROB-1111(PR #1693)로 수정·배포됨.
- **US**: `kiwoom_mock_us_*` 경로는 kt00009/mrkt_tp와 무관 — 코드 전수 확인 + 회귀 테스트로 고정.
