### PR TITLE
fix(kiwoom): recover read requests from 8005 once

### DIFF
--- a/app/services/brokers/kiwoom/auth.py
+++ b/app/services/brokers/kiwoom/auth.py
@@ -1,23 +1,67 @@
 # app/services/brokers/kiwoom/auth.py
-"""Kiwoom OAuth token issuance and cache.
+"""Kiwoom OAuth token issuance and Redis-backed single-flight cache.
 
 Uses ``expires_dt`` returned by Kiwoom (``YYYYMMDDHHMMSS``) to schedule
-refreshes ``TOKEN_REFRESH_LEEWAY_SECONDS`` before expiry. Logs intentionally
-omit the token, app secret and full response body.
+refreshes ``TOKEN_REFRESH_LEEWAY_SECONDS`` before expiry. Token issuance is
+serialized across processes with the same Redis lock / failed-token
+double-check pattern used by Toss OAuth. Logs intentionally omit the token,
+app secret and full response body.
 """
 
 from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import hashlib
+import json
 import logging
-from typing import Any
+import random
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Final
 
 import httpx
+import redis.asyncio as redis
 
 from app.services.brokers.kiwoom import constants
 
 _log = logging.getLogger(__name__)
+
+TOKEN_LOCK_TTL_SECONDS: Final[int] = 30
+TOKEN_WAIT_TIMEOUT_SECONDS: float = 5.0
+TOKEN_WAIT_POLL_SECONDS: float = 0.05
+
+_redis_client: redis.Redis | None = None
+
+
+@dataclass(frozen=True)
+class KiwoomToken:
+    access_token: str
+    expires_at: dt.datetime
+
+
+class KiwoomTokenIssuanceUnavailable(RuntimeError):
+    """Raised when another issuer never publishes a usable token."""
+
+
+async def _get_redis_client() -> redis.Redis:
+    global _redis_client
+    if _redis_client is None:
+        from app.core.config import settings
+
+        _redis_client = redis.from_url(
+            settings.get_redis_url(),
+            max_connections=settings.redis_max_connections,
+            socket_timeout=settings.redis_socket_timeout,
+            socket_connect_timeout=settings.redis_socket_connect_timeout,
+            decode_responses=True,
+        )
+    return _redis_client
+
+
+def _client_fingerprint(app_key: str) -> str:
+    return hashlib.sha256(app_key.encode("utf-8")).hexdigest()[:16]
 
 
 def _parse_expires_dt(value: str) -> dt.datetime:
@@ -33,6 +77,7 @@ class KiwoomAuthClient:
         app_secret: str,
         transport: httpx.BaseTransport | None = None,
         timeout: float = constants.DEFAULT_TIMEOUT,
+        redis_client: redis.Redis | None = None,
     ) -> None:
         if str(base_url).rstrip("/") != constants.MOCK_BASE_URL:
             raise ValueError(
@@ -43,25 +88,122 @@ class KiwoomAuthClient:
         self._app_secret = app_secret
         self._transport = transport
         self._timeout = timeout
-        self._lock = asyncio.Lock()
-        self._cached_token: str | None = None
-        self._cached_expires_at: dt.datetime | None = None
+        self._redis_client = redis_client
+        namespace = f"kiwoom:oauth:{_client_fingerprint(app_key)}"
+        self.token_key = f"{namespace}:access_token"
+        self.lock_key = f"{namespace}:lock"
 
-    async def get_token(self) -> str:
-        async with self._lock:
-            if self._cached_token and self._still_fresh():
-                return self._cached_token
-            await self._refresh()
-            assert self._cached_token is not None
-            return self._cached_token
+    async def get_token(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
+        if not force_reissue:
+            cached = await self._get_cached_token()
+            if cached is not None:
+                return cached
+        elif failed_token is not None:
+            cached = await self._get_cached_token()
+            if cached is not None and cached != failed_token:
+                return cached
+        return await self._issue_single_flight(
+            force_reissue=force_reissue,
+            failed_token=failed_token,
+        )
 
-    def _still_fresh(self) -> bool:
-        if self._cached_expires_at is None:
-            return False
-        leeway = dt.timedelta(seconds=constants.TOKEN_REFRESH_LEEWAY_SECONDS)
-        return dt.datetime.now(dt.UTC) + leeway < self._cached_expires_at
+    async def _get_redis(self) -> redis.Redis:
+        if self._redis_client is not None:
+            return self._redis_client
+        return await _get_redis_client()
 
-    async def _refresh(self) -> None:
+    async def _get_cached_token(self) -> str | None:
+        redis_client = await self._get_redis()
+        raw = await redis_client.get(self.token_key)
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+            access_token = data["access_token"]
+            expires_at = float(data["expires_at"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        if time.time() >= expires_at - constants.TOKEN_REFRESH_LEEWAY_SECONDS:
+            return None
+        return str(access_token)
+
+    async def _cache_token(self, token: KiwoomToken) -> None:
+        redis_client = await self._get_redis()
+        expires_at = token.expires_at.timestamp()
+        ttl = max(int(expires_at - time.time()), 1)
+        payload = {
+            "access_token": token.access_token,
+            "expires_at": expires_at,
+        }
+        await redis_client.set(self.token_key, json.dumps(payload), ex=ttl)
+
+    async def _issue_single_flight(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
+        redis_client = await self._get_redis()
+        lock_token = str(uuid.uuid4())
+        acquired = await redis_client.set(
+            self.lock_key,
+            lock_token,
+            nx=True,
+            ex=TOKEN_LOCK_TTL_SECONDS,
+        )
+        if acquired:
+            try:
+                cached = await self._get_cached_token()
+                if cached is not None:
+                    if not force_reissue:
+                        return cached
+                    if failed_token is not None and cached != failed_token:
+                        return cached
+                if force_reissue:
+                    await redis_client.delete(self.token_key)
+                issued = await self._issue_token()
+                await self._cache_token(issued)
+                _log.info("Kiwoom OAuth token issued and cached")
+                return issued.access_token
+            finally:
+                await self._release_lock(redis_client, lock_token)
+
+        waited = await self._wait_for_cached_token(failed_token=failed_token)
+        if waited is not None:
+            return waited
+        raise KiwoomTokenIssuanceUnavailable(
+            "Kiwoom OAuth token issuance contended; no cached token after bounded wait"
+        )
+
+    async def _wait_for_cached_token(
+        self, *, failed_token: str | None = None
+    ) -> str | None:
+        deadline = time.monotonic() + TOKEN_WAIT_TIMEOUT_SECONDS
+        while True:
+            cached = await self._get_cached_token()
+            if cached is not None and cached != failed_token:
+                return cached
+            if time.monotonic() >= deadline:
+                return None
+            poll = max(float(TOKEN_WAIT_POLL_SECONDS), 0.0)
+            await asyncio.sleep(poll + random.uniform(0.0, poll))
+
+    async def _release_lock(self, redis_client: redis.Redis, lock_token: str) -> None:
+        script = """
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            return redis.call('DEL', KEYS[1])
+        else
+            return 0
+        end
+        """
+        try:
+            await redis_client.eval(script, 1, self.lock_key, lock_token)
+        except Exception as exc:  # noqa: BLE001
+            _log.debug(
+                "Kiwoom OAuth lock release best-effort failure type=%s",
+                type(exc).__name__,
+            )
+
+    async def _issue_token(self) -> KiwoomToken:
         body = {
             "grant_type": constants.OAUTH_GRANT_TYPE,
             "appkey": self._app_key,
@@ -88,6 +230,8 @@ class KiwoomAuthClient:
         expires_raw = str(payload.get("expires_dt") or "").strip()
         if not token or not expires_raw:
             raise RuntimeError("Kiwoom OAuth response missing token/expires_dt")
-        self._cached_token = token
-        self._cached_expires_at = _parse_expires_dt(expires_raw)
         _log.debug("Kiwoom OAuth token refreshed (expires_at hidden)")
+        return KiwoomToken(
+            access_token=token,
+            expires_at=_parse_expires_dt(expires_raw),
+        )

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -10,7 +10,7 @@ so callers cannot smuggle in the live host. The token is fetched via
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Final
 
 import httpx
 
@@ -18,6 +18,25 @@ from app.services.brokers.kiwoom import constants
 from app.services.brokers.kiwoom.auth import KiwoomAuthClient
 
 _log = logging.getLogger(__name__)
+
+_AUTH_REJECT_RETURN_CODE: Final[int] = 8005
+# ROB-733-style fail-closed bound: a loop counter, never recursive resubmission.
+_MAX_TOKEN_REFRESH_RESUBMITS: Final[int] = 1
+# Explicit allowlist keeps every domestic/US order mutation out of token retry.
+_AUTH_RETRY_READ_API_IDS: Final[frozenset[str]] = frozenset(
+    {
+        constants.ACCOUNT_ORDER_DETAIL_API_ID,
+        constants.ACCOUNT_ORDER_STATUS_API_ID,
+        constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
+        constants.ACCOUNT_DEPOSIT_API_ID,
+        constants.ACCOUNT_BALANCE_API_ID,
+        constants.US_ACCOUNT_OPEN_ORDERS_API_ID,
+        constants.US_ACCOUNT_POSITIONS_API_ID,
+        constants.US_ACCOUNT_TODAY_ORDERS_API_ID,
+        constants.US_ACCOUNT_DEPOSIT_DETAIL_API_ID,
+        constants.US_ACCOUNT_FOREIGN_DEPOSIT_API_ID,
+    }
+)
 
 
 class KiwoomConfigurationError(RuntimeError):
@@ -129,9 +148,16 @@ class KiwoomMockClient:
     def account_no(self) -> str:
         return self._account_no
 
-    async def _resolve_token(self) -> str:
+    async def _resolve_token(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
         if self._token_override is not None:
             return self._token_override
+        if force_reissue:
+            return await self._auth.get_token(
+                force_reissue=True,
+                failed_token=failed_token,
+            )
         return await self._auth.get_token()
 
     async def _before_api_dispatch(self, api_id: str) -> None:
@@ -153,11 +179,73 @@ class KiwoomMockClient:
             raise ValueError(
                 "Kiwoom mock request resolved to non-mock host; refusing to send."
             )
-        stage = "token_resolution"
-        dispatch_started = False
+
         try:
             token = await self._resolve_token()
-            stage = "pre_dispatch_hook"
+        except Exception as exc:
+            raise KiwoomPreDispatchError(
+                stage="token_resolution",
+                api_id=api_id,
+                cause_type=type(exc).__name__,
+            ) from exc
+
+        token_refresh_resubmits = 0
+        while True:
+            response = await self._send_api_once(
+                token=token,
+                api_id=api_id,
+                path=path,
+                body=body,
+                cont_yn=cont_yn,
+                next_key=next_key,
+            )
+            response.raise_for_status()
+            payload: dict[str, Any] = dict(response.json())
+            payload["continuation"] = {
+                "cont_yn": response.headers.get(constants.HEADER_CONT_YN, ""),
+                "next_key": response.headers.get(constants.HEADER_NEXT_KEY, ""),
+            }
+            if (
+                api_id in _AUTH_RETRY_READ_API_IDS
+                and payload.get("return_code")
+                in {_AUTH_REJECT_RETURN_CODE, str(_AUTH_REJECT_RETURN_CODE)}
+                and token_refresh_resubmits < _MAX_TOKEN_REFRESH_RESUBMITS
+            ):
+                token_refresh_resubmits += 1
+                try:
+                    token = await self._resolve_token(
+                        force_reissue=True,
+                        failed_token=token,
+                    )
+                except Exception as exc:
+                    raise KiwoomPreDispatchError(
+                        stage="token_refresh",
+                        api_id=api_id,
+                        cause_type=type(exc).__name__,
+                    ) from exc
+                continue
+
+            if int(payload.get("return_code", 0)) != constants.SUCCESS_RETURN_CODE:
+                _log.info(
+                    "Kiwoom api_id=%s returned non-zero return_code=%s",
+                    api_id,
+                    payload.get("return_code"),
+                )
+            return payload
+
+    async def _send_api_once(
+        self,
+        *,
+        token: str,
+        api_id: str,
+        path: str,
+        body: dict[str, Any],
+        cont_yn: str | None,
+        next_key: str | None,
+    ) -> httpx.Response:
+        stage = "pre_dispatch_hook"
+        dispatch_started = False
+        try:
             await self._before_api_dispatch(api_id)
             stage = "request_build"
             headers = {
@@ -190,16 +278,4 @@ class KiwoomMockClient:
                     stage=stage, api_id=api_id, cause_type=type(exc).__name__
                 ) from exc
             raise
-        response.raise_for_status()
-        payload: dict[str, Any] = dict(response.json())
-        payload["continuation"] = {
-            "cont_yn": response.headers.get(constants.HEADER_CONT_YN, ""),
-            "next_key": response.headers.get(constants.HEADER_NEXT_KEY, ""),
-        }
-        if int(payload.get("return_code", 0)) != constants.SUCCESS_RETURN_CODE:
-            _log.info(
-                "Kiwoom api_id=%s returned non-zero return_code=%s",
-                api_id,
-                payload.get("return_code"),
-            )
-        return payload
+        return response

--- a/tests/test_kiwoom_auth_token_cache.py
+++ b/tests/test_kiwoom_auth_token_cache.py
@@ -5,13 +5,63 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import json
 import logging
+import time
 
 import httpx
 import pytest
 
 from app.services.brokers.kiwoom import constants
-from app.services.brokers.kiwoom.auth import KiwoomAuthClient
+from app.services.brokers.kiwoom.auth import KiwoomAuthClient, KiwoomToken
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.strings: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.strings.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value: str,
+        *,
+        nx: bool = False,
+        ex: int | None = None,
+    ) -> bool | None:
+        del ex
+        if nx and key in self.strings:
+            return None
+        self.strings[key] = value
+        return True
+
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            if key in self.strings:
+                self.strings.pop(key)
+                removed += 1
+        return removed
+
+    async def eval(
+        self,
+        script: str,
+        key_count: int,
+        key: str,
+        lock_token: str,
+    ) -> int:
+        del script, key_count
+        if self.strings.get(key) == lock_token:
+            self.strings.pop(key)
+            return 1
+        return 0
+
+
+@pytest.fixture
+def fake_redis():
+    return _FakeRedis()
 
 
 @pytest.fixture
@@ -44,12 +94,13 @@ def mock_token_transport() -> httpx.MockTransport:
 
 
 @pytest.mark.asyncio
-async def test_token_is_cached_until_near_expiry(mock_token_transport):
+async def test_token_is_cached_until_near_expiry(mock_token_transport, fake_redis):
     auth = KiwoomAuthClient(
         base_url=constants.MOCK_BASE_URL,
         app_key="ak",
         app_secret="SECRET-VAL",
         transport=mock_token_transport,
+        redis_client=fake_redis,
     )
     t1 = await auth.get_token()
     t2 = await auth.get_token()
@@ -58,12 +109,15 @@ async def test_token_is_cached_until_near_expiry(mock_token_transport):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_token_requests_share_one_refresh(mock_token_transport):
+async def test_concurrent_token_requests_share_one_refresh(
+    mock_token_transport, fake_redis
+):
     auth = KiwoomAuthClient(
         base_url=constants.MOCK_BASE_URL,
         app_key="ak",
         app_secret="SECRET-VAL",
         transport=mock_token_transport,
+        redis_client=fake_redis,
     )
 
     tokens = await asyncio.gather(*(auth.get_token() for _ in range(12)))
@@ -73,30 +127,113 @@ async def test_concurrent_token_requests_share_one_refresh(mock_token_transport)
 
 
 @pytest.mark.asyncio
-async def test_token_refreshed_when_expired(monkeypatch, mock_token_transport):
+async def test_token_refreshed_when_expired(mock_token_transport, fake_redis):
     auth = KiwoomAuthClient(
         base_url=constants.MOCK_BASE_URL,
         app_key="ak",
         app_secret="SECRET-VAL",
         transport=mock_token_transport,
+        redis_client=fake_redis,
     )
     await auth.get_token()
-    # Force expiry.
-    auth._cached_expires_at = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1)
+    raw = await fake_redis.get(auth.token_key)
+    cached = json.loads(raw)
+    cached["expires_at"] = time.time() - 1
+    await fake_redis.set(auth.token_key, json.dumps(cached))
     await auth.get_token()
     assert mock_token_transport.calls["count"] == 2
 
 
 @pytest.mark.asyncio
-async def test_logs_never_contain_secret_or_token(caplog, mock_token_transport):
+async def test_logs_never_contain_secret_or_token(
+    caplog, mock_token_transport, fake_redis
+):
     caplog.set_level(logging.DEBUG, logger="app.services.brokers.kiwoom")
     auth = KiwoomAuthClient(
         base_url=constants.MOCK_BASE_URL,
         app_key="ak",
         app_secret="SECRET-VAL",
         transport=mock_token_transport,
+        redis_client=fake_redis,
     )
     token = await auth.get_token()
     rendered = "\n".join(rec.getMessage() for rec in caplog.records)
     assert "SECRET-VAL" not in rendered
     assert token not in rendered
+
+
+@pytest.mark.asyncio
+async def test_concurrent_managers_share_one_redis_single_flight(
+    monkeypatch, fake_redis
+):
+    managers = [
+        KiwoomAuthClient(
+            base_url=constants.MOCK_BASE_URL,
+            app_key="shared-app-key",
+            app_secret="SECRET-VAL",
+            redis_client=fake_redis,
+        )
+        for _ in range(8)
+    ]
+    issue_calls = 0
+
+    async def issue_token() -> KiwoomToken:
+        nonlocal issue_calls
+        issue_calls += 1
+        await asyncio.sleep(0.05)
+        return KiwoomToken(
+            access_token="shared-token",
+            expires_at=dt.datetime.now(dt.UTC) + dt.timedelta(minutes=5),
+        )
+
+    for manager in managers:
+        monkeypatch.setattr(manager, "_issue_token", issue_token)
+
+    tokens = await asyncio.gather(*(manager.get_token() for manager in managers))
+
+    assert tokens == ["shared-token"] * len(managers)
+    assert issue_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_failed_token_reissue_mints_once(monkeypatch, fake_redis):
+    managers = [
+        KiwoomAuthClient(
+            base_url=constants.MOCK_BASE_URL,
+            app_key="shared-app-key",
+            app_secret="SECRET-VAL",
+            redis_client=fake_redis,
+        )
+        for _ in range(8)
+    ]
+    stale = KiwoomToken(
+        access_token="stale-token",
+        expires_at=dt.datetime.now(dt.UTC) + dt.timedelta(minutes=5),
+    )
+    await managers[0]._cache_token(stale)
+    issue_calls = 0
+
+    async def issue_token() -> KiwoomToken:
+        nonlocal issue_calls
+        issue_calls += 1
+        await asyncio.sleep(0.05)
+        return KiwoomToken(
+            access_token="fresh-token",
+            expires_at=dt.datetime.now(dt.UTC) + dt.timedelta(minutes=5),
+        )
+
+    for manager in managers:
+        monkeypatch.setattr(manager, "_issue_token", issue_token)
+
+    tokens = await asyncio.gather(
+        *(
+            manager.get_token(
+                force_reissue=True,
+                failed_token="stale-token",
+            )
+            for manager in managers
+        )
+    )
+
+    assert tokens == ["fresh-token"] * len(managers)
+    assert issue_calls == 1

--- a/tests/test_kiwoom_mock_preflight.py
+++ b/tests/test_kiwoom_mock_preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import fakeredis.aioredis
 import pytest
 
 from app.services.brokers.kiwoom.client import KiwoomPreDispatchError
@@ -807,6 +808,7 @@ async def test_concurrent_auth_refresh_dedupes_to_single_mint():
         app_key="k",
         app_secret="s",
         transport=httpx.MockTransport(handler),
+        redis_client=fakeredis.aioredis.FakeRedis(decode_responses=True),
     )
 
     import asyncio

--- a/tests/test_kiwoom_token_refresh.py
+++ b/tests/test_kiwoom_token_refresh.py
@@ -1,0 +1,167 @@
+"""Kiwoom 8005 recovery is read-only, single-resubmit, and fail-closed."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import fakeredis.aioredis
+import httpx
+import pytest
+
+from app.services.brokers.kiwoom import constants
+from app.services.brokers.kiwoom.auth import KiwoomAuthClient, KiwoomToken
+from app.services.brokers.kiwoom.client import KiwoomMockClient
+
+
+class _RecordingAuth:
+    def __init__(self) -> None:
+        self.calls: list[tuple[bool, str | None]] = []
+
+    async def get_token(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
+        self.calls.append((force_reissue, failed_token))
+        return "fresh-token" if force_reissue else "stale-token"
+
+
+def _client_with_transport(
+    handler: Any,
+) -> KiwoomMockClient:
+    client = KiwoomMockClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="app-key",
+        app_secret="app-secret",
+        account_no="account-no",
+    )
+    client._transport = httpx.MockTransport(handler)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_read_8005_invalidates_cached_token_and_retries_once(monkeypatch):
+    redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    auth = KiwoomAuthClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="app-key",
+        app_secret="app-secret",
+        redis_client=redis_client,
+    )
+    await auth._cache_token(
+        KiwoomToken(
+            access_token="stale-token",
+            expires_at=dt.datetime.now(dt.UTC) + dt.timedelta(minutes=5),
+        )
+    )
+    issue_calls = 0
+
+    async def issue_token() -> KiwoomToken:
+        nonlocal issue_calls
+        issue_calls += 1
+        return KiwoomToken(
+            access_token="fresh-token",
+            expires_at=dt.datetime.now(dt.UTC) + dt.timedelta(minutes=5),
+        )
+
+    monkeypatch.setattr(auth, "_issue_token", issue_token)
+    dispatched_authorizations: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        authorization = request.headers[constants.HEADER_AUTHORIZATION]
+        dispatched_authorizations.append(authorization)
+        if authorization == "Bearer stale-token":
+            return httpx.Response(
+                200,
+                json={"return_code": 8005, "return_msg": "Token invalid"},
+            )
+        return httpx.Response(
+            200,
+            json={"return_code": 0, "return_msg": "OK", "result_list": []},
+        )
+
+    client = _client_with_transport(handler)
+    client._auth = auth
+
+    result = await client.post_api(
+        api_id=constants.US_ACCOUNT_POSITIONS_API_ID,
+        path=constants.US_ACCOUNT_PATH,
+        body={},
+    )
+
+    assert result["return_code"] == 0
+    assert dispatched_authorizations == [
+        "Bearer stale-token",
+        "Bearer fresh-token",
+    ]
+    assert issue_calls == 1
+    assert await auth.get_token() == "fresh-token"
+
+
+@pytest.mark.asyncio
+async def test_repeated_read_8005_is_resubmitted_only_once():
+    dispatch_count = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal dispatch_count
+        dispatch_count += 1
+        return httpx.Response(
+            200,
+            json={"return_code": "8005", "return_msg": "Token invalid"},
+        )
+
+    auth = _RecordingAuth()
+    client = _client_with_transport(handler)
+    client._auth = auth  # type: ignore[assignment]
+
+    result = await client.post_api(
+        api_id=constants.US_ACCOUNT_POSITIONS_API_ID,
+        path=constants.US_ACCOUNT_PATH,
+        body={},
+    )
+
+    assert result["return_code"] == "8005"
+    assert dispatch_count == 2
+    assert auth.calls == [
+        (False, None),
+        (True, "stale-token"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("api_id", "path"),
+    [
+        (constants.ORDER_BUY_API_ID, constants.ORDER_PATH),
+        (constants.ORDER_SELL_API_ID, constants.ORDER_PATH),
+        (constants.ORDER_MODIFY_API_ID, constants.ORDER_PATH),
+        (constants.ORDER_CANCEL_API_ID, constants.ORDER_PATH),
+        (constants.US_ORDER_BUY_API_ID, constants.US_ORDER_PATH),
+        (constants.US_ORDER_SELL_API_ID, constants.US_ORDER_PATH),
+        (constants.US_ORDER_MODIFY_API_ID, constants.US_ORDER_PATH),
+        (constants.US_ORDER_CANCEL_API_ID, constants.US_ORDER_PATH),
+    ],
+)
+@pytest.mark.asyncio
+async def test_order_mutation_8005_is_not_resubmitted(api_id: str, path: str):
+    dispatch_count = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal dispatch_count
+        dispatch_count += 1
+        return httpx.Response(
+            200,
+            json={"return_code": 8005, "return_msg": "Token invalid"},
+        )
+
+    auth = _RecordingAuth()
+    client = _client_with_transport(handler)
+    client._auth = auth  # type: ignore[assignment]
+
+    result = await client.post_api(
+        api_id=api_id,
+        path=path,
+        body={},
+    )
+
+    assert result["return_code"] == 8005
+    assert dispatch_count == 1
+    assert auth.calls == [(False, None)]

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import fakeredis.aioredis
 import pytest
 
 
@@ -2509,6 +2510,7 @@ async def test_confirmed_place_cold_cache_token_issued_once():
     )
     client._transport = httpx.MockTransport(tr_handler)
     client._auth._transport = httpx.MockTransport(oauth_handler)
+    client._auth._redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
 
     account_client = KiwoomDomesticAccountClient(client)
     order_client = KiwoomDomesticOrderClient(client)
@@ -2736,6 +2738,7 @@ def _patch_real_confirmed_sell_client(monkeypatch, mod, *, stage: str | None = N
     )
     client._transport = httpx.MockTransport(broker_handler)
     client._auth._transport = httpx.MockTransport(oauth_handler)
+    client._auth._redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
 
     if stage == "pre_dispatch_hook":
 


### PR DESCRIPTION
## Summary
- move Kiwoom OAuth caching to Redis-backed single-flight issuance with failed-token double-check
- invalidate a rejected cached token and resubmit allowlisted read requests exactly once on return_code 8005
- keep all domestic and US order mutation API IDs outside the retry allowlist

## Validation
- `uv run --group test pytest -q tests/test_kiwoom*.py tests/test_mcp_kiwoom*.py tests/scripts/test_kiwoom_mock_smoke_contract.py` (652 passed)
- changed-scope Ruff check and format check
- changed-scope `ty check --error-on-warning`
- no live or mock broker call was made

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved authentication token caching and coordination across multiple processes, reducing unnecessary token requests.
  * Added safer handling when token issuance is temporarily unavailable.

* **Bug Fixes**
  * Read-only API requests now automatically refresh invalid tokens and retry once.
  * Order actions are not automatically resubmitted after authentication failures, helping prevent duplicate transactions.

* **Tests**
  * Added coverage for token expiry, concurrent refreshes, retry behavior, and order safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->