### PR TITLE
test: isolate pytest databases and fixture scopes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test-services-split: ## Run split service tests for former test_services.py scop
 		tests/test_services_upbit.py \
 		tests/test_services_kis_client.py \
 		tests/test_services_kis_market_data.py \
+		tests/test_services_kis_market_data_unit.py \
 		tests/test_services_kis_logging.py \
 		tests/test_services_dart.py \
 		tests/test_services_yahoo.py

--- a/tests/TEST_DATABASES.md
+++ b/tests/TEST_DATABASES.md
@@ -1,0 +1,47 @@
+# Pytest PostgreSQL ownership
+
+Database-backed pytest selections create one database per serial run or xdist
+worker. Names have the exact shape
+`test_db_pytest_<12 lowercase hex>_<main|gwN>`. The database also contains
+`public._pytest_database_owner`; teardown verifies its random ownership token
+before issuing an exact-name `DROP DATABASE`.
+
+Pure unit and collect-only selections choose a name but do not create or connect
+to PostgreSQL. The first selected integration/DB fixture owns creation, schema
+bootstrap, and cleanup.
+
+The legacy shared `test_db` behavior is available only by explicit opt-in:
+
+```bash
+AUTO_TRADER_PYTEST_USE_SHARED_DB=1 uv run pytest ...
+```
+
+`AUTO_TRADER_TEST_DATABASE_URL` may change connection details, but it must still
+target a PostgreSQL database named exactly `test_db`. A different/general
+database is rejected before pytest can use it. Shared mode never drops
+`test_db`.
+
+## Interrupted-run cleanup
+
+Normal `SIGINT` lets pytest finalizers remove the owned database. `SIGKILL`,
+host crashes, or PostgreSQL loss can leave an exact run-owned database behind.
+List candidates without deleting anything:
+
+```sql
+SELECT datname
+FROM pg_database
+WHERE datname LIKE 'test_db_pytest_%'
+ORDER BY datname;
+```
+
+For each exact candidate, connect to that one database and inspect:
+
+```sql
+SELECT database_name, owner_token, created_at
+FROM public._pytest_database_owner;
+```
+
+Only after the exact name and marker have been reviewed should an operator run
+`DROP DATABASE "<exact database name>" WITH (FORCE)` from another database.
+Never automate cleanup with a wildcard or drop a database lacking the ownership
+marker.

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -1,7 +1,7 @@
 """Shared test scaffolding for ROB-265 investment_reports tests.
 
-Centralises the per-test async session fixture, the truncated-table
-list, the xdist guard lock, and a couple of small helpers so the ORM, schema, repository,
+Centralises the per-test async session fixture, the cleanup-table
+list, the shared-DB guard lock, and a couple of small helpers so the ORM, schema, repository,
 ingestion, decisions, watch-activation, and query-service test files
 don't each re-declare the same boilerplate (Sonar duplicated-line fix).
 """
@@ -15,10 +15,8 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
-    create_async_engine,
 )
 
-from app.core.config import settings
 from app.models.investment_reports import (
     InvestmentReport,
     InvestmentReportItem,
@@ -28,6 +26,7 @@ from app.models.investment_reports import (
     InvestmentWatchAlert,
     InvestmentWatchEvent,
 )
+from tests._run_owned_database import uses_shared_test_database
 
 INVESTMENT_REPORTS_TABLES = [
     InvestmentReport.__table__,
@@ -43,50 +42,92 @@ INVESTMENT_REPORTS_TEST_LOCK_ID = 265_202_605
 
 @pytest_asyncio.fixture
 async def session(_bootstrap_test_schema) -> AsyncSession:
-    """Per-test AsyncSession against the current PostgreSQL test database.
+    """Rollback-isolated AsyncSession against the current PostgreSQL test DB.
 
     Schema is owned by the session-scoped ``_bootstrap_test_schema`` barrier
-    (ROB-723) — this fixture performs no DDL. Between tests it TRUNCATEs the
-    investment-report table family, serialized against the conftest cleanup by
-    the shared advisory lock and made deadlock-resilient by run_with_deadlock_retry.
+    (ROB-723) — this fixture performs no DDL. A SAVEPOINT-aware session lets
+    tests exercise ``commit()`` while the outer transaction remains owned by
+    the fixture and is rolled back after the test. The shared-DB opt-in keeps
+    the legacy advisory lock; ordinary run-owned DBs need no serialization.
     """
     import sqlalchemy as sa
 
-    from tests._db_retry import run_with_deadlock_retry
+    from app.core.db import engine
 
-    engine = create_async_engine(settings.DATABASE_URL, future=True)
-
-    async def _truncate() -> None:
-        async with engine.begin() as conn:
-            for table in reversed(INVESTMENT_REPORTS_TABLES):
-                await conn.execute(
-                    sa.text(
-                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
-                    )
-                )
-
+    guard = None
     try:
-        async with engine.connect() as guard:
+        if uses_shared_test_database():
+            guard = await engine.connect()
             await guard.execute(
                 sa.text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
                 {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
             )
+        async with engine.connect() as connection:
+            outer = await connection.begin()
             try:
-                await run_with_deadlock_retry(_truncate)
-                factory = async_sessionmaker(engine, expire_on_commit=False)
+                factory = async_sessionmaker(
+                    bind=connection,
+                    expire_on_commit=False,
+                    join_transaction_mode="create_savepoint",
+                )
                 async with factory() as sess:
-                    try:
-                        yield sess
-                    finally:
-                        await sess.rollback()
-                await run_with_deadlock_retry(_truncate)
+                    yield sess
             finally:
+                if outer.is_active:
+                    await outer.rollback()
+    finally:
+        if guard is not None:
+            try:
                 await guard.execute(
                     sa.text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
                     {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
                 )
+            finally:
+                await guard.close()
+
+
+@pytest_asyncio.fixture
+async def committed_investment_reports_session(
+    _bootstrap_test_schema,
+) -> AsyncSession:
+    """Session for tests whose production handler opens independent sessions.
+
+    Those commits cannot participate in the fixture's outer transaction. Keep
+    this exceptional path explicit and clean only its seven-table family with
+    row-level DELETEs, avoiding repeated engines and AccessExclusive TRUNCATE.
+    """
+    import sqlalchemy as sa
+
+    from app.core.db import AsyncSessionLocal, engine
+
+    async def _delete_rows() -> None:
+        async with engine.begin() as connection:
+            for table in reversed(INVESTMENT_REPORTS_TABLES):
+                await connection.execute(sa.text(f'DELETE FROM review."{table.name}"'))
+
+    guard = None
+    try:
+        if uses_shared_test_database():
+            guard = await engine.connect()
+            await guard.execute(
+                sa.text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
+                {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
+            )
+        await _delete_rows()
+        try:
+            async with AsyncSessionLocal() as sess:
+                yield sess
+        finally:
+            await _delete_rows()
     finally:
-        await engine.dispose()
+        if guard is not None:
+            try:
+                await guard.execute(
+                    sa.text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                    {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
+                )
+            finally:
+                await guard.close()
 
 
 def future_datetime(days: int = 7) -> datetime:

--- a/tests/_mcp_screen_stocks_support.py
+++ b/tests/_mcp_screen_stocks_support.py
@@ -26,8 +26,6 @@ from tests._mcp_tooling_support import (
     build_tools,
 )
 
-pytest_plugins = ("tests._mcp_tooling_support",)
-
 ToolFunc = Callable[..., Awaitable[Any]]
 
 
@@ -609,44 +607,6 @@ def mock_upbit_coins():
             "acc_trade_price_24h": 800_000_000_000,
         },
     ]
-
-
-@pytest.fixture(autouse=True)
-def _mock_crypto_external_sources(monkeypatch: pytest.MonkeyPatch):
-    async def mock_get_upbit_warning_markets(
-        db=None,
-        quote_currency: str | None = None,
-        fiat: str | None = None,
-    ):
-        _ = (quote_currency, fiat, db)
-        return set()
-
-    async def mock_market_cap_cache_get():
-        return {
-            "data": {},
-            "cached": True,
-            "age_seconds": 0.0,
-            "stale": False,
-            "error": None,
-        }
-
-    async def mock_fetch_ohlcv_for_indicators(
-        symbol: str, market_type: str, count: int
-    ):
-        import pandas as pd
-
-        return pd.DataFrame()
-
-    monkeypatch.setattr(
-        screening_crypto,
-        "get_upbit_warning_markets",
-        mock_get_upbit_warning_markets,
-    )
-    monkeypatch.setattr(
-        screening_crypto._CRYPTO_MARKET_CAP_CACHE,
-        "get",
-        mock_market_cap_cache_get,
-    )
 
 
 class TestScreenStocksCrypto:

--- a/tests/_run_owned_database.py
+++ b/tests/_run_owned_database.py
@@ -1,0 +1,249 @@
+"""Fail-closed lifecycle helpers for pytest-owned PostgreSQL databases."""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+from typing import Any
+
+from sqlalchemy.engine import URL, make_url
+
+DEFAULT_TEST_DATABASE_URL = (
+    "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+)
+DATABASE_NAME_ENV = "AUTO_TRADER_XDIST_DATABASE_NAME"
+BASE_DATABASE_URL_ENV = "AUTO_TRADER_XDIST_BASE_DATABASE_URL"
+RUN_UID_ENV = "AUTO_TRADER_PYTEST_RUN_UID"
+OWNER_TOKEN_ENV = "AUTO_TRADER_PYTEST_OWNER_TOKEN"
+SHARED_DATABASE_ENV = "AUTO_TRADER_PYTEST_USE_SHARED_DB"
+TEST_DATABASE_URL_ENV = "AUTO_TRADER_TEST_DATABASE_URL"
+
+_RUN_UID_PATTERN = re.compile(r"[0-9a-f]{12}")
+_OWNER_TOKEN_PATTERN = re.compile(r"[0-9a-f]{32}")
+_WORKER_PATTERN = re.compile(r"(?:main|gw[0-9]+)")
+_OWNED_DATABASE_PATTERN = re.compile(
+    r"test_db_pytest_(?P<run_uid>[0-9a-f]{12})_(?P<worker>main|gw[0-9]+)"
+)
+_OWNER_TABLE = "public._pytest_database_owner"
+
+
+def _shared_database_requested() -> bool:
+    raw = os.environ.get(SHARED_DATABASE_ENV, "0").strip()
+    if raw in {"", "0"}:
+        return False
+    if raw == "1":
+        return True
+    raise RuntimeError(f"{SHARED_DATABASE_ENV} must be exactly 0 or 1")
+
+
+def _validated_base_url() -> URL:
+    raw = os.environ.get(TEST_DATABASE_URL_ENV, DEFAULT_TEST_DATABASE_URL)
+    url = make_url(raw)
+    if url.get_backend_name() != "postgresql":
+        raise RuntimeError(f"{TEST_DATABASE_URL_ENV} must use PostgreSQL")
+    if url.database != "test_db":
+        raise RuntimeError(
+            f"{TEST_DATABASE_URL_ENV} must target the dedicated test_db database"
+        )
+    if not url.username or not url.host:
+        raise RuntimeError(f"{TEST_DATABASE_URL_ENV} must include username and host")
+    return url
+
+
+def _validated_run_uid() -> str:
+    run_uid = os.environ.get(RUN_UID_ENV, "")
+    if not _RUN_UID_PATTERN.fullmatch(run_uid):
+        raise RuntimeError("refusing invalid pytest run UID")
+    return run_uid
+
+
+def _validated_owner_token() -> str:
+    owner_token = os.environ.get(OWNER_TOKEN_ENV, "")
+    if not _OWNER_TOKEN_PATTERN.fullmatch(owner_token):
+        raise RuntimeError("refusing invalid pytest database owner token")
+    return owner_token
+
+
+def validate_owned_database_name(database_name: str) -> re.Match[str]:
+    match = _OWNED_DATABASE_PATTERN.fullmatch(database_name)
+    if match is None:
+        raise RuntimeError("refusing unsafe or unowned pytest database name")
+    if match.group("run_uid") != _validated_run_uid():
+        raise RuntimeError("refusing pytest database from a different run")
+    return match
+
+
+def configure_test_database_environment() -> None:
+    """Select a run-owned DB name without connecting to PostgreSQL.
+
+    The controller/serial process creates a fresh run UID and ownership token.
+    Xdist workers inherit those values and append their validated worker ID.
+    Pure unit and collect-only runs stop here and therefore remain DB-free.
+    """
+
+    base_url = _validated_base_url()
+    rendered_base_url = base_url.render_as_string(hide_password=False)
+    os.environ[BASE_DATABASE_URL_ENV] = rendered_base_url
+
+    if _shared_database_requested():
+        os.environ.pop(DATABASE_NAME_ENV, None)
+        os.environ["DATABASE_URL"] = rendered_base_url
+        return
+
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id and worker_id != "master":
+        if not re.fullmatch(r"gw[0-9]+", worker_id):
+            raise RuntimeError("refusing invalid xdist worker ID")
+        run_uid = _validated_run_uid()
+        _validated_owner_token()
+        worker = worker_id
+    else:
+        run_uid = secrets.token_hex(6)
+        os.environ[RUN_UID_ENV] = run_uid
+        os.environ[OWNER_TOKEN_ENV] = secrets.token_hex(16)
+        worker = "main"
+
+    database_name = f"test_db_pytest_{run_uid}_{worker}"
+    validate_owned_database_name(database_name)
+    os.environ[DATABASE_NAME_ENV] = database_name
+    os.environ["DATABASE_URL"] = base_url.set(database=database_name).render_as_string(
+        hide_password=False
+    )
+
+
+def uses_run_owned_database() -> bool:
+    database_name = os.environ.get(DATABASE_NAME_ENV)
+    if not database_name:
+        return False
+    validate_owned_database_name(database_name)
+    return True
+
+
+def uses_shared_test_database() -> bool:
+    return not uses_run_owned_database()
+
+
+def _connection_kwargs(url: URL, *, database: str) -> dict[str, Any]:
+    return {
+        "user": url.username,
+        "password": url.password,
+        "host": url.host,
+        "port": url.port,
+        "database": database,
+        "timeout": 10,
+    }
+
+
+async def ensure_run_owned_database() -> bool:
+    """Create and mark this process's exact run-owned database.
+
+    Existing databases are never adopted, even when their names match the
+    pytest pattern. This prevents a stale or user-created database from being
+    mistaken for the current run's property.
+    """
+
+    database_name = os.environ.get(DATABASE_NAME_ENV)
+    if not database_name:
+        return False
+    validate_owned_database_name(database_name)
+    owner_token = _validated_owner_token()
+
+    import asyncpg
+
+    base_url = make_url(os.environ[BASE_DATABASE_URL_ENV])
+    admin = await asyncpg.connect(**_connection_kwargs(base_url, database="postgres"))
+    created = False
+    try:
+        exists = await admin.fetchval(
+            "SELECT 1 FROM pg_database WHERE datname = $1", database_name
+        )
+        if exists:
+            raise RuntimeError("refusing to reuse an existing pytest database")
+        await admin.execute(f'CREATE DATABASE "{database_name}"')
+        created = True
+    finally:
+        await admin.close()
+
+    try:
+        target = await asyncpg.connect(
+            **_connection_kwargs(base_url, database=database_name)
+        )
+        try:
+            await target.execute(
+                f"CREATE TABLE {_OWNER_TABLE} ("
+                "database_name TEXT PRIMARY KEY, "
+                "owner_token TEXT NOT NULL, "
+                "created_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+            )
+            await target.execute(
+                f"INSERT INTO {_OWNER_TABLE} (database_name, owner_token) VALUES ($1, $2)",
+                database_name,
+                owner_token,
+            )
+        finally:
+            await target.close()
+    except BaseException:
+        # The name was absent immediately before this process created it, so
+        # exact cleanup is safe even if owner-marker initialization failed.
+        if created:
+            admin = await asyncpg.connect(
+                **_connection_kwargs(base_url, database="postgres")
+            )
+            try:
+                await admin.execute(
+                    f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'
+                )
+            finally:
+                await admin.close()
+        raise
+    return True
+
+
+async def drop_run_owned_database() -> bool:
+    """Drop only a database whose exact ownership marker matches this run."""
+
+    database_name = os.environ.get(DATABASE_NAME_ENV)
+    if not database_name:
+        return False
+    validate_owned_database_name(database_name)
+    owner_token = _validated_owner_token()
+
+    import asyncpg
+
+    base_url = make_url(os.environ[BASE_DATABASE_URL_ENV])
+    admin = await asyncpg.connect(**_connection_kwargs(base_url, database="postgres"))
+    try:
+        exists = await admin.fetchval(
+            "SELECT 1 FROM pg_database WHERE datname = $1", database_name
+        )
+    finally:
+        await admin.close()
+    if not exists:
+        return False
+
+    target = await asyncpg.connect(
+        **_connection_kwargs(base_url, database=database_name)
+    )
+    try:
+        marker = await target.fetchrow(
+            f"SELECT database_name, owner_token FROM {_OWNER_TABLE} "
+            "WHERE database_name = $1",
+            database_name,
+        )
+    except (asyncpg.PostgresError, asyncpg.InterfaceError) as exc:
+        raise RuntimeError(
+            "refusing to drop pytest database without an ownership marker"
+        ) from exc
+    finally:
+        await target.close()
+
+    if marker is None or marker["owner_token"] != owner_token:
+        raise RuntimeError("refusing to drop pytest database owned by another run")
+
+    admin = await asyncpg.connect(**_connection_kwargs(base_url, database="postgres"))
+    try:
+        await admin.execute(f'DROP DATABASE "{database_name}" WITH (FORCE)')
+    finally:
+        await admin.close()
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ Pytest configuration and common fixtures for auto-trader tests.
 import asyncio
 import contextlib
 import os
-import re
 import tempfile
+import time
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -15,20 +15,28 @@ import pandas as pd
 import pytest
 import pytest_asyncio
 
-# Cross-worker mutex serialising the Alpaca-paper suites that mutate the shared
-# `market_quote_snapshots` / `alpaca_paper_order_ledger` tables. See
-# `_serialize_alpaca_paper_db_suites` below. Lives in the temp dir so every
-# `pytest -n auto` worker process (same machine, same DB) contends on one file.
+from tests._run_owned_database import (
+    DATABASE_NAME_ENV as _XDIST_DATABASE_NAME_ENV,
+)
+from tests._run_owned_database import (
+    DEFAULT_TEST_DATABASE_URL as _DEFAULT_TEST_DATABASE_URL,
+)
+from tests._run_owned_database import (
+    configure_test_database_environment,
+    drop_run_owned_database,
+    ensure_run_owned_database,
+    uses_run_owned_database,
+    uses_shared_test_database,
+)
+
+# Compatibility mutex for the explicit shared-DB opt-in. Normal serial and
+# xdist runs own separate databases and never take this lock. It lives in the
+# temp dir so opted-in workers using the same database contend on one file.
 # Uses stdlib fcntl.flock (posix; the Linux CI + macOS dev boxes) — no extra
 # dependency — and no-ops on the rare non-posix host.
 _ALPACA_PAPER_DB_LOCK_PATH = (
     Path(tempfile.gettempdir()) / "auto_trader_alpaca_paper_db_suite.lock"
 )
-_DEFAULT_TEST_DATABASE_URL = (
-    "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
-)
-_XDIST_DATABASE_NAME_ENV = "AUTO_TRADER_XDIST_DATABASE_NAME"
-_XDIST_BASE_DATABASE_URL_ENV = "AUTO_TRADER_XDIST_BASE_DATABASE_URL"
 _DATABASE_FIXTURE_NAMES = frozenset(
     {
         "db_session",
@@ -39,6 +47,41 @@ _DATABASE_FIXTURE_NAMES = frozenset(
         "binance_demo_reservation_lock",
         "binance_demo_smoke_ledger_isolation",
     }
+)
+_SCHEMA_METRICS_KEY = pytest.StashKey[list[dict[str, object]]]()
+_KIS_DEFAULT_SCOPE_PARTS = (
+    "/brokers/kis/",
+    "/services/brokers/kis/",
+    "/services/order_proposals/",
+    "/test_kis",
+    "/test_mcp_order",
+    "/test_mcp_place_order",
+    "/test_nxt",
+    "/test_order",
+    "/test_services_kis",
+)
+_KR_CALENDAR_SCOPE_PARTS = (
+    "market_session",
+    "session_calendar",
+    "/test_daily_scan.py",
+    "/test_market_events",
+    "/test_mcp_",
+    "/test_preopen",
+    "/test_screener",
+    "/services/market_events/",
+)
+_AUTH_DB_SCOPE_PARTS = (
+    "/routers/",
+    "/test_admin",
+    "/test_agent_callback",
+    "/test_api",
+    "/test_auth",
+    "/test_dependencies",
+    "/test_invest_api",
+    "/test_main",
+    "/test_middleware",
+    "/test_routers",
+    "/test_web",
 )
 
 
@@ -121,25 +164,10 @@ def _ensure_test_env() -> None:
     # regardless of what's in env.example or .env
     os.environ["SECRET_KEY"] = "Test_Secret_Key_12345_Test_Secret_Key_12345"
 
-    # Force overwrite DATABASE_URL to ensure tests use the correct test database
-    # regardless of what's in env.example (which may contain placeholder values)
-    os.environ["DATABASE_URL"] = _DEFAULT_TEST_DATABASE_URL
-
-    # Each xdist worker gets its own PostgreSQL database. File-based distribution
-    # prevents two workers from running one file, but it does not isolate table
-    # rows: broad cleanup and fixed-key fixtures in different files can still
-    # delete or duplicate one another's data. A run-unique database removes that
-    # race while leaving ordinary serial pytest runs on the conventional test_db.
-    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
-    if worker_id and worker_id != "master":
-        run_uid = os.environ.get("PYTEST_XDIST_TESTRUNUID", "local")
-        safe_suffix = re.sub(r"[^a-zA-Z0-9_]", "_", f"{run_uid}_{worker_id}")
-        database_name = f"test_db_{safe_suffix[:55]}"
-        os.environ[_XDIST_DATABASE_NAME_ENV] = database_name
-        os.environ[_XDIST_BASE_DATABASE_URL_ENV] = _DEFAULT_TEST_DATABASE_URL
-        os.environ["DATABASE_URL"] = (
-            _DEFAULT_TEST_DATABASE_URL.rsplit("/", 1)[0] + f"/{database_name}"
-        )
+    # Select a run-owned database name without opening a connection. Serial
+    # pytest and every xdist worker get an exact, validated target. Pure unit
+    # and collect-only runs never cross the PostgreSQL boundary.
+    configure_test_database_environment()
 
     # ROB-469 PR2: force tests onto NullPool. Production defaults to the async queue
     # pool (DB_POOL_CLASS=queue), but pytest-asyncio uses a fresh event loop PER TEST,
@@ -309,7 +337,7 @@ def mock_redis_service():
     return mock_redis
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _mock_nxt_eligible(monkeypatch):
     """Default NXT eligible to True for tests that expect 'SOR' (legacy compatibility).
 
@@ -323,7 +351,7 @@ def _mock_nxt_eligible(monkeypatch):
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _mock_kr_market_session_calendar(monkeypatch):
     """Use a deterministic lightweight KRX calendar in fast tests.
 
@@ -360,7 +388,7 @@ def _mock_kr_market_session_calendar(monkeypatch):
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _serialize_alpaca_paper_db_suites(request):
     """Serialize Alpaca-paper suites that mutate shared DB tables across workers.
 
@@ -393,19 +421,14 @@ def _serialize_alpaca_paper_db_suites(request):
     also wrap this file's own cleanup in ``_alpaca_paper_db_suite_lock()`` —
     ``fcntl.flock`` is not reentrant across separate ``open()`` calls even
     within one process, so nesting it under this fixture would deadlock.)"""
-    path = str(getattr(request.node, "fspath", "") or "")
-    if (
-        "alpaca_paper" not in path
-        and "paper_approval_packet" not in path
-        and "test_trade_retrospective_pending" not in path
-    ):
+    if uses_run_owned_database():
         yield
         return
     with _alpaca_paper_db_suite_lock():
         yield
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _isolate_kis_circuit_breaker(monkeypatch):
     # ROB-699: the KIS circuit breaker is a per-process singleton, enabled by
     # default. Force it OFF + reset it for every test so the existing KIS suite
@@ -449,7 +472,7 @@ def _block_tvscreener_http_boundary(request, monkeypatch):
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_auth_middleware_db():
     """Mock AsyncSessionLocal in AuthMiddleware to prevent DB connection attempts."""
     with patch("app.middleware.auth.AsyncSessionLocal") as mock:
@@ -560,12 +583,13 @@ def sample_yahoo_data():
     }
 
 
-# Markers for different test types
+# Markers for different test types.
 pytest_plugins = ["pytest_asyncio", "tests._investment_reports_helpers"]
 
 
 def pytest_configure(config):
     """Configure pytest with custom markers."""
+    config.stash[_SCHEMA_METRICS_KEY] = []
     config.addinivalue_line(
         "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
     )
@@ -573,6 +597,37 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "unit: marks tests as unit tests")
     config.addinivalue_line(
         "markers", "live: marks tests as live API tests (require --run-live to execute)"
+    )
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    """Forward per-worker schema metrics to the xdist controller."""
+
+    worker_output = getattr(session.config, "workeroutput", None)
+    if worker_output is not None:
+        worker_output["auto_trader_schema_metrics"] = session.config.stash[
+            _SCHEMA_METRICS_KEY
+        ]
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node, error) -> None:  # noqa: ARG001
+    metrics = node.workeroutput.get("auto_trader_schema_metrics", [])
+    node.config.stash[_SCHEMA_METRICS_KEY].extend(metrics)
+
+
+def pytest_terminal_summary(terminalreporter) -> None:
+    metrics = terminalreporter.config.stash[_SCHEMA_METRICS_KEY]
+    if not metrics:
+        return
+    applied = sum(bool(metric["schema_applied"]) for metric in metrics)
+    schema_seconds = sum(float(metric["schema_seconds"]) for metric in metrics)
+    database_seconds = sum(float(metric["database_seconds"]) for metric in metrics)
+    terminalreporter.write_line(
+        "test schema bootstrap: "
+        f"databases={len(metrics)} applied={applied} "
+        f"schema_seconds={schema_seconds:.2f} "
+        f"database_seconds={database_seconds:.2f}"
     )
 
 
@@ -605,58 +660,24 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_live)
 
 
-async def _ensure_xdist_test_database() -> None:
-    """Create the current worker's isolated database before its first DB test."""
-    database_name = os.environ.get(_XDIST_DATABASE_NAME_ENV)
-    if not database_name:
-        return
-    if not re.fullmatch(r"[A-Za-z0-9_]+", database_name):
-        raise RuntimeError("refusing unsafe xdist database name")
+@pytest.fixture(autouse=True)
+def _scoped_test_defaults(request: pytest.FixtureRequest) -> None:
+    """Activate compatibility defaults only for their owning test areas."""
 
-    import asyncpg
-    from sqlalchemy.engine import make_url
-
-    base_url = make_url(os.environ[_XDIST_BASE_DATABASE_URL_ENV])
-    admin = await asyncpg.connect(
-        user=base_url.username,
-        password=base_url.password,
-        host=base_url.host,
-        port=base_url.port,
-        database="postgres",
-    )
-    try:
-        exists = await admin.fetchval(
-            "SELECT 1 FROM pg_database WHERE datname = $1", database_name
-        )
-        if not exists:
-            await admin.execute(f'CREATE DATABASE "{database_name}"')
-    finally:
-        await admin.close()
-
-
-async def _drop_xdist_test_database() -> None:
-    """Drop only the validated, run-owned xdist database."""
-    database_name = os.environ.get(_XDIST_DATABASE_NAME_ENV)
-    if not database_name:
-        return
-    if not re.fullmatch(r"test_db_[A-Za-z0-9_]+", database_name):
-        raise RuntimeError("refusing to drop an unowned xdist database")
-
-    import asyncpg
-    from sqlalchemy.engine import make_url
-
-    base_url = make_url(os.environ[_XDIST_BASE_DATABASE_URL_ENV])
-    admin = await asyncpg.connect(
-        user=base_url.username,
-        password=base_url.password,
-        host=base_url.host,
-        port=base_url.port,
-        database="postgres",
-    )
-    try:
-        await admin.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
-    finally:
-        await admin.close()
+    path = str(getattr(request.node, "path", "") or "")
+    if any(part in path for part in _KIS_DEFAULT_SCOPE_PARTS):
+        request.getfixturevalue("_mock_nxt_eligible")
+        request.getfixturevalue("_isolate_kis_circuit_breaker")
+    if any(part in path for part in _KR_CALENDAR_SCOPE_PARTS):
+        request.getfixturevalue("_mock_kr_market_session_calendar")
+    if any(part in path for part in _AUTH_DB_SCOPE_PARTS):
+        request.getfixturevalue("mock_auth_middleware_db")
+    if uses_shared_test_database() and (
+        "alpaca_paper" in path
+        or "paper_approval_packet" in path
+        or "test_trade_retrospective_pending" in path
+    ):
+        request.getfixturevalue("_serialize_alpaca_paper_db_suites")
 
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
@@ -682,65 +703,90 @@ async def _bootstrap_test_schema(request: pytest.FixtureRequest):
         yield
         return
 
-    await _ensure_xdist_test_database()
+    database_created = False
+    database_seconds = 0.0
+    engine = None
+    try:
+        database_started = time.perf_counter()
+        database_created = await ensure_run_owned_database()
+        database_seconds = time.perf_counter() - database_started
 
-    from sqlalchemy import text
+        from sqlalchemy import text
 
-    from app.core.db import engine
-    from tests._db_retry import run_with_deadlock_retry
-    from tests._investment_reports_helpers import INVESTMENT_REPORTS_TEST_LOCK_ID
-    from tests._schema_bootstrap import apply_test_schema, schema_content_hash
+        from app.core.db import engine as app_engine
+        from tests._db_retry import run_with_deadlock_retry
+        from tests._investment_reports_helpers import INVESTMENT_REPORTS_TEST_LOCK_ID
+        from tests._schema_bootstrap import apply_test_schema, schema_content_hash
 
-    wanted = schema_content_hash()
+        engine = app_engine
+        wanted = schema_content_hash()
+        schema_applied = False
 
-    async def _bootstrap_once() -> None:
-        async with engine.connect() as guard:
-            await guard.execute(
-                text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
-                {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
-            )
-            try:
-                async with engine.begin() as conn:
-                    await conn.execute(
-                        text(
-                            "CREATE TABLE IF NOT EXISTS public._pytest_schema_ready ("
-                            "content_hash TEXT PRIMARY KEY, "
-                            "applied_at TIMESTAMPTZ NOT NULL DEFAULT now())"
-                        )
-                    )
-                    already = (
+        async def _bootstrap_once() -> None:
+            nonlocal schema_applied
+            async with app_engine.connect() as guard:
+                await guard.execute(
+                    text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
+                    {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
+                )
+                try:
+                    async with app_engine.begin() as conn:
                         await conn.execute(
                             text(
-                                "SELECT 1 FROM public._pytest_schema_ready "
-                                "WHERE content_hash = :h"
+                                "CREATE TABLE IF NOT EXISTS "
+                                "public._pytest_schema_ready ("
+                                "content_hash TEXT PRIMARY KEY, "
+                                "applied_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+                            )
+                        )
+                        already = (
+                            await conn.execute(
+                                text(
+                                    "SELECT 1 FROM public._pytest_schema_ready "
+                                    "WHERE content_hash = :h"
+                                ),
+                                {"h": wanted},
+                            )
+                        ).first()
+                        if already:
+                            return
+                        await apply_test_schema(conn)
+                        schema_applied = True
+                        await conn.execute(
+                            text("DELETE FROM public._pytest_schema_ready")
+                        )
+                        await conn.execute(
+                            text(
+                                "INSERT INTO public._pytest_schema_ready "
+                                "(content_hash) VALUES (:h)"
                             ),
                             {"h": wanted},
                         )
-                    ).first()
-                    if already:
-                        return
-                    await apply_test_schema(conn)
-                    await conn.execute(text("DELETE FROM public._pytest_schema_ready"))
-                    await conn.execute(
-                        text(
-                            "INSERT INTO public._pytest_schema_ready (content_hash) "
-                            "VALUES (:h)"
-                        ),
-                        {"h": wanted},
+                finally:
+                    await guard.execute(
+                        text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                        {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
                     )
-            finally:
-                await guard.execute(
-                    text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
-                    {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
-                )
 
-    try:
+        schema_started = time.perf_counter()
         await run_with_deadlock_retry(_bootstrap_once)
+        request.config.stash[_SCHEMA_METRICS_KEY].append(
+            {
+                "database": os.environ.get(_XDIST_DATABASE_NAME_ENV, "test_db"),
+                "database_created": database_created,
+                "database_seconds": database_seconds,
+                "schema_applied": schema_applied,
+                "schema_seconds": time.perf_counter() - schema_started,
+            }
+        )
         yield
     finally:
-        if os.environ.get(_XDIST_DATABASE_NAME_ENV):
-            await engine.dispose()
-            await _drop_xdist_test_database()
+        if uses_run_owned_database():
+            try:
+                if engine is not None:
+                    await engine.dispose()
+            finally:
+                await drop_run_owned_database()
 
 
 # Database fixtures for integration tests
@@ -761,11 +807,12 @@ async def db_session(_bootstrap_test_schema):
 
 @pytest_asyncio.fixture
 async def investment_reports_cleanup_lock(db_session):
-    """Hold the investment-report cleanup lock for tests using ``db_session``.
+    """Isolate committed investment-report rows for global ``db_session`` tests.
 
-    Most investment-report table tests use ``tests._investment_reports_helpers.session``.
-    That fixture serializes its own body and cleanup because it truncates
-    ``review.investment_reports`` and child tables after each test.
+    Most investment-report table tests use
+    ``tests._investment_reports_helpers.session``. That fixture uses an outer
+    transaction plus SAVEPOINT-aware sessions, so ordinary test cleanup is a
+    rollback rather than committed table-wide deletion.
 
     A few cross-domain tests must use the global ``db_session`` fixture because
     they span ``review.investment_reports`` plus snapshot/stage tables. During
@@ -787,41 +834,45 @@ async def investment_reports_cleanup_lock(db_session):
         INVESTMENT_REPORTS_TEST_LOCK_ID,
     )
 
-    async def _truncate_investment_report_tables() -> None:
+    async def _delete_investment_report_rows() -> None:
         # Keep this cleanup aligned with tests._investment_reports_helpers.session:
         # only the investment-report table family is reset here. Snapshot/stage
         # tables use UUID-scoped test rows and are intentionally left alone.
         async with engine.begin() as cleanup:
             for table in reversed(INVESTMENT_REPORTS_TABLES):
                 table_name = table.name  # type: ignore[attr-defined]
-                await cleanup.execute(
-                    text(
-                        f'TRUNCATE TABLE review."{table_name}" RESTART IDENTITY CASCADE'
-                    )
-                )
+                await cleanup.execute(text(f'DELETE FROM review."{table_name}"'))
 
-    async with engine.connect() as guard:
-        await guard.execute(
-            text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
-            {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
-        )
-        try:
-            await db_session.rollback()
-            await run_with_deadlock_retry(
-                _truncate_investment_report_tables,
-                rollback=db_session.rollback,
-            )
-            yield db_session
-            await db_session.rollback()
-            await run_with_deadlock_retry(
-                _truncate_investment_report_tables,
-                rollback=db_session.rollback,
-            )
-        finally:
+    guard = None
+    try:
+        if uses_shared_test_database():
+            guard = await engine.connect()
             await guard.execute(
-                text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
                 {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
             )
+        await db_session.rollback()
+        await run_with_deadlock_retry(
+            _delete_investment_report_rows,
+            rollback=db_session.rollback,
+        )
+        try:
+            yield db_session
+        finally:
+            await db_session.rollback()
+            await run_with_deadlock_retry(
+                _delete_investment_report_rows,
+                rollback=db_session.rollback,
+            )
+    finally:
+        if guard is not None:
+            try:
+                await guard.execute(
+                    text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                    {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
+                )
+            finally:
+                await guard.close()
 
 
 @pytest_asyncio.fixture
@@ -833,6 +884,10 @@ async def retrospective_action_control_lock(_bootstrap_test_schema):
     workers share one PostgreSQL database, so those tests must not observe one
     another's temporary canonical mode or DDL state.
     """
+    if uses_run_owned_database():
+        yield
+        return
+
     from sqlalchemy import text
 
     from app.core.db import engine

--- a/tests/infra/test_run_owned_database.py
+++ b/tests/infra/test_run_owned_database.py
@@ -1,0 +1,103 @@
+"""Unit contracts for fail-closed pytest database ownership."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests import _run_owned_database as owned_db
+
+pytestmark = pytest.mark.unit
+
+
+def _clear_database_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        owned_db.DATABASE_NAME_ENV,
+        owned_db.BASE_DATABASE_URL_ENV,
+        owned_db.RUN_UID_ENV,
+        owned_db.OWNER_TOKEN_ENV,
+        owned_db.SHARED_DATABASE_ENV,
+        owned_db.TEST_DATABASE_URL_ENV,
+        "PYTEST_XDIST_WORKER",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_serial_configuration_uses_fresh_owned_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+
+    owned_db.configure_test_database_environment()
+
+    database_name = owned_db.os.environ[owned_db.DATABASE_NAME_ENV]
+    assert re.fullmatch(r"test_db_pytest_[0-9a-f]{12}_main", database_name)
+    assert owned_db.os.environ["DATABASE_URL"].endswith(f"/{database_name}")
+    assert owned_db.uses_run_owned_database() is True
+
+
+def test_xdist_worker_reuses_run_identity_but_gets_worker_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv(owned_db.RUN_UID_ENV, "a1b2c3d4e5f6")
+    monkeypatch.setenv(owned_db.OWNER_TOKEN_ENV, "7" * 32)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+
+    owned_db.configure_test_database_environment()
+
+    assert (
+        owned_db.os.environ[owned_db.DATABASE_NAME_ENV]
+        == "test_db_pytest_a1b2c3d4e5f6_gw3"
+    )
+
+
+def test_shared_database_requires_exact_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv(owned_db.SHARED_DATABASE_ENV, "1")
+
+    owned_db.configure_test_database_environment()
+
+    assert owned_db.DATABASE_NAME_ENV not in owned_db.os.environ
+    assert owned_db.os.environ["DATABASE_URL"].endswith("/test_db")
+    assert owned_db.uses_shared_test_database() is True
+
+
+@pytest.mark.parametrize("value", ["true", "yes", "2", "-1"])
+def test_shared_database_rejects_ambiguous_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv(owned_db.SHARED_DATABASE_ENV, value)
+
+    with pytest.raises(RuntimeError, match="must be exactly 0 or 1"):
+        owned_db.configure_test_database_environment()
+
+
+def test_general_database_url_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv(
+        owned_db.TEST_DATABASE_URL_ENV,
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/auto_trader",
+    )
+
+    with pytest.raises(RuntimeError, match="dedicated test_db"):
+        owned_db.configure_test_database_environment()
+
+
+def test_drop_name_must_belong_to_current_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv(owned_db.RUN_UID_ENV, "a1b2c3d4e5f6")
+
+    with pytest.raises(RuntimeError, match="different run"):
+        owned_db.validate_owned_database_name("test_db_pytest_000000000000_main")
+    with pytest.raises(RuntimeError, match="unsafe or unowned"):
+        owned_db.validate_owned_database_name("production")

--- a/tests/infra/test_schema_barrier.py
+++ b/tests/infra/test_schema_barrier.py
@@ -10,14 +10,12 @@ Covers four concerns:
    pre-ROB-723 fixtures (incl. the ROB-455 decision CHECK unique to the
    investment-reports helper).
 3. The session-scoped barrier fixture in ``tests.conftest`` must leave a
-   durable sentinel behind so subsequent (workers') bootstrap calls can
-   short-circuit.
+   durable sentinel in each run-owned database.
 4. The ``db_session`` and helper ``session`` fixtures must no longer carry
    DDL inline (schema parity is owned by the barrier).
 
-A concurrency stress test exercises real contention against the shared
-test DB to confirm the buffer (combined with the barrier) absorbs the
-deadlock window.
+A concurrency stress test keeps the explicit shared-DB opt-in cleanup path
+covered even though normal serial and xdist runs no longer share a database.
 """
 
 from __future__ import annotations
@@ -42,10 +40,10 @@ from tests._db_retry import run_with_deadlock_retry
 async def _throwaway_schema_db() -> AsyncIterator[AsyncEngine]:
     """Yield an engine on a dedicated one-off database (ROB-968).
 
-    The DDL-idempotency and TRUNCATE-hammer tests below must NOT run against
+    The DDL-idempotency and cleanup-hammer tests below must NOT run against
     the shared xdist test DB: apply_test_schema takes AccessExclusiveLock per
-    DDL statement and the hammer's ``TRUNCATE ... CASCADE`` both locks AND
-    empties every FK-connected table — deadlocking (and deleting rows under)
+    DDL statement and the cleanup hammer both lock and empty related tables —
+    deadlocking (and deleting rows under)
     sibling workers whenever shard composition co-schedules review-DML files
     (runs 29643108579 / 29643559556 / 29643876785). A throwaway database
     preserves exactly what these tests assert while making the module inert
@@ -257,23 +255,22 @@ def test_helper_session_fixture_is_ddl_free():
     assert "create_all" not in src
     assert "ADD CONSTRAINT" not in src
     assert "ALTER TABLE" not in src
+    assert "create_async_engine" not in src
+    assert "TRUNCATE" not in src
 
 
 # --------------------------------------------------------------------------- #
-# Task 6: concurrency — the advisory-lock serialization the real fixtures use  #
-# must let concurrent TRUNCATE + read complete without a deadlock escaping.    #
+# Task 6: explicit shared-DB compatibility keeps cleanup/read serialization.   #
 # --------------------------------------------------------------------------- #
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_concurrent_serialized_access_no_deadlock_escape():
     """Model the REAL fixture invariant and assert it is deadlock-free.
 
-    The ``session``/``investment_reports_cleanup_lock`` fixtures serialize ALL
-    review-table access (TRUNCATE *and* the report-table reads/writes that opt
-    into the cleanup lock) under ``INVESTMENT_REPORTS_TEST_LOCK_ID``. When both
-    sides hold that lock there is no cross-transaction lock-order cycle, so the
-    multi-table TRUNCATE-vs-read hazard that produced ROB-723 cannot form. This
-    test drives that exact shape concurrently and asserts nothing escapes.
+    Normal runs use separate databases and need no cross-worker serialization.
+    Explicit shared-DB compatibility still serializes report-family DELETE and
+    reads under ``INVESTMENT_REPORTS_TEST_LOCK_ID``. This test drives that
+    fallback shape concurrently and asserts nothing escapes.
 
     The retry buffer for the un-opted-in reader tail is proven independently by
     the ``run_with_deadlock_retry`` unit tests above; asserting "retry alone
@@ -316,16 +313,11 @@ async def _drive_hammer(
 
         await run_with_deadlock_retry(_op)
 
-    async def truncate_cycle():
+    async def cleanup_cycle():
         async def _body():
             async with engine.begin() as conn:
                 for table in reversed(INVESTMENT_REPORTS_TABLES):
-                    await conn.execute(
-                        text(
-                            f'TRUNCATE TABLE review."{table.name}" '
-                            "RESTART IDENTITY CASCADE"
-                        )
-                    )
+                    await conn.execute(text(f'DELETE FROM review."{table.name}"'))
 
         await _under_advisory_lock(_body)
 
@@ -341,7 +333,7 @@ async def _drive_hammer(
 
     tasks = []
     for _ in range(8):
-        tasks.append(truncate_cycle())
+        tasks.append(cleanup_cycle())
         tasks.append(read_cycle())
     # Must complete without a DeadlockDetectedError propagating.
     await asyncio.gather(*tasks)

--- a/tests/mcp_server/test_watch_events_list_recent_tool.py
+++ b/tests/mcp_server/test_watch_events_list_recent_tool.py
@@ -1,6 +1,9 @@
 """ROB-602 Task 3: investment_watch_events_list_recent MCP 도구 테스트."""
 
+from collections.abc import AsyncIterator
+
 import pytest
+import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.mcp_server.tooling.investment_reports_handlers import (
@@ -9,6 +12,14 @@ from app.mcp_server.tooling.investment_reports_handlers import (
 from tests._watch_events_helpers import mk_watch_event, utc_at
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture(name="session")
+async def _committed_session(
+    committed_investment_reports_session: AsyncSession,
+) -> AsyncIterator[AsyncSession]:
+    """Expose committed rows to the tool's independent database session."""
+    yield committed_investment_reports_session
 
 
 async def test_tool_returns_delivered_events_json(session: AsyncSession):

--- a/tests/scripts/test_list_recent_watch_events_cli.py
+++ b/tests/scripts/test_list_recent_watch_events_cli.py
@@ -1,11 +1,21 @@
 import json
 import uuid
+from collections.abc import AsyncIterator
 
 import pytest
+import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from scripts.list_recent_watch_events import _source_report_link_state, collect, main
 from tests._watch_events_helpers import mk_watch_event, utc_at
+
+
+@pytest_asyncio.fixture(name="session")
+async def _committed_session(
+    committed_investment_reports_session: AsyncSession,
+) -> AsyncIterator[AsyncSession]:
+    """Expose committed rows to the CLI's independent database session."""
+    yield committed_investment_reports_session
 
 
 @pytest.mark.asyncio

--- a/tests/test_binance_r4_p0_hardening.py
+++ b/tests/test_binance_r4_p0_hardening.py
@@ -474,9 +474,16 @@ async def test_historical_retry_appends_terminal_attempt(tmp_path) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_taker_history_shift_restores_full_epoch_coverage(tmp_path) -> None:
+async def test_taker_history_shift_restores_full_epoch_coverage(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     cadence = dt.timedelta(minutes=5)
     interval_start = EPOCH - dt.timedelta(hours=4)
+    monkeypatch.setattr(
+        collector_module,
+        "utc_now",
+        lambda: EPOCH + dt.timedelta(minutes=1),
+    )
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/futures/data/takerlongshortRatio"

--- a/tests/test_crypto_composite_score.py
+++ b/tests/test_crypto_composite_score.py
@@ -29,9 +29,10 @@ from app.mcp_server.tooling.market_data_indicators import (
     _calculate_adx,
 )
 from app.mcp_server.tooling.screening import crypto as screening_crypto
-from tests._mcp_tooling_support import build_tools
+from tests._mcp_tooling_support import build_tools, fake_crypto_tvscreener_module
 
-pytest_plugins = ("tests._mcp_tooling_support",)
+__all__ = ["fake_crypto_tvscreener_module"]
+
 pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -2,17 +2,20 @@
 
 Each tool's ``*_impl`` is called directly (matches the legacy
 ``test_analysis_report_workflow.py`` style). The handlers open their
-own ``AsyncSessionLocal`` against the same test_db that the ``session``
-fixture manages; the fixture's per-test TRUNCATE keeps state clean.
+own ``AsyncSessionLocal`` against the current run-owned DB. This module
+explicitly selects the committed-session fixture, whose narrow DELETE cleanup
+keeps independent handler transactions isolated without table-wide TRUNCATE.
 """
 
 from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import AsyncIterator
 from datetime import timedelta
 
 import pytest
+import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -37,6 +40,14 @@ from app.mcp_server.tooling.investment_reports_handlers import (
 )
 from app.services.investment_reports.ingestion import InvestmentReportIngestionService
 from tests._investment_reports_helpers import future_datetime
+
+
+@pytest_asyncio.fixture(name="session")
+async def _committed_session(
+    committed_investment_reports_session: AsyncSession,
+) -> AsyncIterator[AsyncSession]:
+    """Expose the explicit cross-session cleanup path under the legacy name."""
+    yield committed_investment_reports_session
 
 
 async def _publish_by_uuid(report_uuid: str) -> None:

--- a/tests/test_investment_watch_scanner.py
+++ b/tests/test_investment_watch_scanner.py
@@ -8,11 +8,13 @@ and stubs Hermes delivery to capture payloads. Asserts both DB state
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any
 
 import pytest
+import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -38,6 +40,14 @@ from app.services.investment_reports.repository import InvestmentReportsReposito
 from app.services.investment_reports.watch_activation import WatchActivationService
 from app.services.investment_reports.watch_create import DirectWatchCreateService
 from tests._investment_reports_helpers import future_datetime
+
+
+@pytest_asyncio.fixture(name="session")
+async def _committed_session(
+    committed_investment_reports_session: AsyncSession,
+) -> AsyncIterator[AsyncSession]:
+    """Expose committed rows to the scanner's independent database sessions."""
+    yield committed_investment_reports_session
 
 
 @dataclass

--- a/tests/test_mcp_recommend_flow.py
+++ b/tests/test_mcp_recommend_flow.py
@@ -14,9 +14,10 @@ from app.mcp_server.tooling import (
 from app.mcp_server.tooling.screening import kr as screening_kr
 from app.mcp_server.tooling.screening import us as screening_us
 from tests._mcp_recommend_support import _mock_empty_holdings, _mock_kr_sources
-from tests._mcp_tooling_support import build_tools
+from tests._mcp_tooling_support import _mock_crypto_external_sources, build_tools
 
-pytest_plugins = ("tests._mcp_tooling_support",)
+__all__ = ["_mock_crypto_external_sources"]
+
 pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 

--- a/tests/test_mcp_screen_stocks_crypto.py
+++ b/tests/test_mcp_screen_stocks_crypto.py
@@ -7,9 +7,19 @@ import sentry_sdk
 
 import app.services.brokers.upbit.client as upbit_service
 from app.mcp_server.tooling.screening import crypto as screening_crypto
-from tests._mcp_tooling_support import build_tools
+from tests._mcp_tooling_support import (
+    _mock_crypto_external_sources,
+    build_tools,
+    fake_crypto_tvscreener_module,
+    mock_upbit_coins,
+)
 
-pytest_plugins = ("tests._mcp_tooling_support",)
+__all__ = [
+    "_mock_crypto_external_sources",
+    "fake_crypto_tvscreener_module",
+    "mock_upbit_coins",
+]
+
 pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 

--- a/tests/test_mcp_screen_stocks_filters_and_rsi.py
+++ b/tests/test_mcp_screen_stocks_filters_and_rsi.py
@@ -7,9 +7,23 @@ import app.services.naver_finance as naver_finance
 from app.mcp_server.tooling.screening import crypto as screening_crypto
 from app.mcp_server.tooling.screening import kr as screening_kr
 from app.mcp_server.tooling.screening import us as screening_us
-from tests._mcp_tooling_support import build_tools
+from tests._mcp_tooling_support import (
+    _mock_crypto_external_sources,
+    build_tools,
+    mock_krx_etfs,
+    mock_krx_stocks,
+    mock_upbit_coins,
+    mock_yfinance_screen,
+)
 
-pytest_plugins = ("tests._mcp_tooling_support",)
+__all__ = [
+    "_mock_crypto_external_sources",
+    "mock_krx_etfs",
+    "mock_krx_stocks",
+    "mock_upbit_coins",
+    "mock_yfinance_screen",
+]
+
 pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -28,7 +28,10 @@ from tests._mcp_screen_stocks_support import (
     mock_yfinance_screen,
     test_screen_stocks_smoke,
 )
-from tests._mcp_tooling_support import _mock_crypto_external_sources
+from tests._mcp_tooling_support import (
+    _mock_crypto_external_sources,
+    fake_crypto_tvscreener_module,
+)
 
 pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
@@ -43,6 +46,7 @@ __all__ = [
     "mock_valuation_data",
     "mock_yfinance_screen",
     "_mock_crypto_external_sources",
+    "fake_crypto_tvscreener_module",
 ]
 
 

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -21,10 +21,15 @@ from tests._mcp_screen_stocks_support import (
     TestScreenStocksKR,
     TestScreenStocksKRRegression,
     build_tools,
+    mock_krx_etfs,
+    mock_krx_stocks,
+    mock_upbit_coins,
+    mock_valuation_data,
+    mock_yfinance_screen,
     test_screen_stocks_smoke,
 )
+from tests._mcp_tooling_support import _mock_crypto_external_sources
 
-pytest_plugins = ("tests._mcp_screen_stocks_support",)
 pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 __all__ = [
@@ -32,6 +37,12 @@ __all__ = [
     "TestScreenStocksKRRegression",
     "TestScreenStocksFundamentalsExpansion",
     "test_screen_stocks_smoke",
+    "mock_krx_etfs",
+    "mock_krx_stocks",
+    "mock_upbit_coins",
+    "mock_valuation_data",
+    "mock_yfinance_screen",
+    "_mock_crypto_external_sources",
 ]
 
 

--- a/tests/test_mcp_screen_stocks_tvscreener_contract.py
+++ b/tests/test_mcp_screen_stocks_tvscreener_contract.py
@@ -10,9 +10,14 @@ from app.services.tvscreener_service import (
     TvScreenerCapabilitySnapshot,
     TvScreenerCapabilityState,
 )
-from tests._mcp_tooling_support import build_tools
+from tests._mcp_tooling_support import (
+    _mock_crypto_external_sources,
+    build_tools,
+    mock_yfinance_screen,
+)
 
-pytest_plugins = ("tests._mcp_tooling_support",)
+__all__ = ["_mock_crypto_external_sources", "mock_yfinance_screen"]
+
 pytestmark = pytest.mark.usefixtures("_mock_crypto_external_sources")
 
 

--- a/tests/test_news_ingestor_bulk.py
+++ b/tests/test_news_ingestor_bulk.py
@@ -312,6 +312,16 @@ class TestNewsReadinessPreopenIntegration:
                 "get_news_readiness",
                 new=AsyncMock(return_value=readiness),
             ),
+            patch.object(
+                preopen_dashboard_service,
+                "get_latest_news_preview",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                preopen_dashboard_service,
+                "_build_market_news_briefing",
+                new=AsyncMock(return_value=None),
+            ),
         ):
             result = await preopen_dashboard_service.get_latest_preopen_dashboard(
                 db=AsyncMock(),

--- a/tests/test_nxt_advisory_only_pilot.py
+++ b/tests/test_nxt_advisory_only_pilot.py
@@ -24,10 +24,12 @@ the full path through Plans 3 and 4 honours it.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from decimal import Decimal
 
 import pytest
+import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -50,6 +52,14 @@ from app.services.investment_reports.ingestion import (
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
 from tests._investment_reports_helpers import future_datetime
+
+
+@pytest_asyncio.fixture(name="session")
+async def _committed_session(
+    committed_investment_reports_session: AsyncSession,
+) -> AsyncIterator[AsyncSession]:
+    """Expose committed rows to the scanner's independent database sessions."""
+    yield committed_investment_reports_session
 
 
 @dataclass

--- a/tests/test_research_run_live_refresh_service.py
+++ b/tests/test_research_run_live_refresh_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,6 +19,14 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.asyncio
 
 
+def _mock_db_without_kr_universe() -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    db.execute.return_value = result
+    return db
+
+
 @pytest.mark.unit
 async def test_build_snapshot_returns_live_refresh_snapshot():
     """Test that build_live_refresh_snapshot returns a LiveRefreshSnapshot."""
@@ -30,7 +38,7 @@ async def test_build_snapshot_returns_live_refresh_snapshot():
         ],
         reconciliations=[],
     )
-    mock_db = AsyncMock()
+    mock_db = _mock_db_without_kr_universe()
 
     with patch("app.services.market_data.get_quote") as mock_quote:
         with patch("app.services.market_data.get_orderbook") as mock_orderbook:
@@ -70,7 +78,7 @@ async def test_build_snapshot_quote_failure_adds_warning():
         ],
         reconciliations=[],
     )
-    mock_db = AsyncMock()
+    mock_db = _mock_db_without_kr_universe()
 
     with patch("app.services.market_data.get_quote") as mock_quote:
         with patch("app.services.market_data.get_orderbook") as mock_orderbook:
@@ -109,7 +117,7 @@ async def test_build_snapshot_us_skips_orderbook():
         ],
         reconciliations=[],
     )
-    mock_db = AsyncMock()
+    mock_db = _mock_db_without_kr_universe()
 
     with patch("app.services.market_data.get_quote") as mock_quote:
         with patch("app.services.market_data.get_orderbook") as mock_orderbook:
@@ -144,7 +152,7 @@ async def test_build_snapshot_missing_kr_universe_adds_warning():
         ],
         reconciliations=[],
     )
-    mock_db = AsyncMock()
+    mock_db = _mock_db_without_kr_universe()
 
     with patch("app.services.market_data.get_quote") as mock_quote:
         with patch("app.services.market_data.get_orderbook") as mock_orderbook:
@@ -186,7 +194,7 @@ async def test_build_snapshot_refreshed_at_after_gather():
         ],
         reconciliations=[],
     )
-    mock_db = AsyncMock()
+    mock_db = _mock_db_without_kr_universe()
     start_time = datetime.now(UTC)
 
     with patch("app.services.market_data.get_quote") as mock_quote:

--- a/tests/test_rob878_transition_core.py
+++ b/tests/test_rob878_transition_core.py
@@ -28,7 +28,6 @@ from app.services.trade_journal.retrospective_action_types import (
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
     pytest.mark.usefixtures("retrospective_action_control_lock"),
 ]
 
@@ -140,7 +139,6 @@ async def _projection(db: AsyncSession, parent_id: int) -> list[dict[str, object
 @pytest_asyncio.fixture(autouse=True)
 async def _isolate_tables(
     db_session: AsyncSession,
-    investment_reports_cleanup_lock: AsyncSession,
     retrospective_action_control_lock: None,
 ) -> AsyncIterator[None]:
     await db_session.rollback()

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -33,7 +33,7 @@ def _fake_external_boundaries_by_default(monkeypatch: pytest.MonkeyPatch) -> Non
 
     async def _empty_positions(
         market_filter: str | None, *, is_mock: bool = False
-    ) -> tuple[list[dict[str, Any]], list[str]]:
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         del market_filter, is_mock
         return [], []
 
@@ -51,14 +51,23 @@ def _fake_external_boundaries_by_default(monkeypatch: pytest.MonkeyPatch) -> Non
         market: str,
         session_factory,
         opinion_provider=None,
+        fetch_kr_sector=None,
+        fetch_us_sector=None,
     ) -> dict[str, Any]:
-        del market, session_factory, opinion_provider
+        del (
+            market,
+            session_factory,
+            opinion_provider,
+            fetch_kr_sector,
+            fetch_us_sector,
+        )
         return {
             "results": rows,
             "summary": {
                 "attempted": len(rows),
                 "consensusSucceeded": 0,
                 "rsiSucceeded": 0,
+                "sectorResolved": 0,
                 "warnings": [],
             },
         }
@@ -269,7 +278,10 @@ async def test_enriches_only_returned_page(monkeypatch) -> None:
         market: str,
         session_factory,
         opinion_provider=None,
-    ):
+        fetch_kr_sector=None,
+        fetch_us_sector=None,
+    ) -> dict[str, Any]:
+        del opinion_provider, fetch_kr_sector, fetch_us_sector
         captured["symbols"] = [row["symbol"] for row in rows]
         captured["market"] = market
         captured["session_factory"] = session_factory
@@ -306,6 +318,7 @@ async def test_enriches_only_returned_page(monkeypatch) -> None:
                 "attempted": len(rows),
                 "consensusSucceeded": len(rows),
                 "rsiSucceeded": len(rows),
+                "sectorResolved": 0,
                 "warnings": [],
             },
         }
@@ -355,7 +368,7 @@ async def test_snapshot_tool_marks_kis_live_held_rows(monkeypatch) -> None:
 
     async def _fake_collect_kis_positions(
         market_filter: str | None, *, is_mock: bool = False
-    ):
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         assert market_filter == "equity_kr"
         assert is_mock is False
         return ([{"market": "kr", "symbol": "005930"}], [])
@@ -412,7 +425,7 @@ async def test_snapshot_tool_marks_us_kis_live_held_rows(monkeypatch) -> None:
 
     async def _fake_collect_kis_positions(
         market_filter: str | None, *, is_mock: bool = False
-    ):
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         assert market_filter == "equity_us"
         assert is_mock is False
         return ([{"market": "us", "symbol": "BRK.B"}], [])
@@ -458,7 +471,8 @@ async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(
 
     async def _fail_collect_kis_positions(
         market_filter: str | None, *, is_mock: bool = False
-    ):
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        del market_filter, is_mock
         raise RuntimeError("kis unavailable")
 
     monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
@@ -501,7 +515,9 @@ async def test_snapshot_tool_holdings_error_tuple_warns_and_keeps_results(
     async def _fake_build(**_kwargs: Any) -> _Resp:
         return _Resp()
 
-    async def _collect_with_errors(market_filter: str | None, *, is_mock: bool = False):
+    async def _collect_with_errors(
+        market_filter: str | None, *, is_mock: bool = False
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         assert market_filter == "equity_kr"
         assert is_mock is False
         return (
@@ -557,7 +573,9 @@ async def test_snapshot_tool_holdings_partial_tuple_warns_and_marks_rows(
         assert resolver.relation("kr", "000660") == "none"
         return _Resp()
 
-    async def _collect_partial(market_filter: str | None, *, is_mock: bool = False):
+    async def _collect_partial(
+        market_filter: str | None, *, is_mock: bool = False
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         assert market_filter == "equity_kr"
         assert is_mock is False
         return (
@@ -892,7 +910,22 @@ async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None
     async def _fake_build(**_kwargs: Any) -> _Resp:
         return _Resp()
 
-    async def _fake_enrich_page(*, rows: list[dict[str, Any]], **kwargs: Any):
+    async def _fake_enrich_page(
+        *,
+        rows: list[dict[str, Any]],
+        market: str,
+        session_factory,
+        opinion_provider=None,
+        fetch_kr_sector=None,
+        fetch_us_sector=None,
+    ) -> dict[str, Any]:
+        del (
+            market,
+            session_factory,
+            opinion_provider,
+            fetch_kr_sector,
+            fetch_us_sector,
+        )
         # S1 has 2 buy ratings, S2 has 0
         enriched = []
         for r in rows:
@@ -909,7 +942,16 @@ async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None
                     },
                 }
             )
-        return {"results": enriched, "summary": {"warnings": []}}
+        return {
+            "results": enriched,
+            "summary": {
+                "attempted": len(rows),
+                "consensusSucceeded": 1,
+                "rsiSucceeded": 0,
+                "sectorResolved": 0,
+                "warnings": [],
+            },
+        }
 
     monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
     monkeypatch.setattr(
@@ -1122,14 +1164,33 @@ async def test_min_analyst_filters_via_counts_and_enriches_only_page(
     enriched_symbols: list[list[str]] = []
 
     async def _fake_enrich_page(
-        *, rows, market, session_factory, opinion_provider=None
-    ):
+        *,
+        rows: list[dict[str, Any]],
+        market: str,
+        session_factory,
+        opinion_provider=None,
+        fetch_kr_sector=None,
+        fetch_us_sector=None,
+    ) -> dict[str, Any]:
+        del (
+            market,
+            session_factory,
+            opinion_provider,
+            fetch_kr_sector,
+            fetch_us_sector,
+        )
         enriched_symbols.append([r["symbol"] for r in rows])
         return {
             "results": [
                 {**r, "analystLabel": "x", "analysisContext": {}} for r in rows
             ],
-            "summary": {"attempted": len(rows), "warnings": []},
+            "summary": {
+                "attempted": len(rows),
+                "consensusSucceeded": 0,
+                "rsiSucceeded": 0,
+                "sectorResolved": 0,
+                "warnings": [],
+            },
         }
 
     monkeypatch.setattr(

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -561,49 +561,6 @@ async def test_kis_inquire_daily_itemchartprice_returns_empty_dataframe_on_empty
     request_mock.assert_awaited_once()
 
 
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_kis_inquire_daily_itemchartprice_rejects_non_positive_n(monkeypatch):
-    from app.services.brokers.kis.client import KISClient
-
-    client = KISClient()
-    monkeypatch.setattr(client, "_ensure_token", AsyncMock())
-
-    with pytest.raises(ValueError, match="greater than or equal to 1"):
-        await client.inquire_daily_itemchartprice("005930", market="J", n=0)
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_kis_inquire_daily_itemchartprice_clamps_oversized_n_to_200(monkeypatch):
-    from app.services.brokers.kis.client import KISClient
-
-    client = KISClient()
-    monkeypatch.setattr(client, "_ensure_token", AsyncMock())
-
-    chunk = [
-        {
-            "stck_bsop_date": (
-                pd.Timestamp("2026-01-01") + pd.Timedelta(days=index)
-            ).strftime("%Y%m%d"),
-            "stck_oprc": str(70000 + index),
-            "stck_hgpr": str(70100 + index),
-            "stck_lwpr": str(69900 + index),
-            "stck_clpr": str(70050 + index),
-            "acml_vol": str(1000 + index),
-            "acml_tr_pbmn": str(70050000 + index),
-        }
-        for index in range(250)
-    ]
-    request_mock = AsyncMock(return_value={"rt_cd": "0", "output2": chunk})
-    monkeypatch.setattr(client, "_request_with_rate_limit", request_mock)
-
-    df = await client.inquire_daily_itemchartprice("005930", market="J", n=9999)
-
-    assert len(df) == 200
-    request_mock.assert_awaited_once()
-
-
 @pytest.mark.asyncio
 async def test_kis_inquire_daily_itemchartprice_raises_controlled_error_on_missing_date(
     monkeypatch,

--- a/tests/test_services_kis_market_data_unit.py
+++ b/tests/test_services_kis_market_data_unit.py
@@ -1,0 +1,53 @@
+"""Pure input-boundary tests split from the mixed KIS market-data suite."""
+
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kis_inquire_daily_itemchartprice_rejects_non_positive_n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.brokers.kis.client import KISClient
+
+    client = KISClient()
+    monkeypatch.setattr(client, "_ensure_token", AsyncMock())
+
+    with pytest.raises(ValueError, match="greater than or equal to 1"):
+        await client.inquire_daily_itemchartprice("005930", market="J", n=0)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kis_inquire_daily_itemchartprice_clamps_oversized_n_to_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.brokers.kis.client import KISClient
+
+    client = KISClient()
+    monkeypatch.setattr(client, "_ensure_token", AsyncMock())
+
+    chunk = [
+        {
+            "stck_bsop_date": (
+                pd.Timestamp("2026-01-01") + pd.Timedelta(days=index)
+            ).strftime("%Y%m%d"),
+            "stck_oprc": str(70000 + index),
+            "stck_hgpr": str(70100 + index),
+            "stck_lwpr": str(69900 + index),
+            "stck_clpr": str(70050 + index),
+            "acml_vol": str(1000 + index),
+            "acml_tr_pbmn": str(70050000 + index),
+        }
+        for index in range(250)
+    ]
+    request_mock = AsyncMock(return_value={"rt_cd": "0", "output2": chunk})
+    monkeypatch.setattr(client, "_request_with_rate_limit", request_mock)
+
+    frame = await client.inquire_daily_itemchartprice("005930", market="J", n=9999)
+
+    assert len(frame) == 200
+    request_mock.assert_awaited_once()


### PR DESCRIPTION
# PR #1704 후속 — 트랙 A 테스트 인프라 결과

- 작업 브랜치: `perf/test-infra-followup-a`
- 최종 base: `origin/main` (`bad2e7759`)
- 커밋: `939ec558b` (`test: isolate pytest databases and fixture scopes`)
- PR: https://github.com/mgh3326/auto_trader/pull/1711
- 작업 worktree: `/Users/mgh3326/work/auto_trader.testperf2a`
- 측정 기준: 별도 표기가 없으면 `/usr/bin/time -p`의 `real` 값이다.
- 보호 사항: 공유 루트의 `ROB-1079 temp stash`와 다른 worktree를 변경하지 않았다.

## P0-2 — 직렬 pytest run-owned PostgreSQL DB

- `tests/_run_owned_database.py:77`에서 직렬 실행은
  `test_db_pytest_<12hex>_main`, xdist는 같은 run UID와 worker ID를 사용한
  `test_db_pytest_<12hex>_gwN`을 선택한다. 환경 선택 단계에는 PostgreSQL
  연결이 없다.
- `tests/_run_owned_database.py:138`에서 DB가 이미 존재하면 재사용하지 않고
  실패한다. 생성 직후 `public._pytest_database_owner`에 DB 이름과 32자리
  무작위 owner token을 기록한다.
- `tests/_run_owned_database.py:203`에서 drop 전 이름 정규식, 현재 run UID,
  ownership marker/token을 모두 검증한다. 하나라도 맞지 않으면 drop하지
  않는다. base URL은 PostgreSQL의 정확한 `test_db`만 허용하므로 production
  또는 사용자가 지정한 일반 DB는 fail-closed다.
- `tests/conftest.py:170`, `tests/conftest.py:684`에서 integration/DB fixture가
  실제 선택된 경우에만 생성·schema bootstrap·정리를 수행한다. 생성 이후의
  import/bootstrap/test teardown 예외도 전체 `try/finally` 안에서 engine
  dispose와 exact-name drop을 시도한다.
- 공유 `test_db`는 `AUTO_TRADER_PYTEST_USE_SHARED_DB=1`의 정확한 opt-in에서만
  사용하며 절대 drop하지 않는다. 다른 값(`true`, `yes`, `2` 등)은 거부한다.
- 계약 단위 테스트는 `tests/infra/test_run_owned_database.py:1`, 운영·강제중단
  잔여 DB 확인 절차는 `tests/TEST_DATABASES.md:1`에 기록했다. wildcard
  삭제는 문서에서도 금지했다.

## P1-1 — 직렬화와 광범위 cleanup 축소

- `tests/conftest.py:393`의 Alpaca file lock은 run-owned DB에서 no-op이며
  explicit shared-DB opt-in에서만 유지된다.
- `tests/test_rob878_transition_core.py:29`, `tests/test_rob878_transition_core.py:139`
  에서 무관한 investment-report cleanup fixture 의존성을 제거했다.
- `tests/_investment_reports_helpers.py:44`의 일반 investment-report session은
  app engine의 한 connection과 outer transaction,
  `join_transaction_mode="create_savepoint"`를 사용한다. 테스트 내부 commit은
  허용하면서 테스트 종료 시 outer rollback으로 격리하며, 테스트별 engine
  생성/폐기와 TRUNCATE를 제거했다.
- production handler가 독립 session을 여는 예외적인 MCP 테스트만
  `tests/_investment_reports_helpers.py:89`의 명시적 fixture를 사용한다. 이
  경로도 7개 연관 테이블의 좁은 DELETE만 수행한다.
- global cleanup fixture도 `tests/conftest.py:809`에서 TRUNCATE 대신 연관
  테이블 DELETE로 바꾸고, shared opt-in일 때만 advisory lock을 사용한다.
- `tests/conftest.py:620`에서 실행별 생성 DB 수, 실제 schema 적용 횟수,
  schema/bootstrap 시간을 terminal summary로 계측한다. 예:
  `databases=4 applied=4 schema_seconds=13.06 database_seconds=1.77`.

### Template DB 검증 결과

적용하지 않고 후속으로 남겼다.

- 기본 pool을 사용한 clone 실험은 source DB active connection 때문에
  `ObjectInUseError`로 실패했다.
- 통제된 NullPool 실험에서는 schema bootstrap 3.276초, active connection
  0개, clone 0.544초, clone 결과 139 tables/727 constraints를 확인했다.
- 성능 가능성은 있으나 controller-owned template lifecycle, xdist worker
  시작/종료 순서, 강제중단 잔여 template 소유권을 아직 안전하게 증명하지
  못했다. production/user DB 보호보다 DDL 감소를 우선하지 않았다.
- 실험용 exact-name DB는 모두 정리했으며 broad wildcard drop은 사용하지
  않았다.

## P1-2 — autouse/plugin fixture 누출

- `tests/_mcp_screen_stocks_support.py`의 두 번째 crypto autouse fixture와
  중첩 `pytest_plugins` 등록을 제거했다.
- 관련 MCP 모듈만 fixture 함수를 명시적으로 import하고
  `pytest.mark.usefixtures("_mock_crypto_external_sources")`를 사용한다
  (`tests/test_mcp_screen_stocks_crypto.py:9`,
  `tests/test_mcp_screen_stocks_kr.py:31`,
  `tests/test_mcp_recommend_flow.py:17` 등).
- `tests/conftest.py:664`에서 NXT/circuit-breaker/calendar/auth/Alpaca 기본
  fixture를 소유 테스트 영역에만 dispatcher로 적용한다. 수집 순서에 따른
  module-level plugin 누출은 없다.
- 외부 HTTP 안전 경계인 TvScreener fail-fast guard는 global autouse로
  유지했다. live 또는 명시적 opt-out 외에는 실제 scanner HTTP를 즉시
  차단한다.
- `pytest --fixtures-per-test`로 무관한 Yahoo 테스트를 검사한 결과
  `event_loop_policy`, `monkeypatch`만 표시되었고 crypto/NXT/calendar/
  circuit/auth/serialization fixture는 적용되지 않았다.

## P2 — 경고와 테스트 품질

- `tests/test_research_run_live_refresh_service.py:22`에서 SQLAlchemy result의
  동기 메서드 `scalar_one_or_none()`까지 AsyncMock이 된 것이 coroutine
  미-await의 실제 원인이었음을 확인하고 MagicMock result fake로 수정했다.
- `tests/test_news_ingestor_bulk.py:312`의 focused test는 테스트 범위 밖
  preview/briefing async 경계를 명시적으로 fake했다.
- 변경 후 `RuntimeWarning`과 `PytestUnraisableExceptionWarning`을 error로
  올린 관련 6개 테스트가 통과했다.
- module-level fixture plugin 등록을 제거해 `_mcp_tooling_support`와
  `_mcp_screen_stocks_support`의 `PytestAssertRewriteWarning`이 사라졌다.
- `tests/test_services_kis_market_data.py`의 두 pure unit 테스트를
  `tests/test_services_kis_market_data_unit.py:1`로 분리하고
  `Makefile:23`의 services split 타깃에 포함했다.
- `tests/test_screener_snapshot_tool.py:33` 이후 fake를 production 계약에
  맞췄다: holdings error는 `list[dict[str, Any]]`,
  enrichment는 `fetch_kr_sector`/`fetch_us_sector` 인자를 받고,
  summary에 `sectorResolved`를 포함한다.

## 전/후 검증 및 시간

기준 전 측정은 `653a83911`에서 수행했다. 후 측정 중 아래 표의 focused,
services, test-fast, DB subset, collect-only 수치는 작업 중 추가된 두
`origin/main` 커밋을 충돌 없이 rebase한 최종 branch에서 다시 측정했다.
ROB878 10-process 반복 수치만 rebase 직전 측정이며 관련 파일 충돌은 없었다.

| 항목 | 전 | 후 | 결과 |
|---|---:|---:|---|
| screener snapshot | 4.38초 (28 passed) | 3.79초 (28 passed) | 통과 |
| KIS pagination | 5.21초 (8 passed) | 3.55초 (8 passed) | 통과 |
| ROB878 lock-order, pytest 프로세스 10회 | 50.48초 | 63.12초 | 10/10 통과, 실행별 DB bootstrap 비용으로 회귀 |
| ROB878 transition 전체 | 38.08초 (77 passed) | 13.13초 (77 passed) | 통과 |
| `make test-services-split` | 10.15초 (144 passed) | 9.32초 (144 passed) | 통과 |
| `make test-fast`, 다른 pytest 없음 | 93.22초 (4,700 passed) | 58.76초 (4,709 passed) | 통과, 22 warnings |
| 직렬 integration subset 1차 | 14.55초 | 6.46초 | 26 passed, 1 deselected |
| 직렬 integration subset 2차 | 15.63초 | 6.28초 | 26 passed, 1 deselected |
| 같은 subset `-n 4 --dist=loadfile` | 14.66초 | 9.28초 | 26 passed |
| collect-only non-live | 20.49초, 17,178/17,185 | 19.66초, 17,199/17,206 | 통과 |
| collect-only unit | 21.88초, 4,700/17,185 | 17.63초, 4,709/17,206 | 통과 |
| collect-only integration not live | 21.05초, 3,047/17,185 | 17.65초, 3,047/17,206 | 통과 |
| collect-only integration live | 21.80초, 7/17,185 | 16.93초, 7/17,206 | 통과 |
| collect-only slow not live | 20.93초, 2/17,185 | 17.27초, 2/17,206 | 통과 |

추가 검증:

- impossible PostgreSQL port를 지정한 pure-unit 선택: 9 passed in 0.16초.
  PostgreSQL 연결 없이 완료됐고 run-owned DB도 생성되지 않았다.
- serial/xdist/의도적 test failure finalizer probe 뒤
  `test_db_*` 조회 결과: 0개.
- investment-report 파일군: 309 passed in 19.45초.
- MCP screen 관련 6개 파일: 204 passed in 53.73초. plugin 구조 최종 변경 후
  대표 4개 테스트도 3.79초에 통과했다.
- schema barrier 계약: 22 passed, 1 deselected.
- shared-DB exact opt-in 대표 테스트: 통과, `test_db` drop 없음.
- 변경 Python 범위 `ruff check`, `ruff format --check`, `ty check
  --error-on-warning`: 통과.
- Makefile parse, `git diff --check`: 통과.
- rebase 후 허용 경로 외 변경 없음 확인.

## 미실행 검증

- 전체 non-live 17k suite (`make test`): **미실행**.
- 전체 integration 3,047개 (`make test-integration`): **미실행**.
- live API 테스트 실행: **미실행** (collect-only만 수행).
- 실제 `SIGKILL`/호스트 crash를 발생시키는 강제중단 복구: **미실행**.
  대신 의도적 pytest failure에서 finalizer cleanup과 marker 검증을 확인했다.
- template DB를 CI 경로에 적용한 검증: **미실행**/미적용.

## 운영자 조치 필요

1. PR CI에서 전체 shard/worker 조합의 독립 검증 결과를 확인한다.
2. 전체 `make test`와 `make test-integration`이 필요하면 별도 장시간 검증으로
   실행한다.
3. pytest 프로세스를 10번 새로 띄우는 ROB878 반복 시나리오는 안전성을 위해
   매번 schema bootstrap하여 12.64초 느려졌다. 실제 CI는 한 pytest 세션
   안에서 파일 전체를 실행하므로 24.95초 빨라졌지만, 프로세스 반복 비용을
   더 줄여야 한다면 안전한 controller-owned template DB 후속을 연다.
4. 강제중단 잔여 DB가 발견되면 `tests/TEST_DATABASES.md`의 exact-name 및
   ownership marker 확인 절차로만 정리한다. wildcard 삭제는 하지 않는다.
