### PR TITLE
fix(ci): propagate TaskIQ smoke failures after readiness

### DIFF
--- a/.github/workflows/taskiq-smoke-test.sh
+++ b/.github/workflows/taskiq-smoke-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+helper="$script_dir/taskiq-smoke.sh"
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/taskiq-smoke-test.XXXXXX")
+
+cleanup() {
+  rm -rf "$test_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_case() {
+  local name=$1
+  local expected_status=$2
+  shift 2
+
+  local output_path="$test_dir/$name.output"
+  local log_path="$test_dir/$name.log"
+  local actual_status=0
+
+  TASKIQ_READINESS_POLLS=3 \
+    TASKIQ_READINESS_INTERVAL=0.05 \
+    TASKIQ_TERM_GRACE_POLLS=3 \
+    TASKIQ_TERM_GRACE_INTERVAL=0.05 \
+    bash "$helper" "$name" READY "$log_path" -- "$@" \
+    > "$output_path" 2>&1 || actual_status=$?
+
+  if [[ "$actual_status" -ne "$expected_status" ]]; then
+    cat "$output_path" >&2
+    fail "$name: expected exit $expected_status, got $actual_status"
+  fi
+
+  echo "PASS: $name (exit $actual_status)"
+}
+
+assert_processes_gone() {
+  local pid_path=$1
+  local pid
+  local poll
+
+  for ((poll = 1; poll <= 20; poll++)); do
+    local found=false
+    while IFS= read -r pid; do
+      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        found=true
+      fi
+    done < "$pid_path"
+    if [[ "$found" == false ]]; then
+      return 0
+    fi
+    sleep 0.05
+  done
+
+  fail "processes remain after helper cleanup: $(tr '\n' ' ' < "$pid_path")"
+}
+
+run_case early-exit 1 bash -c 'exit 23'
+run_case readiness-timeout 1 bash -c 'trap "exit 0" TERM; while :; do sleep 1; done'
+run_case normal-shutdown 0 bash -c \
+  'trap "exit 0" TERM; printf "READY\n"; while :; do sleep 1; done'
+
+term_ignore_pids="$test_dir/term-ignore.pids"
+# shellcheck disable=SC2016  # The nested bash processes expand these expressions.
+run_case term-ignore 0 bash -c \
+  'trap "" TERM; printf "%s\n" "$$" > "$1"; bash -c '"'"'trap "" TERM; printf "%s\n" "$$" >> "$1"; while :; do sleep 1; done'"'"' _ "$1" & while [[ $(wc -l < "$1") -lt 2 ]]; do sleep 0.01; done; printf "READY\n"; wait' \
+  _ "$term_ignore_pids"
+assert_processes_gone "$term_ignore_pids"
+
+run_case ready-then-exit-42 42 bash -c 'printf "READY\n"; exit 42'
+
+trap_pids="$test_dir/trap.pids"
+trap_output="$test_dir/trap.output"
+trap_log="$test_dir/trap.log"
+# shellcheck disable=SC2016  # The nested bash processes expand these expressions.
+TASKIQ_READINESS_POLLS=100 \
+  TASKIQ_READINESS_INTERVAL=0.05 \
+  TASKIQ_TERM_GRACE_POLLS=3 \
+  TASKIQ_TERM_GRACE_INTERVAL=0.05 \
+  bash "$helper" trap-cleanup NEVER "$trap_log" -- bash -c \
+  'trap "" TERM; printf "%s\n" "$$" > "$1"; bash -c '"'"'trap "" TERM; printf "%s\n" "$$" >> "$1"; while :; do sleep 1; done'"'"' _ "$1" & wait' \
+  _ "$trap_pids" > "$trap_output" 2>&1 &
+helper_pid=$!
+
+for ((poll = 1; poll <= 20; poll++)); do
+  if [[ -s "$trap_pids" ]] && [[ $(wc -l < "$trap_pids") -ge 2 ]]; then
+    break
+  fi
+  sleep 0.05
+done
+[[ -s "$trap_pids" ]] || fail "trap-cleanup: child PID file was not created"
+
+kill -TERM "$helper_pid"
+trap_status=0
+wait "$helper_pid" || trap_status=$?
+[[ "$trap_status" -eq 143 ]] ||
+  fail "trap-cleanup: expected helper exit 143, got $trap_status"
+assert_processes_gone "$trap_pids"
+echo "PASS: trap-cleanup (exit $trap_status; process group reaped)"

--- a/.github/workflows/taskiq-smoke-test.sh
+++ b/.github/workflows/taskiq-smoke-test.sh
@@ -42,11 +42,18 @@ run_case() {
 
 assert_processes_gone() {
   local pid_path=$1
+  local process_group_id
   local pid
   local poll
 
+  IFS= read -r process_group_id < "$pid_path"
+  [[ -n "$process_group_id" ]] || fail "missing process-group leader PID: $pid_path"
+
   for ((poll = 1; poll <= 20; poll++)); do
     local found=false
+    if kill -0 -- "-$process_group_id" 2>/dev/null; then
+      found=true
+    fi
     while IFS= read -r pid; do
       if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
         found=true
@@ -58,7 +65,7 @@ assert_processes_gone() {
     sleep 0.05
   done
 
-  fail "processes remain after helper cleanup: $(tr '\n' ' ' < "$pid_path")"
+  fail "process group $process_group_id or recorded processes remain after helper cleanup: $(tr '\n' ' ' < "$pid_path")"
 }
 
 run_case early-exit 1 bash -c 'exit 23'
@@ -72,6 +79,56 @@ run_case term-ignore 0 bash -c \
   'trap "" TERM; printf "%s\n" "$$" > "$1"; bash -c '"'"'trap "" TERM; printf "%s\n" "$$" >> "$1"; while :; do sleep 1; done'"'"' _ "$1" & while [[ $(wc -l < "$1") -lt 2 ]]; do sleep 0.01; done; printf "READY\n"; wait' \
   _ "$term_ignore_pids"
 assert_processes_gone "$term_ignore_pids"
+
+post_kill_pids="$test_dir/post-kill-remains.pids"
+post_kill_output="$test_dir/post-kill-remains.output"
+post_kill_log="$test_dir/post-kill-remains.log"
+post_kill_bash_env="$test_dir/post-kill-remains.bash-env"
+post_kill_status=0
+# The helper still sends a real KILL. This helper-only Bash environment forces
+# subsequent group probes to report the group as present, deterministically
+# exercising the post-KILL fail-closed path without a production test hook.
+cat > "$post_kill_bash_env" <<'BASH_ENV_EOF'
+if [[ "${TASKIQ_TEST_INSTALL_KILL_WRAPPER:-0}" == 1 ]]; then
+  unset TASKIQ_TEST_INSTALL_KILL_WRAPPER
+  kill() {
+    local status=0
+    if [[ "${1:-}" == "-KILL" ]]; then
+      builtin kill "$@" || status=$?
+      TASKIQ_TEST_KILL_SEEN=1
+      return "$status"
+    fi
+    if [[ "${1:-}" == "-0" && "${TASKIQ_TEST_KILL_SEEN:-0}" == 1 ]]; then
+      return 0
+    fi
+    builtin kill "$@"
+  }
+fi
+BASH_ENV_EOF
+# shellcheck disable=SC2016  # The nested bash processes expand these expressions.
+BASH_ENV="$post_kill_bash_env" \
+  TASKIQ_TEST_INSTALL_KILL_WRAPPER=1 \
+  TASKIQ_READINESS_POLLS=20 \
+  TASKIQ_READINESS_INTERVAL=0.05 \
+  TASKIQ_TERM_GRACE_POLLS=0 \
+  TASKIQ_TERM_GRACE_INTERVAL=0.05 \
+  bash "$helper" post-kill-remains READY "$post_kill_log" -- bash -c \
+  'if declare -F kill >/dev/null; then printf "HOOK_LEAKED\n"; exit 88; fi; trap "" TERM; printf "%s\n" "$$" > "$1"; bash -c '\''trap "" TERM; printf "%s\n" "$$" >> "$1"; while :; do sleep 1; done'\'' _ "$1" & while [[ $(wc -l < "$1") -lt 2 ]]; do sleep 0.01; done; printf "READY\n"; wait' \
+  _ "$post_kill_pids" > "$post_kill_output" 2>&1 || post_kill_status=$?
+if grep -Fq "HOOK_LEAKED" "$post_kill_log"; then
+  cat "$post_kill_log" >&2
+  fail "post-kill-remains: helper probe leaked into managed workload"
+fi
+[[ "$post_kill_status" -eq 1 ]] || {
+  cat "$post_kill_output" >&2
+  fail "post-kill-remains: expected helper exit 1, got $post_kill_status"
+}
+grep -Fq "remains after KILL fallback" "$post_kill_output" || {
+  cat "$post_kill_output" >&2
+  fail "post-kill-remains: missing process-group diagnostic"
+}
+assert_processes_gone "$post_kill_pids"
+echo "PASS: post-kill-remains (exit $post_kill_status; diagnostic emitted)"
 
 run_case ready-then-exit-42 42 bash -c 'printf "READY\n"; exit 42'
 
@@ -94,7 +151,12 @@ for ((poll = 1; poll <= 20; poll++)); do
   fi
   sleep 0.05
 done
-[[ -s "$trap_pids" ]] || fail "trap-cleanup: child PID file was not created"
+trap_pid_count=0
+if [[ -f "$trap_pids" ]]; then
+  trap_pid_count=$(wc -l < "$trap_pids")
+fi
+((trap_pid_count >= 2)) ||
+  fail "trap-cleanup: expected leader and descendant PIDs, got $trap_pid_count"
 
 kill -TERM "$helper_pid"
 trap_status=0

--- a/.github/workflows/taskiq-smoke.sh
+++ b/.github/workflows/taskiq-smoke.sh
@@ -21,41 +21,129 @@ readiness_interval=${TASKIQ_READINESS_INTERVAL:-0.5}
 term_grace_polls=${TASKIQ_TERM_GRACE_POLLS:-20}
 term_grace_interval=${TASKIQ_TERM_GRACE_INTERVAL:-0.25}
 
+process_id=
+process_group_id=
+child_reaped=false
+child_status=0
+shutdown_requested=false
+term_sent=false
+kill_sent=false
+
+leader_is_running() {
+  jobs -pr | grep -Fxq "$process_id"
+}
+
+process_group_exists() {
+  [[ -n "$process_group_id" ]] &&
+    kill -0 -- "-$process_group_id" 2>/dev/null
+}
+
+reap_child() {
+  if [[ "$child_reaped" == false ]]; then
+    child_status=0
+    wait "$process_id" || child_status=$?
+    child_reaped=true
+  fi
+}
+
 terminate_and_reap() {
-  local process_id=$1
-  local status=0
+  local poll
 
-  if kill -0 "$process_id" 2>/dev/null; then
-    kill -TERM "$process_id" 2>/dev/null || true
-    for ((poll = 1; poll <= term_grace_polls; poll++)); do
-      if ! kill -0 "$process_id" 2>/dev/null; then
-        wait "$process_id" || status=$?
-        return 0
-      fi
-      sleep "$term_grace_interval"
-    done
-
-    echo "$label ignored TERM for ${term_grace_polls} grace polls; sending KILL."
-    kill -KILL "$process_id" 2>/dev/null || true
+  if [[ "$child_reaped" == false ]] && leader_is_running; then
+    shutdown_requested=true
   fi
 
-  wait "$process_id" || status=$?
+  if process_group_exists; then
+    if kill -TERM -- "-$process_group_id" 2>/dev/null; then
+      term_sent=true
+    fi
+  fi
+
+  for ((poll = 1; poll <= term_grace_polls; poll++)); do
+    if [[ "$child_reaped" == false ]] && ! leader_is_running; then
+      reap_child
+    fi
+    if ! process_group_exists; then
+      return 0
+    fi
+    sleep "$term_grace_interval"
+  done
+
+  if process_group_exists; then
+    echo "$label ignored TERM for ${term_grace_polls} grace polls; sending KILL."
+    if kill -KILL -- "-$process_group_id" 2>/dev/null; then
+      kill_sent=true
+    fi
+  fi
+
+  reap_child
+
+  for ((poll = 1; poll <= term_grace_polls; poll++)); do
+    if ! process_group_exists; then
+      break
+    fi
+    sleep "$term_grace_interval"
+  done
+
   return 0
 }
 
-"$@" > "$log_path" 2>&1 &
-process_id=$!
+# shellcheck disable=SC2329  # Invoked by the EXIT trap.
+cleanup_on_exit() {
+  local status=$?
 
-for ((poll = 1; poll <= readiness_polls; poll++)); do
-  if grep -Fq "$ready_marker" "$log_path"; then
-    terminate_and_reap "$process_id"
+  trap - EXIT INT TERM
+  if [[ -n "$process_id" ]]; then
+    terminate_and_reap
+  fi
+  exit "$status"
+}
+
+# shellcheck disable=SC2329  # Invoked by the INT/TERM traps.
+exit_on_signal() {
+  exit "$1"
+}
+
+trap cleanup_on_exit EXIT
+trap 'exit_on_signal 130' INT
+trap 'exit_on_signal 143' TERM
+
+if command -v setsid >/dev/null 2>&1; then
+  setsid "$@" > "$log_path" 2>&1 &
+else
+  python3 -c \
+    'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
+    "$@" > "$log_path" 2>&1 &
+fi
+process_id=$!
+process_group_id=$process_id
+
+finish_after_readiness() {
+  terminate_and_reap
+  if ((child_status == 0)) ||
+    { [[ "$shutdown_requested" == true && "$term_sent" == true ]] &&
+      ((child_status == 143)); } ||
+    { [[ "$shutdown_requested" == true && "$kill_sent" == true ]] &&
+      ((child_status == 137)); }; then
     exit 0
   fi
 
-  if ! kill -0 "$process_id" 2>/dev/null; then
-    status=0
-    wait "$process_id" || status=$?
-    echo "$label exited before readiness (status $status)."
+  echo "$label exited after readiness (status $child_status)."
+  tail -n 200 "$log_path" || true
+  exit "$child_status"
+}
+
+for ((poll = 1; poll <= readiness_polls; poll++)); do
+  if grep -Fq "$ready_marker" "$log_path"; then
+    finish_after_readiness
+  fi
+
+  if ! leader_is_running; then
+    terminate_and_reap
+    if grep -Fq "$ready_marker" "$log_path"; then
+      finish_after_readiness
+    fi
+    echo "$label exited before readiness (status $child_status)."
     tail -n 200 "$log_path" || true
     exit 1
   fi
@@ -63,7 +151,7 @@ for ((poll = 1; poll <= readiness_polls; poll++)); do
   sleep "$readiness_interval"
 done
 
-terminate_and_reap "$process_id"
+terminate_and_reap
 echo "$label did not become ready within ${readiness_polls} readiness polls."
 tail -n 200 "$log_path" || true
 exit 1

--- a/.github/workflows/taskiq-smoke.sh
+++ b/.github/workflows/taskiq-smoke.sh
@@ -28,6 +28,7 @@ child_status=0
 shutdown_requested=false
 term_sent=false
 kill_sent=false
+cleanup_failure_status=0
 
 leader_is_running() {
   jobs -pr | grep -Fxq "$process_id"
@@ -64,7 +65,7 @@ terminate_and_reap() {
       reap_child
     fi
     if ! process_group_exists; then
-      return 0
+      break
     fi
     sleep "$term_grace_interval"
   done
@@ -76,8 +77,6 @@ terminate_and_reap() {
     fi
   fi
 
-  reap_child
-
   for ((poll = 1; poll <= term_grace_polls; poll++)); do
     if ! process_group_exists; then
       break
@@ -85,16 +84,33 @@ terminate_and_reap() {
     sleep "$term_grace_interval"
   done
 
+  if process_group_exists; then
+    echo "$label process group $process_group_id remains after KILL fallback " \
+      "(TERM sent: $term_sent; KILL sent: $kill_sent; child status pending reap)." >&2
+    cleanup_failure_status=1
+  fi
+
+  # Always wait for the direct child. When KILL does not clear the group within
+  # the bounded polls, emit the failure first so a blocked wait is not silent.
+  reap_child
+
+  if ((cleanup_failure_status != 0)); then
+    return "$cleanup_failure_status"
+  fi
   return 0
 }
 
 # shellcheck disable=SC2329  # Invoked by the EXIT trap.
 cleanup_on_exit() {
   local status=$?
+  local cleanup_status=0
 
   trap - EXIT INT TERM
   if [[ -n "$process_id" ]]; then
-    terminate_and_reap
+    terminate_and_reap || cleanup_status=$?
+  fi
+  if ((status == 0 && cleanup_status != 0)); then
+    status=$cleanup_status
   fi
   exit "$status"
 }
@@ -119,7 +135,14 @@ process_id=$!
 process_group_id=$process_id
 
 finish_after_readiness() {
-  terminate_and_reap
+  local cleanup_status=0
+
+  terminate_and_reap || cleanup_status=$?
+  if ((cleanup_status != 0)); then
+    tail -n 200 "$log_path" || true
+    exit "$cleanup_status"
+  fi
+
   if ((child_status == 0)) ||
     { [[ "$shutdown_requested" == true && "$term_sent" == true ]] &&
       ((child_status == 143)); } ||
@@ -139,7 +162,9 @@ for ((poll = 1; poll <= readiness_polls; poll++)); do
   fi
 
   if ! leader_is_running; then
-    terminate_and_reap
+    if ! terminate_and_reap; then
+      echo "$label cleanup failed before readiness." >&2
+    fi
     if grep -Fq "$ready_marker" "$log_path"; then
       finish_after_readiness
     fi
@@ -151,7 +176,9 @@ for ((poll = 1; poll <= readiness_polls; poll++)); do
   sleep "$readiness_interval"
 done
 
-terminate_and_reap
+if ! terminate_and_reap; then
+  echo "$label cleanup failed after readiness timeout." >&2
+fi
 echo "$label did not become ready within ${readiness_polls} readiness polls."
 tail -n 200 "$log_path" || true
 exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,6 +207,9 @@ jobs:
     - name: Install dependencies
       run: uv sync --group test
 
+    - name: Run TaskIQ smoke helper regression tests
+      run: bash .github/workflows/taskiq-smoke-test.sh
+
     - name: Set environment variables from env.example
       run: |
         chmod +x scripts/setup-test-env.sh


### PR DESCRIPTION
## 요약

- READY marker 뒤 child가 자발적으로 비정상 종료하면 실제 `wait` status를 helper exit로 전파합니다.
- worker/scheduler를 별도 process group에서 실행하고 EXIT/INT/TERM trap에서도 TERM → grace polling → KILL fallback → reap 계약을 적용합니다.
- `.github/workflows/taskiq-smoke-test.sh`를 추가해 5개 상태 계약과 process-group trap cleanup을 CI에서 고정합니다.

## 근본 원인

기존 `.github/workflows/taskiq-smoke.sh:24-43`의 `terminate_and_reap`은 `wait` status를 지역 변수에 저장한 뒤 무조건 0을 반환했고, readiness 분기(`:50-52`)도 marker 확인 후 무조건 `exit 0` 했습니다. 따라서 READY 뒤 `exit 42`가 관측되어도 실패 정보가 소실됐습니다.

## 종료 코드 계약

- readiness 전 조기 종료: helper 1
- readiness timeout: helper 1
- 정상 TERM 종료: helper 0
- TERM 무시 → KILL fallback: helper 0, process group 잔존 없음
- READY 후 `exit 42`: helper 42
- helper TERM trap: helper 143, process group 잔존 없음

helper가 보낸 TERM(143) 또는 KILL(137)만 성공 정리로 정규화하며, 그 외 READY 이후 child status는 그대로 반환합니다.

## 검증

- `bash .github/workflows/taskiq-smoke-test.sh` 통과; 5개 시나리오 + trap cleanup
- 동일 회귀 스크립트 10회 반복 통과
- `bash -n` helper/test 및 모든 workflow `run:` 블록 통과
- workflow YAML 7개 Ruby/Psych parse 통과
- ShellCheck helper/test 통과
- `git diff --check` 통과
- actionlint: 로컬 미설치로 미실행

## 경계

- 변경은 `.github/workflows/` 아래 3개 파일뿐입니다.
- `tests/**`, `tests/conftest.py`, stash, 주문/배포/production DB는 건드리지 않았습니다.

Follow-up to #1709.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TaskIQ smoke-helper shutdown and cleanup behavior, including process-group termination and reliable child-process reaping.
  * Improved handling of readiness timeouts, early exits, signal termination, and non-zero worker failures.

* **Tests**
  * Added regression coverage for readiness, shutdown, signal handling, process cleanup, and exit-status scenarios.
  * Integrated the smoke-helper regression tests into the automated test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->