### PR TITLE
feat(#1700): typed strategy_learning_events recorder CLI (N6 minimal path)

### DIFF
--- a/scripts/record_strategy_learning_event.py
+++ b/scripts/record_strategy_learning_event.py
@@ -1,0 +1,155 @@
+"""ROB-1115 typed strategy-learning-event recorder (#1700 follow-up, N6).
+
+Minimal-path operator CLI around ``app.services.strategy_learning_event_service``.
+There is no service/router/scheduler wiring here — this only gives operators a
+typed, enum-validated way to append rows without hand-written SQL.
+
+Dry-run is the default: the CLI always builds and validates a
+``StrategyLearningEventRequest`` (enum + shape checks included) and prints the
+canonical payload plus derived ``request_hash`` / ``memory_event_id``. Only
+``--commit`` opens a DB session and calls ``record_learning_event``.
+
+Payload input is JSON, either inline (``--payload-json``) or from a file
+(``--payload-file``), so the two-part JSONB fields (``failure_fingerprint``,
+``learning_payload``) are expressed the same way the API/tests express them.
+Field-by-field flags are intentionally omitted — cramming ``learning_payload``'s
+9-field contract into argparse flags would just duplicate the Pydantic schema
+with a worse error surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from typing import Any
+
+from pydantic import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Append one typed research.strategy_learning_events row (ROB-1115). "
+            "Dry-run by default; pass --commit to actually write."
+        )
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--payload-json",
+        help="Inline JSON object matching StrategyLearningEventRequest.",
+    )
+    source.add_argument(
+        "--payload-file",
+        help="Path to a JSON file matching StrategyLearningEventRequest.",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually write the row. Without this flag the CLI only validates "
+        "and prints the payload (default behavior).",
+    )
+    return parser
+
+
+def _load_payload(args: argparse.Namespace) -> dict[str, Any]:
+    if args.payload_json is not None:
+        raw = args.payload_json
+    else:
+        with open(args.payload_file, encoding="utf-8") as fh:
+            raw = fh.read()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid JSON payload: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit("payload must be a JSON object")
+    return data
+
+
+def _build_request(payload: dict[str, Any]):
+    from app.schemas.strategy_learning_event import StrategyLearningEventRequest
+
+    try:
+        return StrategyLearningEventRequest.model_validate(payload)
+    except ValidationError as exc:
+        # Enum / shape rejection surfaces here — this is the "record refusal"
+        # path: invalid failure_class, verdict, stage, or malformed
+        # reason_codes/evidence_refs/failure_fingerprint/learning_payload all
+        # raise before any DB call is attempted.
+        raise SystemExit(f"payload rejected by typed contract:\n{exc}") from exc
+
+
+def _print_preview(request: Any) -> None:
+    from app.schemas.strategy_learning_event import canonical_event_request_payload
+    from app.services.strategy_learning_event_service import (
+        compute_learning_event_request_hash,
+        derive_memory_event_id,
+    )
+
+    request_hash = compute_learning_event_request_hash(request)
+    memory_event_id = derive_memory_event_id(
+        idempotency_key=request.idempotency_key,
+        request_hash=request_hash,
+    )
+    preview = {
+        "mode": "dry_run",
+        "request_hash": request_hash,
+        "memory_event_id": memory_event_id,
+        "request": canonical_event_request_payload(request),
+        "idempotency_key": request.idempotency_key,
+    }
+    print(json.dumps(preview, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+async def _commit(request: Any) -> dict[str, Any]:
+    from app.core.db import AsyncSessionLocal
+    from app.services.strategy_learning_event_service import (
+        LearningEventExperimentNotFound,
+        LearningEventIdempotencyConflict,
+        StoredLearningEventInvalid,
+        record_learning_event,
+        to_learning_event_record,
+    )
+
+    async with AsyncSessionLocal() as db:
+        try:
+            row = await record_learning_event(db, request)
+            await db.commit()
+        except (
+            LearningEventExperimentNotFound,
+            LearningEventIdempotencyConflict,
+            StoredLearningEventInvalid,
+        ) as exc:
+            await db.rollback()
+            raise SystemExit(f"record refused: {exc}") from exc
+        record = to_learning_event_record(row)
+    return {
+        "mode": "committed",
+        "memory_event_id": record.memory_event_id,
+        "request_hash": record.request_hash,
+        "created_at": record.created_at.isoformat(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    args = _build_parser().parse_args(argv)
+    payload = _load_payload(args)
+    request = _build_request(payload)
+
+    if not args.commit:
+        _print_preview(request)
+        return 0
+
+    result = asyncio.run(_commit(request))
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_record_strategy_learning_event.py
+++ b/tests/scripts/test_record_strategy_learning_event.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.record_strategy_learning_event import main
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_payload(**overrides) -> dict:
+    payload = {
+        "experiment_id": None,
+        "stage": "paper",
+        "verdict": "iterate",
+        "failure_class": "operational",
+        "reason_codes": ["non_canonical_contract_drift"],
+        "evidence_refs": ["artifact:" + "a1" * 32],
+        "failure_fingerprint": {
+            "market": "us_equity",
+            "horizon": "directional-lab-us",
+        },
+        "learning_payload": {
+            "tested_claim": "test claim",
+            "observed": "test observation",
+            "falsified_claims": [],
+            "preserved_claims": [],
+            "next_question": "test question",
+            "allowed_change_axis": "operator_contract_enforcement",
+            "prohibited_changes": [],
+            "stop_rule": "test stop rule",
+            "schema_version": "1",
+        },
+        "idempotency_key": "test-key-001",
+        "actor_id": "test-operator",
+        "actor_role": "operator",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_dry_run_prints_canonical_preview_without_commit(capsys) -> None:
+    payload = _valid_payload()
+    rc = main(["--payload-json", json.dumps(payload)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["mode"] == "dry_run"
+    assert len(out["request_hash"]) == 64
+    assert len(out["memory_event_id"]) == 64
+    assert out["request"]["failure_class"] == "operational"
+
+
+def test_dry_run_is_default_and_deterministic(capsys) -> None:
+    payload = _valid_payload()
+    main(["--payload-json", json.dumps(payload)])
+    first = json.loads(capsys.readouterr().out)
+    main(["--payload-json", json.dumps(payload)])
+    second = json.loads(capsys.readouterr().out)
+    assert first["memory_event_id"] == second["memory_event_id"]
+    assert first["request_hash"] == second["request_hash"]
+
+
+def test_invalid_failure_class_is_rejected() -> None:
+    payload = _valid_payload(failure_class="NON_CANONICAL_CONTRACT_DRIFT")
+    with pytest.raises(SystemExit, match="payload rejected by typed contract"):
+        main(["--payload-json", json.dumps(payload)])
+
+
+def test_invalid_stage_is_rejected() -> None:
+    payload = _valid_payload(stage="not_a_real_stage")
+    with pytest.raises(SystemExit, match="payload rejected by typed contract"):
+        main(["--payload-json", json.dumps(payload)])
+
+
+def test_invalid_verdict_is_rejected() -> None:
+    payload = _valid_payload(verdict="not_a_real_verdict")
+    with pytest.raises(SystemExit, match="payload rejected by typed contract"):
+        main(["--payload-json", json.dumps(payload)])
+
+
+def test_empty_reason_codes_rejected() -> None:
+    payload = _valid_payload(reason_codes=[])
+    with pytest.raises(SystemExit, match="payload rejected by typed contract"):
+        main(["--payload-json", json.dumps(payload)])
+
+
+def test_inline_evidence_ref_rejected() -> None:
+    payload = _valid_payload(evidence_refs=["not-a-sha256-and-has-inline-data"])
+    with pytest.raises(SystemExit, match="payload rejected by typed contract"):
+        main(["--payload-json", json.dumps(payload)])
+
+
+def test_malformed_json_is_rejected() -> None:
+    with pytest.raises(SystemExit, match="invalid JSON payload"):
+        main(["--payload-json", "{not valid json"])
+
+
+def test_non_object_json_is_rejected() -> None:
+    with pytest.raises(SystemExit, match="payload must be a JSON object"):
+        main(["--payload-json", "[1, 2, 3]"])
+
+
+def test_payload_file_input(tmp_path, capsys) -> None:
+    payload = _valid_payload()
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(json.dumps(payload), encoding="utf-8")
+    rc = main(["--payload-file", str(payload_path)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["mode"] == "dry_run"
+
+
+def test_payload_json_and_payload_file_are_mutually_exclusive() -> None:
+    with pytest.raises(SystemExit):
+        main(["--payload-json", "{}", "--payload-file", "x.json"])


### PR DESCRIPTION
## Summary

Adds a minimal-path operator CLI (`scripts/record_strategy_learning_event.py`) that wraps the existing, already-merged `app.services.strategy_learning_event_service.record_learning_event` (ROB-1115, merged via #1700). No service/router/scheduler wiring — CLI only, per stated N6 scope.

- Dry-run by default. `--commit` is required to actually write a row.
- Payload is validated through `StrategyLearningEventRequest` (Pydantic) before any DB call — invalid `failure_class`/`stage`/`verdict` enum values, empty `reason_codes`, or non-hash `evidence_refs` are all rejected with no silent pass-through.
- Accepts payload via `--payload-json` (inline) or `--payload-file` (JSON file); no per-field argparse flags, since the 9-field `learning_payload` contract is already fully specified by the Pydantic schema.

## Enum source (cited, not re-derived)

`app/models/strategy_learning_event.py:34-53` and `app/schemas/strategy_learning_event.py:14-38` define:
- `stage`: discovery/offline/sealed_oos/shadow/paper/live/ops
- `verdict`: promote/iterate/retire/inconclusive/retry_same_identity
- `failure_class`: data_quality/insufficient_evidence/no_signal/gross_edge/cost_turnover/robustness/risk/execution_gap/operational

`NON_CANONICAL_CONTRACT_DRIFT` is confirmed **not** a valid enum value anywhere in this model — the correct mapping is `failure_class=operational` + `reason_codes=["non_canonical_contract_drift", ...]`.

## Deployment status of #1700 (checked, not assumed)

- `origin/main` (fetched fresh) contains the ROB-1115 model, schema, service, and migration (`653a83911`, merged via #1700).
- The known CHECK-constraint-naming BLOCK from independent review (`op.f()` wrapping) **was fixed before merge** — confirmed by grep on the merged migration file (10/10 constraints use `op.f(...)`).
- Whether this migration has been applied to the actual **production** database could not be verified from this workspace — no read-only production DB credentials were available/appropriate to use here. This is a known gap, not a "confirmed applied" or "confirmed missing" state. See `n6-recorder-2026-07-29.md` for detail.
- A local dev DB (`auto_trader_dev`) does have the table, but that DB has no `alembic_version` row at all, so its state is not informative about production migration history.

## Not done in this PR (explicit scope limits)

- No actual event rows recorded — only dry-run payload previews (see report).
- No service/router/scheduler wiring.
- No production DB access, no migration execution, no deploy/restart.

## Testing

- `tests/scripts/test_record_strategy_learning_event.py`: 11 new unit tests covering dry-run preview, determinism, enum/shape rejection paths, and file/inline payload input. All pass locally.
- `ruff check`, `ruff format --check`, `ty check` all pass on the new files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operator command-line tool for recording strategy-learning events from inline JSON or a payload file.
  * Added a safe dry-run mode that previews the canonical payload and derived identifiers without saving changes.
  * Added an explicit commit option to persist validated events and return a concise result.
  * Added clear validation and error handling for malformed or unsupported payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->