### PR TITLE
fix(ROB-1129/ROB-1130): correct paper preflight pairing check and fail closed on unverified snapshots

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -545,7 +545,7 @@ only; it deliberately does not infer position or final reconciliation without
 independent evidence.
 
 `alpaca_paper_execution_preflight_check` is a read-only runner gate for the
-later automated paper cycle. It reads recent ledger rows and accepts optional
+later automated paper cycle. It reads recent ledger rows and accepts
 caller-supplied read-only `open_orders`, `positions`, and `approval_packet`
 snapshots, then returns severity-classified anomalies plus `should_block`. Scoped
 callers may pass `lifecycle_correlation_id`, `client_order_id`, `candidate_uuid`,
@@ -558,7 +558,8 @@ flow test-mode: residual positions and stale preview/approval packets are
 returned as warnings instead of blockers so operators can test buy/sell/order
 adjust/close flows on a used paper account. It does not weaken open-order
 conflicts, duplicate `client_order_id`, ledger/order/fill anomalies, missing
-linked sells, unclosed sell snapshots, or symbol mismatches; those remain
+linked sells, unclosed sell snapshots, unverified broker snapshots, or symbol
+mismatches; those remain
 blocking. ROB-93
 checks include unexpected open orders, residual positions, duplicate
 `client_order_id`, filled buys without linked sells, filled sells without a zero
@@ -570,6 +571,37 @@ findings return the dry-run action hint
 surface an explicit cleanup-required state before any separately approved repair
 write. The preflight itself performs no broker mutation, no repair writes, and
 no direct DB backfill.
+
+The broker snapshot is fail-closed (ROB-1130). `open_orders` and `positions` must
+both be supplied together with `broker_snapshot_fetched_at`, the time the
+snapshot was read from the broker:
+
+```python
+positions = await alpaca_paper_list_positions()
+open_orders = await alpaca_paper_list_orders(status="open")
+report = await alpaca_paper_execution_preflight_check(
+    positions=positions["positions"],
+    open_orders=open_orders["orders"],
+    broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+)
+```
+
+A snapshot that is missing, empty without an attestation, older than
+`snapshot_max_age_minutes` (default 5), or carries an unparseable/future
+timestamp is reported as a `broker_snapshot_unverified` blocker. Previously an
+omitted snapshot silently became `positions=0` and passed the gate while the
+account held positions. `counts.positions` and `counts.open_orders` are now
+omitted rather than reported as `0` when the snapshot cannot be verified, and
+`broker_snapshot` carries the per-kind `provided` / `verified` / `reason` state.
+This blocker is never downgraded by `legacy_cycle_blockers_as_warnings`.
+
+Buy legs that hold an open position are no longer reported as missing sell legs
+(ROB-1129). A filled/reconciled buy with no linked sell row is classified against
+the verified position snapshot: still-held symbols produce the informational
+`open_position_without_sell_leg` finding, while symbols the broker no longer
+holds, buys already in `closed`/`final_reconciled`, and rows with no verified
+snapshot keep blocking under `previous_buy_filled_sell_missing` with a per-row
+`reason`.
 
 The broker inspection tools instantiate `AlpacaPaperBrokerService`, so they
 inherit the

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -16,6 +16,7 @@ from app.services.alpaca_paper_account_modes import (
     normalize_alpaca_paper_account_mode,
 )
 from app.services.alpaca_paper_anomaly_checks import (
+    DEFAULT_SNAPSHOT_MAX_AGE_MINUTES,
     build_paper_execution_preflight_report,
 )
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
@@ -149,6 +150,8 @@ async def alpaca_paper_execution_preflight_check(
     limit: int = 50,
     open_orders: list[dict[str, Any]] | None = None,
     positions: list[dict[str, Any]] | None = None,
+    broker_snapshot_fetched_at: str | None = None,
+    snapshot_max_age_minutes: int = DEFAULT_SNAPSHOT_MAX_AGE_MINUTES,
     approval_packet: dict[str, Any] | None = None,
     expected_signal_symbol: str | None = None,
     expected_execution_symbol: str | None = None,
@@ -168,6 +171,14 @@ async def alpaca_paper_execution_preflight_check(
     cancels, repairs, or writes data. The returned ``should_block`` field is
     intended for runner preflight gates.
 
+    Broker snapshots are fail-closed (ROB-1130). ``open_orders`` and
+    ``positions`` must both be supplied together with
+    ``broker_snapshot_fetched_at``, the time the snapshot was read from the
+    broker. A missing, empty-but-unattested, stale, or unparseable snapshot is
+    reported as a ``broker_snapshot_unverified`` blocker instead of passing as
+    ``positions=0``. Fetch them with ``alpaca_paper_list_positions`` and
+    ``alpaca_paper_list_orders(status="open")`` immediately before this call.
+
     When a correlation/candidate/client/briefing scope is provided directly or
     via approval_packet, stale and symbol-context checks evaluate only rows in
     that scope. Calls without scope preserve the global recent-ledger safety
@@ -177,7 +188,8 @@ async def alpaca_paper_execution_preflight_check(
     ``legacy_cycle_blockers_as_warnings`` is an explicit Alpaca Paper test-mode
     switch: residual-position and stale-preview cleanup findings are returned as
     warnings, while open-order conflicts, duplicate IDs, ledger/fill anomalies,
-    symbol mismatches, and other execution-safety findings remain blockers.
+    symbol mismatches, unverified broker snapshots, and other execution-safety
+    findings remain blockers.
     """
     selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
     if limit < 1:
@@ -185,6 +197,8 @@ async def alpaca_paper_execution_preflight_check(
     limit = min(limit, 200)
     if stale_after_minutes < 1:
         raise ValueError("stale_after_minutes must be >= 1")
+    if snapshot_max_age_minutes < 1:
+        raise ValueError("snapshot_max_age_minutes must be >= 1")
 
     scope = {
         "lifecycle_correlation_id": _clean_scope_value(lifecycle_correlation_id)
@@ -230,8 +244,11 @@ async def alpaca_paper_execution_preflight_check(
 
     report = build_paper_execution_preflight_report(
         ledger_rows=rows,
-        open_orders=open_orders or [],
-        positions=positions or [],
+        open_orders=open_orders,
+        positions=positions,
+        open_orders_fetched_at=broker_snapshot_fetched_at,
+        positions_fetched_at=broker_snapshot_fetched_at,
+        snapshot_max_age_minutes=snapshot_max_age_minutes,
         approval_packet=approval_packet,
         expected_signal_symbol=expected_signal_symbol,
         expected_execution_symbol=expected_execution_symbol,
@@ -382,6 +399,10 @@ def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
         description=(
             "Read-only Alpaca Paper execution anomaly preflight. Returns "
             "severity-classified findings and should_block for cycle runners. "
+            "Broker snapshots are fail-closed: pass open_orders, positions and "
+            "broker_snapshot_fetched_at from reads taken immediately before the "
+            "call, otherwise the gate blocks with broker_snapshot_unverified "
+            "rather than passing as positions=0. "
             "Supports direct or approval_packet-derived correlation/client/"
             "candidate/briefing/session scope to avoid unrelated ledger rows. "
             "No broker mutation and no repair writes."

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -9,7 +9,7 @@ snapshots, and the service returns an operator-readable preflight report.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
@@ -17,6 +17,13 @@ from typing import Any
 
 STALE_PREVIEW_CLEANUP_REQUIRED_STATE = "stale_preview_cleanup_required"
 STALE_PREVIEW_CLEANUP_ACTION = "mark_stale_preview_cleanup_required"
+
+# ROB-1130: a broker snapshot is only evidence if the caller states when it was
+# fetched. Without that, "queried and genuinely empty" and "never queried" arrive
+# as the same empty list and the gate cannot tell them apart.
+DEFAULT_SNAPSHOT_MAX_AGE_MINUTES = 5
+_SNAPSHOT_FUTURE_TOLERANCE = timedelta(seconds=60)
+_SNAPSHOT_KINDS = ("positions", "open_orders")
 
 
 class PaperExecutionAnomalySeverity(StrEnum):
@@ -55,6 +62,7 @@ class PaperExecutionPreflightReport:
     stale_after_minutes: int
     anomalies: tuple[PaperExecutionAnomaly, ...]
     counts: dict[str, int]
+    broker_snapshot: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -63,6 +71,7 @@ class PaperExecutionPreflightReport:
             "checked_at": self.checked_at.isoformat(),
             "stale_after_minutes": self.stale_after_minutes,
             "counts": self.counts,
+            "broker_snapshot": self.broker_snapshot,
             "anomalies": [a.to_dict() for a in self.anomalies],
         }
 
@@ -156,8 +165,8 @@ def _iter_nested_values(payload: Any) -> Iterable[tuple[str, Any]]:
 
 def _source_client_order_ids(row: Any) -> set[str]:
     ids: set[str] = set()
-    for field in ("preview_payload", "validation_summary", "raw_responses"):
-        for key, value in _iter_nested_values(_get(row, field) or {}):
+    for field_name in ("preview_payload", "validation_summary", "raw_responses"):
+        for key, value in _iter_nested_values(_get(row, field_name) or {}):
             if key in _SELL_SOURCE_KEYS and value:
                 ids.add(str(value))
     return ids
@@ -327,11 +336,57 @@ def _cleanup_required_row_ref(row: Any) -> dict[str, Any]:
     return ref
 
 
+def _verify_broker_snapshot(
+    *,
+    rows: list[dict[str, Any]] | None,
+    fetched_at: Any,
+    checked_at: datetime,
+    max_age_minutes: int,
+) -> dict[str, Any]:
+    """Classify whether a caller-supplied broker snapshot counts as evidence.
+
+    ROB-1130: an empty list is not evidence of an empty account. The caller must
+    also state when the snapshot was fetched, otherwise "positions=0 because we
+    looked" is indistinguishable from "positions=0 because we did not look" and
+    the gate silently passes while the account holds positions.
+    """
+    state: dict[str, Any] = {
+        "provided": rows is not None,
+        "count": len(rows) if rows is not None else None,
+        "fetched_at": None,
+        "verified": False,
+        "reason": None,
+    }
+    if rows is None:
+        state["reason"] = "snapshot_missing"
+        return state
+    if fetched_at is None or (isinstance(fetched_at, str) and not fetched_at.strip()):
+        state["reason"] = "snapshot_not_attested"
+        return state
+    parsed = _as_aware_utc(_parse_datetime(fetched_at))
+    if parsed is None:
+        state["reason"] = "snapshot_attestation_unparseable"
+        return state
+    state["fetched_at"] = parsed.isoformat()
+    if parsed > checked_at + _SNAPSHOT_FUTURE_TOLERANCE:
+        state["reason"] = "snapshot_attestation_in_future"
+        return state
+    if parsed < checked_at - timedelta(minutes=max_age_minutes):
+        state["reason"] = "snapshot_stale"
+        return state
+    state["verified"] = True
+    return state
+
+
 def build_paper_execution_preflight_report(
     *,
     ledger_rows: Iterable[Any] = (),
-    open_orders: Iterable[dict[str, Any]] = (),
-    positions: Iterable[dict[str, Any]] = (),
+    open_orders: Iterable[dict[str, Any]] | None = None,
+    positions: Iterable[dict[str, Any]] | None = None,
+    open_orders_fetched_at: datetime | str | None = None,
+    positions_fetched_at: datetime | str | None = None,
+    snapshot_max_age_minutes: int = DEFAULT_SNAPSHOT_MAX_AGE_MINUTES,
+    snapshot_evidence_required: bool = True,
     approval_packet: dict[str, Any] | None = None,
     expected_signal_symbol: str | None = None,
     expected_execution_symbol: str | None = None,
@@ -345,11 +400,24 @@ def build_paper_execution_preflight_report(
         ledger_rows: Recent or correlation-scoped ledger rows. ORM rows and
             dictionaries are both accepted for deterministic tests.
         open_orders: Read-only broker open-order snapshot already fetched by
-            the caller. Non-terminal rows block a new cycle.
+            the caller. Non-terminal rows block a new cycle. ``None`` means the
+            snapshot was never fetched, which is itself a blocker.
         positions: Read-only position snapshot already fetched by the caller.
             Any non-zero quantity blocks a new cycle. The snapshot is also the
             evidence used to tell a still-open buy leg apart from a buy whose
-            sell leg was never recorded (ROB-1129).
+            sell leg was never recorded (ROB-1129). ``None`` means the snapshot
+            was never fetched, which is itself a blocker.
+        open_orders_fetched_at: When the open-order snapshot was read from the
+            broker. Required for the snapshot to count as evidence (ROB-1130).
+        positions_fetched_at: When the position snapshot was read from the
+            broker. Required for the snapshot to count as evidence (ROB-1130).
+        snapshot_max_age_minutes: Maximum snapshot age that still counts as a
+            current view of the account.
+        snapshot_evidence_required: When True (the default, and the only correct
+            setting for any pre-order gate) a missing, unattested, stale, or
+            unparseable broker snapshot is a blocker. Historical audit report
+            builders that are not authorizing an order may set this to False;
+            it does not downgrade any other blocker.
         approval_packet: Optional preview/approval packet being considered for
             execution. Used for duplicate, stale, and symbol checks.
         expected_signal_symbol: Optional symbol from the signal artifact.
@@ -362,12 +430,15 @@ def build_paper_execution_preflight_report(
             testing where operators deliberately exercise buy/sell/adjust/close
             paths against an already-used paper account. Open orders,
             duplicate client IDs, ledger/order/fill mismatches, unclosed sells,
-            missing linked sells, and symbol mismatches still block.
+            missing linked sells, unverified broker snapshots, and symbol
+            mismatches still block.
     """
+    if snapshot_max_age_minutes < 1:
+        raise ValueError("snapshot_max_age_minutes must be >= 1")
     checked_at = _as_aware_utc(now) or datetime.now(UTC)
     unscoped_ledger = list(ledger_rows)
-    orders = list(open_orders)
-    position_rows = list(positions)
+    orders = list(open_orders) if open_orders is not None else None
+    position_rows = list(positions) if positions is not None else None
     packet = approval_packet or {}
     preflight_scope = _preflight_scope_from_packet(packet)
     ledger = [
@@ -384,6 +455,59 @@ def build_paper_execution_preflight_report(
         details: dict[str, Any],
     ) -> None:
         anomalies.append(PaperExecutionAnomaly(check_id, severity, summary, details))
+
+    # 0. Broker snapshot evidence (ROB-1130). This runs first because every
+    # check below that concludes "nothing is there" depends on it.
+    snapshot_state: dict[str, Any] = {
+        "positions": _verify_broker_snapshot(
+            rows=position_rows,
+            fetched_at=positions_fetched_at,
+            checked_at=checked_at,
+            max_age_minutes=snapshot_max_age_minutes,
+        ),
+        "open_orders": _verify_broker_snapshot(
+            rows=orders,
+            fetched_at=open_orders_fetched_at,
+            checked_at=checked_at,
+            max_age_minutes=snapshot_max_age_minutes,
+        ),
+        "max_age_minutes": snapshot_max_age_minutes,
+        "evidence_required": snapshot_evidence_required,
+    }
+    unverified_kinds = [
+        kind for kind in _SNAPSHOT_KINDS if not snapshot_state[kind]["verified"]
+    ]
+    if snapshot_evidence_required and unverified_kinds:
+        add(
+            "broker_snapshot_unverified",
+            PaperExecutionAnomalySeverity.block,
+            "Broker state snapshot is missing or unverified, so an empty "
+            "account cannot be distinguished from an unqueried one",
+            {
+                "unverified": unverified_kinds,
+                "reasons": {
+                    kind: snapshot_state[kind]["reason"] for kind in unverified_kinds
+                },
+                "max_age_minutes": snapshot_max_age_minutes,
+                "required_reads": [
+                    "alpaca_paper_list_positions",
+                    "alpaca_paper_list_orders(status=open)",
+                ],
+                "remediation": (
+                    "Fetch the broker snapshot immediately before the gate and "
+                    "pass it together with the time it was fetched."
+                ),
+                "snapshot": {kind: snapshot_state[kind] for kind in _SNAPSHOT_KINDS},
+            },
+        )
+
+    positions_are_evidence = (
+        snapshot_state["positions"]["verified"]
+        if snapshot_evidence_required
+        else bool(position_rows)
+    )
+    orders = orders if orders is not None else []
+    position_rows = position_rows if position_rows is not None else []
 
     # 1. Unexpected open orders.
     open_snapshot = [o for o in orders if _is_open_order(o)]
@@ -476,7 +600,7 @@ def build_paper_execution_preflight_report(
         for source_id in _source_client_order_ids(row)
     }
     held_symbols = _held_position_symbols(position_rows)
-    positions_verified = bool(position_rows)
+    positions_verified = positions_are_evidence
     open_position_buys: list[Any] = []
     unresolved_buys: list[dict[str, Any]] = []
     for row in ledger:
@@ -720,31 +844,41 @@ def build_paper_execution_preflight_report(
     should_block = any(
         a.severity == PaperExecutionAnomalySeverity.block for a in anomalies
     )
+    counts: dict[str, int] = {
+        "ledger_rows": len(ledger),
+        "unscoped_ledger_rows": len(unscoped_ledger),
+        "block": sum(
+            a.severity == PaperExecutionAnomalySeverity.block for a in anomalies
+        ),
+        "warning": sum(
+            a.severity == PaperExecutionAnomalySeverity.warning for a in anomalies
+        ),
+        "info": sum(
+            a.severity == PaperExecutionAnomalySeverity.info for a in anomalies
+        ),
+    }
+    # Only report a snapshot count that actually describes the account. Emitting
+    # ``positions: 0`` for a snapshot we could not verify is the exact false
+    # assurance ROB-1130 was filed for.
+    for kind in _SNAPSHOT_KINDS:
+        kind_state = snapshot_state[kind]
+        if kind_state["count"] is None:
+            continue
+        if kind_state["verified"] or not snapshot_evidence_required:
+            counts[kind] = kind_state["count"]
     return PaperExecutionPreflightReport(
         status="blocked" if should_block else "pass",
         should_block=should_block,
         checked_at=checked_at,
         stale_after_minutes=stale_after_minutes,
         anomalies=tuple(anomalies),
-        counts={
-            "ledger_rows": len(ledger),
-            "unscoped_ledger_rows": len(unscoped_ledger),
-            "open_orders": len(orders),
-            "positions": len(position_rows),
-            "block": sum(
-                a.severity == PaperExecutionAnomalySeverity.block for a in anomalies
-            ),
-            "warning": sum(
-                a.severity == PaperExecutionAnomalySeverity.warning for a in anomalies
-            ),
-            "info": sum(
-                a.severity == PaperExecutionAnomalySeverity.info for a in anomalies
-            ),
-        },
+        counts=counts,
+        broker_snapshot=snapshot_state,
     )
 
 
 __all__ = [
+    "DEFAULT_SNAPSHOT_MAX_AGE_MINUTES",
     "STALE_PREVIEW_CLEANUP_ACTION",
     "STALE_PREVIEW_CLEANUP_REQUIRED_STATE",
     "PaperExecutionAnomaly",

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -73,6 +73,15 @@ _CANONICAL_FILLED_LEDGER_STATES = frozenset(
 )
 _FILLED_STATES = frozenset({"filled", "partially_filled"})
 _BUY_REQUIRES_LINKED_SELL_STATES = _FILLED_STATES | _CANONICAL_FILLED_LEDGER_STATES
+# States in which a buy leg legitimately holds an open position and therefore
+# has no sell leg yet. Reaching one of these states is not evidence that a sell
+# is missing; only a contradiction against the live position snapshot is.
+_BUY_OPEN_POSITION_STATES = frozenset(
+    {"filled", "partially_filled", "position_reconciled"}
+)
+# States that assert the roundtrip already finished. A completed buy leg with no
+# sell row is a genuine missing-leg defect regardless of current holdings.
+_BUY_COMPLETED_ROUNDTRIP_STATES = frozenset({"closed", "final_reconciled"})
 _TERMINAL_STATES = frozenset({"filled", "canceled"})
 _TERMINAL_PREVIEW_SIBLING_STATES = frozenset({"final_reconciled", "closed", "canceled"})
 _SELL_SOURCE_KEYS = frozenset(
@@ -239,6 +248,39 @@ def _position_qty(position: dict[str, Any]) -> Decimal:
     )
 
 
+def _position_symbol(position: dict[str, Any]) -> str:
+    return _normalize_symbol(
+        position.get("symbol")
+        or position.get("asset_symbol")
+        or position.get("execution_symbol")
+    )
+
+
+def _held_position_symbols(positions: Iterable[dict[str, Any]]) -> set[str]:
+    """Normalized symbols with a non-zero quantity in the position snapshot."""
+    held: set[str] = set()
+    for position in positions:
+        if _position_qty(position) == Decimal("0"):
+            continue
+        symbol = _position_symbol(position)
+        if symbol:
+            held.add(symbol)
+    return held
+
+
+def _ledger_row_broker_symbol(row: Any) -> str:
+    """Broker-side symbol for a ledger row.
+
+    ``execution_symbol`` is the symbol the order was actually placed with, so it
+    is the only field comparable to a broker position snapshot. ``signal_symbol``
+    is only used when the execution symbol is missing, because signal symbols use
+    a different namespace for crypto (``KRW-BTC`` vs ``BTCUSD``).
+    """
+    return _normalize_symbol(_get(row, "execution_symbol")) or _normalize_symbol(
+        _get(row, "signal_symbol")
+    )
+
+
 def _latest_preview_time(row: Any) -> datetime | None:
     candidates = [
         _get(row, "approval_bridge_generated_at"),
@@ -305,7 +347,9 @@ def build_paper_execution_preflight_report(
         open_orders: Read-only broker open-order snapshot already fetched by
             the caller. Non-terminal rows block a new cycle.
         positions: Read-only position snapshot already fetched by the caller.
-            Any non-zero quantity blocks a new cycle.
+            Any non-zero quantity blocks a new cycle. The snapshot is also the
+            evidence used to tell a still-open buy leg apart from a buy whose
+            sell leg was never recorded (ROB-1129).
         approval_packet: Optional preview/approval packet being considered for
             execution. Used for duplicate, stale, and symbol checks.
         expected_signal_symbol: Optional symbol from the signal artifact.
@@ -410,29 +454,76 @@ def build_paper_execution_preflight_report(
         )
 
     # 4. Previous buy filled but no linked sell exists.
+    #
+    # ROB-1129: reaching a filled/reconciled state is NOT by itself evidence
+    # that a sell leg is missing. A buy that is still holding an open position
+    # legitimately has no sell row yet, and reporting it as an anomaly turned
+    # normal open positions into preflight blockers. The live position snapshot
+    # is the only thing that separates the two cases:
+    #
+    #   holding state + symbol still held    -> open position, expected (info)
+    #   holding state + symbol not held      -> broker closed it, ledger did not
+    #                                           record the sell leg (block)
+    #   closed/final_reconciled + no sell    -> ledger claims the roundtrip
+    #                                           finished with no sell row (block)
+    #
+    # Trusting the snapshot is a separate concern; when no snapshot is available
+    # the row stays a blocker rather than being assumed open (fail-closed).
     sell_source_ids = {
         source_id
         for row in ledger
         if str(_get(row, "side") or "").lower() == "sell"
         for source_id in _source_client_order_ids(row)
     }
-    filled_buys_missing_sell = []
+    held_symbols = _held_position_symbols(position_rows)
+    positions_verified = bool(position_rows)
+    open_position_buys: list[Any] = []
+    unresolved_buys: list[dict[str, Any]] = []
     for row in ledger:
         side = str(_get(row, "side") or "").lower()
         state = str(_get(row, "lifecycle_state") or "").lower()
         client_id = str(_get(row, "client_order_id") or "").strip()
-        if (
-            side == "buy"
-            and state in _BUY_REQUIRES_LINKED_SELL_STATES
-            and client_id not in sell_source_ids
-        ):
-            filled_buys_missing_sell.append(row)
-    if filled_buys_missing_sell:
+        if side != "buy" or state not in _BUY_REQUIRES_LINKED_SELL_STATES:
+            continue
+        if client_id in sell_source_ids:
+            continue
+        if state in _BUY_COMPLETED_ROUNDTRIP_STATES:
+            unresolved_buys.append(
+                {"reason": "completed_state_without_sell_leg", **_row_ref(row)}
+            )
+            continue
+        if not positions_verified:
+            unresolved_buys.append(
+                {"reason": "position_snapshot_unverified", **_row_ref(row)}
+            )
+            continue
+        symbol = _ledger_row_broker_symbol(row)
+        if symbol and symbol in held_symbols:
+            open_position_buys.append(row)
+        else:
+            unresolved_buys.append(
+                {"reason": "holding_state_without_open_position", **_row_ref(row)}
+            )
+
+    if open_position_buys:
+        add(
+            "open_position_without_sell_leg",
+            PaperExecutionAnomalySeverity.info,
+            "Filled buy has no sell leg because the position is still open",
+            {
+                "count": len(open_position_buys),
+                "rows": [_row_ref(r) for r in open_position_buys[:10]],
+            },
+        )
+    if unresolved_buys:
         add(
             "previous_buy_filled_sell_missing",
             PaperExecutionAnomalySeverity.block,
             "A previous filled buy has no linked sell ledger row",
-            {"rows": [_row_ref(r) for r in filled_buys_missing_sell[:10]]},
+            {
+                "count": len(unresolved_buys),
+                "rows": unresolved_buys[:10],
+            },
         )
 
     # 5. Sell filled but final position not closed.

--- a/app/services/alpaca_paper_roundtrip_report_service.py
+++ b/app/services/alpaca_paper_roundtrip_report_service.py
@@ -297,6 +297,12 @@ class AlpacaPaperRoundtripReportService:
             ledger_rows=[],
             open_orders=open_orders,
             positions=positions,
+            # This is a historical audit view over already-persisted rows, not a
+            # pre-order gate, so it must not turn every report into an anomaly
+            # just because the caller passed no live broker snapshot. The
+            # fail-closed snapshot requirement (ROB-1130) applies to
+            # alpaca_paper_execution_preflight_check, which authorizes orders.
+            snapshot_evidence_required=False,
             stale_after_minutes=stale_after_minutes,
             now=generated_at,
         ).to_dict()

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -223,6 +224,8 @@ async def test_execution_preflight_check_returns_blocking_report(monkeypatch):
     result = await mod.alpaca_paper_execution_preflight_check(
         limit=20,
         open_orders=[{"id": "order-1", "status": "new", "symbol": "BTCUSD"}],
+        positions=[],
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
     )
 
     assert result["success"] is True
@@ -231,6 +234,76 @@ async def test_execution_preflight_check_returns_blocking_report(monkeypatch):
     assert result["should_block"] is True
     assert result["anomalies"][0]["check_id"] == "unexpected_open_orders"
     mock_svc.list_recent.assert_awaited_once_with(limit=20)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_blocks_on_empty_broker_snapshot(monkeypatch):
+    """ROB-1130: no snapshot must not pass as positions=0."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.alpaca_paper_execution_preflight_check(limit=20)
+
+    assert result["should_block"] is True
+    assert result["status"] == "blocked"
+    finding = next(
+        a for a in result["anomalies"] if a["check_id"] == "broker_snapshot_unverified"
+    )
+    assert finding["severity"] == "block"
+    assert finding["details"]["reasons"] == {
+        "positions": "snapshot_missing",
+        "open_orders": "snapshot_missing",
+    }
+    assert "positions" not in result["counts"]
+    assert result["broker_snapshot"]["positions"]["provided"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_passes_on_attested_empty_snapshot(monkeypatch):
+    """ROB-1130: a genuinely queried flat account keeps the normal pass path."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        open_orders=[],
+        positions=[],
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+    )
+
+    assert result["should_block"] is False
+    assert result["status"] == "pass"
+    assert result["counts"]["positions"] == 0
+    assert result["broker_snapshot"]["positions"]["verified"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_reflects_held_position(monkeypatch):
+    """ROB-1130: a real snapshot with a holding must surface the holding."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        open_orders=[],
+        positions=[{"symbol": "UBER", "qty": "1", "asset_class": "us_equity"}],
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+    )
+
+    assert result["should_block"] is True
+    assert result["counts"]["positions"] == 1
+    check_ids = {a["check_id"] for a in result["anomalies"]}
+    assert "residual_position_exists" in check_ids
+    assert "broker_snapshot_unverified" not in check_ids
 
 
 @pytest.mark.asyncio
@@ -280,6 +353,8 @@ async def test_execution_preflight_check_invalid_inputs_raise():
         await alpaca_paper_execution_preflight_check(limit=0)
     with pytest.raises(ValueError, match="stale_after_minutes must be >= 1"):
         await alpaca_paper_execution_preflight_check(stale_after_minutes=0)
+    with pytest.raises(ValueError, match="snapshot_max_age_minutes must be >= 1"):
+        await alpaca_paper_execution_preflight_check(snapshot_max_age_minutes=0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -1147,3 +1147,78 @@ def test_rob1130_audit_callers_may_opt_out_without_downgrading_other_blockers():
 def test_rob1130_invalid_snapshot_max_age_raises():
     with pytest.raises(ValueError, match="snapshot_max_age_minutes must be >= 1"):
         build_paper_execution_preflight_report(snapshot_max_age_minutes=0)
+
+
+# ---------------------------------------------------------------------------
+# ROB-1129 + ROB-1130 combined: what the 07-28 account looks like after both fixes
+# ---------------------------------------------------------------------------
+
+
+def _rob1129_measured_sell_legs():
+    """The seven sell rows measured as `sell_filled_position_not_closed` on 07-28.
+
+    Source: ~/work/herdr-inbox/alpaca-paper-block-proposal-2026-07-28.md 2-B.
+    Their stored `position_snapshot` is the pre-fill sell_claim_baseline rather
+    than a post-fill re-read, which is a separate defect from the buy/sell
+    pairing one and is deliberately left untouched by the ROB-1129 fix.
+    """
+    measured = [
+        ("rob73-ce5159550b11e626", "F"),
+        ("rob73-abc306c7599f4b63", "F"),
+        ("rob73-cce8e0d3264fb86d", "ROST"),
+        ("rob73-9dd2e832f0e9dd05", "REGN"),
+        ("rob73-2b58a4ff9b6645ff", "F"),
+        ("rob73-e37deae38a423090", "DPZ"),
+        ("rob73-6623cf6a1009e34c", "AMC"),
+    ]
+    return [
+        _row(
+            client_order_id=client_order_id,
+            lifecycle_correlation_id=client_order_id,
+            side="sell",
+            lifecycle_state="filled",
+            order_status="filled",
+            execution_symbol=symbol,
+            signal_symbol=symbol,
+            filled_qty="1",
+            position_snapshot={"qty": "1"},
+        )
+        for client_order_id, symbol in measured
+    ]
+
+
+@pytest.mark.unit
+def test_rob1129_stage_one_does_not_release_the_account_block():
+    """Both fixes together shrink the findings but the account still blocks.
+
+    Fixing the checker removes the five false positives and fixing the snapshot
+    input makes the holdings visible. What remains is real: four buy legs the
+    broker already closed, seven sell legs whose ledger rows never advanced, and
+    the flat-account residual gate. Advancing those rows needs the stage 2/3
+    tooling, not a checker change.
+    """
+    report = build_paper_execution_preflight_report(
+        ledger_rows=_rob1129_measured_buy_legs() + _rob1129_measured_sell_legs(),
+        positions=[
+            {"symbol": "ISRG", "qty": "1.014", "asset_class": "us_equity"},
+            {"symbol": "UBER", "qty": "5", "asset_class": "us_equity"},
+            {"symbol": "WDC", "qty": "1", "asset_class": "us_equity"},
+            {"symbol": "OLED", "qty": "0.0614", "asset_class": "us_equity"},
+        ],
+        positions_fetched_at=_ROB1130_NOW,
+        open_orders=[],
+        open_orders_fetched_at=_ROB1130_NOW,
+        now=_ROB1130_NOW,
+    )
+
+    assert report.should_block is True
+    assert _blocking_check_ids(report) == {
+        "residual_position_exists",
+        "previous_buy_filled_sell_missing",
+        "sell_filled_position_not_closed",
+    }
+    assert _anomaly(report, "open_position_without_sell_leg").details["count"] == 5
+    assert _anomaly(report, "previous_buy_filled_sell_missing").details["count"] == 4
+    assert len(_anomaly(report, "sell_filled_position_not_closed").details["rows"]) == 7
+    # No bypass: the test-mode downgrade flag stays off and untouched.
+    assert report.broker_snapshot["evidence_required"] is True

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -133,6 +133,202 @@ def test_previous_buy_filled_without_linked_sell_blocks():
     assert "previous_buy_filled_sell_missing" in _check_ids(report)
 
 
+# ---------------------------------------------------------------------------
+# ROB-1129: open position vs missing sell leg
+# ---------------------------------------------------------------------------
+
+
+def _blocking_check_ids(report):
+    return {
+        a.check_id
+        for a in report.anomalies
+        if a.severity == PaperExecutionAnomalySeverity.block
+    }
+
+
+def _anomaly(report, check_id):
+    return next(a for a in report.anomalies if a.check_id == check_id)
+
+
+@pytest.mark.unit
+def test_open_position_buy_without_sell_leg_is_info_not_block():
+    """A filled buy whose symbol is still held is a normal open position."""
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="rob73-ac562d42b1d3ec16",
+                side="buy",
+                lifecycle_state="filled",
+                execution_symbol="UBER",
+                signal_symbol="UBER",
+                filled_qty="4",
+            )
+        ],
+        positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+    )
+
+    assert "previous_buy_filled_sell_missing" not in _check_ids(report)
+    open_finding = _anomaly(report, "open_position_without_sell_leg")
+    assert open_finding.severity == PaperExecutionAnomalySeverity.info
+    assert open_finding.details["count"] == 1
+    # The only remaining blocker is the flat-account residual gate, which is a
+    # separate design assumption and not part of the ROB-1129 pairing defect.
+    assert _blocking_check_ids(report) == {"residual_position_exists"}
+
+
+@pytest.mark.unit
+def test_holding_state_buy_without_broker_position_still_blocks():
+    """Ledger says holding, broker says flat -> the sell leg was never recorded."""
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="rob73-ac4103900976a38d",
+                side="buy",
+                lifecycle_state="filled",
+                execution_symbol="DPZ",
+                signal_symbol="DPZ",
+                filled_qty="1",
+            )
+        ],
+        positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+    )
+
+    assert report.should_block is True
+    finding = _anomaly(report, "previous_buy_filled_sell_missing")
+    assert [r["reason"] for r in finding.details["rows"]] == [
+        "holding_state_without_open_position"
+    ]
+
+
+@pytest.mark.unit
+def test_completed_roundtrip_state_without_sell_leg_blocks_even_when_held():
+    """closed/final_reconciled asserts the roundtrip ended, so a sell row is required."""
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="buy-closed-without-sell",
+                side="buy",
+                lifecycle_state="closed",
+                execution_symbol="UBER",
+                signal_symbol="UBER",
+            )
+        ],
+        positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+    )
+
+    assert report.should_block is True
+    finding = _anomaly(report, "previous_buy_filled_sell_missing")
+    assert [r["reason"] for r in finding.details["rows"]] == [
+        "completed_state_without_sell_leg"
+    ]
+    assert "open_position_without_sell_leg" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_missing_position_snapshot_keeps_unlinked_buy_blocked():
+    """Without a snapshot the two cases are indistinguishable -> stay blocked."""
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="rob73-ac562d42b1d3ec16",
+                side="buy",
+                lifecycle_state="filled",
+                execution_symbol="UBER",
+                signal_symbol="UBER",
+            )
+        ],
+        positions=[],
+    )
+
+    assert report.should_block is True
+    finding = _anomaly(report, "previous_buy_filled_sell_missing")
+    assert [r["reason"] for r in finding.details["rows"]] == [
+        "position_snapshot_unverified"
+    ]
+
+
+def _rob1129_measured_buy_legs():
+    """The nine buy rows measured as `previous_buy_filled_sell_missing` on 07-28.
+
+    Source: ~/work/herdr-inbox/alpaca-paper-block-proposal-2026-07-28.md §2-A.
+    Every row carries its own lifecycle_correlation_id equal to its
+    client_order_id, which is why payload-based buy/sell pairing never matches.
+    """
+    measured = [
+        ("rob73-93bc5d4b6ba0ac6e", "ISRG", "1"),
+        ("rob73-ac562d42b1d3ec16", "UBER", "4"),
+        ("rob73-3ccf09a984c7758e", "WDC", "1"),
+        ("rob73-47a669297ff57cb3", "F", "1"),
+        ("rob73-a8691ab4f782af06", "ROST", "1"),
+        ("rob73-1862fd0d16137ff6", "OLED", "0.0614"),
+        ("rob73-ac4103900976a38d", "DPZ", "1"),
+        ("rob73-c9726ec2359bd763", "AMC", "1"),
+        ("rob73-08ebbf8c64e2dd93", "ISRG", "0.014"),
+    ]
+    return [
+        _row(
+            client_order_id=client_order_id,
+            lifecycle_correlation_id=client_order_id,
+            side="buy",
+            lifecycle_state="filled",
+            order_status="filled",
+            execution_symbol=symbol,
+            signal_symbol=symbol,
+            filled_qty=filled_qty,
+            position_snapshot=None,
+        )
+        for client_order_id, symbol, filled_qty in measured
+    ]
+
+
+@pytest.mark.unit
+def test_rob1129_measured_ledger_drops_five_false_positive_open_positions():
+    """Regression fixture for the 07-28 measurement: 9 findings -> 4 real ones.
+
+    Positions are the live broker holdings measured the same day. ISRG, UBER,
+    WDC and OLED are still held, so those five buy legs are open positions.
+    F, ROST, DPZ and AMC are flat at the broker, so their missing sell legs are
+    real ledger defects and must keep blocking.
+    """
+    report = build_paper_execution_preflight_report(
+        ledger_rows=_rob1129_measured_buy_legs(),
+        positions=[
+            {"symbol": "ISRG", "qty": "1.014", "asset_class": "us_equity"},
+            {"symbol": "UBER", "qty": "5", "asset_class": "us_equity"},
+            {"symbol": "WDC", "qty": "1", "asset_class": "us_equity"},
+            {"symbol": "OLED", "qty": "0.0614", "asset_class": "us_equity"},
+            {"symbol": "BSX", "qty": "1", "asset_class": "us_equity"},
+            {"symbol": "HCA", "qty": "1", "asset_class": "us_equity"},
+            {"symbol": "CPNG", "qty": "1", "asset_class": "us_equity"},
+        ],
+        now=datetime(2026, 7, 28, 14, 0, tzinfo=UTC),
+    )
+
+    open_finding = _anomaly(report, "open_position_without_sell_leg")
+    assert open_finding.severity == PaperExecutionAnomalySeverity.info
+    assert open_finding.details["count"] == 5
+    assert {r["client_order_id"] for r in open_finding.details["rows"]} == {
+        "rob73-93bc5d4b6ba0ac6e",  # ISRG 07-24
+        "rob73-08ebbf8c64e2dd93",  # ISRG 07-17 tranche
+        "rob73-ac562d42b1d3ec16",  # UBER
+        "rob73-3ccf09a984c7758e",  # WDC
+        "rob73-1862fd0d16137ff6",  # OLED
+    }
+
+    missing_finding = _anomaly(report, "previous_buy_filled_sell_missing")
+    assert missing_finding.severity == PaperExecutionAnomalySeverity.block
+    assert missing_finding.details["count"] == 4
+    assert {r["client_order_id"] for r in missing_finding.details["rows"]} == {
+        "rob73-47a669297ff57cb3",  # F 07-23
+        "rob73-a8691ab4f782af06",  # ROST 07-21
+        "rob73-ac4103900976a38d",  # DPZ 07-20
+        "rob73-c9726ec2359bd763",  # AMC 07-20
+    }
+    assert {r["reason"] for r in missing_finding.details["rows"]} == {
+        "holding_state_without_open_position"
+    }
+
+
 @pytest.mark.unit
 def test_linked_sell_prevents_missing_sell_anomaly():
     report = build_paper_execution_preflight_report(

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -39,6 +39,21 @@ def _check_ids(report):
     return {a.check_id for a in report.anomalies}
 
 
+def _verified_snapshot(positions=None, open_orders=None, now=None):
+    """Kwargs for a freshly fetched, attested broker snapshot (ROB-1130).
+
+    The preflight gate is fail-closed: an empty list only counts as evidence of
+    an empty account when the caller also states when it was fetched.
+    """
+    fetched_at = now or datetime.now(UTC)
+    return {
+        "positions": list(positions or []),
+        "open_orders": list(open_orders or []),
+        "positions_fetched_at": fetched_at,
+        "open_orders_fetched_at": fetched_at,
+    }
+
+
 @pytest.mark.unit
 def test_clean_preflight_returns_info_and_does_not_block():
     report = build_paper_execution_preflight_report(
@@ -52,6 +67,8 @@ def test_clean_preflight_returns_info_and_does_not_block():
         ],
         open_orders=[],
         positions=[],
+        positions_fetched_at=datetime(2026, 5, 3, 12, 5, tzinfo=UTC),
+        open_orders_fetched_at=datetime(2026, 5, 3, 12, 5, tzinfo=UTC),
         approval_packet={"client_order_id": "rob93-buy-002"},
         expected_signal_symbol="KRW-BTC",
         expected_execution_symbol="BTC/USD",
@@ -95,7 +112,9 @@ def test_residual_position_blocks_new_cycle():
 @pytest.mark.unit
 def test_residual_position_can_warn_in_paper_execution_test_mode():
     report = build_paper_execution_preflight_report(
-        positions=[{"symbol": "BTCUSD", "qty": "0.001", "asset_class": "crypto"}],
+        **_verified_snapshot(
+            positions=[{"symbol": "BTCUSD", "qty": "0.001", "asset_class": "crypto"}]
+        ),
         legacy_cycle_blockers_as_warnings=True,
     )
 
@@ -165,6 +184,9 @@ def test_open_position_buy_without_sell_leg_is_info_not_block():
             )
         ],
         positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+        positions_fetched_at=datetime.now(UTC),
+        open_orders=[],
+        open_orders_fetched_at=datetime.now(UTC),
     )
 
     assert "previous_buy_filled_sell_missing" not in _check_ids(report)
@@ -191,6 +213,9 @@ def test_holding_state_buy_without_broker_position_still_blocks():
             )
         ],
         positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+        positions_fetched_at=datetime.now(UTC),
+        open_orders=[],
+        open_orders_fetched_at=datetime.now(UTC),
     )
 
     assert report.should_block is True
@@ -214,6 +239,9 @@ def test_completed_roundtrip_state_without_sell_leg_blocks_even_when_held():
             )
         ],
         positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+        positions_fetched_at=datetime.now(UTC),
+        open_orders=[],
+        open_orders_fetched_at=datetime.now(UTC),
     )
 
     assert report.should_block is True
@@ -301,6 +329,9 @@ def test_rob1129_measured_ledger_drops_five_false_positive_open_positions():
             {"symbol": "HCA", "qty": "1", "asset_class": "us_equity"},
             {"symbol": "CPNG", "qty": "1", "asset_class": "us_equity"},
         ],
+        positions_fetched_at=datetime(2026, 7, 28, 14, 0, tzinfo=UTC),
+        open_orders=[],
+        open_orders_fetched_at=datetime(2026, 7, 28, 14, 0, tzinfo=UTC),
         now=datetime(2026, 7, 28, 14, 0, tzinfo=UTC),
     )
 
@@ -362,8 +393,7 @@ def test_canonical_completed_roundtrip_states_do_not_block():
                 raw_responses={"payload": {"source_client_order_id": "buy-reconciled"}},
             ),
         ],
-        open_orders=[],
-        positions=[],
+        **_verified_snapshot(),
     )
 
     assert report.status == "pass"
@@ -487,6 +517,7 @@ def test_spent_stale_preview_with_final_reconciled_sibling_warns_not_blocks():
                 signal_symbol="SOL/USD",
             ),
         ],
+        **_verified_snapshot(now=now),
         now=now,
         stale_after_minutes=30,
     )
@@ -527,6 +558,7 @@ def test_scoped_stale_preview_uses_unscoped_terminal_sibling_evidence():
             ),
         ],
         approval_packet={"candidate_uuid": "candidate-current"},
+        **_verified_snapshot(now=now),
         now=now,
         stale_after_minutes=30,
     )
@@ -583,6 +615,7 @@ def test_spent_stale_preview_fixture_for_rob_950_two_terminal_pairs_does_not_blo
                 signal_symbol="BTC/USD",
             ),
         ],
+        **_verified_snapshot(now=now),
         now=now,
         stale_after_minutes=30,
     )
@@ -684,6 +717,7 @@ def test_stale_preview_can_warn_in_paper_execution_test_mode():
                 created_at=now - timedelta(minutes=45),
             )
         ],
+        **_verified_snapshot(now=now),
         now=now,
         stale_after_minutes=30,
         legacy_cycle_blockers_as_warnings=True,
@@ -740,7 +774,10 @@ def test_signal_execution_symbol_mismatch_blocks():
 @pytest.mark.unit
 def test_report_to_dict_is_operator_readable():
     report = build_paper_execution_preflight_report(
-        open_orders=[{"id": "order-1", "status": "new", "symbol": "BTCUSD"}],
+        **_verified_snapshot(
+            open_orders=[{"id": "order-1", "status": "new", "symbol": "BTCUSD"}],
+            now=datetime(2026, 5, 3, 12, 0, tzinfo=UTC),
+        ),
         now=datetime(2026, 5, 3, 12, 0, tzinfo=UTC),
     )
     data = report.to_dict()
@@ -749,6 +786,8 @@ def test_report_to_dict_is_operator_readable():
     assert data["should_block"] is True
     assert data["counts"]["block"] == 1
     assert data["anomalies"][0]["check_id"] == "unexpected_open_orders"
+    assert data["broker_snapshot"]["positions"]["verified"] is True
+    assert data["broker_snapshot"]["open_orders"]["verified"] is True
 
 
 @pytest.mark.unit
@@ -783,6 +822,7 @@ def test_scoped_preflight_ignores_unrelated_stale_and_symbol_rows():
             "signal_symbol": "KRW-BTC",
             "execution_symbol": "BTC/USD",
         },
+        **_verified_snapshot(now=now),
         now=now,
         stale_after_minutes=30,
     )
@@ -876,10 +916,234 @@ def test_preflight_does_not_flag_canceled_state_as_anomaly():
                 raw_responses={"payload": {"source_client_order_id": "buy-reconciled"}},
             ),
         ],
-        open_orders=[],
-        positions=[],
+        **_verified_snapshot(),
     )
 
     assert report.status == "pass"
     assert report.should_block is False
     assert "ledger_anomaly_row" not in _check_ids(report)
+
+
+# ---------------------------------------------------------------------------
+# ROB-1130: broker snapshot is fail-closed
+# ---------------------------------------------------------------------------
+
+_ROB1130_NOW = datetime(2026, 7, 28, 14, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_rob1130_empty_snapshot_without_attestation_blocks():
+    """Regression 1/4: an empty snapshot is not evidence of an empty account."""
+    report = build_paper_execution_preflight_report(
+        open_orders=[],
+        positions=[],
+        now=_ROB1130_NOW,
+    )
+
+    assert report.should_block is True
+    assert report.status == "blocked"
+    finding = _anomaly(report, "broker_snapshot_unverified")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["unverified"] == ["positions", "open_orders"]
+    assert finding.details["reasons"] == {
+        "positions": "snapshot_not_attested",
+        "open_orders": "snapshot_not_attested",
+    }
+    # The misleading "positions: 0" signal from ROB-1130 must not be reported as
+    # a verified count.
+    assert report.broker_snapshot["positions"]["verified"] is False
+    assert "positions" not in report.counts
+
+
+@pytest.mark.unit
+def test_rob1130_missing_snapshot_fields_block():
+    """Regression 2/4: omitting the snapshot entirely blocks."""
+    report = build_paper_execution_preflight_report(now=_ROB1130_NOW)
+
+    assert report.should_block is True
+    finding = _anomaly(report, "broker_snapshot_unverified")
+    assert finding.details["reasons"] == {
+        "positions": "snapshot_missing",
+        "open_orders": "snapshot_missing",
+    }
+    assert report.broker_snapshot["positions"]["provided"] is False
+    assert report.broker_snapshot["positions"]["count"] is None
+    assert "positions" not in report.counts
+    assert "open_orders" not in report.counts
+
+
+@pytest.mark.unit
+def test_rob1130_partial_snapshot_blocks_on_the_missing_half():
+    """Attesting positions only still leaves the open-order view unqueried."""
+    report = build_paper_execution_preflight_report(
+        positions=[],
+        positions_fetched_at=_ROB1130_NOW,
+        now=_ROB1130_NOW,
+    )
+
+    assert report.should_block is True
+    finding = _anomaly(report, "broker_snapshot_unverified")
+    assert finding.details["unverified"] == ["open_orders"]
+    assert report.broker_snapshot["positions"]["verified"] is True
+
+
+@pytest.mark.unit
+def test_rob1130_genuinely_queried_empty_account_passes():
+    """Regression 3/4: a real positions=0 read keeps the normal pass path."""
+    report = build_paper_execution_preflight_report(
+        open_orders=[],
+        positions=[],
+        open_orders_fetched_at=_ROB1130_NOW,
+        positions_fetched_at=_ROB1130_NOW,
+        now=_ROB1130_NOW,
+    )
+
+    assert report.status == "pass"
+    assert report.should_block is False
+    assert _check_ids(report) == {"preflight_clean"}
+    assert report.counts["positions"] == 0
+    assert report.counts["open_orders"] == 0
+    assert report.broker_snapshot["positions"] == {
+        "provided": True,
+        "count": 0,
+        "fetched_at": _ROB1130_NOW.isoformat(),
+        "verified": True,
+        "reason": None,
+    }
+
+
+@pytest.mark.unit
+def test_rob1130_held_position_in_real_snapshot_is_reflected():
+    """Regression 4/4: the UBER holding measured on 07-28 must be seen."""
+    report = build_paper_execution_preflight_report(
+        open_orders=[],
+        positions=[{"symbol": "UBER", "qty": "1", "asset_class": "us_equity"}],
+        open_orders_fetched_at=_ROB1130_NOW,
+        positions_fetched_at=_ROB1130_NOW,
+        now=_ROB1130_NOW,
+    )
+
+    assert report.should_block is True
+    finding = _anomaly(report, "residual_position_exists")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["positions"] == [
+        {"symbol": "UBER", "qty": "1", "asset_class": "us_equity"}
+    ]
+    assert report.counts["positions"] == 1
+    assert "broker_snapshot_unverified" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_rob1130_stale_snapshot_blocks():
+    report = build_paper_execution_preflight_report(
+        open_orders=[],
+        positions=[],
+        open_orders_fetched_at=_ROB1130_NOW - timedelta(minutes=30),
+        positions_fetched_at=_ROB1130_NOW - timedelta(minutes=30),
+        snapshot_max_age_minutes=5,
+        now=_ROB1130_NOW,
+    )
+
+    assert report.should_block is True
+    finding = _anomaly(report, "broker_snapshot_unverified")
+    assert finding.details["reasons"] == {
+        "positions": "snapshot_stale",
+        "open_orders": "snapshot_stale",
+    }
+
+
+@pytest.mark.unit
+def test_rob1130_unparseable_and_future_attestations_block():
+    unparseable = build_paper_execution_preflight_report(
+        open_orders=[],
+        positions=[],
+        open_orders_fetched_at="not-a-timestamp",
+        positions_fetched_at="not-a-timestamp",
+        now=_ROB1130_NOW,
+    )
+    assert unparseable.should_block is True
+    assert _anomaly(unparseable, "broker_snapshot_unverified").details["reasons"] == {
+        "positions": "snapshot_attestation_unparseable",
+        "open_orders": "snapshot_attestation_unparseable",
+    }
+
+    future = build_paper_execution_preflight_report(
+        open_orders=[],
+        positions=[],
+        open_orders_fetched_at=_ROB1130_NOW + timedelta(minutes=10),
+        positions_fetched_at=_ROB1130_NOW + timedelta(minutes=10),
+        now=_ROB1130_NOW,
+    )
+    assert future.should_block is True
+    assert _anomaly(future, "broker_snapshot_unverified").details["reasons"] == {
+        "positions": "snapshot_attestation_in_future",
+        "open_orders": "snapshot_attestation_in_future",
+    }
+
+
+@pytest.mark.unit
+def test_rob1130_snapshot_blocker_is_not_downgradeable_by_legacy_flag():
+    """legacy_cycle_blockers_as_warnings must not reopen the fail-open hole."""
+    report = build_paper_execution_preflight_report(
+        legacy_cycle_blockers_as_warnings=True,
+        now=_ROB1130_NOW,
+    )
+
+    assert report.should_block is True
+    assert (
+        _anomaly(report, "broker_snapshot_unverified").severity
+        == PaperExecutionAnomalySeverity.block
+    )
+
+
+@pytest.mark.unit
+def test_rob1130_unverified_snapshot_keeps_open_position_classification_closed():
+    """Without snapshot evidence a filled buy stays blocked, never assumed open."""
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="rob73-ac562d42b1d3ec16",
+                side="buy",
+                lifecycle_state="filled",
+                execution_symbol="UBER",
+                signal_symbol="UBER",
+            )
+        ],
+        now=_ROB1130_NOW,
+    )
+
+    assert report.should_block is True
+    assert "open_position_without_sell_leg" not in _check_ids(report)
+    finding = _anomaly(report, "previous_buy_filled_sell_missing")
+    assert [r["reason"] for r in finding.details["rows"]] == [
+        "position_snapshot_unverified"
+    ]
+
+
+@pytest.mark.unit
+def test_rob1130_audit_callers_may_opt_out_without_downgrading_other_blockers():
+    """Historical audit views are not order gates, but keep every real blocker."""
+    report = build_paper_execution_preflight_report(
+        snapshot_evidence_required=False,
+        now=_ROB1130_NOW,
+    )
+    assert report.should_block is False
+    assert _check_ids(report) == {"preflight_clean"}
+
+    still_blocking = build_paper_execution_preflight_report(
+        open_orders=[{"id": "order-1", "status": "new", "symbol": "BTCUSD"}],
+        positions=[{"symbol": "UBER", "qty": "1"}],
+        snapshot_evidence_required=False,
+        now=_ROB1130_NOW,
+    )
+    assert still_blocking.should_block is True
+    assert "broker_snapshot_unverified" not in _check_ids(still_blocking)
+    assert {"unexpected_open_orders", "residual_position_exists"} <= _check_ids(
+        still_blocking
+    )
+
+
+@pytest.mark.unit
+def test_rob1130_invalid_snapshot_max_age_raises():
+    with pytest.raises(ValueError, match="snapshot_max_age_minutes must be >= 1"):
+        build_paper_execution_preflight_report(snapshot_max_age_minutes=0)


### PR DESCRIPTION
Fixes the two blockers that stop `alpaca_paper` order flow from resuming. The
two defects have different causes and are in separate commits: ROB-1129 is
judgment logic, ROB-1130 is input validation.

## A — ROB-1129: open position vs missing sell leg

`previous_buy_filled_sell_missing` treated *any* filled/reconciled buy leg with
no linked sell row as an anomaly. A buy that is still holding an open position
legitimately has no sell leg yet, so normal holdings became preflight blockers.
Measured on 2026-07-28: 9 findings, of which only 4 were real.

The live position snapshot is now the evidence that separates the cases:

| ledger row | snapshot | verdict |
| --- | --- | --- |
| `filled`/`partially_filled`/`position_reconciled` | symbol still held | `open_position_without_sell_leg` (info) |
| `filled`/`partially_filled`/`position_reconciled` | symbol not held | block — broker closed it, ledger never recorded the sell |
| `closed`/`final_reconciled` | any | block — roundtrip claimed complete with no sell row |
| any | no verified snapshot | block — cannot classify, fail-closed |

Each blocking row carries a `reason` so the categories are distinguishable.
Symbol comparison uses `execution_symbol`, because `signal_symbol` lives in a
different namespace for crypto (`KRW-BTC` vs `BTCUSD`).

## B — ROB-1130: fail closed on unverified broker snapshots

The tool normalised a missing snapshot with `positions or []`, so calling it
with no snapshot produced `positions=0` and a PASS. It was measured passing
while the account held UBER. "Queried and genuinely empty" and "never queried"
arrived as the same empty list, so the gate could not tell them apart — that
indistinguishability was the root cause.

Snapshots now carry an attestation of when they were read from the broker.
Missing, empty-but-unattested, stale (default max age 5 min), and
unparseable/future timestamps all produce a `broker_snapshot_unverified`
blocker. `counts.positions` / `counts.open_orders` are omitted rather than
reported as `0` when unverifiable, and `broker_snapshot` exposes per-kind
`provided` / `verified` / `reason`.

```python
positions = await alpaca_paper_list_positions()
open_orders = await alpaca_paper_list_orders(status="open")
report = await alpaca_paper_execution_preflight_check(
    positions=positions["positions"],
    open_orders=open_orders["orders"],
    broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
)
```

`alpaca_paper_roundtrip_report` is a historical audit view rather than an order
gate, so its report builder opts out with `snapshot_evidence_required=False`.
That flag does not downgrade any other finding.

## No bypass was used

`legacy_cycle_blockers_as_warnings` is untouched and cannot downgrade the new
blocker (pinned by test). No ledger rows were modified, no transitions were
proposed, and the gate now blocks strictly more often than before. Nothing was
disabled to make a check pass.

## Does this release the BLOCK? No.

Replaying the 16 measured blocking rows with the 07-28 broker snapshot (the
fixture reproduces the measured before-state exactly: `block:2, warning:1,
positions:0`):

| | before | after |
| --- | --- | --- |
| `previous_buy_filled_sell_missing` | block, 9 | **block, 4** |
| `open_position_without_sell_leg` | — | **info, 5** |
| `sell_filled_position_not_closed` | block, 7 | block, 7 (untouched) |
| `residual_position_exists` | invisible (empty snapshot) | **block, 7 — now visible** |

The 5 false positives are gone. The account still blocks on work that is
explicitly out of this scope: 4 buy legs the broker already closed, 7 sell legs
whose ledger rows never advanced (stage 2 needs transition tooling that does
not exist yet), and the flat-account residual gate, which is a separate design
assumption — the gate models "start a new cycle from flat" while the account is
now a multi-position portfolio.

Note that B makes the account block *harder*, not softer: with a real snapshot
passed, `residual_position_exists` appears for the first time. That is correct
fail-closed behaviour.

## Verification

- `tests/services/test_alpaca_paper_anomaly_checks.py` — 43 tests, including the
  ROB-1130 matrix (empty snapshot blocks, missing fields block, real
  `positions=0` still passes, holding is reflected) and the ROB-1129 fixture
  built from the 07-28 measurement.
- `tests/mcp_server/test_alpaca_paper_ledger_read_tools.py` — tool-level
  fail-closed / pass / holding-reflected cases.
- Full suite: 17220 passed, 15 skipped. `ruff format`, `ruff check`, `ty check`
  clean.
- No deploy, migration, restart, broker mutation, or DB write was performed
  (US market open). Post-deploy re-measurement against the live account has
  **not** been run and is required to confirm the numbers above on real data.

Refs ROB-1129, ROB-1130
