### PR TITLE
fix(r4): recover PIK slots and gate collector build versions

### DIFF
--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -15,12 +15,14 @@ import json
 import logging
 import random
 import sqlite3
+import subprocess
 import traceback
 import urllib.parse
 import uuid
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Final
 
@@ -73,7 +75,7 @@ PIT_COLUMNS: Final = (
     "gap_detected",
     "reconnect_id",
 )
-COLLECTOR_VERSION: Final = "r4-p0-collector.v3"
+COLLECTOR_VERSION: Final = "r4-p0-collector.v4"
 BASIS_RECOVERY_LIMIT: Final = 100
 # Binance's taker ratio endpoint maps requested boundaries to the preceding
 # 5-minute buckets ([S-5m, E-5m]); the other epoch-history endpoints use their
@@ -148,6 +150,31 @@ def canonical_json(value: Any) -> str:
 
 def sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode()).hexdigest()
+
+
+@lru_cache(maxsize=1)
+def runtime_code_hash() -> str:
+    """Return the exact deployed Git commit loaded by this process."""
+
+    repository_root = Path(__file__).resolve().parents[4]
+    try:
+        result = subprocess.run(
+            ("git", "-C", str(repository_root), "rev-parse", "HEAD"),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(
+            "cannot resolve deployed HEAD from the loaded source tree"
+        ) from exc
+    resolved = result.stdout.strip().lower()
+    if len(resolved) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in resolved
+    ):
+        raise RuntimeError(f"invalid deployed HEAD returned by git: {resolved!r}")
+    return resolved
 
 
 def assert_rest_target(path: str) -> None:
@@ -312,6 +339,17 @@ class AppendOnlyPITStore:
         row = self._db.execute(
             """
             SELECT MIN(event_time) AS event_time
+            FROM pit_records
+            WHERE source = ? AND symbol = ?
+            """,
+            (source, symbol),
+        ).fetchone()
+        return row["event_time"] if row is not None else None
+
+    def latest_event_time(self, source: str, symbol: str) -> str | None:
+        row = self._db.execute(
+            """
+            SELECT MAX(event_time) AS event_time
             FROM pit_records
             WHERE source = ? AND symbol = ?
             """,
@@ -494,6 +532,7 @@ class BinanceR4P0Collector:
         self.session_counts: Counter[str] = Counter()
         self.duplicate_counts: Counter[str] = Counter()
         self.failure_counts: Counter[str] = Counter()
+        self.code_hash = runtime_code_hash()
         self._previous_sequence: dict[tuple[str, str], int] = {}
         self._seen_on_connection: set[tuple[str, str, str]] = set()
         self._last_book_snapshot: dict[str, dt.datetime] = {}
@@ -519,9 +558,18 @@ class BinanceR4P0Collector:
         self._last_epoch_retry: dt.datetime | None = None
 
     async def run(self) -> None:
+        started_at = utc_now()
+        self.epoch_ledger.append_process_version(
+            collector_instance_id=self.config.collector_instance_id,
+            run_id=self.run_id,
+            started_at=started_at,
+            code_hash=self.code_hash,
+            collector_version=COLLECTOR_VERSION,
+        )
         log.info(
-            "collector.start run_id=%s symbols=%s artifact=%s",
+            "collector.start run_id=%s code_hash=%s symbols=%s artifact=%s",
             self.run_id,
+            self.code_hash,
             ",".join(self.config.symbols),
             self.store.path,
         )
@@ -578,6 +626,8 @@ class BinanceR4P0Collector:
             "failures": dict(self.failure_counts),
             "session_counts": dict(self.session_counts),
             "duplicate_counts": dict(self.duplicate_counts),
+            "code_hash": self.code_hash,
+            "collector_version": COLLECTOR_VERSION,
         }
 
     async def _duration_timer(self) -> None:
@@ -625,6 +675,7 @@ class BinanceR4P0Collector:
                 self.epoch_policy,
                 observed_at=observed_at,
                 stale_after_seconds=self.config.heartbeat_stale_seconds,
+                expected_code_hash=self.code_hash,
             )
             if (
                 availability["healthy_replica_count"]
@@ -1309,8 +1360,32 @@ class BinanceR4P0Collector:
         path = "/fapi/v1/premiumIndexKlines"
         assert_rest_target(path)
         started = utc_now()
-        params = {"symbol": symbol, "interval": "1m", "limit": 2}
         target_epoch = decision_epoch or decision_epoch_for_event(started)
+        source = "binance_usdm.premiumIndexKline1m"
+        latest_event_time = self.store.latest_event_time(source, symbol)
+        latest_event_ms: int | None = None
+        params: dict[str, Any] = {"symbol": symbol, "interval": "1m", "limit": 2}
+        if latest_event_time is not None:
+            latest_event = dt.datetime.fromisoformat(
+                latest_event_time.replace("Z", "+00:00")
+            )
+            latest_event_ms = int(latest_event.timestamp() * 1000)
+            interval_start = target_epoch - dt.timedelta(hours=4)
+            request_end_ms = min(
+                int(started.timestamp() * 1000),
+                int(target_epoch.timestamp() * 1000) - 1,
+            )
+            request_start_ms = max(
+                int(interval_start.timestamp() * 1000),
+                min(latest_event_ms + 1, request_end_ms),
+            )
+            params = {
+                "symbol": symbol,
+                "interval": "1m",
+                "startTime": request_start_ms,
+                "endTime": request_end_ms,
+                "limit": 500,
+            }
         attempt_id = self._begin_rest_attempt(
             decision_epoch=target_epoch,
             attempted_at=started,
@@ -1340,24 +1415,43 @@ class BinanceR4P0Collector:
                 and int(row[6]) <= completed_ms
             ]
             if not complete_rows:
-                raise ValueError(f"no completed 1m row from allowlisted path {path}")
-            item = complete_rows[-1]
-            source = "binance_usdm.premiumIndexKline1m"
-            inserted = self.store.append(
-                source=source,
-                symbol=symbol,
-                raw_payload=item,
-                local_receive_time=completed,
-                run_id=self.run_id,
-                event_time=epoch_ms(item[6]),
-                transaction_time=epoch_ms(item[6]),
-                request_started_at=iso_utc(started),
-                request_completed_at=iso_utc(completed),
-                sequence_or_trade_id=str(item[0]),
-                gap_detected=False,
-                reconnect_id=f"{self.run_id}:rest:{path}",
-            )
-            self._count_result(source, inserted)
+                if latest_event_ms is None:
+                    raise ValueError(
+                        f"no completed 1m row from allowlisted path {path}"
+                    )
+            elif latest_event_ms is None:
+                # Establish the live collection floor without seed backfill.
+                complete_rows = [max(complete_rows, key=lambda row: int(row[6]))]
+            else:
+                interval_start_ms = int(
+                    (target_epoch - dt.timedelta(hours=4)).timestamp() * 1000
+                )
+                interval_end_ms = int(target_epoch.timestamp() * 1000)
+                complete_rows = [
+                    row
+                    for row in complete_rows
+                    if latest_event_ms < int(row[6])
+                    and interval_start_ms <= int(row[6]) < interval_end_ms
+                ]
+
+            inserted_count = 0
+            for item in sorted(complete_rows, key=lambda row: int(row[6])):
+                inserted = self.store.append(
+                    source=source,
+                    symbol=symbol,
+                    raw_payload=item,
+                    local_receive_time=completed,
+                    run_id=self.run_id,
+                    event_time=epoch_ms(item[6]),
+                    transaction_time=epoch_ms(item[6]),
+                    request_started_at=iso_utc(started),
+                    request_completed_at=iso_utc(completed),
+                    sequence_or_trade_id=str(item[0]),
+                    gap_detected=False,
+                    reconnect_id=f"{self.run_id}:rest:{path}",
+                )
+                self._count_result(source, inserted)
+                inserted_count += int(inserted)
         except Exception as exc:
             self._append_rest_attempt(
                 decision_epoch=target_epoch,
@@ -1385,7 +1479,7 @@ class BinanceR4P0Collector:
             symbol=symbol,
             sources=("binance_usdm.premiumIndexKline1m",),
             response_hash=response_hash,
-            terminal_status="SUCCESS" if inserted else "EXACT_DUPLICATE",
+            terminal_status="SUCCESS" if inserted_count else "EXACT_DUPLICATE",
             attempt_id=attempt_id,
         )
 

--- a/app/services/brokers/binance/r4_p0_hardening.py
+++ b/app/services/brokers/binance/r4_p0_hardening.py
@@ -354,6 +354,23 @@ class EpochLedger:
                 study_id, policy_hash, collector_instance_id, append_id
             );
 
+        CREATE TABLE IF NOT EXISTS collector_process_versions (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            version_stamp_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            collector_instance_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            code_hash TEXT NOT NULL,
+            collector_version TEXT NOT NULL,
+            UNIQUE (study_id, policy_hash, collector_instance_id, run_id)
+        );
+        CREATE INDEX IF NOT EXISTS ix_collector_process_version_latest
+            ON collector_process_versions (
+                study_id, policy_hash, collector_instance_id, append_id
+            );
+
         CREATE TABLE IF NOT EXISTS collector_alert_events (
             append_id INTEGER PRIMARY KEY AUTOINCREMENT,
             alert_event_id TEXT NOT NULL UNIQUE,
@@ -377,6 +394,7 @@ class EpochLedger:
             + _trigger_sql("symbol_epoch_finalizations")
             + _trigger_sql("late_only_corrections")
             + _trigger_sql("collector_heartbeats")
+            + _trigger_sql("collector_process_versions")
             + _trigger_sql("collector_alert_events")
         )
         attempt_columns = {
@@ -577,6 +595,35 @@ class EpochLedger:
                 iso_utc(observed_at),
                 sha256_text(health_json),
                 health_json,
+            ),
+        )
+        self.db.commit()
+
+    def append_process_version(
+        self,
+        *,
+        collector_instance_id: str,
+        run_id: str,
+        started_at: dt.datetime,
+        code_hash: str,
+        collector_version: str,
+    ) -> None:
+        self.db.execute(
+            """
+            INSERT INTO collector_process_versions (
+                version_stamp_id, study_id, policy_hash, collector_instance_id,
+                run_id, started_at, code_hash, collector_version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                uuid.uuid4().hex,
+                self.policy.study_id,
+                self.policy.policy_hash,
+                collector_instance_id,
+                run_id,
+                iso_utc(started_at),
+                code_hash,
+                collector_version,
             ),
         )
         self.db.commit()
@@ -1275,46 +1322,109 @@ def latest_heartbeat(path: Path, policy: EpochPolicy) -> dict[str, Any] | None:
     return dict(row) if row is not None else None
 
 
+def latest_process_version(
+    path: Path,
+    policy: EpochPolicy,
+    *,
+    run_id: str | None = None,
+) -> dict[str, Any] | None:
+    path = path.expanduser().resolve()
+    if not path.is_file():
+        return None
+    uri = f"file:{urllib.parse.quote(str(path))}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            connection.row_factory = sqlite3.Row
+            sql = """
+                SELECT * FROM collector_process_versions
+                WHERE study_id = ? AND policy_hash = ?
+            """
+            params = [policy.study_id, policy.policy_hash]
+            if run_id is not None:
+                sql += " AND run_id = ?"
+                params.append(run_id)
+            sql += " ORDER BY append_id DESC LIMIT 1"
+            row = connection.execute(sql, params).fetchone()
+    except sqlite3.Error:
+        return None
+    return dict(row) if row is not None else None
+
+
 def availability_report(
     artifact_paths: Sequence[Path],
     policy: EpochPolicy,
     *,
     observed_at: dt.datetime,
     stale_after_seconds: float,
+    expected_code_hash: str | None = None,
 ) -> dict[str, Any]:
     replicas: list[dict[str, Any]] = []
     fresh_instance_ids: set[str] = set()
     instance_path_counts: dict[str, int] = defaultdict(int)
+    unstamped_artifacts: list[str] = []
+    version_mismatches: list[dict[str, str]] = []
     for path in sorted(
         {item.expanduser().resolve() for item in artifact_paths}, key=str
     ):
         heartbeat = latest_heartbeat(path, policy)
         if heartbeat is None:
             replicas.append({"artifact": str(path), "status": "UNAVAILABLE"})
+            if expected_code_hash is not None:
+                unstamped_artifacts.append(str(path))
             continue
         age = (observed_at - parse_utc(heartbeat["observed_at"])).total_seconds()
         status = "HEALTHY" if 0 <= age <= stale_after_seconds else "STALE"
+        version = latest_process_version(path, policy, run_id=heartbeat["run_id"])
+        if expected_code_hash is not None:
+            if version is None:
+                status = "VERSION_UNSTAMPED"
+                unstamped_artifacts.append(str(path))
+            elif version["code_hash"] != expected_code_hash:
+                status = "VERSION_MISMATCH"
+                version_mismatches.append(
+                    {
+                        "actual_code_hash": version["code_hash"],
+                        "artifact": str(path),
+                        "expected_code_hash": expected_code_hash,
+                    }
+                )
         if status == "HEALTHY":
             fresh_instance_ids.add(heartbeat["collector_instance_id"])
             instance_path_counts[heartbeat["collector_instance_id"]] += 1
-        replicas.append(
-            {
-                "age_seconds": age,
-                "artifact": str(path),
-                "collector_instance_id": heartbeat["collector_instance_id"],
-                "observed_at": heartbeat["observed_at"],
-                "status": status,
-            }
-        )
+        replica = {
+            "age_seconds": age,
+            "artifact": str(path),
+            "collector_instance_id": heartbeat["collector_instance_id"],
+            "observed_at": heartbeat["observed_at"],
+            "status": status,
+        }
+        if version is not None:
+            replica.update(
+                {
+                    "code_hash": version["code_hash"],
+                    "collector_version": version["collector_version"],
+                    "version_run_id": version["run_id"],
+                    "version_started_at": version["started_at"],
+                }
+            )
+        replicas.append(replica)
     return {
         "duplicate_collector_instance_ids": sorted(
             instance_id
             for instance_id, count in instance_path_counts.items()
             if count > 1
         ),
+        "expected_code_hash": expected_code_hash,
         "healthy_replica_count": len(fresh_instance_ids),
         "observed_at": iso_utc(observed_at),
         "replicas": replicas,
+        "unstamped_artifacts": sorted(set(unstamped_artifacts)),
+        "version_mismatches": version_mismatches,
+        "version_stamp_match": (
+            None
+            if expected_code_hash is None
+            else not unstamped_artifacts and not version_mismatches
+        ),
     }
 
 

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -4,7 +4,8 @@ This is a manual, research-artifact-only point-in-time collector. It never
 writes the production database and is not registered with TaskIQ, cron, or
 Prefect. ROB-1108 adds epoch finalization, deadline recovery, independent
 replica awareness, and fail-fast alerting without changing feature, score,
-candidate, or stage-decision logic.
+candidate, or stage-decision logic. DFC-4H 1.5 advances the collector to
+`r4-p0-collector.v4`.
 
 ## Hard boundary
 
@@ -51,6 +52,13 @@ recovery path from acting as seed backfill. Any absence still unresolved at
 epoch finalization is `FINAL_MISSING`; two different canonical payloads for the
 same source identity are `FINAL_CONFLICT`, never last-write-wins
 `FINAL_COMPLETE`.
+
+The premium-index 1-minute poll establishes its live floor with the latest
+completed row. Every later poll requests the bounded range after the last
+stored close through the current request time, capped by the active four-hour
+contract window. A loop longer than 60 seconds therefore replays every missed
+completed slot instead of keeping only the newest row. The epoch supervisor
+remains the recovery path for a slot in the just-closed window.
 
 ## Modes
 
@@ -99,7 +107,7 @@ All persistence uses INSERT; database triggers reject UPDATE and DELETE.
 `record_id` is a semantic unique key, so replayed websocket events and
 unchanged REST periods are ignored after restart.
 
-ROB-1108 adds seven tables to the same local artifact. Every table has
+ROB-1108 and DFC-4H 1.5 add eight tables to the same local artifact. Every table has
 UPDATE/DELETE rejection triggers:
 
 - `epoch_source_events`: one immutable `OPEN` event per
@@ -116,6 +124,8 @@ UPDATE/DELETE rejection triggers:
 - `late_only_corrections`: observations received after the deadline. These
   never rewrite a finalization.
 - `collector_heartbeats`: append-only replica liveness evidence.
+- `collector_process_versions`: one append-only startup stamp per run with the
+  exact Git commit hash and collector version loaded by that process.
 - `collector_alert_events`: alert creation and each delivery result; failed
   delivery attempts are not overwritten.
 
@@ -128,8 +138,10 @@ silently reuse another finalization key.
 allows either every change or 1s snapshots); raw aggTrade, forceOrder snapshots,
 and top-5 depth updates are not sampled.
 
-The premium poll stores the live mark/index/predicted-funding snapshot and the
-latest completed 1-minute premium-index kline. An in-progress kline whose close
+The premium poll stores the live mark/index/predicted-funding snapshot and every
+completed 1-minute premium-index kline after the last stored close in the active
+contract window. The first observation still stores only the latest completed
+row, so this path cannot become seed backfill. An in-progress kline whose close
 time is after `request_completed_at` is rejected, so downstream PIT consumers
 cannot accidentally use its future close.
 
@@ -238,6 +250,14 @@ uv run python -m scripts.r4_p0_watchdog --run \
   --minimum-healthy-replicas 2
 ```
 
+At collector startup, `git rev-parse HEAD` is resolved from the loaded source
+tree and written to `collector_process_versions` before collection tasks start.
+The watchdog resolves its own deployed HEAD and compares it with the stamp tied
+to each current heartbeat `run_id`. Missing stamps and hash mismatches are
+`COLLECTOR_VERSION_MISMATCH`, remove that replica from the healthy count, and
+fail the rehearsal version gate. A checkout without resolvable Git metadata
+fails closed rather than starting an unstamped collector.
+
 The alert path is:
 
 ```text
@@ -245,6 +265,7 @@ epoch deadline risk (last hour) -> append-only alert ledger -> CRITICAL/WARNING 
                                                      \-> HTTPS webhook(s)
 final MISSING/CONFLICT --------> DATA_INTEGRITY_FAIL through the same path
 stale replica/finalizer --------> independent watchdog through the same path
+missing/mismatched code stamp --> COLLECTOR_VERSION_MISMATCH through the same path
 ```
 
 Logging is formatted in real UTC before adding the `Z` suffix. Webhook delivery
@@ -277,4 +298,5 @@ uv run python -m scripts.r4_p0_watchdog \
 Before T_WEEK0, the operator-owned one-week rehearsal must use the same source
 manifest, two-host topology, finalizer, and alert route. Acceptance is 100%
 `FINAL_COMPLETE`, zero `FINAL_MISSING`, zero `FINAL_CONFLICT`, zero stalled
-finalizers, and demonstrated page delivery under injected process/host loss.
+finalizers, a matching process-version stamp on both current collector run IDs,
+and demonstrated page delivery under injected process/host loss.

--- a/scripts/r4_p0_collector.py
+++ b/scripts/r4_p0_collector.py
@@ -25,6 +25,7 @@ from app.services.brokers.binance.r4_p0_collector import (
     BinanceR4P0Collector,
     CollectorConfig,
     redact_sample,
+    runtime_code_hash,
 )
 
 ENABLED_ENV = "R4_P0_COLLECTOR_ENABLED"
@@ -110,6 +111,7 @@ def _dry_run_payload(args: argparse.Namespace) -> dict[str, object]:
         "database_write": False,
         "broker_mutation": False,
         "collector_version": COLLECTOR_VERSION,
+        "code_hash": runtime_code_hash(),
         "symbols": list(SYMBOLS),
         "signal_symbols": ["XRPUSDT", "DOGEUSDT", "SOLUSDT"],
         "predictor_only_symbols": ["BTCUSDT"],

--- a/scripts/r4_p0_watchdog.py
+++ b/scripts/r4_p0_watchdog.py
@@ -20,6 +20,7 @@ from app.services.brokers.binance.r4_p0_collector import (
     REQUIRED_ACTIVE_SOURCES,
     SIGNAL_SYMBOLS,
     AppendOnlyPITStore,
+    runtime_code_hash,
     utc_now,
 )
 from app.services.brokers.binance.r4_p0_hardening import (
@@ -85,6 +86,7 @@ def _policy() -> EpochPolicy:
 
 async def _watch(args: argparse.Namespace) -> int:
     policy = _policy()
+    expected_code_hash = runtime_code_hash()
     artifact_paths = tuple(Path(path) for path in args.artifact)
     stop = asyncio.Event()
     loop = asyncio.get_running_loop()
@@ -105,7 +107,22 @@ async def _watch(args: argparse.Namespace) -> int:
                 policy,
                 observed_at=now,
                 stale_after_seconds=args.stale_after_seconds,
+                expected_code_hash=expected_code_hash,
             )
+            if not availability["version_stamp_match"]:
+                await dispatcher.emit(
+                    alert_key=(
+                        "COLLECTOR_VERSION_MISMATCH:"
+                        f"{policy.study_id}:{policy.policy_hash}:"
+                        f"{int(now.timestamp()) // 900}"
+                    ),
+                    severity="CRITICAL",
+                    payload={
+                        "alert_type": "COLLECTOR_VERSION_MISMATCH",
+                        **availability,
+                    },
+                    now=now,
+                )
             if availability["healthy_replica_count"] < args.minimum_healthy_replicas:
                 await dispatcher.emit(
                     alert_key=(
@@ -170,6 +187,7 @@ def main() -> int:
         "artifacts": [str(Path(path).expanduser()) for path in args.artifact],
         "broker_mutation": False,
         "database_write": bool(args.run),
+        "expected_code_hash": runtime_code_hash(),
         "minimum_healthy_replicas": args.minimum_healthy_replicas,
         "mode": "run" if args.run else "dry_run",
         "network": bool(args.run and _alert_webhook_urls()),

--- a/tests/test_binance_r4_p0_collector.py
+++ b/tests/test_binance_r4_p0_collector.py
@@ -7,6 +7,7 @@ import sqlite3
 import httpx
 import pytest
 
+from app.services.brokers.binance import r4_p0_collector as collector_module
 from app.services.brokers.binance.r4_p0_collector import (
     BASIS_RECOVERY_LIMIT,
     PIT_COLUMNS,
@@ -218,6 +219,90 @@ async def test_premium_kline_persists_only_a_completed_period(tmp_path) -> None:
         assert row["source"] == "binance_usdm.premiumIndexKline1m"
         assert json.loads(row["raw_payload"]) == closed
         assert row["event_time"] == row["transaction_time"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_premium_kline_long_poll_recovers_every_completed_slot(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = dt.datetime(2026, 7, 29, tzinfo=dt.UTC)
+    clock = iter(
+        (
+            base + dt.timedelta(minutes=1, seconds=10),
+            base + dt.timedelta(minutes=1, seconds=11),
+            base + dt.timedelta(minutes=4, seconds=10),
+            base + dt.timedelta(minutes=4, seconds=11),
+        )
+    )
+    monkeypatch.setattr(collector_module, "utc_now", lambda: next(clock))
+    calls = 0
+
+    def kline(minute: int) -> list[object]:
+        opened = base + dt.timedelta(minutes=minute)
+        closed = opened + dt.timedelta(minutes=1) - dt.timedelta(milliseconds=1)
+        return [
+            int(opened.timestamp() * 1000),
+            "0.1",
+            "0.2",
+            "0.0",
+            "0.1",
+            "0",
+            int(closed.timestamp() * 1000),
+        ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            assert dict(request.url.params) == {
+                "symbol": "XRPUSDT",
+                "interval": "1m",
+                "limit": "2",
+            }
+            return httpx.Response(200, json=[kline(0), kline(1)])
+        if "startTime" not in request.url.params:
+            # Current HEAD's latest-two request permanently skips minutes 1 and 2.
+            return httpx.Response(200, json=[kline(3), kline(4)])
+        assert request.url.params["startTime"] == str(kline(0)[6] + 1)
+        return httpx.Response(
+            200,
+            json=[kline(1), kline(2), kline(3), kline(4)],
+        )
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(artifact_root=tmp_path, symbols=("XRPUSDT",)),
+            store,
+        )
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._rest_premium_kline(  # noqa: SLF001
+                client, symbol="XRPUSDT"
+            )
+            await collector._rest_premium_kline(  # noqa: SLF001
+                client, symbol="XRPUSDT"
+            )
+
+        rows = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT event_time
+                FROM pit_records
+                WHERE source = 'binance_usdm.premiumIndexKline1m'
+                ORDER BY event_time
+                """
+            )
+        )
+        assert [row["event_time"] for row in rows] == [
+            "2026-07-29T00:00:59.999000Z",
+            "2026-07-29T00:01:59.999000Z",
+            "2026-07-29T00:02:59.999000Z",
+            "2026-07-29T00:03:59.999000Z",
+        ]
 
 
 @pytest.mark.unit

--- a/tests/test_binance_r4_p0_hardening.py
+++ b/tests/test_binance_r4_p0_hardening.py
@@ -10,6 +10,7 @@ import pytest
 from app.services.brokers.binance import r4_p0_collector as collector_module
 from app.services.brokers.binance.r4_p0_collector import (
     AppendOnlyPITStore,
+    BasisPollError,
     BinanceR4P0Collector,
     CollectorConfig,
 )
@@ -288,6 +289,159 @@ async def test_partial_periodic_coverage_triggers_historical_retry(
             )
 
         assert calls == [("binance_usdm.basis", "XRPUSDT")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_exception", "terminal_status"),
+    (
+        ("empty", BasisPollError, "INVALID_RESPONSE"),
+        ("http", httpx.HTTPStatusError, "HTTP_ERROR"),
+    ),
+)
+async def test_basis_failure_recovers_only_inside_epoch_contract_window(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+    expected_exception: type[Exception],
+    terminal_status: str,
+) -> None:
+    recovery_time = EPOCH + dt.timedelta(hours=1)
+    clock = iter((RECEIVED, RECEIVED, recovery_time, recovery_time))
+    monkeypatch.setattr(collector_module, "utc_now", lambda: next(clock))
+    interval_start = EPOCH - dt.timedelta(hours=4)
+    calls = 0
+
+    def basis_row(event_time: dt.datetime) -> dict[str, object]:
+        return {
+            "basis": str(event_time.timestamp()),
+            "contractType": "PERPETUAL",
+            "pair": "XRPUSDT",
+            "timestamp": int(event_time.timestamp() * 1000),
+        }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            assert "startTime" not in request.url.params
+            if failure_kind == "empty":
+                return httpx.Response(200, json=[])
+            return httpx.Response(503, text="provider unavailable")
+
+        assert request.url.params["startTime"] == str(
+            int(interval_start.timestamp() * 1000)
+        )
+        assert request.url.params["endTime"] == str(int(EPOCH.timestamp() * 1000) - 1)
+        return httpx.Response(
+            200,
+            json=[
+                basis_row(interval_start - dt.timedelta(minutes=5)),
+                *[
+                    basis_row(interval_start + dt.timedelta(minutes=5 * index))
+                    for index in range(48)
+                ],
+                basis_row(EPOCH),
+            ],
+        )
+
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        ledger, finalizer = _finalizer(store, policy=policy)
+        collector.epoch_policy = policy
+        collector.epoch_ledger = ledger
+        collector.epoch_finalizer = finalizer
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with pytest.raises(expected_exception):
+                await collector._poll_family(client, "basis")  # noqa: SLF001
+            await collector._retry_incomplete_epoch(  # noqa: SLF001
+                client,
+                EPOCH,
+                recovery_time,
+            )
+
+        rows = list(
+            store._db.execute(  # noqa: SLF001
+                """
+                SELECT event_time
+                FROM pit_records
+                WHERE source = 'binance_usdm.basis'
+                ORDER BY event_time
+                """
+            )
+        )
+        assert len(rows) == 48
+        assert rows[0]["event_time"] == "2026-07-28T04:00:00.000000Z"
+        assert rows[-1]["event_time"] == "2026-07-28T07:55:00.000000Z"
+        assert finalizer.preview("XRPUSDT", EPOCH).final_status == FINAL_COMPLETE
+        statuses = [
+            row["terminal_status"]
+            for row in store._db.execute(  # noqa: SLF001
+                "SELECT terminal_status FROM collector_attempts ORDER BY append_id"
+            )
+        ]
+        assert statuses == [terminal_status, "SUCCESS"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_basis_recovery_never_starts_at_or_after_deadline(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("deadline-expired recovery must not call the provider")
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        ledger, finalizer = _finalizer(store, policy=policy)
+        collector.epoch_policy = policy
+        collector.epoch_ledger = ledger
+        collector.epoch_finalizer = finalizer
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._retry_incomplete_epoch(  # noqa: SLF001
+                client,
+                EPOCH,
+                finalize_at(EPOCH),
+            )
+
+        attempt = store._db.execute(  # noqa: SLF001
+            "SELECT terminal_status, request_identity_json FROM collector_attempts"
+        ).fetchone()
+        assert attempt["terminal_status"] == "DEADLINE_EXPIRED"
+        assert json.loads(attempt["request_identity_json"]) == {
+            "method": "GET",
+            "source_name": "binance_usdm.basis",
+            "symbol": "XRPUSDT",
+            "target": "deadline-recovery",
+        }
 
 
 @pytest.mark.unit
@@ -701,6 +855,88 @@ async def test_retry_failures_are_logged_counted_and_preserve_diagnostics(
             assert "500 Internal Server Error" in attempt["error_message"]
             assert "httpx.HTTPStatusError" in attempt["error_traceback"]
             assert attempt["response_body_summary"] == "provider failed: incident-247"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_collector_start_stamps_runtime_code_hash(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    code_hash = "a" * 40
+    monkeypatch.setattr(collector_module, "runtime_code_hash", lambda: code_hash)
+    monkeypatch.setattr(collector_module, "utc_now", lambda: RECEIVED)
+
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        collector.stop.set()
+        await collector.run()
+
+        stamp = store._db.execute(  # noqa: SLF001
+            "SELECT * FROM collector_process_versions"
+        ).fetchone()
+        assert stamp["collector_instance_id"] == "replica-a"
+        assert stamp["run_id"] == collector.run_id
+        assert stamp["started_at"] == "2026-07-28T07:01:00.000000Z"
+        assert stamp["code_hash"] == code_hash
+        assert stamp["collector_version"] == collector_module.COLLECTOR_VERSION
+
+
+@pytest.mark.unit
+def test_watchdog_availability_detects_deployed_head_mismatch(tmp_path) -> None:
+    expected_code_hash = "a" * 40
+    stores: list[AppendOnlyPITStore] = []
+    try:
+        for name, code_hash in (("a", expected_code_hash), ("b", "b" * 40)):
+            store = AppendOnlyPITStore(tmp_path / name)
+            stores.append(store)
+            ledger = EpochLedger(store._db, POLICY)  # noqa: SLF001
+            ledger.append_process_version(
+                collector_instance_id=f"replica-{name}",
+                run_id=f"run-{name}",
+                started_at=RECEIVED,
+                code_hash=code_hash,
+                collector_version=collector_module.COLLECTOR_VERSION,
+            )
+            ledger.append_heartbeat(
+                collector_instance_id=f"replica-{name}",
+                run_id=f"run-{name}",
+                observed_at=RECEIVED,
+                health={"ok": True},
+            )
+
+        report = availability_report(
+            [store.path for store in stores],
+            POLICY,
+            observed_at=RECEIVED + dt.timedelta(seconds=30),
+            stale_after_seconds=60,
+            expected_code_hash=expected_code_hash,
+        )
+
+        assert report["healthy_replica_count"] == 1
+        assert report["version_stamp_match"] is False
+        assert report["unstamped_artifacts"] == []
+        assert report["version_mismatches"] == [
+            {
+                "actual_code_hash": "b" * 40,
+                "artifact": str(stores[1].path),
+                "expected_code_hash": expected_code_hash,
+            }
+        ]
+        assert [replica["status"] for replica in report["replicas"]] == [
+            "HEALTHY",
+            "VERSION_MISMATCH",
+        ]
+    finally:
+        for store in stores:
+            store.close()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Reproduced the PIK long-loop gap on origin/main ab6642670, then changed the v4 live poll to fetch the bounded range after the last stored close inside the active four-hour contract window.
- Confirmed BAS does not reproduce on current HEAD: #1695 supplies bounded live replay and symbol isolation, while #1697 supplies exact epoch-window recovery. Added empty-response and HTTP-error regressions without applying a second BAS correction.
- Added append-only collector startup stamps containing the running Git commit and collector version. The independent watchdog compares each current heartbeat run stamp with its deployed HEAD, removes mismatches from healthy replica count, and emits COLLECTOR_VERSION_MISMATCH.
- Updated the runbook so matching process-version stamps are an explicit rehearsal acceptance gate.

## Verification

- PIK regression: 1 passed
- BAS empty/HTTP plus deadline boundary regressions: 3 passed
- Version startup stamp and watchdog mismatch regressions: 2 passed
- R4 collector/hardening suites: 35 passed in 3.19s
- make lint: Ruff check, Ruff format check, and ty all passed
- Collector dry-run reports v4 and commit 1416c565b465cce37124ea7e1dd092cc01ef755e

## Safety

No collector restart or stop, no two-host rehearsal, no deployment, no broker/order mutation, no Linear mutation, and no existing seal or data changes.