### PR TITLE
feat(ROB-1145): --strategy selector + first signal-emitting demo plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,11 +160,21 @@ scans `app/**/*.py` for forbidden provider imports and deleted provider files.
 별도 커밋(미포함), 기본 플러그인 `NullStrategy`는 항상 `None`.
 
 - **패키지**: `app/services/brokers/binance/demo_strategy_loop/` — `bars.py`(H1 재사용 + 1m fetch),
-  `strategy.py`(`Signal`/`StrategyPlugin`/`NullStrategy`), `kill_switch.py`(최대동시포지션1 +
+  `strategy.py`(`Signal`/`StrategyPlugin`/`NullStrategy`/`LastBarDirectionStrategy`),
+  `registry.py`(ROB-1145 `--strategy` 셀렉터), `kill_switch.py`(최대동시포지션1 +
   연속 SL/UTC일), `sizing.py`, `execution.py`(open MARKET + reduceOnly close round-trip, ROB-298
   smoke CLI와 동일 lifecycle), `correlation.py`, `orchestrator.py`(`run_tick`)
 - **CLI**: `scripts/binance_demo_strategy_loop.py` (default-disabled, `--once`/`--loop`/
   `--paper-signal`/`--readiness`) — `--paper-signal`이 ROB-993 e2e 스모크 경로(주문 1건 데모 왕복)
+- **전략 셀렉터(ROB-1145)**: `--strategy <key>` — 기본 `null`(=`NullStrategy`, 신호 0건, 제거되지 않음),
+  opt-in `last-bar-direction`(=`LastBarDirectionStrategy`). 미등록 키는 `UnknownStrategyKey`로
+  자격증명 읽기·HTTP·DB **이전에** fail-closed(exit 1). 플러그인은 `(symbol, side)`만 제안 —
+  하드 인바리언트는 전부 하류(`sizing`/`kill_switch`/`execution`)에 있고 플러그인에서 도달 불가.
+  `last-bar-direction`은 **알파가 아니라 인프라 증명**(직전 완결 4h bar의 close vs open 방향, 파라미터·
+  상태·룩백 없음, 기대수익 주장 없음 — ROB-316 OOS gross-negative 교훈 때문에 기본값이 아니다).
+- **`--readiness` 범위(ROB-1145 실측)**: `BINANCE_DEMO_STRATEGY_LOOP_ENABLED` + `--strategy` 키만
+  검사한다. **자격증명을 전혀 확인하지 않는다** — readiness exit 0은 `BINANCE_DEMO_API_*` 해석·
+  계정 도달 가능성의 증거가 아니다. 그 확인은 `scripts.binance_futures_demo_smoke --preflight`(서명 read).
 - **env**: `BINANCE_DEMO_STRATEGY_LOOP_ENABLED`(기본 false) — 기존 `BINANCE_FUTURES_DEMO_*`
   자격증명/호스트 allowlist 그대로 상속, 신규 자격증명 표면 없음
 - **kill switch**: env 게이트 + 동시 포지션 1 상한(`count_open_lifecycles` 재사용) + 연속 SL 2회/UTC일

--- a/app/services/brokers/binance/demo_strategy_loop/registry.py
+++ b/app/services/brokers/binance/demo_strategy_loop/registry.py
@@ -1,0 +1,65 @@
+"""ROB-1145 — strategy plugin registry for the Binance Demo strategy loop.
+
+Before this module the plugin was hardcoded at the CLI call site
+(``strategy=NullStrategy()`` in ``scripts/binance_demo_strategy_loop.py``),
+so swapping a plugin meant editing code. The registry turns that into a
+``--strategy <key>`` selector.
+
+Deliberate properties:
+
+* **``NullStrategy`` stays the default.** ``DEFAULT_STRATEGY_KEY`` is
+  ``"null"``; a caller that passes nothing keeps the ROB-993 behaviour of
+  never emitting a signal. The selector adds a way to opt IN to a
+  signal-emitting plugin, it never changes the default posture.
+* **Fail closed on an unknown key.** ``build_strategy`` raises
+  ``UnknownStrategyKey`` rather than falling back to some plugin — a typo
+  must stop the run, not silently trade a different strategy.
+* **No safety dial.** A plugin only proposes ``(symbol, side)``. Leg
+  notional ``[6, 10]`` USDT, the one-concurrent-position and
+  two-consecutive-stop-loss caps, 1x leverage, the reduceOnly close and
+  the ``demo-fapi.binance.com`` host allowlist are all enforced
+  downstream in ``sizing``/``kill_switch``/``execution`` and are not
+  reachable from here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from .strategy import LastBarDirectionStrategy, NullStrategy, StrategyPlugin
+
+DEFAULT_STRATEGY_KEY = "null"
+
+_FACTORIES: Mapping[str, Callable[[], StrategyPlugin]] = {
+    "null": NullStrategy,
+    "last-bar-direction": LastBarDirectionStrategy,
+}
+
+
+class UnknownStrategyKey(ValueError):
+    """Raised for a ``--strategy`` key that is not registered."""
+
+
+def available_strategy_keys() -> tuple[str, ...]:
+    """Registered keys, default first then the rest sorted (stable for
+    ``--help`` output and for argparse ``choices``)."""
+    rest = sorted(key for key in _FACTORIES if key != DEFAULT_STRATEGY_KEY)
+    return (DEFAULT_STRATEGY_KEY, *rest)
+
+
+def build_strategy(key: str | None = None) -> StrategyPlugin:
+    """Instantiate the registered plugin for ``key``.
+
+    ``None`` resolves to :data:`DEFAULT_STRATEGY_KEY` (``NullStrategy``).
+    An unregistered key raises :class:`UnknownStrategyKey` — never a
+    silent fallback.
+    """
+    resolved = DEFAULT_STRATEGY_KEY if key is None else key.strip().lower()
+    try:
+        factory = _FACTORIES[resolved]
+    except KeyError as exc:
+        raise UnknownStrategyKey(
+            f"unknown strategy {key!r} — registered keys: "
+            f"{', '.join(available_strategy_keys())}"
+        ) from exc
+    return factory()

--- a/app/services/brokers/binance/demo_strategy_loop/strategy.py
+++ b/app/services/brokers/binance/demo_strategy_loop/strategy.py
@@ -10,6 +10,11 @@ ROB-980) is a separate, later commit — deliberately not implemented here.
 ``NullStrategy`` is the safe default (always ``None``); it lets the loop's
 infra (bar aggregation, kill switch, execution wiring) be exercised and
 smoke-tested before any real strategy is plugged in.
+
+ROB-1145 adds ``LastBarDirectionStrategy`` — the first plugin that can
+actually emit a signal. It is an **infrastructure proof, not an alpha**
+(see its docstring); ``NullStrategy`` remains the CLI default and is
+selected by ``--strategy null``.
 """
 
 from __future__ import annotations
@@ -19,6 +24,10 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Literal, Protocol
 
+from app.services.brokers.binance.futures_demo.sizing import (
+    FUTURES_DEMO_EXCLUDED_SYMBOLS,
+    FUTURES_DEMO_FALLBACK_SYMBOLS,
+)
 from research.nautilus_scalping.rob974_features import Bar4h
 
 Side = Literal["BUY", "SELL"]
@@ -81,4 +90,82 @@ class NullStrategy:
         *,
         decision_ts: int,
     ) -> Signal | None:
+        return None
+
+
+# ROB-1145: the symbol priority the first non-null plugin walks. Ordered
+# view of ``FUTURES_DEMO_FALLBACK_SYMBOLS`` (a frozenset, so it carries no
+# order) with the lane's documented primary symbol first. This is NOT a new
+# allowlist surface: ``LastBarDirectionStrategy`` intersects it with the
+# canonical allowlist on every call, and ``orchestrator.run_tick``
+# independently re-runs ``assert_symbol_allowed`` on the emitted signal.
+LAST_BAR_DIRECTION_SYMBOL_PRIORITY: tuple[str, ...] = ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
+
+
+@dataclass(frozen=True)
+class LastBarDirectionStrategy:
+    """ROB-1145 — the loop's first signal-emitting plugin. **Not an alpha.**
+
+    Deliberately the simplest deterministic rule that consumes the bar
+    plane the loop hands it, so that "does the loop place an order on its
+    own?" can be answered without entangling it with signal research:
+
+      * pick the target symbol as the first entry of
+        ``symbol_priority`` that (a) is in the canonical futures-demo
+        allowlist and (b) has a complete 4h bar whose ``close_ts`` equals
+        ``decision_ts``;
+      * ``close > open`` -> ``BUY``, ``close < open`` -> ``SELL``,
+        ``close == open`` -> no signal.
+
+    No lookback beyond the single decision bar, no parameters, no
+    thresholds, no state — the same bar always produces the same signal.
+    It makes **no claim of expected return**; the ROB-316 lesson (an
+    OOS gross-negative micro-breakout signal) is exactly why this is
+    labelled infrastructure proof rather than a validated strategy, and
+    why it is not the CLI default (``NullStrategy`` still is).
+
+    Every hard lane invariant (leg notional ``[6, 10]`` USDT, one
+    concurrent position, two consecutive stop-losses, 1x leverage,
+    reduceOnly close, ``demo-fapi.binance.com``) lives downstream in
+    ``sizing``/``kill_switch``/``execution`` and is untouched by this
+    plugin — a plugin can only propose a symbol and a side.
+    """
+
+    strategy_id: str = "last-bar-direction"
+    symbol_priority: tuple[str, ...] = LAST_BAR_DIRECTION_SYMBOL_PRIORITY
+
+    def evaluate(
+        self,
+        bars_4h_multi_symbol: Mapping[str, tuple[Bar4h, ...]],
+        *,
+        decision_ts: int,
+    ) -> Signal | None:
+        for symbol in self.symbol_priority:
+            candidate = symbol.upper()
+            if candidate in FUTURES_DEMO_EXCLUDED_SYMBOLS:
+                continue
+            if candidate not in FUTURES_DEMO_FALLBACK_SYMBOLS:
+                continue
+            bars = bars_4h_multi_symbol.get(candidate)
+            if not bars:
+                continue
+            bar = bars[-1]
+            if bar.close_ts != decision_ts:
+                # H1 semantics: absence is NO_SIGNAL. Never reach further
+                # back for a stale bar to manufacture a decision.
+                continue
+            if bar.close == bar.open:
+                return None
+            side: Side = "BUY" if bar.close > bar.open else "SELL"
+            return Signal(
+                symbol=candidate,
+                side=side,
+                decision_ts=decision_ts,
+                strategy_id=self.strategy_id,
+                reason=(
+                    f"last complete 4h bar direction: open={bar.open} "
+                    f"close={bar.close} -> {side} (infrastructure proof, "
+                    "no expected-return claim)"
+                ),
+            )
         return None

--- a/docs/runbooks/binance-demo-strategy-loop.md
+++ b/docs/runbooks/binance-demo-strategy-loop.md
@@ -97,6 +97,16 @@ end-to-end, which is exactly the ROB-993 verification AC ("페이퍼
 **No new credential surface** — this loop reuses `BinanceFuturesDemoExecutionClient.from_env()`
 unchanged.
 
+> **`--readiness` scope (measured 2026-07-29, ROB-1145).** `--readiness`
+> asserts **only** `BINANCE_DEMO_STRATEGY_LOOP_ENABLED` (plus, since
+> ROB-1145, the `--strategy` key). It performs **no credential
+> resolution** — a `--readiness` exit 0 is *not* evidence that
+> `BINANCE_DEMO_API_*` resolves or that the Demo account is reachable,
+> and its exit 1 with the flag unset means only "master gate off".
+> To verify the credential path, run the ROB-298 signed read instead:
+> `uv run python -m scripts.binance_futures_demo_smoke --preflight`
+> (expect `can_trade: true` + a redacted `api_key_fingerprint`).
+
 ---
 
 ## 4. CLI modes
@@ -107,6 +117,7 @@ uv run python -m scripts.binance_demo_strategy_loop --once
 uv run python -m scripts.binance_demo_strategy_loop --once --confirm
 uv run python -m scripts.binance_demo_strategy_loop --loop --poll-interval-seconds 300
 uv run python -m scripts.binance_demo_strategy_loop --paper-signal --confirm
+uv run python -m scripts.binance_demo_strategy_loop --once --strategy last-bar-direction
 ```
 
 | Mode | HTTP/DB | Purpose |
@@ -118,8 +129,9 @@ uv run python -m scripts.binance_demo_strategy_loop --paper-signal --confirm
 | `--paper-signal` | bars skipped; execution if `--confirm` | Injects a canned `Signal` (`--paper-symbol`/`--paper-side`), bypassing bar-fetch + strategy. **This is the ROB-993 e2e smoke path.** |
 
 Shared flags: `--symbols` (default `XRPUSDT,DOGEUSDT,SOLUSDT`), `--leverage`
-(default 1, only 1 accepted), `--confirm` (operator gate — without it every
-mode is dry-run, zero broker mutation).
+(default 1, only 1 accepted), `--strategy` (plugin key, default `null` —
+see §4.1), `--confirm` (operator gate — without it every mode is dry-run,
+zero broker mutation).
 
 **No CLI flag exists for leg notional, max concurrent positions, or
 consecutive-SL limit.** Per the ROB-993 adversarial review
@@ -138,8 +150,57 @@ status — grep-friendly, mirrors the ROB-298 smoke CLI's evidence convention.
 
 **Exit codes**: `0` clean (disabled / no signal / dry-run / kill-switch
 gated / reconciled round trip), `1` operator misconfiguration (missing
-env/credentials), `2` runtime failure (broker/ledger anomaly raised
-mid-lifecycle — investigate the ledger row before retrying).
+env/credentials, **unknown `--strategy` key**), `2` runtime failure
+(broker/ledger anomaly raised mid-lifecycle — investigate the ledger row
+before retrying).
+
+### 4.1 `--strategy` selector (ROB-1145)
+
+Before ROB-1145 the plugin was hardcoded at the CLI call site
+(`strategy=NullStrategy()`), so swapping a plugin meant editing code.
+`--strategy <key>` now resolves through
+`app/services/brokers/binance/demo_strategy_loop/registry.py`.
+
+| Key | Plugin | Emits a signal? |
+|---|---|---|
+| `null` (**default**) | `NullStrategy` | Never. Unchanged ROB-993 posture. |
+| `last-bar-direction` | `LastBarDirectionStrategy` | Yes — opt-in only. |
+
+Properties the registry deliberately holds:
+
+* **`null` remains the default.** Passing no `--strategy` keeps the loop
+  incapable of placing an order. `NullStrategy` was not removed.
+* **Unknown key fails closed** (`UnknownStrategyKey`, exit 1) *before*
+  `from_env()` reads credentials and before any HTTP/DB — a typo stops
+  the run rather than silently trading a different strategy.
+* **A plugin is not a safety dial.** It can only propose
+  `(symbol, side)`. Leg notional `[6, 10]` USDT, max concurrent
+  positions `1`, consecutive-SL cap `2`, 1x leverage, the reduceOnly
+  close and the `demo-fapi.binance.com` allowlist are all enforced
+  downstream (`sizing` / `kill_switch` / `execution`) and are unreachable
+  from a plugin. `--readiness` reports the resolved plugin plus every
+  registered key, with no HTTP and no credentials.
+
+#### `last-bar-direction` — infrastructure proof, NOT an alpha
+
+The rule, in full: pick the first symbol of `("XRPUSDT", "DOGEUSDT",
+"SOLUSDT")` that is in the canonical futures-demo allowlist **and** has a
+complete 4h bar whose `close_ts == decision_ts`; then `close > open` →
+`BUY`, `close < open` → `SELL`, `close == open` → no signal. No lookback
+beyond that single bar, no parameters, no thresholds, no state.
+
+It exists to answer one question — *does the loop place an order on its
+own?* — and it makes **no claim of expected return**. ROB-316 (an OOS
+gross-negative micro-breakout signal) is precisely why this is labelled
+infra proof and why it is not the default. A real strategy with an
+expected-return claim is separate work and additionally needs the
+position-hold / TP-SL state machine that §6 lists as missing.
+
+Consequence worth stating plainly: with `--loop --strategy
+last-bar-direction --confirm`, the loop opens and immediately
+reduceOnly-closes a `[6, 10]` USDT leg on essentially every 4h bar close
+where the decision bar is not exactly flat (≤6 round trips/UTC day). That
+is intended for a Demo account and is not a strategy result.
 
 ---
 

--- a/scripts/binance_demo_strategy_loop.py
+++ b/scripts/binance_demo_strategy_loop.py
@@ -7,11 +7,19 @@ XRP/DOGE/SOL). Strategy-pluggable: the default plugin is ``NullStrategy``
 (always no signal) — the S3 signal-engine adapter (ROB-980) is a separate,
 later commit, deliberately not wired here.
 
+ROB-1145 replaced the hardcoded ``NullStrategy()`` call site with a
+``--strategy <key>`` selector backed by
+``app.services.brokers.binance.demo_strategy_loop.registry``. The default
+is unchanged (``null``); ``last-bar-direction`` is an opt-in
+infrastructure-proof plugin (no expected-return claim — see its
+docstring), and an unknown key fails closed before any HTTP/DB.
+
 Modes (mutually exclusive; default with no flag prints guidance):
 
   1. **default-disabled** — ``BINANCE_DEMO_STRATEGY_LOOP_ENABLED`` unset
      or false: one log line, exit 0, zero HTTP/DB.
-  2. ``--readiness`` — no-secret env readiness report. No HTTP, no
+  2. ``--readiness`` — no-secret env readiness report (including the
+     resolved ``--strategy`` plugin and the registered keys). No HTTP, no
      credentials required.
   3. ``--once`` — one tick: fetch 1m bars, aggregate to 4h (H1 semantics),
      evaluate the strategy, act on a signal if any (dry-run unless
@@ -164,6 +172,15 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         help="--paper-signal side (default: BUY).",
     )
     parser.add_argument(
+        "--strategy",
+        default=None,
+        help=(
+            "Strategy plugin key (default: null — NullStrategy, never "
+            "emits a signal). Registered keys are listed by "
+            "--readiness. An unknown key is refused before any HTTP/DB."
+        ),
+    )
+    parser.add_argument(
         "--confirm",
         action="store_true",
         help=(
@@ -245,16 +262,28 @@ async def _run_tick(
         assert_demo_only,
         run_tick,
     )
+    from app.services.brokers.binance.demo_strategy_loop.registry import (
+        UnknownStrategyKey,
+        build_strategy,
+    )
     from app.services.brokers.binance.demo_strategy_loop.sizing import (
         LEG_NOTIONAL_CAP_MAX_USDT,
     )
-    from app.services.brokers.binance.demo_strategy_loop.strategy import NullStrategy
     from app.services.brokers.binance.futures_demo.errors import (
         BinanceFuturesDemoMissingCredentials,
     )
     from app.services.brokers.binance.futures_demo.execution_client import (
         BinanceFuturesDemoExecutionClient,
     )
+
+    # ROB-1145: resolve the plugin BEFORE constructing any client — an
+    # unknown --strategy key must fail closed with zero HTTP/DB, not after
+    # credentials have been read.
+    try:
+        strategy = build_strategy(getattr(args, "strategy", None))
+    except UnknownStrategyKey as exc:
+        logger.error("strategy loop refused: %s", exc)
+        return 1, None
 
     try:
         execution = BinanceFuturesDemoExecutionClient.from_env()
@@ -286,7 +315,7 @@ async def _run_tick(
         async with AsyncSessionLocal() as session:
             ledger = BinanceDemoLedgerService(session)
             outcome = await run_tick(
-                strategy=NullStrategy(),
+                strategy=strategy,
                 execution=execution,
                 ledger=ledger,
                 session=session,
@@ -345,14 +374,34 @@ async def _run_loop(args: argparse.Namespace) -> int:
 
 async def _run(args: argparse.Namespace) -> int:
     if getattr(args, "readiness", False):
+        from app.services.brokers.binance.demo_strategy_loop.registry import (
+            DEFAULT_STRATEGY_KEY,
+            UnknownStrategyKey,
+            available_strategy_keys,
+            build_strategy,
+        )
+
         enabled = _truthy(os.environ.get("BINANCE_DEMO_STRATEGY_LOOP_ENABLED"))
+        requested = getattr(args, "strategy", None)
+        strategy_error: str | None = None
+        try:
+            strategy_id = build_strategy(requested).strategy_id
+        except UnknownStrategyKey as exc:
+            strategy_id = None
+            strategy_error = str(exc)
         _evidence(
             {
                 "event": "strategy_loop_env_readiness",
                 "BINANCE_DEMO_STRATEGY_LOOP_ENABLED": enabled,
                 "symbols": args.symbols,
+                "strategy_requested": requested or DEFAULT_STRATEGY_KEY,
+                "strategy_id": strategy_id,
+                "strategy_error": strategy_error,
+                "strategy_keys_available": list(available_strategy_keys()),
             }
         )
+        if strategy_error is not None:
+            return 1
         return 0 if enabled else 1
 
     # Hard invariant: default-disabled. Checked AFTER argparse (so --help

--- a/tests/scripts/test_binance_demo_strategy_loop.py
+++ b/tests/scripts/test_binance_demo_strategy_loop.py
@@ -100,3 +100,216 @@ def test_build_paper_signal_uses_cli_flags() -> None:
     assert signal.side == "SELL"
     assert signal.decision_ts == 1_700_000_000_000
     assert signal.strategy_id == "rob-993-paper-signal"
+
+
+# ---------------------------------------------------------------------------
+# ROB-1145 — --strategy selector (replaces the hardcoded NullStrategy()).
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_defaults_to_none_arg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No --strategy flag -> args.strategy is None -> registry default (null)."""
+    args = cli._parse_args(["--once"])
+    assert args.strategy is None
+
+
+def test_readiness_reports_default_strategy(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_DEMO_STRATEGY_LOOP_ENABLED", "true")
+    exit_code = cli.main(["--readiness"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert '"strategy_requested": "null"' in out
+    assert '"strategy_id": "null"' in out
+    assert '"strategy_error": null' in out
+    assert "last-bar-direction" in out
+
+
+def test_readiness_reports_selected_strategy(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_DEMO_STRATEGY_LOOP_ENABLED", "true")
+    exit_code = cli.main(["--readiness", "--strategy", "last-bar-direction"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert '"strategy_id": "last-bar-direction"' in out
+
+
+def test_readiness_unknown_strategy_fails_closed(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_DEMO_STRATEGY_LOOP_ENABLED", "true")
+    exit_code = cli.main(["--readiness", "--strategy", "not-a-strategy"])
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert '"strategy_id": null' in out
+    assert "not-a-strategy" in out
+
+
+def test_unknown_strategy_refused_before_any_client_construction(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An unknown --strategy key must exit 1 with zero HTTP/DB — in
+    particular before ``from_env()`` reads credentials."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_DEMO_STRATEGY_LOOP_ENABLED", "true")
+
+    from app.services.brokers.binance.futures_demo import (
+        execution_client as execution_client_mod,
+    )
+
+    def _explode(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("from_env must not be reached for an unknown strategy")
+
+    monkeypatch.setattr(
+        execution_client_mod.BinanceFuturesDemoExecutionClient,
+        "from_env",
+        classmethod(lambda cls: _explode()),
+    )
+    caplog.set_level(logging.ERROR, logger="scripts.binance_demo_strategy_loop")
+    exit_code = cli.main(["--once", "--strategy", "nope"])
+    assert exit_code == 1
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("unknown strategy" in m and "nope" in m for m in messages), messages
+
+
+def test_selected_strategy_is_passed_to_run_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The plugin the CLI resolves is the plugin run_tick receives — the
+    ROB-1145 regression: scripts:289 used to hardcode NullStrategy()."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_DEMO_STRATEGY_LOOP_ENABLED", "true")
+
+    import asyncio
+
+    from app.services.brokers.binance.demo_strategy_loop import (
+        orchestrator as orchestrator_mod,
+    )
+    from app.services.brokers.binance.demo_strategy_loop.strategy import (
+        LastBarDirectionStrategy,
+    )
+    from app.services.brokers.binance.futures_demo import (
+        execution_client as execution_client_mod,
+    )
+
+    seen: list[object] = []
+
+    class _FakeExecution:
+        @classmethod
+        def from_env(cls) -> _FakeExecution:
+            return cls()
+
+        async def aclose(self) -> None:
+            return None
+
+    class _FakeMarketClient:
+        base_url = __import__("httpx").URL("https://demo-fapi.binance.com")
+
+        async def aclose(self) -> None:
+            return None
+
+    async def _fake_run_tick(**kwargs: object):
+        seen.append(kwargs["strategy"])
+        return orchestrator_mod.TickOutcome(
+            decision_ts=1,
+            signal=None,
+            round_trip=None,
+            blocked_reason="no_signal",
+        )
+
+    class _FakeSession:
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        execution_client_mod.BinanceFuturesDemoExecutionClient,
+        "from_env",
+        classmethod(lambda cls: _FakeExecution()),
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.binance.demo_strategy_loop.bars.build_bars_client",
+        lambda *a, **k: _FakeMarketClient(),
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.binance.demo_strategy_loop.orchestrator.run_tick",
+        _fake_run_tick,
+    )
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: _FakeSession())
+
+    args = cli._parse_args(["--once", "--strategy", "last-bar-direction"])
+    exit_code, _ = asyncio.run(cli._run_tick(args))
+    assert exit_code == 0
+    assert len(seen) == 1
+    assert isinstance(seen[0], LastBarDirectionStrategy)
+
+
+def test_default_strategy_is_still_null_strategy_at_run_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-1145 must not change the default posture: no --strategy flag
+    still means NullStrategy (never emits a signal)."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_DEMO_STRATEGY_LOOP_ENABLED", "true")
+
+    import asyncio
+
+    from app.services.brokers.binance.demo_strategy_loop import (
+        orchestrator as orchestrator_mod,
+    )
+    from app.services.brokers.binance.demo_strategy_loop.strategy import NullStrategy
+    from app.services.brokers.binance.futures_demo import (
+        execution_client as execution_client_mod,
+    )
+
+    seen: list[object] = []
+
+    class _FakeExecution:
+        async def aclose(self) -> None:
+            return None
+
+    class _FakeMarketClient:
+        base_url = __import__("httpx").URL("https://demo-fapi.binance.com")
+
+        async def aclose(self) -> None:
+            return None
+
+    async def _fake_run_tick(**kwargs: object):
+        seen.append(kwargs["strategy"])
+        return orchestrator_mod.TickOutcome(
+            decision_ts=1, signal=None, round_trip=None, blocked_reason="no_signal"
+        )
+
+    class _FakeSession:
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        execution_client_mod.BinanceFuturesDemoExecutionClient,
+        "from_env",
+        classmethod(lambda cls: _FakeExecution()),
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.binance.demo_strategy_loop.bars.build_bars_client",
+        lambda *a, **k: _FakeMarketClient(),
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.binance.demo_strategy_loop.orchestrator.run_tick",
+        _fake_run_tick,
+    )
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: _FakeSession())
+
+    args = cli._parse_args(["--once"])
+    exit_code, _ = asyncio.run(cli._run_tick(args))
+    assert exit_code == 0
+    assert isinstance(seen[0], NullStrategy)

--- a/tests/services/brokers/binance/demo_strategy_loop/test_registry.py
+++ b/tests/services/brokers/binance/demo_strategy_loop/test_registry.py
@@ -1,0 +1,56 @@
+"""ROB-1145 — strategy plugin registry / ``--strategy`` selector."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.demo_strategy_loop.registry import (
+    DEFAULT_STRATEGY_KEY,
+    UnknownStrategyKey,
+    available_strategy_keys,
+    build_strategy,
+)
+from app.services.brokers.binance.demo_strategy_loop.strategy import (
+    LastBarDirectionStrategy,
+    NullStrategy,
+)
+
+
+def test_default_is_null_strategy() -> None:
+    assert DEFAULT_STRATEGY_KEY == "null"
+    assert isinstance(build_strategy(), NullStrategy)
+    assert isinstance(build_strategy(None), NullStrategy)
+    assert isinstance(build_strategy("null"), NullStrategy)
+
+
+def test_null_strategy_is_still_registered_and_listed_first() -> None:
+    """ROB-1145 must not remove the safe default."""
+    keys = available_strategy_keys()
+    assert keys[0] == "null"
+    assert "last-bar-direction" in keys
+
+
+def test_last_bar_direction_is_selectable() -> None:
+    strategy = build_strategy("last-bar-direction")
+    assert isinstance(strategy, LastBarDirectionStrategy)
+    assert strategy.strategy_id == "last-bar-direction"
+
+
+def test_key_resolution_is_case_and_whitespace_insensitive() -> None:
+    assert isinstance(build_strategy("  Last-Bar-Direction "), LastBarDirectionStrategy)
+
+
+def test_unknown_key_fails_closed() -> None:
+    with pytest.raises(UnknownStrategyKey) as excinfo:
+        build_strategy("s3-signal-engine")
+    assert "s3-signal-engine" in str(excinfo.value)
+    # The error must enumerate the real options rather than silently
+    # falling back to a plugin the operator did not ask for.
+    assert "null" in str(excinfo.value)
+
+
+def test_every_registered_key_builds_a_plugin_with_matching_contract() -> None:
+    for key in available_strategy_keys():
+        plugin = build_strategy(key)
+        assert isinstance(plugin.strategy_id, str) and plugin.strategy_id
+        assert callable(plugin.evaluate)

--- a/tests/services/brokers/binance/demo_strategy_loop/test_strategy.py
+++ b/tests/services/brokers/binance/demo_strategy_loop/test_strategy.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from app.services.brokers.binance.demo_strategy_loop.strategy import (
+    LastBarDirectionStrategy,
     NullStrategy,
     Signal,
+    StrategyPlugin,
 )
+from research.nautilus_scalping.rob974_features import Bar4h
 
 
 def test_null_strategy_always_returns_none() -> None:
@@ -32,3 +35,152 @@ def test_signal_is_frozen_dataclass() -> None:
         pass
     else:
         raise AssertionError("Signal must be frozen")
+
+
+# ---------------------------------------------------------------------------
+# ROB-1145 — LastBarDirectionStrategy (first signal-emitting plugin).
+# ---------------------------------------------------------------------------
+
+_FOUR_HOUR_MS = 4 * 60 * 60 * 1000
+
+
+def _bar(*, ts: int, open_: float, close: float) -> Bar4h:
+    return Bar4h(
+        ts=ts,
+        close_ts=ts + _FOUR_HOUR_MS,
+        open=open_,
+        high=max(open_, close),
+        low=min(open_, close),
+        close=close,
+        volume=1.0,
+        is_segment_start=False,
+    )
+
+
+def _aligned_ts() -> int:
+    return 1_785_000_000_000 // _FOUR_HOUR_MS * _FOUR_HOUR_MS
+
+
+def test_last_bar_direction_up_bar_emits_buy() -> None:
+    ts = _aligned_ts()
+    strategy = LastBarDirectionStrategy()
+    assert strategy.strategy_id == "last-bar-direction"
+    signal = strategy.evaluate(
+        {"XRPUSDT": (_bar(ts=ts, open_=0.50, close=0.55),)},
+        decision_ts=ts + _FOUR_HOUR_MS,
+    )
+    assert signal is not None
+    assert signal.symbol == "XRPUSDT"
+    assert signal.side == "BUY"
+    assert signal.decision_ts == ts + _FOUR_HOUR_MS
+    assert signal.strategy_id == "last-bar-direction"
+    assert signal.sl_price is None and signal.tp_price is None
+
+
+def test_last_bar_direction_down_bar_emits_sell() -> None:
+    ts = _aligned_ts()
+    signal = LastBarDirectionStrategy().evaluate(
+        {"XRPUSDT": (_bar(ts=ts, open_=0.55, close=0.50),)},
+        decision_ts=ts + _FOUR_HOUR_MS,
+    )
+    assert signal is not None
+    assert signal.side == "SELL"
+
+
+def test_last_bar_direction_flat_bar_emits_no_signal() -> None:
+    ts = _aligned_ts()
+    assert (
+        LastBarDirectionStrategy().evaluate(
+            {"XRPUSDT": (_bar(ts=ts, open_=0.50, close=0.50),)},
+            decision_ts=ts + _FOUR_HOUR_MS,
+        )
+        is None
+    )
+
+
+def test_last_bar_direction_is_deterministic() -> None:
+    """Same input -> same signal, twice (no state, no randomness)."""
+    ts = _aligned_ts()
+    bars = {"XRPUSDT": (_bar(ts=ts, open_=0.50, close=0.55),)}
+    strategy = LastBarDirectionStrategy()
+    first = strategy.evaluate(bars, decision_ts=ts + _FOUR_HOUR_MS)
+    second = strategy.evaluate(bars, decision_ts=ts + _FOUR_HOUR_MS)
+    assert first == second
+
+
+def test_last_bar_direction_prefers_xrp_over_other_symbols() -> None:
+    ts = _aligned_ts()
+    signal = LastBarDirectionStrategy().evaluate(
+        {
+            "SOLUSDT": (_bar(ts=ts, open_=100.0, close=90.0),),
+            "DOGEUSDT": (_bar(ts=ts, open_=0.10, close=0.09),),
+            "XRPUSDT": (_bar(ts=ts, open_=0.50, close=0.55),),
+        },
+        decision_ts=ts + _FOUR_HOUR_MS,
+    )
+    assert signal is not None
+    assert signal.symbol == "XRPUSDT"
+    assert signal.side == "BUY"
+
+
+def test_last_bar_direction_falls_through_priority_when_primary_absent() -> None:
+    ts = _aligned_ts()
+    signal = LastBarDirectionStrategy().evaluate(
+        {
+            "SOLUSDT": (_bar(ts=ts, open_=100.0, close=90.0),),
+            "DOGEUSDT": (_bar(ts=ts, open_=0.10, close=0.11),),
+        },
+        decision_ts=ts + _FOUR_HOUR_MS,
+    )
+    assert signal is not None
+    assert signal.symbol == "DOGEUSDT"
+    assert signal.side == "BUY"
+
+
+def test_last_bar_direction_ignores_stale_bar() -> None:
+    """A bar whose close_ts != decision_ts is never used (H1: absence is
+    NO_SIGNAL — never reach back for a stale bar)."""
+    ts = _aligned_ts()
+    assert (
+        LastBarDirectionStrategy().evaluate(
+            {"XRPUSDT": (_bar(ts=ts - _FOUR_HOUR_MS, open_=0.50, close=0.55),)},
+            decision_ts=ts + _FOUR_HOUR_MS,
+        )
+        is None
+    )
+
+
+def test_last_bar_direction_empty_inputs_emit_no_signal() -> None:
+    ts = _aligned_ts()
+    strategy = LastBarDirectionStrategy()
+    assert strategy.evaluate({}, decision_ts=ts + _FOUR_HOUR_MS) is None
+    assert strategy.evaluate({"XRPUSDT": ()}, decision_ts=ts + _FOUR_HOUR_MS) is None
+
+
+def test_last_bar_direction_never_targets_excluded_or_unlisted_symbol() -> None:
+    """Even if a caller hands the plugin a priority list containing BTCUSDT
+    (excluded: MIN_NOTIONAL 50 > 10 USDT cap) or an unlisted symbol, the
+    plugin refuses to target it."""
+    ts = _aligned_ts()
+    strategy = LastBarDirectionStrategy(
+        symbol_priority=("BTCUSDT", "ETHUSDT", "XRPUSDT")
+    )
+    signal = strategy.evaluate(
+        {
+            "BTCUSDT": (_bar(ts=ts, open_=60000.0, close=61000.0),),
+            "ETHUSDT": (_bar(ts=ts, open_=3000.0, close=3100.0),),
+            "XRPUSDT": (_bar(ts=ts, open_=0.55, close=0.50),),
+        },
+        decision_ts=ts + _FOUR_HOUR_MS,
+    )
+    assert signal is not None
+    assert signal.symbol == "XRPUSDT"
+    assert signal.side == "SELL"
+
+
+def test_last_bar_direction_satisfies_strategy_plugin_protocol() -> None:
+    def _accepts(plugin: StrategyPlugin) -> str:
+        return plugin.strategy_id
+
+    assert _accepts(LastBarDirectionStrategy()) == "last-bar-direction"
+    assert _accepts(NullStrategy()) == "null"


### PR DESCRIPTION
## What

`scripts/binance_demo_strategy_loop.py` hardcoded `strategy=NullStrategy()`, so
changing the plugin meant editing code. This adds a `--strategy <key>` selector
plus the lane's first plugin that can actually emit a signal.

| Key | Plugin | Emits? |
|---|---|---|
| `null` (**default, unchanged**) | `NullStrategy` (kept, not removed) | never |
| `last-bar-direction` (opt-in) | `LastBarDirectionStrategy` | yes |

`LastBarDirectionStrategy` rule, in full: first symbol of `(XRPUSDT, DOGEUSDT,
SOLUSDT)` that is in the canonical futures-demo allowlist **and** has a complete
4h bar with `close_ts == decision_ts`; then `close > open` → BUY, `close < open`
→ SELL, `close == open` → no signal. No lookback beyond that bar, no parameters,
no thresholds, no state.

**It is an infrastructure proof, not an alpha.** It answers only "does the loop
place an order on its own?" and makes no expected-return claim. ROB-316 (OOS
gross-negative micro-breakout) is exactly why it is not the default.

## Safety

A plugin can only propose `(symbol, side)`. Every hard lane invariant is
untouched and still enforced downstream:

- leg notional `[6, 10]` USDT (`sizing.LEG_NOTIONAL_CAP_MIN/MAX_USDT`)
- max concurrent positions `1`, consecutive-SL `2` (`kill_switch.LOCKED_LIMITS`)
- 1x leverage, reduceOnly close, `demo-fapi.binance.com` only, BTCUSDT excluded
- `run_tick` still raises `LegNotionalCapNotLocked` / `KillSwitchLimitsNotLocked`
  before any network/DB call

New fail-closed behaviour: an unknown `--strategy` key raises
`UnknownStrategyKey` and exits 1 **before** `from_env()` reads credentials —
zero HTTP/DB. No env gate was relaxed and no new credential surface was added.

## Measured correction to the runbook

`--readiness` asserts **only** `BINANCE_DEMO_STRATEGY_LOOP_ENABLED` (plus, now,
the strategy key) and performs **no credential resolution**. A `--readiness`
exit 0 is not evidence that `BINANCE_DEMO_API_*` resolves; its exit 1 with the
flag unset means only "master gate off". Runbook §3 and CLAUDE.md now say so,
and point at `binance_futures_demo_smoke --preflight` for the credential path.

## Verification

Ran against the real `demo-fapi.binance.com` Demo account (operator-approved,
demo only), full raw evidence in the ROB-1145 report.

- `--preflight` (signed read): HTTP 200, `can_trade: true`, one-way mode,
  account-wide flat (0 non-zero positions of 730 rows, 0 open orders) — the
  canonical `BINANCE_DEMO_API_*` fallback path works at runtime.
- `--paper-signal --confirm`: reconciled round trip, ledger rows
  `438` (root BUY) / `439` (child SELL reduceOnly), notional `9.8992` USDT,
  `forecast_saved: true`, no anomaly.
- `--once --strategy last-bar-direction` (dry-run, real bars): emitted
  `XRPUSDT BUY` from `open=1.0608 close=1.0686`, then stopped at
  `blocked_reason: "dry_run"`. Default `--once` still `no_signal`.
- `--once --strategy nope`: exit 1, zero HTTP.
- Concurrent-position kill switch, proven live with two simultaneous
  `--paper-signal --confirm` processes: one reconciled (rows `440`/`441`), the
  other blocked with `kill_switch:exposure_slot_taken:global_open_root_cap` and
  zero broker submits. `count_open_lifecycles` back to `0`, account flat.
- Widening attempts all refused: `max_concurrent_positions=2/99`,
  `max_consecutive_sl=5`, `cap_usdt=1/50/1000`.

Tests / gates:

- `tests/services/brokers/binance/` + `tests/scripts/` — **1297 passed**
- `demo_strategy_loop` + CLI suites — 76 passed (was 52; +24 new)
- false-green check: neutering `build_strategy` to always return
  `NullStrategy` fails 4 of the new tests, including
  `test_selected_strategy_is_passed_to_run_tick`
- `make lint` (ruff check + ruff format --check + ty) clean
- repo guards `test_no_internal_llm_imports`,
  `test_repository_import_boundary_enforced` pass

## Known gap (relevant to `--loop` residency, not fixed here)

The consecutive-SL gate reads `extra_metadata["exit_reason"] == "stop_loss"`,
but this lane's round trip only ever writes `immediate_close`, so that gate
**cannot trip against this loop's own traffic**. The 3 `stop_loss` rows in the
ledger belong to `rob-307-pr2-executor` and are correctly excluded by
`strategy_loop_tag` scoping. Verified at unit level only. A hold-to-TP/SL
state machine is separate work.

Refs ROB-1145, ROB-993.
