### PR TITLE
fix(ROB-1155): correct kt00007 official body + read-only MCP order-detail tool

### DIFF
--- a/app/mcp_server/tooling/account_read_registration.py
+++ b/app/mcp_server/tooling/account_read_registration.py
@@ -49,6 +49,14 @@ KIWOOM_MOCK_ACCOUNT_READ_TOOL_NAMES: set[str] = {
     "kiwoom_mock_get_positions",
     "kiwoom_mock_get_orderable_cash",
     "kiwoom_mock_get_order_history",
+    # ROB-1155 — kiwoom_mock_get_order_detail (kt00007) is deliberately NOT
+    # listed. It is a pure read, but this set is unioned into
+    # TRADINGCODEX_EXECUTION_TOOL_NAMES, so adding it here would silently widen
+    # that privileged profile too — exactly what the boundary comment in
+    # tradingcodex_execution_registration.py forbids. KR-B1's forced profile is
+    # MCP_PROFILE=kiwoom, which registers the whole Kiwoom registrar, so the
+    # tool is reachable where it is needed without touching either restricted
+    # profile. Widening these two is a separate, explicit decision.
 }
 
 ACCOUNT_READ_TOOL_NAMES: set[str] = {

--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -33,6 +33,7 @@ from app.services.brokers.kiwoom.normalization import (
     KiwoomMockEvidenceError,
     build_mock_provenance,
     normalize_deposit,
+    normalize_order_detail,
     normalize_orders,
     normalize_positions,
     redact_broker_response,
@@ -65,8 +66,19 @@ KIWOOM_MOCK_TOOL_NAMES: set[str] = {
     "kiwoom_mock_cancel_order",
     "kiwoom_mock_modify_order",
     "kiwoom_mock_get_order_history",
+    "kiwoom_mock_get_order_detail",
     "kiwoom_mock_get_positions",
     "kiwoom_mock_get_orderable_cash",
+}
+
+# ROB-1155 — kt00007 read scope -> official qry_tp. The official values are
+# "1:주문순, 2:역순, 3:미체결, 4:체결내역만"; these names keep the MCP surface
+# self-describing without leaking Kiwoom enum digits into prompts.
+_ORDER_DETAIL_SCOPES: dict[str, str] = {
+    "all": constants.ACCOUNT_ORDER_DETAIL_QRY_TP_ORDER_SEQUENCE,
+    "all_reverse": constants.ACCOUNT_ORDER_DETAIL_QRY_TP_REVERSE,
+    "unfilled": constants.ACCOUNT_ORDER_DETAIL_QRY_TP_UNFILLED,
+    "filled": constants.ACCOUNT_ORDER_DETAIL_QRY_TP_FILLED,
 }
 
 _SAFE_ORDER_ID_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
@@ -234,6 +246,58 @@ def _finalize_normalized_read_response(
         response["success"] = False
         response["error"] = exc.code
         response["error_detail"] = str(exc)
+    return response
+
+
+def _finalize_order_detail_read_response(
+    base: dict[str, Any],
+    broker_response: dict[str, Any],
+    *,
+    order_id: str | None,
+) -> dict[str, Any]:
+    """kt00007-only sibling of :func:`_finalize_normalized_read_response`.
+
+    ROB-1155 — a separate finalizer, not a widening of the shared one. The shared
+    finalizer pins ``result_key`` to ``positions``/``orders`` and hardcodes which
+    normalizer to call; injecting a callable there would put the already-shipped
+    kt00009 / kt00018 read paths on the diff. This duplicates only the
+    provenance + error-envelope shape and leaves those paths byte-identical.
+
+    ``order_id`` filtering is local and exact. ``fr_ord_no`` narrows the broker
+    query to "this order number and later" (official semantics), so the broker
+    response is a superset; without the local filter a single-order lookup would
+    silently report unrelated later orders. ``matched_order_count`` is reported
+    so a caller can tell "not found" from "found".
+    """
+
+    response = _finalize_broker_response(base, broker_response)
+    response["provenance"] = build_mock_provenance(
+        constants.ACCOUNT_ORDER_DETAIL_API_ID
+    )
+    response["orders"] = []
+    if not response["success"]:
+        response["error"] = "kiwoom_mock_broker_error"
+        return response
+    try:
+        validate_mock_response_provenance(broker_response)
+        orders = normalize_order_detail(broker_response)
+    except KiwoomMockEvidenceError as exc:
+        response["success"] = False
+        response["error"] = exc.code
+        response["error_detail"] = str(exc)
+        return response
+
+    response["broker_order_count"] = len(orders)
+    if order_id is not None:
+        orders = [row for row in orders if row["order_id"] == order_id]
+    response["orders"] = orders
+    response["matched_order_count"] = len(orders)
+    # CP6 evidence: which venue the broker actually recorded each row on, as
+    # opposed to the venue we requested. Both are echoed so a mismatch is visible
+    # without re-reading the raw broker_response.
+    response["response_venues"] = sorted(
+        {row["venue"] for row in orders if row["venue"]}
+    )
     return response
 
 
@@ -603,6 +667,75 @@ async def _kiwoom_mock_order_history_impl(**kwargs: Any) -> dict[str, Any]:
     )
 
 
+async def _kiwoom_mock_order_detail_impl(**kwargs: Any) -> dict[str, Any]:
+    """kt00007 read-only order-detail lookup (ROB-1155).
+
+    Read-only by construction: builds ONLY a ``KiwoomDomesticAccountClient`` and
+    never a ``KiwoomDomesticOrderClient``, so no place/modify/cancel code path is
+    reachable from here.
+    """
+
+    order_id_raw = kwargs.get("order_id")
+    order_id = None if order_id_raw is None else str(order_id_raw).strip()
+    scope = str(kwargs.get("scope") or "all")
+    venue = str(kwargs.get("venue") or constants.ACCOUNT_READ_VENUE_KRX).strip().upper()
+    order_date = kwargs.get("order_date")
+    symbol_raw = kwargs.get("symbol")
+    symbol = None if symbol_raw is None else normalize_krx_symbol(symbol_raw)
+    qry_tp = _ORDER_DETAIL_SCOPES[scope]
+
+    extra: dict[str, Any] = {
+        "order_id": order_id,
+        "requested_scope": scope,
+        "requested_qry_tp": qry_tp,
+        "requested_venue": venue,
+        "order_date": None if order_date is None else str(order_date).strip(),
+        **({"symbol": symbol} if symbol is not None else {}),
+    }
+
+    try:
+        client = KiwoomMockClient.from_app_settings()
+        account_client = KiwoomDomesticAccountClient(cast(Any, client))
+        broker_response = await account_client.get_order_detail(
+            order_date=order_date,
+            qry_tp=qry_tp,
+            symbol=symbol,
+            from_order_no=order_id,
+            dmst_stex_tp=venue,
+        )
+    except ValueError as exc:
+        # Locally raised official-contract validation (venue/qry_tp/date/order
+        # number shape). Never dispatched, so it is not a transport failure.
+        return _stable_read_failure(
+            result_key="orders",
+            result_value=[],
+            api_id=constants.ACCOUNT_ORDER_DETAIL_API_ID,
+            error="kiwoom_mock_request_invalid",
+            error_detail=str(exc),
+            extra=extra,
+        )
+    except Exception as exc:  # noqa: BLE001 - MCP tools fail closed with JSON
+        return _stable_read_failure(
+            result_key="orders",
+            result_value=[],
+            api_id=constants.ACCOUNT_ORDER_DETAIL_API_ID,
+            error="kiwoom_mock_transport_error",
+            error_detail=(
+                f"kiwoom_mock_get_order_detail transport failed: {type(exc).__name__}"
+            ),
+            extra=extra,
+        )
+    return _finalize_order_detail_read_response(
+        {
+            "source": "kiwoom",
+            "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+            **extra,
+        },
+        broker_response,
+        order_id=order_id,
+    )
+
+
 async def _kiwoom_mock_positions_impl(**kwargs: Any) -> dict[str, Any]:
     cont_yn = kwargs.get("cont_yn")
     next_key = kwargs.get("next_key")
@@ -911,6 +1044,89 @@ def register(mcp: FastMCP) -> None:
                 error_detail=str(guard["error"]),
             )
         return await _kiwoom_mock_order_history_impl(cont_yn=cont_yn, next_key=next_key)
+
+    @mcp.tool(
+        name="kiwoom_mock_get_order_detail",
+        description=(
+            "Read Kiwoom mock order/fill DETAIL via kt00007 (read-only). Tracks a "
+            "single known order number, or scopes to unfilled/filled rows. "
+            "venue='NXT' is an observation-only argument; order placement stays "
+            "KRX-pinned."
+        ),
+    )
+    async def kiwoom_mock_get_order_detail(
+        order_id: str | None = None,
+        order_date: str | None = None,
+        scope: Literal["all", "all_reverse", "unfilled", "filled"] = "all",
+        symbol: str | None = None,
+        venue: Literal["KRX", "NXT"] = "KRX",
+    ) -> dict[str, Any]:
+        api_id = constants.ACCOUNT_ORDER_DETAIL_API_ID
+        extra: dict[str, Any] = {
+            "order_id": order_id,
+            "requested_scope": scope,
+            "requested_venue": venue,
+        }
+        if (guard := _mock_config_error()) is not None:
+            return _stable_read_failure(
+                result_key="orders",
+                result_value=[],
+                api_id=api_id,
+                error="kiwoom_mock_config_invalid",
+                error_detail=str(guard["error"]),
+                extra=extra,
+            )
+        if order_id is not None and (guard := _order_id_error(order_id)) is not None:
+            return _stable_read_failure(
+                result_key="orders",
+                result_value=[],
+                api_id=api_id,
+                error="kiwoom_mock_order_id_invalid",
+                error_detail=str(guard["error"]),
+                extra=extra,
+            )
+        if symbol is not None and (guard := _symbol_error(symbol)) is not None:
+            return _stable_read_failure(
+                result_key="orders",
+                result_value=[],
+                api_id=api_id,
+                error="kiwoom_mock_symbol_invalid",
+                error_detail=str(guard["error"]),
+                extra={**extra, "symbol": symbol},
+            )
+        # Read-only venue allowlist, deliberately NOT _exchange_error: that guard
+        # enforces the KRX-only ORDER boundary and must stay untouched (ROB-1155).
+        if str(venue).strip().upper() not in constants.ACCOUNT_READ_VENUE_ALLOWLIST:
+            return _stable_read_failure(
+                result_key="orders",
+                result_value=[],
+                api_id=api_id,
+                error="kiwoom_mock_read_venue_invalid",
+                error_detail=(
+                    "kiwoom_mock_get_order_detail venue must be one of "
+                    f"{sorted(constants.ACCOUNT_READ_VENUE_ALLOWLIST)}; got {venue!r}"
+                ),
+                extra=extra,
+            )
+        if scope not in _ORDER_DETAIL_SCOPES:
+            return _stable_read_failure(
+                result_key="orders",
+                result_value=[],
+                api_id=api_id,
+                error="kiwoom_mock_read_scope_invalid",
+                error_detail=(
+                    "kiwoom_mock_get_order_detail scope must be one of "
+                    f"{sorted(_ORDER_DETAIL_SCOPES)}; got {scope!r}"
+                ),
+                extra=extra,
+            )
+        return await _kiwoom_mock_order_detail_impl(
+            order_id=order_id,
+            order_date=order_date,
+            scope=scope,
+            symbol=symbol,
+            venue=venue,
+        )
 
     @mcp.tool(
         name="kiwoom_mock_get_positions",

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -262,6 +262,10 @@ STATUS_HELPER_TOOLS: frozenset[str] = frozenset(
         "kis_live_get_order_history",
         "kis_mock_get_order_history",
         "kiwoom_mock_get_order_history",
+        # ROB-1155: kt00007 read-only order-detail lookup. Lands in the legacy
+        # MUTATION_TOOLS bucket only because KIWOOM_MOCK_TOOL_NAMES is unioned in
+        # wholesale; it never calls the order client.
+        "kiwoom_mock_get_order_detail",
         "kiwoom_mock_get_orderable_cash",
         "kiwoom_mock_get_positions",
         "toss_get_order_history",

--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -88,6 +88,57 @@ ACCOUNT_ORDER_QRY_TP_DEFAULT = "0"  # kt00009 조회구분(전체)
 # MOCK_REJECTED_EXCHANGES={"NXT","SOR"}이 그 경계를 강제한다. "%"(전체)는 NXT/SOR
 # 결과까지 섞어 그 fail-closed 경계를 사실상 무력화하므로 선택하지 않는다.
 
+# ROB-1155 (2026-07-29) — kt00007(계좌별주문체결내역상세요청) 공식 요청 body.
+# 공식 문서 https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00007&jobTp=FS_JOB_TP&jobTpCode=08
+# (2026-07-29 직접 확인 + 로컬 추출본
+#  ~/Downloads/kiwoom_api_docs/kt00007_계좌별주문체결내역상세요청.md 교차 확인)의
+# 요청 Body 표는 다음 7필드다. `ord_no`는 요청 필드에 **없다**.
+#   ord_dt        Required=N  주문일자 YYYYMMDD
+#   qry_tp        Required=Y  "1:주문순, 2:역순, 3:미체결, 4:체결내역만"
+#   stk_bond_tp   Required=Y  "0:전체, 1:주식, 2:채권"
+#   sell_tp       Required=Y  "0:전체, 1:매도, 2:매수"
+#   stk_cd        Required=N  종목코드 (전체 조회는 빈값 '')
+#   fr_ord_no     Required=N  시작주문번호 (입력 시 이전 주문 제외, 전체 조회는 빈값 '')
+#   dmst_stex_tp  Required=Y  "%:(전체), KRX, NXT, SOR"
+# 공식 Request Example은 optional 3필드를 **빈 문자열로 명시 전송**한다:
+#   {"ord_dt":"", "qry_tp":"1", "stk_bond_tp":"0", "sell_tp":"0",
+#    "stk_cd":"005930", "fr_ord_no":"", "dmst_stex_tp":"%"}
+# 교정 전 구현은 `{"ord_no": ...}` 단일 필드만 보냈다 — Required=Y 4필드가 모두
+# 누락되고 존재하지 않는 필드를 보내는 계약 불일치였다(return_code 2 구조).
+ACCOUNT_ORDER_DETAIL_QRY_TP_ORDER_SEQUENCE = "1"  # 주문순
+ACCOUNT_ORDER_DETAIL_QRY_TP_REVERSE = "2"  # 역순
+ACCOUNT_ORDER_DETAIL_QRY_TP_UNFILLED = "3"  # 미체결
+ACCOUNT_ORDER_DETAIL_QRY_TP_FILLED = "4"  # 체결내역만
+ACCOUNT_ORDER_DETAIL_QRY_TYPES: frozenset[str] = frozenset(
+    {
+        ACCOUNT_ORDER_DETAIL_QRY_TP_ORDER_SEQUENCE,
+        ACCOUNT_ORDER_DETAIL_QRY_TP_REVERSE,
+        ACCOUNT_ORDER_DETAIL_QRY_TP_UNFILLED,
+        ACCOUNT_ORDER_DETAIL_QRY_TP_FILLED,
+    }
+)
+ACCOUNT_ORDER_DETAIL_QRY_TP_DEFAULT = ACCOUNT_ORDER_DETAIL_QRY_TP_ORDER_SEQUENCE
+ACCOUNT_ORDER_DETAIL_STK_BOND_TP_DEFAULT = "0"  # 전체
+ACCOUNT_ORDER_DETAIL_SELL_TP_DEFAULT = "0"  # 전체
+ACCOUNT_ORDER_DETAIL_LIST_KEY = "acnt_ord_cntr_prps_dtl"
+
+# ROB-1155 — 관측(read-only) 전용 거래소 allowlist.
+# 🔴 주문 경로와 완전히 분리된 상수다. 주문(kt10000~kt10003)은 계속
+# MOCK_EXCHANGE_KRX 고정이고 MOCK_REJECTED_EXCHANGES={"NXT","SOR"}가 그 경계를
+# 강제한다 — 이 allowlist는 그 상수들을 건드리지 않으며 주문 경로에서 참조되지
+# 않는다. CP6("주문이 실제로 어느 venue에 기록됐는가")은 KRX 요청만으로는
+# 관측할 수 없으므로 kt00007 조회에만 NXT 요청을 허용한다. 공식 문서가 허용하는
+# "%"(전체)와 "SOR"은 의도적으로 제외한다: "%"는 fail-closed 경계를 흐리고,
+# SOR은 현재 관측 필요가 없다.
+# ⚠️ 공식 문서는 mockapi.kiwoom.com을 "KRX만 지원가능"으로 표기한다. 이 allowlist는
+# "NXT 요청을 만들 수 있음"까지만 보장하고, 모의서버가 NXT 조회를 실제로 지원하는지
+# 또는 빈 결과가 미이월인지 미지원인지는 증명하지 않는다.
+ACCOUNT_READ_VENUE_KRX = MOCK_EXCHANGE_KRX
+ACCOUNT_READ_VENUE_NXT = "NXT"
+ACCOUNT_READ_VENUE_ALLOWLIST: frozenset[str] = frozenset(
+    {ACCOUNT_READ_VENUE_KRX, ACCOUNT_READ_VENUE_NXT}
+)
+
 # ROB-460 — Kiwoom REST account-cash reads also require dmst_stex_tp (국내거래소구분).
 # 2026-06-09 live: get_positions(kt00018)·get_orderable_cash returned return_code 2
 # (필수입력 파라미터=dmst_stex_tp). Unlike the qry_tp/stk_bond_tp convention-defaults,
@@ -98,8 +149,10 @@ ACCOUNT_ORDER_QRY_TP_DEFAULT = "0"  # kt00009 조회구분(전체)
 # it is no longer sent on those endpoints.
 # ROB-1088 (2026-07-28) — kt00009 order-history reads DO require dmst_stex_tp per
 # the official docs (see the ROB-1088 block above); "KRX" is reused here for that
-# endpoint too, on top of the already-applied kt00018 usage. kt00007 remains
-# untouched (not yet called by this codebase).
+# endpoint too, on top of the already-applied kt00018 usage.
+# ROB-1155 (2026-07-29) — kt00007 order-detail reads also require dmst_stex_tp
+# (Required=Y, official doc). This same "KRX" default applies there; the read-only
+# venue override is bounded by ACCOUNT_READ_VENUE_ALLOWLIST above.
 ACCOUNT_DMST_STEX_TP_DEFAULT = MOCK_EXCHANGE_KRX  # "KRX" — 국내거래소구분
 
 # ---------------------------------------------------------------------------

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -8,6 +8,7 @@ they are passed through untransformed for the parent project to consume.
 
 from __future__ import annotations
 
+import re
 from typing import Any, Protocol
 
 from app.services.brokers.kiwoom import constants
@@ -169,14 +170,71 @@ class KiwoomDomesticAccountClient:
     async def get_order_detail(
         self,
         *,
-        order_no: str,
+        order_date: str | None = None,
+        qry_tp: str = constants.ACCOUNT_ORDER_DETAIL_QRY_TP_DEFAULT,
+        symbol: str | None = None,
+        from_order_no: str | None = None,
+        dmst_stex_tp: str = constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
         cont_yn: str | None = None,
         next_key: str | None = None,
     ) -> dict[str, Any]:
+        """Read kt00007 (계좌별주문체결내역상세요청) with the official body.
+
+        ROB-1155 — the previous implementation sent ``{"ord_no": ...}``: a field
+        that does not exist in kt00007's official request table, while omitting
+        all four Required=Y fields. Official body (verified 2026-07-29 against
+        https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00007&jobTp=FS_JOB_TP&jobTpCode=08
+        and the local extraction of the same doc) is exactly these 7 fields:
+
+            ord_dt (N) · qry_tp (Y) · stk_bond_tp (Y) · sell_tp (Y)
+            stk_cd (N) · fr_ord_no (N) · dmst_stex_tp (Y)
+
+        Optional fields are sent as empty strings, matching the official Request
+        Example (which spells out ``"ord_dt": ""`` rather than omitting the key);
+        key-omission and empty-string are not documented as equivalent.
+
+        ``from_order_no`` maps to ``fr_ord_no``, whose official semantics are
+        "start order number — earlier orders are excluded". It is a lower bound,
+        NOT an exact match, so single-order lookups must filter the response rows
+        on ``ord_no`` locally (see ``kiwoom_mock_get_order_detail``).
+
+        ``dmst_stex_tp`` accepts only ACCOUNT_READ_VENUE_ALLOWLIST ({KRX, NXT}).
+        This is a read-only observation argument: the order path (kt10000-kt10003)
+        is untouched and stays KRX-pinned.
+        """
+        venue = str(dmst_stex_tp).strip().upper()
+        if venue not in constants.ACCOUNT_READ_VENUE_ALLOWLIST:
+            raise ValueError(
+                "kt00007 read venue must be one of "
+                f"{sorted(constants.ACCOUNT_READ_VENUE_ALLOWLIST)}; got {dmst_stex_tp!r}"
+            )
+        query_type = str(qry_tp).strip()
+        if query_type not in constants.ACCOUNT_ORDER_DETAIL_QRY_TYPES:
+            raise ValueError(
+                "kt00007 qry_tp must be one of "
+                f"{sorted(constants.ACCOUNT_ORDER_DETAIL_QRY_TYPES)}; got {qry_tp!r}"
+            )
+        ord_dt = "" if order_date is None else str(order_date).strip()
+        if ord_dt and not re.fullmatch(r"[0-9]{8}", ord_dt):
+            raise ValueError(f"kt00007 order_date must be YYYYMMDD; got {order_date!r}")
+        stk_cd = "" if symbol is None else normalize_krx_symbol(symbol)
+        fr_ord_no = "" if from_order_no is None else str(from_order_no).strip()
+        if fr_ord_no and not re.fullmatch(r"[0-9]+", fr_ord_no):
+            raise ValueError(
+                f"kt00007 from_order_no must be numeric; got {from_order_no!r}"
+            )
         return await self._client.post_api(
             api_id=constants.ACCOUNT_ORDER_DETAIL_API_ID,
             path=ACCOUNT_PATH,
-            body={"ord_no": str(order_no).strip()},
+            body={
+                "ord_dt": ord_dt,
+                "qry_tp": query_type,
+                "stk_bond_tp": constants.ACCOUNT_ORDER_DETAIL_STK_BOND_TP_DEFAULT,
+                "sell_tp": constants.ACCOUNT_ORDER_DETAIL_SELL_TP_DEFAULT,
+                "stk_cd": stk_cd,
+                "fr_ord_no": fr_ord_no,
+                "dmst_stex_tp": venue,
+            },
             cont_yn=cont_yn,
             next_key=next_key,
         )

--- a/app/services/brokers/kiwoom/normalization.py
+++ b/app/services/brokers/kiwoom/normalization.py
@@ -221,6 +221,87 @@ def normalize_orders(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return orders
 
 
+def normalize_order_detail(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Parse kt00007 ``acnt_ord_cntr_prps_dtl`` rows (ROB-1155).
+
+    Deliberately a kt00007-only sibling of :func:`normalize_orders` rather than a
+    generalization of it: kt00009 returns ``acnt_ord_cntr_prst_array`` with
+    ``mdfy_cncl_tp``, while kt00007 returns ``acnt_ord_cntr_prps_dtl`` with
+    ``mdfy_cncl`` plus ``ord_remnq`` (주문잔량) and a per-row ``dmst_stex_tp``.
+    Widening the shared normalizer would put the already-shipped kt00009 read
+    surface at regression risk for no gain.
+
+    Evidence preserved beyond kt00009's shape:
+
+    * ``remaining_quantity`` — broker-reported ``ord_remnq``, not derived.
+    * ``unfilled_quantity`` — ``ord_qty - cntr_qty``, derived, for cross-checking.
+    * ``remaining_quantity_consistent`` — whether the two agree. A partial cancel
+      legitimately leaves ``ord_remnq`` below the unfilled amount, so a mismatch
+      in that direction is surfaced as a flag rather than an error.
+    * ``venue`` — raw per-row ``dmst_stex_tp``. Required=N in the official
+      response table, so ``None`` when the broker omits it; never fabricated.
+      This is the only field that can answer "which venue did the broker record
+      this order on", so it is passed through untransformed.
+    * ``change_type`` — raw ``mdfy_cncl`` text.
+
+    Fail-close on malformed evidence: missing list, non-mapping rows, non-numeric
+    ``ord_no``, missing/negative integers, non-positive ``ord_qty``, fills above
+    the ordered quantity, or a remaining quantity above the unfilled quantity
+    (arithmetically impossible).
+    """
+
+    orders: list[dict[str, Any]] = []
+    for row in _required_rows(payload, constants.ACCOUNT_ORDER_DETAIL_LIST_KEY):
+        ordered_quantity = _required_non_negative_int(row, "ord_qty")
+        filled_quantity = _required_non_negative_int(row, "cntr_qty")
+        remaining_quantity = _required_non_negative_int(row, "ord_remnq")
+        if ordered_quantity <= 0:
+            raise KiwoomMockEvidenceError("Kiwoom order quantity must be positive")
+        if filled_quantity > ordered_quantity:
+            raise KiwoomMockEvidenceError(
+                "Kiwoom filled quantity exceeds ordered quantity"
+            )
+        unfilled_quantity = ordered_quantity - filled_quantity
+        if remaining_quantity > unfilled_quantity:
+            raise KiwoomMockEvidenceError(
+                "Kiwoom remaining quantity exceeds unfilled quantity"
+            )
+
+        change_type = str(row.get("mdfy_cncl") or "").strip()
+        change_type_key = change_type.lower()
+        if "취소" in change_type or "cancel" in change_type_key:
+            status = "cancelled"
+        elif filled_quantity == 0:
+            status = "open"
+        elif filled_quantity < ordered_quantity:
+            status = "partially_filled"
+        else:
+            status = "filled"
+
+        raw_venue = row.get("dmst_stex_tp")
+        venue = str(raw_venue).strip() if raw_venue is not None else ""
+
+        orders.append(
+            {
+                "order_id": _required_order_id(row),
+                "symbol": _normalize_kr_symbol(row),
+                "status": status,
+                "ordered_quantity": ordered_quantity,
+                "ordered_price": _required_non_negative_int(row, "ord_uv"),
+                "filled_quantity": filled_quantity,
+                "average_price": _required_non_negative_int(row, "cntr_uv"),
+                "remaining_quantity": remaining_quantity,
+                "unfilled_quantity": unfilled_quantity,
+                "remaining_quantity_consistent": (
+                    remaining_quantity == unfilled_quantity
+                ),
+                "change_type": change_type or None,
+                "venue": venue or None,
+            }
+        )
+    return orders
+
+
 def redact_broker_response(payload: dict[str, Any]) -> dict[str, Any]:
     def is_sensitive_key(value: Any) -> bool:
         parts = _key_parts(value)
@@ -335,6 +416,7 @@ __all__ = [
     "build_mock_provenance",
     "normalize_deposit",
     "normalize_orderable_cash",
+    "normalize_order_detail",
     "normalize_orders",
     "normalize_positions",
     "redact_broker_response",

--- a/docs/runbooks/kiwoom-mock-smoke.md
+++ b/docs/runbooks/kiwoom-mock-smoke.md
@@ -40,8 +40,9 @@ these boundaries:
   필요가 입증되지 않았다(작동 중인 엔드포인트에 추측 파라미터를 더해 회귀시키지 않음).
   **이 판단은 ROB-1088(2026-07-28)에서 뒤집혔다** — kt00009는 공식 문서 확인 결과
   `dmst_stex_tp`를 포함한 5필드 전부가 Required=Y이며, 현재 코드는 5필드를 모두
-  보낸다(kt00007은 여전히 코드가 호출하지 않으므로 미해당). 아래 ROB-1111/ROB-1088
-  블록 참고.
+  보낸다. **kt00007도 ROB-1155(2026-07-29)에서 교정됐다** — 공식 요청 표의 7필드
+  (`ord_dt`/`qry_tp`/`stk_bond_tp`/`sell_tp`/`stk_cd`/`fr_ord_no`/`dmst_stex_tp`)를
+  보내며 그중 `dmst_stex_tp`는 Required=Y다. 아래 ROB-1111/ROB-1088 블록 참고.
   아래 smoke 체크리스트로 4개 read 도구를 한 번에 검증하여 잔여 누락을 선제 포착한다.
 - **ROB-899 — confirmed place preflight/dispatch client reuse:** confirmed place는
   preflight와 broker POST가 하나의 request-scoped `KiwoomMockClient`를 재사용하며,
@@ -169,12 +170,39 @@ stays deferred). To pick a conservative buy limit well below market that will
 | kt00001 | no-symbol 예수금/주문가능현금 | `qry_tp=2` | `ord_alow_amt` |
 | kt00010 | symbol/side/price 주문가능금액 | `stk_cd`, `trde_tp`, `uv` | `ord_alowa` |
 | kt00009 | 주문 이력 | `stk_bond_tp=0`, `mrkt_tp=0`, `sell_tp=0`, `qry_tp=0`, `dmst_stex_tp=KRX` | `acnt_ord_cntr_prst_array` |
+| kt00007 | 주문 체결 내역 상세 | `ord_dt=""`, `qry_tp=1`, `stk_bond_tp=0`, `sell_tp=0`, `stk_cd=""`, `fr_ord_no=""`, `dmst_stex_tp=KRX` | `acnt_ord_cntr_prps_dtl` |
 
 - 어떤 도구든 `필수입력 파라미터=<name>`(`return_code 2`)가 나오면 그 `<name>`을
   기록하고 해당 broker API 본문에 추가하는 follow-up을 연다(추측 금지, 증명된 누락만).
 - kt00009는 ROB-418(`stk_bond_tp`)·ROB-1111(`mrkt_tp`)·ROB-1088(공식 문서 확정,
   `sell_tp`/`qry_tp`/`dmst_stex_tp`)로 완전히 5필드 공식 계약을 만족하도록 복구됐다
-  — 위 ROB-1111/ROB-1088 경고 참고. kt00007은 코드가 아직 호출하지 않으므로 미해당.
+  — 위 ROB-1111/ROB-1088 경고 참고.
+- **ROB-1155(2026-07-29) — kt00007 공식 body 교정 + read-only MCP 노출:**
+  교정 전 `get_order_detail()`은 `{"ord_no": ...}` 단일 필드를 보냈다. `ord_no`는
+  kt00007 공식 요청 표에 **없는 필드**이고 Required=Y 4개(`qry_tp`/`stk_bond_tp`/
+  `sell_tp`/`dmst_stex_tp`)가 모두 빠져 있었다(→ `return_code 2` 구조). 지금은 위
+  표의 7필드를 보내며 optional 3필드는 공식 Request Example대로 빈 문자열로
+  **명시 전송**한다(키 생략 ≠ 빈 문자열; 문서에 등가라는 기재 없음).
+  - 신규 read 도구 `kiwoom_mock_get_order_detail` — `MCP_PROFILE=kiwoom`에만 등록된다.
+    `account_read`/`tradingcodex_execution` 제한 profile에는 **의도적으로 미노출**
+    (`ACCOUNT_READ_TOOL_NAMES`가 tradingcodex allowlist에 union되므로 전자에 넣으면
+    후자가 조용히 넓어진다).
+  - `scope` → 공식 `qry_tp`: `all`=1(주문순) · `all_reverse`=2(역순) ·
+    `unfilled`=3(미체결) · `filled`=4(체결내역만).
+  - `order_id`는 broker 쪽 `fr_ord_no`(**시작**주문번호 = 하한, exact match 아님)로
+    전달되고 **정확 일치 필터는 로컬**에서 한다. 응답의 `broker_order_count` vs
+    `matched_order_count`로 "창 안에 없음"과 "조회 실패"를 구분한다.
+  - `venue`는 **관측 전용** 인자이며 `{KRX, NXT}`만 받는다(`ACCOUNT_READ_VENUE_ALLOWLIST`).
+    🔴 주문 경로(kt10000-kt10003)의 `dmst_stex_tp=KRX` 고정과 `MOCK_REJECTED_EXCHANGES=
+    {NXT, SOR}`는 **불변**이고 이 allowlist는 주문 경로에서 참조되지 않는다. 공식
+    값인 `%`(전체)·`SOR`은 의도적으로 제외했다.
+  - 응답은 요청 venue와 broker가 기록한 행별 venue를 **양쪽 다** echo한다
+    (`requested_venue` / `response_venues`, 행 단위 `venue`) — CP6 판단 근거.
+  - ⚠️ **공식 문서는 mock 도메인을 "KRX만 지원가능"으로 표기한다. 이 교정은 "공식
+    계약에 맞는 요청을 보낸다"까지만 보장하고, 모의서버가 kt00007을 실제로
+    지원하는지·NXT 조회가 동작하는지는 증명하지 않는다.** 실지원 판정은 과거
+    주문번호로 하는 read-only broker smoke(`return_code`·요청 scope·응답 venue
+    원문 보존)와 그 결과에 대한 운영자 판단이 있어야 한다.
 - **US 경로(`kiwoom_mock_us_*`)는 kt00009/mrkt_tp와 무관하다** — `ust21050`/
   `ust21070`/`ust21510`/`ust21160` 등 별도 TR family를 쓰며 어떤 US 코드도
   `ACCOUNT_ORDER_STATUS_API_ID`("kt00009")를 참조하지 않는다(ROB-1088, 2026-07-28

--- a/tests/test_kiwoom_constants.py
+++ b/tests/test_kiwoom_constants.py
@@ -40,6 +40,34 @@ def test_kt00009_order_status_defaults():
     assert k.ACCOUNT_ORDER_MRKT_TP_DEFAULT == "0"
 
 
+def test_kt00007_order_detail_official_values():
+    # ROB-1155 — official kt00007 qry_tp enum: "1:주문순, 2:역순, 3:미체결,
+    # 4:체결내역만". Defaults for the two other Required=Y scope fields are 전체.
+    assert k.ACCOUNT_ORDER_DETAIL_QRY_TP_ORDER_SEQUENCE == "1"
+    assert k.ACCOUNT_ORDER_DETAIL_QRY_TP_REVERSE == "2"
+    assert k.ACCOUNT_ORDER_DETAIL_QRY_TP_UNFILLED == "3"
+    assert k.ACCOUNT_ORDER_DETAIL_QRY_TP_FILLED == "4"
+    assert k.ACCOUNT_ORDER_DETAIL_QRY_TYPES == frozenset({"1", "2", "3", "4"})
+    assert k.ACCOUNT_ORDER_DETAIL_QRY_TP_DEFAULT == "1"
+    assert k.ACCOUNT_ORDER_DETAIL_STK_BOND_TP_DEFAULT == "0"
+    assert k.ACCOUNT_ORDER_DETAIL_SELL_TP_DEFAULT == "0"
+    # kt00007's response list key differs from kt00009's acnt_ord_cntr_prst_array.
+    assert k.ACCOUNT_ORDER_DETAIL_LIST_KEY == "acnt_ord_cntr_prps_dtl"
+
+
+def test_read_venue_allowlist_does_not_relax_the_order_krx_pin():
+    # ROB-1155 hard invariant — the read-only observation allowlist is a separate
+    # constant from the order-path exchange boundary. NXT is observable but stays
+    # a rejected ORDER exchange; "%" and SOR are not observable either.
+    assert k.ACCOUNT_READ_VENUE_ALLOWLIST == frozenset({"KRX", "NXT"})
+    assert k.ACCOUNT_READ_VENUE_KRX == k.MOCK_EXCHANGE_KRX == "KRX"
+    assert k.ACCOUNT_READ_VENUE_NXT == "NXT"
+    assert k.MOCK_REJECTED_EXCHANGES == frozenset({"NXT", "SOR"})
+    assert "NXT" in k.MOCK_REJECTED_EXCHANGES
+    assert "SOR" not in k.ACCOUNT_READ_VENUE_ALLOWLIST
+    assert "%" not in k.ACCOUNT_READ_VENUE_ALLOWLIST
+
+
 def test_kt00001_deposit_qry_tp_is_general_query_two():
     # ROB-891 — Official kt00001 (예수금상세현황) body is exactly {"qry_tp": "2"}.
     # "2" is 일반조회, used for current orderable cash. Must NOT reuse

--- a/tests/test_kiwoom_domestic_account.py
+++ b/tests/test_kiwoom_domestic_account.py
@@ -227,16 +227,146 @@ async def test_get_order_status_dmst_stex_tp_never_nxt_or_sor():
 
 
 @pytest.mark.asyncio
-async def test_get_order_detail_uses_kt00007():
+async def test_get_order_detail_body_is_exactly_the_official_seven_fields():
+    # ROB-1155 — pins the exact kt00007 wire body to the official contract.
+    # Official request table (verified 2026-07-29 against
+    # https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00007&jobTp=FS_JOB_TP&jobTpCode=08
+    # and the local extraction of the same doc) is 7 fields:
+    #   ord_dt(N) qry_tp(Y) stk_bond_tp(Y) sell_tp(Y) stk_cd(N) fr_ord_no(N)
+    #   dmst_stex_tp(Y)
+    # The previous implementation sent {"ord_no": ...} — a field that does not
+    # exist in this TR's request table — and omitted all four Required=Y fields.
     fake = FakeClient()
     acct = KiwoomDomesticAccountClient(fake)
-    await acct.get_order_detail(order_no="0000111222")
+    await acct.get_order_detail()
     call = fake.calls[-1]
     assert call["api_id"] == constants.ACCOUNT_ORDER_DETAIL_API_ID
-    assert call["body"]["ord_no"] == "0000111222"
-    # ROB-460 boundary — kt00007 order-detail read left untouched (not proven to
-    # need dmst_stex_tp; not exercised by the bug). Smoke-validated follow-up.
-    assert "dmst_stex_tp" not in call["body"]
+    assert call["body"] == {
+        "ord_dt": "",
+        "qry_tp": constants.ACCOUNT_ORDER_DETAIL_QRY_TP_DEFAULT,
+        "stk_bond_tp": constants.ACCOUNT_ORDER_DETAIL_STK_BOND_TP_DEFAULT,
+        "sell_tp": constants.ACCOUNT_ORDER_DETAIL_SELL_TP_DEFAULT,
+        "stk_cd": "",
+        "fr_ord_no": "",
+        "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
+    }
+    # ord_no is NOT an official kt00007 request field.
+    assert "ord_no" not in call["body"]
+
+
+@pytest.mark.asyncio
+async def test_get_order_detail_sends_optional_fields_as_empty_strings():
+    # ROB-1155 — the official Request Example spells the optional fields out as
+    # "" rather than omitting the keys; key-omission is not documented as
+    # equivalent to an empty value, so we mirror the example.
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_detail()
+    body = fake.calls[-1]["body"]
+    for key in ("ord_dt", "stk_cd", "fr_ord_no"):
+        assert key in body
+        assert body[key] == ""
+
+
+@pytest.mark.asyncio
+async def test_get_order_detail_maps_optional_inputs_onto_official_fields():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_detail(
+        order_date="20260729",
+        qry_tp=constants.ACCOUNT_ORDER_DETAIL_QRY_TP_FILLED,
+        symbol="005930",
+        from_order_no="0000123",
+        cont_yn="Y",
+        next_key="page-2",
+    )
+    call = fake.calls[-1]
+    assert call["body"] == {
+        "ord_dt": "20260729",
+        "qry_tp": "4",
+        "stk_bond_tp": constants.ACCOUNT_ORDER_DETAIL_STK_BOND_TP_DEFAULT,
+        "sell_tp": constants.ACCOUNT_ORDER_DETAIL_SELL_TP_DEFAULT,
+        "stk_cd": "005930",
+        "fr_ord_no": "0000123",
+        "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
+    }
+    assert call["cont_yn"] == "Y"
+    assert call["next_key"] == "page-2"
+
+
+@pytest.mark.asyncio
+async def test_get_order_detail_defaults_to_krx():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_detail()
+    assert fake.calls[-1]["body"]["dmst_stex_tp"] == constants.MOCK_EXCHANGE_KRX
+
+
+@pytest.mark.asyncio
+async def test_get_order_detail_allows_nxt_for_read_only_observation():
+    # ROB-1155 — kt00007 is a read-only observation surface, so NXT is a legal
+    # query scope (CP6 needs to see which venue the broker recorded). This does
+    # NOT relax the order path: see
+    # test_order_krx_pin_is_unaffected_by_read_venue_allowlist below.
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_detail(dmst_stex_tp="NXT")
+    assert fake.calls[-1]["body"]["dmst_stex_tp"] == "NXT"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("venue", ["%", "SOR", "", "krx-nxt", "ALL", None])
+async def test_get_order_detail_rejects_venues_outside_the_read_allowlist(venue):
+    # ROB-1155 — "%"(전체) and SOR are official kt00007 values but deliberately
+    # NOT allowlisted: "%" would blend every venue into a surface whose safety
+    # boundary is per-venue, and SOR has no observation need.
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    with pytest.raises(ValueError):
+        await acct.get_order_detail(dmst_stex_tp=venue)
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("qry_tp", ["0", "5", "", "unfilled", None])
+async def test_get_order_detail_rejects_qry_tp_outside_official_values(qry_tp):
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    with pytest.raises(ValueError):
+        await acct.get_order_detail(qry_tp=qry_tp)
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("order_date", ["2026-07-29", "2026072", "abcdefgh"])
+async def test_get_order_detail_rejects_malformed_order_date(order_date):
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    with pytest.raises(ValueError):
+        await acct.get_order_detail(order_date=order_date)
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("from_order_no", ["12a", "0000123/../x", "12 34"])
+async def test_get_order_detail_rejects_non_numeric_from_order_no(from_order_no):
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    with pytest.raises(ValueError):
+        await acct.get_order_detail(from_order_no=from_order_no)
+    assert fake.calls == []
+
+
+def test_order_krx_pin_is_unaffected_by_read_venue_allowlist():
+    # ROB-1155 hard invariant — the read-only venue allowlist must never leak
+    # into the order path. NXT/SOR stay rejected exchanges for orders, and the
+    # order-side default stays KRX.
+    assert constants.ACCOUNT_READ_VENUE_ALLOWLIST == frozenset({"KRX", "NXT"})
+    assert constants.MOCK_REJECTED_EXCHANGES == frozenset({"NXT", "SOR"})
+    assert constants.MOCK_EXCHANGE_KRX == "KRX"
+    assert "NXT" in constants.MOCK_REJECTED_EXCHANGES
+    assert "SOR" not in constants.ACCOUNT_READ_VENUE_ALLOWLIST
+    assert "%" not in constants.ACCOUNT_READ_VENUE_ALLOWLIST
 
 
 @pytest.mark.asyncio

--- a/tests/test_kiwoom_mock_normalization.py
+++ b/tests/test_kiwoom_mock_normalization.py
@@ -9,6 +9,7 @@ from app.services.brokers.kiwoom.normalization import (
     KiwoomMockEvidenceError,
     build_mock_provenance,
     normalize_deposit,
+    normalize_order_detail,
     normalize_orderable_cash,
     normalize_orders,
     normalize_positions,
@@ -364,3 +365,187 @@ def test_mock_provenance_is_stable_and_api_specific() -> None:
         "host": "mockapi.kiwoom.com",
         "api_id": "kt00018",
     }
+
+
+# ---------------------------------------------------------------------------
+# ROB-1155 — kt00007 (계좌별주문체결내역상세요청) order-detail normalizer.
+#
+# Row shape below is taken from the official response table / Response Example
+# at https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00007&jobTp=FS_JOB_TP&jobTpCode=08
+# (list key acnt_ord_cntr_prps_dtl; mdfy_cncl and ord_remnq, NOT kt00009's
+# mdfy_cncl_tp), including the 0-padded numeric strings.
+# ---------------------------------------------------------------------------
+
+
+def _detail_row(**overrides: str) -> dict[str, str]:
+    row = {
+        "ord_no": "0000050",
+        "stk_cd": "A005930",
+        "ord_qty": "0000000010",
+        "ord_uv": "0000072300",
+        "cntr_qty": "0000000000",
+        "cntr_uv": "0000000000",
+        "ord_remnq": "0000000010",
+        "mdfy_cncl": "",
+        "dmst_stex_tp": "KRX",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_normalize_kt00007_order_detail_open_row() -> None:
+    payload = {"return_code": 0, "acnt_ord_cntr_prps_dtl": [_detail_row()]}
+
+    assert normalize_order_detail(payload) == [
+        {
+            "order_id": "0000050",
+            "symbol": "005930",
+            "status": "open",
+            "ordered_quantity": 10,
+            "ordered_price": 72_300,
+            "filled_quantity": 0,
+            "average_price": 0,
+            "remaining_quantity": 10,
+            "unfilled_quantity": 10,
+            "remaining_quantity_consistent": True,
+            "change_type": None,
+            "venue": "KRX",
+        }
+    ]
+
+
+def test_normalize_kt00007_order_detail_partial_and_filled_rows() -> None:
+    payload = {
+        "return_code": 0,
+        "acnt_ord_cntr_prps_dtl": [
+            _detail_row(
+                ord_no="0000051",
+                cntr_qty="0000000004",
+                cntr_uv="0000072000",
+                ord_remnq="0000000006",
+            ),
+            _detail_row(
+                ord_no="0000052",
+                cntr_qty="0000000010",
+                cntr_uv="0000072100",
+                ord_remnq="0000000000",
+            ),
+        ],
+    }
+
+    statuses = [row["status"] for row in normalize_order_detail(payload)]
+    assert statuses == ["partially_filled", "filled"]
+    rows = normalize_order_detail(payload)
+    assert rows[0]["remaining_quantity"] == 6
+    assert rows[0]["unfilled_quantity"] == 6
+    assert rows[1]["remaining_quantity"] == 0
+    assert all(row["remaining_quantity_consistent"] for row in rows)
+
+
+def test_normalize_kt00007_order_detail_cancelled_row_uses_mdfy_cncl() -> None:
+    # kt00007's cancel marker is mdfy_cncl, not kt00009's mdfy_cncl_tp.
+    payload = {
+        "return_code": 0,
+        "acnt_ord_cntr_prps_dtl": [
+            _detail_row(ord_no="0000053", mdfy_cncl="취소", ord_remnq="0000000000")
+        ],
+    }
+
+    (row,) = normalize_order_detail(payload)
+    assert row["status"] == "cancelled"
+    assert row["change_type"] == "취소"
+    assert row["remaining_quantity"] == 0
+
+
+def test_normalize_kt00007_order_detail_flags_partial_cancel_remainder() -> None:
+    # A partial cancel legitimately drops ord_remnq below the unfilled amount.
+    # That is surfaced as a flag, not a fail-close, because the broker — not our
+    # arithmetic — owns 주문잔량.
+    payload = {
+        "return_code": 0,
+        "acnt_ord_cntr_prps_dtl": [
+            _detail_row(cntr_qty="0000000004", ord_remnq="0000000002")
+        ],
+    }
+
+    (row,) = normalize_order_detail(payload)
+    assert row["unfilled_quantity"] == 6
+    assert row["remaining_quantity"] == 2
+    assert row["remaining_quantity_consistent"] is False
+
+
+def test_normalize_kt00007_order_detail_preserves_response_venue() -> None:
+    # CP6 evidence: the venue the broker recorded, passed through untransformed.
+    payload = {
+        "return_code": 0,
+        "acnt_ord_cntr_prps_dtl": [
+            _detail_row(ord_no="0000054", dmst_stex_tp="NXT"),
+            _detail_row(ord_no="0000055", dmst_stex_tp="SOR"),
+        ],
+    }
+
+    assert [row["venue"] for row in normalize_order_detail(payload)] == ["NXT", "SOR"]
+
+
+def test_normalize_kt00007_order_detail_venue_is_none_when_broker_omits_it() -> None:
+    # dmst_stex_tp is Required=N in the official response table — absent means
+    # unknown, never a fabricated "KRX".
+    payload = {
+        "return_code": 0,
+        "acnt_ord_cntr_prps_dtl": [
+            {k: v for k, v in _detail_row().items() if k != "dmst_stex_tp"},
+            _detail_row(ord_no="0000056", dmst_stex_tp="   "),
+        ],
+    }
+
+    assert [row["venue"] for row in normalize_order_detail(payload)] == [None, None]
+
+
+def test_normalize_kt00007_order_detail_rejects_kt00009_payload_shape() -> None:
+    # Guards against wiring the kt00009 list key into the kt00007 tool.
+    payload = {
+        "return_code": 0,
+        "acnt_ord_cntr_prst_array": [_detail_row()],
+    }
+
+    with pytest.raises(KiwoomMockEvidenceError):
+        normalize_order_detail(payload)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"ord_no": "ORD-50"},
+        {"ord_no": ""},
+        {"ord_qty": "0000000000"},
+        {"ord_qty": ""},
+        {"ord_qty": "-0000000010"},
+        {"cntr_qty": "0000000011"},
+        {"cntr_qty": "abc"},
+        {"ord_remnq": ""},
+        {"ord_remnq": "0000000011"},
+        {"cntr_uv": "-0000000001"},
+        {"stk_cd": "AAPL"},
+        {"stk_cd": ""},
+    ],
+)
+def test_normalize_kt00007_order_detail_fails_closed_on_malformed_rows(
+    overrides: dict[str, str],
+) -> None:
+    payload = {"return_code": 0, "acnt_ord_cntr_prps_dtl": [_detail_row(**overrides)]}
+
+    with pytest.raises(KiwoomMockEvidenceError):
+        normalize_order_detail(payload)
+
+
+@pytest.mark.parametrize("rows", [None, {}, "rows", [["not-a-mapping"]], [None]])
+def test_normalize_kt00007_order_detail_fails_closed_on_malformed_list(rows) -> None:
+    with pytest.raises(KiwoomMockEvidenceError):
+        normalize_order_detail({"return_code": 0, "acnt_ord_cntr_prps_dtl": rows})
+
+
+def test_normalize_kt00007_order_detail_accepts_empty_list() -> None:
+    # An empty result is a legitimate broker answer, not malformed evidence.
+    assert (
+        normalize_order_detail({"return_code": 0, "acnt_ord_cntr_prps_dtl": []}) == []
+    )

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -30,6 +30,7 @@ EXPECTED_TOOL_NAMES = {
     "kiwoom_mock_cancel_order",
     "kiwoom_mock_modify_order",
     "kiwoom_mock_get_order_history",
+    "kiwoom_mock_get_order_detail",
     "kiwoom_mock_get_positions",
     "kiwoom_mock_get_orderable_cash",
 }
@@ -41,7 +42,7 @@ def _register(mcp: DummyMCP) -> None:
     orders_kiwoom_variants.register(mcp)
 
 
-def test_all_seven_tools_register():
+def test_all_eight_tools_register():
     mcp = DummyMCP()
     _register(mcp)
     assert EXPECTED_TOOL_NAMES.issubset(set(mcp.tools))
@@ -956,6 +957,13 @@ def _patch_fake_kiwoom_account_client(monkeypatch, mod, payloads):
             calls.append({"method": "order_status", **kwargs})
             return payloads.get("order_status", {"return_code": 0})
 
+        async def get_order_detail(self, **kwargs):
+            calls.append({"method": "order_detail", **kwargs})
+            return payloads.get(
+                "order_detail",
+                {"return_code": 0, "acnt_ord_cntr_prps_dtl": []},
+            )
+
     monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
     monkeypatch.setattr(mod, "KiwoomMockClient", FakeKiwoomMockClient, raising=False)
     monkeypatch.setattr(
@@ -1693,6 +1701,7 @@ async def test_registered_order_history_recursively_redacts_aliases_and_passthro
     [
         ("kiwoom_mock_get_positions", "positions", "kt00018"),
         ("kiwoom_mock_get_order_history", "orders", "kt00009"),
+        ("kiwoom_mock_get_order_detail", "orders", "kt00007"),
     ],
 )
 async def test_registered_reads_config_failure_has_stable_envelope(
@@ -1752,6 +1761,7 @@ async def test_registered_cash_config_failure_has_stable_source(
     [
         ("kiwoom_mock_get_positions", "positions", "kt00018"),
         ("kiwoom_mock_get_order_history", "orders", "kt00009"),
+        ("kiwoom_mock_get_order_detail", "orders", "kt00007"),
     ],
 )
 async def test_registered_reads_transport_exception_has_stable_envelope(
@@ -1772,6 +1782,9 @@ async def test_registered_reads_transport_exception_has_stable_envelope(
             raise RuntimeError("transport secret must not escape")
 
         async def get_order_status(self, **kwargs):  # noqa: ARG002
+            raise RuntimeError("transport secret must not escape")
+
+        async def get_order_detail(self, **kwargs):  # noqa: ARG002
             raise RuntimeError("transport secret must not escape")
 
     monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
@@ -1797,6 +1810,7 @@ async def test_registered_reads_transport_exception_has_stable_envelope(
     [
         ("kiwoom_mock_get_positions", "positions", "kt00018", "balance"),
         ("kiwoom_mock_get_order_history", "orders", "kt00009", "order_status"),
+        ("kiwoom_mock_get_order_detail", "orders", "kt00007", "order_detail"),
     ],
 )
 async def test_registered_reads_broker_failure_has_stable_envelope(
@@ -1864,6 +1878,409 @@ async def test_registered_order_history_rejects_malformed_official_order_id(
         api_id="kt00009",
         error="kiwoom_mock_evidence_invalid",
     )
+
+
+# ---------------------------------------------------------------------------
+# ROB-1155 — kt00007 read-only order-detail tool
+# ---------------------------------------------------------------------------
+
+_DETAIL_ROW = {
+    "ord_no": "0000050",
+    "stk_cd": "A005930",
+    "ord_qty": "0000000010",
+    "ord_uv": "0000072300",
+    "cntr_qty": "0000000004",
+    "cntr_uv": "0000072000",
+    "ord_remnq": "0000000006",
+    "mdfy_cncl": "",
+    "dmst_stex_tp": "KRX",
+}
+
+
+def _detail_payload(*rows: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "return_code": 0,
+        "return_msg": "조회가 완료되었습니다",
+        "acnt_ord_cntr_prps_dtl": list(rows) or [dict(_DETAIL_ROW)],
+    }
+
+
+def _patch_detail(monkeypatch, mod, payload: dict[str, Any] | None = None):
+    return _patch_fake_kiwoom_account_client(
+        monkeypatch,
+        mod,
+        payloads={
+            "orderable_amount": {"return_code": 0},
+            "balance": {"return_code": 0},
+            "order_status": {"return_code": 0},
+            "order_detail": payload if payload is not None else _detail_payload(),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_order_detail_sends_official_kt00007_scope_and_echoes_request(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](
+        order_id="0000050", order_date="20260729", scope="filled", symbol="005930"
+    )
+
+    detail_call = next(c for c in calls if c.get("method") == "order_detail")
+    assert detail_call["order_date"] == "20260729"
+    assert detail_call["qry_tp"] == "4"  # official: 4:체결내역만
+    assert detail_call["symbol"] == "005930"
+    assert detail_call["from_order_no"] == "0000050"
+    assert detail_call["dmst_stex_tp"] == "KRX"
+
+    assert response["success"] is True
+    assert response["provenance"]["api_id"] == "kt00007"
+    assert response["requested_scope"] == "filled"
+    assert response["requested_qry_tp"] == "4"
+    assert response["requested_venue"] == "KRX"
+    assert response["order_id"] == "0000050"
+    assert response["order_date"] == "20260729"
+
+
+@pytest.mark.asyncio
+async def test_order_detail_normalizes_rows_and_preserves_remnq_and_venue(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"]()
+
+    assert response["orders"] == [
+        {
+            "order_id": "0000050",
+            "symbol": "005930",
+            "status": "partially_filled",
+            "ordered_quantity": 10,
+            "ordered_price": 72_300,
+            "filled_quantity": 4,
+            "average_price": 72_000,
+            "remaining_quantity": 6,
+            "unfilled_quantity": 6,
+            "remaining_quantity_consistent": True,
+            "change_type": None,
+            "venue": "KRX",
+        }
+    ]
+    assert response["response_venues"] == ["KRX"]
+
+
+@pytest.mark.asyncio
+async def test_order_detail_filters_to_the_exact_order_number(monkeypatch):
+    # fr_ord_no is a LOWER BOUND per the official docs ("이전 주문은 조회되지
+    # 않음"), so the broker legitimately returns later orders too. Without the
+    # local exact filter a single-order lookup would report unrelated orders.
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(
+        monkeypatch,
+        mod,
+        _detail_payload(
+            dict(_DETAIL_ROW),
+            {**_DETAIL_ROW, "ord_no": "0000051", "stk_cd": "A000660"},
+            {**_DETAIL_ROW, "ord_no": "0000052", "stk_cd": "A035420"},
+        ),
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](order_id="0000050")
+
+    assert [row["order_id"] for row in response["orders"]] == ["0000050"]
+    assert response["broker_order_count"] == 3
+    assert response["matched_order_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_order_detail_without_order_id_returns_every_row(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(
+        monkeypatch,
+        mod,
+        _detail_payload(
+            dict(_DETAIL_ROW),
+            {**_DETAIL_ROW, "ord_no": "0000051", "stk_cd": "A000660"},
+        ),
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"]()
+
+    assert [row["order_id"] for row in response["orders"]] == ["0000050", "0000051"]
+    assert response["matched_order_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_order_detail_unmatched_order_id_is_success_with_zero_matches(
+    monkeypatch,
+):
+    # "Broker answered, order not in the window" must be distinguishable from
+    # "read failed" — success stays True and the count says zero.
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](order_id="9999999")
+
+    assert response["success"] is True
+    assert response["orders"] == []
+    assert response["broker_order_count"] == 1
+    assert response["matched_order_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_order_detail_reports_response_venue_mismatch_evidence(monkeypatch):
+    # CP6: requested venue vs the venue the broker actually recorded are both
+    # surfaced, so a mismatch is visible without re-parsing broker_response.
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(
+        monkeypatch,
+        mod,
+        _detail_payload(
+            {**_DETAIL_ROW, "dmst_stex_tp": "NXT"},
+            {**_DETAIL_ROW, "ord_no": "0000051", "dmst_stex_tp": "KRX"},
+        ),
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](venue="KRX")
+
+    assert response["requested_venue"] == "KRX"
+    assert response["response_venues"] == ["KRX", "NXT"]
+
+
+@pytest.mark.asyncio
+async def test_order_detail_accepts_nxt_as_a_read_only_observation_venue(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](venue="NXT")
+
+    detail_call = next(c for c in calls if c.get("method") == "order_detail")
+    assert detail_call["dmst_stex_tp"] == "NXT"
+    assert response["success"] is True
+    assert response["requested_venue"] == "NXT"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("venue", ["%", "SOR", "sor", "", "ALL"])
+async def test_order_detail_rejects_venues_outside_the_read_allowlist(
+    monkeypatch, venue
+):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](venue=venue)
+
+    _assert_stable_read_failure(
+        response,
+        result_key="orders",
+        api_id="kt00007",
+        error="kiwoom_mock_read_venue_invalid",
+    )
+    assert not [c for c in calls if c.get("method") == "order_detail"]
+
+
+@pytest.mark.asyncio
+async def test_order_detail_rejects_unknown_scope(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](scope="everything")
+
+    _assert_stable_read_failure(
+        response,
+        result_key="orders",
+        api_id="kt00007",
+        error="kiwoom_mock_read_scope_invalid",
+    )
+    assert not [c for c in calls if c.get("method") == "order_detail"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_order_id", ["   ", "12 34", "../123", "123?x=1", "12/34"])
+async def test_order_detail_rejects_unsafe_order_ids(monkeypatch, bad_order_id):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](order_id=bad_order_id)
+
+    _assert_stable_read_failure(
+        response,
+        result_key="orders",
+        api_id="kt00007",
+        error="kiwoom_mock_order_id_invalid",
+    )
+    assert not [c for c in calls if c.get("method") == "order_detail"]
+
+
+@pytest.mark.asyncio
+async def test_order_detail_rejects_non_krx_symbol(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = _patch_detail(monkeypatch, mod)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](symbol="AAPL")
+
+    _assert_stable_read_failure(
+        response,
+        result_key="orders",
+        api_id="kt00007",
+        error="kiwoom_mock_symbol_invalid",
+    )
+    assert not [c for c in calls if c.get("method") == "order_detail"]
+
+
+@pytest.mark.asyncio
+async def test_order_detail_rejects_malformed_order_date_without_dispatch(monkeypatch):
+    # The client raises ValueError locally, so the request is provably never
+    # dispatched — classified as request-invalid, not transport failure.
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    class FakeKiwoomMockClient:
+        @classmethod
+        def from_app_settings(cls):
+            return cls()
+
+    monkeypatch.setattr(mod, "KiwoomMockClient", FakeKiwoomMockClient, raising=False)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](order_date="2026-07-29")
+
+    _assert_stable_read_failure(
+        response,
+        result_key="orders",
+        api_id="kt00007",
+        error="kiwoom_mock_request_invalid",
+    )
+
+
+@pytest.mark.asyncio
+async def test_order_detail_fails_closed_on_live_provenance(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(
+        monkeypatch,
+        mod,
+        {
+            "return_code": 0,
+            "provenance": {"environment": "live", "host": "api.kiwoom.com"},
+            "acnt_ord_cntr_prps_dtl": [],
+        },
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"]()
+
+    _assert_stable_read_failure(
+        response,
+        result_key="orders",
+        api_id="kt00007",
+        error="kiwoom_mock_provenance_conflict",
+    )
+
+
+@pytest.mark.asyncio
+async def test_order_detail_redacts_account_identifiers(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(
+        monkeypatch,
+        mod,
+        {
+            "return_code": 0,
+            "acnt_no": "12345678-01",
+            "authorization": "Bearer super-secret",
+            "acnt_ord_cntr_prps_dtl": [dict(_DETAIL_ROW)],
+        },
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"]()
+
+    rendered = str(response)
+    assert "12345678-01" not in rendered
+    assert "super-secret" not in rendered
+    assert response["broker_response"]["acnt_no"] == "[REDACTED]"
+
+
+@pytest.mark.asyncio
+async def test_order_detail_fails_closed_on_malformed_rows(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(
+        monkeypatch, mod, _detail_payload({**_DETAIL_ROW, "ord_no": "ORD-50"})
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"]()
+
+    _assert_stable_read_failure(
+        response,
+        result_key="orders",
+        api_id="kt00007",
+        error="kiwoom_mock_evidence_invalid",
+    )
+
+
+@pytest.mark.asyncio
+async def test_order_detail_never_constructs_an_order_client(monkeypatch):
+    # Read-only by construction: the kt00007 path must not be able to reach
+    # place/modify/cancel.
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    _patch_detail(monkeypatch, mod)
+
+    def exploded_order_client(*_args, **_kwargs):
+        raise AssertionError("read tool must never build an order client")
+
+    monkeypatch.setattr(
+        mod, "KiwoomDomesticOrderClient", exploded_order_client, raising=False
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_get_order_detail"](order_id="0000050")
+
+    assert response["success"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -61,6 +61,7 @@ from app.mcp_server.tooling.paper_limit_order_handler import (
 )
 from app.mcp_server.tooling.registry import register_all_tools
 from app.mcp_server.tooling.tradingcodex_execution_registration import (
+    KIWOOM_MOCK_EXECUTION_TOOL_NAMES,
     TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES,
     TRADINGCODEX_EXECUTION_TOOL_NAMES,
 )
@@ -321,7 +322,11 @@ _ORDER_SURFACE_MATRIX: dict[McpProfile, set[str]] = {
         "kis_live_place_order",
         "kis_live_cancel_order",
         "kis_live_get_order_history",
-        *KIWOOM_MOCK_TOOL_NAMES,
+        # ROB-1155 — the explicit tradingcodex allowlist, NOT the full
+        # KIWOOM_MOCK_TOOL_NAMES set: kiwoom_mock_get_order_detail (kt00007) is
+        # registered on the KIWOOM profile only and must stay out of this
+        # privileged profile unless added deliberately.
+        *KIWOOM_MOCK_EXECUTION_TOOL_NAMES,
         "toss_preview_order",
         "toss_place_order",
         "toss_cancel_order",
@@ -575,6 +580,17 @@ class TestAccountReadProfile:
             "kiwoom_mock_get_orderable_cash",
             "kiwoom_mock_get_order_history",
         }
+
+    def test_kt00007_order_detail_is_deliberately_absent(self) -> None:
+        # ROB-1155 — kiwoom_mock_get_order_detail is a pure read but is NOT on
+        # this profile by design: ACCOUNT_READ_TOOL_NAMES is unioned into
+        # TRADINGCODEX_EXECUTION_TOOL_NAMES, so listing it here would silently
+        # widen that privileged profile as well. Absence here is a decision, not
+        # an oversight; KR-B1 reaches the tool via MCP_PROFILE=kiwoom.
+        mcp = _build_mcp(McpProfile.ACCOUNT_READ)
+        assert "kiwoom_mock_get_order_detail" not in mcp.tools
+        assert "kiwoom_mock_get_order_detail" in KIWOOM_MOCK_TOOL_NAMES
+        assert "kiwoom_mock_get_order_detail" in _build_mcp(McpProfile.KIWOOM).tools
 
     def test_expected_account_read_tools_are_present(self) -> None:
         mcp = _build_mcp(McpProfile.ACCOUNT_READ)


### PR DESCRIPTION
Closes part of ROB-1155 (steps 1–4 only). Steps 5 (read-only broker smoke) and 6 (P0 evidence adoption) are **out of scope for this PR** and belong to a separate verifier / the operator.

## Why this is a bug fix, not just an exposure

`kt00007` (계좌별주문체결내역상세요청) was not an unexposed-but-correct implementation. `get_order_detail()` sent:

```python
body={"ord_no": str(order_no).strip()}
```

`ord_no` **is not a field in kt00007's official request table**, and all four `Required=Y` fields were missing. Wrapping this in MCP as-is would have produced `return_code 2 (필수입력 파라미터)`.

Official request body — verified 2026-07-29 against the [official doc](https://openapi.kiwoom.com/m/guide/apiguide?apiId=kt00007&jobTp=FS_JOB_TP&jobTpCode=08) directly *and* the local doc extraction:

| field | Required | note |
|---|---|---|
| `ord_dt` | N | YYYYMMDD |
| `qry_tp` | **Y** | 1:주문순 2:역순 3:미체결 4:체결내역만 |
| `stk_bond_tp` | **Y** | 0:전체 |
| `sell_tp` | **Y** | 0:전체 |
| `stk_cd` | N | 전체는 빈값 |
| `fr_ord_no` | N | **시작**주문번호 — 하한, exact match 아님 |
| `dmst_stex_tp` | **Y** | %/KRX/NXT/SOR |

Optional fields are sent as empty strings, mirroring the official Request Example (`"ord_dt": ""`); key omission is not documented as equivalent to an empty value.

## What changed

- **`constants.py`** — official kt00007 scope values, response list key, and a **new, separate** `ACCOUNT_READ_VENUE_ALLOWLIST = {KRX, NXT}`.
- **`domestic_account.py`** — `get_order_detail()` now sends the exact 7-field official body, validating venue / `qry_tp` / date shape / order-number shape locally before dispatch.
- **`normalization.py`** — `normalize_order_detail()`, a **kt00007-only sibling** of `normalize_orders` (kt00007: `acnt_ord_cntr_prps_dtl` + `mdfy_cncl` + `ord_remnq` + per-row `dmst_stex_tp`; kt00009: `acnt_ord_cntr_prst_array` + `mdfy_cncl_tp`). Widening the shared normalizer would have put the already-shipped kt00009 read surface at regression risk for no gain. Preserves broker-reported 주문잔량, the derived unfilled quantity, a consistency flag, and the raw venue; absent venue is `None`, never a fabricated `"KRX"`.
- **`orders_kiwoom_variants.py`** — `kiwoom_mock_get_order_detail` read tool + a sibling finalizer. **216 insertions, 0 deletions.** `order_id` maps to `fr_ord_no` (a lower bound), so exact matching is local, and `broker_order_count` vs `matched_order_count` separates "not in window" from "read failed".
- **`route_request_lanes.py`** — classified into `STATUS_HELPER_TOOLS` (keeps the action taxonomy disjoint-and-total).
- **runbook** — kt00007 row + the ROB-1155 block, including the explicit "official contract ≠ mock support" caveat.

## 🔴 Order hot path untouched

`domestic_orders.py`, `order_preflight.py`, `orders_modify_cancel.py` are **not in this diff**. `_exchange_error`, `_ensure_krx`, `MOCK_REJECTED_EXCHANGES`, `ACCOUNT_DMST_STEX_TP_DEFAULT` and the kt10000–kt10003 `dmst_stex_tp=KRX` pin are unchanged. The read venue allowlist is a separate constant that no order path references. Pinned by `test_order_krx_pin_is_unaffected_by_read_venue_allowlist` and `test_read_venue_allowlist_does_not_relax_the_order_krx_pin`.

Deliberately **not** done: no ledger work (ROB-1153 stays parked), no new scheduler, no gate relaxation, no exposure on the restricted `account_read` / `tradingcodex_execution` profiles (that set is unioned into the privileged allowlist — absence is pinned as a decision by `test_kt00007_order_detail_is_deliberately_absent`).

## What this does NOT claim

**It is not claimed that mockapi.kiwoom.com actually supports kt00007.** The official doc marks the mock domain "KRX만 지원가능", and codex-mock left real mock support as *unknown*. This PR only makes the request conform to the official contract. The NXT read argument guarantees "an NXT request can be formed" — it does not prove an empty NXT result means non-migration rather than mock non-support. Real support needs a read-only broker smoke on a known past order number (`return_code` / requested scope / response venue preserved verbatim) and an operator ruling.

## Tests

`make lint` clean (ruff check + format + ty). Targeted sweep: **638 passed**. Full `pytest -m "not live"`: **17316 passed, 4 failed** — those 4 (`daily_candles/test_full_cycle.py` ×3, `test_forecast_read_window_candles.py` ×1, all `relation "public.kr_candles_1d" does not exist`) reproduce identically on canonical `main` @ `7b0d3a113` and are unrelated to this change.

False-green check — three mutations were each caught: dropping `ord_dt` from the body (3 failures), removing the exact order-number local filter (2 failures), widening the read allowlist to `SOR`/`%` (7 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only order-detail lookup for Kiwoom accounts.
  * Supports filtering by order ID, date, symbol, scope, and venue.
  * Returns normalized order status, quantities, prices, and venue details.
  * Supports KRX and NXT for read-only observations while maintaining safety restrictions.

* **Bug Fixes**
  * Corrected order-detail request fields and validation.
  * Added fail-closed handling for invalid inputs, malformed broker data, and unsupported venues.

* **Documentation**
  * Updated the Kiwoom mock smoke runbook with the new order-detail workflow and safety requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->