### PR TITLE
test: fix 4th order dependency and restore cache-hit coverage (ROB-1144 follow-up)

### DIFF
--- a/tests/brokers/kis/test_vts_distributed_gate.py
+++ b/tests/brokers/kis/test_vts_distributed_gate.py
@@ -202,6 +202,21 @@ def real_redis() -> Any:
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_real_redis_state(request: pytest.FixtureRequest):
+    """Keep module-scoped Redis state within each test that requests it."""
+    if "real_redis" not in request.fixturenames:
+        yield
+        return
+
+    rd = request.getfixturevalue("real_redis")
+    rd.flush()
+    try:
+        yield
+    finally:
+        rd.flush()
+
+
 def _make_gate(
     redis_url: str,
     *,

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -166,6 +166,24 @@ async def test_cache_returns_isolated_copies(db_session, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_cache_hit_returns_isolated_copy(db_session, monkeypatch):
+    async def empty_load_fills(*a, **k):
+        return []
+
+    monkeypatch.setattr(agg, "load_fills", empty_load_fills)
+    stamp = datetime(2026, 7, 6, tzinfo=UTC)
+
+    await agg.build_trading_scoreboard(db_session, now=stamp)  # populate
+    cached = await agg.build_trading_scoreboard(db_session, now=stamp)  # hit
+    cached["groups"].append({"tag": "MUTANT"})
+    cached["count"] = 999
+
+    later = await agg.build_trading_scoreboard(db_session, now=stamp)  # hit again
+    assert later["groups"] == []
+    assert later["count"] == 0
+
+
+@pytest.mark.asyncio
 async def test_counterfactual_delta_loads_fills_once(db_session, monkeypatch):
     calls = []
 


### PR DESCRIPTION
## 배경

PR #1722 (ROB-1144, `test/stabilization-batch1`) 는 SHA `169cbf44a` 상태로 머지됐다.
그 SHA 에 대한 **2차 독립 적대검증**이 판정 **FIX NEEDED** 로 findings 2건을 냈고,
머지가 진행되는 동안 그 2건에 대한 수정이 완료됐다. 이 PR 은 그 수정만 담은 후속이다.

원본 커밋: `8a83b8d0d` (머지된 `test/stabilization-batch1` 위에 있어 최신 `origin/main`
기준 새 브랜치로 cherry-pick). 트리는 원본과 동일하다.

검증 보고 원문:
- 1차: `~/work/herdr-inbox/rob1144-verify-2026-07-29.md`
- 2차: `~/work/herdr-inbox/rob1144-nb-verify-2026-07-29.md`
- 작업 보고: `~/work/herdr-inbox/rob1144-nb-2026-07-29.md`

## 변경 (tests-only, +33 / −0)

### 1. `tests/brokers/kis/test_vts_distributed_gate.py` — 4번째 순서 의존성 제거

`real_redis` 가 module-scoped 인데 테스트 간 flush 가 없어, 선행 테스트들이 남긴 게이트
슬롯 예약이 누적됐다. `test_first_admit_is_immediate` 가 랜덤 순서에서 뒤로 밀리면
`contention_attempts == 1` 이 깨진다.

```
검증자 발견 (새 seed 8675309, 부하 없는 클린 재실행):
FAILED tests/brokers/kis/test_vts_distributed_gate.py::test_first_admit_is_immediate
  AssertionError: assert 2 == 1
  waited_seconds=0.8316272399388254, contention_attempts=2
1 failed, 17242 passed, 10 skipped in 382.49s
```

- merge-base clone 에서도 같은 seed 로 동일 재현 → **PR #1722 유발 아님, 기존 결함**
- 선언 순서(`-p no:randomly`)에서는 `47 passed`
- 조치: autouse `_isolate_real_redis_state` 가 `real_redis` 를 요청한 테스트에 한해
  전/후 `flush()`. **skip/xfail 추가나 기대값 완화 없음** — `contention_attempts == 1`
  계약은 그대로 보존했다.

### 2. `tests/services/test_trade_journal_aggregates_scoreboard.py` — #1722 이 없앤 탐지력 복구

#1722 에서 추가한 autouse `_isolate_scoreboard_cache`(module-global 캐시 격리, 그 자체는
옳은 수정)가 부작용으로 **cache hit read-side 방어 복사의 mutation 탐지력**을 없앴다.
merge-base 에서는 테스트 오염 덕에 *우연히* 잡히고 있던 커버리지였다.

```
mutation: aggregates.py:758  return copy.deepcopy(cached[1]) → return cached[1]
  #1722 머지 SHA (fixture 있음)  : 13 passed        → SURVIVED
  merge-base       (fixture 없음): 1 failed, 12 passed → RED
```

- 조치: `test_cache_hit_returns_isolated_copy` 1건 추가 — call1 적재 → call2 가 hit →
  call2 결과 변형 → call3 이 오염되지 않음을 assert. 우연한 오염에 의존하지 않고
  테스트가 스스로 hit 상황을 만든다.
- 격리 fixture 는 유지했다. 없앤 커버리지를 명시 테스트로 되살리는 방향이다.

## 검증

랜덤 순서 전체 스위트 (`uv run --with pytest-randomly pytest tests/ -q -ra -m "not live"
--no-cov -n 4 --dist=loadfile --randomly-seed=<SEED>`), 각 실행은 병행 부하 없이 단독:

| seed | 결과 |
|---|---|
| 8675309 (finding 을 드러낸 seed) | **17,244 passed, 10 skipped** in 312.84s |
| 20260730 | **17,244 passed, 10 skipped** in 459.57s |
| 424242 | 최초 1 failed → 클린 재실행 **17,244 passed, 10 skipped** in 538.17s |

새 브랜치(최신 `origin/main` 기준)에서 대상 2파일 + seed 8675309: `61 passed in 25.03s`.

`make lint` 통과. `app/**`·`alembic/**`·`config/**`·broker/order/ledger/scheduler 변경 0건.
`pyproject.toml`/lockfile 변경 0건 (`pytest-randomly` 는 `uv run --with` overlay 전용).
skip/xfail 추가 0건, assertion 삭제 0건.

## 알려진 미해결 (이 PR 범위 아님)

1. **`test_consecutive_gainers_filters_by_market_cap_and_trade_value` 비결정 실패** —
   seed 424242 최초 실행에서 1회 실패, 파일 단독(같은 seed) `13 passed`,
   클린 재실행 전체 green. 순서-결정적이 아니라 비결정적이며 재현되지 않았다.
   별건 추적 필요.
2. **테스트 스키마 미러 드리프트 가드 부재** — `tests/_schema_bootstrap.py` 의
   candle DDL 과 raw-SQL 마이그레이션은 현재 논리 스키마 100% 일치하나, 자동 대조
   장치가 없어 향후 드리프트 가능. 후속 별건 권고.
3. **`app/mcp_server/tooling/screening/kr.py:391` valuation merge 커버리지 공백** —
   무력화 mutation 이 merge-base·HEAD 양쪽에서 SURVIVED. 사전 존재 별건, 미수정.
4. **scoreboard cache write 무력화 mutation** 은 양쪽 SURVIVED — 사전 존재 별건.

## 계약 대조

- ROB-501 런타임 LLM 경계: `app/**` 변경 0, 정적 가드 통과
- 브로커 게이트·env 게이트·`confirm=True`·하드 인바리언트: 런타임 파일 diff 부재로 무변경
- 레저 직접 SQL·신규 스케줄러 등록: 해당 없음
- tests-only diff, secret material 없음
