### PR TITLE
ROB-1161: US regular-session raw evidence capture

### DIFF
--- a/app/services/us_regular_session_raw_capture.py
+++ b/app/services/us_regular_session_raw_capture.py
@@ -13,7 +13,7 @@ import os
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, time
+from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Protocol
@@ -180,6 +180,57 @@ def _write_append_only(path: Path, data: bytes) -> None:
         artifact.write(data)
 
 
+def _attempt_record(
+    *,
+    request: CaptureRequest,
+    started: datetime,
+    finished: datetime,
+    status: int | None,
+    response_headers: dict[str, str],
+    raw: bytes,
+    outcome: str,
+    transport_error: str | None,
+    session_label: str,
+    u06_shadow: bool,
+) -> dict[str, Any]:
+    body, encoding = _sanitize_body(raw)
+    body_bytes = body.encode("utf-8")
+    record: dict[str, Any] = {
+        "schema_version": "rob1161.raw-capture.v1",
+        "provider": request.provider,
+        "product": request.product,
+        "endpoint": request.endpoint,
+        "version": request.version or "UNKNOWN",
+        "request_params": request.params,
+        "response_status": status,
+        "response_headers": response_headers,
+        "provider_timestamp_raw": _provider_timestamp(body),
+        "local_request_started_utc": _iso(started),
+        "local_receive_completed_utc": _iso(finished),
+        "symbol": request.symbol,
+        "feed": request.feed,
+        "session_label": session_label,
+        "outcome": outcome,
+        "raw_response_sha256": hashlib.sha256(raw).hexdigest(),
+        "stored_body_sha256": hashlib.sha256(body_bytes).hexdigest(),
+        "body_encoding": encoding,
+        "body": body,
+        "transport_error": transport_error,
+    }
+    if (
+        u06_shadow
+        and request.provider == "alpaca"
+        and request.product == "latest_quote"
+    ):
+        record["u06_shadow"] = _u06_fields(body, finished)
+    if request.provider == "alpaca" and request.product == "historical_1m_bars":
+        record["historical_reread"] = {
+            "window_label": "09:30-09:36 America/New_York",
+            "statement": "Historical reread only; it does not establish first appearance or decision-time availability.",
+        }
+    return record
+
+
 async def _attempt(
     client: AsyncGetClient,
     request: CaptureRequest,
@@ -205,47 +256,49 @@ async def _attempt(
             _safe_headers(response.headers),
             response.content,
         )
+    except asyncio.CancelledError:
+        finished = _utc_now()
+        record = _attempt_record(
+            request=request,
+            started=started,
+            finished=finished,
+            status=None,
+            response_headers={},
+            raw=b"",
+            outcome="deadline_cancelled",
+            transport_error="deadline_cancelled",
+            session_label=session_label,
+            u06_shadow=u06_shadow,
+        )
+        target = artifact_dir / (
+            f"{request.provider}-{request.product}-{request.symbol}-{uuid.uuid4().hex}.json"
+        )
+        _write_append_only(
+            target,
+            json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True).encode()
+            + b"\n",
+        )
+        raise
     except httpx.HTTPError as exc:
         transport_error = f"{type(exc).__name__}: {str(exc)}"
     received = _utc_now()
-    body, encoding = _sanitize_body(raw)
-    body_bytes = body.encode("utf-8")
     outcome = _classification(
-        status, body, alpaca_sip=request.provider == "alpaca" and request.feed == "sip"
+        status,
+        _sanitize_body(raw)[0],
+        alpaca_sip=request.provider == "alpaca" and request.feed == "sip",
     )
-    record: dict[str, Any] = {
-        "schema_version": "rob1161.raw-capture.v1",
-        "provider": request.provider,
-        "product": request.product,
-        "endpoint": request.endpoint,
-        "version": request.version or "UNKNOWN",
-        "request_params": request.params,
-        "response_status": status,
-        "response_headers": response_headers,
-        "provider_timestamp_raw": _provider_timestamp(body),
-        "local_request_started_utc": _iso(started),
-        "local_receive_completed_utc": _iso(received),
-        "symbol": request.symbol,
-        "feed": request.feed,
-        "session_label": session_label,
-        "outcome": outcome,
-        "raw_response_sha256": hashlib.sha256(raw).hexdigest(),
-        "stored_body_sha256": hashlib.sha256(body_bytes).hexdigest(),
-        "body_encoding": encoding,
-        "body": body,
-        "transport_error": transport_error,
-    }
-    if (
-        u06_shadow
-        and request.provider == "alpaca"
-        and request.product == "latest_quote"
-    ):
-        record["u06_shadow"] = _u06_fields(body, received)
-    if request.provider == "alpaca" and request.product == "historical_1m_bars":
-        record["historical_reread"] = {
-            "window_label": "09:30-09:36 America/New_York",
-            "statement": "Historical reread only; it does not establish first appearance or decision-time availability.",
-        }
+    record = _attempt_record(
+        request=request,
+        started=started,
+        finished=received,
+        status=status,
+        response_headers=response_headers,
+        raw=raw,
+        outcome=outcome,
+        transport_error=transport_error,
+        session_label=session_label,
+        u06_shadow=u06_shadow,
+    )
     filename = (
         f"{request.provider}-{request.product}-{request.symbol}-{uuid.uuid4().hex}.json"
     )
@@ -388,20 +441,45 @@ def _manifest(
     requests: list[CaptureRequest],
     preflight_missing: dict[str, list[str]],
     deadline_exceeded: bool,
+    run_started: datetime,
+    run_finished: datetime,
+    deadline_at: datetime | None,
 ) -> dict[str, Any]:
     records = [json.loads(path.read_text(encoding="utf-8")) for path in artifact_paths]
     by_key = {(row["provider"], row["product"], row["symbol"]): row for row in records}
-    missing_or_unsuccessful = [
+    required = [
         {
             "provider": request.provider,
             "product": request.product,
             "symbol": request.symbol,
         }
         for request in requests
-        if by_key.get((request.provider, request.product, request.symbol), {}).get(
-            "outcome"
-        )
-        != "success"
+    ]
+    terminal_timeline: list[dict[str, Any]] = []
+    for request, identity in zip(requests, required, strict=True):
+        record = by_key.get((request.provider, request.product, request.symbol))
+        if record is None:
+            terminal_timeline.append(
+                {
+                    **identity,
+                    "outcome": "not_started_deadline"
+                    if deadline_exceeded
+                    else "preflight_blocked",
+                    "local_request_started_utc": None,
+                    "terminal_utc": _iso(run_finished),
+                }
+            )
+        else:
+            terminal_timeline.append(
+                {
+                    **identity,
+                    "outcome": record["outcome"],
+                    "local_request_started_utc": record["local_request_started_utc"],
+                    "terminal_utc": record["local_receive_completed_utc"],
+                }
+            )
+    missing_or_unsuccessful = [
+        entry for entry in terminal_timeline if entry["outcome"] != "success"
     ]
     exit_code = (
         0
@@ -413,19 +491,20 @@ def _manifest(
     return {
         "schema_version": "rob1161.raw-capture-manifest.v1",
         "run_dir": str(run_dir),
+        "run_started_utc": _iso(run_started),
+        "run_finished_utc": _iso(run_finished),
+        "deadline_utc": _iso(deadline_at) if deadline_at else None,
         "preflight_missing_credentials": preflight_missing,
         "u06_deadline_seconds": U06_DEADLINE_SECONDS,
         "u06_deadline_exceeded": deadline_exceeded,
         "artifact_paths": [str(path) for path in artifact_paths],
-        "coverage_required_success": [
-            {
-                "provider": request.provider,
-                "product": request.product,
-                "symbol": request.symbol,
-            }
-            for request in requests
-        ],
+        "coverage_required_success": required,
         "coverage_missing_or_unsuccessful": missing_or_unsuccessful,
+        "terminal_timeline": terminal_timeline,
+        "outcome_counts": {
+            outcome: sum(entry["outcome"] == outcome for entry in terminal_timeline)
+            for outcome in sorted({entry["outcome"] for entry in terminal_timeline})
+        },
         "exit_code": exit_code,
         "statement": "Nonzero exit records unavailable/auth/error/empty or missing credential coverage; it does not trigger a provider fallback.",
     }
@@ -448,9 +527,10 @@ async def capture_run(
     if u06_shadow and symbols != DEFAULT_SYMBOLS:
         raise ValueError("U06 shadow requires exactly AAPL IBM SPY SIP quotes")
     label = session_label or ("u06_shadow" if u06_shadow else default_session_label())
+    run_started = _utc_now()
     run_dir = (
         artifact_root
-        / f"run-{_utc_now().strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
+        / f"run-{run_started.strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
     )
     opening_date = historical_sip_date or _utc_now().astimezone(_NEW_YORK).date()
     requests = [
@@ -465,6 +545,29 @@ async def capture_run(
     preflight_missing = missing_credentials()
     artifact_paths: list[Path] = []
     deadline_exceeded = False
+    deadline_at = (
+        run_started + timedelta(seconds=U06_DEADLINE_SECONDS) if u06_shadow else None
+    )
+
+    if preflight_missing:
+        run_finished = _utc_now()
+        manifest = _manifest(
+            run_dir=run_dir,
+            artifact_paths=artifact_paths,
+            requests=requests,
+            preflight_missing=preflight_missing,
+            deadline_exceeded=False,
+            run_started=run_started,
+            run_finished=run_finished,
+            deadline_at=deadline_at,
+        )
+        manifest_path = run_dir / "manifest.json"
+        _write_append_only(
+            manifest_path,
+            json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True).encode()
+            + b"\n",
+        )
+        return CaptureRun(artifact_paths, manifest_path, manifest["exit_code"])
 
     async def execute(active_client: AsyncGetClient) -> None:
         nonlocal deadline_exceeded
@@ -501,12 +604,20 @@ async def capture_run(
     else:
         async with httpx.AsyncClient(follow_redirects=False) as http_client:
             await execute(http_client)
+    # A deadline cancels gather before it returns results; recover terminal
+    # artifacts synchronously written by each cancelled attempt.
+    if deadline_exceeded:
+        artifact_paths = sorted(run_dir.glob("*.json")) if run_dir.exists() else []
+    run_finished = _utc_now()
     manifest = _manifest(
         run_dir=run_dir,
         artifact_paths=artifact_paths,
         requests=requests,
         preflight_missing=preflight_missing,
         deadline_exceeded=deadline_exceeded,
+        run_started=run_started,
+        run_finished=run_finished,
+        deadline_at=deadline_at,
     )
     manifest_path = run_dir / "manifest.json"
     _write_append_only(

--- a/app/services/us_regular_session_raw_capture.py
+++ b/app/services/us_regular_session_raw_capture.py
@@ -12,7 +12,7 @@ import os
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, time
 from pathlib import Path
 from typing import Any, Protocol
 from zoneinfo import ZoneInfo
@@ -228,6 +228,11 @@ async def _attempt(
         and request.product == "latest_quote"
     ):
         record["u06_shadow"] = _u06_fields(body, received)
+    if request.provider == "alpaca" and request.product == "historical_1m_bars":
+        record["historical_reread"] = {
+            "window_label": "09:30-09:36 America/New_York",
+            "statement": "Historical reread only; it does not establish first appearance or decision-time availability.",
+        }
     filename = (
         f"{request.provider}-{request.product}-{request.symbol}-{uuid.uuid4().hex}.json"
     )
@@ -240,7 +245,7 @@ async def _attempt(
     return target
 
 
-def _requests_for(symbol: str) -> list[CaptureRequest]:
+def _requests_for(symbol: str, historical_sip_date: date) -> list[CaptureRequest]:
     alpaca_headers = {
         "APCA-API-KEY-ID": os.getenv("ALPACA_PAPER_API_KEY", ""),
         "APCA-API-SECRET-KEY": os.getenv("ALPACA_PAPER_API_SECRET", ""),
@@ -284,6 +289,16 @@ def _requests_for(symbol: str) -> list[CaptureRequest]:
             alpaca_headers,
         ),
         CaptureRequest(
+            "alpaca",
+            "historical_1m_bars",
+            f"https://data.alpaca.markets/v2/stocks/{symbol}/bars",
+            "v2",
+            symbol,
+            "sip",
+            historical_sip_opening_window_params(historical_sip_date),
+            alpaca_headers,
+        ),
+        CaptureRequest(
             "kis",
             "overseas_1m",
             "https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice",
@@ -322,12 +337,30 @@ def kst_window_description() -> str:
     return _iso(date)
 
 
+def historical_sip_opening_window_params(trading_date: date) -> dict[str, str]:
+    """Build the 09:30–09:36 ET retrospective window without a fixed UTC offset.
+
+    ``end`` is 09:37 so a provider with an end-exclusive bar range can return
+    the seven 1-minute bars labelled 09:30 through 09:36.  This is a historical
+    reread only, never evidence of first appearance or decision-time access.
+    """
+    start = datetime.combine(trading_date, time(9, 30), tzinfo=_NEW_YORK)
+    end = datetime.combine(trading_date, time(9, 37), tzinfo=_NEW_YORK)
+    return {
+        "timeframe": "1Min",
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "feed": "sip",
+    }
+
+
 async def capture(
     *,
     symbols: tuple[str, ...] = DEFAULT_SYMBOLS,
     artifact_root: Path = Path("artifacts/us-regular-session-raw-capture"),
     session_label: str | None = None,
     u06_shadow: bool = False,
+    historical_sip_date: date | None = None,
     client: AsyncGetClient | None = None,
 ) -> list[Path]:
     """Perform independent GET observations and return append-only artifact paths."""
@@ -336,6 +369,7 @@ async def capture(
         artifact_root
         / f"run-{_utc_now().strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
     )
+    opening_date = historical_sip_date or _utc_now().astimezone(_NEW_YORK).date()
     if client is not None:
         return [
             await _attempt(
@@ -346,7 +380,7 @@ async def capture(
                 u06_shadow=u06_shadow,
             )
             for symbol in symbols
-            for item in _requests_for(symbol)
+            for item in _requests_for(symbol, opening_date)
         ]
     async with httpx.AsyncClient(follow_redirects=False) as http_client:
         return [
@@ -358,5 +392,5 @@ async def capture(
                 u06_shadow=u06_shadow,
             )
             for symbol in symbols
-            for item in _requests_for(symbol)
+            for item in _requests_for(symbol, opening_date)
         ]

--- a/app/services/us_regular_session_raw_capture.py
+++ b/app/services/us_regular_session_raw_capture.py
@@ -1,0 +1,362 @@
+"""Append-only, GET-only US regular-session market-data evidence capture.
+
+This module deliberately has no database or broker-execution dependencies.  It is
+an operator-facing observation tool, not a trading surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from app.core.symbol import to_kis_symbol, to_yahoo_symbol
+
+DEFAULT_SYMBOLS = ("AAPL", "IBM", "SPY")
+_SENSITIVE = re.compile(
+    r"(authorization|cookie|token|secret|api[-_]?key|password)", re.I
+)
+_VALUE_SECRET = re.compile(
+    r"(?i)(bearer\s+)[^\s,;]+|((?:token|secret|api[-_]?key|password)=)[^&\s,;]+"
+)
+_NEW_YORK = ZoneInfo("America/New_York")
+_SEOUL = ZoneInfo("Asia/Seoul")
+
+
+class AsyncGetClient(Protocol):
+    async def get(self, url: str, **kwargs: Any) -> httpx.Response: ...
+
+
+@dataclass(frozen=True)
+class CaptureRequest:
+    provider: str
+    product: str
+    endpoint: str
+    version: str
+    symbol: str
+    feed: str | None
+    params: dict[str, str]
+    headers: dict[str, str]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _safe_headers(headers: Any) -> dict[str, str]:
+    return {
+        str(key): "[REDACTED]"
+        if _SENSITIVE.search(str(key))
+        else _VALUE_SECRET.sub(r"\1[REDACTED]", str(value))
+        for key, value in headers.items()
+        if not _SENSITIVE.search(str(key))
+    }
+
+
+def _sanitize_body(raw: bytes) -> tuple[str, str]:
+    """Return a secret-free textual body and its encoding label."""
+    text = raw.decode("utf-8", errors="replace")
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError:
+        return _VALUE_SECRET.sub(r"\1[REDACTED]", text), "utf-8"
+
+    def scrub(value: Any, key: str = "") -> Any:
+        if _SENSITIVE.search(key):
+            return "[REDACTED]"
+        if isinstance(value, dict):
+            return {str(k): scrub(v, str(k)) for k, v in value.items()}
+        if isinstance(value, list):
+            return [scrub(v) for v in value]
+        if isinstance(value, str):
+            return _VALUE_SECRET.sub(r"\1[REDACTED]", value)
+        return value
+
+    return json.dumps(scrub(decoded), ensure_ascii=False, sort_keys=True), "json-utf-8"
+
+
+def _classification(status: int | None, body: str, *, alpaca_sip: bool = False) -> str:
+    lower = body.lower()
+    if status is None:
+        return "error"
+    if status in {401}:
+        return "auth"
+    if status == 403:
+        if alpaca_sip and any(
+            token in lower
+            for token in ("sip", "entitlement", "subscription", "not authorized")
+        ):
+            return "unavailable"
+        return "auth"
+    if not 200 <= status < 300:
+        return "error"
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        return "success" if body.strip() else "empty"
+    if parsed in ({}, [], None) or (
+        isinstance(parsed, dict) and not any(parsed.values())
+    ):
+        return "empty"
+    return "success"
+
+
+def _provider_timestamp(payload: str) -> Any:
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, dict):
+        candidates = [data]
+        for wrapper in ("quote", "bar", "chart", "output", "output1", "output2"):
+            nested = data.get(wrapper)
+            if isinstance(nested, dict):
+                candidates.append(nested)
+            elif isinstance(nested, list) and nested and isinstance(nested[0], dict):
+                candidates.append(nested[0])
+        found: dict[str, Any] = {}
+        for candidate in candidates:
+            found.update(
+                {
+                    key: candidate[key]
+                    for key in ("timestamp", "t", "xymd", "xhms")
+                    if key in candidate
+                }
+            )
+        return found or None
+    return None
+
+
+def _u06_fields(payload: str, received_at: datetime) -> dict[str, Any] | None:
+    try:
+        quote = json.loads(payload).get("quote", {})
+        nbb = quote.get("bp")
+        nbb_number = float(nbb) if nbb is not None else None
+    except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return {
+        "sip_nbb": nbb_number,
+        "hypothetical_limit_price": nbb_number * 0.998
+        if nbb_number is not None
+        else None,
+        "participant_or_source_timestamp_raw": quote.get("t"),
+        "local_receive_timestamp_utc": _iso(received_at),
+        "quote_age_inputs": {
+            "participant_or_source_timestamp_raw": quote.get("t"),
+            "local_receive_timestamp_utc": _iso(received_at),
+        },
+        "statement": "Observation only; no submission, preview, automatic reference selection, or marketability assertion.",
+    }
+
+
+def _write_append_only(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("xb") as artifact:
+        artifact.write(data)
+
+
+async def _attempt(
+    client: AsyncGetClient,
+    request: CaptureRequest,
+    *,
+    artifact_dir: Path,
+    session_label: str,
+    u06_shadow: bool,
+) -> Path:
+    started = _utc_now()
+    status: int | None = None
+    response_headers: dict[str, str] = {}
+    raw = b""
+    transport_error: str | None = None
+    try:
+        response = await client.get(
+            request.endpoint,
+            params=request.params,
+            headers=request.headers,
+            timeout=15.0,
+        )
+        status, response_headers, raw = (
+            response.status_code,
+            _safe_headers(response.headers),
+            response.content,
+        )
+    except httpx.HTTPError as exc:
+        transport_error = f"{type(exc).__name__}: {str(exc)}"
+    received = _utc_now()
+    body, encoding = _sanitize_body(raw)
+    body_bytes = body.encode("utf-8")
+    outcome = _classification(
+        status, body, alpaca_sip=request.provider == "alpaca" and request.feed == "sip"
+    )
+    record: dict[str, Any] = {
+        "schema_version": "rob1161.raw-capture.v1",
+        "provider": request.provider,
+        "product": request.product,
+        "endpoint": request.endpoint,
+        "version": request.version or "UNKNOWN",
+        "request_params": request.params,
+        "response_status": status,
+        "response_headers": response_headers,
+        "provider_timestamp_raw": _provider_timestamp(body),
+        "local_request_started_utc": _iso(started),
+        "local_receive_completed_utc": _iso(received),
+        "symbol": request.symbol,
+        "feed": request.feed,
+        "session_label": session_label,
+        "outcome": outcome,
+        "body_sha256": hashlib.sha256(body_bytes).hexdigest(),
+        "body_encoding": encoding,
+        "body": body,
+        "transport_error": transport_error,
+    }
+    if (
+        u06_shadow
+        and request.provider == "alpaca"
+        and request.product == "latest_quote"
+    ):
+        record["u06_shadow"] = _u06_fields(body, received)
+    filename = (
+        f"{request.provider}-{request.product}-{request.symbol}-{uuid.uuid4().hex}.json"
+    )
+    target = artifact_dir / filename
+    _write_append_only(
+        target,
+        json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True).encode()
+        + b"\n",
+    )
+    return target
+
+
+def _requests_for(symbol: str) -> list[CaptureRequest]:
+    alpaca_headers = {
+        "APCA-API-KEY-ID": os.getenv("ALPACA_PAPER_API_KEY", ""),
+        "APCA-API-SECRET-KEY": os.getenv("ALPACA_PAPER_API_SECRET", ""),
+    }
+    kis_headers = {
+        "appkey": os.getenv("KIS_APP_KEY", ""),
+        "appsecret": os.getenv("KIS_APP_SECRET", ""),
+        "authorization": f"Bearer {os.getenv('KIS_ACCESS_TOKEN', '')}",
+        "tr_id": "HHDFS76950200",
+    }
+    kis_params = {
+        "AUTH": "",
+        "EXCD": "NAS",
+        "SYMB": to_kis_symbol(symbol),
+        "NMIN": "1",
+        "PINC": "1",
+        "NEXT": "",
+        "NREC": "1",
+        "FILL": "",
+        "KEYB": "",
+    }
+    return [
+        CaptureRequest(
+            "alpaca",
+            "latest_quote",
+            f"https://data.alpaca.markets/v2/stocks/{symbol}/quotes/latest",
+            "v2",
+            symbol,
+            "sip",
+            {"feed": "sip"},
+            alpaca_headers,
+        ),
+        CaptureRequest(
+            "alpaca",
+            "latest_bar",
+            f"https://data.alpaca.markets/v2/stocks/{symbol}/bars/latest",
+            "v2",
+            symbol,
+            "sip",
+            {"feed": "sip"},
+            alpaca_headers,
+        ),
+        CaptureRequest(
+            "kis",
+            "overseas_1m",
+            "https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/inquire-time-itemchartprice",
+            "HHDFS76950200",
+            symbol,
+            None,
+            kis_params,
+            kis_headers,
+        ),
+        CaptureRequest(
+            "yahoo",
+            "chart_1m",
+            f"https://query1.finance.yahoo.com/v8/finance/chart/{to_yahoo_symbol(symbol)}",
+            "v8",
+            symbol,
+            None,
+            {"interval": "1m", "range": "1d"},
+            {},
+        ),
+    ]
+
+
+def default_session_label(now: datetime | None = None) -> str:
+    current = (now or _utc_now()).astimezone(_NEW_YORK)
+    return (
+        "us_regular_session"
+        if (current.hour, current.minute) >= (9, 30)
+        and (current.hour, current.minute) < (16, 0)
+        else "outside_us_regular_session"
+    )
+
+
+def kst_window_description() -> str:
+    # ZoneInfo conversion intentionally avoids a hard-coded UTC offset across DST.
+    date = datetime(2026, 7, 30, 4, 54, 50, tzinfo=_SEOUL)
+    return _iso(date)
+
+
+async def capture(
+    *,
+    symbols: tuple[str, ...] = DEFAULT_SYMBOLS,
+    artifact_root: Path = Path("artifacts/us-regular-session-raw-capture"),
+    session_label: str | None = None,
+    u06_shadow: bool = False,
+    client: AsyncGetClient | None = None,
+) -> list[Path]:
+    """Perform independent GET observations and return append-only artifact paths."""
+    label = session_label or ("u06_shadow" if u06_shadow else default_session_label())
+    run_dir = (
+        artifact_root
+        / f"run-{_utc_now().strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
+    )
+    if client is not None:
+        return [
+            await _attempt(
+                client,
+                item,
+                artifact_dir=run_dir,
+                session_label=label,
+                u06_shadow=u06_shadow,
+            )
+            for symbol in symbols
+            for item in _requests_for(symbol)
+        ]
+    async with httpx.AsyncClient(follow_redirects=False) as http_client:
+        return [
+            await _attempt(
+                http_client,
+                item,
+                artifact_dir=run_dir,
+                session_label=label,
+                u06_shadow=u06_shadow,
+            )
+            for symbol in symbols
+            for item in _requests_for(symbol)
+        ]

--- a/app/services/us_regular_session_raw_capture.py
+++ b/app/services/us_regular_session_raw_capture.py
@@ -6,6 +6,7 @@ an operator-facing observation tool, not a trading surface.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -14,6 +15,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Protocol
 from zoneinfo import ZoneInfo
 
@@ -22,11 +24,14 @@ import httpx
 from app.core.symbol import to_kis_symbol, to_yahoo_symbol
 
 DEFAULT_SYMBOLS = ("AAPL", "IBM", "SPY")
+KIS_US_EXCHANGE_CODES = MappingProxyType({"AAPL": "NAS", "IBM": "NYS", "SPY": "AMS"})
+U06_DEADLINE_SECONDS = 60
 _SENSITIVE = re.compile(
-    r"(authorization|cookie|token|secret|api[-_]?key|password)", re.I
+    r"(authorization|cookie|token|secret|(?:x-)?app[-_]?key|api[-_]?key|password)",
+    re.I,
 )
 _VALUE_SECRET = re.compile(
-    r"(?i)(bearer\s+)[^\s,;]+|((?:token|secret|api[-_]?key|password)=)[^&\s,;]+"
+    r"(?i)(bearer\s+)[^\s,;]+|((?:token|secret|(?:x-)?app[-_]?key|api[-_]?key|password)=)[^&\s,;]+"
 )
 _NEW_YORK = ZoneInfo("America/New_York")
 _SEOUL = ZoneInfo("Asia/Seoul")
@@ -46,6 +51,13 @@ class CaptureRequest:
     feed: str | None
     params: dict[str, str]
     headers: dict[str, str]
+
+
+@dataclass(frozen=True)
+class CaptureRun:
+    artifact_paths: list[Path]
+    manifest_path: Path
+    exit_code: int
 
 
 def _utc_now() -> datetime:
@@ -217,7 +229,8 @@ async def _attempt(
         "feed": request.feed,
         "session_label": session_label,
         "outcome": outcome,
-        "body_sha256": hashlib.sha256(body_bytes).hexdigest(),
+        "raw_response_sha256": hashlib.sha256(raw).hexdigest(),
+        "stored_body_sha256": hashlib.sha256(body_bytes).hexdigest(),
         "body_encoding": encoding,
         "body": body,
         "transport_error": transport_error,
@@ -256,9 +269,10 @@ def _requests_for(symbol: str, historical_sip_date: date) -> list[CaptureRequest
         "authorization": f"Bearer {os.getenv('KIS_ACCESS_TOKEN', '')}",
         "tr_id": "HHDFS76950200",
     }
+    kis_exchange = KIS_US_EXCHANGE_CODES[symbol]
     kis_params = {
         "AUTH": "",
-        "EXCD": "NAS",
+        "EXCD": kis_exchange,
         "SYMB": to_kis_symbol(symbol),
         "NMIN": "1",
         "PINC": "1",
@@ -354,6 +368,155 @@ def historical_sip_opening_window_params(trading_date: date) -> dict[str, str]:
     }
 
 
+def missing_credentials() -> dict[str, list[str]]:
+    """Return missing names only; credential values never enter diagnostics."""
+    required = {
+        "alpaca": ("ALPACA_PAPER_API_KEY", "ALPACA_PAPER_API_SECRET"),
+        "kis": ("KIS_APP_KEY", "KIS_APP_SECRET", "KIS_ACCESS_TOKEN"),
+    }
+    return {
+        provider: [name for name in names if not os.getenv(name)]
+        for provider, names in required.items()
+        if any(not os.getenv(name) for name in names)
+    }
+
+
+def _manifest(
+    *,
+    run_dir: Path,
+    artifact_paths: list[Path],
+    requests: list[CaptureRequest],
+    preflight_missing: dict[str, list[str]],
+    deadline_exceeded: bool,
+) -> dict[str, Any]:
+    records = [json.loads(path.read_text(encoding="utf-8")) for path in artifact_paths]
+    by_key = {(row["provider"], row["product"], row["symbol"]): row for row in records}
+    missing_or_unsuccessful = [
+        {
+            "provider": request.provider,
+            "product": request.product,
+            "symbol": request.symbol,
+        }
+        for request in requests
+        if by_key.get((request.provider, request.product, request.symbol), {}).get(
+            "outcome"
+        )
+        != "success"
+    ]
+    exit_code = (
+        0
+        if not preflight_missing
+        and not deadline_exceeded
+        and not missing_or_unsuccessful
+        else 2
+    )
+    return {
+        "schema_version": "rob1161.raw-capture-manifest.v1",
+        "run_dir": str(run_dir),
+        "preflight_missing_credentials": preflight_missing,
+        "u06_deadline_seconds": U06_DEADLINE_SECONDS,
+        "u06_deadline_exceeded": deadline_exceeded,
+        "artifact_paths": [str(path) for path in artifact_paths],
+        "coverage_required_success": [
+            {
+                "provider": request.provider,
+                "product": request.product,
+                "symbol": request.symbol,
+            }
+            for request in requests
+        ],
+        "coverage_missing_or_unsuccessful": missing_or_unsuccessful,
+        "exit_code": exit_code,
+        "statement": "Nonzero exit records unavailable/auth/error/empty or missing credential coverage; it does not trigger a provider fallback.",
+    }
+
+
+async def capture_run(
+    *,
+    symbols: tuple[str, ...] = DEFAULT_SYMBOLS,
+    artifact_root: Path = Path("artifacts/us-regular-session-raw-capture"),
+    session_label: str | None = None,
+    u06_shadow: bool = False,
+    historical_sip_date: date | None = None,
+    client: AsyncGetClient | None = None,
+) -> CaptureRun:
+    """Capture a run, write its append-only manifest, and provide a deterministic exit."""
+    if any(symbol not in KIS_US_EXCHANGE_CODES for symbol in symbols):
+        raise ValueError(
+            "Unsupported symbol: KIS exchange code must be explicitly mapped"
+        )
+    if u06_shadow and symbols != DEFAULT_SYMBOLS:
+        raise ValueError("U06 shadow requires exactly AAPL IBM SPY SIP quotes")
+    label = session_label or ("u06_shadow" if u06_shadow else default_session_label())
+    run_dir = (
+        artifact_root
+        / f"run-{_utc_now().strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
+    )
+    opening_date = historical_sip_date or _utc_now().astimezone(_NEW_YORK).date()
+    requests = [
+        item for symbol in symbols for item in _requests_for(symbol, opening_date)
+    ]
+    quote_requests = [
+        item
+        for item in requests
+        if item.provider == "alpaca" and item.product == "latest_quote"
+    ]
+    remaining_requests = [item for item in requests if item not in quote_requests]
+    preflight_missing = missing_credentials()
+    artifact_paths: list[Path] = []
+    deadline_exceeded = False
+
+    async def execute(active_client: AsyncGetClient) -> None:
+        nonlocal deadline_exceeded
+
+        async def run_requests(items: list[CaptureRequest]) -> list[Path]:
+            return list(
+                await asyncio.gather(
+                    *[
+                        _attempt(
+                            active_client,
+                            item,
+                            artifact_dir=run_dir,
+                            session_label=label,
+                            u06_shadow=u06_shadow,
+                        )
+                        for item in items
+                    ]
+                )
+            )
+
+        try:
+            if u06_shadow:
+                async with asyncio.timeout(U06_DEADLINE_SECONDS):
+                    # The three SIP quotes start together before any other provider/product.
+                    artifact_paths.extend(await run_requests(quote_requests))
+                    artifact_paths.extend(await run_requests(remaining_requests))
+            else:
+                artifact_paths.extend(await run_requests(requests))
+        except TimeoutError:
+            deadline_exceeded = True
+
+    if client is not None:
+        await execute(client)
+    else:
+        async with httpx.AsyncClient(follow_redirects=False) as http_client:
+            await execute(http_client)
+    manifest = _manifest(
+        run_dir=run_dir,
+        artifact_paths=artifact_paths,
+        requests=requests,
+        preflight_missing=preflight_missing,
+        deadline_exceeded=deadline_exceeded,
+    )
+    manifest_path = run_dir / "manifest.json"
+    _write_append_only(
+        manifest_path,
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True).encode()
+        + b"\n",
+    )
+    return CaptureRun(artifact_paths, manifest_path, manifest["exit_code"])
+
+
 async def capture(
     *,
     symbols: tuple[str, ...] = DEFAULT_SYMBOLS,
@@ -364,33 +527,12 @@ async def capture(
     client: AsyncGetClient | None = None,
 ) -> list[Path]:
     """Perform independent GET observations and return append-only artifact paths."""
-    label = session_label or ("u06_shadow" if u06_shadow else default_session_label())
-    run_dir = (
-        artifact_root
-        / f"run-{_utc_now().strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
+    run = await capture_run(
+        symbols=symbols,
+        artifact_root=artifact_root,
+        session_label=session_label,
+        u06_shadow=u06_shadow,
+        historical_sip_date=historical_sip_date,
+        client=client,
     )
-    opening_date = historical_sip_date or _utc_now().astimezone(_NEW_YORK).date()
-    if client is not None:
-        return [
-            await _attempt(
-                client,
-                item,
-                artifact_dir=run_dir,
-                session_label=label,
-                u06_shadow=u06_shadow,
-            )
-            for symbol in symbols
-            for item in _requests_for(symbol, opening_date)
-        ]
-    async with httpx.AsyncClient(follow_redirects=False) as http_client:
-        return [
-            await _attempt(
-                http_client,
-                item,
-                artifact_dir=run_dir,
-                session_label=label,
-                u06_shadow=u06_shadow,
-            )
-            for symbol in symbols
-            for item in _requests_for(symbol, opening_date)
-        ]
+    return run.artifact_paths

--- a/scripts/us_regular_session_raw_capture.py
+++ b/scripts/us_regular_session_raw_capture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from datetime import date
 from pathlib import Path
 
 from app.services.us_regular_session_raw_capture import DEFAULT_SYMBOLS, capture
@@ -25,6 +26,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Record SIP NBB and hypothetical 0.998 × NBB only.",
     )
+    parser.add_argument(
+        "--historical-sip-date",
+        type=date.fromisoformat,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help=(
+            "ET trading date for the 09:30–09:36 historical SIP 1Min reread; "
+            "defaults to the current America/New_York date."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -34,6 +45,7 @@ async def main() -> int:
         symbols=tuple(args.symbols),
         artifact_root=args.artifact_root,
         u06_shadow=args.u06_shadow,
+        historical_sip_date=args.historical_sip_date,
     )
     print("\n".join(str(path) for path in paths))
     return 0

--- a/scripts/us_regular_session_raw_capture.py
+++ b/scripts/us_regular_session_raw_capture.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import sys
 from datetime import date
 from pathlib import Path
 
-from app.services.us_regular_session_raw_capture import DEFAULT_SYMBOLS, capture
+from app.services.us_regular_session_raw_capture import (
+    DEFAULT_SYMBOLS,
+    capture_run,
+    missing_credentials,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -41,14 +46,20 @@ def parse_args() -> argparse.Namespace:
 
 async def main() -> int:
     args = parse_args()
-    paths = await capture(
+    for provider, names in missing_credentials().items():
+        print(
+            f"{provider}: missing required env keys: {', '.join(names)}",
+            file=sys.stderr,
+        )
+    run = await capture_run(
         symbols=tuple(args.symbols),
         artifact_root=args.artifact_root,
         u06_shadow=args.u06_shadow,
         historical_sip_date=args.historical_sip_date,
     )
-    print("\n".join(str(path) for path in paths))
-    return 0
+    print("\n".join(str(path) for path in run.artifact_paths))
+    print(str(run.manifest_path))
+    return run.exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/us_regular_session_raw_capture.py
+++ b/scripts/us_regular_session_raw_capture.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Manual, GET-only raw evidence capture for ROB-1161."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from app.services.us_regular_session_raw_capture import DEFAULT_SYMBOLS, capture
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Append-only US market-data raw capture (GET-only; no database)."
+    )
+    parser.add_argument("--symbols", nargs="+", default=list(DEFAULT_SYMBOLS))
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=Path("artifacts/us-regular-session-raw-capture"),
+    )
+    parser.add_argument(
+        "--u06-shadow",
+        action="store_true",
+        help="Record SIP NBB and hypothetical 0.998 × NBB only.",
+    )
+    return parser.parse_args()
+
+
+async def main() -> int:
+    args = parse_args()
+    paths = await capture(
+        symbols=tuple(args.symbols),
+        artifact_root=args.artifact_root,
+        u06_shadow=args.u06_shadow,
+    )
+    print("\n".join(str(path) for path in paths))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/services/test_us_regular_session_raw_capture.py
+++ b/tests/services/test_us_regular_session_raw_capture.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 from datetime import date, datetime
 from pathlib import Path
@@ -24,6 +25,19 @@ class FixtureClient:
         return response
 
 
+class OrderedFixtureClient(FixtureClient):
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        self.calls.append((url, kwargs))
+        # Yield every quote request so all three are scheduled before any returns.
+        await asyncio.sleep(0)
+        return self.responses.get(
+            url,
+            httpx.Response(
+                200, json={"quote": {"bp": 100, "t": "2026-07-29T15:55:00Z"}}
+            ),
+        )
+
+
 def test_write_append_only_never_overwrites(tmp_path: Path) -> None:
     target = tmp_path / "artifact.json"
     capture_module._write_append_only(target, b"first")
@@ -38,8 +52,13 @@ def test_secret_redaction_covers_headers_and_json_body(
     monkeypatch.setenv("ALPACA_PAPER_API_KEY", "super-secret-key")
     response = httpx.Response(
         403,
-        headers={"x-request-id": "safe", "set-cookie": "bad"},
-        json={"message": "token=private-token", "api_key": "do-not-save"},
+        headers={"x-request-id": "safe", "set-cookie": "bad", "x-appkey": "no-save"},
+        json={
+            "message": "token=private-token",
+            "api_key": "do-not-save",
+            "appkey": "also-do-not-save",
+            "x_appkey": "still-do-not-save",
+        },
     )
     client = FixtureClient(
         {"https://data.alpaca.markets/v2/stocks/AAPL/quotes/latest": response}
@@ -51,7 +70,32 @@ def test_secret_redaction_covers_headers_and_json_body(
     assert "super-secret-key" not in text
     assert "private-token" not in text
     assert "do-not-save" not in text
+    assert "also-do-not-save" not in text
+    assert "still-do-not-save" not in text
+    assert "no-save" not in text
     assert "set-cookie" not in text.lower()
+
+
+def test_raw_and_sanitized_body_hashes_are_preserved_separately(tmp_path: Path) -> None:
+    raw = b'{"appkey":"redact-me","value":1}'
+    response = httpx.Response(200, content=raw)
+    client = FixtureClient(
+        {"https://data.alpaca.markets/v2/stocks/AAPL/quotes/latest": response}
+    )
+    record = json.loads(
+        asyncio.run(
+            capture_module.capture(
+                symbols=("AAPL",), artifact_root=tmp_path, client=client
+            )
+        )[0].read_text()
+    )
+    assert record["raw_response_sha256"] == hashlib.sha256(raw).hexdigest()
+    assert (
+        record["stored_body_sha256"]
+        == hashlib.sha256(record["body"].encode()).hexdigest()
+    )
+    assert record["raw_response_sha256"] != record["stored_body_sha256"]
+    assert "redact-me" not in record["body"]
 
 
 def test_alpaca_sip_entitlement_is_unavailable_without_fallback(tmp_path: Path) -> None:
@@ -154,11 +198,9 @@ def test_provider_outcome_taxonomy(status: int, payload: object, expected: str) 
 def test_u06_shadow_is_observation_only_and_has_hypothetical_price(
     tmp_path: Path,
 ) -> None:
-    client = FixtureClient()
+    client = OrderedFixtureClient()
     paths = asyncio.run(
-        capture_module.capture(
-            symbols=("AAPL",), artifact_root=tmp_path, u06_shadow=True, client=client
-        )
+        capture_module.capture(artifact_root=tmp_path, u06_shadow=True, client=client)
     )
     quote = json.loads(
         next(path for path in paths if "latest_quote" in path.name).read_text()
@@ -172,6 +214,91 @@ def test_u06_shadow_is_observation_only_and_has_hypothetical_price(
     source = Path(capture_module.__file__).read_text()
     assert "execution_client" not in source
     assert "orders" not in source
+    assert [url.split("/")[-3] for url, _ in client.calls[:3]] == [
+        "AAPL",
+        "IBM",
+        "SPY",
+    ]
+    assert all("quotes/latest" in url for url, _ in client.calls[:3])
+    assert capture_module.U06_DEADLINE_SECONDS < 140
+
+
+def test_kis_exchange_codes_are_explicit_and_not_nas_for_all_symbols() -> None:
+    assert capture_module.KIS_US_EXCHANGE_CODES == {
+        "AAPL": "NAS",
+        "IBM": "NYS",
+        "SPY": "AMS",
+    }
+    requests = [
+        next(
+            request
+            for request in capture_module._requests_for(symbol, date(2026, 7, 29))
+            if request.provider == "kis"
+        )
+        for symbol in capture_module.DEFAULT_SYMBOLS
+    ]
+    assert [request.params["EXCD"] for request in requests] == ["NAS", "NYS", "AMS"]
+
+
+def test_manifest_and_exit_are_nonzero_for_missing_credentials_or_coverage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in (
+        "ALPACA_PAPER_API_KEY",
+        "ALPACA_PAPER_API_SECRET",
+        "KIS_APP_KEY",
+        "KIS_APP_SECRET",
+        "KIS_ACCESS_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    run = asyncio.run(
+        capture_module.capture_run(
+            symbols=("AAPL",), artifact_root=tmp_path, client=FixtureClient()
+        )
+    )
+    manifest = json.loads(run.manifest_path.read_text())
+    assert run.exit_code == 2
+    assert manifest["exit_code"] == 2
+    assert manifest["preflight_missing_credentials"]["alpaca"] == [
+        "ALPACA_PAPER_API_KEY",
+        "ALPACA_PAPER_API_SECRET",
+    ]
+    assert manifest["coverage_missing_or_unsuccessful"] == []
+    assert run.manifest_path.exists()
+
+
+def test_manifest_exit_is_nonzero_for_provider_coverage_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for key in (
+        "ALPACA_PAPER_API_KEY",
+        "ALPACA_PAPER_API_SECRET",
+        "KIS_APP_KEY",
+        "KIS_APP_SECRET",
+        "KIS_ACCESS_TOKEN",
+    ):
+        monkeypatch.setenv(key, "fixture-value")
+    client = FixtureClient(
+        {
+            "https://data.alpaca.markets/v2/stocks/AAPL/quotes/latest": httpx.Response(
+                403,
+                json={
+                    "message": "subscription does not permit querying recent SIP data"
+                },
+            )
+        }
+    )
+    run = asyncio.run(
+        capture_module.capture_run(
+            symbols=("AAPL",), artifact_root=tmp_path, client=client
+        )
+    )
+    manifest = json.loads(run.manifest_path.read_text())
+    assert run.exit_code == 2
+    assert manifest["preflight_missing_credentials"] == {}
+    assert manifest["coverage_missing_or_unsuccessful"] == [
+        {"provider": "alpaca", "product": "latest_quote", "symbol": "AAPL"}
+    ]
 
 
 def test_timezone_conversion_uses_zoneinfo_not_hard_coded_offset() -> None:

--- a/tests/services/test_us_regular_session_raw_capture.py
+++ b/tests/services/test_us_regular_session_raw_capture.py
@@ -1,0 +1,122 @@
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.services import us_regular_session_raw_capture as capture_module
+
+
+class FixtureClient:
+    def __init__(self, responses: dict[str, httpx.Response] | None = None) -> None:
+        self.responses = responses or {}
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        self.calls.append((url, kwargs))
+        response = self.responses.get(url)
+        if response is None:
+            return httpx.Response(
+                200, json={"quote": {"bp": 100, "t": "2026-07-29T15:55:00Z"}}
+            )
+        return response
+
+
+def test_write_append_only_never_overwrites(tmp_path: Path) -> None:
+    target = tmp_path / "artifact.json"
+    capture_module._write_append_only(target, b"first")
+    with pytest.raises(FileExistsError):
+        capture_module._write_append_only(target, b"second")
+    assert target.read_bytes() == b"first"
+
+
+def test_secret_redaction_covers_headers_and_json_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ALPACA_PAPER_API_KEY", "super-secret-key")
+    response = httpx.Response(
+        403,
+        headers={"x-request-id": "safe", "set-cookie": "bad"},
+        json={"message": "token=private-token", "api_key": "do-not-save"},
+    )
+    client = FixtureClient(
+        {"https://data.alpaca.markets/v2/stocks/AAPL/quotes/latest": response}
+    )
+    path = asyncio.run(
+        capture_module.capture(symbols=("AAPL",), artifact_root=tmp_path, client=client)
+    )[0]
+    text = path.read_text()
+    assert "super-secret-key" not in text
+    assert "private-token" not in text
+    assert "do-not-save" not in text
+    assert "set-cookie" not in text.lower()
+
+
+def test_alpaca_sip_entitlement_is_unavailable_without_fallback(tmp_path: Path) -> None:
+    quote_url = "https://data.alpaca.markets/v2/stocks/AAPL/quotes/latest"
+    client = FixtureClient(
+        {
+            quote_url: httpx.Response(
+                403, json={"message": "SIP subscription entitlement required"}
+            )
+        }
+    )
+    paths = asyncio.run(
+        capture_module.capture(symbols=("AAPL",), artifact_root=tmp_path, client=client)
+    )
+    records = [json.loads(path.read_text()) for path in paths]
+    quote = next(row for row in records if row["product"] == "latest_quote")
+    assert quote["outcome"] == "unavailable"
+    alpaca_calls = [call for call in client.calls if "alpaca" in call[0]]
+    assert len(alpaca_calls) == 2
+    assert all(call[1]["params"] == {"feed": "sip"} for call in alpaca_calls)
+    assert all("iex" not in call[0].lower() for call in client.calls)
+
+
+@pytest.mark.parametrize(
+    ("status", "payload", "expected"),
+    [
+        (200, {"chart": {"result": [1]}}, "success"),
+        (401, {"message": "bad credentials"}, "auth"),
+        (200, {}, "empty"),
+        (500, {"message": "upstream failed"}, "error"),
+    ],
+)
+def test_provider_outcome_taxonomy(status: int, payload: object, expected: str) -> None:
+    assert capture_module._classification(status, json.dumps(payload)) == expected
+
+
+def test_u06_shadow_is_observation_only_and_has_hypothetical_price(
+    tmp_path: Path,
+) -> None:
+    client = FixtureClient()
+    paths = asyncio.run(
+        capture_module.capture(
+            symbols=("AAPL",), artifact_root=tmp_path, u06_shadow=True, client=client
+        )
+    )
+    quote = json.loads(
+        next(path for path in paths if "latest_quote" in path.name).read_text()
+    )
+    shadow = quote["u06_shadow"]
+    assert shadow["sip_nbb"] == 100.0
+    assert shadow["hypothetical_limit_price"] == 99.8
+    assert shadow["participant_or_source_timestamp_raw"] == "2026-07-29T15:55:00Z"
+    assert quote["provider_timestamp_raw"] == {"t": "2026-07-29T15:55:00Z"}
+    assert "submission" in shadow["statement"]
+    source = Path(capture_module.__file__).read_text()
+    assert "execution_client" not in source
+    assert "orders" not in source
+
+
+def test_timezone_conversion_uses_zoneinfo_not_hard_coded_offset() -> None:
+    summer_et = datetime(2026, 7, 29, 15, 55, tzinfo=capture_module._NEW_YORK)
+    winter_et = datetime(2026, 1, 29, 15, 55, tzinfo=capture_module._NEW_YORK)
+    assert summer_et.utcoffset() != winter_et.utcoffset()
+    assert (
+        summer_et.astimezone(capture_module._SEOUL).hour
+        != winter_et.astimezone(capture_module._SEOUL).hour
+    )
+    assert capture_module.kst_window_description() == "2026-07-29T19:54:50Z"

--- a/tests/services/test_us_regular_session_raw_capture.py
+++ b/tests/services/test_us_regular_session_raw_capture.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import httpx
@@ -70,8 +70,71 @@ def test_alpaca_sip_entitlement_is_unavailable_without_fallback(tmp_path: Path) 
     quote = next(row for row in records if row["product"] == "latest_quote")
     assert quote["outcome"] == "unavailable"
     alpaca_calls = [call for call in client.calls if "alpaca" in call[0]]
-    assert len(alpaca_calls) == 2
-    assert all(call[1]["params"] == {"feed": "sip"} for call in alpaca_calls)
+    assert len(alpaca_calls) == 3
+    assert all(call[1]["params"].get("feed") == "sip" for call in alpaca_calls)
+    assert all("iex" not in call[0].lower() for call in client.calls)
+
+
+def test_recent_sip_unavailable_and_historical_sip_success_are_separate_attempts(
+    tmp_path: Path,
+) -> None:
+    base = "https://data.alpaca.markets/v2/stocks/AAPL"
+    client = FixtureClient(
+        {
+            f"{base}/quotes/latest": httpx.Response(
+                403,
+                json={
+                    "message": "subscription does not permit querying recent SIP data"
+                },
+            ),
+            f"{base}/bars/latest": httpx.Response(
+                403,
+                json={
+                    "message": "subscription does not permit querying recent SIP data"
+                },
+            ),
+            f"{base}/bars": httpx.Response(
+                200,
+                json={
+                    "bars": [
+                        {"t": f"2026-07-29T09:{minute:02}:00-04:00"}
+                        for minute in range(30, 37)
+                    ]
+                },
+            ),
+        }
+    )
+    paths = asyncio.run(
+        capture_module.capture(
+            symbols=("AAPL",),
+            artifact_root=tmp_path,
+            historical_sip_date=date(2026, 7, 29),
+            client=client,
+        )
+    )
+    records = {
+        json.loads(path.read_text())["product"]: json.loads(path.read_text())
+        for path in paths
+    }
+    assert records["latest_quote"]["outcome"] == "unavailable"
+    assert records["latest_bar"]["outcome"] == "unavailable"
+    historical = records["historical_1m_bars"]
+    assert historical["outcome"] == "success"
+    assert historical["request_params"] == {
+        "timeframe": "1Min",
+        "start": "2026-07-29T09:30:00-04:00",
+        "end": "2026-07-29T09:37:00-04:00",
+        "feed": "sip",
+    }
+    assert (
+        "does not establish first appearance"
+        in historical["historical_reread"]["statement"]
+    )
+    assert all(
+        call[1]["params"].get("feed") == "sip"
+        for call in client.calls
+        if "alpaca" in call[0]
+    )
     assert all("iex" not in call[0].lower() for call in client.calls)
 
 
@@ -120,3 +183,6 @@ def test_timezone_conversion_uses_zoneinfo_not_hard_coded_offset() -> None:
         != winter_et.astimezone(capture_module._SEOUL).hour
     )
     assert capture_module.kst_window_description() == "2026-07-29T19:54:50Z"
+    assert capture_module.historical_sip_opening_window_params(date(2026, 1, 29))[
+        "start"
+    ].endswith("-05:00")

--- a/tests/services/test_us_regular_session_raw_capture.py
+++ b/tests/services/test_us_regular_session_raw_capture.py
@@ -38,6 +38,25 @@ class OrderedFixtureClient(FixtureClient):
         )
 
 
+class HangingFixtureClient(FixtureClient):
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        self.calls.append((url, kwargs))
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+@pytest.fixture(autouse=True)
+def _configured_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "ALPACA_PAPER_API_KEY",
+        "ALPACA_PAPER_API_SECRET",
+        "KIS_APP_KEY",
+        "KIS_APP_SECRET",
+        "KIS_ACCESS_TOKEN",
+    ):
+        monkeypatch.setenv(key, "fixture-value")
+
+
 def test_write_append_only_never_overwrites(tmp_path: Path) -> None:
     target = tmp_path / "artifact.json"
     capture_module._write_append_only(target, b"first")
@@ -251,9 +270,10 @@ def test_manifest_and_exit_are_nonzero_for_missing_credentials_or_coverage(
         "KIS_ACCESS_TOKEN",
     ):
         monkeypatch.delenv(key, raising=False)
+    client = FixtureClient()
     run = asyncio.run(
         capture_module.capture_run(
-            symbols=("AAPL",), artifact_root=tmp_path, client=FixtureClient()
+            symbols=("AAPL",), artifact_root=tmp_path, client=client
         )
     )
     manifest = json.loads(run.manifest_path.read_text())
@@ -263,7 +283,11 @@ def test_manifest_and_exit_are_nonzero_for_missing_credentials_or_coverage(
         "ALPACA_PAPER_API_KEY",
         "ALPACA_PAPER_API_SECRET",
     ]
-    assert manifest["coverage_missing_or_unsuccessful"] == []
+    assert client.calls == []
+    assert len(manifest["terminal_timeline"]) == 5
+    assert {entry["outcome"] for entry in manifest["terminal_timeline"]} == {
+        "preflight_blocked"
+    }
     assert run.manifest_path.exists()
 
 
@@ -296,9 +320,52 @@ def test_manifest_exit_is_nonzero_for_provider_coverage_failure(
     manifest = json.loads(run.manifest_path.read_text())
     assert run.exit_code == 2
     assert manifest["preflight_missing_credentials"] == {}
-    assert manifest["coverage_missing_or_unsuccessful"] == [
-        {"provider": "alpaca", "product": "latest_quote", "symbol": "AAPL"}
+    assert [
+        {key: entry[key] for key in ("provider", "product", "symbol", "outcome")}
+        for entry in manifest["coverage_missing_or_unsuccessful"]
+    ] == [
+        {
+            "provider": "alpaca",
+            "product": "latest_quote",
+            "symbol": "AAPL",
+            "outcome": "unavailable",
+        }
     ]
+
+
+def test_u06_deadline_preserves_terminal_timeline_for_all_requests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(capture_module, "U06_DEADLINE_SECONDS", 0.01)
+    client = HangingFixtureClient()
+    run = asyncio.run(
+        capture_module.capture_run(
+            artifact_root=tmp_path, u06_shadow=True, client=client
+        )
+    )
+    manifest = json.loads(run.manifest_path.read_text())
+    assert run.exit_code == 2
+    assert manifest["u06_deadline_exceeded"] is True
+    assert manifest["run_started_utc"] <= manifest["run_finished_utc"]
+    assert manifest["deadline_utc"]
+    assert len(manifest["terminal_timeline"]) == 15
+    assert (
+        len(
+            {
+                (row["provider"], row["product"], row["symbol"])
+                for row in manifest["terminal_timeline"]
+            }
+        )
+        == 15
+    )
+    assert manifest["outcome_counts"] == {
+        "deadline_cancelled": 3,
+        "not_started_deadline": 12,
+    }
+    assert len(run.artifact_paths) == 3
+    assert {json.loads(path.read_text())["outcome"] for path in run.artifact_paths} == {
+        "deadline_cancelled"
+    }
 
 
 def test_timezone_conversion_uses_zoneinfo_not_hard_coded_offset() -> None:


### PR DESCRIPTION
## Summary
- add a manual, GET-only, append-only US regular-session raw evidence capture CLI
- capture Alpaca SIP latest quote/bar, KIS overseas 1m, and Yahoo chart 1m independently
- add U06 observation-only SIP NBB / hypothetical 0.998 × NBB records and focused fixture tests

## Verification
- ============================= test session starts ==============================
platform darwin -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0 -- /Users/mgh3326/work/auto_trader.rob1161/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/mgh3326/work/auto_trader.rob1161
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, xdist-3.8.0, split-0.11.0, asyncio-1.3.0, httpx-0.36.2, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 9 items

tests/services/test_us_regular_session_raw_capture.py::test_write_append_only_never_overwrites PASSED [ 11%]
tests/services/test_us_regular_session_raw_capture.py::test_secret_redaction_covers_headers_and_json_body PASSED [ 22%]
tests/services/test_us_regular_session_raw_capture.py::test_alpaca_sip_entitlement_is_unavailable_without_fallback PASSED [ 33%]
tests/services/test_us_regular_session_raw_capture.py::test_provider_outcome_taxonomy[200-payload0-success] PASSED [ 44%]
tests/services/test_us_regular_session_raw_capture.py::test_provider_outcome_taxonomy[401-payload1-auth] PASSED [ 55%]
tests/services/test_us_regular_session_raw_capture.py::test_provider_outcome_taxonomy[200-payload2-empty] PASSED [ 66%]
tests/services/test_us_regular_session_raw_capture.py::test_provider_outcome_taxonomy[500-payload3-error] PASSED [ 77%]
tests/services/test_us_regular_session_raw_capture.py::test_u06_shadow_is_observation_only_and_has_hypothetical_price PASSED [ 88%]
tests/services/test_us_regular_session_raw_capture.py::test_timezone_conversion_uses_zoneinfo_not_hard_coded_offset PASSED [100%]

============================== 9 passed in 0.21s =============================== (9 passed)
- All checks passed!
- 3 files already formatted

## Safety
No database access, order/preview/cancel calls, scheduler registration, or provider fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual, GET-only capture tool for US market-data evidence.
  * Supports configurable symbols, including AAPL, IBM, and SPY by default.
  * Saves timestamped, append-only JSON artifacts with response metadata and outcome classifications.
  * Redacts sensitive credentials and token values before saving captured data.
  * Adds optional U06 shadow quote observations.
  * Reports whether captures occurred during regular US trading hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->