### PR TITLE
fix(ROB-1162): bound Binance public smoke duration

### DIFF
--- a/app/services/brokers/binance/ws_client.py
+++ b/app/services/brokers/binance/ws_client.py
@@ -15,6 +15,7 @@ Open items lean adopted (per ROB-285 plan §Open items):
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import json
 import random
@@ -77,9 +78,15 @@ def _assert_url_host_allowed(url: str, *, allowed: frozenset[str]) -> None:
 class BinancePublicWSClient:
     """Read-only WS subscriber for Binance combined streams."""
 
-    def __init__(self, *, url: str) -> None:
+    def __init__(self, *, url: str, close_timeout: float | None = None) -> None:
         _assert_url_host_allowed(url, allowed=PUBLIC_HOSTS)
+        if close_timeout is not None and close_timeout <= 0:
+            raise ValueError("close_timeout must be greater than zero")
         self._url = url
+        # ``None`` preserves websockets' existing default close behavior.
+        # Short-lived callers such as the smoke CLI may inject a bounded
+        # shutdown budget without changing production/library consumers.
+        self._close_timeout = close_timeout
         self._ws: Any = None
 
     async def __aenter__(self) -> BinancePublicWSClient:
@@ -87,8 +94,22 @@ class BinancePublicWSClient:
         return self
 
     async def __aexit__(self, *exc: Any) -> None:
-        if self._ws is not None:
+        if self._ws is None:
+            return
+        if self._close_timeout is None:
             await self._ws.close()
+            return
+        try:
+            async with asyncio.timeout(self._close_timeout):
+                await self._ws.close()
+        except TimeoutError:
+            # The close coroutine was cancelled at the caller-provided
+            # deadline. Abort the underlying transport so a slow peer cannot
+            # keep the smoke process alive until websockets' default 10s
+            # closing-handshake timeout.
+            transport = getattr(self._ws, "transport", None)
+            if transport is not None:
+                transport.abort()
 
     async def events(self, *, stop_after: int | None = None) -> AsyncIterator[WsEvent]:
         emitted = 0

--- a/docs/runbooks/binance-public-market-data.md
+++ b/docs/runbooks/binance-public-market-data.md
@@ -79,6 +79,11 @@ uv run python -m scripts.binance_public_smoke \
     --symbols BTCUSDT,ETHUSDT,SOLUSDT --duration 30
 ```
 
+`--duration` is the WebSocket receive budget. The smoke client adds an explicit
+1-second shutdown budget, so a silent peer cannot extend cleanup to the
+`websockets` library's default 10-second closing-handshake timeout. REST phases
+run before this WS budget and retain their own transport timeouts.
+
 Exit codes are documented in the script docstring. `0` is success; `5` is
 "allowlist defense-in-depth check failed" (i.e., `fapi.binance.com` was
 not rejected — investigate immediately).

--- a/scripts/binance_public_smoke.py
+++ b/scripts/binance_public_smoke.py
@@ -7,10 +7,10 @@ end-to-end 가시화.
 
 Exit codes:
     0   - 모든 smoke 성공
-    1   - 예기치 못한 예외
+    1   - 잘못된 duration 또는 예기치 못한 예외
     2   - REST exchangeInfo 실패
     3   - REST klines backfill 실패
-    4   - WebSocket connect 실패
+    4   - WebSocket connect/receive 실패 또는 duration 내 이벤트 0건
     5   - 호스트 allowlist rejection 동작 실패 (defense-in-depth 검증)
     130 - SIGINT (Ctrl-C)
 
@@ -27,6 +27,7 @@ import asyncio
 import datetime as dt
 import logging
 import sys
+from contextlib import aclosing
 
 from app.services.brokers.binance.errors import BinanceLiveHostBlocked
 from app.services.brokers.binance.rest_client import BinancePublicRestClient
@@ -55,6 +56,10 @@ def _parse_args() -> argparse.Namespace:
 async def _run(args: argparse.Namespace) -> int:
     log = logging.getLogger("binance_public_smoke")
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if args.duration <= 0:
+        log.error("--duration must be greater than zero seconds")
+        return 1
 
     symbol = args.symbol or args.symbols.split(",")[0]
 
@@ -107,18 +112,30 @@ async def _run(args: argparse.Namespace) -> int:
     url = f"wss://stream.binance.com:9443/stream?streams={syms}"
     received = 0
     try:
-        async with BinancePublicWSClient(url=url) as ws:
-            loop = asyncio.get_event_loop()
-            stop_at = loop.time() + args.duration
-            async for event in ws.events():
-                log.info(f"ws event: {event}")
-                received += 1
-                if loop.time() >= stop_at:
-                    break
-                if received >= 3:
-                    break
+        async with asyncio.timeout(args.duration):
+            async with BinancePublicWSClient(url=url) as ws:
+                async with aclosing(ws.events()) as events:
+                    async for event in events:
+                        log.info(f"ws event: {event}")
+                        received += 1
+                        if received >= 3:
+                            break
+    except TimeoutError:
+        if received == 0:
+            log.error(
+                "WS FAIL: no events received before "
+                f"--duration={args.duration} seconds elapsed"
+            )
+            return 4
+        log.info(
+            f"WS duration elapsed after receiving {received} event(s); closing cleanly"
+        )
     except Exception as exc:
         log.error(f"WS FAIL: {exc}")
+        return 4
+
+    if received == 0:
+        log.error("WS FAIL: stream ended before any event was received")
         return 4
 
     log.info(f"smoke OK (dry_run={args.dry_run}; received {received} WS events)")

--- a/scripts/binance_public_smoke.py
+++ b/scripts/binance_public_smoke.py
@@ -28,10 +28,13 @@ import datetime as dt
 import logging
 import sys
 from contextlib import aclosing
+from typing import Final
 
 from app.services.brokers.binance.errors import BinanceLiveHostBlocked
 from app.services.brokers.binance.rest_client import BinancePublicRestClient
 from app.services.brokers.binance.ws_client import BinancePublicWSClient
+
+_WS_CLOSE_TIMEOUT_SECONDS: Final[float] = 1.0
 
 
 def _parse_args() -> argparse.Namespace:
@@ -46,7 +49,10 @@ def _parse_args() -> argparse.Namespace:
         "--duration",
         type=int,
         default=15,
-        help="WS subscribe duration in seconds",
+        help=(
+            "WS receive duration in seconds "
+            f"(plus at most {_WS_CLOSE_TIMEOUT_SECONDS:g}s shutdown cleanup)"
+        ),
     )
     p.add_argument("--dry-run", action="store_true", default=True)
     p.add_argument("--no-dry-run", dest="dry_run", action="store_false")
@@ -113,7 +119,10 @@ async def _run(args: argparse.Namespace) -> int:
     received = 0
     try:
         async with asyncio.timeout(args.duration):
-            async with BinancePublicWSClient(url=url) as ws:
+            async with BinancePublicWSClient(
+                url=url,
+                close_timeout=_WS_CLOSE_TIMEOUT_SECONDS,
+            ) as ws:
                 async with aclosing(ws.events()) as events:
                     async for event in events:
                         log.info(f"ws event: {event}")

--- a/tests/scripts/test_binance_public_smoke.py
+++ b/tests/scripts/test_binance_public_smoke.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 
 import scripts.binance_public_smoke as smoke
+from app.services.brokers.binance import ws_client as ws_client_module
 from app.services.brokers.binance.errors import BinanceLiveHostBlocked
 
 
@@ -40,6 +41,7 @@ class _FakeRestClient:
 @dataclass
 class _WSState:
     event_count: int
+    close_timeout: float | None = None
     entered: bool = False
     exited: bool = False
     iterator_closed: bool = False
@@ -49,8 +51,14 @@ class _WSState:
 
 def _fake_ws_client(state: _WSState) -> type:
     class _FakeWSClient:
-        def __init__(self, *, url: str) -> None:
+        def __init__(
+            self,
+            *,
+            url: str,
+            close_timeout: float | None = None,
+        ) -> None:
             self.url = url
+            state.close_timeout = close_timeout
 
         async def __aenter__(self) -> _FakeWSClient:
             state.entered = True
@@ -125,6 +133,7 @@ async def test_zero_event_timeout_is_bounded_secret_free_and_cleans_up(
     assert state.stalled is True
     assert state.stall_cancelled is True
     assert state.iterator_closed is True
+    assert state.close_timeout == smoke._WS_CLOSE_TIMEOUT_SECONDS
     assert (
         "WS FAIL: no events received before --duration=0.02 seconds elapsed"
         in caplog.text
@@ -176,3 +185,77 @@ async def test_three_events_finish_normally_and_close_iterator_and_context(
     assert state.iterator_closed is True
     assert "WS duration elapsed" not in caplog.text
     assert "received 3 WS events" in caplog.text
+
+
+@dataclass
+class _SlowCloseState:
+    iterator_cancelled: bool = False
+    iterator_closed: bool = False
+    close_started: bool = False
+    close_cancelled: bool = False
+    transport_aborted: bool = False
+
+
+class _SlowCloseTransport:
+    def __init__(self, state: _SlowCloseState) -> None:
+        self._state = state
+
+    def abort(self) -> None:
+        self._state.transport_aborted = True
+
+
+class _SlowClosingSocket:
+    def __init__(self, state: _SlowCloseState) -> None:
+        self._state = state
+        self.transport = _SlowCloseTransport(state)
+
+    def __aiter__(self):
+        return self._messages()
+
+    async def _messages(self):
+        try:
+            await asyncio.Event().wait()
+            yield ""
+        except asyncio.CancelledError:
+            self._state.iterator_cancelled = True
+            raise
+        finally:
+            self._state.iterator_closed = True
+
+    async def close(self) -> None:
+        self._state.close_started = True
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self._state.close_cancelled = True
+            raise
+
+
+@pytest.mark.asyncio
+async def test_zero_event_slow_close_has_wall_clock_bound_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _SlowCloseState()
+    socket = _SlowClosingSocket(state)
+
+    async def _connect(*args: Any, **kwargs: Any) -> _SlowClosingSocket:
+        return socket
+
+    monkeypatch.setattr(smoke, "BinancePublicRestClient", _FakeRestClient)
+    monkeypatch.setattr(ws_client_module.websockets, "connect", _connect)
+    monkeypatch.setattr(smoke, "_WS_CLOSE_TIMEOUT_SECONDS", 0.02)
+
+    started_at = asyncio.get_running_loop().time()
+    result = await asyncio.wait_for(
+        smoke._run(_args(duration=0.02)),
+        timeout=0.5,
+    )
+    elapsed = asyncio.get_running_loop().time() - started_at
+
+    assert result == 4
+    assert elapsed < 0.25
+    assert state.iterator_cancelled is True
+    assert state.iterator_closed is True
+    assert state.close_started is True
+    assert state.close_cancelled is True
+    assert state.transport_aborted is True

--- a/tests/scripts/test_binance_public_smoke.py
+++ b/tests/scripts/test_binance_public_smoke.py
@@ -1,0 +1,178 @@
+"""ROB-1162 — Binance public smoke wall-clock timeout regressions."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import scripts.binance_public_smoke as smoke
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+
+
+class _FakeRestClient:
+    async def __aenter__(self) -> _FakeRestClient:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+    async def exchange_info(self, symbol: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            symbol=symbol,
+            status="TRADING",
+            base_asset="BTC",
+            quote_asset="USDT",
+        )
+
+    async def klines(self, *args: Any, **kwargs: Any) -> list[object]:
+        return [object()]
+
+    async def _send(self, *args: Any, **kwargs: Any) -> None:
+        raise BinanceLiveHostBlocked("expected public-host rejection")
+
+
+@dataclass
+class _WSState:
+    event_count: int
+    entered: bool = False
+    exited: bool = False
+    iterator_closed: bool = False
+    stalled: bool = False
+    stall_cancelled: bool = False
+
+
+def _fake_ws_client(state: _WSState) -> type:
+    class _FakeWSClient:
+        def __init__(self, *, url: str) -> None:
+            self.url = url
+
+        async def __aenter__(self) -> _FakeWSClient:
+            state.entered = True
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            state.exited = True
+
+        async def events(self):
+            try:
+                for index in range(state.event_count):
+                    yield {"event": index}
+                if state.event_count < 3:
+                    state.stalled = True
+                    await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                state.stall_cancelled = True
+                raise
+            finally:
+                state.iterator_closed = True
+
+    return _FakeWSClient
+
+
+def _args(*, duration: float) -> argparse.Namespace:
+    return argparse.Namespace(
+        symbol="BTCUSDT",
+        symbols="BTCUSDT,DO-NOT-LOG-THIS",
+        duration=duration,
+        dry_run=True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("duration", [0, -1])
+async def test_non_positive_duration_fails_before_client_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    duration: int,
+) -> None:
+    class _UnexpectedClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise AssertionError(
+                "non-positive duration must fail before network clients"
+            )
+
+    monkeypatch.setattr(smoke, "BinancePublicRestClient", _UnexpectedClient)
+    monkeypatch.setattr(smoke, "BinancePublicWSClient", _UnexpectedClient)
+    caplog.set_level(logging.ERROR, logger="binance_public_smoke")
+
+    result = await smoke._run(_args(duration=duration))
+
+    assert result == 1
+    assert "--duration must be greater than zero seconds" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_zero_event_timeout_is_bounded_secret_free_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    state = _WSState(event_count=0)
+    monkeypatch.setattr(smoke, "BinancePublicRestClient", _FakeRestClient)
+    monkeypatch.setattr(smoke, "BinancePublicWSClient", _fake_ws_client(state))
+    caplog.set_level(logging.INFO, logger="binance_public_smoke")
+
+    result = await asyncio.wait_for(smoke._run(_args(duration=0.02)), timeout=1)
+
+    assert result == 4
+    assert state.entered is True
+    assert state.exited is True
+    assert state.stalled is True
+    assert state.stall_cancelled is True
+    assert state.iterator_closed is True
+    assert (
+        "WS FAIL: no events received before --duration=0.02 seconds elapsed"
+        in caplog.text
+    )
+    assert "DO-NOT-LOG-THIS" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_count", [1, 2])
+async def test_partial_events_finish_at_duration_and_clean_up(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    event_count: int,
+) -> None:
+    state = _WSState(event_count=event_count)
+    monkeypatch.setattr(smoke, "BinancePublicRestClient", _FakeRestClient)
+    monkeypatch.setattr(smoke, "BinancePublicWSClient", _fake_ws_client(state))
+    caplog.set_level(logging.INFO, logger="binance_public_smoke")
+
+    result = await asyncio.wait_for(smoke._run(_args(duration=0.02)), timeout=1)
+
+    assert result == 0
+    assert state.entered is True
+    assert state.exited is True
+    assert state.stalled is True
+    assert state.stall_cancelled is True
+    assert state.iterator_closed is True
+    assert f"WS duration elapsed after receiving {event_count} event(s)" in caplog.text
+    assert f"received {event_count} WS events" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_three_events_finish_normally_and_close_iterator_and_context(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    state = _WSState(event_count=3)
+    monkeypatch.setattr(smoke, "BinancePublicRestClient", _FakeRestClient)
+    monkeypatch.setattr(smoke, "BinancePublicWSClient", _fake_ws_client(state))
+    caplog.set_level(logging.INFO, logger="binance_public_smoke")
+
+    result = await asyncio.wait_for(smoke._run(_args(duration=1)), timeout=0.2)
+
+    assert result == 0
+    assert state.entered is True
+    assert state.exited is True
+    assert state.stalled is False
+    assert state.stall_cancelled is False
+    assert state.iterator_closed is True
+    assert "WS duration elapsed" not in caplog.text
+    assert "received 3 WS events" in caplog.text

--- a/tests/services/brokers/binance/test_ws_client.py
+++ b/tests/services/brokers/binance/test_ws_client.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import dataclass
+from typing import Any
 
 import pytest
 import websockets
 
+from app.services.brokers.binance import ws_client as ws_client_module
 from app.services.brokers.binance.ws_client import (
     BinancePublicWSClient,
     KlineEvent,
@@ -155,3 +158,93 @@ async def test_ws_rejects_non_allowed_host() -> None:
         BinancePublicWSClient(
             url="wss://evil.example.com/stream?streams=btcusdt@kline_1m"
         )
+
+
+@pytest.mark.parametrize("close_timeout", [0, -1])
+def test_ws_rejects_non_positive_close_timeout(close_timeout: int) -> None:
+    with pytest.raises(ValueError, match="close_timeout must be greater than zero"):
+        BinancePublicWSClient(
+            url="ws://127.0.0.1/stream?streams=btcusdt@kline_1m",
+            close_timeout=close_timeout,
+        )
+
+
+@dataclass
+class _CloseState:
+    close_started: bool = False
+    close_cancelled: bool = False
+    transport_aborted: bool = False
+
+
+class _Transport:
+    def __init__(self, state: _CloseState) -> None:
+        self._state = state
+
+    def abort(self) -> None:
+        self._state.transport_aborted = True
+
+
+class _SlowClosingSocket:
+    def __init__(self, state: _CloseState) -> None:
+        self._state = state
+        self.transport = _Transport(state)
+
+    async def close(self) -> None:
+        self._state.close_started = True
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self._state.close_cancelled = True
+            raise
+
+
+@pytest.mark.asyncio
+async def test_ws_optional_close_timeout_aborts_slow_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _CloseState()
+    socket = _SlowClosingSocket(state)
+
+    async def _connect(*args: Any, **kwargs: Any) -> _SlowClosingSocket:
+        return socket
+
+    monkeypatch.setattr(ws_client_module.websockets, "connect", _connect)
+    client = BinancePublicWSClient(
+        url="ws://127.0.0.1/stream?streams=btcusdt@kline_1m",
+        close_timeout=0.02,
+    )
+
+    started_at = asyncio.get_running_loop().time()
+    async with client:
+        pass
+    elapsed = asyncio.get_running_loop().time() - started_at
+
+    assert elapsed < 0.2
+    assert state.close_started is True
+    assert state.close_cancelled is True
+    assert state.transport_aborted is True
+
+
+@pytest.mark.asyncio
+async def test_ws_default_close_behavior_remains_unbounded_by_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ImmediateClosingSocket:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    socket = _ImmediateClosingSocket()
+
+    async def _connect(*args: Any, **kwargs: Any) -> _ImmediateClosingSocket:
+        return socket
+
+    monkeypatch.setattr(ws_client_module.websockets, "connect", _connect)
+
+    async with BinancePublicWSClient(
+        url="ws://127.0.0.1/stream?streams=btcusdt@kline_1m"
+    ):
+        pass
+
+    assert socket.closed is True


### PR DESCRIPTION
## Summary
- enforce `--duration` as a wall-clock bound around Binance public WS connect and event consumption
- give the smoke-only WS client an explicit 1-second close-handshake budget, aborting a stalled transport instead of inheriting the library's 10-second default
- preserve existing WS client behavior for every caller that does not opt into `close_timeout`
- fail closed with exit 4 when the bounded window yields zero events while allowing 1-2 events at timeout and normal completion at 3
- explicitly close the async event iterator and WS context on timeout and normal completion
- reject non-positive duration and close-timeout budgets

## Safety
- public REST and WebSocket paths only
- no `bookTicker` liveness semantic change; that remains separate
- no broker mutation, DB write, scheduler, allowlist, fallback, or gate changes

## Tests
- `uv run pytest tests/scripts/test_binance_public_smoke.py tests/services/brokers/binance/test_ws_client.py -q` (14 passed)
- slow/zero-event integration regression proves iterator cancellation/closure, close cancellation, transport abort, and bounded wall-clock termination
- `uv run ruff check ...`, `ruff format --check ...`, `ty check ...`, and `git diff --check` all pass
- read-only public probe with `--duration 5`: exit 4 as expected, 6.69s process wall clock including startup and REST phases (previously about 12.37s)
