### PR TITLE
fix(ROB-1169): normalize Upbit candle partitions

### DIFF
--- a/app/mcp_server/tooling/market_data_indicators.py
+++ b/app/mcp_server/tooling/market_data_indicators.py
@@ -285,13 +285,12 @@ async def _cache_first_crypto(
     legacy one-SELECT-per-symbol path.
     """
     from app.core.db import AsyncSessionLocal
+    from app.services.daily_candles.crypto_identity import (
+        upbit_daily_candle_partition,
+    )
     from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
 
-    # Derive the market quote currency from the symbol (e.g. "KRW-BTC" → "KRW").
-    if "-" in symbol:
-        partition = symbol.split("-", 1)[0]
-    else:
-        partition = "KRW"
+    partition = upbit_daily_candle_partition(symbol)
 
     async with AsyncSessionLocal() as session:
         repo = DailyCandlesRepository(session=session)

--- a/app/services/daily_candles/crypto_identity.py
+++ b/app/services/daily_candles/crypto_identity.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import re
+
 _SUPPORTED_UPBIT_QUOTE_CURRENCIES = frozenset({"KRW", "USDT"})
+_UPBIT_BASE_ASSET = re.compile(r"[A-Z0-9]+")
 
 
 def upbit_daily_candle_partition(symbol: str) -> str:
@@ -19,6 +22,7 @@ def upbit_daily_candle_partition(symbol: str) -> str:
         separator != "-"
         or not base
         or "-" in base
+        or _UPBIT_BASE_ASSET.fullmatch(base) is None
         or quote not in _SUPPORTED_UPBIT_QUOTE_CURRENCIES
     ):
         raise ValueError("Upbit daily-candle symbols must use a KRW-/USDT- market code")

--- a/app/services/daily_candles/crypto_identity.py
+++ b/app/services/daily_candles/crypto_identity.py
@@ -1,0 +1,28 @@
+"""Canonical crypto identity helpers for the daily-candle store."""
+
+from __future__ import annotations
+
+_SUPPORTED_UPBIT_QUOTE_CURRENCIES = frozenset({"KRW", "USDT"})
+
+
+def upbit_daily_candle_partition(symbol: str) -> str:
+    """Return the canonical daily-candle partition for an Upbit market code.
+
+    Generic crypto routing currently accepts only ``KRW-*`` and ``USDT-*``
+    Upbit-style symbols.  Keep that boundary explicit: a plain symbol or an
+    unknown quote prefix must not be guessed into the Upbit venue.
+    """
+
+    normalized = str(symbol).strip().upper()
+    quote, separator, base = normalized.partition("-")
+    if (
+        separator != "-"
+        or not base
+        or "-" in base
+        or quote not in _SUPPORTED_UPBIT_QUOTE_CURRENCIES
+    ):
+        raise ValueError("Upbit daily-candle symbols must use a KRW-/USDT- market code")
+    return f"upbit_{quote.lower()}"
+
+
+__all__ = ["upbit_daily_candle_partition"]

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -73,8 +73,8 @@ def _recent_time_floor(count: int, *, now: datetime) -> datetime:
 def _crypto_venue_for_partition(partition: str) -> str:
     """Map a legacy crypto ``partition`` label to its ``crypto_instruments.venue`` value.
 
-    Today only Upbit KRW is producing crypto rows; ``partition='upbit_krw'`` maps
-    to ``venue='upbit'``. Children B/C will add Binance/Alpaca mappings via
+    Upbit quote partitions such as ``upbit_krw`` and ``upbit_usdt`` map to
+    ``venue='upbit'``. Children B/C will add Binance/Alpaca mappings via
     additional rows in ``crypto_instruments``.
     """
     return "upbit" if partition == "upbit_krw" else partition.split("_")[0]

--- a/app/services/daily_candles/sync_service.py
+++ b/app/services/daily_candles/sync_service.py
@@ -21,6 +21,7 @@ from typing import Any
 import pandas as pd
 
 from app.services.daily_candles.converters import frame_to_rows
+from app.services.daily_candles.crypto_identity import upbit_daily_candle_partition
 from app.services.daily_candles.repository import (
     DailyCandleRow,
     DailyCandlesRepository,
@@ -287,7 +288,11 @@ class DailyCandleSyncService:
             )
             result = await session.execute(sql)
             return [
-                SyncTarget(market=MarketKey.CRYPTO, symbol=row.market, partition="KRW")
+                SyncTarget(
+                    market=MarketKey.CRYPTO,
+                    symbol=row.market,
+                    partition=upbit_daily_candle_partition(row.market),
+                )
                 for row in result
             ]
         raise ValueError(f"Unknown market: {market}")

--- a/app/services/daily_candles/sync_service.py
+++ b/app/services/daily_candles/sync_service.py
@@ -207,6 +207,13 @@ class DailyCandleSyncService:
     async def _sync_crypto(
         self, target: SyncTarget, horizon_bars: int
     ) -> SyncOneResult:
+        canonical_partition = upbit_daily_candle_partition(target.symbol)
+        if target.partition != canonical_partition:
+            raise ValueError(
+                "Crypto daily-candle target partition must match its canonical "
+                f"Upbit symbol identity: symbol={target.symbol!r}, "
+                f"partition={target.partition!r}, expected={canonical_partition!r}"
+            )
         frame = await self._upbit(market=target.symbol, days=horizon_bars)
         rows = frame_to_rows(
             frame, symbol=target.symbol, partition=target.partition, source="upbit"

--- a/docs/runbooks/daily-candles-store.md
+++ b/docs/runbooks/daily-candles-store.md
@@ -87,7 +87,9 @@ uv run python scripts/backfill_daily_candles.py --market crypto --symbols KRW-BT
 Symbol format notes:
 - KR: plain numeric code (`005930`), no exchange prefix.
 - US: DB-canonical dot notation (`BRK.B`). The CLI/service translates to KIS slash notation (`BRK/B`) or Yahoo hyphen notation (`BRK-B`) internally.
-- Crypto: full Upbit market string (`KRW-BTC`), including the quote-currency prefix.
+- Crypto: full Upbit market string (`KRW-BTC` or `USDT-ETH`), including the
+  quote-currency prefix. The CLI derives `upbit_krw` or `upbit_usdt` from each
+  symbol; a conflicting explicit `--partition` fails closed.
 
 ---
 

--- a/scripts/backfill_daily_candles.py
+++ b/scripts/backfill_daily_candles.py
@@ -83,23 +83,29 @@ async def _amain(args: argparse.Namespace) -> int:
     horizon = args.horizon_bars if args.horizon_bars is not None else default_bars
     requested_partition = args.partition or default_partition
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
-
-    svc = await _build_default_service()
-    try:
-        for symbol in symbols:
-            partition = _partition_for_symbol(
+    targets = [
+        SyncTarget(
+            market=market_key,
+            symbol=symbol,
+            partition=_partition_for_symbol(
                 market=market_key,
                 symbol=symbol,
                 requested_partition=requested_partition,
-            )
-            target = SyncTarget(market=market_key, symbol=symbol, partition=partition)
+            ),
+        )
+        for symbol in symbols
+    ]
+
+    svc = await _build_default_service()
+    try:
+        for target in targets:
             if args.dry_run:
                 logger.info("DRY RUN - would sync %s", target)
                 continue
             result = await svc.sync_one(target=target, horizon_bars=horizon)
             logger.info(
                 "backfill done symbol=%s upserted=%d fallback=%s",
-                symbol,
+                target.symbol,
                 result.rows_upserted,
                 result.fallback_used,
             )

--- a/scripts/backfill_daily_candles.py
+++ b/scripts/backfill_daily_candles.py
@@ -23,6 +23,7 @@ from app.services.daily_candles.constants import (
     DAILY_CANDLE_BACKFILL_BARS_KR,
     DAILY_CANDLE_BACKFILL_BARS_US,
 )
+from app.services.daily_candles.crypto_identity import upbit_daily_candle_partition
 from app.services.daily_candles.repository import MarketKey
 from app.services.daily_candles.sync_service import (
     SyncTarget,
@@ -34,7 +35,7 @@ logger = logging.getLogger(__name__)
 _MARKET_DEFAULTS = {
     "kr": (MarketKey.KR, DAILY_CANDLE_BACKFILL_BARS_KR, "KRX"),
     "us": (MarketKey.US, DAILY_CANDLE_BACKFILL_BARS_US, "NASD"),
-    "crypto": (MarketKey.CRYPTO, DAILY_CANDLE_BACKFILL_BARS_CRYPTO, "KRW"),
+    "crypto": (MarketKey.CRYPTO, DAILY_CANDLE_BACKFILL_BARS_CRYPTO, None),
 }
 
 
@@ -50,21 +51,47 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--partition",
         default=None,
-        help="exchange (US) / venue (KR) / market (crypto). Defaults: NASD / KRX / KRW.",
+        help=(
+            "exchange (US) / venue (KR) / canonical crypto partition. "
+            "Defaults: NASD / KRX / symbol-derived upbit_krw or upbit_usdt."
+        ),
     )
     parser.add_argument("--dry-run", action="store_true")
     return parser
 
 
+def _partition_for_symbol(
+    *, market: MarketKey, symbol: str, requested_partition: str | None
+) -> str:
+    if market != MarketKey.CRYPTO:
+        if not requested_partition:
+            raise ValueError("Non-crypto backfill requires a partition")
+        return requested_partition
+
+    canonical = upbit_daily_candle_partition(symbol)
+    if requested_partition is not None and requested_partition != canonical:
+        raise ValueError(
+            "Crypto --partition must match the symbol-derived canonical partition: "
+            f"symbol={symbol!r}, partition={requested_partition!r}, "
+            f"expected={canonical!r}"
+        )
+    return canonical
+
+
 async def _amain(args: argparse.Namespace) -> int:
     market_key, default_bars, default_partition = _MARKET_DEFAULTS[args.market]
     horizon = args.horizon_bars if args.horizon_bars is not None else default_bars
-    partition = args.partition or default_partition
+    requested_partition = args.partition or default_partition
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
 
     svc = await _build_default_service()
     try:
         for symbol in symbols:
+            partition = _partition_for_symbol(
+                market=market_key,
+                symbol=symbol,
+                requested_partition=requested_partition,
+            )
             target = SyncTarget(market=market_key, symbol=symbol, partition=partition)
             if args.dry_run:
                 logger.info("DRY RUN - would sync %s", target)

--- a/tests/services/daily_candles/test_crypto_venue_resolution.py
+++ b/tests/services/daily_candles/test_crypto_venue_resolution.py
@@ -52,6 +52,60 @@ async def test_crypto_instrument_id_resolution_with_upbit_venue(
 
 
 @pytest.mark.asyncio
+async def test_crypto_instrument_id_resolution_with_upbit_usdt_partition(
+    db_session: AsyncSession,
+) -> None:
+    inst = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="USDT-ROBSOL",
+        base_asset="ROBSOL",
+        quote_asset="USDT",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = DailyCandlesRepository(session=db_session)
+    resolved = await repo.resolve_crypto_instrument_ids(
+        symbols=["USDT-ROBSOL"], partition="upbit_usdt"
+    )
+    assert resolved == {"USDT-ROBSOL": inst.id}
+
+    candle_time = dt.datetime(2026, 7, 29, tzinfo=dt.UTC)
+    inserted = await repo.upsert_rows(
+        market=MarketKey.CRYPTO,
+        rows=[
+            DailyCandleRow(
+                time_utc=candle_time,
+                symbol="USDT-ROBSOL",
+                partition="upbit_usdt",
+                open=100.0,
+                high=110.0,
+                low=90.0,
+                close=105.0,
+                adj_close=None,
+                volume=12.0,
+                value=1260.0,
+                source="upbit",
+            )
+        ],
+    )
+    await db_session.flush()
+    fetched = await repo.fetch_range(
+        market=MarketKey.CRYPTO,
+        symbol="USDT-ROBSOL",
+        partition="upbit_usdt",
+        start=candle_time,
+        end=candle_time,
+    )
+
+    assert inserted == 1
+    assert [row.symbol for row in fetched] == ["USDT-ROBSOL"]
+    assert [row.partition for row in fetched] == ["upbit_usdt"]
+
+
+@pytest.mark.asyncio
 async def test_crypto_instrument_id_resolution_warning_when_venue_is_krw(
     db_session: AsyncSession, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/unit/mcp_server/tooling/test_market_data_indicators_cache_first.py
+++ b/tests/unit/mcp_server/tooling/test_market_data_indicators_cache_first.py
@@ -1,8 +1,10 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
+
+from app.services.daily_candles.repository import MarketKey
 
 
 def _make_row(
@@ -26,6 +28,111 @@ def _make_row(
 
 
 class TestCacheFirstReadPath:
+    @pytest.mark.asyncio
+    async def test_crypto_db_hit_uses_canonical_upbit_partition(self):
+        from app.mcp_server.tooling.market_data_indicators import (
+            _fetch_ohlcv_for_indicators,
+        )
+
+        rows = [
+            _make_row(
+                "KRW-BTC",
+                "upbit_krw",
+                datetime.now(UTC) - timedelta(days=i),
+                100_000_000.0 + i,
+                source="upbit",
+            )
+            for i in range(10)
+        ]
+        session = MagicMock()
+
+        class SessionFactory:
+            async def __aenter__(self) -> object:
+                return session
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+        fetch_recent = AsyncMock(return_value=list(reversed(rows)))
+        with (
+            patch("app.core.db.AsyncSessionLocal", return_value=SessionFactory()),
+            patch(
+                "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+                new=fetch_recent,
+            ),
+            patch(
+                "app.mcp_server.tooling.market_data_indicators._cache_is_fresh_crypto",
+                return_value=True,
+            ),
+            patch(
+                "app.mcp_server.tooling.market_data_indicators.upbit_service.fetch_ohlcv",
+                new=AsyncMock(),
+            ) as upbit_fetch,
+        ):
+            df = await _fetch_ohlcv_for_indicators("KRW-BTC", "crypto", count=10)
+
+        assert len(df) == 10
+        fetch_recent.assert_awaited_once_with(
+            market=MarketKey.CRYPTO,
+            symbol="KRW-BTC",
+            partition="upbit_krw",
+            count=10,
+        )
+        upbit_fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_crypto_live_miss_writes_canonical_upbit_partition(self):
+        from app.mcp_server.tooling.market_data_indicators import (
+            _fetch_ohlcv_for_indicators,
+        )
+
+        frame = pd.DataFrame(
+            {
+                "date": pd.date_range("2026-06-01", periods=2, freq="D"),
+                "open": [100.0, 101.0],
+                "high": [102.0, 103.0],
+                "low": [99.0, 100.0],
+                "close": [101.0, 102.0],
+                "volume": [10.0, 11.0],
+                "value": [1010.0, 1122.0],
+            }
+        )
+        session = MagicMock()
+        session.commit = AsyncMock()
+
+        class SessionFactory:
+            async def __aenter__(self) -> object:
+                return session
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+        upsert = AsyncMock(return_value=2)
+        with (
+            patch("app.core.db.AsyncSessionLocal", return_value=SessionFactory()),
+            patch(
+                "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "app.services.daily_candles.repository.DailyCandlesRepository.upsert_rows",
+                new=upsert,
+            ),
+            patch(
+                "app.mcp_server.tooling.market_data_indicators.upbit_service.fetch_ohlcv",
+                new=AsyncMock(return_value=frame),
+            ),
+        ):
+            df = await _fetch_ohlcv_for_indicators("KRW-BTC", "crypto", count=2)
+
+        assert len(df) == 2
+        upsert.assert_awaited_once()
+        assert upsert.await_args.kwargs["market"] is MarketKey.CRYPTO
+        assert {row.partition for row in upsert.await_args.kwargs["rows"]} == {
+            "upbit_krw"
+        }
+        session.commit.assert_awaited_once()
+
     @pytest.mark.asyncio
     async def test_kr_db_hit_skips_external_api(self):
         """When DB has fresh, sufficient rows, KIS is not called."""

--- a/tests/unit/scripts/test_backfill_daily_candles.py
+++ b/tests/unit/scripts/test_backfill_daily_candles.py
@@ -90,3 +90,36 @@ async def test_crypto_backfill_builds_symbol_specific_canonical_targets(
         ),
     ]
     service.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "symbols",
+    [
+        "KRW-BTC,USDT-ETH",
+        "KRW-BTC,KRW-BTC/USD",
+    ],
+)
+async def test_crypto_backfill_preflights_all_targets_before_service_or_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    symbols: str,
+) -> None:
+    import scripts.backfill_daily_candles as cli
+
+    service_factory = AsyncMock()
+    monkeypatch.setattr(cli, "_build_default_service", service_factory)
+    args = cli._build_parser().parse_args(
+        [
+            "--market",
+            "crypto",
+            "--symbols",
+            symbols,
+            "--partition",
+            "upbit_krw",
+        ]
+    )
+
+    with pytest.raises(ValueError):
+        await cli._amain(args)
+
+    service_factory.assert_not_awaited()

--- a/tests/unit/scripts/test_backfill_daily_candles.py
+++ b/tests/unit/scripts/test_backfill_daily_candles.py
@@ -1,3 +1,12 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.daily_candles.repository import MarketKey
+from app.services.daily_candles.sync_service import SyncTarget
+
+
 def test_cli_argument_parser_accepts_required_args():
     from scripts.backfill_daily_candles import _build_parser
 
@@ -17,3 +26,67 @@ def test_cli_dry_run_flag():
     parser = _build_parser()
     ns = parser.parse_args(["--market", "kr", "--symbols", "005930", "--dry-run"])
     assert ns.dry_run is True
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected"),
+    [
+        ("KRW-BTC", "upbit_krw"),
+        ("USDT-ETH", "upbit_usdt"),
+    ],
+)
+def test_crypto_partition_is_derived_from_symbol(symbol: str, expected: str) -> None:
+    from scripts.backfill_daily_candles import _partition_for_symbol
+
+    assert (
+        _partition_for_symbol(
+            market=MarketKey.CRYPTO,
+            symbol=symbol,
+            requested_partition=None,
+        )
+        == expected
+    )
+
+
+def test_crypto_partition_override_must_match_symbol() -> None:
+    from scripts.backfill_daily_candles import _partition_for_symbol
+
+    with pytest.raises(ValueError, match="must match"):
+        _partition_for_symbol(
+            market=MarketKey.CRYPTO,
+            symbol="USDT-ETH",
+            requested_partition="upbit_krw",
+        )
+
+
+@pytest.mark.asyncio
+async def test_crypto_backfill_builds_symbol_specific_canonical_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.backfill_daily_candles as cli
+
+    service = SimpleNamespace(
+        sync_one=AsyncMock(
+            return_value=SimpleNamespace(rows_upserted=1, fallback_used=False)
+        ),
+        close=AsyncMock(),
+    )
+    monkeypatch.setattr(cli, "_build_default_service", AsyncMock(return_value=service))
+    args = cli._build_parser().parse_args(
+        ["--market", "crypto", "--symbols", "KRW-BTC,USDT-ETH"]
+    )
+
+    assert await cli._amain(args) == 0
+    assert [call.kwargs["target"] for call in service.sync_one.await_args_list] == [
+        SyncTarget(
+            market=MarketKey.CRYPTO,
+            symbol="KRW-BTC",
+            partition="upbit_krw",
+        ),
+        SyncTarget(
+            market=MarketKey.CRYPTO,
+            symbol="USDT-ETH",
+            partition="upbit_usdt",
+        ),
+    ]
+    service.close.assert_awaited_once()

--- a/tests/unit/services/daily_candles/test_repository.py
+++ b/tests/unit/services/daily_candles/test_repository.py
@@ -22,7 +22,10 @@ def test_upbit_daily_candle_partition_is_canonical(symbol: str, expected: str) -
     assert upbit_daily_candle_partition(symbol) == expected
 
 
-@pytest.mark.parametrize("symbol", ["BTC", "BTC-ETH", "BINANCE:BTCUSDT", "", "KRW-"])
+@pytest.mark.parametrize(
+    "symbol",
+    ["BTC", "BTC-ETH", "BINANCE:BTCUSDT", "", "KRW-", "KRW-BTC/USD"],
+)
 def test_upbit_daily_candle_partition_rejects_ambiguous_symbols(symbol: str) -> None:
     with pytest.raises(ValueError, match="KRW-/USDT-"):
         upbit_daily_candle_partition(symbol)

--- a/tests/unit/services/daily_candles/test_repository.py
+++ b/tests/unit/services/daily_candles/test_repository.py
@@ -3,11 +3,29 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.services.daily_candles.crypto_identity import upbit_daily_candle_partition
 from app.services.daily_candles.repository import (
     DailyCandleRow,
     DailyCandlesRepository,
     MarketKey,
 )
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected"),
+    [
+        ("KRW-BTC", "upbit_krw"),
+        ("usdt-eth", "upbit_usdt"),
+    ],
+)
+def test_upbit_daily_candle_partition_is_canonical(symbol: str, expected: str) -> None:
+    assert upbit_daily_candle_partition(symbol) == expected
+
+
+@pytest.mark.parametrize("symbol", ["BTC", "BTC-ETH", "BINANCE:BTCUSDT", "", "KRW-"])
+def test_upbit_daily_candle_partition_rejects_ambiguous_symbols(symbol: str) -> None:
+    with pytest.raises(ValueError, match="KRW-/USDT-"):
+        upbit_daily_candle_partition(symbol)
 
 
 def _row(

--- a/tests/unit/services/daily_candles/test_sync_service.py
+++ b/tests/unit/services/daily_candles/test_sync_service.py
@@ -178,6 +178,34 @@ async def test_crypto_universe_uses_canonical_upbit_partition() -> None:
 
 
 @pytest.mark.asyncio
+async def test_crypto_sync_rejects_partition_that_disagrees_with_symbol() -> None:
+    repo = MagicMock()
+    repo.session = MagicMock()
+    repo.upsert_rows = AsyncMock()
+    upbit_fetcher = AsyncMock()
+    svc = DailyCandleSyncService(
+        repository=repo,
+        kis_kr_fetcher=AsyncMock(),
+        kis_us_fetcher=AsyncMock(),
+        yahoo_us_fetcher=AsyncMock(),
+        upbit_crypto_fetcher=upbit_fetcher,
+    )
+
+    with pytest.raises(ValueError, match="must match"):
+        await svc.sync_one(
+            target=SyncTarget(
+                market=MarketKey.CRYPTO,
+                symbol="USDT-ETH",
+                partition="upbit_krw",
+            ),
+            horizon_bars=30,
+        )
+
+    upbit_fetcher.assert_not_awaited()
+    repo.upsert_rows.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_service_close_awaits_callbacks():
     repo = MagicMock()
     repo.session = MagicMock()

--- a/tests/unit/services/daily_candles/test_sync_service.py
+++ b/tests/unit/services/daily_candles/test_sync_service.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
@@ -150,6 +151,30 @@ class TestSyncOneSymbol:
         repo.upsert_rows.assert_awaited_once()  # upsert ran
         repo.session.commit.assert_awaited_once()  # commit attempted
         repo.session.rollback.assert_awaited_once()  # rollback called
+
+
+@pytest.mark.asyncio
+async def test_crypto_universe_uses_canonical_upbit_partition() -> None:
+    repo = MagicMock()
+    repo.session = MagicMock()
+    repo.session.execute = AsyncMock(return_value=[SimpleNamespace(market="KRW-BTC")])
+    svc = DailyCandleSyncService(
+        repository=repo,
+        kis_kr_fetcher=AsyncMock(),
+        kis_us_fetcher=AsyncMock(),
+        yahoo_us_fetcher=AsyncMock(),
+        upbit_crypto_fetcher=AsyncMock(),
+    )
+
+    targets = await svc._resolve_universe(market="crypto")
+
+    assert targets == [
+        SyncTarget(
+            market=MarketKey.CRYPTO,
+            symbol="KRW-BTC",
+            partition="upbit_krw",
+        )
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- canonicalize KRW-/USDT- Upbit market codes to upbit_krw/upbit_usdt daily-candle partitions
- use the same identity in indicator cache reads/write-back and universe sync
- reject ambiguous crypto symbols instead of guessing a venue

## Verification
- 162 related tests passed
- make lint passed (Ruff, format, ty)
- make typecheck passed
- git diff --check passed

## Safety
No order, account mutation, production DB write/migration execution, scheduler, merge, or deployment.