### PR TITLE
fix(ROB-1129): reconcile legacy Alpaca preflight evidence

### DIFF
--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -95,6 +95,7 @@ _TERMINAL_STATES = frozenset({"filled", "canceled"})
 _TERMINAL_PREVIEW_SIBLING_STATES = frozenset({"final_reconciled", "closed", "canceled"})
 _SELL_SOURCE_KEYS = frozenset(
     {
+        "source_buy_client_order_id",
         "source_client_order_id",
         "source_order_client_order_id",
         "previous_buy_client_order_id",
@@ -116,13 +117,14 @@ def _iso(value: Any) -> Any:
     return value
 
 
-def _decimal(value: Any) -> Decimal:
+def _strict_decimal(value: Any) -> Decimal | None:
     if value is None or value == "":
-        return Decimal("0")
+        return None
     try:
-        return Decimal(str(value))
+        decimal = Decimal(str(value))
     except (InvalidOperation, ValueError, TypeError):
-        return Decimal("0")
+        return None
+    return decimal if decimal.is_finite() else None
 
 
 def _normalize_symbol(symbol: Any) -> str:
@@ -248,15 +250,6 @@ def _is_open_order(order: dict[str, Any]) -> bool:
     return status not in {"filled", "canceled", "cancelled", "expired", "rejected"}
 
 
-def _position_qty(position: dict[str, Any]) -> Decimal:
-    return _decimal(
-        position.get("qty")
-        or position.get("quantity")
-        or position.get("position_qty")
-        or position.get("available")
-    )
-
-
 def _position_symbol(position: dict[str, Any]) -> str:
     return _normalize_symbol(
         position.get("symbol")
@@ -274,20 +267,57 @@ def _strict_position_qty(position: dict[str, Any]) -> Decimal | None:
         ),
         None,
     )
-    try:
-        qty = Decimal(str(raw_qty)) if raw_qty is not None else None
-    except (InvalidOperation, ValueError, TypeError):
-        return None
-    return qty if qty is not None and qty.is_finite() else None
+    return _strict_decimal(raw_qty)
+
+
+def _position_snapshot_issues(positions: Iterable[Any]) -> list[dict[str, Any]]:
+    """Return standalone schema defects in a caller-supplied position snapshot."""
+    issues: list[dict[str, Any]] = []
+    for index, position in enumerate(positions):
+        if not isinstance(position, dict):
+            issues.append({"index": index, "reason": "position_row_not_object"})
+            continue
+        symbol = _position_symbol(position)
+        if not symbol:
+            issues.append({"index": index, "reason": "position_symbol_missing"})
+            continue
+        raw_qty = next(
+            (
+                position[key]
+                for key in ("qty", "quantity", "position_qty", "available")
+                if key in position and position[key] not in (None, "")
+            ),
+            None,
+        )
+        if raw_qty is None:
+            issues.append(
+                {
+                    "index": index,
+                    "reason": "position_qty_missing",
+                    "symbol": symbol,
+                }
+            )
+            continue
+        if _strict_decimal(raw_qty) is None:
+            issues.append(
+                {
+                    "index": index,
+                    "reason": "position_qty_invalid",
+                    "symbol": symbol,
+                }
+            )
+    return issues
 
 
 def _position_qty_by_symbol(
-    positions: Iterable[dict[str, Any]],
+    positions: Iterable[Any],
 ) -> tuple[dict[str, Decimal], set[str]]:
     """Aggregate a broker position snapshot by normalized execution symbol."""
     quantities: dict[str, Decimal] = {}
     invalid_symbols: set[str] = set()
     for position in positions:
+        if not isinstance(position, dict):
+            continue
         symbol = _position_symbol(position)
         if not symbol:
             continue
@@ -323,13 +353,14 @@ def _is_filled_sell_evidence(row: Any) -> bool:
         and str(_get(row, "lifecycle_state") or "").lower()
         in _CANONICAL_FILLED_LEDGER_STATES
         and str(_get(row, "order_status") or "").lower() == "filled"
-        and _decimal(_get(row, "filled_qty")) > Decimal("0")
+        and (filled_qty := _strict_decimal(_get(row, "filled_qty"))) is not None
+        and filled_qty > Decimal("0")
     )
 
 
 def _match_filled_buys_to_sells(
     ledger: Iterable[Any],
-) -> tuple[set[int], list[dict[str, Any]]]:
+) -> tuple[set[int], list[dict[str, Any]], list[dict[str, Any]]]:
     """Match filled buys to completed sells without inventing shared identities.
 
     Current submit paths persist ``source_buy_client_order_id`` on source-bound
@@ -349,10 +380,12 @@ def _match_filled_buys_to_sells(
         and str(_get(row, "lifecycle_state") or "").lower()
         in _BUY_REQUIRES_LINKED_SELL_STATES
     ]
-    sells = [row for row in rows if _is_filled_sell_evidence(row)]
+    all_sells = [row for row in rows if str(_get(row, "side") or "").lower() == "sell"]
+    sells = [row for row in all_sells if _is_filled_sell_evidence(row)]
     used_sell_tokens: set[int] = set()
     matched_buy_tokens: set[int] = set()
     legacy_matches: list[dict[str, Any]] = []
+    source_issues: list[dict[str, Any]] = []
 
     buys_by_client_id: dict[str, list[Any]] = {}
     for buy in buys:
@@ -360,20 +393,142 @@ def _match_filled_buys_to_sells(
         if client_id:
             buys_by_client_id.setdefault(client_id, []).append(buy)
 
-    # Strong path: a terminal, filled sell explicitly names its source buy.
-    for sell in sells:
+    # Strong path: all explicit source evidence is reserved from the legacy
+    # fallback. A source buy is complete only when one or more terminal filled
+    # sells consume exactly its positive filled quantity after the buy timestamp.
+    valid_source_sells: dict[int, list[tuple[Any, Decimal]]] = {}
+    source_buys: dict[int, Any] = {}
+    invalid_source_buy_tokens: set[int] = set()
+    for sell in all_sells:
         source_ids = _source_client_order_ids(sell)
         if not source_ids:
             continue
         used_sell_tokens.add(id(sell))
         if len(source_ids) != 1:
+            source_issues.append(
+                {
+                    "reason": "ambiguous_source_buy_ids",
+                    "source_buy_client_order_ids": sorted(source_ids),
+                    "sell": _row_ref(sell),
+                }
+            )
             continue
-        sell_symbol = _ledger_row_broker_symbol(sell)
         source_id = next(iter(source_ids))
-        for buy in buys_by_client_id.get(source_id, []):
-            buy_symbol = _ledger_row_broker_symbol(buy)
-            if buy_symbol and buy_symbol == sell_symbol:
-                matched_buy_tokens.add(id(buy))
+        source_candidates = buys_by_client_id.get(source_id, [])
+        if len(source_candidates) != 1:
+            source_issues.append(
+                {
+                    "reason": (
+                        "source_buy_not_found"
+                        if not source_candidates
+                        else "source_buy_ambiguous"
+                    ),
+                    "source_buy_client_order_id": source_id,
+                    "sell": _row_ref(sell),
+                }
+            )
+            continue
+        buy = source_candidates[0]
+        buy_token = id(buy)
+        source_buys[buy_token] = buy
+        buy_symbol = _ledger_row_broker_symbol(buy)
+        sell_symbol = _ledger_row_broker_symbol(sell)
+        if not buy_symbol or buy_symbol != sell_symbol:
+            invalid_source_buy_tokens.add(buy_token)
+            source_issues.append(
+                {
+                    "reason": "source_sell_symbol_mismatch",
+                    "source_buy_client_order_id": source_id,
+                    "buy": _row_ref(buy),
+                    "sell": _row_ref(sell),
+                }
+            )
+            continue
+        buy_created_at = _ledger_row_created_at(buy)
+        sell_created_at = _ledger_row_created_at(sell)
+        if buy_created_at is None or sell_created_at is None:
+            invalid_source_buy_tokens.add(buy_token)
+            source_issues.append(
+                {
+                    "reason": "source_chronology_missing",
+                    "source_buy_client_order_id": source_id,
+                    "buy": _row_ref(buy),
+                    "sell": _row_ref(sell),
+                }
+            )
+            continue
+        if sell_created_at < buy_created_at:
+            invalid_source_buy_tokens.add(buy_token)
+            source_issues.append(
+                {
+                    "reason": "source_sell_before_buy",
+                    "source_buy_client_order_id": source_id,
+                    "buy": _row_ref(buy),
+                    "sell": _row_ref(sell),
+                }
+            )
+            continue
+        sell_qty = _strict_decimal(_get(sell, "filled_qty"))
+        if sell_qty is None or sell_qty <= Decimal("0"):
+            invalid_source_buy_tokens.add(buy_token)
+            source_issues.append(
+                {
+                    "reason": "source_sell_qty_invalid",
+                    "source_buy_client_order_id": source_id,
+                    "sell": _row_ref(sell),
+                }
+            )
+            continue
+        if not _is_filled_sell_evidence(sell):
+            invalid_source_buy_tokens.add(buy_token)
+            source_issues.append(
+                {
+                    "reason": "source_sell_not_terminal_filled",
+                    "source_buy_client_order_id": source_id,
+                    "sell": _row_ref(sell),
+                }
+            )
+            continue
+        valid_source_sells.setdefault(buy_token, []).append((sell, sell_qty))
+
+    for buy_token, buy in source_buys.items():
+        buy_qty = _strict_decimal(_get(buy, "filled_qty"))
+        if buy_qty is None or buy_qty <= Decimal("0"):
+            invalid_source_buy_tokens.add(buy_token)
+            source_issues.append(
+                {
+                    "reason": "source_buy_qty_invalid",
+                    "buy": _row_ref(buy),
+                }
+            )
+            continue
+        total_sell_qty = sum(
+            (qty for _, qty in valid_source_sells.get(buy_token, [])),
+            start=Decimal("0"),
+        )
+        if buy_token in invalid_source_buy_tokens:
+            continue
+        if total_sell_qty < buy_qty:
+            source_issues.append(
+                {
+                    "reason": "source_sell_qty_incomplete",
+                    "buy_filled_qty": str(buy_qty),
+                    "source_sell_filled_qty": str(total_sell_qty),
+                    "buy": _row_ref(buy),
+                }
+            )
+            continue
+        if total_sell_qty > buy_qty:
+            source_issues.append(
+                {
+                    "reason": "source_sell_qty_exceeds_buy",
+                    "buy_filled_qty": str(buy_qty),
+                    "source_sell_filled_qty": str(total_sell_qty),
+                    "buy": _row_ref(buy),
+                }
+            )
+            continue
+        matched_buy_tokens.add(buy_token)
 
     # Legacy path: exact economic identity plus chronology, one sell per buy.
     def _sort_key(row: Any) -> tuple[datetime, str]:
@@ -386,9 +541,14 @@ def _match_filled_buys_to_sells(
         if id(buy) in matched_buy_tokens:
             continue
         buy_symbol = _ledger_row_broker_symbol(buy)
-        buy_qty = _decimal(_get(buy, "filled_qty"))
+        buy_qty = _strict_decimal(_get(buy, "filled_qty"))
         buy_created_at = _ledger_row_created_at(buy)
-        if not buy_symbol or buy_qty <= Decimal("0") or buy_created_at is None:
+        if (
+            not buy_symbol
+            or buy_qty is None
+            or buy_qty <= Decimal("0")
+            or buy_created_at is None
+        ):
             continue
 
         candidate = next(
@@ -398,7 +558,7 @@ def _match_filled_buys_to_sells(
                 if id(sell) not in used_sell_tokens
                 and not _source_client_order_ids(sell)
                 and _ledger_row_broker_symbol(sell) == buy_symbol
-                and _decimal(_get(sell, "filled_qty")) == buy_qty
+                and _strict_decimal(_get(sell, "filled_qty")) == buy_qty
                 and (
                     (sell_created_at := _ledger_row_created_at(sell)) is not None
                     and sell_created_at >= buy_created_at
@@ -420,7 +580,7 @@ def _match_filled_buys_to_sells(
             }
         )
 
-    return matched_buy_tokens, legacy_matches
+    return matched_buy_tokens, legacy_matches, source_issues
 
 
 def _latest_preview_time(row: Any) -> datetime | None:
@@ -634,13 +794,26 @@ def build_paper_execution_preflight_report(
             },
         )
 
+    position_rows = position_rows if position_rows is not None else []
+    malformed_positions = _position_snapshot_issues(position_rows)
+    if malformed_positions:
+        add(
+            "broker_position_snapshot_malformed",
+            PaperExecutionAnomalySeverity.block,
+            "Broker position snapshot contains a row with missing or invalid "
+            "symbol/quantity evidence",
+            {
+                "count": len(malformed_positions),
+                "rows": malformed_positions[:10],
+            },
+        )
+
     positions_are_evidence = (
         snapshot_state["positions"]["verified"]
         if snapshot_evidence_required
         else bool(position_rows)
-    )
+    ) and not malformed_positions
     orders = orders if orders is not None else []
-    position_rows = position_rows if position_rows is not None else []
 
     # 1. Unexpected open orders.
     open_snapshot = [o for o in orders if _is_open_order(o)]
@@ -665,7 +838,13 @@ def build_paper_execution_preflight_report(
         )
 
     # 2. Residual positions before a new cycle.
-    residual_positions = [p for p in position_rows if _position_qty(p) != Decimal("0")]
+    residual_positions: list[tuple[dict[str, Any], Decimal]] = []
+    for position in position_rows:
+        if not isinstance(position, dict):
+            continue
+        qty = _strict_position_qty(position)
+        if qty is not None and qty != Decimal("0"):
+            residual_positions.append((position, qty))
     if residual_positions:
         add(
             "residual_position_exists",
@@ -678,10 +857,10 @@ def build_paper_execution_preflight_report(
                 "positions": [
                     {
                         "symbol": p.get("symbol"),
-                        "qty": str(_position_qty(p)),
+                        "qty": str(qty),
                         "asset_class": p.get("asset_class"),
                     }
-                    for p in residual_positions
+                    for p, qty in residual_positions
                 ],
             },
         )
@@ -724,7 +903,22 @@ def build_paper_execution_preflight_report(
     #
     # Trusting the snapshot is a separate concern; when no snapshot is available
     # the row stays a blocker rather than being assumed open (fail-closed).
-    matched_buy_tokens, legacy_buy_sell_matches = _match_filled_buys_to_sells(ledger)
+    (
+        matched_buy_tokens,
+        legacy_buy_sell_matches,
+        source_evidence_issues,
+    ) = _match_filled_buys_to_sells(ledger)
+    if source_evidence_issues:
+        add(
+            "sell_source_evidence_invalid",
+            PaperExecutionAnomalySeverity.block,
+            "Explicit sell source evidence is ambiguous, incomplete, or "
+            "inconsistent with the source buy",
+            {
+                "count": len(source_evidence_issues),
+                "rows": source_evidence_issues[:10],
+            },
+        )
     if legacy_buy_sell_matches:
         add(
             "legacy_buy_sell_match",
@@ -774,12 +968,16 @@ def build_paper_execution_preflight_report(
             )
             continue
         symbol = _ledger_row_broker_symbol(row)
-        filled_qty = _decimal(_get(row, "filled_qty"))
+        filled_qty = _strict_decimal(_get(row, "filled_qty"))
         available_qty = remaining_position_qty.get(symbol, Decimal("0"))
+        if filled_qty is None or filled_qty <= Decimal("0"):
+            unresolved_buys.append(
+                {"reason": "holding_state_filled_qty_invalid", **_row_ref(row)}
+            )
+            continue
         if (
             symbol
             and symbol not in invalid_position_symbols
-            and filled_qty > Decimal("0")
             and available_qty >= filled_qty
         ):
             open_position_buys.append(row)
@@ -833,9 +1031,7 @@ def build_paper_execution_preflight_report(
         position_rows
     )
     for row in ledger:
-        side = str(_get(row, "side") or "").lower()
-        state = str(_get(row, "lifecycle_state") or "").lower()
-        if side != "sell" or state != "filled":
+        if not _is_filled_sell_evidence(row):
             continue
         snapshot = _get(row, "position_snapshot") or {}
         snapshot_kind = (
@@ -904,13 +1100,33 @@ def build_paper_execution_preflight_report(
     # 6. Ledger/order/fill mismatches.
     mismatches = []
     for row in ledger:
+        side = str(_get(row, "side") or "").lower()
         state = str(_get(row, "lifecycle_state") or "").lower()
         order_status = str(_get(row, "order_status") or "").lower()
-        filled_qty = _decimal(_get(row, "filled_qty"))
-        if state == "filled" and filled_qty <= Decimal("0"):
+        filled_qty = _strict_decimal(_get(row, "filled_qty"))
+        if state == "filled" and (filled_qty is None or filled_qty <= Decimal("0")):
             mismatches.append(
                 {"reason": "filled_state_without_filled_qty", **_row_ref(row)}
             )
+        if side == "sell":
+            if state == "filled" and order_status != "filled":
+                mismatches.append(
+                    {
+                        "reason": "filled_lifecycle_without_terminal_order_status",
+                        **_row_ref(row),
+                    }
+                )
+            elif state in _CANONICAL_FILLED_LEDGER_STATES and order_status != "filled":
+                mismatches.append(
+                    {
+                        "reason": "completed_sell_without_terminal_order_status",
+                        **_row_ref(row),
+                    }
+                )
+            elif state in _OPEN_LEDGER_STATES:
+                mismatches.append(
+                    {"reason": "sell_lifecycle_not_terminal", **_row_ref(row)}
+                )
         if (
             order_status == "filled"
             and state

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -265,16 +265,38 @@ def _position_symbol(position: dict[str, Any]) -> str:
     )
 
 
-def _held_position_symbols(positions: Iterable[dict[str, Any]]) -> set[str]:
-    """Normalized symbols with a non-zero quantity in the position snapshot."""
-    held: set[str] = set()
+def _strict_position_qty(position: dict[str, Any]) -> Decimal | None:
+    raw_qty = next(
+        (
+            position[key]
+            for key in ("qty", "quantity", "position_qty", "available")
+            if key in position and position[key] not in (None, "")
+        ),
+        None,
+    )
+    try:
+        qty = Decimal(str(raw_qty)) if raw_qty is not None else None
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return qty if qty is not None and qty.is_finite() else None
+
+
+def _position_qty_by_symbol(
+    positions: Iterable[dict[str, Any]],
+) -> tuple[dict[str, Decimal], set[str]]:
+    """Aggregate a broker position snapshot by normalized execution symbol."""
+    quantities: dict[str, Decimal] = {}
+    invalid_symbols: set[str] = set()
     for position in positions:
-        if _position_qty(position) == Decimal("0"):
-            continue
         symbol = _position_symbol(position)
-        if symbol:
-            held.add(symbol)
-    return held
+        if not symbol:
+            continue
+        qty = _strict_position_qty(position)
+        if qty is None:
+            invalid_symbols.add(symbol)
+            continue
+        quantities[symbol] = quantities.get(symbol, Decimal("0")) + qty
+    return quantities, invalid_symbols
 
 
 def _ledger_row_broker_symbol(row: Any) -> str:
@@ -288,6 +310,117 @@ def _ledger_row_broker_symbol(row: Any) -> str:
     return _normalize_symbol(_get(row, "execution_symbol")) or _normalize_symbol(
         _get(row, "signal_symbol")
     )
+
+
+def _ledger_row_created_at(row: Any) -> datetime | None:
+    return _as_aware_utc(_parse_datetime(_get(row, "created_at")))
+
+
+def _is_filled_sell_evidence(row: Any) -> bool:
+    """Return whether a ledger row proves that a sell filled at the broker."""
+    return (
+        str(_get(row, "side") or "").lower() == "sell"
+        and str(_get(row, "lifecycle_state") or "").lower()
+        in _CANONICAL_FILLED_LEDGER_STATES
+        and str(_get(row, "order_status") or "").lower() == "filled"
+        and _decimal(_get(row, "filled_qty")) > Decimal("0")
+    )
+
+
+def _match_filled_buys_to_sells(
+    ledger: Iterable[Any],
+) -> tuple[set[int], list[dict[str, Any]]]:
+    """Match filled buys to completed sells without inventing shared identities.
+
+    Current submit paths persist ``source_buy_client_order_id`` on source-bound
+    sells. The ROB-1129 historical rows predate that contract: every leg has its
+    own correlation/client ID and no source field. For those rows only, use a
+    conservative one-to-one fallback requiring the same broker symbol, exactly
+    equal positive filled quantity, and a sell timestamp at or after the buy.
+
+    A sell with any explicit source ID is never reassigned by the legacy
+    fallback, and each sell can discharge at most one buy.
+    """
+    rows = list(ledger)
+    buys = [
+        row
+        for row in rows
+        if str(_get(row, "side") or "").lower() == "buy"
+        and str(_get(row, "lifecycle_state") or "").lower()
+        in _BUY_REQUIRES_LINKED_SELL_STATES
+    ]
+    sells = [row for row in rows if _is_filled_sell_evidence(row)]
+    used_sell_tokens: set[int] = set()
+    matched_buy_tokens: set[int] = set()
+    legacy_matches: list[dict[str, Any]] = []
+
+    buys_by_client_id: dict[str, list[Any]] = {}
+    for buy in buys:
+        client_id = str(_get(buy, "client_order_id") or "").strip()
+        if client_id:
+            buys_by_client_id.setdefault(client_id, []).append(buy)
+
+    # Strong path: a terminal, filled sell explicitly names its source buy.
+    for sell in sells:
+        source_ids = _source_client_order_ids(sell)
+        if not source_ids:
+            continue
+        used_sell_tokens.add(id(sell))
+        if len(source_ids) != 1:
+            continue
+        sell_symbol = _ledger_row_broker_symbol(sell)
+        source_id = next(iter(source_ids))
+        for buy in buys_by_client_id.get(source_id, []):
+            buy_symbol = _ledger_row_broker_symbol(buy)
+            if buy_symbol and buy_symbol == sell_symbol:
+                matched_buy_tokens.add(id(buy))
+
+    # Legacy path: exact economic identity plus chronology, one sell per buy.
+    def _sort_key(row: Any) -> tuple[datetime, str]:
+        return (
+            _ledger_row_created_at(row) or datetime.max.replace(tzinfo=UTC),
+            str(_get(row, "client_order_id") or ""),
+        )
+
+    for buy in sorted(buys, key=_sort_key):
+        if id(buy) in matched_buy_tokens:
+            continue
+        buy_symbol = _ledger_row_broker_symbol(buy)
+        buy_qty = _decimal(_get(buy, "filled_qty"))
+        buy_created_at = _ledger_row_created_at(buy)
+        if not buy_symbol or buy_qty <= Decimal("0") or buy_created_at is None:
+            continue
+
+        candidate = next(
+            (
+                sell
+                for sell in sorted(sells, key=_sort_key)
+                if id(sell) not in used_sell_tokens
+                and not _source_client_order_ids(sell)
+                and _ledger_row_broker_symbol(sell) == buy_symbol
+                and _decimal(_get(sell, "filled_qty")) == buy_qty
+                and (
+                    (sell_created_at := _ledger_row_created_at(sell)) is not None
+                    and sell_created_at >= buy_created_at
+                )
+            ),
+            None,
+        )
+        if candidate is None:
+            continue
+        matched_buy_tokens.add(id(buy))
+        used_sell_tokens.add(id(candidate))
+        legacy_matches.append(
+            {
+                "match_basis": "legacy_exact_symbol_qty_chronology",
+                "symbol": buy_symbol,
+                "filled_qty": str(buy_qty),
+                "buy": _row_ref(buy),
+                "sell": _row_ref(candidate),
+            }
+        )
+
+    return matched_buy_tokens, legacy_matches
 
 
 def _latest_preview_time(row: Any) -> datetime | None:
@@ -577,7 +710,7 @@ def build_paper_execution_preflight_report(
             },
         )
 
-    # 4. Previous buy filled but no linked sell exists.
+    # 4. Previous buy filled but no completed sell evidence exists.
     #
     # ROB-1129: reaching a filled/reconciled state is NOT by itself evidence
     # that a sell leg is missing. A buy that is still holding an open position
@@ -585,31 +718,50 @@ def build_paper_execution_preflight_report(
     # normal open positions into preflight blockers. The live position snapshot
     # is the only thing that separates the two cases:
     #
-    #   holding state + symbol still held    -> open position, expected (info)
-    #   holding state + symbol not held      -> broker closed it, ledger did not
-    #                                           record the sell leg (block)
-    #   closed/final_reconciled + no sell    -> ledger claims the roundtrip
-    #                                           finished with no sell row (block)
+    #   completed sell evidence              -> closed leg, expected
+    #   unmatched buy + enough held quantity -> open position, expected (info)
+    #   unmatched buy + insufficient holding -> unresolved lifecycle (block)
     #
     # Trusting the snapshot is a separate concern; when no snapshot is available
     # the row stays a blocker rather than being assumed open (fail-closed).
-    sell_source_ids = {
-        source_id
-        for row in ledger
-        if str(_get(row, "side") or "").lower() == "sell"
-        for source_id in _source_client_order_ids(row)
-    }
-    held_symbols = _held_position_symbols(position_rows)
+    matched_buy_tokens, legacy_buy_sell_matches = _match_filled_buys_to_sells(ledger)
+    if legacy_buy_sell_matches:
+        add(
+            "legacy_buy_sell_match",
+            PaperExecutionAnomalySeverity.info,
+            "Historical buy and sell legs have exact fill evidence despite missing "
+            "source-link provenance",
+            {
+                "count": len(legacy_buy_sell_matches),
+                "rows": legacy_buy_sell_matches[:10],
+            },
+        )
+
+    remaining_position_qty, invalid_position_symbols = _position_qty_by_symbol(
+        position_rows
+    )
     positions_verified = positions_are_evidence
     open_position_buys: list[Any] = []
     unresolved_buys: list[dict[str, Any]] = []
-    for row in ledger:
+    buy_rows = [
+        row
+        for row in ledger
+        if str(_get(row, "side") or "").lower() == "buy"
+        and str(_get(row, "lifecycle_state") or "").lower()
+        in _BUY_REQUIRES_LINKED_SELL_STATES
+    ]
+    buy_rows.sort(
+        key=lambda row: (
+            _ledger_row_created_at(row) or datetime.max.replace(tzinfo=UTC),
+            str(_get(row, "client_order_id") or ""),
+        )
+    )
+    for row in buy_rows:
         side = str(_get(row, "side") or "").lower()
         state = str(_get(row, "lifecycle_state") or "").lower()
-        client_id = str(_get(row, "client_order_id") or "").strip()
         if side != "buy" or state not in _BUY_REQUIRES_LINKED_SELL_STATES:
             continue
-        if client_id in sell_source_ids:
+        if id(row) in matched_buy_tokens:
             continue
         if state in _BUY_COMPLETED_ROUNDTRIP_STATES:
             unresolved_buys.append(
@@ -622,11 +774,28 @@ def build_paper_execution_preflight_report(
             )
             continue
         symbol = _ledger_row_broker_symbol(row)
-        if symbol and symbol in held_symbols:
+        filled_qty = _decimal(_get(row, "filled_qty"))
+        available_qty = remaining_position_qty.get(symbol, Decimal("0"))
+        if (
+            symbol
+            and symbol not in invalid_position_symbols
+            and filled_qty > Decimal("0")
+            and available_qty >= filled_qty
+        ):
             open_position_buys.append(row)
+            remaining_position_qty[symbol] = available_qty - filled_qty
         else:
+            reason = (
+                "holding_state_without_open_position"
+                if available_qty == Decimal("0")
+                else "holding_state_without_sufficient_open_position"
+            )
             unresolved_buys.append(
-                {"reason": "holding_state_without_open_position", **_row_ref(row)}
+                {
+                    "reason": reason,
+                    "broker_position_qty_remaining": str(available_qty),
+                    **_row_ref(row),
+                }
             )
 
     if open_position_buys:
@@ -651,21 +820,85 @@ def build_paper_execution_preflight_report(
         )
 
     # 5. Sell filled but final position not closed.
-    sells_not_closed = []
+    #
+    # ``sell_claim_baseline`` is captured before submit and proves only that the
+    # quantity was available to sell. It is not a post-fill position snapshot.
+    # Prefer a stored post-fill zero snapshot; otherwise require a verified,
+    # current broker snapshot to prove the symbol is flat. A current non-zero
+    # position remains blocking because a later re-entry cannot be distinguished
+    # without stronger lifecycle provenance.
+    sells_closed_by_current_snapshot: list[dict[str, Any]] = []
+    sells_not_closed: list[dict[str, Any]] = []
+    current_position_qty, invalid_position_symbols = _position_qty_by_symbol(
+        position_rows
+    )
     for row in ledger:
         side = str(_get(row, "side") or "").lower()
         state = str(_get(row, "lifecycle_state") or "").lower()
         if side != "sell" or state != "filled":
             continue
         snapshot = _get(row, "position_snapshot") or {}
-        if not isinstance(snapshot, dict) or _position_qty(snapshot) != Decimal("0"):
-            sells_not_closed.append(row)
+        snapshot_kind = (
+            str(snapshot.get("snapshot_kind") or "")
+            if isinstance(snapshot, dict)
+            else ""
+        )
+        if (
+            isinstance(snapshot, dict)
+            and snapshot_kind != "sell_claim_baseline"
+            and _strict_position_qty(snapshot) == Decimal("0")
+        ):
+            continue
+        if not positions_verified:
+            sells_not_closed.append(
+                {"reason": "position_snapshot_unverified", **_row_ref(row)}
+            )
+            continue
+        symbol = _ledger_row_broker_symbol(row)
+        if not symbol:
+            sells_not_closed.append(
+                {"reason": "execution_symbol_missing", **_row_ref(row)}
+            )
+            continue
+        if symbol in invalid_position_symbols:
+            sells_not_closed.append(
+                {"reason": "broker_position_qty_invalid", **_row_ref(row)}
+            )
+            continue
+        broker_qty = current_position_qty.get(symbol, Decimal("0"))
+        if broker_qty == Decimal("0"):
+            sells_closed_by_current_snapshot.append(
+                {
+                    "reason": "verified_current_broker_position_flat",
+                    "stored_snapshot_kind": snapshot_kind or None,
+                    **_row_ref(row),
+                }
+            )
+        else:
+            sells_not_closed.append(
+                {
+                    "reason": "verified_current_broker_position_nonzero",
+                    "broker_position_qty": str(broker_qty),
+                    "stored_snapshot_kind": snapshot_kind or None,
+                    **_row_ref(row),
+                }
+            )
+    if sells_closed_by_current_snapshot:
+        add(
+            "sell_closed_by_current_position_snapshot",
+            PaperExecutionAnomalySeverity.info,
+            "Filled sell is closed by a verified current flat broker position",
+            {
+                "count": len(sells_closed_by_current_snapshot),
+                "rows": sells_closed_by_current_snapshot[:10],
+            },
+        )
     if sells_not_closed:
         add(
             "sell_filled_position_not_closed",
             PaperExecutionAnomalySeverity.block,
-            "A filled sell does not have a zero final position snapshot",
-            {"rows": [_row_ref(r) for r in sells_not_closed[:10]]},
+            "A filled sell lacks verified evidence that its final position is closed",
+            {"rows": sells_not_closed[:10]},
         )
 
     # 6. Ledger/order/fill mismatches.

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -185,6 +185,15 @@ both broker snapshots plus a fresh `broker_snapshot_fetched_at`; missing,
 unattested, stale, or future-dated evidence remains a blocker.
 
 New source-bound sell paths persist `preview_payload.source_buy_client_order_id`.
+The checker treats that persisted key and the recognized historical aliases as
+one provenance set. Conflicting source IDs are ambiguous and block; an explicit
+source that does not resolve to exactly one buy is never reassigned through the
+legacy fallback. One or more terminal `filled` source sells close a buy only
+when they occur no earlier than the buy and their positive finite filled
+quantities sum exactly to the source buy's filled quantity. Incomplete,
+overfilled, missing/invalid-quantity, non-terminal, or impossible-chronology
+source evidence blocks.
+
 Historical execution rows created before that contract have independent
 `client_order_id` / `lifecycle_correlation_id` values. For those rows only, the
 checker accepts a one-to-one legacy match when broker symbol and positive
@@ -197,7 +206,11 @@ position snapshot proves the unmatched buy quantity is still open.
 reservation evidence, not a post-fill close snapshot. A filled sell is closed
 only by a stored post-fill zero snapshot or a fresh verified broker snapshot
 showing that symbol flat. A non-zero or malformed current quantity remains
-blocking.
+blocking. Every fresh broker position row must have a symbol and a finite,
+parseable quantity; a missing/invalid row is a standalone blocker even when the
+ledger is empty. Current-flat evidence is considered only for sells whose
+lifecycle and broker order status both prove a terminal fill. Partial or
+otherwise non-terminal sell lifecycle evidence remains blocking.
 
 ---
 

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -178,6 +178,27 @@ alpaca_paper_ledger_get_by_correlation(lifecycle_correlation_id)
 alpaca_paper_roundtrip_report(lifecycle_correlation_id=None, client_order_id=None, candidate_uuid=None, briefing_artifact_run_uuid=None, open_orders=None, positions=None)
 ```
 
+### Execution preflight lifecycle evidence (ROB-1129 / ROB-1130)
+
+`alpaca_paper_execution_preflight_check` is fail-closed and read-only. Supply
+both broker snapshots plus a fresh `broker_snapshot_fetched_at`; missing,
+unattested, stale, or future-dated evidence remains a blocker.
+
+New source-bound sell paths persist `preview_payload.source_buy_client_order_id`.
+Historical execution rows created before that contract have independent
+`client_order_id` / `lifecycle_correlation_id` values. For those rows only, the
+checker accepts a one-to-one legacy match when broker symbol and positive
+`filled_qty` are exactly equal and the filled sell is no earlier than the buy.
+Different quantity, missing chronology, non-filled/canceled sell, ambiguous
+source IDs, or sell reuse does not match and remains blocking unless the fresh
+position snapshot proves the unmatched buy quantity is still open.
+
+`position_snapshot.snapshot_kind="sell_claim_baseline"` is pre-submit
+reservation evidence, not a post-fill close snapshot. A filled sell is closed
+only by a stored post-fill zero snapshot or a fresh verified broker snapshot
+showing that symbol flat. A non-zero or malformed current quantity remains
+blocking.
+
 ---
 
 ## Profile exposure (ROB-908 — DEFAULT-profile flag)

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -283,15 +283,60 @@ def _rob1129_measured_buy_legs():
     client_order_id, which is why payload-based buy/sell pairing never matches.
     """
     measured = [
-        ("rob73-93bc5d4b6ba0ac6e", "ISRG", "1"),
-        ("rob73-ac562d42b1d3ec16", "UBER", "4"),
-        ("rob73-3ccf09a984c7758e", "WDC", "1"),
-        ("rob73-47a669297ff57cb3", "F", "1"),
-        ("rob73-a8691ab4f782af06", "ROST", "1"),
-        ("rob73-1862fd0d16137ff6", "OLED", "0.0614"),
-        ("rob73-ac4103900976a38d", "DPZ", "1"),
-        ("rob73-c9726ec2359bd763", "AMC", "1"),
-        ("rob73-08ebbf8c64e2dd93", "ISRG", "0.014"),
+        (
+            "rob73-93bc5d4b6ba0ac6e",
+            "ISRG",
+            "1",
+            datetime(2026, 7, 24, 14, 10, 27, tzinfo=UTC),
+        ),
+        (
+            "rob73-ac562d42b1d3ec16",
+            "UBER",
+            "4",
+            datetime(2026, 7, 24, 14, 10, 16, tzinfo=UTC),
+        ),
+        (
+            "rob73-3ccf09a984c7758e",
+            "WDC",
+            "1",
+            datetime(2026, 7, 24, 14, 10, 3, tzinfo=UTC),
+        ),
+        (
+            "rob73-47a669297ff57cb3",
+            "F",
+            "0.353",
+            datetime(2026, 7, 23, 13, 43, 38, tzinfo=UTC),
+        ),
+        (
+            "rob73-a8691ab4f782af06",
+            "ROST",
+            "0.0217",
+            datetime(2026, 7, 21, 13, 55, 11, tzinfo=UTC),
+        ),
+        (
+            "rob73-1862fd0d16137ff6",
+            "OLED",
+            "0.0614",
+            datetime(2026, 7, 21, 13, 55, 8, tzinfo=UTC),
+        ),
+        (
+            "rob73-ac4103900976a38d",
+            "DPZ",
+            "0.0145",
+            datetime(2026, 7, 20, 13, 34, 38, tzinfo=UTC),
+        ),
+        (
+            "rob73-c9726ec2359bd763",
+            "AMC",
+            "2.12",
+            datetime(2026, 7, 20, 13, 33, 59, tzinfo=UTC),
+        ),
+        (
+            "rob73-08ebbf8c64e2dd93",
+            "ISRG",
+            "0.014",
+            datetime(2026, 7, 17, 13, 51, 3, tzinfo=UTC),
+        ),
     ]
     return [
         _row(
@@ -304,8 +349,9 @@ def _rob1129_measured_buy_legs():
             signal_symbol=symbol,
             filled_qty=filled_qty,
             position_snapshot=None,
+            created_at=created_at,
         )
-        for client_order_id, symbol, filled_qty in measured
+        for client_order_id, symbol, filled_qty, created_at in measured
     ]
 
 
@@ -899,7 +945,7 @@ def test_scoped_preflight_still_blocks_symbol_mismatch_inside_same_correlation()
 
 @pytest.mark.unit
 def test_preflight_does_not_flag_canceled_state_as_anomaly():
-    # Check that a canceled row does not trigger unexpected anomalies
+    """A canceled sell is not an anomaly row, but also is not fill evidence."""
     report = build_paper_execution_preflight_report(
         ledger_rows=[
             _row(
@@ -919,9 +965,12 @@ def test_preflight_does_not_flag_canceled_state_as_anomaly():
         **_verified_snapshot(),
     )
 
-    assert report.status == "pass"
-    assert report.should_block is False
+    assert report.status == "blocked"
+    assert report.should_block is True
     assert "ledger_anomaly_row" not in _check_ids(report)
+    finding = _anomaly(report, "previous_buy_filled_sell_missing")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["client_order_id"] == "buy-reconciled"
 
 
 # ---------------------------------------------------------------------------
@@ -1159,17 +1208,52 @@ def _rob1129_measured_sell_legs():
 
     Source: ~/work/herdr-inbox/alpaca-paper-block-proposal-2026-07-28.md 2-B.
     Their stored `position_snapshot` is the pre-fill sell_claim_baseline rather
-    than a post-fill re-read, which is a separate defect from the buy/sell
-    pairing one and is deliberately left untouched by the ROB-1129 fix.
+    than a post-fill re-read. It therefore cannot prove that a filled sell left
+    a residual position.
     """
     measured = [
-        ("rob73-ce5159550b11e626", "F"),
-        ("rob73-abc306c7599f4b63", "F"),
-        ("rob73-cce8e0d3264fb86d", "ROST"),
-        ("rob73-9dd2e832f0e9dd05", "REGN"),
-        ("rob73-2b58a4ff9b6645ff", "F"),
-        ("rob73-e37deae38a423090", "DPZ"),
-        ("rob73-6623cf6a1009e34c", "AMC"),
+        (
+            "rob73-ce5159550b11e626",
+            "F",
+            "0.26999594",
+            datetime(2026, 7, 27, 14, 4, 18, tzinfo=UTC),
+        ),
+        (
+            "rob73-abc306c7599f4b63",
+            "F",
+            "0.353",
+            datetime(2026, 7, 23, 13, 43, 57, tzinfo=UTC),
+        ),
+        (
+            "rob73-cce8e0d3264fb86d",
+            "ROST",
+            "0.0217",
+            datetime(2026, 7, 23, 13, 42, 19, tzinfo=UTC),
+        ),
+        (
+            "rob73-9dd2e832f0e9dd05",
+            "REGN",
+            "1",
+            datetime(2026, 7, 23, 13, 42, 6, tzinfo=UTC),
+        ),
+        (
+            "rob73-2b58a4ff9b6645ff",
+            "F",
+            "0.34371125",
+            datetime(2026, 7, 22, 14, 25, 53, tzinfo=UTC),
+        ),
+        (
+            "rob73-e37deae38a423090",
+            "DPZ",
+            "0.0145",
+            datetime(2026, 7, 20, 19, 39, 9, tzinfo=UTC),
+        ),
+        (
+            "rob73-6623cf6a1009e34c",
+            "AMC",
+            "2.12",
+            datetime(2026, 7, 20, 19, 39, 6, tzinfo=UTC),
+        ),
     ]
     return [
         _row(
@@ -1180,31 +1264,43 @@ def _rob1129_measured_sell_legs():
             order_status="filled",
             execution_symbol=symbol,
             signal_symbol=symbol,
-            filled_qty="1",
-            position_snapshot={"qty": "1"},
+            filled_qty=filled_qty,
+            position_snapshot={
+                "qty": filled_qty,
+                "snapshot_kind": "sell_claim_baseline",
+            },
+            created_at=created_at,
         )
-        for client_order_id, symbol in measured
+        for client_order_id, symbol, filled_qty, created_at in measured
+    ]
+
+
+def _rob1129_current_positions():
+    """07-30 read-only broker snapshot (8 positions, MCP read-only surface)."""
+    return [
+        {"symbol": "BSX", "qty": "5", "asset_class": "us_equity"},
+        {"symbol": "BTCUSD", "qty": "0.000824864", "asset_class": "crypto"},
+        {"symbol": "CPNG", "qty": "1", "asset_class": "us_equity"},
+        {"symbol": "HCA", "qty": "1", "asset_class": "us_equity"},
+        {"symbol": "ISRG", "qty": "1.014", "asset_class": "us_equity"},
+        {"symbol": "UBER", "qty": "5", "asset_class": "us_equity"},
+        {"symbol": "WDC", "qty": "1", "asset_class": "us_equity"},
+        {"symbol": "OLED", "qty": "0.0614", "asset_class": "us_equity"},
     ]
 
 
 @pytest.mark.unit
-def test_rob1129_stage_one_does_not_release_the_account_block():
-    """Both fixes together shrink the findings but the account still blocks.
+def test_rob1129_current_16_rows_classify_without_pairing_false_blocks():
+    """Replay the 16 rows against the 07-30 read-only broker state.
 
-    Fixing the checker removes the five false positives and fixing the snapshot
-    input makes the holdings visible. What remains is real: four buy legs the
-    broker already closed, seven sell legs whose ledger rows never advanced, and
-    the flat-account residual gate. Advancing those rows needs the stage 2/3
-    tooling, not a checker change.
+    Five buys are still open, four buys have exact later sell fills despite
+    missing source-link provenance, and all seven sells are flat in the current
+    broker snapshot. The account remains blocked by the independent residual
+    position gate; no blocker is downgraded or bypassed.
     """
     report = build_paper_execution_preflight_report(
         ledger_rows=_rob1129_measured_buy_legs() + _rob1129_measured_sell_legs(),
-        positions=[
-            {"symbol": "ISRG", "qty": "1.014", "asset_class": "us_equity"},
-            {"symbol": "UBER", "qty": "5", "asset_class": "us_equity"},
-            {"symbol": "WDC", "qty": "1", "asset_class": "us_equity"},
-            {"symbol": "OLED", "qty": "0.0614", "asset_class": "us_equity"},
-        ],
+        positions=_rob1129_current_positions(),
         positions_fetched_at=_ROB1130_NOW,
         open_orders=[],
         open_orders_fetched_at=_ROB1130_NOW,
@@ -1212,13 +1308,72 @@ def test_rob1129_stage_one_does_not_release_the_account_block():
     )
 
     assert report.should_block is True
-    assert _blocking_check_ids(report) == {
-        "residual_position_exists",
-        "previous_buy_filled_sell_missing",
-        "sell_filled_position_not_closed",
-    }
+    assert _blocking_check_ids(report) == {"residual_position_exists"}
     assert _anomaly(report, "open_position_without_sell_leg").details["count"] == 5
-    assert _anomaly(report, "previous_buy_filled_sell_missing").details["count"] == 4
-    assert len(_anomaly(report, "sell_filled_position_not_closed").details["rows"]) == 7
+    legacy_matches = _anomaly(report, "legacy_buy_sell_match")
+    assert legacy_matches.details["count"] == 4
+    assert {
+        row["buy"]["client_order_id"] for row in legacy_matches.details["rows"]
+    } == {
+        "rob73-47a669297ff57cb3",
+        "rob73-a8691ab4f782af06",
+        "rob73-ac4103900976a38d",
+        "rob73-c9726ec2359bd763",
+    }
+    closed_sells = _anomaly(report, "sell_closed_by_current_position_snapshot")
+    assert closed_sells.details["count"] == 7
+    assert "previous_buy_filled_sell_missing" not in _check_ids(report)
+    assert "sell_filled_position_not_closed" not in _check_ids(report)
     # No bypass: the test-mode downgrade flag stays off and untouched.
     assert report.broker_snapshot["evidence_required"] is True
+
+
+@pytest.mark.unit
+def test_rob1129_mutation_missing_sell_still_blocks():
+    """Fixture-only mutation: remove DPZ's sell and keep DPZ broker-flat."""
+    rows = _rob1129_measured_buy_legs() + [
+        row
+        for row in _rob1129_measured_sell_legs()
+        if row.client_order_id != "rob73-e37deae38a423090"
+    ]
+
+    report = build_paper_execution_preflight_report(
+        ledger_rows=rows,
+        positions=_rob1129_current_positions(),
+        positions_fetched_at=_ROB1130_NOW,
+        open_orders=[],
+        open_orders_fetched_at=_ROB1130_NOW,
+        now=_ROB1130_NOW,
+    )
+
+    finding = _anomaly(report, "previous_buy_filled_sell_missing")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert [row["client_order_id"] for row in finding.details["rows"]] == [
+        "rob73-ac4103900976a38d"
+    ]
+    assert finding.details["rows"][0]["reason"] == (
+        "holding_state_without_open_position"
+    )
+
+
+@pytest.mark.unit
+def test_rob1129_mutation_nonflat_sell_still_blocks():
+    """Fixture-only mutation: current DPZ residual disproves sell closure."""
+    report = build_paper_execution_preflight_report(
+        ledger_rows=_rob1129_measured_buy_legs() + _rob1129_measured_sell_legs(),
+        positions=_rob1129_current_positions()
+        + [{"symbol": "DPZ", "qty": "0.001", "asset_class": "us_equity"}],
+        positions_fetched_at=_ROB1130_NOW,
+        open_orders=[],
+        open_orders_fetched_at=_ROB1130_NOW,
+        now=_ROB1130_NOW,
+    )
+
+    finding = _anomaly(report, "sell_filled_position_not_closed")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert [row["client_order_id"] for row in finding.details["rows"]] == [
+        "rob73-e37deae38a423090"
+    ]
+    assert finding.details["rows"][0]["reason"] == (
+        "verified_current_broker_position_nonzero"
+    )

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -1377,3 +1377,291 @@ def test_rob1129_mutation_nonflat_sell_still_blocks():
     assert finding.details["rows"][0]["reason"] == (
         "verified_current_broker_position_nonzero"
     )
+
+
+# ---------------------------------------------------------------------------
+# ROB-1129 adversarial verifier follow-up: eight formerly false-PASS boundaries
+# ---------------------------------------------------------------------------
+
+_ROB1129_VERIFY_NOW = datetime(2026, 7, 30, 0, 0, tzinfo=UTC)
+_ROB1129_VERIFY_BUY_AT = datetime(2026, 7, 29, 23, 0, tzinfo=UTC)
+_ROB1129_VERIFY_SELL_AT = datetime(2026, 7, 29, 23, 1, tzinfo=UTC)
+
+
+def _rob1129_verify_report(*, ledger_rows=(), positions=()):
+    return build_paper_execution_preflight_report(
+        ledger_rows=ledger_rows,
+        positions=positions,
+        positions_fetched_at=_ROB1129_VERIFY_NOW,
+        open_orders=[],
+        open_orders_fetched_at=_ROB1129_VERIFY_NOW,
+        now=_ROB1129_VERIFY_NOW,
+    )
+
+
+def _rob1129_verify_buy(**kwargs):
+    values = {
+        "client_order_id": "buy-1",
+        "lifecycle_correlation_id": "buy-1",
+        "execution_symbol": "AAPL",
+        "signal_symbol": "AAPL",
+        "filled_qty": "1",
+        "created_at": _ROB1129_VERIFY_BUY_AT,
+    }
+    values.update(kwargs)
+    return _row(**values)
+
+
+def _rob1129_verify_sell(**kwargs):
+    values = {
+        "client_order_id": "sell-1",
+        "lifecycle_correlation_id": "sell-1",
+        "side": "sell",
+        "execution_symbol": "AAPL",
+        "signal_symbol": "AAPL",
+        "filled_qty": "1",
+        "position_snapshot": {
+            "snapshot_kind": "sell_claim_baseline",
+            "qty": "1",
+        },
+        "created_at": _ROB1129_VERIFY_SELL_AT,
+    }
+    values.update(kwargs)
+    return _row(**values)
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_ambiguous_actual_plus_recognized_source_blocks():
+    report = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_buy(),
+            _rob1129_verify_sell(
+                preview_payload={"source_buy_client_order_id": "buy-other"},
+                raw_responses={"payload": {"source_client_order_id": "buy-1"}},
+            ),
+        ]
+    )
+
+    finding = _anomaly(report, "sell_source_evidence_invalid")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == "ambiguous_source_buy_ids"
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_broker_qty_missing_blocks():
+    report = _rob1129_verify_report(positions=[{"symbol": "AAPL", "qty": None}])
+
+    finding = _anomaly(report, "broker_position_snapshot_malformed")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == "position_qty_missing"
+    assert "preflight_clean" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_broker_qty_invalid_blocks():
+    report = _rob1129_verify_report(positions=[{"symbol": "AAPL", "qty": "bad"}])
+
+    finding = _anomaly(report, "broker_position_snapshot_malformed")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == "position_qty_invalid"
+    assert "preflight_clean" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_source_partial_qty_blocks():
+    report = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_buy(),
+            _rob1129_verify_sell(
+                filled_qty="0.4",
+                preview_payload={"source_buy_client_order_id": "buy-1"},
+            ),
+        ]
+    )
+
+    finding = _anomaly(report, "sell_source_evidence_invalid")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == "source_sell_qty_incomplete"
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_source_sell_before_buy_blocks():
+    report = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_buy(),
+            _rob1129_verify_sell(
+                created_at=_ROB1129_VERIFY_BUY_AT - timedelta(minutes=1),
+                preview_payload={"source_buy_client_order_id": "buy-1"},
+            ),
+        ]
+    )
+
+    finding = _anomaly(report, "sell_source_evidence_invalid")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == "source_sell_before_buy"
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_filled_state_partial_order_status_blocks():
+    report = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_sell(
+                lifecycle_state="filled",
+                order_status="partially_filled",
+                filled_qty="0.4",
+            )
+        ]
+    )
+
+    finding = _anomaly(report, "ledger_order_fill_mismatch")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == (
+        "filled_lifecycle_without_terminal_order_status"
+    )
+    assert "sell_closed_by_current_position_snapshot" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_partial_state_partial_order_status_blocks():
+    report = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_sell(
+                lifecycle_state="partially_filled",
+                order_status="partially_filled",
+                filled_qty="0.4",
+            )
+        ]
+    )
+
+    finding = _anomaly(report, "ledger_order_fill_mismatch")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == ("sell_lifecycle_not_terminal")
+    assert "preflight_clean" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_rob1129_refuted_persisted_key_wrong_source_blocks():
+    report = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_buy(),
+            _rob1129_verify_sell(
+                preview_payload={"source_buy_client_order_id": "buy-other"}
+            ),
+        ]
+    )
+
+    finding = _anomaly(report, "sell_source_evidence_invalid")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == "source_buy_not_found"
+    assert "legacy_buy_sell_match" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_rob1129_source_partial_sells_must_sum_exactly_to_buy_qty():
+    first_sell = _rob1129_verify_sell(
+        client_order_id="sell-partial-1",
+        filled_qty="0.4",
+        preview_payload={"source_buy_client_order_id": "buy-1"},
+    )
+    second_sell = _rob1129_verify_sell(
+        client_order_id="sell-partial-2",
+        filled_qty="0.6",
+        created_at=_ROB1129_VERIFY_SELL_AT + timedelta(minutes=1),
+        preview_payload={"source_buy_client_order_id": "buy-1"},
+    )
+
+    exact = _rob1129_verify_report(
+        ledger_rows=[_rob1129_verify_buy(), first_sell, second_sell]
+    )
+    assert exact.should_block is False
+    assert "sell_source_evidence_invalid" not in _check_ids(exact)
+    assert "previous_buy_filled_sell_missing" not in _check_ids(exact)
+
+    overfilled = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_buy(),
+            first_sell,
+            _rob1129_verify_sell(
+                client_order_id="sell-partial-over",
+                filled_qty="0.7",
+                created_at=_ROB1129_VERIFY_SELL_AT + timedelta(minutes=1),
+                preview_payload={"source_buy_client_order_id": "buy-1"},
+            ),
+        ]
+    )
+    finding = _anomaly(overfilled, "sell_source_evidence_invalid")
+    assert finding.details["rows"][0]["reason"] == "source_sell_qty_exceeds_buy"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("position", "reason"),
+    [
+        ({"qty": "1"}, "position_symbol_missing"),
+        ({"symbol": "AAPL", "qty": "NaN"}, "position_qty_invalid"),
+        ({"symbol": "AAPL", "qty": "Infinity"}, "position_qty_invalid"),
+    ],
+)
+def test_rob1129_every_malformed_position_row_blocks(position, reason):
+    report = _rob1129_verify_report(positions=[position])
+
+    finding = _anomaly(report, "broker_position_snapshot_malformed")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert finding.details["rows"][0]["reason"] == reason
+
+
+@pytest.mark.unit
+def test_rob1129_new_evidence_blockers_are_not_downgraded_by_legacy_flag():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _rob1129_verify_buy(),
+            _rob1129_verify_sell(
+                filled_qty="0.4",
+                preview_payload={"source_buy_client_order_id": "buy-1"},
+            ),
+            _rob1129_verify_sell(
+                client_order_id="sell-partial-lifecycle",
+                lifecycle_state="partially_filled",
+                order_status="partially_filled",
+                filled_qty="0.2",
+                created_at=_ROB1129_VERIFY_SELL_AT + timedelta(minutes=1),
+            ),
+        ],
+        positions=[{"symbol": "AAPL", "qty": "bad"}],
+        positions_fetched_at=_ROB1129_VERIFY_NOW,
+        open_orders=[],
+        open_orders_fetched_at=_ROB1129_VERIFY_NOW,
+        now=_ROB1129_VERIFY_NOW,
+        legacy_cycle_blockers_as_warnings=True,
+    )
+
+    assert report.should_block is True
+    severities = {finding.check_id: finding.severity for finding in report.anomalies}
+    assert severities["broker_position_snapshot_malformed"] == (
+        PaperExecutionAnomalySeverity.block
+    )
+    assert severities["sell_source_evidence_invalid"] == (
+        PaperExecutionAnomalySeverity.block
+    )
+    assert severities["ledger_order_fill_mismatch"] == (
+        PaperExecutionAnomalySeverity.block
+    )
+
+
+@pytest.mark.unit
+def test_rob1129_stored_post_fill_zero_current_nonzero_still_blocks():
+    report = _rob1129_verify_report(
+        ledger_rows=[
+            _rob1129_verify_sell(
+                position_snapshot={
+                    "snapshot_kind": "post_fill",
+                    "qty": "0",
+                }
+            )
+        ],
+        positions=[{"symbol": "AAPL", "qty": "1"}],
+    )
+
+    finding = _anomaly(report, "residual_position_exists")
+    assert finding.severity == PaperExecutionAnomalySeverity.block
+    assert report.should_block is True


### PR DESCRIPTION
## Summary

- correct the Alpaca Paper preflight checker to distinguish current source-bound sell provenance from historical rows whose buy/sell legs have independent IDs
- add a conservative one-to-one legacy match requiring the same broker symbol, exact positive filled quantity, completed sell evidence, and sell-after-buy chronology
- treat `sell_claim_baseline` as pre-submit reservation evidence, never as a post-fill close snapshot; require stored post-fill zero or a fresh verified broker-flat snapshot
- keep unmatched, quantity-insufficient, canceled, ambiguous, non-flat, malformed, and unverified cases blocking
- document the ROB-1129/ROB-1130 evidence contract and replay the measured 2026-07-28 16 rows against the 2026-07-30 read-only snapshot

## Root cause

The issue description attributes the failure to direct `lifecycle_correlation_id` pairing. The actual checker at `app/services/alpaca_paper_anomaly_checks.py` collected source buy client IDs from sell payloads and compared them to buy `client_order_id` values. The 16 historical rows have neither shared correlation IDs nor persisted source-link payloads, so four genuinely closed buy legs could never match. Separately, the sell check interpreted the persisted pre-fill `sell_claim_baseline` as though it were a final position snapshot, blocking seven filled sells even though the fresh broker snapshot is flat for those symbols.

## 2026-07-30 evidence

Production was queried only through read-only MCP surfaces:

- ledger: 36 rows
- positions: 8
- open orders: 0
- deployed #1716 checker: 5 open buys INFO, 4 buys BLOCK, 7 sells BLOCK

The local updated checker replays the documented 16-row fixture as:

- 5 unmatched buys covered by current held quantity: INFO
- 4 exact historical buy/sell pairs: INFO
- 7 filled sells with current broker-flat symbols: INFO
- independent residual position gate: still BLOCK

This is an offline replay using the read-only current snapshot, not a deployed production remeasurement of the new code.

## Mutation / fail-closed proof

- remove the DPZ sell fixture while DPZ remains broker-flat -> `previous_buy_filled_sell_missing` BLOCK
- mutate current DPZ quantity to non-zero -> `sell_filled_position_not_closed` BLOCK
- canceled sell source ID no longer counts as fill evidence
- ROB-1130 empty/missing/unattested snapshot cases remain BLOCK

## Validation

Seed: `PYTHONHASHSEED=1129`

- focused acceptance matrix: `8 passed, 37 deselected in 0.46s`
- related Alpaca Paper suite: `135 passed in 18.19s`
- ROB-501 static LLM boundary: `3 passed in 7.08s`
- `make lint`: Ruff passed; 3410 files formatted; `ty check app/ --error-on-warning` passed
- `git diff --check`: passed

No deployment, merge, broker/order mutation, ledger/DB write, scheduler change, or Linear write was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened execution preflight checks using verified broker positions and transaction evidence.
  * Improved detection of unmatched buys, incomplete sells, malformed position data, and non-flat positions.
  * Ambiguous or insufficient evidence now blocks execution instead of allowing potentially unsafe activity.
  * Historical transaction records receive clearer handling when legacy matching rules apply.

* **Documentation**
  * Added runbook guidance covering evidence requirements, matching behavior, and position-closure validation.

* **Tests**
  * Expanded regression coverage for canceled trades, missing sells, and non-flat broker positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->