### PR TITLE
test(ROB-1171): bootstrap daily candle tables

### DIFF
--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -64,7 +64,9 @@ from sqlalchemy import text
 # v31: Alpaca paper lab account_mode CHECK expansions.
 # v32 (ROB-1103): nullable direct-watch source links + future-write FKs.
 # v33 (ROB-1115): strategy_learning_events ORM table + append-only triggers.
-SCHEMA_BOOTSTRAP_VERSION = 33
+# v34 (ROB-1171): non-ORM kr/us_candles_1d tables used by repository
+# integration tests.
+SCHEMA_BOOTSTRAP_VERSION = 34
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -624,6 +626,50 @@ _PAPER_EVALUATION_TRIGGER_DDL: tuple[str, ...] = (
 _DDL_STATEMENTS: tuple[str, ...] = (
     *_PAPER_COHORT_TRIGGER_DDL,
     *_PAPER_EVALUATION_TRIGGER_DDL,
+    # ---- daily candle repository tables (non-ORM production hypertables) ----
+    # The test PostgreSQL instance does not need Timescale chunking to verify
+    # repository SQL semantics, but it does need the production column,
+    # constraint, and index contract.
+    "CREATE TABLE IF NOT EXISTS public.kr_candles_1d ("
+    "time TIMESTAMPTZ NOT NULL, "
+    "symbol TEXT NOT NULL, "
+    "venue TEXT NOT NULL, "
+    "open NUMERIC NOT NULL, "
+    "high NUMERIC NOT NULL, "
+    "low NUMERIC NOT NULL, "
+    "close NUMERIC NOT NULL, "
+    "volume NUMERIC NOT NULL, "
+    "value NUMERIC NOT NULL, "
+    "source TEXT NOT NULL, "
+    "ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(), "
+    "CONSTRAINT ck_kr_candles_1d_venue CHECK (venue IN ('KRX', 'NTX')), "
+    "CONSTRAINT uq_kr_candles_1d_time_symbol_venue "
+    "UNIQUE (time, symbol, venue))",
+    "CREATE INDEX IF NOT EXISTS ix_kr_candles_1d_symbol_venue_time_desc "
+    "ON public.kr_candles_1d (symbol, venue, time DESC)",
+    "CREATE INDEX IF NOT EXISTS ix_kr_candles_1d_source_time "
+    "ON public.kr_candles_1d (source, time DESC)",
+    "CREATE TABLE IF NOT EXISTS public.us_candles_1d ("
+    "time TIMESTAMPTZ NOT NULL, "
+    "symbol TEXT NOT NULL, "
+    "exchange TEXT NOT NULL, "
+    "open NUMERIC NOT NULL, "
+    "high NUMERIC NOT NULL, "
+    "low NUMERIC NOT NULL, "
+    "close NUMERIC NOT NULL, "
+    "adj_close NUMERIC, "
+    "volume NUMERIC NOT NULL, "
+    "value NUMERIC NOT NULL, "
+    "source TEXT NOT NULL, "
+    "ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(), "
+    "CONSTRAINT ck_us_candles_1d_exchange "
+    "CHECK (exchange IN ('NASD', 'NYSE', 'AMEX')), "
+    "CONSTRAINT uq_us_candles_1d_time_symbol_exchange "
+    "UNIQUE (time, symbol, exchange))",
+    "CREATE INDEX IF NOT EXISTS ix_us_candles_1d_symbol_exchange_time_desc "
+    "ON public.us_candles_1d (symbol, exchange, time DESC)",
+    "CREATE INDEX IF NOT EXISTS ix_us_candles_1d_source_time "
+    "ON public.us_candles_1d (source, time DESC)",
     # ---- market_events / us_symbol_universe ----
     "ALTER TABLE market_events ADD COLUMN IF NOT EXISTS currency TEXT",
     "ALTER TABLE us_symbol_universe ADD COLUMN IF NOT EXISTS is_common_stock BOOLEAN",

--- a/tests/integration/services/daily_candles/test_full_cycle.py
+++ b/tests/integration/services/daily_candles/test_full_cycle.py
@@ -1,24 +1,18 @@
 """Integration tests: daily candle store upsert / fetch round-trip and
 source-precedence invariant.
 
-These tests connect directly to the dev Timescale container (port 5434,
-db auto_trader) because the test-suite conftest force-overrides DATABASE_URL
-to test_db at port 5432, which does not contain the hypertable schema.
-We read the real DATABASE_URL from the .env file before the conftest
-applies its override.
+The candle tables have no ORM models, so the shared test-schema bootstrap
+creates their production-compatible relational shape in the run-owned
+PostgreSQL database before these tests execute.
 """
 
 from __future__ import annotations
 
-import os
 import uuid
 from datetime import UTC, datetime
-from pathlib import Path
 
 import pytest
-import pytest_asyncio
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.services.daily_candles.repository import (
     DailyCandleRow,
@@ -33,58 +27,11 @@ _SYMBOL_KR = f"TSTKR{_TEST_SUFFIX}"
 _SYMBOL_US = f"TSTUS{_TEST_SUFFIX}"
 
 
-def _find_dotenv_path() -> Path | None:
-    for parent in Path(__file__).resolve().parents:
-        if (parent / "pyproject.toml").is_file():
-            candidate = parent / ".env"
-            return candidate if candidate.is_file() else None
-    return None
-
-
-def _read_dev_database_url() -> str | None:
-    """Read DATABASE_URL from the .env file (not the test-overridden env var).
-
-    The conftest force-sets DATABASE_URL to test_db at port 5432.  Integration
-    tests that exercise Timescale hypertables must use the real dev DB at port
-    5434.  We read .env directly to recover the original URL.
-    """
-    env_path = _find_dotenv_path()
-    if env_path is None:
-        return None
-    with env_path.open(encoding="utf-8") as f:
-        for raw_line in f:
-            line = raw_line.strip()
-            if line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            if key.strip() == "DATABASE_URL":
-                return value.strip()
-    return None
-
-
-_DEV_DB_URL = _read_dev_database_url() or os.environ.get("DEV_DATABASE_URL")
-
-
-@pytest_asyncio.fixture
-async def dev_session():
-    """Async session against an explicitly configured dev Timescale database."""
-    if not _DEV_DB_URL:
-        pytest.skip(
-            "DEV_DATABASE_URL or local .env DATABASE_URL is required for live Timescale integration tests"
-        )
-
-    engine = create_async_engine(_DEV_DB_URL, echo=False)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-    await engine.dispose()
-
-
 @pytest.mark.integration
 class TestFullCycle:
     @pytest.mark.asyncio
-    async def test_upsert_then_fetch_round_trip(self, dev_session):
-        repo = DailyCandlesRepository(session=dev_session)
+    async def test_upsert_then_fetch_round_trip(self, db_session):
+        repo = DailyCandlesRepository(session=db_session)
         rows = [
             DailyCandleRow(
                 time_utc=datetime(2026, 5, d, tzinfo=UTC),
@@ -103,7 +50,7 @@ class TestFullCycle:
         ]
         try:
             inserted = await repo.upsert_rows(market=MarketKey.KR, rows=rows)
-            await dev_session.commit()
+            await db_session.commit()
             # rowcount for batch ON CONFLICT upserts is not reliable across
             # drivers (asyncpg returns 0 for bulk execute) — assert non-negative.
             assert inserted >= 0
@@ -117,20 +64,20 @@ class TestFullCycle:
             assert len(fetched) == 5
             assert all(r.source == "kis" for r in fetched)
         except Exception:
-            await dev_session.rollback()
+            await db_session.rollback()
             raise
         finally:
             # Rollback any aborted transaction before cleanup.
-            await dev_session.rollback()
-            await dev_session.execute(
+            await db_session.rollback()
+            await db_session.execute(
                 text("DELETE FROM public.kr_candles_1d WHERE symbol = :symbol"),
                 {"symbol": _SYMBOL_KR},
             )
-            await dev_session.commit()
+            await db_session.commit()
 
     @pytest.mark.asyncio
-    async def test_yahoo_fallback_does_not_clobber_kis(self, dev_session):
-        repo = DailyCandlesRepository(session=dev_session)
+    async def test_yahoo_fallback_does_not_clobber_kis(self, db_session):
+        repo = DailyCandlesRepository(session=db_session)
         t = datetime(2026, 5, 14, tzinfo=UTC)
         kis_row = DailyCandleRow(
             time_utc=t,
@@ -160,9 +107,9 @@ class TestFullCycle:
         )
         try:
             await repo.upsert_rows(market=MarketKey.US, rows=[kis_row])
-            await dev_session.commit()
+            await db_session.commit()
             await repo.upsert_rows(market=MarketKey.US, rows=[yahoo_row])
-            await dev_session.commit()
+            await db_session.commit()
 
             fetched = await repo.fetch_recent(
                 market=MarketKey.US,
@@ -174,28 +121,28 @@ class TestFullCycle:
             assert fetched[0].source == "kis"
             assert fetched[0].close == pytest.approx(100.5)  # KIS row not clobbered
         except Exception:
-            await dev_session.rollback()
+            await db_session.rollback()
             raise
         finally:
             # Rollback any aborted transaction before cleanup.
-            await dev_session.rollback()
-            await dev_session.execute(
+            await db_session.rollback()
+            await db_session.execute(
                 text(
                     "DELETE FROM public.us_candles_1d "
                     "WHERE symbol = :symbol AND exchange = :exchange AND time = :t"
                 ),
                 {"symbol": _SYMBOL_US, "exchange": "NASD", "t": t},
             )
-            await dev_session.commit()
+            await db_session.commit()
 
     @pytest.mark.asyncio
-    async def test_fetch_recent_bounded_window_matches_unbounded(self, dev_session):
+    async def test_fetch_recent_bounded_window_matches_unbounded(self, db_session):
         """ROB-812: the bounded time predicate must not drop rows vs an
-        unbounded LIMIT.  Insert 250 daily rows (>2 chunks of 90 days), then
+        unbounded LIMIT. Insert a 250-row daily history, then
         assert fetch_recent(count=200) returns exactly the newest 200 rows."""
         from datetime import UTC, datetime, timedelta
 
-        repo = DailyCandlesRepository(session=dev_session)
+        repo = DailyCandlesRepository(session=db_session)
         base = datetime(2026, 1, 1, tzinfo=UTC)
         rows = [
             DailyCandleRow(
@@ -211,11 +158,11 @@ class TestFullCycle:
                 value=15.0,
                 source="test",
             )
-            for i in range(250)  # 250 days => spans >2 chunks (90d each)
+            for i in range(250)
         ]
         try:
             await repo.upsert_rows(market=MarketKey.KR, rows=rows)
-            await dev_session.commit()
+            await db_session.commit()
 
             fetched = await repo.fetch_recent(
                 market=MarketKey.KR,
@@ -227,7 +174,7 @@ class TestFullCycle:
             # Unbounded reference (no time predicate) — the source of truth.
             ref = (
                 (
-                    await dev_session.execute(
+                    await db_session.execute(
                         text(
                             "SELECT time FROM public.kr_candles_1d "
                             "WHERE symbol=:s AND venue='KRX' "
@@ -245,12 +192,12 @@ class TestFullCycle:
             fetched_times = {r.time_utc for r in fetched}
             assert fetched_times == set(ref)
         except Exception:
-            await dev_session.rollback()
+            await db_session.rollback()
             raise
         finally:
-            await dev_session.rollback()
-            await dev_session.execute(
+            await db_session.rollback()
+            await db_session.execute(
                 text("DELETE FROM public.kr_candles_1d WHERE symbol = :symbol"),
                 {"symbol": _SYMBOL_KR},
             )
-            await dev_session.commit()
+            await db_session.commit()

--- a/tests/integration/services/test_forecast_read_window_candles.py
+++ b/tests/integration/services/test_forecast_read_window_candles.py
@@ -1,28 +1,19 @@
 """ROB-659: real-path coverage for forecast_service._read_window_candles.
 
 The forecast resolve tests in tests/test_forecast_service.py all monkeypatch
-_read_window_candles with canned bars, because the daily-candle store
-(kr_candles_1d) is a Timescale hypertable with no ORM model and is absent from
-the create_all test DB. This test exercises the actual reader end-to-end against
-the dev Timescale container (port 5434) — the market/partition mapping, the
-DailyCandlesRepository.fetch_range call, and the inclusive-window [start, review]
-filter — so that code path is no longer test-blind.
-
-Mirrors the dev-DB harness in
-tests/integration/services/daily_candles/test_full_cycle.py.
+_read_window_candles with canned bars. This test instead exercises the actual
+reader end-to-end against the run-owned PostgreSQL test schema: the
+market/partition mapping, DailyCandlesRepository.fetch_range call, and inclusive
+window [start, review] filter.
 """
 
 from __future__ import annotations
 
-import os
 import uuid
 from datetime import UTC, date, datetime
-from pathlib import Path
 
 import pytest
-import pytest_asyncio
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.services.daily_candles.repository import (
     DailyCandleRow,
@@ -33,46 +24,6 @@ from app.services.trade_journal import forecast_service as svc
 
 _TEST_SUFFIX = uuid.uuid4().hex[:8].upper()
 _SYMBOL_KR = f"FCKR{_TEST_SUFFIX}"
-
-
-def _find_dotenv_path() -> Path | None:
-    for parent in Path(__file__).resolve().parents:
-        if (parent / "pyproject.toml").is_file():
-            candidate = parent / ".env"
-            return candidate if candidate.is_file() else None
-    return None
-
-
-def _read_dev_database_url() -> str | None:
-    env_path = _find_dotenv_path()
-    if env_path is None:
-        return None
-    with env_path.open(encoding="utf-8") as f:
-        for raw_line in f:
-            line = raw_line.strip()
-            if line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            if key.strip() == "DATABASE_URL":
-                return value.strip()
-    return None
-
-
-_DEV_DB_URL = _read_dev_database_url() or os.environ.get("DEV_DATABASE_URL")
-
-
-@pytest_asyncio.fixture
-async def dev_session():
-    if not _DEV_DB_URL:
-        pytest.skip(
-            "DEV_DATABASE_URL or local .env DATABASE_URL is required for live "
-            "Timescale integration tests"
-        )
-    engine = create_async_engine(_DEV_DB_URL, echo=False)
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with factory() as session:
-        yield session
-    await engine.dispose()
 
 
 def _kr_candle(day: int, high: float) -> DailyCandleRow:
@@ -93,16 +44,16 @@ def _kr_candle(day: int, high: float) -> DailyCandleRow:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_read_window_candles_inclusive_window_kr(dev_session):
-    repo = DailyCandlesRepository(session=dev_session)
+async def test_read_window_candles_inclusive_window_kr(db_session):
+    repo = DailyCandlesRepository(session=db_session)
     # Days 1..7; the resolve window is [2026-06-02, 2026-06-05] inclusive.
     rows = [_kr_candle(d, 100.0 + d) for d in range(1, 8)]
     try:
         await repo.upsert_rows(market=MarketKey.KR, rows=rows)
-        await dev_session.commit()
+        await db_session.commit()
 
         got = await svc._read_window_candles(
-            dev_session,
+            db_session,
             symbol=_SYMBOL_KR,
             instrument_type="equity_kr",
             start_date=date(2026, 6, 2),
@@ -114,22 +65,22 @@ async def test_read_window_candles_inclusive_window_kr(dev_session):
         # ±2-day UTC fetch padding.
         assert got_days == [2, 3, 4, 5]
     except Exception:
-        await dev_session.rollback()
+        await db_session.rollback()
         raise
     finally:
-        await dev_session.rollback()
-        await dev_session.execute(
+        await db_session.rollback()
+        await db_session.execute(
             text("DELETE FROM public.kr_candles_1d WHERE symbol = :symbol"),
             {"symbol": _SYMBOL_KR},
         )
-        await dev_session.commit()
+        await db_session.commit()
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_read_window_candles_unknown_instrument_returns_none(dev_session):
+async def test_read_window_candles_unknown_instrument_returns_none(db_session):
     got = await svc._read_window_candles(
-        dev_session,
+        db_session,
         symbol=_SYMBOL_KR,
         instrument_type="bond",  # not in the auto-resolvable set
         start_date=date(2026, 6, 2),


### PR DESCRIPTION
## Superseded by #1722

Closed without merge because current main already contains the ROB-1171 fix in commit f3efb7366b42ca86acf2d97214a53ac8faaacd3d via #1722.

Independent revalidation after fetching origin/main at ce497abc7db049b993fbab2ff006b5a216ab18ea:
- all six KR/US candle DDL statements are semantically identical after SQL whitespace normalization
- both affected integration test files have identical executable ASTs after docstrings are removed
- current main related test files: 5 passed
- main schema_content_hash already differs from the pre-fix merge-base because _DDL_STATEMENTS is part of the hash; the standalone version 34 bump is unnecessary
- PR #1739 is DIRTY with content conflicts in all three changed files

The pushed branch commit fab1bbff691e85a15eb7c4e229a2b46518caba6e remains as implementation evidence. No rebase, force-push, new push, or merge was performed during supersession.

---

## Original summary
- add the non-ORM kr_candles_1d and us_candles_1d relational contract to the run-owned pytest schema bootstrap
- move the affected integration tests from an externally prepared dev database to the standard db_session fixture
- keep Timescale-specific migration behavior outside the plain PostgreSQL repository tests

## Original verification
- affected four nodes: 4 passed
- related files: 5 passed
- schema barrier: 10 passed
- random full suite seed 20260729: 17243 passed, 10 skipped
- random full suite seed 20260730: 17243 passed, 10 skipped
- make lint: passed
- git diff --check: passed

## Non-blocking pre-existing random-order evidence
- seed 1171: 3 unrelated failures, no candle failures
- seed 1144: 2 unrelated failures, no candle failures
- ROB-968/order pollution is intentionally not changed in this PR

Linear: ROB-1171