### PR TITLE
fix(ROB-1130): fail closed on unattributable paper preflight snapshots

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -574,15 +574,18 @@ no direct DB backfill.
 
 The broker snapshot is fail-closed (ROB-1130). `open_orders` and `positions` must
 both be supplied together with `broker_snapshot_fetched_at`, the time the
-snapshot was read from the broker:
+snapshot was read from the broker, and `broker_snapshot_account_mode`, the
+account those reads were taken from:
 
 ```python
-positions = await alpaca_paper_list_positions()
-open_orders = await alpaca_paper_list_orders(status="open")
+positions = await alpaca_paper_list_positions(account_mode="alpaca_paper")
+open_orders = await alpaca_paper_list_orders(status="open", account_mode="alpaca_paper")
 report = await alpaca_paper_execution_preflight_check(
+    account_mode="alpaca_paper",
     positions=positions["positions"],
     open_orders=open_orders["orders"],
     broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+    broker_snapshot_account_mode=positions["account_mode"],
 )
 ```
 
@@ -594,6 +597,17 @@ account held positions. `counts.positions` and `counts.open_orders` are now
 omitted rather than reported as `0` when the snapshot cannot be verified, and
 `broker_snapshot` carries the per-kind `provided` / `verified` / `reason` state.
 This blocker is never downgraded by `legacy_cycle_blockers_as_warnings`.
+
+Two further shapes of "empty means flat" are also blocked rather than passed:
+
+- Passing the whole MCP response envelope (or any mapping/string) instead of the
+  row list — `positions={...}` normalizes to an empty list and would otherwise
+  read as a flat account. Reason: `snapshot_container_not_a_row_list`.
+- A snapshot read from the other paper account. `alpaca_paper` and
+  `alpaca_paper_lab` use different credentials and hold different inventory, so
+  an unattested or mismatched `broker_snapshot_account_mode` blocks with reason
+  `snapshot_account_unattested` / `snapshot_account_mismatch`, and
+  `broker_snapshot.account` reports `expected` vs `attested`.
 
 Buy legs that hold an open position are no longer reported as missing sell legs
 (ROB-1129). A filled/reconciled buy with no linked sell row is classified against

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -151,6 +151,7 @@ async def alpaca_paper_execution_preflight_check(
     open_orders: list[dict[str, Any]] | None = None,
     positions: list[dict[str, Any]] | None = None,
     broker_snapshot_fetched_at: str | None = None,
+    broker_snapshot_account_mode: str | None = None,
     snapshot_max_age_minutes: int = DEFAULT_SNAPSHOT_MAX_AGE_MINUTES,
     approval_packet: dict[str, Any] | None = None,
     expected_signal_symbol: str | None = None,
@@ -174,10 +175,13 @@ async def alpaca_paper_execution_preflight_check(
     Broker snapshots are fail-closed (ROB-1130). ``open_orders`` and
     ``positions`` must both be supplied together with
     ``broker_snapshot_fetched_at``, the time the snapshot was read from the
-    broker. A missing, empty-but-unattested, stale, or unparseable snapshot is
-    reported as a ``broker_snapshot_unverified`` blocker instead of passing as
-    ``positions=0``. Fetch them with ``alpaca_paper_list_positions`` and
-    ``alpaca_paper_list_orders(status="open")`` immediately before this call.
+    broker, and ``broker_snapshot_account_mode``, the account it was read from.
+    A missing, empty-but-unattested, wrong-shaped, stale, unparseable, or
+    other-account snapshot is reported as a ``broker_snapshot_unverified``
+    blocker instead of passing as ``positions=0``. Fetch them with
+    ``alpaca_paper_list_positions`` and
+    ``alpaca_paper_list_orders(status="open")`` immediately before this call and
+    pass the ``account_mode`` those reads echo back.
 
     When a correlation/candidate/client/briefing scope is provided directly or
     via approval_packet, stale and symbol-context checks evaluate only rows in
@@ -249,6 +253,8 @@ async def alpaca_paper_execution_preflight_check(
         open_orders_fetched_at=broker_snapshot_fetched_at,
         positions_fetched_at=broker_snapshot_fetched_at,
         snapshot_max_age_minutes=snapshot_max_age_minutes,
+        expected_account_mode=selected_account_mode,
+        snapshot_account_mode=broker_snapshot_account_mode,
         approval_packet=approval_packet,
         expected_signal_symbol=expected_signal_symbol,
         expected_execution_symbol=expected_execution_symbol,
@@ -399,10 +405,11 @@ def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
         description=(
             "Read-only Alpaca Paper execution anomaly preflight. Returns "
             "severity-classified findings and should_block for cycle runners. "
-            "Broker snapshots are fail-closed: pass open_orders, positions and "
-            "broker_snapshot_fetched_at from reads taken immediately before the "
-            "call, otherwise the gate blocks with broker_snapshot_unverified "
-            "rather than passing as positions=0. "
+            "Broker snapshots are fail-closed: pass open_orders, positions, "
+            "broker_snapshot_fetched_at and broker_snapshot_account_mode from "
+            "reads taken immediately before the call, otherwise the gate blocks "
+            "with broker_snapshot_unverified rather than passing as "
+            "positions=0. "
             "Supports direct or approval_packet-derived correlation/client/"
             "candidate/briefing/session scope to avoid unrelated ledger rows. "
             "No broker mutation and no repair writes."

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -8,7 +8,7 @@ snapshots, and the service returns an operator-readable preflight report.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
@@ -183,6 +183,26 @@ def _packet_value(packet: Any, key: str) -> Any:
 def _scope_value(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
+
+
+def _clean_lower(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    return text or None
+
+
+def _snapshot_rows(value: Any) -> list[Any] | None:
+    """Row list for a caller-supplied broker snapshot.
+
+    ``None`` means the snapshot was never fetched. A mapping/string container is
+    not a row sequence (ROB-1130) — handing over the whole MCP response envelope
+    must never let its keys be read as broker rows — so it degrades to an empty
+    but unusable list that ``_verify_broker_snapshot`` reports as unverified.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (Mapping, str, bytes)):
+        return []
+    return list(value)
 
 
 def _preflight_scope_from_packet(packet: Any) -> dict[str, str]:
@@ -632,6 +652,7 @@ def _cleanup_required_row_ref(row: Any) -> dict[str, Any]:
 def _verify_broker_snapshot(
     *,
     rows: list[dict[str, Any]] | None,
+    container: Any = None,
     fetched_at: Any,
     checked_at: datetime,
     max_age_minutes: int,
@@ -642,6 +663,11 @@ def _verify_broker_snapshot(
     also state when the snapshot was fetched, otherwise "positions=0 because we
     looked" is indistinguishable from "positions=0 because we did not look" and
     the gate silently passes while the account holds positions.
+
+    ``container`` is the value as the caller passed it, before list
+    normalization. A mapping or string is not a broker row sequence: handing the
+    whole MCP response envelope (or an empty ``{}``) to the gate would otherwise
+    normalize to ``[]`` and read as a genuinely flat account.
     """
     state: dict[str, Any] = {
         "provided": rows is not None,
@@ -652,6 +678,11 @@ def _verify_broker_snapshot(
     }
     if rows is None:
         state["reason"] = "snapshot_missing"
+        return state
+    if isinstance(container, (Mapping, str, bytes)):
+        # e.g. positions={"success": True, "positions": [...]} or positions={}.
+        state["count"] = None
+        state["reason"] = "snapshot_container_not_a_row_list"
         return state
     if fetched_at is None or (isinstance(fetched_at, str) and not fetched_at.strip()):
         state["reason"] = "snapshot_not_attested"
@@ -671,6 +702,42 @@ def _verify_broker_snapshot(
     return state
 
 
+def _verify_snapshot_account(
+    *,
+    expected_account_mode: str | None,
+    snapshot_account_mode: str | None,
+) -> dict[str, Any]:
+    """Classify whether the snapshot is attested to the account being gated.
+
+    ROB-1130: the required pre-gate reads are positions, open orders **and the
+    account identity** they were read from. Two Alpaca paper account modes
+    (``alpaca_paper`` and ``alpaca_paper_lab``) use different credentials and
+    hold different inventory, so a fresh, correctly attested snapshot of the
+    *other* account still reads as "this account is flat".
+    """
+    expected = _clean_lower(expected_account_mode)
+    attested = _clean_lower(snapshot_account_mode)
+    state: dict[str, Any] = {
+        "expected": expected,
+        "attested": attested,
+        "verified": False,
+        "reason": None,
+    }
+    if not expected:
+        # No gated account declared: identity cannot be checked and is not
+        # claimed. Only non-authorizing callers reach this branch.
+        state["reason"] = "account_scope_not_declared"
+        return state
+    if not attested:
+        state["reason"] = "snapshot_account_unattested"
+        return state
+    if attested != expected:
+        state["reason"] = "snapshot_account_mismatch"
+        return state
+    state["verified"] = True
+    return state
+
+
 def build_paper_execution_preflight_report(
     *,
     ledger_rows: Iterable[Any] = (),
@@ -680,6 +747,8 @@ def build_paper_execution_preflight_report(
     positions_fetched_at: datetime | str | None = None,
     snapshot_max_age_minutes: int = DEFAULT_SNAPSHOT_MAX_AGE_MINUTES,
     snapshot_evidence_required: bool = True,
+    expected_account_mode: str | None = None,
+    snapshot_account_mode: str | None = None,
     approval_packet: dict[str, Any] | None = None,
     expected_signal_symbol: str | None = None,
     expected_execution_symbol: str | None = None,
@@ -711,6 +780,15 @@ def build_paper_execution_preflight_report(
             unparseable broker snapshot is a blocker. Historical audit report
             builders that are not authorizing an order may set this to False;
             it does not downgrade any other blocker.
+        expected_account_mode: The Alpaca paper account being gated. Order
+            gates must declare it so the snapshot can be checked against the
+            account it authorizes (ROB-1130). When omitted, snapshot account
+            identity is reported as not declared and the positions snapshot is
+            not treated as account evidence.
+        snapshot_account_mode: The account the caller actually read the
+            snapshot from, as echoed by ``alpaca_paper_list_positions`` /
+            ``alpaca_paper_list_orders``. A different account's fresh snapshot
+            is not evidence about this account.
         approval_packet: Optional preview/approval packet being considered for
             execution. Used for duplicate, stale, and symbol checks.
         expected_signal_symbol: Optional symbol from the signal artifact.
@@ -730,8 +808,8 @@ def build_paper_execution_preflight_report(
         raise ValueError("snapshot_max_age_minutes must be >= 1")
     checked_at = _as_aware_utc(now) or datetime.now(UTC)
     unscoped_ledger = list(ledger_rows)
-    orders = list(open_orders) if open_orders is not None else None
-    position_rows = list(positions) if positions is not None else None
+    orders = _snapshot_rows(open_orders)
+    position_rows = _snapshot_rows(positions)
     packet = approval_packet or {}
     preflight_scope = _preflight_scope_from_packet(packet)
     ledger = [
@@ -754,12 +832,14 @@ def build_paper_execution_preflight_report(
     snapshot_state: dict[str, Any] = {
         "positions": _verify_broker_snapshot(
             rows=position_rows,
+            container=positions,
             fetched_at=positions_fetched_at,
             checked_at=checked_at,
             max_age_minutes=snapshot_max_age_minutes,
         ),
         "open_orders": _verify_broker_snapshot(
             rows=orders,
+            container=open_orders,
             fetched_at=open_orders_fetched_at,
             checked_at=checked_at,
             max_age_minutes=snapshot_max_age_minutes,
@@ -767,6 +847,21 @@ def build_paper_execution_preflight_report(
         "max_age_minutes": snapshot_max_age_minutes,
         "evidence_required": snapshot_evidence_required,
     }
+    account_state = _verify_snapshot_account(
+        expected_account_mode=expected_account_mode,
+        snapshot_account_mode=snapshot_account_mode,
+    )
+    snapshot_state["account"] = account_state
+    # An unverified account identity invalidates both snapshot kinds: a fresh,
+    # well-formed snapshot of a different Alpaca paper account still reads as
+    # "this account is flat". Marking the kinds unverified keeps one blocker
+    # path and stops the counts from reporting someone else's zero.
+    if not account_state["verified"] and expected_account_mode is not None:
+        for kind in _SNAPSHOT_KINDS:
+            kind_state = snapshot_state[kind]
+            if kind_state["verified"]:
+                kind_state["verified"] = False
+                kind_state["reason"] = account_state["reason"]
     unverified_kinds = [
         kind for kind in _SNAPSHOT_KINDS if not snapshot_state[kind]["verified"]
     ]
@@ -785,11 +880,14 @@ def build_paper_execution_preflight_report(
                 "required_reads": [
                     "alpaca_paper_list_positions",
                     "alpaca_paper_list_orders(status=open)",
+                    "account identity (account_mode echoed by those reads)",
                 ],
                 "remediation": (
                     "Fetch the broker snapshot immediately before the gate and "
-                    "pass it together with the time it was fetched."
+                    "pass it together with the time it was fetched and the "
+                    "account_mode it was read from."
                 ),
+                "account": account_state,
                 "snapshot": {kind: snapshot_state[kind] for kind in _SNAPSHOT_KINDS},
             },
         )

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -226,6 +226,7 @@ async def test_execution_preflight_check_returns_blocking_report(monkeypatch):
         open_orders=[{"id": "order-1", "status": "new", "symbol": "BTCUSD"}],
         positions=[],
         broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+        broker_snapshot_account_mode="alpaca_paper",
     )
 
     assert result["success"] is True
@@ -275,12 +276,14 @@ async def test_execution_preflight_check_passes_on_attested_empty_snapshot(monke
         open_orders=[],
         positions=[],
         broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+        broker_snapshot_account_mode="alpaca_paper",
     )
 
     assert result["should_block"] is False
     assert result["status"] == "pass"
     assert result["counts"]["positions"] == 0
     assert result["broker_snapshot"]["positions"]["verified"] is True
+    assert result["broker_snapshot"]["account"]["verified"] is True
 
 
 @pytest.mark.asyncio
@@ -297,6 +300,7 @@ async def test_execution_preflight_check_reflects_held_position(monkeypatch):
         open_orders=[],
         positions=[{"symbol": "UBER", "qty": "1", "asset_class": "us_equity"}],
         broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+        broker_snapshot_account_mode="alpaca_paper",
     )
 
     assert result["should_block"] is True
@@ -304,6 +308,100 @@ async def test_execution_preflight_check_reflects_held_position(monkeypatch):
     check_ids = {a["check_id"] for a in result["anomalies"]}
     assert "residual_position_exists" in check_ids
     assert "broker_snapshot_unverified" not in check_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_blocks_snapshot_from_other_account(
+    monkeypatch,
+):
+    """ROB-1130: a fresh snapshot of the lab account cannot clear the default one."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        account_mode="alpaca_paper",
+        open_orders=[],
+        positions=[],
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+        broker_snapshot_account_mode="alpaca_paper_lab",
+    )
+
+    assert result["should_block"] is True
+    assert result["status"] == "blocked"
+    finding = next(
+        a for a in result["anomalies"] if a["check_id"] == "broker_snapshot_unverified"
+    )
+    assert finding["details"]["account"] == {
+        "expected": "alpaca_paper",
+        "attested": "alpaca_paper_lab",
+        "verified": False,
+        "reason": "snapshot_account_mismatch",
+    }
+    assert "positions" not in result["counts"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_blocks_snapshot_without_account_attestation(
+    monkeypatch,
+):
+    """ROB-1130: whose snapshot it is must be stated, not assumed."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        open_orders=[],
+        positions=[],
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+    )
+
+    assert result["should_block"] is True
+    finding = next(
+        a for a in result["anomalies"] if a["check_id"] == "broker_snapshot_unverified"
+    )
+    assert finding["details"]["account"]["reason"] == "snapshot_account_unattested"
+    assert "positions" not in result["counts"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_blocks_response_envelope_snapshot(monkeypatch):
+    """ROB-1130: passing the whole read response must not read as a flat account."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    positions_response = {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "count": 1,
+        "positions": [{"symbol": "UBER", "qty": "1"}],
+    }
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        open_orders=[],
+        positions=positions_response,  # type: ignore[arg-type]
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+        broker_snapshot_account_mode="alpaca_paper",
+    )
+
+    assert result["should_block"] is True
+    finding = next(
+        a for a in result["anomalies"] if a["check_id"] == "broker_snapshot_unverified"
+    )
+    assert finding["details"]["reasons"]["positions"] == (
+        "snapshot_container_not_a_row_list"
+    )
+    assert "positions" not in result["counts"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_alpaca_paper_snapshot_attestation.py
+++ b/tests/services/test_alpaca_paper_snapshot_attestation.py
@@ -1,0 +1,343 @@
+"""ROB-1130: the preflight broker snapshot must be fail-closed.
+
+These tests live in their own module (not in
+``tests/services/test_alpaca_paper_anomaly_checks.py``) because ROB-1129 is
+editing that file in parallel; the assertions here only cover snapshot-level
+evidence, which is ROB-1130's scope.
+
+Covered holes:
+
+* the snapshot is absent / empty-but-unattested / stale / future / unparseable,
+* the snapshot container is the response envelope instead of the row list,
+* the snapshot is a fresh, well-formed read of the *other* paper account.
+
+In every case a new-cycle gate must block instead of reporting ``positions=0``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.alpaca_paper_anomaly_checks import (
+    build_paper_execution_preflight_report,
+)
+
+NOW = datetime(2026, 7, 30, 3, 0, tzinfo=UTC)
+UBER_POSITION = {
+    "asset_id": "uber-asset",
+    "symbol": "UBER",
+    "qty": "1",
+    "avg_entry_price": "69.65",
+    "side": "long",
+}
+
+
+def _check_ids(report):
+    return {a.check_id for a in report.anomalies}
+
+
+def _finding(report, check_id):
+    return next(a for a in report.anomalies if a.check_id == check_id)
+
+
+def _report(**overrides):
+    """Gate-shaped call: an order-authorizing preflight declares its account."""
+    kwargs = {
+        "ledger_rows": [],
+        "expected_account_mode": "alpaca_paper",
+        "now": NOW,
+    }
+    kwargs.update(overrides)
+    return build_paper_execution_preflight_report(**kwargs)
+
+
+def _attested(**overrides):
+    """A freshly fetched, fully attested snapshot of the gated account."""
+    kwargs = {
+        "positions": [],
+        "open_orders": [],
+        "positions_fetched_at": NOW,
+        "open_orders_fetched_at": NOW,
+        "snapshot_account_mode": "alpaca_paper",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# (A) the snapshot itself is absent or unattested
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_absent_snapshot_blocks_and_reports_no_position_count():
+    report = _report()
+
+    assert report.should_block is True
+    assert report.status == "blocked"
+    assert "broker_snapshot_unverified" in _check_ids(report)
+    # The false-assurance signal ROB-1130 was filed for: "positions: 0".
+    assert "positions" not in report.counts
+    assert report.broker_snapshot["positions"] == {
+        "provided": False,
+        "count": None,
+        "fetched_at": None,
+        "verified": False,
+        "reason": "snapshot_missing",
+    }
+
+
+@pytest.mark.unit
+def test_empty_snapshot_without_attestation_blocks():
+    report = _report(positions=[], open_orders=[])
+
+    assert report.should_block is True
+    assert _finding(report, "broker_snapshot_unverified").details["reasons"] == {
+        "positions": "snapshot_not_attested",
+        "open_orders": "snapshot_not_attested",
+    }
+    assert "positions" not in report.counts
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("fetched_at", "expected_reason"),
+    [
+        (NOW - timedelta(minutes=30), "snapshot_stale"),
+        (NOW + timedelta(minutes=30), "snapshot_attestation_in_future"),
+        ("not-a-timestamp", "snapshot_attestation_unparseable"),
+        ("", "snapshot_not_attested"),
+    ],
+)
+def test_untrustworthy_attestation_blocks(fetched_at, expected_reason):
+    report = _report(
+        **_attested(positions_fetched_at=fetched_at, open_orders_fetched_at=fetched_at)
+    )
+
+    assert report.should_block is True
+    assert _finding(report, "broker_snapshot_unverified").details["reasons"] == {
+        "positions": expected_reason,
+        "open_orders": expected_reason,
+    }
+    assert "positions" not in report.counts
+
+
+# ---------------------------------------------------------------------------
+# (A') "no snapshot" vs "genuinely zero positions" stay distinguishable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_genuinely_queried_flat_account_passes():
+    report = _report(**_attested())
+
+    assert report.should_block is False
+    assert report.status == "pass"
+    assert report.counts["positions"] == 0
+    assert report.counts["open_orders"] == 0
+    assert report.broker_snapshot["positions"]["verified"] is True
+    assert report.broker_snapshot["account"]["verified"] is True
+    assert _check_ids(report) == {"preflight_clean"}
+
+
+@pytest.mark.unit
+def test_absent_and_zero_position_snapshots_are_not_the_same_state():
+    absent = _report()
+    queried_zero = _report(**_attested())
+
+    assert absent.counts.get("positions") is None
+    assert queried_zero.counts["positions"] == 0
+    assert absent.broker_snapshot["positions"]["provided"] is False
+    assert queried_zero.broker_snapshot["positions"]["provided"] is True
+    assert absent.should_block is not queried_zero.should_block
+
+
+@pytest.mark.unit
+def test_held_position_in_a_correct_snapshot_blocks_the_new_cycle():
+    report = _report(**_attested(positions=[UBER_POSITION]))
+
+    assert report.should_block is True
+    assert report.counts["positions"] == 1
+    assert "residual_position_exists" in _check_ids(report)
+    # The holding must be reported as a holding, not as an unverified snapshot.
+    assert "broker_snapshot_unverified" not in _check_ids(report)
+
+
+# ---------------------------------------------------------------------------
+# (A'') the snapshot container is not a row list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_response_envelope_instead_of_row_list_blocks():
+    """``positions=<whole MCP response>`` must not normalize to a flat account."""
+    envelope = {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "count": 1,
+        "positions": [UBER_POSITION],
+    }
+
+    report = _report(**_attested(positions=envelope))
+
+    assert report.should_block is True
+    reasons = _finding(report, "broker_snapshot_unverified").details["reasons"]
+    assert reasons["positions"] == "snapshot_container_not_a_row_list"
+    assert "positions" not in report.counts
+    assert report.broker_snapshot["positions"]["count"] is None
+
+
+@pytest.mark.unit
+def test_empty_mapping_snapshot_blocks():
+    report = _report(**_attested(positions={}, open_orders={}))
+
+    assert report.should_block is True
+    assert _finding(report, "broker_snapshot_unverified").details["reasons"] == {
+        "positions": "snapshot_container_not_a_row_list",
+        "open_orders": "snapshot_container_not_a_row_list",
+    }
+
+
+# ---------------------------------------------------------------------------
+# (A''') the snapshot belongs to another paper account
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unattested_account_identity_blocks():
+    report = _report(**_attested(snapshot_account_mode=None))
+
+    assert report.should_block is True
+    finding = _finding(report, "broker_snapshot_unverified")
+    assert finding.details["account"] == {
+        "expected": "alpaca_paper",
+        "attested": None,
+        "verified": False,
+        "reason": "snapshot_account_unattested",
+    }
+    assert finding.details["reasons"] == {
+        "positions": "snapshot_account_unattested",
+        "open_orders": "snapshot_account_unattested",
+    }
+    assert "positions" not in report.counts
+    assert (
+        "account identity (account_mode echoed by those reads)"
+        in (finding.details["required_reads"])
+    )
+
+
+@pytest.mark.unit
+def test_other_paper_accounts_flat_snapshot_does_not_clear_this_account():
+    """The lab account being flat says nothing about the default account."""
+    report = _report(**_attested(snapshot_account_mode="alpaca_paper_lab"))
+
+    assert report.should_block is True
+    assert _finding(report, "broker_snapshot_unverified").details["account"] == {
+        "expected": "alpaca_paper",
+        "attested": "alpaca_paper_lab",
+        "verified": False,
+        "reason": "snapshot_account_mismatch",
+    }
+    assert "positions" not in report.counts
+
+
+@pytest.mark.unit
+def test_account_attestation_is_case_and_whitespace_insensitive():
+    report = _report(**_attested(snapshot_account_mode="  Alpaca_Paper "))
+
+    assert report.should_block is False
+    assert report.broker_snapshot["account"]["verified"] is True
+
+
+@pytest.mark.unit
+def test_lab_gate_accepts_only_the_lab_snapshot():
+    blocked = build_paper_execution_preflight_report(
+        ledger_rows=[],
+        expected_account_mode="alpaca_paper_lab",
+        now=NOW,
+        **_attested(snapshot_account_mode="alpaca_paper"),
+    )
+    passed = build_paper_execution_preflight_report(
+        ledger_rows=[],
+        expected_account_mode="alpaca_paper_lab",
+        now=NOW,
+        **_attested(snapshot_account_mode="alpaca_paper_lab"),
+    )
+
+    assert blocked.should_block is True
+    assert blocked.broker_snapshot["account"]["reason"] == "snapshot_account_mismatch"
+    assert passed.should_block is False
+
+
+# ---------------------------------------------------------------------------
+# The snapshot blocker cannot be downgraded, and audit callers are unaffected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {"positions": {}, "open_orders": {}},
+        {"snapshot_account_mode": "alpaca_paper_lab"},
+    ],
+)
+def test_legacy_flag_never_downgrades_a_snapshot_blocker(overrides):
+    kwargs = _attested(**overrides) if overrides else {}
+    report = _report(legacy_cycle_blockers_as_warnings=True, **kwargs)
+
+    assert report.should_block is True
+    assert _finding(report, "broker_snapshot_unverified").severity == "block"
+
+
+@pytest.mark.unit
+def test_audit_callers_without_a_declared_account_are_unchanged():
+    """``snapshot_evidence_required=False`` is the audit path (roundtrip report)."""
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[],
+        open_orders=[],
+        positions=[],
+        snapshot_evidence_required=False,
+        now=NOW,
+    )
+
+    assert report.should_block is False
+    assert report.broker_snapshot["account"]["reason"] == "account_scope_not_declared"
+    assert report.counts["positions"] == 0
+
+
+@pytest.mark.unit
+def test_unverified_account_snapshot_is_not_used_as_open_position_evidence():
+    """A wrong-account snapshot must not settle a buy leg's missing sell either.
+
+    ROB-1129 uses the position snapshot to tell a still-held buy apart from a
+    buy whose sell was never recorded. That evidence path must not accept a
+    snapshot this gate could not attribute to the gated account.
+    """
+    buy = SimpleNamespace(
+        client_order_id="uber-buy-1",
+        lifecycle_correlation_id="corr-uber",
+        side="buy",
+        lifecycle_state="filled",
+        order_status="filled",
+        execution_symbol="UBER",
+        signal_symbol="UBER",
+        filled_qty="1",
+        position_snapshot={"qty": "1"},
+        preview_payload={},
+        validation_summary={},
+        raw_responses={},
+        created_at=NOW - timedelta(minutes=10),
+    )
+
+    report = _report(
+        ledger_rows=[buy],
+        **_attested(snapshot_account_mode="alpaca_paper_lab"),
+    )
+
+    assert report.should_block is True
+    assert report.broker_snapshot["positions"]["verified"] is False


### PR DESCRIPTION
## What

ROB-1130 filed that `alpaca_paper_execution_preflight_check` called with an empty snapshot returned `positions=0` and **PASSed while the account held UBER**. The timestamp-attestation half of that contract landed in #1716 (missing / unattested / stale / future / unparseable → `broker_snapshot_unverified`). This PR closes the two remaining shapes of "empty means flat" that still passed:

1. **The read response envelope instead of the row list.** `positions={"success": True, "positions": [...]}` (or `{}`) normalized to `[]` and read as a flat account. Now `snapshot_container_not_a_row_list`; the mapping's keys can never be walked as broker rows.
2. **A fresh, well-formed snapshot of the other paper account.** `alpaca_paper` and `alpaca_paper_lab` use different credentials and hold different inventory (`app/services/brokers/alpaca/config.py:16-38`), so the lab account being flat says nothing about the account being gated. The issue's required pre-gate reads are positions, open orders **and the account identity** they were read from. Now `snapshot_account_unattested` / `snapshot_account_mismatch`.

Both are reported through the existing `broker_snapshot_unverified` blocker (no new check id), `counts.positions` stays omitted rather than reported as `0`, and the snapshot is not used as ROB-1129 open-position evidence. `legacy_cycle_blockers_as_warnings` cannot downgrade it.

`alpaca_paper_execution_preflight_check` gains `broker_snapshot_account_mode` and always declares the gated account, so the attestation is mandatory at the authorizing surface. Non-authorizing audit callers (`alpaca_paper_roundtrip_report`, `snapshot_evidence_required=False`) are unchanged: `broker_snapshot.account.reason = account_scope_not_declared`.

## Deliberately not in this PR

Row-level position `qty` missing/invalid/NaN/Infinity validation. That hole is real (verifier finding 3) but is **owned by ROB-1129 #1738** (`_position_snapshot_issues` / `broker_position_snapshot_malformed`). Re-implementing it here would collide. Verified by merge simulation that the two combine.

## Verification

`uv run pytest`, `-p no:randomly` (fixed order) unless noted.

- `tests/services/test_alpaca_paper_snapshot_attestation.py` (new file, kept out of `test_alpaca_paper_anomaly_checks.py` because #1738 is editing that file): **20 passed**
- `tests/services/test_alpaca_paper_snapshot_attestation.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py tests/services/test_alpaca_paper_anomaly_checks.py`: **88 passed**
- `uv run pytest tests -k alpaca_paper` (default random order): **642 passed, 16641 deselected**
- `make lint`: ruff check + format + ty all pass

Mutation (each defense reverted separately, then restored):

| Mutation | Result |
|---|---|
| drop the container guard | 4 failed (envelope/mapping/legacy-flag/tool-level) |
| drop the account-identity downgrade | 7 failed |
| restore pre-ROB-1130 "absent snapshot is evidence" | 6 failed, incl. 4 pre-existing ROB-1130 tests |

Merge simulation with #1738 head `4add62c01` (`sim/rob1130-1738`, now deleted): **no conflicts**, 104 focused + **668 `-k alpaca_paper` passed**, and every case blocks:

```
[A] no snapshot / empty unattested / stale / envelope / other account -> broker_snapshot_unverified
[B] qty None / "bad" / NaN / Infinity                                 -> broker_position_snapshot_malformed
[A+B] wrong account AND malformed qty                                 -> both blockers
[C] genuinely queried flat account                                    -> pass (normal path preserved)
[C] UBER 1 share in a correct snapshot                                -> residual_position_exists
```

No broker calls, no order submission, no DB/ledger writes, no scheduler registration.

Closes ROB-1130 (snapshot-level scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preflight checks now block when broker snapshots are missing, stale, malformed, unattested, or sourced from the wrong paper account.
  * Invalid snapshot containers are no longer treated as evidence of a flat account.
  * Account matching now supports case and whitespace differences while preventing cross-account snapshot use.

* **Documentation**
  * Updated guidance and examples to include explicit account-mode attestation when retrieving and validating snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->