### PR TITLE
fix(ROB-1140): fail closed on untracked watch orders

### DIFF
--- a/app/services/investment_reports/watch_auto_execute.py
+++ b/app/services/investment_reports/watch_auto_execute.py
@@ -82,7 +82,12 @@ def _normalize_place_result(result: Any) -> _PlaceOutcome:
         )
         return _PlaceOutcome(False, reason, normalized_detail)
 
-    ledger_id = result.get("ledger_id")
+    # ROB-1140 R1: explicit None is the ROB-843 benign-conflict signal; a
+    # missing key is a malformed contract and must not collapse into that case.
+    if "ledger_id" not in result:
+        return _PlaceOutcome(False, "missing_ledger_id", normalized_detail)
+
+    ledger_id = result["ledger_id"]
     if ledger_id is not None and (
         not isinstance(ledger_id, int) or isinstance(ledger_id, bool) or ledger_id <= 0
     ):

--- a/app/services/investment_reports/watch_auto_execute.py
+++ b/app/services/investment_reports/watch_auto_execute.py
@@ -46,19 +46,49 @@ class _PlaceOutcome:
 def _normalize_place_result(result: Any) -> _PlaceOutcome:
     """Interpret the order function's normalized result truthfully (ROB-843).
 
-    A non-dict result or an explicit ``success=False`` is a failure — never a
-    silent executed=True. The stable reason/detail is preserved from the
-    normalized native contract so the watch intent records why it failed.
+    Executed requires broker acceptance, a non-preview response, a broker order
+    id, and explicit durable-tracking availability. ``ledger_id=None`` alone is
+    not a failure: ROB-843's benign on-conflict path re-checks the existing
+    native row and returns ``ledger_tracking_unavailable=False`` without the id.
     """
     if not isinstance(result, dict):
         return _PlaceOutcome(False, "malformed_result", str(result)[:200])
-    if result.get("success"):
-        return _PlaceOutcome(True)
-    reason = result.get("reason") or result.get("status") or "order_failed"
     detail = (
         result.get("detail") or result.get("response_message") or result.get("message")
     )
-    return _PlaceOutcome(False, str(reason), str(detail) if detail else None)
+    normalized_detail = str(detail) if detail else None
+
+    if result.get("success") is not True:
+        reason = result.get("reason") or result.get("status") or "order_failed"
+        return _PlaceOutcome(False, str(reason), normalized_detail)
+    if result.get("dry_run") is not False:
+        reason = (
+            "dry_run_result"
+            if result.get("dry_run") is True
+            else "invalid_dry_run_flag"
+        )
+        return _PlaceOutcome(False, reason, normalized_detail)
+
+    order_no = result.get("order_no")
+    if not isinstance(order_no, str) or not order_no.strip():
+        return _PlaceOutcome(False, "missing_broker_order_id", normalized_detail)
+
+    tracking_unavailable = result.get("ledger_tracking_unavailable")
+    if tracking_unavailable is not False:
+        reason = (
+            "ledger_tracking_unavailable"
+            if tracking_unavailable is True
+            else "invalid_ledger_tracking_flag"
+        )
+        return _PlaceOutcome(False, reason, normalized_detail)
+
+    ledger_id = result.get("ledger_id")
+    if ledger_id is not None and (
+        not isinstance(ledger_id, int) or isinstance(ledger_id, bool) or ledger_id <= 0
+    ):
+        return _PlaceOutcome(False, "invalid_ledger_id", normalized_detail)
+
+    return _PlaceOutcome(True)
 
 
 async def _default_place_order_fn(**kwargs):

--- a/tests/test_watch_auto_execute.py
+++ b/tests/test_watch_auto_execute.py
@@ -60,9 +60,53 @@ def _make_place_spy():
 
     async def _spy(**kwargs):
         calls.append(kwargs)
-        return {"success": True, "order_no": "X1"}
+        return {
+            "success": True,
+            "dry_run": False,
+            "order_no": "X1",
+            "ledger_id": 101,
+            "ledger_tracking_unavailable": False,
+        }
 
     return _spy, calls
+
+
+class _FakeInsertResult:
+    def scalar_one_or_none(self):
+        return 101
+
+
+class _FakeDb:
+    """Capture SQL statements without opening a database connection."""
+
+    def __init__(self):
+        self.statements = []
+        self.commit_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _FakeInsertResult()
+
+    async def commit(self):
+        self.commit_count += 1
+
+
+def _assert_failed_intent_update(
+    db: _FakeDb,
+    *,
+    correlation_id: str,
+    reason: str,
+    failure_detail: str,
+) -> None:
+    assert len(db.statements) == 2
+    update_params = db.statements[1].compile().params
+    assert update_params["lifecycle_state"] == "failed"
+    assert update_params["execution_allowed"] is False
+    assert update_params["blocked_by"] == reason
+    assert update_params["blocking_reasons"] == [reason]
+    assert update_params["preview_line"]["failure_detail"] == failure_detail
+    assert update_params["correlation_id_1"] == correlation_id
+    assert db.commit_count == 2
 
 
 @pytest.mark.asyncio
@@ -112,6 +156,114 @@ async def test_happy_path_places_order(db_session: AsyncSession, monkeypatch):
     row = await _intent_for(db_session, cid)
     assert row.lifecycle_state == "previewed"
     assert row.execution_allowed is True
+
+
+@pytest.mark.asyncio
+async def test_broker_order_without_ledger_row_fails_intent(monkeypatch):
+    """ROB-1140/ROB-843 P1: an accepted broker order with zero native ledger
+    rows keeps the write-ahead reservation unresolved and must not be executed."""
+    monkeypatch.setattr(
+        watch_auto_execute.settings, "WATCH_AUTO_EXECUTE_MOCK_ENABLED", True
+    )
+    calls = []
+    detail = "KIS mock order accepted but ledger insert returned no id"
+
+    async def _accepted_but_untracked(**kwargs):
+        calls.append(kwargs)
+        return {
+            "success": True,
+            "dry_run": False,
+            "order_no": "0001234567",
+            "ledger_id": None,
+            "ledger_tracking_unavailable": True,
+            "message": detail,
+        }
+
+    db = _FakeDb()
+    alert = _alert(_good_max_action())
+    cid = f"corr-{uuid.uuid4().hex}"
+    outcome = await watch_auto_execute.maybe_auto_execute(
+        db,
+        alert=alert,
+        correlation_id=cid,
+        kst_date="2026-06-01",
+        place_order_fn=_accepted_but_untracked,
+    )
+
+    assert outcome == {
+        "executed": False,
+        "reason": "ledger_tracking_unavailable",
+        "detail": detail,
+        "correlation_id": cid,
+    }
+    assert len(calls) == 1
+    assert calls[0]["dry_run"] is False
+    _assert_failed_intent_update(
+        db,
+        correlation_id=cid,
+        reason="ledger_tracking_unavailable",
+        failure_detail=detail,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_preview_fails_intent_instead_of_executing(monkeypatch):
+    """ROB-1140: success-shaped preview evidence is never an execution."""
+    monkeypatch.setattr(
+        watch_auto_execute.settings, "WATCH_AUTO_EXECUTE_MOCK_ENABLED", True
+    )
+    calls = []
+    detail = "Order preview (dry_run=True)"
+
+    async def _preview(**kwargs):
+        calls.append(kwargs)
+        return {
+            "success": True,
+            "dry_run": True,
+            "order_no": None,
+            "ledger_id": None,
+            "ledger_tracking_unavailable": False,
+            "message": detail,
+        }
+
+    db = _FakeDb()
+    alert = _alert(_good_max_action())
+    cid = f"corr-{uuid.uuid4().hex}"
+    outcome = await watch_auto_execute.maybe_auto_execute(
+        db,
+        alert=alert,
+        correlation_id=cid,
+        kst_date="2026-06-01",
+        place_order_fn=_preview,
+    )
+
+    assert outcome == {
+        "executed": False,
+        "reason": "dry_run_result",
+        "detail": detail,
+        "correlation_id": cid,
+    }
+    assert len(calls) == 1
+    _assert_failed_intent_update(
+        db,
+        correlation_id=cid,
+        reason="dry_run_result",
+        failure_detail=detail,
+    )
+
+
+def test_rob843_existing_native_row_without_returned_id_stays_durable():
+    """ROB-843 P1 benign conflicts already proved a native row exists."""
+    outcome = watch_auto_execute._normalize_place_result(
+        {
+            "success": True,
+            "dry_run": False,
+            "order_no": "0001234567",
+            "ledger_id": None,
+            "ledger_tracking_unavailable": False,
+        }
+    )
+    assert outcome.executed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_watch_auto_execute.py
+++ b/tests/test_watch_auto_execute.py
@@ -96,7 +96,7 @@ def _assert_failed_intent_update(
     *,
     correlation_id: str,
     reason: str,
-    failure_detail: str,
+    failure_detail: str | None,
 ) -> None:
     assert len(db.statements) == 2
     update_params = db.statements[1].compile().params
@@ -252,7 +252,50 @@ async def test_dry_run_preview_fails_intent_instead_of_executing(monkeypatch):
     )
 
 
-def test_rob843_existing_native_row_without_returned_id_stays_durable():
+@pytest.mark.asyncio
+async def test_missing_ledger_id_key_fails_intent_instead_of_benign_null(monkeypatch):
+    """ROB-1140 R1: a missing key is malformed, unlike explicit null from the
+    ROB-843 benign-conflict path."""
+    monkeypatch.setattr(
+        watch_auto_execute.settings, "WATCH_AUTO_EXECUTE_MOCK_ENABLED", True
+    )
+    place_result = {
+        "success": True,
+        "dry_run": False,
+        "order_no": "0001234567",
+        "ledger_tracking_unavailable": False,
+    }
+
+    async def _missing_ledger_id(**_kwargs):
+        return place_result
+
+    db = _FakeDb()
+    alert = _alert(_good_max_action())
+    cid = f"corr-{uuid.uuid4().hex}"
+    outcome = await watch_auto_execute.maybe_auto_execute(
+        db,
+        alert=alert,
+        correlation_id=cid,
+        kst_date="2026-06-01",
+        place_order_fn=_missing_ledger_id,
+    )
+
+    assert "ledger_id" not in place_result
+    assert outcome == {
+        "executed": False,
+        "reason": "missing_ledger_id",
+        "detail": None,
+        "correlation_id": cid,
+    }
+    _assert_failed_intent_update(
+        db,
+        correlation_id=cid,
+        reason="missing_ledger_id",
+        failure_detail=None,
+    )
+
+
+def test_rob843_explicit_null_ledger_id_conflict_stays_durable():
     """ROB-843 P1 benign conflicts already proved a native row exists."""
     outcome = watch_auto_execute._normalize_place_result(
         {
@@ -264,6 +307,21 @@ def test_rob843_existing_native_row_without_returned_id_stays_durable():
         }
     )
     assert outcome.executed is True
+
+
+def test_invalid_non_null_ledger_id_is_rejected_separately():
+    """Invalid non-null ids are neither missing nor benign explicit null."""
+    outcome = watch_auto_execute._normalize_place_result(
+        {
+            "success": True,
+            "dry_run": False,
+            "order_no": "0001234567",
+            "ledger_id": 0,
+            "ledger_tracking_unavailable": False,
+        }
+    )
+    assert outcome.executed is False
+    assert outcome.reason == "invalid_ledger_id"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Harden watch_auto_execute consumer normalization so success alone cannot become executed.
- Require a real non-preview response, a non-blank broker order_no, explicit ledger tracking availability, and a valid returned ledger_id when one is present.
- Preserve the ROB-843 producer contract unchanged.

## Producer vs consumer choice

The producer intentionally preserves broker acceptance while signaling lost bookkeeping with ledger_tracking_unavailable=True. Changing producer success would collapse broker truth into bookkeeping truth and break the ROB-843 P1 write-ahead reservation design. The consumer now fails closed on that signal instead.

A benign on-conflict response can have ledger_id=None after the producer re-confirms an existing native row. That remains executable only when ledger_tracking_unavailable=False, and has an explicit regression assertion.

## Acceptance criteria and tests

- AC 1: _normalize_place_result inspects success, dry_run, order_no, ledger_tracking_unavailable, and ledger_id.
- AC 2: test_broker_order_without_ledger_row_fails_intent uses success=True, dry_run=False, order_no present, ledger_id=None, ledger_tracking_unavailable=True and asserts executed=False plus the captured intent update values lifecycle_state=failed and execution_allowed=False.
- AC 3: test_dry_run_preview_fails_intent_instead_of_executing asserts a success-shaped dry-run response is failed, not executed, including the intent update values.
- Durable execution regression: test_happy_path_places_order now returns dry_run=False, order_no present, ledger_id present, and ledger_tracking_unavailable=False.
- ROB-843 P1 preservation: test_rob843_existing_native_row_without_returned_id_stays_durable and the existing producer conflict/lost-write tests.

## Validation

- PYTHONHASHSEED=1140 uv run pytest tests/test_watch_auto_execute.py -vv — 11 passed
- PYTHONHASHSEED=1140 uv run pytest tests/test_kis_mock_order_ledger.py -vv -k "record_native_conflict_requeries_existing_row or record_native_error_signals_tracking_unavailable" — 2 passed, 37 deselected
- make lint — Ruff check, Ruff format check, and ty check passed
- git diff --check — passed with no output

pytest-randomly is not installed and pytest exposes no random-order seed option, so PYTHONHASHSEED=1140 is used for deterministic hash ordering.

## Safety

No order smoke, actual order, preview call, broker endpoint call, broker mutation, operational DB write, Linear write, migration/schema change, scheduler change, or merge was performed. The new AC 2/3 tests use injected fake place functions and a SQL-capturing fake DB; the existing regression suite uses its run-owned test schema.