### PR TITLE
ROB-1137: local retry semantics and precommitted T0 gates

### DIFF
--- a/app/services/brokers/binance/r4_p0_collector.py
+++ b/app/services/brokers/binance/r4_p0_collector.py
@@ -550,6 +550,10 @@ class BinanceR4P0Collector:
         self.epoch_finalizer = DeterministicEpochFinalizer(
             self.epoch_ledger, self.raw_reader
         )
+        self.local_raw_reader = RawPITReader(store._db, store.path, ())
+        self.local_epoch_finalizer = DeterministicEpochFinalizer(
+            self.epoch_ledger, self.local_raw_reader
+        )
         self.alert_dispatcher = AlertDispatcher(
             self.epoch_ledger, config.alert_webhook_urls
         )
@@ -559,6 +563,7 @@ class BinanceR4P0Collector:
 
     async def run(self) -> None:
         started_at = utc_now()
+        self.epoch_ledger.validate_t0_startup(started_at=started_at)
         self.epoch_ledger.append_process_version(
             collector_instance_id=self.config.collector_instance_id,
             run_id=self.run_id,
@@ -865,7 +870,7 @@ class BinanceR4P0Collector:
             "binance_usdm.takerLongShortRatio",
         }
         for symbol in self.epoch_policy.symbols:
-            preview = self.epoch_finalizer.preview(symbol, epoch)
+            preview = self.local_epoch_finalizer.preview(symbol, epoch)
             retry_sources = sorted(
                 (set(preview.missing_sources) | set(preview.invalid_sources))
                 & recoverable

--- a/app/services/brokers/binance/r4_p0_hardening.py
+++ b/app/services/brokers/binance/r4_p0_hardening.py
@@ -429,16 +429,18 @@ class EpochLedger:
         """Fail closed before collection starts if the committed T0 is unsafe."""
 
         configured_t0 = iso_utc(self.policy.t0)
-        stored_rows = self.db.execute(
+        identity_stamp_rows = self.db.execute(
             """
-            SELECT DISTINCT t0_utc
+            SELECT t0_utc
             FROM collector_process_versions
-            WHERE study_id = ? AND policy_hash = ? AND t0_utc IS NOT NULL
-            ORDER BY t0_utc
+            WHERE study_id = ? AND policy_hash = ?
+            ORDER BY append_id
             """,
             (self.policy.study_id, self.policy.policy_hash),
         ).fetchall()
-        stored_t0_values = [row["t0_utc"] for row in stored_rows]
+        stored_t0_values = sorted(
+            {row["t0_utc"] for row in identity_stamp_rows if row["t0_utc"] is not None}
+        )
         mismatched_t0_values = [
             stored_t0 for stored_t0 in stored_t0_values if stored_t0 != configured_t0
         ]
@@ -452,12 +454,23 @@ class EpochLedger:
         has_pit_records = (
             self.db.execute("SELECT 1 FROM pit_records LIMIT 1").fetchone() is not None
         )
+        has_current_identity_stamp = bool(identity_stamp_rows)
+        has_any_process_stamp = (
+            self.db.execute(
+                "SELECT 1 FROM collector_process_versions LIMIT 1"
+            ).fetchone()
+            is not None
+        )
+        is_legacy_v2_restart = not has_any_process_stamp and has_pit_records
         t0_minus_4h = self.policy.t0 - dt.timedelta(hours=EPOCH_HOURS)
-        if not has_pit_records and started_at > t0_minus_4h:
+        is_warmup_ready = started_at <= t0_minus_4h
+        if not (is_warmup_ready or has_current_identity_stamp or is_legacy_v2_restart):
             raise T0StartupGateError(
                 "G-T0-B refused fresh-artifact startup: "
                 f"started_at={iso_utc(started_at)} "
                 f"t0_minus_4h={iso_utc(t0_minus_4h)}; "
+                "warm-up cutoff 초과, 현재 study_id/policy_hash stamp 없음, "
+                "stamp 없는 legacy v2 artifact 재기동에도 해당하지 않음; "
                 "기존 T0 를 바꾸지 말고 새 커밋·새 T0 를 사전 고정하라"
             )
 

--- a/app/services/brokers/binance/r4_p0_hardening.py
+++ b/app/services/brokers/binance/r4_p0_hardening.py
@@ -209,6 +209,10 @@ class FinalizationInvariantError(RuntimeError):
     """Raised when immutable finalization disagrees with reconstructed input."""
 
 
+class T0StartupGateError(RuntimeError):
+    """Raised when a collector would violate the precommitted T0 contract."""
+
+
 class EpochLedger:
     """Append-only operational ledger sharing the raw collector connection."""
 
@@ -364,6 +368,7 @@ class EpochLedger:
             started_at TEXT NOT NULL,
             code_hash TEXT NOT NULL,
             collector_version TEXT NOT NULL,
+            t0_utc TEXT,
             UNIQUE (study_id, policy_hash, collector_instance_id, run_id)
         );
         CREATE INDEX IF NOT EXISTS ix_collector_process_version_latest
@@ -410,7 +415,51 @@ class EpochLedger:
                 self.db.execute(
                     f"ALTER TABLE collector_attempts ADD COLUMN {column} TEXT"
                 )
+        process_version_columns = {
+            row["name"]
+            for row in self.db.execute("PRAGMA table_info(collector_process_versions)")
+        }
+        if "t0_utc" not in process_version_columns:
+            self.db.execute(
+                "ALTER TABLE collector_process_versions ADD COLUMN t0_utc TEXT"
+            )
         self.db.commit()
+
+    def validate_t0_startup(self, *, started_at: dt.datetime) -> None:
+        """Fail closed before collection starts if the committed T0 is unsafe."""
+
+        configured_t0 = iso_utc(self.policy.t0)
+        stored_rows = self.db.execute(
+            """
+            SELECT DISTINCT t0_utc
+            FROM collector_process_versions
+            WHERE study_id = ? AND policy_hash = ? AND t0_utc IS NOT NULL
+            ORDER BY t0_utc
+            """,
+            (self.policy.study_id, self.policy.policy_hash),
+        ).fetchall()
+        stored_t0_values = [row["t0_utc"] for row in stored_rows]
+        mismatched_t0_values = [
+            stored_t0 for stored_t0 in stored_t0_values if stored_t0 != configured_t0
+        ]
+        if mismatched_t0_values:
+            raise T0StartupGateError(
+                "G-T0-A refused collector startup: "
+                f"stored_t0={','.join(mismatched_t0_values)} "
+                f"configured_t0={configured_t0}"
+            )
+
+        has_pit_records = (
+            self.db.execute("SELECT 1 FROM pit_records LIMIT 1").fetchone() is not None
+        )
+        t0_minus_4h = self.policy.t0 - dt.timedelta(hours=EPOCH_HOURS)
+        if not has_pit_records and started_at > t0_minus_4h:
+            raise T0StartupGateError(
+                "G-T0-B refused fresh-artifact startup: "
+                f"started_at={iso_utc(started_at)} "
+                f"t0_minus_4h={iso_utc(t0_minus_4h)}; "
+                "기존 T0 를 바꾸지 말고 새 커밋·새 T0 를 사전 고정하라"
+            )
 
     def ensure_open_rows(
         self, decision_epoch: dt.datetime, collector_instance_id: str, now: dt.datetime
@@ -612,8 +661,8 @@ class EpochLedger:
             """
             INSERT INTO collector_process_versions (
                 version_stamp_id, study_id, policy_hash, collector_instance_id,
-                run_id, started_at, code_hash, collector_version
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                run_id, started_at, code_hash, collector_version, t0_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 uuid.uuid4().hex,
@@ -624,6 +673,7 @@ class EpochLedger:
                 iso_utc(started_at),
                 code_hash,
                 collector_version,
+                iso_utc(self.policy.t0),
             ),
         )
         self.db.commit()

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -125,7 +125,8 @@ UPDATE/DELETE rejection triggers:
   never rewrite a finalization.
 - `collector_heartbeats`: append-only replica liveness evidence.
 - `collector_process_versions`: one append-only startup stamp per run with the
-  exact Git commit hash and collector version loaded by that process.
+  exact Git commit hash, collector version, and precommitted `t0_utc` loaded by
+  that process.
 - `collector_alert_events`: alert creation and each delivery result; failed
   delivery attempts are not overwritten.
 
@@ -221,6 +222,10 @@ supervisor therefore does not relabel a later snapshot as an earlier one.
 Those sources rely on independent live replicas. Missing, invalid, and
 partial-coverage recoverable sources are retried only while
 `now < finalize_at`; the finalizer never waits past the deadline.
+Retry eligibility is evaluated from that collector's local artifact only.
+Finalization and `EPOCH_DEADLINE_RISK` remain based on the local+peer union.
+This prevents one replica from hiding a recoverable hole in the other without
+changing the immutable union verdict.
 
 Each request, including invalid responses and transport/HTTP failures, appends
 a terminal attempt row. The raw response body SHA-256 is retained even when
@@ -257,6 +262,43 @@ to each current heartbeat `run_id`. Missing stamps and hash mismatches are
 `COLLECTOR_VERSION_MISMATCH`, remove that replica from the healthy count, and
 fail the rehearsal version gate. A checkout without resolvable Git metadata
 fails closed rather than starting an unstamped collector.
+
+## Precommitted T0 procedure
+
+T0 is not selected after startup verification. That would be circular: changing
+the module constant creates a new commit and code hash, invalidating the
+verification that was just performed. The operator sequence is fixed:
+
+1. Commit `DEFAULT_T0`, `DEFAULT_STUDY_ID`, and `DEFAULT_POLICY_HASH` first,
+   choosing a sufficiently distant UTC four-hour boundary.
+2. Start both hosts from that exact fixed commit.
+3. Before `T0-4h`, run the one-shot read-only preflight against both collector
+   artifacts:
+
+   ```bash
+   uv run python -m scripts.r4_p0_watchdog --t0-preflight \
+     --artifact /path/to/host-a/r4_p0_collector.sqlite3 \
+     --artifact /path/to/host-b/r4_p0_collector.sqlite3
+   ```
+
+4. Proceed only when the JSON reports `ok: true`: verification time
+   `V <= T0-4h`, every current process stamp matches the deployed code hash,
+   at least two distinct replicas are healthy, and every stamp has the
+   committed T0.
+5. If any gate fails, do not retroactively adjust or reuse that T0. Precommit a
+   new commit and a new T0, restart both hosts from that commit, and repeat the
+   verification.
+
+`--t0-preflight` does not require `R4_P0_WATCHDOG_ENABLED`; it opens collector
+artifacts with SQLite `mode=ro`, performs one check, creates no watchdog state,
+does no network I/O, and exits nonzero when a gate is closed.
+
+Collector startup enforces the same contract before collection tasks or network
+clients start. For the same `(study_id, policy_hash)`, a non-null stored
+`t0_utc` that differs from the configured T0 is rejected. A completely fresh
+artifact (`pit_records` has zero rows) is also rejected when startup is later
+than `T0-4h`. An artifact with existing PIT rows is treated as a restart and is
+not blocked by the warm-up check, while the stored-T0 check still applies.
 
 The alert path is:
 

--- a/docs/runbooks/r4-p0-collector.md
+++ b/docs/runbooks/r4-p0-collector.md
@@ -271,7 +271,9 @@ verification that was just performed. The operator sequence is fixed:
 
 1. Commit `DEFAULT_T0`, `DEFAULT_STUDY_ID`, and `DEFAULT_POLICY_HASH` first,
    choosing a sufficiently distant UTC four-hour boundary.
-2. Start both hosts from that exact fixed commit.
+2. Start both hosts from that exact fixed commit. A new
+   `(DEFAULT_STUDY_ID, DEFAULT_POLICY_HASH)` run must use fresh artifact roots;
+   never reuse PIT rows from another study or policy as warm-up evidence.
 3. Before `T0-4h`, run the one-shot read-only preflight against both collector
    artifacts:
 
@@ -286,19 +288,31 @@ verification that was just performed. The operator sequence is fixed:
    at least two distinct replicas are healthy, and every stamp has the
    committed T0.
 5. If any gate fails, do not retroactively adjust or reuse that T0. Precommit a
-   new commit and a new T0, restart both hosts from that commit, and repeat the
-   verification.
+   new commit containing a new `DEFAULT_T0`, `DEFAULT_STUDY_ID`, and
+   `DEFAULT_POLICY_HASH`, restart both hosts from that commit with fresh
+   artifact roots, and repeat the verification.
 
 `--t0-preflight` does not require `R4_P0_WATCHDOG_ENABLED`; it opens collector
 artifacts with SQLite `mode=ro`, performs one check, creates no watchdog state,
 does no network I/O, and exits nonzero when a gate is closed.
 
-Collector startup enforces the same contract before collection tasks or network
-clients start. For the same `(study_id, policy_hash)`, a non-null stored
-`t0_utc` that differs from the configured T0 is rejected. A completely fresh
-artifact (`pit_records` has zero rows) is also rejected when startup is later
-than `T0-4h`. An artifact with existing PIT rows is treated as a restart and is
-not blocked by the warm-up check, while the stored-T0 check still applies.
+Collector startup applies two hard gates before collection tasks or network
+clients start; the four-gate preflight above remains a required operator check
+and is not replaced by startup. For the same `(study_id, policy_hash)`, every
+non-null stored `t0_utc` is checked and a value that differs from the configured
+T0 is rejected. Startup passes the warm-up gate when it is no later than
+`T0-4h`, or when a process stamp exists for the current `(study_id,
+policy_hash)`. A narrow compatibility exception also permits a ledger-before-
+stamp v2 artifact when it has PIT rows but no process-version stamp for any
+study. Once any process stamp exists, PIT rows from another study or policy do
+not bypass the warm-up gate.
+
+The v2 compatibility exception cannot identify which study produced its
+unscoped PIT rows. Reusing such an artifact for a new study after `T0-4h` can
+therefore still pass startup. This is an intentional residual needed to preserve
+restartability of the operational pre-stamp artifact. The operator hard rule is
+that every new study/policy run uses a fresh artifact root; the read-only
+four-gate preflight remains mandatory before proceeding.
 
 The alert path is:
 

--- a/scripts/r4_p0_watchdog.py
+++ b/scripts/r4_p0_watchdog.py
@@ -26,6 +26,7 @@ from app.services.brokers.binance.r4_p0_collector import (
     utc_now,
 )
 from app.services.brokers.binance.r4_p0_hardening import (
+    EPOCH_HOURS,
     AlertDispatcher,
     EpochLedger,
     EpochPolicy,
@@ -148,7 +149,7 @@ def t0_preflight_report(
         )
 
     configured_t0 = iso_utc(policy.t0)
-    t0_minus_4h = policy.t0 - dt.timedelta(hours=4)
+    t0_minus_4h = policy.t0 - dt.timedelta(hours=EPOCH_HOURS)
     gates = {
         "v_le_t0_minus_4h": verified_at <= t0_minus_4h,
         "code_hash_match_all": len(replicas) >= 2

--- a/scripts/r4_p0_watchdog.py
+++ b/scripts/r4_p0_watchdog.py
@@ -14,7 +14,9 @@ import logging
 import os
 import signal
 import time
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 from app.services.brokers.binance.r4_p0_collector import (
     REQUIRED_ACTIVE_SOURCES,
@@ -30,6 +32,9 @@ from app.services.brokers.binance.r4_p0_hardening import (
     availability_report,
     finalization_report,
     floor_epoch,
+    iso_utc,
+    latest_heartbeat,
+    latest_process_version,
 )
 
 ENABLED_ENV = "R4_P0_WATCHDOG_ENABLED"
@@ -37,12 +42,18 @@ ALERT_WEBHOOKS_ENV = "R4_P0_ALERT_WEBHOOK_URLS"
 DEFAULT_STATE_ROOT = "~/work/herdr-artifacts/r4-p0-watchdog"
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--run",
         action="store_true",
         help=f"run until stopped; requires {ENABLED_ENV}=true",
+    )
+    mode.add_argument(
+        "--t0-preflight",
+        action="store_true",
+        help="run one read-only preflight of the precommitted T0 and exit",
     )
     parser.add_argument(
         "--artifact",
@@ -64,7 +75,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="explicitly allow no HTTPS webhook during manual validation",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def _alert_webhook_urls() -> tuple[str, ...]:
@@ -82,6 +93,90 @@ def _policy() -> EpochPolicy:
         required_sources=tuple(sorted(REQUIRED_ACTIVE_SOURCES)),
         symbols=tuple(sorted(SIGNAL_SYMBOLS)),
     )
+
+
+def t0_preflight_report(
+    artifact_paths: Sequence[Path],
+    policy: EpochPolicy,
+    *,
+    verified_at: dt.datetime,
+    expected_code_hash: str,
+    stale_after_seconds: float,
+) -> dict[str, Any]:
+    """Read collector artifacts once, without creating any local state."""
+
+    paths = tuple(
+        sorted({path.expanduser().resolve() for path in artifact_paths}, key=str)
+    )
+    availability = availability_report(
+        paths,
+        policy,
+        observed_at=verified_at,
+        stale_after_seconds=stale_after_seconds,
+        expected_code_hash=expected_code_hash,
+    )
+    availability_by_path = {
+        replica["artifact"]: replica for replica in availability["replicas"]
+    }
+    replicas: list[dict[str, Any]] = []
+    for path in paths:
+        heartbeat = latest_heartbeat(path, policy)
+        version = (
+            latest_process_version(path, policy, run_id=heartbeat["run_id"])
+            if heartbeat is not None
+            else None
+        )
+        availability_replica = availability_by_path[str(path)]
+        replicas.append(
+            {
+                "artifact": str(path),
+                "status": availability_replica["status"],
+                "collector_instance_id": (
+                    heartbeat["collector_instance_id"]
+                    if heartbeat is not None
+                    else None
+                ),
+                "code_hash": version["code_hash"] if version is not None else None,
+                "stamped_t0_utc": (
+                    version.get("t0_utc") if version is not None else None
+                ),
+                "heartbeat_observed_at": (
+                    heartbeat["observed_at"] if heartbeat is not None else None
+                ),
+                "age_seconds": availability_replica.get("age_seconds"),
+            }
+        )
+
+    configured_t0 = iso_utc(policy.t0)
+    t0_minus_4h = policy.t0 - dt.timedelta(hours=4)
+    gates = {
+        "v_le_t0_minus_4h": verified_at <= t0_minus_4h,
+        "code_hash_match_all": len(replicas) >= 2
+        and all(replica["code_hash"] == expected_code_hash for replica in replicas),
+        "healthy_replica_count_ge_2": availability["healthy_replica_count"] >= 2,
+        "stamped_t0_matches_all": len(replicas) >= 2
+        and all(replica["stamped_t0_utc"] == configured_t0 for replica in replicas),
+    }
+    ok = all(gates.values())
+    return {
+        "t0_utc": configured_t0,
+        "t0_minus_4h": iso_utc(t0_minus_4h),
+        "verified_at": iso_utc(verified_at),
+        "expected_code_hash": expected_code_hash,
+        "replicas": replicas,
+        "gates": gates,
+        "ok": ok,
+        "summary": (
+            "PASS: committed T0 preflight gates are satisfied"
+            if ok
+            else "FAIL: one or more committed T0 preflight gates are closed"
+        ),
+        "next_action": (
+            "고정된 T0 로 진행"
+            if ok
+            else "기존 T0 를 소급 변경하지 말고 새 커밋과 새 T0 를 사전 고정하라"
+        ),
+    }
 
 
 async def _watch(args: argparse.Namespace) -> int:
@@ -174,14 +269,32 @@ async def _watch(args: argparse.Namespace) -> int:
     return 0
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
     formatter = logging.Formatter(fmt="%(asctime)sZ %(levelname)s %(message)s")
     formatter.converter = time.gmtime
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     logging.basicConfig(level=logging.INFO, handlers=[handler])
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    artifacts = {str(Path(path).expanduser().resolve()) for path in args.artifact}
+    if args.t0_preflight:
+        if len(artifacts) < 2:
+            raise SystemExit(
+                "--t0-preflight requires at least two distinct collector artifacts"
+            )
+        if args.stale_after_seconds <= 0:
+            raise SystemExit("--stale-after-seconds must be positive")
+        report = t0_preflight_report(
+            tuple(Path(path) for path in artifacts),
+            _policy(),
+            verified_at=utc_now(),
+            expected_code_hash=runtime_code_hash(),
+            stale_after_seconds=args.stale_after_seconds,
+        )
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0 if report["ok"] else 1
+
     payload = {
         "alert_webhook_count": len(_alert_webhook_urls()),
         "artifacts": [str(Path(path).expanduser()) for path in args.artifact],
@@ -199,7 +312,6 @@ def main() -> int:
         return 0
     if os.getenv(ENABLED_ENV, "").strip().lower() != "true":
         raise SystemExit(f"refusing --run: set {ENABLED_ENV}=true explicitly")
-    artifacts = {str(Path(path).expanduser().resolve()) for path in args.artifact}
     if args.minimum_healthy_replicas < 2 or len(artifacts) < 2:
         raise SystemExit("--run requires at least two distinct collector artifacts")
     if args.interval_seconds <= 0 or args.stale_after_seconds <= 0:

--- a/tests/test_binance_r4_p0_hardening.py
+++ b/tests/test_binance_r4_p0_hardening.py
@@ -444,6 +444,82 @@ async def test_local_47_peer_1_union_complete_still_retries_without_ledger_write
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_production_init_wires_retry_to_local_only_reader(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recovery_time = EPOCH + dt.timedelta(hours=1)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    monkeypatch.setattr(
+        collector_module,
+        "REQUIRED_ACTIVE_SOURCES",
+        frozenset({"binance_usdm.basis"}),
+    )
+    monkeypatch.setattr(collector_module, "utc_now", lambda: recovery_time)
+    with (
+        AppendOnlyPITStore(tmp_path / "local") as local_store,
+        AppendOnlyPITStore(tmp_path / "peer") as peer_store,
+    ):
+        _append_complete_periodic_source(
+            local_store,
+            "binance_usdm.basis",
+            observations=47,
+        )
+        missing_time = EPOCH - dt.timedelta(minutes=5)
+        _append(
+            peer_store,
+            "binance_usdm.basis",
+            event_time=missing_time,
+            sequence=str(int(missing_time.timestamp() * 1000)),
+        )
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path / "local",
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+                replica_artifacts=(peer_store.path,),
+            ),
+            local_store,
+        )
+
+        assert collector.raw_reader.replica_paths == (peer_store.path.resolve(),)
+        assert collector.local_raw_reader.replica_paths == ()
+        assert (
+            collector.epoch_finalizer.preview("XRPUSDT", EPOCH).final_status
+            == FINAL_COMPLETE
+        )
+        assert (
+            collector.local_epoch_finalizer.preview("XRPUSDT", EPOCH).final_status
+            == FINAL_MISSING
+        )
+
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._retry_incomplete_epoch(  # noqa: SLF001
+                client,
+                EPOCH,
+                recovery_time,
+            )
+
+        finalization_rows = local_store._db.execute(  # noqa: SLF001
+            "SELECT COUNT(*) FROM symbol_epoch_finalizations"
+        ).fetchone()[0]
+        assert len(requests) == 1
+        assert requests[0].url.path == "/futures/data/basis"
+        assert requests[0].url.params["pair"] == "XRPUSDT"
+        assert requests[0].url.params["limit"] == "500"
+        assert finalization_rows == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_local_47_peer_1_finalization_remains_union_complete(tmp_path) -> None:
     policy = EpochPolicy(
         required_sources=("binance_usdm.basis",),
@@ -810,6 +886,54 @@ def test_finalization_ignores_late_payload_and_records_late_only(tmp_path) -> No
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_production_finalize_records_peer_late_payload_from_union_reader(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        collector_module,
+        "REQUIRED_ACTIVE_SOURCES",
+        frozenset({"binance_usdm.basis"}),
+    )
+    with (
+        AppendOnlyPITStore(tmp_path / "local") as local_store,
+        AppendOnlyPITStore(tmp_path / "peer") as peer_store,
+    ):
+        _append_complete_periodic_source(local_store, "binance_usdm.basis")
+        _append(
+            peer_store,
+            "binance_usdm.basis",
+            received=finalize_at(EPOCH) + dt.timedelta(seconds=1),
+            event_time=EPOCH - dt.timedelta(minutes=5),
+            sequence="peer-late-only",
+        )
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path / "local",
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+                replica_artifacts=(peer_store.path,),
+            ),
+            local_store,
+        )
+
+        await collector._finalize_epoch(EPOCH, finalize_at(EPOCH))  # noqa: SLF001
+
+        correction = local_store._db.execute(  # noqa: SLF001
+            """
+            SELECT correction_status, raw_record_id
+            FROM late_only_corrections
+            """
+        ).fetchone()
+        peer_record_id = peer_store._db.execute(  # noqa: SLF001
+            "SELECT record_id FROM pit_records"
+        ).fetchone()["record_id"]
+        assert correction["correction_status"] == "LATE_ONLY"
+        assert correction["raw_record_id"] == peer_record_id
+
+
+@pytest.mark.unit
 def test_attempt_and_finalization_tables_reject_update_delete(tmp_path) -> None:
     with AppendOnlyPITStore(tmp_path) as store:
         for source in POLICY.required_sources:
@@ -1172,8 +1296,9 @@ async def test_collector_start_stamps_runtime_code_hash(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     code_hash = "a" * 40
+    started_at = dt.datetime(2026, 7, 26, 20, tzinfo=dt.UTC)
     monkeypatch.setattr(collector_module, "runtime_code_hash", lambda: code_hash)
-    monkeypatch.setattr(collector_module, "utc_now", lambda: RECEIVED)
+    monkeypatch.setattr(collector_module, "utc_now", lambda: started_at)
 
     with AppendOnlyPITStore(tmp_path) as store:
         _append(store, "binance_usdm.openInterestHist")
@@ -1193,7 +1318,7 @@ async def test_collector_start_stamps_runtime_code_hash(
         ).fetchone()
         assert stamp["collector_instance_id"] == "replica-a"
         assert stamp["run_id"] == collector.run_id
-        assert stamp["started_at"] == "2026-07-28T07:01:00.000000Z"
+        assert stamp["started_at"] == "2026-07-26T20:00:00.000000Z"
         assert stamp["code_hash"] == code_hash
         assert stamp["collector_version"] == collector_module.COLLECTOR_VERSION
         assert stamp["t0_utc"] == "2026-07-27T00:00:00.000000Z"
@@ -1236,6 +1361,46 @@ def test_t0_gate_a_rejects_retroactive_change_with_both_values(tmp_path) -> None
 
         with pytest.raises(T0StartupGateError) as error:
             changed_ledger.validate_t0_startup(started_at=EPOCH - dt.timedelta(hours=8))
+
+        assert "stored_t0=2026-07-28T08:00:00.000000Z" in str(error.value)
+        assert "configured_t0=2026-07-28T12:00:00.000000Z" in str(error.value)
+
+
+@pytest.mark.unit
+def test_t0_gate_a_checks_every_stamp_not_only_latest(tmp_path) -> None:
+    original_policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        study_id="study-t0-all-stamps",
+        policy_hash="policy-t0-all-stamps",
+        t0=EPOCH,
+    )
+    current_policy = EpochPolicy(
+        required_sources=original_policy.required_sources,
+        symbols=original_policy.symbols,
+        study_id=original_policy.study_id,
+        policy_hash=original_policy.policy_hash,
+        t0=EPOCH + dt.timedelta(hours=4),
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        EpochLedger(store._db, original_policy).append_process_version(  # noqa: SLF001
+            collector_instance_id="replica-a",
+            run_id="older-mismatched-run",
+            started_at=EPOCH - dt.timedelta(hours=8),
+            code_hash="a" * 40,
+            collector_version=collector_module.COLLECTOR_VERSION,
+        )
+        current_ledger = EpochLedger(store._db, current_policy)  # noqa: SLF001
+        current_ledger.append_process_version(
+            collector_instance_id="replica-a",
+            run_id="latest-matching-run",
+            started_at=EPOCH - dt.timedelta(hours=7),
+            code_hash="a" * 40,
+            collector_version=collector_module.COLLECTOR_VERSION,
+        )
+
+        with pytest.raises(T0StartupGateError) as error:
+            current_ledger.validate_t0_startup(started_at=EPOCH - dt.timedelta(hours=6))
 
         assert "stored_t0=2026-07-28T08:00:00.000000Z" in str(error.value)
         assert "configured_t0=2026-07-28T12:00:00.000000Z" in str(error.value)
@@ -1308,10 +1473,45 @@ def test_t0_gate_b_allows_timely_start_for_fresh_artifact(tmp_path) -> None:
 
 
 @pytest.mark.unit
-def test_t0_gate_b_allows_late_restart_when_pit_rows_exist(tmp_path) -> None:
+def test_t0_gate_b_allows_start_before_warmup_cutoff(tmp_path) -> None:
     policy = EpochPolicy(
         required_sources=("binance_usdm.basis",),
         symbols=("XRPUSDT",),
+        t0=EPOCH,
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+
+        ledger.validate_t0_startup(started_at=EPOCH - dt.timedelta(hours=4, seconds=1))
+
+
+@pytest.mark.unit
+def test_t0_gate_b_allows_late_restart_with_current_identity_stamp(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        t0=EPOCH,
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+        ledger.append_process_version(
+            collector_instance_id="replica-a",
+            run_id="existing-run",
+            started_at=EPOCH - dt.timedelta(hours=5),
+            code_hash="a" * 40,
+            collector_version=collector_module.COLLECTOR_VERSION,
+        )
+
+        ledger.validate_t0_startup(started_at=EPOCH + dt.timedelta(days=1))
+
+
+@pytest.mark.unit
+def test_t0_gate_b_allows_legacy_v2_pit_rows_without_any_stamp(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        study_id="study-operational-legacy",
+        policy_hash="policy-operational-legacy",
         t0=EPOCH,
     )
     with AppendOnlyPITStore(tmp_path) as store:
@@ -1319,6 +1519,51 @@ def test_t0_gate_b_allows_late_restart_when_pit_rows_exist(tmp_path) -> None:
         ledger = EpochLedger(store._db, policy)  # noqa: SLF001
 
         ledger.validate_t0_startup(started_at=EPOCH + dt.timedelta(days=1))
+
+        ledger.append_process_version(
+            collector_instance_id="replica-a",
+            run_id="first-stamped-restart",
+            started_at=EPOCH + dt.timedelta(days=1),
+            code_hash="a" * 40,
+            collector_version=collector_module.COLLECTOR_VERSION,
+        )
+        ledger.validate_t0_startup(started_at=EPOCH + dt.timedelta(days=2))
+
+
+@pytest.mark.unit
+def test_t0_gate_b_rejects_new_identity_reusing_stale_pit_rows(tmp_path) -> None:
+    old_policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        study_id="study-old",
+        policy_hash="policy-old",
+        t0=EPOCH,
+    )
+    new_policy = EpochPolicy(
+        required_sources=old_policy.required_sources,
+        symbols=old_policy.symbols,
+        study_id="study-new",
+        policy_hash="policy-new",
+        t0=EPOCH + dt.timedelta(days=23),
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        _append(store, "binance_usdm.basis")
+        EpochLedger(store._db, old_policy).append_process_version(  # noqa: SLF001
+            collector_instance_id="replica-a",
+            run_id="old-run",
+            started_at=EPOCH - dt.timedelta(hours=5),
+            code_hash="a" * 40,
+            collector_version=collector_module.COLLECTOR_VERSION,
+        )
+        new_ledger = EpochLedger(store._db, new_policy)  # noqa: SLF001
+
+        with pytest.raises(T0StartupGateError, match="G-T0-B") as error:
+            new_ledger.validate_t0_startup(
+                started_at=new_policy.t0 + dt.timedelta(hours=6)
+            )
+
+        assert "현재 study_id/policy_hash stamp 없음" in str(error.value)
+        assert "새 커밋·새 T0" in str(error.value)
 
 
 @pytest.mark.unit
@@ -1358,6 +1603,12 @@ async def test_t0_startup_gate_runs_before_collection_or_network(
         assert (
             store._db.execute(  # noqa: SLF001
                 "SELECT COUNT(*) FROM collector_process_versions"
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            store._db.execute(  # noqa: SLF001
+                "SELECT COUNT(*) FROM collector_attempt_starts"
             ).fetchone()[0]
             == 0
         )

--- a/tests/test_binance_r4_p0_hardening.py
+++ b/tests/test_binance_r4_p0_hardening.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import json
 import sqlite3
+from collections import Counter
 
 import httpx
 import pytest
@@ -24,6 +25,7 @@ from app.services.brokers.binance.r4_p0_hardening import (
     EpochPolicy,
     RawPITReader,
     RawPITReadError,
+    T0StartupGateError,
     availability_report,
     decision_epoch_for_event,
     finalization_report,
@@ -46,25 +48,26 @@ def _payload(
     value: str = "10",
     *,
     timestamp: int = 1785222000000,
+    symbol: str = "XRPUSDT",
 ) -> dict[str, str]:
     if source == "binance_usdm.openInterestHist":
         return {
             "sumOpenInterest": value,
-            "symbol": "XRPUSDT",
+            "symbol": symbol,
             "timestamp": str(timestamp),
         }
     if source == "binance_usdm.basis":
         return {
             "basis": value,
             "contractType": "PERPETUAL",
-            "pair": "XRPUSDT",
+            "pair": symbol,
             "timestamp": str(timestamp),
         }
     return {
         "buySellRatio": value,
         "buyVol": "20",
         "sellVol": "2",
-        "symbol": "XRPUSDT",
+        "symbol": symbol,
         "timestamp": str(timestamp),
     }
 
@@ -77,12 +80,13 @@ def _append(
     received: dt.datetime = RECEIVED,
     sequence: str = "1785222000000",
     event_time: dt.datetime = dt.datetime(2026, 7, 28, 7, tzinfo=dt.UTC),
+    symbol: str = "XRPUSDT",
 ) -> None:
     timestamp = int(event_time.timestamp() * 1000)
     assert store.append(
         source=source,
-        symbol="XRPUSDT",
-        raw_payload=_payload(source, value, timestamp=timestamp),
+        symbol=symbol,
+        raw_payload=_payload(source, value, timestamp=timestamp, symbol=symbol),
         local_receive_time=received,
         run_id="replica:test",
         event_time=event_time.isoformat().replace("+00:00", "Z"),
@@ -100,6 +104,7 @@ def _append_complete_periodic_source(
     source: str,
     *,
     observations: int = 48,
+    symbol: str = "XRPUSDT",
 ) -> None:
     interval_start = EPOCH - dt.timedelta(hours=4)
     for index in range(observations):
@@ -109,6 +114,7 @@ def _append_complete_periodic_source(
             source,
             sequence=str(int(event_time.timestamp() * 1000)),
             event_time=event_time,
+            symbol=symbol,
         )
 
 
@@ -145,6 +151,67 @@ def _finalizer(
     ledger = EpochLedger(store._db, policy)  # noqa: SLF001
     reader = RawPITReader(store._db, store.path, replicas)  # noqa: SLF001
     return ledger, DeterministicEpochFinalizer(ledger, reader)
+
+
+def _configure_collector_policy(
+    collector: BinanceR4P0Collector,
+    store: AppendOnlyPITStore,
+    policy: EpochPolicy,
+    *,
+    replicas: tuple = (),
+) -> tuple[DeterministicEpochFinalizer, DeterministicEpochFinalizer]:
+    ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+    union_reader = RawPITReader(store._db, store.path, replicas)  # noqa: SLF001
+    local_reader = RawPITReader(store._db, store.path, ())  # noqa: SLF001
+    union_finalizer = DeterministicEpochFinalizer(ledger, union_reader)
+    local_finalizer = DeterministicEpochFinalizer(ledger, local_reader)
+    collector.epoch_policy = policy
+    collector.epoch_ledger = ledger
+    collector.raw_reader = union_reader
+    collector.epoch_finalizer = union_finalizer
+    collector.local_raw_reader = local_reader
+    collector.local_epoch_finalizer = local_finalizer
+    return union_finalizer, local_finalizer
+
+
+def _append_complete_recoverable_source(
+    store: AppendOnlyPITStore,
+    source: str,
+    symbol: str,
+) -> None:
+    interval_start = EPOCH - dt.timedelta(hours=4)
+    cadence_minutes = 1 if source == "binance_usdm.premiumIndexKline1m" else 5
+    observations = 240 if cadence_minutes == 1 else 48
+    for index in range(observations):
+        event_time = interval_start + dt.timedelta(minutes=cadence_minutes * index)
+        timestamp = int(event_time.timestamp() * 1000)
+        payload: object
+        if source == "binance_usdm.premiumIndexKline1m":
+            payload = [
+                timestamp - 59_999,
+                "1",
+                "2",
+                "0.5",
+                "1.5",
+                "3",
+                timestamp,
+            ]
+        else:
+            payload = _payload(source, timestamp=timestamp, symbol=symbol)
+        assert store.append(
+            source=source,
+            symbol=symbol,
+            raw_payload=payload,
+            local_receive_time=EPOCH + dt.timedelta(hours=1),
+            run_id="replica:peer",
+            event_time=event_time.isoformat().replace("+00:00", "Z"),
+            transaction_time=None,
+            request_started_at="2026-07-28T08:59:59.000000Z",
+            request_completed_at="2026-07-28T09:00:00.000000Z",
+            sequence_or_trade_id=str(timestamp),
+            gap_detected=False,
+            reconnect_id="replica:peer:rest",
+        )
 
 
 @pytest.mark.unit
@@ -257,7 +324,6 @@ async def test_partial_periodic_coverage_triggers_historical_retry(
             "binance_usdm.basis",
             observations=24,
         )
-        _, finalizer = _finalizer(store, policy=policy)
         collector = BinanceR4P0Collector(
             CollectorConfig(
                 artifact_root=tmp_path,
@@ -266,8 +332,7 @@ async def test_partial_periodic_coverage_triggers_historical_retry(
             ),
             store,
         )
-        collector.epoch_policy = policy
-        collector.epoch_finalizer = finalizer
+        _configure_collector_policy(collector, store, policy)
         calls: list[tuple[str, str]] = []
 
         async def retry_history(
@@ -289,6 +354,255 @@ async def test_partial_periodic_coverage_triggers_historical_retry(
             )
 
         assert calls == [("binance_usdm.basis", "XRPUSDT")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_local_47_peer_1_union_complete_still_retries_without_ledger_write(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+    )
+    recovery_time = EPOCH + dt.timedelta(hours=1)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        missing_time = EPOCH - dt.timedelta(minutes=5)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "basis": "1",
+                    "contractType": "PERPETUAL",
+                    "pair": "XRPUSDT",
+                    "timestamp": int(missing_time.timestamp() * 1000),
+                }
+            ],
+        )
+
+    monkeypatch.setattr(collector_module, "utc_now", lambda: recovery_time)
+    with (
+        AppendOnlyPITStore(tmp_path / "local") as local_store,
+        AppendOnlyPITStore(tmp_path / "peer") as peer_store,
+    ):
+        _append_complete_periodic_source(
+            local_store,
+            "binance_usdm.basis",
+            observations=47,
+        )
+        missing_time = EPOCH - dt.timedelta(minutes=5)
+        _append(
+            peer_store,
+            "binance_usdm.basis",
+            event_time=missing_time,
+            sequence=str(int(missing_time.timestamp() * 1000)),
+        )
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path / "local",
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+                replica_artifacts=(peer_store.path,),
+            ),
+            local_store,
+        )
+        union_finalizer, local_finalizer = _configure_collector_policy(
+            collector,
+            local_store,
+            policy,
+            replicas=(peer_store.path,),
+        )
+        assert local_finalizer.preview("XRPUSDT", EPOCH).final_status == FINAL_MISSING
+        assert union_finalizer.preview("XRPUSDT", EPOCH).final_status == FINAL_COMPLETE
+        rows_before = local_store._db.execute(  # noqa: SLF001
+            "SELECT COUNT(*) FROM symbol_epoch_finalizations"
+        ).fetchone()[0]
+
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await collector._retry_incomplete_epoch(  # noqa: SLF001
+                client,
+                EPOCH,
+                recovery_time,
+            )
+
+        rows_after = local_store._db.execute(  # noqa: SLF001
+            "SELECT COUNT(*) FROM symbol_epoch_finalizations"
+        ).fetchone()[0]
+        assert rows_before == rows_after == 0
+        assert len(requests) == 1
+        assert requests[0].url.path == "/futures/data/basis"
+        assert requests[0].url.params["pair"] == "XRPUSDT"
+        assert requests[0].url.params["limit"] == "500"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_local_47_peer_1_finalization_remains_union_complete(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+    )
+    with (
+        AppendOnlyPITStore(tmp_path / "local") as local_store,
+        AppendOnlyPITStore(tmp_path / "peer") as peer_store,
+    ):
+        _append_complete_periodic_source(
+            local_store,
+            "binance_usdm.basis",
+            observations=47,
+        )
+        missing_time = EPOCH - dt.timedelta(minutes=5)
+        _append(
+            peer_store,
+            "binance_usdm.basis",
+            event_time=missing_time,
+            sequence=str(int(missing_time.timestamp() * 1000)),
+        )
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path / "local",
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+                replica_artifacts=(peer_store.path,),
+            ),
+            local_store,
+        )
+        union_finalizer, _ = _configure_collector_policy(
+            collector,
+            local_store,
+            policy,
+            replicas=(peer_store.path,),
+        )
+        preview = union_finalizer.preview("XRPUSDT", EPOCH)
+        assert preview.final_status == FINAL_COMPLETE
+
+        await collector._finalize_epoch(EPOCH, finalize_at(EPOCH))  # noqa: SLF001
+
+        row = local_store._db.execute(  # noqa: SLF001
+            """
+            SELECT final_status, evaluation_hash
+            FROM symbol_epoch_finalizations
+            """
+        ).fetchone()
+        assert row["final_status"] == FINAL_COMPLETE
+        assert row["evaluation_hash"] == preview.evaluation_hash
+        await collector._alert_deadline_risk(  # noqa: SLF001
+            EPOCH,
+            finalize_at(EPOCH) - dt.timedelta(minutes=30),
+        )
+        assert (
+            local_store._db.execute(  # noqa: SLF001
+                "SELECT COUNT(*) FROM collector_alert_events"
+            ).fetchone()[0]
+            == 0
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bounded_retry_request_count_union_vs_local(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sources = tuple(
+        sorted(
+            {
+                "binance_usdm.basis",
+                "binance_usdm.openInterestHist",
+                "binance_usdm.premiumIndexKline1m",
+                "binance_usdm.takerLongShortRatio",
+            }
+        )
+    )
+    symbols = ("DOGEUSDT", "SOLUSDT", "XRPUSDT")
+    policy = EpochPolicy(required_sources=sources, symbols=symbols)
+    recovery_time = EPOCH + dt.timedelta(hours=1)
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return httpx.Response(200, json=[])
+
+    monkeypatch.setattr(collector_module, "utc_now", lambda: recovery_time)
+    with (
+        AppendOnlyPITStore(tmp_path / "local") as local_store,
+        AppendOnlyPITStore(tmp_path / "peer") as peer_store,
+    ):
+        for symbol in symbols:
+            for source in sources:
+                _append_complete_recoverable_source(peer_store, source, symbol)
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path / "local",
+                symbols=symbols,
+                collector_instance_id="replica-a",
+                replica_artifacts=(peer_store.path,),
+            ),
+            local_store,
+        )
+        union_finalizer, local_finalizer = _configure_collector_policy(
+            collector,
+            local_store,
+            policy,
+            replicas=(peer_store.path,),
+        )
+        assert all(
+            union_finalizer.preview(symbol, EPOCH).final_status == FINAL_COMPLETE
+            for symbol in symbols
+        )
+
+        async with httpx.AsyncClient(
+            base_url="https://fapi.binance.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            collector.local_epoch_finalizer = union_finalizer
+            await collector._retry_incomplete_epoch(  # noqa: SLF001
+                client,
+                EPOCH,
+                recovery_time,
+            )
+            union_request_count = len(paths)
+
+            collector.local_epoch_finalizer = local_finalizer
+            await collector._retry_incomplete_epoch(  # noqa: SLF001
+                client,
+                EPOCH,
+                recovery_time,
+            )
+            local_request_count = len(paths) - union_request_count
+
+        assert union_request_count == 0
+        assert local_request_count == len(sources) * len(symbols) == 12
+        assert Counter(paths) == {
+            "/fapi/v1/premiumIndexKlines": 3,
+            "/futures/data/basis": 3,
+            "/futures/data/openInterestHist": 3,
+            "/futures/data/takerlongshortRatio": 3,
+        }
+        measurement = {
+            "cycle_seconds": 30,
+            "union_requests_per_cycle": union_request_count,
+            "local_requests_per_cycle": local_request_count,
+            "increase_per_cycle": local_request_count - union_request_count,
+            "local_requests_per_hour": local_request_count * 120,
+            "local_requests_per_4h": local_request_count * 480,
+        }
+        assert measurement == {
+            "cycle_seconds": 30,
+            "union_requests_per_cycle": 0,
+            "local_requests_per_cycle": 12,
+            "increase_per_cycle": 12,
+            "local_requests_per_hour": 1440,
+            "local_requests_per_4h": 5760,
+        }
+        print(json.dumps(measurement, sort_keys=True))
 
 
 @pytest.mark.unit
@@ -359,10 +673,7 @@ async def test_basis_failure_recovers_only_inside_epoch_contract_window(
             ),
             store,
         )
-        ledger, finalizer = _finalizer(store, policy=policy)
-        collector.epoch_policy = policy
-        collector.epoch_ledger = ledger
-        collector.epoch_finalizer = finalizer
+        finalizer, _ = _configure_collector_policy(collector, store, policy)
         async with httpx.AsyncClient(
             base_url="https://fapi.binance.com",
             transport=httpx.MockTransport(handler),
@@ -418,10 +729,7 @@ async def test_basis_recovery_never_starts_at_or_after_deadline(tmp_path) -> Non
             ),
             store,
         )
-        ledger, finalizer = _finalizer(store, policy=policy)
-        collector.epoch_policy = policy
-        collector.epoch_ledger = ledger
-        collector.epoch_finalizer = finalizer
+        _, finalizer = _configure_collector_policy(collector, store, policy)
         async with httpx.AsyncClient(
             base_url="https://fapi.binance.com",
             transport=httpx.MockTransport(handler),
@@ -868,6 +1176,7 @@ async def test_collector_start_stamps_runtime_code_hash(
     monkeypatch.setattr(collector_module, "utc_now", lambda: RECEIVED)
 
     with AppendOnlyPITStore(tmp_path) as store:
+        _append(store, "binance_usdm.openInterestHist")
         collector = BinanceR4P0Collector(
             CollectorConfig(
                 artifact_root=tmp_path,
@@ -887,6 +1196,229 @@ async def test_collector_start_stamps_runtime_code_hash(
         assert stamp["started_at"] == "2026-07-28T07:01:00.000000Z"
         assert stamp["code_hash"] == code_hash
         assert stamp["collector_version"] == collector_module.COLLECTOR_VERSION
+        assert stamp["t0_utc"] == "2026-07-27T00:00:00.000000Z"
+        with pytest.raises(
+            sqlite3.IntegrityError,
+            match="collector_process_versions is append-only",
+        ):
+            store._db.execute(  # noqa: SLF001
+                "UPDATE collector_process_versions SET t0_utc = NULL"
+            )
+        store._db.rollback()  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_t0_gate_a_rejects_retroactive_change_with_both_values(tmp_path) -> None:
+    original_policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        study_id="study-t0-a",
+        policy_hash="policy-t0-a",
+        t0=EPOCH,
+    )
+    changed_policy = EpochPolicy(
+        required_sources=original_policy.required_sources,
+        symbols=original_policy.symbols,
+        study_id=original_policy.study_id,
+        policy_hash=original_policy.policy_hash,
+        t0=EPOCH + dt.timedelta(hours=4),
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        ledger = EpochLedger(store._db, original_policy)  # noqa: SLF001
+        ledger.append_process_version(
+            collector_instance_id="replica-a",
+            run_id="run-a",
+            started_at=EPOCH - dt.timedelta(hours=8),
+            code_hash="a" * 40,
+            collector_version=collector_module.COLLECTOR_VERSION,
+        )
+        changed_ledger = EpochLedger(store._db, changed_policy)  # noqa: SLF001
+
+        with pytest.raises(T0StartupGateError) as error:
+            changed_ledger.validate_t0_startup(started_at=EPOCH - dt.timedelta(hours=8))
+
+        assert "stored_t0=2026-07-28T08:00:00.000000Z" in str(error.value)
+        assert "configured_t0=2026-07-28T12:00:00.000000Z" in str(error.value)
+
+
+@pytest.mark.unit
+def test_t0_gate_a_ignores_legacy_null_stamp(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        study_id="study-t0-null",
+        policy_hash="policy-t0-null",
+        t0=EPOCH,
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+        ledger.db.execute(
+            """
+            INSERT INTO collector_process_versions (
+                version_stamp_id, study_id, policy_hash, collector_instance_id,
+                run_id, started_at, code_hash, collector_version, t0_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+            """,
+            (
+                "legacy-null",
+                policy.study_id,
+                policy.policy_hash,
+                "replica-a",
+                "legacy-run",
+                "2026-07-28T00:00:00.000000Z",
+                "a" * 40,
+                collector_module.COLLECTOR_VERSION,
+            ),
+        )
+        ledger.db.commit()
+
+        ledger.validate_t0_startup(started_at=EPOCH - dt.timedelta(hours=4))
+
+
+@pytest.mark.unit
+def test_t0_gate_b_rejects_late_start_for_fresh_artifact(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        t0=EPOCH,
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+
+        with pytest.raises(
+            T0StartupGateError,
+            match="기존 T0 를 바꾸지 말고 새 커밋·새 T0 를 사전 고정하라",
+        ):
+            ledger.validate_t0_startup(
+                started_at=EPOCH - dt.timedelta(hours=4) + dt.timedelta(seconds=1)
+            )
+
+
+@pytest.mark.unit
+def test_t0_gate_b_allows_timely_start_for_fresh_artifact(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        t0=EPOCH,
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+
+        ledger.validate_t0_startup(started_at=EPOCH - dt.timedelta(hours=4))
+
+
+@pytest.mark.unit
+def test_t0_gate_b_allows_late_restart_when_pit_rows_exist(tmp_path) -> None:
+    policy = EpochPolicy(
+        required_sources=("binance_usdm.basis",),
+        symbols=("XRPUSDT",),
+        t0=EPOCH,
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        _append(store, "binance_usdm.basis")
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+
+        ledger.validate_t0_startup(started_at=EPOCH + dt.timedelta(days=1))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_t0_startup_gate_runs_before_collection_or_network(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    network_calls = 0
+
+    async def forbidden_network(*_args, **_kwargs) -> None:
+        nonlocal network_calls
+        network_calls += 1
+        raise AssertionError("collection task started before T0 gate")
+
+    monkeypatch.setattr(
+        collector_module,
+        "utc_now",
+        lambda: dt.datetime(2026, 7, 30, tzinfo=dt.UTC),
+    )
+    with AppendOnlyPITStore(tmp_path) as store:
+        collector = BinanceR4P0Collector(
+            CollectorConfig(
+                artifact_root=tmp_path,
+                symbols=("XRPUSDT",),
+                collector_instance_id="replica-a",
+            ),
+            store,
+        )
+        monkeypatch.setattr(collector, "_ws_supervisor", forbidden_network)
+        monkeypatch.setattr(collector, "_poll_loop", forbidden_network)
+
+        with pytest.raises(T0StartupGateError, match="G-T0-B"):
+            await collector.run()
+
+        assert network_calls == 0
+        assert (
+            store._db.execute(  # noqa: SLF001
+                "SELECT COUNT(*) FROM collector_process_versions"
+            ).fetchone()[0]
+            == 0
+        )
+
+
+@pytest.mark.unit
+def test_process_version_t0_additive_migration_preserves_legacy_rows(tmp_path) -> None:
+    database_path = tmp_path / "legacy.sqlite3"
+    connection = sqlite3.connect(database_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute(
+        """
+        CREATE TABLE collector_process_versions (
+            append_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            version_stamp_id TEXT NOT NULL UNIQUE,
+            study_id TEXT NOT NULL,
+            policy_hash TEXT NOT NULL,
+            collector_instance_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            code_hash TEXT NOT NULL,
+            collector_version TEXT NOT NULL,
+            UNIQUE (study_id, policy_hash, collector_instance_id, run_id)
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO collector_process_versions (
+            version_stamp_id, study_id, policy_hash, collector_instance_id,
+            run_id, started_at, code_hash, collector_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "legacy-stamp",
+            POLICY.study_id,
+            POLICY.policy_hash,
+            "replica-a",
+            "legacy-run",
+            "2026-07-26T00:00:00.000000Z",
+            "a" * 40,
+            collector_module.COLLECTOR_VERSION,
+        ),
+    )
+    connection.commit()
+
+    try:
+        EpochLedger(connection, POLICY)
+        columns = {
+            row["name"]
+            for row in connection.execute(
+                "PRAGMA table_info(collector_process_versions)"
+            )
+        }
+        row = connection.execute(
+            "SELECT version_stamp_id, t0_utc FROM collector_process_versions"
+        ).fetchone()
+        assert "t0_utc" in columns
+        assert dict(row) == {"version_stamp_id": "legacy-stamp", "t0_utc": None}
+    finally:
+        connection.close()
 
 
 @pytest.mark.unit

--- a/tests/test_binance_r4_p0_watchdog.py
+++ b/tests/test_binance_r4_p0_watchdog.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app.services.brokers.binance.r4_p0_collector import (
+    COLLECTOR_VERSION,
+    AppendOnlyPITStore,
+)
+from app.services.brokers.binance.r4_p0_hardening import EpochLedger, EpochPolicy
+from scripts import r4_p0_watchdog
+
+T0 = dt.datetime(2026, 8, 2, tzinfo=dt.UTC)
+VERIFIED_AT = T0 - dt.timedelta(hours=5)
+EXPECTED_CODE_HASH = "a" * 40
+POLICY = EpochPolicy(
+    required_sources=("binance_usdm.basis",),
+    symbols=("XRPUSDT",),
+    study_id="study-t0-preflight",
+    policy_hash="policy-t0-preflight",
+    t0=T0,
+)
+
+
+def _write_replica(
+    root: Path,
+    *,
+    name: str,
+    policy: EpochPolicy = POLICY,
+    code_hash: str = EXPECTED_CODE_HASH,
+    heartbeat_at: dt.datetime = VERIFIED_AT,
+) -> Path:
+    with AppendOnlyPITStore(root) as store:
+        ledger = EpochLedger(store._db, policy)  # noqa: SLF001
+        ledger.append_process_version(
+            collector_instance_id=f"replica-{name}",
+            run_id=f"run-{name}",
+            started_at=heartbeat_at - dt.timedelta(minutes=1),
+            code_hash=code_hash,
+            collector_version=COLLECTOR_VERSION,
+        )
+        ledger.append_heartbeat(
+            collector_instance_id=f"replica-{name}",
+            run_id=f"run-{name}",
+            observed_at=heartbeat_at,
+            health={"ok": True},
+        )
+        return store.path
+
+
+def _report(
+    paths: list[Path],
+    *,
+    verified_at: dt.datetime = VERIFIED_AT,
+) -> dict:
+    return r4_p0_watchdog.t0_preflight_report(
+        paths,
+        POLICY,
+        verified_at=verified_at,
+        expected_code_hash=EXPECTED_CODE_HASH,
+        stale_after_seconds=120,
+    )
+
+
+def _process_version_count(path: Path) -> int:
+    with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as connection:
+        return connection.execute(
+            "SELECT COUNT(*) FROM collector_process_versions"
+        ).fetchone()[0]
+
+
+@pytest.mark.unit
+def test_t0_preflight_all_gates_pass(tmp_path) -> None:
+    paths = [
+        _write_replica(tmp_path / "a", name="a"),
+        _write_replica(tmp_path / "b", name="b"),
+    ]
+
+    report = _report(paths)
+
+    assert report["ok"] is True
+    assert report["gates"] == {
+        "v_le_t0_minus_4h": True,
+        "code_hash_match_all": True,
+        "healthy_replica_count_ge_2": True,
+        "stamped_t0_matches_all": True,
+    }
+    assert report["t0_utc"] == "2026-08-02T00:00:00.000000Z"
+    assert report["t0_minus_4h"] == "2026-08-01T20:00:00.000000Z"
+    assert len(report["replicas"]) == 2
+    assert all(replica["status"] == "HEALTHY" for replica in report["replicas"])
+    assert all(
+        replica["stamped_t0_utc"] == report["t0_utc"] for replica in report["replicas"]
+    )
+
+
+@pytest.mark.unit
+def test_t0_preflight_fails_v_after_warmup_cutoff(tmp_path) -> None:
+    paths = [
+        _write_replica(tmp_path / "a", name="a"),
+        _write_replica(tmp_path / "b", name="b"),
+    ]
+
+    report = _report(
+        paths, verified_at=T0 - dt.timedelta(hours=4) + dt.timedelta(seconds=1)
+    )
+
+    assert report["gates"]["v_le_t0_minus_4h"] is False
+    assert report["ok"] is False
+    assert "새 커밋과 새 T0" in report["next_action"]
+
+
+@pytest.mark.unit
+def test_t0_preflight_fails_code_hash_mismatch(tmp_path) -> None:
+    paths = [
+        _write_replica(tmp_path / "a", name="a"),
+        _write_replica(tmp_path / "b", name="b", code_hash="b" * 40),
+    ]
+
+    report = _report(paths)
+
+    assert report["gates"]["code_hash_match_all"] is False
+    assert report["ok"] is False
+
+
+@pytest.mark.unit
+def test_t0_preflight_fails_when_fewer_than_two_replicas_are_healthy(
+    tmp_path,
+) -> None:
+    paths = [
+        _write_replica(tmp_path / "a", name="a"),
+        _write_replica(
+            tmp_path / "b",
+            name="b",
+            heartbeat_at=VERIFIED_AT - dt.timedelta(minutes=3),
+        ),
+    ]
+
+    report = _report(paths)
+
+    assert report["gates"]["healthy_replica_count_ge_2"] is False
+    assert report["ok"] is False
+
+
+@pytest.mark.unit
+def test_t0_preflight_fails_stamped_t0_mismatch(tmp_path) -> None:
+    other_t0_policy = EpochPolicy(
+        required_sources=POLICY.required_sources,
+        symbols=POLICY.symbols,
+        study_id=POLICY.study_id,
+        policy_hash=POLICY.policy_hash,
+        t0=T0 + dt.timedelta(hours=4),
+    )
+    paths = [
+        _write_replica(tmp_path / "a", name="a"),
+        _write_replica(tmp_path / "b", name="b", policy=other_t0_policy),
+    ]
+
+    report = _report(paths)
+
+    assert report["gates"]["stamped_t0_matches_all"] is False
+    assert report["ok"] is False
+
+
+@pytest.mark.unit
+def test_t0_preflight_exit_codes_pass_and_fail(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    paths = [
+        _write_replica(tmp_path / "a", name="a"),
+        _write_replica(tmp_path / "b", name="b"),
+    ]
+    argv = [
+        "--t0-preflight",
+        "--artifact",
+        str(paths[0]),
+        "--artifact",
+        str(paths[1]),
+        "--state-root",
+        str(tmp_path / "must-not-exist"),
+    ]
+    monkeypatch.setattr(r4_p0_watchdog, "_policy", lambda: POLICY)
+    monkeypatch.setattr(r4_p0_watchdog, "runtime_code_hash", lambda: EXPECTED_CODE_HASH)
+    monkeypatch.setattr(r4_p0_watchdog, "utc_now", lambda: VERIFIED_AT)
+
+    assert r4_p0_watchdog.main(argv) == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+    assert not (tmp_path / "must-not-exist").exists()
+
+    monkeypatch.setattr(
+        r4_p0_watchdog,
+        "utc_now",
+        lambda: T0 - dt.timedelta(hours=4) + dt.timedelta(seconds=1),
+    )
+    assert r4_p0_watchdog.main(argv) == 1
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+
+
+@pytest.mark.unit
+def test_t0_preflight_opens_collector_artifacts_read_only(tmp_path) -> None:
+    paths = [
+        _write_replica(tmp_path / "a", name="a"),
+        _write_replica(tmp_path / "b", name="b"),
+    ]
+    before = {
+        path: (
+            path.stat().st_mtime_ns,
+            path.stat().st_size,
+            _process_version_count(path),
+        )
+        for path in paths
+    }
+    for path in paths:
+        os.chmod(path, 0o444)
+
+    try:
+        report = _report(paths)
+    finally:
+        for path in paths:
+            os.chmod(path, 0o644)
+
+    after = {
+        path: (
+            path.stat().st_mtime_ns,
+            path.stat().st_size,
+            _process_version_count(path),
+        )
+        for path in paths
+    }
+    assert report["ok"] is True
+    assert after == before

--- a/tests/test_binance_r4_p0_watchdog.py
+++ b/tests/test_binance_r4_p0_watchdog.py
@@ -116,6 +116,20 @@ def test_t0_preflight_fails_v_after_warmup_cutoff(tmp_path) -> None:
 
 
 @pytest.mark.unit
+def test_t0_preflight_allows_v_exactly_at_warmup_cutoff(tmp_path) -> None:
+    boundary = T0 - dt.timedelta(hours=4)
+    paths = [
+        _write_replica(tmp_path / "a", name="a", heartbeat_at=boundary),
+        _write_replica(tmp_path / "b", name="b", heartbeat_at=boundary),
+    ]
+
+    report = _report(paths, verified_at=boundary)
+
+    assert report["gates"]["v_le_t0_minus_4h"] is True
+    assert report["ok"] is True
+
+
+@pytest.mark.unit
 def test_t0_preflight_fails_code_hash_mismatch(tmp_path) -> None:
     paths = [
         _write_replica(tmp_path / "a", name="a"),


### PR DESCRIPTION
## Scope

Implements only approved ROB-1137 D2 tranche 1 and tranche 2:

- keep finalization and deadline-risk evaluation on local+peer union while deciding history retry from local-only coverage
- stamp precommitted T0 in collector process versions and fail closed on retroactive T0 changes or late fresh-artifact startup
- add a one-shot read-only watchdog T0 preflight and operator runbook procedure
- add bounded MockTransport request-count measurement; no live probe, scheduler registration, rehearsal, or new T0 consumption

## Verification

- uv run pytest tests/test_binance_r4_p0_*.py -vv --tb=long — 58 passed, 0 skipped
- uv run --with pytest-randomly pytest tests/test_binance_r4_p0_*.py -q --randomly-seed=1137 — 58 passed
- requested literal -p randomly command is unavailable in the prepared environment with ModuleNotFoundError: randomly; failure preserved in worker report
- make lint — passed
- static no-internal-LLM guard — 3 passed
- make test — 17,268 passed, 10 skipped, 7 deselected

## Safety

- DEFAULT_T0, DEFAULT_STUDY_ID, and DEFAULT_POLICY_HASH unchanged
- no scheduler, deploy, rehearsal, replication-barrier, or watchdog-monitor expansion
- no broker mutation or operational artifact access
- stop point is this PR; do not merge as part of this task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a watchdog **`--t0-preflight`** mode that outputs a JSON health report (including replica status and gate checks).
  - Introduced **T0 startup gating** to enforce immutable, policy-aligned startup stamps before collection begins.
  - Hardened incomplete-epoch recovery with **local artifact–based preview/retry behavior** to avoid writing finalization from inappropriate sources.
- **Documentation**
  - Updated the r4-p0 collector runbook to reflect the T0 stamping, gate behavior, and recovery rules.
- **Bug Fixes**
  - Improved retry targeting when local vs peer histories differ, including correct “late-only” correction handling.
- **Tests**
  - Expanded hardening and watchdog coverage for T0 gate, retries, and reporting edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->