### PR TITLE
fix(ROB-1121): remove fabricated trade clock and type freshness fail-closed

### DIFF
--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -120,10 +120,14 @@ async def _resolve_kr_quote(
         # ROB-725: during NXT premarket/after-hours the KRX regular quote is the
         # prior close — overlay the live NXT price so current_price + S/R
         # distance_pct track the real market.
+        # ROB-1121: overlay 낸 NXT orderbook에는 provider 체결 timestamp가 없으므로
+        # overlay 적용 시 unavailable/fail-closed로 다시 태그한다.
+        # _apply_nxt_quote_overlay 낸부에서도 동일하게 처리하지만, caller 측에서
+        # 한 번 더 보장하면 커스텀 overlay mock 등에서 누락을 막는다.
         if await _apply_nxt_quote_overlay(
             symbol, quote, data_state=kr_market_data_state()
         ):
-            _annotate_kr_price_freshness(quote, now_kst(), trading_date=trading_date)
+            _annotate_kr_price_freshness(quote, None, trading_date=trading_date)
         return quote
 
     live = await _fetch_kr_live_quote(symbol)

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -474,7 +474,9 @@ async def _apply_nxt_quote_overlay(
     quote["regular_session_data_state"] = data_state
     quote["data_state"] = DATA_STATE_FRESH
     _annotate_nxt_session_change(quote, session=session, krx_prev_close=krx_prev_close)
-    _annotate_kr_price_freshness(quote, now_kst())
+    # ROB-1121: NXT orderbook overlay에는 provider 체결 timestamp가 없다.
+    # 벽시계를 as_of로 위장하지 않고 unavailable/fail-closed로 표현.
+    _annotate_kr_price_freshness(quote, None)
     return True
 
 
@@ -727,6 +729,12 @@ async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
 
     공유 _fetch_quote_equity_kr(orders/portfolio 사용)는 건드리지 않는다.
     실패/빈응답이면 None (호출자가 일봉으로 fallback).
+
+    ROB-1121:
+    - provider timestamp(체결일자+시각)가 부재하면 price_as_of를 None으로 두고
+      freshness는 downstream _annotate_kr_price_freshness가 unavailable/fail-closed
+      로 표현한다. 날짜만 있을 때 자정을 합성하지 않는다.
+    - provider timestamp와 무관한 호출/수신 시각은 fetched_at으로만 보존.
     """
     kis = KISClient()
     try:
@@ -740,12 +748,10 @@ async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
     as_of: datetime.datetime | None = None
     date_val = row.get("date")
     time_val = row.get("time")
-    if date_val is not None:
+    # ROB-1121: date/time 중 하나라도 provider가 주지 않으면 합성하지 않는다.
+    if date_val is not None and not pd.isna(date_val) and time_val is not None:
         d = pd.Timestamp(date_val).to_pydatetime()
-        if time_val is not None:
-            as_of = datetime.datetime.combine(d.date(), time_val)
-        else:
-            as_of = d
+        as_of = datetime.datetime.combine(d.date(), time_val)
 
     return {
         "symbol": symbol,
@@ -758,6 +764,7 @@ async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
         "value": row.get("value"),
         "source": "kis",
         "price_as_of": as_of.isoformat() if as_of is not None else None,
+        "fetched_at": now_kst().isoformat(),
     }
 
 

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -617,8 +617,14 @@ async def _search_master_data(
 
 
 def _parse_price_as_of(value: Any) -> datetime.datetime | None:
-    """Parse a provider timestamp without turning integer indexes into epoch data."""
+    """Parse a provider timestamp without turning integer indexes into epoch data.
+
+    ROB-1121: Reject timezone-naive datetime objects at the freshness boundary.
+    Provider timestamps must be timezone-aware (or constructed as KST-aware).
+    """
     if value is None:
+        return None
+    if isinstance(value, datetime.datetime) and value.tzinfo is None:
         return None
     try:
         timestamp = pd.Timestamp(value)
@@ -626,19 +632,34 @@ def _parse_price_as_of(value: Any) -> datetime.datetime | None:
         return None
     if pd.isna(timestamp) or timestamp.value <= 0:
         return None
-    return timestamp.to_pydatetime()
+    dt = timestamp.to_pydatetime()
+    if dt.tzinfo is None:
+        return None
+    return dt
 
 
 def _kr_price_as_of_from_frame(df: pd.DataFrame) -> datetime.datetime | None:
     """Read a real candle date; RangeIndex values are not timestamps."""
     if df.empty:
         return None
+    val = None
     row_value = df.iloc[-1].get("date")
     if row_value is not None and not pd.isna(row_value):
-        return _parse_price_as_of(row_value)
-    if isinstance(df.index, pd.DatetimeIndex):
-        return _parse_price_as_of(df.index[-1])
-    return None
+        val = row_value
+    elif isinstance(df.index, pd.DatetimeIndex):
+        val = df.index[-1]
+    if val is None:
+        return None
+    try:
+        timestamp = pd.Timestamp(val)
+        if pd.isna(timestamp) or timestamp.value <= 0:
+            return None
+        dt = timestamp.to_pydatetime()
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_KST)
+        return dt
+    except (TypeError, ValueError, OverflowError):
+        return None
 
 
 def _annotate_kr_price_freshness(
@@ -749,9 +770,10 @@ async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
     date_val = row.get("date")
     time_val = row.get("time")
     # ROB-1121: date/time 중 하나라도 provider가 주지 않으면 합성하지 않는다.
+    # provider timestamp는 KST-aware로 생성한다.
     if date_val is not None and not pd.isna(date_val) and time_val is not None:
         d = pd.Timestamp(date_val).to_pydatetime()
-        as_of = datetime.datetime.combine(d.date(), time_val)
+        as_of = datetime.datetime.combine(d.date(), time_val, tzinfo=_KST)
 
     return {
         "symbol": symbol,
@@ -1463,7 +1485,11 @@ async def _get_quote_impl(
         # previous_close used for gap calculations.
         data_state = kr_market_data_state()
         quote = await _fetch_quote_equity_kr(symbol)
-        tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
+        try:
+            tradability_map = await get_kr_nxt_tradability([symbol])
+            tradability = tradability_map.get(symbol)
+        except Exception:
+            tradability = None
         if tradability is not None:
             quote.update(tradability.public_fields())
         if await _apply_nxt_quote_overlay(symbol, quote, data_state=data_state):

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -635,7 +635,7 @@ def _parse_price_as_of(value: Any) -> datetime.datetime | None:
     dt = timestamp.to_pydatetime()
     if dt.tzinfo is None:
         return None
-    return dt
+    return dt.astimezone(_KST)
 
 
 def _kr_price_as_of_from_frame(df: pd.DataFrame) -> datetime.datetime | None:
@@ -771,9 +771,18 @@ async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
     time_val = row.get("time")
     # ROB-1121: date/time 중 하나라도 provider가 주지 않으면 합성하지 않는다.
     # provider timestamp는 KST-aware로 생성한다.
-    if date_val is not None and not pd.isna(date_val) and time_val is not None:
-        d = pd.Timestamp(date_val).to_pydatetime()
-        as_of = datetime.datetime.combine(d.date(), time_val, tzinfo=_KST)
+    if (
+        date_val is not None
+        and not pd.isna(date_val)
+        and isinstance(time_val, datetime.time)
+        and not pd.isna(time_val)
+    ):
+        try:
+            d = pd.Timestamp(date_val).to_pydatetime()
+        except (TypeError, ValueError, OverflowError):
+            d = None
+        if d is not None:
+            as_of = datetime.datetime.combine(d.date(), time_val, tzinfo=_KST)
 
     return {
         "symbol": symbol,
@@ -1485,11 +1494,8 @@ async def _get_quote_impl(
         # previous_close used for gap calculations.
         data_state = kr_market_data_state()
         quote = await _fetch_quote_equity_kr(symbol)
-        try:
-            tradability_map = await get_kr_nxt_tradability([symbol])
-            tradability = tradability_map.get(symbol)
-        except Exception:
-            tradability = None
+        tradability_map = await get_kr_nxt_tradability([symbol])
+        tradability = tradability_map.get(symbol)
         if tradability is not None:
             quote.update(tradability.public_fields())
         if await _apply_nxt_quote_overlay(symbol, quote, data_state=data_state):

--- a/app/services/brokers/kis/domestic_market_data.py
+++ b/app/services/brokers/kis/domestic_market_data.py
@@ -20,6 +20,22 @@ def _empty_day_frame() -> pd.DataFrame:
     return pd.DataFrame(columns=constants.DAY_FRAME_COLUMNS)
 
 
+def _parse_kis_provider_date(value: Any) -> pd.Timestamp | None:
+    """Parse a raw KIS date without discarding the rest of the quote evidence."""
+    if value is None or value == "":
+        return None
+    parsed = pd.to_datetime(value, format="%Y%m%d", errors="coerce")
+    return None if pd.isna(parsed) else parsed
+
+
+def _parse_kis_provider_time(value: Any) -> datetime.time | None:
+    """Parse a raw KIS clock value; malformed/non-finite values stay unavailable."""
+    if value is None or value == "":
+        return None
+    parsed = pd.to_datetime(value, format="%H%M%S", errors="coerce")
+    return None if pd.isna(parsed) else parsed.time()
+
+
 def _validate_daily_itemchartprice_chunk(chunk: list[dict[str, Any]]) -> None:
     if not isinstance(chunk, list):
         raise RuntimeError(
@@ -210,14 +226,10 @@ class DomesticMarketDataMixin(MarketDataBase):
         # stck_bsop_date / stck_cntg_hour|time 부재 시 None을 유지하고,
         # 호출부는 호출 시각을 별도 observed_at/fetched_at으로만 태깅한다.
         trade_date_str = out.get("stck_bsop_date")  # 예: '20250805'
-        trade_date = (
-            pd.to_datetime(trade_date_str, format="%Y%m%d") if trade_date_str else None
-        )
+        trade_date = _parse_kis_provider_date(trade_date_str)
 
         time_str = out.get("stck_cntg_hour") or out.get("stck_cntg_time")  # 'HHMMSS'
-        trade_time = (
-            pd.to_datetime(time_str, format="%H%M%S").time() if time_str else None
-        )
+        trade_time = _parse_kis_provider_time(time_str)
 
         row = {
             "code": out["stck_shrn_iscd"],

--- a/app/services/brokers/kis/domestic_market_data.py
+++ b/app/services/brokers/kis/domestic_market_data.py
@@ -205,18 +205,20 @@ class DomesticMarketDataMixin(MarketDataBase):
             api_name="inquire_price",
         )
         out = js["output"]  # 단일 dict
-        trade_date_str = out.get("stck_bsop_date")  # 예: '20250805'
-        if trade_date_str:
-            trade_date = pd.to_datetime(trade_date_str, format="%Y%m%d")
-        else:  # 필드가 없으면 오늘 날짜
-            trade_date = pd.Timestamp(datetime.date.today())
 
-        # ── ② 체결 시각 ──
+        # ROB-1121: provider가 주지 않은 local trade time 합성 금지.
+        # stck_bsop_date / stck_cntg_hour|time 부재 시 None을 유지하고,
+        # 호출부는 호출 시각을 별도 observed_at/fetched_at으로만 태깅한다.
+        trade_date_str = out.get("stck_bsop_date")  # 예: '20250805'
+        trade_date = (
+            pd.to_datetime(trade_date_str, format="%Y%m%d") if trade_date_str else None
+        )
+
         time_str = out.get("stck_cntg_hour") or out.get("stck_cntg_time")  # 'HHMMSS'
-        if time_str:
-            trade_time = pd.to_datetime(time_str, format="%H%M%S").time()
-        else:
-            trade_time = datetime.datetime.now().time()  # 필드가 없으면 현재 시각
+        trade_time = (
+            pd.to_datetime(time_str, format="%H%M%S").time() if time_str else None
+        )
+
         row = {
             "code": out["stck_shrn_iscd"],
             "date": trade_date,

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -9,6 +9,8 @@ from app.mcp_server.tooling import analysis_analyze
 
 KST = ZoneInfo("Asia/Seoul")
 
+pytestmark = [pytest.mark.integration]
+
 
 @pytest.fixture(autouse=True)
 def _no_nxt_overlay_by_default(monkeypatch):
@@ -134,9 +136,12 @@ async def test_kr_quote_overlays_nxt_price_in_premarket(monkeypatch):
 
     assert quote["price"] == 173500.0
     assert quote["price_source"] == "nxt_expected_price"
-    assert quote["is_stale_price"] is False  # overlay price is fresh
-    # price_as_of refreshed to the live NXT fetch time (today, not yesterday)
-    assert quote["price_as_of"].startswith(str(today.date()))
+    # ROB-1121: NXT orderbook overlay에는 provider 체결 timestamp가 없으므로
+    # freshness를 unavailable/fail-closed로 표현. 벽시계를 as_of로 위장하지 않는다.
+    assert quote["is_stale_price"] is True
+    assert quote["price_freshness"] == "unavailable"
+    assert quote["price_usable"] is False
+    assert quote["price_as_of"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -224,3 +224,50 @@ async def test_kr_quote_keeps_kis_price_when_no_overlay(monkeypatch):
     assert quote["price"] == 168300.0
     assert "price_source" not in quote
     assert quote["is_stale_price"] is False  # today's KIS as_of, unchanged
+
+
+@pytest.mark.asyncio
+async def test_kr_malformed_live_timestamp_does_not_fallback_to_fresh_daily(
+    monkeypatch,
+):
+    """AC3 / Finding 1: malformed provider date/time in live quote must remain unavailable
+
+    and must not collapse into same-day daily OHLCV fallback that would evaluate fresh.
+    """
+    today = pd.Timestamp(datetime.now(KST).date())
+    same_day_ohlcv = pd.DataFrame(
+        {
+            "open": [100.0],
+            "high": [110.0],
+            "low": [90.0],
+            "close": [105.0],
+            "volume": [1000],
+            "value": [105000.0],
+        },
+        index=[today],
+    )
+
+    async def fake_live_malformed(symbol):
+        return {
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 105.0,
+            "open": 100.0,
+            "high": 110.0,
+            "low": 90.0,
+            "volume": 1000,
+            "value": 105000,
+            "source": "kis",
+            "price_as_of": None,
+            "fetched_at": datetime.now(KST).isoformat(),
+        }
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live_malformed)
+    quote = await analysis_analyze._resolve_kr_quote("012450", same_day_ohlcv)
+
+    assert quote is not None
+    assert quote["price_as_of"] is None
+    assert quote["is_stale_price"] is True
+    assert quote["price_freshness"] == "unavailable"
+    assert quote["price_usable"] is False
+    assert quote["price_unavailable_reason"] == "missing_price_asof"

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -5,7 +5,9 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 import pytest
 
-from app.mcp_server.tooling import analysis_analyze
+from app.mcp_server.tooling import analysis_analyze, market_data_quotes
+from app.services.brokers.kis.domestic_market_data import DomesticMarketDataMixin
+from tests._mcp_tooling_support import build_tools
 
 KST = ZoneInfo("Asia/Seoul")
 
@@ -43,6 +45,17 @@ def _ohlcv():
         },
         index=[yesterday],
     )
+
+
+class _RawKISPriceParser(DomesticMarketDataMixin):
+    def __init__(self, raw_output):
+        self._raw_output = raw_output
+
+    def _kis_url(self, path: str) -> str:
+        return f"https://mock.kis/{path}"
+
+    async def _request_with_token_retry(self, **kwargs):
+        return {"output": self._raw_output}
 
 
 @pytest.mark.asyncio
@@ -268,6 +281,85 @@ async def test_kr_malformed_live_timestamp_does_not_fallback_to_fresh_daily(
     assert quote is not None
     assert quote["price_as_of"] is None
     assert quote["is_stale_price"] is True
+    assert quote["price_freshness"] == "unavailable"
+    assert quote["price_usable"] is False
+    assert quote["price_unavailable_reason"] == "missing_price_asof"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_date", "raw_time"),
+    [
+        pytest.param("not-a-date", "093000", id="malformed-date-valid-time"),
+        pytest.param("20260601", "not-a-time", id="valid-date-malformed-time"),
+        pytest.param("20260601", "NaT", id="raw-nat-time"),
+    ],
+)
+async def test_registered_analyze_stock_preserves_malformed_live_clock_provenance(
+    monkeypatch,
+    raw_date,
+    raw_time,
+):
+    """Exercise raw KIS parser -> real live fetch -> registered MCP analyze_stock."""
+    raw_payload = {
+        "stck_shrn_iscd": "012450",
+        "stck_bsop_date": raw_date,
+        "stck_cntg_hour": raw_time,
+        "stck_oprc": "200",
+        "stck_hgpr": "230",
+        "stck_lwpr": "190",
+        "stck_prpr": "222",
+        "acml_vol": "10",
+        "acml_tr_pbmn": "2220",
+    }
+    parser = _RawKISPriceParser(raw_payload)
+    monkeypatch.setattr(market_data_quotes, "KISClient", lambda: parser)
+
+    same_day_ohlcv = pd.DataFrame(
+        {
+            "date": [pd.Timestamp("2026-06-01")],
+            "open": [100.0],
+            "high": [110.0],
+            "low": [90.0],
+            "close": [105.0],
+            "volume": [1000],
+            "value": [105000.0],
+        }
+    )
+
+    async def fake_ohlcv(symbol, market_type, count):
+        return same_day_ohlcv
+
+    async def no_tradability(symbols):
+        return {}
+
+    async def no_overlay(symbol, quote, *, data_state):
+        return False
+
+    async def no_market_tasks(
+        named_tasks,
+        normalized_symbol,
+        market_type,
+        loop,
+        refresh=False,
+    ):
+        return None
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_ohlcv_for_indicators", fake_ohlcv)
+    monkeypatch.setattr(analysis_analyze, "get_kr_nxt_tradability", no_tradability)
+    monkeypatch.setattr(analysis_analyze, "_apply_nxt_quote_overlay", no_overlay)
+    monkeypatch.setattr(
+        analysis_analyze, "_append_common_tasks", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "_append_market_specific_tasks", no_market_tasks
+    )
+
+    result = await build_tools()["analyze_stock"]("012450", market="kr")
+    quote = result["quote"]
+
+    assert quote["price"] == 222.0
+    assert quote["price_as_of"] is None
     assert quote["price_freshness"] == "unavailable"
     assert quote["price_usable"] is False
     assert quote["price_unavailable_reason"] == "missing_price_asof"

--- a/tests/test_kr_live_quote.py
+++ b/tests/test_kr_live_quote.py
@@ -111,6 +111,32 @@ async def test_fetch_kr_live_quote_as_of_missing_date_time_is_unavailable(monkey
 
 
 @pytest.mark.asyncio
+async def test_fetch_kr_live_quote_pd_nat_time_is_unavailable(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "date": pd.Timestamp("2026-06-01"),
+                "time": pd.NaT,
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1225000.0,
+                "volume": 1,
+                "value": 1,
+            }
+        ],
+        index=["012450"],
+    )
+    monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(df))
+
+    quote = await market_data_quotes._fetch_kr_live_quote("012450")
+
+    assert quote is not None
+    assert quote["price_as_of"] is None
+    assert quote["fetched_at"] is not None
+
+
+@pytest.mark.asyncio
 async def test_fetch_kr_live_quote_empty_df_returns_none(monkeypatch):
     monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(pd.DataFrame()))
 
@@ -179,6 +205,44 @@ async def test_inquire_price_parser_date_only():
     assert row["time"] is None
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_date", "raw_time"),
+    [
+        pytest.param("not-a-date", "093000", id="malformed-date-valid-time"),
+        pytest.param("20260601", "not-a-time", id="valid-date-malformed-time"),
+        pytest.param("20260601", "NaT", id="raw-nat-time"),
+    ],
+)
+async def test_inquire_price_parser_preserves_quote_with_unusable_clock(
+    raw_date,
+    raw_time,
+):
+    raw_payload = {
+        "stck_shrn_iscd": "005930",
+        "stck_bsop_date": raw_date,
+        "stck_cntg_hour": raw_time,
+        "stck_oprc": "100",
+        "stck_hgpr": "110",
+        "stck_lwpr": "90",
+        "stck_prpr": "105",
+        "acml_vol": "1000",
+        "acml_tr_pbmn": "105000",
+    }
+
+    df = await _DummyMarketData(raw_payload).inquire_price("005930")
+
+    assert not df.empty
+    row = df.iloc[0].to_dict()
+    assert row["close"] == 105.0
+    if raw_date == "not-a-date":
+        assert row["date"] is None
+        assert row["time"] == datetime.time(9, 30)
+    else:
+        assert row["date"] == pd.Timestamp("2026-06-01")
+        assert row["time"] is None
+
+
 def test_annotate_kr_price_freshness_timezone_naive_is_unavailable():
     naive_as_of = datetime.datetime(2026, 6, 1, 9, 30, 0)
     quote = {}
@@ -189,6 +253,47 @@ def test_annotate_kr_price_freshness_timezone_naive_is_unavailable():
     assert quote["price_freshness"] == "unavailable"
     assert quote["price_usable"] is False
     assert quote["price_unavailable_reason"] == "missing_price_asof"
+
+
+@pytest.mark.parametrize(
+    ("as_of", "expected_as_of", "expected_freshness"),
+    [
+        pytest.param(
+            "2026-05-31T15:30:00Z",
+            "2026-06-01T00:30:00+09:00",
+            "fresh",
+            id="utc-z-same-kst-trading-date",
+        ),
+        pytest.param(
+            "2026-05-31T11:30:00-04:00",
+            "2026-06-01T00:30:00+09:00",
+            "fresh",
+            id="minus-four-same-kst-trading-date",
+        ),
+        pytest.param(
+            "2026-05-30T15:30:00Z",
+            "2026-05-31T00:30:00+09:00",
+            "stale",
+            id="prior-kst-date-control",
+        ),
+    ],
+)
+def test_annotate_kr_price_freshness_compares_kst_trading_date(
+    as_of,
+    expected_as_of,
+    expected_freshness,
+):
+    quote = {}
+
+    market_data_quotes._annotate_kr_price_freshness(
+        quote,
+        as_of,
+        trading_date=datetime.date(2026, 6, 1),
+    )
+
+    assert quote["price_as_of"] == expected_as_of
+    assert quote["price_freshness"] == expected_freshness
+    assert quote["price_usable"] is (expected_freshness == "fresh")
 
 
 @pytest.mark.asyncio

--- a/tests/test_kr_live_quote.py
+++ b/tests/test_kr_live_quote.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 
 from app.mcp_server.tooling import market_data_quotes
+from app.services.brokers.kis.domestic_market_data import DomesticMarketDataMixin
 
 
 def _make_kis(df=None, *, raises=False):
@@ -51,7 +52,7 @@ async def test_fetch_kr_live_quote_parses_price_and_as_of(monkeypatch):
     assert quote["price"] == 1225000.0  # stck_prpr → close (live, not prev close)
     assert quote["source"] == "kis"
     assert quote["instrument_type"] == "equity_kr"
-    assert quote["price_as_of"] == "2026-06-01T09:30:00"
+    assert quote["price_as_of"] == "2026-06-01T09:30:00+09:00"
     assert quote["fetched_at"] is not None
 
 
@@ -121,3 +122,100 @@ async def test_fetch_kr_live_quote_swallows_kis_error_returns_none(monkeypatch):
     monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(raises=True))
 
     assert await market_data_quotes._fetch_kr_live_quote("012450") is None
+
+
+class _DummyMarketData(DomesticMarketDataMixin):
+    def __init__(self, raw_output):
+        self._raw_output = raw_output
+
+    def _kis_url(self, path: str) -> str:
+        return f"https://mock.kis/{path}"
+
+    async def _request_with_token_retry(self, **kwargs):
+        return {"output": self._raw_output}
+
+
+@pytest.mark.asyncio
+async def test_inquire_price_parser_does_not_synthesize_local_clock():
+    raw_payload = {
+        "stck_shrn_iscd": "005930",
+        "stck_bsop_date": "",
+        "stck_cntg_hour": "",
+        "stck_oprc": "100",
+        "stck_hgpr": "110",
+        "stck_lwpr": "90",
+        "stck_prpr": "105",
+        "acml_vol": "1000",
+        "acml_tr_pbmn": "105000",
+    }
+    client = _DummyMarketData(raw_payload)
+    df = await client.inquire_price("005930")
+
+    assert not df.empty
+    row = df.iloc[0].to_dict()
+    assert row["date"] is None
+    assert row["time"] is None
+
+
+@pytest.mark.asyncio
+async def test_inquire_price_parser_date_only():
+    raw_payload = {
+        "stck_shrn_iscd": "005930",
+        "stck_bsop_date": "20260601",
+        "stck_cntg_hour": "",
+        "stck_oprc": "100",
+        "stck_hgpr": "110",
+        "stck_lwpr": "90",
+        "stck_prpr": "105",
+        "acml_vol": "1000",
+        "acml_tr_pbmn": "105000",
+    }
+    client = _DummyMarketData(raw_payload)
+    df = await client.inquire_price("005930")
+
+    assert not df.empty
+    row = df.iloc[0].to_dict()
+    assert row["date"] == pd.Timestamp("2026-06-01")
+    assert row["time"] is None
+
+
+def test_annotate_kr_price_freshness_timezone_naive_is_unavailable():
+    naive_as_of = datetime.datetime(2026, 6, 1, 9, 30, 0)
+    quote = {}
+    market_data_quotes._annotate_kr_price_freshness(quote, naive_as_of)
+
+    assert quote["price_as_of"] is None
+    assert quote["is_stale_price"] is True
+    assert quote["price_freshness"] == "unavailable"
+    assert quote["price_usable"] is False
+    assert quote["price_unavailable_reason"] == "missing_price_asof"
+
+
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_stamps_unavailable_freshness(monkeypatch):
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_overlay(symbol, *, session):
+        return {
+            "price": 105.0,
+            "session": session,
+            "venue": "nxt",
+            "price_source": "nxt_expected_price",
+        }
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    quote = {"price": 100.0}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "005930", quote, data_state="premarket_unavailable"
+    )
+
+    assert applied is True
+    assert quote["price"] == 105.0
+    assert quote["price_as_of"] is None
+    assert quote["price_freshness"] == "unavailable"
+    assert quote["price_usable"] is False
+    assert quote["is_stale_price"] is True
+    assert quote["price_unavailable_reason"] == "missing_price_asof"

--- a/tests/test_kr_live_quote.py
+++ b/tests/test_kr_live_quote.py
@@ -52,10 +52,12 @@ async def test_fetch_kr_live_quote_parses_price_and_as_of(monkeypatch):
     assert quote["source"] == "kis"
     assert quote["instrument_type"] == "equity_kr"
     assert quote["price_as_of"] == "2026-06-01T09:30:00"
+    assert quote["fetched_at"] is not None
 
 
 @pytest.mark.asyncio
-async def test_fetch_kr_live_quote_as_of_without_time_uses_date(monkeypatch):
+async def test_fetch_kr_live_quote_as_of_without_time_is_unavailable(monkeypatch):
+    # ROB-1121: provider가 time을 주지 않으면 날짜만으로 자정을 합성하지 않는다.
     df = pd.DataFrame(
         [
             {
@@ -76,7 +78,35 @@ async def test_fetch_kr_live_quote_as_of_without_time_uses_date(monkeypatch):
     quote = await market_data_quotes._fetch_kr_live_quote("012450")
 
     assert quote is not None
-    assert quote["price_as_of"] == "2026-06-01T00:00:00"
+    assert quote["price_as_of"] is None
+    assert quote["fetched_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_live_quote_as_of_missing_date_time_is_unavailable(monkeypatch):
+    # ROB-1121: provider가 date와 time 둘 다 주지 않으면 price_as_of는 None.
+    df = pd.DataFrame(
+        [
+            {
+                "date": None,
+                "time": None,
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1225000.0,
+                "volume": 1,
+                "value": 1,
+            }
+        ],
+        index=["012450"],
+    )
+    monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(df))
+
+    quote = await market_data_quotes._fetch_kr_live_quote("012450")
+
+    assert quote is not None
+    assert quote["price_as_of"] is None
+    assert quote["fetched_at"] is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4604,7 +4604,7 @@ async def test_analyze_stock_kr_reuses_preloaded_ohlcv_and_bundled_naver(monkeyp
         "volume": 1000000,
         "value": 75000000000.0,
         "source": "kis",
-        "price_as_of": "2024-01-01T00:00:00",
+        "price_as_of": "2024-01-01T00:00:00+09:00",
         "is_stale_price": True,
         "price_freshness": "stale",
         "price_usable": False,

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -382,6 +382,17 @@ def _two_row_kr_quote_df() -> pd.DataFrame:
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_kr_nxt_tradability(monkeypatch):
+    """Keep standalone quote tests independent of the shared NXT database."""
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def no_tradability(symbols):
+        return {}
+
+    monkeypatch.setattr(market_data_quotes, "get_kr_nxt_tradability", no_tradability)
+
+
 def _nxt_quote_book(
     *,
     expected_price: int | None = None,
@@ -1632,6 +1643,34 @@ async def test_get_quote_kr_exposes_nxt_tradable(monkeypatch):
     assert result["nxt_tradable_reason"] == "stale_asof"
     assert result["nxt_tradable_source"] == "kr_symbol_universe"
     assert result["nxt_tradable_asof"] is not None
+
+
+@pytest.mark.asyncio
+async def test_registered_get_quote_surfaces_nxt_schema_fault(monkeypatch):
+    from app.mcp_server.tooling import market_data_quotes
+
+    tools = build_tools()
+    df = _single_row_df()
+
+    class DummyKISClient:
+        async def inquire_daily_itemchartprice(self, code, market, n):
+            return df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+
+    async def schema_fault(symbols):
+        raise RuntimeError('relation "kr_symbol_universe" does not exist')
+
+    monkeypatch.setattr(market_data_quotes, "get_kr_nxt_tradability", schema_fault)
+
+    result = await tools["get_quote"]("005930", market="kr")
+
+    assert result == {
+        "error": 'relation "kr_symbol_universe" does not exist',
+        "source": "kis",
+        "symbol": "005930",
+        "instrument_type": "equity_kr",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

ROB-1121 r2 preserves fail-closed price-evidence provenance across malformed KIS clocks, `pd.NaT`, NXT metadata faults, and non-KST aware timestamps. It does not synthesize a local wall clock or silently upgrade unusable live evidence to a same-day daily price.

Start SHA: `783fe8a6d380c5d2c92e711fd794505fb1e4b56b`
R2 SHA: `56b1321991929ff279444d7e9e19dc9d207d6563`

## R2 corrections

- Malformed nonempty KIS date/time and raw `NaT` are coerced to an unavailable provider clock while the live price row remains evidence. Registered `analyze_stock` returns `price_as_of=null`, `price_freshness=unavailable`, `price_usable=false`, and `price_unavailable_reason=missing_price_asof`.
- Constructed frames with `time_val=pd.NaT` no longer enter `datetime.combine`.
- Removed the r1 runtime `except Exception: tradability=None` suppression. NXT DB/session/schema/programming faults flow to the established registered `get_quote` error payload. Standalone quote tests use an explicit empty-tradability fixture instead of runtime suppression.
- Timezone-aware UTC/Z/other-offset price timestamps are normalized to KST before trading-date comparison. Same KST trading-day instants remain fresh; prior KST dates remain stale. Naive timestamps remain unavailable.
- Updated the bundled-fundamentals golden to the intended KST-aware daily timestamp.

## Actual R2 changed files

- `app/mcp_server/tooling/market_data_quotes.py`
- `app/services/brokers/kis/domestic_market_data.py`
- `tests/test_analyze_stock_kr_live_price.py`
- `tests/test_kr_live_quote.py`
- `tests/test_mcp_fundamentals_tools.py`
- `tests/test_mcp_quotes_tools.py`

`app/mcp_server/tooling/analysis_analyze.py` was not changed by r2.

## Verification

- Focused raw-parser/live-fetch/registered-MCP, quote/NXT, timezone, and exact golden set: `85 passed in 17.61s`
- Affected consumers: `182 passed, 6 warnings in 15.82s`
- Quote/freshness plus ROB-501 and symbol guards: `124 passed in 20.54s`
- NXT truth and advisory-preflight consumers: `49 passed in 20.49s`
- Post-environment-restore exact anchors: `9 passed in 14.27s`
- `make lint`: Ruff check PASS; 3412 files formatted; ty PASS
- `git diff --check`: clean
- Isolated exact-SHA full `make test`: `17320 passed, 10 skipped, 7 deselected, 35 warnings in 1152.57s (0:19:12)`, exit 0

The isolated full suite reproduced the existing tracked `.smoke-out/rob179-feed-research-evidence.json` side effect only in the disposable clone; the shared correction worktree remained clean.

## Mutant RED evidence

All mutants ran only in disposable detached worktrees:

- malformed parser exception collapsed to daily fallback: registered analyze anchor RED (`105.0 != 222.0`)
- `pd.NaT` accepted by the combine branch: RED with `TypeError: combine() argument 2 must be datetime.time, not NaTType`
- KST normalization removed: UTC Z / `-04:00` / prior-date matrix `3 failed`
- broad NXT exception swallowing restored: registered schema-fault `get_quote` anchor RED because it returned a successful partial quote instead of the error payload

## Scope boundary

Market-data/analysis freshness semantics and deterministic tests only. No broker/API/live call, order/preview/cancel, ledger or operational DB write, direct SQL, scheduler/deploy mutation, env gate, host allowlist, confirm gate, hard invariant, symbol conversion, runtime LLM, main push, production push, or merge.

Self-verification is not merge verification; independent re-verification is still required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Korean price freshness accuracy with stricter, KST-aware handling of malformed or timezone-naive timestamps (fail-closed).
  * Prevented missing provider trade date/time from being synthesized as “today/now”; unavailable quotes now correctly remain unavailable (no same-day OHLCV fallback).
  * Updated KR NXT quote overlays so overlay-derived prices are marked freshness-unavailable when provider timing can’t be trusted.
  * Added `fetched_at` to live quote responses and ensured overlay freshness follows unavailable semantics.

* **Tests**
  * Expanded integration and behavior-level coverage for KR freshness/overlay edge cases and updated assertions for timezone-qualified `price_as_of`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->