### PR TITLE
[ROB-1195] Add immutable fill observation foundation

### DIFF
--- a/alembic/versions/20260801_rob1195_fill_observation_foundation.py
+++ b/alembic/versions/20260801_rob1195_fill_observation_foundation.py
@@ -31,8 +31,8 @@ _IMMUTABILITY_DDL = (
     RETURNS trigger AS $$
     BEGIN
         RAISE EXCEPTION
-            'review.fill_observations is append-only/immutable; % rejected',
-            TG_OP
+            '%.% is append-only/immutable; % rejected',
+            TG_TABLE_SCHEMA, TG_TABLE_NAME, TG_OP
             USING ERRCODE = 'restrict_violation';
     END;
     $$ LANGUAGE plpgsql
@@ -45,6 +45,17 @@ _IMMUTABILITY_DDL = (
     """
     CREATE TRIGGER trg_fill_observations_truncate_immutable
     BEFORE TRUNCATE ON review.fill_observations
+    FOR EACH STATEMENT EXECUTE FUNCTION
+        review.reject_fill_observation_mutation()
+    """,
+    """
+    CREATE TRIGGER trg_fill_settlement_enrichments_immutable
+    BEFORE UPDATE OR DELETE ON review.fill_settlement_enrichments
+    FOR EACH ROW EXECUTE FUNCTION review.reject_fill_observation_mutation()
+    """,
+    """
+    CREATE TRIGGER trg_fill_settlement_enrichments_truncate_immutable
+    BEFORE TRUNCATE ON review.fill_settlement_enrichments
     FOR EACH STATEMENT EXECUTE FUNCTION
         review.reject_fill_observation_mutation()
     """,
@@ -80,7 +91,7 @@ def upgrade() -> None:
         sa.Column("fee_total", sa.Numeric(38, 18), nullable=True),
         sa.Column("evidence_source", sa.String(64), nullable=False),
         sa.Column("evidence_ref", sa.Text(), nullable=False),
-        sa.Column("evidence_hash", sa.String(64), nullable=False),
+        sa.Column("fill_fact_hash", sa.String(64), nullable=False),
         sa.Column("observed_at", sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column("filled_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("correlation_id", sa.Text(), nullable=True),
@@ -95,7 +106,7 @@ def upgrade() -> None:
             name="uq_fill_observation_identity",
         ),
         sa.CheckConstraint(
-            f"observation_identity ~ '{_SHA256}' AND evidence_hash ~ '{_SHA256}'",
+            f"observation_identity ~ '{_SHA256}' AND fill_fact_hash ~ '{_SHA256}'",
             name=op.f("ck_fill_observation_hashes"),
         ),
         sa.CheckConstraint(
@@ -149,6 +160,70 @@ def upgrade() -> None:
         "ix_fill_observation_created_at",
         "fill_observations",
         [sa.text("created_at DESC"), sa.text("id DESC")],
+        schema=_SCHEMA,
+    )
+
+    op.create_table(
+        "fill_settlement_enrichments",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("fill_observation_id", sa.BigInteger(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("settlement_hash", sa.String(64), nullable=False),
+        sa.Column("cumulative_quantity", sa.Numeric(38, 18), nullable=True),
+        sa.Column("reported_fill_quantity", sa.Numeric(38, 18), nullable=True),
+        sa.Column("average_price", sa.Numeric(38, 18), nullable=True),
+        sa.Column("last_fill_price", sa.Numeric(38, 18), nullable=True),
+        sa.Column("cumulative_notional", sa.Numeric(38, 18), nullable=True),
+        sa.Column("fee_total", sa.Numeric(38, 18), nullable=True),
+        sa.Column("filled_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("evidence_source", sa.String(64), nullable=False),
+        sa.Column("evidence_ref", sa.Text(), nullable=False),
+        sa.Column("observed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["fill_observation_id"],
+            ["review.fill_observations.id"],
+            ondelete="RESTRICT",
+            name="fk_fill_settlement_enrichment_observation",
+        ),
+        sa.UniqueConstraint(
+            "fill_observation_id",
+            "revision",
+            name="uq_fill_settlement_enrichment_revision",
+        ),
+        sa.CheckConstraint(
+            f"settlement_hash ~ '{_SHA256}'",
+            name=op.f("ck_fill_settlement_enrichment_hash"),
+        ),
+        sa.CheckConstraint(
+            "revision >= 1",
+            name=op.f("ck_fill_settlement_enrichment_revision"),
+        ),
+        sa.CheckConstraint(
+            "(cumulative_quantity IS NULL OR cumulative_quantity > 0) "
+            "AND (reported_fill_quantity IS NULL "
+            "OR reported_fill_quantity >= 0) "
+            "AND (average_price IS NULL OR average_price > 0) "
+            "AND (last_fill_price IS NULL OR last_fill_price > 0) "
+            "AND (cumulative_notional IS NULL OR cumulative_notional >= 0) "
+            "AND (fee_total IS NULL OR fee_total >= 0)",
+            name=op.f("ck_fill_settlement_enrichment_economics"),
+        ),
+        sa.CheckConstraint(
+            "btrim(evidence_source) <> '' AND btrim(evidence_ref) <> ''",
+            name=op.f("ck_fill_settlement_enrichment_nonblank_evidence"),
+        ),
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_fill_settlement_enrichment_latest",
+        "fill_settlement_enrichments",
+        ["fill_observation_id", sa.text("revision DESC")],
         schema=_SCHEMA,
     )
 
@@ -334,6 +409,21 @@ def downgrade() -> None:
         schema=_SCHEMA,
     )
     op.drop_table("fill_projection_outbox", schema=_SCHEMA)
+    op.execute(
+        "DROP TRIGGER IF EXISTS "
+        "trg_fill_settlement_enrichments_truncate_immutable "
+        "ON review.fill_settlement_enrichments"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_fill_settlement_enrichments_immutable "
+        "ON review.fill_settlement_enrichments"
+    )
+    op.drop_index(
+        "ix_fill_settlement_enrichment_latest",
+        table_name="fill_settlement_enrichments",
+        schema=_SCHEMA,
+    )
+    op.drop_table("fill_settlement_enrichments", schema=_SCHEMA)
     op.execute(
         "DROP TRIGGER IF EXISTS trg_fill_observations_truncate_immutable "
         "ON review.fill_observations"

--- a/alembic/versions/20260801_rob1195_fill_observation_foundation.py
+++ b/alembic/versions/20260801_rob1195_fill_observation_foundation.py
@@ -1,0 +1,356 @@
+"""ROB-1195 immutable fill observation and projection foundation.
+
+Revision ID: 20260801_rob1195_fillobs
+Revises: 20260728_rob1109_watch_intent
+Create Date: 2026-08-01
+
+This migration is additive and intentionally performs no backfill or consumer
+cutover. Existing broker-native ledgers and ``review.trades`` remain intact.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260801_rob1195_fillobs"
+down_revision: str | Sequence[str] | None = "20260728_rob1109_watch_intent"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SCHEMA = "review"
+_SHA256 = "^[0-9a-f]{64}$"
+
+_IMMUTABILITY_DDL = (
+    """
+    CREATE OR REPLACE FUNCTION review.reject_fill_observation_mutation()
+    RETURNS trigger AS $$
+    BEGIN
+        RAISE EXCEPTION
+            'review.fill_observations is append-only/immutable; % rejected',
+            TG_OP
+            USING ERRCODE = 'restrict_violation';
+    END;
+    $$ LANGUAGE plpgsql
+    """,
+    """
+    CREATE TRIGGER trg_fill_observations_immutable
+    BEFORE UPDATE OR DELETE ON review.fill_observations
+    FOR EACH ROW EXECUTE FUNCTION review.reject_fill_observation_mutation()
+    """,
+    """
+    CREATE TRIGGER trg_fill_observations_truncate_immutable
+    BEFORE TRUNCATE ON review.fill_observations
+    FOR EACH STATEMENT EXECUTE FUNCTION
+        review.reject_fill_observation_mutation()
+    """,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fill_observations",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("observation_identity", sa.String(64), nullable=False),
+        sa.Column("identity_kind", sa.String(32), nullable=False),
+        sa.Column("broker", sa.String(32), nullable=False),
+        sa.Column("account_ref", sa.String(128), nullable=False),
+        sa.Column("account_mode", sa.String(32), nullable=False),
+        sa.Column("venue", sa.String(64), nullable=False),
+        sa.Column("order_id", sa.String(128), nullable=False),
+        sa.Column(
+            "instrument_type",
+            postgresql.ENUM(name="instrument_type", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("side", sa.String(8), nullable=False),
+        sa.Column("currency", sa.String(16), nullable=False),
+        sa.Column("broker_fill_sequence", sa.String(128), nullable=True),
+        sa.Column("cumulative_quantity", sa.Numeric(38, 18), nullable=True),
+        sa.Column("reported_fill_quantity", sa.Numeric(38, 18), nullable=True),
+        sa.Column("fill_delta_quantity", sa.Numeric(38, 18), nullable=False),
+        sa.Column("average_price", sa.Numeric(38, 18), nullable=True),
+        sa.Column("last_fill_price", sa.Numeric(38, 18), nullable=True),
+        sa.Column("cumulative_notional", sa.Numeric(38, 18), nullable=True),
+        sa.Column("fee_total", sa.Numeric(38, 18), nullable=True),
+        sa.Column("evidence_source", sa.String(64), nullable=False),
+        sa.Column("evidence_ref", sa.Text(), nullable=False),
+        sa.Column("evidence_hash", sa.String(64), nullable=False),
+        sa.Column("observed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("filled_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "observation_identity",
+            name="uq_fill_observation_identity",
+        ),
+        sa.CheckConstraint(
+            f"observation_identity ~ '{_SHA256}' AND evidence_hash ~ '{_SHA256}'",
+            name=op.f("ck_fill_observation_hashes"),
+        ),
+        sa.CheckConstraint(
+            "identity_kind IN ('broker_fill_sequence','cumulative_quantity')",
+            name=op.f("ck_fill_observation_identity_kind"),
+        ),
+        sa.CheckConstraint(
+            "(identity_kind = 'broker_fill_sequence' "
+            "AND broker_fill_sequence IS NOT NULL "
+            "AND btrim(broker_fill_sequence) <> '') "
+            "OR (identity_kind = 'cumulative_quantity' "
+            "AND broker_fill_sequence IS NULL "
+            "AND cumulative_quantity IS NOT NULL)",
+            name=op.f("ck_fill_observation_identity_source"),
+        ),
+        sa.CheckConstraint(
+            "fill_delta_quantity > 0 "
+            "AND (cumulative_quantity IS NULL OR cumulative_quantity > 0) "
+            "AND (reported_fill_quantity IS NULL "
+            "OR reported_fill_quantity >= 0)",
+            name=op.f("ck_fill_observation_positive_quantity"),
+        ),
+        sa.CheckConstraint(
+            "(average_price IS NULL OR average_price > 0) "
+            "AND (last_fill_price IS NULL OR last_fill_price > 0) "
+            "AND (cumulative_notional IS NULL OR cumulative_notional >= 0) "
+            "AND (fee_total IS NULL OR fee_total >= 0)",
+            name=op.f("ck_fill_observation_nonnegative_economics"),
+        ),
+        sa.CheckConstraint(
+            "side IN ('buy','sell')",
+            name=op.f("ck_fill_observation_side"),
+        ),
+        sa.CheckConstraint(
+            "btrim(broker) <> '' AND btrim(account_ref) <> '' "
+            "AND btrim(account_mode) <> '' AND btrim(venue) <> '' "
+            "AND btrim(order_id) <> '' AND btrim(symbol) <> '' "
+            "AND btrim(currency) <> '' AND btrim(evidence_source) <> '' "
+            "AND btrim(evidence_ref) <> ''",
+            name=op.f("ck_fill_observation_nonblank_scope"),
+        ),
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_fill_observation_order_stream",
+        "fill_observations",
+        ["broker", "account_ref", "order_id", "id"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_fill_observation_created_at",
+        "fill_observations",
+        [sa.text("created_at DESC"), sa.text("id DESC")],
+        schema=_SCHEMA,
+    )
+
+    op.create_table(
+        "fill_projection_outbox",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("delivery_key", sa.String(64), nullable=False),
+        sa.Column("projection_name", sa.String(128), nullable=False),
+        sa.Column("partition_key", sa.String(64), nullable=False),
+        sa.Column("fill_observation_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "state",
+            sa.String(16),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "attempt_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "available_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "lease_token",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("lease_expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["fill_observation_id"],
+            ["review.fill_observations.id"],
+            ondelete="RESTRICT",
+            name="fk_fill_projection_outbox_observation",
+        ),
+        sa.UniqueConstraint(
+            "delivery_key",
+            name="uq_fill_projection_outbox_delivery_key",
+        ),
+        sa.UniqueConstraint(
+            "projection_name",
+            "fill_observation_id",
+            name="uq_fill_projection_outbox_observation",
+        ),
+        sa.CheckConstraint(
+            f"delivery_key ~ '{_SHA256}' AND partition_key ~ '{_SHA256}'",
+            name=op.f("ck_fill_projection_outbox_hashes"),
+        ),
+        sa.CheckConstraint(
+            "state IN ('pending','processing','retry','succeeded')",
+            name=op.f("ck_fill_projection_outbox_state"),
+        ),
+        sa.CheckConstraint(
+            "attempt_count >= 0",
+            name=op.f("ck_fill_projection_outbox_attempt_count"),
+        ),
+        sa.CheckConstraint(
+            "(state = 'processing' AND lease_token IS NOT NULL "
+            "AND lease_expires_at IS NOT NULL) "
+            "OR (state <> 'processing' AND lease_token IS NULL "
+            "AND lease_expires_at IS NULL)",
+            name=op.f("ck_fill_projection_outbox_lease"),
+        ),
+        sa.CheckConstraint(
+            "(state = 'succeeded' AND completed_at IS NOT NULL) "
+            "OR (state <> 'succeeded' AND completed_at IS NULL)",
+            name=op.f("ck_fill_projection_outbox_completion"),
+        ),
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_fill_projection_outbox_ready",
+        "fill_projection_outbox",
+        ["projection_name", "state", "available_at", "fill_observation_id"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_fill_projection_outbox_partition",
+        "fill_projection_outbox",
+        ["projection_name", "partition_key", "fill_observation_id"],
+        schema=_SCHEMA,
+    )
+
+    op.create_table(
+        "fill_projection_cursors",
+        sa.Column("projection_name", sa.String(128), primary_key=True),
+        sa.Column("partition_key", sa.String(64), primary_key=True),
+        sa.Column("last_fill_observation_id", sa.BigInteger(), nullable=False),
+        sa.Column("last_observation_identity", sa.String(64), nullable=False),
+        sa.Column(
+            "advanced_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["last_fill_observation_id"],
+            ["review.fill_observations.id"],
+            ondelete="RESTRICT",
+            name="fk_fill_projection_cursor_observation",
+        ),
+        sa.CheckConstraint(
+            f"partition_key ~ '{_SHA256}' AND last_observation_identity ~ '{_SHA256}'",
+            name=op.f("ck_fill_projection_cursor_hashes"),
+        ),
+        sa.CheckConstraint(
+            "btrim(projection_name) <> ''",
+            name=op.f("ck_fill_projection_cursor_projection_name"),
+        ),
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_fill_projection_cursor_observation",
+        "fill_projection_cursors",
+        ["last_fill_observation_id"],
+        schema=_SCHEMA,
+    )
+
+    for statement in _IMMUTABILITY_DDL:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    # Operational rollback is writer-off, never observation deletion. Refuse a
+    # schema downgrade after authority rows exist so audit evidence survives.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM review.fill_observations) THEN
+                RAISE EXCEPTION
+                    'cannot downgrade: review.fill_observations contains immutable evidence';
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.drop_index(
+        "ix_fill_projection_cursor_observation",
+        table_name="fill_projection_cursors",
+        schema=_SCHEMA,
+    )
+    op.drop_table("fill_projection_cursors", schema=_SCHEMA)
+    op.drop_index(
+        "ix_fill_projection_outbox_partition",
+        table_name="fill_projection_outbox",
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "ix_fill_projection_outbox_ready",
+        table_name="fill_projection_outbox",
+        schema=_SCHEMA,
+    )
+    op.drop_table("fill_projection_outbox", schema=_SCHEMA)
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_fill_observations_truncate_immutable "
+        "ON review.fill_observations"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_fill_observations_immutable "
+        "ON review.fill_observations"
+    )
+    op.execute("DROP FUNCTION IF EXISTS review.reject_fill_observation_mutation()")
+    op.drop_index(
+        "ix_fill_observation_created_at",
+        table_name="fill_observations",
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "ix_fill_observation_order_stream",
+        table_name="fill_observations",
+        schema=_SCHEMA,
+    )
+    op.drop_table("fill_observations", schema=_SCHEMA)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,11 @@ from .crypto_insight_snapshot import CryptoInsightSnapshot
 from .crypto_instrument_health import CryptoInstrumentHealth
 from .crypto_instruments import CryptoInstrument
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
+from .fill_observation import (
+    FillObservation,
+    FillProjectionCursor,
+    FillProjectionOutbox,
+)
 from .financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
 from .invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
 from .invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
@@ -164,6 +169,9 @@ __all__ = [
     "ScalpingReviewAction",
     "ExecutionLedger",
     "ExecutionLedgerReconcileRun",
+    "FillObservation",
+    "FillProjectionCursor",
+    "FillProjectionOutbox",
     "CryptoCandle1d",
     "CryptoCandle1m",
     "CryptoInsightSnapshot",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -13,6 +13,7 @@ from .fill_observation import (
     FillObservation,
     FillProjectionCursor,
     FillProjectionOutbox,
+    FillSettlementEnrichment,
 )
 from .financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
 from .invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
@@ -172,6 +173,7 @@ __all__ = [
     "FillObservation",
     "FillProjectionCursor",
     "FillProjectionOutbox",
+    "FillSettlementEnrichment",
     "CryptoCandle1d",
     "CryptoCandle1m",
     "CryptoInsightSnapshot",

--- a/app/models/fill_observation.py
+++ b/app/models/fill_observation.py
@@ -1,0 +1,302 @@
+"""Immutable broker fill observations and durable projection state (ROB-1195)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.schema import conv
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+from app.models.trading import InstrumentType
+
+FILL_OBSERVATION_IDENTITY_KINDS: tuple[str, ...] = (
+    "broker_fill_sequence",
+    "cumulative_quantity",
+)
+FILL_PROJECTION_OUTBOX_STATES: tuple[str, ...] = (
+    "pending",
+    "processing",
+    "retry",
+    "succeeded",
+)
+
+_SHA256_PATTERN = "^[0-9a-f]{64}$"
+_IDENTITY_KINDS_SQL = ",".join(
+    f"'{value}'" for value in FILL_OBSERVATION_IDENTITY_KINDS
+)
+_OUTBOX_STATES_SQL = ",".join(f"'{value}'" for value in FILL_PROJECTION_OUTBOX_STATES)
+
+
+class FillObservation(Base):
+    """One positive fill delta proven by broker evidence.
+
+    Rows are append-only at the database boundary. Re-observing an existing
+    identity is handled by the service and never creates a second row.
+    """
+
+    __tablename__ = "fill_observations"
+    __table_args__ = (
+        UniqueConstraint(
+            "observation_identity",
+            name="uq_fill_observation_identity",
+        ),
+        CheckConstraint(
+            f"observation_identity ~ '{_SHA256_PATTERN}' "
+            f"AND evidence_hash ~ '{_SHA256_PATTERN}'",
+            name=conv("ck_fill_observation_hashes"),
+        ),
+        CheckConstraint(
+            f"identity_kind IN ({_IDENTITY_KINDS_SQL})",
+            name=conv("ck_fill_observation_identity_kind"),
+        ),
+        CheckConstraint(
+            "(identity_kind = 'broker_fill_sequence' "
+            "AND broker_fill_sequence IS NOT NULL "
+            "AND btrim(broker_fill_sequence) <> '') "
+            "OR (identity_kind = 'cumulative_quantity' "
+            "AND broker_fill_sequence IS NULL "
+            "AND cumulative_quantity IS NOT NULL)",
+            name=conv("ck_fill_observation_identity_source"),
+        ),
+        CheckConstraint(
+            "fill_delta_quantity > 0 "
+            "AND (cumulative_quantity IS NULL OR cumulative_quantity > 0) "
+            "AND (reported_fill_quantity IS NULL "
+            "OR reported_fill_quantity >= 0)",
+            name=conv("ck_fill_observation_positive_quantity"),
+        ),
+        CheckConstraint(
+            "(average_price IS NULL OR average_price > 0) "
+            "AND (last_fill_price IS NULL OR last_fill_price > 0) "
+            "AND (cumulative_notional IS NULL OR cumulative_notional >= 0) "
+            "AND (fee_total IS NULL OR fee_total >= 0)",
+            name=conv("ck_fill_observation_nonnegative_economics"),
+        ),
+        CheckConstraint(
+            "side IN ('buy','sell')",
+            name=conv("ck_fill_observation_side"),
+        ),
+        CheckConstraint(
+            "btrim(broker) <> '' AND btrim(account_ref) <> '' "
+            "AND btrim(account_mode) <> '' AND btrim(venue) <> '' "
+            "AND btrim(order_id) <> '' AND btrim(symbol) <> '' "
+            "AND btrim(currency) <> '' AND btrim(evidence_source) <> '' "
+            "AND btrim(evidence_ref) <> ''",
+            name=conv("ck_fill_observation_nonblank_scope"),
+        ),
+        Index(
+            "ix_fill_observation_order_stream",
+            "broker",
+            "account_ref",
+            "order_id",
+            "id",
+        ),
+        Index(
+            "ix_fill_observation_created_at",
+            text("created_at DESC"),
+            text("id DESC"),
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    observation_identity: Mapped[str] = mapped_column(String(64), nullable=False)
+    identity_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    broker: Mapped[str] = mapped_column(String(32), nullable=False)
+    account_ref: Mapped[str] = mapped_column(String(128), nullable=False)
+    account_mode: Mapped[str] = mapped_column(String(32), nullable=False)
+    venue: Mapped[str] = mapped_column(String(64), nullable=False)
+    order_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False),
+        nullable=False,
+    )
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    side: Mapped[str] = mapped_column(String(8), nullable=False)
+    currency: Mapped[str] = mapped_column(String(16), nullable=False)
+    broker_fill_sequence: Mapped[str | None] = mapped_column(String(128))
+    cumulative_quantity: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    reported_fill_quantity: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    fill_delta_quantity: Mapped[Decimal] = mapped_column(
+        Numeric(38, 18), nullable=False
+    )
+    average_price: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    last_fill_price: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    cumulative_notional: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    fee_total: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    evidence_source: Mapped[str] = mapped_column(String(64), nullable=False)
+    evidence_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    evidence_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    observed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    filled_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    correlation_id: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class FillProjectionOutbox(Base):
+    """Durable per-projection delivery state for one fill observation."""
+
+    __tablename__ = "fill_projection_outbox"
+    __table_args__ = (
+        UniqueConstraint(
+            "delivery_key",
+            name="uq_fill_projection_outbox_delivery_key",
+        ),
+        UniqueConstraint(
+            "projection_name",
+            "fill_observation_id",
+            name="uq_fill_projection_outbox_observation",
+        ),
+        CheckConstraint(
+            f"delivery_key ~ '{_SHA256_PATTERN}' "
+            f"AND partition_key ~ '{_SHA256_PATTERN}'",
+            name=conv("ck_fill_projection_outbox_hashes"),
+        ),
+        CheckConstraint(
+            f"state IN ({_OUTBOX_STATES_SQL})",
+            name=conv("ck_fill_projection_outbox_state"),
+        ),
+        CheckConstraint(
+            "attempt_count >= 0",
+            name=conv("ck_fill_projection_outbox_attempt_count"),
+        ),
+        CheckConstraint(
+            "(state = 'processing' AND lease_token IS NOT NULL "
+            "AND lease_expires_at IS NOT NULL) "
+            "OR (state <> 'processing' AND lease_token IS NULL "
+            "AND lease_expires_at IS NULL)",
+            name=conv("ck_fill_projection_outbox_lease"),
+        ),
+        CheckConstraint(
+            "(state = 'succeeded' AND completed_at IS NOT NULL) "
+            "OR (state <> 'succeeded' AND completed_at IS NULL)",
+            name=conv("ck_fill_projection_outbox_completion"),
+        ),
+        Index(
+            "ix_fill_projection_outbox_ready",
+            "projection_name",
+            "state",
+            "available_at",
+            "fill_observation_id",
+        ),
+        Index(
+            "ix_fill_projection_outbox_partition",
+            "projection_name",
+            "partition_key",
+            "fill_observation_id",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    delivery_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    projection_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    partition_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    fill_observation_id: Mapped[int] = mapped_column(
+        ForeignKey(
+            "review.fill_observations.id",
+            ondelete="RESTRICT",
+            name="fk_fill_projection_outbox_observation",
+        ),
+        nullable=False,
+    )
+    state: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'pending'")
+    )
+    attempt_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    available_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    lease_token: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    lease_expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    last_error: Mapped[str | None] = mapped_column(Text)
+    completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class FillProjectionCursor(Base):
+    """Last atomically completed observation for a projection partition."""
+
+    __tablename__ = "fill_projection_cursors"
+    __table_args__ = (
+        CheckConstraint(
+            f"partition_key ~ '{_SHA256_PATTERN}' "
+            f"AND last_observation_identity ~ '{_SHA256_PATTERN}'",
+            name=conv("ck_fill_projection_cursor_hashes"),
+        ),
+        CheckConstraint(
+            "btrim(projection_name) <> ''",
+            name=conv("ck_fill_projection_cursor_projection_name"),
+        ),
+        Index(
+            "ix_fill_projection_cursor_observation",
+            "last_fill_observation_id",
+        ),
+        {"schema": "review"},
+    )
+
+    projection_name: Mapped[str] = mapped_column(String(128), primary_key=True)
+    partition_key: Mapped[str] = mapped_column(String(64), primary_key=True)
+    last_fill_observation_id: Mapped[int] = mapped_column(
+        ForeignKey(
+            "review.fill_observations.id",
+            ondelete="RESTRICT",
+            name="fk_fill_projection_cursor_observation",
+        ),
+        nullable=False,
+    )
+    last_observation_identity: Mapped[str] = mapped_column(String(64), nullable=False)
+    advanced_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+__all__ = [
+    "FILL_OBSERVATION_IDENTITY_KINDS",
+    "FILL_PROJECTION_OUTBOX_STATES",
+    "FillObservation",
+    "FillProjectionCursor",
+    "FillProjectionOutbox",
+]

--- a/app/models/fill_observation.py
+++ b/app/models/fill_observation.py
@@ -51,6 +51,10 @@ class FillObservation(Base):
 
     Rows are append-only at the database boundary. Re-observing an existing
     identity is handled by the service and never creates a second row.
+
+    The economic columns hold the settlement values as they were first observed
+    and never change. Later provider revisions are appended to
+    ``review.fill_settlement_enrichments`` instead of mutating this row.
     """
 
     __tablename__ = "fill_observations"
@@ -61,7 +65,7 @@ class FillObservation(Base):
         ),
         CheckConstraint(
             f"observation_identity ~ '{_SHA256_PATTERN}' "
-            f"AND evidence_hash ~ '{_SHA256_PATTERN}'",
+            f"AND fill_fact_hash ~ '{_SHA256_PATTERN}'",
             name=conv("ck_fill_observation_hashes"),
         ),
         CheckConstraint(
@@ -145,12 +149,86 @@ class FillObservation(Base):
     fee_total: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
     evidence_source: Mapped[str] = mapped_column(String(64), nullable=False)
     evidence_ref: Mapped[str] = mapped_column(Text, nullable=False)
-    evidence_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    fill_fact_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     observed_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False
     )
     filled_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     correlation_id: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class FillSettlementEnrichment(Base):
+    """One durable revision of the post-trade values for a recorded fill.
+
+    Rows are append-only, so the full provider revision history is retained.
+    ``revision`` is dense and 1-based per observation; the highest revision is
+    the latest settlement the provider reported. A repeated poll whose values
+    equal the latest revision appends nothing.
+    """
+
+    __tablename__ = "fill_settlement_enrichments"
+    __table_args__ = (
+        UniqueConstraint(
+            "fill_observation_id",
+            "revision",
+            name="uq_fill_settlement_enrichment_revision",
+        ),
+        CheckConstraint(
+            f"settlement_hash ~ '{_SHA256_PATTERN}'",
+            name=conv("ck_fill_settlement_enrichment_hash"),
+        ),
+        CheckConstraint(
+            "revision >= 1",
+            name=conv("ck_fill_settlement_enrichment_revision"),
+        ),
+        CheckConstraint(
+            "(cumulative_quantity IS NULL OR cumulative_quantity > 0) "
+            "AND (reported_fill_quantity IS NULL "
+            "OR reported_fill_quantity >= 0) "
+            "AND (average_price IS NULL OR average_price > 0) "
+            "AND (last_fill_price IS NULL OR last_fill_price > 0) "
+            "AND (cumulative_notional IS NULL OR cumulative_notional >= 0) "
+            "AND (fee_total IS NULL OR fee_total >= 0)",
+            name=conv("ck_fill_settlement_enrichment_economics"),
+        ),
+        CheckConstraint(
+            "btrim(evidence_source) <> '' AND btrim(evidence_ref) <> ''",
+            name=conv("ck_fill_settlement_enrichment_nonblank_evidence"),
+        ),
+        Index(
+            "ix_fill_settlement_enrichment_latest",
+            "fill_observation_id",
+            text("revision DESC"),
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    fill_observation_id: Mapped[int] = mapped_column(
+        ForeignKey(
+            "review.fill_observations.id",
+            ondelete="RESTRICT",
+            name="fk_fill_settlement_enrichment_observation",
+        ),
+        nullable=False,
+    )
+    revision: Mapped[int] = mapped_column(Integer, nullable=False)
+    settlement_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    cumulative_quantity: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    reported_fill_quantity: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    average_price: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    last_fill_price: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    cumulative_notional: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    fee_total: Mapped[Decimal | None] = mapped_column(Numeric(38, 18))
+    filled_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    evidence_source: Mapped[str] = mapped_column(String(64), nullable=False)
+    evidence_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    observed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
@@ -299,4 +377,5 @@ __all__ = [
     "FillObservation",
     "FillProjectionCursor",
     "FillProjectionOutbox",
+    "FillSettlementEnrichment",
 ]

--- a/app/services/fill_observation/__init__.py
+++ b/app/services/fill_observation/__init__.py
@@ -1,0 +1,49 @@
+"""Broker-evidenced immutable fill observation foundation (ROB-1195)."""
+
+from app.services.fill_observation.contracts import (
+    BrokerFillEvidence,
+    FillDualReadStatus,
+    FillDualReadValidation,
+    FillObservationWriteResult,
+    FillObservationWriteStatus,
+    FillProjectionDelivery,
+)
+from app.services.fill_observation.dual_read import FillObservationDualReader
+from app.services.fill_observation.errors import (
+    FillObservationError,
+    FillObservationIdentityConflict,
+    FillProjectionCursorRegression,
+    FillProjectionDeliveryError,
+    FillProjectionLeaseMismatch,
+    InvalidFillEvidence,
+    NonMonotonicFillCumulative,
+)
+from app.services.fill_observation.projection import FillProjectionQueue
+from app.services.fill_observation.writer import (
+    DEFAULT_FILL_PROJECTIONS,
+    FILL_OBSERVATION_WRITER_ENABLED_ENV,
+    FillObservationWriter,
+    fill_observation_writer_enabled,
+)
+
+__all__ = [
+    "DEFAULT_FILL_PROJECTIONS",
+    "FILL_OBSERVATION_WRITER_ENABLED_ENV",
+    "BrokerFillEvidence",
+    "FillDualReadStatus",
+    "FillDualReadValidation",
+    "FillObservationDualReader",
+    "FillObservationError",
+    "FillObservationIdentityConflict",
+    "FillObservationWriteResult",
+    "FillObservationWriteStatus",
+    "FillObservationWriter",
+    "FillProjectionDelivery",
+    "FillProjectionCursorRegression",
+    "FillProjectionDeliveryError",
+    "FillProjectionLeaseMismatch",
+    "FillProjectionQueue",
+    "InvalidFillEvidence",
+    "NonMonotonicFillCumulative",
+    "fill_observation_writer_enabled",
+]

--- a/app/services/fill_observation/__init__.py
+++ b/app/services/fill_observation/__init__.py
@@ -7,6 +7,8 @@ from app.services.fill_observation.contracts import (
     FillObservationWriteResult,
     FillObservationWriteStatus,
     FillProjectionDelivery,
+    FillSettlementStatus,
+    NormalizedFillSettlement,
 )
 from app.services.fill_observation.dual_read import FillObservationDualReader
 from app.services.fill_observation.errors import (
@@ -43,7 +45,9 @@ __all__ = [
     "FillProjectionDeliveryError",
     "FillProjectionLeaseMismatch",
     "FillProjectionQueue",
+    "FillSettlementStatus",
     "InvalidFillEvidence",
     "NonMonotonicFillCumulative",
+    "NormalizedFillSettlement",
     "fill_observation_writer_enabled",
 ]

--- a/app/services/fill_observation/contracts.py
+++ b/app/services/fill_observation/contracts.py
@@ -27,6 +27,20 @@ class FillDualReadStatus(StrEnum):
     EMPTY = "empty"
 
 
+class FillSettlementStatus(StrEnum):
+    """Outcome of the settlement-enrichment branch of one write.
+
+    Settlement values are post-trade corrections (fees, refined average price,
+    settled fill timestamp). They never mutate the immutable observation and
+    never create a second fill delta.
+    """
+
+    RECORDED = "recorded"
+    UNCHANGED = "unchanged"
+    ABSENT = "absent"
+    NOT_APPLICABLE = "not_applicable"
+
+
 @dataclass(frozen=True, slots=True)
 class BrokerFillEvidence:
     """Sanitized broker facts supplied by a future reconcile adapter.
@@ -85,10 +99,46 @@ class NormalizedBrokerFillEvidence:
 
 
 @dataclass(frozen=True, slots=True)
+class NormalizedFillSettlement:
+    """Post-trade values a provider may still revise for a settled fill.
+
+    These are deliberately outside ``fill_fact_hash``. A broker that returns a
+    late fee, a refined average price, or a corrected settlement timestamp for
+    an already recorded fill is reporting the same fill, not a contradiction.
+    """
+
+    settlement_hash: str
+    cumulative_quantity: Decimal | None
+    reported_fill_quantity: Decimal | None
+    average_price: Decimal | None
+    last_fill_price: Decimal | None
+    cumulative_notional: Decimal | None
+    fee_total: Decimal | None
+    filled_at: datetime | None
+
+    @property
+    def has_values(self) -> bool:
+        """Return whether the provider supplied any settlement value."""
+        return any(
+            value is not None
+            for value in (
+                self.cumulative_quantity,
+                self.reported_fill_quantity,
+                self.average_price,
+                self.last_fill_price,
+                self.cumulative_notional,
+                self.fee_total,
+                self.filled_at,
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class FillObservationIdentity:
     value: str
     kind: str
-    evidence_hash: str
+    fill_fact_hash: str
+    settlement: NormalizedFillSettlement
     order_lock_key: int
     partition_key: str
 
@@ -100,6 +150,8 @@ class FillObservationWriteResult:
     observation_id: int | None
     fill_delta_quantity: Decimal
     outbox_count: int
+    settlement_status: FillSettlementStatus = FillSettlementStatus.NOT_APPLICABLE
+    settlement_revision: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,5 +189,7 @@ __all__ = [
     "FillObservationWriteResult",
     "FillObservationWriteStatus",
     "FillProjectionDelivery",
+    "FillSettlementStatus",
     "NormalizedBrokerFillEvidence",
+    "NormalizedFillSettlement",
 ]

--- a/app/services/fill_observation/contracts.py
+++ b/app/services/fill_observation/contracts.py
@@ -1,0 +1,141 @@
+"""Typed service contracts for the ROB-1195 fill-observation boundary."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+
+from app.models.trading import InstrumentType
+
+
+class FillObservationWriteStatus(StrEnum):
+    INSERTED = "inserted"
+    DUPLICATE = "duplicate"
+    NO_DELTA = "no_delta"
+    NO_FILL_EVIDENCE = "no_fill_evidence"
+    WRITER_DISABLED = "writer_disabled"
+
+
+class FillDualReadStatus(StrEnum):
+    MATCH = "match"
+    MISMATCH = "mismatch"
+    NEW_ONLY = "new_only"
+    LEGACY_ONLY = "legacy_only"
+    EMPTY = "empty"
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerFillEvidence:
+    """Sanitized broker facts supplied by a future reconcile adapter.
+
+    The contract intentionally contains no broker client or raw response. The
+    stable ``evidence_ref`` points at retained broker/native-ledger evidence;
+    callers must not put credentials or an unredacted broker payload here.
+    """
+
+    broker: str
+    account_ref: str
+    account_mode: str
+    venue: str
+    order_id: str
+    instrument_type: InstrumentType | str
+    symbol: str
+    side: str
+    currency: str
+    evidence_source: str
+    evidence_ref: str
+    observed_at: datetime
+    broker_fill_sequence: str | None = None
+    cumulative_quantity: Decimal | int | str | None = None
+    fill_quantity: Decimal | int | str | None = None
+    average_price: Decimal | int | str | None = None
+    last_fill_price: Decimal | int | str | None = None
+    cumulative_notional: Decimal | int | str | None = None
+    fee_total: Decimal | int | str | None = None
+    filled_at: datetime | None = None
+    correlation_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBrokerFillEvidence:
+    broker: str
+    account_ref: str
+    account_mode: str
+    venue: str
+    order_id: str
+    instrument_type: InstrumentType
+    symbol: str
+    side: str
+    currency: str
+    evidence_source: str
+    evidence_ref: str
+    observed_at: datetime
+    broker_fill_sequence: str | None
+    cumulative_quantity: Decimal | None
+    fill_quantity: Decimal | None
+    average_price: Decimal | None
+    last_fill_price: Decimal | None
+    cumulative_notional: Decimal | None
+    fee_total: Decimal | None
+    filled_at: datetime | None
+    correlation_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class FillObservationIdentity:
+    value: str
+    kind: str
+    evidence_hash: str
+    order_lock_key: int
+    partition_key: str
+
+
+@dataclass(frozen=True, slots=True)
+class FillObservationWriteResult:
+    status: FillObservationWriteStatus
+    observation_identity: str | None
+    observation_id: int | None
+    fill_delta_quantity: Decimal
+    outbox_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class FillProjectionDelivery:
+    outbox_id: int
+    delivery_key: str
+    projection_name: str
+    partition_key: str
+    fill_observation_id: int
+    observation_identity: str
+    attempt_count: int
+    lease_token: uuid.UUID
+
+
+@dataclass(frozen=True, slots=True)
+class FillDualReadValidation:
+    broker: str
+    account_ref: str
+    account_mode: str
+    venue: str
+    order_id: str
+    observation_count: int
+    observation_quantity: Decimal
+    review_trade_quantity: Decimal | None
+    execution_ledger_quantity: Decimal | None
+    status: FillDualReadStatus
+    mismatched_sources: tuple[str, ...]
+
+
+__all__ = [
+    "BrokerFillEvidence",
+    "FillDualReadStatus",
+    "FillDualReadValidation",
+    "FillObservationIdentity",
+    "FillObservationWriteResult",
+    "FillObservationWriteStatus",
+    "FillProjectionDelivery",
+    "NormalizedBrokerFillEvidence",
+]

--- a/app/services/fill_observation/dual_read.py
+++ b/app/services/fill_observation/dual_read.py
@@ -1,0 +1,145 @@
+"""Read-only validation between fill observations and legacy projections."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal
+from app.models.execution_ledger import ExecutionLedger
+from app.models.fill_observation import FillObservation
+from app.models.review import Trade
+from app.services.fill_observation.contracts import (
+    FillDualReadStatus,
+    FillDualReadValidation,
+)
+from app.services.fill_observation.errors import InvalidFillEvidence
+
+
+def _scope_text(value: str, *, field: str, lower: bool = False) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise InvalidFillEvidence(f"{field} must not be blank")
+    return normalized.lower() if lower else normalized
+
+
+def _optional_decimal(value: object | None) -> Decimal | None:
+    return None if value is None else Decimal(str(value))
+
+
+def _classify_dual_read(
+    *,
+    observation_count: int,
+    observation_quantity: Decimal,
+    review_trade_quantity: Decimal | None,
+    execution_ledger_quantity: Decimal | None,
+) -> tuple[FillDualReadStatus, tuple[str, ...]]:
+    observation_present = observation_count > 0
+    legacy = {
+        "review.trades": review_trade_quantity,
+        "review.execution_ledger": execution_ledger_quantity,
+    }
+    legacy_present = any(value is not None for value in legacy.values())
+    if observation_present and legacy_present:
+        mismatches = tuple(
+            source
+            for source, quantity in legacy.items()
+            if quantity is not None and quantity != observation_quantity
+        )
+        return (
+            FillDualReadStatus.MISMATCH if mismatches else FillDualReadStatus.MATCH,
+            mismatches,
+        )
+    if observation_present:
+        return FillDualReadStatus.NEW_ONLY, ()
+    if legacy_present:
+        return FillDualReadStatus.LEGACY_ONLY, ()
+    return FillDualReadStatus.EMPTY, ()
+
+
+class FillObservationDualReader:
+    """Compare quantities without changing either read source."""
+
+    def __init__(
+        self,
+        session_factory: Callable[[], AsyncSession] = AsyncSessionLocal,
+    ) -> None:
+        self._session_factory = session_factory
+
+    async def validate_order(
+        self,
+        *,
+        broker: str,
+        account_ref: str,
+        account_mode: str,
+        venue: str,
+        order_id: str,
+    ) -> FillDualReadValidation:
+        normalized_broker = _scope_text(broker, field="broker", lower=True)
+        normalized_account = _scope_text(account_ref, field="account_ref")
+        normalized_mode = _scope_text(
+            account_mode,
+            field="account_mode",
+            lower=True,
+        )
+        normalized_venue = _scope_text(venue, field="venue", lower=True)
+        normalized_order = _scope_text(order_id, field="order_id")
+
+        async with self._session_factory() as session:
+            observation_result = await session.execute(
+                select(
+                    func.count(FillObservation.id),
+                    func.coalesce(
+                        func.sum(FillObservation.fill_delta_quantity),
+                        0,
+                    ),
+                )
+                .where(FillObservation.broker == normalized_broker)
+                .where(FillObservation.account_ref == normalized_account)
+                .where(FillObservation.account_mode == normalized_mode)
+                .where(FillObservation.venue == normalized_venue)
+                .where(FillObservation.order_id == normalized_order)
+            )
+            observation_count_raw, observation_quantity_raw = observation_result.one()
+            review_trade_quantity_raw = await session.scalar(
+                select(func.sum(Trade.quantity))
+                .where(Trade.account == normalized_account)
+                .where(Trade.order_id == normalized_order)
+            )
+            execution_ledger_quantity_raw = await session.scalar(
+                select(func.sum(ExecutionLedger.filled_qty))
+                .where(ExecutionLedger.broker == normalized_broker)
+                .where(ExecutionLedger.account_mode == normalized_mode)
+                .where(ExecutionLedger.venue == normalized_venue)
+                .where(ExecutionLedger.broker_order_id == normalized_order)
+            )
+
+        observation_count = int(observation_count_raw or 0)
+        observation_quantity = Decimal(str(observation_quantity_raw or 0))
+        review_trade_quantity = _optional_decimal(review_trade_quantity_raw)
+        execution_ledger_quantity = _optional_decimal(execution_ledger_quantity_raw)
+        status, mismatches = _classify_dual_read(
+            observation_count=observation_count,
+            observation_quantity=observation_quantity,
+            review_trade_quantity=review_trade_quantity,
+            execution_ledger_quantity=execution_ledger_quantity,
+        )
+        return FillDualReadValidation(
+            broker=normalized_broker,
+            account_ref=normalized_account,
+            account_mode=normalized_mode,
+            venue=normalized_venue,
+            order_id=normalized_order,
+            observation_count=observation_count,
+            observation_quantity=observation_quantity,
+            review_trade_quantity=review_trade_quantity,
+            execution_ledger_quantity=execution_ledger_quantity,
+            status=status,
+            mismatched_sources=mismatches,
+        )
+
+
+__all__ = ["FillObservationDualReader"]

--- a/app/services/fill_observation/errors.py
+++ b/app/services/fill_observation/errors.py
@@ -1,0 +1,40 @@
+"""Typed failures for fill observation persistence and projection delivery."""
+
+
+class FillObservationError(RuntimeError):
+    """Base error for the fill-observation service boundary."""
+
+
+class InvalidFillEvidence(FillObservationError):
+    """The supplied facts cannot prove a positive broker fill."""
+
+
+class FillObservationIdentityConflict(FillObservationError):
+    """A deterministic identity was reused with different semantic evidence."""
+
+
+class NonMonotonicFillCumulative(FillObservationError):
+    """Cumulative broker quantity regressed below already recorded deltas."""
+
+
+class FillProjectionDeliveryError(FillObservationError):
+    """Base error for outbox claim/completion operations."""
+
+
+class FillProjectionLeaseMismatch(FillProjectionDeliveryError):
+    """The requested completion/retry does not own the active delivery lease."""
+
+
+class FillProjectionCursorRegression(FillProjectionDeliveryError):
+    """A delivery attempted to move a projection cursor backwards."""
+
+
+__all__ = [
+    "FillObservationError",
+    "FillObservationIdentityConflict",
+    "FillProjectionCursorRegression",
+    "FillProjectionDeliveryError",
+    "FillProjectionLeaseMismatch",
+    "InvalidFillEvidence",
+    "NonMonotonicFillCumulative",
+]

--- a/app/services/fill_observation/identity.py
+++ b/app/services/fill_observation/identity.py
@@ -14,11 +14,13 @@ from app.services.fill_observation.contracts import (
     BrokerFillEvidence,
     FillObservationIdentity,
     NormalizedBrokerFillEvidence,
+    NormalizedFillSettlement,
 )
 from app.services.fill_observation.errors import InvalidFillEvidence
 
 _IDENTITY_SCHEMA = "fill_observation_identity.v1"
-_EVIDENCE_SCHEMA = "fill_observation_evidence.v1"
+_FILL_FACT_SCHEMA = "fill_observation_fill_fact.v1"
+_SETTLEMENT_SCHEMA = "fill_observation_settlement.v1"
 _ORDER_SCOPE_SCHEMA = "fill_observation_order_scope.v1"
 _PARTITION_SCHEMA = "fill_projection_partition.v1"
 _DELIVERY_SCHEMA = "fill_projection_delivery.v1"
@@ -113,7 +115,11 @@ def normalize_fill_evidence(
 
     symbol = _required_text(evidence.symbol, field="symbol")
     if instrument_type is InstrumentType.equity_us:
-        symbol = to_db_symbol(symbol)
+        # US tickers are canonically dot-separated upper case (``BRK.B``).
+        # Case drift between two polls of the same order is representation, not
+        # a different fill fact. Only this branch touches the symbol, so crypto
+        # (``KRW-BTC``), KR, forex, and index symbols keep their exact meaning.
+        symbol = to_db_symbol(symbol).upper()
 
     side = _required_text(evidence.side, field="side", lower=True)
     if side not in {"buy", "sell"}:
@@ -194,7 +200,22 @@ def has_positive_fill(evidence: NormalizedBrokerFillEvidence) -> bool:
 def derive_fill_observation_identity(
     evidence: NormalizedBrokerFillEvidence,
 ) -> FillObservationIdentity:
-    """Derive stable identity, evidence fingerprint, and lock keys."""
+    """Derive stable identity, fill-fact fingerprint, settlement, and locks.
+
+    ``fill_fact_hash`` covers only the stable broker fill fact: the order scope,
+    the instrument facts, and exactly the quantity the identity is keyed on. A
+    contradiction there is a real conflict and stays fail-closed with zero write.
+
+    Everything a provider legitimately revises after the fill — fees, average or
+    last price, notional, settled ``filled_at``, and the quantity field the
+    identity is *not* keyed on — is carried in a separate settlement payload with
+    its own hash. Those never enter ``fill_fact_hash``:
+
+    - Under sequence identity the same fill is re-observed later while the
+      order's cumulative quantity has legitimately grown.
+    - Under cumulative identity the per-poll reported increment is a snapshot of
+      that poll, not a property of the cumulative state.
+    """
     if evidence.broker_fill_sequence is not None:
         identity_kind = "broker_fill_sequence"
         identity_value = evidence.broker_fill_sequence
@@ -218,25 +239,21 @@ def derive_fill_observation_identity(
             "identity_value": identity_value,
         }
     )
-    evidence_hash = _sha256(
-        {
-            "schema": _EVIDENCE_SCHEMA,
-            "order_scope": order_scope,
-            "instrument_type": evidence.instrument_type.value,
-            "symbol": evidence.symbol,
-            "side": evidence.side,
-            "currency": evidence.currency,
-            "broker_fill_sequence": evidence.broker_fill_sequence,
-            "cumulative_quantity": _decimal_text(evidence.cumulative_quantity),
-            "fill_quantity": _decimal_text(evidence.fill_quantity),
-            "average_price": _decimal_text(evidence.average_price),
-            "last_fill_price": _decimal_text(evidence.last_fill_price),
-            "cumulative_notional": _decimal_text(evidence.cumulative_notional),
-            "fee_total": _decimal_text(evidence.fee_total),
-            "filled_at": _datetime_text(evidence.filled_at),
-            "evidence_source": evidence.evidence_source,
-        }
-    )
+    fill_fact: dict[str, Any] = {
+        "schema": _FILL_FACT_SCHEMA,
+        "order_scope": order_scope,
+        "instrument_type": evidence.instrument_type.value,
+        "symbol": evidence.symbol,
+        "side": evidence.side,
+        "currency": evidence.currency,
+        "identity_kind": identity_kind,
+        "identity_value": identity_value,
+    }
+    if identity_kind == "broker_fill_sequence":
+        # The reported quantity is that sequence's own delta, so it is a stable
+        # fact. Under cumulative identity it is a per-poll snapshot instead.
+        fill_fact["fill_quantity"] = _decimal_text(evidence.fill_quantity)
+    fill_fact_hash = _sha256(fill_fact)
     partition_key = _sha256(
         {
             "schema": _PARTITION_SCHEMA,
@@ -246,9 +263,49 @@ def derive_fill_observation_identity(
     return FillObservationIdentity(
         value=observation_identity,
         kind=identity_kind,
-        evidence_hash=evidence_hash,
+        fill_fact_hash=fill_fact_hash,
+        settlement=derive_fill_settlement(
+            evidence,
+            observation_identity=observation_identity,
+        ),
         order_lock_key=_stable_signed_int64(order_scope),
         partition_key=partition_key,
+    )
+
+
+def derive_fill_settlement(
+    evidence: NormalizedBrokerFillEvidence,
+    *,
+    observation_identity: str,
+) -> NormalizedFillSettlement:
+    """Fingerprint the revisable post-trade values of one observed fill.
+
+    ``evidence_source``, ``evidence_ref``, and ``observed_at`` are provenance of
+    the poll rather than settlement values, so they stay out of the hash. That
+    keeps a repeated poll of unchanged settlement idempotent instead of
+    appending a revision per poll.
+    """
+    return NormalizedFillSettlement(
+        settlement_hash=_sha256(
+            {
+                "schema": _SETTLEMENT_SCHEMA,
+                "observation_identity": observation_identity,
+                "cumulative_quantity": _decimal_text(evidence.cumulative_quantity),
+                "fill_quantity": _decimal_text(evidence.fill_quantity),
+                "average_price": _decimal_text(evidence.average_price),
+                "last_fill_price": _decimal_text(evidence.last_fill_price),
+                "cumulative_notional": _decimal_text(evidence.cumulative_notional),
+                "fee_total": _decimal_text(evidence.fee_total),
+                "filled_at": _datetime_text(evidence.filled_at),
+            }
+        ),
+        cumulative_quantity=evidence.cumulative_quantity,
+        reported_fill_quantity=evidence.fill_quantity,
+        average_price=evidence.average_price,
+        last_fill_price=evidence.last_fill_price,
+        cumulative_notional=evidence.cumulative_notional,
+        fee_total=evidence.fee_total,
+        filled_at=evidence.filled_at,
     )
 
 
@@ -278,6 +335,7 @@ def derive_projection_lock_key(*, projection_name: str, partition_key: str) -> i
 
 __all__ = [
     "derive_fill_observation_identity",
+    "derive_fill_settlement",
     "derive_projection_delivery_key",
     "derive_projection_lock_key",
     "has_positive_fill",

--- a/app/services/fill_observation/identity.py
+++ b/app/services/fill_observation/identity.py
@@ -1,0 +1,285 @@
+"""Deterministic identity and canonicalization for broker fill evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.core.symbol import to_db_symbol
+from app.models.trading import InstrumentType
+from app.services.fill_observation.contracts import (
+    BrokerFillEvidence,
+    FillObservationIdentity,
+    NormalizedBrokerFillEvidence,
+)
+from app.services.fill_observation.errors import InvalidFillEvidence
+
+_IDENTITY_SCHEMA = "fill_observation_identity.v1"
+_EVIDENCE_SCHEMA = "fill_observation_evidence.v1"
+_ORDER_SCOPE_SCHEMA = "fill_observation_order_scope.v1"
+_PARTITION_SCHEMA = "fill_projection_partition.v1"
+_DELIVERY_SCHEMA = "fill_projection_delivery.v1"
+_PROJECTION_LOCK_SCHEMA = "fill_projection_lock.v1"
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def _sha256(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+
+
+def _stable_signed_int64(payload: dict[str, Any]) -> int:
+    digest = hashlib.sha256(_canonical_bytes(payload)).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+def _required_text(value: object, *, field: str, lower: bool = False) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise InvalidFillEvidence(f"{field} must not be blank")
+    return normalized.lower() if lower else normalized
+
+
+def _optional_text(value: object | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if not normalized:
+        raise InvalidFillEvidence(f"{field} must not be blank when supplied")
+    return normalized
+
+
+def _decimal(
+    value: Decimal | int | str | None,
+    *,
+    field: str,
+    strictly_positive: bool = False,
+) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        normalized = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise InvalidFillEvidence(f"{field} must be a finite decimal") from exc
+    if not normalized.is_finite():
+        raise InvalidFillEvidence(f"{field} must be a finite decimal")
+    if strictly_positive and normalized <= 0:
+        raise InvalidFillEvidence(f"{field} must be greater than zero")
+    if not strictly_positive and normalized < 0:
+        raise InvalidFillEvidence(f"{field} must not be negative")
+    return normalized
+
+
+def _decimal_text(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    if value == 0:
+        return "0"
+    return format(value.normalize(), "f")
+
+
+def _aware_datetime(value: datetime | None, *, field: str) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise InvalidFillEvidence(f"{field} must be timezone-aware")
+    return value
+
+
+def _datetime_text(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(UTC).isoformat(timespec="microseconds")
+
+
+def normalize_fill_evidence(
+    evidence: BrokerFillEvidence,
+) -> NormalizedBrokerFillEvidence:
+    """Normalize only representation, never infer broker fill facts."""
+    try:
+        instrument_type = InstrumentType(str(evidence.instrument_type))
+    except ValueError as exc:
+        raise InvalidFillEvidence("instrument_type is not supported") from exc
+
+    symbol = _required_text(evidence.symbol, field="symbol")
+    if instrument_type is InstrumentType.equity_us:
+        symbol = to_db_symbol(symbol)
+
+    side = _required_text(evidence.side, field="side", lower=True)
+    if side not in {"buy", "sell"}:
+        raise InvalidFillEvidence("side must be buy or sell")
+
+    sequence = _optional_text(
+        evidence.broker_fill_sequence,
+        field="broker_fill_sequence",
+    )
+    cumulative_quantity = _decimal(
+        evidence.cumulative_quantity,
+        field="cumulative_quantity",
+    )
+    fill_quantity = _decimal(evidence.fill_quantity, field="fill_quantity")
+    if sequence is None and cumulative_quantity is None:
+        raise InvalidFillEvidence(
+            "broker_fill_sequence or cumulative_quantity is required"
+        )
+
+    return NormalizedBrokerFillEvidence(
+        broker=_required_text(evidence.broker, field="broker", lower=True),
+        account_ref=_required_text(evidence.account_ref, field="account_ref"),
+        account_mode=_required_text(
+            evidence.account_mode,
+            field="account_mode",
+            lower=True,
+        ),
+        venue=_required_text(evidence.venue, field="venue", lower=True),
+        order_id=_required_text(evidence.order_id, field="order_id"),
+        instrument_type=instrument_type,
+        symbol=symbol,
+        side=side,
+        currency=_required_text(evidence.currency, field="currency").upper(),
+        evidence_source=_required_text(
+            evidence.evidence_source,
+            field="evidence_source",
+            lower=True,
+        ),
+        evidence_ref=_required_text(evidence.evidence_ref, field="evidence_ref"),
+        observed_at=_aware_datetime(
+            evidence.observed_at,
+            field="observed_at",
+        ),
+        broker_fill_sequence=sequence,
+        cumulative_quantity=cumulative_quantity,
+        fill_quantity=fill_quantity,
+        average_price=_decimal(
+            evidence.average_price,
+            field="average_price",
+            strictly_positive=True,
+        ),
+        last_fill_price=_decimal(
+            evidence.last_fill_price,
+            field="last_fill_price",
+            strictly_positive=True,
+        ),
+        cumulative_notional=_decimal(
+            evidence.cumulative_notional,
+            field="cumulative_notional",
+        ),
+        fee_total=_decimal(evidence.fee_total, field="fee_total"),
+        filled_at=_aware_datetime(evidence.filled_at, field="filled_at"),
+        correlation_id=_optional_text(
+            evidence.correlation_id,
+            field="correlation_id",
+        ),
+    )
+
+
+def has_positive_fill(evidence: NormalizedBrokerFillEvidence) -> bool:
+    """Return whether the typed facts prove any positive filled quantity."""
+    return bool(
+        (evidence.cumulative_quantity or Decimal(0)) > 0
+        or (evidence.fill_quantity or Decimal(0)) > 0
+    )
+
+
+def derive_fill_observation_identity(
+    evidence: NormalizedBrokerFillEvidence,
+) -> FillObservationIdentity:
+    """Derive stable identity, evidence fingerprint, and lock keys."""
+    if evidence.broker_fill_sequence is not None:
+        identity_kind = "broker_fill_sequence"
+        identity_value = evidence.broker_fill_sequence
+    else:
+        identity_kind = "cumulative_quantity"
+        identity_value = _decimal_text(evidence.cumulative_quantity)
+
+    order_scope = {
+        "schema": _ORDER_SCOPE_SCHEMA,
+        "broker": evidence.broker,
+        "account_ref": evidence.account_ref,
+        "account_mode": evidence.account_mode,
+        "venue": evidence.venue,
+        "order_id": evidence.order_id,
+    }
+    observation_identity = _sha256(
+        {
+            "schema": _IDENTITY_SCHEMA,
+            "order_scope": order_scope,
+            "identity_kind": identity_kind,
+            "identity_value": identity_value,
+        }
+    )
+    evidence_hash = _sha256(
+        {
+            "schema": _EVIDENCE_SCHEMA,
+            "order_scope": order_scope,
+            "instrument_type": evidence.instrument_type.value,
+            "symbol": evidence.symbol,
+            "side": evidence.side,
+            "currency": evidence.currency,
+            "broker_fill_sequence": evidence.broker_fill_sequence,
+            "cumulative_quantity": _decimal_text(evidence.cumulative_quantity),
+            "fill_quantity": _decimal_text(evidence.fill_quantity),
+            "average_price": _decimal_text(evidence.average_price),
+            "last_fill_price": _decimal_text(evidence.last_fill_price),
+            "cumulative_notional": _decimal_text(evidence.cumulative_notional),
+            "fee_total": _decimal_text(evidence.fee_total),
+            "filled_at": _datetime_text(evidence.filled_at),
+            "evidence_source": evidence.evidence_source,
+        }
+    )
+    partition_key = _sha256(
+        {
+            "schema": _PARTITION_SCHEMA,
+            "order_scope": order_scope,
+        }
+    )
+    return FillObservationIdentity(
+        value=observation_identity,
+        kind=identity_kind,
+        evidence_hash=evidence_hash,
+        order_lock_key=_stable_signed_int64(order_scope),
+        partition_key=partition_key,
+    )
+
+
+def derive_projection_delivery_key(
+    *,
+    projection_name: str,
+    observation_identity: str,
+) -> str:
+    return _sha256(
+        {
+            "schema": _DELIVERY_SCHEMA,
+            "projection_name": projection_name,
+            "observation_identity": observation_identity,
+        }
+    )
+
+
+def derive_projection_lock_key(*, projection_name: str, partition_key: str) -> int:
+    return _stable_signed_int64(
+        {
+            "schema": _PROJECTION_LOCK_SCHEMA,
+            "projection_name": projection_name,
+            "partition_key": partition_key,
+        }
+    )
+
+
+__all__ = [
+    "derive_fill_observation_identity",
+    "derive_projection_delivery_key",
+    "derive_projection_lock_key",
+    "has_positive_fill",
+    "normalize_fill_evidence",
+]

--- a/app/services/fill_observation/projection.py
+++ b/app/services/fill_observation/projection.py
@@ -1,0 +1,213 @@
+"""Durable claim/retry/cursor operations for future fill projections."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal
+from app.services.fill_observation.contracts import FillProjectionDelivery
+from app.services.fill_observation.errors import (
+    FillProjectionCursorRegression,
+    FillProjectionDeliveryError,
+    FillProjectionLeaseMismatch,
+)
+from app.services.fill_observation.identity import derive_projection_lock_key
+from app.services.fill_observation.repository import FillProjectionRepository
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _projection_name(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized or len(normalized) > 128:
+        raise FillProjectionDeliveryError(
+            "projection_name must contain 1 to 128 characters"
+        )
+    return normalized
+
+
+class FillProjectionQueue:
+    """Service-layer writer for only the new outbox/cursor tables.
+
+    This class is intentionally not wired to a scheduler or existing consumer.
+    A future projection worker can claim, retry, and complete deliveries while
+    preserving the observation row as immutable authority.
+    """
+
+    def __init__(
+        self,
+        session_factory: Callable[[], AsyncSession] = AsyncSessionLocal,
+        *,
+        clock: Callable[[], datetime] = _utc_now,
+        token_factory: Callable[[], uuid.UUID] = uuid.uuid4,
+    ) -> None:
+        self._session_factory = session_factory
+        self._clock = clock
+        self._token_factory = token_factory
+
+    async def claim(
+        self,
+        *,
+        projection_name: str,
+        limit: int = 100,
+        lease_seconds: int = 60,
+    ) -> list[FillProjectionDelivery]:
+        projection = _projection_name(projection_name)
+        if not 1 <= limit <= 500:
+            raise FillProjectionDeliveryError("limit must be between 1 and 500")
+        if not 1 <= lease_seconds <= 3600:
+            raise FillProjectionDeliveryError(
+                "lease_seconds must be between 1 and 3600"
+            )
+
+        now = self._clock()
+        token = self._token_factory()
+        lease_expires_at = now + timedelta(seconds=lease_seconds)
+        async with self._session_factory() as session:
+            async with session.begin():
+                repository = FillProjectionRepository(session)
+                rows = await repository.claim_ready(
+                    projection_name=projection,
+                    now=now,
+                    lease_token=token,
+                    lease_expires_at=lease_expires_at,
+                    limit=limit,
+                )
+                deliveries: list[FillProjectionDelivery] = []
+                for row in rows:
+                    observation = await repository.get_observation(
+                        row.fill_observation_id
+                    )
+                    if observation is None:
+                        raise FillProjectionDeliveryError(
+                            "outbox row references a missing fill observation"
+                        )
+                    deliveries.append(
+                        FillProjectionDelivery(
+                            outbox_id=row.id,
+                            delivery_key=row.delivery_key,
+                            projection_name=row.projection_name,
+                            partition_key=row.partition_key,
+                            fill_observation_id=row.fill_observation_id,
+                            observation_identity=observation.observation_identity,
+                            attempt_count=row.attempt_count,
+                            lease_token=token,
+                        )
+                    )
+                return deliveries
+
+    async def complete(
+        self,
+        *,
+        outbox_id: int,
+        lease_token: uuid.UUID,
+    ) -> None:
+        now = self._clock()
+        async with self._session_factory() as session:
+            async with session.begin():
+                repository = FillProjectionRepository(session)
+                outbox = await repository.get_outbox_for_update(outbox_id)
+                if (
+                    outbox is None
+                    or outbox.state != "processing"
+                    or outbox.lease_token != lease_token
+                ):
+                    raise FillProjectionLeaseMismatch(
+                        "outbox completion does not own the active lease"
+                    )
+                observation = await repository.get_observation(
+                    outbox.fill_observation_id
+                )
+                if observation is None:
+                    raise FillProjectionDeliveryError(
+                        "outbox row references a missing fill observation"
+                    )
+
+                lock_key = derive_projection_lock_key(
+                    projection_name=outbox.projection_name,
+                    partition_key=outbox.partition_key,
+                )
+                await repository.lock_projection_partition(lock_key)
+                cursor = await repository.get_cursor_for_update(
+                    projection_name=outbox.projection_name,
+                    partition_key=outbox.partition_key,
+                )
+                if cursor is None:
+                    repository.add_cursor(
+                        projection_name=outbox.projection_name,
+                        partition_key=outbox.partition_key,
+                        observation=observation,
+                        now=now,
+                    )
+                elif observation.id > cursor.last_fill_observation_id:
+                    cursor.last_fill_observation_id = observation.id
+                    cursor.last_observation_identity = observation.observation_identity
+                    cursor.advanced_at = now
+                    cursor.updated_at = now
+                elif (
+                    observation.id == cursor.last_fill_observation_id
+                    and observation.observation_identity
+                    != cursor.last_observation_identity
+                ):
+                    raise FillProjectionDeliveryError(
+                        "projection cursor identity disagrees with its observation"
+                    )
+                elif observation.id < cursor.last_fill_observation_id:
+                    raise FillProjectionCursorRegression(
+                        "projection delivery is older than the durable cursor"
+                    )
+
+                outbox.state = "succeeded"
+                outbox.lease_token = None
+                outbox.lease_expires_at = None
+                outbox.last_error = None
+                outbox.completed_at = now
+                outbox.updated_at = now
+                await repository.flush()
+
+    async def retry(
+        self,
+        *,
+        outbox_id: int,
+        lease_token: uuid.UUID,
+        error: str,
+        retry_after_seconds: int = 60,
+    ) -> None:
+        if not 0 <= retry_after_seconds <= 86_400:
+            raise FillProjectionDeliveryError(
+                "retry_after_seconds must be between 0 and 86400"
+            )
+        normalized_error = str(error or "").strip()
+        if not normalized_error:
+            raise FillProjectionDeliveryError("retry error must not be blank")
+
+        now = self._clock()
+        async with self._session_factory() as session:
+            async with session.begin():
+                repository = FillProjectionRepository(session)
+                outbox = await repository.get_outbox_for_update(outbox_id)
+                if (
+                    outbox is None
+                    or outbox.state != "processing"
+                    or outbox.lease_token != lease_token
+                ):
+                    raise FillProjectionLeaseMismatch(
+                        "outbox retry does not own the active lease"
+                    )
+                outbox.state = "retry"
+                outbox.lease_token = None
+                outbox.lease_expires_at = None
+                outbox.last_error = normalized_error[:4000]
+                outbox.completed_at = None
+                outbox.available_at = now + timedelta(seconds=retry_after_seconds)
+                outbox.updated_at = now
+                await repository.flush()
+
+
+__all__ = ["FillProjectionQueue"]

--- a/app/services/fill_observation/repository.py
+++ b/app/services/fill_observation/repository.py
@@ -14,10 +14,12 @@ from app.models.fill_observation import (
     FillObservation,
     FillProjectionCursor,
     FillProjectionOutbox,
+    FillSettlementEnrichment,
 )
 from app.services.fill_observation.contracts import (
     FillObservationIdentity,
     NormalizedBrokerFillEvidence,
+    NormalizedFillSettlement,
 )
 from app.services.fill_observation.identity import derive_projection_delivery_key
 
@@ -88,7 +90,7 @@ class FillObservationRepository:
             fee_total=evidence.fee_total,
             evidence_source=evidence.evidence_source,
             evidence_ref=evidence.evidence_ref,
-            evidence_hash=identity.evidence_hash,
+            fill_fact_hash=identity.fill_fact_hash,
             observed_at=evidence.observed_at,
             filled_at=evidence.filled_at,
             correlation_id=evidence.correlation_id,
@@ -113,6 +115,46 @@ class FillObservationRepository:
         self.session.add_all(outbox_rows)
         await self.session.flush()
         return observation, len(outbox_rows)
+
+    async def latest_settlement(
+        self,
+        fill_observation_id: int,
+    ) -> FillSettlementEnrichment | None:
+        """Return the highest settlement revision for one observation."""
+        return await self.session.scalar(
+            select(FillSettlementEnrichment)
+            .where(FillSettlementEnrichment.fill_observation_id == fill_observation_id)
+            .order_by(FillSettlementEnrichment.revision.desc())
+            .limit(1)
+        )
+
+    async def append_settlement(
+        self,
+        *,
+        fill_observation_id: int,
+        evidence: NormalizedBrokerFillEvidence,
+        settlement: NormalizedFillSettlement,
+        revision: int,
+    ) -> FillSettlementEnrichment:
+        """Append one settlement revision without touching the observation."""
+        enrichment = FillSettlementEnrichment(
+            fill_observation_id=fill_observation_id,
+            revision=revision,
+            settlement_hash=settlement.settlement_hash,
+            cumulative_quantity=settlement.cumulative_quantity,
+            reported_fill_quantity=settlement.reported_fill_quantity,
+            average_price=settlement.average_price,
+            last_fill_price=settlement.last_fill_price,
+            cumulative_notional=settlement.cumulative_notional,
+            fee_total=settlement.fee_total,
+            filled_at=settlement.filled_at,
+            evidence_source=evidence.evidence_source,
+            evidence_ref=evidence.evidence_ref,
+            observed_at=evidence.observed_at,
+        )
+        self.session.add(enrichment)
+        await self.session.flush()
+        return enrichment
 
 
 class FillProjectionRepository:

--- a/app/services/fill_observation/repository.py
+++ b/app/services/fill_observation/repository.py
@@ -1,0 +1,232 @@
+"""Internal SQLAlchemy repository for the ROB-1195 service boundary."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import and_, func, or_, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.models.fill_observation import (
+    FillObservation,
+    FillProjectionCursor,
+    FillProjectionOutbox,
+)
+from app.services.fill_observation.contracts import (
+    FillObservationIdentity,
+    NormalizedBrokerFillEvidence,
+)
+from app.services.fill_observation.identity import derive_projection_delivery_key
+
+
+class FillObservationRepository:
+    """The only ORM construction surface for immutable fill observations."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def lock_order_scope(self, lock_key: int) -> None:
+        await self.session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": lock_key},
+        )
+
+    async def find_by_identity(
+        self,
+        observation_identity: str,
+    ) -> FillObservation | None:
+        return await self.session.scalar(
+            select(FillObservation).where(
+                FillObservation.observation_identity == observation_identity
+            )
+        )
+
+    async def recorded_quantity(
+        self,
+        evidence: NormalizedBrokerFillEvidence,
+    ) -> Decimal:
+        value = await self.session.scalar(
+            select(func.coalesce(func.sum(FillObservation.fill_delta_quantity), 0))
+            .where(FillObservation.broker == evidence.broker)
+            .where(FillObservation.account_ref == evidence.account_ref)
+            .where(FillObservation.account_mode == evidence.account_mode)
+            .where(FillObservation.venue == evidence.venue)
+            .where(FillObservation.order_id == evidence.order_id)
+        )
+        return Decimal(str(value or 0))
+
+    async def append(
+        self,
+        *,
+        evidence: NormalizedBrokerFillEvidence,
+        identity: FillObservationIdentity,
+        fill_delta_quantity: Decimal,
+        projection_names: tuple[str, ...],
+    ) -> tuple[FillObservation, int]:
+        observation = FillObservation(
+            observation_identity=identity.value,
+            identity_kind=identity.kind,
+            broker=evidence.broker,
+            account_ref=evidence.account_ref,
+            account_mode=evidence.account_mode,
+            venue=evidence.venue,
+            order_id=evidence.order_id,
+            instrument_type=evidence.instrument_type,
+            symbol=evidence.symbol,
+            side=evidence.side,
+            currency=evidence.currency,
+            broker_fill_sequence=evidence.broker_fill_sequence,
+            cumulative_quantity=evidence.cumulative_quantity,
+            reported_fill_quantity=evidence.fill_quantity,
+            fill_delta_quantity=fill_delta_quantity,
+            average_price=evidence.average_price,
+            last_fill_price=evidence.last_fill_price,
+            cumulative_notional=evidence.cumulative_notional,
+            fee_total=evidence.fee_total,
+            evidence_source=evidence.evidence_source,
+            evidence_ref=evidence.evidence_ref,
+            evidence_hash=identity.evidence_hash,
+            observed_at=evidence.observed_at,
+            filled_at=evidence.filled_at,
+            correlation_id=evidence.correlation_id,
+        )
+        self.session.add(observation)
+        await self.session.flush()
+
+        outbox_rows = [
+            FillProjectionOutbox(
+                delivery_key=derive_projection_delivery_key(
+                    projection_name=projection_name,
+                    observation_identity=identity.value,
+                ),
+                projection_name=projection_name,
+                partition_key=identity.partition_key,
+                fill_observation_id=observation.id,
+                state="pending",
+                attempt_count=0,
+            )
+            for projection_name in projection_names
+        ]
+        self.session.add_all(outbox_rows)
+        await self.session.flush()
+        return observation, len(outbox_rows)
+
+
+class FillProjectionRepository:
+    """Mutable outbox/cursor primitives; callers own the transaction."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def claim_ready(
+        self,
+        *,
+        projection_name: str,
+        now: datetime,
+        lease_token: uuid.UUID,
+        lease_expires_at: datetime,
+        limit: int,
+    ) -> list[FillProjectionOutbox]:
+        predecessor = aliased(FillProjectionOutbox)
+        eligible = or_(
+            and_(
+                FillProjectionOutbox.state.in_(("pending", "retry")),
+                FillProjectionOutbox.available_at <= now,
+            ),
+            and_(
+                FillProjectionOutbox.state == "processing",
+                FillProjectionOutbox.lease_expires_at <= now,
+            ),
+        )
+        unfinished_predecessor = (
+            select(predecessor.id)
+            .where(predecessor.projection_name == FillProjectionOutbox.projection_name)
+            .where(predecessor.partition_key == FillProjectionOutbox.partition_key)
+            .where(
+                predecessor.fill_observation_id
+                < FillProjectionOutbox.fill_observation_id
+            )
+            .where(predecessor.state != "succeeded")
+            .exists()
+        )
+        rows = list(
+            (
+                await self.session.scalars(
+                    select(FillProjectionOutbox)
+                    .where(FillProjectionOutbox.projection_name == projection_name)
+                    .where(eligible)
+                    .where(~unfinished_predecessor)
+                    .order_by(FillProjectionOutbox.fill_observation_id.asc())
+                    .limit(limit)
+                    .with_for_update(skip_locked=True)
+                )
+            ).all()
+        )
+        for row in rows:
+            row.state = "processing"
+            row.attempt_count += 1
+            row.lease_token = lease_token
+            row.lease_expires_at = lease_expires_at
+            row.completed_at = None
+            row.updated_at = now
+        await self.session.flush()
+        return rows
+
+    async def get_outbox_for_update(
+        self, outbox_id: int
+    ) -> FillProjectionOutbox | None:
+        return await self.session.scalar(
+            select(FillProjectionOutbox)
+            .where(FillProjectionOutbox.id == outbox_id)
+            .with_for_update()
+        )
+
+    async def get_observation(self, observation_id: int) -> FillObservation | None:
+        return await self.session.get(FillObservation, observation_id)
+
+    async def lock_projection_partition(self, lock_key: int) -> None:
+        await self.session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": lock_key},
+        )
+
+    async def get_cursor_for_update(
+        self,
+        *,
+        projection_name: str,
+        partition_key: str,
+    ) -> FillProjectionCursor | None:
+        return await self.session.scalar(
+            select(FillProjectionCursor)
+            .where(FillProjectionCursor.projection_name == projection_name)
+            .where(FillProjectionCursor.partition_key == partition_key)
+            .with_for_update()
+        )
+
+    def add_cursor(
+        self,
+        *,
+        projection_name: str,
+        partition_key: str,
+        observation: FillObservation,
+        now: datetime,
+    ) -> FillProjectionCursor:
+        cursor = FillProjectionCursor(
+            projection_name=projection_name,
+            partition_key=partition_key,
+            last_fill_observation_id=observation.id,
+            last_observation_identity=observation.observation_identity,
+            advanced_at=now,
+            updated_at=now,
+        )
+        self.session.add(cursor)
+        return cursor
+
+    async def flush(self) -> None:
+        await self.session.flush()
+
+
+__all__ = ["FillObservationRepository", "FillProjectionRepository"]

--- a/app/services/fill_observation/writer.py
+++ b/app/services/fill_observation/writer.py
@@ -10,13 +10,15 @@ from typing import Protocol
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import AsyncSessionLocal
-from app.models.fill_observation import FillObservation
+from app.models.fill_observation import FillObservation, FillSettlementEnrichment
 from app.services.fill_observation.contracts import (
     BrokerFillEvidence,
     FillObservationIdentity,
     FillObservationWriteResult,
     FillObservationWriteStatus,
+    FillSettlementStatus,
     NormalizedBrokerFillEvidence,
+    NormalizedFillSettlement,
 )
 from app.services.fill_observation.errors import (
     FillObservationIdentityConflict,
@@ -56,6 +58,20 @@ class _ObservationRepository(Protocol):
         projection_names: tuple[str, ...],
     ) -> tuple[FillObservation, int]: ...
 
+    async def latest_settlement(
+        self,
+        fill_observation_id: int,
+    ) -> FillSettlementEnrichment | None: ...
+
+    async def append_settlement(
+        self,
+        *,
+        fill_observation_id: int,
+        evidence: NormalizedBrokerFillEvidence,
+        settlement: NormalizedFillSettlement,
+        revision: int,
+    ) -> FillSettlementEnrichment: ...
+
 
 def fill_observation_writer_enabled() -> bool:
     """Read the additive rollback flag; absence and unknown values are off."""
@@ -83,6 +99,34 @@ def _normalize_projection_names(values: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(normalized)
 
 
+async def _record_settlement(
+    repository: _ObservationRepository,
+    *,
+    fill_observation_id: int,
+    evidence: NormalizedBrokerFillEvidence,
+    settlement: NormalizedFillSettlement,
+) -> tuple[FillSettlementStatus, int | None]:
+    """Append a settlement revision only when the values actually changed.
+
+    This never updates the immutable observation and never produces a fill
+    delta. The caller already holds the order-scope advisory lock, so the
+    revision number is assigned under serialized access for the order.
+    """
+    if not settlement.has_values:
+        return FillSettlementStatus.ABSENT, None
+    latest = await repository.latest_settlement(fill_observation_id)
+    if latest is not None and latest.settlement_hash == settlement.settlement_hash:
+        return FillSettlementStatus.UNCHANGED, latest.revision
+    revision = 1 if latest is None else latest.revision + 1
+    await repository.append_settlement(
+        fill_observation_id=fill_observation_id,
+        evidence=evidence,
+        settlement=settlement,
+        revision=revision,
+    )
+    return FillSettlementStatus.RECORDED, revision
+
+
 async def _record_with_repository(
     repository: _ObservationRepository,
     *,
@@ -94,16 +138,26 @@ async def _record_with_repository(
     await repository.lock_order_scope(identity.order_lock_key)
     existing = await repository.find_by_identity(identity.value)
     if existing is not None:
-        if existing.evidence_hash != identity.evidence_hash:
+        if existing.fill_fact_hash != identity.fill_fact_hash:
             raise FillObservationIdentityConflict(
-                "fill observation identity already has different broker evidence"
+                "fill observation identity already has a different broker fill fact"
             )
+        # The stable fill fact matches, so this is the same fill re-observed.
+        # Settlement drift is preserved as a new revision instead of a conflict.
+        settlement_status, settlement_revision = await _record_settlement(
+            repository,
+            fill_observation_id=existing.id,
+            evidence=evidence,
+            settlement=identity.settlement,
+        )
         return FillObservationWriteResult(
             status=FillObservationWriteStatus.DUPLICATE,
             observation_identity=identity.value,
             observation_id=existing.id,
             fill_delta_quantity=Decimal(0),
             outbox_count=0,
+            settlement_status=settlement_status,
+            settlement_revision=settlement_revision,
         )
 
     if evidence.cumulative_quantity is not None:
@@ -131,12 +185,20 @@ async def _record_with_repository(
         fill_delta_quantity=delta,
         projection_names=projection_names,
     )
+    settlement_status, settlement_revision = await _record_settlement(
+        repository,
+        fill_observation_id=observation.id,
+        evidence=evidence,
+        settlement=identity.settlement,
+    )
     return FillObservationWriteResult(
         status=FillObservationWriteStatus.INSERTED,
         observation_identity=identity.value,
         observation_id=observation.id,
         fill_delta_quantity=delta,
         outbox_count=outbox_count,
+        settlement_status=settlement_status,
+        settlement_revision=settlement_revision,
     )
 
 

--- a/app/services/fill_observation/writer.py
+++ b/app/services/fill_observation/writer.py
@@ -1,0 +1,208 @@
+"""Default-off transactional writer for immutable fill observations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from decimal import Decimal
+from typing import Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal
+from app.models.fill_observation import FillObservation
+from app.services.fill_observation.contracts import (
+    BrokerFillEvidence,
+    FillObservationIdentity,
+    FillObservationWriteResult,
+    FillObservationWriteStatus,
+    NormalizedBrokerFillEvidence,
+)
+from app.services.fill_observation.errors import (
+    FillObservationIdentityConflict,
+    InvalidFillEvidence,
+    NonMonotonicFillCumulative,
+)
+from app.services.fill_observation.identity import (
+    derive_fill_observation_identity,
+    has_positive_fill,
+    normalize_fill_evidence,
+)
+from app.services.fill_observation.repository import FillObservationRepository
+
+FILL_OBSERVATION_WRITER_ENABLED_ENV = "FILL_OBSERVATION_WRITER_ENABLED"
+DEFAULT_FILL_PROJECTIONS: tuple[str, ...] = ("legacy_dual_read_validation.v1",)
+
+
+class _ObservationRepository(Protocol):
+    async def lock_order_scope(self, lock_key: int) -> None: ...
+
+    async def find_by_identity(
+        self,
+        observation_identity: str,
+    ) -> FillObservation | None: ...
+
+    async def recorded_quantity(
+        self,
+        evidence: NormalizedBrokerFillEvidence,
+    ) -> Decimal: ...
+
+    async def append(
+        self,
+        *,
+        evidence: NormalizedBrokerFillEvidence,
+        identity: FillObservationIdentity,
+        fill_delta_quantity: Decimal,
+        projection_names: tuple[str, ...],
+    ) -> tuple[FillObservation, int]: ...
+
+
+def fill_observation_writer_enabled() -> bool:
+    """Read the additive rollback flag; absence and unknown values are off."""
+    return os.getenv(FILL_OBSERVATION_WRITER_ENABLED_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _normalize_projection_names(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        name = str(value or "").strip()
+        if not name:
+            raise InvalidFillEvidence("projection_name must not be blank")
+        if len(name) > 128:
+            raise InvalidFillEvidence("projection_name exceeds 128 characters")
+        if name not in seen:
+            normalized.append(name)
+            seen.add(name)
+    if not normalized:
+        raise InvalidFillEvidence("at least one projection_name is required")
+    return tuple(normalized)
+
+
+async def _record_with_repository(
+    repository: _ObservationRepository,
+    *,
+    evidence: NormalizedBrokerFillEvidence,
+    identity: FillObservationIdentity,
+    projection_names: tuple[str, ...],
+) -> FillObservationWriteResult:
+    """Execute one append plan inside the caller's open transaction."""
+    await repository.lock_order_scope(identity.order_lock_key)
+    existing = await repository.find_by_identity(identity.value)
+    if existing is not None:
+        if existing.evidence_hash != identity.evidence_hash:
+            raise FillObservationIdentityConflict(
+                "fill observation identity already has different broker evidence"
+            )
+        return FillObservationWriteResult(
+            status=FillObservationWriteStatus.DUPLICATE,
+            observation_identity=identity.value,
+            observation_id=existing.id,
+            fill_delta_quantity=Decimal(0),
+            outbox_count=0,
+        )
+
+    if evidence.cumulative_quantity is not None:
+        recorded_quantity = await repository.recorded_quantity(evidence)
+        if evidence.cumulative_quantity < recorded_quantity:
+            raise NonMonotonicFillCumulative(
+                "broker cumulative fill quantity regressed below durable deltas"
+            )
+        delta = evidence.cumulative_quantity - recorded_quantity
+    else:
+        delta = evidence.fill_quantity or Decimal(0)
+
+    if delta <= 0:
+        return FillObservationWriteResult(
+            status=FillObservationWriteStatus.NO_DELTA,
+            observation_identity=identity.value,
+            observation_id=None,
+            fill_delta_quantity=Decimal(0),
+            outbox_count=0,
+        )
+
+    observation, outbox_count = await repository.append(
+        evidence=evidence,
+        identity=identity,
+        fill_delta_quantity=delta,
+        projection_names=projection_names,
+    )
+    return FillObservationWriteResult(
+        status=FillObservationWriteStatus.INSERTED,
+        observation_identity=identity.value,
+        observation_id=observation.id,
+        fill_delta_quantity=delta,
+        outbox_count=outbox_count,
+    )
+
+
+class FillObservationWriter:
+    """Own the atomic observation + outbox transaction.
+
+    No existing reconcile path instantiates this writer in ROB-1195. The
+    additive env flag is false by default so deploying the foundation performs
+    zero writes until a separately approved consumer migration wires it.
+    """
+
+    def __init__(
+        self,
+        session_factory: Callable[[], AsyncSession] = AsyncSessionLocal,
+        *,
+        enabled: bool | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._enabled = (
+            fill_observation_writer_enabled() if enabled is None else enabled
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def write(
+        self,
+        evidence: BrokerFillEvidence,
+        *,
+        projection_names: tuple[str, ...] = DEFAULT_FILL_PROJECTIONS,
+    ) -> FillObservationWriteResult:
+        normalized = normalize_fill_evidence(evidence)
+        identity = derive_fill_observation_identity(normalized)
+        if not has_positive_fill(normalized):
+            return FillObservationWriteResult(
+                status=FillObservationWriteStatus.NO_FILL_EVIDENCE,
+                observation_identity=identity.value,
+                observation_id=None,
+                fill_delta_quantity=Decimal(0),
+                outbox_count=0,
+            )
+        if not self._enabled:
+            return FillObservationWriteResult(
+                status=FillObservationWriteStatus.WRITER_DISABLED,
+                observation_identity=identity.value,
+                observation_id=None,
+                fill_delta_quantity=Decimal(0),
+                outbox_count=0,
+            )
+
+        normalized_projections = _normalize_projection_names(projection_names)
+        async with self._session_factory() as session:
+            async with session.begin():
+                repository = FillObservationRepository(session)
+                return await _record_with_repository(
+                    repository,
+                    evidence=normalized,
+                    identity=identity,
+                    projection_names=normalized_projections,
+                )
+
+
+__all__ = [
+    "DEFAULT_FILL_PROJECTIONS",
+    "FILL_OBSERVATION_WRITER_ENABLED_ENV",
+    "FillObservationWriter",
+    "fill_observation_writer_enabled",
+]

--- a/docs/runbooks/fill-observation-foundation.md
+++ b/docs/runbooks/fill-observation-foundation.md
@@ -6,24 +6,33 @@
 that was proven by broker evidence. The invariant is:
 
 > A broker-evidenced fill delta is durably appended once. Re-observing the same
-> broker fill sequence or cumulative quantity appends zero delta.
+> broker fill fact appends zero delta, whether or not the provider has since
+> revised the settlement values of that fill.
+
+Only a contradicted **fill fact** fails closed. Post-trade revisions — fee,
+average or last price, notional, settled `filled_at` — are not contradictions;
+they are appended to a separate settlement history. See "Fill fact versus
+settlement enrichment" below for the exact split.
 
 ROB-1195 only ships the schema and service-layer foundation. It does **not**
 wire KIS, Upbit, Toss, Alpaca, Binance, or Kiwoom reconcile paths to the writer.
 It does not change `review.trades`, `review.execution_ledger`, any broker-native
 ledger, trade journals, proposals, scheduler registration, or broker gates.
 
-The three additive tables are:
+The four additive tables are:
 
 - `review.fill_observations`: append-only broker evidence and positive deltas.
+- `review.fill_settlement_enrichments`: append-only revision history of the
+  post-trade values for one observation. `(fill_observation_id, revision)` is
+  unique and `revision` is dense and 1-based.
 - `review.fill_projection_outbox`: durable pending/processing/retry/succeeded
   delivery state. `(projection_name, fill_observation_id)` is unique.
 - `review.fill_projection_cursors`: durable high-watermark per
   `(projection_name, partition_key)`.
 
-The observation migration installs database triggers that reject UPDATE,
-DELETE, and TRUNCATE. A downgrade also refuses to remove the schema once an
-observation exists.
+The migration installs database triggers that reject UPDATE, DELETE, and
+TRUNCATE on both `fill_observations` and `fill_settlement_enrichments`. A
+downgrade also refuses to remove the schema once an observation exists.
 
 ## Identity and delta rules
 
@@ -33,12 +42,18 @@ The service canonicalizes a deterministic SHA-256 identity from:
 2. broker fill sequence when available, otherwise canonical cumulative fill
    quantity.
 
+US equity symbols are canonicalized to dot-separated upper case (`brk-b` and
+`BRK/B` both become `BRK.B`) through `app/core/symbol.py`. Case and separator
+drift between two polls of the same order is representation, not a different
+fill. Crypto, KR, forex, and index symbols are never rewritten.
+
 The writer obtains a transaction-scoped PostgreSQL advisory lock derived from
 the canonical order scope using a stable signed 64-bit SHA-256 prefix. It then
 checks the deterministic identity before calculating a delta.
 
-- Same identity and same semantic evidence hash: duplicate, zero write.
-- Same identity and different semantic evidence hash: fail closed, zero write.
+- Same identity and same fill fact: duplicate, zero fill delta. Settlement is
+  reconciled per the next section.
+- Same identity and a **contradicted fill fact**: fail closed, zero write.
 - Larger cumulative quantity: append only `cumulative - already recorded`.
 - Equal cumulative quantity: zero delta, zero write.
 - Regressed cumulative quantity: fail closed, zero write.
@@ -48,6 +63,49 @@ checks the deterministic identity before calculating a delta.
 
 `evidence_ref` must point to retained sanitized broker/native-ledger evidence.
 Do not put credentials, tokens, or an unredacted broker response in it.
+
+## Fill fact versus settlement enrichment
+
+`fill_observations.fill_fact_hash` fingerprints only the stable broker fill
+fact: the order scope, `instrument_type`, `symbol`, `side`, `currency`, and
+exactly the quantity the identity is keyed on. Under sequence identity that is
+the sequence plus its own reported `fill_quantity`; under cumulative identity it
+is the cumulative quantity. A mismatch there is a genuine contradiction and
+raises `FillObservationIdentityConflict` with zero write.
+
+Everything a provider legitimately revises afterwards is carried in
+`review.fill_settlement_enrichments` and is deliberately **outside**
+`fill_fact_hash`:
+
+- `fee_total`, `average_price`, `last_fill_price`, `cumulative_notional`, and
+  the settled `filled_at`;
+- the quantity field the identity is *not* keyed on. Under sequence identity the
+  order's cumulative quantity legitimately grows while the same fill is
+  re-observed; under cumulative identity the per-poll reported increment is a
+  snapshot of that poll, not a property of the cumulative state.
+
+`evidence_source`, `evidence_ref`, and `observed_at` are the provenance of a
+poll, not settlement values, so they stay out of `settlement_hash`. A repeated
+poll of unchanged settlement is therefore idempotent instead of appending one
+revision per poll.
+
+Reconciliation rules, all under the order-scope advisory lock:
+
+- No settlement value supplied at all: no revision, status `absent`.
+- The values equal the **latest** revision: no revision, status `unchanged`, and
+  the write result echoes that revision number.
+- The values differ from the latest revision: append `revision + 1`, status
+  `recorded`. A reverted correction appends a further revision rather than
+  rewriting history, so the highest revision is always the most recently
+  observed settlement.
+- No observation row exists for the identity (`no_delta`, `no_fill_evidence`, or
+  `writer_disabled`): status `not_applicable`.
+
+The observation's own economic columns hold the settlement values **as first
+observed** and never change; revision 1 is that same snapshot. Consumers that
+need the current settlement must read the highest revision, not the observation
+row. Nothing in this path issues an UPDATE against `fill_observations`, and a
+settlement revision never produces a fill delta or an outbox row.
 
 ## Default-off activation
 
@@ -69,9 +127,9 @@ Live backfill is outside this runbook.
 
 ## Atomic outbox and cursor behavior
 
-For a new positive delta, `FillObservationWriter` inserts the observation and
-its `legacy_dual_read_validation.v1` outbox row in one database transaction.
-Neither row commits alone.
+For a new positive delta, `FillObservationWriter` inserts the observation, its
+`legacy_dual_read_validation.v1` outbox row, and settlement revision 1 in one
+database transaction. No row commits alone.
 
 `FillProjectionQueue` is an unscheduled service foundation:
 
@@ -106,8 +164,26 @@ orders and require:
 
 1. repeated cumulative observations return zero delta;
 2. observation quantity equals broker cumulative evidence;
-3. any legacy mismatch is explained and retained as rollout evidence; and
-4. no observation exists for an order without a broker evidence reference.
+3. any legacy mismatch is explained and retained as rollout evidence;
+4. no observation exists for an order without a broker evidence reference; and
+5. late fee/price settlement produced settlement revisions rather than either a
+   second fill delta or a fail-closed conflict.
+
+## Local verification
+
+`tests/services/fill_observation/test_postgresql_integration.py` exercises the
+real SQL, constraints, and triggers against the isolated pytest-owned local
+`test_db` database (`tests/_run_owned_database.py` refuses any base URL whose
+database is not `test_db`). It covers observation+outbox atomicity, rollback on
+failure, the append-only triggers, partition ordering with
+`FOR UPDATE SKIP LOCKED`, lease fencing, cursor advance/regression, settlement
+revisioning, and an upgrade/downgrade/upgrade round trip on a throwaway local
+database.
+
+Run it with `uv run pytest tests/services/fill_observation/ -q`. It never
+contacts a broker, an external API, a shared database, or production. Because
+observations are append-only the tests cannot delete their rows, so each one
+scopes itself to a fresh UUID order scope.
 
 ## Writer-off rollback
 
@@ -126,7 +202,12 @@ consumer cutover, or mutation of any legacy ledger.
 
 ## Migration ownership
 
-The migration file is additive, but applying it is operator-owned. ROB-1195
-development and verification must not run `alembic upgrade`, touch a shared
-database, or perform a live backfill. Static Alembic head inspection and
-unit/contract tests are the permitted pre-PR validation path.
+The migration file is additive, but applying it to any shared or production
+database is operator-owned. ROB-1195 development and verification must not touch
+a shared or production database and must not perform a live backfill.
+
+The permitted pre-PR validation path is static Alembic head inspection,
+unit/contract tests, and the isolated local integration suite above — including
+its upgrade/downgrade/upgrade round trip, which runs against a throwaway
+database created and dropped on the local test PostgreSQL instance. No other
+`alembic upgrade` is in scope for this issue.

--- a/docs/runbooks/fill-observation-foundation.md
+++ b/docs/runbooks/fill-observation-foundation.md
@@ -1,0 +1,132 @@
+# Fill observation foundation (ROB-1195)
+
+## Purpose and boundary
+
+`review.fill_observations` is the immutable authority for a positive fill delta
+that was proven by broker evidence. The invariant is:
+
+> A broker-evidenced fill delta is durably appended once. Re-observing the same
+> broker fill sequence or cumulative quantity appends zero delta.
+
+ROB-1195 only ships the schema and service-layer foundation. It does **not**
+wire KIS, Upbit, Toss, Alpaca, Binance, or Kiwoom reconcile paths to the writer.
+It does not change `review.trades`, `review.execution_ledger`, any broker-native
+ledger, trade journals, proposals, scheduler registration, or broker gates.
+
+The three additive tables are:
+
+- `review.fill_observations`: append-only broker evidence and positive deltas.
+- `review.fill_projection_outbox`: durable pending/processing/retry/succeeded
+  delivery state. `(projection_name, fill_observation_id)` is unique.
+- `review.fill_projection_cursors`: durable high-watermark per
+  `(projection_name, partition_key)`.
+
+The observation migration installs database triggers that reject UPDATE,
+DELETE, and TRUNCATE. A downgrade also refuses to remove the schema once an
+observation exists.
+
+## Identity and delta rules
+
+The service canonicalizes a deterministic SHA-256 identity from:
+
+1. broker, account reference, account mode, venue, and broker order ID; plus
+2. broker fill sequence when available, otherwise canonical cumulative fill
+   quantity.
+
+The writer obtains a transaction-scoped PostgreSQL advisory lock derived from
+the canonical order scope using a stable signed 64-bit SHA-256 prefix. It then
+checks the deterministic identity before calculating a delta.
+
+- Same identity and same semantic evidence hash: duplicate, zero write.
+- Same identity and different semantic evidence hash: fail closed, zero write.
+- Larger cumulative quantity: append only `cumulative - already recorded`.
+- Equal cumulative quantity: zero delta, zero write.
+- Regressed cumulative quantity: fail closed, zero write.
+- Sequence-only evidence: append the positive reported fill quantity once.
+- Missing evidence reference, missing sequence/cumulative identity, negative
+  quantity, or zero total filled quantity: zero observation.
+
+`evidence_ref` must point to retained sanitized broker/native-ledger evidence.
+Do not put credentials, tokens, or an unredacted broker response in it.
+
+## Default-off activation
+
+The only new flag is:
+
+```text
+FILL_OBSERVATION_WRITER_ENABLED=false
+```
+
+Absence, an empty value, and unknown values are all treated as false. When the
+writer is disabled, it does not open a database session. This PR deliberately
+has no runtime caller, so deployment of the schema alone writes nothing.
+
+Setting the flag true does not create a caller. Wiring a broker reconcile path
+to `FillObservationWriter` is a later consumer migration and requires separate
+approval. That migration must keep the existing broker evidence gate and must
+not start mid-order unless its cumulative baseline behavior has been reviewed.
+Live backfill is outside this runbook.
+
+## Atomic outbox and cursor behavior
+
+For a new positive delta, `FillObservationWriter` inserts the observation and
+its `legacy_dual_read_validation.v1` outbox row in one database transaction.
+Neither row commits alone.
+
+`FillProjectionQueue` is an unscheduled service foundation:
+
+- `claim` leases ready or expired deliveries with `FOR UPDATE SKIP LOCKED` and
+  increments the durable attempt count. It only leases the oldest unfinished
+  observation in each partition, so a cursor cannot skip an earlier delivery.
+- `retry` clears the lease and persists `last_error` plus `available_at` in one
+  transaction.
+- `complete` takes a deterministic projection-partition advisory lock, marks
+  the outbox row succeeded, and advances the cursor in one transaction. A
+  delivery older than the durable cursor fails closed.
+
+No TaskIQ, cron, Prefect, CLI, MCP, or HTTP consumer is registered by ROB-1195.
+
+## Dual-read validation
+
+`FillObservationDualReader.validate_order(...)` is read-only. It compares the
+sum of immutable observation deltas with both available legacy projections:
+
+- `review.trades.quantity` for `(account, order_id)`; and
+- `review.execution_ledger.filled_qty` for
+  `(broker, account_mode, venue, broker_order_id)`.
+
+Its statuses are `match`, `mismatch`, `new_only`, `legacy_only`, and `empty`.
+`mismatched_sources` identifies which present projection differs. This makes
+the existing `review.trades` `(account, order_id)` conflict visible when a
+later partial-fill delta was discarded there; it does not repair or mutate the
+legacy row.
+
+Before a future consumer cutover, validate a bounded set of newly dual-written
+orders and require:
+
+1. repeated cumulative observations return zero delta;
+2. observation quantity equals broker cumulative evidence;
+3. any legacy mismatch is explained and retained as rollout evidence; and
+4. no observation exists for an order without a broker evidence reference.
+
+## Writer-off rollback
+
+Rollback is additive and non-destructive:
+
+1. Set `FILL_OBSERVATION_WRITER_ENABLED=false` (or remove it) in the process
+   environment and restart only the separately approved caller process.
+2. Confirm the caller reports `writer_disabled` and that no new
+   `fill_observations.created_at` values appear after the restart.
+3. Continue the unchanged native reconcile/ledger paths.
+4. Leave existing observations, outbox rows, and cursors intact for audit and
+   replay. Do not DELETE, TRUNCATE, or force an Alembic downgrade.
+
+Writer-off does not authorize broker calls, backfill, projection repair,
+consumer cutover, or mutation of any legacy ledger.
+
+## Migration ownership
+
+The migration file is additive, but applying it is operator-owned. ROB-1195
+development and verification must not run `alembic upgrade`, touch a shared
+database, or perform a live backfill. Static Alembic head inspection and
+unit/contract tests are the permitted pre-PR validation path.

--- a/env.example
+++ b/env.example
@@ -117,6 +117,11 @@ TOP_N=30
 # 하락률 임계값 (%)
 DROP_PCT=-3.0
 
+# ROB-1195 immutable fill-observation writer (additive foundation, no consumer
+# is wired by default). Operational rollback is false; do not enable until a
+# separately approved reconcile consumer migration is ready.
+FILL_OBSERVATION_WRITER_ENABLED=false
+
 # ========================================
 # 스케줄러 설정
 # ========================================
@@ -488,4 +493,3 @@ MCP_TRADINGCODEX_EXECUTION_PORT=8770
 # ========================================
 # watch 트리거 알림 전송 수단 ("hermes_webhook" | "python_direct")
 WATCH_NOTIFY_TRANSPORT=hermes_webhook
-

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -64,7 +64,8 @@ from sqlalchemy import text
 # v31: Alpaca paper lab account_mode CHECK expansions.
 # v32 (ROB-1103): nullable direct-watch source links + future-write FKs.
 # v33 (ROB-1115): strategy_learning_events ORM table + append-only triggers.
-SCHEMA_BOOTSTRAP_VERSION = 33
+# v34 (ROB-1195): fill_observations ORM tables + append-only triggers.
+SCHEMA_BOOTSTRAP_VERSION = 34
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -1312,6 +1313,24 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "BEFORE TRUNCATE ON research.strategy_learning_events "
     "FOR EACH STATEMENT EXECUTE FUNCTION "
     "research.reject_strategy_learning_event_mutation()",
+    # ---- ROB-1195: immutable broker-evidenced fill observations.
+    "CREATE OR REPLACE FUNCTION review.reject_fill_observation_mutation() "
+    "RETURNS trigger AS $$ BEGIN "
+    "RAISE EXCEPTION "
+    "'review.fill_observations is append-only/immutable; % rejected', TG_OP "
+    "USING ERRCODE = 'restrict_violation'; "
+    "END; $$ LANGUAGE plpgsql",
+    "DROP TRIGGER IF EXISTS trg_fill_observations_immutable "
+    "ON review.fill_observations",
+    "CREATE TRIGGER trg_fill_observations_immutable "
+    "BEFORE UPDATE OR DELETE ON review.fill_observations "
+    "FOR EACH ROW EXECUTE FUNCTION review.reject_fill_observation_mutation()",
+    "DROP TRIGGER IF EXISTS trg_fill_observations_truncate_immutable "
+    "ON review.fill_observations",
+    "CREATE TRIGGER trg_fill_observations_truncate_immutable "
+    "BEFORE TRUNCATE ON review.fill_observations "
+    "FOR EACH STATEMENT EXECUTE FUNCTION "
+    "review.reject_fill_observation_mutation()",
     # ---- ROB-848: immutable paper-validation audit + experiment hash binding
     # Tables/checks/FKs are owned by the ORM metadata above; these PostgreSQL
     # trigger functions are non-ORM DDL and mirror the Alembic revision.

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -65,7 +65,9 @@ from sqlalchemy import text
 # v32 (ROB-1103): nullable direct-watch source links + future-write FKs.
 # v33 (ROB-1115): strategy_learning_events ORM table + append-only triggers.
 # v34 (ROB-1195): fill_observations ORM tables + append-only triggers.
-SCHEMA_BOOTSTRAP_VERSION = 34
+# v35 (ROB-1195 S2): fill_settlement_enrichments ORM table + append-only
+# triggers, and a table-agnostic rejection message for the shared function.
+SCHEMA_BOOTSTRAP_VERSION = 35
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -1313,11 +1315,14 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "BEFORE TRUNCATE ON research.strategy_learning_events "
     "FOR EACH STATEMENT EXECUTE FUNCTION "
     "research.reject_strategy_learning_event_mutation()",
-    # ---- ROB-1195: immutable broker-evidenced fill observations.
+    # ---- ROB-1195: immutable broker-evidenced fill observations plus their
+    # append-only settlement revisions. Both tables share one rejection
+    # function, so the message is derived from the firing table.
     "CREATE OR REPLACE FUNCTION review.reject_fill_observation_mutation() "
     "RETURNS trigger AS $$ BEGIN "
     "RAISE EXCEPTION "
-    "'review.fill_observations is append-only/immutable; % rejected', TG_OP "
+    "'%.% is append-only/immutable; % rejected', "
+    "TG_TABLE_SCHEMA, TG_TABLE_NAME, TG_OP "
     "USING ERRCODE = 'restrict_violation'; "
     "END; $$ LANGUAGE plpgsql",
     "DROP TRIGGER IF EXISTS trg_fill_observations_immutable "
@@ -1329,6 +1334,18 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ON review.fill_observations",
     "CREATE TRIGGER trg_fill_observations_truncate_immutable "
     "BEFORE TRUNCATE ON review.fill_observations "
+    "FOR EACH STATEMENT EXECUTE FUNCTION "
+    "review.reject_fill_observation_mutation()",
+    "DROP TRIGGER IF EXISTS trg_fill_settlement_enrichments_immutable "
+    "ON review.fill_settlement_enrichments",
+    "CREATE TRIGGER trg_fill_settlement_enrichments_immutable "
+    "BEFORE UPDATE OR DELETE ON review.fill_settlement_enrichments "
+    "FOR EACH ROW EXECUTE FUNCTION review.reject_fill_observation_mutation()",
+    "DROP TRIGGER IF EXISTS "
+    "trg_fill_settlement_enrichments_truncate_immutable "
+    "ON review.fill_settlement_enrichments",
+    "CREATE TRIGGER trg_fill_settlement_enrichments_truncate_immutable "
+    "BEFORE TRUNCATE ON review.fill_settlement_enrichments "
     "FOR EACH STATEMENT EXECUTE FUNCTION "
     "review.reject_fill_observation_mutation()",
     # ---- ROB-848: immutable paper-validation audit + experiment hash binding

--- a/tests/services/fill_observation/test_dual_read.py
+++ b/tests/services/fill_observation/test_dual_read.py
@@ -1,0 +1,61 @@
+from decimal import Decimal
+
+import pytest
+
+from app.services.fill_observation.contracts import FillDualReadStatus
+from app.services.fill_observation.dual_read import _classify_dual_read
+
+pytestmark = pytest.mark.unit
+
+
+def test_dual_read_exposes_review_trades_partial_fill_loss() -> None:
+    status, mismatches = _classify_dual_read(
+        observation_count=2,
+        observation_quantity=Decimal("5"),
+        review_trade_quantity=Decimal("2"),
+        execution_ledger_quantity=Decimal("5"),
+    )
+
+    assert status is FillDualReadStatus.MISMATCH
+    assert mismatches == ("review.trades",)
+
+
+def test_dual_read_matches_all_present_legacy_projections() -> None:
+    status, mismatches = _classify_dual_read(
+        observation_count=2,
+        observation_quantity=Decimal("5"),
+        review_trade_quantity=Decimal("5"),
+        execution_ledger_quantity=Decimal("5"),
+    )
+
+    assert status is FillDualReadStatus.MATCH
+    assert mismatches == ()
+
+
+@pytest.mark.parametrize(
+    (
+        "observation_count",
+        "trade_quantity",
+        "execution_quantity",
+        "expected",
+    ),
+    [
+        (1, None, None, FillDualReadStatus.NEW_ONLY),
+        (0, Decimal("1"), None, FillDualReadStatus.LEGACY_ONLY),
+        (0, None, None, FillDualReadStatus.EMPTY),
+    ],
+)
+def test_dual_read_reports_migration_presence_states(
+    observation_count: int,
+    trade_quantity: Decimal | None,
+    execution_quantity: Decimal | None,
+    expected: FillDualReadStatus,
+) -> None:
+    status, mismatches = _classify_dual_read(
+        observation_count=observation_count,
+        observation_quantity=(Decimal("1") if observation_count else Decimal(0)),
+        review_trade_quantity=trade_quantity,
+        execution_ledger_quantity=execution_quantity,
+    )
+    assert status is expected
+    assert mismatches == ()

--- a/tests/services/fill_observation/test_identity_and_writer.py
+++ b/tests/services/fill_observation/test_identity_and_writer.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.trading import InstrumentType
+from app.services.fill_observation import writer as writer_module
+from app.services.fill_observation.contracts import (
+    BrokerFillEvidence,
+    FillObservationWriteStatus,
+)
+from app.services.fill_observation.errors import (
+    FillObservationIdentityConflict,
+    InvalidFillEvidence,
+    NonMonotonicFillCumulative,
+)
+from app.services.fill_observation.identity import (
+    derive_fill_observation_identity,
+    has_positive_fill,
+    normalize_fill_evidence,
+)
+from app.services.fill_observation.writer import (
+    FILL_OBSERVATION_WRITER_ENABLED_ENV,
+    FillObservationWriter,
+    _record_with_repository,
+    fill_observation_writer_enabled,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _evidence(**overrides: object) -> BrokerFillEvidence:
+    values: dict[str, object] = {
+        "broker": "toss",
+        "account_ref": "acct-live-1",
+        "account_mode": "live",
+        "venue": "toss_us",
+        "order_id": "order-42",
+        "instrument_type": InstrumentType.equity_us,
+        "symbol": "BRK-B",
+        "side": "BUY",
+        "currency": "usd",
+        "evidence_source": "reconciler",
+        "evidence_ref": "toss_live_order_ledger:42",
+        "observed_at": datetime(2026, 8, 1, 12, 0, tzinfo=UTC),
+        "cumulative_quantity": Decimal("2.5000"),
+        "average_price": Decimal("430.25"),
+        "filled_at": datetime(2026, 8, 1, 11, 59, tzinfo=UTC),
+    }
+    values.update(overrides)
+    return BrokerFillEvidence(**values)  # type: ignore[arg-type]
+
+
+class _FakeObservationRepository:
+    def __init__(
+        self,
+        *,
+        recorded: Decimal = Decimal(0),
+        existing: object | None = None,
+    ) -> None:
+        self.recorded = recorded
+        self.existing = existing
+        self.lock_keys: list[int] = []
+        self.appends: list[dict[str, object]] = []
+
+    async def lock_order_scope(self, lock_key: int) -> None:
+        self.lock_keys.append(lock_key)
+
+    async def find_by_identity(self, _identity: str) -> object | None:
+        return self.existing
+
+    async def recorded_quantity(self, _evidence: object) -> Decimal:
+        return self.recorded
+
+    async def append(self, **kwargs: object) -> tuple[object, int]:
+        self.appends.append(kwargs)
+        return SimpleNamespace(id=91), len(kwargs["projection_names"])
+
+
+class _FakeWriterSession:
+    def __init__(self) -> None:
+        self.transactions = 0
+
+    async def __aenter__(self) -> _FakeWriterSession:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    def begin(self) -> _FakeWriterSession:
+        self.transactions += 1
+        return self
+
+
+def test_identity_is_decimal_canonical_and_reobservation_stable() -> None:
+    first = normalize_fill_evidence(_evidence())
+    second = normalize_fill_evidence(
+        _evidence(
+            cumulative_quantity="2.5",
+            evidence_ref="another-poll:99",
+            observed_at=first.observed_at + timedelta(minutes=5),
+        )
+    )
+
+    first_identity = derive_fill_observation_identity(first)
+    second_identity = derive_fill_observation_identity(second)
+
+    assert first.symbol == "BRK.B"
+    assert first_identity.value == second_identity.value
+    assert first_identity.evidence_hash == second_identity.evidence_hash
+    assert first_identity.order_lock_key == second_identity.order_lock_key
+    assert -(2**63) <= first_identity.order_lock_key < 2**63
+
+
+def test_sequence_identity_takes_precedence_over_cumulative_quantity() -> None:
+    first = normalize_fill_evidence(_evidence(broker_fill_sequence="fill-1"))
+    second = normalize_fill_evidence(_evidence(broker_fill_sequence="fill-2"))
+
+    first_identity = derive_fill_observation_identity(first)
+    second_identity = derive_fill_observation_identity(second)
+
+    assert first_identity.kind == "broker_fill_sequence"
+    assert first_identity.value != second_identity.value
+    assert first_identity.partition_key == second_identity.partition_key
+
+
+def test_crypto_venue_symbol_is_not_rewritten_as_us_share_class() -> None:
+    normalized = normalize_fill_evidence(
+        _evidence(
+            broker="upbit",
+            venue="upbit",
+            instrument_type=InstrumentType.crypto,
+            symbol="KRW-BTC",
+            currency="KRW",
+        )
+    )
+    assert normalized.symbol == "KRW-BTC"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"evidence_ref": ""}, "evidence_ref"),
+        (
+            {"broker_fill_sequence": None, "cumulative_quantity": None},
+            "broker_fill_sequence or cumulative_quantity",
+        ),
+        ({"cumulative_quantity": Decimal("-1")}, "must not be negative"),
+        ({"average_price": Decimal("0")}, "greater than zero"),
+        (
+            {"observed_at": datetime(2026, 8, 1, 12, 0)},
+            "timezone-aware",
+        ),
+    ],
+)
+def test_invalid_or_missing_broker_evidence_fails_closed(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(InvalidFillEvidence, match=message):
+        normalize_fill_evidence(_evidence(**overrides))
+
+
+@pytest.mark.asyncio
+async def test_default_off_writer_does_not_open_a_database_session() -> None:
+    def forbidden_session() -> object:
+        raise AssertionError("disabled writer must not construct a DB session")
+
+    writer = FillObservationWriter(forbidden_session, enabled=False)  # type: ignore[arg-type]
+    result = await writer.write(_evidence())
+
+    assert result.status is FillObservationWriteStatus.WRITER_DISABLED
+    assert result.fill_delta_quantity == 0
+    assert result.observation_id is None
+
+
+def test_writer_env_gate_is_default_false_and_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(FILL_OBSERVATION_WRITER_ENABLED_ENV, raising=False)
+    assert fill_observation_writer_enabled() is False
+
+    monkeypatch.setenv(FILL_OBSERVATION_WRITER_ENABLED_ENV, "unexpected")
+    assert fill_observation_writer_enabled() is False
+
+    monkeypatch.setenv(FILL_OBSERVATION_WRITER_ENABLED_ENV, "true")
+    assert fill_observation_writer_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_enabled_writer_owns_one_observation_and_outbox_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _FakeObservationRepository()
+    session = _FakeWriterSession()
+    monkeypatch.setattr(
+        writer_module,
+        "FillObservationRepository",
+        lambda _session: repository,
+    )
+    writer = FillObservationWriter(
+        lambda: session,  # type: ignore[arg-type]
+        enabled=True,
+    )
+
+    result = await writer.write(_evidence())
+
+    assert result.status is FillObservationWriteStatus.INSERTED
+    assert result.outbox_count == 1
+    assert session.transactions == 1
+    assert len(repository.appends) == 1
+
+
+@pytest.mark.asyncio
+async def test_zero_cumulative_is_no_fill_and_opens_no_session() -> None:
+    def forbidden_session() -> object:
+        raise AssertionError("zero fill evidence must not construct a DB session")
+
+    writer = FillObservationWriter(forbidden_session, enabled=True)  # type: ignore[arg-type]
+    result = await writer.write(_evidence(cumulative_quantity=Decimal(0)))
+
+    normalized = normalize_fill_evidence(_evidence(cumulative_quantity=Decimal(0)))
+    assert has_positive_fill(normalized) is False
+    assert result.status is FillObservationWriteStatus.NO_FILL_EVIDENCE
+    assert result.fill_delta_quantity == 0
+
+
+@pytest.mark.asyncio
+async def test_progressive_cumulative_partial_preserves_only_the_increase() -> None:
+    evidence = normalize_fill_evidence(_evidence(cumulative_quantity="5.5"))
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository(recorded=Decimal("2.5"))
+
+    result = await _record_with_repository(
+        repository,  # type: ignore[arg-type]
+        evidence=evidence,
+        identity=identity,
+        projection_names=("legacy_dual_read_validation.v1",),
+    )
+
+    assert result.status is FillObservationWriteStatus.INSERTED
+    assert result.fill_delta_quantity == Decimal("3.0")
+    assert result.outbox_count == 1
+    assert repository.appends[0]["fill_delta_quantity"] == Decimal("3.0")
+    assert repository.lock_keys == [identity.order_lock_key]
+
+
+@pytest.mark.asyncio
+async def test_same_cumulative_reobservation_is_zero_delta() -> None:
+    evidence = normalize_fill_evidence(
+        _evidence(broker_fill_sequence="new-sequence", cumulative_quantity="2.5")
+    )
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository(recorded=Decimal("2.5"))
+
+    result = await _record_with_repository(
+        repository,  # type: ignore[arg-type]
+        evidence=evidence,
+        identity=identity,
+        projection_names=("legacy_dual_read_validation.v1",),
+    )
+
+    assert result.status is FillObservationWriteStatus.NO_DELTA
+    assert result.fill_delta_quantity == 0
+    assert repository.appends == []
+
+
+@pytest.mark.asyncio
+async def test_identical_identity_replay_is_zero_delta_and_zero_outbox() -> None:
+    evidence = normalize_fill_evidence(_evidence())
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository(
+        existing=SimpleNamespace(id=17, evidence_hash=identity.evidence_hash)
+    )
+
+    result = await _record_with_repository(
+        repository,  # type: ignore[arg-type]
+        evidence=evidence,
+        identity=identity,
+        projection_names=("legacy_dual_read_validation.v1",),
+    )
+
+    assert result.status is FillObservationWriteStatus.DUPLICATE
+    assert result.observation_id == 17
+    assert result.fill_delta_quantity == 0
+    assert result.outbox_count == 0
+    assert repository.appends == []
+
+
+@pytest.mark.asyncio
+async def test_identity_payload_conflict_fails_closed_with_zero_write() -> None:
+    evidence = normalize_fill_evidence(_evidence())
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository(
+        existing=SimpleNamespace(id=17, evidence_hash="f" * 64)
+    )
+
+    with pytest.raises(FillObservationIdentityConflict):
+        await _record_with_repository(
+            repository,  # type: ignore[arg-type]
+            evidence=evidence,
+            identity=identity,
+            projection_names=("legacy_dual_read_validation.v1",),
+        )
+
+    assert repository.appends == []
+
+
+@pytest.mark.asyncio
+async def test_cumulative_regression_fails_closed_with_zero_write() -> None:
+    evidence = normalize_fill_evidence(_evidence(cumulative_quantity="2"))
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository(recorded=Decimal("3"))
+
+    with pytest.raises(NonMonotonicFillCumulative):
+        await _record_with_repository(
+            repository,  # type: ignore[arg-type]
+            evidence=evidence,
+            identity=identity,
+            projection_names=("legacy_dual_read_validation.v1",),
+        )
+
+    assert repository.appends == []
+
+
+@pytest.mark.asyncio
+async def test_sequence_only_fill_uses_reported_positive_quantity() -> None:
+    evidence = normalize_fill_evidence(
+        replace(
+            _evidence(),
+            broker_fill_sequence="fill-seq-7",
+            cumulative_quantity=None,
+            fill_quantity=Decimal("0.125"),
+        )
+    )
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository()
+
+    result = await _record_with_repository(
+        repository,  # type: ignore[arg-type]
+        evidence=evidence,
+        identity=identity,
+        projection_names=("legacy_dual_read_validation.v1",),
+    )
+
+    assert result.status is FillObservationWriteStatus.INSERTED
+    assert result.fill_delta_quantity == Decimal("0.125")

--- a/tests/services/fill_observation/test_identity_and_writer.py
+++ b/tests/services/fill_observation/test_identity_and_writer.py
@@ -12,6 +12,7 @@ from app.services.fill_observation import writer as writer_module
 from app.services.fill_observation.contracts import (
     BrokerFillEvidence,
     FillObservationWriteStatus,
+    FillSettlementStatus,
 )
 from app.services.fill_observation.errors import (
     FillObservationIdentityConflict,
@@ -61,11 +62,13 @@ class _FakeObservationRepository:
         *,
         recorded: Decimal = Decimal(0),
         existing: object | None = None,
+        settlements: list[SimpleNamespace] | None = None,
     ) -> None:
         self.recorded = recorded
         self.existing = existing
         self.lock_keys: list[int] = []
         self.appends: list[dict[str, object]] = []
+        self.settlements: list[SimpleNamespace] = list(settlements or [])
 
     async def lock_order_scope(self, lock_key: int) -> None:
         self.lock_keys.append(lock_key)
@@ -79,6 +82,34 @@ class _FakeObservationRepository:
     async def append(self, **kwargs: object) -> tuple[object, int]:
         self.appends.append(kwargs)
         return SimpleNamespace(id=91), len(kwargs["projection_names"])
+
+    async def latest_settlement(
+        self,
+        fill_observation_id: int,
+    ) -> SimpleNamespace | None:
+        rows = [
+            row
+            for row in self.settlements
+            if row.fill_observation_id == fill_observation_id
+        ]
+        return max(rows, key=lambda row: row.revision) if rows else None
+
+    async def append_settlement(
+        self,
+        *,
+        fill_observation_id: int,
+        evidence: object,
+        settlement: object,
+        revision: int,
+    ) -> SimpleNamespace:
+        row = SimpleNamespace(
+            fill_observation_id=fill_observation_id,
+            revision=revision,
+            settlement_hash=settlement.settlement_hash,  # type: ignore[attr-defined]
+            evidence=evidence,
+        )
+        self.settlements.append(row)
+        return row
 
 
 class _FakeWriterSession:
@@ -111,7 +142,7 @@ def test_identity_is_decimal_canonical_and_reobservation_stable() -> None:
 
     assert first.symbol == "BRK.B"
     assert first_identity.value == second_identity.value
-    assert first_identity.evidence_hash == second_identity.evidence_hash
+    assert first_identity.fill_fact_hash == second_identity.fill_fact_hash
     assert first_identity.order_lock_key == second_identity.order_lock_key
     assert -(2**63) <= first_identity.order_lock_key < 2**63
 
@@ -274,7 +305,14 @@ async def test_identical_identity_replay_is_zero_delta_and_zero_outbox() -> None
     evidence = normalize_fill_evidence(_evidence())
     identity = derive_fill_observation_identity(evidence)
     repository = _FakeObservationRepository(
-        existing=SimpleNamespace(id=17, evidence_hash=identity.evidence_hash)
+        existing=SimpleNamespace(id=17, fill_fact_hash=identity.fill_fact_hash),
+        settlements=[
+            SimpleNamespace(
+                fill_observation_id=17,
+                revision=1,
+                settlement_hash=identity.settlement.settlement_hash,
+            )
+        ],
     )
 
     result = await _record_with_repository(
@@ -288,7 +326,10 @@ async def test_identical_identity_replay_is_zero_delta_and_zero_outbox() -> None
     assert result.observation_id == 17
     assert result.fill_delta_quantity == 0
     assert result.outbox_count == 0
+    assert result.settlement_status is FillSettlementStatus.UNCHANGED
+    assert result.settlement_revision == 1
     assert repository.appends == []
+    assert len(repository.settlements) == 1
 
 
 @pytest.mark.asyncio
@@ -296,7 +337,7 @@ async def test_identity_payload_conflict_fails_closed_with_zero_write() -> None:
     evidence = normalize_fill_evidence(_evidence())
     identity = derive_fill_observation_identity(evidence)
     repository = _FakeObservationRepository(
-        existing=SimpleNamespace(id=17, evidence_hash="f" * 64)
+        existing=SimpleNamespace(id=17, fill_fact_hash="f" * 64)
     )
 
     with pytest.raises(FillObservationIdentityConflict):
@@ -308,6 +349,7 @@ async def test_identity_payload_conflict_fails_closed_with_zero_write() -> None:
         )
 
     assert repository.appends == []
+    assert repository.settlements == []
 
 
 @pytest.mark.asyncio
@@ -325,6 +367,221 @@ async def test_cumulative_regression_fails_closed_with_zero_write() -> None:
         )
 
     assert repository.appends == []
+
+
+@pytest.mark.parametrize(
+    "settlement_drift",
+    [
+        {"fee_total": Decimal("1.5")},
+        {"average_price": Decimal("430.31")},
+        {"last_fill_price": Decimal("430.40")},
+        {"cumulative_notional": Decimal("1075.75")},
+        {"filled_at": datetime(2026, 8, 1, 11, 59, 30, tzinfo=UTC)},
+        {"symbol": "brk-b"},
+    ],
+)
+def test_settlement_and_case_drift_keep_the_same_fill_fact(
+    settlement_drift: dict[str, object],
+) -> None:
+    first = derive_fill_observation_identity(normalize_fill_evidence(_evidence()))
+    second = derive_fill_observation_identity(
+        normalize_fill_evidence(_evidence(**settlement_drift))
+    )
+
+    assert first.value == second.value
+    assert first.fill_fact_hash == second.fill_fact_hash
+
+
+def test_us_symbol_case_drift_normalizes_without_touching_other_instruments() -> None:
+    assert normalize_fill_evidence(_evidence(symbol="brk-b")).symbol == "BRK.B"
+    assert normalize_fill_evidence(_evidence(symbol="aapl")).symbol == "AAPL"
+
+    crypto = normalize_fill_evidence(
+        _evidence(
+            broker="upbit",
+            venue="upbit",
+            instrument_type=InstrumentType.crypto,
+            symbol="krw-btc",
+            currency="KRW",
+        )
+    )
+    assert crypto.symbol == "krw-btc"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "changes_fill_fact"),
+    [
+        ({"side": "sell"}, True),
+        ({"symbol": "AAPL"}, True),
+        ({"currency": "krw"}, True),
+        ({"instrument_type": InstrumentType.equity_kr}, True),
+        ({"fee_total": Decimal("1.5")}, False),
+        ({"evidence_source": "websocket"}, False),
+    ],
+)
+def test_fill_fact_hash_covers_only_stable_broker_facts(
+    overrides: dict[str, object],
+    changes_fill_fact: bool,
+) -> None:
+    baseline = derive_fill_observation_identity(normalize_fill_evidence(_evidence()))
+    variant = derive_fill_observation_identity(
+        normalize_fill_evidence(_evidence(**overrides))
+    )
+
+    assert (baseline.fill_fact_hash != variant.fill_fact_hash) is changes_fill_fact
+
+
+def test_sequence_identity_ignores_cumulative_growth_in_the_fill_fact() -> None:
+    early = derive_fill_observation_identity(
+        normalize_fill_evidence(
+            _evidence(
+                broker_fill_sequence="fill-1",
+                cumulative_quantity="2.5",
+                fill_quantity="2.5",
+            )
+        )
+    )
+    later = derive_fill_observation_identity(
+        normalize_fill_evidence(
+            _evidence(
+                broker_fill_sequence="fill-1",
+                cumulative_quantity="10",
+                fill_quantity="2.5",
+            )
+        )
+    )
+    contradiction = derive_fill_observation_identity(
+        normalize_fill_evidence(
+            _evidence(
+                broker_fill_sequence="fill-1",
+                cumulative_quantity="10",
+                fill_quantity="9",
+            )
+        )
+    )
+
+    assert early.value == later.value == contradiction.value
+    assert early.fill_fact_hash == later.fill_fact_hash
+    assert early.settlement.settlement_hash != later.settlement.settlement_hash
+    # The sequence's own quantity is the fact it is keyed on, so a contradiction
+    # there is still a conflict.
+    assert contradiction.fill_fact_hash != early.fill_fact_hash
+
+
+def test_cumulative_identity_ignores_per_poll_reported_increment() -> None:
+    first = derive_fill_observation_identity(
+        normalize_fill_evidence(_evidence(fill_quantity="2.5"))
+    )
+    second = derive_fill_observation_identity(
+        normalize_fill_evidence(_evidence(fill_quantity=None))
+    )
+
+    assert first.value == second.value
+    assert first.fill_fact_hash == second.fill_fact_hash
+    assert first.settlement.settlement_hash != second.settlement.settlement_hash
+
+
+@pytest.mark.asyncio
+async def test_late_fee_settlement_is_a_revision_not_a_conflict() -> None:
+    booked = normalize_fill_evidence(_evidence(fee_total=Decimal(0)))
+    booked_identity = derive_fill_observation_identity(booked)
+    repository = _FakeObservationRepository(
+        existing=SimpleNamespace(id=17, fill_fact_hash=booked_identity.fill_fact_hash),
+        settlements=[
+            SimpleNamespace(
+                fill_observation_id=17,
+                revision=1,
+                settlement_hash=booked_identity.settlement.settlement_hash,
+            )
+        ],
+    )
+
+    settled = normalize_fill_evidence(
+        _evidence(fee_total=Decimal("1.5"), evidence_ref="another-poll:99")
+    )
+    settled_identity = derive_fill_observation_identity(settled)
+    result = await _record_with_repository(
+        repository,  # type: ignore[arg-type]
+        evidence=settled,
+        identity=settled_identity,
+        projection_names=("legacy_dual_read_validation.v1",),
+    )
+
+    assert result.status is FillObservationWriteStatus.DUPLICATE
+    assert result.fill_delta_quantity == 0
+    assert result.outbox_count == 0
+    assert result.settlement_status is FillSettlementStatus.RECORDED
+    assert result.settlement_revision == 2
+    assert repository.appends == []
+    assert [row.revision for row in repository.settlements] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_insert_records_the_first_settlement_revision() -> None:
+    evidence = normalize_fill_evidence(_evidence())
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository()
+
+    result = await _record_with_repository(
+        repository,  # type: ignore[arg-type]
+        evidence=evidence,
+        identity=identity,
+        projection_names=("legacy_dual_read_validation.v1",),
+    )
+
+    assert result.status is FillObservationWriteStatus.INSERTED
+    assert result.settlement_status is FillSettlementStatus.RECORDED
+    assert result.settlement_revision == 1
+    assert repository.settlements[0].fill_observation_id == 91
+
+
+@pytest.mark.asyncio
+async def test_fill_without_settlement_values_records_no_revision() -> None:
+    evidence = normalize_fill_evidence(
+        replace(
+            _evidence(),
+            broker_fill_sequence="fill-seq-11",
+            cumulative_quantity=None,
+            fill_quantity=None,
+            average_price=None,
+            filled_at=None,
+        )
+    )
+    assert has_positive_fill(evidence) is False
+
+    with_quantity = normalize_fill_evidence(
+        replace(
+            _evidence(),
+            broker_fill_sequence="fill-seq-11",
+            cumulative_quantity=None,
+            fill_quantity=Decimal("3"),
+            average_price=None,
+            filled_at=None,
+        )
+    )
+    identity = derive_fill_observation_identity(with_quantity)
+    assert identity.settlement.has_values is True
+
+
+@pytest.mark.asyncio
+async def test_no_delta_reobservation_records_no_settlement_revision() -> None:
+    evidence = normalize_fill_evidence(
+        _evidence(broker_fill_sequence="new-sequence", cumulative_quantity="2.5")
+    )
+    identity = derive_fill_observation_identity(evidence)
+    repository = _FakeObservationRepository(recorded=Decimal("2.5"))
+
+    result = await _record_with_repository(
+        repository,  # type: ignore[arg-type]
+        evidence=evidence,
+        identity=identity,
+        projection_names=("legacy_dual_read_validation.v1",),
+    )
+
+    assert result.status is FillObservationWriteStatus.NO_DELTA
+    assert result.settlement_status is FillSettlementStatus.NOT_APPLICABLE
+    assert result.settlement_revision is None
+    assert repository.settlements == []
 
 
 @pytest.mark.asyncio

--- a/tests/services/fill_observation/test_postgresql_integration.py
+++ b/tests/services/fill_observation/test_postgresql_integration.py
@@ -1,0 +1,777 @@
+"""Real-PostgreSQL acceptance for the ROB-1195 persistence boundary.
+
+Every test here runs the actual repository SQL, constraints, and triggers
+against the isolated pytest-owned local ``test_db`` database (see
+``tests/_run_owned_database.py``, which refuses any base URL whose database is
+not ``test_db``). No broker, external API, shared database, or production
+database is touched.
+
+Observations are append-only by design, so these tests can never delete their
+rows. Each test therefore scopes itself with a fresh UUID order scope and
+asserts only on its own rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import asyncpg
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import delete, func, select, text, update
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from app.core.config import settings
+from app.models.base import Base
+from app.models.fill_observation import (
+    FillObservation,
+    FillProjectionCursor,
+    FillProjectionOutbox,
+    FillSettlementEnrichment,
+)
+from app.models.trading import InstrumentType
+from app.services.fill_observation.contracts import (
+    BrokerFillEvidence,
+    FillObservationWriteStatus,
+    FillSettlementStatus,
+)
+from app.services.fill_observation.errors import (
+    FillObservationIdentityConflict,
+    FillProjectionCursorRegression,
+    FillProjectionLeaseMismatch,
+)
+from app.services.fill_observation.identity import (
+    derive_fill_observation_identity,
+    normalize_fill_evidence,
+)
+from app.services.fill_observation.projection import FillProjectionQueue
+from app.services.fill_observation.repository import (
+    FillObservationRepository,
+    FillProjectionRepository,
+)
+from app.services.fill_observation.writer import FillObservationWriter
+
+pytestmark = pytest.mark.integration
+
+REPO = Path(__file__).resolve().parents[3]
+PROJECTION = "legacy_dual_read_validation.v1"
+
+
+def _order_scope() -> dict[str, str]:
+    """Return a unique, never-reused order scope for one test."""
+    nonce = uuid.uuid4().hex
+    return {
+        "broker": "toss",
+        "account_ref": f"acct-{nonce}",
+        "account_mode": "live",
+        "venue": "toss_us",
+        "order_id": f"order-{nonce}",
+    }
+
+
+def _evidence(scope: dict[str, str], **overrides: object) -> BrokerFillEvidence:
+    values: dict[str, object] = {
+        **scope,
+        "instrument_type": InstrumentType.equity_us,
+        "symbol": "BRK-B",
+        "side": "buy",
+        "currency": "usd",
+        "evidence_source": "reconciler",
+        "evidence_ref": "toss_live_order_ledger:1",
+        "observed_at": datetime(2026, 8, 2, 12, 0, tzinfo=UTC),
+        "cumulative_quantity": Decimal("2.5"),
+        "average_price": Decimal("430.25"),
+        "fee_total": Decimal("0"),
+        "filled_at": datetime(2026, 8, 2, 11, 59, tzinfo=UTC),
+    }
+    values.update(overrides)
+    return BrokerFillEvidence(**values)  # type: ignore[arg-type]
+
+
+def _writer() -> FillObservationWriter:
+    """Build a writer that owns its own session exactly like production."""
+    return FillObservationWriter(enabled=True)
+
+
+async def _count_observations(session: AsyncSession, identity: str) -> int:
+    return int(
+        await session.scalar(
+            select(func.count())
+            .select_from(FillObservation)
+            .where(FillObservation.observation_identity == identity)
+        )
+        or 0
+    )
+
+
+async def _count_outbox(session: AsyncSession, observation_id: int) -> int:
+    return int(
+        await session.scalar(
+            select(func.count())
+            .select_from(FillProjectionOutbox)
+            .where(FillProjectionOutbox.fill_observation_id == observation_id)
+        )
+        or 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_observation_and_outbox_commit_together_in_one_transaction(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    result = await _writer().write(_evidence(scope))
+
+    assert result.status is FillObservationWriteStatus.INSERTED
+    assert result.observation_id is not None
+    assert result.outbox_count == 1
+
+    # Read the durable rows back through a fresh statement, not the write result.
+    observation = await db_session.scalar(
+        select(FillObservation).where(FillObservation.id == result.observation_id)
+    )
+    assert observation is not None
+    assert observation.fill_delta_quantity == Decimal("2.5")
+    assert observation.symbol == "BRK.B"
+
+    outbox_rows = list(
+        (
+            await db_session.scalars(
+                select(FillProjectionOutbox).where(
+                    FillProjectionOutbox.fill_observation_id == result.observation_id
+                )
+            )
+        ).all()
+    )
+    assert len(outbox_rows) == 1
+    assert outbox_rows[0].projection_name == PROJECTION
+    assert outbox_rows[0].state == "pending"
+    assert outbox_rows[0].lease_token is None
+
+
+@pytest.mark.asyncio
+async def test_failed_outbox_insert_rolls_back_the_observation(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    evidence = normalize_fill_evidence(_evidence(scope))
+    identity = derive_fill_observation_identity(evidence)
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            repository = FillObservationRepository(db_session)
+            await repository.append(
+                evidence=evidence,
+                identity=identity,
+                fill_delta_quantity=Decimal("2.5"),
+                projection_names=(PROJECTION,),
+            )
+            # A second delivery row for the same (projection, observation) pair
+            # violates uq_fill_projection_outbox_observation at flush time.
+            await db_session.execute(
+                text(
+                    "INSERT INTO review.fill_projection_outbox "
+                    "(delivery_key, projection_name, partition_key, "
+                    "fill_observation_id, state, attempt_count) "
+                    "SELECT :delivery_key, :projection, :partition, id, "
+                    "'pending', 0 FROM review.fill_observations "
+                    "WHERE observation_identity = :identity"
+                ),
+                {
+                    "delivery_key": uuid.uuid4().hex + uuid.uuid4().hex[:32],
+                    "projection": PROJECTION,
+                    "partition": identity.partition_key,
+                    "identity": identity.value,
+                },
+            )
+    await db_session.rollback()
+
+    assert await _count_observations(db_session, identity.value) == 0
+    orphan_outbox = await db_session.scalar(
+        select(func.count())
+        .select_from(FillProjectionOutbox)
+        .where(FillProjectionOutbox.partition_key == identity.partition_key)
+    )
+    assert orphan_outbox == 0
+
+
+@pytest.mark.asyncio
+async def test_writer_exception_leaves_neither_observation_nor_outbox(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    evidence = normalize_fill_evidence(_evidence(scope))
+    identity = derive_fill_observation_identity(evidence)
+
+    class _Boom(RuntimeError):
+        pass
+
+    with pytest.raises(_Boom):
+        async with db_session.begin():
+            repository = FillObservationRepository(db_session)
+            await repository.append(
+                evidence=evidence,
+                identity=identity,
+                fill_delta_quantity=Decimal("2.5"),
+                projection_names=(PROJECTION,),
+            )
+            raise _Boom("delivery planning failed after the append")
+    await db_session.rollback()
+
+    assert await _count_observations(db_session, identity.value) == 0
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(FillProjectionOutbox)
+            .where(FillProjectionOutbox.partition_key == identity.partition_key)
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_observation_update_delete_and_truncate_are_rejected(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    result = await _writer().write(_evidence(scope))
+    observation_id = result.observation_id
+    assert observation_id is not None
+
+    with pytest.raises(DBAPIError, match="append-only"):
+        await db_session.execute(
+            update(FillObservation)
+            .where(FillObservation.id == observation_id)
+            .values(fill_delta_quantity=Decimal("99"))
+        )
+        await db_session.commit()
+    await db_session.rollback()
+
+    with pytest.raises(DBAPIError, match="append-only"):
+        await db_session.execute(
+            delete(FillObservation).where(FillObservation.id == observation_id)
+        )
+        await db_session.commit()
+    await db_session.rollback()
+
+    with pytest.raises(DBAPIError, match="append-only"):
+        await db_session.execute(
+            text("TRUNCATE TABLE review.fill_observations CASCADE")
+        )
+    await db_session.rollback()
+
+    # The row survived every rejected mutation.
+    survivor = await db_session.scalar(
+        select(FillObservation).where(FillObservation.id == observation_id)
+    )
+    assert survivor is not None
+    assert survivor.fill_delta_quantity == Decimal("2.5")
+
+
+@pytest.mark.asyncio
+async def test_settlement_enrichment_is_append_only_and_never_mutates_the_fill(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    writer = _writer()
+
+    booked = await writer.write(_evidence(scope, fee_total=Decimal("0")))
+    assert booked.status is FillObservationWriteStatus.INSERTED
+    assert booked.settlement_status is FillSettlementStatus.RECORDED
+    assert booked.settlement_revision == 1
+    observation_id = booked.observation_id
+    assert observation_id is not None
+
+    # Same fill re-polled after fee settlement and average-price refinement.
+    settled = await writer.write(
+        _evidence(
+            scope,
+            fee_total=Decimal("1.5"),
+            average_price=Decimal("430.31"),
+            filled_at=datetime(2026, 8, 2, 11, 59, 30, tzinfo=UTC),
+            evidence_ref="toss_live_order_ledger:2",
+        )
+    )
+
+    assert settled.status is FillObservationWriteStatus.DUPLICATE
+    assert settled.fill_delta_quantity == 0
+    assert settled.outbox_count == 0
+    assert settled.settlement_status is FillSettlementStatus.RECORDED
+    assert settled.settlement_revision == 2
+
+    # Replaying the settled poll is idempotent.
+    replay = await writer.write(
+        _evidence(
+            scope,
+            fee_total=Decimal("1.5"),
+            average_price=Decimal("430.31"),
+            filled_at=datetime(2026, 8, 2, 11, 59, 30, tzinfo=UTC),
+            evidence_ref="toss_live_order_ledger:3",
+            observed_at=datetime(2026, 8, 2, 13, 0, tzinfo=UTC),
+        )
+    )
+    assert replay.settlement_status is FillSettlementStatus.UNCHANGED
+    assert replay.settlement_revision == 2
+
+    revisions = list(
+        (
+            await db_session.scalars(
+                select(FillSettlementEnrichment)
+                .where(FillSettlementEnrichment.fill_observation_id == observation_id)
+                .order_by(FillSettlementEnrichment.revision)
+            )
+        ).all()
+    )
+    assert [row.revision for row in revisions] == [1, 2]
+    assert revisions[0].fee_total == Decimal("0")
+    assert revisions[1].fee_total == Decimal("1.5")
+
+    # Exactly one observation, one outbox row, and an unchanged immutable row.
+    assert await _count_observations(db_session, booked.observation_identity or "") == 1
+    assert await _count_outbox(db_session, observation_id) == 1
+    observation = await db_session.scalar(
+        select(FillObservation).where(FillObservation.id == observation_id)
+    )
+    assert observation is not None
+    assert observation.fee_total == Decimal("0")
+    assert observation.filled_at == datetime(2026, 8, 2, 11, 59, tzinfo=UTC)
+
+    with pytest.raises(DBAPIError, match="append-only"):
+        await db_session.execute(
+            update(FillSettlementEnrichment)
+            .where(FillSettlementEnrichment.id == revisions[0].id)
+            .values(fee_total=Decimal("9"))
+        )
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_contradicted_fill_fact_still_fails_closed_with_zero_write(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    writer = _writer()
+    booked = await writer.write(_evidence(scope))
+    observation_id = booked.observation_id
+    assert observation_id is not None
+
+    with pytest.raises(FillObservationIdentityConflict):
+        await writer.write(_evidence(scope, side="sell"))
+
+    assert await _count_observations(db_session, booked.observation_identity or "") == 1
+    assert await _count_outbox(db_session, observation_id) == 1
+    settlement_rows = await db_session.scalar(
+        select(func.count())
+        .select_from(FillSettlementEnrichment)
+        .where(FillSettlementEnrichment.fill_observation_id == observation_id)
+    )
+    assert settlement_rows == 1
+
+
+async def _seed_two_partition_deliveries(
+    scope: dict[str, str],
+) -> tuple[int, int, str]:
+    writer = _writer()
+    first = await writer.write(
+        _evidence(
+            scope,
+            broker_fill_sequence="fill-1",
+            cumulative_quantity=Decimal("2.5"),
+            fill_quantity=Decimal("2.5"),
+        )
+    )
+    second = await writer.write(
+        _evidence(
+            scope,
+            broker_fill_sequence="fill-2",
+            cumulative_quantity=Decimal("4.0"),
+            fill_quantity=Decimal("1.5"),
+        )
+    )
+    assert first.observation_id is not None
+    assert second.observation_id is not None
+    identity = derive_fill_observation_identity(
+        normalize_fill_evidence(
+            _evidence(
+                scope,
+                broker_fill_sequence="fill-1",
+                cumulative_quantity=Decimal("2.5"),
+            )
+        )
+    )
+    return first.observation_id, second.observation_id, identity.partition_key
+
+
+@pytest.mark.asyncio
+async def test_unfinished_partition_predecessor_blocks_the_next_claim() -> None:
+    scope = _order_scope()
+    first_id, second_id, _partition = await _seed_two_partition_deliveries(scope)
+    queue = FillProjectionQueue()
+
+    claimed = await queue.claim(projection_name=PROJECTION, limit=50)
+    mine = [
+        delivery
+        for delivery in claimed
+        if delivery.fill_observation_id in {first_id, second_id}
+    ]
+    assert [delivery.fill_observation_id for delivery in mine] == [first_id]
+
+    # The successor stays invisible while its predecessor is unfinished.
+    again = await queue.claim(projection_name=PROJECTION, limit=50)
+    assert [
+        delivery.fill_observation_id
+        for delivery in again
+        if delivery.fill_observation_id == second_id
+    ] == []
+
+    await queue.complete(outbox_id=mine[0].outbox_id, lease_token=mine[0].lease_token)
+
+    after = await queue.claim(projection_name=PROJECTION, limit=50)
+    assert [
+        delivery.fill_observation_id
+        for delivery in after
+        if delivery.fill_observation_id == second_id
+    ] == [second_id]
+
+
+@pytest.mark.asyncio
+async def test_for_update_skip_locked_hides_rows_locked_by_another_session() -> None:
+    from app.core.db import AsyncSessionLocal
+
+    scope = _order_scope()
+    first_id, _second_id, _partition = await _seed_two_partition_deliveries(scope)
+
+    holder = AsyncSessionLocal()
+    try:
+        await holder.begin()
+        locked = await holder.scalar(
+            select(FillProjectionOutbox)
+            .where(FillProjectionOutbox.fill_observation_id == first_id)
+            .with_for_update()
+        )
+        assert locked is not None
+
+        claimed = await FillProjectionQueue().claim(
+            projection_name=PROJECTION, limit=50
+        )
+        assert [
+            delivery.fill_observation_id
+            for delivery in claimed
+            if delivery.fill_observation_id == first_id
+        ] == []
+    finally:
+        await holder.rollback()
+        await holder.close()
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_is_refenced_and_the_stale_token_is_rejected(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    first_id, _second_id, _partition = await _seed_two_partition_deliveries(scope)
+
+    stale_clock = datetime(2026, 8, 2, 9, 0, tzinfo=UTC)
+    stale_queue = FillProjectionQueue(clock=lambda: stale_clock)
+    stale = await stale_queue.claim(
+        projection_name=PROJECTION, limit=50, lease_seconds=1
+    )
+    stale_mine = [
+        delivery for delivery in stale if delivery.fill_observation_id == first_id
+    ]
+    assert len(stale_mine) == 1
+
+    fresh_clock = stale_clock + timedelta(hours=1)
+    fresh_queue = FillProjectionQueue(clock=lambda: fresh_clock)
+    refenced = await fresh_queue.claim(projection_name=PROJECTION, limit=50)
+    refenced_mine = [
+        delivery for delivery in refenced if delivery.fill_observation_id == first_id
+    ]
+    assert len(refenced_mine) == 1
+    assert refenced_mine[0].lease_token != stale_mine[0].lease_token
+    assert refenced_mine[0].attempt_count == stale_mine[0].attempt_count + 1
+
+    with pytest.raises(FillProjectionLeaseMismatch):
+        await fresh_queue.complete(
+            outbox_id=stale_mine[0].outbox_id,
+            lease_token=stale_mine[0].lease_token,
+        )
+
+    with pytest.raises(FillProjectionLeaseMismatch):
+        await fresh_queue.retry(
+            outbox_id=stale_mine[0].outbox_id,
+            lease_token=stale_mine[0].lease_token,
+            error="stale worker",
+        )
+
+    await fresh_queue.complete(
+        outbox_id=refenced_mine[0].outbox_id,
+        lease_token=refenced_mine[0].lease_token,
+    )
+    settled = await db_session.scalar(
+        select(FillProjectionOutbox).where(
+            FillProjectionOutbox.id == refenced_mine[0].outbox_id
+        )
+    )
+    assert settled is not None
+    assert settled.state == "succeeded"
+    assert settled.lease_token is None
+    assert settled.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cursor_advances_forward_and_refuses_to_move_backwards(
+    db_session: AsyncSession,
+) -> None:
+    scope = _order_scope()
+    first_id, second_id, partition = await _seed_two_partition_deliveries(scope)
+    queue = FillProjectionQueue()
+
+    first_batch = await queue.claim(projection_name=PROJECTION, limit=50)
+    first_delivery = next(
+        delivery for delivery in first_batch if delivery.fill_observation_id == first_id
+    )
+    await queue.complete(
+        outbox_id=first_delivery.outbox_id,
+        lease_token=first_delivery.lease_token,
+    )
+
+    cursor = await db_session.scalar(
+        select(FillProjectionCursor)
+        .where(FillProjectionCursor.projection_name == PROJECTION)
+        .where(FillProjectionCursor.partition_key == partition)
+    )
+    assert cursor is not None
+    assert cursor.last_fill_observation_id == first_id
+
+    second_batch = await queue.claim(projection_name=PROJECTION, limit=50)
+    second_delivery = next(
+        delivery
+        for delivery in second_batch
+        if delivery.fill_observation_id == second_id
+    )
+    await queue.complete(
+        outbox_id=second_delivery.outbox_id,
+        lease_token=second_delivery.lease_token,
+    )
+
+    # The pre-existing cursor advanced instead of being recreated.
+    await db_session.refresh(cursor)
+    assert cursor.last_fill_observation_id == second_id
+    assert cursor.advanced_at is not None
+
+    # Replaying the older delivery must never move the cursor backwards.
+    await db_session.commit()
+    async with db_session.begin():
+        repository = FillProjectionRepository(db_session)
+        replayed = await repository.get_outbox_for_update(first_delivery.outbox_id)
+        assert replayed is not None
+        replayed.state = "processing"
+        replayed.lease_token = uuid.uuid4()
+        replayed.lease_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+        replayed.completed_at = None
+        stale_token = replayed.lease_token
+
+    with pytest.raises(FillProjectionCursorRegression):
+        await queue.complete(
+            outbox_id=first_delivery.outbox_id,
+            lease_token=stale_token,
+        )
+    await db_session.rollback()
+
+    survivor = await db_session.scalar(
+        select(FillProjectionCursor)
+        .where(FillProjectionCursor.projection_name == PROJECTION)
+        .where(FillProjectionCursor.partition_key == partition)
+    )
+    assert survivor is not None
+    assert survivor.last_fill_observation_id == second_id
+
+
+@pytest.mark.asyncio
+async def test_cursor_identity_mismatch_fails_closed(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.fill_observation.errors import FillProjectionDeliveryError
+
+    scope = _order_scope()
+    first_id, _second_id, partition = await _seed_two_partition_deliveries(scope)
+    queue = FillProjectionQueue()
+
+    batch = await queue.claim(projection_name=PROJECTION, limit=50)
+    delivery = next(item for item in batch if item.fill_observation_id == first_id)
+    await queue.complete(outbox_id=delivery.outbox_id, lease_token=delivery.lease_token)
+
+    # Corrupt only the durable cursor identity, then replay the same delivery.
+    await db_session.rollback()
+    async with db_session.begin():
+        cursor = await db_session.scalar(
+            select(FillProjectionCursor)
+            .where(FillProjectionCursor.projection_name == PROJECTION)
+            .where(FillProjectionCursor.partition_key == partition)
+        )
+        assert cursor is not None
+        cursor.last_observation_identity = "a" * 64
+        outbox = await db_session.scalar(
+            select(FillProjectionOutbox).where(
+                FillProjectionOutbox.id == delivery.outbox_id
+            )
+        )
+        assert outbox is not None
+        outbox.state = "processing"
+        outbox.lease_token = uuid.uuid4()
+        outbox.lease_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+        outbox.completed_at = None
+        replay_token = outbox.lease_token
+
+    with pytest.raises(FillProjectionDeliveryError):
+        await queue.complete(outbox_id=delivery.outbox_id, lease_token=replay_token)
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("retrospective_action_control_lock")
+async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
+    """Apply, roll back, and re-apply ROB-1195 on a throwaway local database."""
+    base_url = make_url(settings.DATABASE_URL)
+    if base_url.get_backend_name() != "postgresql":
+        pytest.skip("ROB-1195 migration acceptance requires PostgreSQL")
+
+    config = Config(str(REPO / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO / "alembic"))
+    script = ScriptDirectory.from_config(config)
+    heads = script.get_heads()
+    assert heads == ["20260801_rob1195_fillobs"]
+
+    database = f"rob1195_migration_{uuid.uuid4().hex}"
+    admin = await asyncpg.connect(
+        user=base_url.username,
+        password=base_url.password,
+        host=base_url.host,
+        port=base_url.port,
+        database="postgres",
+    )
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    target_url = base_url.set(database=database)
+    target_url_text = target_url.render_as_string(hide_password=False)
+    engine = create_async_engine(target_url_text)
+    try:
+        async with engine.begin() as connection:
+            for schema in ("paper", "research", "review"):
+                await connection.execute(
+                    text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+                )
+            await connection.run_sync(Base.metadata.create_all)
+            # create_all materializes the current head. Remove exactly the
+            # ROB-1195 boundary so the migration itself is executed here.
+            for table in (
+                "fill_projection_cursors",
+                "fill_projection_outbox",
+                "fill_settlement_enrichments",
+                "fill_observations",
+            ):
+                await connection.execute(text(f"DROP TABLE review.{table}"))
+
+        env = {**os.environ, "DATABASE_URL": target_url_text}
+
+        def alembic(*args: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [str(REPO / ".venv/bin/alembic"), *args],
+                cwd=REPO,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        for command in (
+            ("stamp", "20260728_rob1109_watch_intent"),
+            ("upgrade", "head"),
+            ("downgrade", "20260728_rob1109_watch_intent"),
+            ("upgrade", "head"),
+        ):
+            completed = await asyncio.to_thread(alembic, *command)
+            assert completed.returncode == 0, completed.stdout + completed.stderr
+
+        current = await asyncio.to_thread(alembic, "current")
+        assert current.returncode == 0, current.stdout + current.stderr
+        assert "20260801_rob1195_fillobs (head)" in current.stdout
+
+        async with engine.connect() as connection:
+            triggers = await connection.scalar(
+                text(
+                    "SELECT count(*) FROM pg_trigger AS t "
+                    "JOIN pg_proc AS p ON p.oid = t.tgfoid "
+                    "WHERE p.proname = 'reject_fill_observation_mutation' "
+                    "AND NOT t.tgisinternal"
+                )
+            )
+            assert triggers == 4
+
+            # The migration-built shape must equal the ORM metadata, otherwise
+            # the test-schema bootstrap and a migrated database diverge.
+            for model in (
+                FillObservation,
+                FillSettlementEnrichment,
+                FillProjectionOutbox,
+                FillProjectionCursor,
+            ):
+                table = model.__table__
+                rows = (
+                    await connection.execute(
+                        text(
+                            "SELECT column_name, is_nullable "
+                            "FROM information_schema.columns "
+                            "WHERE table_schema = 'review' "
+                            "AND table_name = :name"
+                        ),
+                        {"name": table.name},
+                    )
+                ).all()
+                migrated = {name: nullable == "YES" for name, nullable in rows}
+                declared = {
+                    column.name: bool(column.nullable) for column in table.columns
+                }
+                assert migrated == declared, table.name
+
+        # An evidence row makes the destructive downgrade refuse to run.
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "INSERT INTO review.fill_observations ("
+                    "observation_identity, identity_kind, broker, account_ref, "
+                    "account_mode, venue, order_id, instrument_type, symbol, "
+                    "side, currency, cumulative_quantity, fill_delta_quantity, "
+                    "evidence_source, evidence_ref, fill_fact_hash, observed_at"
+                    ") VALUES ("
+                    ":identity, 'cumulative_quantity', 'toss', 'acct-guard', "
+                    "'live', 'toss_us', 'order-guard', 'equity_us', 'BRK.B', "
+                    "'buy', 'USD', 2.5, 2.5, 'reconciler', 'ledger:1', "
+                    ":fact_hash, now())"
+                ),
+                {"identity": "b" * 64, "fact_hash": "c" * 64},
+            )
+        refused = await asyncio.to_thread(
+            alembic, "downgrade", "20260728_rob1109_watch_intent"
+        )
+        assert refused.returncode != 0
+        assert "cannot downgrade" in (refused.stdout + refused.stderr)
+    finally:
+        await engine.dispose()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = $1 AND pid <> pg_backend_pid()",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE IF EXISTS "{database}"')
+        await admin.close()

--- a/tests/services/fill_observation/test_projection_queue.py
+++ b/tests/services/fill_observation/test_projection_queue.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.fill_observation import projection as projection_module
+from app.services.fill_observation.errors import (
+    FillProjectionCursorRegression,
+    FillProjectionLeaseMismatch,
+)
+from app.services.fill_observation.projection import FillProjectionQueue
+
+pytestmark = pytest.mark.unit
+
+
+class _AsyncContext:
+    def __init__(self, value: object, on_enter: object | None = None) -> None:
+        self.value = value
+        self.on_enter = on_enter
+
+    async def __aenter__(self) -> object:
+        if callable(self.on_enter):
+            self.on_enter()
+        return self.value
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.transactions = 0
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    def begin(self) -> _AsyncContext:
+        return _AsyncContext(None, self._begin)
+
+    def _begin(self) -> None:
+        self.transactions += 1
+
+
+class _FakeProjectionRepository:
+    def __init__(self) -> None:
+        self.outbox: object | None = None
+        self.observation = SimpleNamespace(
+            id=7,
+            observation_identity="a" * 64,
+        )
+        self.cursor: object | None = None
+        self.added_cursor: object | None = None
+        self.claimed: list[object] = []
+        self.lock_keys: list[int] = []
+        self.flushed = 0
+
+    async def claim_ready(self, **_kwargs: object) -> list[object]:
+        return self.claimed
+
+    async def get_observation(self, _observation_id: int) -> object:
+        return self.observation
+
+    async def get_outbox_for_update(self, _outbox_id: int) -> object | None:
+        return self.outbox
+
+    async def lock_projection_partition(self, lock_key: int) -> None:
+        self.lock_keys.append(lock_key)
+
+    async def get_cursor_for_update(self, **_kwargs: object) -> object | None:
+        return self.cursor
+
+    def add_cursor(self, **kwargs: object) -> None:
+        observation = kwargs["observation"]
+        self.added_cursor = SimpleNamespace(
+            projection_name=kwargs["projection_name"],
+            partition_key=kwargs["partition_key"],
+            last_fill_observation_id=observation.id,  # type: ignore[attr-defined]
+            last_observation_identity=(
+                observation.observation_identity  # type: ignore[attr-defined]
+            ),
+        )
+
+    async def flush(self) -> None:
+        self.flushed += 1
+
+
+def _queue(
+    monkeypatch: pytest.MonkeyPatch,
+    repository: _FakeProjectionRepository,
+    *,
+    now: datetime,
+    token: uuid.UUID,
+) -> tuple[FillProjectionQueue, _FakeSession]:
+    session = _FakeSession()
+    monkeypatch.setattr(
+        projection_module,
+        "FillProjectionRepository",
+        lambda _session: repository,
+    )
+    queue = FillProjectionQueue(
+        lambda: session,  # type: ignore[arg-type]
+        clock=lambda: now,
+        token_factory=lambda: token,
+    )
+    return queue, session
+
+
+@pytest.mark.asyncio
+async def test_claim_returns_durable_delivery_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    token = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    repository = _FakeProjectionRepository()
+    repository.claimed = [
+        SimpleNamespace(
+            id=3,
+            delivery_key="b" * 64,
+            projection_name="legacy_dual_read_validation.v1",
+            partition_key="c" * 64,
+            fill_observation_id=7,
+            attempt_count=2,
+        )
+    ]
+    queue, session = _queue(
+        monkeypatch,
+        repository,
+        now=now,
+        token=token,
+    )
+
+    deliveries = await queue.claim(projection_name="legacy_dual_read_validation.v1")
+
+    assert len(deliveries) == 1
+    assert deliveries[0].observation_identity == "a" * 64
+    assert deliveries[0].attempt_count == 2
+    assert deliveries[0].lease_token == token
+    assert session.transactions == 1
+
+
+@pytest.mark.asyncio
+async def test_completion_advances_cursor_and_outbox_in_one_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    token = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    repository = _FakeProjectionRepository()
+    repository.outbox = SimpleNamespace(
+        id=3,
+        state="processing",
+        lease_token=token,
+        lease_expires_at=now,
+        projection_name="legacy_dual_read_validation.v1",
+        partition_key="c" * 64,
+        fill_observation_id=7,
+        last_error="old",
+        completed_at=None,
+        updated_at=None,
+    )
+    queue, session = _queue(
+        monkeypatch,
+        repository,
+        now=now,
+        token=token,
+    )
+
+    await queue.complete(outbox_id=3, lease_token=token)
+
+    outbox = repository.outbox
+    assert outbox is not None
+    assert outbox.state == "succeeded"  # type: ignore[attr-defined]
+    assert outbox.completed_at == now  # type: ignore[attr-defined]
+    assert outbox.lease_token is None  # type: ignore[attr-defined]
+    assert repository.added_cursor is not None
+    assert (
+        repository.added_cursor.last_observation_identity  # type: ignore[attr-defined]
+        == "a" * 64
+    )
+    assert len(repository.lock_keys) == 1
+    assert -(2**63) <= repository.lock_keys[0] < 2**63
+    assert repository.flushed == 1
+    assert session.transactions == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_persists_error_and_clears_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    token = uuid.UUID("33333333-3333-3333-3333-333333333333")
+    repository = _FakeProjectionRepository()
+    repository.outbox = SimpleNamespace(
+        state="processing",
+        lease_token=token,
+        lease_expires_at=now,
+        last_error=None,
+        completed_at=None,
+        available_at=now,
+        updated_at=None,
+    )
+    queue, session = _queue(
+        monkeypatch,
+        repository,
+        now=now,
+        token=token,
+    )
+
+    await queue.retry(
+        outbox_id=3,
+        lease_token=token,
+        error="projection failed",
+        retry_after_seconds=30,
+    )
+
+    outbox = repository.outbox
+    assert outbox is not None
+    assert outbox.state == "retry"  # type: ignore[attr-defined]
+    assert outbox.last_error == "projection failed"  # type: ignore[attr-defined]
+    assert outbox.lease_token is None  # type: ignore[attr-defined]
+    assert int((outbox.available_at - now).total_seconds()) == 30  # type: ignore[attr-defined]
+    assert repository.flushed == 1
+    assert session.transactions == 1
+
+
+@pytest.mark.asyncio
+async def test_completion_with_wrong_lease_fails_before_cursor_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    token = uuid.UUID("44444444-4444-4444-4444-444444444444")
+    repository = _FakeProjectionRepository()
+    repository.outbox = SimpleNamespace(
+        state="processing",
+        lease_token=token,
+    )
+    queue, _session = _queue(
+        monkeypatch,
+        repository,
+        now=now,
+        token=token,
+    )
+
+    with pytest.raises(FillProjectionLeaseMismatch):
+        await queue.complete(outbox_id=3, lease_token=uuid.uuid4())
+
+    assert repository.added_cursor is None
+    assert repository.flushed == 0
+
+
+@pytest.mark.asyncio
+async def test_completion_older_than_cursor_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    token = uuid.UUID("55555555-5555-5555-5555-555555555555")
+    repository = _FakeProjectionRepository()
+    repository.outbox = SimpleNamespace(
+        state="processing",
+        lease_token=token,
+        projection_name="legacy_dual_read_validation.v1",
+        partition_key="c" * 64,
+        fill_observation_id=7,
+        last_error=None,
+        completed_at=None,
+        updated_at=None,
+    )
+    repository.cursor = SimpleNamespace(
+        last_fill_observation_id=8,
+        last_observation_identity="b" * 64,
+        advanced_at=now,
+        updated_at=now,
+    )
+    queue, _session = _queue(
+        monkeypatch,
+        repository,
+        now=now,
+        token=token,
+    )
+
+    with pytest.raises(FillProjectionCursorRegression):
+        await queue.complete(outbox_id=3, lease_token=token)
+
+    assert repository.outbox.state == "processing"  # type: ignore[union-attr]
+    assert repository.flushed == 0

--- a/tests/services/fill_observation/test_schema_and_boundaries.py
+++ b/tests/services/fill_observation/test_schema_and_boundaries.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from app.models.fill_observation import (
+    FillObservation,
+    FillProjectionCursor,
+    FillProjectionOutbox,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[3]
+MIGRATION = REPO / "alembic/versions/20260801_rob1195_fill_observation_foundation.py"
+SERVICE_ROOT = REPO / "app/services/fill_observation"
+SCHEMA_BOOTSTRAP = REPO / "tests/_schema_bootstrap.py"
+
+
+def _constraint_names(model: type[object]) -> set[str]:
+    return {
+        str(constraint.name)
+        for constraint in model.__table__.constraints  # type: ignore[attr-defined]
+        if constraint.name is not None
+    }
+
+
+def test_models_define_observation_outbox_and_cursor_uniqueness() -> None:
+    observation_constraints = _constraint_names(FillObservation)
+    outbox_constraints = _constraint_names(FillProjectionOutbox)
+
+    assert "uq_fill_observation_identity" in observation_constraints
+    assert "uq_fill_projection_outbox_delivery_key" in outbox_constraints
+    assert "uq_fill_projection_outbox_observation" in outbox_constraints
+    assert [column.name for column in FillProjectionCursor.__table__.primary_key] == [
+        "projection_name",
+        "partition_key",
+    ]
+    assert FillObservation.__table__.schema == "review"
+    assert FillProjectionOutbox.__table__.schema == "review"
+    assert FillProjectionCursor.__table__.schema == "review"
+
+
+def test_observation_has_no_mutable_updated_at_column() -> None:
+    assert "updated_at" not in FillObservation.__table__.columns
+    assert "created_at" in FillObservation.__table__.columns
+    assert "fill_delta_quantity" in FillObservation.__table__.columns
+    assert "cumulative_quantity" in FillObservation.__table__.columns
+
+
+def test_migration_is_single_head_and_has_no_data_movement() -> None:
+    source = MIGRATION.read_text(encoding="utf-8")
+    assert 'revision: str = "20260801_rob1195_fillobs"' in source
+    assert (
+        'down_revision: str | Sequence[str] | None = "20260728_rob1109_watch_intent"'
+    ) in source
+
+    config = Config(str(REPO / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO / "alembic"))
+    assert ScriptDirectory.from_config(config).get_heads() == [
+        "20260801_rob1195_fillobs"
+    ]
+    assert "op.bulk_insert" not in source
+    assert "INSERT INTO" not in source
+    assert "UPDATE review." not in source
+    assert "DELETE FROM" not in source
+
+
+def test_migration_enforces_append_only_and_non_destructive_rollback() -> None:
+    source = MIGRATION.read_text(encoding="utf-8")
+    bootstrap = SCHEMA_BOOTSTRAP.read_text(encoding="utf-8")
+    assert "reject_fill_observation_mutation" in source
+    assert "BEFORE UPDATE OR DELETE ON review.fill_observations" in source
+    assert "BEFORE TRUNCATE ON review.fill_observations" in source
+    assert "cannot downgrade: review.fill_observations contains" in source
+    assert "SCHEMA_BOOTSTRAP_VERSION = 34" in bootstrap
+    assert "reject_fill_observation_mutation" in bootstrap
+
+
+def test_migration_contains_durable_retry_and_cursor_fields() -> None:
+    source = MIGRATION.read_text(encoding="utf-8")
+    for required in (
+        "fill_projection_outbox",
+        "fill_projection_cursors",
+        "uq_fill_projection_outbox_observation",
+        "uq_fill_projection_outbox_delivery_key",
+        "attempt_count",
+        "available_at",
+        "lease_token",
+        "lease_expires_at",
+        "last_error",
+        "last_fill_observation_id",
+        "last_observation_identity",
+    ):
+        assert required in source
+
+
+def test_fill_service_has_no_broker_mcp_scheduler_or_llm_imports() -> None:
+    forbidden_prefixes = (
+        "app.mcp_server",
+        "app.tasks",
+        "app.jobs",
+        "app.services.brokers",
+        "openai",
+        "google.generativeai",
+        "anthropic",
+        "xai",
+    )
+    violations: list[str] = []
+    for path in SERVICE_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            module: str | None = None
+            if isinstance(node, ast.ImportFrom):
+                module = node.module
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith(forbidden_prefixes):
+                        violations.append(f"{path.relative_to(REPO)}:{alias.name}")
+            if module is not None and module.startswith(forbidden_prefixes):
+                violations.append(f"{path.relative_to(REPO)}:{module}")
+    assert violations == []
+
+
+def test_lock_keys_are_stable_hash_bytes_and_transactions_have_no_inner_commit() -> (
+    None
+):
+    identity_source = (SERVICE_ROOT / "identity.py").read_text(encoding="utf-8")
+    repository_source = (SERVICE_ROOT / "repository.py").read_text(encoding="utf-8")
+    writer_source = (SERVICE_ROOT / "writer.py").read_text(encoding="utf-8")
+
+    assert "int.from_bytes" in identity_source
+    assert "signed=True" in identity_source
+    assert "hash(" not in identity_source
+    assert "pg_advisory_xact_lock(:lock_key)" in repository_source
+    assert ".commit(" not in repository_source
+    assert "async with session.begin()" in writer_source
+
+
+def test_projection_claim_blocks_unfinished_partition_predecessors() -> None:
+    repository_source = (SERVICE_ROOT / "repository.py").read_text(encoding="utf-8")
+
+    assert "unfinished_predecessor" in repository_source
+    assert 'predecessor.state != "succeeded"' in repository_source
+    assert ".where(~unfinished_predecessor)" in repository_source
+
+
+def test_new_models_are_constructed_only_inside_service_repository() -> None:
+    model_names = {
+        "FillObservation",
+        "FillProjectionCursor",
+        "FillProjectionOutbox",
+    }
+    allowed = Path("app/services/fill_observation/repository.py")
+    violations: list[str] = []
+    for root in (REPO / "app", REPO / "scripts"):
+        for path in root.rglob("*.py"):
+            relative = path.relative_to(REPO)
+            if relative == allowed or relative == Path(
+                "app/models/fill_observation.py"
+            ):
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id in model_names
+                ):
+                    violations.append(f"{relative}:{node.lineno}:{node.func.id}")
+    assert violations == []
+
+
+def test_no_existing_consumer_imports_the_new_writer() -> None:
+    allowed_root = Path("app/services/fill_observation")
+    violations: list[str] = []
+    for path in (REPO / "app").rglob("*.py"):
+        relative = path.relative_to(REPO)
+        if allowed_root in relative.parents or relative == Path(
+            "app/models/__init__.py"
+        ):
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "app.services.fill_observation" in source:
+            violations.append(str(relative))
+    assert violations == []

--- a/tests/services/fill_observation/test_schema_and_boundaries.py
+++ b/tests/services/fill_observation/test_schema_and_boundaries.py
@@ -11,6 +11,7 @@ from app.models.fill_observation import (
     FillObservation,
     FillProjectionCursor,
     FillProjectionOutbox,
+    FillSettlementEnrichment,
 )
 
 pytestmark = pytest.mark.unit
@@ -52,6 +53,40 @@ def test_observation_has_no_mutable_updated_at_column() -> None:
     assert "cumulative_quantity" in FillObservation.__table__.columns
 
 
+def test_settlement_enrichment_is_append_only_and_revision_scoped() -> None:
+    table = FillSettlementEnrichment.__table__
+    assert table.schema == "review"
+    assert "updated_at" not in table.columns
+    assert "uq_fill_settlement_enrichment_revision" in _constraint_names(
+        FillSettlementEnrichment
+    )
+    for column in (
+        "fill_observation_id",
+        "revision",
+        "settlement_hash",
+        "fee_total",
+        "average_price",
+        "last_fill_price",
+        "cumulative_notional",
+        "filled_at",
+    ):
+        assert column in table.columns
+
+
+def test_settlement_service_never_updates_the_immutable_observation() -> None:
+    repository_source = (SERVICE_ROOT / "repository.py").read_text(encoding="utf-8")
+    writer_source = (SERVICE_ROOT / "writer.py").read_text(encoding="utf-8")
+
+    # Settlement is appended as a new revision row; nothing writes back onto an
+    # existing FillObservation instance or issues an UPDATE against it.
+    assert "append_settlement" in repository_source
+    assert "sqlalchemy import update" not in repository_source
+    assert "update(FillObservation)" not in repository_source
+    assert "existing." not in writer_source.replace("existing.id", "").replace(
+        "existing.fill_fact_hash", ""
+    )
+
+
 def test_migration_is_single_head_and_has_no_data_movement() -> None:
     source = MIGRATION.read_text(encoding="utf-8")
     assert 'revision: str = "20260801_rob1195_fillobs"' in source
@@ -76,9 +111,12 @@ def test_migration_enforces_append_only_and_non_destructive_rollback() -> None:
     assert "reject_fill_observation_mutation" in source
     assert "BEFORE UPDATE OR DELETE ON review.fill_observations" in source
     assert "BEFORE TRUNCATE ON review.fill_observations" in source
+    assert "BEFORE UPDATE OR DELETE ON review.fill_settlement_enrichments" in source
+    assert "BEFORE TRUNCATE ON review.fill_settlement_enrichments" in source
     assert "cannot downgrade: review.fill_observations contains" in source
-    assert "SCHEMA_BOOTSTRAP_VERSION = 34" in bootstrap
+    assert "SCHEMA_BOOTSTRAP_VERSION = 35" in bootstrap
     assert "reject_fill_observation_mutation" in bootstrap
+    assert "trg_fill_settlement_enrichments_immutable" in bootstrap
 
 
 def test_migration_contains_durable_retry_and_cursor_fields() -> None:
@@ -86,8 +124,12 @@ def test_migration_contains_durable_retry_and_cursor_fields() -> None:
     for required in (
         "fill_projection_outbox",
         "fill_projection_cursors",
+        "fill_settlement_enrichments",
         "uq_fill_projection_outbox_observation",
         "uq_fill_projection_outbox_delivery_key",
+        "uq_fill_settlement_enrichment_revision",
+        "fk_fill_settlement_enrichment_observation",
+        "settlement_hash",
         "attempt_count",
         "available_at",
         "lease_token",
@@ -154,6 +196,7 @@ def test_new_models_are_constructed_only_inside_service_repository() -> None:
         "FillObservation",
         "FillProjectionCursor",
         "FillProjectionOutbox",
+        "FillSettlementEnrichment",
     }
     allowed = Path("app/services/fill_observation/repository.py")
     violations: list[str] = []

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -128,6 +128,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             # the ROB-849 boundary so later migrations are exercised instead
             # of colliding with tables that create_all already materialized.
             for table in (
+                "fill_projection_cursors",
+                "fill_projection_outbox",
+                "fill_observations",
+            ):
+                await connection.execute(text(f"DROP TABLE review.{table}"))
+            for table in (
                 "strategy_learning_events",
                 "evaluation_scorecards",
                 "evaluation_verdicts",

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -130,6 +130,7 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             for table in (
                 "fill_projection_cursors",
                 "fill_projection_outbox",
+                "fill_settlement_enrichments",
                 "fill_observations",
             ):
                 await connection.execute(text(f"DROP TABLE review.{table}"))

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -126,6 +126,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             await connection.run_sync(Base.metadata.create_all)
             # Base metadata includes the current head, while this test stamps
             # ROB-850 and replays every later migration.
+            for table in (
+                "fill_projection_cursors",
+                "fill_projection_outbox",
+                "fill_observations",
+            ):
+                await connection.execute(text(f"DROP TABLE review.{table}"))
             await connection.execute(
                 text("DROP TABLE research.strategy_learning_events")
             )

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -129,6 +129,7 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             for table in (
                 "fill_projection_cursors",
                 "fill_projection_outbox",
+                "fill_settlement_enrichments",
                 "fill_observations",
             ):
                 await connection.execute(text(f"DROP TABLE review.{table}"))


### PR DESCRIPTION
## Summary

- add immutable `review.fill_observations` authority with deterministic broker-evidence identity and progressive cumulative delta handling
- add atomic per-projection outbox, ordered lease/retry semantics, and durable projection cursors
- add default-off service writer, read-only legacy dual-read validator, static/unit contracts, and writer-off rollback runbook

## Safety boundary

- no existing broker/reconcile consumer is wired or cut over
- `FILL_OBSERVATION_WRITER_ENABLED` is false and fail-closed by default
- no scheduler, broker/API call, live backfill, ledger mutation, gate change, or migration apply is included
- existing `review.trades`, execution ledger, and broker-native ledgers remain unchanged

## Validation

- `uv run pytest -q tests/services/fill_observation tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py tests/test_conftest_schema_patches.py` — 45 passed
- `make lint` — Ruff check/format and ty all passed
- `uv run python -m py_compile alembic/versions/20260801_rob1195_fill_observation_foundation.py app/models/fill_observation.py app/services/fill_observation/*.py` — passed
- `uv run alembic heads` — `20260801_rob1195_fillobs (head)`
- `git diff --check` — passed

Per the approved A-1 boundary, no integration tests, database upgrade, shared-DB write, broker call, or live backfill were run.

## Coordination note

Open PR #1640 also touches `tests/services/paper_evaluation/test_migration.py`. This branch only adds the three new ROB-1195 tables to that test and the separate paper-cohort replay test pre-replay drop lists. Any overlap with #1640 should therefore be a mechanical rebase conflict, with no intended semantic coupling.