### PR TITLE
[ROB-1036] Add uber-invalid-sample-eligibility.v1 contract + post-fill writer

### DIFF
--- a/alembic/versions/20260802_rob1036_sample_elig.py
+++ b/alembic/versions/20260802_rob1036_sample_elig.py
@@ -1,0 +1,328 @@
+"""ROB-1036 invalid-sample eligibility + cleanup binding (additive, append-only).
+
+Revision ID: 20260802_rob1036_sample_elig
+Revises: 20260728_rob1109_watch_intent
+Create Date: 2026-08-02
+
+Purely additive: three new tables in the existing ``review`` schema plus their
+append-only triggers. No existing table, column, constraint, or row is touched,
+and nothing here backfills a historical decision — a subject with no row is
+``UNIDENTIFIABLE`` by the service contract, never ``INCLUDE``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20260802_rob1036_sample_elig"
+down_revision = "20260728_rob1109_watch_intent"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SHA256 = "^[0-9a-f]{64}$"
+_APPEND_ONLY_TABLES = (
+    "sample_eligibility_decisions",
+    "invalid_sample_cleanup_bindings",
+    "invalid_sample_cleanup_lifecycle_events",
+)
+
+
+def _create_reject_function() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION review.reject_invalid_sample_mutation()
+        RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION 'review.% is append-only; % rejected',
+                TG_TABLE_NAME, TG_OP
+                USING ERRCODE = 'restrict_violation';
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+
+
+def _create_append_only_triggers(table: str) -> None:
+    op.execute(
+        f"CREATE TRIGGER trg_rob1036_{table}_append_only "
+        f"BEFORE UPDATE OR DELETE ON review.{table} FOR EACH ROW EXECUTE "
+        "FUNCTION review.reject_invalid_sample_mutation()"
+    )
+    op.execute(
+        f"CREATE TRIGGER trg_rob1036_{table}_truncate_append_only "
+        f"BEFORE TRUNCATE ON review.{table} FOR EACH STATEMENT EXECUTE "
+        "FUNCTION review.reject_invalid_sample_mutation()"
+    )
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS review")
+    _create_reject_function()
+
+    op.create_table(
+        "sample_eligibility_decisions",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("subject_kind", sa.Text(), nullable=False),
+        sa.Column("subject_ref", sa.Text(), nullable=False),
+        sa.Column("contract_version", sa.Text(), nullable=False),
+        sa.Column("revision_no", sa.Integer(), nullable=False),
+        sa.Column("supersedes_revision_no", sa.Integer(), nullable=True),
+        sa.Column("forecast_outcome_observability", sa.Text(), nullable=False),
+        sa.Column("calibration_eligibility", sa.Text(), nullable=False),
+        sa.Column("trade_performance_eligibility", sa.Text(), nullable=False),
+        sa.Column("operational_reliability_eligibility", sa.Text(), nullable=False),
+        sa.Column("decision_reason", sa.Text(), nullable=False),
+        sa.Column("decided_by", sa.Text(), nullable=False),
+        sa.Column("evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("evidence_hash", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "subject_kind",
+            "subject_ref",
+            "revision_no",
+            name="uq_sample_eligibility_subject_revision",
+        ),
+        sa.CheckConstraint(
+            "subject_kind IN ('forecast','trade_lifecycle')",
+            name="ck_sample_eligibility_subject_kind",
+        ),
+        sa.CheckConstraint(
+            "revision_no >= 1", name="ck_sample_eligibility_revision_no"
+        ),
+        sa.CheckConstraint(
+            "(revision_no = 1 AND supersedes_revision_no IS NULL) OR "
+            "(revision_no > 1 AND supersedes_revision_no = revision_no - 1)",
+            name="ck_sample_eligibility_revision_chain",
+        ),
+        sa.CheckConstraint(
+            "forecast_outcome_observability IN "
+            "('observable','blocked_pending_audit_evidence','unidentifiable')",
+            name="ck_sample_eligibility_observability",
+        ),
+        sa.CheckConstraint(
+            "calibration_eligibility IN "
+            "('calibration_include','calibration_exclude','calibration_unidentifiable')",
+            name="ck_sample_eligibility_calibration",
+        ),
+        sa.CheckConstraint(
+            "trade_performance_eligibility IN ('trade_performance_include',"
+            "'trade_performance_exclude','trade_performance_unidentifiable')",
+            name="ck_sample_eligibility_trade_performance",
+        ),
+        sa.CheckConstraint(
+            "operational_reliability_eligibility IN "
+            "('operational_include','operational_exclude','operational_unidentifiable')",
+            name="ck_sample_eligibility_operational",
+        ),
+        sa.CheckConstraint(
+            f"evidence_hash ~ '{_SHA256}'",
+            name="ck_sample_eligibility_evidence_hash",
+        ),
+        sa.CheckConstraint(
+            "btrim(contract_version) <> ''",
+            name="ck_sample_eligibility_contract_version",
+        ),
+        sa.CheckConstraint(
+            "btrim(decision_reason) <> ''",
+            name="ck_sample_eligibility_decision_reason",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "uq_sample_eligibility_supersedes",
+        "sample_eligibility_decisions",
+        ["subject_kind", "subject_ref", "supersedes_revision_no"],
+        unique=True,
+        schema="review",
+        postgresql_where=sa.text("supersedes_revision_no IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_sample_eligibility_subject",
+        "sample_eligibility_decisions",
+        ["subject_kind", "subject_ref"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_sample_eligibility_contract_version",
+        "sample_eligibility_decisions",
+        ["contract_version"],
+        schema="review",
+    )
+
+    op.create_table(
+        "invalid_sample_cleanup_bindings",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("purpose", sa.Text(), nullable=False),
+        sa.Column("contract_version", sa.Text(), nullable=False),
+        sa.Column("forecast_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sample_ref", sa.Text(), nullable=False),
+        sa.Column("approval_id", sa.Text(), nullable=False),
+        sa.Column("approval_hash", sa.Text(), nullable=False),
+        sa.Column("approval_expires_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("approval_session_id", sa.Text(), nullable=False),
+        sa.Column("mission_id", sa.Text(), nullable=False),
+        sa.Column("account_mode", sa.Text(), nullable=False),
+        sa.Column("client_order_id", sa.Text(), nullable=False),
+        sa.Column("lifecycle_correlation_id", sa.Text(), nullable=False),
+        sa.Column("binding_hash", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "client_order_id", name="uq_invalid_sample_binding_client_order_id"
+        ),
+        sa.UniqueConstraint("binding_hash", name="uq_invalid_sample_binding_hash"),
+        sa.CheckConstraint(
+            "purpose = 'invalid_sample_cleanup'",
+            name="ck_invalid_sample_binding_purpose",
+        ),
+        sa.CheckConstraint(
+            f"binding_hash ~ '{_SHA256}'",
+            name="ck_invalid_sample_binding_hash_format",
+        ),
+        sa.CheckConstraint(
+            "btrim(mission_id) <> '' AND btrim(approval_id) <> '' "
+            "AND btrim(approval_session_id) <> ''",
+            name="ck_invalid_sample_binding_identities",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_invalid_sample_binding_forecast_id",
+        "invalid_sample_cleanup_bindings",
+        ["forecast_id"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_invalid_sample_binding_correlation_id",
+        "invalid_sample_cleanup_bindings",
+        ["lifecycle_correlation_id"],
+        schema="review",
+    )
+
+    op.create_table(
+        "invalid_sample_cleanup_lifecycle_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("binding_hash", sa.Text(), nullable=False),
+        sa.Column("client_order_id", sa.Text(), nullable=False),
+        sa.Column("contract_version", sa.Text(), nullable=False),
+        sa.Column("event_kind", sa.Text(), nullable=False),
+        sa.Column("completion_status", sa.Text(), nullable=False),
+        sa.Column("manual_review_reason", sa.Text(), nullable=True),
+        sa.Column("fill_evidence", sa.Text(), nullable=False),
+        sa.Column("position_effect_evidence", sa.Text(), nullable=False),
+        sa.Column("evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("evidence_hash", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "binding_hash",
+            "event_kind",
+            "evidence_hash",
+            name="uq_invalid_sample_lifecycle_event_identity",
+        ),
+        sa.CheckConstraint(
+            "event_kind IN ('post_fill_completion','post_fill_manual_review',"
+            "'timeout_recovery_lookup')",
+            name="ck_invalid_sample_lifecycle_event_kind",
+        ),
+        sa.CheckConstraint(
+            "completion_status IN ('complete','manual_review')",
+            name="ck_invalid_sample_lifecycle_completion_status",
+        ),
+        sa.CheckConstraint(
+            "(completion_status = 'complete' AND manual_review_reason IS NULL) OR "
+            "(completion_status = 'manual_review' AND manual_review_reason IS NOT NULL)",
+            name="ck_invalid_sample_lifecycle_reason_pairing",
+        ),
+        sa.CheckConstraint(
+            f"evidence_hash ~ '{_SHA256}'",
+            name="ck_invalid_sample_lifecycle_evidence_hash",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_invalid_sample_lifecycle_binding_hash",
+        "invalid_sample_cleanup_lifecycle_events",
+        ["binding_hash"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_invalid_sample_lifecycle_client_order_id",
+        "invalid_sample_cleanup_lifecycle_events",
+        ["client_order_id"],
+        schema="review",
+    )
+
+    for table in _APPEND_ONLY_TABLES:
+        _create_append_only_triggers(table)
+
+
+def downgrade() -> None:
+    for table in _APPEND_ONLY_TABLES:
+        op.execute(
+            f"DROP TRIGGER IF EXISTS trg_rob1036_{table}_truncate_append_only "
+            f"ON review.{table}"
+        )
+        op.execute(
+            f"DROP TRIGGER IF EXISTS trg_rob1036_{table}_append_only ON review.{table}"
+        )
+    op.drop_index(
+        "ix_invalid_sample_lifecycle_client_order_id",
+        table_name="invalid_sample_cleanup_lifecycle_events",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_invalid_sample_lifecycle_binding_hash",
+        table_name="invalid_sample_cleanup_lifecycle_events",
+        schema="review",
+    )
+    op.drop_table("invalid_sample_cleanup_lifecycle_events", schema="review")
+    op.drop_index(
+        "ix_invalid_sample_binding_correlation_id",
+        table_name="invalid_sample_cleanup_bindings",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_invalid_sample_binding_forecast_id",
+        table_name="invalid_sample_cleanup_bindings",
+        schema="review",
+    )
+    op.drop_table("invalid_sample_cleanup_bindings", schema="review")
+    op.drop_index(
+        "ix_sample_eligibility_contract_version",
+        table_name="sample_eligibility_decisions",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_sample_eligibility_subject",
+        table_name="sample_eligibility_decisions",
+        schema="review",
+    )
+    op.drop_index(
+        "uq_sample_eligibility_supersedes",
+        table_name="sample_eligibility_decisions",
+        schema="review",
+    )
+    op.drop_table("sample_eligibility_decisions", schema="review")
+    op.execute("DROP FUNCTION IF EXISTS review.reject_invalid_sample_mutation()")

--- a/app/mcp_server/tooling/forecast_tools.py
+++ b/app/mcp_server/tooling/forecast_tools.py
@@ -9,6 +9,10 @@ from typing import Any, cast
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+)
+from app.services.invalid_sample_eligibility.contract import CONTRACT_VERSION
 from app.services.trade_journal.forecast_service import (
     ForecastValidationError,
     build_forecast_calibration_aggregate,
@@ -209,6 +213,11 @@ async def get_forecast_calibration(
         async with _session_factory()() as db:
             result = await build_forecast_calibration_aggregate(
                 db,
+                # ROB-1036 D-1 (option ②): the cohort is stated, not implied.
+                # It admits undecided samples so this tool keeps working, and
+                # the response reports how many of those there were.
+                contract_version=CONTRACT_VERSION,
+                predicate=COMPATIBILITY_CALIBRATION_COHORT,
                 group_by=group_by,
                 created_by=created_by,
                 symbol=symbol,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,6 +10,11 @@ from .crypto_instrument_health import CryptoInstrumentHealth
 from .crypto_instruments import CryptoInstrument
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
 from .financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
+from .invalid_sample_eligibility import (
+    InvalidSampleCleanupBinding,
+    InvalidSampleCleanupLifecycleEvent,
+    SampleEligibilityDecision,
+)
 from .invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
 from .invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
 from .invest_momentum_event_snapshot import (
@@ -206,6 +211,9 @@ __all__ = [
     "InvestmentSnapshotBundle",
     "InvestmentSnapshotBundleItem",
     "InvestorFlowSnapshot",
+    "InvalidSampleCleanupBinding",
+    "InvalidSampleCleanupLifecycleEvent",
+    "SampleEligibilityDecision",
     "InvestCryptoScreenerSnapshot",
     "InvestKrFundamentalsSnapshot",
     "InvestScreenerSnapshot",

--- a/app/models/invalid_sample_eligibility.py
+++ b/app/models/invalid_sample_eligibility.py
@@ -1,0 +1,270 @@
+"""ROB-1036 — append-only eligibility / cleanup-binding tables.
+
+Three tables, all append-only at the database edge (BEFORE UPDATE/DELETE/TRUNCATE
+triggers created by the migration):
+
+``review.sample_eligibility_decisions``
+    One row per revision of the four-domain eligibility decision.  A correction
+    is a superseding revision, never an overwrite.
+``review.invalid_sample_cleanup_bindings``
+    Immutable purpose ↔ sample ↔ approval ↔ mission ↔ broker-lifecycle binding.
+``review.invalid_sample_cleanup_lifecycle_events``
+    Append-only post-fill evidence trail for a bound cleanup leg.
+
+Every write goes through
+``app.services.invalid_sample_eligibility.service.InvalidSampleEligibilityService``.
+Direct SQL writes are forbidden (guarded by
+``tests/services/invalid_sample_eligibility/test_static_boundaries.py``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+_SHA256_HEX = "^[0-9a-f]{64}$"
+
+
+class SampleEligibilityDecision(Base):
+    """Append-only revision of the four independent validity domains.
+
+    The four domain columns are stored separately and are never reduced to one
+    ``is_valid`` column: a forecast whose outcome stays observable can still be
+    excluded from calibration, and vice versa.
+    """
+
+    __tablename__ = "sample_eligibility_decisions"
+    __table_args__ = (
+        UniqueConstraint(
+            "subject_kind",
+            "subject_ref",
+            "revision_no",
+            name="uq_sample_eligibility_subject_revision",
+        ),
+        # No two revisions may supersede the same predecessor: that is a branch.
+        Index(
+            "uq_sample_eligibility_supersedes",
+            "subject_kind",
+            "subject_ref",
+            "supersedes_revision_no",
+            unique=True,
+            postgresql_where=text("supersedes_revision_no IS NOT NULL"),
+        ),
+        CheckConstraint(
+            "subject_kind IN ('forecast','trade_lifecycle')",
+            name="ck_sample_eligibility_subject_kind",
+        ),
+        CheckConstraint("revision_no >= 1", name="ck_sample_eligibility_revision_no"),
+        # Revision 1 opens the chain; every later revision supersedes exactly its
+        # predecessor. This makes a gap, a branch, and a cycle unrepresentable.
+        CheckConstraint(
+            "(revision_no = 1 AND supersedes_revision_no IS NULL) OR "
+            "(revision_no > 1 AND supersedes_revision_no = revision_no - 1)",
+            name="ck_sample_eligibility_revision_chain",
+        ),
+        CheckConstraint(
+            "forecast_outcome_observability IN "
+            "('observable','blocked_pending_audit_evidence','unidentifiable')",
+            name="ck_sample_eligibility_observability",
+        ),
+        CheckConstraint(
+            "calibration_eligibility IN "
+            "('calibration_include','calibration_exclude','calibration_unidentifiable')",
+            name="ck_sample_eligibility_calibration",
+        ),
+        CheckConstraint(
+            "trade_performance_eligibility IN ('trade_performance_include',"
+            "'trade_performance_exclude','trade_performance_unidentifiable')",
+            name="ck_sample_eligibility_trade_performance",
+        ),
+        CheckConstraint(
+            "operational_reliability_eligibility IN "
+            "('operational_include','operational_exclude','operational_unidentifiable')",
+            name="ck_sample_eligibility_operational",
+        ),
+        CheckConstraint(
+            f"evidence_hash ~ '{_SHA256_HEX}'",
+            name="ck_sample_eligibility_evidence_hash",
+        ),
+        CheckConstraint(
+            "btrim(contract_version) <> ''",
+            name="ck_sample_eligibility_contract_version",
+        ),
+        CheckConstraint(
+            "btrim(decision_reason) <> ''",
+            name="ck_sample_eligibility_decision_reason",
+        ),
+        Index(
+            "ix_sample_eligibility_subject",
+            "subject_kind",
+            "subject_ref",
+        ),
+        Index("ix_sample_eligibility_contract_version", "contract_version"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    subject_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    subject_ref: Mapped[str] = mapped_column(Text, nullable=False)
+
+    contract_version: Mapped[str] = mapped_column(Text, nullable=False)
+    revision_no: Mapped[int] = mapped_column(Integer, nullable=False)
+    supersedes_revision_no: Mapped[int | None] = mapped_column(Integer)
+
+    # Four independent domains — deliberately four columns, not one flag.
+    forecast_outcome_observability: Mapped[str] = mapped_column(Text, nullable=False)
+    calibration_eligibility: Mapped[str] = mapped_column(Text, nullable=False)
+    trade_performance_eligibility: Mapped[str] = mapped_column(Text, nullable=False)
+    operational_reliability_eligibility: Mapped[str] = mapped_column(
+        Text, nullable=False
+    )
+
+    decision_reason: Mapped[str] = mapped_column(Text, nullable=False)
+    decided_by: Mapped[str] = mapped_column(Text, nullable=False)
+    evidence: Mapped[dict | None] = mapped_column(JSONB)
+    evidence_hash: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class InvalidSampleCleanupBinding(Base):
+    """Immutable binding of a cleanup leg to its approval and mission."""
+
+    __tablename__ = "invalid_sample_cleanup_bindings"
+    __table_args__ = (
+        UniqueConstraint(
+            "client_order_id", name="uq_invalid_sample_binding_client_order_id"
+        ),
+        UniqueConstraint("binding_hash", name="uq_invalid_sample_binding_hash"),
+        CheckConstraint(
+            "purpose = 'invalid_sample_cleanup'",
+            name="ck_invalid_sample_binding_purpose",
+        ),
+        CheckConstraint(
+            f"binding_hash ~ '{_SHA256_HEX}'",
+            name="ck_invalid_sample_binding_hash_format",
+        ),
+        CheckConstraint(
+            "btrim(mission_id) <> '' AND btrim(approval_id) <> '' "
+            "AND btrim(approval_session_id) <> ''",
+            name="ck_invalid_sample_binding_identities",
+        ),
+        Index("ix_invalid_sample_binding_forecast_id", "forecast_id"),
+        Index(
+            "ix_invalid_sample_binding_correlation_id",
+            "lifecycle_correlation_id",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    purpose: Mapped[str] = mapped_column(Text, nullable=False)
+    contract_version: Mapped[str] = mapped_column(Text, nullable=False)
+
+    forecast_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    sample_ref: Mapped[str] = mapped_column(Text, nullable=False)
+
+    approval_id: Mapped[str] = mapped_column(Text, nullable=False)
+    approval_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    approval_expires_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    approval_session_id: Mapped[str] = mapped_column(Text, nullable=False)
+    mission_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    account_mode: Mapped[str] = mapped_column(Text, nullable=False)
+    client_order_id: Mapped[str] = mapped_column(Text, nullable=False)
+    lifecycle_correlation_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    binding_hash: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class InvalidSampleCleanupLifecycleEvent(Base):
+    """Append-only post-fill evidence trail for a bound cleanup leg."""
+
+    __tablename__ = "invalid_sample_cleanup_lifecycle_events"
+    __table_args__ = (
+        # Replaying the same evidence is a no-op, not a second event.
+        UniqueConstraint(
+            "binding_hash",
+            "event_kind",
+            "evidence_hash",
+            name="uq_invalid_sample_lifecycle_event_identity",
+        ),
+        CheckConstraint(
+            "event_kind IN ('post_fill_completion','post_fill_manual_review',"
+            "'timeout_recovery_lookup')",
+            name="ck_invalid_sample_lifecycle_event_kind",
+        ),
+        CheckConstraint(
+            "completion_status IN ('complete','manual_review')",
+            name="ck_invalid_sample_lifecycle_completion_status",
+        ),
+        # A complete event carries no refusal reason; a manual-review event must.
+        CheckConstraint(
+            "(completion_status = 'complete' AND manual_review_reason IS NULL) OR "
+            "(completion_status = 'manual_review' AND manual_review_reason IS NOT NULL)",
+            name="ck_invalid_sample_lifecycle_reason_pairing",
+        ),
+        CheckConstraint(
+            f"evidence_hash ~ '{_SHA256_HEX}'",
+            name="ck_invalid_sample_lifecycle_evidence_hash",
+        ),
+        Index("ix_invalid_sample_lifecycle_binding_hash", "binding_hash"),
+        Index("ix_invalid_sample_lifecycle_client_order_id", "client_order_id"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    binding_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    client_order_id: Mapped[str] = mapped_column(Text, nullable=False)
+    contract_version: Mapped[str] = mapped_column(Text, nullable=False)
+
+    event_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    completion_status: Mapped[str] = mapped_column(Text, nullable=False)
+    manual_review_reason: Mapped[str | None] = mapped_column(Text)
+
+    fill_evidence: Mapped[str] = mapped_column(Text, nullable=False)
+    position_effect_evidence: Mapped[str] = mapped_column(Text, nullable=False)
+
+    evidence: Mapped[dict | None] = mapped_column(JSONB)
+    evidence_hash: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+__all__ = [
+    "InvalidSampleCleanupBinding",
+    "InvalidSampleCleanupLifecycleEvent",
+    "SampleEligibilityDecision",
+]

--- a/app/routers/invest_forecasts.py
+++ b/app/routers/invest_forecasts.py
@@ -22,9 +22,14 @@ from app.schemas.invest_forecasts import (
     VALID_INSTRUMENT_TYPES,
     CalibrationGroupRow,
     CalibrationResponse,
+    EligibilityCounts,
     ForecastListResponse,
     ForecastRow,
 )
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+)
+from app.services.invalid_sample_eligibility.contract import CONTRACT_VERSION
 from app.services.trade_journal import forecast_service as fc_svc
 
 router = APIRouter(
@@ -55,6 +60,11 @@ async def get_forecast_calibration(
     _validate_instrument_type(instrument_type)
     result = await fc_svc.build_forecast_calibration_aggregate(
         db,
+        # ROB-1036 D-1 (option ②): the cohort is stated, not implied. It admits
+        # undecided samples so this endpoint keeps returning data, and the
+        # response reports the undecided count alongside the groups.
+        contract_version=CONTRACT_VERSION,
+        predicate=COMPATIBILITY_CALIBRATION_COHORT,
         group_by=group_by,
         created_by=created_by,
         symbol=symbol,
@@ -71,6 +81,10 @@ async def get_forecast_calibration(
         count=len(groups),
         groups=[CalibrationGroupRow(**g) for g in groups],
         as_of=datetime.now(UTC),
+        contract_version=result["contract_version"],
+        eligibility_cohort=result["eligibility_cohort"],
+        eligibility_stage=result["eligibility_stage"],
+        eligibility_counts=EligibilityCounts(**result["eligibility_counts"]),
     )
 
 

--- a/app/schemas/invest_forecasts.py
+++ b/app/schemas/invest_forecasts.py
@@ -31,6 +31,21 @@ class CalibrationGroupRow(BaseModel):
     calibration_gap: float | None = None
 
 
+class EligibilityCounts(BaseModel):
+    """ROB-1036 D-1 — the three classification counts, reported separately.
+
+    They are never summed into a single "eligible" number: ``unidentifiable`` is
+    the undecided contamination currently admitted by the compatibility cohort,
+    and a caller has to be able to see it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    included: int = Field(ge=0)
+    excluded: int = Field(ge=0)
+    unidentifiable: int = Field(ge=0)
+
+
 class CalibrationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -42,6 +57,13 @@ class CalibrationResponse(BaseModel):
     count: int = Field(ge=0)
     groups: list[CalibrationGroupRow]
     as_of: datetime
+    # ROB-1036 D-1 provenance: which contract and cohort produced these numbers.
+    # Kept on the response so a value stays attributable after the cohort
+    # definition is promoted.
+    contract_version: str
+    eligibility_cohort: str
+    eligibility_stage: str
+    eligibility_counts: EligibilityCounts
 
 
 class ForecastRow(BaseModel):

--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -30,6 +30,10 @@ from app.models.review import (
     TradeRetrospective,
     TradeRetrospectiveAction,
 )
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+)
+from app.services.invalid_sample_eligibility.contract import CONTRACT_VERSION
 from app.services.trade_journal.forecast_service import (
     _normalize_symbol_for_filter,
     build_forecast_calibration_aggregate,
@@ -116,12 +120,25 @@ async def build_decision_context(
     ):
         return None  # no signal — omit the field entirely
 
+    # ROB-1036 D-1 (option ②): both cohorts are stated explicitly and admit
+    # undecided samples, so these figures stay populated; the undecided count
+    # rides along in the folded payload.
     brier_symbol = _fold_brier(
         await build_forecast_calibration_aggregate(
-            db, symbol=norm, instrument_type=instrument_type
+            db,
+            contract_version=CONTRACT_VERSION,
+            predicate=COMPATIBILITY_CALIBRATION_COHORT,
+            symbol=norm,
+            instrument_type=instrument_type,
         )
     )
-    brier_global = _fold_brier(await build_forecast_calibration_aggregate(db))
+    brier_global = _fold_brier(
+        await build_forecast_calibration_aggregate(
+            db,
+            contract_version=CONTRACT_VERSION,
+            predicate=COMPATIBILITY_CALIBRATION_COHORT,
+        )
+    )
     realized_r = await _realized_r_by_tag(db, market, setup_tag, account_mode)
 
     ctx: dict[str, Any] = {
@@ -152,10 +169,22 @@ def _fold_brier(agg: dict[str, Any]) -> dict[str, Any]:
         if denom
         else None
     )
+    counts = agg.get("eligibility_counts") or {}
     return {
         "n": n,
         "mean_brier": round(mean, 4) if mean is not None else None,
         "flag": "insufficient_sample" if n < 10 else "ok",
+        # ROB-1036 D-1: this number feeds a live trading judgement, so how much
+        # of it rests on undecided samples travels with it. The counts stay
+        # separate — never folded into ``n``.
+        "contract_version": agg.get("contract_version"),
+        "eligibility_cohort": agg.get("eligibility_cohort"),
+        "eligibility_stage": agg.get("eligibility_stage"),
+        "eligibility_counts": {
+            "included": int(counts.get("included", 0)),
+            "excluded": int(counts.get("excluded", 0)),
+            "unidentifiable": int(counts.get("unidentifiable", 0)),
+        },
     }
 
 

--- a/app/services/invalid_sample_eligibility/__init__.py
+++ b/app/services/invalid_sample_eligibility/__init__.py
@@ -1,0 +1,6 @@
+"""ROB-1036 — ``uber-invalid-sample-eligibility.v1``.
+
+Import the submodules directly. This package intentionally re-exports nothing:
+``read_model`` imports ``trade_journal.forecast_service``, which imports
+``contract``, so an eager re-export here would close an import cycle.
+"""

--- a/app/services/invalid_sample_eligibility/binding.py
+++ b/app/services/invalid_sample_eligibility/binding.py
@@ -1,0 +1,182 @@
+"""ROB-1036 — immutable ``invalid_sample_cleanup`` binding contract.
+
+A cleanup leg is only auditable if the purpose, the sample it is cleaning up,
+the approval it was authorised by, the operational mission it belongs to, and
+the broker lifecycle it produced are bound together at the moment of authoring
+and never edited afterwards.
+
+The binding is authored once, in the approval window, for one session.  An
+expired or missed window fails closed, and a binding is never carried over into
+a later session — a new session needs a new approval, not a reused one.
+
+This module is pure: stdlib only, no DB, broker, network, or clock access.  The
+caller supplies the clock, exactly like ``verify_packet_freshness``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from app.services.invalid_sample_eligibility.contract import (
+    CONTRACT_VERSION,
+    canonical_evidence_hash,
+)
+
+#: The only purpose this binding may carry.  A different cleanup purpose needs
+#: its own contract, not a widened enum member.
+CLEANUP_PURPOSE = "invalid_sample_cleanup"
+
+
+class CleanupBindingError(ValueError):
+    """Raised when a binding cannot be authored under the contract."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupBinding:
+    """Frozen purpose ↔ sample ↔ approval ↔ mission ↔ lifecycle binding."""
+
+    purpose: str
+    contract_version: str
+    forecast_id: uuid.UUID
+    sample_ref: str
+    approval_id: str
+    approval_hash: str
+    approval_expires_at: datetime
+    approval_session_id: str
+    mission_id: str
+    account_mode: str
+    client_order_id: str
+    lifecycle_correlation_id: str
+
+    def __post_init__(self) -> None:
+        if self.purpose != CLEANUP_PURPOSE:
+            raise CleanupBindingError(
+                "unsupported_purpose",
+                f"purpose must be {CLEANUP_PURPOSE!r}; got {self.purpose!r}",
+            )
+        if not isinstance(self.forecast_id, uuid.UUID):
+            raise TypeError("forecast_id must be a uuid.UUID")
+        if self.approval_expires_at.tzinfo is None or (
+            self.approval_expires_at.tzinfo.utcoffset(self.approval_expires_at) is None
+        ):
+            raise CleanupBindingError(
+                "naive_approval_expires_at",
+                "approval_expires_at must be timezone-aware",
+            )
+        for field_name in (
+            "contract_version",
+            "sample_ref",
+            "approval_id",
+            "approval_hash",
+            "approval_session_id",
+            "mission_id",
+            "account_mode",
+            "client_order_id",
+            "lifecycle_correlation_id",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise CleanupBindingError(
+                    "missing_binding_field", f"{field_name} must be a non-empty string"
+                )
+            object.__setattr__(self, field_name, value.strip())
+
+    @property
+    def binding_hash(self) -> str:
+        """Canonical digest over every bound identity."""
+
+        return canonical_evidence_hash(
+            {
+                "purpose": self.purpose,
+                "contract_version": self.contract_version,
+                "forecast_id": str(self.forecast_id),
+                "sample_ref": self.sample_ref,
+                "approval_id": self.approval_id,
+                "approval_hash": self.approval_hash,
+                "approval_session_id": self.approval_session_id,
+                "mission_id": self.mission_id,
+                "account_mode": self.account_mode,
+                "client_order_id": self.client_order_id,
+                "lifecycle_correlation_id": self.lifecycle_correlation_id,
+            }
+        )
+
+
+def build_cleanup_binding(
+    *,
+    forecast_id: uuid.UUID,
+    sample_ref: str,
+    approval_id: str,
+    approval_hash: str,
+    approval_expires_at: datetime,
+    approval_session_id: str,
+    mission_id: str,
+    account_mode: str,
+    client_order_id: str,
+    lifecycle_correlation_id: str,
+    now: datetime,
+    session_id: str,
+    contract_version: str = CONTRACT_VERSION,
+) -> CleanupBinding:
+    """Author a binding, refusing an expired approval or a cross-session reuse.
+
+    Raises:
+        CleanupBindingError('naive_now') if ``now`` has no tzinfo.
+        CleanupBindingError('approval_window_expired') if the approval window
+            has closed — a missed window is not silently carried forward.
+        CleanupBindingError('cross_session_carry_over_blocked') if the approval
+            was issued to a different session.
+    """
+
+    if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
+        raise CleanupBindingError(
+            "naive_now", "now must be timezone-aware; supply an explicit UTC clock"
+        )
+    if approval_expires_at.tzinfo is None or (
+        approval_expires_at.tzinfo.utcoffset(approval_expires_at) is None
+    ):
+        raise CleanupBindingError(
+            "naive_approval_expires_at", "approval_expires_at must be timezone-aware"
+        )
+    if now >= approval_expires_at:
+        raise CleanupBindingError(
+            "approval_window_expired",
+            (
+                f"approval window closed at {approval_expires_at.isoformat()}; "
+                f"now={now.isoformat()}"
+            ),
+        )
+    if session_id.strip() != approval_session_id.strip():
+        raise CleanupBindingError(
+            "cross_session_carry_over_blocked",
+            "an approval issued to another session is not reusable here",
+        )
+    return CleanupBinding(
+        purpose=CLEANUP_PURPOSE,
+        contract_version=contract_version,
+        forecast_id=forecast_id,
+        sample_ref=sample_ref,
+        approval_id=approval_id,
+        approval_hash=approval_hash,
+        approval_expires_at=approval_expires_at,
+        approval_session_id=approval_session_id,
+        mission_id=mission_id,
+        account_mode=account_mode,
+        client_order_id=client_order_id,
+        lifecycle_correlation_id=lifecycle_correlation_id,
+    )
+
+
+__all__ = [
+    "CLEANUP_PURPOSE",
+    "CleanupBinding",
+    "CleanupBindingError",
+    "build_cleanup_binding",
+]

--- a/app/services/invalid_sample_eligibility/cohort.py
+++ b/app/services/invalid_sample_eligibility/cohort.py
@@ -1,0 +1,317 @@
+"""ROB-1036 D-1 — cohort predicates for eligibility-aware aggregates.
+
+Pure: stdlib + :mod:`contract` only. It deliberately imports no aggregate
+implementation, so an aggregate module can require a predicate without a cycle.
+
+Operator decision D-1 (2026-08-02) selected **option ②**: every calibration call
+must state its contract version and cohort, and the default cohort admits
+``UNIDENTIFIABLE`` alongside ``INCLUDE`` so the existing calibration surfaces keep
+working while the undecided population is made visible rather than silent.
+
+.. _rob1036-d1-termination:
+
+Termination condition
+---------------------
+:data:`COMPATIBILITY_CALIBRATION_COHORT` is a **transitional** stage, not the end
+state. It ends when both hold:
+
+1. every forecast in the scored population carries an explicit eligibility
+   decision recorded through ``InvalidSampleEligibilityService`` — recorded by an
+   operator, never by an automatic historical backfill (§4.2-4); and
+2. the reported ``unidentifiable`` count for the cohorts an operator relies on has
+   been 0 for a full review cycle.
+
+At that point the call sites move to :data:`DECIDED_ONLY_CALIBRATION_COHORT` and
+the compatibility cohort is deleted. Because option ② is a superset of the
+end state — same machinery, wider admitted set — that promotion is a one-line
+change per call site and closes no door.
+
+Every result stamped with a cohort keeps its provenance, so numbers produced
+during this stage stay distinguishable from post-promotion numbers and a
+before/after comparison report remains possible.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from app.services.invalid_sample_eligibility.contract import (
+    CONTRACT_VERSION,
+    CalibrationEligibility,
+    EligibilityContractError,
+    EligibilityDecision,
+    ForecastOutcomeObservability,
+    OperationalReliabilityEligibility,
+    TradePerformanceEligibility,
+)
+
+#: Marks a result as produced during the D-1 option-② compatibility stage.
+COMPATIBILITY_STAGE = "rob-1036-d1-option-2-compatibility"
+
+#: Marks a result as produced by the option-① end-state cohort.
+DECIDED_ONLY_STAGE = "rob-1036-decided-only"
+
+
+class EligibilityDomain(StrEnum):
+    """Which of the four validity questions a predicate asks."""
+
+    FORECAST_OUTCOME_OBSERVABILITY = "forecast_outcome_observability"
+    CALIBRATION = "calibration_eligibility"
+    TRADE_PERFORMANCE = "trade_performance_eligibility"
+    OPERATIONAL_RELIABILITY = "operational_reliability_eligibility"
+
+
+_DOMAIN_ENUMS: dict[EligibilityDomain, type[StrEnum]] = {
+    EligibilityDomain.FORECAST_OUTCOME_OBSERVABILITY: ForecastOutcomeObservability,
+    EligibilityDomain.CALIBRATION: CalibrationEligibility,
+    EligibilityDomain.TRADE_PERFORMANCE: TradePerformanceEligibility,
+    EligibilityDomain.OPERATIONAL_RELIABILITY: OperationalReliabilityEligibility,
+}
+
+_INCLUDE_MEMBERS = frozenset(
+    {
+        ForecastOutcomeObservability.OBSERVABLE,
+        CalibrationEligibility.INCLUDE,
+        TradePerformanceEligibility.INCLUDE,
+        OperationalReliabilityEligibility.INCLUDE,
+    }
+)
+_EXCLUDE_MEMBERS = frozenset(
+    {
+        ForecastOutcomeObservability.BLOCKED_PENDING_AUDIT_EVIDENCE,
+        CalibrationEligibility.EXCLUDE,
+        TradePerformanceEligibility.EXCLUDE,
+        OperationalReliabilityEligibility.EXCLUDE,
+    }
+)
+_UNIDENTIFIABLE_MEMBERS = frozenset(
+    {
+        ForecastOutcomeObservability.UNIDENTIFIABLE,
+        CalibrationEligibility.UNIDENTIFIABLE,
+        TradePerformanceEligibility.UNIDENTIFIABLE,
+        OperationalReliabilityEligibility.UNIDENTIFIABLE,
+    }
+)
+
+
+class EligibilityBucket(StrEnum):
+    """How one subject was classified before the admitted set is consulted."""
+
+    INCLUDED = "included"
+    EXCLUDED = "excluded"
+    UNIDENTIFIABLE = "unidentifiable"
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityPredicate:
+    """One domain, one named cohort, one explicit admitted set, one version.
+
+    ``label`` is stamped onto every result built with this predicate, so a stored
+    or reported number stays attributable to the cohort definition that produced
+    it (D-1 provenance requirement).
+    """
+
+    contract_version: str
+    domain: EligibilityDomain
+    admitted: frozenset[StrEnum]
+    label: str
+    stage: str = COMPATIBILITY_STAGE
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.domain, EligibilityDomain):
+            raise TypeError("domain must be an EligibilityDomain")
+        if not self.contract_version.strip():
+            raise EligibilityContractError(
+                "missing_contract_version", "contract_version must be non-empty"
+            )
+        if not self.label.strip():
+            raise EligibilityContractError(
+                "missing_cohort_label",
+                "a cohort must be named so its results stay attributable",
+            )
+        if not self.admitted:
+            raise EligibilityContractError(
+                "empty_admitted_set",
+                "an eligibility predicate must admit at least one value",
+            )
+        expected = _DOMAIN_ENUMS[self.domain]
+        for member in self.admitted:
+            if not isinstance(member, expected):
+                raise EligibilityContractError(
+                    "cross_domain_predicate",
+                    f"{member!r} is not a {expected.__name__} value",
+                )
+
+    @property
+    def admits_unidentifiable(self) -> bool:
+        return bool(self.admitted & _UNIDENTIFIABLE_MEMBERS)
+
+    def value_of(self, decision: EligibilityDecision) -> StrEnum:
+        return getattr(decision, self.domain.value)
+
+    def bucket_of(self, decision: EligibilityDecision) -> EligibilityBucket:
+        """Classify a decision independently of what this cohort admits.
+
+        An explicit exclusion is an exclusion under **any** contract version — a
+        version bump must never resurrect an excluded sample. An inclusion is only
+        trusted under the matching version; otherwise it is unidentifiable.
+        """
+
+        value = self.value_of(decision)
+        if value in _EXCLUDE_MEMBERS:
+            return EligibilityBucket.EXCLUDED
+        if decision.contract_version != self.contract_version:
+            return EligibilityBucket.UNIDENTIFIABLE
+        if value in _INCLUDE_MEMBERS:
+            return EligibilityBucket.INCLUDED
+        return EligibilityBucket.UNIDENTIFIABLE
+
+    def admits(self, decision: EligibilityDecision) -> bool:
+        return self.value_of(decision) in self.admitted
+
+
+#: D-1 option ② — the transitional default. Admits decided inclusions *and*
+#: undecided samples, and reports the two quantities separately so the undecided
+#: contamination is visible to the caller instead of silently folded in.
+#: See :ref:`the termination condition <rob1036-d1-termination>`.
+COMPATIBILITY_CALIBRATION_COHORT = EligibilityPredicate(
+    contract_version=CONTRACT_VERSION,
+    domain=EligibilityDomain.CALIBRATION,
+    admitted=frozenset(
+        {CalibrationEligibility.INCLUDE, CalibrationEligibility.UNIDENTIFIABLE}
+    ),
+    label="calibration-compatibility",
+    stage=COMPATIBILITY_STAGE,
+)
+
+#: The option-① end state: decided inclusions only. Available now so callers that
+#: want the fully-decided cohort can ask for it, and so the promotion is a
+#: one-line swap rather than a redesign.
+DECIDED_ONLY_CALIBRATION_COHORT = EligibilityPredicate(
+    contract_version=CONTRACT_VERSION,
+    domain=EligibilityDomain.CALIBRATION,
+    admitted=frozenset({CalibrationEligibility.INCLUDE}),
+    label="calibration-decided-only",
+    stage=DECIDED_ONLY_STAGE,
+)
+
+#: Trade-performance counterpart of the end-state cohort (ROB-1036 B2 wiring).
+DECIDED_ONLY_TRADE_PERFORMANCE_COHORT = EligibilityPredicate(
+    contract_version=CONTRACT_VERSION,
+    domain=EligibilityDomain.TRADE_PERFORMANCE,
+    admitted=frozenset({TradePerformanceEligibility.INCLUDE}),
+    label="trade-performance-decided-only",
+    stage=DECIDED_ONLY_STAGE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityPartition:
+    """Classification buckets, the admitted cohort, and the cohort's provenance.
+
+    ``included`` / ``excluded`` / ``unidentifiable`` are **classification**
+    buckets and are always reported separately — they are never summed into a
+    single "eligible" number. ``admitted`` is the cohort the aggregate actually
+    runs over, which under the compatibility cohort is
+    ``included + unidentifiable``.
+    """
+
+    included: list[Any]
+    excluded: list[Any]
+    unidentifiable: list[Any]
+    admitted: list[Any]
+    contract_version: str
+    domain: EligibilityDomain
+    cohort_label: str
+    cohort_stage: str
+    cohort_admits: tuple[str, ...]
+    reasons: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        """The three classification counts, kept separate on purpose."""
+
+        return {
+            "included": len(self.included),
+            "excluded": len(self.excluded),
+            "unidentifiable": len(self.unidentifiable),
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "eligibility_domain": self.domain.value,
+            "eligibility_cohort": self.cohort_label,
+            "eligibility_stage": self.cohort_stage,
+            "eligibility_cohort_admits": list(self.cohort_admits),
+            "eligibility_counts": self.counts,
+            "eligibility_admitted_count": len(self.admitted),
+            "eligibility_reasons": dict(self.reasons),
+        }
+
+
+def partition_by_eligibility(
+    items: Sequence[tuple[Any, EligibilityDecision]],
+    *,
+    predicate: EligibilityPredicate,
+) -> EligibilityPartition:
+    """Classify ``(row, decision)`` pairs and build the admitted cohort.
+
+    Classification is independent of the admitted set, so the three counts mean
+    the same thing under every cohort and a compatibility-stage number can be
+    compared against a post-promotion number.
+    """
+
+    included: list[Any] = []
+    excluded: list[Any] = []
+    unidentifiable: list[Any] = []
+    admitted: list[Any] = []
+    reasons: Counter[str] = Counter()
+
+    for row, decision in items:
+        bucket = predicate.bucket_of(decision)
+        value = predicate.value_of(decision)
+        if bucket is EligibilityBucket.EXCLUDED:
+            excluded.append(row)
+            reasons[str(value)] += 1
+        elif bucket is EligibilityBucket.UNIDENTIFIABLE:
+            unidentifiable.append(row)
+            if decision.contract_version != predicate.contract_version:
+                reasons[f"contract_version_mismatch:{decision.contract_version}"] += 1
+            else:
+                reasons[str(value)] += 1
+        else:
+            included.append(row)
+        if value in predicate.admitted:
+            admitted.append(row)
+
+    return EligibilityPartition(
+        included=included,
+        excluded=excluded,
+        unidentifiable=unidentifiable,
+        admitted=admitted,
+        contract_version=predicate.contract_version,
+        domain=predicate.domain,
+        cohort_label=predicate.label,
+        cohort_stage=predicate.stage,
+        cohort_admits=tuple(sorted(str(member) for member in predicate.admitted)),
+        reasons=dict(reasons),
+    )
+
+
+__all__ = [
+    "COMPATIBILITY_CALIBRATION_COHORT",
+    "COMPATIBILITY_STAGE",
+    "DECIDED_ONLY_CALIBRATION_COHORT",
+    "DECIDED_ONLY_STAGE",
+    "DECIDED_ONLY_TRADE_PERFORMANCE_COHORT",
+    "EligibilityBucket",
+    "EligibilityDomain",
+    "EligibilityPartition",
+    "EligibilityPredicate",
+    "partition_by_eligibility",
+]

--- a/app/services/invalid_sample_eligibility/contract.py
+++ b/app/services/invalid_sample_eligibility/contract.py
@@ -1,0 +1,315 @@
+"""ROB-1036 — ``uber-invalid-sample-eligibility.v1`` validity algebra.
+
+A trade can be an invalid sample without the forecast attached to it being
+worthless, and a forecast can be unusable for calibration while its operational
+record still counts.  Those are four different questions, so this module keeps
+four *separate* domains and deliberately offers no combined ``is_valid`` bit:
+
+``ForecastOutcomeObservability``
+    May the forecast outcome be observed/resolved at all?  Trade invalidity
+    alone never discards the outcome record; the UBER decision is that the
+    outcome stays but resolution is blocked until audit-grade provider evidence
+    exists.
+``CalibrationEligibility``
+    Does the forecast enter the calibration primary cohort?
+``TradePerformanceEligibility``
+    Does the lifecycle enter trade-performance / PnL aggregates?
+``OperationalReliabilityEligibility``
+    Does the lifecycle count towards operational reliability?
+
+The four enums are distinct types with distinct member sets, so a caller cannot
+silently substitute one domain's decision for another's.
+
+This module is pure: stdlib only, no DB, broker, network, or clock access.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+#: Append-only contract version fixed by the operator decision.  A decision row
+#: is only meaningful together with the version it was taken under.
+CONTRACT_VERSION = "uber-invalid-sample-eligibility.v1"
+
+#: Versions this build knows how to interpret.  An unknown version is never
+#: coerced to the current one.
+KNOWN_CONTRACT_VERSIONS = frozenset({CONTRACT_VERSION})
+
+
+class EligibilityContractError(ValueError):
+    """Raised when a decision or revision chain violates the contract."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class EligibilitySubjectKind(StrEnum):
+    """What a decision is *about*.
+
+    A forecast and the broker lifecycle that was supposed to realise it are
+    separate subjects: one can be identifiable while the other is not.
+    """
+
+    FORECAST = "forecast"
+    TRADE_LIFECYCLE = "trade_lifecycle"
+
+
+class ForecastOutcomeObservability(StrEnum):
+    """Domain 1 — may the forecast outcome be observed/resolved?
+
+    ``BLOCKED_PENDING_AUDIT_EVIDENCE`` is *not* a discard: the outcome record is
+    retained, but price/Brier derivation is withheld until audit-grade provider
+    evidence lands.
+    """
+
+    OBSERVABLE = "observable"
+    BLOCKED_PENDING_AUDIT_EVIDENCE = "blocked_pending_audit_evidence"
+    UNIDENTIFIABLE = "unidentifiable"
+
+
+class CalibrationEligibility(StrEnum):
+    """Domain 2 — does the forecast enter the calibration primary cohort?"""
+
+    INCLUDE = "calibration_include"
+    EXCLUDE = "calibration_exclude"
+    UNIDENTIFIABLE = "calibration_unidentifiable"
+
+
+class TradePerformanceEligibility(StrEnum):
+    """Domain 3 — does the lifecycle enter trade-performance / PnL aggregates?"""
+
+    INCLUDE = "trade_performance_include"
+    EXCLUDE = "trade_performance_exclude"
+    UNIDENTIFIABLE = "trade_performance_unidentifiable"
+
+
+class OperationalReliabilityEligibility(StrEnum):
+    """Domain 4 — does the lifecycle count towards operational reliability?"""
+
+    INCLUDE = "operational_include"
+    EXCLUDE = "operational_exclude"
+    UNIDENTIFIABLE = "operational_unidentifiable"
+
+
+#: The four domain enums, in declaration order.  Used by the guard tests that
+#: prove the member sets stay disjoint (no accidental cross-domain assignment).
+ELIGIBILITY_DOMAIN_ENUMS: tuple[type[StrEnum], ...] = (
+    ForecastOutcomeObservability,
+    CalibrationEligibility,
+    TradePerformanceEligibility,
+    OperationalReliabilityEligibility,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilitySubject:
+    """Identity a decision is attached to."""
+
+    kind: EligibilitySubjectKind
+    ref: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, EligibilitySubjectKind):
+            raise TypeError("kind must be an EligibilitySubjectKind")
+        cleaned = self.ref.strip()
+        if not cleaned:
+            raise EligibilityContractError("empty_subject_ref", "ref must be non-empty")
+        object.__setattr__(self, "ref", cleaned)
+
+
+def canonical_evidence_hash(evidence: Any) -> str:
+    """SHA-256 over the canonical JSON encoding of ``evidence``."""
+
+    blob = json.dumps(
+        evidence, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str
+    ).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityDecision:
+    """One revision of the four-domain decision for one subject.
+
+    There is intentionally no ``is_valid`` / ``eligible`` / ``success``
+    aggregate property.  Collapsing the four domains into one bit is the exact
+    failure this contract exists to prevent, and a static guard test asserts no
+    such member appears.
+    """
+
+    subject: EligibilitySubject
+    contract_version: str
+    revision_no: int
+    supersedes_revision_no: int | None
+    forecast_outcome_observability: ForecastOutcomeObservability
+    calibration_eligibility: CalibrationEligibility
+    trade_performance_eligibility: TradePerformanceEligibility
+    operational_reliability_eligibility: OperationalReliabilityEligibility
+    decision_reason: str
+    evidence_hash: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.subject, EligibilitySubject):
+            raise TypeError("subject must be an EligibilitySubject")
+        if not isinstance(
+            self.forecast_outcome_observability, ForecastOutcomeObservability
+        ):
+            raise TypeError(
+                "forecast_outcome_observability must be a ForecastOutcomeObservability"
+            )
+        if not isinstance(self.calibration_eligibility, CalibrationEligibility):
+            raise TypeError("calibration_eligibility must be a CalibrationEligibility")
+        if not isinstance(
+            self.trade_performance_eligibility, TradePerformanceEligibility
+        ):
+            raise TypeError(
+                "trade_performance_eligibility must be a TradePerformanceEligibility"
+            )
+        if not isinstance(
+            self.operational_reliability_eligibility, OperationalReliabilityEligibility
+        ):
+            raise TypeError(
+                "operational_reliability_eligibility must be an "
+                "OperationalReliabilityEligibility"
+            )
+        if not self.contract_version.strip():
+            raise EligibilityContractError(
+                "missing_contract_version", "contract_version must be non-empty"
+            )
+        if not self.decision_reason.strip():
+            raise EligibilityContractError(
+                "missing_decision_reason", "decision_reason must be non-empty"
+            )
+        if not isinstance(self.revision_no, int) or isinstance(self.revision_no, bool):
+            raise TypeError("revision_no must be an int")
+        if self.revision_no < 1:
+            raise EligibilityContractError(
+                "invalid_revision_no", "revision_no must be >= 1"
+            )
+        expected_supersedes = None if self.revision_no == 1 else self.revision_no - 1
+        if self.supersedes_revision_no != expected_supersedes:
+            raise EligibilityContractError(
+                "invalid_supersedes_revision_no",
+                (
+                    f"revision {self.revision_no} must supersede "
+                    f"{expected_supersedes!r}, got {self.supersedes_revision_no!r}"
+                ),
+            )
+        if len(self.evidence_hash) != 64 or any(
+            character not in "0123456789abcdef" for character in self.evidence_hash
+        ):
+            raise EligibilityContractError(
+                "invalid_evidence_hash", "evidence_hash must be a lowercase sha256 hex"
+            )
+
+
+def unidentifiable_decision(
+    subject: EligibilitySubject,
+    *,
+    contract_version: str = CONTRACT_VERSION,
+    reason: str = "no_recorded_eligibility_decision",
+) -> EligibilityDecision:
+    """The fail-closed default for a subject with no decision on record.
+
+    A missing decision is ``UNIDENTIFIABLE`` in every domain.  It is never
+    coalesced to ``INCLUDE`` and never triggers a historical backfill.
+    """
+
+    return EligibilityDecision(
+        subject=subject,
+        contract_version=contract_version,
+        revision_no=1,
+        supersedes_revision_no=None,
+        forecast_outcome_observability=ForecastOutcomeObservability.UNIDENTIFIABLE,
+        calibration_eligibility=CalibrationEligibility.UNIDENTIFIABLE,
+        trade_performance_eligibility=TradePerformanceEligibility.UNIDENTIFIABLE,
+        operational_reliability_eligibility=(
+            OperationalReliabilityEligibility.UNIDENTIFIABLE
+        ),
+        decision_reason=reason,
+        evidence_hash=canonical_evidence_hash({"absent": True, "reason": reason}),
+    )
+
+
+def validate_revision_chain(decisions: Sequence[EligibilityDecision]) -> None:
+    """Assert ``decisions`` form one gapless, unbranched, acyclic chain.
+
+    Raises :class:`EligibilityContractError` on a duplicate revision (branch), a
+    missing revision (gap), a self/backwards reference (cycle), a subject
+    mismatch, or a contract-version switch mid-chain.
+    """
+
+    if not decisions:
+        return
+    subject = decisions[0].subject
+    version = decisions[0].contract_version
+    seen: set[int] = set()
+    for decision in decisions:
+        if decision.subject != subject:
+            raise EligibilityContractError(
+                "subject_mismatch", "a revision chain must describe one subject"
+            )
+        if decision.contract_version != version:
+            raise EligibilityContractError(
+                "contract_version_switch",
+                "a revision chain must stay on one contract version",
+            )
+        if decision.revision_no in seen:
+            raise EligibilityContractError(
+                "branched_revision_chain",
+                f"revision {decision.revision_no} appears more than once",
+            )
+        if (
+            decision.supersedes_revision_no is not None
+            and decision.supersedes_revision_no >= decision.revision_no
+        ):
+            raise EligibilityContractError(
+                "cyclic_revision_chain",
+                f"revision {decision.revision_no} cannot supersede "
+                f"{decision.supersedes_revision_no}",
+            )
+        seen.add(decision.revision_no)
+    ordered = sorted(seen)
+    if ordered != list(range(1, len(ordered) + 1)):
+        raise EligibilityContractError(
+            "revision_chain_gap", f"revision chain is not contiguous: {ordered}"
+        )
+
+
+def latest_decision(
+    decisions: Sequence[EligibilityDecision],
+    subject: EligibilitySubject,
+    *,
+    contract_version: str = CONTRACT_VERSION,
+) -> EligibilityDecision:
+    """Return the highest revision, or the fail-closed unidentifiable default."""
+
+    if not decisions:
+        return unidentifiable_decision(subject, contract_version=contract_version)
+    validate_revision_chain(decisions)
+    return max(decisions, key=lambda decision: decision.revision_no)
+
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "ELIGIBILITY_DOMAIN_ENUMS",
+    "KNOWN_CONTRACT_VERSIONS",
+    "CalibrationEligibility",
+    "EligibilityContractError",
+    "EligibilityDecision",
+    "EligibilitySubject",
+    "EligibilitySubjectKind",
+    "ForecastOutcomeObservability",
+    "OperationalReliabilityEligibility",
+    "TradePerformanceEligibility",
+    "canonical_evidence_hash",
+    "latest_decision",
+    "unidentifiable_decision",
+    "validate_revision_chain",
+]

--- a/app/services/invalid_sample_eligibility/post_fill.py
+++ b/app/services/invalid_sample_eligibility/post_fill.py
@@ -1,0 +1,216 @@
+"""ROB-1036 — post-fill completion gate for an invalid-sample cleanup leg.
+
+Two independent evidence facts must both hold before a cleanup leg is called
+complete:
+
+1. the broker fill evidence is *complete* (the observed fill set accounts for
+   the broker's own cumulative quantity — the ROB-953 ``summarize_fill_set``
+   invariant), and
+2. the position effect is *consistent* with that fill (the post-trade position
+   moved by exactly the filled delta).
+
+A ``filled`` status without a complete activity set, or a complete fill set with
+no position evidence, is a typed manual-review outcome — never terminal success.
+
+Recovery after a timeout/crash is evidence lookup on the *same*
+``client_order_id``.  There is no resend variant, mirroring
+``app.services.execution_outcomes.contract.OutcomeNextAction``.
+
+This module is pure: stdlib only, no DB, broker, network, or clock access.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import StrEnum
+from typing import Literal
+
+
+class FillEvidenceCompleteness(StrEnum):
+    """Whether the broker fill evidence accounts for the cumulative quantity."""
+
+    COMPLETE = "complete"
+    INCOMPLETE = "incomplete"
+    ABSENT = "absent"
+
+
+class PositionEffectEvidence(StrEnum):
+    """Whether the observed position effect matches the fill."""
+
+    CONSISTENT = "consistent"
+    INCONSISTENT = "inconsistent"
+    ABSENT = "absent"
+
+
+class PostFillCompletionStatus(StrEnum):
+    """Terminal classification of one post-fill completion attempt."""
+
+    COMPLETE = "complete"
+    MANUAL_REVIEW = "manual_review"
+
+
+class PostFillManualReviewReason(StrEnum):
+    """Why a completion attempt was refused.
+
+    Every value is a refusal.  There is deliberately no ``none``/``ok`` member,
+    so a reason can never be rendered as a success.
+    """
+
+    ABSENT_FILL_EVIDENCE = "absent_fill_evidence"
+    INCOMPLETE_FILL_EVIDENCE = "incomplete_fill_evidence"
+    ABSENT_POSITION_EFFECT_EVIDENCE = "absent_position_effect_evidence"
+    INCONSISTENT_POSITION_EFFECT_EVIDENCE = "inconsistent_position_effect_evidence"
+
+
+class RecoveryAction(StrEnum):
+    """Safe next step after a timeout or crash.
+
+    ``RESUBMIT`` intentionally does not exist: a new broker POST or a new order
+    identity is a separately approved command, never an automatic consequence of
+    losing the response to one already sent.
+    """
+
+    LOOKUP_EXISTING_ORDER_EVIDENCE = "lookup_existing_order_evidence"
+    ESCALATE_MANUAL_REVIEW = "escalate_manual_review"
+
+
+@dataclass(frozen=True, slots=True)
+class PostFillCompletion:
+    """Outcome of the two-evidence completion gate."""
+
+    status: PostFillCompletionStatus
+    reason: PostFillManualReviewReason | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, PostFillCompletionStatus):
+            raise TypeError("status must be a PostFillCompletionStatus")
+        if self.status is PostFillCompletionStatus.COMPLETE:
+            if self.reason is not None:
+                raise ValueError("a complete outcome carries no manual-review reason")
+        elif not isinstance(self.reason, PostFillManualReviewReason):
+            raise ValueError("a manual-review outcome requires a typed reason")
+
+    @property
+    def is_terminal_success(self) -> bool:
+        return self.status is PostFillCompletionStatus.COMPLETE
+
+
+def evaluate_post_fill_completion(
+    *,
+    fill_evidence: FillEvidenceCompleteness,
+    position_effect: PositionEffectEvidence,
+) -> PostFillCompletion:
+    """Complete only when *both* evidence facts hold; otherwise manual review."""
+
+    if not isinstance(fill_evidence, FillEvidenceCompleteness):
+        raise TypeError("fill_evidence must be a FillEvidenceCompleteness")
+    if not isinstance(position_effect, PositionEffectEvidence):
+        raise TypeError("position_effect must be a PositionEffectEvidence")
+
+    if fill_evidence is FillEvidenceCompleteness.ABSENT:
+        return PostFillCompletion(
+            PostFillCompletionStatus.MANUAL_REVIEW,
+            PostFillManualReviewReason.ABSENT_FILL_EVIDENCE,
+        )
+    if fill_evidence is FillEvidenceCompleteness.INCOMPLETE:
+        return PostFillCompletion(
+            PostFillCompletionStatus.MANUAL_REVIEW,
+            PostFillManualReviewReason.INCOMPLETE_FILL_EVIDENCE,
+        )
+    if position_effect is PositionEffectEvidence.ABSENT:
+        return PostFillCompletion(
+            PostFillCompletionStatus.MANUAL_REVIEW,
+            PostFillManualReviewReason.ABSENT_POSITION_EFFECT_EVIDENCE,
+        )
+    if position_effect is PositionEffectEvidence.INCONSISTENT:
+        return PostFillCompletion(
+            PostFillCompletionStatus.MANUAL_REVIEW,
+            PostFillManualReviewReason.INCONSISTENT_POSITION_EFFECT_EVIDENCE,
+        )
+    return PostFillCompletion(PostFillCompletionStatus.COMPLETE, None)
+
+
+def classify_position_effect(
+    *,
+    filled_qty: Decimal | None,
+    qty_before: Decimal | None,
+    qty_after: Decimal | None,
+    side: str,
+) -> PositionEffectEvidence:
+    """Compare the observed position delta against the filled quantity.
+
+    A sell reduces the position by the filled quantity; a buy increases it.  Any
+    missing input is ``ABSENT`` — an unobserved position is never assumed to have
+    moved correctly.
+    """
+
+    normalized_side = side.strip().lower()
+    if normalized_side not in {"buy", "sell"}:
+        raise ValueError(f"side must be buy or sell; got {side!r}")
+    if filled_qty is None or qty_before is None or qty_after is None:
+        return PositionEffectEvidence.ABSENT
+    expected_delta = filled_qty if normalized_side == "buy" else -filled_qty
+    if (qty_after - qty_before) != expected_delta:
+        return PositionEffectEvidence.INCONSISTENT
+    return PositionEffectEvidence.CONSISTENT
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryPlan:
+    """What a timeout/crash recovery is allowed to do.
+
+    ``broker_post_allowed`` and ``new_identity_allowed`` are ``Literal[False]``
+    return types, not configurable flags: this plan can never authorise either.
+    """
+
+    action: RecoveryAction
+    client_order_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.action, RecoveryAction):
+            raise TypeError("action must be a RecoveryAction")
+        cleaned = self.client_order_id.strip()
+        if not cleaned:
+            raise ValueError("client_order_id must be non-empty")
+        object.__setattr__(self, "client_order_id", cleaned)
+
+    @property
+    def broker_post_allowed(self) -> Literal[False]:
+        return False
+
+    @property
+    def new_identity_allowed(self) -> Literal[False]:
+        return False
+
+
+def plan_timeout_recovery(
+    *, client_order_id: str, evidence_lookup_available: bool
+) -> RecoveryPlan:
+    """Recover by reading the *existing* identity's evidence, never by resending.
+
+    When evidence lookup is unavailable the plan escalates to manual review; it
+    still carries the original ``client_order_id`` so a later attempt cannot
+    invent a new one.
+    """
+
+    action = (
+        RecoveryAction.LOOKUP_EXISTING_ORDER_EVIDENCE
+        if evidence_lookup_available
+        else RecoveryAction.ESCALATE_MANUAL_REVIEW
+    )
+    return RecoveryPlan(action=action, client_order_id=client_order_id)
+
+
+__all__ = [
+    "FillEvidenceCompleteness",
+    "PositionEffectEvidence",
+    "PostFillCompletion",
+    "PostFillCompletionStatus",
+    "PostFillManualReviewReason",
+    "RecoveryAction",
+    "RecoveryPlan",
+    "classify_position_effect",
+    "evaluate_post_fill_completion",
+    "plan_timeout_recovery",
+]

--- a/app/services/invalid_sample_eligibility/read_model.py
+++ b/app/services/invalid_sample_eligibility/read_model.py
@@ -1,0 +1,246 @@
+"""ROB-1036 — eligibility-aware read models.
+
+``status == 'closed' AND brier_score IS NOT NULL`` is *not* an eligibility
+predicate: it says the row was scored, not that it belongs in the cohort.  Every
+builder here therefore demands an explicit contract version and an explicit
+:class:`EligibilityPredicate`, and every result carries the
+included/excluded/unidentifiable counts plus the reasons, so a caller can never
+present a filtered cohort as if nothing had been dropped.
+
+The partition helper is pure, so trade-performance / PnL consumers apply exactly
+the same gate as calibration without re-deriving it.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.invalid_sample_eligibility.contract import (
+    CalibrationEligibility,
+    EligibilityContractError,
+    EligibilityDecision,
+    EligibilitySubject,
+    EligibilitySubjectKind,
+    ForecastOutcomeObservability,
+    OperationalReliabilityEligibility,
+    TradePerformanceEligibility,
+)
+from app.services.invalid_sample_eligibility.service import (
+    InvalidSampleEligibilityService,
+)
+from app.services.trade_journal.forecast_service import (
+    aggregate_calibration_rows,
+    list_scored_forecasts_for_calibration,
+)
+
+
+class EligibilityDomain(StrEnum):
+    """Which of the four validity questions a predicate asks."""
+
+    FORECAST_OUTCOME_OBSERVABILITY = "forecast_outcome_observability"
+    CALIBRATION = "calibration_eligibility"
+    TRADE_PERFORMANCE = "trade_performance_eligibility"
+    OPERATIONAL_RELIABILITY = "operational_reliability_eligibility"
+
+
+_DOMAIN_ENUMS: dict[EligibilityDomain, type[StrEnum]] = {
+    EligibilityDomain.FORECAST_OUTCOME_OBSERVABILITY: ForecastOutcomeObservability,
+    EligibilityDomain.CALIBRATION: CalibrationEligibility,
+    EligibilityDomain.TRADE_PERFORMANCE: TradePerformanceEligibility,
+    EligibilityDomain.OPERATIONAL_RELIABILITY: OperationalReliabilityEligibility,
+}
+
+_UNIDENTIFIABLE_MEMBERS = {
+    ForecastOutcomeObservability.UNIDENTIFIABLE,
+    CalibrationEligibility.UNIDENTIFIABLE,
+    TradePerformanceEligibility.UNIDENTIFIABLE,
+    OperationalReliabilityEligibility.UNIDENTIFIABLE,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityPredicate:
+    """One domain, one explicit admitted set, one contract version.
+
+    ``admitted`` must be members of that domain's own enum — a calibration
+    predicate cannot be satisfied by a trade-performance value.
+    """
+
+    contract_version: str
+    domain: EligibilityDomain
+    admitted: frozenset[StrEnum]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.domain, EligibilityDomain):
+            raise TypeError("domain must be an EligibilityDomain")
+        if not self.contract_version.strip():
+            raise EligibilityContractError(
+                "missing_contract_version", "contract_version must be non-empty"
+            )
+        if not self.admitted:
+            raise EligibilityContractError(
+                "empty_admitted_set",
+                "an eligibility predicate must admit at least one value",
+            )
+        expected = _DOMAIN_ENUMS[self.domain]
+        for member in self.admitted:
+            if not isinstance(member, expected):
+                raise EligibilityContractError(
+                    "cross_domain_predicate",
+                    f"{member!r} is not a {expected.__name__} value",
+                )
+
+    def value_of(self, decision: EligibilityDecision) -> StrEnum:
+        return getattr(decision, self.domain.value)
+
+    def admits(self, decision: EligibilityDecision) -> bool:
+        if decision.contract_version != self.contract_version:
+            return False
+        return self.value_of(decision) in self.admitted
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityPartition:
+    """Admitted rows plus a full account of what was held back and why."""
+
+    included: list[Any]
+    excluded: list[Any]
+    unidentifiable: list[Any]
+    contract_version: str
+    domain: EligibilityDomain
+    reasons: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        return {
+            "included": len(self.included),
+            "excluded": len(self.excluded),
+            "unidentifiable": len(self.unidentifiable),
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "eligibility_domain": self.domain.value,
+            "eligibility_counts": self.counts,
+            "eligibility_reasons": dict(self.reasons),
+        }
+
+
+def partition_by_eligibility(
+    items: Sequence[tuple[Any, EligibilityDecision]],
+    *,
+    predicate: EligibilityPredicate,
+) -> EligibilityPartition:
+    """Split ``(row, decision)`` pairs into included / excluded / unidentifiable."""
+
+    included: list[Any] = []
+    excluded: list[Any] = []
+    unidentifiable: list[Any] = []
+    reasons: Counter[str] = Counter()
+
+    for row, decision in items:
+        value = predicate.value_of(decision)
+        if decision.contract_version != predicate.contract_version:
+            unidentifiable.append(row)
+            reasons[f"contract_version_mismatch:{decision.contract_version}"] += 1
+            continue
+        if value in _UNIDENTIFIABLE_MEMBERS:
+            unidentifiable.append(row)
+            reasons[str(value)] += 1
+            continue
+        if value in predicate.admitted:
+            included.append(row)
+            continue
+        excluded.append(row)
+        reasons[str(value)] += 1
+
+    return EligibilityPartition(
+        included=included,
+        excluded=excluded,
+        unidentifiable=unidentifiable,
+        contract_version=predicate.contract_version,
+        domain=predicate.domain,
+        reasons=dict(reasons),
+    )
+
+
+async def build_eligible_forecast_calibration_aggregate(
+    db: AsyncSession,
+    *,
+    contract_version: str,
+    predicate: EligibilityPredicate,
+    group_by: str = "created_by",
+    created_by: str | None = None,
+    symbol: str | None = None,
+    instrument_type: str | None = None,
+    days: int | None = None,
+) -> dict[str, Any]:
+    """Calibration over the *eligible* cohort only.
+
+    ``contract_version`` and ``predicate`` are required keyword arguments with no
+    defaults: a caller cannot obtain a cohort without stating, on the record,
+    which contract and which admitted values it is asking for.
+    """
+
+    if predicate.contract_version != contract_version:
+        raise EligibilityContractError(
+            "predicate_contract_version_mismatch",
+            (
+                f"predicate is bound to {predicate.contract_version!r} but the "
+                f"cohort was requested for {contract_version!r}"
+            ),
+        )
+    if predicate.domain is not EligibilityDomain.CALIBRATION:
+        raise EligibilityContractError(
+            "wrong_predicate_domain",
+            "a calibration cohort requires an EligibilityDomain.CALIBRATION predicate",
+        )
+
+    rows = await list_scored_forecasts_for_calibration(
+        db,
+        created_by=created_by,
+        symbol=symbol,
+        instrument_type=instrument_type,
+        days=days,
+        apply_eligibility_exclusion=False,
+    )
+    service = InvalidSampleEligibilityService(db)
+    subjects = [
+        EligibilitySubject(
+            kind=EligibilitySubjectKind.FORECAST, ref=str(row.forecast_id)
+        )
+        for row in rows
+    ]
+    decisions = await service.get_decisions(subjects, contract_version=contract_version)
+    partition = partition_by_eligibility(
+        [
+            (
+                row,
+                decisions[
+                    EligibilitySubject(
+                        kind=EligibilitySubjectKind.FORECAST, ref=str(row.forecast_id)
+                    )
+                ],
+            )
+            for row in rows
+        ],
+        predicate=predicate,
+    )
+    aggregate = aggregate_calibration_rows(partition.included, group_by=group_by)
+    return {**aggregate, **partition.as_dict()}
+
+
+__all__ = [
+    "EligibilityDomain",
+    "EligibilityPartition",
+    "EligibilityPredicate",
+    "build_eligible_forecast_calibration_aggregate",
+    "partition_by_eligibility",
+]

--- a/app/services/invalid_sample_eligibility/read_model.py
+++ b/app/services/invalid_sample_eligibility/read_model.py
@@ -1,246 +1,84 @@
 """ROB-1036 — eligibility-aware read models.
 
 ``status == 'closed' AND brier_score IS NOT NULL`` is *not* an eligibility
-predicate: it says the row was scored, not that it belongs in the cohort.  Every
-builder here therefore demands an explicit contract version and an explicit
-:class:`EligibilityPredicate`, and every result carries the
-included/excluded/unidentifiable counts plus the reasons, so a caller can never
-present a filtered cohort as if nothing had been dropped.
+predicate: it says the row was scored, not that it belongs in the cohort. The
+calibration aggregate therefore demands an explicit contract version and an
+explicit :class:`EligibilityPredicate`, and every result carries the cohort it
+was produced under plus separately-reported included / excluded / unidentifiable
+counts — so a caller can never present a cohort as if nothing had been held back
+or folded in.
 
-The partition helper is pure, so trade-performance / PnL consumers apply exactly
-the same gate as calibration without re-deriving it.
+The cohort vocabulary itself lives in :mod:`.cohort` (pure, no aggregate import)
+and is re-exported here for callers that already import this module. The
+calibration aggregate lives in ``trade_journal.forecast_service``; this module
+adds the decided-only convenience wrapper and the generic partition helper that
+trade-performance / PnL consumers reuse.
 """
 
 from __future__ import annotations
 
-from collections import Counter
-from collections.abc import Sequence
-from dataclasses import dataclass, field
-from enum import StrEnum
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.services.invalid_sample_eligibility.contract import (
-    CalibrationEligibility,
-    EligibilityContractError,
-    EligibilityDecision,
-    EligibilitySubject,
-    EligibilitySubjectKind,
-    ForecastOutcomeObservability,
-    OperationalReliabilityEligibility,
-    TradePerformanceEligibility,
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+    COMPATIBILITY_STAGE,
+    DECIDED_ONLY_CALIBRATION_COHORT,
+    DECIDED_ONLY_STAGE,
+    DECIDED_ONLY_TRADE_PERFORMANCE_COHORT,
+    EligibilityBucket,
+    EligibilityDomain,
+    EligibilityPartition,
+    EligibilityPredicate,
+    partition_by_eligibility,
 )
-from app.services.invalid_sample_eligibility.service import (
-    InvalidSampleEligibilityService,
-)
+from app.services.invalid_sample_eligibility.contract import CONTRACT_VERSION
 from app.services.trade_journal.forecast_service import (
-    aggregate_calibration_rows,
-    list_scored_forecasts_for_calibration,
+    build_forecast_calibration_aggregate,
 )
 
 
-class EligibilityDomain(StrEnum):
-    """Which of the four validity questions a predicate asks."""
-
-    FORECAST_OUTCOME_OBSERVABILITY = "forecast_outcome_observability"
-    CALIBRATION = "calibration_eligibility"
-    TRADE_PERFORMANCE = "trade_performance_eligibility"
-    OPERATIONAL_RELIABILITY = "operational_reliability_eligibility"
-
-
-_DOMAIN_ENUMS: dict[EligibilityDomain, type[StrEnum]] = {
-    EligibilityDomain.FORECAST_OUTCOME_OBSERVABILITY: ForecastOutcomeObservability,
-    EligibilityDomain.CALIBRATION: CalibrationEligibility,
-    EligibilityDomain.TRADE_PERFORMANCE: TradePerformanceEligibility,
-    EligibilityDomain.OPERATIONAL_RELIABILITY: OperationalReliabilityEligibility,
-}
-
-_UNIDENTIFIABLE_MEMBERS = {
-    ForecastOutcomeObservability.UNIDENTIFIABLE,
-    CalibrationEligibility.UNIDENTIFIABLE,
-    TradePerformanceEligibility.UNIDENTIFIABLE,
-    OperationalReliabilityEligibility.UNIDENTIFIABLE,
-}
-
-
-@dataclass(frozen=True, slots=True)
-class EligibilityPredicate:
-    """One domain, one explicit admitted set, one contract version.
-
-    ``admitted`` must be members of that domain's own enum — a calibration
-    predicate cannot be satisfied by a trade-performance value.
-    """
-
-    contract_version: str
-    domain: EligibilityDomain
-    admitted: frozenset[StrEnum]
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.domain, EligibilityDomain):
-            raise TypeError("domain must be an EligibilityDomain")
-        if not self.contract_version.strip():
-            raise EligibilityContractError(
-                "missing_contract_version", "contract_version must be non-empty"
-            )
-        if not self.admitted:
-            raise EligibilityContractError(
-                "empty_admitted_set",
-                "an eligibility predicate must admit at least one value",
-            )
-        expected = _DOMAIN_ENUMS[self.domain]
-        for member in self.admitted:
-            if not isinstance(member, expected):
-                raise EligibilityContractError(
-                    "cross_domain_predicate",
-                    f"{member!r} is not a {expected.__name__} value",
-                )
-
-    def value_of(self, decision: EligibilityDecision) -> StrEnum:
-        return getattr(decision, self.domain.value)
-
-    def admits(self, decision: EligibilityDecision) -> bool:
-        if decision.contract_version != self.contract_version:
-            return False
-        return self.value_of(decision) in self.admitted
-
-
-@dataclass(frozen=True, slots=True)
-class EligibilityPartition:
-    """Admitted rows plus a full account of what was held back and why."""
-
-    included: list[Any]
-    excluded: list[Any]
-    unidentifiable: list[Any]
-    contract_version: str
-    domain: EligibilityDomain
-    reasons: dict[str, int] = field(default_factory=dict)
-
-    @property
-    def counts(self) -> dict[str, int]:
-        return {
-            "included": len(self.included),
-            "excluded": len(self.excluded),
-            "unidentifiable": len(self.unidentifiable),
-        }
-
-    def as_dict(self) -> dict[str, Any]:
-        return {
-            "contract_version": self.contract_version,
-            "eligibility_domain": self.domain.value,
-            "eligibility_counts": self.counts,
-            "eligibility_reasons": dict(self.reasons),
-        }
-
-
-def partition_by_eligibility(
-    items: Sequence[tuple[Any, EligibilityDecision]],
-    *,
-    predicate: EligibilityPredicate,
-) -> EligibilityPartition:
-    """Split ``(row, decision)`` pairs into included / excluded / unidentifiable."""
-
-    included: list[Any] = []
-    excluded: list[Any] = []
-    unidentifiable: list[Any] = []
-    reasons: Counter[str] = Counter()
-
-    for row, decision in items:
-        value = predicate.value_of(decision)
-        if decision.contract_version != predicate.contract_version:
-            unidentifiable.append(row)
-            reasons[f"contract_version_mismatch:{decision.contract_version}"] += 1
-            continue
-        if value in _UNIDENTIFIABLE_MEMBERS:
-            unidentifiable.append(row)
-            reasons[str(value)] += 1
-            continue
-        if value in predicate.admitted:
-            included.append(row)
-            continue
-        excluded.append(row)
-        reasons[str(value)] += 1
-
-    return EligibilityPartition(
-        included=included,
-        excluded=excluded,
-        unidentifiable=unidentifiable,
-        contract_version=predicate.contract_version,
-        domain=predicate.domain,
-        reasons=dict(reasons),
-    )
-
-
-async def build_eligible_forecast_calibration_aggregate(
+async def build_decided_only_forecast_calibration_aggregate(
     db: AsyncSession,
     *,
-    contract_version: str,
-    predicate: EligibilityPredicate,
+    contract_version: str = CONTRACT_VERSION,
     group_by: str = "created_by",
     created_by: str | None = None,
     symbol: str | None = None,
     instrument_type: str | None = None,
     days: int | None = None,
 ) -> dict[str, Any]:
-    """Calibration over the *eligible* cohort only.
+    """Calibration over decided inclusions only — the option-① end-state cohort.
 
-    ``contract_version`` and ``predicate`` are required keyword arguments with no
-    defaults: a caller cannot obtain a cohort without stating, on the record,
-    which contract and which admitted values it is asking for.
+    Available now so a caller that wants the fully-decided cohort can ask for it
+    today, and so promoting the default is a one-line swap. Today this returns an
+    empty cohort until eligibility decisions exist; the reported
+    ``unidentifiable`` count says exactly how many rows are waiting on a decision.
     """
 
-    if predicate.contract_version != contract_version:
-        raise EligibilityContractError(
-            "predicate_contract_version_mismatch",
-            (
-                f"predicate is bound to {predicate.contract_version!r} but the "
-                f"cohort was requested for {contract_version!r}"
-            ),
-        )
-    if predicate.domain is not EligibilityDomain.CALIBRATION:
-        raise EligibilityContractError(
-            "wrong_predicate_domain",
-            "a calibration cohort requires an EligibilityDomain.CALIBRATION predicate",
-        )
-
-    rows = await list_scored_forecasts_for_calibration(
+    return await build_forecast_calibration_aggregate(
         db,
+        contract_version=contract_version,
+        predicate=DECIDED_ONLY_CALIBRATION_COHORT,
+        group_by=group_by,
         created_by=created_by,
         symbol=symbol,
         instrument_type=instrument_type,
         days=days,
-        apply_eligibility_exclusion=False,
     )
-    service = InvalidSampleEligibilityService(db)
-    subjects = [
-        EligibilitySubject(
-            kind=EligibilitySubjectKind.FORECAST, ref=str(row.forecast_id)
-        )
-        for row in rows
-    ]
-    decisions = await service.get_decisions(subjects, contract_version=contract_version)
-    partition = partition_by_eligibility(
-        [
-            (
-                row,
-                decisions[
-                    EligibilitySubject(
-                        kind=EligibilitySubjectKind.FORECAST, ref=str(row.forecast_id)
-                    )
-                ],
-            )
-            for row in rows
-        ],
-        predicate=predicate,
-    )
-    aggregate = aggregate_calibration_rows(partition.included, group_by=group_by)
-    return {**aggregate, **partition.as_dict()}
 
 
 __all__ = [
+    "COMPATIBILITY_CALIBRATION_COHORT",
+    "COMPATIBILITY_STAGE",
+    "DECIDED_ONLY_CALIBRATION_COHORT",
+    "DECIDED_ONLY_STAGE",
+    "DECIDED_ONLY_TRADE_PERFORMANCE_COHORT",
+    "EligibilityBucket",
     "EligibilityDomain",
     "EligibilityPartition",
     "EligibilityPredicate",
-    "build_eligible_forecast_calibration_aggregate",
+    "build_decided_only_forecast_calibration_aggregate",
     "partition_by_eligibility",
 ]

--- a/app/services/invalid_sample_eligibility/repository.py
+++ b/app/services/invalid_sample_eligibility/repository.py
@@ -2,8 +2,8 @@
 
 Service-internal. Import it from
 ``app.services.invalid_sample_eligibility.service`` only; the static boundary
-test rejects any other importer, mirroring the ROB-298 Binance demo ledger and
-ROB-816 order-proposal repository rules.
+test rejects any other importer, following the same service-private repository
+rule as ROB-298 and ROB-816.
 """
 
 from __future__ import annotations

--- a/app/services/invalid_sample_eligibility/repository.py
+++ b/app/services/invalid_sample_eligibility/repository.py
@@ -1,0 +1,114 @@
+"""ROB-1036 — SQLAlchemy access for the eligibility / cleanup-binding tables.
+
+Service-internal. Import it from
+``app.services.invalid_sample_eligibility.service`` only; the static boundary
+test rejects any other importer, mirroring the ROB-298 Binance demo ledger and
+ROB-816 order-proposal repository rules.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invalid_sample_eligibility import (
+    InvalidSampleCleanupBinding,
+    InvalidSampleCleanupLifecycleEvent,
+    SampleEligibilityDecision,
+)
+
+
+class InvalidSampleEligibilityRepository:
+    """Reads and appends; it never updates or deletes a row."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def list_decisions(
+        self, *, subject_kind: str, subject_ref: str
+    ) -> list[SampleEligibilityDecision]:
+        result = await self._db.execute(
+            select(SampleEligibilityDecision)
+            .where(
+                SampleEligibilityDecision.subject_kind == subject_kind,
+                SampleEligibilityDecision.subject_ref == subject_ref,
+            )
+            .order_by(SampleEligibilityDecision.revision_no)
+        )
+        return list(result.scalars().all())
+
+    async def list_decisions_for_refs(
+        self, *, subject_kind: str, subject_refs: Sequence[str]
+    ) -> list[SampleEligibilityDecision]:
+        if not subject_refs:
+            return []
+        result = await self._db.execute(
+            select(SampleEligibilityDecision)
+            .where(
+                SampleEligibilityDecision.subject_kind == subject_kind,
+                SampleEligibilityDecision.subject_ref.in_(list(subject_refs)),
+            )
+            .order_by(
+                SampleEligibilityDecision.subject_ref,
+                SampleEligibilityDecision.revision_no,
+            )
+        )
+        return list(result.scalars().all())
+
+    async def add_decision(self, values: dict[str, Any]) -> SampleEligibilityDecision:
+        row = SampleEligibilityDecision(**values)
+        self._db.add(row)
+        await self._db.flush()
+        return row
+
+    async def get_binding_by_hash(
+        self, binding_hash: str
+    ) -> InvalidSampleCleanupBinding | None:
+        result = await self._db.execute(
+            select(InvalidSampleCleanupBinding).where(
+                InvalidSampleCleanupBinding.binding_hash == binding_hash
+            )
+        )
+        return result.scalars().first()
+
+    async def get_binding_by_client_order_id(
+        self, client_order_id: str
+    ) -> InvalidSampleCleanupBinding | None:
+        result = await self._db.execute(
+            select(InvalidSampleCleanupBinding).where(
+                InvalidSampleCleanupBinding.client_order_id == client_order_id
+            )
+        )
+        return result.scalars().first()
+
+    async def add_binding(self, values: dict[str, Any]) -> InvalidSampleCleanupBinding:
+        row = InvalidSampleCleanupBinding(**values)
+        self._db.add(row)
+        await self._db.flush()
+        return row
+
+    async def get_lifecycle_event(
+        self, *, binding_hash: str, event_kind: str, evidence_hash: str
+    ) -> InvalidSampleCleanupLifecycleEvent | None:
+        result = await self._db.execute(
+            select(InvalidSampleCleanupLifecycleEvent).where(
+                InvalidSampleCleanupLifecycleEvent.binding_hash == binding_hash,
+                InvalidSampleCleanupLifecycleEvent.event_kind == event_kind,
+                InvalidSampleCleanupLifecycleEvent.evidence_hash == evidence_hash,
+            )
+        )
+        return result.scalars().first()
+
+    async def add_lifecycle_event(
+        self, values: dict[str, Any]
+    ) -> InvalidSampleCleanupLifecycleEvent:
+        row = InvalidSampleCleanupLifecycleEvent(**values)
+        self._db.add(row)
+        await self._db.flush()
+        return row
+
+
+__all__ = ["InvalidSampleEligibilityRepository"]

--- a/app/services/invalid_sample_eligibility/service.py
+++ b/app/services/invalid_sample_eligibility/service.py
@@ -148,6 +148,39 @@ class InvalidSampleEligibilityService:
             for subject in subjects
         }
 
+    async def list_trade_performance_excluded(
+        self,
+        correlation_ids: Sequence[str],
+        *,
+        contract_version: str = CONTRACT_VERSION,
+    ) -> frozenset[str]:
+        """Lifecycle correlation ids explicitly excluded from trade performance.
+
+        Reports **only** an explicit ``trade_performance_exclude`` under
+        ``contract_version``. A missing decision is ``UNIDENTIFIABLE`` and is
+        deliberately *not* reported here: whether an undecided lifecycle belongs
+        in a PnL cohort is the caller's stated cohort policy, and this method
+        must not answer it silently in either direction.
+        """
+
+        unique = [ref for ref in dict.fromkeys(correlation_ids) if ref]
+        if not unique:
+            return frozenset()
+        subjects = [
+            EligibilitySubject(kind=EligibilitySubjectKind.TRADE_LIFECYCLE, ref=ref)
+            for ref in unique
+        ]
+        decisions = await self.get_decisions(
+            subjects, contract_version=contract_version
+        )
+        return frozenset(
+            subject.ref
+            for subject, decision in decisions.items()
+            if decision.contract_version == contract_version
+            and decision.trade_performance_eligibility
+            is TradePerformanceEligibility.EXCLUDE
+        )
+
     async def record_decision(
         self,
         *,

--- a/app/services/invalid_sample_eligibility/service.py
+++ b/app/services/invalid_sample_eligibility/service.py
@@ -1,0 +1,320 @@
+"""ROB-1036 — the only write surface for the eligibility / cleanup tables.
+
+Nothing here calls a broker, a market-data provider, or a scheduler.  The
+service appends rows; it never updates or deletes one, and it never resolves a
+forecast outcome or derives a price/Brier value.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.invalid_sample_eligibility.binding import (
+    CLEANUP_PURPOSE,
+    CleanupBinding,
+    CleanupBindingError,
+)
+from app.services.invalid_sample_eligibility.contract import (
+    CONTRACT_VERSION,
+    CalibrationEligibility,
+    EligibilityContractError,
+    EligibilityDecision,
+    EligibilitySubject,
+    EligibilitySubjectKind,
+    ForecastOutcomeObservability,
+    OperationalReliabilityEligibility,
+    TradePerformanceEligibility,
+    canonical_evidence_hash,
+    latest_decision,
+    validate_revision_chain,
+)
+from app.services.invalid_sample_eligibility.post_fill import (
+    FillEvidenceCompleteness,
+    PositionEffectEvidence,
+    PostFillCompletion,
+    PostFillCompletionStatus,
+    evaluate_post_fill_completion,
+)
+from app.services.invalid_sample_eligibility.repository import (
+    InvalidSampleEligibilityRepository,
+)
+
+_EVENT_KIND_BY_STATUS = {
+    PostFillCompletionStatus.COMPLETE: "post_fill_completion",
+    PostFillCompletionStatus.MANUAL_REVIEW: "post_fill_manual_review",
+}
+
+
+def _to_decision(row: Any) -> EligibilityDecision:
+    """Rebuild the typed decision from a persisted row, re-validating the hash.
+
+    The stored ``evidence_hash`` is recomputed from the stored ``evidence``. A
+    row whose evidence no longer hashes to its digest is refused rather than
+    read: a decision is only as trustworthy as the evidence bound to it.
+    """
+
+    recomputed = canonical_evidence_hash(
+        row.evidence if row.evidence is not None else {}
+    )
+    if recomputed != row.evidence_hash:
+        raise EligibilityContractError(
+            "evidence_hash_mismatch",
+            (
+                f"stored evidence for {row.subject_kind}:{row.subject_ref} "
+                f"revision {row.revision_no} does not match its digest"
+            ),
+        )
+    return EligibilityDecision(
+        subject=EligibilitySubject(
+            kind=EligibilitySubjectKind(row.subject_kind), ref=row.subject_ref
+        ),
+        contract_version=row.contract_version,
+        revision_no=int(row.revision_no),
+        supersedes_revision_no=(
+            None
+            if row.supersedes_revision_no is None
+            else int(row.supersedes_revision_no)
+        ),
+        forecast_outcome_observability=ForecastOutcomeObservability(
+            row.forecast_outcome_observability
+        ),
+        calibration_eligibility=CalibrationEligibility(row.calibration_eligibility),
+        trade_performance_eligibility=TradePerformanceEligibility(
+            row.trade_performance_eligibility
+        ),
+        operational_reliability_eligibility=OperationalReliabilityEligibility(
+            row.operational_reliability_eligibility
+        ),
+        decision_reason=row.decision_reason,
+        evidence_hash=row.evidence_hash,
+    )
+
+
+class InvalidSampleEligibilityService:
+    """Append-only service layer for ``uber-invalid-sample-eligibility.v1``."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+        self._repo = InvalidSampleEligibilityRepository(db)
+
+    # -- eligibility decisions ------------------------------------------------
+
+    async def get_decision(
+        self, subject: EligibilitySubject, *, contract_version: str = CONTRACT_VERSION
+    ) -> EligibilityDecision:
+        """Latest revision, or the fail-closed unidentifiable default.
+
+        A subject with no decision on record is ``UNIDENTIFIABLE`` in all four
+        domains.  It is never coalesced to ``INCLUDE``.
+        """
+
+        rows = await self._repo.list_decisions(
+            subject_kind=subject.kind.value, subject_ref=subject.ref
+        )
+        decisions = [_to_decision(row) for row in rows]
+        return latest_decision(decisions, subject, contract_version=contract_version)
+
+    async def get_decisions(
+        self,
+        subjects: Sequence[EligibilitySubject],
+        *,
+        contract_version: str = CONTRACT_VERSION,
+    ) -> dict[EligibilitySubject, EligibilityDecision]:
+        """Bulk variant of :meth:`get_decision`, same fail-closed default."""
+
+        by_kind: dict[EligibilitySubjectKind, list[str]] = {}
+        for subject in subjects:
+            by_kind.setdefault(subject.kind, []).append(subject.ref)
+
+        chains: dict[tuple[str, str], list[EligibilityDecision]] = {}
+        for kind, refs in by_kind.items():
+            rows = await self._repo.list_decisions_for_refs(
+                subject_kind=kind.value, subject_refs=refs
+            )
+            for row in rows:
+                chains.setdefault((row.subject_kind, row.subject_ref), []).append(
+                    _to_decision(row)
+                )
+
+        return {
+            subject: latest_decision(
+                chains.get((subject.kind.value, subject.ref), []),
+                subject,
+                contract_version=contract_version,
+            )
+            for subject in subjects
+        }
+
+    async def record_decision(
+        self,
+        *,
+        subject: EligibilitySubject,
+        forecast_outcome_observability: ForecastOutcomeObservability,
+        calibration_eligibility: CalibrationEligibility,
+        trade_performance_eligibility: TradePerformanceEligibility,
+        operational_reliability_eligibility: OperationalReliabilityEligibility,
+        decision_reason: str,
+        decided_by: str,
+        evidence: dict[str, Any] | None = None,
+        contract_version: str = CONTRACT_VERSION,
+    ) -> EligibilityDecision:
+        """Append the next revision. A correction supersedes; it never overwrites."""
+
+        existing_rows = await self._repo.list_decisions(
+            subject_kind=subject.kind.value, subject_ref=subject.ref
+        )
+        existing = [_to_decision(row) for row in existing_rows]
+        validate_revision_chain(existing)
+        if existing and existing[-1].contract_version != contract_version:
+            raise EligibilityContractError(
+                "contract_version_switch",
+                (
+                    f"subject is recorded under {existing[-1].contract_version!r}; "
+                    f"refusing to append {contract_version!r}"
+                ),
+            )
+        next_revision = len(existing) + 1
+        evidence_payload = dict(evidence or {})
+        decision = EligibilityDecision(
+            subject=subject,
+            contract_version=contract_version,
+            revision_no=next_revision,
+            supersedes_revision_no=None if next_revision == 1 else next_revision - 1,
+            forecast_outcome_observability=forecast_outcome_observability,
+            calibration_eligibility=calibration_eligibility,
+            trade_performance_eligibility=trade_performance_eligibility,
+            operational_reliability_eligibility=operational_reliability_eligibility,
+            decision_reason=decision_reason,
+            evidence_hash=canonical_evidence_hash(evidence_payload),
+        )
+        await self._repo.add_decision(
+            {
+                "subject_kind": subject.kind.value,
+                "subject_ref": subject.ref,
+                "contract_version": decision.contract_version,
+                "revision_no": decision.revision_no,
+                "supersedes_revision_no": decision.supersedes_revision_no,
+                "forecast_outcome_observability": (
+                    decision.forecast_outcome_observability.value
+                ),
+                "calibration_eligibility": decision.calibration_eligibility.value,
+                "trade_performance_eligibility": (
+                    decision.trade_performance_eligibility.value
+                ),
+                "operational_reliability_eligibility": (
+                    decision.operational_reliability_eligibility.value
+                ),
+                "decision_reason": decision.decision_reason,
+                "decided_by": decided_by,
+                "evidence": evidence_payload,
+                "evidence_hash": decision.evidence_hash,
+            }
+        )
+        return decision
+
+    # -- cleanup binding ------------------------------------------------------
+
+    async def record_cleanup_binding(self, binding: CleanupBinding) -> Any:
+        """Persist the immutable binding, or return the identical existing row.
+
+        Re-authoring the same binding is idempotent.  A *different* binding for
+        an already-bound ``client_order_id`` is refused: the identity is claimed.
+        """
+
+        if binding.purpose != CLEANUP_PURPOSE:
+            raise CleanupBindingError(
+                "unsupported_purpose", f"purpose must be {CLEANUP_PURPOSE!r}"
+            )
+        existing = await self._repo.get_binding_by_client_order_id(
+            binding.client_order_id
+        )
+        if existing is not None:
+            if existing.binding_hash != binding.binding_hash:
+                raise CleanupBindingError(
+                    "conflicting_binding_for_client_order_id",
+                    (
+                        f"client_order_id {binding.client_order_id!r} is already "
+                        "bound to a different approval/mission identity"
+                    ),
+                )
+            return existing
+        return await self._repo.add_binding(
+            {
+                "purpose": binding.purpose,
+                "contract_version": binding.contract_version,
+                "forecast_id": binding.forecast_id,
+                "sample_ref": binding.sample_ref,
+                "approval_id": binding.approval_id,
+                "approval_hash": binding.approval_hash,
+                "approval_expires_at": binding.approval_expires_at,
+                "approval_session_id": binding.approval_session_id,
+                "mission_id": binding.mission_id,
+                "account_mode": binding.account_mode,
+                "client_order_id": binding.client_order_id,
+                "lifecycle_correlation_id": binding.lifecycle_correlation_id,
+                "binding_hash": binding.binding_hash,
+            }
+        )
+
+    # -- post-fill evidence ---------------------------------------------------
+
+    async def record_post_fill_evidence(
+        self,
+        *,
+        binding: CleanupBinding,
+        fill_evidence: FillEvidenceCompleteness,
+        position_effect: PositionEffectEvidence,
+        evidence: dict[str, Any] | None = None,
+    ) -> PostFillCompletion:
+        """Evaluate the two-evidence gate and append the resulting event.
+
+        Terminal success requires complete broker fill evidence *and* consistent
+        position-effect evidence.  Anything else is recorded as a typed
+        manual-review event.  Replaying identical evidence appends nothing.
+        """
+
+        stored = await self._repo.get_binding_by_hash(binding.binding_hash)
+        if stored is None:
+            raise CleanupBindingError(
+                "unbound_lifecycle",
+                "post-fill evidence requires a persisted cleanup binding",
+            )
+        completion = evaluate_post_fill_completion(
+            fill_evidence=fill_evidence, position_effect=position_effect
+        )
+        evidence_payload = {
+            "fill_evidence": fill_evidence.value,
+            "position_effect_evidence": position_effect.value,
+            "detail": dict(evidence or {}),
+        }
+        evidence_hash = canonical_evidence_hash(evidence_payload)
+        event_kind = _EVENT_KIND_BY_STATUS[completion.status]
+        duplicate = await self._repo.get_lifecycle_event(
+            binding_hash=binding.binding_hash,
+            event_kind=event_kind,
+            evidence_hash=evidence_hash,
+        )
+        if duplicate is None:
+            await self._repo.add_lifecycle_event(
+                {
+                    "binding_hash": binding.binding_hash,
+                    "client_order_id": binding.client_order_id,
+                    "contract_version": binding.contract_version,
+                    "event_kind": event_kind,
+                    "completion_status": completion.status.value,
+                    "manual_review_reason": (
+                        None if completion.reason is None else completion.reason.value
+                    ),
+                    "fill_evidence": fill_evidence.value,
+                    "position_effect_evidence": position_effect.value,
+                    "evidence": evidence_payload,
+                    "evidence_hash": evidence_hash,
+                }
+            )
+        return completion
+
+
+__all__ = ["InvalidSampleEligibilityService"]

--- a/app/services/paper_evaluation/evidence.py
+++ b/app/services/paper_evaluation/evidence.py
@@ -8,10 +8,11 @@ uses caller supplied lineage or gate timestamps.
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Literal, Never
+from typing import Any, Literal, Never
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,6 +31,9 @@ from app.models.paper_evaluation import EvaluationConfig as EvaluationConfigRow
 from app.models.paper_evaluation import EvaluationEpoch as EvaluationEpochRow
 from app.models.paper_validation import PaperValidationStateTransition
 from app.models.review import AlpacaPaperOrderLedger
+from app.services.invalid_sample_eligibility.service import (
+    InvalidSampleEligibilityService,
+)
 from app.services.paper_cohort.market_snapshot import CanonicalSnapshotPayload
 from app.services.paper_cohort.signals import (
     CanonicalTargetSignal,
@@ -634,6 +638,44 @@ class AuthoritativeEvidenceReader:
             _fail("out_of_order_evidence")
         return tuple(observations)
 
+    async def _trade_performance_excluded_row_ids(
+        self, rows: Sequence[Any]
+    ) -> frozenset[int]:
+        """ROB-1036 — native Alpaca row ids excluded from trade performance.
+
+        Returns **row ids**, never correlation ids, so ``_load_native`` stays
+        free of correlation-scoped vocabulary and its ROB-850 assignment-scoping
+        invariant is untouched: the rows considered here are exactly the ones the
+        assignment-scoped link query already produced. Nothing is *discovered* by
+        correlation id; an already-discovered row is merely filtered out.
+
+        Only an explicit ``trade_performance_exclude`` decision filters a row.
+        A lifecycle with no decision is ``UNIDENTIFIABLE`` and is left in place,
+        so this is additive: with no decisions on record the evidence set is
+        identical to before.
+        """
+
+        by_correlation: dict[str, list[int]] = {}
+        for link, *_rest in rows:
+            if link.venue == "binance":
+                continue
+            row = await self._session.get(
+                AlpacaPaperOrderLedger, link.native_ledger_row_id
+            )
+            key = None if row is None else row.lifecycle_correlation_id
+            if row is not None and key:
+                by_correlation.setdefault(key, []).append(row.id)
+        if not by_correlation:
+            return frozenset()
+        service = InvalidSampleEligibilityService(self._session)
+        excluded = await service.list_trade_performance_excluded(list(by_correlation))
+        return frozenset(
+            row_id
+            for key, row_ids in by_correlation.items()
+            if key in excluded
+            for row_id in row_ids
+        )
+
     async def _load_native(
         self,
         *,
@@ -679,6 +721,7 @@ class AuthoritativeEvidenceReader:
         fills: dict[str, list[NativeFill]] = {"binance": [], "alpaca": []}
         marks: dict[str, list[NativeMark]] = {"binance": [], "alpaca": []}
         native_keys: set[tuple[str, int]] = set()
+        excluded_row_ids = await self._trade_performance_excluded_row_ids(rows)
         for link, intent, decision, snapshot in rows:
             if link.venue == "binance":
                 row = await self._session.get(
@@ -689,6 +732,14 @@ class AuthoritativeEvidenceReader:
                 row = await self._session.get(
                     AlpacaPaperOrderLedger, link.native_ledger_row_id
                 )
+                # ROB-1036: a row whose lifecycle carries an explicit
+                # trade-performance exclusion never enters the PnL evidence set.
+                # An invalid sample stays a real operational record; it just
+                # stops being a performance data point. The excluded set is
+                # resolved by row id above, so this method performs no
+                # correlation-scoped discovery (ROB-850 invariant).
+                if row is not None and row.id in excluded_row_ids:
+                    continue
                 filled_at = (
                     None if row is None else _alpaca_filled_at(row.raw_responses)
                 )

--- a/app/services/paper_evaluation/pnl.py
+++ b/app/services/paper_evaluation/pnl.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Protocol
@@ -478,13 +478,22 @@ class PaperEvaluationPnL:
         evaluated_at: datetime | None = None,
         native_marks: Mapping[str, Decimal] | None = None,
         benchmark_marks: Mapping[str, tuple[Decimal, Decimal]] | None = None,
+        excluded_correlation_ids: Collection[str] = (),
     ) -> ViewMetrics:
         """Compute View 2: Alpaca broker P&L (native USD).
 
         Reads execution rows via ``ledger.list_by_correlation_id``.
         Filters to ``record_kind='execution'`` and executed lifecycle states.
         Filters to ``currency='USD'``.
+
+        ROB-1036: ``excluded_correlation_ids`` drops lifecycles carrying an
+        explicit ``trade_performance_exclude`` decision, so an invalid sample
+        cannot re-enter the PnL aggregate. The caller resolves them through
+        ``InvalidSampleEligibilityService.list_trade_performance_excluded``;
+        this method stays free of DB access. The default is empty, so a caller
+        that supplies nothing gets exactly the previous behaviour.
         """
+        excluded = frozenset(excluded_correlation_ids)
         _EXECUTED_LIFECYCLE_STATES = frozenset(
             {
                 "submitted",
@@ -507,8 +516,12 @@ class PaperEvaluationPnL:
         turnover = _ZERO
 
         for corr_id in correlation_ids:
+            if corr_id in excluded:
+                continue
             rows = await ledger.list_by_correlation_id(corr_id)
             for row in rows:
+                if row.lifecycle_correlation_id in excluded:
+                    continue
                 if row.record_kind != _RECORD_KIND_EXECUTION:
                     if (
                         row.record_kind == "reconcile"

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -34,9 +34,19 @@ from app.services.daily_candles.repository import (
     DailyCandlesRepository,
     MarketKey,
 )
+from app.services.invalid_sample_eligibility.cohort import (
+    EligibilityDomain,
+    EligibilityPredicate,
+    partition_by_eligibility,
+)
 from app.services.invalid_sample_eligibility.contract import (
     CalibrationEligibility,
+    EligibilityContractError,
+    EligibilitySubject,
     EligibilitySubjectKind,
+)
+from app.services.invalid_sample_eligibility.service import (
+    InvalidSampleEligibilityService,
 )
 from app.services.trading_policy_service import policy_version_stamp
 
@@ -1442,6 +1452,8 @@ def aggregate_calibration_rows(
 async def build_forecast_calibration_aggregate(
     db: AsyncSession,
     *,
+    contract_version: str,
+    predicate: EligibilityPredicate,
     group_by: str = "created_by",
     created_by: str | None = None,
     symbol: str | None = None,
@@ -1455,23 +1467,70 @@ async def build_forecast_calibration_aggregate(
     "does another LLM reach the same result" comparison. ``calibration_gap`` is
     ``avg_probability - hit_rate`` (positive = over-confident).
 
-    ROB-1036: forecasts carrying an explicit ``calibration_exclude`` decision are
-    dropped here too, so an invalid sample cannot re-enter through this legacy
-    entry point. Callers that need the excluded/unidentifiable counts should use
-    ``build_eligible_forecast_calibration_aggregate`` instead.
+    ROB-1036 D-1 (option ②): ``contract_version`` and ``predicate`` are required
+    keyword arguments with no defaults. ``status='closed' AND brier_score IS NOT
+    NULL`` is not, by itself, a cohort definition — a caller must say which
+    contract and which admitted values it is asking for, and the answer carries
+    that statement back (``eligibility_cohort`` / ``eligibility_stage``) so the
+    number stays attributable after the cohort definition changes.
+
+    The counts are reported **separately** — ``included`` / ``excluded`` /
+    ``unidentifiable`` are never summed into one "eligible" number. Under
+    ``COMPATIBILITY_CALIBRATION_COHORT`` the undecided rows are admitted *and*
+    counted, which is the whole point: the contamination is visible rather than
+    silent. See the termination condition in
+    ``app/services/invalid_sample_eligibility/cohort.py``.
     """
     if group_by not in _GROUP_BY_FIELDS:
         group_by = "created_by"
+    if predicate.contract_version != contract_version:
+        raise EligibilityContractError(
+            "predicate_contract_version_mismatch",
+            (
+                f"predicate is bound to {predicate.contract_version!r} but the "
+                f"cohort was requested for {contract_version!r}"
+            ),
+        )
+    if predicate.domain is not EligibilityDomain.CALIBRATION:
+        raise EligibilityContractError(
+            "wrong_predicate_domain",
+            "a calibration cohort requires an EligibilityDomain.CALIBRATION predicate",
+        )
 
+    # Fetched unfiltered: the partition is the authoritative classifier here and
+    # must see the excluded rows in order to count them.
     rows = await list_scored_forecasts_for_calibration(
         db,
         created_by=created_by,
         symbol=symbol,
         instrument_type=instrument_type,
         days=days,
-        apply_eligibility_exclusion=True,
+        apply_eligibility_exclusion=False,
     )
-    return _aggregate_calibration_groups(rows, group_by=group_by)
+    service = InvalidSampleEligibilityService(db)
+    subjects = [
+        EligibilitySubject(
+            kind=EligibilitySubjectKind.FORECAST, ref=str(row.forecast_id)
+        )
+        for row in rows
+    ]
+    decisions = await service.get_decisions(subjects, contract_version=contract_version)
+    partition = partition_by_eligibility(
+        [
+            (
+                row,
+                decisions[
+                    EligibilitySubject(
+                        kind=EligibilitySubjectKind.FORECAST, ref=str(row.forecast_id)
+                    )
+                ],
+            )
+            for row in rows
+        ],
+        predicate=predicate,
+    )
+    aggregate = _aggregate_calibration_groups(partition.admitted, group_by=group_by)
+    return {**aggregate, **partition.as_dict()}
 
 
 def _aggregate_calibration_groups(

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -14,23 +14,29 @@ import datetime as dt
 import logging
 import math
 import uuid
+from collections.abc import Sequence
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import Text, and_, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer
 
 from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
+from app.models.invalid_sample_eligibility import SampleEligibilityDecision
 from app.models.review import TradeForecast
 from app.models.trading import InstrumentType
 from app.services.daily_candles.repository import (
     DailyCandleRow,
     DailyCandlesRepository,
     MarketKey,
+)
+from app.services.invalid_sample_eligibility.contract import (
+    CalibrationEligibility,
+    EligibilitySubjectKind,
 )
 from app.services.trading_policy_service import policy_version_stamp
 
@@ -1350,6 +1356,89 @@ async def _fetch_calibration_rows(
     return list(result.scalars().all())
 
 
+def _explicit_calibration_exclusion_filter():
+    """ROB-1036: drop forecasts whose *latest* eligibility revision says EXCLUDE.
+
+    Scoped deliberately narrowly. A forecast with no decision on record is
+    untouched — this is not a historical backfill and never coerces a missing
+    decision to either INCLUDE or EXCLUDE. It only stops an explicitly excluded
+    invalid sample (the UBER cleanup case) from re-entering the calibration
+    aggregate through the legacy ``closed + scored`` predicate.
+    """
+
+    decision = SampleEligibilityDecision
+    subject_ref = cast(TradeForecast.forecast_id, Text)
+    latest_revision = (
+        select(func.max(decision.revision_no))
+        .where(
+            decision.subject_kind == EligibilitySubjectKind.FORECAST.value,
+            decision.subject_ref == subject_ref,
+        )
+        .correlate(TradeForecast)
+        .scalar_subquery()
+    )
+    excluded = (
+        select(decision.id)
+        .where(
+            decision.subject_kind == EligibilitySubjectKind.FORECAST.value,
+            decision.subject_ref == subject_ref,
+            decision.revision_no == latest_revision,
+            decision.calibration_eligibility == CalibrationEligibility.EXCLUDE.value,
+        )
+        .correlate(TradeForecast)
+        .exists()
+    )
+    return ~excluded
+
+
+async def list_scored_forecasts_for_calibration(
+    db: AsyncSession,
+    *,
+    created_by: str | None = None,
+    symbol: str | None = None,
+    instrument_type: str | None = None,
+    days: int | None = None,
+    apply_eligibility_exclusion: bool = True,
+) -> list[TradeForecast]:
+    """Closed + scored forecasts matching the cohort filters.
+
+    ``apply_eligibility_exclusion`` drops explicitly excluded samples at the SQL
+    edge. The eligibility-aware read model passes ``False`` because it partitions
+    every domain itself and must report the excluded/unidentifiable counts rather
+    than silently losing the rows.
+    """
+
+    filters = [
+        TradeForecast.status == "closed",
+        TradeForecast.brier_score.isnot(None),
+    ]
+    if apply_eligibility_exclusion:
+        filters.append(_explicit_calibration_exclusion_filter())
+    if created_by is not None:
+        filters.append(TradeForecast.created_by == created_by)
+    if symbol is not None:
+        filters.append(
+            TradeForecast.symbol
+            == _normalize_symbol_for_filter(symbol, instrument_type)
+        )
+    if instrument_type is not None:
+        filters.append(TradeForecast.instrument_type == instrument_type)
+    if days is not None:
+        filters.append(TradeForecast.resolved_at >= now_kst() - timedelta(days=days))
+
+    return await _fetch_calibration_rows(db, filters=filters)
+
+
+def aggregate_calibration_rows(
+    rows: Sequence[TradeForecast], *, group_by: str = "created_by"
+) -> dict[str, Any]:
+    """Pure Brier/hit-rate aggregation over an already-selected cohort."""
+
+    if group_by not in _GROUP_BY_FIELDS:
+        group_by = "created_by"
+    return _aggregate_calibration_groups(rows, group_by=group_by)
+
+
 async def build_forecast_calibration_aggregate(
     db: AsyncSession,
     *,
@@ -1365,28 +1454,29 @@ async def build_forecast_calibration_aggregate(
     ``model_label`` / KST ``day`` — the objective metric behind an operator's
     "does another LLM reach the same result" comparison. ``calibration_gap`` is
     ``avg_probability - hit_rate`` (positive = over-confident).
+
+    ROB-1036: forecasts carrying an explicit ``calibration_exclude`` decision are
+    dropped here too, so an invalid sample cannot re-enter through this legacy
+    entry point. Callers that need the excluded/unidentifiable counts should use
+    ``build_eligible_forecast_calibration_aggregate`` instead.
     """
     if group_by not in _GROUP_BY_FIELDS:
         group_by = "created_by"
 
-    filters = [
-        TradeForecast.status == "closed",
-        TradeForecast.brier_score.isnot(None),
-    ]
-    if created_by is not None:
-        filters.append(TradeForecast.created_by == created_by)
-    if symbol is not None:
-        filters.append(
-            TradeForecast.symbol
-            == _normalize_symbol_for_filter(symbol, instrument_type)
-        )
-    if instrument_type is not None:
-        filters.append(TradeForecast.instrument_type == instrument_type)
-    if days is not None:
-        filters.append(TradeForecast.resolved_at >= now_kst() - timedelta(days=days))
+    rows = await list_scored_forecasts_for_calibration(
+        db,
+        created_by=created_by,
+        symbol=symbol,
+        instrument_type=instrument_type,
+        days=days,
+        apply_eligibility_exclusion=True,
+    )
+    return _aggregate_calibration_groups(rows, group_by=group_by)
 
-    rows = await _fetch_calibration_rows(db, filters=filters)
 
+def _aggregate_calibration_groups(
+    rows: Sequence[TradeForecast], *, group_by: str
+) -> dict[str, Any]:
     groups: dict[str, list[TradeForecast]] = {}
     for r in rows:
         groups.setdefault(_group_key(r, group_by), []).append(r)

--- a/docs/runbooks/uber-invalid-sample-eligibility.md
+++ b/docs/runbooks/uber-invalid-sample-eligibility.md
@@ -113,6 +113,42 @@ Re-authoring the *identical* binding is idempotent.
 `status = 'closed' AND brier_score IS NOT NULL` is explicitly **not** an
 eligibility predicate.
 
+### 6-1. 🔴 OPEN — the legacy aggregate still admits UNIDENTIFIABLE
+
+The pre-existing `build_forecast_calibration_aggregate` — used by
+`mcp_server/tooling/forecast_tools.py`, `routers/invest_forecasts.py`, and
+`services/decision_history.py` — drops explicit `calibration_exclude` but still
+**admits forecasts with no decision**. That is semantically a default-include and
+does not satisfy §4.2-4/§4.2-5 on the surface that is actually consumed.
+
+It is left in place deliberately, not by oversight. Closing it makes every
+calibration surface return empty: there are zero decision rows, and §4.2-4
+forbids historical backfill, so nothing would ever repopulate them without a
+per-forecast operator decision. That is a product decision, escalated as
+`NEEDS_INFO`; see the round-3 worker report for the options and their blast radius.
+
+`tests/services/invalid_sample_eligibility/test_persistence.py::
+test_undecided_forecasts_strict_cohort_excludes_legacy_aggregate_admits` pins both
+behaviours side by side so the divergence stays visible until it is decided.
+
+### 6-2. Trade performance (ROB-1036 B2)
+
+`TradePerformanceEligibility` is wired into the real Alpaca PnL path:
+
+- `InvalidSampleEligibilityService.list_trade_performance_excluded(correlation_ids)`
+  resolves explicit `trade_performance_exclude` decisions.
+- `paper_evaluation/evidence.py` — `_trade_performance_excluded_row_ids()` turns
+  those into **native row ids**, and `_load_native` skips them when building
+  `alpaca_fills`. Row ids (not correlation ids) are used so the ROB-850
+  assignment-scoping guard on `_load_native` stays intact: nothing is discovered
+  by correlation id, an already-discovered row is merely filtered out.
+- `paper_evaluation/pnl.py` — `compute_alpaca_view(..., excluded_correlation_ids=…)`
+  skips both the correlation bucket and any individual row carrying an excluded
+  lifecycle id.
+
+Only an explicit `EXCLUDE` filters. An undecided lifecycle is `UNIDENTIFIABLE`
+and stays, so with no decisions on record the PnL inputs are unchanged.
+
 ## 7. Post-fill completion gate
 
 `evaluate_post_fill_completion(fill_evidence=…, position_effect=…)` returns
@@ -184,10 +220,12 @@ Verified in an isolated throwaway database by
 
 - Recording the actual UBER decision row is an **operator action**, not part of
   this change.
-- The trade-performance gate ships as the pure `partition_by_eligibility`
-  predicate. No cross-lifecycle PnL aggregate over the Alpaca paper ledger exists
-  in `main` today, so there is no second call site to wire; the next consumer
-  applies the same predicate.
+- **The legacy calibration aggregate's treatment of UNIDENTIFIABLE is undecided**
+  (§6-1). This is the one open operator decision in this change.
+- The trade-performance gate is wired into the Alpaca PnL path (§6-2). Other
+  aggregates (`trade_journal/aggregates.py`, keyed by symbol/tag over
+  `review.trades`) have no forecast/lifecycle identity to join on and are
+  untouched; a future consumer applies the same predicate.
 - Physical-account identity registration stays in `ROB-1204` and is untouched.
 - Fill-observation projection (`ROB-1195`) is a separate lane; this contract
   consumes fill/position evidence as typed inputs and does not duplicate it.

--- a/docs/runbooks/uber-invalid-sample-eligibility.md
+++ b/docs/runbooks/uber-invalid-sample-eligibility.md
@@ -1,0 +1,193 @@
+# UBER invalid-sample eligibility — `uber-invalid-sample-eligibility.v1`
+
+ROB-1036. Additive eligibility record + contract-compatible post-fill writer for the
+`alpaca_paper_lab` UBER `invalid_sample_cleanup` case.
+
+This runbook describes **what exists in code**. It does not authorise an order, a
+cleanup retry, a forecast resolve, a migration apply, or a scheduler registration.
+
+---
+
+## 1. Why this exists
+
+The 2026-07-30 readiness audit
+(`herdr-inbox/uber-d2-execution-readiness-2026-07-30.md`) and the 2026-07-31
+result (`…-execution-result-2026-07-31.md`) recorded
+`EXECUTION_RESULT=BLOCKED_STATIC_CONTRACT_GAP` / `SUBMIT_RESULT=NO_SUBMIT`. The
+blocker was not the order boundary — it was that there was no way to record
+"this sample is invalid for scoring" without either
+
+- calling `forecast_resolve(dry_run=false)`, which books outcome + Brier and
+  therefore violates *exclude from strategy performance*, or
+- not calling it, which leaves the approved post-fill step unfinished.
+
+This contract removes that dilemma by making eligibility a separate, append-only
+record instead of a side effect of resolution.
+
+## 2. The four validity domains
+
+They are **four questions, not one flag**. Collapsing them is a contract
+violation, and `EligibilityDecision` deliberately exposes no aggregate bit.
+
+| Domain | Type | Question |
+|---|---|---|
+| `forecast_outcome_observability` | `ForecastOutcomeObservability` | May the outcome be observed/resolved? |
+| `calibration_eligibility` | `CalibrationEligibility` | Does it enter the calibration primary cohort? |
+| `trade_performance_eligibility` | `TradePerformanceEligibility` | Does it enter PnL / trade-performance aggregates? |
+| `operational_reliability_eligibility` | `OperationalReliabilityEligibility` | Does it count towards operational reliability? |
+
+The four enums have disjoint value sets, so a cross-domain assignment raises
+`TypeError` rather than silently type-checking.
+
+**The fixed UBER decision** (operator, carried in
+`query-codexmock-orch-strategy-roadmap-2026-07-31-2333.md` §2.2):
+
+```
+forecast_outcome_observability     = blocked_pending_audit_evidence   # retained, not discarded
+calibration_eligibility            = calibration_exclude
+trade_performance_eligibility      = trade_performance_exclude
+operational_reliability_eligibility= operational_include              # the attempt is a real operational event
+```
+
+## 3. Fail-closed default
+
+A subject with **no** decision row is `UNIDENTIFIABLE` in all four domains. There
+is no `COALESCE(..., INCLUDE)` and no historical backfill: the migration inserts
+zero rows, and `unidentifiable_decision()` is the only default.
+
+`UNIDENTIFIABLE` is *not* the same as `EXCLUDE`. The strict cohort builder admits
+neither; the legacy calibration aggregate drops only explicit `EXCLUDE`, so
+undecided legacy rows keep their existing behaviour (see §6).
+
+## 4. Append-only revisions
+
+A correction is a **superseding revision**, never an overwrite.
+
+- `revision_no` starts at 1; every later revision has
+  `supersedes_revision_no = revision_no - 1` (CHECK constraint) — a gap, a
+  branch, and a cycle are all unrepresentable.
+- `(subject_kind, subject_ref, revision_no)` is unique — no branch.
+- a partial unique index on `supersedes_revision_no` blocks two revisions
+  claiming the same predecessor.
+- `BEFORE UPDATE OR DELETE OR TRUNCATE` triggers reject mutation at the DB edge.
+- `evidence_hash` is a SHA-256 over the canonical JSON evidence and is recomputed
+  on every read; a mismatch raises `evidence_hash_mismatch` instead of returning
+  the row.
+
+Only the **latest** revision decides. A later revision may legitimately readmit a
+previously excluded subject once audit-grade evidence lands.
+
+## 5. Cleanup binding
+
+`review.invalid_sample_cleanup_bindings` immutably binds, in one row:
+
+`purpose=invalid_sample_cleanup` · `forecast_id` + `sample_ref` ·
+`approval_id` + `approval_hash` + `approval_expires_at` + `approval_session_id` ·
+`mission_id` · `account_mode` + `client_order_id` + `lifecycle_correlation_id`
+· `binding_hash` (SHA-256 over all of the above).
+
+`build_cleanup_binding()` fails closed on:
+
+| code | condition |
+|---|---|
+| `naive_now` / `naive_approval_expires_at` | a non-timezone-aware clock |
+| `approval_window_expired` | `now >= approval_expires_at` — a missed window is **not** carried forward |
+| `cross_session_carry_over_blocked` | the approval belongs to another session |
+| `conflicting_binding_for_client_order_id` | that identity is already bound to a different approval/mission |
+
+Re-authoring the *identical* binding is idempotent.
+
+## 6. Read models
+
+- `build_eligible_forecast_calibration_aggregate(db, *, contract_version, predicate, …)`
+  — both keyword arguments are **required with no default**. It returns the
+  normal calibration groups *plus* `eligibility_counts`
+  (`included`/`excluded`/`unidentifiable`), `eligibility_reasons`, and the
+  `contract_version`, so a filtered cohort can never be presented as complete.
+- `partition_by_eligibility(items, *, predicate)` — the pure gate, reused by
+  trade-performance / PnL consumers so they apply the same rule.
+- `build_forecast_calibration_aggregate(db, …)` (legacy entry point) now also
+  drops forecasts whose **latest** revision says `calibration_exclude`. Rows with
+  no decision are untouched — this is a re-entry guard, not a backfill.
+
+`status = 'closed' AND brier_score IS NOT NULL` is explicitly **not** an
+eligibility predicate.
+
+## 7. Post-fill completion gate
+
+`evaluate_post_fill_completion(fill_evidence=…, position_effect=…)` returns
+`COMPLETE` only when the broker fill evidence is `COMPLETE` **and** the position
+effect is `CONSISTENT`. Exactly 1 of the 9 combinations is terminal success; the
+other 8 are typed manual-review reasons:
+
+`absent_fill_evidence` · `incomplete_fill_evidence` ·
+`absent_position_effect_evidence` · `inconsistent_position_effect_evidence`
+
+A `filled` broker status with an incomplete activity set, or a complete fill with
+no observed position change, is a refusal — never a silent success.
+
+## 8. Timeout / crash recovery
+
+`plan_timeout_recovery(client_order_id=…, evidence_lookup_available=…)` returns a
+plan whose only actions are `lookup_existing_order_evidence` or
+`escalate_manual_review`. There is no resend variant; `broker_post_allowed` and
+`new_identity_allowed` are `Literal[False]` properties, not flags. The original
+`client_order_id` is carried through both branches so no new identity can be
+minted.
+
+In this change this is proven with a **fake transport only** — no broker call was
+made (`tests/…/test_post_fill.py::test_timeout_recovery_reads_the_same_identity_and_posts_nothing`).
+
+## 9. Write surface
+
+`InvalidSampleEligibilityService` is the only writer. Static guards
+(`tests/services/invalid_sample_eligibility/test_static_boundaries.py`) enforce:
+
+- the repository is imported by `service.py` and nothing else;
+- `contract.py` / `post_fill.py` / `binding.py` import no SQLAlchemy, HTTP
+  client, or broker module;
+- no raw SQL write statement anywhere in `app/` names these tables;
+- the service performs no `update`/`delete`/`execute` call;
+- the package imports no broker / MCP / Alpaca order surface.
+
+## 10. What this change does NOT do
+
+- ❌ no order, preview, cancel, reconcile, position read, or any broker/account call
+- ❌ no UBER outcome / price / Brier lookup, computation, or `forecast_resolve`
+- ❌ no cleanup retry, and no carry-over of the missed 2026-07-30 15:55 ET window
+- ❌ no migration applied to the runtime/production database (see §11)
+- ❌ no scheduler / cron / TaskIQ / Prefect registration; no deploy; no activation
+- ❌ no historical backfill — the migration inserts zero rows
+- ❌ no MCP tool registered
+
+## 11. Operator cutover
+
+The migration ships in the PR but is **not** applied by it.
+
+```bash
+uv run alembic current            # expect 20260728_rob1109_watch_intent
+uv run alembic upgrade head       # applies 20260802_rob1036_sample_elig
+uv run alembic downgrade -1       # rollback (drops the three tables + trigger fn)
+```
+
+The upgrade is additive: three new `review` tables, their indexes, and the
+`review.reject_invalid_sample_mutation()` trigger function. No existing table,
+column, constraint, or row is touched. Downgrade drops exactly what upgrade
+created; because the tables are append-only, a downgrade **destroys** any
+decisions recorded in between — export them first if any exist.
+
+Verified in an isolated throwaway database by
+`tests/services/invalid_sample_eligibility/test_migration.py::test_isolated_upgrade_downgrade_upgrade`
+(upgrade → trigger check → downgrade → upgrade).
+
+## 12. Open / deferred
+
+- Recording the actual UBER decision row is an **operator action**, not part of
+  this change.
+- The trade-performance gate ships as the pure `partition_by_eligibility`
+  predicate. No cross-lifecycle PnL aggregate over the Alpaca paper ledger exists
+  in `main` today, so there is no second call site to wire; the next consumer
+  applies the same predicate.
+- Physical-account identity registration stays in `ROB-1204` and is untouched.
+- Fill-observation projection (`ROB-1195`) is a separate lane; this contract
+  consumes fill/position evidence as typed inputs and does not duplicate it.

--- a/docs/runbooks/uber-invalid-sample-eligibility.md
+++ b/docs/runbooks/uber-invalid-sample-eligibility.md
@@ -55,9 +55,9 @@ A subject with **no** decision row is `UNIDENTIFIABLE` in all four domains. Ther
 is no `COALESCE(..., INCLUDE)` and no historical backfill: the migration inserts
 zero rows, and `unidentifiable_decision()` is the only default.
 
-`UNIDENTIFIABLE` is *not* the same as `EXCLUDE`. The strict cohort builder admits
-neither; the legacy calibration aggregate drops only explicit `EXCLUDE`, so
-undecided legacy rows keep their existing behaviour (see §6).
+`UNIDENTIFIABLE` is *not* the same as `EXCLUDE`. An explicit `EXCLUDE` is held out
+by every cohort; an undecided row's treatment is a property of the cohort a
+caller names (see §6).
 
 ## 4. Append-only revisions
 
@@ -97,39 +97,78 @@ previously excluded subject once audit-grade evidence lands.
 
 Re-authoring the *identical* binding is idempotent.
 
-## 6. Read models
+## 6. Read models — cohorts (operator decision D-1, option ②)
 
-- `build_eligible_forecast_calibration_aggregate(db, *, contract_version, predicate, …)`
-  — both keyword arguments are **required with no default**. It returns the
-  normal calibration groups *plus* `eligibility_counts`
-  (`included`/`excluded`/`unidentifiable`), `eligibility_reasons`, and the
-  `contract_version`, so a filtered cohort can never be presented as complete.
-- `partition_by_eligibility(items, *, predicate)` — the pure gate, reused by
-  trade-performance / PnL consumers so they apply the same rule.
-- `build_forecast_calibration_aggregate(db, …)` (legacy entry point) now also
-  drops forecasts whose **latest** revision says `calibration_exclude`. Rows with
-  no decision are untouched — this is a re-entry guard, not a backfill.
+Every calibration call must **name its cohort**. There is no default:
 
-`status = 'closed' AND brier_score IS NOT NULL` is explicitly **not** an
-eligibility predicate.
+```python
+build_forecast_calibration_aggregate(
+    db, *, contract_version: str, predicate: EligibilityPredicate, ...
+)
+```
 
-### 6-1. 🔴 OPEN — the legacy aggregate still admits UNIDENTIFIABLE
+Both are keyword-only with no default, so `status = 'closed' AND brier_score IS
+NOT NULL` can never again stand in for a cohort definition. The result carries
+the cohort back:
 
-The pre-existing `build_forecast_calibration_aggregate` — used by
-`mcp_server/tooling/forecast_tools.py`, `routers/invest_forecasts.py`, and
-`services/decision_history.py` — drops explicit `calibration_exclude` but still
-**admits forecasts with no decision**. That is semantically a default-include and
-does not satisfy §4.2-4/§4.2-5 on the surface that is actually consumed.
+| field | meaning |
+|---|---|
+| `contract_version` | which eligibility contract was asked for |
+| `eligibility_cohort` | the cohort label that produced these numbers |
+| `eligibility_stage` | `rob-1036-d1-option-2-compatibility` or `rob-1036-decided-only` |
+| `eligibility_cohort_admits` | the exact admitted values |
+| `eligibility_counts` | `included` / `excluded` / `unidentifiable`, **kept separate** |
+| `eligibility_admitted_count` | how many rows entered the aggregate |
+| `eligibility_reasons` | per-value tally of what was held back |
 
-It is left in place deliberately, not by oversight. Closing it makes every
-calibration surface return empty: there are zero decision rows, and §4.2-4
-forbids historical backfill, so nothing would ever repopulate them without a
-per-forecast operator decision. That is a product decision, escalated as
-`NEEDS_INFO`; see the round-3 worker report for the options and their blast radius.
+🔴 The three counts are **never summed** into one "eligible" number. Under the
+compatibility cohort the undecided rows are admitted *and* counted, and showing
+that quantity is the entire reason this cohort exists.
 
-`tests/services/invalid_sample_eligibility/test_persistence.py::
-test_undecided_forecasts_strict_cohort_excludes_legacy_aggregate_admits` pins both
-behaviours side by side so the divergence stays visible until it is decided.
+### 6-1. The two shipped cohorts
+
+`COMPATIBILITY_CALIBRATION_COHORT` (`app/services/invalid_sample_eligibility/cohort.py`)
+admits `{INCLUDE, UNIDENTIFIABLE}`. It is what the three live call sites use:
+
+| call site | file:line |
+|---|---|
+| MCP `get_forecast_calibration` | `app/mcp_server/tooling/forecast_tools.py:213-217` |
+| `GET /trading/api/invest/forecasts/calibration` | `app/routers/invest_forecasts.py:61-67` |
+| decision-history running Brier | `app/services/decision_history.py:122-137` |
+
+`DECIDED_ONLY_CALIBRATION_COHORT` admits `{INCLUDE}` only — the end state. It is
+available today (`build_decided_only_forecast_calibration_aggregate`) so a caller
+that wants the fully-decided cohort can ask for it and the promotion is a
+one-line swap per call site.
+
+An explicit `calibration_exclude` is held out by **both**. Widening admission
+never resurrects an excluded sample.
+
+### 6-1-1. 🔴 This is a transitional stage, not the end state
+
+The compatibility cohort exists so the calibration surfaces keep working while
+the undecided population becomes visible. It is deliberately **not** presented as
+a final or "correct" configuration.
+
+**Termination condition** (also in `cohort.py`, next to the constant):
+
+1. every forecast in the scored population carries an explicit eligibility
+   decision recorded through `InvalidSampleEligibilityService` — recorded by an
+   operator, never by an automatic historical backfill (§4.2-4); **and**
+2. the reported `unidentifiable` count has been 0 for a full review cycle on the
+   cohorts an operator relies on.
+
+Then the call sites move to `DECIDED_ONLY_CALIBRATION_COHORT` and the
+compatibility cohort is deleted.
+
+**Promotion provenance.** Option ② is a superset of the end state — same
+machinery, wider admitted set — so no door is closed. Because every result is
+stamped with `eligibility_cohort` / `eligibility_stage` /
+`eligibility_cohort_admits`, a number produced during this stage stays
+distinguishable from a post-promotion number, and a before/after comparison
+report over the same population remains possible. Classification is independent
+of admission, so the counts mean the same thing under both cohorts and are
+directly comparable.
 
 ### 6-2. Trade performance (ROB-1036 B2)
 
@@ -220,8 +259,10 @@ Verified in an isolated throwaway database by
 
 - Recording the actual UBER decision row is an **operator action**, not part of
   this change.
-- **The legacy calibration aggregate's treatment of UNIDENTIFIABLE is undecided**
-  (§6-1). This is the one open operator decision in this change.
+- Operator decision **D-1 selected option ②** (2026-08-02): every calibration
+  call names its cohort, and the default cohort admits undecided samples while
+  reporting them separately (§6). The termination condition for that stage is in
+  §6-1-1 — this is transitional, not the end state.
 - The trade-performance gate is wired into the Alpaca PnL path (§6-2). Other
   aggregates (`trade_journal/aggregates.py`, keyed by symbol/tag over
   `review.trades`) have no forecast/lifecycle identity to join on and are

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -64,7 +64,10 @@ from sqlalchemy import text
 # v31: Alpaca paper lab account_mode CHECK expansions.
 # v32 (ROB-1103): nullable direct-watch source links + future-write FKs.
 # v33 (ROB-1115): strategy_learning_events ORM table + append-only triggers.
-SCHEMA_BOOTSTRAP_VERSION = 33
+# v34 (ROB-1036): review.sample_eligibility_decisions /
+# invalid_sample_cleanup_bindings / invalid_sample_cleanup_lifecycle_events ORM
+# tables (create_all) + their append-only triggers mirrored below.
+SCHEMA_BOOTSTRAP_VERSION = 34
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -1312,6 +1315,33 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "BEFORE TRUNCATE ON research.strategy_learning_events "
     "FOR EACH STATEMENT EXECUTE FUNCTION "
     "research.reject_strategy_learning_event_mutation()",
+    # ---- ROB-1036: invalid-sample eligibility tables are append-only.
+    # The tables themselves come from the ORM metadata above; these trigger
+    # functions are non-ORM DDL mirroring the Alembic revision.
+    "CREATE OR REPLACE FUNCTION review.reject_invalid_sample_mutation() "
+    "RETURNS trigger AS $$ BEGIN RAISE EXCEPTION "
+    "'review.% is append-only; % rejected', TG_TABLE_NAME, TG_OP "
+    "USING ERRCODE = 'restrict_violation'; END; $$ LANGUAGE plpgsql",
+    *tuple(
+        statement
+        for table in (
+            "sample_eligibility_decisions",
+            "invalid_sample_cleanup_bindings",
+            "invalid_sample_cleanup_lifecycle_events",
+        )
+        for statement in (
+            f"DROP TRIGGER IF EXISTS trg_rob1036_{table}_append_only ON review.{table}",
+            f"CREATE TRIGGER trg_rob1036_{table}_append_only "
+            f"BEFORE UPDATE OR DELETE ON review.{table} "
+            "FOR EACH ROW EXECUTE FUNCTION review.reject_invalid_sample_mutation()",
+            f"DROP TRIGGER IF EXISTS trg_rob1036_{table}_truncate_append_only "
+            f"ON review.{table}",
+            f"CREATE TRIGGER trg_rob1036_{table}_truncate_append_only "
+            f"BEFORE TRUNCATE ON review.{table} "
+            "FOR EACH STATEMENT EXECUTE FUNCTION "
+            "review.reject_invalid_sample_mutation()",
+        )
+    ),
     # ---- ROB-848: immutable paper-validation audit + experiment hash binding
     # Tables/checks/FKs are owned by the ORM metadata above; these PostgreSQL
     # trigger functions are non-ORM DDL and mirror the Alembic revision.

--- a/tests/routers/test_invest_forecasts_router.py
+++ b/tests/routers/test_invest_forecasts_router.py
@@ -16,7 +16,25 @@ def _make_client(monkeypatch, *, calib=None, open_res=None, closed_res=None):
 
     async def _fake_calib(db, **kwargs):
         calls["calib"] = kwargs
-        return calib or {"group_by": kwargs.get("group_by", "created_by"), "groups": []}
+        # ROB-1036 D-1: the aggregate now returns the cohort provenance and the
+        # separated eligibility counts alongside the groups.
+        base = {
+            "contract_version": "uber-invalid-sample-eligibility.v1",
+            "eligibility_cohort": "calibration-compatibility",
+            "eligibility_stage": "rob-1036-d1-option-2-compatibility",
+            "eligibility_counts": {
+                "included": 0,
+                "excluded": 0,
+                "unidentifiable": 0,
+            },
+        }
+        if calib is not None:
+            return {**base, **calib}
+        return {
+            **base,
+            "group_by": kwargs.get("group_by", "created_by"),
+            "groups": [],
+        }
 
     async def _fake_open(db, **kwargs):
         calls["open"] = kwargs

--- a/tests/services/invalid_sample_eligibility/test_binding.py
+++ b/tests/services/invalid_sample_eligibility/test_binding.py
@@ -1,0 +1,137 @@
+"""ROB-1036 §4.3-9 — approval window and cross-session carry-over are fail-closed.
+
+Offline: the clock is caller-supplied, so no wall-clock or network dependency.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.invalid_sample_eligibility.binding import (
+    CLEANUP_PURPOSE,
+    CleanupBinding,
+    CleanupBindingError,
+    build_cleanup_binding,
+)
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 8, 2, 6, 0, tzinfo=UTC)
+FORECAST_ID = uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+def _build(**overrides):
+    kwargs = {
+        "forecast_id": FORECAST_ID,
+        "sample_ref": "uber-d2-cleanup",
+        "approval_id": "approval-uber-001",
+        "approval_hash": "a" * 64,
+        "approval_expires_at": NOW + timedelta(minutes=5),
+        "approval_session_id": "session-A",
+        "mission_id": "invalid-sample-cleanup-mission-1",
+        "account_mode": "alpaca_paper_lab",
+        "client_order_id": "cleanup-uber-001",
+        "lifecycle_correlation_id": "corr-uber-001",
+        "now": NOW,
+        "session_id": "session-A",
+    }
+    kwargs.update(overrides)
+    return build_cleanup_binding(**kwargs)
+
+
+def test_binding_carries_every_identity() -> None:
+    binding = _build()
+    assert binding.purpose == CLEANUP_PURPOSE
+    assert binding.forecast_id == FORECAST_ID
+    assert binding.approval_id == "approval-uber-001"
+    assert binding.mission_id == "invalid-sample-cleanup-mission-1"
+    assert binding.client_order_id == "cleanup-uber-001"
+    assert binding.lifecycle_correlation_id == "corr-uber-001"
+    assert len(binding.binding_hash) == 64
+
+
+def test_binding_hash_changes_with_any_bound_identity() -> None:
+    baseline = _build().binding_hash
+    assert _build(mission_id="other-mission").binding_hash != baseline
+    assert _build(approval_id="approval-uber-002").binding_hash != baseline
+    assert _build(client_order_id="cleanup-uber-002").binding_hash != baseline
+    assert _build(sample_ref="other-sample").binding_hash != baseline
+
+
+def test_binding_is_frozen() -> None:
+    binding = _build()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        binding.mission_id = "tampered"  # type: ignore[misc]
+
+
+def test_expired_approval_window_fails_closed() -> None:
+    with pytest.raises(CleanupBindingError) as excinfo:
+        _build(approval_expires_at=NOW - timedelta(seconds=1))
+    assert excinfo.value.code == "approval_window_expired"
+
+
+def test_window_boundary_is_exclusive() -> None:
+    with pytest.raises(CleanupBindingError) as excinfo:
+        _build(approval_expires_at=NOW)
+    assert excinfo.value.code == "approval_window_expired"
+
+
+def test_missed_window_is_not_carried_into_a_later_session() -> None:
+    """A missed 15:55 ET window is not silently reused by the next session."""
+
+    later = NOW + timedelta(hours=12)
+    with pytest.raises(CleanupBindingError) as excinfo:
+        _build(now=later)
+    assert excinfo.value.code == "approval_window_expired"
+
+
+def test_cross_session_reuse_of_a_live_approval_is_blocked() -> None:
+    with pytest.raises(CleanupBindingError) as excinfo:
+        _build(session_id="session-B")
+    assert excinfo.value.code == "cross_session_carry_over_blocked"
+
+
+def test_naive_now_is_rejected() -> None:
+    with pytest.raises(CleanupBindingError) as excinfo:
+        _build(now=datetime(2026, 8, 2, 6, 0))
+    assert excinfo.value.code == "naive_now"
+
+
+def test_naive_expiry_is_rejected() -> None:
+    with pytest.raises(CleanupBindingError) as excinfo:
+        _build(approval_expires_at=datetime(2026, 8, 2, 7, 0))
+    assert excinfo.value.code == "naive_approval_expires_at"
+
+
+def test_other_purposes_cannot_use_this_binding() -> None:
+    binding = _build()
+    with pytest.raises(CleanupBindingError) as excinfo:
+        CleanupBinding(
+            purpose="some_other_cleanup",
+            contract_version=binding.contract_version,
+            forecast_id=binding.forecast_id,
+            sample_ref=binding.sample_ref,
+            approval_id=binding.approval_id,
+            approval_hash=binding.approval_hash,
+            approval_expires_at=binding.approval_expires_at,
+            approval_session_id=binding.approval_session_id,
+            mission_id=binding.mission_id,
+            account_mode=binding.account_mode,
+            client_order_id=binding.client_order_id,
+            lifecycle_correlation_id=binding.lifecycle_correlation_id,
+        )
+    assert excinfo.value.code == "unsupported_purpose"
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["approval_id", "mission_id", "sample_ref", "client_order_id", "account_mode"],
+)
+def test_blank_identity_is_rejected(field: str) -> None:
+    with pytest.raises(CleanupBindingError) as excinfo:
+        _build(**{field: "   "})
+    assert excinfo.value.code == "missing_binding_field"

--- a/tests/services/invalid_sample_eligibility/test_contract.py
+++ b/tests/services/invalid_sample_eligibility/test_contract.py
@@ -1,0 +1,309 @@
+"""ROB-1036 §4.3 — four-domain independence, revision chain, fail-closed default.
+
+Offline: stdlib + the pure contract module only. No DB, broker, or network.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from app.services.invalid_sample_eligibility.contract import (
+    CONTRACT_VERSION,
+    ELIGIBILITY_DOMAIN_ENUMS,
+    CalibrationEligibility,
+    EligibilityContractError,
+    EligibilityDecision,
+    EligibilitySubject,
+    EligibilitySubjectKind,
+    ForecastOutcomeObservability,
+    OperationalReliabilityEligibility,
+    TradePerformanceEligibility,
+    canonical_evidence_hash,
+    latest_decision,
+    unidentifiable_decision,
+    validate_revision_chain,
+)
+
+pytestmark = pytest.mark.unit
+
+SUBJECT = EligibilitySubject(
+    kind=EligibilitySubjectKind.FORECAST, ref="11111111-2222-3333-4444-555555555555"
+)
+
+
+def _decision(
+    *,
+    revision_no: int = 1,
+    observability: ForecastOutcomeObservability = (
+        ForecastOutcomeObservability.OBSERVABLE
+    ),
+    calibration: CalibrationEligibility = CalibrationEligibility.INCLUDE,
+    trade: TradePerformanceEligibility = TradePerformanceEligibility.INCLUDE,
+    operational: OperationalReliabilityEligibility = (
+        OperationalReliabilityEligibility.INCLUDE
+    ),
+    supersedes: int | None = -1,
+    subject: EligibilitySubject = SUBJECT,
+    contract_version: str = CONTRACT_VERSION,
+) -> EligibilityDecision:
+    if supersedes == -1:
+        supersedes = None if revision_no == 1 else revision_no - 1
+    return EligibilityDecision(
+        subject=subject,
+        contract_version=contract_version,
+        revision_no=revision_no,
+        supersedes_revision_no=supersedes,
+        forecast_outcome_observability=observability,
+        calibration_eligibility=calibration,
+        trade_performance_eligibility=trade,
+        operational_reliability_eligibility=operational,
+        decision_reason="test",
+        evidence_hash=canonical_evidence_hash({}),
+    )
+
+
+# --- §4.3-1: the four domains vary independently ---------------------------
+
+
+def test_every_combination_of_the_four_domains_is_representable() -> None:
+    """A domain is never inferable from another: all 81 combinations construct."""
+
+    combinations = list(
+        itertools.product(
+            ForecastOutcomeObservability,
+            CalibrationEligibility,
+            TradePerformanceEligibility,
+            OperationalReliabilityEligibility,
+        )
+    )
+    assert len(combinations) == 3 * 3 * 3 * 3
+
+    for observability, calibration, trade, operational in combinations:
+        decision = _decision(
+            observability=observability,
+            calibration=calibration,
+            trade=trade,
+            operational=operational,
+        )
+        assert decision.forecast_outcome_observability is observability
+        assert decision.calibration_eligibility is calibration
+        assert decision.trade_performance_eligibility is trade
+        assert decision.operational_reliability_eligibility is operational
+
+
+def test_domain_enums_share_no_member_values() -> None:
+    """Distinct value spaces make a cross-domain assignment detectable."""
+
+    seen: set[str] = set()
+    for enum_type in ELIGIBILITY_DOMAIN_ENUMS:
+        values = {member.value for member in enum_type}
+        assert not (values & seen), (
+            f"{enum_type.__name__} reuses another domain's value"
+        )
+        seen |= values
+
+
+def test_decision_exposes_no_collapsed_validity_bit() -> None:
+    """No ``is_valid`` / ``eligible`` / ``success`` aggregate may exist."""
+
+    forbidden = {
+        "is_valid",
+        "valid",
+        "eligible",
+        "is_eligible",
+        "success",
+        "ok",
+        "overall",
+        "overall_eligibility",
+    }
+    exposed = set(dir(EligibilityDecision))
+    assert not (exposed & forbidden)
+
+
+@pytest.mark.parametrize(
+    ("domain_value", "wrong_field"),
+    [
+        (CalibrationEligibility.EXCLUDE, "forecast_outcome_observability"),
+        (TradePerformanceEligibility.EXCLUDE, "calibration_eligibility"),
+        (OperationalReliabilityEligibility.EXCLUDE, "trade_performance_eligibility"),
+        (
+            ForecastOutcomeObservability.OBSERVABLE,
+            "operational_reliability_eligibility",
+        ),
+    ],
+)
+def test_cross_domain_assignment_is_rejected(domain_value, wrong_field: str) -> None:
+    kwargs = {
+        "subject": SUBJECT,
+        "contract_version": CONTRACT_VERSION,
+        "revision_no": 1,
+        "supersedes_revision_no": None,
+        "forecast_outcome_observability": ForecastOutcomeObservability.OBSERVABLE,
+        "calibration_eligibility": CalibrationEligibility.INCLUDE,
+        "trade_performance_eligibility": TradePerformanceEligibility.INCLUDE,
+        "operational_reliability_eligibility": (
+            OperationalReliabilityEligibility.INCLUDE
+        ),
+        "decision_reason": "test",
+        "evidence_hash": canonical_evidence_hash({}),
+    }
+    kwargs[wrong_field] = domain_value
+    with pytest.raises(TypeError):
+        EligibilityDecision(**kwargs)
+
+
+# --- §4.3-2: an invalid sample does not discard the outcome record ---------
+
+
+def test_uber_shaped_decision_keeps_the_outcome_record() -> None:
+    """The UBER decision: excluded from scoring cohorts, outcome NOT discarded.
+
+    Observability is *blocked pending evidence* — a hold, not a deletion — while
+    calibration and trade performance are excluded.  Operational reliability
+    stays included: the cleanup attempt is still a real operational event.
+    """
+
+    decision = _decision(
+        observability=ForecastOutcomeObservability.BLOCKED_PENDING_AUDIT_EVIDENCE,
+        calibration=CalibrationEligibility.EXCLUDE,
+        trade=TradePerformanceEligibility.EXCLUDE,
+        operational=OperationalReliabilityEligibility.INCLUDE,
+    )
+    assert (
+        decision.forecast_outcome_observability
+        is not ForecastOutcomeObservability.UNIDENTIFIABLE
+    )
+    assert decision.calibration_eligibility is CalibrationEligibility.EXCLUDE
+    assert decision.trade_performance_eligibility is TradePerformanceEligibility.EXCLUDE
+    assert (
+        decision.operational_reliability_eligibility
+        is OperationalReliabilityEligibility.INCLUDE
+    )
+    # There is no contract-level operation that deletes or resolves an outcome.
+    assert not hasattr(decision, "discard")
+    assert not hasattr(decision, "resolve")
+
+
+# --- §4.3-4: missing decision / legacy row is UNIDENTIFIABLE ---------------
+
+
+def test_missing_decision_is_unidentifiable_in_all_four_domains() -> None:
+    decision = unidentifiable_decision(SUBJECT)
+    assert (
+        decision.forecast_outcome_observability
+        is ForecastOutcomeObservability.UNIDENTIFIABLE
+    )
+    assert decision.calibration_eligibility is CalibrationEligibility.UNIDENTIFIABLE
+    assert (
+        decision.trade_performance_eligibility
+        is TradePerformanceEligibility.UNIDENTIFIABLE
+    )
+    assert (
+        decision.operational_reliability_eligibility
+        is OperationalReliabilityEligibility.UNIDENTIFIABLE
+    )
+
+
+def test_empty_chain_never_defaults_to_include() -> None:
+    decision = latest_decision([], SUBJECT)
+    for value in (
+        decision.forecast_outcome_observability,
+        decision.calibration_eligibility,
+        decision.trade_performance_eligibility,
+        decision.operational_reliability_eligibility,
+    ):
+        assert "include" not in value.value
+
+
+# --- §4.3-5: revision chain gaps, branches, cycles -------------------------
+
+
+def test_valid_chain_returns_highest_revision() -> None:
+    chain = [
+        _decision(revision_no=1, calibration=CalibrationEligibility.INCLUDE),
+        _decision(revision_no=2, calibration=CalibrationEligibility.EXCLUDE),
+    ]
+    assert latest_decision(chain, SUBJECT).calibration_eligibility is (
+        CalibrationEligibility.EXCLUDE
+    )
+
+
+def test_revision_gap_is_rejected() -> None:
+    chain = [_decision(revision_no=1), _decision(revision_no=3)]
+    with pytest.raises(EligibilityContractError) as excinfo:
+        validate_revision_chain(chain)
+    assert excinfo.value.code == "revision_chain_gap"
+
+
+def test_branched_chain_is_rejected() -> None:
+    chain = [
+        _decision(revision_no=1),
+        _decision(revision_no=2, calibration=CalibrationEligibility.EXCLUDE),
+        _decision(revision_no=2, calibration=CalibrationEligibility.INCLUDE),
+    ]
+    with pytest.raises(EligibilityContractError) as excinfo:
+        validate_revision_chain(chain)
+    assert excinfo.value.code == "branched_revision_chain"
+
+
+@pytest.mark.parametrize("supersedes", [1, 2, 3])
+def test_self_or_forward_reference_is_unconstructable(supersedes: int) -> None:
+    """A cycle cannot even be built: supersedes must be exactly revision - 1."""
+
+    with pytest.raises(EligibilityContractError) as excinfo:
+        _decision(revision_no=2, supersedes=supersedes if supersedes != 1 else 0)
+    assert excinfo.value.code == "invalid_supersedes_revision_no"
+
+
+def test_revision_one_must_not_supersede_anything() -> None:
+    with pytest.raises(EligibilityContractError) as excinfo:
+        _decision(revision_no=1, supersedes=0)
+    assert excinfo.value.code == "invalid_supersedes_revision_no"
+
+
+def test_chain_may_not_switch_contract_version() -> None:
+    chain = [
+        _decision(revision_no=1),
+        _decision(revision_no=2, contract_version="some-other-contract.v9"),
+    ]
+    with pytest.raises(EligibilityContractError) as excinfo:
+        validate_revision_chain(chain)
+    assert excinfo.value.code == "contract_version_switch"
+
+
+def test_chain_may_not_mix_subjects() -> None:
+    other = EligibilitySubject(
+        kind=EligibilitySubjectKind.TRADE_LIFECYCLE, ref="corr-other"
+    )
+    chain = [_decision(revision_no=1), _decision(revision_no=2, subject=other)]
+    with pytest.raises(EligibilityContractError) as excinfo:
+        validate_revision_chain(chain)
+    assert excinfo.value.code == "subject_mismatch"
+
+
+def test_malformed_evidence_hash_is_rejected() -> None:
+    with pytest.raises(EligibilityContractError) as excinfo:
+        EligibilityDecision(
+            subject=SUBJECT,
+            contract_version=CONTRACT_VERSION,
+            revision_no=1,
+            supersedes_revision_no=None,
+            forecast_outcome_observability=ForecastOutcomeObservability.OBSERVABLE,
+            calibration_eligibility=CalibrationEligibility.INCLUDE,
+            trade_performance_eligibility=TradePerformanceEligibility.INCLUDE,
+            operational_reliability_eligibility=(
+                OperationalReliabilityEligibility.INCLUDE
+            ),
+            decision_reason="test",
+            evidence_hash="NOT-A-HASH",
+        )
+    assert excinfo.value.code == "invalid_evidence_hash"
+
+
+def test_canonical_evidence_hash_is_key_order_independent() -> None:
+    assert canonical_evidence_hash({"a": 1, "b": 2}) == canonical_evidence_hash(
+        {"b": 2, "a": 1}
+    )
+    assert canonical_evidence_hash({"a": 1}) != canonical_evidence_hash({"a": 2})

--- a/tests/services/invalid_sample_eligibility/test_migration.py
+++ b/tests/services/invalid_sample_eligibility/test_migration.py
@@ -1,0 +1,233 @@
+"""ROB-1036 — migration static contract + isolated upgrade/downgrade/upgrade.
+
+The upgrade/downgrade acceptance runs against a throwaway database created for
+this test alone (model: ``tests/services/paper_evaluation/test_migration.py``).
+It never touches the runtime/production database.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+import asyncpg
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.core.config import settings
+from app.models.base import Base
+
+pytestmark = pytest.mark.integration
+
+REPO = Path(__file__).resolve().parents[3]
+MIGRATION = REPO / "alembic/versions/20260802_rob1036_sample_elig.py"
+REVISION = "20260802_rob1036_sample_elig"
+DOWN_REVISION = "20260728_rob1109_watch_intent"
+NEW_TABLES = (
+    "sample_eligibility_decisions",
+    "invalid_sample_cleanup_bindings",
+    "invalid_sample_cleanup_lifecycle_events",
+)
+
+
+def _literal(tree: ast.AST, name: str):
+    for node in getattr(tree, "body", []):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"missing {name!r}")
+
+
+def test_migration_descends_from_the_current_head_and_is_the_single_head() -> None:
+    tree = ast.parse(MIGRATION.read_text(encoding="utf-8"))
+    assert _literal(tree, "revision") == REVISION
+    assert _literal(tree, "down_revision") == DOWN_REVISION
+
+    config = Config(str(REPO / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO / "alembic"))
+    assert list(ScriptDirectory.from_config(config).get_heads()) == [REVISION]
+
+
+def test_migration_is_purely_additive() -> None:
+    """No existing table/column is altered, dropped, or backfilled."""
+
+    source = MIGRATION.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    op_calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "op"
+    }
+    forbidden = {
+        "alter_column",
+        "drop_column",
+        "add_column",
+        "bulk_insert",
+        "rename_table",
+    }
+    assert not (op_calls & forbidden), op_calls
+    # upgrade() creates only the three new tables.
+    created = [
+        node.args[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_table"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+    ]
+    assert sorted(created) == sorted(NEW_TABLES)
+    # No data statement writes or rewrites a historical eligibility decision.
+    # (The append-only trigger DDL legitimately contains "BEFORE UPDATE OR
+    # DELETE ON review.x", so the check targets data statements specifically.)
+    lowered = source.lower()
+    for statement in ("insert into review.", "update review.", "delete from review."):
+        assert statement not in lowered, statement
+
+
+@pytest.mark.asyncio
+async def test_isolated_upgrade_downgrade_upgrade() -> None:
+    base_url = make_url(settings.DATABASE_URL)
+    if base_url.get_backend_name() != "postgresql":
+        pytest.skip("ROB-1036 migration acceptance requires PostgreSQL")
+
+    database = f"rob1036_migration_{uuid4().hex}"
+    admin = await asyncpg.connect(
+        user=base_url.username,
+        password=base_url.password,
+        host=base_url.host,
+        port=base_url.port,
+        database="postgres",
+    )
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    target_url = base_url.set(database=database)
+    target_url_text = target_url.render_as_string(hide_password=False)
+    engine = create_async_engine(target_url_text)
+    try:
+        async with engine.begin() as connection:
+            for schema in ("paper", "research", "review"):
+                await connection.execute(
+                    text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+                )
+            await connection.run_sync(Base.metadata.create_all)
+            # Reconstruct the pre-ROB-1036 boundary: current metadata already
+            # contains this revision's tables, so drop them before stamping.
+            for table in NEW_TABLES:
+                await connection.execute(text(f"DROP TABLE review.{table}"))
+
+        env = {**os.environ, "DATABASE_URL": target_url_text}
+
+        def alembic(*args: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [str(REPO / ".venv/bin/alembic"), *args],
+                cwd=REPO,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        stamped = alembic("stamp", DOWN_REVISION)
+        assert stamped.returncode == 0, stamped.stderr
+
+        upgraded = alembic("upgrade", "head")
+        assert upgraded.returncode == 0, upgraded.stderr
+
+        async with engine.connect() as connection:
+            for table in NEW_TABLES:
+                exists = await connection.scalar(
+                    text(
+                        "SELECT to_regclass(:name) IS NOT NULL",
+                    ),
+                    {"name": f"review.{table}"},
+                )
+                assert exists is True, table
+            triggers = await connection.scalar(
+                text(
+                    "SELECT count(*) FROM pg_trigger t "
+                    "JOIN pg_class c ON c.oid = t.tgrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE n.nspname = 'review' AND NOT t.tgisinternal "
+                    "AND t.tgname LIKE 'trg_rob1036_%'"
+                )
+            )
+            # Two triggers (row + truncate) per table.
+            assert triggers == 2 * len(NEW_TABLES)
+
+        # The append-only trigger is live right after the upgrade.
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "INSERT INTO review.sample_eligibility_decisions "
+                    "(subject_kind, subject_ref, contract_version, revision_no, "
+                    "supersedes_revision_no, forecast_outcome_observability, "
+                    "calibration_eligibility, trade_performance_eligibility, "
+                    "operational_reliability_eligibility, decision_reason, "
+                    "decided_by, evidence, evidence_hash) VALUES "
+                    "('forecast', 'mig-check', 'uber-invalid-sample-eligibility.v1', "
+                    "1, NULL, 'observable', 'calibration_include', "
+                    "'trade_performance_include', 'operational_include', 'seed', "
+                    "'test', '{}'::jsonb, :digest)"
+                ),
+                {"digest": "0" * 64},
+            )
+        with pytest.raises(DBAPIError):
+            async with engine.begin() as connection:
+                await connection.execute(
+                    text(
+                        "UPDATE review.sample_eligibility_decisions "
+                        "SET decision_reason = 'tampered'"
+                    )
+                )
+
+        downgraded = alembic("downgrade", "-1")
+        assert downgraded.returncode == 0, downgraded.stderr
+
+        async with engine.connect() as connection:
+            for table in NEW_TABLES:
+                exists = await connection.scalar(
+                    text("SELECT to_regclass(:name) IS NOT NULL"),
+                    {"name": f"review.{table}"},
+                )
+                assert exists is False, table
+            function_left = await connection.scalar(
+                text(
+                    "SELECT count(*) FROM pg_proc p "
+                    "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                    "WHERE n.nspname = 'review' "
+                    "AND p.proname = 'reject_invalid_sample_mutation'"
+                )
+            )
+            assert function_left == 0
+
+        re_upgraded = alembic("upgrade", "head")
+        assert re_upgraded.returncode == 0, re_upgraded.stderr
+
+        async with engine.connect() as connection:
+            for table in NEW_TABLES:
+                exists = await connection.scalar(
+                    text("SELECT to_regclass(:name) IS NOT NULL"),
+                    {"name": f"review.{table}"},
+                )
+                assert exists is True, table
+    finally:
+        await engine.dispose()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE IF EXISTS "{database}"')
+        await admin.close()

--- a/tests/services/invalid_sample_eligibility/test_persistence.py
+++ b/tests/services/invalid_sample_eligibility/test_persistence.py
@@ -1,0 +1,627 @@
+"""ROB-1036 §4.3-5/6 — append-only persistence and aggregate non-re-entry.
+
+Runs against the isolated pytest database only (``tests/conftest.py`` pins
+``test_db``). No broker, account, network, or production database is touched.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select, text, update
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invalid_sample_eligibility import (
+    InvalidSampleCleanupBinding,
+    InvalidSampleCleanupLifecycleEvent,
+    SampleEligibilityDecision,
+)
+from app.models.review import TradeForecast
+from app.services.invalid_sample_eligibility.binding import (
+    CleanupBindingError,
+    build_cleanup_binding,
+)
+from app.services.invalid_sample_eligibility.contract import (
+    CONTRACT_VERSION,
+    CalibrationEligibility,
+    EligibilityContractError,
+    EligibilitySubject,
+    EligibilitySubjectKind,
+    ForecastOutcomeObservability,
+    OperationalReliabilityEligibility,
+    TradePerformanceEligibility,
+)
+from app.services.invalid_sample_eligibility.post_fill import (
+    FillEvidenceCompleteness,
+    PositionEffectEvidence,
+    PostFillCompletionStatus,
+    PostFillManualReviewReason,
+)
+from app.services.invalid_sample_eligibility.read_model import (
+    EligibilityDomain,
+    EligibilityPredicate,
+    build_eligible_forecast_calibration_aggregate,
+)
+from app.services.invalid_sample_eligibility.service import (
+    InvalidSampleEligibilityService,
+)
+from app.services.trade_journal import forecast_service as svc
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+NOW = datetime(2026, 8, 2, 6, 0, tzinfo=UTC)
+CALIBRATION_PREDICATE = EligibilityPredicate(
+    contract_version=CONTRACT_VERSION,
+    domain=EligibilityDomain.CALIBRATION,
+    admitted=frozenset({CalibrationEligibility.INCLUDE}),
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
+    # Append-only triggers block DELETE, so the fixture disables them for the
+    # duration of the cleanup instead of pretending the rows are mutable.
+    for table in (
+        "invalid_sample_cleanup_lifecycle_events",
+        "invalid_sample_cleanup_bindings",
+        "sample_eligibility_decisions",
+    ):
+        await db_session.execute(
+            text(f"ALTER TABLE review.{table} DISABLE TRIGGER USER")
+        )
+        await db_session.execute(text(f"DELETE FROM review.{table}"))
+        await db_session.execute(
+            text(f"ALTER TABLE review.{table} ENABLE TRIGGER USER")
+        )
+    await db_session.execute(delete(TradeForecast))
+    await db_session.commit()
+    yield
+
+
+def _subject(ref: str) -> EligibilitySubject:
+    return EligibilitySubject(kind=EligibilitySubjectKind.FORECAST, ref=ref)
+
+
+async def _record(
+    service: InvalidSampleEligibilityService,
+    subject: EligibilitySubject,
+    *,
+    calibration: CalibrationEligibility,
+    trade: TradePerformanceEligibility = TradePerformanceEligibility.INCLUDE,
+    observability: ForecastOutcomeObservability = (
+        ForecastOutcomeObservability.OBSERVABLE
+    ),
+    reason: str = "operator decision",
+    evidence: dict | None = None,
+):
+    return await service.record_decision(
+        subject=subject,
+        forecast_outcome_observability=observability,
+        calibration_eligibility=calibration,
+        trade_performance_eligibility=trade,
+        operational_reliability_eligibility=OperationalReliabilityEligibility.INCLUDE,
+        decision_reason=reason,
+        decided_by="test-operator",
+        evidence=evidence or {"source": "uber-d2-execution-result-2026-07-31.md"},
+    )
+
+
+async def _make_scored_forecast(
+    db_session: AsyncSession, *, created_by: str = "claude", probability: str = "0.8"
+) -> TradeForecast:
+    row = TradeForecast(
+        created_by=created_by,
+        symbol="UBER",
+        instrument_type="equity_us",
+        forecast_target={
+            "kind": "terminal_close",
+            "direction": "up",
+            "target_price": 100.0,
+            "outcome_rule_version": "terminal-close-v1-up-gte-down-lt",
+        },
+        probability=Decimal(probability),
+        review_date=date(2026, 7, 30),
+        status="closed",
+        outcome=True,
+        brier_score=Decimal("0.04000"),
+        resolved_at=NOW,
+    )
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+    return row
+
+
+def _binding(client_order_id: str = "cleanup-uber-001", **overrides):
+    kwargs = {
+        "forecast_id": uuid.uuid4(),
+        "sample_ref": "uber-d2-cleanup",
+        "approval_id": "approval-uber-001",
+        "approval_hash": "a" * 64,
+        "approval_expires_at": NOW + timedelta(minutes=5),
+        "approval_session_id": "session-A",
+        "mission_id": "invalid-sample-cleanup-mission-1",
+        "account_mode": "alpaca_paper_lab",
+        "client_order_id": client_order_id,
+        "lifecycle_correlation_id": f"corr-{client_order_id}",
+        "now": NOW,
+        "session_id": "session-A",
+    }
+    kwargs.update(overrides)
+    return build_cleanup_binding(**kwargs)
+
+
+# --- §4.3-5: append-only, no mutable update/delete -------------------------
+
+
+async def test_decision_row_cannot_be_updated(db_session: AsyncSession) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    subject = _subject(str(uuid.uuid4()))
+    await _record(service, subject, calibration=CalibrationEligibility.INCLUDE)
+    await db_session.commit()
+
+    with pytest.raises(DBAPIError):
+        await db_session.execute(
+            update(SampleEligibilityDecision)
+            .where(SampleEligibilityDecision.subject_ref == subject.ref)
+            .values(calibration_eligibility=CalibrationEligibility.EXCLUDE.value)
+        )
+    await db_session.rollback()
+
+
+async def test_decision_row_cannot_be_deleted(db_session: AsyncSession) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    subject = _subject(str(uuid.uuid4()))
+    await _record(service, subject, calibration=CalibrationEligibility.INCLUDE)
+    await db_session.commit()
+
+    with pytest.raises(DBAPIError):
+        await db_session.execute(
+            delete(SampleEligibilityDecision).where(
+                SampleEligibilityDecision.subject_ref == subject.ref
+            )
+        )
+    await db_session.rollback()
+
+
+async def test_binding_and_lifecycle_event_rows_are_append_only(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    binding = _binding()
+    await service.record_cleanup_binding(binding)
+    await service.record_post_fill_evidence(
+        binding=binding,
+        fill_evidence=FillEvidenceCompleteness.COMPLETE,
+        position_effect=PositionEffectEvidence.CONSISTENT,
+    )
+    await db_session.commit()
+
+    with pytest.raises(DBAPIError):
+        await db_session.execute(
+            update(InvalidSampleCleanupBinding).values(mission_id="tampered")
+        )
+    await db_session.rollback()
+
+    with pytest.raises(DBAPIError):
+        await db_session.execute(delete(InvalidSampleCleanupLifecycleEvent))
+    await db_session.rollback()
+
+
+async def test_correction_is_a_superseding_revision(db_session: AsyncSession) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    subject = _subject(str(uuid.uuid4()))
+
+    first = await _record(service, subject, calibration=CalibrationEligibility.INCLUDE)
+    second = await _record(
+        service,
+        subject,
+        calibration=CalibrationEligibility.EXCLUDE,
+        observability=ForecastOutcomeObservability.BLOCKED_PENDING_AUDIT_EVIDENCE,
+        trade=TradePerformanceEligibility.EXCLUDE,
+        reason="invalid sample: cleanup lifecycle blocked",
+    )
+    await db_session.commit()
+
+    assert first.revision_no == 1
+    assert first.supersedes_revision_no is None
+    assert second.revision_no == 2
+    assert second.supersedes_revision_no == 1
+
+    rows = (
+        (
+            await db_session.execute(
+                select(SampleEligibilityDecision)
+                .where(SampleEligibilityDecision.subject_ref == subject.ref)
+                .order_by(SampleEligibilityDecision.revision_no)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [row.revision_no for row in rows] == [1, 2]
+    assert rows[0].calibration_eligibility == CalibrationEligibility.INCLUDE.value
+
+    latest = await service.get_decision(subject)
+    assert latest.revision_no == 2
+    assert latest.calibration_eligibility is CalibrationEligibility.EXCLUDE
+
+
+async def test_duplicate_revision_number_is_rejected_by_the_database(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    subject = _subject(str(uuid.uuid4()))
+    await _record(service, subject, calibration=CalibrationEligibility.INCLUDE)
+    await db_session.commit()
+
+    db_session.add(
+        SampleEligibilityDecision(
+            subject_kind=subject.kind.value,
+            subject_ref=subject.ref,
+            contract_version=CONTRACT_VERSION,
+            revision_no=1,
+            supersedes_revision_no=None,
+            forecast_outcome_observability=(
+                ForecastOutcomeObservability.OBSERVABLE.value
+            ),
+            calibration_eligibility=CalibrationEligibility.EXCLUDE.value,
+            trade_performance_eligibility=TradePerformanceEligibility.INCLUDE.value,
+            operational_reliability_eligibility=(
+                OperationalReliabilityEligibility.INCLUDE.value
+            ),
+            decision_reason="branch attempt",
+            decided_by="test",
+            evidence={},
+            evidence_hash="0" * 64,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+async def test_revision_gap_is_rejected_by_the_database(
+    db_session: AsyncSession,
+) -> None:
+    subject = _subject(str(uuid.uuid4()))
+    db_session.add(
+        SampleEligibilityDecision(
+            subject_kind=subject.kind.value,
+            subject_ref=subject.ref,
+            contract_version=CONTRACT_VERSION,
+            revision_no=3,
+            supersedes_revision_no=1,  # gap: must be 2
+            forecast_outcome_observability=(
+                ForecastOutcomeObservability.OBSERVABLE.value
+            ),
+            calibration_eligibility=CalibrationEligibility.INCLUDE.value,
+            trade_performance_eligibility=TradePerformanceEligibility.INCLUDE.value,
+            operational_reliability_eligibility=(
+                OperationalReliabilityEligibility.INCLUDE.value
+            ),
+            decision_reason="gap attempt",
+            decided_by="test",
+            evidence={},
+            evidence_hash="0" * 64,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+async def test_tampered_evidence_hash_is_refused_on_read(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    subject = _subject(str(uuid.uuid4()))
+    await _record(service, subject, calibration=CalibrationEligibility.EXCLUDE)
+    await db_session.commit()
+
+    # Only reachable by bypassing the append-only trigger — exactly the tampering
+    # the digest exists to catch.
+    await db_session.execute(
+        text("ALTER TABLE review.sample_eligibility_decisions DISABLE TRIGGER USER")
+    )
+    await db_session.execute(
+        update(SampleEligibilityDecision)
+        .where(SampleEligibilityDecision.subject_ref == subject.ref)
+        .values(evidence={"source": "swapped"})
+    )
+    await db_session.execute(
+        text("ALTER TABLE review.sample_eligibility_decisions ENABLE TRIGGER USER")
+    )
+    db_session.expire_all()
+
+    with pytest.raises(EligibilityContractError) as excinfo:
+        await service.get_decision(subject)
+    assert excinfo.value.code == "evidence_hash_mismatch"
+    await db_session.rollback()
+
+
+# --- §4.3-6: idempotent replay --------------------------------------------
+
+
+async def test_duplicate_binding_authoring_is_idempotent(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    binding = _binding()
+    first = await service.record_cleanup_binding(binding)
+    second = await service.record_cleanup_binding(binding)
+    await db_session.commit()
+
+    assert first.id == second.id
+    count = await db_session.scalar(
+        select(text("count(*)")).select_from(InvalidSampleCleanupBinding)
+    )
+    assert count == 1
+
+
+async def test_conflicting_binding_for_same_client_order_id_is_refused(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    await service.record_cleanup_binding(_binding())
+    await db_session.commit()
+
+    with pytest.raises(CleanupBindingError) as excinfo:
+        await service.record_cleanup_binding(_binding(mission_id="other-mission"))
+    assert excinfo.value.code == "conflicting_binding_for_client_order_id"
+    await db_session.rollback()
+
+
+async def test_duplicate_post_fill_delivery_appends_once(
+    db_session: AsyncSession,
+) -> None:
+    """A replayed callback/reconcile/outbox delivery is a no-op."""
+
+    service = InvalidSampleEligibilityService(db_session)
+    binding = _binding()
+    await service.record_cleanup_binding(binding)
+
+    for _ in range(3):
+        completion = await service.record_post_fill_evidence(
+            binding=binding,
+            fill_evidence=FillEvidenceCompleteness.COMPLETE,
+            position_effect=PositionEffectEvidence.CONSISTENT,
+            evidence={"broker_order_id": "abc"},
+        )
+        assert completion.status is PostFillCompletionStatus.COMPLETE
+    await db_session.commit()
+
+    count = await db_session.scalar(
+        select(text("count(*)")).select_from(InvalidSampleCleanupLifecycleEvent)
+    )
+    assert count == 1
+
+
+async def test_manual_review_event_is_recorded_not_completed(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    binding = _binding()
+    await service.record_cleanup_binding(binding)
+
+    completion = await service.record_post_fill_evidence(
+        binding=binding,
+        fill_evidence=FillEvidenceCompleteness.COMPLETE,
+        position_effect=PositionEffectEvidence.ABSENT,
+    )
+    await db_session.commit()
+
+    assert completion.status is PostFillCompletionStatus.MANUAL_REVIEW
+    assert completion.reason is (
+        PostFillManualReviewReason.ABSENT_POSITION_EFFECT_EVIDENCE
+    )
+    row = (
+        (await db_session.execute(select(InvalidSampleCleanupLifecycleEvent)))
+        .scalars()
+        .one()
+    )
+    assert row.event_kind == "post_fill_manual_review"
+    assert row.completion_status == "manual_review"
+    assert row.manual_review_reason == (
+        PostFillManualReviewReason.ABSENT_POSITION_EFFECT_EVIDENCE.value
+    )
+
+
+async def test_post_fill_evidence_requires_a_persisted_binding(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    with pytest.raises(CleanupBindingError) as excinfo:
+        await service.record_post_fill_evidence(
+            binding=_binding(),
+            fill_evidence=FillEvidenceCompleteness.COMPLETE,
+            position_effect=PositionEffectEvidence.CONSISTENT,
+        )
+    assert excinfo.value.code == "unbound_lifecycle"
+    await db_session.rollback()
+
+
+# --- §4.3-3/10: aggregates ------------------------------------------------
+
+
+async def test_excluded_forecast_leaves_the_legacy_calibration_aggregate(
+    db_session: AsyncSession,
+) -> None:
+    included = await _make_scored_forecast(db_session, created_by="claude")
+    excluded = await _make_scored_forecast(db_session, created_by="claude")
+
+    before = await svc.build_forecast_calibration_aggregate(db_session)
+    assert before["groups"][0]["sample_size"] == 2
+
+    service = InvalidSampleEligibilityService(db_session)
+    await _record(
+        service,
+        _subject(str(excluded.forecast_id)),
+        calibration=CalibrationEligibility.EXCLUDE,
+        trade=TradePerformanceEligibility.EXCLUDE,
+        observability=ForecastOutcomeObservability.BLOCKED_PENDING_AUDIT_EVIDENCE,
+    )
+    await db_session.commit()
+
+    after = await svc.build_forecast_calibration_aggregate(db_session)
+    assert after["groups"][0]["sample_size"] == 1
+
+    remaining = await svc.list_scored_forecasts_for_calibration(db_session)
+    assert [row.id for row in remaining] == [included.id]
+
+
+async def test_removing_the_sql_exclusion_readmits_the_excluded_forecast(
+    db_session: AsyncSession,
+) -> None:
+    """Mutation evidence for the legacy entry point.
+
+    ``apply_eligibility_exclusion=False`` is exactly the mutant "drop the
+    eligibility filter". If the excluded row did not reappear, the filter above
+    would be proving nothing.
+    """
+
+    await _make_scored_forecast(db_session)
+    excluded = await _make_scored_forecast(db_session)
+    service = InvalidSampleEligibilityService(db_session)
+    await _record(
+        service,
+        _subject(str(excluded.forecast_id)),
+        calibration=CalibrationEligibility.EXCLUDE,
+    )
+    await db_session.commit()
+
+    filtered = await svc.list_scored_forecasts_for_calibration(db_session)
+    mutated = await svc.list_scored_forecasts_for_calibration(
+        db_session, apply_eligibility_exclusion=False
+    )
+
+    assert len(filtered) == 1
+    assert len(mutated) == 2
+    assert excluded.id in {row.id for row in mutated}
+    assert excluded.id not in {row.id for row in filtered}
+
+
+async def test_superseding_revision_can_readmit_a_previously_excluded_forecast(
+    db_session: AsyncSession,
+) -> None:
+    """Only the *latest* revision decides — the chain is not a tombstone."""
+
+    forecast = await _make_scored_forecast(db_session)
+    service = InvalidSampleEligibilityService(db_session)
+    subject = _subject(str(forecast.forecast_id))
+    await _record(service, subject, calibration=CalibrationEligibility.EXCLUDE)
+    await db_session.commit()
+    assert await svc.list_scored_forecasts_for_calibration(db_session) == []
+
+    await _record(
+        service,
+        subject,
+        calibration=CalibrationEligibility.INCLUDE,
+        reason="audit-grade provider evidence landed",
+    )
+    await db_session.commit()
+
+    rows = await svc.list_scored_forecasts_for_calibration(db_session)
+    assert [row.id for row in rows] == [forecast.id]
+
+
+async def test_eligible_cohort_reports_counts_and_reasons(
+    db_session: AsyncSession,
+) -> None:
+    included = await _make_scored_forecast(db_session)
+    excluded = await _make_scored_forecast(db_session)
+    await _make_scored_forecast(db_session)  # no decision → unidentifiable
+
+    service = InvalidSampleEligibilityService(db_session)
+    await _record(
+        service,
+        _subject(str(included.forecast_id)),
+        calibration=CalibrationEligibility.INCLUDE,
+    )
+    await _record(
+        service,
+        _subject(str(excluded.forecast_id)),
+        calibration=CalibrationEligibility.EXCLUDE,
+    )
+    await db_session.commit()
+
+    result = await build_eligible_forecast_calibration_aggregate(
+        db_session,
+        contract_version=CONTRACT_VERSION,
+        predicate=CALIBRATION_PREDICATE,
+    )
+
+    assert result["contract_version"] == CONTRACT_VERSION
+    assert result["eligibility_counts"] == {
+        "included": 1,
+        "excluded": 1,
+        "unidentifiable": 1,
+    }
+    assert result["eligibility_reasons"][CalibrationEligibility.EXCLUDE.value] == 1
+    assert (
+        result["eligibility_reasons"][CalibrationEligibility.UNIDENTIFIABLE.value] == 1
+    )
+    assert sum(group["sample_size"] for group in result["groups"]) == 1
+
+
+async def test_eligible_cohort_rejects_a_mismatched_predicate(
+    db_session: AsyncSession,
+) -> None:
+    with pytest.raises(EligibilityContractError) as excinfo:
+        await build_eligible_forecast_calibration_aggregate(
+            db_session,
+            contract_version="some-other-contract.v9",
+            predicate=CALIBRATION_PREDICATE,
+        )
+    assert excinfo.value.code == "predicate_contract_version_mismatch"
+
+
+async def test_eligible_cohort_rejects_a_non_calibration_predicate(
+    db_session: AsyncSession,
+) -> None:
+    trade_predicate = EligibilityPredicate(
+        contract_version=CONTRACT_VERSION,
+        domain=EligibilityDomain.TRADE_PERFORMANCE,
+        admitted=frozenset({TradePerformanceEligibility.INCLUDE}),
+    )
+    with pytest.raises(EligibilityContractError) as excinfo:
+        await build_eligible_forecast_calibration_aggregate(
+            db_session,
+            contract_version=CONTRACT_VERSION,
+            predicate=trade_predicate,
+        )
+    assert excinfo.value.code == "wrong_predicate_domain"
+
+
+async def test_recording_a_decision_never_resolves_the_forecast(
+    db_session: AsyncSession,
+) -> None:
+    """§4.3-2: the outcome record survives an invalid-sample decision untouched."""
+
+    forecast = await _make_scored_forecast(db_session)
+    before = (forecast.status, forecast.outcome, forecast.brier_score)
+
+    service = InvalidSampleEligibilityService(db_session)
+    await _record(
+        service,
+        _subject(str(forecast.forecast_id)),
+        calibration=CalibrationEligibility.EXCLUDE,
+        trade=TradePerformanceEligibility.EXCLUDE,
+        observability=ForecastOutcomeObservability.BLOCKED_PENDING_AUDIT_EVIDENCE,
+    )
+    await db_session.commit()
+    await db_session.refresh(forecast)
+
+    assert (forecast.status, forecast.outcome, forecast.brier_score) == before
+    assert forecast.resolved_at is not None

--- a/tests/services/invalid_sample_eligibility/test_persistence.py
+++ b/tests/services/invalid_sample_eligibility/test_persistence.py
@@ -6,6 +6,7 @@ Runs against the isolated pytest database only (``tests/conftest.py`` pins
 
 from __future__ import annotations
 
+import inspect
 import uuid
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
@@ -26,6 +27,14 @@ from app.services.invalid_sample_eligibility.binding import (
     CleanupBindingError,
     build_cleanup_binding,
 )
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+    COMPATIBILITY_STAGE,
+    DECIDED_ONLY_CALIBRATION_COHORT,
+    DECIDED_ONLY_STAGE,
+    EligibilityDomain,
+    EligibilityPredicate,
+)
 from app.services.invalid_sample_eligibility.contract import (
     CONTRACT_VERSION,
     CalibrationEligibility,
@@ -42,11 +51,6 @@ from app.services.invalid_sample_eligibility.post_fill import (
     PostFillCompletionStatus,
     PostFillManualReviewReason,
 )
-from app.services.invalid_sample_eligibility.read_model import (
-    EligibilityDomain,
-    EligibilityPredicate,
-    build_eligible_forecast_calibration_aggregate,
-)
 from app.services.invalid_sample_eligibility.service import (
     InvalidSampleEligibilityService,
 )
@@ -59,11 +63,7 @@ pytestmark = [
 ]
 
 NOW = datetime(2026, 8, 2, 6, 0, tzinfo=UTC)
-CALIBRATION_PREDICATE = EligibilityPredicate(
-    contract_version=CONTRACT_VERSION,
-    domain=EligibilityDomain.CALIBRATION,
-    admitted=frozenset({CalibrationEligibility.INCLUDE}),
-)
+CALIBRATION_PREDICATE = DECIDED_ONLY_CALIBRATION_COHORT
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -455,14 +455,13 @@ async def test_post_fill_evidence_requires_a_persisted_binding(
 # --- §4.3-3/10: aggregates ------------------------------------------------
 
 
-async def test_excluded_forecast_leaves_the_legacy_calibration_aggregate(
+async def test_excluded_forecast_leaves_the_calibration_aggregate(
     db_session: AsyncSession,
 ) -> None:
-    """An explicit ``calibration_exclude`` drops out of the legacy aggregate.
+    """An explicit ``calibration_exclude`` is held out under every cohort.
 
-    This asserts only the exclusion guarantee. It deliberately does NOT assert
-    anything about how the legacy aggregate treats *undecided* forecasts — that
-    is the open ROB-1036 B1 question, pinned separately below.
+    The compatibility cohort widens what is *admitted*; it never resurrects an
+    explicitly excluded sample. The excluded row is reported in its own count.
     """
 
     included = await _make_scored_forecast(db_session, created_by="claude")
@@ -478,62 +477,131 @@ async def test_excluded_forecast_leaves_the_legacy_calibration_aggregate(
     )
     await db_session.commit()
 
-    after = await svc.build_forecast_calibration_aggregate(db_session)
+    after = await svc.build_forecast_calibration_aggregate(
+        db_session,
+        contract_version=CONTRACT_VERSION,
+        predicate=COMPATIBILITY_CALIBRATION_COHORT,
+    )
     assert after["groups"][0]["sample_size"] == 1
+    assert after["eligibility_counts"]["excluded"] == 1
 
     remaining = await svc.list_scored_forecasts_for_calibration(db_session)
     assert [row.id for row in remaining] == [included.id]
 
 
-async def test_undecided_forecasts_strict_cohort_excludes_legacy_aggregate_admits(
+async def test_undecided_admission_is_the_stated_contract_of_the_cohort(
     db_session: AsyncSession,
 ) -> None:
-    """🔴 KNOWN GAP (ROB-1036 B1) — the two surfaces disagree on UNIDENTIFIABLE.
+    """D-1 option ② — undecided rows are admitted *by contract*, and counted.
 
-    Contract-correct behaviour is the strict cohort's: a forecast with no
-    eligibility decision is ``UNIDENTIFIABLE`` and does **not** enter a
-    calibration cohort (prompt.md §4.2-4/§4.2-5).
+    This is the operator-approved behaviour, not an accident of the old
+    ``closed + scored`` predicate. The test therefore asserts the three things
+    that make it a contract rather than a coincidence:
 
-    The pre-existing public aggregate — still used by
-    ``mcp_server/tooling/forecast_tools.py``, ``routers/invest_forecasts.py``
-    and ``services/decision_history.py`` — admits them, which is semantically a
-    default-include. Closing that gap makes every existing calibration surface
-    return empty (there are zero decision rows and §4.2-4 forbids backfill), so
-    it is an operator decision, escalated as NEEDS_INFO rather than taken here.
+    1. the call **cannot be made without** naming a contract version and cohort;
+    2. the cohort's admitted set explicitly contains the UNIDENTIFIABLE value;
+    3. the undecided quantity is reported **separately** — never folded into the
+       included count or into a single "eligible" number.
 
-    This test pins BOTH behaviours side by side so the divergence is visible and
-    machine-checked. When the operator decides, exactly one branch changes.
+    The end-state cohort is available in the same call for comparison, so the
+    promotion path stays exercised.
     """
 
     await _make_scored_forecast(db_session, created_by="claude")
     await _make_scored_forecast(db_session, created_by="claude")
     await db_session.commit()
 
-    # Contract-correct surface: undecided rows are held out of the cohort.
-    strict = await build_eligible_forecast_calibration_aggregate(
+    # (1) contract_version and predicate are required, not defaulted.
+    signature = inspect.signature(svc.build_forecast_calibration_aggregate)
+    for name in ("contract_version", "predicate"):
+        parameter = signature.parameters[name]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is inspect.Parameter.empty
+    with pytest.raises(TypeError):
+        await svc.build_forecast_calibration_aggregate(db_session)  # type: ignore[call-arg]
+
+    # (2) the admission is declared in the cohort itself.
+    assert (
+        CalibrationEligibility.UNIDENTIFIABLE
+        in COMPATIBILITY_CALIBRATION_COHORT.admitted
+    )
+    assert COMPATIBILITY_CALIBRATION_COHORT.admits_unidentifiable is True
+
+    result = await svc.build_forecast_calibration_aggregate(
         db_session,
         contract_version=CONTRACT_VERSION,
-        predicate=CALIBRATION_PREDICATE,
+        predicate=COMPATIBILITY_CALIBRATION_COHORT,
     )
-    assert strict["eligibility_counts"] == {
+
+    # (3) admitted into the cohort AND reported as undecided, side by side.
+    assert result["groups"][0]["sample_size"] == 2
+    assert result["eligibility_counts"] == {
         "included": 0,
         "excluded": 0,
         "unidentifiable": 2,
     }
-    assert strict["groups"] == []
+    assert result["eligibility_admitted_count"] == 2
+    # The undecided quantity is not silently merged into "included".
+    assert result["eligibility_counts"]["included"] == 0
+    assert (
+        CalibrationEligibility.UNIDENTIFIABLE.value
+        in result["eligibility_cohort_admits"]
+    )
 
-    # Legacy surface: admits them. Asserted as the CURRENT, KNOWN-WRONG state —
-    # not as a correctness expectation.
-    legacy = await svc.build_forecast_calibration_aggregate(db_session)
-    legacy_sample_size = legacy["groups"][0]["sample_size"]
-    assert legacy_sample_size == 2, (
-        "legacy aggregate behaviour changed; if this is the ROB-1036 B1 fix, "
-        "update this pin and the strict/legacy divergence note"
+    # Provenance: the number is attributable to the cohort that produced it.
+    assert result["contract_version"] == CONTRACT_VERSION
+    assert result["eligibility_cohort"] == COMPATIBILITY_CALIBRATION_COHORT.label
+    assert result["eligibility_stage"] == COMPATIBILITY_STAGE
+
+    # The end-state cohort holds the same rows out, and says so in its own stamp.
+    decided_only = await svc.build_forecast_calibration_aggregate(
+        db_session,
+        contract_version=CONTRACT_VERSION,
+        predicate=DECIDED_ONLY_CALIBRATION_COHORT,
     )
-    assert legacy_sample_size != strict["eligibility_counts"]["included"], (
-        "the strict cohort and the legacy aggregate must be shown to disagree "
-        "while B1 is open"
+    assert decided_only["groups"] == []
+    assert decided_only["eligibility_counts"]["unidentifiable"] == 2
+    assert decided_only["eligibility_admitted_count"] == 0
+    assert decided_only["eligibility_stage"] == DECIDED_ONLY_STAGE
+    # Same classification, different admission — that is the whole difference.
+    assert decided_only["eligibility_counts"] == result["eligibility_counts"]
+
+
+async def test_cohort_provenance_distinguishes_two_results_over_same_rows(
+    db_session: AsyncSession,
+) -> None:
+    """Promotion prerequisite: two cohorts' outputs are never confusable.
+
+    Without this, a compatibility-stage number and an end-state number over the
+    same population could not be told apart afterwards and no before/after
+    comparison report would be possible.
+    """
+
+    await _make_scored_forecast(db_session, created_by="claude")
+    await db_session.commit()
+
+    compatibility = await svc.build_forecast_calibration_aggregate(
+        db_session,
+        contract_version=CONTRACT_VERSION,
+        predicate=COMPATIBILITY_CALIBRATION_COHORT,
     )
+    decided_only = await svc.build_forecast_calibration_aggregate(
+        db_session,
+        contract_version=CONTRACT_VERSION,
+        predicate=DECIDED_ONLY_CALIBRATION_COHORT,
+    )
+
+    assert compatibility["eligibility_cohort"] != decided_only["eligibility_cohort"]
+    assert compatibility["eligibility_stage"] != decided_only["eligibility_stage"]
+    assert (
+        compatibility["eligibility_cohort_admits"]
+        != decided_only["eligibility_cohort_admits"]
+    )
+    # Same contract, same rows classified identically — only admission differs.
+    assert compatibility["contract_version"] == decided_only["contract_version"]
+    assert compatibility["eligibility_counts"] == decided_only["eligibility_counts"]
+    assert compatibility["eligibility_admitted_count"] == 1
+    assert decided_only["eligibility_admitted_count"] == 0
 
 
 async def test_removing_the_sql_exclusion_readmits_the_excluded_forecast(
@@ -611,7 +679,7 @@ async def test_eligible_cohort_reports_counts_and_reasons(
     )
     await db_session.commit()
 
-    result = await build_eligible_forecast_calibration_aggregate(
+    result = await svc.build_forecast_calibration_aggregate(
         db_session,
         contract_version=CONTRACT_VERSION,
         predicate=CALIBRATION_PREDICATE,
@@ -634,7 +702,7 @@ async def test_eligible_cohort_rejects_a_mismatched_predicate(
     db_session: AsyncSession,
 ) -> None:
     with pytest.raises(EligibilityContractError) as excinfo:
-        await build_eligible_forecast_calibration_aggregate(
+        await svc.build_forecast_calibration_aggregate(
             db_session,
             contract_version="some-other-contract.v9",
             predicate=CALIBRATION_PREDICATE,
@@ -649,9 +717,10 @@ async def test_eligible_cohort_rejects_a_non_calibration_predicate(
         contract_version=CONTRACT_VERSION,
         domain=EligibilityDomain.TRADE_PERFORMANCE,
         admitted=frozenset({TradePerformanceEligibility.INCLUDE}),
+        label="trade-performance-test",
     )
     with pytest.raises(EligibilityContractError) as excinfo:
-        await build_eligible_forecast_calibration_aggregate(
+        await svc.build_forecast_calibration_aggregate(
             db_session,
             contract_version=CONTRACT_VERSION,
             predicate=trade_predicate,

--- a/tests/services/invalid_sample_eligibility/test_persistence.py
+++ b/tests/services/invalid_sample_eligibility/test_persistence.py
@@ -458,11 +458,15 @@ async def test_post_fill_evidence_requires_a_persisted_binding(
 async def test_excluded_forecast_leaves_the_legacy_calibration_aggregate(
     db_session: AsyncSession,
 ) -> None:
+    """An explicit ``calibration_exclude`` drops out of the legacy aggregate.
+
+    This asserts only the exclusion guarantee. It deliberately does NOT assert
+    anything about how the legacy aggregate treats *undecided* forecasts — that
+    is the open ROB-1036 B1 question, pinned separately below.
+    """
+
     included = await _make_scored_forecast(db_session, created_by="claude")
     excluded = await _make_scored_forecast(db_session, created_by="claude")
-
-    before = await svc.build_forecast_calibration_aggregate(db_session)
-    assert before["groups"][0]["sample_size"] == 2
 
     service = InvalidSampleEligibilityService(db_session)
     await _record(
@@ -479,6 +483,57 @@ async def test_excluded_forecast_leaves_the_legacy_calibration_aggregate(
 
     remaining = await svc.list_scored_forecasts_for_calibration(db_session)
     assert [row.id for row in remaining] == [included.id]
+
+
+async def test_undecided_forecasts_strict_cohort_excludes_legacy_aggregate_admits(
+    db_session: AsyncSession,
+) -> None:
+    """🔴 KNOWN GAP (ROB-1036 B1) — the two surfaces disagree on UNIDENTIFIABLE.
+
+    Contract-correct behaviour is the strict cohort's: a forecast with no
+    eligibility decision is ``UNIDENTIFIABLE`` and does **not** enter a
+    calibration cohort (prompt.md §4.2-4/§4.2-5).
+
+    The pre-existing public aggregate — still used by
+    ``mcp_server/tooling/forecast_tools.py``, ``routers/invest_forecasts.py``
+    and ``services/decision_history.py`` — admits them, which is semantically a
+    default-include. Closing that gap makes every existing calibration surface
+    return empty (there are zero decision rows and §4.2-4 forbids backfill), so
+    it is an operator decision, escalated as NEEDS_INFO rather than taken here.
+
+    This test pins BOTH behaviours side by side so the divergence is visible and
+    machine-checked. When the operator decides, exactly one branch changes.
+    """
+
+    await _make_scored_forecast(db_session, created_by="claude")
+    await _make_scored_forecast(db_session, created_by="claude")
+    await db_session.commit()
+
+    # Contract-correct surface: undecided rows are held out of the cohort.
+    strict = await build_eligible_forecast_calibration_aggregate(
+        db_session,
+        contract_version=CONTRACT_VERSION,
+        predicate=CALIBRATION_PREDICATE,
+    )
+    assert strict["eligibility_counts"] == {
+        "included": 0,
+        "excluded": 0,
+        "unidentifiable": 2,
+    }
+    assert strict["groups"] == []
+
+    # Legacy surface: admits them. Asserted as the CURRENT, KNOWN-WRONG state —
+    # not as a correctness expectation.
+    legacy = await svc.build_forecast_calibration_aggregate(db_session)
+    legacy_sample_size = legacy["groups"][0]["sample_size"]
+    assert legacy_sample_size == 2, (
+        "legacy aggregate behaviour changed; if this is the ROB-1036 B1 fix, "
+        "update this pin and the strict/legacy divergence note"
+    )
+    assert legacy_sample_size != strict["eligibility_counts"]["included"], (
+        "the strict cohort and the legacy aggregate must be shown to disagree "
+        "while B1 is open"
+    )
 
 
 async def test_removing_the_sql_exclusion_readmits_the_excluded_forecast(

--- a/tests/services/invalid_sample_eligibility/test_pnl_eligibility_wiring.py
+++ b/tests/services/invalid_sample_eligibility/test_pnl_eligibility_wiring.py
@@ -1,0 +1,381 @@
+"""ROB-1036 B2 — trade-performance eligibility is wired into the real PnL path.
+
+Covers both Alpaca PnL entry points:
+
+* ``PaperEvaluationPnL.compute_alpaca_view`` — the ledger-row path, driven with
+  a fake read-only ledger (no broker, no network).
+* ``AuthoritativeEvidenceReader._trade_performance_excluded_row_ids`` — the
+  resolver the live ``alpaca_fills`` evidence loader calls before building fills.
+
+The exclusion is keyed on an explicit ``trade_performance_exclude`` decision.
+A lifecycle with no decision is ``UNIDENTIFIABLE`` and is left in place, so the
+wiring is additive: with no decisions recorded, the PnL inputs are unchanged.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast
+from app.services.invalid_sample_eligibility.contract import (
+    CalibrationEligibility,
+    EligibilitySubject,
+    EligibilitySubjectKind,
+    ForecastOutcomeObservability,
+    OperationalReliabilityEligibility,
+    TradePerformanceEligibility,
+)
+from app.services.invalid_sample_eligibility.service import (
+    InvalidSampleEligibilityService,
+)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
+    for table in (
+        "invalid_sample_cleanup_lifecycle_events",
+        "invalid_sample_cleanup_bindings",
+        "sample_eligibility_decisions",
+    ):
+        await db_session.execute(
+            text(f"ALTER TABLE review.{table} DISABLE TRIGGER USER")
+        )
+        await db_session.execute(text(f"DELETE FROM review.{table}"))
+        await db_session.execute(
+            text(f"ALTER TABLE review.{table} ENABLE TRIGGER USER")
+        )
+    await db_session.execute(delete(TradeForecast))
+    await db_session.commit()
+    yield
+
+
+async def _exclude_lifecycle(db_session: AsyncSession, correlation_id: str) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    await service.record_decision(
+        subject=EligibilitySubject(
+            kind=EligibilitySubjectKind.TRADE_LIFECYCLE, ref=correlation_id
+        ),
+        forecast_outcome_observability=(
+            ForecastOutcomeObservability.BLOCKED_PENDING_AUDIT_EVIDENCE
+        ),
+        calibration_eligibility=CalibrationEligibility.EXCLUDE,
+        trade_performance_eligibility=TradePerformanceEligibility.EXCLUDE,
+        operational_reliability_eligibility=OperationalReliabilityEligibility.INCLUDE,
+        decision_reason="invalid sample cleanup",
+        decided_by="test-operator",
+        evidence={"source": "uber-d2-execution-result-2026-07-31.md"},
+    )
+    await db_session.commit()
+
+
+# --- the service-layer resolver -------------------------------------------
+
+
+async def test_resolver_reports_only_explicit_exclusions(
+    db_session: AsyncSession,
+) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    await _exclude_lifecycle(db_session, "corr-excluded")
+
+    excluded = await service.list_trade_performance_excluded(
+        ["corr-excluded", "corr-undecided"]
+    )
+
+    assert excluded == frozenset({"corr-excluded"})
+    # Undecided is UNIDENTIFIABLE — never silently reported as excluded.
+    assert "corr-undecided" not in excluded
+
+
+async def test_resolver_ignores_a_calibration_only_exclusion(
+    db_session: AsyncSession,
+) -> None:
+    """The four domains stay independent at the PnL boundary too."""
+
+    service = InvalidSampleEligibilityService(db_session)
+    await service.record_decision(
+        subject=EligibilitySubject(
+            kind=EligibilitySubjectKind.TRADE_LIFECYCLE, ref="corr-cal-only"
+        ),
+        forecast_outcome_observability=ForecastOutcomeObservability.OBSERVABLE,
+        calibration_eligibility=CalibrationEligibility.EXCLUDE,
+        trade_performance_eligibility=TradePerformanceEligibility.INCLUDE,
+        operational_reliability_eligibility=OperationalReliabilityEligibility.INCLUDE,
+        decision_reason="calibration-only exclusion",
+        decided_by="test-operator",
+    )
+    await db_session.commit()
+
+    assert (
+        await service.list_trade_performance_excluded(["corr-cal-only"]) == frozenset()
+    )
+
+
+async def test_resolver_is_empty_without_decisions(db_session: AsyncSession) -> None:
+    service = InvalidSampleEligibilityService(db_session)
+    assert await service.list_trade_performance_excluded(["a", "b"]) == frozenset()
+    assert await service.list_trade_performance_excluded([]) == frozenset()
+
+
+# --- compute_alpaca_view ---------------------------------------------------
+
+
+def _alpaca_ledger_with_two_lifecycles():
+    """Two profitable round trips on two separate lifecycles.
+
+    Reuses the ROB-850 PnL harness so the assertions run through the *real*
+    ``compute_alpaca_view``, not a re-implementation of its filter.
+    """
+
+    from tests.services.paper_evaluation.test_pnl import (
+        FakeAlpacaLedgerReader,
+        _make_alpaca_execution_row,
+    )
+
+    def roundtrip(corr: str, first_row_id: int):
+        return [
+            _make_alpaca_execution_row(
+                side="buy",
+                filled_qty="1",
+                filled_price="50000",
+                row_id=first_row_id,
+                corr_id=corr,
+            ),
+            _make_alpaca_execution_row(
+                side="sell",
+                filled_qty="1",
+                filled_price="51000",
+                row_id=first_row_id + 1,
+                corr_id=corr,
+            ),
+        ]
+
+    return FakeAlpacaLedgerReader(
+        rows_by_correlation={
+            "corr_kept": roundtrip("corr_kept", 1),
+            "corr_excluded": roundtrip("corr_excluded", 3),
+        }
+    )
+
+
+async def test_compute_alpaca_view_drops_an_excluded_lifecycle_from_pnl() -> None:
+    """§4.2-10 through the production PnL function, not a source assertion.
+
+    Same ledger, same correlation ids; the only difference is the exclusion set.
+    The excluded lifecycle's realised P&L must vanish from the result.
+    """
+
+    from tests.services.paper_evaluation.test_pnl import _make_service
+
+    service = _make_service()
+    correlation_ids = ["corr_kept", "corr_excluded"]
+
+    both = await service.compute_alpaca_view(
+        _alpaca_ledger_with_two_lifecycles(), correlation_ids=correlation_ids
+    )
+    filtered = await service.compute_alpaca_view(
+        _alpaca_ledger_with_two_lifecycles(),
+        correlation_ids=correlation_ids,
+        excluded_correlation_ids={"corr_excluded"},
+    )
+    only_kept = await service.compute_alpaca_view(
+        _alpaca_ledger_with_two_lifecycles(), correlation_ids=["corr_kept"]
+    )
+
+    # The excluded lifecycle really did contribute before being filtered...
+    assert both.nominal_net_pnl != filtered.nominal_net_pnl
+    assert both.turnover > filtered.turnover
+    # ...and filtering it is exactly equivalent to never supplying it.
+    assert filtered.nominal_net_pnl == only_kept.nominal_net_pnl
+    assert filtered.turnover == only_kept.turnover
+    assert filtered.fill_count == only_kept.fill_count
+
+
+async def test_compute_alpaca_view_exclusion_is_additive_by_default() -> None:
+    """Omitting the argument reproduces the previous behaviour byte for byte."""
+
+    from tests.services.paper_evaluation.test_pnl import _make_service
+
+    service = _make_service()
+    correlation_ids = ["corr_kept", "corr_excluded"]
+
+    default = await service.compute_alpaca_view(
+        _alpaca_ledger_with_two_lifecycles(), correlation_ids=correlation_ids
+    )
+    explicit_empty = await service.compute_alpaca_view(
+        _alpaca_ledger_with_two_lifecycles(),
+        correlation_ids=correlation_ids,
+        excluded_correlation_ids=frozenset(),
+    )
+
+    assert default.nominal_net_pnl == explicit_empty.nominal_net_pnl
+    assert default.turnover == explicit_empty.turnover
+    assert default.fill_count == explicit_empty.fill_count
+
+
+async def test_compute_alpaca_view_drops_a_foreign_row_carrying_an_excluded_id() -> (
+    None
+):
+    """A ledger row whose own lifecycle id is excluded is dropped too.
+
+    ``list_by_correlation_id`` is a fake-able boundary: a row returned under one
+    correlation id may carry another. The per-row guard covers that case, so the
+    filter cannot be defeated by a mis-keyed read.
+    """
+
+    from tests.services.paper_evaluation.test_pnl import (
+        FakeAlpacaLedgerReader,
+        _make_alpaca_execution_row,
+        _make_service,
+    )
+
+    service = _make_service()
+    ledger = FakeAlpacaLedgerReader(
+        rows_by_correlation={
+            "corr_kept": [
+                _make_alpaca_execution_row(
+                    side="buy",
+                    filled_qty="1",
+                    filled_price="50000",
+                    row_id=1,
+                    corr_id="corr_kept",
+                ),
+                # Same bucket, foreign (excluded) lifecycle id.
+                _make_alpaca_execution_row(
+                    side="buy",
+                    filled_qty="1",
+                    filled_price="50000",
+                    row_id=2,
+                    corr_id="corr_excluded",
+                ),
+            ]
+        }
+    )
+    metrics = await service.compute_alpaca_view(
+        ledger,
+        correlation_ids=["corr_kept"],
+        excluded_correlation_ids={"corr_excluded"},
+    )
+
+    baseline = await service.compute_alpaca_view(
+        FakeAlpacaLedgerReader(
+            rows_by_correlation={
+                "corr_kept": [
+                    _make_alpaca_execution_row(
+                        side="buy",
+                        filled_qty="1",
+                        filled_price="50000",
+                        row_id=1,
+                        corr_id="corr_kept",
+                    )
+                ]
+            }
+        ),
+        correlation_ids=["corr_kept"],
+    )
+    assert metrics.turnover == baseline.turnover
+
+
+# --- the live evidence loader ---------------------------------------------
+
+
+async def test_evidence_reader_resolves_exclusions_for_alpaca_links(
+    db_session: AsyncSession,
+) -> None:
+    """``AuthoritativeEvidenceReader`` consults the eligibility service."""
+
+    from app.services.paper_evaluation.evidence import AuthoritativeEvidenceReader
+
+    await _exclude_lifecycle(db_session, "corr-excluded")
+    reader = AuthoritativeEvidenceReader(db_session)
+
+    @dataclass
+    class FakeLink:
+        venue: str
+        native_ledger_row_id: int
+
+    # Binance links are ignored by this resolver (different ledger/contract).
+    rows = [(FakeLink("binance", 999),)]
+    assert await reader._trade_performance_excluded_row_ids(rows) == frozenset()
+
+
+async def test_evidence_loader_filters_the_excluded_alpaca_row(
+    db_session: AsyncSession,
+) -> None:
+    """The live loader skips a ledger row bound to an excluded lifecycle."""
+
+    from app.models.review import AlpacaPaperOrderLedger
+    from app.services.paper_evaluation.evidence import AuthoritativeEvidenceReader
+
+    correlation_id = f"corr-{uuid.uuid4().hex[:12]}"
+    client_order_id = f"cleanup-{uuid.uuid4().hex[:12]}"
+    row = AlpacaPaperOrderLedger(
+        client_order_id=client_order_id,
+        lifecycle_correlation_id=correlation_id,
+        record_kind="execution",
+        broker="alpaca",
+        account_mode="alpaca_paper_lab",
+        lifecycle_state="filled",
+        execution_symbol="UBER",
+        execution_venue="alpaca_paper",
+        instrument_type="equity_us",
+        side="sell",
+        order_type="market",
+        currency="USD",
+        filled_qty=Decimal("1"),
+        filled_avg_price=Decimal("70"),
+        raw_responses={"filled_at": datetime.now(UTC).isoformat()},
+    )
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+
+    reader = AuthoritativeEvidenceReader(db_session)
+
+    @dataclass
+    class FakeLink:
+        venue: str
+        native_ledger_row_id: int
+
+    links = [(FakeLink("alpaca", row.id),)]
+
+    # Before any decision: UNIDENTIFIABLE, so the row stays (additive).
+    assert await reader._trade_performance_excluded_row_ids(links) == frozenset()
+
+    await _exclude_lifecycle(db_session, correlation_id)
+
+    # After an explicit trade-performance exclusion: filtered out. The resolver
+    # returns native *row ids* so the ROB-850-guarded loader never handles a
+    # correlation id.
+    assert await reader._trade_performance_excluded_row_ids(links) == frozenset(
+        {row.id}
+    )
+
+
+async def test_evidence_loader_applies_the_filter_in_the_fill_loop() -> None:
+    """The resolved set is actually consumed where fills are built."""
+
+    import inspect
+
+    from app.services.paper_evaluation.evidence import AuthoritativeEvidenceReader
+
+    source = inspect.getsource(AuthoritativeEvidenceReader._load_native)
+    assert "excluded_row_ids = await self._trade_performance_excluded_row_ids" in source
+    assert "row.id in excluded_row_ids" in source
+    # ROB-850: the guarded method must stay free of correlation vocabulary.
+    assert "lifecycle_correlation_id" not in source

--- a/tests/services/invalid_sample_eligibility/test_post_fill.py
+++ b/tests/services/invalid_sample_eligibility/test_post_fill.py
@@ -1,0 +1,259 @@
+"""ROB-1036 §4.3 — post-fill completion gate and no-resend timeout recovery.
+
+Offline: a fake transport counts what a real one would have been asked to do.
+Nothing here touches a broker, an account, the network, or the runtime DB.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+import pytest
+
+from app.services.invalid_sample_eligibility.post_fill import (
+    FillEvidenceCompleteness,
+    PositionEffectEvidence,
+    PostFillCompletion,
+    PostFillCompletionStatus,
+    PostFillManualReviewReason,
+    RecoveryAction,
+    classify_position_effect,
+    evaluate_post_fill_completion,
+    plan_timeout_recovery,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class FakeBrokerTransport:
+    """Counts the mutations a recovery path would have performed."""
+
+    post_count: int = 0
+    issued_identities: list[str] = field(default_factory=list)
+    evidence_lookups: list[str] = field(default_factory=list)
+
+    def post_order(self, client_order_id: str) -> None:  # pragma: no cover - guard
+        self.post_count += 1
+        self.issued_identities.append(client_order_id)
+
+    def lookup_order_by_client_order_id(self, client_order_id: str) -> dict[str, str]:
+        self.evidence_lookups.append(client_order_id)
+        return {"client_order_id": client_order_id, "status": "filled"}
+
+
+def execute_recovery(plan, transport: FakeBrokerTransport) -> dict[str, str] | None:
+    """Minimal driver: the plan decides, the transport only obeys."""
+
+    assert plan.broker_post_allowed is False
+    assert plan.new_identity_allowed is False
+    if plan.action is RecoveryAction.LOOKUP_EXISTING_ORDER_EVIDENCE:
+        return transport.lookup_order_by_client_order_id(plan.client_order_id)
+    return None
+
+
+# --- §4.3-7: both evidences required --------------------------------------
+
+
+def test_complete_only_when_both_evidences_hold() -> None:
+    result = evaluate_post_fill_completion(
+        fill_evidence=FillEvidenceCompleteness.COMPLETE,
+        position_effect=PositionEffectEvidence.CONSISTENT,
+    )
+    assert result.status is PostFillCompletionStatus.COMPLETE
+    assert result.reason is None
+    assert result.is_terminal_success is True
+
+
+@pytest.mark.parametrize(
+    ("fill_evidence", "position_effect", "expected_reason"),
+    [
+        (
+            FillEvidenceCompleteness.ABSENT,
+            PositionEffectEvidence.CONSISTENT,
+            PostFillManualReviewReason.ABSENT_FILL_EVIDENCE,
+        ),
+        (
+            FillEvidenceCompleteness.INCOMPLETE,
+            PositionEffectEvidence.CONSISTENT,
+            PostFillManualReviewReason.INCOMPLETE_FILL_EVIDENCE,
+        ),
+        (
+            FillEvidenceCompleteness.COMPLETE,
+            PositionEffectEvidence.ABSENT,
+            PostFillManualReviewReason.ABSENT_POSITION_EFFECT_EVIDENCE,
+        ),
+        (
+            FillEvidenceCompleteness.COMPLETE,
+            PositionEffectEvidence.INCONSISTENT,
+            PostFillManualReviewReason.INCONSISTENT_POSITION_EFFECT_EVIDENCE,
+        ),
+    ],
+)
+def test_every_missing_evidence_is_typed_manual_review(
+    fill_evidence: FillEvidenceCompleteness,
+    position_effect: PositionEffectEvidence,
+    expected_reason: PostFillManualReviewReason,
+) -> None:
+    result = evaluate_post_fill_completion(
+        fill_evidence=fill_evidence, position_effect=position_effect
+    )
+    assert result.status is PostFillCompletionStatus.MANUAL_REVIEW
+    assert result.reason is expected_reason
+    assert result.is_terminal_success is False
+
+
+def test_exactly_one_of_nine_evidence_combinations_is_terminal_success() -> None:
+    """`filled` status alone never completes: 8 of 9 combinations refuse."""
+
+    successes = [
+        (fill, position)
+        for fill, position in itertools.product(
+            FillEvidenceCompleteness, PositionEffectEvidence
+        )
+        if evaluate_post_fill_completion(
+            fill_evidence=fill, position_effect=position
+        ).is_terminal_success
+    ]
+    assert successes == [
+        (FillEvidenceCompleteness.COMPLETE, PositionEffectEvidence.CONSISTENT)
+    ]
+
+
+def test_manual_review_outcome_requires_a_reason() -> None:
+    with pytest.raises(ValueError):
+        PostFillCompletion(PostFillCompletionStatus.MANUAL_REVIEW, None)
+
+
+def test_complete_outcome_rejects_a_reason() -> None:
+    with pytest.raises(ValueError):
+        PostFillCompletion(
+            PostFillCompletionStatus.COMPLETE,
+            PostFillManualReviewReason.ABSENT_FILL_EVIDENCE,
+        )
+
+
+def test_manual_review_reason_enum_has_no_success_member() -> None:
+    """Every reason is a refusal — there is no ``none``/``ok`` escape hatch."""
+
+    values = {member.value for member in PostFillManualReviewReason}
+    assert not (values & {"none", "ok", "complete", "success", "n_a"})
+    for member in PostFillManualReviewReason:
+        # A reason is only constructible alongside a manual-review status.
+        assert (
+            PostFillCompletion(
+                PostFillCompletionStatus.MANUAL_REVIEW, member
+            ).is_terminal_success
+            is False
+        )
+        with pytest.raises(ValueError):
+            PostFillCompletion(PostFillCompletionStatus.COMPLETE, member)
+
+
+# --- partial fill after a crash -------------------------------------------
+
+
+def test_partial_fill_after_crash_is_not_completed() -> None:
+    """Cumulative 1, only 0.4 observed → incomplete fill set → manual review."""
+
+    result = evaluate_post_fill_completion(
+        fill_evidence=FillEvidenceCompleteness.INCOMPLETE,
+        position_effect=PositionEffectEvidence.CONSISTENT,
+    )
+    assert result.reason is PostFillManualReviewReason.INCOMPLETE_FILL_EVIDENCE
+
+
+@pytest.mark.parametrize(
+    ("side", "before", "after", "filled", "expected"),
+    [
+        ("sell", "1", "0", "1", PositionEffectEvidence.CONSISTENT),
+        ("buy", "0", "1", "1", PositionEffectEvidence.CONSISTENT),
+        ("sell", "1", "1", "1", PositionEffectEvidence.INCONSISTENT),
+        ("sell", "1", "0", "2", PositionEffectEvidence.INCONSISTENT),
+        ("sell", "1", None, "1", PositionEffectEvidence.ABSENT),
+        ("sell", None, "0", "1", PositionEffectEvidence.ABSENT),
+        ("sell", "1", "0", None, PositionEffectEvidence.ABSENT),
+    ],
+)
+def test_position_effect_classification(
+    side: str,
+    before: str | None,
+    after: str | None,
+    filled: str | None,
+    expected: PositionEffectEvidence,
+) -> None:
+    assert (
+        classify_position_effect(
+            filled_qty=None if filled is None else Decimal(filled),
+            qty_before=None if before is None else Decimal(before),
+            qty_after=None if after is None else Decimal(after),
+            side=side,
+        )
+        is expected
+    )
+
+
+def test_unobserved_position_is_never_assumed_correct() -> None:
+    effect = classify_position_effect(
+        filled_qty=Decimal("1"), qty_before=None, qty_after=None, side="sell"
+    )
+    assert effect is PositionEffectEvidence.ABSENT
+    assert (
+        evaluate_post_fill_completion(
+            fill_evidence=FillEvidenceCompleteness.COMPLETE, position_effect=effect
+        ).status
+        is PostFillCompletionStatus.MANUAL_REVIEW
+    )
+
+
+# --- §4.3-8: timeout recovery makes no POST and no new identity -----------
+
+
+def test_timeout_recovery_reads_the_same_identity_and_posts_nothing() -> None:
+    transport = FakeBrokerTransport()
+    plan = plan_timeout_recovery(
+        client_order_id="cleanup-uber-001", evidence_lookup_available=True
+    )
+
+    assert plan.action is RecoveryAction.LOOKUP_EXISTING_ORDER_EVIDENCE
+    evidence = execute_recovery(plan, transport)
+
+    assert evidence == {"client_order_id": "cleanup-uber-001", "status": "filled"}
+    assert transport.post_count == 0
+    assert transport.issued_identities == []
+    assert transport.evidence_lookups == ["cleanup-uber-001"]
+
+
+def test_repeated_recovery_never_increments_the_post_count() -> None:
+    transport = FakeBrokerTransport()
+    for _ in range(5):
+        execute_recovery(
+            plan_timeout_recovery(
+                client_order_id="cleanup-uber-001", evidence_lookup_available=True
+            ),
+            transport,
+        )
+    assert transport.post_count == 0
+    assert set(transport.evidence_lookups) == {"cleanup-uber-001"}
+
+
+def test_unavailable_lookup_escalates_and_still_keeps_the_identity() -> None:
+    transport = FakeBrokerTransport()
+    plan = plan_timeout_recovery(
+        client_order_id="cleanup-uber-001", evidence_lookup_available=False
+    )
+    assert plan.action is RecoveryAction.ESCALATE_MANUAL_REVIEW
+    assert plan.client_order_id == "cleanup-uber-001"
+    assert execute_recovery(plan, transport) is None
+    assert transport.post_count == 0
+
+
+def test_recovery_action_enum_has_no_resend_variant() -> None:
+    values = {member.value for member in RecoveryAction}
+    assert not any(
+        token in value
+        for value in values
+        for token in ("resend", "resubmit", "retry", "repost", "new_identity")
+    )

--- a/tests/services/invalid_sample_eligibility/test_read_model.py
+++ b/tests/services/invalid_sample_eligibility/test_read_model.py
@@ -1,0 +1,263 @@
+"""ROB-1036 §4.3-3/10 — the read model requires an explicit predicate.
+
+Offline: the partition helper is pure, so the eligibility gate is provable
+without a database.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+
+import pytest
+
+from app.services.invalid_sample_eligibility.contract import (
+    CONTRACT_VERSION,
+    CalibrationEligibility,
+    EligibilityContractError,
+    EligibilityDecision,
+    EligibilitySubject,
+    EligibilitySubjectKind,
+    ForecastOutcomeObservability,
+    OperationalReliabilityEligibility,
+    TradePerformanceEligibility,
+    canonical_evidence_hash,
+    unidentifiable_decision,
+)
+from app.services.invalid_sample_eligibility.read_model import (
+    EligibilityDomain,
+    EligibilityPredicate,
+    build_eligible_forecast_calibration_aggregate,
+    partition_by_eligibility,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass(frozen=True)
+class FakeForecastRow:
+    """Only what the calibration aggregate reads."""
+
+    forecast_id: str
+    status: str = "closed"
+    brier_score: float | None = 0.09
+
+
+def _subject(ref: str) -> EligibilitySubject:
+    return EligibilitySubject(kind=EligibilitySubjectKind.FORECAST, ref=ref)
+
+
+def _decision(
+    ref: str,
+    *,
+    calibration: CalibrationEligibility,
+    trade: TradePerformanceEligibility = TradePerformanceEligibility.INCLUDE,
+    contract_version: str = CONTRACT_VERSION,
+) -> EligibilityDecision:
+    return EligibilityDecision(
+        subject=_subject(ref),
+        contract_version=contract_version,
+        revision_no=1,
+        supersedes_revision_no=None,
+        forecast_outcome_observability=ForecastOutcomeObservability.OBSERVABLE,
+        calibration_eligibility=calibration,
+        trade_performance_eligibility=trade,
+        operational_reliability_eligibility=OperationalReliabilityEligibility.INCLUDE,
+        decision_reason="test",
+        evidence_hash=canonical_evidence_hash({}),
+    )
+
+
+CALIBRATION_PREDICATE = EligibilityPredicate(
+    contract_version=CONTRACT_VERSION,
+    domain=EligibilityDomain.CALIBRATION,
+    admitted=frozenset({CalibrationEligibility.INCLUDE}),
+)
+TRADE_PREDICATE = EligibilityPredicate(
+    contract_version=CONTRACT_VERSION,
+    domain=EligibilityDomain.TRADE_PERFORMANCE,
+    admitted=frozenset({TradePerformanceEligibility.INCLUDE}),
+)
+
+
+# --- §4.3-3: excluded samples never re-enter -------------------------------
+
+
+def test_excluded_and_unidentifiable_rows_are_partitioned_out() -> None:
+    included_row = FakeForecastRow("f-included")
+    excluded_row = FakeForecastRow("f-excluded")
+    unknown_row = FakeForecastRow("f-unknown")
+
+    partition = partition_by_eligibility(
+        [
+            (
+                included_row,
+                _decision("f-included", calibration=CalibrationEligibility.INCLUDE),
+            ),
+            (
+                excluded_row,
+                _decision("f-excluded", calibration=CalibrationEligibility.EXCLUDE),
+            ),
+            (unknown_row, unidentifiable_decision(_subject("f-unknown"))),
+        ],
+        predicate=CALIBRATION_PREDICATE,
+    )
+
+    assert partition.included == [included_row]
+    assert partition.excluded == [excluded_row]
+    assert partition.unidentifiable == [unknown_row]
+    assert partition.counts == {"included": 1, "excluded": 1, "unidentifiable": 1}
+
+
+def test_partition_preserves_reasons_and_contract_version() -> None:
+    partition = partition_by_eligibility(
+        [
+            (
+                FakeForecastRow("f-excluded"),
+                _decision("f-excluded", calibration=CalibrationEligibility.EXCLUDE),
+            )
+        ],
+        predicate=CALIBRATION_PREDICATE,
+    )
+    payload = partition.as_dict()
+    assert payload["contract_version"] == CONTRACT_VERSION
+    assert payload["eligibility_domain"] == "calibration_eligibility"
+    assert payload["eligibility_counts"]["excluded"] == 1
+    assert payload["eligibility_reasons"] == {CalibrationEligibility.EXCLUDE.value: 1}
+
+
+def test_trade_performance_uses_its_own_domain_independently() -> None:
+    """Excluded from trade performance, still included in calibration."""
+
+    row = FakeForecastRow("f-1")
+    decision = _decision(
+        "f-1",
+        calibration=CalibrationEligibility.INCLUDE,
+        trade=TradePerformanceEligibility.EXCLUDE,
+    )
+
+    calibration = partition_by_eligibility(
+        [(row, decision)], predicate=CALIBRATION_PREDICATE
+    )
+    trade = partition_by_eligibility([(row, decision)], predicate=TRADE_PREDICATE)
+
+    assert calibration.included == [row]
+    assert trade.excluded == [row]
+
+
+def test_uber_shaped_decision_is_out_of_both_aggregates() -> None:
+    row = FakeForecastRow("f-uber")
+    decision = _decision(
+        "f-uber",
+        calibration=CalibrationEligibility.EXCLUDE,
+        trade=TradePerformanceEligibility.EXCLUDE,
+    )
+    assert (
+        partition_by_eligibility(
+            [(row, decision)], predicate=CALIBRATION_PREDICATE
+        ).included
+        == []
+    )
+    assert (
+        partition_by_eligibility([(row, decision)], predicate=TRADE_PREDICATE).included
+        == []
+    )
+
+
+def test_decision_under_another_contract_version_is_unidentifiable() -> None:
+    row = FakeForecastRow("f-legacy")
+    partition = partition_by_eligibility(
+        [
+            (
+                row,
+                _decision(
+                    "f-legacy",
+                    calibration=CalibrationEligibility.INCLUDE,
+                    contract_version="legacy-contract.v0",
+                ),
+            )
+        ],
+        predicate=CALIBRATION_PREDICATE,
+    )
+    assert partition.unidentifiable == [row]
+    assert partition.included == []
+
+
+# --- §4.3-10: the mutant must fail ----------------------------------------
+
+
+def test_removing_the_eligibility_filter_readmits_the_excluded_row() -> None:
+    """Mutation evidence: without the predicate gate, the exclusion vanishes.
+
+    The unfiltered pass-through is what a "just aggregate everything closed and
+    scored" implementation does. If this assertion ever matched the filtered
+    result, the filter would be doing nothing and the guard tests above would be
+    self-fulfilling.
+    """
+
+    row = FakeForecastRow("f-uber")
+    pairs = [(row, _decision("f-uber", calibration=CalibrationEligibility.EXCLUDE))]
+
+    filtered = partition_by_eligibility(pairs, predicate=CALIBRATION_PREDICATE)
+
+    def mutant_partition(items, *, predicate):  # filter removed
+        return [row for row, _decision in items]
+
+    mutated = mutant_partition(pairs, predicate=CALIBRATION_PREDICATE)
+
+    assert filtered.included == []
+    assert mutated == [row]
+    assert filtered.included != mutated
+
+
+def test_status_closed_plus_brier_alone_is_not_an_eligibility_predicate() -> None:
+    """A scored row with no decision is still not admitted."""
+
+    row = FakeForecastRow("f-scored", status="closed", brier_score=0.04)
+    partition = partition_by_eligibility(
+        [(row, unidentifiable_decision(_subject("f-scored")))],
+        predicate=CALIBRATION_PREDICATE,
+    )
+    assert partition.included == []
+    assert partition.unidentifiable == [row]
+
+
+# --- predicate hygiene ----------------------------------------------------
+
+
+def test_contract_version_and_predicate_are_required_keyword_arguments() -> None:
+    signature = inspect.signature(build_eligible_forecast_calibration_aggregate)
+    for name in ("contract_version", "predicate"):
+        parameter = signature.parameters[name]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is inspect.Parameter.empty
+
+
+def test_predicate_rejects_a_cross_domain_admitted_value() -> None:
+    with pytest.raises(EligibilityContractError) as excinfo:
+        EligibilityPredicate(
+            contract_version=CONTRACT_VERSION,
+            domain=EligibilityDomain.CALIBRATION,
+            admitted=frozenset({TradePerformanceEligibility.INCLUDE}),
+        )
+    assert excinfo.value.code == "cross_domain_predicate"
+
+
+def test_predicate_rejects_an_empty_admitted_set() -> None:
+    with pytest.raises(EligibilityContractError) as excinfo:
+        EligibilityPredicate(
+            contract_version=CONTRACT_VERSION,
+            domain=EligibilityDomain.CALIBRATION,
+            admitted=frozenset(),
+        )
+    assert excinfo.value.code == "empty_admitted_set"
+
+
+def test_predicate_rejects_a_blank_contract_version() -> None:
+    with pytest.raises(EligibilityContractError) as excinfo:
+        EligibilityPredicate(
+            contract_version="  ",
+            domain=EligibilityDomain.CALIBRATION,
+            admitted=frozenset({CalibrationEligibility.INCLUDE}),
+        )
+    assert excinfo.value.code == "missing_contract_version"

--- a/tests/services/invalid_sample_eligibility/test_read_model.py
+++ b/tests/services/invalid_sample_eligibility/test_read_model.py
@@ -11,6 +11,14 @@ from dataclasses import dataclass
 
 import pytest
 
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+    DECIDED_ONLY_CALIBRATION_COHORT,
+    DECIDED_ONLY_TRADE_PERFORMANCE_COHORT,
+    EligibilityDomain,
+    EligibilityPredicate,
+    partition_by_eligibility,
+)
 from app.services.invalid_sample_eligibility.contract import (
     CONTRACT_VERSION,
     CalibrationEligibility,
@@ -24,11 +32,8 @@ from app.services.invalid_sample_eligibility.contract import (
     canonical_evidence_hash,
     unidentifiable_decision,
 )
-from app.services.invalid_sample_eligibility.read_model import (
-    EligibilityDomain,
-    EligibilityPredicate,
-    build_eligible_forecast_calibration_aggregate,
-    partition_by_eligibility,
+from app.services.trade_journal.forecast_service import (
+    build_forecast_calibration_aggregate,
 )
 
 pytestmark = pytest.mark.unit
@@ -68,16 +73,8 @@ def _decision(
     )
 
 
-CALIBRATION_PREDICATE = EligibilityPredicate(
-    contract_version=CONTRACT_VERSION,
-    domain=EligibilityDomain.CALIBRATION,
-    admitted=frozenset({CalibrationEligibility.INCLUDE}),
-)
-TRADE_PREDICATE = EligibilityPredicate(
-    contract_version=CONTRACT_VERSION,
-    domain=EligibilityDomain.TRADE_PERFORMANCE,
-    admitted=frozenset({TradePerformanceEligibility.INCLUDE}),
-)
+CALIBRATION_PREDICATE = DECIDED_ONLY_CALIBRATION_COHORT
+TRADE_PREDICATE = DECIDED_ONLY_TRADE_PERFORMANCE_COHORT
 
 
 # --- §4.3-3: excluded samples never re-enter -------------------------------
@@ -229,7 +226,7 @@ def test_status_closed_plus_brier_alone_is_not_an_eligibility_predicate() -> Non
 
 
 def test_contract_version_and_predicate_are_required_keyword_arguments() -> None:
-    signature = inspect.signature(build_eligible_forecast_calibration_aggregate)
+    signature = inspect.signature(build_forecast_calibration_aggregate)
     for name in ("contract_version", "predicate"):
         parameter = signature.parameters[name]
         assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
@@ -242,6 +239,7 @@ def test_predicate_rejects_a_cross_domain_admitted_value() -> None:
             contract_version=CONTRACT_VERSION,
             domain=EligibilityDomain.CALIBRATION,
             admitted=frozenset({TradePerformanceEligibility.INCLUDE}),
+            label="test-cohort",
         )
     assert excinfo.value.code == "cross_domain_predicate"
 
@@ -252,6 +250,7 @@ def test_predicate_rejects_an_empty_admitted_set() -> None:
             contract_version=CONTRACT_VERSION,
             domain=EligibilityDomain.CALIBRATION,
             admitted=frozenset(),
+            label="test-cohort",
         )
     assert excinfo.value.code == "empty_admitted_set"
 
@@ -262,5 +261,80 @@ def test_predicate_rejects_a_blank_contract_version() -> None:
             contract_version="  ",
             domain=EligibilityDomain.CALIBRATION,
             admitted=frozenset({CalibrationEligibility.INCLUDE}),
+            label="test-cohort",
         )
     assert excinfo.value.code == "missing_contract_version"
+
+
+# --- D-1 option ② at the pure layer ---------------------------------------
+
+
+def test_compatibility_cohort_admits_undecided_but_counts_them_separately() -> None:
+    """The undecided rows enter the cohort AND stay visible as their own count."""
+
+    included_row = FakeForecastRow("f-included")
+    excluded_row = FakeForecastRow("f-excluded")
+    undecided_row = FakeForecastRow("f-undecided")
+
+    partition = partition_by_eligibility(
+        [
+            (
+                included_row,
+                _decision("f-included", calibration=CalibrationEligibility.INCLUDE),
+            ),
+            (
+                excluded_row,
+                _decision("f-excluded", calibration=CalibrationEligibility.EXCLUDE),
+            ),
+            (undecided_row, unidentifiable_decision(_subject("f-undecided"))),
+        ],
+        predicate=COMPATIBILITY_CALIBRATION_COHORT,
+    )
+
+    # Admitted into the cohort: decided inclusions + undecided.
+    assert partition.admitted == [included_row, undecided_row]
+    # Classification is unchanged by the wider admission — the counts still
+    # separate the two, and the excluded row is still held out.
+    assert partition.counts == {"included": 1, "excluded": 1, "unidentifiable": 1}
+    assert excluded_row not in partition.admitted
+
+
+def test_the_two_cohorts_classify_identically_and_admit_differently() -> None:
+    """Only admission differs, so compatibility and end-state stay comparable."""
+
+    rows = [
+        (
+            FakeForecastRow("f-included"),
+            _decision("f-included", calibration=CalibrationEligibility.INCLUDE),
+        ),
+        (
+            FakeForecastRow("f-undecided"),
+            unidentifiable_decision(_subject("f-undecided")),
+        ),
+    ]
+
+    compatibility = partition_by_eligibility(
+        rows, predicate=COMPATIBILITY_CALIBRATION_COHORT
+    )
+    decided_only = partition_by_eligibility(
+        rows, predicate=DECIDED_ONLY_CALIBRATION_COHORT
+    )
+
+    assert compatibility.counts == decided_only.counts
+    assert len(compatibility.admitted) == 2
+    assert len(decided_only.admitted) == 1
+    assert compatibility.cohort_label != decided_only.cohort_label
+    assert compatibility.cohort_stage != decided_only.cohort_stage
+
+
+def test_an_explicit_exclusion_is_never_admitted_by_any_shipped_cohort() -> None:
+    for cohort in (COMPATIBILITY_CALIBRATION_COHORT, DECIDED_ONLY_CALIBRATION_COHORT):
+        assert CalibrationEligibility.EXCLUDE not in cohort.admitted
+
+
+def test_no_shipped_cohort_is_labelled_strict() -> None:
+    """D-1: this transitional stage must not be presented as a final state."""
+
+    for cohort in (COMPATIBILITY_CALIBRATION_COHORT, DECIDED_ONLY_CALIBRATION_COHORT):
+        assert "strict" not in cohort.label.lower()
+        assert "strict" not in cohort.stage.lower()

--- a/tests/services/invalid_sample_eligibility/test_read_model.py
+++ b/tests/services/invalid_sample_eligibility/test_read_model.py
@@ -200,14 +200,17 @@ def test_removing_the_eligibility_filter_readmits_the_excluded_row() -> None:
 
     filtered = partition_by_eligibility(pairs, predicate=CALIBRATION_PREDICATE)
 
-    def mutant_partition(items, *, predicate):  # filter removed
-        return [row for row, _decision in items]
+    # The "mutant" is the unfiltered input itself — what an implementation that
+    # aggregated every closed+scored row would produce. Comparing the production
+    # function against its own input avoids defining a stand-in filter here.
+    # The authoritative source-level mutation lives in test_persistence.py
+    # (apply_eligibility_exclusion=False against the real SQL predicate).
+    unfiltered = [candidate for candidate, _ in pairs]
 
-    mutated = mutant_partition(pairs, predicate=CALIBRATION_PREDICATE)
-
+    assert unfiltered == [row]
     assert filtered.included == []
-    assert mutated == [row]
-    assert filtered.included != mutated
+    assert filtered.included != unfiltered
+    assert filtered.excluded == [row]
 
 
 def test_status_closed_plus_brier_alone_is_not_an_eligibility_predicate() -> None:

--- a/tests/services/invalid_sample_eligibility/test_static_boundaries.py
+++ b/tests/services/invalid_sample_eligibility/test_static_boundaries.py
@@ -1,0 +1,143 @@
+"""ROB-1036 §4.2-9 / §4.3-11 — service-layer-only writes, offline modules.
+
+Static AST guards, modelled on
+``tests/services/order_proposals/test_no_repository_imports.py``. No DB,
+broker, network, or account access anywhere in this file.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PACKAGE = REPO_ROOT / "app/services/invalid_sample_eligibility"
+
+_REPOSITORY_MODULE = "app.services.invalid_sample_eligibility.repository"
+_REPOSITORY_ALLOWED_IMPORTERS = {
+    pathlib.Path("app/services/invalid_sample_eligibility/service.py")
+}
+
+_ELIGIBILITY_TABLES = (
+    "sample_eligibility_decisions",
+    "invalid_sample_cleanup_bindings",
+    "invalid_sample_cleanup_lifecycle_events",
+)
+_WRITE_SQL_TOKENS = ("insert into", "update ", "delete from", "truncate ")
+
+# Pure modules must not reach a database, a broker, the network, or a clock.
+_PURE_MODULES = ("contract.py", "post_fill.py", "binding.py")
+_PURE_FORBIDDEN_PREFIXES = (
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "app.core.db",
+    "app.services.brokers",
+)
+
+
+def _module_names(path: pathlib.Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+        elif isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+    return names
+
+
+def _imports_repository(path: pathlib.Path) -> bool:
+    return any(
+        name == _REPOSITORY_MODULE or name.startswith(_REPOSITORY_MODULE + ".")
+        for name in _module_names(path)
+    )
+
+
+def test_repository_is_imported_only_by_the_service() -> None:
+    offenders = [
+        str(path.relative_to(REPO_ROOT))
+        for path in (REPO_ROOT / "app").rglob("*.py")
+        if path.relative_to(REPO_ROOT) not in _REPOSITORY_ALLOWED_IMPORTERS
+        and _imports_repository(path)
+    ]
+    assert not offenders, f"repository imported outside its service: {offenders}"
+
+
+def test_service_actually_imports_the_repository() -> None:
+    """Without this the boundary guard above would be vacuous."""
+
+    assert _imports_repository(PACKAGE / "service.py")
+
+
+def test_pure_modules_have_no_io_dependencies() -> None:
+    offenders: list[tuple[str, str]] = []
+    for module in _PURE_MODULES:
+        for name in _module_names(PACKAGE / module):
+            if any(name.startswith(prefix) for prefix in _PURE_FORBIDDEN_PREFIXES):
+                offenders.append((module, name))
+    assert not offenders, f"pure module reached I/O: {offenders}"
+
+
+def test_no_raw_sql_writes_to_the_eligibility_tables_anywhere_in_app() -> None:
+    """Every write goes through the ORM models via the service layer."""
+
+    offenders: list[tuple[str, str]] = []
+    for path in (REPO_ROOT / "app").rglob("*.py"):
+        lowered = path.read_text(encoding="utf-8").lower()
+        for table in _ELIGIBILITY_TABLES:
+            if table not in lowered:
+                continue
+            for token in _WRITE_SQL_TOKENS:
+                if token in lowered:
+                    # Only flag when the write token and the table name share a line.
+                    for line in lowered.splitlines():
+                        if table in line and token in line:
+                            offenders.append((str(path.relative_to(REPO_ROOT)), line))
+    assert not offenders, f"raw SQL write against an append-only table: {offenders}"
+
+
+def test_service_never_updates_or_deletes() -> None:
+    """The service module contains no ORM update/delete construct."""
+
+    source = (PACKAGE / "service.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_calls = {"update", "delete", "merge", "execute"}
+    offenders = [
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in forbidden_calls
+    ]
+    assert not offenders, f"service performs a mutation call: {offenders}"
+
+
+def test_repository_exposes_no_update_or_delete_method() -> None:
+    tree = ast.parse((PACKAGE / "repository.py").read_text(encoding="utf-8"))
+    method_names = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+    }
+    assert not any(
+        name.startswith(("update_", "delete_", "remove_", "purge_"))
+        for name in method_names
+    ), method_names
+
+
+def test_package_never_imports_a_broker_or_order_surface() -> None:
+    forbidden = ("app.services.brokers", "app.mcp_server", "app.services.alpaca_paper")
+    offenders: list[tuple[str, str]] = []
+    for path in PACKAGE.rglob("*.py"):
+        for name in _module_names(path):
+            if any(name.startswith(prefix) for prefix in forbidden):
+                offenders.append((path.name, name))
+    assert not offenders, f"eligibility package reached a broker surface: {offenders}"

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -147,6 +147,14 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             await connection.execute(
                 text("DROP TABLE review.watch_order_intent_ledger")
             )
+            # ROB-1036 is likewise later than this boundary; its three
+            # append-only tables are already in Base.metadata.
+            for table in (
+                "invalid_sample_cleanup_lifecycle_events",
+                "invalid_sample_cleanup_bindings",
+                "sample_eligibility_decisions",
+            ):
+                await connection.execute(text(f"DROP TABLE review.{table}"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -135,6 +135,14 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             await connection.execute(
                 text("DROP TABLE review.watch_order_intent_ledger")
             )
+            # ROB-1036 is likewise later than this boundary; its three
+            # append-only tables are already in Base.metadata.
+            for table in (
+                "invalid_sample_cleanup_lifecycle_events",
+                "invalid_sample_cleanup_bindings",
+                "sample_eligibility_decisions",
+            ):
+                await connection.execute(text(f"DROP TABLE review.{table}"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/test_decision_history.py
+++ b/tests/services/test_decision_history.py
@@ -30,6 +30,11 @@ from app.models.review import (
     TradeRetrospective,
 )
 from app.services.decision_history import build_decision_context
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+    COMPATIBILITY_STAGE,
+)
+from app.services.invalid_sample_eligibility.contract import CONTRACT_VERSION
 from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
 
 # ROB-723: these tests use the global committing ``db_session`` and touch the
@@ -251,11 +256,28 @@ async def test_brier_insufficient_sample_and_empty_returns_none(
         "n": 0,
         "mean_brier": None,
         "flag": "insufficient_sample",
+        # ROB-1036 D-1: the cohort that produced the number rides along, and the
+        # eligibility counts stay separate from ``n``.
+        "contract_version": CONTRACT_VERSION,
+        "eligibility_cohort": COMPATIBILITY_CALIBRATION_COHORT.label,
+        "eligibility_stage": COMPATIBILITY_STAGE,
+        "eligibility_counts": {"included": 0, "excluded": 0, "unidentifiable": 0},
     }
     # global Brier aggregates ALL closed+scored forecasts DB-wide; other suites'
     # committed rows leak in under xdist, so assert STRUCTURE only, not the flag.
     g = ctx["running_brier_global"]
-    assert set(g.keys()) == {"n", "mean_brier", "flag"}
+    assert set(g.keys()) == {
+        "n",
+        "mean_brier",
+        "flag",
+        "contract_version",
+        "eligibility_cohort",
+        "eligibility_stage",
+        "eligibility_counts",
+    }
+    # The undecided quantity is reported on its own, never folded into ``n``.
+    assert set(g["eligibility_counts"]) == {"included", "excluded", "unidentifiable"}
+    assert g["eligibility_stage"] == COMPATIBILITY_STAGE
     assert isinstance(g["n"], int)
 
     # a symbol with no history anywhere → None (nothing to inject)

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -12,6 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.review import TradeForecast
 from app.services.daily_candles.repository import DailyCandleRow
+from app.services.invalid_sample_eligibility.cohort import (
+    COMPATIBILITY_CALIBRATION_COHORT,
+)
+from app.services.invalid_sample_eligibility.contract import CONTRACT_VERSION
 from app.services.trade_journal import forecast_service as svc
 
 pytestmark = [
@@ -926,7 +930,13 @@ async def test_no_claim_placeholder_auto_closes_without_score_and_leaves_due_que
     assert row.brier_score is None
     assert row.resolved_at is not None
     assert await svc.list_due_forecasts(db_session) == []
-    assert (await svc.build_forecast_calibration_aggregate(db_session))["groups"] == []
+    assert (
+        await svc.build_forecast_calibration_aggregate(
+            db_session,
+            contract_version=CONTRACT_VERSION,
+            predicate=COMPATIBILITY_CALIBRATION_COHORT,
+        )
+    )["groups"] == []
 
 
 @pytest.mark.asyncio
@@ -1034,7 +1044,10 @@ async def test_calibration_aggregate_groups_by_created_by(db_session: AsyncSessi
     await _make("gpt", 0.9, True)
 
     agg = await svc.build_forecast_calibration_aggregate(
-        db_session, group_by="created_by"
+        db_session,
+        contract_version=CONTRACT_VERSION,
+        predicate=COMPATIBILITY_CALIBRATION_COHORT,
+        group_by="created_by",
     )
     assert agg["group_by"] == "created_by"
     groups = {g["group"]: g for g in agg["groups"]}


### PR DESCRIPTION
Implements `uber-invalid-sample-eligibility.v1` — the additive eligibility record and
contract-compatible post-fill writer for the `alpaca_paper_lab` UBER
`invalid_sample_cleanup` case.

This PR **only adds the contract**. It does not record the UBER decision, place or
reconcile an order, resolve a forecast, apply a migration, or register a scheduler.

## The blocker this removes

`uber-d2-execution-readiness-2026-07-30.md` / `uber-d2-execution-result-2026-07-31.md`
recorded `EXECUTION_RESULT=BLOCKED_STATIC_CONTRACT_GAP` / `SUBMIT_RESULT=NO_SUBMIT`.
The order boundary was fine; there was no way to record "invalid sample" without
either calling `forecast_resolve(dry_run=false)` (which books outcome + Brier and so
violates *exclude from strategy performance*) or leaving the approved post-fill step
unfinished. Eligibility is now a separate append-only record, not a side effect of
resolution.

## Four validity domains, never one bit

`forecast_outcome_observability` · `calibration_eligibility` ·
`trade_performance_eligibility` · `operational_reliability_eligibility`

Four distinct enums with disjoint value sets, so a cross-domain assignment raises
`TypeError`. `EligibilityDecision` exposes no `is_valid`/`eligible`/`success`
aggregate (guard test asserts absence).

The fixed UBER shape: observability `blocked_pending_audit_evidence` (retained, **not**
discarded), calibration `exclude`, trade performance `exclude`, operational `include`.

## Append-only, not mutable

- `revision_no` starts at 1; every later revision has `supersedes_revision_no =
  revision_no - 1` (CHECK) → gap / branch / cycle are unrepresentable
- unique `(subject_kind, subject_ref, revision_no)`; partial unique index on
  `supersedes_revision_no` blocks two revisions claiming one predecessor
- `BEFORE UPDATE OR DELETE OR TRUNCATE` triggers on all three tables
- `evidence_hash` recomputed on every read; a tampered row raises
  `evidence_hash_mismatch` rather than being returned
- a correction is a superseding revision; only the latest revision decides

## Fail-closed default

No decision row → `UNIDENTIFIABLE` in all four domains. No `COALESCE(..., INCLUDE)`.
The migration inserts **zero** rows — no historical backfill.

## Read models

`build_eligible_forecast_calibration_aggregate(db, *, contract_version, predicate, …)`
— both required keyword-only with no default — returns the calibration groups plus
`eligibility_counts` (included/excluded/unidentifiable), `eligibility_reasons`, and the
contract version. `status='closed' AND brier_score IS NOT NULL` is explicitly not an
eligibility predicate.

The legacy `build_forecast_calibration_aggregate` additionally drops forecasts whose
latest revision says `calibration_exclude`, so an invalid sample cannot re-enter
through it. Rows with **no** decision keep their existing behaviour — this is a
re-entry guard, not a backfill.

## Post-fill completion + recovery

`evaluate_post_fill_completion` returns `COMPLETE` only when broker fill evidence is
`COMPLETE` **and** the position effect is `CONSISTENT` — exactly 1 of 9 combinations;
the other 8 are typed manual-review reasons. `plan_timeout_recovery` only looks up the
**same** `client_order_id`; `RecoveryAction` has no resend variant and
`broker_post_allowed` / `new_identity_allowed` are `Literal[False]` properties.
Verified with a fake transport (`post_count == 0`, `issued_identities == []`).

## Service-layer-only writes

`InvalidSampleEligibilityService` is the only writer. Static AST guards enforce: the
repository is service-private, the pure modules import no SQLAlchemy/HTTP/broker, no
raw SQL write names these tables anywhere in `app/`, the service makes no
`update`/`delete`/`execute` call, and the package imports no broker / MCP / Alpaca
order surface.

## Migration

`20260802_rob1036_sample_elig` (down: `20260728_rob1109_watch_intent`, single head).
Purely additive: three new `review` tables + indexes + the
`review.reject_invalid_sample_mutation()` trigger function. Nothing existing is
altered. **Not applied to any runtime DB by this PR** — operator cutover in runbook §11.

Upgrade → downgrade → upgrade verified in a throwaway database created for the test
alone.

## Tests

98 passed (`tests/services/invalid_sample_eligibility/`), plus 58 regression tests
across `test_forecast_service.py`, `test_alembic_revision_ids.py`,
`test_import_contracts.py`, `test_invest_forecasts_router.py`, `test_forecast_web_read.py`.
`ruff check` / `ruff format --check` clean repo-wide; `ty check app` clean.

Mutation evidence for the eligibility filter is explicit in both directions —
`test_removing_the_eligibility_filter_readmits_the_excluded_row` (pure) and
`test_removing_the_sql_exclusion_readmits_the_excluded_forecast` (DB) both assert the
excluded row **reappears** when the filter is removed, so the guard tests cannot be
self-fulfilling.

## Not done here

no broker/account call · no preview/order/cancel/reconcile/position · no UBER
outcome/price/Brier lookup or `forecast_resolve` · no cleanup retry · no runtime
migration apply or backfill · no scheduler/cron/TaskIQ/Prefect · no deploy · no MCP
tool · no third Alpaca keyset · `ROB-1204` physical-account identity untouched

## Note for reviewers

Four files are also touched (additively) by open PR #1751 (ROB-1195, separate lane):
`app/models/__init__.py`, `tests/_schema_bootstrap.py`,
`tests/services/paper_cohort/test_migration.py`, and
`tests/services/paper_evaluation/test_migration.py`. Whichever merges second needs a
trivial rebase on those; there is no semantic overlap. Both PRs also add a new alembic
head off the same parent, so the second to merge must re-point its `down_revision` and
extend the two migration-acceptance drop lists for the other's tables.

The last two commits fix CI, not design:
- `b8446ca` — the ROB-285 guard is a plain text scan (`grep -rln -i binance
  --include=*.py app/`), and a docstring citing a precedent tripped it. The word is
  gone; **no allowlist was extended** (`ALLOWED_LEGACY_FILES` / `ALLOWED_PACKAGE_PATHS`
  untouched), and this PR's diff now contains zero `/binance/i` lines.
- `0d977db` — the ROB-849/ROB-850 migration acceptance tests reconstruct a pre-boundary
  DB via `create_all` + drop-the-newer-tables + stamp + replay. A new head makes their
  drop lists incomplete, so they hit `DuplicateTableError`. Extended both lists exactly
  as ROB-1109/ROB-1115 did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sample eligibility decisions with included, excluded, and unidentifiable classifications.
  * Calibration results now show eligibility cohort, contract version, processing stage, and eligibility counts.
  * Trade-performance reporting excludes explicitly ineligible samples while preserving undecided results.
  * Added safeguards for invalid-sample cleanup, post-fill verification, timeout recovery, and duplicate event handling.
* **Documentation**
  * Added an operational runbook covering eligibility, calibration, cleanup, and recovery workflows.
* **Bug Fixes**
  * Preserved forecast outcomes while applying eligibility filtering to calibration and performance evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->