### PR TITLE
fix(ROB-1205): compare linked Binance instrument by venue_symbol

### DIFF
--- a/app/services/paper_evaluation/evidence.py
+++ b/app/services/paper_evaluation/evidence.py
@@ -811,7 +811,11 @@ class AuthoritativeEvidenceReader:
                 if (
                     row is None
                     or instrument is None
-                    or instrument.symbol != link.symbol
+                    # ``crypto_instruments`` names the exchange symbol
+                    # ``venue_symbol``; for a Binance spot instrument that is
+                    # the same notation the link carries (``BTCUSDT``), which is
+                    # why this is an equality check and not a mapping.
+                    or instrument.venue_symbol != link.symbol
                     or row.client_order_id != link.client_order_id
                     or str(row.broker_order_id) != link.broker_order_id
                     or row.lifecycle_state not in {"filled", "closed", "reconciled"}

--- a/app/services/paper_evaluation/evidence.py
+++ b/app/services/paper_evaluation/evidence.py
@@ -648,6 +648,14 @@ class AuthoritativeEvidenceReader:
         tuple[NativeMark, ...],
         datetime,
     ]:
+        # The authoritative product for every native row in this evaluation.
+        # ``paper_run_order_links`` carries venue and symbol but no product, and
+        # the cohort row is the only lineage-bound source of it (DB CHECK
+        # ``market = 'spot'``).  Resolve it once and fail closed rather than
+        # letting a per-row default decide what a link "meant".
+        expected_product = cohort.market
+        if not expected_product:
+            _fail("missing_evidence", "cohort market missing")
         rows = (
             await self._session.execute(
                 select(
@@ -811,6 +819,19 @@ class AuthoritativeEvidenceReader:
                 if (
                     row is None
                     or instrument is None
+                    # ``crypto_instruments`` identity is the whole triple
+                    # ``(venue, product, venue_symbol)`` — the unique constraint
+                    # is on all three, so ``venue_symbol`` alone identifies
+                    # nothing.  ``binance/usdm_futures/BTCUSDT`` is a real row
+                    # shape (scripts/binance_futures_demo_smoke.py seeds it), so
+                    # a spot ledger row pointing at the futures instrument of
+                    # the same symbol would otherwise be accepted and book
+                    # cross-product fill evidence silently.  Bind the ledger row
+                    # and the instrument to the cohort's product, and the
+                    # instrument to the link's venue.
+                    or row.product != expected_product
+                    or instrument.venue != link.venue
+                    or instrument.product != expected_product
                     # ``crypto_instruments`` names the exchange symbol
                     # ``venue_symbol``; for a Binance spot instrument that is
                     # the same notation the link carries (``BTCUSDT``), which is

--- a/tests/services/paper_evaluation/test_evidence_native_binance.py
+++ b/tests/services/paper_evaluation/test_evidence_native_binance.py
@@ -1,0 +1,578 @@
+"""ROB-1205 — the Binance link branch of ``_load_native`` executed for real.
+
+Every other test of :class:`AuthoritativeEvidenceReader` either mocks the
+session, substitutes a fake reader, or asserts on ``inspect.getsource``
+strings.  None of them reach ``_load_native``'s per-link Binance identity
+check, which is why ``instrument.symbol`` (an attribute
+:class:`CryptoInstrument` has never had) survived on ``main``.
+
+These tests build the lineage with the production
+:class:`PaperCohortRunner` — snapshot, decision, intent, link and both
+native ledger rows are produced by shipping code, not hand-written — and
+then drive ``load()`` end to end so the identity comparison is actually
+evaluated.  Inverting or deleting that comparison must turn one of them
+red.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
+from app.models.crypto_instruments import CryptoInstrument
+from app.models.paper_cohort import (
+    PaperRunOrderLink,
+    PaperValidationCohort,
+)
+from app.models.paper_evaluation import EvaluationConfig as EvaluationConfigRow
+from app.models.paper_evaluation import EvaluationEpoch as EvaluationEpochRow
+from app.models.paper_validation import PaperValidationStateTransition
+from app.models.research_backtest import (
+    ResearchBacktestRun,
+    ResearchStrategyExperiment,
+)
+from app.models.review import AlpacaPaperOrderLedger
+from app.services.brokers.capabilities import Broker
+from app.services.brokers.paper.application import PaperExecutionApplication
+from app.services.brokers.paper.contracts import (
+    PaperOperation,
+    PaperOperationResult,
+    PaperOperationStatus,
+)
+from app.services.paper_cohort.cohort_service import PaperCohortService
+from app.services.paper_cohort.contracts import (
+    CohortAssignmentInput,
+    PaperCohortError,
+    RunMode,
+    SymbolTargetWeight,
+)
+from app.services.paper_cohort.native_links import NativeOrderIdentity
+from app.services.paper_cohort.provenance import PaperCohortProvenanceVerifier
+from app.services.paper_cohort.runner import CohortRunInvocation, PaperCohortRunner
+from app.services.paper_evaluation.contracts import EvaluationConfigError
+from app.services.paper_evaluation.evidence import AuthoritativeEvidenceReader
+from app.services.paper_validation.contracts import ActorRole
+from app.services.paper_validation.service import PaperValidationService
+from tests.services.paper_cohort.test_cohort_service import _activation
+from tests.services.paper_cohort.test_market_snapshot import CAPTURED_AT
+from tests.services.paper_cohort.test_runner_shadow import FakeCapture, FakeQuotes
+from tests.services.paper_evaluation.conftest import make_evaluation_config
+from tests.services.paper_validation.conftest import (
+    FakeActorRoleProvider,
+    FakeFrozenInputHashProvider,
+    FakePolicyHashProvider,
+    stable_hash,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    # Same rationale as tests/services/paper_cohort/test_runner_paper_active.py:
+    # this file writes review.alpaca_paper_order_ledger rows through the global
+    # ``db_session``, so it must hold the ROB-968 cleanup advisory lock.
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+SHADOW_START = CAPTURED_AT - timedelta(hours=2)
+PAPER_START = CAPTURED_AT - timedelta(hours=1)
+# ``FakeQuotes`` marks at CAPTURED_AT + 300ms; a fill must land at or before the
+# resolved as-of mark or ``_load_native`` drops it from the window.
+FILLED_AT = CAPTURED_AT + timedelta(milliseconds=200)
+ALPACA_SYMBOL = {"BTCUSDT": "BTC/USD", "ETHUSDT": "ETH/USD"}
+COHORT_SYMBOLS = ("BTCUSDT", "ETHUSDT")
+
+
+def _evaluated_at() -> datetime:
+    # ``paper_run_order_links.created_at`` is a server-side ``now()`` and the
+    # loader filters ``link.created_at <= end``.
+    return datetime.now(UTC) + timedelta(hours=1)
+
+
+@pytest.fixture(autouse=True)
+def _enabled_server_flags(monkeypatch) -> None:
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "PAPER_COHORT_ENABLED", True)
+    monkeypatch.setattr(settings, "PAPER_EXECUTION_ENABLED", True)
+
+
+@dataclass
+class _RecordingAdapter:
+    """Paper adapter that remembers which cohort symbol each order carries."""
+
+    broker: Broker
+    symbol_by_client: dict[str, str]
+
+    async def submit(self, intent):
+        suffix = stable_hash(f"{self.broker.value}:{intent.idempotency_key}")[:16]
+        client_order_id = f"client-{suffix}"
+        self.symbol_by_client[client_order_id] = intent.symbol
+        return PaperOperationResult(
+            operation=PaperOperation.SUBMIT,
+            status=PaperOperationStatus.SUCCEEDED,
+            reason_code="ok",
+            venue=self.broker,
+            native_order_id=f"broker-{suffix}",
+            native_client_order_id=client_order_id,
+        )
+
+    async def cancel(self, intent):  # pragma: no cover - unused by these tests
+        raise AssertionError("no cancel in this fixture")
+
+
+@dataclass
+class _Registry:
+    adapters: dict[Broker, _RecordingAdapter]
+
+    def resolve(self, broker: Broker) -> _RecordingAdapter:
+        return self.adapters[broker]
+
+
+async def _instrument_id(session: AsyncSession, venue_symbol: str) -> int:
+    """Resolve-or-create the ``(binance, spot, venue_symbol)`` identity.
+
+    Mirrors ``BinanceDemoLedgerRepository.resolve_or_create_instrument``: the
+    triple is unique, so a row seeded by an earlier test must be reused rather
+    than duplicated.
+    """
+    existing = await session.scalar(
+        select(CryptoInstrument).where(
+            CryptoInstrument.venue == "binance",
+            CryptoInstrument.product == "spot",
+            CryptoInstrument.venue_symbol == venue_symbol,
+        )
+    )
+    if existing is not None:
+        return existing.id
+    instrument = CryptoInstrument(
+        venue="binance",
+        product="spot",
+        venue_symbol=venue_symbol,
+        base_asset=venue_symbol.removesuffix("USDT"),
+        quote_asset="USDT",
+        status="active",
+    )
+    session.add(instrument)
+    await session.flush()
+    return instrument.id
+
+
+@dataclass
+class _LedgerBackedNativeResolver:
+    """Materialise a real native ledger row for each submitted order.
+
+    ``instrument_venue_symbol`` maps the cohort symbol to the
+    ``crypto_instruments.venue_symbol`` the Binance ledger row points at, so a
+    test can bind a link to a deliberately wrong instrument.
+    """
+
+    session: AsyncSession
+    symbol_by_client: dict[str, str]
+    instrument_venue_symbol: dict[str, str] = field(
+        default_factory=lambda: {symbol: symbol for symbol in COHORT_SYMBOLS}
+    )
+
+    async def resolve(
+        self, venue: str, client_order_id: str, broker_order_id: str
+    ) -> NativeOrderIdentity:
+        symbol = self.symbol_by_client[client_order_id]
+        if venue == "binance":
+            row: BinanceDemoOrderLedger | AlpacaPaperOrderLedger = (
+                BinanceDemoOrderLedger(
+                    instrument_id=await _instrument_id(
+                        self.session, self.instrument_venue_symbol[symbol]
+                    ),
+                    product="spot",
+                    venue_host="demo-api.binance.com",
+                    client_order_id=client_order_id,
+                    broker_order_id=broker_order_id,
+                    side="BUY",
+                    order_type="MARKET",
+                    qty=Decimal("1"),
+                    # ``filled`` is a *blocking root* state: the partial-unique
+                    # index allows one per (product, instrument), and these
+                    # tests deliberately share the real BTCUSDT/ETHUSDT
+                    # instrument rows. A settled round trip is terminal anyway,
+                    # and the reader accepts filled/closed/reconciled alike.
+                    lifecycle_state="reconciled",
+                    filled_at=FILLED_AT,
+                    closed_at=FILLED_AT,
+                    reconciled_at=FILLED_AT,
+                    extra_metadata={
+                        "filled_qty": "1",
+                        "filled_avg_price": "100",
+                        "fee_usdt": "0.1",
+                    },
+                )
+            )
+            kind = "binance_demo_order_ledger"
+        else:
+            row = AlpacaPaperOrderLedger(
+                client_order_id=client_order_id,
+                broker_order_id=broker_order_id,
+                lifecycle_correlation_id=f"corr-{uuid4().hex[:12]}",
+                record_kind="execution",
+                broker="alpaca",
+                account_mode="alpaca_paper_lab",
+                lifecycle_state="filled",
+                # The Alpaca paper intent already carries the venue symbol.
+                execution_symbol=ALPACA_SYMBOL.get(symbol, symbol),
+                execution_venue="alpaca_paper",
+                instrument_type="equity_us",
+                side="buy",
+                order_type="market",
+                currency="USD",
+                requested_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                filled_avg_price=Decimal("100"),
+                fee_amount=Decimal("0"),
+                fee_currency="USD",
+                raw_responses={"filled_at": FILLED_AT.isoformat()},
+            )
+            kind = "alpaca_paper_order_ledger"
+        self.session.add(row)
+        await self.session.flush()
+        return NativeOrderIdentity(
+            venue=venue,
+            ledger_kind=kind,
+            ledger_row_id=row.id,
+            client_order_id=client_order_id,
+            broker_order_id=broker_order_id,
+        )
+
+    async def resolve_prepared(  # pragma: no cover - recovery path unused here
+        self, request, provenance
+    ) -> NativeOrderIdentity:
+        del request, provenance
+        raise PaperCohortError("native_order_not_found")
+
+
+async def _authoritative_history(session: AsyncSession, activation) -> None:
+    """Seed the transition path with explicit gate timestamps.
+
+    ``_authoritative_history`` in the cohort-service tests relies on a
+    server-side ``now()``, which cannot satisfy the reader's
+    ``shadow_start < paper_start`` window check.
+    """
+    path = ["draft", "offline_eligible", "shadow_soak", "paper_active"]
+    stamps = {"shadow_soak": SHADOW_START, "paper_active": PAPER_START}
+    for assignment in activation.assignments:
+        for sequence, new_state in enumerate(path, start=1):
+            session.add(
+                PaperValidationStateTransition(
+                    validation_id=assignment.validation_id,
+                    validation_version=assignment.validation_version,
+                    experiment_id=assignment.experiment_id,
+                    strategy_version_id=assignment.strategy_version_id,
+                    cohort_id=activation.cohort_id,
+                    sequence=sequence,
+                    idempotency_key=f"activate-{assignment.validation_id}-{sequence}",
+                    request_hash=stable_hash(
+                        f"request-{assignment.validation_id}-{sequence}"
+                    ),
+                    prior_state=None if sequence == 1 else path[sequence - 2],
+                    new_state=new_state,
+                    actor_id="operator-1",
+                    actor_role="operator",
+                    reason_code="test_evidence",
+                    reason_text="ROB-1205 native evidence history",
+                    experiment_hash=assignment.experiment_hash,
+                    cohort_hash=activation.expected_cohort_hash,
+                    strategy_hash=assignment.strategy_hash,
+                    config_hash=assignment.config_hash,
+                    policy_hash=assignment.policy_hash,
+                    input_hash=assignment.input_hash,
+                    input_bundle_id=f"bundle-{assignment.assignment_id}",
+                    policy_version="policy-v1",
+                    evidence_ids=["evidence-1"],
+                    created_at=stamps.get(new_state, SHADOW_START - timedelta(hours=1)),
+                )
+            )
+    await session.flush()
+
+
+@dataclass(frozen=True)
+class _Lineage:
+    cohort_id: str
+    assignment_id: str
+    links: tuple[PaperRunOrderLink, ...]
+
+
+async def _build_lineage(
+    session: AsyncSession, *, instrument_venue_symbol: dict[str, str] | None = None
+) -> _Lineage:
+    """Run the production paper-active pipeline and seed the evaluation epoch."""
+    nonce = uuid4().hex
+    config = make_evaluation_config(min_observations=1, min_fills=1)
+    experiment = ResearchStrategyExperiment(
+        experiment_id=stable_hash(f"experiment-{nonce}"),
+        strategy_key=f"strategy-{nonce}",
+        strategy_version="strategy-v1",
+        strategy_hash=stable_hash(f"strategy-{nonce}"),
+        code_hash=stable_hash(f"code-{nonce}"),
+        params_hash=stable_hash(f"params-{nonce}"),
+        dataset_manifest_hash=stable_hash(f"dataset-{nonce}"),
+        universe_hash=stable_hash(f"universe-{nonce}"),
+        pit_hash=stable_hash(f"pit-{nonce}"),
+        # The evaluation epoch is keyed by the assignment's config hash, so the
+        # frozen experiment config and the evaluation config must agree.
+        frozen_config_hash=config.config_hash(),
+        policy_hash=stable_hash(f"policy-{nonce}"),
+        benchmark_hash=stable_hash(f"benchmark-{nonce}"),
+        cost_hash=stable_hash(f"cost-{nonce}"),
+        mdd_hash=stable_hash(f"mdd-{nonce}"),
+        manifest={},
+    )
+    session.add(experiment)
+    await session.flush()
+    backtest = ResearchBacktestRun(
+        run_id=f"backtest-{nonce}",
+        strategy_name=experiment.strategy_key,
+        strategy_version=experiment.strategy_version,
+        exchange="binance",
+        market="spot",
+        timeframe="1m",
+        runner="pytest",
+        total_trades=10,
+        profit_factor=Decimal("1.2"),
+        max_drawdown=Decimal("0.1"),
+        strategy_experiment_id=experiment.id,
+        trial_index=1,
+        trial_status="completed",
+        trial_idempotency_key=f"trial-{nonce}",
+    )
+    session.add(backtest)
+    await session.flush()
+
+    assignment_input = CohortAssignmentInput(
+        assignment_id=f"assignment-{nonce}-0",
+        ordinal=0,
+        role="champion",
+        validation_id=f"validation-{nonce}-0",
+        validation_version=1,
+        experiment_id=experiment.experiment_id,
+        source_backtest_run_id=backtest.id,
+        strategy_version_id=experiment.strategy_version,
+        target_weights=(
+            SymbolTargetWeight(symbol="BTCUSDT", weight=Decimal("0.6")),
+            SymbolTargetWeight(symbol="ETHUSDT", weight=Decimal("0.4")),
+        ),
+        experiment_hash=experiment.experiment_id,
+        strategy_hash=experiment.strategy_hash,
+        config_hash=experiment.frozen_config_hash,
+        policy_hash=experiment.policy_hash,
+        input_hash=stable_hash(f"input-{nonce}"),
+    )
+    activation = _activation((assignment_input,), nonce=nonce).model_copy(
+        update={"required_lookback": 3}
+    )
+    activation = activation.model_copy(
+        update={"expected_cohort_hash": activation.computed_cohort_hash()}
+    )
+    await _authoritative_history(session, activation)
+    await PaperCohortService(session).activate(activation)
+    await session.commit()
+
+    validation = PaperValidationService(
+        session,
+        actor_role_provider=FakeActorRoleProvider(
+            {"paper-cohort-runner": ActorRole.SYSTEM}
+        ),
+        frozen_input_provider=FakeFrozenInputHashProvider(assignment_input.input_hash),
+        policy_provider=FakePolicyHashProvider(assignment_input.policy_hash),
+    )
+    symbol_by_client: dict[str, str] = {}
+    runner = PaperCohortRunner(
+        session,
+        capture=FakeCapture(),
+        quote_provider=FakeQuotes(session),
+        verifier=PaperCohortProvenanceVerifier(
+            session,
+            validation_service=validation,
+            caller_id="paper-cohort-runner",
+            clock=lambda: CAPTURED_AT + timedelta(seconds=1),
+        ),
+        application_factory=lambda verifier: PaperExecutionApplication(
+            registry=_Registry(
+                {
+                    Broker.BINANCE: _RecordingAdapter(Broker.BINANCE, symbol_by_client),
+                    Broker.ALPACA: _RecordingAdapter(Broker.ALPACA, symbol_by_client),
+                }
+            ),
+            verifier=verifier,
+        ),
+        native_resolver=_LedgerBackedNativeResolver(
+            session,
+            symbol_by_client,
+            instrument_venue_symbol=(
+                instrument_venue_symbol
+                if instrument_venue_symbol is not None
+                else {symbol: symbol for symbol in COHORT_SYMBOLS}
+            ),
+        ),
+        clock=lambda: CAPTURED_AT + timedelta(milliseconds=300),
+        enablement=lambda _mode: True,
+    )
+    result = await runner.run(
+        CohortRunInvocation(
+            cohort_id=activation.cohort_id,
+            run_id=f"run-{nonce}",
+            round_decision_id=f"round-{nonce}",
+            mode=RunMode.PAPER_ACTIVE,
+        )
+    )
+    await session.commit()
+    assert result.intent_count == 4
+
+    links = tuple(
+        (
+            await session.scalars(
+                select(PaperRunOrderLink).where(
+                    PaperRunOrderLink.run_id == f"run-{nonce}"
+                )
+            )
+        ).all()
+    )
+    assert {(link.venue, link.symbol) for link in links} == {
+        (venue, symbol) for venue in ("binance", "alpaca") for symbol in COHORT_SYMBOLS
+    }
+
+    cohort = await session.scalar(
+        select(PaperValidationCohort).where(
+            PaperValidationCohort.cohort_id == activation.cohort_id
+        )
+    )
+    assert cohort is not None
+    # ``evaluation_configs`` is content-addressed and immutable, so a config
+    # hash seeded by an earlier test is the same row, not a conflict.
+    if (
+        await session.scalar(
+            select(EvaluationConfigRow).where(
+                EvaluationConfigRow.config_hash == config.config_hash()
+            )
+        )
+        is None
+    ):
+        session.add(
+            EvaluationConfigRow(
+                config_hash=config.config_hash(),
+                schema_id="paper_evaluation_config.v1",
+                formula_version="v1",
+                currency_conversion_policy="none",
+                payload=config.model_dump(mode="json"),
+            )
+        )
+        await session.flush()
+    session.add(
+        EvaluationEpochRow(
+            epoch_id=f"epoch-{nonce}",
+            assignment_id=assignment_input.assignment_id,
+            validation_id=assignment_input.validation_id,
+            cohort_id=activation.cohort_id,
+            config_hash=config.config_hash(),
+            initial_equity={
+                view.value: str(amount)
+                for view, amount in config.initial_equity.items()
+            },
+            started_at=PAPER_START,
+            experiment_hash=assignment_input.experiment_hash,
+            cohort_hash=cohort.cohort_hash,
+        )
+    )
+    await session.commit()
+    return _Lineage(
+        cohort_id=activation.cohort_id,
+        assignment_id=assignment_input.assignment_id,
+        links=links,
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_assembles_binance_fills_from_linked_instrument_identity(
+    db_session: AsyncSession,
+) -> None:
+    """``load()`` completes and returns the Binance fills for real linked rows.
+
+    The Binance branch resolves ``CryptoInstrument`` and compares it against
+    the link, so this asserts on the assembled output rather than on source
+    text.  Comparing the wrong instrument attribute raises ``AttributeError``;
+    comparing the right one against the wrong link fails ``cross_wired``.
+    """
+    lineage = await _build_lineage(db_session)
+    reader = AuthoritativeEvidenceReader(db_session)
+
+    evidence = await reader.load(
+        evaluated_at=_evaluated_at(),
+        cohort_id=lineage.cohort_id,
+        assignment_id=lineage.assignment_id,
+    )
+
+    binance_links = {
+        link.symbol: link for link in lineage.links if link.venue == "binance"
+    }
+    assert {fill.symbol for fill in evidence.binance_fills} == set(COHORT_SYMBOLS)
+    for fill in evidence.binance_fills:
+        link = binance_links[fill.symbol]
+        assert fill.native_row_id == link.native_ledger_row_id
+        assert fill.client_order_id == link.client_order_id
+        assert fill.broker_order_id == link.broker_order_id
+        assert fill.quantity == Decimal("1")
+        assert fill.price == Decimal("100")
+        assert fill.fee == Decimal("0.1")
+    # The instrument identity is what the branch under test resolves; confirm
+    # the row it accepted really is the one the link names.
+    for symbol, link in binance_links.items():
+        ledger = await db_session.get(BinanceDemoOrderLedger, link.native_ledger_row_id)
+        assert ledger is not None
+        instrument = await db_session.get(CryptoInstrument, ledger.instrument_id)
+        assert instrument is not None
+        assert instrument.venue_symbol == symbol
+    assert {fill.symbol for fill in evidence.alpaca_fills} == {"BTC/USD", "ETH/USD"}
+
+
+@pytest.mark.asyncio
+async def test_load_rejects_binance_row_bound_to_another_symbols_instrument(
+    db_session: AsyncSession,
+) -> None:
+    """A Binance ledger row pointing at the wrong instrument must fail closed.
+
+    Both instruments are real, active ``(binance, spot)`` rows — only the
+    symbol binding is crossed.  Dropping the instrument-identity comparison
+    lets this evidence through, so this test is what keeps that comparison
+    alive.
+    """
+    lineage = await _build_lineage(
+        db_session,
+        instrument_venue_symbol={"BTCUSDT": "ETHUSDT", "ETHUSDT": "BTCUSDT"},
+    )
+    reader = AuthoritativeEvidenceReader(db_session)
+
+    with pytest.raises(EvaluationConfigError) as exc:
+        await reader.load(
+            evaluated_at=_evaluated_at(),
+            cohort_id=lineage.cohort_id,
+            assignment_id=lineage.assignment_id,
+        )
+    assert exc.value.reason_code == "cross_wired_evidence"
+    assert str(exc.value) == "linked Binance row mismatch"
+
+
+@pytest.mark.asyncio
+async def test_assignment_identity_is_required_before_any_native_read(
+    db_session: AsyncSession,
+) -> None:
+    """The reader still refuses ambiguous identity against a real session."""
+    reader = AuthoritativeEvidenceReader(db_session)
+    with pytest.raises(EvaluationConfigError) as exc:
+        await reader.load(
+            evaluated_at=_evaluated_at(),
+            validation_id="validation-x",
+            cohort_id="cohort-x",
+        )
+    assert exc.value.reason_code == "invalid_evaluation_identity"

--- a/tests/services/paper_evaluation/test_evidence_native_binance.py
+++ b/tests/services/paper_evaluation/test_evidence_native_binance.py
@@ -30,6 +30,7 @@ from app.models.crypto_instruments import CryptoInstrument
 from app.models.paper_cohort import (
     PaperRunOrderLink,
     PaperValidationCohort,
+    PaperValidationCohortAssignment,
 )
 from app.models.paper_evaluation import EvaluationConfig as EvaluationConfigRow
 from app.models.paper_evaluation import EvaluationEpoch as EvaluationEpochRow
@@ -86,6 +87,9 @@ PAPER_START = CAPTURED_AT - timedelta(hours=1)
 FILLED_AT = CAPTURED_AT + timedelta(milliseconds=200)
 ALPACA_SYMBOL = {"BTCUSDT": "BTC/USD", "ETHUSDT": "ETH/USD"}
 COHORT_SYMBOLS = ("BTCUSDT", "ETHUSDT")
+# Demo hosts are product-disjoint (see CLAUDE.md ROB-298); keep the ledger row's
+# host consistent with its own discriminator.
+DEMO_HOST = {"spot": "demo-api.binance.com", "usdm_futures": "demo-fapi.binance.com"}
 
 
 def _evaluated_at() -> datetime:
@@ -134,25 +138,33 @@ class _Registry:
         return self.adapters[broker]
 
 
-async def _instrument_id(session: AsyncSession, venue_symbol: str) -> int:
-    """Resolve-or-create the ``(binance, spot, venue_symbol)`` identity.
+async def _instrument_id(
+    session: AsyncSession,
+    venue_symbol: str,
+    *,
+    venue: str = "binance",
+    product: str = "spot",
+) -> int:
+    """Resolve-or-create the ``(venue, product, venue_symbol)`` identity.
 
     Mirrors ``BinanceDemoLedgerRepository.resolve_or_create_instrument``: the
     triple is unique, so a row seeded by an earlier test must be reused rather
-    than duplicated.
+    than duplicated.  All three components are parameters because
+    ``venue_symbol`` on its own identifies nothing — ``binance/spot/BTCUSDT``
+    and ``binance/usdm_futures/BTCUSDT`` are different, equally valid rows.
     """
     existing = await session.scalar(
         select(CryptoInstrument).where(
-            CryptoInstrument.venue == "binance",
-            CryptoInstrument.product == "spot",
+            CryptoInstrument.venue == venue,
+            CryptoInstrument.product == product,
             CryptoInstrument.venue_symbol == venue_symbol,
         )
     )
     if existing is not None:
         return existing.id
     instrument = CryptoInstrument(
-        venue="binance",
-        product="spot",
+        venue=venue,
+        product=product,
         venue_symbol=venue_symbol,
         base_asset=venue_symbol.removesuffix("USDT"),
         quote_asset="USDT",
@@ -167,9 +179,10 @@ async def _instrument_id(session: AsyncSession, venue_symbol: str) -> int:
 class _LedgerBackedNativeResolver:
     """Materialise a real native ledger row for each submitted order.
 
-    ``instrument_venue_symbol`` maps the cohort symbol to the
-    ``crypto_instruments.venue_symbol`` the Binance ledger row points at, so a
-    test can bind a link to a deliberately wrong instrument.
+    ``instrument_venue`` / ``instrument_product`` / ``instrument_venue_symbol``
+    select which ``crypto_instruments`` row the Binance ledger row points at,
+    and ``ledger_product`` sets the ledger row's own discriminator, so a test
+    can make the identity wrong in exactly one component at a time.
     """
 
     session: AsyncSession
@@ -177,6 +190,9 @@ class _LedgerBackedNativeResolver:
     instrument_venue_symbol: dict[str, str] = field(
         default_factory=lambda: {symbol: symbol for symbol in COHORT_SYMBOLS}
     )
+    instrument_venue: str = "binance"
+    instrument_product: str = "spot"
+    ledger_product: str = "spot"
 
     async def resolve(
         self, venue: str, client_order_id: str, broker_order_id: str
@@ -186,10 +202,13 @@ class _LedgerBackedNativeResolver:
             row: BinanceDemoOrderLedger | AlpacaPaperOrderLedger = (
                 BinanceDemoOrderLedger(
                     instrument_id=await _instrument_id(
-                        self.session, self.instrument_venue_symbol[symbol]
+                        self.session,
+                        self.instrument_venue_symbol[symbol],
+                        venue=self.instrument_venue,
+                        product=self.instrument_product,
                     ),
-                    product="spot",
-                    venue_host="demo-api.binance.com",
+                    product=self.ledger_product,
+                    venue_host=DEMO_HOST[self.ledger_product],
                     client_order_id=client_order_id,
                     broker_order_id=broker_order_id,
                     side="BUY",
@@ -305,7 +324,12 @@ class _Lineage:
 
 
 async def _build_lineage(
-    session: AsyncSession, *, instrument_venue_symbol: dict[str, str] | None = None
+    session: AsyncSession,
+    *,
+    instrument_venue_symbol: dict[str, str] | None = None,
+    instrument_venue: str = "binance",
+    instrument_product: str = "spot",
+    ledger_product: str = "spot",
 ) -> _Lineage:
     """Run the production paper-active pipeline and seed the evaluation epoch."""
     nonce = uuid4().hex
@@ -415,6 +439,9 @@ async def _build_lineage(
                 if instrument_venue_symbol is not None
                 else {symbol: symbol for symbol in COHORT_SYMBOLS}
             ),
+            instrument_venue=instrument_venue,
+            instrument_product=instrument_product,
+            ledger_product=ledger_product,
         ),
         clock=lambda: CAPTURED_AT + timedelta(milliseconds=300),
         enablement=lambda _mode: True,
@@ -532,7 +559,13 @@ async def test_load_assembles_binance_fills_from_linked_instrument_identity(
         assert ledger is not None
         instrument = await db_session.get(CryptoInstrument, ledger.instrument_id)
         assert instrument is not None
-        assert instrument.venue_symbol == symbol
+        # The whole identity triple, not just the symbol.
+        assert (instrument.venue, instrument.product, instrument.venue_symbol) == (
+            "binance",
+            "spot",
+            symbol,
+        )
+        assert ledger.product == "spot"
     assert {fill.symbol for fill in evidence.alpaca_fills} == {"BTC/USD", "ETH/USD"}
 
 
@@ -561,6 +594,89 @@ async def test_load_rejects_binance_row_bound_to_another_symbols_instrument(
         )
     assert exc.value.reason_code == "cross_wired_evidence"
     assert str(exc.value) == "linked Binance row mismatch"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("ledger_product", "instrument_venue", "instrument_product"),
+    [
+        # The one the ROB-1205 r1 fix still admitted: a spot ledger row whose
+        # FK target is the USD-M futures instrument carrying the very same
+        # ``BTCUSDT``/``ETHUSDT`` venue_symbol. Both rows are legitimate —
+        # scripts/binance_futures_demo_smoke.py seeds exactly this shape — so
+        # ``venue_symbol`` alone cannot tell them apart, and accepting it books
+        # cross-product fill evidence with no crash to notice.
+        ("spot", "binance", "usdm_futures"),
+        # Same hole one component over: nothing in the schema stops a Binance
+        # ledger row's FK from landing on another venue's instrument.
+        ("spot", "upbit", "spot"),
+        # And the mirror image: a futures ledger row whose instrument is the
+        # correct spot one. Here every ``instrument`` field matches, so only the
+        # ledger row's own discriminator reveals that this fill did not happen
+        # in the cohort's market.
+        ("usdm_futures", "binance", "spot"),
+    ],
+    ids=[
+        "usdm_futures_instrument_same_symbol",
+        "other_venue_instrument_same_symbol",
+        "futures_ledger_row_in_spot_cohort",
+    ],
+)
+async def test_load_rejects_binance_row_bound_to_wrong_instrument_identity(
+    db_session: AsyncSession,
+    ledger_product: str,
+    instrument_venue: str,
+    instrument_product: str,
+) -> None:
+    """A spot cohort must not accept evidence off its ``(venue, product)``.
+
+    ``crypto_instruments`` is unique on ``(venue, product, venue_symbol)``, so
+    the reader must compare all three, and the ledger row's own ``product`` must
+    agree with the cohort's market as well.  Each case breaks exactly one
+    component and every one of them must fail closed.
+    """
+    lineage = await _build_lineage(
+        db_session,
+        instrument_venue=instrument_venue,
+        instrument_product=instrument_product,
+        ledger_product=ledger_product,
+    )
+    reader = AuthoritativeEvidenceReader(db_session)
+
+    with pytest.raises(EvaluationConfigError) as exc:
+        await reader.load(
+            evaluated_at=_evaluated_at(),
+            cohort_id=lineage.cohort_id,
+            assignment_id=lineage.assignment_id,
+        )
+    assert exc.value.reason_code == "cross_wired_evidence"
+    assert str(exc.value) == "linked Binance row mismatch"
+
+
+@pytest.mark.asyncio
+async def test_native_load_fails_closed_when_cohort_product_is_unresolvable(
+    db_session: AsyncSession,
+) -> None:
+    """No cohort product means no way to bind identity — refuse, don't guess.
+
+    ``paper_run_order_links`` carries venue and symbol but no product, so
+    ``cohort.market`` is the only lineage-bound source of it.  If it cannot be
+    resolved the reader must fail closed rather than fall back to assuming
+    ``spot``.
+    """
+    reader = AuthoritativeEvidenceReader(db_session)
+    with pytest.raises(EvaluationConfigError) as exc:
+        await reader._load_native(
+            assignment=PaperValidationCohortAssignment(
+                assignment_id="assignment-x",
+                cohort_id="cohort-x",
+            ),
+            cohort=PaperValidationCohort(cohort_id="cohort-x", market=None),
+            start=PAPER_START,
+            end=_evaluated_at(),
+        )
+    assert exc.value.reason_code == "missing_evidence"
+    assert str(exc.value) == "cohort market missing"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 요약

`AuthoritativeEvidenceReader._load_native` 가 링크된 Binance native 행을 검증할 때
`CryptoInstrument.symbol` 을 읽는다. 그 속성은 존재한 적이 없다 — 컬럼은 `venue_symbol` 이다.
따라서 **binance run-order link 가 존재하는 모든 평가가 `AttributeError` 로 죽는다.**
`load()` 호출부(`evidence.py:384` 부근)에 `try/except` 가 없어 그대로 전파된다.

`origin/main = ba052c2e` 의 **선재 결함**이며 PR #1752 가 만든 것이 아니다 (ROB-1205).

이 PR 은 두 라운드로 구성된다.

| | 내용 |
|---|---|
| r1 `99d9139c` | `symbol` → `venue_symbol` 치환 + 동적 테스트 3건 |
| r2 `a312a1e0` | **식별자 전체 `(venue, product, venue_symbol)` 검증** + fail-closed + cross-product 테스트 |

r2 는 교차계열 검증자(codex)의 BLOCKER 판정에 대한 대응이다. **치환만으로는 크래시가
조용한 오판정으로 바뀔 뿐이었다.**

## r2 — BLOCKER: `venue_symbol` 단독 비교는 아무것도 식별하지 못한다

`crypto_instruments` 의 unique 제약은 **세 컬럼 전체**다.

```
app/models/crypto_instruments.py:36-41
    UniqueConstraint("venue", "product", "venue_symbol",
                     name="uq_crypto_instruments_venue_product_symbol")
```

즉 `binance/spot/BTCUSDT` 와 `binance/usdm_futures/BTCUSDT` 는 **서로 다른, 둘 다 정상인
행**이다. 가설이 아니라 실재하는 행 모양이다 — futures 스모크가 그대로 만든다.

```
scripts/binance_futures_demo_smoke.py:1286-1293
    inst = CryptoInstrument(venue="binance", product="usdm_futures",
                            venue_symbol=symbol, ...)
```

r1 상태에서는 spot ledger 행이 **같은 `venue_symbol` 을 가진 futures instrument** 를 FK 로
가리켜도 비교가 정상 case 와 **똑같이 통과**한다. 크래시가 사라진 대신
**cross-product fill evidence 가 조용히 수용된다** — 더 나쁜 결과다.

### link / ledger row 가 실제로 들고 있는 식별 정보 (지어내지 않고 조사한 결과)

| 식별 성분 | 출처 | 확인 |
|---|---|---|
| venue | `paper_run_order_links.venue` | **있다.** CHECK `venue IN ('binance','alpaca')` (`paper_cohort.py:587-590`) |
| venue_symbol | `paper_run_order_links.symbol` | **있다.** `Literal["BTCUSDT","ETHUSDT"]` (`paper_cohort/contracts.py:100`) |
| product | **link 에는 없다** | ledger 행의 `BinanceDemoOrderLedger.product` (CHECK `IN ('spot','usdm_futures')`) 와, **lineage 상 권위 있는 값**인 `PaperValidationCohort.market` (NOT NULL + CHECK `market = 'spot'`, `paper_cohort.py:49-51,87`) |

→ `link` 자체는 product 를 모른다. 그러나 `_load_native` 는 이미 `cohort` 를 인자로 받고
있고, `cohort.market` 이 **이 평가 전체의 권위 있는 product** 다. 지어낼 필요가 없었다.

토큰 어휘도 대조했다 — `cohort.market='spot'` / `CryptoInstrument.product ∈ {spot,
usdm_futures}` / `BinanceDemoOrderLedger.product ∈ {spot, usdm_futures}` 로 동일 어휘이며,
`resolve_or_create_instrument` 가 instrument 와 ledger 행에 **같은 product 토큰**을 넘긴다
(`demo/ledger/service.py:158-190`).

### 변경 (제품 코드 diff 요약)

```python
# _load_native 진입부 — 한 번만 해석하고, 못 하면 거부
expected_product = cohort.market
if not expected_product:
    _fail("missing_evidence", "cohort market missing")
```

```diff
                 if (
                     row is None
                     or instrument is None
+                    or row.product != expected_product
+                    or instrument.venue != link.venue
+                    or instrument.product != expected_product
                     or instrument.venue_symbol != link.symbol
                     or row.client_order_id != link.client_order_id
                     or str(row.broker_order_id) != link.broker_order_id
                     or row.lifecycle_state not in {"filled", "closed", "reconciled"}
                 ):
                     _fail("cross_wired_evidence", "linked Binance row mismatch")
```

- **비교하는 식별 필드**: `row.product` · `instrument.venue` · `instrument.product` ·
  `instrument.venue_symbol` (+ 기존 `client_order_id` · `broker_order_id` · `lifecycle_state`).
- **fail-closed**: `cohort.market` 을 확정할 수 없으면 `"spot"` 으로 가정하지 **않고**
  `missing_evidence` 로 거부한다. 의심스러우면 거부하는 방향이다.

### cross-product 영구 테스트 — 수정 전 RED 원문

`test_load_rejects_binance_row_bound_to_wrong_instrument_identity` (parametrize 3 케이스).
ledger 행 / instrument 중 **한 성분만** 틀린다.

| id | ledger row | instrument |
|---|---|---|
| `usdm_futures_instrument_same_symbol` | `spot` | `binance/usdm_futures/BTCUSDT` ← 검증자 재현 시나리오 |
| `other_venue_instrument_same_symbol` | `spot` | `upbit/spot/BTCUSDT` |
| `futures_ledger_row_in_spot_cohort` | `usdm_futures` | `binance/spot/BTCUSDT` |

**r1 코드(치환만 적용된 상태)에서 실행한 원문** — 증거가 통과해 버린다:

```text
$ git stash push -- app/services/paper_evaluation/evidence.py     # r2 수정 제거
$ grep -n "instrument.venue_symbol != link.symbol" app/services/paper_evaluation/evidence.py
818:                    or instrument.venue_symbol != link.symbol      ← r1 상태 확인

$ uv run pytest tests/services/paper_evaluation/test_evidence_native_binance.py \
    -q -p no:randomly --no-cov -k "wrong_instrument_identity"
E       Failed: DID NOT RAISE EvaluationConfigError
E       Failed: DID NOT RAISE EvaluationConfigError
2 failed, 4 deselected in 5.77s
```

fail-closed 가드 테스트도 r1 에서 RED 였다
(`3 failed, 3 passed` — 위 2건 + `test_native_load_fails_closed_when_cohort_product_is_unresolvable`).

r2 수정 적용 후: **7 passed**.

### 뮤턴트 6종 전부 RED (생존자 0)

각 비교를 하나씩 무력화하되 **source 문자열은 보존**했다(R3 를 통과했던 바로 그 방식).

| 뮤턴트 | 대상 | RED 로 만든 테스트 |
|---|---|---|
| A | `venue_symbol !=` → `==` | `..._assembles_...` + `..._another_symbols_instrument` |
| B | `venue_symbol` 비교 무력화 | `..._another_symbols_instrument` |
| C | `instrument.product` 비교 무력화 | `[usdm_futures_instrument_same_symbol]` |
| D | `instrument.venue` 비교 무력화 | `[other_venue_instrument_same_symbol]` |
| E | `row.product` 비교 무력화 | `[futures_ledger_row_in_spot_cohort]` |
| F | fail-closed 가드 → `cohort.market or "spot"` | `..._fails_closed_when_cohort_product_is_unresolvable` |

A/B 는 r1 뮤턴트로 **회귀 없음 확인**. E 는 처음 넣었을 때 **생존**했고(= `row.product`
검사가 테스트되지 않은 상태였다 — 이 사건을 만든 바로 그 냄새), 세 번째 파라미터 케이스를
추가해 닫았다. 전 뮤턴트 원복 완료.

## 테스트 커버리지 결함을 같은 PR 에서 닫음

`tests/services/paper_evaluation/test_evidence_native_binance.py` 신규 (7 tests, integration).

기존 테스트는 전부 (a) `AsyncMock()` 세션, (b) 가짜 `_EvidenceReader` 대체,
(c) `inspect.getsource` 문자열 검사 중 하나라서 이 분기에 **한 번도 닿지 않았다**.
신규 테스트는 셋 다 쓰지 않고, lineage 를 **프로덕션 코드로** 세운다 — 실
`PaperCohortService.activate()`, 실 `PaperCohortRunner(mode=PAPER_ACTIVE)` 가
snapshot/decision/intent/link 생산(signal_hash·content_hash·request_hash 전부 프로덕션
함수 산출), 실 `CryptoInstrument`+`BinanceDemoOrderLedger`/`AlpacaPaperOrderLedger` 행.
그 위에서 `_load_native` 가 아니라 **`load()` 를 end-to-end** 구동한다.

## 과거 결과 오염 판정 — `NEEDS_INFO` / scope `UNKNOWN`

**r1 에서 `NEVER_EXECUTED` / `NONE` 으로 적었던 것을 정정한다.** 그것은 증명되지 않은
부재 단정이었다.

**확인한 것 (레포 범위):**
- 현재 `PaperEvaluationService` / `AuthoritativeEvidenceReader` 참조가 자기 모듈 + `tests/`
  밖에 0건.
- 전 git 이력에서 `git log -S "paper_evaluation" --all -- app/routers app/flows app/jobs
  app/mcp_server app/tasks scripts config` → **0 commit**. 레포 안에 실행 진입점이 존재한
  적이 없다.
- 결함 라인을 되돌린 채 기존 스위트 실행 → **391 passed**. 그 줄은 도달 즉시 무조건
  `AttributeError` 이므로, 기존 테스트 중 그 줄을 실행한 것은 없다(실측).

**확인하지 못한 것:**
- **운영 DB** (`research.evaluation_scorecards` / `evaluation_epochs` 실제 행) — 지시상
  조회 금지로 **미조사**.
- **운영 로그** — 미조사.
- **out-of-repo 수동 호출**(세션/노트북/일회성 스크립트 등) — 조사 수단 없음.

→ 레포 내 증거만으로는 "실행된 적 없음"을 **증명할 수 없다**. 따라서 판정은
`PAST_CONTAMINATION_VERDICT = NEEDS_INFO`, `CONTAMINATION_SCOPE = UNKNOWN`.
**이는 과거 오염을 발견했다는 뜻이 아니다** — 부재를 증명하지 못했다는 뜻이다.

한 가지는 확실하다: 호출부에 `try/except` 가 없으므로 **r1 이전 코드가 실행되었다면
크래시했지 틀린 값을 낼 수 없다**. 조용한 오판정 위험은 r1 상태(치환만 적용)에서 처음
생겼고, r2 가 그것을 닫는다.

## 안전 경계

- 정지점 = PR. **merge 0 · deploy 0**.
- PR #1752 의 브랜치·파일 **미접촉**.
- **운영 DB 조회/쓰기 0** · migration apply 0 · `ENV_FILE=.env.prod` 미사용.
  테스트는 `tests/conftest.py` 의 `test_db` 경로에서만 실행.
- broker/account API · preview/order/cancel/reconcile/position 호출 0.
- scheduler/cron/TaskIQ/Prefect 등록 0 · Linear write 0 · canonical repo 변경 0.
- 하드 인바리언트 완화 0 · fail-open 전환 0 · allowlist 확장 0 — 방향은 전부 **fail-closed
  강화**이며, 한 번도 동작한 적 없는 검사를 처음으로 실제 동작시킨다.

Linear: ROB-1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
