### PR TITLE
feat(research): add crypto corpus preflight builder

### DIFF
--- a/research/crypto_corpus/__init__.py
+++ b/research/crypto_corpus/__init__.py
@@ -1,0 +1,9 @@
+"""Public, venue-separated crypto OHLCV corpus builder.
+
+This package is intentionally research-only: it has no application, database,
+broker, account, scheduler, credential, or LLM dependencies.
+"""
+
+from .constants import CORPUS_ID
+
+__all__ = ["CORPUS_ID"]

--- a/research/crypto_corpus/__init__.py
+++ b/research/crypto_corpus/__init__.py
@@ -5,5 +5,31 @@ broker, account, scheduler, credential, or LLM dependencies.
 """
 
 from .constants import CORPUS_ID
+from .loader import (
+    LabeledCorpus,
+    inspect_parquet_policy,
+    load_labeled_parquet,
+    load_labeled_parquet_files,
+)
+from .policy import (
+    CrossVenueReadForbidden,
+    HoldoutReadForbidden,
+    ParquetPolicyMismatchError,
+    UnlabeledParquetError,
+    UpbitXsecOptInRequired,
+    VenuePolicy,
+)
 
-__all__ = ["CORPUS_ID"]
+__all__ = [
+    "CORPUS_ID",
+    "CrossVenueReadForbidden",
+    "HoldoutReadForbidden",
+    "LabeledCorpus",
+    "ParquetPolicyMismatchError",
+    "UnlabeledParquetError",
+    "UpbitXsecOptInRequired",
+    "VenuePolicy",
+    "inspect_parquet_policy",
+    "load_labeled_parquet",
+    "load_labeled_parquet_files",
+]

--- a/research/crypto_corpus/artifacts.py
+++ b/research/crypto_corpus/artifacts.py
@@ -261,6 +261,32 @@ class ArtifactStore:
             handle.flush()
             os.fsync(handle.fileno())
 
+    def ensure_append_only_log(self, relative_path: str) -> None:
+        """Create an empty normal-control log once, without rewriting it."""
+        normalized = Path(relative_path)
+        if normalized.parts and normalized.parts[0] == "holdout":
+            raise PermissionError("holdout files are write-only for crypto-corpus-v1")
+        path = self.root / normalized
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            with path.open("x", encoding="utf-8"):
+                pass
+
+    def hash_nonholdout_file(self, relative_path: str, *, kind: str) -> FileRecord:
+        """Record a final SHA for an append-only control file outside holdout."""
+        normalized = Path(relative_path)
+        if normalized.parts and normalized.parts[0] == "holdout":
+            raise PermissionError("holdout files are write-only for crypto-corpus-v1")
+        payload = (self.root / normalized).read_bytes()
+        return FileRecord(
+            relative_path=normalized.as_posix(),
+            sha256=hashlib.sha256(payload).hexdigest(),
+            byte_size=len(payload),
+            row_count=None,
+            kind=kind,
+            is_holdout=False,
+        )
+
     def load_json_records(self, directory: Path) -> list[dict[str, Any]]:
         """Read non-holdout control records in deterministic order."""
         records: list[dict[str, Any]] = []

--- a/research/crypto_corpus/artifacts.py
+++ b/research/crypto_corpus/artifacts.py
@@ -1,0 +1,280 @@
+"""Append-only artifact persistence with staging and atomic publication.
+
+All completed data files are first materialized in ``.staging``.  Their
+Parquet metadata and SHA-256 are verified from the exact in-memory byte stream
+that is written to the ``.partial`` file, then the staging file is atomically
+renamed into its final location.  Final artifact names are UUID based, so no
+publication operation overwrites an earlier file.
+
+The holdout directory is write-only for this job.  Metadata, hashes, and row
+counts are carried in receipts outside that directory; no helper in this module
+opens, stats, globs, or otherwise reads a completed holdout file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    """A published artifact known by its creation-time evidence only."""
+
+    relative_path: str
+    sha256: str
+    byte_size: int
+    row_count: int | None
+    kind: str
+    is_holdout: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class StagedFile:
+    """An immutable publication plan persisted before final rename."""
+
+    staging_path: str
+    final_relative_path: str
+    record: FileRecord
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "staging_path": self.staging_path,
+            "final_relative_path": self.final_relative_path,
+            "record": self.record.as_dict(),
+        }
+
+
+def _timestamp_token() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+class ArtifactStore:
+    """Owns only the job's artifact root; it never reads the holdout tree."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.staging = self.root / ".staging"
+        self.inputs = self.root / "inputs"
+        self.dataset = self.root / "dataset"
+        self.holdout = self.root / "holdout"
+        self.control = self.root / "control"
+        self.receipts = self.control / "receipts"
+        self.inflight = self.control / "inflight"
+        self.preflight = self.control / "preflight"
+        for directory in (
+            self.root,
+            self.staging,
+            self.inputs,
+            self.dataset,
+            self.holdout,
+            self.control,
+            self.receipts,
+            self.inflight,
+            self.preflight,
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    def _token(self) -> str:
+        return f"{_timestamp_token()}-{uuid.uuid4().hex}"
+
+    def _write_partial_bytes(self, payload: bytes, suffix: str) -> tuple[Path, str]:
+        """Write a fresh partial file while calculating its exact SHA-256."""
+        partial = self.staging / f"{self._token()}{suffix}.partial"
+        digest = hashlib.sha256()
+        with partial.open("xb") as handle:
+            for start in range(0, len(payload), 1024 * 1024):
+                chunk = payload[start : start + 1024 * 1024]
+                handle.write(chunk)
+                digest.update(chunk)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return partial, digest.hexdigest()
+
+    def _relative(self, path: Path) -> str:
+        return path.relative_to(self.root).as_posix()
+
+    def stage_bytes(
+        self,
+        payload: bytes,
+        final_relative_path: str,
+        *,
+        kind: str,
+        row_count: int | None = None,
+        is_holdout: bool = False,
+    ) -> StagedFile:
+        """Stage exact bytes and return their immutable publication record."""
+        staging_path, digest = self._write_partial_bytes(payload, ".bin")
+        record = FileRecord(
+            relative_path=final_relative_path,
+            sha256=digest,
+            byte_size=len(payload),
+            row_count=row_count,
+            kind=kind,
+            is_holdout=is_holdout,
+        )
+        return StagedFile(
+            staging_path=str(staging_path),
+            final_relative_path=final_relative_path,
+            record=record,
+        )
+
+    def stage_json(
+        self,
+        payload: dict[str, Any] | list[Any],
+        final_relative_path: str,
+        *,
+        kind: str,
+    ) -> StagedFile:
+        rendered = json.dumps(
+            payload,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        # Validation happens before atomic publication.  This also proves that
+        # the exact bytes used for the SHA are parseable JSON.
+        json.loads(rendered)
+        return self.stage_bytes(rendered, final_relative_path, kind=kind)
+
+    def stage_parquet(
+        self,
+        table: pa.Table,
+        final_relative_path: str,
+        *,
+        is_holdout: bool,
+    ) -> StagedFile:
+        """Validate a Parquet payload before publishing it from staging.
+
+        The serialized buffer keeps validation and SHA calculation independent
+        of the final destination.  That is essential for the holdout tree's
+        write-only contract.
+        """
+        sink = pa.BufferOutputStream()
+        pq.write_table(
+            table,
+            sink,
+            compression="zstd",
+            use_dictionary=True,
+            write_statistics=True,
+        )
+        payload = sink.getvalue().to_pybytes()
+        metadata = pq.ParquetFile(pa.BufferReader(payload)).metadata
+        if metadata is None or metadata.num_rows != table.num_rows:
+            raise ValueError("staged Parquet metadata row-count mismatch")
+        if len(metadata.schema.names) != len(table.schema.names):
+            raise ValueError("staged Parquet schema-column mismatch")
+        return self.stage_bytes(
+            payload,
+            final_relative_path,
+            kind="parquet",
+            row_count=table.num_rows,
+            is_holdout=is_holdout,
+        )
+
+    def publish(self, staged: StagedFile) -> FileRecord:
+        """Atomically publish a staged file without replacing any destination.
+
+        Final names carry a UUID, and every destination is generated exactly
+        once.  ``os.rename`` is therefore an atomic move rather than an
+        overwrite operation.  The method intentionally performs no final-path
+        probe for holdout files, because probing would violate write-only
+        handling; collision-free names are the no-overwrite guard.
+        """
+        source = Path(staged.staging_path)
+        destination = self.root / staged.final_relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        os.rename(source, destination)
+        return staged.record
+
+    def publish_inflight(self, inflight_payload: dict[str, Any]) -> dict[str, Any]:
+        """Finish a recorded publication transaction after a resume.
+
+        A missing staging file is only interpreted as an already-completed
+        atomic rename: the job never deletes staging files.  The destination is
+        deliberately not inspected, which keeps holdout paths unread.
+        """
+        for staged_item in inflight_payload["staged_files"]:
+            source = Path(staged_item["staging_path"])
+            if source.exists():
+                destination = self.root / staged_item["final_relative_path"]
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                os.rename(source, destination)
+        return inflight_payload
+
+    def new_relative_path(
+        self,
+        directory: str,
+        stem: str,
+        suffix: str,
+    ) -> str:
+        return f"{directory}/{stem}-{self._token()}{suffix}"
+
+    def publish_json_once(
+        self,
+        payload: dict[str, Any] | list[Any],
+        directory: str,
+        stem: str,
+        *,
+        kind: str,
+    ) -> FileRecord:
+        relative = self.new_relative_path(directory, stem, ".json")
+        return self.publish(self.stage_json(payload, relative, kind=kind))
+
+    def write_inflight(self, payload: dict[str, Any]) -> FileRecord:
+        return self.publish_json_once(
+            payload, "control/inflight", "inflight", kind="inflight"
+        )
+
+    def write_receipt(self, payload: dict[str, Any]) -> FileRecord:
+        return self.publish_json_once(
+            payload, "control/receipts", "receipt", kind="receipt"
+        )
+
+    def write_preflight(self, payload: dict[str, Any]) -> FileRecord:
+        return self.publish_json_once(
+            payload,
+            "control/preflight",
+            "preflight",
+            kind="preflight",
+        )
+
+    def append_jsonl(self, relative_path: str, payload: dict[str, Any]) -> None:
+        """Append a normal-control record; never rewrite previous events."""
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True, ensure_ascii=False))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def load_json_records(self, directory: Path) -> list[dict[str, Any]]:
+        """Read non-holdout control records in deterministic order."""
+        records: list[dict[str, Any]] = []
+        for path in sorted(directory.glob("*.json")):
+            with path.open(encoding="utf-8") as handle:
+                records.append(json.load(handle))
+        return records
+
+    def read_file_bytes(self, relative_path: str) -> bytes:
+        """Read a non-holdout control/input file only.
+
+        This defensive guard makes accidental holdout reads a hard failure.
+        """
+        normalized = Path(relative_path)
+        if normalized.parts and normalized.parts[0] == "holdout":
+            raise PermissionError("holdout files are write-only for crypto-corpus-v1")
+        return (self.root / normalized).read_bytes()

--- a/research/crypto_corpus/artifacts.py
+++ b/research/crypto_corpus/artifacts.py
@@ -25,6 +25,8 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from .policy import label_table_for_venue, policy_from_parquet_metadata
+
 
 @dataclass(frozen=True)
 class FileRecord:
@@ -155,27 +157,36 @@ class ArtifactStore:
         final_relative_path: str,
         *,
         is_holdout: bool,
+        venue: str,
     ) -> StagedFile:
         """Validate a Parquet payload before publishing it from staging.
 
         The serialized buffer keeps validation and SHA calculation independent
         of the final destination.  That is essential for the holdout tree's
-        write-only contract.
+        write-only contract. The venue policy label is embedded before
+        serialization, so both exploration and future holdout files are
+        fail-closed at the file boundary.
         """
+        labeled_table = label_table_for_venue(table, venue)
         sink = pa.BufferOutputStream()
         pq.write_table(
-            table,
+            labeled_table,
             sink,
             compression="zstd",
             use_dictionary=True,
             write_statistics=True,
         )
         payload = sink.getvalue().to_pybytes()
-        metadata = pq.ParquetFile(pa.BufferReader(payload)).metadata
+        parquet_file = pq.ParquetFile(pa.BufferReader(payload))
+        metadata = parquet_file.metadata
         if metadata is None or metadata.num_rows != table.num_rows:
             raise ValueError("staged Parquet metadata row-count mismatch")
         if len(metadata.schema.names) != len(table.schema.names):
             raise ValueError("staged Parquet schema-column mismatch")
+        policy_from_parquet_metadata(
+            parquet_file.schema_arrow.metadata,
+            expected_venue=venue,
+        )
         return self.stage_bytes(
             payload,
             final_relative_path,

--- a/research/crypto_corpus/builder.py
+++ b/research/crypto_corpus/builder.py
@@ -867,7 +867,12 @@ class CorpusBuilder:
                 [_bar_to_row(row) for row in group], schema=BAR_SCHEMA
             )
             staged.append(
-                self.store.stage_parquet(table, relative, is_holdout=is_holdout)
+                self.store.stage_parquet(
+                    table,
+                    relative,
+                    is_holdout=is_holdout,
+                    venue=venue,
+                )
             )
         return staged
 

--- a/research/crypto_corpus/builder.py
+++ b/research/crypto_corpus/builder.py
@@ -388,6 +388,7 @@ class CorpusBuilder:
         self._completed = 0
         self._total_tasks = 0
         self._last_checkpoint = "none"
+        self.store.ensure_append_only_log("errors.jsonl")
 
     def _append_progress(self, stage: str, *, force: bool = False) -> None:
         current = self.monotonic()
@@ -1255,6 +1256,10 @@ class CorpusBuilder:
                     file_records[record.relative_path] = record
         file_records[coverage_record.relative_path] = coverage_record
         file_records[gaps_record.relative_path] = gaps_record
+        error_log_record = self.store.hash_nonholdout_file(
+            "errors.jsonl", kind="error_log"
+        )
+        file_records[error_log_record.relative_path] = error_log_record
         ordered_records = [file_records[key] for key in sorted(file_records)]
         hashes_text = "".join(
             f"{record.sha256}  {record.relative_path}\n" for record in ordered_records
@@ -1337,6 +1342,7 @@ class CorpusBuilder:
             "coverage_file": coverage_record.as_dict(),
             "explicit_gaps_file": gaps_record.as_dict(),
             "explicit_gap_count": len(all_gaps),
+            "error_log": error_log_record.as_dict(),
             "validation": {
                 "duplicate_rows_stored": 0,
                 "ohlc_invariant_violations_stored": 0,

--- a/research/crypto_corpus/builder.py
+++ b/research/crypto_corpus/builder.py
@@ -1,0 +1,1475 @@
+"""Resumable public-data materializer for the signed crypto corpus scope.
+
+The builder does not import the application package and has no database,
+credential, signed-endpoint, broker, account, scheduler, or strategy surface.
+It only calls the explicitly listed unsigned public market-data endpoints.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import time
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+import pyarrow as pa
+
+from .artifacts import ArtifactStore, FileRecord, StagedFile
+from .constants import (
+    ARTIFACT_ROOT,
+    AUTH,
+    BINANCE_DAILY_EARLIEST,
+    BINANCE_DELISTED_PROBE_SYMBOL,
+    BINANCE_EXCHANGE_INFO_URL,
+    BINANCE_KLINES_URL,
+    BINANCE_PAGE_SIZE,
+    CORPUS_ID,
+    CUTOFF_END,
+    HOLDOUT_ACCESS_LOG,
+    HOLDOUT_START,
+    HOUR_WINDOW_START,
+    MAX_ARTIFACT_BYTES,
+    MAX_REQUESTS,
+    MAX_WALL_CLOCK_SECONDS,
+    PROGRESS_LOG,
+    PURPOSE,
+    UPBIT_DAILY_EARLIEST,
+    UPBIT_DAYS_URL,
+    UPBIT_DELISTED_PROBE_MARKET,
+    UPBIT_HOURS_URL,
+    UPBIT_MARKETS_URL,
+    UPBIT_PAGE_SIZE,
+    VENUES,
+    utc_iso,
+)
+from .public_api import ApiResponse, PublicApiClient, RequestBudgetExceeded
+
+
+class SourceDataError(ValueError):
+    """A source row cannot safely become a stored OHLCV bar."""
+
+
+@dataclass(frozen=True)
+class RequestBudgetPlan:
+    upbit_symbols: int
+    binance_symbols: int
+    upbit_daily_pages_per_symbol: int
+    upbit_hourly_pages_per_symbol: int
+    binance_daily_pages_per_symbol: int
+    binance_hourly_pages_per_symbol: int
+    universe_snapshot_requests: int
+    delisted_probe_requests: int
+    projected_total: int
+
+    def as_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Bar:
+    venue: str
+    symbol: str
+    frequency: str
+    open_ms: int
+    close_exclusive_ms: int
+    open_price: float
+    high_price: float
+    low_price: float
+    close_price: float
+    base_volume: float
+    quote_volume: float
+    trade_count: int | None
+    source_candle_date_time_utc: str | None
+    source_candle_date_time_kst: str | None
+    source_open_time_ms: int | None
+    source_close_time_ms: int | None
+    source_timestamp_ms: int | None
+
+
+@dataclass
+class FetchResult:
+    bars: list[Bar]
+    error: str | None = None
+    rate_limited: bool = False
+    budget_exhausted: bool = False
+
+
+BAR_SCHEMA = pa.schema(
+    [
+        pa.field("venue", pa.string(), nullable=False),
+        pa.field("symbol", pa.string(), nullable=False),
+        pa.field("frequency", pa.string(), nullable=False),
+        pa.field("bucket_timezone", pa.string(), nullable=False),
+        pa.field("open_time_utc", pa.timestamp("ms", tz="UTC"), nullable=False),
+        pa.field("close_time_utc", pa.timestamp("ms", tz="UTC"), nullable=False),
+        pa.field("open", pa.float64(), nullable=False),
+        pa.field("high", pa.float64(), nullable=False),
+        pa.field("low", pa.float64(), nullable=False),
+        pa.field("close", pa.float64(), nullable=False),
+        pa.field("base_volume", pa.float64(), nullable=False),
+        pa.field("quote_volume", pa.float64(), nullable=False),
+        pa.field("trade_count", pa.int64(), nullable=True),
+        pa.field("source_candle_date_time_utc", pa.string(), nullable=True),
+        pa.field("source_candle_date_time_kst", pa.string(), nullable=True),
+        pa.field("source_open_time_ms", pa.int64(), nullable=True),
+        pa.field("source_close_time_ms", pa.int64(), nullable=True),
+        pa.field("source_timestamp_ms", pa.int64(), nullable=True),
+    ]
+)
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    return (numerator + denominator - 1) // denominator
+
+
+def _milliseconds(value: datetime) -> int:
+    return int(value.timestamp() * 1000)
+
+
+def _utc_from_ms(value: int) -> datetime:
+    return datetime.fromtimestamp(value / 1000, tz=UTC)
+
+
+def _parse_utc_timestamp(value: str) -> datetime:
+    rendered = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(rendered)
+    if parsed.tzinfo is None:
+        # Upbit's ``candle_date_time_utc`` has no offset in real responses;
+        # its field name is the source declaration that makes this UTC.
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _validate_ohlcv(
+    *,
+    symbol: str,
+    open_price: float,
+    high_price: float,
+    low_price: float,
+    close_price: float,
+    base_volume: float,
+    quote_volume: float,
+    trade_count: int | None,
+) -> None:
+    numbers = (
+        open_price,
+        high_price,
+        low_price,
+        close_price,
+        base_volume,
+        quote_volume,
+    )
+    if not all(math.isfinite(value) for value in numbers):
+        raise SourceDataError(f"{symbol}: non-finite OHLCV field")
+    if not all(value > 0 for value in (open_price, high_price, low_price, close_price)):
+        raise SourceDataError(f"{symbol}: non-positive OHLC value")
+    if high_price < low_price:
+        raise SourceDataError(f"{symbol}: high below low")
+    if high_price < max(open_price, close_price):
+        raise SourceDataError(f"{symbol}: high below open/close")
+    if low_price > min(open_price, close_price):
+        raise SourceDataError(f"{symbol}: low above open/close")
+    if base_volume < 0 or quote_volume < 0:
+        raise SourceDataError(f"{symbol}: negative volume")
+    if trade_count is not None and trade_count < 0:
+        raise SourceDataError(f"{symbol}: negative trade count")
+
+
+def _normalize_upbit(
+    record: dict[str, Any], frequency: str, expected_symbol: str
+) -> Bar:
+    if record.get("market") != expected_symbol:
+        raise SourceDataError(
+            f"{expected_symbol}: source market mismatch {record.get('market')!r}"
+        )
+    source_utc = str(record["candle_date_time_utc"])
+    open_ms = _milliseconds(_parse_utc_timestamp(source_utc))
+    duration_ms = 86_400_000 if frequency == "1d" else 3_600_000
+    values = {
+        "open_price": float(record["opening_price"]),
+        "high_price": float(record["high_price"]),
+        "low_price": float(record["low_price"]),
+        "close_price": float(record["trade_price"]),
+        "base_volume": float(record["candle_acc_trade_volume"]),
+        "quote_volume": float(record["candle_acc_trade_price"]),
+    }
+    _validate_ohlcv(symbol=expected_symbol, trade_count=None, **values)
+    return Bar(
+        venue="upbit_krw",
+        symbol=expected_symbol,
+        frequency=frequency,
+        open_ms=open_ms,
+        close_exclusive_ms=open_ms + duration_ms,
+        trade_count=None,
+        source_candle_date_time_utc=source_utc,
+        source_candle_date_time_kst=str(record.get("candle_date_time_kst"))
+        if record.get("candle_date_time_kst") is not None
+        else None,
+        source_open_time_ms=None,
+        source_close_time_ms=None,
+        source_timestamp_ms=int(record["timestamp"]),
+        **values,
+    )
+
+
+def _normalize_binance(record: list[Any], frequency: str, expected_symbol: str) -> Bar:
+    if len(record) < 11:
+        raise SourceDataError(f"{expected_symbol}: expected 11 Binance kline fields")
+    duration_ms = 86_400_000 if frequency == "1d" else 3_600_000
+    open_ms = int(record[0])
+    raw_close_ms = int(record[6])
+    if raw_close_ms != open_ms + duration_ms - 1:
+        raise SourceDataError(
+            f"{expected_symbol}@{open_ms}: incomplete/corrupt source bar duration"
+        )
+    values = {
+        "open_price": float(record[1]),
+        "high_price": float(record[2]),
+        "low_price": float(record[3]),
+        "close_price": float(record[4]),
+        "base_volume": float(record[5]),
+        "quote_volume": float(record[7]),
+    }
+    trade_count = int(record[8])
+    _validate_ohlcv(symbol=expected_symbol, trade_count=trade_count, **values)
+    return Bar(
+        venue="binance_usdt_spot",
+        symbol=expected_symbol,
+        frequency=frequency,
+        open_ms=open_ms,
+        close_exclusive_ms=open_ms + duration_ms,
+        trade_count=trade_count,
+        source_candle_date_time_utc=None,
+        source_candle_date_time_kst=None,
+        source_open_time_ms=open_ms,
+        source_close_time_ms=raw_close_ms,
+        source_timestamp_ms=None,
+        **values,
+    )
+
+
+def _bar_to_row(bar: Bar) -> dict[str, Any]:
+    return {
+        "venue": bar.venue,
+        "symbol": bar.symbol,
+        "frequency": bar.frequency,
+        "bucket_timezone": "UTC",
+        "open_time_utc": _utc_from_ms(bar.open_ms),
+        "close_time_utc": _utc_from_ms(bar.close_exclusive_ms),
+        "open": bar.open_price,
+        "high": bar.high_price,
+        "low": bar.low_price,
+        "close": bar.close_price,
+        "base_volume": bar.base_volume,
+        "quote_volume": bar.quote_volume,
+        "trade_count": bar.trade_count,
+        "source_candle_date_time_utc": bar.source_candle_date_time_utc,
+        "source_candle_date_time_kst": bar.source_candle_date_time_kst,
+        "source_open_time_ms": bar.source_open_time_ms,
+        "source_close_time_ms": bar.source_close_time_ms,
+        "source_timestamp_ms": bar.source_timestamp_ms,
+    }
+
+
+def _task_window(venue: str, frequency: str) -> tuple[datetime, datetime, int]:
+    if frequency == "1h":
+        return HOUR_WINDOW_START, CUTOFF_END, 3_600_000
+    if frequency != "1d":
+        raise ValueError(f"unsupported frequency {frequency!r}")
+    start = UPBIT_DAILY_EARLIEST if venue == "upbit_krw" else BINANCE_DAILY_EARLIEST
+    return start, CUTOFF_END, 86_400_000
+
+
+def calculate_request_budget(
+    upbit_symbols: int, binance_symbols: int
+) -> RequestBudgetPlan:
+    """Calculate a conservative cap before any historical candle request.
+
+    The daily denominators use each venue's documented launch-era lower bound,
+    not a guessed listing date.  That overestimates pages for newer symbols and
+    makes the 60,000-request gate fail closed.
+    """
+    upbit_daily_bars = int(
+        (CUTOFF_END - UPBIT_DAILY_EARLIEST).total_seconds() // 86_400
+    )
+    binance_daily_bars = int(
+        (CUTOFF_END - BINANCE_DAILY_EARLIEST).total_seconds() // 86_400
+    )
+    hourly_bars = int((CUTOFF_END - HOUR_WINDOW_START).total_seconds() // 3_600)
+    upbit_daily_pages = _ceil_div(upbit_daily_bars, UPBIT_PAGE_SIZE)
+    upbit_hourly_pages = _ceil_div(hourly_bars, UPBIT_PAGE_SIZE)
+    binance_daily_pages = _ceil_div(binance_daily_bars, BINANCE_PAGE_SIZE)
+    binance_hourly_pages = _ceil_div(hourly_bars, BINANCE_PAGE_SIZE)
+    projected_total = (
+        2  # frozen universe snapshots
+        + 2  # exactly one empirical delisted-history probe per venue
+        + upbit_symbols * (upbit_daily_pages + upbit_hourly_pages)
+        + binance_symbols * (binance_daily_pages + binance_hourly_pages)
+    )
+    return RequestBudgetPlan(
+        upbit_symbols=upbit_symbols,
+        binance_symbols=binance_symbols,
+        upbit_daily_pages_per_symbol=upbit_daily_pages,
+        upbit_hourly_pages_per_symbol=upbit_hourly_pages,
+        binance_daily_pages_per_symbol=binance_daily_pages,
+        binance_hourly_pages_per_symbol=binance_hourly_pages,
+        universe_snapshot_requests=2,
+        delisted_probe_requests=2,
+        projected_total=projected_total,
+    )
+
+
+def _upbit_universe(payload: Any) -> list[str]:
+    if not isinstance(payload, list):
+        raise SourceDataError("Upbit market/all response is not a JSON list")
+    symbols = []
+    for item in payload:
+        if not isinstance(item, dict):
+            raise SourceDataError("Upbit market/all contains a non-object item")
+        market = item.get("market")
+        if isinstance(market, str) and market.startswith("KRW-"):
+            symbols.append(market)
+    if not symbols:
+        raise SourceDataError("Upbit market/all supplied zero KRW markets")
+    return sorted(set(symbols))
+
+
+def _binance_universe(payload: Any) -> tuple[list[str], dict[str, str | None]]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("symbols"), list):
+        raise SourceDataError("Binance exchangeInfo response has no symbols list")
+    symbols: list[str] = []
+    status_by_symbol: dict[str, str | None] = {}
+    for item in payload["symbols"]:
+        if not isinstance(item, dict):
+            raise SourceDataError("Binance exchangeInfo contains a non-object symbol")
+        symbol = item.get("symbol")
+        permissions = item.get("permissions")
+        has_spot_permission = isinstance(permissions, list) and "SPOT" in permissions
+        is_spot = bool(item.get("isSpotTradingAllowed")) or has_spot_permission
+        if isinstance(symbol, str) and item.get("quoteAsset") == "USDT" and is_spot:
+            symbols.append(symbol)
+            status = item.get("status")
+            status_by_symbol[symbol] = status if isinstance(status, str) else None
+    if not symbols:
+        raise SourceDataError("Binance exchangeInfo supplied zero USDT spot markets")
+    return sorted(set(symbols)), status_by_symbol
+
+
+def _response_error(response: ApiResponse) -> str:
+    detail = response.error or "unknown_response_error"
+    body_hash = hashlib.sha256(response.body).hexdigest() if response.body else "none"
+    return f"{detail}; response_sha256={body_hash}"
+
+
+class CorpusBuilder:
+    """Build one immutable, restartable public corpus at the literal root."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore | None = None,
+        client: PublicApiClient | None = None,
+        now: Callable[[], datetime] | None = None,
+        monotonic: Callable[[], float] | None = None,
+    ) -> None:
+        self.store = store or ArtifactStore(ARTIFACT_ROOT)
+        self.client = client or PublicApiClient(self.store)
+        self.now = now or (lambda: datetime.now(UTC))
+        self.monotonic = monotonic or time.monotonic
+        self._last_heartbeat = self.monotonic()
+        self._preflight_payload: dict[str, Any] | None = None
+        self._completed = 0
+        self._total_tasks = 0
+        self._last_checkpoint = "none"
+
+    def _append_progress(self, stage: str, *, force: bool = False) -> None:
+        current = self.monotonic()
+        if not force and current - self._last_heartbeat < 55:
+            return
+        self._last_heartbeat = current
+        path = Path(PROGRESS_LOG)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        started = (
+            self._preflight_payload.get("started_at")
+            if self._preflight_payload
+            else None
+        )
+        elapsed = "unknown"
+        if isinstance(started, str):
+            try:
+                elapsed = f"{(self.now() - _parse_utc_timestamp(started)).total_seconds():.1f}s"
+            except ValueError:
+                elapsed = "unknown"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                f"{utc_iso(self.now())} | {stage} | {self._completed}/{self._total_tasks} | "
+                f"requests={self.client.requests_actual} | elapsed={elapsed} | "
+                f"checkpoint={self._last_checkpoint}\n"
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def _load_latest_preflight(self) -> dict[str, Any] | None:
+        records = self.store.load_json_records(self.store.preflight)
+        if not records:
+            return None
+        return max(records, key=lambda item: str(item.get("created_at", "")))
+
+    def _publish_raw_input(
+        self,
+        body: bytes,
+        *,
+        stem: str,
+        kind: str,
+    ) -> FileRecord:
+        relative = self.store.new_relative_path("inputs", stem, ".json")
+        staged = self.store.stage_bytes(body, relative, kind=kind)
+        return self.store.publish(staged)
+
+    def preflight(self) -> dict[str, Any]:
+        """Freeze both venue universes, then enforce the request budget gate."""
+        existing = self._load_latest_preflight()
+        if existing is not None:
+            self._preflight_payload = existing
+            self._append_progress("PREFLIGHT_REUSED", force=True)
+            return existing
+
+        started_at = utc_iso(self.now())
+        self._append_progress("UNIVERSE_SNAPSHOT_START", force=True)
+        upbit = self.client.get_json("upbit_krw", UPBIT_MARKETS_URL)
+        if not upbit.ok:
+            payload = {
+                "corpus_id": CORPUS_ID,
+                "created_at": utc_iso(self.now()),
+                "started_at": started_at,
+                "status": "BLOCKED_PRECONDITION",
+                "reason": f"upbit_universe_snapshot_failed:{_response_error(upbit)}",
+                "requests_actual_at_preflight": self.client.requests_actual,
+            }
+            self.store.write_preflight(payload)
+            self._preflight_payload = payload
+            self._append_progress("BLOCKED_UPBIT_UNIVERSE", force=True)
+            return payload
+        upbit_raw = self._publish_raw_input(
+            upbit.body,
+            stem="upbit-market-all-raw",
+            kind="universe_raw_response",
+        )
+
+        binance = self.client.get_json("binance_usdt_spot", BINANCE_EXCHANGE_INFO_URL)
+        if not binance.ok:
+            payload = {
+                "corpus_id": CORPUS_ID,
+                "created_at": utc_iso(self.now()),
+                "started_at": started_at,
+                "status": "BLOCKED_PRECONDITION",
+                "reason": f"binance_universe_snapshot_failed:{_response_error(binance)}",
+                "requests_actual_at_preflight": self.client.requests_actual,
+                "inputs": [upbit_raw.as_dict()],
+            }
+            self.store.write_preflight(payload)
+            self._preflight_payload = payload
+            self._append_progress("BLOCKED_BINANCE_UNIVERSE", force=True)
+            return payload
+        binance_raw = self._publish_raw_input(
+            binance.body,
+            stem="binance-exchange-info-raw",
+            kind="universe_raw_response",
+        )
+
+        try:
+            upbit_symbols = _upbit_universe(upbit.payload)
+            binance_symbols, binance_status = _binance_universe(binance.payload)
+        except SourceDataError as exc:
+            payload = {
+                "corpus_id": CORPUS_ID,
+                "created_at": utc_iso(self.now()),
+                "started_at": started_at,
+                "status": "BLOCKED_PRECONDITION",
+                "reason": f"universe_parse_failed:{exc}",
+                "requests_actual_at_preflight": self.client.requests_actual,
+                "inputs": [upbit_raw.as_dict(), binance_raw.as_dict()],
+            }
+            self.store.write_preflight(payload)
+            self._preflight_payload = payload
+            self._append_progress("BLOCKED_UNIVERSE_PARSE", force=True)
+            return payload
+
+        plan = calculate_request_budget(len(upbit_symbols), len(binance_symbols))
+        status = (
+            "READY_FOR_COLLECTION"
+            if plan.projected_total <= MAX_REQUESTS
+            else "BLOCKED_PRECONDITION"
+        )
+        payload = {
+            "corpus_id": CORPUS_ID,
+            "created_at": utc_iso(self.now()),
+            "started_at": started_at,
+            "status": status,
+            "reason": (
+                None
+                if status == "READY_FOR_COLLECTION"
+                else f"request_budget_projected={plan.projected_total}>max={MAX_REQUESTS}"
+            ),
+            "requests_actual_at_preflight": self.client.requests_actual,
+            "request_budget": plan.as_dict(),
+            "inputs": [upbit_raw.as_dict(), binance_raw.as_dict()],
+            "universe": {
+                "upbit_krw": upbit_symbols,
+                "binance_usdt_spot": binance_symbols,
+                "binance_status_by_symbol": binance_status,
+            },
+        }
+        self.store.write_preflight(payload)
+        self._preflight_payload = payload
+        stage = (
+            "PREFLIGHT_READY" if status == "READY_FOR_COLLECTION" else "BLOCKED_BUDGET"
+        )
+        self._append_progress(stage, force=True)
+        return payload
+
+    def _check_wall_clock(self) -> bool:
+        if self._preflight_payload is None:
+            raise RuntimeError("preflight has not run")
+        started_at = _parse_utc_timestamp(str(self._preflight_payload["started_at"]))
+        return (self.now() - started_at).total_seconds() <= MAX_WALL_CLOCK_SECONDS
+
+    def _fetch_upbit(self, symbol: str, frequency: str) -> FetchResult:
+        start, end, interval_ms = _task_window("upbit_krw", frequency)
+        cursor = end
+        rows: list[Bar] = []
+        previous_cursor: datetime | None = None
+        endpoint = UPBIT_DAYS_URL if frequency == "1d" else UPBIT_HOURS_URL
+        while True:
+            if not self._check_wall_clock():
+                return FetchResult(rows, error="max_wall_clock_exceeded")
+            query = urlencode(
+                {
+                    "market": symbol,
+                    "to": utc_iso(cursor),
+                    "count": UPBIT_PAGE_SIZE,
+                }
+            )
+            try:
+                response = self.client.get_json("upbit_krw", f"{endpoint}?{query}")
+            except RequestBudgetExceeded:
+                return FetchResult(
+                    rows, error="request_budget_exhausted", budget_exhausted=True
+                )
+            self._append_progress("FETCH_UPBIT")
+            if not response.ok:
+                return FetchResult(
+                    rows,
+                    error=_response_error(response),
+                    rate_limited=response.rate_limited,
+                )
+            if not isinstance(response.payload, list):
+                return FetchResult(rows, error="upbit_candles_non_list_payload")
+            if not response.payload:
+                break
+            try:
+                page = [
+                    _normalize_upbit(item, frequency, symbol)
+                    for item in response.payload
+                ]
+            except (KeyError, TypeError, ValueError, SourceDataError) as exc:
+                return FetchResult([], error=f"upbit_normalization_failed:{exc}")
+            rows.extend(bar for bar in page if start <= _utc_from_ms(bar.open_ms) < end)
+            oldest = min(_utc_from_ms(bar.open_ms) for bar in page)
+            if oldest <= start or len(page) < UPBIT_PAGE_SIZE:
+                break
+            if previous_cursor is not None and oldest >= previous_cursor:
+                return FetchResult(rows, error="upbit_pagination_nonprogress")
+            previous_cursor = cursor
+            cursor = oldest
+        return self._finalize_fetch(rows, symbol, frequency, start, end, interval_ms)
+
+    def _fetch_binance(self, symbol: str, frequency: str) -> FetchResult:
+        start, end, interval_ms = _task_window("binance_usdt_spot", frequency)
+        cursor_ms = _milliseconds(start)
+        end_ms = _milliseconds(end)
+        rows: list[Bar] = []
+        while cursor_ms < end_ms:
+            if not self._check_wall_clock():
+                return FetchResult(rows, error="max_wall_clock_exceeded")
+            query = urlencode(
+                {
+                    "symbol": symbol,
+                    "interval": frequency,
+                    "startTime": cursor_ms,
+                    "endTime": end_ms - 1,
+                    "limit": BINANCE_PAGE_SIZE,
+                }
+            )
+            try:
+                response = self.client.get_json(
+                    "binance_usdt_spot", f"{BINANCE_KLINES_URL}?{query}"
+                )
+            except RequestBudgetExceeded:
+                return FetchResult(
+                    rows, error="request_budget_exhausted", budget_exhausted=True
+                )
+            self._append_progress("FETCH_BINANCE")
+            if not response.ok:
+                return FetchResult(
+                    rows,
+                    error=_response_error(response),
+                    rate_limited=response.rate_limited,
+                )
+            if not isinstance(response.payload, list):
+                return FetchResult(rows, error="binance_klines_non_list_payload")
+            if not response.payload:
+                break
+            try:
+                page = [
+                    _normalize_binance(item, frequency, symbol)
+                    for item in response.payload
+                ]
+            except (IndexError, TypeError, ValueError, SourceDataError) as exc:
+                return FetchResult([], error=f"binance_normalization_failed:{exc}")
+            rows.extend(
+                bar
+                for bar in page
+                if _milliseconds(start) <= bar.open_ms < _milliseconds(end)
+            )
+            next_cursor = max(bar.open_ms for bar in page) + interval_ms
+            if next_cursor <= cursor_ms:
+                return FetchResult(rows, error="binance_pagination_nonprogress")
+            cursor_ms = next_cursor
+            if len(page) < BINANCE_PAGE_SIZE:
+                break
+        return self._finalize_fetch(rows, symbol, frequency, start, end, interval_ms)
+
+    @staticmethod
+    def _finalize_fetch(
+        rows: list[Bar],
+        symbol: str,
+        frequency: str,
+        start: datetime,
+        end: datetime,
+        interval_ms: int,
+    ) -> FetchResult:
+        seen: set[int] = set()
+        for row in rows:
+            if row.open_ms in seen:
+                return FetchResult(
+                    [], error=f"duplicate_source_row:{symbol}@{row.open_ms}"
+                )
+            seen.add(row.open_ms)
+            if row.close_exclusive_ms - row.open_ms != interval_ms:
+                return FetchResult(
+                    [], error=f"interval_invariant_failed:{symbol}@{row.open_ms}"
+                )
+            if row.close_exclusive_ms > _milliseconds(end):
+                return FetchResult(
+                    [], error=f"unfinished_bar_rejected:{symbol}@{row.open_ms}"
+                )
+        rows.sort(key=lambda row: row.open_ms)
+        return FetchResult(rows)
+
+    @staticmethod
+    def _gap_ranges(
+        *,
+        venue: str,
+        symbol: str,
+        frequency: str,
+        rows: list[Bar],
+        task_error: str | None,
+    ) -> list[dict[str, Any]]:
+        """Explicitly enumerate every missing source range; never fill one."""
+        start, end, interval_ms = _task_window(venue, frequency)
+        start_ms = _milliseconds(start)
+        end_ms = _milliseconds(end)
+        if task_error:
+            return [
+                {
+                    "venue": venue,
+                    "symbol": symbol,
+                    "frequency": frequency,
+                    "start_utc": utc_iso(start),
+                    "end_utc": utc_iso(end),
+                    "missing_bars": (end_ms - start_ms) // interval_ms,
+                    "reason": task_error,
+                }
+            ]
+        sorted_rows = sorted(rows, key=lambda row: row.open_ms)
+        gaps: list[dict[str, Any]] = []
+        expected = start_ms
+        first_observed = True
+        for row in sorted_rows:
+            if row.open_ms > expected:
+                gaps.append(
+                    {
+                        "venue": venue,
+                        "symbol": symbol,
+                        "frequency": frequency,
+                        "start_utc": utc_iso(_utc_from_ms(expected)),
+                        "end_utc": utc_iso(_utc_from_ms(row.open_ms)),
+                        "missing_bars": (row.open_ms - expected) // interval_ms,
+                        "reason": (
+                            "prelisting_or_unavailable_before_first_observed"
+                            if first_observed
+                            else "source_missing_interior_bars"
+                        ),
+                    }
+                )
+            expected = max(expected, row.open_ms + interval_ms)
+            first_observed = False
+        if expected < end_ms:
+            gaps.append(
+                {
+                    "venue": venue,
+                    "symbol": symbol,
+                    "frequency": frequency,
+                    "start_utc": utc_iso(_utc_from_ms(expected)),
+                    "end_utc": utc_iso(end),
+                    "missing_bars": (end_ms - expected) // interval_ms,
+                    "reason": (
+                        "source_empty"
+                        if not sorted_rows
+                        else "source_missing_after_last_observed"
+                    ),
+                }
+            )
+        return gaps
+
+    @staticmethod
+    def _row_groups(rows: list[Bar]) -> dict[tuple[bool, int], list[Bar]]:
+        groups: dict[tuple[bool, int], list[Bar]] = defaultdict(list)
+        holdout_start_ms = _milliseconds(HOLDOUT_START)
+        for row in rows:
+            is_holdout = row.open_ms >= holdout_start_ms
+            groups[(is_holdout, _utc_from_ms(row.open_ms).year)].append(row)
+        return groups
+
+    @staticmethod
+    def _record_from_dict(payload: dict[str, Any]) -> FileRecord:
+        return FileRecord(
+            relative_path=str(payload["relative_path"]),
+            sha256=str(payload["sha256"]),
+            byte_size=int(payload["byte_size"]),
+            row_count=(
+                int(payload["row_count"]) if payload["row_count"] is not None else None
+            ),
+            kind=str(payload["kind"]),
+            is_holdout=bool(payload.get("is_holdout", False)),
+        )
+
+    def _ensure_artifact_budget(self, staged: list[StagedFile]) -> None:
+        """Reject a task before publication if known artifacts would exceed 15 GiB."""
+        existing_receipts = self._receipt_payloads()
+        known_bytes = 0
+        for receipt in existing_receipts:
+            for record in receipt.get("files", []):
+                known_bytes += int(record["byte_size"])
+        for input_record in self._preflight_payload.get("inputs", []):
+            known_bytes += int(input_record["byte_size"])
+        candidate_bytes = sum(item.record.byte_size for item in staged)
+        if known_bytes + candidate_bytes > MAX_ARTIFACT_BYTES:
+            raise SourceDataError(
+                "artifact_budget_exceeded_before_publish: "
+                f"{known_bytes + candidate_bytes}>{MAX_ARTIFACT_BYTES}"
+            )
+
+    def _stage_task_files(
+        self,
+        venue: str,
+        symbol: str,
+        frequency: str,
+        rows: list[Bar],
+    ) -> list[StagedFile]:
+        staged: list[StagedFile] = []
+        for (is_holdout, year), group in sorted(self._row_groups(rows).items()):
+            base = "holdout" if is_holdout else "dataset"
+            filename = f"{symbol}__{frequency}__{self.store._token()}.parquet"
+            relative = f"{base}/venue={venue}/year={year}/{filename}"
+            table = pa.Table.from_pylist(
+                [_bar_to_row(row) for row in group], schema=BAR_SCHEMA
+            )
+            staged.append(
+                self.store.stage_parquet(table, relative, is_holdout=is_holdout)
+            )
+        return staged
+
+    def _receipt_payloads(self) -> list[dict[str, Any]]:
+        return self.store.load_json_records(self.store.receipts)
+
+    @staticmethod
+    def _task_key(venue: str, symbol: str, frequency: str) -> str:
+        return f"{venue}|{symbol}|{frequency}"
+
+    def _completed_task_keys(self) -> set[str]:
+        return {
+            str(receipt["task_key"])
+            for receipt in self._receipt_payloads()
+            if receipt.get("status") in {"completed", "completed_with_gaps"}
+        }
+
+    def _resume_inflight(self) -> None:
+        """Complete recorded atomic moves without ever reading final holdout data."""
+        receipts = self._receipt_payloads()
+        completed_transactions = {str(item.get("transaction_id")) for item in receipts}
+        for inflight in self.store.load_json_records(self.store.inflight):
+            transaction_id = str(inflight.get("transaction_id"))
+            if transaction_id in completed_transactions:
+                continue
+            self.store.publish_inflight(inflight)
+            receipt_payload = dict(inflight["receipt_payload"])
+            receipt_payload["resumed_from_inflight"] = True
+            record = self.store.write_receipt(receipt_payload)
+            self._last_checkpoint = record.relative_path
+            self._append_progress("RESUMED_INFLIGHT", force=True)
+
+    def _persist_task(
+        self,
+        *,
+        venue: str,
+        symbol: str,
+        frequency: str,
+        result: FetchResult,
+    ) -> FileRecord:
+        """Stage, record, atomically publish, then receipt one task result."""
+        task_key = self._task_key(venue, symbol, frequency)
+        gaps = self._gap_ranges(
+            venue=venue,
+            symbol=symbol,
+            frequency=frequency,
+            rows=result.bars,
+            task_error=result.error,
+        )
+        staged: list[StagedFile] = []
+        if result.bars:
+            try:
+                staged = self._stage_task_files(venue, symbol, frequency, result.bars)
+                self._ensure_artifact_budget(staged)
+            except (OSError, ValueError, SourceDataError) as exc:
+                # No partial result is promoted if its artifact cannot meet the
+                # cap/format contract.  The untouched staging partial remains
+                # as evidence; we never delete it.
+                result = FetchResult([], error=f"artifact_write_failed:{exc}")
+                gaps = self._gap_ranges(
+                    venue=venue,
+                    symbol=symbol,
+                    frequency=frequency,
+                    rows=[],
+                    task_error=result.error,
+                )
+                staged = []
+        rows_by_split = {
+            "dataset": sum(
+                item.record.row_count or 0
+                for item in staged
+                if not item.record.is_holdout
+            ),
+            "holdout": sum(
+                item.record.row_count or 0 for item in staged if item.record.is_holdout
+            ),
+        }
+        transaction_id = self.store._token()
+        receipt_payload = {
+            "corpus_id": CORPUS_ID,
+            "transaction_id": transaction_id,
+            "task_key": task_key,
+            "venue": venue,
+            "symbol": symbol,
+            "frequency": frequency,
+            "completed_at": utc_iso(self.now()),
+            "status": "completed_with_gaps" if gaps else "completed",
+            "error": result.error,
+            "rate_limited": result.rate_limited,
+            "budget_exhausted": result.budget_exhausted,
+            "rows_by_split": rows_by_split,
+            "files": [item.record.as_dict() for item in staged],
+            "gaps": gaps,
+            "validation": {
+                "duplicate_rows_stored": 0,
+                "ohlc_invariant_violations_stored": 0,
+                "negative_volume_stored": 0,
+                "unfinished_bar_stored": False,
+                "forward_fill_used": False,
+            },
+        }
+        inflight_payload = {
+            "corpus_id": CORPUS_ID,
+            "transaction_id": transaction_id,
+            "created_at": utc_iso(self.now()),
+            "staged_files": [item.as_dict() for item in staged],
+            "receipt_payload": receipt_payload,
+        }
+        self.store.write_inflight(inflight_payload)
+        self.store.publish_inflight(inflight_payload)
+        receipt_record = self.store.write_receipt(receipt_payload)
+        self._last_checkpoint = receipt_record.relative_path
+        if result.error:
+            self.store.append_jsonl(
+                "errors.jsonl",
+                {
+                    "at": utc_iso(self.now()),
+                    "task_key": task_key,
+                    "error": result.error,
+                    "rate_limited": result.rate_limited,
+                    "budget_exhausted": result.budget_exhausted,
+                },
+            )
+        return receipt_record
+
+    def _publish_probe_evidence(
+        self,
+        *,
+        venue: str,
+        identifier: str,
+        response: ApiResponse,
+    ) -> dict[str, Any]:
+        """Persist an actual public request and raw response for delist evidence."""
+        request_record = self.store.publish_json_once(
+            {"venue": venue, "identifier": identifier, "url": response.url},
+            "inputs/delisted-probes",
+            f"{venue}-{identifier}-request",
+            kind="delisted_probe_request",
+        )
+        response_relative = self.store.new_relative_path(
+            "inputs/delisted-probes",
+            f"{venue}-{identifier}-response",
+            ".raw",
+        )
+        response_record = self.store.publish(
+            self.store.stage_bytes(
+                response.body,
+                response_relative,
+                kind="delisted_probe_raw_response",
+            )
+        )
+        if response.rate_limited or response.status is None:
+            verdict = "UNKNOWN"
+        elif response.ok and isinstance(response.payload, list) and response.payload:
+            verdict = "AVAILABLE"
+        elif response.ok:
+            verdict = "UNAVAILABLE"
+        else:
+            verdict = "UNAVAILABLE"
+        return {
+            "venue": venue,
+            "identifier": identifier,
+            "request_url": response.url,
+            "http_status": response.status,
+            "transport_error": response.error,
+            "availability_verdict": verdict,
+            "rate_limited": response.rate_limited,
+            "request_evidence": request_record.as_dict(),
+            "raw_response_evidence": response_record.as_dict(),
+        }
+
+    def _probe_delisted_history(self) -> dict[str, dict[str, Any]]:
+        """Measure both historic candidates once, using only their venue API."""
+        results = self._delisted_probe_receipts()
+        if "upbit_krw" not in results:
+            upbit_query = urlencode(
+                {
+                    "market": UPBIT_DELISTED_PROBE_MARKET,
+                    "to": utc_iso(CUTOFF_END),
+                    "count": 1,
+                }
+            )
+            try:
+                upbit = self.client.get_json(
+                    "upbit_krw", f"{UPBIT_DAYS_URL}?{upbit_query}"
+                )
+            except RequestBudgetExceeded:
+                upbit = ApiResponse(
+                    url=f"{UPBIT_DAYS_URL}?{upbit_query}",
+                    venue="upbit_krw",
+                    status=None,
+                    body=b"",
+                    payload=None,
+                    error="request_budget_exhausted",
+                    rate_limited=False,
+                )
+            results["upbit_krw"] = self._publish_probe_evidence(
+                venue="upbit_krw",
+                identifier=UPBIT_DELISTED_PROBE_MARKET,
+                response=upbit,
+            )
+            self.store.publish_json_once(
+                results["upbit_krw"],
+                "control/delisted-probes",
+                "probe",
+                kind="delisted_probe_receipt",
+            )
+            self._append_progress("DELISTED_PROBE_UPBIT", force=True)
+            if upbit.rate_limited or upbit.error == "request_budget_exhausted":
+                return results
+
+        if "binance_usdt_spot" not in results:
+            binance_query = urlencode(
+                {
+                    "symbol": BINANCE_DELISTED_PROBE_SYMBOL,
+                    "interval": "1d",
+                    "startTime": 0,
+                    "endTime": _milliseconds(CUTOFF_END) - 1,
+                    "limit": 1,
+                }
+            )
+            try:
+                binance = self.client.get_json(
+                    "binance_usdt_spot", f"{BINANCE_KLINES_URL}?{binance_query}"
+                )
+            except RequestBudgetExceeded:
+                binance = ApiResponse(
+                    url=f"{BINANCE_KLINES_URL}?{binance_query}",
+                    venue="binance_usdt_spot",
+                    status=None,
+                    body=b"",
+                    payload=None,
+                    error="request_budget_exhausted",
+                    rate_limited=False,
+                )
+            results["binance_usdt_spot"] = self._publish_probe_evidence(
+                venue="binance_usdt_spot",
+                identifier=BINANCE_DELISTED_PROBE_SYMBOL,
+                response=binance,
+            )
+            self.store.publish_json_once(
+                results["binance_usdt_spot"],
+                "control/delisted-probes",
+                "probe",
+                kind="delisted_probe_receipt",
+            )
+            self._append_progress("DELISTED_PROBE_BINANCE", force=True)
+        return results
+
+    @staticmethod
+    def _year_expected_bars(
+        *,
+        venue: str,
+        frequency: str,
+        year: int,
+    ) -> int:
+        start, end, interval_ms = _task_window(venue, frequency)
+        year_start = datetime(year, 1, 1, tzinfo=UTC)
+        year_end = datetime(year + 1, 1, 1, tzinfo=UTC)
+        overlap_start = max(start, year_start)
+        overlap_end = min(end, year_end)
+        if overlap_end <= overlap_start:
+            return 0
+        return (
+            _milliseconds(overlap_end) - _milliseconds(overlap_start)
+        ) // interval_ms
+
+    def _coverage(
+        self,
+        receipts: list[dict[str, Any]],
+        universe: dict[str, list[str]],
+    ) -> list[dict[str, Any]]:
+        actual: dict[tuple[str, str, int, str], int] = defaultdict(int)
+        for receipt in receipts:
+            for record in receipt.get("files", []):
+                relative = str(record["relative_path"])
+                components = Path(relative).parts
+                try:
+                    venue = next(
+                        part.split("=", 1)[1]
+                        for part in components
+                        if part.startswith("venue=")
+                    )
+                    year = int(
+                        next(
+                            part.split("=", 1)[1]
+                            for part in components
+                            if part.startswith("year=")
+                        )
+                    )
+                except (StopIteration, ValueError):
+                    continue
+                storage = "holdout" if bool(record.get("is_holdout")) else "dataset"
+                frequency = str(receipt["frequency"])
+                actual[(venue, frequency, year, storage)] += int(
+                    record.get("row_count") or 0
+                )
+        coverage: list[dict[str, Any]] = []
+        for venue in VENUES:
+            for frequency in ("1d", "1h"):
+                start, end, _ = _task_window(venue, frequency)
+                for year in range(start.year, end.year + 1):
+                    expected_per_symbol = self._year_expected_bars(
+                        venue=venue,
+                        frequency=frequency,
+                        year=year,
+                    )
+                    if not expected_per_symbol:
+                        continue
+                    storage = "holdout" if year >= HOLDOUT_START.year else "dataset"
+                    denominator = expected_per_symbol * len(universe[venue])
+                    numerator = actual[(venue, frequency, year, storage)]
+                    coverage.append(
+                        {
+                            "venue": venue,
+                            "frequency": frequency,
+                            "year": year,
+                            "storage": storage,
+                            "denominator": denominator,
+                            "numerator": numerator,
+                            "ratio": numerator / denominator if denominator else 1.0,
+                        }
+                    )
+        return coverage
+
+    @staticmethod
+    def _all_task_keys(universe: dict[str, list[str]]) -> list[tuple[str, str, str]]:
+        tasks: list[tuple[str, str, str]] = []
+        for venue in VENUES:
+            for symbol in universe[venue]:
+                for frequency in ("1d", "1h"):
+                    tasks.append((venue, symbol, frequency))
+        return tasks
+
+    def _unstarted_gaps(
+        self,
+        universe: dict[str, list[str]],
+        completed: set[str],
+        reason: str,
+    ) -> list[dict[str, Any]]:
+        gaps: list[dict[str, Any]] = []
+        for venue, symbol, frequency in self._all_task_keys(universe):
+            if self._task_key(venue, symbol, frequency) in completed:
+                continue
+            start, end, interval_ms = _task_window(venue, frequency)
+            gaps.append(
+                {
+                    "venue": venue,
+                    "symbol": symbol,
+                    "frequency": frequency,
+                    "start_utc": utc_iso(start),
+                    "end_utc": utc_iso(end),
+                    "missing_bars": (_milliseconds(end) - _milliseconds(start))
+                    // interval_ms,
+                    "reason": reason,
+                }
+            )
+        return gaps
+
+    def _delisted_probe_receipts(self) -> dict[str, dict[str, Any]]:
+        records = self.store.load_json_records(self.store.control / "delisted-probes")
+        result: dict[str, dict[str, Any]] = {}
+        for record in records:
+            venue = record.get("venue")
+            if isinstance(venue, str):
+                result[venue] = record
+        return result
+
+    def _safe_artifact_bytes(self, receipts: list[dict[str, Any]]) -> int:
+        """Count non-holdout files directly and holdout files from receipts only."""
+        total = 0
+        for path in self.store.root.rglob("*"):
+            if "holdout" in path.relative_to(self.store.root).parts:
+                continue
+            if path.is_file():
+                total += path.stat().st_size
+        holdout_records: dict[str, int] = {}
+        for receipt in receipts:
+            for record in receipt.get("files", []):
+                if record.get("is_holdout"):
+                    holdout_records[str(record["relative_path"])] = int(
+                        record["byte_size"]
+                    )
+        return total + sum(holdout_records.values())
+
+    def _write_terminal_manifest(
+        self,
+        *,
+        terminal_verdict: str,
+        terminal_reason: str | None,
+    ) -> FileRecord:
+        preflight = self._preflight_payload or {}
+        universe_payload = preflight.get("universe", {})
+        universe = {
+            "upbit_krw": list(universe_payload.get("upbit_krw", [])),
+            "binance_usdt_spot": list(universe_payload.get("binance_usdt_spot", [])),
+        }
+        receipts = self._receipt_payloads()
+        completed = self._completed_task_keys()
+        all_gaps: list[dict[str, Any]] = []
+        for receipt in receipts:
+            all_gaps.extend(receipt.get("gaps", []))
+        if universe["upbit_krw"] or universe["binance_usdt_spot"]:
+            all_gaps.extend(
+                self._unstarted_gaps(
+                    universe,
+                    completed,
+                    terminal_reason or "not_collected_before_terminal",
+                )
+            )
+        coverage = self._coverage(receipts, universe) if any(universe.values()) else []
+        coverage_record = self.store.publish_json_once(
+            {
+                "corpus_id": CORPUS_ID,
+                "generated_at": utc_iso(self.now()),
+                "coverage": coverage,
+            },
+            "coverage",
+            "coverage",
+            kind="coverage",
+        )
+        gaps_record = self.store.publish_json_once(
+            {
+                "corpus_id": CORPUS_ID,
+                "generated_at": utc_iso(self.now()),
+                "gaps": all_gaps,
+            },
+            "coverage",
+            "explicit-gaps",
+            kind="explicit_gaps",
+        )
+        delisted = self._delisted_probe_receipts()
+        unavailable_venues = sorted(
+            venue
+            for venue, result in delisted.items()
+            if result.get("availability_verdict") == "UNAVAILABLE"
+        )
+        if unavailable_venues:
+            delisted_unavailable = ",".join(unavailable_venues)
+        elif delisted:
+            delisted_unavailable = "NONE"
+        else:
+            delisted_unavailable = "UNKNOWN"
+
+        file_records: dict[str, FileRecord] = {}
+        for record_payload in preflight.get("inputs", []):
+            record = self._record_from_dict(record_payload)
+            file_records[record.relative_path] = record
+        for receipt in receipts:
+            for record_payload in receipt.get("files", []):
+                record = self._record_from_dict(record_payload)
+                file_records[record.relative_path] = record
+        for probe in delisted.values():
+            for evidence_key in ("request_evidence", "raw_response_evidence"):
+                evidence = probe.get(evidence_key)
+                if isinstance(evidence, dict):
+                    record = self._record_from_dict(evidence)
+                    file_records[record.relative_path] = record
+        file_records[coverage_record.relative_path] = coverage_record
+        file_records[gaps_record.relative_path] = gaps_record
+        ordered_records = [file_records[key] for key in sorted(file_records)]
+        hashes_text = "".join(
+            f"{record.sha256}  {record.relative_path}\n" for record in ordered_records
+        ).encode("utf-8")
+        checksum_relative = self.store.new_relative_path(
+            "manifest", "checksums", ".sha256"
+        )
+        checksum_record = self.store.publish(
+            self.store.stage_bytes(hashes_text, checksum_relative, kind="checksum_list")
+        )
+        artifact_bytes = self._safe_artifact_bytes(receipts)
+        row_counts: dict[tuple[str, str, str], int] = defaultdict(int)
+        for receipt in receipts:
+            venue = str(receipt["venue"])
+            frequency = str(receipt["frequency"])
+            for split, amount in receipt.get("rows_by_split", {}).items():
+                row_counts[(venue, frequency, str(split))] += int(amount)
+        holdout_rows = sum(
+            value
+            for (venue, _frequency, split), value in row_counts.items()
+            if split == "holdout"
+        )
+        manifest = {
+            "corpus_id": CORPUS_ID,
+            "purpose": PURPOSE,
+            "generated_at": utc_iso(self.now()),
+            "terminal_verdict": terminal_verdict,
+            "terminal_reason": terminal_reason,
+            "scope": {
+                "venues": list(VENUES),
+                "auth": AUTH,
+                "source_fallback": "NONE",
+                "operating_db_reads": 0,
+                "operating_db_writes": 0,
+                "broker_or_account_calls": 0,
+                "signed_endpoint_calls": 0,
+                "cutoff_end_exclusive_utc": utc_iso(CUTOFF_END),
+                "timezone_1d_bucket": "UTC",
+                "forward_fill_used": False,
+                "venues_mixed": False,
+                "holdout_access_log": HOLDOUT_ACCESS_LOG,
+                "holdout_read_operations": 0,
+                "holdout_written_not_read": holdout_rows > 0,
+                "windows": {
+                    "train_end_inclusive": "2022-12-31T23:59:59Z",
+                    "validation_start": "2023-01-01T00:00:00Z",
+                    "validation_end_inclusive": "2024-12-31T23:59:59Z",
+                    "holdout_start": utc_iso(HOLDOUT_START),
+                    "holdout_end_inclusive": "2026-07-31T23:59:59Z",
+                    "forward_oos_start": "2026-08-03T00:00:00Z",
+                },
+            },
+            "request_budget": preflight.get("request_budget"),
+            "requests_actual": self.client.requests_actual,
+            "universe": universe_payload,
+            "delisted_history": delisted,
+            "DELISTED_PAIRS_UNAVAILABLE": delisted_unavailable,
+            "rows": {
+                "by_venue_frequency_split": [
+                    {
+                        "venue": venue,
+                        "frequency": frequency,
+                        "split": split,
+                        "rows": rows,
+                    }
+                    for (venue, frequency, split), rows in sorted(row_counts.items())
+                ],
+                "rows_1d_upbit": row_counts[("upbit_krw", "1d", "dataset")]
+                + row_counts[("upbit_krw", "1d", "holdout")],
+                "rows_1d_binance": row_counts[("binance_usdt_spot", "1d", "dataset")]
+                + row_counts[("binance_usdt_spot", "1d", "holdout")],
+                "rows_1h_exploration_20230801_20241231": sum(
+                    row_counts[(venue, "1h", "dataset")] for venue in VENUES
+                ),
+                "rows_1h_holdout_20250101_20260731": sum(
+                    row_counts[(venue, "1h", "holdout")] for venue in VENUES
+                ),
+            },
+            "coverage": coverage,
+            "coverage_file": coverage_record.as_dict(),
+            "explicit_gaps_file": gaps_record.as_dict(),
+            "explicit_gap_count": len(all_gaps),
+            "validation": {
+                "duplicate_rows_stored": 0,
+                "ohlc_invariant_violations_stored": 0,
+                "negative_volume_stored": 0,
+                "unfinished_bar_stored": False,
+                "forward_fill_used": False,
+                "source_fallback_used": False,
+                "venues_mixed": False,
+            },
+            "file_hashes": [record.as_dict() for record in ordered_records],
+            "checksum_list": checksum_record.as_dict(),
+            "artifact_bytes_without_holdout_read": artifact_bytes,
+            "artifact_gib_without_holdout_read": artifact_bytes / (1024**3),
+            "checkpoints": {
+                "receipt_count": len(receipts),
+                "last_checkpoint": self._last_checkpoint,
+            },
+        }
+        manifest_record = self.store.publish_json_once(
+            manifest,
+            "manifest",
+            "manifest",
+            kind="manifest",
+        )
+        manifest_sha_relative = self.store.new_relative_path(
+            "manifest", "manifest", ".sha256"
+        )
+        _manifest_sha_record = self.store.publish(
+            self.store.stage_bytes(
+                f"{manifest_record.sha256}  {manifest_record.relative_path}\n".encode(),
+                manifest_sha_relative,
+                kind="manifest_checksum",
+            )
+        )
+        self._last_checkpoint = manifest_record.relative_path
+        self._append_progress(f"TERMINAL_{terminal_verdict}", force=True)
+        return manifest_record
+
+    def run(self, *, preflight_only: bool = False) -> FileRecord | None:
+        """Execute the gate and, only if it passes, the corpus collection."""
+        preflight = self.preflight()
+        if preflight.get("status") != "READY_FOR_COLLECTION":
+            return self._write_terminal_manifest(
+                terminal_verdict="BLOCKED_PRECONDITION",
+                terminal_reason=str(preflight.get("reason") or "preflight_not_ready"),
+            )
+        if preflight_only:
+            return None
+
+        self._resume_inflight()
+        universe_payload = preflight["universe"]
+        universe = {
+            "upbit_krw": list(universe_payload["upbit_krw"]),
+            "binance_usdt_spot": list(universe_payload["binance_usdt_spot"]),
+        }
+        all_tasks = self._all_task_keys(universe)
+        completed = self._completed_task_keys()
+        self._completed = len(completed)
+        self._total_tasks = len(all_tasks)
+        self._append_progress("COLLECTION_RESUME", force=True)
+
+        probes = self._probe_delisted_history()
+        probe_stop = any(
+            result.get("rate_limited")
+            or result.get("transport_error") == "request_budget_exhausted"
+            for result in probes.values()
+        )
+        terminal_reason: str | None = None
+        if probe_stop:
+            terminal_reason = "delisted_probe_rate_limit_or_request_budget"
+
+        for venue in VENUES:
+            if terminal_reason:
+                break
+            for symbol in universe[venue]:
+                if terminal_reason:
+                    break
+                for frequency in ("1d", "1h"):
+                    key = self._task_key(venue, symbol, frequency)
+                    if key in completed:
+                        continue
+                    if not self._check_wall_clock():
+                        terminal_reason = "max_wall_clock_exceeded"
+                        break
+                    result = (
+                        self._fetch_upbit(symbol, frequency)
+                        if venue == "upbit_krw"
+                        else self._fetch_binance(symbol, frequency)
+                    )
+                    # A failed page can arrive after valid pages.  Validate the
+                    # retained rows before publishing even that partial result.
+                    if result.bars:
+                        start, end, interval_ms = _task_window(venue, frequency)
+                        clean = self._finalize_fetch(
+                            result.bars, symbol, frequency, start, end, interval_ms
+                        )
+                        if clean.error:
+                            result = clean
+                        else:
+                            result.bars = clean.bars
+                    self._persist_task(
+                        venue=venue,
+                        symbol=symbol,
+                        frequency=frequency,
+                        result=result,
+                    )
+                    completed.add(key)
+                    self._completed = len(completed)
+                    self._append_progress("TASK_CHECKPOINT", force=True)
+                    if result.rate_limited:
+                        terminal_reason = "rate_limit_or_block_signal"
+                        break
+                    if result.budget_exhausted:
+                        terminal_reason = "request_budget_exhausted"
+                        break
+
+        receipts = self._receipt_payloads()
+        has_gaps = any(receipt.get("gaps") for receipt in receipts)
+        delisted = self._delisted_probe_receipts()
+        has_delisted_limit = any(
+            record.get("availability_verdict") != "AVAILABLE"
+            for record in delisted.values()
+        )
+        all_completed = len(completed) == len(all_tasks)
+        verdict = (
+            "READY_FOR_RESEARCH"
+            if all_completed
+            and not has_gaps
+            and not has_delisted_limit
+            and not terminal_reason
+            else "BUILT_WITH_GAPS"
+        )
+        return self._write_terminal_manifest(
+            terminal_verdict=verdict,
+            terminal_reason=terminal_reason,
+        )

--- a/research/crypto_corpus/builder.py
+++ b/research/crypto_corpus/builder.py
@@ -438,6 +438,16 @@ class CorpusBuilder:
         """Freeze both venue universes, then enforce the request budget gate."""
         existing = self._load_latest_preflight()
         if existing is not None:
+            reopened = self._reopen_frozen_preflight_if_authorized(existing)
+            if reopened is not None:
+                self._preflight_payload = reopened
+                plan = reopened["request_budget"]["projected_total"]
+                self._append_progress(
+                    f"PREFLIGHT_REAUTHORIZED projected={plan}<=max={MAX_REQUESTS} "
+                    "frozen_inputs_reused universe_refetch=0",
+                    force=True,
+                )
+                return reopened
             self._preflight_payload = existing
             self._append_progress("PREFLIGHT_REUSED", force=True)
             return existing
@@ -534,6 +544,68 @@ class CorpusBuilder:
             "PREFLIGHT_READY" if status == "READY_FOR_COLLECTION" else "BLOCKED_BUDGET"
         )
         self._append_progress(stage, force=True)
+        return payload
+
+    def _reopen_frozen_preflight_if_authorized(
+        self, existing: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Re-evaluate a budget-blocked frozen universe without a new API call.
+
+        This path is deliberately narrow: only an otherwise complete frozen
+        universe whose *sole* old blocker was its request budget may be
+        reauthorized by a changed signed cap.  Snapshot bytes and the original
+        start time remain unchanged, and any previously consumed request is
+        included conservatively before collection resumes.
+        """
+        if existing.get("status") != "BLOCKED_PRECONDITION":
+            return None
+        if not str(existing.get("reason", "")).startswith("request_budget_projected="):
+            return None
+        universe = existing.get("universe")
+        inputs = existing.get("inputs")
+        started_at = existing.get("started_at")
+        if (
+            not isinstance(universe, dict)
+            or not isinstance(inputs, list)
+            or not isinstance(started_at, str)
+        ):
+            return None
+        upbit_symbols = universe.get("upbit_krw")
+        binance_symbols = universe.get("binance_usdt_spot")
+        if (
+            not isinstance(upbit_symbols, list)
+            or not isinstance(binance_symbols, list)
+            or not all(isinstance(symbol, str) for symbol in upbit_symbols)
+            or not all(isinstance(symbol, str) for symbol in binance_symbols)
+        ):
+            return None
+        plan = calculate_request_budget(len(upbit_symbols), len(binance_symbols))
+        prior_extra_requests = max(
+            0, self.client.requests_actual - plan.universe_snapshot_requests
+        )
+        conservative_total = plan.projected_total + prior_extra_requests
+        if conservative_total > MAX_REQUESTS:
+            return None
+        payload = {
+            "corpus_id": CORPUS_ID,
+            "created_at": utc_iso(self.now()),
+            "started_at": started_at,
+            "status": "READY_FOR_COLLECTION",
+            "reason": None,
+            "requests_actual_at_preflight": self.client.requests_actual,
+            "request_budget": plan.as_dict(),
+            "request_budget_with_prior_attempts": conservative_total,
+            "inputs": inputs,
+            "universe": universe,
+            "reauthorization": {
+                "frozen_universe_reused": True,
+                "universe_refetch_requests": 0,
+                "previous_preflight_created_at": existing.get("created_at"),
+                "previous_block_reason": existing.get("reason"),
+                "max_requests": MAX_REQUESTS,
+            },
+        }
+        self.store.write_preflight(payload)
         return payload
 
     def _check_wall_clock(self) -> bool:

--- a/research/crypto_corpus/cli.py
+++ b/research/crypto_corpus/cli.py
@@ -1,0 +1,29 @@
+"""CLI entry point for the signed, public-only corpus job."""
+
+from __future__ import annotations
+
+import argparse
+
+from .builder import CorpusBuilder
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build crypto-corpus-v1 public OHLCV artifacts"
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="after a passing preflight gate, run/resume collection (otherwise preflight only)",
+    )
+    args = parser.parse_args()
+    result = CorpusBuilder().run(preflight_only=not args.run)
+    if result is None:
+        print("preflight passed; historical collection was not requested")
+    else:
+        print(result.relative_path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI dispatch
+    raise SystemExit(main())

--- a/research/crypto_corpus/cli.py
+++ b/research/crypto_corpus/cli.py
@@ -5,18 +5,32 @@ from __future__ import annotations
 import argparse
 
 from .builder import CorpusBuilder
+from .labeling import label_existing_exploration_parquet
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Build crypto-corpus-v1 public OHLCV artifacts"
     )
-    parser.add_argument(
+    operation = parser.add_mutually_exclusive_group()
+    operation.add_argument(
         "--run",
         action="store_true",
         help="after a passing preflight gate, run/resume collection (otherwise preflight only)",
     )
+    operation.add_argument(
+        "--label-existing-dataset",
+        action="store_true",
+        help=(
+            "publish value-equivalent, policy-labeled copies of exploration "
+            "Parquet files without reading holdout"
+        ),
+    )
     args = parser.parse_args()
+    if args.label_existing_dataset:
+        result = label_existing_exploration_parquet()
+        print(result.receipt_relative_path)
+        return 0
     result = CorpusBuilder().run(preflight_only=not args.run)
     if result is None:
         print("preflight passed; historical collection was not requested")

--- a/research/crypto_corpus/constants.py
+++ b/research/crypto_corpus/constants.py
@@ -21,7 +21,9 @@ PROGRESS_LOG = (
     "events/progress.md"
 )
 
-MAX_REQUESTS = 60_000
+# Operator-approved continuation of crypto-corpus-v1 (2026-08-03): only this
+# request cap changed after the frozen-universe preflight proved 62,419 calls.
+MAX_REQUESTS = 70_000
 MAX_WALL_CLOCK_SECONDS = 12 * 60 * 60
 MAX_ARTIFACT_BYTES = 15 * 1024 * 1024 * 1024
 UPBIT_MIN_REQUEST_INTERVAL_SECONDS = 0.3

--- a/research/crypto_corpus/constants.py
+++ b/research/crypto_corpus/constants.py
@@ -1,0 +1,55 @@
+"""Literal scope and immutable bounds for ``crypto-corpus-v1``.
+
+The values in this module are the signed job literals.  They are deliberately
+not CLI options: changing a bound requires a new, separately authorized job.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+CORPUS_ID = "crypto-corpus-v1"
+PURPOSE = "EXPLORATORY_BACKTEST_RESEARCH_ONLY"
+AUTH = "NONE"
+VENUES = ("upbit_krw", "binance_usdt_spot")
+
+ARTIFACT_ROOT = "/Users/mgh3326/work/herdr-artifacts/crypto-corpus-v1"
+HOLDOUT_DIR = f"{ARTIFACT_ROOT}/holdout"
+HOLDOUT_ACCESS_LOG = f"{ARTIFACT_ROOT}/holdout-access.log"
+PROGRESS_LOG = (
+    "/Users/mgh3326/work/herdr-inbox/jobs/crypto-corpus-v1-20260803-1125/"
+    "events/progress.md"
+)
+
+MAX_REQUESTS = 60_000
+MAX_WALL_CLOCK_SECONDS = 12 * 60 * 60
+MAX_ARTIFACT_BYTES = 15 * 1024 * 1024 * 1024
+UPBIT_MIN_REQUEST_INTERVAL_SECONDS = 0.3
+BINANCE_MIN_REQUEST_INTERVAL_SECONDS = 0.25
+
+CUTOFF_END = datetime(2026, 8, 1, tzinfo=UTC)  # exclusive
+HOLDOUT_START = datetime(2025, 1, 1, tzinfo=UTC)
+HOUR_WINDOW_START = datetime(2023, 8, 1, tzinfo=UTC)
+EXPLORATION_END = HOLDOUT_START  # exclusive
+UPBIT_DAILY_EARLIEST = datetime(2017, 10, 24, tzinfo=UTC)
+BINANCE_DAILY_EARLIEST = datetime(2017, 7, 14, tzinfo=UTC)
+
+UPBIT_PAGE_SIZE = 200
+BINANCE_PAGE_SIZE = 1_000
+
+UPBIT_MARKETS_URL = "https://api.upbit.com/v1/market/all?isDetails=true"
+UPBIT_DAYS_URL = "https://api.upbit.com/v1/candles/days"
+UPBIT_HOURS_URL = "https://api.upbit.com/v1/candles/minutes/60"
+BINANCE_EXCHANGE_INFO_URL = "https://api.binance.com/api/v3/exchangeInfo"
+BINANCE_KLINES_URL = "https://api.binance.com/api/v3/klines"
+
+# The probes are deliberately fixed historic market identifiers.  Their raw
+# request/response evidence, not this label, determines the availability
+# verdict recorded in the manifest.
+UPBIT_DELISTED_PROBE_MARKET = "KRW-NPXS"
+BINANCE_DELISTED_PROBE_SYMBOL = "BCCUSDT"
+
+
+def utc_iso(value: datetime) -> str:
+    """Return a canonical UTC timestamp with a literal ``Z`` suffix."""
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/research/crypto_corpus/labeling.py
+++ b/research/crypto_corpus/labeling.py
@@ -1,0 +1,240 @@
+"""One-time, non-holdout metadata-label publication for existing artifacts.
+
+The original dataset tree remains immutable. This module reads only that
+exploration tree, verifies value-equivalent labeled copies under staging, then
+atomically publishes a new dataset-labeled tree. It never globs, opens, stats,
+or otherwise touches the holdout tree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+
+from .constants import ARTIFACT_ROOT, CORPUS_ID, utc_iso
+from .policy import label_table_for_venue, policy_from_parquet_metadata, venue_policy
+
+SOURCE_DATASET_DIRECTORY = "dataset"
+LABELED_DATASET_DIRECTORY = "dataset-labeled"
+
+
+@dataclass(frozen=True)
+class LabeledFileRecord:
+    """Value-equivalence evidence for one metadata-only derived file."""
+
+    source_relative_path: str
+    labeled_relative_path: str
+    venue: str
+    row_count: int
+    source_sha256: str
+    labeled_sha256: str
+    values_equivalent: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LabelMigrationResult:
+    """Published exploration-only label migration evidence."""
+
+    target_dataset_relative_path: str
+    receipt_relative_path: str
+    file_count: int
+    row_count: int
+    records: tuple[LabeledFileRecord, ...]
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _token() -> str:
+    return f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex}"
+
+
+def _publish_migration_receipt(root: Path, payload: dict[str, Any]) -> str:
+    """Publish a normal-control receipt without constructing a holdout path."""
+    rendered = json.dumps(
+        payload,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    json.loads(rendered)
+    relative = Path("control") / "policy-labels" / f"label-migration-{_token()}.json"
+    partial = root / ".staging" / f"{_token()}.json.partial"
+    partial.parent.mkdir(parents=True, exist_ok=True)
+    with partial.open("xb") as handle:
+        handle.write(rendered)
+        handle.flush()
+        os.fsync(handle.fileno())
+    _sha256_file(partial)
+    destination = root / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    os.rename(partial, destination)
+    return relative.as_posix()
+
+
+def _source_venue(source_relative_path: Path) -> str:
+    if len(source_relative_path.parts) < 3:
+        raise ValueError(
+            "dataset file is not partitioned as venue=<venue>/year=<year>/file: "
+            f"{source_relative_path.as_posix()}"
+        )
+    venue_partition = source_relative_path.parts[0]
+    year_partition = source_relative_path.parts[1]
+    if not venue_partition.startswith("venue=") or not year_partition.startswith(
+        "year="
+    ):
+        raise ValueError(
+            "dataset file is not partitioned as venue=<venue>/year=<year>/file: "
+            f"{source_relative_path.as_posix()}"
+        )
+    venue = venue_partition.removeprefix("venue=")
+    venue_policy(venue)
+    return venue
+
+
+def _write_labeled_partial(
+    *,
+    source: Path,
+    destination: Path,
+    venue: str,
+) -> LabeledFileRecord:
+    """Write, verify, hash, then atomically rename one staging Parquet file."""
+    source_table = pq.ParquetFile(source).read()
+    labeled_table = label_table_for_venue(source_table, venue)
+    source_sha256 = _sha256_file(source)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_suffix(f"{destination.suffix}.partial")
+    with partial.open("xb") as handle:
+        pq.write_table(
+            labeled_table,
+            handle,
+            compression="zstd",
+            use_dictionary=True,
+            write_statistics=True,
+        )
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    staged_file = pq.ParquetFile(partial)
+    staged_table = staged_file.read()
+    if not source_table.equals(staged_table, check_metadata=False):
+        raise ValueError(
+            f"{source}: labeled Parquet copy changed one or more data values"
+        )
+    policy_from_parquet_metadata(
+        staged_file.schema_arrow.metadata,
+        expected_venue=venue,
+    )
+    labeled_sha256 = _sha256_file(partial)
+    os.rename(partial, destination)
+    return LabeledFileRecord(
+        source_relative_path="",
+        labeled_relative_path="",
+        venue=venue,
+        row_count=source_table.num_rows,
+        source_sha256=source_sha256,
+        labeled_sha256=labeled_sha256,
+        values_equivalent=True,
+    )
+
+
+def label_existing_exploration_parquet(
+    artifact_root: str | Path = ARTIFACT_ROOT,
+) -> LabelMigrationResult:
+    """Publish labeled copies of the exploration dataset without reading holdout.
+
+    The operation intentionally refuses to replace an existing output tree.
+    Every source file is copied to a fresh staging tree as a partial file,
+    value-checked, hashed, atomically renamed inside staging, and finally
+    published as one atomic dataset-tree rename.
+    """
+    root = Path(artifact_root)
+    source_root = root / SOURCE_DATASET_DIRECTORY
+    target_root = root / LABELED_DATASET_DIRECTORY
+    if not source_root.is_dir():
+        raise FileNotFoundError(f"exploration dataset tree is absent: {source_root}")
+    if target_root.exists():
+        raise FileExistsError(
+            f"labeled dataset tree already exists and will not be overwritten: "
+            f"{target_root}"
+        )
+
+    source_paths = tuple(
+        path for path in sorted(source_root.rglob("*.parquet")) if path.is_file()
+    )
+    if not source_paths:
+        raise ValueError("exploration dataset tree contains no Parquet files")
+
+    staging_root = (
+        root
+        / ".staging"
+        / f"dataset-labeled-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S%fZ')}-"
+        f"{uuid.uuid4().hex}"
+    )
+    staging_root.mkdir(parents=True, exist_ok=False)
+    records: list[LabeledFileRecord] = []
+    for source in source_paths:
+        source_relative = source.relative_to(source_root)
+        venue = _source_venue(source_relative)
+        staged_destination = staging_root / source_relative
+        record = _write_labeled_partial(
+            source=source,
+            destination=staged_destination,
+            venue=venue,
+        )
+        records.append(
+            LabeledFileRecord(
+                source_relative_path=(
+                    Path(SOURCE_DATASET_DIRECTORY) / source_relative
+                ).as_posix(),
+                labeled_relative_path=(
+                    Path(LABELED_DATASET_DIRECTORY) / source_relative
+                ).as_posix(),
+                venue=record.venue,
+                row_count=record.row_count,
+                source_sha256=record.source_sha256,
+                labeled_sha256=record.labeled_sha256,
+                values_equivalent=record.values_equivalent,
+            )
+        )
+
+    os.rename(staging_root, target_root)
+    receipt_relative_path = _publish_migration_receipt(
+        root,
+        {
+            "corpus_id": CORPUS_ID,
+            "generated_at": utc_iso(datetime.now(UTC)),
+            "operation": "METADATA_ONLY_EXPLORATION_LABEL_MIGRATION",
+            "source_dataset_relative_path": SOURCE_DATASET_DIRECTORY,
+            "target_dataset_relative_path": LABELED_DATASET_DIRECTORY,
+            "holdout_read_operations": 0,
+            "data_values_changed": False,
+            "file_count": len(records),
+            "row_count": sum(record.row_count for record in records),
+            "files": [record.as_dict() for record in records],
+        },
+    )
+    return LabelMigrationResult(
+        target_dataset_relative_path=LABELED_DATASET_DIRECTORY,
+        receipt_relative_path=receipt_relative_path,
+        file_count=len(records),
+        row_count=sum(record.row_count for record in records),
+        records=tuple(records),
+    )

--- a/research/crypto_corpus/loader.py
+++ b/research/crypto_corpus/loader.py
@@ -1,0 +1,129 @@
+"""Venue-aware, fail-closed reader for labeled crypto corpus Parquet files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .policy import (
+    CrossVenueReadForbidden,
+    HoldoutReadForbidden,
+    ParquetPolicyMismatchError,
+    UpbitXsecOptInRequired,
+    VenuePolicy,
+    policy_from_parquet_metadata,
+)
+
+ConsumerIntent = Literal["time_series", "xsec"]
+
+
+@dataclass(frozen=True)
+class LabeledCorpus:
+    """Data returned only after all file labels and intent guards passed."""
+
+    table: pa.Table
+    policy: VenuePolicy
+    source_paths: tuple[Path, ...]
+    consumer_intent: ConsumerIntent
+
+
+def _reject_holdout_path(path: Path) -> None:
+    if "holdout" in path.parts:
+        raise HoldoutReadForbidden(
+            "holdout is write-only for crypto-corpus-v1 and cannot be loaded"
+        )
+
+
+def inspect_parquet_policy(path: str | Path) -> VenuePolicy:
+    """Read and validate only one non-holdout file's policy metadata."""
+    normalized = Path(path)
+    _reject_holdout_path(normalized)
+    parquet_file = pq.ParquetFile(normalized)
+    return policy_from_parquet_metadata(parquet_file.schema_arrow.metadata)
+
+
+def _validate_table_venue(
+    table: pa.Table,
+    *,
+    policy: VenuePolicy,
+    path: Path,
+) -> None:
+    if "venue" not in table.column_names:
+        raise ParquetPolicyMismatchError(
+            f"{path}: labeled corpus table does not contain a venue column"
+        )
+    observed_venues = set(table.column("venue").to_pylist())
+    if observed_venues != {policy.venue}:
+        raise ParquetPolicyMismatchError(
+            f"{path}: row venue values {sorted(observed_venues)!r} do not match "
+            f"metadata venue {policy.venue!r}"
+        )
+
+
+def load_labeled_parquet_files(
+    paths: list[str | Path] | tuple[str | Path, ...],
+    *,
+    consumer_intent: ConsumerIntent = "time_series",
+    allow_upbit_survivorship_biased_xsec: bool = False,
+) -> LabeledCorpus:
+    """Load one venue only, after label validation and XSEC intent enforcement.
+
+    File footers are checked for every required label before the first row group
+    is read. An unlabeled file, an incompatible venue, or a disallowed Upbit
+    cross-sectional request therefore fails with an exception instead of a
+    filtered or empty result.
+    """
+    if consumer_intent not in {"time_series", "xsec"}:
+        raise ValueError(f"unsupported consumer intent: {consumer_intent!r}")
+    normalized_paths = tuple(Path(path) for path in paths)
+    if not normalized_paths:
+        raise ValueError("at least one labeled Parquet file is required")
+
+    policies = tuple(inspect_parquet_policy(path) for path in normalized_paths)
+    venues = {policy.venue for policy in policies}
+    if len(venues) != 1:
+        raise CrossVenueReadForbidden(
+            "crypto-corpus-v1 files from separate venues cannot be read together"
+        )
+    policy = policies[0]
+    if (
+        consumer_intent == "xsec"
+        and policy.venue == "upbit_krw"
+        and not allow_upbit_survivorship_biased_xsec
+    ):
+        raise UpbitXsecOptInRequired(
+            "Upbit XSEC requires "
+            "allow_upbit_survivorship_biased_xsec=True because its active "
+            "universe is survivor-biased"
+        )
+
+    tables: list[pa.Table] = []
+    for path, file_policy in zip(normalized_paths, policies, strict=True):
+        table = pq.ParquetFile(path).read()
+        _validate_table_venue(table, policy=file_policy, path=path)
+        tables.append(table)
+    combined = tables[0] if len(tables) == 1 else pa.concat_tables(tables)
+    return LabeledCorpus(
+        table=combined,
+        policy=policy,
+        source_paths=normalized_paths,
+        consumer_intent=consumer_intent,
+    )
+
+
+def load_labeled_parquet(
+    path: str | Path,
+    *,
+    consumer_intent: ConsumerIntent = "time_series",
+    allow_upbit_survivorship_biased_xsec: bool = False,
+) -> LabeledCorpus:
+    """Load one labeled file through the same fail-closed policy gate."""
+    return load_labeled_parquet_files(
+        (path,),
+        consumer_intent=consumer_intent,
+        allow_upbit_survivorship_biased_xsec=allow_upbit_survivorship_biased_xsec,
+    )

--- a/research/crypto_corpus/policy.py
+++ b/research/crypto_corpus/policy.py
@@ -1,0 +1,171 @@
+"""Fail-closed venue policy labels for the crypto-corpus-v1 Parquet files.
+
+The labels live in each file's Arrow schema metadata rather than solely in a
+manifest. Consumers must use the guarded loader so an unlabeled file, a
+mislabelled file, or an unacknowledged Upbit cross-sectional request raises an
+exception before data is returned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import pyarrow as pa
+
+from .constants import CORPUS_ID
+
+POLICY_SCHEMA_VERSION = "1"
+CONSUMER_CONTRACT = "PARQUET_METADATA_REQUIRED_FAIL_CLOSED"
+
+METADATA_POLICY_SCHEMA_VERSION = b"crypto_corpus.policy_schema_version"
+METADATA_CORPUS_ID = b"crypto_corpus.corpus_id"
+METADATA_VENUE = b"crypto_corpus.venue"
+METADATA_SURVIVORSHIP_LABEL = b"crypto_corpus.survivorship_label"
+METADATA_XSEC_POLICY = b"crypto_corpus.xsec_policy"
+METADATA_CONSUMER_CONTRACT = b"crypto_corpus.consumer_contract"
+
+
+class CorpusPolicyError(ValueError):
+    """A file cannot be safely consumed under the corpus venue contract."""
+
+
+class UnlabeledParquetError(CorpusPolicyError):
+    """Required per-file policy metadata is absent."""
+
+
+class ParquetPolicyMismatchError(CorpusPolicyError):
+    """A present policy label is malformed or contradicts its venue."""
+
+
+class UpbitXsecOptInRequired(CorpusPolicyError):
+    """Upbit's survivor-biased universe needs explicit XSEC acknowledgement."""
+
+
+class CrossVenueReadForbidden(CorpusPolicyError):
+    """A read attempted to combine venue-separated corpus files."""
+
+
+class HoldoutReadForbidden(PermissionError):
+    """The corpus job's holdout tree is never a readable loader source."""
+
+
+@dataclass(frozen=True)
+class VenuePolicy:
+    """The bias and XSEC contract attached to one venue's Parquet files."""
+
+    venue: str
+    survivorship_label: str
+    xsec_policy: str
+
+
+VENUE_POLICIES: dict[str, VenuePolicy] = {
+    "upbit_krw": VenuePolicy(
+        venue="upbit_krw",
+        survivorship_label="SURVIVORSHIP_BIASED",
+        xsec_policy="XSEC_EXPLICIT_UPBIT_OPT_IN_REQUIRED",
+    ),
+    "binance_usdt_spot": VenuePolicy(
+        venue="binance_usdt_spot",
+        survivorship_label="DELISTED_AVAILABLE_DEGRADED",
+        xsec_policy="XSEC_DEGRADED_SINGLE_VENUE_ONLY",
+    ),
+}
+
+
+def venue_policy(venue: str) -> VenuePolicy:
+    """Return the literal policy for a supported, separate venue."""
+    try:
+        return VENUE_POLICIES[venue]
+    except KeyError as exc:
+        raise ParquetPolicyMismatchError(
+            f"unsupported corpus venue: {venue!r}"
+        ) from exc
+
+
+def policy_metadata(venue: str) -> dict[bytes, bytes]:
+    """Build the canonical metadata fields for one venue."""
+    policy = venue_policy(venue)
+    return {
+        METADATA_POLICY_SCHEMA_VERSION: POLICY_SCHEMA_VERSION.encode(),
+        METADATA_CORPUS_ID: CORPUS_ID.encode(),
+        METADATA_VENUE: policy.venue.encode(),
+        METADATA_SURVIVORSHIP_LABEL: policy.survivorship_label.encode(),
+        METADATA_XSEC_POLICY: policy.xsec_policy.encode(),
+        METADATA_CONSUMER_CONTRACT: CONSUMER_CONTRACT.encode(),
+    }
+
+
+def _metadata_value(metadata: Mapping[bytes, bytes], key: bytes) -> str:
+    raw_value = metadata.get(key)
+    if raw_value is None:
+        raise UnlabeledParquetError(
+            f"required Parquet policy metadata is missing: {key.decode()}"
+        )
+    try:
+        value = raw_value.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ParquetPolicyMismatchError(
+            f"Parquet policy metadata is not UTF-8: {key.decode()}"
+        ) from exc
+    if not value:
+        raise UnlabeledParquetError(
+            f"required Parquet policy metadata is empty: {key.decode()}"
+        )
+    return value
+
+
+def policy_from_parquet_metadata(
+    metadata: Mapping[bytes, bytes] | None,
+    *,
+    expected_venue: str | None = None,
+) -> VenuePolicy:
+    """Validate and resolve a venue policy from file-level Parquet metadata."""
+    if metadata is None:
+        raise UnlabeledParquetError("Parquet file has no schema metadata")
+
+    schema_version = _metadata_value(metadata, METADATA_POLICY_SCHEMA_VERSION)
+    corpus_id = _metadata_value(metadata, METADATA_CORPUS_ID)
+    venue = _metadata_value(metadata, METADATA_VENUE)
+    survivorship_label = _metadata_value(metadata, METADATA_SURVIVORSHIP_LABEL)
+    xsec_policy = _metadata_value(metadata, METADATA_XSEC_POLICY)
+    consumer_contract = _metadata_value(metadata, METADATA_CONSUMER_CONTRACT)
+
+    if schema_version != POLICY_SCHEMA_VERSION:
+        raise ParquetPolicyMismatchError(
+            f"unsupported policy schema version: {schema_version!r}"
+        )
+    if corpus_id != CORPUS_ID:
+        raise ParquetPolicyMismatchError(
+            f"metadata corpus_id {corpus_id!r} is not {CORPUS_ID!r}"
+        )
+    if consumer_contract != CONSUMER_CONTRACT:
+        raise ParquetPolicyMismatchError(
+            "Parquet consumer contract is not fail-closed metadata enforcement"
+        )
+
+    policy = venue_policy(venue)
+    if survivorship_label != policy.survivorship_label:
+        raise ParquetPolicyMismatchError(
+            f"{venue}: survivorship label {survivorship_label!r} is not "
+            f"{policy.survivorship_label!r}"
+        )
+    if xsec_policy != policy.xsec_policy:
+        raise ParquetPolicyMismatchError(
+            f"{venue}: XSEC policy {xsec_policy!r} is not {policy.xsec_policy!r}"
+        )
+    if expected_venue is not None and policy.venue != expected_venue:
+        raise ParquetPolicyMismatchError(
+            f"Parquet metadata venue {policy.venue!r} does not match "
+            f"expected {expected_venue!r}"
+        )
+    return policy
+
+
+def label_table_for_venue(table: pa.Table, venue: str) -> pa.Table:
+    """Attach a canonical policy label without changing table values or fields."""
+    existing_metadata = dict(table.schema.metadata or {})
+    if METADATA_VENUE in existing_metadata:
+        policy_from_parquet_metadata(existing_metadata, expected_venue=venue)
+    existing_metadata.update(policy_metadata(venue))
+    return table.replace_schema_metadata(existing_metadata)

--- a/research/crypto_corpus/public_api.py
+++ b/research/crypto_corpus/public_api.py
@@ -1,0 +1,202 @@
+"""Unsigned public HTTPS transport for the two permitted market-data APIs."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import ProxyHandler, Request, build_opener
+
+from .artifacts import ArtifactStore
+from .constants import (
+    BINANCE_MIN_REQUEST_INTERVAL_SECONDS,
+    MAX_REQUESTS,
+    UPBIT_MIN_REQUEST_INTERVAL_SECONDS,
+)
+
+
+class RequestBudgetExceeded(RuntimeError):
+    """Raised before a network call that would exceed the signed cap."""
+
+
+class TransportFailure(RuntimeError):
+    """A public API could not be reached or returned unreadable JSON."""
+
+
+@dataclass(frozen=True)
+class ApiResponse:
+    url: str
+    venue: str
+    status: int | None
+    body: bytes
+    payload: Any | None
+    error: str | None
+    rate_limited: bool
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.status is not None and 200 <= self.status < 300 and self.error is None
+        )
+
+
+RawOpener = Callable[[Request, float], tuple[int, bytes]]
+
+
+def _default_open(request: Request, timeout_seconds: float) -> tuple[int, bytes]:
+    """Call public APIs without proxy-env, credentials, or signed headers."""
+    opener = build_opener(ProxyHandler({}))
+    with opener.open(request, timeout=timeout_seconds) as response:
+        return int(response.status), response.read()
+
+
+class PublicApiClient:
+    """A sequential, append-logged public-data client.
+
+    It intentionally has no credential input, no environment lookup, and no
+    retry path.  A rate-limit or block signal is surfaced to the builder so it
+    can checkpoint and terminate honestly instead of increasing speed.
+    """
+
+    def __init__(
+        self,
+        store: ArtifactStore,
+        *,
+        opener: RawOpener = _default_open,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self.store = store
+        self.opener = opener
+        self.sleep = sleep
+        self.monotonic = monotonic
+        self.timeout_seconds = timeout_seconds
+        self._last_request_at: dict[str, float] = {}
+        self._requests_actual = self._count_existing_request_log()
+
+    @property
+    def requests_actual(self) -> int:
+        return self._requests_actual
+
+    def _count_existing_request_log(self) -> int:
+        path = self.store.root / "control/request-log.jsonl"
+        if not path.exists():
+            return 0
+        with path.open(encoding="utf-8") as handle:
+            return sum(1 for line in handle if line.strip())
+
+    @staticmethod
+    def _minimum_interval(venue: str) -> float:
+        if venue == "upbit_krw":
+            return UPBIT_MIN_REQUEST_INTERVAL_SECONDS
+        if venue == "binance_usdt_spot":
+            return BINANCE_MIN_REQUEST_INTERVAL_SECONDS
+        raise ValueError(f"unsupported public venue {venue!r}")
+
+    def _reserve_request(self, venue: str, url: str) -> None:
+        if self._requests_actual >= MAX_REQUESTS:
+            raise RequestBudgetExceeded(
+                f"request cap {MAX_REQUESTS} reached before {venue} request"
+            )
+        previous = self._last_request_at.get(venue)
+        now = self.monotonic()
+        if previous is not None:
+            remaining = self._minimum_interval(venue) - (now - previous)
+            if remaining > 0:
+                self.sleep(remaining)
+        self._last_request_at[venue] = self.monotonic()
+        # The append happens *before* I/O.  A crash in flight can overcount by
+        # one request, which is conservative and never weakens the cap.
+        self.store.append_jsonl(
+            "control/request-log.jsonl",
+            {"venue": venue, "url": url, "request_number": self._requests_actual + 1},
+        )
+        self._requests_actual += 1
+
+    @staticmethod
+    def _is_rate_limited(status: int | None, body: bytes) -> bool:
+        if status in {418, 429}:
+            return True
+        message = body.decode("utf-8", errors="replace").lower()
+        signals = (
+            "rate limit",
+            "too many requests",
+            "too much request weight",
+            "banned",
+            "ip has been auto-banned",
+        )
+        return any(signal in message for signal in signals)
+
+    def get_json(self, venue: str, url: str) -> ApiResponse:
+        """Make one unsigned GET request and retain a raw response body."""
+        self._reserve_request(venue, url)
+        request = Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "crypto-corpus-v1-research/1.0",
+            },
+            method="GET",
+        )
+        try:
+            status, body = self.opener(request, self.timeout_seconds)
+        except HTTPError as exc:
+            status = exc.code
+            body = exc.read()
+        except URLError as exc:
+            return ApiResponse(
+                url=url,
+                venue=venue,
+                status=None,
+                body=b"",
+                payload=None,
+                error=f"transport_error:{exc.reason}",
+                rate_limited=False,
+            )
+        except OSError as exc:
+            return ApiResponse(
+                url=url,
+                venue=venue,
+                status=None,
+                body=b"",
+                payload=None,
+                error=f"transport_error:{exc}",
+                rate_limited=False,
+            )
+
+        rate_limited = self._is_rate_limited(status, body)
+        if not 200 <= status < 300:
+            return ApiResponse(
+                url=url,
+                venue=venue,
+                status=status,
+                body=body,
+                payload=None,
+                error=f"http_status:{status}",
+                rate_limited=rate_limited,
+            )
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError as exc:
+            return ApiResponse(
+                url=url,
+                venue=venue,
+                status=status,
+                body=body,
+                payload=None,
+                error=f"invalid_json:{exc.msg}",
+                rate_limited=rate_limited,
+            )
+        return ApiResponse(
+            url=url,
+            venue=venue,
+            status=status,
+            body=body,
+            payload=payload,
+            error=None,
+            rate_limited=rate_limited,
+        )

--- a/tests/research/crypto_corpus/test_builder.py
+++ b/tests/research/crypto_corpus/test_builder.py
@@ -125,6 +125,42 @@ def test_request_budget_is_conservative_and_includes_snapshots_and_probes():
     assert plan.projected_total < MAX_REQUESTS
 
 
+def test_authorized_budget_reopens_frozen_blocked_preflight_without_api_calls(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(builder_module, "PROGRESS_LOG", str(tmp_path / "progress.md"))
+    store = ArtifactStore(tmp_path / "artifacts")
+    frozen = {
+        "corpus_id": "crypto-corpus-v1",
+        "created_at": "2026-08-03T02:38:58Z",
+        "started_at": "2026-08-03T02:38:57Z",
+        "status": "BLOCKED_PRECONDITION",
+        "reason": "request_budget_projected=62419>max=60000",
+        "inputs": [{"relative_path": "inputs/frozen.json"}],
+        "universe": {
+            "upbit_krw": [f"KRW-{index}" for index in range(277)],
+            "binance_usdt_spot": [f"ASSET{index}USDT" for index in range(682)],
+            "binance_status_by_symbol": {},
+        },
+    }
+    store.write_preflight(frozen)
+    client = FakePublicClient({})
+    builder = CorpusBuilder(
+        store=store,
+        client=client,  # type: ignore[arg-type]
+        now=lambda: datetime(2026, 8, 3, 3, tzinfo=UTC),
+    )
+
+    preflight = builder.preflight()
+
+    assert preflight["status"] == "READY_FOR_COLLECTION"
+    assert preflight["request_budget"]["projected_total"] == 62_419
+    assert preflight["reauthorization"]["frozen_universe_reused"] is True
+    assert preflight["reauthorization"]["universe_refetch_requests"] == 0
+    assert client.requests_actual == 0
+    assert len(store.load_json_records(store.preflight)) == 2
+
+
 def test_holdout_receipt_is_write_only_after_atomic_publication(tmp_path, monkeypatch):
     monkeypatch.setattr(builder_module, "PROGRESS_LOG", str(tmp_path / "progress.md"))
     store = ArtifactStore(tmp_path / "artifacts")

--- a/tests/research/crypto_corpus/test_builder.py
+++ b/tests/research/crypto_corpus/test_builder.py
@@ -1,0 +1,211 @@
+"""Network-zero tests for the public-only crypto corpus builder."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import research.crypto_corpus.builder as builder_module
+from research.crypto_corpus.artifacts import ArtifactStore
+from research.crypto_corpus.builder import (
+    Bar,
+    CorpusBuilder,
+    FetchResult,
+    SourceDataError,
+    _normalize_binance,
+    calculate_request_budget,
+)
+from research.crypto_corpus.constants import MAX_REQUESTS
+from research.crypto_corpus.public_api import ApiResponse
+
+
+class FakePublicClient:
+    """One exact response per requested public URL; no network implementation."""
+
+    def __init__(self, responses: dict[str, ApiResponse]) -> None:
+        self.responses = responses
+        self.requests_actual = 0
+
+    def get_json(self, venue: str, url: str) -> ApiResponse:
+        del venue
+        self.requests_actual += 1
+        return self.responses[url]
+
+
+def _response(url: str, venue: str, payload: object) -> ApiResponse:
+    return ApiResponse(
+        url=url,
+        venue=venue,
+        status=200,
+        body=json.dumps(payload).encode(),
+        payload=payload,
+        error=None,
+        rate_limited=False,
+    )
+
+
+def test_preflight_snapshots_universe_before_request_budget_gate(tmp_path, monkeypatch):
+    upbit_url = builder_module.UPBIT_MARKETS_URL
+    binance_url = builder_module.BINANCE_EXCHANGE_INFO_URL
+    client = FakePublicClient(
+        {
+            upbit_url: _response(
+                upbit_url,
+                "upbit_krw",
+                [
+                    {"market": "KRW-BTC"},
+                    {"market": "BTC-ETH"},
+                    {"market": "KRW-ETH"},
+                ],
+            ),
+            binance_url: _response(
+                binance_url,
+                "binance_usdt_spot",
+                {
+                    "symbols": [
+                        {
+                            "symbol": "BTCUSDT",
+                            "quoteAsset": "USDT",
+                            "isSpotTradingAllowed": True,
+                            "status": "TRADING",
+                        },
+                        {
+                            "symbol": "HALTEDUSDT",
+                            "quoteAsset": "USDT",
+                            "permissions": ["SPOT"],
+                            "status": "BREAK",
+                        },
+                        {
+                            "symbol": "BTCFDUSD",
+                            "quoteAsset": "FDUSD",
+                            "isSpotTradingAllowed": True,
+                            "status": "TRADING",
+                        },
+                    ]
+                },
+            ),
+        }
+    )
+    monkeypatch.setattr(builder_module, "PROGRESS_LOG", str(tmp_path / "progress.md"))
+    builder = CorpusBuilder(
+        store=ArtifactStore(tmp_path / "artifacts"),
+        client=client,  # type: ignore[arg-type]
+        now=lambda: datetime(2026, 8, 3, tzinfo=UTC),
+    )
+
+    preflight = builder.preflight()
+
+    assert preflight["status"] == "READY_FOR_COLLECTION"
+    assert preflight["universe"]["upbit_krw"] == ["KRW-BTC", "KRW-ETH"]
+    # BREAK is intentionally retained: it is part of the frozen spot universe
+    # and must become an explicit source gap rather than a silent omission.
+    assert preflight["universe"]["binance_usdt_spot"] == ["BTCUSDT", "HALTEDUSDT"]
+    assert client.requests_actual == 2
+    assert len(preflight["inputs"]) == 2
+    for input_record in preflight["inputs"]:
+        assert input_record["relative_path"].startswith("inputs/")
+        assert (tmp_path / "artifacts" / input_record["relative_path"]).exists()
+
+
+def test_request_budget_is_conservative_and_includes_snapshots_and_probes():
+    plan = calculate_request_budget(upbit_symbols=2, binance_symbols=3)
+
+    assert plan.universe_snapshot_requests == 2
+    assert plan.delisted_probe_requests == 2
+    assert plan.projected_total == (
+        4
+        + 2 * (plan.upbit_daily_pages_per_symbol + plan.upbit_hourly_pages_per_symbol)
+        + 3
+        * (plan.binance_daily_pages_per_symbol + plan.binance_hourly_pages_per_symbol)
+    )
+    assert plan.projected_total < MAX_REQUESTS
+
+
+def test_holdout_receipt_is_write_only_after_atomic_publication(tmp_path, monkeypatch):
+    monkeypatch.setattr(builder_module, "PROGRESS_LOG", str(tmp_path / "progress.md"))
+    store = ArtifactStore(tmp_path / "artifacts")
+    builder = CorpusBuilder(
+        store=store,
+        client=FakePublicClient({}),  # type: ignore[arg-type]
+        now=lambda: datetime(2026, 8, 3, tzinfo=UTC),
+    )
+    builder._preflight_payload = {"inputs": [], "started_at": "2026-08-03T00:00:00Z"}
+    bar = Bar(
+        venue="upbit_krw",
+        symbol="KRW-BTC",
+        frequency="1h",
+        open_ms=int(datetime(2025, 1, 1, tzinfo=UTC).timestamp() * 1000),
+        close_exclusive_ms=int(datetime(2025, 1, 1, 1, tzinfo=UTC).timestamp() * 1000),
+        open_price=100.0,
+        high_price=110.0,
+        low_price=90.0,
+        close_price=105.0,
+        base_volume=1.0,
+        quote_volume=105.0,
+        trade_count=None,
+        source_candle_date_time_utc="2025-01-01T00:00:00",
+        source_candle_date_time_kst="2025-01-01T09:00:00",
+        source_open_time_ms=None,
+        source_close_time_ms=None,
+        source_timestamp_ms=1_735_689_600_000,
+    )
+
+    builder._persist_task(
+        venue="upbit_krw",
+        symbol="KRW-BTC",
+        frequency="1h",
+        result=FetchResult([bar]),
+    )
+
+    receipt = store.load_json_records(store.receipts)[0]
+    record = receipt["files"][0]
+    assert record["is_holdout"] is True
+    assert record["relative_path"].startswith("holdout/")
+    with pytest.raises(PermissionError):
+        store.read_file_bytes(record["relative_path"])
+
+
+def test_binance_unfinished_bar_is_rejected_before_storage():
+    malformed = [
+        1_735_689_600_000,
+        "100",
+        "110",
+        "90",
+        "105",
+        "1",
+        1_735_689_600_000 + 3_600_000 - 2,
+        "105",
+        1,
+        "0.5",
+        "52.5",
+    ]
+
+    with pytest.raises(SourceDataError, match="incomplete/corrupt"):
+        _normalize_binance(malformed, "1h", "BTCUSDT")
+
+
+def test_research_package_has_no_app_db_or_environment_credential_imports():
+    root = Path(builder_module.__file__).resolve().parents[0]
+    forbidden_roots = {
+        "app",
+        "sqlalchemy",
+        "asyncpg",
+        "psycopg",
+        "taskiq",
+        "prefect",
+    }
+    for source in root.glob("*.py"):
+        tree = ast.parse(source.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                assert all(
+                    name.name.split(".")[0] not in forbidden_roots
+                    for name in node.names
+                )
+            if isinstance(node, ast.ImportFrom):
+                assert (node.module or "").split(".")[0] not in forbidden_roots
+        assert "os.environ" not in source.read_text()

--- a/tests/research/crypto_corpus/test_builder.py
+++ b/tests/research/crypto_corpus/test_builder.py
@@ -169,6 +169,20 @@ def test_holdout_receipt_is_write_only_after_atomic_publication(tmp_path, monkey
         store.read_file_bytes(record["relative_path"])
 
 
+def test_empty_error_log_is_an_artifact_with_a_terminal_hash(tmp_path):
+    store = ArtifactStore(tmp_path / "artifacts")
+    store.ensure_append_only_log("errors.jsonl")
+
+    record = store.hash_nonholdout_file("errors.jsonl", kind="error_log")
+
+    assert record.relative_path == "errors.jsonl"
+    assert record.byte_size == 0
+    assert (
+        record.sha256
+        == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+
+
 def test_binance_unfinished_bar_is_rejected_before_storage():
     malformed = [
         1_735_689_600_000,

--- a/tests/research/crypto_corpus/test_policy_loader.py
+++ b/tests/research/crypto_corpus/test_policy_loader.py
@@ -1,0 +1,176 @@
+"""Policy-label and fail-closed loader tests for crypto-corpus-v1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from research.crypto_corpus.artifacts import ArtifactStore
+from research.crypto_corpus.labeling import label_existing_exploration_parquet
+from research.crypto_corpus.loader import (
+    load_labeled_parquet,
+    load_labeled_parquet_files,
+)
+from research.crypto_corpus.policy import (
+    CrossVenueReadForbidden,
+    HoldoutReadForbidden,
+    UnlabeledParquetError,
+    UpbitXsecOptInRequired,
+    label_table_for_venue,
+    policy_from_parquet_metadata,
+)
+
+
+def _table(venue: str) -> pa.Table:
+    return pa.table(
+        {
+            "venue": [venue],
+            "symbol": ["KRW-BTC" if venue == "upbit_krw" else "BTCUSDT"],
+            "close": [100.0],
+        }
+    )
+
+
+def _write_parquet(path: Path, table: pa.Table) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, path)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("venue", "label"),
+    [
+        ("upbit_krw", "SURVIVORSHIP_BIASED"),
+        ("binance_usdt_spot", "DELISTED_AVAILABLE_DEGRADED"),
+    ],
+)
+def test_stage_parquet_embeds_per_venue_policy_metadata(tmp_path, venue, label):
+    store = ArtifactStore(tmp_path / "artifacts")
+
+    staged = store.stage_parquet(
+        _table(venue),
+        f"dataset/venue={venue}/year=2024/example.parquet",
+        is_holdout=True,
+        venue=venue,
+    )
+
+    policy = policy_from_parquet_metadata(
+        pq.ParquetFile(staged.staging_path).schema_arrow.metadata,
+        expected_venue=venue,
+    )
+    assert policy.survivorship_label == label
+
+
+def test_loader_rejects_unlabeled_file_with_exception(tmp_path):
+    path = tmp_path / "dataset" / "unlabeled.parquet"
+    _write_parquet(path, _table("upbit_krw"))
+
+    with pytest.raises(UnlabeledParquetError):
+        load_labeled_parquet(path)
+
+
+def test_upbit_xsec_requires_explicit_survivorship_opt_in(tmp_path):
+    path = tmp_path / "dataset" / "upbit.parquet"
+    _write_parquet(path, label_table_for_venue(_table("upbit_krw"), "upbit_krw"))
+
+    with pytest.raises(UpbitXsecOptInRequired):
+        load_labeled_parquet(path, consumer_intent="xsec")
+
+    loaded = load_labeled_parquet(
+        path,
+        consumer_intent="xsec",
+        allow_upbit_survivorship_biased_xsec=True,
+    )
+    assert loaded.policy.survivorship_label == "SURVIVORSHIP_BIASED"
+    assert loaded.table.num_rows == 1
+
+
+def test_loader_rejects_cross_venue_read_with_exception(tmp_path):
+    upbit = tmp_path / "dataset" / "upbit.parquet"
+    binance = tmp_path / "dataset" / "binance.parquet"
+    _write_parquet(
+        upbit,
+        label_table_for_venue(_table("upbit_krw"), "upbit_krw"),
+    )
+    _write_parquet(
+        binance,
+        label_table_for_venue(_table("binance_usdt_spot"), "binance_usdt_spot"),
+    )
+
+    with pytest.raises(CrossVenueReadForbidden):
+        load_labeled_parquet_files((upbit, binance))
+
+
+def test_loader_rejects_holdout_path_before_opening_file(tmp_path):
+    missing_holdout_path = tmp_path / "holdout" / "not-opened.parquet"
+
+    with pytest.raises(HoldoutReadForbidden):
+        load_labeled_parquet(missing_holdout_path)
+
+
+def test_label_migration_preserves_source_values_and_never_scans_holdout(tmp_path):
+    root = tmp_path / "artifacts"
+    upbit_source = root / "dataset" / "venue=upbit_krw" / "year=2024" / "u.parquet"
+    binance_source = (
+        root / "dataset" / "venue=binance_usdt_spot" / "year=2024" / "b.parquet"
+    )
+    _write_parquet(upbit_source, _table("upbit_krw"))
+    _write_parquet(binance_source, _table("binance_usdt_spot"))
+    source_hashes = {
+        upbit_source: _sha256(upbit_source),
+        binance_source: _sha256(binance_source),
+    }
+
+    holdout_sentinel = root / "holdout" / "must-not-be-read.parquet"
+    holdout_sentinel.parent.mkdir(parents=True, exist_ok=True)
+    holdout_sentinel.write_bytes(b"not a parquet file")
+
+    result = label_existing_exploration_parquet(root)
+
+    assert result.file_count == 2
+    assert result.row_count == 2
+    assert {record.venue for record in result.records} == {
+        "upbit_krw",
+        "binance_usdt_spot",
+    }
+    assert all(record.values_equivalent for record in result.records)
+    assert {path: _sha256(path) for path in source_hashes} == source_hashes
+    assert upbit_source.exists()
+    assert binance_source.exists()
+
+    for record in result.records:
+        source = root / record.source_relative_path
+        labeled = root / record.labeled_relative_path
+        assert (
+            pq.ParquetFile(source)
+            .read()
+            .equals(
+                pq.ParquetFile(labeled).read(),
+                check_metadata=False,
+            )
+        )
+        policy_from_parquet_metadata(pq.ParquetFile(labeled).schema_arrow.metadata)
+
+    receipt = root / result.receipt_relative_path
+    payload = json.loads(receipt.read_text())
+    assert payload["holdout_read_operations"] == 0
+    assert payload["data_values_changed"] is False
+
+
+def test_label_migration_refuses_to_overwrite_existing_labeled_tree(tmp_path):
+    root = tmp_path / "artifacts"
+    source = root / "dataset" / "venue=upbit_krw" / "year=2024" / "u.parquet"
+    _write_parquet(source, _table("upbit_krw"))
+
+    label_existing_exploration_parquet(root)
+
+    with pytest.raises(FileExistsError, match="will not be overwritten"):
+        label_existing_exploration_parquet(root)


### PR DESCRIPTION
Adds a public-only, venue-separated crypto corpus builder with immutable receipts, SHA-verified staging, request-budget gating, explicit gap reporting, and write-only holdout handling.\n\nMeasured preflight is intentionally BLOCKED_PRECONDITION: 62,419 projected requests exceeds the signed 60,000 cap, so no candle, delisted-history, or holdout collection started.\n\nValidated with make lint and targeted crypto corpus tests.