### PR TITLE
feat(research): add US and crypto harness adapters

### DIFF
--- a/research/kr_corpus/backtest/holdout_guard.py
+++ b/research/kr_corpus/backtest/holdout_guard.py
@@ -21,17 +21,20 @@ symlink-to-file · CASE(UPPER/Title/Mixed).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 
 from windows import HOLDOUT_WINDOW, parse_iso_date
 
 __all__ = [
+    "DEFAULT_HOLDOUT_POLICY",
     "HOLDOUT_DIR",
     "HOLDOUT_END",
     "HOLDOUT_START",
     "HoldoutAccessError",
     "HoldoutDateBlocked",
+    "HoldoutPolicy",
     "HoldoutPathBlocked",
     "assert_date_not_holdout",
     "assert_partition_year_not_holdout",
@@ -47,6 +50,36 @@ HOLDOUT_START = parse_iso_date(HOLDOUT_WINDOW.start)  # 2025-01-01
 HOLDOUT_END = parse_iso_date(HOLDOUT_WINDOW.end)  # 2026-07-31
 
 
+@dataclass(frozen=True)
+class HoldoutPolicy:
+    """A corpus-specific holdout root with the shared closed date window.
+
+    The guard algorithm below is deliberately shared by every market adapter.
+    A different corpus may name a different holdout directory, but it must not
+    receive a copied / weakened path or date implementation.
+    """
+
+    holdout_dir: Path
+    start: date
+    end: date
+
+    def __post_init__(self) -> None:
+        if self.start > self.end:
+            raise ValueError(
+                "invalid holdout policy: "
+                f"start {self.start.isoformat()} > end {self.end.isoformat()}"
+            )
+
+
+# Preserve the original KR policy and public constants as the default. Other
+# corpus adapters bind their own root to this same guard implementation.
+DEFAULT_HOLDOUT_POLICY = HoldoutPolicy(
+    holdout_dir=HOLDOUT_DIR,
+    start=HOLDOUT_START,
+    end=HOLDOUT_END,
+)
+
+
 class HoldoutAccessError(RuntimeError):
     """Base: holdout was requested; harness refuses."""
 
@@ -59,10 +92,10 @@ class HoldoutDateBlocked(HoldoutAccessError):
     """Session date or range intersects HOLDOUT_WINDOW."""
 
 
-def holdout_root_resolved() -> Path:
+def holdout_root_resolved(*, policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY) -> Path:
     """Return the canonical holdout root (resolved, not necessarily existing)."""
     # resolve(strict=False) normalizes .. and symlinks when parents exist.
-    return HOLDOUT_DIR.expanduser().resolve()
+    return policy.holdout_dir.expanduser().resolve()
 
 
 def _casefold_key(path: Path | str) -> str:
@@ -77,7 +110,11 @@ def _casefold_key(path: Path | str) -> str:
     return text.casefold()
 
 
-def path_is_under_holdout(path: Path | str) -> bool:
+def path_is_under_holdout(
+    path: Path | str,
+    *,
+    policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY,
+) -> bool:
     """True if ``path`` is HOLDOUT_DIR or a descendant (case-fold + resolve).
 
     Does **not** open or read any file under holdout — pure path algebra.
@@ -89,7 +126,7 @@ def path_is_under_holdout(path: Path | str) -> bool:
     else:
         raise TypeError(f"path must be Path|str, got {type(path)!r}")
 
-    root = holdout_root_resolved()
+    root = holdout_root_resolved(policy=policy)
     resolved = candidate.expanduser().resolve()
 
     # 1) Structural (case-sensitive) — catches symlink / .. after resolve.
@@ -117,7 +154,11 @@ def path_is_under_holdout(path: Path | str) -> bool:
     return False
 
 
-def assert_path_not_holdout(path: Path | str) -> Path:
+def assert_path_not_holdout(
+    path: Path | str,
+    *,
+    policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY,
+) -> Path:
     """Resolve ``path`` and refuse if it is under HOLDOUT_DIR.
 
     Symlinks, relative segments (``..``, ``.``), absolute paths, and
@@ -132,8 +173,8 @@ def assert_path_not_holdout(path: Path | str) -> Path:
         raise TypeError(f"path must be Path|str, got {type(path)!r}")
 
     resolved = candidate.expanduser().resolve()
-    if path_is_under_holdout(candidate):
-        root = holdout_root_resolved()
+    if path_is_under_holdout(candidate, policy=policy):
+        root = holdout_root_resolved(policy=policy)
         raise HoldoutPathBlocked(
             f"holdout path blocked: {resolved} is under HOLDOUT_DIR={root} "
             f"(case-fold path gate)"
@@ -141,7 +182,11 @@ def assert_path_not_holdout(path: Path | str) -> Path:
     return resolved
 
 
-def assert_date_not_holdout(d: date | datetime | str) -> date:
+def assert_date_not_holdout(
+    d: date | datetime | str,
+    *,
+    policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY,
+) -> date:
     """Refuse if ``d`` falls inside HOLDOUT_WINDOW (inclusive).
 
     ``datetime`` is accepted and converted via ``.date()``; a holdout calendar
@@ -150,15 +195,19 @@ def assert_date_not_holdout(d: date | datetime | str) -> date:
     """
     session = _as_date(d)
 
-    if HOLDOUT_START <= session <= HOLDOUT_END:
+    if policy.start <= session <= policy.end:
         raise HoldoutDateBlocked(
             f"holdout date blocked: {session.isoformat()} is inside "
-            f"HOLDOUT_WINDOW={HOLDOUT_WINDOW.start}..{HOLDOUT_WINDOW.end}"
+            f"HOLDOUT_WINDOW={policy.start.isoformat()}..{policy.end.isoformat()}"
         )
     return session
 
 
-def assert_partition_year_not_holdout(year: int) -> int:
+def assert_partition_year_not_holdout(
+    year: int,
+    *,
+    policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY,
+) -> int:
     """Refuse a partition ``year`` whose calendar year intersects HOLDOUT_WINDOW.
 
     Pre-parse / pre-open gate for ``dataset/market/year`` partitions so holdout
@@ -170,16 +219,19 @@ def assert_partition_year_not_holdout(year: int) -> int:
         )
     year_start = date(year, 1, 1)
     year_end = date(year, 12, 31)
-    if year_start <= HOLDOUT_END and year_end >= HOLDOUT_START:
+    if year_start <= policy.end and year_end >= policy.start:
         raise HoldoutDateBlocked(
             f"holdout date blocked: partition year={year} intersects "
-            f"HOLDOUT_WINDOW={HOLDOUT_WINDOW.start}..{HOLDOUT_WINDOW.end}"
+            f"HOLDOUT_WINDOW={policy.start.isoformat()}..{policy.end.isoformat()}"
         )
     return year
 
 
 def assert_range_not_holdout(
-    start: date | datetime | str, end: date | datetime | str
+    start: date | datetime | str,
+    end: date | datetime | str,
+    *,
+    policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY,
 ) -> tuple[date, date]:
     """Refuse if the closed range ``[start, end]`` intersects HOLDOUT_WINDOW."""
     s = _as_date(start)
@@ -187,10 +239,10 @@ def assert_range_not_holdout(
     if s > e:
         raise ValueError(f"invalid range: start {s} > end {e}")
     # Intersect closed intervals [s, e] and [HOLDOUT_START, HOLDOUT_END].
-    if s <= HOLDOUT_END and e >= HOLDOUT_START:
+    if s <= policy.end and e >= policy.start:
         raise HoldoutDateBlocked(
             f"holdout range blocked: requested {s.isoformat()}..{e.isoformat()} "
-            f"intersects HOLDOUT_WINDOW={HOLDOUT_WINDOW.start}..{HOLDOUT_WINDOW.end}"
+            f"intersects HOLDOUT_WINDOW={policy.start.isoformat()}..{policy.end.isoformat()}"
         )
     return s, e
 

--- a/research/kr_corpus/backtest/loader.py
+++ b/research/kr_corpus/backtest/loader.py
@@ -38,13 +38,15 @@ from typing import Any, Literal
 import pyarrow as pa
 import pyarrow.parquet as pq
 from holdout_guard import (
+    DEFAULT_HOLDOUT_POLICY,
     HoldoutAccessError,
+    HoldoutPolicy,
     assert_date_not_holdout,
     assert_partition_year_not_holdout,
     assert_path_not_holdout,
     assert_range_not_holdout,
 )
-from schema_contract import SchemaMismatchError, validate_table_schema
+from schema_contract import CONTRACT_PATH, SchemaMismatchError, validate_table_schema
 from windows import EXPLORATION_WINDOW, parse_iso_date
 
 __all__ = [
@@ -126,18 +128,23 @@ def sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _resolve_within_root(artifact_root: Path, relative_path: str) -> Path:
+def _resolve_within_root(
+    artifact_root: Path,
+    relative_path: str,
+    *,
+    holdout_policy: HoldoutPolicy,
+) -> Path:
     # Holdout path gate first — even before root-escape logic — so a request
     # that points at HOLDOUT_DIR is refused as HoldoutPathBlocked specifically.
     if Path(relative_path).is_absolute():
-        assert_path_not_holdout(relative_path)
+        assert_path_not_holdout(relative_path, policy=holdout_policy)
 
     root = artifact_root.expanduser().resolve()
     # Refuse if the artifact_root itself is under holdout.
-    assert_path_not_holdout(root)
+    assert_path_not_holdout(root, policy=holdout_policy)
 
     candidate = (root / relative_path).resolve()
-    assert_path_not_holdout(candidate)
+    assert_path_not_holdout(candidate, policy=holdout_policy)
 
     if candidate != root and root not in candidate.parents:
         # Case-fold escape check already done via assert_path_not_holdout on
@@ -148,26 +155,35 @@ def _resolve_within_root(artifact_root: Path, relative_path: str) -> Path:
     return candidate
 
 
-def _gate_manifest_entry(entry: ManifestEntry, *, manifest_parent: Path) -> None:
+def _gate_manifest_entry(
+    entry: ManifestEntry,
+    *,
+    manifest_parent: Path,
+    holdout_policy: HoldoutPolicy,
+) -> None:
     """Dual path+date gate for one manifest row (before any shard open)."""
     # Date / partition-year gate (NICE-1: refuse before parquet open).
-    assert_partition_year_not_holdout(entry.year)
+    assert_partition_year_not_holdout(entry.year, policy=holdout_policy)
 
     rel = entry.relative_path
     if Path(rel).is_absolute():
-        assert_path_not_holdout(rel)
+        assert_path_not_holdout(rel, policy=holdout_policy)
     else:
-        assert_path_not_holdout(manifest_parent / rel)
+        assert_path_not_holdout(manifest_parent / rel, policy=holdout_policy)
 
 
-def load_manifest(manifest_path: Path | str) -> list[ManifestEntry]:
+def load_manifest(
+    manifest_path: Path | str,
+    *,
+    holdout_policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY,
+) -> list[ManifestEntry]:
     """Load a manifest JSON list under dual holdout gates.
 
     Gates (both required — brief §4-3):
     * **path**: manifest path itself + each entry's relative_path
     * **date**: each entry's partition ``year`` must not intersect HOLDOUT_WINDOW
     """
-    path = assert_path_not_holdout(manifest_path)
+    path = assert_path_not_holdout(manifest_path, policy=holdout_policy)
     if not path.is_file():
         raise ShardFileMissingError(f"manifest missing at {path}")
     raw = json.loads(path.read_text(encoding="utf-8"))
@@ -177,7 +193,11 @@ def load_manifest(manifest_path: Path | str) -> list[ManifestEntry]:
     entries: list[ManifestEntry] = []
     for item in raw:
         entry = ManifestEntry.from_dict(item)
-        _gate_manifest_entry(entry, manifest_parent=parent)
+        _gate_manifest_entry(
+            entry,
+            manifest_parent=parent,
+            holdout_policy=holdout_policy,
+        )
         entries.append(entry)
     return entries
 
@@ -188,6 +208,8 @@ def load_shard(
     *,
     allowed_window_start: date | str | None = None,
     allowed_window_end: date | str | None = None,
+    contract_path: Path | str = CONTRACT_PATH,
+    holdout_policy: HoldoutPolicy = DEFAULT_HOLDOUT_POLICY,
 ) -> pa.Table:
     """Load one parquet shard under manifest SHA-256 gate + holdout dual gate.
 
@@ -203,10 +225,14 @@ def load_shard(
     6. caller / default exploration window date gate
     """
     # Date gate first — refuse holdout partition years without opening files.
-    assert_partition_year_not_holdout(entry.year)
+    assert_partition_year_not_holdout(entry.year, policy=holdout_policy)
 
     root = Path(artifact_root)
-    path = _resolve_within_root(root, entry.relative_path)
+    path = _resolve_within_root(
+        root,
+        entry.relative_path,
+        holdout_policy=holdout_policy,
+    )
     if not path.is_file():
         raise ShardFileMissingError(f"shard file missing at {path}")
 
@@ -221,7 +247,7 @@ def load_shard(
 
     table = pq.read_table(pa.BufferReader(data))
     try:
-        validate_table_schema(table, entry.dataset)
+        validate_table_schema(table, entry.dataset, contract_path=contract_path)
     except SchemaMismatchError as exc:
         raise LoaderError(str(exc)) from exc
 
@@ -231,19 +257,31 @@ def load_shard(
             f"manifest={entry.row_count} actual={table.num_rows}"
         )
 
-    _assert_no_holdout_rows(table)
+    _assert_no_holdout_rows(table, holdout_policy=holdout_policy)
 
     # Optional caller window: still dual-gated against holdout.
     if allowed_window_start is not None and allowed_window_end is not None:
-        assert_range_not_holdout(allowed_window_start, allowed_window_end)
+        assert_range_not_holdout(
+            allowed_window_start,
+            allowed_window_end,
+            policy=holdout_policy,
+        )
     else:
         # Default exploration window — never opens holdout by accident.
-        assert_range_not_holdout(EXPLORATION_WINDOW.start, EXPLORATION_WINDOW.end)
+        assert_range_not_holdout(
+            EXPLORATION_WINDOW.start,
+            EXPLORATION_WINDOW.end,
+            policy=holdout_policy,
+        )
 
     return table
 
 
-def _assert_no_holdout_rows(table: pa.Table) -> None:
+def _assert_no_holdout_rows(
+    table: pa.Table,
+    *,
+    holdout_policy: HoldoutPolicy,
+) -> None:
     """Date-level holdout gate over every session_date in the table."""
     if "session_date" not in table.column_names:
         raise LoaderError("table missing session_date column")
@@ -251,7 +289,7 @@ def _assert_no_holdout_rows(table: pa.Table) -> None:
     for i in range(len(col)):
         raw = col[i].as_py()
         try:
-            assert_date_not_holdout(raw)
+            assert_date_not_holdout(raw, policy=holdout_policy)
         except HoldoutAccessError:
             raise
         # Bound check also rejects non-ISO via parse_iso_date inside guard.

--- a/research/kr_corpus/backtest/market_adapters/__init__.py
+++ b/research/kr_corpus/backtest/market_adapters/__init__.py
@@ -1,0 +1,8 @@
+"""Contract-backed US and crypto market adapters for the fixture-only harness.
+
+The modules in this package contain no data fetch or backtest execution path.
+They bind declared, inferred contracts to the shared holdout, SHA, schema, and
+PIT guards in the parent harness.
+"""
+
+from __future__ import annotations

--- a/research/kr_corpus/backtest/market_adapters/common.py
+++ b/research/kr_corpus/backtest/market_adapters/common.py
@@ -1,0 +1,116 @@
+"""Shared adapter binding for inferred local corpus contracts.
+
+Adapters use this thin object instead of reimplementing the KR harness guards:
+``loader`` performs SHA-before-parse and row-date refusal, ``holdout_guard``
+performs case-fold/symlink/path traversal refusal, and ``schema_contract``
+performs exact-schema refusal. Contract files are committed declarations, not
+real corpus artifacts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import pyarrow as pa
+from holdout_guard import (
+    HoldoutPolicy,
+    assert_date_not_holdout,
+    assert_path_not_holdout,
+    assert_range_not_holdout,
+)
+from loader import ManifestEntry, load_manifest, load_shard
+from schema_contract import arrow_schema_for, load_contract, validate_table_schema
+
+__all__ = [
+    "ContractBackedCorpusAdapter",
+    "TimestampContractError",
+    "parse_utc_timestamp",
+]
+
+
+class TimestampContractError(ValueError):
+    """A timestamp_utc field is absent, naive, malformed, or non-UTC."""
+
+
+def parse_utc_timestamp(value: datetime | str) -> datetime:
+    """Parse and retain an aware UTC timestamp without local re-anchoring.
+
+    Contract rows carry ``timestamp_utc`` as an ISO-8601 string. A non-UTC
+    offset and a naive value are loud failures: silently interpreting either as
+    ET/KST would recreate the US daily-candle date-shift failure mode.
+    """
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise TimestampContractError(
+                f"timestamp_utc must be ISO-8601 UTC, got {value!r}"
+            ) from exc
+    elif isinstance(value, datetime):
+        parsed = value
+    else:
+        raise TimestampContractError(
+            f"timestamp_utc must be datetime|str, got {type(value)!r}"
+        )
+
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise TimestampContractError("timestamp_utc must be timezone-aware UTC")
+    if parsed.utcoffset() != timedelta(0):
+        raise TimestampContractError(
+            "timestamp_utc must have a UTC (+00:00) offset; local anchors are refused"
+        )
+    return parsed.astimezone(UTC)
+
+
+@dataclass(frozen=True)
+class ContractBackedCorpusAdapter:
+    """Bind a local schema declaration and holdout policy to shared loaders."""
+
+    contract_path: Path
+    holdout_policy: HoldoutPolicy
+
+    def contract(self) -> dict:
+        return load_contract(self.contract_path)
+
+    def arrow_schema_for(self, dataset: str) -> pa.Schema:
+        return arrow_schema_for(dataset, contract_path=self.contract_path)
+
+    def validate_table_schema(self, table: pa.Table, dataset: str) -> None:
+        validate_table_schema(table, dataset, contract_path=self.contract_path)
+
+    def assert_path_allowed(self, path: Path | str) -> Path:
+        return assert_path_not_holdout(path, policy=self.holdout_policy)
+
+    def assert_date_allowed(self, value: date | datetime | str) -> date:
+        return assert_date_not_holdout(value, policy=self.holdout_policy)
+
+    def assert_range_allowed(
+        self,
+        start: date | datetime | str,
+        end: date | datetime | str,
+    ) -> tuple[date, date]:
+        return assert_range_not_holdout(start, end, policy=self.holdout_policy)
+
+    def load_manifest(self, manifest_path: Path | str) -> list[ManifestEntry]:
+        """Load only through the shared dual-gated manifest loader."""
+        return load_manifest(manifest_path, holdout_policy=self.holdout_policy)
+
+    def load_shard(
+        self,
+        artifact_root: Path | str,
+        entry: ManifestEntry,
+        *,
+        allowed_window_start: date | str | None = None,
+        allowed_window_end: date | str | None = None,
+    ) -> pa.Table:
+        """Load only through the shared SHA-before-parse loader."""
+        return load_shard(
+            artifact_root,
+            entry,
+            allowed_window_start=allowed_window_start,
+            allowed_window_end=allowed_window_end,
+            contract_path=self.contract_path,
+            holdout_policy=self.holdout_policy,
+        )

--- a/research/kr_corpus/backtest/market_adapters/contracts/crypto-corpus-v1.schema.json
+++ b/research/kr_corpus/backtest/market_adapters/contracts/crypto-corpus-v1.schema.json
@@ -1,0 +1,46 @@
+{
+  "contract_id": "crypto-corpus-v1.harness-schema.v1",
+  "schema_origin": "INFERRED_FROM_LITERALS",
+  "schema_origin_note": "INFERRED_FROM_LITERALS: declared from the harness adapter brief, not a real crypto-corpus-v1 manifest. Stage B must contrast a terminal manifest and loud-fail on any mismatch; silent coercion is forbidden.",
+  "corpus_schema_source": "crypto adapter brief literals",
+  "frequency": "1d",
+  "timestamp_storage": "timestamp_utc is ISO-8601 aware UTC and is retained without local re-anchoring",
+  "session_date_derivation": "UTC calendar date from timestamp_utc",
+  "session_calendar": "24_7_UTC",
+  "venues_allowed": ["upbit_krw", "binance_usdt"],
+  "venue_rule": "Exactly one venue per adapter view and manifest load. Mixed venue rows or entries raise an exception.",
+  "partition_keys": ["dataset", "market", "year"],
+  "partition_layout": "dataset/market/year where market is exactly the bound venue",
+  "windows": {
+    "exploration": {"start": "2015-01-01", "end": "2024-12-31"},
+    "historical_oos_holdout": {"start": "2025-01-01", "end": "2026-07-31"}
+  },
+  "datasets": {
+    "ohlcv": {
+      "required_columns": ["symbol", "venue", "timestamp_utc", "session_date", "open", "high", "low", "close", "volume", "trading_value"],
+      "column_dtypes": {
+        "symbol": "string",
+        "venue": "string",
+        "timestamp_utc": "string",
+        "session_date": "string",
+        "open": "float64",
+        "high": "float64",
+        "low": "float64",
+        "close": "float64",
+        "volume": "float64",
+        "trading_value": "float64"
+      },
+      "notes": {
+        "session_date": "must equal UTC date(timestamp_utc); every UTC calendar day is valid",
+        "prelisting": "No pre-listing synthetic bars or zero-fill are allowed",
+        "delist": "A held delisted symbol must liquidate at its last valid close",
+        "venue_bias": "upbit delisted history is unavailable while binance history is available; the code guard prohibits mixing them"
+      }
+    }
+  },
+  "manifest": {
+    "required_fields": ["relative_path", "file_sha256", "row_count", "dataset", "market", "year"],
+    "file_sha256": "hex lowercase SHA-256 of full file bytes; verified BEFORE parquet parse",
+    "gate_policy": "mismatch => hard refusal (exception), never warning-and-continue"
+  }
+}

--- a/research/kr_corpus/backtest/market_adapters/contracts/us-corpus-v1.schema.json
+++ b/research/kr_corpus/backtest/market_adapters/contracts/us-corpus-v1.schema.json
@@ -1,0 +1,61 @@
+{
+  "contract_id": "us-corpus-v1.harness-schema.v1",
+  "schema_origin": "INFERRED_FROM_LITERALS",
+  "schema_origin_note": "INFERRED_FROM_LITERALS: declared from the harness adapter brief, not a real us-corpus-v1 manifest. The raw timestamp_utc field is required to preserve UTC source time and derive session_date in America/New_York. Stage B must contrast a terminal manifest and loud-fail on any mismatch; silent coercion is forbidden.",
+  "corpus_schema_source": "US adapter brief literals",
+  "frequency": "1d",
+  "price_mode": "adjusted",
+  "timestamp_storage": "timestamp_utc is ISO-8601 aware UTC and is retained without local re-anchoring",
+  "session_date_derivation": "America/New_York from timestamp_utc",
+  "session_calendar": "XNYS",
+  "markets_allowed": ["US"],
+  "partition_keys": ["dataset", "market", "year"],
+  "partition_layout": "dataset/market/year",
+  "membership_storage": "separate_from_ohlcv",
+  "windows": {
+    "exploration": {"start": "2015-01-01", "end": "2024-12-31"},
+    "historical_oos_holdout": {"start": "2025-01-01", "end": "2026-07-31"}
+  },
+  "datasets": {
+    "ohlcv": {
+      "required_columns": ["symbol", "timestamp_utc", "session_date", "open", "high", "low", "close", "volume", "trading_value", "market"],
+      "column_dtypes": {
+        "symbol": "string",
+        "timestamp_utc": "string",
+        "session_date": "string",
+        "open": "float64",
+        "high": "float64",
+        "low": "float64",
+        "close": "float64",
+        "volume": "float64",
+        "trading_value": "float64",
+        "market": "string"
+      },
+      "notes": {
+        "session_date": "must equal date(timestamp_utc at America/New_York)",
+        "calendar": "must be an XNYS session; holiday/non-session rows fail loudly",
+        "schema_inference": "The common OHLCV / manifest envelope is inferred. timestamp_utc is explicitly required by the UTC-preservation rule."
+      }
+    },
+    "membership": {
+      "required_columns": ["symbol", "session_date", "market", "member", "status"],
+      "column_dtypes": {
+        "symbol": "string",
+        "session_date": "string",
+        "market": "string",
+        "member": "bool",
+        "status": "string"
+      },
+      "status_enum": ["listed", "delisted", "suspended"],
+      "notes": {
+        "pit": "universe at session t uses membership rows <= t only",
+        "terminal": "delisted holdings require an explicit terminal event"
+      }
+    }
+  },
+  "manifest": {
+    "required_fields": ["relative_path", "file_sha256", "row_count", "dataset", "market", "year"],
+    "file_sha256": "hex lowercase SHA-256 of full file bytes; verified BEFORE parquet parse",
+    "gate_policy": "mismatch => hard refusal (exception), never warning-and-continue"
+  }
+}

--- a/research/kr_corpus/backtest/market_adapters/costs.py
+++ b/research/kr_corpus/backtest/market_adapters/costs.py
@@ -1,0 +1,53 @@
+"""Deterministic, conservative per-side fixture cost accounting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = ["CostModel", "OrderSide"]
+
+OrderSide = Literal["buy", "sell"]
+
+
+@dataclass(frozen=True)
+class CostModel:
+    """Fee plus slippage expressed in basis points per side.
+
+    Integer minor units use ceiling division on each side. That makes an
+    indivisible unit conservatively more expensive rather than silently losing
+    a fractional cost.
+    """
+
+    fee_bp: int
+    slippage_bp_per_side: int
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("fee_bp", self.fee_bp),
+            ("slippage_bp_per_side", self.slippage_bp_per_side),
+        ):
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{field_name} must be a non-negative int")
+
+    @property
+    def side_bp(self) -> int:
+        return self.fee_bp + self.slippage_bp_per_side
+
+    @property
+    def round_trip_bp(self) -> int:
+        return self.side_bp * 2
+
+    def side_cost_minor_units(self, notional_minor: int, *, side: OrderSide) -> int:
+        """Return the rounded-up cost for one buy or sell leg."""
+        if side not in ("buy", "sell"):
+            raise ValueError(f"unsupported side {side!r}")
+        if type(notional_minor) is not int or notional_minor < 0:
+            raise ValueError("notional_minor must be a non-negative int")
+        return (notional_minor * self.side_bp + 9_999) // 10_000
+
+    def round_trip_cost_minor_units(self, notional_minor: int) -> int:
+        """Charge independently rounded buy and sell costs."""
+        return self.side_cost_minor_units(
+            notional_minor, side="buy"
+        ) + self.side_cost_minor_units(notional_minor, side="sell")

--- a/research/kr_corpus/backtest/market_adapters/crypto.py
+++ b/research/kr_corpus/backtest/market_adapters/crypto.py
@@ -1,0 +1,269 @@
+"""Venue-isolated crypto adapter for UTC-calendar fixture wiring.
+
+No API in this module accepts more than one venue. A view is bound to exactly
+one of ``upbit_krw`` or ``binance_usdt`` and raises on a mismatched manifest
+entry or row. This is a code guard against cross-sectional mixing of the
+documented biased/unbiased delisted-history universes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Literal
+
+import pyarrow as pa
+from holdout_guard import (
+    HOLDOUT_END,
+    HOLDOUT_START,
+    HoldoutPolicy,
+    assert_date_not_holdout,
+)
+from loader import ManifestEntry
+from market_adapters.common import ContractBackedCorpusAdapter, parse_utc_timestamp
+from market_adapters.costs import CostModel
+from terminal_events import TerminalEvent, force_exit_delisted_holdings
+
+__all__ = [
+    "BINANCE_USDT_COST",
+    "CRYPTO_CALENDAR",
+    "CRYPTO_HOLDOUT_POLICY",
+    "CRYPTO_SCHEMA_CONTRACT_PATH",
+    "CryptoBar",
+    "CryptoPrelistingBarsUnavailable",
+    "CryptoSessionDateMismatchError",
+    "CryptoTerminalPriceUnavailable",
+    "CryptoVenueAdapter",
+    "CryptoVenueMixError",
+    "CryptoVenueView",
+    "CryptoVenue",
+    "UPBIT_KRW_COST",
+]
+
+CryptoVenue = Literal["upbit_krw", "binance_usdt"]
+_SUPPORTED_VENUES: frozenset[str] = frozenset({"upbit_krw", "binance_usdt"})
+CRYPTO_CALENDAR = "24_7_UTC"
+CRYPTO_SCHEMA_CONTRACT_PATH = (
+    Path(__file__).resolve().parent / "contracts" / "crypto-corpus-v1.schema.json"
+)
+# This literal is a guard-only path; this module never reads this corpus root.
+CRYPTO_HOLDOUT_POLICY = HoldoutPolicy(
+    holdout_dir=Path("/Users/mgh3326/work/herdr-artifacts/crypto-corpus-v1/holdout/"),
+    start=HOLDOUT_START,
+    end=HOLDOUT_END,
+)
+UPBIT_KRW_COST = CostModel(fee_bp=5, slippage_bp_per_side=10)
+BINANCE_USDT_COST = CostModel(fee_bp=10, slippage_bp_per_side=10)
+
+
+class CryptoVenueMixError(ValueError):
+    """Rows or manifest entries attempted to cross a bound venue boundary."""
+
+
+class CryptoSessionDateMismatchError(ValueError):
+    """A declared UTC calendar day differs from the raw UTC timestamp date."""
+
+
+class CryptoTerminalPriceUnavailable(RuntimeError):
+    """A delisted held symbol has no earlier valid price for liquidation."""
+
+
+class CryptoPrelistingBarsUnavailable(LookupError):
+    """Raised only by callers that demand a pre-listing bar instead of no bar."""
+
+
+def _assert_supported_venue(venue: str) -> CryptoVenue:
+    if venue not in _SUPPORTED_VENUES:
+        raise CryptoVenueMixError(
+            f"unsupported crypto venue {venue!r}; expected one of "
+            f"{sorted(_SUPPORTED_VENUES)!r}"
+        )
+    return venue  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class CryptoBar:
+    symbol: str
+    venue: CryptoVenue
+    timestamp_utc: datetime
+    session_date: date
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    trading_value: float
+
+
+@dataclass(frozen=True)
+class CryptoVenueView:
+    """A single-venue immutable bar view; mixed construction is rejected."""
+
+    venue: CryptoVenue
+    bars: tuple[CryptoBar, ...]
+    holdout_policy: HoldoutPolicy = CRYPTO_HOLDOUT_POLICY
+
+    def __post_init__(self) -> None:
+        _assert_supported_venue(self.venue)
+        mixed = sorted({bar.venue for bar in self.bars if bar.venue != self.venue})
+        if mixed:
+            raise CryptoVenueMixError(
+                f"venue view={self.venue!r} cannot expose mixed rows {mixed!r}"
+            )
+
+    def bars_available_at(
+        self, symbol: str, session_date: date
+    ) -> tuple[CryptoBar, ...]:
+        """Return prior/current bars only; pre-listing gets an empty sequence.
+
+        Empty is intentional. It is not a synthetic zero bar or an imputed
+        pre-listing history that could distort a cross-sectional universe.
+        """
+        allowed_session = assert_date_not_holdout(
+            session_date,
+            policy=self.holdout_policy,
+        )
+        return tuple(
+            bar
+            for bar in self.bars
+            if bar.symbol == symbol and bar.session_date <= allowed_session
+        )
+
+    def require_last_valid_bar(self, symbol: str, session_date: date) -> CryptoBar:
+        """Return the latest real bar on/before ``session_date`` or fail loudly."""
+        eligible = self.bars_available_at(symbol, session_date)
+        if not eligible:
+            raise CryptoPrelistingBarsUnavailable(
+                f"no listed bar for {symbol!r} at/before {session_date.isoformat()}"
+            )
+        return max(eligible, key=lambda bar: bar.session_date)
+
+    def liquidate_delisted(
+        self,
+        *,
+        session_date: date,
+        held_symbols: set[str],
+        delisted_as_of: frozenset[str],
+    ) -> tuple[set[str], list[TerminalEvent]]:
+        """Emit explicit delist exits at each held symbol's last valid close."""
+        allowed_session = assert_date_not_holdout(
+            session_date,
+            policy=self.holdout_policy,
+        )
+        last_close_by_symbol: dict[str, float] = {}
+        for symbol in held_symbols & set(delisted_as_of):
+            try:
+                last_close_by_symbol[symbol] = self.require_last_valid_bar(
+                    symbol, allowed_session
+                ).close
+            except CryptoPrelistingBarsUnavailable as exc:
+                raise CryptoTerminalPriceUnavailable(
+                    f"cannot liquidate delisted {symbol!r} without a last valid bar"
+                ) from exc
+        return force_exit_delisted_holdings(
+            session_date=allowed_session,
+            held_symbols=held_symbols,
+            delisted_as_of=delisted_as_of,
+            last_close_by_symbol=last_close_by_symbol,
+        )
+
+
+@dataclass(frozen=True)
+class CryptoVenueAdapter:
+    """Adapter whose manifest, table, and resulting view are one venue only."""
+
+    venue: CryptoVenue
+    holdout_policy: HoldoutPolicy = CRYPTO_HOLDOUT_POLICY
+
+    def __post_init__(self) -> None:
+        _assert_supported_venue(self.venue)
+
+    @property
+    def corpus(self) -> ContractBackedCorpusAdapter:
+        return ContractBackedCorpusAdapter(
+            contract_path=CRYPTO_SCHEMA_CONTRACT_PATH,
+            holdout_policy=self.holdout_policy,
+        )
+
+    @property
+    def cost_model(self) -> CostModel:
+        if self.venue == "upbit_krw":
+            return UPBIT_KRW_COST
+        return BINANCE_USDT_COST
+
+    def load_manifest(self, manifest_path: Path | str) -> list[ManifestEntry]:
+        entries = self.corpus.load_manifest(manifest_path)
+        for entry in entries:
+            self._assert_entry_venue(entry)
+        return entries
+
+    def load_shard(
+        self,
+        artifact_root: Path | str,
+        entry: ManifestEntry,
+        *,
+        allowed_window_start: date | str | None = None,
+        allowed_window_end: date | str | None = None,
+    ) -> CryptoVenueView:
+        self._assert_entry_venue(entry)
+        table = self.corpus.load_shard(
+            artifact_root,
+            entry,
+            allowed_window_start=allowed_window_start,
+            allowed_window_end=allowed_window_end,
+        )
+        return self.view_from_table(table)
+
+    def view_from_table(self, table: pa.Table) -> CryptoVenueView:
+        """Validate one table and refuse even one row from another venue."""
+        self.corpus.validate_table_schema(table, "ohlcv")
+        data = table.to_pydict()
+        bars: list[CryptoBar] = []
+        for i in range(table.num_rows):
+            row_venue = _assert_supported_venue(str(data["venue"][i]))
+            if row_venue != self.venue:
+                raise CryptoVenueMixError(
+                    f"row {i} venue={row_venue!r} cannot enter {self.venue!r} view"
+                )
+            raw_utc = parse_utc_timestamp(data["timestamp_utc"][i])
+            derived = raw_utc.date()  # 24/7 UTC calendar day; no session calendar.
+            self.corpus.assert_date_allowed(derived)
+            try:
+                declared = date.fromisoformat(data["session_date"][i])
+            except (TypeError, ValueError) as exc:
+                raise CryptoSessionDateMismatchError(
+                    f"row {i} session_date must be ISO UTC date, got "
+                    f"{data['session_date'][i]!r}"
+                ) from exc
+            if declared != derived:
+                raise CryptoSessionDateMismatchError(
+                    f"row {i} session_date={declared.isoformat()} differs from "
+                    f"UTC timestamp date {derived.isoformat()}"
+                )
+            bars.append(
+                CryptoBar(
+                    symbol=str(data["symbol"][i]),
+                    venue=row_venue,
+                    timestamp_utc=raw_utc,
+                    session_date=derived,
+                    open=float(data["open"][i]),
+                    high=float(data["high"][i]),
+                    low=float(data["low"][i]),
+                    close=float(data["close"][i]),
+                    volume=float(data["volume"][i]),
+                    trading_value=float(data["trading_value"][i]),
+                )
+            )
+        return CryptoVenueView(
+            venue=self.venue,
+            bars=tuple(bars),
+            holdout_policy=self.holdout_policy,
+        )
+
+    def _assert_entry_venue(self, entry: ManifestEntry) -> None:
+        if entry.market != self.venue:
+            raise CryptoVenueMixError(
+                f"manifest entry market={entry.market!r} cannot enter "
+                f"{self.venue!r} adapter"
+            )

--- a/research/kr_corpus/backtest/market_adapters/tests/test_crypto_adapter.py
+++ b/research/kr_corpus/backtest/market_adapters/tests/test_crypto_adapter.py
@@ -1,0 +1,176 @@
+"""Crypto golden tests: UTC 24/7, venue isolation, costs, and delisting."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from loader import ManifestEntry, sha256_bytes
+from market_adapters.crypto import (
+    BINANCE_USDT_COST,
+    UPBIT_KRW_COST,
+    CryptoPrelistingBarsUnavailable,
+    CryptoSessionDateMismatchError,
+    CryptoVenueAdapter,
+    CryptoVenueMixError,
+)
+from pit import LookaheadViolation, assert_no_lookahead
+
+
+def _row(
+    *,
+    venue: str = "upbit_krw",
+    timestamp_utc: str = "2024-06-01T00:00:00+00:00",
+    session_date: str = "2024-06-01",
+    symbol: str = "KRW-NEW",
+    close: float = 100.0,
+) -> dict:
+    return {
+        "symbol": symbol,
+        "venue": venue,
+        "timestamp_utc": timestamp_utc,
+        "session_date": session_date,
+        "open": close,
+        "high": close,
+        "low": close,
+        "close": close,
+        "volume": 1000.0,
+        "trading_value": close * 1000.0,
+    }
+
+
+def _table(adapter: CryptoVenueAdapter, rows: list[dict]) -> pa.Table:
+    return pa.Table.from_pylist(
+        rows,
+        schema=adapter.corpus.arrow_schema_for("ohlcv"),
+    )
+
+
+def test_crypto_uses_24_7_utc_calendar_including_weekend():
+    adapter = CryptoVenueAdapter("upbit_krw")
+    view = adapter.view_from_table(_table(adapter, [_row()]))  # Saturday 2024-06-01
+    assert view.bars[0].session_date == date(2024, 6, 1)
+    assert view.bars[0].timestamp_utc.date() == date(2024, 6, 1)
+
+
+def test_crypto_loads_single_venue_synthetic_fixture_through_shared_sha_loader(
+    tmp_path,
+):
+    adapter = CryptoVenueAdapter("upbit_krw")
+    rel = "ohlcv/upbit_krw/2024/bars.parquet"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True)
+    pq.write_table(_table(adapter, [_row()]), path)
+    data = path.read_bytes()
+    entry = ManifestEntry(
+        relative_path=rel,
+        file_sha256=sha256_bytes(data),
+        row_count=1,
+        dataset="ohlcv",
+        market="upbit_krw",
+        year=2024,
+    )
+
+    view = adapter.load_shard(tmp_path, entry)
+    assert view.venue == "upbit_krw"
+    assert view.bars[0].symbol == "KRW-NEW"
+
+
+def test_crypto_rejects_non_utc_calendar_date_declaration():
+    adapter = CryptoVenueAdapter("upbit_krw")
+    table = _table(adapter, [_row(session_date="2024-05-31")])
+    with pytest.raises(CryptoSessionDateMismatchError):
+        adapter.view_from_table(table)
+
+
+def test_crypto_lookahead_goes_red_on_future_row():
+    adapter = CryptoVenueAdapter("upbit_krw")
+    view = adapter.view_from_table(
+        _table(
+            adapter,
+            [
+                _row(
+                    timestamp_utc="2024-06-01T00:00:00+00:00", session_date="2024-06-01"
+                ),
+                _row(
+                    timestamp_utc="2024-06-02T00:00:00+00:00", session_date="2024-06-02"
+                ),
+            ],
+        )
+    )
+    with pytest.raises(LookaheadViolation) as exc_info:
+        assert_no_lookahead(view.bars, "2024-06-01")
+    assert "2024-06-02" in str(exc_info.value)
+
+
+def test_crypto_venue_mix_is_exception_not_documentation_only():
+    adapter = CryptoVenueAdapter("upbit_krw")
+    table = _table(
+        adapter,
+        [_row(venue="upbit_krw"), _row(venue="binance_usdt", symbol="BTCUSDT")],
+    )
+    with pytest.raises(CryptoVenueMixError) as exc_info:
+        adapter.view_from_table(table)
+    assert "cannot enter" in str(exc_info.value)
+
+
+def test_crypto_manifest_entry_from_other_venue_is_rejected_before_read(tmp_path):
+    adapter = CryptoVenueAdapter("upbit_krw")
+    entry = ManifestEntry(
+        relative_path="ohlcv/binance_usdt/2024/bars.parquet",
+        file_sha256="0" * 64,
+        row_count=0,
+        dataset="ohlcv",
+        market="binance_usdt",
+        year=2024,
+    )
+    with pytest.raises(CryptoVenueMixError):
+        adapter.load_shard(tmp_path, entry)
+
+
+def test_crypto_costs_are_venue_specific_and_bidirectional():
+    notional_minor = 1_000_000
+    assert UPBIT_KRW_COST.fee_bp == 5
+    assert UPBIT_KRW_COST.slippage_bp_per_side == 10
+    assert UPBIT_KRW_COST.side_cost_minor_units(notional_minor, side="buy") == 1_500
+    assert UPBIT_KRW_COST.side_cost_minor_units(notional_minor, side="sell") == 1_500
+    assert UPBIT_KRW_COST.round_trip_cost_minor_units(notional_minor) == 3_000
+    assert BINANCE_USDT_COST.fee_bp == 10
+    assert BINANCE_USDT_COST.slippage_bp_per_side == 10
+    assert BINANCE_USDT_COST.round_trip_cost_minor_units(notional_minor) == 4_000
+
+
+def test_crypto_prelisting_has_no_synthetic_bar_and_delist_uses_last_valid_close():
+    adapter = CryptoVenueAdapter("upbit_krw")
+    view = adapter.view_from_table(
+        _table(
+            adapter,
+            [
+                _row(
+                    timestamp_utc="2024-06-02T00:00:00+00:00",
+                    session_date="2024-06-02",
+                    close=101.0,
+                ),
+                _row(
+                    timestamp_utc="2024-06-03T00:00:00+00:00",
+                    session_date="2024-06-03",
+                    close=123.45,
+                ),
+            ],
+        )
+    )
+    assert view.bars_available_at("KRW-NEW", date(2024, 6, 1)) == ()
+    with pytest.raises(CryptoPrelistingBarsUnavailable):
+        view.require_last_valid_bar("KRW-NEW", date(2024, 6, 1))
+
+    residual, events = view.liquidate_delisted(
+        session_date=date(2024, 6, 4),
+        held_symbols={"KRW-NEW", "KRW-OTHER"},
+        delisted_as_of=frozenset({"KRW-NEW"}),
+    )
+    assert residual == {"KRW-OTHER"}
+    assert len(events) == 1
+    assert events[0].symbol == "KRW-NEW"
+    assert events[0].last_close == 123.45

--- a/research/kr_corpus/backtest/market_adapters/tests/test_shared_guard_reuse.py
+++ b/research/kr_corpus/backtest/market_adapters/tests/test_shared_guard_reuse.py
@@ -1,0 +1,142 @@
+"""Both adapters bind the parent harness guards; no market-local copies."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from holdout_guard import (
+    HOLDOUT_END,
+    HOLDOUT_START,
+    HoldoutDateBlocked,
+    HoldoutPathBlocked,
+    HoldoutPolicy,
+)
+from loader import ManifestEntry, ManifestShaMismatchError
+from market_adapters.crypto import CryptoVenueAdapter
+from market_adapters.us import USMarketAdapter
+from schema_contract import SchemaMismatchError
+
+
+def _adapter(market: str, policy: HoldoutPolicy):
+    if market == "us":
+        return USMarketAdapter(holdout_policy=policy)
+    if market == "crypto":
+        return CryptoVenueAdapter("upbit_krw", holdout_policy=policy)
+    raise AssertionError(f"unexpected market {market!r}")
+
+
+def _market_field(market: str) -> str:
+    return "US" if market == "us" else "upbit_krw"
+
+
+def _row(market: str) -> dict:
+    common = {
+        "symbol": "ABC" if market == "us" else "KRW-ABC",
+        "timestamp_utc": "2024-07-03T20:00:00+00:00",
+        "session_date": "2024-07-03",
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.5,
+        "volume": 1000.0,
+        "trading_value": 100_000.0,
+    }
+    if market == "us":
+        return {**common, "market": "US"}
+    return {**common, "venue": "upbit_krw"}
+
+
+@pytest.mark.parametrize("market", ["us", "crypto"])
+def test_shared_holdout_policy_blocks_date_boundaries(market: str, tmp_path: Path):
+    policy = HoldoutPolicy(tmp_path / "holdout", HOLDOUT_START, HOLDOUT_END)
+    adapter = _adapter(market, policy)
+
+    assert adapter.corpus.assert_date_allowed("2024-12-31") == date(2024, 12, 31)
+    with pytest.raises(HoldoutDateBlocked):
+        adapter.corpus.assert_date_allowed("2025-01-01")
+
+
+@pytest.mark.parametrize("market", ["us", "crypto"])
+def test_shared_holdout_policy_blocks_case_symlink_and_dotdot(
+    market: str, tmp_path: Path
+):
+    """The exact common path gate rejects every market's bypass attempts."""
+    holdout_root = tmp_path / "holdout"
+    holdout_root.mkdir()
+    policy = HoldoutPolicy(holdout_root, HOLDOUT_START, HOLDOUT_END)
+    adapter = _adapter(market, policy)
+    symlink = tmp_path / "symlink_to_holdout"
+    symlink.symlink_to(holdout_root, target_is_directory=True)
+
+    candidates = (
+        holdout_root,
+        holdout_root / "child.parquet",
+        holdout_root / ".." / "holdout" / "via-dotdot.parquet",
+        holdout_root.parent / "HOLDOUT" / "case-variant.parquet",
+        symlink / "via-symlink.parquet",
+    )
+    for candidate in candidates:
+        with pytest.raises(HoldoutPathBlocked):
+            adapter.corpus.assert_path_allowed(candidate)
+
+
+@pytest.mark.parametrize("market", ["us", "crypto"])
+def test_shared_loader_entrypoints_block_holdout_paths(market: str, tmp_path: Path):
+    """Both manifest and shard entrypoints use the same configured policy."""
+    holdout_root = tmp_path / "holdout"
+    holdout_root.mkdir()
+    policy = HoldoutPolicy(holdout_root, HOLDOUT_START, HOLDOUT_END)
+    adapter = _adapter(market, policy)
+
+    with pytest.raises(HoldoutPathBlocked):
+        adapter.load_manifest(holdout_root / "manifest.json")
+
+    entry = ManifestEntry(
+        relative_path=str(holdout_root / "ohlcv" / "bars.parquet"),
+        file_sha256="0" * 64,
+        row_count=0,
+        dataset="ohlcv",
+        market=_market_field(market),
+        year=2024,
+    )
+    with pytest.raises(HoldoutPathBlocked):
+        adapter.load_shard(tmp_path, entry)
+
+
+@pytest.mark.parametrize("market", ["us", "crypto"])
+def test_shared_schema_mismatch_is_loud(market: str, tmp_path: Path):
+    policy = HoldoutPolicy(tmp_path / "holdout", HOLDOUT_START, HOLDOUT_END)
+    adapter = _adapter(market, policy)
+    with pytest.raises(SchemaMismatchError) as exc_info:
+        adapter.corpus.validate_table_schema(pa.table({"symbol": ["only"]}), "ohlcv")
+    assert "mismatch" in str(exc_info.value).lower()
+
+
+@pytest.mark.parametrize("market", ["us", "crypto"])
+def test_shared_manifest_sha_gate_rejects_tampered_fixture(market: str, tmp_path: Path):
+    """Synthetic fixture only: digest mismatch fails before parquet parsing."""
+    policy = HoldoutPolicy(tmp_path / "holdout", HOLDOUT_START, HOLDOUT_END)
+    adapter = _adapter(market, policy)
+    rel = f"ohlcv/{_market_field(market)}/2024/bars.parquet"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True)
+    table = pa.Table.from_pylist(
+        [_row(market)],
+        schema=adapter.corpus.arrow_schema_for("ohlcv"),
+    )
+    pq.write_table(table, path)
+
+    entry = ManifestEntry(
+        relative_path=rel,
+        file_sha256="f" * 64,
+        row_count=1,
+        dataset="ohlcv",
+        market=_market_field(market),
+        year=2024,
+    )
+    with pytest.raises(ManifestShaMismatchError):
+        adapter.load_shard(tmp_path, entry)

--- a/research/kr_corpus/backtest/market_adapters/tests/test_us_adapter.py
+++ b/research/kr_corpus/backtest/market_adapters/tests/test_us_adapter.py
@@ -1,0 +1,156 @@
+"""US adapter golden tests: ET session dates, XNYS, costs, and terminals."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from loader import ManifestEntry, sha256_bytes
+from market_adapters.us import (
+    US_ADAPTER,
+    US_DEFAULT_COST,
+    US_SLIPPAGE_SENSITIVITY_COST,
+    USCalendarError,
+    USSessionDateMismatchError,
+    is_xnys_early_close,
+    is_xnys_session,
+)
+from pit import LookaheadViolation, assert_no_lookahead
+
+
+def _row(
+    *,
+    timestamp_utc: str = "2024-07-03T20:00:00+00:00",
+    session_date: str = "2024-07-03",
+    symbol: str = "ABC",
+) -> dict:
+    return {
+        "symbol": symbol,
+        "timestamp_utc": timestamp_utc,
+        "session_date": session_date,
+        "open": 100.0,
+        "high": 102.0,
+        "low": 99.0,
+        "close": 101.0,
+        "volume": 1000.0,
+        "trading_value": 101_000.0,
+        "market": "US",
+    }
+
+
+def _table(rows: list[dict]) -> pa.Table:
+    return pa.Table.from_pylist(
+        rows,
+        schema=US_ADAPTER.corpus.arrow_schema_for("ohlcv"),
+    )
+
+
+def test_us_keeps_raw_utc_and_derives_et_session_date():
+    bars = US_ADAPTER.bars_from_table(_table([_row()]))
+    assert len(bars) == 1
+    bar = bars[0]
+    assert bar.timestamp_utc == datetime(2024, 7, 3, 20, 0, tzinfo=UTC)
+    assert bar.session_date == date(2024, 7, 3)
+
+
+def test_us_loads_synthetic_fixture_through_shared_sha_loader(tmp_path):
+    rel = "ohlcv/US/2024/bars.parquet"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True)
+    pq.write_table(_table([_row()]), path)
+    data = path.read_bytes()
+    entry = ManifestEntry(
+        relative_path=rel,
+        file_sha256=sha256_bytes(data),
+        row_count=1,
+        dataset="ohlcv",
+        market="US",
+        year=2024,
+    )
+
+    bars = US_ADAPTER.load_shard(tmp_path, entry)
+    assert bars[0].timestamp_utc == datetime(2024, 7, 3, 20, 0, tzinfo=UTC)
+
+
+def test_us_rejects_kst_anchor_style_session_date_shift():
+    """00:00 UTC is Jul-03 ET, so a Jul-04 declared day cannot pass silently."""
+    table = _table(
+        [
+            _row(
+                timestamp_utc="2024-07-04T00:00:00+00:00",
+                session_date="2024-07-04",
+            )
+        ]
+    )
+    with pytest.raises(USSessionDateMismatchError) as exc_info:
+        US_ADAPTER.bars_from_table(table)
+    assert "derived ET date 2024-07-03" in str(exc_info.value)
+
+
+def test_us_xnys_holiday_and_half_day_are_calendar_backed():
+    assert not is_xnys_session(date(2024, 7, 4))  # Independence Day
+    assert is_xnys_session(date(2024, 11, 29))  # Black Friday
+    assert is_xnys_early_close(date(2024, 11, 29))
+    assert not is_xnys_early_close(date(2024, 7, 4))
+
+
+def test_us_rejects_non_xnys_session_row():
+    table = _table(
+        [
+            _row(
+                timestamp_utc="2024-07-04T20:00:00+00:00",
+                session_date="2024-07-04",
+            )
+        ]
+    )
+    with pytest.raises(USCalendarError):
+        US_ADAPTER.bars_from_table(table)
+
+
+def test_us_lookahead_goes_red_on_future_row():
+    bars = US_ADAPTER.bars_from_table(
+        _table(
+            [
+                _row(
+                    timestamp_utc="2024-07-02T20:00:00+00:00", session_date="2024-07-02"
+                ),
+                _row(
+                    timestamp_utc="2024-07-03T20:00:00+00:00", session_date="2024-07-03"
+                ),
+            ]
+        )
+    )
+    with pytest.raises(LookaheadViolation) as exc_info:
+        assert_no_lookahead(bars, "2024-07-02")
+    assert "2024-07-03" in str(exc_info.value)
+
+
+def test_us_costs_are_per_side_integer_rounded_and_bidirectional():
+    notional_minor = 1_000_000
+    assert US_DEFAULT_COST.fee_bp == 0
+    assert US_DEFAULT_COST.slippage_bp_per_side == 10
+    assert US_DEFAULT_COST.side_cost_minor_units(notional_minor, side="buy") == 1_000
+    assert US_DEFAULT_COST.side_cost_minor_units(notional_minor, side="sell") == 1_000
+    assert US_DEFAULT_COST.round_trip_cost_minor_units(notional_minor) == 2_000
+    assert US_SLIPPAGE_SENSITIVITY_COST.slippage_bp_per_side == 5
+    assert (
+        US_SLIPPAGE_SENSITIVITY_COST.round_trip_cost_minor_units(notional_minor)
+        == 1_000
+    )
+    assert US_DEFAULT_COST.round_trip_cost_minor_units(1) == 2  # ceil each leg
+
+
+def test_us_delist_terminal_event_is_explicit_when_present():
+    residual, events = US_ADAPTER.terminalize_delisted(
+        session_date=date(2024, 7, 3),
+        held_symbols={"ABC", "STILL"},
+        delisted_as_of=frozenset({"ABC"}),
+        last_close_by_symbol={"ABC": 87.5},
+    )
+    assert residual == {"STILL"}
+    assert len(events) == 1
+    assert events[0].symbol == "ABC"
+    assert events[0].reason == "delisted"
+    assert events[0].last_close == 87.5

--- a/research/kr_corpus/backtest/market_adapters/us.py
+++ b/research/kr_corpus/backtest/market_adapters/us.py
@@ -1,0 +1,214 @@
+"""US daily-bar adapter: raw UTC timestamps and XNYS-derived session dates.
+
+This is fixture-only contract wiring. It intentionally does not fetch corpus
+data or execute a backtest. A source row must carry both raw ``timestamp_utc``
+and a declared session_date; disagreement with America/New_York derivation is
+a loud contract failure, preventing a KST-anchored daily candle from silently
+shifting every US row one day backward.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from functools import lru_cache
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import exchange_calendars as xcals
+import pyarrow as pa
+from holdout_guard import HOLDOUT_END, HOLDOUT_START, HoldoutPolicy
+from loader import ManifestEntry
+from market_adapters.common import ContractBackedCorpusAdapter, parse_utc_timestamp
+from market_adapters.costs import CostModel
+from membership import MembershipRow, membership_rows_from_table
+from terminal_events import TerminalEvent, force_exit_delisted_holdings
+
+__all__ = [
+    "US_ADAPTER",
+    "US_CALENDAR",
+    "US_DEFAULT_COST",
+    "US_HOLDOUT_POLICY",
+    "US_SCHEMA_CONTRACT_PATH",
+    "US_SESSION_TIMEZONE",
+    "US_SLIPPAGE_SENSITIVITY_COST",
+    "USBar",
+    "USCalendarError",
+    "USMarketAdapter",
+    "USSessionDateMismatchError",
+    "derive_us_session_date",
+    "is_xnys_early_close",
+    "is_xnys_session",
+]
+
+US_CALENDAR = "XNYS"
+US_SESSION_TIMEZONE = ZoneInfo("America/New_York")
+US_SCHEMA_CONTRACT_PATH = (
+    Path(__file__).resolve().parent / "contracts" / "us-corpus-v1.schema.json"
+)
+# This literal is a guard-only path; this module never reads this corpus root.
+US_HOLDOUT_POLICY = HoldoutPolicy(
+    holdout_dir=Path("/Users/mgh3326/work/herdr-artifacts/us-corpus-v1/holdout/"),
+    start=HOLDOUT_START,
+    end=HOLDOUT_END,
+)
+US_DEFAULT_COST = CostModel(fee_bp=0, slippage_bp_per_side=10)
+US_SLIPPAGE_SENSITIVITY_COST = CostModel(fee_bp=0, slippage_bp_per_side=5)
+
+
+class USCalendarError(ValueError):
+    """A derived US session is not an XNYS trading session."""
+
+
+class USSessionDateMismatchError(ValueError):
+    """Declared session_date differs from raw-UTC → ET derivation."""
+
+
+@lru_cache(maxsize=1)
+def _xnys_calendar():
+    return xcals.get_calendar(US_CALENDAR)
+
+
+def derive_us_session_date(timestamp_utc: datetime | str) -> date:
+    """Derive the US calendar date from an unmodified UTC source timestamp."""
+    raw_utc = parse_utc_timestamp(timestamp_utc)
+    return raw_utc.astimezone(US_SESSION_TIMEZONE).date()
+
+
+def is_xnys_session(session_date: date) -> bool:
+    """Return whether ``session_date`` is a regular XNYS session day."""
+    return bool(_xnys_calendar().is_session(session_date))
+
+
+def is_xnys_early_close(session_date: date) -> bool:
+    """Return whether an open XNYS session closes before 16:00 ET."""
+    calendar = _xnys_calendar()
+    if not calendar.is_session(session_date):
+        return False
+    close_et = (
+        calendar.session_close(session_date)
+        .to_pydatetime()
+        .astimezone(US_SESSION_TIMEZONE)
+    )
+    return close_et.timetz().replace(tzinfo=None) < time(16, 0)
+
+
+@dataclass(frozen=True)
+class USBar:
+    """US bar preserving raw UTC time alongside its ET-derived session date."""
+
+    symbol: str
+    timestamp_utc: datetime
+    session_date: date
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    trading_value: float
+    market: str
+
+
+@dataclass(frozen=True)
+class USMarketAdapter:
+    """Bind the US inferred contract to shared holdout/SHA/schema guards."""
+
+    holdout_policy: HoldoutPolicy = US_HOLDOUT_POLICY
+
+    @property
+    def corpus(self) -> ContractBackedCorpusAdapter:
+        return ContractBackedCorpusAdapter(
+            contract_path=US_SCHEMA_CONTRACT_PATH,
+            holdout_policy=self.holdout_policy,
+        )
+
+    def load_manifest(self, manifest_path: Path | str) -> list[ManifestEntry]:
+        return self.corpus.load_manifest(manifest_path)
+
+    def load_shard(
+        self,
+        artifact_root: Path | str,
+        entry: ManifestEntry,
+        *,
+        allowed_window_start: date | str | None = None,
+        allowed_window_end: date | str | None = None,
+    ) -> list[USBar]:
+        """Load an OHLCV shard through shared guards, then enforce ET dates."""
+        table = self.corpus.load_shard(
+            artifact_root,
+            entry,
+            allowed_window_start=allowed_window_start,
+            allowed_window_end=allowed_window_end,
+        )
+        return self.bars_from_table(table)
+
+    def bars_from_table(self, table: pa.Table) -> list[USBar]:
+        """Validate rows, derive ET dates, and preserve the raw UTC instant."""
+        self.corpus.validate_table_schema(table, "ohlcv")
+        data = table.to_pydict()
+        bars: list[USBar] = []
+        for i in range(table.num_rows):
+            raw_utc = parse_utc_timestamp(data["timestamp_utc"][i])
+            derived = derive_us_session_date(raw_utc)
+            self.corpus.assert_date_allowed(derived)
+            try:
+                declared = date.fromisoformat(data["session_date"][i])
+            except (TypeError, ValueError) as exc:
+                raise USSessionDateMismatchError(
+                    f"row {i} session_date must be ISO date, got "
+                    f"{data['session_date'][i]!r}"
+                ) from exc
+            if declared != derived:
+                raise USSessionDateMismatchError(
+                    f"row {i} session_date={declared.isoformat()} differs from "
+                    f"UTC timestamp {raw_utc.isoformat()} derived ET date "
+                    f"{derived.isoformat()}"
+                )
+            if not is_xnys_session(derived):
+                raise USCalendarError(
+                    f"row {i} ET-derived session_date {derived.isoformat()} "
+                    "is not an XNYS session"
+                )
+            market = str(data["market"][i])
+            if market != "US":
+                raise ValueError(f"row {i} market must be 'US', got {market!r}")
+            bars.append(
+                USBar(
+                    symbol=str(data["symbol"][i]),
+                    timestamp_utc=raw_utc,
+                    session_date=derived,
+                    open=float(data["open"][i]),
+                    high=float(data["high"][i]),
+                    low=float(data["low"][i]),
+                    close=float(data["close"][i]),
+                    volume=float(data["volume"][i]),
+                    trading_value=float(data["trading_value"][i]),
+                    market=market,
+                )
+            )
+        return bars
+
+    def membership_from_table(self, table: pa.Table) -> list[MembershipRow]:
+        """Reuse shared PIT membership parsing after US-contract validation."""
+        self.corpus.validate_table_schema(table, "membership")
+        return membership_rows_from_table(table)
+
+    def terminalize_delisted(
+        self,
+        *,
+        session_date: date,
+        held_symbols: set[str],
+        delisted_as_of: frozenset[str],
+        last_close_by_symbol: dict[str, float],
+    ) -> tuple[set[str], list[TerminalEvent]]:
+        """Reuse the shared explicit terminal-event path for US delists."""
+        self.corpus.assert_date_allowed(session_date)
+        return force_exit_delisted_holdings(
+            session_date=session_date,
+            held_symbols=held_symbols,
+            delisted_as_of=delisted_as_of,
+            last_close_by_symbol=last_close_by_symbol,
+        )
+
+
+US_ADAPTER = USMarketAdapter()

--- a/research/kr_corpus/backtest/schema_contract.py
+++ b/research/kr_corpus/backtest/schema_contract.py
@@ -49,9 +49,15 @@ class SchemaMismatchError(SchemaContractError):
     """Parquet/table schema does not exactly match the declared contract."""
 
 
-def load_contract() -> dict[str, Any]:
-    """Load the declared JSON contract (source of truth for column/dtype)."""
-    raw = CONTRACT_PATH.read_text(encoding="utf-8")
+def load_contract(contract_path: Path | str | None = None) -> dict[str, Any]:
+    """Load a declared local JSON contract (source of truth for schema).
+
+    ``CONTRACT_PATH`` remains the KR default. Market adapters pass a committed
+    inferred contract explicitly; this loader never discovers a schema from a
+    live corpus artifact.
+    """
+    path = Path(contract_path) if contract_path is not None else CONTRACT_PATH
+    raw = path.read_text(encoding="utf-8")
     contract = json.loads(raw)
     if contract.get("schema_origin") != SCHEMA_ORIGIN:
         raise SchemaContractError(
@@ -61,9 +67,13 @@ def load_contract() -> dict[str, Any]:
     return contract
 
 
-def arrow_schema_for(dataset: str) -> pa.Schema:
+def arrow_schema_for(
+    dataset: str,
+    *,
+    contract_path: Path | str | None = None,
+) -> pa.Schema:
     """Exact Arrow schema pinned by the declared contract for ``dataset``."""
-    contract = load_contract()
+    contract = load_contract(contract_path)
     try:
         ds = contract["datasets"][dataset]
     except KeyError as exc:
@@ -82,12 +92,17 @@ def arrow_schema_for(dataset: str) -> pa.Schema:
     return pa.schema(fields)
 
 
-def validate_table_schema(table: pa.Table, dataset: str) -> None:
+def validate_table_schema(
+    table: pa.Table,
+    dataset: str,
+    *,
+    contract_path: Path | str | None = None,
+) -> None:
     """Refuse unless ``table.schema`` exactly matches the contract schema.
 
     No silent column drop, rename, or dtype coercion.
     """
-    expected = arrow_schema_for(dataset)
+    expected = arrow_schema_for(dataset, contract_path=contract_path)
     actual = table.schema
     # Exact name+type match; ignore metadata only.
     if not actual.equals(expected, check_metadata=False):


### PR DESCRIPTION
## Summary
- add fixture-only US adapter with raw UTC retention, America/New_York session-date derivation, XNYS holiday/early-close checks, and 0 bp fee + 10 bp/side slippage (5 bp sensitivity)
- add venue-isolated crypto adapters for upbit_krw and binance_usdt; mixed manifest entries/rows/views raise CryptoVenueMixError
- bind both markets to the existing holdout, manifest SHA-before-parse, exact-schema, PIT, and terminal-event paths through configurable shared policies rather than copied guards
- declare inferred us-corpus-v1 and crypto-corpus-v1 contracts; no real corpus artifact is read

## Safety
- no app/** changes, no scheduler/broker/DB mutation paths, no backtest execution
- research/kr_corpus/__init__.py untouched
- default shared guard behavior remains KR-compatible; all existing KR harness tests were rerun

## Verification
- uv run pytest research/kr_corpus/backtest/tests research/kr_corpus/backtest/market_adapters/tests -v (92 passed)
- uv run ruff check research/kr_corpus/backtest
- uv run ruff format --check research/kr_corpus/backtest
- dedicated golden coverage: lookahead RED, holdout date/path/case/symlink/.. refusal, SHA/schema loud failures, costs, XNYS calendar, 24/7 UTC, venue-mix rejection, prelisting/delist terminals