### PR TITLE
fix(kis_mock): enforce attribution before the send, not after

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,17 @@
    fill 기록은 evidence-first — 브로커 증거 없이 `filled` 마킹 금지.
 6. **스케줄러 등록 금지**: 신규 TaskIQ/cron/Prefect 스케줄 연결은 명시 승인 없이 금지.
    기본은 scheduleless 출고(CLI/수동 lever만).
-7. **심볼 형식**: DB 기준은 `.` 구분(`BRK.B`). 변환은 `app/core/symbol.py`
+7. **kis_mock 주문은 귀속 없이 나가지 않는다**: `place_order(is_mock=True)` /
+   `account_mode="kis_mock"` 는 **`strategy` 필수**. 브로커 전송 **이전에**
+   `review.kis_mock_signal_ledger` 에 신호 행이 커밋돼야 하고, 실패하면 주문을 보내지 않는다
+   (`error_code`: `attribution_required` / `signal_record_unavailable`).
+   **이 게이트를 우회·완화하거나 placeholder strategy 를 만들어 넣지 마라** — 귀속 불가는
+   값이 아니라 에러다. 귀속을 못 정하겠으면 멈추고 운영자에게 보고하라.
+8. **심볼 형식**: DB 기준은 `.` 구분(`BRK.B`). 변환은 `app/core/symbol.py`
    (`to_kis_symbol`/`to_yahoo_symbol`/`to_db_symbol`)만 사용하고 직접 문자열 치환 금지.
-8. **검증·보고 규율**: 완료 주장 전 관련 테스트를 실제 실행하고 결과 원문을 보고하라.
+9. **검증·보고 규율**: 완료 주장 전 관련 테스트를 실제 실행하고 결과 원문을 보고하라.
    실패·스킵을 성공으로 보고 금지. push 완료 주장은 `git ls-remote`로 대조 가능해야 한다.
-9. **Secrets**: API 키·토큰 repo 커밋 금지. 로그·보고에 secret 값 출력 금지
+10. **Secrets**: API 키·토큰 repo 커밋 금지. 로그·보고에 secret 값 출력 금지
    (missing env는 key 이름만 보고).
 
 ## 최소 명령어

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,20 @@ scans `app/**/*.py` for forbidden provider imports and deleted provider files.
 - **런북**: `docs/runbooks/kis-websocket-mock-smoke.md`
 - **이벤트 태깅**: `app/services/kis_websocket_internal/events.py::build_lifecycle_event` (ROB-100 `OrderLifecycleEvent`)
 
+### kis_mock 귀속 사슬 — pre-submit 강제
+
+`kis_mock` 주문은 **브로커 전송 전에** 귀속이 확정돼야 한다. 확정 못 하면 주문이 나가지 않는다(fail-closed).
+
+- **모델**: `app/models/review.KISMockSignalLedger` (`review.kis_mock_signal_ledger`) — `correlation_id`/`strategy`/`signal_source` **NOT NULL + 공백거부 CHECK**
+- **서비스**: `app/services/kis_mock_attribution.py` — `resolve_attribution`(순수, 실패 시 `MissingAttribution`) / `record_signal` / `mark_signal_outcome`
+- **조회**: `app/services/kis_mock_attribution_chain.py::load_attribution_chain` — gap 코드 `signal_missing`/`order_missing`/`order_unattributed`/`reconcile_missing`
+- **게이트 위치**: `order_execution._execute_and_record` 최상단 (브로커 read 보다도 앞)
+- **런북**: `docs/runbooks/kis-mock-attribution-chain.md`
+
+**호출자 계약(파괴적)**: `place_order(is_mock=True)` 는 이제 `strategy` 필수 — 없으면 `error_code="attribution_required"`. `mirror_cohort="mock_counterfactual"` 은 레인 라벨 자동 판정. `thesis` 는 여전히 불필요.
+
+**주의**: `kis_mock_order_ledger.correlation_id`/`strategy` 는 과거 NULL 행 때문에 nullable 유지 — DB 제약은 pre-submit 신호 테이블에 걸려 있다. 원장 백필은 별건.
+
 ### KIS Live Order Fill-Evidence Gate (ROB-395)
 
 `kis_live_place_order(dry_run=False)` (KR domestic) records **accepted-only** to

--- a/alembic/versions/20260803_kis_mock_signal_ledger.py
+++ b/alembic/versions/20260803_kis_mock_signal_ledger.py
@@ -1,0 +1,126 @@
+"""kis_mock pre-submit signal ledger (additive: one new table only).
+
+Revision ID: 20260803_kis_mock_signal
+Revises: 20260802_rob1036_sample_elig
+Create Date: 2026-08-03
+
+Purely additive. Creates ``review.kis_mock_signal_ledger`` and nothing else:
+no existing table, column, constraint, index, or row is altered or dropped.
+
+Why a new table rather than NOT NULL on ``review.kis_mock_order_ledger``:
+``correlation_id`` / ``strategy`` there were added additively as nullable
+(ROB-321 / ROB-730) and historical rows predating the place-time mint carry
+NULLs, so a NOT NULL rewrite would fail on production data. Attribution is
+instead enforced NOT NULL on this fresh table, which is written *before* the
+broker send — that is where pre-submit enforcement belongs, and it has no
+legacy rows to break. See docs/runbooks/kis-mock-attribution-chain.md.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20260803_kis_mock_signal"
+down_revision = "20260802_rob1036_sample_elig"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "kis_mock_signal_ledger"
+_SCHEMA = "review"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("correlation_id", sa.Text(), nullable=False),
+        sa.Column("strategy", sa.Text(), nullable=False),
+        sa.Column("signal_source", sa.Text(), nullable=False),
+        sa.Column(
+            "account_mode",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'kis_mock'"),
+        ),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("instrument_type", sa.Text(), nullable=True),
+        sa.Column("side", sa.Text(), nullable=True),
+        sa.Column("intended_quantity", sa.Numeric(20, 8), nullable=True),
+        sa.Column("intended_price", sa.Numeric(20, 4), nullable=True),
+        sa.Column("decision", sa.Text(), nullable=False),
+        sa.Column(
+            "outcome_state",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'recorded'"),
+        ),
+        sa.Column("suppressed_reason", sa.Text(), nullable=True),
+        sa.Column("report_item_uuid", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "detail",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("kst_date", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "correlation_id", name="uq_kis_mock_signal_ledger_correlation_id"
+        ),
+        sa.CheckConstraint(
+            "account_mode = 'kis_mock'", name="ck_kis_mock_signal_account_mode"
+        ),
+        sa.CheckConstraint(
+            "decision IN ('order','no_order')", name="ck_kis_mock_signal_decision"
+        ),
+        sa.CheckConstraint(
+            "outcome_state IN ('recorded','submitted','suppressed','failed')",
+            name="ck_kis_mock_signal_outcome_state",
+        ),
+        sa.CheckConstraint(
+            "side IS NULL OR side IN ('buy','sell')", name="ck_kis_mock_signal_side"
+        ),
+        sa.CheckConstraint(
+            "length(btrim(strategy)) > 0",
+            name="ck_kis_mock_signal_strategy_nonblank",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(signal_source)) > 0",
+            name="ck_kis_mock_signal_source_nonblank",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(correlation_id)) > 0",
+            name="ck_kis_mock_signal_correlation_nonblank",
+        ),
+        schema=_SCHEMA,
+    )
+    op.create_index("ix_kis_mock_signal_kst_date", _TABLE, ["kst_date"], schema=_SCHEMA)
+    op.create_index("ix_kis_mock_signal_strategy", _TABLE, ["strategy"], schema=_SCHEMA)
+    op.create_index("ix_kis_mock_signal_symbol", _TABLE, ["symbol"], schema=_SCHEMA)
+    op.create_index(
+        "ix_kis_mock_signal_outcome_state", _TABLE, ["outcome_state"], schema=_SCHEMA
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_kis_mock_signal_outcome_state", _TABLE, schema=_SCHEMA)
+    op.drop_index("ix_kis_mock_signal_symbol", _TABLE, schema=_SCHEMA)
+    op.drop_index("ix_kis_mock_signal_strategy", _TABLE, schema=_SCHEMA)
+    op.drop_index("ix_kis_mock_signal_kst_date", _TABLE, schema=_SCHEMA)
+    op.drop_table(_TABLE, schema=_SCHEMA)

--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -249,6 +249,7 @@ async def run_kis_mock_reconciliation(
             ),
             accepted_at=row.trade_date,
             price=_to_decimal(row.price),
+            correlation_id=row.correlation_id,
         )
         for row in open_rows
     ]
@@ -270,6 +271,10 @@ async def run_kis_mock_reconciliation(
         # delta it did NOT receive). ``attributed_fill_qty`` is the authoritative
         # apportioned quantity that drives lifecycle and order-history status.
         detail = {
+            # The chain's last hop. Without this the reconciler recorded which
+            # ledger row moved but not which decision it belonged to, so
+            # signal -> submit -> fill could not be followed past the ledger id.
+            "correlation_id": proposal.correlation_id,
             "observed_holdings_qty": (
                 str(proposal.observed_holdings_qty)
                 if proposal.observed_holdings_qty is not None
@@ -302,6 +307,9 @@ async def run_kis_mock_reconciliation(
                 execution_source="reconciler",
                 state=proposal.next_state,
                 occurred_at=now,
+                # OrderLifecycleEvent has carried a first-class correlation_id
+                # field since ROB-100; the reconciler simply never set it.
+                correlation_id=proposal.correlation_id,
                 detail={
                     "ledger_id": proposal.ledger_id,
                     "symbol": proposal.symbol,

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -548,10 +548,13 @@ async def _record_kis_mock_order(
         failure_reason = "unknown_response"
         failure_detail = msg or f"rt_cd={rt_cd} order_no={order_no}"
 
-    # ROB-730 provenance spine: mint a deterministic place-time correlation_id so
-    # this mock order joins forecast → fill → journal → retrospective, mirroring
-    # the kis_live path verbatim. Preserve an explicit id (ROB-402 scalping
-    # entry/exit pairing passes one) rather than overwriting it.
+    # ROB-730 provenance spine: the correlation_id joins forecast → fill →
+    # journal → retrospective, mirroring the kis_live path verbatim.
+    #
+    # The authoritative mint now happens PRE-submit in the attribution gate
+    # (app/services/kis_mock_attribution.py), which passes the id in. This
+    # branch is only a fallback for direct callers of this helper; it uses the
+    # identical inputs and helper, so it yields the identical id.
     if correlation_id is None:
         correlation_id = live_correlation_id(
             account_scope="kis_mock",

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -62,6 +62,13 @@ from app.services.brokers.kis.send_outcome import (
     OrderSendOutcomeTracker,
 )
 from app.services.crypto_trade_cooldown_service import CryptoTradeCooldownService
+from app.services.kis_mock_attribution import (
+    KisMockAttribution,
+    MissingAttribution,
+    mark_signal_outcome,
+    record_signal,
+    resolve_attribution,
+)
 from app.services.order_send_intent_service import (
     DuplicateOrderIntent,
     OrderSendIntentService,
@@ -780,6 +787,80 @@ async def _execute_and_record(
     send_outcome: OrderSendOutcomeTracker | None = None,
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
+    # Pre-submit attribution gate (kis_mock). Deliberately the FIRST thing in
+    # this function: an unattributed mock order must not reach the broker at
+    # all, not even the baseline holdings read below. Resolution is pure, and
+    # the signal row is committed before the send — so an order that exists at
+    # the broker always has a durable owner, even if this process dies between
+    # the POST and the ledger write.
+    kis_mock_attribution: KisMockAttribution | None = None
+    if is_mock:
+        try:
+            kis_mock_attribution = resolve_attribution(
+                symbol=normalized_symbol,
+                side=side,
+                # Mint from the same normalized preview values the post-send
+                # path used, so the id is unchanged — only earlier.
+                price=_to_float(dry_run_result.get("price"), default=0.0),
+                quantity=_to_float(dry_run_result.get("quantity"), default=0.0),
+                strategy=strategy,
+                correlation_id=correlation_id,
+                mirror_cohort=mirror_cohort,
+            )
+        except MissingAttribution as attribution_exc:
+            logger.warning(
+                "kis_mock order blocked, unattributed: symbol=%s side=%s missing=%s",
+                normalized_symbol,
+                side,
+                list(attribution_exc.missing),
+            )
+            err = order_error_fn(str(attribution_exc))
+            err["error_code"] = "attribution_required"
+            err["missing_attribution"] = list(attribution_exc.missing)
+            return err
+
+        try:
+            async with _order_session_factory()() as signal_db:
+                await record_signal(
+                    signal_db,
+                    attribution=kis_mock_attribution,
+                    symbol=normalized_symbol,
+                    decision="order",
+                    instrument_type=market_type,
+                    side=side,
+                    intended_quantity=order_quantity,
+                    intended_price=price,
+                    report_item_uuid=report_item_uuid,
+                    detail={
+                        "reason": reason or None,
+                        "order_type": order_type,
+                        "mirror_cohort": mirror_cohort,
+                        "mirror_source_bucket": mirror_source_bucket,
+                    },
+                )
+        except Exception as signal_exc:  # noqa: BLE001 — no record, no send
+            # Fail closed. A send we cannot attribute durably is exactly the
+            # untraceable order this gate exists to prevent.
+            logger.error(
+                "kis_mock signal record failed, refusing to send: "
+                "symbol=%s side=%s correlation_id=%s error=%s",
+                normalized_symbol,
+                side,
+                kis_mock_attribution.correlation_id,
+                describe_exception(signal_exc),
+            )
+            err = order_error_fn(
+                "kis_mock signal ledger write failed; order not sent "
+                f"({describe_exception(signal_exc)})"
+            )
+            err["error_code"] = "signal_record_unavailable"
+            return err
+
+        # From here on the ledger row inherits the pre-submit attribution
+        # rather than re-deriving it after the fact.
+        correlation_id = kis_mock_attribution.correlation_id
+        strategy = kis_mock_attribution.strategy
+
     # ROB-102: capture pre-order KIS mock holdings as the reconciler baseline.
     # Best-effort — failure leaves the column NULL and the reconciler will
     # surface the row as `baseline_missing → anomaly` for operator review.
@@ -1040,6 +1121,33 @@ async def _execute_and_record(
                 send_outcome.mark_provider_rejected()
             else:
                 send_outcome.mark_unknown()
+        # Close the signal row out with what actually happened. Best-effort by
+        # design: the attribution itself is already durable, so a failure here
+        # degrades the outcome label, never the ownership of the order.
+        if kis_mock_attribution is not None:
+            try:
+                async with _order_session_factory()() as outcome_db:
+                    await mark_signal_outcome(
+                        outcome_db,
+                        correlation_id=kis_mock_attribution.correlation_id,
+                        outcome_state=(
+                            "submitted" if result.get("success") else "failed"
+                        ),
+                        suppressed_reason=(
+                            None if result.get("success") else result.get("reason")
+                        ),
+                        detail_patch={
+                            "order_no": result.get("order_no"),
+                            "status": result.get("status"),
+                            "ledger_id": result.get("ledger_id"),
+                        },
+                    )
+            except Exception as outcome_exc:  # noqa: BLE001
+                logger.warning(
+                    "kis_mock signal outcome update failed correlation_id=%s: %s",
+                    kis_mock_attribution.correlation_id,
+                    describe_exception(outcome_exc),
+                )
         return result
 
     # ROB-395: live KR orders record accepted-only to the live ledger; fills,

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -292,6 +292,98 @@ class KISMockOrderLedger(Base):
     )
 
 
+class KISMockSignalLedger(Base):
+    """Durable pre-submit signal record for the kis_mock lane.
+
+    Written BEFORE the broker send, never after: the row is the proof that a
+    decision was made and *what strategy owns it*. ``correlation_id`` is the
+    single key that joins this row to ``review.kis_mock_order_ledger`` and to
+    every downstream lifecycle event.
+
+    Why this table exists at all: ``kis_mock_order_ledger.correlation_id`` and
+    ``.strategy`` are nullable (ROB-321/ROB-730 added them additively), and the
+    native place path minted the correlation id *after* the broker responded.
+    An order that was sent but whose ledger write was lost therefore carried no
+    attribution anywhere — the ROB-1093 failure mode, where a nullable column
+    meant "passes without being filled in" rather than "may be filled in".
+
+    Signals that never become orders are recorded too (``decision='no_order'``).
+    Counting only the signals that produced orders skews the denominator of any
+    hit-rate/attribution measurement, so suppression is first-class evidence.
+    """
+
+    __tablename__ = "kis_mock_signal_ledger"
+    __table_args__ = (
+        UniqueConstraint(
+            "correlation_id", name="uq_kis_mock_signal_ledger_correlation_id"
+        ),
+        CheckConstraint(
+            "account_mode = 'kis_mock'", name="ck_kis_mock_signal_account_mode"
+        ),
+        CheckConstraint(
+            "decision IN ('order','no_order')", name="ck_kis_mock_signal_decision"
+        ),
+        CheckConstraint(
+            "outcome_state IN ('recorded','submitted','suppressed','failed')",
+            name="ck_kis_mock_signal_outcome_state",
+        ),
+        CheckConstraint(
+            "side IS NULL OR side IN ('buy','sell')", name="ck_kis_mock_signal_side"
+        ),
+        # The whole point of the table: attribution can never be blank. Unlike a
+        # nullable column, a blank-rejecting CHECK makes "unattributed" an
+        # insert-time error rather than a silent NULL discovered months later.
+        CheckConstraint(
+            "length(btrim(strategy)) > 0", name="ck_kis_mock_signal_strategy_nonblank"
+        ),
+        CheckConstraint(
+            "length(btrim(signal_source)) > 0",
+            name="ck_kis_mock_signal_source_nonblank",
+        ),
+        CheckConstraint(
+            "length(btrim(correlation_id)) > 0",
+            name="ck_kis_mock_signal_correlation_nonblank",
+        ),
+        Index("ix_kis_mock_signal_kst_date", "kst_date"),
+        Index("ix_kis_mock_signal_strategy", "strategy"),
+        Index("ix_kis_mock_signal_symbol", "symbol"),
+        Index("ix_kis_mock_signal_outcome_state", "outcome_state"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    correlation_id: Mapped[str] = mapped_column(Text, nullable=False)
+    strategy: Mapped[str] = mapped_column(Text, nullable=False)
+    signal_source: Mapped[str] = mapped_column(Text, nullable=False)
+    account_mode: Mapped[str] = mapped_column(Text, nullable=False, default="kis_mock")
+
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    instrument_type: Mapped[str | None] = mapped_column(Text)
+    side: Mapped[str | None] = mapped_column(Text)
+    intended_quantity: Mapped[Decimal | None] = mapped_column(Numeric(20, 8))
+    intended_price: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
+
+    decision: Mapped[str] = mapped_column(Text, nullable=False)
+    outcome_state: Mapped[str] = mapped_column(Text, nullable=False, default="recorded")
+    suppressed_reason: Mapped[str | None] = mapped_column(Text)
+
+    report_item_uuid: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    detail: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    kst_date: Mapped[str] = mapped_column(Text, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
 class KISLiveOrderLedger(Base):
     """ROB-395 — KIS live (real-money) order lifecycle ledger.
 

--- a/app/services/investment_reports/watch_auto_execute.py
+++ b/app/services/investment_reports/watch_auto_execute.py
@@ -26,6 +26,11 @@ from app.services.investment_reports.auto_execute_guard import (
 
 logger = logging.getLogger(__name__)
 
+# Strategy label carried into review.kis_mock_signal_ledger / kis_mock_order_ledger
+# so a watch-sourced order is attributable without joining back through the
+# watch intent row.
+WATCH_AUTO_EXECUTE_STRATEGY = "watch_auto_execute_mock"
+
 
 def _to_decimal(v: Any) -> Decimal | None:
     if v in (None, ""):
@@ -208,6 +213,10 @@ async def maybe_auto_execute(
             reason="watch auto_execute_mock",
             is_mock=True,
             correlation_id=correlation_id,
+            # Names the lane that owns the order. The kis_mock pre-submit
+            # attribution gate refuses to send without it; this path is still
+            # gated off by WATCH_AUTO_EXECUTE_MOCK_ENABLED either way.
+            strategy=WATCH_AUTO_EXECUTE_STRATEGY,
         )
     except Exception as exc:  # noqa: BLE001 — surface as a truthful failed outcome
         place_result = {

--- a/app/services/kis_mock_attribution.py
+++ b/app/services/kis_mock_attribution.py
@@ -1,0 +1,257 @@
+"""Pre-submit attribution for the kis_mock lane.
+
+Two jobs, in this order:
+
+1. :func:`resolve_attribution` decides — with no I/O — who owns an order.
+   It either produces a complete ``(correlation_id, strategy, signal_source)``
+   triple or raises :class:`MissingAttribution`. There is no third outcome and
+   no placeholder: "unattributed" is an error, not a value.
+2. :func:`record_signal` makes that decision durable *before* the broker send.
+
+The ordering is the whole point. ``review.kis_mock_order_ledger`` previously
+minted its ``correlation_id`` inside the response handler, i.e. after the order
+POST had already returned, and left ``strategy`` NULL whenever the caller did
+not bother to pass one. An order sent by a process that then died — or whose
+ledger insert failed — existed at the broker with no attribution anywhere. That
+is the ROB-1093 shape: a nullable column does not mean "may be filled in", it
+means "passes without being filled in".
+
+Signals that are evaluated and deliberately produce no order are recorded too
+(``decision='no_order'``). Measuring a strategy only by the signals that became
+orders silently drops the denominator.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from sqlalchemy import cast, select, update
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.review import KISMockSignalLedger
+from app.services.live_correlation import live_correlation_id
+
+ACCOUNT_SCOPE = "kis_mock"
+
+# Lane labels derived from unambiguous execution context. These are real
+# attribution — each names exactly one code path that owns the order — not
+# stand-ins for a missing answer. A context that matches none of them is
+# unattributed and must fail closed.
+MIRROR_STRATEGY = "mock_counterfactual_mirror"
+MIRROR_SIGNAL_SOURCE = "mirror"
+DEFAULT_SIGNAL_SOURCE = "manual"
+
+_DECISION_ORDER = "order"
+_DECISION_NO_ORDER = "no_order"
+
+
+class MissingAttribution(Exception):
+    """Raised when an order cannot be attributed to a strategy before send.
+
+    Callers must treat this as a hard block: the broker call does not happen.
+    """
+
+    def __init__(self, missing: tuple[str, ...]) -> None:
+        self.missing = missing
+        super().__init__(
+            f"kis_mock order is unattributed; refusing to send. missing={list(missing)}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class KisMockAttribution:
+    """A complete attribution triple. Constructed only via resolve_attribution."""
+
+    correlation_id: str
+    strategy: str
+    signal_source: str
+
+
+def _clean(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def mint_correlation_id(
+    *,
+    symbol: str,
+    side: str,
+    price: Any,
+    quantity: Any,
+    kst_trade_day: str | None = None,
+    rung: int = 0,
+) -> str:
+    """Deterministic kis_mock correlation id.
+
+    Identical inputs produce the identical id the post-send path used before
+    (same helper, same ``account_scope``), so moving the mint ahead of the send
+    does not renumber anything — it only makes the id exist earlier.
+    """
+    return live_correlation_id(
+        account_scope=ACCOUNT_SCOPE,
+        symbol=symbol,
+        side=side,
+        price=_to_decimal(price) or Decimal("0"),
+        quantity=_to_decimal(quantity) or Decimal("0"),
+        kst_trade_day=kst_trade_day or now_kst().strftime("%Y-%m-%d"),
+        rung=rung,
+    )
+
+
+def resolve_attribution(
+    *,
+    symbol: str,
+    side: str,
+    price: Any,
+    quantity: Any,
+    strategy: str | None = None,
+    signal_source: str | None = None,
+    correlation_id: str | None = None,
+    mirror_cohort: str | None = None,
+    kst_trade_day: str | None = None,
+) -> KisMockAttribution:
+    """Resolve the attribution triple, or raise :class:`MissingAttribution`.
+
+    Pure: no DB, no network, no clock beyond the KST trading day used for the
+    deterministic id. An explicit ``strategy`` always wins; ``mirror_cohort``
+    identifies the counterfactual-mirror lane on its own. Anything else without
+    a strategy is unattributable and raises.
+    """
+    resolved_strategy = _clean(strategy)
+    resolved_source = _clean(signal_source)
+
+    if resolved_strategy is None and _clean(mirror_cohort) == "mock_counterfactual":
+        resolved_strategy = MIRROR_STRATEGY
+        resolved_source = resolved_source or MIRROR_SIGNAL_SOURCE
+
+    missing: list[str] = []
+    if resolved_strategy is None:
+        missing.append("strategy")
+    if missing or resolved_strategy is None:
+        raise MissingAttribution(tuple(missing or ("strategy",)))
+
+    return KisMockAttribution(
+        correlation_id=_clean(correlation_id)
+        or mint_correlation_id(
+            symbol=symbol,
+            side=side,
+            price=price,
+            quantity=quantity,
+            kst_trade_day=kst_trade_day,
+        ),
+        strategy=resolved_strategy,
+        signal_source=resolved_source or DEFAULT_SIGNAL_SOURCE,
+    )
+
+
+async def record_signal(
+    db: AsyncSession,
+    *,
+    attribution: KisMockAttribution,
+    symbol: str,
+    decision: str,
+    instrument_type: str | None = None,
+    side: str | None = None,
+    intended_quantity: Any = None,
+    intended_price: Any = None,
+    outcome_state: str | None = None,
+    suppressed_reason: str | None = None,
+    report_item_uuid: uuid.UUID | None = None,
+    detail: dict[str, Any] | None = None,
+    kst_date: str | None = None,
+) -> int:
+    """Persist the signal row and return its id (existing id when replayed).
+
+    Idempotent on ``correlation_id``: a retry of the same decision re-reads the
+    durable row instead of inserting a second one. The caller commits nothing
+    itself — this function owns the transaction so the row is on disk before
+    the caller proceeds to the broker.
+    """
+    if decision not in (_DECISION_ORDER, _DECISION_NO_ORDER):
+        raise ValueError(f"unknown decision {decision!r}")
+
+    resolved_outcome = outcome_state or (
+        "recorded" if decision == _DECISION_ORDER else "suppressed"
+    )
+    stmt = (
+        pg_insert(KISMockSignalLedger)
+        .values(
+            correlation_id=attribution.correlation_id,
+            strategy=attribution.strategy,
+            signal_source=attribution.signal_source,
+            account_mode=ACCOUNT_SCOPE,
+            symbol=symbol,
+            instrument_type=instrument_type,
+            side=side,
+            intended_quantity=_to_decimal(intended_quantity),
+            intended_price=_to_decimal(intended_price),
+            decision=decision,
+            outcome_state=resolved_outcome,
+            suppressed_reason=suppressed_reason,
+            report_item_uuid=report_item_uuid,
+            detail=detail or {},
+            kst_date=kst_date or now_kst().strftime("%Y-%m-%d"),
+        )
+        .on_conflict_do_nothing(constraint="uq_kis_mock_signal_ledger_correlation_id")
+        .returning(KISMockSignalLedger.id)
+    )
+    inserted = (await db.execute(stmt)).scalar_one_or_none()
+    if inserted is None:
+        inserted = await db.scalar(
+            select(KISMockSignalLedger.id).where(
+                KISMockSignalLedger.correlation_id == attribution.correlation_id
+            )
+        )
+    await db.commit()
+    if inserted is None:  # pragma: no cover — conflict without a readable row
+        raise RuntimeError(
+            "kis_mock signal row neither inserted nor found: "
+            f"{attribution.correlation_id}"
+        )
+    return int(inserted)
+
+
+async def mark_signal_outcome(
+    db: AsyncSession,
+    *,
+    correlation_id: str,
+    outcome_state: str,
+    suppressed_reason: str | None = None,
+    detail_patch: dict[str, Any] | None = None,
+) -> int:
+    """Advance a recorded signal to its post-send outcome.
+
+    Never used to *create* attribution — only to say what happened to a row
+    that already existed before the send.
+    """
+    values: dict[str, Any] = {"outcome_state": outcome_state}
+    if suppressed_reason is not None:
+        values["suppressed_reason"] = suppressed_reason
+    if detail_patch:
+        values["detail"] = KISMockSignalLedger.detail.op("||")(
+            cast(detail_patch, JSONB)
+        )
+    result = await db.execute(
+        update(KISMockSignalLedger)
+        .where(KISMockSignalLedger.correlation_id == correlation_id)
+        .values(**values)
+    )
+    await db.commit()
+    return int(result.rowcount or 0)

--- a/app/services/kis_mock_attribution_chain.py
+++ b/app/services/kis_mock_attribution_chain.py
@@ -1,0 +1,163 @@
+"""Read-only chain query: one correlation_id -> every stage that recorded it.
+
+Read-only by construction. The module imports no insert/update/delete helper
+and holds no session factory of its own; callers hand in a session. It exists
+so "attribution is 100%" is a query someone can run and disagree with, rather
+than a claim.
+
+A chain is complete when the signal row, the order row, and at least one
+lifecycle transition all resolve from the same key. Anything else is reported
+as a named gap — a missing stage is the finding, not an empty result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import KISMockOrderLedger, KISMockSignalLedger
+
+# Gap codes. Stable strings — tests and runbooks reference them by name.
+GAP_SIGNAL_MISSING = "signal_missing"
+GAP_ORDER_MISSING = "order_missing"
+GAP_ORDER_UNATTRIBUTED = "order_unattributed"
+GAP_RECONCILE_MISSING = "reconcile_missing"
+
+# A row that never left the pre-send stages cannot be expected to carry a
+# reconcile transition, so its absence is not a gap.
+_PRE_RECONCILE_STATES = frozenset({"planned", "previewed", "failed", "anomaly"})
+
+
+@dataclass(frozen=True, slots=True)
+class ChainStage:
+    name: str
+    present: bool
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class AttributionChain:
+    correlation_id: str
+    stages: tuple[ChainStage, ...]
+    gaps: tuple[str, ...]
+    strategy: str | None = None
+
+    @property
+    def unbroken(self) -> bool:
+        return not self.gaps
+
+    def stage(self, name: str) -> ChainStage | None:
+        for stage in self.stages:
+            if stage.name == name:
+                return stage
+        return None
+
+
+async def load_attribution_chain(
+    db: AsyncSession, *, correlation_id: str
+) -> AttributionChain:
+    """Assemble every stage recorded under ``correlation_id``."""
+    signal = await db.scalar(
+        select(KISMockSignalLedger).where(
+            KISMockSignalLedger.correlation_id == correlation_id
+        )
+    )
+    order_rows = list(
+        (
+            await db.execute(
+                select(KISMockOrderLedger)
+                .where(KISMockOrderLedger.correlation_id == correlation_id)
+                .order_by(KISMockOrderLedger.id.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    stages: list[ChainStage] = []
+    gaps: list[str] = []
+
+    stages.append(
+        ChainStage(
+            name="signal",
+            present=signal is not None,
+            detail=(
+                {}
+                if signal is None
+                else {
+                    "signal_ledger_id": signal.id,
+                    "strategy": signal.strategy,
+                    "signal_source": signal.signal_source,
+                    "decision": signal.decision,
+                    "outcome_state": signal.outcome_state,
+                    "suppressed_reason": signal.suppressed_reason,
+                }
+            ),
+        )
+    )
+    if signal is None:
+        gaps.append(GAP_SIGNAL_MISSING)
+
+    stages.append(
+        ChainStage(
+            name="order",
+            present=bool(order_rows),
+            detail={
+                "ledger_ids": [row.id for row in order_rows],
+                "order_nos": [row.order_no for row in order_rows],
+                "lifecycle_states": [row.lifecycle_state for row in order_rows],
+                "strategies": [row.strategy for row in order_rows],
+            },
+        )
+    )
+
+    # A signal that deliberately produced no order is a complete chain, not a
+    # broken one — that is exactly the "decided not to trade" evidence the
+    # signal ledger exists to keep.
+    expects_order = signal is None or signal.decision == "order"
+    if expects_order and not order_rows:
+        gaps.append(GAP_ORDER_MISSING)
+    if order_rows and any(not (row.strategy or "").strip() for row in order_rows):
+        gaps.append(GAP_ORDER_UNATTRIBUTED)
+
+    reconciled = [
+        row
+        for row in order_rows
+        if (row.last_reconcile_detail or {}) or row.reconciled_at
+    ]
+    stages.append(
+        ChainStage(
+            name="reconcile",
+            present=bool(reconciled),
+            detail={
+                "ledger_ids": [row.id for row in reconciled],
+                "reconcile_details": [row.last_reconcile_detail for row in reconciled],
+                "reconciled_at": [
+                    row.reconciled_at.isoformat() if row.reconciled_at else None
+                    for row in reconciled
+                ],
+            },
+        )
+    )
+    awaiting_reconcile = [
+        row for row in order_rows if row.lifecycle_state not in _PRE_RECONCILE_STATES
+    ]
+    if awaiting_reconcile and not reconciled:
+        gaps.append(GAP_RECONCILE_MISSING)
+
+    return AttributionChain(
+        correlation_id=correlation_id,
+        stages=tuple(stages),
+        gaps=tuple(gaps),
+        strategy=(
+            signal.strategy
+            if signal is not None
+            else next(
+                (row.strategy for row in order_rows if (row.strategy or "").strip()),
+                None,
+            )
+        ),
+    )

--- a/app/services/kis_mock_holdings_reconciler.py
+++ b/app/services/kis_mock_holdings_reconciler.py
@@ -43,6 +43,10 @@ class LedgerOrderInput:
     holdings_baseline_qty: Decimal | None
     accepted_at: datetime
     price: Decimal = Decimal("0")
+    # Carried purely so downstream lifecycle events can name the order's owner.
+    # Optional because the classifier's decisions never depend on it — a row
+    # with no correlation id still reconciles, it just reports the gap.
+    correlation_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +72,7 @@ class LifecycleTransitionProposal:
     observed_holdings_qty: Decimal | None
     observed_delta: Decimal | None
     attributed_fill_qty: Decimal | None = None
+    correlation_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,6 +121,7 @@ def _anomaly(
         observed_holdings_qty=None,
         observed_delta=None,
         attributed_fill_qty=None,
+        correlation_id=order.correlation_id,
     )
 
 
@@ -257,6 +263,7 @@ def _proposal_for(
         observed_holdings_qty=snapshot.quantity,
         observed_delta=per_order_delta,
         attributed_fill_qty=attributed,
+        correlation_id=order.correlation_id,
     )
 
 

--- a/docs/runbooks/kis-mock-attribution-chain.md
+++ b/docs/runbooks/kis-mock-attribution-chain.md
@@ -89,7 +89,16 @@ chain.strategy
 
 - 주문으로 이어지지 **않은** 신호(`decision="no_order"`)는 gap 이 아니다 —
   분모를 유지하기 위한 증거다.
-- `previewed/failed/anomaly` 상태 행은 reconcile 을 기대하지 않는다.
+- `_PRE_RECONCILE_STATES` = `planned` · `previewed` · `failed` · `anomaly`.
+  이 4개 상태의 행은 reconcile 을 기대하지 않으므로 부재가 gap 이 아니다.
+  (이 목록은 코드와 **정확히** 일치해야 한다 — 어긋나면 그 자체가 버그다.)
+- ⚠️ `cancelled` 는 위 목록에 **없다.** 일부러다: `cancelled` 는
+  `TERMINAL_LIFECYCLE_STATES` 이고 `apply_lifecycle_transition` 이 모든 전이에
+  `last_reconcile_detail` 을, terminal 전이에 `reconciled_at` 을 기록하므로
+  **정상 취소 경로는 이미 증거를 남긴다** → 오탐 없음. 목록에 넣어버리면 증거 없는
+  `cancelled` 행까지 조용히 통과하게 된다. 고정 테스트:
+  `test_cancelled_order_does_not_report_a_false_reconcile_gap`
+  (손으로 만든 행이 아니라 실제 `mark_kis_mock_order_cancelled` 경로를 태운다).
 
 ## 6. 남은 한계
 

--- a/docs/runbooks/kis-mock-attribution-chain.md
+++ b/docs/runbooks/kis-mock-attribution-chain.md
@@ -1,0 +1,141 @@
+# kis_mock 귀속 사슬 (signal → submit → ledger → reconcile)
+
+`kis_mock` 주문 하나를 **단일 `correlation_id`** 로 신호 발생 시점부터
+reconcile 까지 추적하기 위한 계약. 성공척도 「주문 귀속 100% · lifecycle
+evidence 100%」를 **측정 가능**하게 만드는 것이 목적이다.
+
+## 1. 왜 필요했나 — 사슬이 끊긴 지점
+
+수리 전 상태:
+
+| 구간 | 상태 | 근거 |
+|---|---|---|
+| signal → submit | **기록 없음** | 신호가 주문이 됐든 안 됐든 durable record 자체가 없음 |
+| submit 시점 귀속 | **사후 부여** | `correlation_id` 를 브로커 응답 처리부(`_record_kis_mock_order`)에서 mint — 즉 **POST 이후** |
+| `strategy` | **nullable + 무검증** | `_place_order_impl` 주석에 "mock 은 thesis/strategy 선택" 이라고 명시돼 있었음 |
+| reconcile | **correlation_id 미전달** | `OrderLifecycleEvent.correlation_id` 필드는 ROB-100 부터 있었으나 reconciler 가 채우지 않음 |
+
+핵심은 **순서**다. 사후 mint 는 "주문은 나갔는데 원장 write 가 실패/프로세스
+사망" 시 **브로커에만 존재하고 귀속은 어디에도 없는 주문**을 만든다.
+ROB-1093(`execution_asset_class` 전부 NULL → 사후 트랙 분리 불가)과 같은 모양:
+nullable 컬럼은 「채워질 수도 있다」가 아니라 **「안 채워져도 통과한다」**.
+
+## 2. 수리 후 구조
+
+```
+resolve_attribution()        ← 순수. strategy 없으면 MissingAttribution
+        │  (네트워크·DB 접촉 0)
+        ▼
+record_signal()              ← review.kis_mock_signal_ledger COMMIT
+        │                       실패하면 여기서 중단 (fail-closed)
+        ▼
+_execute_order()             ← 브로커 POST. 여기 도달했다는 것 자체가
+        │                      "귀속이 이미 durable 하다" 는 증거
+        ▼
+kis_mock_order_ledger        ← 같은 correlation_id + strategy 상속
+        ▼
+reconcile event              ← OrderLifecycleEvent.correlation_id +
+                               last_reconcile_detail.correlation_id
+```
+
+- 게이트 위치: `app/mcp_server/tooling/order_execution.py::_execute_and_record`
+  **함수 최상단**. 보유 baseline 조회(브로커 read)보다도 앞 — 귀속 없는 주문은
+  브로커 I/O 를 **한 번도** 하지 않는다.
+- 서비스: `app/services/kis_mock_attribution.py`
+- 조회: `app/services/kis_mock_attribution_chain.py::load_attribution_chain`
+
+## 3. 강제 수준
+
+| 대상 | 수준 | 이유 |
+|---|---|---|
+| `review.kis_mock_signal_ledger.{correlation_id,strategy,signal_source}` | **DB NOT NULL + 공백거부 CHECK** | 신규 테이블 → legacy row 없음 → 제약 추가가 마이그레이션을 깨뜨리지 않음 |
+| 주문 전송 | **APP FAIL-CLOSED** | 신호 row 를 못 쓰면 전송 안 함 |
+| `review.kis_mock_order_ledger.{correlation_id,strategy}` | nullable 유지 | 과거 행에 NULL 존재(ROB-321/730 이전) → NOT NULL 은 마이그레이션 파괴 |
+
+즉 **DB 제약은 pre-submit 레코드에 걸려 있다.** 주문은 그 레코드가 성공해야만
+나가므로, 결과적으로 "전송된 주문 = DB 가 NOT NULL 을 검증한 귀속을 가진 주문"
+이다. 주문 원장 쪽 과거 NULL 백필은 별건(§6).
+
+## 4. 호출자 계약 (파괴적 변경)
+
+`place_order(..., is_mock=True)` / `account_mode="kis_mock"` 는 이제
+**`strategy` 를 요구**한다. 없으면:
+
+```json
+{"success": false, "error_code": "attribution_required",
+ "missing_attribution": ["strategy"]}
+```
+
+레인 자동 판정(명시 strategy 불필요):
+
+| 컨텍스트 | strategy | signal_source |
+|---|---|---|
+| `mirror_cohort="mock_counterfactual"` | `mock_counterfactual_mirror` | `mirror` |
+| 그 외 · strategy 없음 | — | **차단** |
+
+레포 내 기존 호출자는 전부 배선 완료: scalping(`strategy_id`), mirror
+(`mirror_counterfactual`), watch auto-execute(`watch_auto_execute_mock`).
+`thesis` 는 여전히 불필요(mock 은 TradeJournal 을 만들지 않음).
+
+## 5. 사슬 조회
+
+```python
+chain = await load_attribution_chain(db, correlation_id=cid)
+chain.unbroken          # gaps 가 비었는가
+chain.gaps              # signal_missing / order_missing /
+                        # order_unattributed / reconcile_missing
+chain.strategy
+```
+
+- 주문으로 이어지지 **않은** 신호(`decision="no_order"`)는 gap 이 아니다 —
+  분모를 유지하기 위한 증거다.
+- `previewed/failed/anomaly` 상태 행은 reconcile 을 기대하지 않는다.
+
+## 6. 남은 한계
+
+1. **주문 원장 과거 NULL 미측정·미백필.** 운영 DB 접속이 금지된 작업 범위여서
+   `kis_mock_order_ledger` 의 기존 NULL 행 수를 실측하지 않았다. 백필/NOT NULL
+   승격은 별도 작업.
+2. **scalping 왕복은 signal row 1개.** entry/exit 두 leg 가 하나의
+   `correlation_id` 를 공유하므로 `uq_..._correlation_id` 에 걸려 entry 것만
+   남는다. 귀속 자체는 온전하나 leg 별 신호 기록이 필요하면 uniqueness 를
+   `(correlation_id, leg)` 로 확장해야 한다.
+3. **전송 중 예외 시 `outcome_state='recorded'` 유지.** 실패로 단정하지 않는
+   것이 의도 — 접수 여부 불명이므로 reconcile 이 판정한다.
+4. **신호 row 는 있고 주문이 없는 창(window)이 존재.** 신호 COMMIT 과 POST
+   사이에서 프로세스가 죽으면 `order_missing` 으로 **탐지된다**. 완전 제거가
+   아니라 관측 가능화다.
+5. **signal 기록은 `_execute_and_record` 경유 주문만.** scalping 어댑터가 직접
+   쓰는 synthetic evidence row(`-entry`/`-exit`/`-anomaly`)는 signal ledger 를
+   거치지 않지만, 동일 `correlation_id` 를 달고 있어 같은 사슬로 조회된다.
+
+## 7. 마이그레이션
+
+`20260803_kis_mock_signal` — `review.kis_mock_signal_ledger` **생성만**.
+기존 테이블/컬럼/제약/인덱스 변경 0.
+
+scratch DB 실측(2026-08-03, 로컬 postgres 17.9):
+
+```
+baseline: ORM 139 테이블 · 스키마 오브젝트 3,657개 (신규 테이블 제외 스냅샷)
+upgrade head    → 신규 테이블 생성  · 나머지 스냅샷 IDENTICAL
+downgrade -1    → 신규 테이블 제거  · 나머지 스냅샷 IDENTICAL
+upgrade head    → 신규 테이블 재생성 · 나머지 스냅샷 IDENTICAL
+NULL strategy / 공백 strategy / NULL correlation_id / 공백 signal_source
+  → 4건 전부 REJECTED, 정상 행은 INSERT (positive control)
+```
+
+⚠️ 로컬 postgres 에 timescaledb 가 없어 **전체 체인 replay 는 불가**했다.
+baseline 은 `Base.metadata.create_all`(신규 테이블 제외)로 구성했다.
+CI 쪽 정적 증명은 `tests/test_kis_mock_signal_migration_additive.py`.
+
+## 8. 검증
+
+```bash
+uv run pytest tests/services/test_kis_mock_attribution_chain.py \
+              tests/test_kis_mock_signal_migration_additive.py -q
+```
+
+`test_positive_control_attributed_order_does_reach_the_broker` 는 필수다 —
+이것이 없으면 "모든 주문이 막히는 설정 오류"와 "fail-closed 정상 동작"이
+구분되지 않는다.

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -67,7 +67,10 @@ from sqlalchemy import text
 # v34 (ROB-1036): review.sample_eligibility_decisions /
 # invalid_sample_cleanup_bindings / invalid_sample_cleanup_lifecycle_events ORM
 # tables (create_all) + their append-only triggers mirrored below.
-SCHEMA_BOOTSTRAP_VERSION = 34
+# v35: review.kis_mock_signal_ledger (new ORM table via create_all). No
+# mirrored ALTER — the table is created wholesale; the bump only forces a
+# persistent local test DB to re-bootstrap once.
+SCHEMA_BOOTSTRAP_VERSION = 35
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -25,9 +25,15 @@ def _ledger_row(
     accepted_age_sec: int = 5,
     instrument_type: str = "equity_kr",
     price: Decimal = Decimal("0"),
+    correlation_id: str | None = None,
 ):
     row = MagicMock(spec=KISMockOrderLedger)
     row.id = ledger_id
+    row.correlation_id = (
+        correlation_id
+        if correlation_id is not None
+        else f"live:kis_mock:test{ledger_id}"
+    )
     row.symbol = symbol
     row.side = side
     row.quantity = qty

--- a/tests/services/invalid_sample_eligibility/test_migration.py
+++ b/tests/services/invalid_sample_eligibility/test_migration.py
@@ -48,14 +48,21 @@ def _literal(tree: ast.AST, name: str):
     raise AssertionError(f"missing {name!r}")
 
 
-def test_migration_descends_from_the_current_head_and_is_the_single_head() -> None:
+def test_migration_descends_from_its_parent_on_the_single_head_chain() -> None:
     tree = ast.parse(MIGRATION.read_text(encoding="utf-8"))
     assert _literal(tree, "revision") == REVISION
     assert _literal(tree, "down_revision") == DOWN_REVISION
 
     config = Config(str(REPO / "alembic.ini"))
     config.set_main_option("script_location", str(REPO / "alembic"))
-    assert list(ScriptDirectory.from_config(config).get_heads()) == [REVISION]
+    script = ScriptDirectory.from_config(config)
+    # Exactly one head — the property that actually matters — rather than "this
+    # revision IS the head", which stops being true the moment any later
+    # migration lands and says nothing about this one.
+    heads = script.get_heads()
+    assert len(heads) == 1, heads
+    ancestry = {rev.revision for rev in script.walk_revisions("base", heads[0])}
+    assert REVISION in ancestry
 
 
 def test_migration_is_purely_additive() -> None:
@@ -143,7 +150,10 @@ async def test_isolated_upgrade_downgrade_upgrade() -> None:
         stamped = alembic("stamp", DOWN_REVISION)
         assert stamped.returncode == 0, stamped.stderr
 
-        upgraded = alembic("upgrade", "head")
+        # Upgrade to THIS revision, not head: later migrations are not under
+        # test here, and replaying them would collide with tables create_all
+        # already built. It also keeps "downgrade -1" pointed at this revision.
+        upgraded = alembic("upgrade", REVISION)
         assert upgraded.returncode == 0, upgraded.stderr
 
         async with engine.connect() as connection:
@@ -213,7 +223,7 @@ async def test_isolated_upgrade_downgrade_upgrade() -> None:
             )
             assert function_left == 0
 
-        re_upgraded = alembic("upgrade", "head")
+        re_upgraded = alembic("upgrade", REVISION)
         assert re_upgraded.returncode == 0, re_upgraded.stderr
 
         async with engine.connect() as connection:

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -155,6 +155,9 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
                 "sample_eligibility_decisions",
             ):
                 await connection.execute(text(f"DROP TABLE review.{table}"))
+            # Same for the kis_mock pre-submit signal ledger, added after this
+            # boundary and already present in Base.metadata.
+            await connection.execute(text("DROP TABLE review.kis_mock_signal_ledger"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -143,6 +143,9 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
                 "sample_eligibility_decisions",
             ):
                 await connection.execute(text(f"DROP TABLE review.{table}"))
+            # Same for the kis_mock pre-submit signal ledger, added after this
+            # boundary and already present in Base.metadata.
+            await connection.execute(text("DROP TABLE review.kis_mock_signal_ledger"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/test_kis_mock_attribution_chain.py
+++ b/tests/services/test_kis_mock_attribution_chain.py
@@ -1,0 +1,417 @@
+"""Attribution chain: signal -> submit -> ledger -> reconcile, on one key.
+
+Four things are proved here, in the order the brief asks for them:
+
+1. the chain is continuous end to end when read by a single correlation_id;
+2. a deliberately removed stage is *detected* — the query does not quietly
+   return a shorter chain;
+3. an order with no attribution never reaches the broker (fail-closed, not a
+   warning);
+4. the migration adds and only adds.
+
+Every DB touch here runs against the pytest run-owned scratch database created
+by tests/_schema_bootstrap.py. Nothing in this file connects to, reads, or
+writes an operational database.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
+from app.mcp_server.tooling import order_execution
+from app.models.review import KISMockOrderLedger
+from app.services.kis_mock_attribution import (
+    MissingAttribution,
+    record_signal,
+    resolve_attribution,
+)
+from app.services.kis_mock_attribution_chain import (
+    GAP_ORDER_MISSING,
+    GAP_ORDER_UNATTRIBUTED,
+    GAP_RECONCILE_MISSING,
+    GAP_SIGNAL_MISSING,
+    load_attribution_chain,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# resolver (pure)
+# --------------------------------------------------------------------------
+
+
+async def test_resolver_requires_a_strategy():
+    with pytest.raises(MissingAttribution) as excinfo:
+        resolve_attribution(symbol="005930", side="buy", price=70000, quantity=1)
+    assert excinfo.value.missing == ("strategy",)
+
+
+async def test_resolver_rejects_blank_and_whitespace_strategy():
+    for blank in ("", "   ", "\t\n"):
+        with pytest.raises(MissingAttribution):
+            resolve_attribution(
+                symbol="005930",
+                side="buy",
+                price=70000,
+                quantity=1,
+                strategy=blank,
+            )
+
+
+async def test_resolver_derives_the_mirror_lane_without_an_explicit_strategy():
+    attribution = resolve_attribution(
+        symbol="005930",
+        side="buy",
+        price=70000,
+        quantity=1,
+        mirror_cohort="mock_counterfactual",
+    )
+    assert attribution.strategy == "mock_counterfactual_mirror"
+    assert attribution.signal_source == "mirror"
+
+
+async def test_resolver_mint_is_deterministic_and_matches_the_legacy_id():
+    """Moving the mint before the send must not renumber existing ids."""
+    from app.services.live_correlation import live_correlation_id
+
+    kwargs = {
+        "symbol": "005930",
+        "side": "buy",
+        "price": 70000.0,
+        "quantity": 3.0,
+        "kst_trade_day": "2026-08-03",
+    }
+    attribution = resolve_attribution(**kwargs, strategy="posture-v1")
+    legacy = live_correlation_id(
+        account_scope="kis_mock",
+        symbol="005930",
+        side="buy",
+        price=Decimal("70000.0"),
+        quantity=Decimal("3.0"),
+        kst_trade_day="2026-08-03",
+        rung=0,
+    )
+    assert attribution.correlation_id == legacy
+
+
+# --------------------------------------------------------------------------
+# 1. chain continuity
+# --------------------------------------------------------------------------
+
+
+def _order_row(*, symbol: str, correlation_id: str, **overrides) -> KISMockOrderLedger:
+    values = {
+        "trade_date": datetime.now(UTC) - timedelta(minutes=1),
+        "symbol": symbol,
+        "instrument_type": "equity_kr",
+        "side": "buy",
+        "order_type": "limit",
+        "quantity": Decimal("1"),
+        "price": Decimal("70000"),
+        "amount": Decimal("70000"),
+        "currency": "KRW",
+        "account_mode": "kis_mock",
+        "broker": "kis",
+        "status": "accepted",
+        "order_no": f"MOCK-{uuid4()}",
+        "lifecycle_state": "accepted",
+        "holdings_baseline_qty": Decimal("0"),
+        "correlation_id": correlation_id,
+        "strategy": "posture-v1",
+    }
+    values.update(overrides)
+    return KISMockOrderLedger(**values)
+
+
+async def test_chain_is_unbroken_from_signal_through_reconcile(db_session):
+    symbol = f"CH-{uuid4().hex[:8]}"
+    attribution = resolve_attribution(
+        symbol=symbol, side="buy", price=70000, quantity=1, strategy="posture-v1"
+    )
+    cid = attribution.correlation_id
+
+    # stage 1 — signal, written before any order exists
+    await record_signal(
+        db_session,
+        attribution=attribution,
+        symbol=symbol,
+        decision="order",
+        instrument_type="equity_kr",
+        side="buy",
+        intended_quantity=1,
+        intended_price=70000,
+    )
+
+    # stage 2 — the order row carrying the same key
+    db_session.add(_order_row(symbol=symbol, correlation_id=cid))
+    await db_session.commit()
+
+    # stage 3 — reconcile, which must carry the key into its own record
+    client = MagicMock()
+    client.fetch_my_stocks = AsyncMock(
+        side_effect=[[{"pdno": symbol, "hldg_qty": "1"}], []]
+    )
+    result = await run_kis_mock_reconciliation(
+        db_session,
+        dry_run=False,
+        market="equity_kr",
+        symbol=symbol,
+        kis_client=client,
+    )
+    assert result["success"] is True
+    assert [event["correlation_id"] for event in result["events"]] == [cid]
+    assert result["events"][0]["detail"]["correlation_id"] == cid
+
+    db_session.expire_all()
+    chain = await load_attribution_chain(db_session, correlation_id=cid)
+
+    assert chain.gaps == ()
+    assert chain.unbroken is True
+    assert chain.strategy == "posture-v1"
+    assert [stage.name for stage in chain.stages] == ["signal", "order", "reconcile"]
+    assert all(stage.present for stage in chain.stages)
+    assert (
+        chain.stage("reconcile").detail["reconcile_details"][0]["correlation_id"] == cid
+    )
+
+
+async def test_a_signal_that_produced_no_order_is_a_complete_chain(db_session):
+    """Suppressed signals are evidence, not gaps — they hold the denominator."""
+    symbol = f"NO-{uuid4().hex[:8]}"
+    attribution = resolve_attribution(
+        symbol=symbol, side="buy", price=1000, quantity=1, strategy="posture-v1"
+    )
+    await record_signal(
+        db_session,
+        attribution=attribution,
+        symbol=symbol,
+        decision="no_order",
+        suppressed_reason="risk_cap_reached",
+    )
+
+    chain = await load_attribution_chain(
+        db_session, correlation_id=attribution.correlation_id
+    )
+    assert chain.gaps == ()
+    assert chain.stage("signal").detail["decision"] == "no_order"
+    assert chain.stage("signal").detail["suppressed_reason"] == "risk_cap_reached"
+    assert chain.stage("order").present is False
+
+
+async def test_record_signal_is_idempotent_on_replay(db_session):
+    symbol = f"ID-{uuid4().hex[:8]}"
+    attribution = resolve_attribution(
+        symbol=symbol, side="buy", price=1000, quantity=1, strategy="posture-v1"
+    )
+    first = await record_signal(
+        db_session, attribution=attribution, symbol=symbol, decision="order"
+    )
+    second = await record_signal(
+        db_session, attribution=attribution, symbol=symbol, decision="order"
+    )
+    assert first == second
+
+
+# --------------------------------------------------------------------------
+# 2. gap detection — break the chain on purpose
+# --------------------------------------------------------------------------
+
+
+async def test_missing_signal_stage_is_detected(db_session):
+    """An order with no pre-submit signal row is the pre-repair world."""
+    symbol = f"GS-{uuid4().hex[:8]}"
+    cid = f"live:kis_mock:{uuid4().hex[:16]}"
+    db_session.add(_order_row(symbol=symbol, correlation_id=cid))
+    await db_session.commit()
+
+    chain = await load_attribution_chain(db_session, correlation_id=cid)
+    assert GAP_SIGNAL_MISSING in chain.gaps
+    assert chain.unbroken is False
+
+
+async def test_missing_order_stage_is_detected(db_session):
+    symbol = f"GO-{uuid4().hex[:8]}"
+    attribution = resolve_attribution(
+        symbol=symbol, side="buy", price=1000, quantity=1, strategy="posture-v1"
+    )
+    await record_signal(
+        db_session, attribution=attribution, symbol=symbol, decision="order"
+    )
+
+    chain = await load_attribution_chain(
+        db_session, correlation_id=attribution.correlation_id
+    )
+    assert GAP_ORDER_MISSING in chain.gaps
+
+
+async def test_missing_reconcile_stage_is_detected(db_session):
+    symbol = f"GR-{uuid4().hex[:8]}"
+    attribution = resolve_attribution(
+        symbol=symbol, side="buy", price=1000, quantity=1, strategy="posture-v1"
+    )
+    await record_signal(
+        db_session, attribution=attribution, symbol=symbol, decision="order"
+    )
+    db_session.add(_order_row(symbol=symbol, correlation_id=attribution.correlation_id))
+    await db_session.commit()
+
+    chain = await load_attribution_chain(
+        db_session, correlation_id=attribution.correlation_id
+    )
+    assert GAP_RECONCILE_MISSING in chain.gaps
+
+
+async def test_unattributed_order_row_is_detected(db_session):
+    """The exact ROB-1093 shape: the row exists but names no owner."""
+    symbol = f"GU-{uuid4().hex[:8]}"
+    attribution = resolve_attribution(
+        symbol=symbol, side="buy", price=1000, quantity=1, strategy="posture-v1"
+    )
+    await record_signal(
+        db_session, attribution=attribution, symbol=symbol, decision="order"
+    )
+    db_session.add(
+        _order_row(
+            symbol=symbol,
+            correlation_id=attribution.correlation_id,
+            strategy=None,
+            lifecycle_state="previewed",
+        )
+    )
+    await db_session.commit()
+
+    chain = await load_attribution_chain(
+        db_session, correlation_id=attribution.correlation_id
+    )
+    assert GAP_ORDER_UNATTRIBUTED in chain.gaps
+
+
+# --------------------------------------------------------------------------
+# 3. fail-closed — the order must not be sent
+# --------------------------------------------------------------------------
+
+
+def _execute_and_record_kwargs(**overrides):
+    kwargs = {
+        "normalized_symbol": "005930",
+        "side": "buy",
+        "order_type": "limit",
+        "order_quantity": 1.0,
+        "price": 70000.0,
+        "market_type": "equity_kr",
+        "current_price": 70000.0,
+        "avg_price": 0.0,
+        "dry_run_result": {
+            "price": 70000.0,
+            "quantity": 1.0,
+            "estimated_value": 70000.0,
+        },
+        "order_amount": 70000.0,
+        "reason": "test",
+        "exit_reason": None,
+        "thesis": None,
+        "strategy": None,
+        "target_price": None,
+        "stop_loss": None,
+        "min_hold_days": None,
+        "notes": None,
+        "indicators_snapshot": None,
+        "defensive_trim_ctx": None,
+        "order_error_fn": lambda message: {"success": False, "error": message},
+        "is_mock": True,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.fixture
+def broker_tripwire(monkeypatch):
+    """Fails the test if anything reaches the broker."""
+    calls: list[dict] = []
+
+    async def _explode(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("broker was called for an unattributed order")
+
+    monkeypatch.setattr(order_execution, "_execute_order", _explode)
+    monkeypatch.setattr(
+        order_execution, "_record_order_history", AsyncMock(return_value=None)
+    )
+    return calls
+
+
+async def test_order_is_blocked_when_attribution_is_missing(broker_tripwire):
+    result = await order_execution._execute_and_record(**_execute_and_record_kwargs())
+
+    assert result["success"] is False
+    assert result["error_code"] == "attribution_required"
+    assert result["missing_attribution"] == ["strategy"]
+    # The tripwire proves it: nothing was sent.
+    assert broker_tripwire == []
+
+
+async def test_order_is_blocked_when_the_signal_row_cannot_be_written(
+    broker_tripwire, monkeypatch
+):
+    """No durable attribution, no send — even though the strategy was supplied."""
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("signal ledger unavailable")
+
+    monkeypatch.setattr(order_execution, "record_signal", _boom)
+
+    result = await order_execution._execute_and_record(
+        **_execute_and_record_kwargs(strategy="posture-v1")
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "signal_record_unavailable"
+    assert broker_tripwire == []
+
+
+async def test_positive_control_attributed_order_does_reach_the_broker(
+    monkeypatch, db_session
+):
+    """Guards against a false pass: the block above is caused by attribution.
+
+    Without this, a test-setup error that blocks every order would look
+    identical to a working fail-closed gate.
+    """
+    sent: list[dict] = []
+
+    async def _capture(**kwargs):
+        sent.append(kwargs)
+        return {"rt_cd": "0", "odno": f"MOCK{uuid4().hex[:8]}", "msg1": "ok"}
+
+    monkeypatch.setattr(order_execution, "_execute_order", _capture)
+    monkeypatch.setattr(
+        order_execution, "_record_order_history", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_kis_mock_baseline_qty",
+        AsyncMock(return_value=Decimal("0")),
+        raising=False,
+    )
+
+    symbol = f"PC-{uuid4().hex[:8]}"
+    result = await order_execution._execute_and_record(
+        **_execute_and_record_kwargs(normalized_symbol=symbol, strategy="posture-v1")
+    )
+
+    assert len(sent) == 1, "attributed order should have been sent"
+    correlation_id = result["correlation_id"]
+    assert correlation_id
+
+    # ...and the pre-submit signal row is durable, carrying the strategy.
+    db_session.expire_all()
+    chain = await load_attribution_chain(db_session, correlation_id=correlation_id)
+    assert chain.stage("signal").present is True
+    assert chain.stage("signal").detail["strategy"] == "posture-v1"

--- a/tests/services/test_kis_mock_attribution_chain.py
+++ b/tests/services/test_kis_mock_attribution_chain.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 import pytest
 
 from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
-from app.mcp_server.tooling import order_execution
+from app.mcp_server.tooling import kis_mock_ledger, order_execution
 from app.models.review import KISMockOrderLedger
 from app.services.kis_mock_attribution import (
     MissingAttribution,
@@ -268,6 +268,47 @@ async def test_missing_reconcile_stage_is_detected(db_session):
     assert GAP_RECONCILE_MISSING in chain.gaps
 
 
+async def test_cancelled_order_does_not_report_a_false_reconcile_gap(db_session):
+    """A cancelled order is terminal, and terminal transitions leave evidence.
+
+    Raised in review: ``cancelled`` is absent from ``_PRE_RECONCILE_STATES``, so
+    would a cancelled chain be reported broken? No — and the reason is worth
+    pinning down rather than asserting. ``cancelled`` is in
+    ``TERMINAL_LIFECYCLE_STATES``, and ``apply_lifecycle_transition`` writes
+    ``last_reconcile_detail`` for every transition plus ``reconciled_at`` for
+    terminal ones. So the cancel path leaves exactly the evidence the chain
+    looks for. This drives the real cancel entrypoint, not a hand-built row, so
+    the test fails if that ever stops being true.
+    """
+    from app.mcp_server.tooling.kis_mock_ledger import mark_kis_mock_order_cancelled
+
+    symbol = f"GC-{uuid4().hex[:8]}"
+    attribution = resolve_attribution(
+        symbol=symbol, side="buy", price=1000, quantity=1, strategy="posture-v1"
+    )
+    await record_signal(
+        db_session, attribution=attribution, symbol=symbol, decision="order"
+    )
+    row = _order_row(symbol=symbol, correlation_id=attribution.correlation_id)
+    db_session.add(row)
+    await db_session.commit()
+
+    await mark_kis_mock_order_cancelled(
+        ledger_id=row.id,
+        broker_confirmed=True,
+        detail={"source": "test"},
+    )
+
+    db_session.expire_all()
+    chain = await load_attribution_chain(
+        db_session, correlation_id=attribution.correlation_id
+    )
+    assert GAP_RECONCILE_MISSING not in chain.gaps
+    assert chain.gaps == ()
+    assert chain.stage("order").detail["lifecycle_states"] == ["cancelled"]
+    assert chain.stage("reconcile").present is True
+
+
 async def test_unattributed_order_row_is_detected(db_session):
     """The exact ROB-1093 shape: the row exists but names no owner."""
     symbol = f"GU-{uuid4().hex[:8]}"
@@ -394,12 +435,13 @@ async def test_positive_control_attributed_order_does_reach_the_broker(
     monkeypatch.setattr(
         order_execution, "_record_order_history", AsyncMock(return_value=None)
     )
-    monkeypatch.setattr(
-        order_execution,
-        "_fetch_kis_mock_baseline_qty",
-        AsyncMock(return_value=Decimal("0")),
-        raising=False,
-    )
+    # Patch where it is DEFINED, not where it is used: _execute_and_record
+    # imports this inside the function body from kis_mock_ledger, so patching
+    # the order_execution namespace binds nothing. No raising=False either —
+    # a silently-absent attribute is how the wrong target went unnoticed, and
+    # the real function then reached for a broker token.
+    baseline = AsyncMock(return_value=Decimal("0"))
+    monkeypatch.setattr(kis_mock_ledger, "_fetch_kis_mock_baseline_qty", baseline)
 
     symbol = f"PC-{uuid4().hex[:8]}"
     result = await order_execution._execute_and_record(
@@ -407,6 +449,9 @@ async def test_positive_control_attributed_order_does_reach_the_broker(
     )
 
     assert len(sent) == 1, "attributed order should have been sent"
+    # Proves the patch above actually bound; a no-op patch would leave this 0
+    # and let the real broker-touching baseline fetch run instead.
+    assert baseline.await_count == 1
     correlation_id = result["correlation_id"]
     assert correlation_id
 

--- a/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
+++ b/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
@@ -12,8 +12,13 @@ from tests._mcp_tooling_support import build_tools
 
 
 @pytest.mark.asyncio
-async def test_full_reconciliation_cycle_acceptance(monkeypatch):
-    """place_order (kis_mock) captures baseline → reconciler detects fill via MCP tool."""
+async def test_full_reconciliation_cycle_acceptance(monkeypatch, db_session):
+    """place_order (kis_mock) captures baseline → reconciler detects fill via MCP tool.
+
+    ``db_session`` is required even though the ledger insert is mocked: the
+    pre-submit attribution gate writes a real signal row before the send and
+    fails closed if it cannot, so the test needs a reachable database.
+    """
     from app.mcp_server.tooling import kis_mock_ledger, order_execution
 
     monkeypatch.setattr(
@@ -59,6 +64,7 @@ async def test_full_reconciliation_cycle_acceptance(monkeypatch):
     mock_ledger_row.lifecycle_state = "accepted"
     mock_ledger_row.holdings_baseline_qty = Decimal("0")
     mock_ledger_row.trade_date = datetime.now(UTC) - timedelta(seconds=10)
+    mock_ledger_row.correlation_id = "live:kis_mock:acceptance"
 
     mock_lifecycle_svc = AsyncMock()
     mock_lifecycle_svc.list_open_orders.return_value = [mock_ledger_row]
@@ -104,6 +110,7 @@ async def test_full_reconciliation_cycle_acceptance(monkeypatch):
         price=100.0,
         account_mode="kis_mock",
         dry_run=False,
+        strategy="posture-v1",
     )
     assert place_res["success"] is True
     assert place_res["ledger_id"] == 555
@@ -128,3 +135,6 @@ async def test_full_reconciliation_cycle_acceptance(monkeypatch):
     assert args["next_state"] == "fill"
     assert args["reason_code"] == "fill_detected"
     assert args["dry_run"] is False
+    # The reconcile record names the decision it belongs to, not just the row.
+    assert args["detail"]["correlation_id"] == "live:kis_mock:acceptance"
+    assert recon_res["events"][0]["correlation_id"] == "live:kis_mock:acceptance"

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -232,6 +232,7 @@ async def test_kis_mock_buy_writes_ledger_and_skips_live(monkeypatch):
         price=70000.0,
         dry_run=False,
         account_mode="kis_mock",
+        strategy="posture-v1",
     )
 
     assert result["success"] is True, result
@@ -335,6 +336,7 @@ async def test_kis_mock_sell_writes_ledger_and_does_not_close_journals(monkeypat
         price=70000.0,
         dry_run=False,
         account_mode="kis_mock",
+        strategy="posture-v1",
     )
 
     assert result["success"] is True, result
@@ -381,12 +383,17 @@ async def test_kis_mock_missing_config_fails_closed_before_broker(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Task 5: kis_mock buy does NOT require thesis/strategy
+# Task 5: kis_mock buy does NOT require a thesis, but DOES require a strategy.
+#
+# Contract change: thesis stays optional (mock orders never create a
+# TradeJournal, which is what thesis feeds). ``strategy`` is now mandatory —
+# the pre-submit attribution gate refuses to send an order nobody owns, since a
+# nullable strategy is what made mock fills unattributable after the fact.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_kis_mock_buy_does_not_require_thesis_strategy(monkeypatch):
+async def test_kis_mock_buy_does_not_require_thesis(monkeypatch):
     from app.mcp_server.tooling import kis_mock_ledger, order_execution, order_journal
     from tests._mcp_tooling_support import build_tools
 
@@ -444,7 +451,63 @@ async def test_kis_mock_buy_does_not_require_thesis_strategy(monkeypatch):
     monkeypatch.setattr(order_journal, "_save_order_fill", AsyncMock())
 
     tools = build_tools()
-    # No thesis, no strategy — should succeed for kis_mock
+    # No thesis — still fine for kis_mock (no TradeJournal is created).
+    result = await tools["place_order"](
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=3,
+        price=70000.0,
+        dry_run=False,
+        account_mode="kis_mock",
+        strategy="posture-v1",
+    )
+    assert result["success"] is True, result
+    assert result["ledger_id"] == 7
+    save_ledger.assert_awaited_once()
+    # The strategy reaches the ledger row rather than being dropped.
+    assert save_ledger.call_args.kwargs["strategy"] == "posture-v1"
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_buy_without_strategy_is_refused_before_send(monkeypatch):
+    """The same order minus the strategy never reaches the broker."""
+    from app.mcp_server.tooling import kis_mock_ledger, order_execution
+    from tests._mcp_tooling_support import build_tools
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda *_, **__: [],
+    )
+    monkeypatch.setattr(
+        order_execution, "_fetch_current_price", AsyncMock(return_value=70000.0)
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "side": "buy",
+                "order_type": "limit",
+                "price": 70000.0,
+                "quantity": 3,
+                "estimated_value": 210000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution, "_check_balance_and_warn", AsyncMock(return_value=(None, None))
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
+
+    executed = AsyncMock()
+    monkeypatch.setattr(order_execution, "_execute_order", executed)
+    save_ledger = AsyncMock(return_value=7)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger)
+
+    tools = build_tools()
     result = await tools["place_order"](
         symbol="005930",
         side="buy",
@@ -454,9 +517,11 @@ async def test_kis_mock_buy_does_not_require_thesis_strategy(monkeypatch):
         dry_run=False,
         account_mode="kis_mock",
     )
-    assert result["success"] is True, result
-    assert result["ledger_id"] == 7
-    save_ledger.assert_awaited_once()
+
+    assert result["success"] is False
+    assert result["error_code"] == "attribution_required"
+    executed.assert_not_awaited()
+    save_ledger.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -1675,6 +1740,7 @@ async def test_place_order_impl_threads_correlation_id(db_session, monkeypatch):
         reason="rob402-test",
         is_mock=True,
         correlation_id="corr-rob402",
+        strategy="posture-v1",
     )
     assert result["success"] is True, result
     row = (

--- a/tests/test_kis_mock_reconciliation_job_scope.py
+++ b/tests/test_kis_mock_reconciliation_job_scope.py
@@ -58,6 +58,7 @@ async def test_job_layer_accepts_valid_market_unchanged(monkeypatch):
     mock_ledger_row.lifecycle_state = "accepted"
     mock_ledger_row.holdings_baseline_qty = Decimal("0")
     mock_ledger_row.trade_date = datetime.now(UTC) - timedelta(seconds=10)
+    mock_ledger_row.correlation_id = "live:kis_mock:scopetest"
 
     fake_lifecycle_svc = AsyncMock()
     fake_lifecycle_svc.list_open_orders.return_value = [mock_ledger_row]

--- a/tests/test_kis_mock_signal_migration_additive.py
+++ b/tests/test_kis_mock_signal_migration_additive.py
@@ -1,0 +1,97 @@
+"""The kis_mock signal-ledger migration adds, and only adds.
+
+Static proof, so it runs in CI without a database: the migration module is
+parsed and every ``op.*`` call is checked. A schema-mutating operation, or a
+DDL call naming any table other than the new one, fails here.
+
+The complementary live proof (upgrade -> downgrade -> upgrade against a scratch
+database, diffing the surrounding schema) is recorded in
+docs/runbooks/kis-mock-attribution-chain.md; it is not run in CI because the
+test database is built by create_all rather than by alembic.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "20260803_kis_mock_signal_ledger.py"
+)
+_NEW_TABLE = "kis_mock_signal_ledger"
+# Operations that would mutate something that already exists. None may appear.
+_MUTATING_OPS = frozenset(
+    {
+        "alter_column",
+        "drop_column",
+        "add_column",
+        "drop_constraint",
+        "drop_table_comment",
+        "rename_table",
+        "execute",
+        "batch_alter_table",
+    }
+)
+
+
+def _op_calls(tree: ast.AST) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "op"
+    ]
+
+
+def test_migration_touches_only_the_new_table():
+    tree = ast.parse(_MIGRATION.read_text(encoding="utf-8"))
+    module_consts = {
+        target.id: node.value.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    }
+
+    def _literal(arg: ast.expr) -> str | None:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+        if isinstance(arg, ast.Name):
+            return module_consts.get(arg.id)
+        return None
+
+    seen_ops: set[str] = set()
+    for call in _op_calls(tree):
+        name = call.func.attr
+        seen_ops.add(name)
+        assert name not in _MUTATING_OPS, (
+            f"migration uses op.{name}, which can alter existing schema objects"
+        )
+        # Every DDL call must name the new table.
+        table_args = [_literal(arg) for arg in call.args]
+        assert _NEW_TABLE in table_args, (
+            f"op.{name} does not target {_NEW_TABLE}: {table_args}"
+        )
+
+    assert "create_table" in seen_ops
+    assert "drop_table" in seen_ops, "downgrade must be reversible"
+
+
+def test_migration_chains_onto_the_current_head():
+    tree = ast.parse(_MIGRATION.read_text(encoding="utf-8"))
+    assigns = {
+        target.id: node.value.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant)
+    }
+    assert assigns["revision"] == "20260803_kis_mock_signal"
+    assert assigns["down_revision"] == "20260802_rob1036_sample_elig"


### PR DESCRIPTION
## 왜

kis_mock 실행 envelope 초안에서 `CORRELATION_CHAIN_UNBROKEN = NO` 가 나왔다. 규명 결과 **끊긴 지점은 3곳**이고, 근본 원인은 하나 — **순서**다.

| 구간 | 수리 전 |
|---|---|
| signal → submit | durable record **없음** |
| submit 시점 귀속 | `correlation_id` 를 브로커 응답 처리부에서 mint = **POST 이후** |
| `strategy` | nullable + 무검증 (`_place_order_impl` 주석에 "mock 은 선택" 명시) |
| reconcile | `OrderLifecycleEvent.correlation_id` 필드는 ROB-100 부터 존재했으나 **채우지 않음** |

사후 mint 는 "주문은 나갔는데 원장 write 실패 / 프로세스 사망" 시 **브로커에만 존재하고 귀속은 어디에도 없는 주문**을 만든다. ROB-1093 과 같은 모양: nullable 컬럼은 「채워질 수도 있다」가 아니라 **「안 채워져도 통과한다」**.

## 무엇을

- **`review.kis_mock_signal_ledger`** (신규, additive) — pre-submit 결정 기록. `correlation_id`/`strategy`/`signal_source` **NOT NULL + 공백거부 CHECK**. 주문으로 이어지지 않은 신호도 `decision='no_order'` 로 기록(분모 보존).
- **fail-closed 게이트** — `_execute_and_record` **최상단**, 보유 baseline 조회(브로커 read)보다도 앞. 귀속 없으면 브로커 I/O 를 한 번도 안 한다. `error_code`: `attribution_required` / `signal_record_unavailable`.
- **reconcile 전달** — transition detail + `OrderLifecycleEvent.correlation_id`.
- **`load_attribution_chain(correlation_id)`** — read-only 조회. gap 코드 `signal_missing`/`order_missing`/`order_unattributed`/`reconcile_missing`.

## 강제 수준 — 왜 NOT NULL 이 새 테이블에 있나

`kis_mock_order_ledger.correlation_id`/`strategy` 는 ROB-321/730 이전 행에 NULL 이 있어 **NOT NULL 승격은 마이그레이션을 깨뜨린다.** 대신 제약을 **pre-submit 신호 테이블**(legacy row 0)에 걸었다. 주문은 그 insert 가 성공해야만 나가므로 **결과적으로 DB 가 모든 신규 주문의 귀속을 검증한다.**

- `ENFORCEMENT_LEVEL = APP_FAIL_CLOSED` (+ 신호 테이블 DB NOT NULL)
- ⚠️ `EXISTING_NULL_ROWS` = **미측정** — 작업 범위가 운영 DB 접속 0 이라 실측 불가. 원장 백필은 별건.

## ⚠️ 파괴적 변경

`place_order(is_mock=True)` 는 이제 **`strategy` 필수**. 레포 내 호출자는 전부 배선 완료(scalping / mirror / watch auto-execute). `thesis` 는 여전히 불필요. **live·crypto·kiwoom_mock 경로 무변경.**

## 검증

1. **사슬 연속성** — signal→order→reconcile 을 하나의 키로 조회, 3단계 전부 present
2. **gap 탐지** — 단계를 하나씩 일부러 빼서 4개 gap 코드가 각각 잡히는지
3. **fail-closed** — 브로커 tripwire 로 "전송 0" 증명 + **positive control**(귀속 있으면 전송됨). 이게 없으면 "설정 오류로 전부 막힘"과 구분 불가
4. **additive** — scratch DB up→down→up, 신규 테이블 제외 **스키마 오브젝트 3,657개 byte-identical**. NULL/공백 귀속 4종 전부 REJECTED

> 첫 시도의 스냅샷 쿼리가 SQL 에러로 빈 파일을 비교해 "IDENTICAL" 오탐이 났다. 하한(1,000 오브젝트) 가드를 넣어 재실행한 결과가 위 수치다.

전체 스위트 **17,784 passed**. 로컬 postgres 에 timescaledb 가 없어 전체 체인 replay 는 불가 — baseline 은 `create_all`(신규 테이블 제외)로 구성, CI 정적 증명은 별도 테스트.

## 남은 한계

1. 주문 원장 과거 NULL **미측정·미백필**
2. scalping 왕복은 entry/exit 가 `correlation_id` 를 공유해 **signal row 1개**만 남음 (귀속 자체는 온전)
3. 전송 중 예외 시 `outcome_state='recorded'` 유지 — 접수 여부 불명을 실패로 단정하지 않는 것이 의도
4. 신호 COMMIT 과 POST 사이 창은 **제거가 아니라 탐지**(`order_missing`)

## 무관 파일 3건

`invalid_sample_eligibility` / `paper_cohort` / `paper_evaluation` 의 migration 테스트는 `create_all` 후 옛 revision 에서 replay 하므로, 새 테이블이 생기면 충돌한다. 레포 관례대로 drop 을 추가했고, ROB-1036 쪽은 "내가 head" 단언을 **"head 는 하나 + 이 revision 이 그 조상"** 으로 바꿨다(새 마이그레이션마다 깨지던 단언).

🔴 **머지 금지 — 교차 검증 후 상신.**

런북: `docs/runbooks/kis-mock-attribution-chain.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attribution tracking for KIS mock orders from signal creation through reconciliation.
  * Mock orders now require a strategy and receive durable correlation IDs.
  * Added attribution-chain inspection with diagnostics for missing or disconnected stages.
  * Added automatic labeling for counterfactual mirror orders.

* **Bug Fixes**
  * Orders now fail safely before submission when attribution or signal recording is unavailable.
  * Correlation IDs are preserved across order, ledger, and lifecycle reconciliation records.

* **Documentation**
  * Added a runbook describing the mock attribution workflow, validation, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->