### PR TITLE
fix(kis_mock): reject placeholder strategies

### DIFF
--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -26,12 +26,12 @@ from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
     LedgerWriteError,
 )
 from app.services.brokers.kis.order_id import normalize_broker_order_id
+from app.services.kis_mock_attribution import validate_strategy
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
 from app.services.kis_mock_reconcile_scope import (
     normalize_kis_mock_reconcile_market,  # noqa: F401 - re-exported for back-compat
     resolve_kis_mock_reconcile_scope,
 )
-from app.services.live_correlation import live_correlation_id
 from app.services.live_place_provenance import publish_place_time_forecast
 
 # ROB-843: sensitive-key fragments to redact from raw broker evidence before it
@@ -481,7 +481,7 @@ async def _record_kis_mock_order(
     execution_result: dict[str, Any],
     reason: str | None,
     thesis: str | None,
-    strategy: str | None,
+    strategy: str,
     notes: str | None,
     holdings_baseline_qty: Decimal | None = None,
     correlation_id: str | None = None,
@@ -492,6 +492,16 @@ async def _record_kis_mock_order(
     mirror_source_bucket: str | None = None,
 ) -> dict[str, Any]:
     """Build ledger row from execution result and return the mock-order response dict."""
+    # This helper is intentionally fail-closed for direct callers too.  The
+    # authoritative attribution is resolved before POST by order_execution;
+    # this post-send writer must only consume that result, never mint a new
+    # identity after the fact.
+    strategy = validate_strategy(strategy)
+    if not isinstance(correlation_id, str) or not correlation_id.strip():
+        raise ValueError(
+            "kis_mock ledger recording requires a pre-submit correlation_id"
+        )
+
     price_val = _to_float(dry_run_result.get("price"), default=0.0)
     qty_val = _to_float(dry_run_result.get("quantity"), default=0.0)
     amt_val = _to_float(dry_run_result.get("estimated_value"), default=0.0)
@@ -547,24 +557,6 @@ async def _record_kis_mock_order(
     else:
         failure_reason = "unknown_response"
         failure_detail = msg or f"rt_cd={rt_cd} order_no={order_no}"
-
-    # ROB-730 provenance spine: the correlation_id joins forecast → fill →
-    # journal → retrospective, mirroring the kis_live path verbatim.
-    #
-    # The authoritative mint now happens PRE-submit in the attribution gate
-    # (app/services/kis_mock_attribution.py), which passes the id in. This
-    # branch is only a fallback for direct callers of this helper; it uses the
-    # identical inputs and helper, so it yields the identical id.
-    if correlation_id is None:
-        correlation_id = live_correlation_id(
-            account_scope="kis_mock",
-            symbol=normalized_symbol,
-            side=side,
-            price=Decimal(str(price_val)),
-            quantity=Decimal(str(qty_val)),
-            kst_trade_day=now_kst().strftime("%Y-%m-%d"),
-            rung=0,
-        )
 
     # ROB-843: redact sensitive keys from the raw broker evidence before it is
     # persisted or returned. Recursive, non-mutating; non-sensitive diagnostics

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -815,7 +815,9 @@ async def _execute_and_record(
                 list(attribution_exc.missing),
             )
             err = order_error_fn(str(attribution_exc))
-            err["error_code"] = "attribution_required"
+            err["error_code"] = getattr(
+                attribution_exc, "error_code", "attribution_required"
+            )
             err["missing_attribution"] = list(attribution_exc.missing)
             return err
 

--- a/app/services/kis_mock_attribution.py
+++ b/app/services/kis_mock_attribution.py
@@ -23,6 +23,8 @@ orders silently drops the denominator.
 
 from __future__ import annotations
 
+import logging
+import unicodedata
 import uuid
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
@@ -38,6 +40,7 @@ from app.models.review import KISMockSignalLedger
 from app.services.live_correlation import live_correlation_id
 
 ACCOUNT_SCOPE = "kis_mock"
+logger = logging.getLogger(__name__)
 
 # Lane labels derived from unambiguous execution context. These are real
 # attribution — each names exactly one code path that owns the order — not
@@ -46,6 +49,25 @@ ACCOUNT_SCOPE = "kis_mock"
 MIRROR_STRATEGY = "mock_counterfactual_mirror"
 MIRROR_SIGNAL_SOURCE = "mirror"
 DEFAULT_SIGNAL_SOURCE = "manual"
+
+# There is no repository-wide registry of strategy identifiers.  Keep this a
+# deliberately small, explicit denylist until one exists; an allowlist here
+# would invent a second source of truth and reject existing real strategies.
+KIS_MOCK_PLACEHOLDER_STRATEGIES = frozenset(
+    {
+        "null",
+        "none",
+        "undefined",
+        "nil",
+        "n/a",
+        "tbd",
+        "todo",
+        "test",
+        "unknown",
+        "-",
+        "?",
+    }
+)
 
 _DECISION_ORDER = "order"
 _DECISION_NO_ORDER = "no_order"
@@ -64,6 +86,19 @@ class MissingAttribution(Exception):
         )
 
 
+class InvalidStrategy(MissingAttribution):
+    """Raised when a supplied strategy is blank or a placeholder value."""
+
+    error_code = "placeholder_strategy"
+
+    def __init__(self, strategy: Any) -> None:
+        self.strategy = strategy
+        super().__init__(("strategy",))
+        self.args = (
+            "kis_mock order strategy is blank or a placeholder; refusing to send",
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class KisMockAttribution:
     """A complete attribution triple. Constructed only via resolve_attribution."""
@@ -78,6 +113,67 @@ def _clean(value: Any) -> str | None:
         return None
     stripped = value.strip()
     return stripped or None
+
+
+_COMMON_CONFUSABLES = str.maketrans(
+    {
+        # Latin-looking Greek/Cyrillic characters used in NULL/NONE/etc.
+        "Ν": "N",
+        "ν": "n",
+        "Ο": "O",
+        "ο": "o",
+        "Ι": "I",
+        "ι": "i",
+        "Λ": "L",
+        "λ": "l",
+        "Ε": "E",
+        "ε": "e",
+        "Τ": "T",
+        "τ": "t",
+        "А": "A",
+        "а": "a",
+        "Е": "E",
+        "е": "e",
+        "О": "O",
+        "о": "o",
+        "Р": "P",
+        "р": "p",
+        "С": "C",
+        "с": "c",
+        "Х": "X",
+        "х": "x",
+        "У": "Y",
+        "у": "y",
+        "І": "I",
+        "і": "i",
+        "Ѕ": "S",
+        "ѕ": "s",
+    }
+)
+
+
+def _normalize_strategy_for_comparison(value: str) -> str:
+    """Canonicalize strategy text only for placeholder comparison.
+
+    NFKC folds fullwidth letters/spaces, ``casefold`` handles case variants,
+    and removing format/control characters prevents zero-width bypasses.
+    """
+    normalized = unicodedata.normalize("NFKC", value).translate(_COMMON_CONFUSABLES)
+    normalized = "".join(
+        char for char in normalized if unicodedata.category(char) not in {"Cc", "Cf"}
+    )
+    return normalized.strip().casefold()
+
+
+def validate_strategy(strategy: Any) -> str:
+    """Return a usable strategy or raise an exception; never substitute one."""
+    cleaned = _clean(strategy)
+    if cleaned is None or (
+        _normalize_strategy_for_comparison(cleaned) in KIS_MOCK_PLACEHOLDER_STRATEGIES
+    ):
+        logger.warning("kis_mock strategy rejected: blank or placeholder")
+        raise InvalidStrategy(strategy)
+    return unicodedata.normalize("NFKC", cleaned).strip()
 
 
 def _to_decimal(value: Any) -> Decimal | None:
@@ -134,11 +230,11 @@ def resolve_attribution(
     identifies the counterfactual-mirror lane on its own. Anything else without
     a strategy is unattributable and raises.
     """
-    resolved_strategy = _clean(strategy)
+    resolved_strategy = validate_strategy(strategy) if strategy is not None else None
     resolved_source = _clean(signal_source)
 
     if resolved_strategy is None and _clean(mirror_cohort) == "mock_counterfactual":
-        resolved_strategy = MIRROR_STRATEGY
+        resolved_strategy = validate_strategy(MIRROR_STRATEGY)
         resolved_source = resolved_source or MIRROR_SIGNAL_SOURCE
 
     missing: list[str] = []

--- a/tests/services/test_kis_mock_attribution_chain.py
+++ b/tests/services/test_kis_mock_attribution_chain.py
@@ -27,6 +27,7 @@ from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
 from app.mcp_server.tooling import kis_mock_ledger, order_execution
 from app.models.review import KISMockOrderLedger
 from app.services.kis_mock_attribution import (
+    InvalidStrategy,
     MissingAttribution,
     record_signal,
     resolve_attribution,
@@ -63,6 +64,84 @@ async def test_resolver_rejects_blank_and_whitespace_strategy():
                 quantity=1,
                 strategy=blank,
             )
+
+
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        "null",
+        "None",
+        "undefined",
+        "",
+        "   ",
+        "NULL",
+        " null ",
+        "nil",
+        "n/a",
+        "tbd",
+        "todo",
+        "test",
+        "unknown",
+        "-",
+        "?",
+        "\u3000NULL\u3000",
+        "ＮＵＬＬ",
+        "ΝULL",  # Greek capital nu
+    ],
+)
+async def test_placeholder_strategy_is_rejected_before_broker_post(
+    placeholder, monkeypatch
+):
+    """The one attribution gate blocks every placeholder without a POST."""
+    calls: list[str] = []
+
+    async def broker_post(**kwargs):
+        calls.append("POST")
+        raise AssertionError("placeholder strategy reached the broker")
+
+    monkeypatch.setattr(order_execution, "_execute_order", broker_post)
+    result = await order_execution._execute_and_record(
+        **_execute_and_record_kwargs(strategy=placeholder)
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "placeholder_strategy"
+    assert calls == []
+
+
+async def test_valid_strategy_reaches_broker_positive_control(monkeypatch, db_session):
+    calls: list[str] = []
+
+    async def broker_post(**kwargs):
+        calls.append("POST")
+        return {"rt_cd": "0", "odno": "MOCK-POSITIVE"}
+
+    monkeypatch.setattr(order_execution, "_execute_order", broker_post)
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_fetch_kis_mock_baseline_qty",
+        AsyncMock(return_value=Decimal("0")),
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
+
+    result = await order_execution._execute_and_record(
+        **_execute_and_record_kwargs(strategy="posture-v1")
+    )
+
+    assert result["success"] is True
+    assert calls == ["POST"]
+
+
+async def test_placeholder_cannot_be_rescued_by_mirror_lane():
+    with pytest.raises(InvalidStrategy):
+        resolve_attribution(
+            symbol="005930",
+            side="buy",
+            price=70000,
+            quantity=1,
+            strategy=" null ",
+            mirror_cohort="mock_counterfactual",
+        )
 
 
 async def test_resolver_derives_the_mirror_lane_without_an_explicit_strategy():

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1175,49 +1175,37 @@ def _mock_preview() -> dict:
 
 
 @pytest.mark.asyncio
-async def test_record_mints_correlation_id_and_publishes_forecast(monkeypatch):
-    """ROB-730: the tool path passes no correlation_id, so the mock record path
-    mints a deterministic namespaced id, stores it on the ledger row, and emits a
-    place-time forecast for an accepted buy with a target — mirroring kis_live."""
+async def test_record_rejects_missing_strategy_without_writing(monkeypatch):
+    """The post-send writer cannot manufacture attribution for direct callers."""
     from app.mcp_server.tooling import kis_mock_ledger
+    from app.services.kis_mock_attribution import InvalidStrategy
 
     save = AsyncMock(return_value=5)
     monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
     pub = AsyncMock(return_value="fc-1")
     monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
 
-    result = await kis_mock_ledger._record_kis_mock_order(
-        normalized_symbol="005930",
-        market_type="equity_kr",
-        side="buy",
-        order_type="limit",
-        dry_run_result=_mock_preview(),
-        execution_result=_mock_exec_result(),
-        reason="t",
-        thesis=None,
-        strategy=None,
-        notes=None,
-        target_price=80000.0,
-        min_hold_days=5,
-    )
-
-    cid = result["correlation_id"]
-    assert cid is not None
-    assert cid.startswith("live:kis_mock:")
-    # stored on the ledger row
-    assert save.await_args.kwargs["correlation_id"] == cid
-    # forecast published for the accepted buy, tagged for mock provenance
-    pub.assert_awaited_once()
-    assert pub.await_args.kwargs["correlation_id"] == cid
-    assert pub.await_args.kwargs["session_label"] == "kis_mock_place"
-    assert pub.await_args.kwargs["created_by"] == "auto_place_mock"
-    assert pub.await_args.kwargs["target_price"] == 80000.0
+    with pytest.raises(InvalidStrategy):
+        await kis_mock_ledger._record_kis_mock_order(
+            normalized_symbol="005930",
+            market_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            dry_run_result=_mock_preview(),
+            execution_result=_mock_exec_result(),
+            reason="t",
+            thesis=None,
+            strategy=None,
+            notes=None,
+            correlation_id="pre-submit-cid",
+        )
+    save.assert_not_awaited()
+    pub.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_record_preserves_explicit_correlation_id(monkeypatch):
-    """ROB-730: an explicit correlation_id (ROB-402 scalping entry/exit pairing)
-    must be preserved, never overwritten by a freshly minted one."""
+    """A direct helper call must provide the pre-submit correlation id."""
     from app.mcp_server.tooling import kis_mock_ledger
 
     save = AsyncMock(return_value=5)
@@ -1225,23 +1213,21 @@ async def test_record_preserves_explicit_correlation_id(monkeypatch):
     pub = AsyncMock(return_value="fc-1")
     monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
 
-    result = await kis_mock_ledger._record_kis_mock_order(
-        normalized_symbol="005930",
-        market_type="equity_kr",
-        side="buy",
-        order_type="limit",
-        dry_run_result=_mock_preview(),
-        execution_result=_mock_exec_result(),
-        reason="t",
-        thesis=None,
-        strategy=None,
-        notes=None,
-        correlation_id="scalp-pair-1",
-    )
-
-    assert result["correlation_id"] == "scalp-pair-1"
-    assert save.await_args.kwargs["correlation_id"] == "scalp-pair-1"
-    assert pub.await_args.kwargs["correlation_id"] == "scalp-pair-1"
+    with pytest.raises(ValueError, match="pre-submit correlation_id"):
+        await kis_mock_ledger._record_kis_mock_order(
+            normalized_symbol="005930",
+            market_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            dry_run_result=_mock_preview(),
+            execution_result=_mock_exec_result(),
+            reason="t",
+            thesis=None,
+            strategy="posture-v1",
+            notes=None,
+        )
+    save.assert_not_awaited()
+    pub.assert_not_awaited()
 
 
 def _make_domestic_orders():
@@ -1309,8 +1295,9 @@ async def test_record_accepts_real_domestic_order_shape(monkeypatch):
         execution_result=exec_result,
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-accepted-1",
     )
     assert result["success"] is True
     assert result["status"] == "accepted"
@@ -1337,8 +1324,9 @@ async def test_record_accepted_returns_success_true(monkeypatch):
         execution_result=_mock_exec_result(rt_cd="0", odno="0001234567"),
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-accepted-2",
     )
     assert result["success"] is True
     assert result["status"] == "accepted"
@@ -1365,8 +1353,9 @@ async def test_record_rejected_returns_success_false(monkeypatch):
         execution_result=exec_result,
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-rejected-1",
     )
     assert result["success"] is False
     assert result["status"] == "rejected"
@@ -1395,8 +1384,9 @@ async def test_record_idless_success_code_returns_unknown_false(monkeypatch):
         execution_result={"rt_cd": "0", "odno": ""},
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-unknown-1",
         target_price=80000.0,
     )
     assert result["success"] is False
@@ -1425,8 +1415,9 @@ async def test_record_malformed_payload_returns_false(monkeypatch):
         execution_result="totally not a dict",  # type: ignore[arg-type]
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-malformed-1",
     )
     assert result["success"] is False
     assert result["status"] == "unknown"
@@ -1454,8 +1445,9 @@ async def test_record_whitespace_order_id_is_not_accepted(monkeypatch):
         execution_result={"rt_cd": "0", "odno": "   "},
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-unknown-2",
     )
     assert result["success"] is False
     assert result["status"] == "unknown"
@@ -1483,8 +1475,9 @@ async def test_record_strips_valid_order_id(monkeypatch):
         execution_result={"rt_cd": "0", "odno": "  0001234567  "},
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-accepted-5",
     )
     assert result["success"] is True
     assert result["order_no"] == "0001234567"
@@ -1512,8 +1505,9 @@ async def test_record_provider_failure_with_order_id_still_rejected(monkeypatch)
         execution_result={"rt_cd": "40", "odno": "0001234567", "msg": "거부"},
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-rejected-4",
     )
     assert result["success"] is False
     assert result["status"] == "rejected"
@@ -1553,8 +1547,9 @@ async def test_record_redacts_sensitive_evidence(monkeypatch):
         execution_result=exec_result,
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-accepted-6",
     )
     saved = save.await_args.kwargs["raw_response"]
     assert saved["AppKey"] == "[REDACTED]"
@@ -1595,7 +1590,7 @@ async def _record_accepted(monkeypatch, **over):
         "execution_result": {"rt_cd": "0", "odno": "0001234567"},
         "reason": "t",
         "thesis": None,
-        "strategy": None,
+        "strategy": "posture-v1",
         "notes": None,
         "correlation_id": "cid-x",
     }
@@ -1663,8 +1658,9 @@ async def test_record_rejected_order_mints_but_does_not_publish(monkeypatch):
         execution_result=_mock_exec_result(rt_cd="40", odno=""),
         reason="t",
         thesis=None,
-        strategy=None,
+        strategy="posture-v1",
         notes=None,
+        correlation_id="direct-record-rejected-5",
         target_price=80000.0,
     )
 


### PR DESCRIPTION
## Summary
- reject blank/placeholder kis_mock strategy values at the central pre-submit attribution gate
- normalize case, Unicode NFKC/fullwidth, common homoglyphs, whitespace, and zero-width controls for denylist comparison
- remove `_record_kis_mock_order` post-send correlation-id mint fallback; require pre-submit strategy and correlation id

## Verification
- `make lint`
- `make test` — 17805 passed, 10 skipped, 7 deselected
- targeted attribution/ledger tests — 75 passed
- entrypoint regression tests — 102 passed

No migration, broker call, order, or operational DB access was performed.