### PR TITLE
feat(research): add Kiwoom mock/live dual-surface backfill pipe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -399,6 +399,42 @@ jobs:
     - name: Run intraday harness v2 freeze and execution tests
       run: uv run pytest research/intraday_harness_v2/tests/ -v -ra --strict-markers
 
+  kiwoom-dual-surface-smoke:
+    # This is an orchestration smoke only: synthetic clients/pool are injected
+    # by the test, so it performs zero broker HTTP, account access, or DB write.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      PYTHON_VERSION: "3.13"
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install UV
+      run: pip install uv
+
+    - name: Load cached venv
+      id: cached-uv-dependencies
+      uses: actions/cache@v5
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}
+
+    - name: Install dependencies
+      run: uv sync --group test
+
+    - name: Run Kiwoom dual-surface synthetic orchestration smoke
+      run: uv run pytest tests/test_kiwoom_dual_surface.py -k 'dual_orchestrator' -v -ra --strict-markers
+
   alpaca-track-walkforward-tests:
     # ROB-1062 H4 remains a separate gate from the consolidated H1/H2/H3 job:
     # it has its own conftest.py sys.path wiring onto its three

--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -34,17 +34,65 @@ from pathlib import Path
 from typing import Any
 
 import asyncpg
-from sources import (  # noqa: E402
-    KST,
-    FetchWindowClosed,
-    Pacer,
-    assert_fetch_window_open,
-    fetch_kis_minutes,
-    fetch_kiwoom_minutes,
-    fetch_toss_minutes,
-    in_regular_session,
-    now_kst,
-)
+
+try:
+    from .dual_surface import (
+        BACKOFF_PACE_SECONDS,
+        KiwoomSurfaceClient,
+        OverlapMismatch,
+        SurfaceAuthError,
+        SurfaceBackoffExhausted,
+        SurfaceContractError,
+        SurfaceManifest,
+        SurfacePacer,
+        assignment_sha256,
+        compare_overlap_exact,
+        http_status_from_exception,
+        read_assignment_csv,
+        validate_surface,
+        write_surface_manifest,
+    )
+except ImportError:  # pragma: no cover - direct CLI execution
+    from dual_surface import (
+        BACKOFF_PACE_SECONDS,
+        KiwoomSurfaceClient,
+        OverlapMismatch,
+        SurfaceAuthError,
+        SurfaceBackoffExhausted,
+        SurfaceContractError,
+        SurfaceManifest,
+        SurfacePacer,
+        assignment_sha256,
+        compare_overlap_exact,
+        http_status_from_exception,
+        read_assignment_csv,
+        validate_surface,
+        write_surface_manifest,
+    )
+try:
+    from .sources import (  # noqa: E402
+        KST,
+        FetchWindowClosed,
+        Pacer,
+        assert_fetch_window_open,
+        fetch_kis_minutes,
+        fetch_kiwoom_minutes,
+        fetch_toss_minutes,
+        in_regular_session,
+        now_kst,
+    )
+except ImportError:  # pragma: no cover - direct CLI execution
+    from sources import (  # noqa: E402
+        KST,
+        FetchWindowClosed,
+        Pacer,
+        assert_fetch_window_open,
+        fetch_kis_minutes,
+        fetch_kiwoom_minutes,
+        fetch_toss_minutes,
+        in_regular_session,
+        now_kst,
+    )
 
 VENUE = "KRX"
 
@@ -76,6 +124,19 @@ MAX_CONSECUTIVE_429 = 3
 @dataclass
 class StreamStats:
     source: str
+    symbols_total: int = 0
+    symbols_done: int = 0
+    calls: int = 0
+    rows_fetched: int = 0
+    rows_inserted: int = 0
+    rows_skipped_conflict: int = 0
+    errors: list[str] = field(default_factory=list)
+    stopped_reason: str | None = None
+
+
+@dataclass
+class SurfaceStats:
+    surface: str
     symbols_total: int = 0
     symbols_done: int = 0
     calls: int = 0
@@ -386,6 +447,432 @@ async def run_stream(
     return stats
 
 
+class OverlapVerifier:
+    """Run the deliberate two-surface sample at a fixed batch cadence."""
+
+    def __init__(
+        self,
+        *,
+        symbols: tuple[str, ...],
+        session_date: date,
+        clients: dict[str, KiwoomSurfaceClient],
+        pacers: dict[str, SurfacePacer],
+        log: ProgressLog,
+        stop_event: asyncio.Event,
+        every_batches: int = 50,
+    ) -> None:
+        if not symbols:
+            raise SurfaceContractError("dual-surface run requires overlap symbols")
+        if len(symbols) > 2:
+            raise SurfaceContractError("overlap sample is capped at two symbols")
+        if every_batches <= 0:
+            raise SurfaceContractError("overlap cadence must be positive")
+        self.symbols = symbols
+        self.session_date = session_date
+        self.clients = clients
+        self.pacers = pacers
+        self.log = log
+        self.stop_event = stop_event
+        self.every_batches = every_batches
+        self.completed_batches = 0
+        self._last_verified_batch = 0
+        self._lock = asyncio.Lock()
+
+    async def after_batch(self) -> None:
+        async with self._lock:
+            self.completed_batches += 1
+            if self.completed_batches % self.every_batches:
+                return
+            if self._last_verified_batch == self.completed_batches:
+                return
+            self._last_verified_batch = self.completed_batches
+            try:
+                evidence = []
+                for symbol in self.symbols:
+                    data: dict[str, dict] = {}
+                    for surface in ("mock", "live"):
+                        try:
+                            rows, _meta = await fetch_kiwoom_minutes(
+                                client=self.clients[surface],
+                                symbol=symbol,
+                                pacer=self.pacers[surface],
+                                max_pages=1,
+                                base_dt=self.session_date.strftime("%Y%m%d"),
+                            )
+                            self.pacers[surface].note_status(None)
+                        except Exception as exc:  # noqa: BLE001
+                            self.pacers[surface].note_exception(exc)
+                            raise
+                        data[surface] = {
+                            timestamp: values
+                            for timestamp, values in rows.items()
+                            if in_regular_session(timestamp)
+                        }
+                    evidence.append(
+                        compare_overlap_exact(symbol, data["mock"], data["live"])
+                    )
+            except Exception:
+                self.stop_event.set()
+                raise
+            self.log.write(
+                {
+                    "event": "overlap_check",
+                    "surface": "mock+live",
+                    "batch_number": self.completed_batches,
+                    "symbols": list(self.symbols),
+                    "evidence": evidence,
+                    "comparison": "exact integer equality including value",
+                    "mismatch_action": "stop_and_report",
+                }
+            )
+
+
+async def run_surface(
+    surface: str,
+    symbols: list[str],
+    client: KiwoomSurfaceClient,
+    pool: asyncpg.Pool,
+    ckpt: Checkpoint,
+    log: ProgressLog,
+    start_date: date,
+    end_date: date,
+    batch_id: str,
+    *,
+    overlap: OverlapVerifier,
+    stop_event: asyncio.Event,
+) -> SurfaceStats:
+    """Collect one immutable symbol partition for one Kiwoom surface."""
+
+    surface = validate_surface(surface)
+    stats = SurfaceStats(surface=surface, symbols_total=len(symbols))
+    pacer = overlap.pacers[surface]
+    start_dt = datetime.combine(start_date, datetime.min.time())
+
+    for symbol in symbols:
+        if stop_event.is_set():
+            stats.stopped_reason = "peer_surface_stopped"
+            return stats
+        state = ckpt.get(symbol)
+        if state.get("done"):
+            stats.symbols_done += 1
+            continue
+        cursor_dt = (
+            datetime.fromisoformat(state["oldest_reached"])
+            if state.get("oldest_reached")
+            else datetime.combine(end_date, datetime.max.time().replace(microsecond=0))
+        )
+        try:
+            while cursor_dt > start_dt:
+                if stop_event.is_set():
+                    stats.stopped_reason = "peer_surface_stopped"
+                    return stats
+                try:
+                    assert_fetch_window_open()
+                except FetchWindowClosed as exc:
+                    stats.stopped_reason = f"market_hours_freeze: {exc}"
+                    log.write(
+                        {
+                            "event": "paused_market_hours",
+                            "surface": surface,
+                            "symbol": symbol,
+                            "cursor": cursor_dt,
+                        }
+                    )
+                    ckpt.save()
+                    return stats
+
+                try:
+                    rows, meta = await fetch_kiwoom_minutes(
+                        client=client,
+                        symbol=symbol,
+                        pacer=pacer,
+                        max_pages=1,
+                        base_dt=cursor_dt.strftime("%Y%m%d"),
+                    )
+                    pacer.note_status(None)
+                except Exception as exc:  # noqa: BLE001
+                    status = http_status_from_exception(exc)
+                    try:
+                        pacer.note_exception(exc)
+                    except (SurfaceAuthError, SurfaceBackoffExhausted) as fatal:
+                        stop_event.set()
+                        stats.stopped_reason = str(fatal)
+                        log.write(
+                            {
+                                "event": "abort",
+                                "surface": surface,
+                                "symbol": symbol,
+                                "reason": str(fatal),
+                                "http_status": status,
+                            }
+                        )
+                        return stats
+                    if status == 429:
+                        # Retry this same page after the surface-local pacing
+                        # interval.  A peer surface has its own pacer/event
+                        # state and continues independently.
+                        log.write(
+                            {
+                                "event": "backoff",
+                                "surface": surface,
+                                "symbol": symbol,
+                                "http_status": 429,
+                                "interval_seconds": pacer.interval,
+                                "backoff_level": pacer.backoff_level,
+                                "auto_recovery": False,
+                            }
+                        )
+                        continue
+                    stats.errors.append(f"{symbol}: {type(exc).__name__}: {exc}")
+                    log.write(
+                        {
+                            "event": "fetch_error",
+                            "surface": surface,
+                            "symbol": symbol,
+                            "error": f"{type(exc).__name__}: {exc}",
+                        }
+                    )
+                    break
+
+                stats.calls = pacer.calls
+                if not rows:
+                    state["done"] = True
+                    break
+
+                oldest = min(rows)
+                keep = {
+                    timestamp: values
+                    for timestamp, values in rows.items()
+                    if in_regular_session(timestamp)
+                    and start_dt
+                    <= timestamp
+                    <= datetime.combine(end_date, datetime.max.time())
+                }
+                stats.rows_fetched += len(rows)
+                inserted, skipped = await insert_bars(
+                    pool,
+                    symbol,
+                    keep,
+                    source="kiwoom",
+                    batch_id=batch_id,
+                )
+                stats.rows_inserted += inserted
+                stats.rows_skipped_conflict += skipped
+                state["rows_inserted"] = state.get("rows_inserted", 0) + inserted
+                state["rows_skipped"] = state.get("rows_skipped", 0) + skipped
+                log.write(
+                    {
+                        "event": "page",
+                        "surface": surface,
+                        "symbol": symbol,
+                        "range": [oldest.isoformat(), max(rows).isoformat()],
+                        "rows_fetched": len(rows),
+                        "rows_kept": len(keep),
+                        "rows_inserted": inserted,
+                        "rows_skipped_conflict": skipped,
+                        "calls_cumulative": pacer.calls,
+                        "batch_id": batch_id,
+                    }
+                )
+                if oldest >= cursor_dt:
+                    state["done"] = True
+                    break
+                cursor_dt = oldest - timedelta(minutes=1)
+                state["oldest_reached"] = cursor_dt.isoformat()
+                ckpt.save()
+                await overlap.after_batch()
+            else:
+                state["done"] = True
+        except (OverlapMismatch, SurfaceAuthError, SurfaceBackoffExhausted) as exc:
+            stop_event.set()
+            stats.stopped_reason = str(exc)
+            log.write({"event": "abort", "surface": surface, "reason": str(exc)})
+            ckpt.save()
+            return stats
+
+        if state.get("done"):
+            stats.symbols_done += 1
+        ckpt.save()
+    return stats
+
+
+def _load_env_file(path: Path, allowed_keys: set[str]) -> None:
+    """Load only surface keys; never print values or import a full env file."""
+
+    if not path.is_file():
+        raise FileNotFoundError(f"surface env file not found: {path}")
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key not in allowed_keys:
+            continue
+        value = value.strip().strip('"').strip("'")
+        os.environ[key] = value
+
+
+def _prepare_surface_env(mock_env_file: Path | None, live_env_file: Path) -> None:
+    if mock_env_file is not None:
+        _load_env_file(
+            mock_env_file,
+            {
+                "KIWOOM_MOCK_ENABLED",
+                "KIWOOM_MOCK_APP_KEY",
+                "KIWOOM_MOCK_APP_SECRET",
+                "KIWOOM_MOCK_ACCOUNT_NO",
+                "KIWOOM_MOCK_BASE_URL",
+            },
+        )
+    _load_env_file(
+        live_env_file,
+        {
+            "KIWOOM_LIVE_MARKETDATA_ENABLED",
+            "KIWOOM_LIVE_APP_KEY",
+            "KIWOOM_LIVE_APP_SECRET",
+            "KIWOOM_LIVE_BASE_URL",
+        },
+    )
+    # pydantic-settings reads this file for non-secret defaults.  The explicit
+    # environment values above win over dotenv values, and the path itself is
+    # recorded only as an operator input, never with credential contents.
+    os.environ["ENV_FILE"] = str(live_env_file)
+
+
+async def _run_dual_surface(args: argparse.Namespace) -> int:
+    rows = read_assignment_csv(args.split_csv)
+    by_surface: dict[str, list[str]] = {"mock": [], "live": []}
+    overlap_symbols: list[str] = []
+    by_symbol: dict[str, list[str]] = {}
+    for row in rows:
+        symbol = row["ticker"].strip()
+        surface = validate_surface(row["surface"].strip())
+        kind = row.get("assignment_kind", "bulk").strip() or "bulk"
+        by_symbol.setdefault(symbol, []).append(surface)
+        if kind == "bulk":
+            by_surface[surface].append(symbol)
+        elif symbol not in overlap_symbols:
+            overlap_symbols.append(symbol)
+    if not overlap_symbols:
+        raise SurfaceContractError(
+            "surface split has no explicit overlap sample; generate the artifact "
+            "with at least one assignment_kind=overlap symbol"
+        )
+
+    selected = [args.surface] if args.surface else ["mock", "live"]
+    for surface in selected:
+        validate_surface(surface)
+    if args.limit_symbols is not None:
+        by_surface = {
+            surface: values[: args.limit_symbols]
+            for surface, values in by_surface.items()
+        }
+
+    batch_id = f"kiwoom-dual-{now_kst():%Y%m%dT%H%M%S}"
+    job_events = args.job_dir / "events"
+    manifest = SurfaceManifest(
+        batch_id=batch_id,
+        assignment_path=str(args.split_csv),
+        assignment_sha256=assignment_sha256(args.split_csv),
+    )
+    manifest_path = job_events / "kiwoom_dual_surface_manifest.json"
+    write_surface_manifest(manifest_path, manifest)
+    summary = {
+        "status": "DRY_RUN_NO_WRITE" if not args.confirm_write else "READY_TO_RUN",
+        "batch_id": batch_id,
+        "assignment_path": str(args.split_csv),
+        "assignment_sha256": manifest.assignment_sha256,
+        "symbols_per_surface": {
+            surface: len(by_surface[surface]) for surface in selected
+        },
+        "overlap_symbols": overlap_symbols[:2],
+        "manifest_path": str(manifest_path),
+        "backoff_intervals": {
+            "mock": [2.0, *BACKOFF_PACE_SECONDS],
+            "live": [0.5, *BACKOFF_PACE_SECONDS],
+        },
+        "auto_recovery": False,
+    }
+    if not args.confirm_write:
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
+        return 0
+
+    # This is the only branch that creates clients.  No client is built by the
+    # dry-run path, so a planning invocation cannot accidentally call a host.
+    _prepare_surface_env(args.mock_env_file, args.live_env_file)
+    from app.services.brokers.kiwoom.client import KiwoomMockClient
+    from app.services.brokers.kiwoom.live_market_data import KiwoomLiveReadOnlyClient
+
+    raw_clients: dict[str, Any] = {
+        "mock": KiwoomMockClient.from_app_settings(),
+        "live": KiwoomLiveReadOnlyClient.from_app_settings(),
+    }
+    clients = {
+        surface: KiwoomSurfaceClient(surface, raw_clients[surface])
+        for surface in selected
+    }
+    pacers = {surface: SurfacePacer(surface) for surface in selected}
+    stop_event = asyncio.Event()
+    overlap = OverlapVerifier(
+        symbols=tuple(overlap_symbols[:2]),
+        session_date=date.fromisoformat(args.end_date),
+        clients={
+            surface: KiwoomSurfaceClient(surface, raw_clients[surface])
+            for surface in ("mock", "live")
+        },
+        pacers={surface: SurfacePacer(surface) for surface in ("mock", "live")},
+        log=ProgressLog(job_events / "progress.jsonl"),
+        stop_event=stop_event,
+    )
+    # Use the same pacers for bulk and overlap calls; every call is accounted
+    # against that surface's budget.
+    overlap.pacers.update(pacers)
+    pool = await asyncpg.create_pool(dsn(), min_size=2, max_size=6)
+    log = overlap.log
+    try:
+        results = await asyncio.gather(
+            *[
+                run_surface(
+                    surface,
+                    by_surface[surface],
+                    clients[surface],
+                    pool,
+                    Checkpoint(job_events / f"checkpoint_{surface}.json"),
+                    log,
+                    date.fromisoformat(args.start_date),
+                    date.fromisoformat(args.end_date),
+                    batch_id,
+                    overlap=overlap,
+                    stop_event=stop_event,
+                )
+                for surface in selected
+            ]
+        )
+    finally:
+        await pool.close()
+        for raw_client in raw_clients.values():
+            close = getattr(raw_client, "aclose", None) or getattr(
+                raw_client, "close", None
+            )
+            if close:
+                result = close()
+                if asyncio.iscoroutine(result):
+                    await result
+        log.close()
+    summary["status"] = "COMPLETE"
+    summary["results"] = [result.__dict__ for result in results]
+    summary["calls_by_surface"] = {
+        surface: pacers[surface].calls for surface in selected
+    }
+    (job_events / "stage_b_dual_surface_summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False, default=str) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False, default=str))
+    return 0
+
+
 async def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--split-csv", required=True, type=Path)
@@ -393,6 +880,26 @@ async def main() -> int:
     ap.add_argument("--start-date", required=True)
     ap.add_argument("--end-date", required=True)
     ap.add_argument("--sources", default="toss,kiwoom,kis")
+    ap.add_argument(
+        "--surface",
+        choices=("mock", "live"),
+        default=None,
+        help="run one pre-assigned Kiwoom surface; a surface CSV selects dual mode",
+    )
+    ap.add_argument(
+        "--live-env-file",
+        type=Path,
+        default=Path(
+            "/Users/mgh3326/services/auto_trader/shared/.env.kiwoom-readonly.native"
+        ),
+        help="native four-key live read-only env file",
+    )
+    ap.add_argument(
+        "--mock-env-file",
+        type=Path,
+        default=None,
+        help="optional env file containing mock gate and credentials",
+    )
     ap.add_argument("--baseline-median-ms", type=float, default=2.127)
     ap.add_argument("--limit-symbols", type=int, default=None)
     ap.add_argument(
@@ -404,6 +911,18 @@ async def main() -> int:
 
     start_date = date.fromisoformat(args.start_date)
     end_date = date.fromisoformat(args.end_date)
+
+    # The generated dual artifact is self-describing.  Its `surface` column is
+    # the switch that prevents the old three-source loader from silently
+    # treating a mock/live split as a generic source split.
+    with args.split_csv.open(newline="", encoding="utf-8") as split_fh:
+        split_fields = set(csv.DictReader(split_fh).fieldnames or ())
+    if "surface" in split_fields:
+        return await _run_dual_surface(args)
+    if args.surface is not None:
+        raise SurfaceContractError(
+            "--surface requires a dual Kiwoom split CSV with a surface column"
+        )
     wanted = [s.strip() for s in args.sources.split(",") if s.strip()]
 
     assignment: dict[str, list[str]] = {s: [] for s in wanted}

--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -742,6 +742,9 @@ def _reject_production_env_file(path: Path) -> None:
 def _prepare_surface_env(
     selected: tuple[str, ...], mock_env_file: Path | None, live_env_file: Path
 ) -> None:
+    ambient_env_file = os.environ.get("ENV_FILE", "")
+    if ambient_env_file:
+        _reject_production_env_file(Path(ambient_env_file))
     if "mock" in selected and mock_env_file is not None:
         _reject_production_env_file(mock_env_file)
         _load_env_file(
@@ -851,31 +854,35 @@ async def _run_dual_surface(args: argparse.Namespace) -> int:
     # This is the only branch that creates clients.  No client is built by the
     # dry-run path, so a planning invocation cannot accidentally call a host.
     selected_tuple = tuple(selected)
-    _prepare_surface_env(selected_tuple, args.mock_env_file, args.live_env_file)
-    from app.services.brokers.kiwoom.client import KiwoomMockClient
-    from app.services.brokers.kiwoom.live_market_data import KiwoomLiveReadOnlyClient
-
-    raw_clients, clients, pacers = _build_surface_runtime(
-        selected_tuple,
-        mock_factory=KiwoomMockClient.from_app_settings,
-        live_factory=KiwoomLiveReadOnlyClient.from_app_settings,
-    )
-    stop_events = {surface: asyncio.Event() for surface in selected}
-    pool = await asyncpg.create_pool(dsn(), min_size=2, max_size=6)
-    log = ProgressLog(job_events / "progress.jsonl")
-    guard = Guard(pool, args.baseline_median_ms, log)
-    await guard.snapshot_witness()
-    overlap = None
-    if len(selected) == 2:
-        overlap = OverlapVerifier(
-            symbols=tuple(overlap_symbols[:2]),
-            session_date=date.fromisoformat(args.end_date),
-            clients=clients,
-            pacers=pacers,
-            log=log,
-            stop_events=stop_events,
-        )
+    raw_clients: dict[str, Any] = {}
+    pool: asyncpg.Pool | None = None
+    log: ProgressLog | None = None
     try:
+        _prepare_surface_env(selected_tuple, args.mock_env_file, args.live_env_file)
+        from app.services.brokers.kiwoom.client import KiwoomMockClient
+        from app.services.brokers.kiwoom.live_market_data import (
+            KiwoomLiveReadOnlyClient,
+        )
+
+        raw_clients, clients, pacers = _build_surface_runtime(
+            selected_tuple,
+            mock_factory=KiwoomMockClient.from_app_settings,
+            live_factory=KiwoomLiveReadOnlyClient.from_app_settings,
+        )
+        stop_events = {surface: asyncio.Event() for surface in selected}
+        pool = await asyncpg.create_pool(dsn(), min_size=2, max_size=6)
+        log = ProgressLog(job_events / "progress.jsonl")
+        guard = Guard(pool, args.baseline_median_ms, log)
+        overlap = None
+        if len(selected) == 2:
+            overlap = OverlapVerifier(
+                symbols=tuple(overlap_symbols[:2]),
+                session_date=date.fromisoformat(args.end_date),
+                clients=clients,
+                pacers=pacers,
+                log=log,
+                stop_events=stop_events,
+            )
         results = await asyncio.gather(
             *[
                 run_surface(
@@ -897,7 +904,8 @@ async def _run_dual_surface(args: argparse.Namespace) -> int:
             ]
         )
     finally:
-        await pool.close()
+        if pool is not None:
+            await pool.close()
         for raw_client in raw_clients.values():
             close = getattr(raw_client, "aclose", None) or getattr(
                 raw_client, "close", None
@@ -906,7 +914,8 @@ async def _run_dual_surface(args: argparse.Namespace) -> int:
                 result = close()
                 if asyncio.iscoroutine(result):
                     await result
-        log.close()
+        if log is not None:
+            log.close()
     summary["status"] = "COMPLETE"
     summary["results"] = [result.__dict__ for result in results]
     summary["calls_by_surface"] = {

--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -16,7 +16,11 @@ Write discipline (all enforced here, not by convention):
 
 Abort conditions (stop the stream, report, do not "work around"):
 conflict ratio far from expectation · query latency regression vs baseline ·
-repeated 429s.
+repeated 429s · any change to a witness table outside kr_candles_1m.
+
+The dual Kiwoom surfaces use these same guards; an abort is isolated to the
+failing surface. An overlap mismatch stops both participating surfaces because
+it invalidates the comparison itself.
 """
 
 from __future__ import annotations
@@ -458,7 +462,7 @@ class OverlapVerifier:
         clients: dict[str, KiwoomSurfaceClient],
         pacers: dict[str, SurfacePacer],
         log: ProgressLog,
-        stop_event: asyncio.Event,
+        stop_events: dict[str, asyncio.Event],
         every_batches: int = 50,
     ) -> None:
         if not symbols:
@@ -472,7 +476,7 @@ class OverlapVerifier:
         self.clients = clients
         self.pacers = pacers
         self.log = log
-        self.stop_event = stop_event
+        self.stop_events = stop_events
         self.every_batches = every_batches
         self.completed_batches = 0
         self._last_verified_batch = 0
@@ -512,7 +516,8 @@ class OverlapVerifier:
                         compare_overlap_exact(symbol, data["mock"], data["live"])
                     )
             except Exception:
-                self.stop_event.set()
+                for event in self.stop_events.values():
+                    event.set()
                 raise
             self.log.write(
                 {
@@ -538,19 +543,20 @@ async def run_surface(
     end_date: date,
     batch_id: str,
     *,
-    overlap: OverlapVerifier,
+    pacer: SurfacePacer,
+    overlap: OverlapVerifier | None,
     stop_event: asyncio.Event,
+    guard: Guard | None = None,
 ) -> SurfaceStats:
     """Collect one immutable symbol partition for one Kiwoom surface."""
 
     surface = validate_surface(surface)
     stats = SurfaceStats(surface=surface, symbols_total=len(symbols))
-    pacer = overlap.pacers[surface]
     start_dt = datetime.combine(start_date, datetime.min.time())
 
     for symbol in symbols:
         if stop_event.is_set():
-            stats.stopped_reason = "peer_surface_stopped"
+            stats.stopped_reason = "surface_stopped"
             return stats
         state = ckpt.get(symbol)
         if state.get("done"):
@@ -564,7 +570,7 @@ async def run_surface(
         try:
             while cursor_dt > start_dt:
                 if stop_event.is_set():
-                    stats.stopped_reason = "peer_surface_stopped"
+                    stats.stopped_reason = "surface_stopped"
                     return stats
                 try:
                     assert_fetch_window_open()
@@ -680,10 +686,16 @@ async def run_surface(
                 cursor_dt = oldest - timedelta(minutes=1)
                 state["oldest_reached"] = cursor_dt.isoformat()
                 ckpt.save()
-                await overlap.after_batch()
+                if overlap is not None:
+                    await overlap.after_batch()
             else:
                 state["done"] = True
-        except (OverlapMismatch, SurfaceAuthError, SurfaceBackoffExhausted) as exc:
+        except (
+            AbortStream,
+            OverlapMismatch,
+            SurfaceAuthError,
+            SurfaceBackoffExhausted,
+        ) as exc:
             stop_event.set()
             stats.stopped_reason = str(exc)
             log.write({"event": "abort", "surface": surface, "reason": str(exc)})
@@ -693,6 +705,15 @@ async def run_surface(
         if state.get("done"):
             stats.symbols_done += 1
         ckpt.save()
+        if guard is not None:
+            try:
+                await guard.check(surface)
+            except AbortStream as exc:
+                stop_event.set()
+                stats.stopped_reason = str(exc)
+                log.write({"event": "abort", "surface": surface, "reason": str(exc)})
+                ckpt.save()
+                return stats
     return stats
 
 
@@ -713,8 +734,16 @@ def _load_env_file(path: Path, allowed_keys: set[str]) -> None:
         os.environ[key] = value
 
 
-def _prepare_surface_env(mock_env_file: Path | None, live_env_file: Path) -> None:
-    if mock_env_file is not None:
+def _reject_production_env_file(path: Path) -> None:
+    if "prod" in str(path).lower():
+        raise SurfaceContractError(f"refusing to read a production env file: {path}")
+
+
+def _prepare_surface_env(
+    selected: tuple[str, ...], mock_env_file: Path | None, live_env_file: Path
+) -> None:
+    if "mock" in selected and mock_env_file is not None:
+        _reject_production_env_file(mock_env_file)
         _load_env_file(
             mock_env_file,
             {
@@ -725,19 +754,42 @@ def _prepare_surface_env(mock_env_file: Path | None, live_env_file: Path) -> Non
                 "KIWOOM_MOCK_BASE_URL",
             },
         )
-    _load_env_file(
-        live_env_file,
-        {
-            "KIWOOM_LIVE_MARKETDATA_ENABLED",
-            "KIWOOM_LIVE_APP_KEY",
-            "KIWOOM_LIVE_APP_SECRET",
-            "KIWOOM_LIVE_BASE_URL",
-        },
-    )
+    if "live" in selected:
+        _reject_production_env_file(live_env_file)
+        _load_env_file(
+            live_env_file,
+            {
+                "KIWOOM_LIVE_MARKETDATA_ENABLED",
+                "KIWOOM_LIVE_APP_KEY",
+                "KIWOOM_LIVE_APP_SECRET",
+                "KIWOOM_LIVE_BASE_URL",
+            },
+        )
     # pydantic-settings reads this file for non-secret defaults.  The explicit
     # environment values above win over dotenv values, and the path itself is
     # recorded only as an operator input, never with credential contents.
-    os.environ["ENV_FILE"] = str(live_env_file)
+    if selected == ("mock",) and mock_env_file is not None:
+        os.environ["ENV_FILE"] = str(mock_env_file)
+    elif "live" in selected:
+        os.environ["ENV_FILE"] = str(live_env_file)
+
+
+def _build_surface_runtime(
+    selected: tuple[str, ...],
+    *,
+    mock_factory: Any,
+    live_factory: Any,
+) -> tuple[dict[str, Any], dict[str, KiwoomSurfaceClient], dict[str, SurfacePacer]]:
+    """Build only selected clients and the exact pacers used by the run."""
+
+    factories = {"mock": mock_factory, "live": live_factory}
+    raw_clients = {surface: factories[surface]() for surface in selected}
+    clients = {
+        surface: KiwoomSurfaceClient(surface, raw_clients[surface])
+        for surface in selected
+    }
+    pacers = {surface: SurfacePacer(surface) for surface in selected}
+    return raw_clients, clients, pacers
 
 
 async def _run_dual_surface(args: argparse.Namespace) -> int:
@@ -754,15 +806,13 @@ async def _run_dual_surface(args: argparse.Namespace) -> int:
             by_surface[surface].append(symbol)
         elif symbol not in overlap_symbols:
             overlap_symbols.append(symbol)
-    if not overlap_symbols:
-        raise SurfaceContractError(
-            "surface split has no explicit overlap sample; generate the artifact "
-            "with at least one assignment_kind=overlap symbol"
-        )
-
     selected = [args.surface] if args.surface else ["mock", "live"]
     for surface in selected:
         validate_surface(surface)
+    if len(selected) == 2 and not overlap_symbols:
+        raise SurfaceContractError(
+            "dual surface run requires an explicit overlap sample"
+        )
     if args.limit_symbols is not None:
         by_surface = {
             surface: values[: args.limit_symbols]
@@ -800,36 +850,31 @@ async def _run_dual_surface(args: argparse.Namespace) -> int:
 
     # This is the only branch that creates clients.  No client is built by the
     # dry-run path, so a planning invocation cannot accidentally call a host.
-    _prepare_surface_env(args.mock_env_file, args.live_env_file)
+    selected_tuple = tuple(selected)
+    _prepare_surface_env(selected_tuple, args.mock_env_file, args.live_env_file)
     from app.services.brokers.kiwoom.client import KiwoomMockClient
     from app.services.brokers.kiwoom.live_market_data import KiwoomLiveReadOnlyClient
 
-    raw_clients: dict[str, Any] = {
-        "mock": KiwoomMockClient.from_app_settings(),
-        "live": KiwoomLiveReadOnlyClient.from_app_settings(),
-    }
-    clients = {
-        surface: KiwoomSurfaceClient(surface, raw_clients[surface])
-        for surface in selected
-    }
-    pacers = {surface: SurfacePacer(surface) for surface in selected}
-    stop_event = asyncio.Event()
-    overlap = OverlapVerifier(
-        symbols=tuple(overlap_symbols[:2]),
-        session_date=date.fromisoformat(args.end_date),
-        clients={
-            surface: KiwoomSurfaceClient(surface, raw_clients[surface])
-            for surface in ("mock", "live")
-        },
-        pacers={surface: SurfacePacer(surface) for surface in ("mock", "live")},
-        log=ProgressLog(job_events / "progress.jsonl"),
-        stop_event=stop_event,
+    raw_clients, clients, pacers = _build_surface_runtime(
+        selected_tuple,
+        mock_factory=KiwoomMockClient.from_app_settings,
+        live_factory=KiwoomLiveReadOnlyClient.from_app_settings,
     )
-    # Use the same pacers for bulk and overlap calls; every call is accounted
-    # against that surface's budget.
-    overlap.pacers.update(pacers)
+    stop_events = {surface: asyncio.Event() for surface in selected}
     pool = await asyncpg.create_pool(dsn(), min_size=2, max_size=6)
-    log = overlap.log
+    log = ProgressLog(job_events / "progress.jsonl")
+    guard = Guard(pool, args.baseline_median_ms, log)
+    await guard.snapshot_witness()
+    overlap = None
+    if len(selected) == 2:
+        overlap = OverlapVerifier(
+            symbols=tuple(overlap_symbols[:2]),
+            session_date=date.fromisoformat(args.end_date),
+            clients=clients,
+            pacers=pacers,
+            log=log,
+            stop_events=stop_events,
+        )
     try:
         results = await asyncio.gather(
             *[
@@ -843,8 +888,10 @@ async def _run_dual_surface(args: argparse.Namespace) -> int:
                     date.fromisoformat(args.start_date),
                     date.fromisoformat(args.end_date),
                     batch_id,
+                    pacer=pacers[surface],
                     overlap=overlap,
-                    stop_event=stop_event,
+                    stop_event=stop_events[surface],
+                    guard=guard,
                 )
                 for surface in selected
             ]

--- a/research/kr_backfill/dual_surface.py
+++ b/research/kr_backfill/dual_surface.py
@@ -8,6 +8,7 @@ parts of the dual-pipe without touching either Kiwoom host.
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import hashlib
 import json
@@ -90,16 +91,15 @@ class SurfacePacer:
         self.backoff_level = 0
         self._last = 0.0
         self._clock = clock
+        self._wait_lock = asyncio.Lock()
 
     async def wait(self) -> None:
-        # Imported lazily so the offline split/pacing tests remain cheap.
-        import asyncio
-
-        delta = self._clock() - self._last
-        if delta < self.interval:
-            await asyncio.sleep(self.interval - delta)
-        self._last = self._clock()
-        self.calls += 1
+        async with self._wait_lock:
+            delta = self._clock() - self._last
+            if delta < self.interval:
+                await asyncio.sleep(self.interval - delta)
+            self._last = self._clock()
+            self.calls += 1
 
     def note_status(self, status_code: int | None) -> None:
         """Apply only fail-closed status handling and monotonic backoff."""

--- a/research/kr_backfill/dual_surface.py
+++ b/research/kr_backfill/dual_surface.py
@@ -20,11 +20,6 @@ from typing import Any, Literal
 Surface = Literal["mock", "live"]
 SURFACES: tuple[Surface, Surface] = ("mock", "live")
 
-SURFACE_HOSTS: dict[Surface, str] = {
-    "mock": "mockapi.kiwoom.com",
-    "live": "api.kiwoom.com",
-}
-
 # The live probe reached 0.5 s without a 429, but only had eight calls per
 # step.  That is not enough evidence to call 0.5 s a proven safe upper bound.
 # Therefore the live lane backs off monotonically to 1.0 s and then 2.0 s.

--- a/research/kr_backfill/dual_surface.py
+++ b/research/kr_backfill/dual_surface.py
@@ -1,0 +1,293 @@
+"""Kiwoom mock/live provenance and pacing contracts for the KR backfill.
+
+This module is deliberately offline-friendly.  It contains no client creation
+or network calls; the collector supplies the client and invokes the pacer.
+Keeping the surface contract here makes it possible to test the dangerous
+parts of the dual-pipe without touching either Kiwoom host.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+Surface = Literal["mock", "live"]
+SURFACES: tuple[Surface, Surface] = ("mock", "live")
+
+SURFACE_HOSTS: dict[Surface, str] = {
+    "mock": "mockapi.kiwoom.com",
+    "live": "api.kiwoom.com",
+}
+
+# The live probe reached 0.5 s without a 429, but only had eight calls per
+# step.  That is not enough evidence to call 0.5 s a proven safe upper bound.
+# Therefore the live lane backs off monotonically to 1.0 s and then 2.0 s.
+# There is intentionally no automatic recovery after a successful response.
+SURFACE_INITIAL_PACE_SECONDS: dict[Surface, float] = {
+    "mock": 2.0,
+    "live": 0.5,
+}
+BACKOFF_PACE_SECONDS: tuple[float, float] = (1.0, 2.0)
+MAX_SURFACE_429 = 3
+
+BAR_FIELDS: tuple[str, ...] = (
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "value",
+)
+
+
+class SurfaceContractError(ValueError):
+    """The immutable split or surface value is invalid."""
+
+
+class SurfaceAuthError(RuntimeError):
+    """A surface returned 401; the lane must stop immediately."""
+
+
+class SurfaceBackoffExhausted(RuntimeError):
+    """A surface returned too many 429s; the lane must stop and be reported."""
+
+
+class OverlapMismatch(RuntimeError):
+    """The intentional cross-surface exact-equality sample disagreed."""
+
+
+def validate_surface(surface: str) -> Surface:
+    if surface not in SURFACES:
+        raise SurfaceContractError(
+            f"surface must be one of {SURFACES!r}; got {surface!r}"
+        )
+    return surface  # type: ignore[return-value]
+
+
+def http_status_from_exception(exc: BaseException) -> int | None:
+    """Extract an HTTP status without relying on a concrete HTTP library."""
+
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        return status
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    match = re.search(r"\b(401|429)\b", str(exc))
+    return int(match.group(1)) if match else None
+
+
+class SurfacePacer:
+    """One independent, monotonic pacer for exactly one Kiwoom surface."""
+
+    def __init__(self, surface: Surface, *, clock: Any = time.monotonic) -> None:
+        self.surface = validate_surface(surface)
+        self.interval = SURFACE_INITIAL_PACE_SECONDS[self.surface]
+        self.calls = 0
+        self.consecutive_429 = 0
+        self.backoff_level = 0
+        self._last = 0.0
+        self._clock = clock
+
+    async def wait(self) -> None:
+        # Imported lazily so the offline split/pacing tests remain cheap.
+        import asyncio
+
+        delta = self._clock() - self._last
+        if delta < self.interval:
+            await asyncio.sleep(self.interval - delta)
+        self._last = self._clock()
+        self.calls += 1
+
+    def note_status(self, status_code: int | None) -> None:
+        """Apply only fail-closed status handling and monotonic backoff."""
+
+        if status_code == 401:
+            raise SurfaceAuthError(f"{self.surface}: HTTP 401; stop surface and report")
+        if status_code != 429:
+            # Keep both the interval and the 429 count monotonic.  A successful
+            # call is not evidence that the earlier 0.5 s boundary is safe;
+            # automatic recovery is NO, and a later recurrence still advances
+            # the same fail-closed backoff ladder.
+            return
+
+        self.consecutive_429 += 1
+        if self.consecutive_429 >= MAX_SURFACE_429:
+            raise SurfaceBackoffExhausted(
+                f"{self.surface}: {MAX_SURFACE_429} HTTP 429 responses; "
+                "stop surface and report"
+            )
+        self.backoff_level = min(self.consecutive_429, len(BACKOFF_PACE_SECONDS))
+        self.interval = max(self.interval, BACKOFF_PACE_SECONDS[self.backoff_level - 1])
+
+    def note_exception(self, exc: BaseException) -> None:
+        self.note_status(http_status_from_exception(exc))
+
+
+def validate_surface_rows(rows: list[dict[str, str]]) -> dict[str, list[Surface]]:
+    """Validate an immutable split CSV and return symbol → allowed surfaces.
+
+    Bulk symbols have exactly one surface.  Only explicit overlap rows may
+    carry both surfaces, and those rows must carry both (not an accidental
+    duplicate of the same surface).
+    """
+
+    if not rows:
+        raise SurfaceContractError("surface split is empty")
+    required = {"ticker", "surface"}
+    missing = required - set(rows[0])
+    if missing:
+        raise SurfaceContractError(f"surface split missing columns: {sorted(missing)}")
+
+    by_symbol: dict[str, list[tuple[Surface, str]]] = {}
+    for row in rows:
+        symbol = str(row.get("ticker", "")).strip()
+        if not symbol:
+            raise SurfaceContractError("surface split contains an empty ticker")
+        surface = validate_surface(str(row.get("surface", "")).strip())
+        kind = str(row.get("assignment_kind", "bulk")).strip() or "bulk"
+        if kind not in {"bulk", "overlap"}:
+            raise SurfaceContractError(
+                f"{symbol}: assignment_kind must be bulk or overlap, got {kind!r}"
+            )
+        by_symbol.setdefault(symbol, []).append((surface, kind))
+
+    result: dict[str, list[Surface]] = {}
+    for symbol, entries in by_symbol.items():
+        surfaces = [surface for surface, _kind in entries]
+        kinds = {kind for _surface, kind in entries}
+        if len(surfaces) != len(set(surfaces)):
+            raise SurfaceContractError(f"{symbol}: duplicate surface assignment")
+        if len(surfaces) == 1:
+            if kinds != {"bulk"}:
+                raise SurfaceContractError(
+                    f"{symbol}: overlap assignment must name both surfaces"
+                )
+        elif surfaces != list(SURFACES) or kinds != {"overlap"}:
+            raise SurfaceContractError(
+                f"{symbol}: cross-surface split is forbidden unless it is an "
+                "explicit mock+live overlap sample"
+            )
+        result[symbol] = surfaces
+    return result
+
+
+def assert_bulk_assignment_is_single_surface(rows: list[dict[str, str]]) -> None:
+    """Adversarial guard used by tests and the collector before any fetch."""
+
+    validate_surface_rows(rows)
+
+
+def compare_overlap_exact(
+    symbol: str,
+    mock_rows: dict[Any, dict[str, float]],
+    live_rows: dict[Any, dict[str, float]],
+) -> dict[str, Any]:
+    """Compare a Kiwoom overlap sample with integer/exact equality semantics."""
+
+    mock_times = set(mock_rows)
+    live_times = set(live_rows)
+    if mock_times != live_times:
+        raise OverlapMismatch(
+            f"{symbol}: overlap coverage differs "
+            f"mock_only={len(mock_times - live_times)} "
+            f"live_only={len(live_times - mock_times)}"
+        )
+    compared = 0
+    for timestamp in sorted(mock_times):
+        for field in BAR_FIELDS:
+            compared += 1
+            if mock_rows[timestamp].get(field) != live_rows[timestamp].get(field):
+                raise OverlapMismatch(
+                    f"{symbol}: exact overlap mismatch at {timestamp!s} field={field}"
+                )
+    return {"symbol": symbol, "rows": len(mock_rows), "cells_compared": compared}
+
+
+@dataclass(frozen=True)
+class SurfaceManifest:
+    """Batch-level provenance sidecar for rows in research.kr_candles_1m."""
+
+    batch_id: str
+    assignment_path: str
+    assignment_sha256: str
+    surfaces: tuple[Surface, Surface] = SURFACES
+    manifest_surface_field: str = "surface"
+    manifest_surface_granularity: str = "batch_and_progress_event"
+    cross_surface_split_prevented: bool = True
+    overlap_sample_size: int = 2
+    overlap_every_batches: int = 50
+    overlap_mismatch_action: str = "stop_and_report"
+    auto_recovery: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "kiwoom_dual_surface.v1",
+            "batch_id": self.batch_id,
+            "assignment_path": self.assignment_path,
+            "assignment_sha256": self.assignment_sha256,
+            "surfaces": list(self.surfaces),
+            "surface": "per_batch_and_progress_event",
+            "manifest_surface_field": self.manifest_surface_field,
+            "manifest_surface_granularity": self.manifest_surface_granularity,
+            "cross_surface_split_prevented": self.cross_surface_split_prevented,
+            "overlap_sample": {
+                "size": self.overlap_sample_size,
+                "every_completed_batches": self.overlap_every_batches,
+                "reason": (
+                    "The 2026-08-03 equality result is historical evidence; "
+                    "a small live-vs-mock exact check is repeated during bulk."
+                ),
+            },
+            "overlap_mismatch_action": self.overlap_mismatch_action,
+            "backoff": {
+                "initial_seconds": dict(SURFACE_INITIAL_PACE_SECONDS),
+                "steps_seconds": list(BACKOFF_PACE_SECONDS),
+                "per_surface": True,
+                "auto_recovery": self.auto_recovery,
+                "probe_sample_note": (
+                    "0.5s was observed for only 8 calls per step; safe upper "
+                    "bound remains unproven."
+                ),
+            },
+        }
+
+
+def write_surface_manifest(path: Path, manifest: SurfaceManifest) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def assignment_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class KiwoomSurfaceClient:
+    """Normalize mock ``post_api`` and live ``post_chart`` for the fetcher."""
+
+    def __init__(self, surface: Surface, client: Any) -> None:
+        self.surface = validate_surface(surface)
+        self.client = client
+
+    async def post_api(self, **kwargs: Any) -> dict[str, Any]:
+        if self.surface == "mock":
+            return await self.client.post_api(**kwargs)
+        kwargs.pop("path", None)
+        return await self.client.post_chart(**kwargs)
+
+
+def read_assignment_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    validate_surface_rows(rows)
+    return rows

--- a/research/kr_backfill/split_assign.py
+++ b/research/kr_backfill/split_assign.py
@@ -22,6 +22,11 @@ import hashlib
 import json
 from pathlib import Path
 
+try:
+    from .dual_surface import SURFACES, Surface, SurfaceContractError, validate_surface
+except ImportError:  # pragma: no cover - direct CLI execution
+    from dual_surface import SURFACES, Surface, SurfaceContractError, validate_surface
+
 #: Balanced-makespan split. Derived, not measured — see PROJECTED_* in the
 #: Stage A report. Recomputed at gate time from measured page size and pacing.
 TARGET_COUNTS: dict[str, int] = {"toss": 246, "kiwoom": 165, "kis": 89}
@@ -45,6 +50,149 @@ SOURCE_SPEC: dict[str, dict] = {
     },
 }
 
+# Kiwoom's measured live pacing is 4x the mock pacing (0.5 s vs 2.0 s).  The
+# default dual-pipe split therefore gives live four times as many symbols so
+# the two lanes have a comparable projected wall clock.  The generated CSV,
+# not this constant, is the immutable run-time input.
+DUAL_SURFACE_TARGET_COUNTS: dict[Surface, int] = {"mock": 100, "live": 400}
+
+
+def assign_surfaces(
+    ranks: list[str],
+    *,
+    target_counts: dict[Surface, int] | None = None,
+) -> dict[str, Surface]:
+    """Deterministically assign each bulk symbol to exactly one surface."""
+
+    if len(set(ranks)) != len(ranks):
+        raise SurfaceContractError("bulk symbol list contains duplicates")
+    if not ranks:
+        raise SurfaceContractError("bulk symbol list is empty")
+    requested = target_counts or DUAL_SURFACE_TARGET_COUNTS
+    if set(requested) != set(SURFACES) or any(v < 0 for v in requested.values()):
+        raise SurfaceContractError(f"invalid surface target counts: {requested!r}")
+    total = sum(requested.values())
+    if target_counts is not None and total != len(ranks):
+        raise SurfaceContractError(
+            f"surface target counts total {total} != symbol count {len(ranks)}"
+        )
+
+    if target_counts is None:
+        live_count = round(len(ranks) * DUAL_SURFACE_TARGET_COUNTS["live"] / 500)
+        counts = {"live": live_count, "mock": len(ranks) - live_count}
+    else:
+        counts = dict(requested)
+
+    out: dict[str, Surface] = {}
+    # Rank order is stable.  Keeping each surface in a contiguous, explicit
+    # slice makes accidental reallocation during a run easy to detect in the
+    # artifact and avoids a hidden hash/random assignment.
+    cursor = 0
+    for surface in SURFACES:
+        for symbol in ranks[cursor : cursor + counts[surface]]:
+            out[symbol] = validate_surface(surface)
+        cursor += counts[surface]
+    if cursor != len(ranks) or len(out) != len(ranks):
+        raise AssertionError("surface assignment did not cover every symbol")
+    return out
+
+
+def write_dual_surface_assignment(
+    *,
+    top500: Path,
+    out_dir: Path,
+    overlap_symbols: tuple[str, ...] = (),
+) -> tuple[Path, Path]:
+    """Write the immutable bulk+overlap split and its manifest.
+
+    Overlap symbols are removed from bulk before assignment and re-added as two
+    explicit ``assignment_kind=overlap`` rows.  They are never silently
+    assigned twice by the ordinary bulk rule.
+    """
+
+    rows = list(csv.DictReader(top500.open(newline="", encoding="utf-8")))
+    rows.sort(key=lambda r: int(r["rank"]))
+    overlap = tuple(dict.fromkeys(s.strip() for s in overlap_symbols if s.strip()))
+    known = {str(r["ticker"]).strip() for r in rows}
+    unknown = set(overlap) - known
+    if unknown:
+        raise SurfaceContractError(
+            f"overlap symbols absent from top500: {sorted(unknown)}"
+        )
+    bulk_rows = [r for r in rows if str(r["ticker"]).strip() not in overlap]
+    mapping = assign_surfaces([str(r["ticker"]).strip() for r in bulk_rows])
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_csv = out_dir / "kiwoom_surface_split.csv"
+    with out_csv.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=["rank", "ticker", "market", "assignment_kind", "surface"],
+        )
+        writer.writeheader()
+        for row in bulk_rows:
+            ticker = str(row["ticker"]).strip()
+            writer.writerow(
+                {
+                    "rank": row["rank"],
+                    "ticker": ticker,
+                    "market": row["market"],
+                    "assignment_kind": "bulk",
+                    "surface": mapping[ticker],
+                }
+            )
+        for row in rows:
+            ticker = str(row["ticker"]).strip()
+            if ticker in overlap:
+                for surface in SURFACES:
+                    writer.writerow(
+                        {
+                            "rank": row["rank"],
+                            "ticker": ticker,
+                            "market": row["market"],
+                            "assignment_kind": "overlap",
+                            "surface": surface,
+                        }
+                    )
+
+    # Import here to keep the legacy three-source CLI independent of the
+    # surface module's JSON/manifest helpers.
+    try:
+        from .dual_surface import assignment_sha256, validate_surface_rows
+    except ImportError:  # pragma: no cover - direct CLI execution
+        from dual_surface import assignment_sha256, validate_surface_rows
+
+    split_rows = list(csv.DictReader(out_csv.open(newline="", encoding="utf-8")))
+    validate_surface_rows(split_rows)
+    manifest = {
+        "schema_version": "kiwoom_dual_surface_split.v1",
+        "job": "kr-backfill-phase1",
+        "split_unit": "symbol",
+        "surfaces": list(SURFACES),
+        "bulk_assignment_counts": {
+            surface: sum(1 for value in mapping.values() if value == surface)
+            for surface in SURFACES
+        },
+        "overlap_symbols": list(overlap),
+        "overlap_rows_are_explicit_exception": True,
+        "cross_surface_split_prevented": True,
+        "assignment_rule": (
+            "rank-ordered contiguous split using 1:4 mock:live pacing ratio; "
+            "only assignment_kind=overlap may name both surfaces"
+        ),
+        "split_assignment_csv": str(out_csv),
+        "split_assignment_sha256": assignment_sha256(out_csv),
+        "top500_sha256": hashlib.sha256(top500.read_bytes()).hexdigest(),
+        "assignment_script_sha256": hashlib.sha256(
+            Path(__file__).read_bytes()
+        ).hexdigest(),
+    }
+    out_manifest = out_dir / "kiwoom_surface_split_manifest.json"
+    out_manifest.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return out_csv, out_manifest
+
 
 def assign(ranks: list[str]) -> dict[str, str]:
     counts = dict.fromkeys(TARGET_COUNTS, 0)
@@ -66,7 +214,37 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--top500", required=True, type=Path)
     ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument(
+        "--dual-surfaces",
+        action="store_true",
+        help="write the Kiwoom mock/live symbol split instead of the legacy 3-source split",
+    )
+    ap.add_argument(
+        "--overlap-symbol",
+        action="append",
+        default=[],
+        help="explicit cross-surface equality sample symbol; repeat at most twice",
+    )
     args = ap.parse_args()
+
+    if args.dual_surfaces:
+        if len(args.overlap_symbol) not in {1, 2}:
+            ap.error("--dual-surfaces requires one or two --overlap-symbol values")
+        csv_path, manifest_path = write_dual_surface_assignment(
+            top500=args.top500,
+            out_dir=args.out_dir,
+            overlap_symbols=tuple(args.overlap_symbol),
+        )
+        print(
+            json.dumps(
+                {
+                    "split_assignment_csv": str(csv_path),
+                    "split_manifest": str(manifest_path),
+                },
+                indent=2,
+            )
+        )
+        return 0
 
     rows = list(csv.DictReader(args.top500.open()))
     rows.sort(key=lambda r: int(r["rank"]))

--- a/tests/test_kiwoom_dual_surface.py
+++ b/tests/test_kiwoom_dual_surface.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
+from research.kr_backfill.collect import _build_surface_runtime, _prepare_surface_env
 from research.kr_backfill.dual_surface import (
     OverlapMismatch,
     SurfaceAuthError,
@@ -112,3 +115,45 @@ def test_split_artifact_records_bulk_owner_and_explicit_overlap(tmp_path):
     assert rows[0] == "rank,ticker,market,assignment_kind,surface"
     assert sum("000002" in row for row in rows) == 2
     assert "cross_surface_split_prevented" in manifest_path.read_text(encoding="utf-8")
+
+
+def test_mock_only_runtime_never_constructs_live_client():
+    dispatched: list[tuple[str, str]] = []
+
+    def mock_factory():
+        dispatched.append(("mock", "constructed"))
+        return object()
+
+    def live_factory():
+        raise AssertionError("live factory must not run for --surface mock")
+
+    raw, clients, pacers = _build_surface_runtime(
+        ("mock",), mock_factory=mock_factory, live_factory=live_factory
+    )
+    assert list(raw) == ["mock"]
+    assert list(clients) == ["mock"]
+    assert list(pacers) == ["mock"]
+    assert dispatched == [("mock", "constructed")]
+
+
+def test_dual_runtime_uses_one_accounted_pacer_per_surface():
+    def factory(surface):
+        return lambda: object()
+
+    raw, clients, pacers = _build_surface_runtime(
+        ("mock", "live"),
+        mock_factory=factory("mock"),
+        live_factory=factory("live"),
+    )
+    assert set(raw) == {"mock", "live"}
+    assert set(clients) == set(pacers) == {"mock", "live"}
+
+
+def test_mock_only_env_does_not_require_or_read_live_file(tmp_path):
+    mock_file = tmp_path / ".env.kiwoom-mock"
+    mock_file.write_text("KIWOOM_MOCK_ENABLED=true\n", encoding="utf-8")
+    missing_live_file = tmp_path / ".env.kiwoom-live"
+
+    _prepare_surface_env(("mock",), mock_file, missing_live_file)
+
+    assert os.environ["ENV_FILE"] == str(mock_file)

--- a/tests/test_kiwoom_dual_surface.py
+++ b/tests/test_kiwoom_dual_surface.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+from research.kr_backfill.dual_surface import (
+    OverlapMismatch,
+    SurfaceAuthError,
+    SurfaceBackoffExhausted,
+    SurfaceContractError,
+    SurfaceManifest,
+    SurfacePacer,
+    compare_overlap_exact,
+    validate_surface_rows,
+)
+from research.kr_backfill.split_assign import (
+    assign_surfaces,
+    write_dual_surface_assignment,
+)
+
+
+def _row(ticker: str, surface: str, kind: str = "bulk") -> dict[str, str]:
+    return {
+        "ticker": ticker,
+        "surface": surface,
+        "assignment_kind": kind,
+    }
+
+
+def test_bulk_symbol_cannot_be_assigned_to_both_surfaces():
+    with pytest.raises(SurfaceContractError, match="cross-surface split"):
+        validate_surface_rows([_row("005930", "mock"), _row("005930", "live")])
+
+
+def test_only_explicit_overlap_rows_may_name_both_surfaces():
+    rows = [_row("005930", "mock", "overlap"), _row("005930", "live", "overlap")]
+    assert validate_surface_rows(rows) == {"005930": ["mock", "live"]}
+
+
+def test_deterministic_bulk_assignment_has_one_surface_per_symbol():
+    assignment = assign_surfaces(["000001", "000002", "000003", "000004"])
+    assert set(assignment) == {"000001", "000002", "000003", "000004"}
+    assert set(assignment.values()) <= {"mock", "live"}
+
+
+def test_surface_pacing_is_independent_and_never_recovers():
+    mock = SurfacePacer("mock")
+    live = SurfacePacer("live")
+    assert mock.interval == 2.0
+    assert live.interval == 0.5
+
+    live.note_status(429)
+    assert live.interval == 1.0
+    assert mock.interval == 2.0
+    live.note_status(200)
+    assert live.interval == 1.0
+    live.note_status(429)
+    assert live.interval == 2.0
+    assert mock.interval == 2.0
+
+    with pytest.raises(SurfaceBackoffExhausted):
+        live.note_status(429)
+    with pytest.raises(SurfaceAuthError):
+        mock.note_status(401)
+
+
+def test_overlap_is_exact_and_mismatch_is_stop_condition():
+    row = {
+        "open": 1.0,
+        "high": 2.0,
+        "low": 0.5,
+        "close": 1.5,
+        "volume": 10.0,
+        "value": 15.0,
+    }
+    assert (
+        compare_overlap_exact("005930", {1: row}, {1: dict(row)})["cells_compared"] == 6
+    )
+    changed = dict(row, close=1.5000000001)
+    with pytest.raises(OverlapMismatch, match="exact overlap mismatch"):
+        compare_overlap_exact("005930", {1: row}, {1: changed})
+
+
+def test_manifest_seals_surface_field_and_overlap_design():
+    payload = SurfaceManifest(
+        batch_id="batch",
+        assignment_path="split.csv",
+        assignment_sha256="0" * 64,
+    ).to_dict()
+    assert payload["manifest_surface_field"] == "surface"
+    assert payload["cross_surface_split_prevented"] is True
+    assert payload["overlap_sample"] == {
+        "size": 2,
+        "every_completed_batches": 50,
+        "reason": payload["overlap_sample"]["reason"],
+    }
+    assert payload["backoff"]["per_surface"] is True
+    assert payload["backoff"]["auto_recovery"] is False
+
+
+def test_split_artifact_records_bulk_owner_and_explicit_overlap(tmp_path):
+    top500 = tmp_path / "top500.csv"
+    top500.write_text(
+        "rank,ticker,market\n1,000001,KOSPI\n2,000002,KOSPI\n3,000003,KOSDAQ\n",
+        encoding="utf-8",
+    )
+    split_path, manifest_path = write_dual_surface_assignment(
+        top500=top500,
+        out_dir=tmp_path / "split",
+        overlap_symbols=("000002",),
+    )
+    rows = split_path.read_text(encoding="utf-8").splitlines()
+    assert rows[0] == "rank,ticker,market,assignment_kind,surface"
+    assert sum("000002" in row for row in rows) == 2
+    assert "cross_surface_split_prevented" in manifest_path.read_text(encoding="utf-8")

--- a/tests/test_kiwoom_dual_surface.py
+++ b/tests/test_kiwoom_dual_surface.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import os
+import time
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
 import pytest
 
+import research.kr_backfill.collect as collect
 from research.kr_backfill.collect import _build_surface_runtime, _prepare_surface_env
 from research.kr_backfill.dual_surface import (
     OverlapMismatch,
@@ -149,11 +154,206 @@ def test_dual_runtime_uses_one_accounted_pacer_per_surface():
     assert set(clients) == set(pacers) == {"mock", "live"}
 
 
-def test_mock_only_env_does_not_require_or_read_live_file(tmp_path):
+def test_mock_only_env_does_not_require_or_read_live_file(monkeypatch, tmp_path):
     mock_file = tmp_path / ".env.kiwoom-mock"
     mock_file.write_text("KIWOOM_MOCK_ENABLED=true\n", encoding="utf-8")
     missing_live_file = tmp_path / ".env.kiwoom-live"
 
-    _prepare_surface_env(("mock",), mock_file, missing_live_file)
+    previous = os.environ.get("ENV_FILE")
+    try:
+        _prepare_surface_env(("mock",), mock_file, missing_live_file)
+        assert os.environ["ENV_FILE"] == str(mock_file)
+    finally:
+        if previous is None:
+            monkeypatch.delenv("ENV_FILE", raising=False)
+        else:
+            monkeypatch.setenv("ENV_FILE", previous)
 
-    assert os.environ["ENV_FILE"] == str(mock_file)
+
+def test_ambient_production_env_file_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.setenv("ENV_FILE", str(tmp_path / ".env.prod"))
+    with pytest.raises(SurfaceContractError, match="production env file"):
+        _prepare_surface_env(("mock",), None, tmp_path / ".env.live")
+
+
+def test_surface_pacer_serializes_concurrent_waits():
+    async def scenario():
+        pacer = SurfacePacer("live")
+        pacer.interval = 0.01
+        pacer._last = time.monotonic()
+        started = time.monotonic()
+        await asyncio.gather(pacer.wait(), pacer.wait())
+        return pacer.calls, time.monotonic() - started
+
+    calls, elapsed = asyncio.run(scenario())
+    assert calls == 2
+    assert elapsed >= 0.019
+
+
+@pytest.mark.asyncio
+async def test_dual_orchestrator_runs_both_surfaces_with_synthetic_fixture(
+    monkeypatch, tmp_path
+):
+    split = tmp_path / "split.csv"
+    split.write_text(
+        "ticker,surface,assignment_kind\n"
+        "000001,mock,bulk\n"
+        "000002,live,bulk\n"
+        "000003,mock,overlap\n"
+        "000003,live,overlap\n",
+        encoding="utf-8",
+    )
+    job_dir = tmp_path / "job"
+    dispatches: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, surface):
+            self.surface = surface
+
+        async def aclose(self):
+            return None
+
+    class FakeConn:
+        async def fetch(self, *_args):
+            return []
+
+    class FakePool:
+        def __init__(self):
+            self.closed = False
+
+        @asynccontextmanager
+        async def acquire(self):
+            yield FakeConn()
+
+        async def close(self):
+            self.closed = True
+
+    pool = FakePool()
+
+    def mock_factory():
+        return FakeClient("mock")
+
+    def live_factory():
+        return FakeClient("live")
+
+    async def fake_fetch(*, client, symbol, **_kwargs):
+        dispatches.append((client.client.surface, symbol))
+        _kwargs["pacer"].calls += 1
+        return {}, {"pages": 1}
+
+    monkeypatch.setattr(collect, "_prepare_surface_env", lambda *args: None)
+
+    async def create_pool(*_args, **_kwargs):
+        return pool
+
+    monkeypatch.setattr(collect.asyncpg, "create_pool", create_pool)
+    monkeypatch.setattr(collect, "dsn", lambda: "postgresql://synthetic")
+    monkeypatch.setattr(collect, "fetch_kiwoom_minutes", fake_fetch)
+    monkeypatch.setattr(collect, "assert_fetch_window_open", lambda: None)
+    monkeypatch.setattr(collect, "now_kst", lambda: collect.datetime(2026, 1, 2))
+    from app.services.brokers.kiwoom.client import KiwoomMockClient
+    from app.services.brokers.kiwoom.live_market_data import KiwoomLiveReadOnlyClient
+
+    monkeypatch.setattr(
+        KiwoomMockClient,
+        "from_app_settings",
+        classmethod(lambda cls: mock_factory()),
+    )
+    monkeypatch.setattr(
+        KiwoomLiveReadOnlyClient,
+        "from_app_settings",
+        classmethod(lambda cls: live_factory()),
+    )
+
+    args = SimpleNamespace(
+        split_csv=split,
+        job_dir=job_dir,
+        start_date="2026-01-01",
+        end_date="2026-01-02",
+        surface=None,
+        limit_symbols=None,
+        confirm_write=True,
+        mock_env_file=None,
+        live_env_file=tmp_path / ".env.live",
+        baseline_median_ms=2.127,
+    )
+
+    result = await collect._run_dual_surface(args)
+
+    assert result == 0
+    print(
+        "SYNTHETIC_DUAL_DISPATCHES",
+        {
+            surface: sum(item[0] == surface for item in dispatches)
+            for surface in ("mock", "live")
+        },
+        "POOL_CLOSED",
+        pool.closed,
+    )
+    assert sorted(dispatches) == [("live", "000002"), ("mock", "000001")]
+    assert pool.closed is True
+    assert (job_dir / "events" / "stage_b_dual_surface_summary.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_dual_orchestrator_closes_pool_when_initialization_fails(
+    monkeypatch, tmp_path
+):
+    split = tmp_path / "split.csv"
+    split.write_text(
+        "ticker,surface,assignment_kind\n"
+        "000001,mock,bulk\n"
+        "000002,live,bulk\n"
+        "000003,mock,overlap\n"
+        "000003,live,overlap\n",
+        encoding="utf-8",
+    )
+
+    class FakePool:
+        closed = False
+
+        async def close(self):
+            self.closed = True
+
+    pool = FakePool()
+    monkeypatch.setattr(collect, "_prepare_surface_env", lambda *args: None)
+
+    async def create_pool(*_args, **_kwargs):
+        return pool
+
+    monkeypatch.setattr(collect.asyncpg, "create_pool", create_pool)
+    monkeypatch.setattr(collect, "dsn", lambda: "postgresql://synthetic")
+
+    def fail_guard_init(self, *args):
+        raise RuntimeError("guard init")
+
+    monkeypatch.setattr(collect.Guard, "__init__", fail_guard_init)
+    from app.services.brokers.kiwoom.client import KiwoomMockClient
+    from app.services.brokers.kiwoom.live_market_data import KiwoomLiveReadOnlyClient
+
+    monkeypatch.setattr(
+        KiwoomMockClient,
+        "from_app_settings",
+        classmethod(lambda cls: object()),
+    )
+    monkeypatch.setattr(
+        KiwoomLiveReadOnlyClient,
+        "from_app_settings",
+        classmethod(lambda cls: object()),
+    )
+    args = SimpleNamespace(
+        split_csv=split,
+        job_dir=tmp_path / "job",
+        start_date="2026-01-01",
+        end_date="2026-01-02",
+        surface=None,
+        limit_symbols=None,
+        confirm_write=True,
+        mock_env_file=None,
+        live_env_file=tmp_path / ".env.live",
+        baseline_median_ms=2.127,
+    )
+
+    with pytest.raises(RuntimeError, match="guard init"):
+        await collect._run_dual_surface(args)
+    assert pool.closed is True


### PR DESCRIPTION
## Summary
- parameterize Kiwoom backfill by mock/live surface with independent pacers
- emit immutable symbol split + batch/progress surface provenance
- add explicit overlap sample exact-equality checks and fail-closed 401/429 backoff

## Safety
- no collection run, no broker/order/account calls, no public.* writes, no mock HTTP calls in this job
- live calls are read-only chart surface only when operator confirms
- 429 pacing is monotonic per surface: live 0.5s → 1.0s → 2.0s → stop/report; no auto-recovery

## Verification
- make lint
- make test-unit: 5169 passed, 12691 deselected, 19 existing warnings
- targeted Kiwoom guards: 79 passed
- dual/corpus tests: 10 passed

MERGED = NO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for collecting data across mock and live trading surfaces in parallel.
  - Added deterministic symbol assignment with configurable targets and optional overlap symbols.
  - Added dry-run planning, environment selection, progress summaries, and provenance manifests.
  - Added separate checkpoints, pacing, retries, and statistics for each surface.
  - Added command-line options for selecting surfaces and environment configuration.

- **Bug Fixes**
  - Surface-specific failures are isolated, while overlap mismatches and fatal conditions stop both runs safely.
  - Added validation for assignments, authentication failures, rate limits, and incomplete coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->