### PR TITLE
docs: seal DFC-2C-4H-v2 registration contract

### DIFF
--- a/docs/contracts/dfc-2c-4h-v2.md
+++ b/docs/contracts/dfc-2c-4h-v2.md
@@ -1,0 +1,164 @@
+# DFC-2C-4H-v2 독립 재등록 계약
+
+상태: 설계 봉인. 이 문서는 백테스트 실행, 데이터 수집, Binance Demo 접촉, 계좌 배정 또는 주문을 승인하지 않는다.
+
+- 정본: `/Users/mgh3326/work/herdr-inbox/answer-codexmock-dfc-adjudication-0821.md` §R-3 (직접 열람)
+- 계약 ID: `DFC-2C-4H-v2`
+- 계약 구현: `research_contracts.dfc_2c_4h_v2` (stdlib-only, I/O 없음)
+- canonical hash: `85673c730555816e3c2c6759a0489ed5543396e5ad588aadef4624198a74b99f`
+
+`DFC-2C-4H-v2`는 `dfc-4h`의 patch, row update 또는 supersession이 아니다. 기존
+`dfc-4h` row와 seal은 수정·숨김·대체하지 않으며, 이 계약은 독립 새 등록이다.
+
+## 1. 고정 universe와 feature
+
+신호 universe는 정확히 `XRPUSDT`, `DOGEUSDT`, `SOLUSDT` 세 종목이다. decision epoch는
+UTC 4시간 경계이고 해당 source interval은 `[e-4h,e)`다.
+
+각 종목·epoch에서 필요한 feature는 정확히 두 개다.
+
+1. Binance USD-M `GET /fapi/v1/klines` (`v1`, `interval=4h`)의 complete Kline에서
+   total base volume `V`와 taker-buy base volume `B`를 읽는다. `S=V-B`로 두고
+   `OFI=log(B/S)`로 계산한다. `V`, `B`, `S`는 모두 finite 및 strictly positive여야 한다.
+   quote volume은 입력이 아니며 epsilon, zero 대체 또는 보간도 허용하지 않는다.
+2. Binance USD-M `GET /fapi/v1/premiumIndexKlines` (`v1`, `interval=4h`)의 complete
+   candle close를 premium feature로 그대로 사용한다. 5분 close들의 평균, 종가 선택,
+   VWAP 등 재집계는 허용하지 않는다.
+
+따라서 `quote_volume_proxy`와 `five_minute_premium_average`는 폐기됐다. 두 endpoint의
+host/path/version, schema version, epoch, raw payload SHA-256은 후속 artifact manifest에
+공개되어야 한다.
+
+## 2. score와 Q0.75 봉인
+
+각 feature `f∈{OFI, Premium}`에 대하여 현재 epoch를 제외한 prior complete finite 관측치
+252개를 `H^f(s,e)`로 둔다. 모든 값이 정확히 252개일 때만 score를 계산한다.
+
+```text
+U_f(s,e) = 2 * mean(h <= f(s,e) for h in H^f(s,e)) - 1
+C(s,e)   = (U_OFI(s,e) + U_Premium(s,e)) / 2
+```
+
+`<=`는 PIT tie rule이다. `C`의 threshold history도 현재값을 제외한 prior score-eligible
+`|C|` 252개다. 오름차순 `a[0]..a[251]`에 대해 오직 다음 linear rule만 쓴다.
+
+```text
+q(s,e) = a[188] + 0.25 * (a[189] - a[188])
+tail(s,e) = abs(C(s,e)) >= q(s,e)
+```
+
+비교는 inclusive다. Q0.75는 runtime 설정도, CLI 인자도, strategy parameter도 아니다.
+`tail_threshold_q75(prior_abs_composites)`는 quantile 인자를 받지 않고,
+`score_symbol(inputs)`도 quantile override를 받지 않는다. 따라서 Q0.70/Q0.80 등의
+발화율 맞춤 sweep은 이 계약 구현으로 호출할 수 없으며, extra argument는 `TypeError`다.
+다른 quantile, window, score definition을 쓰려면 새 ID와 새 canonical hash가 필요하다.
+
+## 3. basket과 one-winner 규칙
+
+세 symbol의 current input이 같은 UTC epoch에 모두 complete여야 한다. 그 후에만
+`candidate_any = any(tail(s,e))`를 계산한다. 하나라도 gap, missing, conflict, invalid 또는
+reference-not-ready이면 epoch는 `not_evaluable_*`이고 `candidate_any`는 `None`이다. 이는
+0/false로 바꾸지 않으며 incidence denominator에서 조용히 제거하지도 않는다.
+
+candidate가 여러 개면 한 event만 남긴다. winner는 `abs(C)`가 가장 큰 tail candidate이며,
+`abs(C)`가 정확히 같으면 다음 사전 고정 순서를 쓴다.
+
+```text
+XRPUSDT, DOGEUSDT, SOLUSDT
+```
+
+따라서 basket은 epoch당 최대 한 winner를 기록한다. 이 규칙은 상품 방향, 주문 또는 PnL
+규칙이 아니며 오직 outcome 관측 단위를 고정한다.
+
+## 4. data integrity와 공개 provenance
+
+complete-only가 hard rule이다. input evidence에는 최소 source ID, endpoint host/path/version,
+symbol, interval, epoch start/end, `complete`, `gap_status`, raw payload SHA-256 및 schema
+version이 있어야 한다. raw hash는 lowercase 64-hex가 아니면 거부한다.
+
+다음은 모두 금지다.
+
+- missing/gap/conflict 값을 forward fill, zero, 평균 또는 다른 심볼 값으로 대체하는 행위
+- incomplete candle을 close로 간주하는 행위
+- gap epoch를 no-candidate로 바꾸는 행위
+- endpoint/version/raw hash를 생략한 artifact 공개
+- v2 candidate rate를 보고 Q0.75 이외의 quantile을 선택하는 행위
+
+`research_contracts.dfc_2c_4h_v2.validate_evidence_manifest`와
+`evaluate_basket`은 complete/gap/reference 상태를 명시적으로 보존하는 회귀 경계를 제공한다.
+이 모듈은 network, database, collector, broker, ledger 또는 runtime app import를 하지 않는다.
+
+## 5. exploration 격리와 별도 검증
+
+기존 `dfc-retro-probe-v1`의 1,095일 artifact (`2023-08-04T00:00:00Z`부터
+`2026-08-03T00:00:00Z`)와 기존 2-of-3 incidence는
+`design_only_exploration`이다. 특히 proxy OFI, 5분 premium 평균, 180/540 window,
+threshold sweep 결과, 그리고 그 수치로부터의 성과·발화율 주장은 v2의 primary evidence,
+promotion evidence 또는 incidence adjudication으로 사용할 수 없다.
+
+새 계약은 뒤늦게 proxy output을 재라벨링하지 않는다. 별도 chronological historical holdout은
+다음처럼 고정한다. 이 문서 자체는 수집이나 백테스트 실행을 승인하지 않으므로, 실행에는 설계
+승인 후 별도 작업 승인이 필요하다.
+
+| 구간 | UTC | 용도 |
+| --- | --- | --- |
+| warm-up | `[2021-02-02T00:00:00Z, 2021-05-02T00:00:00Z)` | prior 252 feature/score history 형성 |
+| historical holdout | `[2021-05-02T00:00:00Z, 2021-10-29T00:00:00Z)` | 정확히 180일, 1,080 scheduled epoch, 단 한 번의 bounded exact-feature backtest |
+| prospective pilot | 새 pilot manifest의 새 T0 뒤 28일 | 168 scheduled epoch의 no-order shadow/paper 관측 |
+
+holdout은 exploratory proxy artifact와 시간적으로 겹치지 않는다. history 또는 outcome이
+부족하면 `NA`와 integrity failure를 기록할 뿐, 다른 기간을 고르거나 새 sensitivity run을
+같은 hash 아래 추가하지 않는다.
+
+## 6. 새 estimand와 promotion budget
+
+새 estimand는 directional alpha나 거래 PnL이 아니다. 사전 고정된 descriptive outcome은
+complete 4h Kline close로 계산한 다음 값이다.
+
+```text
+Y(s,e) = abs(log(close(s,e+4h) / close(s,e))) * 10,000
+Delta  = mean(Y(winner,e) | candidate_any=true)
+         - mean(mean_s Y(s,e) | candidate_any=false)
+```
+
+candidate epoch에는 §3의 유일 winner만, non-candidate epoch에는 세 symbol의 cross-sectional
+mean만 사용한다. alternative horizon, side, control, cost model 또는 PnL comparator를 추가할
+수 없다. candidate가 전혀 없으면 `Delta=NA`로 보고하며, 그 결과로 sweep하거나 기간을
+연장하지 않는다.
+
+새 promotion budget은 다음과 같다.
+
+- 한 번의 180일 historical backtest와 한 번의 28일 no-order shadow/paper pilot만 허용한다.
+- 주문 0, Binance Demo 접촉 0, 계좌 배정 0, 자동 promotion 0이다.
+- 기존 608 effective outcomes와 기존 365일 cap은 모두 상속하지 않는다.
+
+180일은 exact-feature 구현을 검증하면서 범위를 6개월로 제한하기 위해 선택했고, 28일은
+4개의 완전한 UTC 주간 cycle에서 data-integrity와 signal logging을 짧게 관찰하기 위해
+선택했다. 둘 다 기존 장기 cap·표본수나 원하는 발화율에서 유도한 값이 아니다. 결과가
+긍정적이어도 account assignment를 자동으로 만들지 않는다.
+
+## 7. Binance Demo와 OI collector 처분
+
+Binance Demo 계좌는 자동 해제되지 않고 v2에 자동 승계되지 않는다. v2 historical holdout
+보고 뒤에도 별도 운영자 배정 상신이 필요하다. 그 전까지 old T0, correlation ID, ledger
+identity, order authority는 재사용 금지다. 향후 별도 배정 검토에서만 fresh account-wide
+positions/open-orders/ledger truth의 read-only flatness 확인과 새 pilot manifest/T0를 수행할
+수 있다. 이 설계는 그런 조회도 수행하지 않았다.
+
+OI collector의 상신용 처분 판정은 **중단 권고**다. 실행은 하지 않았다. 이유는 v2가 OFI와
+premium의 두 성분으로 봉인돼 있어 OI를 유지하면 다른 3성분 계약이 되기 때문이다. OI를
+필수로 유지하려면 권위 있는 장기 OI history source를 조달하거나 prospective accumulation을
+별도 계약으로 받아들여야 하며, 이번 proxy로 기다림을 단축할 수 없다. 이 권고는 DFC lane에
+한정되며 기존 collector의 stop, 삭제 또는 변경을 이 문서가 수행하지 않는다.
+
+## 8. 검증 경로
+
+```bash
+uv run pytest tests/research_contracts/test_dfc_2c_4h_v2.py -q -ra
+uv run ruff check research_contracts/dfc_2c_4h_v2.py tests/research_contracts/test_dfc_2c_4h_v2.py
+```
+
+회귀 테스트는 새 ID/hash, old seal 보존, base-volume OFI, complete 4h premium close,
+current-excluded PIT, fixed linear Q0.75, sweep 불가 API, 3-symbol inner alignment, one-winner
+tie rule, provenance fail-closed, exploration isolation, non-inherited budget, Binance Demo
+non-succession 및 OI stop recommendation을 확인한다.

--- a/research_contracts/dfc_2c_4h_v2.py
+++ b/research_contracts/dfc_2c_4h_v2.py
@@ -1,0 +1,525 @@
+"""Immutable, offline-only registration contract for ``DFC-2C-4H-v2``.
+
+This module is deliberately separate from the old DFC-4H seal and from every
+collector, broker, account, ledger, and runtime service.  It fixes the two
+feature calculations and the only allowed tail threshold so a caller cannot
+turn a desired incidence rate into a quantile-search parameter.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any, Final
+
+from research_contracts.canonical_hash import canonical_sha256
+
+__all__ = [
+    "CANONICAL_HASH",
+    "CONTRACT_ID",
+    "CONTRACT_SCHEMA_VERSION",
+    "FIXED_QUANTILE_DENOMINATOR",
+    "FIXED_QUANTILE_NUMERATOR",
+    "HISTORICAL_HOLDOUT_END_UTC",
+    "HISTORICAL_HOLDOUT_START_UTC",
+    "HISTORICAL_HOLDOUT_SCHEDULED_EPOCHS",
+    "HISTORICAL_WARMUP_START_UTC",
+    "PIT_LOOKBACK",
+    "PROSPECTIVE_SHADOW_DAYS",
+    "PROSPECTIVE_SHADOW_SCHEDULED_EPOCHS",
+    "REQUIRED_EVIDENCE_FIELDS",
+    "SIGNAL_SYMBOLS",
+    "SYMBOL_PRIORITY",
+    "TAIL_LOOKBACK",
+    "BasketDecision",
+    "BasketEvaluationState",
+    "IntegrityState",
+    "SymbolEpochInput",
+    "SymbolScore",
+    "canonical_contract_hash",
+    "contract_as_machine_data",
+    "evaluate_basket",
+    "ofi_from_base_volumes",
+    "pit_rank",
+    "premium_index_close_from_complete_4h",
+    "score_symbol",
+    "tail_threshold_q75",
+    "validate_evidence_manifest",
+]
+
+
+CONTRACT_ID: Final = "DFC-2C-4H-v2"
+CONTRACT_SCHEMA_VERSION: Final = "dfc-2c-4h-v2.contract.v1"
+SIGNAL_SYMBOLS: Final = ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
+SYMBOL_PRIORITY: Final = MappingProxyType(
+    {symbol: index for index, symbol in enumerate(SIGNAL_SYMBOLS)}
+)
+
+EPOCH_HOURS: Final = 4
+PIT_LOOKBACK: Final = 252
+TAIL_LOOKBACK: Final = 252
+FIXED_QUANTILE_NUMERATOR: Final = 3
+FIXED_QUANTILE_DENOMINATOR: Final = 4
+
+# These windows are deliberately disjoint from the 2023-08-04 through
+# 2026-08-03 exploratory proxy artifact.  The historical holdout is bounded
+# and fixed before the exact-feature implementation is run.
+HISTORICAL_WARMUP_START_UTC: Final = "2021-02-02T00:00:00Z"
+HISTORICAL_HOLDOUT_START_UTC: Final = "2021-05-02T00:00:00Z"
+HISTORICAL_HOLDOUT_END_UTC: Final = "2021-10-29T00:00:00Z"
+HISTORICAL_HOLDOUT_SCHEDULED_EPOCHS: Final = 1_080
+PROSPECTIVE_SHADOW_DAYS: Final = 28
+PROSPECTIVE_SHADOW_SCHEDULED_EPOCHS: Final = 168
+
+REQUIRED_EVIDENCE_FIELDS: Final = frozenset(
+    {
+        "source_id",
+        "endpoint_host",
+        "endpoint_path",
+        "endpoint_version",
+        "symbol",
+        "interval",
+        "epoch_start_utc",
+        "epoch_end_utc",
+        "complete",
+        "gap_status",
+        "raw_payload_sha256",
+        "schema_version",
+    }
+)
+
+
+class IntegrityState(StrEnum):
+    """The only states admitted before a symbol can enter the score."""
+
+    COMPLETE = "complete"
+    GAP = "gap"
+    MISSING = "missing"
+    CONFLICT = "conflict"
+    INVALID = "invalid"
+
+
+class BasketEvaluationState(StrEnum):
+    """A non-evaluable epoch is not silently counted as no candidate."""
+
+    CANDIDATE = "candidate"
+    NO_CANDIDATE = "no_candidate"
+    NOT_EVALUABLE_INTEGRITY = "not_evaluable_integrity"
+    REFERENCE_NOT_READY = "reference_not_ready"
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolEpochInput:
+    """All current and strictly-prior values needed for one signal symbol."""
+
+    symbol: str
+    integrity: IntegrityState
+    current_ofi: float | None
+    current_premium_close: float | None
+    prior_ofi: tuple[float, ...]
+    prior_premium_close: tuple[float, ...]
+    prior_abs_composite: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if self.symbol not in SYMBOL_PRIORITY:
+            raise ValueError(f"unknown DFC-2C symbol: {self.symbol!r}")
+        if not isinstance(self.integrity, IntegrityState):
+            raise ValueError("integrity must be an IntegrityState")
+        object.__setattr__(self, "prior_ofi", tuple(self.prior_ofi))
+        object.__setattr__(self, "prior_premium_close", tuple(self.prior_premium_close))
+        object.__setattr__(self, "prior_abs_composite", tuple(self.prior_abs_composite))
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolScore:
+    """One deterministic score; only a tail candidate can win its epoch."""
+
+    symbol: str
+    ofi_rank: float
+    premium_rank: float
+    composite: float
+    threshold: float
+    is_candidate: bool
+
+
+@dataclass(frozen=True, slots=True)
+class BasketDecision:
+    """One result per UTC 4h epoch, with at most one winning symbol."""
+
+    state: BasketEvaluationState
+    candidate_any: bool | None
+    winner: str | None
+    scores: tuple[SymbolScore, ...]
+
+
+def _finite(name: str, value: float | None) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be a finite numeric value")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be finite")
+    return numeric
+
+
+def _history(
+    name: str, values: Sequence[float], *, nonnegative: bool = False
+) -> tuple[float, ...]:
+    if len(values) != PIT_LOOKBACK:
+        raise ValueError(f"{name} must contain exactly {PIT_LOOKBACK} prior values")
+    materialized = tuple(
+        _finite(f"{name}[{index}]", value) for index, value in enumerate(values)
+    )
+    if nonnegative and any(value < 0 for value in materialized):
+        raise ValueError(f"{name} must contain absolute, nonnegative values")
+    return materialized
+
+
+def ofi_from_base_volumes(
+    total_base_volume: float, taker_buy_base_volume: float
+) -> float:
+    """Return ``log(buy_base / sell_base)`` from one complete 4h Kline.
+
+    Quote-volume inputs, epsilons, and zero-volume substitutions are absent by
+    design.  A nonpositive buy or sell side makes the epoch invalid instead of
+    manufactured by imputation.
+    """
+
+    total = _finite("total_base_volume", total_base_volume)
+    buy = _finite("taker_buy_base_volume", taker_buy_base_volume)
+    sell = total - buy
+    if total <= 0 or buy <= 0 or sell <= 0:
+        raise ValueError("complete Kline requires strictly positive base buy and sell")
+    return math.log(buy / sell)
+
+
+def premium_index_close_from_complete_4h(
+    premium_index_close: float, *, is_complete: bool
+) -> float:
+    """Accept exactly one completed 4h premium-index candle close.
+
+    The function deliberately accepts a scalar rather than a five-minute
+    series, so it cannot average or otherwise aggregate a lower-frequency
+    proxy.
+    """
+
+    if is_complete is not True:
+        raise ValueError("premium-index candle must be complete")
+    return _finite("premium_index_close", premium_index_close)
+
+
+def pit_rank(current: float, prior_values: Sequence[float]) -> float:
+    """Current-excluded empirical PIT rank using the fixed <= tie rule."""
+
+    current_value = _finite("current", current)
+    history = _history("prior_values", prior_values)
+    less_or_equal = sum(value <= current_value for value in history)
+    return 2.0 * (less_or_equal / PIT_LOOKBACK) - 1.0
+
+
+def tail_threshold_q75(prior_abs_composites: Sequence[float]) -> float:
+    """The only permitted tail threshold: linear Q0.75 of prior 252 |C| values.
+
+    There is intentionally no quantile argument.  With 252 observations,
+    ``(252 - 1) * 0.75 == 188.25``, so the rule is exactly
+    ``a[188] + 0.25 * (a[189] - a[188])`` after sorting.
+    """
+
+    history = _history("prior_abs_composites", prior_abs_composites, nonnegative=True)
+    ordered = sorted(history)
+    return ordered[188] + 0.25 * (ordered[189] - ordered[188])
+
+
+def _has_reference_history(inputs: SymbolEpochInput) -> bool:
+    return (
+        len(inputs.prior_ofi) == PIT_LOOKBACK
+        and len(inputs.prior_premium_close) == PIT_LOOKBACK
+        and len(inputs.prior_abs_composite) == TAIL_LOOKBACK
+    )
+
+
+def score_symbol(inputs: SymbolEpochInput) -> SymbolScore:
+    """Score one complete symbol epoch using only its prior 252 observations."""
+
+    if inputs.integrity is not IntegrityState.COMPLETE:
+        raise ValueError("only complete symbol epochs can be scored")
+    if not _has_reference_history(inputs):
+        raise ValueError("reference history is not ready")
+    if inputs.current_ofi is None or inputs.current_premium_close is None:
+        raise ValueError("complete symbol epoch is missing a current feature")
+
+    ofi_rank = pit_rank(inputs.current_ofi, inputs.prior_ofi)
+    premium_value = premium_index_close_from_complete_4h(
+        inputs.current_premium_close, is_complete=True
+    )
+    premium_rank = pit_rank(premium_value, inputs.prior_premium_close)
+    composite = (ofi_rank + premium_rank) / 2.0
+    threshold = tail_threshold_q75(inputs.prior_abs_composite)
+    return SymbolScore(
+        symbol=inputs.symbol,
+        ofi_rank=ofi_rank,
+        premium_rank=premium_rank,
+        composite=composite,
+        threshold=threshold,
+        is_candidate=abs(composite) >= threshold,
+    )
+
+
+def _require_inner_aligned_symbols(inputs: Mapping[str, SymbolEpochInput]) -> None:
+    if set(inputs) != set(SIGNAL_SYMBOLS):
+        raise ValueError(
+            "basket requires exactly the three inner-aligned signal symbols"
+        )
+    for symbol in SIGNAL_SYMBOLS:
+        if inputs[symbol].symbol != symbol:
+            raise ValueError("symbol mapping key must match SymbolEpochInput.symbol")
+
+
+def evaluate_basket(inputs: Mapping[str, SymbolEpochInput]) -> BasketDecision:
+    """Evaluate a UTC 4h inner-aligned basket and deterministically select one.
+
+    The winner rule is fixed before any data: choose the candidate with largest
+    ``abs(C)``; exact ties use the immutable ``SIGNAL_SYMBOLS`` order.  Missing,
+    gapped, conflicting, invalid, or reference-not-ready inputs yield ``None``
+    for ``candidate_any`` rather than a fabricated false observation.
+    """
+
+    _require_inner_aligned_symbols(inputs)
+    ordered_inputs = tuple(inputs[symbol] for symbol in SIGNAL_SYMBOLS)
+    if any(item.integrity is not IntegrityState.COMPLETE for item in ordered_inputs):
+        return BasketDecision(
+            state=BasketEvaluationState.NOT_EVALUABLE_INTEGRITY,
+            candidate_any=None,
+            winner=None,
+            scores=(),
+        )
+    if any(not _has_reference_history(item) for item in ordered_inputs):
+        return BasketDecision(
+            state=BasketEvaluationState.REFERENCE_NOT_READY,
+            candidate_any=None,
+            winner=None,
+            scores=(),
+        )
+
+    scores = tuple(score_symbol(item) for item in ordered_inputs)
+    candidates = tuple(score for score in scores if score.is_candidate)
+    if not candidates:
+        return BasketDecision(
+            state=BasketEvaluationState.NO_CANDIDATE,
+            candidate_any=False,
+            winner=None,
+            scores=scores,
+        )
+    winner = min(
+        candidates,
+        key=lambda score: (-abs(score.composite), SYMBOL_PRIORITY[score.symbol]),
+    )
+    return BasketDecision(
+        state=BasketEvaluationState.CANDIDATE,
+        candidate_any=True,
+        winner=winner.symbol,
+        scores=scores,
+    )
+
+
+def validate_evidence_manifest(record: Mapping[str, Any]) -> None:
+    """Reject an evidence record that omits provenance required by this contract."""
+
+    missing = sorted(
+        field for field in REQUIRED_EVIDENCE_FIELDS if record.get(field) in (None, "")
+    )
+    if missing:
+        raise ValueError(
+            f"missing required DFC-2C evidence fields: {', '.join(missing)}"
+        )
+    if record["complete"] is not True:
+        raise ValueError("only complete evidence can enter DFC-2C scoring")
+    if record["gap_status"] != "none":
+        raise ValueError("gapped evidence cannot enter DFC-2C scoring")
+    raw_hash = record["raw_payload_sha256"]
+    if (
+        not isinstance(raw_hash, str)
+        or len(raw_hash) != 64
+        or any(character not in "0123456789abcdef" for character in raw_hash)
+    ):
+        raise ValueError("raw_payload_sha256 must be lowercase 64-character hex")
+
+
+def contract_as_machine_data() -> dict[str, Any]:
+    """Return the sealed, JSON-ready registration data without performing I/O."""
+
+    return {
+        "contract_schema_version": CONTRACT_SCHEMA_VERSION,
+        "contract_id": CONTRACT_ID,
+        "registration_mode": "independent_new_registration",
+        "predecessor_preservation": {
+            "old_identity": "dfc-4h",
+            "old_row_mutation": "forbidden",
+            "old_seal_mutation": "forbidden",
+            "old_supersede_or_hide": "forbidden",
+        },
+        "universe": {
+            "signal_symbols": list(SIGNAL_SYMBOLS),
+            "decision_epoch": "UTC 4h boundary",
+            "source_interval": "[e-4h,e)",
+            "basket_alignment": "all three symbols inner-aligned at one epoch",
+        },
+        "features": {
+            "ofi": {
+                "source": "Binance USD-M Kline",
+                "endpoint": {
+                    "host": "fapi.binance.com",
+                    "path": "/fapi/v1/klines",
+                    "version": "v1",
+                    "method": "GET",
+                    "interval": "4h",
+                },
+                "formula": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume))",
+                "complete_only": True,
+                "zero_or_nonpositive_side": "invalid_not_imputed",
+            },
+            "premium": {
+                "source": "Binance USD-M premium-index Kline",
+                "endpoint": {
+                    "host": "fapi.binance.com",
+                    "path": "/fapi/v1/premiumIndexKlines",
+                    "version": "v1",
+                    "method": "GET",
+                    "interval": "4h",
+                },
+                "value": "complete_4h_candle_close",
+                "complete_only": True,
+            },
+            "deprecated": [
+                "quote_volume_proxy",
+                "five_minute_premium_average",
+            ],
+        },
+        "score": {
+            "feature_pit_rank": {
+                "prior_observations": PIT_LOOKBACK,
+                "current_excluded": True,
+                "formula": "2 * mean(prior_value <= current_value) - 1",
+                "tie_rule": "inclusive_less_or_equal",
+            },
+            "composite": "(U_OFI + U_PREMIUM) / 2",
+            "tail_threshold": {
+                "prior_abs_composites": TAIL_LOOKBACK,
+                "current_excluded": True,
+                "quantile": {
+                    "numerator": FIXED_QUANTILE_NUMERATOR,
+                    "denominator": FIXED_QUANTILE_DENOMINATOR,
+                },
+                "interpolation": "a[188] + 0.25 * (a[189] - a[188])",
+                "comparator": "abs(C) >= threshold",
+                "runtime_quantile_parameter": False,
+                "quantile_sweep": "forbidden",
+            },
+        },
+        "basket": {
+            "candidate": "any(symbol_tail_candidate)",
+            "maximum_events_per_epoch": 1,
+            "winner_rule": "largest_abs_C_then_SIGNAL_SYMBOLS_order",
+            "tie_order": list(SIGNAL_SYMBOLS),
+        },
+        "data_integrity": {
+            "complete_only": True,
+            "imputation": "forbidden",
+            "missing_or_gap": "not_evaluable_and_reported_not_false",
+            "required_evidence_fields": sorted(REQUIRED_EVIDENCE_FIELDS),
+            "publish": [
+                "gap_status",
+                "endpoint_host",
+                "endpoint_path",
+                "endpoint_version",
+                "schema_version",
+                "raw_payload_sha256",
+            ],
+        },
+        "exploration_isolation": {
+            "artifact": "dfc-retro-probe-v1",
+            "artifact_window": "2023-08-04T00:00:00Z/2026-08-03T00:00:00Z",
+            "label": "design_only_exploration",
+            "forbidden_uses": [
+                "v2_performance_claim",
+                "v2_promotion_evidence",
+                "v2_incidence_adjudication",
+            ],
+        },
+        "estimand": {
+            "name": "winner_conditional_next_4h_absolute_log_return_delta",
+            "outcome": "abs(log(close[e+4h] / close[e])) * 10000",
+            "candidate_term": "mean(outcome of the sole pre-fixed winner where candidate_any is true)",
+            "control_term": "mean(cross-sectional mean outcome of the three symbols where candidate_any is false)",
+            "estimate": "candidate_term - control_term",
+            "outcome_source": "complete 4h Binance USD-M Kline close",
+            "not_a_claim_of": [
+                "directional_alpha",
+                "trading_pnl",
+                "execution_readiness",
+            ],
+            "no_alternate_horizon_or_control": True,
+        },
+        "promotion_budget": {
+            "legacy_608_effective_outcomes_inherited": False,
+            "legacy_365_day_cap_inherited": False,
+            "historical_backtest": {
+                "runs": 1,
+                "warmup_start_utc": HISTORICAL_WARMUP_START_UTC,
+                "holdout_start_utc": HISTORICAL_HOLDOUT_START_UTC,
+                "holdout_end_utc": HISTORICAL_HOLDOUT_END_UTC,
+                "scheduled_epochs": HISTORICAL_HOLDOUT_SCHEDULED_EPOCHS,
+                "calendar_days": 180,
+                "purpose": "bounded_exact_feature_backtest",
+            },
+            "prospective_no_order_shadow": {
+                "runs": 1,
+                "calendar_days": PROSPECTIVE_SHADOW_DAYS,
+                "scheduled_epochs": PROSPECTIVE_SHADOW_SCHEDULED_EPOCHS,
+                "operational_t0": "unassigned_requires_new_pilot_manifest",
+            },
+            "orders": 0,
+            "binance_demo_contact": 0,
+            "account_assignments": 0,
+            "automatic_promotion": False,
+            "rationale": "A single six-month historical implementation check and four-week no-order pilot bound effort without tuning to a desired firing rate or inheriting the prior long-run budget.",
+        },
+        "binance_demo_boundary": {
+            "automatic_account_release": False,
+            "automatic_successor_assignment": False,
+            "required_before_any_future_assignment": [
+                "v2_historical_holdout_report",
+                "separate_operator_assignment_submission",
+                "fresh_read_only_account_wide_flatness_check",
+                "new_pilot_manifest_and_t0",
+            ],
+            "forbidden_reuse": [
+                "old_t0",
+                "old_correlation_id",
+                "old_ledger_identity",
+                "old_order_authority",
+            ],
+        },
+        "oi_collector_disposition": {
+            "recommendation": "stop_subject_to_operator_execution",
+            "execution_performed": False,
+            "rationale": "v2 is fixed to OFI plus premium only; retaining OI for this lane would require a different three-component contract and formal long-history source or prospective accumulation, which this proxy cannot shorten.",
+        },
+        "implementation": {
+            "module": "research_contracts.dfc_2c_4h_v2",
+            "algorithm_version": "dfc-2c-4h-v2-algorithm.v1",
+            "canonicalization": "research_contracts.canonical_hash",
+            "io": "none",
+        },
+    }
+
+
+def canonical_contract_hash() -> str:
+    """Return the canonical SHA-256 over the complete JSON-ready contract."""
+
+    return canonical_sha256(contract_as_machine_data())
+
+
+CANONICAL_HASH: Final = canonical_contract_hash()

--- a/tests/research_contracts/test_dfc_2c_4h_v2.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v2.py
@@ -1,0 +1,224 @@
+"""Contract tests for the isolated DFC-2C-4H-v2 registration."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import math
+from dataclasses import replace
+from datetime import datetime, timedelta
+
+import pytest
+
+from research_contracts import dfc_2c_4h_v2 as contract
+
+
+def _score_input(
+    symbol: str,
+    *,
+    integrity: contract.IntegrityState = contract.IntegrityState.COMPLETE,
+    history_size: int = contract.PIT_LOOKBACK,
+) -> contract.SymbolEpochInput:
+    return contract.SymbolEpochInput(
+        symbol=symbol,
+        integrity=integrity,
+        current_ofi=1.0,
+        current_premium_close=1.0,
+        prior_ofi=(0.0,) * history_size,
+        prior_premium_close=(0.0,) * history_size,
+        prior_abs_composite=(0.0,) * history_size,
+    )
+
+
+def _all_inputs() -> dict[str, contract.SymbolEpochInput]:
+    return {symbol: _score_input(symbol) for symbol in contract.SIGNAL_SYMBOLS}
+
+
+def test_contract_identity_canonical_hash_and_legacy_seal_preservation_are_fixed():
+    payload = contract.contract_as_machine_data()
+
+    assert contract.CONTRACT_ID == "DFC-2C-4H-v2"
+    assert contract.CANONICAL_HASH == (
+        "85673c730555816e3c2c6759a0489ed5543396e5ad588aadef4624198a74b99f"
+    )
+    assert contract.canonical_contract_hash() == contract.CANONICAL_HASH
+    assert json.loads(json.dumps(payload, sort_keys=True)) == payload
+    assert payload["predecessor_preservation"] == {
+        "old_identity": "dfc-4h",
+        "old_row_mutation": "forbidden",
+        "old_seal_mutation": "forbidden",
+        "old_supersede_or_hide": "forbidden",
+    }
+
+
+def test_features_are_exact_base_volume_ofi_and_complete_4h_premium_close():
+    assert contract.ofi_from_base_volumes(10.0, 6.0) == pytest.approx(math.log(1.5))
+    assert contract.premium_index_close_from_complete_4h(
+        0.00125, is_complete=True
+    ) == pytest.approx(0.00125)
+
+    assert list(inspect.signature(contract.ofi_from_base_volumes).parameters) == [
+        "total_base_volume",
+        "taker_buy_base_volume",
+    ]
+    with pytest.raises(ValueError, match="strictly positive"):
+        contract.ofi_from_base_volumes(10.0, 10.0)
+    with pytest.raises(ValueError, match="must be complete"):
+        contract.premium_index_close_from_complete_4h(0.00125, is_complete=False)
+
+    features = contract.contract_as_machine_data()["features"]
+    assert features["ofi"]["endpoint"]["path"] == "/fapi/v1/klines"
+    assert features["premium"]["value"] == "complete_4h_candle_close"
+    assert features["deprecated"] == [
+        "quote_volume_proxy",
+        "five_minute_premium_average",
+    ]
+
+
+def test_current_excluded_pit_ranks_and_fixed_linear_q75_are_exact():
+    history = tuple(float(index) for index in range(contract.PIT_LOOKBACK))
+
+    assert contract.pit_rank(100.0, history) == pytest.approx(
+        2.0 * (101.0 / 252.0) - 1.0
+    )
+    assert contract.tail_threshold_q75(history) == pytest.approx(188.25)
+    assert contract.tail_threshold_q75((0.0,) * 252) == 0.0
+
+    score = contract.score_symbol(_score_input("XRPUSDT"))
+    assert score.ofi_rank == 1.0
+    assert score.premium_rank == 1.0
+    assert score.composite == 1.0
+    assert score.threshold == 0.0
+    assert score.is_candidate is True
+
+
+def test_quantile_sweep_is_structurally_unavailable():
+    history = tuple(float(index) for index in range(contract.PIT_LOOKBACK))
+
+    assert list(inspect.signature(contract.tail_threshold_q75).parameters) == [
+        "prior_abs_composites"
+    ]
+    assert list(inspect.signature(contract.score_symbol).parameters) == ["inputs"]
+    with pytest.raises(TypeError):
+        contract.tail_threshold_q75(history, 0.70)  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        contract.score_symbol(_score_input("XRPUSDT"), quantile=0.70)  # type: ignore[call-arg]
+
+    threshold = contract.contract_as_machine_data()["score"]["tail_threshold"]
+    assert threshold["quantile"] == {"numerator": 3, "denominator": 4}
+    assert threshold["runtime_quantile_parameter"] is False
+    assert threshold["quantile_sweep"] == "forbidden"
+
+
+def test_basket_is_inner_aligned_any_candidate_with_one_pre_fixed_winner():
+    decision = contract.evaluate_basket(_all_inputs())
+
+    assert decision.state is contract.BasketEvaluationState.CANDIDATE
+    assert decision.candidate_any is True
+    assert decision.winner == "XRPUSDT"
+    assert len(decision.scores) == 3
+
+    missing_symbol = _all_inputs()
+    missing_symbol.pop("SOLUSDT")
+    with pytest.raises(ValueError, match="inner-aligned"):
+        contract.evaluate_basket(missing_symbol)
+
+    gapped = _all_inputs()
+    gapped["DOGEUSDT"] = replace(
+        gapped["DOGEUSDT"], integrity=contract.IntegrityState.GAP
+    )
+    no_evaluation = contract.evaluate_basket(gapped)
+    assert no_evaluation.state is contract.BasketEvaluationState.NOT_EVALUABLE_INTEGRITY
+    assert no_evaluation.candidate_any is None
+    assert no_evaluation.winner is None
+
+
+def test_reference_not_ready_never_becomes_a_false_candidate():
+    inputs = _all_inputs()
+    inputs["SOLUSDT"] = _score_input("SOLUSDT", history_size=251)
+
+    decision = contract.evaluate_basket(inputs)
+    assert decision.state is contract.BasketEvaluationState.REFERENCE_NOT_READY
+    assert decision.candidate_any is None
+    assert decision.winner is None
+
+
+def test_evidence_manifest_requires_complete_gap_free_versioned_raw_provenance():
+    evidence = {
+        "source_id": "binance_usdm.klines_4h",
+        "endpoint_host": "fapi.binance.com",
+        "endpoint_path": "/fapi/v1/klines",
+        "endpoint_version": "v1",
+        "symbol": "XRPUSDT",
+        "interval": "4h",
+        "epoch_start_utc": "2021-05-02T00:00:00Z",
+        "epoch_end_utc": "2021-05-02T04:00:00Z",
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": "a" * 64,
+        "schema_version": "binance-usdm-kline.v1",
+    }
+
+    contract.validate_evidence_manifest(evidence)
+    with pytest.raises(ValueError, match="gapped"):
+        contract.validate_evidence_manifest({**evidence, "gap_status": "detected"})
+    with pytest.raises(ValueError, match="raw_payload_sha256"):
+        contract.validate_evidence_manifest({**evidence, "raw_payload_sha256": "BAD"})
+
+
+def test_exploration_isolation_budget_demo_boundary_and_oi_disposition_are_explicit():
+    payload = contract.contract_as_machine_data()
+
+    assert payload["exploration_isolation"]["label"] == "design_only_exploration"
+    assert payload["exploration_isolation"]["forbidden_uses"] == [
+        "v2_performance_claim",
+        "v2_promotion_evidence",
+        "v2_incidence_adjudication",
+    ]
+    budget = payload["promotion_budget"]
+    assert budget["legacy_608_effective_outcomes_inherited"] is False
+    assert budget["legacy_365_day_cap_inherited"] is False
+    assert budget["historical_backtest"]["calendar_days"] == 180
+    assert budget["prospective_no_order_shadow"]["calendar_days"] == 28
+    warmup_start = datetime.fromisoformat(
+        contract.HISTORICAL_WARMUP_START_UTC.replace("Z", "+00:00")
+    )
+    holdout_start = datetime.fromisoformat(
+        contract.HISTORICAL_HOLDOUT_START_UTC.replace("Z", "+00:00")
+    )
+    holdout_end = datetime.fromisoformat(
+        contract.HISTORICAL_HOLDOUT_END_UTC.replace("Z", "+00:00")
+    )
+    assert holdout_start - warmup_start >= timedelta(days=84)
+    assert (holdout_end - holdout_start).days == 180
+    assert (holdout_end - holdout_start).total_seconds() / (
+        4 * 60 * 60
+    ) == contract.HISTORICAL_HOLDOUT_SCHEDULED_EPOCHS
+    assert (
+        contract.PROSPECTIVE_SHADOW_DAYS * 6
+        == contract.PROSPECTIVE_SHADOW_SCHEDULED_EPOCHS
+    )
+    assert budget["orders"] == 0
+    assert budget["binance_demo_contact"] == 0
+    assert budget["account_assignments"] == 0
+    assert budget["automatic_promotion"] is False
+    assert payload["binance_demo_boundary"]["automatic_successor_assignment"] is False
+    assert payload["oi_collector_disposition"] == {
+        "recommendation": "stop_subject_to_operator_execution",
+        "execution_performed": False,
+        "rationale": "v2 is fixed to OFI plus premium only; retaining OI for this lane would require a different three-component contract and formal long-history source or prospective accumulation, which this proxy cannot shorten.",
+    }
+
+
+def test_contract_is_offline_and_does_not_import_runtime_or_transport_code():
+    source = inspect.getsource(contract)
+    for forbidden in (
+        "import app",
+        "from app",
+        "httpx",
+        "requests",
+        "socket",
+        "sqlite",
+        "subprocess",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
## Summary
- add an immutable, offline-only DFC-2C-4H-v2 contract with exact base-volume OFI, complete 4h premium close, current-excluded PIT scoring, and a fixed Q0.75 API
- add a Korean registration document covering exploration isolation, a bounded non-inherited budget, Demo non-succession, and the OI stop recommendation
- add regression coverage for structural quantile-sweep blocking, inner-aligned one-winner basket selection, and provenance gates

## Validation
- uv run pytest tests/research_contracts -q -ra
- uv run ruff check research_contracts tests/research_contracts
- uv run ruff format --check research_contracts tests/research_contracts

No collector run, Binance Demo contact, account assignment, or order was performed.