### PR TITLE
feat(toss): add Phase 2 staging corpus

### DIFF
--- a/alembic/versions/20260804_toss_phase2_corpus.py
+++ b/alembic/versions/20260804_toss_phase2_corpus.py
@@ -86,35 +86,12 @@ def _comment_cagg(view_name: str) -> None:
 
 
 def _drop_cagg(view_name: str) -> None:
-    """Drop only the view representation actually created by this migration."""
+    """Drop a Timescale continuous aggregate through its required API."""
 
-    op.execute(
-        f"""
-        DO $$
-        BEGIN
-            IF EXISTS (
-                SELECT 1
-                FROM pg_class AS c
-                JOIN pg_namespace AS n ON n.oid = c.relnamespace
-                WHERE n.nspname = 'research'
-                  AND c.relname = '{view_name}'
-                  AND c.relkind = 'm'
-            ) THEN
-                EXECUTE 'DROP MATERIALIZED VIEW research.{view_name}';
-            ELSIF EXISTS (
-                SELECT 1
-                FROM pg_class AS c
-                JOIN pg_namespace AS n ON n.oid = c.relnamespace
-                WHERE n.nspname = 'research'
-                  AND c.relname = '{view_name}'
-                  AND c.relkind = 'v'
-            ) THEN
-                EXECUTE 'DROP VIEW research.{view_name}';
-            END IF;
-        END
-        $$
-        """
-    )
+    # Continuous aggregates can appear as ``relkind='v'`` in the PostgreSQL
+    # catalog, but Timescale still requires the MATERIALIZED VIEW drop command.
+    # The migration creates no ordinary view with these names.
+    op.execute(f"DROP MATERIALIZED VIEW IF EXISTS research.{view_name}")
 
 
 def upgrade() -> None:
@@ -185,6 +162,18 @@ def upgrade() -> None:
         DO $$
         BEGIN
             IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_extension
+                    WHERE extname = 'timescaledb'
+                      AND string_to_array(
+                          regexp_replace(extversion, '[^0-9.]', '', 'g'), '.'
+                      )::INTEGER[] >= ARRAY[2, 8, 0]
+                ) THEN
+                    RAISE EXCEPTION
+                        'TimescaleDB 2.8.0 or newer is required for timezone-aware '
+                        'time_bucket continuous aggregates';
+                END IF;
                 PERFORM create_hypertable('research.{TABLE_NAME}', 'time_utc');
                 PERFORM set_chunk_time_interval(
                     'research.{TABLE_NAME}', INTERVAL '7 days'

--- a/alembic/versions/20260804_toss_phase2_corpus.py
+++ b/alembic/versions/20260804_toss_phase2_corpus.py
@@ -38,6 +38,85 @@ def _quoted(values: Sequence[str]) -> str:
     return ", ".join(f"'{value}'" for value in values)
 
 
+def _comment_cagg(view_name: str) -> None:
+    """Comment a Timescale cagg without assuming its PostgreSQL relkind.
+
+    Timescale exposes continuous aggregates as ``relkind='v'`` on the target
+    production version, while a plain PostgreSQL materialized view is ``'m'``.
+    The migration must remain additive under either representation.
+    """
+
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_class AS c
+                JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'research'
+                  AND c.relname = '{view_name}'
+                  AND c.relkind = 'm'
+            ) THEN
+                EXECUTE $sql$
+                    COMMENT ON MATERIALIZED VIEW research.{view_name} IS
+                    'Derived from research.{TABLE_NAME}; preserves time-based session '
+                    'labels and padding visibility. value remains synthetic close*volume; '
+                    'no cagg refresh policy is installed.'
+                $sql$;
+            ELSIF EXISTS (
+                SELECT 1
+                FROM pg_class AS c
+                JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'research'
+                  AND c.relname = '{view_name}'
+                  AND c.relkind = 'v'
+            ) THEN
+                EXECUTE $sql$
+                    COMMENT ON VIEW research.{view_name} IS
+                    'Derived from research.{TABLE_NAME}; preserves time-based session '
+                    'labels and padding visibility. value remains synthetic close*volume; '
+                    'no cagg refresh policy is installed.'
+                $sql$;
+            END IF;
+        END
+        $$
+        """
+    )
+
+
+def _drop_cagg(view_name: str) -> None:
+    """Drop only the view representation actually created by this migration."""
+
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_class AS c
+                JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'research'
+                  AND c.relname = '{view_name}'
+                  AND c.relkind = 'm'
+            ) THEN
+                EXECUTE 'DROP MATERIALIZED VIEW research.{view_name}';
+            ELSIF EXISTS (
+                SELECT 1
+                FROM pg_class AS c
+                JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'research'
+                  AND c.relname = '{view_name}'
+                  AND c.relkind = 'v'
+            ) THEN
+                EXECUTE 'DROP VIEW research.{view_name}';
+            END IF;
+        END
+        $$
+        """
+    )
+
+
 def upgrade() -> None:
     # The research schema already exists.  Do not alter the earlier KRX-only
     # table or any public relation; this table is the physical separation.
@@ -169,22 +248,7 @@ def upgrade() -> None:
             $$
             """
         )
-        op.execute(
-            f"""
-            DO $$
-            BEGIN
-                IF to_regclass('research.{view_name}') IS NOT NULL THEN
-                    EXECUTE $sql$
-                        COMMENT ON MATERIALIZED VIEW research.{view_name} IS
-                        'Derived from research.{TABLE_NAME}; preserves time-based session '
-                        'labels and padding visibility. value remains synthetic close*volume; '
-                        'no cagg refresh policy is installed.'
-                    $sql$;
-                END IF;
-            END
-            $$
-            """
-        )
+        _comment_cagg(view_name)
 
     # The approved backfill role is explicitly allowlisted for only the new raw
     # table.  This fresh table has no serial/identity column, hence no sequence
@@ -215,5 +279,5 @@ def downgrade() -> None:
     # Only objects created above are removed.  No existing table, cagg, role,
     # or default privilege is altered by either direction of this migration.
     for view_name, _ in CAGG_SPECS:
-        op.execute(f"DROP MATERIALIZED VIEW IF EXISTS research.{view_name}")
+        _drop_cagg(view_name)
     op.execute(f"DROP TABLE IF EXISTS research.{TABLE_NAME}")

--- a/alembic/versions/20260804_toss_phase2_corpus.py
+++ b/alembic/versions/20260804_toss_phase2_corpus.py
@@ -14,7 +14,9 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "20260804_toss_phase2"
-down_revision: str | Sequence[str] | None = "20260803_research_kr_candles"
+# Rebased after #1782's merge revision advanced the sole Alembic head.  This
+# remains additive: the Toss research objects do not alter Alpaca's migration.
+down_revision: str | Sequence[str] | None = "20260804_alpaca_clean_account"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/20260804_toss_phase2_corpus.py
+++ b/alembic/versions/20260804_toss_phase2_corpus.py
@@ -21,7 +21,10 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 TABLE_NAME = "kr_candles_1m_toss"
-SESSION_SEGMENTS = ("NXT_PRE", "KRX_REGULAR", "NXT_POST", "UNKNOWN")
+# A Toss row whose clock-time segment cannot be proven is rejected by the
+# collector/loader before it reaches this table.  ``UNKNOWN`` is deliberately
+# absent: storing it would turn a fail-closed classification error into data.
+SESSION_SEGMENTS = ("NXT_PRE", "KRX_REGULAR", "NXT_POST")
 VALUE_SEMANTICS = "CLOSE_X_VOLUME_SYNTHETIC"
 CAGG_SPECS = (
     ("kr_candles_5m_toss", "5 minutes"),

--- a/alembic/versions/20260804_toss_phase2_corpus.py
+++ b/alembic/versions/20260804_toss_phase2_corpus.py
@@ -1,0 +1,214 @@
+"""Toss combined-KRX/NXT research corpus (additive, staging-load target only).
+
+Toss may return a combined KRX+NXT minute product.  It is therefore stored in
+its own physical table rather than being mixed with the KRX-only research
+shard.  ``session_segment`` is a KST clock-time label, not a venue claim; this
+migration intentionally defines no ``venue`` column.
+
+The migration creates schema objects only.  It neither reads from nor writes
+to the staging Parquet corpus, and it does not promote any pre-NXT row.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260804_toss_phase2"
+down_revision: str | Sequence[str] | None = "20260803_research_kr_candles"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE_NAME = "kr_candles_1m_toss"
+SESSION_SEGMENTS = ("NXT_PRE", "KRX_REGULAR", "NXT_POST", "UNKNOWN")
+VALUE_SEMANTICS = "CLOSE_X_VOLUME_SYNTHETIC"
+CAGG_SPECS = (
+    ("kr_candles_5m_toss", "5 minutes"),
+    ("kr_candles_15m_toss", "15 minutes"),
+    ("kr_candles_30m_toss", "30 minutes"),
+    ("kr_candles_1h_toss", "1 hour"),
+)
+
+
+def _quoted(values: Sequence[str]) -> str:
+    return ", ".join(f"'{value}'" for value in values)
+
+
+def upgrade() -> None:
+    # The research schema already exists.  Do not alter the earlier KRX-only
+    # table or any public relation; this table is the physical separation.
+    op.execute(
+        f"""
+        CREATE TABLE research.{TABLE_NAME} (
+            time_utc TIMESTAMPTZ NOT NULL,
+            session_date_kst DATE NOT NULL,
+            symbol TEXT NOT NULL,
+            session_segment TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'TOSS',
+            open NUMERIC NOT NULL,
+            high NUMERIC NOT NULL,
+            low NUMERIC NOT NULL,
+            close NUMERIC NOT NULL,
+            volume NUMERIC NOT NULL,
+            value NUMERIC NOT NULL,
+            value_semantics TEXT NOT NULL DEFAULT '{VALUE_SEMANTICS}',
+            is_padding BOOLEAN NOT NULL,
+            pre_nxt BOOLEAN,
+            retrieved_at TIMESTAMPTZ NOT NULL,
+            batch_id TEXT NOT NULL,
+            CONSTRAINT ck_research_{TABLE_NAME}_session_segment
+                CHECK (session_segment IN ({_quoted(SESSION_SEGMENTS)})),
+            CONSTRAINT ck_research_{TABLE_NAME}_source
+                CHECK (source = 'TOSS'),
+            CONSTRAINT ck_research_{TABLE_NAME}_value_semantics
+                CHECK (value_semantics = '{VALUE_SEMANTICS}'),
+            CONSTRAINT uq_research_{TABLE_NAME}_time_symbol
+                UNIQUE (time_utc, symbol)
+        )
+        """
+    )
+    op.execute(
+        f"""
+        COMMENT ON TABLE research.{TABLE_NAME} IS
+        'Toss combined KRX+NXT minute corpus. This table deliberately has no '
+        'venue column: session_segment is a KST time-of-day label, not a trade-'
+        'venue assertion. Toss 15:30 bars omit closing-auction volume, so daily '
+        'volume/value aggregation undercounts. is_padding=true is a volume-zero '
+        'provider placeholder and must not be counted as a coverage gap. value is '
+        'synthetic close*volume ({VALUE_SEMANTICS}), not exchange-reported trade '
+        'value. pre_nxt NULL means UNKNOWN until an exact sourced NXT launch date '
+        'and boundary validation exist; this migration performs no promotion. '
+        'Staging-to-DB loading requires a separate approved operation.'
+        """
+    )
+    op.execute(
+        f"CREATE INDEX ix_research_{TABLE_NAME}_symbol_time_desc "
+        f"ON research.{TABLE_NAME} (symbol, time_utc DESC)"
+    )
+    op.execute(
+        f"CREATE INDEX ix_research_{TABLE_NAME}_session_date "
+        f"ON research.{TABLE_NAME} (session_date_kst, symbol)"
+    )
+    op.execute(
+        f"CREATE INDEX ix_research_{TABLE_NAME}_batch "
+        f"ON research.{TABLE_NAME} (batch_id)"
+    )
+
+    # Match the existing research-candle fallback: plain PostgreSQL remains
+    # usable in CI, while production TimescaleDB gets the dedicated hypertable
+    # and four cagg objects.  No refresh policy is registered here.
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+                PERFORM create_hypertable('research.{TABLE_NAME}', 'time_utc');
+                PERFORM set_chunk_time_interval(
+                    'research.{TABLE_NAME}', INTERVAL '7 days'
+                );
+            ELSE
+                RAISE WARNING
+                    'timescaledb absent: research.{TABLE_NAME} created as a plain '
+                    'table; hypertable and continuous aggregates skipped';
+            END IF;
+        END
+        $$
+        """
+    )
+
+    for view_name, interval in CAGG_SPECS:
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+                    EXECUTE $sql$
+                        CREATE MATERIALIZED VIEW research.{view_name}
+                        WITH (
+                            timescaledb.continuous,
+                            timescaledb.materialized_only = false
+                        )
+                        AS
+                        SELECT
+                            time_bucket(
+                                INTERVAL '{interval}', time_utc, 'Asia/Seoul'
+                            ) AS bucket,
+                            session_date_kst,
+                            symbol,
+                            session_segment,
+                            source,
+                            value_semantics,
+                            pre_nxt,
+                            FIRST(open, time_utc) AS open,
+                            MAX(high) AS high,
+                            MIN(low) AS low,
+                            LAST(close, time_utc) AS close,
+                            SUM(volume) AS volume,
+                            SUM(value) AS value,
+                            COUNT(*) AS bar_count,
+                            BOOL_AND(is_padding) AS is_padding,
+                            SUM(CASE WHEN is_padding THEN 1 ELSE 0 END)
+                                AS padding_bar_count
+                        FROM research.{TABLE_NAME}
+                        GROUP BY
+                            bucket,
+                            session_date_kst,
+                            symbol,
+                            session_segment,
+                            source,
+                            value_semantics,
+                            pre_nxt
+                        WITH NO DATA
+                    $sql$;
+                END IF;
+            END
+            $$
+            """
+        )
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF to_regclass('research.{view_name}') IS NOT NULL THEN
+                    EXECUTE $sql$
+                        COMMENT ON MATERIALIZED VIEW research.{view_name} IS
+                        'Derived from research.{TABLE_NAME}; preserves time-based session '
+                        'labels and padding visibility. value remains synthetic close*volume; '
+                        'no cagg refresh policy is installed.'
+                    $sql$;
+                END IF;
+            END
+            $$
+            """
+        )
+
+    # The approved backfill role is explicitly allowlisted for only the new raw
+    # table.  This fresh table has no serial/identity column, hence no sequence
+    # exists to grant; granting an unrelated sequence would violate least
+    # privilege.  The conditional keeps the migration chain runnable in CI
+    # databases where the operator-owned login role is intentionally absent.
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_roles WHERE rolname = 'auto_trader_kr_backfill'
+            ) THEN
+                EXECUTE
+                    'GRANT SELECT, INSERT ON TABLE research.{TABLE_NAME} '
+                    'TO auto_trader_kr_backfill';
+            ELSE
+                RAISE NOTICE
+                    'auto_trader_kr_backfill absent; no grant applied in this database';
+            END IF;
+        END
+        $$
+        """
+    )
+
+
+def downgrade() -> None:
+    # Only objects created above are removed.  No existing table, cagg, role,
+    # or default privilege is altered by either direction of this migration.
+    for view_name, _ in CAGG_SPECS:
+        op.execute(f"DROP MATERIALIZED VIEW IF EXISTS research.{view_name}")
+    op.execute(f"DROP TABLE IF EXISTS research.{TABLE_NAME}")

--- a/alembic/versions/20260805_merge_toss_phase2_and_kis_mock_runner_heads.py
+++ b/alembic/versions/20260805_merge_toss_phase2_and_kis_mock_runner_heads.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-revision: str = "20260805_merge_toss_phase2_kis_mock_runner"
+revision: str = "20260805_toss_merge"
 down_revision: str | Sequence[str] | None = (
     "20260804_toss_phase2",
     "20260805_kis_mock_runner",

--- a/alembic/versions/20260805_merge_toss_phase2_and_kis_mock_runner_heads.py
+++ b/alembic/versions/20260805_merge_toss_phase2_and_kis_mock_runner_heads.py
@@ -1,0 +1,26 @@
+"""Merge the independent Toss corpus and KR-B0 mock-runner migration heads.
+
+No schema object is created or changed here.  The merge preserves the already
+applied Toss history instead of rewriting its parent after a newer main-branch
+migration landed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+revision: str = "20260805_merge_toss_phase2_kis_mock_runner"
+down_revision: str | Sequence[str] | None = (
+    "20260804_toss_phase2",
+    "20260805_kis_mock_runner",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Join histories only; each parent owns its own additive schema changes."""
+
+
+def downgrade() -> None:
+    """Split histories only; no schema object belongs to this merge revision."""

--- a/app/services/brokers/toss/auth.py
+++ b/app/services/brokers/toss/auth.py
@@ -143,6 +143,17 @@ class TossOAuthTokenManager:
             force_reissue=force_reissue, failed_token=failed_token
         )
 
+    async def get_cached_access_token(self) -> str | None:
+        """Return a currently valid shared token without issuing a new one.
+
+        Read-only bulk consumers that share the live OAuth client can use this
+        narrow path when their operating contract prohibits them from changing
+        the active token.  A cache miss is deliberately surfaced as ``None``;
+        the caller, rather than this manager, decides whether it may wait for a
+        production peer to refresh the token or must stop.
+        """
+        return await self._get_cached_token()
+
     async def _get_cached_token(self) -> str | None:
         redis_client = await _get_redis_client()
         raw = await redis_client.get(self.token_key)

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -181,7 +181,19 @@ class TossReadClient:
                     force_reissue=True, failed_token=token
                 )
                 headers["Authorization"] = f"Bearer {token}"
-                retry, _rate_limit_headers = await send()
+                try:
+                    retry, _rate_limit_headers = await send()
+                except httpx.HTTPError as retry_exc:
+                    await self._publish_error(
+                        status_code=None,
+                        error_type=type(retry_exc).__name__,
+                    )
+                    raise
+                if retry.status_code >= 400:
+                    await self._publish_error(
+                        status_code=retry.status_code,
+                        error_type="http_response",
+                    )
                 return parse_toss_response(retry)
             raise
 

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -32,7 +32,9 @@ from app.services.brokers.toss.health import publish_toss_api_error
 from app.services.brokers.toss.rate_limiter import (
     TossApiGroup,
     TossRateLimiter,
+    TossRateLimitHeaders,
     get_shared_rate_limiter,
+    parse_rate_limit_headers,
     retry_delay_seconds,
 )
 from app.services.brokers.toss.transport import DEFAULT_TOSS_BASE_URL, build_toss_client
@@ -40,6 +42,7 @@ from app.services.brokers.toss.transport import DEFAULT_TOSS_BASE_URL, build_tos
 _TOKEN_CODES = {"invalid-token", "expired-token"}
 _GET_REISSUABLE_NON_JSON_STATUSES = {403}
 PreSendHook = Callable[[], Awaitable[None]]
+ResponseObserver = Callable[[TossApiGroup, int, TossRateLimitHeaders], None]
 
 
 def _should_retry_get_non_json_auth_error(
@@ -63,6 +66,8 @@ class TossReadClient:
         rate_limiter: TossRateLimiter | None = None,
         retry_on_429: bool = True,
         retry_auth_reissue: bool = True,
+        response_observer: ResponseObserver | None = None,
+        publish_error_signals: bool = True,
     ) -> None:
         self._token_manager = token_manager
         self._account_seq = account_seq
@@ -74,6 +79,8 @@ class TossReadClient:
         # OAuth token.
         self._retry_on_429 = retry_on_429
         self._retry_auth_reissue = retry_auth_reissue
+        self._response_observer = response_observer
+        self._publish_error_signals = publish_error_signals
 
     @classmethod
     def from_settings(cls, settings_obj: Any = settings) -> TossReadClient:
@@ -93,6 +100,18 @@ class TossReadClient:
     async def aclose(self) -> None:
         await self._client.aclose()
 
+    async def _publish_error(
+        self,
+        *,
+        status_code: int | None,
+        error_type: str,
+    ) -> None:
+        if self._publish_error_signals:
+            await publish_toss_api_error(
+                status_code=status_code,
+                error_type=error_type,
+            )
+
     async def _request(
         self,
         method: str,
@@ -110,23 +129,27 @@ class TossReadClient:
         if account_required:
             headers["X-Tossinvest-Account"] = str(await self._resolve_account_seq())
 
-        async def send() -> httpx.Response:
+        async def send() -> tuple[httpx.Response, TossRateLimitHeaders]:
             if pre_send_hook is not None:
                 await pre_send_hook()
-            return await self._client.request(
+            response = await self._client.request(
                 method, path, params=params, json=json, headers=headers
             )
+            rate_limit_headers = parse_rate_limit_headers(response.headers)
+            if self._response_observer is not None:
+                self._response_observer(group, response.status_code, rate_limit_headers)
+            return response, rate_limit_headers
 
         try:
-            response = await send()
+            response, _rate_limit_headers = await send()
         except httpx.HTTPError as exc:
-            await publish_toss_api_error(
+            await self._publish_error(
                 status_code=None,
                 error_type=type(exc).__name__,
             )
             raise
         if response.status_code >= 400:
-            await publish_toss_api_error(
+            await self._publish_error(
                 status_code=response.status_code,
                 error_type="http_response",
             )
@@ -135,15 +158,15 @@ class TossReadClient:
                 retry_delay_seconds(response.headers.get("Retry-After"), attempt=0)
             )
             try:
-                response = await send()
+                response, _rate_limit_headers = await send()
             except httpx.HTTPError as exc:
-                await publish_toss_api_error(
+                await self._publish_error(
                     status_code=None,
                     error_type=type(exc).__name__,
                 )
                 raise
             if response.status_code >= 400:
-                await publish_toss_api_error(
+                await self._publish_error(
                     status_code=response.status_code,
                     error_type="http_response",
                 )
@@ -158,7 +181,7 @@ class TossReadClient:
                     force_reissue=True, failed_token=token
                 )
                 headers["Authorization"] = f"Bearer {token}"
-                retry = await send()
+                retry, _rate_limit_headers = await send()
                 return parse_toss_response(retry)
             raise
 

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -28,6 +28,7 @@ from app.services.brokers.toss.dto import (
     parse_warnings,
 )
 from app.services.brokers.toss.errors import TossApiResponseError, parse_toss_response
+from app.services.brokers.toss.health import publish_toss_api_error
 from app.services.brokers.toss.rate_limiter import (
     TossApiGroup,
     TossRateLimiter,
@@ -60,11 +61,19 @@ class TossReadClient:
         base_url: str = DEFAULT_TOSS_BASE_URL,
         transport: httpx.AsyncBaseTransport | None = None,
         rate_limiter: TossRateLimiter | None = None,
+        retry_on_429: bool = True,
+        retry_auth_reissue: bool = True,
     ) -> None:
         self._token_manager = token_manager
         self._account_seq = account_seq
         self._client = build_toss_client(base_url=base_url, transport=transport)
         self._rate_limiter = rate_limiter or TossRateLimiter()
+        # The default preserves the established live-client behaviour.  A
+        # separately approved bulk reader can disable both retries so one
+        # upstream failure stops only that reader and never churns the shared
+        # OAuth token.
+        self._retry_on_429 = retry_on_429
+        self._retry_auth_reissue = retry_auth_reissue
 
     @classmethod
     def from_settings(cls, settings_obj: Any = settings) -> TossReadClient:
@@ -108,16 +117,40 @@ class TossReadClient:
                 method, path, params=params, json=json, headers=headers
             )
 
-        response = await send()
-        if response.status_code == 429:
+        try:
+            response = await send()
+        except httpx.HTTPError as exc:
+            await publish_toss_api_error(
+                status_code=None,
+                error_type=type(exc).__name__,
+            )
+            raise
+        if response.status_code >= 400:
+            await publish_toss_api_error(
+                status_code=response.status_code,
+                error_type="http_response",
+            )
+        if response.status_code == 429 and self._retry_on_429:
             await asyncio.sleep(
                 retry_delay_seconds(response.headers.get("Retry-After"), attempt=0)
             )
-            response = await send()
+            try:
+                response = await send()
+            except httpx.HTTPError as exc:
+                await publish_toss_api_error(
+                    status_code=None,
+                    error_type=type(exc).__name__,
+                )
+                raise
+            if response.status_code >= 400:
+                await publish_toss_api_error(
+                    status_code=response.status_code,
+                    error_type="http_response",
+                )
         try:
             return parse_toss_response(response)
         except TossApiResponseError as exc:
-            if (
+            if self._retry_auth_reissue and (
                 exc.envelope.code in _TOKEN_CODES
                 or _should_retry_get_non_json_auth_error(method, exc)
             ):

--- a/app/services/brokers/toss/health.py
+++ b/app/services/brokers/toss/health.py
@@ -1,0 +1,102 @@
+"""Best-effort shared visibility for Toss API failures.
+
+The production Toss callers keep their existing response semantics.  They only
+publish a small, secret-free marker after an upstream error so a concurrent,
+optional bulk reader can stop itself rather than adding load while the shared
+Toss surface is unhealthy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from app.services.brokers.toss.auth import _get_redis_client
+
+_ERROR_EVENT_KEY = "toss:health:last_error"
+_ERROR_SEQUENCE_KEY = "toss:health:error_sequence"
+_ERROR_TTL_SECONDS = 60 * 60
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TossApiErrorSignal:
+    """A redacted marker for a Toss response or transport failure."""
+
+    sequence: int
+    observed_at: str
+    status_code: int | None
+    error_type: str
+    error_code: str | None
+
+
+def _encode(signal: TossApiErrorSignal) -> str:
+    return json.dumps(
+        {
+            "sequence": signal.sequence,
+            "observed_at": signal.observed_at,
+            "status_code": signal.status_code,
+            "error_type": signal.error_type,
+            "error_code": signal.error_code,
+        },
+        separators=(",", ":"),
+    )
+
+
+def _decode(raw: str | bytes | None) -> TossApiErrorSignal | None:
+    if not raw:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    try:
+        payload: Any = json.loads(raw)
+        return TossApiErrorSignal(
+            sequence=int(payload["sequence"]),
+            observed_at=str(payload["observed_at"]),
+            status_code=(
+                int(payload["status_code"])
+                if payload.get("status_code") is not None
+                else None
+            ),
+            error_type=str(payload["error_type"]),
+            error_code=(
+                str(payload["error_code"])
+                if payload.get("error_code") is not None
+                else None
+            ),
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+async def publish_toss_api_error(
+    *,
+    status_code: int | None,
+    error_type: str,
+    error_code: str | None = None,
+) -> None:
+    """Publish a redacted error marker without changing the caller outcome."""
+    try:
+        redis_client = await _get_redis_client()
+        sequence = int(await redis_client.incr(_ERROR_SEQUENCE_KEY))
+        signal = TossApiErrorSignal(
+            sequence=sequence,
+            observed_at=datetime.now(UTC).isoformat(),
+            status_code=status_code,
+            error_type=error_type,
+            error_code=error_code,
+        )
+        await redis_client.set(_ERROR_EVENT_KEY, _encode(signal), ex=_ERROR_TTL_SECONDS)
+    except Exception:  # noqa: BLE001
+        # Health publishing must never hide or replace the original API error.
+        logger.debug("best-effort Toss health marker publish failed", exc_info=True)
+
+
+async def read_toss_api_error_signal() -> TossApiErrorSignal | None:
+    """Read the latest shared error marker for a self-stopping bulk reader."""
+    redis_client = await _get_redis_client()
+    return _decode(await redis_client.get(_ERROR_EVENT_KEY))

--- a/app/services/brokers/toss/rate_limiter.py
+++ b/app/services/brokers/toss/rate_limiter.py
@@ -4,6 +4,8 @@ import asyncio
 import random
 import time
 from collections import deque
+from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from zoneinfo import ZoneInfo
@@ -34,6 +36,67 @@ _BASE_LIMITS: dict[TossApiGroup, int] = {
     TossApiGroup.ORDER_HISTORY: 5,
     TossApiGroup.ORDER_INFO: 6,
 }
+
+
+@dataclass(frozen=True)
+class TossRateLimitHeaders:
+    """Rate-limit metadata supplied by the Toss Open API response.
+
+    The provider may change limits without notice.  Consumers that need a
+    current cap must use ``limit`` from this response snapshot, not
+    ``_BASE_LIMITS`` (which remains only a local, process-level guard for the
+    established runtime clients).
+    """
+
+    limit: int | None
+    remaining: int | None
+    reset_seconds: float | None
+    retry_after_seconds: float | None
+
+
+def _header_value(headers: Mapping[str, str], name: str) -> str | None:
+    """Read a header case-insensitively for both httpx and plain test mappings."""
+
+    expected = name.casefold()
+    for key, value in headers.items():
+        if key.casefold() == expected:
+            return value
+    return None
+
+
+def _positive_int(value: str | None) -> int | None:
+    try:
+        parsed = int(value) if value is not None else None
+    except ValueError:
+        return None
+    return parsed if parsed is not None and parsed > 0 else None
+
+
+def _nonnegative_int(value: str | None) -> int | None:
+    try:
+        parsed = int(value) if value is not None else None
+    except ValueError:
+        return None
+    return parsed if parsed is not None and parsed >= 0 else None
+
+
+def _nonnegative_float(value: str | None) -> float | None:
+    try:
+        parsed = float(value) if value is not None else None
+    except ValueError:
+        return None
+    return parsed if parsed is not None and parsed >= 0.0 else None
+
+
+def parse_rate_limit_headers(headers: Mapping[str, str]) -> TossRateLimitHeaders:
+    """Parse the documented Toss rate headers without inventing a fallback cap."""
+
+    return TossRateLimitHeaders(
+        limit=_positive_int(_header_value(headers, "X-RateLimit-Limit")),
+        remaining=_nonnegative_int(_header_value(headers, "X-RateLimit-Remaining")),
+        reset_seconds=_nonnegative_float(_header_value(headers, "X-RateLimit-Reset")),
+        retry_after_seconds=_nonnegative_float(_header_value(headers, "Retry-After")),
+    )
 
 
 class TossRateLimiter:

--- a/research/toss_phase2/README.md
+++ b/research/toss_phase2/README.md
@@ -23,4 +23,25 @@ Consumer rules:
   proposal, but this collector performs no promotion.
 
 The collector uses a shared cached Toss token only. It cannot issue or force
-reissue OAuth, and it stops itself on a new shared Toss 401/429/upstream error.
+reissue OAuth.
+
+## Shared chart-budget control
+
+`MARKET_DATA_CHART` is a client × API-group budget shared with the production
+Toss-first chart reader. The Phase-2 collector therefore does not treat a
+documented chart cap as a source constant:
+
+- The first chart response must expose `X-RateLimit-Limit`; that header is the
+  active cap. A missing cap fails closed before a second page request.
+- During 09:00–20:00 KST, the collector targets at most
+  `min(2 TPS, discovered-cap − 3 TPS)`, preserving three TPS for production
+  chart readers. If the provider's cap cannot preserve that reservation, the
+  collector stops before it consumes another page budget.
+- After 20:00 KST it may use 3–4 TPS only while headers remain healthy.
+  `X-RateLimit-Remaining` below 40% triggers a Reset-window recovery pause;
+  `X-RateLimit-Reset` is interpreted as seconds to one-token replenishment.
+- A collector 429 honors `Retry-After` and combines it with exponential
+  backoff plus jitter (1 → 2 → 4 seconds …). It does not immediately stop;
+  only five consecutive chart 429s stop the collector. New shared 429 markers
+  are likewise non-fatal, while 401 and other upstream errors remain
+  fail-closed.

--- a/research/toss_phase2/README.md
+++ b/research/toss_phase2/README.md
@@ -1,0 +1,26 @@
+# Toss Phase 2 combined-KRX/NXT staging
+
+This collector creates an append-only **STAGING ONLY — NOT A BACKTEST INPUT**
+Parquet corpus for Toss 1-minute candles. It does not connect to PostgreSQL and
+does not load data into any table.
+
+The product is physically separate because Toss may combine KRX and NXT bars
+for NXT-eligible symbols. `session_segment` is only a KST time-of-day label
+(`NXT_PRE`, `KRX_REGULAR`, `NXT_POST`, or `UNKNOWN`); it is never a trade-venue
+claim and no `venue` column is produced.
+
+Consumer rules:
+
+- Toss's 15:30 candle omits closing-auction volume. Daily volume and derived
+  daily value from this corpus understate the market total.
+- `is_padding=true` means the provider returned a volume-zero placeholder. It
+  is not a coverage gap and must be excluded when comparing traded-minute
+  coverage.
+- `value` is synthetic `close * volume`; `value_semantics` is always
+  `CLOSE_X_VOLUME_SYNTHETIC`, not exchange-reported trade value.
+- `pre_nxt` stays NULL/UNKNOWN without an exact, sourced NXT launch date. A
+  later label review may make pre-NXT rows eligible for a separate promotion
+  proposal, but this collector performs no promotion.
+
+The collector uses a shared cached Toss token only. It cannot issue or force
+reissue OAuth, and it stops itself on a new shared Toss 401/429/upstream error.

--- a/research/toss_phase2/README.md
+++ b/research/toss_phase2/README.md
@@ -47,3 +47,8 @@ documented chart cap as a source constant:
   only five consecutive chart 429s stop the collector. New shared 429 markers
   are likewise non-fatal, while 401 and other upstream errors remain
   fail-closed.
+- A missing shared cached token or a one-off HTTP transport/timeout failure
+  retries the same checkpoint cursor with jittered 1 → 2 → 4 → 8 second
+  waits. This retry path still only reads the shared token cache, never issues
+  OAuth, and stops fail-closed on five consecutive failures. The staging
+  `latest_summary.json` is atomically refreshed while the collector runs.

--- a/research/toss_phase2/README.md
+++ b/research/toss_phase2/README.md
@@ -25,6 +25,10 @@ Consumer rules:
 The collector uses a shared cached Toss token only. It cannot issue or force
 reissue OAuth.
 
+The declared call budget is staging-wide rather than process-local: a resumed
+collector recovers prior chart attempts from the append-only progress log and
+will not reset that budget by restarting.
+
 ## Shared chart-budget control
 
 `MARKET_DATA_CHART` is a client × API-group budget shared with the production

--- a/research/toss_phase2/README.md
+++ b/research/toss_phase2/README.md
@@ -6,8 +6,9 @@ does not load data into any table.
 
 The product is physically separate because Toss may combine KRX and NXT bars
 for NXT-eligible symbols. `session_segment` is only a KST time-of-day label
-(`NXT_PRE`, `KRX_REGULAR`, `NXT_POST`, or `UNKNOWN`); it is never a trade-venue
-claim and no `venue` column is produced.
+(`NXT_PRE`, `KRX_REGULAR`, or `NXT_POST`); it is never a trade-venue claim and
+no `venue` column is produced. An unclassifiable timestamp is a fail-closed
+error: it is neither staged nor loaded as `UNKNOWN`.
 
 Consumer rules:
 

--- a/research/toss_phase2/README.md
+++ b/research/toss_phase2/README.md
@@ -32,7 +32,9 @@ Toss-first chart reader. The Phase-2 collector therefore does not treat a
 documented chart cap as a source constant:
 
 - The first chart response must expose `X-RateLimit-Limit`; that header is the
-  active cap. A missing cap fails closed before a second page request.
+  active cap. The single startup probe and all subsequent chart calls bypass
+  the runtime's static process-local chart limiter; a missing header cap fails
+  closed before a second page request.
 - During 09:00–20:00 KST, the collector targets at most
   `min(2 TPS, discovered-cap − 3 TPS)`, preserving three TPS for production
   chart readers. If the provider's cap cannot preserve that reservation, the

--- a/research/toss_phase2/__init__.py
+++ b/research/toss_phase2/__init__.py
@@ -1,0 +1,5 @@
+"""Toss Phase 2 combined-KRX/NXT staging collector.
+
+This package deliberately writes Parquet staging only.  It has no database
+loader and is not a backtest input surface.
+"""

--- a/research/toss_phase2/__init__.py
+++ b/research/toss_phase2/__init__.py
@@ -1,5 +1,6 @@
 """Toss Phase 2 combined-KRX/NXT staging collector.
 
-This package deliberately writes Parquet staging only.  It has no database
-loader and is not a backtest input surface.
+The collector writes Parquet staging only.  The separately invoked loader
+snapshots completed fragments into the dedicated combined-KRX/NXT research
+table; neither surface is a backtest input.
 """

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -23,6 +23,7 @@ import os
 import random
 import re
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime, timedelta, timezone
 from datetime import time as local_time
@@ -48,6 +49,8 @@ AFTER_CLOSE_TARGET_TPS_MIN = 3.0
 AFTER_CLOSE_TARGET_TPS_MAX = 4.0
 LOW_REMAINING_FRACTION = 0.4
 CONSECUTIVE_429_STOP_AT = 5
+CONSECUTIVE_TRANSIENT_RESUME_STOP_AT = 5
+SUMMARY_UPDATE_INTERVAL_SECONDS = 60.0
 DEFAULT_SHARED_REDIS_URL = "redis://127.0.0.1:6379/0"
 _SETTINGS_PLACEHOLDERS = {
     "KIS_APP_KEY": "toss-phase2-unused",
@@ -63,6 +66,55 @@ _SETTINGS_PLACEHOLDERS = {
 
 class CollectionStopped(RuntimeError):
     """A deliberate, fail-closed stop that leaves staging resumable."""
+
+
+def _transient_resume_reason(exc: Exception) -> str | None:
+    """Classify only failures safe to retry without issuing an OAuth token."""
+
+    if isinstance(exc, httpx.TransportError):
+        return "httpx_transport_error"
+    if isinstance(exc, CollectionStopped) and str(exc).startswith(
+        "shared_toss_token_cache_miss"
+    ):
+        return "shared_toss_token_cache_miss"
+    return None
+
+
+class TransientResumeBackoff:
+    """Bounded retry path for a cache gap or a one-off transport failure.
+
+    It deliberately excludes every other ``CollectionStopped`` reason, 401,
+    and 429.  Those retain their specific fail-closed or header-driven paths.
+    """
+
+    def __init__(
+        self,
+        *,
+        sleep: Any = asyncio.sleep,
+        jitter_fn: Any = random.uniform,
+    ) -> None:
+        self._sleep = sleep
+        self._jitter = jitter_fn
+        self._consecutive = 0
+
+    @property
+    def consecutive(self) -> int:
+        return self._consecutive
+
+    def reset(self) -> None:
+        self._consecutive = 0
+
+    async def backoff(self, *, reason: str) -> tuple[int, float]:
+        self._consecutive += 1
+        if self._consecutive >= CONSECUTIVE_TRANSIENT_RESUME_STOP_AT:
+            raise CollectionStopped(
+                "transient_resume_exhausted:"
+                f"reason={reason}:stop_at={CONSECUTIVE_TRANSIENT_RESUME_STOP_AT}"
+            )
+        exponential = min(2.0 ** (self._consecutive - 1), 16.0)
+        delay_seconds = exponential + self._jitter(0.0, exponential)
+        await self._sleep(delay_seconds)
+        return self._consecutive, delay_seconds
 
 
 class CachedTokenProvider(Protocol):
@@ -713,6 +765,13 @@ def build_manifest(
                 "exponential_backoff_with_jitter": True,
                 "consecutive_stop_at": CONSECUTIVE_429_STOP_AT,
             },
+            "on_isolated_cache_or_transport_failure": {
+                "same_checkpoint_cursor_retry": True,
+                "shared_cache_only_no_token_issue": True,
+                "exponential_backoff_seconds": [1, 2, 4, 8],
+                "jitter": True,
+                "consecutive_stop_at": CONSECUTIVE_TRANSIENT_RESUME_STOP_AT,
+            },
         },
         "value_semantics": VALUE_SEMANTICS,
         "padding_contract": "is_padding=true iff provider volume is zero; not coverage missing",
@@ -787,7 +846,119 @@ class CollectionStats:
     http_429: int = 0
     chart_rate_limit_cap: int | None = None
     rate_limit_backoffs: int = 0
+    transient_resume_failures: int = 0
+    transient_resume_backoffs: int = 0
     stopped_reason: str | None = None
+
+
+class LatestSummaryWriter:
+    """Atomically expose a fresh, redacted staging-only progress snapshot."""
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        stats: CollectionStats,
+        transport: CountingTransport,
+        call_budget: int,
+        monotonic_fn: Any = time.monotonic,
+        now_kst_fn: Any = now_kst,
+    ) -> None:
+        self._path = path
+        self._stats = stats
+        self._transport = transport
+        self._call_budget = call_budget
+        self._monotonic = monotonic_fn
+        self._now_kst = now_kst_fn
+        self._last_write_at: float | None = None
+
+    def _payload(self, *, collector_state: str) -> dict[str, Any]:
+        return {
+            **asdict(self._stats),
+            "calls_actual": self._transport.calls,
+            "call_budget_declared": self._call_budget,
+            "token_issued_by_collector": False,
+            "database_load_performed": False,
+            "artifact_state": STAGING_CONTRACT,
+            "collector_state": collector_state,
+            "updated_at_kst": self._now_kst().isoformat(),
+        }
+
+    def write(self, *, collector_state: str) -> dict[str, Any]:
+        payload = self._payload(collector_state=collector_state)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self._path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary, self._path)
+        self._last_write_at = self._monotonic()
+        return payload
+
+    def maybe_write(self) -> None:
+        if (
+            self._last_write_at is None
+            or self._monotonic() - self._last_write_at
+            >= SUMMARY_UPDATE_INTERVAL_SECONDS
+        ):
+            self.write(collector_state="RUNNING")
+
+
+async def _backoff_transient_failure(
+    *,
+    exc: Exception,
+    transient_resumer: TransientResumeBackoff,
+    progress: ProgressLog,
+    stats: CollectionStats,
+    calls_actual: int,
+    on_progress: Callable[[], None] | None,
+) -> bool:
+    reason = _transient_resume_reason(exc)
+    if reason is None:
+        return False
+    stats.transient_resume_failures += 1
+    consecutive, delay_seconds = await transient_resumer.backoff(reason=reason)
+    stats.transient_resume_backoffs += 1
+    progress.write(
+        "transient_resume_backoff",
+        reason=reason,
+        consecutive_transient_failures=consecutive,
+        delay_seconds=delay_seconds,
+        calls_actual=calls_actual,
+    )
+    if on_progress is not None:
+        on_progress()
+    return True
+
+
+async def _preflight_cached_token(
+    *,
+    token_provider: CachedTokenProvider,
+    transient_resumer: TransientResumeBackoff,
+    progress: ProgressLog,
+    stats: CollectionStats,
+    transport: CountingTransport,
+    on_progress: Callable[[], None] | None,
+) -> None:
+    """Wait through a short shared-cache gap without ever issuing OAuth."""
+
+    while True:
+        try:
+            await token_provider.get_access_token()
+        except Exception as exc:  # noqa: BLE001
+            if await _backoff_transient_failure(
+                exc=exc,
+                transient_resumer=transient_resumer,
+                progress=progress,
+                stats=stats,
+                calls_actual=transport.calls,
+                on_progress=on_progress,
+            ):
+                continue
+            raise
+        transient_resumer.reset()
+        return
 
 
 async def collect(
@@ -805,8 +976,11 @@ async def collect(
     official_nxt_launch_date: date | None,
     progress: ProgressLog,
     stats: CollectionStats,
+    transient_resumer: TransientResumeBackoff | None = None,
+    on_progress: Callable[[], None] | None = None,
 ) -> CollectionStats:
     checkpoint = Checkpoint(staging_dir / "state" / "checkpoint.json")
+    transient_resumer = transient_resumer or TransientResumeBackoff()
 
     for symbol in symbols:
         state = checkpoint.state_for(symbol)
@@ -850,11 +1024,22 @@ async def collect(
                     # Do not advance the checkpoint.  Retrying the same cursor
                     # is safe because no Parquet page has been written for it.
                     continue
+                if await _backoff_transient_failure(
+                    exc=exc,
+                    transient_resumer=transient_resumer,
+                    progress=progress,
+                    stats=stats,
+                    calls_actual=transport.calls,
+                    on_progress=on_progress,
+                ):
+                    # The checkpoint deliberately remains on the same cursor.
+                    continue
                 raise CollectionStopped(
                     f"toss_request_failed:{type(exc).__name__}:status={status}"
                 ) from exc
 
             chart_pacer.ensure_cap_discovered()
+            transient_resumer.reset()
             if stats.chart_rate_limit_cap != chart_pacer.cap:
                 stats.chart_rate_limit_cap = chart_pacer.cap
                 progress.write(
@@ -912,6 +1097,8 @@ async def collect(
                 rate_limit_reset_seconds=chart_pacer.reset_seconds,
                 target_tps=chart_pacer.target_tps(),
             )
+            if on_progress is not None:
+                on_progress()
             await monitor.assert_healthy()
     return stats
 
@@ -992,11 +1179,12 @@ async def async_main(args: argparse.Namespace) -> int:
     transport = CountingTransport()
     shared_limiter = get_shared_rate_limiter()
     manager = TossOAuthTokenManager.from_settings(settings, rate_limiter=shared_limiter)
+    token_provider = CachedTokenOnlyProvider(manager)
     chart_pacer = HeaderAdaptiveChartRateLimiter(
         shared_limiter, TossApiGroup.MARKET_DATA_CHART
     )
     client = TossReadClient(
-        token_manager=CachedTokenOnlyProvider(manager),
+        token_manager=token_provider,
         base_url=resolve_toss_base_url(
             getattr(settings, "toss_api_base_url", None), DEFAULT_TOSS_BASE_URL
         ),
@@ -1014,11 +1202,15 @@ async def async_main(args: argparse.Namespace) -> int:
         ProductionTossLogMonitor(args.production_log),
     )
     stats = CollectionStats(symbols_total=len(symbols))
+    transient_resumer = TransientResumeBackoff()
+    summary_writer = LatestSummaryWriter(
+        path=args.staging_dir / "events" / "latest_summary.json",
+        stats=stats,
+        transport=transport,
+        call_budget=args.call_budget,
+    )
     try:
         await monitor.start()
-        # This preflight can only hit shared Redis.  It proves the first request
-        # cannot start an OAuth issuance; no Toss HTTP is sent here.
-        await CachedTokenOnlyProvider(manager).get_access_token()
         progress.write(
             "collection_started",
             scope="top-200 x 4.6y",
@@ -1041,6 +1233,17 @@ async def async_main(args: argparse.Namespace) -> int:
             settings_placeholders=sorted(_SETTINGS_PLACEHOLDERS),
             production_logs=[str(path) for path in args.production_log],
         )
+        summary_writer.write(collector_state="RUNNING")
+        # This preflight can only hit shared Redis.  A short cache gap retries
+        # the exact same cache lookup and never starts an OAuth issuance.
+        await _preflight_cached_token(
+            token_provider=token_provider,
+            transient_resumer=transient_resumer,
+            progress=progress,
+            stats=stats,
+            transport=transport,
+            on_progress=summary_writer.maybe_write,
+        )
         stats = await collect(
             client=client,
             transport=transport,
@@ -1055,25 +1258,26 @@ async def async_main(args: argparse.Namespace) -> int:
             official_nxt_launch_date=args.official_nxt_launch_date,
             progress=progress,
             stats=stats,
+            transient_resumer=transient_resumer,
+            on_progress=summary_writer.maybe_write,
         )
     except CollectionStopped as exc:
         stats.stopped_reason = str(exc)
         progress.write(
             "collection_stopped", reason=str(exc), calls_actual=transport.calls
         )
+    except Exception as exc:  # noqa: BLE001
+        stats.stopped_reason = f"unexpected:{type(exc).__name__}:{exc}"
+        progress.write(
+            "collection_stopped",
+            reason=stats.stopped_reason,
+            calls_actual=transport.calls,
+        )
+        raise
     finally:
         await client.aclose()
-        summary = {
-            **asdict(stats),
-            "calls_actual": transport.calls,
-            "call_budget_declared": args.call_budget,
-            "token_issued_by_collector": False,
-            "database_load_performed": False,
-            "artifact_state": STAGING_CONTRACT,
-        }
-        (args.staging_dir / "events" / "latest_summary.json").write_text(
-            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
+        summary = summary_writer.write(
+            collector_state=("STOPPED" if stats.stopped_reason else "COMPLETED")
         )
         progress.close()
     print(json.dumps(summary, ensure_ascii=False))

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -1,0 +1,802 @@
+"""Append-only staging collector for the Toss combined KRX/NXT 1-minute corpus.
+
+The Toss response for NXT-eligible names combines KRX and NXT activity.  This
+collector keeps that fact explicit: it emits a separate STAGING-only Parquet
+corpus, never connects to PostgreSQL, never calls order/account endpoints, and
+never promotes a row into the KRX-only research corpus.
+
+The caller must supply the sealed top-200 universe and declare a finite call
+budget.  A checkpoint is durable after every page.  Final Parquet pages are
+write-once; a restart recovers the next cursor from an already-written page
+rather than replacing it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime, timedelta, timezone
+from datetime import time as local_time
+from pathlib import Path
+from typing import Any, Protocol
+
+import httpx
+import pyarrow as pa
+import pyarrow.parquet as pq
+from dotenv import load_dotenv
+
+KST = timezone(timedelta(hours=9))
+
+STAGING_CONTRACT = "STAGING_ONLY_NOT_BACKTEST_INPUT"
+SOURCE = "TOSS"
+VALUE_SEMANTICS = "CLOSE_X_VOLUME_SYNTHETIC"
+DEFAULT_START_DATE = date(2021, 12, 20)
+EXPECTED_UNIVERSE_SIZE = 200
+PAGE_SIZE = 200
+PACING_SECONDS_DURING_MARKET = 0.5
+PACING_SECONDS_AFTER_CLOSE = 0.3
+DEFAULT_SHARED_REDIS_URL = "redis://127.0.0.1:6379/0"
+_SETTINGS_PLACEHOLDERS = {
+    "KIS_APP_KEY": "toss-phase2-unused",
+    "KIS_APP_SECRET": "toss-phase2-unused",
+    "OPENDART_API_KEY": "toss-phase2-unused",
+    # A deliberately invalid port ensures an accidental database path fails.
+    "DATABASE_URL": "postgresql+asyncpg://tossphase2:tossphase2@127.0.0.1:1/unused",
+    "UPBIT_ACCESS_KEY": "toss-phase2-unused",
+    "UPBIT_SECRET_KEY": "toss-phase2-unused",
+    "SECRET_KEY": "TossPhase2UnusedConfig_20260804_A1b2C3d4E5f6G7h8I9j0KLMNOP",
+}
+
+
+class CollectionStopped(RuntimeError):
+    """A deliberate, fail-closed stop that leaves staging resumable."""
+
+
+class CachedTokenProvider(Protocol):
+    async def get_access_token(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str: ...
+
+
+class CachedTokenOnlyProvider:
+    """Expose only the shared cache-hit path; this collector cannot issue OAuth."""
+
+    def __init__(self, manager: Any) -> None:
+        self._manager = manager
+
+    async def get_access_token(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
+        if force_reissue or failed_token is not None:
+            raise CollectionStopped("force_reissue_prohibited_for_toss_phase2")
+        token = await self._manager.get_cached_access_token()
+        if token is None:
+            raise CollectionStopped(
+                "shared_toss_token_cache_miss: collector will not issue OAuth"
+            )
+        return token
+
+
+class CountingTransport(httpx.AsyncBaseTransport):
+    """Count actual Toss HTTP attempts, rather than successful parsed pages."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self._inner = httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def now_kst() -> datetime:
+    return datetime.now(KST)
+
+
+def pacing_seconds(at: datetime | None = None) -> float:
+    """Use the operator-approved 0.5 s during KR/NXT hours, else 0.3 s."""
+    current = (at or now_kst()).astimezone(KST).time()
+    if local_time(9, 0) <= current < local_time(20, 0):
+        return PACING_SECONDS_DURING_MARKET
+    return PACING_SECONDS_AFTER_CLOSE
+
+
+class PacingRateLimiter:
+    """Keep the process-wide Toss limiter and add the Phase 2 serial pacing."""
+
+    def __init__(self, base: Any, chart_group: Any) -> None:
+        self._base = base
+        self._chart_group = chart_group
+        self._last_chart_call = 0.0
+
+    async def acquire(self, group: Any) -> None:
+        await self._base.acquire(group)
+        if group != self._chart_group:
+            return
+        interval = pacing_seconds()
+        elapsed = time.monotonic() - self._last_chart_call
+        if elapsed < interval:
+            await asyncio.sleep(interval - elapsed)
+        self._last_chart_call = time.monotonic()
+
+
+@dataclass(frozen=True)
+class SharedErrorBaseline:
+    sequence: int
+
+
+class SharedTossHealthMonitor:
+    """Stop this collector if a new shared Toss error is published."""
+
+    def __init__(self, read_signal: Any) -> None:
+        self._read_signal = read_signal
+        self._baseline = SharedErrorBaseline(sequence=0)
+
+    async def start(self) -> None:
+        signal = await self._read_signal()
+        self._baseline = SharedErrorBaseline(
+            sequence=signal.sequence if signal is not None else 0
+        )
+
+    async def assert_healthy(self) -> None:
+        signal = await self._read_signal()
+        if signal is not None and signal.sequence > self._baseline.sequence:
+            raise CollectionStopped(
+                "shared_toss_error_observed: "
+                f"status={signal.status_code} type={signal.error_type} "
+                f"code={signal.error_code} sequence={signal.sequence}"
+            )
+
+
+_TOSS_ERROR_LINE = re.compile(
+    r"(?:toss|openapi\.tossinvest).{0,160}(?:\b401\b|\b429\b|error|exception)"
+    r"|(?:\b401\b|\b429\b).{0,160}(?:toss|openapi\.tossinvest)",
+    re.IGNORECASE,
+)
+
+
+class ProductionTossLogMonitor:
+    """Tail existing production logs without changing their running processes."""
+
+    def __init__(self, paths: list[Path]) -> None:
+        self._paths = paths
+        self._positions: dict[Path, tuple[int, int]] = {}
+
+    async def start(self) -> None:
+        for path in self._paths:
+            if not path.is_file():
+                raise CollectionStopped(f"production_toss_log_missing:{path}")
+            stat = path.stat()
+            self._positions[path] = (stat.st_ino, stat.st_size)
+
+    async def assert_healthy(self) -> None:
+        for path in self._paths:
+            if not path.is_file():
+                raise CollectionStopped(f"production_toss_log_missing:{path}")
+            stat = path.stat()
+            old_inode, offset = self._positions[path]
+            if stat.st_ino != old_inode or stat.st_size < offset:
+                offset = 0
+            with path.open("r", encoding="utf-8", errors="replace") as fh:
+                fh.seek(offset)
+                appended = fh.read()
+            self._positions[path] = (stat.st_ino, stat.st_size)
+            if _TOSS_ERROR_LINE.search(appended):
+                # Do not copy log content: it can contain an upstream request id
+                # and is unnecessary for the collector's fail-closed decision.
+                raise CollectionStopped(f"production_toss_error_log_observed:{path}")
+
+
+class CombinedTossHealthMonitor:
+    def __init__(
+        self,
+        shared: SharedTossHealthMonitor,
+        production_logs: ProductionTossLogMonitor,
+    ) -> None:
+        self._shared = shared
+        self._production_logs = production_logs
+
+    async def start(self) -> None:
+        await self._shared.start()
+        await self._production_logs.start()
+
+    async def assert_healthy(self) -> None:
+        await self._shared.assert_healthy()
+        await self._production_logs.assert_healthy()
+
+
+class Checkpoint:
+    """Durable per-symbol cursor state; only this file is rewritten on resume."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.data: dict[str, Any] = {"version": 1, "symbols": {}}
+        if path.exists():
+            self.data = json.loads(path.read_text())
+
+    def state_for(self, symbol: str) -> dict[str, Any]:
+        return self.data.setdefault("symbols", {}).setdefault(
+            symbol,
+            {"before": None, "done": False, "pages": 0, "rows_staged": 0},
+        )
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(self.data, indent=2, ensure_ascii=False) + "\n")
+        os.replace(temporary, self.path)
+
+
+class ProgressLog:
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = path.open("a", encoding="utf-8", buffering=1)
+
+    def write(self, event: str, **fields: Any) -> None:
+        record = {"event": event, "at_kst": now_kst().isoformat(), **fields}
+        self._fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+        self._fh.flush()
+        os.fsync(self._fh.fileno())
+
+    def close(self) -> None:
+        self._fh.close()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_universe(path: Path) -> list[str]:
+    with path.open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    symbols = [str(row.get("ticker", "")).strip() for row in rows]
+    if len(symbols) != EXPECTED_UNIVERSE_SIZE or any(not symbol for symbol in symbols):
+        raise ValueError(
+            f"universe must contain exactly {EXPECTED_UNIVERSE_SIZE} non-empty tickers"
+        )
+    if len(set(symbols)) != len(symbols):
+        raise ValueError("universe contains duplicate tickers")
+    return symbols
+
+
+def load_readonly_toss_environment(env_file: Path) -> str:
+    """Load the dedicated three-key Toss env without reading a general env file."""
+    if "prod" in env_file.name.casefold() or not env_file.is_file():
+        raise ValueError("dedicated non-production-named Toss env file is required")
+    inherited_env_file = os.environ.get("ENV_FILE", "")
+    if inherited_env_file and "prod" in Path(inherited_env_file).name.casefold():
+        raise ValueError("ENV_FILE must not point at a production env file")
+    load_dotenv(env_file, override=True)
+    if os.getenv("TOSS_LIVE_ORDER_MUTATIONS_ENABLED", "").casefold() == "true":
+        raise ValueError("TOSS_LIVE_ORDER_MUTATIONS_ENABLED must not be enabled")
+    if os.getenv("TOSS_API_ENABLED", "").casefold() not in {"1", "true", "yes"}:
+        raise ValueError("TOSS_API_ENABLED must be truthy in the readonly env file")
+    missing = [
+        name
+        for name in ("TOSS_API_CLIENT_ID", "TOSS_API_CLIENT_SECRET")
+        if not os.getenv(name)
+    ]
+    if missing:
+        raise ValueError("readonly Toss env missing: " + ", ".join(missing))
+    # Settings imports require unrelated fields, but no route in this process
+    # uses them.  Keep their values inert and point ENV_FILE only at the scoped
+    # Toss file so it cannot fall back to a general deployment dotenv.
+    os.environ["ENV_FILE"] = str(env_file)
+    for name, value in _SETTINGS_PLACEHOLDERS.items():
+        os.environ.setdefault(name, value)
+    if not os.getenv("REDIS_URL"):
+        os.environ["REDIS_URL"] = DEFAULT_SHARED_REDIS_URL
+        return f"defaulted:{DEFAULT_SHARED_REDIS_URL}"
+    return "process_env_preexisting"
+
+
+def resolve_toss_base_url(configured: str | None, default: str) -> str:
+    """Mirror ``TossReadClient.from_settings`` for a scoped env file."""
+    return str(configured or default)
+
+
+def classify_session_segment(timestamp_kst: datetime) -> str:
+    """Classify by clock time only; it asserts no execution venue claim."""
+    clock = timestamp_kst.astimezone(KST).time()
+    if local_time(8, 0) <= clock < local_time(9, 0):
+        return "NXT_PRE"
+    if local_time(9, 0) <= clock <= local_time(15, 30):
+        return "KRX_REGULAR"
+    if local_time(15, 30) < clock <= local_time(20, 0):
+        return "NXT_POST"
+    return "UNKNOWN"
+
+
+def normalize_timestamp(raw: Any) -> tuple[datetime, datetime]:
+    parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=KST)
+    timestamp_kst = parsed.astimezone(KST).replace(second=0, microsecond=0)
+    return timestamp_kst.astimezone(UTC), timestamp_kst
+
+
+def page_token(before: str | None) -> str:
+    raw = before if before is not None else "initial"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:20]
+
+
+def page_path(staging_dir: Path, symbol: str, before: str | None) -> Path:
+    return (
+        staging_dir / "data" / f"symbol={symbol}" / f"part-{page_token(before)}.parquet"
+    )
+
+
+def _page_metadata(
+    *,
+    batch_id: str,
+    symbol: str,
+    request_before: str | None,
+    next_before: str | None,
+) -> dict[bytes, bytes]:
+    metadata = {
+        "artifact_state": STAGING_CONTRACT,
+        "source": SOURCE,
+        "value_semantics": VALUE_SEMANTICS,
+        "batch_id": batch_id,
+        "symbol": symbol,
+        "request_before": request_before or "",
+        "next_before": next_before or "",
+        "pre_nxt_contract": "NULL=UNKNOWN_UNTIL_OFFICIAL_LAUNCH_DATE",
+        "promotion_performed": "false",
+    }
+    return {key.encode(): value.encode() for key, value in metadata.items()}
+
+
+def _existing_next_before(path: Path) -> str | None:
+    metadata = pq.read_metadata(path).metadata or {}
+    raw = metadata.get(b"next_before", b"")
+    value = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+    return value or None
+
+
+def write_page(
+    *,
+    staging_dir: Path,
+    symbol: str,
+    request_before: str | None,
+    next_before: str | None,
+    rows: list[dict[str, Any]],
+    batch_id: str,
+) -> tuple[Path | None, bool]:
+    """Write an immutable page, returning ``(path, existed_already)``."""
+    if not rows:
+        return None, False
+    destination = page_path(staging_dir, symbol, request_before)
+    if destination.exists():
+        return destination, True
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".partial")
+    table = pa.Table.from_pylist(rows)
+    table = table.replace_schema_metadata(
+        {
+            **(table.schema.metadata or {}),
+            **_page_metadata(
+                batch_id=batch_id,
+                symbol=symbol,
+                request_before=request_before,
+                next_before=next_before,
+            ),
+        }
+    )
+    pq.write_table(table, temporary, compression="zstd")
+    with temporary.open("rb") as fh:
+        os.fsync(fh.fileno())
+    try:
+        # link(2) is create-only: another process cannot be silently overwritten.
+        os.link(temporary, destination)
+    except FileExistsError:
+        temporary.unlink(missing_ok=True)
+        return destination, True
+    temporary.unlink(missing_ok=True)
+    return destination, False
+
+
+def make_rows(
+    *,
+    candles: list[Any],
+    symbol: str,
+    start_date: date,
+    last_eligible_date: date,
+    retrieved_at: datetime,
+    batch_id: str,
+    official_nxt_launch_date: date | None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for candle in candles:
+        time_utc, timestamp_kst = normalize_timestamp(candle.timestamp)
+        session_date = timestamp_kst.date()
+        # The newest KST session is intentionally excluded, including every
+        # still-forming minute in it.  This is not a coverage failure.
+        if not start_date <= session_date <= last_eligible_date:
+            continue
+        volume = float(candle.volume)
+        close = float(candle.close_price)
+        rows.append(
+            {
+                "time_utc": time_utc,
+                "session_date_kst": session_date,
+                "symbol": symbol,
+                "session_segment": classify_session_segment(timestamp_kst),
+                "source": SOURCE,
+                "open": float(candle.open_price),
+                "high": float(candle.high_price),
+                "low": float(candle.low_price),
+                "close": close,
+                "volume": volume,
+                "value": close * volume,
+                "value_semantics": VALUE_SEMANTICS,
+                "is_padding": volume == 0.0,
+                # Without an exact, sourced NXT launch date this remains NULL
+                # (UNKNOWN), never an approximation such as "2025-03".
+                "pre_nxt": (
+                    session_date < official_nxt_launch_date
+                    if official_nxt_launch_date is not None
+                    else None
+                ),
+                "retrieved_at": retrieved_at,
+                "batch_id": batch_id,
+            }
+        )
+    return rows
+
+
+def build_manifest(
+    *,
+    symbols: list[str],
+    universe_csv: Path,
+    start_date: date,
+    last_eligible_date: date,
+    call_budget: int,
+    batch_id: str,
+    official_nxt_launch_date: date | None,
+    official_nxt_launch_source: str | None,
+) -> dict[str, Any]:
+    return {
+        "artifact_state": STAGING_CONTRACT,
+        "backtest_input": False,
+        "source": SOURCE,
+        "scope": "top-200 x 4.6y",
+        "symbol_count": len(symbols),
+        "universe_csv": str(universe_csv),
+        "universe_sha256": sha256_file(universe_csv),
+        "window": {
+            "start_date": start_date.isoformat(),
+            "end_date": last_eligible_date.isoformat(),
+        },
+        "latest_session_excluded": {
+            "enabled": True,
+            "definition": "all rows with session_date_kst >= collection_start_kst_date are excluded",
+        },
+        "call_budget_declared": call_budget,
+        "page_size": PAGE_SIZE,
+        "pacing": {
+            "during_09_00_to_20_00_kst_seconds": PACING_SECONDS_DURING_MARKET,
+            "after_close_seconds": PACING_SECONDS_AFTER_CLOSE,
+        },
+        "value_semantics": VALUE_SEMANTICS,
+        "padding_contract": "is_padding=true iff provider volume is zero; not coverage missing",
+        "session_segment_contract": "time-of-day only; never a venue assertion",
+        "pre_nxt": {
+            "launch_date": official_nxt_launch_date.isoformat()
+            if official_nxt_launch_date
+            else None,
+            "launch_date_source": official_nxt_launch_source,
+            "unknown_when_launch_date_absent": True,
+            "promotion_performed": False,
+        },
+        "batch_id": batch_id,
+        "database_load_performed": False,
+        "order_or_account_endpoint_calls": 0,
+        "token_mode": "shared_cached_token_reuse_only_no_issue_no_force_reissue",
+    }
+
+
+def initialize_staging(
+    *,
+    staging_dir: Path,
+    manifest: dict[str, Any],
+) -> None:
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = staging_dir / "manifest.json"
+    if manifest_path.exists():
+        existing = json.loads(manifest_path.read_text())
+        immutable_keys = (
+            "artifact_state",
+            "scope",
+            "symbol_count",
+            "universe_sha256",
+            "window",
+            "call_budget_declared",
+            "batch_id",
+        )
+        if any(existing.get(key) != manifest.get(key) for key in immutable_keys):
+            raise ValueError("existing staging manifest does not match this collection")
+        return
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+    (staging_dir / "STAGING_ONLY.md").write_text(
+        "# STAGING ONLY — NOT A BACKTEST INPUT\n\n"
+        "This is an append-only Toss combined KRX/NXT collection. It must not be "
+        "loaded into a database or used by a backtest until a separately approved "
+        "review and load step. `is_padding=true` is a provider placeholder, and "
+        "`value` is synthetic `close * volume`.\n",
+        encoding="utf-8",
+    )
+
+
+@dataclass
+class CollectionStats:
+    symbols_total: int
+    symbols_done: int = 0
+    rows_staged: int = 0
+    pages_staged: int = 0
+    pages_reused: int = 0
+    http_401: int = 0
+    http_429: int = 0
+    stopped_reason: str | None = None
+
+
+async def collect(
+    *,
+    client: Any,
+    transport: CountingTransport,
+    monitor: CombinedTossHealthMonitor,
+    staging_dir: Path,
+    symbols: list[str],
+    start_date: date,
+    last_eligible_date: date,
+    call_budget: int,
+    batch_id: str,
+    official_nxt_launch_date: date | None,
+    progress: ProgressLog,
+    stats: CollectionStats,
+) -> CollectionStats:
+    checkpoint = Checkpoint(staging_dir / "state" / "checkpoint.json")
+
+    for symbol in symbols:
+        state = checkpoint.state_for(symbol)
+        if state["done"]:
+            stats.symbols_done += 1
+            continue
+        while not state["done"]:
+            await monitor.assert_healthy()
+            if transport.calls >= call_budget:
+                raise CollectionStopped(f"call_budget_reached:{call_budget}")
+            request_before = state["before"]
+            try:
+                page = await client.candles(
+                    symbol,
+                    interval="1m",
+                    count=PAGE_SIZE,
+                    before=request_before,
+                )
+            except Exception as exc:  # noqa: BLE001
+                status = getattr(exc, "status_code", None)
+                if status == 401:
+                    stats.http_401 += 1
+                if status == 429:
+                    stats.http_429 += 1
+                raise CollectionStopped(
+                    f"toss_request_failed:{type(exc).__name__}:status={status}"
+                ) from exc
+
+            next_before = page.next_before
+            rows = make_rows(
+                candles=list(page.candles),
+                symbol=symbol,
+                start_date=start_date,
+                last_eligible_date=last_eligible_date,
+                retrieved_at=datetime.now(UTC),
+                batch_id=batch_id,
+                official_nxt_launch_date=official_nxt_launch_date,
+            )
+            destination, reused = write_page(
+                staging_dir=staging_dir,
+                symbol=symbol,
+                request_before=request_before,
+                next_before=next_before,
+                rows=rows,
+                batch_id=batch_id,
+            )
+            if reused and destination is not None:
+                next_before = _existing_next_before(destination)
+                stats.pages_reused += 1
+            elif destination is not None:
+                stats.pages_staged += 1
+                stats.rows_staged += len(rows)
+
+            state["before"] = next_before
+            state["pages"] += 1
+            state["rows_staged"] += len(rows) if not reused else 0
+            if not page.candles or not next_before:
+                state["done"] = True
+                stats.symbols_done += 1
+            checkpoint.save()
+            progress.write(
+                "page",
+                symbol=symbol,
+                request_before=request_before,
+                next_before=next_before,
+                rows_received=len(page.candles),
+                rows_staged=len(rows),
+                output=str(destination) if destination is not None else None,
+                output_reused=reused,
+                calls_actual=transport.calls,
+                pacing_seconds=pacing_seconds(),
+            )
+            await monitor.assert_healthy()
+    return stats
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--staging-dir", required=True, type=Path)
+    parser.add_argument("--universe-csv", required=True, type=Path)
+    parser.add_argument("--env-file", required=True, type=Path)
+    parser.add_argument(
+        "--start-date", type=date.fromisoformat, default=DEFAULT_START_DATE
+    )
+    parser.add_argument("--last-eligible-date", required=True, type=date.fromisoformat)
+    parser.add_argument("--call-budget", required=True, type=int)
+    parser.add_argument("--official-nxt-launch-date", type=date.fromisoformat)
+    parser.add_argument("--official-nxt-launch-source")
+    parser.add_argument(
+        "--production-log",
+        action="append",
+        type=Path,
+        default=[],
+        help="existing production log to tail for new Toss 401/429/error lines",
+    )
+    parser.add_argument("--confirm-staging", action="store_true")
+    return parser.parse_args()
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    if not args.confirm_staging:
+        raise SystemExit("--confirm-staging is required; no Toss call was made")
+    if args.call_budget <= 0:
+        raise ValueError("--call-budget must be positive")
+    if not args.production_log:
+        raise ValueError("at least one --production-log is required")
+    if args.official_nxt_launch_date and not args.official_nxt_launch_source:
+        raise ValueError("official NXT launch date requires its exact source")
+    collection_start_date = now_kst().date()
+    if args.last_eligible_date >= collection_start_date:
+        raise ValueError(
+            "--last-eligible-date must precede collection-start KST date; "
+            "latest session is excluded"
+        )
+    if args.start_date > args.last_eligible_date:
+        raise ValueError("start date is after last eligible date")
+    redis_url_source = load_readonly_toss_environment(args.env_file)
+
+    # Delay all app imports until the dedicated readonly environment is loaded.
+    from app.core.config import settings
+    from app.services.brokers.toss.auth import TossOAuthTokenManager
+    from app.services.brokers.toss.client import TossReadClient
+    from app.services.brokers.toss.health import read_toss_api_error_signal
+    from app.services.brokers.toss.rate_limiter import (
+        TossApiGroup,
+        get_shared_rate_limiter,
+    )
+    from app.services.brokers.toss.transport import DEFAULT_TOSS_BASE_URL
+
+    symbols = load_universe(args.universe_csv)
+    existing_manifest_path = args.staging_dir / "manifest.json"
+    if existing_manifest_path.exists():
+        batch_id = str(json.loads(existing_manifest_path.read_text())["batch_id"])
+    else:
+        batch_id = f"toss-phase2-staging-{now_kst():%Y%m%dT%H%M%S}"
+    manifest = build_manifest(
+        symbols=symbols,
+        universe_csv=args.universe_csv,
+        start_date=args.start_date,
+        last_eligible_date=args.last_eligible_date,
+        call_budget=args.call_budget,
+        batch_id=batch_id,
+        official_nxt_launch_date=args.official_nxt_launch_date,
+        official_nxt_launch_source=args.official_nxt_launch_source,
+    )
+    initialize_staging(staging_dir=args.staging_dir, manifest=manifest)
+    existing_manifest = json.loads((args.staging_dir / "manifest.json").read_text())
+    batch_id = str(existing_manifest["batch_id"])
+    progress = ProgressLog(args.staging_dir / "events" / "progress.jsonl")
+    transport = CountingTransport()
+    shared_limiter = get_shared_rate_limiter()
+    manager = TossOAuthTokenManager.from_settings(settings, rate_limiter=shared_limiter)
+    client = TossReadClient(
+        token_manager=CachedTokenOnlyProvider(manager),
+        base_url=resolve_toss_base_url(
+            getattr(settings, "toss_api_base_url", None), DEFAULT_TOSS_BASE_URL
+        ),
+        transport=transport,
+        rate_limiter=PacingRateLimiter(shared_limiter, TossApiGroup.MARKET_DATA_CHART),
+        retry_on_429=False,
+        retry_auth_reissue=False,
+    )
+    monitor = CombinedTossHealthMonitor(
+        SharedTossHealthMonitor(read_toss_api_error_signal),
+        ProductionTossLogMonitor(args.production_log),
+    )
+    stats = CollectionStats(symbols_total=len(symbols))
+    try:
+        await monitor.start()
+        # This preflight can only hit shared Redis.  It proves the first request
+        # cannot start an OAuth issuance; no Toss HTTP is sent here.
+        await CachedTokenOnlyProvider(manager).get_access_token()
+        progress.write(
+            "collection_started",
+            scope="top-200 x 4.6y",
+            call_budget_declared=args.call_budget,
+            pacing_seconds=pacing_seconds(),
+            latest_session_excluded=True,
+            latest_session_definition=(
+                "session_date_kst >= collection_start_kst_date is excluded"
+            ),
+            token_mode="shared_cached_token_reuse_only_no_issue_no_force_reissue",
+            redis_url_source=redis_url_source,
+            settings_placeholders=sorted(_SETTINGS_PLACEHOLDERS),
+            production_logs=[str(path) for path in args.production_log],
+        )
+        stats = await collect(
+            client=client,
+            transport=transport,
+            monitor=monitor,
+            staging_dir=args.staging_dir,
+            symbols=symbols,
+            start_date=args.start_date,
+            last_eligible_date=args.last_eligible_date,
+            call_budget=args.call_budget,
+            batch_id=batch_id,
+            official_nxt_launch_date=args.official_nxt_launch_date,
+            progress=progress,
+            stats=stats,
+        )
+    except CollectionStopped as exc:
+        stats.stopped_reason = str(exc)
+        progress.write(
+            "collection_stopped", reason=str(exc), calls_actual=transport.calls
+        )
+    finally:
+        await client.aclose()
+        summary = {
+            **asdict(stats),
+            "calls_actual": transport.calls,
+            "call_budget_declared": args.call_budget,
+            "token_issued_by_collector": False,
+            "database_load_performed": False,
+            "artifact_state": STAGING_CONTRACT,
+        }
+        (args.staging_dir / "events" / "latest_summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        progress.close()
+    print(json.dumps(summary, ensure_ascii=False))
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(async_main(parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -73,6 +73,35 @@ class UnclassifiableSessionSegment(CollectionStopped):
     """A candle outside the approved KST session labels must not be staged."""
 
 
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Durably replace a resume-critical JSON document.
+
+    The temporary file is synced before it becomes visible.  A directory sync
+    is attempted after the rename as well; a few local development filesystems
+    do not support syncing directory descriptors, where atomic replacement
+    still prevents a torn JSON file.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(temporary, path)
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        try:
+            os.fsync(directory_fd)
+        except OSError:
+            # macOS and a few network filesystems do not permit directory
+            # fsync.  The file itself was already synced before the rename.
+            pass
+    finally:
+        os.close(directory_fd)
+
+
 def _transient_resume_reason(exc: Exception) -> str | None:
     """Classify only failures safe to retry without issuing an OAuth token."""
 
@@ -497,10 +526,7 @@ class Checkpoint:
         )
 
     def save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        temporary = self.path.with_suffix(".tmp")
-        temporary.write_text(json.dumps(self.data, indent=2, ensure_ascii=False) + "\n")
-        os.replace(temporary, self.path)
+        _atomic_write_json(self.path, self.data)
 
 
 class ProgressLog:
@@ -544,42 +570,45 @@ def cumulative_calls_from_progress(path: Path) -> int:
         else:
             legacy_total += run_max
 
-    for line_number, line in enumerate(
-        path.read_text(encoding="utf-8").splitlines(), 1
-    ):
-        if not line.strip():
-            continue
-        try:
-            record = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"malformed progress log at line {line_number}; refusing to reset call budget"
-            ) from exc
-        if not isinstance(record, dict):
-            raise ValueError(
-                f"malformed progress log at line {line_number}; expected object"
-            )
-        if record.get("event") == "collection_started":
-            finish_run()
-            run_seen = True
-            run_is_cumulative = record.get("call_accounting") == CALL_BUDGET_ACCOUNTING
-            prior_calls = record.get("prior_calls_actual", 0)
-            if not isinstance(prior_calls, int) or isinstance(prior_calls, bool):
+    with path.open(encoding="utf-8") as progress:
+        for line_number, line in enumerate(progress, 1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
                 raise ValueError(
-                    f"malformed prior_calls_actual at progress line {line_number}"
-                )
-            if prior_calls < 0:
+                    f"malformed progress log at line {line_number}; refusing to reset call budget"
+                ) from exc
+            if not isinstance(record, dict):
                 raise ValueError(
-                    f"negative prior_calls_actual at progress line {line_number}"
+                    f"malformed progress log at line {line_number}; expected object"
                 )
-            run_max = prior_calls if run_is_cumulative else 0
+            if record.get("event") == "collection_started":
+                finish_run()
+                run_seen = True
+                run_is_cumulative = (
+                    record.get("call_accounting") == CALL_BUDGET_ACCOUNTING
+                )
+                prior_calls = record.get("prior_calls_actual", 0)
+                if not isinstance(prior_calls, int) or isinstance(prior_calls, bool):
+                    raise ValueError(
+                        f"malformed prior_calls_actual at progress line {line_number}"
+                    )
+                if prior_calls < 0:
+                    raise ValueError(
+                        f"negative prior_calls_actual at progress line {line_number}"
+                    )
+                run_max = prior_calls if run_is_cumulative else 0
 
-        if not run_seen or "calls_actual" not in record:
-            continue
-        calls = record["calls_actual"]
-        if not isinstance(calls, int) or isinstance(calls, bool) or calls < 0:
-            raise ValueError(f"malformed calls_actual at progress line {line_number}")
-        run_max = max(run_max, calls)
+            if not run_seen or "calls_actual" not in record:
+                continue
+            calls = record["calls_actual"]
+            if not isinstance(calls, int) or isinstance(calls, bool) or calls < 0:
+                raise ValueError(
+                    f"malformed calls_actual at progress line {line_number}"
+                )
+            run_max = max(run_max, calls)
 
     finish_run()
     return max(legacy_total, cumulative_max)
@@ -894,12 +923,9 @@ def initialize_staging(
         if existing.get("rate_limit_control") != manifest["rate_limit_control"]:
             existing.pop("pacing", None)
             existing["rate_limit_control"] = manifest["rate_limit_control"]
-            manifest_path.write_text(
-                json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
-                encoding="utf-8",
-            )
+            _atomic_write_json(manifest_path, existing)
         return
-    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+    _atomic_write_json(manifest_path, manifest)
     (staging_dir / "STAGING_ONLY.md").write_text(
         "# STAGING ONLY — NOT A BACKTEST INPUT\n\n"
         "This is an append-only Toss combined KRX/NXT collection. It must not be "
@@ -1013,13 +1039,7 @@ class LatestSummaryWriter:
 
     def write(self, *, collector_state: str) -> dict[str, Any]:
         payload = self._payload(collector_state=collector_state)
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        temporary = self._path.with_suffix(".tmp")
-        temporary.write_text(
-            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
-        os.replace(temporary, self._path)
+        _atomic_write_json(self._path, payload)
         self._last_write_at = self._monotonic()
         return payload
 

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -51,6 +51,7 @@ LOW_REMAINING_FRACTION = 0.4
 CONSECUTIVE_429_STOP_AT = 5
 CONSECUTIVE_TRANSIENT_RESUME_STOP_AT = 5
 SUMMARY_UPDATE_INTERVAL_SECONDS = 60.0
+CALL_BUDGET_ACCOUNTING = "cumulative_staging_scope"
 DEFAULT_SHARED_REDIS_URL = "redis://127.0.0.1:6379/0"
 _SETTINGS_PLACEHOLDERS = {
     "KIS_APP_KEY": "toss-phase2-unused",
@@ -145,8 +146,10 @@ class CachedTokenOnlyProvider:
 class CountingTransport(httpx.AsyncBaseTransport):
     """Count actual Toss HTTP attempts, rather than successful parsed pages."""
 
-    def __init__(self) -> None:
-        self.calls = 0
+    def __init__(self, *, initial_calls: int = 0) -> None:
+        if initial_calls < 0:
+            raise ValueError("initial_calls must be non-negative")
+        self.calls = initial_calls
         self._inner = httpx.AsyncHTTPTransport()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
@@ -511,6 +514,73 @@ class ProgressLog:
         self._fh.close()
 
 
+def cumulative_calls_from_progress(path: Path) -> int:
+    """Return the staging-wide chart-call total across collector restarts.
+
+    Older runs recorded a per-process counter.  Once a run declares the
+    cumulative accounting marker, its counter already includes all preceding
+    calls and must replace—not be added to—the legacy total.
+    """
+
+    if not path.exists():
+        return 0
+
+    legacy_total = 0
+    cumulative_max = 0
+    run_seen = False
+    run_is_cumulative = False
+    run_max = 0
+
+    def finish_run() -> None:
+        nonlocal legacy_total, cumulative_max
+        if not run_seen:
+            return
+        if run_is_cumulative:
+            cumulative_max = max(cumulative_max, run_max)
+        else:
+            legacy_total += run_max
+
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"malformed progress log at line {line_number}; refusing to reset call budget"
+            ) from exc
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"malformed progress log at line {line_number}; expected object"
+            )
+        if record.get("event") == "collection_started":
+            finish_run()
+            run_seen = True
+            run_is_cumulative = record.get("call_accounting") == CALL_BUDGET_ACCOUNTING
+            prior_calls = record.get("prior_calls_actual", 0)
+            if not isinstance(prior_calls, int) or isinstance(prior_calls, bool):
+                raise ValueError(
+                    f"malformed prior_calls_actual at progress line {line_number}"
+                )
+            if prior_calls < 0:
+                raise ValueError(
+                    f"negative prior_calls_actual at progress line {line_number}"
+                )
+            run_max = prior_calls if run_is_cumulative else 0
+
+        if not run_seen or "calls_actual" not in record:
+            continue
+        calls = record["calls_actual"]
+        if not isinstance(calls, int) or isinstance(calls, bool) or calls < 0:
+            raise ValueError(f"malformed calls_actual at progress line {line_number}")
+        run_max = max(run_max, calls)
+
+    finish_run()
+    return max(legacy_total, cumulative_max)
+
+
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as fh:
@@ -746,6 +816,7 @@ def build_manifest(
             "definition": "all rows with session_date_kst >= collection_start_kst_date are excluded",
         },
         "call_budget_declared": call_budget,
+        "call_budget_accounting": CALL_BUDGET_ACCOUNTING,
         "page_size": PAGE_SIZE,
         "rate_limit_control": {
             "mode": "response_header_adaptive",
@@ -851,6 +922,54 @@ class CollectionStats:
     stopped_reason: str | None = None
 
 
+def collection_stats_from_checkpoint(
+    *,
+    staging_dir: Path,
+    symbols: list[str],
+) -> CollectionStats:
+    """Seed a resumed summary from durable staging state, not process memory."""
+
+    checkpoint = Checkpoint(staging_dir / "state" / "checkpoint.json")
+    states = checkpoint.data.get("symbols", {})
+    if not isinstance(states, dict):
+        raise ValueError("checkpoint symbols must be an object")
+    unexpected_symbols = set(states) - set(symbols)
+    if unexpected_symbols:
+        raise ValueError(
+            "checkpoint contains symbols outside sealed universe: "
+            + ", ".join(sorted(unexpected_symbols))
+        )
+
+    symbols_done = 0
+    pages_staged = 0
+    rows_staged = 0
+    for symbol, state in states.items():
+        if not isinstance(state, dict):
+            raise ValueError(f"checkpoint state for {symbol} must be an object")
+        pages = state.get("pages", 0)
+        rows = state.get("rows_staged", 0)
+        if (
+            not isinstance(pages, int)
+            or isinstance(pages, bool)
+            or pages < 0
+            or not isinstance(rows, int)
+            or isinstance(rows, bool)
+            or rows < 0
+        ):
+            raise ValueError(f"checkpoint counters for {symbol} must be non-negative")
+        pages_staged += pages
+        rows_staged += rows
+        if state.get("done") is True:
+            symbols_done += 1
+
+    return CollectionStats(
+        symbols_total=len(symbols),
+        symbols_done=symbols_done,
+        pages_staged=pages_staged,
+        rows_staged=rows_staged,
+    )
+
+
 class LatestSummaryWriter:
     """Atomically expose a fresh, redacted staging-only progress snapshot."""
 
@@ -877,6 +996,8 @@ class LatestSummaryWriter:
             **asdict(self._stats),
             "calls_actual": self._transport.calls,
             "call_budget_declared": self._call_budget,
+            "call_budget_accounting": CALL_BUDGET_ACCOUNTING,
+            "call_budget_remaining": max(self._call_budget - self._transport.calls, 0),
             "token_issued_by_collector": False,
             "database_load_performed": False,
             "artifact_state": STAGING_CONTRACT,
@@ -985,7 +1106,6 @@ async def collect(
     for symbol in symbols:
         state = checkpoint.state_for(symbol)
         if state["done"]:
-            stats.symbols_done += 1
             continue
         while not state["done"]:
             await monitor.assert_healthy()
@@ -1175,8 +1295,10 @@ async def async_main(args: argparse.Namespace) -> int:
     initialize_staging(staging_dir=args.staging_dir, manifest=manifest)
     existing_manifest = json.loads((args.staging_dir / "manifest.json").read_text())
     batch_id = str(existing_manifest["batch_id"])
-    progress = ProgressLog(args.staging_dir / "events" / "progress.jsonl")
-    transport = CountingTransport()
+    progress_path = args.staging_dir / "events" / "progress.jsonl"
+    prior_calls_actual = cumulative_calls_from_progress(progress_path)
+    progress = ProgressLog(progress_path)
+    transport = CountingTransport(initial_calls=prior_calls_actual)
     shared_limiter = get_shared_rate_limiter()
     manager = TossOAuthTokenManager.from_settings(settings, rate_limiter=shared_limiter)
     token_provider = CachedTokenOnlyProvider(manager)
@@ -1201,7 +1323,10 @@ async def async_main(args: argparse.Namespace) -> int:
         SharedTossHealthMonitor(read_toss_api_error_signal),
         ProductionTossLogMonitor(args.production_log),
     )
-    stats = CollectionStats(symbols_total=len(symbols))
+    stats = collection_stats_from_checkpoint(
+        staging_dir=args.staging_dir,
+        symbols=symbols,
+    )
     transient_resumer = TransientResumeBackoff()
     summary_writer = LatestSummaryWriter(
         path=args.staging_dir / "events" / "latest_summary.json",
@@ -1215,6 +1340,9 @@ async def async_main(args: argparse.Namespace) -> int:
             "collection_started",
             scope="top-200 x 4.6y",
             call_budget_declared=args.call_budget,
+            call_accounting=CALL_BUDGET_ACCOUNTING,
+            prior_calls_actual=prior_calls_actual,
+            call_budget_remaining=max(args.call_budget - prior_calls_actual, 0),
             cap_auto_discovery="X-RateLimit-Limit response header",
             intraday_target_tps_max=INTRADAY_TARGET_TPS_MAX,
             intraday_production_chart_headroom_tps=INTRADAY_CHART_HEADROOM_TPS,

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -18,7 +18,9 @@ import asyncio
 import csv
 import hashlib
 import json
+import math
 import os
+import random
 import re
 import time
 from dataclasses import asdict, dataclass
@@ -40,8 +42,12 @@ VALUE_SEMANTICS = "CLOSE_X_VOLUME_SYNTHETIC"
 DEFAULT_START_DATE = date(2021, 12, 20)
 EXPECTED_UNIVERSE_SIZE = 200
 PAGE_SIZE = 200
-PACING_SECONDS_DURING_MARKET = 0.5
-PACING_SECONDS_AFTER_CLOSE = 0.3
+INTRADAY_TARGET_TPS_MAX = 2.0
+INTRADAY_CHART_HEADROOM_TPS = 3.0
+AFTER_CLOSE_TARGET_TPS_MIN = 3.0
+AFTER_CLOSE_TARGET_TPS_MAX = 4.0
+LOW_REMAINING_FRACTION = 0.4
+CONSECUTIVE_429_STOP_AT = 5
 DEFAULT_SHARED_REDIS_URL = "redis://127.0.0.1:6379/0"
 _SETTINGS_PLACEHOLDERS = {
     "KIS_APP_KEY": "toss-phase2-unused",
@@ -103,31 +109,211 @@ def now_kst() -> datetime:
     return datetime.now(KST)
 
 
-def pacing_seconds(at: datetime | None = None) -> float:
-    """Use the operator-approved 0.5 s during KR/NXT hours, else 0.3 s."""
-    current = (at or now_kst()).astimezone(KST).time()
-    if local_time(9, 0) <= current < local_time(20, 0):
-        return PACING_SECONDS_DURING_MARKET
-    return PACING_SECONDS_AFTER_CLOSE
+def _is_intraday(at: datetime) -> bool:
+    current = at.astimezone(KST).time()
+    return local_time(9, 0) <= current < local_time(20, 0)
 
 
-class PacingRateLimiter:
-    """Keep the process-wide Toss limiter and add the Phase 2 serial pacing."""
+class HeaderAdaptiveChartRateLimiter:
+    """A chart-only pace controller whose cap comes from Toss response headers.
 
-    def __init__(self, base: Any, chart_group: Any) -> None:
+    The process-local Toss limiter remains a backstop, but it is not the
+    authoritative chart cap for this bulk collector.  After the first chart
+    response exposes ``X-RateLimit-Limit``, intraday requests reserve three TPS
+    for the production Toss-first chart consumer.  If the provider lowers its
+    cap below that reservation, the collector fails closed before another page
+    request rather than consuming the production budget.
+    """
+
+    def __init__(
+        self,
+        base: Any,
+        chart_group: Any,
+        *,
+        now_kst_fn: Any = now_kst,
+        monotonic_fn: Any = time.monotonic,
+        sleep: Any = asyncio.sleep,
+        jitter_fn: Any = random.uniform,
+    ) -> None:
         self._base = base
         self._chart_group = chart_group
-        self._last_chart_call = 0.0
+        self._now_kst = now_kst_fn
+        self._monotonic = monotonic_fn
+        self._sleep = sleep
+        self._jitter = jitter_fn
+        self._cap: int | None = None
+        self._remaining: int | None = None
+        self._reset_seconds: float | None = None
+        self._retry_after_seconds: float | None = None
+        self._last_chart_call: float | None = None
+        self._low_remaining_not_before = 0.0
+        self._retry_not_before = 0.0
+        self._consecutive_429 = 0
 
-    async def acquire(self, group: Any) -> None:
-        await self._base.acquire(group)
+    @property
+    def cap(self) -> int | None:
+        return self._cap
+
+    @property
+    def cap_auto_discovered(self) -> bool:
+        return self._cap is not None
+
+    @property
+    def consecutive_429(self) -> int:
+        return self._consecutive_429
+
+    @property
+    def remaining(self) -> int | None:
+        return self._remaining
+
+    @property
+    def reset_seconds(self) -> float | None:
+        return self._reset_seconds
+
+    @property
+    def retry_after_seconds(self) -> float | None:
+        return self._retry_after_seconds
+
+    def target_tps(self, at: datetime | None = None) -> float:
+        """Return a dynamic target, never treating a documented value as fixed."""
+
+        current = at or self._now_kst()
+        if _is_intraday(current):
+            if self._cap is None:
+                # At most one startup request can happen before the response
+                # header discovers the cap; no second request is admitted until
+                # ``ensure_cap_discovered`` has run.
+                return INTRADAY_TARGET_TPS_MAX
+            return max(
+                0.0,
+                min(
+                    INTRADAY_TARGET_TPS_MAX,
+                    float(self._cap) - INTRADAY_CHART_HEADROOM_TPS,
+                ),
+            )
+        if self._cap is None:
+            return AFTER_CLOSE_TARGET_TPS_MIN
+        if (
+            self._remaining is not None
+            and self._remaining / self._cap < LOW_REMAINING_FRACTION
+        ):
+            return min(AFTER_CLOSE_TARGET_TPS_MIN, float(self._cap))
+        return min(AFTER_CLOSE_TARGET_TPS_MAX, float(self._cap))
+
+    def intraday_headroom_preserved(self) -> bool | None:
+        if self._cap is None:
+            return None
+        target = max(
+            0.0,
+            min(
+                INTRADAY_TARGET_TPS_MAX,
+                float(self._cap) - INTRADAY_CHART_HEADROOM_TPS,
+            ),
+        )
+        return self._cap - target >= INTRADAY_CHART_HEADROOM_TPS
+
+    def observe_response(
+        self,
+        group: Any,
+        status_code: int,
+        rate_limit_headers: Any,
+    ) -> None:
+        """Consume one response's redacted rate-limit metadata.
+
+        ``TossReadClient`` calls this for successes and failures before it parses
+        the envelope, so a 429 still contributes its Retry-After and reset data.
+        """
+
         if group != self._chart_group:
             return
-        interval = pacing_seconds()
-        elapsed = time.monotonic() - self._last_chart_call
-        if elapsed < interval:
-            await asyncio.sleep(interval - elapsed)
-        self._last_chart_call = time.monotonic()
+        limit = getattr(rate_limit_headers, "limit", None)
+        remaining = getattr(rate_limit_headers, "remaining", None)
+        reset_seconds = getattr(rate_limit_headers, "reset_seconds", None)
+        retry_after_seconds = getattr(rate_limit_headers, "retry_after_seconds", None)
+        if isinstance(limit, int) and not isinstance(limit, bool) and limit > 0:
+            self._cap = limit
+        self._remaining = (
+            remaining
+            if isinstance(remaining, int)
+            and not isinstance(remaining, bool)
+            and remaining >= 0
+            else None
+        )
+        self._reset_seconds = (
+            float(reset_seconds)
+            if isinstance(reset_seconds, (float, int)) and reset_seconds >= 0.0
+            else None
+        )
+        self._retry_after_seconds = (
+            float(retry_after_seconds)
+            if isinstance(retry_after_seconds, (float, int))
+            and retry_after_seconds >= 0.0
+            else None
+        )
+        self._schedule_low_remaining_recovery()
+        if status_code < 400:
+            self._consecutive_429 = 0
+
+    def _schedule_low_remaining_recovery(self) -> None:
+        if (
+            self._cap is None
+            or self._remaining is None
+            or self._reset_seconds is None
+            or self._remaining / self._cap >= LOW_REMAINING_FRACTION
+        ):
+            self._low_remaining_not_before = 0.0
+            return
+        recovery_floor = math.ceil(self._cap * LOW_REMAINING_FRACTION)
+        tokens_to_rebuild = max(recovery_floor - self._remaining + 1, 1)
+        self._low_remaining_not_before = max(
+            self._low_remaining_not_before,
+            self._monotonic() + self._reset_seconds * tokens_to_rebuild,
+        )
+
+    def ensure_cap_discovered(self) -> None:
+        """Fail closed if the documented cap cannot protect shared chart traffic."""
+
+        if self._cap is None:
+            raise CollectionStopped(
+                "chart_rate_limit_cap_not_discovered:X-RateLimit-Limit missing"
+            )
+        if _is_intraday(self._now_kst()) and self.target_tps() <= 0.0:
+            raise CollectionStopped(
+                "chart_headroom_unavailable: "
+                f"cap={self._cap} reserve={INTRADAY_CHART_HEADROOM_TPS:g}"
+            )
+
+    async def acquire(self, group: Any) -> None:
+        if group != self._chart_group:
+            await self._base.acquire(group)
+            return
+        if self._cap is not None:
+            self.ensure_cap_discovered()
+        target_tps = self.target_tps()
+        delay_until = max(self._low_remaining_not_before, self._retry_not_before)
+        if self._last_chart_call is not None and target_tps > 0.0:
+            delay_until = max(delay_until, self._last_chart_call + 1.0 / target_tps)
+        wait_seconds = delay_until - self._monotonic()
+        if wait_seconds > 0.0:
+            await self._sleep(wait_seconds)
+        await self._base.acquire(group)
+        self._last_chart_call = self._monotonic()
+
+    async def backoff_after_429(self) -> tuple[int, float]:
+        """Honor Retry-After and add the documented exponential backoff+jitter."""
+
+        self._consecutive_429 += 1
+        if self._consecutive_429 >= CONSECUTIVE_429_STOP_AT:
+            raise CollectionStopped(f"consecutive_chart_429:{CONSECUTIVE_429_STOP_AT}")
+        exponential = min(2.0 ** (self._consecutive_429 - 1), 16.0)
+        backoff_seconds = exponential + self._jitter(0.0, exponential)
+        retry_after_seconds = self._retry_after_seconds or 0.0
+        delay_seconds = max(retry_after_seconds, backoff_seconds)
+        self._retry_not_before = max(
+            self._retry_not_before, self._monotonic() + delay_seconds
+        )
+        await self._sleep(delay_seconds)
+        return self._consecutive_429, delay_seconds
 
 
 @dataclass(frozen=True)
@@ -136,7 +322,13 @@ class SharedErrorBaseline:
 
 
 class SharedTossHealthMonitor:
-    """Stop this collector if a new shared Toss error is published."""
+    """Stop this collector for non-rate-limit shared Toss failures only.
+
+    A 429 is an overload signal with a documented recovery path, not an
+    immediate stop condition.  Advance the baseline so one external 429 cannot
+    repeatedly trip the collector; the collector's own header-aware retry path
+    controls subsequent chart requests.
+    """
 
     def __init__(self, read_signal: Any) -> None:
         self._read_signal = read_signal
@@ -151,6 +343,9 @@ class SharedTossHealthMonitor:
     async def assert_healthy(self) -> None:
         signal = await self._read_signal()
         if signal is not None and signal.sequence > self._baseline.sequence:
+            self._baseline = SharedErrorBaseline(sequence=signal.sequence)
+            if signal.status_code == 429:
+                return
             raise CollectionStopped(
                 "shared_toss_error_observed: "
                 f"status={signal.status_code} type={signal.error_type} "
@@ -163,6 +358,7 @@ _TOSS_ERROR_LINE = re.compile(
     r"|(?:\b401\b|\b429\b).{0,160}(?:toss|openapi\.tossinvest)",
     re.IGNORECASE,
 )
+_HTTP_429_LINE = re.compile(r"\b429\b")
 
 
 class ProductionTossLogMonitor:
@@ -191,7 +387,14 @@ class ProductionTossLogMonitor:
                 fh.seek(offset)
                 appended = fh.read()
             self._positions[path] = (stat.st_ino, stat.st_size)
-            if _TOSS_ERROR_LINE.search(appended):
+            for line in appended.splitlines():
+                if not _TOSS_ERROR_LINE.search(line):
+                    continue
+                if _HTTP_429_LINE.search(line):
+                    # Retry-After is not available in a redacted log line.  The
+                    # collector must not treat it as a fatal pipe error; its own
+                    # response headers govern retries and adaptive pacing.
+                    continue
                 # Do not copy log content: it can contain an upstream request id
                 # and is unnecessary for the collector's fail-closed decision.
                 raise CollectionStopped(f"production_toss_error_log_observed:{path}")
@@ -488,9 +691,24 @@ def build_manifest(
         },
         "call_budget_declared": call_budget,
         "page_size": PAGE_SIZE,
-        "pacing": {
-            "during_09_00_to_20_00_kst_seconds": PACING_SECONDS_DURING_MARKET,
-            "after_close_seconds": PACING_SECONDS_AFTER_CLOSE,
+        "rate_limit_control": {
+            "mode": "response_header_adaptive",
+            "cap_source": "X-RateLimit-Limit",
+            "hardcoded_chart_cap": False,
+            "remaining_low_fraction": LOW_REMAINING_FRACTION,
+            "intraday": {
+                "target_tps_max": INTRADAY_TARGET_TPS_MAX,
+                "reserved_production_chart_headroom_tps": INTRADAY_CHART_HEADROOM_TPS,
+            },
+            "after_close": {
+                "target_tps_min": AFTER_CLOSE_TARGET_TPS_MIN,
+                "target_tps_max": AFTER_CLOSE_TARGET_TPS_MAX,
+            },
+            "on_429": {
+                "retry_after_required": True,
+                "exponential_backoff_with_jitter": True,
+                "consecutive_stop_at": CONSECUTIVE_429_STOP_AT,
+            },
         },
         "value_semantics": VALUE_SEMANTICS,
         "padding_contract": "is_padding=true iff provider volume is zero; not coverage missing",
@@ -530,6 +748,16 @@ def initialize_staging(
         )
         if any(existing.get(key) != manifest.get(key) for key in immutable_keys):
             raise ValueError("existing staging manifest does not match this collection")
+        # Pages are write-once, but the control policy is operational metadata.
+        # Upgrade the previously staged corpus from the withdrawn fixed-interval
+        # policy before a later, separately authorized resume can append pages.
+        if existing.get("rate_limit_control") != manifest["rate_limit_control"]:
+            existing.pop("pacing", None)
+            existing["rate_limit_control"] = manifest["rate_limit_control"]
+            manifest_path.write_text(
+                json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
         return
     manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
     (staging_dir / "STAGING_ONLY.md").write_text(
@@ -537,7 +765,9 @@ def initialize_staging(
         "This is an append-only Toss combined KRX/NXT collection. It must not be "
         "loaded into a database or used by a backtest until a separately approved "
         "review and load step. `is_padding=true` is a provider placeholder, and "
-        "`value` is synthetic `close * volume`.\n",
+        "`value` is synthetic `close * volume`. Chart rate control is derived from "
+        "the Toss response headers; the collector reserves intraday headroom for "
+        "production chart readers.\n",
         encoding="utf-8",
     )
 
@@ -551,6 +781,8 @@ class CollectionStats:
     pages_reused: int = 0
     http_401: int = 0
     http_429: int = 0
+    chart_rate_limit_cap: int | None = None
+    rate_limit_backoffs: int = 0
     stopped_reason: str | None = None
 
 
@@ -558,6 +790,7 @@ async def collect(
     *,
     client: Any,
     transport: CountingTransport,
+    chart_pacer: HeaderAdaptiveChartRateLimiter,
     monitor: CombinedTossHealthMonitor,
     staging_dir: Path,
     symbols: list[str],
@@ -594,10 +827,36 @@ async def collect(
                     stats.http_401 += 1
                 if status == 429:
                     stats.http_429 += 1
+                    consecutive, delay_seconds = await chart_pacer.backoff_after_429()
+                    stats.rate_limit_backoffs += 1
+                    progress.write(
+                        "chart_429_backoff",
+                        consecutive_429=consecutive,
+                        delay_seconds=delay_seconds,
+                        retry_after_seconds=chart_pacer.retry_after_seconds,
+                        rate_limit_cap=chart_pacer.cap,
+                        rate_limit_remaining=chart_pacer.remaining,
+                        rate_limit_reset_seconds=chart_pacer.reset_seconds,
+                        calls_actual=transport.calls,
+                    )
+                    # Do not advance the checkpoint.  Retrying the same cursor
+                    # is safe because no Parquet page has been written for it.
+                    continue
                 raise CollectionStopped(
                     f"toss_request_failed:{type(exc).__name__}:status={status}"
                 ) from exc
 
+            chart_pacer.ensure_cap_discovered()
+            if stats.chart_rate_limit_cap != chart_pacer.cap:
+                stats.chart_rate_limit_cap = chart_pacer.cap
+                progress.write(
+                    "chart_rate_limit_cap_discovered",
+                    cap=chart_pacer.cap,
+                    remaining=chart_pacer.remaining,
+                    reset_seconds=chart_pacer.reset_seconds,
+                    target_tps=chart_pacer.target_tps(),
+                    intraday_headroom_preserved=chart_pacer.intraday_headroom_preserved(),
+                )
             next_before = page.next_before
             rows = make_rows(
                 candles=list(page.candles),
@@ -640,7 +899,10 @@ async def collect(
                 output=str(destination) if destination is not None else None,
                 output_reused=reused,
                 calls_actual=transport.calls,
-                pacing_seconds=pacing_seconds(),
+                rate_limit_cap=chart_pacer.cap,
+                rate_limit_remaining=chart_pacer.remaining,
+                rate_limit_reset_seconds=chart_pacer.reset_seconds,
+                target_tps=chart_pacer.target_tps(),
             )
             await monitor.assert_healthy()
     return stats
@@ -722,15 +984,22 @@ async def async_main(args: argparse.Namespace) -> int:
     transport = CountingTransport()
     shared_limiter = get_shared_rate_limiter()
     manager = TossOAuthTokenManager.from_settings(settings, rate_limiter=shared_limiter)
+    chart_pacer = HeaderAdaptiveChartRateLimiter(
+        shared_limiter, TossApiGroup.MARKET_DATA_CHART
+    )
     client = TossReadClient(
         token_manager=CachedTokenOnlyProvider(manager),
         base_url=resolve_toss_base_url(
             getattr(settings, "toss_api_base_url", None), DEFAULT_TOSS_BASE_URL
         ),
         transport=transport,
-        rate_limiter=PacingRateLimiter(shared_limiter, TossApiGroup.MARKET_DATA_CHART),
+        rate_limiter=chart_pacer,
         retry_on_429=False,
         retry_auth_reissue=False,
+        response_observer=chart_pacer.observe_response,
+        # This optional reader must not emit its own errors as production health
+        # signals while it is applying its dedicated 429 recovery policy.
+        publish_error_signals=False,
     )
     monitor = CombinedTossHealthMonitor(
         SharedTossHealthMonitor(read_toss_api_error_signal),
@@ -746,7 +1015,15 @@ async def async_main(args: argparse.Namespace) -> int:
             "collection_started",
             scope="top-200 x 4.6y",
             call_budget_declared=args.call_budget,
-            pacing_seconds=pacing_seconds(),
+            cap_auto_discovery="X-RateLimit-Limit response header",
+            intraday_target_tps_max=INTRADAY_TARGET_TPS_MAX,
+            intraday_production_chart_headroom_tps=INTRADAY_CHART_HEADROOM_TPS,
+            low_remaining_fraction=LOW_REMAINING_FRACTION,
+            after_close_target_tps_range=[
+                AFTER_CLOSE_TARGET_TPS_MIN,
+                AFTER_CLOSE_TARGET_TPS_MAX,
+            ],
+            consecutive_429_stop_at=CONSECUTIVE_429_STOP_AT,
             latest_session_excluded=True,
             latest_session_definition=(
                 "session_date_kst >= collection_start_kst_date is excluded"
@@ -759,6 +1036,7 @@ async def async_main(args: argparse.Namespace) -> int:
         stats = await collect(
             client=client,
             transport=transport,
+            chart_pacer=chart_pacer,
             monitor=monitor,
             staging_dir=args.staging_dir,
             symbols=symbols,

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -117,12 +117,14 @@ def _is_intraday(at: datetime) -> bool:
 class HeaderAdaptiveChartRateLimiter:
     """A chart-only pace controller whose cap comes from Toss response headers.
 
-    The process-local Toss limiter remains a backstop, but it is not the
-    authoritative chart cap for this bulk collector.  After the first chart
-    response exposes ``X-RateLimit-Limit``, intraday requests reserve three TPS
-    for the production Toss-first chart consumer.  If the provider lowers its
-    cap below that reservation, the collector fails closed before another page
-    request rather than consuming the production budget.
+    The process-local Toss limiter is retained only for non-chart groups.  The
+    chart path deliberately does not invoke its static local default: this
+    bulk collector's chart cap is determined solely from Toss response headers.
+    After the first chart response exposes ``X-RateLimit-Limit``, intraday
+    requests reserve three TPS for the production Toss-first chart consumer.
+    If the provider lowers its cap below that reservation, the collector fails
+    closed before another page request rather than consuming the production
+    budget.
     """
 
     def __init__(
@@ -296,7 +298,9 @@ class HeaderAdaptiveChartRateLimiter:
         wait_seconds = delay_until - self._monotonic()
         if wait_seconds > 0.0:
             await self._sleep(wait_seconds)
-        await self._base.acquire(group)
+        # Do not defer chart calls to TossRateLimiter here.  Its established
+        # per-process chart default is not shared across clients and would turn
+        # a documented value into a hidden fixed cap for this collector.
         self._last_chart_call = self._monotonic()
 
     async def backoff_after_429(self) -> tuple[int, float]:

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -69,6 +69,10 @@ class CollectionStopped(RuntimeError):
     """A deliberate, fail-closed stop that leaves staging resumable."""
 
 
+class UnclassifiableSessionSegment(CollectionStopped):
+    """A candle outside the approved KST session labels must not be staged."""
+
+
 def _transient_resume_reason(exc: Exception) -> str | None:
     """Classify only failures safe to retry without issuing an OAuth token."""
 
@@ -647,7 +651,9 @@ def classify_session_segment(timestamp_kst: datetime) -> str:
         return "KRX_REGULAR"
     if local_time(15, 30) < clock <= local_time(20, 0):
         return "NXT_POST"
-    return "UNKNOWN"
+    raise UnclassifiableSessionSegment(
+        "session_segment_unclassifiable:" + timestamp_kst.astimezone(KST).isoformat()
+    )
 
 
 def normalize_timestamp(raw: Any) -> tuple[datetime, datetime]:

--- a/research/toss_phase2/collect.py
+++ b/research/toss_phase2/collect.py
@@ -831,6 +831,10 @@ async def collect(
                     stats.http_401 += 1
                 if status == 429:
                     stats.http_429 += 1
+                    # The startup 429 is still the first response from which
+                    # the provider must reveal the live cap.  Never send a
+                    # second chart request under an unknown cap.
+                    chart_pacer.ensure_cap_discovered()
                     consecutive, delay_seconds = await chart_pacer.backoff_after_429()
                     stats.rate_limit_backoffs += 1
                     progress.write(

--- a/research/toss_phase2/load.py
+++ b/research/toss_phase2/load.py
@@ -13,6 +13,7 @@ import asyncio
 import fcntl
 import hashlib
 import json
+import math
 import os
 import sqlite3
 import time
@@ -62,6 +63,11 @@ DEFAULT_COMMIT_ROWS = 20_000
 PREFLIGHT_FRAGMENT_CHUNK = 500
 STATE_VERSION = 1
 KST = timezone(timedelta(hours=9))
+# Staging values are emitted as IEEE-754 doubles.  This admits only the
+# round-off expected from serialising ``close * volume``, not a materially
+# different synthetic value.
+VALUE_RELATIVE_TOLERANCE = 1e-12
+VALUE_ABSOLUTE_TOLERANCE = 1e-6
 
 
 class LoadStopped(RuntimeError):
@@ -245,7 +251,7 @@ def freeze_completed_fragments(
         return existing
 
     if min_fragment_age_seconds <= 0:
-        raise ValueError("min_fragment_age_seconds must be positive")
+        raise LoadStopped("min_fragment_age_seconds_must_be_positive")
     manifest = _manifest(staging_dir)
     batch_id = str(manifest["batch_id"])
     cutoff_ns = (now_ns if now_ns is not None else time.time_ns()) - (
@@ -388,6 +394,58 @@ def _validate_batch(
         for volume, padding in zip(volumes, paddings, strict=True)
     ):
         raise StagingValidationError(f"invalid_padding_semantics:{path.name}")
+
+    opens = _column(batch, "open").to_pylist()
+    highs = _column(batch, "high").to_pylist()
+    lows = _column(batch, "low").to_pylist()
+    closes = _column(batch, "close").to_pylist()
+    values = _column(batch, "value").to_pylist()
+    for open_, high, low, close, volume, value in zip(
+        opens,
+        highs,
+        lows,
+        closes,
+        volumes,
+        values,
+        strict=True,
+    ):
+        try:
+            open_float = float(open_)
+            high_float = float(high)
+            low_float = float(low)
+            close_float = float(close)
+            volume_float = float(volume)
+            value_float = float(value)
+        except (TypeError, ValueError) as exc:
+            raise StagingValidationError(
+                f"non_numeric_candle_value:{path.name}"
+            ) from exc
+        numeric_values = (
+            open_float,
+            high_float,
+            low_float,
+            close_float,
+            volume_float,
+            value_float,
+        )
+        if not all(math.isfinite(number) for number in numeric_values):
+            raise StagingValidationError(f"non_finite_candle_value:{path.name}")
+        if volume_float < 0:
+            raise StagingValidationError(f"negative_volume:{path.name}")
+        if min(open_float, high_float, low_float, close_float) < 0:
+            raise StagingValidationError(f"negative_ohlc_value:{path.name}")
+        if high_float < max(open_float, close_float) or low_float > min(
+            open_float, close_float
+        ):
+            raise StagingValidationError(f"incoherent_ohlc_values:{path.name}")
+        expected_value = close_float * volume_float
+        if not math.isclose(
+            value_float,
+            expected_value,
+            rel_tol=VALUE_RELATIVE_TOLERANCE,
+            abs_tol=VALUE_ABSOLUTE_TOLERANCE,
+        ):
+            raise StagingValidationError(f"synthetic_value_mismatch:{path.name}")
 
 
 def iter_validated_batches(
@@ -718,6 +776,8 @@ async def _assert_database_ready(
     target_rows = int(await conn.fetchval(f"SELECT count(*) FROM {TARGET_TABLE}"))
     initial_rows = checkpoint.get("initial_target_rows")
     if initial_rows is None:
+        if target_rows != 0:
+            raise DatabaseLoadError("nonempty_target_at_initial_load")
         checkpoint["initial_target_rows"] = target_rows
     elif initial_rows != 0:
         raise DatabaseLoadError("nonempty_target_at_initial_load")
@@ -807,7 +867,7 @@ async def load_snapshot(
     """Load the frozen snapshot with DB transactions before checkpoint writes."""
 
     if commit_rows <= 0:
-        raise ValueError("commit_rows must be positive")
+        raise LoadStopped("commit_rows_must_be_positive")
     fragments = _frozen_fragments(snapshot)
     checkpoint = _load_checkpoint(state_dir, str(snapshot["digest"]))
     start_index = checkpoint.get("next_fragment_index")
@@ -953,7 +1013,7 @@ async def verify_snapshot(
         )
         duplicate_rows = int(
             await conn.fetchval(
-                f"SELECT count(*) - count(DISTINCT (session_date_kst, symbol, time_utc)) "
+                f"SELECT count(*) - count(DISTINCT (time_utc, symbol)) "
                 f"FROM {TARGET_TABLE}"
             )
         )
@@ -997,6 +1057,10 @@ def parse_args() -> argparse.Namespace:
 async def async_main(args: argparse.Namespace) -> int:
     staging_dir = args.staging_dir.resolve()
     state_dir = args.state_dir.resolve()
+    if args.min_fragment_age_seconds <= 0:
+        raise LoadStopped("min_fragment_age_seconds_must_be_positive")
+    if args.commit_rows <= 0:
+        raise LoadStopped("commit_rows_must_be_positive")
     _assert_state_dir_is_separate(staging_dir, state_dir)
     with StateDirectoryLock(state_dir):
         snapshot = freeze_completed_fragments(

--- a/research/toss_phase2/load.py
+++ b/research/toss_phase2/load.py
@@ -1,0 +1,1064 @@
+"""Fail-closed, resumable loader for the Toss combined-KRX/NXT staging corpus.
+
+This is intentionally a manual CLI, never a scheduled job.  It snapshots only
+old-enough, immutable Parquet pages and writes only
+``research.kr_candles_1m_toss``.  The source staging directory is read-only;
+all loader state lives in a separate operator-selected directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import fcntl
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from collections.abc import Iterator, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import asyncpg
+import pyarrow as pa
+import pyarrow.parquet as pq
+from dotenv import dotenv_values
+
+TARGET_TABLE = "research.kr_candles_1m_toss"
+EXPECTED_DB_ROLE = "auto_trader_kr_backfill"
+SOURCE = "TOSS"
+VALUE_SEMANTICS = "CLOSE_X_VOLUME_SYNTHETIC"
+STAGING_CONTRACT = "STAGING_ONLY_NOT_BACKTEST_INPUT"
+VALID_SESSION_SEGMENTS = frozenset({"NXT_PRE", "KRX_REGULAR", "NXT_POST"})
+
+# This order is deliberately shared by Parquet reads, COPY records, the temp
+# table, and the target INSERT.  It is the entire physical target schema: no
+# public relation or KRX-only research table appears in this loader.
+REQUIRED_COLUMNS = (
+    "time_utc",
+    "session_date_kst",
+    "symbol",
+    "session_segment",
+    "source",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "value",
+    "value_semantics",
+    "is_padding",
+    "pre_nxt",
+    "retrieved_at",
+    "batch_id",
+)
+NULLABLE_COLUMNS = frozenset({"pre_nxt"})
+DEFAULT_MIN_FRAGMENT_AGE_SECONDS = 120
+DEFAULT_COMMIT_ROWS = 20_000
+PREFLIGHT_FRAGMENT_CHUNK = 500
+STATE_VERSION = 1
+KST = timezone(timedelta(hours=9))
+
+
+class LoadStopped(RuntimeError):
+    """A fail-closed stop; callers must not continue around it."""
+
+
+class StagingValidationError(LoadStopped):
+    """A staged fragment violates the frozen loader contract."""
+
+
+class DatabaseLoadError(LoadStopped):
+    """The database did not provide the expected all-or-nothing result."""
+
+
+@dataclass(frozen=True)
+class FrozenFragment:
+    """A stable, completed Parquet file selected into one immutable snapshot."""
+
+    relative_path: str
+    symbol: str
+    size_bytes: int
+    mtime_ns: int
+    row_count: int
+
+
+@dataclass(frozen=True)
+class MergeResult:
+    source_rows: int
+    preexisting_rows: int
+    inserted_rows: int
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    source_rows: int
+    db_rows_verified: int
+    target_rows: int
+    batch_rows: int
+    duplicate_rows: int
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False, indent=2, sort_keys=True)
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(temporary, path)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LoadStopped(f"invalid_state_file:{path.name}") from exc
+    if not isinstance(payload, dict):
+        raise LoadStopped(f"invalid_state_object:{path.name}")
+    return payload
+
+
+def _snapshot_digest(snapshot: dict[str, Any]) -> str:
+    stable = {
+        "batch_id": snapshot["batch_id"],
+        "fragments": snapshot["fragments"],
+        "source_rows": snapshot["source_rows"],
+        "staging_dir": snapshot["staging_dir"],
+    }
+    encoded = json.dumps(stable, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _metadata_text(metadata: dict[bytes, bytes], key: str, path: Path) -> str:
+    raw = metadata.get(key.encode())
+    if raw is None:
+        raise StagingValidationError(f"missing_parquet_metadata:{key}:{path.name}")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise StagingValidationError(
+            f"invalid_parquet_metadata:{key}:{path.name}"
+        ) from exc
+
+
+def _fragment_symbol(relative_path: Path) -> str:
+    if len(relative_path.parts) < 3 or relative_path.parts[0] != "data":
+        raise StagingValidationError(f"unexpected_fragment_path:{relative_path}")
+    partition = relative_path.parts[-2]
+    if not partition.startswith("symbol=") or not partition.removeprefix("symbol="):
+        raise StagingValidationError(f"unexpected_fragment_partition:{relative_path}")
+    return partition.removeprefix("symbol=")
+
+
+def _read_fragment_header(
+    path: Path,
+    *,
+    expected_batch_id: str,
+    expected_symbol: str,
+) -> int:
+    parquet = pq.ParquetFile(path)
+    try:
+        metadata = parquet.metadata.metadata or {}
+        if _metadata_text(metadata, "artifact_state", path) != STAGING_CONTRACT:
+            raise StagingValidationError(f"unexpected_artifact_state:{path.name}")
+        if _metadata_text(metadata, "source", path) != SOURCE:
+            raise StagingValidationError(f"unexpected_fragment_source:{path.name}")
+        if _metadata_text(metadata, "value_semantics", path) != VALUE_SEMANTICS:
+            raise StagingValidationError(f"unexpected_value_semantics:{path.name}")
+        if _metadata_text(metadata, "batch_id", path) != expected_batch_id:
+            raise StagingValidationError(f"batch_id_mismatch:{path.name}")
+        if _metadata_text(metadata, "symbol", path) != expected_symbol:
+            raise StagingValidationError(f"symbol_metadata_mismatch:{path.name}")
+        missing = set(REQUIRED_COLUMNS) - set(parquet.schema_arrow.names)
+        if missing:
+            raise StagingValidationError(
+                "missing_parquet_columns:" + ",".join(sorted(missing)) + f":{path.name}"
+            )
+        row_count = parquet.metadata.num_rows
+        if row_count <= 0:
+            raise StagingValidationError(f"empty_completed_fragment:{path.name}")
+        return row_count
+    finally:
+        parquet.close()
+
+
+def _manifest(staging_dir: Path) -> dict[str, Any]:
+    manifest_path = staging_dir / "manifest.json"
+    payload = _read_json(manifest_path)
+    if payload.get("artifact_state") != STAGING_CONTRACT:
+        raise StagingValidationError("unexpected_staging_manifest_contract")
+    batch_id = payload.get("batch_id")
+    if not isinstance(batch_id, str) or not batch_id:
+        raise StagingValidationError("missing_staging_batch_id")
+    return payload
+
+
+def _assert_state_dir_is_separate(staging_dir: Path, state_dir: Path) -> None:
+    staging = staging_dir.resolve()
+    state = state_dir.resolve()
+    if state == Path("/") or state == staging or staging in state.parents:
+        raise LoadStopped("state_dir_must_be_outside_staging_dir")
+
+
+def _snapshot_path(state_dir: Path) -> Path:
+    return state_dir / "snapshot.json"
+
+
+def _load_snapshot(state_dir: Path) -> dict[str, Any] | None:
+    path = _snapshot_path(state_dir)
+    if not path.exists():
+        return None
+    snapshot = _read_json(path)
+    if snapshot.get("version") != STATE_VERSION:
+        raise LoadStopped("unsupported_snapshot_version")
+    if not isinstance(snapshot.get("fragments"), list):
+        raise LoadStopped("invalid_snapshot_fragments")
+    if snapshot.get("digest") != _snapshot_digest(snapshot):
+        raise LoadStopped("snapshot_digest_mismatch")
+    return snapshot
+
+
+def freeze_completed_fragments(
+    *,
+    staging_dir: Path,
+    state_dir: Path,
+    min_fragment_age_seconds: int,
+    now_ns: int | None = None,
+) -> dict[str, Any]:
+    """Freeze only final, old-enough Parquet pages without changing staging."""
+
+    _assert_state_dir_is_separate(staging_dir, state_dir)
+    existing = _load_snapshot(state_dir)
+    if existing is not None:
+        if Path(str(existing["staging_dir"])).resolve() != staging_dir.resolve():
+            raise LoadStopped("snapshot_staging_dir_mismatch")
+        return existing
+
+    if min_fragment_age_seconds <= 0:
+        raise ValueError("min_fragment_age_seconds must be positive")
+    manifest = _manifest(staging_dir)
+    batch_id = str(manifest["batch_id"])
+    cutoff_ns = (now_ns if now_ns is not None else time.time_ns()) - (
+        min_fragment_age_seconds * 1_000_000_000
+    )
+    data_dir = staging_dir / "data"
+    if not data_dir.is_dir():
+        raise StagingValidationError("staging_data_directory_missing")
+
+    fragments: list[FrozenFragment] = []
+    skipped_too_recent = 0
+    for path in sorted(data_dir.rglob("*.parquet")):
+        stat_before = path.stat()
+        if stat_before.st_mtime_ns > cutoff_ns:
+            skipped_too_recent += 1
+            continue
+        relative_path = path.relative_to(staging_dir)
+        symbol = _fragment_symbol(relative_path)
+        row_count = _read_fragment_header(
+            path,
+            expected_batch_id=batch_id,
+            expected_symbol=symbol,
+        )
+        stat_after = path.stat()
+        if (
+            stat_before.st_size != stat_after.st_size
+            or stat_before.st_mtime_ns != stat_after.st_mtime_ns
+        ):
+            raise StagingValidationError(
+                f"fragment_changed_during_snapshot:{path.name}"
+            )
+        fragments.append(
+            FrozenFragment(
+                relative_path=str(relative_path),
+                symbol=symbol,
+                size_bytes=stat_before.st_size,
+                mtime_ns=stat_before.st_mtime_ns,
+                row_count=row_count,
+            )
+        )
+
+    if not fragments:
+        raise StagingValidationError("no_completed_fragments_available")
+    partial_files = sum(1 for _ in data_dir.rglob("*.partial"))
+    snapshot: dict[str, Any] = {
+        "version": STATE_VERSION,
+        "created_at_utc": _utc_now(),
+        "staging_dir": str(staging_dir.resolve()),
+        "batch_id": batch_id,
+        "min_fragment_age_seconds": min_fragment_age_seconds,
+        "completed_fragments_only": True,
+        "partial_files_excluded": partial_files,
+        "too_recent_files_excluded": skipped_too_recent,
+        "fragments": [asdict(fragment) for fragment in fragments],
+        "source_rows": sum(fragment.row_count for fragment in fragments),
+    }
+    snapshot["digest"] = _snapshot_digest(snapshot)
+    _atomic_write_json(_snapshot_path(state_dir), snapshot)
+    return snapshot
+
+
+def _frozen_fragments(snapshot: dict[str, Any]) -> list[FrozenFragment]:
+    try:
+        fragments = [FrozenFragment(**fragment) for fragment in snapshot["fragments"]]
+    except (TypeError, KeyError) as exc:
+        raise LoadStopped("invalid_snapshot_fragment_shape") from exc
+    if sum(fragment.row_count for fragment in fragments) != snapshot["source_rows"]:
+        raise LoadStopped("snapshot_row_count_mismatch")
+    return fragments
+
+
+def _assert_fragment_unchanged(
+    staging_dir: Path,
+    fragment: FrozenFragment,
+) -> Path:
+    path = staging_dir / fragment.relative_path
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        raise StagingValidationError(
+            f"frozen_fragment_missing:{fragment.relative_path}"
+        ) from exc
+    if stat.st_size != fragment.size_bytes or stat.st_mtime_ns != fragment.mtime_ns:
+        raise StagingValidationError(
+            f"frozen_fragment_changed:{fragment.relative_path}"
+        )
+    return path
+
+
+def _column(batch: pa.RecordBatch, name: str) -> pa.Array:
+    index = batch.schema.get_field_index(name)
+    if index < 0:
+        raise StagingValidationError(f"missing_batch_column:{name}")
+    return batch.column(index)
+
+
+def _validate_batch(
+    batch: pa.RecordBatch,
+    *,
+    symbol: str,
+    batch_id: str,
+    path: Path,
+) -> None:
+    for name in REQUIRED_COLUMNS:
+        if name not in NULLABLE_COLUMNS and _column(batch, name).null_count:
+            raise StagingValidationError(f"null_required_value:{name}:{path.name}")
+
+    segments = set(_column(batch, "session_segment").to_pylist())
+    invalid_segments = segments - VALID_SESSION_SEGMENTS
+    if invalid_segments:
+        raise StagingValidationError(
+            "session_segment_unclassifiable:"
+            + ",".join(sorted(str(value) for value in invalid_segments))
+            + f":{path.name}"
+        )
+    if any(value != symbol for value in _column(batch, "symbol").to_pylist()):
+        raise StagingValidationError(f"fragment_symbol_row_mismatch:{path.name}")
+    if any(value != SOURCE for value in _column(batch, "source").to_pylist()):
+        raise StagingValidationError(f"unexpected_row_source:{path.name}")
+    if any(
+        value != VALUE_SEMANTICS
+        for value in _column(batch, "value_semantics").to_pylist()
+    ):
+        raise StagingValidationError(f"unexpected_row_value_semantics:{path.name}")
+    if any(value != batch_id for value in _column(batch, "batch_id").to_pylist()):
+        raise StagingValidationError(f"fragment_batch_id_row_mismatch:{path.name}")
+
+    times = _column(batch, "time_utc").to_pylist()
+    dates = _column(batch, "session_date_kst").to_pylist()
+    for timestamp, session_date in zip(times, dates, strict=True):
+        if timestamp.tzinfo is None or timestamp.astimezone(KST).date() != session_date:
+            raise StagingValidationError(f"session_date_timestamp_mismatch:{path.name}")
+        if timestamp.second or timestamp.microsecond:
+            raise StagingValidationError(f"non_minute_timestamp:{path.name}")
+
+    volumes = _column(batch, "volume").to_pylist()
+    paddings = _column(batch, "is_padding").to_pylist()
+    if any(
+        bool(padding) is not (float(volume) == 0.0)
+        for volume, padding in zip(volumes, paddings, strict=True)
+    ):
+        raise StagingValidationError(f"invalid_padding_semantics:{path.name}")
+
+
+def iter_validated_batches(
+    *,
+    staging_dir: Path,
+    fragment: FrozenFragment,
+    batch_id: str,
+) -> Iterator[pa.RecordBatch]:
+    """Read one frozen page and validate every row before exposing it."""
+
+    path = _assert_fragment_unchanged(staging_dir, fragment)
+    _read_fragment_header(
+        path,
+        expected_batch_id=batch_id,
+        expected_symbol=fragment.symbol,
+    )
+    parquet = pq.ParquetFile(path)
+    rows_read = 0
+    try:
+        for batch in parquet.iter_batches(
+            batch_size=8192,
+            columns=list(REQUIRED_COLUMNS),
+        ):
+            _validate_batch(
+                batch,
+                symbol=fragment.symbol,
+                batch_id=batch_id,
+                path=path,
+            )
+            rows_read += batch.num_rows
+            yield batch
+    finally:
+        parquet.close()
+    if rows_read != fragment.row_count:
+        raise StagingValidationError(f"fragment_row_count_changed:{path.name}")
+
+
+def _key_pairs(batch: pa.RecordBatch) -> list[tuple[int, str]]:
+    timestamps = _column(batch, "time_utc").cast(pa.int64()).to_pylist()
+    symbols = _column(batch, "symbol").to_pylist()
+    return list(zip(timestamps, symbols, strict=True))
+
+
+def _records(batch: pa.RecordBatch) -> list[tuple[Any, ...]]:
+    values = [_column(batch, column).to_pylist() for column in REQUIRED_COLUMNS]
+    return list(zip(*values, strict=True))
+
+
+class SourceKeyIndex:
+    """Durable local uniqueness proof for the frozen source rows."""
+
+    def __init__(self, *, state_dir: Path, snapshot_digest: str) -> None:
+        self._path = state_dir / "source_keys.sqlite3"
+        self._connection = sqlite3.connect(self._path)
+        self._connection.execute("PRAGMA journal_mode=DELETE")
+        self._connection.execute("PRAGMA synchronous=FULL")
+        self._connection.execute(
+            "CREATE TABLE IF NOT EXISTS load_metadata "
+            "(key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        self._connection.execute(
+            "CREATE TABLE IF NOT EXISTS source_keys "
+            "(time_utc_us INTEGER NOT NULL, symbol TEXT NOT NULL, "
+            "PRIMARY KEY (time_utc_us, symbol)) WITHOUT ROWID"
+        )
+        existing = self._metadata("snapshot_digest")
+        if existing is None:
+            self._set_metadata("snapshot_digest", snapshot_digest)
+            self._set_metadata("preflight_next_fragment", "0")
+            self._set_metadata("preflight_complete", "0")
+            self._connection.commit()
+        elif existing != snapshot_digest:
+            raise LoadStopped("source_key_index_snapshot_mismatch")
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def _metadata(self, key: str) -> str | None:
+        row = self._connection.execute(
+            "SELECT value FROM load_metadata WHERE key = ?", (key,)
+        ).fetchone()
+        return None if row is None else str(row[0])
+
+    def _set_metadata(self, key: str, value: str) -> None:
+        self._connection.execute(
+            "INSERT INTO load_metadata (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+
+    @property
+    def next_fragment(self) -> int:
+        value = self._metadata("preflight_next_fragment")
+        if value is None or not value.isdigit():
+            raise LoadStopped("invalid_preflight_checkpoint")
+        return int(value)
+
+    @property
+    def complete(self) -> bool:
+        return self._metadata("preflight_complete") == "1"
+
+    def begin(self) -> None:
+        self._connection.execute("BEGIN IMMEDIATE")
+
+    def add(self, pairs: Sequence[tuple[int, str]]) -> None:
+        try:
+            self._connection.executemany(
+                "INSERT INTO source_keys (time_utc_us, symbol) VALUES (?, ?)",
+                pairs,
+            )
+        except sqlite3.IntegrityError as exc:
+            raise StagingValidationError("duplicate_staging_key") from exc
+
+    def commit_through(self, next_fragment: int) -> None:
+        self._set_metadata("preflight_next_fragment", str(next_fragment))
+        self._connection.commit()
+
+    def mark_complete(self) -> None:
+        self._connection.execute("BEGIN IMMEDIATE")
+        self._set_metadata("preflight_complete", "1")
+        self._connection.commit()
+
+    def rollback(self) -> None:
+        self._connection.rollback()
+
+    def key_count(self) -> int:
+        return int(
+            self._connection.execute("SELECT count(*) FROM source_keys").fetchone()[0]
+        )
+
+
+def preflight_source(
+    *,
+    staging_dir: Path,
+    state_dir: Path,
+    snapshot: dict[str, Any],
+) -> None:
+    """Prove every frozen row is valid and source-key-unique before DB writes."""
+
+    fragments = _frozen_fragments(snapshot)
+    index = SourceKeyIndex(state_dir=state_dir, snapshot_digest=str(snapshot["digest"]))
+    try:
+        if index.complete:
+            if index.key_count() != snapshot["source_rows"]:
+                raise LoadStopped("completed_source_key_index_count_mismatch")
+            return
+        next_fragment = index.next_fragment
+        if next_fragment > len(fragments):
+            raise LoadStopped("preflight_checkpoint_out_of_range")
+        for start in range(next_fragment, len(fragments), PREFLIGHT_FRAGMENT_CHUNK):
+            stop = min(start + PREFLIGHT_FRAGMENT_CHUNK, len(fragments))
+            index.begin()
+            try:
+                for fragment in fragments[start:stop]:
+                    for batch in iter_validated_batches(
+                        staging_dir=staging_dir,
+                        fragment=fragment,
+                        batch_id=str(snapshot["batch_id"]),
+                    ):
+                        index.add(_key_pairs(batch))
+                index.commit_through(stop)
+            except Exception:
+                index.rollback()
+                raise
+        if index.key_count() != snapshot["source_rows"]:
+            raise StagingValidationError("staging_key_count_mismatch")
+        index.mark_complete()
+    finally:
+        index.close()
+
+
+class StateDirectoryLock:
+    """Refuse two local loaders from sharing one checkpoint state directory."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self._path = state_dir / ".loader.lock"
+        self._handle: Any | None = None
+
+    def __enter__(self) -> StateDirectoryLock:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self._path.open("a", encoding="utf-8")
+        try:
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            self._handle.close()
+            raise LoadStopped("loader_state_directory_locked") from exc
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._handle is not None:
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+            self._handle.close()
+
+
+def _load_checkpoint_path(state_dir: Path) -> Path:
+    return state_dir / "load_checkpoint.json"
+
+
+def _load_checkpoint(state_dir: Path, snapshot_digest: str) -> dict[str, Any]:
+    path = _load_checkpoint_path(state_dir)
+    if not path.exists():
+        checkpoint = {
+            "version": STATE_VERSION,
+            "snapshot_digest": snapshot_digest,
+            "next_fragment_index": 0,
+            "checkpointed_source_rows": 0,
+            "db_batches": 0,
+            "initial_target_rows": None,
+            "load_complete": False,
+        }
+        _atomic_write_json(path, checkpoint)
+        return checkpoint
+    checkpoint = _read_json(path)
+    if checkpoint.get("version") != STATE_VERSION:
+        raise LoadStopped("unsupported_load_checkpoint_version")
+    if checkpoint.get("snapshot_digest") != snapshot_digest:
+        raise LoadStopped("load_checkpoint_snapshot_mismatch")
+    return checkpoint
+
+
+def _save_load_checkpoint(state_dir: Path, checkpoint: dict[str, Any]) -> None:
+    _atomic_write_json(_load_checkpoint_path(state_dir), checkpoint)
+
+
+def _database_url(env_file: Path) -> str:
+    if "prod" in env_file.name.casefold() or not env_file.is_file():
+        raise LoadStopped("dedicated_non_production_named_db_env_file_required")
+    configured = dotenv_values(env_file).get("DATABASE_URL")
+    if not configured:
+        raise LoadStopped("DATABASE_URL_missing_from_dedicated_db_env_file")
+    url = str(configured).replace("postgresql+asyncpg://", "postgresql://", 1)
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"postgresql", "postgres"} or not parsed.hostname:
+        raise LoadStopped("invalid_dedicated_database_url")
+    if parsed.username != EXPECTED_DB_ROLE:
+        raise LoadStopped("unexpected_database_role")
+    return url
+
+
+TEMP_TABLE = "toss_phase2_load_stage"
+TEMP_TABLE_SQL = f"""
+CREATE TEMP TABLE IF NOT EXISTS {TEMP_TABLE} (
+    time_utc TIMESTAMPTZ NOT NULL,
+    session_date_kst DATE NOT NULL,
+    symbol TEXT NOT NULL,
+    session_segment TEXT NOT NULL,
+    source TEXT NOT NULL,
+    open DOUBLE PRECISION NOT NULL,
+    high DOUBLE PRECISION NOT NULL,
+    low DOUBLE PRECISION NOT NULL,
+    close DOUBLE PRECISION NOT NULL,
+    volume DOUBLE PRECISION NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    value_semantics TEXT NOT NULL,
+    is_padding BOOLEAN NOT NULL,
+    pre_nxt BOOLEAN,
+    retrieved_at TIMESTAMPTZ NOT NULL,
+    batch_id TEXT NOT NULL
+) ON COMMIT DELETE ROWS
+"""
+INSERT_SQL = f"""
+INSERT INTO {TARGET_TABLE} ({", ".join(REQUIRED_COLUMNS)})
+SELECT
+    time_utc,
+    session_date_kst,
+    symbol,
+    session_segment,
+    source,
+    open::numeric,
+    high::numeric,
+    low::numeric,
+    close::numeric,
+    volume::numeric,
+    value::numeric,
+    value_semantics,
+    is_padding,
+    pre_nxt,
+    retrieved_at,
+    batch_id
+FROM {TEMP_TABLE}
+ON CONFLICT (time_utc, symbol) DO NOTHING
+"""
+CONFLICT_COUNT_SQL = f"""
+SELECT count(*)
+FROM {TEMP_TABLE} AS incoming
+JOIN {TARGET_TABLE} AS stored USING (time_utc, symbol)
+WHERE stored.session_date_kst IS DISTINCT FROM incoming.session_date_kst
+   OR stored.session_segment IS DISTINCT FROM incoming.session_segment
+   OR stored.source IS DISTINCT FROM incoming.source
+   OR stored.open IS DISTINCT FROM incoming.open::numeric
+   OR stored.high IS DISTINCT FROM incoming.high::numeric
+   OR stored.low IS DISTINCT FROM incoming.low::numeric
+   OR stored.close IS DISTINCT FROM incoming.close::numeric
+   OR stored.volume IS DISTINCT FROM incoming.volume::numeric
+   OR stored.value IS DISTINCT FROM incoming.value::numeric
+   OR stored.value_semantics IS DISTINCT FROM incoming.value_semantics
+   OR stored.is_padding IS DISTINCT FROM incoming.is_padding
+   OR stored.pre_nxt IS DISTINCT FROM incoming.pre_nxt
+"""
+STAGED_COUNT_SQL = f"SELECT count(*) FROM {TEMP_TABLE}"
+STAGED_DUPLICATE_COUNT_SQL = f"""
+SELECT count(*) - count(DISTINCT (time_utc, symbol)) FROM {TEMP_TABLE}
+"""
+PRESENT_COUNT_SQL = f"""
+SELECT count(*) FROM {TEMP_TABLE} AS incoming
+JOIN {TARGET_TABLE} AS stored USING (time_utc, symbol)
+"""
+EXISTING_COUNT_SQL = PRESENT_COUNT_SQL
+
+
+async def _assert_database_ready(
+    conn: asyncpg.Connection,
+    *,
+    expected_source_rows: int,
+    checkpoint: dict[str, Any],
+) -> None:
+    current_role = await conn.fetchval("SELECT current_user")
+    if current_role != EXPECTED_DB_ROLE:
+        raise DatabaseLoadError("database_role_changed_after_connect")
+    relation = await conn.fetchval("SELECT to_regclass($1)", TARGET_TABLE)
+    if relation is None:
+        raise DatabaseLoadError("target_table_missing")
+    can_insert = await conn.fetchval(
+        "SELECT has_table_privilege(current_user, $1, 'INSERT')", TARGET_TABLE
+    )
+    if not can_insert:
+        raise DatabaseLoadError("target_insert_privilege_missing")
+    target_rows = int(await conn.fetchval(f"SELECT count(*) FROM {TARGET_TABLE}"))
+    initial_rows = checkpoint.get("initial_target_rows")
+    if initial_rows is None:
+        checkpoint["initial_target_rows"] = target_rows
+    elif initial_rows != 0:
+        raise DatabaseLoadError("nonempty_target_at_initial_load")
+    if target_rows > expected_source_rows:
+        raise DatabaseLoadError("target_row_count_exceeds_frozen_source")
+
+
+async def _acquire_database_lock(conn: asyncpg.Connection) -> None:
+    acquired = await conn.fetchval(
+        "SELECT pg_try_advisory_lock(hashtext($1))", "toss_phase2_staging_loader_v1"
+    )
+    if not acquired:
+        raise DatabaseLoadError("another_toss_loader_holds_database_lock")
+
+
+async def _connect_database(database_url: str) -> asyncpg.Connection:
+    try:
+        return await asyncpg.connect(database_url)
+    except asyncpg.PostgresError as exc:
+        raise DatabaseLoadError(f"database_error:{type(exc).__name__}") from exc
+
+
+async def _merge_records(
+    conn: asyncpg.Connection,
+    records: Sequence[tuple[Any, ...]],
+) -> MergeResult:
+    if not records:
+        return MergeResult(source_rows=0, preexisting_rows=0, inserted_rows=0)
+    async with conn.transaction():
+        await conn.copy_records_to_table(
+            TEMP_TABLE,
+            records=records,
+            columns=list(REQUIRED_COLUMNS),
+        )
+        staged_rows = int(await conn.fetchval(STAGED_COUNT_SQL))
+        if staged_rows != len(records):
+            raise DatabaseLoadError("temporary_stage_row_count_mismatch")
+        staged_duplicates = int(await conn.fetchval(STAGED_DUPLICATE_COUNT_SQL))
+        if staged_duplicates:
+            raise DatabaseLoadError("duplicate_key_reached_database_stage")
+        conflicts = int(await conn.fetchval(CONFLICT_COUNT_SQL))
+        if conflicts:
+            raise DatabaseLoadError("existing_target_value_conflict")
+        preexisting = int(await conn.fetchval(EXISTING_COUNT_SQL))
+        await conn.execute(INSERT_SQL)
+        present = int(await conn.fetchval(PRESENT_COUNT_SQL))
+        if present != len(records):
+            raise DatabaseLoadError("target_coverage_mismatch_after_merge")
+    return MergeResult(
+        source_rows=len(records),
+        preexisting_rows=preexisting,
+        inserted_rows=len(records) - preexisting,
+    )
+
+
+def _record_fragments(
+    *,
+    staging_dir: Path,
+    fragments: Sequence[FrozenFragment],
+    batch_id: str,
+) -> Iterator[tuple[int, list[tuple[Any, ...]]]]:
+    """Yield full-file buffers so a checkpoint never splits a source page."""
+
+    for index, fragment in enumerate(fragments):
+        records: list[tuple[Any, ...]] = []
+        for batch in iter_validated_batches(
+            staging_dir=staging_dir,
+            fragment=fragment,
+            batch_id=batch_id,
+        ):
+            records.extend(_records(batch))
+        if len(records) != fragment.row_count:
+            raise StagingValidationError(
+                f"record_materialization_count_mismatch:{fragment.relative_path}"
+            )
+        yield index, records
+
+
+async def load_snapshot(
+    *,
+    staging_dir: Path,
+    state_dir: Path,
+    snapshot: dict[str, Any],
+    database_url: str,
+    commit_rows: int,
+) -> dict[str, Any]:
+    """Load the frozen snapshot with DB transactions before checkpoint writes."""
+
+    if commit_rows <= 0:
+        raise ValueError("commit_rows must be positive")
+    fragments = _frozen_fragments(snapshot)
+    checkpoint = _load_checkpoint(state_dir, str(snapshot["digest"]))
+    start_index = checkpoint.get("next_fragment_index")
+    if not isinstance(start_index, int) or not 0 <= start_index <= len(fragments):
+        raise LoadStopped("load_checkpoint_index_out_of_range")
+    if checkpoint.get("load_complete") and start_index != len(fragments):
+        raise LoadStopped("inconsistent_completed_load_checkpoint")
+
+    conn = await _connect_database(database_url)
+    try:
+        await _acquire_database_lock(conn)
+        await _assert_database_ready(
+            conn,
+            expected_source_rows=int(snapshot["source_rows"]),
+            checkpoint=checkpoint,
+        )
+        _save_load_checkpoint(state_dir, checkpoint)
+        await conn.execute(TEMP_TABLE_SQL)
+
+        pending: list[tuple[Any, ...]] = []
+        pending_through = start_index
+        totals = MergeResult(source_rows=0, preexisting_rows=0, inserted_rows=0)
+        for index, records in _record_fragments(
+            staging_dir=staging_dir,
+            fragments=fragments[start_index:],
+            batch_id=str(snapshot["batch_id"]),
+        ):
+            actual_index = start_index + index
+            pending.extend(records)
+            pending_through = actual_index + 1
+            if len(pending) < commit_rows:
+                continue
+            merged = await _merge_records(conn, pending)
+            totals = MergeResult(
+                source_rows=totals.source_rows + merged.source_rows,
+                preexisting_rows=totals.preexisting_rows + merged.preexisting_rows,
+                inserted_rows=totals.inserted_rows + merged.inserted_rows,
+            )
+            checkpoint.update(
+                {
+                    "next_fragment_index": pending_through,
+                    "checkpointed_source_rows": int(
+                        checkpoint["checkpointed_source_rows"]
+                    )
+                    + merged.source_rows,
+                    "db_batches": int(checkpoint["db_batches"]) + 1,
+                }
+            )
+            _save_load_checkpoint(state_dir, checkpoint)
+            pending = []
+        if pending:
+            merged = await _merge_records(conn, pending)
+            totals = MergeResult(
+                source_rows=totals.source_rows + merged.source_rows,
+                preexisting_rows=totals.preexisting_rows + merged.preexisting_rows,
+                inserted_rows=totals.inserted_rows + merged.inserted_rows,
+            )
+            checkpoint.update(
+                {
+                    "next_fragment_index": pending_through,
+                    "checkpointed_source_rows": int(
+                        checkpoint["checkpointed_source_rows"]
+                    )
+                    + merged.source_rows,
+                    "db_batches": int(checkpoint["db_batches"]) + 1,
+                }
+            )
+            _save_load_checkpoint(state_dir, checkpoint)
+        if checkpoint["next_fragment_index"] != len(fragments):
+            raise DatabaseLoadError("load_checkpoint_not_at_snapshot_end")
+        checkpoint["load_complete"] = True
+        _save_load_checkpoint(state_dir, checkpoint)
+        return {
+            "rows_merged_this_invocation": totals.source_rows,
+            "rows_preexisting_this_invocation": totals.preexisting_rows,
+            "rows_inserted_this_invocation": totals.inserted_rows,
+            "checkpoint": checkpoint,
+        }
+    except asyncpg.PostgresError as exc:
+        raise DatabaseLoadError(f"database_error:{type(exc).__name__}") from exc
+    finally:
+        # Closing the session releases its advisory lock, even after a database
+        # error.  Do not run any retry path after that error.
+        await conn.close()
+
+
+async def _verify_records(
+    conn: asyncpg.Connection,
+    records: Sequence[tuple[Any, ...]],
+) -> int:
+    async with conn.transaction():
+        await conn.copy_records_to_table(
+            TEMP_TABLE,
+            records=records,
+            columns=list(REQUIRED_COLUMNS),
+        )
+        staged_rows = int(await conn.fetchval(STAGED_COUNT_SQL))
+        if staged_rows != len(records):
+            raise DatabaseLoadError("verification_stage_row_count_mismatch")
+        conflicts = int(await conn.fetchval(CONFLICT_COUNT_SQL))
+        if conflicts:
+            raise DatabaseLoadError("verification_target_value_conflict")
+        present = int(await conn.fetchval(PRESENT_COUNT_SQL))
+        if present != len(records):
+            raise DatabaseLoadError("verification_target_coverage_mismatch")
+    return present
+
+
+async def verify_snapshot(
+    *,
+    staging_dir: Path,
+    snapshot: dict[str, Any],
+    database_url: str,
+    commit_rows: int,
+) -> VerificationResult:
+    """Independently re-read the frozen source and verify every target key."""
+
+    fragments = _frozen_fragments(snapshot)
+    conn = await _connect_database(database_url)
+    try:
+        await _acquire_database_lock(conn)
+        await conn.execute(TEMP_TABLE_SQL)
+        verified = 0
+        pending: list[tuple[Any, ...]] = []
+        for _, records in _record_fragments(
+            staging_dir=staging_dir,
+            fragments=fragments,
+            batch_id=str(snapshot["batch_id"]),
+        ):
+            pending.extend(records)
+            if len(pending) < commit_rows:
+                continue
+            verified += await _verify_records(conn, pending)
+            pending = []
+        if pending:
+            verified += await _verify_records(conn, pending)
+        target_rows = int(await conn.fetchval(f"SELECT count(*) FROM {TARGET_TABLE}"))
+        batch_rows = int(
+            await conn.fetchval(
+                f"SELECT count(*) FROM {TARGET_TABLE} WHERE batch_id = $1",
+                str(snapshot["batch_id"]),
+            )
+        )
+        duplicate_rows = int(
+            await conn.fetchval(
+                f"SELECT count(*) - count(DISTINCT (session_date_kst, symbol, time_utc)) "
+                f"FROM {TARGET_TABLE}"
+            )
+        )
+    except asyncpg.PostgresError as exc:
+        raise DatabaseLoadError(f"database_error:{type(exc).__name__}") from exc
+    finally:
+        await conn.close()
+    expected_rows = int(snapshot["source_rows"])
+    if (
+        verified != expected_rows
+        or target_rows != expected_rows
+        or batch_rows != expected_rows
+    ):
+        raise DatabaseLoadError("row_reconciliation_mismatch")
+    if duplicate_rows != 0:
+        raise DatabaseLoadError("deduplication_verification_failed")
+    return VerificationResult(
+        source_rows=expected_rows,
+        db_rows_verified=verified,
+        target_rows=target_rows,
+        batch_rows=batch_rows,
+        duplicate_rows=duplicate_rows,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--staging-dir", required=True, type=Path)
+    parser.add_argument("--state-dir", required=True, type=Path)
+    parser.add_argument("--db-env-file", required=True, type=Path)
+    parser.add_argument(
+        "--min-fragment-age-seconds",
+        type=int,
+        default=DEFAULT_MIN_FRAGMENT_AGE_SECONDS,
+    )
+    parser.add_argument("--commit-rows", type=int, default=DEFAULT_COMMIT_ROWS)
+    parser.add_argument("--confirm-load", action="store_true")
+    return parser.parse_args()
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    staging_dir = args.staging_dir.resolve()
+    state_dir = args.state_dir.resolve()
+    _assert_state_dir_is_separate(staging_dir, state_dir)
+    with StateDirectoryLock(state_dir):
+        snapshot = freeze_completed_fragments(
+            staging_dir=staging_dir,
+            state_dir=state_dir,
+            min_fragment_age_seconds=args.min_fragment_age_seconds,
+        )
+        preflight_source(
+            staging_dir=staging_dir,
+            state_dir=state_dir,
+            snapshot=snapshot,
+        )
+        prepared = {
+            "status": "PREFLIGHT_COMPLETE",
+            "completed_fragments_only": snapshot["completed_fragments_only"],
+            "fragment_count": len(snapshot["fragments"]),
+            "partial_files_excluded": snapshot["partial_files_excluded"],
+            "source_rows": snapshot["source_rows"],
+            "too_recent_files_excluded": snapshot["too_recent_files_excluded"],
+        }
+        if not args.confirm_load:
+            print(json.dumps(prepared, ensure_ascii=False, sort_keys=True))
+            return 0
+        database_url = _database_url(args.db_env_file)
+        merged = await load_snapshot(
+            staging_dir=staging_dir,
+            state_dir=state_dir,
+            snapshot=snapshot,
+            database_url=database_url,
+            commit_rows=args.commit_rows,
+        )
+        verification = await verify_snapshot(
+            staging_dir=staging_dir,
+            snapshot=snapshot,
+            database_url=database_url,
+            commit_rows=args.commit_rows,
+        )
+        result = {
+            **prepared,
+            **merged,
+            "verification": asdict(verification),
+            "status": "COMPLETED",
+            "target_table": TARGET_TABLE,
+        }
+        _atomic_write_json(state_dir / "load_summary.json", result)
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0
+
+
+def main() -> int:
+    try:
+        return asyncio.run(async_main(parse_args()))
+    except LoadStopped as exc:
+        print(
+            json.dumps(
+                {"status": "STOPPED", "reason": str(exc)},
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/toss_phase2/load.py
+++ b/research/toss_phase2/load.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import math
 import os
+import re
 import sqlite3
 import time
 from collections.abc import Iterator, Sequence
@@ -103,7 +104,7 @@ class MergeResult:
 @dataclass(frozen=True)
 class VerificationResult:
     source_rows: int
-    db_rows_verified: int
+    source_rows_revalidated: int
     target_rows: int
     batch_rows: int
     duplicate_rows: int
@@ -751,11 +752,7 @@ STAGED_COUNT_SQL = f"SELECT count(*) FROM {TEMP_TABLE}"
 STAGED_DUPLICATE_COUNT_SQL = f"""
 SELECT count(*) - count(DISTINCT (time_utc, symbol)) FROM {TEMP_TABLE}
 """
-PRESENT_COUNT_SQL = f"""
-SELECT count(*) FROM {TEMP_TABLE} AS incoming
-JOIN {TARGET_TABLE} AS stored USING (time_utc, symbol)
-"""
-EXISTING_COUNT_SQL = PRESENT_COUNT_SQL
+INSERT_COMMAND_TAG = re.compile(r"INSERT 0 (?P<rows>\d+)")
 
 
 async def _assert_database_ready(
@@ -816,6 +813,15 @@ async def _prefer_target_key_lookups(conn: asyncpg.Connection) -> None:
     await conn.execute("SET LOCAL enable_mergejoin TO off")
 
 
+def _inserted_row_count(command_tag: str) -> int:
+    """Parse the PostgreSQL command tag without treating an unknown tag as OK."""
+
+    matched = INSERT_COMMAND_TAG.fullmatch(command_tag)
+    if matched is None:
+        raise DatabaseLoadError("unexpected_insert_command_tag")
+    return int(matched["rows"])
+
+
 async def _merge_records(
     conn: asyncpg.Connection,
     records: Sequence[tuple[Any, ...]],
@@ -828,21 +834,25 @@ async def _merge_records(
             records=records,
             columns=list(REQUIRED_COLUMNS),
         )
-        await _prefer_target_key_lookups(conn)
         staged_rows = int(await conn.fetchval(STAGED_COUNT_SQL))
         if staged_rows != len(records):
             raise DatabaseLoadError("temporary_stage_row_count_mismatch")
         staged_duplicates = int(await conn.fetchval(STAGED_DUPLICATE_COUNT_SQL))
         if staged_duplicates:
             raise DatabaseLoadError("duplicate_key_reached_database_stage")
-        conflicts = int(await conn.fetchval(CONFLICT_COUNT_SQL))
-        if conflicts:
-            raise DatabaseLoadError("existing_target_value_conflict")
-        preexisting = int(await conn.fetchval(EXISTING_COUNT_SQL))
-        await conn.execute(INSERT_SQL)
-        present = int(await conn.fetchval(PRESENT_COUNT_SQL))
-        if present != len(records):
-            raise DatabaseLoadError("target_coverage_mismatch_after_merge")
+        inserted = _inserted_row_count(await conn.execute(INSERT_SQL))
+        if inserted > len(records):
+            raise DatabaseLoadError("inserted_row_count_exceeds_stage")
+        preexisting = len(records) - inserted
+        if preexisting:
+            # A skipped ON CONFLICT row is valid only if it is byte-for-byte
+            # equivalent in every meaningful stored field.  This is the only
+            # path that needs a target lookup; normal forward batches are all
+            # newly inserted and have no target relation to scan.
+            await _prefer_target_key_lookups(conn)
+            conflicts = int(await conn.fetchval(CONFLICT_COUNT_SQL))
+            if conflicts:
+                raise DatabaseLoadError("existing_target_value_conflict")
     return MergeResult(
         source_rows=len(records),
         preexisting_rows=preexisting,
@@ -971,29 +981,6 @@ async def load_snapshot(
         await conn.close()
 
 
-async def _verify_records(
-    conn: asyncpg.Connection,
-    records: Sequence[tuple[Any, ...]],
-) -> int:
-    async with conn.transaction():
-        await conn.copy_records_to_table(
-            TEMP_TABLE,
-            records=records,
-            columns=list(REQUIRED_COLUMNS),
-        )
-        await _prefer_target_key_lookups(conn)
-        staged_rows = int(await conn.fetchval(STAGED_COUNT_SQL))
-        if staged_rows != len(records):
-            raise DatabaseLoadError("verification_stage_row_count_mismatch")
-        conflicts = int(await conn.fetchval(CONFLICT_COUNT_SQL))
-        if conflicts:
-            raise DatabaseLoadError("verification_target_value_conflict")
-        present = int(await conn.fetchval(PRESENT_COUNT_SQL))
-        if present != len(records):
-            raise DatabaseLoadError("verification_target_coverage_mismatch")
-    return present
-
-
 async def verify_snapshot(
     *,
     staging_dir: Path,
@@ -1007,8 +994,7 @@ async def verify_snapshot(
     conn = await _connect_database(database_url)
     try:
         await _acquire_database_lock(conn)
-        await conn.execute(TEMP_TABLE_SQL)
-        verified = 0
+        revalidated = 0
         pending: list[tuple[Any, ...]] = []
         for _, records in _record_fragments(
             staging_dir=staging_dir,
@@ -1018,10 +1004,15 @@ async def verify_snapshot(
             pending.extend(records)
             if len(pending) < commit_rows:
                 continue
-            verified += await _verify_records(conn, pending)
+            # _record_fragments has already re-read every frozen Parquet value
+            # through the fail-closed validator.  Its source key index plus
+            # the target's initial-empty/unique-key contract and committed
+            # INSERT command tags prove coverage; avoid rejoining every stage
+            # batch to every Timescale chunk merely to recount those keys.
+            revalidated += len(pending)
             pending = []
         if pending:
-            verified += await _verify_records(conn, pending)
+            revalidated += len(pending)
         target_rows = int(await conn.fetchval(f"SELECT count(*) FROM {TARGET_TABLE}"))
         batch_rows = int(
             await conn.fetchval(
@@ -1041,7 +1032,7 @@ async def verify_snapshot(
         await conn.close()
     expected_rows = int(snapshot["source_rows"])
     if (
-        verified != expected_rows
+        revalidated != expected_rows
         or target_rows != expected_rows
         or batch_rows != expected_rows
     ):
@@ -1050,7 +1041,7 @@ async def verify_snapshot(
         raise DatabaseLoadError("deduplication_verification_failed")
     return VerificationResult(
         source_rows=expected_rows,
-        db_rows_verified=verified,
+        source_rows_revalidated=revalidated,
         target_rows=target_rows,
         batch_rows=batch_rows,
         duplicate_rows=duplicate_rows,

--- a/research/toss_phase2/load.py
+++ b/research/toss_phase2/load.py
@@ -387,18 +387,11 @@ def _validate_batch(
         if timestamp.second or timestamp.microsecond:
             raise StagingValidationError(f"non_minute_timestamp:{path.name}")
 
-    volumes = _column(batch, "volume").to_pylist()
-    paddings = _column(batch, "is_padding").to_pylist()
-    if any(
-        bool(padding) is not (float(volume) == 0.0)
-        for volume, padding in zip(volumes, paddings, strict=True)
-    ):
-        raise StagingValidationError(f"invalid_padding_semantics:{path.name}")
-
     opens = _column(batch, "open").to_pylist()
     highs = _column(batch, "high").to_pylist()
     lows = _column(batch, "low").to_pylist()
     closes = _column(batch, "close").to_pylist()
+    volumes = _column(batch, "volume").to_pylist()
     values = _column(batch, "value").to_pylist()
     for open_, high, low, close, volume, value in zip(
         opens,
@@ -446,6 +439,15 @@ def _validate_batch(
             abs_tol=VALUE_ABSOLUTE_TOLERANCE,
         ):
             raise StagingValidationError(f"synthetic_value_mismatch:{path.name}")
+
+    paddings = _column(batch, "is_padding").to_pylist()
+    if any(not isinstance(padding, bool) for padding in paddings):
+        raise StagingValidationError(f"invalid_padding_type:{path.name}")
+    if any(
+        padding is not (float(volume) == 0.0)
+        for volume, padding in zip(volumes, paddings, strict=True)
+    ):
+        raise StagingValidationError(f"invalid_padding_semantics:{path.name}")
 
 
 def iter_validated_batches(

--- a/research/toss_phase2/load.py
+++ b/research/toss_phase2/load.py
@@ -802,6 +802,20 @@ async def _connect_database(database_url: str) -> asyncpg.Connection:
         raise DatabaseLoadError(f"database_error:{type(exc).__name__}") from exc
 
 
+async def _prefer_target_key_lookups(conn: asyncpg.Connection) -> None:
+    """Keep per-batch coverage checks on the Toss target's unique key.
+
+    A Timescale hypertable has many chunks.  A default merge/hash plan can
+    scan their complete index append for a 20k-row temporary stage, whereas a
+    nested loop parameterized by ``(time_utc, symbol)`` uses the target's
+    unique key per incoming row.  These settings are transaction-local, so
+    they cannot affect unrelated backfill or production sessions.
+    """
+
+    await conn.execute("SET LOCAL enable_hashjoin TO off")
+    await conn.execute("SET LOCAL enable_mergejoin TO off")
+
+
 async def _merge_records(
     conn: asyncpg.Connection,
     records: Sequence[tuple[Any, ...]],
@@ -814,6 +828,7 @@ async def _merge_records(
             records=records,
             columns=list(REQUIRED_COLUMNS),
         )
+        await _prefer_target_key_lookups(conn)
         staged_rows = int(await conn.fetchval(STAGED_COUNT_SQL))
         if staged_rows != len(records):
             raise DatabaseLoadError("temporary_stage_row_count_mismatch")
@@ -966,6 +981,7 @@ async def _verify_records(
             records=records,
             columns=list(REQUIRED_COLUMNS),
         )
+        await _prefer_target_key_lookups(conn)
         staged_rows = int(await conn.fetchval(STAGED_COUNT_SQL))
         if staged_rows != len(records):
             raise DatabaseLoadError("verification_stage_row_count_mismatch")

--- a/tests/research/toss_phase2/test_adaptive_pacing.py
+++ b/tests/research/toss_phase2/test_adaptive_pacing.py
@@ -271,3 +271,59 @@ async def test_collect_retries_a_429_without_stopping_the_pipeline(tmp_path) -> 
     assert stats.symbols_done == 1
     assert stats.stopped_reason is None
     assert clock.sleeps == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_startup_429_without_limit_header_stops_before_a_second_request(
+    tmp_path,
+) -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    pacer = HeaderAdaptiveChartRateLimiter(
+        _BaseLimiter(),
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+    )
+    transport = SimpleNamespace(calls=0)
+
+    class _RateLimitError(RuntimeError):
+        status_code = 429
+
+    class _Client:
+        async def candles(self, *args, **kwargs):
+            del args, kwargs
+            transport.calls += 1
+            pacer.observe_response(
+                "MARKET_DATA_CHART",
+                429,
+                _headers(limit=None, remaining=0, reset_seconds=0.25),
+            )
+            raise _RateLimitError()
+
+    class _Monitor:
+        async def assert_healthy(self) -> None:
+            return None
+
+    progress = ProgressLog(tmp_path / "events" / "progress.jsonl")
+    try:
+        with pytest.raises(CollectionStopped, match="cap_not_discovered"):
+            await collect(
+                client=_Client(),
+                transport=transport,
+                chart_pacer=pacer,
+                monitor=_Monitor(),
+                staging_dir=tmp_path,
+                symbols=["005930"],
+                start_date=date(2021, 12, 20),
+                last_eligible_date=date(2026, 8, 3),
+                call_budget=10,
+                batch_id="batch",
+                official_nxt_launch_date=None,
+                progress=progress,
+                stats=CollectionStats(symbols_total=1),
+            )
+    finally:
+        progress.close()
+
+    assert transport.calls == 1

--- a/tests/research/toss_phase2/test_adaptive_pacing.py
+++ b/tests/research/toss_phase2/test_adaptive_pacing.py
@@ -1,20 +1,27 @@
 from __future__ import annotations
 
+import json
 from datetime import date, datetime
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 from research.toss_phase2.collect import (
     AFTER_CLOSE_TARGET_TPS_MIN,
     CONSECUTIVE_429_STOP_AT,
+    CONSECUTIVE_TRANSIENT_RESUME_STOP_AT,
     INTRADAY_CHART_HEADROOM_TPS,
     INTRADAY_TARGET_TPS_MAX,
     KST,
+    SUMMARY_UPDATE_INTERVAL_SECONDS,
     CollectionStats,
     CollectionStopped,
     HeaderAdaptiveChartRateLimiter,
+    LatestSummaryWriter,
     ProgressLog,
+    TransientResumeBackoff,
+    _preflight_cached_token,
     collect,
 )
 
@@ -327,3 +334,228 @@ async def test_startup_429_without_limit_header_stops_before_a_second_request(
         progress.close()
 
     assert transport.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_retries_shared_cache_gap_on_the_same_cursor(tmp_path) -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    pacer = HeaderAdaptiveChartRateLimiter(
+        _BaseLimiter(),
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+        jitter_fn=lambda _low, _high: 0.0,
+    )
+    transport = SimpleNamespace(calls=0)
+
+    class _Client:
+        attempts = 0
+
+        async def candles(self, *args, **kwargs):
+            del args, kwargs
+            self.attempts += 1
+            if self.attempts == 1:
+                raise CollectionStopped(
+                    "shared_toss_token_cache_miss: collector will not issue OAuth"
+                )
+            transport.calls += 1
+            pacer.observe_response(
+                "MARKET_DATA_CHART",
+                200,
+                _headers(limit=4, remaining=4, reset_seconds=0.25),
+            )
+            return SimpleNamespace(candles=[], next_before=None)
+
+    class _Monitor:
+        async def assert_healthy(self) -> None:
+            return None
+
+    progress = ProgressLog(tmp_path / "events" / "progress.jsonl")
+    try:
+        stats = await collect(
+            client=_Client(),
+            transport=transport,
+            chart_pacer=pacer,
+            monitor=_Monitor(),
+            staging_dir=tmp_path,
+            symbols=["005930"],
+            start_date=date(2021, 12, 20),
+            last_eligible_date=date(2026, 8, 3),
+            call_budget=10,
+            batch_id="batch",
+            official_nxt_launch_date=None,
+            progress=progress,
+            stats=CollectionStats(symbols_total=1),
+            transient_resumer=TransientResumeBackoff(
+                sleep=clock.sleep,
+                jitter_fn=lambda _low, _high: 0.0,
+            ),
+        )
+    finally:
+        progress.close()
+
+    assert transport.calls == 1
+    assert stats.transient_resume_failures == 1
+    assert stats.transient_resume_backoffs == 1
+    assert stats.symbols_done == 1
+    assert clock.sleeps == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_collect_retries_one_transport_timeout_on_the_same_cursor(
+    tmp_path,
+) -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    pacer = HeaderAdaptiveChartRateLimiter(
+        _BaseLimiter(),
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+        jitter_fn=lambda _low, _high: 0.0,
+    )
+    transport = SimpleNamespace(calls=0)
+
+    class _Client:
+        async def candles(self, *args, **kwargs):
+            del args, kwargs
+            transport.calls += 1
+            if transport.calls == 1:
+                raise httpx.ReadTimeout("one-off timeout")
+            pacer.observe_response(
+                "MARKET_DATA_CHART",
+                200,
+                _headers(limit=4, remaining=4, reset_seconds=0.25),
+            )
+            return SimpleNamespace(candles=[], next_before=None)
+
+    class _Monitor:
+        async def assert_healthy(self) -> None:
+            return None
+
+    progress = ProgressLog(tmp_path / "events" / "progress.jsonl")
+    try:
+        stats = await collect(
+            client=_Client(),
+            transport=transport,
+            chart_pacer=pacer,
+            monitor=_Monitor(),
+            staging_dir=tmp_path,
+            symbols=["005930"],
+            start_date=date(2021, 12, 20),
+            last_eligible_date=date(2026, 8, 3),
+            call_budget=10,
+            batch_id="batch",
+            official_nxt_launch_date=None,
+            progress=progress,
+            stats=CollectionStats(symbols_total=1),
+            transient_resumer=TransientResumeBackoff(
+                sleep=clock.sleep,
+                jitter_fn=lambda _low, _high: 0.0,
+            ),
+        )
+    finally:
+        progress.close()
+
+    assert transport.calls == 2
+    assert stats.transient_resume_failures == 1
+    assert stats.transient_resume_backoffs == 1
+    assert stats.symbols_done == 1
+    assert clock.sleeps == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_preflight_retries_only_a_shared_cache_gap(tmp_path) -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    transport = SimpleNamespace(calls=0)
+
+    class _Provider:
+        attempts = 0
+
+        async def get_access_token(self, **kwargs) -> str:
+            del kwargs
+            self.attempts += 1
+            if self.attempts == 1:
+                raise CollectionStopped(
+                    "shared_toss_token_cache_miss: collector will not issue OAuth"
+                )
+            return "cached-token"
+
+    progress = ProgressLog(tmp_path / "events" / "progress.jsonl")
+    stats = CollectionStats(symbols_total=1)
+    try:
+        await _preflight_cached_token(
+            token_provider=_Provider(),
+            transient_resumer=TransientResumeBackoff(
+                sleep=clock.sleep,
+                jitter_fn=lambda _low, _high: 0.0,
+            ),
+            progress=progress,
+            stats=stats,
+            transport=transport,
+            on_progress=None,
+        )
+    finally:
+        progress.close()
+
+    assert stats.transient_resume_failures == 1
+    assert stats.transient_resume_backoffs == 1
+    assert transport.calls == 0
+    assert clock.sleeps == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_transient_resume_stops_at_five_consecutive_failures() -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    resumer = TransientResumeBackoff(
+        sleep=clock.sleep,
+        jitter_fn=lambda _low, _high: 0.0,
+    )
+
+    for expected in (1.0, 2.0, 4.0, 8.0):
+        _consecutive, delay = await resumer.backoff(reason="httpx_transport_error")
+        assert delay == expected
+
+    with pytest.raises(
+        CollectionStopped,
+        match=(
+            "transient_resume_exhausted:reason=httpx_transport_error:"
+            f"stop_at={CONSECUTIVE_TRANSIENT_RESUME_STOP_AT}"
+        ),
+    ):
+        await resumer.backoff(reason="httpx_transport_error")
+
+    assert clock.sleeps == [1.0, 2.0, 4.0, 8.0]
+
+
+def test_latest_summary_refreshes_atomically_while_running(tmp_path) -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    transport = SimpleNamespace(calls=3)
+    stats = CollectionStats(symbols_total=200, rows_staged=10, pages_staged=1)
+    summary_path = tmp_path / "events" / "latest_summary.json"
+    writer = LatestSummaryWriter(
+        path=summary_path,
+        stats=stats,
+        transport=transport,
+        call_budget=820000,
+        monotonic_fn=clock.monotonic,
+        now_kst_fn=lambda: clock.now,
+    )
+
+    writer.write(collector_state="RUNNING")
+    initial = json.loads(summary_path.read_text())
+    assert initial["collector_state"] == "RUNNING"
+    assert initial["calls_actual"] == 3
+    assert initial["database_load_performed"] is False
+
+    clock.monotonic_now += SUMMARY_UPDATE_INTERVAL_SECONDS - 0.1
+    writer.maybe_write()
+    assert json.loads(summary_path.read_text()) == initial
+
+    transport.calls = 4
+    clock.monotonic_now += 0.2
+    writer.maybe_write()
+    refreshed = json.loads(summary_path.read_text())
+    assert refreshed["calls_actual"] == 4
+    assert refreshed["collector_state"] == "RUNNING"

--- a/tests/research/toss_phase2/test_adaptive_pacing.py
+++ b/tests/research/toss_phase2/test_adaptive_pacing.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from research.toss_phase2.collect import (
+    AFTER_CLOSE_TARGET_TPS_MIN,
+    CONSECUTIVE_429_STOP_AT,
+    INTRADAY_CHART_HEADROOM_TPS,
+    INTRADAY_TARGET_TPS_MAX,
+    KST,
+    CollectionStats,
+    CollectionStopped,
+    HeaderAdaptiveChartRateLimiter,
+    ProgressLog,
+    collect,
+)
+
+
+class _Clock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+        self.monotonic_now = 100.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.monotonic_now
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.monotonic_now += seconds
+
+
+class _BaseLimiter:
+    def __init__(self) -> None:
+        self.groups: list[object] = []
+
+    async def acquire(self, group: object) -> None:
+        self.groups.append(group)
+
+
+def _headers(
+    *,
+    limit: int | None,
+    remaining: int | None,
+    reset_seconds: float | None,
+    retry_after_seconds: float | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        limit=limit,
+        remaining=remaining,
+        reset_seconds=reset_seconds,
+        retry_after_seconds=retry_after_seconds,
+    )
+
+
+@pytest.mark.asyncio
+async def test_intraday_target_tracks_discovered_cap_and_preserves_headroom() -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    base = _BaseLimiter()
+    pacer = HeaderAdaptiveChartRateLimiter(
+        base,
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+        jitter_fn=lambda _low, _high: 0.0,
+    )
+
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        200,
+        _headers(limit=4, remaining=4, reset_seconds=0.25),
+    )
+
+    assert pacer.cap_auto_discovered is True
+    assert pacer.cap == 4
+    assert pacer.target_tps() == 1.0
+    assert pacer.intraday_headroom_preserved() is True
+    assert pacer.cap - pacer.target_tps() >= INTRADAY_CHART_HEADROOM_TPS
+    assert pacer.target_tps() <= INTRADAY_TARGET_TPS_MAX
+
+    await pacer.acquire("MARKET_DATA_CHART")
+    assert base.groups == ["MARKET_DATA_CHART"]
+
+
+@pytest.mark.asyncio
+async def test_low_remaining_uses_reset_window_before_after_close_request() -> None:
+    clock = _Clock(datetime(2026, 8, 4, 20, 1, tzinfo=KST))
+    base = _BaseLimiter()
+    pacer = HeaderAdaptiveChartRateLimiter(
+        base,
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+        jitter_fn=lambda _low, _high: 0.0,
+    )
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        200,
+        _headers(limit=10, remaining=3, reset_seconds=0.5),
+    )
+
+    assert pacer.target_tps() == AFTER_CLOSE_TARGET_TPS_MIN
+    await pacer.acquire("MARKET_DATA_CHART")
+
+    # 40% of ten tokens is four. Recovering from three to leave the bucket at
+    # that floor after the next request requires two documented Reset windows.
+    assert clock.sleeps == [1.0]
+    assert base.groups == ["MARKET_DATA_CHART"]
+
+
+@pytest.mark.asyncio
+async def test_429_honors_retry_after_then_uses_exponential_backoff_and_stops_at_five() -> (
+    None
+):
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    pacer = HeaderAdaptiveChartRateLimiter(
+        _BaseLimiter(),
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+        jitter_fn=lambda _low, _high: 0.0,
+    )
+
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        429,
+        _headers(limit=7, remaining=0, reset_seconds=0.25, retry_after_seconds=3.0),
+    )
+    assert await pacer.backoff_after_429() == (1, 3.0)
+
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        429,
+        _headers(limit=7, remaining=0, reset_seconds=0.25),
+    )
+    assert await pacer.backoff_after_429() == (2, 2.0)
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        429,
+        _headers(limit=7, remaining=0, reset_seconds=0.25),
+    )
+    assert await pacer.backoff_after_429() == (3, 4.0)
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        429,
+        _headers(limit=7, remaining=0, reset_seconds=0.25),
+    )
+    assert await pacer.backoff_after_429() == (4, 8.0)
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        429,
+        _headers(limit=7, remaining=0, reset_seconds=0.25),
+    )
+    with pytest.raises(
+        CollectionStopped,
+        match=f"consecutive_chart_429:{CONSECUTIVE_429_STOP_AT}",
+    ):
+        await pacer.backoff_after_429()
+
+    assert clock.sleeps == [3.0, 2.0, 4.0, 8.0]
+
+
+def test_missing_cap_fails_closed_after_the_startup_response() -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    pacer = HeaderAdaptiveChartRateLimiter(
+        _BaseLimiter(),
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+    )
+    pacer.observe_response(
+        "MARKET_DATA_CHART",
+        200,
+        _headers(limit=None, remaining=None, reset_seconds=None),
+    )
+
+    with pytest.raises(CollectionStopped, match="cap_not_discovered"):
+        pacer.ensure_cap_discovered()
+
+
+@pytest.mark.asyncio
+async def test_collect_retries_a_429_without_stopping_the_pipeline(tmp_path) -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    pacer = HeaderAdaptiveChartRateLimiter(
+        _BaseLimiter(),
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+        jitter_fn=lambda _low, _high: 0.0,
+    )
+    transport = SimpleNamespace(calls=0)
+
+    class _RateLimitError(RuntimeError):
+        status_code = 429
+
+    class _Client:
+        async def candles(self, *args, **kwargs):
+            del args, kwargs
+            transport.calls += 1
+            if transport.calls == 1:
+                pacer.observe_response(
+                    "MARKET_DATA_CHART",
+                    429,
+                    _headers(
+                        limit=4,
+                        remaining=0,
+                        reset_seconds=0.25,
+                        retry_after_seconds=2.0,
+                    ),
+                )
+                raise _RateLimitError()
+            pacer.observe_response(
+                "MARKET_DATA_CHART",
+                200,
+                _headers(limit=4, remaining=4, reset_seconds=0.25),
+            )
+            return SimpleNamespace(candles=[], next_before=None)
+
+    class _Monitor:
+        async def assert_healthy(self) -> None:
+            return None
+
+    progress = ProgressLog(tmp_path / "events" / "progress.jsonl")
+    try:
+        stats = await collect(
+            client=_Client(),
+            transport=transport,
+            chart_pacer=pacer,
+            monitor=_Monitor(),
+            staging_dir=tmp_path,
+            symbols=["005930"],
+            start_date=date(2021, 12, 20),
+            last_eligible_date=date(2026, 8, 3),
+            call_budget=10,
+            batch_id="batch",
+            official_nxt_launch_date=None,
+            progress=progress,
+            stats=CollectionStats(symbols_total=1),
+        )
+    finally:
+        progress.close()
+
+    assert transport.calls == 2
+    assert stats.http_429 == 1
+    assert stats.rate_limit_backoffs == 1
+    assert stats.symbols_done == 1
+    assert stats.stopped_reason is None
+    assert clock.sleeps == [2.0]

--- a/tests/research/toss_phase2/test_adaptive_pacing.py
+++ b/tests/research/toss_phase2/test_adaptive_pacing.py
@@ -83,7 +83,7 @@ async def test_intraday_target_tracks_discovered_cap_and_preserves_headroom() ->
     assert pacer.target_tps() <= INTRADAY_TARGET_TPS_MAX
 
     await pacer.acquire("MARKET_DATA_CHART")
-    assert base.groups == ["MARKET_DATA_CHART"]
+    assert base.groups == []
 
 
 @pytest.mark.asyncio
@@ -110,7 +110,24 @@ async def test_low_remaining_uses_reset_window_before_after_close_request() -> N
     # 40% of ten tokens is four. Recovering from three to leave the bucket at
     # that floor after the next request requires two documented Reset windows.
     assert clock.sleeps == [1.0]
-    assert base.groups == ["MARKET_DATA_CHART"]
+    assert base.groups == []
+
+
+@pytest.mark.asyncio
+async def test_startup_probe_never_uses_the_static_chart_limiter() -> None:
+    clock = _Clock(datetime(2026, 8, 4, 10, 0, tzinfo=KST))
+    base = _BaseLimiter()
+    pacer = HeaderAdaptiveChartRateLimiter(
+        base,
+        "MARKET_DATA_CHART",
+        now_kst_fn=lambda: clock.now,
+        monotonic_fn=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    await pacer.acquire("MARKET_DATA_CHART")
+
+    assert base.groups == []
 
 
 @pytest.mark.asyncio

--- a/tests/research/toss_phase2/test_collect.py
+++ b/tests/research/toss_phase2/test_collect.py
@@ -9,6 +9,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from research.toss_phase2.collect import (
+    CALL_BUDGET_ACCOUNTING,
     KST,
     STAGING_CONTRACT,
     VALUE_SEMANTICS,
@@ -17,6 +18,8 @@ from research.toss_phase2.collect import (
     ProductionTossLogMonitor,
     SharedTossHealthMonitor,
     classify_session_segment,
+    collection_stats_from_checkpoint,
+    cumulative_calls_from_progress,
     initialize_staging,
     load_readonly_toss_environment,
     make_rows,
@@ -166,6 +169,66 @@ def test_existing_staging_manifest_replaces_only_withdrawn_pacing_metadata(
     assert updated["rate_limit_control"] == {"mode": "response_header_adaptive"}
     assert updated["preserve"] == "staging-data-contract"
     assert page.read_bytes() == b"existing-page-must-not-change"
+
+
+def test_resumed_summary_is_seeded_from_checkpoint_without_rewriting_pages(
+    tmp_path,
+) -> None:
+    checkpoint_path = tmp_path / "state" / "checkpoint.json"
+    checkpoint_path.parent.mkdir()
+    checkpoint_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "symbols": {
+                    "005930": {
+                        "before": None,
+                        "done": True,
+                        "pages": 12,
+                        "rows_staged": 2398,
+                    },
+                    "000660": {
+                        "before": "cursor",
+                        "done": False,
+                        "pages": 3,
+                        "rows_staged": 600,
+                    },
+                },
+            }
+        )
+    )
+
+    stats = collection_stats_from_checkpoint(
+        staging_dir=tmp_path,
+        symbols=["005930", "000660"],
+    )
+
+    assert stats.symbols_total == 2
+    assert stats.symbols_done == 1
+    assert stats.pages_staged == 15
+    assert stats.rows_staged == 2998
+
+
+def test_call_budget_is_cumulative_across_legacy_and_resumed_processes(
+    tmp_path,
+) -> None:
+    progress = tmp_path / "events" / "progress.jsonl"
+    progress.parent.mkdir()
+    events = [
+        {"event": "collection_started"},
+        {"event": "page", "calls_actual": 125},
+        {"event": "collection_started"},
+        {"event": "page", "calls_actual": 201},
+        {
+            "event": "collection_started",
+            "call_accounting": CALL_BUDGET_ACCOUNTING,
+            "prior_calls_actual": 326,
+        },
+        {"event": "page", "calls_actual": 330},
+    ]
+    progress.write_text("\n".join(json.dumps(event) for event in events) + "\n")
+
+    assert cumulative_calls_from_progress(progress) == 330
 
 
 @pytest.mark.asyncio

--- a/tests/research/toss_phase2/test_collect.py
+++ b/tests/research/toss_phase2/test_collect.py
@@ -9,11 +9,13 @@ import pyarrow.parquet as pq
 import pytest
 
 from research.toss_phase2.collect import (
+    _SETTINGS_PLACEHOLDERS,
     CALL_BUDGET_ACCOUNTING,
     KST,
     STAGING_CONTRACT,
     VALUE_SEMANTICS,
     CachedTokenOnlyProvider,
+    Checkpoint,
     CollectionStopped,
     ProductionTossLogMonitor,
     SharedTossHealthMonitor,
@@ -236,6 +238,43 @@ def test_call_budget_is_cumulative_across_legacy_and_resumed_processes(
     assert cumulative_calls_from_progress(progress) == 330
 
 
+def test_call_budget_progress_is_streamed_not_read_as_one_large_string(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    progress = tmp_path / "events" / "progress.jsonl"
+    progress.parent.mkdir()
+    progress.write_text(
+        "\n".join(
+            [
+                json.dumps({"event": "collection_started"}),
+                json.dumps({"event": "page", "calls_actual": 7}),
+            ]
+        )
+        + "\n"
+    )
+
+    def fail_read_text(*_args, **_kwargs) -> str:
+        raise AssertionError("progress accounting must stream the log")
+
+    monkeypatch.setattr(type(progress), "read_text", fail_read_text)
+
+    assert cumulative_calls_from_progress(progress) == 7
+
+
+def test_checkpoint_save_syncs_json_before_replacing_it(tmp_path, monkeypatch) -> None:
+    checkpoint_path = tmp_path / "state" / "checkpoint.json"
+    checkpoint = Checkpoint(checkpoint_path)
+    checkpoint.state_for("005930")["pages"] = 1
+    synced_fds: list[int] = []
+
+    monkeypatch.setattr(os, "fsync", lambda fd: synced_fds.append(fd))
+    checkpoint.save()
+
+    assert json.loads(checkpoint_path.read_text())["symbols"]["005930"]["pages"] == 1
+    assert synced_fds
+
+
 @pytest.mark.asyncio
 async def test_cached_token_provider_never_issues_or_forces() -> None:
     class Manager:
@@ -308,6 +347,7 @@ def test_readonly_env_loads_only_toss_and_inert_settings(tmp_path, monkeypatch) 
         "TOSS_API_ENABLED",
         "TOSS_API_CLIENT_ID",
         "TOSS_API_CLIENT_SECRET",
+        *_SETTINGS_PLACEHOLDERS,
     ):
         monkeypatch.delenv(name, raising=False)
 

--- a/tests/research/toss_phase2/test_collect.py
+++ b/tests/research/toss_phase2/test_collect.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
@@ -16,6 +17,7 @@ from research.toss_phase2.collect import (
     ProductionTossLogMonitor,
     SharedTossHealthMonitor,
     classify_session_segment,
+    initialize_staging,
     load_readonly_toss_environment,
     make_rows,
     resolve_toss_base_url,
@@ -128,6 +130,44 @@ def test_write_page_is_immutable_and_labels_parquet(tmp_path) -> None:
     assert pq.read_table(path).column("close")[0].as_py() == 1.0
 
 
+def test_existing_staging_manifest_replaces_only_withdrawn_pacing_metadata(
+    tmp_path,
+) -> None:
+    immutable = {
+        "artifact_state": STAGING_CONTRACT,
+        "scope": "top-200 x 4.6y",
+        "symbol_count": 200,
+        "universe_sha256": "sealed-universe",
+        "window": {"start_date": "2021-12-20", "end_date": "2026-08-03"},
+        "call_budget_declared": 820000,
+        "batch_id": "batch",
+    }
+    legacy_manifest = {
+        **immutable,
+        "pacing": {"during_09_00_to_20_00_kst_seconds": 0.5},
+        "preserve": "staging-data-contract",
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(legacy_manifest))
+    page = tmp_path / "data" / "symbol=005930" / "part-existing.parquet"
+    page.parent.mkdir(parents=True)
+    page.write_bytes(b"existing-page-must-not-change")
+
+    initialize_staging(
+        staging_dir=tmp_path,
+        manifest={
+            **immutable,
+            "rate_limit_control": {"mode": "response_header_adaptive"},
+        },
+    )
+
+    updated = json.loads(manifest_path.read_text())
+    assert "pacing" not in updated
+    assert updated["rate_limit_control"] == {"mode": "response_header_adaptive"}
+    assert updated["preserve"] == "staging-data-contract"
+    assert page.read_bytes() == b"existing-page-must-not-change"
+
+
 @pytest.mark.asyncio
 async def test_cached_token_provider_never_issues_or_forces() -> None:
     class Manager:
@@ -141,28 +181,32 @@ async def test_cached_token_provider_never_issues_or_forces() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shared_monitor_stops_on_new_error() -> None:
+async def test_shared_monitor_treats_429_as_recoverable_but_stops_other_errors() -> (
+    None
+):
     class Signal:
-        def __init__(self, sequence: int) -> None:
+        def __init__(self, sequence: int, status_code: int) -> None:
             self.sequence = sequence
-            self.status_code = 429
+            self.status_code = status_code
             self.error_type = "http_response"
             self.error_code = "too-many-requests"
 
-    signal: Signal | None = Signal(3)
+    signal: Signal | None = Signal(3, 429)
 
     async def read() -> Signal | None:
         return signal
 
     monitor = SharedTossHealthMonitor(read)
     await monitor.start()
-    signal = Signal(4)
+    signal = Signal(4, 429)
+    await monitor.assert_healthy()
+    signal = Signal(5, 500)
     with pytest.raises(CollectionStopped, match="shared_toss_error_observed"):
         await monitor.assert_healthy()
 
 
 @pytest.mark.asyncio
-async def test_production_log_monitor_stops_only_for_new_toss_error(tmp_path) -> None:
+async def test_production_log_monitor_treats_new_429_as_recoverable(tmp_path) -> None:
     log = tmp_path / "production.log"
     log.write_text("old Toss API error status=429\n")
     monitor = ProductionTossLogMonitor([log])
@@ -170,6 +214,10 @@ async def test_production_log_monitor_stops_only_for_new_toss_error(tmp_path) ->
 
     with log.open("a") as fh:
         fh.write("ordinary startup message\n")
+    await monitor.assert_healthy()
+
+    with log.open("a") as fh:
+        fh.write("Toss API error status=429 code=rate-limit-exceeded\n")
     await monitor.assert_healthy()
 
     with log.open("a") as fh:

--- a/tests/research/toss_phase2/test_collect.py
+++ b/tests/research/toss_phase2/test_collect.py
@@ -17,6 +17,7 @@ from research.toss_phase2.collect import (
     CollectionStopped,
     ProductionTossLogMonitor,
     SharedTossHealthMonitor,
+    UnclassifiableSessionSegment,
     classify_session_segment,
     collection_stats_from_checkpoint,
     cumulative_calls_from_progress,
@@ -44,12 +45,16 @@ def test_empty_configured_base_url_uses_toss_transport_default() -> None:
         ((15, 30), "KRX_REGULAR"),
         ((15, 31), "NXT_POST"),
         ((20, 0), "NXT_POST"),
-        ((20, 1), "UNKNOWN"),
+        ((20, 1), None),
     ],
 )
 def test_session_segment_is_clock_time_only(clock, expected) -> None:
     timestamp = datetime(2026, 8, 3, *clock, tzinfo=KST)
-    assert classify_session_segment(timestamp) == expected
+    if expected is None:
+        with pytest.raises(UnclassifiableSessionSegment):
+            classify_session_segment(timestamp)
+    else:
+        assert classify_session_segment(timestamp) == expected
 
 
 @dataclass

--- a/tests/research/toss_phase2/test_collect.py
+++ b/tests/research/toss_phase2/test_collect.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+
+import pyarrow.parquet as pq
+import pytest
+
+from research.toss_phase2.collect import (
+    KST,
+    STAGING_CONTRACT,
+    VALUE_SEMANTICS,
+    CachedTokenOnlyProvider,
+    CollectionStopped,
+    ProductionTossLogMonitor,
+    SharedTossHealthMonitor,
+    classify_session_segment,
+    load_readonly_toss_environment,
+    make_rows,
+    resolve_toss_base_url,
+    write_page,
+)
+
+
+def test_empty_configured_base_url_uses_toss_transport_default() -> None:
+    """The scoped env intentionally omits TOSS_API_BASE_URL."""
+    from app.services.brokers.toss.transport import DEFAULT_TOSS_BASE_URL
+
+    assert resolve_toss_base_url("", DEFAULT_TOSS_BASE_URL) == DEFAULT_TOSS_BASE_URL
+
+
+@pytest.mark.parametrize(
+    ("clock", "expected"),
+    [
+        ((8, 0), "NXT_PRE"),
+        ((8, 59), "NXT_PRE"),
+        ((9, 0), "KRX_REGULAR"),
+        ((15, 30), "KRX_REGULAR"),
+        ((15, 31), "NXT_POST"),
+        ((20, 0), "NXT_POST"),
+        ((20, 1), "UNKNOWN"),
+    ],
+)
+def test_session_segment_is_clock_time_only(clock, expected) -> None:
+    timestamp = datetime(2026, 8, 3, *clock, tzinfo=KST)
+    assert classify_session_segment(timestamp) == expected
+
+
+@dataclass
+class _Candle:
+    timestamp: str
+    open_price: str
+    high_price: str
+    low_price: str
+    close_price: str
+    volume: str
+
+
+def test_rows_are_staging_shaped_and_exclude_latest_session() -> None:
+    eligible = _Candle("2026-08-03T15:30:00+09:00", "10", "12", "9", "11", "0")
+    latest = _Candle("2026-08-04T09:00:00+09:00", "10", "12", "9", "11", "5")
+
+    rows = make_rows(
+        candles=[eligible, latest],
+        symbol="005930",
+        start_date=date(2021, 12, 20),
+        last_eligible_date=date(2026, 8, 3),
+        retrieved_at=datetime(2026, 8, 4, tzinfo=UTC),
+        batch_id="batch",
+        official_nxt_launch_date=None,
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["session_segment"] == "KRX_REGULAR"
+    assert row["value"] == 0.0
+    assert row["value_semantics"] == VALUE_SEMANTICS
+    assert row["is_padding"] is True
+    assert row["pre_nxt"] is None
+    assert row["time_utc"] == datetime(2026, 8, 3, 6, 30, tzinfo=UTC)
+
+
+def test_write_page_is_immutable_and_labels_parquet(tmp_path) -> None:
+    row = {
+        "time_utc": datetime(2026, 8, 3, tzinfo=UTC),
+        "session_date_kst": date(2026, 8, 3),
+        "symbol": "005930",
+        "session_segment": "NXT_PRE",
+        "source": "TOSS",
+        "open": 1.0,
+        "high": 1.0,
+        "low": 1.0,
+        "close": 1.0,
+        "volume": 0.0,
+        "value": 0.0,
+        "value_semantics": VALUE_SEMANTICS,
+        "is_padding": True,
+        "pre_nxt": None,
+        "retrieved_at": datetime(2026, 8, 4, tzinfo=UTC),
+        "batch_id": "batch",
+    }
+    path, reused = write_page(
+        staging_dir=tmp_path,
+        symbol="005930",
+        request_before=None,
+        next_before="cursor-1",
+        rows=[row],
+        batch_id="batch",
+    )
+    assert path is not None
+    assert reused is False
+    metadata = pq.read_metadata(path).metadata
+    assert metadata is not None
+    assert metadata[b"artifact_state"] == STAGING_CONTRACT.encode()
+    assert metadata[b"next_before"] == b"cursor-1"
+
+    same_path, reused = write_page(
+        staging_dir=tmp_path,
+        symbol="005930",
+        request_before=None,
+        next_before="different-cursor-must-not-overwrite",
+        rows=[{**row, "close": 99.0}],
+        batch_id="batch",
+    )
+    assert same_path == path
+    assert reused is True
+    assert pq.read_table(path).column("close")[0].as_py() == 1.0
+
+
+@pytest.mark.asyncio
+async def test_cached_token_provider_never_issues_or_forces() -> None:
+    class Manager:
+        async def get_cached_access_token(self) -> str | None:
+            return "cached-token"
+
+    provider = CachedTokenOnlyProvider(Manager())
+    assert await provider.get_access_token() == "cached-token"
+    with pytest.raises(CollectionStopped, match="force_reissue_prohibited"):
+        await provider.get_access_token(force_reissue=True)
+
+
+@pytest.mark.asyncio
+async def test_shared_monitor_stops_on_new_error() -> None:
+    class Signal:
+        def __init__(self, sequence: int) -> None:
+            self.sequence = sequence
+            self.status_code = 429
+            self.error_type = "http_response"
+            self.error_code = "too-many-requests"
+
+    signal: Signal | None = Signal(3)
+
+    async def read() -> Signal | None:
+        return signal
+
+    monitor = SharedTossHealthMonitor(read)
+    await monitor.start()
+    signal = Signal(4)
+    with pytest.raises(CollectionStopped, match="shared_toss_error_observed"):
+        await monitor.assert_healthy()
+
+
+@pytest.mark.asyncio
+async def test_production_log_monitor_stops_only_for_new_toss_error(tmp_path) -> None:
+    log = tmp_path / "production.log"
+    log.write_text("old Toss API error status=429\n")
+    monitor = ProductionTossLogMonitor([log])
+    await monitor.start()
+
+    with log.open("a") as fh:
+        fh.write("ordinary startup message\n")
+    await monitor.assert_healthy()
+
+    with log.open("a") as fh:
+        fh.write("Toss API error status=401 code=invalid-token\n")
+    with pytest.raises(CollectionStopped, match="production_toss_error_log_observed"):
+        await monitor.assert_healthy()
+
+
+def test_readonly_env_loads_only_toss_and_inert_settings(tmp_path, monkeypatch) -> None:
+    env_file = tmp_path / ".env.toss-data-readonly.native"
+    env_file.write_text(
+        "TOSS_API_ENABLED=true\n"
+        "TOSS_API_CLIENT_ID=test-client\n"
+        "TOSS_API_CLIENT_SECRET=test-secret\n"
+    )
+    for name in (
+        "ENV_FILE",
+        "REDIS_URL",
+        "TOSS_LIVE_ORDER_MUTATIONS_ENABLED",
+        "TOSS_API_ENABLED",
+        "TOSS_API_CLIENT_ID",
+        "TOSS_API_CLIENT_SECRET",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    source = load_readonly_toss_environment(env_file)
+
+    assert source.startswith("defaulted:")
+    assert "test-secret" not in source
+    assert "prod" not in str(os.environ["ENV_FILE"])

--- a/tests/research/toss_phase2/test_load.py
+++ b/tests/research/toss_phase2/test_load.py
@@ -20,6 +20,7 @@ from research.toss_phase2.load import (
     LoadStopped,
     StagingValidationError,
     _assert_database_ready,
+    _inserted_row_count,
     _prefer_target_key_lookups,
     freeze_completed_fragments,
     preflight_source,
@@ -305,6 +306,25 @@ async def test_batch_coverage_queries_prefer_transaction_local_target_key_lookup
         "SET LOCAL enable_hashjoin TO off",
         "SET LOCAL enable_mergejoin TO off",
     ]
+
+
+@pytest.mark.parametrize(
+    ("command_tag", "expected"),
+    [
+        ("INSERT 0 0", 0),
+        ("INSERT 0 20000", 20000),
+    ],
+)
+def test_insert_command_tag_is_an_explicit_coverage_proof(
+    command_tag: str,
+    expected: int,
+) -> None:
+    assert _inserted_row_count(command_tag) == expected
+
+
+def test_unknown_insert_command_tag_fails_closed() -> None:
+    with pytest.raises(DatabaseLoadError, match="unexpected_insert_command_tag"):
+        _inserted_row_count("UPDATE 20000")
 
 
 def test_invalid_minimum_fragment_age_stops_with_structured_reason(

--- a/tests/research/toss_phase2/test_load.py
+++ b/tests/research/toss_phase2/test_load.py
@@ -15,7 +15,11 @@ from research.toss_phase2.collect import (
 )
 from research.toss_phase2.load import (
     SOURCE,
+    TARGET_TABLE,
+    DatabaseLoadError,
+    LoadStopped,
     StagingValidationError,
+    _assert_database_ready,
     freeze_completed_fragments,
     preflight_source,
 )
@@ -63,13 +67,16 @@ def _write_page(
     request_before: str,
     timestamp: datetime,
     segment: str = "KRX_REGULAR",
+    row_overrides: dict[str, object] | None = None,
 ) -> Path:
+    row = _row(timestamp=timestamp, segment=segment)
+    row.update(row_overrides or {})
     path, reused = write_page(
         staging_dir=staging_dir,
         symbol="005930",
         request_before=request_before,
         next_before="next",
-        rows=[_row(timestamp=timestamp, segment=segment)],
+        rows=[row],
         batch_id="toss-staging-batch",
     )
     assert path is not None
@@ -109,15 +116,24 @@ def test_freeze_selects_only_completed_old_enough_pages_without_staging_writes(
     )
     old_stat = old.stat()
     os.utime(old, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns - 5_000_000_000))
-    before = old.read_bytes()
+    before = {
+        path.relative_to(staging_dir): path.read_bytes()
+        for path in staging_dir.rglob("*")
+        if path.is_file()
+    }
 
     snapshot = _freeze(staging_dir, state_dir, recent, seconds_after=0)
 
     assert snapshot["completed_fragments_only"] is True
     assert snapshot["source_rows"] == 1
     assert snapshot["too_recent_files_excluded"] == 1
-    assert old.read_bytes() == before
-    assert not (staging_dir / "loader-state").exists()
+    after = {
+        path.relative_to(staging_dir): path.read_bytes()
+        for path in staging_dir.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    assert (state_dir / "snapshot.json").is_file()
 
 
 def test_preflight_rejects_unclassifiable_session_segment_before_any_db_work(
@@ -168,6 +184,36 @@ def test_preflight_rejects_duplicate_source_key(
         )
 
 
+@pytest.mark.parametrize(
+    ("row_overrides", "reason"),
+    [
+        ({"volume": -1.0, "value": -11.0}, "negative_volume"),
+        ({"high": 10.0}, "incoherent_ohlc_values"),
+        ({"value": 54.0}, "synthetic_value_mismatch"),
+    ],
+)
+def test_preflight_rejects_invalid_numeric_candle_invariants(
+    tmp_path: Path,
+    row_overrides: dict[str, object],
+    reason: str,
+) -> None:
+    staging_dir, state_dir = _staging(tmp_path)
+    page = _write_page(
+        staging_dir,
+        request_before="invalid-numeric",
+        timestamp=datetime(2026, 8, 3, 6, 4, tzinfo=UTC),
+        row_overrides=row_overrides,
+    )
+    snapshot = _freeze(staging_dir, state_dir, page)
+
+    with pytest.raises(StagingValidationError, match=reason):
+        preflight_source(
+            staging_dir=staging_dir,
+            state_dir=state_dir,
+            snapshot=snapshot,
+        )
+
+
 def test_preflight_reuses_completed_checkpoint_without_reloading_source(
     tmp_path: Path,
 ) -> None:
@@ -197,9 +243,54 @@ def test_loader_has_no_main_or_public_write_surface() -> None:
     ).read_text()
 
     assert 'TARGET_TABLE = "research.kr_candles_1m_toss"' in source
-    assert not re.search(
-        r"(?:INSERT INTO|UPDATE|DELETE FROM)\\s+research\\.kr_candles_1m(?:\\s|$)",
-        source,
+    main_write = re.compile(
+        r"(?:INSERT INTO|UPDATE|DELETE FROM)\s+research\.kr_candles_1m(?=\s|$)",
+        re.IGNORECASE,
     )
-    assert not re.search(r"(?:INSERT INTO|UPDATE|DELETE FROM)\\s+public\\.", source)
+    public_write = re.compile(
+        r"(?:INSERT INTO|UPDATE|DELETE FROM)\s+public\.", re.IGNORECASE
+    )
+    # A mutation must match these guards; otherwise the source assertion below
+    # could pass due to an inert pattern rather than an absent write surface.
+    assert main_write.search("INSERT INTO research.kr_candles_1m (time_utc)")
+    assert public_write.search("DELETE FROM public.orders")
+    assert not main_write.search(source)
+    assert not public_write.search(source)
     assert "session_segment_unclassifiable" in source
+    assert "count(DISTINCT (time_utc, symbol))" in source
+
+
+@pytest.mark.asyncio
+async def test_loader_refuses_a_nonempty_target_before_initial_load() -> None:
+    class Connection:
+        async def fetchval(self, query: str, *args: object) -> object:
+            if query == "SELECT current_user":
+                return "auto_trader_kr_backfill"
+            if query == "SELECT to_regclass($1)":
+                assert args == (TARGET_TABLE,)
+                return TARGET_TABLE
+            if query.startswith("SELECT has_table_privilege"):
+                return True
+            if query == f"SELECT count(*) FROM {TARGET_TABLE}":
+                return 1
+            raise AssertionError(f"unexpected query: {query}")
+
+    checkpoint = {"initial_target_rows": None}
+    with pytest.raises(DatabaseLoadError, match="nonempty_target_at_initial_load"):
+        await _assert_database_ready(
+            Connection(),
+            expected_source_rows=1,
+            checkpoint=checkpoint,
+        )
+    assert checkpoint["initial_target_rows"] is None
+
+
+def test_invalid_minimum_fragment_age_stops_with_structured_reason(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(LoadStopped, match="min_fragment_age_seconds_must_be_positive"):
+        freeze_completed_fragments(
+            staging_dir=tmp_path / "staging",
+            state_dir=tmp_path / "state",
+            min_fragment_age_seconds=0,
+        )

--- a/tests/research/toss_phase2/test_load.py
+++ b/tests/research/toss_phase2/test_load.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from research.toss_phase2.collect import (
+    STAGING_CONTRACT,
+    VALUE_SEMANTICS,
+    write_page,
+)
+from research.toss_phase2.load import (
+    SOURCE,
+    StagingValidationError,
+    freeze_completed_fragments,
+    preflight_source,
+)
+
+
+def _row(*, timestamp: datetime, segment: str = "KRX_REGULAR") -> dict[str, object]:
+    return {
+        "time_utc": timestamp,
+        "session_date_kst": date(2026, 8, 3),
+        "symbol": "005930",
+        "session_segment": segment,
+        "source": SOURCE,
+        "open": 10.0,
+        "high": 12.0,
+        "low": 9.0,
+        "close": 11.0,
+        "volume": 5.0,
+        "value": 55.0,
+        "value_semantics": VALUE_SEMANTICS,
+        "is_padding": False,
+        "pre_nxt": None,
+        "retrieved_at": datetime(2026, 8, 4, tzinfo=UTC),
+        "batch_id": "toss-staging-batch",
+    }
+
+
+def _staging(tmp_path: Path) -> tuple[Path, Path]:
+    staging_dir = tmp_path / "staging"
+    state_dir = tmp_path / "loader-state"
+    staging_dir.mkdir()
+    (staging_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "artifact_state": STAGING_CONTRACT,
+                "batch_id": "toss-staging-batch",
+            }
+        )
+    )
+    return staging_dir, state_dir
+
+
+def _write_page(
+    staging_dir: Path,
+    *,
+    request_before: str,
+    timestamp: datetime,
+    segment: str = "KRX_REGULAR",
+) -> Path:
+    path, reused = write_page(
+        staging_dir=staging_dir,
+        symbol="005930",
+        request_before=request_before,
+        next_before="next",
+        rows=[_row(timestamp=timestamp, segment=segment)],
+        batch_id="toss-staging-batch",
+    )
+    assert path is not None
+    assert reused is False
+    return path
+
+
+def _freeze(
+    staging_dir: Path,
+    state_dir: Path,
+    page: Path,
+    *,
+    seconds_after: int = 2,
+) -> dict[str, object]:
+    stat = page.stat()
+    return freeze_completed_fragments(
+        staging_dir=staging_dir,
+        state_dir=state_dir,
+        min_fragment_age_seconds=1,
+        now_ns=stat.st_mtime_ns + seconds_after * 1_000_000_000,
+    )
+
+
+def test_freeze_selects_only_completed_old_enough_pages_without_staging_writes(
+    tmp_path: Path,
+) -> None:
+    staging_dir, state_dir = _staging(tmp_path)
+    old = _write_page(
+        staging_dir,
+        request_before="old",
+        timestamp=datetime(2026, 8, 3, 6, 0, tzinfo=UTC),
+    )
+    recent = _write_page(
+        staging_dir,
+        request_before="recent",
+        timestamp=datetime(2026, 8, 3, 6, 1, tzinfo=UTC),
+    )
+    old_stat = old.stat()
+    os.utime(old, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns - 5_000_000_000))
+    before = old.read_bytes()
+
+    snapshot = _freeze(staging_dir, state_dir, recent, seconds_after=0)
+
+    assert snapshot["completed_fragments_only"] is True
+    assert snapshot["source_rows"] == 1
+    assert snapshot["too_recent_files_excluded"] == 1
+    assert old.read_bytes() == before
+    assert not (staging_dir / "loader-state").exists()
+
+
+def test_preflight_rejects_unclassifiable_session_segment_before_any_db_work(
+    tmp_path: Path,
+) -> None:
+    staging_dir, state_dir = _staging(tmp_path)
+    page = _write_page(
+        staging_dir,
+        request_before="unknown-segment",
+        timestamp=datetime(2026, 8, 3, 11, 1, tzinfo=UTC),
+        segment="UNKNOWN",
+    )
+    snapshot = _freeze(staging_dir, state_dir, page)
+
+    with pytest.raises(StagingValidationError, match="session_segment_unclassifiable"):
+        preflight_source(
+            staging_dir=staging_dir,
+            state_dir=state_dir,
+            snapshot=snapshot,
+        )
+
+
+def test_preflight_rejects_duplicate_source_key(
+    tmp_path: Path,
+) -> None:
+    staging_dir, state_dir = _staging(tmp_path)
+    first = _write_page(
+        staging_dir,
+        request_before="first",
+        timestamp=datetime(2026, 8, 3, 6, 2, tzinfo=UTC),
+    )
+    second = _write_page(
+        staging_dir,
+        request_before="second",
+        timestamp=datetime(2026, 8, 3, 6, 2, tzinfo=UTC),
+    )
+    second_stat = second.stat()
+    os.utime(
+        second, ns=(second_stat.st_atime_ns, second_stat.st_mtime_ns - 5_000_000_000)
+    )
+    snapshot = _freeze(staging_dir, state_dir, first, seconds_after=5)
+
+    with pytest.raises(StagingValidationError, match="duplicate_staging_key"):
+        preflight_source(
+            staging_dir=staging_dir,
+            state_dir=state_dir,
+            snapshot=snapshot,
+        )
+
+
+def test_preflight_reuses_completed_checkpoint_without_reloading_source(
+    tmp_path: Path,
+) -> None:
+    staging_dir, state_dir = _staging(tmp_path)
+    page = _write_page(
+        staging_dir,
+        request_before="only",
+        timestamp=datetime(2026, 8, 3, 6, 3, tzinfo=UTC),
+    )
+    snapshot = _freeze(staging_dir, state_dir, page)
+
+    preflight_source(
+        staging_dir=staging_dir,
+        state_dir=state_dir,
+        snapshot=snapshot,
+    )
+    preflight_source(
+        staging_dir=staging_dir,
+        state_dir=state_dir,
+        snapshot=snapshot,
+    )
+
+
+def test_loader_has_no_main_or_public_write_surface() -> None:
+    source = (
+        Path(__file__).resolve().parents[3] / "research" / "toss_phase2" / "load.py"
+    ).read_text()
+
+    assert 'TARGET_TABLE = "research.kr_candles_1m_toss"' in source
+    assert not re.search(
+        r"(?:INSERT INTO|UPDATE|DELETE FROM)\\s+research\\.kr_candles_1m(?:\\s|$)",
+        source,
+    )
+    assert not re.search(r"(?:INSERT INTO|UPDATE|DELETE FROM)\\s+public\\.", source)
+    assert "session_segment_unclassifiable" in source

--- a/tests/research/toss_phase2/test_load.py
+++ b/tests/research/toss_phase2/test_load.py
@@ -188,6 +188,7 @@ def test_preflight_rejects_duplicate_source_key(
     ("row_overrides", "reason"),
     [
         ({"volume": -1.0, "value": -11.0}, "negative_volume"),
+        ({"volume": "not-a-number"}, "non_numeric_candle_value"),
         ({"high": 10.0}, "incoherent_ohlc_values"),
         ({"value": 54.0}, "synthetic_value_mismatch"),
     ],

--- a/tests/research/toss_phase2/test_load.py
+++ b/tests/research/toss_phase2/test_load.py
@@ -20,6 +20,7 @@ from research.toss_phase2.load import (
     LoadStopped,
     StagingValidationError,
     _assert_database_ready,
+    _prefer_target_key_lookups,
     freeze_completed_fragments,
     preflight_source,
 )
@@ -284,6 +285,26 @@ async def test_loader_refuses_a_nonempty_target_before_initial_load() -> None:
             checkpoint=checkpoint,
         )
     assert checkpoint["initial_target_rows"] is None
+
+
+@pytest.mark.asyncio
+async def test_batch_coverage_queries_prefer_transaction_local_target_key_lookups() -> (
+    None
+):
+    class Connection:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        async def execute(self, query: str) -> None:
+            self.statements.append(query)
+
+    conn = Connection()
+    await _prefer_target_key_lookups(conn)
+
+    assert conn.statements == [
+        "SET LOCAL enable_hashjoin TO off",
+        "SET LOCAL enable_mergejoin TO off",
+    ]
 
 
 def test_invalid_minimum_fragment_age_stops_with_structured_reason(

--- a/tests/research/toss_phase2/test_migration.py
+++ b/tests/research/toss_phase2/test_migration.py
@@ -21,6 +21,7 @@ def test_toss_corpus_is_separate_and_venue_free() -> None:
     assert "venue TEXT" not in source
     assert "UNIQUE (time_utc, symbol)" in source
     assert "session_segment TEXT NOT NULL" in source
+    assert "UNKNOWN" not in migration.SESSION_SEGMENTS
     assert "CHECK (source = 'TOSS')" in source
 
 

--- a/tests/research/toss_phase2/test_migration.py
+++ b/tests/research/toss_phase2/test_migration.py
@@ -50,7 +50,7 @@ def test_toss_migration_history_merges_the_newer_main_head() -> None:
     )
     source = merge_path.read_text()
 
-    assert 'revision: str = "20260805_merge_toss_phase2_kis_mock_runner"' in source
+    assert 'revision: str = "20260805_toss_merge"' in source
     assert '"20260804_toss_phase2"' in source
     assert '"20260805_kis_mock_runner"' in source
     assert "op." not in source

--- a/tests/research/toss_phase2/test_migration.py
+++ b/tests/research/toss_phase2/test_migration.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+MIGRATION_PATH = REPO / "alembic" / "versions" / "20260804_toss_phase2_corpus.py"
+
+spec = importlib.util.spec_from_file_location("toss_phase2_migration", MIGRATION_PATH)
+assert spec is not None and spec.loader is not None
+migration = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migration)
+
+
+def test_toss_corpus_is_separate_and_venue_free() -> None:
+    source = MIGRATION_PATH.read_text()
+
+    assert migration.down_revision == "20260803_research_kr_candles"
+    assert migration.TABLE_NAME == "kr_candles_1m_toss"
+    assert len(migration.CAGG_SPECS) == 4
+    assert "venue TEXT" not in source
+    assert "UNIQUE (time_utc, symbol)" in source
+    assert "session_segment TEXT NOT NULL" in source
+    assert "CHECK (source = 'TOSS')" in source
+
+
+def test_toss_migration_is_additive_and_least_privilege() -> None:
+    source = MIGRATION_PATH.read_text()
+
+    assert "ALTER DEFAULT PRIVILEGES" not in source
+    assert "GRANT SELECT, INSERT ON TABLE research.{TABLE_NAME}" in source
+    assert "GRANT ALL" not in source
+    assert "DROP TABLE IF EXISTS research.{TABLE_NAME}" in source
+    assert "pre_nxt BOOLEAN" in source
+    assert "BOOL_AND(is_padding) AS is_padding" in source
+    assert "no cagg refresh policy is installed" in source

--- a/tests/research/toss_phase2/test_migration.py
+++ b/tests/research/toss_phase2/test_migration.py
@@ -15,7 +15,7 @@ spec.loader.exec_module(migration)
 def test_toss_corpus_is_separate_and_venue_free() -> None:
     source = MIGRATION_PATH.read_text()
 
-    assert migration.down_revision == "20260803_research_kr_candles"
+    assert migration.down_revision == "20260804_alpaca_clean_account"
     assert migration.TABLE_NAME == "kr_candles_1m_toss"
     assert len(migration.CAGG_SPECS) == 4
     assert "venue TEXT" not in source

--- a/tests/research/toss_phase2/test_migration.py
+++ b/tests/research/toss_phase2/test_migration.py
@@ -35,3 +35,7 @@ def test_toss_migration_is_additive_and_least_privilege() -> None:
     assert "pre_nxt BOOLEAN" in source
     assert "BOOL_AND(is_padding) AS is_padding" in source
     assert "no cagg refresh policy is installed" in source
+    assert "COMMENT ON VIEW research.{view_name}" in source
+    assert "COMMENT ON MATERIALIZED VIEW research.{view_name}" in source
+    assert "DROP VIEW research.{view_name}" in source
+    assert "DROP MATERIALIZED VIEW research.{view_name}" in source

--- a/tests/research/toss_phase2/test_migration.py
+++ b/tests/research/toss_phase2/test_migration.py
@@ -37,8 +37,9 @@ def test_toss_migration_is_additive_and_least_privilege() -> None:
     assert "no cagg refresh policy is installed" in source
     assert "COMMENT ON VIEW research.{view_name}" in source
     assert "COMMENT ON MATERIALIZED VIEW research.{view_name}" in source
-    assert "DROP VIEW research.{view_name}" in source
-    assert "DROP MATERIALIZED VIEW research.{view_name}" in source
+    assert "DROP MATERIALIZED VIEW IF EXISTS research.{view_name}" in source
+    assert "TimescaleDB 2.8.0 or newer is required" in source
+    assert ")::INTEGER[] >= ARRAY[2, 8, 0]" in source
 
 
 def test_toss_migration_history_merges_the_newer_main_head() -> None:

--- a/tests/research/toss_phase2/test_migration.py
+++ b/tests/research/toss_phase2/test_migration.py
@@ -39,3 +39,18 @@ def test_toss_migration_is_additive_and_least_privilege() -> None:
     assert "COMMENT ON MATERIALIZED VIEW research.{view_name}" in source
     assert "DROP VIEW research.{view_name}" in source
     assert "DROP MATERIALIZED VIEW research.{view_name}" in source
+
+
+def test_toss_migration_history_merges_the_newer_main_head() -> None:
+    merge_path = (
+        REPO
+        / "alembic"
+        / "versions"
+        / "20260805_merge_toss_phase2_and_kis_mock_runner_heads.py"
+    )
+    source = merge_path.read_text()
+
+    assert 'revision: str = "20260805_merge_toss_phase2_kis_mock_runner"' in source
+    assert '"20260804_toss_phase2"' in source
+    assert '"20260805_kis_mock_runner"' in source
+    assert "op." not in source

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -14,6 +14,7 @@ from app.services.brokers.toss import rate_limiter as rate_limiter_module
 from app.services.brokers.toss.auth import TossOAuthTokenManager
 from app.services.brokers.toss.client import TossReadClient
 from app.services.brokers.toss.errors import TossApiResponseError
+from app.services.brokers.toss.rate_limiter import TossApiGroup
 
 
 @dataclass
@@ -343,9 +344,10 @@ async def test_strict_reader_does_not_reissue_after_401(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_strict_reader_does_not_retry_after_429(monkeypatch) -> None:
     calls = 0
+    health_writes = []
 
     async def no_health_write(**kwargs) -> None:
-        del kwargs
+        health_writes.append(kwargs)
 
     monkeypatch.setattr(toss_client_module, "publish_toss_api_error", no_health_write)
 
@@ -368,6 +370,7 @@ async def test_strict_reader_does_not_retry_after_429(monkeypatch) -> None:
         token_manager=_TokenManager(),
         transport=httpx.MockTransport(handler),
         retry_on_429=False,
+        publish_error_signals=False,
     )
     try:
         with pytest.raises(TossApiResponseError) as exc_info:
@@ -377,6 +380,7 @@ async def test_strict_reader_does_not_retry_after_429(monkeypatch) -> None:
 
     assert exc_info.value.status_code == 429
     assert calls == 1
+    assert health_writes == []
 
 
 @pytest.mark.asyncio
@@ -665,6 +669,42 @@ async def test_candles_returns_typed_page_and_sends_query_params() -> None:
     }
     assert page.next_before == "2026-06-11T00:00:00.000+09:00"
     assert page.candles[0].close_price == Decimal("326000")
+
+
+@pytest.mark.asyncio
+async def test_candles_response_observer_receives_documented_rate_headers() -> None:
+    observed = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=_json({"candles": [], "nextBefore": None}),
+            headers={
+                "X-RateLimit-Limit": "7",
+                "X-RateLimit-Remaining": "6",
+                "X-RateLimit-Reset": "0.25",
+            },
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        transport=httpx.MockTransport(handler),
+        response_observer=lambda group, status, headers: observed.append(
+            (group, status, headers)
+        ),
+    )
+    try:
+        await client.candles("005930", interval="1m", count=1)
+    finally:
+        await client.aclose()
+
+    group, status, headers = observed[0]
+    assert group is TossApiGroup.MARKET_DATA_CHART
+    assert status == 200
+    assert headers.limit == 7
+    assert headers.remaining == 6
+    assert headers.reset_seconds == 0.25
 
 
 @pytest.mark.asyncio

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -292,6 +292,109 @@ async def test_get_order_retries_once_after_invalid_token() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reissued_token_retry_publishes_its_http_failure(monkeypatch) -> None:
+    calls = 0
+    health_writes: list[dict[str, object]] = []
+
+    async def capture_health_write(**kwargs: object) -> None:
+        health_writes.append(kwargs)
+
+    monkeypatch.setattr(
+        toss_client_module, "publish_toss_api_error", capture_health_write
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                401,
+                json={
+                    "error": {
+                        "requestId": "invalid-token",
+                        "code": "invalid-token",
+                        "message": "expired",
+                    }
+                },
+                request=request,
+            )
+        return httpx.Response(
+            500,
+            json={
+                "error": {
+                    "requestId": "retry-500",
+                    "code": "upstream-failure",
+                    "message": "retry failed",
+                }
+            },
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(TossApiResponseError) as exc_info:
+            await client.candles("005930", interval="1m", count=1)
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.status_code == 500
+    assert health_writes == [
+        {"status_code": 401, "error_type": "http_response"},
+        {"status_code": 500, "error_type": "http_response"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reissued_token_retry_publishes_its_transport_failure(
+    monkeypatch,
+) -> None:
+    calls = 0
+    health_writes: list[dict[str, object]] = []
+
+    async def capture_health_write(**kwargs: object) -> None:
+        health_writes.append(kwargs)
+
+    monkeypatch.setattr(
+        toss_client_module, "publish_toss_api_error", capture_health_write
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                401,
+                json={
+                    "error": {
+                        "requestId": "invalid-token",
+                        "code": "invalid-token",
+                        "message": "expired",
+                    }
+                },
+                request=request,
+            )
+        raise httpx.ConnectError("reissue retry failed", request=request)
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(httpx.ConnectError):
+            await client.candles("005930", interval="1m", count=1)
+    finally:
+        await client.aclose()
+
+    assert health_writes == [
+        {"status_code": 401, "error_type": "http_response"},
+        {"status_code": None, "error_type": "ConnectError"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_strict_reader_does_not_reissue_after_401(monkeypatch) -> None:
     """A bulk reader can fail closed without churning the shared OAuth token."""
     calls = 0

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 from pydantic import SecretStr
 
+from app.services.brokers.toss import client as toss_client_module
 from app.services.brokers.toss import rate_limiter as rate_limiter_module
 from app.services.brokers.toss.auth import TossOAuthTokenManager
 from app.services.brokers.toss.client import TossReadClient
@@ -287,6 +288,95 @@ async def test_get_order_retries_once_after_invalid_token() -> None:
     # ROB-547: the reissue must carry the failed token so a peer's fresher
     # token can be reused instead of force-churning a new one.
     assert failed_tokens == [None, "token-1"]
+
+
+@pytest.mark.asyncio
+async def test_strict_reader_does_not_reissue_after_401(monkeypatch) -> None:
+    """A bulk reader can fail closed without churning the shared OAuth token."""
+    calls = 0
+    token_calls: list[bool] = []
+
+    async def no_health_write(**kwargs) -> None:
+        del kwargs
+
+    monkeypatch.setattr(toss_client_module, "publish_toss_api_error", no_health_write)
+
+    class TokenManager(_TokenManager):
+        async def get_access_token(
+            self, *, force_reissue: bool = False, failed_token: str | None = None
+        ) -> str:
+            del failed_token
+            token_calls.append(force_reissue)
+            return "token-1"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            401,
+            json={
+                "error": {
+                    "requestId": "req-401",
+                    "code": "invalid-token",
+                    "message": "expired",
+                }
+            },
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=TokenManager(),
+        transport=httpx.MockTransport(handler),
+        retry_auth_reissue=False,
+    )
+    try:
+        with pytest.raises(TossApiResponseError) as exc_info:
+            await client.candles("005930", interval="1m", count=1)
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.status_code == 401
+    assert calls == 1
+    assert token_calls == [False]
+
+
+@pytest.mark.asyncio
+async def test_strict_reader_does_not_retry_after_429(monkeypatch) -> None:
+    calls = 0
+
+    async def no_health_write(**kwargs) -> None:
+        del kwargs
+
+    monkeypatch.setattr(toss_client_module, "publish_toss_api_error", no_health_write)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            429,
+            json={
+                "error": {
+                    "requestId": "req-429",
+                    "code": "too-many-requests",
+                    "message": "slow down",
+                }
+            },
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        transport=httpx.MockTransport(handler),
+        retry_on_429=False,
+    )
+    try:
+        with pytest.raises(TossApiResponseError) as exc_info:
+            await client.candles("005930", interval="1m", count=1)
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.status_code == 429
+    assert calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/services/brokers/toss/test_health.py
+++ b/tests/services/brokers/toss/test_health.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.toss import health
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.increments: dict[str, int] = {}
+
+    async def incr(self, key: str) -> int:
+        self.increments[key] = self.increments.get(key, 0) + 1
+        return self.increments[key]
+
+    async def set(self, key: str, value: str, *, ex: int) -> bool:
+        assert ex == health._ERROR_TTL_SECONDS
+        self.values[key] = value
+        return True
+
+    async def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+
+@pytest.mark.asyncio
+async def test_published_toss_error_is_redacted_and_readable(monkeypatch) -> None:
+    redis = _FakeRedis()
+
+    async def get_redis() -> _FakeRedis:
+        return redis
+
+    monkeypatch.setattr(health, "_get_redis_client", get_redis)
+
+    await health.publish_toss_api_error(
+        status_code=429,
+        error_type="http_response",
+        error_code="too-many-requests",
+    )
+    signal = await health.read_toss_api_error_signal()
+
+    assert signal is not None
+    assert signal.sequence == 1
+    assert signal.status_code == 429
+    assert signal.error_code == "too-many-requests"
+    assert "Authorization" not in redis.values[health._ERROR_EVENT_KEY]
+    assert "token" not in redis.values[health._ERROR_EVENT_KEY]

--- a/tests/services/brokers/toss/test_rate_limiter.py
+++ b/tests/services/brokers/toss/test_rate_limiter.py
@@ -11,7 +11,9 @@ from app.services.brokers.toss import rate_limiter as rate_limiter_module
 from app.services.brokers.toss.rate_limiter import (
     TossApiGroup,
     TossRateLimiter,
+    TossRateLimitHeaders,
     get_shared_rate_limiter,
+    parse_rate_limit_headers,
     retry_delay_seconds,
 )
 
@@ -32,6 +34,39 @@ def test_market_data_limit_is_ten_tps() -> None:
     limiter = TossRateLimiter()
 
     assert limiter.limit_for(TossApiGroup.MARKET_DATA) == 10
+
+
+def test_rate_limit_headers_are_parsed_case_insensitively_without_fallback_cap() -> (
+    None
+):
+    headers = parse_rate_limit_headers(
+        {
+            "x-ratelimit-limit": "7",
+            "X-RateLimit-Remaining": "2",
+            "X-RATELIMIT-RESET": "0.25",
+            "retry-after": "3",
+        }
+    )
+
+    assert headers == TossRateLimitHeaders(
+        limit=7,
+        remaining=2,
+        reset_seconds=0.25,
+        retry_after_seconds=3.0,
+    )
+
+
+def test_rate_limit_headers_leave_malformed_or_missing_cap_unknown() -> None:
+    headers = parse_rate_limit_headers(
+        {
+            "X-RateLimit-Limit": "not-a-number",
+            "X-RateLimit-Remaining": "-1",
+            "X-RateLimit-Reset": "bad",
+            "Retry-After": "-2",
+        }
+    )
+
+    assert headers == TossRateLimitHeaders(None, None, None, None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add append-only, checkpointed Parquet staging for the separate Toss combined KRX/NXT corpus
- add additive research.kr_candles_1m_toss migration with four dedicated caggs and least-privilege backfill-role grant
- preserve no-venue semantics, synthetic value labels, padding labels, latest-session exclusion, and pre-NXT UNKNOWN state
- stop the staging collector on a shared production Toss 401/429/error signal; no token issuance or force-reissue

## Safety
- no order/account endpoint calls, public writes, scheduler registration, staging-to-DB load, or pre-NXT promotion
- table comment and Phase 2 note carry the consumer warnings
- role grant is SELECT/INSERT only; this table has no sequence and no broad default privileges are changed

## Validation
- make lint
- 52 focused Toss/Phase2/static-LLM tests passed
- isolated local scratch migration upgrade/downgrade passed; scratch DB removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Toss KRX/NXT market-data staging and loading workflow with resumable collection, validation, and verification.
  - Added adaptive rate-limit handling, retry controls, cached-token authentication, and API health monitoring.
  - Added support for storing and aggregating minute-candle research data.

- **Documentation**
  - Documented staging, loading, session handling, rate limits, retries, and recovery behavior.

- **Tests**
  - Added comprehensive coverage for collection, loading, migrations, rate limiting, retries, and health signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->