### PR TITLE
fix(research): remove KR backfill count witness

### DIFF
--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -1,8 +1,7 @@
 """Stage B collector — three independent source streams into research history.
 
 Destination is ``research.kr_candles_1m``. Production ``public.kr_candles_1m``
-is a **witness table** here: it is read for latency probing and checked for
-unexpected row-count change, but never written.
+is read only for latency probing and is never written.
 
 Write discipline (all enforced here, not by convention):
 
@@ -17,7 +16,7 @@ Write discipline (all enforced here, not by convention):
 
 Abort conditions (stop the stream, report, do not "work around"):
 conflict ratio far from expectation · query latency regression vs baseline ·
-repeated 429s · any change to a witness table outside kr_candles_1m.
+repeated 429s.
 """
 
 from __future__ import annotations
@@ -66,16 +65,12 @@ SELECT * FROM UNNEST($1::text[], $2::timestamptz[], $3::date[], $4::text[],
 ON CONFLICT (time_utc, symbol, venue) DO NOTHING
 """
 
-#: Production tables that this job must never modify. Checked before and during.
-WITNESS_TABLES = (
-    "public.kr_candles_1m",
-    "public.kr_symbol_universe",
-    "public.stock_info",
-)
-
 #: Latency regression threshold vs the Stage A baseline median (2.127 ms).
 LATENCY_ABORT_FACTOR = 5.0
 MAX_CONSECUTIVE_429 = 3
+
+# DB 권한으로 대체됨(role auto_trader_kr_backfill, 2026-08-04 적용).
+# 행수 감시는 프로덕션 동시 쓰기와 구분 불가.
 
 
 @dataclass
@@ -196,29 +191,16 @@ async def insert_bars(
 
 
 class Guard:
-    """Abort-condition monitor shared by all streams."""
+    """Latency and 429 abort-condition monitor shared by all streams."""
 
     def __init__(self, pool: asyncpg.Pool, baseline_median_ms: float, log: ProgressLog):
         self.pool = pool
         self.baseline = baseline_median_ms
         self.log = log
-        self.witness: dict[str, int] = {}
         self.consecutive_429: dict[str, int] = {}
-
-    async def snapshot_witness(self) -> None:
-        async with self.pool.acquire() as c:
-            for t in WITNESS_TABLES:
-                self.witness[t] = await c.fetchval(f"SELECT count(*) FROM {t}")
 
     async def check(self, source: str) -> None:
         async with self.pool.acquire() as c:
-            for t in WITNESS_TABLES:
-                n = await c.fetchval(f"SELECT count(*) FROM {t}")
-                if n != self.witness[t]:
-                    raise AbortStream(
-                        f"witness table {t} changed {self.witness[t]}->{n} "
-                        f"(out-of-scope write detected)"
-                    )
             samples = []
             for _ in range(5):
                 t0 = time.perf_counter()
@@ -456,7 +438,6 @@ async def main() -> int:
     pool = await asyncpg.create_pool(dsn(), min_size=2, max_size=6)
     log = ProgressLog(args.job_dir / "events" / "progress.jsonl")
     guard = Guard(pool, args.baseline_median_ms, log)
-    await guard.snapshot_witness()
 
     log.write(
         {

--- a/tests/research/test_kr_backfill_count_witness_removal.py
+++ b/tests/research/test_kr_backfill_count_witness_removal.py
@@ -1,0 +1,118 @@
+"""Regression coverage for the 2026-08-04 count-witness retirement."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+COLLECT_PATH = REPOSITORY_ROOT / "research" / "kr_backfill" / "collect.py"
+
+
+@pytest.fixture
+def collect_module() -> ModuleType:
+    module_name = "kr_backfill_collect_count_witness_test"
+    sys.path.insert(0, str(COLLECT_PATH.parent))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, COLLECT_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        sys.path.remove(str(COLLECT_PATH.parent))
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    async def fetch(self, query: str, *args: object) -> list[object]:
+        self.queries.append(query)
+        return []
+
+
+class _Acquire:
+    def __init__(self, connection: _Connection) -> None:
+        self.connection = connection
+
+    async def __aenter__(self) -> _Connection:
+        return self.connection
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.connection = _Connection()
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self.connection)
+
+
+class _Log:
+    def __init__(self) -> None:
+        self.records: list[dict[str, object]] = []
+
+    def write(self, record: dict[str, object]) -> None:
+        self.records.append(record)
+
+
+@pytest.mark.asyncio
+async def test_count_witness_is_removed_but_latency_probe_remains(
+    collect_module: ModuleType,
+) -> None:
+    pool = _Pool()
+    log = _Log()
+    guard = collect_module.Guard(pool, baseline_median_ms=1_000.0, log=log)
+
+    await guard.check("toss")
+
+    assert not hasattr(guard, "witness")
+    assert not hasattr(guard, "snapshot_witness")
+    assert len(pool.connection.queries) == 5
+    assert all(
+        "SELECT time, close FROM public.kr_candles_1m" in query
+        for query in pool.connection.queries
+    )
+    assert all("count(" not in query.lower() for query in pool.connection.queries)
+    assert [record["event"] for record in log.records] == ["latency_probe"]
+
+
+@pytest.mark.asyncio
+async def test_latency_abort_is_preserved(
+    collect_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ticks = iter([0.0, 0.006] * 5)
+    monkeypatch.setattr(collect_module.time, "perf_counter", lambda: next(ticks))
+    pool = _Pool()
+    log = _Log()
+    guard = collect_module.Guard(pool, baseline_median_ms=1.0, log=log)
+
+    with pytest.raises(collect_module.AbortStream, match="query latency"):
+        await guard.check("toss")
+
+    assert len(pool.connection.queries) == 5
+    assert [record["event"] for record in log.records] == ["latency_probe"]
+
+
+def test_consecutive_429_abort_is_preserved(collect_module: ModuleType) -> None:
+    guard = collect_module.Guard(_Pool(), baseline_median_ms=1.0, log=_Log())
+
+    guard.note_429("kiwoom", True)
+    guard.note_429("kiwoom", True)
+    with pytest.raises(collect_module.AbortStream, match="3 consecutive 429s"):
+        guard.note_429("kiwoom", True)
+
+
+def test_research_upsert_target_is_unchanged(collect_module: ModuleType) -> None:
+    assert collect_module.TARGET_TABLE == "research.kr_candles_1m"
+    assert "INSERT INTO research.kr_candles_1m" in collect_module.UPSERT_SQL
+    assert "public." not in collect_module.UPSERT_SQL


### PR DESCRIPTION
## Summary
- Remove the count-based public-table witness snapshot and comparison loop.
- Preserve the latency and consecutive-429 abort paths, with the DB-role rationale in code.
- Add regression coverage for count-witness removal, latency abort, 429 abort, and the research-only upsert target.

## Verification
- `make lint`
- `uv run pytest -q tests/research` (31 passed)
- #1766 AST static guard replay against current `research/kr_backfill/**/*.py` (PASS; no new public DML path)
- restricted-role zero-row research UPSERT privilege probe (`INSERT 0 0`)

No Stage-B canary, backfill resume, orders, or witness-adjacent abort removals were run.