### PR TITLE
fix(research): gate daytime backfill with approval env

### DIFF
--- a/research/kr_backfill/sources.py
+++ b/research/kr_backfill/sources.py
@@ -15,6 +15,7 @@ to operator discipline: `assert_fetch_window_open()` is called by every fetcher.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from datetime import date, datetime, timedelta, timezone
 from datetime import time as dtime
@@ -55,6 +56,10 @@ def now_kst() -> datetime:
 def assert_fetch_window_open(*, override_now: datetime | None = None) -> None:
     n = override_now or now_kst()
     if FREEZE_START <= n.time() < FREEZE_END:
+        # 2026-08-04 운영자 승인: 주간 백필 가동. dbrole 적용으로
+        # public.* write가 차단된다는 전제에서 exact "true"만 허용한다.
+        if os.getenv("BACKFILL_DAYTIME_APPROVED") == "true":
+            return
         raise FetchWindowClosed(
             f"fetch frozen 09:00-20:00 KST (regular session + NXT); now {n:%H:%M:%S} KST"
         )

--- a/tests/research/test_kr_backfill_fetch_window.py
+++ b/tests/research/test_kr_backfill_fetch_window.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+import pytest
+
+from research.kr_backfill.sources import (
+    KST,
+    FetchWindowClosed,
+    assert_fetch_window_open,
+)
+
+
+@pytest.mark.parametrize(
+    ("hour", "minute", "approved", "blocked"),
+    [
+        pytest.param(11, 22, None, True, id="daytime-unset-blocked"),
+        pytest.param(11, 22, "true", False, id="daytime-true-open"),
+        pytest.param(20, 0, None, False, id="outside-unset-open"),
+        pytest.param(20, 0, "true", False, id="outside-true-open"),
+    ],
+)
+def test_fetch_window_daytime_override_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    hour: int,
+    minute: int,
+    approved: str | None,
+    blocked: bool,
+) -> None:
+    if approved is None:
+        monkeypatch.delenv("BACKFILL_DAYTIME_APPROVED", raising=False)
+    else:
+        monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", approved)
+
+    now = datetime(2026, 8, 4, hour, minute, tzinfo=KST)
+    if blocked:
+        with pytest.raises(FetchWindowClosed):
+            assert_fetch_window_open(override_now=now)
+    else:
+        assert_fetch_window_open(override_now=now)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("false", id="false"),
+        pytest.param("TRUE", id="uppercase-TRUE"),
+        pytest.param("1", id="one"),
+        pytest.param("yes", id="yes"),
+        pytest.param("", id="empty"),
+        pytest.param(" ", id="whitespace"),
+    ],
+)
+def test_fetch_window_rejects_every_non_true_override(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", value)
+
+    with pytest.raises(FetchWindowClosed):
+        assert_fetch_window_open(override_now=datetime(2026, 8, 4, 11, 22, tzinfo=KST))


### PR DESCRIPTION
## Summary

- Allow the 09:00-20:00 KST fetch window only when BACKFILL_DAYTIME_APPROVED is exactly true.
- Preserve assert_fetch_window_open and fail closed for unset or non-exact values.
- Record the 2026-08-04 operator approval and dbrole/public-write precondition in code.

## Verification

- Before implementation: 1 failed, 9 passed; daytime true reproduced the missing override.
- After implementation: 14 passed across the 10 new cases and 4 adjacent count-witness regression cases.
- Ruff check and format check passed for both changed files.
- Negative daytime values blocked: unset, false, TRUE, 1, yes, empty string, whitespace.

## Safety

- No backfill run, broker API call, account access, order, or database write was performed.