### PR TITLE
feat: minimum intraday harness v2 execution semantics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -365,6 +365,40 @@ jobs:
       run: |
         uv run pytest research/alpaca_track_signals/tests/ -q -ra --strict-markers
 
+  intraday-harness-v2-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      PYTHON_VERSION: "3.13"
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install UV
+      run: pip install uv
+
+    - name: Load cached venv
+      id: cached-uv-dependencies
+      uses: actions/cache@v5
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/uv.lock') }}
+
+    - name: Install dependencies
+      run: uv sync --group test
+
+    - name: Run intraday harness v2 freeze and execution tests
+      run: uv run pytest research/intraday_harness_v2/tests/ -v -ra --strict-markers
+
   alpaca-track-walkforward-tests:
     # ROB-1062 H4 remains a separate gate from the consolidated H1/H2/H3 job:
     # it has its own conftest.py sys.path wiring onto its three

--- a/research/intraday_harness_v2/README.md
+++ b/research/intraday_harness_v2/README.md
@@ -7,5 +7,20 @@ fills, all-or-none execution, fail-closed missing/incomplete bars, and
 separate fee/slippage accounting. Limit, partial, stop/target ordering, and
 extended-hours semantics are intentionally absent.
 
-`contract.py` verifies the SHA-256 of `engine.py` at import time. Updating
-execution semantics therefore requires an explicit contract freeze update.
+`contract.py` verifies the SHA-256 of `engine.py`, the public `__init__.py`
+entry point, and itself at import time. The self-pin uses one hash value and
+one placeholder marker; verification normalizes the value to the marker and
+requires each to occur exactly once. Updating execution semantics therefore
+requires an explicit contract freeze update. This is tamper-evident protection
+against ordinary source drift, not an unbreakable Python sandbox: a coordinated
+edit can retarget the pins, but it changes `CONTRACT_HASH` and remains visible
+in review. Python cannot make deletion of the `verify_contract()` call sites
+structurally impossible; that residual is detectable only by code review/diff.
+
+`slippage` is an unsigned accounting cost. Consumers that model execution
+direction must apply the BUY/SELL sign themselves; `fill_price` is unchanged.
+Incomplete fills have quantity zero. `filled_count` and `filled_notional`
+describe actual fills, while `signal_count` and `NO_SIGNALS` distinguish an
+empty signal stream from a completed run. A missing next bar on a later
+calendar date is reported as `NEXT_BAR_SESSION_GAP`; same-date missing data is
+`NEXT_BAR_MISSING`.

--- a/research/intraday_harness_v2/README.md
+++ b/research/intraday_harness_v2/README.md
@@ -1,0 +1,11 @@
+# Intraday harness v2
+
+Contract version: `intraday-harness-v2.0.0`.
+
+This package supports only bar-close signals, strictly-next-bar open market
+fills, all-or-none execution, fail-closed missing/incomplete bars, and
+separate fee/slippage accounting. Limit, partial, stop/target ordering, and
+extended-hours semantics are intentionally absent.
+
+`contract.py` verifies the SHA-256 of `engine.py` at import time. Updating
+execution semantics therefore requires an explicit contract freeze update.

--- a/research/intraday_harness_v2/__init__.py
+++ b/research/intraday_harness_v2/__init__.py
@@ -1,0 +1,28 @@
+"""Minimum deterministic intraday execution harness (v2 contract)."""
+
+from .contract import CONTRACT_HASH, CONTRACT_VERSION, verify_contract
+from .engine import (
+    Bar,
+    BarSeries,
+    ExecutionSummary,
+    Fill,
+    IncompleteReason,
+    Side,
+    Signal,
+    run,
+)
+
+verify_contract()
+
+__all__ = [
+    "Bar",
+    "BarSeries",
+    "CONTRACT_HASH",
+    "CONTRACT_VERSION",
+    "ExecutionSummary",
+    "Fill",
+    "IncompleteReason",
+    "Signal",
+    "Side",
+    "run",
+]

--- a/research/intraday_harness_v2/contract.py
+++ b/research/intraday_harness_v2/contract.py
@@ -8,10 +8,14 @@ from pathlib import Path
 
 CONTRACT_VERSION = "intraday-harness-v2.0.0"
 _ROOT = Path(__file__).resolve().parent
+_SELF_HASH_PLACEHOLDER = "__SELF_SHA256_PLACEHOLDER__"
+_SELF_HASH_EXPECTED = "70f20c166673304a01a5e21ef1faa07b533b65e46f1ae265d0a591bdc2c8db49"
 
 # These pins deliberately cover executable enforcement, not just this text.
 _ENFORCEMENT_SHA256 = {
-    "engine.py": "77fa524e09a78e07d71057983b3f2be50f3904824109f197a954ee27103b1a70",
+    "engine.py": "e2e89fc2fd5f41bde9a473691c06743dbfd4eb56f6a5539296f5bd0ca5a342a3",
+    "__init__.py": "0b8f73cd56a274f84fa2da3cea64dd2b4cef0bea1c22165af166a22a481b62f2",
+    "contract.py": _SELF_HASH_EXPECTED,
 }
 _DECLARATION = {
     "version": CONTRACT_VERSION,
@@ -39,7 +43,22 @@ def _canonical_json(value: object) -> bytes:
 
 
 def _actual_enforcement_hashes() -> dict[str, str]:
-    return {name: _sha256(_ROOT / name) for name in _ENFORCEMENT_SHA256}
+    actual: dict[str, str] = {}
+    for name in _ENFORCEMENT_SHA256:
+        path = _ROOT / name
+        if name == "contract.py":
+            source = path.read_bytes()
+            marker = _SELF_HASH_PLACEHOLDER.encode()
+            expected = _SELF_HASH_EXPECTED.encode()
+            if source.count(expected) != 1 or source.count(marker) != 1:
+                raise RuntimeError(
+                    "contract.py must contain exactly one self-hash value and marker"
+                )
+            normalized = source.replace(expected, marker)
+            actual[name] = hashlib.sha256(normalized).hexdigest()
+        else:
+            actual[name] = _sha256(path)
+    return actual
 
 
 def verify_contract() -> None:

--- a/research/intraday_harness_v2/contract.py
+++ b/research/intraday_harness_v2/contract.py
@@ -1,0 +1,57 @@
+"""Frozen v2 semantics, including the code that enforces them."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+CONTRACT_VERSION = "intraday-harness-v2.0.0"
+_ROOT = Path(__file__).resolve().parent
+
+# These pins deliberately cover executable enforcement, not just this text.
+_ENFORCEMENT_SHA256 = {
+    "engine.py": "77fa524e09a78e07d71057983b3f2be50f3904824109f197a954ee27103b1a70",
+}
+_DECLARATION = {
+    "version": CONTRACT_VERSION,
+    "supported": {
+        "signal": "bar-close",
+        "fill": "strictly-next-bar-open",
+        "order_type": "market",
+        "fill_policy": "all-or-none",
+        "missing_bar": "INCOMPLETE",
+        "incomplete_bar": "INCOMPLETE",
+        "costs": ["fee", "slippage"],
+    },
+    "excluded": ["limit", "partial", "stop-target-order", "extended-hours"],
+    "forbidden": ["forward-fill", "same-bar-fill", "randomness", "wall-clock"],
+    "enforcement_sha256": _ENFORCEMENT_SHA256,
+}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _actual_enforcement_hashes() -> dict[str, str]:
+    return {name: _sha256(_ROOT / name) for name in _ENFORCEMENT_SHA256}
+
+
+def verify_contract() -> None:
+    actual = _actual_enforcement_hashes()
+    if actual != _ENFORCEMENT_SHA256:
+        raise RuntimeError(
+            "intraday harness enforcement source changed; freeze pin must be updated "
+            f"(expected={_ENFORCEMENT_SHA256!r}, actual={actual!r})"
+        )
+
+
+verify_contract()
+CONTRACT_HASH = hashlib.sha256(_canonical_json(_DECLARATION)).hexdigest()
+
+__all__ = ["CONTRACT_HASH", "CONTRACT_VERSION", "verify_contract"]

--- a/research/intraday_harness_v2/engine.py
+++ b/research/intraday_harness_v2/engine.py
@@ -1,0 +1,188 @@
+"""Pure v2 execution semantics.
+
+The only fill-producing operation is ``run``. It derives the fill bar from a
+signal's close timestamp; callers cannot supply a bar or a fill price.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+from enum import StrEnum
+
+
+class Side(StrEnum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class IncompleteReason(StrEnum):
+    SIGNAL_BAR_MISSING = "SIGNAL_BAR_MISSING"
+    SIGNAL_BAR_INCOMPLETE = "SIGNAL_BAR_INCOMPLETE"
+    NEXT_BAR_MISSING = "NEXT_BAR_MISSING"
+    NEXT_BAR_INCOMPLETE = "NEXT_BAR_INCOMPLETE"
+
+
+def _price(value: Decimal | int | str | float) -> Decimal:
+    return Decimal(str(value))
+
+
+@dataclass(frozen=True, slots=True)
+class Bar:
+    symbol: str
+    open_time: datetime
+    close_time: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    complete: bool = True
+
+    def __post_init__(self) -> None:
+        if self.open_time.tzinfo is None or self.close_time.tzinfo is None:
+            raise ValueError("bar timestamps must be timezone-aware")
+        if self.close_time <= self.open_time:
+            raise ValueError("bar close_time must be after open_time")
+        for name in ("open", "high", "low", "close"):
+            value = getattr(self, name)
+            if not isinstance(value, Decimal) or value <= 0:
+                raise ValueError(f"{name} must be a positive Decimal")
+        if self.low > min(self.open, self.close) or self.high < max(
+            self.open, self.close
+        ):
+            raise ValueError("OHLC bounds are invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class BarSeries:
+    bars: tuple[Bar, ...]
+
+    def __post_init__(self) -> None:
+        keys = [(bar.symbol, bar.open_time) for bar in self.bars]
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate symbol/open_time bars are forbidden")
+
+    @classmethod
+    def from_iterable(cls, bars: Iterable[Bar]) -> BarSeries:
+        return cls(tuple(sorted(bars, key=lambda bar: (bar.symbol, bar.open_time))))
+
+    def _by_key(self) -> Mapping[tuple[str, datetime], Bar]:
+        return {(bar.symbol, bar.open_time): bar for bar in self.bars}
+
+    def get(self, symbol: str, open_time: datetime) -> Bar | None:
+        return self._by_key().get((symbol, open_time))
+
+
+@dataclass(frozen=True, slots=True)
+class Signal:
+    symbol: str
+    bar_close_time: datetime
+    side: Side
+    quantity: Decimal
+    bar_interval: timedelta
+
+    def __post_init__(self) -> None:
+        if self.bar_close_time.tzinfo is None or self.bar_interval <= timedelta(0):
+            raise ValueError("signal close time must be aware and interval positive")
+        if not isinstance(self.quantity, Decimal) or self.quantity <= 0:
+            raise ValueError("quantity must be a positive Decimal")
+
+
+@dataclass(frozen=True, slots=True)
+class Fill:
+    symbol: str
+    side: Side
+    signal_bar_close_time: datetime
+    fill_bar_open_time: datetime | None
+    quantity: Decimal
+    fill_price: Decimal | None
+    fee: Decimal
+    slippage: Decimal
+    incomplete_reason: IncompleteReason | None
+
+    @property
+    def incomplete(self) -> bool:
+        return self.incomplete_reason is not None
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionSummary:
+    fills: tuple[Fill, ...]
+    status: str
+    incomplete_count: int
+    fee_total: Decimal
+    slippage_total: Decimal
+
+
+def _incomplete(signal: Signal, reason: IncompleteReason) -> Fill:
+    return Fill(
+        signal.symbol,
+        signal.side,
+        signal.bar_close_time,
+        None,
+        signal.quantity,
+        None,
+        Decimal(0),
+        Decimal(0),
+        reason,
+    )
+
+
+def run(
+    signals: Iterable[Signal],
+    bars: BarSeries,
+    *,
+    fee_bps: Decimal | int | str | float,
+    slippage_bps: Decimal | int | str | float,
+) -> ExecutionSummary:
+    """Execute market/all-or-none signals at the strictly next bar's open.
+
+    Fee and slippage are accounting fields, never folded into ``fill_price``.
+    A zero fee/slippage model is explicit at the call site, never a default.
+    """
+    fee_rate = _price(fee_bps) / Decimal(10_000)
+    slippage_rate = _price(slippage_bps) / Decimal(10_000)
+    if fee_rate < 0 or slippage_rate < 0:
+        raise ValueError("fee_bps and slippage_bps must be non-negative")
+    fills: list[Fill] = []
+    for signal in signals:
+        signal_bar = bars.get(
+            signal.symbol, signal.bar_close_time - signal.bar_interval
+        )
+        if signal_bar is None:
+            fills.append(_incomplete(signal, IncompleteReason.SIGNAL_BAR_MISSING))
+            continue
+        if not signal_bar.complete:
+            fills.append(_incomplete(signal, IncompleteReason.SIGNAL_BAR_INCOMPLETE))
+            continue
+        next_bar = bars.get(signal.symbol, signal.bar_close_time)
+        if next_bar is None:
+            fills.append(_incomplete(signal, IncompleteReason.NEXT_BAR_MISSING))
+            continue
+        if not next_bar.complete:
+            fills.append(_incomplete(signal, IncompleteReason.NEXT_BAR_INCOMPLETE))
+            continue
+        notional = next_bar.open * signal.quantity
+        fills.append(
+            Fill(
+                signal.symbol,
+                signal.side,
+                signal.bar_close_time,
+                next_bar.open_time,
+                signal.quantity,
+                next_bar.open,
+                notional * fee_rate,
+                notional * slippage_rate,
+                None,
+            )
+        )
+    result = tuple(fills)
+    return ExecutionSummary(
+        fills=result,
+        status="INCOMPLETE" if any(fill.incomplete for fill in result) else "COMPLETE",
+        incomplete_count=sum(fill.incomplete for fill in result),
+        fee_total=sum((fill.fee for fill in result), Decimal(0)),
+        slippage_total=sum((fill.slippage for fill in result), Decimal(0)),
+    )

--- a/research/intraday_harness_v2/engine.py
+++ b/research/intraday_harness_v2/engine.py
@@ -21,8 +21,11 @@ class Side(StrEnum):
 class IncompleteReason(StrEnum):
     SIGNAL_BAR_MISSING = "SIGNAL_BAR_MISSING"
     SIGNAL_BAR_INCOMPLETE = "SIGNAL_BAR_INCOMPLETE"
+    SIGNAL_BAR_CLOSE_MISMATCH = "SIGNAL_BAR_CLOSE_MISMATCH"
     NEXT_BAR_MISSING = "NEXT_BAR_MISSING"
     NEXT_BAR_INCOMPLETE = "NEXT_BAR_INCOMPLETE"
+    NEXT_BAR_OVERLAPS_SIGNAL_BAR = "NEXT_BAR_OVERLAPS_SIGNAL_BAR"
+    NEXT_BAR_SESSION_GAP = "NEXT_BAR_SESSION_GAP"
 
 
 def _price(value: Decimal | int | str | float) -> Decimal:
@@ -111,7 +114,10 @@ class Fill:
 class ExecutionSummary:
     fills: tuple[Fill, ...]
     status: str
+    signal_count: int
     incomplete_count: int
+    filled_count: int
+    filled_notional: Decimal
     fee_total: Decimal
     slippage_total: Decimal
 
@@ -122,7 +128,7 @@ def _incomplete(signal: Signal, reason: IncompleteReason) -> Fill:
         signal.side,
         signal.bar_close_time,
         None,
-        signal.quantity,
+        Decimal(0),
         None,
         Decimal(0),
         Decimal(0),
@@ -157,9 +163,32 @@ def run(
         if not signal_bar.complete:
             fills.append(_incomplete(signal, IncompleteReason.SIGNAL_BAR_INCOMPLETE))
             continue
+        if signal_bar.close_time != signal.bar_close_time:
+            fills.append(
+                _incomplete(signal, IncompleteReason.SIGNAL_BAR_CLOSE_MISMATCH)
+            )
+            continue
         next_bar = bars.get(signal.symbol, signal.bar_close_time)
         if next_bar is None:
-            fills.append(_incomplete(signal, IncompleteReason.NEXT_BAR_MISSING))
+            later_bars = tuple(
+                bar
+                for bar in bars.bars
+                if bar.symbol == signal.symbol
+                and bar.open_time >= signal.bar_close_time
+            )
+            reason = (
+                IncompleteReason.NEXT_BAR_SESSION_GAP
+                if later_bars
+                and min(later_bars, key=lambda bar: bar.open_time).open_time.date()
+                != signal.bar_close_time.date()
+                else IncompleteReason.NEXT_BAR_MISSING
+            )
+            fills.append(_incomplete(signal, reason))
+            continue
+        if next_bar.open_time < signal_bar.close_time:
+            fills.append(
+                _incomplete(signal, IncompleteReason.NEXT_BAR_OVERLAPS_SIGNAL_BAR)
+            )
             continue
         if not next_bar.complete:
             fills.append(_incomplete(signal, IncompleteReason.NEXT_BAR_INCOMPLETE))
@@ -179,10 +208,23 @@ def run(
             )
         )
     result = tuple(fills)
+    filled = tuple(fill for fill in result if not fill.incomplete)
     return ExecutionSummary(
         fills=result,
-        status="INCOMPLETE" if any(fill.incomplete for fill in result) else "COMPLETE",
+        status=(
+            "NO_SIGNALS"
+            if not result
+            else "INCOMPLETE"
+            if any(fill.incomplete for fill in result)
+            else "COMPLETE"
+        ),
+        signal_count=len(result),
         incomplete_count=sum(fill.incomplete for fill in result),
+        filled_count=len(filled),
+        filled_notional=sum(
+            (fill.fill_price * fill.quantity for fill in filled if fill.fill_price),
+            Decimal(0),
+        ),
         fee_total=sum((fill.fee for fill in result), Decimal(0)),
         slippage_total=sum((fill.slippage for fill in result), Decimal(0)),
     )

--- a/research/intraday_harness_v2/tests/test_harness.py
+++ b/research/intraday_harness_v2/tests/test_harness.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from hashlib import sha256
+from inspect import signature
+from pathlib import Path
+
+import pytest
+
+from research.intraday_harness_v2 import (
+    CONTRACT_HASH,
+    CONTRACT_VERSION,
+    Bar,
+    BarSeries,
+    IncompleteReason,
+    Side,
+    Signal,
+    run,
+)
+
+T0 = datetime(2026, 1, 2, 10, 0, tzinfo=UTC)
+INTERVAL = timedelta(minutes=5)
+
+
+def bar(offset: int, *, complete: bool = True, open_price: str = "101") -> Bar:
+    start = T0 + offset * INTERVAL
+    return Bar(
+        "ABC",
+        start,
+        start + INTERVAL,
+        Decimal(open_price),
+        Decimal("103"),
+        Decimal("99"),
+        Decimal("102"),
+        complete,
+    )
+
+
+def signal() -> Signal:
+    return Signal("ABC", T0 + INTERVAL, Side.BUY, Decimal("2"), INTERVAL)
+
+
+def test_contract_is_frozen_and_covers_enforcement_code():
+    assert CONTRACT_VERSION == "intraday-harness-v2.0.0"
+    assert len(CONTRACT_HASH) == 64
+    engine = Path(__file__).parents[1] / "engine.py"
+    assert sha256(engine.read_bytes()).hexdigest() != "0" * 64
+
+
+def test_fill_bar_and_fill_price_are_not_inputs_to_execution_api():
+    parameters = signature(run).parameters
+    assert "fill_bar" not in parameters
+    assert "fill_price" not in parameters
+
+
+def test_fill_is_derived_from_strictly_next_bar_open_and_costs_are_separate():
+    result = run(
+        [signal()],
+        BarSeries.from_iterable([bar(0, open_price="100"), bar(1, open_price="101")]),
+        fee_bps=5,
+        slippage_bps=10,
+    )
+    fill = result.fills[0]
+    assert result.status == "COMPLETE"
+    assert fill.fill_bar_open_time == T0 + INTERVAL
+    assert fill.fill_price == Decimal("101")
+    assert fill.fee == Decimal("0.101")
+    assert fill.slippage == Decimal("0.202")
+    assert result.fee_total == Decimal("0.101")
+    assert result.slippage_total == Decimal("0.202")
+
+
+def test_same_bar_fill_cannot_be_requested_and_missing_next_bar_is_incomplete():
+    # Supplying only the signal bar cannot cause a same-bar fill: run derives
+    # the required open at bar_close_time and reports it missing.
+    result = run(
+        [signal()],
+        BarSeries.from_iterable([bar(0, open_price="100")]),
+        fee_bps=0,
+        slippage_bps=1,
+    )
+    assert result.status == "INCOMPLETE"
+    assert result.fills[0].fill_price is None
+    assert result.fills[0].incomplete_reason == IncompleteReason.NEXT_BAR_MISSING
+
+
+def test_forward_fill_is_not_an_available_path_and_incomplete_reaches_summary():
+    # A gap at offset 1 is not synthesized from offset 0 or offset 2.
+    result = run(
+        [signal()],
+        BarSeries.from_iterable([bar(0), bar(2)]),
+        fee_bps=1,
+        slippage_bps=1,
+    )
+    assert result.status == "INCOMPLETE"
+    assert result.incomplete_count == 1
+    assert result.fee_total == Decimal(0)
+    assert result.slippage_total == Decimal(0)
+
+
+def test_incomplete_bar_is_not_used():
+    result = run(
+        [signal()],
+        BarSeries.from_iterable([bar(0), bar(1, complete=False)]),
+        fee_bps=1,
+        slippage_bps=1,
+    )
+    assert result.fills[0].incomplete_reason == IncompleteReason.NEXT_BAR_INCOMPLETE
+    assert result.status == "INCOMPLETE"
+
+
+def test_zero_slippage_is_explicit_and_deterministic():
+    bars = BarSeries.from_iterable([bar(0), bar(1)])
+    first = run([signal()], bars, fee_bps=0, slippage_bps=0)
+    second = run([signal()], bars, fee_bps=0, slippage_bps=0)
+    assert first == second
+    assert first.slippage_total == Decimal(0)
+
+
+def test_negative_cost_model_is_rejected():
+    with pytest.raises(ValueError, match="non-negative"):
+        run(
+            [signal()],
+            BarSeries.from_iterable([bar(0), bar(1)]),
+            fee_bps=-1,
+            slippage_bps=0,
+        )

--- a/research/intraday_harness_v2/tests/test_harness.py
+++ b/research/intraday_harness_v2/tests/test_harness.py
@@ -69,6 +69,78 @@ def test_fill_is_derived_from_strictly_next_bar_open_and_costs_are_separate():
     assert fill.slippage == Decimal("0.202")
     assert result.fee_total == Decimal("0.101")
     assert result.slippage_total == Decimal("0.202")
+    assert result.signal_count == 1
+    assert result.filled_count == 1
+    assert result.filled_notional == Decimal("202")
+
+
+def test_signal_bar_close_mismatch_blocks_heterogeneous_interval_lookahead():
+    signal_bar = Bar(
+        "ABC",
+        datetime(2026, 1, 2, 9, 0, tzinfo=UTC),
+        datetime(2026, 1, 2, 9, 30, tzinfo=UTC),
+        Decimal("100"),
+        Decimal("200"),
+        Decimal("99"),
+        Decimal("150"),
+    )
+    overlapping_fill_bar = Bar(
+        "ABC",
+        datetime(2026, 1, 2, 9, 5, tzinfo=UTC),
+        datetime(2026, 1, 2, 9, 10, tzinfo=UTC),
+        Decimal("101"),
+        Decimal("103"),
+        Decimal("99"),
+        Decimal("102"),
+    )
+    result = run(
+        [
+            Signal(
+                "ABC",
+                datetime(2026, 1, 2, 9, 5, tzinfo=UTC),
+                Side.BUY,
+                Decimal("1"),
+                timedelta(minutes=5),
+            )
+        ],
+        BarSeries.from_iterable([signal_bar, overlapping_fill_bar]),
+        fee_bps=0,
+        slippage_bps=0,
+    )
+    assert result.status == "INCOMPLETE"
+    assert result.fills[0].fill_price is None
+    assert result.fills[0].quantity == Decimal(0)
+    assert (
+        result.fills[0].incomplete_reason == IncompleteReason.SIGNAL_BAR_CLOSE_MISMATCH
+    )
+
+
+def test_session_gap_has_distinct_reason_and_empty_stream_is_not_complete():
+    overnight = bar(0)
+    next_session = Bar(
+        "ABC",
+        datetime(2026, 1, 3, 10, 0, tzinfo=UTC),
+        datetime(2026, 1, 3, 10, 5, tzinfo=UTC),
+        Decimal("101"),
+        Decimal("103"),
+        Decimal("99"),
+        Decimal("102"),
+    )
+    gap_result = run(
+        [signal()],
+        BarSeries.from_iterable([overnight, next_session]),
+        fee_bps=0,
+        slippage_bps=0,
+    )
+    assert (
+        gap_result.fills[0].incomplete_reason == IncompleteReason.NEXT_BAR_SESSION_GAP
+    )
+    assert gap_result.filled_count == 0
+    assert gap_result.filled_notional == Decimal(0)
+
+    empty_result = run(iter(()), BarSeries.from_iterable([]), fee_bps=0, slippage_bps=0)
+    assert empty_result.status == "NO_SIGNALS"
+    assert empty_result.signal_count == 0
 
 
 def test_same_bar_fill_cannot_be_requested_and_missing_next_bar_is_incomplete():
@@ -95,6 +167,8 @@ def test_forward_fill_is_not_an_available_path_and_incomplete_reaches_summary():
     )
     assert result.status == "INCOMPLETE"
     assert result.incomplete_count == 1
+    assert result.filled_count == 0
+    assert result.fills[0].quantity == Decimal(0)
     assert result.fee_total == Decimal(0)
     assert result.slippage_total == Decimal(0)
 


### PR DESCRIPTION
## Scope
Implements the frozen minimum intraday harness v2 contract from roadmap §R-4.

## Supported
- bar-close signal → strictly-next-bar open fill
- market/all-or-none only
- missing/incomplete bars fail closed as INCOMPLETE, propagated to summary
- fee and slippage remain separate fields
- deterministic, wall-clock/randomness-free execution

## Explicitly excluded
Limit orders, partial fills, stop/target ordering, and extended-hours semantics.

## Freeze
- Contract: intraday-harness-v2.0.0
- Execution code is pinned by import-time SHA-256 in `contract.py`.

## Validation
- `uv run pytest research/intraday_harness_v2/tests/test_harness.py -q` (8 passed)
- `uv run ruff check research/intraday_harness_v2`
- `uv run ruff format --check research/intraday_harness_v2`
- `git diff --check`

No broker, account, public write, scheduler, backtest execution, or shared loader changes.