### PR TITLE
docs(research): clarify signed predicate operational duties

### DIFF
--- a/docs/runbooks/kr-research-candles-promotion.md
+++ b/docs/runbooks/kr-research-candles-promotion.md
@@ -107,3 +107,24 @@ re-run with a wider window; re-collect the missing range from the providers
 against the production database by hand.
 
 Requires the `timescaledb` extension (>= 2.8.1; production is on 2.26.3).
+
+## 7. 1-minute strategy promotion gate
+
+`KR_1M_SOURCE_SENSITIVITY_V1` is required before promoting any strategy that
+consumes this corpus at 1-minute resolution. It is an operator evidence gate,
+not a scheduler and not an automatic strategy deployment path.
+
+For overlap symbols with both eligible sources, run the identical frozen
+strategy configuration once per source and retain the comparison artifact for:
+
+- signal timestamps and values;
+- resulting trade sequence; and
+- PnL.
+
+Any source-sensitive difference blocks promotion on the mixed corpus. Re-run
+that strategy against one declared canonical source, retain the reason and
+artifacts, and only then continue the normal promotion review. The review must
+also cite the raw 1-minute audit result and, when an adjacent-window exception
+is present, its predicate version/hash, independent-holdout evidence, and exact
+5m/15m/30m/1h bucket evidence. A documented exception never enables two-way
+operation by itself; the required operator approval remains separate.

--- a/docs/runbooks/kr-research-candles-promotion.md
+++ b/docs/runbooks/kr-research-candles-promotion.md
@@ -128,3 +128,11 @@ also cite the raw 1-minute audit result and, when an adjacent-window exception
 is present, its predicate version/hash, independent-holdout evidence, and exact
 5m/15m/30m/1h bucket evidence. A documented exception never enables two-way
 operation by itself; the required operator approval remains separate.
+
+`ADJACENT_WINDOW_EQUIVALENT_V1` audit records must cite both its declarative
+specification SHA-256 and module-source SHA-256. The import checks detect
+accidental edits to the declared contract, execution code, and frozen
+operational constants. This is not a claim that Python code cannot be changed:
+changing a digest alongside source, `object.__setattr__`, and post-import
+monkeypatching remain residual bypasses that controlled review and deployment
+must prevent.

--- a/docs/runbooks/kr-research-candles-promotion.md
+++ b/docs/runbooks/kr-research-candles-promotion.md
@@ -133,6 +133,21 @@ operation by itself; the required operator approval remains separate.
 specification SHA-256 and module-source SHA-256. The import checks detect
 accidental edits to the declared contract, execution code, and frozen
 operational constants. This is not a claim that Python code cannot be changed:
-changing a digest alongside source, `object.__setattr__`, and post-import
-monkeypatching remain residual bypasses that controlled review and deployment
-must prevent.
+changing a digest alongside source, removing the
+`_assert_module_source_is_frozen()` check call (검사 호출 제거),
+`object.__setattr__`, and post-import monkeypatching remain residual bypasses
+that controlled review and deployment must prevent.
+
+## 8. Adjacent-window predicate evidence citation duties
+
+`ADJACENT_WINDOW_EQUIVALENT_V1` is a pure local classifier. The following
+facts are operational evidence duties, not guarantees that the module can
+establish by itself:
+
+- Record the holdout and design session declarations in the Phase B artifact;
+  the caller must directly compare those sets and report the result.
+- Cite `SHARD_GATE = PASS_WITH_DOCUMENTED_EXCEPTION` only together with the
+  raw comparison artifact and its SHA-256.
+- Attach an independently reaggregated higher-timeframe table for 5m, 15m,
+  30m, and 1h. For each timeframe, the table must show bucket count, compared
+  cell count, and mismatch count.

--- a/research/kr_backfill/adjacent_window_predicate.py
+++ b/research/kr_backfill/adjacent_window_predicate.py
@@ -11,9 +11,9 @@ reaggregation remain separate operator work.
 
 The frozen hashes detect accidental edits to the declared contract and this
 module's source at import time.  They do not make Python code unchangeable:
-an actor who changes a digest with the source, uses ``object.__setattr__``, or
-monkeypatches after import can still bypass them.  Review and controlled
-deployment remain required.
+an actor who changes a digest with the source, removes the source-freeze
+assertion call, uses ``object.__setattr__``, or monkeypatches after import can
+still bypass them.  Review and controlled deployment remain required.
 """
 
 from __future__ import annotations
@@ -177,7 +177,7 @@ if _spec_hash() != PREDICATE_SPEC_SHA256:
 # own literal with a stable marker.  It therefore covers implementation code
 # and operational constants as well as the declarative specification above.
 MODULE_SOURCE_SHA256 = (
-    "584f08d4025467ce5ae0f8fb6edc9800e0df5abaf74795dd8d3929612cc65ba5"
+    "3ebedb9e7e0bdc1cab18e95c8026cbd9440fe74ca3b941894d0e30131d3e54d0"
 )
 
 
@@ -192,6 +192,17 @@ def _module_source_hash() -> str:
     return hashlib.sha256(
         source.replace(literal, b"<MODULE_SOURCE_SHA256>", 1)
     ).hexdigest()
+
+
+def _assert_module_source_is_frozen() -> None:
+    if _module_source_hash() != MODULE_SOURCE_SHA256:
+        raise RuntimeError(
+            "ADJACENT_WINDOW_EQUIVALENT_V1 module source changed; issue a new "
+            "version and frozen SHA-256 before use"
+        )
+
+
+_assert_module_source_is_frozen()
 
 
 @dataclass(frozen=True)
@@ -934,14 +945,3 @@ def _isolation_failures(
 def _is_krx_regular_minute(timestamp: datetime) -> bool:
     minute = timestamp.timetz().replace(tzinfo=None)
     return REGULAR_SESSION_START <= minute <= REGULAR_SESSION_END
-
-
-def _assert_module_source_is_frozen() -> None:
-    if _module_source_hash() != MODULE_SOURCE_SHA256:
-        raise RuntimeError(
-            "ADJACENT_WINDOW_EQUIVALENT_V1 module source changed; issue a new "
-            "version and frozen SHA-256 before use"
-        )
-
-
-_assert_module_source_is_frozen()

--- a/research/kr_backfill/adjacent_window_predicate.py
+++ b/research/kr_backfill/adjacent_window_predicate.py
@@ -8,6 +8,12 @@ two-minute structural contract is satisfied.  It never changes the raw result:
 This is a pure, local module.  It performs no fetches, database writes, or
 broker/account operations.  Phase B collection and higher-timeframe
 reaggregation remain separate operator work.
+
+The frozen hashes detect accidental edits to the declared contract and this
+module's source at import time.  They do not make Python code unchangeable:
+an actor who changes a digest with the source, uses ``object.__setattr__``, or
+monkeypatches after import can still bypass them.  Review and controlled
+deployment remain required.
 """
 
 from __future__ import annotations
@@ -16,12 +22,13 @@ import hashlib
 import json
 import math
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 PREDICATE_NAME = "ADJACENT_WINDOW_EQUIVALENT_V1"
-PREDICATE_VERSION = "1.0.0"
+PREDICATE_VERSION = "1.0.1"
 
 COMPARED_FIELDS: tuple[str, ...] = ("open", "high", "low", "close", "volume")
 NORMALISATION_RULE = "int(round(x)) for finite numeric OHLCV inputs"
@@ -39,6 +46,12 @@ FROZEN_BAR_LABEL_CONVENTION = "KRX_1M_BAR_START_KST_V1"
 FROZEN_OFFSET_MINUTES = 0
 
 REQUIRED_HIGHER_TIMEFRAMES: tuple[str, ...] = ("5m", "15m", "30m", "1h")
+
+# A Phase-B gate must cover more than one hand-picked result.  Coverage is
+# calculated from the immutable classification results, never self-attested.
+MIN_HOLDOUT_SYMBOLS = 2
+MIN_HOLDOUT_SESSIONS = 2
+MIN_HOLDOUT_COMPARED_CELLS = 1_000
 
 
 @dataclass(frozen=True)
@@ -122,6 +135,18 @@ def predicate_spec_payload() -> dict[str, Any]:
             "offset_minutes": FROZEN_OFFSET_MINUTES,
             "timezone": KST_TIMEZONE_NAME,
         },
+        "regular_session": {
+            "market": "KRX",
+            "segment": KRX_REGULAR_SEGMENT,
+            "start": REGULAR_SESSION_START.isoformat(),
+            "end": REGULAR_SESSION_END.isoformat(),
+        },
+        "required_higher_timeframes": list(REQUIRED_HIGHER_TIMEFRAMES),
+        "holdout_coverage_minimums": {
+            "symbols": MIN_HOLDOUT_SYMBOLS,
+            "sessions": MIN_HOLDOUT_SESSIONS,
+            "compared_cells": MIN_HOLDOUT_COMPARED_CELLS,
+        },
         "invariants": [invariant.as_record() for invariant in INVARIANT_SPEC],
     }
 
@@ -136,17 +161,37 @@ def _spec_hash() -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-# The literal is intentionally checked at import time. Changing even one byte of
-# the canonical contract without an explicit new version/hash makes the gate
-# unavailable instead of silently reinterpreting prior audit records.
+# The literals are intentionally checked at import time. Changing either the
+# canonical contract or module source without an explicit new version/hash
+# makes the gate unavailable instead of silently reinterpreting prior records.
 PREDICATE_SPEC_SHA256 = (
-    "207d3f6f1a87413b8788446fde59e6fcad866478674fb99411c804df41de1e99"
+    "abbd692cd91c0efc07ce21409ad043a199bad97d954d1a97f55852e29c929618"
 )
 if _spec_hash() != PREDICATE_SPEC_SHA256:
     raise RuntimeError(
         "ADJACENT_WINDOW_EQUIVALENT_V1 specification changed; issue a new "
         "version and frozen SHA-256 before use"
     )
+
+# This digest is calculated over the complete module source after replacing its
+# own literal with a stable marker.  It therefore covers implementation code
+# and operational constants as well as the declarative specification above.
+MODULE_SOURCE_SHA256 = (
+    "584f08d4025467ce5ae0f8fb6edc9800e0df5abaf74795dd8d3929612cc65ba5"
+)
+
+
+def _module_source_hash() -> str:
+    source = Path(__file__).read_bytes()
+    literal = MODULE_SOURCE_SHA256.encode("ascii")
+    if source.count(literal) != 1:
+        raise RuntimeError(
+            "ADJACENT_WINDOW_EQUIVALENT_V1 module-source digest literal is "
+            "missing or duplicated"
+        )
+    return hashlib.sha256(
+        source.replace(literal, b"<MODULE_SOURCE_SHA256>", 1)
+    ).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -212,18 +257,18 @@ class PairVerdict:
         }
 
 
-@dataclass
+@dataclass(frozen=True)
 class ClassificationResult:
-    """Raw and structural verdicts kept separate for auditability."""
+    """Raw and structural verdicts kept separate and immutable for auditability."""
 
     symbol: str
     session: date
     common_minutes: int = 0
-    raw_mismatches: list[MinuteMismatch] = field(default_factory=list)
-    one_sided_minutes: list[datetime] = field(default_factory=list)
-    accepted_pairs: list[PairVerdict] = field(default_factory=list)
-    rejected_pairs: list[PairVerdict] = field(default_factory=list)
-    invariant_failures: list[InvariantFailure] = field(default_factory=list)
+    raw_mismatches: tuple[MinuteMismatch, ...] = ()
+    one_sided_minutes: tuple[datetime, ...] = ()
+    accepted_pairs: tuple[PairVerdict, ...] = ()
+    rejected_pairs: tuple[PairVerdict, ...] = ()
+    invariant_failures: tuple[InvariantFailure, ...] = ()
     noncompliant_mismatch_cells: int = 0
 
     @property
@@ -260,6 +305,7 @@ class ClassificationResult:
             "predicate": PREDICATE_NAME,
             "predicate_version": PREDICATE_VERSION,
             "predicate_spec_sha256": PREDICATE_SPEC_SHA256,
+            "module_source_sha256": MODULE_SOURCE_SHA256,
             "cause_name": PREDICATE_NAME,
             "symbol": self.symbol,
             "session": self.session.isoformat(),
@@ -309,6 +355,9 @@ class ShardGateDecision:
     status: str
     reasons: tuple[str, ...]
     noncompliant_mismatch_cells: int
+    covered_symbols: int
+    covered_sessions: int
+    compared_cells: int
 
     @property
     def two_way_enabled(self) -> bool:
@@ -319,14 +368,50 @@ class ShardGateDecision:
             "predicate": PREDICATE_NAME,
             "predicate_version": PREDICATE_VERSION,
             "predicate_spec_sha256": PREDICATE_SPEC_SHA256,
+            "module_source_sha256": MODULE_SOURCE_SHA256,
             "SHARD_GATE": self.status,
             "reasons": list(self.reasons),
             "noncompliant_mismatch_cells": self.noncompliant_mismatch_cells,
+            "holdout_coverage": {
+                "symbols": self.covered_symbols,
+                "sessions": self.covered_sessions,
+                "compared_cells": self.compared_cells,
+                "minimum_symbols": MIN_HOLDOUT_SYMBOLS,
+                "minimum_sessions": MIN_HOLDOUT_SESSIONS,
+                "minimum_compared_cells": MIN_HOLDOUT_COMPARED_CELLS,
+            },
             "TWO_WAY_ENABLED": "NO",
         }
 
 
 NormalisedBars = dict[datetime, dict[str, int]]
+
+
+def _classification_result(
+    *,
+    symbol: str,
+    session: date,
+    common_minutes: int,
+    raw_mismatches: Sequence[MinuteMismatch],
+    one_sided_minutes: Sequence[datetime],
+    accepted_pairs: Sequence[PairVerdict],
+    rejected_pairs: Sequence[PairVerdict],
+    invariant_failures: Sequence[InvariantFailure],
+    noncompliant_mismatch_cells: int,
+) -> ClassificationResult:
+    """Freeze local classification state before handing it to the gate."""
+
+    return ClassificationResult(
+        symbol=symbol,
+        session=session,
+        common_minutes=common_minutes,
+        raw_mismatches=tuple(raw_mismatches),
+        one_sided_minutes=tuple(one_sided_minutes),
+        accepted_pairs=tuple(accepted_pairs),
+        rejected_pairs=tuple(rejected_pairs),
+        invariant_failures=tuple(invariant_failures),
+        noncompliant_mismatch_cells=noncompliant_mismatch_cells,
+    )
 
 
 def classify(
@@ -339,30 +424,31 @@ def classify(
 ) -> ClassificationResult:
     """Classify one symbol and completed KRX session without changing raw facts."""
 
-    result = ClassificationResult(symbol=symbol, session=session)
-    result.invariant_failures.extend(_validate_context(context))
+    invariant_failures = _validate_context(context)
+    raw_mismatches: list[MinuteMismatch] = []
+    accepted_pairs: list[PairVerdict] = []
+    rejected_pairs: list[PairVerdict] = []
 
     normalised_a, failures_a = _normalise_source_bars(bars_a, session, "A")
     normalised_b, failures_b = _normalise_source_bars(bars_b, session, "B")
-    result.invariant_failures.extend(failures_a)
-    result.invariant_failures.extend(failures_b)
+    invariant_failures.extend(failures_a)
+    invariant_failures.extend(failures_b)
 
     only_a = sorted(set(normalised_a) - set(normalised_b))
     only_b = sorted(set(normalised_b) - set(normalised_a))
-    result.one_sided_minutes.extend((*only_a, *only_b))
-    if result.one_sided_minutes:
-        result.invariant_failures.append(
+    one_sided_minutes = [*only_a, *only_b]
+    if one_sided_minutes:
+        invariant_failures.append(
             InvariantFailure(
                 "I1",
                 "one-sided minute(s) cannot be structurally classified: "
-                + ", ".join(minute.isoformat() for minute in result.one_sided_minutes),
+                + ", ".join(minute.isoformat() for minute in one_sided_minutes),
             )
         )
 
     common_minutes = sorted(set(normalised_a) & set(normalised_b))
-    result.common_minutes = len(common_minutes)
     if not common_minutes:
-        result.invariant_failures.append(
+        invariant_failures.append(
             InvariantFailure("I1", "no comparable minute exists in both sources")
         )
 
@@ -371,30 +457,62 @@ def classify(
         fields = _mismatching_fields(normalised_a[minute], normalised_b[minute])
         if fields:
             mismatch_fields_by_minute[minute] = fields
-            result.raw_mismatches.append(MinuteMismatch(minute, fields))
+            raw_mismatches.append(MinuteMismatch(minute, fields))
 
     # A bad semantic/input contract invalidates every raw mismatch; accepting a
     # pair after any such failure would make an unavailable fact look verified.
-    if result.invariant_failures:
-        result.noncompliant_mismatch_cells = result.raw_mismatch_cells
-        return result
+    if invariant_failures:
+        return _classification_result(
+            symbol=symbol,
+            session=session,
+            common_minutes=len(common_minutes),
+            raw_mismatches=raw_mismatches,
+            one_sided_minutes=one_sided_minutes,
+            accepted_pairs=accepted_pairs,
+            rejected_pairs=rejected_pairs,
+            invariant_failures=invariant_failures,
+            noncompliant_mismatch_cells=sum(
+                len(mismatch.fields) for mismatch in raw_mismatches
+            ),
+        )
 
     mismatch_minutes = tuple(sorted(mismatch_fields_by_minute))
     if not mismatch_minutes:
-        return result
+        return _classification_result(
+            symbol=symbol,
+            session=session,
+            common_minutes=len(common_minutes),
+            raw_mismatches=raw_mismatches,
+            one_sided_minutes=one_sided_minutes,
+            accepted_pairs=accepted_pairs,
+            rejected_pairs=rejected_pairs,
+            invariant_failures=invariant_failures,
+            noncompliant_mismatch_cells=0,
+        )
 
     pairs, partition_failure = _partition_mismatch_minutes(mismatch_minutes)
     if partition_failure is not None:
-        result.invariant_failures.append(partition_failure)
-        result.invariant_failures.append(
+        invariant_failures.append(partition_failure)
+        invariant_failures.append(
             InvariantFailure(
                 "I8",
                 "because no complete accepted-pair partition exists, every raw "
                 "OHLCV mismatch remains outside the accepted exception set",
             )
         )
-        result.noncompliant_mismatch_cells = result.raw_mismatch_cells
-        return result
+        return _classification_result(
+            symbol=symbol,
+            session=session,
+            common_minutes=len(common_minutes),
+            raw_mismatches=raw_mismatches,
+            one_sided_minutes=one_sided_minutes,
+            accepted_pairs=accepted_pairs,
+            rejected_pairs=rejected_pairs,
+            invariant_failures=invariant_failures,
+            noncompliant_mismatch_cells=sum(
+                len(mismatch.fields) for mismatch in raw_mismatches
+            ),
+        )
 
     accepted_minutes: set[datetime] = set()
     for t, t_next in pairs:
@@ -406,30 +524,40 @@ def classify(
             t_next,
         )
         if pair.equivalent:
-            result.accepted_pairs.append(pair)
+            accepted_pairs.append(pair)
             accepted_minutes.update((t, t_next))
         else:
-            result.rejected_pairs.append(pair)
+            rejected_pairs.append(pair)
 
     noncompliant_minutes = set(mismatch_fields_by_minute) - accepted_minutes
-    result.noncompliant_mismatch_cells = sum(
+    noncompliant_mismatch_cells = sum(
         len(mismatch_fields_by_minute[minute]) for minute in noncompliant_minutes
     )
     if noncompliant_minutes:
-        result.invariant_failures.append(
+        invariant_failures.append(
             InvariantFailure(
                 "I8",
                 "OHLCV mismatch remains outside the accepted exception pair set",
             )
         )
-        result.invariant_failures.append(
+        invariant_failures.append(
             InvariantFailure(
                 "I9",
                 "rejected or unpaired raw mismatch minute(s) remain ordinary "
                 "mismatches",
             )
         )
-    return result
+    return _classification_result(
+        symbol=symbol,
+        session=session,
+        common_minutes=len(common_minutes),
+        raw_mismatches=raw_mismatches,
+        one_sided_minutes=one_sided_minutes,
+        accepted_pairs=accepted_pairs,
+        rejected_pairs=rejected_pairs,
+        invariant_failures=invariant_failures,
+        noncompliant_mismatch_cells=noncompliant_mismatch_cells,
+    )
 
 
 def evaluate_shard_gate(
@@ -441,7 +569,8 @@ def evaluate_shard_gate(
 
     Phase A callers should pass their pending evidence.  The result is then
     necessarily ``FAIL``.  A future Phase B caller must supply independent,
-    completed holdout sessions and all actual higher-timeframe bucket results.
+    completed holdout results, enough actual result coverage, and all actual
+    higher-timeframe bucket results.
     """
 
     reasons: list[str] = []
@@ -449,6 +578,17 @@ def evaluate_shard_gate(
         reasons.append("no_classification_results")
 
     noncompliant = sum(result.noncompliant_mismatch_cells for result in results)
+    result_sessions = {result.session for result in results}
+    result_symbols = {result.symbol for result in results}
+    result_keys = [(result.symbol, result.session) for result in results]
+    unique_results: dict[tuple[str, date], ClassificationResult] = {}
+    for result in results:
+        unique_results.setdefault((result.symbol, result.session), result)
+    compared_cells = sum(
+        result.common_minutes * len(COMPARED_FIELDS)
+        for result in unique_results.values()
+    )
+
     for result in results:
         if not result.adjacent_window_equivalent:
             reasons.append(
@@ -463,9 +603,41 @@ def evaluate_shard_gate(
         reasons.append("holdout_sessions_not_declared")
     if design_sessions & holdout_sessions:
         reasons.append("holdout_overlaps_design_sessions")
-    if not phase_b.holdout_revalidation_completed:
+    for result in results:
+        if result.session not in holdout_sessions:
+            reasons.append(
+                "result_session_not_in_holdout_sessions:"
+                f"{result.symbol}:{result.session.isoformat()}"
+            )
+        if result.session in design_sessions:
+            reasons.append(
+                "result_session_is_design_session:"
+                f"{result.symbol}:{result.session.isoformat()}"
+            )
+    for missing_session in sorted(holdout_sessions - result_sessions):
+        reasons.append(
+            "declared_holdout_session_has_no_result:" + missing_session.isoformat()
+        )
+    if len(set(result_keys)) != len(result_keys):
+        reasons.append("duplicate_symbol_session_classification_result")
+    if len(result_symbols) < MIN_HOLDOUT_SYMBOLS:
+        reasons.append(
+            "holdout_symbol_coverage_below_minimum:"
+            f"{len(result_symbols)}<{MIN_HOLDOUT_SYMBOLS}"
+        )
+    if len(result_sessions) < MIN_HOLDOUT_SESSIONS:
+        reasons.append(
+            "holdout_session_coverage_below_minimum:"
+            f"{len(result_sessions)}<{MIN_HOLDOUT_SESSIONS}"
+        )
+    if compared_cells < MIN_HOLDOUT_COMPARED_CELLS:
+        reasons.append(
+            "holdout_compared_cell_coverage_below_minimum:"
+            f"{compared_cells}<{MIN_HOLDOUT_COMPARED_CELLS}"
+        )
+    if phase_b.holdout_revalidation_completed is not True:
         reasons.append("holdout_revalidation_not_completed")
-    if not phase_b.holdout_sessions_completed:
+    if phase_b.holdout_sessions_completed is not True:
         reasons.append("holdout_includes_uncompleted_session")
     if noncompliant:
         reasons.append("noncompliant_mismatch_cells_present")
@@ -479,6 +651,9 @@ def evaluate_shard_gate(
         status=status,
         reasons=tuple(reasons),
         noncompliant_mismatch_cells=noncompliant,
+        covered_symbols=len(result_symbols),
+        covered_sessions=len(result_sessions),
+        compared_cells=compared_cells,
     )
 
 
@@ -759,3 +934,14 @@ def _isolation_failures(
 def _is_krx_regular_minute(timestamp: datetime) -> bool:
     minute = timestamp.timetz().replace(tzinfo=None)
     return REGULAR_SESSION_START <= minute <= REGULAR_SESSION_END
+
+
+def _assert_module_source_is_frozen() -> None:
+    if _module_source_hash() != MODULE_SOURCE_SHA256:
+        raise RuntimeError(
+            "ADJACENT_WINDOW_EQUIVALENT_V1 module source changed; issue a new "
+            "version and frozen SHA-256 before use"
+        )
+
+
+_assert_module_source_is_frozen()

--- a/research/kr_backfill/adjacent_window_predicate.py
+++ b/research/kr_backfill/adjacent_window_predicate.py
@@ -1,0 +1,761 @@
+"""Frozen structural-equivalence predicate for KRX one-minute source checks.
+
+``ADJACENT_WINDOW_EQUIVALENT_V1`` is deliberately narrower than a numerical
+tolerance.  It may classify a raw one-minute mismatch only when the complete
+two-minute structural contract is satisfied.  It never changes the raw result:
+``RAW_1M_EXACT`` remains ``FAIL`` whenever a raw OHLCV cell differs.
+
+This is a pure, local module.  It performs no fetches, database writes, or
+broker/account operations.  Phase B collection and higher-timeframe
+reaggregation remain separate operator work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any
+
+PREDICATE_NAME = "ADJACENT_WINDOW_EQUIVALENT_V1"
+PREDICATE_VERSION = "1.0.0"
+
+COMPARED_FIELDS: tuple[str, ...] = ("open", "high", "low", "close", "volume")
+NORMALISATION_RULE = "int(round(x)) for finite numeric OHLCV inputs"
+
+KST = timezone(timedelta(hours=9), name="KST")
+KST_UTC_OFFSET = timedelta(hours=9)
+KST_TIMEZONE_NAME = "Asia/Seoul"
+KRX_REGULAR_SEGMENT = "KRX_REGULAR"
+REGULAR_SESSION_START = time(9, 0)
+REGULAR_SESSION_END = time(15, 30)
+
+# The predicate does not discover an offset.  V1's already-frozen label
+# convention is KST bar-start labels at the same timestamp on both sources.
+FROZEN_BAR_LABEL_CONVENTION = "KRX_1M_BAR_START_KST_V1"
+FROZEN_OFFSET_MINUTES = 0
+
+REQUIRED_HIGHER_TIMEFRAMES: tuple[str, ...] = ("5m", "15m", "30m", "1h")
+
+
+@dataclass(frozen=True)
+class Invariant:
+    """One immutable clause from the governing predicate contract."""
+
+    identifier: str
+    name: str
+    rule: str
+
+    def as_record(self) -> dict[str, str]:
+        return {"id": self.identifier, "name": self.name, "rule": self.rule}
+
+
+INVARIANT_SPEC: tuple[Invariant, ...] = (
+    Invariant(
+        "I1",
+        "same_semantics",
+        "KRX regular session; identical adjustment and timezone; completed "
+        "session; latest-session exclusion applied first; and both sources "
+        "contain the candidate minutes.",
+    ),
+    Invariant(
+        "I2",
+        "fixed_timestamp_convention",
+        "Use only the frozen bar-label convention and offset; do not search "
+        "for an offset after comparison.",
+    ),
+    Invariant(
+        "I3",
+        "isolated_adjacent_pairs",
+        "The mismatch-minute set must partition exactly into disjoint adjacent "
+        "two-minute pairs. Neighbours t-1 and t+2 must not mismatch; chains, "
+        "one-sided minutes, and duplicate pairs fail.",
+    ),
+    Invariant(
+        "I4",
+        "outer_prices_exact",
+        "open_A(t) equals open_B(t), and close_A(t+1) equals close_B(t+1).",
+    ),
+    Invariant(
+        "I5",
+        "two_minute_ohlc_exact",
+        "The two-minute maximum high and minimum low are exactly equal.",
+    ),
+    Invariant(
+        "I6",
+        "two_minute_volume_exact",
+        "The two-minute volume sum is exactly equal.",
+    ),
+    Invariant(
+        "I7",
+        "movement_cancels",
+        "Per-minute volume deltas are non-zero and exact opposites.",
+    ),
+    Invariant(
+        "I8",
+        "fields_restricted",
+        "Every OHLCV cell outside accepted pairs remains exact; synthetic or "
+        "cumulative value is excluded from this predicate.",
+    ),
+    Invariant(
+        "I9",
+        "fail_closed",
+        "Any failure remains an ordinary mismatch and makes the shard gate "
+        "FAIL; neither mismatch size nor match-rate can rescue it.",
+    ),
+)
+
+
+def predicate_spec_payload() -> dict[str, Any]:
+    """Return the canonical payload whose hash identifies this frozen contract."""
+
+    return {
+        "name": PREDICATE_NAME,
+        "version": PREDICATE_VERSION,
+        "compared_fields": list(COMPARED_FIELDS),
+        "normalisation_rule": NORMALISATION_RULE,
+        "timestamp_convention": {
+            "bar_label": FROZEN_BAR_LABEL_CONVENTION,
+            "offset_minutes": FROZEN_OFFSET_MINUTES,
+            "timezone": KST_TIMEZONE_NAME,
+        },
+        "invariants": [invariant.as_record() for invariant in INVARIANT_SPEC],
+    }
+
+
+def _spec_hash() -> str:
+    payload = json.dumps(
+        predicate_spec_payload(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+# The literal is intentionally checked at import time. Changing even one byte of
+# the canonical contract without an explicit new version/hash makes the gate
+# unavailable instead of silently reinterpreting prior audit records.
+PREDICATE_SPEC_SHA256 = (
+    "207d3f6f1a87413b8788446fde59e6fcad866478674fb99411c804df41de1e99"
+)
+if _spec_hash() != PREDICATE_SPEC_SHA256:
+    raise RuntimeError(
+        "ADJACENT_WINDOW_EQUIVALENT_V1 specification changed; issue a new "
+        "version and frozen SHA-256 before use"
+    )
+
+
+@dataclass(frozen=True)
+class ComparisonContext:
+    """Preconditions that must be explicit before structural classification.
+
+    The context has no defaults by design.  A caller cannot quietly omit the
+    completed-session, KIS latest-session, adjustment, timezone, or timestamp
+    convention checks and still receive an equivalence result.
+    """
+
+    source_a: str
+    source_b: str
+    market: str
+    session_segment: str
+    adjustment_a: str
+    adjustment_b: str
+    timezone_a: str
+    timezone_b: str
+    completed_session: bool
+    latest_session_rule_applied_first: bool
+    bar_label_convention: str
+    offset_minutes: int
+
+
+@dataclass(frozen=True)
+class InvariantFailure:
+    """An auditable failure instead of an exception that could hide a mismatch."""
+
+    invariant: str
+    detail: str
+
+    def as_record(self) -> dict[str, str]:
+        return {"invariant": self.invariant, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class MinuteMismatch:
+    """All raw OHLCV fields that differ at one comparable minute."""
+
+    minute: datetime
+    fields: tuple[str, ...]
+
+    def as_record(self) -> dict[str, Any]:
+        return {"minute_kst": self.minute.isoformat(), "fields": list(self.fields)}
+
+
+@dataclass(frozen=True)
+class PairVerdict:
+    """The structural outcome for one disjoint two-minute candidate pair."""
+
+    t: datetime
+    t_next: datetime
+    equivalent: bool
+    failures: tuple[InvariantFailure, ...] = ()
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "t_kst": self.t.isoformat(),
+            "t_next_kst": self.t_next.isoformat(),
+            "equivalent": self.equivalent,
+            "failures": [failure.as_record() for failure in self.failures],
+        }
+
+
+@dataclass
+class ClassificationResult:
+    """Raw and structural verdicts kept separate for auditability."""
+
+    symbol: str
+    session: date
+    common_minutes: int = 0
+    raw_mismatches: list[MinuteMismatch] = field(default_factory=list)
+    one_sided_minutes: list[datetime] = field(default_factory=list)
+    accepted_pairs: list[PairVerdict] = field(default_factory=list)
+    rejected_pairs: list[PairVerdict] = field(default_factory=list)
+    invariant_failures: list[InvariantFailure] = field(default_factory=list)
+    noncompliant_mismatch_cells: int = 0
+
+    @property
+    def raw_mismatch_cells(self) -> int:
+        return sum(len(mismatch.fields) for mismatch in self.raw_mismatches)
+
+    @property
+    def raw_mismatch_minutes(self) -> int:
+        return len(self.raw_mismatches)
+
+    @property
+    def raw_1m_exact(self) -> bool:
+        """The raw verdict never changes when a pair is structurally accepted."""
+
+        return (
+            self.common_minutes > 0
+            and self.raw_mismatch_cells == 0
+            and not self.one_sided_minutes
+        )
+
+    @property
+    def adjacent_window_equivalent(self) -> bool:
+        """True only if every raw mismatch belongs to an accepted pair."""
+
+        return not (
+            self.invariant_failures
+            or self.one_sided_minutes
+            or self.rejected_pairs
+            or self.noncompliant_mismatch_cells
+        )
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "predicate": PREDICATE_NAME,
+            "predicate_version": PREDICATE_VERSION,
+            "predicate_spec_sha256": PREDICATE_SPEC_SHA256,
+            "cause_name": PREDICATE_NAME,
+            "symbol": self.symbol,
+            "session": self.session.isoformat(),
+            "RAW_1M_EXACT": "PASS" if self.raw_1m_exact else "FAIL",
+            "common_minutes": self.common_minutes,
+            "raw_mismatch_cells": self.raw_mismatch_cells,
+            "raw_mismatch_minutes": self.raw_mismatch_minutes,
+            "raw_mismatch_locations": [
+                mismatch.as_record() for mismatch in self.raw_mismatches
+            ],
+            "ADJACENT_WINDOW_EQUIVALENCE": (
+                "PASS" if self.adjacent_window_equivalent else "FAIL"
+            ),
+            "exception_pair_count": len(self.accepted_pairs),
+            "exception_pairs": [pair.as_record() for pair in self.accepted_pairs],
+            "rejected_pairs": [pair.as_record() for pair in self.rejected_pairs],
+            "one_sided_minutes": [
+                minute.isoformat() for minute in self.one_sided_minutes
+            ],
+            "noncompliant_mismatch_cells": self.noncompliant_mismatch_cells,
+            "invariant_failures": [
+                failure.as_record() for failure in self.invariant_failures
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class PhaseBEvidence:
+    """Evidence required before a shard may receive the documented-exception pass.
+
+    Constructing this object does not perform Phase B.  It only makes the
+    required evidence explicit so an uncollected holdout cannot become a pass
+    through a default value or a match-rate shortcut.
+    """
+
+    design_sessions: tuple[date, ...]
+    holdout_sessions: tuple[date, ...]
+    holdout_revalidation_completed: bool
+    holdout_sessions_completed: bool
+    higher_timeframe_bucket_exact: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class ShardGateDecision:
+    """A fail-closed shard result; this module never enables two-way operation."""
+
+    status: str
+    reasons: tuple[str, ...]
+    noncompliant_mismatch_cells: int
+
+    @property
+    def two_way_enabled(self) -> bool:
+        return False
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "predicate": PREDICATE_NAME,
+            "predicate_version": PREDICATE_VERSION,
+            "predicate_spec_sha256": PREDICATE_SPEC_SHA256,
+            "SHARD_GATE": self.status,
+            "reasons": list(self.reasons),
+            "noncompliant_mismatch_cells": self.noncompliant_mismatch_cells,
+            "TWO_WAY_ENABLED": "NO",
+        }
+
+
+NormalisedBars = dict[datetime, dict[str, int]]
+
+
+def classify(
+    symbol: str,
+    session: date,
+    bars_a: Mapping[datetime, Mapping[str, Any]],
+    bars_b: Mapping[datetime, Mapping[str, Any]],
+    *,
+    context: ComparisonContext,
+) -> ClassificationResult:
+    """Classify one symbol and completed KRX session without changing raw facts."""
+
+    result = ClassificationResult(symbol=symbol, session=session)
+    result.invariant_failures.extend(_validate_context(context))
+
+    normalised_a, failures_a = _normalise_source_bars(bars_a, session, "A")
+    normalised_b, failures_b = _normalise_source_bars(bars_b, session, "B")
+    result.invariant_failures.extend(failures_a)
+    result.invariant_failures.extend(failures_b)
+
+    only_a = sorted(set(normalised_a) - set(normalised_b))
+    only_b = sorted(set(normalised_b) - set(normalised_a))
+    result.one_sided_minutes.extend((*only_a, *only_b))
+    if result.one_sided_minutes:
+        result.invariant_failures.append(
+            InvariantFailure(
+                "I1",
+                "one-sided minute(s) cannot be structurally classified: "
+                + ", ".join(minute.isoformat() for minute in result.one_sided_minutes),
+            )
+        )
+
+    common_minutes = sorted(set(normalised_a) & set(normalised_b))
+    result.common_minutes = len(common_minutes)
+    if not common_minutes:
+        result.invariant_failures.append(
+            InvariantFailure("I1", "no comparable minute exists in both sources")
+        )
+
+    mismatch_fields_by_minute: dict[datetime, tuple[str, ...]] = {}
+    for minute in common_minutes:
+        fields = _mismatching_fields(normalised_a[minute], normalised_b[minute])
+        if fields:
+            mismatch_fields_by_minute[minute] = fields
+            result.raw_mismatches.append(MinuteMismatch(minute, fields))
+
+    # A bad semantic/input contract invalidates every raw mismatch; accepting a
+    # pair after any such failure would make an unavailable fact look verified.
+    if result.invariant_failures:
+        result.noncompliant_mismatch_cells = result.raw_mismatch_cells
+        return result
+
+    mismatch_minutes = tuple(sorted(mismatch_fields_by_minute))
+    if not mismatch_minutes:
+        return result
+
+    pairs, partition_failure = _partition_mismatch_minutes(mismatch_minutes)
+    if partition_failure is not None:
+        result.invariant_failures.append(partition_failure)
+        result.invariant_failures.append(
+            InvariantFailure(
+                "I8",
+                "because no complete accepted-pair partition exists, every raw "
+                "OHLCV mismatch remains outside the accepted exception set",
+            )
+        )
+        result.noncompliant_mismatch_cells = result.raw_mismatch_cells
+        return result
+
+    accepted_minutes: set[datetime] = set()
+    for t, t_next in pairs:
+        pair = _evaluate_pair(
+            normalised_a,
+            normalised_b,
+            mismatch_fields_by_minute,
+            t,
+            t_next,
+        )
+        if pair.equivalent:
+            result.accepted_pairs.append(pair)
+            accepted_minutes.update((t, t_next))
+        else:
+            result.rejected_pairs.append(pair)
+
+    noncompliant_minutes = set(mismatch_fields_by_minute) - accepted_minutes
+    result.noncompliant_mismatch_cells = sum(
+        len(mismatch_fields_by_minute[minute]) for minute in noncompliant_minutes
+    )
+    if noncompliant_minutes:
+        result.invariant_failures.append(
+            InvariantFailure(
+                "I8",
+                "OHLCV mismatch remains outside the accepted exception pair set",
+            )
+        )
+        result.invariant_failures.append(
+            InvariantFailure(
+                "I9",
+                "rejected or unpaired raw mismatch minute(s) remain ordinary "
+                "mismatches",
+            )
+        )
+    return result
+
+
+def evaluate_shard_gate(
+    results: Sequence[ClassificationResult],
+    *,
+    phase_b: PhaseBEvidence,
+) -> ShardGateDecision:
+    """Issue only the documented-exception verdict, never a two-way enablement.
+
+    Phase A callers should pass their pending evidence.  The result is then
+    necessarily ``FAIL``.  A future Phase B caller must supply independent,
+    completed holdout sessions and all actual higher-timeframe bucket results.
+    """
+
+    reasons: list[str] = []
+    if not results:
+        reasons.append("no_classification_results")
+
+    noncompliant = sum(result.noncompliant_mismatch_cells for result in results)
+    for result in results:
+        if not result.adjacent_window_equivalent:
+            reasons.append(
+                f"classification_failed:{result.symbol}:{result.session.isoformat()}"
+            )
+
+    design_sessions = set(phase_b.design_sessions)
+    holdout_sessions = set(phase_b.holdout_sessions)
+    if not design_sessions:
+        reasons.append("design_sessions_not_declared")
+    if not holdout_sessions:
+        reasons.append("holdout_sessions_not_declared")
+    if design_sessions & holdout_sessions:
+        reasons.append("holdout_overlaps_design_sessions")
+    if not phase_b.holdout_revalidation_completed:
+        reasons.append("holdout_revalidation_not_completed")
+    if not phase_b.holdout_sessions_completed:
+        reasons.append("holdout_includes_uncompleted_session")
+    if noncompliant:
+        reasons.append("noncompliant_mismatch_cells_present")
+
+    for timeframe in REQUIRED_HIGHER_TIMEFRAMES:
+        if phase_b.higher_timeframe_bucket_exact.get(timeframe) != "PASS":
+            reasons.append(f"higher_timeframe_bucket_not_exact:{timeframe}")
+
+    status = "FAIL" if reasons else "PASS_WITH_DOCUMENTED_EXCEPTION"
+    return ShardGateDecision(
+        status=status,
+        reasons=tuple(reasons),
+        noncompliant_mismatch_cells=noncompliant,
+    )
+
+
+def _validate_context(context: ComparisonContext) -> list[InvariantFailure]:
+    failures: list[InvariantFailure] = []
+    source_a = context.source_a if isinstance(context.source_a, str) else ""
+    source_b = context.source_b if isinstance(context.source_b, str) else ""
+    if not source_a.strip() or not source_b.strip():
+        failures.append(InvariantFailure("I1", "both source identities are required"))
+    elif source_a == source_b:
+        failures.append(InvariantFailure("I1", "the two source identities must differ"))
+    if context.market != "KRX" or context.session_segment != KRX_REGULAR_SEGMENT:
+        failures.append(
+            InvariantFailure(
+                "I1",
+                "comparison must be explicitly limited to the KRX regular session",
+            )
+        )
+    if not context.adjustment_a or context.adjustment_a != context.adjustment_b:
+        failures.append(
+            InvariantFailure("I1", "sources must declare the same adjustment basis")
+        )
+    if (
+        context.timezone_a != KST_TIMEZONE_NAME
+        or context.timezone_b != KST_TIMEZONE_NAME
+    ):
+        failures.append(
+            InvariantFailure("I1", "both source timestamps must declare Asia/Seoul")
+        )
+    if context.completed_session is not True:
+        failures.append(InvariantFailure("I1", "session is not declared complete"))
+    if context.latest_session_rule_applied_first is not True:
+        failures.append(
+            InvariantFailure(
+                "I1",
+                "latest-session exclusion was not applied before this predicate",
+            )
+        )
+    if context.bar_label_convention != FROZEN_BAR_LABEL_CONVENTION:
+        failures.append(
+            InvariantFailure(
+                "I2",
+                "bar-label convention differs from the frozen V1 convention",
+            )
+        )
+    if (
+        isinstance(context.offset_minutes, bool)
+        or not isinstance(context.offset_minutes, int)
+        or context.offset_minutes != FROZEN_OFFSET_MINUTES
+    ):
+        failures.append(
+            InvariantFailure(
+                "I2",
+                "applied timestamp offset differs from the frozen V1 offset",
+            )
+        )
+    return failures
+
+
+def _normalise_source_bars(
+    bars: Mapping[datetime, Mapping[str, Any]],
+    session: date,
+    source_label: str,
+) -> tuple[NormalisedBars, list[InvariantFailure]]:
+    normalised: NormalisedBars = {}
+    failures: list[InvariantFailure] = []
+    if not isinstance(bars, Mapping):
+        return {}, [
+            InvariantFailure("I1", f"source {source_label} bars are not a mapping")
+        ]
+    if not bars:
+        failures.append(InvariantFailure("I1", f"source {source_label} has no bars"))
+
+    for timestamp, raw_bar in bars.items():
+        local_timestamp, timestamp_failure = _normalise_timestamp(timestamp, session)
+        if timestamp_failure is not None:
+            failures.append(timestamp_failure)
+            continue
+        if local_timestamp in normalised:
+            failures.append(
+                InvariantFailure(
+                    "I3",
+                    "duplicate normalized timestamp in source "
+                    f"{source_label}: {local_timestamp.isoformat()}",
+                )
+            )
+            continue
+        bar, bar_failures = _normalise_bar(raw_bar, source_label, local_timestamp)
+        failures.extend(bar_failures)
+        if bar is not None:
+            normalised[local_timestamp] = bar
+    return normalised, failures
+
+
+def _normalise_timestamp(
+    timestamp: object,
+    session: date,
+) -> tuple[datetime | None, InvariantFailure | None]:
+    if not isinstance(timestamp, datetime):
+        return None, InvariantFailure("I1", "bar timestamp is not a datetime")
+    if timestamp.tzinfo is None or timestamp.utcoffset() != KST_UTC_OFFSET:
+        return None, InvariantFailure(
+            "I1",
+            "bar timestamp is not timezone-aware Asia/Seoul (+09:00)",
+        )
+    local = timestamp.astimezone(KST)
+    if local.date() != session:
+        return None, InvariantFailure(
+            "I1",
+            "bar timestamp session does not match the declared completed session",
+        )
+    if not _is_krx_regular_minute(local):
+        return None, InvariantFailure(
+            "I1",
+            "bar timestamp is outside the declared KRX regular session",
+        )
+    return local, None
+
+
+def _normalise_bar(
+    raw_bar: object,
+    source_label: str,
+    timestamp: datetime,
+) -> tuple[dict[str, int] | None, list[InvariantFailure]]:
+    if not isinstance(raw_bar, Mapping):
+        return None, [
+            InvariantFailure(
+                "I1",
+                f"source {source_label} bar at {timestamp.isoformat()} is not a mapping",
+            )
+        ]
+
+    normalised: dict[str, int] = {}
+    failures: list[InvariantFailure] = []
+    for field_name in COMPARED_FIELDS:
+        if field_name not in raw_bar:
+            failures.append(
+                InvariantFailure(
+                    "I1",
+                    f"source {source_label} bar at {timestamp.isoformat()} "
+                    f"omits {field_name}",
+                )
+            )
+            continue
+        try:
+            normalised[field_name] = _normalise_value(raw_bar[field_name])
+        except (OverflowError, TypeError, ValueError):
+            failures.append(
+                InvariantFailure(
+                    "I1",
+                    f"source {source_label} bar at {timestamp.isoformat()} has "
+                    f"non-finite or non-numeric {field_name}",
+                )
+            )
+    return (normalised if not failures else None), failures
+
+
+def _normalise_value(value: object) -> int:
+    if isinstance(value, (bool, str, bytes)):
+        raise TypeError("not a numeric candle value")
+    converted = float(value)
+    if not math.isfinite(converted):
+        raise ValueError("not finite")
+    return int(round(converted))
+
+
+def _mismatching_fields(a: Mapping[str, int], b: Mapping[str, int]) -> tuple[str, ...]:
+    return tuple(
+        field_name for field_name in COMPARED_FIELDS if a[field_name] != b[field_name]
+    )
+
+
+def _partition_mismatch_minutes(
+    minutes: Sequence[datetime],
+) -> tuple[list[tuple[datetime, datetime]], InvariantFailure | None]:
+    """Enforce I3 before looking at any candidate pair's aggregate values."""
+
+    if not minutes:
+        return [], None
+    if len(set(minutes)) != len(minutes):
+        return [], InvariantFailure(
+            "I3", "duplicate mismatch minute cannot form a pair"
+        )
+    ordered = sorted(minutes)
+    if len(ordered) % 2:
+        return [], InvariantFailure(
+            "I3", "odd number of mismatch minutes cannot partition into pairs"
+        )
+
+    pairs: list[tuple[datetime, datetime]] = []
+    used_minutes: set[datetime] = set()
+    for index in range(0, len(ordered), 2):
+        t, t_next = ordered[index], ordered[index + 1]
+        if t_next - t != timedelta(minutes=1):
+            return [], InvariantFailure(
+                "I3",
+                "mismatch minutes are not adjacent: "
+                f"{t.isoformat()} and {t_next.isoformat()}",
+            )
+        if pairs and t - pairs[-1][1] == timedelta(minutes=1):
+            return [], InvariantFailure(
+                "I3", f"three-or-more-minute mismatch chain begins at {t.isoformat()}"
+            )
+        if t in used_minutes or t_next in used_minutes:
+            return [], InvariantFailure("I3", "duplicate or overlapping pair")
+        pairs.append((t, t_next))
+        used_minutes.update((t, t_next))
+    return pairs, None
+
+
+def _evaluate_pair(
+    bars_a: NormalisedBars,
+    bars_b: NormalisedBars,
+    mismatch_fields_by_minute: Mapping[datetime, tuple[str, ...]],
+    t: datetime,
+    t_next: datetime,
+) -> PairVerdict:
+    failures = _isolation_failures(bars_a, bars_b, mismatch_fields_by_minute, t, t_next)
+    a_t, a_next = bars_a[t], bars_a[t_next]
+    b_t, b_next = bars_b[t], bars_b[t_next]
+
+    if a_t["open"] != b_t["open"]:
+        failures.append(InvariantFailure("I4", "opening price differs at t"))
+    if a_next["close"] != b_next["close"]:
+        failures.append(InvariantFailure("I4", "closing price differs at t+1"))
+    if max(a_t["high"], a_next["high"]) != max(b_t["high"], b_next["high"]):
+        failures.append(InvariantFailure("I5", "two-minute high differs"))
+    if min(a_t["low"], a_next["low"]) != min(b_t["low"], b_next["low"]):
+        failures.append(InvariantFailure("I5", "two-minute low differs"))
+
+    volume_a = a_t["volume"] + a_next["volume"]
+    volume_b = b_t["volume"] + b_next["volume"]
+    if volume_a != volume_b:
+        failures.append(InvariantFailure("I6", "two-minute volume sum differs"))
+
+    delta_t = a_t["volume"] - b_t["volume"]
+    delta_next = a_next["volume"] - b_next["volume"]
+    if delta_t == 0 or delta_next == 0:
+        failures.append(
+            InvariantFailure("I7", "volume movement must be non-zero in both minutes")
+        )
+    if delta_t != -delta_next:
+        failures.append(InvariantFailure("I7", "volume deltas do not cancel"))
+
+    return PairVerdict(t, t_next, equivalent=not failures, failures=tuple(failures))
+
+
+def _isolation_failures(
+    bars_a: NormalisedBars,
+    bars_b: NormalisedBars,
+    mismatch_fields_by_minute: Mapping[datetime, tuple[str, ...]],
+    t: datetime,
+    t_next: datetime,
+) -> list[InvariantFailure]:
+    failures: list[InvariantFailure] = []
+    for neighbour in (t - timedelta(minutes=1), t_next + timedelta(minutes=1)):
+        if not _is_krx_regular_minute(neighbour):
+            continue
+        if neighbour not in bars_a or neighbour not in bars_b:
+            failures.append(
+                InvariantFailure(
+                    "I3",
+                    "cannot prove pair isolation because adjacent regular-session "
+                    f"minute is absent: {neighbour.isoformat()}",
+                )
+            )
+        elif neighbour in mismatch_fields_by_minute:
+            failures.append(
+                InvariantFailure(
+                    "I3",
+                    "mismatch reaches an adjacent regular-session minute: "
+                    f"{neighbour.isoformat()}",
+                )
+            )
+    return failures
+
+
+def _is_krx_regular_minute(timestamp: datetime) -> bool:
+    minute = timestamp.timetz().replace(tzinfo=None)
+    return REGULAR_SESSION_START <= minute <= REGULAR_SESSION_END

--- a/tests/research/test_adjacent_window_predicate.py
+++ b/tests/research/test_adjacent_window_predicate.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import ast
 import copy
 import hashlib
+import importlib.util
 import json
-from dataclasses import replace
-from datetime import date, datetime, timedelta, timezone
+import sys
+from dataclasses import FrozenInstanceError, replace
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -21,6 +23,7 @@ from research.kr_backfill import adjacent_window_predicate as predicate
 pytestmark = pytest.mark.unit
 
 SESSION = date(2026, 7, 30)
+HOLDOUT_SESSIONS = (date(2026, 7, 28), date(2026, 7, 29))
 KST = timezone(timedelta(hours=9), name="KST")
 T = datetime(2026, 7, 30, 14, 55, tzinfo=KST)
 T_NEXT = T + timedelta(minutes=1)
@@ -102,6 +105,34 @@ def classify(source_a, source_b, **context_changes):
     )
 
 
+def holdout_result(symbol: str, session: date):
+    """Create a long completed-session fixture outside the design session."""
+
+    start = datetime.combine(session, time(14, 0), tzinfo=KST)
+    source_a = {}
+    source_b = {}
+    for offset in range(60):
+        timestamp = start + timedelta(minutes=offset)
+        source_a[timestamp] = bar(100, 105, 95, 100, 100)
+        source_b[timestamp] = bar(100, 105, 95, 100, 100)
+
+    pair_start = start + timedelta(minutes=20)
+    pair_next = pair_start + timedelta(minutes=1)
+    source_a[pair_start] = bar(100, 105, 95, 100, 100)
+    source_a[pair_next] = bar(100, 105, 95, 101, 100)
+    source_b[pair_start] = bar(100, 105, 95, 101, 90)
+    source_b[pair_next] = bar(100, 105, 95, 101, 110)
+    return predicate.classify(symbol, session, source_a, source_b, context=context())
+
+
+def completed_holdout_results():
+    return [
+        holdout_result(symbol, session)
+        for session in HOLDOUT_SESSIONS
+        for symbol in ("000270", "005930")
+    ]
+
+
 def invariant_ids(result):
     ids = {failure.invariant for failure in result.invariant_failures}
     for pair in result.rejected_pairs:
@@ -125,7 +156,7 @@ def full_window_with_two_pairs():
 def phase_b_evidence(**changes):
     base = predicate.PhaseBEvidence(
         design_sessions=(SESSION,),
-        holdout_sessions=(date(2026, 7, 29),),
+        holdout_sessions=HOLDOUT_SESSIONS,
         holdout_revalidation_completed=True,
         holdout_sessions_completed=True,
         higher_timeframe_bucket_exact={
@@ -136,6 +167,19 @@ def phase_b_evidence(**changes):
         },
     )
     return replace(base, **changes)
+
+
+def import_predicate_copy(path: Path) -> None:
+    module_name = f"_adjacent_window_predicate_copy_{path.stat().st_mtime_ns}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
 
 
 def test_observed_shape_is_accepted_but_raw_exact_stays_failed():
@@ -159,6 +203,18 @@ def test_observed_shape_is_accepted_but_raw_exact_stays_failed():
     ]
 
 
+def test_classification_result_is_frozen_and_tuple_backed():
+    result = classify(*accepted_input())
+
+    assert isinstance(result.raw_mismatches, tuple)
+    assert isinstance(result.accepted_pairs, tuple)
+    assert isinstance(result.invariant_failures, tuple)
+    with pytest.raises(FrozenInstanceError):
+        result.noncompliant_mismatch_cells = 1
+    with pytest.raises(AttributeError):
+        result.accepted_pairs.clear()
+
+
 # I1: same semantic input and both candidate minutes must exist in both sources.
 
 
@@ -168,7 +224,7 @@ def test_I1_one_sided_only_input_fails_even_without_raw_cells():
     result = classify(source_a, source_b)
 
     assert result.raw_mismatch_cells == 0
-    assert result.one_sided_minutes == [T_NEXT]
+    assert result.one_sided_minutes == (T_NEXT,)
     assert result.adjacent_window_equivalent is False
     assert "I1" in invariant_ids(result)
 
@@ -435,31 +491,92 @@ def test_phase_a_evidence_cannot_issue_a_documented_exception_pass():
 
 
 def test_shard_pass_requires_distinct_completed_holdout_and_all_bucket_results():
-    result = classify(*accepted_input())
-    decision = predicate.evaluate_shard_gate([result], phase_b=phase_b_evidence())
+    results = completed_holdout_results()
+    decision = predicate.evaluate_shard_gate(results, phase_b=phase_b_evidence())
 
     assert decision.status == "PASS_WITH_DOCUMENTED_EXCEPTION"
+    assert decision.covered_symbols == predicate.MIN_HOLDOUT_SYMBOLS
+    assert decision.covered_sessions == predicate.MIN_HOLDOUT_SESSIONS
+    assert decision.compared_cells >= predicate.MIN_HOLDOUT_COMPARED_CELLS
     assert decision.two_way_enabled is False
 
 
-def test_shard_fails_when_holdout_overlaps_design_session():
-    result = classify(*accepted_input())
+def test_verifier_forged_evidence_now_fails_against_actual_result_session():
+    # Reproduce the verifier's exact B1 forgery: a design-cell result plus
+    # unrelated declared date tuples and PASS strings.
+    design_result = classify(*accepted_input())
+    forged = predicate.PhaseBEvidence(
+        design_sessions=(date(1999, 1, 1),),
+        holdout_sessions=(date(2000, 1, 1),),
+        holdout_revalidation_completed=True,
+        holdout_sessions_completed=True,
+        higher_timeframe_bucket_exact={
+            "5m": "PASS",
+            "15m": "PASS",
+            "30m": "PASS",
+            "1h": "PASS",
+        },
+    )
+
+    decision = predicate.evaluate_shard_gate([design_result], phase_b=forged)
+
+    assert decision.status == "FAIL"
+    assert (
+        "result_session_not_in_holdout_sessions:000270:2026-07-30" in decision.reasons
+    )
+    assert "holdout_symbol_coverage_below_minimum:1<2" in decision.reasons
+    assert "holdout_session_coverage_below_minimum:1<2" in decision.reasons
+    assert decision.two_way_enabled is False
+
+
+def test_design_session_result_cannot_be_retroactively_passed():
+    design_result = classify(*accepted_input())
     decision = predicate.evaluate_shard_gate(
-        [result],
+        [design_result],
         phase_b=phase_b_evidence(holdout_sessions=(SESSION,)),
     )
 
     assert decision.status == "FAIL"
     assert "holdout_overlaps_design_sessions" in decision.reasons
+    assert "result_session_is_design_session:000270:2026-07-30" in decision.reasons
+
+
+def test_shard_requires_minimum_actual_holdout_coverage():
+    result = holdout_result("000270", HOLDOUT_SESSIONS[0])
+    decision = predicate.evaluate_shard_gate(
+        [result],
+        phase_b=phase_b_evidence(holdout_sessions=(HOLDOUT_SESSIONS[0],)),
+    )
+
+    assert decision.status == "FAIL"
+    assert "holdout_symbol_coverage_below_minimum:1<2" in decision.reasons
+    assert "holdout_session_coverage_below_minimum:1<2" in decision.reasons
+    assert "holdout_compared_cell_coverage_below_minimum:300<1000" in decision.reasons
+
+
+def test_every_declared_holdout_session_must_have_an_actual_result():
+    result = holdout_result("000270", HOLDOUT_SESSIONS[0])
+    decision = predicate.evaluate_shard_gate([result], phase_b=phase_b_evidence())
+
+    assert decision.status == "FAIL"
+    assert "declared_holdout_session_has_no_result:2026-07-29" in decision.reasons
 
 
 def test_predicate_name_version_and_hash_are_frozen():
     assert predicate.PREDICATE_NAME == "ADJACENT_WINDOW_EQUIVALENT_V1"
-    assert predicate.PREDICATE_VERSION == "1.0.0"
+    assert predicate.PREDICATE_VERSION == "1.0.1"
     assert (
         predicate.PREDICATE_SPEC_SHA256
-        == "207d3f6f1a87413b8788446fde59e6fcad866478674fb99411c804df41de1e99"
+        == "abbd692cd91c0efc07ce21409ad043a199bad97d954d1a97f55852e29c929618"
     )
+    assert predicate._spec_hash() == predicate.PREDICATE_SPEC_SHA256
+    assert predicate._module_source_hash() == predicate.MODULE_SOURCE_SHA256
+    assert predicate.predicate_spec_payload()["required_higher_timeframes"] == [
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+    ]
     assert [item.identifier for item in predicate.INVARIANT_SPEC] == [
         f"I{number}" for number in range(1, 10)
     ]
@@ -478,6 +595,55 @@ def test_changing_the_canonical_spec_changes_its_hash():
     ).hexdigest()
 
     assert altered_hash != predicate.PREDICATE_SPEC_SHA256
+
+
+def test_module_source_freeze_detects_removed_I7_implementation(tmp_path):
+    source = PREDICATE_SOURCE.read_text(encoding="utf-8")
+    i7_enforcement = """\
+    if delta_t == 0 or delta_next == 0:
+        failures.append(
+            InvariantFailure("I7", "volume movement must be non-zero in both minutes")
+        )
+    if delta_t != -delta_next:
+        failures.append(InvariantFailure("I7", "volume deltas do not cancel"))
+"""
+    assert i7_enforcement in source
+    edited_path = tmp_path / "adjacent_window_predicate_i7_deleted.py"
+    edited_path.write_text(source.replace(i7_enforcement, "", 1), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="module source changed"):
+        import_predicate_copy(edited_path)
+
+
+def test_verifier_two_source_edits_now_fail_at_import(tmp_path):
+    """Reproduce the verifier's B3 edits without monkeypatching the module."""
+
+    source = PREDICATE_SOURCE.read_text(encoding="utf-8")
+    i7_enforcement = """\
+    if delta_t == 0 or delta_next == 0:
+        failures.append(
+            InvariantFailure("I7", "volume movement must be non-zero in both minutes")
+        )
+    if delta_t != -delta_next:
+        failures.append(InvariantFailure("I7", "volume deltas do not cancel"))
+"""
+    assert i7_enforcement in source
+    assert (
+        'REQUIRED_HIGHER_TIMEFRAMES: tuple[str, ...] = ("5m", "15m", "30m", "1h")'
+        in source
+    )
+    edited = source.replace(i7_enforcement, "", 1).replace(
+        'REQUIRED_HIGHER_TIMEFRAMES: tuple[str, ...] = ("5m", "15m", "30m", "1h")',
+        "REQUIRED_HIGHER_TIMEFRAMES: tuple[str, ...] = ()",
+        1,
+    )
+    edited_path = tmp_path / "adjacent_window_predicate_verifier_edits.py"
+    edited_path.write_text(edited, encoding="utf-8")
+
+    with pytest.raises(
+        RuntimeError, match="specification changed|module source changed"
+    ):
+        import_predicate_copy(edited_path)
 
 
 def test_predicate_is_pure_and_has_no_offset_search_or_match_rate_escape_hatch():

--- a/tests/research/test_adjacent_window_predicate.py
+++ b/tests/research/test_adjacent_window_predicate.py
@@ -582,6 +582,14 @@ def test_predicate_name_version_and_hash_are_frozen():
     ]
 
 
+def test_module_source_freeze_assertion_runs_before_predicate_body():
+    source = PREDICATE_SOURCE.read_text(encoding="utf-8")
+
+    assert source.index("\n_assert_module_source_is_frozen()\n") < source.index(
+        "\n@dataclass(frozen=True)\nclass ComparisonContext"
+    )
+
+
 def test_changing_the_canonical_spec_changes_its_hash():
     altered = copy.deepcopy(predicate.predicate_spec_payload())
     altered["invariants"][0]["rule"] += " changed"
@@ -671,3 +679,7 @@ def test_promotion_gate_is_registered_in_the_operator_runbook():
     assert "trade" in runbook
     assert "PnL" in runbook
     assert "canonical" in runbook
+    assert "holdout and design session declarations" in runbook
+    assert "raw comparison artifact and its SHA-256" in runbook
+    assert "bucket count, compared" in runbook
+    assert "검사 호출 제거" in runbook

--- a/tests/research/test_adjacent_window_predicate.py
+++ b/tests/research/test_adjacent_window_predicate.py
@@ -1,0 +1,507 @@
+"""Adversarial unit tests for the frozen adjacent-window predicate.
+
+Each invariant is deliberately broken at least once.  A happy-path-only suite
+would not prove the required fail-closed behavior.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+from dataclasses import replace
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from research.kr_backfill import adjacent_window_predicate as predicate
+
+pytestmark = pytest.mark.unit
+
+SESSION = date(2026, 7, 30)
+KST = timezone(timedelta(hours=9), name="KST")
+T = datetime(2026, 7, 30, 14, 55, tzinfo=KST)
+T_NEXT = T + timedelta(minutes=1)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PREDICATE_SOURCE = (
+    REPO_ROOT / "research" / "kr_backfill" / "adjacent_window_predicate.py"
+)
+PROMOTION_RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "kr-research-candles-promotion.md"
+
+
+def bar(open_, high, low, close, volume, *, value=None):
+    record = {
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    }
+    if value is not None:
+        record["value"] = value
+    return record
+
+
+def context(**changes):
+    base = predicate.ComparisonContext(
+        source_a="KIWOOM_MOCK",
+        source_b="KIS_LIVE",
+        market="KRX",
+        session_segment=predicate.KRX_REGULAR_SEGMENT,
+        adjustment_a="UNADJUSTED",
+        adjustment_b="UNADJUSTED",
+        timezone_a=predicate.KST_TIMEZONE_NAME,
+        timezone_b=predicate.KST_TIMEZONE_NAME,
+        completed_session=True,
+        latest_session_rule_applied_first=True,
+        bar_label_convention=predicate.FROZEN_BAR_LABEL_CONVENTION,
+        offset_minutes=predicate.FROZEN_OFFSET_MINUTES,
+    )
+    return replace(base, **changes)
+
+
+def observed_pair():
+    """The observed 000270 14:55/14:56 shape: exactly three raw cells differ."""
+
+    source_a = {
+        T: bar(119300, 119500, 119200, 119400, 11628),
+        T_NEXT: bar(119400, 119600, 119300, 119500, 4538),
+    }
+    source_b = {
+        T: bar(119300, 119500, 119200, 119500, 11613),
+        T_NEXT: bar(119400, 119600, 119300, 119500, 4553),
+    }
+    return source_a, source_b
+
+
+def with_neighbours(source_a, source_b, *, before=1, after=1):
+    for step in range(1, before + 1):
+        timestamp = T - timedelta(minutes=step)
+        source_a[timestamp] = bar(100, 100, 100, 100, 10)
+        source_b[timestamp] = bar(100, 100, 100, 100, 10)
+    for step in range(1, after + 1):
+        timestamp = T_NEXT + timedelta(minutes=step)
+        source_a[timestamp] = bar(100, 100, 100, 100, 10)
+        source_b[timestamp] = bar(100, 100, 100, 100, 10)
+    return source_a, source_b
+
+
+def accepted_input():
+    return with_neighbours(*observed_pair())
+
+
+def classify(source_a, source_b, **context_changes):
+    return predicate.classify(
+        "000270",
+        SESSION,
+        source_a,
+        source_b,
+        context=context(**context_changes),
+    )
+
+
+def invariant_ids(result):
+    ids = {failure.invariant for failure in result.invariant_failures}
+    for pair in result.rejected_pairs:
+        ids.update(failure.invariant for failure in pair.failures)
+    return ids
+
+
+def full_window_with_two_pairs():
+    source_a = {}
+    source_b = {}
+    for offset in range(-5, 13):
+        timestamp = T + timedelta(minutes=offset)
+        source_a[timestamp] = bar(100, 100, 100, 100, 10)
+        source_b[timestamp] = bar(100, 100, 100, 100, 10)
+    observed_a, observed_b = observed_pair()
+    source_a.update(observed_a)
+    source_b.update(observed_b)
+    return source_a, source_b
+
+
+def phase_b_evidence(**changes):
+    base = predicate.PhaseBEvidence(
+        design_sessions=(SESSION,),
+        holdout_sessions=(date(2026, 7, 29),),
+        holdout_revalidation_completed=True,
+        holdout_sessions_completed=True,
+        higher_timeframe_bucket_exact={
+            "5m": "PASS",
+            "15m": "PASS",
+            "30m": "PASS",
+            "1h": "PASS",
+        },
+    )
+    return replace(base, **changes)
+
+
+def test_observed_shape_is_accepted_but_raw_exact_stays_failed():
+    result = classify(*accepted_input())
+
+    assert result.adjacent_window_equivalent is True
+    assert result.raw_1m_exact is False
+    assert result.raw_mismatch_cells == 3
+    assert result.raw_mismatch_minutes == 2
+    assert len(result.accepted_pairs) == 1
+    assert result.noncompliant_mismatch_cells == 0
+
+    record = result.as_record()
+    assert record["RAW_1M_EXACT"] == "FAIL"
+    assert record["ADJACENT_WINDOW_EQUIVALENCE"] == "PASS"
+    assert record["exception_pair_count"] == 1
+    assert record["exception_pairs"][0]["t_kst"] == T.isoformat()
+    assert record["raw_mismatch_locations"] == [
+        {"minute_kst": T.isoformat(), "fields": ["close", "volume"]},
+        {"minute_kst": T_NEXT.isoformat(), "fields": ["volume"]},
+    ]
+
+
+# I1: same semantic input and both candidate minutes must exist in both sources.
+
+
+def test_I1_one_sided_only_input_fails_even_without_raw_cells():
+    source_a = {T: bar(100, 100, 100, 100, 10), T_NEXT: bar(100, 100, 100, 100, 10)}
+    source_b = {T: bar(100, 100, 100, 100, 10)}
+    result = classify(source_a, source_b)
+
+    assert result.raw_mismatch_cells == 0
+    assert result.one_sided_minutes == [T_NEXT]
+    assert result.adjacent_window_equivalent is False
+    assert "I1" in invariant_ids(result)
+
+
+def test_I1_no_data_cannot_be_reported_as_raw_exact():
+    result = classify({}, {})
+
+    assert result.common_minutes == 0
+    assert result.raw_1m_exact is False
+    assert result.adjacent_window_equivalent is False
+    assert result.as_record()["RAW_1M_EXACT"] == "FAIL"
+    assert "I1" in invariant_ids(result)
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected"),
+    [
+        ({"market": "NXT"}, "KRX regular"),
+        ({"adjustment_b": "ADJUSTED"}, "same adjustment"),
+        ({"timezone_b": "UTC"}, "Asia/Seoul"),
+        ({"completed_session": False}, "not declared complete"),
+        ({"latest_session_rule_applied_first": False}, "not applied"),
+        ({"completed_session": 1}, "not declared complete"),
+        ({"latest_session_rule_applied_first": "yes"}, "not applied"),
+    ],
+)
+def test_I1_semantic_preconditions_fail_closed(changes, expected):
+    result = classify(*accepted_input(), **changes)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I1" in invariant_ids(result)
+    assert any(expected in failure.detail for failure in result.invariant_failures)
+
+
+def test_I1_naive_timestamp_fails():
+    source_a, source_b = accepted_input()
+    naive = T.replace(tzinfo=None)
+    source_b[naive] = source_b.pop(T)
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I1" in invariant_ids(result)
+
+
+# I2: no discovered or non-frozen timestamp convention.
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"offset_minutes": -1},
+        {"bar_label_convention": "POST_HOC_OFFSET_SEARCH"},
+    ],
+)
+def test_I2_non_frozen_timestamp_contract_fails(changes):
+    result = classify(*accepted_input(), **changes)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I2" in invariant_ids(result)
+
+
+# I3: isolated, disjoint, adjacent pairs only.
+
+
+def test_I3_three_minute_chain_fails():
+    source_a, source_b = accepted_input()
+    third = T_NEXT + timedelta(minutes=1)
+    source_b[third] = {**source_b[third], "volume": 11}
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I3" in invariant_ids(result)
+    assert result.noncompliant_mismatch_cells == result.raw_mismatch_cells
+
+
+def test_I3_lone_nonadjacent_mismatch_fails():
+    source_a, source_b = accepted_input()
+    far = T + timedelta(minutes=10)
+    source_a[far] = bar(100, 100, 100, 100, 10)
+    source_b[far] = bar(100, 100, 100, 101, 10)
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I3" in invariant_ids(result)
+
+
+def test_I3_duplicate_mismatch_minutes_fail_partition():
+    _, failure = predicate._partition_mismatch_minutes((T, T_NEXT, T, T_NEXT))
+
+    assert failure is not None
+    assert failure.invariant == "I3"
+    assert "duplicate" in failure.detail
+
+
+def test_I3_missing_both_neighbour_bars_fails_isolation():
+    source_a, source_b = accepted_input()
+    previous = T - timedelta(minutes=1)
+    del source_a[previous]
+    del source_b[previous]
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I3" in invariant_ids(result)
+
+
+# I4: outer price exactness.
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "field_name", "value"),
+    [
+        (T, "open", 119310),
+        (T_NEXT, "close", 119510),
+    ],
+)
+def test_I4_outer_price_difference_fails(timestamp, field_name, value):
+    source_a, source_b = accepted_input()
+    source_b[timestamp] = {**source_b[timestamp], field_name: value}
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I4" in invariant_ids(result)
+
+
+# I5: aggregate high/low exactness.
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "field_name", "value"),
+    [
+        (T, "high", 119900),
+        (T_NEXT, "low", 119000),
+    ],
+)
+def test_I5_two_minute_high_or_low_difference_fails(timestamp, field_name, value):
+    source_a, source_b = accepted_input()
+    source_b[timestamp] = {**source_b[timestamp], field_name: value}
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I5" in invariant_ids(result)
+
+
+# I6: aggregate volume exactness.
+
+
+def test_I6_two_minute_volume_sum_difference_fails():
+    source_a, source_b = accepted_input()
+    source_b[T_NEXT] = {**source_b[T_NEXT], "volume": 4600}
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I6" in invariant_ids(result)
+
+
+# I7: non-zero, cancelling volume movement.
+
+
+def test_I7_zero_volume_movement_fails():
+    source_a, source_b = observed_pair()
+    source_b[T] = {**source_a[T], "close": source_a[T]["close"] + 1}
+    source_b[T_NEXT] = {**source_a[T_NEXT], "open": source_a[T_NEXT]["open"] + 1}
+    source_a, source_b = with_neighbours(source_a, source_b)
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert "I7" in invariant_ids(result)
+
+
+def test_I7_non_cancelling_movement_is_reported_alongside_sum_failure():
+    source_a, source_b = accepted_input()
+    source_b[T_NEXT] = {**source_b[T_NEXT], "volume": source_a[T_NEXT]["volume"] - 40}
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert {"I6", "I7"}.issubset(invariant_ids(result))
+
+
+# I8: no OHLCV mismatch may remain outside an accepted pair; value stays excluded.
+
+
+def test_I8_ohlcv_difference_outside_candidate_pair_fails():
+    source_a, source_b = accepted_input()
+    far = T + timedelta(minutes=10)
+    source_a[far] = bar(100, 100, 100, 100, 10)
+    source_b[far] = bar(100, 100, 100, 101, 10)
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert result.noncompliant_mismatch_cells > 0
+    assert "I8" in invariant_ids(result)
+
+
+def test_I8_synthetic_or_cumulative_value_is_ignored_even_when_it_differs():
+    source_a, source_b = accepted_input()
+    source_a[T]["value"] = 1
+    source_b[T]["value"] = 99_999_999
+    source_a[T_NEXT]["value"] = 2
+    source_b[T_NEXT]["value"] = 88_888_888
+    result = classify(source_a, source_b)
+
+    assert "value" not in predicate.COMPARED_FIELDS
+    assert result.adjacent_window_equivalent is True
+    assert result.raw_mismatch_cells == 3
+
+
+# I9: every failure remains a raw mismatch; there is no size/rate rescue.
+
+
+def test_I9_rejected_pair_is_left_noncompliant():
+    source_a, source_b = accepted_input()
+    source_b[T] = {**source_b[T], "high": 999999}
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert result.noncompliant_mismatch_cells == result.raw_mismatch_cells
+    assert "I9" in invariant_ids(result)
+
+
+def test_I9_one_share_error_is_not_rescued_by_its_small_size():
+    source_a, source_b = accepted_input()
+    source_b[T] = {**source_b[T], "volume": source_a[T]["volume"] - 1}
+    source_b[T_NEXT] = {
+        **source_b[T_NEXT],
+        "volume": source_a[T_NEXT]["volume"] - 1,
+    }
+    result = classify(source_a, source_b)
+
+    assert result.adjacent_window_equivalent is False
+    assert result.noncompliant_mismatch_cells > 0
+
+
+def test_I9_many_accepted_pairs_do_not_rescue_one_rejected_pair():
+    source_a, source_b = full_window_with_two_pairs()
+    bad = T + timedelta(minutes=6)
+    bad_next = bad + timedelta(minutes=1)
+    source_a[bad] = bar(100, 100, 100, 100, 50)
+    source_b[bad] = bar(100, 100, 100, 100, 40)
+    source_a[bad_next] = bar(100, 100, 100, 100, 50)
+    source_b[bad_next] = bar(100, 100, 100, 100, 45)
+    result = classify(source_a, source_b)
+
+    assert len(result.accepted_pairs) == 1
+    assert len(result.rejected_pairs) == 1
+    assert result.adjacent_window_equivalent is False
+    assert result.noncompliant_mismatch_cells > 0
+
+
+def test_phase_a_evidence_cannot_issue_a_documented_exception_pass():
+    result = classify(*accepted_input())
+    decision = predicate.evaluate_shard_gate(
+        [result],
+        phase_b=phase_b_evidence(
+            holdout_sessions=(),
+            holdout_revalidation_completed=False,
+            holdout_sessions_completed=False,
+            higher_timeframe_bucket_exact={},
+        ),
+    )
+
+    assert decision.status == "FAIL"
+    assert "holdout_revalidation_not_completed" in decision.reasons
+    assert decision.two_way_enabled is False
+
+
+def test_shard_pass_requires_distinct_completed_holdout_and_all_bucket_results():
+    result = classify(*accepted_input())
+    decision = predicate.evaluate_shard_gate([result], phase_b=phase_b_evidence())
+
+    assert decision.status == "PASS_WITH_DOCUMENTED_EXCEPTION"
+    assert decision.two_way_enabled is False
+
+
+def test_shard_fails_when_holdout_overlaps_design_session():
+    result = classify(*accepted_input())
+    decision = predicate.evaluate_shard_gate(
+        [result],
+        phase_b=phase_b_evidence(holdout_sessions=(SESSION,)),
+    )
+
+    assert decision.status == "FAIL"
+    assert "holdout_overlaps_design_sessions" in decision.reasons
+
+
+def test_predicate_name_version_and_hash_are_frozen():
+    assert predicate.PREDICATE_NAME == "ADJACENT_WINDOW_EQUIVALENT_V1"
+    assert predicate.PREDICATE_VERSION == "1.0.0"
+    assert (
+        predicate.PREDICATE_SPEC_SHA256
+        == "207d3f6f1a87413b8788446fde59e6fcad866478674fb99411c804df41de1e99"
+    )
+    assert [item.identifier for item in predicate.INVARIANT_SPEC] == [
+        f"I{number}" for number in range(1, 10)
+    ]
+
+
+def test_changing_the_canonical_spec_changes_its_hash():
+    altered = copy.deepcopy(predicate.predicate_spec_payload())
+    altered["invariants"][0]["rule"] += " changed"
+    altered_hash = hashlib.sha256(
+        json.dumps(
+            altered,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert altered_hash != predicate.PREDICATE_SPEC_SHA256
+
+
+def test_predicate_is_pure_and_has_no_offset_search_or_match_rate_escape_hatch():
+    source = PREDICATE_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.partition(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.partition(".")[0])
+
+    assert not imports.intersection(
+        {"aiohttp", "app", "asyncpg", "httpx", "requests", "socket", "urllib"}
+    )
+    assert "best_offset" not in source
+    assert "match_rate" not in source
+
+
+def test_promotion_gate_is_registered_in_the_operator_runbook():
+    runbook = PROMOTION_RUNBOOK.read_text(encoding="utf-8")
+
+    assert "KR_1M_SOURCE_SENSITIVITY_V1" in runbook
+    assert "signal" in runbook
+    assert "trade" in runbook
+    assert "PnL" in runbook
+    assert "canonical" in runbook


### PR DESCRIPTION
## Summary
- Adds the frozen `ADJACENT_WINDOW_EQUIVALENT_V1` predicate and fail-closed shard gate evidence binding.
- Applies the signed 1.0.1 follow-up: documents assertion-call removal as a residual bypass and moves the source-freeze assertion immediately after its hash helper.
- Records the three required operator evidence duties and the holdout-zero-mismatch nuance.

## Validation
- `uv run --group test pytest tests/research -v -rA` (84 passed)
- `uv run ruff check research/kr_backfill/adjacent_window_predicate.py tests/research/test_adjacent_window_predicate.py`
- `uv run ruff format --check research/kr_backfill/adjacent_window_predicate.py tests/research/test_adjacent_window_predicate.py`
- `uv run ty check research/kr_backfill/adjacent_window_predicate.py`

## Governance
- Based on `origin/main` `603abd4843e19d0a1b6abf0832c4301d23611ab0`.
- No broker, exchange, account, database, or backfill operation was run.
- This PR is not merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict validation for classifying isolated two-minute KRX data mismatches.
  * Added audit records, integrity checks, holdout coverage validation, and promotion gate decisions.
  * Added safeguards that prevent promotion when source-sensitive differences or incomplete evidence are detected.

* **Documentation**
  * Documented required comparison artifacts, canonical-source reruns, review evidence, and audit integrity citations.
  * Added operational guidance for holdouts, shard exceptions, and independently reaggregated results.

* **Tests**
  * Added extensive coverage for validation rules, tamper detection, immutable results, evidence requirements, and promotion safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->