### PR TITLE
fix(research): lazy-load backfill clients by source

### DIFF
--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -434,7 +434,7 @@ async def main() -> int:
 
     from equality_gate import build_clients
 
-    clients = await build_clients()
+    clients = await build_clients(wanted)
     pool = await asyncpg.create_pool(dsn(), min_size=2, max_size=6)
     log = ProgressLog(args.job_dir / "events" / "progress.jsonl")
     guard = Guard(pool, args.baseline_median_ms, log)

--- a/research/kr_backfill/equality_gate.py
+++ b/research/kr_backfill/equality_gate.py
@@ -18,6 +18,7 @@ import csv
 import json
 import os
 from collections import Counter
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ from sources import (  # noqa: E402
 
 PRICE_FIELDS = ("open", "high", "low", "close")
 COMPARED_FIELDS = (*PRICE_FIELDS, "volume")
+CLIENT_SOURCES = ("toss", "kiwoom", "kis")
 
 CRITERION = {
     "unit": "(symbol, minute_ts) x field",
@@ -143,21 +145,38 @@ def compare_pair(
     }
 
 
-async def build_clients() -> dict[str, Any]:
-    from app.services.brokers.kis.client import KISClient
-    from app.services.brokers.kiwoom import constants as kw_constants
-    from app.services.brokers.kiwoom.client import KiwoomMockClient
-    from app.services.brokers.toss.client import TossReadClient
+async def build_clients(sources: Iterable[str] | None = None) -> dict[str, Any]:
+    """Build only requested sources, without importing unselected providers."""
+    requested = tuple(dict.fromkeys(CLIENT_SOURCES if sources is None else sources))
+    unknown = sorted(set(requested) - set(CLIENT_SOURCES))
+    if not requested:
+        raise ValueError("at least one backfill client source is required")
+    if unknown:
+        raise ValueError(f"unknown backfill client sources: {unknown}")
 
-    kiwoom = KiwoomMockClient(
-        base_url=kw_constants.MOCK_BASE_URL,
-        app_key=os.environ["KIWOOM_MOCK_APP_KEY"],
-        app_secret=os.environ["KIWOOM_MOCK_APP_SECRET"],
-        account_no="",  # chart TRs ignore it; the scoped env has none
-    )
-    kis = KISClient(is_mock=True)
-    toss = TossReadClient.from_settings()
-    return {"kiwoom": kiwoom, "kis": kis, "toss": toss}
+    clients: dict[str, Any] = {}
+    if "kiwoom" in requested:
+        from app.services.brokers.kiwoom import constants as kw_constants
+        from app.services.brokers.kiwoom.client import KiwoomMockClient
+
+        clients["kiwoom"] = KiwoomMockClient(
+            base_url=kw_constants.MOCK_BASE_URL,
+            app_key=os.environ["KIWOOM_MOCK_APP_KEY"],
+            app_secret=os.environ["KIWOOM_MOCK_APP_SECRET"],
+            account_no="",  # chart TRs ignore it; the scoped env has none
+        )
+
+    if "kis" in requested:
+        from app.services.brokers.kis.client import KISClient
+
+        clients["kis"] = KISClient(is_mock=True)
+
+    if "toss" in requested:
+        from app.services.brokers.toss.client import TossReadClient
+
+        clients["toss"] = TossReadClient.from_settings()
+
+    return clients
 
 
 async def probe_depth(clients: dict, pacers: dict, symbol: str) -> dict[str, Any]:

--- a/tests/research/test_kr_backfill_build_clients.py
+++ b/tests/research/test_kr_backfill_build_clients.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EQUALITY_GATE_PATH = REPOSITORY_ROOT / "research" / "kr_backfill" / "equality_gate.py"
+
+
+@pytest.fixture
+def equality_gate_module() -> ModuleType:
+    module_name = "kr_backfill_equality_gate_build_clients_test"
+    sys.path.insert(0, str(EQUALITY_GATE_PATH.parent))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, EQUALITY_GATE_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        sys.path.remove(str(EQUALITY_GATE_PATH.parent))
+
+
+def _minimal_subprocess_env() -> dict[str, str]:
+    env = {
+        key: os.environ[key]
+        for key in ("HOME", "LANG", "LC_ALL", "PATH", "TMPDIR")
+        if key in os.environ
+    }
+    env.update(
+        {
+            "KIWOOM_MOCK_APP_KEY": "test-kiwoom-key",
+            "KIWOOM_MOCK_APP_SECRET": "test-kiwoom-secret",
+        }
+    )
+    return env
+
+
+def _run_build_clients(source_expression: str) -> subprocess.CompletedProcess[str]:
+    script = f"""
+import asyncio
+import sys
+sys.path.insert(0, {str(EQUALITY_GATE_PATH.parent)!r})
+from equality_gate import build_clients
+
+async def main():
+    try:
+        clients = await build_clients({source_expression})
+    except Exception as exc:
+        print(f"FAIL_CLOSED={{type(exc).__name__}}")
+        return 17
+    print("CLIENTS=" + ",".join(sorted(clients)))
+    print("KIS_IMPORTED=" + str("app.services.brokers.kis.client" in sys.modules))
+    print("TOSS_IMPORTED=" + str("app.services.brokers.toss.client" in sys.modules))
+    print("SETTINGS_IMPORTED=" + str("app.core.config" in sys.modules))
+    return 0
+
+raise SystemExit(asyncio.run(main()))
+"""
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPOSITORY_ROOT,
+        env=_minimal_subprocess_env(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_kiwoom_only_does_not_import_other_providers_or_settings() -> None:
+    result = _run_build_clients("['kiwoom']")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.splitlines() == [
+        "CLIENTS=kiwoom",
+        "KIS_IMPORTED=False",
+        "TOSS_IMPORTED=False",
+        "SETTINGS_IMPORTED=False",
+    ]
+
+
+@pytest.mark.parametrize("sources", ["['kis']", "['toss']", "['kiwoom', 'kis']"])
+def test_selected_configured_providers_still_fail_closed_without_env(
+    sources: str,
+) -> None:
+    result = _run_build_clients(sources)
+
+    assert result.returncode == 17, result.stdout + result.stderr
+    assert result.stdout.startswith("FAIL_CLOSED=ValidationError")
+
+
+@pytest.mark.asyncio
+async def test_default_callsite_still_requests_all_sources(
+    equality_gate_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[str] = []
+
+    class _Kiwoom:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+            seen.append("kiwoom")
+
+    class _KIS:
+        def __init__(self, *, is_mock: bool) -> None:
+            assert is_mock is True
+            seen.append("kis")
+
+    class _Toss:
+        @classmethod
+        def from_settings(cls) -> _Toss:
+            seen.append("toss")
+            return cls()
+
+    fake_modules = {
+        "app.services.brokers.kiwoom.constants": ModuleType("constants"),
+        "app.services.brokers.kiwoom.client": ModuleType("kiwoom_client"),
+        "app.services.brokers.kis.client": ModuleType("kis_client"),
+        "app.services.brokers.toss.client": ModuleType("toss_client"),
+    }
+    fake_modules[
+        "app.services.brokers.kiwoom.constants"
+    ].MOCK_BASE_URL = "https://mockapi.kiwoom.com"
+    fake_modules["app.services.brokers.kiwoom.client"].KiwoomMockClient = _Kiwoom
+    fake_modules["app.services.brokers.kis.client"].KISClient = _KIS
+    fake_modules["app.services.brokers.toss.client"].TossReadClient = _Toss
+    for name, module in fake_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setenv("KIWOOM_MOCK_APP_KEY", "test-key")
+    monkeypatch.setenv("KIWOOM_MOCK_APP_SECRET", "test-secret")
+
+    clients = await equality_gate_module.build_clients()
+
+    assert set(clients) == {"kiwoom", "kis", "toss"}
+    assert seen == ["kiwoom", "kis", "toss"]
+
+
+@pytest.mark.parametrize("sources", [[], ["unknown"]])
+def test_invalid_source_selection_fails_before_provider_imports(
+    equality_gate_module: ModuleType, sources: list[str]
+) -> None:
+    with pytest.raises(ValueError):
+        asyncio.run(equality_gate_module.build_clients(sources))


### PR DESCRIPTION
## Summary
- validate requested backfill sources before importing provider modules
- instantiate only selected clients; Kiwoom-only no longer imports KIS, Toss, or global Settings
- preserve equality-gate default behavior by building all three sources when no selection is supplied

## Safety
- scoped backfill env was not modified
- no credentials were added
- no broker API, account, DB, or backfill execution occurred
- collection logic, Pacer, window guard, latency guard, and 429 guard are unchanged

## Verification
- scoped-env construction: CLIENTS=kiwoom; KIS_IMPORTED=False; TOSS_IMPORTED=False; SETTINGS_IMPORTED=False
- missing-env fail closed: KIS=ValidationError; Kiwoom+KIS=ValidationError
- uv run pytest tests/research -q: 48 passed
- make lint: Ruff check/format and ty passed