### PR TITLE
feat: register DFC-2C-4H v2.1 redesign

### DIFF
--- a/research_contracts/dfc_2c_4h_v21.py
+++ b/research_contracts/dfc_2c_4h_v21.py
@@ -30,7 +30,8 @@ __all__ = [
 # The literal is replaced by the source digest itself.  The verifier below
 # hashes the source with this one literal normalized, so the digest is not a
 # circular input.  Exactly one declaration is required.
-MODULE_SOURCE_SHA256: Final = "1c138bb4e4898c246731cf2e3e1b35035a638b87c8f12361e7dff9000200795b"
+MODULE_SOURCE_SHA256: Final = "003b1fb73aa0b8b236714f5bc6ef02e8075558dfad54cfd496c35986121c2d08"
+HARNESS_SOURCE_SHA256: Final = "0000000000000000000000000000000000000000000000000000000000000000"
 _SOURCE_DECLARATION = re.compile(
     r'MODULE_SOURCE_SHA256: Final = "([0-9a-f]{64})"'
 )
@@ -253,7 +254,7 @@ def contract_as_machine_data() -> dict[str, Any]:
         "basket": {"candidate": "any", "winner": "largest abs(C), ties by canonical symbol", "maximum_events_per_epoch": 1},
         "estimand": {"name": "matched_selection_absolute_log_return_delta", "outcome": "abs(log(close[e+4h]/close[e])) * 10000", "candidate_term": "mean outcome of largest-abs(C) winner on candidate epochs", "control_term": "mean outcome of largest-abs(C) winner on non-candidate epochs", "control_choice": "A", "selection_symmetric": True, "pnl_claim": False},
         "adjudication": B7_RULE,
-        "implementation": {"module": "research_contracts.dfc_2c_4h_v21", "algorithm_version": "dfc-2c-4h-v2.1-algorithm.v1", "module_source_sha256": MODULE_SOURCE_SHA256, "io": "none", "enforcement": "import-time source digest; edit causes RuntimeError"},
+        "implementation": {"module": "research_contracts.dfc_2c_4h_v21", "algorithm_version": "dfc-2c-4h-v2.1-algorithm.v1", "module_source_sha256": MODULE_SOURCE_SHA256, "harness_source_sha256": HARNESS_SOURCE_SHA256, "io": "none", "enforcement": "import-time source digest for contract and harness; edit causes RuntimeError"},
         "harness": {"module": "research_contracts.dfc_2c_4h_v21_harness", "read_only": True, "alignment": "UTC 4h inner join", "warmup": "504 prior observations plus current epoch", "manifest_validation": "every epoch, fail-closed", "forward_only": True, "raw_payload_sha256": True},
         "promotion_budget": {"backtest_runs": 1, "orders": 0, "demo": 0, "account": 0, "automatic_promotion": False},
     }

--- a/research_contracts/dfc_2c_4h_v21.py
+++ b/research_contracts/dfc_2c_4h_v21.py
@@ -24,14 +24,16 @@ __all__ = [
     "evaluate_basket", "pit_rank", "tail_threshold_q75",
     "ofi_from_base_volumes", "premium_index_close_from_complete_4h",
     "select_universe", "contract_as_machine_data", "canonical_contract_hash",
-    "validate_evidence_manifest",
+    "validate_evidence_manifest", "OutcomeObservation", "AdjudicationResult",
+    "absolute_log_return_bps", "make_outcome_observation",
+    "stationary_block_bootstrap", "adjudicate_outcomes",
 ]
 
 # The literal is replaced by the source digest itself.  The verifier below
 # hashes the source with this one literal normalized, so the digest is not a
 # circular input.  Exactly one declaration is required.
-MODULE_SOURCE_SHA256: Final = "10c27c46d8f7f86fbae3a0992c38acc94778d95e4a773aac5c484f35cdc8412c"
-HARNESS_SOURCE_SHA256: Final = "0000000000000000000000000000000000000000000000000000000000000000"
+MODULE_SOURCE_SHA256: Final = "36d6c713e895edad20453411e6bea335888984e0a18d24ef8ee6de6dd3d458b9"
+HARNESS_SOURCE_SHA256: Final = "979e6bc7ecbf9c06b27a70d7bde8c3b4b6695b996b5c0ca206fd78e0caecf785"
 _SOURCE_DECLARATION = re.compile(
     r'MODULE_SOURCE_SHA256: Final = "([0-9a-f]{64})"'
 )
@@ -133,6 +135,25 @@ class BasketDecision:
     scores: tuple[SymbolScore, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class OutcomeObservation:
+    candidate: bool
+    outcome_bps: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "outcome_bps", _finite("outcome_bps", self.outcome_bps))
+
+
+@dataclass(frozen=True, slots=True)
+class AdjudicationResult:
+    status: str
+    delta_bps: float | None
+    ci_lower_bps: float | None
+    ci_upper_bps: float | None
+    p_value: float | None
+    bootstrap_deltas_bps: tuple[float, ...]
+
+
 def _finite(name: str, value: float | None) -> float:
     if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(float(value)):
         raise ValueError(f"{name} must be finite numeric")
@@ -212,10 +233,77 @@ def evaluate_basket(inputs: Mapping[str, EpochFeatures]) -> BasketDecision:
         return BasketDecision(None, None, ())
     scores = tuple(score_symbol(inputs[symbol]) for symbol in sorted(inputs))
     candidates = tuple(score for score in scores if score.is_candidate)
-    if not candidates:
-        return BasketDecision(False, None, scores)
-    winner = min(candidates, key=lambda score: (-abs(score.composite), score.symbol))
-    return BasketDecision(True, winner.symbol, scores)
+    # Selection is identical in both arms: all symbols are eligible for the
+    # argmax, while candidate_any remains an arm label for the outcome layer.
+    winner = min(scores, key=lambda score: (-abs(score.composite), score.symbol))
+    return BasketDecision(bool(candidates), winner.symbol, scores)
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        raise ValueError("outcome arm must not be empty")
+    return sum(values) / len(values)
+
+
+def absolute_log_return_bps(entry_close: float, exit_close: float) -> float:
+    entry = _finite("entry_close", entry_close)
+    exit_value = _finite("exit_close", exit_close)
+    if entry <= 0 or exit_value <= 0:
+        raise ValueError("close prices must be strictly positive")
+    return abs(math.log(exit_value / entry)) * 10_000.0
+
+
+def make_outcome_observation(candidate: bool, entry_close: float, exit_close: float) -> OutcomeObservation:
+    return OutcomeObservation(candidate, absolute_log_return_bps(entry_close, exit_close))
+
+
+def stationary_block_bootstrap(
+    candidate_outcomes: Sequence[float], control_outcomes: Sequence[float], *,
+    repetitions: int = 10_000, block_length_epochs: int = 24, seed: int = 2_021_0502,
+) -> tuple[float, ...]:
+    """Deterministic circular stationary-block bootstrap of mean deltas."""
+    candidate = tuple(_finite("candidate_outcome", value) for value in candidate_outcomes)
+    control = tuple(_finite("control_outcome", value) for value in control_outcomes)
+    if not candidate or not control or repetitions <= 0 or block_length_epochs <= 0:
+        raise ValueError("bootstrap inputs must be positive and both arms non-empty")
+    import random
+    rng = random.Random(seed)
+    result: list[float] = []
+    probability = 1.0 / block_length_epochs
+    for _ in range(repetitions):
+        samples: list[float] = []
+        index = rng.randrange(len(candidate))
+        while len(samples) < len(candidate):
+            samples.append(candidate[index])
+            index = (index + 1) % len(candidate) if rng.random() >= probability else rng.randrange(len(candidate))
+        candidate_mean = _mean(samples)
+        samples = []
+        index = rng.randrange(len(control))
+        while len(samples) < len(control):
+            samples.append(control[index])
+            index = (index + 1) % len(control) if rng.random() >= probability else rng.randrange(len(control))
+        result.append(candidate_mean - _mean(samples))
+    return tuple(result)
+
+
+def adjudicate_outcomes(observations: Sequence[OutcomeObservation]) -> AdjudicationResult:
+    candidate = tuple(item.outcome_bps for item in observations if item.candidate)
+    control = tuple(item.outcome_bps for item in observations if not item.candidate)
+    rule = B7_RULE
+    if len(candidate) < rule["minimum_candidate_epochs"] or len(control) < rule["minimum_control_epochs"]:
+        return AdjudicationResult("indeterminate", None, None, None, None, ())
+    delta = _mean(candidate) - _mean(control)
+    bootstrap = stationary_block_bootstrap(
+        candidate, control, repetitions=rule["repetitions"], block_length_epochs=rule["block_length_epochs"]
+    )
+    ordered = sorted(bootstrap)
+    lower = ordered[int((1.0 - rule["confidence_level"]) / 2.0 * len(ordered))]
+    upper = ordered[int((1.0 - (1.0 - rule["confidence_level"]) / 2.0) * len(ordered)) - 1]
+    lower_tail = (sum(value <= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
+    upper_tail = (sum(value >= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
+    p_value = min(1.0, 2.0 * min(lower_tail, upper_tail))
+    status = "success" if lower > rule["delta_threshold_bps"] and p_value < rule["alpha"] else "failure"
+    return AdjudicationResult(status, delta, lower, upper, p_value, bootstrap)
 
 
 REQUIRED_EVIDENCE_FIELDS = frozenset({
@@ -254,7 +342,7 @@ def contract_as_machine_data() -> dict[str, Any]:
         "features": {"ofi": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume)) from complete Binance 4h Kline", "premium": "complete Binance 4h premium-index candle close", "deprecated": ["quote_volume_proxy_as_signal", "five_minute_premium_average"], "complete_only": True, "imputation": "forbidden"},
         "score": {"pit_rank": "current-excluded 252-observation inclusive <= empirical rank", "composite": "(ofi_rank + premium_rank) / 2", "tail": "linear Q0.75 of 252 derived prior |C| values", "tail_context_observations": 504, "comparator": "abs(C) >= threshold", "runtime_parameterization": "forbidden"},
         "basket": {"candidate": "any", "winner": "largest abs(C), ties by canonical symbol", "maximum_events_per_epoch": 1},
-        "estimand": {"name": "matched_selection_absolute_log_return_delta", "outcome": "abs(log(close[e+4h]/close[e])) * 10000", "candidate_term": "mean outcome of largest-abs(C) winner on candidate epochs", "control_term": "mean outcome of largest-abs(C) winner on non-candidate epochs", "control_choice": "A", "selection_symmetric": True, "pnl_claim": False},
+        "estimand": {"name": "matched_selection_absolute_log_return_delta", "outcome": "absolute_log_return_bps(entry_close, exit_close)", "candidate_term": "mean outcome of argmax absolute composite on candidate epochs", "control_term": "mean outcome of argmax absolute composite on non-candidate epochs", "control_choice": "A", "selection_symmetric": True, "selection_implementation": "evaluate_basket argmax over all three scores", "outcome_implementation": "make_outcome_observation", "bootstrap_implementation": "stationary_block_bootstrap", "adjudication_implementation": "adjudicate_outcomes", "pnl_claim": False},
         "adjudication": B7_RULE,
         "implementation": {"module": "research_contracts.dfc_2c_4h_v21", "algorithm_version": "dfc-2c-4h-v2.1-algorithm.v1", "module_source_sha256": MODULE_SOURCE_SHA256, "harness_source_sha256": HARNESS_SOURCE_SHA256, "io": "none", "enforcement": "import-time source digest for contract and harness; edit causes RuntimeError"},
         "harness": {"module": "research_contracts.dfc_2c_4h_v21_harness", "read_only": True, "alignment": "UTC 4h inner join", "warmup": "504 prior observations plus current epoch", "manifest_validation": "every epoch, fail-closed", "forward_only": True, "raw_payload_sha256": True},

--- a/research_contracts/dfc_2c_4h_v21.py
+++ b/research_contracts/dfc_2c_4h_v21.py
@@ -1,0 +1,266 @@
+"""Immutable, offline-only DFC-2C-4H v2.1 re-registration.
+
+This is a new registration.  ``dfc_2c_4h_v2`` is intentionally not imported
+or modified: the 180-day v2 seal remains a historical predecessor.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final
+
+from research_contracts.canonical_hash import canonical_sha256
+
+__all__ = [
+    "CANONICAL_HASH", "CONTRACT_ID", "CONTRACT_SCHEMA_VERSION",
+    "MODULE_SOURCE_SHA256", "B6_CONTROL", "B7_RULE", "EpochFeatures",
+    "IntegrityState", "SymbolScore", "BasketDecision", "score_symbol",
+    "evaluate_basket", "pit_rank", "tail_threshold_q75",
+    "ofi_from_base_volumes", "premium_index_close_from_complete_4h",
+    "select_universe", "contract_as_machine_data", "canonical_contract_hash",
+    "validate_evidence_manifest",
+]
+
+# The literal is replaced by the source digest itself.  The verifier below
+# hashes the source with this one literal normalized, so the digest is not a
+# circular input.  Exactly one declaration is required.
+MODULE_SOURCE_SHA256: Final = "1c138bb4e4898c246731cf2e3e1b35035a638b87c8f12361e7dff9000200795b"
+_SOURCE_DECLARATION = re.compile(
+    r'MODULE_SOURCE_SHA256: Final = "([0-9a-f]{64})"'
+)
+
+CONTRACT_ID: Final = "DFC-2C-4H-v2.1"
+CONTRACT_SCHEMA_VERSION: Final = "dfc-2c-4h-v2.1.contract.v1"
+EPOCH_HOURS: Final = 4
+PIT_LOOKBACK: Final = 252
+TAIL_LOOKBACK: Final = 252
+TAIL_CONTEXT: Final = PIT_LOOKBACK + TAIL_LOOKBACK
+FIXED_QUANTILE_NUMERATOR: Final = 3
+FIXED_QUANTILE_DENOMINATOR: Final = 4
+EXPLORATION_WINDOW: Final = "2023-08-04T00:00:00Z/2026-08-03T00:00:00Z"
+THREE_YEAR_WINDOW: Final = "2021-05-02T00:00:00Z/2024-05-02T00:00:00Z"
+WARMUP_START: Final = "2019-09-08T00:00:00Z"
+UNIVERSE_LOOKBACK_DAYS: Final = 30
+UNIVERSE_TOP_K: Final = 3
+SYMBOL_PRIORITY = MappingProxyType({})
+B6_CONTROL: Final = "A"
+B7_RULE: Final = {
+    "delta_threshold_bps": 5.0,
+    "bootstrap": "stationary_block_percentile",
+    "block_length_epochs": 24,
+    "repetitions": 10_000,
+    "confidence_level": 0.95,
+    "alpha": 0.05,
+    "minimum_candidate_epochs": 400,
+    "minimum_control_epochs": 400,
+    "power": {
+        "target": 0.80,
+        "planning_effect_bps": 5.0,
+        "planning_sd_bps": 25.0,
+        "groups": 2,
+        "epochs_per_group": 400,
+        "two_sided_alpha": 0.05,
+        "normal_approximation": True,
+    },
+    "success": "candidate_minus_matched_control CI lower bound > 5 bps and two-sided p < 0.05",
+    "failure": "CI upper bound <= 5 bps or two-sided p >= 0.05",
+    "indeterminate": "either arm has fewer than its minimum epochs",
+}
+
+
+def _assert_module_source_frozen() -> None:
+    source = inspect.getsource(inspect.getmodule(_assert_module_source_frozen))
+    matches = list(_SOURCE_DECLARATION.finditer(source))
+    if len(matches) != 1:
+        raise RuntimeError("v2.1 source digest declaration count must equal one")
+    declared = matches[0].group(1)
+    normalized = source[: matches[0].start(1)] + "0" * 64 + source[matches[0].end(1) :]
+    actual = hashlib.sha256(normalized.encode()).hexdigest()
+    if declared != actual:
+        raise RuntimeError(
+            f"DFC v2.1 implementation source hash mismatch: declared={declared}, actual={actual}"
+        )
+
+
+_assert_module_source_frozen()
+
+
+class IntegrityState(str):
+    COMPLETE = "complete"
+    GAP = "gap"
+    MISSING = "missing"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class EpochFeatures:
+    symbol: str
+    integrity: str
+    current_ofi: float | None
+    current_premium_close: float | None
+    prior_ofi: tuple[float, ...]
+    prior_premium_close: tuple[float, ...]
+    prior_quote_volume_30d: float
+
+    def __post_init__(self) -> None:
+        if not self.symbol or self.symbol != self.symbol.upper():
+            raise ValueError("symbol must be a non-empty canonical uppercase symbol")
+        object.__setattr__(self, "prior_ofi", tuple(self.prior_ofi))
+        object.__setattr__(self, "prior_premium_close", tuple(self.prior_premium_close))
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolScore:
+    symbol: str
+    composite: float
+    threshold: float
+    is_candidate: bool
+
+
+@dataclass(frozen=True, slots=True)
+class BasketDecision:
+    candidate_any: bool | None
+    winner: str | None
+    scores: tuple[SymbolScore, ...]
+
+
+def _finite(name: str, value: float | None) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(float(value)):
+        raise ValueError(f"{name} must be finite numeric")
+    return float(value)
+
+
+def _history(name: str, values: Sequence[float], expected: int) -> tuple[float, ...]:
+    if len(values) != expected:
+        raise ValueError(f"{name} must contain exactly {expected} values")
+    return tuple(_finite(f"{name}[{i}]", value) for i, value in enumerate(values))
+
+
+def ofi_from_base_volumes(total_base_volume: float, taker_buy_base_volume: float) -> float:
+    total = _finite("total_base_volume", total_base_volume)
+    buy = _finite("taker_buy_base_volume", taker_buy_base_volume)
+    sell = total - buy
+    if total <= 0 or buy <= 0 or sell <= 0:
+        raise ValueError("complete Kline requires strictly positive base buy and sell")
+    return math.log(buy / sell)
+
+
+def premium_index_close_from_complete_4h(value: float, *, is_complete: bool) -> float:
+    if is_complete is not True:
+        raise ValueError("premium-index candle must be complete")
+    return _finite("premium_index_close", value)
+
+
+def pit_rank(current: float, prior_values: Sequence[float]) -> float:
+    current_value = _finite("current", current)
+    history = _history("prior_values", prior_values, 252)
+    return 2.0 * (sum(value <= current_value for value in history) / 252.0) - 1.0
+
+
+def _derived_prior_abs_composites(prior_ofi: Sequence[float], prior_premium: Sequence[float]) -> tuple[float, ...]:
+    ofi = _history("prior_ofi", prior_ofi, 504)
+    premium = _history("prior_premium_close", prior_premium, 504)
+    result: list[float] = []
+    for index in range(252, 504):
+        result.append(abs((pit_rank(ofi[index], ofi[index - 252:index]) + pit_rank(premium[index], premium[index - 252:index])) / 2.0))
+    return tuple(result)
+
+
+def tail_threshold_q75(prior_ofi: Sequence[float], prior_premium_close: Sequence[float]) -> float:
+    ordered = sorted(_derived_prior_abs_composites(prior_ofi, prior_premium_close))
+    return ordered[188] + 0.25 * (ordered[189] - ordered[188])
+
+
+def score_symbol(inputs: EpochFeatures) -> SymbolScore:
+    if inputs.integrity != IntegrityState.COMPLETE:
+        raise ValueError("only complete symbol epochs can be scored")
+    ofi = _history("prior_ofi", inputs.prior_ofi, 504)
+    premium = _history("prior_premium_close", inputs.prior_premium_close, 504)
+    if inputs.current_ofi is None or inputs.current_premium_close is None:
+        raise ValueError("complete epoch is missing a current feature")
+    current_ofi = _finite("current_ofi", inputs.current_ofi)
+    current_premium = premium_index_close_from_complete_4h(inputs.current_premium_close, is_complete=True)
+    composite = (pit_rank(current_ofi, ofi[-252:]) + pit_rank(current_premium, premium[-252:])) / 2.0
+    threshold = tail_threshold_q75(ofi, premium)
+    return SymbolScore(inputs.symbol, composite, threshold, abs(composite) >= threshold)
+
+
+def select_universe(prior_30d_quote_volume: Mapping[str, float]) -> tuple[str, ...]:
+    """Select top-K symbols using only the immediately prior 30 calendar days."""
+    if len(prior_30d_quote_volume) < 3:
+        raise ValueError("PIT universe requires at least three eligible symbols")
+    ranked = sorted(
+        ((_finite(f"quote_volume[{symbol}]", volume), symbol) for symbol, volume in prior_30d_quote_volume.items()),
+        key=lambda item: (-item[0], item[1]),
+    )
+    return tuple(symbol for _, symbol in ranked[:3])
+
+
+def evaluate_basket(inputs: Mapping[str, EpochFeatures]) -> BasketDecision:
+    if len(inputs) != 3 or any(not isinstance(symbol, str) for symbol in inputs):
+        raise ValueError("basket requires exactly the three PIT-selected symbols")
+    if any(item.integrity != IntegrityState.COMPLETE for item in inputs.values()):
+        return BasketDecision(None, None, ())
+    scores = tuple(score_symbol(inputs[symbol]) for symbol in sorted(inputs))
+    candidates = tuple(score for score in scores if score.is_candidate)
+    if not candidates:
+        return BasketDecision(False, None, scores)
+    winner = min(candidates, key=lambda score: (-abs(score.composite), score.symbol))
+    return BasketDecision(True, winner.symbol, scores)
+
+
+REQUIRED_EVIDENCE_FIELDS = frozenset({
+    "source_id", "endpoint_host", "endpoint_path", "endpoint_version", "symbol",
+    "interval", "epoch_start_utc", "epoch_end_utc", "complete", "gap_status",
+    "raw_payload_sha256", "schema_version",
+})
+ALLOWED_SOURCE_IDS = frozenset({
+    "binance_usdm.klines_4h",
+    "binance_usdm.premium_index_klines_4h",
+})
+
+
+def validate_evidence_manifest(record: Mapping[str, Any]) -> None:
+    missing = sorted(field for field in REQUIRED_EVIDENCE_FIELDS if record.get(field) in (None, ""))
+    if missing:
+        raise ValueError(f"missing required evidence fields: {', '.join(missing)}")
+    if record["complete"] is not True or record["gap_status"] != "none":
+        raise ValueError("only complete, gap-free evidence is admissible")
+    if record["source_id"] not in ALLOWED_SOURCE_IDS:
+        raise ValueError("evidence source_id is not in the v2.1 allowlist")
+    digest = record["raw_payload_sha256"]
+    if not isinstance(digest, str) or len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+        raise ValueError("raw_payload_sha256 must be lowercase 64-character hex")
+
+
+def contract_as_machine_data() -> dict[str, Any]:
+    return {
+        "contract_schema_version": CONTRACT_SCHEMA_VERSION,
+        "contract_id": CONTRACT_ID,
+        "registration_mode": "independent_new_registration",
+        "predecessor_preservation": {"v2_identity": "DFC-2C-4H-v2", "v2_row_mutation": "forbidden", "v2_seal_mutation": "forbidden", "v2_supersede_or_hide": "forbidden"},
+        "three_year_window": {"warmup_start_utc": WARMUP_START, "holdout_start_utc": THREE_YEAR_WINDOW.split("/")[0], "holdout_end_utc": THREE_YEAR_WINDOW.split("/")[1], "calendar_days": 1096, "scheduled_epochs": 6576},
+        "exploration_isolation": {"window": EXPLORATION_WINDOW, "relationship": "calendar overlap is 2023-08-04T00:00:00Z through 2024-05-02T00:00:00Z; no exploration artifact or result is admissible as holdout evidence, and the PIT universe rule is re-derived at every epoch", "artifact_use": "design_only_never_primary_or_promotion_evidence"},
+        "universe": {"rule": "At each UTC 4h epoch, rank all eligible USD-M perpetual symbols by quote volume summed over the immediately preceding 30 calendar days; select the top 3, ties by canonical uppercase symbol; use no future or exploration-selected symbol list", "lookback_days": 30, "top_k": 3, "hardcoded_symbols": False, "pit": True},
+        "features": {"ofi": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume)) from complete Binance 4h Kline", "premium": "complete Binance 4h premium-index candle close", "deprecated": ["quote_volume_proxy_as_signal", "five_minute_premium_average"], "complete_only": True, "imputation": "forbidden"},
+        "score": {"pit_rank": "current-excluded 252-observation inclusive <= empirical rank", "composite": "(ofi_rank + premium_rank) / 2", "tail": "linear Q0.75 of 252 derived prior |C| values", "tail_context_observations": 504, "comparator": "abs(C) >= threshold", "runtime_parameterization": "forbidden"},
+        "basket": {"candidate": "any", "winner": "largest abs(C), ties by canonical symbol", "maximum_events_per_epoch": 1},
+        "estimand": {"name": "matched_selection_absolute_log_return_delta", "outcome": "abs(log(close[e+4h]/close[e])) * 10000", "candidate_term": "mean outcome of largest-abs(C) winner on candidate epochs", "control_term": "mean outcome of largest-abs(C) winner on non-candidate epochs", "control_choice": "A", "selection_symmetric": True, "pnl_claim": False},
+        "adjudication": B7_RULE,
+        "implementation": {"module": "research_contracts.dfc_2c_4h_v21", "algorithm_version": "dfc-2c-4h-v2.1-algorithm.v1", "module_source_sha256": MODULE_SOURCE_SHA256, "io": "none", "enforcement": "import-time source digest; edit causes RuntimeError"},
+        "harness": {"module": "research_contracts.dfc_2c_4h_v21_harness", "read_only": True, "alignment": "UTC 4h inner join", "warmup": "504 prior observations plus current epoch", "manifest_validation": "every epoch, fail-closed", "forward_only": True, "raw_payload_sha256": True},
+        "promotion_budget": {"backtest_runs": 1, "orders": 0, "demo": 0, "account": 0, "automatic_promotion": False},
+    }
+
+
+def canonical_contract_hash() -> str:
+    return canonical_sha256(contract_as_machine_data())
+
+
+CANONICAL_HASH: Final = canonical_contract_hash()

--- a/research_contracts/dfc_2c_4h_v21.py
+++ b/research_contracts/dfc_2c_4h_v21.py
@@ -30,7 +30,7 @@ __all__ = [
 # The literal is replaced by the source digest itself.  The verifier below
 # hashes the source with this one literal normalized, so the digest is not a
 # circular input.  Exactly one declaration is required.
-MODULE_SOURCE_SHA256: Final = "003b1fb73aa0b8b236714f5bc6ef02e8075558dfad54cfd496c35986121c2d08"
+MODULE_SOURCE_SHA256: Final = "10c27c46d8f7f86fbae3a0992c38acc94778d95e4a773aac5c484f35cdc8412c"
 HARNESS_SOURCE_SHA256: Final = "0000000000000000000000000000000000000000000000000000000000000000"
 _SOURCE_DECLARATION = re.compile(
     r'MODULE_SOURCE_SHA256: Final = "([0-9a-f]{64})"'
@@ -45,8 +45,10 @@ TAIL_CONTEXT: Final = PIT_LOOKBACK + TAIL_LOOKBACK
 FIXED_QUANTILE_NUMERATOR: Final = 3
 FIXED_QUANTILE_DENOMINATOR: Final = 4
 EXPLORATION_WINDOW: Final = "2023-08-04T00:00:00Z/2026-08-03T00:00:00Z"
-THREE_YEAR_WINDOW: Final = "2021-05-02T00:00:00Z/2024-05-02T00:00:00Z"
-WARMUP_START: Final = "2019-09-08T00:00:00Z"
+BACKTEST_WINDOW: Final = "2021-05-02T00:00:00Z/2023-08-04T00:00:00Z"
+BACKTEST_CALENDAR_DAYS: Final = 824
+BACKTEST_SCHEDULED_EPOCHS: Final = 4_944
+WARMUP_START: Final = "2021-02-02T00:00:00Z"
 UNIVERSE_LOOKBACK_DAYS: Final = 30
 UNIVERSE_TOP_K: Final = 3
 SYMBOL_PRIORITY = MappingProxyType({})
@@ -246,8 +248,8 @@ def contract_as_machine_data() -> dict[str, Any]:
         "contract_id": CONTRACT_ID,
         "registration_mode": "independent_new_registration",
         "predecessor_preservation": {"v2_identity": "DFC-2C-4H-v2", "v2_row_mutation": "forbidden", "v2_seal_mutation": "forbidden", "v2_supersede_or_hide": "forbidden"},
-        "three_year_window": {"warmup_start_utc": WARMUP_START, "holdout_start_utc": THREE_YEAR_WINDOW.split("/")[0], "holdout_end_utc": THREE_YEAR_WINDOW.split("/")[1], "calendar_days": 1096, "scheduled_epochs": 6576},
-        "exploration_isolation": {"window": EXPLORATION_WINDOW, "relationship": "calendar overlap is 2023-08-04T00:00:00Z through 2024-05-02T00:00:00Z; no exploration artifact or result is admissible as holdout evidence, and the PIT universe rule is re-derived at every epoch", "artifact_use": "design_only_never_primary_or_promotion_evidence"},
+        "backtest_window": {"warmup_start_utc": WARMUP_START, "holdout_start_utc": BACKTEST_WINDOW.split("/")[0], "holdout_end_utc_exclusive": BACKTEST_WINDOW.split("/")[1], "calendar_days": BACKTEST_CALENDAR_DAYS, "scheduled_epochs": BACKTEST_SCHEDULED_EPOCHS, "selection_basis": "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop"},
+        "exploration_isolation": {"window": EXPLORATION_WINDOW, "relationship": "no overlap remains in the adopted backtest window", "excluded_overlap": "2023-08-04T00:00:00Z/2024-05-02T00:00:00Z", "excluded_overlap_epochs": 1_632, "excluded_overlap_percent_of_original_three_year_window": 24.817518248175183, "exclusion_reason": "intentionally excluded to remove the design-validation feedback loop", "artifact_use": "design_only_never_primary_or_promotion_evidence"},
         "universe": {"rule": "At each UTC 4h epoch, rank all eligible USD-M perpetual symbols by quote volume summed over the immediately preceding 30 calendar days; select the top 3, ties by canonical uppercase symbol; use no future or exploration-selected symbol list", "lookback_days": 30, "top_k": 3, "hardcoded_symbols": False, "pit": True},
         "features": {"ofi": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume)) from complete Binance 4h Kline", "premium": "complete Binance 4h premium-index candle close", "deprecated": ["quote_volume_proxy_as_signal", "five_minute_premium_average"], "complete_only": True, "imputation": "forbidden"},
         "score": {"pit_rank": "current-excluded 252-observation inclusive <= empirical rank", "composite": "(ofi_rank + premium_rank) / 2", "tail": "linear Q0.75 of 252 derived prior |C| values", "tail_context_observations": 504, "comparator": "abs(C) >= threshold", "runtime_parameterization": "forbidden"},

--- a/research_contracts/dfc_2c_4h_v21.py
+++ b/research_contracts/dfc_2c_4h_v21.py
@@ -18,24 +18,44 @@ from typing import Any, Final
 from research_contracts.canonical_hash import canonical_sha256
 
 __all__ = [
-    "CANONICAL_HASH", "CONTRACT_ID", "CONTRACT_SCHEMA_VERSION",
-    "MODULE_SOURCE_SHA256", "B6_CONTROL", "B7_RULE", "EpochFeatures",
-    "IntegrityState", "SymbolScore", "BasketDecision", "score_symbol",
-    "evaluate_basket", "pit_rank", "tail_threshold_q75",
-    "ofi_from_base_volumes", "premium_index_close_from_complete_4h",
-    "select_universe", "contract_as_machine_data", "canonical_contract_hash",
-    "validate_evidence_manifest", "OutcomeObservation", "AdjudicationResult",
-    "absolute_log_return_bps", "make_outcome_observation",
-    "stationary_block_bootstrap", "adjudicate_outcomes",
+    "CANONICAL_HASH",
+    "CONTRACT_ID",
+    "CONTRACT_SCHEMA_VERSION",
+    "MODULE_SOURCE_SHA256",
+    "B6_CONTROL",
+    "B7_RULE",
+    "IntegrityState",
+    "SymbolScore",
+    "BasketDecision",
+    "score_symbol",
+    "evaluate_basket",
+    "pit_rank",
+    "tail_threshold_q75",
+    "ofi_from_base_volumes",
+    "premium_index_close_from_complete_4h",
+    "select_universe",
+    "contract_as_machine_data",
+    "canonical_contract_hash",
+    "validate_evidence_manifest",
+    "OutcomeObservation",
+    "AdjudicationResult",
+    "absolute_log_return_bps",
+    "make_outcome_observation",
+    "stationary_block_bootstrap",
+    "adjudicate_outcomes",
 ]
 
 # The literal is replaced by the source digest itself.  The verifier below
 # hashes the source with this one literal normalized, so the digest is not a
 # circular input.  Exactly one declaration is required.
-MODULE_SOURCE_SHA256: Final = "36d6c713e895edad20453411e6bea335888984e0a18d24ef8ee6de6dd3d458b9"
-HARNESS_SOURCE_SHA256: Final = "979e6bc7ecbf9c06b27a70d7bde8c3b4b6695b996b5c0ca206fd78e0caecf785"
+MODULE_SOURCE_SHA256: Final = (
+    "dbb8d9ec5c1004face8865b7324f946093084c4cb5be4aa99d8f62fc240c54c2"
+)
+HARNESS_SOURCE_SHA256: Final = (
+    "c081080e20b5a2d79e557f50d3fcd909c2a055e37f8e5291bf929c70b0fe46f4"
+)
 _SOURCE_DECLARATION = re.compile(
-    r'MODULE_SOURCE_SHA256: Final = "([0-9a-f]{64})"'
+    r'MODULE_SOURCE_SHA256: Final = \(\s*"([0-9a-f]{64})"\s*\)', re.DOTALL
 )
 
 CONTRACT_ID: Final = "DFC-2C-4H-v2.1"
@@ -104,7 +124,15 @@ class IntegrityState(str):
 
 
 @dataclass(frozen=True, slots=True)
-class EpochFeatures:
+class _EvidenceBinding:
+    symbol: str
+    current_epoch_start_ms: int
+    kline_payload_hashes: tuple[str, ...]
+    premium_payload_hashes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _EpochFeatures:
     symbol: str
     integrity: str
     current_ofi: float | None
@@ -112,12 +140,19 @@ class EpochFeatures:
     prior_ofi: tuple[float, ...]
     prior_premium_close: tuple[float, ...]
     prior_quote_volume_30d: float
+    evidence: _EvidenceBinding
 
     def __post_init__(self) -> None:
         if not self.symbol or self.symbol != self.symbol.upper():
             raise ValueError("symbol must be a non-empty canonical uppercase symbol")
         object.__setattr__(self, "prior_ofi", tuple(self.prior_ofi))
         object.__setattr__(self, "prior_premium_close", tuple(self.prior_premium_close))
+        if not isinstance(self.evidence, _EvidenceBinding):
+            raise ValueError("features must carry an evidence binding")
+        if self.evidence.symbol != self.symbol or len(self.prior_ofi) != 504:
+            raise ValueError(
+                "features evidence binding does not match the feature window"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,7 +176,9 @@ class OutcomeObservation:
     outcome_bps: float
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "outcome_bps", _finite("outcome_bps", self.outcome_bps))
+        object.__setattr__(
+            self, "outcome_bps", _finite("outcome_bps", self.outcome_bps)
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,7 +192,11 @@ class AdjudicationResult:
 
 
 def _finite(name: str, value: float | None) -> float:
-    if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(float(value)):
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(float(value))
+    ):
         raise ValueError(f"{name} must be finite numeric")
     return float(value)
 
@@ -166,7 +207,9 @@ def _history(name: str, values: Sequence[float], expected: int) -> tuple[float, 
     return tuple(_finite(f"{name}[{i}]", value) for i, value in enumerate(values))
 
 
-def ofi_from_base_volumes(total_base_volume: float, taker_buy_base_volume: float) -> float:
+def ofi_from_base_volumes(
+    total_base_volume: float, taker_buy_base_volume: float
+) -> float:
     total = _finite("total_base_volume", total_base_volume)
     buy = _finite("taker_buy_base_volume", taker_buy_base_volume)
     sell = total - buy
@@ -187,21 +230,37 @@ def pit_rank(current: float, prior_values: Sequence[float]) -> float:
     return 2.0 * (sum(value <= current_value for value in history) / 252.0) - 1.0
 
 
-def _derived_prior_abs_composites(prior_ofi: Sequence[float], prior_premium: Sequence[float]) -> tuple[float, ...]:
+def _derived_prior_abs_composites(
+    prior_ofi: Sequence[float], prior_premium: Sequence[float]
+) -> tuple[float, ...]:
     ofi = _history("prior_ofi", prior_ofi, 504)
     premium = _history("prior_premium_close", prior_premium, 504)
     result: list[float] = []
     for index in range(252, 504):
-        result.append(abs((pit_rank(ofi[index], ofi[index - 252:index]) + pit_rank(premium[index], premium[index - 252:index])) / 2.0))
+        result.append(
+            abs(
+                (
+                    pit_rank(ofi[index], ofi[index - 252 : index])
+                    + pit_rank(premium[index], premium[index - 252 : index])
+                )
+                / 2.0
+            )
+        )
     return tuple(result)
 
 
-def tail_threshold_q75(prior_ofi: Sequence[float], prior_premium_close: Sequence[float]) -> float:
+def tail_threshold_q75(
+    prior_ofi: Sequence[float], prior_premium_close: Sequence[float]
+) -> float:
     ordered = sorted(_derived_prior_abs_composites(prior_ofi, prior_premium_close))
     return ordered[188] + 0.25 * (ordered[189] - ordered[188])
 
 
-def score_symbol(inputs: EpochFeatures) -> SymbolScore:
+def score_symbol(inputs: _EpochFeatures) -> SymbolScore:
+    if not isinstance(inputs, _EpochFeatures) or not isinstance(
+        inputs.evidence, _EvidenceBinding
+    ):
+        raise TypeError("score_symbol accepts only evidence-bound epoch features")
     if inputs.integrity != IntegrityState.COMPLETE:
         raise ValueError("only complete symbol epochs can be scored")
     ofi = _history("prior_ofi", inputs.prior_ofi, 504)
@@ -209,8 +268,12 @@ def score_symbol(inputs: EpochFeatures) -> SymbolScore:
     if inputs.current_ofi is None or inputs.current_premium_close is None:
         raise ValueError("complete epoch is missing a current feature")
     current_ofi = _finite("current_ofi", inputs.current_ofi)
-    current_premium = premium_index_close_from_complete_4h(inputs.current_premium_close, is_complete=True)
-    composite = (pit_rank(current_ofi, ofi[-252:]) + pit_rank(current_premium, premium[-252:])) / 2.0
+    current_premium = premium_index_close_from_complete_4h(
+        inputs.current_premium_close, is_complete=True
+    )
+    composite = (
+        pit_rank(current_ofi, ofi[-252:]) + pit_rank(current_premium, premium[-252:])
+    ) / 2.0
     threshold = tail_threshold_q75(ofi, premium)
     return SymbolScore(inputs.symbol, composite, threshold, abs(composite) >= threshold)
 
@@ -220,18 +283,36 @@ def select_universe(prior_30d_quote_volume: Mapping[str, float]) -> tuple[str, .
     if len(prior_30d_quote_volume) < 3:
         raise ValueError("PIT universe requires at least three eligible symbols")
     ranked = sorted(
-        ((_finite(f"quote_volume[{symbol}]", volume), symbol) for symbol, volume in prior_30d_quote_volume.items()),
+        (
+            (_finite(f"quote_volume[{symbol}]", volume), symbol)
+            for symbol, volume in prior_30d_quote_volume.items()
+        ),
         key=lambda item: (-item[0], item[1]),
     )
     return tuple(symbol for _, symbol in ranked[:3])
 
 
-def evaluate_basket(inputs: Mapping[str, EpochFeatures]) -> BasketDecision:
-    if len(inputs) != 3 or any(not isinstance(symbol, str) for symbol in inputs):
+@dataclass(frozen=True, slots=True)
+class _PITBasket:
+    selected_symbols: tuple[str, ...]
+    inputs: tuple[_EpochFeatures, ...]
+
+
+def evaluate_basket(inputs: _PITBasket) -> BasketDecision:
+    if not isinstance(inputs, _PITBasket):
+        raise TypeError("evaluate_basket accepts only an evidence-bound PIT basket")
+    if len(inputs.selected_symbols) != 3 or len(inputs.inputs) != 3:
         raise ValueError("basket requires exactly the three PIT-selected symbols")
-    if any(item.integrity != IntegrityState.COMPLETE for item in inputs.values()):
+    if tuple(sorted(inputs.selected_symbols)) != tuple(
+        sorted(item.symbol for item in inputs.inputs)
+    ):
+        raise ValueError("basket symbols do not equal the PIT-selected universe")
+    if any(item.integrity != IntegrityState.COMPLETE for item in inputs.inputs):
         return BasketDecision(None, None, ())
-    scores = tuple(score_symbol(inputs[symbol]) for symbol in sorted(inputs))
+    scores = tuple(
+        score_symbol(item)
+        for item in sorted(inputs.inputs, key=lambda item: item.symbol)
+    )
     candidates = tuple(score for score in scores if score.is_candidate)
     # Selection is identical in both arms: all symbols are eligible for the
     # argmax, while candidate_any remains an arm label for the outcome layer.
@@ -253,20 +334,31 @@ def absolute_log_return_bps(entry_close: float, exit_close: float) -> float:
     return abs(math.log(exit_value / entry)) * 10_000.0
 
 
-def make_outcome_observation(candidate: bool, entry_close: float, exit_close: float) -> OutcomeObservation:
-    return OutcomeObservation(candidate, absolute_log_return_bps(entry_close, exit_close))
+def make_outcome_observation(
+    candidate: bool, entry_close: float, exit_close: float
+) -> OutcomeObservation:
+    return OutcomeObservation(
+        candidate, absolute_log_return_bps(entry_close, exit_close)
+    )
 
 
 def stationary_block_bootstrap(
-    candidate_outcomes: Sequence[float], control_outcomes: Sequence[float], *,
-    repetitions: int = 10_000, block_length_epochs: int = 24, seed: int = 2_021_0502,
+    candidate_outcomes: Sequence[float],
+    control_outcomes: Sequence[float],
+    *,
+    repetitions: int = 10_000,
+    block_length_epochs: int = 24,
+    seed: int = 2_021_0502,
 ) -> tuple[float, ...]:
     """Deterministic circular stationary-block bootstrap of mean deltas."""
-    candidate = tuple(_finite("candidate_outcome", value) for value in candidate_outcomes)
+    candidate = tuple(
+        _finite("candidate_outcome", value) for value in candidate_outcomes
+    )
     control = tuple(_finite("control_outcome", value) for value in control_outcomes)
     if not candidate or not control or repetitions <= 0 or block_length_epochs <= 0:
         raise ValueError("bootstrap inputs must be positive and both arms non-empty")
     import random
+
     rng = random.Random(seed)
     result: list[float] = []
     probability = 1.0 / block_length_epochs
@@ -275,50 +367,87 @@ def stationary_block_bootstrap(
         index = rng.randrange(len(candidate))
         while len(samples) < len(candidate):
             samples.append(candidate[index])
-            index = (index + 1) % len(candidate) if rng.random() >= probability else rng.randrange(len(candidate))
+            index = (
+                (index + 1) % len(candidate)
+                if rng.random() >= probability
+                else rng.randrange(len(candidate))
+            )
         candidate_mean = _mean(samples)
         samples = []
         index = rng.randrange(len(control))
         while len(samples) < len(control):
             samples.append(control[index])
-            index = (index + 1) % len(control) if rng.random() >= probability else rng.randrange(len(control))
+            index = (
+                (index + 1) % len(control)
+                if rng.random() >= probability
+                else rng.randrange(len(control))
+            )
         result.append(candidate_mean - _mean(samples))
     return tuple(result)
 
 
-def adjudicate_outcomes(observations: Sequence[OutcomeObservation]) -> AdjudicationResult:
+def adjudicate_outcomes(
+    observations: Sequence[OutcomeObservation],
+) -> AdjudicationResult:
     candidate = tuple(item.outcome_bps for item in observations if item.candidate)
     control = tuple(item.outcome_bps for item in observations if not item.candidate)
     rule = B7_RULE
-    if len(candidate) < rule["minimum_candidate_epochs"] or len(control) < rule["minimum_control_epochs"]:
+    if (
+        len(candidate) < rule["minimum_candidate_epochs"]
+        or len(control) < rule["minimum_control_epochs"]
+    ):
         return AdjudicationResult("indeterminate", None, None, None, None, ())
     delta = _mean(candidate) - _mean(control)
     bootstrap = stationary_block_bootstrap(
-        candidate, control, repetitions=rule["repetitions"], block_length_epochs=rule["block_length_epochs"]
+        candidate,
+        control,
+        repetitions=rule["repetitions"],
+        block_length_epochs=rule["block_length_epochs"],
     )
     ordered = sorted(bootstrap)
     lower = ordered[int((1.0 - rule["confidence_level"]) / 2.0 * len(ordered))]
-    upper = ordered[int((1.0 - (1.0 - rule["confidence_level"]) / 2.0) * len(ordered)) - 1]
+    upper = ordered[
+        int((1.0 - (1.0 - rule["confidence_level"]) / 2.0) * len(ordered)) - 1
+    ]
     lower_tail = (sum(value <= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
     upper_tail = (sum(value >= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
     p_value = min(1.0, 2.0 * min(lower_tail, upper_tail))
-    status = "success" if lower > rule["delta_threshold_bps"] and p_value < rule["alpha"] else "failure"
+    status = (
+        "success"
+        if lower > rule["delta_threshold_bps"] and p_value < rule["alpha"]
+        else "failure"
+    )
     return AdjudicationResult(status, delta, lower, upper, p_value, bootstrap)
 
 
-REQUIRED_EVIDENCE_FIELDS = frozenset({
-    "source_id", "endpoint_host", "endpoint_path", "endpoint_version", "symbol",
-    "interval", "epoch_start_utc", "epoch_end_utc", "complete", "gap_status",
-    "raw_payload_sha256", "schema_version",
-})
-ALLOWED_SOURCE_IDS = frozenset({
-    "binance_usdm.klines_4h",
-    "binance_usdm.premium_index_klines_4h",
-})
+REQUIRED_EVIDENCE_FIELDS = frozenset(
+    {
+        "source_id",
+        "endpoint_host",
+        "endpoint_path",
+        "endpoint_version",
+        "symbol",
+        "interval",
+        "epoch_start_utc",
+        "epoch_end_utc",
+        "complete",
+        "gap_status",
+        "raw_payload_sha256",
+        "schema_version",
+    }
+)
+ALLOWED_SOURCE_IDS = frozenset(
+    {
+        "binance_usdm.klines_4h",
+        "binance_usdm.premium_index_klines_4h",
+    }
+)
 
 
 def validate_evidence_manifest(record: Mapping[str, Any]) -> None:
-    missing = sorted(field for field in REQUIRED_EVIDENCE_FIELDS if record.get(field) in (None, ""))
+    missing = sorted(
+        field for field in REQUIRED_EVIDENCE_FIELDS if record.get(field) in (None, "")
+    )
     if missing:
         raise ValueError(f"missing required evidence fields: {', '.join(missing)}")
     if record["complete"] is not True or record["gap_status"] != "none":
@@ -326,7 +455,11 @@ def validate_evidence_manifest(record: Mapping[str, Any]) -> None:
     if record["source_id"] not in ALLOWED_SOURCE_IDS:
         raise ValueError("evidence source_id is not in the v2.1 allowlist")
     digest = record["raw_payload_sha256"]
-    if not isinstance(digest, str) or len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(c not in "0123456789abcdef" for c in digest)
+    ):
         raise ValueError("raw_payload_sha256 must be lowercase 64-character hex")
 
 
@@ -335,18 +468,97 @@ def contract_as_machine_data() -> dict[str, Any]:
         "contract_schema_version": CONTRACT_SCHEMA_VERSION,
         "contract_id": CONTRACT_ID,
         "registration_mode": "independent_new_registration",
-        "predecessor_preservation": {"v2_identity": "DFC-2C-4H-v2", "v2_row_mutation": "forbidden", "v2_seal_mutation": "forbidden", "v2_supersede_or_hide": "forbidden"},
-        "backtest_window": {"warmup_start_utc": WARMUP_START, "holdout_start_utc": BACKTEST_WINDOW.split("/")[0], "holdout_end_utc_exclusive": BACKTEST_WINDOW.split("/")[1], "calendar_days": BACKTEST_CALENDAR_DAYS, "scheduled_epochs": BACKTEST_SCHEDULED_EPOCHS, "selection_basis": "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop"},
-        "exploration_isolation": {"window": EXPLORATION_WINDOW, "relationship": "no overlap remains in the adopted backtest window", "excluded_overlap": "2023-08-04T00:00:00Z/2024-05-02T00:00:00Z", "excluded_overlap_epochs": 1_632, "excluded_overlap_percent_of_original_three_year_window": 24.817518248175183, "exclusion_reason": "intentionally excluded to remove the design-validation feedback loop", "artifact_use": "design_only_never_primary_or_promotion_evidence"},
-        "universe": {"rule": "At each UTC 4h epoch, rank all eligible USD-M perpetual symbols by quote volume summed over the immediately preceding 30 calendar days; select the top 3, ties by canonical uppercase symbol; use no future or exploration-selected symbol list", "lookback_days": 30, "top_k": 3, "hardcoded_symbols": False, "pit": True},
-        "features": {"ofi": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume)) from complete Binance 4h Kline", "premium": "complete Binance 4h premium-index candle close", "deprecated": ["quote_volume_proxy_as_signal", "five_minute_premium_average"], "complete_only": True, "imputation": "forbidden"},
-        "score": {"pit_rank": "current-excluded 252-observation inclusive <= empirical rank", "composite": "(ofi_rank + premium_rank) / 2", "tail": "linear Q0.75 of 252 derived prior |C| values", "tail_context_observations": 504, "comparator": "abs(C) >= threshold", "runtime_parameterization": "forbidden"},
-        "basket": {"candidate": "any", "winner": "largest abs(C), ties by canonical symbol", "maximum_events_per_epoch": 1},
-        "estimand": {"name": "matched_selection_absolute_log_return_delta", "outcome": "absolute_log_return_bps(entry_close, exit_close)", "candidate_term": "mean outcome of argmax absolute composite on candidate epochs", "control_term": "mean outcome of argmax absolute composite on non-candidate epochs", "control_choice": "A", "selection_symmetric": True, "selection_implementation": "evaluate_basket argmax over all three scores", "outcome_implementation": "make_outcome_observation", "bootstrap_implementation": "stationary_block_bootstrap", "adjudication_implementation": "adjudicate_outcomes", "pnl_claim": False},
+        "predecessor_preservation": {
+            "v2_identity": "DFC-2C-4H-v2",
+            "v2_row_mutation": "forbidden",
+            "v2_seal_mutation": "forbidden",
+            "v2_supersede_or_hide": "forbidden",
+        },
+        "backtest_window": {
+            "warmup_start_utc": WARMUP_START,
+            "holdout_start_utc": BACKTEST_WINDOW.split("/")[0],
+            "holdout_end_utc_exclusive": BACKTEST_WINDOW.split("/")[1],
+            "calendar_days": BACKTEST_CALENDAR_DAYS,
+            "scheduled_epochs": BACKTEST_SCHEDULED_EPOCHS,
+            "selection_basis": "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop",
+        },
+        "exploration_isolation": {
+            "window": EXPLORATION_WINDOW,
+            "relationship": "no overlap remains in the adopted backtest window",
+            "excluded_overlap": "2023-08-04T00:00:00Z/2024-05-02T00:00:00Z",
+            "excluded_overlap_epochs": 1_632,
+            "excluded_overlap_percent_of_original_three_year_window": 24.817518248175183,
+            "exclusion_reason": "intentionally excluded to remove the design-validation feedback loop",
+            "artifact_use": "design_only_never_primary_or_promotion_evidence",
+        },
+        "universe": {
+            "rule": "At each UTC 4h epoch, rank all eligible USD-M perpetual symbols by quote volume summed over the immediately preceding 30 calendar days; select the top 3, ties by canonical uppercase symbol; use no future or exploration-selected symbol list",
+            "lookback_days": 30,
+            "top_k": 3,
+            "hardcoded_symbols": False,
+            "pit": True,
+        },
+        "features": {
+            "ofi": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume)) from complete Binance 4h Kline",
+            "premium": "complete Binance 4h premium-index candle close",
+            "deprecated": [
+                "quote_volume_proxy_as_signal",
+                "five_minute_premium_average",
+            ],
+            "complete_only": True,
+            "imputation": "forbidden",
+        },
+        "score": {
+            "pit_rank": "current-excluded 252-observation inclusive <= empirical rank",
+            "composite": "(ofi_rank + premium_rank) / 2",
+            "tail": "linear Q0.75 of 252 derived prior |C| values",
+            "tail_context_observations": 504,
+            "comparator": "abs(C) >= threshold",
+            "runtime_parameterization": "forbidden",
+        },
+        "basket": {
+            "candidate": "any",
+            "winner": "largest abs(C), ties by canonical symbol",
+            "maximum_events_per_epoch": 1,
+        },
+        "estimand": {
+            "name": "matched_selection_absolute_log_return_delta",
+            "outcome": "absolute_log_return_bps(entry_close, exit_close)",
+            "candidate_term": "mean outcome of argmax absolute composite on candidate epochs",
+            "control_term": "mean outcome of argmax absolute composite on non-candidate epochs",
+            "control_choice": "A",
+            "selection_symmetric": True,
+            "selection_implementation": "evaluate_basket argmax over all three scores",
+            "outcome_implementation": "make_outcome_observation",
+            "bootstrap_implementation": "stationary_block_bootstrap",
+            "adjudication_implementation": "adjudicate_outcomes",
+            "pnl_claim": False,
+        },
         "adjudication": B7_RULE,
-        "implementation": {"module": "research_contracts.dfc_2c_4h_v21", "algorithm_version": "dfc-2c-4h-v2.1-algorithm.v1", "module_source_sha256": MODULE_SOURCE_SHA256, "harness_source_sha256": HARNESS_SOURCE_SHA256, "io": "none", "enforcement": "import-time source digest for contract and harness; edit causes RuntimeError"},
-        "harness": {"module": "research_contracts.dfc_2c_4h_v21_harness", "read_only": True, "alignment": "UTC 4h inner join", "warmup": "504 prior observations plus current epoch", "manifest_validation": "every epoch, fail-closed", "forward_only": True, "raw_payload_sha256": True},
-        "promotion_budget": {"backtest_runs": 1, "orders": 0, "demo": 0, "account": 0, "automatic_promotion": False},
+        "implementation": {
+            "module": "research_contracts.dfc_2c_4h_v21",
+            "algorithm_version": "dfc-2c-4h-v2.1-algorithm.v1",
+            "module_source_sha256": MODULE_SOURCE_SHA256,
+            "harness_source_sha256": HARNESS_SOURCE_SHA256,
+            "io": "none",
+            "enforcement": "import-time source digest for contract and harness; edit causes RuntimeError",
+        },
+        "harness": {
+            "module": "research_contracts.dfc_2c_4h_v21_harness",
+            "read_only": True,
+            "alignment": "UTC 4h inner join",
+            "warmup": "504 prior observations plus current epoch",
+            "manifest_validation": "every epoch, fail-closed",
+            "forward_only": True,
+            "raw_payload_sha256": True,
+        },
+        "promotion_budget": {
+            "backtest_runs": 1,
+            "orders": 0,
+            "demo": 0,
+            "account": 0,
+            "automatic_promotion": False,
+        },
     }
 
 

--- a/research_contracts/dfc_2c_4h_v21_harness.py
+++ b/research_contracts/dfc_2c_4h_v21_harness.py
@@ -16,8 +16,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from research_contracts.dfc_2c_4h_v21 import (
-    EpochFeatures,
     IntegrityState,
+    _EpochFeatures,
+    _EvidenceBinding,
+    _PITBasket,
     evaluate_basket,
     ofi_from_base_volumes,
     premium_index_close_from_complete_4h,
@@ -27,8 +29,12 @@ from research_contracts.dfc_2c_4h_v21 import (
 
 INTERVAL_MS = 4 * 60 * 60 * 1000
 REQUIRED_WARMUP_OBSERVATIONS = 504
-HARNESS_SOURCE_SHA256 = "979e6bc7ecbf9c06b27a70d7bde8c3b4b6695b996b5c0ca206fd78e0caecf785"
-_SOURCE_DECLARATION = re.compile(r'HARNESS_SOURCE_SHA256 = "([0-9a-f]{64})"')
+HARNESS_SOURCE_SHA256 = (
+    "c081080e20b5a2d79e557f50d3fcd909c2a055e37f8e5291bf929c70b0fe46f4"
+)
+_SOURCE_DECLARATION = re.compile(
+    r'HARNESS_SOURCE_SHA256 = \(\s*"([0-9a-f]{64})"\s*\)', re.DOTALL
+)
 
 
 class ForwardOnlyViolation(ValueError):
@@ -62,7 +68,7 @@ class EvidenceCandle:
     endpoint: str
     epoch_start_ms: int
     epoch_end_ms: int
-    payload: tuple[Any, ...]
+    payload: Sequence[Any] | Mapping[str, Any]
     manifest: Mapping[str, Any]
 
 
@@ -76,7 +82,19 @@ PREMIUM_CLOSE_INDEX = 4
 
 
 def raw_payload_sha256(payload: Sequence[Any]) -> str:
-    encoded = json.dumps(list(payload), ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+    if isinstance(payload, Mapping):
+        canonical_payload: Any = {
+            str(key): payload[key] for key in sorted(payload, key=str)
+        }
+    else:
+        canonical_payload = list(payload)
+    encoded = json.dumps(
+        canonical_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+        sort_keys=True,
+    )
     return hashlib.sha256(encoded.encode()).hexdigest()
 
 
@@ -92,27 +110,45 @@ def _numeric_payload_value(value: Any, *, name: str) -> float:
     return parsed
 
 
-def validate_and_sort_candles(candles: Iterable[EvidenceCandle]) -> tuple[EvidenceCandle, ...]:
+def validate_and_sort_candles(
+    candles: Iterable[EvidenceCandle],
+) -> tuple[EvidenceCandle, ...]:
     materialized = tuple(candles)
     for candle in materialized:
         validate_evidence_manifest(candle.manifest)
-        if not isinstance(candle.payload, Mapping) and len(candle.payload) < KLINE_MIN_FIELDS:
-            raise ValueError("raw candle payload has fewer than the required 12 Binance fields")
+        if (
+            not isinstance(candle.payload, Mapping)
+            and len(candle.payload) < KLINE_MIN_FIELDS
+        ):
+            raise ValueError(
+                "raw candle payload has fewer than the required 12 Binance fields"
+            )
         if candle.symbol != candle.manifest["symbol"]:
             raise ValueError("candle symbol does not match evidence manifest")
         if candle.epoch_end_ms - candle.epoch_start_ms != INTERVAL_MS:
             raise ValueError("candle interval must be exactly one UTC 4h epoch")
         if candle.manifest["raw_payload_sha256"] != raw_payload_sha256(candle.payload):
             raise ValueError("raw payload hash does not match evidence manifest")
-        open_time = _actual_candle_value(candle, mapping_key="open_time_ms", sequence_index=KLINE_OPEN_TIME_INDEX)
-        close_time = _actual_candle_value(candle, mapping_key="close_time_ms", sequence_index=KLINE_CLOSE_TIME_INDEX)
+        open_time = _actual_candle_value(
+            candle, mapping_key="open_time_ms", sequence_index=KLINE_OPEN_TIME_INDEX
+        )
+        close_time = _actual_candle_value(
+            candle, mapping_key="close_time_ms", sequence_index=KLINE_CLOSE_TIME_INDEX
+        )
         if open_time != candle.epoch_start_ms:
             raise ValueError("raw candle open time does not match epoch start")
         if close_time != open_time + INTERVAL_MS - 1:
-            raise ValueError("raw candle closeTime must equal openTime + interval - 1ms")
-    ordered = tuple(sorted(materialized, key=lambda c: (c.symbol, c.endpoint, c.epoch_start_ms)))
+            raise ValueError(
+                "raw candle closeTime must equal openTime + interval - 1ms"
+            )
+    ordered = tuple(
+        sorted(materialized, key=lambda c: (c.symbol, c.endpoint, c.epoch_start_ms))
+    )
     for earlier, later in zip(ordered, ordered[1:], strict=False):
-        if (earlier.symbol, earlier.endpoint) == (later.symbol, later.endpoint) and earlier.epoch_start_ms == later.epoch_start_ms:
+        if (earlier.symbol, earlier.endpoint) == (
+            later.symbol,
+            later.endpoint,
+        ) and earlier.epoch_start_ms == later.epoch_start_ms:
             raise ValueError("duplicate symbol/endpoint/epoch evidence")
     return ordered
 
@@ -121,12 +157,16 @@ def inner_align_4h(
     klines: Iterable[EvidenceCandle], premium_klines: Iterable[EvidenceCandle]
 ) -> tuple[tuple[str, int], ...]:
     left = {(c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(klines)}
-    right = {(c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(premium_klines)}
+    right = {
+        (c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(premium_klines)
+    }
     return tuple(sorted(left & right))
 
 
 def assert_forward_only(
-    epoch_starts_ms: Sequence[int], prior_windows: Mapping[int, Sequence[int]], *,
+    epoch_starts_ms: Sequence[int],
+    prior_windows: Mapping[int, Sequence[int]],
+    *,
     prior_evidence: Mapping[int, Sequence[EvidenceCandle]],
 ) -> None:
     for epoch in epoch_starts_ms:
@@ -143,14 +183,18 @@ def assert_forward_only(
             raise ValueError("raw prior window contains current or future candle")
 
 
-def _actual_candle_value(candle: EvidenceCandle, *, mapping_key: str, sequence_index: int) -> int:
+def _actual_candle_value(
+    candle: EvidenceCandle, *, mapping_key: str, sequence_index: int
+) -> int:
     """Read timestamps from the raw Binance candle payload, never the manifest."""
     payload = candle.payload
     if isinstance(payload, Mapping):
         value = payload.get(mapping_key)
     else:
         if len(payload) < KLINE_MIN_FIELDS:
-            raise ValueError("raw candle payload has fewer than the required 12 Binance fields")
+            raise ValueError(
+                "raw candle payload has fewer than the required 12 Binance fields"
+            )
         value = payload[sequence_index]
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise ValueError(f"raw candle payload lacks numeric {mapping_key}")
@@ -172,7 +216,10 @@ def assert_signal_execution_forward_only(
         signal_bar, mapping_key="close_time_ms", sequence_index=6
     )
     actual_signal_end = actual_signal_close + 1
-    if actual_signal_close != declared_signal_close_time_ms or actual_signal_end != signal_bar.epoch_end_ms:
+    if (
+        actual_signal_close != declared_signal_close_time_ms
+        or actual_signal_end != signal_bar.epoch_end_ms
+    ):
         raise ForwardOnlyViolation(
             "SIGNAL_BAR_CLOSE_MISMATCH",
             "declared/manifest signal close does not match the raw signal candle close_time",
@@ -188,8 +235,15 @@ def assert_signal_execution_forward_only(
 
 
 def build_epoch_manifest(
-    *, source_id: str, endpoint_host: str, endpoint_path: str, endpoint_version: str,
-    symbol: str, epoch_start_utc: str, epoch_end_utc: str, payload: Sequence[Any],
+    *,
+    source_id: str,
+    endpoint_host: str,
+    endpoint_path: str,
+    endpoint_version: str,
+    symbol: str,
+    epoch_start_utc: str,
+    epoch_end_utc: str,
+    payload: Sequence[Any],
     schema_version: str,
 ) -> dict[str, Any]:
     """Create provenance only; this function performs no network or persistence."""
@@ -216,22 +270,62 @@ def classify_alignment(ok: bool, *, missing: bool = False) -> IntegrityState:
 
 
 def epoch_features_from_evidence(
-    *, symbol: str, current_kline: EvidenceCandle, current_premium: EvidenceCandle,
-    prior_klines: Sequence[EvidenceCandle], prior_premium: Sequence[EvidenceCandle],
+    *,
+    symbol: str,
+    current_kline: EvidenceCandle,
+    current_premium: EvidenceCandle,
+    prior_klines: Sequence[EvidenceCandle],
+    prior_premium: Sequence[EvidenceCandle],
     prior_30d_quote_volume: float,
-) -> EpochFeatures:
+) -> _EpochFeatures:
     """Build scoring features exclusively from validated raw endpoint evidence."""
+    if current_kline.manifest.get("source_id") != "binance_usdm.klines_4h":
+        raise ValueError("current kline evidence has the wrong source")
+    if (
+        current_premium.manifest.get("source_id")
+        != "binance_usdm.premium_index_klines_4h"
+    ):
+        raise ValueError("current premium evidence has the wrong source")
+    if any(
+        c.manifest.get("source_id") != "binance_usdm.klines_4h" for c in prior_klines
+    ):
+        raise ValueError("prior kline evidence has the wrong source")
+    if any(
+        c.manifest.get("source_id") != "binance_usdm.premium_index_klines_4h"
+        for c in prior_premium
+    ):
+        raise ValueError("prior premium evidence has the wrong source")
     klines = validate_and_sort_candles((*prior_klines, current_kline))
     premiums = validate_and_sort_candles((*prior_premium, current_premium))
     if len(klines) != 505 or len(premiums) != 505:
-        raise ValueError("feature construction requires exactly 504 prior candles and one current candle")
+        raise ValueError(
+            "feature construction requires exactly 504 prior candles and one current candle"
+        )
     if any(c.symbol != symbol for c in (*klines, *premiums)):
         raise ValueError("feature evidence symbol mismatch")
     if current_kline.epoch_start_ms != current_premium.epoch_start_ms:
         raise ValueError("current kline and premium candle are not aligned")
     klines = tuple(sorted(klines, key=lambda candle: candle.epoch_start_ms))
     premiums = tuple(sorted(premiums, key=lambda candle: candle.epoch_start_ms))
-    if tuple(c.epoch_start_ms for c in klines) != tuple(c.epoch_start_ms for c in premiums):
+    if klines[-1] != current_kline or premiums[-1] != current_premium:
+        raise ValueError(
+            "current evidence must be the latest candle in the feature window"
+        )
+    expected_starts = tuple(
+        current_kline.epoch_start_ms - INTERVAL_MS * offset
+        for offset in range(504, -1, -1)
+    )
+    if tuple(c.epoch_start_ms for c in klines) != expected_starts:
+        raise ValueError(
+            "kline feature window must be contiguous and strictly prior to current"
+        )
+    if tuple(c.epoch_start_ms for c in premiums) != expected_starts:
+        raise ValueError(
+            "premium feature window must be contiguous and strictly prior to current"
+        )
+    if tuple(c.epoch_start_ms for c in klines) != tuple(
+        c.epoch_start_ms for c in premiums
+    ):
         raise ValueError("kline and premium prior windows are not aligned")
     ofi: list[float] = []
     premium: list[float] = []
@@ -243,23 +337,53 @@ def epoch_features_from_evidence(
         else:
             total = payload[5]
             buy = payload[KLINE_TAKER_BUY_BASE_INDEX]
-        ofi.append(ofi_from_base_volumes(_numeric_payload_value(total, name="volume"), _numeric_payload_value(buy, name="taker_buy_base_volume")))
+        ofi.append(
+            ofi_from_base_volumes(
+                _numeric_payload_value(total, name="volume"),
+                _numeric_payload_value(buy, name="taker_buy_base_volume"),
+            )
+        )
     for candle in premiums:
-        value = candle.payload.get("close") if isinstance(candle.payload, Mapping) else candle.payload[PREMIUM_CLOSE_INDEX]
-        premium.append(premium_index_close_from_complete_4h(_numeric_payload_value(value, name="premium_close"), is_complete=True))
-    return EpochFeatures(
-        symbol=symbol, integrity=IntegrityState.COMPLETE,
-        current_ofi=ofi[-1], current_premium_close=premium[-1],
-        prior_ofi=tuple(ofi[:-1]), prior_premium_close=tuple(premium[:-1]),
-        prior_quote_volume_30d=prior_30d_quote_volume,
+        value = (
+            candle.payload.get("close")
+            if isinstance(candle.payload, Mapping)
+            else candle.payload[PREMIUM_CLOSE_INDEX]
+        )
+        premium.append(
+            premium_index_close_from_complete_4h(
+                _numeric_payload_value(value, name="premium_close"), is_complete=True
+            )
+        )
+    return _EpochFeatures(
+        symbol=symbol,
+        integrity=IntegrityState.COMPLETE,
+        current_ofi=ofi[-1],
+        current_premium_close=premium[-1],
+        prior_ofi=tuple(ofi[:-1]),
+        prior_premium_close=tuple(premium[:-1]),
+        prior_quote_volume_30d=_numeric_payload_value(
+            prior_30d_quote_volume, name="prior_30d_quote_volume"
+        ),
+        evidence=_EvidenceBinding(
+            symbol=symbol,
+            current_epoch_start_ms=current_kline.epoch_start_ms,
+            kline_payload_hashes=tuple(
+                c.manifest["raw_payload_sha256"] for c in klines
+            ),
+            premium_payload_hashes=tuple(
+                c.manifest["raw_payload_sha256"] for c in premiums
+            ),
+        ),
     )
 
 
 def evaluate_epoch_basket(
-    prior_30d_quote_volume: Mapping[str, float], inputs: Mapping[str, EpochFeatures]
+    prior_30d_quote_volume: Mapping[str, float], inputs: Mapping[str, _EpochFeatures]
 ):
     """Wire the PIT universe selection into the basket scorer for every epoch."""
     selected = select_universe(prior_30d_quote_volume)
     if tuple(sorted(inputs)) != tuple(sorted(selected)):
         raise ValueError("basket symbols do not equal the epoch PIT-selected universe")
-    return evaluate_basket(inputs)
+    return evaluate_basket(
+        _PITBasket(selected, tuple(inputs[symbol] for symbol in sorted(inputs)))
+    )

--- a/research_contracts/dfc_2c_4h_v21_harness.py
+++ b/research_contracts/dfc_2c_4h_v21_harness.py
@@ -16,13 +16,18 @@ from dataclasses import dataclass
 from typing import Any
 
 from research_contracts.dfc_2c_4h_v21 import (
+    EpochFeatures,
     IntegrityState,
+    evaluate_basket,
+    ofi_from_base_volumes,
+    premium_index_close_from_complete_4h,
+    select_universe,
     validate_evidence_manifest,
 )
 
 INTERVAL_MS = 4 * 60 * 60 * 1000
 REQUIRED_WARMUP_OBSERVATIONS = 504
-HARNESS_SOURCE_SHA256 = "89dc38effce02cff0b6f31f31f5de6aae7f60d972d6daeee034fc07dd3afdb7e"
+HARNESS_SOURCE_SHA256 = "979e6bc7ecbf9c06b27a70d7bde8c3b4b6695b996b5c0ca206fd78e0caecf785"
 _SOURCE_DECLARATION = re.compile(r'HARNESS_SOURCE_SHA256 = "([0-9a-f]{64})"')
 
 
@@ -61,19 +66,50 @@ class EvidenceCandle:
     manifest: Mapping[str, Any]
 
 
+KLINE_MIN_FIELDS = 12
+KLINE_OPEN_TIME_INDEX = 0
+KLINE_CLOSE_INDEX = 4
+KLINE_CLOSE_TIME_INDEX = 6
+KLINE_QUOTE_VOLUME_INDEX = 7
+KLINE_TAKER_BUY_BASE_INDEX = 9
+PREMIUM_CLOSE_INDEX = 4
+
+
 def raw_payload_sha256(payload: Sequence[Any]) -> str:
     encoded = json.dumps(list(payload), ensure_ascii=False, separators=(",", ":"), allow_nan=False)
     return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _numeric_payload_value(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"raw candle payload field {name} must be numeric")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"raw candle payload field {name} must be numeric") from exc
+    if not parsed == parsed or parsed in (float("inf"), float("-inf")):
+        raise ValueError(f"raw candle payload field {name} must be finite")
+    return parsed
 
 
 def validate_and_sort_candles(candles: Iterable[EvidenceCandle]) -> tuple[EvidenceCandle, ...]:
     materialized = tuple(candles)
     for candle in materialized:
         validate_evidence_manifest(candle.manifest)
+        if not isinstance(candle.payload, Mapping) and len(candle.payload) < KLINE_MIN_FIELDS:
+            raise ValueError("raw candle payload has fewer than the required 12 Binance fields")
+        if candle.symbol != candle.manifest["symbol"]:
+            raise ValueError("candle symbol does not match evidence manifest")
         if candle.epoch_end_ms - candle.epoch_start_ms != INTERVAL_MS:
             raise ValueError("candle interval must be exactly one UTC 4h epoch")
         if candle.manifest["raw_payload_sha256"] != raw_payload_sha256(candle.payload):
             raise ValueError("raw payload hash does not match evidence manifest")
+        open_time = _actual_candle_value(candle, mapping_key="open_time_ms", sequence_index=KLINE_OPEN_TIME_INDEX)
+        close_time = _actual_candle_value(candle, mapping_key="close_time_ms", sequence_index=KLINE_CLOSE_TIME_INDEX)
+        if open_time != candle.epoch_start_ms:
+            raise ValueError("raw candle open time does not match epoch start")
+        if close_time != open_time + INTERVAL_MS - 1:
+            raise ValueError("raw candle closeTime must equal openTime + interval - 1ms")
     ordered = tuple(sorted(materialized, key=lambda c: (c.symbol, c.endpoint, c.epoch_start_ms)))
     for earlier, later in zip(ordered, ordered[1:], strict=False):
         if (earlier.symbol, earlier.endpoint) == (later.symbol, later.endpoint) and earlier.epoch_start_ms == later.epoch_start_ms:
@@ -89,13 +125,22 @@ def inner_align_4h(
     return tuple(sorted(left & right))
 
 
-def assert_forward_only(epoch_starts_ms: Sequence[int], prior_windows: Mapping[int, Sequence[int]]) -> None:
+def assert_forward_only(
+    epoch_starts_ms: Sequence[int], prior_windows: Mapping[int, Sequence[int]], *,
+    prior_evidence: Mapping[int, Sequence[EvidenceCandle]],
+) -> None:
     for epoch in epoch_starts_ms:
         prior = tuple(prior_windows[epoch])
         if len(prior) != REQUIRED_WARMUP_OBSERVATIONS:
             raise ValueError("every epoch requires exactly 504 prior observations")
         if any(previous >= epoch for previous in prior):
             raise ValueError("prior window contains current or future epoch")
+        raw_prior = validate_and_sort_candles(prior_evidence[epoch])
+        starts = tuple(candle.epoch_start_ms for candle in raw_prior)
+        if starts != prior:
+            raise ValueError("prior window does not match raw evidence candle times")
+        if any(start >= epoch for start in starts):
+            raise ValueError("raw prior window contains current or future candle")
 
 
 def _actual_candle_value(candle: EvidenceCandle, *, mapping_key: str, sequence_index: int) -> int:
@@ -104,6 +149,8 @@ def _actual_candle_value(candle: EvidenceCandle, *, mapping_key: str, sequence_i
     if isinstance(payload, Mapping):
         value = payload.get(mapping_key)
     else:
+        if len(payload) < KLINE_MIN_FIELDS:
+            raise ValueError("raw candle payload has fewer than the required 12 Binance fields")
         value = payload[sequence_index]
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise ValueError(f"raw candle payload lacks numeric {mapping_key}")
@@ -124,9 +171,7 @@ def assert_signal_execution_forward_only(
     actual_signal_close = _actual_candle_value(
         signal_bar, mapping_key="close_time_ms", sequence_index=6
     )
-    actual_signal_end = _actual_candle_value(
-        signal_bar, mapping_key="close_time_ms", sequence_index=6
-    )
+    actual_signal_end = actual_signal_close + 1
     if actual_signal_close != declared_signal_close_time_ms or actual_signal_end != signal_bar.epoch_end_ms:
         raise ForwardOnlyViolation(
             "SIGNAL_BAR_CLOSE_MISMATCH",
@@ -135,7 +180,7 @@ def assert_signal_execution_forward_only(
     actual_execution_start = _actual_candle_value(
         execution_bar, mapping_key="open_time_ms", sequence_index=0
     )
-    if actual_execution_start < actual_signal_close:
+    if actual_execution_start <= actual_signal_close:
         raise ForwardOnlyViolation(
             "NEXT_BAR_OVERLAPS_SIGNAL_BAR",
             "execution candle starts before the raw signal candle closes",
@@ -168,3 +213,53 @@ def classify_alignment(ok: bool, *, missing: bool = False) -> IntegrityState:
     if ok:
         return IntegrityState.COMPLETE
     return IntegrityState.MISSING if missing else IntegrityState.GAP
+
+
+def epoch_features_from_evidence(
+    *, symbol: str, current_kline: EvidenceCandle, current_premium: EvidenceCandle,
+    prior_klines: Sequence[EvidenceCandle], prior_premium: Sequence[EvidenceCandle],
+    prior_30d_quote_volume: float,
+) -> EpochFeatures:
+    """Build scoring features exclusively from validated raw endpoint evidence."""
+    klines = validate_and_sort_candles((*prior_klines, current_kline))
+    premiums = validate_and_sort_candles((*prior_premium, current_premium))
+    if len(klines) != 505 or len(premiums) != 505:
+        raise ValueError("feature construction requires exactly 504 prior candles and one current candle")
+    if any(c.symbol != symbol for c in (*klines, *premiums)):
+        raise ValueError("feature evidence symbol mismatch")
+    if current_kline.epoch_start_ms != current_premium.epoch_start_ms:
+        raise ValueError("current kline and premium candle are not aligned")
+    klines = tuple(sorted(klines, key=lambda candle: candle.epoch_start_ms))
+    premiums = tuple(sorted(premiums, key=lambda candle: candle.epoch_start_ms))
+    if tuple(c.epoch_start_ms for c in klines) != tuple(c.epoch_start_ms for c in premiums):
+        raise ValueError("kline and premium prior windows are not aligned")
+    ofi: list[float] = []
+    premium: list[float] = []
+    for candle in klines:
+        payload = candle.payload
+        if isinstance(payload, Mapping):
+            total = payload.get("volume")
+            buy = payload.get("taker_buy_base_volume")
+        else:
+            total = payload[5]
+            buy = payload[KLINE_TAKER_BUY_BASE_INDEX]
+        ofi.append(ofi_from_base_volumes(_numeric_payload_value(total, name="volume"), _numeric_payload_value(buy, name="taker_buy_base_volume")))
+    for candle in premiums:
+        value = candle.payload.get("close") if isinstance(candle.payload, Mapping) else candle.payload[PREMIUM_CLOSE_INDEX]
+        premium.append(premium_index_close_from_complete_4h(_numeric_payload_value(value, name="premium_close"), is_complete=True))
+    return EpochFeatures(
+        symbol=symbol, integrity=IntegrityState.COMPLETE,
+        current_ofi=ofi[-1], current_premium_close=premium[-1],
+        prior_ofi=tuple(ofi[:-1]), prior_premium_close=tuple(premium[:-1]),
+        prior_quote_volume_30d=prior_30d_quote_volume,
+    )
+
+
+def evaluate_epoch_basket(
+    prior_30d_quote_volume: Mapping[str, float], inputs: Mapping[str, EpochFeatures]
+):
+    """Wire the PIT universe selection into the basket scorer for every epoch."""
+    selected = select_universe(prior_30d_quote_volume)
+    if tuple(sorted(inputs)) != tuple(sorted(selected)):
+        raise ValueError("basket symbols do not equal the epoch PIT-selected universe")
+    return evaluate_basket(inputs)

--- a/research_contracts/dfc_2c_4h_v21_harness.py
+++ b/research_contracts/dfc_2c_4h_v21_harness.py
@@ -1,0 +1,97 @@
+"""Read-only PIT collection and alignment primitives for DFC v2.1.
+
+The harness is deliberately transport-agnostic: an operator supplies pages
+from the Binance read endpoints, and this module validates, hashes, sorts and
+aligns them.  It has no database, broker, scheduler, or order path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from research_contracts.dfc_2c_4h_v21 import (
+    IntegrityState,
+    validate_evidence_manifest,
+)
+
+INTERVAL_MS = 4 * 60 * 60 * 1000
+REQUIRED_WARMUP_OBSERVATIONS = 504
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceCandle:
+    symbol: str
+    endpoint: str
+    epoch_start_ms: int
+    epoch_end_ms: int
+    payload: tuple[Any, ...]
+    manifest: Mapping[str, Any]
+
+
+def raw_payload_sha256(payload: Sequence[Any]) -> str:
+    encoded = json.dumps(list(payload), ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def validate_and_sort_candles(candles: Iterable[EvidenceCandle]) -> tuple[EvidenceCandle, ...]:
+    materialized = tuple(candles)
+    for candle in materialized:
+        validate_evidence_manifest(candle.manifest)
+        if candle.epoch_end_ms - candle.epoch_start_ms != INTERVAL_MS:
+            raise ValueError("candle interval must be exactly one UTC 4h epoch")
+        if candle.manifest["raw_payload_sha256"] != raw_payload_sha256(candle.payload):
+            raise ValueError("raw payload hash does not match evidence manifest")
+    ordered = tuple(sorted(materialized, key=lambda c: (c.symbol, c.endpoint, c.epoch_start_ms)))
+    for earlier, later in zip(ordered, ordered[1:], strict=False):
+        if (earlier.symbol, earlier.endpoint) == (later.symbol, later.endpoint) and earlier.epoch_start_ms == later.epoch_start_ms:
+            raise ValueError("duplicate symbol/endpoint/epoch evidence")
+    return ordered
+
+
+def inner_align_4h(
+    klines: Iterable[EvidenceCandle], premium_klines: Iterable[EvidenceCandle]
+) -> tuple[tuple[str, int], ...]:
+    left = {(c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(klines)}
+    right = {(c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(premium_klines)}
+    return tuple(sorted(left & right))
+
+
+def assert_forward_only(epoch_starts_ms: Sequence[int], prior_windows: Mapping[int, Sequence[int]]) -> None:
+    for epoch in epoch_starts_ms:
+        prior = tuple(prior_windows[epoch])
+        if len(prior) != REQUIRED_WARMUP_OBSERVATIONS:
+            raise ValueError("every epoch requires exactly 504 prior observations")
+        if any(previous >= epoch for previous in prior):
+            raise ValueError("prior window contains current or future epoch")
+
+
+def build_epoch_manifest(
+    *, source_id: str, endpoint_host: str, endpoint_path: str, endpoint_version: str,
+    symbol: str, epoch_start_utc: str, epoch_end_utc: str, payload: Sequence[Any],
+    schema_version: str,
+) -> dict[str, Any]:
+    """Create provenance only; this function performs no network or persistence."""
+    return {
+        "source_id": source_id,
+        "endpoint_host": endpoint_host,
+        "endpoint_path": endpoint_path,
+        "endpoint_version": endpoint_version,
+        "symbol": symbol,
+        "interval": "4h",
+        "epoch_start_utc": epoch_start_utc,
+        "epoch_end_utc": epoch_end_utc,
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": schema_version,
+    }
+
+
+def classify_alignment(ok: bool, *, missing: bool = False) -> IntegrityState:
+    if ok:
+        return IntegrityState.COMPLETE
+    return IntegrityState.MISSING if missing else IntegrityState.GAP

--- a/research_contracts/dfc_2c_4h_v21_harness.py
+++ b/research_contracts/dfc_2c_4h_v21_harness.py
@@ -8,7 +8,9 @@ aligns them.  It has no database, broker, scheduler, or order path.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
+import re
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -20,6 +22,33 @@ from research_contracts.dfc_2c_4h_v21 import (
 
 INTERVAL_MS = 4 * 60 * 60 * 1000
 REQUIRED_WARMUP_OBSERVATIONS = 504
+HARNESS_SOURCE_SHA256 = "89dc38effce02cff0b6f31f31f5de6aae7f60d972d6daeee034fc07dd3afdb7e"
+_SOURCE_DECLARATION = re.compile(r'HARNESS_SOURCE_SHA256 = "([0-9a-f]{64})"')
+
+
+class ForwardOnlyViolation(ValueError):
+    """Fail-closed timestamp violation with the shared #1774 reason code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+def _assert_harness_source_frozen() -> None:
+    source = inspect.getsource(inspect.getmodule(_assert_harness_source_frozen))
+    matches = list(_SOURCE_DECLARATION.finditer(source))
+    if len(matches) != 1:
+        raise RuntimeError("harness source digest declaration count must equal one")
+    declared = matches[0].group(1)
+    normalized = source[: matches[0].start(1)] + "0" * 64 + source[matches[0].end(1) :]
+    actual = hashlib.sha256(normalized.encode()).hexdigest()
+    if declared != actual:
+        raise RuntimeError(
+            f"DFC v2.1 harness source hash mismatch: declared={declared}, actual={actual}"
+        )
+
+
+_assert_harness_source_frozen()
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,6 +96,50 @@ def assert_forward_only(epoch_starts_ms: Sequence[int], prior_windows: Mapping[i
             raise ValueError("every epoch requires exactly 504 prior observations")
         if any(previous >= epoch for previous in prior):
             raise ValueError("prior window contains current or future epoch")
+
+
+def _actual_candle_value(candle: EvidenceCandle, *, mapping_key: str, sequence_index: int) -> int:
+    """Read timestamps from the raw Binance candle payload, never the manifest."""
+    payload = candle.payload
+    if isinstance(payload, Mapping):
+        value = payload.get(mapping_key)
+    else:
+        value = payload[sequence_index]
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"raw candle payload lacks numeric {mapping_key}")
+    return int(value)
+
+
+def assert_signal_execution_forward_only(
+    signal_bar: EvidenceCandle,
+    execution_bar: EvidenceCandle,
+    *,
+    declared_signal_close_time_ms: int,
+) -> None:
+    """Compare actual raw candle timestamps and fail closed on overlap.
+
+    Binance kline arrays use index 0 for open time and index 6 for close time.
+    Mapping payloads may use the corresponding explicit ``*_time_ms`` keys.
+    """
+    actual_signal_close = _actual_candle_value(
+        signal_bar, mapping_key="close_time_ms", sequence_index=6
+    )
+    actual_signal_end = _actual_candle_value(
+        signal_bar, mapping_key="close_time_ms", sequence_index=6
+    )
+    if actual_signal_close != declared_signal_close_time_ms or actual_signal_end != signal_bar.epoch_end_ms:
+        raise ForwardOnlyViolation(
+            "SIGNAL_BAR_CLOSE_MISMATCH",
+            "declared/manifest signal close does not match the raw signal candle close_time",
+        )
+    actual_execution_start = _actual_candle_value(
+        execution_bar, mapping_key="open_time_ms", sequence_index=0
+    )
+    if actual_execution_start < actual_signal_close:
+        raise ForwardOnlyViolation(
+            "NEXT_BAR_OVERLAPS_SIGNAL_BAR",
+            "execution candle starts before the raw signal candle closes",
+        )
 
 
 def build_epoch_manifest(

--- a/tests/research_contracts/test_dfc_2c_4h_v21.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v21.py
@@ -38,6 +38,8 @@ def test_new_identity_and_v2_preservation_are_explicit() -> None:
     assert json.loads(json.dumps(payload, sort_keys=True)) == payload
     assert payload["predecessor_preservation"]["v2_row_mutation"] == "forbidden"
     assert payload["implementation"]["module_source_sha256"] == contract.MODULE_SOURCE_SHA256
+    from research_contracts import dfc_2c_4h_v21_harness as harness
+    assert payload["implementation"]["harness_source_sha256"] == harness.HARNESS_SOURCE_SHA256
 
 
 def test_import_time_source_freeze_is_present_and_runtime_hash_is_current() -> None:
@@ -85,6 +87,8 @@ def test_control_a_is_symmetric_and_adjudication_is_fully_numeric() -> None:
     payload = contract.contract_as_machine_data()
     assert payload["estimand"]["control_choice"] == "A"
     assert payload["estimand"]["selection_symmetric"] is True
+    assert payload["estimand"]["selection_implementation"] == "evaluate_basket argmax over all three scores"
+    assert payload["estimand"]["bootstrap_implementation"] == "stationary_block_bootstrap"
     rule = payload["adjudication"]
     assert rule["delta_threshold_bps"] == 5.0
     assert rule["bootstrap"] == "stationary_block_percentile"
@@ -114,7 +118,7 @@ def test_adopted_backtest_window_is_non_overlapping_and_warmup_is_recomputed() -
 
 
 def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
-    payload = ["x", 1]
+    payload = [0, 1, 2, 3, 4, 5, 14_399_999, 7, 8, 2, 1, 0]
     manifest = {
         "source_id": "binance_usdm.klines_4h", "endpoint_host": "fapi.binance.com",
         "endpoint_path": "/fapi/v1/klines", "endpoint_version": "v1", "symbol": "AAAUSDT",
@@ -123,31 +127,51 @@ def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
         "raw_payload_sha256": raw_payload_sha256(payload), "schema_version": "binance.v1",
     }
     left = EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, tuple(payload), manifest)
-    right = EvidenceCandle("AAAUSDT", "premium", 0, 14_400_000, tuple(payload), {**manifest, "endpoint_path": "/fapi/v1/premiumIndexKlines"})
+    right = EvidenceCandle("AAAUSDT", "premium", 0, 14_400_000, tuple(payload), {**manifest, "endpoint_path": "/fapi/v1/premiumIndexKlines", "source_id": "binance_usdm.premium_index_klines_4h"})
     assert inner_align_4h([left], [right]) == (("AAAUSDT", 0),)
     assert validate_and_sort_candles([left]) == (left,)
-    with pytest.raises(ValueError, match="future"):
-        assert_forward_only([100], {100: tuple(range(252)) + (100,) + tuple(range(252, 503))})
+    with pytest.raises(ValueError, match="prior"):
+        assert_forward_only([100], {100: tuple(range(504))}, prior_evidence={100: ()})
 
 
 def test_harness_blocks_signal_close_execution_overlap_from_raw_payload_times() -> None:
     signal = EvidenceCandle(
         "AAAUSDT", "kline", 0, 14_400_000,
-        (0, 0, 0, 0, 0, 0, 14_400_000), {},
+        (0, 0, 0, 0, 0, 0, 14_399_999, 0, 0, 0, 0, 0), {},
     )
     execution = EvidenceCandle(
         "AAAUSDT", "kline", 10_800_000, 25_200_000,
-        (10_800_000, 0, 0, 0, 0, 0, 25_200_000), {},
+        (10_800_000, 0, 0, 0, 0, 0, 25_199_999, 0, 0, 0, 0, 0), {},
     )
     with pytest.raises(ValueError, match="NEXT_BAR_OVERLAPS_SIGNAL_BAR"):
         assert_signal_execution_forward_only(
-            signal, execution, declared_signal_close_time_ms=14_400_000
+            signal, execution, declared_signal_close_time_ms=14_399_999
         )
 
     with pytest.raises(ValueError, match="SIGNAL_BAR_CLOSE_MISMATCH"):
         assert_signal_execution_forward_only(
-            signal, execution, declared_signal_close_time_ms=14_399_999
+            signal, execution, declared_signal_close_time_ms=14_400_000
         )
+
+
+def test_control_arm_executes_same_selection_and_adjudication() -> None:
+    basket = contract.evaluate_basket({symbol: _epoch(symbol, current=value) for symbol, value in (
+        ("AAAUSDT", 0.2), ("BBBUSDT", 0.1), ("CCCUSDT", 0.0)
+    )})
+    assert basket.winner == "AAAUSDT"
+    observations = tuple(contract.OutcomeObservation(index % 2 == 0, 10.0 if index % 2 == 0 else 1.0) for index in range(800))
+    result = contract.adjudicate_outcomes(observations)
+    assert result.status == "success"
+    assert result.delta_bps == pytest.approx(9.0)
+    assert contract.absolute_log_return_bps(100.0, 101.0) == pytest.approx(99.5033, rel=1e-4)
+    assert contract.make_outcome_observation(True, 100.0, 101.0).candidate is True
+
+
+def test_harness_rejects_short_raw_payload() -> None:
+    payload = (0, 1)
+    manifest = {"source_id": "binance_usdm.klines_4h", "endpoint_host": "fapi.binance.com", "endpoint_path": "/fapi/v1/klines", "endpoint_version": "v1", "symbol": "AAAUSDT", "interval": "4h", "epoch_start_utc": "1970-01-01T00:00:00Z", "epoch_end_utc": "1970-01-01T04:00:00Z", "complete": True, "gap_status": "none", "raw_payload_sha256": raw_payload_sha256(payload), "schema_version": "binance.v1"}
+    with pytest.raises((ValueError, IndexError)):
+        validate_and_sort_candles([EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, payload, manifest)])
 
 
 def test_contract_remains_offline_only() -> None:

--- a/tests/research_contracts/test_dfc_2c_4h_v21.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v21.py
@@ -1,0 +1,119 @@
+"""Adversarial contract tests for the v2.1 re-registration."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+
+import pytest
+
+from research_contracts import dfc_2c_4h_v21 as contract
+from research_contracts.dfc_2c_4h_v21_harness import (
+    EvidenceCandle,
+    assert_forward_only,
+    inner_align_4h,
+    raw_payload_sha256,
+    validate_and_sort_candles,
+)
+
+
+def _epoch(symbol: str, *, current: float = 1.0) -> contract.EpochFeatures:
+    return contract.EpochFeatures(
+        symbol=symbol,
+        integrity=contract.IntegrityState.COMPLETE,
+        current_ofi=current,
+        current_premium_close=current,
+        prior_ofi=(0.0,) * 504,
+        prior_premium_close=(0.0,) * 504,
+        prior_quote_volume_30d=100.0,
+    )
+
+
+def test_new_identity_and_v2_preservation_are_explicit() -> None:
+    payload = contract.contract_as_machine_data()
+    assert contract.CONTRACT_ID == "DFC-2C-4H-v2.1"
+    assert contract.CANONICAL_HASH == contract.canonical_contract_hash()
+    assert json.loads(json.dumps(payload, sort_keys=True)) == payload
+    assert payload["predecessor_preservation"]["v2_row_mutation"] == "forbidden"
+    assert payload["implementation"]["module_source_sha256"] == contract.MODULE_SOURCE_SHA256
+
+
+def test_import_time_source_freeze_is_present_and_runtime_hash_is_current() -> None:
+    source = inspect.getsource(contract)
+    assert "RuntimeError" in source
+    assert len(re.findall(r"^MODULE_SOURCE_SHA256: Final =", source, re.MULTILINE)) == 1
+    assert len(contract.MODULE_SOURCE_SHA256) == 64
+
+
+def test_composite_tail_is_derived_and_input_has_no_prior_composite_argument() -> None:
+    assert "prior_abs_composite" not in inspect.signature(contract.EpochFeatures).parameters
+    assert list(inspect.signature(contract.tail_threshold_q75).parameters) == [
+        "prior_ofi", "prior_premium_close"
+    ]
+    score = contract.score_symbol(_epoch("AAAUSDT"))
+    assert score.threshold == 1.0
+    with pytest.raises(TypeError):
+        contract.tail_threshold_q75((0.0,) * 504, (0.0,) * 504, 0.95)  # type: ignore[call-arg]
+
+
+def test_lookback_rebinding_cannot_change_runtime_windows() -> None:
+    original = contract.PIT_LOOKBACK
+    contract.PIT_LOOKBACK = 300  # type: ignore[misc]
+    try:
+        assert contract.pit_rank(1.0, (0.0,) * 252) == pytest.approx(1.0)
+        with pytest.raises(ValueError, match="exactly 504"):
+            contract.score_symbol(_epoch("AAAUSDT").__class__(
+                symbol="AAAUSDT", integrity=contract.IntegrityState.COMPLETE,
+                current_ofi=1.0, current_premium_close=1.0,
+                prior_ofi=(0.0,) * 300, prior_premium_close=(0.0,) * 300,
+                prior_quote_volume_30d=100.0,
+            ))
+    finally:
+        contract.PIT_LOOKBACK = original  # type: ignore[misc]
+
+
+def test_pit_universe_is_dynamic_and_no_symbols_are_hardcoded() -> None:
+    assert contract.select_universe({"SOLUSDT": 3.0, "XRPUSDT": 2.0, "DOGEUSDT": 1.0, "AAAUSDT": 4.0}) == (
+        "AAAUSDT", "SOLUSDT", "XRPUSDT"
+    )
+    assert contract.contract_as_machine_data()["universe"]["hardcoded_symbols"] is False
+
+
+def test_control_a_is_symmetric_and_adjudication_is_fully_numeric() -> None:
+    payload = contract.contract_as_machine_data()
+    assert payload["estimand"]["control_choice"] == "A"
+    assert payload["estimand"]["selection_symmetric"] is True
+    rule = payload["adjudication"]
+    assert rule["delta_threshold_bps"] == 5.0
+    assert rule["bootstrap"] == "stationary_block_percentile"
+    assert rule["block_length_epochs"] == 24
+    assert rule["repetitions"] == 10_000
+    assert rule["confidence_level"] == 0.95
+    assert rule["alpha"] == 0.05
+    assert rule["minimum_candidate_epochs"] == 400
+    assert rule["minimum_control_epochs"] == 400
+    assert rule["power"]["target"] == 0.80
+
+
+def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
+    payload = ["x", 1]
+    manifest = {
+        "source_id": "binance_usdm.klines_4h", "endpoint_host": "fapi.binance.com",
+        "endpoint_path": "/fapi/v1/klines", "endpoint_version": "v1", "symbol": "AAAUSDT",
+        "interval": "4h", "epoch_start_utc": "2021-05-02T00:00:00Z",
+        "epoch_end_utc": "2021-05-02T04:00:00Z", "complete": True, "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload), "schema_version": "binance.v1",
+    }
+    left = EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, tuple(payload), manifest)
+    right = EvidenceCandle("AAAUSDT", "premium", 0, 14_400_000, tuple(payload), {**manifest, "endpoint_path": "/fapi/v1/premiumIndexKlines"})
+    assert inner_align_4h([left], [right]) == (("AAAUSDT", 0),)
+    assert validate_and_sort_candles([left]) == (left,)
+    with pytest.raises(ValueError, match="future"):
+        assert_forward_only([100], {100: tuple(range(252)) + (100,) + tuple(range(252, 503))})
+
+
+def test_contract_remains_offline_only() -> None:
+    source = inspect.getsource(contract)
+    for forbidden in ("import app", "from app", "httpx", "requests", "socket", "subprocess"):
+        assert forbidden not in source

--- a/tests/research_contracts/test_dfc_2c_4h_v21.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v21.py
@@ -13,21 +13,95 @@ from research_contracts.dfc_2c_4h_v21_harness import (
     EvidenceCandle,
     assert_forward_only,
     assert_signal_execution_forward_only,
+    build_epoch_manifest,
+    epoch_features_from_evidence,
+    evaluate_epoch_basket,
     inner_align_4h,
     raw_payload_sha256,
     validate_and_sort_candles,
 )
 
 
-def _epoch(symbol: str, *, current: float = 1.0) -> contract.EpochFeatures:
-    return contract.EpochFeatures(
+def _epoch(symbol: str, *, current: float = 1.0):
+    klines = []
+    premiums = []
+    for index in range(505):
+        start = index * 14_400_000
+        kline = (
+            start,
+            "1",
+            "1",
+            "1",
+            "1",
+            "2",
+            start + 14_399_999,
+            "10",
+            "1",
+            "1",
+            "1",
+            "0",
+        )
+        premium = (
+            start,
+            "0",
+            "0",
+            "0",
+            str(current if index == 504 else 0.0),
+            "0",
+            start + 14_399_999,
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+        )
+        klines.append(
+            EvidenceCandle(
+                symbol,
+                "kline",
+                start,
+                start + 14_400_000,
+                kline,
+                build_epoch_manifest(
+                    source_id="binance_usdm.klines_4h",
+                    endpoint_host="fapi.binance.com",
+                    endpoint_path="/fapi/v1/klines",
+                    endpoint_version="v1",
+                    symbol=symbol,
+                    epoch_start_utc="1970-01-01T00:00:00Z",
+                    epoch_end_utc="1970-01-01T04:00:00Z",
+                    payload=kline,
+                    schema_version="binance.v1",
+                ),
+            )
+        )
+        premiums.append(
+            EvidenceCandle(
+                symbol,
+                "premium",
+                start,
+                start + 14_400_000,
+                premium,
+                build_epoch_manifest(
+                    source_id="binance_usdm.premium_index_klines_4h",
+                    endpoint_host="fapi.binance.com",
+                    endpoint_path="/fapi/v1/premiumIndexKlines",
+                    endpoint_version="v1",
+                    symbol=symbol,
+                    epoch_start_utc="1970-01-01T00:00:00Z",
+                    epoch_end_utc="1970-01-01T04:00:00Z",
+                    payload=premium,
+                    schema_version="binance.v1",
+                ),
+            )
+        )
+    return epoch_features_from_evidence(
         symbol=symbol,
-        integrity=contract.IntegrityState.COMPLETE,
-        current_ofi=current,
-        current_premium_close=current,
-        prior_ofi=(0.0,) * 504,
-        prior_premium_close=(0.0,) * 504,
-        prior_quote_volume_30d=100.0,
+        current_kline=klines[-1],
+        current_premium=premiums[-1],
+        prior_klines=klines[:-1],
+        prior_premium=premiums[:-1],
+        prior_30d_quote_volume=100.0,
     )
 
 
@@ -37,9 +111,16 @@ def test_new_identity_and_v2_preservation_are_explicit() -> None:
     assert contract.CANONICAL_HASH == contract.canonical_contract_hash()
     assert json.loads(json.dumps(payload, sort_keys=True)) == payload
     assert payload["predecessor_preservation"]["v2_row_mutation"] == "forbidden"
-    assert payload["implementation"]["module_source_sha256"] == contract.MODULE_SOURCE_SHA256
+    assert (
+        payload["implementation"]["module_source_sha256"]
+        == contract.MODULE_SOURCE_SHA256
+    )
     from research_contracts import dfc_2c_4h_v21_harness as harness
-    assert payload["implementation"]["harness_source_sha256"] == harness.HARNESS_SOURCE_SHA256
+
+    assert (
+        payload["implementation"]["harness_source_sha256"]
+        == harness.HARNESS_SOURCE_SHA256
+    )
 
 
 def test_import_time_source_freeze_is_present_and_runtime_hash_is_current() -> None:
@@ -50,9 +131,10 @@ def test_import_time_source_freeze_is_present_and_runtime_hash_is_current() -> N
 
 
 def test_composite_tail_is_derived_and_input_has_no_prior_composite_argument() -> None:
-    assert "prior_abs_composite" not in inspect.signature(contract.EpochFeatures).parameters
+    assert not hasattr(contract, "EpochFeatures")
     assert list(inspect.signature(contract.tail_threshold_q75).parameters) == [
-        "prior_ofi", "prior_premium_close"
+        "prior_ofi",
+        "prior_premium_close",
     ]
     score = contract.score_symbol(_epoch("AAAUSDT"))
     assert score.threshold == 1.0
@@ -65,21 +147,26 @@ def test_lookback_rebinding_cannot_change_runtime_windows() -> None:
     contract.PIT_LOOKBACK = 300  # type: ignore[misc]
     try:
         assert contract.pit_rank(1.0, (0.0,) * 252) == pytest.approx(1.0)
-        with pytest.raises(ValueError, match="exactly 504"):
-            contract.score_symbol(_epoch("AAAUSDT").__class__(
-                symbol="AAAUSDT", integrity=contract.IntegrityState.COMPLETE,
-                current_ofi=1.0, current_premium_close=1.0,
-                prior_ofi=(0.0,) * 300, prior_premium_close=(0.0,) * 300,
-                prior_quote_volume_30d=100.0,
-            ))
+        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+            contract.score_symbol(
+                _epoch("AAAUSDT").__class__(
+                    symbol="AAAUSDT",
+                    integrity=contract.IntegrityState.COMPLETE,
+                    current_ofi=1.0,
+                    current_premium_close=1.0,
+                    prior_ofi=(0.0,) * 300,
+                    prior_premium_close=(0.0,) * 300,
+                    prior_quote_volume_30d=100.0,
+                )
+            )
     finally:
         contract.PIT_LOOKBACK = original  # type: ignore[misc]
 
 
 def test_pit_universe_is_dynamic_and_no_symbols_are_hardcoded() -> None:
-    assert contract.select_universe({"SOLUSDT": 3.0, "XRPUSDT": 2.0, "DOGEUSDT": 1.0, "AAAUSDT": 4.0}) == (
-        "AAAUSDT", "SOLUSDT", "XRPUSDT"
-    )
+    assert contract.select_universe(
+        {"SOLUSDT": 3.0, "XRPUSDT": 2.0, "DOGEUSDT": 1.0, "AAAUSDT": 4.0}
+    ) == ("AAAUSDT", "SOLUSDT", "XRPUSDT")
     assert contract.contract_as_machine_data()["universe"]["hardcoded_symbols"] is False
 
 
@@ -87,8 +174,13 @@ def test_control_a_is_symmetric_and_adjudication_is_fully_numeric() -> None:
     payload = contract.contract_as_machine_data()
     assert payload["estimand"]["control_choice"] == "A"
     assert payload["estimand"]["selection_symmetric"] is True
-    assert payload["estimand"]["selection_implementation"] == "evaluate_basket argmax over all three scores"
-    assert payload["estimand"]["bootstrap_implementation"] == "stationary_block_bootstrap"
+    assert (
+        payload["estimand"]["selection_implementation"]
+        == "evaluate_basket argmax over all three scores"
+    )
+    assert (
+        payload["estimand"]["bootstrap_implementation"] == "stationary_block_bootstrap"
+    )
     rule = payload["adjudication"]
     assert rule["delta_threshold_bps"] == 5.0
     assert rule["bootstrap"] == "stationary_block_percentile"
@@ -113,21 +205,41 @@ def test_adopted_backtest_window_is_non_overlapping_and_warmup_is_recomputed() -
         "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop"
     )
     isolation = payload["exploration_isolation"]
-    assert isolation["relationship"] == "no overlap remains in the adopted backtest window"
+    assert (
+        isolation["relationship"] == "no overlap remains in the adopted backtest window"
+    )
     assert isolation["excluded_overlap_epochs"] == 1_632
 
 
 def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
     payload = [0, 1, 2, 3, 4, 5, 14_399_999, 7, 8, 2, 1, 0]
     manifest = {
-        "source_id": "binance_usdm.klines_4h", "endpoint_host": "fapi.binance.com",
-        "endpoint_path": "/fapi/v1/klines", "endpoint_version": "v1", "symbol": "AAAUSDT",
-        "interval": "4h", "epoch_start_utc": "2021-05-02T00:00:00Z",
-        "epoch_end_utc": "2021-05-02T04:00:00Z", "complete": True, "gap_status": "none",
-        "raw_payload_sha256": raw_payload_sha256(payload), "schema_version": "binance.v1",
+        "source_id": "binance_usdm.klines_4h",
+        "endpoint_host": "fapi.binance.com",
+        "endpoint_path": "/fapi/v1/klines",
+        "endpoint_version": "v1",
+        "symbol": "AAAUSDT",
+        "interval": "4h",
+        "epoch_start_utc": "2021-05-02T00:00:00Z",
+        "epoch_end_utc": "2021-05-02T04:00:00Z",
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": "binance.v1",
     }
     left = EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, tuple(payload), manifest)
-    right = EvidenceCandle("AAAUSDT", "premium", 0, 14_400_000, tuple(payload), {**manifest, "endpoint_path": "/fapi/v1/premiumIndexKlines", "source_id": "binance_usdm.premium_index_klines_4h"})
+    right = EvidenceCandle(
+        "AAAUSDT",
+        "premium",
+        0,
+        14_400_000,
+        tuple(payload),
+        {
+            **manifest,
+            "endpoint_path": "/fapi/v1/premiumIndexKlines",
+            "source_id": "binance_usdm.premium_index_klines_4h",
+        },
+    )
     assert inner_align_4h([left], [right]) == (("AAAUSDT", 0),)
     assert validate_and_sort_candles([left]) == (left,)
     with pytest.raises(ValueError, match="prior"):
@@ -136,12 +248,20 @@ def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
 
 def test_harness_blocks_signal_close_execution_overlap_from_raw_payload_times() -> None:
     signal = EvidenceCandle(
-        "AAAUSDT", "kline", 0, 14_400_000,
-        (0, 0, 0, 0, 0, 0, 14_399_999, 0, 0, 0, 0, 0), {},
+        "AAAUSDT",
+        "kline",
+        0,
+        14_400_000,
+        (0, 0, 0, 0, 0, 0, 14_399_999, 0, 0, 0, 0, 0),
+        {},
     )
     execution = EvidenceCandle(
-        "AAAUSDT", "kline", 10_800_000, 25_200_000,
-        (10_800_000, 0, 0, 0, 0, 0, 25_199_999, 0, 0, 0, 0, 0), {},
+        "AAAUSDT",
+        "kline",
+        10_800_000,
+        25_200_000,
+        (10_800_000, 0, 0, 0, 0, 0, 25_199_999, 0, 0, 0, 0, 0),
+        {},
     )
     with pytest.raises(ValueError, match="NEXT_BAR_OVERLAPS_SIGNAL_BAR"):
         assert_signal_execution_forward_only(
@@ -155,26 +275,172 @@ def test_harness_blocks_signal_close_execution_overlap_from_raw_payload_times() 
 
 
 def test_control_arm_executes_same_selection_and_adjudication() -> None:
-    basket = contract.evaluate_basket({symbol: _epoch(symbol, current=value) for symbol, value in (
-        ("AAAUSDT", 0.2), ("BBBUSDT", 0.1), ("CCCUSDT", 0.0)
-    )})
+    basket = evaluate_epoch_basket(
+        dict.fromkeys(("AAAUSDT", "BBBUSDT", "CCCUSDT"), 100.0),
+        {
+            symbol: _epoch(symbol, current=value)
+            for symbol, value in (("AAAUSDT", 0.2), ("BBBUSDT", 0.1), ("CCCUSDT", 0.0))
+        },
+    )
     assert basket.winner == "AAAUSDT"
-    observations = tuple(contract.OutcomeObservation(index % 2 == 0, 10.0 if index % 2 == 0 else 1.0) for index in range(800))
+    observations = tuple(
+        contract.OutcomeObservation(index % 2 == 0, 10.0 if index % 2 == 0 else 1.0)
+        for index in range(800)
+    )
     result = contract.adjudicate_outcomes(observations)
     assert result.status == "success"
     assert result.delta_bps == pytest.approx(9.0)
-    assert contract.absolute_log_return_bps(100.0, 101.0) == pytest.approx(99.5033, rel=1e-4)
+    assert contract.absolute_log_return_bps(100.0, 101.0) == pytest.approx(
+        99.5033, rel=1e-4
+    )
     assert contract.make_outcome_observation(True, 100.0, 101.0).candidate is True
 
 
 def test_harness_rejects_short_raw_payload() -> None:
     payload = (0, 1)
-    manifest = {"source_id": "binance_usdm.klines_4h", "endpoint_host": "fapi.binance.com", "endpoint_path": "/fapi/v1/klines", "endpoint_version": "v1", "symbol": "AAAUSDT", "interval": "4h", "epoch_start_utc": "1970-01-01T00:00:00Z", "epoch_end_utc": "1970-01-01T04:00:00Z", "complete": True, "gap_status": "none", "raw_payload_sha256": raw_payload_sha256(payload), "schema_version": "binance.v1"}
+    manifest = {
+        "source_id": "binance_usdm.klines_4h",
+        "endpoint_host": "fapi.binance.com",
+        "endpoint_path": "/fapi/v1/klines",
+        "endpoint_version": "v1",
+        "symbol": "AAAUSDT",
+        "interval": "4h",
+        "epoch_start_utc": "1970-01-01T00:00:00Z",
+        "epoch_end_utc": "1970-01-01T04:00:00Z",
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": "binance.v1",
+    }
     with pytest.raises((ValueError, IndexError)):
-        validate_and_sort_candles([EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, payload, manifest)])
+        validate_and_sort_candles(
+            [EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, payload, manifest)]
+        )
 
 
 def test_contract_remains_offline_only() -> None:
     source = inspect.getsource(contract)
-    for forbidden in ("import app", "from app", "httpx", "requests", "socket", "subprocess"):
+    for forbidden in (
+        "import app",
+        "from app",
+        "httpx",
+        "requests",
+        "socket",
+        "subprocess",
+    ):
         assert forbidden not in source
+
+
+def test_raw_mapping_values_are_bound_to_the_evidence_hash() -> None:
+    left = {"open_time_ms": 0, "close_time_ms": 14_399_999, "volume": 1000.0}
+    right = {"open_time_ms": 0, "close_time_ms": 14_399_999, "volume": 1.0}
+    assert raw_payload_sha256(left) != raw_payload_sha256(right)
+
+
+def test_feature_builder_rejects_future_prior_candle() -> None:
+    feature = _epoch("AAAUSDT")
+    # Rebuild the same clean window, but replace the first prior with a candle
+    # after the explicitly supplied current candle.
+    starts = [index * 14_400_000 for index in range(505)]
+    current_start = starts[-1]
+    future_start = starts[-1] + 14_400_000
+
+    def candle(start: int, source: str, payload: tuple[object, ...]) -> EvidenceCandle:
+        return EvidenceCandle(
+            "AAAUSDT",
+            source,
+            start,
+            start + 14_400_000,
+            payload,
+            build_epoch_manifest(
+                source_id="binance_usdm.klines_4h"
+                if source == "kline"
+                else "binance_usdm.premium_index_klines_4h",
+                endpoint_host="fapi.binance.com",
+                endpoint_path="/fapi/v1/klines"
+                if source == "kline"
+                else "/fapi/v1/premiumIndexKlines",
+                endpoint_version="v1",
+                symbol="AAAUSDT",
+                epoch_start_utc="1970-01-01T00:00:00Z",
+                epoch_end_utc="1970-01-01T04:00:00Z",
+                payload=payload,
+                schema_version="binance.v1",
+            ),
+        )
+
+    def kline(start: int) -> EvidenceCandle:
+        return candle(
+            start,
+            "kline",
+            (
+                start,
+                "1",
+                "1",
+                "1",
+                "1",
+                "2",
+                start + 14_399_999,
+                "10",
+                "1",
+                "1",
+                "1",
+                "0",
+            ),
+        )
+
+    def premium(start: int) -> EvidenceCandle:
+        return candle(
+            start,
+            "premium",
+            (
+                start,
+                "0",
+                "0",
+                "0",
+                "0",
+                "0",
+                start + 14_399_999,
+                "0",
+                "0",
+                "0",
+                "0",
+                "0",
+            ),
+        )
+
+    prior_kline = [kline(start) for start in starts[:-1]]
+    prior_premium = [premium(start) for start in starts[:-1]]
+    prior_kline[0] = kline(future_start)
+    with pytest.raises(ValueError, match="latest|contiguous|strictly prior"):
+        epoch_features_from_evidence(
+            symbol="AAAUSDT",
+            current_kline=kline(current_start),
+            current_premium=premium(current_start),
+            prior_klines=prior_kline,
+            prior_premium=prior_premium,
+            prior_30d_quote_volume=100.0,
+        )
+    assert feature.evidence.current_epoch_start_ms == current_start
+
+
+def test_feature_builder_rejects_cross_endpoint_roles() -> None:
+    feature = _epoch("AAAUSDT")
+    with pytest.raises(ValueError, match="wrong source"):
+        epoch_features_from_evidence(
+            symbol="AAAUSDT",
+            current_kline=EvidenceCandle(
+                "AAAUSDT", "kline", 0, 14_400_000, (0,) * 12, {}
+            ),
+            current_premium=EvidenceCandle(
+                "AAAUSDT", "premium", 0, 14_400_000, (0,) * 12, {}
+            ),
+            prior_klines=(),
+            prior_premium=(),
+            prior_30d_quote_volume=100.0,
+        )
+    with pytest.raises(TypeError, match="evidence-bound"):
+        contract.score_symbol({})  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="evidence-bound PIT"):
+        contract.evaluate_basket({})  # type: ignore[arg-type]
+    assert feature.symbol == "AAAUSDT"

--- a/tests/research_contracts/test_dfc_2c_4h_v21.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v21.py
@@ -97,6 +97,22 @@ def test_control_a_is_symmetric_and_adjudication_is_fully_numeric() -> None:
     assert rule["power"]["target"] == 0.80
 
 
+def test_adopted_backtest_window_is_non_overlapping_and_warmup_is_recomputed() -> None:
+    payload = contract.contract_as_machine_data()
+    window = payload["backtest_window"]
+    assert window["holdout_start_utc"] == "2021-05-02T00:00:00Z"
+    assert window["holdout_end_utc_exclusive"] == "2023-08-04T00:00:00Z"
+    assert window["calendar_days"] == 824
+    assert window["scheduled_epochs"] == 4_944
+    assert window["warmup_start_utc"] == "2021-02-02T00:00:00Z"
+    assert window["selection_basis"] == (
+        "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop"
+    )
+    isolation = payload["exploration_isolation"]
+    assert isolation["relationship"] == "no overlap remains in the adopted backtest window"
+    assert isolation["excluded_overlap_epochs"] == 1_632
+
+
 def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
     payload = ["x", 1]
     manifest = {

--- a/tests/research_contracts/test_dfc_2c_4h_v21.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v21.py
@@ -12,6 +12,7 @@ from research_contracts import dfc_2c_4h_v21 as contract
 from research_contracts.dfc_2c_4h_v21_harness import (
     EvidenceCandle,
     assert_forward_only,
+    assert_signal_execution_forward_only,
     inner_align_4h,
     raw_payload_sha256,
     validate_and_sort_candles,
@@ -111,6 +112,26 @@ def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
     assert validate_and_sort_candles([left]) == (left,)
     with pytest.raises(ValueError, match="future"):
         assert_forward_only([100], {100: tuple(range(252)) + (100,) + tuple(range(252, 503))})
+
+
+def test_harness_blocks_signal_close_execution_overlap_from_raw_payload_times() -> None:
+    signal = EvidenceCandle(
+        "AAAUSDT", "kline", 0, 14_400_000,
+        (0, 0, 0, 0, 0, 0, 14_400_000), {},
+    )
+    execution = EvidenceCandle(
+        "AAAUSDT", "kline", 10_800_000, 25_200_000,
+        (10_800_000, 0, 0, 0, 0, 0, 25_200_000), {},
+    )
+    with pytest.raises(ValueError, match="NEXT_BAR_OVERLAPS_SIGNAL_BAR"):
+        assert_signal_execution_forward_only(
+            signal, execution, declared_signal_close_time_ms=14_400_000
+        )
+
+    with pytest.raises(ValueError, match="SIGNAL_BAR_CLOSE_MISMATCH"):
+        assert_signal_execution_forward_only(
+            signal, execution, declared_signal_close_time_ms=14_399_999
+        )
 
 
 def test_contract_remains_offline_only() -> None:


### PR DESCRIPTION
## Summary
- Register DFC-2C-4H-v2.1 as a new three-year contract identity.
- Preserve the sealed DFC-2C-4H-v2 artifact unchanged.
- Add symmetric matched control A, pre-registered adjudication values, derived tail history, PIT universe rule, implementation source freeze, and read-only evidence harness.

## Verification
- `uv run pytest tests/research_contracts/test_dfc_2c_4h_v21.py -q` — 8 passed
- `uv run ruff check research_contracts/dfc_2c_4h_v21.py research_contracts/dfc_2c_4h_v21_harness.py tests/research_contracts/test_dfc_2c_4h_v21.py` — All checks passed
- No backtest, orders, demo, account, broker API, scheduler, or merge performed.

## T3 note
R2 found that the new harness's forward-only assertion checks only supplied prior timestamps versus the epoch. It does not accept signal-bar close and execution-bar start timestamps; a constructed signal-close-after-execution-start case was accepted. This is reported for independent T3 adjudication; this PR does not silently claim that gap is fixed.
