### PR TITLE
fix(backfill): add preflight and reliable exit codes

### DIFF
--- a/app/services/brokers/kis/domestic_market_data.py
+++ b/app/services/brokers/kis/domestic_market_data.py
@@ -723,7 +723,18 @@ class DomesticMarketDataMixin(MarketDataBase):
             api_name="inquire_time_dailychartprice",
         )
 
-        rows = js.get("output2") or js.get("output") or []
+        if "output2" in js:
+            rows = js["output2"]
+        elif "output" in js:
+            rows = js["output"]
+        else:
+            raise RuntimeError(
+                "Malformed KIS minute chart response: missing output2/output"
+            )
+        if not isinstance(rows, list):
+            raise RuntimeError(
+                "Malformed KIS minute chart response: expected output2/output list"
+            )
         if not rows:
             return pd.DataFrame(
                 columns=[

--- a/app/services/brokers/kiwoom/auth.py
+++ b/app/services/brokers/kiwoom/auth.py
@@ -15,6 +15,7 @@ import datetime as dt
 import hashlib
 import json
 import logging
+import os
 import random
 import time
 import uuid
@@ -34,6 +35,10 @@ TOKEN_WAIT_POLL_SECONDS: float = 0.05
 
 _redis_client: redis.Redis | None = None
 
+_REDIS_MAX_CONNECTIONS_DEFAULT: Final[int] = 20
+_REDIS_SOCKET_TIMEOUT_DEFAULT: Final[float] = 5.0
+_REDIS_SOCKET_CONNECT_TIMEOUT_DEFAULT: Final[float] = 5.0
+
 
 @dataclass(frozen=True)
 class KiwoomToken:
@@ -45,18 +50,49 @@ class KiwoomTokenIssuanceUnavailable(RuntimeError):
     """Raised when another issuer never publishes a usable token."""
 
 
+class KiwoomRedisConfigurationError(RuntimeError):
+    """Raised with env names only when scoped Redis configuration is invalid."""
+
+
+def _positive_number_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise KiwoomRedisConfigurationError(f"invalid numeric env: {name}") from exc
+    if value <= 0:
+        raise KiwoomRedisConfigurationError(f"non-positive numeric env: {name}")
+    return value
+
+
+def _redis_client_from_env() -> redis.Redis:
+    redis_url = str(os.getenv("REDIS_URL", "")).strip()
+    if not redis_url:
+        raise KiwoomRedisConfigurationError("missing required env: REDIS_URL")
+    max_connections = _positive_number_env(
+        "REDIS_MAX_CONNECTIONS", float(_REDIS_MAX_CONNECTIONS_DEFAULT)
+    )
+    socket_timeout = _positive_number_env(
+        "REDIS_SOCKET_TIMEOUT", _REDIS_SOCKET_TIMEOUT_DEFAULT
+    )
+    socket_connect_timeout = _positive_number_env(
+        "REDIS_SOCKET_CONNECT_TIMEOUT", _REDIS_SOCKET_CONNECT_TIMEOUT_DEFAULT
+    )
+    return redis.from_url(
+        redis_url,
+        max_connections=int(max_connections),
+        socket_timeout=socket_timeout,
+        socket_connect_timeout=socket_connect_timeout,
+        decode_responses=True,
+    )
+
+
 async def _get_redis_client() -> redis.Redis:
     global _redis_client
     if _redis_client is None:
-        from app.core.config import settings
-
-        _redis_client = redis.from_url(
-            settings.get_redis_url(),
-            max_connections=settings.redis_max_connections,
-            socket_timeout=settings.redis_socket_timeout,
-            socket_connect_timeout=settings.redis_socket_connect_timeout,
-            decode_responses=True,
-        )
+        _redis_client = _redis_client_from_env()
     return _redis_client
 
 

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -23,13 +23,21 @@ _log = logging.getLogger(__name__)
 _AUTH_REJECT_RETURN_CODE: Final[int] = 8005
 # ROB-733-style fail-closed bound: a loop counter, never recursive resubmission.
 _MAX_TOKEN_REFRESH_RESUBMITS: Final[int] = 1
-# Explicit allowlist keeps every domestic/US order mutation out of token retry.
-_AUTH_RETRY_READ_API_IDS: Final[frozenset[str]] = frozenset(
+AUTH_STALE_TOKEN: Final[str] = "AUTH_STALE_TOKEN"
+PROVIDER_REJECTED: Final[str] = "PROVIDER_REJECTED"
+MALFORMED_RESPONSE: Final[str] = "MALFORMED_RESPONSE"
+_CHART_READ_API_IDS: Final[frozenset[str]] = frozenset(
     {
         constants.CHART_MINUTE_API_ID,
         constants.CHART_DAILY_API_ID,
         constants.CHART_WEEKLY_API_ID,
         constants.CHART_MONTHLY_API_ID,
+    }
+)
+# Explicit allowlist keeps every domestic/US order mutation out of token retry.
+_AUTH_RETRY_READ_API_IDS: Final[frozenset[str]] = frozenset(
+    _CHART_READ_API_IDS
+    | {
         constants.ACCOUNT_ORDER_DETAIL_API_ID,
         constants.ACCOUNT_ORDER_STATUS_API_ID,
         constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
@@ -50,6 +58,16 @@ def _is_auth_rejection(payload: dict[str, Any]) -> bool:
         return True
     return_msg = str(payload.get("return_msg") or "")
     return re.search(r"(?<!\d)8005(?!\d)", return_msg) is not None
+
+
+def _strict_return_code(payload: dict[str, Any]) -> int | None:
+    raw = payload.get("return_code")
+    if isinstance(raw, bool):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
 
 
 class KiwoomConfigurationError(RuntimeError):
@@ -78,6 +96,28 @@ class KiwoomPreDispatchError(RuntimeError):
         super().__init__(
             f"Kiwoom request failed before dispatch "
             f"(stage={stage}, api_id={api_id}, cause_type={cause_type})"
+        )
+
+
+class KiwoomReadResponseError(RuntimeError):
+    """Typed, value-redacted failure for a read-only provider response."""
+
+    def __init__(
+        self,
+        *,
+        reason_code: str,
+        api_id: str,
+        return_code: int | None,
+        retry_disposition: str,
+    ) -> None:
+        self.reason_code = reason_code
+        self.api_id = api_id
+        self.return_code = return_code
+        self.retry_disposition = retry_disposition
+        super().__init__(
+            "Kiwoom read response rejected "
+            f"reason_code={reason_code} api_id={api_id} "
+            f"return_code={return_code!r} retry={retry_disposition}"
         )
 
 
@@ -236,6 +276,31 @@ class KiwoomMockClient:
                         cause_type=type(exc).__name__,
                     ) from exc
                 continue
+
+            if api_id in _AUTH_RETRY_READ_API_IDS and _is_auth_rejection(payload):
+                raise KiwoomReadResponseError(
+                    reason_code=AUTH_STALE_TOKEN,
+                    api_id=api_id,
+                    return_code=_strict_return_code(payload),
+                    retry_disposition="RETRIED_ONCE_THEN_STOP",
+                )
+
+            if api_id in _CHART_READ_API_IDS:
+                return_code = _strict_return_code(payload)
+                if return_code is None:
+                    raise KiwoomReadResponseError(
+                        reason_code=MALFORMED_RESPONSE,
+                        api_id=api_id,
+                        return_code=None,
+                        retry_disposition="STOP_NO_RETRY",
+                    )
+                if return_code != constants.SUCCESS_RETURN_CODE:
+                    raise KiwoomReadResponseError(
+                        reason_code=PROVIDER_REJECTED,
+                        api_id=api_id,
+                        return_code=return_code,
+                        retry_disposition="STOP_NO_RETRY",
+                    )
 
             if int(payload.get("return_code", 0)) != constants.SUCCESS_RETURN_CODE:
                 _log.info(

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -10,6 +10,7 @@ so callers cannot smuggle in the live host. The token is fetched via
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Final
 
 import httpx
@@ -25,6 +26,10 @@ _MAX_TOKEN_REFRESH_RESUBMITS: Final[int] = 1
 # Explicit allowlist keeps every domestic/US order mutation out of token retry.
 _AUTH_RETRY_READ_API_IDS: Final[frozenset[str]] = frozenset(
     {
+        constants.CHART_MINUTE_API_ID,
+        constants.CHART_DAILY_API_ID,
+        constants.CHART_WEEKLY_API_ID,
+        constants.CHART_MONTHLY_API_ID,
         constants.ACCOUNT_ORDER_DETAIL_API_ID,
         constants.ACCOUNT_ORDER_STATUS_API_ID,
         constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
@@ -37,6 +42,14 @@ _AUTH_RETRY_READ_API_IDS: Final[frozenset[str]] = frozenset(
         constants.US_ACCOUNT_FOREIGN_DEPOSIT_API_ID,
     }
 )
+
+
+def _is_auth_rejection(payload: dict[str, Any]) -> bool:
+    """Recognize both documented and observed Kiwoom 8005 response shapes."""
+    if str(payload.get("return_code", "")).strip() == str(_AUTH_REJECT_RETURN_CODE):
+        return True
+    return_msg = str(payload.get("return_msg") or "")
+    return re.search(r"(?<!\d)8005(?!\d)", return_msg) is not None
 
 
 class KiwoomConfigurationError(RuntimeError):
@@ -207,8 +220,7 @@ class KiwoomMockClient:
             }
             if (
                 api_id in _AUTH_RETRY_READ_API_IDS
-                and payload.get("return_code")
-                in {_AUTH_REJECT_RETURN_CODE, str(_AUTH_REJECT_RETURN_CODE)}
+                and _is_auth_rejection(payload)
                 and token_refresh_resubmits < _MAX_TOKEN_REFRESH_RESUBMITS
             ):
                 token_refresh_resubmits += 1

--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -43,6 +43,7 @@ TRADE_TYPE_SELL = "1"  # 매도
 TRADE_TYPE_BUY = "2"  # 매수
 
 # Chart API IDs (scaffolded, deferred — NOT routed from get_ohlcv)
+CHART_PATH = "/api/dostk/chart"
 CHART_MINUTE_API_ID = "ka10080"
 CHART_DAILY_API_ID = "ka10081"
 CHART_WEEKLY_API_ID = "ka10082"

--- a/app/services/brokers/kiwoom/live_market_data.py
+++ b/app/services/brokers/kiwoom/live_market_data.py
@@ -53,6 +53,7 @@ from app.services.brokers.kiwoom.constants import (
     CHART_DAILY_API_ID,
     CHART_MINUTE_API_ID,
     CHART_MONTHLY_API_ID,
+    CHART_PATH,
     CHART_WEEKLY_API_ID,
     DEFAULT_TIMEOUT,
     HEADER_API_ID,
@@ -72,9 +73,6 @@ _log = logging.getLogger(__name__)
 # --------------------------------------------------------------------------
 # Allowlists (items 3 and 4)
 # --------------------------------------------------------------------------
-
-#: Official doc (ka10080-ka10083): URL is ``/api/dostk/chart`` for all four.
-CHART_PATH: Final[str] = "/api/dostk/chart"
 
 #: The only api-ids this client may ever send. Read-only chart TRs.
 ALLOWED_API_IDS: Final[frozenset[str]] = frozenset(

--- a/app/services/brokers/toss/dto.py
+++ b/app/services/brokers/toss/dto.py
@@ -314,6 +314,8 @@ class TossCandlesPage:
 
 
 def parse_candles(raw: dict[str, Any]) -> TossCandlesPage:
+    if "candles" not in raw or not isinstance(raw["candles"], list):
+        raise ValueError("Malformed Toss candles response: expected candles list")
     candles = [
         TossCandle(
             timestamp=str(row["timestamp"]),
@@ -324,7 +326,7 @@ def parse_candles(raw: dict[str, Any]) -> TossCandlesPage:
             volume=parse_decimal_string(row["volume"]),
             currency=str(row["currency"]),
         )
-        for row in raw.get("candles", [])
+        for row in raw["candles"]
     ]
     next_before = raw.get("nextBefore")
     return TossCandlesPage(

--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -68,6 +68,9 @@ ON CONFLICT (time_utc, symbol, venue) DO NOTHING
 #: Latency regression threshold vs the Stage A baseline median (2.127 ms).
 LATENCY_ABORT_FACTOR = 5.0
 MAX_CONSECUTIVE_429 = 3
+EXIT_SUCCESS = 0
+EXIT_PARTIAL_FAILURE = 1
+EXIT_TOTAL_FAILURE = 2
 
 # DB 권한으로 대체됨(role auto_trader_kr_backfill, 2026-08-04 적용).
 # 행수 감시는 프로덕션 동시 쓰기와 구분 불가.
@@ -311,6 +314,7 @@ async def run_stream(
                     guard.note_429(source, False)
                 except Exception as exc:  # noqa: BLE001
                     msg = f"{type(exc).__name__}: {exc}"
+                    stats.calls = pacer.calls
                     guard.note_429(source, "429" in msg or "TooManyRequests" in msg)
                     stats.errors.append(f"{symbol}: {msg}")
                     log.write(
@@ -384,6 +388,27 @@ async def run_stream(
         await guard.check(source)
 
     return stats
+
+
+def exit_code_for_results(results: list[StreamStats | BaseException]) -> int:
+    """Return 0=all useful+clean, 1=partial, 2=no useful successful work."""
+    any_useful_work = False
+    any_failure = False
+    for result in results:
+        if isinstance(result, BaseException):
+            any_failure = True
+            continue
+        useful = result.rows_fetched > 0
+        any_useful_work = any_useful_work or useful
+        clean = useful and not result.errors and result.stopped_reason is None
+        if not clean:
+            any_failure = True
+
+    if not any_useful_work:
+        return EXIT_TOTAL_FAILURE
+    if any_failure:
+        return EXIT_PARTIAL_FAILURE
+    return EXIT_SUCCESS
 
 
 async def main() -> int:
@@ -492,7 +517,7 @@ async def main() -> int:
     )
     print(json.dumps(summary, indent=2, default=str, ensure_ascii=False))
     log.close()
-    return 0
+    return exit_code_for_results(results)
 
 
 if __name__ == "__main__":

--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -35,6 +35,8 @@ from typing import Any
 
 import asyncpg
 from sources import (  # noqa: E402
+    AUTH_STALE_TOKEN,
+    EMPTY_RESPONSE,
     KST,
     FetchWindowClosed,
     Pacer,
@@ -85,6 +87,8 @@ class StreamStats:
     rows_fetched: int = 0
     rows_inserted: int = 0
     rows_skipped_conflict: int = 0
+    empty_responses: int = 0
+    empty_symbols: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     stopped_reason: str | None = None
 
@@ -314,6 +318,7 @@ async def run_stream(
                     guard.note_429(source, False)
                 except Exception as exc:  # noqa: BLE001
                     msg = f"{type(exc).__name__}: {exc}"
+                    reason_code = str(getattr(exc, "reason_code", type(exc).__name__))
                     stats.calls = pacer.calls
                     guard.note_429(source, "429" in msg or "TooManyRequests" in msg)
                     stats.errors.append(f"{symbol}: {msg}")
@@ -323,12 +328,34 @@ async def run_stream(
                             "source": source,
                             "symbol": symbol,
                             "error": msg,
+                            "reason_code": reason_code,
+                            "retry_disposition": getattr(
+                                exc, "retry_disposition", "NONE"
+                            ),
                         }
                     )
+                    if reason_code == AUTH_STALE_TOKEN:
+                        stats.stopped_reason = (
+                            "AUTH_STALE_TOKEN after one read-only retry"
+                        )
+                        ckpt.save()
+                        return stats
                     break
 
                 stats.calls = pacer.calls
                 if not bars:
+                    reason_code = str(meta.get("outcome_code") or EMPTY_RESPONSE)
+                    stats.empty_responses += 1
+                    stats.empty_symbols.append(symbol)
+                    log.write(
+                        {
+                            "event": "empty_response",
+                            "source": source,
+                            "symbol": symbol,
+                            "reason_code": reason_code,
+                            "calls_cumulative": pacer.calls,
+                        }
+                    )
                     st["done"] = True
                     break
 
@@ -400,7 +427,12 @@ def exit_code_for_results(results: list[StreamStats | BaseException]) -> int:
             continue
         useful = result.rows_fetched > 0
         any_useful_work = any_useful_work or useful
-        clean = useful and not result.errors and result.stopped_reason is None
+        clean = (
+            useful
+            and not result.errors
+            and result.stopped_reason is None
+            and result.empty_responses == 0
+        )
         if not clean:
             any_failure = True
 

--- a/research/kr_backfill/preflight.py
+++ b/research/kr_backfill/preflight.py
@@ -110,7 +110,6 @@ async def _check_offline_fetch(report: PreflightReport, client: Any) -> None:
                         "low_pric": "99",
                         "cur_prc": "100",
                         "trde_qty": "10",
-                        "trde_prica": "1000",
                     }
                 ],
             },
@@ -130,7 +129,13 @@ async def _check_offline_fetch(report: PreflightReport, client: Any) -> None:
             max_pages=1,
             base_dt="20260801",
         )
-        if len(rows) != 1 or meta.get("pages") != 1 or seen_hosts != [ALLOWED_HOST]:
+        only_row = next(iter(rows.values()), {})
+        if (
+            len(rows) != 1
+            or only_row.get("value") != 1000.0
+            or meta.get("pages") != 1
+            or seen_hosts != [ALLOWED_HOST]
+        ):
             raise RuntimeError("offline fetch contract mismatch")
         report.passed("offline_first_fetch", resolved_hosts=seen_hosts)
     except Exception as exc:  # noqa: BLE001

--- a/research/kr_backfill/preflight.py
+++ b/research/kr_backfill/preflight.py
@@ -1,0 +1,298 @@
+"""Kiwoom-only Stage-B preflight with no broker HTTP and no database DML."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import httpx
+from collect import UPSERT_SQL, dsn
+from equality_gate import build_clients
+from sources import (
+    Pacer,
+    assert_fetch_window_open,
+    fetch_kiwoom_minutes,
+)
+
+REQUIRED_ENV = (
+    "DATABASE_URL",
+    "KIWOOM_MOCK_APP_KEY",
+    "KIWOOM_MOCK_APP_SECRET",
+    "REDIS_URL",
+)
+TARGET_TABLE = "research.kr_candles_1m"
+LATENCY_TABLE = "public.kr_candles_1m"
+ALLOWED_HOST = "mockapi.kiwoom.com"
+
+
+@dataclass
+class PreflightReport:
+    checks: dict[str, dict[str, Any]] = field(default_factory=dict)
+    missing_dependencies: list[str] = field(default_factory=list)
+
+    def passed(self, name: str, **details: Any) -> None:
+        self.checks[name] = {"status": "PASS", **details}
+
+    def failed(
+        self, name: str, *, dependency: str, exc: Exception | None = None
+    ) -> None:
+        self.missing_dependencies.append(dependency)
+        record: dict[str, Any] = {"status": "FAIL", "dependency": dependency}
+        if exc is not None:
+            record["error_type"] = type(exc).__name__
+        self.checks[name] = record
+
+    def render(self) -> dict[str, Any]:
+        missing = sorted(set(self.missing_dependencies))
+        return {
+            "status": "PASS" if not missing else "FAIL",
+            "missing_dependencies": missing,
+            "checks": self.checks,
+            "broker_http_requests": 0,
+            "database_dml_statements": 0,
+            "allowed_host": ALLOWED_HOST,
+        }
+
+
+def _nonempty_env(name: str) -> bool:
+    return bool(str(os.getenv(name, "")).strip())
+
+
+def _validate_inputs(
+    report: PreflightReport, *, split_csv: Path, job_dir: Path
+) -> None:
+    try:
+        with split_csv.open() as fh:
+            kiwoom_symbols = [
+                row.get("ticker", "")
+                for row in csv.DictReader(fh)
+                if row.get("source") == "kiwoom" and row.get("ticker")
+            ]
+        if not kiwoom_symbols:
+            raise ValueError("no Kiwoom symbols")
+        report.passed("split_csv", kiwoom_symbols=len(kiwoom_symbols))
+    except Exception as exc:  # noqa: BLE001
+        report.failed("split_csv", dependency="KIWOOM_SPLIT_INPUT", exc=exc)
+
+    events_dir = job_dir / "events"
+    if events_dir.is_dir() and os.access(events_dir, os.W_OK):
+        report.passed("job_events_directory")
+    else:
+        report.failed(
+            "job_events_directory", dependency="WRITABLE_JOB_EVENTS_DIRECTORY"
+        )
+
+
+async def _check_offline_fetch(report: PreflightReport, client: Any) -> None:
+    seen_hosts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        host = request.url.host or ""
+        seen_hosts.append(host)
+        return httpx.Response(
+            200,
+            json={
+                "return_code": 0,
+                "stk_min_pole_chart_qry": [
+                    {
+                        "cntr_tm": "20260801153000",
+                        "open_pric": "100",
+                        "high_pric": "101",
+                        "low_pric": "99",
+                        "cur_prc": "100",
+                        "trde_qty": "10",
+                        "trde_prica": "1000",
+                    }
+                ],
+            },
+            request=request,
+        )
+
+    try:
+        client.set_transport_for_test(
+            httpx.MockTransport(handler), token="preflight-offline-token"
+        )
+        pacer = Pacer("kiwoom")
+        pacer.interval = 0.0
+        rows, meta = await fetch_kiwoom_minutes(
+            client=client,
+            symbol="005930",
+            pacer=pacer,
+            max_pages=1,
+            base_dt="20260801",
+        )
+        if len(rows) != 1 or meta.get("pages") != 1 or seen_hosts != [ALLOWED_HOST]:
+            raise RuntimeError("offline fetch contract mismatch")
+        report.passed("offline_first_fetch", resolved_hosts=seen_hosts)
+    except Exception as exc:  # noqa: BLE001
+        report.failed("offline_first_fetch", dependency="KIWOOM_FETCH_PATH", exc=exc)
+
+
+async def _check_redis(report: PreflightReport) -> None:
+    try:
+        from app.services.brokers.kiwoom.auth import _get_redis_client
+
+        redis_client = await _get_redis_client()
+        await redis_client.ping()
+        report.passed("redis_connectivity")
+    except Exception as exc:  # noqa: BLE001
+        report.failed("redis_connectivity", dependency="REDIS_CONNECTIVITY", exc=exc)
+
+    if "app.core.config" in sys.modules:
+        report.failed(
+            "global_settings_isolation", dependency="GLOBAL_SETTINGS_ISOLATION"
+        )
+    else:
+        report.passed("global_settings_isolation")
+
+
+async def _check_database(report: PreflightReport) -> None:
+    pool: asyncpg.Pool | None = None
+    try:
+        pool = await asyncpg.create_pool(dsn(), min_size=1, max_size=2)
+        async with pool.acquire() as conn:
+            target_exists = await conn.fetchval("SELECT to_regclass($1)", TARGET_TABLE)
+            latency_exists = await conn.fetchval(
+                "SELECT to_regclass($1)", LATENCY_TABLE
+            )
+            if target_exists is None:
+                report.failed("target_table", dependency=TARGET_TABLE)
+            else:
+                report.passed("target_table")
+            if latency_exists is None:
+                report.failed("latency_table", dependency=LATENCY_TABLE)
+            else:
+                report.passed("latency_table")
+
+            can_insert = await conn.fetchval(
+                "SELECT has_table_privilege(current_user, $1, 'INSERT')",
+                TARGET_TABLE,
+            )
+            if can_insert:
+                report.passed("research_insert_privilege")
+            else:
+                report.failed(
+                    "research_insert_privilege",
+                    dependency="RESEARCH_INSERT_PRIVILEGE",
+                )
+
+            can_read_latency = await conn.fetchval(
+                "SELECT has_table_privilege(current_user, $1, 'SELECT')",
+                LATENCY_TABLE,
+            )
+            if can_read_latency:
+                report.passed("public_latency_read_privilege")
+            else:
+                report.failed(
+                    "public_latency_read_privilege",
+                    dependency="PUBLIC_LATENCY_SELECT_PRIVILEGE",
+                )
+
+            public_write = await conn.fetchval(
+                """
+                SELECT has_table_privilege(current_user, $1, 'INSERT')
+                    OR has_table_privilege(current_user, $1, 'UPDATE')
+                    OR has_table_privilege(current_user, $1, 'DELETE')
+                """,
+                LATENCY_TABLE,
+            )
+            if public_write:
+                report.failed(
+                    "public_write_denied", dependency="PUBLIC_WRITE_DENY_GRANT"
+                )
+            else:
+                report.passed("public_write_denied")
+
+            try:
+                await conn.prepare(UPSERT_SQL)
+                report.passed("upsert_prepare")
+            except Exception as exc:  # noqa: BLE001
+                report.failed(
+                    "upsert_prepare", dependency="UPSERT_SQL_PREPARE", exc=exc
+                )
+
+            try:
+                await conn.fetch(
+                    "SELECT time, close FROM public.kr_candles_1m "
+                    "WHERE symbol=$1 AND time >= $2 ORDER BY time DESC LIMIT 1",
+                    "005930",
+                    datetime.now().astimezone(),
+                )
+                report.passed("latency_query_read")
+            except Exception as exc:  # noqa: BLE001
+                report.failed(
+                    "latency_query_read", dependency="LATENCY_QUERY_READ", exc=exc
+                )
+    except Exception as exc:  # noqa: BLE001
+        report.failed(
+            "database_connectivity", dependency="DATABASE_CONNECTIVITY", exc=exc
+        )
+    else:
+        report.passed("database_connectivity")
+    finally:
+        if pool is not None:
+            await pool.close()
+
+
+async def run_preflight(
+    *, split_csv: Path, job_dir: Path
+) -> tuple[int, dict[str, Any]]:
+    report = PreflightReport()
+    for name in REQUIRED_ENV:
+        if _nonempty_env(name):
+            report.passed(f"env:{name}")
+        else:
+            report.failed(f"env:{name}", dependency=name)
+
+    try:
+        assert_fetch_window_open()
+        report.passed("fetch_window")
+    except Exception as exc:  # noqa: BLE001
+        report.failed("fetch_window", dependency="BACKFILL_DAYTIME_APPROVED", exc=exc)
+
+    _validate_inputs(report, split_csv=split_csv, job_dir=job_dir)
+
+    client: Any | None = None
+    try:
+        clients = await build_clients(["kiwoom"])
+        client = clients["kiwoom"]
+        report.passed("kiwoom_client_build")
+    except Exception as exc:  # noqa: BLE001
+        report.failed("kiwoom_client_build", dependency="KIWOOM_CLIENT_BUILD", exc=exc)
+
+    if client is not None:
+        await _check_offline_fetch(report, client)
+    else:
+        report.failed("offline_first_fetch", dependency="KIWOOM_FETCH_PATH")
+
+    await _check_redis(report)
+    await _check_database(report)
+
+    rendered = report.render()
+    return (0 if rendered["status"] == "PASS" else 2), rendered
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--split-csv", required=True, type=Path)
+    parser.add_argument("--job-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    exit_code, report = await run_preflight(
+        split_csv=args.split_csv, job_dir=args.job_dir
+    )
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/research/kr_backfill/sources.py
+++ b/research/kr_backfill/sources.py
@@ -106,7 +106,7 @@ async def fetch_kiwoom_minutes(
     max_pages: int = 1,
     base_dt: str | None = None,
 ) -> tuple[dict[datetime, dict[str, float]], dict[str, Any]]:
-    from app.services.brokers.kiwoom.live_market_data import CHART_PATH
+    from app.services.brokers.kiwoom.constants import CHART_PATH
 
     assert_fetch_window_open()
     out: dict[datetime, dict[str, float]] = {}

--- a/research/kr_backfill/sources.py
+++ b/research/kr_backfill/sources.py
@@ -33,8 +33,8 @@ FREEZE_END = dtime(20, 0)
 
 #: What each source's `value` field actually is. Discovered during Stage A prep.
 VALUE_SEMANTICS: dict[str, str] = {
-    # broker-reported traded value (거래대금)
-    "kiwoom": "broker_reported_trde_prica",
+    # ka10080 minute rows omit traded value; derive the stable proxy explicitly.
+    "kiwoom": "synthesised_close_times_volume",
     "kis": "broker_reported_acml_tr_pbmn",
     # NOT broker-reported: app/services/brokers/toss/candles.py computes
     # value = close * volume. Comparing it against the others measures the
@@ -85,7 +85,12 @@ class Pacer:
 def _to_float(raw: Any) -> float:
     # Kiwoom prefixes price/volume with a direction sign ("-78800"); the
     # magnitude is the value, the sign is 전일대비 direction.
-    return abs(float(str(raw).strip().replace(",", "") or 0))
+    if raw is None:
+        return 0.0
+    normalized = str(raw).strip().replace(",", "")
+    if not normalized or normalized.lower() == "none":
+        return 0.0
+    return abs(float(normalized))
 
 
 def in_regular_session(ts: datetime) -> bool:
@@ -129,6 +134,11 @@ async def fetch_kiwoom_minutes(
             body=body,
             **({"cont_yn": cont_yn, "next_key": next_key} if cont_yn else {}),
         )
+        if int(payload.get("return_code", 0)) != 0:
+            raise RuntimeError(
+                "Kiwoom ka10080 rejected request "
+                f"return_code={payload.get('return_code')!r}"
+            )
         rows = payload.get("stk_min_pole_chart_qry") or []
         meta["pages"] += 1
         meta["rows_raw"] += len(rows)
@@ -139,13 +149,15 @@ async def fetch_kiwoom_minutes(
             if len(raw_ts) < 12:
                 continue
             ts = datetime.strptime(raw_ts[:12], "%Y%m%d%H%M")
+            close = _to_float(r.get("cur_prc"))
+            volume = _to_float(r.get("trde_qty"))
             out[ts] = {
                 "open": _to_float(r.get("open_pric")),
                 "high": _to_float(r.get("high_pric")),
                 "low": _to_float(r.get("low_pric")),
-                "close": _to_float(r.get("cur_prc")),
-                "volume": _to_float(r.get("trde_qty")),
-                "value": _to_float(r.get("trde_prica")),
+                "close": close,
+                "volume": volume,
+                "value": close * volume,
             }
         # post_api merges the cont-yn / next-key response headers into payload.
         more = str(payload.get("cont_yn", "")).strip().upper() == "Y"

--- a/research/kr_backfill/sources.py
+++ b/research/kr_backfill/sources.py
@@ -43,10 +43,37 @@ VALUE_SEMANTICS: dict[str, str] = {
 }
 
 PACE_SECONDS: dict[str, float] = {"toss": 0.3, "kiwoom": 2.0, "kis": 0.5}
+ROWS_RETURNED = "ROWS_RETURNED"
+EMPTY_RESPONSE = "EMPTY_RESPONSE"
+EMPTY_RESPONSE_PLACEHOLDER = "EMPTY_RESPONSE_PLACEHOLDER"
+AUTH_STALE_TOKEN = "AUTH_STALE_TOKEN"
+PROVIDER_REJECTED = "PROVIDER_REJECTED"
+MALFORMED_RESPONSE = "MALFORMED_RESPONSE"
 
 
 class FetchWindowClosed(RuntimeError):
     """Raised when a fetch is attempted inside the 09:00-20:00 KST freeze."""
+
+
+class BackfillSourceResponseError(RuntimeError):
+    """Value-redacted source failure with an operator-facing reason code."""
+
+    def __init__(
+        self,
+        *,
+        reason_code: str,
+        source: str,
+        retry_disposition: str,
+        provider_code: int | str | None = None,
+    ) -> None:
+        self.reason_code = reason_code
+        self.source = source
+        self.retry_disposition = retry_disposition
+        self.provider_code = provider_code
+        super().__init__(
+            f"{source} response failure reason_code={reason_code} "
+            f"provider_code={provider_code!r} retry={retry_disposition}"
+        )
 
 
 def now_kst() -> datetime:
@@ -115,7 +142,12 @@ async def fetch_kiwoom_minutes(
 
     assert_fetch_window_open()
     out: dict[datetime, dict[str, float]] = {}
-    meta: dict[str, Any] = {"pages": 0, "rows_raw": 0, "next_key_seen": False}
+    meta: dict[str, Any] = {
+        "pages": 0,
+        "rows_raw": 0,
+        "next_key_seen": False,
+        "outcome_code": None,
+    }
 
     cont_yn: str | None = None
     next_key: str | None = None
@@ -134,31 +166,84 @@ async def fetch_kiwoom_minutes(
             body=body,
             **({"cont_yn": cont_yn, "next_key": next_key} if cont_yn else {}),
         )
-        if int(payload.get("return_code", 0)) != 0:
-            raise RuntimeError(
-                "Kiwoom ka10080 rejected request "
-                f"return_code={payload.get('return_code')!r}"
+        raw_return_code = payload.get("return_code")
+        try:
+            return_code = int(raw_return_code)
+        except (TypeError, ValueError) as exc:
+            raise BackfillSourceResponseError(
+                reason_code=MALFORMED_RESPONSE,
+                source="kiwoom",
+                retry_disposition="STOP_NO_RETRY",
+            ) from exc
+        if return_code != 0:
+            raise BackfillSourceResponseError(
+                reason_code=PROVIDER_REJECTED,
+                source="kiwoom",
+                retry_disposition="STOP_NO_RETRY",
+                provider_code=return_code,
             )
-        rows = payload.get("stk_min_pole_chart_qry") or []
+        if "stk_min_pole_chart_qry" not in payload:
+            raise BackfillSourceResponseError(
+                reason_code=MALFORMED_RESPONSE,
+                source="kiwoom",
+                retry_disposition="STOP_NO_RETRY",
+            )
+        rows = payload["stk_min_pole_chart_qry"]
+        if not isinstance(rows, list):
+            raise BackfillSourceResponseError(
+                reason_code=MALFORMED_RESPONSE,
+                source="kiwoom",
+                retry_disposition="STOP_NO_RETRY",
+            )
         meta["pages"] += 1
         meta["rows_raw"] += len(rows)
         if not rows:
+            if meta["outcome_code"] is None:
+                meta["outcome_code"] = EMPTY_RESPONSE
             break
+        blank_placeholders = 0
         for r in rows:
             raw_ts = str(r.get("cntr_tm", "")).strip()
             if len(raw_ts) < 12:
-                continue
-            ts = datetime.strptime(raw_ts[:12], "%Y%m%d%H%M")
-            close = _to_float(r.get("cur_prc"))
-            volume = _to_float(r.get("trde_qty"))
+                if all(value is None or not str(value).strip() for value in r.values()):
+                    blank_placeholders += 1
+                    continue
+                raise BackfillSourceResponseError(
+                    reason_code=MALFORMED_RESPONSE,
+                    source="kiwoom",
+                    retry_disposition="STOP_NO_RETRY",
+                )
+            try:
+                ts = datetime.strptime(raw_ts[:12], "%Y%m%d%H%M")
+                close = _to_float(r.get("cur_prc"))
+                volume = _to_float(r.get("trde_qty"))
+                open_price = _to_float(r.get("open_pric"))
+                high_price = _to_float(r.get("high_pric"))
+                low_price = _to_float(r.get("low_pric"))
+            except (TypeError, ValueError) as exc:
+                raise BackfillSourceResponseError(
+                    reason_code=MALFORMED_RESPONSE,
+                    source="kiwoom",
+                    retry_disposition="STOP_NO_RETRY",
+                ) from exc
             out[ts] = {
-                "open": _to_float(r.get("open_pric")),
-                "high": _to_float(r.get("high_pric")),
-                "low": _to_float(r.get("low_pric")),
+                "open": open_price,
+                "high": high_price,
+                "low": low_price,
                 "close": close,
                 "volume": volume,
                 "value": close * volume,
             }
+        if blank_placeholders:
+            if blank_placeholders != len(rows) or out:
+                raise BackfillSourceResponseError(
+                    reason_code=MALFORMED_RESPONSE,
+                    source="kiwoom",
+                    retry_disposition="STOP_NO_RETRY",
+                )
+            meta["outcome_code"] = EMPTY_RESPONSE_PLACEHOLDER
+            break
+        meta["outcome_code"] = ROWS_RETURNED
         # post_api merges the cont-yn / next-key response headers into payload.
         more = str(payload.get("cont_yn", "")).strip().upper() == "Y"
         nk = str(payload.get("next_key", "")).strip() or None
@@ -186,7 +271,12 @@ async def fetch_toss_minutes(
 ) -> tuple[dict[datetime, dict[str, float]], dict[str, Any]]:
     assert_fetch_window_open()
     out: dict[datetime, dict[str, float]] = {}
-    meta: dict[str, Any] = {"pages": 0, "rows_raw": 0, "next_before": None}
+    meta: dict[str, Any] = {
+        "pages": 0,
+        "rows_raw": 0,
+        "next_before": None,
+        "outcome_code": None,
+    }
 
     cursor = before
     for _ in range(max_pages):
@@ -197,7 +287,9 @@ async def fetch_toss_minutes(
         meta["pages"] += 1
         meta["rows_raw"] += len(page.candles)
         if not page.candles:
+            meta["outcome_code"] = EMPTY_RESPONSE
             break
+        meta["outcome_code"] = ROWS_RETURNED
         for c in page.candles:
             ts = datetime.fromisoformat(str(c.timestamp).replace("Z", "+00:00"))
             ts = ts.astimezone(KST).replace(tzinfo=None) if ts.tzinfo else ts
@@ -236,7 +328,7 @@ async def fetch_kis_minutes(
 ) -> tuple[dict[datetime, dict[str, float]], dict[str, Any]]:
     assert_fetch_window_open()
     out: dict[datetime, dict[str, float]] = {}
-    meta: dict[str, Any] = {"pages": 0, "rows_raw": 0}
+    meta: dict[str, Any] = {"pages": 0, "rows_raw": 0, "outcome_code": None}
 
     cursor = end_time
     for _ in range(max_pages):
@@ -247,7 +339,9 @@ async def fetch_kis_minutes(
         meta["pages"] += 1
         meta["rows_raw"] += len(frame)
         if frame.empty:
+            meta["outcome_code"] = EMPTY_RESPONSE
             break
+        meta["outcome_code"] = ROWS_RETURNED
         for _idx, r in frame.iterrows():
             ts = r["datetime"]
             ts = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts

--- a/tests/research/test_kr_backfill_collector_exit_codes.py
+++ b/tests/research/test_kr_backfill_collector_exit_codes.py
@@ -92,3 +92,17 @@ def test_stopped_stream_after_rows_is_partial_failure(
     )
 
     assert collect_module.exit_code_for_results([result]) == 1
+
+
+def test_empty_symbol_among_useful_rows_is_partial_failure(
+    collect_module: ModuleType,
+) -> None:
+    result = _stats(
+        collect_module,
+        rows_fetched=900,
+        rows_inserted=700,
+        empty_responses=1,
+        empty_symbols=["001570"],
+    )
+
+    assert collect_module.exit_code_for_results([result]) == 1

--- a/tests/research/test_kr_backfill_collector_exit_codes.py
+++ b/tests/research/test_kr_backfill_collector_exit_codes.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+COLLECT_PATH = REPOSITORY_ROOT / "research" / "kr_backfill" / "collect.py"
+
+
+@pytest.fixture
+def collect_module() -> ModuleType:
+    module_name = "kr_backfill_collect_exit_code_test"
+    sys.path.insert(0, str(COLLECT_PATH.parent))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, COLLECT_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        sys.path.remove(str(COLLECT_PATH.parent))
+
+
+def _stats(module: ModuleType, **updates: object) -> object:
+    stats = module.StreamStats(source="kiwoom")
+    for name, value in updates.items():
+        setattr(stats, name, value)
+    return stats
+
+
+def test_all_clean_useful_streams_exit_zero(collect_module: ModuleType) -> None:
+    result = _stats(collect_module, rows_fetched=900, rows_inserted=700)
+
+    assert collect_module.exit_code_for_results([result]) == 0
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        None,
+        RuntimeError("stream exploded"),
+    ],
+)
+def test_no_useful_rows_is_total_failure(
+    collect_module: ModuleType, result: BaseException | None
+) -> None:
+    value = result if result is not None else _stats(collect_module)
+
+    assert collect_module.exit_code_for_results([value]) == 2
+
+
+def test_error_before_rows_is_total_failure(collect_module: ModuleType) -> None:
+    result = _stats(collect_module, errors=["fetch failed"])
+
+    assert collect_module.exit_code_for_results([result]) == 2
+
+
+def test_rows_then_error_is_partial_failure(collect_module: ModuleType) -> None:
+    result = _stats(
+        collect_module,
+        rows_fetched=900,
+        rows_inserted=700,
+        errors=["later fetch failed"],
+    )
+
+    assert collect_module.exit_code_for_results([result]) == 1
+
+
+def test_clean_and_failed_streams_are_partial_failure(
+    collect_module: ModuleType,
+) -> None:
+    clean = _stats(collect_module, rows_fetched=900, rows_inserted=700)
+    failed = _stats(collect_module, errors=["fetch failed"])
+
+    assert collect_module.exit_code_for_results([clean, failed]) == 1
+
+
+def test_stopped_stream_after_rows_is_partial_failure(
+    collect_module: ModuleType,
+) -> None:
+    result = _stats(
+        collect_module,
+        rows_fetched=900,
+        rows_inserted=700,
+        stopped_reason="latency abort",
+    )
+
+    assert collect_module.exit_code_for_results([result]) == 1

--- a/tests/research/test_kr_backfill_kiwoom_payload.py
+++ b/tests/research/test_kr_backfill_kiwoom_payload.py
@@ -88,7 +88,9 @@ async def test_kiwoom_provider_rejection_is_not_reported_as_empty_data(
     pacer = sources_module.Pacer("kiwoom")
     pacer.interval = 0.0
 
-    with pytest.raises(RuntimeError, match="return_code=3") as exc_info:
+    with pytest.raises(
+        sources_module.BackfillSourceResponseError, match="PROVIDER_REJECTED"
+    ) as exc_info:
         await sources_module.fetch_kiwoom_minutes(
             client=client,
             symbol="196170",
@@ -98,3 +100,111 @@ async def test_kiwoom_provider_rejection_is_not_reported_as_empty_data(
         )
 
     assert "sensitive provider text" not in str(exc_info.value)
+    assert exc_info.value.provider_code == 3
+
+
+@pytest.mark.asyncio
+async def test_kiwoom_successful_empty_has_distinct_outcome_code(
+    sources_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", "true")
+    client = _Client({"return_code": 0, "stk_min_pole_chart_qry": []})
+    pacer = sources_module.Pacer("kiwoom")
+    pacer.interval = 0.0
+
+    rows, meta = await sources_module.fetch_kiwoom_minutes(
+        client=client,
+        symbol="001570",
+        pacer=pacer,
+        max_pages=1,
+        base_dt="20260724",
+    )
+
+    assert rows == {}
+    assert meta["outcome_code"] == sources_module.EMPTY_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_kiwoom_missing_row_key_is_malformed_not_empty(
+    sources_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", "true")
+    client = _Client({"return_code": 0})
+    pacer = sources_module.Pacer("kiwoom")
+    pacer.interval = 0.0
+
+    with pytest.raises(
+        sources_module.BackfillSourceResponseError, match="MALFORMED_RESPONSE"
+    ):
+        await sources_module.fetch_kiwoom_minutes(
+            client=client,
+            symbol="001570",
+            pacer=pacer,
+            max_pages=1,
+            base_dt="20260724",
+        )
+
+
+@pytest.mark.asyncio
+async def test_kiwoom_all_blank_sentinel_is_distinct_empty_placeholder(
+    sources_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", "true")
+    client = _Client(
+        {
+            "return_code": 0,
+            "stk_min_pole_chart_qry": [
+                {
+                    "cntr_tm": "",
+                    "open_pric": "",
+                    "high_pric": "",
+                    "low_pric": "",
+                    "cur_prc": "",
+                    "trde_qty": "",
+                }
+            ],
+        }
+    )
+    pacer = sources_module.Pacer("kiwoom")
+    pacer.interval = 0.0
+
+    rows, meta = await sources_module.fetch_kiwoom_minutes(
+        client=client,
+        symbol="001570",
+        pacer=pacer,
+        max_pages=1,
+        base_dt="20260724",
+    )
+
+    assert rows == {}
+    assert meta["outcome_code"] == sources_module.EMPTY_RESPONSE_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_kiwoom_partially_blank_row_is_malformed(
+    sources_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", "true")
+    client = _Client(
+        {
+            "return_code": 0,
+            "stk_min_pole_chart_qry": [{"cntr_tm": "", "cur_prc": "100"}],
+        }
+    )
+    pacer = sources_module.Pacer("kiwoom")
+    pacer.interval = 0.0
+
+    with pytest.raises(
+        sources_module.BackfillSourceResponseError, match="MALFORMED_RESPONSE"
+    ):
+        await sources_module.fetch_kiwoom_minutes(
+            client=client,
+            symbol="001570",
+            pacer=pacer,
+            max_pages=1,
+            base_dt="20260724",
+        )

--- a/tests/research/test_kr_backfill_kiwoom_payload.py
+++ b/tests/research/test_kr_backfill_kiwoom_payload.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SOURCES_PATH = REPOSITORY_ROOT / "research" / "kr_backfill" / "sources.py"
+
+
+@pytest.fixture
+def sources_module() -> ModuleType:
+    module_name = "kr_backfill_sources_payload_test"
+    spec = importlib.util.spec_from_file_location(module_name, SOURCES_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+class _Client:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    async def post_api(self, **_kwargs: Any) -> dict[str, Any]:
+        return self.payload
+
+
+@pytest.mark.asyncio
+async def test_kiwoom_missing_trade_value_uses_close_volume_proxy(
+    sources_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", "true")
+    client = _Client(
+        {
+            "return_code": 0,
+            "stk_min_pole_chart_qry": [
+                {
+                    "cntr_tm": "20260724153000",
+                    "open_pric": "-100",
+                    "high_pric": "-101",
+                    "low_pric": "-99",
+                    "cur_prc": "-100",
+                    "trde_qty": "10",
+                    "trde_prica": None,
+                }
+            ],
+        }
+    )
+    pacer = sources_module.Pacer("kiwoom")
+    pacer.interval = 0.0
+
+    rows, meta = await sources_module.fetch_kiwoom_minutes(
+        client=client,
+        symbol="196170",
+        pacer=pacer,
+        max_pages=1,
+        base_dt="20260724",
+    )
+
+    assert meta["rows_raw"] == 1
+    assert next(iter(rows.values())) == {
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.0,
+        "volume": 10.0,
+        "value": 1000.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_kiwoom_provider_rejection_is_not_reported_as_empty_data(
+    sources_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKFILL_DAYTIME_APPROVED", "true")
+    client = _Client({"return_code": 3, "return_msg": "sensitive provider text"})
+    pacer = sources_module.Pacer("kiwoom")
+    pacer.interval = 0.0
+
+    with pytest.raises(RuntimeError, match="return_code=3") as exc_info:
+        await sources_module.fetch_kiwoom_minutes(
+            client=client,
+            symbol="196170",
+            pacer=pacer,
+            max_pages=1,
+            base_dt="20260724",
+        )
+
+    assert "sensitive provider text" not in str(exc_info.value)

--- a/tests/services/brokers/toss/test_dto.py
+++ b/tests/services/brokers/toss/test_dto.py
@@ -176,6 +176,14 @@ def test_parse_candles_rejects_float_prices() -> None:
         )
 
 
+@pytest.mark.parametrize("payload", [{}, {"candles": None}, {"candles": {}}])
+def test_parse_candles_rejects_missing_or_malformed_rows(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="expected candles list"):
+        parse_candles(payload)
+
+
 def test_parse_warnings_converts_fields() -> None:
     from app.services.brokers.toss.dto import parse_warnings
 

--- a/tests/test_kiwoom_auth_token_cache.py
+++ b/tests/test_kiwoom_auth_token_cache.py
@@ -7,13 +7,19 @@ import asyncio
 import datetime as dt
 import json
 import logging
+import sys
 import time
 
 import httpx
 import pytest
 
+from app.services.brokers.kiwoom import auth as auth_module
 from app.services.brokers.kiwoom import constants
-from app.services.brokers.kiwoom.auth import KiwoomAuthClient, KiwoomToken
+from app.services.brokers.kiwoom.auth import (
+    KiwoomAuthClient,
+    KiwoomRedisConfigurationError,
+    KiwoomToken,
+)
 
 
 class _FakeRedis:
@@ -57,6 +63,46 @@ class _FakeRedis:
             self.strings.pop(key)
             return 1
         return 0
+
+
+@pytest.mark.asyncio
+async def test_scoped_redis_env_does_not_import_global_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeRedis()
+    captured: dict[str, object] = {}
+
+    def from_url(url: str, **kwargs: object) -> _FakeRedis:
+        captured["url_present"] = bool(url)
+        captured.update(kwargs)
+        return fake
+
+    monkeypatch.setenv("REDIS_URL", "redis://scoped.invalid:6379/0")
+    monkeypatch.delenv("REDIS_MAX_CONNECTIONS", raising=False)
+    monkeypatch.delenv("REDIS_SOCKET_TIMEOUT", raising=False)
+    monkeypatch.delenv("REDIS_SOCKET_CONNECT_TIMEOUT", raising=False)
+    monkeypatch.setattr(auth_module.redis, "from_url", from_url)
+    monkeypatch.setattr(auth_module, "_redis_client", None)
+    sys.modules.pop("app.core.config", None)
+
+    client = await auth_module._get_redis_client()
+
+    assert client is fake
+    assert captured == {
+        "url_present": True,
+        "max_connections": 20,
+        "socket_timeout": 5.0,
+        "socket_connect_timeout": 5.0,
+        "decode_responses": True,
+    }
+    assert "app.core.config" not in sys.modules
+
+
+def test_scoped_redis_env_requires_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    with pytest.raises(KiwoomRedisConfigurationError, match="REDIS_URL"):
+        auth_module._redis_client_from_env()
 
 
 @pytest.fixture

--- a/tests/test_kiwoom_token_refresh.py
+++ b/tests/test_kiwoom_token_refresh.py
@@ -127,6 +127,82 @@ async def test_repeated_read_8005_is_resubmitted_only_once():
     ]
 
 
+@pytest.mark.asyncio
+async def test_chart_observed_return_code_3_with_8005_message_refreshes_once():
+    dispatched_authorizations: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        authorization = request.headers[constants.HEADER_AUTHORIZATION]
+        dispatched_authorizations.append(authorization)
+        if authorization == "Bearer stale-token":
+            return httpx.Response(
+                200,
+                json={
+                    "return_code": 3,
+                    "return_msg": "인증에 실패했습니다[8005:Token이 유효하지 않습니다]",
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "return_code": 0,
+                "return_msg": "정상",
+                "stk_min_pole_chart_qry": [{"cntr_tm": "20260724153000"}],
+            },
+        )
+
+    auth = _RecordingAuth()
+    client = _client_with_transport(handler)
+    client._auth = auth  # type: ignore[assignment]
+
+    result = await client.post_api(
+        api_id=constants.CHART_MINUTE_API_ID,
+        path=constants.CHART_PATH,
+        body={"stk_cd": "196170", "tic_scope": "1"},
+    )
+
+    assert result["return_code"] == 0
+    assert len(result["stk_min_pole_chart_qry"]) == 1
+    assert dispatched_authorizations == [
+        "Bearer stale-token",
+        "Bearer fresh-token",
+    ]
+    assert auth.calls == [
+        (False, None),
+        (True, "stale-token"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_order_mutation_observed_return_code_3_with_8005_is_not_resubmitted():
+    dispatch_count = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal dispatch_count
+        dispatch_count += 1
+        return httpx.Response(
+            200,
+            json={
+                "return_code": 3,
+                "return_msg": "인증에 실패했습니다[8005:Token이 유효하지 않습니다]",
+            },
+        )
+
+    auth = _RecordingAuth()
+    client = _client_with_transport(handler)
+    client._auth = auth  # type: ignore[assignment]
+
+    result = await client.post_api(
+        api_id=constants.ORDER_BUY_API_ID,
+        path=constants.ORDER_PATH,
+        body={},
+    )
+
+    assert result["return_code"] == 3
+    assert dispatch_count == 1
+    assert auth.calls == [(False, None)]
+
+
 @pytest.mark.parametrize(
     ("api_id", "path"),
     [

--- a/tests/test_kiwoom_token_refresh.py
+++ b/tests/test_kiwoom_token_refresh.py
@@ -11,7 +11,13 @@ import pytest
 
 from app.services.brokers.kiwoom import constants
 from app.services.brokers.kiwoom.auth import KiwoomAuthClient, KiwoomToken
-from app.services.brokers.kiwoom.client import KiwoomMockClient
+from app.services.brokers.kiwoom.client import (
+    AUTH_STALE_TOKEN,
+    MALFORMED_RESPONSE,
+    PROVIDER_REJECTED,
+    KiwoomMockClient,
+    KiwoomReadResponseError,
+)
 
 
 class _RecordingAuth:
@@ -113,13 +119,15 @@ async def test_repeated_read_8005_is_resubmitted_only_once():
     client = _client_with_transport(handler)
     client._auth = auth  # type: ignore[assignment]
 
-    result = await client.post_api(
-        api_id=constants.US_ACCOUNT_POSITIONS_API_ID,
-        path=constants.US_ACCOUNT_PATH,
-        body={},
-    )
+    with pytest.raises(KiwoomReadResponseError) as exc_info:
+        await client.post_api(
+            api_id=constants.US_ACCOUNT_POSITIONS_API_ID,
+            path=constants.US_ACCOUNT_PATH,
+            body={},
+        )
 
-    assert result["return_code"] == "8005"
+    assert exc_info.value.reason_code == AUTH_STALE_TOKEN
+    assert exc_info.value.retry_disposition == "RETRIED_ONCE_THEN_STOP"
     assert dispatch_count == 2
     assert auth.calls == [
         (False, None),
@@ -201,6 +209,35 @@ async def test_order_mutation_observed_return_code_3_with_8005_is_not_resubmitte
     assert result["return_code"] == 3
     assert dispatch_count == 1
     assert auth.calls == [(False, None)]
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason_code"),
+    [
+        ({"return_code": 20, "return_msg": "rejected"}, PROVIDER_REJECTED),
+        ({"return_msg": "missing code"}, MALFORMED_RESPONSE),
+        ({"return_code": "not-a-number"}, MALFORMED_RESPONSE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_chart_provider_errors_are_typed_not_returned_as_empty(
+    payload: dict[str, object], reason_code: str
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    client = _client_with_transport(handler)
+    client._auth = _RecordingAuth()  # type: ignore[assignment]
+
+    with pytest.raises(KiwoomReadResponseError) as exc_info:
+        await client.post_api(
+            api_id=constants.CHART_MINUTE_API_ID,
+            path=constants.CHART_PATH,
+            body={"stk_cd": "001570", "tic_scope": "1"},
+        )
+
+    assert exc_info.value.reason_code == reason_code
+    assert exc_info.value.retry_disposition == "STOP_NO_RETRY"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -536,6 +536,36 @@ async def test_kis_inquire_time_dailychartprice_uses_end_time_when_provided(
 
 
 @pytest.mark.asyncio
+async def test_kis_inquire_time_dailychartprice_missing_rows_key_is_not_empty(
+    monkeypatch,
+):
+    from app.services.brokers.kis.client import KISClient
+
+    client = KISClient()
+    monkeypatch.setattr(client, "_ensure_token", AsyncMock())
+    request_mock = AsyncMock(return_value={"rt_cd": "0"})
+    monkeypatch.setattr(client, "_request_with_rate_limit", request_mock)
+
+    with pytest.raises(RuntimeError, match="missing output2/output"):
+        await client.inquire_time_dailychartprice("005930", market="J", n=1)
+
+
+@pytest.mark.asyncio
+async def test_kis_inquire_time_dailychartprice_malformed_rows_is_not_empty(
+    monkeypatch,
+):
+    from app.services.brokers.kis.client import KISClient
+
+    client = KISClient()
+    monkeypatch.setattr(client, "_ensure_token", AsyncMock())
+    request_mock = AsyncMock(return_value={"rt_cd": "0", "output2": {}})
+    monkeypatch.setattr(client, "_request_with_rate_limit", request_mock)
+
+    with pytest.raises(RuntimeError, match="expected output2/output list"):
+        await client.inquire_time_dailychartprice("005930", market="J", n=1)
+
+
+@pytest.mark.asyncio
 async def test_kis_inquire_daily_itemchartprice_returns_empty_dataframe_on_empty_payload(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- add a Kiwoom-only preflight that enumerates env, Redis, database, privilege, fetch-path, and global-settings isolation failures without broker HTTP or DB DML
- remove the backfill token path dependency on global application Settings
- return distinct collector exit codes for success, partial failure, and zero-row/total failure
- recover read-only chart calls from the observed stale-token response shape: return_code 3 with provider code 8005 in return_msg, with one resubmit maximum
- handle the actual ka10080 payload contract where minute rows omit traded value, deriving the existing close-times-volume proxy

## Verification
- final preflight passed all checks with broker HTTP 0 and DB DML 0
- relevant suite: 94 passed
- make lint: passed
- Stage-B 1 symbol over five proven trading days: exit 0, 3/3 requests, 2700 fetched, 2175 kept, 0 errors
- measured 482.841 kept rows/s and 0.666 requests/s
- 30-minute canary was not started because the deliberately overlapping Stage-B window produced 100% conflicts, exceeding the predeclared stop-condition range

## Safety
- zero-row exit-2 guard unchanged
- order mutation APIs remain excluded from token resubmission
- credentials added: no
- scoped env modified: no
- public writes: no
- orders/account queries: no
- allowed broker host only: mockapi.kiwoom.com
- full backfill started: no