### PR TITLE
feat: KR lean scheduleless shadow runner

### DIFF
--- a/app/services/kis_lean_execution.py
+++ b/app/services/kis_lean_execution.py
@@ -1,0 +1,157 @@
+"""A KR-only, scheduleless and shadow-first execution vertical slice.
+
+This module deliberately contains no broker client or order mutation primitive.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+Stage = Literal[
+    "decision",
+    "order_intent",
+    "kis_pre_submit",
+    "fill",
+    "position_reconcile",
+    "discord",
+]
+EventSink = Callable[[dict[str, object]], None]
+
+
+@dataclass(frozen=True)
+class LeanRunResult:
+    correlation_id: str
+    status: Literal["shadow_complete", "failed"]
+    decision: Literal["NO_ORDER"]
+    stages: tuple[Stage, ...]
+
+
+class SyntheticNoOpStrategy:
+    """Replaceable calculation seam; it can never emit an order signal."""
+
+    def evaluate(self, snapshot: Mapping[str, object]) -> dict[str, object]:
+        return {
+            "decision": "NO_ORDER",
+            "symbol": snapshot.get("symbol", "005930"),
+            "reason": "synthetic_no_op",
+            "signal_emitted": False,
+        }
+
+
+class ShadowOnlyKisPreSubmit:
+    """KIS pre-submit observation with no submit operation by construction."""
+
+    def inspect(self, intent: Mapping[str, object]) -> dict[str, object]:
+        return {
+            "mode": "shadow",
+            "accepted_for_submission": False,
+            "blocked_reason": "account_ownership_unconfirmed",
+            "competing_surface": "watch_auto_execute_mock",
+            "concurrent_writer_action": "refuse_and_report",
+            "intent": dict(intent),
+        }
+
+
+def _event(
+    correlation_id: str,
+    stage: Stage,
+    status: str,
+    input_data: Mapping[str, object],
+    output_data: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "correlation_id": correlation_id,
+        "occurred_at": datetime.now(UTC).isoformat(),
+        "stage": stage,
+        "status": status,
+        "input": dict(input_data),
+        "output": dict(output_data),
+    }
+
+
+def run_once(
+    snapshot: Mapping[str, object],
+    *,
+    correlation_id: str,
+    emit: EventSink,
+    strategy: SyntheticNoOpStrategy | None = None,
+    pre_submit: ShadowOnlyKisPreSubmit | None = None,
+) -> LeanRunResult:
+    """Run exactly one observable, mutation-free KR shadow lifecycle."""
+
+    strategy = strategy or SyntheticNoOpStrategy()
+    pre_submit = pre_submit or ShadowOnlyKisPreSubmit()
+    stages: list[Stage] = []
+    try:
+        decision_input = {"symbol": snapshot.get("symbol", "005930")}
+        decision = strategy.evaluate(snapshot)
+        emit(_event(correlation_id, "decision", "completed", decision_input, decision))
+        stages.append("decision")
+
+        intent = {
+            "kind": "no_order",
+            "side": None,
+            "quantity": None,
+            "decision": decision["decision"],
+        }
+        emit(_event(correlation_id, "order_intent", "completed", decision, intent))
+        stages.append("order_intent")
+
+        pre_submit_result = pre_submit.inspect(intent)
+        emit(
+            _event(
+                correlation_id,
+                "kis_pre_submit",
+                "blocked",
+                intent,
+                pre_submit_result,
+            )
+        )
+        stages.append("kis_pre_submit")
+
+        fill = {"attempted": False, "evidence": None, "status": "not_applicable"}
+        emit(_event(correlation_id, "fill", "skipped", pre_submit_result, fill))
+        stages.append("fill")
+
+        reconcile = {
+            "attempted": False,
+            "broker_read": False,
+            "status": "not_applicable_no_order",
+        }
+        emit(_event(correlation_id, "position_reconcile", "skipped", fill, reconcile))
+        stages.append("position_reconcile")
+
+        discord = {
+            "kind": "shadow_complete",
+            "must_notify": True,
+            "message": "KR lean shadow completed: NO_ORDER; KIS pre-submit blocked",
+        }
+        emit(_event(correlation_id, "discord", "completed", reconcile, discord))
+        stages.append("discord")
+        return LeanRunResult(
+            correlation_id=correlation_id,
+            status="shadow_complete",
+            decision="NO_ORDER",
+            stages=tuple(stages),
+        )
+    except Exception as exc:
+        failure = {
+            "kind": "failure",
+            "must_notify": True,
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+        }
+        emit(_event(correlation_id, "discord", "failed", {}, failure))
+        return LeanRunResult(
+            correlation_id=correlation_id,
+            status="failed",
+            decision="NO_ORDER",
+            stages=tuple(stages + ["discord"]),
+        )
+
+
+def result_dict(result: LeanRunResult) -> dict[str, object]:
+    return asdict(result)

--- a/docs/runbooks/kis-lean-once.md
+++ b/docs/runbooks/kis-lean-once.md
@@ -1,0 +1,21 @@
+# KR lean `--once` shadow runner
+
+This is a manual, KR-only vertical slice. It is not registered with TaskIQ,
+cron, Prefect, or any supervisor. The current strategy is synthetic and always
+returns `NO_ORDER`.
+
+```bash
+uv run python scripts/kis_lean_once.py --symbol 005930 --events /tmp/kr-lean-events.jsonl
+```
+
+The command emits JSONL for decision, order intent, KIS pre-submit, fill,
+position/reconcile, and Discord. The pre-submit stage is structurally
+shadow-only: it has inspection but no broker client or submit operation, and
+blocks until account ownership is confirmed. It also records the existing
+`watch_auto_execute_mock` surface as a competing writer concern; this runner
+does not import, call, or modify that surface.
+
+Discord output is represented by an observable event sink in this slice. Both
+successful shadow completion and failure/stop paths set `must_notify=true`.
+Actual webhook delivery belongs to the operational shell contract and is not
+added here.

--- a/scripts/kis_lean_once.py
+++ b/scripts/kis_lean_once.py
@@ -1,0 +1,56 @@
+"""Manual KR lean shadow runner; intentionally has no loop or scheduler mode."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from app.services.kis_lean_execution import result_dict, run_once
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one KR KIS shadow lifecycle")
+    parser.add_argument("--symbol", default="005930")
+    parser.add_argument("--events", type=Path, help="append observable JSONL events")
+    args = parser.parse_args()
+
+    correlation_id = f"kr-lean-once:{uuid4().hex}"
+    events: list[dict[str, object]] = []
+
+    def emit(event: dict[str, object]) -> None:
+        events.append(event)
+        print(json.dumps(event, ensure_ascii=False, sort_keys=True))
+
+    result = run_once(
+        {"symbol": args.symbol, "source": "synthetic_fixed_input"},
+        correlation_id=correlation_id,
+        emit=emit,
+    )
+    if args.events:
+        args.events.parent.mkdir(parents=True, exist_ok=True)
+        with args.events.open("a", encoding="utf-8") as stream:
+            for event in events:
+                stream.write(
+                    json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n"
+                )
+            stream.write(
+                json.dumps(
+                    {
+                        "correlation_id": correlation_id,
+                        "occurred_at": datetime.now(UTC).isoformat(),
+                        "result": result_dict(result),
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+    return 0 if result.status == "shadow_complete" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/brokers/kis/test_lean_execution_once.py
+++ b/tests/brokers/kis/test_lean_execution_once.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from app.services.kis_lean_execution import run_once
+
+
+def test_once_is_fixed_no_order_and_observes_all_six_stages() -> None:
+    events: list[dict[str, object]] = []
+
+    result = run_once(
+        {"symbol": "005930", "price": 70000},
+        correlation_id="test-run",
+        emit=events.append,
+    )
+
+    assert result.status == "shadow_complete"
+    assert result.decision == "NO_ORDER"
+    assert [event["stage"] for event in events] == [
+        "decision",
+        "order_intent",
+        "kis_pre_submit",
+        "fill",
+        "position_reconcile",
+        "discord",
+    ]
+    assert events[1]["output"] == {
+        "kind": "no_order",
+        "side": None,
+        "quantity": None,
+        "decision": "NO_ORDER",
+    }
+    assert events[2]["output"]["accepted_for_submission"] is False
+    assert events[2]["output"]["blocked_reason"] == "account_ownership_unconfirmed"
+    assert events[2]["output"]["concurrent_writer_action"] == "refuse_and_report"
+    assert events[-1]["output"]["must_notify"] is True
+
+
+def test_custom_strategy_is_a_calculation_seam_but_pre_submit_remains_shadow() -> None:
+    class CandidateAdapter:
+        def evaluate(self, snapshot: dict[str, object]) -> dict[str, object]:
+            return {"decision": "NO_ORDER", "signal_emitted": False, "candidate": True}
+
+    events: list[dict[str, object]] = []
+    result = run_once(
+        {"symbol": "005930"},
+        correlation_id="adapter-test",
+        emit=events.append,
+        strategy=CandidateAdapter(),  # type: ignore[arg-type]
+    )
+
+    assert result.status == "shadow_complete"
+    assert events[0]["output"]["candidate"] is True
+    assert events[2]["output"]["accepted_for_submission"] is False
+
+
+def test_strategy_failure_emits_discord_failure_event() -> None:
+    class BrokenAdapter:
+        def evaluate(self, snapshot: dict[str, object]) -> dict[str, object]:
+            raise RuntimeError("synthetic adapter failure")
+
+    events: list[dict[str, object]] = []
+    result = run_once(
+        {"symbol": "005930"},
+        correlation_id="failure-test",
+        emit=events.append,
+        strategy=BrokenAdapter(),  # type: ignore[arg-type]
+    )
+
+    assert result.status == "failed"
+    assert events[-1]["stage"] == "discord"
+    assert events[-1]["status"] == "failed"
+    assert events[-1]["output"]["must_notify"] is True


### PR DESCRIPTION
## Summary
- add a KR-only manual `--once` synthetic/no-op shadow lifecycle
- record six observable stages as JSONL
- structurally block KIS submission until account ownership is confirmed
- no scheduler, broker mutation, ledger write, or Discord webhook side effect

## Verification
- `6 passed` targeted pytest
- `make lint`
- `git ls-remote origin refs/heads/feature/rob-lean-kr-once` verified HEAD

Account writer coordination with the existing `watch_auto_execute_mock` surface is reported as a concern; singleton enforcement remains in the R-3-3 shell scope.