### PR TITLE
feat: canonical Alpaca physical-account routing

### DIFF
--- a/alembic/versions/20260804_alpaca_clean_account_mode.py
+++ b/alembic/versions/20260804_alpaca_clean_account_mode.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "20260804_alpaca_clean_account"
@@ -26,6 +27,44 @@ _LEDGER_TEMP = "alpaca_paper_ledger_account_mode_next"
 _RETRO = "review.trade_retrospectives"
 _RETRO_CHECK = "ck_trade_retrospectives_ck_trade_retrospectives_account_mode"
 _RETRO_TEMP = "trade_retrospectives_account_mode_next"
+_LEDGER_TABLE = "alpaca_paper_order_ledger"
+_LEDGER_SCHEMA = "review"
+
+
+def _table_exists(qualified_name: str) -> bool:
+    """Keep the additive migration safe across legacy downgrade boundaries."""
+
+    schema, table = qualified_name.split(".", maxsplit=1)
+    return (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT EXISTS ("
+                "SELECT 1 FROM pg_catalog.pg_class AS c "
+                "JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace "
+                "WHERE n.nspname = :schema AND c.relname = :table "
+                "AND c.relkind IN ('r', 'p', 'v', 'm', 'f'))"
+            ),
+            {"schema": schema, "table": table},
+        )
+        .scalar()
+    )
+
+
+def _column_exists(table: str, column: str) -> bool:
+    schema, table_name = table.split(".", maxsplit=1)
+    return bool(
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :schema AND table_name = :table "
+                "AND column_name = :column)"
+            ),
+            {"schema": schema, "table": table_name, "column": column},
+        )
+        .scalar()
+    )
 
 
 def _swap(table: str, current: str, temporary: str, expression: str) -> None:
@@ -39,44 +78,63 @@ def _swap(table: str, current: str, temporary: str, expression: str) -> None:
 
 
 def upgrade() -> None:
-    op.add_column(_LEDGER, sa.Column("strategy_key", sa.Text(), nullable=True))
-    _swap(
-        _LEDGER,
-        _LEDGER_CHECK,
-        _LEDGER_TEMP,
-        "account_mode IN ('alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto')",
-    )
-    _swap(
-        _RETRO,
-        _RETRO_CHECK,
-        _RETRO_TEMP,
-        "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
-        "'alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto','upbit_live','paper')",
-    )
+    if _table_exists(_LEDGER):
+        if not _column_exists(_LEDGER, "strategy_key"):
+            op.add_column(
+                _LEDGER_TABLE,
+                sa.Column("strategy_key", sa.Text(), nullable=True),
+                schema=_LEDGER_SCHEMA,
+            )
+        _swap(
+            _LEDGER,
+            _LEDGER_CHECK,
+            _LEDGER_TEMP,
+            "account_mode IN ('alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto')",
+        )
+    if _table_exists(_RETRO):
+        _swap(
+            _RETRO,
+            _RETRO_CHECK,
+            _RETRO_TEMP,
+            "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
+            "'alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto','upbit_live','paper')",
+        )
 
 
 def downgrade() -> None:
-    op.execute(
-        """DO $$ BEGIN
-        IF EXISTS (SELECT 1 FROM review.alpaca_paper_order_ledger
-                   WHERE account_mode = 'alpaca_paper_crypto') OR
-           EXISTS (SELECT 1 FROM review.trade_retrospectives
-                   WHERE account_mode = 'alpaca_paper_crypto') THEN
-            RAISE EXCEPTION 'cannot downgrade: alpaca_paper_crypto rows exist';
-        END IF;
-        END $$;"""
-    )
-    _swap(
-        _RETRO,
-        _RETRO_CHECK,
-        _RETRO_TEMP,
-        "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
-        "'alpaca_paper','alpaca_paper_lab','upbit_live','paper')",
-    )
-    _swap(
-        _LEDGER,
-        _LEDGER_CHECK,
-        _LEDGER_TEMP,
-        "account_mode IN ('alpaca_paper','alpaca_paper_lab')",
-    )
-    op.drop_column(_LEDGER, "strategy_key")
+    ledger_exists = _table_exists(_LEDGER)
+    retro_exists = _table_exists(_RETRO)
+    if ledger_exists or retro_exists:
+        checks = []
+        if ledger_exists:
+            checks.append(
+                "EXISTS (SELECT 1 FROM review.alpaca_paper_order_ledger "
+                "WHERE account_mode = 'alpaca_paper_crypto')"
+            )
+        if retro_exists:
+            checks.append(
+                "EXISTS (SELECT 1 FROM review.trade_retrospectives "
+                "WHERE account_mode = 'alpaca_paper_crypto')"
+            )
+        op.execute(
+            "DO $$ BEGIN IF "
+            + " OR ".join(checks)
+            + " THEN RAISE EXCEPTION 'cannot downgrade: alpaca_paper_crypto rows exist'; "
+            "END IF; END $$;"
+        )
+    if retro_exists:
+        _swap(
+            _RETRO,
+            _RETRO_CHECK,
+            _RETRO_TEMP,
+            "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
+            "'alpaca_paper','alpaca_paper_lab','upbit_live','paper')",
+        )
+    if ledger_exists:
+        _swap(
+            _LEDGER,
+            _LEDGER_CHECK,
+            _LEDGER_TEMP,
+            "account_mode IN ('alpaca_paper','alpaca_paper_lab')",
+        )
+        op.drop_column(_LEDGER_TABLE, "strategy_key", schema=_LEDGER_SCHEMA)

--- a/alembic/versions/20260804_alpaca_clean_account_mode.py
+++ b/alembic/versions/20260804_alpaca_clean_account_mode.py
@@ -1,0 +1,82 @@
+"""Add canonical Alpaca physical-account routing mode additively.
+
+Existing account-mode expressions are widened only; no prior value is removed
+or tightened. The ledger strategy_key is nullable for legacy rows and is not a
+strategy/account hard-coded one-to-one mapping.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260804_alpaca_clean_account"
+down_revision: str | Sequence[str] | None = (
+    "20260727_alpaca_paper_lab",
+    "20260803_research_kr_candles",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_LEDGER = "review.alpaca_paper_order_ledger"
+_LEDGER_CHECK = "ck_alpaca_paper_order_ledger_alpaca_paper_ledger_account_mode"
+_LEDGER_TEMP = "alpaca_paper_ledger_account_mode_next"
+_RETRO = "review.trade_retrospectives"
+_RETRO_CHECK = "ck_trade_retrospectives_ck_trade_retrospectives_account_mode"
+_RETRO_TEMP = "trade_retrospectives_account_mode_next"
+
+
+def _swap(table: str, current: str, temporary: str, expression: str) -> None:
+    op.execute(f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{temporary}"')
+    op.execute(
+        f'ALTER TABLE {table} ADD CONSTRAINT "{temporary}" CHECK ({expression}) NOT VALID'
+    )
+    op.execute(f'ALTER TABLE {table} VALIDATE CONSTRAINT "{temporary}"')
+    op.execute(f'ALTER TABLE {table} DROP CONSTRAINT IF EXISTS "{current}"')
+    op.execute(f'ALTER TABLE {table} RENAME CONSTRAINT "{temporary}" TO "{current}"')
+
+
+def upgrade() -> None:
+    op.add_column(_LEDGER, sa.Column("strategy_key", sa.Text(), nullable=True))
+    _swap(
+        _LEDGER,
+        _LEDGER_CHECK,
+        _LEDGER_TEMP,
+        "account_mode IN ('alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto')",
+    )
+    _swap(
+        _RETRO,
+        _RETRO_CHECK,
+        _RETRO_TEMP,
+        "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
+        "'alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto','upbit_live','paper')",
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """DO $$ BEGIN
+        IF EXISTS (SELECT 1 FROM review.alpaca_paper_order_ledger
+                   WHERE account_mode = 'alpaca_paper_crypto') OR
+           EXISTS (SELECT 1 FROM review.trade_retrospectives
+                   WHERE account_mode = 'alpaca_paper_crypto') THEN
+            RAISE EXCEPTION 'cannot downgrade: alpaca_paper_crypto rows exist';
+        END IF;
+        END $$;"""
+    )
+    _swap(
+        _RETRO,
+        _RETRO_CHECK,
+        _RETRO_TEMP,
+        "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
+        "'alpaca_paper','alpaca_paper_lab','upbit_live','paper')",
+    )
+    _swap(
+        _LEDGER,
+        _LEDGER_CHECK,
+        _LEDGER_TEMP,
+        "account_mode IN ('alpaca_paper','alpaca_paper_lab')",
+    )
+    op.drop_column(_LEDGER, "strategy_key")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -874,10 +874,24 @@ class Settings(BaseSettings):
     # Only paper credentials/endpoint — no live trading support.
     alpaca_paper_api_key: str | None = None
     alpaca_paper_api_secret: SecretStr | None = None
+    alpaca_paper_expected_account_id_suffix: str | None = None
+    alpaca_paper_expected_account_number_suffix: str | None = None
     # directional-lab uses a distinct Alpaca paper account. The endpoint is
     # intentionally shared; credentials are not allowed to fall back.
     alpaca_paper_lab_api_key: str | None = None
     alpaca_paper_lab_api_secret: SecretStr | None = None
+    alpaca_paper_lab_expected_account_id_suffix: str | None = None
+    alpaca_paper_lab_expected_account_number_suffix: str | None = None
+    # Clean-account onboarding. Credentials are intentionally a separate
+    # namespace; they must never fall back to default or lab credentials.
+    alpaca_paper_crypto_enabled: bool = False
+    alpaca_paper_crypto_api_key: str | None = None
+    alpaca_paper_crypto_api_secret: SecretStr | None = None
+    # Expected suffixes are deployment bindings, not account-purpose labels.
+    # They are required for the clean onboarding profile and are never inferred
+    # from the credential keyset or from an MCP/profile name.
+    alpaca_paper_crypto_expected_account_id_suffix: str | None = None
+    alpaca_paper_crypto_expected_account_number_suffix: str | None = None
     alpaca_paper_base_url: str = "https://paper-api.alpaca.markets"
     alpaca_paper_data_base_url: str = "https://data.alpaca.markets"
 

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -59,6 +59,7 @@ def _validate_profile_auth_token(
         McpProfile.ACCOUNT_READ,
         McpProfile.TRADINGCODEX_EXECUTION,
         McpProfile.PAPER_EXECUTION,
+        McpProfile.ALPACA_PAPER_CLEAN,
     }
     if profile in token_required_profiles and not (token or "").strip():
         raise RuntimeError(
@@ -81,6 +82,27 @@ def _validate_profile_auth_token(
 
 
 def _validate_profile_runtime_settings(profile: McpProfile) -> None:
+    if profile is McpProfile.ALPACA_PAPER_CLEAN:
+        if not settings.alpaca_paper_crypto_enabled:
+            raise RuntimeError(
+                "MCP_PROFILE=alpaca-paper-clean requires "
+                "ALPACA_PAPER_CRYPTO_ENABLED=true"
+            )
+        # Validate only non-secret configuration here. The broker service
+        # performs the remote account read and fails closed on mismatch.
+        required = (
+            "alpaca_paper_crypto_api_key",
+            "alpaca_paper_crypto_api_secret",
+            "alpaca_paper_crypto_expected_account_id_suffix",
+            "alpaca_paper_crypto_expected_account_number_suffix",
+        )
+        missing = [name for name in required if not getattr(settings, name, None)]
+        if missing:
+            raise RuntimeError(
+                f"MCP_PROFILE={profile.value} has incomplete Alpaca clean config: "
+                + ", ".join(missing)
+            )
+        return
     if profile is McpProfile.PAPER_EXECUTION:
         if not settings.PAPER_EXECUTION_ENABLED:
             raise RuntimeError(

--- a/app/mcp_server/profiles.py
+++ b/app/mcp_server/profiles.py
@@ -24,6 +24,9 @@ class McpProfile(StrEnum):
     ACCOUNT_READ = "account_read"
     TRADINGCODEX_EXECUTION = "tradingcodex_execution"
     PAPER_EXECUTION = "paper_execution"
+    # Canonical physical-account routing surface. The name is a route label;
+    # strategy/universe admission is governed by separate contracts.
+    ALPACA_PAPER_CLEAN = "alpaca-paper-clean"
 
 
 def resolve_mcp_profile(env: str | None) -> McpProfile:

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -31,6 +31,7 @@ from app.services.alpaca_paper_account_modes import (
     ALPACA_PAPER_LAB_ACCOUNT_MODE,
     normalize_alpaca_paper_account_mode,
     profile_for_account_mode,
+    validate_alpaca_paper_asset_class,
 )
 from app.services.alpaca_paper_ledger_service import (
     KNOWN_OPEN_BROKER_STATUSES,
@@ -257,6 +258,7 @@ async def alpaca_paper_submit_order(
     fallback and this behaviour does not depend on the automated feature flag.
     """
     selected_account_mode = normalize_alpaca_paper_account_mode(account_mode)
+    validate_alpaca_paper_asset_class(selected_account_mode, asset_class)
     validated = PreviewOrderInput(
         symbol=symbol,
         side=side,

--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -19,6 +19,7 @@ from app.services.alpaca_paper_account_modes import (
     ALPACA_PAPER_LAB_ACCOUNT_MODE,
     normalize_alpaca_paper_account_mode,
     profile_for_account_mode,
+    validate_alpaca_paper_asset_class,
 )
 from app.services.brokers.alpaca.exceptions import (
     AlpacaPaperConfigurationError,
@@ -289,6 +290,7 @@ async def alpaca_paper_preview_order(
     tools.
     """
     selected = normalize_alpaca_paper_account_mode(account_mode)
+    validate_alpaca_paper_asset_class(selected, asset_class)
     validated = PreviewOrderInput(
         symbol=symbol,
         side=side,

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -90,6 +90,8 @@ See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 
 from __future__ import annotations
 
+import inspect
+from functools import wraps
 from typing import TYPE_CHECKING
 
 from app.core.config import settings
@@ -221,6 +223,55 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
+class _AccountPinnedMCP:
+    """Registration proxy that binds every registered tool to one account.
+
+    The clean Alpaca profile is a physical-account surface, so its tools must
+    not inherit the legacy ``account_mode='alpaca_paper'`` defaults.  Keeping
+    this at registration time also makes the binding apply uniformly to read,
+    preview, and ledger tools without changing their public direct-call APIs.
+    """
+
+    def __init__(self, mcp: FastMCP, account_mode: str) -> None:
+        self._mcp = mcp
+        self._account_mode = account_mode
+
+    def tool(self, *args, **kwargs):
+        register = self._mcp.tool(*args, **kwargs)
+
+        def decorate(function):
+            signature = inspect.signature(function)
+            account_parameter = signature.parameters.get("account_mode")
+            if account_parameter is None:
+                return register(function)
+
+            @wraps(function)
+            async def pinned(*call_args, **call_kwargs):
+                bound = signature.bind_partial(*call_args, **call_kwargs)
+                supplied = bound.arguments.get("account_mode")
+                if supplied is not None and supplied != self._account_mode:
+                    raise ValueError(
+                        "alpaca-paper-clean tools are pinned to "
+                        f"account_mode='{self._account_mode}'"
+                    )
+                bound.arguments["account_mode"] = self._account_mode
+                return await function(*bound.args, **bound.kwargs)
+
+            pinned.__signature__ = signature.replace(
+                parameters=[
+                    (
+                        parameter.replace(default=self._account_mode)
+                        if name == "account_mode"
+                        else parameter
+                    )
+                    for name, parameter in signature.parameters.items()
+                ]
+            )
+            return register(pinned)
+
+        return decorate
+
+
 def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -> None:
     """Register MCP tools according to the given profile.
 
@@ -273,15 +324,15 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         return
 
     if profile is McpProfile.ALPACA_PAPER_CLEAN:
-        # Default-disabled exact route. Even when enabled this preparation
-        # profile has no order mutation registrar; preview and reconciliation
-        # are separate operator approvals.
+        # Default-disabled exact route. This is a closed-world physical-account
+        # surface: only the clean account's read/preview/ledger tools are
+        # registered, and every one is pinned to its account mode.
         if settings.alpaca_paper_crypto_enabled:
-            register_alpaca_paper_tools(mcp)
-            register_alpaca_paper_preview_tools(mcp)
-            register_alpaca_paper_ledger_read_tools(mcp)
-        # Continue through the common read-only registration block. This route
-        # is not a crypto-purpose branch; it is a physical-account address.
+            clean_mcp = _AccountPinnedMCP(mcp, account_mode="alpaca_paper_crypto")
+            register_alpaca_paper_tools(clean_mcp)
+            register_alpaca_paper_preview_tools(clean_mcp)
+            register_alpaca_paper_ledger_read_tools(clean_mcp)
+        return
 
     if profile is McpProfile.KIWOOM_KR:
         # ROB-1173: constrain the entire profile before any shared registrar

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -272,6 +272,17 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
             register_paper_cohort_control_tools(mcp)
         return
 
+    if profile is McpProfile.ALPACA_PAPER_CLEAN:
+        # Default-disabled exact route. Even when enabled this preparation
+        # profile has no order mutation registrar; preview and reconciliation
+        # are separate operator approvals.
+        if settings.alpaca_paper_crypto_enabled:
+            register_alpaca_paper_tools(mcp)
+            register_alpaca_paper_preview_tools(mcp)
+            register_alpaca_paper_ledger_read_tools(mcp)
+        # Continue through the common read-only registration block. This route
+        # is not a crypto-purpose branch; it is a physical-account address.
+
     if profile is McpProfile.KIWOOM_KR:
         # ROB-1173: constrain the entire profile before any shared registrar
         # runs. This exact-set registration proxy is independent of central

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -798,7 +798,7 @@ class AlpacaPaperOrderLedger(Base):
         ),
         CheckConstraint("broker = 'alpaca'", name="alpaca_paper_ledger_broker"),
         CheckConstraint(
-            "account_mode IN ('alpaca_paper','alpaca_paper_lab')",
+            "account_mode IN ('alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto')",
             name="alpaca_paper_ledger_account_mode",
         ),
         CheckConstraint(
@@ -895,6 +895,9 @@ class AlpacaPaperOrderLedger(Base):
     # Signal provenance (kept separate from execution)
     signal_symbol: Mapped[str | None] = mapped_column(Text)
     signal_venue: Mapped[str | None] = mapped_column(Text)
+    # Strategy ownership is optional for legacy rows, but available for new
+    # canonical routing so fills can be attributed without using account NAV.
+    strategy_key: Mapped[str | None] = mapped_column(Text)
 
     # Execution venue/symbol
     execution_symbol: Mapped[str] = mapped_column(Text, nullable=False)
@@ -1142,7 +1145,7 @@ class TradeRetrospective(Base):
         ),
         CheckConstraint(
             "account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live',"
-            "'alpaca_paper','alpaca_paper_lab','upbit_live','paper')",
+            "'alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto','upbit_live','paper')",
             name="account_mode",
         ),
         CheckConstraint(

--- a/app/services/alpaca_paper_account_modes.py
+++ b/app/services/alpaca_paper_account_modes.py
@@ -54,6 +54,27 @@ def account_mode_for_profile(profile: str | None) -> AlpacaPaperAccountMode:
     )
 
 
+def validate_alpaca_paper_asset_class(
+    account_mode: str,
+    asset_class: str,
+) -> None:
+    """Enforce the asset-class contract owned by the selected account.
+
+    The clean/crypto account is not a generic Alpaca account with a cosmetic
+    symbol list.  It may only receive crypto orders; otherwise the crypto
+    symbol and notional restrictions could be bypassed through the equity
+    validator.
+    """
+
+    normalized_mode = normalize_alpaca_paper_account_mode(account_mode)
+    normalized_asset_class = str(asset_class or "").strip().lower()
+    if (
+        normalized_mode == ALPACA_PAPER_CRYPTO_ACCOUNT_MODE
+        and normalized_asset_class != "crypto"
+    ):
+        raise ValueError("alpaca_paper_crypto supports crypto orders only")
+
+
 __all__ = [
     "ALPACA_PAPER_ACCOUNT_MODE",
     "ALPACA_PAPER_ACCOUNT_MODES",
@@ -63,4 +84,5 @@ __all__ = [
     "account_mode_for_profile",
     "normalize_alpaca_paper_account_mode",
     "profile_for_account_mode",
+    "validate_alpaca_paper_asset_class",
 ]

--- a/app/services/alpaca_paper_account_modes.py
+++ b/app/services/alpaca_paper_account_modes.py
@@ -6,10 +6,17 @@ from typing import Literal, cast
 
 ALPACA_PAPER_ACCOUNT_MODE = "alpaca_paper"
 ALPACA_PAPER_LAB_ACCOUNT_MODE = "alpaca_paper_lab"
-AlpacaPaperAccountMode = Literal["alpaca_paper", "alpaca_paper_lab"]
+ALPACA_PAPER_CRYPTO_ACCOUNT_MODE = "alpaca_paper_crypto"
+AlpacaPaperAccountMode = Literal[
+    "alpaca_paper", "alpaca_paper_lab", "alpaca_paper_crypto"
+]
 
 ALPACA_PAPER_ACCOUNT_MODES = frozenset(
-    {ALPACA_PAPER_ACCOUNT_MODE, ALPACA_PAPER_LAB_ACCOUNT_MODE}
+    {
+        ALPACA_PAPER_ACCOUNT_MODE,
+        ALPACA_PAPER_LAB_ACCOUNT_MODE,
+        ALPACA_PAPER_CRYPTO_ACCOUNT_MODE,
+    }
 )
 
 
@@ -27,6 +34,8 @@ def profile_for_account_mode(account_mode: str) -> str | None:
     normalized = normalize_alpaca_paper_account_mode(account_mode)
     if normalized == ALPACA_PAPER_LAB_ACCOUNT_MODE:
         return "lab"
+    if normalized == ALPACA_PAPER_CRYPTO_ACCOUNT_MODE:
+        return "clean"
     return None
 
 
@@ -38,8 +47,10 @@ def account_mode_for_profile(profile: str | None) -> AlpacaPaperAccountMode:
         return ALPACA_PAPER_ACCOUNT_MODE
     if normalized == "lab":
         return ALPACA_PAPER_LAB_ACCOUNT_MODE
+    if normalized == "clean":
+        return ALPACA_PAPER_CRYPTO_ACCOUNT_MODE
     raise AlpacaPaperConfigurationError(
-        "Alpaca paper profile must be one of: default, lab"
+        "Alpaca paper profile must be one of: default, lab, clean"
     )
 
 
@@ -47,6 +58,7 @@ __all__ = [
     "ALPACA_PAPER_ACCOUNT_MODE",
     "ALPACA_PAPER_ACCOUNT_MODES",
     "ALPACA_PAPER_LAB_ACCOUNT_MODE",
+    "ALPACA_PAPER_CRYPTO_ACCOUNT_MODE",
     "AlpacaPaperAccountMode",
     "account_mode_for_profile",
     "normalize_alpaca_paper_account_mode",

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -283,6 +283,7 @@ class ApprovalProvenance:
     candidate_uuid: uuid.UUID | None = None
     signal_symbol: str | None = None
     signal_venue: str | None = None
+    strategy_key: str | None = None
     workflow_stage: str | None = None
     purpose: str | None = None
     briefing_artifact_run_uuid: uuid.UUID | None = None
@@ -1173,6 +1174,7 @@ class AlpacaPaperLedgerService:
         return {
             "signal_symbol": prov.signal_symbol,
             "signal_venue": prov.signal_venue,
+            "strategy_key": prov.strategy_key,
             "workflow_stage": prov.workflow_stage,
             "purpose": prov.purpose,
             "briefing_artifact_run_uuid": prov.briefing_artifact_run_uuid,
@@ -1504,6 +1506,7 @@ class AlpacaPaperLedgerService:
             "validation_summary": source_row.validation_summary,
             "signal_symbol": source_row.signal_symbol,
             "signal_venue": source_row.signal_venue,
+            "strategy_key": source_row.strategy_key,
             "execution_asset_class": source_row.execution_asset_class,
             "workflow_stage": source_row.workflow_stage,
             "purpose": source_row.purpose,

--- a/app/services/brokers/alpaca/config.py
+++ b/app/services/brokers/alpaca/config.py
@@ -10,12 +10,21 @@ class AlpacaPaperSettings:
     api_key: str
     api_secret: str
     base_url: str = PAPER_TRADING_BASE_URL
+    expected_account_id_suffix: str | None = None
+    expected_account_number_suffix: str | None = None
 
     @classmethod
     def from_app_settings(cls, profile: str | None = None) -> "AlpacaPaperSettings":
         from app.core.config import settings
 
         account_mode = account_mode_for_profile(profile)
+        if (
+            account_mode == "alpaca_paper_crypto"
+            and not settings.alpaca_paper_crypto_enabled
+        ):
+            raise AlpacaPaperConfigurationError(
+                "ALPACA_PAPER_CRYPTO_ENABLED must be true for the clean route"
+            )
         if account_mode == "alpaca_paper_lab":
             key = settings.alpaca_paper_lab_api_key
             secret_field = settings.alpaca_paper_lab_api_secret
@@ -23,16 +32,44 @@ class AlpacaPaperSettings:
                 "alpaca_paper_lab_api_key and "
                 "alpaca_paper_lab_api_secret must both be set"
             )
+            expected_id = settings.alpaca_paper_lab_expected_account_id_suffix
+            expected_number = settings.alpaca_paper_lab_expected_account_number_suffix
+        elif account_mode == "alpaca_paper_crypto":
+            key = settings.alpaca_paper_crypto_api_key
+            secret_field = settings.alpaca_paper_crypto_api_secret
+            required_fields = (
+                "alpaca_paper_crypto_api_key and "
+                "alpaca_paper_crypto_api_secret must both be set"
+            )
+            expected_id = settings.alpaca_paper_crypto_expected_account_id_suffix
+            expected_number = (
+                settings.alpaca_paper_crypto_expected_account_number_suffix
+            )
         else:
             key = settings.alpaca_paper_api_key
             secret_field = settings.alpaca_paper_api_secret
             required_fields = (
                 "alpaca_paper_api_key and alpaca_paper_api_secret must both be set"
             )
+            expected_id = settings.alpaca_paper_expected_account_id_suffix
+            expected_number = settings.alpaca_paper_expected_account_number_suffix
         secret = secret_field.get_secret_value() if secret_field is not None else None
         base_url = str(settings.alpaca_paper_base_url).rstrip("/")
 
         if not key or not secret:
             raise AlpacaPaperConfigurationError(required_fields)
 
-        return cls(api_key=key, api_secret=secret, base_url=base_url)
+        if account_mode == "alpaca_paper_crypto" and (
+            not expected_id or not expected_number
+        ):
+            raise AlpacaPaperConfigurationError(
+                "alpaca_paper_crypto expected account identity suffixes must both be set"
+            )
+
+        return cls(
+            api_key=key,
+            api_secret=secret,
+            base_url=base_url,
+            expected_account_id_suffix=expected_id,
+            expected_account_number_suffix=expected_number,
+        )

--- a/app/services/brokers/alpaca/exceptions.py
+++ b/app/services/brokers/alpaca/exceptions.py
@@ -6,6 +6,10 @@ class AlpacaPaperEndpointError(Exception):
     """Raised when a forbidden or non-paper endpoint is used as the trading base URL."""
 
 
+class AlpacaPaperIdentityMismatch(AlpacaPaperConfigurationError):
+    """Raised when clean-account credentials resolve to another Alpaca account."""
+
+
 class AlpacaPaperRequestError(Exception):
     """Raised when an HTTP request to the Alpaca paper API fails."""
 

--- a/app/services/brokers/alpaca/schemas.py
+++ b/app/services/brokers/alpaca/schemas.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 class AccountSnapshot(BaseModel):
     id: str
+    account_number: str | None = None
     buying_power: Decimal
     cash: Decimal
     portfolio_value: Decimal

--- a/app/services/brokers/alpaca/service.py
+++ b/app/services/brokers/alpaca/service.py
@@ -11,6 +11,7 @@ from app.services.brokers.alpaca.endpoints import (
 from app.services.brokers.alpaca.exceptions import (
     AlpacaPaperConfigurationError,
     AlpacaPaperEndpointError,
+    AlpacaPaperIdentityMismatch,
     AlpacaPaperRequestError,
 )
 from app.services.brokers.alpaca.schemas import (
@@ -40,6 +41,18 @@ class AlpacaPaperBrokerService:
                 else AlpacaPaperSettings.from_app_settings(profile=profile)
             )
 
+        if (
+            profile == "clean"
+            or settings.expected_account_id_suffix is not None
+            or settings.expected_account_number_suffix is not None
+        ) and (
+            not settings.expected_account_id_suffix
+            or not settings.expected_account_number_suffix
+        ):
+            raise AlpacaPaperConfigurationError(
+                "clean Alpaca route requires expected account identity suffixes"
+            )
+
         if not settings.api_key or not settings.api_secret:
             raise AlpacaPaperConfigurationError(
                 "alpaca_paper_api_key and alpaca_paper_api_secret must both be set"
@@ -60,6 +73,8 @@ class AlpacaPaperBrokerService:
             )
 
         self._settings = settings
+        self._identity_verified = False
+        self._identity_check_in_progress = False
         self._transport: HTTPTransport = transport or HttpxTransport(
             base_url=base_url,
             api_key=settings.api_key,
@@ -72,6 +87,16 @@ class AlpacaPaperBrokerService:
         path: str,
         **kwargs: Any,
     ) -> Any:
+        skip_identity = bool(kwargs.pop("_skip_identity", False))
+        if (
+            not skip_identity
+            and not self._identity_verified
+            and (
+                self._settings.expected_account_id_suffix is not None
+                or self._settings.expected_account_number_suffix is not None
+            )
+        ):
+            await self._verify_physical_identity()
         try:
             response = await self._transport.request(method, path, **kwargs)
         except httpx.HTTPError as exc:
@@ -87,6 +112,39 @@ class AlpacaPaperBrokerService:
             return None
 
         return response.json()
+
+    async def _verify_physical_identity(self) -> None:
+        """Bind configured credentials to the configured physical account.
+
+        The expected values are deployment configuration. They are deliberately
+        not derived from ``profile`` or from a crypto/equity label.
+        """
+        if self._identity_verified:
+            return
+        if self._identity_check_in_progress:
+            raise AlpacaPaperConfigurationError(
+                "Alpaca account identity check re-entered"
+            )
+        self._identity_check_in_progress = True
+        try:
+            data = await self._request("GET", "/v2/account", _skip_identity=True)
+            actual_id = str(data.get("id") or "").strip().lower()
+            actual_number = str(data.get("account_number") or "").strip().lower()
+            expected_id = (
+                str(self._settings.expected_account_id_suffix or "").strip().lower()
+            )
+            expected_number = (
+                str(self._settings.expected_account_number_suffix or "").strip().lower()
+            )
+            if not actual_id.endswith(expected_id) or not actual_number.endswith(
+                expected_number
+            ):
+                raise AlpacaPaperIdentityMismatch(
+                    "Alpaca account physical identity mismatch; refusing broker access"
+                )
+            self._identity_verified = True
+        finally:
+            self._identity_check_in_progress = False
 
     async def get_account(self) -> AccountSnapshot:
         data = await self._request("GET", "/v2/account")

--- a/docs/capabilities/alpaca_paper_spot_v1.json
+++ b/docs/capabilities/alpaca_paper_spot_v1.json
@@ -1,0 +1,12 @@
+{
+  "manifest": "alpaca-paper-spot-capability",
+  "version": "2026-08-04.v1",
+  "provider": "alpaca_paper",
+  "read_only_probe": true,
+  "authorization": {
+    "orders_allowed_by_manifest": false,
+    "exact_survivor_universe_approval_required": true
+  },
+  "symbols": ["BTC/USD", "ETH/USD", "SOL/USD"],
+  "notes": "Provider capability evidence is not an order allowlist. Extra pairs require exact survivor-universe approval."
+}

--- a/scripts/alpaca_paper_capability_probe.py
+++ b/scripts/alpaca_paper_capability_probe.py
@@ -1,0 +1,55 @@
+"""Read-only Alpaca capability probe for the canonical clean-account route.
+
+This command only reads ``/v2/assets``. Its output is capability evidence, not
+an order allowlist; survivor-universe approval remains a separate operator
+decision. It never imports an order submitter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import UTC, datetime
+
+from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+
+_CANDIDATES = ("BTC/USD", "ETH/USD", "SOL/USD")
+
+
+async def _probe() -> dict[str, object]:
+    service = AlpacaPaperBrokerService(profile="clean")
+    assets = await service.list_assets(status="active", asset_class="crypto")
+    available = {asset.symbol.upper() for asset in assets}
+    return {
+        "manifest": "alpaca-paper-spot-capability",
+        "version": datetime.now(UTC).strftime("%Y-%m-%d.v1"),
+        "provider": "alpaca_paper",
+        "read_only_probe": True,
+        "authorization": {
+            "orders_allowed_by_manifest": False,
+            "exact_survivor_universe_approval_required": True,
+        },
+        "candidate_symbols": list(_CANDIDATES),
+        "provider_supported_symbols": [
+            symbol for symbol in _CANDIDATES if symbol in available
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        required=True,
+        help="required acknowledgement; this command has no mutation path",
+    )
+    args = parser.parse_args()
+    if not args.read_only:  # pragma: no cover - argparse enforces this
+        raise SystemExit("read-only acknowledgement required")
+    print(json.dumps(asyncio.run(_probe()), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -44,6 +44,9 @@ def test_account_routing_tool_names_register():
 # ROB-760 — account_read is also a physical allowlist profile: it must expose
 # exactly the account-sync read surface pinned in tests/test_mcp_profiles.py,
 # without route/advisory tools.
+#
+# ROB-1782 R2 — alpaca-paper-clean is also a closed-world physical-account
+# surface; it contains only its pinned Alpaca read/preview/ledger tools.
 _READ_PROFILES = [
     p
     for p in McpProfile
@@ -52,6 +55,7 @@ _READ_PROFILES = [
         McpProfile.SHADOW_REPLAY,
         McpProfile.ACCOUNT_READ,
         McpProfile.PAPER_EXECUTION,
+        McpProfile.ALPACA_PAPER_CLEAN,
     )
 ]
 

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -175,7 +175,7 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
         config.set_main_option("script_location", str(REPO / "alembic"))
         expected_head = ScriptDirectory.from_config(config).get_current_head()
         assert expected_head is not None
-        assert current.stdout.strip() == f"{expected_head} (head)"
+        assert current.stdout.strip().startswith(f"{expected_head} (head)")
 
         async with engine.connect() as connection:
             triggers = await connection.scalar(

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -310,6 +310,7 @@ def _make_row(**kwargs) -> Any:
         "record_kind": "execution",
         "broker": "alpaca",
         "account_mode": "alpaca_paper",
+        "strategy_key": None,
         "lifecycle_state": "previewed",
         "execution_symbol": "BTCUSD",
         "execution_venue": "alpaca_paper",

--- a/tests/test_alpaca_clean_identity_binding.py
+++ b/tests/test_alpaca_clean_identity_binding.py
@@ -1,0 +1,74 @@
+"""Physical-account binding tests for canonical Alpaca routing."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.services.brokers.alpaca.config import AlpacaPaperSettings
+from app.services.brokers.alpaca.endpoints import PAPER_TRADING_BASE_URL
+from app.services.brokers.alpaca.exceptions import AlpacaPaperIdentityMismatch
+from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+
+
+def _response(payload: dict[str, object]) -> httpx.Response:
+    return httpx.Response(200, json=payload)
+
+
+def _settings() -> AlpacaPaperSettings:
+    return AlpacaPaperSettings(
+        api_key="key",
+        api_secret="secret",
+        base_url=PAPER_TRADING_BASE_URL,
+        expected_account_id_suffix="c60c74",
+        expected_account_number_suffix="4AE7",
+    )
+
+
+def _account(account_id: str, account_number: str) -> dict[str, object]:
+    return {
+        "id": account_id,
+        "account_number": account_number,
+        "buying_power": "100",
+        "cash": "100",
+        "portfolio_value": "100",
+        "status": "ACTIVE",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clean_route_verifies_physical_identity_before_account_use():
+    transport = AsyncMock()
+    transport.request = AsyncMock(
+        return_value=_response(_account("acct-c60c74", "1234AE7"))
+    )
+    service = AlpacaPaperBrokerService(
+        transport=transport, settings=_settings(), profile="clean"
+    )
+
+    account = await service.get_account()
+
+    assert account.id == "acct-c60c74"
+    assert transport.request.await_count == 2  # bind, then return the snapshot
+    assert all(
+        call.args[:2] == ("GET", "/v2/account")
+        for call in transport.request.await_args_list
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clean_route_fails_closed_on_identity_mismatch():
+    transport = AsyncMock()
+    transport.request = AsyncMock(
+        return_value=_response(_account("acct-other", "1234AE7"))
+    )
+    service = AlpacaPaperBrokerService(
+        transport=transport, settings=_settings(), profile="clean"
+    )
+
+    with pytest.raises(AlpacaPaperIdentityMismatch):
+        await service.list_positions()
+
+    assert transport.request.await_count == 1

--- a/tests/test_alpaca_paper_lab_profile.py
+++ b/tests/test_alpaca_paper_lab_profile.py
@@ -152,8 +152,14 @@ def test_existing_check_constraints_only_gain_lab_value():
         if hasattr(item, "sqltext")
     )
 
-    assert "account_mode IN ('alpaca_paper','alpaca_paper_lab')" in ledger_checks
-    assert "'alpaca_paper','alpaca_paper_lab','upbit_live'" in retrospective_checks
+    assert (
+        "account_mode IN ('alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto')"
+        in ledger_checks
+    )
+    assert (
+        "'alpaca_paper','alpaca_paper_lab','alpaca_paper_crypto','upbit_live','paper'"
+        in retrospective_checks
+    )
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -2128,6 +2128,8 @@ class TestGetFxRateToolRegistration:
     #
     # ROB-760 — account_read is a physical account-sync allowlist and must not
     # inherit fundamentals tools.
+    # ROB-1782 R2 — alpaca-paper-clean is a closed-world physical-account
+    # surface and must not inherit the common fundamentals block.
     @pytest.mark.parametrize(
         "profile",
         [
@@ -2138,6 +2140,7 @@ class TestGetFxRateToolRegistration:
                 McpProfile.SHADOW_REPLAY,
                 McpProfile.ACCOUNT_READ,
                 McpProfile.PAPER_EXECUTION,
+                McpProfile.ALPACA_PAPER_CLEAN,
             )
         ],
     )

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -419,6 +419,7 @@ _ORDER_SURFACE_MATRIX: dict[McpProfile, set[str]] = {
     # Default-off profile: the direct registry exposes zero tools until the
     # dedicated feature flag is explicitly enabled.
     McpProfile.PAPER_EXECUTION: set(),
+    McpProfile.ALPACA_PAPER_CLEAN: set(),
 }
 _ALL_ORDER_TOOL_NAMES = (
     _LEGACY_ORDER_TOOL_NAMES

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -8,6 +8,7 @@ Verifies that:
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, cast
 
 import pytest
@@ -203,6 +204,68 @@ class TestUsPaperProfile:
     def test_registers_us_paper_tools(self) -> None:
         mcp = _build_mcp(McpProfile.US_PAPER)
         assert _US_PAPER_TOOL_NAMES <= mcp.tools.keys()
+
+
+class TestAlpacaCleanProfile:
+    def test_is_closed_world_and_contains_only_clean_alpaca_tools(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "alpaca_paper_crypto_enabled", True)
+        mcp = _build_mcp(McpProfile.ALPACA_PAPER_CLEAN)
+
+        assert len(mcp.tools) == 13
+        assert set(mcp.tools) == (
+            ALPACA_PAPER_READONLY_TOOL_NAMES
+            | ALPACA_PAPER_PREVIEW_TOOL_NAMES
+            | {
+                "alpaca_paper_ledger_list_recent",
+                "alpaca_paper_ledger_get",
+                "alpaca_paper_ledger_get_by_correlation",
+                "alpaca_paper_roundtrip_report",
+                "alpaca_paper_execution_preflight_check",
+            }
+        )
+        assert "kis_mock_mirror_execute_report" not in mcp.tools
+        assert _ALL_ORDER_TOOL_NAMES.isdisjoint(mcp.tools)
+
+    def test_pins_account_mode_and_rejects_other_account(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "alpaca_paper_crypto_enabled", True)
+        mcp = _build_mcp(McpProfile.ALPACA_PAPER_CLEAN)
+        get_account = mcp.tools["alpaca_paper_get_account"]
+
+        assert (
+            inspect.signature(get_account).parameters["account_mode"].default
+            == "alpaca_paper_crypto"
+        )
+        with pytest.raises(ValueError, match="pinned to account_mode"):
+            import asyncio
+
+            asyncio.run(get_account(account_mode="alpaca_paper"))
+
+        preview = mcp.tools["alpaca_paper_preview_order"]
+        with pytest.raises(ValueError, match="supports crypto orders only"):
+            asyncio.run(
+                preview(
+                    symbol="AAPL",
+                    side="buy",
+                    type="limit",
+                    qty=1,
+                    limit_price=100,
+                )
+            )
+        with pytest.raises(ValueError, match="crypto symbol must be one of"):
+            asyncio.run(
+                preview(
+                    symbol="XRP/USD",
+                    side="buy",
+                    type="limit",
+                    qty=1,
+                    limit_price=1,
+                    asset_class="crypto",
+                )
+            )
 
 
 class TestDbPaperProfile:
@@ -470,6 +533,7 @@ _PROFILES_WITH_RESEARCH_SURFACE = [
         McpProfile.ACCOUNT_READ,
         McpProfile.TRADINGCODEX_EXECUTION,
         McpProfile.PAPER_EXECUTION,
+        McpProfile.ALPACA_PAPER_CLEAN,
     )
 ]
 

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -147,6 +147,7 @@ def _load_main_module(
     account_read_profile = _FakeProfileMember("account_read")
     tradingcodex_execution_profile = _FakeProfileMember("tradingcodex_execution")
     paper_execution_profile = _FakeProfileMember("paper_execution")
+    alpaca_paper_clean_profile = _FakeProfileMember("alpaca-paper-clean")
     default_profile = _FakeProfileMember("default")
     kiwoom_profile = _FakeProfileMember("kiwoom")
     kiwoom_kr_profile = _FakeProfileMember("kiwoom_kr")
@@ -170,6 +171,7 @@ def _load_main_module(
         ACCOUNT_READ=account_read_profile,
         TRADINGCODEX_EXECUTION=tradingcodex_execution_profile,
         PAPER_EXECUTION=paper_execution_profile,
+        ALPACA_PAPER_CLEAN=alpaca_paper_clean_profile,
         DEFAULT=default_profile,
         KIWOOM=kiwoom_profile,
         KIWOOM_KR=kiwoom_kr_profile,

--- a/tests/test_route_request.py
+++ b/tests/test_route_request.py
@@ -296,7 +296,12 @@ class TestRouteRequestRegisteredEveryProfile:
         [
             profile
             for profile in McpProfile
-            if profile not in (McpProfile.ACCOUNT_READ, McpProfile.PAPER_EXECUTION)
+            if profile
+            not in (
+                McpProfile.ACCOUNT_READ,
+                McpProfile.PAPER_EXECUTION,
+                McpProfile.ALPACA_PAPER_CLEAN,
+            )
         ],
     )
     def test_route_request_present(self, profile: McpProfile) -> None:


### PR DESCRIPTION
## Summary
- add `alpaca_paper_crypto` account mode with isolated credentials and default-off `alpaca-paper-clean` MCP route
- verify configured Alpaca account id/number suffixes before broker access and fail closed on mismatch
- widen ledger/retrospective account-mode checks additively and add versioned read-only capability manifest/probe

## Safety
- no orders, account mutations, or arming performed
- manifest explicitly is not order authorization; initial symbols are BTC/USD, ETH/USD, SOL/USD
- baseline snapshot and attributed fill PnL remain unsupported and are recorded as follow-up requirements

## Verification
- `uv run ruff check .`
- `uv run pytest tests/test_alpaca_paper*.py tests/test_mcp_alpaca_paper*.py tests/test_mcp_profiles.py -q`
- 309 passed