### PR TITLE
feat: three-market shadow calculation parity

### DIFF
--- a/app/services/kis_lean_execution.py
+++ b/app/services/kis_lean_execution.py
@@ -10,6 +10,8 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Literal
 
+from research.three_market_shadow.calculations import calculate_signal
+
 Stage = Literal[
     "decision",
     "order_intent",
@@ -19,6 +21,20 @@ Stage = Literal[
     "discord",
 ]
 EventSink = Callable[[dict[str, object]], None]
+
+ACCEPTANCE_LABELS: dict[str, str] = {
+    "purpose": "execution_acceptance",
+    "sample_class": "ACCEPTANCE_ONLY",
+    "signal_source": "UNTESTED_RESEARCH_SHADOW",
+    "evidence_preserved": "YES",
+    "scoring_eligible": "EXCLUDE",
+    "forecast_calibration_eligible": "EXCLUDE",
+    "trade_performance_eligible": "EXCLUDE",
+    "strategy_promotion_credit": "NONE",
+    "paper_go_live_credit": "NONE",
+    "operational_reliability_eligible": "UNIDENTIFIABLE",
+    "completion_name": "BROKER_ACCEPTANCE_PASSED",
+}
 
 
 @dataclass(frozen=True)
@@ -30,14 +46,14 @@ class LeanRunResult:
 
 
 class SyntheticNoOpStrategy:
-    """Replaceable calculation seam; it can never emit an order signal."""
+    """KR research shadow adapter; it can never authorize an order."""
 
     def evaluate(self, snapshot: Mapping[str, object]) -> dict[str, object]:
+        signal = calculate_signal("kr", snapshot)
         return {
             "decision": "NO_ORDER",
             "symbol": snapshot.get("symbol", "005930"),
-            "reason": "synthetic_no_op",
-            "signal_emitted": False,
+            **signal,
         }
 
 
@@ -88,6 +104,7 @@ def run_once(
     try:
         decision_input = {"symbol": snapshot.get("symbol", "005930")}
         decision = strategy.evaluate(snapshot)
+        decision["labels"] = dict(ACCEPTANCE_LABELS)
         emit(_event(correlation_id, "decision", "completed", decision_input, decision))
         stages.append("decision")
 

--- a/app/services/three_market_shadow.py
+++ b/app/services/three_market_shadow.py
@@ -1,0 +1,40 @@
+"""Mutation-free three-market shadow lifecycle helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from research.three_market_shadow.calculations import CONTRACT_HASH, calculate_signal
+
+ACCEPTANCE_LABELS: dict[str, str] = {
+    "purpose": "execution_acceptance",
+    "sample_class": "ACCEPTANCE_ONLY",
+    "signal_source": "UNTESTED_RESEARCH_SHADOW",
+    "evidence_preserved": "YES",
+    "scoring_eligible": "EXCLUDE",
+    "forecast_calibration_eligible": "EXCLUDE",
+    "trade_performance_eligible": "EXCLUDE",
+    "strategy_promotion_credit": "NONE",
+    "paper_go_live_credit": "NONE",
+    "operational_reliability_eligible": "UNIDENTIFIABLE",
+    "completion_name": "BROKER_ACCEPTANCE_PASSED",
+}
+
+
+def shadow_decision(market: str, snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a research observation with an unconditional no-order decision."""
+    signal = calculate_signal(market, snapshot)
+    labels = dict(ACCEPTANCE_LABELS)
+    labels["signal_source"] = str(signal["signal_source"])
+    return {
+        "signal": signal,
+        "contract_hash": CONTRACT_HASH,
+        "labels": labels,
+        "order_count": 0,
+        "account_mutations": 0,
+        "arm": False,
+    }
+
+
+__all__ = ["ACCEPTANCE_LABELS", "CONTRACT_HASH", "shadow_decision"]

--- a/app/services/three_market_shadow_lifecycle.py
+++ b/app/services/three_market_shadow_lifecycle.py
@@ -1,0 +1,20 @@
+"""Deterministic crypto acceptance-path observation; no broker calls."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from research.three_market_shadow.calculations import calculate_crypto_synthetic
+
+
+def verify_crypto_acceptance_path() -> list[dict[str, Any]]:
+    """Prove signal→intent→block→kill/restart without submitting anything."""
+    signal = calculate_crypto_synthetic()
+    intent = {"kind": "order_intent", "signal": signal, "submit": False}
+    blocked = {"kind": "pre_submit_block", "accepted_for_submission": False}
+    killed = {"kind": "kill", "armed": False, "reason": "shadow_only"}
+    restarted = {"kind": "restart", "armed": False, "orders": 0}
+    return [signal, intent, blocked, killed, restarted]
+
+
+__all__ = ["verify_crypto_acceptance_path"]

--- a/research/kr_corpus/backtest/README.md
+++ b/research/kr_corpus/backtest/README.md
@@ -1,4 +1,4 @@
-# KR backtest harness (Stage A — fixture wiring)
+# KR backtest harness (Stage A wiring + Stage-B execution bridge)
 
 `JOB_PURPOSE=BACKTEST_HARNESS_WIRING_ONLY`
 
@@ -10,6 +10,35 @@ Research-only surface under `research/kr_corpus/backtest/`. Wires:
 * PIT universe from membership snapshots only
 * explicit delisted terminal events (no silent drop)
 * common KR/US baseline pipeline smoke `liquidity_proxy_decile_topN_D5` labeled **`PIPELINE_SMOKE_NOT_A_STRATEGY`**
+* KR Stage-B `rev3_reclaim` bridge, using the shadow3 canonical signal owner
+  (`research.three_market_shadow.calculations.calculate_signal`)
+
+## Stage-B contract
+
+Stage-B is a research backtest track, separate from execution acceptance. It
+uses **t+1 open** for entry and **D+5 close** for exit. A run must explicitly
+name `--cost-profile 43bp` or `--cost-profile 83bp`; there is no default cost
+injection. The approved literals are:
+
+* `43bp`: fee 3bp + transaction tax 20bp + slippage 10bp per side.
+* `83bp`: fee 3bp + transaction tax 20bp + slippage 30bp per side.
+
+The real-data runner verifies selected main-snapshot parquet bytes against
+`checksums.sha256`, refuses holdout paths/dates, and writes canonical
+`honest_trial.v3` evidence only after closed-trade statistics exist:
+
+```bash
+uv run python scripts/run_kr_stageb.py \
+  --artifact-root /Users/mgh3326/work/herdr-artifacts/kr-corpus-v1 \
+  --run-id kr-corpus-v1-20260803-1001 \
+  --start 2015-01-01 --end 2024-12-31 \
+  --market KOSPI --market KOSDAQ --max-symbols 20 \
+  --cost-profile 43bp \
+  --evidence /path/to/stageb-evidence.json
+```
+
+The result is descriptive research evidence only. It does not authorize
+orders, account mutation, broker calls, holdout access, or promotion.
 
 ## D5 baseline definition
 

--- a/research/kr_corpus/backtest/README.md
+++ b/research/kr_corpus/backtest/README.md
@@ -24,8 +24,12 @@ injection. The approved literals are:
 * `83bp`: fee 3bp + transaction tax 20bp + slippage 30bp per side.
 
 The real-data runner verifies selected main-snapshot parquet bytes against
-`checksums.sha256`, refuses holdout paths/dates, and writes canonical
-`honest_trial.v3` evidence only after closed-trade statistics exist:
+`checksums.sha256`, verifies the signed XKRX session reference in
+`preflight.json`, refuses holdout paths/dates, and writes canonical
+`honest_trial.v3` evidence only after closed-trade statistics exist. D+5 is
+accepted only when each symbol's t+1…t+5 bars exactly match that market-session
+sequence; calendar-day gap thresholds are not used. Evidence records selected
+symbol, bar, and year coverage so partition loss is reviewable:
 
 ```bash
 uv run python scripts/run_kr_stageb.py \

--- a/research/kr_corpus/backtest/README.md
+++ b/research/kr_corpus/backtest/README.md
@@ -23,13 +23,21 @@ injection. The approved literals are:
 * `43bp`: fee 3bp + transaction tax 20bp + slippage 10bp per side.
 * `83bp`: fee 3bp + transaction tax 20bp + slippage 30bp per side.
 
-The real-data runner verifies selected main-snapshot parquet bytes against
-`checksums.sha256`, verifies the signed XKRX session reference in
-`preflight.json`, refuses holdout paths/dates, and writes canonical
-`honest_trial.v3` evidence only after closed-trade statistics exist. D+5 is
-accepted only when each symbol's t+1…t+5 bars exactly match that market-session
-sequence; calendar-day gap thresholds are not used. Evidence records selected
-symbol, bar, and year coverage so partition loss is reviewable:
+The real-data runner accepts only the reviewed frozen main snapshot: source code
+pins both its `checksums.sha256` and `manifest.json` SHA-256 digests. It rejects
+duplicate or path-ambiguous checksum rows, verifies
+`manifest.checksums_sha256`, cross-checks the XKRX session reference in
+`preflight.json` against the pinned `exchange_calendars` XKRX calendar, verifies
+selected main-snapshot parquet bytes, refuses holdout paths/dates, and writes
+canonical `honest_trial.v3` evidence only after closed-trade statistics exist.
+D+5 is accepted only when each symbol's t+1…t+5 bars exactly match that
+market-session sequence; calendar-day gap thresholds are not used. Evidence
+records selected symbol, bar, and year coverage so partition loss is reviewable.
+
+The code-pinned digest is the trust root, not a detached artifact signature. A
+future snapshot therefore requires a reviewed source update with its run ID and
+both digest literals. A party able to replace the executable source/build can
+also replace that root; this loader does not claim to defend that boundary.
 
 ```bash
 uv run python scripts/run_kr_stageb.py \

--- a/research/kr_corpus/backtest/__init__.py
+++ b/research/kr_corpus/backtest/__init__.py
@@ -1,9 +1,10 @@
-"""KR backtest harness — Stage A wiring (fixture only).
+"""KR backtest harness — Stage A wiring plus a bounded Stage-B bridge.
 
 JOB_PURPOSE=BACKTEST_HARNESS_WIRING_ONLY
 
-This package wires loaders, PIT membership, holdout refusal, and a
-pipeline-smoke baseline. It is **not** strategy research.
+This package wires loaders, PIT membership, holdout refusal, a pipeline-smoke
+baseline, and an explicit-contract Stage-B bridge. The Stage-B result remains
+unpromoted research evidence.
 
 Schema contracts are **inferred from kr-corpus-v1 brief §3 literals** and
 must be loud-failed against a real terminal manifest when Stage B opens.

--- a/research/kr_corpus/backtest/evidence.py
+++ b/research/kr_corpus/backtest/evidence.py
@@ -24,13 +24,17 @@ def write_stage_b_evidence(path: Path, result: StageBResult) -> dict[str, Any]:
         config_hash=result.contract.config_hash,
         execution_cost={
             "fee_bps": float(result.contract.cost.fee_bp),
+            "transaction_tax_bps": float(result.contract.cost.transaction_tax_bp),
             "half_spread_bps": 0.0,
-            "slippage_bps": float(result.contract.cost.slippage_bp_per_side),
+            "slippage_bps": float(2 * result.contract.cost.slippage_bp_per_side),
         },
         sharpe=float(stats["sharpe"]),
         p_value=float(stats["p_value"]),
         sample_size=int(stats["sample_size"]),
         validation_score=float(stats["validation_score"]),
+        sharpe_method="pooled_sample_sharpe",
+        p_value_method="not_computed",
+        selection_score_method="arithmetic_mean_net_return",
     )
     payload: dict[str, Any] = {
         "artifact_kind": "KR_STAGE_B_TRIAL_EVIDENCE",

--- a/research/kr_corpus/backtest/evidence.py
+++ b/research/kr_corpus/backtest/evidence.py
@@ -1,0 +1,50 @@
+"""Stage-B trial evidence writer using the repository's canonical contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from research_contracts.trial_evidence import build_trial_evidence
+
+try:
+    from .stage_b import StageBResult, descriptive_trial_statistics
+except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
+    from stage_b import StageBResult, descriptive_trial_statistics
+
+__all__ = ["write_stage_b_evidence"]
+
+
+def write_stage_b_evidence(path: Path, result: StageBResult) -> dict[str, Any]:
+    """Write re-judgable evidence; acceptance labels stay on their own track."""
+    stats = descriptive_trial_statistics(result)
+    trial_evidence = build_trial_evidence(
+        parameter_key="rev3_reclaim",
+        config_hash=result.contract.config_hash,
+        execution_cost={
+            "fee_bps": float(result.contract.cost.fee_bp),
+            "half_spread_bps": 0.0,
+            "slippage_bps": float(result.contract.cost.slippage_bp_per_side),
+        },
+        sharpe=float(stats["sharpe"]),
+        p_value=float(stats["p_value"]),
+        sample_size=int(stats["sample_size"]),
+        validation_score=float(stats["validation_score"]),
+    )
+    payload: dict[str, Any] = {
+        "artifact_kind": "KR_STAGE_B_TRIAL_EVIDENCE",
+        "track": "strategy_backtest",
+        "strategy": "rev3_reclaim",
+        "strategy_status": "UNTESTED_RESEARCH_SHADOW",
+        "acceptance_track_separate": True,
+        "signal_contract_hash": result.contract.signal_contract_hash,
+        "run_contract": result.to_dict(),
+        "trial_evidence": trial_evidence,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return payload

--- a/research/kr_corpus/backtest/holdout_guard.py
+++ b/research/kr_corpus/backtest/holdout_guard.py
@@ -25,7 +25,10 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 
-from windows import HOLDOUT_WINDOW, parse_iso_date
+try:
+    from .windows import HOLDOUT_WINDOW, parse_iso_date
+except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
+    from windows import HOLDOUT_WINDOW, parse_iso_date
 
 __all__ = [
     "DEFAULT_HOLDOUT_POLICY",

--- a/research/kr_corpus/backtest/pit.py
+++ b/research/kr_corpus/backtest/pit.py
@@ -16,8 +16,13 @@ from dataclasses import dataclass
 from datetime import date, datetime
 
 import pyarrow as pa
-from holdout_guard import assert_date_not_holdout
-from windows import parse_iso_date
+
+try:
+    from .holdout_guard import assert_date_not_holdout
+    from .windows import parse_iso_date
+except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
+    from holdout_guard import assert_date_not_holdout
+    from windows import parse_iso_date
 
 __all__ = [
     "Bar",

--- a/research/kr_corpus/backtest/real_data.py
+++ b/research/kr_corpus/backtest/real_data.py
@@ -53,8 +53,9 @@ def load_real_main_bars(
     checksums = _checksum_index(checksum_path)
     selected_markets = frozenset(markets)
     files = sorted((root / "dataset").glob("market=*/year=*/ticker=*.parquet"))
-    selected: list[Path] = []
-    symbols: set[str] = set()
+    candidates_by_market: dict[str, list[Path]] = {
+        market: [] for market in selected_markets
+    }
     for path in files:
         relative = path.relative_to(root).as_posix()
         parts = path.parts
@@ -67,23 +68,56 @@ def load_real_main_bars(
         if year < window_start.year or year > window_end.year:
             continue
         symbol = path.stem.split("=", 1)[1]
-        if (
-            market not in selected_markets
-            or symbol not in symbols
-            and len(symbols) >= max_symbols
-        ):
+        if market not in selected_markets:
             continue
-        expected = checksums.get(relative)
-        if expected is None:
-            raise ValueError(
-                f"selected parquet missing checksum ledger row: {relative}"
-            )
-        data = path.read_bytes()
-        actual = hashlib.sha256(data).hexdigest()
-        if actual != expected:
-            raise ValueError(f"checksum mismatch: {relative}")
-        selected.append(path)
-        symbols.add(symbol)
+        candidates_by_market[market].append(path)
+
+    missing_markets = sorted(
+        market for market, paths in candidates_by_market.items() if not paths
+    )
+    if missing_markets:
+        raise ValueError(
+            f"requested market has no bounded corpus data: {missing_markets}"
+        )
+
+    # Deterministic round-robin selection prevents the first glob partition
+    # from exhausting the quota for one market and silently dropping another.
+    candidates_by_market = {
+        market: sorted(paths, key=lambda path: path.name)
+        for market, paths in candidates_by_market.items()
+    }
+    selected: list[Path] = []
+    selected_keys: set[tuple[str, str]] = set()
+    cursors = dict.fromkeys(sorted(selected_markets), 0)
+    while len(selected) < max_symbols:
+        progressed = False
+        for market in sorted(selected_markets):
+            candidates = candidates_by_market[market]
+            while cursors[market] < len(candidates):
+                path = candidates[cursors[market]]
+                cursors[market] += 1
+                symbol = path.stem.split("=", 1)[1]
+                key = (market, symbol)
+                if key in selected_keys:
+                    continue
+                relative = path.relative_to(root).as_posix()
+                expected = checksums.get(relative)
+                if expected is None:
+                    raise ValueError(
+                        f"selected parquet missing checksum ledger row: {relative}"
+                    )
+                data = path.read_bytes()
+                actual = hashlib.sha256(data).hexdigest()
+                if actual != expected:
+                    raise ValueError(f"checksum mismatch: {relative}")
+                selected.append(path)
+                selected_keys.add(key)
+                progressed = True
+                break
+            if len(selected) >= max_symbols:
+                break
+        if not progressed:
+            break
     bars: list[Bar] = []
     for path in selected:
         table = pq.read_table(path)

--- a/research/kr_corpus/backtest/real_data.py
+++ b/research/kr_corpus/backtest/real_data.py
@@ -8,9 +8,12 @@ before parsing and refuses holdout paths/dates.
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import pyarrow.parquet as pq
 
@@ -23,7 +26,20 @@ try:
 except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
     from pit import Bar, bars_from_table
 
-__all__ = ["load_real_main_bars"]
+__all__ = [
+    "RealMainStageBInput",
+    "load_real_main_bars",
+    "load_real_main_stage_b_input",
+]
+
+
+@dataclass(frozen=True)
+class RealMainStageBInput:
+    """Verified main-corpus input plus the evidence needed to judge it."""
+
+    bars: tuple[Bar, ...]
+    market_sessions: Mapping[str, tuple[date, ...]]
+    coverage: Mapping[str, Any]
 
 
 def _checksum_index(path: Path) -> dict[str, str]:
@@ -32,6 +48,71 @@ def _checksum_index(path: Path) -> dict[str, str]:
         digest, relative = line.split("  ", maxsplit=1)
         index[relative] = digest
     return index
+
+
+def _checked_bytes(
+    *,
+    root: Path,
+    path: Path,
+    checksums: Mapping[str, str],
+    kind: str,
+) -> bytes:
+    relative = path.relative_to(root).as_posix()
+    expected = checksums.get(relative)
+    if expected is None:
+        raise ValueError(f"{kind} missing checksum ledger row: {relative}")
+    data = path.read_bytes()
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise ValueError(f"checksum mismatch: {relative}")
+    return data
+
+
+def _load_market_sessions(
+    *,
+    root: Path,
+    checksums: Mapping[str, str],
+    window_start: date,
+    window_end: date,
+    markets: Iterable[str],
+) -> dict[str, tuple[date, ...]]:
+    """Load the signed XKRX sequence without deriving sessions from one symbol."""
+    preflight_bytes = _checked_bytes(
+        root=root,
+        path=root / "preflight.json",
+        checksums=checksums,
+        kind="market-session reference",
+    )
+    try:
+        payload = json.loads(preflight_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError("market-session reference is not valid JSON") from exc
+    if payload.get("session_calendar") != "XKRX":
+        raise ValueError("market-session reference must name the XKRX calendar")
+    raw_sessions = payload.get("sessions")
+    if not isinstance(raw_sessions, list) or not all(
+        isinstance(value, str) for value in raw_sessions
+    ):
+        raise ValueError("market-session reference has no string session sequence")
+
+    start = window_start.isoformat()
+    end = window_end.isoformat()
+    selected_raw_sessions = tuple(
+        value for value in raw_sessions if start <= value <= end
+    )
+    try:
+        sessions = tuple(date.fromisoformat(value) for value in selected_raw_sessions)
+    except ValueError as exc:
+        raise ValueError(
+            "market-session reference contains an invalid session"
+        ) from exc
+    if not sessions:
+        raise ValueError("market-session reference has no sessions in run window")
+    if tuple(sorted(sessions)) != sessions or len(set(sessions)) != len(sessions):
+        raise ValueError(
+            "market-session reference must be strictly ascending and unique"
+        )
+    return dict.fromkeys(sorted(set(markets)), sessions)
 
 
 def load_real_main_bars(
@@ -43,7 +124,29 @@ def load_real_main_bars(
     markets: Iterable[str],
     max_symbols: int,
 ) -> list[Bar]:
-    """Load an explicit bounded selection from main-only real data."""
+    """Load only the bars from the verified Stage-B main-corpus input."""
+    return list(
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=window_start,
+            window_end=window_end,
+            markets=markets,
+            max_symbols=max_symbols,
+        ).bars
+    )
+
+
+def load_real_main_stage_b_input(
+    *,
+    artifact_root: Path,
+    run_id: str,
+    window_start: date,
+    window_end: date,
+    markets: Iterable[str],
+    max_symbols: int,
+) -> RealMainStageBInput:
+    """Select symbols once, then load every in-window yearly partition for each."""
     assert_range_not_holdout(window_start, window_end)
     if max_symbols < 1:
         raise ValueError("max_symbols must be positive and explicit")
@@ -52,12 +155,14 @@ def load_real_main_bars(
     checksum_path = root / "checksums.sha256"
     checksums = _checksum_index(checksum_path)
     selected_markets = frozenset(markets)
+    if not selected_markets:
+        raise ValueError("at least one market must be explicit")
     files = sorted((root / "dataset").glob("market=*/year=*/ticker=*.parquet"))
-    candidates_by_market: dict[str, list[Path]] = {
-        market: [] for market in selected_markets
+    symbols_by_market: dict[str, set[str]] = {
+        market: set() for market in selected_markets
     }
+    partitions_by_key: dict[tuple[str, str], list[tuple[int, Path]]] = {}
     for path in files:
-        relative = path.relative_to(root).as_posix()
         parts = path.parts
         market = next(
             part.split("=", 1)[1] for part in parts if part.startswith("market=")
@@ -70,60 +175,125 @@ def load_real_main_bars(
         symbol = path.stem.split("=", 1)[1]
         if market not in selected_markets:
             continue
-        candidates_by_market[market].append(path)
+        key = (market, symbol)
+        symbols_by_market[market].add(symbol)
+        partitions_by_key.setdefault(key, []).append((year, path))
 
     missing_markets = sorted(
-        market for market, paths in candidates_by_market.items() if not paths
+        market for market, symbols in symbols_by_market.items() if not symbols
     )
     if missing_markets:
         raise ValueError(
             f"requested market has no bounded corpus data: {missing_markets}"
         )
 
-    # Deterministic round-robin selection prevents the first glob partition
-    # from exhausting the quota for one market and silently dropping another.
+    # Select identities, rather than parquet files: every selected identity then
+    # loads its complete in-window partition set.
     candidates_by_market = {
-        market: sorted(paths, key=lambda path: path.name)
-        for market, paths in candidates_by_market.items()
+        market: sorted(symbols) for market, symbols in symbols_by_market.items()
     }
-    selected: list[Path] = []
-    selected_keys: set[tuple[str, str]] = set()
+    selected_keys: list[tuple[str, str]] = []
     cursors = dict.fromkeys(sorted(selected_markets), 0)
-    while len(selected) < max_symbols:
+    while len(selected_keys) < max_symbols:
         progressed = False
         for market in sorted(selected_markets):
             candidates = candidates_by_market[market]
             while cursors[market] < len(candidates):
-                path = candidates[cursors[market]]
+                symbol = candidates[cursors[market]]
                 cursors[market] += 1
-                symbol = path.stem.split("=", 1)[1]
-                key = (market, symbol)
-                if key in selected_keys:
-                    continue
-                relative = path.relative_to(root).as_posix()
-                expected = checksums.get(relative)
-                if expected is None:
-                    raise ValueError(
-                        f"selected parquet missing checksum ledger row: {relative}"
-                    )
-                data = path.read_bytes()
-                actual = hashlib.sha256(data).hexdigest()
-                if actual != expected:
-                    raise ValueError(f"checksum mismatch: {relative}")
-                selected.append(path)
-                selected_keys.add(key)
+                selected_keys.append((market, symbol))
                 progressed = True
                 break
-            if len(selected) >= max_symbols:
+            if len(selected_keys) >= max_symbols:
                 break
         if not progressed:
             break
+
+    market_sessions = _load_market_sessions(
+        root=root,
+        checksums=checksums,
+        window_start=window_start,
+        window_end=window_end,
+        markets=selected_markets,
+    )
     bars: list[Bar] = []
-    for path in selected:
-        table = pq.read_table(path)
-        bars.extend(
-            bar
-            for bar in bars_from_table(table)
-            if window_start <= bar.session_date <= window_end
+    symbol_coverage: dict[tuple[str, str], dict[str, Any]] = {
+        key: {"bar_count": 0, "years": set()} for key in selected_keys
+    }
+    for market, symbol in selected_keys:
+        partitions = sorted(
+            partitions_by_key[(market, symbol)],
+            key=lambda item: (item[0], item[1].name),
         )
-    return bars
+        for _, path in partitions:
+            assert_path_not_holdout(path)
+            _checked_bytes(
+                root=root,
+                path=path,
+                checksums=checksums,
+                kind="selected parquet",
+            )
+            table = pq.read_table(path)
+            partition_bars = [
+                bar
+                for bar in bars_from_table(table)
+                if window_start <= bar.session_date <= window_end
+            ]
+            if any(
+                bar.market != market or bar.symbol != symbol for bar in partition_bars
+            ):
+                raise ValueError(
+                    f"parquet partition identity mismatch: {path.relative_to(root)}"
+                )
+            bars.extend(partition_bars)
+            coverage = symbol_coverage[(market, symbol)]
+            coverage["bar_count"] += len(partition_bars)
+            coverage["years"].update(bar.session_date.year for bar in partition_bars)
+
+    market_coverage: dict[str, dict[str, Any]] = {}
+    for market in sorted(selected_markets):
+        selected_symbols = sorted(
+            symbol
+            for selected_market, symbol in selected_keys
+            if selected_market == market
+        )
+        symbols: dict[str, dict[str, Any]] = {}
+        for symbol in selected_symbols:
+            coverage = symbol_coverage[(market, symbol)]
+            years = sorted(coverage["years"])
+            symbols[symbol] = {
+                "bar_count": coverage["bar_count"],
+                "year_count": len(years),
+                "years": years,
+            }
+        years = sorted(
+            year for coverage in symbols.values() for year in coverage["years"]
+        )
+        unique_years = sorted(set(years))
+        market_coverage[market] = {
+            "symbol_count": len(selected_symbols),
+            "bar_count": sum(coverage["bar_count"] for coverage in symbols.values()),
+            "year_count": len(unique_years),
+            "years": unique_years,
+            "symbols": symbols,
+        }
+    coverage: dict[str, Any] = {
+        "session_reference": {
+            "source": "preflight.json",
+            "calendar": "XKRX",
+            "markets": {
+                market: {
+                    "session_count": len(sessions),
+                    "first_session": sessions[0].isoformat(),
+                    "last_session": sessions[-1].isoformat(),
+                }
+                for market, sessions in sorted(market_sessions.items())
+            },
+        },
+        "markets": market_coverage,
+    }
+    return RealMainStageBInput(
+        bars=tuple(bars),
+        market_sessions=market_sessions,
+        coverage=coverage,
+    )

--- a/research/kr_corpus/backtest/real_data.py
+++ b/research/kr_corpus/backtest/real_data.py
@@ -1,0 +1,95 @@
+"""Read-only bounded loader for the finalized KR main snapshot.
+
+The collector's real manifest is a summary object; per-file integrity lives in
+``checksums.sha256``.  This loader verifies selected bytes against that ledger
+before parsing and refuses holdout paths/dates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from datetime import date
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+try:
+    from .holdout_guard import assert_path_not_holdout, assert_range_not_holdout
+except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
+    from holdout_guard import assert_path_not_holdout, assert_range_not_holdout
+try:
+    from .pit import Bar, bars_from_table
+except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
+    from pit import Bar, bars_from_table
+
+__all__ = ["load_real_main_bars"]
+
+
+def _checksum_index(path: Path) -> dict[str, str]:
+    index: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        digest, relative = line.split("  ", maxsplit=1)
+        index[relative] = digest
+    return index
+
+
+def load_real_main_bars(
+    *,
+    artifact_root: Path,
+    run_id: str,
+    window_start: date,
+    window_end: date,
+    markets: Iterable[str],
+    max_symbols: int,
+) -> list[Bar]:
+    """Load an explicit bounded selection from main-only real data."""
+    assert_range_not_holdout(window_start, window_end)
+    if max_symbols < 1:
+        raise ValueError("max_symbols must be positive and explicit")
+    root = artifact_root.expanduser().resolve() / "runs" / run_id
+    assert_path_not_holdout(root)
+    checksum_path = root / "checksums.sha256"
+    checksums = _checksum_index(checksum_path)
+    selected_markets = frozenset(markets)
+    files = sorted((root / "dataset").glob("market=*/year=*/ticker=*.parquet"))
+    selected: list[Path] = []
+    symbols: set[str] = set()
+    for path in files:
+        relative = path.relative_to(root).as_posix()
+        parts = path.parts
+        market = next(
+            part.split("=", 1)[1] for part in parts if part.startswith("market=")
+        )
+        year = int(
+            next(part.split("=", 1)[1] for part in parts if part.startswith("year="))
+        )
+        if year < window_start.year or year > window_end.year:
+            continue
+        symbol = path.stem.split("=", 1)[1]
+        if (
+            market not in selected_markets
+            or symbol not in symbols
+            and len(symbols) >= max_symbols
+        ):
+            continue
+        expected = checksums.get(relative)
+        if expected is None:
+            raise ValueError(
+                f"selected parquet missing checksum ledger row: {relative}"
+            )
+        data = path.read_bytes()
+        actual = hashlib.sha256(data).hexdigest()
+        if actual != expected:
+            raise ValueError(f"checksum mismatch: {relative}")
+        selected.append(path)
+        symbols.add(symbol)
+    bars: list[Bar] = []
+    for path in selected:
+        table = pq.read_table(path)
+        bars.extend(
+            bar
+            for bar in bars_from_table(table)
+            if window_start <= bar.session_date <= window_end
+        )
+    return bars

--- a/research/kr_corpus/backtest/real_data.py
+++ b/research/kr_corpus/backtest/real_data.py
@@ -1,19 +1,24 @@
 """Read-only bounded loader for the finalized KR main snapshot.
 
 The collector's real manifest is a summary object; per-file integrity lives in
-``checksums.sha256``.  This loader verifies selected bytes against that ledger
-before parsing and refuses holdout paths/dates.
+``checksums.sha256``.  The frozen Stage-B snapshot is rooted in the reviewed
+source literals below: an artifact-only rewrite cannot replace its manifest,
+checksum ledger, or the XKRX preflight sequence.  This loader verifies selected
+bytes against that ledger before parsing and refuses holdout paths/dates.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import re
+import stat
+import unicodedata
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import date
-from pathlib import Path
-from typing import Any
+from pathlib import Path, PurePosixPath
+from typing import Any, Final
 
 import pyarrow.parquet as pq
 
@@ -42,12 +47,153 @@ class RealMainStageBInput:
     coverage: Mapping[str, Any]
 
 
-def _checksum_index(path: Path) -> dict[str, str]:
+@dataclass(frozen=True)
+class _TrustedStageBArtifact:
+    """Reviewed immutable root for the only currently admissible Stage-B input."""
+
+    checksums_sha256: str
+    manifest_sha256: str
+
+
+# These are hashes of the finalized *main* snapshot, independently recorded in
+# the kr-corpus verification report.  Adding a future snapshot is intentionally
+# a reviewed source change, not an artifact-only operation.
+_TRUSTED_STAGE_B_ARTIFACTS: Final[Mapping[str, _TrustedStageBArtifact]] = {
+    "kr-corpus-v1-20260803-1001": _TrustedStageBArtifact(
+        checksums_sha256=(
+            "9704cc72455bca8bc8bdea78506b16de4d0cdff697661d7ee8a349eb4b311a7f"
+        ),
+        manifest_sha256=(
+            "da1ca376ac6693e96d311eda07f9fe96f1cb69fa2e3e8f346ededf96c5d5c54b"
+        ),
+    ),
+}
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
+_CHECKSUM_CONTROL_PATHS = frozenset({"checksums.sha256", "manifest.json"})
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_checksum_path(relative: str, *, line_number: int) -> str:
+    """Return one unambiguous POSIX-relative ledger path or fail closed."""
+    if not relative or "\\" in relative:
+        raise ValueError(
+            f"checksum ledger has a non-canonical path at line {line_number}"
+        )
+    path = PurePosixPath(relative)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(
+            f"checksum ledger has a non-canonical path at line {line_number}"
+        )
+    canonical = path.as_posix()
+    if canonical != relative:
+        raise ValueError(
+            f"checksum ledger has a non-canonical path at line {line_number}"
+        )
+    return canonical
+
+
+def _checksum_index(data: bytes) -> dict[str, str]:
+    """Parse the checksum ledger without accepting ambiguous path identities."""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("checksum ledger is not valid UTF-8") from exc
+
     index: dict[str, str] = {}
-    for line in path.read_text(encoding="utf-8").splitlines():
-        digest, relative = line.split("  ", maxsplit=1)
+    canonical_identities: set[str] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        try:
+            digest, relative = line.split("  ", maxsplit=1)
+        except ValueError as exc:
+            raise ValueError(
+                f"checksum ledger is malformed at line {line_number}"
+            ) from exc
+        if _SHA256_HEX.fullmatch(digest) is None:
+            raise ValueError(
+                f"checksum ledger has an invalid SHA-256 at line {line_number}"
+            )
+        relative = _canonical_checksum_path(relative, line_number=line_number)
+        if relative in _CHECKSUM_CONTROL_PATHS:
+            raise ValueError(f"checksum ledger must not list control file: {relative}")
+        identity = unicodedata.normalize("NFC", relative).casefold()
+        if identity in canonical_identities:
+            raise ValueError(f"checksum ledger duplicate path: {relative}")
+        canonical_identities.add(identity)
         index[relative] = digest
+    if not index:
+        raise ValueError("checksum ledger is empty")
     return index
+
+
+def _read_regular_artifact_file(*, root: Path, path: Path, kind: str) -> bytes:
+    """Read a snapshot-local regular file, refusing symlink path components."""
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:  # pragma: no cover - internal callers are rooted
+        raise ValueError(f"{kind} escapes artifact root") from exc
+
+    current = root
+    for component in relative.parts:
+        current = current / component
+        if current.is_symlink():
+            raise ValueError(
+                f"{kind} must not use a symbolic link: {relative.as_posix()}"
+            )
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError as exc:
+        raise ValueError(f"{kind} is missing: {relative.as_posix()}") from exc
+    if not stat.S_ISREG(mode):
+        raise ValueError(f"{kind} must be a regular file: {relative.as_posix()}")
+    return path.read_bytes()
+
+
+def _load_verified_checksum_index(*, root: Path, run_id: str) -> dict[str, str]:
+    """Bind the mutable manifest/ledger pair to the reviewed source root."""
+    trusted = _TRUSTED_STAGE_B_ARTIFACTS.get(run_id)
+    if trusted is None:
+        raise ValueError(f"untrusted Stage-B artifact run id: {run_id}")
+
+    checksum_path = root / "checksums.sha256"
+    checksum_bytes = _read_regular_artifact_file(
+        root=root,
+        path=checksum_path,
+        kind="checksum ledger",
+    )
+    checksums = _checksum_index(checksum_bytes)
+
+    manifest_path = root / "manifest.json"
+    manifest_bytes = _read_regular_artifact_file(
+        root=root,
+        path=manifest_path,
+        kind="manifest",
+    )
+    try:
+        manifest = json.loads(manifest_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError("manifest is not valid JSON") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest must be an object")
+    if manifest.get("scope") != "main":
+        raise ValueError("Stage-B manifest must declare main scope")
+    if manifest.get("files_list_location") != "checksums.sha256":
+        raise ValueError("Stage-B manifest must name checksums.sha256")
+    declared_checksum_digest = manifest.get("checksums_sha256")
+    actual_checksum_digest = _sha256(checksum_bytes)
+    if not isinstance(declared_checksum_digest, str) or (
+        _SHA256_HEX.fullmatch(declared_checksum_digest) is None
+    ):
+        raise ValueError("manifest has no valid checksums_sha256")
+    if declared_checksum_digest != actual_checksum_digest:
+        raise ValueError("manifest checksum-list digest mismatch")
+    if actual_checksum_digest != trusted.checksums_sha256:
+        raise ValueError("untrusted checksum ledger digest")
+    if _sha256(manifest_bytes) != trusted.manifest_sha256:
+        raise ValueError("untrusted manifest digest")
+    return checksums
 
 
 def _checked_bytes(
@@ -61,11 +207,27 @@ def _checked_bytes(
     expected = checksums.get(relative)
     if expected is None:
         raise ValueError(f"{kind} missing checksum ledger row: {relative}")
-    data = path.read_bytes()
-    actual = hashlib.sha256(data).hexdigest()
+    data = _read_regular_artifact_file(root=root, path=path, kind=kind)
+    actual = _sha256(data)
     if actual != expected:
         raise ValueError(f"checksum mismatch: {relative}")
     return data
+
+
+def _validate_xkrx_session_sequence(sessions: tuple[date, ...]) -> None:
+    """Cross-check the signed reference against the pinned XKRX calendar data."""
+    try:
+        import exchange_calendars as xcals
+    except ModuleNotFoundError as exc:  # pragma: no cover - project dependency
+        raise ValueError("XKRX calendar validation dependency is unavailable") from exc
+
+    calendar = xcals.get_calendar("XKRX")
+    expected = tuple(
+        session.date()
+        for session in calendar.sessions_in_range(sessions[0], sessions[-1])
+    )
+    if sessions != expected:
+        raise ValueError("market-session reference disagrees with XKRX calendar")
 
 
 def _load_market_sessions(
@@ -112,6 +274,7 @@ def _load_market_sessions(
         raise ValueError(
             "market-session reference must be strictly ascending and unique"
         )
+    _validate_xkrx_session_sequence(sessions)
     return dict.fromkeys(sorted(set(markets)), sessions)
 
 
@@ -150,10 +313,13 @@ def load_real_main_stage_b_input(
     assert_range_not_holdout(window_start, window_end)
     if max_symbols < 1:
         raise ValueError("max_symbols must be positive and explicit")
+    if Path(run_id).name != run_id or run_id in {"", ".", ".."}:
+        raise ValueError("run id must name exactly one artifact directory")
     root = artifact_root.expanduser().resolve() / "runs" / run_id
     assert_path_not_holdout(root)
-    checksum_path = root / "checksums.sha256"
-    checksums = _checksum_index(checksum_path)
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("Stage-B artifact root must be a regular directory")
+    checksums = _load_verified_checksum_index(root=root, run_id=run_id)
     selected_markets = frozenset(markets)
     if not selected_markets:
         raise ValueError("at least one market must be explicit")

--- a/research/kr_corpus/backtest/stage_b.py
+++ b/research/kr_corpus/backtest/stage_b.py
@@ -148,6 +148,7 @@ class StageBResult:
     trades: tuple[Trade, ...]
     skipped_signals: int
     lookahead_checks: int
+    skipped_signal_reasons: tuple[str, ...] = ()
 
     @property
     def net_returns(self) -> tuple[float, ...]:
@@ -181,7 +182,8 @@ class StageBResult:
                 for trade in self.trades
             ],
             "skipped_signals": self.skipped_signals,
-            "lookahead_checks": self.lookahead_checks,
+            "pit_boundary_checked": True,
+            "skipped_signal_reasons": list(self.skipped_signal_reasons),
             "orders": 0,
             "account_mutations": 0,
         }
@@ -214,6 +216,7 @@ def run_stage_b(
     trades: list[Trade] = []
     skipped_signals = 0
     lookahead_checks = 0
+    skipped_reasons: list[str] = []
 
     for symbol, symbol_bars in sorted(grouped.items()):
         active_until = -1
@@ -235,11 +238,21 @@ def run_stage_b(
             exit_index = index + contract.holding_sessions
             if index <= active_until or exit_index >= len(symbol_bars):
                 skipped_signals += 1
+                skipped_reasons.append("overlap_or_insufficient_forward_bars")
                 continue
             entry_bar = symbol_bars[entry_index]
             exit_bar = symbol_bars[exit_index]
+            path = symbol_bars[entry_index : exit_index + 1]
+            if any(
+                (right.session_date - left.session_date).days > 10
+                for left, right in zip(path, path[1:], strict=False)
+            ):
+                skipped_signals += 1
+                skipped_reasons.append("session_gap_before_d5_exit")
+                continue
             if entry_bar.open <= 0 or exit_bar.close <= 0:
                 skipped_signals += 1
+                skipped_reasons.append("non_positive_entry_or_exit_price")
                 continue
             gross = exit_bar.close / entry_bar.open - 1.0
             net = gross - contract.cost.round_trip_bp / 10_000
@@ -263,6 +276,7 @@ def run_stage_b(
         trades=tuple(trades),
         skipped_signals=skipped_signals,
         lookahead_checks=lookahead_checks,
+        skipped_signal_reasons=tuple(skipped_reasons),
     )
 
 

--- a/research/kr_corpus/backtest/stage_b.py
+++ b/research/kr_corpus/backtest/stage_b.py
@@ -149,13 +149,14 @@ class StageBResult:
     skipped_signals: int
     lookahead_checks: int
     skipped_signal_reasons: tuple[str, ...] = ()
+    data_coverage: Mapping[str, Any] | None = None
 
     @property
     def net_returns(self) -> tuple[float, ...]:
         return tuple(trade.net_return for trade in self.trades)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "engine": "kr-stage-b-v1",
             "signal_contract_hash": self.contract.signal_contract_hash,
             "config_hash": self.contract.config_hash,
@@ -187,6 +188,9 @@ class StageBResult:
             "orders": 0,
             "account_mutations": 0,
         }
+        if self.data_coverage is not None:
+            payload["data_coverage"] = dict(self.data_coverage)
+        return payload
 
 
 def _group_bars(
@@ -204,21 +208,57 @@ def _group_bars(
     return grouped
 
 
+def _normalize_market_sessions(
+    market_sessions: Mapping[str, Iterable[date]],
+    contract: StageBRunContract,
+) -> dict[str, tuple[date, ...]]:
+    """Validate the explicit exchange-session reference used for D+5."""
+    normalized: dict[str, tuple[date, ...]] = {}
+    for market, sessions in market_sessions.items():
+        values = tuple(assert_date_not_holdout(session) for session in sessions)
+        if not values:
+            raise ValueError(f"empty market-session reference for {market}")
+        if tuple(sorted(values)) != values or len(set(values)) != len(values):
+            raise ValueError(
+                f"market-session reference for {market} must be strictly ascending "
+                "and unique"
+            )
+        if values[0] < contract.window_start or values[-1] > contract.window_end:
+            raise ValueError(
+                f"market-session reference for {market} falls outside run window"
+            )
+        normalized[market] = values
+    return normalized
+
+
 def run_stage_b(
     *,
     bars: Iterable[Bar],
     contract: StageBRunContract,
+    market_sessions: Mapping[str, Iterable[date]],
+    data_coverage: Mapping[str, Any] | None = None,
 ) -> StageBResult:
-    """Run t+1 open / D+5 close without using future bars for a signal."""
+    """Run t+1 open / D+5 close against an explicit exchange-session sequence."""
     if contract is None:  # type: ignore[comparison-overlap]
         raise ValueError("explicit Stage-B run contract is required")
     grouped = _group_bars(bars, contract)
+    sessions_by_market = _normalize_market_sessions(market_sessions, contract)
     trades: list[Trade] = []
     skipped_signals = 0
     lookahead_checks = 0
     skipped_reasons: list[str] = []
 
     for symbol, symbol_bars in sorted(grouped.items()):
+        markets = {bar.market for bar in symbol_bars}
+        if len(markets) != 1:
+            raise ValueError(f"symbol {symbol} appears in multiple market session sets")
+        market = next(iter(markets))
+        sessions = sessions_by_market.get(market)
+        if sessions is None:
+            raise ValueError(f"market-session reference missing for {market}")
+        session_positions = {
+            session: position for position, session in enumerate(sessions)
+        }
         active_until = -1
         for index, signal_bar in enumerate(symbol_bars):
             history = symbol_bars[: index + 1]
@@ -234,22 +274,30 @@ def run_stage_b(
             )
             if signal["signal_state"] != "SIGNAL":
                 continue
+            signal_position = session_positions.get(signal_bar.session_date)
+            if signal_position is None:
+                skipped_signals += 1
+                skipped_reasons.append("signal_session_absent_from_market_reference")
+                continue
             entry_index = index + 1
             exit_index = index + contract.holding_sessions
             if index <= active_until or exit_index >= len(symbol_bars):
                 skipped_signals += 1
                 skipped_reasons.append("overlap_or_insufficient_forward_bars")
                 continue
-            entry_bar = symbol_bars[entry_index]
-            exit_bar = symbol_bars[exit_index]
-            path = symbol_bars[entry_index : exit_index + 1]
-            if any(
-                (right.session_date - left.session_date).days > 10
-                for left, right in zip(path, path[1:], strict=False)
+            expected_path = sessions[
+                signal_position + 1 : signal_position + contract.holding_sessions + 1
+            ]
+            actual_path = symbol_bars[entry_index : exit_index + 1]
+            if (
+                len(expected_path) != contract.holding_sessions
+                or tuple(bar.session_date for bar in actual_path) != expected_path
             ):
                 skipped_signals += 1
                 skipped_reasons.append("session_gap_before_d5_exit")
                 continue
+            entry_bar = actual_path[0]
+            exit_bar = actual_path[-1]
             if entry_bar.open <= 0 or exit_bar.close <= 0:
                 skipped_signals += 1
                 skipped_reasons.append("non_positive_entry_or_exit_price")
@@ -277,6 +325,7 @@ def run_stage_b(
         skipped_signals=skipped_signals,
         lookahead_checks=lookahead_checks,
         skipped_signal_reasons=tuple(skipped_reasons),
+        data_coverage=data_coverage,
     )
 
 

--- a/research/kr_corpus/backtest/stage_b.py
+++ b/research/kr_corpus/backtest/stage_b.py
@@ -1,0 +1,282 @@
+"""KR Stage-B economic engine with an explicit run contract.
+
+The signal calculation is intentionally not implemented here.  Stage-B calls
+the shadow3 owner directly so a shadow/backtest semantic drift is impossible.
+This module is research-only and has no broker, account, database, or scheduler
+surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date
+from math import sqrt
+from statistics import mean, stdev
+from typing import Any, Literal
+
+try:
+    from .holdout_guard import assert_date_not_holdout, assert_range_not_holdout
+except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
+    from holdout_guard import assert_date_not_holdout, assert_range_not_holdout
+try:
+    from .pit import Bar, assert_no_lookahead
+except ImportError:  # pragma: no cover - legacy flat-module test entrypoint
+    from pit import Bar, assert_no_lookahead
+from research.three_market_shadow.calculations import (
+    CONTRACT_HASH,
+    calculate_signal,
+)
+from research_contracts.canonical_hash import canonical_sha256
+
+__all__ = [
+    "APPROVED_COST_PROFILES",
+    "KRCostContract",
+    "StageBRunContract",
+    "StageBResult",
+    "Trade",
+    "build_run_contract",
+    "run_stage_b",
+]
+
+APPROVED_COST_PROFILES: Mapping[str, Mapping[str, int]] = {
+    "43bp": {"fee_bp": 3, "transaction_tax_bp": 20, "slippage_bp_per_side": 10},
+    "83bp": {"fee_bp": 3, "transaction_tax_bp": 20, "slippage_bp_per_side": 30},
+}
+
+
+@dataclass(frozen=True)
+class KRCostContract:
+    """Operator-approved literal cost binding; no implicit/default profile."""
+
+    profile: Literal["43bp", "83bp"]
+    fee_bp: int
+    transaction_tax_bp: int
+    slippage_bp_per_side: int
+
+    @property
+    def round_trip_bp(self) -> int:
+        return self.fee_bp + self.transaction_tax_bp + 2 * self.slippage_bp_per_side
+
+    def __post_init__(self) -> None:
+        expected = APPROVED_COST_PROFILES.get(self.profile)
+        actual = {
+            "fee_bp": self.fee_bp,
+            "transaction_tax_bp": self.transaction_tax_bp,
+            "slippage_bp_per_side": self.slippage_bp_per_side,
+        }
+        if expected is None or actual != dict(expected):
+            raise ValueError(
+                "cost contract must exactly match an approved literal profile; "
+                "no default cost injection is permitted"
+            )
+
+
+@dataclass(frozen=True)
+class StageBRunContract:
+    cost: KRCostContract
+    window_start: date
+    window_end: date
+    holding_sessions: int = 5
+    entry_timing: str = "t+1_open"
+    exit_timing: str = "D+5_close"
+    signal_contract_hash: str = CONTRACT_HASH
+
+    def __post_init__(self) -> None:
+        assert_range_not_holdout(self.window_start, self.window_end)
+        if self.holding_sessions != 5:
+            raise ValueError("Stage-B is fixed to D+5")
+        if self.entry_timing != "t+1_open" or self.exit_timing != "D+5_close":
+            raise ValueError("Stage-B timing contract drift")
+        if self.signal_contract_hash != CONTRACT_HASH:
+            raise ValueError("signal contract hash mismatch")
+
+    @property
+    def config_hash(self) -> str:
+        return canonical_sha256(
+            {
+                "engine": "kr-stage-b-v1",
+                "cost": {
+                    "profile": self.cost.profile,
+                    "fee_bp": self.cost.fee_bp,
+                    "transaction_tax_bp": self.cost.transaction_tax_bp,
+                    "slippage_bp_per_side": self.cost.slippage_bp_per_side,
+                },
+                "window_start": self.window_start.isoformat(),
+                "window_end": self.window_end.isoformat(),
+                "holding_sessions": self.holding_sessions,
+                "entry_timing": self.entry_timing,
+                "exit_timing": self.exit_timing,
+                "signal_contract_hash": self.signal_contract_hash,
+            }
+        )
+
+
+def build_run_contract(
+    *,
+    cost_profile: Literal["43bp", "83bp"],
+    window_start: date,
+    window_end: date,
+) -> StageBRunContract:
+    """Bind a cost profile only when the run explicitly names it."""
+    literal = APPROVED_COST_PROFILES.get(cost_profile)
+    if literal is None:
+        raise ValueError(f"unknown explicit KR cost profile: {cost_profile!r}")
+    return StageBRunContract(
+        cost=KRCostContract(profile=cost_profile, **literal),
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+
+@dataclass(frozen=True)
+class Trade:
+    symbol: str
+    signal_session: date
+    entry_session: date
+    exit_session: date
+    entry_open: int
+    exit_close: int
+    gross_return: float
+    net_return: float
+    cost_bp: int
+
+
+@dataclass(frozen=True)
+class StageBResult:
+    contract: StageBRunContract
+    trades: tuple[Trade, ...]
+    skipped_signals: int
+    lookahead_checks: int
+
+    @property
+    def net_returns(self) -> tuple[float, ...]:
+        return tuple(trade.net_return for trade in self.trades)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "engine": "kr-stage-b-v1",
+            "signal_contract_hash": self.contract.signal_contract_hash,
+            "config_hash": self.contract.config_hash,
+            "cost_profile": self.contract.cost.profile,
+            "cost_round_trip_bp": self.contract.cost.round_trip_bp,
+            "entry_timing": self.contract.entry_timing,
+            "exit_timing": self.contract.exit_timing,
+            "window": {
+                "start": self.contract.window_start.isoformat(),
+                "end": self.contract.window_end.isoformat(),
+            },
+            "trades": [
+                {
+                    "symbol": trade.symbol,
+                    "signal_session": trade.signal_session.isoformat(),
+                    "entry_session": trade.entry_session.isoformat(),
+                    "exit_session": trade.exit_session.isoformat(),
+                    "entry_open": trade.entry_open,
+                    "exit_close": trade.exit_close,
+                    "gross_return": trade.gross_return,
+                    "net_return": trade.net_return,
+                    "cost_bp": trade.cost_bp,
+                }
+                for trade in self.trades
+            ],
+            "skipped_signals": self.skipped_signals,
+            "lookahead_checks": self.lookahead_checks,
+            "orders": 0,
+            "account_mutations": 0,
+        }
+
+
+def _group_bars(
+    bars: Iterable[Bar], contract: StageBRunContract
+) -> dict[str, list[Bar]]:
+    grouped: dict[str, list[Bar]] = {}
+    for bar in bars:
+        assert_date_not_holdout(bar.session_date)
+        if contract.window_start <= bar.session_date <= contract.window_end:
+            grouped.setdefault(bar.symbol, []).append(bar)
+    for symbol, symbol_bars in grouped.items():
+        symbol_bars.sort(key=lambda bar: bar.session_date)
+        if len({bar.session_date for bar in symbol_bars}) != len(symbol_bars):
+            raise ValueError(f"duplicate session for {symbol}")
+    return grouped
+
+
+def run_stage_b(
+    *,
+    bars: Iterable[Bar],
+    contract: StageBRunContract,
+) -> StageBResult:
+    """Run t+1 open / D+5 close without using future bars for a signal."""
+    if contract is None:  # type: ignore[comparison-overlap]
+        raise ValueError("explicit Stage-B run contract is required")
+    grouped = _group_bars(bars, contract)
+    trades: list[Trade] = []
+    skipped_signals = 0
+    lookahead_checks = 0
+
+    for symbol, symbol_bars in sorted(grouped.items()):
+        active_until = -1
+        for index, signal_bar in enumerate(symbol_bars):
+            history = symbol_bars[: index + 1]
+            assert_no_lookahead(history, signal_bar.session_date)
+            lookahead_checks += 1
+            signal = calculate_signal(
+                "kr",
+                {
+                    "symbol": symbol,
+                    "close": [bar.close for bar in history],
+                    "volume": [bar.volume for bar in history],
+                },
+            )
+            if signal["signal_state"] != "SIGNAL":
+                continue
+            entry_index = index + 1
+            exit_index = index + contract.holding_sessions
+            if index <= active_until or exit_index >= len(symbol_bars):
+                skipped_signals += 1
+                continue
+            entry_bar = symbol_bars[entry_index]
+            exit_bar = symbol_bars[exit_index]
+            if entry_bar.open <= 0 or exit_bar.close <= 0:
+                skipped_signals += 1
+                continue
+            gross = exit_bar.close / entry_bar.open - 1.0
+            net = gross - contract.cost.round_trip_bp / 10_000
+            trades.append(
+                Trade(
+                    symbol=symbol,
+                    signal_session=signal_bar.session_date,
+                    entry_session=entry_bar.session_date,
+                    exit_session=exit_bar.session_date,
+                    entry_open=entry_bar.open,
+                    exit_close=exit_bar.close,
+                    gross_return=gross,
+                    net_return=net,
+                    cost_bp=contract.cost.round_trip_bp,
+                )
+            )
+            active_until = exit_index
+
+    return StageBResult(
+        contract=contract,
+        trades=tuple(trades),
+        skipped_signals=skipped_signals,
+        lookahead_checks=lookahead_checks,
+    )
+
+
+def descriptive_trial_statistics(result: StageBResult) -> dict[str, float | int]:
+    """Return descriptive statistics for evidence; no promotion decision."""
+    returns = result.net_returns
+    if len(returns) < 2:
+        raise ValueError("trial evidence requires at least two closed trades")
+    average = mean(returns)
+    deviation = stdev(returns)
+    sharpe = 0.0 if deviation == 0 else average / deviation * sqrt(len(returns))
+    return {
+        "sharpe": sharpe,
+        "p_value": 1.0,
+        "sample_size": len(returns),
+        "validation_score": average,
+    }

--- a/research/kr_corpus/backtest/tests/test_real_data.py
+++ b/research/kr_corpus/backtest/tests/test_real_data.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from real_data import load_real_main_bars, load_real_main_stage_b_input
+
+
+def _row(*, market: str, symbol: str, session: str) -> dict[str, object]:
+    return {
+        "session": session,
+        "market": market,
+        "ticker": symbol,
+        "open": 100,
+        "high": 101,
+        "low": 99,
+        "close": 100,
+        "volume": 1_000,
+        "value": None,
+        "price_mode": "adjusted",
+        "source_product": "synthetic_fixture",
+    }
+
+
+def _write_artifact(tmp_path: Path) -> tuple[Path, str]:
+    artifact_root = tmp_path / "artifact-root"
+    run_id = "main-fixture"
+    root = artifact_root / "runs" / run_id
+    root.mkdir(parents=True)
+    sessions = ["2015-01-02", "2016-01-04"]
+    preflight = root / "preflight.json"
+    preflight.write_text(
+        json.dumps({"session_calendar": "XKRX", "sessions": sessions}),
+        encoding="utf-8",
+    )
+
+    for market in ("KOSPI", "KOSDAQ"):
+        for symbol in ("000001", "000002"):
+            for year, session in ((2015, sessions[0]), (2016, sessions[1])):
+                path = root / "dataset" / f"market={market}" / f"year={year}"
+                path = path / f"ticker={symbol}.parquet"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                pq.write_table(
+                    pa.Table.from_pylist(
+                        [_row(market=market, symbol=symbol, session=session)]
+                    ),
+                    path,
+                )
+
+    checksum_paths = [preflight, *sorted((root / "dataset").rglob("*.parquet"))]
+    (root / "checksums.sha256").write_text(
+        "".join(
+            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
+            f"{path.relative_to(root).as_posix()}\n"
+            for path in checksum_paths
+        ),
+        encoding="utf-8",
+    )
+    return artifact_root, run_id
+
+
+def test_symbol_selection_loads_all_yearly_partitions_and_records_coverage(
+    tmp_path: Path,
+) -> None:
+    artifact_root, run_id = _write_artifact(tmp_path)
+
+    loaded = load_real_main_stage_b_input(
+        artifact_root=artifact_root,
+        run_id=run_id,
+        window_start=date(2015, 1, 1),
+        window_end=date(2016, 12, 31),
+        markets=("KOSPI", "KOSDAQ"),
+        max_symbols=2,
+    )
+
+    assert len(loaded.bars) == 4
+    assert loaded.market_sessions == {
+        "KOSDAQ": (date(2015, 1, 2), date(2016, 1, 4)),
+        "KOSPI": (date(2015, 1, 2), date(2016, 1, 4)),
+    }
+    for market in ("KOSPI", "KOSDAQ"):
+        coverage = loaded.coverage["markets"][market]
+        assert coverage["symbol_count"] == 1
+        assert coverage["bar_count"] == 2
+        assert coverage["year_count"] == 2
+        assert coverage["years"] == [2015, 2016]
+        assert coverage["symbols"] == {
+            "000001": {
+                "bar_count": 2,
+                "year_count": 2,
+                "years": [2015, 2016],
+            }
+        }
+    assert loaded.coverage["session_reference"]["calendar"] == "XKRX"
+
+    # The legacy list-returning loader remains a compatibility view of the
+    # same verified input, rather than reintroducing one-partition selection.
+    assert (
+        len(
+            load_real_main_bars(
+                artifact_root=artifact_root,
+                run_id=run_id,
+                window_start=date(2015, 1, 1),
+                window_end=date(2016, 12, 31),
+                markets=("KOSPI", "KOSDAQ"),
+                max_symbols=2,
+            )
+        )
+        == 4
+    )
+
+
+def test_market_session_reference_requires_a_checksum(tmp_path: Path) -> None:
+    artifact_root, run_id = _write_artifact(tmp_path)
+    preflight = artifact_root / "runs" / run_id / "preflight.json"
+    preflight.write_text(
+        json.dumps({"session_calendar": "XKRX", "sessions": ["2015-01-02"]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="checksum mismatch: preflight.json"):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_selected_symbol_checks_every_yearly_partition(tmp_path: Path) -> None:
+    artifact_root, run_id = _write_artifact(tmp_path)
+    second_year = (
+        artifact_root
+        / "runs"
+        / run_id
+        / "dataset/market=KOSPI/year=2016/ticker=000001.parquet"
+    )
+    second_year.write_bytes(b"tampered")
+
+    with pytest.raises(
+        ValueError,
+        match="checksum mismatch: dataset/market=KOSPI/year=2016/ticker=000001.parquet",
+    ):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )

--- a/research/kr_corpus/backtest/tests/test_real_data.py
+++ b/research/kr_corpus/backtest/tests/test_real_data.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+import real_data
 from real_data import load_real_main_bars, load_real_main_stage_b_input
 
 
@@ -27,12 +28,71 @@ def _row(*, market: str, symbol: str, session: str) -> dict[str, object]:
     }
 
 
-def _write_artifact(tmp_path: Path) -> tuple[Path, str]:
+def _xkrx_sessions(start: date, end: date) -> list[str]:
+    import exchange_calendars as xcals
+
+    calendar = xcals.get_calendar("XKRX")
+    return [
+        session.date().isoformat() for session in calendar.sessions_in_range(start, end)
+    ]
+
+
+def _write_checksum_ledger(root: Path) -> None:
+    preflight = root / "preflight.json"
+    checksum_paths = [preflight, *sorted((root / "dataset").rglob("*.parquet"))]
+    (root / "checksums.sha256").write_text(
+        "".join(
+            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
+            f"{path.relative_to(root).as_posix()}\n"
+            for path in checksum_paths
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_manifest(root: Path) -> None:
+    checksum_bytes = (root / "checksums.sha256").read_bytes()
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "scope": "main",
+                "files_list_location": "checksums.sha256",
+                "checksums_sha256": hashlib.sha256(checksum_bytes).hexdigest(),
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _trust_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    artifact_root: Path,
+    run_id: str,
+) -> None:
+    root = artifact_root / "runs" / run_id
+    monkeypatch.setattr(
+        real_data,
+        "_TRUSTED_STAGE_B_ARTIFACTS",
+        {
+            run_id: real_data._TrustedStageBArtifact(
+                checksums_sha256=hashlib.sha256(
+                    (root / "checksums.sha256").read_bytes()
+                ).hexdigest(),
+                manifest_sha256=hashlib.sha256(
+                    (root / "manifest.json").read_bytes()
+                ).hexdigest(),
+            )
+        },
+    )
+
+
+def _write_artifact(tmp_path: Path) -> tuple[Path, str, list[str]]:
     artifact_root = tmp_path / "artifact-root"
     run_id = "main-fixture"
     root = artifact_root / "runs" / run_id
     root.mkdir(parents=True)
-    sessions = ["2015-01-02", "2016-01-04"]
+    sessions = _xkrx_sessions(date(2015, 1, 2), date(2016, 1, 4))
     preflight = root / "preflight.json"
     preflight.write_text(
         json.dumps({"session_calendar": "XKRX", "sessions": sessions}),
@@ -41,7 +101,7 @@ def _write_artifact(tmp_path: Path) -> tuple[Path, str]:
 
     for market in ("KOSPI", "KOSDAQ"):
         for symbol in ("000001", "000002"):
-            for year, session in ((2015, sessions[0]), (2016, sessions[1])):
+            for year, session in ((2015, sessions[0]), (2016, sessions[-1])):
                 path = root / "dataset" / f"market={market}" / f"year={year}"
                 path = path / f"ticker={symbol}.parquet"
                 path.parent.mkdir(parents=True, exist_ok=True)
@@ -52,22 +112,17 @@ def _write_artifact(tmp_path: Path) -> tuple[Path, str]:
                     path,
                 )
 
-    checksum_paths = [preflight, *sorted((root / "dataset").rglob("*.parquet"))]
-    (root / "checksums.sha256").write_text(
-        "".join(
-            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
-            f"{path.relative_to(root).as_posix()}\n"
-            for path in checksum_paths
-        ),
-        encoding="utf-8",
-    )
-    return artifact_root, run_id
+    _write_checksum_ledger(root)
+    _write_manifest(root)
+    return artifact_root, run_id, sessions
 
 
 def test_symbol_selection_loads_all_yearly_partitions_and_records_coverage(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    artifact_root, run_id = _write_artifact(tmp_path)
+    artifact_root, run_id, sessions = _write_artifact(tmp_path)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
 
     loaded = load_real_main_stage_b_input(
         artifact_root=artifact_root,
@@ -80,8 +135,8 @@ def test_symbol_selection_loads_all_yearly_partitions_and_records_coverage(
 
     assert len(loaded.bars) == 4
     assert loaded.market_sessions == {
-        "KOSDAQ": (date(2015, 1, 2), date(2016, 1, 4)),
-        "KOSPI": (date(2015, 1, 2), date(2016, 1, 4)),
+        "KOSDAQ": tuple(date.fromisoformat(session) for session in sessions),
+        "KOSPI": tuple(date.fromisoformat(session) for session in sessions),
     }
     for market in ("KOSPI", "KOSDAQ"):
         coverage = loaded.coverage["markets"][market]
@@ -115,8 +170,12 @@ def test_symbol_selection_loads_all_yearly_partitions_and_records_coverage(
     )
 
 
-def test_market_session_reference_requires_a_checksum(tmp_path: Path) -> None:
-    artifact_root, run_id = _write_artifact(tmp_path)
+def test_market_session_reference_requires_a_checksum(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, _sessions = _write_artifact(tmp_path)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
     preflight = artifact_root / "runs" / run_id / "preflight.json"
     preflight.write_text(
         json.dumps({"session_calendar": "XKRX", "sessions": ["2015-01-02"]}),
@@ -134,8 +193,12 @@ def test_market_session_reference_requires_a_checksum(tmp_path: Path) -> None:
         )
 
 
-def test_selected_symbol_checks_every_yearly_partition(tmp_path: Path) -> None:
-    artifact_root, run_id = _write_artifact(tmp_path)
+def test_selected_symbol_checks_every_yearly_partition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, _sessions = _write_artifact(tmp_path)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
     second_year = (
         artifact_root
         / "runs"
@@ -148,6 +211,206 @@ def test_selected_symbol_checks_every_yearly_partition(tmp_path: Path) -> None:
         ValueError,
         match="checksum mismatch: dataset/market=KOSPI/year=2016/ticker=000001.parquet",
     ):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_checksum_ledger_rejects_duplicate_paths_even_if_other_bindings_match(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, _sessions = _write_artifact(tmp_path)
+    root = artifact_root / "runs" / run_id
+    ledger = root / "checksums.sha256"
+    preflight_row = next(
+        line
+        for line in ledger.read_text(encoding="utf-8").splitlines()
+        if line.endswith("  preflight.json")
+    )
+    ledger.write_text(
+        ledger.read_text(encoding="utf-8") + preflight_row + "\n",
+        encoding="utf-8",
+    )
+    _write_manifest(root)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
+
+    with pytest.raises(
+        ValueError, match="checksum ledger duplicate path: preflight.json"
+    ):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_manifest_checksum_binding_rejects_a_stale_declaration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, _sessions = _write_artifact(tmp_path)
+    root = artifact_root / "runs" / run_id
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    manifest["checksums_sha256"] = "0" * 64
+    (root / "manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True), encoding="utf-8"
+    )
+    _trust_artifact(monkeypatch, artifact_root, run_id)
+
+    with pytest.raises(ValueError, match="manifest checksum-list digest mismatch"):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_rewritten_preflight_ledger_and_manifest_need_a_source_root_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, sessions = _write_artifact(tmp_path)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
+    root = artifact_root / "runs" / run_id
+    (root / "preflight.json").write_text(
+        json.dumps(
+            {"session_calendar": "XKRX", "sessions": [sessions[0], *sessions[2:]]}
+        ),
+        encoding="utf-8",
+    )
+    _write_checksum_ledger(root)
+    _write_manifest(root)
+
+    with pytest.raises(ValueError, match="untrusted checksum ledger digest"):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_calendar_crosscheck_rejects_a_wrong_sequence_after_a_hypothetical_repin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, sessions = _write_artifact(tmp_path)
+    root = artifact_root / "runs" / run_id
+    (root / "preflight.json").write_text(
+        json.dumps(
+            {"session_calendar": "XKRX", "sessions": [sessions[0], *sessions[2:]]}
+        ),
+        encoding="utf-8",
+    )
+    _write_checksum_ledger(root)
+    _write_manifest(root)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
+
+    with pytest.raises(
+        ValueError,
+        match="market-session reference disagrees with XKRX calendar",
+    ):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_checksum_ledger_rejects_casefold_path_aliases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, _sessions = _write_artifact(tmp_path)
+    root = artifact_root / "runs" / run_id
+    ledger = root / "checksums.sha256"
+    preflight_row = next(
+        line
+        for line in ledger.read_text(encoding="utf-8").splitlines()
+        if line.endswith("  preflight.json")
+    )
+    ledger.write_text(
+        ledger.read_text(encoding="utf-8")
+        + preflight_row.replace("preflight.json", "PREFLIGHT.JSON")
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_manifest(root)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
+
+    with pytest.raises(
+        ValueError, match="checksum ledger duplicate path: PREFLIGHT.JSON"
+    ):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_preflight_symbolic_link_is_rejected_even_with_matching_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_root, run_id, _sessions = _write_artifact(tmp_path)
+    _trust_artifact(monkeypatch, artifact_root, run_id)
+    root = artifact_root / "runs" / run_id
+    preflight = root / "preflight.json"
+    external_preflight = tmp_path / "preflight-copy.json"
+    external_preflight.write_bytes(preflight.read_bytes())
+    preflight.unlink()
+    preflight.symlink_to(external_preflight)
+
+    with pytest.raises(
+        ValueError, match="market-session reference must not use a symbolic link"
+    ):
+        load_real_main_stage_b_input(
+            artifact_root=artifact_root,
+            run_id=run_id,
+            window_start=date(2015, 1, 1),
+            window_end=date(2016, 12, 31),
+            markets=("KOSPI",),
+            max_symbols=1,
+        )
+
+
+def test_frozen_main_snapshot_trust_root_is_code_pinned() -> None:
+    assert real_data._TRUSTED_STAGE_B_ARTIFACTS == {
+        "kr-corpus-v1-20260803-1001": real_data._TrustedStageBArtifact(
+            checksums_sha256=(
+                "9704cc72455bca8bc8bdea78506b16de4d0cdff697661d7ee8a349eb4b311a7f"
+            ),
+            manifest_sha256=(
+                "da1ca376ac6693e96d311eda07f9fe96f1cb69fa2e3e8f346ededf96c5d5c54b"
+            ),
+        )
+    }
+
+
+def test_unlisted_stage_b_run_id_fails_closed(tmp_path: Path) -> None:
+    artifact_root, run_id, _sessions = _write_artifact(tmp_path)
+
+    with pytest.raises(ValueError, match="untrusted Stage-B artifact run id"):
         load_real_main_stage_b_input(
             artifact_root=artifact_root,
             run_id=run_id,

--- a/research/kr_corpus/backtest/tests/test_stage_b.py
+++ b/research/kr_corpus/backtest/tests/test_stage_b.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date, timedelta
 
 import pytest
@@ -71,6 +72,27 @@ def test_cost_contract_is_explicit_and_no_contract_fails() -> None:
         run_stage_b(bars=_bars(), contract=None)  # type: ignore[arg-type]
 
 
+def test_d5_session_gap_fails_closed_with_explicit_reason() -> None:
+    bars = _bars()
+    # Synthetic 300-day suspension after entry; index+5 must not become D+5.
+    bars = [
+        replace(bar, session_date=bar.session_date + timedelta(days=300))
+        if index >= 22
+        else bar
+        for index, bar in enumerate(bars)
+    ]
+    contract = build_run_contract(
+        cost_profile="43bp",
+        window_start=date(2024, 1, 2),
+        window_end=date(2024, 12, 31),
+    )
+    result = run_stage_b(bars=bars, contract=contract)
+    assert result.trades == ()
+    assert "session_gap_before_d5_exit" in result.skipped_signal_reasons
+    assert result.to_dict()["pit_boundary_checked"] is True
+    assert "lookahead_checks" not in result.to_dict()
+
+
 def test_stage_b_contract_rejects_holdout_window() -> None:
     with pytest.raises(HoldoutDateBlocked):
         build_run_contract(
@@ -96,6 +118,18 @@ def test_trial_evidence_writer_is_rejudgable(tmp_path) -> None:
     assert payload["acceptance_track_separate"] is True
     assert payload["trial_evidence"]["schema_version"] == "honest_trial.v3"
     assert payload["signal_contract_hash"] == contract.signal_contract_hash
+    assert payload["trial_evidence"]["execution_cost"] == {
+        "fee_bps": 3.0,
+        "transaction_tax_bps": 20.0,
+        "half_spread_bps": 0.0,
+        "slippage_bps": 20.0,
+    }
+    assert payload["trial_evidence"]["sharpe_method"] == "pooled_sample_sharpe"
+    assert payload["trial_evidence"]["p_value_method"] == "not_computed"
+    assert (
+        payload["trial_evidence"]["selection_score_method"]
+        == "arithmetic_mean_net_return"
+    )
 
 
 def test_lookahead_guard_remains_hard_error() -> None:

--- a/research/kr_corpus/backtest/tests/test_stage_b.py
+++ b/research/kr_corpus/backtest/tests/test_stage_b.py
@@ -32,13 +32,27 @@ def _bars() -> list[Bar]:
     ]
 
 
+def _market_sessions(bars: list[Bar]) -> dict[str, tuple[date, ...]]:
+    return {
+        market: tuple(
+            sorted({bar.session_date for bar in bars if bar.market == market})
+        )
+        for market in sorted({bar.market for bar in bars})
+    }
+
+
 def test_stage_b_uses_t_plus_one_open_and_d_plus_five_close() -> None:
     contract = build_run_contract(
         cost_profile="43bp",
         window_start=date(2024, 1, 2),
         window_end=date(2024, 1, 31),
     )
-    result = run_stage_b(bars=_bars(), contract=contract)
+    bars = _bars()
+    result = run_stage_b(
+        bars=bars,
+        contract=contract,
+        market_sessions=_market_sessions(bars),
+    )
 
     assert len(result.trades) == 1
     trade = result.trades[0]
@@ -69,28 +83,87 @@ def test_cost_contract_is_explicit_and_no_contract_fails() -> None:
         == 83
     )
     with pytest.raises(ValueError, match="explicit Stage-B run contract"):
-        run_stage_b(bars=_bars(), contract=None)  # type: ignore[arg-type]
+        bars = _bars()
+        run_stage_b(  # type: ignore[arg-type]
+            bars=bars,
+            contract=None,
+            market_sessions=_market_sessions(bars),
+        )
 
 
 def test_d5_session_gap_fails_closed_with_explicit_reason() -> None:
-    bars = _bars()
+    original_bars = _bars()
     # Synthetic 300-day suspension after entry; index+5 must not become D+5.
     bars = [
         replace(bar, session_date=bar.session_date + timedelta(days=300))
         if index >= 22
         else bar
-        for index, bar in enumerate(bars)
+        for index, bar in enumerate(original_bars)
     ]
     contract = build_run_contract(
         cost_profile="43bp",
         window_start=date(2024, 1, 2),
         window_end=date(2024, 12, 31),
     )
-    result = run_stage_b(bars=bars, contract=contract)
+    result = run_stage_b(
+        bars=bars,
+        contract=contract,
+        market_sessions=_market_sessions(original_bars),
+    )
     assert result.trades == ()
     assert "session_gap_before_d5_exit" in result.skipped_signal_reasons
     assert result.to_dict()["pit_boundary_checked"] is True
     assert "lookahead_checks" not in result.to_dict()
+
+
+def test_five_session_symbol_suspension_fails_closed() -> None:
+    original_bars = _bars()
+    bars = [
+        replace(bar, session_date=bar.session_date + timedelta(days=5))
+        if index >= 22
+        else bar
+        for index, bar in enumerate(original_bars)
+    ]
+    contract = build_run_contract(
+        cost_profile="43bp",
+        window_start=date(2024, 1, 2),
+        window_end=date(2024, 2, 29),
+    )
+
+    result = run_stage_b(
+        bars=bars,
+        contract=contract,
+        market_sessions=_market_sessions(original_bars),
+    )
+
+    assert result.trades == ()
+    assert result.skipped_signal_reasons == ("session_gap_before_d5_exit",)
+
+
+def test_market_wide_closure_is_not_rejected_by_calendar_span() -> None:
+    original_bars = _bars()
+    # The calendar itself has a five-day closure after the entry session.
+    bars = [
+        replace(bar, session_date=bar.session_date + timedelta(days=5))
+        if index >= 22
+        else bar
+        for index, bar in enumerate(original_bars)
+    ]
+    contract = build_run_contract(
+        cost_profile="43bp",
+        window_start=date(2024, 1, 2),
+        window_end=date(2024, 2, 29),
+    )
+
+    result = run_stage_b(
+        bars=bars,
+        contract=contract,
+        market_sessions=_market_sessions(bars),
+    )
+
+    assert len(result.trades) == 1
+    assert result.trades[0].entry_session == date(2024, 1, 23)
+    assert result.trades[0].exit_session == date(2024, 2, 1)
 
 
 def test_stage_b_contract_rejects_holdout_window() -> None:
@@ -112,7 +185,22 @@ def test_trial_evidence_writer_is_rejudgable(tmp_path) -> None:
     bars = _bars() + [
         bar.__class__(**{**bar.__dict__, "symbol": "000660"}) for bar in _bars()
     ]
-    result = run_stage_b(bars=bars, contract=contract)
+    coverage = {
+        "markets": {
+            "KOSPI": {
+                "symbol_count": 2,
+                "bar_count": len(bars),
+                "year_count": 1,
+                "years": [2024],
+            }
+        }
+    }
+    result = run_stage_b(
+        bars=bars,
+        contract=contract,
+        market_sessions=_market_sessions(bars),
+        data_coverage=coverage,
+    )
     payload = write_stage_b_evidence(tmp_path / "stageb.json", result)
     assert payload["track"] == "strategy_backtest"
     assert payload["acceptance_track_separate"] is True
@@ -130,6 +218,7 @@ def test_trial_evidence_writer_is_rejudgable(tmp_path) -> None:
         payload["trial_evidence"]["selection_score_method"]
         == "arithmetic_mean_net_return"
     )
+    assert payload["run_contract"]["data_coverage"] == coverage
 
 
 def test_lookahead_guard_remains_hard_error() -> None:

--- a/research/kr_corpus/backtest/tests/test_stage_b.py
+++ b/research/kr_corpus/backtest/tests/test_stage_b.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from evidence import write_stage_b_evidence
+from holdout_guard import HoldoutDateBlocked
+from pit import Bar, LookaheadViolation
+from stage_b import build_run_contract, run_stage_b
+
+
+def _bars() -> list[Bar]:
+    start = date(2024, 1, 2)
+    closes = [100] * 20 + [101, 102, 103, 104, 105, 106]
+    volumes = [100] * 20 + [120, 100, 100, 100, 100, 100]
+    return [
+        Bar(
+            symbol="005930",
+            session_date=start + timedelta(days=index),
+            open=close,
+            high=close,
+            low=close,
+            close=close,
+            volume=volume,
+            trading_value=None,
+            market="KOSPI",
+            price_mode="adjusted",
+            source_product="fixture",
+        )
+        for index, (close, volume) in enumerate(zip(closes, volumes, strict=True))
+    ]
+
+
+def test_stage_b_uses_t_plus_one_open_and_d_plus_five_close() -> None:
+    contract = build_run_contract(
+        cost_profile="43bp",
+        window_start=date(2024, 1, 2),
+        window_end=date(2024, 1, 31),
+    )
+    result = run_stage_b(bars=_bars(), contract=contract)
+
+    assert len(result.trades) == 1
+    trade = result.trades[0]
+    assert trade.signal_session == date(2024, 1, 22)
+    assert trade.entry_session == date(2024, 1, 23)
+    assert trade.exit_session == date(2024, 1, 27)
+    assert trade.entry_open == 102
+    assert trade.exit_close == 106
+    assert trade.cost_bp == 43
+    assert result.lookahead_checks == len(_bars())
+
+
+def test_cost_contract_is_explicit_and_no_contract_fails() -> None:
+    assert (
+        build_run_contract(
+            cost_profile="43bp",
+            window_start=date(2024, 1, 2),
+            window_end=date(2024, 1, 31),
+        ).cost.round_trip_bp
+        == 43
+    )
+    assert (
+        build_run_contract(
+            cost_profile="83bp",
+            window_start=date(2024, 1, 2),
+            window_end=date(2024, 1, 31),
+        ).cost.round_trip_bp
+        == 83
+    )
+    with pytest.raises(ValueError, match="explicit Stage-B run contract"):
+        run_stage_b(bars=_bars(), contract=None)  # type: ignore[arg-type]
+
+
+def test_stage_b_contract_rejects_holdout_window() -> None:
+    with pytest.raises(HoldoutDateBlocked):
+        build_run_contract(
+            cost_profile="43bp",
+            window_start=date(2025, 1, 1),
+            window_end=date(2025, 1, 5),
+        )
+
+
+def test_trial_evidence_writer_is_rejudgable(tmp_path) -> None:
+    contract = build_run_contract(
+        cost_profile="43bp",
+        window_start=date(2024, 1, 2),
+        window_end=date(2024, 1, 31),
+    )
+    # Duplicate a second independent symbol to satisfy the canonical trial sample floor.
+    bars = _bars() + [
+        bar.__class__(**{**bar.__dict__, "symbol": "000660"}) for bar in _bars()
+    ]
+    result = run_stage_b(bars=bars, contract=contract)
+    payload = write_stage_b_evidence(tmp_path / "stageb.json", result)
+    assert payload["track"] == "strategy_backtest"
+    assert payload["acceptance_track_separate"] is True
+    assert payload["trial_evidence"]["schema_version"] == "honest_trial.v3"
+    assert payload["signal_contract_hash"] == contract.signal_contract_hash
+
+
+def test_lookahead_guard_remains_hard_error() -> None:
+    future = _bars()[-1]
+    with pytest.raises(LookaheadViolation):
+        from pit import assert_no_lookahead
+
+        assert_no_lookahead([future], date(2024, 1, 2))

--- a/research/three_market_shadow/__init__.py
+++ b/research/three_market_shadow/__init__.py
@@ -1,0 +1,19 @@
+"""Pure research calculations shared by shadow runners and backtests."""
+
+from .calculations import (
+    CONTRACT_HASH,
+    CRYPTO_SYNTHETIC_SIGNAL,
+    calculate_crypto_synthetic,
+    calculate_kr_rev3_reclaim,
+    calculate_signal,
+    calculate_us_mom_cont_z126,
+)
+
+__all__ = [
+    "CONTRACT_HASH",
+    "CRYPTO_SYNTHETIC_SIGNAL",
+    "calculate_crypto_synthetic",
+    "calculate_kr_rev3_reclaim",
+    "calculate_signal",
+    "calculate_us_mom_cont_z126",
+]

--- a/research/three_market_shadow/calculations.py
+++ b/research/three_market_shadow/calculations.py
@@ -53,8 +53,10 @@ def _series(snapshot: Mapping[str, Any]) -> tuple[list[float], list[float]]:
     volumes = [float(value) for value in snapshot.get("volume", ())]
     if len(closes) != len(volumes):
         raise ValueError("close and volume must have equal lengths")
-    if any(not math.isfinite(value) or value <= 0 for value in (*closes, *volumes)):
-        raise ValueError("close and volume values must be finite and positive")
+    if any(not math.isfinite(value) or value <= 0 for value in closes):
+        raise ValueError("close values must be finite and positive")
+    if any(not math.isfinite(value) or value < 0 for value in volumes):
+        raise ValueError("volume values must be finite and non-negative")
     return closes, volumes
 
 
@@ -79,7 +81,7 @@ def calculate_kr_rev3_reclaim(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     prior = closes[-lookback - 1 : -1]
     average_volume = sum(volumes[-lookback - 1 : -1]) / lookback
     reclaimed = closes[-2] <= min(prior) and closes[-1] > min(prior)
-    volume_ok = volumes[-1] >= average_volume * 1.2
+    volume_ok = average_volume > 0 and volumes[-1] >= average_volume * 1.2
     if not (reclaimed and volume_ok):
         return _no_signal("kr", "rev3_reclaim", "predicate_false")
     return {
@@ -105,7 +107,7 @@ def calculate_us_mom_cont_z126(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     average_volume = sum(volumes[-lookback - 1 : -1]) / lookback
     momentum = closes[-1] > closes[-1 - momentum_bars]
     continuation = closes[-1] > max(prior_window)
-    volume_ok = volumes[-1] >= average_volume * 1.1
+    volume_ok = average_volume > 0 and volumes[-1] >= average_volume * 1.1
     if not (momentum and continuation and volume_ok):
         return _no_signal("us", "MOM-CONT-Z126", "predicate_false")
     return {

--- a/research/three_market_shadow/calculations.py
+++ b/research/three_market_shadow/calculations.py
@@ -8,6 +8,8 @@ research result is evidence, never an order authorization.
 
 from __future__ import annotations
 
+import hashlib
+import inspect
 import math
 from collections.abc import Mapping
 from typing import Any, Literal
@@ -37,7 +39,13 @@ _CONTRACT = {
     },
 }
 
-CONTRACT_HASH = canonical_sha256(_CONTRACT)
+# This digest binds the executable predicates, not just the declarative
+# thresholds above.  Update it in the same change as an intentional predicate
+# edit; an unpaired edit fails at import time.
+_EXPECTED_ENFORCEMENT_SOURCE_SHA256 = (
+    "a7517ab80b7e83337625599a7995636a34eb7b41f6502727abb4e8d98915bb52"
+)
+CONTRACT_HASH: str
 CRYPTO_SYNTHETIC_SIGNAL: dict[str, Any] = {
     "market": "crypto",
     "strategy": "SYNTHETIC_ACCEPTANCE",
@@ -138,6 +146,27 @@ def calculate_signal(market: str, snapshot: Mapping[str, Any]) -> dict[str, Any]
     if market == "crypto":
         return calculate_crypto_synthetic(snapshot)
     raise ValueError(f"unsupported shadow market: {market}")
+
+
+def _enforcement_source_sha256() -> str:
+    source = "\n".join(
+        (
+            inspect.getsource(calculate_kr_rev3_reclaim),
+            inspect.getsource(calculate_signal),
+        )
+    ).encode("utf-8")
+    return hashlib.sha256(source).hexdigest()
+
+
+_actual_enforcement_source_sha256 = _enforcement_source_sha256()
+if _EXPECTED_ENFORCEMENT_SOURCE_SHA256 != _actual_enforcement_source_sha256:
+    raise RuntimeError(
+        "signal enforcement source hash mismatch; predicate edits require "
+        "an explicit contract update"
+    )
+CONTRACT_HASH = canonical_sha256(
+    {**_CONTRACT, "enforcement_source_sha256": _actual_enforcement_source_sha256}
+)
 
 
 __all__ = [

--- a/research/three_market_shadow/calculations.py
+++ b/research/three_market_shadow/calculations.py
@@ -9,9 +9,9 @@ research result is evidence, never an order authorization.
 from __future__ import annotations
 
 import hashlib
-import inspect
 import math
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any, Literal
 
 from research_contracts.canonical_hash import canonical_sha256
@@ -39,12 +39,14 @@ _CONTRACT = {
     },
 }
 
-# This digest binds the executable predicates, not just the declarative
-# thresholds above.  Update it in the same change as an intentional predicate
-# edit; an unpaired edit fails at import time.
+# This digest binds the complete module-defined enforcement surface, not just
+# declarative thresholds or a hand-maintained function list.  The expected
+# literal is normalized solely to avoid a self-referential digest; changing it
+# alone still fails import unless it is paired with the measured module digest.
 _EXPECTED_ENFORCEMENT_SOURCE_SHA256 = (
-    "a7517ab80b7e83337625599a7995636a34eb7b41f6502727abb4e8d98915bb52"
+    "7c8be76fefbccb8aa6a39b9d1bd1a060a9f590ab126b4d8cc249cb845865e082"
 )
+_ENFORCEMENT_DIGEST_PLACEHOLDER = "<expected-enforcement-source-sha256>"
 CONTRACT_HASH: str
 CRYPTO_SYNTHETIC_SIGNAL: dict[str, Any] = {
     "market": "crypto",
@@ -149,13 +151,15 @@ def calculate_signal(market: str, snapshot: Mapping[str, Any]) -> dict[str, Any]
 
 
 def _enforcement_source_sha256() -> str:
-    source = "\n".join(
-        (
-            inspect.getsource(calculate_kr_rev3_reclaim),
-            inspect.getsource(calculate_signal),
-        )
-    ).encode("utf-8")
-    return hashlib.sha256(source).hexdigest()
+    """Hash normalized bytes of this complete enforcement module at import."""
+    source = Path(__file__).read_text(encoding="utf-8")
+    if source.count(_EXPECTED_ENFORCEMENT_SOURCE_SHA256) != 1:
+        raise RuntimeError("enforcement digest literal must occur exactly once")
+    normalized = source.replace(
+        _EXPECTED_ENFORCEMENT_SOURCE_SHA256,
+        _ENFORCEMENT_DIGEST_PLACEHOLDER,
+    )
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
 _actual_enforcement_source_sha256 = _enforcement_source_sha256()

--- a/research/three_market_shadow/calculations.py
+++ b/research/three_market_shadow/calculations.py
@@ -1,0 +1,148 @@
+"""Frozen, pure calculation contracts for the three-market shadow.
+
+This module has no broker, database, clock, or order imports.  Both the
+broker-neutral backtest harness and the runtime shadow runner import these
+functions directly.  The rules are deliberately shadow-only: a positive
+research result is evidence, never an order authorization.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from research_contracts.canonical_hash import canonical_sha256
+
+SignalState = Literal["SIGNAL", "NO_SIGNAL"]
+
+_CONTRACT = {
+    "version": "three-market-shadow-v1",
+    "kr": {
+        "key": "rev3_reclaim",
+        "lookback": 20,
+        "cross": "previous_close<=prior_window_low and close>prior_window_low",
+        "volume_ratio_min": 1.2,
+    },
+    "us": {
+        "key": "MOM-CONT-Z126",
+        "lookback": 20,
+        "momentum_bars": 6,
+        "cross": "close>prior_window_high",
+        "volume_ratio_min": 1.1,
+    },
+    "crypto": {
+        "key": "SYNTHETIC_ACCEPTANCE",
+        "fixture": "fixed_signal_v1",
+    },
+}
+
+CONTRACT_HASH = canonical_sha256(_CONTRACT)
+CRYPTO_SYNTHETIC_SIGNAL: dict[str, Any] = {
+    "market": "crypto",
+    "strategy": "SYNTHETIC_ACCEPTANCE",
+    "signal_state": "SIGNAL",
+    "signal_source": "SYNTHETIC_ACCEPTANCE",
+    "fixture_id": "crypto-shadow-fixed-signal-v1",
+    "decision": "NO_ORDER",
+}
+
+
+def _series(snapshot: Mapping[str, Any]) -> tuple[list[float], list[float]]:
+    closes = [float(value) for value in snapshot.get("close", ())]
+    volumes = [float(value) for value in snapshot.get("volume", ())]
+    if len(closes) != len(volumes):
+        raise ValueError("close and volume must have equal lengths")
+    if any(not math.isfinite(value) or value <= 0 for value in (*closes, *volumes)):
+        raise ValueError("close and volume values must be finite and positive")
+    return closes, volumes
+
+
+def _no_signal(market: str, strategy: str, reason: str) -> dict[str, Any]:
+    return {
+        "market": market,
+        "strategy": strategy,
+        "signal_state": "NO_SIGNAL",
+        "signal_source": "UNTESTED_RESEARCH_SHADOW",
+        "reason": reason,
+        "decision": "NO_ORDER",
+        "contract_hash": CONTRACT_HASH,
+    }
+
+
+def calculate_kr_rev3_reclaim(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Calculate the frozen KR rev3 reclaim shadow predicate."""
+    closes, volumes = _series(snapshot)
+    lookback = 20
+    if len(closes) < lookback + 1:
+        return _no_signal("kr", "rev3_reclaim", "insufficient_bars")
+    prior = closes[-lookback - 1 : -1]
+    average_volume = sum(volumes[-lookback - 1 : -1]) / lookback
+    reclaimed = closes[-2] <= min(prior) and closes[-1] > min(prior)
+    volume_ok = volumes[-1] >= average_volume * 1.2
+    if not (reclaimed and volume_ok):
+        return _no_signal("kr", "rev3_reclaim", "predicate_false")
+    return {
+        "market": "kr",
+        "strategy": "rev3_reclaim",
+        "signal_state": "SIGNAL",
+        "signal_source": "UNTESTED_RESEARCH_SHADOW",
+        "side": "buy",
+        "reason": "rev3_reclaim_predicate_true",
+        "decision": "NO_ORDER",
+        "contract_hash": CONTRACT_HASH,
+    }
+
+
+def calculate_us_mom_cont_z126(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Calculate the frozen US MOM-CONT-Z126 shadow predicate."""
+    closes, volumes = _series(snapshot)
+    lookback = 20
+    momentum_bars = 6
+    if len(closes) < lookback + momentum_bars:
+        return _no_signal("us", "MOM-CONT-Z126", "insufficient_bars")
+    prior_window = closes[-lookback - 1 : -1]
+    average_volume = sum(volumes[-lookback - 1 : -1]) / lookback
+    momentum = closes[-1] > closes[-1 - momentum_bars]
+    continuation = closes[-1] > max(prior_window)
+    volume_ok = volumes[-1] >= average_volume * 1.1
+    if not (momentum and continuation and volume_ok):
+        return _no_signal("us", "MOM-CONT-Z126", "predicate_false")
+    return {
+        "market": "us",
+        "strategy": "MOM-CONT-Z126",
+        "signal_state": "SIGNAL",
+        "signal_source": "UNTESTED_RESEARCH_SHADOW",
+        "side": "buy",
+        "reason": "momentum_continuation_predicate_true",
+        "decision": "NO_ORDER",
+        "contract_hash": CONTRACT_HASH,
+    }
+
+
+def calculate_crypto_synthetic(
+    _snapshot: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the deterministic acceptance fixture; never a research signal."""
+    return {**CRYPTO_SYNTHETIC_SIGNAL, "contract_hash": CONTRACT_HASH}
+
+
+def calculate_signal(market: str, snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Dispatch to exactly one shared market calculation."""
+    if market == "kr":
+        return calculate_kr_rev3_reclaim(snapshot)
+    if market == "us":
+        return calculate_us_mom_cont_z126(snapshot)
+    if market == "crypto":
+        return calculate_crypto_synthetic(snapshot)
+    raise ValueError(f"unsupported shadow market: {market}")
+
+
+__all__ = [
+    "CONTRACT_HASH",
+    "CRYPTO_SYNTHETIC_SIGNAL",
+    "calculate_crypto_synthetic",
+    "calculate_kr_rev3_reclaim",
+    "calculate_signal",
+    "calculate_us_mom_cont_z126",
+]

--- a/research/three_market_shadow/harness.py
+++ b/research/three_market_shadow/harness.py
@@ -1,0 +1,17 @@
+"""Broker-neutral parity harness for the three-market shadow."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .calculations import CONTRACT_HASH, calculate_signal
+
+
+def run_harness(market: str, snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Compute a replay result using the same function as the runtime runner."""
+    result = calculate_signal(market, snapshot)
+    return {"market": market, "contract_hash": CONTRACT_HASH, "signal": result}
+
+
+__all__ = ["run_harness"]

--- a/research_contracts/trial_evidence.py
+++ b/research_contracts/trial_evidence.py
@@ -15,7 +15,11 @@ PRODUCER_VERSION = "1"
 SHARPE_METHOD = "mean_cv_fold_sharpe"
 P_VALUE_METHOD = "one_sided_normal_cv_fold_sharpe"
 SELECTION_SCORE_METHOD = "canonical_cv_score"
-_EXECUTION_COST_KEYS = frozenset({"fee_bps", "half_spread_bps", "slippage_bps"})
+_LEGACY_EXECUTION_COST_KEYS = frozenset({"fee_bps", "half_spread_bps", "slippage_bps"})
+_EXECUTION_COST_KEYS = _LEGACY_EXECUTION_COST_KEYS | {"transaction_tax_bps"}
+_SHARPE_METHODS = frozenset({"mean_cv_fold_sharpe", "pooled_sample_sharpe"})
+_P_VALUE_METHODS = frozenset({"one_sided_normal_cv_fold_sharpe", "not_computed"})
+_SELECTION_METHODS = frozenset({"canonical_cv_score", "arithmetic_mean_net_return"})
 
 
 class TrialEvidenceError(ValueError):
@@ -61,6 +65,9 @@ def build_trial_evidence(
     p_value: float,
     sample_size: int,
     validation_score: float,
+    sharpe_method: str = SHARPE_METHOD,
+    p_value_method: str = P_VALUE_METHOD,
+    selection_score_method: str = SELECTION_SCORE_METHOD,
 ) -> dict[str, Any]:
     """Build the only accepted JSON payload for an evaluated trial."""
     payload: dict[str, Any] = {
@@ -71,12 +78,12 @@ def build_trial_evidence(
         "config_hash": config_hash,
         "execution_cost": dict(execution_cost),
         "sharpe": sharpe,
-        "sharpe_method": SHARPE_METHOD,
+        "sharpe_method": sharpe_method,
         "p_value": p_value,
-        "p_value_method": P_VALUE_METHOD,
+        "p_value_method": p_value_method,
         "sample_size": sample_size,
         "validation_score": validation_score,
-        "selection_score_method": SELECTION_SCORE_METHOD,
+        "selection_score_method": selection_score_method,
     }
     parse_trial_evidence(payload)
     return payload
@@ -123,9 +130,9 @@ def parse_trial_evidence(payload: Any) -> TrialEvidence:
         raise TrialEvidenceError("invalid_trial_evidence")
     if set(payload) != expected_keys:
         raise TrialEvidenceError("invalid_trial_evidence")
-    if payload.get("sharpe_method") != SHARPE_METHOD:
+    if payload.get("sharpe_method") not in _SHARPE_METHODS:
         raise TrialEvidenceError("invalid_trial_evidence")
-    if payload.get("p_value_method") != P_VALUE_METHOD:
+    if payload.get("p_value_method") not in _P_VALUE_METHODS:
         raise TrialEvidenceError("invalid_trial_evidence")
 
     parameter_key = payload.get("parameter_key")
@@ -136,7 +143,10 @@ def parse_trial_evidence(payload: Any) -> TrialEvidence:
         raise TrialEvidenceError("invalid_trial_evidence")
 
     raw_cost = payload.get("execution_cost")
-    if not isinstance(raw_cost, dict) or set(raw_cost) != _EXECUTION_COST_KEYS:
+    if not isinstance(raw_cost, dict) or set(raw_cost) not in {
+        _LEGACY_EXECUTION_COST_KEYS,
+        _EXECUTION_COST_KEYS,
+    }:
         raise TrialEvidenceError("invalid_trial_evidence")
     execution_cost = {key: _finite_number(raw_cost[key]) for key in raw_cost}
 
@@ -154,10 +164,10 @@ def parse_trial_evidence(payload: Any) -> TrialEvidence:
     validation_score: float | None = None
     selection_score_method: str | None = None
     if schema_version in {SCHEMA_VERSION, SELECTION_SCHEMA_VERSION}:
-        if payload.get("selection_score_method") != SELECTION_SCORE_METHOD:
+        if payload.get("selection_score_method") not in _SELECTION_METHODS:
             raise TrialEvidenceError("invalid_trial_evidence")
         validation_score = _finite_number(payload.get("validation_score"))
-        selection_score_method = SELECTION_SCORE_METHOD
+        selection_score_method = str(payload["selection_score_method"])
     return TrialEvidence(
         schema_version=schema_version,
         producer=producer,
@@ -166,9 +176,9 @@ def parse_trial_evidence(payload: Any) -> TrialEvidence:
         config_hash=config_hash,
         execution_cost=execution_cost,
         sharpe=sharpe,
-        sharpe_method=SHARPE_METHOD,
+        sharpe_method=str(payload["sharpe_method"]),
         p_value=p_value,
-        p_value_method=P_VALUE_METHOD,
+        p_value_method=str(payload["p_value_method"]),
         sample_size=sample_size,
         validation_score=validation_score,
         selection_score_method=selection_score_method,

--- a/scripts/run_kr_stageb.py
+++ b/scripts/run_kr_stageb.py
@@ -9,7 +9,7 @@ from datetime import date
 from pathlib import Path
 
 from research.kr_corpus.backtest.evidence import write_stage_b_evidence
-from research.kr_corpus.backtest.real_data import load_real_main_bars
+from research.kr_corpus.backtest.real_data import load_real_main_stage_b_input
 from research.kr_corpus.backtest.stage_b import build_run_contract, run_stage_b
 
 
@@ -31,7 +31,7 @@ def main() -> int:
         window_start=args.start,
         window_end=args.end,
     )
-    bars = load_real_main_bars(
+    real_input = load_real_main_stage_b_input(
         artifact_root=args.artifact_root,
         run_id=args.run_id,
         window_start=args.start,
@@ -39,7 +39,12 @@ def main() -> int:
         markets=args.market,
         max_symbols=args.max_symbols,
     )
-    result = run_stage_b(bars=bars, contract=contract)
+    result = run_stage_b(
+        bars=real_input.bars,
+        contract=contract,
+        market_sessions=real_input.market_sessions,
+        data_coverage=real_input.coverage,
+    )
     payload = write_stage_b_evidence(args.evidence, result)
     print(
         json.dumps(

--- a/scripts/run_kr_stageb.py
+++ b/scripts/run_kr_stageb.py
@@ -1,0 +1,59 @@
+"""Bounded KR Stage-B real-data runner; read-only and scheduleless."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+from research.kr_corpus.backtest.evidence import write_stage_b_evidence
+from research.kr_corpus.backtest.real_data import load_real_main_bars
+from research.kr_corpus.backtest.stage_b import build_run_contract, run_stage_b
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run explicit KR Stage-B real-data trial"
+    )
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--start", type=date.fromisoformat, required=True)
+    parser.add_argument("--end", type=date.fromisoformat, required=True)
+    parser.add_argument("--market", action="append", required=True)
+    parser.add_argument("--max-symbols", type=int, required=True)
+    parser.add_argument("--cost-profile", choices=("43bp", "83bp"), required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    args = parser.parse_args()
+    contract = build_run_contract(
+        cost_profile=args.cost_profile,
+        window_start=args.start,
+        window_end=args.end,
+    )
+    bars = load_real_main_bars(
+        artifact_root=args.artifact_root,
+        run_id=args.run_id,
+        window_start=args.start,
+        window_end=args.end,
+        markets=args.market,
+        max_symbols=args.max_symbols,
+    )
+    result = run_stage_b(bars=bars, contract=contract)
+    payload = write_stage_b_evidence(args.evidence, result)
+    print(
+        json.dumps(
+            {
+                "result": result.to_dict(),
+                "evidence": str(args.evidence),
+                "trial_evidence_schema": payload["trial_evidence"]["schema_version"],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/three_market_shadow_once.py
+++ b/scripts/three_market_shadow_once.py
@@ -1,0 +1,33 @@
+"""Run one broker-neutral three-market shadow from a JSON snapshot.
+
+No database, account, broker, scheduler, or order code is imported here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from app.services.three_market_shadow import shadow_decision
+from research_contracts.canonical_hash import canonical_sha256
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one mutation-free market shadow")
+    parser.add_argument("market", choices=("kr", "us", "crypto"))
+    parser.add_argument(
+        "snapshot", type=Path, help="JSON object containing the input snapshot"
+    )
+    args = parser.parse_args()
+    snapshot: dict[str, Any] = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    result = shadow_decision(args.market, snapshot)
+    result["input_hash"] = canonical_sha256(snapshot)
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/services/test_three_market_shadow_parity.py
+++ b/tests/services/test_three_market_shadow_parity.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from app.services.kis_lean_execution import SyntheticNoOpStrategy
+from app.services.three_market_shadow import shadow_decision
+from app.services.three_market_shadow_lifecycle import verify_crypto_acceptance_path
+from research.three_market_shadow.calculations import (
+    CONTRACT_HASH,
+    calculate_signal,
+)
+from research.three_market_shadow.harness import run_harness
+
+
+def _snapshot() -> dict[str, object]:
+    closes = [100.0 + index for index in range(25)]
+    volumes = [100.0] * 25
+    return {"symbol": "005930", "close": closes, "volume": volumes}
+
+
+def test_runner_and_harness_import_and_return_same_pure_calculation() -> None:
+    snapshot = _snapshot()
+    runner_signal = SyntheticNoOpStrategy().evaluate(snapshot)
+    harness_signal = run_harness("kr", snapshot)["signal"]
+
+    assert runner_signal["contract_hash"] == CONTRACT_HASH
+    assert {key: value for key, value in runner_signal.items() if key != "labels"} == {
+        "decision": "NO_ORDER",
+        "symbol": "005930",
+        **harness_signal,
+    }
+    assert run_harness("kr", snapshot)["contract_hash"] == CONTRACT_HASH
+
+
+def test_dispatch_is_shared_for_kr_us_and_crypto() -> None:
+    snapshot = _snapshot()
+    for market in ("kr", "us", "crypto"):
+        assert run_harness(market, snapshot)["signal"] == calculate_signal(
+            market, snapshot
+        )
+
+
+def test_shadow_has_acceptance_labels_and_zero_mutation() -> None:
+    result = shadow_decision("us", _snapshot())
+    assert result["order_count"] == 0
+    assert result["account_mutations"] == 0
+    assert result["arm"] is False
+    assert result["labels"] == {
+        "purpose": "execution_acceptance",
+        "sample_class": "ACCEPTANCE_ONLY",
+        "signal_source": "UNTESTED_RESEARCH_SHADOW",
+        "evidence_preserved": "YES",
+        "scoring_eligible": "EXCLUDE",
+        "forecast_calibration_eligible": "EXCLUDE",
+        "trade_performance_eligible": "EXCLUDE",
+        "strategy_promotion_credit": "NONE",
+        "paper_go_live_credit": "NONE",
+        "operational_reliability_eligible": "UNIDENTIFIABLE",
+        "completion_name": "BROKER_ACCEPTANCE_PASSED",
+    }
+
+
+def test_crypto_path_is_signal_intent_block_kill_restart() -> None:
+    path = verify_crypto_acceptance_path()
+    assert [item.get("kind") for item in path[1:]] == [
+        "order_intent",
+        "pre_submit_block",
+        "kill",
+        "restart",
+    ]
+    assert path[0]["signal_source"] == "SYNTHETIC_ACCEPTANCE"
+    assert path[2]["accepted_for_submission"] is False
+    assert path[-1]["orders"] == 0

--- a/tests/services/test_three_market_shadow_parity.py
+++ b/tests/services/test_three_market_shadow_parity.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
 from app.services.kis_lean_execution import SyntheticNoOpStrategy
 from app.services.three_market_shadow import shadow_decision
 from app.services.three_market_shadow_lifecycle import verify_crypto_acceptance_path
@@ -8,6 +14,9 @@ from research.three_market_shadow.calculations import (
     calculate_signal,
 )
 from research.three_market_shadow.harness import run_harness
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CALCULATIONS_PATH = _REPO_ROOT / "research/three_market_shadow/calculations.py"
 
 
 def _snapshot() -> dict[str, object]:
@@ -69,3 +78,58 @@ def test_crypto_path_is_signal_intent_block_kill_restart() -> None:
     assert path[0]["signal_source"] == "SYNTHETIC_ACCEPTANCE"
     assert path[2]["accepted_for_submission"] is False
     assert path[-1]["orders"] == 0
+
+
+@pytest.mark.parametrize(
+    ("name", "original", "replacement"),
+    (
+        ("contract", '"three-market-shadow-v1"', '"three-market-shadow-v2"'),
+        ("series_close_guard", "value <= 0", "value < 0"),
+        ("no_signal", '"reason": reason,', '"reason": f"changed:{reason}",'),
+        ("kr_predicate", "average_volume * 1.2", "average_volume * 1.0"),
+        ("us_predicate", "average_volume * 1.1", "average_volume * 1.0"),
+        (
+            "crypto_payload",
+            '"fixture_id": "crypto-shadow-fixed-signal-v1",',
+            '"fixture_id": "crypto-shadow-fixed-signal-v2",',
+        ),
+        ("dispatch", 'if market == "kr":', 'if market == "KR":'),
+        (
+            "digest_helper",
+            'normalized.encode("utf-8")',
+            'normalized.encode("ascii")',
+        ),
+    ),
+)
+def test_unpaired_full_module_enforcement_edit_fails_import(
+    tmp_path: Path,
+    name: str,
+    original: str,
+    replacement: str,
+) -> None:
+    """Every module-defined enforcement helper is inside the import-time digest."""
+    source = _CALCULATIONS_PATH.read_text(encoding="utf-8")
+    assert source.count(original) == 1, name
+    mutated = tmp_path / "calculations.py"
+    mutated.write_text(source.replace(original, replacement), encoding="utf-8")
+    command = "\n".join(
+        (
+            "import importlib.util",
+            "import sys",
+            f"path = {str(mutated)!r}",
+            "spec = importlib.util.spec_from_file_location('mutated_calculations', path)",
+            "module = importlib.util.module_from_spec(spec)",
+            "sys.modules[spec.name] = module",
+            "spec.loader.exec_module(module)",
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", command],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode != 0, name
+    assert "signal enforcement source hash mismatch" in result.stderr


### PR DESCRIPTION
## Summary
- retain one canonical rev3_reclaim pure function shared by shadow3 and KR Stage-B
- add t+1 open / D+5 close Stage-B engine and checksum-verified bounded real-data loader
- bind explicit 43bp and 83bp cost contracts; no default cost injection
- write canonical honest_trial.v3 strategy-backtest evidence on a separate track

## Safety
- no broker/account/ledger/backfill imports or calls
- holdout paths and dates fail closed
- existing PIPELINE_SMOKE_NOT_A_STRATEGY label is retained; Stage-B remains UNTESTED_RESEARCH_SHADOW
- orders=0, account_mutations=0; merge/deploy does not authorize orders

## Verification
- 80 KR backtest/shadow regression tests passed
- make lint passed (Ruff + format + ty)
- D5 real-data run: 434 trades, 33 skipped signals, 44,278 PIT checks, 43bp explicit contract
- contract hash: 2ffbcc7eed44683df52173aca4df800648e54a23fa25589a6620f825f4886345
- HEAD: 837b88b59f5fca71746a48e999867f01a8c928bd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic shadow-signal evaluation across KR, US, and crypto markets.
  - Added read-only tools for shadow decisions and bounded KR research trials.
  - Added Stage-B KR backtesting with configurable costs, fixed timing, holdout safeguards, and descriptive statistics.
  - Added verified real-data loading, coverage reporting, and structured evidence with checksums and acceptance status.

- **Bug Fixes**
  - Improved compatibility for package and legacy import paths.

- **Tests**
  - Added coverage for signal parity, lifecycle safeguards, data validation, timing, costs, and lookahead protection.

- **Documentation**
  - Documented Stage-B workflows, evidence requirements, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->