### PR TITLE
fix(us-intraday): repair evidence and reseal exploration only

### DIFF
--- a/research/us_intraday_corpus/alpaca_data.py
+++ b/research/us_intraday_corpus/alpaca_data.py
@@ -13,10 +13,12 @@ Boundary (brief §4), enforced rather than promised:
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlparse
 
@@ -32,6 +34,7 @@ from . import config
 CONTACTED_HOSTS: set[str] = set()
 
 HOST_EVIDENCE_FILENAME = "host_evidence.json"
+REQUEST_LEDGER_FILENAME = "request_attempts.jsonl"
 
 
 def host_evidence_path():
@@ -81,6 +84,74 @@ def record_host_evidence(host: str) -> None:
     if prior is not None:
         payload["prior_reconstructed_evidence"] = prior
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def request_ledger_path():
+    return config.STAGING_DIR / REQUEST_LEDGER_FILENAME
+
+
+def record_request_attempt(
+    *,
+    attempt: int,
+    request_number: int,
+    host: str,
+    url: str,
+    params: dict[str, Any],
+    outcome: str,
+    status_code: int | None = None,
+    error_type: str | None = None,
+) -> None:
+    """Persist one sanitized HTTP attempt, including retries.
+
+    This is deliberately JSONL rather than a counter: a 429 followed by a
+    successful retry must remain two independently auditable attempts. Request
+    parameters contain no credentials; the response body is never recorded.
+    """
+    safe_params = {
+        key: value
+        for key, value in params.items()
+        if key
+        in {
+            "symbols",
+            "timeframe",
+            "start",
+            "end",
+            "limit",
+            "adjustment",
+            "feed",
+            "sort",
+            "page_token",
+        }
+    }
+    entry = {
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "attempt": attempt,
+        "request_number": request_number,
+        "host": host,
+        "path": urlparse(url).path,
+        "params": safe_params,
+        "outcome": outcome,
+        "status_code": status_code,
+        "error_type": error_type,
+    }
+    path = request_ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def load_request_attempts() -> list[dict[str, Any]]:
+    path = request_ledger_path()
+    if not path.exists():
+        return []
+    entries = []
+    with path.open(encoding="utf-8") as handle:
+        for raw in handle:
+            if raw.strip():
+                entries.append(json.loads(raw))
+    return entries
 
 
 def load_host_evidence() -> dict:
@@ -290,7 +361,7 @@ class AlpacaDataClient:
         CONTACTED_HOSTS.add(host)
 
         backoff = 1.0
-        for _attempt in range(8):
+        for _attempt in range(1, 9):
             self.limiter.wait()
             self.counter.spend()
             # Recorded INSIDE the retry loop, immediately before each HTTP
@@ -298,13 +369,56 @@ class AlpacaDataClient:
             # (two actual HTTP attempts) as a single request, so the sidecar was
             # not a record of all requests.
             record_host_evidence(host)
-            response = self._session.get(url, params=params, timeout=30)
+            try:
+                response = self._session.get(url, params=params, timeout=30)
+            except Exception as exc:
+                record_request_attempt(
+                    attempt=_attempt,
+                    request_number=self.counter.count,
+                    host=host,
+                    url=url,
+                    params=params,
+                    outcome="exception",
+                    error_type=type(exc).__name__,
+                )
+                raise
             if response.status_code == 429:
+                record_request_attempt(
+                    attempt=_attempt,
+                    request_number=self.counter.count,
+                    host=host,
+                    url=url,
+                    params=params,
+                    outcome="retryable_429",
+                    status_code=response.status_code,
+                )
                 self.counter.rate_429 += 1
                 time.sleep(backoff)
                 backoff = min(backoff * 2, 60.0)  # back off only; never speed up
                 continue
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except Exception as exc:
+                record_request_attempt(
+                    attempt=_attempt,
+                    request_number=self.counter.count,
+                    host=host,
+                    url=url,
+                    params=params,
+                    outcome="http_error",
+                    status_code=response.status_code,
+                    error_type=type(exc).__name__,
+                )
+                raise
+            record_request_attempt(
+                attempt=_attempt,
+                request_number=self.counter.count,
+                host=host,
+                url=url,
+                params=params,
+                outcome="success",
+                status_code=response.status_code,
+            )
             return response.json()
         raise RuntimeError(f"giving up after repeated 429s: {url} {params}")
 

--- a/research/us_intraday_corpus/build.py
+++ b/research/us_intraday_corpus/build.py
@@ -44,6 +44,7 @@ from . import alpaca_data, bars, config, finalize, labels, writer
 # minimum, it does not raise throughput.
 BATCH_1H = 100
 BATCH_1M = 1
+FIELDWISE_NULL_REPORT = "fieldwise_null_report.json"
 
 
 @dataclass
@@ -516,6 +517,95 @@ def write_checkpoint(name: str, payload: dict[str, Any]) -> None:
     labels.write_labelled_json(config.REPORTS_DIR / f"checkpoint_{name}.json", payload)
 
 
+def build_fieldwise_null_report() -> dict[str, Any]:
+    """Count nulls in readable exploration parquet, field by field.
+
+    The scan is deliberately rooted at ``dataset/`` and guards every path
+    before opening it. It never enumerates or inspects ``holdout/``.
+    """
+    import pyarrow.parquet as pq
+
+    files = sorted(config.DATASET_DIR.rglob("*.parquet"))
+    fields: dict[str, dict[str, int]] = {}
+    total_rows = 0
+    for path in files:
+        from . import loader
+
+        loader.assert_not_holdout_path(path)
+        parquet = pq.ParquetFile(str(path))
+        names = parquet.schema_arrow.names
+        for name in names:
+            fields.setdefault(name, {"null_count": 0, "row_count": 0})
+        for batch in parquet.iter_batches(batch_size=65_536):
+            total_rows += batch.num_rows
+            for index, name in enumerate(names):
+                column = batch.column(index)
+                fields[name]["row_count"] += batch.num_rows
+                fields[name]["null_count"] += column.null_count
+
+    field_rows = []
+    for name in sorted(fields):
+        row = fields[name]
+        count = row["row_count"]
+        nulls = row["null_count"]
+        field_rows.append(
+            {
+                "field": name,
+                "null_count": nulls,
+                "row_count": count,
+                "null_rate": (nulls / count if count else None),
+            }
+        )
+    report = {
+        "scope": "exploration_only",
+        "files_scanned": len(files),
+        "row_count": total_rows,
+        "fields": field_rows,
+        "holdout_opened": False,
+        "holdout_read_count": 0,
+    }
+    labels.write_labelled_json(config.REPORTS_DIR / FIELDWISE_NULL_REPORT, report)
+    return report
+
+
+def reseal_exploration_snapshot() -> int:
+    """Reseal existing readable exploration artifacts without collection.
+
+    This path has no credential/client construction and cannot promote or
+    inspect holdout data. It exists specifically for repair/reseal after the
+    collector contract has been corrected.
+    """
+    finalize.load_registry()
+    null_report = build_fieldwise_null_report()
+    request_attempts = alpaca_data.load_request_attempts()
+    manifest = finalize.seal(
+        terminal_verdict="BUILT_WITH_GAPS",
+        body={
+            "RESEAL_SCOPE": "exploration_only",
+            "repair": {
+                "marker_migration_or_failclose": "FAIL_CLOSED",
+                "empty_success_rejected": True,
+                "per_attempt_request_ledger": bool(request_attempts),
+                "request_attempt_count": len(request_attempts),
+                "fieldwise_null_report": f"reports/{FIELDWISE_NULL_REPORT}",
+            },
+            "fieldwise_null_report": null_report,
+            "baseline_computed": False,
+            "strategy_admission": False,
+        },
+    )
+    print(
+        json.dumps(
+            {
+                "RESEAL_SCOPE": manifest["RESEAL_SCOPE"],
+                "terminal_verdict": manifest["terminal_verdict"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
 MEASUREMENT_CACHE = "measurement_1m.json"
 
 
@@ -584,6 +674,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="build us-intraday-corpus-v1")
     parser.add_argument("--probe-only", action="store_true")
     parser.add_argument(
+        "--reseal-exploration",
+        action="store_true",
+        help="reseal existing exploration artifacts only; never collect or open holdout",
+    )
+    parser.add_argument(
         "--skip-1m",
         action="store_true",
         help="legacy: only meaningful with --phase both; suppresses the 1Min phase",
@@ -603,6 +698,9 @@ def main(argv: list[str] | None = None) -> int:
         help="explicitly opt out of scope C to collect 1Hour (see config.HOUR_DATA_GAP)",
     )
     args = parser.parse_args(argv)
+
+    if args.reseal_exploration:
+        return reseal_exploration_snapshot()
 
     # Resolve which phases will actually run, then refuse an empty selection.
     # `--skip-1m` predates the scope-C default: with `--phase 1m` it suppresses

--- a/research/us_intraday_corpus/finalize.py
+++ b/research/us_intraday_corpus/finalize.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -100,17 +101,24 @@ def _shippable_files() -> list[Path]:
     included, which is exactly what let a stale CSV escape the sister corpus.
     """
     out: list[Path] = []
-    for path in sorted(config.ARTIFACT_ROOT.rglob("*")):
-        if not path.is_file():
-            continue
-        parts = path.parts
-        if "_staging" in parts:
-            continue
-        if access_log.is_holdout_path(path):
-            continue  # <-- pitfall 1: never re-read the seal
-        if path.name in {"checksums.sha256", "manifest.json"}:
-            continue
-        out.append(path)
+    # Prune sealed directories before walking them. The older rglob form did
+    # not open holdout files, but it still enumerated their directory entries;
+    # repair/reseal must make the exploration-only boundary explicit.
+    for root, dirs, files in os.walk(config.ARTIFACT_ROOT, followlinks=False):
+        root_path = Path(root)
+        dirs[:] = [
+            name
+            for name in dirs
+            if name != "_staging" and not access_log.is_holdout_path(root_path / name)
+        ]
+        for name in files:
+            path = root_path / name
+            if access_log.is_holdout_path(path):
+                continue  # <-- pitfall 1: never re-read the seal
+            if path.name in {"checksums.sha256", "manifest.json"}:
+                continue
+            out.append(path)
+    out.sort()
     return out
 
 

--- a/research/us_intraday_corpus/tests/test_corpus_invariants.py
+++ b/research/us_intraday_corpus/tests/test_corpus_invariants.py
@@ -456,6 +456,46 @@ def test_request_counter_enforces_hard_cap():
         counter.spend()
 
 
+def test_request_ledger_records_each_retry_attempt(artifact_root, monkeypatch):
+    """A retry is two request attempts, not one logical page fetch."""
+
+    class _Response:
+        def __init__(self, status_code, payload=None):
+            self.status_code = status_code
+            self._payload = payload or {"bars": {}, "next_page_token": None}
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP {self.status_code}")
+
+        def json(self):
+            return self._payload
+
+    class _Session:
+        def __init__(self):
+            self.responses = [_Response(429), _Response(200)]
+            self.headers = {}
+
+        def get(self, *_args, **_kwargs):
+            return self.responses.pop(0)
+
+    monkeypatch.setattr(alpaca_data, "load_credentials", lambda: ("key", "secret"))
+    monkeypatch.setattr(alpaca_data.time, "sleep", lambda *_args: None)
+    client = alpaca_data.AlpacaDataClient(
+        limiter=alpaca_data.RateLimiter(min_interval_sec=0),
+        counter=alpaca_data.RequestCounter(max_requests=2),
+        session=_Session(),
+    )
+    client.fetch_bars_page(
+        ["AAPL"], "1Min", "2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z"
+    )
+
+    entries = alpaca_data.load_request_attempts()
+    assert [entry["outcome"] for entry in entries] == ["retryable_429", "success"]
+    assert [entry["request_number"] for entry in entries] == [1, 2]
+    assert all("secret" not in json.dumps(entry) for entry in entries)
+
+
 # --------------------------------------------------------------------------
 # ROB-1206 -- UTC storage, America/New_York session_date, never KST
 # --------------------------------------------------------------------------
@@ -885,6 +925,46 @@ def test_old_snapshot_form_would_fail_the_regression_guard():
     for _payload, chain in _TwoPageClient().iter_bars(["AAPL"], "1Min", "s", "e"):
         live = chain
     assert live.as_dict()["complete"] is True  # post-exhaustion snapshot
+
+
+def test_fieldwise_null_report_is_exploration_only(artifact_root):
+    table = pa.Table.from_pylist(
+        [
+            {"symbol": "AAPL", "open": 1.0, "close": None, "volume": 10},
+            {"symbol": "AAPL", "open": None, "close": 1.5, "volume": 11},
+        ]
+    )
+    path = config.DATASET_DIR / "freq=1m" / "year=2024" / "part.parquet"
+    writer.write_parquet_atomic(table, path)
+
+    report = build.build_fieldwise_null_report()
+    by_field = {row["field"]: row for row in report["fields"]}
+    assert report["scope"] == "exploration_only"
+    assert report["row_count"] == 2
+    assert by_field["open"]["null_count"] == 1
+    assert by_field["open"]["null_rate"] == 0.5
+    assert by_field["close"]["null_count"] == 1
+    assert report["holdout_opened"] is False
+    assert report["holdout_read_count"] == 0
+
+
+def test_reseal_exploration_does_not_need_credentials_or_holdout(
+    artifact_root, monkeypatch
+):
+    path = config.DATASET_DIR / "freq=1m" / "year=2024" / "part.parquet"
+    writer.write_parquet_atomic(_table(), path)
+    monkeypatch.setattr(
+        alpaca_data,
+        "load_credentials",
+        lambda: (_ for _ in ()).throw(AssertionError("network path")),
+    )
+
+    assert build.main(["--reseal-exploration"]) == 0
+    manifest = json.loads(config.MANIFEST_PATH.read_text())
+    assert manifest["RESEAL_SCOPE"] == "exploration_only"
+    assert manifest["baseline_computed"] is False
+    assert manifest["strategy_admission"] is False
+    assert manifest["holdout"]["written_not_read"] is True
 
 
 def test_page_chain_marks_incomplete_when_not_exhausted():


### PR DESCRIPTION
## Summary

- Keep legacy resume markers fail-closed; do not infer exploration coverage from the old `symbols` field.
- Reject `--skip-1m` empty-success paths (existing R5 contract retained).
- Persist one sanitized JSONL request-attempt record per HTTP retry attempt.
- Generate an exploration-only fieldwise null report.
- Add an explicit `--reseal-exploration` path with no credential/client construction and no holdout traversal.

## Verification

- `uv run pytest research/us_intraday_corpus/tests/ -q` — 52 passed
- `uv run ruff check research/us_intraday_corpus` — passed
- `uv run ruff format --check research/us_intraday_corpus` — passed
- Exploration reseal completed: `RESEAL_SCOPE=exploration_only`, `BUILT_WITH_GAPS`
- Exploration null report: 4,699 files / 409,638,229 rows; all listed fields 0 nulls
- Holdout: not opened, not hashed, not scanned; manifest evidence `written_not_read=true`, `holdout_opened=false`, `holdout_read_count=0`
- No baseline computation or strategy admission

No merge is requested in this step.
