### PR TITLE
feat(backfill): add KIS live reuse-only surface wrapper

### DIFF
--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -74,6 +74,18 @@ except ImportError:  # pragma: no cover - direct CLI execution
         write_surface_manifest,
     )
 try:
+    from .surface_runtime import (
+        build_kis_surface_client,
+        is_kis_live_immediate_stop,
+        source_for_surface,
+    )
+except ImportError:  # pragma: no cover - direct CLI execution
+    from surface_runtime import (
+        build_kis_surface_client,
+        is_kis_live_immediate_stop,
+        source_for_surface,
+    )
+try:
     from .sources import (  # noqa: E402
         AUTH_STALE_TOKEN,
         EMPTY_RESPONSE,
@@ -465,8 +477,10 @@ async def run_stream(
     start_date: date,
     end_date: date,
     batch_id: str,
+    *,
+    surface_id: str | None = None,
 ) -> StreamStats:
-    pipe_id = source
+    pipe_id = surface_id or source
     stats = StreamStats(source=pipe_id, symbols_total=len(symbols))
     pacer = Pacer(source)
     start_dt = datetime.combine(start_date, datetime.min.time())
@@ -565,6 +579,10 @@ async def run_stream(
                             "pacer": pacer.snapshot(),
                         }
                     )
+                    if pipe_id == "kis_live" and is_kis_live_immediate_stop(exc):
+                        stats.stopped_reason = f"kis_live immediate stop: {reason_code}"
+                        ckpt.save()
+                        return stats
                     guard.note_429(pipe_id, is_429)
                     if reason_code == AUTH_STALE_TOKEN:
                         stats.stopped_reason = (
@@ -1417,6 +1435,17 @@ async def main() -> int:
     ap.add_argument("--end-date", required=True)
     ap.add_argument("--sources", default="toss,kiwoom,kis")
     ap.add_argument(
+        "--surface-id",
+        choices=("kis_mock", "kis_live"),
+        default=None,
+        help="bind a single generic source stream to one explicit KIS surface",
+    )
+    ap.add_argument(
+        "--kis-latest-eligible-date",
+        default=None,
+        help="required for KIS surfaces; newest date after latest-session exclusion",
+    )
+    ap.add_argument(
         "--surface",
         choices=("mock", "live"),
         default=None,
@@ -1454,12 +1483,34 @@ async def main() -> int:
     with args.split_csv.open(newline="", encoding="utf-8") as split_fh:
         split_fields = set(csv.DictReader(split_fh).fieldnames or ())
     if "surface" in split_fields:
+        if args.surface_id is not None:
+            raise SurfaceContractError(
+                "--surface-id cannot be combined with a Kiwoom surface CSV"
+            )
         return await _run_dual_surface(args)
     if args.surface is not None:
         raise SurfaceContractError(
             "--surface requires a dual Kiwoom split CSV with a surface column"
         )
     wanted = [s.strip() for s in args.sources.split(",") if s.strip()]
+    if args.surface_id is not None:
+        expected_source = source_for_surface(args.surface_id)
+        if wanted != [expected_source]:
+            raise SurfaceContractError(
+                f"--surface-id {args.surface_id} requires "
+                f"--sources {expected_source} only"
+            )
+        if expected_source == "kis":
+            if args.kis_latest_eligible_date is None:
+                raise SurfaceContractError(
+                    "KIS surfaces require --kis-latest-eligible-date"
+                )
+            latest_eligible = date.fromisoformat(args.kis_latest_eligible_date)
+            if end_date > latest_eligible:
+                raise SurfaceContractError(
+                    f"KIS end-date {end_date} exceeds latest eligible "
+                    f"session boundary {latest_eligible}"
+                )
 
     assignment: dict[str, list[str]] = {s: [] for s in wanted}
     with args.split_csv.open() as fh:
@@ -1485,11 +1536,15 @@ async def main() -> int:
 
     assert_fetch_window_open()
 
-    batch_id = f"kr-backfill-p1-{now_kst():%Y%m%dT%H%M%S}"
+    pipe_label = args.surface_id or "generic"
+    batch_id = f"kr-backfill-p1-{pipe_label}-{now_kst():%Y%m%dT%H%M%S}"
 
-    from equality_gate import build_clients
+    if args.surface_id in {"kis_mock", "kis_live"}:
+        clients = {"kis": await build_kis_surface_client(args.surface_id)}
+    else:
+        from equality_gate import build_clients
 
-    clients = await build_clients(wanted)
+        clients = await build_clients(wanted)
     pool = await asyncpg.create_pool(dsn(), min_size=2, max_size=6)
     log = ProgressLog(args.job_dir / "events" / "progress.jsonl")
     guard = Guard(pool, args.baseline_median_ms, log)
@@ -1499,6 +1554,8 @@ async def main() -> int:
             "event": "stage_b_start",
             "target_table": TARGET_TABLE,
             "batch_id": batch_id,
+            "surface": args.surface_id,
+            "kis_latest_eligible_date": args.kis_latest_eligible_date,
             "window": [args.start_date, args.end_date],
             "symbols_per_source": {k: len(v) for k, v in assignment.items()},
         }
@@ -1512,12 +1569,17 @@ async def main() -> int:
                     assignment[src],
                     clients[src],
                     pool,
-                    Checkpoint(args.job_dir / "events" / f"checkpoint_{src}.json"),
+                    Checkpoint(
+                        args.job_dir
+                        / "events"
+                        / f"checkpoint_{args.surface_id or src}.json"
+                    ),
                     log,
                     guard,
                     start_date,
                     end_date,
                     batch_id,
+                    surface_id=args.surface_id,
                 )
                 for src in wanted
             ],

--- a/research/kr_backfill/surface_runtime.py
+++ b/research/kr_backfill/surface_runtime.py
@@ -1,0 +1,76 @@
+"""Fail-closed runtime bindings for individually owned backfill surfaces."""
+
+from __future__ import annotations
+
+from typing import Any
+
+SURFACE_SOURCES = {
+    "kiwoom_mock": "kiwoom",
+    "kiwoom_live": "kiwoom",
+    "kis_mock": "kis",
+    "kis_live": "kis",
+}
+
+
+class SurfaceRuntimeError(RuntimeError):
+    def __init__(self, reason_code: str) -> None:
+        self.reason_code = reason_code
+        self.retry_disposition = "STOP_NO_RETRY"
+        super().__init__(reason_code)
+
+
+class ReuseOnlyTokenManager:
+    """Allow KIS live Redis token reads, but never issuance or cache mutation."""
+
+    def __init__(self, delegate: Any) -> None:
+        self._delegate = delegate
+
+    async def get_token(self, *args: Any, **kwargs: Any) -> str | None:
+        return await self._delegate.get_token(*args, **kwargs)
+
+    async def refresh_token_with_lock(self, _token_fetcher: Any) -> str:
+        raise SurfaceRuntimeError("KIS_LIVE_TOKEN_CACHE_MISS_STOP")
+
+    async def clear_token(self) -> None:
+        raise SurfaceRuntimeError("KIS_LIVE_TOKEN_REJECTED_STOP")
+
+
+def source_for_surface(surface_id: str) -> str:
+    try:
+        return SURFACE_SOURCES[surface_id]
+    except KeyError as exc:
+        raise SurfaceRuntimeError(f"UNKNOWN_SURFACE:{surface_id}") from exc
+
+
+async def build_kis_surface_client(surface_id: str) -> Any:
+    """Build one KIS market-data client with surface-specific token policy."""
+    if surface_id not in {"kis_mock", "kis_live"}:
+        raise SurfaceRuntimeError(f"NOT_A_KIS_SURFACE:{surface_id}")
+
+    from app.services.brokers.kis.client import KISClient
+
+    client = KISClient(is_mock=surface_id == "kis_mock")
+    if surface_id == "kis_live":
+        from app.services.redis_token_manager import redis_token_manager
+
+        token = await redis_token_manager.get_token(force_redis_check=True)
+        if not token:
+            raise SurfaceRuntimeError("KIS_LIVE_TOKEN_CACHE_MISS_STOP")
+        client._settings.kis_access_token = token
+        client._token_manager = ReuseOnlyTokenManager(redis_token_manager)
+    return client
+
+
+def is_kis_live_immediate_stop(exc: BaseException) -> bool:
+    """KIS live 401/429/auth failures stop this pipe without retrying here."""
+    reason = str(getattr(exc, "reason_code", ""))
+    message = f"{type(exc).__name__}: {exc}".lower()
+    return bool(
+        reason.startswith("KIS_LIVE_TOKEN_")
+        or " 401" in message
+        or "401 " in message
+        or " 429" in message
+        or "429 " in message
+        or "ratelimitexceeded" in message
+        or "rate limit retries exhausted" in message
+    )

--- a/tests/research/test_kr_backfill_surface_runtime.py
+++ b/tests/research/test_kr_backfill_surface_runtime.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_DIR = Path(__file__).resolve().parents[2] / "research" / "kr_backfill"
+
+
+@pytest.fixture
+def runtime_module():
+    sys.path.insert(0, str(MODULE_DIR))
+    try:
+        yield importlib.import_module("surface_runtime")
+    finally:
+        sys.modules.pop("surface_runtime", None)
+        sys.path.remove(str(MODULE_DIR))
+
+
+@pytest.mark.asyncio
+async def test_kis_live_token_wrapper_never_refreshes_or_clears(runtime_module) -> None:
+    class Delegate:
+        async def get_token(self, **_kwargs: object) -> str:
+            return "cached-token"
+
+    wrapper = runtime_module.ReuseOnlyTokenManager(Delegate())
+
+    assert await wrapper.get_token(force_redis_check=True) == "cached-token"
+    with pytest.raises(
+        runtime_module.SurfaceRuntimeError,
+        match="KIS_LIVE_TOKEN_CACHE_MISS_STOP",
+    ):
+        await wrapper.refresh_token_with_lock(object())
+    with pytest.raises(
+        runtime_module.SurfaceRuntimeError,
+        match="KIS_LIVE_TOKEN_REJECTED_STOP",
+    ):
+        await wrapper.clear_token()
+
+
+@pytest.mark.parametrize(
+    ("surface", "source"),
+    [
+        ("kiwoom_mock", "kiwoom"),
+        ("kiwoom_live", "kiwoom"),
+        ("kis_mock", "kis"),
+        ("kis_live", "kis"),
+    ],
+)
+def test_surface_source_is_explicit(runtime_module, surface: str, source: str) -> None:
+    assert runtime_module.source_for_surface(surface) == source
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "HTTPStatusError: 401 Unauthorized",
+        "HTTPStatusError: 429 Too Many Requests",
+        "RateLimitExceededError: rate limit retries exhausted",
+    ],
+)
+def test_kis_live_failure_classifier_is_fail_closed(
+    runtime_module, message: str
+) -> None:
+    assert runtime_module.is_kis_live_immediate_stop(RuntimeError(message))


### PR DESCRIPTION
## Summary
- add an explicit `kis_live` surface binding on top of the Stage-1 Kiwoom join PR
- require a pre-existing shared KIS token and refuse token refresh/cache mutation
- stop KIS live immediately on auth/401/429/rate-limit failures
- require an operator-declared latest eligible KIS session and refuse newer end dates
- keep checkpoint and progress attribution under `kis_live`

## Verification
- focused backfill + Kiwoom safety suite: 141 passed in 7.39s
- Ruff: All checks passed
- remote head verified: d4f1706651399387efbc5a2cd90c589c3855c943

## Safety / rollout
- stacked on PR #1785; this is intentionally a separate PR
- branch-state KIS live run: NOT RUN
- requires independent review before any traffic
- orders 0, account queries 0, public writes 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit runtime surface selection for KIS mock and live backfills.
  * Added validation for eligible dates, approved session boundaries, and compatible data sources.
  * Added surface-specific progress tracking, checkpoints, batch identifiers, and stream labels.
  * Added fail-closed handling for missing credentials and KIS live authentication or rate-limit failures.

* **Bug Fixes**
  * KIS live runs now stop immediately when unrecoverable runtime errors occur.

* **Tests**
  * Added coverage for surface mappings, token safety, and fail-closed error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->