### PR TITLE
chore: guard legacy Alpaca ledger timestamps

### DIFF
--- a/app/models/review.py
+++ b/app/models/review.py
@@ -923,15 +923,23 @@ class AlpacaPaperOrderLedger(Base):
     preview_payload: Mapped[dict | None] = mapped_column(JSONB)
     validation_summary: Mapped[dict | None] = mapped_column(JSONB)
 
-    # Broker order fields
+    # Broker order fields. These two legacy columns are consumer-local write
+    # timestamps, not Alpaca/broker or execution-partner clock observations.
+    # Keep the names and historical values for compatibility; source-qualified
+    # broker evidence belongs in a future additive field, not in these columns.
     broker_order_id: Mapped[str | None] = mapped_column(Text)
+    # LEGACY: local record_submit()/record_submit_failure() time; never a
+    # broker receipt, partner-dispatch time, latency/SLA clock, or receipt t0.
     submitted_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     order_status: Mapped[str | None] = mapped_column(Text)
     filled_qty: Mapped[float | None] = mapped_column(Numeric(20, 8))
     filled_avg_price: Mapped[float | None] = mapped_column(Numeric(20, 8))
 
-    # Cancel tracking
+    # Cancel tracking. The legacy value is local record_cancel() time, not
+    # Alpaca cancel_requested_at or execution-partner canceled_at.
     cancel_status: Mapped[str | None] = mapped_column(Text)
+    # LEGACY: local cancellation-record time; never terminal partner evidence
+    # and never a broker/execution clock for latency or SLA comparisons.
     canceled_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
 
     # Position snapshot — null=not checked; {qty,avg_entry_price,fetched_at}=checked

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -3,6 +3,13 @@
 Pure record-keeping only. Must not import or call broker mutation services,
 KIS, Upbit, watch alerts, order intents, or scheduler code.
 All writes receive already-produced payload data and persist state only.
+
+Timestamp contract: the legacy ``submitted_at`` and ``canceled_at`` ledger
+columns are stamped with local consumer record time. They are not Alpaca,
+broker-receipt, or execution-partner clock observations and must not be used
+as latency/SLA/clock-comparison inputs. Do not estimate or backfill historical
+rows from these values. Future source-qualified evidence must use additive
+fields and preserve these legacy columns unchanged.
 """
 
 from __future__ import annotations

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -10,6 +10,46 @@ It was introduced in ROB-84 as a prerequisite for automating the preopen→paper
 
 Related: ROB-83 introduced the Alpaca Paper smoke workflow. ROB-84 adds persistent records. ROB-90 normalizes lifecycle states and adds roundtrip correlation. ROB-92 adds a read-only structured roundtrip audit report; see `docs/runbooks/alpaca-paper-roundtrip-report.md`.
 
+## Legacy timestamp contract (Alpaca timestamp consumption)
+
+`submitted_at` and `canceled_at` on `review.alpaca_paper_order_ledger` are
+legacy local record timestamps. `submitted_at` is the local time recorded by
+the ledger submit writer; it is not an Alpaca broker receipt, Alpaca's mutable
+partner-dispatch observation, or an execution-partner clock. `canceled_at` is
+the local time recorded by the cancel writer; it is not Alpaca
+`cancel_requested_at` and not the execution partner's terminal `canceled_at`.
+
+Consumers must not use either legacy column for latency, SLA, queue-delay,
+receipt-t0, or cross-clock comparisons. `submitted_at - created_at` is only a
+diagnostic if encountered in historical analysis, not a canonical latency
+measure; asynchronous updates can make it negative. HTTP cancel 204 is also
+not terminal evidence. Future source-qualified fields may be added
+additively; these legacy columns must retain their names and meaning.
+
+Historical rows must not be estimated or backfilled from local timestamps.
+There is no approved backfill for these columns.
+
+### Static guard boundary
+
+`tests/research/test_alpaca_timestamp_consumption_contract.py` checks the
+repository's statically visible Python AST for these columns used in timestamp
+arithmetic, non-identity comparisons, suspicious latency/SLA/clock helper
+calls, or suspicious latency-like assignments. The guard is an explicit
+source-pattern boundary: it does **not** claim to block every indirect,
+dynamic, SQL-string, reflection, or runtime use. The guard is intended to
+fail when a new statically visible consumer treats a local legacy value as a
+clock; ordinary state checks (`is None`/`is not None`) and serialization remain
+allowed.
+
+### Alpaca track / walk-forward audit note
+
+Code verification confirms the sealed `alpaca_track` path uses market-data
+`decision_ts_ms` and PIT bars, while `rob944_walkforward` orders trades by
+bar-derived `entry_ts`/`exit_ts`; neither consumes Alpaca order timestamps.
+Therefore the sealed alpaca_track/walk-forward results are unaffected by this
+legacy ledger timestamp contract. Future paper calibration must use
+source-qualified partner evidence, not these local columns.
+
 ---
 
 ## Lifecycle States (ROB-90 Canonical)
@@ -428,7 +468,7 @@ Table: `review.alpaca_paper_order_ledger`
 - `client_order_id`: per-leg caller-supplied correlation key
 - `lifecycle_correlation_id`: cross-leg roundtrip key (buy + sell share this value)
 - `broker`: always `alpaca`
-- `account_mode`: always `alpaca_paper`
+- `account_mode`: `alpaca_paper`, `alpaca_paper_lab`, or `alpaca_paper_crypto`
 - `lifecycle_state`: canonical ROB-90 state (see table above)
 - `record_kind`: row type — `plan`, `preview`, `validation_attempt`, `execution`, `reconcile`, `anomaly`
 

--- a/tests/research/test_alpaca_timestamp_consumption_contract.py
+++ b/tests/research/test_alpaca_timestamp_consumption_contract.py
@@ -1,0 +1,137 @@
+"""Static guard for the legacy Alpaca ledger timestamp contract.
+
+Coverage boundary: this AST guard detects statically visible arithmetic,
+non-identity comparisons, latency/SLA/clock-like helper calls, and
+latency-like assignments involving ``submitted_at`` or ``canceled_at``.
+It intentionally does not parse SQL, evaluate reflection/dynamic attribute
+access, inspect runtime values, or claim to make every indirect use
+structurally impossible. State checks and serialization are allowed because
+the columns remain legacy fields used for compatibility and lifecycle reads.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = REPOSITORY_ROOT / "app"
+TARGET_FIELDS = frozenset({"submitted_at", "canceled_at"})
+SUSPICIOUS_NAME = re.compile(
+    r"(?:latency|sla|clock|elapsed|duration|queue|receipt|t0|age|lag|skew|"
+    r"delta|timeout|compare|comparison|difference|diff)",
+    re.IGNORECASE,
+)
+
+
+def _attribute_is_target(node: ast.AST) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr in TARGET_FIELDS
+
+
+def _call_name(node: ast.Call) -> str:
+    function = node.func
+    if isinstance(function, ast.Name):
+        return function.id
+    if isinstance(function, ast.Attribute):
+        return function.attr
+    return ""
+
+
+def _target_name(node: ast.Assign | ast.AnnAssign) -> str:
+    target = node.targets[0] if isinstance(node, ast.Assign) else node.target
+    if isinstance(target, ast.Name):
+        return target.id
+    return ""
+
+
+def find_forbidden_consumption(source: str, *, filename: str = "<source>") -> list[str]:
+    tree = ast.parse(source, filename=filename)
+    parents = {
+        id(child): parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if not _attribute_is_target(node):
+            continue
+        current: ast.AST | None = node
+        while current is not None:
+            parent = parents.get(id(current))
+            if isinstance(parent, ast.BinOp):
+                violations.append(
+                    f"{filename}:{node.lineno}: {node.attr} used in timestamp arithmetic"
+                )
+                break
+            if isinstance(parent, ast.Compare) and not all(
+                isinstance(op, (ast.Is, ast.IsNot)) for op in parent.ops
+            ):
+                violations.append(
+                    f"{filename}:{node.lineno}: {node.attr} used in clock comparison"
+                )
+                break
+            if isinstance(parent, ast.Call) and SUSPICIOUS_NAME.search(
+                _call_name(parent)
+            ):
+                violations.append(
+                    f"{filename}:{node.lineno}: {node.attr} passed to clock-like helper"
+                )
+                break
+            if isinstance(
+                parent, (ast.Assign, ast.AnnAssign)
+            ) and SUSPICIOUS_NAME.search(_target_name(parent)):
+                violations.append(
+                    f"{filename}:{node.lineno}: {node.attr} assigned to clock-like name"
+                )
+                break
+            current = parent
+    return violations
+
+
+def find_repository_violations(paths: Iterable[Path]) -> list[str]:
+    violations: list[str] = []
+    for path in sorted(paths):
+        violations.extend(
+            find_forbidden_consumption(
+                path.read_text(encoding="utf-8"), filename=str(path)
+            )
+        )
+    return violations
+
+
+def test_app_has_no_forbidden_legacy_timestamp_consumption() -> None:
+    violations = find_repository_violations(APP_ROOT.rglob("*.py"))
+    assert not violations, (
+        "forbidden legacy Alpaca timestamp consumption found:\n" + "\n".join(violations)
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "latency = row.submitted_at - row.created_at",
+        "if row.canceled_at >= deadline: pass",
+        "measure_queue_latency(row.submitted_at)",
+        "clock_delta = row.canceled_at",
+    ),
+)
+def test_guard_rejects_new_clock_consumers(source: str) -> None:
+    assert find_forbidden_consumption(source, filename="new_consumer.py")
+
+
+def test_guard_allows_legacy_state_and_serialization_reads() -> None:
+    source = """
+if row.submitted_at is not None:
+    payload[\"submitted_at\"] = row.submitted_at.isoformat()
+if row.canceled_at is None:
+    payload[\"canceled_at\"] = None
+"""
+    assert find_forbidden_consumption(source) == []
+
+
+__all__ = ["find_forbidden_consumption", "find_repository_violations"]


### PR DESCRIPTION
## Summary
- mark Alpaca ledger `submitted_at` / `canceled_at` as local legacy record timestamps
- document no broker-clock/latency/SLA use and prohibit estimated historical backfill
- add an AST regression guard for statically visible timestamp arithmetic/comparisons and clock-like consumers
- record verified alpaca_track/walk-forward non-use of order timestamps

## Verification
- `uv run pytest tests/research/test_alpaca_timestamp_consumption_contract.py tests/services/test_alpaca_paper_ledger_service.py tests/services/test_alpaca_paper_order_application.py tests/services/test_alpaca_paper_reconcile_service.py tests/services/test_alpaca_paper_roundtrip_report_service.py tests/routers/test_alpaca_paper_ledger_router.py research/alpaca_track/tests research/nautilus_scalping/tests/test_rob944_walkforward.py -q` — 439 passed, 2 warnings
- targeted Ruff/format/diff checks passed
- no migration run, broker/API/account/order mutation: 0

The guard is intentionally a static source-pattern boundary and does not claim to block every indirect, dynamic, SQL-string, reflection, or runtime use.

Merge intentionally not performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that legacy submission and cancellation timestamps represent local record times, not broker or execution timing.
  - Documented that these timestamps must not support latency, SLA, clock comparisons, or historical backfills.
  - Updated paper-trading account mode documentation with additional supported modes.
  - Clarified that audits use independent market-data timestamps.

- **Tests**
  - Added automated checks to prevent incorrect use of legacy timestamps for timing or latency calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->