### PR TITLE
feat(kis): add KR-B0 mock runner safety shell

### DIFF
--- a/alembic/versions/20260805_kis_mock_runner_control.py
+++ b/alembic/versions/20260805_kis_mock_runner_control.py
@@ -1,0 +1,54 @@
+"""Add the durable KR-B0 KIS mock runner kill-switch control row.
+
+This migration is additive: it creates one new review-schema table and seeds
+its only permitted row as ACTIVE.  Applying it to an operator database is a
+separate KR-B2 deployment action; KR-B0 tests use only pytest-owned databases.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260805_kis_mock_runner"
+down_revision: str | Sequence[str] | None = "20260804_alpaca_clean_account"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "kis_mock_runner_control"
+_SCHEMA = "review"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.SmallInteger(), nullable=False),
+        sa.Column("mode", sa.Text(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("updated_by", sa.Text(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint("id = 1", name="ck_kis_mock_runner_control_singleton"),
+        sa.CheckConstraint(
+            "mode IN ('ACTIVE','ENTRY_HALT','GLOBAL_FREEZE')",
+            name="ck_kis_mock_runner_control_mode",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_kis_mock_runner_control"),
+        schema=_SCHEMA,
+    )
+    op.execute(
+        "INSERT INTO review.kis_mock_runner_control "
+        "(id, mode, reason, updated_by) "
+        "VALUES (1, 'ACTIVE', 'initial_control_row', 'migration:KR-B0')"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table(_TABLE, schema=_SCHEMA)

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
+from functools import wraps
 from typing import TYPE_CHECKING, Any, cast
 
+from app.services.kis_mock_runner.gates import is_truthy
+from app.services.kis_mock_runner.singleton import enforce_kis_mock_mutation_writer
 from app.services.kr_symbol_universe_service import is_nxt_eligible
 
 from . import constants
@@ -26,6 +30,42 @@ if TYPE_CHECKING:
 # fail-closed(RuntimeError). KR live mutation 경로(order/cancel/modify)의 무한 재-POST
 # 및 실 주문 다중 제출 리스크를 차단한다.
 _MAX_TOKEN_REFRESH_RESUBMITS = 1
+
+
+async def _domestic_exchange_route(stock_code: str, *, is_mock: bool) -> str:
+    """Resolve the venue at every domestic mutation boundary.
+
+    KR-B0's KIS mock runner is KRX regular-session only.  This is deliberately
+    a route decision inside the existing place/cancel/modify path rather than
+    an ``is_mock`` bypass around it: mock retries execute this helper again and
+    can never inherit SOR from an NXT-eligible symbol.
+    """
+    if is_mock:
+        return "KRX"
+    nxt = await is_nxt_eligible(stock_code)
+    return "SOR" if nxt else "KRX"
+
+
+def _guard_kis_mock_writer(method):
+    """Use the B0 account-mode singleton for every armed mock KRX mutation.
+
+    ``DomesticOrderClient`` is the common KRX wire boundary for runner, watch
+    auto-execute, smoke, and manual MCP place/cancel/modify.  The wrapper keeps
+    the original route/preflight method intact and is deliberately active only
+    once the default-disabled KIS mock runner master gate has been armed.
+    """
+    signature = inspect.signature(method)
+
+    @wraps(method)
+    async def guarded(self, *args, **kwargs):
+        bound = signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        is_mock = bool(bound.arguments.get("is_mock", False))
+        enabled = is_truthy(os.getenv("KIS_MOCK_RUNNER_ENABLED"))
+        async with enforce_kis_mock_mutation_writer(enabled=is_mock and enabled):
+            return await method(self, *args, **kwargs)
+
+    return guarded
 
 
 def _domestic_order_key(order: dict[str, Any]) -> str | None:
@@ -247,6 +287,7 @@ class DomesticOrderClient:
 
         return all_orders
 
+    @_guard_kis_mock_writer
     async def order_korea_stock(
         self,
         stock_code: str,
@@ -318,8 +359,7 @@ class DomesticOrderClient:
         # 주문 구분: 00(지정가), 01(시장가)
         ord_dvsn = "01" if price == 0 else "00"
 
-        nxt = await is_nxt_eligible(stock_code)
-        excg_id_dvsn_cd = "SOR" if nxt else "KRX"
+        excg_id_dvsn_cd = await _domestic_exchange_route(stock_code, is_mock=is_mock)
 
         body = {
             "CANO": cano,
@@ -507,6 +547,7 @@ class DomesticOrderClient:
             stock_code, "sell", quantity, price, is_mock
         )
 
+    @_guard_kis_mock_writer
     async def cancel_korea_order(
         self,
         order_number: str,
@@ -586,8 +627,7 @@ class DomesticOrderClient:
                 is_mock=is_mock,
             )
 
-        nxt = await is_nxt_eligible(stock_code)
-        excg_id_dvsn_cd = "SOR" if nxt else "KRX"
+        excg_id_dvsn_cd = await _domestic_exchange_route(stock_code, is_mock=is_mock)
 
         body = {
             "CANO": cano,
@@ -890,6 +930,7 @@ class DomesticOrderClient:
         logging.info(f"국내주식 체결조회 완료: 총 {len(all_orders)}건")
         return all_orders
 
+    @_guard_kis_mock_writer
     async def modify_korea_order(
         self,
         order_number: str,
@@ -956,8 +997,7 @@ class DomesticOrderClient:
                 is_mock=is_mock,
             )
 
-        nxt = await is_nxt_eligible(stock_code)
-        excg_id_dvsn_cd = "SOR" if nxt else "KRX"
+        excg_id_dvsn_cd = await _domestic_exchange_route(stock_code, is_mock=is_mock)
 
         body = {
             "CANO": cano,

--- a/app/services/kis_mock_runner/__init__.py
+++ b/app/services/kis_mock_runner/__init__.py
@@ -1,0 +1,18 @@
+"""Strategy-neutral, default-disabled KIS mock execution shell.
+
+KR-B0 deliberately provides the safety boundary only.  It does not select a
+strategy, symbol, price, or any other survivor-specific value; KR-B1 supplies
+an immutable overlay only after the upstream candidate has passed.
+"""
+
+from .control import KillMode
+from .overlay import OverlayBinding, OverlayRequired
+from .runner import KISMockRunner, RunnerResult
+
+__all__ = [
+    "KISMockRunner",
+    "KillMode",
+    "OverlayBinding",
+    "OverlayRequired",
+    "RunnerResult",
+]

--- a/app/services/kis_mock_runner/control.py
+++ b/app/services/kis_mock_runner/control.py
@@ -1,0 +1,157 @@
+"""Durable two-state KIS mock trading kill switch.
+
+The existing ``KISCircuitBreaker`` is a network/retry breaker.  It is not
+imported here: this control plane owns the separate trading-mutation policy.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol
+
+from sqlalchemy import text
+
+logger = logging.getLogger(__name__)
+
+
+class KillMode(StrEnum):
+    ACTIVE = "ACTIVE"
+    ENTRY_HALT = "ENTRY_HALT"
+    GLOBAL_FREEZE = "GLOBAL_FREEZE"
+
+
+@dataclass(frozen=True)
+class KillSwitchState:
+    mode: KillMode
+    reason: str
+    updated_by: str
+    updated_at: datetime | None = None
+    read_failed: bool = False
+
+
+class KillSwitchReadError(RuntimeError):
+    """The durable state could not be read or was structurally invalid."""
+
+
+class KillSwitchRearmUnauthorized(RuntimeError):
+    """The only re-arm route is an operator CLI with both gates supplied."""
+
+
+class KillSwitchStore(Protocol):
+    async def read(self) -> KillSwitchState: ...
+
+    async def set_mode(
+        self, *, mode: KillMode, reason: str, updated_by: str
+    ) -> KillSwitchState: ...
+
+
+class PostgresKillSwitchStore:
+    """Control-table service; all writes remain inside this service layer."""
+
+    _TABLE = "review.kis_mock_runner_control"
+
+    async def read(self) -> KillSwitchState:
+        from app.core.db import AsyncSessionLocal
+
+        try:
+            async with AsyncSessionLocal() as session:
+                result = await session.execute(
+                    text(
+                        "SELECT mode, reason, updated_by, updated_at "
+                        f"FROM {self._TABLE} WHERE id = 1"
+                    )
+                )
+                row = result.mappings().one_or_none()
+        except Exception as exc:  # noqa: BLE001 - caller must fail closed
+            raise KillSwitchReadError("kill control table read failed") from exc
+        if row is None:
+            raise KillSwitchReadError("kill control row is missing")
+        try:
+            return KillSwitchState(
+                mode=KillMode(str(row["mode"])),
+                reason=str(row["reason"]),
+                updated_by=str(row["updated_by"]),
+                updated_at=row["updated_at"],
+            )
+        except (TypeError, ValueError) as exc:
+            raise KillSwitchReadError(
+                "kill control row contains an invalid mode"
+            ) from exc
+
+    async def set_mode(
+        self, *, mode: KillMode, reason: str, updated_by: str
+    ) -> KillSwitchState:
+        if not reason.strip() or not updated_by.strip():
+            raise ValueError("kill switch reason and updated_by must be non-blank")
+        from app.core.db import AsyncSessionLocal
+
+        try:
+            async with AsyncSessionLocal() as session:
+                result = await session.execute(
+                    text(
+                        f"UPDATE {self._TABLE} "
+                        "SET mode = :mode, reason = :reason, "
+                        "updated_by = :updated_by, updated_at = now() "
+                        "WHERE id = 1 RETURNING mode, reason, updated_by, updated_at"
+                    ),
+                    {
+                        "mode": mode.value,
+                        "reason": reason,
+                        "updated_by": updated_by,
+                    },
+                )
+                row = result.mappings().one_or_none()
+                if row is None:
+                    await session.rollback()
+                    raise KillSwitchReadError("kill control row is missing")
+                await session.commit()
+        except KillSwitchReadError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - fail closed for caller
+            raise KillSwitchReadError("kill control table write failed") from exc
+        return KillSwitchState(
+            mode=KillMode(str(row["mode"])),
+            reason=str(row["reason"]),
+            updated_by=str(row["updated_by"]),
+            updated_at=row["updated_at"],
+        )
+
+
+async def read_effective_kill_switch(store: KillSwitchStore) -> KillSwitchState:
+    """Turn every durable-state read failure into an explicit GLOBAL_FREEZE."""
+    try:
+        return await store.read()
+    except Exception:  # noqa: BLE001 - no failure may open a trading path
+        logger.exception("KIS mock kill switch read failed; GLOBAL_FREEZE applied")
+        return KillSwitchState(
+            mode=KillMode.GLOBAL_FREEZE,
+            reason="kill_control_read_failed",
+            updated_by="fail_closed",
+            read_failed=True,
+        )
+
+
+async def rearm_active(
+    store: KillSwitchStore,
+    *,
+    operator_gate: bool,
+    confirm: bool,
+    updated_by: str,
+) -> KillSwitchState:
+    """The sole re-arm primitive, called only by the dedicated operator CLI."""
+    if not operator_gate or not confirm or not updated_by.strip():
+        raise KillSwitchRearmUnauthorized(
+            "re-arm requires operator gate, explicit confirmation, and updated_by"
+        )
+    return await store.set_mode(
+        mode=KillMode.ACTIVE,
+        reason="operator_rearm_confirmed",
+        updated_by=updated_by,
+    )
+
+
+AsyncStateSetter = Callable[[KillMode, str, str], Awaitable[KillSwitchState]]

--- a/app/services/kis_mock_runner/correlation.py
+++ b/app/services/kis_mock_runner/correlation.py
@@ -1,0 +1,26 @@
+"""Deterministic correlation spine for the KIS mock runner."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def kis_mock_runner_correlation_id(
+    *,
+    tag: str,
+    candidate_id: str,
+    contract_hash: str,
+    strategy_id: str,
+    decision_key: str,
+) -> str:
+    """Build the one ID carried unchanged to ledger and forecast attribution.
+
+    ``decision_key`` is supplied by a future overlay (for example, a frozen
+    session/signal identity).  B0 never fabricates one.
+    """
+    values = (tag, candidate_id, contract_hash, strategy_id, decision_key)
+    if any(not value.strip() for value in values):
+        raise ValueError("correlation inputs must all be non-blank")
+    canonical = "|".join(values)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return f"kis-mock-runner:{tag}:{digest}"

--- a/app/services/kis_mock_runner/envelope.py
+++ b/app/services/kis_mock_runner/envelope.py
@@ -205,8 +205,12 @@ def evaluate_envelope(
         >= envelope.max_planned_exits_per_xkrx_session
     ):
         reasons.append(EnvelopeReason.SESSION_PLANNED_EXIT_CAP)
-    if snapshot.current_nlv_krw <= snapshot.session_start_nlv_krw * (
-        Decimal("1") - envelope.daily_loss_halt_fraction
+    # A daily-loss breach transitions the durable control plane to ENTRY_HALT.
+    # It is deliberately an entry-only no-submit reason: B-03 requires the
+    # resulting halt to leave liquidation/exit mutations available.
+    if intent.role == "entry" and snapshot.current_nlv_krw <= (
+        snapshot.session_start_nlv_krw
+        * (Decimal("1") - envelope.daily_loss_halt_fraction)
     ):
         reasons.append(EnvelopeReason.DAILY_LOSS_ENTRY_HALT)
     return EnvelopeDecision(allowed=not reasons, reason_codes=tuple(reasons))

--- a/app/services/kis_mock_runner/envelope.py
+++ b/app/services/kis_mock_runner/envelope.py
@@ -1,0 +1,212 @@
+"""Locked common execution envelope for the strategy-neutral KIS mock shell.
+
+All values in this module are the KR-B0 operator-approved invariants.  They are
+not configuration: environment variables and CLI flags attempting to replace
+them are rejected before any state, network, or broker work.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+from typing import Final, Literal
+
+# This literal is intentionally machine-readable.  Acceptance tests assert it
+# remains ``NO`` and that no CLI/env route can make the envelope configurable.
+CONFIGURABLE_OFF_SWITCH: Final[str] = "NO"
+
+
+class EnvelopeReason(StrEnum):
+    OVERLAY_REQUIRED = "OVERLAY_REQUIRED"
+    LIMIT_ONLY = "limit_only"
+    LIMIT_PRICE_REQUIRED = "limit_price_required"
+    INVALID_QUANTITY = "invalid_quantity"
+    CASH_NOT_FRESH = "cash_not_fresh"
+    MARGIN_OR_SHORT_FORBIDDEN = "margin_or_short_forbidden"
+    STALE_QUOTE = "stale_quote"
+    INSUFFICIENT_CASH = "insufficient_cash"
+    TRADING_HALTED = "trading_halted"
+    PRICE_LIMIT = "price_limit"
+    CORPORATE_ACTION_UNCERTAIN = "corporate_action_uncertain"
+    PER_ORDER_NOTIONAL_CAP = "per_order_notional_cap"
+    GROSS_EXPOSURE_CAP = "gross_exposure_cap"
+    POSITION_CAP = "position_cap"
+    SESSION_NEW_ENTRY_CAP = "session_new_entry_cap"
+    SESSION_PLANNED_EXIT_CAP = "session_planned_exit_cap"
+    DAILY_LOSS_ENTRY_HALT = "daily_loss_entry_halt"
+
+
+class EnvelopeOverrideAttempt(RuntimeError):
+    """Raised if an environment tries to turn a locked invariant into config."""
+
+
+class EnvelopeNotLocked(ValueError):
+    """Raised if a caller supplies values other than the approved envelope."""
+
+
+@dataclass(frozen=True)
+class HardEnvelope:
+    max_single_notional_krw: Decimal = Decimal("5000000")
+    session_start_nlv_fraction: Decimal = Decimal("0.05")
+    max_gross_exposure_fraction: Decimal = Decimal("0.50")
+    max_positions_including_pending_reserved: int = 10
+    max_new_entries_per_xkrx_session: int = 10
+    max_planned_exits_per_xkrx_session: int = 10
+    daily_loss_halt_fraction: Decimal = Decimal("0.025")
+
+    def per_order_notional_cap(self, session_start_nlv_krw: Decimal) -> Decimal:
+        return min(
+            self.max_single_notional_krw,
+            session_start_nlv_krw * self.session_start_nlv_fraction,
+        )
+
+
+LOCKED_ENVELOPE: Final[HardEnvelope] = HardEnvelope()
+
+# These names are rejected rather than read.  Keeping them explicit prevents a
+# future "helpful" configuration layer from silently widening a hard limit.
+_FORBIDDEN_OVERRIDE_ENV_NAMES: Final[tuple[str, ...]] = (
+    "KIS_MOCK_RUNNER_MAX_SINGLE_NOTIONAL_KRW",
+    "KIS_MOCK_RUNNER_SESSION_START_NLV_FRACTION",
+    "KIS_MOCK_RUNNER_MAX_GROSS_EXPOSURE_FRACTION",
+    "KIS_MOCK_RUNNER_MAX_POSITIONS",
+    "KIS_MOCK_RUNNER_MAX_NEW_ENTRIES_PER_SESSION",
+    "KIS_MOCK_RUNNER_MAX_PLANNED_EXITS_PER_SESSION",
+    "KIS_MOCK_RUNNER_DAILY_LOSS_HALT_FRACTION",
+)
+
+
+def assert_no_envelope_overrides(environment: Mapping[str, str]) -> None:
+    """Fail closed on any attempted CLI/environment envelope override."""
+    attempted = tuple(
+        name
+        for name in _FORBIDDEN_OVERRIDE_ENV_NAMES
+        if str(environment.get(name, "")).strip()
+    )
+    if attempted:
+        raise EnvelopeOverrideAttempt(
+            "locked KIS mock runner envelope rejects environment overrides: "
+            + ", ".join(attempted)
+        )
+
+
+def assert_envelope_locked(envelope: HardEnvelope) -> None:
+    """Protect non-CLI callers too; no alternative safety profile exists."""
+    if envelope != LOCKED_ENVELOPE:
+        raise EnvelopeNotLocked(
+            "KIS mock runner hard envelope differs from approved locked values"
+        )
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    """A fully specified future overlay intent; B0 never constructs this itself."""
+
+    side: Literal["buy", "sell"]
+    role: Literal["entry", "exit"]
+    order_type: str
+    quantity: Decimal
+    limit_price_krw: Decimal | None
+
+    @property
+    def notional_krw(self) -> Decimal | None:
+        if self.limit_price_krw is None:
+            return None
+        return self.quantity * self.limit_price_krw
+
+
+@dataclass(frozen=True)
+class AccountEnvelopeSnapshot:
+    """Fresh account evidence needed before an overlay may submit an intent."""
+
+    session_start_nlv_krw: Decimal
+    current_nlv_krw: Decimal
+    available_cash_krw: Decimal
+    projected_gross_exposure_krw: Decimal
+    positions_including_pending_reserved: int
+    new_entries_this_xkrx_session: int
+    planned_exits_this_xkrx_session: int
+    cash_is_fresh: bool
+    is_cash_only: bool
+    margin_enabled: bool
+    short_enabled: bool
+    stale_quote: bool = False
+    trading_halted: bool = False
+    price_limit_blocked: bool = False
+    corporate_action_uncertain: bool = False
+
+
+@dataclass(frozen=True)
+class EnvelopeDecision:
+    allowed: bool
+    reason_codes: tuple[EnvelopeReason, ...] = field(default_factory=tuple)
+
+    @property
+    def requires_entry_halt(self) -> bool:
+        return EnvelopeReason.DAILY_LOSS_ENTRY_HALT in self.reason_codes
+
+
+def evaluate_envelope(
+    *,
+    intent: OrderIntent,
+    snapshot: AccountEnvelopeSnapshot,
+    envelope: HardEnvelope = LOCKED_ENVELOPE,
+) -> EnvelopeDecision:
+    """Evaluate every no-submit reason; callers may never widen the envelope."""
+    assert_envelope_locked(envelope)
+    reasons: list[EnvelopeReason] = []
+    if intent.order_type.lower() != "limit":
+        reasons.append(EnvelopeReason.LIMIT_ONLY)
+    if intent.limit_price_krw is None or intent.limit_price_krw <= 0:
+        reasons.append(EnvelopeReason.LIMIT_PRICE_REQUIRED)
+    if intent.quantity <= 0:
+        reasons.append(EnvelopeReason.INVALID_QUANTITY)
+    if not snapshot.cash_is_fresh:
+        reasons.append(EnvelopeReason.CASH_NOT_FRESH)
+    if not snapshot.is_cash_only or snapshot.margin_enabled or snapshot.short_enabled:
+        reasons.append(EnvelopeReason.MARGIN_OR_SHORT_FORBIDDEN)
+    if snapshot.stale_quote:
+        reasons.append(EnvelopeReason.STALE_QUOTE)
+    if snapshot.trading_halted:
+        reasons.append(EnvelopeReason.TRADING_HALTED)
+    if snapshot.price_limit_blocked:
+        reasons.append(EnvelopeReason.PRICE_LIMIT)
+    if snapshot.corporate_action_uncertain:
+        reasons.append(EnvelopeReason.CORPORATE_ACTION_UNCERTAIN)
+
+    notional = intent.notional_krw
+    if notional is not None:
+        if notional > envelope.per_order_notional_cap(snapshot.session_start_nlv_krw):
+            reasons.append(EnvelopeReason.PER_ORDER_NOTIONAL_CAP)
+        if intent.role == "entry" and notional > snapshot.available_cash_krw:
+            reasons.append(EnvelopeReason.INSUFFICIENT_CASH)
+
+    if (
+        snapshot.projected_gross_exposure_krw
+        > snapshot.session_start_nlv_krw * envelope.max_gross_exposure_fraction
+    ):
+        reasons.append(EnvelopeReason.GROSS_EXPOSURE_CAP)
+    if (
+        snapshot.positions_including_pending_reserved
+        > envelope.max_positions_including_pending_reserved
+    ):
+        reasons.append(EnvelopeReason.POSITION_CAP)
+    if (
+        intent.role == "entry"
+        and snapshot.new_entries_this_xkrx_session
+        >= envelope.max_new_entries_per_xkrx_session
+    ):
+        reasons.append(EnvelopeReason.SESSION_NEW_ENTRY_CAP)
+    if (
+        intent.role == "exit"
+        and snapshot.planned_exits_this_xkrx_session
+        >= envelope.max_planned_exits_per_xkrx_session
+    ):
+        reasons.append(EnvelopeReason.SESSION_PLANNED_EXIT_CAP)
+    if snapshot.current_nlv_krw <= snapshot.session_start_nlv_krw * (
+        Decimal("1") - envelope.daily_loss_halt_fraction
+    ):
+        reasons.append(EnvelopeReason.DAILY_LOSS_ENTRY_HALT)
+    return EnvelopeDecision(allowed=not reasons, reason_codes=tuple(reasons))

--- a/app/services/kis_mock_runner/gates.py
+++ b/app/services/kis_mock_runner/gates.py
@@ -1,0 +1,41 @@
+"""Runtime gates for the KIS mock runner.
+
+The runner intentionally reads its small, deployment-owned environment surface
+directly instead of adding a broadly available settings field.  That keeps the
+new execution shell default-disabled in every existing process.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+RUNNER_ENABLED_ENV = "KIS_MOCK_RUNNER_ENABLED"
+REARM_ENABLED_ENV = "KIS_MOCK_RUNNER_REARM_ENABLED"
+
+
+class KISMockRunnerDisabled(RuntimeError):
+    """Raised before any DB, lock, broker, or webhook work when unarmed."""
+
+
+class KISMockRunnerRearmUnauthorized(RuntimeError):
+    """Raised unless the operator CLI's two re-arm gates are both present."""
+
+
+def is_truthy(value: str | None) -> bool:
+    return bool(value and value.strip().lower() in {"1", "true", "yes", "on"})
+
+
+def assert_runner_enabled(environment: Mapping[str, str]) -> None:
+    """Enforce the default-disabled master gate at the top of every run."""
+    if not is_truthy(environment.get(RUNNER_ENABLED_ENV)):
+        raise KISMockRunnerDisabled(
+            f"{RUNNER_ENABLED_ENV} is not explicitly enabled; refusing runner start"
+        )
+
+
+def assert_rearm_authorized(environment: Mapping[str, str], *, confirm: bool) -> None:
+    """Require an operator-only CLI env gate and a per-invocation confirmation."""
+    if not is_truthy(environment.get(REARM_ENABLED_ENV)) or not confirm:
+        raise KISMockRunnerRearmUnauthorized(
+            "re-arm requires KIS_MOCK_RUNNER_REARM_ENABLED=true and --confirm"
+        )

--- a/app/services/kis_mock_runner/notifications.py
+++ b/app/services/kis_mock_runner/notifications.py
@@ -1,0 +1,101 @@
+"""Best-effort Discord observation boundary for the KIS mock runner.
+
+Webhook delivery is deliberately orthogonal to trading logic: a delivery
+failure records an alert retry but can never transform a rejected/no-submit
+decision into success or cause a broker retry.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+KR_WEBHOOK_ENV = "DISCORD_WEBHOOK_KR"
+ALERTS_WEBHOOK_ENV = "DISCORD_WEBHOOK_ALERTS"
+
+
+@dataclass(frozen=True)
+class DeliveryReport:
+    channel: str
+    delivered: bool
+    skipped: bool = False
+    retry_recorded: bool = False
+
+
+class RetryRecorder(Protocol):
+    async def record(self, *, channel: str, event: str, error_type: str) -> None: ...
+
+
+class LoggingRetryRecorder:
+    """Scheduleless retry evidence: structured log only, never a hidden job."""
+
+    async def record(self, *, channel: str, event: str, error_type: str) -> None:
+        logger.warning(
+            "KIS mock notification retry recorded channel=%s event=%s error_type=%s",
+            channel,
+            event,
+            error_type,
+        )
+
+
+WebhookPost = Callable[[str, dict[str, Any]], Awaitable[None]]
+
+
+async def _post_webhook(url: str, payload: dict[str, Any]) -> None:
+    """Post a compact event without logging or otherwise exposing the URL."""
+    import httpx
+
+    async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:
+        response = await client.post(url, json=payload)
+        response.raise_for_status()
+
+
+class DiscordNotifier:
+    def __init__(
+        self,
+        environment: Mapping[str, str],
+        *,
+        post: WebhookPost = _post_webhook,
+        retry_recorder: RetryRecorder | None = None,
+    ) -> None:
+        self._environment = environment
+        self._post = post
+        self._retry_recorder = retry_recorder or LoggingRetryRecorder()
+
+    async def lifecycle(self, *, event: str, payload: dict[str, Any]) -> DeliveryReport:
+        return await self._deliver(
+            channel="kr_lifecycle", env_key=KR_WEBHOOK_ENV, event=event, payload=payload
+        )
+
+    async def alert(self, *, event: str, payload: dict[str, Any]) -> DeliveryReport:
+        return await self._deliver(
+            channel="alerts", env_key=ALERTS_WEBHOOK_ENV, event=event, payload=payload
+        )
+
+    async def _deliver(
+        self,
+        *,
+        channel: str,
+        env_key: str,
+        event: str,
+        payload: dict[str, Any],
+    ) -> DeliveryReport:
+        url = str(self._environment.get(env_key, "")).strip()
+        if not url:
+            return DeliveryReport(channel=channel, delivered=False, skipped=True)
+        try:
+            await self._post(url, {"event": event, "payload": payload})
+        except Exception as exc:  # noqa: BLE001 - notification is never trading truth
+            await self._retry_recorder.record(
+                channel=channel, event=event, error_type=type(exc).__name__
+            )
+            return DeliveryReport(
+                channel=channel,
+                delivered=False,
+                retry_recorded=True,
+            )
+        return DeliveryReport(channel=channel, delivered=True)

--- a/app/services/kis_mock_runner/overlay.py
+++ b/app/services/kis_mock_runner/overlay.py
@@ -1,0 +1,43 @@
+"""Survivor overlay boundary for KR-B0.
+
+There is intentionally no default strategy, ticker, price rule, or holding
+window in this package.  An absent overlay is a normal B0 state and must stop
+before an order intent can be constructed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class OverlayRequired(RuntimeError):
+    """Raised when execution is requested before KR-B1 binds a survivor."""
+
+    code = "OVERLAY_REQUIRED"
+
+
+@dataclass(frozen=True)
+class OverlayBinding:
+    """Immutable identifiers supplied by the later survivor-integration job."""
+
+    candidate_id: str
+    contract_hash: str
+    strategy_id: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("candidate_id", self.candidate_id),
+            ("contract_hash", self.contract_hash),
+            ("strategy_id", self.strategy_id),
+        ):
+            if not value.strip():
+                raise ValueError(f"{name} must be non-blank")
+
+
+def require_overlay(overlay: OverlayBinding | None) -> OverlayBinding:
+    """Return an explicit overlay or fail closed without inventing one."""
+    if overlay is None:
+        raise OverlayRequired(
+            "OVERLAY_REQUIRED: no survivor overlay is bound; no order intent exists"
+        )
+    return overlay

--- a/app/services/kis_mock_runner/runner.py
+++ b/app/services/kis_mock_runner/runner.py
@@ -1,0 +1,322 @@
+"""Foreground, strategy-neutral KIS mock runner safety shell (KR-B0)."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Protocol
+
+from .control import (
+    KillMode,
+    KillSwitchState,
+    KillSwitchStore,
+    PostgresKillSwitchStore,
+    read_effective_kill_switch,
+)
+from .correlation import kis_mock_runner_correlation_id
+from .envelope import (
+    AccountEnvelopeSnapshot,
+    EnvelopeDecision,
+    OrderIntent,
+    assert_no_envelope_overrides,
+    evaluate_envelope,
+)
+from .gates import KISMockRunnerDisabled, assert_runner_enabled
+from .notifications import DeliveryReport, DiscordNotifier
+from .overlay import OverlayBinding, OverlayRequired, require_overlay
+from .session import is_krx_regular_session
+from .singleton import KISMockWriterLease
+
+# A supervised foreground loop only; this is neither a task registration nor a
+# cron cadence.  The constant is intentionally not a user-configurable option.
+FOREGROUND_TICK_SECONDS = 60
+
+
+class RunnerStatus(StrEnum):
+    DEFAULT_DISABLED = "default_disabled"
+    OVERLAY_REQUIRED = "OVERLAY_REQUIRED"
+    ENTRY_HALT = "entry_halt"
+    GLOBAL_FREEZE = "global_freeze"
+    KRX_RTH_REQUIRED = "krx_rth_required"
+    ENVELOPE_BLOCKED = "envelope_blocked"
+    READY_NO_INTENT = "ready_no_intent"
+
+
+class MutationKind(StrEnum):
+    ENTRY = "entry"
+    EXIT = "exit"
+    CANCEL_PENDING_ENTRY = "cancel_pending_entry"
+    CANCEL_EXIT = "cancel_exit"
+    MODIFY_ENTRY = "modify_entry"
+    MODIFY_EXIT = "modify_exit"
+    RETRY_ENTRY = "retry_entry"
+    RETRY_EXIT = "retry_exit"
+
+
+@dataclass(frozen=True)
+class MutationPermission:
+    allowed: bool
+    reason: str | None = None
+
+
+def mutation_permission(mode: KillMode, kind: MutationKind) -> MutationPermission:
+    """State table for all automatic KIS mock mutation kinds.
+
+    ENTRY_HALT lets attributed pending entries be cancelled and lets all exit
+    activity proceed.  GLOBAL_FREEZE blocks every automatic mutation.
+    """
+    if mode is KillMode.ACTIVE:
+        return MutationPermission(allowed=True)
+    if mode is KillMode.GLOBAL_FREEZE:
+        return MutationPermission(allowed=False, reason="GLOBAL_FREEZE")
+    allowed_while_halted = {
+        MutationKind.EXIT,
+        MutationKind.CANCEL_PENDING_ENTRY,
+        MutationKind.CANCEL_EXIT,
+        MutationKind.MODIFY_EXIT,
+        MutationKind.RETRY_EXIT,
+    }
+    if kind in allowed_while_halted:
+        return MutationPermission(allowed=True)
+    return MutationPermission(allowed=False, reason="ENTRY_HALT")
+
+
+@dataclass(frozen=True)
+class AttributedPendingEntry:
+    """Only a real attribution chain may be cancelled by ENTRY_HALT."""
+
+    order_id: str
+    correlation_id: str
+    strategy_id: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("order_id", self.order_id),
+            ("correlation_id", self.correlation_id),
+            ("strategy_id", self.strategy_id),
+        ):
+            if not value.strip():
+                raise ValueError(f"{name} must be non-blank")
+
+
+class PendingEntryPort(Protocol):
+    async def list_attributed_pending_entries(
+        self,
+    ) -> tuple[AttributedPendingEntry, ...]: ...
+
+    async def cancel_pending_entry(self, entry: AttributedPendingEntry) -> None: ...
+
+
+class EmptyPendingEntryPort:
+    """B0's normal no-overlay state: no order list and therefore no mutation."""
+
+    async def list_attributed_pending_entries(
+        self,
+    ) -> tuple[AttributedPendingEntry, ...]:
+        return ()
+
+    async def cancel_pending_entry(self, entry: AttributedPendingEntry) -> None:
+        del entry
+        raise AssertionError("B0 has no pending-entry cancellation adapter")
+
+
+@dataclass(frozen=True)
+class RunnerResult:
+    status: RunnerStatus
+    kill_switch: KillSwitchState | None = None
+    canceled_pending_entries: int = 0
+    correlation_id: str | None = None
+    envelope: EnvelopeDecision | None = None
+    notification_reports: tuple[DeliveryReport, ...] = field(default_factory=tuple)
+    broker_calls: int = 0
+
+
+class KISMockRunner:
+    """The B0 shell: it can guard future intents but cannot invent one."""
+
+    def __init__(
+        self,
+        *,
+        environment: Mapping[str, str],
+        tag: str,
+        overlay: OverlayBinding | None = None,
+        kill_switch_store: KillSwitchStore | None = None,
+        writer_lease: KISMockWriterLease | None = None,
+        pending_entry_port: PendingEntryPort | None = None,
+        notifier: DiscordNotifier | None = None,
+    ) -> None:
+        if not tag.strip():
+            raise ValueError("runner tag must be non-blank")
+        self._environment = environment
+        self._tag = tag
+        self._overlay = overlay
+        self._kill_switch_store = kill_switch_store or PostgresKillSwitchStore()
+        self._writer_lease = writer_lease or KISMockWriterLease()
+        self._pending_entry_port = pending_entry_port or EmptyPendingEntryPort()
+        self._notifier = notifier or DiscordNotifier(environment)
+
+    async def run_once(self) -> RunnerResult:
+        """Run one guarded tick; it never creates an order without an overlay."""
+        try:
+            # This must precede lock, DB, broker, and webhook work.
+            assert_runner_enabled(self._environment)
+        except KISMockRunnerDisabled:
+            return RunnerResult(status=RunnerStatus.DEFAULT_DISABLED)
+        assert_no_envelope_overrides(self._environment)
+
+        async with self._writer_lease:
+            state = await read_effective_kill_switch(self._kill_switch_store)
+            if state.mode is KillMode.GLOBAL_FREEZE:
+                reports = await self._notify_alert(
+                    event="kis_mock_runner_global_freeze",
+                    payload={"reason": state.reason, "read_failed": state.read_failed},
+                )
+                return RunnerResult(
+                    status=RunnerStatus.GLOBAL_FREEZE,
+                    kill_switch=state,
+                    notification_reports=reports,
+                )
+            if state.mode is KillMode.ENTRY_HALT:
+                cancelled = await self._cancel_attributed_pending_entries(state)
+                reports = await self._notify_alert(
+                    event="kis_mock_runner_entry_halt",
+                    payload={
+                        "reason": state.reason,
+                        "cancelled_pending_entries": cancelled,
+                    },
+                )
+                return RunnerResult(
+                    status=RunnerStatus.ENTRY_HALT,
+                    kill_switch=state,
+                    canceled_pending_entries=cancelled,
+                    notification_reports=reports,
+                )
+            try:
+                require_overlay(self._overlay)
+            except OverlayRequired:
+                reports = await self._notify_lifecycle(
+                    event="kis_mock_runner_overlay_required",
+                    payload={"status": RunnerStatus.OVERLAY_REQUIRED.value},
+                )
+                return RunnerResult(
+                    status=RunnerStatus.OVERLAY_REQUIRED,
+                    kill_switch=state,
+                    notification_reports=reports,
+                )
+
+            # An overlay can be bound only by KR-B1.  B0 deliberately does not
+            # evaluate it or construct an intent; that would be a hidden default.
+            reports = await self._notify_lifecycle(
+                event="kis_mock_runner_ready_no_intent",
+                payload={"status": RunnerStatus.READY_NO_INTENT.value},
+            )
+            return RunnerResult(
+                status=RunnerStatus.READY_NO_INTENT,
+                kill_switch=state,
+                notification_reports=reports,
+            )
+
+    async def run_forever(self) -> RunnerResult:
+        """Foreground supervised loop; terminal safety states stop cleanly."""
+        while True:
+            result = await self.run_once()
+            if result.status in {
+                RunnerStatus.DEFAULT_DISABLED,
+                RunnerStatus.OVERLAY_REQUIRED,
+                RunnerStatus.ENTRY_HALT,
+                RunnerStatus.GLOBAL_FREEZE,
+            }:
+                return result
+            await asyncio.sleep(FOREGROUND_TICK_SECONDS)
+
+    async def evaluate_overlay_intent(
+        self,
+        *,
+        intent: OrderIntent,
+        snapshot: AccountEnvelopeSnapshot,
+        now: datetime | None = None,
+        decision_key: str,
+    ) -> RunnerResult:
+        """Validate a future overlay intent without dispatching a broker mutation.
+
+        A B1 executor must call this immediately before its own KRX adapter.  It
+        handles the RTH, kill state, locked envelope, and daily-loss durable
+        ENTRY_HALT transition.  The return value intentionally carries
+        ``broker_calls=0``; broker dispatch belongs to a later bound adapter.
+        """
+        assert_runner_enabled(self._environment)
+        assert_no_envelope_overrides(self._environment)
+        overlay = require_overlay(self._overlay)
+        current = now or datetime.now(UTC)
+        async with self._writer_lease:
+            state = await read_effective_kill_switch(self._kill_switch_store)
+            kind = MutationKind.ENTRY if intent.role == "entry" else MutationKind.EXIT
+            permission = mutation_permission(state.mode, kind)
+            if not permission.allowed:
+                status = (
+                    RunnerStatus.GLOBAL_FREEZE
+                    if state.mode is KillMode.GLOBAL_FREEZE
+                    else RunnerStatus.ENTRY_HALT
+                )
+                return RunnerResult(status=status, kill_switch=state)
+            if intent.role == "entry" and not is_krx_regular_session(current):
+                return RunnerResult(
+                    status=RunnerStatus.KRX_RTH_REQUIRED, kill_switch=state
+                )
+            envelope = evaluate_envelope(intent=intent, snapshot=snapshot)
+            if envelope.requires_entry_halt:
+                state = await self._kill_switch_store.set_mode(
+                    mode=KillMode.ENTRY_HALT,
+                    reason="daily_loss_halt_threshold_reached",
+                    updated_by="kis_mock_runner",
+                )
+            if not envelope.allowed:
+                return RunnerResult(
+                    status=RunnerStatus.ENVELOPE_BLOCKED,
+                    kill_switch=state,
+                    envelope=envelope,
+                )
+            correlation_id = kis_mock_runner_correlation_id(
+                tag=self._tag,
+                candidate_id=overlay.candidate_id,
+                contract_hash=overlay.contract_hash,
+                strategy_id=overlay.strategy_id,
+                decision_key=decision_key,
+            )
+            return RunnerResult(
+                status=RunnerStatus.READY_NO_INTENT,
+                kill_switch=state,
+                correlation_id=correlation_id,
+                envelope=envelope,
+            )
+
+    async def _cancel_attributed_pending_entries(self, state: KillSwitchState) -> int:
+        permission = mutation_permission(state.mode, MutationKind.CANCEL_PENDING_ENTRY)
+        if not permission.allowed:
+            return 0
+        entries = await self._pending_entry_port.list_attributed_pending_entries()
+        for entry in entries:
+            # Dataclass validation makes attribution mandatory before the adapter
+            # is ever asked to mutate.  There is no placeholder strategy path.
+            await self._pending_entry_port.cancel_pending_entry(entry)
+        return len(entries)
+
+    async def _notify_lifecycle(
+        self, *, event: str, payload: dict[str, object]
+    ) -> tuple[DeliveryReport, ...]:
+        lifecycle = await self._notifier.lifecycle(event=event, payload=payload)
+        if lifecycle.delivered or lifecycle.skipped:
+            return (lifecycle,)
+        alert = await self._notifier.alert(
+            event="kis_mock_runner_lifecycle_delivery_failure",
+            payload={"event": event, "retry_recorded": lifecycle.retry_recorded},
+        )
+        return lifecycle, alert
+
+    async def _notify_alert(
+        self, *, event: str, payload: dict[str, object]
+    ) -> tuple[DeliveryReport, ...]:
+        return (await self._notifier.alert(event=event, payload=payload),)

--- a/app/services/kis_mock_runner/session.py
+++ b/app/services/kis_mock_runner/session.py
@@ -1,0 +1,23 @@
+"""Fail-closed KRX regular-session gate for new runner entries."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.services.market_events.session_calendar import regular_session_bounds
+
+
+def is_krx_regular_session(moment: datetime) -> bool:
+    """True only inside a confirmed XKRX regular session.
+
+    The shared XKRX calendar handles weekends, holidays, and calendar failures
+    fail-closed.  NXT/SOR windows are deliberately not considered here.
+    """
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    utc_moment = moment.astimezone(UTC)
+    bounds = regular_session_bounds("kr", utc_moment.date())
+    if bounds is None:
+        return False
+    open_at, close_at = bounds
+    return open_at <= utc_moment < close_at

--- a/app/services/kis_mock_runner/singleton.py
+++ b/app/services/kis_mock_runner/singleton.py
@@ -1,0 +1,264 @@
+"""Cross-process writer singleton for the KIS mock account mode.
+
+The lock is intentionally not a ``ps`` scan: a process list cannot reliably
+identify containers, stale PIDs, or another host.  A non-blocking PostgreSQL
+advisory lock keyed by the account mode is the authority.  A PID-bearing file
+lock gives local operator visibility and catches same-host contention before a
+database connection is opened.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from contextvars import ContextVar, Token
+from pathlib import Path
+from typing import Protocol
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+ACCOUNT_MODE = "kis_mock"
+MUTATION_WRITER_SURFACES = frozenset(
+    {
+        "runner",
+        "watch_auto_execute",
+        "smoke_cli",
+        "manual_mcp_mutation",
+    }
+)
+_ACTIVE_WRITER_LEASE: ContextVar[bool] = ContextVar(
+    "kis_mock_runner_active_writer_lease", default=False
+)
+
+
+class WriterSingletonContended(RuntimeError):
+    """Another writer is active; the caller must fail closed immediately."""
+
+
+class WriterSingletonUnavailable(RuntimeError):
+    """The durable advisory-lock authority could not be reached."""
+
+
+class WriterSurfaceUnknown(ValueError):
+    """Prevent a new mutation path from bypassing the explicit writer catalog."""
+
+
+def account_mode_advisory_key(account_mode: str = ACCOUNT_MODE) -> int:
+    """Stable signed bigint key accepted by PostgreSQL advisory-lock functions."""
+    if not account_mode.strip():
+        raise ValueError("account_mode must be non-blank")
+    digest = hashlib.sha256(account_mode.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+def assert_known_writer_surface(writer_surface: str) -> None:
+    if writer_surface not in MUTATION_WRITER_SURFACES:
+        raise WriterSurfaceUnknown(
+            f"KIS mock mutation writer is not catalogued: {writer_surface!r}"
+        )
+
+
+class AdvisoryLock(Protocol):
+    async def try_acquire(self, key: int) -> bool: ...
+
+    async def release(self, key: int) -> None: ...
+
+
+class FileLock(Protocol):
+    def try_acquire(self) -> bool: ...
+
+    def release(self) -> None: ...
+
+
+class PidFileLock:
+    """Non-blocking local lock carrying a diagnostic PID, never a lock authority."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._handle = None
+
+    def try_acquire(self) -> bool:
+        try:
+            import fcntl
+        except ImportError as exc:  # pragma: no cover - Linux/macOS CI supports it
+            raise WriterSingletonUnavailable(
+                "fcntl file locking is unavailable"
+            ) from exc
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self._path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            handle.close()
+            return False
+        handle.seek(0)
+        handle.truncate()
+        handle.write(f"pid={os.getpid()}\n")
+        handle.flush()
+        self._handle = handle
+        return True
+
+    def release(self) -> None:
+        if self._handle is None:
+            return
+        try:
+            import fcntl
+
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._handle.close()
+            self._handle = None
+
+
+class PostgresAdvisoryLock:
+    """Hold a dedicated PostgreSQL connection for the lifetime of the writer."""
+
+    def __init__(self) -> None:
+        self._connection: AsyncConnection | None = None
+
+    async def try_acquire(self, key: int) -> bool:
+        if self._connection is not None:
+            raise RuntimeError("advisory lock instance is already acquired")
+        from app.core import db
+
+        connection = await db.engine.connect()
+        try:
+            result = await connection.execute(
+                text("SELECT pg_try_advisory_lock(CAST(:key AS bigint))"),
+                {"key": key},
+            )
+            acquired = bool(result.scalar_one())
+            if not acquired:
+                await connection.close()
+                return False
+            self._connection = connection
+            return True
+        except BaseException:
+            await connection.close()
+            raise
+
+    async def release(self, key: int) -> None:
+        connection = self._connection
+        self._connection = None
+        if connection is None:
+            return
+        try:
+            await connection.execute(
+                text("SELECT pg_advisory_unlock(CAST(:key AS bigint))"),
+                {"key": key},
+            )
+        finally:
+            await connection.close()
+
+
+class KISMockWriterLease:
+    """Acquire both local visibility and authoritative DB singleton locks."""
+
+    def __init__(
+        self,
+        *,
+        writer_surface: str = "runner",
+        account_mode: str = ACCOUNT_MODE,
+        file_lock: FileLock | None = None,
+        advisory_lock: AdvisoryLock | None = None,
+    ) -> None:
+        assert_known_writer_surface(writer_surface)
+        self._writer_surface = writer_surface
+        self._key = account_mode_advisory_key(account_mode)
+        default_path = Path(tempfile.gettempdir()) / "auto_trader_kis_mock_writer.lock"
+        self._file_lock = file_lock or PidFileLock(default_path)
+        self._advisory_lock = advisory_lock or PostgresAdvisoryLock()
+        self._acquired = False
+        self._context_token: Token[bool] | None = None
+
+    @property
+    def acquired(self) -> bool:
+        return self._acquired
+
+    async def acquire(self) -> None:
+        """Acquire non-blocking locks; contention and DB failure both close the path."""
+        if self._acquired:
+            raise RuntimeError("writer lease is already acquired")
+        try:
+            file_acquired = self._file_lock.try_acquire()
+        except WriterSingletonUnavailable:
+            raise
+        except Exception as exc:  # noqa: BLE001 - file lock failure must not open writes
+            raise WriterSingletonUnavailable("KIS mock PID lock unavailable") from exc
+        if not file_acquired:
+            raise WriterSingletonContended(
+                "KIS mock writer singleton contended at local PID lock"
+            )
+        try:
+            advisory_acquired = await self._advisory_lock.try_acquire(self._key)
+        except Exception as exc:  # noqa: BLE001 - cross-process authority unavailable
+            self._file_lock.release()
+            raise WriterSingletonUnavailable(
+                "KIS mock PostgreSQL advisory lock unavailable"
+            ) from exc
+        if not advisory_acquired:
+            self._file_lock.release()
+            raise WriterSingletonContended(
+                "KIS mock writer singleton contended at PostgreSQL advisory lock"
+            )
+        self._acquired = True
+
+    async def release(self) -> None:
+        """Release in reverse order; an unlock error never leaves the file lock held."""
+        if not self._acquired:
+            return
+        self._acquired = False
+        try:
+            await self._advisory_lock.release(self._key)
+        finally:
+            self._file_lock.release()
+
+    async def __aenter__(self) -> KISMockWriterLease:
+        await self.acquire()
+        self._context_token = _ACTIVE_WRITER_LEASE.set(True)
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        del exc_type, exc, traceback
+        try:
+            await self.release()
+        finally:
+            if self._context_token is not None:
+                _ACTIVE_WRITER_LEASE.reset(self._context_token)
+                self._context_token = None
+
+
+def has_active_writer_lease() -> bool:
+    """Whether this task already owns the advisory lease (retry-safe/reentrant)."""
+    return _ACTIVE_WRITER_LEASE.get()
+
+
+@asynccontextmanager
+async def enforce_kis_mock_mutation_writer(
+    *,
+    enabled: bool,
+    lease_factory: Callable[[], KISMockWriterLease] = KISMockWriterLease,
+) -> AsyncIterator[None]:
+    """Enforce writer cardinality for every KRX mock mutation boundary.
+
+    The runner gate makes this dormant until KR-B2 explicitly arms the shell.
+    Once armed, unscoped legacy/manual callers obtain the same one-call lease;
+    runner-owned retries see the context and reuse their long-lived lease.
+    """
+    if not enabled or has_active_writer_lease():
+        yield
+        return
+    lease = lease_factory()
+    async with lease:
+        token = _ACTIVE_WRITER_LEASE.set(True)
+        try:
+            yield
+        finally:
+            _ACTIVE_WRITER_LEASE.reset(token)
+
+
+AdvisoryAcquire = Awaitable[bool]

--- a/scripts/kis_mock_runner.py
+++ b/scripts/kis_mock_runner.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""KR-B0 KIS mock runner operator entry point.
+
+This is a scheduleless, foreground-only process.  It remains disabled unless
+``KIS_MOCK_RUNNER_ENABLED=true`` is explicitly present, and B0 has no strategy
+overlay, so its normal ``--once`` result is ``OVERLAY_REQUIRED`` with zero
+broker calls.  No option accepts a symbol, strategy, pricing rule, or safety
+envelope override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+from app.services.kis_mock_runner.control import (
+    KillSwitchRearmUnauthorized,
+    PostgresKillSwitchStore,
+    rearm_active,
+)
+from app.services.kis_mock_runner.gates import (
+    KISMockRunnerRearmUnauthorized,
+    assert_rearm_authorized,
+)
+from app.services.kis_mock_runner.runner import KISMockRunner, RunnerResult
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "KIS mock runner (KR-B0): default-disabled, foreground supervised, "
+            "strategy-neutral."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--once", action="store_true", help="Run one guarded tick.")
+    mode.add_argument(
+        "--loop",
+        action="store_true",
+        help="Run the fixed-cadence foreground loop; no scheduler is registered.",
+    )
+    mode.add_argument(
+        "--rearm",
+        action="store_true",
+        help="Operator-only durable kill-switch re-arm; also needs --confirm.",
+    )
+    parser.add_argument(
+        "--tag",
+        default="foreground",
+        help="Correlation tag only; it does not select a strategy or symbol.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Required per-invocation confirmation for --rearm.",
+    )
+    parser.add_argument(
+        "--updated-by",
+        default="",
+        help="Required non-secret operator audit label for --rearm.",
+    )
+    return parser.parse_args(argv)
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str))
+
+
+def _result_payload(result: RunnerResult) -> dict[str, Any]:
+    return {
+        "event": "kis_mock_runner",
+        "status": result.status.value,
+        "kill_mode": None
+        if result.kill_switch is None
+        else result.kill_switch.mode.value,
+        "kill_reason": None
+        if result.kill_switch is None
+        else result.kill_switch.reason,
+        "canceled_pending_entries": result.canceled_pending_entries,
+        "correlation_id": result.correlation_id,
+        "broker_calls": result.broker_calls,
+        "notification_delivery": [
+            {
+                "channel": report.channel,
+                "delivered": report.delivered,
+                "skipped": report.skipped,
+                "retry_recorded": report.retry_recorded,
+            }
+            for report in result.notification_reports
+        ],
+    }
+
+
+async def _run(args: argparse.Namespace, *, environment: dict[str, str]) -> int:
+    if args.rearm:
+        try:
+            assert_rearm_authorized(environment, confirm=args.confirm)
+            state = await rearm_active(
+                PostgresKillSwitchStore(),
+                operator_gate=True,
+                confirm=args.confirm,
+                updated_by=args.updated_by,
+            )
+        except (KISMockRunnerRearmUnauthorized, KillSwitchRearmUnauthorized) as exc:
+            _emit({"event": "kis_mock_runner_rearm_refused", "reason": str(exc)})
+            return 2
+        _emit(
+            {
+                "event": "kis_mock_runner_rearmed",
+                "mode": state.mode.value,
+                "updated_by": state.updated_by,
+            }
+        )
+        return 0
+
+    runner = KISMockRunner(environment=environment, tag=args.tag)
+    result = await (runner.run_forever() if args.loop else runner.run_once())
+    _emit(_result_payload(result))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = _parse_args(argv)
+    try:
+        return asyncio.run(_run(args, environment=dict(os.environ)))
+    except Exception as exc:  # noqa: BLE001 - fail closed, no secrets in output
+        logger.exception(
+            "KIS mock runner stopped before mutation: %s", type(exc).__name__
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/services/kis_mock_runner/__init__.py
+++ b/tests/services/kis_mock_runner/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the KR-B0 strategy-neutral KIS mock runner."""

--- a/tests/services/kis_mock_runner/test_cli.py
+++ b/tests/services/kis_mock_runner/test_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from scripts.kis_mock_runner import _parse_args, _run
+
+
+def test_cli_exposes_no_hard_envelope_override_flags() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_args(["--once", "--max-single-notional-krw", "999999999"])
+    assert exc_info.value.code == 2
+
+
+def test_cli_requires_explicit_foreground_mode() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_args([])
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.asyncio
+async def test_rearm_cli_needs_env_gate_confirmation_and_audit_actor() -> None:
+    args = argparse.Namespace(
+        rearm=True,
+        confirm=False,
+        updated_by="operator-a",
+        once=False,
+        loop=False,
+        tag="test",
+    )
+    assert await _run(args, environment={}) == 2
+
+    args.confirm = True
+    args.updated_by = ""
+    assert await _run(args, environment={"KIS_MOCK_RUNNER_REARM_ENABLED": "true"}) == 2

--- a/tests/services/kis_mock_runner/test_control.py
+++ b/tests/services/kis_mock_runner/test_control.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.kis_mock_runner.control import (
+    KillMode,
+    KillSwitchRearmUnauthorized,
+    KillSwitchState,
+    read_effective_kill_switch,
+    rearm_active,
+)
+from app.services.kis_mock_runner.runner import MutationKind, mutation_permission
+
+
+class FakeControlStore:
+    def __init__(self, state: KillSwitchState | Exception) -> None:
+        self.state = state
+        self.writes: list[tuple[KillMode, str, str]] = []
+
+    async def read(self) -> KillSwitchState:
+        if isinstance(self.state, Exception):
+            raise self.state
+        return self.state
+
+    async def set_mode(
+        self, *, mode: KillMode, reason: str, updated_by: str
+    ) -> KillSwitchState:
+        self.writes.append((mode, reason, updated_by))
+        state = KillSwitchState(
+            mode=mode,
+            reason=reason,
+            updated_by=updated_by,
+            updated_at=datetime.now(UTC),
+        )
+        self.state = state
+        return state
+
+
+@pytest.mark.asyncio
+async def test_kill_read_failure_is_global_freeze() -> None:
+    state = await read_effective_kill_switch(FakeControlStore(RuntimeError("db down")))
+    assert state.mode is KillMode.GLOBAL_FREEZE
+    assert state.read_failed is True
+    assert state.reason == "kill_control_read_failed"
+
+
+@pytest.mark.parametrize(
+    ("mode", "allowed", "blocked"),
+    [
+        (KillMode.ACTIVE, set(MutationKind), set()),
+        (
+            KillMode.ENTRY_HALT,
+            {
+                MutationKind.EXIT,
+                MutationKind.CANCEL_PENDING_ENTRY,
+                MutationKind.CANCEL_EXIT,
+                MutationKind.MODIFY_EXIT,
+                MutationKind.RETRY_EXIT,
+            },
+            {
+                MutationKind.ENTRY,
+                MutationKind.MODIFY_ENTRY,
+                MutationKind.RETRY_ENTRY,
+            },
+        ),
+        (KillMode.GLOBAL_FREEZE, set(), set(MutationKind)),
+    ],
+)
+def test_kill_state_transition_table(
+    mode: KillMode, allowed: set[MutationKind], blocked: set[MutationKind]
+) -> None:
+    for kind in allowed:
+        assert mutation_permission(mode, kind).allowed is True
+    for kind in blocked:
+        decision = mutation_permission(mode, kind)
+        assert decision.allowed is False
+        assert decision.reason == mode.value
+
+
+@pytest.mark.asyncio
+async def test_rearm_requires_both_operator_gate_and_confirm() -> None:
+    store = FakeControlStore(
+        KillSwitchState(
+            mode=KillMode.GLOBAL_FREEZE,
+            reason="operator_stop",
+            updated_by="operator",
+        )
+    )
+    with pytest.raises(KillSwitchRearmUnauthorized):
+        await rearm_active(
+            store, operator_gate=False, confirm=True, updated_by="operator-a"
+        )
+    with pytest.raises(KillSwitchRearmUnauthorized):
+        await rearm_active(
+            store, operator_gate=True, confirm=False, updated_by="operator-a"
+        )
+    state = await rearm_active(
+        store, operator_gate=True, confirm=True, updated_by="operator-a"
+    )
+    assert state.mode is KillMode.ACTIVE
+    assert store.writes == [(KillMode.ACTIVE, "operator_rearm_confirmed", "operator-a")]

--- a/tests/services/kis_mock_runner/test_correlation.py
+++ b/tests/services/kis_mock_runner/test_correlation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from app.services.kis_mock_runner.correlation import kis_mock_runner_correlation_id
+
+
+def test_correlation_id_is_deterministic_and_namespaced() -> None:
+    values = {
+        "tag": "foreground",
+        "candidate_id": "kr-candidate-v1",
+        "contract_hash": "abc123",
+        "strategy_id": "survivor-v1",
+        "decision_key": "2026-08-05:005930:buy",
+    }
+    correlation_id = kis_mock_runner_correlation_id(**values)
+    assert correlation_id == kis_mock_runner_correlation_id(**values)
+    assert correlation_id.startswith("kis-mock-runner:foreground:")
+    assert len(correlation_id.rsplit(":", maxsplit=1)[-1]) == 16

--- a/tests/services/kis_mock_runner/test_domestic_route.py
+++ b/tests/services/kis_mock_runner/test_domestic_route.py
@@ -1,0 +1,150 @@
+"""KR-B0 route proof: KIS mock domestic mutations can never emit SOR."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_NXT_ELIGIBLE_PATH = "app.services.brokers.kis.domestic_orders.is_nxt_eligible"
+
+
+def _make_client():
+    from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+
+    parent = MagicMock()
+    parent._hdr_base = {"content-type": "application/json"}
+    parent._ensure_token = AsyncMock()
+    parent._token_manager = AsyncMock()
+    settings = MagicMock()
+    settings.kis_account_no = "1234567890"
+    settings.kis_access_token = "test-token"
+    parent._settings = settings
+    return DomesticOrderClient(parent), parent
+
+
+def _success_response() -> dict[str, object]:
+    return {"rt_cd": "0", "output": {"ODNO": "00001", "ORD_TMD": "120000"}}
+
+
+def _assert_krx_calls(parent: MagicMock) -> None:
+    assert parent._request_with_rate_limit.await_count >= 1
+    for call in parent._request_with_rate_limit.await_args_list:
+        assert call.kwargs["json_body"]["EXCG_ID_DVSN_CD"] == "KRX"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["place", "cancel", "modify"])
+async def test_mock_domestic_mutations_ignore_nxt_and_force_krx(operation: str) -> None:
+    client, parent = _make_client()
+    parent._request_with_rate_limit = AsyncMock(return_value=_success_response())
+    nxt = AsyncMock(return_value=True)
+    with patch(_NXT_ELIGIBLE_PATH, nxt):
+        if operation == "place":
+            await client.order_korea_stock("005930", "buy", 10, 70000, is_mock=True)
+        elif operation == "cancel":
+            await client.cancel_korea_order(
+                "00001",
+                "005930",
+                10,
+                70000,
+                "buy",
+                is_mock=True,
+                krx_fwdg_ord_orgno="00091",
+            )
+        else:
+            await client.modify_korea_order(
+                "00001",
+                "005930",
+                10,
+                71000,
+                is_mock=True,
+                krx_fwdg_ord_orgno="00091",
+            )
+    _assert_krx_calls(parent)
+    nxt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mock_token_retry_re_resolves_krx_and_never_sor() -> None:
+    client, parent = _make_client()
+    parent._request_with_rate_limit = AsyncMock(
+        side_effect=[
+            {"rt_cd": "1", "msg_cd": "EGW00123", "msg1": "expired"},
+            _success_response(),
+        ]
+    )
+    nxt = AsyncMock(return_value=True)
+    with patch(_NXT_ELIGIBLE_PATH, nxt):
+        await client.order_korea_stock("005930", "buy", 10, 70000, is_mock=True)
+    _assert_krx_calls(parent)
+    assert parent._request_with_rate_limit.await_count == 2
+    nxt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_live_nxt_route_remains_sor() -> None:
+    client, parent = _make_client()
+    parent._request_with_rate_limit = AsyncMock(return_value=_success_response())
+    with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=True)):
+        await client.order_korea_stock("005930", "buy", 10, 70000, is_mock=False)
+    assert (
+        parent._request_with_rate_limit.await_args.kwargs["json_body"][
+            "EXCG_ID_DVSN_CD"
+        ]
+        == "SOR"
+    )
+
+
+def test_all_domestic_mutation_entry_points_use_writer_guard_when_armed() -> None:
+    from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+
+    for method_name in (
+        "order_korea_stock",
+        "cancel_korea_order",
+        "modify_korea_order",
+    ):
+        assert hasattr(getattr(DomesticOrderClient, method_name), "__wrapped__")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["place", "cancel", "modify"])
+async def test_armed_mock_mutations_enter_the_shared_writer_scope(
+    monkeypatch, operation: str
+) -> None:
+    import app.services.brokers.kis.domestic_orders as domestic_orders
+
+    client, parent = _make_client()
+    parent._request_with_rate_limit = AsyncMock(return_value=_success_response())
+    entered: list[bool] = []
+
+    @asynccontextmanager
+    async def fake_scope(*, enabled: bool):
+        entered.append(enabled)
+        yield
+
+    monkeypatch.setenv("KIS_MOCK_RUNNER_ENABLED", "true")
+    monkeypatch.setattr(domestic_orders, "enforce_kis_mock_mutation_writer", fake_scope)
+    if operation == "place":
+        await client.order_korea_stock("005930", "buy", 10, 70000, is_mock=True)
+    elif operation == "cancel":
+        await client.cancel_korea_order(
+            "00001",
+            "005930",
+            10,
+            70000,
+            "buy",
+            is_mock=True,
+            krx_fwdg_ord_orgno="00091",
+        )
+    else:
+        await client.modify_korea_order(
+            "00001",
+            "005930",
+            10,
+            71000,
+            is_mock=True,
+            krx_fwdg_ord_orgno="00091",
+        )
+    assert entered == [True]

--- a/tests/services/kis_mock_runner/test_envelope.py
+++ b/tests/services/kis_mock_runner/test_envelope.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+
+from app.services.kis_mock_runner.envelope import (
+    CONFIGURABLE_OFF_SWITCH,
+    LOCKED_ENVELOPE,
+    AccountEnvelopeSnapshot,
+    EnvelopeOverrideAttempt,
+    EnvelopeReason,
+    HardEnvelope,
+    OrderIntent,
+    assert_envelope_locked,
+    assert_no_envelope_overrides,
+    evaluate_envelope,
+)
+
+
+def _snapshot(**overrides: object) -> AccountEnvelopeSnapshot:
+    values: dict[str, object] = {
+        "session_start_nlv_krw": Decimal("100000000"),
+        "current_nlv_krw": Decimal("100000000"),
+        "available_cash_krw": Decimal("10000000"),
+        "projected_gross_exposure_krw": Decimal("40000000"),
+        "positions_including_pending_reserved": 4,
+        "new_entries_this_xkrx_session": 2,
+        "planned_exits_this_xkrx_session": 2,
+        "cash_is_fresh": True,
+        "is_cash_only": True,
+        "margin_enabled": False,
+        "short_enabled": False,
+    }
+    values.update(overrides)
+    return AccountEnvelopeSnapshot(**values)  # type: ignore[arg-type]
+
+
+def _entry(**overrides: object) -> OrderIntent:
+    values: dict[str, object] = {
+        "side": "buy",
+        "role": "entry",
+        "order_type": "limit",
+        "quantity": Decimal("10"),
+        "limit_price_krw": Decimal("100000"),
+    }
+    values.update(overrides)
+    return OrderIntent(**values)  # type: ignore[arg-type]
+
+
+def test_locked_envelope_has_operator_approved_literals() -> None:
+    assert CONFIGURABLE_OFF_SWITCH == "NO"
+    assert LOCKED_ENVELOPE.max_single_notional_krw == Decimal("5000000")
+    assert LOCKED_ENVELOPE.session_start_nlv_fraction == Decimal("0.05")
+    assert LOCKED_ENVELOPE.max_gross_exposure_fraction == Decimal("0.50")
+    assert LOCKED_ENVELOPE.max_positions_including_pending_reserved == 10
+    assert LOCKED_ENVELOPE.max_new_entries_per_xkrx_session == 10
+    assert LOCKED_ENVELOPE.max_planned_exits_per_xkrx_session == 10
+    assert LOCKED_ENVELOPE.daily_loss_halt_fraction == Decimal("0.025")
+    assert LOCKED_ENVELOPE.per_order_notional_cap(Decimal("200000000")) == Decimal(
+        "5000000"
+    )
+    assert LOCKED_ENVELOPE.per_order_notional_cap(Decimal("40000000")) == Decimal(
+        "2000000"
+    )
+
+
+def test_environment_override_attempt_fails_closed() -> None:
+    with pytest.raises(EnvelopeOverrideAttempt, match="MAX_SINGLE_NOTIONAL"):
+        assert_no_envelope_overrides(
+            {"KIS_MOCK_RUNNER_MAX_SINGLE_NOTIONAL_KRW": "999999999"}
+        )
+
+
+def test_non_cli_caller_cannot_supply_a_wider_envelope() -> None:
+    with pytest.raises(ValueError, match="differs"):
+        assert_envelope_locked(
+            replace(LOCKED_ENVELOPE, max_positions_including_pending_reserved=11)
+        )
+    with pytest.raises(ValueError, match="differs"):
+        evaluate_envelope(
+            intent=_entry(),
+            snapshot=_snapshot(),
+            envelope=HardEnvelope(max_single_notional_krw=Decimal("9000000")),
+        )
+
+
+def test_envelope_rejects_market_price_missing_and_unfresh_cash() -> None:
+    decision = evaluate_envelope(
+        intent=_entry(order_type="market", limit_price_krw=None),
+        snapshot=_snapshot(cash_is_fresh=False),
+    )
+    assert decision.allowed is False
+    assert set(decision.reason_codes) >= {
+        EnvelopeReason.LIMIT_ONLY,
+        EnvelopeReason.LIMIT_PRICE_REQUIRED,
+        EnvelopeReason.CASH_NOT_FRESH,
+    }
+
+
+def test_envelope_rejects_hard_caps_and_daily_loss_halt() -> None:
+    decision = evaluate_envelope(
+        intent=_entry(quantity=Decimal("100"), limit_price_krw=Decimal("100000")),
+        snapshot=_snapshot(
+            current_nlv_krw=Decimal("97500000"),
+            projected_gross_exposure_krw=Decimal("50000001"),
+            positions_including_pending_reserved=11,
+            new_entries_this_xkrx_session=10,
+        ),
+    )
+    assert decision.allowed is False
+    assert set(decision.reason_codes) >= {
+        EnvelopeReason.PER_ORDER_NOTIONAL_CAP,
+        EnvelopeReason.GROSS_EXPOSURE_CAP,
+        EnvelopeReason.POSITION_CAP,
+        EnvelopeReason.SESSION_NEW_ENTRY_CAP,
+        EnvelopeReason.DAILY_LOSS_ENTRY_HALT,
+    }
+    assert decision.requires_entry_halt is True
+
+
+def test_exit_cap_is_distinct_from_new_entry_cap() -> None:
+    decision = evaluate_envelope(
+        intent=OrderIntent(
+            side="sell",
+            role="exit",
+            order_type="limit",
+            quantity=Decimal("1"),
+            limit_price_krw=Decimal("100000"),
+        ),
+        snapshot=_snapshot(planned_exits_this_xkrx_session=10),
+    )
+    assert decision.allowed is False
+    assert decision.reason_codes == (EnvelopeReason.SESSION_PLANNED_EXIT_CAP,)

--- a/tests/services/kis_mock_runner/test_envelope.py
+++ b/tests/services/kis_mock_runner/test_envelope.py
@@ -120,6 +120,27 @@ def test_envelope_rejects_hard_caps_and_daily_loss_halt() -> None:
     assert decision.requires_entry_halt is True
 
 
+def test_daily_loss_halt_blocks_entries_but_not_exits() -> None:
+    drawdown_snapshot = _snapshot(current_nlv_krw=Decimal("97500000"))
+    entry = evaluate_envelope(intent=_entry(), snapshot=drawdown_snapshot)
+    exit = evaluate_envelope(
+        intent=OrderIntent(
+            side="sell",
+            role="exit",
+            order_type="limit",
+            quantity=Decimal("1"),
+            limit_price_krw=Decimal("100000"),
+        ),
+        snapshot=drawdown_snapshot,
+    )
+
+    assert entry.allowed is False
+    assert entry.requires_entry_halt is True
+    assert EnvelopeReason.DAILY_LOSS_ENTRY_HALT in entry.reason_codes
+    assert exit.allowed is True
+    assert exit.reason_codes == ()
+
+
 def test_exit_cap_is_distinct_from_new_entry_cap() -> None:
     decision = evaluate_envelope(
         intent=OrderIntent(

--- a/tests/services/kis_mock_runner/test_migration.py
+++ b/tests/services/kis_mock_runner/test_migration.py
@@ -1,0 +1,120 @@
+"""KR-B0 control-table migration proof, including pytest-owned PostgreSQL DDL."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import io
+from pathlib import Path
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "alembic"
+    / "versions"
+    / "20260805_kis_mock_runner_control.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "kis_mock_runner_control", _MIGRATION_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MIGRATION = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MIGRATION)
+
+
+def test_migration_is_additive_and_chains_from_current_head() -> None:
+    tree = ast.parse(_MIGRATION_PATH.read_text(encoding="utf-8"))
+    assignments = {
+        node.target.id: node.value.value
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    }
+    assert assignments["revision"] == "20260805_kis_mock_runner"
+    assert assignments["down_revision"] == "20260804_alpaca_clean_account"
+    source = _MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "op.create_table(" in source
+    assert "op.drop_table(" in source
+    assert "kis_mock_runner_control" in source
+    assert "alter_" not in source
+    assert "drop_column" not in source
+
+
+def test_offline_migration_renders_singleton_mode_constraints() -> None:
+    output = io.StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    original_op = _MIGRATION.op
+    _MIGRATION.op = Operations(context)
+    try:
+        _MIGRATION.upgrade()
+    finally:
+        _MIGRATION.op = original_op
+    sql = output.getvalue()
+    assert "CREATE TABLE review.kis_mock_runner_control" in sql
+    assert "CHECK (id = 1)" in sql
+    assert "'ACTIVE','ENTRY_HALT','GLOBAL_FREEZE'" in sql
+    assert "initial_control_row" in sql
+
+
+@pytest.mark.asyncio
+async def test_migration_applies_and_round_trips_on_pytest_owned_database(
+    db_session,
+) -> None:
+    """No operator database is touched: db_session selects a run-owned test DB."""
+    del db_session
+    from app.core.db import engine
+
+    async with engine.connect() as connection:
+        transaction = await connection.begin()
+        try:
+
+            def upgrade(sync_connection) -> None:
+                context = MigrationContext.configure(sync_connection)
+                original_op = _MIGRATION.op
+                _MIGRATION.op = Operations(context)
+                try:
+                    _MIGRATION.upgrade()
+                finally:
+                    _MIGRATION.op = original_op
+
+            await connection.run_sync(upgrade)
+            row = (
+                (
+                    await connection.execute(
+                        text(
+                            "SELECT id, mode, reason, updated_by "
+                            "FROM review.kis_mock_runner_control WHERE id = 1"
+                        )
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            assert dict(row) == {
+                "id": 1,
+                "mode": "ACTIVE",
+                "reason": "initial_control_row",
+                "updated_by": "migration:KR-B0",
+            }
+            with pytest.raises(IntegrityError):
+                await connection.execute(
+                    text(
+                        "INSERT INTO review.kis_mock_runner_control "
+                        "(id, mode, reason, updated_by) "
+                        "VALUES (2, 'ACTIVE', 'bad', 'test')"
+                    )
+                )
+            await transaction.rollback()
+        finally:
+            if transaction.is_active:
+                await transaction.rollback()

--- a/tests/services/kis_mock_runner/test_runner.py
+++ b/tests/services/kis_mock_runner/test_runner.py
@@ -179,9 +179,7 @@ async def test_control_read_failure_blocks_all_automatic_work() -> None:
 
 
 @pytest.mark.asyncio
-async def test_entry_halt_cancels_only_attributed_pending_entries_and_allows_exits() -> (
-    None
-):
+async def test_entry_halt_cancels_only_attributed_pending_entries() -> None:
     pending = PendingEntryPort(
         (
             AttributedPendingEntry(
@@ -207,8 +205,49 @@ async def test_entry_halt_cancels_only_attributed_pending_entries_and_allows_exi
     assert result.status is RunnerStatus.ENTRY_HALT
     assert result.canceled_pending_entries == 1
     assert pending.cancelled == ["order-1"]
-    # Exit permission itself is asserted exhaustively in test_control; this run
-    # demonstrates that ENTRY_HALT's automatic mutation is only entry cancellation.
+    assert result.broker_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_entry_halt_allows_exit_through_terminal_envelope_path() -> None:
+    store = FakeStore(
+        KillSwitchState(
+            mode=KillMode.ENTRY_HALT,
+            reason="daily_loss_halt_threshold_reached",
+            updated_by="kis_mock_runner",
+        )
+    )
+    runner = KISMockRunner(
+        environment={"KIS_MOCK_RUNNER_ENABLED": "true"},
+        tag="test",
+        overlay=OverlayBinding(
+            candidate_id="candidate-v1",
+            contract_hash="hash-v1",
+            strategy_id="strategy-v1",
+        ),
+        kill_switch_store=store,
+        writer_lease=TrackingLease(),
+        notifier=RecordingNotifier(),
+    )
+
+    result = await runner.evaluate_overlay_intent(
+        intent=OrderIntent(
+            side="sell",
+            role="exit",
+            order_type="limit",
+            quantity=Decimal("1"),
+            limit_price_krw=Decimal("100000"),
+        ),
+        snapshot=_snapshot(current_nlv_krw=Decimal("97500000")),
+        decision_key="2026-08-05:exit-after-halt",
+    )
+
+    assert result.status is RunnerStatus.READY_NO_INTENT
+    assert result.kill_switch is not None
+    assert result.kill_switch.mode is KillMode.ENTRY_HALT
+    assert result.envelope is not None and result.envelope.allowed is True
+    assert result.correlation_id is not None
+    assert store.writes == []
     assert result.broker_calls == 0
 
 

--- a/tests/services/kis_mock_runner/test_runner.py
+++ b/tests/services/kis_mock_runner/test_runner.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.kis_mock_runner.control import KillMode, KillSwitchState
+from app.services.kis_mock_runner.envelope import AccountEnvelopeSnapshot, OrderIntent
+from app.services.kis_mock_runner.notifications import DeliveryReport, DiscordNotifier
+from app.services.kis_mock_runner.overlay import OverlayBinding, OverlayRequired
+from app.services.kis_mock_runner.runner import (
+    AttributedPendingEntry,
+    KISMockRunner,
+    RunnerStatus,
+)
+
+
+class FakeStore:
+    def __init__(self, state: KillSwitchState | Exception) -> None:
+        self.state = state
+        self.writes: list[tuple[KillMode, str, str]] = []
+
+    async def read(self) -> KillSwitchState:
+        if isinstance(self.state, Exception):
+            raise self.state
+        return self.state
+
+    async def set_mode(
+        self, *, mode: KillMode, reason: str, updated_by: str
+    ) -> KillSwitchState:
+        self.writes.append((mode, reason, updated_by))
+        state = KillSwitchState(mode=mode, reason=reason, updated_by=updated_by)
+        self.state = state
+        return state
+
+
+class TrackingLease:
+    def __init__(self) -> None:
+        self.entered = 0
+        self.exited = 0
+
+    async def __aenter__(self) -> TrackingLease:
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        del exc_type, exc, traceback
+        self.exited += 1
+
+
+class PendingEntryPort:
+    def __init__(self, entries: tuple[AttributedPendingEntry, ...]) -> None:
+        self.entries = entries
+        self.cancelled: list[str] = []
+
+    async def list_attributed_pending_entries(
+        self,
+    ) -> tuple[AttributedPendingEntry, ...]:
+        return self.entries
+
+    async def cancel_pending_entry(self, entry: AttributedPendingEntry) -> None:
+        self.cancelled.append(entry.order_id)
+
+
+class RecordingNotifier:
+    def __init__(self) -> None:
+        self.lifecycle_events: list[str] = []
+        self.alert_events: list[str] = []
+
+    async def lifecycle(self, *, event: str, payload: dict) -> DeliveryReport:
+        del payload
+        self.lifecycle_events.append(event)
+        return DeliveryReport(channel="kr_lifecycle", delivered=True)
+
+    async def alert(self, *, event: str, payload: dict) -> DeliveryReport:
+        del payload
+        self.alert_events.append(event)
+        return DeliveryReport(channel="alerts", delivered=True)
+
+
+def _active_state() -> KillSwitchState:
+    return KillSwitchState(
+        mode=KillMode.ACTIVE,
+        reason="initial_control_row",
+        updated_by="migration:KR-B0",
+    )
+
+
+def _snapshot(**overrides: object) -> AccountEnvelopeSnapshot:
+    values: dict[str, object] = {
+        "session_start_nlv_krw": Decimal("100000000"),
+        "current_nlv_krw": Decimal("100000000"),
+        "available_cash_krw": Decimal("10000000"),
+        "projected_gross_exposure_krw": Decimal("10000000"),
+        "positions_including_pending_reserved": 1,
+        "new_entries_this_xkrx_session": 1,
+        "planned_exits_this_xkrx_session": 0,
+        "cash_is_fresh": True,
+        "is_cash_only": True,
+        "margin_enabled": False,
+        "short_enabled": False,
+    }
+    values.update(overrides)
+    return AccountEnvelopeSnapshot(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_default_disabled_stops_before_lock_db_or_notification() -> None:
+    class ExplodingStore:
+        async def read(self):
+            raise AssertionError("kill store must not be read")
+
+        async def set_mode(self, **kwargs):
+            raise AssertionError("kill store must not be written")
+
+    lease = TrackingLease()
+    notifier = RecordingNotifier()
+    runner = KISMockRunner(
+        environment={},
+        tag="test",
+        kill_switch_store=ExplodingStore(),
+        writer_lease=lease,
+        notifier=notifier,
+    )
+    result = await runner.run_once()
+    assert result.status is RunnerStatus.DEFAULT_DISABLED
+    assert result.broker_calls == 0
+    assert lease.entered == 0
+    assert notifier.lifecycle_events == []
+    assert notifier.alert_events == []
+
+
+@pytest.mark.asyncio
+async def test_empty_overlay_refuses_before_intent_generation() -> None:
+    lease = TrackingLease()
+    notifier = RecordingNotifier()
+    runner = KISMockRunner(
+        environment={"KIS_MOCK_RUNNER_ENABLED": "true"},
+        tag="test",
+        kill_switch_store=FakeStore(_active_state()),
+        writer_lease=lease,
+        notifier=notifier,
+    )
+    result = await runner.run_once()
+    assert result.status is RunnerStatus.OVERLAY_REQUIRED
+    assert result.broker_calls == 0
+    assert lease.entered == lease.exited == 1
+    assert notifier.lifecycle_events == ["kis_mock_runner_overlay_required"]
+    with pytest.raises(OverlayRequired, match="OVERLAY_REQUIRED"):
+        await runner.evaluate_overlay_intent(
+            intent=OrderIntent(
+                side="buy",
+                role="entry",
+                order_type="limit",
+                quantity=Decimal("1"),
+                limit_price_krw=Decimal("1000"),
+            ),
+            snapshot=_snapshot(),
+            decision_key="must-not-be-used",
+        )
+
+
+@pytest.mark.asyncio
+async def test_control_read_failure_blocks_all_automatic_work() -> None:
+    notifier = RecordingNotifier()
+    runner = KISMockRunner(
+        environment={"KIS_MOCK_RUNNER_ENABLED": "true"},
+        tag="test",
+        kill_switch_store=FakeStore(RuntimeError("read failure")),
+        writer_lease=TrackingLease(),
+        notifier=notifier,
+    )
+    result = await runner.run_once()
+    assert result.status is RunnerStatus.GLOBAL_FREEZE
+    assert result.kill_switch is not None
+    assert result.kill_switch.read_failed is True
+    assert result.broker_calls == 0
+    assert notifier.alert_events == ["kis_mock_runner_global_freeze"]
+
+
+@pytest.mark.asyncio
+async def test_entry_halt_cancels_only_attributed_pending_entries_and_allows_exits() -> (
+    None
+):
+    pending = PendingEntryPort(
+        (
+            AttributedPendingEntry(
+                order_id="order-1", correlation_id="cid-1", strategy_id="strategy-1"
+            ),
+        )
+    )
+    runner = KISMockRunner(
+        environment={"KIS_MOCK_RUNNER_ENABLED": "true"},
+        tag="test",
+        kill_switch_store=FakeStore(
+            KillSwitchState(
+                mode=KillMode.ENTRY_HALT,
+                reason="daily_loss_halt_threshold_reached",
+                updated_by="runner",
+            )
+        ),
+        writer_lease=TrackingLease(),
+        pending_entry_port=pending,
+        notifier=RecordingNotifier(),
+    )
+    result = await runner.run_once()
+    assert result.status is RunnerStatus.ENTRY_HALT
+    assert result.canceled_pending_entries == 1
+    assert pending.cancelled == ["order-1"]
+    # Exit permission itself is asserted exhaustively in test_control; this run
+    # demonstrates that ENTRY_HALT's automatic mutation is only entry cancellation.
+    assert result.broker_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_daily_loss_transitions_durably_to_entry_halt(monkeypatch) -> None:
+    from app.services.kis_mock_runner import runner as runner_module
+
+    monkeypatch.setattr(runner_module, "is_krx_regular_session", lambda now: True)
+    store = FakeStore(_active_state())
+    runner = KISMockRunner(
+        environment={"KIS_MOCK_RUNNER_ENABLED": "true"},
+        tag="test",
+        overlay=OverlayBinding(
+            candidate_id="candidate-v1",
+            contract_hash="hash-v1",
+            strategy_id="strategy-v1",
+        ),
+        kill_switch_store=store,
+        writer_lease=TrackingLease(),
+        notifier=RecordingNotifier(),
+    )
+    result = await runner.evaluate_overlay_intent(
+        intent=OrderIntent(
+            side="buy",
+            role="entry",
+            order_type="limit",
+            quantity=Decimal("1"),
+            limit_price_krw=Decimal("100000"),
+        ),
+        snapshot=_snapshot(current_nlv_krw=Decimal("97500000")),
+        decision_key="2026-08-05:entry-1",
+    )
+    assert result.status is RunnerStatus.ENVELOPE_BLOCKED
+    assert result.envelope is not None and result.envelope.requires_entry_halt
+    assert store.writes == [
+        (
+            KillMode.ENTRY_HALT,
+            "daily_loss_halt_threshold_reached",
+            "kis_mock_runner",
+        )
+    ]
+    assert result.broker_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_notification_failure_does_not_change_no_submit_result() -> None:
+    retries: list[tuple[str, str, str]] = []
+
+    class Recorder:
+        async def record(self, *, channel: str, event: str, error_type: str) -> None:
+            retries.append((channel, event, error_type))
+
+    async def failing_post(url: str, payload: dict) -> None:
+        del url, payload
+        raise OSError("synthetic delivery failure")
+
+    notifier = DiscordNotifier(
+        {
+            "DISCORD_WEBHOOK_KR": "https://invalid.example/kr",
+            "DISCORD_WEBHOOK_ALERTS": "https://invalid.example/alerts",
+        },
+        post=failing_post,
+        retry_recorder=Recorder(),
+    )
+    runner = KISMockRunner(
+        environment={"KIS_MOCK_RUNNER_ENABLED": "true"},
+        tag="test",
+        kill_switch_store=FakeStore(_active_state()),
+        writer_lease=TrackingLease(),
+        notifier=notifier,
+    )
+    result = await runner.run_once()
+    assert result.status is RunnerStatus.OVERLAY_REQUIRED
+    assert result.broker_calls == 0
+    assert len(result.notification_reports) == 2
+    assert all(report.retry_recorded for report in result.notification_reports)
+    assert retries == [
+        ("kr_lifecycle", "kis_mock_runner_overlay_required", "OSError"),
+        ("alerts", "kis_mock_runner_lifecycle_delivery_failure", "OSError"),
+    ]

--- a/tests/services/kis_mock_runner/test_session.py
+++ b/tests/services/kis_mock_runner/test_session.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.services.kis_mock_runner import session
+
+
+def test_krx_regular_session_uses_confirmed_calendar_bounds(monkeypatch) -> None:
+    open_at = datetime(2026, 8, 5, 0, 0, tzinfo=UTC)  # 09:00 KST
+    close_at = datetime(2026, 8, 5, 6, 30, tzinfo=UTC)  # 15:30 KST
+    monkeypatch.setattr(
+        session,
+        "regular_session_bounds",
+        lambda market, day: (open_at, close_at) if market == "kr" else None,
+    )
+    assert session.is_krx_regular_session(open_at) is True
+    assert session.is_krx_regular_session(close_at - timedelta(microseconds=1)) is True
+    assert session.is_krx_regular_session(close_at) is False
+
+
+def test_krx_regular_session_fails_closed_when_calendar_cannot_confirm(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(session, "regular_session_bounds", lambda market, day: None)
+    assert (
+        session.is_krx_regular_session(datetime(2026, 8, 5, 3, 0, tzinfo=UTC)) is False
+    )

--- a/tests/services/kis_mock_runner/test_singleton.py
+++ b/tests/services/kis_mock_runner/test_singleton.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services.kis_mock_runner.singleton import (
+    MUTATION_WRITER_SURFACES,
+    KISMockWriterLease,
+    PidFileLock,
+    WriterSingletonContended,
+    WriterSingletonUnavailable,
+    account_mode_advisory_key,
+    enforce_kis_mock_mutation_writer,
+    has_active_writer_lease,
+)
+
+
+class SharedAdvisoryLock:
+    def __init__(self) -> None:
+        self.held = False
+        self.keys: list[int] = []
+
+    async def try_acquire(self, key: int) -> bool:
+        self.keys.append(key)
+        if self.held:
+            return False
+        self.held = True
+        return True
+
+    async def release(self, key: int) -> None:
+        self.keys.append(key)
+        self.held = False
+
+
+class UnavailableAdvisoryLock:
+    async def try_acquire(self, key: int) -> bool:
+        del key
+        raise RuntimeError("database unavailable")
+
+    async def release(self, key: int) -> None:
+        del key
+
+
+class FakeLease:
+    def __init__(self) -> None:
+        self.entered = 0
+        self.exited = 0
+
+    async def __aenter__(self) -> FakeLease:
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        del exc_type, exc, traceback
+        self.exited += 1
+
+
+@pytest.mark.asyncio
+async def test_db_advisory_lock_contention_fails_closed(tmp_path: Path) -> None:
+    advisory = SharedAdvisoryLock()
+    first = KISMockWriterLease(
+        file_lock=PidFileLock(tmp_path / "first.lock"), advisory_lock=advisory
+    )
+    second = KISMockWriterLease(
+        file_lock=PidFileLock(tmp_path / "second.lock"), advisory_lock=advisory
+    )
+    await first.acquire()
+    with pytest.raises(WriterSingletonContended, match="PostgreSQL advisory"):
+        await second.acquire()
+    assert second.acquired is False
+    await first.release()
+    await second.acquire()
+    await second.release()
+    assert all(key == account_mode_advisory_key("kis_mock") for key in advisory.keys)
+
+
+@pytest.mark.asyncio
+async def test_local_pid_file_lock_contention_fails_closed(tmp_path: Path) -> None:
+    shared_path = tmp_path / "kis-mock.lock"
+    first = KISMockWriterLease(
+        file_lock=PidFileLock(shared_path), advisory_lock=SharedAdvisoryLock()
+    )
+    second = KISMockWriterLease(
+        file_lock=PidFileLock(shared_path), advisory_lock=SharedAdvisoryLock()
+    )
+    await first.acquire()
+    with pytest.raises(WriterSingletonContended, match="local PID lock"):
+        await second.acquire()
+    await first.release()
+
+
+@pytest.mark.asyncio
+async def test_db_lock_failure_releases_local_file_lock(tmp_path: Path) -> None:
+    path = tmp_path / "recoverable.lock"
+    unavailable = KISMockWriterLease(
+        file_lock=PidFileLock(path), advisory_lock=UnavailableAdvisoryLock()
+    )
+    with pytest.raises(WriterSingletonUnavailable, match="advisory lock unavailable"):
+        await unavailable.acquire()
+    recovered = KISMockWriterLease(
+        file_lock=PidFileLock(path), advisory_lock=SharedAdvisoryLock()
+    )
+    await recovered.acquire()
+    await recovered.release()
+
+
+def test_account_mode_key_is_stable_and_signed_bigint() -> None:
+    key = account_mode_advisory_key("kis_mock")
+    assert key == account_mode_advisory_key("kis_mock")
+    assert -(2**63) <= key < 2**63
+
+
+@pytest.mark.asyncio
+async def test_armed_mutation_scope_acquires_once_and_marks_reentrant_context() -> None:
+    lease = FakeLease()
+    async with enforce_kis_mock_mutation_writer(
+        enabled=True,
+        lease_factory=lambda: lease,  # type: ignore[arg-type]
+    ):
+        assert has_active_writer_lease() is True
+        async with enforce_kis_mock_mutation_writer(
+            enabled=True, lease_factory=lambda: (_ for _ in ()).throw(AssertionError())
+        ):
+            assert has_active_writer_lease() is True
+    assert has_active_writer_lease() is False
+    assert lease.entered == lease.exited == 1
+
+
+def test_writer_catalog_enumerates_all_approved_kis_mock_surfaces() -> None:
+    assert MUTATION_WRITER_SURFACES == {
+        "runner",
+        "watch_auto_execute",
+        "smoke_cli",
+        "manual_mcp_mutation",
+    }

--- a/tests/test_services_kis_logging.py
+++ b/tests/test_services_kis_logging.py
@@ -238,23 +238,24 @@ class TestKISFailureLogging:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("order_type", "is_mock", "expected_tr_id"),
+        ("order_type", "is_mock", "expected_tr_id", "expected_exchange"),
         [
-            ("buy", False, "TTTC0012U"),
-            ("buy", True, "VTTC0012U"),
-            ("sell", False, "TTTC0011U"),
-            ("sell", True, "VTTC0011U"),
+            ("buy", False, "TTTC0012U", "SOR"),
+            ("buy", True, "VTTC0012U", "KRX"),
+            ("sell", False, "TTTC0011U", "SOR"),
+            ("sell", True, "VTTC0011U", "KRX"),
         ],
     )
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")
     @patch("app.services.brokers.kis.client.settings")
-    async def test_order_korea_stock_uses_new_tr_and_sor(
+    async def test_order_korea_stock_uses_new_tr_and_mock_krx_route(
         self,
         mock_settings,
         mock_client_class,
         order_type,
         is_mock,
         expected_tr_id,
+        expected_exchange,
     ):
         from app.services.brokers.kis.client import KISClient
 
@@ -294,24 +295,25 @@ class TestKISFailureLogging:
         body = mock_client.post.call_args.kwargs["json"]
 
         assert headers["tr_id"] == expected_tr_id
-        assert body["EXCG_ID_DVSN_CD"] == "SOR"
+        assert body["EXCG_ID_DVSN_CD"] == expected_exchange
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("is_mock", "expected_tr_id"),
+        ("is_mock", "expected_tr_id", "expected_exchange"),
         [
-            (False, "TTTC0013U"),
-            (True, "VTTC0013U"),
+            (False, "TTTC0013U", "SOR"),
+            (True, "VTTC0013U", "KRX"),
         ],
     )
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")
     @patch("app.services.brokers.kis.client.settings")
-    async def test_cancel_korea_order_uses_new_tr_sor_and_explicit_orgno(
+    async def test_cancel_korea_order_uses_new_tr_and_mock_krx_route(
         self,
         mock_settings,
         mock_client_class,
         is_mock,
         expected_tr_id,
+        expected_exchange,
     ):
         from app.services.brokers.kis.client import KISClient
 
@@ -353,26 +355,27 @@ class TestKISFailureLogging:
         body = mock_client.post.call_args.kwargs["json"]
 
         assert headers["tr_id"] == expected_tr_id
-        assert body["EXCG_ID_DVSN_CD"] == "SOR"
+        assert body["EXCG_ID_DVSN_CD"] == expected_exchange
         assert body["KRX_FWDG_ORD_ORGNO"] == "06010"
         assert body["RVSE_CNCL_DVSN_CD"] == "02"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("is_mock", "expected_tr_id"),
+        ("is_mock", "expected_tr_id", "expected_exchange"),
         [
-            (False, "TTTC0013U"),
-            (True, "VTTC0013U"),
+            (False, "TTTC0013U", "SOR"),
+            (True, "VTTC0013U", "KRX"),
         ],
     )
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")
     @patch("app.services.brokers.kis.client.settings")
-    async def test_modify_korea_order_uses_new_tr_sor_and_resolved_orgno(
+    async def test_modify_korea_order_uses_new_tr_and_mock_krx_route(
         self,
         mock_settings,
         mock_client_class,
         is_mock,
         expected_tr_id,
+        expected_exchange,
     ):
         from app.services.brokers.kis.client import KISClient
 
@@ -421,7 +424,7 @@ class TestKISFailureLogging:
         body = mock_client.post.call_args.kwargs["json"]
 
         assert headers["tr_id"] == expected_tr_id
-        assert body["EXCG_ID_DVSN_CD"] == "SOR"
+        assert body["EXCG_ID_DVSN_CD"] == expected_exchange
         assert body["KRX_FWDG_ORD_ORGNO"] == "06010"
         assert body["RVSE_CNCL_DVSN_CD"] == "01"
 


### PR DESCRIPTION
## Summary
- Adds the strategy-neutral, default-disabled KR-B0 KIS mock safety shell and foreground `--once`/`--loop` CLI.
- Enforces KRX-only routing for all KIS mock domestic place, modify, cancel, and retry paths without bypassing existing route/preflight logic.
- Adds durable fail-closed kill controls, locked cash-only DAY-limit envelope, PostgreSQL advisory-lock writer singleton, Discord lifecycle/alert handling, correlation spine, and the additive control-table migration.
- Preserves liquidation after the daily-loss ENTRY_HALT: entries remain blocked at the -2.5% threshold while exit intents pass the terminal guarded path.

## Validation
- `uv run pytest -q tests/services/kis_mock_runner tests/test_services_kis_logging.py tests/test_kis_domestic_orders_nxt.py tests/test_kis_domestic_orders_retry.py tests/test_kis_mock_cancel_modify.py tests/test_kis_mock_routing.py tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py` — 101 passed
- `make lint` — passed
- `uv run alembic heads` — `20260805_kis_mock_runner (head)`
- Default-disabled CLI proof: `broker_calls=0`; unauthorised rearm CLI refuses before DB/broker work.
- Independent T3 adversarial review found the daily-loss/exit BLOCKER, the F1 fix was independently revalidated as PASS, including terminal exit behavior under durable ENTRY_HALT.
- GitHub Actions run `30964103610`: all executable checks passed. `WIP` remains pending because this PR is intentionally draft.
- Local full-suite `kr_backfill` false-reds are caused by this worktree's `.env` symlink; the verifier reproduced the same code without `.env` and recovered the expected fail-closed result.

No orders, account contact, deployment, scheduler registration, or operational DB migration were performed.