### PR TITLE
fix(backfill): redesign latency sampling guard

### DIFF
--- a/research/kr_backfill/collect.py
+++ b/research/kr_backfill/collect.py
@@ -136,6 +136,9 @@ ON CONFLICT (time_utc, symbol, venue) DO NOTHING
 #: Latency regression threshold vs the Stage A baseline median (2.127 ms).
 LATENCY_ABORT_FACTOR = 5.0
 MAX_CONSECUTIVE_429 = 3
+DB_LATENCY_SAMPLES_PER_WINDOW = 15
+DB_LATENCY_CONSECUTIVE_WINDOWS = 2
+DB_LATENCY_RAW_HARD_STOP_MS = 100.0
 DB_INSERT_CONFLICT_ABORT_RATIO = 0.005
 CURSOR_OVERLAP_ABORT_RATIO = 0.40
 EXIT_SUCCESS = 0
@@ -430,11 +433,19 @@ class Guard:
         self.baseline = baseline_median_ms
         self.log = log
         self.consecutive_429: dict[str, int] = {}
+        self.latency_p95_breach_streak: dict[str, int] = {}
+
+    @staticmethod
+    def _nearest_rank_p95(samples: list[float]) -> float:
+        if not samples:
+            raise ValueError("latency samples must not be empty")
+        rank = max(1, (95 * len(samples) + 99) // 100)
+        return sorted(samples)[rank - 1]
 
     async def check(self, source: str) -> None:
         async with self.pool.acquire() as c:
-            samples = []
-            for _ in range(5):
+            samples: list[float] = []
+            for _ in range(DB_LATENCY_SAMPLES_PER_WINDOW):
                 t0 = time.perf_counter()
                 await c.fetch(
                     "SELECT time, close FROM public.kr_candles_1m "
@@ -442,19 +453,56 @@ class Guard:
                     "005930",
                     datetime.now(KST) - timedelta(days=1),
                 )
-                samples.append((time.perf_counter() - t0) * 1000)
+                elapsed_ms = (time.perf_counter() - t0) * 1000
+                samples.append(elapsed_ms)
+                if elapsed_ms > DB_LATENCY_RAW_HARD_STOP_MS:
+                    self.log.write(
+                        {
+                            "event": "latency_probe",
+                            "source": source,
+                            "window_complete": False,
+                            "sample_count": len(samples),
+                            "p95_ms": round(self._nearest_rank_p95(samples), 3),
+                            "raw_max_ms": round(max(samples), 3),
+                            "baseline_ms": self.baseline,
+                            "breach_streak": self.latency_p95_breach_streak.get(
+                                source, 0
+                            ),
+                            "hard_stop": "raw_gt_100ms",
+                        }
+                    )
+                    raise AbortStream(
+                        f"query latency raw {elapsed_ms:.2f}ms > "
+                        f"{DB_LATENCY_RAW_HARD_STOP_MS:.1f}ms"
+                    )
         med = statistics.median(samples)
+        p95 = self._nearest_rank_p95(samples)
+        threshold_ms = self.baseline * LATENCY_ABORT_FACTOR
+        streak = (
+            self.latency_p95_breach_streak.get(source, 0) + 1
+            if p95 > threshold_ms
+            else 0
+        )
+        self.latency_p95_breach_streak[source] = streak
         self.log.write(
             {
                 "event": "latency_probe",
                 "source": source,
+                "window_complete": True,
+                "sample_count": len(samples),
                 "median_ms": round(med, 3),
+                "p95_ms": round(p95, 3),
+                "raw_max_ms": round(max(samples), 3),
                 "baseline_ms": self.baseline,
+                "threshold_ms": round(threshold_ms, 3),
+                "breach_streak": streak,
             }
         )
-        if med > self.baseline * LATENCY_ABORT_FACTOR:
+        if streak >= DB_LATENCY_CONSECUTIVE_WINDOWS:
             raise AbortStream(
-                f"query latency {med:.2f}ms > {LATENCY_ABORT_FACTOR}x baseline {self.baseline}ms"
+                f"query latency p95 {p95:.2f}ms > {LATENCY_ABORT_FACTOR}x "
+                f"baseline {self.baseline}ms for "
+                f"{DB_LATENCY_CONSECUTIVE_WINDOWS} consecutive windows"
             )
 
     def note_429(self, source: str, is_429: bool) -> None:

--- a/tests/research/test_kr_backfill_count_witness_removal.py
+++ b/tests/research/test_kr_backfill_count_witness_removal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 
@@ -65,6 +66,15 @@ class _Log:
         self.records.append(record)
 
 
+def _perf_counter_ticks(durations_ms: list[float]) -> Iterator[float]:
+    ticks: list[float] = []
+    cursor = 0.0
+    for duration_ms in durations_ms:
+        ticks.extend((cursor, cursor + duration_ms / 1_000))
+        cursor += duration_ms / 1_000 + 0.001
+    return iter(ticks)
+
+
 @pytest.mark.asyncio
 async def test_count_witness_is_removed_but_latency_probe_remains(
     collect_module: ModuleType,
@@ -77,7 +87,7 @@ async def test_count_witness_is_removed_but_latency_probe_remains(
 
     assert not hasattr(guard, "witness")
     assert not hasattr(guard, "snapshot_witness")
-    assert len(pool.connection.queries) == 5
+    assert len(pool.connection.queries) == 15
     assert all(
         "SELECT time, close FROM public.kr_candles_1m" in query
         for query in pool.connection.queries
@@ -87,20 +97,82 @@ async def test_count_witness_is_removed_but_latency_probe_remains(
 
 
 @pytest.mark.asyncio
-async def test_latency_abort_is_preserved(
+async def test_latency_p95_requires_two_consecutive_windows(
     collect_module: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    ticks = iter([0.0, 0.006] * 5)
+    ticks = _perf_counter_ticks([6.0] * 30)
     monkeypatch.setattr(collect_module.time, "perf_counter", lambda: next(ticks))
     pool = _Pool()
     log = _Log()
     guard = collect_module.Guard(pool, baseline_median_ms=1.0, log=log)
 
-    with pytest.raises(collect_module.AbortStream, match="query latency"):
+    await guard.check("toss")
+    assert len(pool.connection.queries) == 15
+    assert log.records[-1]["p95_ms"] == 6.0
+    assert log.records[-1]["breach_streak"] == 1
+
+    with pytest.raises(collect_module.AbortStream, match="for 2 consecutive windows"):
         await guard.check("toss")
 
-    assert len(pool.connection.queries) == 5
-    assert [record["event"] for record in log.records] == ["latency_probe"]
+    assert len(pool.connection.queries) == 30
+    assert [record["event"] for record in log.records] == [
+        "latency_probe",
+        "latency_probe",
+    ]
+    assert log.records[-1]["breach_streak"] == 2
+
+
+@pytest.mark.asyncio
+async def test_latency_p95_streak_resets_after_normal_window(
+    collect_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ticks = _perf_counter_ticks([6.0] * 15 + [1.0] * 15 + [6.0] * 15)
+    monkeypatch.setattr(collect_module.time, "perf_counter", lambda: next(ticks))
+    guard = collect_module.Guard(_Pool(), baseline_median_ms=1.0, log=_Log())
+
+    await guard.check("kiwoom_live")
+    await guard.check("kiwoom_live")
+    await guard.check("kiwoom_live")
+
+    assert guard.latency_p95_breach_streak["kiwoom_live"] == 1
+
+
+@pytest.mark.asyncio
+async def test_latency_raw_over_100ms_aborts_immediately(
+    collect_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ticks = _perf_counter_ticks([150.0])
+    monkeypatch.setattr(collect_module.time, "perf_counter", lambda: next(ticks))
+    pool = _Pool()
+    log = _Log()
+    guard = collect_module.Guard(pool, baseline_median_ms=1.0, log=log)
+
+    with pytest.raises(collect_module.AbortStream, match="raw 150.00ms"):
+        await guard.check("kiwoom_live")
+
+    assert len(pool.connection.queries) == 1
+    assert log.records == [
+        {
+            "event": "latency_probe",
+            "source": "kiwoom_live",
+            "window_complete": False,
+            "sample_count": 1,
+            "p95_ms": 150.0,
+            "raw_max_ms": 150.0,
+            "baseline_ms": 1.0,
+            "breach_streak": 0,
+            "hard_stop": "raw_gt_100ms",
+        }
+    ]
+
+
+def test_latency_statistic_constants_are_hard_coded(
+    collect_module: ModuleType,
+) -> None:
+    assert collect_module.LATENCY_ABORT_FACTOR == 5.0
+    assert collect_module.DB_LATENCY_SAMPLES_PER_WINDOW == 15
+    assert collect_module.DB_LATENCY_CONSECUTIVE_WINDOWS == 2
+    assert collect_module.DB_LATENCY_RAW_HARD_STOP_MS == 100.0
 
 
 def test_consecutive_429_abort_is_preserved(collect_module: ModuleType) -> None:


### PR DESCRIPTION
## Summary
- keep the 5x latency threshold and replace the 5-sample median decision with two consecutive 15-sample nearest-rank p95 windows
- retain a non-configurable raw >100ms immediate stop
- log p95, raw max, window completeness, and breach streak

## Safety
- threshold unchanged
- no CLI/env off switch
- 429 guard and research-only write target unchanged

## Verification
- `uv run pytest tests/research -q` (138 passed)
- `make lint` (Ruff/format/ty passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database latency monitoring with configurable sampling and thresholds.
  * Latency checks now report median, p95, maximum values, and breach streaks.
  * Backfill operations stop immediately when a sample exceeds the hard limit or after repeated high-latency windows.

* **Bug Fixes**
  * Improved protection against sustained or sudden database performance degradation.
  * Added handling to reset latency breach tracking when performance returns to acceptable levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->