### PR TITLE
fix(ROB-1209): permit verified Alpaca cleanup sells

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -556,7 +556,8 @@ scope keep the broad recent-ledger safety behavior for global runners. Passing
 `legacy_cycle_blockers_as_warnings=True` is an explicit Alpaca Paper execution
 flow test-mode: residual positions and stale preview/approval packets are
 returned as warnings instead of blockers so operators can test buy/sell/order
-adjust/close flows on a used paper account. It does not weaken open-order
+adjust/close flows on a used paper account. That test-mode flag by itself does
+not weaken open-order
 conflicts, duplicate `client_order_id`, ledger/order/fill anomalies, missing
 linked sells, unclosed sell snapshots, unverified broker snapshots, or symbol
 mismatches; those remain
@@ -571,6 +572,23 @@ findings return the dry-run action hint
 surface an explicit cleanup-required state before any separately approved repair
 write. The preflight itself performs no broker mutation, no repair writes, and
 no direct DB backfill.
+
+ROB-1209 adds optional `candidate_order` context for an account-maintenance
+sell. It does **not** skip preflight or trust a `purpose`/`reduce_only` label.
+The report treats a candidate as reduce-only only when all of the following are
+true: `side="sell"`, an execution symbol is present, `qty` (or packet-style
+`max_qty`) is finite and positive, the positions snapshot is fresh/attested for
+the selected account, and the requested quantity is no greater than that exact
+live position. Notional-only, unknown-symbol, oversized, or buy candidates do
+not qualify. If an `approval_packet` supplies order fields, the candidate must
+also match its side, execution symbol, and any `max_qty`; a sell context cannot
+clear a buy packet. Under that narrow condition, `residual_position_exists`,
+`sell_source_evidence_invalid`, and `previous_buy_filled_sell_missing` remain
+visible as warnings rather than blocking the reducing sell. All other evidence
+gates remain unchanged: missing/stale snapshots, open orders, duplicate IDs,
+ledger/fill inconsistencies, unclosed prior sells, stale packets, and symbol
+mismatches still block. The submit boundary separately re-reads live available
+quantity before any broker POST.
 
 The broker snapshot is fail-closed (ROB-1130). `open_orders` and `positions` must
 both be supplied together with `broker_snapshot_fetched_at`, the time the
@@ -615,7 +633,9 @@ the verified position snapshot: still-held symbols produce the informational
 `open_position_without_sell_leg` finding, while symbols the broker no longer
 holds, buys already in `closed`/`final_reconciled`, and rows with no verified
 snapshot keep blocking under `previous_buy_filled_sell_missing` with a per-row
-`reason`.
+`reason`. The only exception is the ROB-1209 candidate context above: a verified,
+snapshot-bounded reducing sell may continue while retaining that historical
+lifecycle discrepancy as a warning; it never releases a buy or unbounded sell.
 
 The broker inspection tools instantiate `AlpacaPaperBrokerService`, so they
 inherit the
@@ -2049,7 +2069,7 @@ Response shape:
 
 ### route_request — advisory lane router (ROB-649)
 
-`route_request(intent, market)` maps a coarse intent
+`route_request(intent, market, purpose=None)` maps a coarse intent
 (`buy_analysis`/`profit_taking`/`discovery`/`market_brief`) to the standard tool
 sequence, advisory allowed/blocked tools, `get_trading_policy` thresholds +
 version stamp, and hard constraints for that lane. Deterministic; registered on
@@ -2097,6 +2117,20 @@ explicit mutation taxonomy or CI fails.
   empty sequence/allowed lists, and the static direct-mutation deny list with
   `blocked_actions_basis="static_fail_closed"`. It never substitutes
   `ALL_KNOWN_TOOLS`.
+
+**Account cleanup exception (ROB-1209):** only
+`route_request(intent="profit_taking", market="us"|"crypto",
+purpose="account_cleanup")` has a separate maintenance sequence:
+`alpaca_paper_list_positions` → `alpaca_paper_list_orders` →
+`alpaca_paper_execution_preflight_check` → `alpaca_paper_submit_order`. It
+allows exactly that Alpaca submit tool and keeps every other direct broker
+mutation in `blocked_actions`. If any required read/preflight/submit tool is
+absent, the route fails closed and does not expose submit as an allowed or
+sequenced shortcut. A buy intent with this purpose returns
+`purpose_not_supported_for_intent`. This remains advisory: the actual submit
+continues to require its trusted quote, live position/reservation checks, and
+`confirm=True`; the preflight itself must receive the exact bounded sell to
+recognize it as reduce-only.
 
 **Discovery non-regression:** discovery is outside ROB-1045 and retains its
 existing `toss_place_order` step and ROB-658 crypto/US generic `place_order`

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -154,6 +154,7 @@ async def alpaca_paper_execution_preflight_check(
     broker_snapshot_account_mode: str | None = None,
     snapshot_max_age_minutes: int = DEFAULT_SNAPSHOT_MAX_AGE_MINUTES,
     approval_packet: dict[str, Any] | None = None,
+    candidate_order: dict[str, Any] | None = None,
     expected_signal_symbol: str | None = None,
     expected_execution_symbol: str | None = None,
     stale_after_minutes: int = 30,
@@ -182,6 +183,15 @@ async def alpaca_paper_execution_preflight_check(
     ``alpaca_paper_list_positions`` and
     ``alpaca_paper_list_orders(status="open")`` immediately before this call and
     pass the ``account_mode`` those reads echo back.
+
+    ``candidate_order`` is optional preflight context, never an execution
+    bypass.  A residual-position/lifecycle finding is downgraded only when it
+    describes a finite positive-quantity ``side="sell"`` whose execution symbol
+    is present in this verified broker snapshot and whose quantity is no greater
+    than that live position.  A cleanup/purpose label, a buy, a notional-only
+    sell, or an over-sized sell leaves the normal fail-closed blockers intact.
+    If ``approval_packet`` provides order fields, they must match this candidate;
+    a sell context cannot clear a buy packet.
 
     When a correlation/candidate/client/briefing scope is provided directly or
     via approval_packet, stale and symbol-context checks evaluate only rows in
@@ -256,6 +266,7 @@ async def alpaca_paper_execution_preflight_check(
         expected_account_mode=selected_account_mode,
         snapshot_account_mode=broker_snapshot_account_mode,
         approval_packet=approval_packet,
+        candidate_order=candidate_order,
         expected_signal_symbol=expected_signal_symbol,
         expected_execution_symbol=expected_execution_symbol,
         stale_after_minutes=stale_after_minutes,

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -182,6 +182,48 @@ ROUTE_CONTRACT_VERSION = "proposal-led-v1"
 PROPOSAL_TOOL = "order_proposal_create"
 PROPOSAL_LED_LANES: frozenset[str] = frozenset({"buy", "sell"})
 
+# ROB-1209: maintenance is not a strategic order.  This narrow route is still
+# advisory, but it expresses the only direct broker action an account-cleanup
+# caller may be shown: a preflighted, quantity-bounded Alpaca Paper sell.  The
+# route never grants generic place/cancel/modify access and purpose alone is not
+# enough to make preflight treat an order as reducing.
+ACCOUNT_CLEANUP_PURPOSE = "account_cleanup"
+ACCOUNT_CLEANUP_MARKETS: frozenset[str] = frozenset({"us", "crypto"})
+ACCOUNT_CLEANUP_DIRECT_TOOL = "alpaca_paper_submit_order"
+ACCOUNT_CLEANUP_REQUIRED_TOOLS: frozenset[str] = frozenset(
+    {
+        "alpaca_paper_list_positions",
+        "alpaca_paper_list_orders",
+        "alpaca_paper_execution_preflight_check",
+        ACCOUNT_CLEANUP_DIRECT_TOOL,
+    }
+)
+ACCOUNT_CLEANUP_SEQUENCE: tuple[dict[str, str], ...] = (
+    {
+        "tool": "alpaca_paper_list_positions",
+        "purpose": "fresh current position evidence for an exact reducing sell",
+    },
+    {
+        "tool": "alpaca_paper_list_orders",
+        "purpose": "fresh open-order evidence before maintenance execution",
+    },
+    {
+        "tool": "alpaca_paper_execution_preflight_check",
+        "purpose": "evaluate the exact sell as snapshot-verified reduce-only",
+    },
+    {
+        "tool": ACCOUNT_CLEANUP_DIRECT_TOOL,
+        "purpose": "submit only after passing preflight and per-call confirmation",
+    },
+)
+ACCOUNT_CLEANUP_HARD_CONSTRAINTS: tuple[str, ...] = (
+    "account_cleanup is sell-only: a finite positive qty must be no greater than the verified current position for the same execution symbol",
+    "purpose text alone never downgrades preflight; buy, notional-only, unknown-symbol, over-sized, stale, or unattested candidates stay blocked",
+    "preflight remains required: unverified snapshots, open orders, duplicate IDs, fill/ledger mismatches, and stale packets remain blockers",
+    "only alpaca_paper_submit_order is allowed directly; all other direct broker mutations remain blocked",
+    "alpaca_paper_submit_order keeps its existing trusted quote, current-position, reservation, and confirm=True gates",
+)
+
 # The legacy MUTATION_TOOLS bucket intentionally remains public and broad for
 # backwards compatibility. ROB-1045 overlays explicit, disjoint action classes
 # so proposal-led lanes can fail closed on direct broker mutations without also
@@ -527,7 +569,30 @@ def _route_contract(
     lane: str,
     *,
     registered_tools: set[str] | None,
+    purpose: str | None = None,
 ) -> dict[str, Any]:
+    if purpose == ACCOUNT_CLEANUP_PURPOSE:
+        required_tools = sorted(ACCOUNT_CLEANUP_REQUIRED_TOOLS)
+        missing_required_tools = (
+            required_tools
+            if registered_tools is None
+            else sorted(set(required_tools) - registered_tools)
+        )
+        execution_ready = registered_tools is not None and not missing_required_tools
+        return {
+            "version": "cleanup-reduce-only-v1",
+            "state": "ready" if execution_ready else "degraded",
+            "execution_mode": "cleanup_reduce_only",
+            "execution_ready": execution_ready,
+            "proposal_tool": None,
+            "approval_channel": "per_call_confirm",
+            "human_approval_required": True,
+            "preview_owner": "preflight_reduce_only",
+            "reconcile_requirement": "broker_evidence",
+            "required_tools": required_tools,
+            "missing_required_tools": missing_required_tools,
+        }
+
     proposal_led = lane in PROPOSAL_LED_LANES
     required_tools = sorted(PROPOSAL_LED_TOOLS) if proposal_led else []
     missing_required_tools = (
@@ -580,6 +645,7 @@ def build_registry_unavailable_plan(
     *,
     verdict_thresholds: dict[str, Any],
     policy_version: dict[str, str],
+    purpose: str | None = None,
 ) -> dict[str, Any]:
     """Return a stable fail-closed response when live registry state is unknown."""
     lane = INTENT_TO_LANE[intent]
@@ -590,14 +656,23 @@ def build_registry_unavailable_plan(
         "intent": intent,
         "lane": lane,
         "market": market,
+        "purpose": purpose,
         "standard_tool_sequence": [],
         "allowed_tools": [],
         "blocked_actions": sorted(DIRECT_BROKER_MUTATION_TOOLS),
         "blocked_actions_basis": "static_fail_closed",
-        "route_contract": _route_contract(lane, registered_tools=None),
+        "route_contract": _route_contract(
+            lane,
+            registered_tools=None,
+            purpose=purpose,
+        ),
         "verdict_thresholds": verdict_thresholds,
         "policy_version": policy_version,
-        "hard_constraints": list(HARD_CONSTRAINTS[lane]),
+        "hard_constraints": list(
+            ACCOUNT_CLEANUP_HARD_CONSTRAINTS
+            if purpose == ACCOUNT_CLEANUP_PURPOSE
+            else HARD_CONSTRAINTS[lane]
+        ),
     }
 
 
@@ -608,10 +683,68 @@ def build_route_plan(
     registered_tools: set[str],
     verdict_thresholds: dict[str, Any],
     policy_version: dict[str, str],
+    purpose: str | None = None,
 ) -> dict[str, Any]:
     """Assemble the deterministic route plan. Pure — no IO. Caller validates
     intent/market and resolves policy before calling."""
     lane = INTENT_TO_LANE[intent]
+    account_cleanup = purpose == ACCOUNT_CLEANUP_PURPOSE
+    if account_cleanup and (
+        intent != "profit_taking" or market not in ACCOUNT_CLEANUP_MARKETS
+    ):
+        raise ValueError(
+            "account_cleanup is only supported for US/crypto profit_taking"
+        )
+
+    if account_cleanup:
+        route_contract = _route_contract(
+            lane,
+            registered_tools=registered_tools,
+            purpose=purpose,
+        )
+        success = route_contract["execution_ready"]
+        sequence = [
+            step
+            for step in ACCOUNT_CLEANUP_SEQUENCE
+            if step["tool"] in registered_tools
+        ]
+        # A missing read/preflight tool must not leave a visible submit shortcut.
+        # The advisory router cannot enforce a tool call, so fail closed in its
+        # own output rather than relying on callers to notice success=false.
+        if not success:
+            sequence = [
+                step for step in sequence if step["tool"] != ACCOUNT_CLEANUP_DIRECT_TOOL
+            ]
+        standard_tool_sequence = [
+            {"step": i, "tool": step["tool"], "purpose": step["purpose"]}
+            for i, step in enumerate(sequence, start=1)
+        ]
+        allowed = (
+            set(READ_ONLY_ADVISORY_TOOLS) | set(ACCOUNT_CLEANUP_REQUIRED_TOOLS)
+        ) & registered_tools
+        if not success:
+            allowed.discard(ACCOUNT_CLEANUP_DIRECT_TOOL)
+        blocked = (MUTATION_TOOLS & registered_tools) - allowed
+        result: dict[str, Any] = {
+            "success": success,
+            "degraded": not success,
+            "intent": intent,
+            "lane": lane,
+            "market": market,
+            "purpose": purpose,
+            "standard_tool_sequence": standard_tool_sequence,
+            "allowed_tools": sorted(allowed),
+            "blocked_actions": sorted(blocked),
+            "blocked_actions_basis": "live_registered_surface",
+            "route_contract": route_contract,
+            "verdict_thresholds": verdict_thresholds,
+            "policy_version": policy_version,
+            "hard_constraints": list(ACCOUNT_CLEANUP_HARD_CONSTRAINTS),
+        }
+        if not success:
+            result["error"] = "required_route_tool_unavailable"
+        return result
+
     lane_tools = lane_tool_names(lane)
     proposal_led = lane in PROPOSAL_LED_LANES
     lane_place_tools = (
@@ -657,7 +790,11 @@ def build_route_plan(
     )
     allowed = allowed_candidates & registered_tools
     blocked = (MUTATION_TOOLS & registered_tools) - allowed
-    route_contract = _route_contract(lane, registered_tools=registered_tools)
+    route_contract = _route_contract(
+        lane,
+        registered_tools=registered_tools,
+        purpose=purpose,
+    )
     success = route_contract["execution_ready"]
 
     result: dict[str, Any] = {
@@ -666,6 +803,7 @@ def build_route_plan(
         "intent": intent,
         "lane": lane,
         "market": market,
+        "purpose": purpose,
         "standard_tool_sequence": standard_tool_sequence,
         "allowed_tools": sorted(allowed),
         "blocked_actions": sorted(blocked),
@@ -687,6 +825,12 @@ __all__ = [
     "LANE_SEQUENCES",
     "HARD_CONSTRAINTS",
     "ROUTE_CONTRACT_VERSION",
+    "ACCOUNT_CLEANUP_PURPOSE",
+    "ACCOUNT_CLEANUP_MARKETS",
+    "ACCOUNT_CLEANUP_DIRECT_TOOL",
+    "ACCOUNT_CLEANUP_REQUIRED_TOOLS",
+    "ACCOUNT_CLEANUP_SEQUENCE",
+    "ACCOUNT_CLEANUP_HARD_CONSTRAINTS",
     "PROPOSAL_TOOL",
     "PROPOSAL_LED_LANES",
     "DIRECT_BROKER_MUTATION_TOOLS",

--- a/app/mcp_server/tooling/route_request_registration.py
+++ b/app/mcp_server/tooling/route_request_registration.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from app.mcp_server.tooling.route_request_lanes import (
+    ACCOUNT_CLEANUP_MARKETS,
+    ACCOUNT_CLEANUP_PURPOSE,
     INTENT_TO_LANE,
     LANE_TO_POLICY_LANE,
     VALID_MARKETS,
@@ -62,7 +64,9 @@ async def _live_registered_names(mcp: Any) -> _RegistrySnapshot:
 
 def register_route_request_tools(mcp: FastMCP) -> None:
     async def route_request(
-        intent: str | None = None, market: str | None = None
+        intent: str | None = None,
+        market: str | None = None,
+        purpose: str | None = None,
     ) -> dict[str, Any]:
         # ROB-659: intent/market are optional in the schema so a MISSING arg
         # returns a deterministic success=false envelope instead of a FastMCP
@@ -92,6 +96,33 @@ def register_route_request_tools(mcp: FastMCP) -> None:
                 "error": "unknown_market",
                 "detail": f"unknown market {market!r}; valid: {sorted(VALID_MARKETS)}",
             }
+        normalized_purpose = (purpose or "").strip() or None
+        if normalized_purpose not in {None, ACCOUNT_CLEANUP_PURPOSE}:
+            return {
+                "success": False,
+                "error": "unknown_purpose",
+                "detail": (
+                    f"unknown purpose {purpose!r}; valid: {[ACCOUNT_CLEANUP_PURPOSE]}"
+                ),
+            }
+        if normalized_purpose == ACCOUNT_CLEANUP_PURPOSE:
+            if intent != "profit_taking":
+                return {
+                    "success": False,
+                    "error": "purpose_not_supported_for_intent",
+                    "detail": (
+                        "purpose='account_cleanup' requires intent='profit_taking'"
+                    ),
+                }
+            if market not in ACCOUNT_CLEANUP_MARKETS:
+                return {
+                    "success": False,
+                    "error": "purpose_not_supported_for_market",
+                    "detail": (
+                        "purpose='account_cleanup' supports markets "
+                        f"{sorted(ACCOUNT_CLEANUP_MARKETS)}"
+                    ),
+                }
         lane = INTENT_TO_LANE[intent]
         policy_lane = LANE_TO_POLICY_LANE[lane]
         version = policy_version_stamp()
@@ -118,6 +149,7 @@ def register_route_request_tools(mcp: FastMCP) -> None:
                 market,
                 verdict_thresholds=verdict_thresholds,
                 policy_version=version,
+                purpose=normalized_purpose,
             )
         return build_route_plan(
             intent,
@@ -125,6 +157,7 @@ def register_route_request_tools(mcp: FastMCP) -> None:
             registered_tools=set(registry_snapshot.names),
             verdict_thresholds=verdict_thresholds,
             policy_version=version,
+            purpose=normalized_purpose,
         )
 
     _ = mcp.tool(
@@ -134,7 +167,11 @@ def register_route_request_tools(mcp: FastMCP) -> None:
             "sequence, allowed/blocked tools, policy thresholds + version stamp, "
             "and hard constraints for that decision lane. Args: intent in "
             "{buy_analysis, profit_taking, discovery, market_brief}, market in "
-            "{kr, us, crypto} (required). Deterministic (same input -> same "
+            "{kr, us, crypto} (required), purpose optional. The only purpose "
+            "exception is purpose='account_cleanup' for US/crypto "
+            "profit_taking: it exposes a read -> preflight -> exact reducing "
+            "Alpaca Paper sell sequence, while keeping every other direct broker "
+            "mutation blocked. Deterministic (same input -> same "
             "output). ADVISORY ONLY — it does not block anything; it echoes "
             "get_trading_policy (ROB-646) with policy_version so a verdict can "
             "cite the criteria. Buy/sell use the proposal-led-v1 contract: "

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -63,6 +63,7 @@ class PaperExecutionPreflightReport:
     anomalies: tuple[PaperExecutionAnomaly, ...]
     counts: dict[str, int]
     broker_snapshot: dict[str, Any] = field(default_factory=dict)
+    candidate_reduction: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -72,6 +73,7 @@ class PaperExecutionPreflightReport:
             "stale_after_minutes": self.stale_after_minutes,
             "counts": self.counts,
             "broker_snapshot": self.broker_snapshot,
+            "candidate_reduction": self.candidate_reduction,
             "anomalies": [a.to_dict() for a in self.anomalies],
         }
 
@@ -347,6 +349,109 @@ def _position_qty_by_symbol(
             continue
         quantities[symbol] = quantities.get(symbol, Decimal("0")) + qty
     return quantities, invalid_symbols
+
+
+def _assess_candidate_reduction(
+    *,
+    candidate_order: Mapping[str, Any] | None,
+    positions: Iterable[Any],
+    positions_are_evidence: bool,
+    approval_packet: Any = None,
+) -> dict[str, Any]:
+    """Determine whether a candidate is a *verified* reducing sell.
+
+    A purpose label is deliberately not an input to this decision.  The only
+    safe way to relax "account must already be flat" cycle checks is to prove
+    from the current, verified broker snapshot that the exact candidate is a
+    positive-quantity sell no larger than the position it names.  Notional-only
+    sells do not qualify because a price move could make their share quantity
+    exceed the position.
+
+    This is preflight context, not an order authorization.  The submit boundary
+    still obtains its own live position/availability evidence immediately before
+    any broker POST.
+    """
+    assessment: dict[str, Any] = {
+        "provided": candidate_order is not None,
+        "reduce_only": False,
+        "reason": None,
+        "side": None,
+        "execution_symbol": None,
+        "qty": None,
+        "position_qty": None,
+    }
+    if candidate_order is None:
+        assessment["reason"] = "candidate_order_missing"
+        return assessment
+
+    side = _clean_lower(candidate_order.get("side"))
+    symbol = _normalize_symbol(
+        candidate_order.get("execution_symbol") or candidate_order.get("symbol")
+    )
+    raw_qty = candidate_order.get("qty")
+    if raw_qty is None:
+        # PaperApprovalPacket calls this guard max_qty; accepting it keeps an
+        # already-frozen packet usable as preflight context without trusting a
+        # notional-only order as reduce-only.
+        raw_qty = candidate_order.get("max_qty")
+    qty = _strict_decimal(raw_qty)
+    assessment.update(
+        {
+            "side": side,
+            "execution_symbol": symbol or None,
+            "qty": str(qty) if qty is not None else None,
+        }
+    )
+
+    if side != "sell":
+        assessment["reason"] = "candidate_side_not_sell"
+        return assessment
+    if not symbol:
+        assessment["reason"] = "candidate_execution_symbol_missing"
+        return assessment
+    if qty is None or qty <= Decimal("0"):
+        assessment["reason"] = "candidate_qty_missing_or_invalid"
+        return assessment
+    # When the caller supplies an approval packet for the order under review,
+    # its direction and execution symbol must agree with the candidate context.
+    # Otherwise a caller could describe a reducing sell while asking preflight to
+    # assess a different (for example buy) packet. A packet without either
+    # order field remains a scope-only packet and is not treated as a mismatch.
+    packet_side = _clean_lower(_packet_value(approval_packet, "side"))
+    packet_symbol = _normalize_symbol(
+        _packet_value(approval_packet, "execution_symbol")
+        or _packet_value(approval_packet, "symbol")
+    )
+    if packet_side is not None and packet_side != side:
+        assessment["reason"] = "candidate_side_mismatch_approval_packet"
+        return assessment
+    if packet_symbol and packet_symbol != symbol:
+        assessment["reason"] = "candidate_symbol_mismatch_approval_packet"
+        return assessment
+    packet_max_qty = _strict_decimal(_packet_value(approval_packet, "max_qty"))
+    if packet_max_qty is not None and qty > packet_max_qty:
+        assessment["reason"] = "candidate_qty_exceeds_approval_packet"
+        return assessment
+    if not positions_are_evidence:
+        assessment["reason"] = "broker_positions_unverified"
+        return assessment
+
+    position_qty_by_symbol, invalid_symbols = _position_qty_by_symbol(positions)
+    if symbol in invalid_symbols:
+        assessment["reason"] = "candidate_position_qty_invalid"
+        return assessment
+    position_qty = position_qty_by_symbol.get(symbol, Decimal("0"))
+    assessment["position_qty"] = str(position_qty)
+    if position_qty <= Decimal("0"):
+        assessment["reason"] = "candidate_position_not_positive"
+        return assessment
+    if qty > position_qty:
+        assessment["reason"] = "candidate_qty_exceeds_position"
+        return assessment
+
+    assessment["reduce_only"] = True
+    assessment["reason"] = "verified_sell_qty_within_current_position"
+    return assessment
 
 
 def _ledger_row_broker_symbol(row: Any) -> str:
@@ -750,6 +855,7 @@ def build_paper_execution_preflight_report(
     expected_account_mode: str | None = None,
     snapshot_account_mode: str | None = None,
     approval_packet: dict[str, Any] | None = None,
+    candidate_order: Mapping[str, Any] | None = None,
     expected_signal_symbol: str | None = None,
     expected_execution_symbol: str | None = None,
     now: datetime | None = None,
@@ -791,6 +897,13 @@ def build_paper_execution_preflight_report(
             is not evidence about this account.
         approval_packet: Optional preview/approval packet being considered for
             execution. Used for duplicate, stale, and symbol checks.
+        candidate_order: Optional proposed order context. Only a ``side="sell"``
+            candidate with an execution symbol and a finite positive ``qty`` (or
+            packet-style ``max_qty``) no greater than that symbol's *verified*
+            current broker position is treated as reduce-only. A purpose label,
+            sell notional, or caller-supplied ``reduce_only`` boolean never
+            qualifies by itself. When an approval packet supplies side, symbol,
+            or ``max_qty``, the candidate must agree with those fields.
         expected_signal_symbol: Optional symbol from the signal artifact.
         expected_execution_symbol: Optional symbol expected at Alpaca Paper.
         now: Clock injection for deterministic tests.
@@ -911,7 +1024,23 @@ def build_paper_execution_preflight_report(
         if snapshot_evidence_required
         else bool(position_rows)
     ) and not malformed_positions
+    # A candidate can relax cycle-only findings only for the actual account
+    # whose position it reduces. Historical/audit callers may opt out of the
+    # general snapshot blocker, but that must never turn an unattested row list
+    # into reducing-order evidence.
+    positions_verified_for_reduction = (
+        bool(snapshot_state["positions"]["verified"])
+        and bool(account_state["verified"])
+        and not malformed_positions
+    )
     orders = orders if orders is not None else []
+    candidate_reduction = _assess_candidate_reduction(
+        candidate_order=candidate_order,
+        positions=position_rows,
+        positions_are_evidence=positions_verified_for_reduction,
+        approval_packet=approval_packet,
+    )
+    verified_reducing_sell = bool(candidate_reduction["reduce_only"])
 
     # 1. Unexpected open orders.
     open_snapshot = [o for o in orders if _is_open_order(o)]
@@ -944,23 +1073,29 @@ def build_paper_execution_preflight_report(
         if qty is not None and qty != Decimal("0"):
             residual_positions.append((position, qty))
     if residual_positions:
+        residual_details: dict[str, Any] = {
+            "count": len(residual_positions),
+            "positions": [
+                {
+                    "symbol": p.get("symbol"),
+                    "qty": str(qty),
+                    "asset_class": p.get("asset_class"),
+                }
+                for p, qty in residual_positions
+            ],
+        }
+        if verified_reducing_sell:
+            residual_details["directional_context"] = candidate_reduction
         add(
             "residual_position_exists",
             PaperExecutionAnomalySeverity.warning
-            if legacy_cycle_blockers_as_warnings
+            if verified_reducing_sell or legacy_cycle_blockers_as_warnings
             else PaperExecutionAnomalySeverity.block,
-            "Residual Alpaca Paper position exists before starting a new cycle",
-            {
-                "count": len(residual_positions),
-                "positions": [
-                    {
-                        "symbol": p.get("symbol"),
-                        "qty": str(qty),
-                        "asset_class": p.get("asset_class"),
-                    }
-                    for p, qty in residual_positions
-                ],
-            },
+            "Residual Alpaca Paper position exists before starting a new cycle"
+            if not verified_reducing_sell
+            else "Residual Alpaca Paper position is the verified target of a "
+            "reduce-only sell candidate",
+            residual_details,
         )
 
     # 3. Duplicate client_order_id, both within the ledger slice and against
@@ -1007,15 +1142,25 @@ def build_paper_execution_preflight_report(
         source_evidence_issues,
     ) = _match_filled_buys_to_sells(ledger)
     if source_evidence_issues:
+        source_evidence_details: dict[str, Any] = {
+            "count": len(source_evidence_issues),
+            "rows": source_evidence_issues[:10],
+        }
+        if verified_reducing_sell:
+            source_evidence_details["directional_context"] = candidate_reduction
         add(
             "sell_source_evidence_invalid",
-            PaperExecutionAnomalySeverity.block,
+            # Historical source-link corruption still needs repair and stays
+            # visible, but it cannot make a separately verified live-position
+            # sell increase exposure. The real submit path re-checks available
+            # quantity (and automated sells re-check their exact source) before
+            # sending anything to the broker.
+            PaperExecutionAnomalySeverity.warning
+            if verified_reducing_sell
+            else PaperExecutionAnomalySeverity.block,
             "Explicit sell source evidence is ambiguous, incomplete, or "
             "inconsistent with the source buy",
-            {
-                "count": len(source_evidence_issues),
-                "rows": source_evidence_issues[:10],
-            },
+            source_evidence_details,
         )
     if legacy_buy_sell_matches:
         add(
@@ -1105,14 +1250,23 @@ def build_paper_execution_preflight_report(
             },
         )
     if unresolved_buys:
+        unresolved_buy_details: dict[str, Any] = {
+            "count": len(unresolved_buys),
+            "rows": unresolved_buys[:10],
+        }
+        if verified_reducing_sell:
+            unresolved_buy_details["directional_context"] = candidate_reduction
         add(
             "previous_buy_filled_sell_missing",
-            PaperExecutionAnomalySeverity.block,
+            # "A previous buy has no sell" is an audit/lifecycle discrepancy,
+            # not evidence that a newly proposed, snapshot-bounded sell would
+            # add risk. Keep it as a warning only for the verified reducing
+            # direction; a buy or an unbounded sell remains blocked above.
+            PaperExecutionAnomalySeverity.warning
+            if verified_reducing_sell
+            else PaperExecutionAnomalySeverity.block,
             "A previous filled buy has no linked sell ledger row",
-            {
-                "count": len(unresolved_buys),
-                "rows": unresolved_buys[:10],
-            },
+            unresolved_buy_details,
         )
 
     # 5. Sell filled but final position not closed.
@@ -1421,6 +1575,7 @@ def build_paper_execution_preflight_report(
         anomalies=tuple(anomalies),
         counts=counts,
         broker_snapshot=snapshot_state,
+        candidate_reduction=candidate_reduction,
     )
 
 

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -312,6 +312,79 @@ async def test_execution_preflight_check_reflects_held_position(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_execution_preflight_check_passes_verified_reduce_only_candidate(
+    monkeypatch,
+):
+    """ROB-1209: public preflight keeps cleanup inside the gate, not around it."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        open_orders=[],
+        positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+        broker_snapshot_account_mode="alpaca_paper",
+        candidate_order={
+            "side": "sell",
+            "execution_symbol": "UBER",
+            "qty": "1",
+        },
+    )
+
+    assert result["status"] == "pass"
+    assert result["should_block"] is False
+    assert result["candidate_reduction"]["reduce_only"] is True
+    residual = next(
+        item
+        for item in result["anomalies"]
+        if item["check_id"] == "residual_position_exists"
+    )
+    assert residual["severity"] == "warning"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("account_mode", ["alpaca_paper_lab", "alpaca_paper_crypto"])
+async def test_execution_preflight_keeps_nondefault_account_scope_unchanged(
+    monkeypatch,
+    account_mode,
+):
+    """Lab and c60c74 clean-account snapshots remain independently attested."""
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+    captured_account_modes: list[str | None] = []
+
+    def _service_factory(db, account_mode=None):  # noqa: ANN001
+        captured_account_modes.append(account_mode)
+        return mock_svc
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
+        _service_factory,
+    )
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        account_mode=account_mode,
+        open_orders=[],
+        positions=[],
+        broker_snapshot_fetched_at=datetime.now(UTC).isoformat(),
+        broker_snapshot_account_mode=account_mode,
+    )
+
+    assert result["status"] == "pass"
+    assert result["account_mode"] == account_mode
+    assert result["candidate_reduction"]["reason"] == "candidate_order_missing"
+    assert captured_account_modes == [account_mode]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_execution_preflight_check_blocks_snapshot_from_other_account(
     monkeypatch,
 ):

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -128,6 +128,200 @@ def test_residual_position_can_warn_in_paper_execution_test_mode():
     assert report.counts["block"] == 0
 
 
+# ---------------------------------------------------------------------------
+# ROB-1209: a verified reducing sell must not be blocked by its own cleanup
+# ---------------------------------------------------------------------------
+
+
+def _rob1209_cleanup_fixture():
+    """Return the three historical cycle findings from the blocked cleanup run.
+
+    The fixture intentionally keeps the source-link and missing-leg defects in
+    the ledger.  The candidate is a different, current broker position so this
+    proves that the cleanup direction is assessed from live position evidence,
+    not by deleting or repairing historical ledger rows.
+    """
+    return {
+        "ledger_rows": [
+            _row(
+                client_order_id="rob1209-buy-missing",
+                execution_symbol="DPZ",
+                signal_symbol="DPZ",
+                filled_qty="1",
+            ),
+            _row(
+                client_order_id="rob1209-sell-invalid-source",
+                side="sell",
+                lifecycle_state="planned",
+                order_status="new",
+                execution_symbol="AAPL",
+                signal_symbol="AAPL",
+                raw_responses={
+                    "payload": {"source_client_order_id": "missing-buy-source"}
+                },
+            ),
+        ],
+        **_verified_snapshot(
+            positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}]
+        ),
+        # The reduction exception needs the identity of the selected account as
+        # well as fresh positions; a row list without an account claim cannot
+        # prove which Alpaca Paper account it reduces.
+        "expected_account_mode": "alpaca_paper",
+        "snapshot_account_mode": "alpaca_paper",
+    }
+
+
+@pytest.mark.unit
+def test_rob1209_verified_reduce_only_sell_passes_without_hiding_history():
+    report = build_paper_execution_preflight_report(
+        **_rob1209_cleanup_fixture(),
+        candidate_order={
+            "side": "sell",
+            "execution_symbol": "UBER",
+            "qty": "1",
+            "purpose": "account_cleanup",
+        },
+    )
+
+    assert report.status == "pass"
+    assert report.should_block is False
+    assert report.candidate_reduction == {
+        "provided": True,
+        "reduce_only": True,
+        "reason": "verified_sell_qty_within_current_position",
+        "side": "sell",
+        "execution_symbol": "UBER",
+        "qty": "1",
+        "position_qty": "5",
+    }
+    for check_id in (
+        "residual_position_exists",
+        "sell_source_evidence_invalid",
+        "previous_buy_filled_sell_missing",
+    ):
+        finding = _anomaly(report, check_id)
+        assert finding.severity == PaperExecutionAnomalySeverity.warning
+        assert finding.details["directional_context"]["reduce_only"] is True
+
+
+@pytest.mark.unit
+def test_rob1209_cleanup_label_cannot_unblock_a_strategy_buy():
+    report = build_paper_execution_preflight_report(
+        **_rob1209_cleanup_fixture(),
+        candidate_order={
+            "side": "buy",
+            "execution_symbol": "UBER",
+            "qty": "1",
+            "purpose": "account_cleanup",
+        },
+    )
+
+    assert report.should_block is True
+    assert report.candidate_reduction["reduce_only"] is False
+    assert report.candidate_reduction["reason"] == "candidate_side_not_sell"
+    assert _blocking_check_ids(report) == {
+        "residual_position_exists",
+        "sell_source_evidence_invalid",
+        "previous_buy_filled_sell_missing",
+    }
+
+
+@pytest.mark.unit
+def test_rob1209_sell_context_cannot_unblock_a_buy_approval_packet():
+    """A reducing candidate must be the same order as a supplied packet."""
+    report = build_paper_execution_preflight_report(
+        **_verified_snapshot(
+            positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}]
+        ),
+        expected_account_mode="alpaca_paper",
+        snapshot_account_mode="alpaca_paper",
+        candidate_order={
+            "side": "sell",
+            "execution_symbol": "UBER",
+            "qty": "1",
+        },
+        approval_packet={
+            "side": "buy",
+            "signal_symbol": "UBER",
+            "execution_symbol": "UBER",
+        },
+    )
+
+    assert report.should_block is True
+    assert report.candidate_reduction["reduce_only"] is False
+    assert (
+        report.candidate_reduction["reason"]
+        == "candidate_side_mismatch_approval_packet"
+    )
+    assert _blocking_check_ids(report) == {"residual_position_exists"}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("candidate_order", "reason"),
+    [
+        (
+            {"side": "sell", "execution_symbol": "UBER", "notional": "10"},
+            "candidate_qty_missing_or_invalid",
+        ),
+        (
+            {"side": "sell", "execution_symbol": "UBER", "qty": "6"},
+            "candidate_qty_exceeds_position",
+        ),
+    ],
+)
+def test_rob1209_unbounded_or_oversized_sell_stays_blocked(candidate_order, reason):
+    report = build_paper_execution_preflight_report(
+        **_rob1209_cleanup_fixture(),
+        candidate_order=candidate_order,
+    )
+
+    assert report.should_block is True
+    assert report.candidate_reduction["reduce_only"] is False
+    assert report.candidate_reduction["reason"] == reason
+    assert "residual_position_exists" in _blocking_check_ids(report)
+
+
+@pytest.mark.unit
+def test_rob1209_reduce_only_requires_an_attested_position_snapshot():
+    report = build_paper_execution_preflight_report(
+        positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}],
+        open_orders=[],
+        candidate_order={"side": "sell", "execution_symbol": "UBER", "qty": "1"},
+    )
+
+    assert report.should_block is True
+    assert report.candidate_reduction["reduce_only"] is False
+    assert report.candidate_reduction["reason"] == "broker_positions_unverified"
+    assert _blocking_check_ids(report) == {
+        "broker_snapshot_unverified",
+        "residual_position_exists",
+    }
+
+
+@pytest.mark.unit
+def test_rob1209_reduce_only_requires_selected_account_attestation():
+    """Fresh rows from an unspecified Alpaca account cannot relax a cycle gate."""
+    report = build_paper_execution_preflight_report(
+        **_verified_snapshot(
+            positions=[{"symbol": "UBER", "qty": "5", "asset_class": "us_equity"}]
+        ),
+        candidate_order={"side": "sell", "execution_symbol": "UBER", "qty": "1"},
+    )
+
+    assert report.should_block is True
+    assert report.candidate_reduction["reduce_only"] is False
+    assert report.candidate_reduction["reason"] == "broker_positions_unverified"
+    assert report.broker_snapshot["account"] == {
+        "expected": None,
+        "attested": None,
+        "verified": False,
+        "reason": "account_scope_not_declared",
+    }
+    assert _blocking_check_ids(report) == {"residual_position_exists"}
+
+
 @pytest.mark.unit
 def test_duplicate_client_order_id_blocks_against_packet_and_ledger():
     report = build_paper_execution_preflight_report(

--- a/tests/test_route_request.py
+++ b/tests/test_route_request.py
@@ -107,6 +107,68 @@ def test_profit_taking_labels_kr_single_share_rule_as_shadow_only():
     assert rule["proposal"]["auto_approve"] is False
 
 
+def test_account_cleanup_route_allows_only_alpaca_reduce_only_path():
+    out = asyncio.run(
+        _route_tool()(
+            intent="profit_taking",
+            market="us",
+            purpose="account_cleanup",
+        )
+    )
+
+    assert out["success"] is True
+    assert out["purpose"] == "account_cleanup"
+    assert out["route_contract"]["execution_mode"] == "cleanup_reduce_only"
+    assert [step["tool"] for step in out["standard_tool_sequence"]] == [
+        "alpaca_paper_list_positions",
+        "alpaca_paper_list_orders",
+        "alpaca_paper_execution_preflight_check",
+        "alpaca_paper_submit_order",
+    ]
+    assert "alpaca_paper_submit_order" in out["allowed_tools"]
+    assert "alpaca_paper_submit_order" not in out["blocked_actions"]
+    assert (DIRECT_BROKER_MUTATION_TOOLS - {"alpaca_paper_submit_order"}) <= set(
+        out["blocked_actions"]
+    )
+
+
+def test_account_cleanup_purpose_cannot_unlock_a_strategy_buy():
+    out = asyncio.run(
+        _route_tool()(
+            intent="buy_analysis",
+            market="us",
+            purpose="account_cleanup",
+        )
+    )
+
+    assert out["success"] is False
+    assert out["error"] == "purpose_not_supported_for_intent"
+
+    strategy_buy = asyncio.run(_route_tool()(intent="buy_analysis", market="us"))
+    assert "alpaca_paper_submit_order" in strategy_buy["blocked_actions"]
+    assert "alpaca_paper_submit_order" not in strategy_buy["allowed_tools"]
+
+    strategy_sell = asyncio.run(_route_tool()(intent="profit_taking", market="us"))
+    assert "alpaca_paper_submit_order" in strategy_sell["blocked_actions"]
+    assert "alpaca_paper_submit_order" not in strategy_sell["allowed_tools"]
+
+
+def test_us_paper_profile_is_cleanup_route_ready():
+    mcp = _build_profile_mcp(McpProfile.US_PAPER)
+
+    out = asyncio.run(
+        mcp.tools["route_request"](
+            intent="profit_taking",
+            market="us",
+            purpose="account_cleanup",
+        )
+    )
+
+    assert out["success"] is True
+    assert out["route_contract"]["missing_required_tools"] == []
+    assert "alpaca_paper_submit_order" in out["allowed_tools"]
+
+
 def test_market_brief_has_version_but_empty_thresholds():
     out = asyncio.run(_route_tool()(intent="market_brief", market="kr"))
 

--- a/tests/test_route_request_lanes.py
+++ b/tests/test_route_request_lanes.py
@@ -40,7 +40,13 @@ _EXPECTED_LANES = {
 }
 
 
-def _plan(intent: str, market: str, *, registered: set[str] | None = None) -> dict:
+def _plan(
+    intent: str,
+    market: str,
+    *,
+    registered: set[str] | None = None,
+    purpose: str | None = None,
+) -> dict:
     lane = L.INTENT_TO_LANE[intent]
     return L.build_route_plan(
         intent,
@@ -48,6 +54,7 @@ def _plan(intent: str, market: str, *, registered: set[str] | None = None) -> di
         registered_tools=_ALL if registered is None else registered,
         verdict_thresholds=_fake_thresholds(market, lane, empty=lane == "bootstrap"),
         policy_version=_VERSION,
+        purpose=purpose,
     )
 
 
@@ -80,6 +87,49 @@ def test_action_taxonomy_is_disjoint_and_total():
     assert L.ALL_KNOWN_TOOLS == L.READ_ONLY_ADVISORY_TOOLS | L.MUTATION_TOOLS
     assert L.ORDER_PROPOSAL_READ_TOOLS <= L.READ_ONLY_ADVISORY_TOOLS
     assert L.PROPOSAL_LED_TOOLS == {"order_proposal_create"}
+
+
+def test_account_cleanup_route_allows_only_preflighted_alpaca_submit():
+    plan = _plan(
+        "profit_taking",
+        "us",
+        purpose=L.ACCOUNT_CLEANUP_PURPOSE,
+    )
+    direct = L.ACCOUNT_CLEANUP_DIRECT_TOOL
+
+    assert plan["success"] is True
+    assert plan["purpose"] == L.ACCOUNT_CLEANUP_PURPOSE
+    assert plan["route_contract"]["version"] == "cleanup-reduce-only-v1"
+    assert plan["route_contract"]["execution_mode"] == "cleanup_reduce_only"
+    assert plan["route_contract"]["required_tools"] == sorted(
+        L.ACCOUNT_CLEANUP_REQUIRED_TOOLS
+    )
+    assert _step_tools(plan) == [step["tool"] for step in L.ACCOUNT_CLEANUP_SEQUENCE]
+    assert direct in plan["allowed_tools"]
+    assert direct not in plan["blocked_actions"]
+    assert (L.DIRECT_BROKER_MUTATION_TOOLS - {direct}) & _ALL <= set(
+        plan["blocked_actions"]
+    )
+
+
+def test_account_cleanup_route_fails_closed_without_preflight_tool():
+    registered = _ALL - {"alpaca_paper_execution_preflight_check"}
+    plan = _plan(
+        "profit_taking",
+        "us",
+        registered=registered,
+        purpose=L.ACCOUNT_CLEANUP_PURPOSE,
+    )
+
+    assert plan["success"] is False
+    assert plan["error"] == "required_route_tool_unavailable"
+    assert (
+        "alpaca_paper_execution_preflight_check"
+        in plan["route_contract"]["missing_required_tools"]
+    )
+    assert L.ACCOUNT_CLEANUP_DIRECT_TOOL not in plan["allowed_tools"]
+    assert L.ACCOUNT_CLEANUP_DIRECT_TOOL in plan["blocked_actions"]
+    assert L.ACCOUNT_CLEANUP_DIRECT_TOOL not in _step_tools(plan)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Permit only an attested, same-symbol, quantity-bounded Alpaca Paper reducing sell to proceed through preflight.
- Keep strategy buys, unbounded/oversized sells, and missing or wrong-account snapshots fail-closed.
- Add an account-cleanup route that requires positions → open orders → preflight before the existing confirm-gated submit surface.

## Verification
- `uv run pytest tests/services/test_alpaca_paper_anomaly_checks.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py tests/test_route_request.py tests/test_route_request_lanes.py tests/test_route_request_registry_diff.py tests/test_mcp_profiles.py tests/test_alpaca_clean_identity_binding.py tests/test_alpaca_paper_lab_profile.py -q`
- `uv run pytest tests/services/test_alpaca_paper_snapshot_attestation.py tests/test_alpaca_paper_sell_close_smoke.py tests/test_alpaca_paper_orders_tools.py tests/test_alpaca_paper_smoke_safety.py -q`
- `make lint`

Orders, account mutations, scheduler changes, and ledger-row repair: none.