### PR TITLE
KR-A0: exact packet binding engine

### DIFF
--- a/research/kr_corpus/backtest/packet_engine.py
+++ b/research/kr_corpus/backtest/packet_engine.py
@@ -1,0 +1,1366 @@
+"""Exact, offline KR-A0 packet engine.
+
+This module is additive to the legacy Stage-B path.  It implements only the
+three hash-bound packet candidates and has no broker, account, database, or
+scheduler dependency.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import statistics
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import date
+from fractions import Fraction
+from pathlib import Path
+from typing import Any, Final, Protocol
+
+from research.kr_corpus.registry.exact_binding import (
+    CandidateBinding,
+    CandidateRegistry,
+)
+
+Z90: Final = 1.2815515655446004
+COST_BASE: Final = 0.0043
+COST_SENSITIVITY: Final = 0.0083
+POPULATION_FLOOR: Final = 20
+MARKETS: Final[tuple[str, str]] = ("KOSPI", "KOSDAQ")
+
+Identity = tuple[str, str]
+
+
+class RunInvalid(RuntimeError):
+    """Fail-closed result for an invalid packet run."""
+
+    def __init__(
+        self,
+        label: str,
+        detail: str = "",
+        *,
+        evidence: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.label = label
+        self.detail = detail
+        self.evidence = dict(evidence or {})
+        message = label if not detail else f"{label} {detail}"
+        super().__init__(message)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "detail": self.detail,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True)
+class Bar:
+    open: float | None
+    high: float | None
+    low: float | None
+    close: float | None
+    volume: int | None
+
+
+@dataclass
+class AccessSpy:
+    """Records attempted reads that would cross the sealed exploration boundary."""
+
+    bar_oob_reads: int = 0
+    membership_oob_reads: int = 0
+    source_oob_records: int = 0
+    source_query_maxima: list[int] = field(default_factory=list)
+
+    @property
+    def total_oob_reads(self) -> int:
+        return self.bar_oob_reads + self.membership_oob_reads
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "bar_oob_reads": self.bar_oob_reads,
+            "membership_oob_reads": self.membership_oob_reads,
+            "source_oob_records": self.source_oob_records,
+            "source_query_maxima": list(self.source_query_maxima),
+            "total_oob_reads": self.total_oob_reads,
+        }
+
+
+@dataclass
+class PacketWorld:
+    """Boundary-clamped materialized input for one packet run."""
+
+    bars: Mapping[tuple[Identity, int], Bar]
+    symbols: tuple[Identity, ...]
+    membership: Mapping[Identity, tuple[int, int]]
+    delist_events: Mapping[Identity, int]
+    dates: Mapping[int, date]
+    month_last_sessions: frozenset[int]
+    exploration_end_session_idx: int
+    spy: AccessSpy = field(default_factory=AccessSpy)
+
+    def bar(self, key: Identity, session_idx: int) -> Bar | None:
+        if session_idx > self.exploration_end_session_idx:
+            self.spy.bar_oob_reads += 1
+            return None
+        if session_idx < 0:
+            return None
+        return self.bars.get((key, session_idx))
+
+    def is_member(self, key: Identity, session_idx: int) -> bool:
+        if session_idx > self.exploration_end_session_idx:
+            self.spy.membership_oob_reads += 1
+            return False
+        interval = self.membership.get(key)
+        return interval is not None and interval[0] <= session_idx <= interval[1]
+
+    def assert_boundary_clean(self) -> None:
+        if self.spy.total_oob_reads != 0:
+            raise RunInvalid(
+                "RUN_INVALID_BOUNDARY_ACCESS",
+                evidence=self.spy.as_dict(),
+            )
+
+
+class BoundedPacketSource(Protocol):
+    """Explicit-query source contract used by the production materializer."""
+
+    def fetch_sessions(
+        self, *, max_session_idx: int
+    ) -> Iterable[Mapping[str, Any]]: ...
+
+    def fetch_bars(self, *, max_session_idx: int) -> Iterable[Mapping[str, Any]]: ...
+
+    def fetch_membership(
+        self, *, max_session_idx: int
+    ) -> Iterable[Mapping[str, Any]]: ...
+
+    def fetch_delist_events(
+        self, *, max_session_idx: int
+    ) -> Iterable[Mapping[str, Any]]: ...
+
+
+class PacketWorldAdapter:
+    """Loads a self-contained fixture directory with boundary-first materialization."""
+
+    @classmethod
+    def from_fixture_directory(cls, directory: Path | str) -> PacketWorld:
+        root = Path(directory)
+        config = _read_config(root / "fixture_config.csv")
+        end = config.get("exploration_end_session_idx")
+        if not isinstance(end, int) or end < 0:
+            raise RunInvalid("RUN_INVALID_CONFIG", "exploration_end_session_idx")
+        spy = AccessSpy()
+        sessions = _read_csv_rows(root / "fixture_sessions.csv")
+        bars = _read_csv_rows(root / "fixture_bars.csv")
+        membership = _read_csv_rows(root / "fixture_membership.csv")
+        delist = _read_csv_rows(root / "fixture_delist_events.csv")
+        return cls._materialize(
+            sessions=sessions,
+            bars=bars,
+            membership=membership,
+            delist_events=delist,
+            exploration_end_session_idx=end,
+            spy=spy,
+        )
+
+    @classmethod
+    def from_source(
+        cls,
+        source: BoundedPacketSource,
+        *,
+        exploration_end_session_idx: int,
+    ) -> PacketWorld:
+        """Materialize only rows that a source explicitly filtered to the boundary."""
+
+        if exploration_end_session_idx < 0:
+            raise RunInvalid("RUN_INVALID_CONFIG", "negative exploration end")
+        spy = AccessSpy()
+        methods = (
+            (source.fetch_sessions, _record_session_index),
+            (source.fetch_bars, _record_session_index),
+            (source.fetch_membership, _membership_start_index),
+            (source.fetch_delist_events, _record_session_index),
+        )
+        records: list[list[Mapping[str, Any]]] = []
+        for method, indexer in methods:
+            spy.source_query_maxima.append(exploration_end_session_idx)
+            fetched = list(method(max_session_idx=exploration_end_session_idx))
+            for record in fetched:
+                idx = indexer(record)
+                if idx > exploration_end_session_idx:
+                    spy.source_oob_records += 1
+                    raise RunInvalid(
+                        "RUN_INVALID_SOURCE_BOUNDARY",
+                        f"source returned s{idx} above exploration end",
+                        evidence=spy.as_dict(),
+                    )
+            records.append(fetched)
+        return cls._materialize(
+            sessions=records[0],
+            bars=records[1],
+            membership=records[2],
+            delist_events=records[3],
+            exploration_end_session_idx=exploration_end_session_idx,
+            spy=spy,
+        )
+
+    @classmethod
+    def _materialize(
+        cls,
+        *,
+        sessions: Iterable[Mapping[str, Any]],
+        bars: Iterable[Mapping[str, Any]],
+        membership: Iterable[Mapping[str, Any]],
+        delist_events: Iterable[Mapping[str, Any]],
+        exploration_end_session_idx: int,
+        spy: AccessSpy,
+    ) -> PacketWorld:
+        dates: dict[int, date] = {}
+        month_last: set[int] = set()
+        for row in sessions:
+            idx = _record_session_index(row)
+            if idx > exploration_end_session_idx:
+                continue
+            if idx in dates:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"session {idx}")
+            raw_date = row.get("date_informational")
+            if not isinstance(raw_date, str):
+                raise RunInvalid("RUN_INVALID_SESSION", f"session {idx} date")
+            try:
+                dates[idx] = date.fromisoformat(raw_date)
+            except ValueError as exc:
+                raise RunInvalid("RUN_INVALID_SESSION", f"session {idx} date") from exc
+            if str(row.get("month_last")) == "1":
+                month_last.add(idx)
+        expected_indices = set(range(exploration_end_session_idx + 1))
+        if set(dates) != expected_indices:
+            raise RunInvalid("RUN_INVALID_DATA_GAP", "session calendar")
+
+        parsed_bars: dict[tuple[Identity, int], Bar] = {}
+        for row in bars:
+            idx = _record_session_index(row)
+            if idx > exploration_end_session_idx:
+                continue
+            key = _identity_from_row(row)
+            compound = (key, idx)
+            if compound in parsed_bars:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", str(compound))
+            parsed_bars[compound] = Bar(
+                open=_optional_float(row.get("open")),
+                high=_optional_float(row.get("high")),
+                low=_optional_float(row.get("low")),
+                close=_optional_float(row.get("close")),
+                volume=_optional_int(row.get("volume")),
+            )
+
+        parsed_membership: dict[Identity, tuple[int, int]] = {}
+        symbols: list[Identity] = []
+        for row in membership:
+            key = _identity_from_row(row)
+            if key in parsed_membership:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"membership {key}")
+            start = _as_int(row.get("start_idx"), "membership start")
+            end = _as_int(row.get("end_idx"), "membership end")
+            if start > end:
+                raise RunInvalid("RUN_INVALID_MEMBERSHIP", str(key))
+            if start > exploration_end_session_idx:
+                continue
+            parsed_membership[key] = (start, min(end, exploration_end_session_idx))
+            symbols.append(key)
+
+        parsed_delist: dict[Identity, int] = {}
+        for row in delist_events:
+            key = _identity_from_row(row)
+            if key in parsed_delist:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"delist {key}")
+            event_session = _as_int(row.get("delist_session_idx"), "delist session")
+            if event_session <= exploration_end_session_idx:
+                parsed_delist[key] = event_session
+
+        return PacketWorld(
+            bars=parsed_bars,
+            symbols=tuple(symbols),
+            membership=parsed_membership,
+            delist_events=parsed_delist,
+            dates=dates,
+            month_last_sessions=frozenset(month_last),
+            exploration_end_session_idx=exploration_end_session_idx,
+            spy=spy,
+        )
+
+
+@dataclass(frozen=True)
+class CandidateRun:
+    """Raw engine artifacts plus a stamped serialized output surface."""
+
+    binding: CandidateBinding
+    input_shas: Mapping[str, Any]
+    log: Mapping[str, Any]
+    trades: tuple[Mapping[str, Any], ...]
+    baselines: Mapping[str, Mapping[str, Any]]
+    verdict: Mapping[str, Any]
+
+    def golden_payload(self) -> dict[str, Any]:
+        """Unstamped payload used only for comparison to upstream golden vectors."""
+
+        return {
+            "log": dict(self.log),
+            "trades": [dict(trade) for trade in self.trades],
+            "baselines": {key: dict(value) for key, value in self.baselines.items()},
+            "verdict": dict(self.verdict),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        stamp = {
+            "strategy_id": self.binding.strategy_id,
+            "contract_hash": self.binding.contract_hash,
+        }
+        return {
+            **stamp,
+            "input_shas": dict(self.input_shas),
+            "log": {**stamp, **dict(self.log)},
+            "trades": [{**stamp, **dict(trade)} for trade in self.trades],
+            "baselines": {
+                key: {**stamp, **dict(value)} for key, value in self.baselines.items()
+            },
+            "verdict": {**stamp, **dict(self.verdict)},
+        }
+
+
+class PacketEngine:
+    """The three exact packet formulae; no shared signal fallback exists."""
+
+    def __init__(self, registry: CandidateRegistry) -> None:
+        self._registry = registry
+
+    def run(self, world: PacketWorld, strategy_id: str) -> CandidateRun:
+        binding = self._registry.binding_for(strategy_id)
+        self._check_identity(world)
+        self._check_data_gaps(world)
+        log, trades = self._execute_candidate(world, binding)
+        baselines = self._build_baselines(world, binding, trades)
+        verdict = compose_verdict(world.dates, trades, baselines)
+        world.assert_boundary_clean()
+        return CandidateRun(
+            binding=binding,
+            input_shas=self._registry.inputs.as_dict(),
+            log=log,
+            trades=tuple(trades),
+            baselines=baselines,
+            verdict=verdict,
+        )
+
+    def signals(
+        self, world: PacketWorld, strategy_id: str, session_idx: int
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        """Expose an exact signal snapshot for golden-level assertions."""
+
+        binding = self._registry.binding_for(strategy_id)
+        return self._signals_for(binding, world, session_idx)
+
+    def _signals_for(
+        self, binding: CandidateBinding, world: PacketWorld, session_idx: int
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        if binding.strategy_id == "rev3_reclaim":
+            return self._signals_rev3(binding, world, session_idx)
+        if binding.strategy_id == "brk20_confirm":
+            return self._signals_brk20(binding, world, session_idx)
+        if binding.strategy_id == "lowvol_up_month":
+            return self._signals_lowvol(binding, world, session_idx)
+        raise RunInvalid(
+            "RUN_INVALID_UNBOUND_STRATEGY",
+            f"shared fallback forbidden for {binding.strategy_id}",
+        )
+
+    def _check_identity(self, world: PacketWorld) -> None:
+        by_symbol: dict[str, list[tuple[str, int, int]]] = {}
+        for (market, symbol), (start, end) in world.membership.items():
+            by_symbol.setdefault(symbol, []).append((market, start, end))
+        conflicts: list[str] = []
+        for symbol, entries in by_symbol.items():
+            for left_idx, left in enumerate(entries):
+                for right in entries[left_idx + 1 :]:
+                    if left[0] == right[0]:
+                        continue
+                    if max(left[1], right[1]) <= min(left[2], right[2]):
+                        conflicts.append(symbol)
+        if conflicts:
+            raise RunInvalid(
+                "RUN_INVALID_IDENTITY_CONFLICT",
+                ",".join(sorted(conflicts)),
+                evidence={"symbols": sorted(conflicts)},
+            )
+
+    def _check_data_gaps(self, world: PacketWorld) -> None:
+        for session_idx in range(world.exploration_end_session_idx + 1):
+            for market in MARKETS:
+                if not any(
+                    world.bar(key, session_idx) is not None
+                    for key in world.symbols
+                    if key[0] == market
+                ):
+                    raise RunInvalid("RUN_INVALID_DATA_GAP", f"{market}@s{session_idx}")
+
+    def _a8_base_set(self, world: PacketWorld, session_idx: int) -> list[Identity]:
+        if session_idx < 20:
+            return []
+        return [
+            key
+            for key in world.symbols
+            if all(
+                world.is_member(key, session_idx - offset)
+                and valid_bar(world.bar(key, session_idx - offset))
+                for offset in range(21)
+            )
+        ]
+
+    def _liquidity_percentiles(
+        self, world: PacketWorld, session_idx: int, base: Iterable[Identity]
+    ) -> dict[Identity, float]:
+        base_values = tuple(base)
+        result: dict[Identity, float] = {}
+        for market in MARKETS:
+            keys = [key for key in base_values if key[0] == market]
+            values = [
+                _require_bar(world.bar(key, session_idx), key, session_idx).close
+                * _require_bar(world.bar(key, session_idx), key, session_idx).volume
+                for key in keys
+            ]
+            for key, value in zip(keys, values, strict=True):
+                result[key] = pct_asc(values, value)
+        return result
+
+    def _per_market_percentiles(
+        self, values_by_market: Mapping[str, Mapping[Identity, float]]
+    ) -> dict[Identity, float]:
+        """A1: each market has an independent, self-inclusive population."""
+
+        result: dict[Identity, float] = {}
+        for market in MARKETS:
+            values_for_market = values_by_market.get(market, {})
+            values = list(values_for_market.values())
+            for key, value in values_for_market.items():
+                result[key] = pct_asc(values, value)
+        return result
+
+    def _populations(
+        self, binding: CandidateBinding, world: PacketWorld, session_idx: int
+    ) -> tuple[dict[str, list[Identity]], dict[Identity, float], list[str]]:
+        if session_idx < 20:
+            return {market: [] for market in MARKETS}, {}, ["insufficient_history"]
+        base = self._a8_base_set(world, session_idx)
+        liquidity = self._liquidity_percentiles(world, session_idx, base)
+        minimum = float(binding.parameters["liquidity_percentile_min"])
+        populations: dict[str, list[Identity]] = {}
+        notes: list[str] = []
+        for market in MARKETS:
+            population = [
+                key
+                for key in base
+                if key[0] == market and self._at_least(liquidity[key], minimum)
+            ]
+            if len(population) < POPULATION_FLOOR:
+                notes.append(f"POPULATION_BELOW_FLOOR:{market}:{len(population)}")
+                population = []
+            populations[market] = population
+        return populations, liquidity, notes
+
+    def _signals_rev3(
+        self, binding: CandidateBinding, world: PacketWorld, session_idx: int
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        populations, liquidity, notes = self._populations(binding, world, session_idx)
+        signals: list[dict[str, Any]] = []
+        lookback = int(binding.parameters["reversal_lookback_sessions"])
+        percentile_max = float(binding.parameters["loser_percentile_max"])
+        clv_min = float(binding.parameters["close_location_min"])
+        volume_min = float(binding.parameters["volume_ratio_min"])
+        r3_by_market: dict[str, dict[Identity, float]] = {}
+        for market in MARKETS:
+            population = populations[market]
+            r3_by_market[market] = {
+                key: _require_bar(world.bar(key, session_idx), key, session_idx).close
+                / _require_bar(
+                    world.bar(key, session_idx - lookback), key, session_idx
+                ).close
+                - 1
+                for key in population
+            }
+        r3_percentiles = self._per_market_percentiles(r3_by_market)
+        for market in MARKETS:
+            population = populations[market]
+            r3 = r3_by_market[market]
+            for key in population:
+                bar = _require_bar(world.bar(key, session_idx), key, session_idx)
+                upper, lower = self._high_c(bar), self._low_c(bar)
+                if upper <= lower:
+                    continue
+                clv = (bar.close - lower) / (upper - lower)
+                median = statistics.median(
+                    _require_bar(
+                        world.bar(key, session_idx - offset), key, session_idx
+                    ).volume
+                    for offset in range(1, 21)
+                )
+                ratio = bar.volume / median
+                percentile = r3_percentiles[key]
+                if (
+                    self._at_most(percentile, percentile_max)
+                    and self._at_least(clv, clv_min)
+                    and self._at_least(ratio, volume_min)
+                ):
+                    signals.append(
+                        {
+                            "market": key[0],
+                            "symbol": key[1],
+                            "r3": r3[key],
+                            "r3_pct": percentile,
+                            "clv": clv,
+                            "volume_ratio": ratio,
+                            "liq_pct": liquidity[key],
+                        }
+                    )
+        signals.sort(key=rev3_rank_key)
+        return signals, notes
+
+    def _signals_brk20(
+        self, binding: CandidateBinding, world: PacketWorld, session_idx: int
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        populations, liquidity, notes = self._populations(binding, world, session_idx)
+        signals: list[dict[str, Any]] = []
+        lookback = int(binding.parameters["breakout_lookback_sessions"])
+        clv_min = float(binding.parameters["close_location_min"])
+        volume_min = float(binding.parameters["volume_ratio_min"])
+        for market in MARKETS:
+            for key in populations[market]:
+                bar = _require_bar(world.bar(key, session_idx), key, session_idx)
+                upper, lower = self._high_c(bar), self._low_c(bar)
+                if upper <= lower:
+                    continue
+                prior_high = max(
+                    self._high_c(
+                        _require_bar(
+                            world.bar(key, session_idx - offset), key, session_idx
+                        )
+                    )
+                    for offset in range(1, lookback + 1)
+                )
+                margin = bar.close / prior_high - 1
+                clv = (bar.close - lower) / (upper - lower)
+                median = statistics.median(
+                    _require_bar(
+                        world.bar(key, session_idx - offset), key, session_idx
+                    ).volume
+                    for offset in range(1, 21)
+                )
+                ratio = bar.volume / median
+                if (
+                    margin > 0
+                    and self._at_least(clv, clv_min)
+                    and self._at_least(ratio, volume_min)
+                ):
+                    signals.append(
+                        {
+                            "market": key[0],
+                            "symbol": key[1],
+                            "margin": margin,
+                            "clv": clv,
+                            "volume_ratio": ratio,
+                            "liq_pct": liquidity[key],
+                        }
+                    )
+        signals.sort(key=brk20_rank_key)
+        return signals, notes
+
+    def _signals_lowvol(
+        self, binding: CandidateBinding, world: PacketWorld, session_idx: int
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        populations, liquidity, notes = self._populations(binding, world, session_idx)
+        signals: list[dict[str, Any]] = []
+        percentile_max = float(binding.parameters["low_volatility_percentile_max"])
+        trend_floor = float(binding.parameters["trend_return_floor"])
+        volatility_by_market: dict[str, dict[Identity, float]] = {}
+        returns_by_market: dict[str, dict[Identity, float]] = {}
+        for market in MARKETS:
+            population = populations[market]
+            volatility: dict[Identity, float] = {}
+            returns: dict[Identity, float] = {}
+            for key in population:
+                closes = [
+                    _require_bar(
+                        world.bar(key, session_idx - offset), key, session_idx
+                    ).close
+                    for offset in range(20, -1, -1)
+                ]
+                daily_returns = [closes[idx + 1] / closes[idx] - 1 for idx in range(20)]
+                volatility[key] = canonical_sample_stdev(daily_returns)
+                returns[key] = closes[-1] / closes[0] - 1
+            volatility_by_market[market] = volatility
+            returns_by_market[market] = returns
+        vol_percentiles = self._per_market_percentiles(volatility_by_market)
+        for market in MARKETS:
+            population = populations[market]
+            volatility = volatility_by_market[market]
+            returns = returns_by_market[market]
+            for key in population:
+                percentile = vol_percentiles[key]
+                if (
+                    self._at_most(percentile, percentile_max)
+                    and returns[key] > trend_floor
+                ):
+                    signals.append(
+                        {
+                            "market": key[0],
+                            "symbol": key[1],
+                            "vol20": volatility[key],
+                            "vol20_pct": percentile,
+                            "r20": returns[key],
+                            "liq_pct": liquidity[key],
+                        }
+                    )
+        signals.sort(key=lowvol_rank_key)
+        return signals, notes
+
+    def _execute_candidate(
+        self, world: PacketWorld, binding: CandidateBinding
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        positions: list[dict[str, Any]] = []
+        log: dict[str, Any] = {
+            "entries": [],
+            "ignored_held": [],
+            "skipped_max10": [],
+            "no_fill": [],
+            "censored": [],
+            "notes": {},
+        }
+        for signal_session in range(world.exploration_end_session_idx + 1):
+            if (
+                binding.strategy_id == "lowvol_up_month"
+                and signal_session not in world.month_last_sessions
+            ):
+                continue
+            signals, notes = self._signals_for(binding, world, signal_session)
+            if notes:
+                log["notes"][signal_session] = notes
+            entry_session = signal_session + 1
+            live: list[dict[str, Any]] = []
+            for signal in signals:
+                if (
+                    entry_session > world.exploration_end_session_idx
+                    or entry_session + binding.holding_sessions
+                    > world.exploration_end_session_idx
+                ):
+                    log["censored"].append(
+                        {
+                            "session": signal_session,
+                            "symbol": signal["symbol"],
+                            "market": signal["market"],
+                            "status": "RIGHT_CENSORED_NOT_TRADEABLE",
+                        }
+                    )
+                else:
+                    live.append(signal)
+
+            occupied = sum(
+                1
+                for position in positions
+                if position["entry_idx"] <= entry_session <= position["occupy_until"]
+            )
+            slots = binding.max_positions - occupied
+            selected, skipped_for_capacity = self._select_two_stage(
+                positions=positions,
+                live=live,
+                entry_session=entry_session,
+                slots=slots,
+                signal_session=signal_session,
+                log=log,
+            )
+            self._attempt_entries(
+                world=world,
+                binding=binding,
+                positions=positions,
+                selected=selected,
+                skipped_for_capacity=skipped_for_capacity,
+                signal_session=signal_session,
+                entry_session=entry_session,
+                log=log,
+            )
+
+        trades = self._resolve_positions(world, positions)
+        trades.sort(
+            key=lambda trade: (trade["entry_idx"], trade["market"], trade["symbol"])
+        )
+        return log, trades
+
+    def _select_two_stage(
+        self,
+        *,
+        positions: list[dict[str, Any]],
+        live: list[dict[str, Any]],
+        entry_session: int,
+        slots: int,
+        signal_session: int,
+        log: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        selected: list[dict[str, Any]] = []
+        skipped_for_capacity: list[dict[str, Any]] = []
+        for signal in live:
+            key = (signal["market"], signal["symbol"])
+            if any(
+                position["key"] == key
+                and position["entry_idx"] <= entry_session <= position["occupy_until"]
+                for position in positions
+            ):
+                log["ignored_held"].append(
+                    {
+                        "session": signal_session,
+                        "market": signal["market"],
+                        "symbol": signal["symbol"],
+                    }
+                )
+                continue
+            if len(selected) >= slots:
+                log["skipped_max10"].append(
+                    {
+                        "session": signal_session,
+                        "market": signal["market"],
+                        "symbol": signal["symbol"],
+                    }
+                )
+                skipped_for_capacity.append(signal)
+                continue
+            selected.append(signal)
+        return selected, skipped_for_capacity
+
+    def _attempt_entries(
+        self,
+        *,
+        world: PacketWorld,
+        binding: CandidateBinding,
+        positions: list[dict[str, Any]],
+        selected: list[dict[str, Any]],
+        skipped_for_capacity: list[dict[str, Any]],
+        signal_session: int,
+        entry_session: int,
+        log: dict[str, Any],
+    ) -> None:
+        fallback = iter(skipped_for_capacity)
+        attempts = iter(selected)
+        for signal in attempts:
+            entry_bar = world.bar((signal["market"], signal["symbol"]), entry_session)
+            if not self._entry_ok(entry_bar):
+                log["no_fill"].append(
+                    {
+                        "session": signal_session,
+                        "market": signal["market"],
+                        "symbol": signal["symbol"],
+                        "entry_session": entry_session,
+                    }
+                )
+                if self._substitute_after_no_fill():
+                    self._attempt_mutant_fallback(
+                        world=world,
+                        binding=binding,
+                        positions=positions,
+                        fallback=fallback,
+                        signal_session=signal_session,
+                        entry_session=entry_session,
+                        log=log,
+                    )
+                continue
+            self._record_position(
+                world=world,
+                binding=binding,
+                positions=positions,
+                signal=signal,
+                signal_session=signal_session,
+                entry_session=entry_session,
+                entry_bar=entry_bar,
+                log=log,
+            )
+
+    def _attempt_mutant_fallback(
+        self,
+        *,
+        world: PacketWorld,
+        binding: CandidateBinding,
+        positions: list[dict[str, Any]],
+        fallback: Iterable[dict[str, Any]],
+        signal_session: int,
+        entry_session: int,
+        log: dict[str, Any],
+    ) -> None:
+        """Test-only hook: subclasses can demonstrate why substitution is forbidden."""
+
+        for candidate in fallback:
+            entry_bar = world.bar(
+                (candidate["market"], candidate["symbol"]), entry_session
+            )
+            if self._entry_ok(entry_bar):
+                self._record_position(
+                    world=world,
+                    binding=binding,
+                    positions=positions,
+                    signal=candidate,
+                    signal_session=signal_session,
+                    entry_session=entry_session,
+                    entry_bar=entry_bar,
+                    log=log,
+                )
+                return
+
+    def _record_position(
+        self,
+        *,
+        world: PacketWorld,
+        binding: CandidateBinding,
+        positions: list[dict[str, Any]],
+        signal: Mapping[str, Any],
+        signal_session: int,
+        entry_session: int,
+        entry_bar: Bar,
+        log: dict[str, Any],
+    ) -> None:
+        key = (str(signal["market"]), str(signal["symbol"]))
+        exit_due = entry_session + binding.holding_sessions
+        event_session = world.delist_events.get(key)
+        occupy_until = (
+            min(exit_due, event_session)
+            if event_session is not None and event_session <= exit_due
+            else exit_due
+        )
+        positions.append(
+            {
+                "key": key,
+                "entry_idx": entry_session,
+                "exit_due": exit_due,
+                "occupy_until": occupy_until,
+                "signal_session": signal_session,
+                "entry_open": entry_bar.open,
+            }
+        )
+        log["entries"].append(
+            {
+                "session": signal_session,
+                "symbol": signal["symbol"],
+                "market": signal["market"],
+                "entry_session": entry_session,
+            }
+        )
+
+    def _resolve_positions(
+        self, world: PacketWorld, positions: Iterable[Mapping[str, Any]]
+    ) -> list[dict[str, Any]]:
+        terminal_trades: list[dict[str, Any]] = []
+        regular_positions: list[Mapping[str, Any]] = []
+        transfer_occurrences: list[dict[str, Any]] = []
+        for position in positions:
+            key = position["key"]
+            event_session = world.delist_events.get(key)
+            if event_session is not None and event_session <= position["exit_due"]:
+                terminal_trades.append(
+                    self._terminal_trade(world, position, event_session)
+                )
+                continue
+            if self._transfer_precedes_maturity() and self._transfer_gate(
+                world, position
+            ):
+                transfer_occurrences.append(self._transfer_evidence(world, position))
+                continue
+            regular_positions.append(position)
+
+        if transfer_occurrences:
+            raise RunInvalid(
+                "RUN_INVALID_MARKET_TRANSFER",
+                evidence={
+                    "occurrence_count": len(transfer_occurrences),
+                    "affected_identities": transfer_occurrences,
+                },
+            )
+
+        trades = list(terminal_trades)
+        deferred_transfers: list[dict[str, Any]] = []
+        for position in regular_positions:
+            key = position["key"]
+            exit_due = position["exit_due"]
+            exit_bar = world.bar(key, exit_due)
+            if not self._maturity_ok(exit_bar):
+                raise RunInvalid("RUN_INVALID_MATURITY_PRICE", f"{key}@s{exit_due}")
+            if not self._transfer_precedes_maturity() and self._transfer_gate(
+                world, position
+            ):
+                deferred_transfers.append(self._transfer_evidence(world, position))
+                continue
+            gross = exit_bar.close / position["entry_open"] - 1
+            trades.append(
+                {
+                    **_trade_position_fields(position),
+                    "market": key[0],
+                    "symbol": key[1],
+                    "exit_session": exit_due,
+                    "exit_close": exit_bar.close,
+                    "gross": gross,
+                    "delisted_exit": False,
+                    "net_43bp": gross - COST_BASE,
+                    "net_83bp": gross - COST_SENSITIVITY,
+                }
+            )
+        if deferred_transfers:
+            raise RunInvalid(
+                "RUN_INVALID_MARKET_TRANSFER",
+                evidence={
+                    "occurrence_count": len(deferred_transfers),
+                    "affected_identities": deferred_transfers,
+                },
+            )
+        return trades
+
+    def _terminal_trade(
+        self, world: PacketWorld, position: Mapping[str, Any], event_session: int
+    ) -> dict[str, Any]:
+        key = position["key"]
+        last_close: float | None = None
+        for session_idx in range(event_session, position["entry_idx"] - 1, -1):
+            bar = world.bar(key, session_idx)
+            if self._maturity_ok(bar):
+                last_close = bar.close
+                break
+        gross = (
+            last_close / position["entry_open"] - 1 if last_close is not None else -1.0
+        )
+        return {
+            **_trade_position_fields(position),
+            "market": key[0],
+            "symbol": key[1],
+            "exit_session": event_session,
+            "exit_close": last_close,
+            "gross": gross,
+            "delisted_exit": True,
+            "net_43bp": gross - COST_BASE,
+            "net_83bp": gross - COST_SENSITIVITY,
+        }
+
+    def _transfer_gate(self, world: PacketWorld, position: Mapping[str, Any]) -> bool:
+        key = position["key"]
+        membership_end = world.membership[key][1]
+        return membership_end < position["exit_due"] and self._other_market_transfer(
+            world, key
+        )
+
+    def _transfer_evidence(
+        self, world: PacketWorld, position: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        market, symbol = position["key"]
+        return {
+            "market": market,
+            "symbol": symbol,
+            "identity": [market, symbol],
+            "membership_end": world.membership[(market, symbol)][1],
+            "exit_due": position["exit_due"],
+        }
+
+    def _other_market_transfer(self, world: PacketWorld, key: Identity) -> bool:
+        market, symbol = key
+        end = world.membership[key][1]
+        return any(
+            other_symbol == symbol and other_market != market and start > end
+            for (other_market, other_symbol), (start, _) in world.membership.items()
+        )
+
+    def _build_baselines(
+        self,
+        world: PacketWorld,
+        binding: CandidateBinding,
+        trades: Iterable[Mapping[str, Any]],
+    ) -> dict[str, Mapping[str, Any]]:
+        baselines: dict[str, Mapping[str, Any]] = {}
+        for trade in trades:
+            signal_session = int(trade["signal_session"])
+            base = self._a8_base_set(world, signal_session)
+            liquidity = self._liquidity_percentiles(world, signal_session, base)
+            key = (str(trade["market"]), str(trade["symbol"]))
+            target_pct = liquidity[key]
+            baseline = self._baseline(
+                world,
+                signal_session=signal_session,
+                holding_sessions=binding.holding_sessions,
+                target_pct=target_pct,
+            )
+            baselines[_baseline_key(key, int(trade["entry_idx"]))] = baseline
+        return baselines
+
+    def _baseline(
+        self,
+        world: PacketWorld,
+        *,
+        signal_session: int,
+        holding_sessions: int,
+        target_pct: float,
+    ) -> dict[str, Any]:
+        base = self._a8_base_set(world, signal_session)
+        liquidity = self._liquidity_percentiles(world, signal_session, base)
+        decile = min(9, int(target_pct * 10))
+        returns: list[float] = []
+        excluded_entry = 0
+        excluded_maturity = 0
+        terminal_included = 0
+        entry_session = signal_session + 1
+        exit_due = entry_session + holding_sessions
+        for key in base:
+            if min(9, int(liquidity[key] * 10)) != decile:
+                continue
+            entry_bar = world.bar(key, entry_session)
+            if not self._entry_ok(entry_bar):
+                excluded_entry += 1
+                continue
+            event_session = world.delist_events.get(key)
+            if event_session is not None and event_session <= exit_due:
+                last_close: float | None = None
+                for session_idx in range(event_session, signal_session, -1):
+                    bar = world.bar(key, session_idx)
+                    if self._maturity_ok(bar):
+                        last_close = bar.close
+                        break
+                returns.append(
+                    last_close / entry_bar.open - 1 if last_close is not None else -1.0
+                )
+                terminal_included += 1
+                continue
+            exit_bar = world.bar(key, exit_due)
+            if not self._maturity_ok(exit_bar):
+                excluded_maturity += 1
+                continue
+            returns.append(exit_bar.close / entry_bar.open - 1)
+        return {
+            "decile": decile,
+            "n": len(returns),
+            "gross_mean": statistics.mean(returns) if returns else None,
+            "cohort_excluded_entry": excluded_entry,
+            "cohort_excluded_maturity": excluded_maturity,
+            "cohort_terminal_included": terminal_included,
+        }
+
+    def _at_least(self, actual: float, threshold: float) -> bool:
+        return actual >= threshold
+
+    def _at_most(self, actual: float, threshold: float) -> bool:
+        return actual <= threshold
+
+    def _high_c(self, bar: Bar) -> float:
+        return high_c(bar)
+
+    def _low_c(self, bar: Bar) -> float:
+        return low_c(bar)
+
+    def _entry_ok(self, bar: Bar | None) -> bool:
+        return entry_ok(bar)
+
+    def _maturity_ok(self, bar: Bar | None) -> bool:
+        return maturity_ok(bar)
+
+    def _substitute_after_no_fill(self) -> bool:
+        return False
+
+    def _transfer_precedes_maturity(self) -> bool:
+        return True
+
+
+def pct_asc(values: Iterable[float], value: float) -> float:
+    """A1: self-inclusive, tie-inclusive ascending percentile."""
+
+    materialized = tuple(values)
+    if not materialized:
+        raise RunInvalid("RUN_INVALID_EMPTY_POPULATION")
+    return sum(1 for candidate in materialized if candidate <= value) / len(
+        materialized
+    )
+
+
+def valid_bar(bar: Bar | None) -> bool:
+    return (
+        bar is not None
+        and all(
+            _finite_positive(getattr(bar, field))
+            for field in ("open", "high", "low", "close")
+        )
+        and _finite_positive(bar.volume)
+    )
+
+
+def entry_ok(bar: Bar | None) -> bool:
+    return (
+        bar is not None and _finite_positive(bar.open) and _finite_positive(bar.volume)
+    )
+
+
+def maturity_ok(bar: Bar | None) -> bool:
+    return (
+        bar is not None and _finite_positive(bar.close) and _finite_positive(bar.volume)
+    )
+
+
+def high_c(bar: Bar) -> float:
+    return max(
+        _required_float(bar.high), _required_float(bar.open), _required_float(bar.close)
+    )
+
+
+def low_c(bar: Bar) -> float:
+    return min(
+        _required_float(bar.low), _required_float(bar.open), _required_float(bar.close)
+    )
+
+
+def rev3_rank_key(row: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        row["r3_pct"],
+        row["r3"],
+        -row["clv"],
+        -row["volume_ratio"],
+        -row["liq_pct"],
+        0 if row["market"] == "KOSPI" else 1,
+        row["symbol"],
+    )
+
+
+def brk20_rank_key(row: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        -row["margin"],
+        -row["volume_ratio"],
+        -row["clv"],
+        -row["liq_pct"],
+        0 if row["market"] == "KOSPI" else 1,
+        row["symbol"],
+    )
+
+
+def lowvol_rank_key(row: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        row["vol20_pct"],
+        row["vol20"],
+        -row["r20"],
+        -row["liq_pct"],
+        0 if row["market"] == "KOSPI" else 1,
+        row["symbol"],
+    )
+
+
+def compose_verdict(
+    dates: Mapping[int, date],
+    trades: Iterable[Mapping[str, Any]],
+    baselines: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    """A11/A14 verdict composition using entry-session equal weighting."""
+
+    materialized = tuple(trades)
+    profiles: dict[str, dict[str, Any]] = {}
+    for tag, cost in (("43bp", COST_BASE), ("83bp", COST_SENSITIVITY)):
+        excesses: list[float] = []
+        by_session: dict[int, list[float]] = {}
+        for trade in materialized:
+            key = _baseline_key(
+                (str(trade["market"]), str(trade["symbol"])), int(trade["entry_idx"])
+            )
+            baseline = baselines.get(key)
+            if baseline is None or baseline.get("gross_mean") is None:
+                raise RunInvalid(
+                    "RUN_INVALID_EMPTY_BASELINE",
+                    f"{trade['symbol']}@e{trade['entry_idx']}",
+                )
+            excess = (float(trade["gross"]) - cost) - float(baseline["gross_mean"])
+            excesses.append(excess)
+            by_session.setdefault(int(trade["entry_idx"]), []).append(excess)
+        session_means = {
+            session: statistics.mean(values)
+            for session, values in sorted(by_session.items())
+        }
+        by_year: dict[int, list[float]] = {}
+        for session, average in session_means.items():
+            try:
+                year = dates[session].year
+            except KeyError as exc:
+                raise RunInvalid(
+                    "RUN_INVALID_SESSION", f"entry session {session}"
+                ) from exc
+            by_year.setdefault(year, []).append(average)
+        positive_years = sum(
+            1 for values in by_year.values() if statistics.mean(values) > 0
+        )
+        clusters = len(session_means)
+        profile: dict[str, Any] = {
+            "filled": len(materialized),
+            "gate_filled_ge_300": len(materialized) >= 300,
+            "trade_mean_excess": statistics.mean(excesses) if excesses else None,
+            "gate_mean_excess_gt_0": bool(excesses) and statistics.mean(excesses) > 0,
+            "n_entry_sessions": clusters,
+            "session_means": session_means,
+            "positive_years": positive_years,
+            "n_years": len(by_year),
+            "year_means": {
+                str(year): statistics.mean(values)
+                for year, values in sorted(by_year.items())
+            },
+            "gate_positive_years_ge_6": positive_years >= 6,
+            "z": Z90,
+        }
+        if clusters < 30:
+            profile["verdict"] = "UNIDENTIFIABLE_CLUSTERS"
+            if clusters >= 2:
+                values = list(session_means.values())
+                profile["lcb_info_only"] = clustered_lcb(values)
+        else:
+            values = list(session_means.values())
+            lcb = clustered_lcb(values)
+            profile["lcb"] = lcb
+            profile["gate_clustered_lcb_gt_0"] = lcb > 0
+            failures = [
+                gate
+                for gate in (
+                    "gate_filled_ge_300",
+                    "gate_mean_excess_gt_0",
+                    "gate_clustered_lcb_gt_0",
+                    "gate_positive_years_ge_6",
+                )
+                if not profile[gate]
+            ]
+            profile["verdict"] = "FALSIFIED" if failures else "PASS"
+            profile["failed_gates"] = failures
+        profiles[tag] = profile
+    base_mean = profiles["43bp"]["trade_mean_excess"]
+    sensitivity_mean = profiles["83bp"]["trade_mean_excess"]
+    return {
+        "verdict": profiles["43bp"]["verdict"],
+        "cost_sensitive": base_mean is not None
+        and base_mean > 0
+        and (sensitivity_mean or 0) <= 0,
+        "profiles": profiles,
+    }
+
+
+def clustered_lcb(session_means: Iterable[float]) -> float:
+    values = tuple(session_means)
+    if len(values) < 2:
+        raise RunInvalid("UNIDENTIFIABLE_CLUSTERS")
+    return statistics.mean(values) - Z90 * canonical_sample_stdev(values) / math.sqrt(
+        len(values)
+    )
+
+
+def canonical_sample_stdev(values: Iterable[float]) -> float:
+    """Pinned v5 ddof=1 standard deviation across supported CPython versions.
+
+    The original v5 generator was sealed with the exact-ratio implementation
+    used by CPython 3.9.  Later stdlib revisions changed the final rounding of
+    ``statistics.stdev`` for a few vectors.  This local, pure implementation
+    preserves the sealed numerical convention rather than allowing a runtime
+    upgrade to silently drift the packet contract.
+    """
+
+    materialized = tuple(values)
+    if len(materialized) < 2:
+        raise RunInvalid("UNIDENTIFIABLE_CLUSTERS")
+    total = sum((Fraction.from_float(value) for value in materialized), Fraction(0, 1))
+    center = float(total / len(materialized))
+    squared = sum(
+        (Fraction.from_float((value - center) ** 2) for value in materialized),
+        Fraction(0, 1),
+    )
+    residual = sum(
+        (Fraction.from_float(value - center) for value in materialized),
+        Fraction(0, 1),
+    )
+    squared -= residual**2 / len(materialized)
+    return math.sqrt(float(squared / (len(materialized) - 1)))
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        raise RunInvalid("RUN_INVALID_FIXTURE", f"missing {path.name}")
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _read_config(path: Path) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for row in _read_csv_rows(path):
+        key = row.get("key")
+        if not isinstance(key, str) or not key:
+            raise RunInvalid("RUN_INVALID_CONFIG", "empty key")
+        if key in result:
+            raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"config {key}")
+        result[key] = _as_int(row.get("value"), f"config {key}")
+    return result
+
+
+def _record_session_index(row: Mapping[str, Any]) -> int:
+    raw = row.get("session_idx", row.get("delist_session_idx"))
+    return _as_int(raw, "session_idx")
+
+
+def _membership_start_index(row: Mapping[str, Any]) -> int:
+    return _as_int(row.get("start_idx"), "membership start_idx")
+
+
+def _identity_from_row(row: Mapping[str, Any]) -> Identity:
+    market, symbol = row.get("market"), row.get("symbol")
+    if market not in MARKETS or not isinstance(symbol, str) or not symbol:
+        raise RunInvalid("RUN_INVALID_IDENTITY", f"market={market!r} symbol={symbol!r}")
+    return str(market), symbol
+
+
+def _optional_float(raw: object) -> float | None:
+    if raw is None or raw == "":
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError) as exc:
+        raise RunInvalid("RUN_INVALID_BAR", f"non-float {raw!r}") from exc
+
+
+def _optional_int(raw: object) -> int | None:
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise RunInvalid("RUN_INVALID_BAR", f"non-int {raw!r}") from exc
+
+
+def _as_int(raw: object, label: str) -> int:
+    try:
+        return int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise RunInvalid("RUN_INVALID_FIXTURE", label) from exc
+
+
+def _finite_positive(value: object) -> bool:
+    return (
+        value is not None
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+        and value > 0
+    )
+
+
+def _required_float(value: float | None) -> float:
+    if value is None:
+        raise RunInvalid("RUN_INVALID_BAR", "required field absent")
+    return value
+
+
+def _require_bar(bar: Bar | None, key: Identity, session_idx: int) -> Bar:
+    if bar is None:
+        raise RunInvalid("RUN_INVALID_DATA_GAP", f"{key}@s{session_idx}")
+    return bar
+
+
+def _trade_position_fields(position: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        name: position[name]
+        for name in ("entry_idx", "exit_due", "signal_session", "entry_open")
+    }
+
+
+def _baseline_key(key: Identity, entry_idx: int) -> str:
+    return f"{key[0]}:{key[1]}@e{entry_idx}"

--- a/research/kr_corpus/registry/__init__.py
+++ b/research/kr_corpus/registry/__init__.py
@@ -1,0 +1,24 @@
+"""Hash-bound registry for the KR-A0 packet candidates.
+
+This package is deliberately separate from the legacy Stage-B implementation.
+"""
+
+from .exact_binding import (
+    ArtifactPaths,
+    CandidateBinding,
+    CandidateRegistry,
+    NeedsUpstream,
+    RegistryStartRejected,
+    VerifiedInputs,
+    sha256_file,
+)
+
+__all__ = [
+    "ArtifactPaths",
+    "CandidateBinding",
+    "CandidateRegistry",
+    "NeedsUpstream",
+    "RegistryStartRejected",
+    "VerifiedInputs",
+    "sha256_file",
+]

--- a/research/kr_corpus/registry/exact_binding.py
+++ b/research/kr_corpus/registry/exact_binding.py
@@ -1,0 +1,508 @@
+"""Fail-closed, hash-bound registry for the KR-A0 packet candidates.
+
+The registry intentionally has no default artifact location.  A caller must name
+all serialized inputs explicitly, and startup verifies every pinned byte stream
+before it returns an executable candidate binding.  It does not import the
+legacy Stage-B or shadow signal implementations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+CANDIDATES_SHA256: Final = (
+    "0f5e92bf7d10dd77588fa08ad949811a68004cf71dd7f2efd232306b22d82d85"
+)
+GOLDEN_V5_SHA256: Final = (
+    "fa9a3a1adbb47f80e0980e99e3f641ef0f331c21e4801bee296366f3735cb97b"
+)
+CONVENTION_SHA256: Final[dict[str, str]] = {
+    "amendment_a1_a9": (
+        "5cbe56934b0e53eba8123c81aa8999e6bc5f862c9ee6e0f0d4664b3d2b098092"
+    ),
+    "amendment_a10_a12": (
+        "79ec69c935af9f271e02cb8b01805d727fd4cf7b9ab342aaa0a49995166d30b9"
+    ),
+    "amendment_a13_a14": (
+        "5bdb261504b7d3c298f3a85cc07cef72dc0528adad72c685dd322884b1bd6b59"
+    ),
+    "generator": ("28866f8e02f2eddd8b990a17324e96b5cebaca8b10bb96065a3f84b68e733517"),
+}
+BASE_FIXTURE_FILENAMES: Final[tuple[str, ...]] = (
+    "fixture_bars.csv",
+    "fixture_sessions.csv",
+    "fixture_config.csv",
+    "fixture_membership.csv",
+    "fixture_delist_events.csv",
+)
+KR_PACKET_ORDER: Final[tuple[str, ...]] = (
+    "rev3_reclaim",
+    "brk20_confirm",
+    "lowvol_up_month",
+)
+PERCENTILE_CONVENTION: Final = "pct_asc_self_inclusive_ties_per_market"
+
+
+class RegistryStartRejected(RuntimeError):
+    """A pinned input or parsed packet contract cannot be trusted."""
+
+
+class NeedsUpstream(RuntimeError):
+    """A policy convention conflict must be returned to the upstream owner."""
+
+    def __init__(self, item: str) -> None:
+        self.item = item
+        super().__init__(f"NEEDS_UPSTREAM({item})")
+
+
+@dataclass(frozen=True)
+class ArtifactPaths:
+    """All serialized inputs required before registry startup is allowed."""
+
+    candidates_yaml: Path
+    golden_v5: Path
+    amendment_a1_a9: Path
+    amendment_a10_a12: Path
+    amendment_a13_a14: Path
+    generator: Path
+    fixture_root: Path
+
+    @classmethod
+    def from_fixture_bundle(cls, root: Path | str) -> ArtifactPaths:
+        """Build paths for a self-contained golden fixture bundle.
+
+        This is intentionally a convenience for offline verification fixtures,
+        not a production default.  Production callers still pass a concrete
+        bundle root and therefore cannot silently fall back to stale inputs.
+        """
+
+        bundle = Path(root)
+        inbox = bundle / "inbox"
+        return cls(
+            candidates_yaml=bundle / "02-active-candidates.yaml",
+            golden_v5=bundle / "golden_v5.json",
+            amendment_a1_a9=inbox
+            / "amendment-kr-engine-conventions-v2-draft-20260805.md",
+            amendment_a10_a12=inbox / "amendment-kr-engine-a10-a12-draft-20260805.md",
+            amendment_a13_a14=inbox / "amendment-kr-engine-a13-a14-draft-20260805.md",
+            generator=bundle / "reference_generator_v4.py",
+            fixture_root=bundle,
+        )
+
+
+@dataclass(frozen=True)
+class VerifiedInputs:
+    """Recomputed proof material retained by the registry and run outputs."""
+
+    candidates_sha256: str
+    golden_sha256: str
+    convention_sha256: Mapping[str, str]
+    fixture_sha256: Mapping[str, str]
+    variant_fixture_sha256: Mapping[str, Mapping[str, str]]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidates_yaml_sha256": self.candidates_sha256,
+            "golden_v5_sha256": self.golden_sha256,
+            "convention_sha256": dict(self.convention_sha256),
+            "fixture_sha256": dict(self.fixture_sha256),
+            "variant_fixture_sha256": {
+                name: dict(files) for name, files in self.variant_fixture_sha256.items()
+            },
+        }
+
+
+@dataclass(frozen=True)
+class CandidateBinding:
+    """A parsed KR packet candidate plus its source-byte contract hash."""
+
+    strategy_id: str
+    market: str
+    contract_hash: str
+    source_block: bytes
+    parameters: Mapping[str, Any]
+    entry: str
+    exit: str
+    ranking: str
+    tie_break: str
+    signal: str
+    missing_data_handling: str
+
+    @property
+    def holding_sessions(self) -> int:
+        value = self.parameters.get("holding_sessions")
+        if not isinstance(value, int) or value <= 0:
+            raise RegistryStartRejected(
+                f"candidate {self.strategy_id} has invalid holding_sessions"
+            )
+        return value
+
+    @property
+    def max_positions(self) -> int:
+        value = self.parameters.get(
+            "max_concurrent_positions", self.parameters.get("max_positions")
+        )
+        if not isinstance(value, int) or value != 10:
+            raise RegistryStartRejected(
+                f"candidate {self.strategy_id} max position contract drift"
+            )
+        return value
+
+
+@dataclass(frozen=True)
+class CandidateRegistry:
+    """Executable registry returned only after all exact bindings have passed."""
+
+    candidates: Mapping[str, CandidateBinding]
+    inputs: VerifiedInputs
+
+    @classmethod
+    def start(
+        cls,
+        paths: ArtifactPaths,
+        *,
+        observed_percentile_convention: str | None = None,
+    ) -> CandidateRegistry:
+        """Verify inputs, parse the source YAML, and reject all unsupported drift."""
+
+        if (
+            observed_percentile_convention is not None
+            and observed_percentile_convention != PERCENTILE_CONVENTION
+        ):
+            raise NeedsUpstream("percentile convention 충돌")
+
+        inputs = verify_bound_inputs(paths)
+        source = _read_regular_file(paths.candidates_yaml, label="candidates YAML")
+        parsed = _parse_yaml_mapping(source, paths.candidates_yaml)
+        raw_blocks = _candidate_block_bytes(source)
+        raw_candidates = parsed.get("candidates")
+        if not isinstance(raw_candidates, list):
+            raise RegistryStartRejected("candidates YAML has no candidates list")
+        if len(raw_candidates) != len(raw_blocks):
+            raise RegistryStartRejected("candidate YAML block parser count mismatch")
+
+        bindings: dict[str, CandidateBinding] = {}
+        for raw, block in zip(raw_candidates, raw_blocks, strict=True):
+            if not isinstance(raw, Mapping):
+                raise RegistryStartRejected("candidate YAML item is not a mapping")
+            if raw.get("market") != "KR":
+                continue
+            binding = _binding_from_candidate(raw, block)
+            if binding.strategy_id in bindings:
+                raise RegistryStartRejected(
+                    f"duplicate KR strategy_id {binding.strategy_id!r}"
+                )
+            bindings[binding.strategy_id] = binding
+
+        if tuple(bindings) != KR_PACKET_ORDER:
+            raise RegistryStartRejected(
+                "KR candidate order/id drift: "
+                f"expected={KR_PACKET_ORDER!r} actual={tuple(bindings)!r}"
+            )
+        for binding in bindings.values():
+            _assert_binding_implements_packet_contract(binding)
+        return cls(candidates=bindings, inputs=inputs)
+
+    def binding_for(self, strategy_id: str) -> CandidateBinding:
+        try:
+            return self.candidates[strategy_id]
+        except KeyError as exc:
+            raise RegistryStartRejected(
+                f"unsupported strategy_id {strategy_id!r}; shared fallback is forbidden"
+            ) from exc
+
+    def stamp(self, strategy_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        """Attach the immutable candidate identity to a materialized output."""
+
+        binding = self.binding_for(strategy_id)
+        return {
+            "strategy_id": binding.strategy_id,
+            "contract_hash": binding.contract_hash,
+            **dict(payload),
+        }
+
+
+def sha256_file(path: Path | str) -> str:
+    """Return a file SHA-256 without accepting a directory or a missing input."""
+
+    resolved = Path(path)
+    if not resolved.is_file():
+        raise RegistryStartRejected(f"required input missing or not a file: {resolved}")
+    return hashlib.sha256(resolved.read_bytes()).hexdigest()
+
+
+def verify_bound_inputs(paths: ArtifactPaths) -> VerifiedInputs:
+    """Recompute and cross-check every SHA named by golden v5.
+
+    The artifact root is allowed to contain only the five named fixture files and
+    explicitly named variant directories for this verification path.  No corpus
+    path, especially no holdout path, is accepted here.
+    """
+
+    fixture_root = _safe_fixture_root(paths.fixture_root)
+    candidate_sha = _require_sha(
+        paths.candidates_yaml, CANDIDATES_SHA256, label="candidate YAML"
+    )
+    golden_sha = _require_sha(paths.golden_v5, GOLDEN_V5_SHA256, label="golden v5")
+    convention_paths = {
+        "amendment_a1_a9": paths.amendment_a1_a9,
+        "amendment_a10_a12": paths.amendment_a10_a12,
+        "amendment_a13_a14": paths.amendment_a13_a14,
+        "generator": paths.generator,
+    }
+    recomputed_conventions = {
+        name: _require_sha(path, CONVENTION_SHA256[name], label=name)
+        for name, path in convention_paths.items()
+    }
+
+    golden_raw = _read_regular_file(paths.golden_v5, label="golden v5")
+    try:
+        golden = json.loads(golden_raw)
+    except json.JSONDecodeError as exc:
+        raise RegistryStartRejected("golden v5 is not valid JSON") from exc
+    if not isinstance(golden, Mapping):
+        raise RegistryStartRejected("golden v5 root is not an object")
+    if golden.get("candidates_yaml_sha256") != candidate_sha:
+        raise RegistryStartRejected("golden/candidate SHA binding mismatch")
+    if golden.get("convention_sha256") != recomputed_conventions:
+        raise RegistryStartRejected("golden/convention SHA binding mismatch")
+
+    fixture_expected = _mapping_of_sha(golden.get("fixture_sha256"), "fixture_sha256")
+    if tuple(fixture_expected) != BASE_FIXTURE_FILENAMES:
+        raise RegistryStartRejected("golden base fixture filename/order drift")
+    fixture_actual = {
+        filename: _require_sha(
+            _fixture_file(fixture_root, filename), expected, label=filename
+        )
+        for filename, expected in fixture_expected.items()
+    }
+
+    raw_variants = golden.get("variant_fixture_sha256")
+    if not isinstance(raw_variants, Mapping) or not raw_variants:
+        raise RegistryStartRejected("golden variant fixture SHA mapping missing")
+    variant_actual: dict[str, Mapping[str, str]] = {}
+    for name, raw_files in raw_variants.items():
+        if not isinstance(name, str) or not name:
+            raise RegistryStartRejected("golden variant name invalid")
+        expected_files = _mapping_of_sha(raw_files, f"variant {name}")
+        if tuple(expected_files) != BASE_FIXTURE_FILENAMES:
+            raise RegistryStartRejected(f"variant fixture filename/order drift: {name}")
+        variant_root = _safe_child(fixture_root / "variants" / name, fixture_root)
+        variant_actual[name] = {
+            filename: _require_sha(
+                _fixture_file(variant_root, filename),
+                expected,
+                label=f"{name}/{filename}",
+            )
+            for filename, expected in expected_files.items()
+        }
+
+    return VerifiedInputs(
+        candidates_sha256=candidate_sha,
+        golden_sha256=golden_sha,
+        convention_sha256=recomputed_conventions,
+        fixture_sha256=fixture_actual,
+        variant_fixture_sha256=variant_actual,
+    )
+
+
+def _require_sha(path: Path | str, expected: str, *, label: str) -> str:
+    actual = sha256_file(path)
+    if actual != expected:
+        raise RegistryStartRejected(
+            f"{label} SHA mismatch: expected={expected} actual={actual}"
+        )
+    return actual
+
+
+def _read_regular_file(path: Path | str, *, label: str) -> bytes:
+    resolved = Path(path)
+    if not resolved.is_file():
+        raise RegistryStartRejected(f"{label} missing or not a file: {resolved}")
+    return resolved.read_bytes()
+
+
+def _safe_fixture_root(path: Path | str) -> Path:
+    root = Path(path).resolve()
+    if "holdout" in {part.casefold() for part in root.parts}:
+        raise RegistryStartRejected("fixture root may not be a holdout path")
+    if not root.is_dir():
+        raise RegistryStartRejected(f"fixture root missing or not a directory: {root}")
+    return root
+
+
+def _safe_child(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    if "holdout" in {part.casefold() for part in resolved.parts}:
+        raise RegistryStartRejected("fixture path may not include holdout")
+    if resolved != root and root not in resolved.parents:
+        raise RegistryStartRejected(f"fixture path escapes root: {path}")
+    return resolved
+
+
+def _fixture_file(root: Path, filename: str) -> Path:
+    if filename not in BASE_FIXTURE_FILENAMES:
+        raise RegistryStartRejected(f"unexpected fixture filename {filename!r}")
+    return _safe_child(root / filename, root)
+
+
+def _mapping_of_sha(raw: object, label: str) -> dict[str, str]:
+    if not isinstance(raw, Mapping):
+        raise RegistryStartRejected(f"{label} is not a SHA mapping")
+    result: dict[str, str] = {}
+    for name, value in raw.items():
+        if not isinstance(name, str) or not isinstance(value, str):
+            raise RegistryStartRejected(f"{label} contains a non-string SHA entry")
+        result[name] = value
+    return result
+
+
+def _parse_yaml_mapping(source: bytes, path: Path) -> Mapping[str, Any]:
+    try:
+        parsed = yaml.safe_load(source)
+    except yaml.YAMLError as exc:
+        raise RegistryStartRejected(f"candidate YAML parse failed: {path}") from exc
+    if not isinstance(parsed, Mapping):
+        raise RegistryStartRejected("candidate YAML root is not a mapping")
+    return parsed
+
+
+def _candidate_block_bytes(source: bytes) -> tuple[bytes, ...]:
+    """Return raw YAML list-item byte ranges, preserving the exact source bytes.
+
+    The source packet has one top-level ``candidates`` sequence.  A byte range
+    begins at the two-space list marker and ends immediately before the next
+    marker; this is the only source used for ``contract_hash``.
+    """
+
+    lines = source.splitlines(keepends=True)
+    offsets: list[int] = []
+    offset = 0
+    for line in lines:
+        if line.startswith(b"  - "):
+            offsets.append(offset)
+        offset += len(line)
+    if not offsets:
+        raise RegistryStartRejected("candidate YAML has no raw candidate blocks")
+    ends = (*offsets[1:], len(source))
+    return tuple(source[start:end] for start, end in zip(offsets, ends, strict=True))
+
+
+def _binding_from_candidate(raw: Mapping[str, Any], block: bytes) -> CandidateBinding:
+    strategy_id = raw.get("strategy_id")
+    market = raw.get("market")
+    parameters = raw.get("parameter_values")
+    required_strings = {
+        "entry": raw.get("entry"),
+        "exit": raw.get("exit"),
+        "ranking": raw.get("ranking"),
+        "tie_break": raw.get("tie_break"),
+        "signal": raw.get("signal"),
+        "missing_data_handling": raw.get("missing_data_handling"),
+    }
+    if not isinstance(strategy_id, str) or not isinstance(market, str):
+        raise RegistryStartRejected("candidate missing strategy_id or market")
+    if not isinstance(parameters, Mapping):
+        raise RegistryStartRejected(f"candidate {strategy_id} lacks parameter_values")
+    if any(not isinstance(value, str) for value in required_strings.values()):
+        raise RegistryStartRejected(
+            f"candidate {strategy_id} has a non-string contract field"
+        )
+    return CandidateBinding(
+        strategy_id=strategy_id,
+        market=market,
+        contract_hash=hashlib.sha256(block).hexdigest(),
+        source_block=block,
+        parameters=dict(parameters),
+        entry=required_strings["entry"],
+        exit=required_strings["exit"],
+        ranking=required_strings["ranking"],
+        tie_break=required_strings["tie_break"],
+        signal=required_strings["signal"],
+        missing_data_handling=required_strings["missing_data_handling"],
+    )
+
+
+def _assert_binding_implements_packet_contract(binding: CandidateBinding) -> None:
+    """Reject parser/code semantic drift before a candidate is executable.
+
+    Full file SHA binding catches any serialized-input change.  These additional
+    checks make the code's three formula implementations explicit and prevent
+    a strategy name from silently reaching a similarly named fallback.
+    """
+
+    expected_parameters: Mapping[str, Mapping[str, Any]] = {
+        "rev3_reclaim": {
+            "liquidity_percentile_min": 0.50,
+            "reversal_lookback_sessions": 3,
+            "loser_percentile_max": 0.05,
+            "close_location_min": 0.65,
+            "volume_ratio_min": 1.50,
+            "holding_sessions": 5,
+            "max_concurrent_positions": 10,
+        },
+        "brk20_confirm": {
+            "liquidity_percentile_min": 0.50,
+            "breakout_lookback_sessions": 20,
+            "close_location_min": 0.75,
+            "volume_ratio_min": 1.25,
+            "holding_sessions": 10,
+            "max_concurrent_positions": 10,
+        },
+        "lowvol_up_month": {
+            "selection_schedule": "calendar_month_last_xkrx_session",
+            "liquidity_percentile_min": 0.50,
+            "volatility_lookback_sessions": 20,
+            "low_volatility_percentile_max": 0.30,
+            "trend_lookback_sessions": 20,
+            "trend_return_floor": 0.0,
+            "holding_sessions": 20,
+            "max_concurrent_positions": 10,
+        },
+    }
+    expected = expected_parameters.get(binding.strategy_id)
+    if expected is None:
+        raise RegistryStartRejected(
+            f"no exact packet implementation for {binding.strategy_id!r}; fallback forbidden"
+        )
+    if binding.market != "KR":
+        raise RegistryStartRejected(f"candidate {binding.strategy_id} market drift")
+    if dict(binding.parameters) != dict(expected):
+        raise RegistryStartRejected(
+            f"candidate {binding.strategy_id} parameter/code binding mismatch"
+        )
+    if binding.entry != "t_plus_1_open":
+        raise RegistryStartRejected(
+            f"candidate {binding.strategy_id} entry contract drift"
+        )
+    if "no-fill" not in binding.missing_data_handling.casefold():
+        raise RegistryStartRejected(
+            f"candidate {binding.strategy_id} no-fill contract drift"
+        )
+    if "KOSPI" not in binding.tie_break or "KOSDAQ" not in binding.tie_break:
+        raise RegistryStartRejected(
+            f"candidate {binding.strategy_id} tie-break contract drift"
+        )
+    if binding.strategy_id == "rev3_reclaim":
+        required = ("r3_pct_t", "clv_t", "volume_ratio_t")
+    elif binding.strategy_id == "brk20_confirm":
+        required = ("prior_high20_t", "breakout_margin_t", "clv_t")
+    else:
+        required = ("vol20_t", "vol20_pct_t", "r20_t")
+    if any(token not in binding.signal for token in required):
+        raise RegistryStartRejected(
+            f"candidate {binding.strategy_id} signal/code binding mismatch"
+        )
+
+
+def expected_variant_names(inputs: VerifiedInputs) -> Sequence[str]:
+    """Expose the immutable variant set for callers that need full E2E coverage."""
+
+    return tuple(inputs.variant_fixture_sha256)

--- a/tests/fixtures/kr_a0_golden_v5/02-active-candidates.yaml
+++ b/tests/fixtures/kr_a0_golden_v5/02-active-candidates.yaml
@@ -1,0 +1,187 @@
+packet_status: active_scope_only
+active_scope_meaning: "이번 prior-art 조사 범위. admission, 승인, 백테스트 통과, paper 승격 또는 주문 승인이 아님. 모든 후보는 UNTESTED."
+source_files:
+  kr:
+    path: gptpro-kr-candidates-v1.md
+    sha256: 0639592817f13db80f1d67b199ffe80898b23675475d1fbf1a611ea2b6b671dc
+  us:
+    path: gptpro-us-candidates-v1.md
+    sha256: 6ec8e31d8252b0f396da205ea37938d85ea4933345bd578573154aa4364a2ae7
+candidates:
+  - market: KR
+    strategy_id: rev3_reclaim
+    family_id:
+      status: NOT_AVAILABLE_IN_SOURCE
+      value: null
+      source_file: gptpro-kr-candidates-v1.md
+      source_location: "candidate block strategy_id=rev3_reclaim; family_id not present in source"
+    cost_assumption:
+      base: "approximately 43 bp round trip (fee 3 bp + sell tax 20 bp + slippage 10 bp/side)"
+      sensitivity: "approximately 83 bp round trip with slippage 30 bp/side"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    hypothesis: "같은 시장의 유동성 적격 종목 중 3세션 수익률이 극단적으로 낮았지만 당일 종가가 일중 범위 상단으로 회복되고 거래량이 급증한 경우, 정보에 의한 영구 재평가보다 일시적 매도 압력이 포함되어 이후 5세션 동안 baseline 대비 반전 초과성과가 나타날 수 있다."
+    side: long
+    universe_filter: "PIT 상장목록 포함; 공통 적격성; liq_pct_t >= 0.50; close×volume은 실제 거래대금이 아닌 유동성 프록시."
+    signal: "r3_t = close_t / close_{t-3} - 1; r3_pct_t = 같은 시장 universe_filter 통과 종목 사이 pct_asc(r3_t); clv_t = (close_t - low_c_t)/(high_c_t - low_c_t); volume_ratio_t = volume_t / median(volume_{t-20}..volume_{t-1}); r3_pct_t <= 0.05 AND clv_t >= 0.65 AND volume_ratio_t >= 1.50 AND high_c_t > low_c_t. r3 percentile은 시장별 계산 후 KOSPI/KOSDAQ 신호를 합쳐 최종 순위."
+    required_history: "현재 세션 포함 연속 21개 XKRX 거래 세션 (close/volume t-20..t)"
+    missing_data_handling: "필요 21세션 중 OHLCV 결측·비양수면 신호 미계산; high_c_t=low_c_t면 clv 미정의로 신호 없음; 보간 금지; 선택 후 t+1 bar 없으면 no-fill, 대체 종목 없음; 보유 중 상폐는 하네스 터미널 규칙."
+    entry: t_plus_1_open
+    exit: "진입 체결일 D 기준 D+5 XKRX 세션 종가 매도"
+    ranking: "r3_pct_t 오름차순 → r3_t 오름차순 → clv_t 내림차순 → volume_ratio_t 내림차순 → liq_pct_t 내림차순"
+    tie_break: "market 순서 KOSPI, KOSDAQ → zero-padded symbol 오름차순"
+    sizing: "정규화 notional 1.0 동일 · 동시 보유 상한 10 · 중복 보유/추가매수 금지, 재신호 무시 후 차순위로 슬롯 충원"
+    parameter_values: {liquidity_percentile_min: 0.50, reversal_lookback_sessions: 3, loser_percentile_max: 0.05, close_location_min: 0.65, volume_ratio_min: 1.50, holding_sessions: 5, max_concurrent_positions: 10}
+    param_sensitivity: "liq↑=거래수↓ · lookback↑=반전 지연 · loser_pct↓=희소·강도↑ · clv↑=표본↓ · vol_ratio↑=빈도↓ · hold↑=회전율↓·노출↑"
+    expected_trade_frequency: "사전 추정 월 10~30건; capacity 상한 ≈ floor(월 세션수/5)×10; corpus 관측 아님."
+    falsification: "2015~2024 filled trade <300; 또는 43bp 비용 후 같은 세션·D+5·유사 유동성 baseline 대비 거래당 평균 초과수익 ≤0; 또는 진입 세션 군집 one-sided 90% CLB ≤0; 또는 10개 연도 중 양수 연도 <6."
+    empirical_status: UNTESTED
+  - market: KR
+    strategy_id: brk20_confirm
+    family_id:
+      status: NOT_AVAILABLE_IN_SOURCE
+      value: null
+      source_file: gptpro-kr-candidates-v1.md
+      source_location: "candidate block strategy_id=brk20_confirm; family_id not present in source"
+    cost_assumption:
+      base: "approximately 43 bp round trip (fee 3 bp + sell tax 20 bp + slippage 10 bp/side)"
+      sensitivity: "approximately 83 bp round trip with slippage 30 bp/side"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    hypothesis: "직전 20세션 모든 고가를 종가로 돌파하고 종가 위치·거래량이 강하면 정보 반영이 여러 세션에 걸쳐 진행되어 이후 10세션 지속 초과성과가 가능하다."
+    side: long
+    universe_filter: "PIT 포함 · 공통 적격성 · liq_pct_t >= 0.50 (close×volume 프록시)"
+    signal: "prior_high20_t = max(high_c_{t-20..t-1}); breakout_margin_t = close_t/prior_high20_t - 1; clv_t = (close_t-low_c_t)/(high_c_t-low_c_t); volume_ratio_t = volume_t/median(volume_{t-20..t-1}); breakout_margin_t > 0 AND clv_t >= 0.75 AND volume_ratio_t >= 1.25 AND high_c_t > low_c_t. 종목 자체 20세션 time-series breakout."
+    required_history: "연속 21개 XKRX 세션 (clamp high·volume t-20..t-1 + 당일 OHLCV)"
+    missing_data_handling: "결측·비양수 시 신호 없음 · high_c=low_c 신호 없음 · 고가 결측 너머 연결 금지 · no-fill 대체 없음 · 상폐 터미널 규칙"
+    entry: t_plus_1_open
+    exit: "D+10 XKRX 세션 종가 매도"
+    ranking: "breakout_margin_t 내림차순 → volume_ratio_t 내림차순 → clv_t 내림차순 → liq_pct_t 내림차순"
+    tie_break: "KOSPI, KOSDAQ → zero-padded symbol 오름차순"
+    sizing: "notional 1.0 · 상한 10 · 중복/추가매수 금지"
+    parameter_values: {liquidity_percentile_min: 0.50, breakout_lookback_sessions: 20, close_location_min: 0.75, volume_ratio_min: 1.25, holding_sessions: 10, max_concurrent_positions: 10}
+    param_sensitivity: "liq↑=거래수↓ · lookback↑=희소·강도↑ · clv↑=표본↓ · vol_ratio↑=정상 돌파 누락 · hold↑=false breakout 노출↑"
+    expected_trade_frequency: "사전 추정 월 6~18건; capacity ≈ floor(월 세션수/10)×10; corpus 관측 아님."
+    falsification: "filled <300; 또는 43bp 후 baseline 초과 ≤0; 또는 진입 세션 군집 90% CLB ≤0; 또는 양수 연도 <6."
+    empirical_status: UNTESTED
+  - market: KR
+    strategy_id: lowvol_up_month
+    family_id:
+      status: NOT_AVAILABLE_IN_SOURCE
+      value: null
+      source_file: gptpro-kr-candidates-v1.md
+      source_location: "candidate block strategy_id=lowvol_up_month; family_id not present in source"
+    cost_assumption:
+      base: "approximately 43 bp round trip (fee 3 bp + sell tax 20 bp + slippage 10 bp/side)"
+      sensitivity: "approximately 83 bp round trip with slippage 30 bp/side"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    hypothesis: "월말 기준 최근 변동성 시장 하위 30%이고 20세션 수익률이 양수인 종목은 하방 변동이 작게 유지되며 다음 20세션 초과성과가 양수일 수 있다."
+    side: long
+    universe_filter: "월 마지막 XKRX 세션 한정 · PIT 포함 · 공통 적격성 · liq_pct_t >= 0.50"
+    signal: "vol20_t = std(r1_{t-19..t}, ddof=1); vol20_pct_t = 같은 시장 내 pct_asc(vol20_t); r20_t = close_t/close_{t-20}-1; vol20_pct_t <= 0.30 AND r20_t > 0."
+    required_history: "월말 포함 연속 21개 XKRX 세션"
+    missing_data_handling: "결측·비양수 시 해당 월 제외 · 보간 금지 · no-fill 차순위 보충 없음 · 기보유 제외 후 차순위 충원 · 상폐 터미널 규칙"
+    entry: t_plus_1_open
+    exit: "D+20 XKRX 세션 종가 매도"
+    ranking: "vol20_pct_t 오름차순 → vol20_t 오름차순 → r20_t 내림차순 → liq_pct_t 내림차순"
+    tie_break: "KOSPI, KOSDAQ → zero-padded symbol 오름차순"
+    sizing: "notional 1.0 · 상한 10 · 월말 강제 청산/재조정 없음, D+20 만기 유지 · 잔여 슬롯만 신규"
+    parameter_values: {selection_schedule: calendar_month_last_xkrx_session, liquidity_percentile_min: 0.50, volatility_lookback_sessions: 20, low_volatility_percentile_max: 0.30, trend_lookback_sessions: 20, trend_return_floor: 0.0, holding_sessions: 20, max_concurrent_positions: 10}
+    param_sensitivity: "liq↑=선택폭↓ · vol lookback↑=반영 지연 · lowvol_pct↓=방어적·참여도↓ · trend_floor↑=momentum 성격화 · hold↑=정합성 약화 · schedule 변경=신규 등록 대상"
+    expected_trade_frequency: "사전 추정 월 5~10건; 월 1회 평가·슬롯 10, D+20 잔존 시 슬롯 감소; corpus 관측 아님."
+    falsification: "filled <300; 또는 43bp 후 baseline 초과 ≤0; 또는 90% CLB ≤0; 또는 양수 연도 <6."
+    empirical_status: UNTESTED
+  - market: US
+    strategy_id: US-TS-MOM-CONT-Z126-H20-v1
+    family_id:
+      status: SOURCE_PROVIDED
+      value: US-TS-MOM-CONT
+      source_file: gptpro-us-candidates-v1.md
+      source_location: "candidate block strategy_id=US-TS-MOM-CONT-Z126-H20-v1; family_id"
+    cost_assumption:
+      base: "10 bp/side (20 bp round trip)"
+      sensitivity: "5 bp/side (10 bp round trip)"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    source_text: "CONDITIONAL_DRAFT; v1.1 survivor corpus 공통 사실 기준으로 설계됨. 역사적 missing_data 문구는 만기 close 부재=하네스 TBD-3 미해결로 run-invalid이라고 기록함."
+    current_constraint_resolution: "현재 US 하네스 v1.2에서 만기 close 부재는 run-invalid으로 해소됨. 후보 정의를 수정하지 않고 현재 실행 제약만 이 값으로 해석한다."
+    hypothesis: "126세션 상승률이 자기 변동성 대비 충분히 크고(z126≥1.0) 21세션 수익률·63세션 SMA가 방향 확인하면 다음 20세션 지속 가능성이 동일 유동성 baseline보다 높다."
+    side: long
+    universe_filter: "ADV20_pre_proxy >= USD 5,000,000 · 20개 volume 전부 양수·유한 · 필요 close 이력 존재 (프록시 명시)"
+    signal: "R126=C_t/C_(t-126)-1; z126=R126/(sigma63×sqrt(126)); signal=(z126>=1.0) AND (R21>0.0) AND (C_t>SMA63) AND no_active_position(symbol). 전 항 자기 이력만."
+    required_history: "127개 corpus session 유효 close · 최근 63개 수익률 · 이전 20개 유효 volume"
+    missing_data_handling: "필요 bar 결측·null·비유한·비양수 시 신호 미생성 · forward-fill/보간/winsorization 금지 · t+1 open 부재=no-fill · 만기 close 부재의 source_text는 역사적 TBD-3이며 현재 v1.2 resolution은 run-invalid (조용한 대체 금지)."
+    entry: t_plus_1_open
+    exit: "D+20 session close (corpus session index 기준, 조기 청산 없음)"
+    ranking: "슬롯 초과 시 ADV20_pre_proxy 내림차순만. 수익률·z126·신호강도 횡단면 순위 금지"
+    tie_break: "sha256(strategy_id || session_date || symbol) 바이트 오름차순"
+    sizing: "종목당 USD 500 고정 notional · 복리 없음 · 최대 10종목 · pyramiding 없음 · execution_envelope_compatible=CONDITIONAL"
+    parameter_values: {adv20_min_usd: 5000000, trend_lookback_sessions: 126, trend_vol_lookback_sessions: 63, trend_z_min: 1.0, confirmation_lookback_sessions: 21, confirmation_return_min: 0.0, sma_lookback_sessions: 63, hold_sessions: 20, fixed_notional_usd: 500, max_positions: 10}
+    param_sensitivity: NOT_AVAILABLE_IN_SOURCE
+    expected_trade_frequency: "DESIGN_PRIOR 월 4~10건; raw incidence 미지; FREQ_QUERY로 확인."
+    falsification: "2024년 말 완료 거래 <400 또는 고유 진입 세션 <120, 또는 validation 2023~2024 <60건·고유 세션 <24면 폐기; 충족해도 validation entry-session 동일가중 비용차감 cohort 초과 ≤0bp면 폐기."
+    execution_envelope: "CONDITIONAL; source envelope의 미확정 실행 세부사항은 UNKNOWN으로 보존."
+    empirical_status: UNTESTED
+  - market: US
+    strategy_id: US-TS-REV-SHORT-Z3-T126-H3-v1
+    family_id:
+      status: SOURCE_PROVIDED
+      value: US-TS-REV-SHORT
+      source_file: gptpro-us-candidates-v1.md
+      source_location: "candidate block strategy_id=US-TS-REV-SHORT-Z3-T126-H3-v1; family_id"
+    cost_assumption:
+      base: "10 bp/side (20 bp round trip)"
+      sensitivity: "5 bp/side (10 bp round trip)"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    source_text: "CONDITIONAL_DRAFT; v1.1 survivor corpus 공통 사실 기준으로 설계됨. 역사적 TBD-3 미해결 문구를 포함함."
+    current_constraint_resolution: "현재 US 하네스 v1.2에서 만기 close 부재는 run-invalid으로 해소됨. 후보 정의를 수정하지 않고 현재 실행 제약만 이 값으로 해석한다."
+    hypothesis: "126세션 자기 추세 양수인 종목의 자기 변동성 대비 과도한 3세션 하락(z3<=-2.0)은 다음 3세션 부분 회귀 가능."
+    side: long
+    universe_filter: "ADV20_pre_proxy >= USD 5,000,000 · 절대 주가 미사용"
+    signal: "R3=C_t/C_(t-3)-1; z3=R3/(sigma60×sqrt(3)); signal=(z3<=-2.0) AND (R126>0.0) AND no_active_position"
+    required_history: "127개 session close · 최근 60개 수익률 · 이전 20개 volume"
+    missing_data_handling: "결측·비유한·비양수·sigma60=0 → 신호 미생성 · 보간 없음 · no-fill/run-invalid 규칙 동일; 역사적 TBD-3는 현재 v1.2에서 만기 close 부재=run-invalid으로 해소."
+    entry: t_plus_1_open
+    exit: "D+3 session close (stop·목표가·조기 청산 없음)"
+    ranking: "ADV20_pre_proxy 내림차순만 (하락폭·z3 우선 금지)"
+    tie_break: "sha256 바이트 오름차순"
+    sizing: "USD 500 · 최대 10 · execution_envelope_compatible=CONDITIONAL_COST_SENSITIVE"
+    parameter_values: {adv20_min_usd: 5000000, shock_lookback_sessions: 3, shock_vol_lookback_sessions: 60, shock_z_max: -2.0, trend_lookback_sessions: 126, trend_return_min: 0.0, hold_sessions: 3, fixed_notional_usd: 500, max_positions: 10}
+    param_sensitivity: NOT_AVAILABLE_IN_SOURCE
+    expected_trade_frequency: "DESIGN_PRIOR 월 15~50건; 실제 2σ 하락 발생률 미지; FREQ_QUERY."
+    falsification: "완료 거래 <1,000 또는 고유 진입 세션 <200, validation <200건·고유 <50·각 연도 <80이면 폐기; 10bp/side에서 2023~2024 초과 ≤0bp 폐기; 5bp/side 양수인데 10bp/side ≤0이면 비용 민감 실패."
+    execution_envelope: "CONDITIONAL_COST_SENSITIVE; source envelope의 장중 집행·프리/애프터·비용은 UNKNOWN."
+    empirical_status: UNTESTED
+  - market: US
+    strategy_id: US-TS-VOLBREAK-C55-V2-H10-v1
+    family_id:
+      status: SOURCE_PROVIDED
+      value: US-TS-VOLBREAK
+      source_file: gptpro-us-candidates-v1.md
+      source_location: "candidate block strategy_id=US-TS-VOLBREAK-C55-V2-H10-v1; family_id"
+    cost_assumption:
+      base: "10 bp/side (20 bp round trip)"
+      sensitivity: "5 bp/side (10 bp round trip)"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    source_text: "CONDITIONAL_DRAFT; v1.1 survivor corpus 공통 사실 기준으로 설계됨. 역사적 TBD-3 미해결 문구를 포함함."
+    current_constraint_resolution: "현재 US 하네스 v1.2에서 만기 close 부재는 run-invalid으로 해소됨. 후보 정의를 수정하지 않고 현재 실행 제약만 이 값으로 해석한다."
+    hypothesis: "55세션 종가 고점 상향 돌파와 자기 거래량 중앙값 2배 이상 동반 시 다음 10세션 지속성 가능."
+    side: long
+    universe_filter: "ADV20_pre_proxy >= USD 5,000,000 · volume 분할조정 여부 UNKNOWN 명시"
+    signal: "prior_close_high55=max(C_(t-55)..C_(t-1)); volume_ratio20=V_t/median(V_(t-20)..V_(t-1)); signal=(C_t>prior_close_high55) AND (R1>0.0) AND (2.0<=volume_ratio20<=10.0) AND no_active_position. high/low 미사용"
+    required_history: "56개 session close · 이전 20개+당일 양수 volume"
+    missing_data_handling: "결측·비유한·비양수·중앙값 0 → 신호 없음 · ratio 상한 10은 극단치 완화 guard이나 분할 오염 완전 제거 아님 · no-fill/run-invalid 동일"
+    entry: t_plus_1_open
+    exit: "D+10 session close (재이탈 조기 청산 없음)"
+    ranking: "ADV20_pre_proxy 내림차순만"
+    tie_break: "sha256 바이트 오름차순"
+    sizing: "USD 500 · 최대 10 · execution_envelope_compatible=CONDITIONAL_DATA_AND_COST"
+    parameter_values: {adv20_min_usd: 5000000, breakout_lookback_sessions: 55, volume_lookback_sessions: 20, volume_ratio_min: 2.0, volume_ratio_max: 10.0, daily_return_min: 0.0, hold_sessions: 10, fixed_notional_usd: 500, max_positions: 10}
+    param_sensitivity: NOT_AVAILABLE_IN_SOURCE
+    expected_trade_frequency: "DESIGN_PRIOR 월 6~19건; FREQ_QUERY."
+    falsification: "완료 <500 또는 고유 세션 <150, validation <100·고유 <30·각 연도 <40이면 폐기; 10bp/side 초과 ≤0bp 폐기; validation volume_ratio 상위 1% 제외 시 초과 ≤0bp 또는 상위 1%가 validation 초과의 50% 초과면 극단치 의존 폐기."
+    execution_envelope: "CONDITIONAL_DATA_AND_COST; volume 조정 여부와 비용은 UNKNOWN."
+    empirical_status: UNTESTED

--- a/tests/fixtures/kr_a0_golden_v5/CONTRACT.md
+++ b/tests/fixtures/kr_a0_golden_v5/CONTRACT.md
@@ -1,0 +1,76 @@
+# kr-golden-vectors-v1 — 소비 계약 (golden v5)
+
+```
+작성: claude-mock (상류 분석, wB:p4R) · 2026-08-05 (v5 — codex-mock 4차 적대검증 FIX_FIRST 반영)
+대상: KR-A0 구현·검증 워커
+후보 정본: prior-art-map-v1/02-active-candidates.yaml
+  sha256 = 0f5e92bf7d10dd77588fa08ad949811a68004cf71dd7f2efd232306b22d82d85
+convention 정본: 운영자 확정 amendment A1~A9 + A10~A12 + A13~A14 (전부 ~/work/herdr-inbox/,
+  지위 ✅확정) — SHA 는 golden_v5.json `convention_sha256` 결속 (generator 자체 포함)
+⚠️ v1~v4 산출물 superseded — 소비 금지. 정본 = golden_v5.json.
+```
+
+## 파일
+
+```
+fa9a3a1adbb47f80e0980e99e3f641ef0f331c21e4801bee296366f3735cb97b  golden_v5.json
+e9e744932594da41…  fixture_bars.csv        9907044e1f54d0a1…  fixture_sessions.csv
+280f829080580d4c…  fixture_config.csv      88709819a088145e…  fixture_membership.csv
+588778f5e883b798…  fixture_delist_events.csv
+variants/<name>/   자기완결 variant 디렉토리 10종 — 실패 7종은 지정 라벨로 **실패해야 하고**,
+                   대조 3종은 지정 결과로 **완주해야 한다** (5파일 전체 SHA 가 golden 에 결속):
+  invalid_maturity → RUN_INVALID_MATURITY_PRICE · data_gap → RUN_INVALID_DATA_GAP ·
+  duplicate_row → RUN_INVALID_DUPLICATE_ROW (로더) · nofill_no_substitution →
+  QA6=NO_FILL·KA5=SKIPPED 유지·16거래 (차순위 대체 구현 격추) ·
+  identity_conflict → RUN_INVALID_IDENTITY_CONFLICT (동시 양시장 membership) ·
+  market_transfer → RUN_INVALID_MARKET_TRANSFER (보유 중 이전상장 — 가격 해석 전
+  membership_end < exit_due 게이트 — **stale-valid 만기 bar 보존**: 만기-무효-시에만 transfer 검사하는 mutant 는 완주해버려 격추됨) ·
+  market_transfer_missing_maturity → 같은 transfer 인데 만기 bar 결측 — 그래도
+  RUN_INVALID_MARKET_TRANSFER (만기-먼저 mutant 는 MATURITY_PRICE 를 내어 격추 —
+  두 variant 가 우선순위 양방향을 봉인) · 대조 3종: data_gap_control_all_invalid →
+  전부-무효-but-존재 rows 는 gap 아님(완주) · stale_delist_bar → 상폐 증거가
+  stale-valid 만기 bar 에 우선(KA4 거래 base 와 동일 + QA5 cohort baseline exact 값 결속 —
+  maturity-first baseline mutant 는 gross_mean 부호가 뒤집혀 격추) · holdout_leg_control →
+  s53+ 시작 membership leg 는 구조적으로 불가시(base 와 결과 동일·oob 0·clamped
+  symbol/membership key set 부재가 golden 에 직렬화됨)
+```
+
+## 핵심 판별기
+
+- **경계 봉인 (A14-5)**: `exploration_end=52` 는 명시 입력, 파일은 s55 까지 존재.
+  **membership 메타데이터도 World 구성 시 경계로 clamp** — identity/transfer 검사가
+  holdout leg 를 구조적으로 볼 수 없음. 엔진의 모든
+  iteration·gap검사·신호계산은 `t ≤ 52`. **access-spy: 경계 밖 bar read == 0** 이 acceptance
+  조건 (`golden_v5.json.access_spy_oob_reads = 0`). KA2@47·KH1@49 는 bar 존재해도 censored.
+- **2단계 선발 (A10-1)**: held 스킵은 선발 대체 허용, no-fill 은 슬롯 소멸 — variant 가 증인.
+- **A13 identity**: `"000420"` = 이전상장 모양 (KOSDAQ 0..20 → KOSPI 23..55, disjoint,
+  신규 leg 의 pre-membership bar 없음) — **적격성은 21세션 전 구간 membership** 이라
+  KOSPI 쪽 최초 신호는 s43 (s42 에는 비적격 — pre-list history 사용 구현 격추). symbol-only 키는 붕괴. 동시 중복·보유 중 이동은 variant 로 격추.
+- **A12 field-level**: KG1 entry (high blank) 체결 · KA3 만기 (open/high/low blank) 정상 청산 ·
+  KA4/QD1 상폐 역탐색 close+volume-only (QD1 은 **event 세션 bar 를 사용** — d−1 구현 격추) ·
+  QD2 = entry close blank 로 체결 후 유효 종가 없음 → **gross −100%** · KE5 blank volume 무효.
+- **exact 경계 (float 정확)**: KB1@45 `clv == 0.65 ∧ ratio == 1.5` (정수 프라이스 13/20) ·
+  KB2@38 `clv == 0.75 ∧ ratio == 1.25` · KH1@49 `r3_pct == 0.05` (모집단 20) · s49 min
+  `liq_pct == 0.5` · KD4@37 `margin == 0.0` · QH1@31 `r20 == 0.0` · LV5 900180@44
+  `vol20_pct == 0.3` (모집단 20, rank 6).
+- **A4**: baseline 이 거래와 동일한 순서 (상폐 증거 → 만기 bar). `cohort_excluded_entry ≥ 1`
+  (QA1) · `cohort_terminal_included ≥ 1` (QA5) 카운트 공개.
+- **A11+A14 합성**: 17거래 × 43/83bp 4게이트 실제 산출, 12 클러스터 → top-level
+  `UNIDENTIFIABLE_CLUSTERS`(축약 금지) + `cost_sensitive` flag. **compose oracle**: 실제 compose 함수 통과 — PASS / FALSIFIED /
+  COST_SENSITIVE / RUN_INVALID_EMPTY_BASELINE + **정확 경계**(filled 300/299 ·
+  클러스터 30/29 · 초과 0 · **양수연도 6/5 가 유일 gate 차이인 full-profile** ·
+  세션동일가중 vs 거래가중 연도 판별 · **Dec진입/Jan청산 entry-year 귀속**) 고정.
+- lowvol: ml {9(이력부족)·29(8진입)·31(held 5 무시 유지+2충원+2 SKIP)·44(전부 censored)} ·
+  Q01 s50 만기까지 강제청산 없음.
+
+## 검증 요구
+
+1. fixture 양자화 — 재계산 exact 일치. `==` 명시 항목은 float 정확 일치.
+2. **양방향 증명**: mutation test (strict `<`·raw high·global percentile·no-fill 대체·full-bar
+   entry/maturity validity·symbol-only identity·경계 밖 read — 각각 검출) + tamper test.
+   실제 CI 테스트로 제공. **access-spy 테스트 필수.**
+3. variant 10종은 지정 결과와 정확히 일치해야 한다 (실패 7종의 라벨·대조 3종의 완주 결과 —
+   golden_v5.json `E2E.variants` 가 정본).
+4. 의도된 결측·오류는 시나리오 — "수리" 금지.
+5. golden 미통과 시 registry 기동 거부 경로 증명.
+6. convention 충돌 → `NEEDS_UPSTREAM` — 조용한 적응 금지.

--- a/tests/fixtures/kr_a0_golden_v5/inbox/amendment-kr-engine-a10-a12-draft-20260805.md
+++ b/tests/fixtures/kr_a0_golden_v5/inbox/amendment-kr-engine-a10-a12-draft-20260805.md
@@ -1,0 +1,54 @@
+# [DRAFT — 운영자 확정 대기] KR 엔진 amendment 추가분 A10~A12
+
+```
+작성: claude-mock (상류 분석, wB:p4R) · 2026-08-05 09:5x KST
+지위: ✅ 확정 — 운영자가 claude-mock 대화에서 2026-08-05 10:0x 승인.
+      결정 정본 operator-decisions-20260805-0830.md §4차 확정에 편입됨.
+근거: codex-mock 2차 적대검증 answer-codexmock-golden-xcheck2-0935.md —
+      "C10 은 운영자 승인 범위(A1~A9)를 넘어선 새 정본" 판정 + empty-baseline·
+      field-level validity 결정 공백 지적. 결과를 보기 전(첫 ㉠ 백테스트 전) 봉인.
+전제: no-fill 차순위 보충 금지는 결정이 아니라 **동결 YAML 위반 수정**(2단계 선발)이므로
+      이 문서에 없다 — v3 에서 구현 수정.
+```
+
+## A10 — temporal semantics (구 C10 의 ratification)
+
+1. **선발 2단계**: 신호 세션 t 에 랭킹 순회로 (held 스킵하며) 가용 슬롯 수만큼 **선발 확정** →
+   t+1 open 에서 체결 평가. **no-fill 은 슬롯 소멸 — 차순위 보충 없음** (YAML literal).
+   held 재신호만 선발 단계에서 차순위로 대체된다 ("재신호 무시 후 차순위로 슬롯 충원").
+2. held/capacity 판정 시점 = **entry 세션(t+1) open**. 세션 s 에 만기(exit_due=s)인 포지션은
+   s open 에 아직 슬롯 점유, s close 청산, **s+1 open 부터 해제**.
+3. 상폐 terminal: event 세션 d 에 종료 기록, 슬롯은 **d+1 부터 해제**.
+4. **A6-1 censoring 판정이 held/capacity 판정에 선행** (달력 판정이 포트폴리오 판정보다 먼저).
+5. 보유 중간 세션의 bar 결측·무효는 **허용** — entry 와 만기(및 상폐 최종 유효가 탐색)만
+   가격 유효성을 요구한다.
+6. **A6-1 의 경계는 명시 입력** `exploration_end_session` (2024 마지막 XKRX 세션) — "corpus
+   파일 끝"으로 유도 금지. D+N > 경계 → RIGHT_CENSORED_NOT_TRADEABLE (사전 제외).
+
+## A11 — verdict 합성·방어 규칙
+
+1. 후보 최종 verdict 우선순위: `RUN_INVALID_* > UNIDENTIFIABLE_*(식별성 floor 미달) >
+   FALSIFIED > PASS`. 식별성 floor = 진입 세션(cluster) ≥ 30 (A5) — 미달 시 개별 게이트
+   판정값은 참고로 병기하되 PASS/FALSIFIED 를 선언하지 않는다.
+2. YAML 4 게이트(filled≥300 · 평균 초과>0 · 군집 90% LCB>0 · 양수 연도≥6)는 **모두 실제
+   fills 에서 합성**되어 단일 verdict 로 이어져야 한다 (단위 수식만 맞추는 구현 불인정).
+3. **empty baseline**: A4 자기 포함 규칙상 체결된 전략 거래의 cohort 는 공집합이 될 수 없다
+   (자기 자신이 항상 구성원 — 상폐 거래도 C8 로 포함). 따라서 공집합 발생 = 구현 오류 신호 —
+   방어적으로 `RUN_INVALID_EMPTY_BASELINE` fail-closed (조용한 분모 제거 금지).
+
+## A12 — field-level 가격 유효성 predicate
+
+`valid_bar`(전 필드 finite·양수 — **volume 도 finite**) 는 **적격성/신호 계산(A8)** 에만 적용.
+실행 단계는 필드별 predicate 로 분리한다:
+
+| 단계 | 요구 필드 | 미충족 시 |
+|---|---|---|
+| entry (t+1 open) | `open` finite·>0 ∧ `volume` >0 (미거래 방지) | NO_FILL |
+| 만기 (D+N close) | `close` finite·>0 ∧ `volume` >0 | 상폐 증거 있으면 C8, 없으면 RUN_INVALID_MATURITY_PRICE |
+| 상폐 최종 유효가 탐색 | `close` finite·>0 ∧ `volume` >0 (event 세션 포함해 역탐색) | 없으면 −100% |
+| liq (close×volume) | A8 전체 bar 유효성에 포함됨 | 모집단 제외 |
+
+## A9 보강 (fail-closed 구체화 — 신규 결정 아님, 검증 벡터 의무화)
+
+- 동일 symbol 이 양시장에 동시 존재하는 fixture + 시장별 독립 처리 golden.
+- duplicate `(market,symbol,session)` 입력 → `RUN_INVALID_DUPLICATE_ROW` fail-closed.

--- a/tests/fixtures/kr_a0_golden_v5/inbox/amendment-kr-engine-a13-a14-draft-20260805.md
+++ b/tests/fixtures/kr_a0_golden_v5/inbox/amendment-kr-engine-a13-a14-draft-20260805.md
@@ -1,0 +1,42 @@
+# [DRAFT — 운영자 확정 대기] KR 엔진 amendment 추가분 A13~A14
+
+```
+작성: claude-mock (상류 분석, wB:p4R) · 2026-08-05 10:5x KST
+지위: ✅ 확정 — 운영자가 claude-mock 대화에서 2026-08-05 11:0x 승인 (+ v4→4차검증→PASS 시
+      추가 왕복 없는 KR-A0 릴레이 자동 진행 승인). 결정 정본 §5차 확정 편입.
+근거: codex-mock 3차 적대검증 answer-codexmock-golden-xcheck3-1025.md — A9 문언 충돌
+      (BLOCKER 2)과 verdict/연도 규약 공백(P1-6)은 구현 워커에게 넘길 수 없는 상류 결정.
+      (경계 밖 접근 BLOCKER 1 은 결정이 아니라 구현 수정 — v4 에서 access-spy 로 봉인.)
+```
+
+## A13 — identity 의미론 단일화 (A9 문언 충돌 해소)
+
+KRX 사실관계: 6자리 종목코드는 시점 기준 양시장 통틀어 유일하다. 같은 코드가 **동시에**
+양시장에 존재 = 데이터 오염. 단 이전상장(KOSDAQ→KOSPI 등)으로 코드가 시장을 **이동**할 수
+있다 (`003670` 사건의 실체).
+
+1. identity = `(market, symbol)` 복합키 (A9 유지).
+2. **동시 중복** (같은 symbol 이 같은 세션에 양시장 membership/bar 보유) =
+   `RUN_INVALID_IDENTITY_CONFLICT` fail-closed.
+3. **시장 이동** (membership 구간이 시장 간 disjoint): 두 `(market,symbol)` 인스턴스는
+   독립 — cross-market 이력 연결(stitching) 금지. 이동 전 시장의 적격성은 그 시장 bar 만으로
+   판정 (연속 이력이 끊기므로 이동 직후 자연 제외 — 보수적).
+4. **보유 중 이동**: 전략 포지션의 만기 전에 해당 시장 membership 이 끝나고 같은 symbol 이
+   타시장에 출현하며 상폐 증거가 없으면 `RUN_INVALID_MARKET_TRANSFER` fail-closed
+   (조용한 stitching·조용한 상폐 해석 둘 다 금지, 발생 수 공개). 실코퍼스에서 이 사유
+   run-invalid 가 유의미하게 발생하면 그때 운영자 에스컬레이션으로 정책 재결정.
+
+## A14 — verdict·비용·연도 규약 pinning
+
+1. **후보 top-level verdict = 43bp(base) 프로파일** 로 단일 선언. 83bp(sensitivity) 는
+   병기 필수 — 83bp 에서 부호가 뒤집히면 `COST_SENSITIVE` 라벨을 붙인다 (veto 아님 —
+   veto 승격은 별도 운영자 결정).
+2. verdict 값은 축약 금지 — `UNIDENTIFIABLE_CLUSTERS` 등 전체 라벨 사용.
+3. 양수 연도 게이트의 귀속·가중: 연도 = **진입 세션의 달력 연도**, 연도 내 집계 =
+   entry-session 동일가중 평균 (A5 와 동일 가중 체계).
+4. data-gap 의미 분리 (A6-2 정밀화): `RUN_INVALID_DATA_GAP` 은 **row/partition 부재**
+   (존재성 검사) 에만. "행은 있으나 전부 무효" 는 A8 universe 제외 경로
+   (→ `POPULATION_BELOW_FLOOR` 가능) — run-invalid 아님.
+5. holdout 비접촉의 기계 증명: 엔진의 모든 iteration·데이터 검사·신호 계산은
+   `t ≤ exploration_end` 로 닫고, **access-spy 검사** (경계 밖 bar read 카운트 == 0) 를
+   golden acceptance 에 포함한다.

--- a/tests/fixtures/kr_a0_golden_v5/inbox/amendment-kr-engine-conventions-v2-draft-20260805.md
+++ b/tests/fixtures/kr_a0_golden_v5/inbox/amendment-kr-engine-conventions-v2-draft-20260805.md
@@ -1,0 +1,77 @@
+# [DRAFT — 운영자 확정 대기] KR 엔진 convention amendment v2
+
+```
+작성: claude-mock (상류 분석, wB:p4R) · 2026-08-05 09:0x KST
+지위: ✅ 확정 — 운영자가 claude-mock 대화에서 2026-08-05 09:1x 승인 (A5 = z + floor 30 채택).
+      결정 정본 operator-decisions-20260805-0830.md §3차 확정에 편입됨.
+근거: answer-codexmock-golden-xcheck-0853.md — 동결 YAML 은 이름·의도만 정의하고
+      exact 수치 convention 을 정의하지 않는 항목 7개 확인. 결과를 보기 전에
+      (첫 ㉠ 백테스트 실행 전에) 봉인해야 post-hoc 오염이 없다.
+```
+
+## A1 (=C1) percentile 정의
+`pct_asc(x_i) = |{j ∈ 모집단 : x_j ≤ x_i}| / N` — 자기 포함, 동값 동percentile, 최솟값 pct = 1/N.
+소표본 경계: 모집단 N < 20 인 세션·시장은 해당 후보 신호 미계산 (r3_pct ≤ 0.05 가 표현 불가능한
+규모에서 우연 통과를 방지).
+
+## A2 (=C3) 기술 통계
+median = 짝수 표본 중앙 2값 산술평균 · 표준편차 = ddof=1. (vol20 ddof=1 은 YAML 명시 — 나머지를
+일반 ratify.)
+
+## A3 (=C4) 비용 적용
+전략 거래: `net = gross − 0.0043` (base) / `− 0.0083` (sensitivity), 정확히 이 값·측면 분해 없음·
+화폐 반올림 없음. 상폐 terminal 거래에도 동일 차감. baseline cohort 는 gross (비용 미차감).
+
+## A4 (=C5) baseline — 명칭 `candidate_counterfactual_baseline_v1`
+#1777 은 pipeline smoke 이며 baseline 정본이 아님 (codex 확정). 정의:
+- cohort = 신호 세션 t 의 **시장별** liq_pct 로 `decile = min(9, floor(pct×10))` 산출 후
+  **두 시장 병합**, 거래 종목과 동일 decile 인 A9 적격 종목 전체 (**자기 포함**).
+- 수익 = t+1 open → 동일 D+N close, 동일가중 gross 평균.
+- cohort = 신호 세션 t 의 **A8 ①② 적격**(PIT + 21세션 유효 bar) 집합에서 산출 (liq 임계 이전 —
+  decile 이 10분위 전체를 가져야 하므로).
+- cohort 구성원 처리 (전략 거래와 구분): t+1 bar 없으면 제외 + `cohort_excluded_entry` 카운트,
+  만기 bar 부재 + 상폐 증거 있으면 **C8 terminal 수익으로 포함**, 증거 없으면 제외 +
+  `cohort_excluded_maturity` 카운트 (조용한 제거 금지 — 카운트 공개가 의무).
+  **RUN_INVALID 는 전략 거래의 만기 결측(A6-3)에만 적용** — cohort 구성원까지 run 무효로 하면
+  실코퍼스에서 정지 종목 1개가 모든 run 을 무효화한다 (2026-08-05 설계 중 발견, 운영자 확정
+  범위 내 정밀화).
+- excess = 전략 net − cohort gross 평균.
+
+## A5 (=C6) 군집 LCB estimator  ← 유일한 실질 선택지
+채택안(권고): **정규 z = 1.2815515655446004** (one-sided 90%, asymptotic 선언) +
+세션 내 동일가중 → 세션 간 동일가중, sd ddof=1, **최소 진입 세션(cluster) 수 = 30** —
+미달 시 verdict = `UNIDENTIFIABLE_CLUSTERS` (PASS/FAIL 판정 자체 거부).
+대안(비채택 시): `t_{n-1, 0.90}` — 더 보수적이나 분위수 테이블 embed 필요.
+bootstrap 은 v1 에서 배제 (seed·반복수 신규 결정 유발 — codex 권고 동일).
+
+## A6 (=C7) 만기 결측 4분기 fail-closed (codex 안 그대로 채택)
+1. D+N 이 pinned 달력상 2025+ (holdout) → `RIGHT_CENSORED_NOT_TRADEABLE` — 진입 전 제외,
+   holdout 미접촉.
+2. D+N 이 2015–2024 인데 시장 세션/partition 자체가 corpus 에 없음 → `RUN_INVALID_DATA_GAP`
+   (조용히 분모에서 빼지 않음 — run 무효).
+3. 세션은 존재·해당 symbol 만기 bar 부재·상폐 증거 없음 → `RUN_INVALID_MATURITY_PRICE`
+   (suspension/결측을 임의 상폐 해석 금지).
+4. **PIT 상폐 증거가 있을 때만** C8 적용.
+기각: "마지막 corpus 종가 조기청산" — D+N 고정 청산의 사후 단축 + 끝단 선택편향 (codex 판정 수용).
+
+## A7 (=C8) 상폐 처리 (문안 유지 + 증거 요건 명시)
+corpus 상폐 이력(constraints §KR)에 **증거가 있는 경우에만**: 마지막 유효 종가 청산 +
+`delisted_exit=true`, 유효가 없으면 −100%.
+
+## A8 (=C9) 적격성·percentile 모집단 순서
+① PIT membership(세션 t 기준) ∧ ② 21세션 연속 **유효** bar (finite ∧ OHLC 양수 ∧ volume 양수 —
+YAML "결측·비양수면 미계산" 준수) → ③ 그 집합에서 시장별 `close_t×volume_t` 로 liq_pct (A1 식)
+→ ④ `liq_pct ≥ 0.50` 통과 집합 = r3_pct·vol20_pct 모집단 (시장별).
+
+## A9 identity
+심볼 identity 는 `(market, symbol)` 복합키. 동일 symbol 의 시장 이동·중복은 fail-closed
+(기존 백테스트 오류 `003670 multiple market session sets` 의 재발 방지 계약).
+
+## golden v2 보강 목록 (amendment 확정 후 상류가 재조립)
+- fixture 를 명시 입력 4종으로: bars(2dp 양자화 — CSV 왕복 exact) · 세션 달력(월말 flag 포함,
+  달력이 입력이며 요일 유도 금지) · membership · 상폐 events
+- P0: stateful max10 E2E(6세션 연속 신호 누적→슬롯 포화) · 재신호 무시/차순위 충원 ·
+  lowvol 2개 월말 persistence · per-market vs global percentile 판별 fixture · invalid-value
+  matrix · fills→gate 전 경로 집계 · V3 기대순서 독립 literal 화
+- P1: brk20 clamp-high mutant fixture · 경계 등식(liq=.50, pct=.05, vol20_pct=.30, r20=0,
+  margin=0) · baseline cohort 상폐/공집합 · golden 내 fixture SHA 결속 + CSV 재독 재현 검사

--- a/tests/fixtures/kr_a0_golden_v5/reference_generator_v4.py.fixture
+++ b/tests/fixtures/kr_a0_golden_v5/reference_generator_v4.py.fixture
@@ -1,0 +1,1310 @@
+#!/usr/bin/env python3
+"""KR golden vector reference generator — kr-golden-vectors-v1 (golden v5).
+
+Per operator-ratified A1~A9, A10~A12, A13~A14 and codex-mock reviews 1(0853)/2(0935)/
+3(1025)/4(1135)/5(1215)/6(1245). Supersedes v1~v4 artifacts. Emits golden_v5.json +
+9 self-contained variant directories (6 failing + 3 controls).
+
+v4 deltas from v3:
+  - BOUNDARY SEALED: every iteration (gap check, signal loop) clamped to
+    t <= exploration_end; World counts out-of-boundary bar reads (access spy) and the
+    generator asserts the count is ZERO across all main-fixture runs (A14-5)
+  - A13 identity: cross-market simultaneous membership overlap -> RUN_INVALID_IDENTITY_CONFLICT;
+    market transfer = independent instances (no stitching); held-through-transfer ->
+    RUN_INVALID_MARKET_TRANSFER. Twin fixture reshaped to a TRANSFER ("000420" KOSDAQ 0..20,
+    KOSPI 23..55); simultaneous-overlap is now a failing variant
+  - A14: data gap = row ABSENCE only (all-invalid rows -> universe exclusion path);
+    full verdict labels; top-level verdict = 43bp with COST_SENSITIVE flag; year = entry
+    session calendar year, session-equal-weight
+  - A12 discriminators: maturity bar with blank open/high/low but valid close+volume
+    SUCCEEDS (KA3); delist last-valid search is close+volume-only and event-session-inclusive
+    (QD1: blank-open bar AT event session is used); entry close not required (QD2 fills with
+    blank close, later -100% no-valid-price terminal); blank-volume bar invalid (KE5)
+  - exact comparators wired to real signals: clv == 0.65 and volume_ratio == 1.5 (KB1),
+    brk clv == 0.75 and ratio == 1.25 (KB2), vol20_pct == 0.3 (LV5 rank ladder at ml44
+    pop 20), plus v3's r3_pct == 0.05 / liq_pct == 0.5 / margin == 0.0 / r20 == 0.0
+  - A4 baseline mirrors trade resolution order (delist evidence BEFORE maturity bar)
+  - compose oracle: n>=30 / filled>=300 synthetic worlds through the REAL compose function
+    (PASS, FALSIFIED, COST_SENSITIVE, RUN_INVALID_EMPTY_BASELINE)
+  - loader hardening: sessions keyed by session_idx, duplicate session/config/membership/
+    delist rows fail-closed; all inputs read from the fixture directory (packet root)
+  - variants as self-contained directories (10 = 7 failing + 3 controls):
+    invalid_maturity, data_gap, duplicate_row, nofill_no_substitution, identity_conflict,
+    market_transfer (stale-valid maturity bar preserved),
+    market_transfer_missing_maturity (complementary precedence case),
+    data_gap_control_all_invalid, stale_delist_bar (A4 exact oracle), holdout_leg_control
+"""
+import csv
+import hashlib
+import json
+import math
+import os
+import random
+import shutil
+import statistics
+from datetime import date, timedelta
+
+OUT = "/Users/mgh3326/work/herdr-artifacts/kr-golden-vectors-v1"
+INBOX = "/Users/mgh3326/work/herdr-inbox"
+Z90 = 1.2815515655446004
+COST_BASE = 0.0043
+COST_SENS = 0.0083
+N_KOSPI = 48
+N_KOSDAQ = 48
+N_SESS = 56
+FLOOR_N = 20
+MONTH_LAST = {9, 29, 31, 44}
+EXPLORATION_END = 52
+
+KA1, KA2, KA3, KA4, KA5 = "000310", "000320", "000330", "000340", "000350"
+KD1, KD2, KD3 = "000360", "000370", "000380"
+KC1, KE1, KF1, TWIN, KG1, KH1, KB1 = "000390", "000400", "000410", "000420", "000430", "000440", "000050"
+CARVED = ["000010", "000020", "000030", "000040", "000450"]
+Q01, QB1, KE2, KE3 = "900010", "900370", "900380", "900390"
+QA1, QA2, QA3, QA4, QA5, QA6 = "900310", "900320", "900330", "900340", "900350", "900360"
+MASS5 = ["900400", "900410", "900420", "900430", "900440"]
+KE4, QH1, QH2, KD4, ZC = "900450", "900460", "900470", "900480", "900160"
+QD1, QD2, KE5, KB2 = "900110", "900120", "900130", "900140"
+CARVED_Q = ["900020", "900030", "900040", "900050"]
+LV5 = [("900060", 0.0002), ("900070", 0.0003), ("900150", 0.0004),
+       ("900170", 0.0005), ("900180", 0.0006)]
+
+
+def pct_asc(values, x):
+    return sum(1 for v in values if v <= x) / len(values)
+
+
+class RunInvalid(Exception):
+    def __init__(self, label, detail=""):
+        super().__init__(label + (f" {detail}" if detail else ""))
+        self.label = label
+
+
+# ---------------------------------------------------------------- fixture build
+def build_world():
+    rng = random.Random(20260805)
+    dates, d = [], date(2022, 9, 19)
+    while len(dates) < N_SESS:
+        if d.weekday() < 5 and d != date(2022, 10, 3):
+            dates.append(d)
+        d += timedelta(days=1)
+    symbols = ([("KOSPI", "%06d" % (10 * (i + 1))) for i in range(N_KOSPI)] +
+               [("KOSDAQ", "%06d" % (900000 + 10 * (i + 1))) for i in range(N_KOSDAQ)] +
+               [("KOSDAQ", TWIN)])
+    membership = {k: (0, N_SESS - 1) for k in symbols}
+    membership[("KOSPI", KF1)] = (40, N_SESS - 1)
+    membership[("KOSPI", KA4)] = (0, 31)
+    for c in CARVED:
+        membership[("KOSPI", c)] = (0, 47)
+    for c in CARVED_Q:
+        membership[("KOSDAQ", c)] = (0, 43)
+    membership[("KOSDAQ", TWIN)] = (0, 20)          # A13 transfer: KOSDAQ leg ends
+    membership[("KOSPI", TWIN)] = (23, N_SESS - 1)  # KOSPI leg starts (disjoint)
+    membership[("KOSDAQ", QD1)] = (0, 46)
+    membership[("KOSDAQ", QD2)] = (0, 43)
+    delist = {("KOSPI", KA4): 32, ("KOSDAQ", QD1): 46, ("KOSDAQ", QD2): 44}
+
+    bars = {}
+    for key in symbols:
+        base = rng.uniform(5000, 50000)
+        vb = rng.randint(50_000, 500_000)
+        close = base
+        for i in range(N_SESS):
+            r = rng.gauss(0.0005, 0.012)
+            o = close * (1 + rng.gauss(0, 0.004))
+            c = close * (1 + r)
+            hi = max(o, c) * (1 + abs(rng.gauss(0, 0.004)))
+            lo = min(o, c) * (1 - abs(rng.gauss(0, 0.004)))
+            v = max(1000, int(vb * rng.uniform(0.8, 1.2)))
+            bars[(key, i)] = {"open": o, "high": hi, "low": lo, "close": c, "volume": v}
+            close = c
+
+    def med_pv(key, s):
+        return statistics.median(bars[(key, s - k)]["volume"] for k in range(1, 21))
+
+    def craft_rev3(key, s, factor):
+        tc = bars[(key, s - 3)]["close"] * factor
+        bars[(key, s)].update(close=tc, open=tc * 0.97, low=tc * 0.94, high=tc * 1.01,
+                              volume=int(med_pv(key, s) * 2.5))
+
+    def craft_drop_clvfail(key, s, factor):
+        tc = bars[(key, s - 3)]["close"] * factor
+        bars[(key, s)].update(close=tc, low=tc, open=tc * 1.03, high=tc * 1.05,
+                              volume=int(med_pv(key, s) * 1.0))
+
+    def hc(b):
+        return max(b["high"], b["open"], b["close"])
+
+    def craft_brk20(key, s):
+        ph = max(hc(bars[(key, s - k)]) for k in range(1, 21))
+        c = ph * 1.03
+        bars[(key, s)].update(close=c, open=ph * 0.995, low=ph * 0.99, high=ph * 1.032,
+                              volume=int(med_pv(key, s) * 1.8))
+
+    def craft_const(key, start, end, drift):
+        c = bars[(key, start)]["close"]
+        for i in range(start + 1, end + 1):
+            c = c * (1 + drift)
+            bars[(key, i)].update(close=c, open=c * 0.999, high=c * 1.001, low=c * 0.998)
+
+    r3crafts = [(("KOSPI", KA1), 24, .80), (("KOSDAQ", QA1), 24, .80),
+                (("KOSPI", KA2), 25, .80), (("KOSDAQ", QA2), 25, .80),
+                (("KOSPI", KA3), 26, .80), (("KOSDAQ", QA3), 26, .80),
+                (("KOSPI", KA1), 27, .80), (("KOSDAQ", QA4), 27, .80),
+                (("KOSPI", KA4), 28, .80), (("KOSDAQ", QA5), 28, .80),
+                (("KOSPI", KA5), 29, .80), (("KOSDAQ", QA6), 29, .79),
+                (("KOSPI", KA1), 30, .80), (("KOSDAQ", QB1), 32, .80),
+                (("KOSPI", KC1), 35, .88), (("KOSPI", KE1), 36, .80),
+                (("KOSPI", KF1), 38, .80), (("KOSPI", KG1), 41, .80),
+                (("KOSDAQ", QD1), 41, .80), (("KOSPI", TWIN), 43, .80),
+                (("KOSDAQ", QD2), 42, .80), (("KOSPI", KA2), 47, .80),
+                (("KOSPI", KH1), 49, .80)]
+    for key, s, f in r3crafts:
+        craft_rev3(key, s, f)
+    for m in MASS5:
+        craft_drop_clvfail(("KOSDAQ", m), 35, .85)
+
+    k1 = ("KOSPI", KD1)
+    raw_max = max(bars[(k1, j)]["high"] for j in range(13, 33))
+    b20 = bars[(k1, 20)]
+    b20["high"] = raw_max * 1.001
+    b20["open"] = b20["high"] * 1.06
+    c33 = b20["high"] * 1.03
+    bars[(k1, 33)].update(close=c33, open=c33 * 0.996, low=c33 * 0.995, high=c33 * 1.001,
+                          volume=int(med_pv(k1, 33) * 1.8))
+    craft_brk20(("KOSPI", KD2), 34)
+    craft_brk20(("KOSPI", KD3), 50)
+    craft_const(("KOSDAQ", Q01), 9, 44, 0.0015)
+    qh1c = bars[(("KOSDAQ", QH1), 10)]["close"]
+    bars[(("KOSDAQ", QH1), 9)]["close"] = qh1c * 1.02
+    for i in range(10, 32):
+        bars[(("KOSDAQ", QH1), i)].update(close=qh1c, open=qh1c * 0.999,
+                                          high=qh1c * 1.001, low=qh1c * 0.998)
+    q2 = ("KOSDAQ", QH2)
+    bars[(q2, 10)]["close"] = bars[(q2, 9)]["close"] * 0.999
+    craft_const(q2, 10, 29, -0.0005)
+    craft_const(q2, 29, 31, 0.012)
+    # LV5: alternating +/-d with +e drift, crafted closes 24..44 (rank ladder at ml44)
+    for (sym, dd) in LV5:
+        key = ("KOSDAQ", sym)
+        c = bars[(key, 23)]["close"]
+        s = 1
+        for i in range(24, 45):
+            c = c * (1 + 0.001 + s * dd)
+            s = -s
+            bars[(key, i)].update(close=c, open=c * 0.999, high=c * 1.001, low=c * 0.998)
+    # KB1: fully crafted calm path with integer-exact boundary bar at s45
+    kb = ("KOSPI", KB1)
+    for i in range(25, 53):
+        bars[(kb, i)].update(close=41000.0, open=40950.0, high=41200.0, low=40800.0,
+                             volume=200000)
+    bars[(kb, 42)]["close"] = 41250.0
+    bars[(kb, 43)]["close"] = 40000.0
+    bars[(kb, 44)]["close"] = 39000.0
+    bars[(kb, 45)].update(close=33000.0, open=38000.0, high=40000.0, low=20000.0,
+                          volume=300000)                     # clv 13/20, ratio 1.5 exact
+    for i in range(46, 53):
+        bars[(kb, i)].update(close=33000.0 - (i - 45) * 50.0, open=33000.0, high=33100.0,
+                             low=32700.0, volume=200000)
+    # KB2: brk exact boundary (clv 15/20, ratio 1.25) at s38
+    k2 = ("KOSDAQ", KB2)
+    for i in range(18, 50):
+        bars[(k2, i)].update(close=30000.0, open=29950.0, high=30300.0, low=29700.0,
+                             volume=200000)
+    bars[(k2, 38)].update(close=35000.0, open=34800.0, high=40000.0, low=20000.0,
+                          volume=250000)
+    for i in range(39, 50):
+        bars[(k2, i)].update(close=35000.0 - (i - 38) * 40.0, open=35000.0, high=35100.0,
+                             low=34700.0, volume=200000)
+
+    # quantize
+    for _, b in bars.items():
+        for f in ("open", "high", "low", "close"):
+            if b[f] is not None:
+                b[f] = round(b[f], 2)
+        b["volume"] = int(b["volume"])
+
+    # post-quantize exact crafts
+    qh1q = bars[(("KOSDAQ", QH1), 11)]["close"]
+    for i in range(11, 32):
+        bars[(("KOSDAQ", QH1), i)]["close"] = qh1q
+    k4 = ("KOSDAQ", KD4)
+    ph4 = max(max(bars[(k4, 37 - k)]["high"], bars[(k4, 37 - k)]["open"],
+                  bars[(k4, 37 - k)]["close"]) for k in range(1, 21))
+    bars[(k4, 37)].update(close=ph4, open=round(ph4 * 0.996, 2), low=round(ph4 * 0.995, 2),
+                          high=round(ph4 * 1.001, 2), volume=int(med_pv(k4, 37) * 1.8))
+
+    def force_liq(key, i):
+        mkt = key[0]
+        vals = sorted(bars[(k, i)]["close"] * bars[(k, i)]["volume"]
+                      for k in symbols if k[0] == mkt and (k, i) in bars and k != key)
+        target = vals[int(len(vals) * 0.75)] * 1.2
+        b = bars[(key, i)]
+        b["volume"] = max(b["volume"], int(target / b["close"]) + 1)
+
+    for key, s, _ in r3crafts:
+        if key == kb:
+            continue                                   # KB1 keeps exact-ratio volume
+        force_liq(key, s)
+    for key, s in ([(("KOSPI", KD1), 33), (("KOSPI", KD2), 34), (("KOSPI", KD3), 50),
+                    (("KOSDAQ", KD4), 37), (("KOSDAQ", Q01), 29), (("KOSDAQ", Q01), 31),
+                    (("KOSDAQ", Q01), 44), (("KOSDAQ", QH1), 31), (("KOSDAQ", QH2), 31)] +
+                   [(("KOSDAQ", m), 35) for m in MASS5] +
+                   [(("KOSDAQ", sym), 44) for sym, _ in LV5]):
+        force_liq(key, s)
+
+    def liq_pct_of(key, i):
+        mkt = key[0]
+        ks = [k for k in symbols if k[0] == mkt and (k, i) in bars]
+        vals = {k: bars[(k, i)]["close"] * bars[(k, i)]["volume"] for k in ks}
+        return pct_asc(list(vals.values()), vals[key])
+
+    def match_decile(tgt, src, i):
+        want = min(9, int(liq_pct_of(src, i) * 10))
+        b = bars[(tgt, i)]
+        for _ in range(400):
+            if min(9, int(liq_pct_of(tgt, i) * 10)) == want:
+                return
+            b["volume"] = int(b["volume"] * 1.05) + 1
+        raise AssertionError(f"decile match failed {tgt}@{i}")
+
+    match_decile(("KOSDAQ", ZC), ("KOSDAQ", QA1), 24)
+    match_decile(("KOSDAQ", QA5), ("KOSPI", KA4), 28)
+
+    # invalid injections + field-level discriminators (post-quantize)
+    bars[(("KOSPI", KE1), 34)]["volume"] = 0
+    bars[(("KOSDAQ", KE2), 40)]["high"] = None
+    bars[(("KOSDAQ", KE3), 42)]["close"] = 0.0
+    bars[(("KOSDAQ", KE4), 43)]["close"] = float("inf")
+    bars[(("KOSDAQ", KE5), 45)]["volume"] = None
+    bars[(("KOSPI", KG1), 42)]["high"] = None            # entry fills on open+volume
+    for f in ("open", "high", "low"):
+        bars[(("KOSPI", KA3), 32)][f] = None             # maturity close+volume-only
+    bars[(("KOSPI", KA4), 31)]["open"] = None            # terminal search close-only
+    bars[(("KOSDAQ", QD1), 46)]["open"] = None           # event-session-inclusive search
+    bars[(("KOSDAQ", QD2), 43)]["close"] = None          # entry fills; later no-valid-price
+
+    # structural deletions
+    del bars[(("KOSDAQ", QB1), 33)]
+    del bars[(("KOSDAQ", ZC), 25)]
+    for i in range(21, N_SESS):                          # transfer: KOSDAQ twin leg ends
+        bars.pop((("KOSDAQ", TWIN), i), None)
+    for i in range(0, 23):                               # new leg bars start at listing
+        bars.pop((("KOSPI", TWIN), i), None)
+    for i in range(32, N_SESS):
+        bars.pop((("KOSPI", KA4), i), None)
+    for i in range(47, N_SESS):
+        bars.pop((("KOSDAQ", QD1), i), None)
+    for i in range(44, N_SESS):
+        bars.pop((("KOSDAQ", QD2), i), None)
+    return bars, symbols, membership, delist, dates
+
+
+# ---------------------------------------------------------------- serialization
+def fmt(x):
+    return "" if x is None else ("%.2f" % x)
+
+
+def write_fixtures(dirpath, bars, symbols, membership, delist, dates):
+    os.makedirs(dirpath, exist_ok=True)
+    with open(f"{dirpath}/fixture_bars.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["market", "symbol", "session_idx", "open", "high", "low", "close",
+                    "volume"])
+        for key in symbols:
+            for i in range(N_SESS):
+                b = bars.get((key, i))
+                if b is None:
+                    continue
+                w.writerow([key[0], key[1], i, fmt(b["open"]), fmt(b["high"]), fmt(b["low"]),
+                            fmt(b["close"]), "" if b["volume"] is None else b["volume"]])
+    with open(f"{dirpath}/fixture_sessions.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["session_idx", "date_informational", "month_last"])
+        for i, d in enumerate(dates):
+            w.writerow([i, d.isoformat(), 1 if i in MONTH_LAST else 0])
+    with open(f"{dirpath}/fixture_config.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["key", "value"])
+        w.writerow(["exploration_end_session_idx", EXPLORATION_END])
+    with open(f"{dirpath}/fixture_membership.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["market", "symbol", "start_idx", "end_idx"])
+        for key in symbols:
+            s, e = membership[key]
+            w.writerow([key[0], key[1], s, e])
+    with open(f"{dirpath}/fixture_delist_events.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["market", "symbol", "delist_session_idx"])
+        for key, dd in delist.items():
+            w.writerow([key[0], key[1], dd])
+
+
+class World:
+    def __init__(self, bars, symbols, membership, delist, dates, month_last, expl_end):
+        self.bars, self.symbols, self.membership = bars, symbols, membership
+        self.delist, self.dates = delist, dates
+        self.month_last, self.expl_end = month_last, expl_end
+        # A14-5 metadata boundary: membership clamped to the exploration window at
+        # construction — identity/transfer checks structurally cannot see holdout legs
+        self.membership = {k: (s, min(e, expl_end))
+                           for k, (s, e) in self.membership.items() if s <= expl_end}
+        self.symbols = [k for k in self.symbols if k in self.membership]
+        self.oob_reads = 0                     # access spy (A14-5)
+
+    def bar(self, key, i):
+        if i > self.expl_end:
+            self.oob_reads += 1
+        return self.bars.get((key, i))
+
+
+def read_world(dirpath):
+    bars = {}
+    with open(f"{dirpath}/fixture_bars.csv", newline="") as f:
+        for row in csv.DictReader(f):
+            key = ((row["market"], row["symbol"]), int(row["session_idx"]))
+            if key in bars:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", str(key))
+            def pf(x):
+                return None if x == "" else float(x)
+            bars[key] = {"open": pf(row["open"]), "high": pf(row["high"]),
+                         "low": pf(row["low"]), "close": pf(row["close"]),
+                         "volume": None if row["volume"] == "" else int(row["volume"])}
+    dates_by_idx, ml = {}, set()
+    with open(f"{dirpath}/fixture_sessions.csv", newline="") as f:
+        for row in csv.DictReader(f):
+            i = int(row["session_idx"])
+            if i in dates_by_idx:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"session {i}")
+            dates_by_idx[i] = date.fromisoformat(row["date_informational"])
+            if row["month_last"] == "1":
+                ml.add(i)
+    dates = [dates_by_idx[i] for i in sorted(dates_by_idx)]
+    cfg = {}
+    with open(f"{dirpath}/fixture_config.csv", newline="") as f:
+        for row in csv.DictReader(f):
+            if row["key"] in cfg:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"config {row['key']}")
+            cfg[row["key"]] = int(row["value"])
+    membership, symbols = {}, []
+    with open(f"{dirpath}/fixture_membership.csv", newline="") as f:
+        for row in csv.DictReader(f):
+            k = (row["market"], row["symbol"])
+            if k in membership:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"membership {k}")
+            membership[k] = (int(row["start_idx"]), int(row["end_idx"]))
+            symbols.append(k)
+    delist = {}
+    with open(f"{dirpath}/fixture_delist_events.csv", newline="") as f:
+        for row in csv.DictReader(f):
+            k = (row["market"], row["symbol"])
+            if k in delist:
+                raise RunInvalid("RUN_INVALID_DUPLICATE_ROW", f"delist {k}")
+            delist[k] = int(row["delist_session_idx"])
+    return World(bars, symbols, membership, delist, dates, ml,
+                 cfg["exploration_end_session_idx"])
+
+
+# ---------------------------------------------------------------- validity (A8/A12)
+def fin_pos(v):
+    return v is not None and math.isfinite(v) and v > 0
+
+
+def vol_ok(v):
+    return v is not None and math.isfinite(v) and v > 0
+
+
+def valid_bar(b):
+    return (b is not None and all(fin_pos(b[f]) for f in ("open", "high", "low", "close"))
+            and vol_ok(b["volume"]))
+
+
+def entry_ok(b):
+    return b is not None and fin_pos(b["open"]) and vol_ok(b["volume"])
+
+
+def maturity_ok(b):
+    return b is not None and fin_pos(b["close"]) and vol_ok(b["volume"])
+
+
+def high_c(b):
+    return max(b["high"], b["open"], b["close"])
+
+
+def low_c(b):
+    return min(b["low"], b["open"], b["close"])
+
+
+def member(w, key, i):
+    s, e = w.membership[key]
+    return s <= i <= e
+
+
+def check_identity(w):
+    """A13-2: simultaneous cross-market membership overlap fail-closed."""
+    by_sym = {}
+    for (mkt, sym), (s, e) in w.membership.items():
+        by_sym.setdefault(sym, []).append((mkt, s, e))
+    for sym, entries in by_sym.items():
+        for a in range(len(entries)):
+            for b in range(a + 1, len(entries)):
+                if entries[a][0] != entries[b][0]:
+                    if max(entries[a][1], entries[b][1]) <= min(entries[a][2],
+                                                                entries[b][2]):
+                        raise RunInvalid("RUN_INVALID_IDENTITY_CONFLICT", sym)
+
+
+def check_data_gaps(w):
+    """A14-4: row PRESENCE per market-session, boundary-clamped."""
+    for i in range(min(N_SESS, w.expl_end + 1)):
+        for mkt in ("KOSPI", "KOSDAQ"):
+            if not any(w.bar(k, i) is not None for k in w.symbols if k[0] == mkt):
+                raise RunInvalid("RUN_INVALID_DATA_GAP", f"{mkt}@s{i}")
+
+
+def a8_base_set(w, i):
+    """A8+A13: PIT membership AND valid bar over the ENTIRE 21-session window —
+    pre-listing history is never used (transfer new leg matures naturally)."""
+    return [k for k in w.symbols
+            if all(member(w, k, i - j) and valid_bar(w.bar(k, i - j))
+                   for j in range(0, 21))]
+
+
+def liq_pcts(w, i, base):
+    res = {}
+    for mkt in ("KOSPI", "KOSDAQ"):
+        ks = [k for k in base if k[0] == mkt]
+        vals = [w.bar(k, i)["close"] * w.bar(k, i)["volume"] for k in ks]
+        for k, v in zip(ks, vals):
+            res[k] = pct_asc(vals, v)
+    return res
+
+
+def populations(w, i):
+    if i < 20:
+        return {"KOSPI": [], "KOSDAQ": []}, {}, ["insufficient_history"]
+    base = a8_base_set(w, i)
+    lp = liq_pcts(w, i, base)
+    pops, notes = {}, []
+    for mkt in ("KOSPI", "KOSDAQ"):
+        pop = [k for k in base if k[0] == mkt and lp[k] >= 0.50]
+        if len(pop) < FLOOR_N:
+            notes.append(f"POPULATION_BELOW_FLOOR:{mkt}:{len(pop)}")
+            pop = []
+        pops[mkt] = pop
+    return pops, lp, notes
+
+
+def rev3_key(r):
+    return (r["r3_pct"], r["r3"], -r["clv"], -r["volume_ratio"], -r["liq_pct"],
+            0 if r["market"] == "KOSPI" else 1, r["symbol"])
+
+
+def sig_rev3(w, i):
+    pops, lp, notes = populations(w, i)
+    sigs = []
+    for mkt in ("KOSPI", "KOSDAQ"):
+        pop = pops[mkt]
+        r3 = {k: w.bar(k, i)["close"] / w.bar(k, i - 3)["close"] - 1 for k in pop}
+        vals = list(r3.values())
+        for k in pop:
+            b = w.bar(k, i)
+            hcv, lcv = high_c(b), low_c(b)
+            if hcv <= lcv:
+                continue
+            clv = (b["close"] - lcv) / (hcv - lcv)
+            vr = b["volume"] / statistics.median(w.bar(k, i - j)["volume"]
+                                                for j in range(1, 21))
+            rp = pct_asc(vals, r3[k])
+            if rp <= 0.05 and clv >= 0.65 and vr >= 1.50:
+                sigs.append({"market": k[0], "symbol": k[1], "r3": r3[k], "r3_pct": rp,
+                             "clv": clv, "volume_ratio": vr, "liq_pct": lp[k]})
+    sigs.sort(key=rev3_key)
+    return sigs, notes
+
+
+def sig_brk20(w, i):
+    pops, lp, notes = populations(w, i)
+    sigs = []
+    for mkt in ("KOSPI", "KOSDAQ"):
+        for k in pops[mkt]:
+            b = w.bar(k, i)
+            hcv, lcv = high_c(b), low_c(b)
+            if hcv <= lcv:
+                continue
+            ph = max(high_c(w.bar(k, i - j)) for j in range(1, 21))
+            margin = b["close"] / ph - 1
+            clv = (b["close"] - lcv) / (hcv - lcv)
+            vr = b["volume"] / statistics.median(w.bar(k, i - j)["volume"]
+                                                for j in range(1, 21))
+            if margin > 0 and clv >= 0.75 and vr >= 1.25:
+                sigs.append({"market": k[0], "symbol": k[1], "margin": margin, "clv": clv,
+                             "volume_ratio": vr, "liq_pct": lp[k]})
+    sigs.sort(key=lambda r: (-r["margin"], -r["volume_ratio"], -r["clv"], -r["liq_pct"],
+                             0 if r["market"] == "KOSPI" else 1, r["symbol"]))
+    return sigs, notes
+
+
+def sig_lowvol(w, i):
+    pops, lp, notes = populations(w, i)
+    sigs = []
+    for mkt in ("KOSPI", "KOSDAQ"):
+        pop = pops[mkt]
+        vol20, r20 = {}, {}
+        for k in pop:
+            closes = [w.bar(k, i - j)["close"] for j in range(20, -1, -1)]
+            r1s = [closes[j + 1] / closes[j] - 1 for j in range(20)]
+            vol20[k] = statistics.stdev(r1s)
+            r20[k] = closes[-1] / closes[0] - 1
+        vals = list(vol20.values())
+        for k in pop:
+            vp = pct_asc(vals, vol20[k])
+            if vp <= 0.30 and r20[k] > 0:
+                sigs.append({"market": k[0], "symbol": k[1], "vol20": vol20[k],
+                             "vol20_pct": vp, "r20": r20[k], "liq_pct": lp[k]})
+    sigs.sort(key=lambda r: (r["vol20_pct"], r["vol20"], -r["r20"], -r["liq_pct"],
+                             0 if r["market"] == "KOSPI" else 1, r["symbol"]))
+    return sigs, notes
+
+
+def other_market_transfer(w, key):
+    """A13-4: same symbol listed in the other market starting after this leg ends."""
+    mkt, sym = key
+    end = w.membership[key][1]
+    for (m2, s2), (st, _) in w.membership.items():
+        if s2 == sym and m2 != mkt and st > end:
+            return True
+    return False
+
+
+def run_candidate(w, signal_fn, hold, schedule=None):
+    check_identity(w)
+    check_data_gaps(w)
+    positions, log = [], {"entries": [], "ignored_held": [], "skipped_max10": [],
+                          "no_fill": [], "censored": [], "notes": {}}
+    for t in range(min(N_SESS, w.expl_end + 1)):       # boundary-sealed iteration
+        if schedule is not None and t not in schedule:
+            continue
+        sigs, notes = signal_fn(w, t)
+        if notes:
+            log["notes"][t] = notes
+        entry_t = t + 1
+        live = []
+        for sig in sigs:
+            if entry_t > w.expl_end or entry_t + hold > w.expl_end:
+                log["censored"].append({"session": t, "symbol": sig["symbol"],
+                                        "market": sig["market"],
+                                        "status": "RIGHT_CENSORED_NOT_TRADEABLE"})
+            else:
+                live.append(sig)
+        occupied = sum(1 for p in positions
+                       if p["entry_idx"] <= entry_t <= p["occupy_until"])
+        slots = 10 - occupied
+        selected = []
+        for sig in live:
+            key = (sig["market"], sig["symbol"])
+            if any(p["key"] == key and p["entry_idx"] <= entry_t <= p["occupy_until"]
+                   for p in positions):
+                log["ignored_held"].append({"session": t, "market": sig["market"],
+                                            "symbol": sig["symbol"]})
+                continue
+            if len(selected) >= slots:
+                log["skipped_max10"].append({"session": t, "market": sig["market"],
+                                             "symbol": sig["symbol"]})
+                continue
+            selected.append(sig)
+        for sig in selected:
+            key = (sig["market"], sig["symbol"])
+            eb = w.bar(key, entry_t)
+            if not entry_ok(eb):
+                log["no_fill"].append({"session": t, "market": sig["market"],
+                                       "symbol": sig["symbol"], "entry_session": entry_t})
+                continue
+            exit_due = entry_t + hold
+            d_evt = w.delist.get(key)
+            occupy_until = min(exit_due, d_evt) if d_evt is not None and d_evt <= exit_due \
+                else exit_due
+            positions.append({"key": key, "entry_idx": entry_t, "exit_due": exit_due,
+                              "occupy_until": occupy_until, "signal_session": t,
+                              "entry_open": eb["open"]})
+            log["entries"].append({"session": t, "symbol": sig["symbol"],
+                                   "market": sig["market"], "entry_session": entry_t})
+    trades = []
+    for p in positions:
+        key = p["key"]
+        d_evt = w.delist.get(key)
+        if d_evt is not None and d_evt <= p["exit_due"]:
+            last = None
+            for k in range(d_evt, p["entry_idx"] - 1, -1):
+                b = w.bar(key, k)
+                if b is not None and maturity_ok(b):
+                    last = b["close"]
+                    break
+            gross = (last / p["entry_open"] - 1) if last is not None else -1.0
+            trades.append({**{x: p[x] for x in ("entry_idx", "exit_due", "signal_session",
+                                                "entry_open")},
+                           "market": key[0], "symbol": key[1], "exit_session": d_evt,
+                           "exit_close": last, "gross": gross, "delisted_exit": True,
+                           "net_43bp": gross - COST_BASE, "net_83bp": gross - COST_SENS})
+            continue
+        # A13-4: transfer gate BEFORE price resolution — membership ending mid-hold with
+        # a later other-market leg is fail-closed regardless of stale bars
+        if w.membership[key][1] < p["exit_due"] and other_market_transfer(w, key):
+            raise RunInvalid("RUN_INVALID_MARKET_TRANSFER", f"{key}")
+        xb = w.bar(key, p["exit_due"])
+        if not maturity_ok(xb):
+            raise RunInvalid("RUN_INVALID_MATURITY_PRICE", f"{key}@s{p['exit_due']}")
+        gross = xb["close"] / p["entry_open"] - 1
+        trades.append({**{x: p[x] for x in ("entry_idx", "exit_due", "signal_session",
+                                            "entry_open")},
+                       "market": key[0], "symbol": key[1], "exit_session": p["exit_due"],
+                       "exit_close": xb["close"], "gross": gross, "delisted_exit": False,
+                       "net_43bp": gross - COST_BASE, "net_83bp": gross - COST_SENS})
+    trades.sort(key=lambda tr: (tr["entry_idx"], tr["market"], tr["symbol"]))
+    return log, trades
+
+
+def baseline(w, t, hold, target_pct):
+    """A4 — mirrors trade resolution order (delist evidence BEFORE maturity bar)."""
+    base = a8_base_set(w, t)
+    lp = liq_pcts(w, t, base)
+    dec = min(9, int(target_pct * 10))
+    rets, excl_e, excl_m, term_inc = [], 0, 0, 0
+    for k in base:
+        if min(9, int(lp[k] * 10)) != dec:
+            continue
+        eb = w.bar(k, t + 1)
+        if not entry_ok(eb):
+            excl_e += 1
+            continue
+        d_evt = w.delist.get(k)
+        if d_evt is not None and d_evt <= t + 1 + hold:
+            last = None
+            for j in range(d_evt, t, -1):
+                b = w.bar(k, j)
+                if b is not None and maturity_ok(b):
+                    last = b["close"]
+                    break
+            rets.append((last / eb["open"] - 1) if last is not None else -1.0)
+            term_inc += 1
+            continue
+        xb = w.bar(k, t + 1 + hold)
+        if not maturity_ok(xb):
+            excl_m += 1
+            continue
+        rets.append(xb["close"] / eb["open"] - 1)
+    return {"decile": dec, "n": len(rets),
+            "gross_mean": statistics.mean(rets) if rets else None,
+            "cohort_excluded_entry": excl_e, "cohort_excluded_maturity": excl_m,
+            "cohort_terminal_included": term_inc}
+
+
+def compose_verdict(dates, trades, baselines):
+    """A11 + A14: full labels, 43bp top-level, COST_SENSITIVE flag."""
+    profiles = {}
+    for tag, cost in (("43bp", COST_BASE), ("83bp", COST_SENS)):
+        ex, by_sess = [], {}
+        for tr in trades:
+            bl = baselines[(tr["market"], tr["symbol"], tr["entry_idx"])]
+            if bl["gross_mean"] is None:
+                raise RunInvalid("RUN_INVALID_EMPTY_BASELINE",
+                                 f"{tr['symbol']}@e{tr['entry_idx']}")
+            e = (tr["gross"] - cost) - bl["gross_mean"]
+            ex.append(e)
+            by_sess.setdefault(tr["entry_idx"], []).append(e)
+        smeans = {s: statistics.mean(v) for s, v in sorted(by_sess.items())}
+        ymeans = {}
+        for s, m in smeans.items():
+            ymeans.setdefault(dates[s].year, []).append(m)
+        pos_years = sum(1 for v in ymeans.values() if statistics.mean(v) > 0)
+        n = len(smeans)
+        comp = {"filled": len(trades), "gate_filled_ge_300": len(trades) >= 300,
+                "trade_mean_excess": statistics.mean(ex) if ex else None,
+                "gate_mean_excess_gt_0": bool(ex) and statistics.mean(ex) > 0,
+                "n_entry_sessions": n, "session_means": smeans,
+                "positive_years": pos_years, "n_years": len(ymeans),
+                "year_means": {str(y): statistics.mean(v) for y, v in sorted(ymeans.items())},
+                "gate_positive_years_ge_6": pos_years >= 6, "z": Z90}
+        if n < 30:
+            comp["verdict"] = "UNIDENTIFIABLE_CLUSTERS"
+            if n >= 2:
+                mv = list(smeans.values())
+                comp["lcb_info_only"] = (statistics.mean(mv) -
+                                         Z90 * statistics.stdev(mv) / math.sqrt(n))
+        else:
+            mv = list(smeans.values())
+            lcb = statistics.mean(mv) - Z90 * statistics.stdev(mv) / math.sqrt(n)
+            comp["lcb"] = lcb
+            comp["gate_clustered_lcb_gt_0"] = lcb > 0
+            fails = [g for g in ("gate_filled_ge_300", "gate_mean_excess_gt_0",
+                                 "gate_clustered_lcb_gt_0", "gate_positive_years_ge_6")
+                     if not comp[g]]
+            comp["verdict"] = "FALSIFIED" if fails else "PASS"
+            comp["failed_gates"] = fails
+        profiles[tag] = comp
+    cs = (profiles["43bp"]["trade_mean_excess"] is not None
+          and profiles["43bp"]["trade_mean_excess"] > 0
+          and (profiles["83bp"]["trade_mean_excess"] or 0) <= 0)
+    return {"verdict": profiles["43bp"]["verdict"], "cost_sensitive": cs,
+            "profiles": profiles}
+
+
+def build_layers():
+    """V1~V5 unit oracles (restored per 4th review; v3 lineage, v4 labels)."""
+    vals = [5.0, 1.0, 3.0, 3.0, 2.0, 8.0, 7.0, 3.0, 9.0, 4.0,
+            6.0, 2.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0]
+    rows = [
+        {"symbol": "000100", "market": "KOSPI",  "r3_pct": 0.04, "r3": -0.20, "clv": 0.90, "volume_ratio": 3.0, "liq_pct": 0.90},
+        {"symbol": "000200", "market": "KOSPI",  "r3_pct": 0.04, "r3": -0.20, "clv": 0.90, "volume_ratio": 3.0, "liq_pct": 0.80},
+        {"symbol": "000300", "market": "KOSDAQ", "r3_pct": 0.04, "r3": -0.20, "clv": 0.90, "volume_ratio": 3.0, "liq_pct": 0.90},
+        {"symbol": "000055", "market": "KOSDAQ", "r3_pct": 0.04, "r3": -0.20, "clv": 0.90, "volume_ratio": 3.0, "liq_pct": 0.90},
+        {"symbol": "000410", "market": "KOSPI",  "r3_pct": 0.02, "r3": -0.30, "clv": 0.70, "volume_ratio": 1.6, "liq_pct": 0.55},
+        {"symbol": "000500", "market": "KOSPI",  "r3_pct": 0.04, "r3": -0.25, "clv": 0.90, "volume_ratio": 3.0, "liq_pct": 0.90},
+        {"symbol": "000600", "market": "KOSDAQ", "r3_pct": 0.04, "r3": -0.20, "clv": 0.95, "volume_ratio": 2.0, "liq_pct": 0.60},
+        {"symbol": "000700", "market": "KOSPI",  "r3_pct": 0.04, "r3": -0.20, "clv": 0.90, "volume_ratio": 4.0, "liq_pct": 0.50},
+        {"symbol": "000800", "market": "KOSPI",  "r3_pct": 0.05, "r3": -0.10, "clv": 0.80, "volume_ratio": 1.5, "liq_pct": 0.95},
+        {"symbol": "000900", "market": "KOSDAQ", "r3_pct": 0.03, "r3": -0.28, "clv": 0.66, "volume_ratio": 1.51, "liq_pct": 0.52},
+        {"symbol": "001000", "market": "KOSPI",  "r3_pct": 0.04, "r3": -0.20, "clv": 0.90, "volume_ratio": 3.0, "liq_pct": 0.90},
+        {"symbol": "001100", "market": "KOSDAQ", "r3_pct": 0.04, "r3": -0.20, "clv": 0.90, "volume_ratio": 3.0, "liq_pct": 0.90},
+    ]
+    literal = ["000410", "000900", "000500", "000600", "000700", "000100", "001000",
+               "000055", "000300", "001100", "000200", "000800"]
+    assert [r["symbol"] for r in sorted(rows, key=rev3_key)] == literal
+    sm = [0.004, -0.002, 0.006, 0.001, -0.003, 0.005, 0.002, -0.001, 0.003, 0.0,
+          0.004, -0.002]
+    m36 = statistics.mean(sm * 3)
+    sd36 = statistics.stdev(sm * 3)
+    lcb36 = m36 - Z90 * sd36 / math.sqrt(36)
+    return {
+        "V1_indicators": {
+            "r3": {"closes": [100.0, 98.0, 97.0, 94.0], "expected_r3": -0.06},
+            "clv_clamped": {"bar": {"open": 96.0, "high": 95.0, "low": 93.0, "close": 94.8},
+                            "expected_high_c": 96.0, "expected_low_c": 93.0,
+                            "expected_clv": (94.8 - 93.0) / 3.0},
+            "clv_undefined": {"bar": {"open": 50.0, "high": 50.0, "low": 50.0,
+                                      "close": 50.0}, "expected_signal": None},
+            "volume_ratio": {"prior20_volumes": [11, 14, 9, 20, 3, 17, 6, 12, 19, 8, 15,
+                                                 2, 13, 10, 18, 5, 16, 4, 7, 1],
+                             "volume_t": 21, "expected_median": 10.5,
+                             "expected_ratio": 2.0},
+            "brk20_margin": {"prior20_high_c": [100.0 + i * 0.5 for i in range(20)],
+                             "close_t": 110.0, "expected_prior_high20": 109.5,
+                             "expected_margin": 110.0 / 109.5 - 1.0},
+            "invalid_value_matrix": [{"volume": 0}, {"high": None}, {"close": 0.0},
+                                     {"low": -1.0},
+                                     {"volume": "non-finite -> invalid"},
+                                     {"note": "open>high invariant violation stays VALID (clamp-admit)"}]},
+        "V2_percentile": {"pct_asc_with_ties": {"values": vals,
+                                                "expected_pct": [pct_asc(vals, x)
+                                                                 for x in vals]},
+                          "exact_thresholds": {"1/20==0.05": 1 / 20 == 0.05,
+                                               "6/20==0.3": 6 / 20 == 0.3,
+                                               "19/38==0.5": 19 / 38 == 0.5,
+                                               "13/20==0.65": 13 / 20 == 0.65,
+                                               "15/20==0.75": 15 / 20 == 0.75},
+                          "population_floor": {"population_size": 19, "floor": FLOOR_N,
+                                               "expected": "POPULATION_BELOW_FLOOR"}},
+        "V3_ranking_selection": {"rev3_ranking": {"rows": rows,
+                                                  "expected_order_literal": literal},
+                                 "two_stage_note": "selection first (held skipped, "
+                                                   "slot-capped); NO_FILL consumes slot"},
+        "V4_execution": {"normal_fill": {"entry": 10000.0, "exit": 10500.0,
+                                         "net_43bp": 0.05 - COST_BASE,
+                                         "net_83bp": 0.05 - COST_SENS},
+                         "delisted_no_price": {"expected_gross": -1.0},
+                         "statuses": ["ENTERED", "IGNORED_HELD", "SKIPPED_MAX10",
+                                      "NO_FILL", "RIGHT_CENSORED_NOT_TRADEABLE",
+                                      "delisted_exit", "RUN_INVALID_DATA_GAP",
+                                      "RUN_INVALID_MATURITY_PRICE",
+                                      "RUN_INVALID_DUPLICATE_ROW",
+                                      "RUN_INVALID_EMPTY_BASELINE",
+                                      "RUN_INVALID_IDENTITY_CONFLICT",
+                                      "RUN_INVALID_MARKET_TRANSFER"]},
+        "V5_gates": {"clustered_lcb_n36": {"session_means": sm * 3, "z": Z90,
+                                           "expected_mean": m36, "expected_sd": sd36,
+                                           "expected_lcb": lcb36,
+                                           "expected_gate_pass": lcb36 > 0},
+                     "verdict_priority": "RUN_INVALID > UNIDENTIFIABLE > FALSIFIED > PASS"}}
+
+
+def compose_oracle():
+    """A11 synthetic oracles through the REAL compose function (n>=30, filled>=300)."""
+    dates40 = []
+    for y in range(2015, 2025):
+        for q in range(4):
+            dates40.append(date(y, 3 + q, 1))
+
+    def mk(excess):
+        trades, bls = [], {}
+        for s in range(40):
+            for i in range(8):
+                sym = "%06d" % (100 + i)
+                trades.append({"market": "KOSPI", "symbol": sym, "entry_idx": s,
+                               "gross": excess + COST_BASE})
+                bls[("KOSPI", sym, s)] = {"gross_mean": 0.0}
+        return trades, bls
+
+    t1, b1 = mk(0.01)
+    t2, b2 = mk(-0.01)
+    t3, b3 = mk(0.002)
+    pass_case = compose_verdict(dates40, t1, b1)
+    fail_case = compose_verdict(dates40, t2, b2)
+    cs_case = compose_verdict(dates40, t3, b3)
+    assert pass_case["verdict"] == "PASS" and not pass_case["cost_sensitive"]
+    assert fail_case["verdict"] == "FALSIFIED"
+    assert cs_case["verdict"] == "PASS" and cs_case["cost_sensitive"]
+    tE, bE = mk(0.01)
+    bE[("KOSPI", "000100", 0)] = {"gross_mean": None}
+    try:
+        compose_verdict(dates40, tE, bE)
+        raise AssertionError("empty baseline not caught")
+    except RunInvalid as e:
+        assert e.label == "RUN_INVALID_EMPTY_BASELINE"
+
+    # exact gate boundaries (4th-review P0): 300/299 filled, 30/29 clusters,
+    # mean excess exactly 0, 6/5 positive years, session-vs-trade year weighting
+    def mkc(n_sess, per_counts, excesses):
+        trades, bls = [], {}
+        for s in range(n_sess):
+            for i in range(per_counts[s]):
+                sym = "%06d" % (100 + i)
+                trades.append({"market": "KOSPI", "symbol": sym, "entry_idx": s,
+                               "gross": excesses[s] + COST_BASE})
+                bls[("KOSPI", sym, s)] = {"gross_mean": 0.0}
+        return trades, bls
+
+    t, b = mkc(30, [10] * 30, [0.01] * 30)
+    v300 = compose_verdict(dates40, t, b)
+    assert v300["profiles"]["43bp"]["filled"] == 300 and v300["verdict"] == "PASS"
+    t, b = mkc(30, [10] * 29 + [9], [0.01] * 30)
+    v299 = compose_verdict(dates40, t, b)
+    assert v299["profiles"]["43bp"]["filled"] == 299 and v299["verdict"] == "FALSIFIED"
+    assert v299["profiles"]["43bp"]["failed_gates"] == ["gate_filled_ge_300"]
+    t, b = mkc(29, [11] * 29, [0.01] * 29)
+    v29 = compose_verdict(dates40, t, b)
+    assert v29["verdict"] == "UNIDENTIFIABLE_CLUSTERS"
+    t, b = mkc(30, [10] * 30, [0.0] * 30)
+    v0 = compose_verdict(dates40, t, b)
+    assert v0["verdict"] == "FALSIFIED"          # mean 0 not > 0; LCB 0 not > 0
+    # positive years 6 vs 5 — the ONLY gate that differs (barely-negative years keep
+    # LCB/mean/filled PASS, isolating >=6 vs >6 mutants)
+    def year_excess(pos_years_count):
+        ex = []
+        for y in range(10):
+            ex.extend([0.01 if y < pos_years_count else -0.001] * 4)
+        return ex
+    t, b = mkc(40, [8] * 40, year_excess(6))
+    v6y = compose_verdict(dates40, t, b)
+    assert v6y["verdict"] == "PASS", v6y["profiles"]["43bp"]
+    assert v6y["profiles"]["43bp"]["positive_years"] == 6
+    assert v6y["profiles"]["43bp"]["gate_positive_years_ge_6"] is True
+    t, b = mkc(40, [8] * 40, year_excess(5))
+    v5y = compose_verdict(dates40, t, b)
+    assert v5y["verdict"] == "FALSIFIED"
+    assert v5y["profiles"]["43bp"]["positive_years"] == 5
+    assert v5y["profiles"]["43bp"]["failed_gates"] == ["gate_positive_years_ge_6"], \
+        v5y["profiles"]["43bp"]["failed_gates"]
+    # entry-year attribution (A14-3): Dec-2015 entry with Jan-2016 exit belongs to 2015 —
+    # an exit-year mutant collapses 2015 out of year_means entirely
+    datesX = [date(2015, 12, 30)]
+    dx = date(2016, 1, 4)
+    while len(datesX) < 31:
+        if dx.weekday() < 5:
+            datesX.append(dx)
+        dx += timedelta(days=7)
+    tX, bX = [], {}
+    for s in range(31):
+        for i in range(8):
+            sym = "%06d" % (100 + i)
+            tX.append({"market": "KOSPI", "symbol": sym, "entry_idx": s,
+                       "exit_idx": min(s + 1, 30),
+                       "gross": (0.05 if s == 0 else -0.001) + COST_BASE})
+            bX[("KOSPI", sym, s)] = {"gross_mean": 0.0}
+    vX = compose_verdict(datesX, tX, bX)
+    ymX = vX["profiles"]["43bp"]["year_means"]
+    assert set(ymX) == {"2015", "2016"} and ymX["2015"] > 0 > ymX["2016"], ymX
+    # year weighting: session-equal (A14-3) vs trade-weighted mutant discriminator —
+    # year 2015: +0.03 (1 trade), -0.01 (9 trades), -0.01 (9), -0.01 (9):
+    # session-equal year mean = 0.0; make it decisive with +0.04 -> +0.0025 positive,
+    # trade-weighted mean = (0.04 - 0.27)/28 < 0 negative
+    ex = [0.04, -0.01, -0.01, -0.01] + [0.01] * 36
+    pc = [1, 9, 9, 9] + [8] * 36
+    t, b = mkc(40, pc, ex)
+    vyw = compose_verdict(dates40, t, b)
+    assert vyw["profiles"]["43bp"]["positive_years"] == 10   # session-equal: 2015 positive
+    return {"pass_case": pass_case, "falsified_case": fail_case,
+            "cost_sensitive_case": cs_case,
+            "empty_baseline": "RUN_INVALID_EMPTY_BASELINE",
+            "boundary_filled_300": v300, "boundary_filled_299": v299,
+            "boundary_clusters_29": v29, "boundary_zero_excess": v0,
+            "boundary_years_6_full": v6y, "boundary_years_5_full": v5y,
+            "entry_year_attribution": {"dates_head": "2015-12-30 entry, 2016 exits",
+                                       "verdict": vX,
+                                       "note": "exit-year mutant erases 2015 bucket"},
+            "year_weight_session_equal": {"positive_years": vyw["profiles"]["43bp"]
+                                          ["positive_years"],
+                                          "note": "trade-weighted mutant -> 9"}}
+
+
+def sha(path):
+    return hashlib.sha256(open(path, "rb").read()).hexdigest()
+
+
+def main():
+    built_bars, symbols, membership, delist, dates = build_world()
+    write_fixtures(OUT, built_bars, symbols, membership, delist, dates)
+    w = read_world(OUT)
+    assert w.bars == built_bars, "bars roundtrip"
+    assert w.month_last == MONTH_LAST and w.expl_end == EXPLORATION_END
+
+    # ---- rev3
+    log3, tr3 = run_candidate(w, sig_rev3, 5)
+    ent = {(e["session"], e["symbol"], e["market"]) for e in log3["entries"]}
+    for s, sym, m in [(24, KA1, "KOSPI"), (24, QA1, "KOSDAQ"), (25, KA2, "KOSPI"),
+                      (25, QA2, "KOSDAQ"), (26, KA3, "KOSPI"), (26, QA3, "KOSDAQ"),
+                      (27, QA4, "KOSDAQ"), (28, KA4, "KOSPI"), (28, QA5, "KOSDAQ"),
+                      (29, QA6, "KOSDAQ"), (30, KA1, "KOSPI"), (35, KC1, "KOSPI"),
+                      (41, KG1, "KOSPI"), (41, QD1, "KOSDAQ"), (43, TWIN, "KOSPI"),
+                      (42, QD2, "KOSDAQ"), (45, KB1, "KOSPI")]:
+        assert (s, sym, m) in ent, (s, sym, m)
+    # A13: transfer new leg matures only after 21 member sessions — never pre-membership
+    assert ("KOSPI", TWIN) not in a8_base_set(w, 42)
+    assert ("KOSPI", TWIN) in a8_base_set(w, 43)
+    assert {(e["session"], e["symbol"]) for e in log3["ignored_held"]} == {(27, KA1)}
+    assert [(e["session"], e["symbol"]) for e in log3["skipped_max10"]] == [(29, KA5)]
+    assert [(e["session"], e["symbol"]) for e in log3["no_fill"]] == [(32, QB1)]
+    cen3 = {(e["session"], e["symbol"]) for e in log3["censored"]}
+    assert (47, KA2) in cen3 and (49, KH1) in cen3, sorted(cen3)
+    assert len(tr3) == 17, len(tr3)
+    tk = {(t["symbol"], t["entry_idx"]): t for t in tr3}
+    ka4 = tk[(KA4, 29)]
+    assert ka4["delisted_exit"] and ka4["exit_session"] == 32
+    assert ka4["exit_close"] == built_bars[(("KOSPI", KA4), 31)]["close"]
+    assert built_bars[(("KOSPI", KA4), 31)]["open"] is None      # close-only search proven
+    ka3 = tk[(KA3, 27)]
+    assert not ka3["delisted_exit"] and ka3["exit_session"] == 32
+    assert ka3["exit_close"] == built_bars[(("KOSPI", KA3), 32)]["close"]
+    assert built_bars[(("KOSPI", KA3), 32)]["open"] is None      # maturity close+volume-only
+    qd1 = tk[(QD1, 42)]
+    assert qd1["delisted_exit"] and qd1["exit_session"] == 46
+    assert qd1["exit_close"] == built_bars[(("KOSDAQ", QD1), 46)]["close"]
+    assert built_bars[(("KOSDAQ", QD1), 46)]["open"] is None     # event-session-inclusive
+    qd2 = tk[(QD2, 43)]
+    assert qd2["delisted_exit"] and qd2["gross"] == -1.0 and qd2["exit_close"] is None
+    kg1 = tk[(KG1, 42)]
+    assert not kg1["delisted_exit"] and kg1["exit_session"] == 47
+    assert (TWIN, 44) in tk and tk[(TWIN, 44)]["market"] == "KOSPI"
+    kb1t = tk[(KB1, 46)]
+    assert kb1t["exit_session"] == 51
+    s45, _ = sig_rev3(w, 45)
+    kb1s = [x for x in s45 if x["symbol"] == KB1][0]
+    assert kb1s["clv"] == 0.65 and kb1s["volume_ratio"] == 1.5, kb1s
+    s49, _ = sig_rev3(w, 49)
+    kh1 = [x for x in s49 if x["symbol"] == KH1][0]
+    assert kh1["r3_pct"] == 0.05, kh1["r3_pct"]
+    pops49, lp49, _ = populations(w, 49)
+    assert len(pops49["KOSPI"]) == 20, len(pops49["KOSPI"])
+    assert min(lp49[k] for k in pops49["KOSPI"]) == 0.5
+    s35, _ = sig_rev3(w, 35)
+    assert [x["symbol"] for x in s35 if x["market"] == "KOSPI"] == [KC1]
+    s36, _ = sig_rev3(w, 36)
+    assert not [x for x in s36 if x["market"] == "KOSPI"]
+    s38r, _ = sig_rev3(w, 38)
+    assert not [x for x in s38r if x["market"] == "KOSPI"]
+    assert ("KOSDAQ", KE5) not in a8_base_set(w, 45)
+    bl3 = {}
+    for t in tr3:
+        lpx = liq_pcts(w, t["signal_session"], a8_base_set(w, t["signal_session"]))
+        bl3[(t["market"], t["symbol"], t["entry_idx"])] = baseline(
+            w, t["signal_session"], 5, lpx[(t["market"], t["symbol"])])
+    assert bl3[("KOSDAQ", QA1, 25)]["cohort_excluded_entry"] >= 1
+    assert bl3[("KOSDAQ", QA5, 29)]["cohort_terminal_included"] >= 1
+    verdict3 = compose_verdict(w.dates, tr3, bl3)
+    assert verdict3["verdict"] == "UNIDENTIFIABLE_CLUSTERS"
+    assert verdict3["profiles"]["43bp"]["n_entry_sessions"] == 12
+
+    # ---- brk20
+    s33, _ = sig_brk20(w, 33)
+    assert all(x["symbol"] != KD1 for x in s33)
+    b33 = w.bar(("KOSPI", KD1), 33)
+    raw_ph = max(w.bar(("KOSPI", KD1), 33 - j)["high"] for j in range(1, 21))
+    clamp_ph = max(high_c(w.bar(("KOSPI", KD1), 33 - j)) for j in range(1, 21))
+    assert b33["close"] / raw_ph - 1 > 0 > b33["close"] / clamp_ph - 1
+    s37b, _ = sig_brk20(w, 37)
+    assert all(x["symbol"] != KD4 for x in s37b)
+    kd4b = w.bar(("KOSDAQ", KD4), 37)
+    ph4 = max(high_c(w.bar(("KOSDAQ", KD4), 37 - j)) for j in range(1, 21))
+    assert kd4b["close"] / ph4 - 1 == 0.0
+    s38b, _ = sig_brk20(w, 38)
+    kb2s = [x for x in s38b if x["symbol"] == KB2][0]
+    assert kb2s["clv"] == 0.75 and kb2s["volume_ratio"] == 1.25, kb2s
+    log_b, tr_b = run_candidate(w, sig_brk20, 10)
+    assert (34, KD2) in {(e["session"], e["symbol"]) for e in log_b["entries"]}
+    assert (38, KB2) in {(e["session"], e["symbol"]) for e in log_b["entries"]}
+    assert (50, KD3) in {(e["session"], e["symbol"]) for e in log_b["censored"]}
+    kd2 = [t for t in tr_b if t["symbol"] == KD2][0]
+    assert kd2["exit_session"] == 45
+    kb2t = [t for t in tr_b if t["symbol"] == KB2][0]
+    assert kb2t["exit_session"] == 49
+
+    # ---- lowvol
+    log_l, tr_l = run_candidate(w, sig_lowvol, 20, schedule=w.month_last)
+    assert 9 in log_l["notes"]
+    le = [(e["session"], e["symbol"]) for e in log_l["entries"]]
+    assert (29, Q01) in le
+    lv44, _ = sig_lowvol(w, 44)
+    lv5_hit = [x for x in lv44 if x["symbol"] == "900180"][0]
+    assert lv5_hit["vol20_pct"] == 0.3, lv5_hit["vol20_pct"]     # exact inclusive boundary
+    pops44, _, _ = populations(w, 44)
+    assert len(pops44["KOSDAQ"]) == 20, len(pops44["KOSDAQ"])
+    lv31, _ = sig_lowvol(w, 31)
+    assert all(x["symbol"] != QH1 for x in lv31)
+    closes_qh1 = [w.bar(("KOSDAQ", QH1), 31 - j)["close"] for j in range(20, -1, -1)]
+    assert closes_qh1[-1] / closes_qh1[0] - 1 == 0.0
+    assert (44, Q01) in {(e["session"], e["symbol"]) for e in log_l["censored"]}
+    q01t = [t for t in tr_l if t["symbol"] == Q01][0]
+    assert q01t["exit_session"] == 50 and not q01t["delisted_exit"]
+    print("lowvol entries:", le)
+    print("lowvol ignored:", [(e["session"], e["symbol"]) for e in log_l["ignored_held"]])
+    print("lowvol skipped:", [(e["session"], e["symbol"]) for e in log_l["skipped_max10"]])
+
+    assert w.oob_reads == 0, w.oob_reads                          # ACCESS SPY (A14-5)
+
+    oracle = compose_oracle()
+
+    # ---- variants (self-contained directories)
+    vroot = f"{OUT}/variants"
+    shutil.rmtree(vroot, ignore_errors=True)
+
+    def make_variant(name, mutate):
+        vd = f"{vroot}/{name}"
+        os.makedirs(vd, exist_ok=True)
+        for fn in ("fixture_bars.csv", "fixture_sessions.csv", "fixture_config.csv",
+                   "fixture_membership.csv", "fixture_delist_events.csv"):
+            shutil.copy(f"{OUT}/{fn}", f"{vd}/{fn}")
+        mutate(vd)
+        return vd
+
+    def drop_bar_rows(vd, pred):
+        p = f"{vd}/fixture_bars.csv"
+        with open(p, newline="") as f:
+            rows = list(csv.reader(f))
+        with open(p, "w", newline="") as f:
+            wcsv = csv.writer(f)
+            wcsv.writerow(rows[0])
+            for r in rows[1:]:
+                if not pred(r):
+                    wcsv.writerow(r)
+
+    expect = {}
+
+    vd = make_variant("invalid_maturity", lambda vd: drop_bar_rows(
+        vd, lambda r: r[0] == "KOSDAQ" and r[1] == QA1 and r[2] == "30"))
+    try:
+        run_candidate(read_world(vd), sig_rev3, 5)
+        raise AssertionError("invalid_maturity passed")
+    except RunInvalid as e:
+        assert e.label == "RUN_INVALID_MATURITY_PRICE", e.label
+        expect["invalid_maturity"] = e.label
+
+    vd = make_variant("data_gap", lambda vd: drop_bar_rows(
+        vd, lambda r: r[0] == "KOSPI" and r[2] == "30"))
+    try:
+        run_candidate(read_world(vd), sig_rev3, 5)
+        raise AssertionError("data_gap passed")
+    except RunInvalid as e:
+        assert e.label == "RUN_INVALID_DATA_GAP", e.label
+        expect["data_gap"] = e.label
+
+    def dup_row(vd):
+        p = f"{vd}/fixture_bars.csv"
+        with open(p, newline="") as f:
+            rows = list(csv.reader(f))
+        with open(p, "a", newline="") as f:
+            csv.writer(f).writerow(rows[1])
+    vd = make_variant("duplicate_row", dup_row)
+    try:
+        read_world(vd)
+        raise AssertionError("duplicate_row passed")
+    except RunInvalid as e:
+        assert e.label == "RUN_INVALID_DUPLICATE_ROW", e.label
+        expect["duplicate_row"] = e.label
+
+    vd = make_variant("nofill_no_substitution", lambda vd: drop_bar_rows(
+        vd, lambda r: r[0] == "KOSDAQ" and r[1] == QA6 and r[2] == "30"))
+    wv = read_world(vd)
+    logv, trv = run_candidate(wv, sig_rev3, 5)
+    assert (29, QA6) in {(e["session"], e["symbol"]) for e in logv["no_fill"]}
+    assert (29, KA5) in {(e["session"], e["symbol"]) for e in logv["skipped_max10"]}
+    assert all(t["symbol"] not in (QA6, KA5) for t in trv)
+    assert len(trv) == len(tr3) - 1
+    expect["nofill_no_substitution"] = {"QA6": "NO_FILL",
+                                        "KA5": "SKIPPED_MAX10 (no substitution)",
+                                        "trades": len(trv)}
+
+    def identity_conflict(vd):
+        p = f"{vd}/fixture_membership.csv"
+        with open(p, newline="") as f:
+            rows = list(csv.reader(f))
+        with open(p, "w", newline="") as f:
+            wcsv = csv.writer(f)
+            for r in rows:
+                if r and r[0] == "KOSDAQ" and r[1] == TWIN:
+                    r = ["KOSDAQ", TWIN, "0", "55"]      # overlaps KOSPI 23..55
+                wcsv.writerow(r)
+    vd = make_variant("identity_conflict", identity_conflict)
+    try:
+        run_candidate(read_world(vd), sig_rev3, 5)
+        raise AssertionError("identity_conflict passed")
+    except RunInvalid as e:
+        assert e.label == "RUN_INVALID_IDENTITY_CONFLICT", e.label
+        expect["identity_conflict"] = e.label
+
+    def market_transfer(vd):
+        # bars stay INTACT (incl. a stale-valid s34 maturity bar): the transfer gate must
+        # fire on membership_end < exit_due BEFORE price resolution — a mutant that only
+        # checks transfer when maturity is invalid completes normally and mismatches
+        p = f"{vd}/fixture_membership.csv"
+        with open(p, newline="") as f:
+            rows = list(csv.reader(f))
+        with open(p, "w", newline="") as f:
+            wcsv = csv.writer(f)
+            for r in rows:
+                if r and r[0] == "KOSDAQ" and r[1] == QA5:
+                    r = ["KOSDAQ", QA5, "0", "33"]
+                wcsv.writerow(r)
+            wcsv.writerow(["KOSPI", QA5, "35", "55"])    # same symbol re-lists on KOSPI
+    vd = make_variant("market_transfer", market_transfer)
+    try:
+        run_candidate(read_world(vd), sig_rev3, 5)
+        raise AssertionError("market_transfer passed")
+    except RunInvalid as e:
+        assert e.label == "RUN_INVALID_MARKET_TRANSFER", e.label
+        expect["market_transfer"] = e.label
+
+    # complementary precedence case: transfer=true + maturity MISSING must still be
+    # MARKET_TRANSFER (a maturity-first mutant emits MATURITY_PRICE here and is killed;
+    # the valid-bar variant above kills the invalid-only-check mutant — both directions)
+    def market_transfer_missing_maturity(vd):
+        market_transfer(vd)
+        drop_bar_rows(vd, lambda r: r[0] == "KOSDAQ" and r[1] == QA5 and int(r[2]) >= 34)
+    vd = make_variant("market_transfer_missing_maturity", market_transfer_missing_maturity)
+    try:
+        run_candidate(read_world(vd), sig_rev3, 5)
+        raise AssertionError("market_transfer_missing_maturity passed")
+    except RunInvalid as e:
+        assert e.label == "RUN_INVALID_MARKET_TRANSFER", e.label
+        expect["market_transfer_missing_maturity"] = e.label
+
+    # control: all-invalid-but-PRESENT rows are NOT a data gap (A14-4) — run completes
+    def blank_volumes(vd):
+        p = f"{vd}/fixture_bars.csv"
+        with open(p, newline="") as f:
+            rows = list(csv.reader(f))
+        with open(p, "w", newline="") as f:
+            wcsv = csv.writer(f)
+            wcsv.writerow(rows[0])
+            for r in rows[1:]:
+                if r[0] == "KOSPI" and r[2] == "21":
+                    r = r[:7] + [""]
+                wcsv.writerow(r)
+    vd = make_variant("data_gap_control_all_invalid", blank_volumes)
+    logc, trc = run_candidate(read_world(vd), sig_rev3, 5)
+    expect["data_gap_control_all_invalid"] = {
+        "result": "COMPLETES_NOT_DATA_GAP", "trades": len(trc),
+        "note": "rows present but invalid -> universe exclusion, not RUN_INVALID_DATA_GAP"}
+
+    # control: stale-valid maturity bar must NOT override delist evidence (A4/A7)
+    def stale_delist_bar(vd):
+        p = f"{vd}/fixture_bars.csv"
+        with open(p, "a", newline="") as f:
+            csv.writer(f).writerow(["KOSPI", KA4, "34", "1000.00", "1010.00", "990.00",
+                                    "1000.00", "1000"])
+    vd = make_variant("stale_delist_bar", stale_delist_bar)
+    wsd = read_world(vd)
+    _, trs = run_candidate(wsd, sig_rev3, 5)
+    ka4s = [t for t in trs if t["symbol"] == KA4][0]
+    assert ka4s["delisted_exit"] and ka4s["exit_session"] == 32
+    assert ka4s["exit_close"] == ka4["exit_close"]     # identical to base — evidence wins
+    # A4 exact oracle: QA5's cohort (contains KA4) must ALSO ignore the stale s34 bar —
+    # a maturity-first baseline mutant flips gross_mean sign and terminal count
+    lp_sd = liq_pcts(wsd, 28, a8_base_set(wsd, 28))
+    bl_sd = baseline(wsd, 28, 5, lp_sd[("KOSDAQ", QA5)])
+    assert bl_sd == bl3[("KOSDAQ", QA5, 29)], (bl_sd, bl3[("KOSDAQ", QA5, 29)])
+    expect["stale_delist_bar"] = {
+        "result": "KA4_TRADE_IDENTICAL_TO_BASE",
+        "qa5_cohort_baseline_exact": bl_sd,
+        "note": "delist evidence precedes stale-valid scheduled maturity bar — for the "
+                "strategy trade AND the A4 cohort member"}
+
+    # control: a holdout-only leg (membership s53+) must be invisible — base unchanged
+    def holdout_leg(vd):
+        with open(f"{vd}/fixture_membership.csv", "a", newline="") as f:
+            csv.writer(f).writerow(["KOSDAQ", "900490", "53", "55"])
+        with open(f"{vd}/fixture_bars.csv", "a", newline="") as f:
+            wcsv = csv.writer(f)
+            for i in (53, 54, 55):
+                wcsv.writerow(["KOSDAQ", "900490", i, "1000.00", "1010.00", "990.00",
+                               "1000.00", "1000"])
+    vd = make_variant("holdout_leg_control", holdout_leg)
+    wh = read_world(vd)
+    logh, trh = run_candidate(wh, sig_rev3, 5)
+    assert trh == tr3 and wh.oob_reads == 0            # invisible: identical results
+    hk = ("KOSDAQ", "900490")
+    assert hk not in wh.membership and hk not in wh.symbols   # structural clamp serialized
+    expect["holdout_leg_control"] = {
+        "result": "IDENTICAL_TO_BASE", "trades": len(trh), "oob_reads": wh.oob_reads,
+        "holdout_key_in_symbols": False, "holdout_key_in_membership": False,
+        "note": "membership leg starting beyond exploration_end is structurally invisible —"
+                " implementations must assert the clamped symbol/membership key sets"}
+
+    # ---- golden
+    fixture_files = ["fixture_bars.csv", "fixture_sessions.csv", "fixture_config.csv",
+                     "fixture_membership.csv", "fixture_delist_events.csv"]
+    variant_shas = {n: {fn: sha(f"{vroot}/{n}/{fn}") for fn in fixture_files} for n in
+                    ("invalid_maturity", "data_gap", "duplicate_row",
+                     "nofill_no_substitution", "identity_conflict", "market_transfer",
+                     "market_transfer_missing_maturity",
+                     "data_gap_control_all_invalid", "stale_delist_bar",
+                     "holdout_leg_control")}
+    golden = {
+        "contract": "kr-golden-vectors-v1 / golden v5",
+        "candidates_yaml_sha256": "0f5e92bf7d10dd77588fa08ad949811a68004cf71dd7f2efd232306b22d82d85",
+        "convention_sha256": {
+            "amendment_a1_a9": sha(f"{INBOX}/amendment-kr-engine-conventions-v2-draft-20260805.md"),
+            "amendment_a10_a12": sha(f"{INBOX}/amendment-kr-engine-a10-a12-draft-20260805.md"),
+            "amendment_a13_a14": sha(f"{INBOX}/amendment-kr-engine-a13-a14-draft-20260805.md"),
+            "generator": sha(f"{OUT}/reference_generator_v4.py")},
+        "fixture_sha256": {n: sha(f"{OUT}/{n}") for n in fixture_files},
+        "variant_fixture_sha256": variant_shas,
+        "exploration_end_session_idx": EXPLORATION_END,
+        "access_spy_oob_reads": w.oob_reads,
+        **build_layers(),
+        "E2E": {
+            "rev3": {"log": log3, "trades": tr3,
+                     "baselines": {f"{k[0]}:{k[1]}@e{k[2]}": v for k, v in bl3.items()},
+                     "verdict": verdict3,
+                     "signals_s35_per_market_proof": s35,
+                     "signals_s45_exact_clv_ratio": s45,
+                     "signals_s49_exact_boundary": s49},
+            "brk20": {"log": log_b, "trades": tr_b,
+                      "signals_s38_exact_clv_ratio": s38b},
+            "lowvol": {"log": log_l, "trades": tr_l,
+                       "signals_s44_exact_vol20_pct": lv44},
+            "compose_oracle": oracle,
+            "variants": expect},
+    }
+    with open(f"{OUT}/golden_v5.json", "w") as f:
+        json.dump(golden, f, indent=1, ensure_ascii=False, default=str)
+    print(sha(f"{OUT}/golden_v5.json"), " golden_v5.json")
+    for n in fixture_files:
+        print(golden["fixture_sha256"][n][:16], n)
+    print("rev3:", len(tr3), "| verdict:", verdict3["verdict"],
+          "| clusters:", verdict3["profiles"]["43bp"]["n_entry_sessions"],
+          "| oob_reads:", w.oob_reads)
+    print("brk20:", len(tr_b), "| lowvol:", len(tr_l))
+    print("ALL_V5_ASSERTIONS_PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/research/kr_corpus/test_kr_a0_exact_binding.py
+++ b/tests/research/kr_corpus/test_kr_a0_exact_binding.py
@@ -1,0 +1,735 @@
+"""Adversarial CI coverage for the KR-A0 exact packet binding.
+
+The fixture bundle is self-contained.  Its hash-pinned reference generator
+materializes the five base files and all ten variants into ``tmp_path``; no
+corpus or holdout path is included in this test's input list.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import shutil
+from collections.abc import Iterable, Mapping
+from datetime import date, timedelta
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from research.kr_corpus.backtest.packet_engine import (
+    COST_BASE,
+    COST_SENSITIVITY,
+    Bar,
+    PacketEngine,
+    PacketWorld,
+    PacketWorldAdapter,
+    RunInvalid,
+    canonical_sample_stdev,
+    clustered_lcb,
+    compose_verdict,
+    high_c,
+    low_c,
+    pct_asc,
+    rev3_rank_key,
+    valid_bar,
+)
+from research.kr_corpus.registry.exact_binding import (
+    CANDIDATES_SHA256,
+    CONVENTION_SHA256,
+    GOLDEN_V5_SHA256,
+    ArtifactPaths,
+    CandidateRegistry,
+    NeedsUpstream,
+    RegistryStartRejected,
+    sha256_file,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_BUNDLE = REPO_ROOT / "tests" / "fixtures" / "kr_a0_golden_v5"
+
+
+@pytest.fixture(scope="session")
+def generated_v5(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Execute the pinned generator under its sealed v5 numeric convention."""
+
+    output = tmp_path_factory.mktemp("kr_a0_golden") / "vectors"
+    output.mkdir()
+    generator = FIXTURE_BUNDLE / "reference_generator_v4.py.fixture"
+    shutil.copy2(generator, output / "reference_generator_v4.py")
+
+    loader = SourceFileLoader("kr_a0_reference", str(generator))
+    spec = importlib.util.spec_from_loader("kr_a0_reference", loader)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # v5 was sealed using CPython 3.9's exact-ratio ddof=1 kernel.  The
+    # generator source itself is byte-pinned; this compatibility kernel avoids
+    # a later stdlib rounding revision changing its JSON output on CI.
+    original_stdev = module.statistics.stdev
+    module.statistics.stdev = canonical_sample_stdev
+    try:
+        module.OUT = str(output)
+        module.INBOX = str(FIXTURE_BUNDLE / "inbox")
+        module.main()
+    finally:
+        module.statistics.stdev = original_stdev
+
+    assert sha256_file(output / "golden_v5.json") == GOLDEN_V5_SHA256
+    return output
+
+
+@pytest.fixture
+def artifact_paths(generated_v5: Path) -> ArtifactPaths:
+    inbox = FIXTURE_BUNDLE / "inbox"
+    return ArtifactPaths(
+        candidates_yaml=FIXTURE_BUNDLE / "02-active-candidates.yaml",
+        golden_v5=generated_v5 / "golden_v5.json",
+        amendment_a1_a9=inbox / "amendment-kr-engine-conventions-v2-draft-20260805.md",
+        amendment_a10_a12=inbox / "amendment-kr-engine-a10-a12-draft-20260805.md",
+        amendment_a13_a14=inbox / "amendment-kr-engine-a13-a14-draft-20260805.md",
+        generator=generated_v5 / "reference_generator_v4.py",
+        fixture_root=generated_v5,
+    )
+
+
+@pytest.fixture
+def registry(artifact_paths: ArtifactPaths) -> CandidateRegistry:
+    return CandidateRegistry.start(artifact_paths)
+
+
+@pytest.fixture
+def golden(generated_v5: Path) -> dict[str, Any]:
+    return json.loads((generated_v5 / "golden_v5.json").read_text(encoding="utf-8"))
+
+
+def _normalized(value: Any) -> Any:
+    return json.loads(json.dumps(value, sort_keys=True, allow_nan=False))
+
+
+def _engine_run(
+    registry: CandidateRegistry, root: Path, strategy_id: str = "rev3_reclaim"
+):
+    world = PacketWorldAdapter.from_fixture_directory(root)
+    result = PacketEngine(registry).run(world, strategy_id)
+    return world, result
+
+
+def _baseline_key(market: str, symbol: str, entry_idx: int) -> str:
+    return f"{market}:{symbol}@e{entry_idx}"
+
+
+def test_v5_inputs_are_recomputed_and_generator_is_byte_exact(
+    artifact_paths: ArtifactPaths,
+    generated_v5: Path,
+    registry: CandidateRegistry,
+    golden: Mapping[str, Any],
+) -> None:
+    """Acceptance 1/2: all base, variant, convention, and generator pins fire."""
+
+    assert (
+        sha256_file(FIXTURE_BUNDLE / "02-active-candidates.yaml") == CANDIDATES_SHA256
+    )
+    assert sha256_file(generated_v5 / "golden_v5.json") == GOLDEN_V5_SHA256
+    assert (
+        sha256_file(generated_v5 / "reference_generator_v4.py")
+        == CONVENTION_SHA256["generator"]
+    )
+    assert "golden v5" in (FIXTURE_BUNDLE / "CONTRACT.md").read_text(encoding="utf-8")
+    assert registry.inputs.candidates_sha256 == golden["candidates_yaml_sha256"]
+    assert registry.inputs.golden_sha256 == GOLDEN_V5_SHA256
+    assert dict(registry.inputs.convention_sha256) == golden["convention_sha256"]
+    assert dict(registry.inputs.fixture_sha256) == golden["fixture_sha256"]
+    assert (
+        dict(registry.inputs.variant_fixture_sha256) == golden["variant_fixture_sha256"]
+    )
+    assert len(registry.inputs.variant_fixture_sha256) == 10
+    assert artifact_paths.fixture_root == generated_v5
+
+
+def test_v1_to_v5_primitives_match_exact_oracles(golden: Mapping[str, Any]) -> None:
+    """V1–V5 are tested independently as well as through all candidate E2Es."""
+
+    v1 = golden["V1_indicators"]
+    closes = v1["r3"]["closes"]
+    assert closes[-1] / closes[-4] - 1 == pytest.approx(v1["r3"]["expected_r3"])
+
+    clamped = v1["clv_clamped"]
+    bar = Bar(**clamped["bar"], volume=1)
+    assert high_c(bar) == clamped["expected_high_c"]
+    assert low_c(bar) == clamped["expected_low_c"]
+    assert (bar.close - low_c(bar)) / (high_c(bar) - low_c(bar)) == clamped[
+        "expected_clv"
+    ]
+
+    undefined = Bar(**v1["clv_undefined"]["bar"], volume=1)
+    assert high_c(undefined) == low_c(undefined)
+    assert v1["clv_undefined"]["expected_signal"] is None
+
+    volume = v1["volume_ratio"]
+    assert statistics_median(volume["prior20_volumes"]) == volume["expected_median"]
+    assert volume["volume_t"] / volume["expected_median"] == volume["expected_ratio"]
+
+    margin = v1["brk20_margin"]
+    assert max(margin["prior20_high_c"]) == margin["expected_prior_high20"]
+    assert (
+        margin["close_t"] / margin["expected_prior_high20"] - 1
+        == margin["expected_margin"]
+    )
+    assert not valid_bar(Bar(open=1.0, high=1.0, low=1.0, close=1.0, volume=0))
+    assert valid_bar(Bar(open=2.0, high=1.0, low=1.0, close=1.0, volume=1))
+
+    v2 = golden["V2_percentile"]
+    values = v2["pct_asc_with_ties"]["values"]
+    assert [pct_asc(values, value) for value in values] == v2["pct_asc_with_ties"][
+        "expected_pct"
+    ]
+    assert all(v2["exact_thresholds"].values())
+    assert v2["population_floor"]["population_size"] < v2["population_floor"]["floor"]
+
+    ranking = golden["V3_ranking_selection"]["rev3_ranking"]
+    assert [
+        row["symbol"] for row in sorted(ranking["rows"], key=rev3_rank_key)
+    ] == ranking["expected_order_literal"]
+
+    v4 = golden["V4_execution"]
+    assert 0.05 - COST_BASE == v4["normal_fill"]["net_43bp"]
+    assert 0.05 - COST_SENSITIVITY == v4["normal_fill"]["net_83bp"]
+    assert v4["delisted_no_price"]["expected_gross"] == -1.0
+
+    v5 = golden["V5_gates"]["clustered_lcb_n36"]
+    assert canonical_sample_stdev(v5["session_means"]) == v5["expected_sd"]
+    assert clustered_lcb(v5["session_means"]) == v5["expected_lcb"]
+    assert (clustered_lcb(v5["session_means"]) > 0) is v5["expected_gate_pass"]
+
+
+def test_all_three_packet_e2es_are_json_normalized_exact(
+    generated_v5: Path,
+    registry: CandidateRegistry,
+    golden: Mapping[str, Any],
+) -> None:
+    engine = PacketEngine(registry)
+    candidates = (
+        ("rev3_reclaim", "rev3"),
+        ("brk20_confirm", "brk20"),
+        ("lowvol_up_month", "lowvol"),
+    )
+    for strategy_id, golden_key in candidates:
+        world = PacketWorldAdapter.from_fixture_directory(generated_v5)
+        result = engine.run(world, strategy_id)
+        expected = golden["E2E"][golden_key]
+        actual = result.golden_payload()
+        expected_keys = ("log", "trades", "baselines", "verdict")
+        if golden_key != "rev3":
+            expected_keys = ("log", "trades")
+        for key in expected_keys:
+            assert _normalized(actual[key]) == expected[key]
+        stamped = result.to_dict()
+        assert stamped["strategy_id"] == strategy_id
+        assert (
+            stamped["contract_hash"] == registry.binding_for(strategy_id).contract_hash
+        )
+        assert stamped["log"]["contract_hash"] == stamped["contract_hash"]
+        assert stamped["verdict"]["strategy_id"] == strategy_id
+        assert all(
+            trade["contract_hash"] == stamped["contract_hash"]
+            for trade in stamped["trades"]
+        )
+        assert world.spy.total_oob_reads == golden["access_spy_oob_reads"] == 0
+
+    rev_world = PacketWorldAdapter.from_fixture_directory(generated_v5)
+    assert (
+        engine.signals(rev_world, "rev3_reclaim", 35)[0]
+        == golden["E2E"]["rev3"]["signals_s35_per_market_proof"]
+    )
+    assert (
+        engine.signals(rev_world, "rev3_reclaim", 45)[0]
+        == golden["E2E"]["rev3"]["signals_s45_exact_clv_ratio"]
+    )
+    assert (
+        engine.signals(rev_world, "rev3_reclaim", 49)[0]
+        == golden["E2E"]["rev3"]["signals_s49_exact_boundary"]
+    )
+    assert (
+        engine.signals(
+            PacketWorldAdapter.from_fixture_directory(generated_v5), "brk20_confirm", 38
+        )[0]
+        == golden["E2E"]["brk20"]["signals_s38_exact_clv_ratio"]
+    )
+    assert (
+        engine.signals(
+            PacketWorldAdapter.from_fixture_directory(generated_v5),
+            "lowvol_up_month",
+            44,
+        )[0]
+        == golden["E2E"]["lowvol"]["signals_s44_exact_vol20_pct"]
+    )
+
+
+def test_compose_oracle_and_entry_year_schema_are_exact(
+    golden: Mapping[str, Any],
+) -> None:
+    """A11/A14: all four gates, full labels, and entry-year-only attribution."""
+
+    oracle = golden["E2E"]["compose_oracle"]
+    dates40 = _dates40()
+
+    for expected_key, excess in (
+        ("pass_case", 0.01),
+        ("falsified_case", -0.01),
+        ("cost_sensitive_case", 0.002),
+    ):
+        trades, baselines = _compose_case(40, [8] * 40, [excess] * 40)
+        assert (
+            _normalized(compose_verdict(dates40, trades, baselines))
+            == oracle[expected_key]
+        )
+
+    trades, baselines = _compose_case(30, [10] * 30, [0.01] * 30)
+    assert (
+        _normalized(compose_verdict(dates40, trades, baselines))
+        == oracle["boundary_filled_300"]
+    )
+    trades, baselines = _compose_case(30, [10] * 29 + [9], [0.01] * 30)
+    assert (
+        _normalized(compose_verdict(dates40, trades, baselines))
+        == oracle["boundary_filled_299"]
+    )
+    trades, baselines = _compose_case(29, [11] * 29, [0.01] * 29)
+    assert (
+        _normalized(compose_verdict(dates40, trades, baselines))
+        == oracle["boundary_clusters_29"]
+    )
+    trades, baselines = _compose_case(30, [10] * 30, [0.0] * 30)
+    assert (
+        _normalized(compose_verdict(dates40, trades, baselines))
+        == oracle["boundary_zero_excess"]
+    )
+
+    for expected_key, positive_years in (
+        ("boundary_years_6_full", 6),
+        ("boundary_years_5_full", 5),
+    ):
+        excesses = [
+            value
+            for year in range(10)
+            for value in ([0.01] if year < positive_years else [-0.001]) * 4
+        ]
+        trades, baselines = _compose_case(40, [8] * 40, excesses)
+        assert (
+            _normalized(compose_verdict(dates40, trades, baselines))
+            == oracle[expected_key]
+        )
+
+    entry_dates = _entry_year_dates()
+    trades, baselines = _compose_case(
+        31,
+        [8] * 31,
+        [0.05] + [-0.001] * 30,
+        include_exit_session=True,
+    )
+    assert all("entry_idx" in trade and "exit_session" in trade for trade in trades)
+    assert all("exit_idx" not in trade for trade in trades)
+    assert (
+        _normalized(compose_verdict(entry_dates, trades, baselines))
+        == oracle["entry_year_attribution"]["verdict"]
+    )
+
+    weighted_excesses = [0.04, -0.01, -0.01, -0.01] + [0.01] * 36
+    weighted_counts = [1, 9, 9, 9] + [8] * 36
+    trades, baselines = _compose_case(40, weighted_counts, weighted_excesses)
+    weighted = compose_verdict(dates40, trades, baselines)
+    assert (
+        weighted["profiles"]["43bp"]["positive_years"]
+        == oracle["year_weight_session_equal"]["positive_years"]
+    )
+
+    trades, baselines = _compose_case(40, [8] * 40, [0.01] * 40)
+    baselines[_baseline_key("KOSPI", "000100", 0)] = {"gross_mean": None}
+    with pytest.raises(RunInvalid, match="RUN_INVALID_EMPTY_BASELINE"):
+        compose_verdict(dates40, trades, baselines)
+
+
+def test_all_ten_variants_match_their_expected_outcome(
+    generated_v5: Path,
+    registry: CandidateRegistry,
+    golden: Mapping[str, Any],
+) -> None:
+    expected = golden["E2E"]["variants"]
+    assert set(expected) == set(registry.inputs.variant_fixture_sha256)
+    _, base = _engine_run(registry, generated_v5)
+
+    for name in ("invalid_maturity", "data_gap", "duplicate_row", "identity_conflict"):
+        with pytest.raises(RunInvalid) as caught:
+            _engine_run(registry, generated_v5 / "variants" / name)
+        assert caught.value.label == expected[name]
+
+    for name in ("market_transfer", "market_transfer_missing_maturity"):
+        with pytest.raises(RunInvalid) as caught:
+            _engine_run(registry, generated_v5 / "variants" / name)
+        assert caught.value.label == expected[name]
+        assert caught.value.evidence["occurrence_count"] >= 1
+        assert caught.value.evidence["affected_identities"][0]["market"] == "KOSDAQ"
+        assert caught.value.evidence["affected_identities"][0]["symbol"] == "900350"
+
+    _, nofill = _engine_run(
+        registry, generated_v5 / "variants" / "nofill_no_substitution"
+    )
+    nofill_actual = {
+        "QA6": "NO_FILL"
+        if any(entry["symbol"] == "900360" for entry in nofill.log["no_fill"])
+        else "UNEXPECTED",
+        "KA5": "SKIPPED_MAX10 (no substitution)"
+        if any(entry["symbol"] == "000350" for entry in nofill.log["skipped_max10"])
+        else "UNEXPECTED",
+        "trades": len(nofill.trades),
+    }
+    assert nofill_actual == expected["nofill_no_substitution"]
+
+    _, all_invalid = _engine_run(
+        registry, generated_v5 / "variants" / "data_gap_control_all_invalid"
+    )
+    assert {
+        "result": "COMPLETES_NOT_DATA_GAP",
+        "trades": len(all_invalid.trades),
+        "note": "rows present but invalid -> universe exclusion, not RUN_INVALID_DATA_GAP",
+    } == expected["data_gap_control_all_invalid"]
+
+    _, stale = _engine_run(registry, generated_v5 / "variants" / "stale_delist_bar")
+    ka4 = next(trade for trade in stale.trades if trade["symbol"] == "000340")
+    stale_actual = {
+        "result": "KA4_TRADE_IDENTICAL_TO_BASE",
+        "qa5_cohort_baseline_exact": stale.baselines[
+            _baseline_key("KOSDAQ", "900350", 29)
+        ],
+        "note": (
+            "delist evidence precedes stale-valid scheduled maturity bar — for the "
+            "strategy trade AND the A4 cohort member"
+        ),
+    }
+    assert ka4 == next(trade for trade in base.trades if trade["symbol"] == "000340")
+    assert _normalized(stale_actual) == expected["stale_delist_bar"]
+
+    holdout_world, holdout = _engine_run(
+        registry, generated_v5 / "variants" / "holdout_leg_control"
+    )
+    holdout_key = ("KOSDAQ", "900490")
+    holdout_actual = {
+        "result": "IDENTICAL_TO_BASE",
+        "trades": len(holdout.trades),
+        "oob_reads": holdout_world.spy.total_oob_reads,
+        "holdout_key_in_symbols": holdout_key in holdout_world.symbols,
+        "holdout_key_in_membership": holdout_key in holdout_world.membership,
+        "note": (
+            "membership leg starting beyond exploration_end is structurally invisible —"
+            " implementations must assert the clamped symbol/membership key sets"
+        ),
+    }
+    assert _normalized(list(holdout.trades)) == _normalized(list(base.trades))
+    assert holdout_actual == expected["holdout_leg_control"]
+
+
+def test_mutations_are_each_killed_by_the_golden_vectors(
+    generated_v5: Path,
+    registry: CandidateRegistry,
+    golden: Mapping[str, Any],
+) -> None:
+    """Bidirectional proof: known wrong implementations do not pass golden v5."""
+
+    expected = golden["E2E"]["rev3"]
+
+    class StrictComparatorMutant(PacketEngine):
+        def _at_least(self, actual: float, threshold: float) -> bool:
+            return actual > threshold
+
+        def _at_most(self, actual: float, threshold: float) -> bool:
+            return actual < threshold
+
+    class RawHighMutant(PacketEngine):
+        def _high_c(self, bar: Bar) -> float:
+            assert bar.high is not None
+            return bar.high
+
+    class GlobalPercentileMutant(PacketEngine):
+        def _per_market_percentiles(
+            self, values_by_market: Mapping[str, Mapping[tuple[str, str], float]]
+        ) -> dict[tuple[str, str], float]:
+            keys = tuple(key for values in values_by_market.values() for key in values)
+            values = [
+                value
+                for market_values in values_by_market.values()
+                for value in market_values.values()
+            ]
+            return {
+                key: pct_asc(values, value)
+                for key, value in zip(keys, values, strict=True)
+            }
+
+    class FullBarExecutionMutant(PacketEngine):
+        def _entry_ok(self, bar: Bar | None) -> bool:
+            return valid_bar(bar)
+
+        def _maturity_ok(self, bar: Bar | None) -> bool:
+            return valid_bar(bar)
+
+    for mutant in (StrictComparatorMutant, GlobalPercentileMutant):
+        world = PacketWorldAdapter.from_fixture_directory(generated_v5)
+        result = mutant(registry).run(world, "rev3_reclaim")
+        actual = result.golden_payload()
+        assert any(
+            _normalized(actual[key]) != expected[key]
+            for key in ("log", "trades", "baselines", "verdict")
+        )
+
+    raw_high = (
+        RawHighMutant(registry)
+        .run(PacketWorldAdapter.from_fixture_directory(generated_v5), "brk20_confirm")
+        .golden_payload()
+    )
+    raw_high_expected = golden["E2E"]["brk20"]
+    assert any(
+        _normalized(raw_high[key]) != raw_high_expected[key]
+        for key in ("log", "trades")
+    )
+
+    with pytest.raises(RunInvalid, match="RUN_INVALID_MATURITY_PRICE"):
+        FullBarExecutionMutant(registry).run(
+            PacketWorldAdapter.from_fixture_directory(generated_v5), "rev3_reclaim"
+        )
+
+    class NoFillSubstitutionMutant(PacketEngine):
+        def _substitute_after_no_fill(self) -> bool:
+            return True
+
+    nofill = NoFillSubstitutionMutant(registry).run(
+        PacketWorldAdapter.from_fixture_directory(
+            generated_v5 / "variants" / "nofill_no_substitution"
+        ),
+        "rev3_reclaim",
+    )
+    assert any(trade["symbol"] == "000350" for trade in nofill.trades)
+
+    class SymbolOnlyIdentityMutant(PacketEngine):
+        def _check_identity(self, world: PacketWorld) -> None:
+            # An identity keyed by (market, symbol) cannot see cross-market overlap.
+            assert len(set(world.membership)) == len(world.membership)
+
+    result = SymbolOnlyIdentityMutant(registry).run(
+        PacketWorldAdapter.from_fixture_directory(
+            generated_v5 / "variants" / "identity_conflict"
+        ),
+        "rev3_reclaim",
+    )
+    assert len(result.trades) == 17
+
+
+def test_transfer_precedence_mutants_are_killed_in_both_directions(
+    generated_v5: Path, registry: CandidateRegistry
+) -> None:
+    class InvalidOnlyTransferMutant(PacketEngine):
+        def _transfer_gate(
+            self, world: PacketWorld, position: Mapping[str, Any]
+        ) -> bool:
+            due = int(position["exit_due"])
+            return not self._maturity_ok(
+                world.bar(position["key"], due)
+            ) and super()._transfer_gate(world, position)
+
+    class MaturityFirstTransferMutant(PacketEngine):
+        def _transfer_precedes_maturity(self) -> bool:
+            return False
+
+    valid_transfer = generated_v5 / "variants" / "market_transfer"
+    missing_transfer = generated_v5 / "variants" / "market_transfer_missing_maturity"
+    completed = InvalidOnlyTransferMutant(registry).run(
+        PacketWorldAdapter.from_fixture_directory(valid_transfer), "rev3_reclaim"
+    )
+    assert len(completed.trades) == 17
+    with pytest.raises(RunInvalid) as caught:
+        MaturityFirstTransferMutant(registry).run(
+            PacketWorldAdapter.from_fixture_directory(missing_transfer), "rev3_reclaim"
+        )
+    assert caught.value.label == "RUN_INVALID_MATURITY_PRICE"
+
+
+def test_access_spy_and_source_materialization_are_boundary_sealed(
+    generated_v5: Path, registry: CandidateRegistry
+) -> None:
+    """Acceptance 5/6: query and materialization both carry the <= end predicate."""
+
+    class SourceSpy:
+        def __init__(self, directory: Path) -> None:
+            self.calls: list[tuple[str, int]] = []
+            self.sessions = _csv_rows(directory / "fixture_sessions.csv")
+            self.bars = _csv_rows(directory / "fixture_bars.csv")
+            self.membership = _csv_rows(directory / "fixture_membership.csv")
+            self.delist = _csv_rows(directory / "fixture_delist_events.csv")
+
+        def fetch_sessions(self, *, max_session_idx: int):
+            self.calls.append(("sessions", max_session_idx))
+            return [
+                row
+                for row in self.sessions
+                if int(row["session_idx"]) <= max_session_idx
+            ]
+
+        def fetch_bars(self, *, max_session_idx: int):
+            self.calls.append(("bars", max_session_idx))
+            return [
+                row for row in self.bars if int(row["session_idx"]) <= max_session_idx
+            ]
+
+        def fetch_membership(self, *, max_session_idx: int):
+            self.calls.append(("membership", max_session_idx))
+            return [
+                row
+                for row in self.membership
+                if int(row["start_idx"]) <= max_session_idx
+            ]
+
+        def fetch_delist_events(self, *, max_session_idx: int):
+            self.calls.append(("delist", max_session_idx))
+            return [
+                row
+                for row in self.delist
+                if int(row["delist_session_idx"]) <= max_session_idx
+            ]
+
+    source = SourceSpy(generated_v5 / "variants" / "holdout_leg_control")
+    world = PacketWorldAdapter.from_source(source, exploration_end_session_idx=52)
+    assert source.calls == [
+        ("sessions", 52),
+        ("bars", 52),
+        ("membership", 52),
+        ("delist", 52),
+    ]
+    assert all(session <= 52 for (_, session) in world.bars)
+    assert all(end <= 52 for _, end in world.membership.values())
+    assert ("KOSDAQ", "900490") not in world.symbols
+    assert ("KOSDAQ", "900490") not in world.membership
+    assert world.spy.source_oob_records == 0
+    result = PacketEngine(registry).run(world, "rev3_reclaim")
+    assert len(result.trades) == 17
+    assert world.spy.total_oob_reads == 0
+
+    class BoundaryReadMutant(PacketEngine):
+        def _execute_candidate(self, world: PacketWorld, binding):
+            world.bar(world.symbols[0], world.exploration_end_session_idx + 1)
+            return super()._execute_candidate(world, binding)
+
+    with pytest.raises(RunInvalid, match="RUN_INVALID_BOUNDARY_ACCESS"):
+        BoundaryReadMutant(registry).run(
+            PacketWorldAdapter.from_fixture_directory(generated_v5), "rev3_reclaim"
+        )
+
+
+def test_tamper_and_fallback_paths_refuse_registry_startup(
+    generated_v5: Path, tmp_path: Path
+) -> None:
+    """Acceptance 7: input tamper, golden mismatch, and fallback all fail closed."""
+
+    mutable = tmp_path / "mutable_bundle"
+    shutil.copytree(generated_v5, mutable)
+    shutil.copy2(
+        FIXTURE_BUNDLE / "02-active-candidates.yaml",
+        mutable / "02-active-candidates.yaml",
+    )
+    shutil.copytree(FIXTURE_BUNDLE / "inbox", mutable / "inbox")
+    paths = ArtifactPaths.from_fixture_bundle(mutable)
+    registry = CandidateRegistry.start(paths)
+    with pytest.raises(RegistryStartRejected, match="shared fallback is forbidden"):
+        registry.binding_for("calculate_signal")
+
+    cases = (
+        ("02-active-candidates.yaml", b"\n# tamper\n"),
+        ("golden_v5.json", b" "),
+        ("fixture_bars.csv", b"\n"),
+    )
+    for relative, addition in cases:
+        case_root = tmp_path / relative.replace("/", "_")
+        shutil.copytree(mutable, case_root)
+        target = case_root / relative
+        target.write_bytes(target.read_bytes() + addition)
+        with pytest.raises(RegistryStartRejected):
+            CandidateRegistry.start(ArtifactPaths.from_fixture_bundle(case_root))
+
+    with pytest.raises(
+        NeedsUpstream, match="NEEDS_UPSTREAM\\(percentile convention 충돌\\)"
+    ):
+        CandidateRegistry.start(
+            paths, observed_percentile_convention="global_rank_average"
+        )
+
+
+def test_new_packet_surface_does_not_import_legacy_or_runtime_paths() -> None:
+    """Acceptance 8 and legacy isolation are statically visible in CI."""
+
+    new_sources = (
+        REPO_ROOT / "research" / "kr_corpus" / "registry" / "exact_binding.py",
+        REPO_ROOT / "research" / "kr_corpus" / "backtest" / "packet_engine.py",
+    )
+    combined = "\n".join(source.read_text(encoding="utf-8") for source in new_sources)
+    assert "research.three_market_shadow" not in combined
+    assert ".stage_b" not in combined
+    assert "calculate_signal" not in combined
+    assert "sqlalchemy" not in combined
+    assert "taskiq" not in combined.casefold()
+
+
+def _dates40() -> dict[int, date]:
+    result: dict[int, date] = {}
+    index = 0
+    for year in range(2015, 2025):
+        for quarter in range(4):
+            result[index] = date(year, 3 + quarter, 1)
+            index += 1
+    return result
+
+
+def _entry_year_dates() -> dict[int, date]:
+    result = {0: date(2015, 12, 30)}
+    cursor = date(2016, 1, 4)
+    while len(result) < 31:
+        if cursor.weekday() < 5:
+            result[len(result)] = cursor
+        cursor += timedelta(days=7)
+    return result
+
+
+def _compose_case(
+    sessions: int,
+    per_counts: list[int],
+    excesses: list[float],
+    *,
+    include_exit_session: bool = False,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, float]]]:
+    trades: list[dict[str, Any]] = []
+    baselines: dict[str, dict[str, float]] = {}
+    for session in range(sessions):
+        for symbol_index in range(per_counts[session]):
+            symbol = f"{100 + symbol_index:06d}"
+            trade = {
+                "market": "KOSPI",
+                "symbol": symbol,
+                "entry_idx": session,
+                "gross": excesses[session] + COST_BASE,
+            }
+            if include_exit_session:
+                trade["exit_session"] = min(session + 1, sessions - 1)
+            trades.append(trade)
+            baselines[_baseline_key("KOSPI", symbol, session)] = {"gross_mean": 0.0}
+    return trades, baselines
+
+
+def _csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def statistics_median(values: Iterable[int]) -> float:
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    return (ordered[midpoint - 1] + ordered[midpoint]) / 2


### PR DESCRIPTION
## Summary
- Add a fail-closed registry that pins candidate, convention, generator, golden, base-fixture, and variant SHA-256 inputs.
- Add an isolated packet engine for the three KR candidates with PIT membership, per-market percentiles, bounded materialization, terminal/transfer handling, baseline, and verdict composition.
- Add self-contained v5 fixture generation plus mutation, tamper, access-spy, and 10-variant CI coverage.

## Verification
- KR-A0 targeted pytest: 10 passed.
- make lint: passed.
- Targeted ty check: passed.

## Scope
- Legacy stage_b.py and research/three_market_shadow remain unchanged.
- No corpus exploration/backtest run, broker/order/account/DB write, scheduler registration, or merge.