### PR TITLE
feat(research): add crypto Stage-B engine

### DIFF
--- a/research/crypto_stage_b/__init__.py
+++ b/research/crypto_stage_b/__init__.py
@@ -1,0 +1,21 @@
+"""Crypto Stage-B research engine, isolated from runtime and KR strategy code."""
+
+from .contracts import CryptoStageBRunContract, VenueCostLiteral
+from .engine import CandidatePairResult, run_candidate_pair, run_execution_arm
+from .registry import CandidateRegistry
+from .report import HarnessReport, build_harness_report
+from .source import DailyBar, InMemoryDailyBarSource, TerminalEvent
+
+__all__ = [
+    "CandidatePairResult",
+    "CandidateRegistry",
+    "CryptoStageBRunContract",
+    "DailyBar",
+    "HarnessReport",
+    "InMemoryDailyBarSource",
+    "TerminalEvent",
+    "VenueCostLiteral",
+    "build_harness_report",
+    "run_candidate_pair",
+    "run_execution_arm",
+]

--- a/research/crypto_stage_b/contracts.py
+++ b/research/crypto_stage_b/contracts.py
@@ -1,0 +1,160 @@
+"""Explicit, frozen run contracts for crypto Stage-B research.
+
+There are deliberately no implicit cost defaults.  A caller has to place the
+operator-frozen literals in every run contract, where they become part of the
+serialised configuration hash and the resulting evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Final
+
+from research.crypto_corpus.constants import EXPLORATION_END
+from research_contracts.canonical_hash import canonical_sha256
+
+from .registry import ADMITTED_STRATEGY_IDS, EXPECTED_RETURN_SHA256, CandidateDefinition
+
+__all__ = [
+    "CRYPTO_CORPUS_HOLDOUT_START",
+    "FROZEN_VENUE_COST_LITERALS",
+    "CryptoStageBRunContract",
+    "ExplorationWindowError",
+    "VenueCostLiteral",
+]
+
+
+CRYPTO_CORPUS_HOLDOUT_START: Final[date] = EXPLORATION_END.date()
+"""The first crypto-corpus holdout UTC calendar day; it is never readable."""
+
+FROZEN_VENUE_COST_LITERALS: Final[dict[str, dict[str, int]]] = {
+    "upbit_krw": {
+        "fee_bp_per_side": 5,
+        "slippage_bp_per_side": 10,
+        "sensitivity_slippage_bp_per_side": 30,
+    },
+    "binance_usdt_spot": {
+        "fee_bp_per_side": 10,
+        "slippage_bp_per_side": 10,
+        "sensitivity_slippage_bp_per_side": 30,
+    },
+}
+"""Validation-only copies of the operator-frozen, pre-result cost literals."""
+
+
+class ExplorationWindowError(ValueError):
+    """A caller attempted an invalid or holdout-intersecting research window."""
+
+
+@dataclass(frozen=True)
+class VenueCostLiteral:
+    """One explicitly supplied venue-specific base and sensitivity cost model."""
+
+    venue: str
+    fee_bp_per_side: int
+    slippage_bp_per_side: int
+    sensitivity_slippage_bp_per_side: int
+
+    def __post_init__(self) -> None:
+        expected = FROZEN_VENUE_COST_LITERALS.get(self.venue)
+        actual = {
+            "fee_bp_per_side": self.fee_bp_per_side,
+            "slippage_bp_per_side": self.slippage_bp_per_side,
+            "sensitivity_slippage_bp_per_side": self.sensitivity_slippage_bp_per_side,
+        }
+        if expected is None or actual != expected:
+            raise ValueError(
+                "cost literal must exactly match the operator-frozen venue profile; "
+                "the engine does not inject defaults"
+            )
+
+    @property
+    def round_trip_bp(self) -> int:
+        return 2 * (self.fee_bp_per_side + self.slippage_bp_per_side)
+
+    @property
+    def sensitivity_round_trip_bp(self) -> int:
+        return 2 * (self.fee_bp_per_side + self.sensitivity_slippage_bp_per_side)
+
+    def to_dict(self) -> dict[str, int | str]:
+        return {
+            "venue": self.venue,
+            "fee_bp_per_side": self.fee_bp_per_side,
+            "slippage_bp_per_side": self.slippage_bp_per_side,
+            "round_trip_bp": self.round_trip_bp,
+            "sensitivity_slippage_bp_per_side": self.sensitivity_slippage_bp_per_side,
+            "sensitivity_round_trip_bp": self.sensitivity_round_trip_bp,
+            "low_liquidity_break_even_round_trip_bp": self.round_trip_bp,
+        }
+
+
+@dataclass(frozen=True)
+class CryptoStageBRunContract:
+    """One candidate × venue × exploration-window execution contract.
+
+    The contract intentionally models one venue at a time.  This prevents a
+    KRW value from becoming comparable to a USDT value anywhere in selection or
+    accounting, and makes a venue-specific result the only possible output.
+    """
+
+    candidate: CandidateDefinition
+    venue: str
+    exploration_start: date
+    exploration_end: date
+    cost: VenueCostLiteral
+
+    def __post_init__(self) -> None:
+        if isinstance(self.exploration_start, datetime) or isinstance(
+            self.exploration_end, datetime
+        ):
+            raise ExplorationWindowError(
+                "exploration bounds must be UTC dates, not datetimes"
+            )
+        if self.exploration_start > self.exploration_end:
+            raise ExplorationWindowError("exploration_start is after exploration_end")
+        if self.exploration_end >= CRYPTO_CORPUS_HOLDOUT_START:
+            raise ExplorationWindowError(
+                "exploration window intersects crypto-corpus holdout; "
+                "holdout reads are forbidden"
+            )
+        if self.candidate.strategy_id not in ADMITTED_STRATEGY_IDS:
+            raise ValueError(
+                "only the three admitted candidates are executable; preserved "
+                "HTA-01 is not an implementation target"
+            )
+        if self.candidate.source_return_sha256 != EXPECTED_RETURN_SHA256:
+            raise ValueError("candidate is not bound to the frozen upstream return")
+        if self.candidate.venue_scope != "both":
+            raise ValueError(
+                "candidate venue scope is not the admitted both-venue scope"
+            )
+        if self.cost.venue != self.venue:
+            raise ValueError("run-contract cost venue does not match run venue")
+        if self.candidate.required_history_days <= 0:
+            raise ValueError("candidate required_history_days must be positive")
+
+    @property
+    def config_hash(self) -> str:
+        return canonical_sha256(self.to_dict())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "engine": "crypto-stage-b-v1",
+            "strategy_id": self.candidate.strategy_id,
+            "contract_hash": self.candidate.contract_hash,
+            "source_return_sha256": self.candidate.source_return_sha256,
+            "venue": self.venue,
+            "exploration_window": {
+                "start": self.exploration_start.isoformat(),
+                "end": self.exploration_end.isoformat(),
+            },
+            "entry_timing": "next_utc_calendar_day_open",
+            "exit_timing": f"entry_day_D_plus_{int(self.candidate.parameter('exit_D_plus_days'))}_utc_close",
+            "max_concurrent_positions_per_venue": int(
+                self.candidate.parameter("max_concurrent_positions_per_venue")
+            ),
+            "symbol_position_limit": 1,
+            "fixed_normalized_notional_unit": 1.0,
+            "cost_literal": self.cost.to_dict(),
+        }

--- a/research/crypto_stage_b/engine.py
+++ b/research/crypto_stage_b/engine.py
@@ -1,0 +1,665 @@
+"""Deterministic daily Stage-B execution engine for the admitted crypto pairs.
+
+This module is research-only.  It has no broker, account, database, scheduler,
+or corpus-write surface.  It performs a candidate's full rule and its
+pre-registered ablation through the same calendar-day execution implementation.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, replace
+from datetime import date, timedelta
+from statistics import fmean
+from typing import Literal
+
+from .contracts import CryptoStageBRunContract
+from .signals import Arm, SignalEvaluation, evaluate_signal
+from .source import BoundaryAccessSpy, CryptoStageBInputError, DailyBar, DailyBarSource
+
+__all__ = [
+    "CandidatePairResult",
+    "ExecutionArmResult",
+    "OutcomeStatus",
+    "TradeOutcome",
+    "run_candidate_pair",
+    "run_execution_arm",
+]
+
+
+OutcomeStatus = Literal[
+    "capacity_rejected",
+    "symbol_position_rejected",
+    "entry_no_fill",
+    "missing_exit",
+    "delisted_exit",
+    "completed",
+    "censored_before_entry_boundary",
+    "censored_at_exploration_boundary",
+]
+
+
+@dataclass(frozen=True)
+class TradeOutcome:
+    """A serialisable execution result for one raw signal after ranking."""
+
+    strategy_id: str
+    contract_hash: str
+    arm: Arm
+    venue: str
+    symbol: str
+    signal_session: date
+    entry_session: date | None
+    scheduled_exit_session: date | None
+    exit_session: date | None
+    status: OutcomeStatus
+    rank: int
+    entry_open: float | None
+    exit_close: float | None
+    gross_return: float | None
+    net_return: float | None
+    sensitivity_net_return: float | None
+    delisted_exit: bool
+    ranking_metrics: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "arm": self.arm,
+            "venue": self.venue,
+            "symbol": self.symbol,
+            "signal_session": self.signal_session.isoformat(),
+            "entry_session": _date_or_none(self.entry_session),
+            "scheduled_exit_session": _date_or_none(self.scheduled_exit_session),
+            "exit_session": _date_or_none(self.exit_session),
+            "status": self.status,
+            "rank": self.rank,
+            "entry_open": self.entry_open,
+            "exit_close": self.exit_close,
+            "gross_return": self.gross_return,
+            "net_return": self.net_return,
+            "sensitivity_net_return": self.sensitivity_net_return,
+            "delisted_exit": self.delisted_exit,
+            "ranking_metrics": dict(sorted(self.ranking_metrics.items())),
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionArmResult:
+    """One full or ablation arm, with enough trace data for an independent check."""
+
+    contract: CryptoStageBRunContract
+    arm: Arm
+    observations: tuple[SignalEvaluation, ...]
+    outcomes: tuple[TradeOutcome, ...]
+    access_summary: Mapping[str, int]
+
+    @property
+    def resolved_returns(self) -> tuple[float, ...]:
+        return tuple(
+            outcome.net_return
+            for outcome in self.outcomes
+            if outcome.net_return is not None
+        )
+
+    @property
+    def net_mean_return(self) -> float | None:
+        returns = self.resolved_returns
+        return fmean(returns) if returns else None
+
+    @property
+    def sensitivity_net_mean_return(self) -> float | None:
+        returns = tuple(
+            outcome.sensitivity_net_return
+            for outcome in self.outcomes
+            if outcome.sensitivity_net_return is not None
+        )
+        return fmean(returns) if returns else None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "engine": "crypto-stage-b-v1",
+            "strategy_id": self.contract.candidate.strategy_id,
+            "contract_hash": self.contract.candidate.contract_hash,
+            "config_hash": self.contract.config_hash,
+            "arm": self.arm,
+            "run_contract": self.contract.to_dict(),
+            "observations": [item.to_dict() for item in self.observations],
+            "outcomes": [item.to_dict() for item in self.outcomes],
+            "net_mean_return": self.net_mean_return,
+            "sensitivity_net_mean_return": self.sensitivity_net_mean_return,
+            "access_summary": dict(self.access_summary),
+            "orders": 0,
+            "account_mutations": 0,
+        }
+
+
+@dataclass(frozen=True)
+class CandidatePairResult:
+    """A candidate's full and ablation arms produced by the same engine."""
+
+    contract: CryptoStageBRunContract
+    full: ExecutionArmResult
+    ablation: ExecutionArmResult
+
+    @property
+    def incremental_net_mean_return(self) -> float | None:
+        if self.full.net_mean_return is None or self.ablation.net_mean_return is None:
+            return None
+        return self.full.net_mean_return - self.ablation.net_mean_return
+
+    @property
+    def incremental_state(self) -> str:
+        if self.incremental_net_mean_return is None:
+            return "INCONCLUSIVE_EMPTY_ARM"
+        if self.incremental_net_mean_return > 0.0:
+            return "FULL_EXCEEDS_ABLATION"
+        return "FULL_DOES_NOT_EXCEED_ABLATION"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "engine": "crypto-stage-b-v1",
+            "strategy_id": self.contract.candidate.strategy_id,
+            "contract_hash": self.contract.candidate.contract_hash,
+            "source_return_sha256": self.contract.candidate.source_return_sha256,
+            "venue": self.contract.venue,
+            "full": self.full.to_dict(),
+            "ablation": self.ablation.to_dict(),
+            "incremental": {
+                "net_mean_return": self.incremental_net_mean_return,
+                "state": self.incremental_state,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class _Reservation:
+    symbol: str
+    entry_session: date
+    occupied_through: date
+
+
+def run_candidate_pair(
+    *,
+    source: DailyBarSource,
+    contract: CryptoStageBRunContract,
+) -> CandidatePairResult:
+    """Run the full candidate and mandatory ablation with identical execution rules."""
+    full = run_execution_arm(source=source, contract=contract, arm="full")
+    ablation = run_execution_arm(source=source, contract=contract, arm="ablation")
+    return CandidatePairResult(contract=contract, full=full, ablation=ablation)
+
+
+def run_execution_arm(
+    *,
+    source: DailyBarSource,
+    contract: CryptoStageBRunContract,
+    arm: Arm,
+) -> ExecutionArmResult:
+    """Evaluate one arm without ever reading beyond the explicit UTC boundary."""
+    if arm not in {"full", "ablation"}:
+        raise ValueError(f"unsupported execution arm: {arm!r}")
+    spy = BoundaryAccessSpy(
+        source,
+        exploration_start=contract.exploration_start,
+        exploration_end=contract.exploration_end,
+    )
+    observations: list[SignalEvaluation] = []
+    signals_by_session: dict[date, list[SignalEvaluation]] = defaultdict(list)
+    symbols = spy.symbols(contract.venue)
+
+    for session in _date_range(contract.exploration_start, contract.exploration_end):
+        for symbol in symbols:
+            observation = _evaluate_symbol_day(
+                spy=spy,
+                contract=contract,
+                symbol=symbol,
+                signal_session=session,
+                arm=arm,
+            )
+            observations.append(observation)
+            if observation.signal:
+                signals_by_session[session].append(observation)
+
+    reservations: list[_Reservation] = []
+    outcomes: list[TradeOutcome] = []
+    max_positions = int(
+        contract.candidate.parameter("max_concurrent_positions_per_venue")
+    )
+    if max_positions != 5:
+        raise ValueError("candidate contract drifted from venue maximum of five")
+
+    for signal_session in sorted(signals_by_session):
+        ranked = sorted(signals_by_session[signal_session], key=_ranking_key)
+        entry_session = signal_session + timedelta(days=1)
+        if entry_session > contract.exploration_end:
+            outcomes.extend(
+                _boundary_censored_outcome(observation, rank=index)
+                for index, observation in enumerate(ranked, start=1)
+            )
+            continue
+
+        active = tuple(
+            reservation
+            for reservation in reservations
+            if _active_on(reservation, entry_session)
+        )
+        active_symbols = {reservation.symbol for reservation in active}
+        available_slots = max_positions - len(active)
+        if available_slots < 0:  # pragma: no cover - invariant guard
+            raise RuntimeError("venue position cap invariant violated")
+        selected = 0
+        for rank, observation in enumerate(ranked, start=1):
+            if observation.symbol in active_symbols:
+                outcomes.append(
+                    _unfilled_outcome(
+                        observation,
+                        status="symbol_position_rejected",
+                        rank=rank,
+                        entry_session=entry_session,
+                    )
+                )
+                continue
+            if selected >= available_slots:
+                outcomes.append(
+                    _unfilled_outcome(
+                        observation,
+                        status="capacity_rejected",
+                        rank=rank,
+                        entry_session=entry_session,
+                    )
+                )
+                continue
+            selected += 1
+            outcome, reservation = _execute_selected_signal(
+                spy=spy,
+                contract=contract,
+                observation=observation,
+                rank=rank,
+            )
+            outcomes.append(outcome)
+            if reservation is not None:
+                reservations.append(reservation)
+                active_symbols.add(reservation.symbol)
+
+    spy.assert_no_outside_access()
+    return ExecutionArmResult(
+        contract=contract,
+        arm=arm,
+        observations=tuple(observations),
+        outcomes=tuple(outcomes),
+        access_summary=spy.summary(),
+    )
+
+
+def _evaluate_symbol_day(
+    *,
+    spy: BoundaryAccessSpy,
+    contract: CryptoStageBRunContract,
+    symbol: str,
+    signal_session: date,
+    arm: Arm,
+) -> SignalEvaluation:
+    history_start = signal_session - timedelta(
+        days=contract.candidate.required_history_days - 1
+    )
+    if history_start < contract.exploration_start:
+        return SignalEvaluation(
+            strategy_id=contract.candidate.strategy_id,
+            contract_hash=contract.candidate.contract_hash,
+            arm=arm,
+            venue=contract.venue,
+            symbol=symbol,
+            signal_session=signal_session,
+            eligible=False,
+            signal=False,
+            exclusion_reason="history_before_exploration_boundary",
+            stages={},
+            metrics={},
+        )
+    history = tuple(
+        _read_expected_bar(spy, contract.venue, symbol, session)
+        for session in _date_range(history_start, signal_session)
+    )
+    evaluated = evaluate_signal(contract.candidate, history, arm=arm)
+    # A missing final bar has no identity inside the signal helper.  The
+    # engine restores the requested symbol-day so exclusions remain auditable.
+    return replace(
+        evaluated,
+        venue=contract.venue,
+        symbol=symbol,
+        signal_session=signal_session,
+    )
+
+
+def _read_expected_bar(
+    spy: BoundaryAccessSpy, venue: str, symbol: str, session: date
+) -> DailyBar | None:
+    bar = spy.get(venue, symbol, session)
+    if bar is None:
+        return None
+    if (bar.venue, bar.symbol, bar.session) != (venue, symbol, session):
+        raise CryptoStageBInputError(
+            "daily source returned a bar that does not match its point-read key"
+        )
+    return bar
+
+
+def _execute_selected_signal(
+    *,
+    spy: BoundaryAccessSpy,
+    contract: CryptoStageBRunContract,
+    observation: SignalEvaluation,
+    rank: int,
+) -> tuple[TradeOutcome, _Reservation | None]:
+    entry_session = observation.signal_session + timedelta(days=1)
+    entry_bar = _read_expected_bar(
+        spy, contract.venue, observation.symbol, entry_session
+    )
+    if entry_bar is None or not _finite_positive(entry_bar.open):
+        return (
+            _unfilled_outcome(
+                observation,
+                status="entry_no_fill",
+                rank=rank,
+                entry_session=entry_session,
+            ),
+            None,
+        )
+
+    exit_days = int(contract.candidate.parameter("exit_D_plus_days"))
+    if exit_days < 0:
+        raise ValueError("exit_D_plus_days must be non-negative")
+    scheduled_exit = entry_session + timedelta(days=exit_days)
+    if scheduled_exit > contract.exploration_end:
+        outcome = TradeOutcome(
+            **_outcome_identity(observation),
+            entry_session=entry_session,
+            scheduled_exit_session=scheduled_exit,
+            exit_session=None,
+            status="censored_at_exploration_boundary",
+            rank=rank,
+            entry_open=entry_bar.open,
+            exit_close=None,
+            gross_return=None,
+            net_return=None,
+            sensitivity_net_return=None,
+            delisted_exit=False,
+            ranking_metrics=_ranking_metrics(observation),
+        )
+        return outcome, _Reservation(
+            symbol=observation.symbol,
+            entry_session=entry_session,
+            occupied_through=contract.exploration_end,
+        )
+
+    exit_bar = _read_expected_bar(
+        spy, contract.venue, observation.symbol, scheduled_exit
+    )
+    if exit_bar is not None and _finite_positive(exit_bar.close):
+        gross = exit_bar.close / entry_bar.open - 1.0
+        outcome = _resolved_outcome(
+            observation,
+            rank=rank,
+            entry_session=entry_session,
+            scheduled_exit=scheduled_exit,
+            exit_session=scheduled_exit,
+            status="completed",
+            entry_open=entry_bar.open,
+            exit_close=exit_bar.close,
+            gross_return=gross,
+            cost_round_trip_bp=contract.cost.round_trip_bp,
+            sensitivity_cost_round_trip_bp=contract.cost.sensitivity_round_trip_bp,
+            delisted_exit=False,
+        )
+        return outcome, _Reservation(
+            symbol=observation.symbol,
+            entry_session=entry_session,
+            occupied_through=scheduled_exit,
+        )
+
+    event = _first_delisted_event(
+        spy=spy,
+        venue=contract.venue,
+        symbol=observation.symbol,
+        start=entry_session,
+        end=scheduled_exit,
+    )
+    if event is not None:
+        last_close = _last_valid_close(
+            spy=spy,
+            venue=contract.venue,
+            symbol=observation.symbol,
+            start=contract.exploration_start,
+            end=event,
+        )
+        gross = -1.0 if last_close is None else last_close / entry_bar.open - 1.0
+        outcome = _resolved_outcome(
+            observation,
+            rank=rank,
+            entry_session=entry_session,
+            scheduled_exit=scheduled_exit,
+            exit_session=event,
+            status="delisted_exit",
+            entry_open=entry_bar.open,
+            exit_close=last_close,
+            gross_return=gross,
+            cost_round_trip_bp=contract.cost.round_trip_bp,
+            sensitivity_cost_round_trip_bp=contract.cost.sensitivity_round_trip_bp,
+            delisted_exit=True,
+        )
+        return outcome, _Reservation(
+            symbol=observation.symbol,
+            entry_session=entry_session,
+            occupied_through=event,
+        )
+
+    return (
+        TradeOutcome(
+            **_outcome_identity(observation),
+            entry_session=entry_session,
+            scheduled_exit_session=scheduled_exit,
+            exit_session=None,
+            status="missing_exit",
+            rank=rank,
+            entry_open=entry_bar.open,
+            exit_close=None,
+            gross_return=None,
+            net_return=None,
+            sensitivity_net_return=None,
+            delisted_exit=False,
+            ranking_metrics=_ranking_metrics(observation),
+        ),
+        _Reservation(
+            symbol=observation.symbol,
+            entry_session=entry_session,
+            occupied_through=scheduled_exit,
+        ),
+    )
+
+
+def _first_delisted_event(
+    *,
+    spy: BoundaryAccessSpy,
+    venue: str,
+    symbol: str,
+    start: date,
+    end: date,
+) -> date | None:
+    for session in _date_range(start, end):
+        event = spy.terminal_event(venue, symbol, session)
+        if event is not None:
+            if event.event_type != "delisted":  # pragma: no cover - source invariant
+                raise CryptoStageBInputError(
+                    "terminal event is not an explicit delisting"
+                )
+            return event.session
+    return None
+
+
+def _last_valid_close(
+    *,
+    spy: BoundaryAccessSpy,
+    venue: str,
+    symbol: str,
+    start: date,
+    end: date,
+) -> float | None:
+    last_close: float | None = None
+    for session in _date_range(start, end):
+        bar = _read_expected_bar(spy, venue, symbol, session)
+        if bar is not None and _finite_positive(bar.close):
+            last_close = bar.close
+    return last_close
+
+
+def _resolved_outcome(
+    observation: SignalEvaluation,
+    *,
+    rank: int,
+    entry_session: date,
+    scheduled_exit: date,
+    exit_session: date,
+    status: Literal["completed", "delisted_exit"],
+    entry_open: float,
+    exit_close: float | None,
+    gross_return: float,
+    cost_round_trip_bp: int,
+    sensitivity_cost_round_trip_bp: int,
+    delisted_exit: bool,
+) -> TradeOutcome:
+    return TradeOutcome(
+        **_outcome_identity(observation),
+        entry_session=entry_session,
+        scheduled_exit_session=scheduled_exit,
+        exit_session=exit_session,
+        status=status,
+        rank=rank,
+        entry_open=entry_open,
+        exit_close=exit_close,
+        gross_return=gross_return,
+        net_return=gross_return - cost_round_trip_bp / 10_000.0,
+        sensitivity_net_return=(
+            gross_return - sensitivity_cost_round_trip_bp / 10_000.0
+        ),
+        delisted_exit=delisted_exit,
+        ranking_metrics=_ranking_metrics(observation),
+    )
+
+
+def _unfilled_outcome(
+    observation: SignalEvaluation,
+    *,
+    status: Literal["capacity_rejected", "symbol_position_rejected", "entry_no_fill"],
+    rank: int,
+    entry_session: date,
+) -> TradeOutcome:
+    return TradeOutcome(
+        **_outcome_identity(observation),
+        entry_session=entry_session,
+        scheduled_exit_session=None,
+        exit_session=None,
+        status=status,
+        rank=rank,
+        entry_open=None,
+        exit_close=None,
+        gross_return=None,
+        net_return=None,
+        sensitivity_net_return=None,
+        delisted_exit=False,
+        ranking_metrics=_ranking_metrics(observation),
+    )
+
+
+def _boundary_censored_outcome(
+    observation: SignalEvaluation, *, rank: int
+) -> TradeOutcome:
+    return TradeOutcome(
+        **_outcome_identity(observation),
+        entry_session=None,
+        scheduled_exit_session=None,
+        exit_session=None,
+        status="censored_before_entry_boundary",
+        rank=rank,
+        entry_open=None,
+        exit_close=None,
+        gross_return=None,
+        net_return=None,
+        sensitivity_net_return=None,
+        delisted_exit=False,
+        ranking_metrics=_ranking_metrics(observation),
+    )
+
+
+def _outcome_identity(observation: SignalEvaluation) -> dict[str, object]:
+    return {
+        "strategy_id": observation.strategy_id,
+        "contract_hash": observation.contract_hash,
+        "arm": observation.arm,
+        "venue": observation.venue,
+        "symbol": observation.symbol,
+        "signal_session": observation.signal_session,
+    }
+
+
+def _ranking_metrics(observation: SignalEvaluation) -> dict[str, float]:
+    return dict(sorted(observation.metrics.items()))
+
+
+def _ranking_key(observation: SignalEvaluation) -> tuple[float | str, ...]:
+    """Apply the source candidate's ranking only after local eligibility/signal."""
+
+    def metric(name: str) -> float:
+        return _ranking_value(observation.metrics.get(name))
+
+    strategy_id = observation.strategy_id
+    if strategy_id == "CR-SPOT-ETR-01":
+        return (
+            -metric("qv_ratio"),
+            -metric("clv"),
+            -metric("tail_severity"),
+            observation.symbol,
+        )
+    if strategy_id == "CR-SPOT-TPR-01":
+        return (
+            -metric("pullback_extension"),
+            -metric("trend_slope"),
+            -metric("qv_ratio"),
+            observation.symbol,
+        )
+    if strategy_id == "CR-SPOT-CEB-01":
+        return (
+            -metric("qv_ratio"),
+            -metric("range_ratio"),
+            -metric("breakout_extension"),
+            observation.symbol,
+        )
+    raise ValueError(f"no ranking implementation for {strategy_id!r}")
+
+
+def _ranking_value(value: float | None) -> float:
+    """Missing ablation-only ranking inputs sort last without changing eligibility."""
+    return value if value is not None and math.isfinite(value) else -math.inf
+
+
+def _active_on(reservation: _Reservation, entry_session: date) -> bool:
+    """An exit-at-close position occupies its slot through that UTC calendar day."""
+    return reservation.entry_session <= entry_session <= reservation.occupied_through
+
+
+def _finite_positive(value: float) -> bool:
+    return math.isfinite(value) and value > 0.0
+
+
+def _date_range(start: date, end: date) -> Iterable[date]:
+    current = start
+    while current <= end:
+        yield current
+        current += timedelta(days=1)
+
+
+def _date_or_none(value: date | None) -> str | None:
+    return value.isoformat() if value is not None else None

--- a/research/crypto_stage_b/registry.py
+++ b/research/crypto_stage_b/registry.py
@@ -1,0 +1,292 @@
+"""Verbatim-bound registry for the admitted crypto Stage-B candidates.
+
+The upstream return is intentionally Markdown, not a hand-maintained Python
+configuration.  This registry reads that exact file, verifies its frozen
+SHA-256 first, and derives each candidate contract from the raw candidate
+block.  Numerical strategy parameters are therefore never copied into this
+module as a second source of truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+
+__all__ = [
+    "ADMITTED_STRATEGY_IDS",
+    "EXPECTED_RETURN_SHA256",
+    "CandidateDefinition",
+    "CandidateParseError",
+    "CandidateRegistry",
+]
+
+
+EXPECTED_RETURN_SHA256 = (
+    "59050a15cc89aa1cbaa680471707d0d09d2908c69e982769eaeb7112fdacdcbf"
+)
+"""Frozen SHA-256 of ``gptpro-crypto-candidates-v1.md``."""
+
+ADMITTED_STRATEGY_IDS = (
+    "CR-SPOT-ETR-01",
+    "CR-SPOT-TPR-01",
+    "CR-SPOT-CEB-01",
+)
+"""The three operator-admitted candidates; HTA-01 remains preserved only."""
+
+_PRESERVED_NOT_IMPLEMENTED_ID = "CR-SPOT-HTA-01"
+_CANDIDATE_START = re.compile(r"(?m)^- strategy_id: (?P<strategy_id>[^\r\n]+)$")
+_TOP_LEVEL_FIELD = re.compile(r"(?m)^  [A-Za-z_][A-Za-z0-9_]*:")
+_PARAMETER_LINE = re.compile(
+    r"\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*): (?P<value>[^\r\n]+)\Z"
+)
+_REQUIRED_HISTORY_DAYS = re.compile(r"(?P<days>\d+)개의")
+_INTEGER = re.compile(r"-?(?:0|[1-9]\d*)\Z")
+_DECIMAL = re.compile(r"-?(?:0|[1-9]\d*)\.\d+\Z")
+
+
+class CandidateParseError(ValueError):
+    """The sealed return cannot be used as an unambiguous strategy contract."""
+
+
+@dataclass(frozen=True)
+class CandidateDefinition:
+    """A candidate contract parsed directly from one raw Markdown block."""
+
+    strategy_id: str
+    family_id: str
+    venue_scope: str
+    required_history_days: int
+    parameter_values: Mapping[str, int | float]
+    signal_text: str
+    entry_text: str
+    exit_text: str
+    ranking_text: str
+    sizing_text: str
+    ablation_text: str
+    harness_query_text: str
+    raw_contract_text: str
+    source_return_sha256: str
+    contract_hash: str
+
+    def parameter(self, name: str) -> int | float:
+        """Return one source-derived parameter or fail closed on contract drift."""
+        try:
+            return self.parameter_values[name]
+        except KeyError as exc:
+            raise CandidateParseError(
+                f"{self.strategy_id}: source contract lacks parameter {name!r}"
+            ) from exc
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe, provenance-stamped contract representation."""
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "source_return_sha256": self.source_return_sha256,
+            "family_id": self.family_id,
+            "venue_scope": self.venue_scope,
+            "required_history_days": self.required_history_days,
+            "parameter_values": dict(self.parameter_values),
+            "signal_text": self.signal_text,
+            "entry_text": self.entry_text,
+            "exit_text": self.exit_text,
+            "ranking_text": self.ranking_text,
+            "sizing_text": self.sizing_text,
+            "ablation_text": self.ablation_text,
+            "harness_query_text": self.harness_query_text,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateRegistry:
+    """A SHA-bound, source-parsed registry with no formula transcription path."""
+
+    source_return_sha256: str
+    definitions: tuple[CandidateDefinition, ...]
+
+    @classmethod
+    def load(
+        cls,
+        source_path: str | Path,
+        *,
+        expected_return_sha256: str = EXPECTED_RETURN_SHA256,
+    ) -> CandidateRegistry:
+        """Read and verify a verbatim upstream return before parsing it."""
+        path = Path(source_path)
+        try:
+            source_bytes = path.read_bytes()
+        except OSError as exc:
+            raise CandidateParseError(
+                f"cannot read verbatim candidate return: {path}"
+            ) from exc
+        return cls.from_verbatim_bytes(
+            source_bytes,
+            expected_return_sha256=expected_return_sha256,
+        )
+
+    @classmethod
+    def from_verbatim_bytes(
+        cls,
+        source_bytes: bytes,
+        *,
+        expected_return_sha256: str,
+    ) -> CandidateRegistry:
+        """Parse bytes only after their exact SHA-256 matches the caller's seal."""
+        actual_sha256 = hashlib.sha256(source_bytes).hexdigest()
+        if actual_sha256 != expected_return_sha256:
+            raise CandidateParseError(
+                "candidate return SHA-256 mismatch: "
+                f"expected={expected_return_sha256} actual={actual_sha256}"
+            )
+        try:
+            source_text = source_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CandidateParseError("candidate return is not UTF-8") from exc
+
+        blocks = _candidate_blocks(source_text)
+        definitions = tuple(
+            _parse_candidate_block(block, source_return_sha256=actual_sha256)
+            for block in blocks
+        )
+        _validate_admission(definitions)
+        return cls(source_return_sha256=actual_sha256, definitions=definitions)
+
+    @property
+    def admitted(self) -> tuple[CandidateDefinition, ...]:
+        """Return only the three approved candidates in operator-specified order."""
+        by_id = {definition.strategy_id: definition for definition in self.definitions}
+        return tuple(by_id[strategy_id] for strategy_id in ADMITTED_STRATEGY_IDS)
+
+    @property
+    def preserved_not_implemented(self) -> CandidateDefinition:
+        """Expose HTA-01 for provenance without making it executable."""
+        for definition in self.definitions:
+            if definition.strategy_id == _PRESERVED_NOT_IMPLEMENTED_ID:
+                return definition
+        raise CandidateParseError("preserved HTA-01 candidate is absent from return")
+
+    def get(self, strategy_id: str) -> CandidateDefinition:
+        """Look up one parsed candidate without silently falling back by family."""
+        for definition in self.definitions:
+            if definition.strategy_id == strategy_id:
+                return definition
+        raise CandidateParseError(f"unknown parsed candidate: {strategy_id!r}")
+
+
+def _candidate_blocks(source_text: str) -> tuple[str, ...]:
+    matches = tuple(_CANDIDATE_START.finditer(source_text))
+    if not matches:
+        raise CandidateParseError("candidate return contains no strategy blocks")
+
+    blocks: list[str] = []
+    for index, match in enumerate(matches):
+        start = match.start()
+        if index + 1 < len(matches):
+            end = matches[index + 1].start()
+        else:
+            boundary = source_text.find("\n요구 산출물 2", start)
+            end = len(source_text) if boundary < 0 else boundary + 1
+        blocks.append(source_text[start:end])
+    return tuple(blocks)
+
+
+def _field(block: str, name: str) -> str:
+    match = re.search(rf"(?m)^  {re.escape(name)}:\s*(?P<first>[^\r\n]*)$", block)
+    if match is None:
+        raise CandidateParseError(f"candidate block lacks required field {name!r}")
+    remainder = block[match.end() :]
+    next_field = _TOP_LEVEL_FIELD.search(remainder)
+    continuation = (
+        remainder[: next_field.start()] if next_field is not None else remainder
+    )
+    first = match.group("first")
+    if first in {">", "|"}:
+        lines = continuation.splitlines()
+        normalized = [line[4:] if line.startswith("    ") else line for line in lines]
+        value = "\n".join(normalized).strip()
+    elif continuation.strip():
+        value = (first + continuation).strip()
+    else:
+        value = first.strip()
+    if not value:
+        raise CandidateParseError(f"candidate field {name!r} is empty")
+    return value
+
+
+def _parse_number(raw: str, *, field: str) -> int | float:
+    text = raw.strip()
+    if _INTEGER.fullmatch(text) is not None:
+        return int(text)
+    if _DECIMAL.fullmatch(text) is not None:
+        return float(text)
+    raise CandidateParseError(f"parameter {field!r} is not a plain numeric literal")
+
+
+def _parameter_values(block: str) -> Mapping[str, int | float]:
+    parameter_section = _field(block, "parameter_values")
+    values: dict[str, int | float] = {}
+    for line in parameter_section.splitlines():
+        match = _PARAMETER_LINE.fullmatch(line)
+        if match is None:
+            raise CandidateParseError(
+                f"candidate parameter_values has malformed row: {line!r}"
+            )
+        name = match.group("name")
+        if name in values:
+            raise CandidateParseError(f"duplicate candidate parameter {name!r}")
+        values[name] = _parse_number(match.group("value"), field=name)
+    if not values:
+        raise CandidateParseError("candidate parameter_values has no numeric rows")
+    return MappingProxyType(values)
+
+
+def _parse_candidate_block(
+    block: str,
+    *,
+    source_return_sha256: str,
+) -> CandidateDefinition:
+    strategy_match = _CANDIDATE_START.match(block)
+    if strategy_match is None:  # pragma: no cover - guarded by _candidate_blocks
+        raise CandidateParseError("candidate block has no strategy_id header")
+    strategy_id = strategy_match.group("strategy_id").strip()
+    required_history = _field(block, "required_history")
+    history_match = _REQUIRED_HISTORY_DAYS.search(required_history)
+    if history_match is None:
+        raise CandidateParseError(
+            f"{strategy_id}: required_history does not declare a day count"
+        )
+    raw_contract_bytes = block.encode("utf-8")
+    return CandidateDefinition(
+        strategy_id=strategy_id,
+        family_id=_field(block, "family_id"),
+        venue_scope=_field(block, "venue_scope"),
+        required_history_days=int(history_match.group("days")),
+        parameter_values=_parameter_values(block),
+        signal_text=_field(block, "signal"),
+        entry_text=_field(block, "entry"),
+        exit_text=_field(block, "exit"),
+        ranking_text=_field(block, "ranking"),
+        sizing_text=_field(block, "sizing"),
+        ablation_text=_field(block, "falsification"),
+        harness_query_text=_field(block, "expected_trade_frequency"),
+        raw_contract_text=block,
+        source_return_sha256=source_return_sha256,
+        contract_hash=hashlib.sha256(raw_contract_bytes).hexdigest(),
+    )
+
+
+def _validate_admission(definitions: tuple[CandidateDefinition, ...]) -> None:
+    ids = tuple(definition.strategy_id for definition in definitions)
+    if len(set(ids)) != len(ids):
+        raise CandidateParseError("candidate return has duplicate strategy_id values")
+    missing = set(ADMITTED_STRATEGY_IDS) - set(ids)
+    if missing:
+        raise CandidateParseError(
+            f"candidate return is missing admitted strategies: {sorted(missing)!r}"
+        )
+    if _PRESERVED_NOT_IMPLEMENTED_ID not in ids:
+        raise CandidateParseError("candidate return is missing preserved HTA-01")

--- a/research/crypto_stage_b/report.py
+++ b/research/crypto_stage_b/report.py
@@ -1,0 +1,245 @@
+"""Venue × UTC-calendar-year HARNESS_QUERY evidence for Stage-B pair results."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from statistics import fmean
+from typing import Any
+
+from .engine import CandidatePairResult, ExecutionArmResult
+
+__all__ = ["HarnessReport", "VenueYearRecord", "build_harness_report"]
+
+
+@dataclass(frozen=True)
+class VenueYearRecord:
+    """One non-aggregated venue × signal-UTC-year evidence row."""
+
+    strategy_id: str
+    contract_hash: str
+    venue: str
+    calendar_year: int
+    full: dict[str, Any]
+    ablation: dict[str, Any]
+    incremental: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "venue": self.venue,
+            "calendar_year": self.calendar_year,
+            "full": self.full,
+            "ablation": self.ablation,
+            "incremental": self.incremental,
+        }
+
+
+@dataclass(frozen=True)
+class HarnessReport:
+    """The required decomposition; it deliberately has no all-years aggregate."""
+
+    strategy_id: str
+    contract_hash: str
+    venue: str
+    source_return_sha256: str
+    records: tuple[VenueYearRecord, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "engine": "crypto-stage-b-v1",
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "source_return_sha256": self.source_return_sha256,
+            "venue": self.venue,
+            "calendar_year_basis": "signal_session_utc_year",
+            "query_schema": "strategy_id_x_venue_x_calendar_year",
+            "records": [record.to_dict() for record in self.records],
+        }
+
+
+def build_harness_report(pair: CandidatePairResult) -> HarnessReport:
+    """Build every requested count per venue and calendar year, never all-years."""
+    contract = pair.contract
+    if pair.full.contract != contract or pair.ablation.contract != contract:
+        raise ValueError("full and ablation results must share one exact run contract")
+    years = sorted(
+        {
+            observation.signal_session.year
+            for arm in (pair.full, pair.ablation)
+            for observation in arm.observations
+        }
+    )
+    records = tuple(
+        VenueYearRecord(
+            strategy_id=contract.candidate.strategy_id,
+            contract_hash=contract.candidate.contract_hash,
+            venue=contract.venue,
+            calendar_year=year,
+            full=_arm_year_metrics(pair.full, year),
+            ablation=_arm_year_metrics(pair.ablation, year),
+            incremental=_incremental_year_metrics(pair.full, pair.ablation, year),
+        )
+        for year in years
+    )
+    return HarnessReport(
+        strategy_id=contract.candidate.strategy_id,
+        contract_hash=contract.candidate.contract_hash,
+        venue=contract.venue,
+        source_return_sha256=contract.candidate.source_return_sha256,
+        records=records,
+    )
+
+
+def _arm_year_metrics(arm: ExecutionArmResult, year: int) -> dict[str, Any]:
+    observations = tuple(
+        item for item in arm.observations if item.signal_session.year == year
+    )
+    outcomes = tuple(item for item in arm.outcomes if item.signal_session.year == year)
+    outcomes_by_status = Counter(item.status for item in outcomes)
+    filled = tuple(item for item in outcomes if item.entry_open is not None)
+    resolved = tuple(item for item in outcomes if item.net_return is not None)
+    symbols = Counter(item.symbol for item in filled)
+    symbol_trade_counts = dict(sorted(symbols.items()))
+    max_symbol_share = max(symbols.values()) / len(filled) if filled else None
+    generic = {
+        "strategy_id": arm.contract.candidate.strategy_id,
+        "contract_hash": arm.contract.candidate.contract_hash,
+        "venue": arm.contract.venue,
+        "calendar_year": year,
+        "eligible_symbol_days": sum(item.eligible for item in observations),
+        "signal_count": sum(item.signal for item in observations),
+        "next_day_open_fill_count": len(filled),
+        "completed_exit_count": outcomes_by_status["completed"],
+        "missing_history_exclusion_count": sum(
+            _is_missing_history_exclusion(item.exclusion_reason)
+            for item in observations
+        ),
+        "entry_no_fill_count": outcomes_by_status["entry_no_fill"],
+        "missing_exit_count": outcomes_by_status["missing_exit"],
+        "delisted_exit_count": outcomes_by_status["delisted_exit"],
+        "capacity_rejected_count": outcomes_by_status["capacity_rejected"],
+        "symbol_position_rejected_count": outcomes_by_status[
+            "symbol_position_rejected"
+        ],
+        "censored_before_entry_boundary_count": outcomes_by_status[
+            "censored_before_entry_boundary"
+        ],
+        "censored_at_exploration_boundary_count": outcomes_by_status[
+            "censored_at_exploration_boundary"
+        ],
+        "distinct_traded_symbols": len(symbols),
+        "symbol_trade_counts": symbol_trade_counts,
+        "max_symbol_trade_share": max_symbol_share,
+        "gross_mean_return": _mean_or_none(item.gross_return for item in resolved),
+        "net_mean_return": _mean_or_none(item.net_return for item in resolved),
+        "sensitivity_net_mean_return": _mean_or_none(
+            item.sensitivity_net_return for item in resolved
+        ),
+        "resolved_exit_count": len(resolved),
+        "fixed_normalized_notional_unit": 1.0,
+        "cost_literal": arm.contract.cost.to_dict(),
+        "low_liquidity_break_even_round_trip_bp": arm.contract.cost.round_trip_bp,
+        "sensitivity_break_even_round_trip_bp": arm.contract.cost.sensitivity_round_trip_bp,
+    }
+    strategy_id = arm.contract.candidate.strategy_id
+    if strategy_id == "CR-SPOT-ETR-01":
+        return generic
+    if strategy_id == "CR-SPOT-TPR-01":
+        return {
+            **generic,
+            "trend_state_days": _stage_count(observations, "trend_state"),
+            "pullback_setup_days": _stage_count(observations, "pullback_setup"),
+            "final_signal_count": generic["signal_count"],
+        }
+    if strategy_id == "CR-SPOT-CEB-01":
+        return {
+            **generic,
+            "complete_history_days": sum(item.eligible for item in observations),
+            "compression_state_days": _stage_count(observations, "compression_state"),
+            "raw_20d_breakout_days": _stage_count(observations, "raw_20d_breakout"),
+            "full_signal_count": generic["signal_count"],
+            "fill_count": len(filled),
+            "distinct_symbols": len(symbols),
+        }
+    raise ValueError(f"unsupported harness strategy: {strategy_id!r}")
+
+
+def _incremental_year_metrics(
+    full: ExecutionArmResult, ablation: ExecutionArmResult, year: int
+) -> dict[str, Any]:
+    full_returns = _resolved_returns_for_year(full, year)
+    ablation_returns = _resolved_returns_for_year(ablation, year)
+    full_sensitivity_returns = _resolved_sensitivity_returns_for_year(full, year)
+    ablation_sensitivity_returns = _resolved_sensitivity_returns_for_year(
+        ablation, year
+    )
+    full_mean = _mean_or_none(full_returns)
+    ablation_mean = _mean_or_none(ablation_returns)
+    full_sensitivity_mean = _mean_or_none(full_sensitivity_returns)
+    ablation_sensitivity_mean = _mean_or_none(ablation_sensitivity_returns)
+    delta = (
+        None
+        if full_mean is None or ablation_mean is None
+        else full_mean - ablation_mean
+    )
+    return {
+        "strategy_id": full.contract.candidate.strategy_id,
+        "contract_hash": full.contract.candidate.contract_hash,
+        "venue": full.contract.venue,
+        "calendar_year": year,
+        "full_net_mean_return": full_mean,
+        "ablation_net_mean_return": ablation_mean,
+        "full_minus_ablation_net_mean_return": delta,
+        "full_sensitivity_net_mean_return": full_sensitivity_mean,
+        "ablation_sensitivity_net_mean_return": ablation_sensitivity_mean,
+        "full_minus_ablation_sensitivity_net_mean_return": (
+            None
+            if full_sensitivity_mean is None or ablation_sensitivity_mean is None
+            else full_sensitivity_mean - ablation_sensitivity_mean
+        ),
+        "incremental_state": (
+            "INCONCLUSIVE_EMPTY_ARM"
+            if delta is None
+            else "FULL_EXCEEDS_ABLATION"
+            if delta > 0.0
+            else "FULL_DOES_NOT_EXCEED_ABLATION"
+        ),
+    }
+
+
+def _resolved_returns_for_year(arm: ExecutionArmResult, year: int) -> tuple[float, ...]:
+    return tuple(
+        item.net_return
+        for item in arm.outcomes
+        if item.signal_session.year == year and item.net_return is not None
+    )
+
+
+def _resolved_sensitivity_returns_for_year(
+    arm: ExecutionArmResult, year: int
+) -> tuple[float, ...]:
+    return tuple(
+        item.sensitivity_net_return
+        for item in arm.outcomes
+        if item.signal_session.year == year and item.sensitivity_net_return is not None
+    )
+
+
+def _mean_or_none(values: Any) -> float | None:
+    materialized = tuple(value for value in values if value is not None)
+    return fmean(materialized) if materialized else None
+
+
+def _stage_count(observations: tuple[Any, ...], name: str) -> int:
+    return sum(item.stages.get(name, False) for item in observations)
+
+
+def _is_missing_history_exclusion(reason: str | None) -> bool:
+    return reason in {
+        "missing_required_history",
+        "non_contiguous_required_history",
+        "invalid_required_close_history",
+        "invalid_required_price_history",
+    }

--- a/research/crypto_stage_b/signals.py
+++ b/research/crypto_stage_b/signals.py
@@ -1,0 +1,716 @@
+"""Exact candidate signal and pre-registered ablation evaluation.
+
+Each implementation receives a source-parsed :class:`CandidateDefinition`.
+The formulas name their upstream parameters by key; their numerical values are
+read from the verbatim registry rather than transcribed into Python constants.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from types import MappingProxyType
+from typing import Literal
+
+from .registry import CandidateDefinition, CandidateParseError
+from .source import DailyBar
+
+__all__ = [
+    "Arm",
+    "SignalEvaluation",
+    "evaluate_signal",
+    "nearest_rank_quantile",
+]
+
+
+Arm = Literal["full", "ablation"]
+
+
+@dataclass(frozen=True)
+class SignalEvaluation:
+    """One symbol-day evaluation, including serialisable intermediate stages."""
+
+    strategy_id: str
+    contract_hash: str
+    arm: Arm
+    venue: str
+    symbol: str
+    signal_session: date
+    eligible: bool
+    signal: bool
+    exclusion_reason: str | None
+    stages: Mapping[str, bool]
+    metrics: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "arm": self.arm,
+            "venue": self.venue,
+            "symbol": self.symbol,
+            "signal_session": self.signal_session.isoformat(),
+            "eligible": self.eligible,
+            "signal": self.signal,
+            "exclusion_reason": self.exclusion_reason,
+            "stages": dict(sorted(self.stages.items())),
+            "metrics": dict(sorted(self.metrics.items())),
+        }
+
+
+def nearest_rank_quantile(values: Sequence[float], probability: float) -> float:
+    """Return Q_p = sorted[ceil(p*n)-1], refusing non-finite inputs.
+
+    The caller must pass a historical sample only.  This helper intentionally
+    has no current-bar argument so it cannot silently include one.
+    """
+    if not values:
+        raise ValueError("nearest-rank quantile requires at least one value")
+    if not 0.0 < probability <= 1.0:
+        raise ValueError("nearest-rank probability must be in (0, 1]")
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("nearest-rank quantile rejects non-finite samples")
+    rank = math.ceil(probability * len(values))
+    return sorted(values)[rank - 1]
+
+
+def evaluate_signal(
+    candidate: CandidateDefinition,
+    history: Sequence[DailyBar | None],
+    *,
+    arm: Arm,
+) -> SignalEvaluation:
+    """Evaluate exactly one candidate/arm against one contiguous symbol history."""
+    if arm not in {"full", "ablation"}:
+        raise ValueError(f"unsupported signal arm: {arm!r}")
+    venue, symbol, session = _history_identity(history)
+    invalid_history_reason = _history_problem(candidate, history)
+    if invalid_history_reason is not None:
+        return _excluded(
+            candidate,
+            arm=arm,
+            venue=venue,
+            symbol=symbol,
+            session=session,
+            reason=invalid_history_reason,
+        )
+
+    bars = tuple(bar for bar in history if bar is not None)
+    if candidate.strategy_id == "CR-SPOT-ETR-01":
+        return _evaluate_etr(candidate, bars, arm=arm)
+    if candidate.strategy_id == "CR-SPOT-TPR-01":
+        return _evaluate_tpr(candidate, bars, arm=arm)
+    if candidate.strategy_id == "CR-SPOT-CEB-01":
+        return _evaluate_ceb(candidate, bars, arm=arm)
+    raise CandidateParseError(
+        f"no implementation exists for strategy_id={candidate.strategy_id!r}; "
+        "no family/name fallback is permitted"
+    )
+
+
+def _history_identity(
+    history: Sequence[DailyBar | None],
+) -> tuple[str, str, date]:
+    present = next((bar for bar in reversed(history) if bar is not None), None)
+    if present is None:
+        return "", "", date.min
+    return present.venue, present.symbol, present.session
+
+
+def _history_problem(
+    candidate: CandidateDefinition,
+    history: Sequence[DailyBar | None],
+) -> str | None:
+    if len(history) != candidate.required_history_days:
+        return "required_history_length_mismatch"
+    if any(bar is None for bar in history):
+        return "missing_required_history"
+    bars = tuple(bar for bar in history if bar is not None)
+    first = bars[0]
+    if any(bar.venue != first.venue or bar.symbol != first.symbol for bar in bars):
+        return "mixed_venue_or_symbol_history"
+    for previous, current in zip(bars, bars[1:], strict=False):
+        if current.session != previous.session + timedelta(days=1):
+            return "non_contiguous_required_history"
+    return None
+
+
+def _excluded(
+    candidate: CandidateDefinition,
+    *,
+    arm: Arm,
+    venue: str,
+    symbol: str,
+    session: date,
+    reason: str,
+) -> SignalEvaluation:
+    return SignalEvaluation(
+        strategy_id=candidate.strategy_id,
+        contract_hash=candidate.contract_hash,
+        arm=arm,
+        venue=venue,
+        symbol=symbol,
+        signal_session=session,
+        eligible=False,
+        signal=False,
+        exclusion_reason=reason,
+        stages=MappingProxyType({}),
+        metrics=MappingProxyType({}),
+    )
+
+
+def _result(
+    candidate: CandidateDefinition,
+    bars: Sequence[DailyBar],
+    *,
+    arm: Arm,
+    eligible: bool,
+    signal: bool,
+    reason: str | None,
+    stages: Mapping[str, bool],
+    metrics: Mapping[str, float],
+) -> SignalEvaluation:
+    current = bars[-1]
+    return SignalEvaluation(
+        strategy_id=candidate.strategy_id,
+        contract_hash=candidate.contract_hash,
+        arm=arm,
+        venue=current.venue,
+        symbol=current.symbol,
+        signal_session=current.session,
+        eligible=eligible,
+        signal=signal,
+        exclusion_reason=reason,
+        stages=MappingProxyType(dict(stages)),
+        metrics=MappingProxyType(dict(metrics)),
+    )
+
+
+def _is_finite_positive(value: float) -> bool:
+    return math.isfinite(value) and value > 0.0
+
+
+def _valid_ohlc(bar: DailyBar, *, require_nonflat: bool = False) -> bool:
+    if not all(
+        _is_finite_positive(value) for value in (bar.open, bar.high, bar.low, bar.close)
+    ):
+        return False
+    if bar.high < max(bar.open, bar.close) or bar.low > min(bar.open, bar.close):
+        return False
+    if require_nonflat and bar.high <= bar.low:
+        return False
+    return bar.high >= bar.low
+
+
+def _valid_closes(bars: Sequence[DailyBar]) -> bool:
+    return all(_is_finite_positive(bar.close) for bar in bars)
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values or not all(math.isfinite(value) for value in values):
+        raise ValueError("median requires finite values")
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2.0
+
+
+def _int_parameter(candidate: CandidateDefinition, name: str) -> int:
+    value = candidate.parameter(name)
+    if isinstance(value, bool) or int(value) != value:
+        raise CandidateParseError(
+            f"{candidate.strategy_id}: parameter {name!r} must be an integer"
+        )
+    return int(value)
+
+
+def _float_parameter(candidate: CandidateDefinition, name: str) -> float:
+    value = float(candidate.parameter(name))
+    if not math.isfinite(value):
+        raise CandidateParseError(
+            f"{candidate.strategy_id}: parameter {name!r} must be finite"
+        )
+    return value
+
+
+def _evaluate_etr(
+    candidate: CandidateDefinition,
+    bars: Sequence[DailyBar],
+    *,
+    arm: Arm,
+) -> SignalEvaluation:
+    return_days = _int_parameter(candidate, "return_history_days")
+    volume_days = _int_parameter(candidate, "quote_volume_median_days")
+    if len(bars) != return_days + 2:
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="etr_required_history_contract_mismatch",
+            stages={},
+            metrics={},
+        )
+    if not _valid_closes(bars):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_required_close_history",
+            stages={},
+            metrics={},
+        )
+
+    previous_returns = tuple(
+        math.log(bars[index].close / bars[index - 1].close)
+        for index in range(1, len(bars) - 1)
+    )
+    if len(previous_returns) != return_days:
+        raise CandidateParseError("ETR historical return sample length drift")
+    q10 = nearest_rank_quantile(
+        previous_returns,
+        _float_parameter(candidate, "return_tail_quantile"),
+    )
+    current = bars[-1]
+    r1 = math.log(current.close / bars[-2].close)
+    tail_day = r1 <= q10
+    metrics: dict[str, float] = {"r1": r1, "q10_r1": q10}
+
+    if arm == "ablation":
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=True,
+            signal=tail_day,
+            reason=None,
+            stages={"tail_day": tail_day},
+            metrics=metrics,
+        )
+
+    if not _valid_ohlc(current, require_nonflat=True):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_current_ohlc",
+            stages={"tail_day": tail_day},
+            metrics=metrics,
+        )
+    if not (
+        _is_finite_positive(current.base_volume)
+        and _is_finite_positive(current.quote_volume)
+    ):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_current_volume",
+            stages={"tail_day": tail_day},
+            metrics=metrics,
+        )
+    volume_sample = tuple(bar.quote_volume for bar in bars[-(volume_days + 1) : -1])
+    if len(volume_sample) != volume_days:
+        raise CandidateParseError("ETR quote-volume sample length drift")
+    try:
+        volume_median = _median(volume_sample)
+    except ValueError:
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_quote_volume_history",
+            stages={"tail_day": tail_day},
+            metrics=metrics,
+        )
+    if not _is_finite_positive(volume_median):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="nonpositive_quote_volume_median",
+            stages={"tail_day": tail_day},
+            metrics=metrics,
+        )
+    price_range = current.high - current.low
+    clv = (current.close - current.low) / price_range
+    lower_wick = (min(current.open, current.close) - current.low) / price_range
+    qv_ratio = current.quote_volume / volume_median
+    metrics.update(
+        {
+            "clv": clv,
+            "lower_wick": lower_wick,
+            "qv_ratio": qv_ratio,
+            "tail_severity": q10 - r1,
+        }
+    )
+    clv_ok = clv >= _float_parameter(candidate, "close_location_min")
+    wick_ok = lower_wick >= _float_parameter(candidate, "lower_wick_fraction_min")
+    volume_ok = qv_ratio >= _float_parameter(candidate, "quote_volume_ratio_min")
+    return _result(
+        candidate,
+        bars,
+        arm=arm,
+        eligible=True,
+        signal=tail_day and clv_ok and wick_ok and volume_ok,
+        reason=None,
+        stages={
+            "tail_day": tail_day,
+            "close_location": clv_ok,
+            "lower_wick": wick_ok,
+            "quote_volume": volume_ok,
+        },
+        metrics=metrics,
+    )
+
+
+def _sma(closes: Sequence[float], days: int) -> float:
+    if len(closes) != days:
+        raise ValueError("SMA sample length drift")
+    return sum(closes) / days
+
+
+def _evaluate_tpr(
+    candidate: CandidateDefinition,
+    bars: Sequence[DailyBar],
+    *,
+    arm: Arm,
+) -> SignalEvaluation:
+    trend_days = _int_parameter(candidate, "long_trend_sma_days")
+    slope_lag = _int_parameter(candidate, "long_trend_slope_lag_days")
+    pullback_days = _int_parameter(candidate, "pullback_sma_days")
+    integrity_days = _int_parameter(candidate, "pullback_integrity_window_days")
+    breakout_days = _int_parameter(candidate, "breakout_exclusion_days")
+    volume_days = _int_parameter(candidate, "quote_volume_median_days")
+    if len(bars) != trend_days + slope_lag:
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="tpr_required_history_contract_mismatch",
+            stages={},
+            metrics={},
+        )
+    if not all(_valid_ohlc(bar) for bar in bars):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_required_price_history",
+            stages={},
+            metrics={},
+        )
+
+    closes = tuple(bar.close for bar in bars)
+    current = bars[-1]
+    sma100 = _sma(closes[-trend_days:], trend_days)
+    sma100_lagged = _sma(closes[-(trend_days + slope_lag) : -slope_lag], trend_days)
+    sma20_current = _sma(closes[-pullback_days:], pullback_days)
+    sma20_previous = _sma(closes[-(pullback_days + 1) : -1], pullback_days)
+    prior_high = max(bar.high for bar in bars[-(breakout_days + 1) : -1])
+    # The upstream interval is i = t-5, ..., t: five elapsed day lags and
+    # therefore six inclusive observations.  Do not collapse it to five rows.
+    integrity_smas = tuple(
+        _sma(closes[index - trend_days + 1 : index + 1], trend_days)
+        for index in range(len(bars) - integrity_days - 1, len(bars))
+    )
+    integrity_min = min(
+        bar.close - sma_value
+        for bar, sma_value in zip(
+            bars[-(integrity_days + 1) :], integrity_smas, strict=True
+        )
+    )
+    trend_state = sma100 > sma100_lagged and current.close > sma100
+    cross_back_above = (
+        bars[-2].close <= sma20_previous and current.close > sma20_current
+    )
+    trend_integrity = integrity_min >= 0.0
+    green_candle = current.close > current.open
+    not_breakout = current.close <= prior_high
+    metrics: dict[str, float] = {
+        "sma100": sma100,
+        "sma100_lagged": sma100_lagged,
+        "sma20": sma20_current,
+        "prior_20d_high": prior_high,
+        "trend_slope": sma100 / sma100_lagged - 1.0,
+        "pullback_extension": current.close / sma20_current - 1.0,
+        "integrity_min": integrity_min,
+    }
+
+    if arm == "ablation":
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=True,
+            signal=trend_state,
+            reason=None,
+            stages={"trend_state": trend_state},
+            metrics=metrics,
+        )
+
+    if not (
+        _is_finite_positive(current.base_volume)
+        and _is_finite_positive(current.quote_volume)
+    ):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_current_volume",
+            stages={"trend_state": trend_state},
+            metrics=metrics,
+        )
+    volume_sample = tuple(bar.quote_volume for bar in bars[-(volume_days + 1) : -1])
+    try:
+        volume_median = _median(volume_sample)
+    except ValueError:
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_quote_volume_history",
+            stages={"trend_state": trend_state},
+            metrics=metrics,
+        )
+    if not _is_finite_positive(volume_median):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="nonpositive_quote_volume_median",
+            stages={"trend_state": trend_state},
+            metrics=metrics,
+        )
+    qv_ratio = current.quote_volume / volume_median
+    volume_ok = qv_ratio >= _float_parameter(candidate, "quote_volume_ratio_min")
+    pullback_setup = (
+        trend_state
+        and cross_back_above
+        and trend_integrity
+        and green_candle
+        and not_breakout
+    )
+    metrics["qv_ratio"] = qv_ratio
+    return _result(
+        candidate,
+        bars,
+        arm=arm,
+        eligible=True,
+        signal=pullback_setup and volume_ok,
+        reason=None,
+        stages={
+            "trend_state": trend_state,
+            "cross_back_above": cross_back_above,
+            "trend_integrity": trend_integrity,
+            "green_candle": green_candle,
+            "not_breakout": not_breakout,
+            "pullback_setup": pullback_setup,
+            "quote_volume": volume_ok,
+        },
+        metrics=metrics,
+    )
+
+
+def _normalized_true_range(current: DailyBar, previous_close: float) -> float:
+    return (
+        max(
+            current.high - current.low,
+            abs(current.high - previous_close),
+            abs(current.low - previous_close),
+        )
+        / previous_close
+    )
+
+
+def _evaluate_ceb(
+    candidate: CandidateDefinition,
+    bars: Sequence[DailyBar],
+    *,
+    arm: Arm,
+) -> SignalEvaluation:
+    atr_days = _int_parameter(candidate, "normalized_true_range_window_days")
+    reference_count = _int_parameter(candidate, "compression_reference_count")
+    breakout_days = _int_parameter(candidate, "breakout_lookback_days")
+    volume_days = _int_parameter(candidate, "quote_volume_median_days")
+    expected_history = reference_count + atr_days + 2
+    if len(bars) != expected_history:
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="ceb_required_history_contract_mismatch",
+            stages={},
+            metrics={},
+        )
+    if not all(_valid_ohlc(bar) for bar in bars):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_required_price_history",
+            stages={},
+            metrics={},
+        )
+
+    ntr = (0.0,) + tuple(
+        _normalized_true_range(bar, previous.close)
+        for previous, bar in zip(bars, bars[1:], strict=False)
+    )
+    atr20 = tuple(
+        _sma(ntr[index - atr_days + 1 : index + 1], atr_days)
+        if index >= atr_days
+        else math.nan
+        for index in range(len(ntr))
+    )
+    current_index = len(bars) - 1
+    reference_start = current_index - reference_count - 1
+    reference_end = current_index - 1
+    reference = tuple(atr20[index] for index in range(reference_start, reference_end))
+    if len(reference) != reference_count or not all(
+        math.isfinite(value) for value in reference
+    ):
+        raise CandidateParseError("CEB compression reference sample length drift")
+    cutoff = nearest_rank_quantile(
+        reference,
+        _float_parameter(candidate, "compression_quantile"),
+    )
+    current = bars[-1]
+    prior_bars = bars[-(breakout_days + 1) : -1]
+    prior_high = max(bar.high for bar in prior_bars)
+    ntr_history = ntr[-(breakout_days + 1) : -1]
+    current_ntr = ntr[-1]
+    clv_denominator = current.high - current.low
+    if clv_denominator <= 0.0:
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="flat_current_range",
+            stages={},
+            metrics={},
+        )
+    clv = (current.close - current.low) / clv_denominator
+    compression_state = atr20[-2] <= cutoff
+    raw_breakout = current.close > prior_high
+    metrics: dict[str, float] = {
+        "atr20_t_minus_1": atr20[-2],
+        "compression_cutoff": cutoff,
+        "prior_20d_high": prior_high,
+        "breakout_extension": current.close / prior_high - 1.0,
+        "clv": clv,
+    }
+    if arm == "ablation":
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=True,
+            signal=raw_breakout,
+            reason=None,
+            stages={
+                "compression_state": compression_state,
+                "raw_20d_breakout": raw_breakout,
+            },
+            metrics=metrics,
+        )
+
+    if not _is_finite_positive(current.quote_volume):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_current_quote_volume",
+            stages={
+                "compression_state": compression_state,
+                "raw_20d_breakout": raw_breakout,
+            },
+            metrics=metrics,
+        )
+    try:
+        ntr_median = _median(ntr_history)
+        volume_median = _median(
+            tuple(bar.quote_volume for bar in bars[-(volume_days + 1) : -1])
+        )
+    except ValueError:
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="invalid_ntr_or_quote_volume_history",
+            stages={
+                "compression_state": compression_state,
+                "raw_20d_breakout": raw_breakout,
+            },
+            metrics=metrics,
+        )
+    if not (_is_finite_positive(ntr_median) and _is_finite_positive(volume_median)):
+        return _result(
+            candidate,
+            bars,
+            arm=arm,
+            eligible=False,
+            signal=False,
+            reason="nonpositive_ntr_or_quote_volume_median",
+            stages={
+                "compression_state": compression_state,
+                "raw_20d_breakout": raw_breakout,
+            },
+            metrics=metrics,
+        )
+    range_ratio = current_ntr / ntr_median
+    qv_ratio = current.quote_volume / volume_median
+    clv_ok = clv >= _float_parameter(candidate, "close_location_min")
+    range_ok = range_ratio >= _float_parameter(candidate, "range_expansion_ratio_min")
+    volume_ok = qv_ratio >= _float_parameter(candidate, "quote_volume_ratio_min")
+    metrics.update({"range_ratio": range_ratio, "qv_ratio": qv_ratio})
+    return _result(
+        candidate,
+        bars,
+        arm=arm,
+        eligible=True,
+        signal=compression_state and raw_breakout and clv_ok and range_ok and volume_ok,
+        reason=None,
+        stages={
+            "compression_state": compression_state,
+            "raw_20d_breakout": raw_breakout,
+            "close_location": clv_ok,
+            "range_expansion": range_ok,
+            "quote_volume": volume_ok,
+        },
+        metrics=metrics,
+    )

--- a/research/crypto_stage_b/source.py
+++ b/research/crypto_stage_b/source.py
@@ -1,0 +1,354 @@
+"""Read-only daily-bar source interfaces and exploration-boundary access spy."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from research.crypto_corpus.loader import LabeledCorpus
+
+__all__ = [
+    "AccessRecord",
+    "BoundaryAccessSpy",
+    "CryptoStageBInputError",
+    "DailyBar",
+    "DailyBarSource",
+    "ExplorationBoundaryAccessError",
+    "InMemoryDailyBarSource",
+    "TerminalEvent",
+    "bars_from_crypto_corpus_records",
+    "source_from_labeled_corpus",
+]
+
+
+class CryptoStageBInputError(ValueError):
+    """The read-only Stage-B input does not meet the daily-corpus contract."""
+
+
+class ExplorationBoundaryAccessError(RuntimeError):
+    """A source read attempted a UTC day outside the explicit exploration window."""
+
+
+@dataclass(frozen=True)
+class DailyBar:
+    """One raw crypto-corpus UTC daily bar; values stay uncleaned for exclusion."""
+
+    venue: str
+    symbol: str
+    session: date
+    open: float
+    high: float
+    low: float
+    close: float
+    base_volume: float
+    quote_volume: float
+    frequency: str = "1d"
+    bucket_timezone: str = "UTC"
+
+    def __post_init__(self) -> None:
+        if not self.venue or not self.symbol:
+            raise CryptoStageBInputError(
+                "daily bar requires non-empty venue and symbol"
+            )
+        if isinstance(self.session, datetime) or not isinstance(self.session, date):
+            raise CryptoStageBInputError(
+                "daily bar session must be a UTC calendar date"
+            )
+        if self.frequency != "1d":
+            raise CryptoStageBInputError("crypto Stage-B accepts daily bars only")
+        if self.bucket_timezone != "UTC":
+            raise CryptoStageBInputError("crypto Stage-B requires UTC daily buckets")
+
+
+@dataclass(frozen=True)
+class TerminalEvent:
+    """An observed terminal event; only explicit delisting evidence is usable."""
+
+    venue: str
+    symbol: str
+    session: date
+    event_type: str = "delisted"
+
+    def __post_init__(self) -> None:
+        if self.event_type != "delisted":
+            raise CryptoStageBInputError(
+                "only explicit delisted terminal events are valid"
+            )
+        if isinstance(self.session, datetime) or not isinstance(self.session, date):
+            raise CryptoStageBInputError("terminal-event session must be a UTC date")
+
+
+class DailyBarSource(Protocol):
+    """A point-read source so the engine can prove it did not read holdout days."""
+
+    def symbols(self, venue: str) -> tuple[str, ...]:
+        """Return immutable venue metadata, not daily-bar data."""
+
+    def get(self, venue: str, symbol: str, session: date) -> DailyBar | None:
+        """Return exactly one UTC daily bar, or a true missing day."""
+
+    def terminal_event(
+        self, venue: str, symbol: str, session: date
+    ) -> TerminalEvent | None:
+        """Return only an observed terminal event at this exact UTC day."""
+
+
+@dataclass(frozen=True)
+class AccessRecord:
+    kind: str
+    venue: str
+    symbol: str
+    session: date
+    allowed: bool
+
+    def to_dict(self) -> dict[str, str | bool]:
+        return {
+            "kind": self.kind,
+            "venue": self.venue,
+            "symbol": self.symbol,
+            "session": self.session.isoformat(),
+            "allowed": self.allowed,
+        }
+
+
+class InMemoryDailyBarSource:
+    """Deterministic read-only fixture/source adapter with duplicate refusal."""
+
+    def __init__(
+        self,
+        bars: Iterable[DailyBar],
+        *,
+        terminal_events: Iterable[TerminalEvent] = (),
+    ) -> None:
+        by_key: dict[tuple[str, str, date], DailyBar] = {}
+        symbols: dict[str, set[str]] = {}
+        for bar in bars:
+            key = (bar.venue, bar.symbol, bar.session)
+            if key in by_key:
+                raise CryptoStageBInputError(
+                    f"duplicate daily bar: {bar.venue}/{bar.symbol}/{bar.session}"
+                )
+            by_key[key] = bar
+            symbols.setdefault(bar.venue, set()).add(bar.symbol)
+
+        events_by_key: dict[tuple[str, str, date], TerminalEvent] = {}
+        for event in terminal_events:
+            key = (event.venue, event.symbol, event.session)
+            if key in events_by_key:
+                raise CryptoStageBInputError(
+                    "duplicate terminal event: "
+                    f"{event.venue}/{event.symbol}/{event.session}"
+                )
+            events_by_key[key] = event
+
+        self._bars = by_key
+        self._symbols = {
+            venue: tuple(sorted(venue_symbols))
+            for venue, venue_symbols in symbols.items()
+        }
+        self._events = events_by_key
+
+    def symbols(self, venue: str) -> tuple[str, ...]:
+        return self._symbols.get(venue, ())
+
+    def get(self, venue: str, symbol: str, session: date) -> DailyBar | None:
+        return self._bars.get((venue, symbol, session))
+
+    def terminal_event(
+        self, venue: str, symbol: str, session: date
+    ) -> TerminalEvent | None:
+        return self._events.get((venue, symbol, session))
+
+
+class BoundaryAccessSpy:
+    """Wrap a source and fail before every read outside an explicit UTC window."""
+
+    def __init__(
+        self,
+        source: DailyBarSource,
+        *,
+        exploration_start: date,
+        exploration_end: date,
+    ) -> None:
+        if exploration_start > exploration_end:
+            raise CryptoStageBInputError("exploration boundary start is after end")
+        self._source = source
+        self._start = exploration_start
+        self._end = exploration_end
+        self._records: list[AccessRecord] = []
+
+    def symbols(self, venue: str) -> tuple[str, ...]:
+        return self._source.symbols(venue)
+
+    def get(self, venue: str, symbol: str, session: date) -> DailyBar | None:
+        self._record_or_refuse("bar", venue, symbol, session)
+        return self._source.get(venue, symbol, session)
+
+    def terminal_event(
+        self, venue: str, symbol: str, session: date
+    ) -> TerminalEvent | None:
+        self._record_or_refuse("terminal_event", venue, symbol, session)
+        return self._source.terminal_event(venue, symbol, session)
+
+    @property
+    def records(self) -> tuple[AccessRecord, ...]:
+        return tuple(self._records)
+
+    @property
+    def outside_boundary_records(self) -> tuple[AccessRecord, ...]:
+        return tuple(record for record in self._records if not record.allowed)
+
+    def assert_no_outside_access(self) -> None:
+        outside = self.outside_boundary_records
+        if outside:
+            raise ExplorationBoundaryAccessError(
+                "outside-boundary source access attempted: "
+                f"{[record.to_dict() for record in outside]!r}"
+            )
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "reads_total": len(self._records),
+            "bar_reads": sum(record.kind == "bar" for record in self._records),
+            "terminal_event_reads": sum(
+                record.kind == "terminal_event" for record in self._records
+            ),
+            "outside_boundary_reads": len(self.outside_boundary_records),
+        }
+
+    def _record_or_refuse(
+        self, kind: str, venue: str, symbol: str, session: date
+    ) -> None:
+        allowed = self._start <= session <= self._end
+        record = AccessRecord(
+            kind=kind,
+            venue=venue,
+            symbol=symbol,
+            session=session,
+            allowed=allowed,
+        )
+        self._records.append(record)
+        if not allowed:
+            raise ExplorationBoundaryAccessError(
+                f"{kind} read outside exploration boundary: {session.isoformat()} "
+                f"not in {self._start.isoformat()}..{self._end.isoformat()}"
+            )
+
+
+def bars_from_crypto_corpus_records(
+    records: Iterable[Mapping[str, Any]],
+) -> tuple[DailyBar, ...]:
+    """Adapt already-authorized labeled-corpus records without data mutation.
+
+    The caller is responsible for obtaining records through the corpus policy
+    loader.  This adapter refuses intraday or non-UTC records and deliberately
+    performs no interpolation, filtering, or write operation.
+    """
+    bars: list[DailyBar] = []
+    required = {
+        "venue",
+        "symbol",
+        "frequency",
+        "bucket_timezone",
+        "open_time_utc",
+        "open",
+        "high",
+        "low",
+        "close",
+        "base_volume",
+        "quote_volume",
+    }
+    for record in records:
+        missing = required - set(record)
+        if missing:
+            raise CryptoStageBInputError(
+                f"crypto corpus record lacks required fields: {sorted(missing)!r}"
+            )
+        raw_timestamp = record["open_time_utc"]
+        if not isinstance(raw_timestamp, datetime) or raw_timestamp.tzinfo is None:
+            raise CryptoStageBInputError(
+                "open_time_utc must be a timezone-aware datetime"
+            )
+        utc_timestamp = raw_timestamp.astimezone(UTC)
+        bars.append(
+            DailyBar(
+                venue=str(record["venue"]),
+                symbol=str(record["symbol"]),
+                session=utc_timestamp.date(),
+                open=float(record["open"]),
+                high=float(record["high"]),
+                low=float(record["low"]),
+                close=float(record["close"]),
+                base_volume=float(record["base_volume"]),
+                quote_volume=float(record["quote_volume"]),
+                frequency=str(record["frequency"]),
+                bucket_timezone=str(record["bucket_timezone"]),
+            )
+        )
+    return tuple(bars)
+
+
+def source_from_labeled_corpus(
+    corpus: LabeledCorpus,
+    *,
+    exploration_start: date,
+    exploration_end: date,
+    terminal_events: Iterable[TerminalEvent] = (),
+) -> InMemoryDailyBarSource:
+    """Bind an already policy-checked, exact-window corpus extract to Stage-B.
+
+    ``crypto_corpus.load_labeled_parquet*`` is the mandatory upstream reader;
+    it validates file labels and refuses holdout paths before rows are decoded.
+    This adapter requires the caller to supply an extract entirely inside the
+    explicit Stage-B window.  It refuses, rather than silently filters, any
+    out-of-window row so a future/holdout bar cannot be smuggled into memory.
+    """
+    if corpus.consumer_intent != "time_series":
+        raise CryptoStageBInputError(
+            "crypto Stage-B requires time_series corpus intent, never xsec"
+        )
+    if exploration_start > exploration_end:
+        raise CryptoStageBInputError("exploration boundary start is after end")
+    required = {
+        "venue",
+        "symbol",
+        "frequency",
+        "bucket_timezone",
+        "open_time_utc",
+        "open",
+        "high",
+        "low",
+        "close",
+        "base_volume",
+        "quote_volume",
+    }
+    observed = set(corpus.table.column_names)
+    missing = required - observed
+    if missing:
+        raise CryptoStageBInputError(
+            f"labeled corpus table lacks required fields: {sorted(missing)!r}"
+        )
+    columns = {name: corpus.table.column(name).to_pylist() for name in sorted(required)}
+    records = tuple(
+        dict(zip(columns, values, strict=True))
+        for values in zip(*(columns[name] for name in columns), strict=True)
+    )
+    bars = bars_from_crypto_corpus_records(records)
+    if any(bar.venue != corpus.policy.venue for bar in bars):
+        raise CryptoStageBInputError(
+            "labeled corpus row venue does not match its verified file policy"
+        )
+    out_of_window = tuple(
+        bar.session
+        for bar in bars
+        if not exploration_start <= bar.session <= exploration_end
+    )
+    if out_of_window:
+        raise CryptoStageBInputError(
+            "labeled corpus extract contains rows outside explicit exploration "
+            f"window; first={out_of_window[0].isoformat()}"
+        )
+    return InMemoryDailyBarSource(bars, terminal_events=terminal_events)

--- a/research/crypto_stage_b/tests/__init__.py
+++ b/research/crypto_stage_b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic, no-corpus-write verification for crypto Stage-B."""

--- a/research/crypto_stage_b/tests/conftest.py
+++ b/research/crypto_stage_b/tests/conftest.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from types import MappingProxyType
+
+from research.crypto_stage_b.contracts import VenueCostLiteral
+from research.crypto_stage_b.registry import EXPECTED_RETURN_SHA256, CandidateDefinition
+from research.crypto_stage_b.source import DailyBar
+
+
+def candidate(strategy_id: str) -> CandidateDefinition:
+    parameters: dict[str, int | float]
+    history_days: int
+    if strategy_id == "CR-SPOT-ETR-01":
+        history_days = 252
+        parameters = {
+            "return_history_days": 250,
+            "return_tail_quantile": 0.10,
+            "close_location_min": 0.70,
+            "lower_wick_fraction_min": 0.40,
+            "quote_volume_median_days": 30,
+            "quote_volume_ratio_min": 1.50,
+            "exit_D_plus_days": 3,
+            "max_concurrent_positions_per_venue": 5,
+        }
+    elif strategy_id == "CR-SPOT-TPR-01":
+        history_days = 120
+        parameters = {
+            "long_trend_sma_days": 100,
+            "long_trend_slope_lag_days": 20,
+            "pullback_sma_days": 20,
+            "pullback_integrity_window_days": 5,
+            "quote_volume_median_days": 30,
+            "quote_volume_ratio_min": 0.75,
+            "breakout_exclusion_days": 20,
+            "exit_D_plus_days": 10,
+            "max_concurrent_positions_per_venue": 5,
+        }
+    elif strategy_id == "CR-SPOT-CEB-01":
+        history_days = 122
+        parameters = {
+            "normalized_true_range_window_days": 20,
+            "compression_reference_count": 100,
+            "compression_quantile": 0.25,
+            "breakout_lookback_days": 20,
+            "close_location_min": 0.80,
+            "range_expansion_ratio_min": 1.50,
+            "quote_volume_median_days": 30,
+            "quote_volume_ratio_min": 2.00,
+            "exit_D_plus_days": 7,
+            "max_concurrent_positions_per_venue": 5,
+        }
+    else:  # pragma: no cover - test helper boundary
+        raise ValueError(strategy_id)
+    return CandidateDefinition(
+        strategy_id=strategy_id,
+        family_id="test",
+        venue_scope="both",
+        required_history_days=history_days,
+        parameter_values=MappingProxyType(parameters),
+        signal_text="source parsed in registry integration test",
+        entry_text="next_day_open_utc",
+        exit_text="source parsed exit",
+        ranking_text="source parsed ranking",
+        sizing_text="source parsed sizing",
+        ablation_text="source parsed ablation",
+        harness_query_text="source parsed harness query",
+        raw_contract_text="test fixture only",
+        source_return_sha256=EXPECTED_RETURN_SHA256,
+        contract_hash=f"test-{strategy_id.lower()}",
+    )
+
+
+def cost(venue: str) -> VenueCostLiteral:
+    if venue == "upbit_krw":
+        return VenueCostLiteral(
+            venue="upbit_krw",
+            fee_bp_per_side=5,
+            slippage_bp_per_side=10,
+            sensitivity_slippage_bp_per_side=30,
+        )
+    if venue == "binance_usdt_spot":
+        return VenueCostLiteral(
+            venue="binance_usdt_spot",
+            fee_bp_per_side=10,
+            slippage_bp_per_side=10,
+            sensitivity_slippage_bp_per_side=30,
+        )
+    raise ValueError(venue)
+
+
+def etr_bars(
+    *,
+    venue: str = "upbit_krw",
+    symbol: str = "TEST",
+    start: date = date(2024, 1, 1),
+    quote_volume_on_signal: float = 200.0,
+    include_entry: bool = True,
+    include_exit: bool = True,
+) -> tuple[DailyBar, ...]:
+    """Create a single ETR signal on index 251 plus optional D+1/D+3 bars."""
+    bars: list[DailyBar] = []
+    for index in range(256):
+        session = start + timedelta(days=index)
+        open_price = 100.0
+        high = 101.0
+        low = 99.0
+        close = 100.0
+        quote_volume = 100.0
+        if index == 251:
+            open_price = 80.0
+            high = 90.0
+            low = 40.0
+            close = 80.0
+            quote_volume = quote_volume_on_signal
+        elif index == 252:
+            open_price = 81.0
+            high = 82.0
+            low = 80.0
+            close = 81.0
+        elif index == 255:
+            open_price = 90.0
+            high = 91.0
+            low = 89.0
+            close = 90.0
+        if (index == 252 and not include_entry) or (index == 255 and not include_exit):
+            continue
+        bars.append(
+            DailyBar(
+                venue=venue,
+                symbol=symbol,
+                session=session,
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+                base_volume=100.0,
+                quote_volume=quote_volume,
+            )
+        )
+    return tuple(bars)

--- a/research/crypto_stage_b/tests/test_contracts_and_isolation.py
+++ b/research/crypto_stage_b/tests/test_contracts_and_isolation.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import ast
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from research.crypto_stage_b.contracts import (
+    CryptoStageBRunContract,
+    ExplorationWindowError,
+    VenueCostLiteral,
+)
+from research.crypto_stage_b.tests.conftest import candidate, cost
+
+
+def test_cost_literals_are_explicit_and_exactly_frozen() -> None:
+    assert cost("upbit_krw").round_trip_bp == 30
+    assert cost("upbit_krw").sensitivity_round_trip_bp == 70
+    assert cost("binance_usdt_spot").round_trip_bp == 40
+    assert cost("binance_usdt_spot").sensitivity_round_trip_bp == 80
+    with pytest.raises(ValueError, match="does not inject defaults"):
+        VenueCostLiteral(
+            venue="upbit_krw",
+            fee_bp_per_side=5,
+            slippage_bp_per_side=11,
+            sensitivity_slippage_bp_per_side=30,
+        )
+
+
+def test_contract_refuses_holdout_intersection_before_source_reads() -> None:
+    with pytest.raises(ExplorationWindowError, match="holdout"):
+        CryptoStageBRunContract(
+            candidate=candidate("CR-SPOT-ETR-01"),
+            venue="upbit_krw",
+            exploration_start=date(2024, 12, 30),
+            exploration_end=date(2025, 1, 1),
+            cost=cost("upbit_krw"),
+        )
+
+
+def test_new_crypto_module_has_no_kr_shadow_or_runtime_import_path() -> None:
+    root = Path(__file__).parents[1]
+    forbidden_prefixes = (
+        "app",
+        "research.kr_corpus",
+        "research.three_market_shadow",
+    )
+    violations: list[str] = []
+    for path in sorted(root.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports = [name.name for name in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                imports = [node.module or ""]
+            else:
+                continue
+            for imported in imports:
+                if imported.startswith(forbidden_prefixes):
+                    violations.append(f"{path.name}:{imported}")
+    assert violations == []

--- a/research/crypto_stage_b/tests/test_engine.py
+++ b/research/crypto_stage_b/tests/test_engine.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+
+from research.crypto_stage_b.contracts import CryptoStageBRunContract
+from research.crypto_stage_b.engine import run_candidate_pair, run_execution_arm
+from research.crypto_stage_b.report import build_harness_report
+from research.crypto_stage_b.source import InMemoryDailyBarSource, TerminalEvent
+from research.crypto_stage_b.tests.conftest import candidate, cost, etr_bars
+
+
+def _contract(*, end_index: int = 255) -> CryptoStageBRunContract:
+    start = date(2024, 1, 1)
+    return CryptoStageBRunContract(
+        candidate=candidate("CR-SPOT-ETR-01"),
+        venue="upbit_krw",
+        exploration_start=start,
+        exploration_end=start + timedelta(days=end_index),
+        cost=cost("upbit_krw"),
+    )
+
+
+def test_entry_is_next_utc_calendar_day_not_next_observed_bar() -> None:
+    result = run_execution_arm(
+        source=InMemoryDailyBarSource(etr_bars(include_entry=False)),
+        contract=_contract(),
+        arm="full",
+    )
+
+    assert [item.status for item in result.outcomes] == ["entry_no_fill"]
+
+
+def test_scheduled_exit_missing_is_not_forward_filled_or_next_observation() -> None:
+    result = run_execution_arm(
+        source=InMemoryDailyBarSource(etr_bars(include_exit=False)),
+        contract=_contract(),
+        arm="full",
+    )
+
+    assert [item.status for item in result.outcomes] == ["missing_exit"]
+
+
+def test_observed_delisting_uses_last_valid_close_and_marks_delisted_exit() -> None:
+    start = date(2024, 1, 1)
+    result = run_execution_arm(
+        source=InMemoryDailyBarSource(
+            etr_bars(include_exit=False),
+            terminal_events=(
+                TerminalEvent(
+                    venue="upbit_krw",
+                    symbol="TEST",
+                    session=start + timedelta(days=254),
+                ),
+            ),
+        ),
+        contract=_contract(),
+        arm="full",
+    )
+
+    outcome = result.outcomes[0]
+    assert outcome.status == "delisted_exit"
+    assert outcome.delisted_exit is True
+    assert outcome.exit_session == start + timedelta(days=254)
+    assert outcome.exit_close == 100.0
+
+
+def test_venue_capacity_is_five_and_tie_breaks_by_symbol() -> None:
+    bars = tuple(
+        bar
+        for symbol in ("A", "B", "C", "D", "E", "F")
+        for bar in etr_bars(symbol=symbol)
+    )
+    result = run_execution_arm(
+        source=InMemoryDailyBarSource(bars),
+        contract=_contract(),
+        arm="full",
+    )
+
+    assert [item.symbol for item in result.outcomes[:5]] == ["A", "B", "C", "D", "E"]
+    assert result.outcomes[-1].symbol == "F"
+    assert result.outcomes[-1].status == "capacity_rejected"
+
+
+def test_venue_result_never_reads_or_ranks_other_venue() -> None:
+    source = InMemoryDailyBarSource(
+        etr_bars(venue="upbit_krw", symbol="KRW-ONLY")
+        + etr_bars(venue="binance_usdt_spot", symbol="USDT-OTHER")
+    )
+    result = run_execution_arm(source=source, contract=_contract(), arm="full")
+
+    assert {item.venue for item in result.observations} == {"upbit_krw"}
+    assert {item.venue for item in result.outcomes} == {"upbit_krw"}
+
+
+def test_boundary_censors_outcome_without_any_outside_read() -> None:
+    result = run_execution_arm(
+        source=InMemoryDailyBarSource(etr_bars()),
+        contract=_contract(end_index=253),
+        arm="full",
+    )
+
+    assert [item.status for item in result.outcomes] == [
+        "censored_at_exploration_boundary"
+    ]
+    assert result.access_summary["outside_boundary_reads"] == 0
+
+
+def test_ablation_pair_and_harness_have_only_venue_year_records() -> None:
+    pair = run_candidate_pair(
+        source=InMemoryDailyBarSource(etr_bars(quote_volume_on_signal=100.0)),
+        contract=_contract(),
+    )
+    report = build_harness_report(pair).to_dict()
+    rendered = json.dumps(report, sort_keys=True)
+
+    assert pair.full.outcomes == ()
+    assert [item.status for item in pair.ablation.outcomes][:1] == ["completed"]
+    assert "pooled" not in rendered
+    assert report["records"]
+    full = report["records"][0]["full"]
+    assert full["low_liquidity_break_even_round_trip_bp"] == 30
+    assert full["sensitivity_break_even_round_trip_bp"] == 70

--- a/research/crypto_stage_b/tests/test_registry.py
+++ b/research/crypto_stage_b/tests/test_registry.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from research.crypto_stage_b.registry import (
+    ADMITTED_STRATEGY_IDS,
+    CandidateParseError,
+    CandidateRegistry,
+)
+
+
+def _candidate_block(strategy_id: str, *, history_days: int) -> str:
+    return f"""- strategy_id: {strategy_id}
+  family_id: TEST
+  venue_scope: both
+  signal: |
+    source signal
+  required_history: {history_days}개의 연속된 UTC 일봉
+  entry: next_day_open_utc
+  exit: entry day D close
+  ranking: >
+    source ranking
+  sizing: >
+    source sizing
+  parameter_values:
+    exit_D_plus_days: 3
+    max_concurrent_positions_per_venue: 5
+  expected_trade_frequency: |
+    HARNESS_QUERY: source schema
+  falsification: >
+    source ablation
+  empirical_status: UNTESTED
+"""
+
+
+def _source() -> bytes:
+    return (
+        "# verbatim fixture\n"
+        + _candidate_block("CR-SPOT-ETR-01", history_days=252)
+        + _candidate_block("CR-SPOT-TPR-01", history_days=120)
+        + _candidate_block("CR-SPOT-CEB-01", history_days=122)
+        + _candidate_block("CR-SPOT-HTA-01", history_days=251)
+        + "요구 산출물 2\n"
+    ).encode()
+
+
+def test_registry_parses_raw_blocks_and_binds_each_contract_hash() -> None:
+    source = _source()
+    registry = CandidateRegistry.from_verbatim_bytes(
+        source,
+        expected_return_sha256=hashlib.sha256(source).hexdigest(),
+    )
+
+    assert (
+        tuple(item.strategy_id for item in registry.admitted) == ADMITTED_STRATEGY_IDS
+    )
+    assert registry.preserved_not_implemented.strategy_id == "CR-SPOT-HTA-01"
+    assert all(item.contract_hash for item in registry.definitions)
+    assert all(
+        item.to_dict()["contract_hash"] == item.contract_hash
+        for item in registry.definitions
+    )
+
+
+def test_registry_refuses_one_byte_drift_before_parsing() -> None:
+    source = _source()
+    with pytest.raises(CandidateParseError, match="SHA-256 mismatch"):
+        CandidateRegistry.from_verbatim_bytes(
+            source + b" ",
+            expected_return_sha256=hashlib.sha256(source).hexdigest(),
+        )

--- a/research/crypto_stage_b/tests/test_signals.py
+++ b/research/crypto_stage_b/tests/test_signals.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+import pytest
+
+from research.crypto_stage_b.signals import evaluate_signal, nearest_rank_quantile
+from research.crypto_stage_b.source import DailyBar
+from research.crypto_stage_b.tests.conftest import candidate, etr_bars
+
+
+def test_nearest_rank_uses_ceil_rank_not_interpolation_or_floor() -> None:
+    assert nearest_rank_quantile((1.0, 2.0, 3.0, 4.0), 0.25) == 1.0
+    assert nearest_rank_quantile((1.0, 2.0, 3.0, 4.0), 0.30) == 2.0
+
+
+def test_etr_quantile_excludes_current_bar() -> None:
+    start = date(2024, 1, 1)
+    closes = [100.0]
+    # Q_0.10 over this 250-return historical sample is -0.10.
+    for value in [-0.10] * 25 + [0.0] * 225:
+        closes.append(closes[-1] * math.exp(value))
+    closes.append(closes[-1] * math.exp(-0.05))
+    bars = []
+    for index, close in enumerate(closes):
+        is_current = index == len(closes) - 1
+        bars.append(
+            DailyBar(
+                venue="upbit_krw",
+                symbol="KRW-Q",
+                session=start + timedelta(days=index),
+                open=close,
+                high=close * 1.10 if is_current else close * 1.01,
+                low=close * 0.50 if is_current else close * 0.99,
+                close=close,
+                base_volume=100.0,
+                quote_volume=200.0 if is_current else 100.0,
+            )
+        )
+
+    result = evaluate_signal(candidate("CR-SPOT-ETR-01"), bars, arm="full")
+
+    assert result.eligible is True
+    assert result.metrics["q10_r1"] == pytest.approx(-0.10)
+    assert result.metrics["r1"] == pytest.approx(-0.05)
+    assert result.signal is False
+
+
+def test_etr_ablation_is_not_a_full_signal_fallback() -> None:
+    bars = etr_bars(quote_volume_on_signal=100.0)
+    full = evaluate_signal(candidate("CR-SPOT-ETR-01"), bars[:252], arm="full")
+    ablation = evaluate_signal(candidate("CR-SPOT-ETR-01"), bars[:252], arm="ablation")
+
+    assert full.signal is False
+    assert ablation.signal is True
+
+
+def test_tpr_uses_six_inclusive_integrity_observations_t_minus_5_through_t() -> None:
+    start = date(2024, 1, 1)
+    bars: list[DailyBar] = []
+    for index in range(120):
+        close = 100.0 + 0.1 * index if index <= 99 else 110.0
+        if 114 <= index <= 118:
+            close = 107.0
+        if index == 119:
+            close = 110.0
+        open_price = close - 1.0 if index == 119 else close
+        bars.append(
+            DailyBar(
+                venue="upbit_krw",
+                symbol="KRW-T",
+                session=start + timedelta(days=index),
+                open=open_price,
+                high=111.0,
+                low=min(open_price, close) - 1.0,
+                close=close,
+                base_volume=100.0,
+                quote_volume=100.0,
+            )
+        )
+
+    result = evaluate_signal(candidate("CR-SPOT-TPR-01"), bars, arm="full")
+
+    assert result.signal is True
+    assert result.stages["trend_integrity"] is True
+
+
+def test_ceb_uses_100_observation_compression_reference_before_current_bar() -> None:
+    start = date(2024, 1, 1)
+    bars: list[DailyBar] = []
+    for index in range(122):
+        open_price, high, low, close, quote_volume = (100.0, 101.0, 99.0, 100.0, 100.0)
+        if index == 121:
+            open_price, high, low, close, quote_volume = (
+                100.0,
+                106.0,
+                95.0,
+                105.0,
+                300.0,
+            )
+        bars.append(
+            DailyBar(
+                venue="binance_usdt_spot",
+                symbol="CEBUSDT",
+                session=start + timedelta(days=index),
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+                base_volume=100.0,
+                quote_volume=quote_volume,
+            )
+        )
+
+    result = evaluate_signal(candidate("CR-SPOT-CEB-01"), bars, arm="full")
+
+    assert result.signal is True
+    assert result.stages["compression_state"] is True
+    assert result.stages["raw_20d_breakout"] is True

--- a/research/crypto_stage_b/tests/test_source_adapter.py
+++ b/research/crypto_stage_b/tests/test_source_adapter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from research.crypto_corpus.loader import LabeledCorpus
+from research.crypto_corpus.policy import venue_policy
+from research.crypto_stage_b.source import (
+    CryptoStageBInputError,
+    source_from_labeled_corpus,
+)
+
+
+def _corpus(
+    *, session: datetime, consumer_intent: str = "time_series"
+) -> LabeledCorpus:
+    table = pa.table(
+        {
+            "venue": ["upbit_krw"],
+            "symbol": ["KRW-TEST"],
+            "frequency": ["1d"],
+            "bucket_timezone": ["UTC"],
+            "open_time_utc": [session],
+            "open": [100.0],
+            "high": [101.0],
+            "low": [99.0],
+            "close": [100.0],
+            "base_volume": [1.0],
+            "quote_volume": [100.0],
+        }
+    )
+    return LabeledCorpus(
+        table=table,
+        policy=venue_policy("upbit_krw"),
+        source_paths=(Path("/sealed/exploration.parquet"),),
+        consumer_intent=consumer_intent,  # type: ignore[arg-type]
+    )
+
+
+def test_labeled_corpus_adapter_requires_time_series_daily_utc_extract() -> None:
+    source = source_from_labeled_corpus(
+        _corpus(session=datetime(2024, 1, 1, tzinfo=UTC)),
+        exploration_start=date(2024, 1, 1),
+        exploration_end=date(2024, 1, 1),
+    )
+
+    assert source.get("upbit_krw", "KRW-TEST", date(2024, 1, 1)) is not None
+
+
+def test_labeled_corpus_adapter_refuses_outside_window_or_xsec_intent() -> None:
+    with pytest.raises(CryptoStageBInputError, match="outside explicit exploration"):
+        source_from_labeled_corpus(
+            _corpus(session=datetime(2024, 1, 2, tzinfo=UTC)),
+            exploration_start=date(2024, 1, 1),
+            exploration_end=date(2024, 1, 1),
+        )
+    with pytest.raises(CryptoStageBInputError, match="time_series"):
+        source_from_labeled_corpus(
+            _corpus(session=datetime(2024, 1, 1, tzinfo=UTC), consumer_intent="xsec"),
+            exploration_start=date(2024, 1, 1),
+            exploration_end=date(2024, 1, 1),
+        )


### PR DESCRIPTION
## Summary
- parse and SHA-bind the verbatim admitted crypto candidate return
- add isolated daily Stage-B full/ablation execution with UTC boundary access guard
- emit venue × calendar-year harness evidence with frozen cost literals

## Verification
- make lint
- uv run pytest -q research/crypto_stage_b/tests
- verbatim candidate registry SHA/admission check

No corpus backtest was executed; this PR only adds the research engine and synthetic verification.