### PR TITLE
feat(research): add US Stage-B engine

### DIFF
--- a/research/us_stage_b/__init__.py
+++ b/research/us_stage_b/__init__.py
@@ -1,0 +1,29 @@
+"""US-only, exploratory Stage-B engine for frozen survivor-biased candidates."""
+
+from .contracts import USCostLiteral, USStageBRunContract
+from .engine import (
+    CohortComparison,
+    TradeOutcome,
+    USStageBRunResult,
+    liquidity_decile_assignments,
+    rank_signal_observations,
+    run_us_stage_b,
+)
+from .registry import CandidateRegistry
+from .source import InMemoryUSBarSource, USStageBDailyBar
+from .verdict import FalsificationVerdict
+
+__all__ = [
+    "CandidateRegistry",
+    "CohortComparison",
+    "FalsificationVerdict",
+    "InMemoryUSBarSource",
+    "TradeOutcome",
+    "USCostLiteral",
+    "USStageBDailyBar",
+    "USStageBRunContract",
+    "USStageBRunResult",
+    "liquidity_decile_assignments",
+    "rank_signal_observations",
+    "run_us_stage_b",
+]

--- a/research/us_stage_b/__init__.py
+++ b/research/us_stage_b/__init__.py
@@ -11,7 +11,7 @@ from .engine import (
 )
 from .registry import CandidateRegistry
 from .source import InMemoryUSBarSource, USStageBDailyBar
-from .verdict import FalsificationVerdict
+from .verdict import FalsificationVerdict, RevCostProfileVerdicts
 
 __all__ = [
     "CandidateRegistry",
@@ -19,6 +19,7 @@ __all__ = [
     "FalsificationVerdict",
     "InMemoryUSBarSource",
     "TradeOutcome",
+    "RevCostProfileVerdicts",
     "USCostLiteral",
     "USStageBDailyBar",
     "USStageBRunContract",

--- a/research/us_stage_b/contracts.py
+++ b/research/us_stage_b/contracts.py
@@ -1,0 +1,147 @@
+"""Explicit run and cost contracts for the isolated US Stage-B engine."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Final
+
+from research_contracts.canonical_hash import canonical_sha256
+
+from .registry import (
+    FROZEN_CANDIDATES_SHA256,
+    US_CANDIDATE_ORDER,
+    CandidateBinding,
+)
+
+__all__ = [
+    "US_EXPLORATION_END",
+    "US_EXPLORATION_START",
+    "US_HOLDOUT_START",
+    "ExplorationWindowError",
+    "USCostLiteral",
+    "USStageBRunContract",
+]
+
+
+US_EXPLORATION_START: Final = date(2016, 1, 1)
+US_EXPLORATION_END: Final = date(2024, 12, 31)
+US_HOLDOUT_START: Final = date(2025, 1, 1)
+_BASE_BP_PER_SIDE: Final = 10
+_SENSITIVITY_BP_PER_SIDE: Final = 5
+
+
+class ExplorationWindowError(ValueError):
+    """A Stage-B caller attempted an invalid or holdout-intersecting window."""
+
+
+@dataclass(frozen=True)
+class USCostLiteral:
+    """The two operator-frozen US slippage literals, supplied by every caller.
+
+    This class intentionally has no defaults.  A construction site must state
+    both values, and values other than the packet's 10bp/side base and
+    5bp/side sensitivity are rejected before an engine can run.
+    """
+
+    base_bp_per_side: int
+    sensitivity_bp_per_side: int
+
+    def __post_init__(self) -> None:
+        if (
+            self.base_bp_per_side != _BASE_BP_PER_SIDE
+            or self.sensitivity_bp_per_side != _SENSITIVITY_BP_PER_SIDE
+        ):
+            raise ValueError(
+                "US cost literal must be exactly 10bp/side base and 5bp/side "
+                "sensitivity; no engine default is available"
+            )
+
+    @property
+    def base_round_trip_bp(self) -> int:
+        return 2 * self.base_bp_per_side
+
+    @property
+    def sensitivity_round_trip_bp(self) -> int:
+        return 2 * self.sensitivity_bp_per_side
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "base_bp_per_side": self.base_bp_per_side,
+            "base_round_trip_bp": self.base_round_trip_bp,
+            "sensitivity_bp_per_side": self.sensitivity_bp_per_side,
+            "sensitivity_round_trip_bp": self.sensitivity_round_trip_bp,
+        }
+
+
+@dataclass(frozen=True)
+class USStageBRunContract:
+    """One explicit candidate × exploration-window run contract.
+
+    The supplied session index, not a calendar or exchange-calendar import,
+    determines D+N timing in the engine.  The date bounds are access barriers:
+    any window that touches 2025+ is refused before source data is read.
+    """
+
+    candidate: CandidateBinding
+    exploration_start: date
+    exploration_end: date
+    cost: USCostLiteral
+
+    def __post_init__(self) -> None:
+        if isinstance(self.exploration_start, datetime) or isinstance(
+            self.exploration_end, datetime
+        ):
+            raise ExplorationWindowError(
+                "US exploration bounds must be dates, not datetimes"
+            )
+        if self.exploration_start > self.exploration_end:
+            raise ExplorationWindowError("exploration_start is after exploration_end")
+        if self.exploration_start < US_EXPLORATION_START:
+            raise ExplorationWindowError(
+                "US exploration starts no earlier than 2016-01-01"
+            )
+        if self.exploration_end > US_EXPLORATION_END:
+            raise ExplorationWindowError(
+                "US exploration window intersects the 2025+ sealed holdout"
+            )
+        if self.candidate.strategy_id not in US_CANDIDATE_ORDER:
+            raise ValueError("only the three frozen US candidates are executable")
+        if self.candidate.source_packet_sha256 != FROZEN_CANDIDATES_SHA256:
+            raise ValueError("candidate is not bound to the frozen US YAML packet")
+        if (
+            self.candidate.contract_hash
+            != hashlib.sha256(self.candidate.source_block).hexdigest()
+        ):
+            raise ValueError("candidate raw-block contract hash mismatch")
+        if self.candidate.parameter("fixed_notional_usd") != 500:
+            raise ValueError("US fixed-notional contract drift")
+        if self.candidate.parameter("max_positions") != 10:
+            raise ValueError("US max-position contract drift")
+
+    @property
+    def config_hash(self) -> str:
+        return canonical_sha256(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.candidate.stamp(
+            {
+                "engine": "us-stage-b-v1",
+                "exploration_window": {
+                    "start": self.exploration_start.isoformat(),
+                    "end": self.exploration_end.isoformat(),
+                },
+                "session_clock": "corpus_session_index_union_of_survivor_symbols",
+                "entry_timing": "t_plus_1_open",
+                "exit_timing": (
+                    "entry_session_D_plus_"
+                    f"{self.candidate.parameter('hold_sessions')}_session_close"
+                ),
+                "fixed_notional_usd": self.candidate.parameter("fixed_notional_usd"),
+                "max_positions": self.candidate.parameter("max_positions"),
+                "cost_literal": self.cost.to_dict(),
+                "maturity_close_missing": "RUN_INVALID",
+                "survivorship_assumption": "SURVIVORSHIP_BIASED=TRUE",
+            }
+        )

--- a/research/us_stage_b/engine.py
+++ b/research/us_stage_b/engine.py
@@ -663,8 +663,7 @@ def _build_cohort_comparisons(
             )
         entry_index = session_index[outcome.entry_session]
         exit_index = session_index[outcome.exit_session]
-        baseline_base: list[float] = []
-        baseline_sensitivity: list[float] = []
+        baseline_gross: list[float] = []
         excluded_no_fill = 0
         excluded_maturity = 0
         for member in eligible:
@@ -682,19 +681,16 @@ def _build_cohort_comparisons(
                 excluded_maturity += 1
                 continue
             gross = float(exit_bar.adjusted_close) / float(entry_bar.open) - 1.0
-            baseline_base.append(gross - contract.cost.base_round_trip_bp / 10_000)
-            baseline_sensitivity.append(
-                gross - contract.cost.sensitivity_round_trip_bp / 10_000
-            )
-        if baseline_base:
-            base_mean = mean(baseline_base)
-            sensitivity_mean = mean(baseline_sensitivity)
+            # §13 US cost amendment: a counterfactual cohort is gross.  The
+            # frozen 10bp/5bp profiles apply only to selected strategy trades.
+            baseline_gross.append(gross)
+        if baseline_gross:
+            baseline_mean = mean(baseline_gross)
             status: Literal["completed", "cohort_unavailable"] = "completed"
-            base_excess = outcome.base_net_return - base_mean
-            sensitivity_excess = outcome.sensitivity_net_return - sensitivity_mean
+            base_excess = outcome.base_net_return - baseline_mean
+            sensitivity_excess = outcome.sensitivity_net_return - baseline_mean
         else:
-            base_mean = None
-            sensitivity_mean = None
+            baseline_mean = None
             status = "cohort_unavailable"
             base_excess = None
             sensitivity_excess = None
@@ -709,14 +705,14 @@ def _build_cohort_comparisons(
                 exit_session=outcome.exit_session,
                 liquidity_decile=own_decile,
                 eligible_universe_size=len(eligible),
-                leave_one_out_member_count=len(baseline_base),
+                leave_one_out_member_count=len(baseline_gross),
                 excluded_entry_no_fill_count=excluded_no_fill,
                 excluded_maturity_close_count=excluded_maturity,
                 status=status,
                 candidate_base_net_return=outcome.base_net_return,
                 candidate_sensitivity_net_return=outcome.sensitivity_net_return,
-                baseline_base_net_return=base_mean,
-                baseline_sensitivity_net_return=sensitivity_mean,
+                baseline_base_net_return=baseline_mean,
+                baseline_sensitivity_net_return=baseline_mean,
                 base_excess_return=base_excess,
                 sensitivity_excess_return=sensitivity_excess,
                 volume_ratio20=outcome.volume_ratio20,

--- a/research/us_stage_b/engine.py
+++ b/research/us_stage_b/engine.py
@@ -1,0 +1,725 @@
+"""Deterministic US Stage-B execution and cohort-comparison engine.
+
+This module is intentionally isolated from KR, crypto, brokers, accounts,
+databases, schedulers, and shared signal implementations.  It consumes an
+explicit corpus-session index, so every entry and D+N maturity is index-based
+rather than inferred from calendar dates.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from statistics import mean
+from typing import Any, Literal
+
+from .contracts import USStageBRunContract
+from .signals import SignalObservation, evaluate_signal
+from .source import (
+    ExplorationBoundaryAccessSpy,
+    USBarSource,
+    USStageBDailyBar,
+    USStageBInputError,
+)
+
+__all__ = [
+    "CohortComparison",
+    "TradeOutcome",
+    "USStageBRunResult",
+    "USStageBRunError",
+    "liquidity_decile_assignments",
+    "rank_signal_observations",
+    "run_us_stage_b",
+]
+
+
+class USStageBRunError(RuntimeError):
+    """A deterministic run input or invariant cannot be trusted."""
+
+
+OutcomeStatus = Literal[
+    "completed",
+    "entry_no_fill",
+    "capacity_rejected",
+    "censored_at_exploration_boundary",
+    "run_invalid_missing_exit",
+]
+
+
+@dataclass(frozen=True)
+class TradeOutcome:
+    """One post-signal decision, including all non-filled outcomes."""
+
+    strategy_id: str
+    contract_hash: str
+    labels: tuple[str, ...]
+    symbol: str
+    signal_session: date
+    entry_session: date | None
+    exit_session: date | None
+    status: OutcomeStatus
+    selection_rank: int | None
+    fixed_notional_usd: float
+    adv20_pre_proxy: float
+    tie_break_sha256: str
+    entry_open: float | None
+    exit_adjusted_close: float | None
+    gross_return: float | None
+    base_net_return: float | None
+    sensitivity_net_return: float | None
+    volume_ratio20: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "labels": list(self.labels),
+            "symbol": self.symbol,
+            "signal_session": self.signal_session.isoformat(),
+            "entry_session": _date_or_none(self.entry_session),
+            "exit_session": _date_or_none(self.exit_session),
+            "status": self.status,
+            "selection_rank": self.selection_rank,
+            "fixed_notional_usd": self.fixed_notional_usd,
+            "adv20_pre_proxy": self.adv20_pre_proxy,
+            "tie_break_sha256": self.tie_break_sha256,
+            "entry_open": self.entry_open,
+            "exit_adjusted_close": self.exit_adjusted_close,
+            "gross_return": self.gross_return,
+            "base_net_return": self.base_net_return,
+            "sensitivity_net_return": self.sensitivity_net_return,
+            "volume_ratio20": self.volume_ratio20,
+        }
+
+
+@dataclass(frozen=True)
+class CohortComparison:
+    """One leave-one-out, same-session, same-ADV-decile comparison artifact."""
+
+    strategy_id: str
+    contract_hash: str
+    labels: tuple[str, ...]
+    symbol: str
+    signal_session: date
+    entry_session: date
+    exit_session: date
+    liquidity_decile: int
+    eligible_universe_size: int
+    leave_one_out_member_count: int
+    excluded_entry_no_fill_count: int
+    excluded_maturity_close_count: int
+    status: Literal["completed", "cohort_unavailable"]
+    candidate_base_net_return: float
+    candidate_sensitivity_net_return: float
+    baseline_base_net_return: float | None
+    baseline_sensitivity_net_return: float | None
+    base_excess_return: float | None
+    sensitivity_excess_return: float | None
+    volume_ratio20: float | None
+    tie_break_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "labels": list(self.labels),
+            "symbol": self.symbol,
+            "signal_session": self.signal_session.isoformat(),
+            "entry_session": self.entry_session.isoformat(),
+            "exit_session": self.exit_session.isoformat(),
+            "liquidity_decile": self.liquidity_decile,
+            "decile_convention": "self_inclusive_adv_percentile_equal_values",
+            "eligible_universe_size": self.eligible_universe_size,
+            "leave_one_out_member_count": self.leave_one_out_member_count,
+            "excluded_entry_no_fill_count": self.excluded_entry_no_fill_count,
+            "excluded_maturity_close_count": self.excluded_maturity_close_count,
+            "status": self.status,
+            "candidate_base_net_return": self.candidate_base_net_return,
+            "candidate_sensitivity_net_return": self.candidate_sensitivity_net_return,
+            "baseline_base_net_return": self.baseline_base_net_return,
+            "baseline_sensitivity_net_return": self.baseline_sensitivity_net_return,
+            "base_excess_return": self.base_excess_return,
+            "sensitivity_excess_return": self.sensitivity_excess_return,
+            "volume_ratio20": self.volume_ratio20,
+            "tie_break_sha256": self.tie_break_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class USStageBRunResult:
+    """Serializable full run state; an empty result remains explicitly labeled."""
+
+    contract: USStageBRunContract
+    corpus_sessions: tuple[date, ...]
+    observations: tuple[SignalObservation, ...]
+    outcomes: tuple[TradeOutcome, ...]
+    cohorts: tuple[CohortComparison, ...]
+    run_invalid: bool
+    invalid_reasons: tuple[str, ...]
+    access_summary: Mapping[str, int]
+    verdict: Any
+
+    @property
+    def strategy_id(self) -> str:
+        return self.contract.candidate.strategy_id
+
+    @property
+    def contract_hash(self) -> str:
+        return self.contract.candidate.contract_hash
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        return self.contract.candidate.labels
+
+    @property
+    def completed_outcomes(self) -> tuple[TradeOutcome, ...]:
+        return tuple(
+            outcome for outcome in self.outcomes if outcome.status == "completed"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        status_counts = Counter(outcome.status for outcome in self.outcomes)
+        return {
+            "engine": "us-stage-b-v1",
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "labels": list(self.labels),
+            "config_hash": self.contract.config_hash,
+            "input_surface": "caller_supplied_read_only_source",
+            "orders": 0,
+            "account_mutations": 0,
+            "database_writes": 0,
+            "session_clock": "corpus_session_index_union_of_survivor_symbols",
+            "corpus_sessions": [
+                session.isoformat() for session in self.corpus_sessions
+            ],
+            "contract": self.contract.to_dict(),
+            "observations": [item.to_dict() for item in self.observations],
+            "outcomes": [item.to_dict() for item in self.outcomes],
+            "cohort_comparisons": [item.to_dict() for item in self.cohorts],
+            "outcome_status_counts": dict(sorted(status_counts.items())),
+            "run_invalid": self.run_invalid,
+            "invalid_reasons": list(self.invalid_reasons),
+            "maturity_close_missing_policy": "RUN_INVALID",
+            "access_summary": dict(self.access_summary),
+            "verdict": self.verdict.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class _Reservation:
+    symbol: str
+    entry_session: date
+    exit_session: date | None
+
+    def active_at_signal_close(self, session: date) -> bool:
+        """A maturity at this close has finished before a new signal is ranked."""
+
+        return self.entry_session <= session and (
+            self.exit_session is None or session < self.exit_session
+        )
+
+    def active_at_entry_open(self, session: date) -> bool:
+        """A maturity at this session's close still occupies an open-time slot."""
+
+        return self.entry_session <= session and (
+            self.exit_session is None or session <= self.exit_session
+        )
+
+
+def run_us_stage_b(
+    *,
+    source: USBarSource,
+    contract: USStageBRunContract,
+    corpus_sessions: Sequence[date],
+) -> USStageBRunResult:
+    """Run one frozen candidate with explicit index timing and no external I/O.
+
+    A missing selected maturity close is a run-level invalidation.  In contrast,
+    a selected entry with no valid next-session open is an ``entry_no_fill`` and
+    is never replaced by a lower-ranked same-session signal.
+    """
+
+    if contract is None:  # type: ignore[comparison-overlap]
+        raise USStageBRunError("an explicit US Stage-B run contract is required")
+    sessions = _validate_corpus_sessions(corpus_sessions, contract)
+    symbols = _validate_symbols(source.symbols())
+    boundary_source = ExplorationBoundaryAccessSpy(
+        source,
+        exploration_start=contract.exploration_start,
+        exploration_end=contract.exploration_end,
+    )
+    bars_by_symbol = _load_aligned_bars(boundary_source, symbols, sessions)
+
+    observations: list[SignalObservation] = []
+    outcomes: list[TradeOutcome] = []
+    reservations: list[_Reservation] = []
+    invalid_reasons: list[str] = []
+    hold_sessions = _required_positive_int(contract, "hold_sessions")
+    max_positions = _required_positive_int(contract, "max_positions")
+
+    for session_index, session in enumerate(sessions):
+        active_symbols = {
+            reservation.symbol
+            for reservation in reservations
+            if reservation.active_at_signal_close(session)
+        }
+        daily_signals: list[SignalObservation] = []
+        for symbol in symbols:
+            observation = evaluate_signal(
+                contract.candidate,
+                symbol=symbol,
+                session_date=session,
+                history=bars_by_symbol[symbol][: session_index + 1],
+                no_active_position=symbol not in active_symbols,
+            )
+            observations.append(observation)
+            if observation.signal:
+                daily_signals.append(observation)
+
+        if not daily_signals:
+            continue
+        if session_index + 1 >= len(sessions):
+            outcomes.extend(
+                _outcome(
+                    contract,
+                    observation,
+                    status="censored_at_exploration_boundary",
+                    selection_rank=None,
+                    entry_session=None,
+                )
+                for observation in rank_signal_observations(daily_signals)
+            )
+            continue
+
+        entry_session = sessions[session_index + 1]
+        active_at_entry = sum(
+            reservation.active_at_entry_open(entry_session)
+            for reservation in reservations
+        )
+        if active_at_entry > max_positions:
+            raise USStageBRunError(
+                "existing reservations exceed the frozen max positions"
+            )
+        ranked = rank_signal_observations(daily_signals)
+        selected = ranked[: max_positions - active_at_entry]
+        rejected = ranked[max_positions - active_at_entry :]
+
+        for rank, observation in enumerate(selected, start=1):
+            outcome, reservation, invalid_reason = _execute_selected_signal(
+                contract=contract,
+                observation=observation,
+                bars=bars_by_symbol[observation.symbol],
+                entry_index=session_index + 1,
+                exit_index=session_index + 1 + hold_sessions,
+                sessions=sessions,
+                selection_rank=rank,
+            )
+            outcomes.append(outcome)
+            if reservation is not None:
+                reservations.append(reservation)
+            if invalid_reason is not None:
+                invalid_reasons.append(invalid_reason)
+        outcomes.extend(
+            _outcome(
+                contract,
+                observation,
+                status="capacity_rejected",
+                selection_rank=None,
+                entry_session=entry_session,
+            )
+            for observation in rejected
+        )
+
+    boundary_source.assert_no_outside_access()
+    cohorts = _build_cohort_comparisons(
+        contract=contract,
+        outcomes=tuple(outcomes),
+        observations=tuple(observations),
+        bars_by_symbol=bars_by_symbol,
+        sessions=sessions,
+    )
+    from .verdict import evaluate_falsification
+
+    verdict = evaluate_falsification(
+        candidate=contract.candidate,
+        outcomes=tuple(outcomes),
+        cohorts=cohorts,
+        run_invalid=bool(invalid_reasons),
+        invalid_reasons=tuple(invalid_reasons),
+    )
+    return USStageBRunResult(
+        contract=contract,
+        corpus_sessions=sessions,
+        observations=tuple(observations),
+        outcomes=tuple(outcomes),
+        cohorts=cohorts,
+        run_invalid=bool(invalid_reasons),
+        invalid_reasons=tuple(invalid_reasons),
+        access_summary=boundary_source.summary(),
+        verdict=verdict,
+    )
+
+
+def rank_signal_observations(
+    observations: Sequence[SignalObservation],
+) -> tuple[SignalObservation, ...]:
+    """Rank only by ADV20-pre descending, then the packet SHA-byte tie break."""
+
+    if any(not observation.signal for observation in observations):
+        raise USStageBRunError("only true signal observations may enter ranking")
+    digests = [observation.tie_break_sha256 for observation in observations]
+    if len(set(digests)) != len(digests):
+        raise USStageBRunError("SHA tie-break collision; no extra fallback is allowed")
+    return tuple(
+        sorted(
+            observations,
+            key=lambda observation: (
+                -_required_adv(observation),
+                bytes.fromhex(observation.tie_break_sha256),
+            ),
+        )
+    )
+
+
+def liquidity_decile_assignments(
+    observations: Sequence[SignalObservation],
+) -> Mapping[str, int]:
+    """Assign same-session ADV deciles without a non-packet ranking fallback.
+
+    Equal ADV values receive the same self-inclusive percentile and therefore
+    the same decile.  Sparse samples stay sparse instead of being silently
+    filled into a cohort; this makes an unavailable leave-one-out baseline
+    visible to the falsification gate.
+    """
+
+    if not observations:
+        return {}
+    if any(not observation.universe_eligible for observation in observations):
+        raise USStageBRunError("liquidity deciles require eligible observations only")
+    values = [_required_adv(observation) for observation in observations]
+    count = len(values)
+    result: dict[str, int] = {}
+    for observation, value in zip(observations, values, strict=True):
+        percentile = sum(other <= value for other in values) / count
+        decile = min(9, max(0, math.ceil(percentile * 10) - 1))
+        result[observation.symbol] = decile
+    return result
+
+
+def _validate_corpus_sessions(
+    corpus_sessions: Sequence[date], contract: USStageBRunContract
+) -> tuple[date, ...]:
+    sessions = tuple(corpus_sessions)
+    if not sessions:
+        raise USStageBRunError("corpus session index is empty")
+    if any(
+        isinstance(session, datetime) or not isinstance(session, date)
+        for session in sessions
+    ):
+        raise USStageBRunError("corpus session index requires date values")
+    if tuple(sorted(sessions)) != sessions or len(set(sessions)) != len(sessions):
+        raise USStageBRunError(
+            "corpus session index must be strictly ascending and unique"
+        )
+    if (
+        sessions[0] < contract.exploration_start
+        or sessions[-1] > contract.exploration_end
+    ):
+        raise USStageBRunError("corpus session index falls outside the explicit window")
+    return sessions
+
+
+def _validate_symbols(raw_symbols: Sequence[str]) -> tuple[str, ...]:
+    if any(not isinstance(symbol, str) or not symbol for symbol in raw_symbols):
+        raise USStageBInputError("US Stage-B source returned an invalid symbol")
+    if len(set(raw_symbols)) != len(raw_symbols):
+        raise USStageBInputError("US Stage-B source returned duplicate symbols")
+    return tuple(sorted(raw_symbols))
+
+
+def _load_aligned_bars(
+    source: ExplorationBoundaryAccessSpy,
+    symbols: Sequence[str],
+    sessions: Sequence[date],
+) -> dict[str, tuple[USStageBDailyBar | None, ...]]:
+    rows: dict[str, tuple[USStageBDailyBar | None, ...]] = {}
+    for symbol in symbols:
+        aligned: list[USStageBDailyBar | None] = []
+        for session in sessions:
+            bar = source.get(symbol, session)
+            if bar is not None and (
+                bar.symbol != symbol or bar.session_date != session
+            ):
+                raise USStageBInputError(
+                    "US Stage-B source returned a bar outside its requested identity"
+                )
+            aligned.append(bar)
+        rows[symbol] = tuple(aligned)
+    return rows
+
+
+def _execute_selected_signal(
+    *,
+    contract: USStageBRunContract,
+    observation: SignalObservation,
+    bars: Sequence[USStageBDailyBar | None],
+    entry_index: int,
+    exit_index: int,
+    sessions: Sequence[date],
+    selection_rank: int,
+) -> tuple[TradeOutcome, _Reservation | None, str | None]:
+    entry_session = sessions[entry_index]
+    entry_bar = bars[entry_index]
+    if entry_bar is None or not _finite_positive(entry_bar.open):
+        return (
+            _outcome(
+                contract,
+                observation,
+                status="entry_no_fill",
+                selection_rank=selection_rank,
+                entry_session=entry_session,
+            ),
+            None,
+            None,
+        )
+    entry_open = float(entry_bar.open)
+    if exit_index >= len(sessions):
+        return (
+            _outcome(
+                contract,
+                observation,
+                status="censored_at_exploration_boundary",
+                selection_rank=selection_rank,
+                entry_session=entry_session,
+                entry_open=entry_open,
+            ),
+            _Reservation(
+                symbol=observation.symbol,
+                entry_session=entry_session,
+                exit_session=None,
+            ),
+            None,
+        )
+    exit_session = sessions[exit_index]
+    exit_bar = bars[exit_index]
+    reservation = _Reservation(
+        symbol=observation.symbol,
+        entry_session=entry_session,
+        exit_session=exit_session,
+    )
+    if exit_bar is None or not _finite_positive(exit_bar.adjusted_close):
+        reason = (
+            f"RUN_INVALID_MISSING_EXIT:{observation.symbol}:{exit_session.isoformat()}"
+        )
+        return (
+            _outcome(
+                contract,
+                observation,
+                status="run_invalid_missing_exit",
+                selection_rank=selection_rank,
+                entry_session=entry_session,
+                exit_session=exit_session,
+                entry_open=entry_open,
+            ),
+            reservation,
+            reason,
+        )
+    exit_adjusted_close = float(exit_bar.adjusted_close)
+    gross_return = exit_adjusted_close / entry_open - 1.0
+    return (
+        _outcome(
+            contract,
+            observation,
+            status="completed",
+            selection_rank=selection_rank,
+            entry_session=entry_session,
+            exit_session=exit_session,
+            entry_open=entry_open,
+            exit_adjusted_close=exit_adjusted_close,
+            gross_return=gross_return,
+            base_net_return=(gross_return - contract.cost.base_round_trip_bp / 10_000),
+            sensitivity_net_return=(
+                gross_return - contract.cost.sensitivity_round_trip_bp / 10_000
+            ),
+        ),
+        reservation,
+        None,
+    )
+
+
+def _outcome(
+    contract: USStageBRunContract,
+    observation: SignalObservation,
+    *,
+    status: OutcomeStatus,
+    selection_rank: int | None,
+    entry_session: date | None,
+    exit_session: date | None = None,
+    entry_open: float | None = None,
+    exit_adjusted_close: float | None = None,
+    gross_return: float | None = None,
+    base_net_return: float | None = None,
+    sensitivity_net_return: float | None = None,
+) -> TradeOutcome:
+    adv20_pre_proxy = _required_adv(observation)
+    volume_ratio = observation.metrics.get("volume_ratio20")
+    return TradeOutcome(
+        strategy_id=contract.candidate.strategy_id,
+        contract_hash=contract.candidate.contract_hash,
+        labels=contract.candidate.labels,
+        symbol=observation.symbol,
+        signal_session=observation.session_date,
+        entry_session=entry_session,
+        exit_session=exit_session,
+        status=status,
+        selection_rank=selection_rank,
+        fixed_notional_usd=float(contract.candidate.parameter("fixed_notional_usd")),
+        adv20_pre_proxy=adv20_pre_proxy,
+        tie_break_sha256=observation.tie_break_sha256,
+        entry_open=entry_open,
+        exit_adjusted_close=exit_adjusted_close,
+        gross_return=gross_return,
+        base_net_return=base_net_return,
+        sensitivity_net_return=sensitivity_net_return,
+        volume_ratio20=volume_ratio,
+    )
+
+
+def _build_cohort_comparisons(
+    *,
+    contract: USStageBRunContract,
+    outcomes: Sequence[TradeOutcome],
+    observations: Sequence[SignalObservation],
+    bars_by_symbol: Mapping[str, Sequence[USStageBDailyBar | None]],
+    sessions: Sequence[date],
+) -> tuple[CohortComparison, ...]:
+    observations_by_session: dict[date, list[SignalObservation]] = defaultdict(list)
+    observation_by_identity: dict[tuple[date, str], SignalObservation] = {}
+    for observation in observations:
+        observations_by_session[observation.session_date].append(observation)
+        observation_by_identity[(observation.session_date, observation.symbol)] = (
+            observation
+        )
+    session_index = {session: index for index, session in enumerate(sessions)}
+    comparisons: list[CohortComparison] = []
+    for outcome in outcomes:
+        if outcome.status != "completed":
+            continue
+        if (
+            outcome.entry_session is None
+            or outcome.exit_session is None
+            or outcome.base_net_return is None
+            or outcome.sensitivity_net_return is None
+        ):
+            raise USStageBRunError("completed outcome lacks a resolved return identity")
+        own_observation = observation_by_identity.get(
+            (outcome.signal_session, outcome.symbol)
+        )
+        if own_observation is None:
+            raise USStageBRunError("completed outcome has no source observation")
+        eligible = tuple(
+            observation
+            for observation in observations_by_session[outcome.signal_session]
+            if observation.universe_eligible
+        )
+        assignments = liquidity_decile_assignments(eligible)
+        own_decile = assignments.get(outcome.symbol)
+        if own_decile is None:
+            raise USStageBRunError(
+                "completed outcome is absent from its eligible cohort"
+            )
+        entry_index = session_index[outcome.entry_session]
+        exit_index = session_index[outcome.exit_session]
+        baseline_base: list[float] = []
+        baseline_sensitivity: list[float] = []
+        excluded_no_fill = 0
+        excluded_maturity = 0
+        for member in eligible:
+            if (
+                member.symbol == outcome.symbol
+                or assignments[member.symbol] != own_decile
+            ):
+                continue
+            entry_bar = bars_by_symbol[member.symbol][entry_index]
+            if entry_bar is None or not _finite_positive(entry_bar.open):
+                excluded_no_fill += 1
+                continue
+            exit_bar = bars_by_symbol[member.symbol][exit_index]
+            if exit_bar is None or not _finite_positive(exit_bar.adjusted_close):
+                excluded_maturity += 1
+                continue
+            gross = float(exit_bar.adjusted_close) / float(entry_bar.open) - 1.0
+            baseline_base.append(gross - contract.cost.base_round_trip_bp / 10_000)
+            baseline_sensitivity.append(
+                gross - contract.cost.sensitivity_round_trip_bp / 10_000
+            )
+        if baseline_base:
+            base_mean = mean(baseline_base)
+            sensitivity_mean = mean(baseline_sensitivity)
+            status: Literal["completed", "cohort_unavailable"] = "completed"
+            base_excess = outcome.base_net_return - base_mean
+            sensitivity_excess = outcome.sensitivity_net_return - sensitivity_mean
+        else:
+            base_mean = None
+            sensitivity_mean = None
+            status = "cohort_unavailable"
+            base_excess = None
+            sensitivity_excess = None
+        comparisons.append(
+            CohortComparison(
+                strategy_id=contract.candidate.strategy_id,
+                contract_hash=contract.candidate.contract_hash,
+                labels=contract.candidate.labels,
+                symbol=outcome.symbol,
+                signal_session=outcome.signal_session,
+                entry_session=outcome.entry_session,
+                exit_session=outcome.exit_session,
+                liquidity_decile=own_decile,
+                eligible_universe_size=len(eligible),
+                leave_one_out_member_count=len(baseline_base),
+                excluded_entry_no_fill_count=excluded_no_fill,
+                excluded_maturity_close_count=excluded_maturity,
+                status=status,
+                candidate_base_net_return=outcome.base_net_return,
+                candidate_sensitivity_net_return=outcome.sensitivity_net_return,
+                baseline_base_net_return=base_mean,
+                baseline_sensitivity_net_return=sensitivity_mean,
+                base_excess_return=base_excess,
+                sensitivity_excess_return=sensitivity_excess,
+                volume_ratio20=outcome.volume_ratio20,
+                tie_break_sha256=outcome.tie_break_sha256,
+            )
+        )
+    return tuple(comparisons)
+
+
+def _required_positive_int(contract: USStageBRunContract, name: str) -> int:
+    value = contract.candidate.parameter(name)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise USStageBRunError(f"frozen parameter {name!r} is not a positive integer")
+    return value
+
+
+def _required_adv(observation: SignalObservation) -> float:
+    if observation.adv20_pre_proxy is None or not math.isfinite(
+        observation.adv20_pre_proxy
+    ):
+        raise USStageBRunError("rankable observation lacks a finite ADV20-pre proxy")
+    return observation.adv20_pre_proxy
+
+
+def _finite_positive(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int | float)
+        and math.isfinite(float(value))
+        and float(value) > 0.0
+    )
+
+
+def _date_or_none(value: date | None) -> str | None:
+    return value.isoformat() if value is not None else None

--- a/research/us_stage_b/engine.py
+++ b/research/us_stage_b/engine.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
 from statistics import mean
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from .contracts import USStageBRunContract
 from .signals import SignalObservation, evaluate_signal
@@ -24,6 +24,9 @@ from .source import (
     USStageBDailyBar,
     USStageBInputError,
 )
+
+if TYPE_CHECKING:
+    from .verdict import FalsificationVerdict, RevCostProfileVerdicts
 
 __all__ = [
     "CohortComparison",
@@ -44,7 +47,6 @@ OutcomeStatus = Literal[
     "completed",
     "entry_no_fill",
     "capacity_rejected",
-    "censored_at_exploration_boundary",
     "run_invalid_missing_exit",
 ]
 
@@ -160,7 +162,23 @@ class USStageBRunResult:
     run_invalid: bool
     invalid_reasons: tuple[str, ...]
     access_summary: Mapping[str, int]
-    verdict: Any
+    verdict: FalsificationVerdict
+    cost_profile_verdicts: RevCostProfileVerdicts | None
+
+    def __post_init__(self) -> None:
+        is_rev = self.strategy_id == "US-TS-REV-SHORT-Z3-T126-H3-v1"
+        if is_rev != (self.cost_profile_verdicts is not None):
+            raise USStageBRunError(
+                "REV runs must retain both frozen cost-profile verdicts"
+            )
+        if self.cost_profile_verdicts is not None:
+            base = self.cost_profile_verdicts.base_10bp_per_side
+            if (
+                base.strategy_id != self.strategy_id
+                or base.contract_hash != self.contract_hash
+                or base.labels != self.labels
+            ):
+                raise USStageBRunError("cost-profile verdict provenance mismatch")
 
     @property
     def strategy_id(self) -> str:
@@ -206,6 +224,11 @@ class USStageBRunResult:
             "maturity_close_missing_policy": "RUN_INVALID",
             "access_summary": dict(self.access_summary),
             "verdict": self.verdict.to_dict(),
+            "cost_profile_verdicts": (
+                self.cost_profile_verdicts.to_dict()
+                if self.cost_profile_verdicts is not None
+                else None
+            ),
         }
 
 
@@ -287,7 +310,7 @@ def run_us_stage_b(
                 _outcome(
                     contract,
                     observation,
-                    status="censored_at_exploration_boundary",
+                    status="entry_no_fill",
                     selection_rank=None,
                     entry_session=None,
                 )
@@ -342,9 +365,9 @@ def run_us_stage_b(
         bars_by_symbol=bars_by_symbol,
         sessions=sessions,
     )
-    from .verdict import evaluate_falsification
+    from .verdict import evaluate_falsification_evidence
 
-    verdict = evaluate_falsification(
+    evaluation = evaluate_falsification_evidence(
         candidate=contract.candidate,
         outcomes=tuple(outcomes),
         cohorts=cohorts,
@@ -360,7 +383,8 @@ def run_us_stage_b(
         run_invalid=bool(invalid_reasons),
         invalid_reasons=tuple(invalid_reasons),
         access_summary=boundary_source.summary(),
-        verdict=verdict,
+        verdict=evaluation.verdict,
+        cost_profile_verdicts=evaluation.cost_profile_verdicts,
     )
 
 
@@ -488,11 +512,16 @@ def _execute_selected_signal(
         )
     entry_open = float(entry_bar.open)
     if exit_index >= len(sessions):
+        reason = (
+            "RUN_INVALID_MISSING_EXIT_TERMINAL:"
+            f"{observation.symbol}:entry={entry_session.isoformat()}:"
+            f"required_exit_session_index={exit_index}"
+        )
         return (
             _outcome(
                 contract,
                 observation,
-                status="censored_at_exploration_boundary",
+                status="run_invalid_missing_exit",
                 selection_rank=selection_rank,
                 entry_session=entry_session,
                 entry_open=entry_open,
@@ -502,7 +531,7 @@ def _execute_selected_signal(
                 entry_session=entry_session,
                 exit_session=None,
             ),
-            None,
+            reason,
         )
     exit_session = sessions[exit_index]
     exit_bar = bars[exit_index]

--- a/research/us_stage_b/registry.py
+++ b/research/us_stage_b/registry.py
@@ -1,0 +1,426 @@
+"""Verbatim-bound registry for the three frozen US Stage-B candidates.
+
+The packet YAML is the only configuration authority.  This module reads the
+original bytes, verifies the packet digest *before* parsing, and derives each
+candidate's contract hash from its raw YAML list-item bytes.  Formula values
+are consumed from the parsed binding by the US-only signal engine; there is no
+fallback to a shared US signal function.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final
+
+import yaml
+
+__all__ = [
+    "FROZEN_CANDIDATES_SHA256",
+    "US_CANDIDATE_ORDER",
+    "CandidateBinding",
+    "CandidateRegistry",
+    "RegistryStartRejected",
+    "mandatory_labels",
+]
+
+
+FROZEN_CANDIDATES_SHA256: Final = (
+    "0f5e92bf7d10dd77588fa08ad949811a68004cf71dd7f2efd232306b22d82d85"
+)
+"""SHA-256 of the frozen ``02-active-candidates.yaml`` packet."""
+
+US_CANDIDATE_ORDER: Final[tuple[str, ...]] = (
+    "US-TS-MOM-CONT-Z126-H20-v1",
+    "US-TS-REV-SHORT-Z3-T126-H3-v1",
+    "US-TS-VOLBREAK-C55-V2-H10-v1",
+)
+
+_COMMON_LABELS: Final[tuple[str, ...]] = (
+    "EXPLORATORY_FALSIFICATION_ONLY",
+    "SURVIVORSHIP_BIASED=TRUE",
+    "PIT_DELIST_MISSING",
+    "EXECUTION_ENVELOPE_UNBOUND",
+)
+_VOLBREAK_LABEL: Final = "VOLUME_CA_UNRESOLVED"
+
+# These checks bind the three explicit code paths to the packet's parsed values.
+# They are guards, not a second configuration source: signal evaluation fetches
+# every value from ``CandidateBinding.parameters`` at runtime.
+_EXPECTED_PARAMETERS: Final[Mapping[str, Mapping[str, int | float]]] = {
+    "US-TS-MOM-CONT-Z126-H20-v1": {
+        "adv20_min_usd": 5_000_000,
+        "trend_lookback_sessions": 126,
+        "trend_vol_lookback_sessions": 63,
+        "trend_z_min": 1.0,
+        "confirmation_lookback_sessions": 21,
+        "confirmation_return_min": 0.0,
+        "sma_lookback_sessions": 63,
+        "hold_sessions": 20,
+        "fixed_notional_usd": 500,
+        "max_positions": 10,
+    },
+    "US-TS-REV-SHORT-Z3-T126-H3-v1": {
+        "adv20_min_usd": 5_000_000,
+        "shock_lookback_sessions": 3,
+        "shock_vol_lookback_sessions": 60,
+        "shock_z_max": -2.0,
+        "trend_lookback_sessions": 126,
+        "trend_return_min": 0.0,
+        "hold_sessions": 3,
+        "fixed_notional_usd": 500,
+        "max_positions": 10,
+    },
+    "US-TS-VOLBREAK-C55-V2-H10-v1": {
+        "adv20_min_usd": 5_000_000,
+        "breakout_lookback_sessions": 55,
+        "volume_lookback_sessions": 20,
+        "volume_ratio_min": 2.0,
+        "volume_ratio_max": 10.0,
+        "daily_return_min": 0.0,
+        "hold_sessions": 10,
+        "fixed_notional_usd": 500,
+        "max_positions": 10,
+    },
+}
+
+_REQUIRED_TEXT: Final[Mapping[str, Mapping[str, tuple[str, ...]]]] = {
+    "US-TS-MOM-CONT-Z126-H20-v1": {
+        "signal": (
+            "R126=",
+            "z126=",
+            "sigma63",
+            "sqrt(126)",
+            "R21",
+            "SMA63",
+            "no_active_position",
+        ),
+        "exit": ("D+20", "corpus session index"),
+        "ranking": ("ADV20_pre_proxy", "수익률·z126·신호강도 횡단면 순위 금지"),
+    },
+    "US-TS-REV-SHORT-Z3-T126-H3-v1": {
+        "signal": ("R3=", "z3=", "sigma60", "sqrt(3)", "R126", "no_active_position"),
+        "exit": ("D+3",),
+        "ranking": ("ADV20_pre_proxy", "하락폭·z3 우선 금지"),
+    },
+    "US-TS-VOLBREAK-C55-V2-H10-v1": {
+        "signal": (
+            "prior_close_high55",
+            "volume_ratio20",
+            "R1",
+            "high/low 미사용",
+            "no_active_position",
+        ),
+        "exit": ("D+10",),
+        "ranking": ("ADV20_pre_proxy",),
+    },
+}
+
+
+class RegistryStartRejected(RuntimeError):
+    """A packet is unsealed, malformed, or drifts from the exact US contract."""
+
+
+def mandatory_labels(strategy_id: str) -> tuple[str, ...]:
+    """Return literal, candidate-scoped caution labels for every output."""
+
+    if strategy_id not in US_CANDIDATE_ORDER:
+        raise RegistryStartRejected(
+            f"unsupported strategy_id {strategy_id!r}; shared fallback is forbidden"
+        )
+    if strategy_id == "US-TS-VOLBREAK-C55-V2-H10-v1":
+        return (*_COMMON_LABELS, _VOLBREAK_LABEL)
+    return _COMMON_LABELS
+
+
+@dataclass(frozen=True)
+class CandidateBinding:
+    """One source-parsed US candidate plus its immutable raw-byte identity."""
+
+    strategy_id: str
+    contract_hash: str
+    source_packet_sha256: str
+    source_block: bytes
+    family_id: str
+    parameters: Mapping[str, int | float]
+    side: str
+    universe_filter: str
+    signal: str
+    required_history: str
+    missing_data_handling: str
+    entry: str
+    exit: str
+    ranking: str
+    tie_break: str
+    sizing: str
+    falsification: str
+    execution_envelope: str
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        return mandatory_labels(self.strategy_id)
+
+    def parameter(self, name: str) -> int | float:
+        """Read one packet-derived parameter without injecting a fallback."""
+
+        try:
+            return self.parameters[name]
+        except KeyError as exc:
+            raise RegistryStartRejected(
+                f"{self.strategy_id} lacks packet parameter {name!r}"
+            ) from exc
+
+    def stamp(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        """Return a JSON-safe payload whose immutable identity cannot be replaced."""
+
+        return {
+            **dict(payload),
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "labels": list(self.labels),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the parsed packet contract with mandatory provenance."""
+
+        return self.stamp(
+            {
+                "source_packet_sha256": self.source_packet_sha256,
+                "family_id": self.family_id,
+                "side": self.side,
+                "parameter_values": dict(self.parameters),
+                "universe_filter": self.universe_filter,
+                "signal": self.signal,
+                "required_history": self.required_history,
+                "missing_data_handling": self.missing_data_handling,
+                "entry": self.entry,
+                "exit": self.exit,
+                "ranking": self.ranking,
+                "tie_break": self.tie_break,
+                "sizing": self.sizing,
+                "falsification": self.falsification,
+                "execution_envelope": self.execution_envelope,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class CandidateRegistry:
+    """Exact US-only registry produced from verified original YAML bytes."""
+
+    source_packet_sha256: str
+    candidates: Mapping[str, CandidateBinding]
+
+    @classmethod
+    def load(
+        cls,
+        candidates_yaml: Path | str,
+        *,
+        expected_sha256: str = FROZEN_CANDIDATES_SHA256,
+    ) -> CandidateRegistry:
+        """Read bytes and bind the parsed candidates only after SHA verification."""
+
+        path = Path(candidates_yaml)
+        if not path.is_file():
+            raise RegistryStartRejected(f"frozen candidates YAML is not a file: {path}")
+        try:
+            source = path.read_bytes()
+        except OSError as exc:
+            raise RegistryStartRejected(
+                f"cannot read frozen candidates YAML: {path}"
+            ) from exc
+        return cls.from_verbatim_bytes(source, expected_sha256=expected_sha256)
+
+    @classmethod
+    def from_verbatim_bytes(
+        cls,
+        source: bytes,
+        *,
+        expected_sha256: str,
+    ) -> CandidateRegistry:
+        """Verify and parse the exact byte stream; no hand-transcribed path exists."""
+
+        actual_sha256 = hashlib.sha256(source).hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise RegistryStartRejected(
+                "frozen candidates YAML SHA mismatch: "
+                f"expected={expected_sha256} actual={actual_sha256}"
+            )
+        try:
+            parsed = yaml.safe_load(source)
+        except yaml.YAMLError as exc:
+            raise RegistryStartRejected("frozen candidates YAML parse failed") from exc
+        if not isinstance(parsed, Mapping):
+            raise RegistryStartRejected("frozen candidates YAML root is not a mapping")
+        raw_candidates = parsed.get("candidates")
+        if not isinstance(raw_candidates, list):
+            raise RegistryStartRejected(
+                "frozen candidates YAML lacks a candidates list"
+            )
+        raw_blocks = _candidate_block_bytes(source)
+        if len(raw_candidates) != len(raw_blocks):
+            raise RegistryStartRejected("YAML candidate/list-item byte count mismatch")
+
+        candidates: dict[str, CandidateBinding] = {}
+        for raw, block in zip(raw_candidates, raw_blocks, strict=True):
+            if not isinstance(raw, Mapping):
+                raise RegistryStartRejected("candidate YAML item is not a mapping")
+            if raw.get("market") != "US":
+                continue
+            binding = _binding_from_raw(
+                raw,
+                source_block=block,
+                source_packet_sha256=actual_sha256,
+            )
+            if binding.strategy_id in candidates:
+                raise RegistryStartRejected(
+                    f"duplicate US strategy_id {binding.strategy_id!r}"
+                )
+            candidates[binding.strategy_id] = binding
+
+        if tuple(candidates) != US_CANDIDATE_ORDER:
+            raise RegistryStartRejected(
+                "US candidate order/id drift: "
+                f"expected={US_CANDIDATE_ORDER!r} actual={tuple(candidates)!r}"
+            )
+        for binding in candidates.values():
+            _assert_exact_contract(binding)
+        return cls(
+            source_packet_sha256=actual_sha256,
+            candidates=MappingProxyType(candidates),
+        )
+
+    @property
+    def admitted(self) -> tuple[CandidateBinding, ...]:
+        """Return the three frozen candidates in the packet's declared order."""
+
+        return tuple(self.candidates[strategy_id] for strategy_id in US_CANDIDATE_ORDER)
+
+    def binding_for(self, strategy_id: str) -> CandidateBinding:
+        """Look up one exact candidate; family/name fallbacks are forbidden."""
+
+        try:
+            return self.candidates[strategy_id]
+        except KeyError as exc:
+            raise RegistryStartRejected(
+                f"unsupported strategy_id {strategy_id!r}; shared fallback is forbidden"
+            ) from exc
+
+
+def _candidate_block_bytes(source: bytes) -> tuple[bytes, ...]:
+    """Return exact top-level candidate list-item ranges from packet bytes."""
+
+    lines = source.splitlines(keepends=True)
+    offsets: list[int] = []
+    offset = 0
+    for line in lines:
+        if line.startswith(b"  - market:"):
+            offsets.append(offset)
+        offset += len(line)
+    if not offsets:
+        raise RegistryStartRejected("frozen candidates YAML has no candidate blocks")
+    ends = (*offsets[1:], len(source))
+    return tuple(source[start:end] for start, end in zip(offsets, ends, strict=True))
+
+
+def _binding_from_raw(
+    raw: Mapping[str, Any],
+    *,
+    source_block: bytes,
+    source_packet_sha256: str,
+) -> CandidateBinding:
+    strategy_id = raw.get("strategy_id")
+    parameters = raw.get("parameter_values")
+    required_text_fields = (
+        "side",
+        "universe_filter",
+        "signal",
+        "required_history",
+        "missing_data_handling",
+        "entry",
+        "exit",
+        "ranking",
+        "tie_break",
+        "sizing",
+        "falsification",
+        "execution_envelope",
+    )
+    if not isinstance(strategy_id, str) or not strategy_id:
+        raise RegistryStartRejected("US candidate lacks a non-empty strategy_id")
+    if not isinstance(parameters, Mapping):
+        raise RegistryStartRejected(f"{strategy_id} lacks parameter_values")
+    if any(not isinstance(raw.get(field), str) for field in required_text_fields):
+        raise RegistryStartRejected(f"{strategy_id} has a non-string contract field")
+    raw_family = raw.get("family_id")
+    if (
+        not isinstance(raw_family, Mapping)
+        or raw_family.get("status") != "SOURCE_PROVIDED"
+        or not isinstance(raw_family.get("value"), str)
+        or not raw_family["value"]
+    ):
+        raise RegistryStartRejected(f"{strategy_id} has an invalid family_id binding")
+
+    normalized_parameters: dict[str, int | float] = {}
+    for name, value in parameters.items():
+        if (
+            not isinstance(name, str)
+            or isinstance(value, bool)
+            or not isinstance(value, int | float)
+        ):
+            raise RegistryStartRejected(
+                f"{strategy_id} has a non-numeric packet parameter {name!r}"
+            )
+        normalized_parameters[name] = value
+    return CandidateBinding(
+        strategy_id=strategy_id,
+        contract_hash=hashlib.sha256(source_block).hexdigest(),
+        source_packet_sha256=source_packet_sha256,
+        source_block=source_block,
+        family_id=str(raw_family["value"]),
+        parameters=MappingProxyType(normalized_parameters),
+        side=str(raw["side"]),
+        universe_filter=str(raw["universe_filter"]),
+        signal=str(raw["signal"]),
+        required_history=str(raw["required_history"]),
+        missing_data_handling=str(raw["missing_data_handling"]),
+        entry=str(raw["entry"]),
+        exit=str(raw["exit"]),
+        ranking=str(raw["ranking"]),
+        tie_break=str(raw["tie_break"]),
+        sizing=str(raw["sizing"]),
+        falsification=str(raw["falsification"]),
+        execution_envelope=str(raw["execution_envelope"]),
+    )
+
+
+def _assert_exact_contract(binding: CandidateBinding) -> None:
+    """Reject a parsed packet whose semantics no longer match a code branch."""
+
+    expected_parameters = _EXPECTED_PARAMETERS.get(binding.strategy_id)
+    if expected_parameters is None:
+        raise RegistryStartRejected(
+            f"no exact US implementation exists for {binding.strategy_id!r}"
+        )
+    if dict(binding.parameters) != dict(expected_parameters):
+        raise RegistryStartRejected(
+            f"{binding.strategy_id} parameter/code binding mismatch"
+        )
+    if binding.side != "long" or binding.entry != "t_plus_1_open":
+        raise RegistryStartRejected(f"{binding.strategy_id} side/entry contract drift")
+    if "run-invalid" not in binding.missing_data_handling:
+        raise RegistryStartRejected(
+            f"{binding.strategy_id} must keep missing maturity close as run-invalid"
+        )
+    if "sha256" not in binding.tie_break:
+        raise RegistryStartRejected(f"{binding.strategy_id} tie-break contract drift")
+    if "ADV20_pre_proxy" not in binding.ranking:
+        raise RegistryStartRejected(f"{binding.strategy_id} ranking contract drift")
+    for field, tokens in _REQUIRED_TEXT[binding.strategy_id].items():
+        value = getattr(binding, field)
+        if any(token not in value for token in tokens):
+            raise RegistryStartRejected(
+                f"{binding.strategy_id} {field} semantic binding mismatch"
+            )

--- a/research/us_stage_b/signals.py
+++ b/research/us_stage_b/signals.py
@@ -1,0 +1,605 @@
+"""Exact, US-only signal calculations for the frozen Stage-B candidates.
+
+All time offsets refer to the caller-supplied corpus-session index.  Formula
+parameters come from the parsed packet binding, while shared US signal helpers
+are deliberately neither imported nor consulted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from types import MappingProxyType
+from typing import Any
+
+from .registry import CandidateBinding, mandatory_labels
+from .source import USStageBDailyBar
+
+__all__ = [
+    "ADV20_PRE_WINDOW",
+    "SignalObservation",
+    "USSignalInputError",
+    "evaluate_signal",
+    "tie_break_digest",
+]
+
+
+ADV20_PRE_WINDOW = 20
+"""Frozen ``ADV20_pre`` window from the packet's common US notation."""
+
+
+class USSignalInputError(ValueError):
+    """Aligned source history cannot be evaluated as a frozen US signal."""
+
+
+@dataclass(frozen=True)
+class SignalObservation:
+    """One deterministic signal-stage artifact, including rejected observations."""
+
+    strategy_id: str
+    contract_hash: str
+    labels: tuple[str, ...]
+    symbol: str
+    session_date: date
+    universe_eligible: bool
+    technical_signal: bool
+    no_active_position: bool
+    signal: bool
+    exclusion_reason: str | None
+    adv20_pre_proxy: float | None
+    tie_break_sha256: str
+    metrics: Mapping[str, float]
+    stages: Mapping[str, bool]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "labels": list(self.labels),
+            "symbol": self.symbol,
+            "session_date": self.session_date.isoformat(),
+            "universe_eligible": self.universe_eligible,
+            "technical_signal": self.technical_signal,
+            "no_active_position": self.no_active_position,
+            "signal": self.signal,
+            "exclusion_reason": self.exclusion_reason,
+            "adv20_pre_proxy": self.adv20_pre_proxy,
+            "tie_break_sha256": self.tie_break_sha256,
+            "metrics": dict(self.metrics),
+            "stages": dict(self.stages),
+        }
+
+
+def tie_break_digest(
+    strategy_id: str,
+    session_date: date,
+    symbol: str,
+) -> bytes:
+    """Implement ``sha256(strategy_id || session_date || symbol)`` exactly."""
+
+    return hashlib.sha256(
+        f"{strategy_id}{session_date.isoformat()}{symbol}".encode()
+    ).digest()
+
+
+def evaluate_signal(
+    candidate: CandidateBinding,
+    *,
+    symbol: str,
+    session_date: date,
+    history: Sequence[USStageBDailyBar | None],
+    no_active_position: bool,
+) -> SignalObservation:
+    """Evaluate one candidate using only history through ``session_date``.
+
+    ``history`` must be aligned to the corpus session index and terminate at the
+    signal session.  Missing observations remain missing; no interpolation,
+    filling, clipping, or cross-sectional ranking occurs in this function.
+    """
+
+    if candidate.strategy_id == "US-TS-MOM-CONT-Z126-H20-v1":
+        return _evaluate_mom(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            history=history,
+            no_active_position=no_active_position,
+        )
+    if candidate.strategy_id == "US-TS-REV-SHORT-Z3-T126-H3-v1":
+        return _evaluate_rev(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            history=history,
+            no_active_position=no_active_position,
+        )
+    if candidate.strategy_id == "US-TS-VOLBREAK-C55-V2-H10-v1":
+        return _evaluate_volbreak(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            history=history,
+            no_active_position=no_active_position,
+        )
+    raise USSignalInputError(
+        f"unsupported strategy_id {candidate.strategy_id!r}; fallback is forbidden"
+    )
+
+
+def _evaluate_mom(
+    candidate: CandidateBinding,
+    *,
+    symbol: str,
+    session_date: date,
+    history: Sequence[USStageBDailyBar | None],
+    no_active_position: bool,
+) -> SignalObservation:
+    trend_lookback = _int_parameter(candidate, "trend_lookback_sessions")
+    volatility_lookback = _int_parameter(candidate, "trend_vol_lookback_sessions")
+    confirmation_lookback = _int_parameter(candidate, "confirmation_lookback_sessions")
+    sma_lookback = _int_parameter(candidate, "sma_lookback_sessions")
+    required = trend_lookback + 1
+    base = _base_observation(
+        symbol=symbol,
+        session_date=session_date,
+        history=history,
+        required_close_count=required,
+    )
+    if base is None:
+        return _excluded(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            no_active_position=no_active_position,
+            reason="insufficient_or_invalid_required_history",
+        )
+    bars, adv20_pre_proxy = base
+    closes = [_close(bar) for bar in bars]
+    latest_returns = _one_session_returns(closes[-(volatility_lookback + 1) :])
+    sigma = _sample_standard_deviation(latest_returns)
+    adv_ok = adv20_pre_proxy >= _float_parameter(candidate, "adv20_min_usd")
+    if sigma is None or sigma == 0.0:
+        return _observation(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            universe_eligible=adv_ok,
+            technical_signal=False,
+            no_active_position=no_active_position,
+            reason="adv20_below_minimum" if not adv_ok else "sigma63_zero_or_invalid",
+            adv20_pre_proxy=adv20_pre_proxy,
+            metrics={"sigma63_ddof1": sigma} if sigma is not None else {},
+            stages={
+                "required_history": True,
+                "adv20_minimum": adv_ok,
+                "sigma_defined": False,
+                "no_active_position": no_active_position,
+            },
+        )
+    r126 = closes[-1] / closes[-(trend_lookback + 1)] - 1.0
+    r21 = closes[-1] / closes[-(confirmation_lookback + 1)] - 1.0
+    sma63 = sum(closes[-sma_lookback:]) / sma_lookback
+    z126 = r126 / (sigma * math.sqrt(trend_lookback))
+    z_ok = z126 >= _float_parameter(candidate, "trend_z_min")
+    r21_ok = r21 > _float_parameter(candidate, "confirmation_return_min")
+    sma_ok = closes[-1] > sma63
+    technical_signal = adv_ok and z_ok and r21_ok and sma_ok
+    return _observation(
+        candidate,
+        symbol=symbol,
+        session_date=session_date,
+        universe_eligible=adv_ok,
+        technical_signal=technical_signal,
+        no_active_position=no_active_position,
+        reason=_reason(
+            adv_ok=adv_ok,
+            technical_signal=technical_signal,
+            no_active_position=no_active_position,
+        ),
+        adv20_pre_proxy=adv20_pre_proxy,
+        metrics={
+            "r126": r126,
+            "sigma63_ddof1": sigma,
+            "z126": z126,
+            "r21": r21,
+            "sma63": sma63,
+        },
+        stages={
+            "required_history": True,
+            "adv20_minimum": adv_ok,
+            "z126_threshold": z_ok,
+            "r21_confirmation": r21_ok,
+            "sma63_confirmation": sma_ok,
+            "no_active_position": no_active_position,
+        },
+    )
+
+
+def _evaluate_rev(
+    candidate: CandidateBinding,
+    *,
+    symbol: str,
+    session_date: date,
+    history: Sequence[USStageBDailyBar | None],
+    no_active_position: bool,
+) -> SignalObservation:
+    trend_lookback = _int_parameter(candidate, "trend_lookback_sessions")
+    shock_lookback = _int_parameter(candidate, "shock_lookback_sessions")
+    volatility_lookback = _int_parameter(candidate, "shock_vol_lookback_sessions")
+    required = trend_lookback + 1
+    base = _base_observation(
+        symbol=symbol,
+        session_date=session_date,
+        history=history,
+        required_close_count=required,
+    )
+    if base is None:
+        return _excluded(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            no_active_position=no_active_position,
+            reason="insufficient_or_invalid_required_history",
+        )
+    bars, adv20_pre_proxy = base
+    closes = [_close(bar) for bar in bars]
+    latest_returns = _one_session_returns(closes[-(volatility_lookback + 1) :])
+    sigma = _sample_standard_deviation(latest_returns)
+    adv_ok = adv20_pre_proxy >= _float_parameter(candidate, "adv20_min_usd")
+    if sigma is None or sigma == 0.0:
+        return _observation(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            universe_eligible=adv_ok,
+            technical_signal=False,
+            no_active_position=no_active_position,
+            reason="adv20_below_minimum" if not adv_ok else "sigma60_zero_or_invalid",
+            adv20_pre_proxy=adv20_pre_proxy,
+            metrics={"sigma60_ddof1": sigma} if sigma is not None else {},
+            stages={
+                "required_history": True,
+                "adv20_minimum": adv_ok,
+                "sigma_defined": False,
+                "no_active_position": no_active_position,
+            },
+        )
+    r3 = closes[-1] / closes[-(shock_lookback + 1)] - 1.0
+    r126 = closes[-1] / closes[-(trend_lookback + 1)] - 1.0
+    z3 = r3 / (sigma * math.sqrt(shock_lookback))
+    z_ok = z3 <= _float_parameter(candidate, "shock_z_max")
+    trend_ok = r126 > _float_parameter(candidate, "trend_return_min")
+    technical_signal = adv_ok and z_ok and trend_ok
+    return _observation(
+        candidate,
+        symbol=symbol,
+        session_date=session_date,
+        universe_eligible=adv_ok,
+        technical_signal=technical_signal,
+        no_active_position=no_active_position,
+        reason=_reason(
+            adv_ok=adv_ok,
+            technical_signal=technical_signal,
+            no_active_position=no_active_position,
+        ),
+        adv20_pre_proxy=adv20_pre_proxy,
+        metrics={
+            "r3": r3,
+            "sigma60_ddof1": sigma,
+            "z3": z3,
+            "r126": r126,
+        },
+        stages={
+            "required_history": True,
+            "adv20_minimum": adv_ok,
+            "z3_threshold": z_ok,
+            "r126_trend": trend_ok,
+            "no_active_position": no_active_position,
+        },
+    )
+
+
+def _evaluate_volbreak(
+    candidate: CandidateBinding,
+    *,
+    symbol: str,
+    session_date: date,
+    history: Sequence[USStageBDailyBar | None],
+    no_active_position: bool,
+) -> SignalObservation:
+    breakout_lookback = _int_parameter(candidate, "breakout_lookback_sessions")
+    volume_lookback = _int_parameter(candidate, "volume_lookback_sessions")
+    required = breakout_lookback + 1
+    base = _base_observation(
+        symbol=symbol,
+        session_date=session_date,
+        history=history,
+        required_close_count=required,
+    )
+    if base is None:
+        return _excluded(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            no_active_position=no_active_position,
+            reason="insufficient_or_invalid_required_history",
+        )
+    bars, adv20_pre_proxy = base
+    closes = [_close(bar) for bar in bars]
+    current_volume = bars[-1].volume
+    previous_volumes = [bar.volume for bar in bars[-(volume_lookback + 1) : -1]]
+    adv_ok = adv20_pre_proxy >= _float_parameter(candidate, "adv20_min_usd")
+    if not _finite_positive(current_volume) or not all(
+        _finite_positive(value) for value in previous_volumes
+    ):
+        return _observation(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            universe_eligible=adv_ok,
+            technical_signal=False,
+            no_active_position=no_active_position,
+            reason=(
+                "adv20_below_minimum"
+                if not adv_ok
+                else "invalid_current_or_prior_volume"
+            ),
+            adv20_pre_proxy=adv20_pre_proxy,
+            metrics={},
+            stages={
+                "required_history": True,
+                "adv20_minimum": adv_ok,
+                "volume_ratio_defined": False,
+                "no_active_position": no_active_position,
+            },
+        )
+    median_volume = _median([float(value) for value in previous_volumes])
+    if median_volume == 0.0:
+        return _observation(
+            candidate,
+            symbol=symbol,
+            session_date=session_date,
+            universe_eligible=adv_ok,
+            technical_signal=False,
+            no_active_position=no_active_position,
+            reason="adv20_below_minimum" if not adv_ok else "median_volume_zero",
+            adv20_pre_proxy=adv20_pre_proxy,
+            metrics={},
+            stages={
+                "required_history": True,
+                "adv20_minimum": adv_ok,
+                "volume_ratio_defined": False,
+                "no_active_position": no_active_position,
+            },
+        )
+    prior_close_high55 = max(closes[-(breakout_lookback + 1) : -1])
+    r1 = closes[-1] / closes[-2] - 1.0
+    volume_ratio20 = float(current_volume) / median_volume
+    close_breakout = closes[-1] > prior_close_high55
+    r1_ok = r1 > _float_parameter(candidate, "daily_return_min")
+    volume_ok = volume_ratio20 >= _float_parameter(
+        candidate, "volume_ratio_min"
+    ) and volume_ratio20 <= _float_parameter(candidate, "volume_ratio_max")
+    technical_signal = adv_ok and close_breakout and r1_ok and volume_ok
+    return _observation(
+        candidate,
+        symbol=symbol,
+        session_date=session_date,
+        universe_eligible=adv_ok,
+        technical_signal=technical_signal,
+        no_active_position=no_active_position,
+        reason=_reason(
+            adv_ok=adv_ok,
+            technical_signal=technical_signal,
+            no_active_position=no_active_position,
+        ),
+        adv20_pre_proxy=adv20_pre_proxy,
+        metrics={
+            "prior_close_high55": prior_close_high55,
+            "r1": r1,
+            "volume_median20": median_volume,
+            "volume_ratio20": volume_ratio20,
+        },
+        stages={
+            "required_history": True,
+            "adv20_minimum": adv_ok,
+            "prior_close_high55_breakout": close_breakout,
+            "r1_positive": r1_ok,
+            "volume_ratio_2_to_10": volume_ok,
+            "no_active_position": no_active_position,
+        },
+    )
+
+
+def _base_observation(
+    *,
+    symbol: str,
+    session_date: date,
+    history: Sequence[USStageBDailyBar | None],
+    required_close_count: int,
+) -> tuple[tuple[USStageBDailyBar, ...], float] | None:
+    if len(history) < required_close_count:
+        return None
+    required = tuple(history[-required_close_count:])
+    if any(bar is None for bar in required):
+        return None
+    bars = tuple(bar for bar in required if bar is not None)
+    if any(bar.symbol != symbol for bar in bars):
+        raise USSignalInputError("history contains a bar for a different symbol")
+    if bars[-1].session_date != session_date:
+        raise USSignalInputError("history does not terminate at the signal session")
+    if not all(_finite_positive(bar.adjusted_close) for bar in bars):
+        return None
+    previous = tuple(history[-(ADV20_PRE_WINDOW + 1) : -1])
+    if len(previous) != ADV20_PRE_WINDOW or any(bar is None for bar in previous):
+        return None
+    prior_bars = tuple(bar for bar in previous if bar is not None)
+    if not all(
+        _finite_positive(bar.adjusted_close) and _finite_positive(bar.volume)
+        for bar in prior_bars
+    ):
+        return None
+    dollar_values = [
+        float(bar.adjusted_close) * float(bar.volume) for bar in prior_bars
+    ]
+    if not all(math.isfinite(value) and value > 0.0 for value in dollar_values):
+        return None
+    return bars, sum(dollar_values) / ADV20_PRE_WINDOW
+
+
+def _excluded(
+    candidate: CandidateBinding,
+    *,
+    symbol: str,
+    session_date: date,
+    no_active_position: bool,
+    reason: str,
+) -> SignalObservation:
+    return _observation(
+        candidate,
+        symbol=symbol,
+        session_date=session_date,
+        universe_eligible=False,
+        technical_signal=False,
+        no_active_position=no_active_position,
+        reason=reason,
+        adv20_pre_proxy=None,
+        metrics={},
+        stages={
+            "required_history": False,
+            "no_active_position": no_active_position,
+        },
+    )
+
+
+def _observation(
+    candidate: CandidateBinding,
+    *,
+    symbol: str,
+    session_date: date,
+    universe_eligible: bool,
+    technical_signal: bool,
+    no_active_position: bool,
+    reason: str | None,
+    adv20_pre_proxy: float | None,
+    metrics: Mapping[str, float | None],
+    stages: Mapping[str, bool],
+) -> SignalObservation:
+    signal = technical_signal and no_active_position
+    resolved_reason = reason
+    if signal:
+        resolved_reason = None
+    elif technical_signal and not no_active_position:
+        resolved_reason = "active_position"
+    metric_values = {
+        name: float(value)
+        for name, value in metrics.items()
+        if value is not None and math.isfinite(float(value))
+    }
+    return SignalObservation(
+        strategy_id=candidate.strategy_id,
+        contract_hash=candidate.contract_hash,
+        labels=mandatory_labels(candidate.strategy_id),
+        symbol=symbol,
+        session_date=session_date,
+        universe_eligible=universe_eligible,
+        technical_signal=technical_signal,
+        no_active_position=no_active_position,
+        signal=signal,
+        exclusion_reason=resolved_reason,
+        adv20_pre_proxy=adv20_pre_proxy,
+        tie_break_sha256=tie_break_digest(
+            candidate.strategy_id, session_date, symbol
+        ).hex(),
+        metrics=MappingProxyType(metric_values),
+        stages=MappingProxyType(dict(stages)),
+    )
+
+
+def _reason(
+    *,
+    adv_ok: bool,
+    technical_signal: bool,
+    no_active_position: bool,
+) -> str | None:
+    if not adv_ok:
+        return "adv20_below_minimum"
+    if not technical_signal:
+        return "signal_conditions_not_met"
+    if not no_active_position:
+        return "active_position"
+    return None
+
+
+def _close(bar: USStageBDailyBar) -> float:
+    value = bar.adjusted_close
+    if not _finite_positive(value):  # pragma: no cover - guarded by _base_observation
+        raise USSignalInputError("required adjusted close is not finite and positive")
+    return float(value)
+
+
+def _finite_positive(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int | float)
+        and math.isfinite(float(value))
+        and float(value) > 0.0
+    )
+
+
+def _one_session_returns(closes: Sequence[float]) -> tuple[float, ...]:
+    if len(closes) < 2:
+        raise USSignalInputError("one-session return window needs at least two closes")
+    returns = tuple(
+        current / previous - 1.0
+        for previous, current in zip(closes, closes[1:], strict=False)
+    )
+    if not all(math.isfinite(value) for value in returns):
+        raise USSignalInputError("one-session return is non-finite")
+    return returns
+
+
+def _sample_standard_deviation(values: Sequence[float]) -> float | None:
+    """Return the packet-defined sample standard deviation (ddof=1)."""
+
+    if len(values) < 2 or not all(math.isfinite(value) for value in values):
+        return None
+    average = sum(values) / len(values)
+    variance = sum((value - average) ** 2 for value in values) / (len(values) - 1)
+    return math.sqrt(variance)
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        raise USSignalInputError("median requires at least one value")
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0
+
+
+def _int_parameter(candidate: CandidateBinding, name: str) -> int:
+    value = candidate.parameter(name)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise USSignalInputError(
+            f"{candidate.strategy_id} parameter {name!r} is not a positive integer"
+        )
+    return value
+
+
+def _float_parameter(candidate: CandidateBinding, name: str) -> float:
+    value = candidate.parameter(name)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise USSignalInputError(
+            f"{candidate.strategy_id} parameter {name!r} is not numeric"
+        )
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise USSignalInputError(
+            f"{candidate.strategy_id} parameter {name!r} is not finite"
+        )
+    return numeric

--- a/research/us_stage_b/source.py
+++ b/research/us_stage_b/source.py
@@ -1,0 +1,162 @@
+"""Read-only, deterministic input types for US Stage-B fixture and U1 wiring.
+
+The source deliberately carries only the fields that the three frozen
+candidates may consume: adjusted close, open, and volume.  There are no
+high/low fields and no corpus loader, broker, database, or write path here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Protocol
+
+__all__ = [
+    "AccessRecord",
+    "ExplorationBoundaryAccessError",
+    "ExplorationBoundaryAccessSpy",
+    "InMemoryUSBarSource",
+    "USBarSource",
+    "USStageBInputError",
+    "USStageBDailyBar",
+]
+
+
+class USStageBInputError(ValueError):
+    """The source does not satisfy the minimal, read-only US Stage-B shape."""
+
+
+class ExplorationBoundaryAccessError(RuntimeError):
+    """An attempted source read fell outside the explicit exploration window."""
+
+
+@dataclass(frozen=True)
+class USStageBDailyBar:
+    """One unmodified daily US observation; null/non-finite cells are preserved.
+
+    Numeric cells are intentionally not cleaned or coerced here.  The signal
+    engine sees them unchanged and excludes an observation when a required
+    field is null, non-finite, or non-positive.
+    """
+
+    symbol: str
+    session_date: date
+    open: float | None
+    adjusted_close: float | None
+    volume: float | None
+
+    def __post_init__(self) -> None:
+        if not self.symbol:
+            raise USStageBInputError("US Stage-B bar requires a non-empty symbol")
+        if isinstance(self.session_date, datetime) or not isinstance(
+            self.session_date, date
+        ):
+            raise USStageBInputError("US Stage-B session_date must be a date")
+
+
+class USBarSource(Protocol):
+    """Point-read input protocol; source implementations are read-only."""
+
+    def symbols(self) -> tuple[str, ...]:
+        """Return source symbols as metadata, without a time-series read."""
+
+    def get(self, symbol: str, session_date: date) -> USStageBDailyBar | None:
+        """Return a true missing observation as ``None`` without filling it."""
+
+
+@dataclass(frozen=True)
+class AccessRecord:
+    """One source read record, serializable for boundary review."""
+
+    symbol: str
+    session_date: date
+    allowed: bool
+
+    def to_dict(self) -> dict[str, str | bool]:
+        return {
+            "symbol": self.symbol,
+            "session_date": self.session_date.isoformat(),
+            "allowed": self.allowed,
+        }
+
+
+class InMemoryUSBarSource:
+    """Fixture source with deterministic symbols and duplicate-row refusal."""
+
+    def __init__(self, bars: Iterable[USStageBDailyBar]) -> None:
+        rows: dict[tuple[str, date], USStageBDailyBar] = {}
+        symbols: set[str] = set()
+        for bar in bars:
+            key = (bar.symbol, bar.session_date)
+            if key in rows:
+                raise USStageBInputError(
+                    f"duplicate US Stage-B bar: {bar.symbol}/{bar.session_date}"
+                )
+            rows[key] = bar
+            symbols.add(bar.symbol)
+        self._rows = rows
+        self._symbols = tuple(sorted(symbols))
+
+    def symbols(self) -> tuple[str, ...]:
+        return self._symbols
+
+    def get(self, symbol: str, session_date: date) -> USStageBDailyBar | None:
+        return self._rows.get((symbol, session_date))
+
+
+class ExplorationBoundaryAccessSpy:
+    """Fail before any point read outside the explicit exploration date bounds."""
+
+    def __init__(
+        self,
+        source: USBarSource,
+        *,
+        exploration_start: date,
+        exploration_end: date,
+    ) -> None:
+        if exploration_start > exploration_end:
+            raise USStageBInputError("exploration boundary start is after end")
+        self._source = source
+        self._start = exploration_start
+        self._end = exploration_end
+        self._records: list[AccessRecord] = []
+
+    def symbols(self) -> tuple[str, ...]:
+        return self._source.symbols()
+
+    def get(self, symbol: str, session_date: date) -> USStageBDailyBar | None:
+        allowed = self._start <= session_date <= self._end
+        record = AccessRecord(
+            symbol=symbol,
+            session_date=session_date,
+            allowed=allowed,
+        )
+        self._records.append(record)
+        if not allowed:
+            raise ExplorationBoundaryAccessError(
+                "US Stage-B source read outside exploration boundary: "
+                f"{session_date.isoformat()} not in "
+                f"{self._start.isoformat()}..{self._end.isoformat()}"
+            )
+        return self._source.get(symbol, session_date)
+
+    @property
+    def records(self) -> tuple[AccessRecord, ...]:
+        return tuple(self._records)
+
+    @property
+    def outside_boundary_records(self) -> tuple[AccessRecord, ...]:
+        return tuple(record for record in self._records if not record.allowed)
+
+    def assert_no_outside_access(self) -> None:
+        if self.outside_boundary_records:
+            raise ExplorationBoundaryAccessError(
+                "US Stage-B attempted outside-boundary source access"
+            )
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "reads_total": len(self._records),
+            "outside_boundary_reads": len(self.outside_boundary_records),
+        }

--- a/research/us_stage_b/verdict.py
+++ b/research/us_stage_b/verdict.py
@@ -20,7 +20,16 @@ from .registry import CandidateBinding
 if TYPE_CHECKING:
     from .engine import CohortComparison, TradeOutcome
 
-__all__ = ["FalsificationVerdict", "evaluate_falsification"]
+__all__ = [
+    "FalsificationEvaluation",
+    "FalsificationVerdict",
+    "RevCostProfileVerdicts",
+    "evaluate_falsification",
+    "evaluate_falsification_evidence",
+]
+
+
+CostProfile = Literal["base_10bp_per_side", "sensitivity_5bp_per_side"]
 
 
 VerdictState = Literal[
@@ -46,6 +55,7 @@ class FalsificationVerdict:
     falsification_literal: str
     gate_results: Mapping[str, Any]
     invalid_reasons: tuple[str, ...]
+    cost_profile: CostProfile | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -56,8 +66,59 @@ class FalsificationVerdict:
             "falsification_literal": self.falsification_literal,
             "gate_results": dict(self.gate_results),
             "invalid_reasons": list(self.invalid_reasons),
+            "cost_profile": self.cost_profile,
             "promotion": "FORBIDDEN",
         }
+
+
+@dataclass(frozen=True)
+class RevCostProfileVerdicts:
+    """Independent REV verdicts for the two frozen execution-cost profiles."""
+
+    base_10bp_per_side: FalsificationVerdict
+    sensitivity_5bp_per_side: FalsificationVerdict
+
+    def __post_init__(self) -> None:
+        base = self.base_10bp_per_side
+        sensitivity = self.sensitivity_5bp_per_side
+        if base is sensitivity:
+            raise ValueError("REV cost profiles must retain distinct verdict objects")
+        if base.cost_profile != "base_10bp_per_side":
+            raise ValueError("REV base verdict lost its 10bp/side identity")
+        if sensitivity.cost_profile != "sensitivity_5bp_per_side":
+            raise ValueError("REV sensitivity verdict lost its 5bp/side identity")
+        if (
+            base.strategy_id != sensitivity.strategy_id
+            or base.contract_hash != sensitivity.contract_hash
+            or base.labels != sensitivity.labels
+        ):
+            raise ValueError("REV cost-profile verdict provenance mismatch")
+
+    def to_dict(self) -> dict[str, dict[str, Any]]:
+        return {
+            "base_10bp_per_side": self.base_10bp_per_side.to_dict(),
+            "sensitivity_5bp_per_side": self.sensitivity_5bp_per_side.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class FalsificationEvaluation:
+    """Aggregate falsification result plus any required cost-profile evidence."""
+
+    verdict: FalsificationVerdict
+    cost_profile_verdicts: RevCostProfileVerdicts | None
+
+    def __post_init__(self) -> None:
+        is_rev = self.verdict.strategy_id == "US-TS-REV-SHORT-Z3-T126-H3-v1"
+        if is_rev != (self.cost_profile_verdicts is not None):
+            raise ValueError("REV alone requires the frozen dual cost-profile verdicts")
+        if self.cost_profile_verdicts is not None:
+            base = self.cost_profile_verdicts.base_10bp_per_side
+            if (
+                self.verdict.contract_hash != base.contract_hash
+                or self.verdict.labels != base.labels
+            ):
+                raise ValueError("aggregate REV verdict provenance mismatch")
 
 
 def evaluate_falsification(
@@ -68,7 +129,26 @@ def evaluate_falsification(
     run_invalid: bool,
     invalid_reasons: Sequence[str],
 ) -> FalsificationVerdict:
-    """Apply only the frozen candidate's own falsification literal and gates."""
+    """Return the aggregate frozen-candidate verdict for compatibility callers."""
+
+    return evaluate_falsification_evidence(
+        candidate=candidate,
+        outcomes=outcomes,
+        cohorts=cohorts,
+        run_invalid=run_invalid,
+        invalid_reasons=invalid_reasons,
+    ).verdict
+
+
+def evaluate_falsification_evidence(
+    *,
+    candidate: CandidateBinding,
+    outcomes: Sequence[TradeOutcome],
+    cohorts: Sequence[CohortComparison],
+    run_invalid: bool,
+    invalid_reasons: Sequence[str],
+) -> FalsificationEvaluation:
+    """Produce aggregate evidence and the mandatory independent REV pair."""
 
     completed = tuple(outcome for outcome in outcomes if outcome.status == "completed")
     validation_completed = tuple(
@@ -102,18 +182,6 @@ def evaluate_falsification(
             for year in (2023, 2024)
         },
     }
-    if run_invalid:
-        return _verdict(
-            candidate,
-            "RUN_INVALID",
-            {
-                **common,
-                "run_invalid": True,
-                "maturity_close_missing_policy": "RUN_INVALID",
-            },
-            invalid_reasons,
-        )
-
     resolved_validation = tuple(
         cohort
         for cohort in cohorts
@@ -134,12 +202,45 @@ def evaluate_falsification(
         ),
     }
 
-    if candidate.strategy_id == "US-TS-MOM-CONT-Z126-H20-v1":
-        return _evaluate_mom(candidate, common, coverage, resolved_validation)
     if candidate.strategy_id == "US-TS-REV-SHORT-Z3-T126-H3-v1":
-        return _evaluate_rev(candidate, common, coverage, resolved_validation)
+        profiles = _evaluate_rev_cost_profile_verdicts(
+            candidate=candidate,
+            common=common,
+            coverage=coverage,
+            validation=resolved_validation,
+            run_invalid=run_invalid,
+            invalid_reasons=invalid_reasons,
+        )
+        return FalsificationEvaluation(
+            verdict=_compose_rev_dual_falsification(candidate, profiles),
+            cost_profile_verdicts=profiles,
+        )
+    if run_invalid:
+        return FalsificationEvaluation(
+            verdict=_verdict(
+                candidate,
+                "RUN_INVALID",
+                {
+                    **common,
+                    "run_invalid": True,
+                    "maturity_close_missing_policy": "RUN_INVALID",
+                },
+                invalid_reasons,
+            ),
+            cost_profile_verdicts=None,
+        )
+    if candidate.strategy_id == "US-TS-MOM-CONT-Z126-H20-v1":
+        return FalsificationEvaluation(
+            verdict=_evaluate_mom(candidate, common, coverage, resolved_validation),
+            cost_profile_verdicts=None,
+        )
     if candidate.strategy_id == "US-TS-VOLBREAK-C55-V2-H10-v1":
-        return _evaluate_volbreak(candidate, common, coverage, resolved_validation)
+        return FalsificationEvaluation(
+            verdict=_evaluate_volbreak(
+                candidate, common, coverage, resolved_validation
+            ),
+            cost_profile_verdicts=None,
+        )
     raise ValueError(f"unsupported US candidate {candidate.strategy_id!r}")
 
 
@@ -183,11 +284,46 @@ def _evaluate_mom(
     return _verdict(candidate, "NOT_FALSIFIED_EXPLORATORY_ONLY", gates)
 
 
-def _evaluate_rev(
+def _evaluate_rev_cost_profile_verdicts(
+    *,
     candidate: CandidateBinding,
     common: Mapping[str, Any],
     coverage: Mapping[str, int],
     validation: Sequence[CohortComparison],
+    run_invalid: bool,
+    invalid_reasons: Sequence[str],
+) -> RevCostProfileVerdicts:
+    return RevCostProfileVerdicts(
+        base_10bp_per_side=_evaluate_rev_at_cost_profile(
+            candidate=candidate,
+            common=common,
+            coverage=coverage,
+            validation=validation,
+            cost_profile="base_10bp_per_side",
+            run_invalid=run_invalid,
+            invalid_reasons=invalid_reasons,
+        ),
+        sensitivity_5bp_per_side=_evaluate_rev_at_cost_profile(
+            candidate=candidate,
+            common=common,
+            coverage=coverage,
+            validation=validation,
+            cost_profile="sensitivity_5bp_per_side",
+            run_invalid=run_invalid,
+            invalid_reasons=invalid_reasons,
+        ),
+    )
+
+
+def _evaluate_rev_at_cost_profile(
+    *,
+    candidate: CandidateBinding,
+    common: Mapping[str, Any],
+    coverage: Mapping[str, int],
+    validation: Sequence[CohortComparison],
+    cost_profile: CostProfile,
+    run_invalid: bool,
+    invalid_reasons: Sequence[str],
 ) -> FalsificationVerdict:
     by_year = common["validation_completed_by_entry_year"]
     frequency_pass = (
@@ -199,18 +335,22 @@ def _evaluate_rev(
         and by_year["2024"] >= 80
     )
     metrics = _validation_metrics(validation)
-    base_excess = metrics["base_entry_session_equal_weighted_excess"]
-    sensitivity_excess = metrics["sensitivity_entry_session_equal_weighted_excess"]
-    cost_sensitive = (
-        base_excess is not None
-        and sensitivity_excess is not None
-        and base_excess <= 0.0
-        and sensitivity_excess > 0.0
-    )
+    metric_name = {
+        "base_10bp_per_side": "base_entry_session_equal_weighted_excess",
+        "sensitivity_5bp_per_side": "sensitivity_entry_session_equal_weighted_excess",
+    }[cost_profile]
+    excess = metrics[metric_name]
+    bp_per_side = 10 if cost_profile == "base_10bp_per_side" else 5
     gates = {
         **common,
         **coverage,
         **metrics,
+        "cost_profile": cost_profile,
+        "cost_bp_per_side": bp_per_side,
+        "profile_entry_session_equal_weighted_excess": excess,
+        "profile_entry_session_equal_weighted_excess_gt_zero": (
+            excess is not None and excess > 0.0
+        ),
         "frequency_gate": {
             "completed_trade_min": 1_000,
             "unique_entry_session_min": 200,
@@ -219,29 +359,79 @@ def _evaluate_rev(
             "validation_each_entry_year_min": 80,
             "passed": frequency_pass,
         },
-        "base_10bp_per_side_entry_session_equal_weighted_excess_gt_zero": (
-            base_excess is not None and base_excess > 0.0
-        ),
-        "sensitivity_5bp_per_side_entry_session_equal_weighted_excess_gt_zero": (
-            sensitivity_excess is not None and sensitivity_excess > 0.0
-        ),
-        "cost_sensitive_failure": cost_sensitive,
     }
-    if not frequency_pass:
-        return _verdict(candidate, "FALSIFIED_FREQUENCY", gates)
-    if coverage["validation_cohort_unavailable_count"]:
-        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
-    if base_excess is None or sensitivity_excess is None:
-        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
-    if base_excess <= 0.0:
+    if run_invalid:
         return _verdict(
             candidate,
-            "FALSIFIED_COST_SENSITIVE"
-            if cost_sensitive
-            else "FALSIFIED_VALIDATION_COHORT_EXCESS",
-            gates,
+            "RUN_INVALID",
+            {
+                **gates,
+                "run_invalid": True,
+                "maturity_close_missing_policy": "RUN_INVALID",
+            },
+            invalid_reasons,
+            cost_profile=cost_profile,
         )
-    return _verdict(candidate, "NOT_FALSIFIED_EXPLORATORY_ONLY", gates)
+    if not frequency_pass:
+        return _verdict(
+            candidate, "FALSIFIED_FREQUENCY", gates, cost_profile=cost_profile
+        )
+    if coverage["validation_cohort_unavailable_count"]:
+        return _verdict(
+            candidate, "UNIDENTIFIABLE_COHORT", gates, cost_profile=cost_profile
+        )
+    if excess is None:
+        return _verdict(
+            candidate, "UNIDENTIFIABLE_COHORT", gates, cost_profile=cost_profile
+        )
+    if excess <= 0.0:
+        return _verdict(
+            candidate,
+            "FALSIFIED_VALIDATION_COHORT_EXCESS",
+            gates,
+            cost_profile=cost_profile,
+        )
+    return _verdict(
+        candidate,
+        "NOT_FALSIFIED_EXPLORATORY_ONLY",
+        gates,
+        cost_profile=cost_profile,
+    )
+
+
+def _compose_rev_dual_falsification(
+    candidate: CandidateBinding,
+    profiles: RevCostProfileVerdicts,
+) -> FalsificationVerdict:
+    """Compose the frozen REV classification from independently evaluated costs."""
+
+    base = profiles.base_10bp_per_side
+    sensitivity = profiles.sensitivity_5bp_per_side
+    cost_sensitive = (
+        base.state == "FALSIFIED_VALIDATION_COHORT_EXCESS"
+        and sensitivity.state == "NOT_FALSIFIED_EXPLORATORY_ONLY"
+    )
+    gates = {
+        "dual_verdicts_are_distinct_objects": base is not sensitivity,
+        "base_10bp_per_side_verdict_state": base.state,
+        "sensitivity_5bp_per_side_verdict_state": sensitivity.state,
+        "base_10bp_per_side_verdict": base.to_dict(),
+        "sensitivity_5bp_per_side_verdict": sensitivity.to_dict(),
+        "cost_sensitive_failure": cost_sensitive,
+    }
+    if base.state == sensitivity.state:
+        state = base.state
+    elif cost_sensitive:
+        state = "FALSIFIED_COST_SENSITIVE"
+    else:
+        # The 10bp/side gate is the frozen decisive gate.  The independent
+        # 5bp/side result remains serialized above rather than being folded
+        # into a single predicate.
+        state = base.state
+    invalid_reasons = tuple(
+        dict.fromkeys((*base.invalid_reasons, *sensitivity.invalid_reasons))
+    )
+    return _verdict(candidate, state, gates, invalid_reasons)
 
 
 def _evaluate_volbreak(
@@ -404,6 +594,8 @@ def _verdict(
     state: VerdictState,
     gates: Mapping[str, Any],
     invalid_reasons: Sequence[str] = (),
+    *,
+    cost_profile: CostProfile | None = None,
 ) -> FalsificationVerdict:
     return FalsificationVerdict(
         strategy_id=candidate.strategy_id,
@@ -413,4 +605,5 @@ def _verdict(
         falsification_literal=candidate.falsification,
         gate_results=dict(gates),
         invalid_reasons=tuple(invalid_reasons),
+        cost_profile=cost_profile,
     )

--- a/research/us_stage_b/verdict.py
+++ b/research/us_stage_b/verdict.py
@@ -1,0 +1,416 @@
+"""Candidate-specific US falsification gates for Stage-B evidence.
+
+The output can only say that a frozen candidate was or was not falsified by
+its stated exploratory gates.  It never produces a promotion, execution, or
+live-trading decision.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from statistics import mean
+from typing import TYPE_CHECKING, Any, Literal
+
+from .registry import CandidateBinding
+
+if TYPE_CHECKING:
+    from .engine import CohortComparison, TradeOutcome
+
+__all__ = ["FalsificationVerdict", "evaluate_falsification"]
+
+
+VerdictState = Literal[
+    "RUN_INVALID",
+    "FALSIFIED_FREQUENCY",
+    "FALSIFIED_VALIDATION_COHORT_EXCESS",
+    "FALSIFIED_COST_SENSITIVE",
+    "FALSIFIED_EXTREME_DEPENDENCE",
+    "UNIDENTIFIABLE_COHORT",
+    "UNIDENTIFIABLE_EXTREME_ANALYSIS",
+    "NOT_FALSIFIED_EXPLORATORY_ONLY",
+]
+
+
+@dataclass(frozen=True)
+class FalsificationVerdict:
+    """A provenance-stamped candidate verdict with explicit gate measurements."""
+
+    strategy_id: str
+    contract_hash: str
+    labels: tuple[str, ...]
+    state: VerdictState
+    falsification_literal: str
+    gate_results: Mapping[str, Any]
+    invalid_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "contract_hash": self.contract_hash,
+            "labels": list(self.labels),
+            "state": self.state,
+            "falsification_literal": self.falsification_literal,
+            "gate_results": dict(self.gate_results),
+            "invalid_reasons": list(self.invalid_reasons),
+            "promotion": "FORBIDDEN",
+        }
+
+
+def evaluate_falsification(
+    *,
+    candidate: CandidateBinding,
+    outcomes: Sequence[TradeOutcome],
+    cohorts: Sequence[CohortComparison],
+    run_invalid: bool,
+    invalid_reasons: Sequence[str],
+) -> FalsificationVerdict:
+    """Apply only the frozen candidate's own falsification literal and gates."""
+
+    completed = tuple(outcome for outcome in outcomes if outcome.status == "completed")
+    validation_completed = tuple(
+        outcome
+        for outcome in completed
+        if outcome.entry_session is not None
+        and outcome.entry_session.year in {2023, 2024}
+    )
+    common = {
+        "completed_trade_count": len(completed),
+        "unique_entry_session_count": len(
+            {
+                outcome.entry_session
+                for outcome in completed
+                if outcome.entry_session is not None
+            }
+        ),
+        "validation_completed_trade_count": len(validation_completed),
+        "validation_unique_entry_session_count": len(
+            {
+                outcome.entry_session
+                for outcome in validation_completed
+                if outcome.entry_session is not None
+            }
+        ),
+        "validation_completed_by_entry_year": {
+            str(year): sum(
+                outcome.entry_session is not None and outcome.entry_session.year == year
+                for outcome in validation_completed
+            )
+            for year in (2023, 2024)
+        },
+    }
+    if run_invalid:
+        return _verdict(
+            candidate,
+            "RUN_INVALID",
+            {
+                **common,
+                "run_invalid": True,
+                "maturity_close_missing_policy": "RUN_INVALID",
+            },
+            invalid_reasons,
+        )
+
+    resolved_validation = tuple(
+        cohort
+        for cohort in cohorts
+        if cohort.status == "completed" and cohort.entry_session.year in {2023, 2024}
+    )
+    completed_identities = {
+        _identity(outcome.entry_session, outcome.symbol)
+        for outcome in validation_completed
+        if outcome.entry_session is not None
+    }
+    resolved_identities = {
+        _identity(cohort.entry_session, cohort.symbol) for cohort in resolved_validation
+    }
+    coverage = {
+        "validation_completed_with_resolved_cohort_count": len(resolved_validation),
+        "validation_cohort_unavailable_count": len(
+            completed_identities - resolved_identities
+        ),
+    }
+
+    if candidate.strategy_id == "US-TS-MOM-CONT-Z126-H20-v1":
+        return _evaluate_mom(candidate, common, coverage, resolved_validation)
+    if candidate.strategy_id == "US-TS-REV-SHORT-Z3-T126-H3-v1":
+        return _evaluate_rev(candidate, common, coverage, resolved_validation)
+    if candidate.strategy_id == "US-TS-VOLBREAK-C55-V2-H10-v1":
+        return _evaluate_volbreak(candidate, common, coverage, resolved_validation)
+    raise ValueError(f"unsupported US candidate {candidate.strategy_id!r}")
+
+
+def _evaluate_mom(
+    candidate: CandidateBinding,
+    common: Mapping[str, Any],
+    coverage: Mapping[str, int],
+    validation: Sequence[CohortComparison],
+) -> FalsificationVerdict:
+    frequency_pass = (
+        common["completed_trade_count"] >= 400
+        and common["unique_entry_session_count"] >= 120
+        and common["validation_completed_trade_count"] >= 60
+        and common["validation_unique_entry_session_count"] >= 24
+    )
+    metrics = _validation_metrics(validation)
+    gates = {
+        **common,
+        **coverage,
+        **metrics,
+        "frequency_gate": {
+            "completed_trade_min": 400,
+            "unique_entry_session_min": 120,
+            "validation_completed_trade_min": 60,
+            "validation_unique_entry_session_min": 24,
+            "passed": frequency_pass,
+        },
+        "validation_entry_session_equal_weighted_base_excess_gt_zero": (
+            metrics["base_entry_session_equal_weighted_excess"] is not None
+            and metrics["base_entry_session_equal_weighted_excess"] > 0.0
+        ),
+    }
+    if not frequency_pass:
+        return _verdict(candidate, "FALSIFIED_FREQUENCY", gates)
+    if coverage["validation_cohort_unavailable_count"]:
+        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
+    if metrics["base_entry_session_equal_weighted_excess"] is None:
+        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
+    if metrics["base_entry_session_equal_weighted_excess"] <= 0.0:
+        return _verdict(candidate, "FALSIFIED_VALIDATION_COHORT_EXCESS", gates)
+    return _verdict(candidate, "NOT_FALSIFIED_EXPLORATORY_ONLY", gates)
+
+
+def _evaluate_rev(
+    candidate: CandidateBinding,
+    common: Mapping[str, Any],
+    coverage: Mapping[str, int],
+    validation: Sequence[CohortComparison],
+) -> FalsificationVerdict:
+    by_year = common["validation_completed_by_entry_year"]
+    frequency_pass = (
+        common["completed_trade_count"] >= 1_000
+        and common["unique_entry_session_count"] >= 200
+        and common["validation_completed_trade_count"] >= 200
+        and common["validation_unique_entry_session_count"] >= 50
+        and by_year["2023"] >= 80
+        and by_year["2024"] >= 80
+    )
+    metrics = _validation_metrics(validation)
+    base_excess = metrics["base_entry_session_equal_weighted_excess"]
+    sensitivity_excess = metrics["sensitivity_entry_session_equal_weighted_excess"]
+    cost_sensitive = (
+        base_excess is not None
+        and sensitivity_excess is not None
+        and base_excess <= 0.0
+        and sensitivity_excess > 0.0
+    )
+    gates = {
+        **common,
+        **coverage,
+        **metrics,
+        "frequency_gate": {
+            "completed_trade_min": 1_000,
+            "unique_entry_session_min": 200,
+            "validation_completed_trade_min": 200,
+            "validation_unique_entry_session_min": 50,
+            "validation_each_entry_year_min": 80,
+            "passed": frequency_pass,
+        },
+        "base_10bp_per_side_entry_session_equal_weighted_excess_gt_zero": (
+            base_excess is not None and base_excess > 0.0
+        ),
+        "sensitivity_5bp_per_side_entry_session_equal_weighted_excess_gt_zero": (
+            sensitivity_excess is not None and sensitivity_excess > 0.0
+        ),
+        "cost_sensitive_failure": cost_sensitive,
+    }
+    if not frequency_pass:
+        return _verdict(candidate, "FALSIFIED_FREQUENCY", gates)
+    if coverage["validation_cohort_unavailable_count"]:
+        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
+    if base_excess is None or sensitivity_excess is None:
+        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
+    if base_excess <= 0.0:
+        return _verdict(
+            candidate,
+            "FALSIFIED_COST_SENSITIVE"
+            if cost_sensitive
+            else "FALSIFIED_VALIDATION_COHORT_EXCESS",
+            gates,
+        )
+    return _verdict(candidate, "NOT_FALSIFIED_EXPLORATORY_ONLY", gates)
+
+
+def _evaluate_volbreak(
+    candidate: CandidateBinding,
+    common: Mapping[str, Any],
+    coverage: Mapping[str, int],
+    validation: Sequence[CohortComparison],
+) -> FalsificationVerdict:
+    by_year = common["validation_completed_by_entry_year"]
+    frequency_pass = (
+        common["completed_trade_count"] >= 500
+        and common["unique_entry_session_count"] >= 150
+        and common["validation_completed_trade_count"] >= 100
+        and common["validation_unique_entry_session_count"] >= 30
+        and by_year["2023"] >= 40
+        and by_year["2024"] >= 40
+    )
+    metrics = _validation_metrics(validation)
+    base_excess = metrics["base_entry_session_equal_weighted_excess"]
+    gates: dict[str, Any] = {
+        **common,
+        **coverage,
+        **metrics,
+        "frequency_gate": {
+            "completed_trade_min": 500,
+            "unique_entry_session_min": 150,
+            "validation_completed_trade_min": 100,
+            "validation_unique_entry_session_min": 30,
+            "validation_each_entry_year_min": 40,
+            "passed": frequency_pass,
+        },
+        "base_10bp_per_side_entry_session_equal_weighted_excess_gt_zero": (
+            base_excess is not None and base_excess > 0.0
+        ),
+    }
+    if not frequency_pass:
+        return _verdict(candidate, "FALSIFIED_FREQUENCY", gates)
+    if coverage["validation_cohort_unavailable_count"]:
+        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
+    if base_excess is None:
+        return _verdict(candidate, "UNIDENTIFIABLE_COHORT", gates)
+    if base_excess <= 0.0:
+        return _verdict(candidate, "FALSIFIED_VALIDATION_COHORT_EXCESS", gates)
+
+    extreme = _volbreak_extreme_metrics(validation)
+    gates.update(extreme)
+    if extreme["top_1_percent_exclusion_entry_session_equal_weighted_excess"] is None:
+        return _verdict(candidate, "UNIDENTIFIABLE_EXTREME_ANALYSIS", gates)
+    if extreme["top_1_percent_excess_contribution_ratio"] is None:
+        return _verdict(candidate, "UNIDENTIFIABLE_EXTREME_ANALYSIS", gates)
+    if (
+        extreme["top_1_percent_exclusion_entry_session_equal_weighted_excess"] <= 0.0
+        or extreme["top_1_percent_excess_contribution_ratio"] > 0.5
+    ):
+        return _verdict(candidate, "FALSIFIED_EXTREME_DEPENDENCE", gates)
+    return _verdict(candidate, "NOT_FALSIFIED_EXPLORATORY_ONLY", gates)
+
+
+def _validation_metrics(
+    validation: Sequence[CohortComparison],
+) -> dict[str, float | None]:
+    base = [item.base_excess_return for item in validation]
+    sensitivity = [item.sensitivity_excess_return for item in validation]
+    if any(value is None for value in base) or any(
+        value is None for value in sensitivity
+    ):
+        return {
+            "base_trade_weighted_excess": None,
+            "base_entry_session_equal_weighted_excess": None,
+            "sensitivity_trade_weighted_excess": None,
+            "sensitivity_entry_session_equal_weighted_excess": None,
+        }
+    base_values = [float(value) for value in base if value is not None]
+    sensitivity_values = [float(value) for value in sensitivity if value is not None]
+    return {
+        "base_trade_weighted_excess": _mean_or_none(base_values),
+        "base_entry_session_equal_weighted_excess": _entry_session_mean(
+            validation, field="base_excess_return"
+        ),
+        "sensitivity_trade_weighted_excess": _mean_or_none(sensitivity_values),
+        "sensitivity_entry_session_equal_weighted_excess": _entry_session_mean(
+            validation, field="sensitivity_excess_return"
+        ),
+    }
+
+
+def _volbreak_extreme_metrics(
+    validation: Sequence[CohortComparison],
+) -> dict[str, Any]:
+    if not validation or any(item.volume_ratio20 is None for item in validation):
+        return {
+            "top_1_percent_count": 0,
+            "top_1_percent_selector": "ceil(validation_count * 0.01), volume_ratio20 desc then SHA bytes",
+            "top_1_percent_exclusion_entry_session_equal_weighted_excess": None,
+            "top_1_percent_excess_contribution_ratio": None,
+        }
+    ordered = sorted(
+        validation,
+        key=lambda item: (
+            -float(item.volume_ratio20),
+            bytes.fromhex(item.tie_break_sha256),
+        ),
+    )
+    top_count = max(1, math.ceil(len(ordered) * 0.01))
+    top = tuple(ordered[:top_count])
+    top_identities = {_identity(item.entry_session, item.symbol) for item in top}
+    remaining = tuple(
+        item
+        for item in validation
+        if _identity(item.entry_session, item.symbol) not in top_identities
+    )
+    all_excess = [
+        float(item.base_excess_return)
+        for item in validation
+        if item.base_excess_return is not None
+    ]
+    top_excess = [
+        float(item.base_excess_return)
+        for item in top
+        if item.base_excess_return is not None
+    ]
+    total = sum(all_excess)
+    contribution = sum(top_excess) / total if total > 0.0 else None
+    return {
+        "top_1_percent_count": top_count,
+        "top_1_percent_selector": "ceil(validation_count * 0.01), volume_ratio20 desc then SHA bytes",
+        "top_1_percent_exclusion_entry_session_equal_weighted_excess": _entry_session_mean(
+            remaining, field="base_excess_return"
+        ),
+        "top_1_percent_excess_contribution_ratio": contribution,
+    }
+
+
+def _entry_session_mean(
+    records: Sequence[CohortComparison],
+    *,
+    field: Literal["base_excess_return", "sensitivity_excess_return"],
+) -> float | None:
+    grouped: dict[date, list[float]] = defaultdict(list)
+    for record in records:
+        value = getattr(record, field)
+        if value is None:
+            return None
+        grouped[record.entry_session].append(float(value))
+    if not grouped:
+        return None
+    return mean(mean(values) for _, values in sorted(grouped.items()))
+
+
+def _mean_or_none(values: Sequence[float]) -> float | None:
+    return mean(values) if values else None
+
+
+def _identity(entry_session: date | None, symbol: str) -> tuple[date | None, str]:
+    return entry_session, symbol
+
+
+def _verdict(
+    candidate: CandidateBinding,
+    state: VerdictState,
+    gates: Mapping[str, Any],
+    invalid_reasons: Sequence[str] = (),
+) -> FalsificationVerdict:
+    return FalsificationVerdict(
+        strategy_id=candidate.strategy_id,
+        contract_hash=candidate.contract_hash,
+        labels=candidate.labels,
+        state=state,
+        falsification_literal=candidate.falsification,
+        gate_results=dict(gates),
+        invalid_reasons=tuple(invalid_reasons),
+    )

--- a/tests/fixtures/us_u0_frozen/02-active-candidates.yaml
+++ b/tests/fixtures/us_u0_frozen/02-active-candidates.yaml
@@ -1,0 +1,187 @@
+packet_status: active_scope_only
+active_scope_meaning: "이번 prior-art 조사 범위. admission, 승인, 백테스트 통과, paper 승격 또는 주문 승인이 아님. 모든 후보는 UNTESTED."
+source_files:
+  kr:
+    path: gptpro-kr-candidates-v1.md
+    sha256: 0639592817f13db80f1d67b199ffe80898b23675475d1fbf1a611ea2b6b671dc
+  us:
+    path: gptpro-us-candidates-v1.md
+    sha256: 6ec8e31d8252b0f396da205ea37938d85ea4933345bd578573154aa4364a2ae7
+candidates:
+  - market: KR
+    strategy_id: rev3_reclaim
+    family_id:
+      status: NOT_AVAILABLE_IN_SOURCE
+      value: null
+      source_file: gptpro-kr-candidates-v1.md
+      source_location: "candidate block strategy_id=rev3_reclaim; family_id not present in source"
+    cost_assumption:
+      base: "approximately 43 bp round trip (fee 3 bp + sell tax 20 bp + slippage 10 bp/side)"
+      sensitivity: "approximately 83 bp round trip with slippage 30 bp/side"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    hypothesis: "같은 시장의 유동성 적격 종목 중 3세션 수익률이 극단적으로 낮았지만 당일 종가가 일중 범위 상단으로 회복되고 거래량이 급증한 경우, 정보에 의한 영구 재평가보다 일시적 매도 압력이 포함되어 이후 5세션 동안 baseline 대비 반전 초과성과가 나타날 수 있다."
+    side: long
+    universe_filter: "PIT 상장목록 포함; 공통 적격성; liq_pct_t >= 0.50; close×volume은 실제 거래대금이 아닌 유동성 프록시."
+    signal: "r3_t = close_t / close_{t-3} - 1; r3_pct_t = 같은 시장 universe_filter 통과 종목 사이 pct_asc(r3_t); clv_t = (close_t - low_c_t)/(high_c_t - low_c_t); volume_ratio_t = volume_t / median(volume_{t-20}..volume_{t-1}); r3_pct_t <= 0.05 AND clv_t >= 0.65 AND volume_ratio_t >= 1.50 AND high_c_t > low_c_t. r3 percentile은 시장별 계산 후 KOSPI/KOSDAQ 신호를 합쳐 최종 순위."
+    required_history: "현재 세션 포함 연속 21개 XKRX 거래 세션 (close/volume t-20..t)"
+    missing_data_handling: "필요 21세션 중 OHLCV 결측·비양수면 신호 미계산; high_c_t=low_c_t면 clv 미정의로 신호 없음; 보간 금지; 선택 후 t+1 bar 없으면 no-fill, 대체 종목 없음; 보유 중 상폐는 하네스 터미널 규칙."
+    entry: t_plus_1_open
+    exit: "진입 체결일 D 기준 D+5 XKRX 세션 종가 매도"
+    ranking: "r3_pct_t 오름차순 → r3_t 오름차순 → clv_t 내림차순 → volume_ratio_t 내림차순 → liq_pct_t 내림차순"
+    tie_break: "market 순서 KOSPI, KOSDAQ → zero-padded symbol 오름차순"
+    sizing: "정규화 notional 1.0 동일 · 동시 보유 상한 10 · 중복 보유/추가매수 금지, 재신호 무시 후 차순위로 슬롯 충원"
+    parameter_values: {liquidity_percentile_min: 0.50, reversal_lookback_sessions: 3, loser_percentile_max: 0.05, close_location_min: 0.65, volume_ratio_min: 1.50, holding_sessions: 5, max_concurrent_positions: 10}
+    param_sensitivity: "liq↑=거래수↓ · lookback↑=반전 지연 · loser_pct↓=희소·강도↑ · clv↑=표본↓ · vol_ratio↑=빈도↓ · hold↑=회전율↓·노출↑"
+    expected_trade_frequency: "사전 추정 월 10~30건; capacity 상한 ≈ floor(월 세션수/5)×10; corpus 관측 아님."
+    falsification: "2015~2024 filled trade <300; 또는 43bp 비용 후 같은 세션·D+5·유사 유동성 baseline 대비 거래당 평균 초과수익 ≤0; 또는 진입 세션 군집 one-sided 90% CLB ≤0; 또는 10개 연도 중 양수 연도 <6."
+    empirical_status: UNTESTED
+  - market: KR
+    strategy_id: brk20_confirm
+    family_id:
+      status: NOT_AVAILABLE_IN_SOURCE
+      value: null
+      source_file: gptpro-kr-candidates-v1.md
+      source_location: "candidate block strategy_id=brk20_confirm; family_id not present in source"
+    cost_assumption:
+      base: "approximately 43 bp round trip (fee 3 bp + sell tax 20 bp + slippage 10 bp/side)"
+      sensitivity: "approximately 83 bp round trip with slippage 30 bp/side"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    hypothesis: "직전 20세션 모든 고가를 종가로 돌파하고 종가 위치·거래량이 강하면 정보 반영이 여러 세션에 걸쳐 진행되어 이후 10세션 지속 초과성과가 가능하다."
+    side: long
+    universe_filter: "PIT 포함 · 공통 적격성 · liq_pct_t >= 0.50 (close×volume 프록시)"
+    signal: "prior_high20_t = max(high_c_{t-20..t-1}); breakout_margin_t = close_t/prior_high20_t - 1; clv_t = (close_t-low_c_t)/(high_c_t-low_c_t); volume_ratio_t = volume_t/median(volume_{t-20..t-1}); breakout_margin_t > 0 AND clv_t >= 0.75 AND volume_ratio_t >= 1.25 AND high_c_t > low_c_t. 종목 자체 20세션 time-series breakout."
+    required_history: "연속 21개 XKRX 세션 (clamp high·volume t-20..t-1 + 당일 OHLCV)"
+    missing_data_handling: "결측·비양수 시 신호 없음 · high_c=low_c 신호 없음 · 고가 결측 너머 연결 금지 · no-fill 대체 없음 · 상폐 터미널 규칙"
+    entry: t_plus_1_open
+    exit: "D+10 XKRX 세션 종가 매도"
+    ranking: "breakout_margin_t 내림차순 → volume_ratio_t 내림차순 → clv_t 내림차순 → liq_pct_t 내림차순"
+    tie_break: "KOSPI, KOSDAQ → zero-padded symbol 오름차순"
+    sizing: "notional 1.0 · 상한 10 · 중복/추가매수 금지"
+    parameter_values: {liquidity_percentile_min: 0.50, breakout_lookback_sessions: 20, close_location_min: 0.75, volume_ratio_min: 1.25, holding_sessions: 10, max_concurrent_positions: 10}
+    param_sensitivity: "liq↑=거래수↓ · lookback↑=희소·강도↑ · clv↑=표본↓ · vol_ratio↑=정상 돌파 누락 · hold↑=false breakout 노출↑"
+    expected_trade_frequency: "사전 추정 월 6~18건; capacity ≈ floor(월 세션수/10)×10; corpus 관측 아님."
+    falsification: "filled <300; 또는 43bp 후 baseline 초과 ≤0; 또는 진입 세션 군집 90% CLB ≤0; 또는 양수 연도 <6."
+    empirical_status: UNTESTED
+  - market: KR
+    strategy_id: lowvol_up_month
+    family_id:
+      status: NOT_AVAILABLE_IN_SOURCE
+      value: null
+      source_file: gptpro-kr-candidates-v1.md
+      source_location: "candidate block strategy_id=lowvol_up_month; family_id not present in source"
+    cost_assumption:
+      base: "approximately 43 bp round trip (fee 3 bp + sell tax 20 bp + slippage 10 bp/side)"
+      sensitivity: "approximately 83 bp round trip with slippage 30 bp/side"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    hypothesis: "월말 기준 최근 변동성 시장 하위 30%이고 20세션 수익률이 양수인 종목은 하방 변동이 작게 유지되며 다음 20세션 초과성과가 양수일 수 있다."
+    side: long
+    universe_filter: "월 마지막 XKRX 세션 한정 · PIT 포함 · 공통 적격성 · liq_pct_t >= 0.50"
+    signal: "vol20_t = std(r1_{t-19..t}, ddof=1); vol20_pct_t = 같은 시장 내 pct_asc(vol20_t); r20_t = close_t/close_{t-20}-1; vol20_pct_t <= 0.30 AND r20_t > 0."
+    required_history: "월말 포함 연속 21개 XKRX 세션"
+    missing_data_handling: "결측·비양수 시 해당 월 제외 · 보간 금지 · no-fill 차순위 보충 없음 · 기보유 제외 후 차순위 충원 · 상폐 터미널 규칙"
+    entry: t_plus_1_open
+    exit: "D+20 XKRX 세션 종가 매도"
+    ranking: "vol20_pct_t 오름차순 → vol20_t 오름차순 → r20_t 내림차순 → liq_pct_t 내림차순"
+    tie_break: "KOSPI, KOSDAQ → zero-padded symbol 오름차순"
+    sizing: "notional 1.0 · 상한 10 · 월말 강제 청산/재조정 없음, D+20 만기 유지 · 잔여 슬롯만 신규"
+    parameter_values: {selection_schedule: calendar_month_last_xkrx_session, liquidity_percentile_min: 0.50, volatility_lookback_sessions: 20, low_volatility_percentile_max: 0.30, trend_lookback_sessions: 20, trend_return_floor: 0.0, holding_sessions: 20, max_concurrent_positions: 10}
+    param_sensitivity: "liq↑=선택폭↓ · vol lookback↑=반영 지연 · lowvol_pct↓=방어적·참여도↓ · trend_floor↑=momentum 성격화 · hold↑=정합성 약화 · schedule 변경=신규 등록 대상"
+    expected_trade_frequency: "사전 추정 월 5~10건; 월 1회 평가·슬롯 10, D+20 잔존 시 슬롯 감소; corpus 관측 아님."
+    falsification: "filled <300; 또는 43bp 후 baseline 초과 ≤0; 또는 90% CLB ≤0; 또는 양수 연도 <6."
+    empirical_status: UNTESTED
+  - market: US
+    strategy_id: US-TS-MOM-CONT-Z126-H20-v1
+    family_id:
+      status: SOURCE_PROVIDED
+      value: US-TS-MOM-CONT
+      source_file: gptpro-us-candidates-v1.md
+      source_location: "candidate block strategy_id=US-TS-MOM-CONT-Z126-H20-v1; family_id"
+    cost_assumption:
+      base: "10 bp/side (20 bp round trip)"
+      sensitivity: "5 bp/side (10 bp round trip)"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    source_text: "CONDITIONAL_DRAFT; v1.1 survivor corpus 공통 사실 기준으로 설계됨. 역사적 missing_data 문구는 만기 close 부재=하네스 TBD-3 미해결로 run-invalid이라고 기록함."
+    current_constraint_resolution: "현재 US 하네스 v1.2에서 만기 close 부재는 run-invalid으로 해소됨. 후보 정의를 수정하지 않고 현재 실행 제약만 이 값으로 해석한다."
+    hypothesis: "126세션 상승률이 자기 변동성 대비 충분히 크고(z126≥1.0) 21세션 수익률·63세션 SMA가 방향 확인하면 다음 20세션 지속 가능성이 동일 유동성 baseline보다 높다."
+    side: long
+    universe_filter: "ADV20_pre_proxy >= USD 5,000,000 · 20개 volume 전부 양수·유한 · 필요 close 이력 존재 (프록시 명시)"
+    signal: "R126=C_t/C_(t-126)-1; z126=R126/(sigma63×sqrt(126)); signal=(z126>=1.0) AND (R21>0.0) AND (C_t>SMA63) AND no_active_position(symbol). 전 항 자기 이력만."
+    required_history: "127개 corpus session 유효 close · 최근 63개 수익률 · 이전 20개 유효 volume"
+    missing_data_handling: "필요 bar 결측·null·비유한·비양수 시 신호 미생성 · forward-fill/보간/winsorization 금지 · t+1 open 부재=no-fill · 만기 close 부재의 source_text는 역사적 TBD-3이며 현재 v1.2 resolution은 run-invalid (조용한 대체 금지)."
+    entry: t_plus_1_open
+    exit: "D+20 session close (corpus session index 기준, 조기 청산 없음)"
+    ranking: "슬롯 초과 시 ADV20_pre_proxy 내림차순만. 수익률·z126·신호강도 횡단면 순위 금지"
+    tie_break: "sha256(strategy_id || session_date || symbol) 바이트 오름차순"
+    sizing: "종목당 USD 500 고정 notional · 복리 없음 · 최대 10종목 · pyramiding 없음 · execution_envelope_compatible=CONDITIONAL"
+    parameter_values: {adv20_min_usd: 5000000, trend_lookback_sessions: 126, trend_vol_lookback_sessions: 63, trend_z_min: 1.0, confirmation_lookback_sessions: 21, confirmation_return_min: 0.0, sma_lookback_sessions: 63, hold_sessions: 20, fixed_notional_usd: 500, max_positions: 10}
+    param_sensitivity: NOT_AVAILABLE_IN_SOURCE
+    expected_trade_frequency: "DESIGN_PRIOR 월 4~10건; raw incidence 미지; FREQ_QUERY로 확인."
+    falsification: "2024년 말 완료 거래 <400 또는 고유 진입 세션 <120, 또는 validation 2023~2024 <60건·고유 세션 <24면 폐기; 충족해도 validation entry-session 동일가중 비용차감 cohort 초과 ≤0bp면 폐기."
+    execution_envelope: "CONDITIONAL; source envelope의 미확정 실행 세부사항은 UNKNOWN으로 보존."
+    empirical_status: UNTESTED
+  - market: US
+    strategy_id: US-TS-REV-SHORT-Z3-T126-H3-v1
+    family_id:
+      status: SOURCE_PROVIDED
+      value: US-TS-REV-SHORT
+      source_file: gptpro-us-candidates-v1.md
+      source_location: "candidate block strategy_id=US-TS-REV-SHORT-Z3-T126-H3-v1; family_id"
+    cost_assumption:
+      base: "10 bp/side (20 bp round trip)"
+      sensitivity: "5 bp/side (10 bp round trip)"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    source_text: "CONDITIONAL_DRAFT; v1.1 survivor corpus 공통 사실 기준으로 설계됨. 역사적 TBD-3 미해결 문구를 포함함."
+    current_constraint_resolution: "현재 US 하네스 v1.2에서 만기 close 부재는 run-invalid으로 해소됨. 후보 정의를 수정하지 않고 현재 실행 제약만 이 값으로 해석한다."
+    hypothesis: "126세션 자기 추세 양수인 종목의 자기 변동성 대비 과도한 3세션 하락(z3<=-2.0)은 다음 3세션 부분 회귀 가능."
+    side: long
+    universe_filter: "ADV20_pre_proxy >= USD 5,000,000 · 절대 주가 미사용"
+    signal: "R3=C_t/C_(t-3)-1; z3=R3/(sigma60×sqrt(3)); signal=(z3<=-2.0) AND (R126>0.0) AND no_active_position"
+    required_history: "127개 session close · 최근 60개 수익률 · 이전 20개 volume"
+    missing_data_handling: "결측·비유한·비양수·sigma60=0 → 신호 미생성 · 보간 없음 · no-fill/run-invalid 규칙 동일; 역사적 TBD-3는 현재 v1.2에서 만기 close 부재=run-invalid으로 해소."
+    entry: t_plus_1_open
+    exit: "D+3 session close (stop·목표가·조기 청산 없음)"
+    ranking: "ADV20_pre_proxy 내림차순만 (하락폭·z3 우선 금지)"
+    tie_break: "sha256 바이트 오름차순"
+    sizing: "USD 500 · 최대 10 · execution_envelope_compatible=CONDITIONAL_COST_SENSITIVE"
+    parameter_values: {adv20_min_usd: 5000000, shock_lookback_sessions: 3, shock_vol_lookback_sessions: 60, shock_z_max: -2.0, trend_lookback_sessions: 126, trend_return_min: 0.0, hold_sessions: 3, fixed_notional_usd: 500, max_positions: 10}
+    param_sensitivity: NOT_AVAILABLE_IN_SOURCE
+    expected_trade_frequency: "DESIGN_PRIOR 월 15~50건; 실제 2σ 하락 발생률 미지; FREQ_QUERY."
+    falsification: "완료 거래 <1,000 또는 고유 진입 세션 <200, validation <200건·고유 <50·각 연도 <80이면 폐기; 10bp/side에서 2023~2024 초과 ≤0bp 폐기; 5bp/side 양수인데 10bp/side ≤0이면 비용 민감 실패."
+    execution_envelope: "CONDITIONAL_COST_SENSITIVE; source envelope의 장중 집행·프리/애프터·비용은 UNKNOWN."
+    empirical_status: UNTESTED
+  - market: US
+    strategy_id: US-TS-VOLBREAK-C55-V2-H10-v1
+    family_id:
+      status: SOURCE_PROVIDED
+      value: US-TS-VOLBREAK
+      source_file: gptpro-us-candidates-v1.md
+      source_location: "candidate block strategy_id=US-TS-VOLBREAK-C55-V2-H10-v1; family_id"
+    cost_assumption:
+      base: "10 bp/side (20 bp round trip)"
+      sensitivity: "5 bp/side (10 bp round trip)"
+      source_file: 03-harness-corpus-constraints.md
+      source_sha256: cf03ce4b93e1b307fec0479563415cf40a5970a0db93904efc4400f694f911ad
+    source_text: "CONDITIONAL_DRAFT; v1.1 survivor corpus 공통 사실 기준으로 설계됨. 역사적 TBD-3 미해결 문구를 포함함."
+    current_constraint_resolution: "현재 US 하네스 v1.2에서 만기 close 부재는 run-invalid으로 해소됨. 후보 정의를 수정하지 않고 현재 실행 제약만 이 값으로 해석한다."
+    hypothesis: "55세션 종가 고점 상향 돌파와 자기 거래량 중앙값 2배 이상 동반 시 다음 10세션 지속성 가능."
+    side: long
+    universe_filter: "ADV20_pre_proxy >= USD 5,000,000 · volume 분할조정 여부 UNKNOWN 명시"
+    signal: "prior_close_high55=max(C_(t-55)..C_(t-1)); volume_ratio20=V_t/median(V_(t-20)..V_(t-1)); signal=(C_t>prior_close_high55) AND (R1>0.0) AND (2.0<=volume_ratio20<=10.0) AND no_active_position. high/low 미사용"
+    required_history: "56개 session close · 이전 20개+당일 양수 volume"
+    missing_data_handling: "결측·비유한·비양수·중앙값 0 → 신호 없음 · ratio 상한 10은 극단치 완화 guard이나 분할 오염 완전 제거 아님 · no-fill/run-invalid 동일"
+    entry: t_plus_1_open
+    exit: "D+10 session close (재이탈 조기 청산 없음)"
+    ranking: "ADV20_pre_proxy 내림차순만"
+    tie_break: "sha256 바이트 오름차순"
+    sizing: "USD 500 · 최대 10 · execution_envelope_compatible=CONDITIONAL_DATA_AND_COST"
+    parameter_values: {adv20_min_usd: 5000000, breakout_lookback_sessions: 55, volume_lookback_sessions: 20, volume_ratio_min: 2.0, volume_ratio_max: 10.0, daily_return_min: 0.0, hold_sessions: 10, fixed_notional_usd: 500, max_positions: 10}
+    param_sensitivity: NOT_AVAILABLE_IN_SOURCE
+    expected_trade_frequency: "DESIGN_PRIOR 월 6~19건; FREQ_QUERY."
+    falsification: "완료 <500 또는 고유 세션 <150, validation <100·고유 <30·각 연도 <40이면 폐기; 10bp/side 초과 ≤0bp 폐기; validation volume_ratio 상위 1% 제외 시 초과 ≤0bp 또는 상위 1%가 validation 초과의 50% 초과면 극단치 의존 폐기."
+    execution_envelope: "CONDITIONAL_DATA_AND_COST; volume 조정 여부와 비용은 UNKNOWN."
+    empirical_status: UNTESTED

--- a/tests/research/us_stage_b/__init__.py
+++ b/tests/research/us_stage_b/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic verification fixtures for the isolated US Stage-B engine."""

--- a/tests/research/us_stage_b/conftest.py
+++ b/tests/research/us_stage_b/conftest.py
@@ -9,8 +9,13 @@ from research.us_stage_b.contracts import USCostLiteral, USStageBRunContract
 from research.us_stage_b.registry import CandidateBinding, CandidateRegistry
 from research.us_stage_b.source import USStageBDailyBar
 
-FROZEN_YAML = Path(
-    "/Users/mgh3326/Documents/prior-art-map-v1/02-active-candidates.yaml"
+# Exact byte-for-byte frozen packet fixture.  Keeping it inside the test tree
+# makes the SHA-verified raw-parse contract portable to clean CI workers.
+FROZEN_YAML = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "us_u0_frozen"
+    / "02-active-candidates.yaml"
 )
 
 

--- a/tests/research/us_stage_b/conftest.py
+++ b/tests/research/us_stage_b/conftest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from research.us_stage_b.contracts import USCostLiteral, USStageBRunContract
+from research.us_stage_b.registry import CandidateBinding, CandidateRegistry
+from research.us_stage_b.source import USStageBDailyBar
+
+FROZEN_YAML = Path(
+    "/Users/mgh3326/Documents/prior-art-map-v1/02-active-candidates.yaml"
+)
+
+
+@pytest.fixture(scope="session")
+def registry() -> CandidateRegistry:
+    return CandidateRegistry.load(FROZEN_YAML)
+
+
+def candidate(registry: CandidateRegistry, strategy_id: str) -> CandidateBinding:
+    return registry.binding_for(strategy_id)
+
+
+def contract(
+    candidate_binding: CandidateBinding,
+    sessions: tuple[date, ...],
+) -> USStageBRunContract:
+    return USStageBRunContract(
+        candidate=candidate_binding,
+        exploration_start=sessions[0],
+        exploration_end=sessions[-1],
+        cost=USCostLiteral(base_bp_per_side=10, sensitivity_bp_per_side=5),
+    )
+
+
+def sequential_sessions(
+    count: int,
+    *,
+    start: date = date(2023, 1, 3),
+) -> tuple[date, ...]:
+    return tuple(start + timedelta(days=index) for index in range(count))
+
+
+def volbreak_bars(
+    symbol: str,
+    sessions: tuple[date, ...],
+    *,
+    adv_multiplier: float = 1.0,
+    no_entry_open: bool = False,
+    omit_exit: bool = False,
+) -> tuple[USStageBDailyBar, ...]:
+    """Build a single exact VOLBREAK signal at session index 55."""
+
+    bars: list[USStageBDailyBar] = []
+    base_volume = 50_000.0 * adv_multiplier
+    for index, session in enumerate(sessions):
+        adjusted_close = 100.0 + index * 0.1
+        volume = base_volume
+        if index == 55:
+            adjusted_close = 107.0
+            volume = 2.0 * base_volume
+        elif index > 55:
+            adjusted_close = 106.0
+        if omit_exit and index == 66:
+            continue
+        bars.append(
+            USStageBDailyBar(
+                symbol=symbol,
+                session_date=session,
+                open=None if no_entry_open and index == 56 else adjusted_close,
+                adjusted_close=adjusted_close,
+                volume=volume,
+            )
+        )
+    return tuple(bars)

--- a/tests/research/us_stage_b/test_engine.py
+++ b/tests/research/us_stage_b/test_engine.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+
+from research.us_stage_b.engine import rank_signal_observations, run_us_stage_b
+from research.us_stage_b.registry import US_CANDIDATE_ORDER
+from research.us_stage_b.signals import SignalObservation, tie_break_digest
+from research.us_stage_b.source import InMemoryUSBarSource, USStageBDailyBar
+
+from .conftest import candidate, contract, sequential_sessions, volbreak_bars
+
+
+def _observation(
+    *,
+    strategy_id: str,
+    contract_hash: str,
+    labels: tuple[str, ...],
+    symbol: str,
+    session: date,
+    adv: float,
+    z: float,
+) -> SignalObservation:
+    return SignalObservation(
+        strategy_id=strategy_id,
+        contract_hash=contract_hash,
+        labels=labels,
+        symbol=symbol,
+        session_date=session,
+        universe_eligible=True,
+        technical_signal=True,
+        no_active_position=True,
+        signal=True,
+        exclusion_reason=None,
+        adv20_pre_proxy=adv,
+        tie_break_sha256=tie_break_digest(strategy_id, session, symbol).hex(),
+        metrics={"z126": z},
+        stages={"signal": True},
+    )
+
+
+def test_rank_is_adv_only_then_exact_sha_byte_tie_break(registry) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[0])
+    session = date(2024, 3, 1)
+    observations = (
+        _observation(
+            strategy_id=binding.strategy_id,
+            contract_hash=binding.contract_hash,
+            labels=binding.labels,
+            symbol="LOW_HIGH_Z",
+            session=session,
+            adv=5_000_001.0,
+            z=100.0,
+        ),
+        _observation(
+            strategy_id=binding.strategy_id,
+            contract_hash=binding.contract_hash,
+            labels=binding.labels,
+            symbol="HIGH_LOW_Z",
+            session=session,
+            adv=5_000_002.0,
+            z=1.0,
+        ),
+    )
+    assert [item.symbol for item in rank_signal_observations(observations)] == [
+        "HIGH_LOW_Z",
+        "LOW_HIGH_Z",
+    ]
+
+    equal_adv = tuple(
+        _observation(
+            strategy_id=binding.strategy_id,
+            contract_hash=binding.contract_hash,
+            labels=binding.labels,
+            symbol=symbol,
+            session=session,
+            adv=5_000_001.0,
+            z=1.0,
+        )
+        for symbol in ("ZZZ", "AAA", "MID")
+    )
+    assert [item.symbol for item in rank_signal_observations(equal_adv)] == [
+        item.symbol
+        for item in sorted(
+            equal_adv, key=lambda item: bytes.fromhex(item.tie_break_sha256)
+        )
+    ]
+
+
+def test_entry_and_maturity_follow_corpus_session_index_not_calendar_days(
+    registry,
+) -> None:
+    first = tuple(date(2023, 1, 3) + timedelta(days=index) for index in range(56))
+    second = tuple(date(2023, 7, 1) + timedelta(days=2 * index) for index in range(14))
+    sessions = (*first, *second)
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    result = run_us_stage_b(
+        source=InMemoryUSBarSource(volbreak_bars("IDX", sessions)),
+        contract=contract(binding, sessions),
+        corpus_sessions=sessions,
+    )
+
+    outcome = next(
+        item
+        for item in result.outcomes
+        if item.symbol == "IDX" and item.signal_session == sessions[55]
+    )
+    assert outcome.status == "completed"
+    assert outcome.entry_session == sessions[56]
+    assert outcome.exit_session == sessions[66]
+    assert outcome.entry_session != outcome.signal_session + timedelta(days=1)
+    assert outcome.exit_session != outcome.entry_session + timedelta(days=10)
+    assert result.access_summary["outside_boundary_reads"] == 0
+
+
+def test_missing_selected_maturity_close_invalidates_the_whole_run(registry) -> None:
+    sessions = sequential_sessions(70)
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    result = run_us_stage_b(
+        source=InMemoryUSBarSource(volbreak_bars("MISS", sessions, omit_exit=True)),
+        contract=contract(binding, sessions),
+        corpus_sessions=sessions,
+    )
+
+    assert result.run_invalid is True
+    assert result.verdict.state == "RUN_INVALID"
+    assert [item.status for item in result.outcomes] == ["run_invalid_missing_exit"]
+    assert result.invalid_reasons[0].startswith("RUN_INVALID_MISSING_EXIT:MISS:")
+    assert "missing_exit" not in result.to_dict()["outcome_status_counts"]
+
+
+def test_no_fill_does_not_promote_a_lower_ranked_same_session_signal(registry) -> None:
+    sessions = sequential_sessions(70)
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    bars = tuple(
+        bar
+        for index in range(1, 12)
+        for bar in volbreak_bars(
+            f"S{index:02d}",
+            sessions,
+            adv_multiplier=float(index),
+            no_entry_open=index == 11,
+        )
+    )
+    result = run_us_stage_b(
+        source=InMemoryUSBarSource(bars),
+        contract=contract(binding, sessions),
+        corpus_sessions=sessions,
+    )
+    outcomes = [item for item in result.outcomes if item.signal_session == sessions[55]]
+
+    assert len(outcomes) == 11
+    assert outcomes[0].symbol == "S11"
+    assert outcomes[0].status == "entry_no_fill"
+    assert [item.status for item in outcomes].count("completed") == 9
+    rejected = [item for item in outcomes if item.status == "capacity_rejected"]
+    assert [item.symbol for item in rejected] == ["S01"]
+
+
+def test_empty_result_is_labeled_serializable_and_not_reported_as_success(
+    registry,
+) -> None:
+    sessions = sequential_sessions(3)
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    source = InMemoryUSBarSource(
+        (
+            USStageBDailyBar(
+                symbol="EMPTY",
+                session_date=sessions[0],
+                open=100.0,
+                adjusted_close=100.0,
+                volume=50_000.0,
+            ),
+        )
+    )
+    result = run_us_stage_b(
+        source=source,
+        contract=contract(binding, sessions),
+        corpus_sessions=sessions,
+    )
+    rendered = json.dumps(result.to_dict(), sort_keys=True)
+
+    assert result.outcomes == ()
+    assert result.verdict.state == "FALSIFIED_FREQUENCY"
+    for label in (
+        "EXPLORATORY_FALSIFICATION_ONLY",
+        "SURVIVORSHIP_BIASED=TRUE",
+        "PIT_DELIST_MISSING",
+        "EXECUTION_ENVELOPE_UNBOUND",
+        "VOLUME_CA_UNRESOLVED",
+    ):
+        assert label in rendered

--- a/tests/research/us_stage_b/test_engine.py
+++ b/tests/research/us_stage_b/test_engine.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from datetime import date, timedelta
 
-from research.us_stage_b.engine import rank_signal_observations, run_us_stage_b
+import research.us_stage_b.engine as engine_module
+from research.us_stage_b.engine import (
+    CohortComparison,
+    rank_signal_observations,
+    run_us_stage_b,
+)
 from research.us_stage_b.registry import US_CANDIDATE_ORDER
 from research.us_stage_b.signals import SignalObservation, tie_break_digest
 from research.us_stage_b.source import InMemoryUSBarSource, USStageBDailyBar
@@ -127,6 +132,170 @@ def test_missing_selected_maturity_close_invalidates_the_whole_run(registry) -> 
     assert [item.status for item in result.outcomes] == ["run_invalid_missing_exit"]
     assert result.invalid_reasons[0].startswith("RUN_INVALID_MISSING_EXIT:MISS:")
     assert "missing_exit" not in result.to_dict()["outcome_status_counts"]
+
+
+def test_terminal_maturity_without_a_close_invalidates_the_whole_run(registry) -> None:
+    """A selected terminal hold is not KR-style censoring or exclusion."""
+
+    sessions = sequential_sessions(57)
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    result = run_us_stage_b(
+        source=InMemoryUSBarSource(volbreak_bars("TERMINAL", sessions)),
+        contract=contract(binding, sessions),
+        corpus_sessions=sessions,
+    )
+
+    assert result.run_invalid is True
+    assert result.verdict.state == "RUN_INVALID"
+    assert len(result.outcomes) == 1
+    outcome = result.outcomes[0]
+    assert outcome.status == "run_invalid_missing_exit"
+    assert outcome.entry_session == sessions[56]
+    assert outcome.exit_session is None
+    assert result.invalid_reasons == (
+        "RUN_INVALID_MISSING_EXIT_TERMINAL:"
+        "TERMINAL:entry=2023-02-28:required_exit_session_index=66",
+    )
+    assert "censored" not in json.dumps(result.to_dict(), sort_keys=True)
+
+
+def test_terminal_signal_without_t_plus_1_open_is_no_fill_not_censoring(
+    registry,
+) -> None:
+    """No executable entry at the boundary stays the frozen no-fill rule."""
+
+    sessions = sequential_sessions(56)
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    result = run_us_stage_b(
+        source=InMemoryUSBarSource(volbreak_bars("LAST", sessions)),
+        contract=contract(binding, sessions),
+        corpus_sessions=sessions,
+    )
+
+    assert result.run_invalid is False
+    assert [outcome.status for outcome in result.outcomes] == ["entry_no_fill"]
+    assert result.outcomes[0].entry_session is None
+    assert "censored" not in json.dumps(result.to_dict(), sort_keys=True)
+
+
+def test_rev_engine_emits_independent_cost_profile_verdicts(
+    monkeypatch, registry
+) -> None:
+    """Engine assembly preserves a 10bp/5bp pair that can genuinely diverge."""
+
+    binding = candidate(registry, US_CANDIDATE_ORDER[1])
+    sessions = tuple(date(2023, 1, 1) + timedelta(days=index) for index in range(731))
+    symbols = tuple(f"R{index:02d}" for index in range(10))
+    session_index = {session: index for index, session in enumerate(sessions)}
+    source = InMemoryUSBarSource(
+        tuple(
+            USStageBDailyBar(
+                symbol=symbol,
+                session_date=session,
+                open=100.0,
+                adjusted_close=101.0,
+                volume=50_000.0,
+            )
+            for symbol in symbols
+            for session in sessions
+        )
+    )
+
+    def staged_rev_signal(
+        candidate_binding,
+        *,
+        symbol,
+        session_date,
+        history,
+        no_active_position,
+    ) -> SignalObservation:
+        del history
+        index = session_index[session_date]
+        scheduled = index <= len(sessions) - 5 and index % 4 == int(symbol[1:]) % 4
+        signal = scheduled and no_active_position
+        return SignalObservation(
+            strategy_id=candidate_binding.strategy_id,
+            contract_hash=candidate_binding.contract_hash,
+            labels=candidate_binding.labels,
+            symbol=symbol,
+            session_date=session_date,
+            universe_eligible=True,
+            technical_signal=scheduled,
+            no_active_position=no_active_position,
+            signal=signal,
+            exclusion_reason=None if signal else "ENGINE_SEMANTIC_FIXTURE",
+            adv20_pre_proxy=5_000_001.0,
+            tie_break_sha256=tie_break_digest(
+                candidate_binding.strategy_id, session_date, symbol
+            ).hex(),
+            metrics={"z3": -2.0},
+            stages={"engine_semantic_fixture": True},
+        )
+
+    def divergent_profile_cohorts(
+        *, contract, outcomes, observations, bars_by_symbol, sessions
+    ) -> tuple[CohortComparison, ...]:
+        del contract, observations, bars_by_symbol, sessions
+        comparisons: list[CohortComparison] = []
+        for outcome in outcomes:
+            if outcome.status != "completed":
+                continue
+            assert outcome.entry_session is not None
+            assert outcome.exit_session is not None
+            assert outcome.base_net_return is not None
+            assert outcome.sensitivity_net_return is not None
+            comparisons.append(
+                CohortComparison(
+                    strategy_id=outcome.strategy_id,
+                    contract_hash=outcome.contract_hash,
+                    labels=outcome.labels,
+                    symbol=outcome.symbol,
+                    signal_session=outcome.signal_session,
+                    entry_session=outcome.entry_session,
+                    exit_session=outcome.exit_session,
+                    liquidity_decile=9,
+                    eligible_universe_size=2,
+                    leave_one_out_member_count=1,
+                    excluded_entry_no_fill_count=0,
+                    excluded_maturity_close_count=0,
+                    status="completed",
+                    candidate_base_net_return=outcome.base_net_return,
+                    candidate_sensitivity_net_return=outcome.sensitivity_net_return,
+                    baseline_base_net_return=outcome.base_net_return + 0.001,
+                    baseline_sensitivity_net_return=(
+                        outcome.sensitivity_net_return - 0.001
+                    ),
+                    base_excess_return=-0.001,
+                    sensitivity_excess_return=0.001,
+                    volume_ratio20=None,
+                    tie_break_sha256=outcome.tie_break_sha256,
+                )
+            )
+        return tuple(comparisons)
+
+    monkeypatch.setattr(engine_module, "evaluate_signal", staged_rev_signal)
+    monkeypatch.setattr(
+        engine_module, "_build_cohort_comparisons", divergent_profile_cohorts
+    )
+    result = run_us_stage_b(
+        source=source,
+        contract=contract(binding, sessions),
+        corpus_sessions=sessions,
+    )
+
+    assert len(result.completed_outcomes) >= 1_000
+    profiles = result.cost_profile_verdicts
+    assert profiles is not None
+    assert profiles.base_10bp_per_side is not profiles.sensitivity_5bp_per_side
+    assert profiles.base_10bp_per_side.state == "FALSIFIED_VALIDATION_COHORT_EXCESS"
+    assert profiles.sensitivity_5bp_per_side.state == "NOT_FALSIFIED_EXPLORATORY_ONLY"
+    assert result.verdict.state == "FALSIFIED_COST_SENSITIVE"
+    rendered = result.to_dict()["cost_profile_verdicts"]
+    assert rendered["base_10bp_per_side"]["cost_profile"] == "base_10bp_per_side"
+    assert (
+        rendered["sensitivity_5bp_per_side"]["cost_profile"]
+        == "sensitivity_5bp_per_side"
+    )
 
 
 def test_no_fill_does_not_promote_a_lower_ranked_same_session_signal(registry) -> None:

--- a/tests/research/us_stage_b/test_engine.py
+++ b/tests/research/us_stage_b/test_engine.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import json
 from datetime import date, timedelta
+from statistics import mean
 
-import research.us_stage_b.engine as engine_module
-from research.us_stage_b.engine import (
-    CohortComparison,
-    rank_signal_observations,
-    run_us_stage_b,
-)
+import pytest
+
+from research.us_stage_b.engine import rank_signal_observations, run_us_stage_b
 from research.us_stage_b.registry import US_CANDIDATE_ORDER
 from research.us_stage_b.signals import SignalObservation, tie_break_digest
 from research.us_stage_b.source import InMemoryUSBarSource, USStageBDailyBar
@@ -178,124 +176,155 @@ def test_terminal_signal_without_t_plus_1_open_is_no_fill_not_censoring(
     assert "censored" not in json.dumps(result.to_dict(), sort_keys=True)
 
 
-def test_rev_engine_emits_independent_cost_profile_verdicts(
-    monkeypatch, registry
-) -> None:
-    """Engine assembly preserves a 10bp/5bp pair that can genuinely diverge."""
+def _raw_rev_cost_discriminator_bars(
+    sessions: tuple[date, ...],
+) -> tuple[tuple[str, ...], tuple[USStageBDailyBar, ...]]:
+    """Build 29,240 deterministic raw bars that straddle the frozen REV costs."""
 
-    binding = candidate(registry, US_CANDIDATE_ORDER[1])
-    sessions = tuple(date(2023, 1, 1) + timedelta(days=index) for index in range(731))
-    symbols = tuple(f"R{index:02d}" for index in range(10))
-    session_index = {session: index for index, session in enumerate(sessions)}
-    source = InMemoryUSBarSource(
-        tuple(
-            USStageBDailyBar(
-                symbol=symbol,
-                session_date=session,
-                open=100.0,
-                adjusted_close=101.0,
-                volume=50_000.0,
-            )
-            for symbol in symbols
-            for session in sessions
-        )
+    phase_count = 20
+    symbols = tuple(
+        f"R{phase:02d}_{member}" for phase in range(phase_count) for member in range(2)
     )
+    first_signal_index = 126
+    last_viable_signal_index = len(sessions) - 5
+    initial_history_last_shock_index = first_signal_index - 4
+    closes: dict[str, list[float]] = {}
+    for phase in range(phase_count):
+        for member in range(2):
+            symbol = f"R{phase:02d}_{member}"
+            close = 100.0
+            values: list[float] = []
+            for index in range(len(sessions)):
+                if index:
+                    shock = index % phase_count == phase and (
+                        index <= initial_history_last_shock_index
+                        or first_signal_index <= index <= last_viable_signal_index
+                    )
+                    close *= 0.8 if shock else 1.014
+                values.append(close)
+            closes[symbol] = values
 
-    def staged_rev_signal(
-        candidate_binding,
-        *,
-        symbol,
-        session_date,
-        history,
-        no_active_position,
-    ) -> SignalObservation:
-        del history
-        index = session_index[session_date]
-        scheduled = index <= len(sessions) - 5 and index % 4 == int(symbol[1:]) % 4
-        signal = scheduled and no_active_position
-        return SignalObservation(
-            strategy_id=candidate_binding.strategy_id,
-            contract_hash=candidate_binding.contract_hash,
-            labels=candidate_binding.labels,
-            symbol=symbol,
-            session_date=session_date,
-            universe_eligible=True,
-            technical_signal=scheduled,
-            no_active_position=no_active_position,
-            signal=signal,
-            exclusion_reason=None if signal else "ENGINE_SEMANTIC_FIXTURE",
-            adv20_pre_proxy=5_000_001.0,
-            tie_break_sha256=tie_break_digest(
-                candidate_binding.strategy_id, session_date, symbol
-            ).hex(),
-            metrics={"z3": -2.0},
-            stages={"engine_semantic_fixture": True},
+    # Two same-phase candidates are the only signal symbols on a session.  Set
+    # their actual D+3 close so each raw cohort has +15bp gross excess.  Under
+    # §13's strategy-only costs that is -5bp at 10bp/side and +5bp at 5bp/side.
+    target_gross_excess = 0.0015
+    adjusted_close_overrides: dict[tuple[str, int], float] = {}
+    for signal_index in range(first_signal_index, last_viable_signal_index + 1):
+        phase = signal_index % phase_count
+        signal_symbols = (f"R{phase:02d}_0", f"R{phase:02d}_1")
+        entry_index = signal_index + 1
+        exit_index = signal_index + 4
+        non_signal_gross_sum = sum(
+            closes[symbol][exit_index] / closes[symbol][entry_index] - 1.0
+            for symbol in symbols
+            if symbol not in signal_symbols
         )
+        target_candidate_gross = (
+            non_signal_gross_sum + (len(symbols) - 1) * target_gross_excess
+        ) / (len(symbols) - 2)
+        for symbol in signal_symbols:
+            adjusted_close_overrides[(symbol, exit_index)] = closes[symbol][
+                entry_index
+            ] * (1.0 + target_candidate_gross)
 
-    def divergent_profile_cohorts(
-        *, contract, outcomes, observations, bars_by_symbol, sessions
-    ) -> tuple[CohortComparison, ...]:
-        del contract, observations, bars_by_symbol, sessions
-        comparisons: list[CohortComparison] = []
-        for outcome in outcomes:
-            if outcome.status != "completed":
-                continue
-            assert outcome.entry_session is not None
-            assert outcome.exit_session is not None
-            assert outcome.base_net_return is not None
-            assert outcome.sensitivity_net_return is not None
-            comparisons.append(
-                CohortComparison(
-                    strategy_id=outcome.strategy_id,
-                    contract_hash=outcome.contract_hash,
-                    labels=outcome.labels,
-                    symbol=outcome.symbol,
-                    signal_session=outcome.signal_session,
-                    entry_session=outcome.entry_session,
-                    exit_session=outcome.exit_session,
-                    liquidity_decile=9,
-                    eligible_universe_size=2,
-                    leave_one_out_member_count=1,
-                    excluded_entry_no_fill_count=0,
-                    excluded_maturity_close_count=0,
-                    status="completed",
-                    candidate_base_net_return=outcome.base_net_return,
-                    candidate_sensitivity_net_return=outcome.sensitivity_net_return,
-                    baseline_base_net_return=outcome.base_net_return + 0.001,
-                    baseline_sensitivity_net_return=(
-                        outcome.sensitivity_net_return - 0.001
-                    ),
-                    base_excess_return=-0.001,
-                    sensitivity_excess_return=0.001,
-                    volume_ratio20=None,
-                    tie_break_sha256=outcome.tie_break_sha256,
+    bars: list[USStageBDailyBar] = []
+    for symbol in symbols:
+        for index, session in enumerate(sessions):
+            adjusted_close = adjusted_close_overrides.get(
+                (symbol, index), closes[symbol][index]
+            )
+            bars.append(
+                USStageBDailyBar(
+                    symbol=symbol,
+                    session_date=session,
+                    open=closes[symbol][index],
+                    adjusted_close=adjusted_close,
+                    # Every same-session eligible member has the same ADV20-pre.
+                    volume=10_000_000.0 / adjusted_close,
                 )
             )
-        return tuple(comparisons)
+    return symbols, tuple(bars)
 
-    monkeypatch.setattr(engine_module, "evaluate_signal", staged_rev_signal)
-    monkeypatch.setattr(
-        engine_module, "_build_cohort_comparisons", divergent_profile_cohorts
-    )
+
+def test_rev_cost_profiles_diverge_from_unpatched_raw_ohlcv(registry) -> None:
+    """The actual 10bp/5bp verdict split must survive the untouched engine."""
+
+    sessions = tuple(date(2023, 1, 1) + timedelta(days=index) for index in range(731))
+    symbols, bars = _raw_rev_cost_discriminator_bars(sessions)
+    binding = candidate(registry, US_CANDIDATE_ORDER[1])
     result = run_us_stage_b(
-        source=source,
+        source=InMemoryUSBarSource(bars),
         contract=contract(binding, sessions),
         corpus_sessions=sessions,
     )
 
-    assert len(result.completed_outcomes) >= 1_000
+    assert len(bars) == 29_240
+    assert result.run_invalid is False
+    assert len(result.completed_outcomes) == 1_202
+    assert len(result.cohorts) == 1_202
+    assert all(cohort.status == "completed" for cohort in result.cohorts)
+    assert len({outcome.entry_session for outcome in result.completed_outcomes}) == 601
+    assert (
+        sum(
+            outcome.entry_session is not None and outcome.entry_session.year == 2023
+            for outcome in result.completed_outcomes
+        )
+        == 476
+    )
+    assert (
+        sum(
+            outcome.entry_session is not None and outcome.entry_session.year == 2024
+            for outcome in result.completed_outcomes
+        )
+        == 726
+    )
+
     profiles = result.cost_profile_verdicts
     assert profiles is not None
     assert profiles.base_10bp_per_side is not profiles.sensitivity_5bp_per_side
     assert profiles.base_10bp_per_side.state == "FALSIFIED_VALIDATION_COHORT_EXCESS"
     assert profiles.sensitivity_5bp_per_side.state == "NOT_FALSIFIED_EXPLORATORY_ONLY"
     assert result.verdict.state == "FALSIFIED_COST_SENSITIVE"
-    rendered = result.to_dict()["cost_profile_verdicts"]
-    assert rendered["base_10bp_per_side"]["cost_profile"] == "base_10bp_per_side"
-    assert (
-        rendered["sensitivity_5bp_per_side"]["cost_profile"]
-        == "sensitivity_5bp_per_side"
+    assert profiles.base_10bp_per_side.gate_results[
+        "profile_entry_session_equal_weighted_excess"
+    ] == pytest.approx(-0.0005)
+    assert profiles.sensitivity_5bp_per_side.gate_results[
+        "profile_entry_session_equal_weighted_excess"
+    ] == pytest.approx(0.0005)
+    rendered_profiles = result.to_dict()["cost_profile_verdicts"]
+    assert rendered_profiles is not None
+    assert rendered_profiles["base_10bp_per_side"]["cost_profile"] == (
+        "base_10bp_per_side"
     )
+    assert rendered_profiles["sensitivity_5bp_per_side"]["cost_profile"] == (
+        "sensitivity_5bp_per_side"
+    )
+
+    bars_by_identity = {(bar.symbol, bar.session_date): bar for bar in bars}
+    first_cohort = result.cohorts[0]
+    assert first_cohort.entry_session is not None
+    assert first_cohort.exit_session is not None
+    baseline_gross_returns: list[float] = []
+    for symbol in symbols:
+        if symbol == first_cohort.symbol:
+            continue
+        entry_bar = bars_by_identity[(symbol, first_cohort.entry_session)]
+        exit_bar = bars_by_identity[(symbol, first_cohort.exit_session)]
+        assert entry_bar.open is not None
+        assert exit_bar.adjusted_close is not None
+        baseline_gross_returns.append(exit_bar.adjusted_close / entry_bar.open - 1.0)
+    baseline_gross = mean(baseline_gross_returns)
+    assert first_cohort.leave_one_out_member_count == 39
+    assert first_cohort.baseline_base_net_return == pytest.approx(baseline_gross)
+    assert first_cohort.baseline_sensitivity_net_return == pytest.approx(baseline_gross)
+    assert first_cohort.base_excess_return == pytest.approx(-0.0005)
+    assert first_cohort.sensitivity_excess_return == pytest.approx(0.0005)
+    for cohort in result.cohorts:
+        assert cohort.base_excess_return is not None
+        assert cohort.sensitivity_excess_return is not None
+        assert cohort.sensitivity_excess_return == pytest.approx(
+            cohort.base_excess_return + 0.001
+        )
 
 
 def test_no_fill_does_not_promote_a_lower_ranked_same_session_signal(registry) -> None:

--- a/tests/research/us_stage_b/test_isolation.py
+++ b/tests/research/us_stage_b/test_isolation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from research.us_stage_b.source import USStageBDailyBar
+
+MODULE_ROOT = Path(__file__).parents[3] / "research" / "us_stage_b"
+
+
+def test_us_engine_is_additive_and_does_not_import_legacy_signal_surfaces() -> None:
+    forbidden_prefixes = (
+        "app",
+        "research.crypto_stage_b",
+        "research.kr_corpus",
+        "research.three_market_shadow",
+        "research.us_corpus",
+    )
+    offenders: list[str] = []
+    for path in sorted(MODULE_ROOT.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [node.module or ""]
+            else:
+                continue
+            if any(name.startswith(forbidden_prefixes) for name in names):
+                offenders.append(f"{path.name}:{node.lineno}:{names!r}")
+    assert offenders == []
+
+
+def test_us_stage_b_input_exposes_only_the_frozen_candidate_fields() -> None:
+    assert tuple(USStageBDailyBar.__dataclass_fields__) == (
+        "symbol",
+        "session_date",
+        "open",
+        "adjusted_close",
+        "volume",
+    )

--- a/tests/research/us_stage_b/test_registry_and_contracts.py
+++ b/tests/research/us_stage_b/test_registry_and_contracts.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+from datetime import date
+
+import pytest
+
+from research.us_stage_b.contracts import (
+    ExplorationWindowError,
+    USCostLiteral,
+    USStageBRunContract,
+)
+from research.us_stage_b.registry import (
+    FROZEN_CANDIDATES_SHA256,
+    US_CANDIDATE_ORDER,
+    CandidateRegistry,
+    RegistryStartRejected,
+)
+
+from .conftest import FROZEN_YAML, candidate, sequential_sessions
+
+
+def test_registry_parses_original_packet_bytes_and_stamps_raw_contract_hashes(
+    registry: CandidateRegistry,
+) -> None:
+    source = FROZEN_YAML.read_bytes()
+    assert hashlib.sha256(source).hexdigest() == FROZEN_CANDIDATES_SHA256
+    assert tuple(item.strategy_id for item in registry.admitted) == US_CANDIDATE_ORDER
+    assert [item.contract_hash for item in registry.admitted] == [
+        "25d06a5e81c03a254948ee20b9180d466e5531a63715dd1ba53b7160ce032509",
+        "7052f69ae1ae20de53750276c006959694941a1b2a430c99c8dbbe616cba9836",
+        "43ff9a4a99ba3717c2d5563aa58c8a482800082c4fa4c41330712c4460848b0f",
+    ]
+    for item in registry.admitted:
+        payload = item.to_dict()
+        assert payload["strategy_id"] == item.strategy_id
+        assert payload["contract_hash"] == item.contract_hash
+        assert "EXPLORATORY_FALSIFICATION_ONLY" in payload["labels"]
+        assert "SURVIVORSHIP_BIASED=TRUE" in payload["labels"]
+
+
+def test_registry_refuses_any_packet_byte_drift_before_parsing() -> None:
+    source = FROZEN_YAML.read_bytes()
+    with pytest.raises(RegistryStartRejected, match="SHA mismatch"):
+        CandidateRegistry.from_verbatim_bytes(
+            source + b" ", expected_sha256=FROZEN_CANDIDATES_SHA256
+        )
+
+
+def test_registry_refuses_unknown_strategy_instead_of_shared_fallback(
+    registry: CandidateRegistry,
+) -> None:
+    with pytest.raises(RegistryStartRejected, match="shared fallback"):
+        registry.binding_for("us_momentum")
+
+
+def test_cost_literals_are_explicit_and_holdout_intersection_is_refused(
+    registry: CandidateRegistry,
+) -> None:
+    signature = inspect.signature(USCostLiteral)
+    assert signature.parameters["base_bp_per_side"].default is inspect.Parameter.empty
+    assert (
+        signature.parameters["sensitivity_bp_per_side"].default
+        is inspect.Parameter.empty
+    )
+    with pytest.raises(ValueError, match="exactly 10bp/side"):
+        USCostLiteral(base_bp_per_side=9, sensitivity_bp_per_side=5)
+
+    with pytest.raises(ExplorationWindowError, match="2025"):
+        USStageBRunContract(
+            candidate=candidate(registry, US_CANDIDATE_ORDER[0]),
+            exploration_start=date(2024, 12, 30),
+            exploration_end=date(2025, 1, 1),
+            cost=USCostLiteral(base_bp_per_side=10, sensitivity_bp_per_side=5),
+        )
+
+
+def test_run_contract_is_stamped_and_does_not_inject_cost_defaults(
+    registry: CandidateRegistry,
+) -> None:
+    sessions = sequential_sessions(3)
+    binding = candidate(registry, US_CANDIDATE_ORDER[1])
+    run = USStageBRunContract(
+        candidate=binding,
+        exploration_start=sessions[0],
+        exploration_end=sessions[-1],
+        cost=USCostLiteral(base_bp_per_side=10, sensitivity_bp_per_side=5),
+    )
+    payload = run.to_dict()
+    assert payload["strategy_id"] == binding.strategy_id
+    assert payload["contract_hash"] == binding.contract_hash
+    assert payload["cost_literal"] == {
+        "base_bp_per_side": 10,
+        "base_round_trip_bp": 20,
+        "sensitivity_bp_per_side": 5,
+        "sensitivity_round_trip_bp": 10,
+    }

--- a/tests/research/us_stage_b/test_signals.py
+++ b/tests/research/us_stage_b/test_signals.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from research.us_stage_b.registry import US_CANDIDATE_ORDER
+from research.us_stage_b.signals import evaluate_signal
+from research.us_stage_b.source import USStageBDailyBar
+
+from .conftest import candidate, sequential_sessions, volbreak_bars
+
+
+def _mom_bars() -> tuple[USStageBDailyBar, ...]:
+    sessions = sequential_sessions(127)
+    close = 100.0
+    bars: list[USStageBDailyBar] = []
+    for index, session in enumerate(sessions):
+        if index:
+            close *= 1.0025 if index % 2 else 1.0015
+        bars.append(
+            USStageBDailyBar(
+                symbol="MOM",
+                session_date=session,
+                open=close,
+                adjusted_close=close,
+                # Current volume is intentionally enormous; ADV20-pre must not use it.
+                volume=5_000_000.0 if index == 126 else 50_000.0,
+            )
+        )
+    return tuple(bars)
+
+
+def _rev_bars() -> tuple[USStageBDailyBar, ...]:
+    sessions = sequential_sessions(127)
+    close = 100.0
+    bars: list[USStageBDailyBar] = []
+    for index, session in enumerate(sessions):
+        if index:
+            close *= 0.97 if index >= 124 else 1.001
+        bars.append(
+            USStageBDailyBar(
+                symbol="REV",
+                session_date=session,
+                open=close,
+                adjusted_close=close,
+                volume=50_000.0,
+            )
+        )
+    return tuple(bars)
+
+
+def _sample_std(values: list[float]) -> float:
+    average = sum(values) / len(values)
+    return math.sqrt(
+        sum((value - average) ** 2 for value in values) / (len(values) - 1)
+    )
+
+
+def test_mom_uses_sample_sigma63_sqrt126_and_pre_signal_adv_only(registry) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[0])
+    bars = _mom_bars()
+    observation = evaluate_signal(
+        binding,
+        symbol="MOM",
+        session_date=bars[-1].session_date,
+        history=bars,
+        no_active_position=True,
+    )
+
+    closes = [float(bar.adjusted_close) for bar in bars]
+    returns = [closes[index] / closes[index - 1] - 1.0 for index in range(64, 127)]
+    sigma63 = _sample_std(returns)
+    expected_z = (closes[-1] / closes[0] - 1.0) / (sigma63 * math.sqrt(126))
+    expected_adv = (
+        sum(closes[index] * float(bars[index].volume) for index in range(106, 126)) / 20
+    )
+
+    assert observation.signal is True
+    assert observation.metrics["sigma63_ddof1"] == pytest.approx(sigma63)
+    assert observation.metrics["z126"] == pytest.approx(expected_z)
+    assert observation.adv20_pre_proxy == pytest.approx(expected_adv)
+    assert observation.adv20_pre_proxy < 10_000_000.0
+
+
+def test_mom_keeps_the_no_active_position_condition_outside_ranking(registry) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[0])
+    bars = _mom_bars()
+    observation = evaluate_signal(
+        binding,
+        symbol="MOM",
+        session_date=bars[-1].session_date,
+        history=bars,
+        no_active_position=False,
+    )
+
+    assert observation.universe_eligible is True
+    assert observation.technical_signal is True
+    assert observation.signal is False
+    assert observation.exclusion_reason == "active_position"
+
+
+def test_rev_uses_r3_sigma60_sqrt3_and_r126_trend(registry) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[1])
+    bars = _rev_bars()
+    observation = evaluate_signal(
+        binding,
+        symbol="REV",
+        session_date=bars[-1].session_date,
+        history=bars,
+        no_active_position=True,
+    )
+
+    closes = [float(bar.adjusted_close) for bar in bars]
+    returns = [closes[index] / closes[index - 1] - 1.0 for index in range(67, 127)]
+    sigma60 = _sample_std(returns)
+    expected_r3 = closes[-1] / closes[-4] - 1.0
+    expected_z = expected_r3 / (sigma60 * math.sqrt(3))
+
+    assert observation.signal is True
+    assert observation.metrics["sigma60_ddof1"] == pytest.approx(sigma60)
+    assert observation.metrics["r3"] == pytest.approx(expected_r3)
+    assert observation.metrics["z3"] == pytest.approx(expected_z)
+    assert observation.metrics["r126"] > 0.0
+
+
+def test_volbreak_uses_prior_close_window_and_current_to_prior_volume_ratio(
+    registry,
+) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    sessions = sequential_sessions(56)
+    bars = volbreak_bars("VOL", sessions)
+    observation = evaluate_signal(
+        binding,
+        symbol="VOL",
+        session_date=sessions[-1],
+        history=bars,
+        no_active_position=True,
+    )
+
+    assert observation.signal is True
+    assert observation.metrics["prior_close_high55"] == pytest.approx(105.4)
+    assert observation.metrics["r1"] > 0.0
+    assert observation.metrics["volume_ratio20"] == pytest.approx(2.0)
+    assert "VOLUME_CA_UNRESOLVED" in observation.labels
+    assert not hasattr(bars[-1], "high")
+    assert not hasattr(bars[-1], "low")
+
+
+def test_volbreak_refuses_nonpositive_current_volume_without_imputation(
+    registry,
+) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    sessions = sequential_sessions(56)
+    bars = list(volbreak_bars("VOL", sessions))
+    bars[-1] = USStageBDailyBar(
+        symbol="VOL",
+        session_date=sessions[-1],
+        open=107.0,
+        adjusted_close=107.0,
+        volume=0.0,
+    )
+    observation = evaluate_signal(
+        binding,
+        symbol="VOL",
+        session_date=sessions[-1],
+        history=bars,
+        no_active_position=True,
+    )
+
+    assert observation.signal is False
+    assert observation.exclusion_reason == "invalid_current_or_prior_volume"

--- a/tests/research/us_stage_b/test_verdict.py
+++ b/tests/research/us_stage_b/test_verdict.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from research.us_stage_b.engine import CohortComparison, TradeOutcome
+from research.us_stage_b.registry import US_CANDIDATE_ORDER
+from research.us_stage_b.verdict import evaluate_falsification
+
+from .conftest import candidate
+
+
+def _outcome(binding, *, symbol: str, entry_session: date) -> TradeOutcome:
+    return TradeOutcome(
+        strategy_id=binding.strategy_id,
+        contract_hash=binding.contract_hash,
+        labels=binding.labels,
+        symbol=symbol,
+        signal_session=entry_session - timedelta(days=1),
+        entry_session=entry_session,
+        exit_session=entry_session + timedelta(days=1),
+        status="completed",
+        selection_rank=1,
+        fixed_notional_usd=500.0,
+        adv20_pre_proxy=5_000_001.0,
+        tie_break_sha256=("00" * 31) + f"{int(symbol[1:]) % 256:02x}",
+        entry_open=100.0,
+        exit_adjusted_close=101.0,
+        gross_return=0.01,
+        base_net_return=0.008,
+        sensitivity_net_return=0.009,
+        volume_ratio20=2.0,
+    )
+
+
+def _cohort(
+    binding,
+    *,
+    symbol: str,
+    entry_session: date,
+    base_excess: float,
+    sensitivity_excess: float,
+    volume_ratio20: float,
+) -> CohortComparison:
+    return CohortComparison(
+        strategy_id=binding.strategy_id,
+        contract_hash=binding.contract_hash,
+        labels=binding.labels,
+        symbol=symbol,
+        signal_session=entry_session - timedelta(days=1),
+        entry_session=entry_session,
+        exit_session=entry_session + timedelta(days=1),
+        liquidity_decile=9,
+        eligible_universe_size=2,
+        leave_one_out_member_count=1,
+        excluded_entry_no_fill_count=0,
+        excluded_maturity_close_count=0,
+        status="completed",
+        candidate_base_net_return=0.008,
+        candidate_sensitivity_net_return=0.009,
+        baseline_base_net_return=0.008 - base_excess,
+        baseline_sensitivity_net_return=0.009 - sensitivity_excess,
+        base_excess_return=base_excess,
+        sensitivity_excess_return=sensitivity_excess,
+        volume_ratio20=volume_ratio20,
+        tie_break_sha256=("00" * 31) + f"{int(symbol[1:]) % 256:02x}",
+    )
+
+
+def _sample(
+    binding,
+    *,
+    total_count: int,
+    validation_2023_count: int,
+    validation_2024_count: int,
+    base_excess: float,
+    sensitivity_excess: float,
+    top_volume_excess: float | None = None,
+) -> tuple[tuple[TradeOutcome, ...], tuple[CohortComparison, ...]]:
+    dates = (
+        tuple(
+            date(2023, 1, 1) + timedelta(days=index)
+            for index in range(validation_2023_count)
+        )
+        + tuple(
+            date(2024, 1, 1) + timedelta(days=index)
+            for index in range(validation_2024_count)
+        )
+        + tuple(
+            date(2020, 1, 1) + timedelta(days=index)
+            for index in range(
+                total_count - validation_2023_count - validation_2024_count
+            )
+        )
+    )
+    outcomes = tuple(
+        _outcome(binding, symbol=f"S{index:05d}", entry_session=entry_session)
+        for index, entry_session in enumerate(dates)
+    )
+    validation_count = validation_2023_count + validation_2024_count
+    cohorts = tuple(
+        _cohort(
+            binding,
+            symbol=f"S{index:05d}",
+            entry_session=dates[index],
+            base_excess=(
+                top_volume_excess
+                if index == 0 and top_volume_excess is not None
+                else base_excess
+            ),
+            sensitivity_excess=sensitivity_excess,
+            volume_ratio20=100.0 if index == 0 else 2.0,
+        )
+        for index in range(validation_count)
+    )
+    return outcomes, cohorts
+
+
+def test_mom_rejects_nonpositive_validation_session_weighted_cohort_excess(
+    registry,
+) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[0])
+    outcomes, cohorts = _sample(
+        binding,
+        total_count=400,
+        validation_2023_count=30,
+        validation_2024_count=30,
+        base_excess=-0.001,
+        sensitivity_excess=-0.001,
+    )
+    verdict = evaluate_falsification(
+        candidate=binding,
+        outcomes=outcomes,
+        cohorts=cohorts,
+        run_invalid=False,
+        invalid_reasons=(),
+    )
+
+    assert verdict.state == "FALSIFIED_VALIDATION_COHORT_EXCESS"
+    assert (
+        verdict.gate_results[
+            "validation_entry_session_equal_weighted_base_excess_gt_zero"
+        ]
+        is False
+    )
+
+
+def test_rev_identifies_the_frozen_10bp_fail_5bp_positive_cost_sensitive_case(
+    registry,
+) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[1])
+    outcomes, cohorts = _sample(
+        binding,
+        total_count=1_000,
+        validation_2023_count=100,
+        validation_2024_count=100,
+        base_excess=-0.001,
+        sensitivity_excess=0.001,
+    )
+    verdict = evaluate_falsification(
+        candidate=binding,
+        outcomes=outcomes,
+        cohorts=cohorts,
+        run_invalid=False,
+        invalid_reasons=(),
+    )
+
+    assert verdict.state == "FALSIFIED_COST_SENSITIVE"
+    assert verdict.gate_results["cost_sensitive_failure"] is True
+
+
+def test_volbreak_rejects_top_one_percent_extreme_dependence(registry) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[2])
+    outcomes, cohorts = _sample(
+        binding,
+        total_count=500,
+        validation_2023_count=50,
+        validation_2024_count=50,
+        base_excess=0.001,
+        sensitivity_excess=0.001,
+        top_volume_excess=0.2,
+    )
+    verdict = evaluate_falsification(
+        candidate=binding,
+        outcomes=outcomes,
+        cohorts=cohorts,
+        run_invalid=False,
+        invalid_reasons=(),
+    )
+
+    assert verdict.state == "FALSIFIED_EXTREME_DEPENDENCE"
+    assert verdict.gate_results["top_1_percent_count"] == 1
+    assert verdict.gate_results["top_1_percent_excess_contribution_ratio"] > 0.5

--- a/tests/research/us_stage_b/test_verdict.py
+++ b/tests/research/us_stage_b/test_verdict.py
@@ -4,7 +4,10 @@ from datetime import date, timedelta
 
 from research.us_stage_b.engine import CohortComparison, TradeOutcome
 from research.us_stage_b.registry import US_CANDIDATE_ORDER
-from research.us_stage_b.verdict import evaluate_falsification
+from research.us_stage_b.verdict import (
+    evaluate_falsification,
+    evaluate_falsification_evidence,
+)
 
 from .conftest import candidate
 
@@ -156,16 +159,44 @@ def test_rev_identifies_the_frozen_10bp_fail_5bp_positive_cost_sensitive_case(
         base_excess=-0.001,
         sensitivity_excess=0.001,
     )
-    verdict = evaluate_falsification(
+    evaluation = evaluate_falsification_evidence(
         candidate=binding,
         outcomes=outcomes,
         cohorts=cohorts,
         run_invalid=False,
         invalid_reasons=(),
     )
+    verdict = evaluation.verdict
 
     assert verdict.state == "FALSIFIED_COST_SENSITIVE"
     assert verdict.gate_results["cost_sensitive_failure"] is True
+    assert evaluation.cost_profile_verdicts is not None
+    assert (
+        evaluation.cost_profile_verdicts.base_10bp_per_side.state
+        == "FALSIFIED_VALIDATION_COHORT_EXCESS"
+    )
+    assert (
+        evaluation.cost_profile_verdicts.sensitivity_5bp_per_side.state
+        == "NOT_FALSIFIED_EXPLORATORY_ONLY"
+    )
+
+
+def test_rev_run_invalid_is_emitted_for_both_cost_profiles(registry) -> None:
+    binding = candidate(registry, US_CANDIDATE_ORDER[1])
+    evaluation = evaluate_falsification_evidence(
+        candidate=binding,
+        outcomes=(),
+        cohorts=(),
+        run_invalid=True,
+        invalid_reasons=("RUN_INVALID_MISSING_EXIT_TERMINAL:REV",),
+    )
+
+    assert evaluation.verdict.state == "RUN_INVALID"
+    assert evaluation.cost_profile_verdicts is not None
+    assert evaluation.cost_profile_verdicts.base_10bp_per_side.state == "RUN_INVALID"
+    assert (
+        evaluation.cost_profile_verdicts.sensitivity_5bp_per_side.state == "RUN_INVALID"
+    )
 
 
 def test_volbreak_rejects_top_one_percent_extreme_dependence(registry) -> None:


### PR DESCRIPTION
## Summary
- Add an additive, US-only Stage-B registry, signal engine, and falsification verdict layer bound directly to the frozen candidate YAML.
- Preserve US semantics: corpus-session indexing, run-invalid missing maturity exit, survivor-bias labels, and explicit 10bp/side plus 5bp/side sensitivity costs.
- Emit deterministic, JSON-serializable intermediate evidence for independent double-implementation comparison; no shared-signal fallback.

## Verification
- `uv run pytest -q tests/research/us_stage_b`
- `uv run pytest -q research/kr_corpus/backtest/market_adapters/tests/test_us_adapter.py research/kr_corpus/backtest/tests/test_holdout_refusal.py`
- `make lint`

## Scope
No corpus run, holdout access, broker/account/DB mutation, scheduler, deployment, or merge. U1 remains the separate run relay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic US Stage-B research engine for momentum, reversal, and volume-breakout strategies.
  * Added validated market data, signal evaluation, trade simulation, liquidity cohorts, cost sensitivity, and falsification verdicts.
  * Added frozen candidate validation with provenance and configuration tracking.
  * Added safeguards for exploration boundaries, missing data, invalid inputs, capacity limits, and unavailable results.

* **Tests**
  * Added comprehensive coverage for signals, execution, contracts, registry integrity, isolation, and verdict evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->