### PR TITLE
feat(research): US Stage-B real-corpus adapter + scheduleless CLI (US-U1)

### DIFF
--- a/research/us_stage_b/__init__.py
+++ b/research/us_stage_b/__init__.py
@@ -9,6 +9,7 @@ from .engine import (
     rank_signal_observations,
     run_us_stage_b,
 )
+from .parquet_source import ParquetUSBarSource, PathAccessSpy
 from .registry import CandidateRegistry
 from .source import InMemoryUSBarSource, USStageBDailyBar
 from .verdict import FalsificationVerdict, RevCostProfileVerdicts
@@ -18,6 +19,8 @@ __all__ = [
     "CohortComparison",
     "FalsificationVerdict",
     "InMemoryUSBarSource",
+    "ParquetUSBarSource",
+    "PathAccessSpy",
     "TradeOutcome",
     "RevCostProfileVerdicts",
     "USCostLiteral",

--- a/research/us_stage_b/cli.py
+++ b/research/us_stage_b/cli.py
@@ -3,7 +3,8 @@
 This entry point is operator-owned and has no TaskIQ/cron/Prefect registration.
 It refuses holdout/staging roots, 2025+ exploration bounds, unknown candidates,
 contract-hash drift, output overwrites, and any input-mutation request.  Output
-is written atomically via a temporary ``.partial`` sibling.
+is written atomically via a temporary ``.partial`` sibling, streaming JSON so
+the full payload string is never held in RAM twice.
 """
 
 from __future__ import annotations
@@ -12,11 +13,12 @@ import argparse
 import json
 import os
 import sys
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from .contracts import (
     US_EXPLORATION_END,
@@ -156,6 +158,7 @@ def run_from_args(args: CliArgs) -> Path:
     _validate_exploration_bounds(args.exploration_start, args.exploration_end)
     _validate_year_roots(args.year_roots)
     _validate_output_path(args.output, year_roots=args.year_roots)
+    _cleanup_stranded_partials(args.output)
 
     try:
         registry = CandidateRegistry.load(args.candidates_yaml)
@@ -184,23 +187,40 @@ def run_from_args(args: CliArgs) -> Path:
             "no corpus sessions remain inside the explicit exploration window"
         )
 
+    symbols = source.symbols()
+    _emit_scale_estimate(
+        sessions=len(sessions),
+        symbols=len(symbols),
+        rows_loaded=int(source.access_summary().get("rows_loaded", 0)),
+        candidate_id=args.candidate_id,
+    )
+
     contract = USStageBRunContract(
         candidate=binding,
         exploration_start=args.exploration_start,
         exploration_end=args.exploration_end,
         cost=USCostLiteral(base_bp_per_side=10, sensitivity_bp_per_side=5),
     )
+    started = time.perf_counter()
     run_result = run_us_stage_b(
         source=source,
         contract=contract,
         corpus_sessions=sessions,
     )
+    elapsed = time.perf_counter() - started
     payload = run_result.to_dict()
     payload["adapter"] = {
         "kind": "parquet_us_bar_source",
         "year_roots": [str(root) for root in args.year_roots],
         "path_access_summary": source.access_summary(),
         "engine_access_summary": dict(run_result.access_summary),
+        "scale_estimate": {
+            "sessions": len(sessions),
+            "symbols": len(symbols),
+            "cell_evals": len(sessions) * len(symbols),
+            "rows_loaded": int(source.access_summary().get("rows_loaded", 0)),
+        },
+        "engine_wall_seconds": elapsed,
         "ORDERS": 0,
         "ACCOUNT_CONTACT": 0,
         "DB_WRITES": 0,
@@ -218,25 +238,79 @@ def run_from_args(args: CliArgs) -> Path:
 
 
 def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
-    """Write JSON via ``.partial`` + fsync + ``os.replace``; refuse overwrites."""
+    """Stream JSON to a unique ``.partial``, fsync, then ``os.replace``.
+
+    Overwrites of the final path are refused.  A stranded partial left by an
+    earlier SIGKILL/OOM is removed before a new attempt (SHOULD-2).  The full
+    payload is never materialised as a second Python ``str`` + ``bytes`` pair;
+    ``json.dump`` writes directly to the file object.
+    """
 
     if path.exists():
         raise CliRejection(f"output overwrite refused: {path}")
     if is_forbidden_corpus_path(path):
         raise CliRejection(f"output path under forbidden corpus segment: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
-    body = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
-    partial = path.with_name(path.name + ".partial")
+    _cleanup_stranded_partials(path)
+    partial = path.with_name(f"{path.name}.{os.getpid()}.{time.time_ns()}.partial")
     try:
-        with partial.open("wb") as handle:
-            handle.write(body)
+        with partial.open("w", encoding="utf-8") as handle:
+            _dump_json(payload, handle)
             handle.flush()
             os.fsync(handle.fileno())
+        if path.exists():
+            raise CliRejection(f"output overwrite refused: {path}")
         os.replace(partial, path)
     except Exception:
         if partial.exists():
             partial.unlink(missing_ok=True)
         raise
+
+
+def _dump_json(payload: dict[str, Any], handle: TextIO) -> None:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+
+
+def _cleanup_stranded_partials(path: Path) -> None:
+    """Remove orphaned partial siblings for this output basename.
+
+    SIGKILL/OOM can leave ``*.partial`` files because process-local ``except``
+    handlers never run.  Cleaning them before a new write prevents silent
+    disk clutter; the final artifact path remains no-overwrite.
+    """
+
+    parent = path.parent
+    if not parent.is_dir():
+        return
+    legacy = path.with_name(path.name + ".partial")
+    if legacy.exists() and legacy.is_file():
+        legacy.unlink(missing_ok=True)
+    prefix = f"{path.name}."
+    for child in parent.iterdir():
+        if not child.is_file():
+            continue
+        if child.name.startswith(prefix) and child.name.endswith(".partial"):
+            child.unlink(missing_ok=True)
+
+
+def _emit_scale_estimate(
+    *,
+    sessions: int,
+    symbols: int,
+    rows_loaded: int,
+    candidate_id: str,
+) -> None:
+    cell_evals = sessions * symbols
+    print(
+        "SCALE_ESTIMATE "
+        f"candidate={candidate_id} "
+        f"sessions={sessions} "
+        f"symbols={symbols} "
+        f"cell_evals={cell_evals} "
+        f"rows_loaded={rows_loaded}",
+        file=sys.stderr,
+    )
 
 
 def _parse_date(raw: str) -> date:

--- a/research/us_stage_b/cli.py
+++ b/research/us_stage_b/cli.py
@@ -1,0 +1,300 @@
+"""Scheduleless CLI for one frozen US Stage-B candidate against explicit year roots.
+
+This entry point is operator-owned and has no TaskIQ/cron/Prefect registration.
+It refuses holdout/staging roots, 2025+ exploration bounds, unknown candidates,
+contract-hash drift, output overwrites, and any input-mutation request.  Output
+is written atomically via a temporary ``.partial`` sibling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from .contracts import (
+    US_EXPLORATION_END,
+    US_EXPLORATION_START,
+    US_HOLDOUT_START,
+    USCostLiteral,
+    USStageBRunContract,
+)
+from .engine import run_us_stage_b
+from .parquet_source import (
+    CorpusPathAccessError,
+    ParquetUSBarSource,
+    PathAccessSpy,
+    assert_year_root_allowed,
+    is_forbidden_corpus_path,
+)
+from .registry import CandidateRegistry, RegistryStartRejected
+
+__all__ = [
+    "CliRejection",
+    "atomic_write_json",
+    "build_parser",
+    "main",
+    "run_from_args",
+]
+
+
+class CliRejection(ValueError):
+    """A CLI argument or gate failed closed before any economic side effect."""
+
+
+@dataclass(frozen=True)
+class CliArgs:
+    candidate_id: str
+    contract_hash: str
+    candidates_yaml: Path
+    year_roots: tuple[Path, ...]
+    exploration_start: date
+    exploration_end: date
+    output: Path
+    mutate_input: bool
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.us_stage_b.cli",
+        description=(
+            "Run one frozen US Stage-B candidate against explicit exploration "
+            "year Parquet roots (scheduleless, read-only corpus)."
+        ),
+    )
+    parser.add_argument(
+        "--candidate-id",
+        required=True,
+        help="Exact frozen strategy_id (no family/name fallback).",
+    )
+    parser.add_argument(
+        "--contract-hash",
+        required=True,
+        help="Raw YAML list-item SHA-256 that must match the registry binding.",
+    )
+    parser.add_argument(
+        "--candidates-yaml",
+        type=Path,
+        required=True,
+        help="Path to the frozen 02-active-candidates.yaml packet.",
+    )
+    parser.add_argument(
+        "--year-root",
+        type=Path,
+        action="append",
+        dest="year_roots",
+        required=True,
+        help=(
+            "Explicit allowlisted year directory (year=2016..year=2024). "
+            "Repeat once per year; parent globs and holdout/staging are refused."
+        ),
+    )
+    parser.add_argument(
+        "--exploration-start",
+        type=_parse_date,
+        required=True,
+        help="Inclusive exploration start date (YYYY-MM-DD), >= 2016-01-01.",
+    )
+    parser.add_argument(
+        "--exploration-end",
+        type=_parse_date,
+        required=True,
+        help="Inclusive exploration end date (YYYY-MM-DD), <= 2024-12-31.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="JSON output path (must not already exist; written atomically).",
+    )
+    parser.add_argument(
+        "--mutate-input",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    namespace = parser.parse_args(list(argv) if argv is not None else None)
+    args = CliArgs(
+        candidate_id=namespace.candidate_id,
+        contract_hash=namespace.contract_hash,
+        candidates_yaml=Path(namespace.candidates_yaml),
+        year_roots=tuple(Path(root) for root in namespace.year_roots),
+        exploration_start=namespace.exploration_start,
+        exploration_end=namespace.exploration_end,
+        output=Path(namespace.output),
+        mutate_input=bool(namespace.mutate_input),
+    )
+    try:
+        result_path = run_from_args(args)
+    except CliRejection as exc:
+        print(f"REJECTED: {exc}", file=sys.stderr)
+        return 2
+    except (CorpusPathAccessError, RegistryStartRejected) as exc:
+        print(f"REJECTED: {exc}", file=sys.stderr)
+        return 2
+    print(str(result_path))
+    return 0
+
+
+def run_from_args(args: CliArgs) -> Path:
+    """Execute one candidate run and atomically publish the JSON artifact."""
+
+    if args.mutate_input:
+        raise CliRejection("input mutation request refused")
+
+    _validate_exploration_bounds(args.exploration_start, args.exploration_end)
+    _validate_year_roots(args.year_roots)
+    _validate_output_path(args.output, year_roots=args.year_roots)
+
+    try:
+        registry = CandidateRegistry.load(args.candidates_yaml)
+        binding = registry.binding_for(args.candidate_id)
+    except RegistryStartRejected as exc:
+        raise CliRejection(str(exc)) from exc
+
+    if binding.contract_hash != args.contract_hash:
+        raise CliRejection(
+            "contract-hash mismatch: "
+            f"expected={binding.contract_hash} provided={args.contract_hash}"
+        )
+
+    access_spy = PathAccessSpy()
+    source = ParquetUSBarSource.from_year_roots(
+        args.year_roots,
+        access_spy=access_spy,
+    )
+    sessions = tuple(
+        session
+        for session in source.corpus_sessions()
+        if args.exploration_start <= session <= args.exploration_end
+    )
+    if not sessions:
+        raise CliRejection(
+            "no corpus sessions remain inside the explicit exploration window"
+        )
+
+    contract = USStageBRunContract(
+        candidate=binding,
+        exploration_start=args.exploration_start,
+        exploration_end=args.exploration_end,
+        cost=USCostLiteral(base_bp_per_side=10, sensitivity_bp_per_side=5),
+    )
+    run_result = run_us_stage_b(
+        source=source,
+        contract=contract,
+        corpus_sessions=sessions,
+    )
+    payload = run_result.to_dict()
+    payload["adapter"] = {
+        "kind": "parquet_us_bar_source",
+        "year_roots": [str(root) for root in args.year_roots],
+        "path_access_summary": source.access_summary(),
+        "engine_access_summary": dict(run_result.access_summary),
+        "ORDERS": 0,
+        "ACCOUNT_CONTACT": 0,
+        "DB_WRITES": 0,
+        "SCHEDULER": 0,
+        "DEPLOY": 0,
+        "HOLDOUT_READS": 0,
+        "FORBIDDEN_ROOT_ENUMERATIONS": access_spy.summary()[
+            "forbidden_root_enumerations"
+        ],
+    }
+    if access_spy.forbidden_root_enumerations():
+        raise CliRejection("forbidden root was enumerated during load")
+    atomic_write_json(args.output, payload)
+    return args.output
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON via ``.partial`` + fsync + ``os.replace``; refuse overwrites."""
+
+    if path.exists():
+        raise CliRejection(f"output overwrite refused: {path}")
+    if is_forbidden_corpus_path(path):
+        raise CliRejection(f"output path under forbidden corpus segment: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    partial = path.with_name(path.name + ".partial")
+    try:
+        with partial.open("wb") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(partial, path)
+    except Exception:
+        if partial.exists():
+            partial.unlink(missing_ok=True)
+        raise
+
+
+def _parse_date(raw: str) -> date:
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid date {raw!r}") from exc
+
+
+def _validate_exploration_bounds(start: date, end: date) -> None:
+    if start > end:
+        raise CliRejection("exploration_start is after exploration_end")
+    if start < US_EXPLORATION_START:
+        raise CliRejection("exploration starts no earlier than 2016-01-01")
+    if end > US_EXPLORATION_END or end >= US_HOLDOUT_START:
+        raise CliRejection("exploration window intersects the 2025+ sealed holdout")
+
+
+def _validate_year_roots(year_roots: Sequence[Path]) -> None:
+    if not year_roots:
+        raise CliRejection("at least one --year-root is required")
+    seen: set[int] = set()
+    for root in year_roots:
+        if is_forbidden_corpus_path(root):
+            raise CliRejection(f"holdout or staging path refused as year root: {root}")
+        try:
+            year = assert_year_root_allowed(root)
+        except CorpusPathAccessError as exc:
+            raise CliRejection(str(exc)) from exc
+        if year in seen:
+            raise CliRejection(f"duplicate --year-root for year={year}")
+        seen.add(year)
+
+
+def _validate_output_path(output: Path, *, year_roots: Sequence[Path]) -> None:
+    if output.exists():
+        raise CliRejection(f"output overwrite refused: {output}")
+    if is_forbidden_corpus_path(output):
+        raise CliRejection(f"output path under forbidden corpus segment: {output}")
+    try:
+        resolved_output = output.resolve(strict=False)
+    except OSError as exc:
+        raise CliRejection(f"cannot resolve output path: {output}") from exc
+    for root in year_roots:
+        try:
+            resolved_root = root.resolve(strict=False)
+        except OSError:
+            continue
+        if resolved_output == resolved_root or resolved_root in resolved_output.parents:
+            raise CliRejection(
+                "output path must not write into a corpus year root: "
+                f"{output} under {root}"
+            )
+        if resolved_output in resolved_root.parents:
+            raise CliRejection(
+                "output path must not be an ancestor of a corpus year root"
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry
+    raise SystemExit(main())

--- a/research/us_stage_b/engine.py
+++ b/research/us_stage_b/engine.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 import math
 from collections import Counter, defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
 from statistics import mean
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from .contracts import USStageBRunContract
 from .signals import SignalObservation, evaluate_signal
@@ -37,6 +37,55 @@ __all__ = [
     "rank_signal_observations",
     "run_us_stage_b",
 ]
+
+
+class _HistoryPrefix(Sequence[USStageBDailyBar | None]):
+    """O(1) prefix view over an aligned bar series.
+
+    The engine evaluates every symbol on every session.  Copying
+    ``bars[:session_index + 1]`` would be O(sessions² × symbols) of tuple
+    allocation without changing any formula result.  This view preserves the
+    Sequence contract used by the signal engine while sharing the underlying
+    row storage.
+    """
+
+    __slots__ = ("_bars", "_end")
+
+    def __init__(
+        self,
+        bars: Sequence[USStageBDailyBar | None],
+        end_exclusive: int,
+    ) -> None:
+        if end_exclusive < 0 or end_exclusive > len(bars):
+            raise USStageBRunError("history prefix end is out of range")
+        self._bars = bars
+        self._end = end_exclusive
+
+    def __len__(self) -> int:
+        return self._end
+
+    @overload
+    def __getitem__(self, index: int) -> USStageBDailyBar | None: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[USStageBDailyBar | None]: ...
+
+    def __getitem__(
+        self, index: int | slice
+    ) -> USStageBDailyBar | None | list[USStageBDailyBar | None]:
+        if isinstance(index, slice):
+            start, stop, step = index.indices(self._end)
+            return [self._bars[position] for position in range(start, stop, step)]
+        if not isinstance(index, int):
+            raise TypeError("history index must be int or slice")
+        position = index if index >= 0 else index + self._end
+        if position < 0 or position >= self._end:
+            raise IndexError("history index out of range")
+        return self._bars[position]
+
+    def __iter__(self) -> Iterator[USStageBDailyBar | None]:
+        for position in range(self._end):
+            yield self._bars[position]
 
 
 class USStageBRunError(RuntimeError):
@@ -152,7 +201,13 @@ class CohortComparison:
 
 @dataclass(frozen=True)
 class USStageBRunResult:
-    """Serializable full run state; an empty result remains explicitly labeled."""
+    """Serializable run state with compact observation persistence.
+
+    Every symbol×session cell is still evaluated for ranking/cohorts.  The
+    retained ``observations`` tuple and artifact JSON keep only true-signal
+    rows; aggregate counts cover the non-signal mass.  Outcomes, cohorts,
+    verdicts, and costs are unchanged.
+    """
 
     contract: USStageBRunContract
     corpus_sessions: tuple[date, ...]
@@ -164,6 +219,7 @@ class USStageBRunResult:
     access_summary: Mapping[str, int]
     verdict: FalsificationVerdict
     cost_profile_verdicts: RevCostProfileVerdicts | None
+    observation_summary: Mapping[str, Any]
 
     def __post_init__(self) -> None:
         is_rev = self.strategy_id == "US-TS-REV-SHORT-Z3-T126-H3-v1"
@@ -179,6 +235,11 @@ class USStageBRunResult:
                 or base.labels != self.labels
             ):
                 raise USStageBRunError("cost-profile verdict provenance mismatch")
+        if any(not observation.signal for observation in self.observations):
+            raise USStageBRunError(
+                "persisted observations must be signal=true only; "
+                "non-signal mass belongs in observation_summary"
+            )
 
     @property
     def strategy_id(self) -> str:
@@ -216,6 +277,7 @@ class USStageBRunResult:
             ],
             "contract": self.contract.to_dict(),
             "observations": [item.to_dict() for item in self.observations],
+            "observation_summary": dict(self.observation_summary),
             "outcomes": [item.to_dict() for item in self.outcomes],
             "cohort_comparisons": [item.to_dict() for item in self.cohorts],
             "outcome_status_counts": dict(sorted(status_counts.items())),
@@ -277,10 +339,17 @@ def run_us_stage_b(
     )
     bars_by_symbol = _load_aligned_bars(boundary_source, symbols, sessions)
 
-    observations: list[SignalObservation] = []
+    # Cohort leave-one-out needs same-session universe_eligible members.  True
+    # signals are a subset.  Non-eligible non-signal cells are counted only.
+    cohort_observations: list[SignalObservation] = []
+    signal_observations: list[SignalObservation] = []
     outcomes: list[TradeOutcome] = []
     reservations: list[_Reservation] = []
     invalid_reasons: list[str] = []
+    observation_total = 0
+    signal_true_count = 0
+    universe_eligible_count = 0
+    exclusion_reason_counts: Counter[str] = Counter()
     hold_sessions = _required_positive_int(contract, "hold_sessions")
     max_positions = _required_positive_int(contract, "max_positions")
 
@@ -296,12 +365,20 @@ def run_us_stage_b(
                 contract.candidate,
                 symbol=symbol,
                 session_date=session,
-                history=bars_by_symbol[symbol][: session_index + 1],
+                history=_HistoryPrefix(bars_by_symbol[symbol], session_index + 1),
                 no_active_position=symbol not in active_symbols,
             )
-            observations.append(observation)
+            observation_total += 1
+            if observation.universe_eligible:
+                universe_eligible_count += 1
+            if observation.exclusion_reason is not None:
+                exclusion_reason_counts[observation.exclusion_reason] += 1
             if observation.signal:
+                signal_true_count += 1
                 daily_signals.append(observation)
+                signal_observations.append(observation)
+            if observation.signal or observation.universe_eligible:
+                cohort_observations.append(observation)
 
         if not daily_signals:
             continue
@@ -361,7 +438,7 @@ def run_us_stage_b(
     cohorts = _build_cohort_comparisons(
         contract=contract,
         outcomes=tuple(outcomes),
-        observations=tuple(observations),
+        observations=tuple(cohort_observations),
         bars_by_symbol=bars_by_symbol,
         sessions=sessions,
     )
@@ -374,10 +451,18 @@ def run_us_stage_b(
         run_invalid=bool(invalid_reasons),
         invalid_reasons=tuple(invalid_reasons),
     )
+    observation_summary: dict[str, Any] = {
+        "total_evaluated": observation_total,
+        "signal_true": signal_true_count,
+        "universe_eligible": universe_eligible_count,
+        "persisted": "signal_true_only",
+        "persisted_count": len(signal_observations),
+        "exclusion_reason_counts": dict(sorted(exclusion_reason_counts.items())),
+    }
     return USStageBRunResult(
         contract=contract,
         corpus_sessions=sessions,
-        observations=tuple(observations),
+        observations=tuple(signal_observations),
         outcomes=tuple(outcomes),
         cohorts=cohorts,
         run_invalid=bool(invalid_reasons),
@@ -385,6 +470,7 @@ def run_us_stage_b(
         access_summary=boundary_source.summary(),
         verdict=evaluation.verdict,
         cost_profile_verdicts=evaluation.cost_profile_verdicts,
+        observation_summary=observation_summary,
     )
 
 

--- a/research/us_stage_b/parquet_source.py
+++ b/research/us_stage_b/parquet_source.py
@@ -1,0 +1,406 @@
+"""Read-only Parquet adapter for the frozen US Stage-B bar contract.
+
+This module binds only the explicit year roots a caller supplies.  It never
+walks a corpus parent, never globs holdout or staging trees, and never falls
+back to a database or network source.  Column names are bound literally —
+there are no heuristic aliases.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Final
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .source import USStageBDailyBar, USStageBInputError
+
+__all__ = [
+    "ALLOWED_EXPLORATION_YEARS",
+    "FORBIDDEN_PATH_SEGMENTS",
+    "REQUIRED_PARQUET_COLUMNS",
+    "CorpusPathAccessError",
+    "ParquetUSBarSource",
+    "PathAccessRecord",
+    "PathAccessSpy",
+    "assert_year_root_allowed",
+    "is_forbidden_corpus_path",
+]
+
+
+ALLOWED_EXPLORATION_YEARS: Final[frozenset[int]] = frozenset(range(2016, 2025))
+FORBIDDEN_PATH_SEGMENTS: Final[frozenset[str]] = frozenset({"holdout", "_staging"})
+REQUIRED_PARQUET_COLUMNS: Final[tuple[str, ...]] = (
+    "symbol",
+    "session_date",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+)
+_YEAR_ROOT_RE: Final = re.compile(r"^year=(?P<year>\d{4})$")
+_HOLDOUT_START: Final = date(2025, 1, 1)
+
+
+class CorpusPathAccessError(USStageBInputError):
+    """A year root, path segment, or Parquet cell violates the US corpus gate."""
+
+
+@dataclass(frozen=True)
+class PathAccessRecord:
+    """One path-touch record used to prove forbidden roots were not enumerated."""
+
+    kind: str
+    path: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "path": self.path}
+
+
+class PathAccessSpy:
+    """Record every validated, listed, or opened path for holdout proofs."""
+
+    def __init__(self) -> None:
+        self._records: list[PathAccessRecord] = []
+
+    def note(self, kind: str, path: Path) -> Path:
+        """Record a path access.  Forbidden segments fail closed immediately."""
+
+        resolved = _resolve_for_log(path)
+        record = PathAccessRecord(kind=kind, path=resolved)
+        self._records.append(record)
+        if is_forbidden_corpus_path(Path(resolved)):
+            raise CorpusPathAccessError(
+                f"forbidden corpus path access refused (kind={kind!r}, path={resolved})"
+            )
+        return path
+
+    @property
+    def records(self) -> tuple[PathAccessRecord, ...]:
+        return tuple(self._records)
+
+    def forbidden_root_enumerations(self) -> tuple[PathAccessRecord, ...]:
+        """Return listdir/open records that touch holdout or staging."""
+
+        return tuple(
+            record
+            for record in self._records
+            if record.kind in {"listdir", "open_parquet"}
+            and is_forbidden_corpus_path(Path(record.path))
+        )
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "path_accesses_total": len(self._records),
+            "validate_count": sum(
+                record.kind == "validate" for record in self._records
+            ),
+            "listdir_count": sum(record.kind == "listdir" for record in self._records),
+            "open_parquet_count": sum(
+                record.kind == "open_parquet" for record in self._records
+            ),
+            "forbidden_root_enumerations": len(self.forbidden_root_enumerations()),
+        }
+
+
+def is_forbidden_corpus_path(path: Path) -> bool:
+    """True when any path component is a sealed holdout or staging segment."""
+
+    return any(part.lower() in FORBIDDEN_PATH_SEGMENTS for part in path.parts)
+
+
+def assert_year_root_allowed(
+    year_root: Path,
+    *,
+    access_spy: PathAccessSpy | None = None,
+) -> int:
+    """Validate one explicit year root without listing any parent tree."""
+
+    if access_spy is not None:
+        access_spy.note("validate", year_root)
+    if is_forbidden_corpus_path(year_root):
+        raise CorpusPathAccessError(
+            f"year root is under a forbidden holdout/staging path: {year_root}"
+        )
+    match = _YEAR_ROOT_RE.fullmatch(year_root.name)
+    if match is None:
+        raise CorpusPathAccessError(
+            f"year root must be named year=YYYY; got {year_root.name!r}"
+        )
+    year = int(match.group("year"))
+    if year not in ALLOWED_EXPLORATION_YEARS:
+        raise CorpusPathAccessError(
+            f"year root {year} is outside the nine allowlisted exploration years "
+            f"{sorted(ALLOWED_EXPLORATION_YEARS)}"
+        )
+    if not year_root.is_dir():
+        raise CorpusPathAccessError(f"year root is not a directory: {year_root}")
+    return year
+
+
+class ParquetUSBarSource:
+    """Deterministic, read-only ``USBarSource`` backed by explicit year Parquet roots."""
+
+    def __init__(
+        self,
+        bars: Iterable[USStageBDailyBar],
+        *,
+        year_roots: Sequence[Path],
+        access_spy: PathAccessSpy | None = None,
+        files_read: Sequence[Path] = (),
+        rows_loaded: int = 0,
+    ) -> None:
+        rows: dict[tuple[str, date], USStageBDailyBar] = {}
+        symbols: set[str] = set()
+        sessions: set[date] = set()
+        for bar in bars:
+            key = (bar.symbol, bar.session_date)
+            if key in rows:
+                raise CorpusPathAccessError(
+                    f"duplicate US Stage-B bar: {bar.symbol}/{bar.session_date}"
+                )
+            if bar.session_date >= _HOLDOUT_START:
+                raise CorpusPathAccessError(
+                    "Parquet row intersects the 2025+ sealed holdout: "
+                    f"{bar.symbol}/{bar.session_date.isoformat()}"
+                )
+            rows[key] = bar
+            symbols.add(bar.symbol)
+            sessions.add(bar.session_date)
+        self._rows = rows
+        self._symbols = tuple(sorted(symbols))
+        self._sessions = tuple(sorted(sessions))
+        self._year_roots = tuple(Path(root) for root in year_roots)
+        self._access_spy = access_spy if access_spy is not None else PathAccessSpy()
+        self._files_read = tuple(Path(path) for path in files_read)
+        self._rows_loaded = rows_loaded
+
+    @classmethod
+    def from_year_roots(
+        cls,
+        year_roots: Sequence[Path | str],
+        *,
+        access_spy: PathAccessSpy | None = None,
+    ) -> ParquetUSBarSource:
+        """Load only the caller-supplied year directories; never expand parents."""
+
+        spy = access_spy if access_spy is not None else PathAccessSpy()
+        if not year_roots:
+            raise CorpusPathAccessError("at least one explicit year root is required")
+
+        roots = [Path(root) for root in year_roots]
+        years: list[int] = []
+        seen_years: set[int] = set()
+        for root in roots:
+            year = assert_year_root_allowed(root, access_spy=spy)
+            if year in seen_years:
+                raise CorpusPathAccessError(f"duplicate year root for {year}")
+            seen_years.add(year)
+            years.append(year)
+
+        bars: list[USStageBDailyBar] = []
+        files_read: list[Path] = []
+        for root, year in zip(roots, years, strict=True):
+            files = _list_parquet_files(root, access_spy=spy)
+            if not files:
+                raise CorpusPathAccessError(
+                    f"year root contains no Parquet files: {root}"
+                )
+            for file_path in files:
+                bars.extend(
+                    _load_bars_from_parquet(
+                        file_path,
+                        expected_year=year,
+                        access_spy=spy,
+                    )
+                )
+                files_read.append(file_path)
+
+        return cls(
+            bars,
+            year_roots=roots,
+            access_spy=spy,
+            files_read=files_read,
+            rows_loaded=len(bars),
+        )
+
+    def symbols(self) -> tuple[str, ...]:
+        return self._symbols
+
+    def get(self, symbol: str, session_date: date) -> USStageBDailyBar | None:
+        return self._rows.get((symbol, session_date))
+
+    def corpus_sessions(self) -> tuple[date, ...]:
+        """Return the sorted union of loaded session dates (corpus session index)."""
+
+        return self._sessions
+
+    @property
+    def access_spy(self) -> PathAccessSpy:
+        return self._access_spy
+
+    @property
+    def year_roots(self) -> tuple[Path, ...]:
+        return self._year_roots
+
+    @property
+    def files_read(self) -> tuple[Path, ...]:
+        return self._files_read
+
+    def access_summary(self) -> dict[str, Any]:
+        summary = self._access_spy.summary()
+        summary.update(
+            {
+                "year_roots": [str(root) for root in self._year_roots],
+                "files_read": [str(path) for path in self._files_read],
+                "rows_loaded": self._rows_loaded,
+                "symbol_count": len(self._symbols),
+                "session_count": len(self._sessions),
+                "holdout_reads": 0,
+                "forbidden_root_enumerations": summary["forbidden_root_enumerations"],
+            }
+        )
+        return summary
+
+
+def _resolve_for_log(path: Path) -> str:
+    try:
+        return str(path.resolve(strict=False))
+    except OSError:
+        return str(path)
+
+
+def _list_parquet_files(
+    year_root: Path, *, access_spy: PathAccessSpy
+) -> tuple[Path, ...]:
+    access_spy.note("listdir", year_root)
+    # Explicit directory listing only — never recursive, never parent glob.
+    names = sorted(path.name for path in year_root.iterdir() if path.is_file())
+    files = tuple(
+        year_root / name
+        for name in names
+        if name.endswith(".parquet") and not name.startswith(".")
+    )
+    return files
+
+
+def _load_bars_from_parquet(
+    path: Path,
+    *,
+    expected_year: int,
+    access_spy: PathAccessSpy,
+) -> list[USStageBDailyBar]:
+    access_spy.note("open_parquet", path)
+    try:
+        parquet_file = pq.ParquetFile(path)
+        observed = set(parquet_file.schema_arrow.names)
+        missing = [name for name in REQUIRED_PARQUET_COLUMNS if name not in observed]
+        if missing:
+            raise CorpusPathAccessError(
+                f"Parquet file {path} lacks required columns: {missing!r}"
+            )
+        # Refuse heuristic aliases: only the literal schema names may be bound.
+        # Additional columns are ignored by the explicit projection below.
+        table = parquet_file.read(columns=list(REQUIRED_PARQUET_COLUMNS))
+    except CorpusPathAccessError:
+        raise
+    except FileNotFoundError as exc:
+        raise CorpusPathAccessError(f"Parquet file missing: {path}") from exc
+    except (OSError, pa.ArrowInvalid, ValueError, KeyError) as exc:
+        raise CorpusPathAccessError(
+            f"failed to read US Parquet file {path}: {exc}"
+        ) from exc
+    symbols = table.column("symbol").to_pylist()
+    session_dates = [
+        _coerce_session_date(value, path=path, row_index=index)
+        for index, value in enumerate(table.column("session_date").to_pylist())
+    ]
+    opens = table.column("open").to_pylist()
+    closes = table.column("close").to_pylist()
+    volumes = table.column("volume").to_pylist()
+    # high/low are contract fields: require presence (already projected) and
+    # materialize once so a truncated file cannot silently drop them.
+    highs = table.column("high").to_pylist()
+    lows = table.column("low").to_pylist()
+    if not (
+        len(symbols)
+        == len(session_dates)
+        == len(opens)
+        == len(closes)
+        == len(volumes)
+        == len(highs)
+        == len(lows)
+    ):
+        raise CorpusPathAccessError(f"Parquet file {path} has ragged columns")
+
+    bars: list[USStageBDailyBar] = []
+    for index, symbol in enumerate(symbols):
+        if symbol is None or not str(symbol):
+            raise CorpusPathAccessError(f"invalid symbol at row {index} in {path}")
+        session = session_dates[index]
+        if session.year != expected_year:
+            raise CorpusPathAccessError(
+                f"row year mismatch in {path}: session={session.isoformat()} "
+                f"expected year={expected_year}"
+            )
+        if session >= _HOLDOUT_START:
+            raise CorpusPathAccessError(
+                f"2025+ session refused in {path}: {session.isoformat()}"
+            )
+        # Touch high/low so incomplete projections cannot pass silently.
+        _ = highs[index]
+        _ = lows[index]
+        bars.append(
+            USStageBDailyBar(
+                symbol=str(symbol),
+                session_date=session,
+                open=_coerce_optional_float(opens[index]),
+                adjusted_close=_coerce_optional_float(closes[index]),
+                volume=_coerce_optional_float(volumes[index]),
+            )
+        )
+    return bars
+
+
+def _coerce_session_date(value: Any, *, path: Path, row_index: int) -> date:
+    if value is None:
+        raise CorpusPathAccessError(f"null session_date at row {row_index} in {path}")
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            raise CorpusPathAccessError(
+                f"timezone-aware session_date refused at row {row_index} in {path}"
+            )
+        return value.date()
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError as exc:
+            raise CorpusPathAccessError(
+                f"unparseable session_date at row {row_index} in {path}: {value!r}"
+            ) from exc
+    raise CorpusPathAccessError(
+        f"unsupported session_date type at row {row_index} in {path}: "
+        f"{type(value).__name__}"
+    )
+
+
+def _coerce_optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise CorpusPathAccessError("boolean numeric cell is invalid for US bars")
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if math.isnan(number) or math.isinf(number):
+            return number
+        return number
+    raise CorpusPathAccessError(f"non-numeric OHLC/volume cell: {type(value).__name__}")

--- a/research/us_stage_b/parquet_source.py
+++ b/research/us_stage_b/parquet_source.py
@@ -8,7 +8,6 @@ there are no heuristic aliases.
 
 from __future__ import annotations
 
-import math
 import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
@@ -394,13 +393,18 @@ def _coerce_session_date(value: Any, *, path: Path, row_index: int) -> date:
 
 
 def _coerce_optional_float(value: Any) -> float | None:
+    """Bind a numeric cell without cleaning.
+
+    Null stays None.  Finite and non-finite floats (NaN/±Inf) are preserved
+    exactly so the #1797 signal engine can exclude them via its own
+    ``_finite_positive`` checks — this adapter must not coerce them away.
+    """
+
     if value is None:
         return None
     if isinstance(value, bool):
         raise CorpusPathAccessError("boolean numeric cell is invalid for US bars")
     if isinstance(value, (int, float)):
-        number = float(value)
-        if math.isnan(number) or math.isinf(number):
-            return number
-        return number
+        # float() preserves math.nan / ±inf; do not special-case them here.
+        return float(value)
     raise CorpusPathAccessError(f"non-numeric OHLC/volume cell: {type(value).__name__}")

--- a/research/us_stage_b/registry.py
+++ b/research/us_stage_b/registry.py
@@ -46,6 +46,12 @@ _COMMON_LABELS: Final[tuple[str, ...]] = (
     "EXECUTION_ENVELOPE_UNBOUND",
 )
 _VOLBREAK_LABEL: Final = "VOLUME_CA_UNRESOLVED"
+# Post U1-B (2026-08-06): all three frozen US candidates failed exploratory
+# gates.  This label is registry-side only — it does not alter YAML source
+# blocks, contract hashes, parameters, costs, or falsification gate text.
+_EXPLORATORY_DISPOSAL_LABEL: Final = (
+    "EXPLORATORY_FALSIFIED (2026-08-06) — 결과 폐기, 승격 불가"
+)
 
 # These checks bind the three explicit code paths to the packet's parsed values.
 # They are guards, not a second configuration source: signal evaluation fetches
@@ -132,8 +138,8 @@ def mandatory_labels(strategy_id: str) -> tuple[str, ...]:
             f"unsupported strategy_id {strategy_id!r}; shared fallback is forbidden"
         )
     if strategy_id == "US-TS-VOLBREAK-C55-V2-H10-v1":
-        return (*_COMMON_LABELS, _VOLBREAK_LABEL)
-    return _COMMON_LABELS
+        return (*_COMMON_LABELS, _VOLBREAK_LABEL, _EXPLORATORY_DISPOSAL_LABEL)
+    return (*_COMMON_LABELS, _EXPLORATORY_DISPOSAL_LABEL)
 
 
 @dataclass(frozen=True)

--- a/research/us_stage_b/u1_exploration_driver.py
+++ b/research/us_stage_b/u1_exploration_driver.py
@@ -1,0 +1,530 @@
+"""Durable, hash-bound driver for the US-U1 exploratory falsification runs.
+
+This module is the only supported U1-B entrypoint.  It pins:
+- the three frozen candidate IDs and their raw-block contract hashes,
+- the nine exploration year roots (2016–2024) under an explicit corpus root,
+- the exploration window 2016-01-01..2024-12-31,
+- the frozen candidates YAML path (SHA-verified by CandidateRegistry).
+
+It does not read holdout/staging, does not register a scheduler, and does not
+retry or substitute a failed candidate.  Each candidate is invoked exactly once
+through ``research.us_stage_b.cli.run_from_args``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from .cli import CliArgs, CliRejection, run_from_args
+from .parquet_source import CorpusPathAccessError
+from .registry import (
+    FROZEN_CANDIDATES_SHA256,
+    US_CANDIDATE_ORDER,
+    CandidateRegistry,
+    RegistryStartRejected,
+)
+
+__all__ = [
+    "ALLOWED_YEARS",
+    "CANDIDATE_SPECS",
+    "EXPLORATION_END",
+    "EXPLORATION_START",
+    "build_parser",
+    "driver_blob_sha256",
+    "main",
+    "run_exploration",
+]
+
+EXPLORATION_START: Final = date(2016, 1, 1)
+EXPLORATION_END: Final = date(2024, 12, 31)
+ALLOWED_YEARS: Final[tuple[int, ...]] = tuple(range(2016, 2025))
+
+# Contract hashes from the frozen packet (raw YAML list-item digests).
+CANDIDATE_SPECS: Final[tuple[tuple[str, str, str], ...]] = (
+    (
+        "US-TS-MOM-CONT-Z126-H20-v1",
+        "25d06a5e81c03a254948ee20b9180d466e5531a63715dd1ba53b7160ce032509",
+        "us-ts-mom-cont-z126-h20-v1.json",
+    ),
+    (
+        "US-TS-REV-SHORT-Z3-T126-H3-v1",
+        "7052f69ae1ae20de53750276c006959694941a1b2a430c99c8dbbe616cba9836",
+        "us-ts-rev-short-z3-t126-h3-v1.json",
+    ),
+    (
+        "US-TS-VOLBREAK-C55-V2-H10-v1",
+        "43ff9a4a99ba3717c2d5563aa58c8a482800082c4fa4c41330712c4460848b0f",
+        "us-ts-volbreak-c55-v2-h10-v1.json",
+    ),
+)
+
+_DEFAULT_CORPUS_ROOT: Final = Path(
+    "/Users/mgh3326/work/herdr-artifacts/us-corpus-v1/dataset/market=us"
+)
+
+
+@dataclass(frozen=True)
+class DriverConfig:
+    corpus_root: Path
+    candidates_yaml: Path
+    output_dir: Path
+    run_log: Path
+    engine_commit: str
+    engine_tree: str
+
+
+def driver_blob_sha256() -> str:
+    """SHA-256 of this driver's source file (hash-bound evidence)."""
+
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def adapter_blob_sha256() -> str:
+    package = Path(__file__).resolve().parent
+    payloads = b"".join(
+        sorted(
+            (path.name.encode() + b"\0" + path.read_bytes())
+            for path in package.glob("*.py")
+        )
+    )
+    return hashlib.sha256(payloads).hexdigest()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.us_stage_b.u1_exploration_driver",
+        description=(
+            "US-U1 exploratory falsification: exactly three frozen candidates, "
+            "one trial each, nine year roots only."
+        ),
+    )
+    parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        default=_DEFAULT_CORPUS_ROOT,
+        help=(
+            "Parent directory that contains year=2016..year=2024 only "
+            f"(default: {_DEFAULT_CORPUS_ROOT})"
+        ),
+    )
+    parser.add_argument(
+        "--candidates-yaml",
+        type=Path,
+        required=True,
+        help="Frozen 02-active-candidates.yaml (SHA-verified).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory for per-candidate JSON, manifest, and checksums.",
+    )
+    parser.add_argument(
+        "--run-log",
+        type=Path,
+        required=True,
+        help="Append-only run.md path (updated after each candidate).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    namespace = parser.parse_args(list(argv) if argv is not None else None)
+    engine_commit, engine_tree = _git_identity()
+    config = DriverConfig(
+        corpus_root=Path(namespace.corpus_root),
+        candidates_yaml=Path(namespace.candidates_yaml),
+        output_dir=Path(namespace.output_dir),
+        run_log=Path(namespace.run_log),
+        engine_commit=engine_commit,
+        engine_tree=engine_tree,
+    )
+    try:
+        run_exploration(config)
+    except (
+        CliRejection,
+        CorpusPathAccessError,
+        RegistryStartRejected,
+        RuntimeError,
+    ) as exc:
+        _append_run_log(
+            config.run_log,
+            f"\n## DRIVER_FATAL\n\n```\n{exc}\n```\n"
+            f"ORDERS=0 / ACCOUNT_CONTACT=0 / DB_WRITES=0 / "
+            f"SCHEDULER=0 / DEPLOY=0 / HOLDOUT_READS=0\n",
+        )
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def run_exploration(config: DriverConfig) -> Mapping[str, Any]:
+    """Run the three candidates once each; append run.md after every finish."""
+
+    year_roots = _resolve_year_roots(config.corpus_root)
+    registry = CandidateRegistry.load(config.candidates_yaml)
+    if registry.source_packet_sha256 != FROZEN_CANDIDATES_SHA256:
+        raise RuntimeError(
+            "candidates YAML SHA drift: "
+            f"expected={FROZEN_CANDIDATES_SHA256} "
+            f"actual={registry.source_packet_sha256}"
+        )
+    for strategy_id, expected_hash, _filename in CANDIDATE_SPECS:
+        if strategy_id not in US_CANDIDATE_ORDER:
+            raise RuntimeError(f"candidate order drift: {strategy_id}")
+        binding = registry.binding_for(strategy_id)
+        if binding.contract_hash != expected_hash:
+            raise RuntimeError(
+                f"contract-hash mismatch for {strategy_id}: "
+                f"expected={expected_hash} actual={binding.contract_hash}"
+            )
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    started_at = datetime.now(UTC)
+    _write_run_header(config, year_roots=year_roots, started_at=started_at)
+
+    candidate_records: list[dict[str, Any]] = []
+    for strategy_id, contract_hash, filename in CANDIDATE_SPECS:
+        output_path = config.output_dir / filename
+        record = _run_one_candidate(
+            config=config,
+            strategy_id=strategy_id,
+            contract_hash=contract_hash,
+            year_roots=year_roots,
+            output_path=output_path,
+        )
+        candidate_records.append(record)
+        _append_candidate_section(config.run_log, record)
+
+    finished_at = datetime.now(UTC)
+    manifest = _build_manifest(
+        config=config,
+        year_roots=year_roots,
+        started_at=started_at,
+        finished_at=finished_at,
+        candidate_records=candidate_records,
+    )
+    manifest_path = config.output_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    checksums_path = config.output_dir / "checksums.sha256"
+    checksum_lines = _write_checksums(
+        config.output_dir,
+        filenames=[spec[2] for spec in CANDIDATE_SPECS] + ["manifest.json"],
+    )
+    checksums_path.write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
+    _append_run_log(
+        config.run_log,
+        _footer(
+            finished_at=finished_at,
+            manifest=manifest,
+            checksums_path=checksums_path,
+        ),
+    )
+    return manifest
+
+
+def _run_one_candidate(
+    *,
+    config: DriverConfig,
+    strategy_id: str,
+    contract_hash: str,
+    year_roots: Sequence[Path],
+    output_path: Path,
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        "-m",
+        "research.us_stage_b.cli",
+        "--candidate-id",
+        strategy_id,
+        "--contract-hash",
+        contract_hash,
+        "--candidates-yaml",
+        str(config.candidates_yaml.resolve()),
+        *[item for root in year_roots for item in ("--year-root", str(root))],
+        "--exploration-start",
+        EXPLORATION_START.isoformat(),
+        "--exploration-end",
+        EXPLORATION_END.isoformat(),
+        "--output",
+        str(output_path),
+    ]
+    started = datetime.now(UTC)
+    started_mono = time.perf_counter()
+    status = "ok"
+    error: str | None = None
+    summary: dict[str, Any] = {}
+    try:
+        if output_path.exists():
+            raise CliRejection(
+                f"output already exists (no overwrite / no retry): {output_path}"
+            )
+        run_from_args(
+            CliArgs(
+                candidate_id=strategy_id,
+                contract_hash=contract_hash,
+                candidates_yaml=config.candidates_yaml,
+                year_roots=tuple(year_roots),
+                exploration_start=EXPLORATION_START,
+                exploration_end=EXPLORATION_END,
+                output=output_path,
+                mutate_input=False,
+            )
+        )
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        summary = _extract_summary(payload)
+    except Exception as exc:  # noqa: BLE001 — persist failure as-is, no retry
+        status = "failed"
+        error = f"{type(exc).__name__}: {exc}"
+    finished = datetime.now(UTC)
+    wall_seconds = time.perf_counter() - started_mono
+    file_sha = (
+        hashlib.sha256(output_path.read_bytes()).hexdigest()
+        if output_path.is_file()
+        else None
+    )
+    return {
+        "strategy_id": strategy_id,
+        "contract_hash": contract_hash,
+        "output_path": str(output_path),
+        "output_filename": output_path.name,
+        "status": status,
+        "error": error,
+        "started_at": started.isoformat(),
+        "finished_at": finished.isoformat(),
+        "wall_seconds": wall_seconds,
+        "command": command,
+        "artifact_sha256": file_sha,
+        "summary": summary,
+    }
+
+
+def _extract_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    adapter = payload.get("adapter") if isinstance(payload.get("adapter"), dict) else {}
+    verdict = payload.get("verdict") if isinstance(payload.get("verdict"), dict) else {}
+    obs = (
+        payload.get("observation_summary")
+        if isinstance(payload.get("observation_summary"), dict)
+        else {}
+    )
+    return {
+        "labels": list(payload.get("labels") or []),
+        "verdict_state": verdict.get("state"),
+        "promotion": verdict.get("promotion"),
+        "run_invalid": payload.get("run_invalid"),
+        "invalid_reasons": list(payload.get("invalid_reasons") or []),
+        "outcome_status_counts": dict(payload.get("outcome_status_counts") or {}),
+        "observation_summary": dict(obs),
+        "scale_estimate": dict(adapter.get("scale_estimate") or {}),
+        "engine_wall_seconds": adapter.get("engine_wall_seconds"),
+        "path_access_summary": dict(adapter.get("path_access_summary") or {}),
+        "engine_access_summary": dict(adapter.get("engine_access_summary") or {}),
+        "cost_literal": dict((payload.get("contract") or {}).get("cost_literal") or {}),
+        "cost_profile_verdicts": payload.get("cost_profile_verdicts"),
+        "ORDERS": adapter.get("ORDERS", payload.get("orders", 0)),
+        "ACCOUNT_CONTACT": adapter.get("ACCOUNT_CONTACT", 0),
+        "DB_WRITES": adapter.get("DB_WRITES", payload.get("database_writes", 0)),
+        "SCHEDULER": adapter.get("SCHEDULER", 0),
+        "DEPLOY": adapter.get("DEPLOY", 0),
+        "HOLDOUT_READS": adapter.get("HOLDOUT_READS", 0),
+        "FORBIDDEN_ROOT_ENUMERATIONS": adapter.get("FORBIDDEN_ROOT_ENUMERATIONS", 0),
+        "config_hash": payload.get("config_hash"),
+        "contract_hash": payload.get("contract_hash"),
+    }
+
+
+def _resolve_year_roots(corpus_root: Path) -> tuple[Path, ...]:
+    roots: list[Path] = []
+    for year in ALLOWED_YEARS:
+        root = (corpus_root / f"year={year}").resolve()
+        if not root.is_dir():
+            raise RuntimeError(f"missing allowlisted year root: {root}")
+        # Refuse any path that somehow includes sealed segments.
+        if any(part.lower() in {"holdout", "_staging"} for part in root.parts):
+            raise RuntimeError(f"year root intersects forbidden segment: {root}")
+        roots.append(root)
+    return tuple(roots)
+
+
+def _git_identity() -> tuple[str, str]:
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    tree = subprocess.check_output(
+        ["git", "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    return commit, tree
+
+
+def _write_run_header(
+    config: DriverConfig,
+    *,
+    year_roots: Sequence[Path],
+    started_at: datetime,
+) -> None:
+    config.run_log.parent.mkdir(parents=True, exist_ok=True)
+    body = f"""# US-U1 exploration run (U1-B)
+
+```
+JOB = us-u1-exploration-run-20260805-2332
+PURPOSE = EXPLORATORY_FALSIFICATION_ONLY
+PROMOTION = FORBIDDEN
+ENGINE_COMMIT = {config.engine_commit}
+ENGINE_TREE = {config.engine_tree}
+DRIVER = research/us_stage_b/u1_exploration_driver.py
+DRIVER_BLOB_SHA256 = {driver_blob_sha256()}
+ADAPTER_PACKAGE_BLOB_SHA256 = {adapter_blob_sha256()}
+CANDIDATES_YAML = {config.candidates_yaml.resolve()}
+CANDIDATES_YAML_SHA256 = {FROZEN_CANDIDATES_SHA256}
+CORPUS_ROOT = {config.corpus_root.resolve()}
+EXPLORATION_WINDOW = {EXPLORATION_START.isoformat()}..{EXPLORATION_END.isoformat()}
+YEAR_ROOTS = {len(year_roots)}
+PYTHON = {sys.version.replace(chr(10), " ")}
+PLATFORM = {platform.platform()}
+STARTED_AT = {started_at.isoformat()}
+TRIALS = 3 candidates × 1 each (no sweep / no retry-as-new-run)
+ORDERS=0 / ACCOUNT_CONTACT=0 / DB_WRITES=0 / SCHEDULER=0 / DEPLOY=0 / HOLDOUT_READS=0
+```
+
+## Explicit year roots
+
+"""
+    for root in year_roots:
+        body += f"- `{root}`\n"
+    body += "\n## Candidate progress (append-only)\n"
+    config.run_log.write_text(body, encoding="utf-8")
+
+
+def _append_candidate_section(run_log: Path, record: Mapping[str, Any]) -> None:
+    summary = record.get("summary") or {}
+    section = f"""
+### {record["strategy_id"]}
+
+```
+status = {record["status"]}
+contract_hash = {record["contract_hash"]}
+started_at = {record["started_at"]}
+finished_at = {record["finished_at"]}
+wall_seconds = {record["wall_seconds"]:.3f}
+output = {record["output_path"]}
+artifact_sha256 = {record["artifact_sha256"]}
+error = {record["error"]!r}
+verdict_state = {summary.get("verdict_state")}
+promotion = {summary.get("promotion")}
+run_invalid = {summary.get("run_invalid")}
+outcome_status_counts = {summary.get("outcome_status_counts")}
+observation_summary = {summary.get("observation_summary")}
+scale_estimate = {summary.get("scale_estimate")}
+labels = {summary.get("labels")}
+ORDERS={summary.get("ORDERS", 0)} ACCOUNT_CONTACT={summary.get("ACCOUNT_CONTACT", 0)} DB_WRITES={summary.get("DB_WRITES", 0)} SCHEDULER={summary.get("SCHEDULER", 0)} DEPLOY={summary.get("DEPLOY", 0)} HOLDOUT_READS={summary.get("HOLDOUT_READS", 0)} FORBIDDEN_ROOT_ENUMERATIONS={summary.get("FORBIDDEN_ROOT_ENUMERATIONS", 0)}
+```
+
+command:
+
+```
+{" ".join(str(part) for part in record["command"])}
+```
+"""
+    _append_run_log(run_log, section)
+
+
+def _append_run_log(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.flush()
+
+
+def _build_manifest(
+    *,
+    config: DriverConfig,
+    year_roots: Sequence[Path],
+    started_at: datetime,
+    finished_at: datetime,
+    candidate_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "job": "us-u1-exploration-run-20260805-2332",
+        "purpose": "EXPLORATORY_FALSIFICATION_ONLY",
+        "promotion": "FORBIDDEN",
+        "engine_commit": config.engine_commit,
+        "engine_tree": config.engine_tree,
+        "driver": "research/us_stage_b/u1_exploration_driver.py",
+        "driver_blob_sha256": driver_blob_sha256(),
+        "adapter_package_blob_sha256": adapter_blob_sha256(),
+        "candidates_yaml": str(config.candidates_yaml.resolve()),
+        "candidates_yaml_sha256": FROZEN_CANDIDATES_SHA256,
+        "corpus_root": str(config.corpus_root.resolve()),
+        "year_roots": [str(root) for root in year_roots],
+        "exploration_window": {
+            "start": EXPLORATION_START.isoformat(),
+            "end": EXPLORATION_END.isoformat(),
+        },
+        "python": sys.version,
+        "platform": platform.platform(),
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "wall_seconds_total": (finished_at - started_at).total_seconds(),
+        "trials": "3_candidates_x_1_each",
+        "candidates": list(candidate_records),
+        "invariants": {
+            "ORDERS": 0,
+            "ACCOUNT_CONTACT": 0,
+            "DB_WRITES": 0,
+            "SCHEDULER": 0,
+            "DEPLOY": 0,
+            "HOLDOUT_READS": 0,
+        },
+    }
+
+
+def _write_checksums(output_dir: Path, *, filenames: Sequence[str]) -> list[str]:
+    lines: list[str] = []
+    for name in filenames:
+        path = output_dir / name
+        if not path.is_file():
+            lines.append(f"MISSING  {name}")
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {name}")
+    return lines
+
+
+def _footer(
+    *,
+    finished_at: datetime,
+    manifest: Mapping[str, Any],
+    checksums_path: Path,
+) -> str:
+    statuses = [
+        f"{item['strategy_id']}={item['status']}" for item in manifest["candidates"]
+    ]
+    return f"""
+## Run complete
+
+```
+FINISHED_AT = {finished_at.isoformat()}
+WALL_SECONDS_TOTAL = {manifest["wall_seconds_total"]:.3f}
+CANDIDATE_STATUSES = {statuses}
+MANIFEST = {manifest.get("engine_commit")}
+CHECKSUMS = {checksums_path}
+ORDERS=0 / ACCOUNT_CONTACT=0 / DB_WRITES=0 / SCHEDULER=0 / DEPLOY=0 / HOLDOUT_READS=0
+```
+"""
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/research/us_stage_b/test_cli.py
+++ b/tests/research/us_stage_b/test_cli.py
@@ -1,0 +1,226 @@
+"""CLI gate tests: seven hard rejections, atomic write, and access conservation."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from research.us_stage_b.cli import (
+    CliArgs,
+    CliRejection,
+    atomic_write_json,
+    main,
+    run_from_args,
+)
+from research.us_stage_b.registry import US_CANDIDATE_ORDER
+
+from .conftest import FROZEN_YAML
+
+VOLBREAK_ID = US_CANDIDATE_ORDER[2]
+VOLBREAK_HASH = "43ff9a4a99ba3717c2d5563aa58c8a482800082c4fa4c41330712c4460848b0f"
+
+
+def _write_year(
+    root: Path,
+    rows: list[dict],
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.Table.from_pylist(rows), root / "part-00000.parquet")
+    return root
+
+
+def _row(
+    symbol: str,
+    session: date,
+    *,
+    close: float = 100.0,
+    volume: float = 50_000.0,
+) -> dict:
+    return {
+        "symbol": symbol,
+        "session_date": datetime(session.year, session.month, session.day),
+        "open": close,
+        "high": close + 1.0,
+        "low": close - 1.0,
+        "close": close,
+        "volume": volume,
+    }
+
+
+def _minimal_volbreak_year(tmp_path: Path) -> Path:
+    """Enough sessions for VOLBREAK lookback (55) + hold (10) on one symbol."""
+
+    year_root = tmp_path / "corpus" / "year=2023"
+    rows: list[dict] = []
+    base = date(2023, 1, 3)
+    for index in range(80):
+        session = date.fromordinal(base.toordinal() + index)
+        close = 100.0 + index * 0.1
+        volume = 50_000.0
+        if index == 55:
+            close = 107.0
+            volume = 100_000.0
+        elif index > 55:
+            close = 106.0
+        rows.append(_row("IDX", session, close=close, volume=volume))
+    return _write_year(year_root, rows)
+
+
+def _base_args(
+    tmp_path: Path,
+    *,
+    year_root: Path,
+    output: Path | None = None,
+    candidate_id: str = VOLBREAK_ID,
+    contract_hash: str = VOLBREAK_HASH,
+    mutate_input: bool = False,
+    exploration_start: date = date(2023, 1, 3),
+    exploration_end: date = date(2023, 3, 23),
+) -> CliArgs:
+    return CliArgs(
+        candidate_id=candidate_id,
+        contract_hash=contract_hash,
+        candidates_yaml=FROZEN_YAML,
+        year_roots=(year_root,),
+        exploration_start=exploration_start,
+        exploration_end=exploration_end,
+        output=output or (tmp_path / "out" / "result.json"),
+        mutate_input=mutate_input,
+    )
+
+
+def test_cli_rejects_year_root_outside_nine_allowlisted(tmp_path: Path) -> None:
+    bad = tmp_path / "year=2015"
+    bad.mkdir()
+    args = _base_args(tmp_path, year_root=bad)
+    with pytest.raises(CliRejection, match="allowlisted|outside"):
+        run_from_args(args)
+
+
+def test_cli_rejects_2025_plus_exploration_end(tmp_path: Path) -> None:
+    year_root = _minimal_volbreak_year(tmp_path)
+    args = _base_args(
+        tmp_path,
+        year_root=year_root,
+        exploration_end=date(2025, 1, 1),
+    )
+    with pytest.raises(CliRejection, match="2025"):
+        run_from_args(args)
+
+
+def test_cli_rejects_holdout_and_staging_year_roots(tmp_path: Path) -> None:
+    holdout = tmp_path / "holdout" / "year=2016"
+    holdout.mkdir(parents=True)
+    with pytest.raises(CliRejection, match="holdout|staging|forbidden"):
+        run_from_args(_base_args(tmp_path, year_root=holdout))
+
+    staging = tmp_path / "_staging" / "year=2017"
+    staging.mkdir(parents=True)
+    with pytest.raises(CliRejection, match="holdout|staging|forbidden"):
+        run_from_args(_base_args(tmp_path, year_root=staging))
+
+
+def test_cli_rejects_unknown_candidate(tmp_path: Path) -> None:
+    year_root = _minimal_volbreak_year(tmp_path)
+    args = _base_args(
+        tmp_path,
+        year_root=year_root,
+        candidate_id="US-UNKNOWN-CANDIDATE",
+        contract_hash=VOLBREAK_HASH,
+    )
+    with pytest.raises(CliRejection, match="shared fallback|unsupported"):
+        run_from_args(args)
+
+
+def test_cli_rejects_contract_hash_mismatch(tmp_path: Path) -> None:
+    year_root = _minimal_volbreak_year(tmp_path)
+    args = _base_args(
+        tmp_path,
+        year_root=year_root,
+        contract_hash="0" * 64,
+    )
+    with pytest.raises(CliRejection, match="contract-hash mismatch"):
+        run_from_args(args)
+
+
+def test_cli_rejects_output_overwrite(tmp_path: Path) -> None:
+    year_root = _minimal_volbreak_year(tmp_path)
+    output = tmp_path / "exists.json"
+    output.write_text("{}", encoding="utf-8")
+    args = _base_args(tmp_path, year_root=year_root, output=output)
+    with pytest.raises(CliRejection, match="overwrite"):
+        run_from_args(args)
+
+
+def test_cli_rejects_input_mutation_request(tmp_path: Path) -> None:
+    year_root = _minimal_volbreak_year(tmp_path)
+    args = _base_args(tmp_path, year_root=year_root, mutate_input=True)
+    with pytest.raises(CliRejection, match="input mutation"):
+        run_from_args(args)
+
+
+def test_cli_main_exit_code_for_rejection(tmp_path: Path) -> None:
+    bad = tmp_path / "year=2010"
+    bad.mkdir()
+    code = main(
+        [
+            "--candidate-id",
+            VOLBREAK_ID,
+            "--contract-hash",
+            VOLBREAK_HASH,
+            "--candidates-yaml",
+            str(FROZEN_YAML),
+            "--year-root",
+            str(bad),
+            "--exploration-start",
+            "2023-01-03",
+            "--exploration-end",
+            "2023-03-23",
+            "--output",
+            str(tmp_path / "out.json"),
+        ]
+    )
+    assert code == 2
+
+
+def test_atomic_write_refuses_overwrite_and_is_durable(tmp_path: Path) -> None:
+    path = tmp_path / "artifact.json"
+    atomic_write_json(path, {"a": 1})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"a": 1}
+    assert not path.with_name(path.name + ".partial").exists()
+    with pytest.raises(CliRejection, match="overwrite"):
+        atomic_write_json(path, {"a": 2})
+
+
+def test_cli_happy_path_writes_labeled_result_without_forbidden_enumeration(
+    tmp_path: Path,
+) -> None:
+    year_root = _minimal_volbreak_year(tmp_path)
+    # Plant forbidden siblings that must never appear in access records.
+    (tmp_path / "corpus" / "holdout").mkdir()
+    (tmp_path / "corpus" / "_staging").mkdir()
+    output = tmp_path / "run.json"
+    args = _base_args(tmp_path, year_root=year_root, output=output)
+    written = run_from_args(args)
+    assert written == output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["strategy_id"] == VOLBREAK_ID
+    assert payload["contract_hash"] == VOLBREAK_HASH
+    assert "EXPLORATORY_FALSIFICATION_ONLY" in payload["labels"]
+    assert "SURVIVORSHIP_BIASED=TRUE" in payload["labels"]
+    assert "VOLUME_CA_UNRESOLVED" in payload["labels"]
+    assert payload["orders"] == 0
+    assert payload["adapter"]["HOLDOUT_READS"] == 0
+    assert payload["adapter"]["FORBIDDEN_ROOT_ENUMERATIONS"] == 0
+    assert payload["adapter"]["ORDERS"] == 0
+    assert payload["adapter"]["ACCOUNT_CONTACT"] == 0
+    assert payload["adapter"]["DB_WRITES"] == 0
+    access_paths = payload["adapter"]["path_access_summary"]["year_roots"]
+    assert str(year_root) in access_paths
+    # No leftover partial after success.
+    assert not output.with_name(output.name + ".partial").exists()

--- a/tests/research/us_stage_b/test_cli.py
+++ b/tests/research/us_stage_b/test_cli.py
@@ -192,13 +192,27 @@ def test_atomic_write_refuses_overwrite_and_is_durable(tmp_path: Path) -> None:
     path = tmp_path / "artifact.json"
     atomic_write_json(path, {"a": 1})
     assert json.loads(path.read_text(encoding="utf-8")) == {"a": 1}
-    assert not path.with_name(path.name + ".partial").exists()
+    assert list(tmp_path.glob("*.partial")) == []
     with pytest.raises(CliRejection, match="overwrite"):
         atomic_write_json(path, {"a": 2})
 
 
+def test_atomic_write_cleans_stranded_partial_before_write(tmp_path: Path) -> None:
+    path = tmp_path / "artifact.json"
+    legacy = path.with_name(path.name + ".partial")
+    legacy.write_text("stranded", encoding="utf-8")
+    unique = path.with_name(f"{path.name}.99999.1.partial")
+    unique.write_text("also-stranded", encoding="utf-8")
+    atomic_write_json(path, {"ok": True})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"ok": True}
+    assert not legacy.exists()
+    assert not unique.exists()
+    assert list(tmp_path.glob("*.partial")) == []
+
+
 def test_cli_happy_path_writes_labeled_result_without_forbidden_enumeration(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     year_root = _minimal_volbreak_year(tmp_path)
     # Plant forbidden siblings that must never appear in access records.
@@ -220,7 +234,32 @@ def test_cli_happy_path_writes_labeled_result_without_forbidden_enumeration(
     assert payload["adapter"]["ORDERS"] == 0
     assert payload["adapter"]["ACCOUNT_CONTACT"] == 0
     assert payload["adapter"]["DB_WRITES"] == 0
+    assert payload["observation_summary"]["persisted"] == "signal_true_only"
+    assert payload["observation_summary"]["total_evaluated"] == 80
+    assert all(item["signal"] is True for item in payload["observations"])
+    assert payload["adapter"]["scale_estimate"]["sessions"] == 80
+    assert payload["adapter"]["scale_estimate"]["symbols"] == 1
     access_paths = payload["adapter"]["path_access_summary"]["year_roots"]
     assert str(year_root) in access_paths
     # No leftover partial after success.
-    assert not output.with_name(output.name + ".partial").exists()
+    assert list(tmp_path.glob("*.partial")) == []
+    err = capsys.readouterr().err
+    assert "SCALE_ESTIMATE" in err
+    assert "sessions=80" in err
+    assert "symbols=1" in err
+
+
+def test_cli_two_runs_are_byte_identical(tmp_path: Path) -> None:
+    year_root = _minimal_volbreak_year(tmp_path)
+    out_a = tmp_path / "a.json"
+    out_b = tmp_path / "b.json"
+    run_from_args(_base_args(tmp_path, year_root=year_root, output=out_a))
+    run_from_args(_base_args(tmp_path, year_root=year_root, output=out_b))
+    # Wall-clock fields differ; strip non-deterministic adapter timing only.
+    payload_a = json.loads(out_a.read_text(encoding="utf-8"))
+    payload_b = json.loads(out_b.read_text(encoding="utf-8"))
+    payload_a["adapter"].pop("engine_wall_seconds", None)
+    payload_b["adapter"].pop("engine_wall_seconds", None)
+    assert json.dumps(payload_a, sort_keys=True) == json.dumps(
+        payload_b, sort_keys=True
+    )

--- a/tests/research/us_stage_b/test_cli.py
+++ b/tests/research/us_stage_b/test_cli.py
@@ -263,3 +263,51 @@ def test_cli_two_runs_are_byte_identical(tmp_path: Path) -> None:
     assert json.dumps(payload_a, sort_keys=True) == json.dumps(
         payload_b, sort_keys=True
     )
+
+
+def _multi_signal_volbreak_year(tmp_path: Path) -> Path:
+    """Two symbols with true VOLBREAK signals so observation list order is tested."""
+
+    year_root = tmp_path / "corpus" / "year=2023"
+    rows: list[dict] = []
+    base = date(2023, 1, 3)
+    for symbol, adv_mult in (("AAA", 2.0), ("BBB", 1.0)):
+        for index in range(80):
+            session = date.fromordinal(base.toordinal() + index)
+            close = 100.0 + index * 0.1
+            volume = 50_000.0 * adv_mult
+            if index == 55:
+                close = 107.0
+                volume = 100_000.0 * adv_mult
+            elif index > 55:
+                close = 106.0
+            rows.append(_row(symbol, session, close=close, volume=volume))
+    return _write_year(year_root, rows)
+
+
+def test_cli_two_runs_byte_identical_with_multi_signal_order(tmp_path: Path) -> None:
+    """Determinism must cover list order when ≥2 signals are present (SHOULD-1)."""
+
+    year_root = _multi_signal_volbreak_year(tmp_path)
+    out_a = tmp_path / "multi-a.json"
+    out_b = tmp_path / "multi-b.json"
+    run_from_args(_base_args(tmp_path, year_root=year_root, output=out_a))
+    run_from_args(_base_args(tmp_path, year_root=year_root, output=out_b))
+    payload_a = json.loads(out_a.read_text(encoding="utf-8"))
+    payload_b = json.loads(out_b.read_text(encoding="utf-8"))
+    payload_a["adapter"].pop("engine_wall_seconds", None)
+    payload_b["adapter"].pop("engine_wall_seconds", None)
+    assert len(payload_a["observations"]) >= 2
+    assert [item["symbol"] for item in payload_a["observations"]] == [
+        item["symbol"] for item in payload_b["observations"]
+    ]
+    assert json.dumps(payload_a, sort_keys=True, separators=(",", ":")) == json.dumps(
+        payload_b, sort_keys=True, separators=(",", ":")
+    )
+    # Order-sensitive mutant: reverse observations must not match original bytes.
+    mutant = json.loads(json.dumps(payload_a))
+    mutant["observations"] = list(reversed(mutant["observations"]))
+    if len(mutant["observations"]) >= 2:
+        assert json.dumps(mutant, sort_keys=True, separators=(",", ":")) != json.dumps(
+            payload_a, sort_keys=True, separators=(",", ":")
+        )

--- a/tests/research/us_stage_b/test_engine.py
+++ b/tests/research/us_stage_b/test_engine.py
@@ -114,6 +114,13 @@ def test_entry_and_maturity_follow_corpus_session_index_not_calendar_days(
     assert outcome.entry_session != outcome.signal_session + timedelta(days=1)
     assert outcome.exit_session != outcome.entry_session + timedelta(days=10)
     assert result.access_summary["outside_boundary_reads"] == 0
+    assert result.observation_summary["total_evaluated"] == len(sessions)
+    assert result.observation_summary["persisted"] == "signal_true_only"
+    assert result.observation_summary["signal_true"] == len(result.observations)
+    assert all(item.signal for item in result.observations)
+    rendered = result.to_dict()
+    assert rendered["observation_summary"]["total_evaluated"] == len(sessions)
+    assert all(item["signal"] is True for item in rendered["observations"])
 
 
 def test_missing_selected_maturity_close_invalidates_the_whole_run(registry) -> None:

--- a/tests/research/us_stage_b/test_parquet_source.py
+++ b/tests/research/us_stage_b/test_parquet_source.py
@@ -92,7 +92,7 @@ def test_parquet_source_loads_literal_columns_deterministically(tmp_path: Path) 
     assert summary["rows_loaded"] == 3
     assert spy.forbidden_root_enumerations() == ()
     assert not any(
-        "holdout" in record.path.lower() or "_staging" in record.path
+        "holdout" in record.path.lower() or "_staging" in record.path.lower()
         for record in spy.records
     )
 

--- a/tests/research/us_stage_b/test_parquet_source.py
+++ b/tests/research/us_stage_b/test_parquet_source.py
@@ -1,0 +1,229 @@
+"""Focused tests for the read-only US Parquet adapter and path-access spy."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from research.us_stage_b.parquet_source import (
+    CorpusPathAccessError,
+    ParquetUSBarSource,
+    PathAccessSpy,
+    assert_year_root_allowed,
+    is_forbidden_corpus_path,
+)
+
+
+def _write_part(
+    directory: Path,
+    rows: list[dict],
+    *,
+    name: str = "part-00000.parquet",
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(rows)
+    path = directory / name
+    pq.write_table(table, path)
+    return path
+
+
+def _bar_row(
+    symbol: str,
+    session: date,
+    *,
+    open_: float = 10.0,
+    high: float = 11.0,
+    low: float = 9.0,
+    close: float = 10.5,
+    volume: float = 1_000.0,
+) -> dict:
+    return {
+        "symbol": symbol,
+        "session_date": datetime(session.year, session.month, session.day),
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    }
+
+
+def test_is_forbidden_corpus_path_detects_holdout_and_staging(tmp_path: Path) -> None:
+    assert is_forbidden_corpus_path(tmp_path / "holdout" / "year=2025")
+    assert is_forbidden_corpus_path(tmp_path / "HOLDOUT" / "x")
+    assert is_forbidden_corpus_path(tmp_path / "_staging" / "year=2016")
+    assert not is_forbidden_corpus_path(tmp_path / "dataset" / "year=2016")
+
+
+def test_parquet_source_loads_literal_columns_deterministically(tmp_path: Path) -> None:
+    year_root = tmp_path / "dataset" / "market=us" / "year=2016"
+    _write_part(
+        year_root,
+        [
+            _bar_row("BBB", date(2016, 1, 5), close=20.0),
+            _bar_row("AAA", date(2016, 1, 4), close=10.0),
+            _bar_row("AAA", date(2016, 1, 5), close=11.0),
+        ],
+    )
+    # Sibling forbidden trees must never be touched when only year_root is passed.
+    (tmp_path / "holdout").mkdir()
+    (tmp_path / "_staging").mkdir()
+    (tmp_path / "holdout" / "poison.parquet").write_bytes(b"not-parquet")
+
+    spy = PathAccessSpy()
+    source = ParquetUSBarSource.from_year_roots([year_root], access_spy=spy)
+
+    assert source.symbols() == ("AAA", "BBB")
+    assert source.corpus_sessions() == (date(2016, 1, 4), date(2016, 1, 5))
+    bar = source.get("AAA", date(2016, 1, 4))
+    assert bar is not None
+    assert bar.adjusted_close == 10.0
+    assert bar.open == 10.0
+    assert bar.volume == 1_000.0
+    assert source.get("MISSING", date(2016, 1, 4)) is None
+
+    summary = source.access_summary()
+    assert summary["forbidden_root_enumerations"] == 0
+    assert summary["holdout_reads"] == 0
+    assert summary["rows_loaded"] == 3
+    assert spy.forbidden_root_enumerations() == ()
+    assert not any(
+        "holdout" in record.path.lower() or "_staging" in record.path
+        for record in spy.records
+    )
+
+
+def test_duplicate_rows_fail_closed(tmp_path: Path) -> None:
+    year_root = tmp_path / "year=2017"
+    _write_part(
+        year_root,
+        [
+            _bar_row("AAA", date(2017, 3, 1)),
+            _bar_row("AAA", date(2017, 3, 1)),
+        ],
+    )
+    with pytest.raises(CorpusPathAccessError, match="duplicate"):
+        ParquetUSBarSource.from_year_roots([year_root])
+
+
+def test_null_symbol_and_null_session_fail_closed(tmp_path: Path) -> None:
+    year_root = tmp_path / "year=2018"
+    _write_part(
+        year_root,
+        [
+            {
+                "symbol": None,
+                "session_date": datetime(2018, 1, 2),
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "volume": 1.0,
+            }
+        ],
+    )
+    with pytest.raises(CorpusPathAccessError, match="invalid symbol"):
+        ParquetUSBarSource.from_year_roots([year_root])
+
+    year_root_b = tmp_path / "year=2019"
+    _write_part(
+        year_root_b,
+        [
+            {
+                "symbol": "AAA",
+                "session_date": None,
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "volume": 1.0,
+            }
+        ],
+    )
+    with pytest.raises(CorpusPathAccessError, match="null session_date"):
+        ParquetUSBarSource.from_year_roots([year_root_b])
+
+
+def test_missing_required_column_fail_closed(tmp_path: Path) -> None:
+    year_root = tmp_path / "year=2020"
+    year_root.mkdir()
+    table = pa.table(
+        {
+            "symbol": ["AAA"],
+            "session_date": [datetime(2020, 1, 2)],
+            "open": [1.0],
+            # high missing
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [1.0],
+        }
+    )
+    pq.write_table(table, year_root / "part-00000.parquet")
+    with pytest.raises(CorpusPathAccessError, match="lacks required columns"):
+        ParquetUSBarSource.from_year_roots([year_root])
+
+
+def test_year_2025_plus_rows_and_roots_fail_closed(tmp_path: Path) -> None:
+    bad_root = tmp_path / "year=2025"
+    bad_root.mkdir()
+    with pytest.raises(CorpusPathAccessError, match="outside the nine allowlisted"):
+        assert_year_root_allowed(bad_root)
+
+    year_root = tmp_path / "year=2024"
+    _write_part(
+        year_root,
+        [_bar_row("AAA", date(2025, 1, 2))],
+    )
+    with pytest.raises(CorpusPathAccessError, match="year mismatch|2025"):
+        ParquetUSBarSource.from_year_roots([year_root])
+
+
+def test_holdout_and_staging_roots_rejected_without_listdir(tmp_path: Path) -> None:
+    holdout_year = tmp_path / "holdout" / "year=2016"
+    holdout_year.mkdir(parents=True)
+    _write_part(holdout_year, [_bar_row("AAA", date(2016, 1, 4))])
+    spy = PathAccessSpy()
+    with pytest.raises(CorpusPathAccessError, match="forbidden"):
+        ParquetUSBarSource.from_year_roots([holdout_year], access_spy=spy)
+    assert all(record.kind != "listdir" for record in spy.records)
+    assert all(record.kind != "open_parquet" for record in spy.records)
+    assert spy.forbidden_root_enumerations() == ()
+
+    staging_year = tmp_path / "_staging" / "year=2017"
+    staging_year.mkdir(parents=True)
+    spy2 = PathAccessSpy()
+    with pytest.raises(CorpusPathAccessError, match="forbidden"):
+        ParquetUSBarSource.from_year_roots([staging_year], access_spy=spy2)
+    assert all(record.kind != "listdir" for record in spy2.records)
+    assert spy2.forbidden_root_enumerations() == ()
+
+
+def test_unknown_year_root_name_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "not-a-year"
+    root.mkdir()
+    with pytest.raises(CorpusPathAccessError, match="year=YYYY"):
+        assert_year_root_allowed(root)
+
+
+def test_multi_file_year_root_is_sorted_and_merged(tmp_path: Path) -> None:
+    year_root = tmp_path / "year=2021"
+    _write_part(
+        year_root,
+        [_bar_row("ZZZ", date(2021, 2, 1))],
+        name="part-00001.parquet",
+    )
+    _write_part(
+        year_root,
+        [_bar_row("AAA", date(2021, 1, 4))],
+        name="part-00000.parquet",
+    )
+    source = ParquetUSBarSource.from_year_roots([year_root])
+    assert source.symbols() == ("AAA", "ZZZ")
+    assert [path.name for path in source.files_read] == [
+        "part-00000.parquet",
+        "part-00001.parquet",
+    ]

--- a/tests/research/us_stage_b/test_registry_and_contracts.py
+++ b/tests/research/us_stage_b/test_registry_and_contracts.py
@@ -32,12 +32,27 @@ def test_registry_parses_original_packet_bytes_and_stamps_raw_contract_hashes(
         "7052f69ae1ae20de53750276c006959694941a1b2a430c99c8dbbe616cba9836",
         "43ff9a4a99ba3717c2d5563aa58c8a482800082c4fa4c41330712c4460848b0f",
     ]
+    expected_hashes = {
+        "US-TS-MOM-CONT-Z126-H20-v1": (
+            "25d06a5e81c03a254948ee20b9180d466e5531a63715dd1ba53b7160ce032509"
+        ),
+        "US-TS-REV-SHORT-Z3-T126-H3-v1": (
+            "7052f69ae1ae20de53750276c006959694941a1b2a430c99c8dbbe616cba9836"
+        ),
+        "US-TS-VOLBREAK-C55-V2-H10-v1": (
+            "43ff9a4a99ba3717c2d5563aa58c8a482800082c4fa4c41330712c4460848b0f"
+        ),
+    }
+    disposal = "EXPLORATORY_FALSIFIED (2026-08-06) — 결과 폐기, 승격 불가"
     for item in registry.admitted:
         payload = item.to_dict()
         assert payload["strategy_id"] == item.strategy_id
         assert payload["contract_hash"] == item.contract_hash
+        assert item.contract_hash == expected_hashes[item.strategy_id]
         assert "EXPLORATORY_FALSIFICATION_ONLY" in payload["labels"]
         assert "SURVIVORSHIP_BIASED=TRUE" in payload["labels"]
+        assert disposal in payload["labels"]
+        assert disposal in item.labels
 
 
 def test_registry_refuses_any_packet_byte_drift_before_parsing() -> None:


### PR DESCRIPTION
## Important — merge is not candidate promotion

**This merge is not candidate promotion.** This PR preserves the US Stage-B
infrastructure (adapter, CLI, driver, tests) as reusable assets. In the
2026-08-06 exploratory run all three candidates were rejected as `RUN_INVALID`
or `FALSIFIED`; those results are discarded and must not be promoted. Account
assignment, execution-envelope decisions, and paper admission do **not** follow
from this merge.

Registry labels now include:
`EXPLORATORY_FALSIFIED (2026-08-06) — 결과 폐기, 승격 불가`
for each of:
- `US-TS-MOM-CONT-Z126-H20-v1` (`RUN_INVALID`)
- `US-TS-REV-SHORT-Z3-T126-H3-v1` (`FALSIFIED_VALIDATION_COHORT_EXCESS`)
- `US-TS-VOLBREAK-C55-V2-H10-v1` (`RUN_INVALID`)

Contract hashes remain frozen and unchanged:
- `25d06a5e81c03a254948ee20b9180d466e5531a63715dd1ba53b7160ce032509`
- `7052f69ae1ae20de53750276c006959694941a1b2a430c99c8dbbe616cba9836`
- `43ff9a4a99ba3717c2d5563aa58c8a482800082c4fa4c41330712c4460848b0f`

## Summary
- Read-only Parquet `USBarSource` over explicit `year=2016..2024` roots with
  deterministic ordering, duplicate/invalid-row fail-closed behavior, and a
  path-access spy that never enumerates holdout/staging.
- Scheduleless CLI and hash-bound U1 exploration driver for one-trial-per-
  candidate exploratory falsification (no scheduler, broker, DB, or deploy).
- Compact signal-true observation persistence + streaming atomic JSON write so
  full-corpus runs complete without multi-ten-GB artifacts.
- Registry disposal labels after U1-B rejection (labels only; frozen contracts
  untouched).

## Scope / non-goals
- No paper/live promotion, no account assignment, no execution envelope.
- No holdout (2025+) reads, no broker/account/DB/scheduler/deploy mutation.
- No changes to frozen candidate YAML parameters, costs, or gate text.

## Test plan
- [x] `uv run pytest -q tests/research/us_stage_b` (46 passed)
- [x] Contract hashes re-verified post-label
- [x] U1-B three-candidate exploration recorded under job `events/run.md`
- [ ] Independent V2 result verification (separate)