### PR TITLE
fix(research): preserve ETR ablation ranking metrics

### DIFF
--- a/research/crypto_stage_b/registry.py
+++ b/research/crypto_stage_b/registry.py
@@ -15,6 +15,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
+from typing import Final
 
 __all__ = [
     "ADMITTED_STRATEGY_IDS",
@@ -22,6 +23,7 @@ __all__ = [
     "CandidateDefinition",
     "CandidateParseError",
     "CandidateRegistry",
+    "mandatory_labels",
 ]
 
 
@@ -38,6 +40,10 @@ ADMITTED_STRATEGY_IDS = (
 """The three operator-admitted candidates; HTA-01 remains preserved only."""
 
 _PRESERVED_NOT_IMPLEMENTED_ID = "CR-SPOT-HTA-01"
+_ETR_RESEARCH_LABELS: Final[tuple[str, ...]] = (
+    "CR-S1 verdict = BLOCKED (B2 unresolved)",
+    "ETR-01×Upbit PASS = exploratory, not promotable",
+)
 _CANDIDATE_START = re.compile(r"(?m)^- strategy_id: (?P<strategy_id>[^\r\n]+)$")
 _TOP_LEVEL_FIELD = re.compile(r"(?m)^  [A-Za-z_][A-Za-z0-9_]*:")
 _PARAMETER_LINE = re.compile(
@@ -50,6 +56,19 @@ _DECIMAL = re.compile(r"-?(?:0|[1-9]\d*)\.\d+\Z")
 
 class CandidateParseError(ValueError):
     """The sealed return cannot be used as an unambiguous strategy contract."""
+
+
+def mandatory_labels(strategy_id: str) -> tuple[str, ...]:
+    """Return additive registry labels that prevent research-status revival.
+
+    These labels are intentionally outside the verbatim candidate blocks: they
+    cannot alter the frozen contract hash, parameters, costs, or ablation
+    definition.  They are carried by every serialized registry definition so a
+    successful exploratory pair cannot be mistaken for a promotion decision.
+    """
+    if strategy_id == "CR-SPOT-ETR-01":
+        return _ETR_RESEARCH_LABELS
+    return ()
 
 
 @dataclass(frozen=True)
@@ -72,6 +91,11 @@ class CandidateDefinition:
     source_return_sha256: str
     contract_hash: str
 
+    @property
+    def labels(self) -> tuple[str, ...]:
+        """Return the mandatory non-promotional registry labels for this candidate."""
+        return mandatory_labels(self.strategy_id)
+
     def parameter(self, name: str) -> int | float:
         """Return one source-derived parameter or fail closed on contract drift."""
         try:
@@ -86,6 +110,7 @@ class CandidateDefinition:
         return {
             "strategy_id": self.strategy_id,
             "contract_hash": self.contract_hash,
+            "labels": self.labels,
             "source_return_sha256": self.source_return_sha256,
             "family_id": self.family_id,
             "venue_scope": self.venue_scope,

--- a/research/crypto_stage_b/signals.py
+++ b/research/crypto_stage_b/signals.py
@@ -283,6 +283,13 @@ def _evaluate_etr(
     metrics: dict[str, float] = {"r1": r1, "q10_r1": q10}
 
     if arm == "ablation":
+        _populate_etr_ablation_ranking_metrics(
+            candidate,
+            bars,
+            q10=q10,
+            r1=r1,
+            metrics=metrics,
+        )
         return _result(
             candidate,
             bars,
@@ -375,6 +382,52 @@ def _evaluate_etr(
             "quote_volume": volume_ok,
         },
         metrics=metrics,
+    )
+
+
+def _populate_etr_ablation_ranking_metrics(
+    candidate: CandidateDefinition,
+    bars: Sequence[DailyBar],
+    *,
+    q10: float,
+    r1: float,
+    metrics: dict[str, float],
+) -> None:
+    """Populate only valid ETR ranking inputs without changing ablation admission.
+
+    The pre-registered ablation remains ``tail_day`` alone.  Ranking is a
+    separate execution concern, so the full-arm thresholds are intentionally
+    not consulted here.  Inputs that fail the full path's existing raw-data
+    validity checks remain absent and therefore retain the engine's established
+    last-place treatment for missing ranking values.
+    """
+    metrics["tail_severity"] = q10 - r1
+    current = bars[-1]
+    if not _valid_ohlc(current, require_nonflat=True):
+        return
+    if not (
+        _is_finite_positive(current.base_volume)
+        and _is_finite_positive(current.quote_volume)
+    ):
+        return
+
+    volume_days = _int_parameter(candidate, "quote_volume_median_days")
+    volume_sample = tuple(bar.quote_volume for bar in bars[-(volume_days + 1) : -1])
+    if len(volume_sample) != volume_days:
+        raise CandidateParseError("ETR quote-volume sample length drift")
+    try:
+        volume_median = _median(volume_sample)
+    except ValueError:
+        return
+    if not _is_finite_positive(volume_median):
+        return
+
+    price_range = current.high - current.low
+    metrics.update(
+        {
+            "clv": (current.close - current.low) / price_range,
+            "qv_ratio": current.quote_volume / volume_median,
+        }
     )
 
 

--- a/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
+++ b/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
@@ -94,9 +94,7 @@ def _simultaneous_ablation_outcomes(
         arm="ablation",
     )
     signal_session = date(2024, 1, 1) + timedelta(days=251)
-    return [
-        item for item in result.outcomes if item.signal_session == signal_session
-    ]
+    return [item for item in result.outcomes if item.signal_session == signal_session]
 
 
 def test_etr_ablation_tied_qv_ratio_uses_clv_before_symbol() -> None:
@@ -130,8 +128,7 @@ def test_etr_ablation_tied_qv_ratio_uses_clv_before_symbol() -> None:
         simultaneous[1].ranking_metrics["qv_ratio"]
     )
     assert (
-        simultaneous[0].ranking_metrics["clv"]
-        > simultaneous[1].ranking_metrics["clv"]
+        simultaneous[0].ranking_metrics["clv"] > simultaneous[1].ranking_metrics["clv"]
     )
 
 
@@ -139,9 +136,7 @@ def test_etr_ablation_tied_qv_and_clv_uses_tail_severity_before_symbol() -> None
     """A later symbol wins ties on the first two frozen ranking keys."""
     weaker_tail = list(etr_bars(symbol="A"))
     for index in range(1, 50, 2):
-        weaker_tail[index] = replace(
-            weaker_tail[index], low=89.0, close=90.0
-        )
+        weaker_tail[index] = replace(weaker_tail[index], low=89.0, close=90.0)
 
     simultaneous = _simultaneous_ablation_outcomes(
         {

--- a/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
+++ b/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
@@ -83,6 +83,87 @@ def test_etr_ablation_uses_frozen_ranking_not_alphabetical_selection() -> None:
     )
 
 
+def _simultaneous_ablation_outcomes(
+    bars_by_symbol: dict[str, tuple[DailyBar, ...]],
+) -> list:
+    result = run_execution_arm(
+        source=InMemoryDailyBarSource(
+            [bar for bars in bars_by_symbol.values() for bar in bars]
+        ),
+        contract=_contract("CR-SPOT-ETR-01", venue="upbit_krw", end_index=255),
+        arm="ablation",
+    )
+    signal_session = date(2024, 1, 1) + timedelta(days=251)
+    return [
+        item for item in result.outcomes if item.signal_session == signal_session
+    ]
+
+
+def test_etr_ablation_tied_qv_ratio_uses_clv_before_symbol() -> None:
+    """A later symbol wins a primary-key tie through the second frozen key."""
+    profiles = {
+        "A": (41.0, 51.0, 40.0, 45.0, 200.0),
+        "Z": (41.0, 51.0, 40.0, 50.0, 200.0),
+    }
+    signal_session = date(2024, 1, 1) + timedelta(days=251)
+    bars_by_symbol: dict[str, tuple[DailyBar, ...]] = {}
+    for symbol, (open_price, high, low, close, quote_volume) in profiles.items():
+        bars_by_symbol[symbol] = tuple(
+            replace(
+                bar,
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+                quote_volume=quote_volume,
+            )
+            if bar.session == signal_session
+            else bar
+            for bar in etr_bars(symbol=symbol)
+        )
+
+    simultaneous = _simultaneous_ablation_outcomes(bars_by_symbol)
+
+    assert [item.symbol for item in simultaneous] == ["Z", "A"]
+    assert [item.rank for item in simultaneous] == [1, 2]
+    assert simultaneous[0].ranking_metrics["qv_ratio"] == pytest.approx(
+        simultaneous[1].ranking_metrics["qv_ratio"]
+    )
+    assert (
+        simultaneous[0].ranking_metrics["clv"]
+        > simultaneous[1].ranking_metrics["clv"]
+    )
+
+
+def test_etr_ablation_tied_qv_and_clv_uses_tail_severity_before_symbol() -> None:
+    """A later symbol wins ties on the first two frozen ranking keys."""
+    weaker_tail = list(etr_bars(symbol="A"))
+    for index in range(1, 50, 2):
+        weaker_tail[index] = replace(
+            weaker_tail[index], low=89.0, close=90.0
+        )
+
+    simultaneous = _simultaneous_ablation_outcomes(
+        {
+            "A": tuple(weaker_tail),
+            "Z": etr_bars(symbol="Z"),
+        }
+    )
+
+    assert [item.symbol for item in simultaneous] == ["Z", "A"]
+    assert [item.rank for item in simultaneous] == [1, 2]
+    assert simultaneous[0].ranking_metrics["qv_ratio"] == pytest.approx(
+        simultaneous[1].ranking_metrics["qv_ratio"]
+    )
+    assert simultaneous[0].ranking_metrics["clv"] == pytest.approx(
+        simultaneous[1].ranking_metrics["clv"]
+    )
+    assert (
+        simultaneous[0].ranking_metrics["tail_severity"]
+        > simultaneous[1].ranking_metrics["tail_severity"]
+    )
+
+
 def test_etr_ablation_populates_ranking_metrics_without_full_arm_admission() -> None:
     bars = etr_bars(quote_volume_on_signal=100.0)
 

--- a/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
+++ b/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from datetime import date, timedelta
+
+import pytest
+
+from research.crypto_stage_b.contracts import CryptoStageBRunContract
+from research.crypto_stage_b.engine import run_candidate_pair, run_execution_arm
+from research.crypto_stage_b.signals import evaluate_signal
+from research.crypto_stage_b.source import DailyBar, InMemoryDailyBarSource
+from research.crypto_stage_b.tests.conftest import candidate, cost, etr_bars
+
+
+def _contract(
+    strategy_id: str, *, venue: str, end_index: int
+) -> CryptoStageBRunContract:
+    start = date(2024, 1, 1)
+    return CryptoStageBRunContract(
+        candidate=candidate(strategy_id),
+        venue=venue,
+        exploration_start=start,
+        exploration_end=start + timedelta(days=end_index),
+        cost=cost(venue),
+    )
+
+
+def _etr_ablation_ranking_result():
+    """Build simultaneous tail days with the strongest tuple at symbol ``F``."""
+    profiles = {
+        "A": (80.0, 100.0, 40.0, 80.0, 100.0),
+        "B": (75.0, 95.0, 40.0, 75.0, 200.0),
+        "C": (70.0, 90.0, 40.0, 70.0, 300.0),
+        "D": (65.0, 85.0, 40.0, 65.0, 400.0),
+        "E": (60.0, 80.0, 40.0, 60.0, 500.0),
+        "F": (41.0, 51.0, 40.0, 50.0, 700.0),
+    }
+    signal_session = date(2024, 1, 1) + timedelta(days=251)
+    bars: list[DailyBar] = []
+    for symbol, (open_price, high, low, close, quote_volume) in profiles.items():
+        for bar in etr_bars(symbol=symbol):
+            if bar.session == signal_session:
+                bar = replace(
+                    bar,
+                    open=open_price,
+                    high=high,
+                    low=low,
+                    close=close,
+                    quote_volume=quote_volume,
+                )
+            bars.append(bar)
+    return run_execution_arm(
+        source=InMemoryDailyBarSource(bars),
+        contract=_contract("CR-SPOT-ETR-01", venue="upbit_krw", end_index=255),
+        arm="ablation",
+    )
+
+
+def test_etr_ablation_uses_frozen_ranking_not_alphabetical_selection() -> None:
+    result = _etr_ablation_ranking_result()
+    signal_session = date(2024, 1, 1) + timedelta(days=251)
+    simultaneous = [
+        item for item in result.outcomes if item.signal_session == signal_session
+    ]
+
+    assert [item.symbol for item in simultaneous] == ["F", "E", "D", "C", "B", "A"]
+    assert [item.rank for item in simultaneous] == [1, 2, 3, 4, 5, 6]
+    assert [item.status for item in simultaneous] == [
+        "completed",
+        "completed",
+        "completed",
+        "completed",
+        "completed",
+        "capacity_rejected",
+    ]
+    assert simultaneous[0].ranking_metrics["qv_ratio"] == pytest.approx(7.0)
+    assert simultaneous[0].ranking_metrics["clv"] == pytest.approx(10.0 / 11.0)
+    assert (
+        simultaneous[0].ranking_metrics["tail_severity"]
+        > simultaneous[1].ranking_metrics["tail_severity"]
+    )
+
+
+def test_etr_ablation_populates_ranking_metrics_without_full_arm_admission() -> None:
+    bars = etr_bars(quote_volume_on_signal=100.0)
+
+    full = evaluate_signal(candidate("CR-SPOT-ETR-01"), bars[:252], arm="full")
+    ablation = evaluate_signal(candidate("CR-SPOT-ETR-01"), bars[:252], arm="ablation")
+
+    assert full.signal is False
+    assert ablation.eligible is True
+    assert ablation.signal is True
+    assert ablation.stages == {"tail_day": True}
+    assert ablation.metrics["qv_ratio"] == pytest.approx(1.0)
+    assert ablation.metrics["clv"] == pytest.approx(0.8)
+    assert ablation.metrics["tail_severity"] > 0.0
+
+
+def test_etr_ablation_retains_tail_only_eligibility_when_rank_inputs_are_invalid() -> (
+    None
+):
+    bars = list(etr_bars())
+    bars[251] = replace(bars[251], high=40.0, low=40.0)
+
+    ablation = evaluate_signal(candidate("CR-SPOT-ETR-01"), bars[:252], arm="ablation")
+
+    assert ablation.eligible is True
+    assert ablation.signal is True
+    assert ablation.metrics["tail_severity"] > 0.0
+    assert "qv_ratio" not in ablation.metrics
+    assert "clv" not in ablation.metrics
+
+
+def _steady_bars(*, strategy_id: str, venue: str, symbol: str) -> tuple[DailyBar, ...]:
+    start = date(2024, 1, 1)
+    return tuple(
+        DailyBar(
+            venue=venue,
+            symbol=symbol,
+            session=start + timedelta(days=index),
+            open=100.0,
+            high=101.0,
+            low=99.0,
+            close=100.0,
+            base_volume=100.0,
+            quote_volume=100.0,
+        )
+        for index in range(candidate(strategy_id).required_history_days)
+    )
+
+
+def _payload_sha256(payload: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _fixed_fixture_output_hashes() -> dict[str, str]:
+    etr_full = run_execution_arm(
+        source=InMemoryDailyBarSource(
+            _steady_bars(
+                strategy_id="CR-SPOT-ETR-01", venue="upbit_krw", symbol="KRW-ETR"
+            )
+        ),
+        contract=_contract("CR-SPOT-ETR-01", venue="upbit_krw", end_index=251),
+        arm="full",
+    )
+    tpr_pair = run_candidate_pair(
+        source=InMemoryDailyBarSource(
+            _steady_bars(
+                strategy_id="CR-SPOT-TPR-01", venue="upbit_krw", symbol="KRW-TPR"
+            )
+        ),
+        contract=_contract("CR-SPOT-TPR-01", venue="upbit_krw", end_index=119),
+    )
+    ceb_pair = run_candidate_pair(
+        source=InMemoryDailyBarSource(
+            _steady_bars(
+                strategy_id="CR-SPOT-CEB-01",
+                venue="binance_usdt_spot",
+                symbol="CEBUSDT",
+            )
+        ),
+        contract=_contract("CR-SPOT-CEB-01", venue="binance_usdt_spot", end_index=121),
+    )
+    return {
+        "etr_full": _payload_sha256(etr_full.to_dict()),
+        "tpr_pair": _payload_sha256(tpr_pair.to_dict()),
+        "ceb_pair": _payload_sha256(ceb_pair.to_dict()),
+    }
+
+
+def test_fixed_fixture_non_target_outputs_are_unchanged() -> None:
+    assert _fixed_fixture_output_hashes() == {
+        "etr_full": "2731e2e4f21636039c715730e9ad19031e8d02b7810d558ddb562cd351cc10ec",
+        "tpr_pair": "7557308966a0668d7949aac88f987197898cf1f5ef1a27ac1703e180a1301859",
+        "ceb_pair": "1c5132d6741ebd768f573af9de7f463757ddd2b5e185e9959a213dc0ea0baca1",
+    }

--- a/research/crypto_stage_b/tests/test_registry.py
+++ b/research/crypto_stage_b/tests/test_registry.py
@@ -62,6 +62,13 @@ def test_registry_parses_raw_blocks_and_binds_each_contract_hash() -> None:
         item.to_dict()["contract_hash"] == item.contract_hash
         for item in registry.definitions
     )
+    etr = registry.get("CR-SPOT-ETR-01")
+    assert etr.labels == (
+        "CR-S1 verdict = BLOCKED (B2 unresolved)",
+        "ETR-01×Upbit PASS = exploratory, not promotable",
+    )
+    assert etr.to_dict()["labels"] == etr.labels
+    assert registry.get("CR-SPOT-TPR-01").labels == ()
 
 
 def test_registry_refuses_one_byte_drift_before_parsing() -> None:

--- a/research/crypto_stage_b/tests/test_replay_cr_s1_etr.py
+++ b/research/crypto_stage_b/tests/test_replay_cr_s1_etr.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from scripts import replay_cr_s1_etr as replay
+
+
+def test_replay_driver_is_bounded_to_the_two_frozen_etr_pairs() -> None:
+    assert set(replay._FROZEN_PAIR_SPECS) == {  # noqa: SLF001 - frozen CLI contract
+        "upbit_krw",
+        "binance_usdt_spot",
+    }
+    assert replay._FROZEN_PAIR_SPECS["upbit_krw"].output_filename == (  # noqa: SLF001
+        "cr-spot-etr-01__upbit_krw.json"
+    )
+    assert replay._FROZEN_PAIR_SPECS["binance_usdt_spot"].output_filename == (  # noqa: SLF001
+        "cr-spot-etr-01__binance_usdt_spot.json"
+    )
+
+
+def test_replay_record_writer_is_atomic_and_refuses_overwrite(tmp_path) -> None:
+    target = tmp_path / "cr-spot-etr-01__upbit_krw.json"
+    payload = {"schema_version": "test", "value": [1, 2, 3]}
+
+    digest = replay.write_json_once(target, payload)
+
+    expected_bytes = json.dumps(
+        payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    assert digest == hashlib.sha256(expected_bytes).hexdigest()
+    assert target.read_bytes() == expected_bytes
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        replay.write_json_once(target, {"schema_version": "replacement"})
+    assert target.read_bytes() == expected_bytes
+
+
+def test_replay_driver_and_engine_manifest_are_content_bound() -> None:
+    driver_sha256 = replay._sha256_file(replay._DRIVER_PATH)  # noqa: SLF001
+    manifest = replay._code_blob_manifest()  # noqa: SLF001
+
+    assert len(driver_sha256) == 64
+    assert all(len(digest) == 64 for digest in manifest.values())
+    assert replay._code_blob_manifest_sha256(manifest) == replay._sha256_json(manifest)  # noqa: SLF001

--- a/scripts/replay_cr_s1_etr.py
+++ b/scripts/replay_cr_s1_etr.py
@@ -1,0 +1,294 @@
+"""Hash-bound, no-overwrite replay driver for the two CR-S1 ETR venue pairs.
+
+The driver is deliberately offline and scheduleless.  It accepts only the
+already-authorized ETR candidate, one already-labeled venue corpus, and the
+frozen exploration window/cost literal for that venue.  It creates one pair
+record through an atomic hard-link publication, refusing to replace any prior
+artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from research.crypto_corpus.loader import load_labeled_parquet_files
+from research.crypto_stage_b.contracts import (
+    FROZEN_VENUE_COST_LITERALS,
+    CryptoStageBRunContract,
+    VenueCostLiteral,
+)
+from research.crypto_stage_b.engine import CandidatePairResult, run_candidate_pair
+from research.crypto_stage_b.registry import CandidateRegistry
+from research.crypto_stage_b.report import build_harness_report
+from research.crypto_stage_b.source import source_from_labeled_corpus
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DRIVER_PATH = Path(__file__).resolve()
+_ETR_STRATEGY_ID = "CR-SPOT-ETR-01"
+
+
+@dataclass(frozen=True)
+class _FrozenPairSpec:
+    venue: str
+    exploration_start: date
+    exploration_end: date
+    output_filename: str
+
+
+_FROZEN_PAIR_SPECS = {
+    "upbit_krw": _FrozenPairSpec(
+        venue="upbit_krw",
+        exploration_start=date(2017, 10, 24),
+        exploration_end=date(2024, 12, 31),
+        output_filename="cr-spot-etr-01__upbit_krw.json",
+    ),
+    "binance_usdt_spot": _FrozenPairSpec(
+        venue="binance_usdt_spot",
+        exploration_start=date(2018, 3, 19),
+        exploration_end=date(2024, 12, 31),
+        output_filename="cr-spot-etr-01__binance_usdt_spot.json",
+    ),
+}
+
+_CODE_BLOB_PATHS = (
+    Path("research/crypto_stage_b/contracts.py"),
+    Path("research/crypto_stage_b/engine.py"),
+    Path("research/crypto_stage_b/registry.py"),
+    Path("research/crypto_stage_b/report.py"),
+    Path("research/crypto_stage_b/signals.py"),
+    Path("research/crypto_stage_b/source.py"),
+)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json_bytes(payload: object) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256_json(payload: object) -> str:
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _code_blob_manifest() -> dict[str, str]:
+    return {
+        path.as_posix(): _sha256_file(_REPO_ROOT / path) for path in _CODE_BLOB_PATHS
+    }
+
+
+def _code_blob_manifest_sha256(manifest: dict[str, str]) -> str:
+    return _sha256_json(manifest)
+
+
+def _git_revision() -> str | None:
+    result = subprocess.run(
+        ("git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD"),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _git_blob_sha1(path: Path) -> str | None:
+    result = subprocess.run(
+        ("git", "-C", str(_REPO_ROOT), "hash-object", str(path)),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def pair_record_stream_sha256(pair: CandidatePairResult) -> str:
+    """Hash the explicitly named, complete deterministic pair-record stream."""
+    return _sha256_json(pair.to_dict())
+
+
+def write_json_once(path: Path, payload: dict[str, Any]) -> str:
+    """Atomically publish one JSON file without exposing or replacing a final.
+
+    A same-directory temporary is fully fsynced, then hard-linked to the final
+    name.  ``link`` fails if that final name already exists, so concurrent or
+    repeated runs cannot overwrite a completed pair record.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = _canonical_json_bytes(payload)
+    digest = hashlib.sha256(rendered).hexdigest()
+    temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.partial"
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o644,
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError as exc:
+            raise FileExistsError(
+                f"refusing to overwrite completed pair record: {path}"
+            ) from exc
+        finally:
+            temporary.unlink(missing_ok=True)
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return digest
+
+
+def build_pair_record(
+    *,
+    candidate_return: Path,
+    labeled_parquet: Sequence[Path],
+    venue: str,
+    expected_driver_sha256: str,
+    expected_code_manifest_sha256: str,
+) -> tuple[str, dict[str, Any]]:
+    """Run one frozen ETR pair only after all replay-code bindings match."""
+    spec = _FROZEN_PAIR_SPECS[venue]
+    driver_sha256 = _sha256_file(_DRIVER_PATH)
+    if driver_sha256 != expected_driver_sha256:
+        raise ValueError("replay driver SHA-256 mismatch; refuse an unbound replay")
+    code_blob_manifest = _code_blob_manifest()
+    code_manifest_sha256 = _code_blob_manifest_sha256(code_blob_manifest)
+    if code_manifest_sha256 != expected_code_manifest_sha256:
+        raise ValueError(
+            "engine code-manifest SHA-256 mismatch; refuse an unbound replay"
+        )
+
+    registry = CandidateRegistry.load(candidate_return)
+    candidate = next(
+        (
+            definition
+            for definition in registry.admitted
+            if definition.strategy_id == _ETR_STRATEGY_ID
+        ),
+        None,
+    )
+    if candidate is None:  # pragma: no cover - admission invariant guard
+        raise ValueError(f"frozen registry does not admit {_ETR_STRATEGY_ID}")
+    corpus = load_labeled_parquet_files(labeled_parquet, consumer_intent="time_series")
+    if corpus.policy.venue != venue:
+        raise ValueError(
+            f"labeled corpus venue {corpus.policy.venue!r} is not requested {venue!r}"
+        )
+    source = source_from_labeled_corpus(
+        corpus,
+        exploration_start=spec.exploration_start,
+        exploration_end=spec.exploration_end,
+    )
+    contract = CryptoStageBRunContract(
+        candidate=candidate,
+        venue=venue,
+        exploration_start=spec.exploration_start,
+        exploration_end=spec.exploration_end,
+        cost=VenueCostLiteral(venue=venue, **_frozen_cost_fields(venue)),
+    )
+    pair = run_candidate_pair(source=source, contract=contract)
+    pair_payload = pair.to_dict()
+    pair_record_stream_hash = pair_record_stream_sha256(pair)
+    record = {
+        "schema_version": "cr-s1-etr-replay-v1",
+        "strategy_id": _ETR_STRATEGY_ID,
+        "venue": venue,
+        "engine_revision": _git_revision(),
+        "driver": {
+            "path": _DRIVER_PATH.relative_to(_REPO_ROOT).as_posix(),
+            "blob_sha256": driver_sha256,
+            "git_blob_sha1": _git_blob_sha1(_DRIVER_PATH),
+        },
+        "engine_code_blobs": code_blob_manifest,
+        "engine_code_manifest_sha256": code_manifest_sha256,
+        "candidate_return": {
+            "path": str(candidate_return),
+            "sha256": _sha256_file(candidate_return),
+        },
+        "labeled_corpus": [
+            {"path": str(path), "sha256": _sha256_file(path)}
+            for path in labeled_parquet
+        ],
+        "terminal_events_input_count": 0,
+        "run_contract": contract.to_dict(),
+        "pair_record_stream_sha256": pair_record_stream_hash,
+        "pair": pair_payload,
+        "harness_query": build_harness_report(pair).to_dict(),
+    }
+    return spec.output_filename, record
+
+
+def _frozen_cost_fields(venue: str) -> dict[str, int]:
+    try:
+        return dict(FROZEN_VENUE_COST_LITERALS[venue])
+    except KeyError as exc:
+        raise ValueError(f"unsupported frozen venue: {venue!r}") from exc
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-return", type=Path, required=True)
+    parser.add_argument("--labeled-parquet", type=Path, action="append", required=True)
+    parser.add_argument("--venue", choices=tuple(_FROZEN_PAIR_SPECS), required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--expected-driver-sha256", required=True)
+    parser.add_argument("--expected-code-manifest-sha256", required=True)
+    args = parser.parse_args(argv)
+
+    output_filename, record = build_pair_record(
+        candidate_return=args.candidate_return,
+        labeled_parquet=tuple(args.labeled_parquet),
+        venue=args.venue,
+        expected_driver_sha256=args.expected_driver_sha256,
+        expected_code_manifest_sha256=args.expected_code_manifest_sha256,
+    )
+    output_path = args.output_dir / output_filename
+    output_sha256 = write_json_once(output_path, record)
+    print(
+        json.dumps(
+            {
+                "output_path": str(output_path),
+                "output_sha256": output_sha256,
+                "pair_record_stream_sha256": record["pair_record_stream_sha256"],
+                "driver_blob_sha256": record["driver"]["blob_sha256"],
+                "driver_git_blob_sha1": record["driver"]["git_blob_sha1"],
+                "engine_code_manifest_sha256": record["engine_code_manifest_sha256"],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Preserve a frozen-contract Crypto Stage-B conformance fix: valid ETR ablation ranking metrics no longer collapse selection to symbol alphabetic order.
- Retain the deterministic, no-overwrite replay driver for exactly CR-SPOT-ETR-01 × Upbit and Binance spot.
- Add rank-key regression coverage, registry-side status labels, and frozen non-target output checks.

## Non-promotion boundary

Merge is not candidate promotion. This PR preserves a crypto Stage-B frozen-contract conformance fix for the ETR ablation-ranking failure that had collapsed to alphabetic selection. The CR-S1 top-level verdict remains BLOCKED pending B2 resolution, and the ETR-01×Upbit PASS is exploratory and not eligible for promotion. No account allocation, paper approval, or HTA-01 promotion follows from this merge.

## Verification

- `uv run pytest research/crypto_stage_b -v -rA` — 28 passed.
- Contract hash and frozen cost literals were re-checked after the additive registry labels.
- No broker, account, DB, scheduler, deployment, promotion, rerun, or merge action was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an offline replay workflow for two supported ETR trading pairs, including validation, provenance tracking, and deterministic JSON result publishing.
  - Added research-status labels to ETR candidate definitions and serialized registry output.
  - Added ranking metrics for eligible evaluations, including tail severity, close location, and quote-volume ratio when valid data is available.

- **Bug Fixes**
  - Preserved tail-day eligibility when ranking inputs are invalid.

- **Tests**
  - Added coverage for ranking tie-breaking, replay integrity, output safety, hash stability, and registry labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->