### PR TITLE
fix(research): conform TPR CEB ablation ranking

### DIFF
--- a/research/crypto_stage_b/signals.py
+++ b/research/crypto_stage_b/signals.py
@@ -509,6 +509,7 @@ def _evaluate_tpr(
     }
 
     if arm == "ablation":
+        _populate_tpr_ablation_ranking_metrics(candidate, bars, metrics=metrics)
         return _result(
             candidate,
             bars,
@@ -587,6 +588,40 @@ def _evaluate_tpr(
         },
         metrics=metrics,
     )
+
+
+def _populate_tpr_ablation_ranking_metrics(
+    candidate: CandidateDefinition,
+    bars: Sequence[DailyBar],
+    *,
+    metrics: dict[str, float],
+) -> None:
+    """Populate valid TPR rank inputs without applying full-arm thresholds.
+
+    TPR ablation remains a trend-state-only arm.  The execution ranking's third
+    key is nevertheless part of the frozen contract, so it is derived whenever
+    the existing full path's raw volume validity permits it.  Invalid inputs
+    remain absent so the engine retains its established last-place behavior.
+    """
+    current = bars[-1]
+    if not (
+        _is_finite_positive(current.base_volume)
+        and _is_finite_positive(current.quote_volume)
+    ):
+        return
+
+    volume_days = _int_parameter(candidate, "quote_volume_median_days")
+    volume_sample = tuple(bar.quote_volume for bar in bars[-(volume_days + 1) : -1])
+    if len(volume_sample) != volume_days:
+        raise CandidateParseError("TPR quote-volume sample length drift")
+    try:
+        volume_median = _median(volume_sample)
+    except ValueError:
+        return
+    if not _is_finite_positive(volume_median):
+        return
+
+    metrics["qv_ratio"] = current.quote_volume / volume_median
 
 
 def _normalized_true_range(current: DailyBar, previous_close: float) -> float:
@@ -684,6 +719,13 @@ def _evaluate_ceb(
         "clv": clv,
     }
     if arm == "ablation":
+        _populate_ceb_ablation_ranking_metrics(
+            candidate,
+            bars,
+            ntr_history=ntr_history,
+            current_ntr=current_ntr,
+            metrics=metrics,
+        )
         return _result(
             candidate,
             bars,
@@ -766,4 +808,40 @@ def _evaluate_ceb(
             "quote_volume": volume_ok,
         },
         metrics=metrics,
+    )
+
+
+def _populate_ceb_ablation_ranking_metrics(
+    candidate: CandidateDefinition,
+    bars: Sequence[DailyBar],
+    *,
+    ntr_history: Sequence[float],
+    current_ntr: float,
+    metrics: dict[str, float],
+) -> None:
+    """Populate valid CEB rank inputs without changing raw-breakout admission.
+
+    CEB ablation remains a raw-20d-breakout arm.  Its first and second frozen
+    rank keys are derived only when the existing full path accepts their raw
+    inputs; range/volume thresholds are intentionally not applied here.
+    """
+    current = bars[-1]
+    if not _is_finite_positive(current.quote_volume):
+        return
+    volume_days = _int_parameter(candidate, "quote_volume_median_days")
+    try:
+        ntr_median = _median(ntr_history)
+        volume_median = _median(
+            tuple(bar.quote_volume for bar in bars[-(volume_days + 1) : -1])
+        )
+    except ValueError:
+        return
+    if not (_is_finite_positive(ntr_median) and _is_finite_positive(volume_median)):
+        return
+
+    metrics.update(
+        {
+            "range_ratio": current_ntr / ntr_median,
+            "qv_ratio": current.quote_volume / volume_median,
+        }
     )

--- a/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
+++ b/research/crypto_stage_b/tests/test_b1_etr_ablation_conformance.py
@@ -8,7 +8,7 @@ from datetime import date, timedelta
 import pytest
 
 from research.crypto_stage_b.contracts import CryptoStageBRunContract
-from research.crypto_stage_b.engine import run_candidate_pair, run_execution_arm
+from research.crypto_stage_b.engine import run_execution_arm
 from research.crypto_stage_b.signals import evaluate_signal
 from research.crypto_stage_b.source import DailyBar, InMemoryDailyBarSource
 from research.crypto_stage_b.tests.conftest import candidate, cost, etr_bars
@@ -215,7 +215,7 @@ def _payload_sha256(payload: object) -> str:
     ).hexdigest()
 
 
-def _fixed_fixture_output_hashes() -> dict[str, str]:
+def _fixed_etr_full_output_hash() -> str:
     etr_full = run_execution_arm(
         source=InMemoryDailyBarSource(
             _steady_bars(
@@ -225,34 +225,11 @@ def _fixed_fixture_output_hashes() -> dict[str, str]:
         contract=_contract("CR-SPOT-ETR-01", venue="upbit_krw", end_index=251),
         arm="full",
     )
-    tpr_pair = run_candidate_pair(
-        source=InMemoryDailyBarSource(
-            _steady_bars(
-                strategy_id="CR-SPOT-TPR-01", venue="upbit_krw", symbol="KRW-TPR"
-            )
-        ),
-        contract=_contract("CR-SPOT-TPR-01", venue="upbit_krw", end_index=119),
-    )
-    ceb_pair = run_candidate_pair(
-        source=InMemoryDailyBarSource(
-            _steady_bars(
-                strategy_id="CR-SPOT-CEB-01",
-                venue="binance_usdt_spot",
-                symbol="CEBUSDT",
-            )
-        ),
-        contract=_contract("CR-SPOT-CEB-01", venue="binance_usdt_spot", end_index=121),
-    )
-    return {
-        "etr_full": _payload_sha256(etr_full.to_dict()),
-        "tpr_pair": _payload_sha256(tpr_pair.to_dict()),
-        "ceb_pair": _payload_sha256(ceb_pair.to_dict()),
-    }
+    return _payload_sha256(etr_full.to_dict())
 
 
-def test_fixed_fixture_non_target_outputs_are_unchanged() -> None:
-    assert _fixed_fixture_output_hashes() == {
-        "etr_full": "2731e2e4f21636039c715730e9ad19031e8d02b7810d558ddb562cd351cc10ec",
-        "tpr_pair": "7557308966a0668d7949aac88f987197898cf1f5ef1a27ac1703e180a1301859",
-        "ceb_pair": "1c5132d6741ebd768f573af9de7f463757ddd2b5e185e9959a213dc0ea0baca1",
-    }
+def test_fixed_etr_full_fixture_is_unchanged() -> None:
+    assert (
+        _fixed_etr_full_output_hash()
+        == "2731e2e4f21636039c715730e9ad19031e8d02b7810d558ddb562cd351cc10ec"
+    )

--- a/research/crypto_stage_b/tests/test_b1_tpr_ceb_ablation_conformance.py
+++ b/research/crypto_stage_b/tests/test_b1_tpr_ceb_ablation_conformance.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from datetime import date, timedelta
+
+import pytest
+
+from research.crypto_stage_b.contracts import CryptoStageBRunContract
+from research.crypto_stage_b.engine import run_candidate_pair, run_execution_arm
+from research.crypto_stage_b.signals import evaluate_signal
+from research.crypto_stage_b.source import DailyBar, InMemoryDailyBarSource
+from research.crypto_stage_b.tests.conftest import candidate, cost, etr_bars
+
+_START = date(2024, 1, 1)
+
+
+def _contract(
+    strategy_id: str, *, venue: str, end_index: int
+) -> CryptoStageBRunContract:
+    return CryptoStageBRunContract(
+        candidate=candidate(strategy_id),
+        venue=venue,
+        exploration_start=_START,
+        exploration_end=_START + timedelta(days=end_index),
+        cost=cost(venue),
+    )
+
+
+def _tpr_bars(*, symbol: str, quote_volume_on_signal: float) -> tuple[DailyBar, ...]:
+    """Return two otherwise-identical trend signals with a controlled qv tuple."""
+    bars: list[DailyBar] = []
+    for index in range(131):
+        close = 100.0 + 0.2 * index
+        bars.append(
+            DailyBar(
+                venue="upbit_krw",
+                symbol=symbol,
+                session=_START + timedelta(days=index),
+                open=close - 0.5,
+                high=close + 1.0,
+                low=close - 1.0,
+                close=close,
+                base_volume=100.0,
+                quote_volume=(quote_volume_on_signal if index == 119 else 100.0),
+            )
+        )
+    return tuple(bars)
+
+
+def _ceb_bars(
+    *,
+    symbol: str,
+    signal_high: float,
+    signal_low: float,
+    signal_close: float,
+    quote_volume_on_signal: float,
+) -> tuple[DailyBar, ...]:
+    """Return a raw-breakout-only fixture with controlled ranking inputs."""
+    bars: list[DailyBar] = []
+    for index in range(129):
+        if index == 121:
+            open_price = 100.0
+            high = signal_high
+            low = signal_low
+            close = signal_close
+            quote_volume = quote_volume_on_signal
+        else:
+            open_price = 100.0
+            high = 101.0
+            low = 99.0
+            close = 100.0
+            quote_volume = 100.0
+        bars.append(
+            DailyBar(
+                venue="upbit_krw",
+                symbol=symbol,
+                session=_START + timedelta(days=index),
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+                base_volume=100.0,
+                quote_volume=quote_volume,
+            )
+        )
+    return tuple(bars)
+
+
+def _simultaneous_outcomes(
+    *, strategy_id: str, bars: tuple[DailyBar, ...], signal_index: int
+):
+    result = run_execution_arm(
+        source=InMemoryDailyBarSource(bars),
+        contract=_contract(
+            strategy_id,
+            venue="upbit_krw",
+            end_index=130 if strategy_id == "CR-SPOT-TPR-01" else 128,
+        ),
+        arm="ablation",
+    )
+    signal_session = _START + timedelta(days=signal_index)
+    return [item for item in result.outcomes if item.signal_session == signal_session]
+
+
+def test_tpr_ablation_alphabetic_fixture_uses_qv_before_symbol() -> None:
+    """The lexically last symbol wins only through TPR's frozen third key."""
+    outcomes = _simultaneous_outcomes(
+        strategy_id="CR-SPOT-TPR-01",
+        bars=_tpr_bars(symbol="A", quote_volume_on_signal=100.0)
+        + _tpr_bars(symbol="Z", quote_volume_on_signal=300.0),
+        signal_index=119,
+    )
+
+    assert [item.symbol for item in outcomes] == ["Z", "A"]
+    assert outcomes[0].ranking_metrics["pullback_extension"] == pytest.approx(
+        outcomes[1].ranking_metrics["pullback_extension"]
+    )
+    assert outcomes[0].ranking_metrics["trend_slope"] == pytest.approx(
+        outcomes[1].ranking_metrics["trend_slope"]
+    )
+    assert outcomes[0].ranking_metrics["qv_ratio"] == pytest.approx(3.0)
+    assert outcomes[1].ranking_metrics["qv_ratio"] == pytest.approx(1.0)
+
+
+def test_tpr_ablation_missing_third_rank_mutant_would_choose_alphabetically() -> None:
+    """Deleting qv_ratio is distinguishable from the frozen three-key ranking."""
+    outcomes = _simultaneous_outcomes(
+        strategy_id="CR-SPOT-TPR-01",
+        bars=_tpr_bars(symbol="A", quote_volume_on_signal=100.0)
+        + _tpr_bars(symbol="M", quote_volume_on_signal=200.0)
+        + _tpr_bars(symbol="Z", quote_volume_on_signal=400.0),
+        signal_index=119,
+    )
+
+    assert [item.symbol for item in outcomes] == ["Z", "M", "A"]
+    assert [
+        item.symbol
+        for item in sorted(
+            outcomes,
+            key=lambda item: (
+                -item.ranking_metrics["pullback_extension"],
+                -item.ranking_metrics["trend_slope"],
+                item.symbol,
+            ),
+        )
+    ] == ["A", "M", "Z"]
+
+
+def test_ceb_ablation_alphabetic_fixture_uses_first_two_frozen_keys() -> None:
+    """The lexical first symbol loses although breakout extension is tied."""
+    outcomes = _simultaneous_outcomes(
+        strategy_id="CR-SPOT-CEB-01",
+        bars=_ceb_bars(
+            symbol="A",
+            signal_high=102.2,
+            signal_low=99.0,
+            signal_close=102.0,
+            quote_volume_on_signal=150.0,
+        )
+        + _ceb_bars(
+            symbol="Z",
+            signal_high=105.0,
+            signal_low=99.0,
+            signal_close=102.0,
+            quote_volume_on_signal=300.0,
+        ),
+        signal_index=121,
+    )
+
+    assert [item.symbol for item in outcomes] == ["Z", "A"]
+    assert (
+        outcomes[0].ranking_metrics["qv_ratio"]
+        > outcomes[1].ranking_metrics["qv_ratio"]
+    )
+    assert (
+        outcomes[0].ranking_metrics["range_ratio"]
+        > outcomes[1].ranking_metrics["range_ratio"]
+    )
+    assert outcomes[0].ranking_metrics["breakout_extension"] == pytest.approx(
+        outcomes[1].ranking_metrics["breakout_extension"]
+    )
+
+
+def test_ceb_ablation_third_rank_substitution_mutant_is_defeated() -> None:
+    """A breakout-only substitute picks A; the frozen tuple must select Z."""
+    outcomes = _simultaneous_outcomes(
+        strategy_id="CR-SPOT-CEB-01",
+        bars=_ceb_bars(
+            symbol="A",
+            signal_high=106.0,
+            signal_low=99.0,
+            signal_close=105.0,
+            quote_volume_on_signal=150.0,
+        )
+        + _ceb_bars(
+            symbol="Z",
+            signal_high=110.0,
+            signal_low=99.0,
+            signal_close=102.0,
+            quote_volume_on_signal=300.0,
+        ),
+        signal_index=121,
+    )
+
+    assert [item.symbol for item in outcomes] == ["Z", "A"]
+    assert (
+        outcomes[0].ranking_metrics["qv_ratio"]
+        > outcomes[1].ranking_metrics["qv_ratio"]
+    )
+    assert (
+        outcomes[0].ranking_metrics["range_ratio"]
+        > outcomes[1].ranking_metrics["range_ratio"]
+    )
+    assert (
+        outcomes[0].ranking_metrics["breakout_extension"]
+        < outcomes[1].ranking_metrics["breakout_extension"]
+    )
+    assert [
+        item.symbol
+        for item in sorted(
+            outcomes,
+            key=lambda item: (-item.ranking_metrics["breakout_extension"], item.symbol),
+        )
+    ] == ["A", "Z"]
+
+
+def test_tpr_ablation_populates_qv_without_full_arm_admission() -> None:
+    bars = _tpr_bars(symbol="TPR", quote_volume_on_signal=50.0)
+
+    full = evaluate_signal(candidate("CR-SPOT-TPR-01"), bars[:120], arm="full")
+    ablation = evaluate_signal(candidate("CR-SPOT-TPR-01"), bars[:120], arm="ablation")
+
+    assert full.signal is False
+    assert ablation.eligible is True
+    assert ablation.signal is True
+    assert ablation.stages == {"trend_state": True}
+    assert ablation.metrics["qv_ratio"] == pytest.approx(0.5)
+
+
+def test_tpr_ablation_keeps_missing_qv_last_when_raw_volume_is_invalid() -> None:
+    bars = list(_tpr_bars(symbol="TPR", quote_volume_on_signal=300.0))
+    bars[119] = replace(bars[119], base_volume=0.0)
+
+    ablation = evaluate_signal(candidate("CR-SPOT-TPR-01"), bars[:120], arm="ablation")
+
+    assert ablation.eligible is True
+    assert ablation.signal is True
+    assert "qv_ratio" not in ablation.metrics
+
+
+def test_ceb_ablation_populates_ranking_inputs_without_full_arm_admission() -> None:
+    bars = _ceb_bars(
+        symbol="CEB",
+        signal_high=106.0,
+        signal_low=99.0,
+        signal_close=105.0,
+        quote_volume_on_signal=100.0,
+    )
+
+    full = evaluate_signal(candidate("CR-SPOT-CEB-01"), bars[:122], arm="full")
+    ablation = evaluate_signal(candidate("CR-SPOT-CEB-01"), bars[:122], arm="ablation")
+
+    assert full.signal is False
+    assert ablation.eligible is True
+    assert ablation.signal is True
+    assert ablation.stages == {
+        "compression_state": True,
+        "raw_20d_breakout": True,
+    }
+    assert ablation.metrics["qv_ratio"] == pytest.approx(1.0)
+    assert ablation.metrics["range_ratio"] > 1.0
+
+
+def test_ceb_ablation_keeps_missing_ranking_inputs_last_when_raw_volume_is_invalid() -> (
+    None
+):
+    bars = _ceb_bars(
+        symbol="CEB",
+        signal_high=106.0,
+        signal_low=99.0,
+        signal_close=105.0,
+        quote_volume_on_signal=0.0,
+    )
+
+    ablation = evaluate_signal(candidate("CR-SPOT-CEB-01"), bars[:122], arm="ablation")
+
+    assert ablation.eligible is True
+    assert ablation.signal is True
+    assert "qv_ratio" not in ablation.metrics
+    assert "range_ratio" not in ablation.metrics
+
+
+def _payload_sha256(payload: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def test_fixed_fixture_full_arms_and_etr_all_arms_are_unchanged_from_base() -> None:
+    """Base ``b342b09f5`` hashes prove the correction has no other arm effect."""
+    etr_pair = run_candidate_pair(
+        source=InMemoryDailyBarSource(etr_bars()),
+        contract=_contract("CR-SPOT-ETR-01", venue="upbit_krw", end_index=255),
+    )
+    tpr_full = run_execution_arm(
+        source=InMemoryDailyBarSource(
+            _tpr_bars(symbol="TPR", quote_volume_on_signal=300.0)
+        ),
+        contract=_contract("CR-SPOT-TPR-01", venue="upbit_krw", end_index=130),
+        arm="full",
+    )
+    ceb_full = run_execution_arm(
+        source=InMemoryDailyBarSource(
+            _ceb_bars(
+                symbol="CEB",
+                signal_high=106.0,
+                signal_low=99.0,
+                signal_close=105.0,
+                quote_volume_on_signal=300.0,
+            )
+        ),
+        contract=_contract("CR-SPOT-CEB-01", venue="upbit_krw", end_index=128),
+        arm="full",
+    )
+
+    assert {
+        "etr_pair_all_arms": _payload_sha256(etr_pair.to_dict()),
+        "tpr_full": _payload_sha256(tpr_full.to_dict()),
+        "ceb_full": _payload_sha256(ceb_full.to_dict()),
+    } == {
+        "etr_pair_all_arms": "14a57dc10a52f6553a7b7a3e31e484d74f263526cf08e28cf513c0cc47a92b5a",
+        "tpr_full": "ca00c7c4890ad1bb1fb8e3acb52aa38b0da08a6911596f53fc38b4383c9188ef",
+        "ceb_full": "6c82a7759bf5cb9d9d032d796745f957c421bdd40d8ebe56aa0ab405e1e6ee0c",
+    }

--- a/research/crypto_stage_b/tests/test_replay_cr_s1_tpr_ceb.py
+++ b/research/crypto_stage_b/tests/test_replay_cr_s1_tpr_ceb.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from scripts import replay_cr_s1_tpr_ceb as replay
+
+
+def test_replay_driver_is_bounded_to_exactly_four_tpr_ceb_pairs() -> None:
+    assert set(replay._FROZEN_PAIR_SPECS) == {  # noqa: SLF001 - frozen CLI contract
+        "tpr_upbit_krw",
+        "tpr_binance_usdt_spot",
+        "ceb_upbit_krw",
+        "ceb_binance_usdt_spot",
+    }
+    assert {
+        spec.strategy_id
+        for spec in replay._FROZEN_PAIR_SPECS.values()  # noqa: SLF001
+    } == {"CR-SPOT-TPR-01", "CR-SPOT-CEB-01"}
+    assert {
+        spec.output_filename
+        for spec in replay._FROZEN_PAIR_SPECS.values()  # noqa: SLF001
+    } == {
+        "cr-spot-tpr-01__upbit_krw.json",
+        "cr-spot-tpr-01__binance_usdt_spot.json",
+        "cr-spot-ceb-01__upbit_krw.json",
+        "cr-spot-ceb-01__binance_usdt_spot.json",
+    }
+
+
+def test_replay_record_writer_is_atomic_and_refuses_overwrite(tmp_path) -> None:
+    target = tmp_path / "cr-spot-tpr-01__upbit_krw.json"
+    payload = {"schema_version": "test", "value": [1, 2, 3]}
+
+    digest = replay.write_json_once(target, payload)
+
+    expected_bytes = json.dumps(
+        payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    assert digest == hashlib.sha256(expected_bytes).hexdigest()
+    assert target.read_bytes() == expected_bytes
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        replay.write_json_once(target, {"schema_version": "replacement"})
+    assert target.read_bytes() == expected_bytes
+
+
+def test_replay_driver_and_engine_manifest_are_content_bound() -> None:
+    driver_sha256 = replay._sha256_file(replay._DRIVER_PATH)  # noqa: SLF001
+    manifest = replay._code_blob_manifest()  # noqa: SLF001
+
+    assert len(driver_sha256) == 64
+    assert all(len(digest) == 64 for digest in manifest.values())
+    assert replay._code_blob_manifest_sha256(manifest) == replay._sha256_json(manifest)  # noqa: SLF001
+
+
+def test_budget_literal_and_accounting_are_bound_to_the_driver() -> None:
+    assert replay._BUDGET_LITERAL == (  # noqa: SLF001 - evidence literal contract
+        "이 replay 는 기존 구현 오류의 correction 이며 새 trial 이 아니다 — D2 예산 미소모."
+    )
+
+
+def test_manifest_seals_exactly_the_four_bound_records(tmp_path) -> None:
+    driver_sha256 = replay._sha256_file(replay._DRIVER_PATH)  # noqa: SLF001
+    code_manifest_sha256 = replay._code_blob_manifest_sha256(  # noqa: SLF001
+        replay._code_blob_manifest()  # noqa: SLF001
+    )
+    for spec in replay._FROZEN_PAIR_SPECS.values():  # noqa: SLF001
+        payload = {
+            "strategy_id": spec.strategy_id,
+            "venue": spec.venue,
+            "driver": {"blob_sha256": driver_sha256},
+            "engine_code_manifest_sha256": code_manifest_sha256,
+            "replay_classification": {
+                "budget_literal": replay._BUDGET_LITERAL,  # noqa: SLF001
+                "trial_count": 0,
+                "correction_replay_count": 1,
+            },
+            "pair_record_stream_sha256": "a" * 64,
+            "run_contract": {
+                "contract_hash": "test-contract",
+                "cost_literal": {
+                    "round_trip_bp": 30,
+                    "sensitivity_round_trip_bp": 70,
+                },
+            },
+        }
+        (tmp_path / spec.output_filename).write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    manifest = replay.build_manifest(
+        output_dir=tmp_path,
+        expected_driver_sha256=driver_sha256,
+        expected_code_manifest_sha256=code_manifest_sha256,
+    )
+
+    assert manifest["replay_classification"]["trial_count"] == 0
+    assert manifest["replay_classification"]["correction_replay_count"] == 4
+    assert manifest["scope"]["etr_pairs_touched"] == 0
+    assert len(manifest["records"]) == 4

--- a/scripts/replay_cr_s1_tpr_ceb.py
+++ b/scripts/replay_cr_s1_tpr_ceb.py
@@ -1,0 +1,418 @@
+"""Hash-bound, no-overwrite correction replay driver for four CR-S1 pairs.
+
+The driver is offline and scheduleless.  It accepts only the four authorized
+TPR/CEB candidate × venue pairs, runs one pair per invocation after binding the
+driver and engine hashes, and atomically publishes immutable JSON records.
+``--write-manifest`` then seals exactly those four records; ETR is not an
+accepted target of any invocation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from research.crypto_corpus.loader import load_labeled_parquet_files
+from research.crypto_stage_b.contracts import (
+    FROZEN_VENUE_COST_LITERALS,
+    CryptoStageBRunContract,
+    VenueCostLiteral,
+)
+from research.crypto_stage_b.engine import CandidatePairResult, run_candidate_pair
+from research.crypto_stage_b.registry import CandidateRegistry
+from research.crypto_stage_b.report import build_harness_report
+from research.crypto_stage_b.source import source_from_labeled_corpus
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DRIVER_PATH = Path(__file__).resolve()
+_BUDGET_LITERAL = (
+    "이 replay 는 기존 구현 오류의 correction 이며 새 trial 이 아니다 — D2 예산 미소모."
+)
+
+
+@dataclass(frozen=True)
+class _FrozenPairSpec:
+    strategy_id: str
+    venue: str
+    exploration_start: date
+    exploration_end: date
+    output_filename: str
+
+
+_FROZEN_PAIR_SPECS = {
+    "tpr_upbit_krw": _FrozenPairSpec(
+        strategy_id="CR-SPOT-TPR-01",
+        venue="upbit_krw",
+        exploration_start=date(2017, 10, 24),
+        exploration_end=date(2024, 12, 31),
+        output_filename="cr-spot-tpr-01__upbit_krw.json",
+    ),
+    "tpr_binance_usdt_spot": _FrozenPairSpec(
+        strategy_id="CR-SPOT-TPR-01",
+        venue="binance_usdt_spot",
+        exploration_start=date(2018, 3, 19),
+        exploration_end=date(2024, 12, 31),
+        output_filename="cr-spot-tpr-01__binance_usdt_spot.json",
+    ),
+    "ceb_upbit_krw": _FrozenPairSpec(
+        strategy_id="CR-SPOT-CEB-01",
+        venue="upbit_krw",
+        exploration_start=date(2017, 10, 24),
+        exploration_end=date(2024, 12, 31),
+        output_filename="cr-spot-ceb-01__upbit_krw.json",
+    ),
+    "ceb_binance_usdt_spot": _FrozenPairSpec(
+        strategy_id="CR-SPOT-CEB-01",
+        venue="binance_usdt_spot",
+        exploration_start=date(2018, 3, 19),
+        exploration_end=date(2024, 12, 31),
+        output_filename="cr-spot-ceb-01__binance_usdt_spot.json",
+    ),
+}
+
+_CODE_BLOB_PATHS = (
+    Path("research/crypto_stage_b/contracts.py"),
+    Path("research/crypto_stage_b/engine.py"),
+    Path("research/crypto_stage_b/registry.py"),
+    Path("research/crypto_stage_b/report.py"),
+    Path("research/crypto_stage_b/signals.py"),
+    Path("research/crypto_stage_b/source.py"),
+)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json_bytes(payload: object) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256_json(payload: object) -> str:
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _code_blob_manifest() -> dict[str, str]:
+    return {
+        path.as_posix(): _sha256_file(_REPO_ROOT / path) for path in _CODE_BLOB_PATHS
+    }
+
+
+def _code_blob_manifest_sha256(manifest: dict[str, str]) -> str:
+    return _sha256_json(manifest)
+
+
+def _git_revision() -> str | None:
+    result = subprocess.run(
+        ("git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD"),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _git_blob_sha1(path: Path) -> str | None:
+    result = subprocess.run(
+        ("git", "-C", str(_REPO_ROOT), "hash-object", str(path)),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def pair_record_stream_sha256(pair: CandidatePairResult) -> str:
+    """Hash the explicitly named, complete deterministic pair-record stream."""
+    return _sha256_json(pair.to_dict())
+
+
+def write_json_once(path: Path, payload: dict[str, Any]) -> str:
+    """Atomically publish one JSON file and refuse to replace a completed file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = _canonical_json_bytes(payload)
+    digest = hashlib.sha256(rendered).hexdigest()
+    temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.partial"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError as exc:
+            raise FileExistsError(
+                f"refusing to overwrite completed replay record: {path}"
+            ) from exc
+        finally:
+            temporary.unlink(missing_ok=True)
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return digest
+
+
+def _bound_code_manifest(
+    *, expected_driver_sha256: str, expected_code_manifest_sha256: str
+) -> tuple[str, dict[str, str], str]:
+    driver_sha256 = _sha256_file(_DRIVER_PATH)
+    if driver_sha256 != expected_driver_sha256:
+        raise ValueError("replay driver SHA-256 mismatch; refuse an unbound replay")
+    code_blob_manifest = _code_blob_manifest()
+    code_manifest_sha256 = _code_blob_manifest_sha256(code_blob_manifest)
+    if code_manifest_sha256 != expected_code_manifest_sha256:
+        raise ValueError(
+            "engine code-manifest SHA-256 mismatch; refuse an unbound replay"
+        )
+    return driver_sha256, code_blob_manifest, code_manifest_sha256
+
+
+def _frozen_cost_fields(venue: str) -> dict[str, int]:
+    try:
+        return dict(FROZEN_VENUE_COST_LITERALS[venue])
+    except KeyError as exc:
+        raise ValueError(f"unsupported frozen venue: {venue!r}") from exc
+
+
+def build_pair_record(
+    *,
+    pair_name: str,
+    candidate_return: Path,
+    labeled_parquet: Sequence[Path],
+    expected_driver_sha256: str,
+    expected_code_manifest_sha256: str,
+) -> tuple[str, dict[str, Any]]:
+    """Run exactly one authorized TPR/CEB pair after binding all replay code."""
+    spec = _FROZEN_PAIR_SPECS[pair_name]
+    driver_sha256, code_blob_manifest, code_manifest_sha256 = _bound_code_manifest(
+        expected_driver_sha256=expected_driver_sha256,
+        expected_code_manifest_sha256=expected_code_manifest_sha256,
+    )
+
+    registry = CandidateRegistry.load(candidate_return)
+    candidate = registry.get(spec.strategy_id)
+    corpus = load_labeled_parquet_files(labeled_parquet, consumer_intent="time_series")
+    if corpus.policy.venue != spec.venue:
+        raise ValueError(
+            f"labeled corpus venue {corpus.policy.venue!r} is not requested "
+            f"{spec.venue!r}"
+        )
+    source = source_from_labeled_corpus(
+        corpus,
+        exploration_start=spec.exploration_start,
+        exploration_end=spec.exploration_end,
+    )
+    contract = CryptoStageBRunContract(
+        candidate=candidate,
+        venue=spec.venue,
+        exploration_start=spec.exploration_start,
+        exploration_end=spec.exploration_end,
+        cost=VenueCostLiteral(venue=spec.venue, **_frozen_cost_fields(spec.venue)),
+    )
+    pair = run_candidate_pair(source=source, contract=contract)
+    record = {
+        "schema_version": "cr-s1-tpr-ceb-correction-replay-v1",
+        "replay_classification": {
+            "budget_literal": _BUDGET_LITERAL,
+            "trial_count": 0,
+            "correction_replay_count": 1,
+        },
+        "strategy_id": spec.strategy_id,
+        "venue": spec.venue,
+        "engine_revision": _git_revision(),
+        "driver": {
+            "path": _DRIVER_PATH.relative_to(_REPO_ROOT).as_posix(),
+            "blob_sha256": driver_sha256,
+            "git_blob_sha1": _git_blob_sha1(_DRIVER_PATH),
+        },
+        "engine_code_blobs": code_blob_manifest,
+        "engine_code_manifest_sha256": code_manifest_sha256,
+        "candidate_return": {
+            "path": str(candidate_return),
+            "sha256": _sha256_file(candidate_return),
+        },
+        "labeled_corpus": [
+            {"path": str(path), "sha256": _sha256_file(path)}
+            for path in labeled_parquet
+        ],
+        "terminal_events_input_count": 0,
+        "run_contract": contract.to_dict(),
+        "pair_record_stream_sha256": pair_record_stream_sha256(pair),
+        "pair": pair.to_dict(),
+        "harness_query": build_harness_report(pair).to_dict(),
+    }
+    return spec.output_filename, record
+
+
+def build_manifest(
+    *,
+    output_dir: Path,
+    expected_driver_sha256: str,
+    expected_code_manifest_sha256: str,
+) -> dict[str, Any]:
+    """Seal precisely the four authorized correction records, never ETR."""
+    driver_sha256, code_blob_manifest, code_manifest_sha256 = _bound_code_manifest(
+        expected_driver_sha256=expected_driver_sha256,
+        expected_code_manifest_sha256=expected_code_manifest_sha256,
+    )
+    records: list[dict[str, Any]] = []
+    for pair_name, spec in _FROZEN_PAIR_SPECS.items():
+        path = output_dir / spec.output_filename
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise ValueError(f"required replay record is absent: {path}") from exc
+        if (
+            payload.get("strategy_id") != spec.strategy_id
+            or payload.get("venue") != spec.venue
+        ):
+            raise ValueError(f"replay record does not match frozen pair: {path}")
+        if payload.get("driver", {}).get("blob_sha256") != driver_sha256:
+            raise ValueError(f"replay record has an unbound driver: {path}")
+        if payload.get("engine_code_manifest_sha256") != code_manifest_sha256:
+            raise ValueError(f"replay record has an unbound engine manifest: {path}")
+        if payload.get("replay_classification") != {
+            "budget_literal": _BUDGET_LITERAL,
+            "trial_count": 0,
+            "correction_replay_count": 1,
+        }:
+            raise ValueError(f"replay record has invalid correction accounting: {path}")
+        records.append(
+            {
+                "pair_name": pair_name,
+                "strategy_id": spec.strategy_id,
+                "venue": spec.venue,
+                "output_file": spec.output_filename,
+                "output_sha256": _sha256_file(path),
+                "pair_record_stream_sha256": payload["pair_record_stream_sha256"],
+                "contract_hash": payload["run_contract"]["contract_hash"],
+                "cost_round_trip_bp": payload["run_contract"]["cost_literal"].get(
+                    "round_trip_bp"
+                ),
+                "sensitivity_cost_round_trip_bp": payload["run_contract"][
+                    "cost_literal"
+                ].get("sensitivity_round_trip_bp"),
+            }
+        )
+    return {
+        "schema_version": "cr-s1-tpr-ceb-correction-manifest-v1",
+        "replay_classification": {
+            "budget_literal": _BUDGET_LITERAL,
+            "trial_count": 0,
+            "correction_replay_count": 4,
+        },
+        "scope": {
+            "authorized_pairs": [
+                "CR-SPOT-TPR-01 × upbit_krw",
+                "CR-SPOT-TPR-01 × binance_usdt_spot",
+                "CR-SPOT-CEB-01 × upbit_krw",
+                "CR-SPOT-CEB-01 × binance_usdt_spot",
+            ],
+            "etr_pairs_touched": 0,
+            "additional_pairs_or_venues": 0,
+            "holdout_reads": 0,
+            "orders": 0,
+            "account_mutations": 0,
+            "database_writes": 0,
+            "scheduler_registrations": 0,
+        },
+        "engine_revision": _git_revision(),
+        "driver": {
+            "path": _DRIVER_PATH.relative_to(_REPO_ROOT).as_posix(),
+            "blob_sha256": driver_sha256,
+            "git_blob_sha1": _git_blob_sha1(_DRIVER_PATH),
+        },
+        "engine_code_blobs": code_blob_manifest,
+        "engine_code_manifest_sha256": code_manifest_sha256,
+        "records": records,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--pair", choices=tuple(_FROZEN_PAIR_SPECS))
+    action.add_argument("--write-manifest", action="store_true")
+    parser.add_argument("--candidate-return", type=Path)
+    parser.add_argument("--labeled-parquet", type=Path, action="append")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--expected-driver-sha256", required=True)
+    parser.add_argument("--expected-code-manifest-sha256", required=True)
+    args = parser.parse_args(argv)
+
+    if args.write_manifest:
+        manifest = build_manifest(
+            output_dir=args.output_dir,
+            expected_driver_sha256=args.expected_driver_sha256,
+            expected_code_manifest_sha256=args.expected_code_manifest_sha256,
+        )
+        output_path = args.output_dir / "manifest.json"
+        output_sha256 = write_json_once(output_path, manifest)
+        print(
+            json.dumps(
+                {
+                    "output_path": str(output_path),
+                    "output_sha256": output_sha256,
+                    "driver_blob_sha256": manifest["driver"]["blob_sha256"],
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    if args.candidate_return is None or not args.labeled_parquet:
+        parser.error("--pair requires --candidate-return and --labeled-parquet")
+    output_filename, record = build_pair_record(
+        pair_name=args.pair,
+        candidate_return=args.candidate_return,
+        labeled_parquet=tuple(args.labeled_parquet),
+        expected_driver_sha256=args.expected_driver_sha256,
+        expected_code_manifest_sha256=args.expected_code_manifest_sha256,
+    )
+    output_path = args.output_dir / output_filename
+    output_sha256 = write_json_once(output_path, record)
+    print(
+        json.dumps(
+            {
+                "output_path": str(output_path),
+                "output_sha256": output_sha256,
+                "pair_record_stream_sha256": record["pair_record_stream_sha256"],
+                "driver_blob_sha256": record["driver"]["blob_sha256"],
+                "driver_git_blob_sha1": record["driver"]["git_blob_sha1"],
+                "engine_code_manifest_sha256": record["engine_code_manifest_sha256"],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Preserve TPR ablation's frozen third ranking key and CEB's frozen first/second ranking keys without changing admission or thresholds.
- Add discriminating alphabetic and third-key-substitution fixtures plus a hash-bound no-overwrite driver limited to the four authorized TPR/CEB pairs.
- Bind four correction replay artifacts to the committed driver/code manifest; ETR was not replayed or altered.

## Evidence
- ..................................................                       [100%]
50 passed in 0.88s — 50 passed
- All checks passed! — passed

This PR is a mechanical conformance correction only. It does not resynthesize B2, determine survivors/HTA/discard counts, or promote any candidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - TPR and CEB ablation evaluations now calculate ranking metrics from validated volume and range data.
  - Invalid or incomplete inputs are handled safely while preserving available signals.
  - Added a controlled replay workflow for four TPR/CEB strategy–venue pairs, with deterministic records and sealed manifests.
  - Replay outputs are written atomically and protected against accidental overwrites.

- **Tests**
  - Added coverage for ranking order, tie-breaking, missing data, replay scope, provenance, budgeting, and regression stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->