### PR TITLE
fix(research): resynthesize CR-S1 B2 correction artifacts

### DIFF
--- a/research/crypto_stage_b/resynthesis.py
+++ b/research/crypto_stage_b/resynthesis.py
@@ -30,6 +30,7 @@ __all__ = [
     "TopLevelResynthesis",
     "apply_inconclusive_predicate",
     "canonical_json_bytes",
+    "resynthesize_artifact_files",
     "resynthesize_artifact_directory",
     "resynthesize_pair_artifact",
     "sha256_file",
@@ -141,22 +142,21 @@ def resynthesize_pair_artifact(
     an empty arm cannot make an annual incremental comparison or contribute to
     the mandatory FRAGILE leave-one-best-year calculation.
     """
-    records = _required_sequence(
-        _required_mapping(artifact, "harness_query"), "records"
-    )
+    source = _normalize_source_artifact(artifact)
+    records = _required_sequence(_required_mapping(source, "harness_query"), "records")
     judgeable_years = sum(_is_judgeable_year(record) for record in records)
     all_arms_empty = _all_arms_empty(records)
-    fragile_evidence = _required_mapping(artifact, "fragile")
+    fragile_evidence = _required_mapping(source, "fragile")
     fragile = fragile_evidence.get("fragile")
     if not isinstance(fragile, bool):
         raise ArtifactSchemaError("fragile.fragile must be a bool")
 
-    source_verdict_base = _required_string(artifact, "verdict_base")
-    source_verdict_sensitivity = _required_string(artifact, "verdict_sensitivity")
+    source_verdict_base = _required_string(source, "verdict_base")
+    source_verdict_sensitivity = _required_string(source, "verdict_sensitivity")
     return TopLevelResynthesis(
-        strategy_id=_required_string(artifact, "strategy_id"),
-        venue=_required_string(artifact, "venue"),
-        contract_hash=_required_string(artifact, "contract_hash"),
+        strategy_id=_required_string(source, "strategy_id"),
+        venue=_required_string(source, "venue"),
+        contract_hash=_required_string(source, "contract_hash"),
         source_artifact_filename=source_artifact_filename,
         source_artifact_sha256=source_artifact_sha256,
         source_verdict_base=source_verdict_base,
@@ -175,6 +175,61 @@ def resynthesize_pair_artifact(
         fragile=fragile,
         fragile_evidence=fragile_evidence,
     )
+
+
+def resynthesize_artifact_files(
+    *,
+    pair_sources: Mapping[str, Path],
+    expected_pair_sha256: Mapping[str, str],
+    manifest_sources: Mapping[str, Path],
+    expected_manifest_sha256: Mapping[str, str],
+) -> dict[str, Any]:
+    """Resynthesize a SHA-bound set of pair records from separate directories.
+
+    A correction can supersede only some candidate × venue records while other
+    records remain in a separately sealed replay.  This helper binds each
+    exact source path before JSON parsing, so that composition never copies,
+    alters, or reruns any original arm artifact.
+    """
+    pair_hashes = _verify_source_files(pair_sources, expected_pair_sha256)
+    manifest_hashes = _verify_source_files(manifest_sources, expected_manifest_sha256)
+
+    pair_results = []
+    for label in sorted(pair_sources):
+        path = pair_sources[label]
+        try:
+            with path.open(encoding="utf-8") as handle:
+                artifact = json.load(handle)
+        except json.JSONDecodeError as exc:
+            raise ArtifactSchemaError(
+                f"source artifact is invalid JSON: {path}"
+            ) from exc
+        if not isinstance(artifact, Mapping):
+            raise ArtifactSchemaError(f"source artifact must be a JSON object: {path}")
+        pair_results.append(
+            resynthesize_pair_artifact(
+                artifact,
+                source_artifact_filename=path.name,
+                source_artifact_sha256=pair_hashes[label],
+            ).to_dict()
+        )
+
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "resynthesis_only": True,
+        "source_manifests": [
+            {
+                "label": label,
+                "filename": manifest_sources[label].name,
+                "sha256": manifest_hashes[label],
+            }
+            for label in sorted(manifest_sources)
+        ],
+        "source_artifact_sha256": {
+            label: pair_hashes[label] for label in sorted(pair_hashes)
+        },
+        "records": pair_results,
+    }
 
 
 def resynthesize_artifact_directory(
@@ -238,6 +293,212 @@ def resynthesize_artifact_directory(
         },
         "records": pair_results,
     }
+
+
+def _normalize_source_artifact(artifact: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the established B2 shape from a compact or replay record.
+
+    The original R2 artifacts already carry source verdict and FRAGILE fields
+    at top level.  The bounded B1/correction replay drivers deliberately
+    preserve only arm evidence, so their equivalent source label and FRAGILE
+    disclosure are mechanically reconstructed from the frozen pair summaries
+    and per-year harness records.  This does not call the engine or create a
+    new threshold.
+    """
+    if {
+        "verdict_base",
+        "verdict_sensitivity",
+        "fragile",
+        "harness_query",
+    }.issubset(artifact):
+        return artifact
+    if "pair" not in artifact:
+        raise ArtifactSchemaError(
+            "source artifact must be a compact B2 artifact or a bounded replay record"
+        )
+
+    pair = _required_mapping(artifact, "pair")
+    harness_query = _required_mapping(artifact, "harness_query")
+    strategy_id = _required_string(artifact, "strategy_id")
+    venue = _required_string(artifact, "venue")
+    contract_hash = _required_string(pair, "contract_hash")
+    _require_matching_pair_identity(
+        pair,
+        strategy_id=strategy_id,
+        venue=venue,
+        contract_hash=contract_hash,
+    )
+    _require_matching_harness_identity(
+        harness_query,
+        strategy_id=strategy_id,
+        venue=venue,
+        contract_hash=contract_hash,
+    )
+
+    full = _required_mapping(pair, "full")
+    ablation = _required_mapping(pair, "ablation")
+    return {
+        "strategy_id": strategy_id,
+        "venue": venue,
+        "contract_hash": contract_hash,
+        "verdict_base": _source_verdict(
+            _optional_finite_number(full, "net_mean_return"),
+            _optional_finite_number(ablation, "net_mean_return"),
+        ),
+        "verdict_sensitivity": _source_verdict(
+            _optional_finite_number(full, "sensitivity_net_mean_return"),
+            _optional_finite_number(ablation, "sensitivity_net_mean_return"),
+        ),
+        "fragile": _fragile_evidence_from_harness(
+            _required_sequence(harness_query, "records"),
+            full_net_mean_return=_optional_finite_number(full, "net_mean_return"),
+        ),
+        "harness_query": harness_query,
+    }
+
+
+def _require_matching_pair_identity(
+    pair: Mapping[str, Any],
+    *,
+    strategy_id: str,
+    venue: str,
+    contract_hash: str,
+) -> None:
+    if _required_string(pair, "strategy_id") != strategy_id:
+        raise ArtifactSchemaError("replay pair strategy_id does not match record")
+    if _required_string(pair, "venue") != venue:
+        raise ArtifactSchemaError("replay pair venue does not match record")
+    if _required_string(pair, "contract_hash") != contract_hash:
+        raise ArtifactSchemaError("replay pair contract_hash does not match record")
+
+
+def _require_matching_harness_identity(
+    harness_query: Mapping[str, Any],
+    *,
+    strategy_id: str,
+    venue: str,
+    contract_hash: str,
+) -> None:
+    if _required_string(harness_query, "strategy_id") != strategy_id:
+        raise ArtifactSchemaError("harness strategy_id does not match record")
+    if _required_string(harness_query, "venue") != venue:
+        raise ArtifactSchemaError("harness venue does not match record")
+    if _required_string(harness_query, "contract_hash") != contract_hash:
+        raise ArtifactSchemaError("harness contract_hash does not match record")
+
+
+def _source_verdict(
+    full_net_mean_return: float | None, ablation_net_mean_return: float | None
+) -> str:
+    """Reconstruct the frozen per-venue label from existing pair summaries."""
+    if full_net_mean_return is None or ablation_net_mean_return is None:
+        return "INCONCLUSIVE_EMPTY_ARM"
+    if full_net_mean_return <= 0.0:
+        return "FALSIFIED_NONPOSITIVE_NET_RETURN"
+    if full_net_mean_return - ablation_net_mean_return <= 0.0:
+        return "FALSIFIED_NO_INCREMENT_OVER_ABLATION"
+    return "PASS"
+
+
+def _fragile_evidence_from_harness(
+    records: Sequence[object], *, full_net_mean_return: float | None
+) -> dict[str, Any]:
+    """Reconstruct mandatory FRAGILE evidence from frozen annual full-arm rows."""
+    contributing_years: list[tuple[int, int, float]] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise ArtifactSchemaError("harness record must be an object")
+        full = _required_mapping(record, "full")
+        net_mean_return = _optional_finite_number(full, "net_mean_return")
+        resolved_exit_count = full.get("resolved_exit_count")
+        if net_mean_return is None:
+            continue
+        if (
+            not isinstance(resolved_exit_count, int)
+            or isinstance(resolved_exit_count, bool)
+            or resolved_exit_count <= 0
+        ):
+            raise ArtifactSchemaError(
+                "finite annual full net_mean_return requires positive resolved_exit_count"
+            )
+        calendar_year = full.get("calendar_year")
+        if not isinstance(calendar_year, int) or isinstance(calendar_year, bool):
+            raise ArtifactSchemaError("annual full calendar_year must be an int")
+        contributing_years.append((calendar_year, resolved_exit_count, net_mean_return))
+
+    if len(contributing_years) < 2 or full_net_mean_return is None:
+        return {
+            "state": "NOT_EVALUABLE",
+            "fragile": False,
+            "reason": "fewer than two contributing full-arm years",
+        }
+
+    total_count = sum(count for _, count, _ in contributing_years)
+    weighted_full_mean = (
+        sum(count * net_mean for _, count, net_mean in contributing_years) / total_count
+    )
+    if not math.isclose(
+        weighted_full_mean, full_net_mean_return, rel_tol=0.0, abs_tol=1e-12
+    ):
+        raise ArtifactSchemaError(
+            "annual full-arm rows do not reproduce pair full net_mean_return"
+        )
+    highest_year_net_mean_return = max(
+        net_mean for _, _, net_mean in contributing_years
+    )
+    highest_years = tuple(
+        year
+        for year, _, net_mean in contributing_years
+        if net_mean == highest_year_net_mean_return
+    )
+    remaining_net_mean_returns: dict[str, float] = {}
+    for highest_year in highest_years:
+        remaining = [
+            (count, net_mean)
+            for year, count, net_mean in contributing_years
+            if year != highest_year
+        ]
+        remaining_count = sum(count for count, _ in remaining)
+        if remaining_count == 0:
+            return {
+                "state": "NOT_EVALUABLE",
+                "fragile": False,
+                "reason": "no full-arm observations remain after highest year removal",
+            }
+        remaining_net_mean_returns[str(highest_year)] = (
+            sum(count * net_mean for count, net_mean in remaining) / remaining_count
+        )
+
+    return {
+        "state": "EVALUATED",
+        "fragile": full_net_mean_return > 0.0
+        and any(value <= 0.0 for value in remaining_net_mean_returns.values()),
+        "highest_year_net_mean_return": highest_year_net_mean_return,
+        "highest_years": list(highest_years),
+        "remaining_net_mean_returns": remaining_net_mean_returns,
+    }
+
+
+def _verify_source_files(
+    sources: Mapping[str, Path], expected_sha256: Mapping[str, str]
+) -> dict[str, str]:
+    if set(sources) != set(expected_sha256):
+        raise ArtifactSchemaError(
+            "source paths and expected SHA-256 table must have exactly the same labels"
+        )
+    hashes: dict[str, str] = {}
+    for label in sorted(sources):
+        path = sources[label]
+        if not path.is_file():
+            raise ArtifactSchemaError(f"required source artifact is missing: {path}")
+        actual_digest = sha256_file(path)
+        if actual_digest != expected_sha256[label]:
+            raise ArtifactSchemaError(
+                f"source SHA-256 mismatch for {label}: expected "
+                f"{expected_sha256[label]}, got {actual_digest}"
+            )
+        hashes[label] = actual_digest
+    return hashes
 
 
 def canonical_json_bytes(payload: object) -> bytes:
@@ -333,6 +594,15 @@ def _required_string(container: Mapping[str, Any], field: str) -> str:
     if not isinstance(value, str) or not value:
         raise ArtifactSchemaError(f"{field} must be a non-empty string")
     return value
+
+
+def _optional_finite_number(container: Mapping[str, Any], field: str) -> float | None:
+    value = container.get(field)
+    if value is None:
+        return None
+    if not _is_finite_number(value):
+        raise ArtifactSchemaError(f"{field} must be a finite number or null")
+    return float(value)
 
 
 def _is_finite_number(value: object) -> bool:

--- a/research/crypto_stage_b/tests/test_resynthesis.py
+++ b/research/crypto_stage_b/tests/test_resynthesis.py
@@ -9,6 +9,7 @@ from research.crypto_stage_b.resynthesis import (
     apply_inconclusive_predicate,
     canonical_json_bytes,
     resynthesize_artifact_directory,
+    resynthesize_artifact_files,
     resynthesize_pair_artifact,
     write_json_once,
 )
@@ -52,6 +53,76 @@ def _resynthesize(records: list[dict[str, object]], **kwargs: object):
         source_artifact_filename="pair.json",
         source_artifact_sha256="a" * 64,
     ).to_dict()
+
+
+def _replay_year(
+    year: int,
+    *,
+    full: float | None,
+    ablation: float | None,
+    full_count: int = 1,
+    ablation_count: int = 1,
+) -> dict[str, object]:
+    return {
+        "full": {
+            "calendar_year": year,
+            "net_mean_return": full,
+            "resolved_exit_count": full_count if full is not None else 0,
+        },
+        "ablation": {
+            "calendar_year": year,
+            "net_mean_return": ablation,
+            "resolved_exit_count": ablation_count if ablation is not None else 0,
+        },
+        "incremental": {
+            "full_net_mean_return": full,
+            "ablation_net_mean_return": ablation,
+            "full_minus_ablation_net_mean_return": (
+                None if full is None or ablation is None else full - ablation
+            ),
+        },
+    }
+
+
+def _replay_artifact(
+    records: list[dict[str, object]],
+    *,
+    full_net_mean_return: float,
+    ablation_net_mean_return: float,
+    full_sensitivity_net_mean_return: float | None = None,
+    ablation_sensitivity_net_mean_return: float | None = None,
+) -> dict[str, object]:
+    return {
+        "strategy_id": "CR-SPOT-TEST-01",
+        "venue": "upbit_krw",
+        "pair": {
+            "strategy_id": "CR-SPOT-TEST-01",
+            "venue": "upbit_krw",
+            "contract_hash": "frozen-contract-hash",
+            "full": {
+                "net_mean_return": full_net_mean_return,
+                "sensitivity_net_mean_return": (
+                    full_net_mean_return
+                    if full_sensitivity_net_mean_return is None
+                    else full_sensitivity_net_mean_return
+                ),
+            },
+            "ablation": {
+                "net_mean_return": ablation_net_mean_return,
+                "sensitivity_net_mean_return": (
+                    ablation_net_mean_return
+                    if ablation_sensitivity_net_mean_return is None
+                    else ablation_sensitivity_net_mean_return
+                ),
+            },
+        },
+        "harness_query": {
+            "strategy_id": "CR-SPOT-TEST-01",
+            "venue": "upbit_krw",
+            "contract_hash": "frozen-contract-hash",
+            "records": records,
+        },
+    }
 
 
 def test_one_contributing_year_is_inconclusive_not_a_new_sample_gate() -> None:
@@ -160,3 +231,112 @@ def test_writer_is_atomic_and_refuses_overwrite(tmp_path) -> None:
     assert digest == hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
     with pytest.raises(FileExistsError, match="refusing to overwrite"):
         write_json_once(target, payload)
+
+
+def test_replay_record_reconstructs_existing_verdict_and_fragile_evidence() -> None:
+    artifact = _replay_artifact(
+        [
+            _replay_year(2020, full=0.10, ablation=0.02),
+            _replay_year(2021, full=-0.01, ablation=0.02),
+        ],
+        full_net_mean_return=0.045,
+        ablation_net_mean_return=0.02,
+    )
+
+    result = resynthesize_pair_artifact(
+        artifact,
+        source_artifact_filename="replay.json",
+        source_artifact_sha256="b" * 64,
+    ).to_dict()
+
+    assert result["source_verdict_base"] == "PASS"
+    assert result["headline"] == {
+        "verdict_base": "PASS",
+        "verdict_sensitivity": "PASS",
+        "judgeable_years": 2,
+        "fragile": True,
+    }
+    assert result["fragile_evidence"] == {
+        "state": "EVALUATED",
+        "fragile": True,
+        "highest_year_net_mean_return": 0.10,
+        "highest_years": [2020],
+        "remaining_net_mean_returns": {"2020": -0.01},
+    }
+
+
+@pytest.mark.parametrize(
+    ("full", "ablation", "expected_verdict"),
+    [
+        (-0.01, -0.02, "FALSIFIED_NONPOSITIVE_NET_RETURN"),
+        (0.01, 0.02, "FALSIFIED_NO_INCREMENT_OVER_ABLATION"),
+    ],
+)
+def test_replay_record_reconstructs_frozen_falsification_precedence(
+    full: float, ablation: float, expected_verdict: str
+) -> None:
+    artifact = _replay_artifact(
+        [
+            _replay_year(2020, full=full, ablation=ablation),
+            _replay_year(2021, full=full, ablation=ablation),
+        ],
+        full_net_mean_return=full,
+        ablation_net_mean_return=ablation,
+    )
+
+    result = resynthesize_pair_artifact(
+        artifact,
+        source_artifact_filename="replay.json",
+        source_artifact_sha256="b" * 64,
+    ).to_dict()
+
+    assert result["source_verdict_base"] == expected_verdict
+    assert result["headline"]["verdict_base"] == expected_verdict
+
+
+def test_file_resynthesis_hash_binds_separate_pair_and_manifest_sources(
+    tmp_path,
+) -> None:
+    pair = tmp_path / "pair.json"
+    correction_manifest = tmp_path / "correction-manifest.json"
+    etr_manifest = tmp_path / "etr-manifest.json"
+    pair.write_bytes(
+        canonical_json_bytes(
+            _replay_artifact(
+                [
+                    _replay_year(2020, full=0.02, ablation=0.01),
+                    _replay_year(2021, full=0.04, ablation=0.01),
+                ],
+                full_net_mean_return=0.03,
+                ablation_net_mean_return=0.01,
+            )
+        )
+    )
+    correction_manifest.write_bytes(canonical_json_bytes({"kind": "correction"}))
+    etr_manifest.write_bytes(canonical_json_bytes({"kind": "etr"}))
+
+    payload = resynthesize_artifact_files(
+        pair_sources={"pair.json": pair},
+        expected_pair_sha256={
+            "pair.json": hashlib.sha256(pair.read_bytes()).hexdigest()
+        },
+        manifest_sources={
+            "correction_manifest": correction_manifest,
+            "etr_manifest": etr_manifest,
+        },
+        expected_manifest_sha256={
+            "correction_manifest": hashlib.sha256(
+                correction_manifest.read_bytes()
+            ).hexdigest(),
+            "etr_manifest": hashlib.sha256(etr_manifest.read_bytes()).hexdigest(),
+        },
+    )
+
+    assert payload["resynthesis_only"] is True
+    assert payload["source_artifact_sha256"] == {
+        "pair.json": hashlib.sha256(pair.read_bytes()).hexdigest()
+    }
+    assert [item["label"] for item in payload["source_manifests"]] == [
+        "correction_manifest",
+        "etr_manifest",
+    ]

--- a/research/crypto_stage_b/tests/test_resynthesize_cr_s1_b2_correction.py
+++ b/research/crypto_stage_b/tests/test_resynthesize_cr_s1_b2_correction.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from scripts import resynthesize_cr_s1_b2_correction as driver
+
+
+def test_resynthesis_driver_is_bounded_to_corrected_four_plus_etr_two() -> None:
+    assert set(driver._FROZEN_PAIR_SOURCES) == {  # noqa: SLF001 - frozen CLI scope
+        "cr-spot-tpr-01__upbit_krw.json",
+        "cr-spot-tpr-01__binance_usdt_spot.json",
+        "cr-spot-ceb-01__upbit_krw.json",
+        "cr-spot-ceb-01__binance_usdt_spot.json",
+        "cr-spot-etr-01__upbit_krw.json",
+        "cr-spot-etr-01__binance_usdt_spot.json",
+    }
+    assert set(driver._FROZEN_PAIR_SOURCES) == set(  # noqa: SLF001
+        driver._EXPECTED_PAIR_SHA256  # noqa: SLF001
+    )
+    assert set(driver._FROZEN_MANIFEST_SOURCES) == {  # noqa: SLF001
+        "tpr_ceb_correction_manifest.json",
+        "etr_b1_manifest.json",
+    }
+    assert set(driver._FROZEN_MANIFEST_SOURCES) == set(  # noqa: SLF001
+        driver._EXPECTED_MANIFEST_SHA256  # noqa: SLF001
+    )
+
+
+def test_resynthesis_driver_refuses_a_source_output_directory() -> None:
+    source_directory = next(
+        iter(driver._FROZEN_PAIR_SOURCES.values())  # noqa: SLF001
+    ).parent
+
+    try:
+        driver._refuse_source_output_directory(source_directory)  # noqa: SLF001
+    except ValueError as exc:
+        assert "outside every sealed source directory" in str(exc)
+    else:  # pragma: no cover - explicit failure reads more clearly than pytest.raises
+        raise AssertionError(
+            "source directory must be refused as an output destination"
+        )

--- a/scripts/resynthesize_cr_s1_b2_correction.py
+++ b/scripts/resynthesize_cr_s1_b2_correction.py
@@ -1,0 +1,131 @@
+"""Recompose CR-S1 B2 labels from the six sealed correction-era artifacts.
+
+This is an artifact-only operation.  It is deliberately bounded to the four
+TPR/CEB correction records and the two previously verified ETR records below;
+it neither loads a corpus nor invokes the Stage-B engine.  Every source byte
+is SHA-256 bound before parsing and publication is no-overwrite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from research.crypto_stage_b.resynthesis import (
+    resynthesize_artifact_files,
+    write_json_once,
+)
+
+_CORRECTION_OUTPUT_DIRECTORY = Path(
+    "/Users/mgh3326/work/herdr-inbox/jobs/"
+    "cr-s1-conform-tpr-ceb-20260806-1510/events/run-output"
+)
+_ETR_OUTPUT_DIRECTORY = Path(
+    "/Users/mgh3326/work/herdr-inbox/jobs/"
+    "cr-s1-b1-conformance-20260805-2332/events/run-output"
+)
+_DEFAULT_OUTPUT_FILENAME = "cr-s1-b2-top-level-resynthesis-correction.json"
+
+# These are the only six candidate × venue records permitted in this B2
+# composition.  No CLI option can add a pair, venue, or replacement artifact.
+_FROZEN_PAIR_SOURCES: dict[str, Path] = {
+    "cr-spot-tpr-01__upbit_krw.json": _CORRECTION_OUTPUT_DIRECTORY
+    / "cr-spot-tpr-01__upbit_krw.json",
+    "cr-spot-tpr-01__binance_usdt_spot.json": _CORRECTION_OUTPUT_DIRECTORY
+    / "cr-spot-tpr-01__binance_usdt_spot.json",
+    "cr-spot-ceb-01__upbit_krw.json": _CORRECTION_OUTPUT_DIRECTORY
+    / "cr-spot-ceb-01__upbit_krw.json",
+    "cr-spot-ceb-01__binance_usdt_spot.json": _CORRECTION_OUTPUT_DIRECTORY
+    / "cr-spot-ceb-01__binance_usdt_spot.json",
+    "cr-spot-etr-01__upbit_krw.json": _ETR_OUTPUT_DIRECTORY
+    / "cr-spot-etr-01__upbit_krw.json",
+    "cr-spot-etr-01__binance_usdt_spot.json": _ETR_OUTPUT_DIRECTORY
+    / "cr-spot-etr-01__binance_usdt_spot.json",
+}
+_EXPECTED_PAIR_SHA256 = {
+    "cr-spot-tpr-01__upbit_krw.json": (
+        "0b705ee6df65bceb20e4a2a8d755ef272c6cdd7d5fef9c8d31147ec455d25bc7"
+    ),
+    "cr-spot-tpr-01__binance_usdt_spot.json": (
+        "bcbc3538c224a23b8c0656c9527dd4eda990ad494e0bfc7f60751efab2f3aa1f"
+    ),
+    "cr-spot-ceb-01__upbit_krw.json": (
+        "a8397a8fe927029faa4cc3444d921def7ae5d8ae66e61c9eb26d723639b929f3"
+    ),
+    "cr-spot-ceb-01__binance_usdt_spot.json": (
+        "9cf299de9764471f022c6e50b5d5a1f30f100ab66a5e8880f7e15899f41cec51"
+    ),
+    "cr-spot-etr-01__upbit_krw.json": (
+        "dd9ee78db25ee803395cfb3cfbfa7f85ccdc997abd51aebb583f614cce825c39"
+    ),
+    "cr-spot-etr-01__binance_usdt_spot.json": (
+        "054ce0523889bce47cc62b88565833aa3dbb28632f9c256c8c63a8996b8bb6b3"
+    ),
+}
+_FROZEN_MANIFEST_SOURCES: dict[str, Path] = {
+    "tpr_ceb_correction_manifest.json": _CORRECTION_OUTPUT_DIRECTORY / "manifest.json",
+    "etr_b1_manifest.json": _ETR_OUTPUT_DIRECTORY / "manifest.json",
+}
+_EXPECTED_MANIFEST_SHA256 = {
+    "tpr_ceb_correction_manifest.json": (
+        "f48bd36513bdce5304e356848f973d48f9a443b441642285c7c7218ff0bc2f98"
+    ),
+    "etr_b1_manifest.json": (
+        "85ea79a2571f1c1ba039485d537748dafc7d96ae18fb9ba54155f3acfad4c24b"
+    ),
+}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--output-filename", default=_DEFAULT_OUTPUT_FILENAME)
+    args = parser.parse_args(argv)
+
+    output_directory = args.output_dir.resolve()
+    _refuse_source_output_directory(output_directory)
+    payload = resynthesize_artifact_files(
+        pair_sources=_FROZEN_PAIR_SOURCES,
+        expected_pair_sha256=_EXPECTED_PAIR_SHA256,
+        manifest_sources=_FROZEN_MANIFEST_SOURCES,
+        expected_manifest_sha256=_EXPECTED_MANIFEST_SHA256,
+    )
+    output_path = output_directory / args.output_filename
+    output_sha256 = write_json_once(output_path, payload)
+    print(
+        json.dumps(
+            {
+                "output_path": str(output_path),
+                "output_sha256": output_sha256,
+                "record_count": len(payload["records"]),
+                "resynthesis_only": payload["resynthesis_only"],
+                "source_manifest_sha256": {
+                    item["label"]: item["sha256"]
+                    for item in payload["source_manifests"]
+                },
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _refuse_source_output_directory(output_directory: Path) -> None:
+    for source_directory in {
+        path.parent.resolve()
+        for path in (*_FROZEN_PAIR_SOURCES.values(), *_FROZEN_MANIFEST_SOURCES.values())
+    }:
+        if output_directory == source_directory or output_directory.is_relative_to(
+            source_directory
+        ):
+            raise ValueError(
+                "output directory must be a new path outside every sealed source directory"
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- SHA-256-bind the four TPR/CEB correction records and two verified ETR records.
- Reconstruct existing per-venue labels and mandatory FRAGILE disclosure from sealed replay evidence, then apply the already-merged B2 predicate.
- Add a no-overwrite, fixed-six-source resynthesis driver and regression coverage.

## Evidence
- Artifact-only composition: no corpus load or Stage-B execution.
- Correction-era output SHA-256: f213572f47d0dcd43449b66cf288af3c85bb807b70cea4b449b14f25439c01a1.
- Top-level labels are unchanged versus PR 1801; DISCARDED_ALL_VENUES_COUNT = 0 and the §9 trigger is not met.

## Tests
- uv run pytest research/crypto_stage_b -v (56 passed)
- uv run ruff check research/crypto_stage_b scripts/resynthesize_cr_s1_b2_correction.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a resynthesis workflow that combines verified pair artifacts and manifests into consolidated provenance metadata.
  - Added a command-line tool for generating corrected CR-S1 B2 labels from approved source artifacts.
  - Outputs include synthesis status, record counts, and source hash metadata.

- **Bug Fixes**
  - Improved reconstruction of replay verdicts and fragile evidence.
  - Added safeguards for inconsistent identities, malformed data, invalid numeric values, missing files, and hash mismatches.
  - Prevented overwriting existing outputs or writing results into protected source directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->