### PR TITLE
feat(research): add D3 primary 16-run harness

### DIFF
--- a/research/kr_corpus/d3_engine/acceptance.py
+++ b/research/kr_corpus/d3_engine/acceptance.py
@@ -39,6 +39,10 @@ from research.kr_corpus.d3_engine.models import (
 )
 from research.kr_corpus.d3_engine.mutants import run_mutant_probes
 from research.kr_corpus.d3_engine.policies import C1Cycle
+from research.kr_corpus.d3_engine.primary import (
+    PrimaryHarnessPaths,
+    measure_primary_run_executed,
+)
 from research.kr_corpus.d3_engine.sources import (
     ContractDrift,
     FrozenKospiIndex,
@@ -519,7 +523,11 @@ def _prove_no_tick_python_import() -> dict[str, Any]:
     }
 
 
-def run_acceptance(paths: ArtifactPaths | None = None) -> dict[str, Any]:
+def run_acceptance(
+    paths: ArtifactPaths | None = None,
+    *,
+    primary_artifact_root: Path | None = None,
+) -> dict[str, Any]:
     paths = paths or ArtifactPaths.defaults()
     sha_gate = verify_start_gate(paths)
     golden_files = verify_golden_checksums(paths.golden_root)
@@ -597,8 +605,11 @@ def run_acceptance(paths: ArtifactPaths | None = None) -> dict[str, Any]:
     if not fib_window_excludes_t:
         raise AssertionError("Fibonacci window includes t or is not 120 sessions")
 
+    primary_measurement = measure_primary_run_executed(
+        primary_artifact_root or PrimaryHarnessPaths.defaults().output_root
+    )
     return {
-        "sha_gate": {"passed": len(sha_gate), "total": 9, "rows": sha_gate},
+        "sha_gate": {"passed": len(sha_gate), "total": 10, "rows": sha_gate},
         "golden_files": golden_files,
         "golden_exact": golden_first.as_dict(),
         "deterministic_2runs": deterministic,
@@ -635,7 +646,8 @@ def run_acceptance(paths: ArtifactPaths | None = None) -> dict[str, Any]:
         "fib_window_excludes_t": fib_window_excludes_t,
         "tick_source": tick_proof,
         "runtime_pins": pins,
-        "primary_run_executed": False,
+        "primary_run": primary_measurement,
+        "primary_run_executed": primary_measurement["primary_run_executed"],
     }
 
 
@@ -646,8 +658,13 @@ def main() -> int:
         action="store_true",
         help="emit complete canonical evidence instead of a compact summary",
     )
+    parser.add_argument(
+        "--primary-artifact-root",
+        type=Path,
+        help="completed D3 primary artifact root to measure (default: frozen job path)",
+    )
     args = parser.parse_args()
-    result = run_acceptance()
+    result = run_acceptance(primary_artifact_root=args.primary_artifact_root)
     if args.full_json:
         print(canonical_bytes(result).decode("utf-8"), end="")
     else:
@@ -658,7 +675,7 @@ def main() -> int:
         print(
             " ".join(
                 (
-                    f"SHA_GATE={result['sha_gate']['passed']}/9",
+                    f"SHA_GATE={result['sha_gate']['passed']}/10",
                     f"GOLDEN_EXACT={result['golden_exact']['passed']}/33",
                     f"DETERMINISTIC_2RUNS={result['deterministic_2runs']}",
                     f"MUTANT_DIFFS={result['mutant_diffs']['passed']}/23",

--- a/research/kr_corpus/d3_engine/constants.py
+++ b/research/kr_corpus/d3_engine/constants.py
@@ -34,6 +34,9 @@ CONTRACT_SHA256 = {
     "checksums.sha256": (
         "f03208c6f1e6ea360a743f261ea0698055493f3cf6800caeb98cd827313f89c0"
     ),
+    "d3-amendment-a1-20260807.md": (
+        "cb26fc5093b73d4bf7835424319ebebab3914001f888e181f34086a22e8f87d2"
+    ),
 }
 
 TICK_TABLE_SHA256 = CONTRACT_SHA256["krx_tick_table_frozen.yaml"]
@@ -85,6 +88,7 @@ class ArtifactPaths:
     tick_yaml: Path
     tick_python_provenance: Path
     golden_root: Path
+    amendment_a1: Path
 
     @classmethod
     def defaults(cls) -> ArtifactPaths:
@@ -100,6 +104,7 @@ class ArtifactPaths:
             tick_yaml=inputs / "krx_tick_table_frozen.yaml",
             tick_python_provenance=inputs / "krx_tick_size_frozen.py",
             golden_root=golden,
+            amendment_a1=inbox / "d3-amendment-a1-20260807.md",
         )
 
 

--- a/research/kr_corpus/d3_engine/costs.py
+++ b/research/kr_corpus/d3_engine/costs.py
@@ -1,0 +1,37 @@
+"""Single contract path for D3 neutral scalar transaction costs."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from research.kr_corpus.d3_engine.constants import FEE_RATE
+
+
+def fee_amount(gross: Decimal, fee_rate: Decimal = FEE_RATE) -> Decimal:
+    """Return the side-specific scalar fee for a non-negative gross amount."""
+
+    if not gross.is_finite() or gross < 0:
+        raise ValueError("gross must be finite and non-negative")
+    if not fee_rate.is_finite() or fee_rate < 0:
+        raise ValueError("fee_rate must be finite and non-negative")
+    return gross * fee_rate
+
+
+def cash_required(gross: Decimal, fee_rate: Decimal = FEE_RATE) -> Decimal:
+    """Return buy-side cash reserved/paid under the scalar convention."""
+
+    return gross + fee_amount(gross, fee_rate)
+
+
+def proceeds_after_fee(gross: Decimal, fee_rate: Decimal = FEE_RATE) -> Decimal:
+    """Return sell-side proceeds under the same scalar convention."""
+
+    return gross - fee_amount(gross, fee_rate)
+
+
+def round_trip_basis_points(fee_rate: Decimal = FEE_RATE) -> Decimal:
+    """Derive the symmetric round-trip scalar in basis points."""
+
+    if not fee_rate.is_finite() or fee_rate < 0:
+        raise ValueError("fee_rate must be finite and non-negative")
+    return fee_rate * Decimal(2) * Decimal(10000)

--- a/research/kr_corpus/d3_engine/engine.py
+++ b/research/kr_corpus/d3_engine/engine.py
@@ -299,7 +299,11 @@ class PortfolioEngine:
                     continue
                 index = history_index[(session, symbol)]
                 segment_start = contiguous_start[(session, symbol)]
-                history = histories[symbol][segment_start : index + 1]
+                history = self._signal_history(
+                    histories[symbol],
+                    index=index,
+                    segment_start=segment_start,
+                )
                 decision_index = len(history) - 1
                 signal = self._signal_for_session(history, decision_index)
                 if signal is None:
@@ -508,10 +512,10 @@ class PortfolioEngine:
                     continue
                 index = history_index[(session, symbol)]
                 segment_start = contiguous_start[(session, symbol)]
-                history = histories[symbol][segment_start : index + 1]
-                decision_index = len(history) - 1
-                if decision_index < 120:
+                if index - segment_start < 120:
                     continue
+                history = histories[symbol][index - 120 : index + 1]
+                decision_index = 120
                 new_sell_orders = self._resistance_orders(
                     symbol=symbol,
                     session=session,
@@ -782,6 +786,14 @@ class PortfolioEngine:
         if l2 is None:
             raise AssertionError("eligible signal has no qualifying L2")
         return rounded_rsi, l2.representative, window.high, window.low
+
+    @staticmethod
+    def _signal_history(
+        symbol_bars: list[Bar], *, index: int, segment_start: int
+    ) -> list[Bar]:
+        """Preserve the full contiguous Wilder history for the base engine."""
+
+        return symbol_bars[segment_start : index + 1]
 
     @staticmethod
     def _c2_session_allows(

--- a/research/kr_corpus/d3_engine/engine.py
+++ b/research/kr_corpus/d3_engine/engine.py
@@ -16,6 +16,11 @@ from research.kr_corpus.d3_engine.constants import (
     TICK_TABLE_SHA256,
     runtime_pins,
 )
+from research.kr_corpus.d3_engine.costs import (
+    cash_required,
+    fee_amount,
+    proceeds_after_fee,
+)
 from research.kr_corpus.d3_engine.guards import SealedAccessGuard
 from research.kr_corpus.d3_engine.indicators import (
     OhlcPoint,
@@ -340,6 +345,7 @@ class PortfolioEngine:
                             "reason": "not_arm_eligible_against_b0_demand",
                             "session": session,
                             "symbol": symbol,
+                            "side": OrderSide.BUY,
                         }
                     )
                     unserved_sessions.add(session)
@@ -361,6 +367,20 @@ class PortfolioEngine:
                             "reason": "c3_time_trim_armed",
                             "session": session,
                             "symbol": candidate.symbol,
+                            "side": OrderSide.BUY,
+                            "class": (
+                                OrderClass.ADD if candidate.is_add else OrderClass.NEW
+                            ),
+                            "rungs": [
+                                {"rung": rung, "limit": limit}
+                                for rung, limit in build_buy_rungs(
+                                    close=histories[candidate.symbol][
+                                        history_index[(session, candidate.symbol)] - 1
+                                    ].close,
+                                    l2_price=candidate_clusters[candidate.symbol],
+                                    tick_table=self._ticks,
+                                )
+                            ],
                         }
                     )
                     unserved_sessions.add(session)
@@ -378,6 +398,20 @@ class PortfolioEngine:
                             "reason": "c2_below_sma200_or_missing",
                             "session": session,
                             "symbol": candidate.symbol,
+                            "side": OrderSide.BUY,
+                            "class": (
+                                OrderClass.ADD if candidate.is_add else OrderClass.NEW
+                            ),
+                            "rungs": [
+                                {"rung": rung, "limit": limit}
+                                for rung, limit in build_buy_rungs(
+                                    close=histories[candidate.symbol][
+                                        history_index[(session, candidate.symbol)] - 1
+                                    ].close,
+                                    l2_price=candidate_clusters[candidate.symbol],
+                                    tick_table=self._ticks,
+                                )
+                            ],
                         }
                     )
                     unserved_sessions.add(session)
@@ -420,14 +454,23 @@ class PortfolioEngine:
                                     "reason": reason,
                                     "session": session,
                                     "symbol": candidate.symbol,
+                                    "side": OrderSide.BUY,
+                                    "class": order.order_class,
                                     "rung": rung,
+                                    "limit": order.limit,
+                                    "quantity": order.quantity,
+                                    "required_cash": cash_required(
+                                        order.gross_limit_notional,
+                                        run_input.config.fee_rate,
+                                    ),
                                 }
                             )
                             unserved_sessions.add(session)
                             unserved_notional += order.gross_limit_notional
                             continue
-                    reservation = order.gross_limit_notional * (
-                        Decimal(1) + run_input.config.fee_rate
+                    reservation = cash_required(
+                        order.gross_limit_notional,
+                        run_input.config.fee_rate,
                     )
                     if not cash.reserve_order(order.order_id, reservation):
                         if run_input.arm is Arm.C1:
@@ -441,7 +484,12 @@ class PortfolioEngine:
                                 "event": "cash_rejected",
                                 "session": session,
                                 "symbol": candidate.symbol,
+                                "side": OrderSide.BUY,
+                                "class": order.order_class,
                                 "rung": rung,
+                                "limit": order.limit,
+                                "quantity": order.quantity,
+                                "required_cash": reservation,
                             }
                         )
                         unserved_sessions.add(session)
@@ -485,7 +533,7 @@ class PortfolioEngine:
                     state.pending_orders.append(order)
                     continue
                 gross = fill_price * order.quantity
-                fee = gross * run_input.config.fee_rate
+                fee = fee_amount(gross, run_input.config.fee_rate)
                 cash.fill_buy(
                     order_id=order.order_id,
                     actual_amount=gross + fee,
@@ -537,7 +585,7 @@ class PortfolioEngine:
                 if quantity < 1:
                     continue
                 gross = fill_price * quantity
-                fee = gross * run_input.config.fee_rate
+                fee = fee_amount(gross, run_input.config.fee_rate)
                 cash.fill_sell(
                     net_amount=gross - fee,
                     trade_session_index=session_index,
@@ -688,7 +736,6 @@ class PortfolioEngine:
                 "order_issue_reserve",
                 "fill_buy_before_sell",
             ],
-            "primary_run_executed": False,
             "runtime_pins": runtime_pins(),
             **self._guard.spy.evidence(),
         }
@@ -844,7 +891,7 @@ class PortfolioEngine:
                 )
                 continue
             gross = bar.open * quantity
-            fee = gross * fee_rate
+            fee = fee_amount(gross, fee_rate)
             cash.fill_sell(net_amount=gross - fee, trade_session_index=session_index)
             position.apply_sell(quantity=quantity)
             mark_c3_trim_filled(position, stage=stage)
@@ -887,6 +934,11 @@ class PortfolioEngine:
                     "session": session,
                     "order_id": order.order_id,
                     "symbol": order.symbol,
+                    "side": order.side,
+                    "class": order.order_class,
+                    "rung": order.rung,
+                    "limit": order.limit,
+                    "quantity": order.quantity,
                 }
             )
         state.pending_orders.clear()
@@ -942,7 +994,9 @@ class PortfolioEngine:
             if close is None:
                 continue
             gross = close * position.quantity
-            positions_value += gross * (Decimal(1) - fee_rate) if terminal else gross
+            positions_value += (
+                proceeds_after_fee(gross, fee_rate) if terminal else gross
+            )
         nav_series.append(
             cash.orderable_cash + reserved_cash + receivable_cash + positions_value
         )

--- a/research/kr_corpus/d3_engine/golden.py
+++ b/research/kr_corpus/d3_engine/golden.py
@@ -16,7 +16,12 @@ from typing import Any
 
 from research.kr_corpus.d3_engine.canonical import fixed, plain
 from research.kr_corpus.d3_engine.cash import CashLedger
-from research.kr_corpus.d3_engine.constants import EXPLANATION_KEYS
+from research.kr_corpus.d3_engine.constants import EXPLANATION_KEYS, FEE_RATE
+from research.kr_corpus.d3_engine.costs import (
+    cash_required,
+    fee_amount,
+    round_trip_basis_points,
+)
 from research.kr_corpus.d3_engine.engine import PortfolioEngine
 from research.kr_corpus.d3_engine.indicators import (
     OhlcPoint,
@@ -751,7 +756,7 @@ def _v015(
     ledger = CashLedger(Decimal(data["settled_cash"]))
     rejected: list[dict[str, Any]] = []
     for item in data["b0_demand_orders_same_session"]:
-        required = Decimal(item["notional"]) * (Decimal(1) + Decimal(data["fee_rate"]))
+        required = cash_required(Decimal(item["notional"]), Decimal(data["fee_rate"]))
         if not ledger.reserve_order(f"golden-{item['symbol']}", required):
             rejected.append(item)
     return [
@@ -920,7 +925,7 @@ def _v023(
 ) -> list[dict[str, Any]]:
     entry = Decimal(data["long_1_share_entry"])
     bull_terminal = Decimal(data["bull_closes"][-1])
-    fee_rate = Decimal("0.00215")
+    fee_rate = FEE_RATE
     bear_rows: list[dict[str, Any]] = []
     position = Position(
         symbol="GOLDEN",
@@ -943,7 +948,7 @@ def _v023(
     return [
         {
             "name": "bull_virtual_exit",
-            "sell_fee_21_5bp": _normalized(bull_terminal * fee_rate),
+            "sell_fee_21_5bp": _normalized(fee_amount(bull_terminal, fee_rate)),
             "terminal_close": plain(bull_terminal),
             "virtual_exit_value": _normalized(
                 virtual_exit_value(
@@ -969,13 +974,13 @@ def _v024(
     open_price = Decimal(data["bar_open"])
     l2_limit = Decimal(data["L2_limit"])
     l1_gross = open_price * quantity
-    l1_fee = l1_gross * Decimal("0.00215")
+    l1_fee = fee_amount(l1_gross)
     ledger.fill_buy_immediate(
         amount=l1_gross + l1_fee,
         trade_session_index=0,
     )
     l2_gross = l2_limit * quantity
-    l2_fee = l2_gross * Decimal("0.00215")
+    l2_fee = fee_amount(l2_gross)
     cash_after_l1 = ledger.orderable_cash
     ledger.fill_buy_immediate(
         amount=l2_gross + l2_fee,
@@ -1061,12 +1066,12 @@ def _v028(
     data: dict[str, Any], _: TickTable, __: FrozenKospiIndex
 ) -> list[dict[str, Any]]:
     gross = Decimal(data["gross"])
-    fee = gross * Decimal("0.00215")
+    fee = fee_amount(gross)
     return [
         {
             "buy_fee": _normalized(fee),
             "name": "fees",
-            "round_trip_bp": "43",
+            "round_trip_bp": _normalized(round_trip_basis_points()),
             "sell_fee": _normalized(fee),
         }
     ]

--- a/research/kr_corpus/d3_engine/guards.py
+++ b/research/kr_corpus/d3_engine/guards.py
@@ -21,11 +21,37 @@ class SealedAccessSpy:
 
     sealed_reads: int = 0
     blocked_attempts: int = 0
+    path_checks: int = 0
+    date_checks: int = 0
+    metadata_key_checks: int = 0
+    actual_file_reads: int = 0
+    manifest_reads: int = 0
+    parquet_reads: int = 0
+    bar_rows_read: int = 0
+    metadata_key_reads: int = 0
+    sealed_file_reads: int = 0
+    sealed_manifest_reads: int = 0
+    sealed_parquet_reads: int = 0
+    sealed_bar_rows_read: int = 0
+    sealed_metadata_key_reads: int = 0
 
     def evidence(self) -> dict[str, int]:
         return {
             "sealed_access_spy": self.sealed_reads,
             "sealed_access_blocked_attempts": self.blocked_attempts,
+            "sealed_access_path_checks": self.path_checks,
+            "sealed_access_date_checks": self.date_checks,
+            "sealed_access_metadata_key_checks": self.metadata_key_checks,
+            "measured_file_reads": self.actual_file_reads,
+            "measured_manifest_reads": self.manifest_reads,
+            "measured_parquet_reads": self.parquet_reads,
+            "measured_bar_rows_read": self.bar_rows_read,
+            "measured_metadata_key_reads": self.metadata_key_reads,
+            "sealed_file_reads": self.sealed_file_reads,
+            "sealed_manifest_reads": self.sealed_manifest_reads,
+            "sealed_parquet_reads": self.sealed_parquet_reads,
+            "sealed_bar_rows_read": self.sealed_bar_rows_read,
+            "sealed_metadata_key_reads": self.sealed_metadata_key_reads,
         }
 
 
@@ -38,6 +64,7 @@ class SealedAccessGuard:
             "calibration",
             "d3_calibration_2025",
             "calibration_2025",
+            "prospective",
             "2025",
         }
     )
@@ -46,26 +73,31 @@ class SealedAccessGuard:
         self.spy = spy or SealedAccessSpy()
 
     def assert_exploration_date(self, value: date | datetime) -> None:
+        self.spy.date_checks += 1
         day = value.date() if isinstance(value, datetime) else value
         if day.year >= 2025:
             self.spy.blocked_attempts += 1
             raise SealedAccessBlocked(f"sealed date blocked before read: {day}")
 
     def assert_exploration_path(self, value: str | Path) -> None:
-        path = Path(value).expanduser()
+        self.spy.path_checks += 1
+        path = Path(value).expanduser().resolve(strict=False)
         tokens = {part.casefold() for part in path.parts}
         if tokens & self._SEALED_SEGMENTS or any(
-            "holdout" in token or "calibration" in token for token in tokens
+            "holdout" in token or "calibration" in token or "prospective" in token
+            for token in tokens
         ):
             self.spy.blocked_attempts += 1
             raise SealedAccessBlocked(f"sealed path blocked before read: {path.name}")
 
     def assert_metadata_key(self, key: str) -> None:
+        self.spy.metadata_key_checks += 1
         folded = key.casefold()
         if (
             folded in self._SEALED_SEGMENTS
             or "holdout" in folded
             or "calibration" in folded
+            or "prospective" in folded
             or "2025" in folded
         ):
             self.spy.blocked_attempts += 1
@@ -78,12 +110,73 @@ class SealedAccessGuard:
     ) -> T:
         self.assert_exploration_path(path)
         self.assert_exploration_date(session)
-        return loader()
+        result = loader()
+        self._record_actual_path_read(path, read_kind="bar")
+        self.spy.bar_rows_read += 1
+        return result
 
     def read_manifest(self, *, path: str | Path, loader: Callable[[], T]) -> T:
         self.assert_exploration_path(path)
-        return loader()
+        result = loader()
+        self._record_actual_path_read(path, read_kind="manifest")
+        self.spy.manifest_reads += 1
+        return result
+
+    def read_file(self, *, path: str | Path, loader: Callable[[], T]) -> T:
+        """Instrument one non-Parquet exploration file read."""
+
+        self.assert_exploration_path(path)
+        result = loader()
+        self._record_actual_path_read(path, read_kind="file")
+        return result
+
+    def read_parquet(self, *, path: str | Path, loader: Callable[[], T]) -> T:
+        """Instrument one Parquet parse after its path gate passes."""
+
+        self.assert_exploration_path(path)
+        result = loader()
+        self._record_actual_path_read(path, read_kind="parquet")
+        self.spy.parquet_reads += 1
+        return result
+
+    def record_bar_rows(self, sessions: list[date] | tuple[date, ...]) -> None:
+        """Measure rows already decoded by a gated exploration Parquet read."""
+
+        for session in sessions:
+            self.spy.date_checks += 1
+            if session.year >= 2025:
+                self.spy.sealed_reads += 1
+                self.spy.sealed_bar_rows_read += 1
+                raise SealedAccessBlocked(
+                    f"sealed bar date observed during measured read: {session}"
+                )
+        self.spy.bar_rows_read += len(sessions)
 
     def read_metadata(self, mapping: Mapping[str, T], key: str) -> T:
         self.assert_metadata_key(key)
-        return mapping[key]
+        result = mapping[key]
+        self.spy.metadata_key_reads += 1
+        return result
+
+    def _record_actual_path_read(self, value: str | Path, *, read_kind: str) -> None:
+        """Count the completed read, including a post-read symlink recheck."""
+
+        path = Path(value).expanduser().resolve(strict=False)
+        tokens = {part.casefold() for part in path.parts}
+        if tokens & self._SEALED_SEGMENTS or any(
+            "holdout" in token or "calibration" in token or "prospective" in token
+            for token in tokens
+        ):
+            self.spy.sealed_reads += 1
+            if read_kind == "manifest":
+                self.spy.sealed_manifest_reads += 1
+            elif read_kind == "parquet":
+                self.spy.sealed_parquet_reads += 1
+            elif read_kind == "bar":
+                self.spy.sealed_bar_rows_read += 1
+            else:
+                self.spy.sealed_file_reads += 1
+            raise SealedAccessBlocked(
+                f"sealed path resolved during measured read: {path.name}"
+            )
+        self.spy.actual_file_reads += 1

--- a/research/kr_corpus/d3_engine/metrics.py
+++ b/research/kr_corpus/d3_engine/metrics.py
@@ -6,6 +6,7 @@ from collections.abc import Hashable, Iterable, Mapping, Sequence
 from decimal import ROUND_CEILING, Decimal, localcontext
 
 from research.kr_corpus.d3_engine.constants import DECIMAL_PRECISION
+from research.kr_corpus.d3_engine.costs import proceeds_after_fee
 
 
 def locked_share_time_weighted_mean(daily_ratios: Sequence[Decimal]) -> Decimal:
@@ -58,9 +59,11 @@ def nearest_rank(values: Iterable[int], percentile: Decimal) -> int:
 def twr_returns(
     *, start_unit_price: Decimal, end_unit_price: Decimal, calendar_days: Decimal
 ) -> tuple[Decimal, Decimal]:
-    if min(start_unit_price, end_unit_price, calendar_days) <= 0:
-        raise ValueError("TWR arguments must be positive")
+    if start_unit_price <= 0 or end_unit_price < 0 or calendar_days <= 0:
+        raise ValueError("TWR start/days must be positive and end must be non-negative")
     cumulative = end_unit_price / start_unit_price - Decimal(1)
+    if end_unit_price == 0:
+        return cumulative, Decimal(-1)
     with localcontext() as context:
         context.prec = DECIMAL_PRECISION
         annualized = (end_unit_price / start_unit_price) ** (
@@ -92,4 +95,4 @@ def virtual_exit_value(
     *, quantity: int, close: Decimal, sell_fee_rate: Decimal
 ) -> Decimal:
     gross = close * quantity
-    return gross - gross * sell_fee_rate
+    return proceeds_after_fee(gross, sell_fee_rate)

--- a/research/kr_corpus/d3_engine/primary.py
+++ b/research/kr_corpus/d3_engine/primary.py
@@ -1,0 +1,1911 @@
+"""Deterministic 16-physical D3 primary exploration harness.
+
+This module adds only the corpus-to-E1-engine execution and artifact surface. It
+does not select a winner, compute Pareto dominance, run sensitivity variants, or
+touch broker/database/scheduler surfaces.
+"""
+
+from __future__ import annotations
+
+import csv
+import gc
+import hashlib
+import io
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from research.kr_corpus.d3_engine.canonical import canonical_bytes
+from research.kr_corpus.d3_engine.cash import CashLedger, Settlement
+from research.kr_corpus.d3_engine.constants import FEE_RATE, ArtifactPaths
+from research.kr_corpus.d3_engine.costs import cash_required
+from research.kr_corpus.d3_engine.engine import PortfolioEngine
+from research.kr_corpus.d3_engine.guards import SealedAccessGuard, SealedAccessSpy
+from research.kr_corpus.d3_engine.metrics import nearest_rank
+from research.kr_corpus.d3_engine.models import (
+    Arm,
+    CashflowView,
+    CorporateAction,
+    DataView,
+    EngineResult,
+    Fill,
+    OrderSide,
+    PortfolioRunInput,
+    RunState,
+)
+from research.kr_corpus.d3_engine.primary_corpus import (
+    CORPUS_BINDINGS,
+    LoadedCorpusView,
+    PrimaryCorpusLoader,
+    PrimaryCorpusPaths,
+    market_for,
+)
+from research.kr_corpus.d3_engine.sources import (
+    FrozenKospiIndex,
+    sha256_file,
+    verify_start_gate,
+)
+from research.kr_corpus.d3_engine.tick import TickTable, load_tick_table
+
+ENGINE_BASE_COMMIT = "10166c850bd9b1579619244bdbec35418091bb35"
+PRIMARY_SCHEMA_VERSION = "d3.primary_run.v1"
+ORDER_CHANGING_SCHEMA_VERSION = "d3.order_changing_clamped_rows.v1"
+FIDELITY_METHOD_CHECKSUMS_SHA256 = (
+    "16f86b089a163192588c41c637ce7b1d9ab57b6a1b9cd28b2ac6fb3bff249293"
+)
+DELIST_CHECKSUMS_SHA256 = (
+    "aa542c9ce90f303191b9812bc696d7d6a6594da6c7f5e9209085850726fb609c"
+)
+DELIST_AUDIT_SHA256 = "b6e4d508997aa37d7659f487657da5dd4b133011d5f2bea95e95a87152b2bcf9"
+STATE_PRIORITY_A1 = (
+    "RUN_INVALID",
+    "INCONCLUSIVE_DATA_BIAS",
+    "INCONCLUSIVE_UNRESOLVED_TERMINAL",
+    "CALIBRATION_DATA_BIAS",
+    "CALIBRATION_MISMATCH",
+    "verdict",
+)
+
+
+class PrimaryRunInvalid(RuntimeError):
+    code = "RUN_INVALID_PRIMARY_HARNESS"
+
+
+@dataclass(frozen=True, slots=True)
+class PrimaryHarnessPaths:
+    artifacts: ArtifactPaths
+    corpus: PrimaryCorpusPaths
+    delist_root: Path
+    fidelity_root: Path
+    output_root: Path
+    progress_report: Path
+
+    @classmethod
+    def defaults(cls) -> PrimaryHarnessPaths:
+        work = Path.home() / "work"
+        return cls(
+            artifacts=ArtifactPaths.defaults(),
+            corpus=PrimaryCorpusPaths.defaults(),
+            delist_root=work / "herdr-artifacts" / "kr-delist-events-v1",
+            fidelity_root=work / "herdr-artifacts" / "d3-fidelity-method-v1",
+            output_root=work / "herdr-artifacts" / "d3-primary-run-v1",
+            progress_report=(
+                work
+                / "herdr-inbox"
+                / "jobs"
+                / "d3-r1-primary-20260807-0850"
+                / "events"
+                / "impl.md"
+            ),
+        )
+
+
+@dataclass(slots=True)
+class _CapitalDays:
+    symbol: str
+    cycle_start_session: date
+    sessions_open: int = 0
+    invested_capital_days_krw: Decimal = Decimal(0)
+    underwater_capital_days_krw: Decimal = Decimal(0)
+    locked_capital_days_krw: Decimal = Decimal(0)
+    max_age_sessions: int = 0
+    last_session: date | None = None
+    terminal_quantity: int = 0
+    terminal_average_price: Decimal = Decimal(0)
+    terminal_cost_basis: Decimal = Decimal(0)
+
+
+@dataclass(slots=True)
+class PrimaryTrace:
+    signals: list[dict[str, object]] = field(default_factory=list)
+    daily: list[dict[str, object]] = field(default_factory=list)
+    capital_days: dict[tuple[str, int], _CapitalDays] = field(default_factory=dict)
+    engine_invocations: int = 0
+
+
+class PrimaryPortfolioEngine(PortfolioEngine):
+    """E1 execution core with a precomputed, exact-equivalent signal tape."""
+
+    def __init__(
+        self,
+        tick_table: TickTable,
+        *,
+        view: LoadedCorpusView,
+        all_clamp_rows: dict[tuple[date, str], object],
+        market_sessions: tuple[date, ...],
+    ) -> None:
+        super().__init__(tick_table, access_guard=SealedAccessGuard(SealedAccessSpy()))
+        self._view = view
+        self._all_clamp_rows = all_clamp_rows
+        self._session_positions = {
+            session: index for index, session in enumerate(market_sessions)
+        }
+        self._trace = PrimaryTrace()
+        self._capture = False
+        self._trace_units = Decimal(0)
+        self._trace_last_unit_price = Decimal(1)
+        self._trace_previous_contribution = Decimal(0)
+
+    def execute(
+        self,
+        run_input: PortfolioRunInput,
+        *,
+        b0_demand_pairs: frozenset[tuple[date, str]] | None = None,
+    ) -> tuple[EngineResult, PrimaryTrace]:
+        self._trace = PrimaryTrace()
+        self._capture = True
+        self._trace_units = run_input.config.initial_cash
+        self._trace_last_unit_price = Decimal(1)
+        self._trace_previous_contribution = Decimal(0)
+        try:
+            self._trace.engine_invocations += 1
+            result = super()._run(
+                run_input,
+                b0_demand_pairs=b0_demand_pairs,
+            )
+        finally:
+            self._capture = False
+        return result, self._trace
+
+    def _signal_for_session(
+        self, history: list[Any], decision_index: int
+    ) -> tuple[Decimal, Decimal, Decimal, Decimal] | None:
+        current = history[decision_index]
+        snapshot = self._view.signals.get((current.session, current.symbol))
+        if snapshot is None:
+            return None
+        if self._capture:
+            prior = history[max(0, decision_index - 120) : decision_index]
+            clamped_keys = [
+                (item.session, item.symbol)
+                for item in prior
+                if (item.session, item.symbol) in self._all_clamp_rows
+            ]
+            current_clamp = self._all_clamp_rows.get((current.session, current.symbol))
+            self._trace.signals.append(
+                {
+                    "session": current.session,
+                    "symbol": current.symbol,
+                    "market": current.market,
+                    "rsi": snapshot.rsi,
+                    "l2_price": snapshot.l2_price,
+                    "fib_high": snapshot.fib_high,
+                    "fib_low": snapshot.fib_low,
+                    "previous_close": snapshot.previous_close,
+                    "indicator_window_start": prior[0].session,
+                    "indicator_window_end": prior[-1].session,
+                    "indicator_window_clamped_rows": len(clamped_keys),
+                    "indicator_window_clamped_key_sha256": _key_list_sha(clamped_keys),
+                    "current_bar_clamped": current_clamp is not None,
+                }
+            )
+        return (
+            snapshot.rsi,
+            snapshot.l2_price,
+            snapshot.fib_high,
+            snapshot.fib_low,
+        )
+
+    def _finish_day(
+        self,
+        *,
+        state: RunState,
+        cash: Any,
+        by_session: dict[tuple[date, str], Any],
+        session: date,
+        cumulative_contribution: Decimal,
+        cumulative_contribution_series: list[Decimal],
+        daily_invested: list[Decimal],
+        daily_locked_ratios: list[Decimal],
+        nav_series: list[Decimal],
+        last_closes: dict[str, Decimal],
+        fee_rate: Decimal,
+        terminal: bool,
+    ) -> None:
+        PortfolioEngine._finish_day(
+            state=state,
+            cash=cash,
+            by_session=by_session,
+            session=session,
+            cumulative_contribution=cumulative_contribution,
+            cumulative_contribution_series=cumulative_contribution_series,
+            daily_invested=daily_invested,
+            daily_locked_ratios=daily_locked_ratios,
+            nav_series=nav_series,
+            last_closes=last_closes,
+            fee_rate=fee_rate,
+            terminal=terminal,
+        )
+        if not self._capture:
+            return
+        contribution = cumulative_contribution - self._trace_previous_contribution
+        if contribution:
+            self._trace_units += contribution / self._trace_last_unit_price
+        nav = nav_series[-1]
+        unit_price = nav / self._trace_units
+        reserved = sum(cash.reserved_orders.values(), Decimal(0))
+        payables = sum((item.amount for item in cash.payables), Decimal(0))
+        receivables = sum((item.amount for item in cash.receivables), Decimal(0))
+        position_market_value = Decimal(0)
+        open_positions = 0
+        session_index = self._session_positions[session]
+        for symbol, position in sorted(state.positions.items()):
+            if position.quantity < 1:
+                continue
+            open_positions += 1
+            close = (
+                by_session[(session, symbol)].close
+                if (session, symbol) in by_session
+                else last_closes[symbol]
+            )
+            position_market_value += close * position.quantity
+            first_index = position.cycle_first_fill_index
+            if first_index is None:
+                raise AssertionError("open position lacks cycle first fill")
+            key = (symbol, first_index)
+            capital = self._trace.capital_days.get(key)
+            if capital is None:
+                capital = _CapitalDays(
+                    symbol=symbol,
+                    cycle_start_session=next(
+                        day
+                        for day, index in self._session_positions.items()
+                        if index == first_index
+                    ),
+                )
+                self._trace.capital_days[key] = capital
+            age = session_index - first_index + 1
+            cost = position.invested_cost_basis
+            capital.sessions_open += 1
+            capital.invested_capital_days_krw += cost
+            if close < position.average_price:
+                capital.underwater_capital_days_krw += cost
+            if position.underwater_streak >= 180:
+                capital.locked_capital_days_krw += cost
+            capital.max_age_sessions = max(capital.max_age_sessions, age)
+            capital.last_session = session
+            capital.terminal_quantity = position.quantity if terminal else 0
+            capital.terminal_average_price = (
+                position.average_price if terminal else Decimal(0)
+            )
+            capital.terminal_cost_basis = cost if terminal else Decimal(0)
+        self._trace.daily.append(
+            {
+                "session": session,
+                "nav": nav,
+                "unit_price": unit_price,
+                "units": self._trace_units,
+                "contribution": contribution,
+                "cumulative_contribution": cumulative_contribution,
+                "invested_cost_basis": daily_invested[-1],
+                "locked_share": daily_locked_ratios[-1],
+                "position_market_value": position_market_value,
+                "open_positions": open_positions,
+                "settled_orderable_cash": cash.orderable_cash,
+                "settled_reserved_order_cash": reserved,
+                "settled_cash_total": cash.orderable_cash + reserved,
+                "unsettled_buy_payables": payables,
+                "unsettled_sell_receivables": receivables,
+                "session_index": session_index,
+                "reserved_orders": [
+                    {"order_id": order_id, "amount": amount}
+                    for order_id, amount in sorted(cash.reserved_orders.items())
+                ],
+                "buy_payables": [
+                    {
+                        "trade_session_index": item.trade_session_index,
+                        "settle_session_index": item.settle_session_index,
+                        "amount": item.amount,
+                        "kind": item.kind,
+                    }
+                    for item in cash.payables
+                ],
+                "sell_receivables": [
+                    {
+                        "trade_session_index": item.trade_session_index,
+                        "settle_session_index": item.settle_session_index,
+                        "amount": item.amount,
+                        "kind": item.kind,
+                    }
+                    for item in cash.receivables
+                ],
+            }
+        )
+        self._trace_last_unit_price = unit_price
+        self._trace_previous_contribution = cumulative_contribution
+
+
+@dataclass(frozen=True, slots=True)
+class PhysicalRun:
+    arm: Arm
+    cashflow_view: CashflowView
+    data_view: DataView
+
+    @property
+    def run_id(self) -> str:
+        return "__".join(
+            (self.arm.value, self.cashflow_view.value, self.data_view.value)
+        )
+
+
+def primary_matrix() -> tuple[PhysicalRun, ...]:
+    return tuple(
+        PhysicalRun(arm, cashflow, view)
+        for view in (DataView.ORIGINAL_VALID_BAR, DataView.CLAMP_ADMIT_V1)
+        for cashflow in (
+            CashflowView.WITH_CONTRIBUTION,
+            CashflowView.NO_CONTRIBUTION,
+        )
+        for arm in Arm
+    )
+
+
+class PrimaryRunHarness:
+    def __init__(
+        self,
+        *,
+        harness_commit: str,
+        paths: PrimaryHarnessPaths | None = None,
+    ) -> None:
+        if len(harness_commit) != 40:
+            raise ValueError("harness_commit must be a full Git SHA")
+        self.harness_commit = harness_commit
+        self.paths = paths or PrimaryHarnessPaths.defaults()
+        self._sha_gate: tuple[dict[str, str], ...] = ()
+        self._stamps: dict[str, object] = {}
+
+    def run_all(self) -> dict[str, object]:
+        self._preflight()
+        tick_table = load_tick_table(self.paths.artifacts.tick_yaml)
+        index = FrozenKospiIndex.load(self.paths.artifacts.index_csv)
+        market_sessions = tuple(row.session for row in index.rows)
+        index_closes = tuple((row.session, row.close) for row in index.rows)
+        corporate_actions, delist_evidence = _load_delist_actions(
+            self.paths.delist_root,
+            market_sessions=market_sessions,
+        )
+
+        loader_guard = SealedAccessGuard(SealedAccessSpy())
+        loader = PrimaryCorpusLoader(paths=self.paths.corpus, guard=loader_guard)
+        clamp = loader.load(
+            DataView.CLAMP_ADMIT_V1,
+            market_sessions=market_sessions,
+        )
+        original = loader.load(
+            DataView.ORIGINAL_VALID_BAR,
+            market_sessions=market_sessions,
+        )
+        views = {
+            DataView.ORIGINAL_VALID_BAR: original,
+            DataView.CLAMP_ADMIT_V1: clamp,
+        }
+        access_evidence = loader_guard.spy.evidence()
+        if access_evidence["sealed_access_spy"] != 0:
+            raise PrimaryRunInvalid("sealed corpus read measured during primary load")
+        if access_evidence["sealed_access_blocked_attempts"] != 0:
+            raise PrimaryRunInvalid("primary loader attempted a sealed access")
+
+        self._stamps = self._build_stamps(
+            original=original,
+            clamp=clamp,
+            delist_evidence=delist_evidence,
+            access_evidence=access_evidence,
+        )
+        self.paths.output_root.mkdir(parents=True, exist_ok=True)
+        (self.paths.output_root / "runs").mkdir(exist_ok=True)
+        self._append_progress(
+            "\nLOADER = PASS · "
+            f"original rows={original.row_count} files={original.parquet_files} · "
+            f"clamp rows={clamp.row_count} files={clamp.parquet_files} · "
+            f"SEALED_ACCESS_MEASURED={access_evidence['sealed_access_spy']}\n"
+        )
+
+        completed: list[dict[str, object]] = []
+        b0_demand: dict[
+            tuple[CashflowView, DataView, int], frozenset[tuple[date, str]]
+        ] = {}
+        for physical in primary_matrix():
+            target = self.paths.output_root / "runs" / physical.run_id
+            if target.exists():
+                existing = _read_completed_run(target, physical)
+                completed.append(existing)
+                if physical.arm is Arm.B0:
+                    for attempt in (1, 2):
+                        b0_demand[
+                            (physical.cashflow_view, physical.data_view, attempt)
+                        ] = _demand_from_orders_file(target / "evidence.json")
+                continue
+            first, first_demand = self._execute_attempt(
+                physical,
+                view=views[physical.data_view],
+                all_clamp_rows=clamp.clamp_rows,
+                tick_table=tick_table,
+                market_sessions=market_sessions,
+                index_closes=index_closes,
+                corporate_actions=corporate_actions,
+                b0_demand_pairs=(
+                    None
+                    if physical.arm is Arm.B0
+                    else b0_demand[(physical.cashflow_view, physical.data_view, 1)]
+                ),
+            )
+            second, second_demand = self._execute_attempt(
+                physical,
+                view=views[physical.data_view],
+                all_clamp_rows=clamp.clamp_rows,
+                tick_table=tick_table,
+                market_sessions=market_sessions,
+                index_closes=index_closes,
+                corporate_actions=corporate_actions,
+                b0_demand_pairs=(
+                    None
+                    if physical.arm is Arm.B0
+                    else b0_demand[(physical.cashflow_view, physical.data_view, 2)]
+                ),
+            )
+            if first != second:
+                raise PrimaryRunInvalid(
+                    f"non-deterministic physical run:{physical.run_id}"
+                )
+            if first_demand != second_demand:
+                raise PrimaryRunInvalid(
+                    f"non-deterministic B0 demand:{physical.run_id}"
+                )
+            finalized = _seal_determinism(
+                physical=physical,
+                first=first,
+                second=second,
+                stamps=self._stamps,
+            )
+            _publish_bundle(target, finalized)
+            run_json_sha = hashlib.sha256(finalized["run.json"]).hexdigest()
+            row = {
+                "run_id": physical.run_id,
+                "arm": physical.arm.value,
+                "cashflow_view": physical.cashflow_view.value,
+                "data_view": physical.data_view.value,
+                "deterministic_2runs": True,
+                "run_json_sha256": run_json_sha,
+                "bundle_sha256": _bundle_sha(finalized),
+            }
+            completed.append(row)
+            if physical.arm is Arm.B0:
+                b0_demand[(physical.cashflow_view, physical.data_view, 1)] = (
+                    first_demand
+                )
+                b0_demand[(physical.cashflow_view, physical.data_view, 2)] = (
+                    second_demand
+                )
+            self._append_progress(
+                f"\nRUN_COMPLETE {len(completed):02d}/16 = {physical.run_id} · "
+                f"2RUN_BYTE_IDENTICAL=PASS · bundle_sha256={row['bundle_sha256']}\n"
+            )
+            gc.collect()
+
+        completed.sort(key=lambda row: str(row["run_id"]))
+        clamped_pair_exposure = _build_clamped_pair_exposure(
+            output_root=self.paths.output_root,
+            completed=completed,
+            stamps=self._stamps,
+        )
+        pairing = _build_order_changing_rows(
+            output_root=self.paths.output_root,
+            completed=completed,
+            stamps=self._stamps,
+        )
+        sealed_payload = {
+            "schema_version": PRIMARY_SCHEMA_VERSION,
+            "stamps": self._stamps,
+            "measurement": {
+                **access_evidence,
+                "measurement_scope": "PrimaryCorpusLoader actual file/parquet/bar/key reads",
+                "sealed_access_measured": access_evidence["sealed_access_spy"],
+                "blocked_attempts_during_primary": access_evidence[
+                    "sealed_access_blocked_attempts"
+                ],
+            },
+        }
+        _write_bytes(
+            self.paths.output_root / "sealed-access.json",
+            canonical_bytes(sealed_payload),
+        )
+        manifest = {
+            "schema_version": PRIMARY_SCHEMA_VERSION,
+            "stamps": self._stamps,
+            "matrix": {
+                "physical_runs": len(completed),
+                "expected_physical_runs": 16,
+                "deterministic_2runs": sum(
+                    bool(row["deterministic_2runs"]) for row in completed
+                ),
+                "runs": completed,
+            },
+            "dual_view_pairing": pairing["pairing"],
+            "order_changing_clamped_rows": pairing["summary"],
+            "clamped_pair_exposure": clamped_pair_exposure,
+            "sealed_access_path": "sealed-access.json",
+            "winner_selected": False,
+            "pareto_computed": False,
+            "sensitivity_runs": 0,
+        }
+        _write_bytes(
+            self.paths.output_root / "manifest.json", canonical_bytes(manifest)
+        )
+        measured = measure_primary_run_executed(self.paths.output_root)
+        if not measured["primary_run_executed"]:
+            raise PrimaryRunInvalid(f"primary measurement failed:{measured}")
+        self._append_progress(
+            "\nRUNS = 16/16 physical · DETERMINISTIC_2RUNS = 16/16 PASS · "
+            "DUAL_VIEW_PAIRED = 8/8 · WINNER_SELECTED = NO\n"
+        )
+        return manifest
+
+    def _preflight(self) -> None:
+        self._sha_gate = verify_start_gate(self.paths.artifacts)
+        if len(self._sha_gate) != 10:
+            raise PrimaryRunInvalid(f"SHA gate count drift:{len(self._sha_gate)}")
+        if sha256_file(self.paths.fidelity_root / "checksums.sha256") != (
+            FIDELITY_METHOD_CHECKSUMS_SHA256
+        ):
+            raise PrimaryRunInvalid("fidelity method checksum drift")
+        self.paths.progress_report.parent.mkdir(parents=True, exist_ok=True)
+
+    def _build_stamps(
+        self,
+        *,
+        original: LoadedCorpusView,
+        clamp: LoadedCorpusView,
+        delist_evidence: dict[str, object],
+        access_evidence: dict[str, int],
+    ) -> dict[str, object]:
+        return {
+            "input_sha256": {str(row["file"]): row["sha256"] for row in self._sha_gate},
+            "engine_commit": ENGINE_BASE_COMMIT,
+            "harness_commit": self.harness_commit,
+            "corpus": {
+                **CORPUS_BINDINGS,
+                "original_rows": original.row_count,
+                "derived_rows": clamp.row_count,
+                "original_signal_tape_sha256": original.signal_tape_sha256,
+                "derived_signal_tape_sha256": clamp.signal_tape_sha256,
+            },
+            "delist_sidecar": delist_evidence,
+            "fidelity_method_checksums_sha256": (FIDELITY_METHOD_CHECKSUMS_SHA256),
+            "state_priority_a1": STATE_PRIORITY_A1,
+            "sealed_access_at_load_complete": access_evidence,
+            "execution_conventions": {
+                "fee": "43bp neutral: 21.5bp/side",
+                "cashflow": "3500000 KRW or none",
+                "settlement": "T+2",
+                "same_bar": "buy-first same symbol",
+                "sensitivity": False,
+            },
+        }
+
+    def _execute_attempt(
+        self,
+        physical: PhysicalRun,
+        *,
+        view: LoadedCorpusView,
+        all_clamp_rows: dict[tuple[date, str], object],
+        tick_table: TickTable,
+        market_sessions: tuple[date, ...],
+        index_closes: tuple[tuple[date, Decimal], ...],
+        corporate_actions: tuple[CorporateAction, ...],
+        b0_demand_pairs: frozenset[tuple[date, str]] | None,
+    ) -> tuple[dict[str, bytes], frozenset[tuple[date, str]]]:
+        engine = PrimaryPortfolioEngine(
+            tick_table,
+            view=view,
+            all_clamp_rows=all_clamp_rows,
+            market_sessions=market_sessions,
+        )
+        result, trace = engine.execute(
+            PortfolioRunInput(
+                arm=physical.arm,
+                cashflow_view=physical.cashflow_view,
+                bars=view.bars,  # type: ignore[arg-type]
+                data_view=physical.data_view,
+                market_sessions=market_sessions,
+                index_closes=index_closes,
+                corporate_actions=corporate_actions,
+                decision_start=date(2015, 1, 1),
+            ),
+            b0_demand_pairs=b0_demand_pairs,
+        )
+        bundle = _artifact_bundle(
+            physical=physical,
+            result=result,
+            trace=trace,
+            view=view,
+            all_clamp_rows=all_clamp_rows,
+            stamps=self._stamps,
+        )
+        demand = frozenset(
+            (row["session"], str(row["symbol"]))
+            for row in result.evidence["counterfactual_demand_pairs"]
+        )
+        return bundle, demand
+
+    def _append_progress(self, text: str) -> None:
+        with self.paths.progress_report.open("a", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+
+
+def _artifact_bundle(
+    *,
+    physical: PhysicalRun,
+    result: EngineResult,
+    trace: PrimaryTrace,
+    view: LoadedCorpusView,
+    all_clamp_rows: dict[tuple[date, str], object],
+    stamps: dict[str, object],
+) -> dict[str, bytes]:
+    signal_rows = sorted(trace.signals, key=lambda row: (row["session"], row["symbol"]))
+    signal_index = {(row["session"], row["symbol"]): row for row in signal_rows}
+    events = list(result.events)
+    submitted = [row for row in events if row["event"] == "order_submitted"]
+    policy_rejects = [row for row in events if row["event"] == "policy_rejected"]
+    cash_rejects = [row for row in events if row["event"] == "cash_rejected"]
+    skip_rows = [
+        row
+        for row in events
+        if row["event"]
+        in {"order_expired", "policy_rejected", "cash_rejected", "c3_time_trim_skipped"}
+    ]
+    fills = _fill_rows(result.fills, submitted)
+    orders = _order_rows(
+        submitted=submitted,
+        fills=fills,
+        skips=skip_rows,
+        signal_index=signal_index,
+        view=view,
+        all_clamp_rows=all_clamp_rows,
+    )
+    order_by_id = {
+        str(order["order_id"]): order
+        for order in orders
+        if order["order_id"] is not None
+    }
+    fill_exposure = []
+    for fill in fills:
+        order = order_by_id.get(str(fill["order_id"]))
+        if order is None:
+            raise PrimaryRunInvalid(f"fill lacks order projection:{fill['order_id']}")
+        if not (
+            order["current_bar_clamped"]
+            or int(order["indicator_window_clamped_rows"]) > 0
+        ):
+            continue
+        fill_exposure.append(
+            {
+                "exposure_type": "fill",
+                **fill,
+                "market": order["market"],
+                "current_bar_clamped": order["current_bar_clamped"],
+                "indicator_window_clamped_rows": order["indicator_window_clamped_rows"],
+                "indicator_window_clamped_key_sha256": order[
+                    "indicator_window_clamped_key_sha256"
+                ],
+            }
+        )
+    clamped_exposure = (
+        [
+            {"exposure_type": "signal", **signal}
+            for signal in signal_rows
+            if signal["current_bar_clamped"]
+            or int(signal["indicator_window_clamped_rows"]) > 0
+        ]
+        + [
+            {"exposure_type": "order", **order}
+            for order in orders
+            if order["current_bar_clamped"]
+            or int(order["indicator_window_clamped_rows"]) > 0
+        ]
+        + fill_exposure
+    )
+    capital_days = [
+        {
+            "symbol": value.symbol,
+            "cycle_start_session": value.cycle_start_session,
+            "last_session": value.last_session,
+            "sessions_open": value.sessions_open,
+            "max_age_sessions": value.max_age_sessions,
+            "invested_capital_days_krw": value.invested_capital_days_krw,
+            "underwater_capital_days_krw": (value.underwater_capital_days_krw),
+            "locked_capital_days_krw": value.locked_capital_days_krw,
+            "terminal_quantity": value.terminal_quantity,
+            "terminal_average_price": value.terminal_average_price,
+            "terminal_cost_basis": value.terminal_cost_basis,
+        }
+        for _, value in sorted(trace.capital_days.items())
+    ]
+    terminal_daily = trace.daily[-1]
+    open_lots = [
+        {
+            **row,
+            "terminal_session": terminal_daily["session"],
+            "market": market_for(
+                view,
+                symbol=str(row["symbol"]),
+                session=terminal_daily["session"],
+            ),
+        }
+        for row in result.terminal_positions
+    ]
+    funding = _funding_p05(trace.daily, events)
+    policy_sessions = sorted({row["session"] for row in policy_rejects})
+    cash_sessions = sorted({row["session"] for row in cash_rejects})
+    metrics = {
+        **result.metrics,
+        "funding_p05_days": funding["p05_days"],
+        "funding_complete_anchor_count": funding["complete_anchor_count"],
+        "funding_right_censored_anchor_count": funding["right_censored_anchor_count"],
+        "policy_rejected_sessions": len(policy_sessions),
+        "cash_rejected_sessions": len(cash_sessions),
+        "unserved_policy_or_cash_sessions": len(
+            set(policy_sessions) | set(cash_sessions)
+        ),
+        "clamped_signal_rows": sum(
+            row["exposure_type"] == "signal" for row in clamped_exposure
+        ),
+        "clamped_order_rows": sum(
+            row["exposure_type"] == "order" for row in clamped_exposure
+        ),
+        "clamped_fill_rows": len(fill_exposure),
+        "clamped_fill_gross_notional": sum(
+            (Decimal(str(row["gross"])) for row in fill_exposure), Decimal(0)
+        ),
+        "clamped_realized_pnl": sum(
+            (
+                Decimal(str(row["realized_pnl"]))
+                for row in fill_exposure
+                if row["realized_pnl"] is not None
+            ),
+            Decimal(0),
+        ),
+        "clamped_view_terminal_nav": result.metrics["terminal_nav"],
+    }
+    evidence = {
+        **result.evidence,
+        "engine_execution": {
+            "class": "PrimaryPortfolioEngine",
+            "base_core": "PortfolioEngine._run",
+            "invocations": trace.engine_invocations,
+            "signal_tape_sha256": view.signal_tape_sha256,
+            "signal_tape_equivalence_test": (
+                "tests/research/kr_corpus/d3_engine/test_d3_primary.py"
+            ),
+        },
+        "physical_run_completed": True,
+        "physical_run_id": physical.run_id,
+        "funding_method": funding,
+        "winner_selected": False,
+        "pareto_computed": False,
+    }
+    cash_daily = [
+        {
+            key: row[key]
+            for key in (
+                "session",
+                "contribution",
+                "cumulative_contribution",
+                "settled_orderable_cash",
+                "settled_reserved_order_cash",
+                "settled_cash_total",
+                "unsettled_buy_payables",
+                "unsettled_sell_receivables",
+                "session_index",
+                "reserved_orders",
+                "buy_payables",
+                "sell_receivables",
+            )
+        }
+        for row in trace.daily
+    ]
+    nav_daily = [
+        {
+            key: row[key]
+            for key in (
+                "session",
+                "nav",
+                "unit_price",
+                "units",
+                "invested_cost_basis",
+                "locked_share",
+                "position_market_value",
+                "open_positions",
+            )
+        }
+        for row in trace.daily
+    ]
+    payloads: dict[str, object] = {
+        "signals.json": signal_rows,
+        "submitted.json": submitted,
+        "fills.json": fills,
+        "skips.json": skip_rows,
+        "policy-rejects.json": policy_rejects,
+        "cash-rejects.json": cash_rejects,
+        "clamped-exposure.json": clamped_exposure,
+        "open-lots.json": open_lots,
+        "capital-days.json": capital_days,
+        "cash-daily.json": cash_daily,
+        "nav-unit-price-daily.json": nav_daily,
+        "events.json": events,
+        "orders.json": orders,
+        "metrics.json": metrics,
+        "evidence.json": evidence,
+    }
+    bundle = {
+        name: canonical_bytes(
+            {
+                "schema_version": PRIMARY_SCHEMA_VERSION,
+                "artifact_kind": name.removesuffix(".json"),
+                "run_id": physical.run_id,
+                "stamps": stamps,
+                "rows" if isinstance(payload, list) else "payload": payload,
+            }
+        )
+        for name, payload in payloads.items()
+    }
+    content_checksums = {
+        name: hashlib.sha256(raw).hexdigest() for name, raw in sorted(bundle.items())
+    }
+    bundle["run.json"] = canonical_bytes(
+        {
+            "schema_version": PRIMARY_SCHEMA_VERSION,
+            "artifact_kind": "physical_run",
+            "run_id": physical.run_id,
+            "stamps": stamps,
+            "parameters": {
+                "arm": physical.arm,
+                "cashflow_view": physical.cashflow_view,
+                "data_view": physical.data_view,
+                "fee_rate": "0.00215",
+                "monthly_contribution": "3500000",
+                "settlement": "T+2",
+                "same_bar": "buy-first same symbol",
+            },
+            "result_status": result.status,
+            "content_checksums": content_checksums,
+            "artifact_count_excluding_run_json": len(content_checksums),
+            "engine_invocations": trace.engine_invocations,
+            "physical_run_completed": True,
+            "winner_selected": False,
+        }
+    )
+    return bundle
+
+
+def _fill_rows(
+    fills: tuple[Fill, ...], submitted: list[dict[str, object]]
+) -> list[dict[str, object]]:
+    orders = {str(row["order_id"]): row for row in submitted}
+    rows: list[dict[str, object]] = []
+    positions: dict[str, tuple[int, Decimal]] = {}
+    for fill in fills:
+        order = orders.get(fill.order_id)
+        rung = order.get("rung") if order else _time_trim_rung(fill.order_id)
+        old_quantity, old_cost_basis = positions.get(fill.symbol, (0, Decimal(0)))
+        cost_basis_added: Decimal | None = None
+        cost_basis_released: Decimal | None = None
+        realized_pnl: Decimal | None = None
+        if fill.side is OrderSide.BUY:
+            cost_basis_added = fill.gross + fill.fee
+            positions[fill.symbol] = (
+                old_quantity + fill.quantity,
+                old_cost_basis + cost_basis_added,
+            )
+        else:
+            if old_quantity < fill.quantity:
+                raise PrimaryRunInvalid(
+                    f"sell fill exceeds reconstructed position:{fill.order_id}"
+                )
+            cost_basis_released = (
+                old_cost_basis * Decimal(fill.quantity) / Decimal(old_quantity)
+            )
+            realized_pnl = fill.gross - fill.fee - cost_basis_released
+            remaining_quantity = old_quantity - fill.quantity
+            positions[fill.symbol] = (
+                remaining_quantity,
+                (
+                    Decimal(0)
+                    if remaining_quantity == 0
+                    else old_cost_basis - cost_basis_released
+                ),
+            )
+        rows.append(
+            {
+                "order_id": fill.order_id,
+                "session": fill.session,
+                "symbol": fill.symbol,
+                "side": fill.side,
+                "class": fill.order_class,
+                "rung": rung,
+                "quantity": fill.quantity,
+                "price": fill.price,
+                "gross": fill.gross,
+                "fee": fill.fee,
+                "cost_basis_added": cost_basis_added,
+                "cost_basis_released": cost_basis_released,
+                "realized_pnl": realized_pnl,
+            }
+        )
+    return rows
+
+
+def _order_rows(
+    *,
+    submitted: list[dict[str, object]],
+    fills: list[dict[str, object]],
+    skips: list[dict[str, object]],
+    signal_index: dict[tuple[date, str], dict[str, object]],
+    view: LoadedCorpusView,
+    all_clamp_rows: dict[tuple[date, str], object],
+) -> list[dict[str, object]]:
+    fill_by_id = {str(row["order_id"]): row for row in fills}
+    expired = {
+        str(row["order_id"]): row for row in skips if row["event"] == "order_expired"
+    }
+    rows: list[dict[str, object]] = []
+    for order in submitted:
+        order_id = str(order["order_id"])
+        fill = fill_by_id.get(order_id)
+        key = (order["session"], str(order["symbol"]))
+        association = _clamp_association(key, signal_index, all_clamp_rows)
+        rows.append(
+            {
+                "order_id": order_id,
+                "market": market_for(
+                    view,
+                    symbol=key[1],
+                    session=key[0],  # type: ignore[arg-type]
+                ),
+                "symbol": key[1],
+                "session_date": key[0],
+                "side": _enum_value(order["side"]),
+                "order_class": _fidelity_order_class(order["class"]),
+                "engine_order_class": _enum_value(order["class"]),
+                "rung_id": str(order["rung"]),
+                "limit_price": order["limit"],
+                "quantity": order["quantity"],
+                "sim_outcome": "filled" if fill else "submitted_unfilled",
+                "sim_fill_price": fill["price"] if fill else None,
+                "skip_reason": "expired" if order_id in expired else None,
+                **association,
+            }
+        )
+    submitted_ids = {str(row["order_id"]) for row in submitted}
+    for fill in fills:
+        if str(fill["order_id"]) in submitted_ids:
+            continue
+        key = (fill["session"], str(fill["symbol"]))
+        rows.append(
+            {
+                "order_id": fill["order_id"],
+                "market": market_for(
+                    view,
+                    symbol=key[1],
+                    session=key[0],  # type: ignore[arg-type]
+                ),
+                "symbol": key[1],
+                "session_date": key[0],
+                "side": _enum_value(fill["side"]),
+                "order_class": _fidelity_order_class(fill["class"]),
+                "engine_order_class": _enum_value(fill["class"]),
+                "rung_id": str(fill["rung"]),
+                "limit_price": fill["price"],
+                "quantity": fill["quantity"],
+                "sim_outcome": "filled",
+                "sim_fill_price": fill["price"],
+                "skip_reason": None,
+                **_clamp_association(key, signal_index, all_clamp_rows),
+            }
+        )
+    for skip in skips:
+        if skip["event"] not in {"policy_rejected", "cash_rejected"}:
+            continue
+        key = (skip["session"], str(skip["symbol"]))
+        raw_rungs = skip.get("rungs")
+        rungs = raw_rungs if isinstance(raw_rungs, list) else [skip]
+        for rung in rungs:
+            if not isinstance(rung, dict):
+                raise PrimaryRunInvalid("malformed rejected rung evidence")
+            rows.append(
+                {
+                    "order_id": None,
+                    "market": market_for(
+                        view,
+                        symbol=key[1],
+                        session=key[0],  # type: ignore[arg-type]
+                    ),
+                    "symbol": key[1],
+                    "session_date": key[0],
+                    "side": _enum_value(skip.get("side", OrderSide.BUY)),
+                    "order_class": _fidelity_order_class(skip.get("class", "other")),
+                    "engine_order_class": _enum_value(skip.get("class", "other")),
+                    "rung_id": str(rung.get("rung", "POLICY")),
+                    "limit_price": rung.get("limit", skip.get("limit")),
+                    "quantity": skip.get("quantity"),
+                    "sim_outcome": "suppressed",
+                    "sim_fill_price": None,
+                    "skip_reason": str(skip.get("reason", skip["event"])),
+                    **_clamp_association(key, signal_index, all_clamp_rows),
+                }
+            )
+    return sorted(
+        rows,
+        key=lambda row: (
+            row["session_date"],
+            row["symbol"],
+            row["side"],
+            row["order_class"],
+            row["rung_id"],
+            row["sim_outcome"],
+        ),
+    )
+
+
+def _clamp_association(
+    key: tuple[object, str],
+    signal_index: dict[tuple[date, str], dict[str, object]],
+    all_clamp_rows: dict[tuple[date, str], object],
+) -> dict[str, object]:
+    typed_key = (key[0], key[1])
+    signal = signal_index.get(typed_key)  # type: ignore[arg-type]
+    return {
+        "current_bar_clamped": typed_key in all_clamp_rows,
+        "indicator_window_clamped_rows": (
+            int(signal["indicator_window_clamped_rows"]) if signal else 0
+        ),
+        "indicator_window_clamped_key_sha256": (
+            signal["indicator_window_clamped_key_sha256"] if signal else None
+        ),
+    }
+
+
+def _funding_p05(
+    daily: list[dict[str, object]],
+    events: list[dict[str, object]],
+) -> dict[str, object]:
+    month_ends: list[date] = []
+    for index, row in enumerate(daily):
+        session = row["session"]
+        if not isinstance(session, date):
+            raise AssertionError("daily session is not a date")
+        if index == len(daily) - 1:
+            month_ends.append(session)
+            continue
+        next_session = daily[index + 1]["session"]
+        if not isinstance(next_session, date):
+            raise AssertionError("daily next session is not a date")
+        if (session.year, session.month) != (next_session.year, next_session.month):
+            month_ends.append(session)
+    terminal = daily[-1]["session"]
+    assert isinstance(terminal, date)
+    events_by_session: dict[date, list[dict[str, object]]] = {}
+    for event in events:
+        session = event.get("session")
+        if isinstance(session, date):
+            events_by_session.setdefault(session, []).append(event)
+    complete: list[dict[str, object]] = []
+    censored = 0
+    for anchor in month_ends:
+        horizon = anchor + timedelta(days=90)
+        if horizon > terminal:
+            censored += 1
+            continue
+        anchor_row = next(row for row in daily if row["session"] == anchor)
+        ledger = _cash_ledger_from_daily(anchor_row)
+        first_reject: date | None = None
+        missed_notional = Decimal(0)
+        missed_signals = 0
+        for row in daily:
+            session = row["session"]
+            if not isinstance(session, date) or not (anchor < session <= horizon):
+                continue
+            session_index = int(row["session_index"])
+            ledger.settle_pre_open(session_index)
+            for event in events_by_session.get(session, []):
+                event_name = event["event"]
+                if event_name in {
+                    "monthly_contribution_pre_open",
+                    "t2_settle_pre_open",
+                }:
+                    continue
+                if event_name == "order_expired":
+                    if _enum_value(event["side"]) == OrderSide.BUY.value:
+                        ledger.expire_order(str(event["order_id"]))
+                    continue
+                if event_name == "order_submitted":
+                    if _enum_value(event["side"]) != OrderSide.BUY.value:
+                        continue
+                    gross_limit = Decimal(str(event["limit"])) * int(event["quantity"])
+                    required = cash_required(gross_limit, FEE_RATE)
+                    if not ledger.reserve_order(str(event["order_id"]), required):
+                        first_reject = session
+                        missed_notional = gross_limit
+                        missed_signals = 1
+                        break
+                    continue
+                if event_name == "cash_rejected":
+                    first_reject = session
+                    missed_notional = Decimal(str(event["limit"])) * int(
+                        event["quantity"]
+                    )
+                    missed_signals = 1
+                    break
+                if event_name != "fill":
+                    continue
+                gross = Decimal(str(event["gross"]))
+                fee = Decimal(str(event["fee"]))
+                if _enum_value(event["side"]) == OrderSide.BUY.value:
+                    ledger.fill_buy(
+                        order_id=str(event["order_id"]),
+                        actual_amount=gross + fee,
+                        trade_session_index=session_index,
+                    )
+                else:
+                    ledger.fill_sell(
+                        net_amount=gross - fee,
+                        trade_session_index=session_index,
+                    )
+            if first_reject is not None:
+                break
+        days = 90 if first_reject is None else (first_reject - anchor).days
+        complete.append(
+            {
+                "anchor": anchor,
+                "horizon": horizon,
+                "first_cash_reject": first_reject,
+                "funded_days": days,
+                "missed_notional_at_first_reject": missed_notional,
+                "missed_signals_at_first_reject": missed_signals,
+            }
+        )
+    values = [int(row["funded_days"]) for row in complete]
+    return {
+        "method": (
+            "month_end_rolling_90_calendar_day_zero_contribution_replay_to_first_"
+            "otherwise_eligible_cash_reject"
+        ),
+        "replay_invariant": (
+            "base event stream is exact until first stress cash rejection; future "
+            "contributions are omitted and settled/reserved/unsettled cash is replayed"
+        ),
+        "nearest_rank_percentile": "0.05",
+        "p05_days": nearest_rank(values, Decimal("0.05")) if values else None,
+        "complete_anchor_count": len(complete),
+        "right_censored_anchor_count": censored,
+        "anchors": complete,
+    }
+
+
+def _cash_ledger_from_daily(row: dict[str, object]) -> CashLedger:
+    ledger = CashLedger(Decimal(str(row["settled_orderable_cash"])))
+    reserved = row["reserved_orders"]
+    payables = row["buy_payables"]
+    receivables = row["sell_receivables"]
+    if not all(isinstance(items, list) for items in (reserved, payables, receivables)):
+        raise PrimaryRunInvalid("daily cash snapshot lists are malformed")
+    ledger.reserved_orders = {
+        str(item["order_id"]): Decimal(str(item["amount"]))
+        for item in reserved
+        if isinstance(item, dict)
+    }
+    ledger.payables = [
+        Settlement(
+            int(item["trade_session_index"]),
+            int(item["settle_session_index"]),
+            Decimal(str(item["amount"])),
+            str(item["kind"]),
+        )
+        for item in payables
+        if isinstance(item, dict)
+    ]
+    ledger.receivables = [
+        Settlement(
+            int(item["trade_session_index"]),
+            int(item["settle_session_index"]),
+            Decimal(str(item["amount"])),
+            str(item["kind"]),
+        )
+        for item in receivables
+        if isinstance(item, dict)
+    ]
+    if len(ledger.reserved_orders) != len(reserved):
+        raise PrimaryRunInvalid("daily reserved cash snapshot malformed")
+    if len(ledger.payables) != len(payables) or len(ledger.receivables) != len(
+        receivables
+    ):
+        raise PrimaryRunInvalid("daily settlement cash snapshot malformed")
+    return ledger
+
+
+def _build_order_changing_rows(
+    *,
+    output_root: Path,
+    completed: list[dict[str, object]],
+    stamps: dict[str, object],
+) -> dict[str, object]:
+    by_combo = {
+        (
+            str(row["arm"]),
+            str(row["cashflow_view"]),
+            str(row["data_view"]),
+        ): row
+        for row in completed
+    }
+    rows: list[dict[str, object]] = []
+    pairs: list[dict[str, object]] = []
+    for arm in Arm:
+        for cashflow in CashflowView:
+            original_meta = by_combo[
+                (arm.value, cashflow.value, DataView.ORIGINAL_VALID_BAR.value)
+            ]
+            clamp_meta = by_combo[
+                (arm.value, cashflow.value, DataView.CLAMP_ADMIT_V1.value)
+            ]
+            original_orders = _read_rows(
+                output_root / "runs" / str(original_meta["run_id"]) / "orders.json"
+            )
+            clamp_orders = _read_rows(
+                output_root / "runs" / str(clamp_meta["run_id"]) / "orders.json"
+            )
+            original_index = _unique_order_index(original_orders)
+            clamp_index = _unique_order_index(clamp_orders)
+            changed = 0
+            for key in sorted(set(original_index) | set(clamp_index)):
+                original = original_index.get(key)
+                clamp = clamp_index.get(key)
+                codes = _oc_codes(original, clamp)
+                if not codes:
+                    continue
+                changed += 1
+                pair_id = hashlib.sha256(
+                    "|".join(
+                        (arm.value, cashflow.value, *(str(item) for item in key))
+                    ).encode()
+                ).hexdigest()[:32]
+                for role, record, source in (
+                    ("orig_side", original, original_meta),
+                    ("clamp_side", clamp, clamp_meta),
+                ):
+                    material = _paired_material(record, original or clamp)
+                    fidelity = {
+                        "pair_id": pair_id,
+                        "arm": arm.value,
+                        "cashflow_view": cashflow.value,
+                        "data_view_role": role,
+                        **material,
+                        "oc_codes": codes,
+                        "source_artifact_sha": source["run_json_sha256"],
+                    }
+                    fidelity["unit_id"] = _fidelity_unit_id(fidelity)
+                    rows.append(fidelity)
+            pairs.append(
+                {
+                    "arm": arm.value,
+                    "cashflow_view": cashflow.value,
+                    "original_run_id": original_meta["run_id"],
+                    "clamp_run_id": clamp_meta["run_id"],
+                    "order_changing_keys": changed,
+                    "paired": True,
+                }
+            )
+    rows.sort(key=lambda row: (row["pair_id"], row["data_view_role"]))
+    schema = _order_changing_schema()
+    _write_bytes(
+        output_root / "order-changing-clamped-rows.json",
+        canonical_bytes(
+            {
+                "schema_version": ORDER_CHANGING_SCHEMA_VERSION,
+                "artifact_kind": "order-changing-clamped-rows",
+                "stamps": stamps,
+                "rows": rows,
+            }
+        ),
+    )
+    _write_bytes(
+        output_root / "order-changing-clamped-rows-schema.json",
+        canonical_bytes(
+            {
+                "schema_version": ORDER_CHANGING_SCHEMA_VERSION,
+                "artifact_kind": "order-changing-clamped-rows-schema",
+                "stamps": stamps,
+                "payload": schema,
+            }
+        ),
+    )
+    _write_bytes(
+        output_root / "dual-view-pairing.json",
+        canonical_bytes(
+            {
+                "schema_version": PRIMARY_SCHEMA_VERSION,
+                "artifact_kind": "dual-view-pairing",
+                "stamps": stamps,
+                "rows": pairs,
+            }
+        ),
+    )
+    return {
+        "pairing": {
+            "pairs": len(pairs),
+            "expected_pairs": 8,
+            "all_paired": len(pairs) == 8 and all(row["paired"] for row in pairs),
+            "rows": pairs,
+        },
+        "summary": {
+            "schema_version": ORDER_CHANGING_SCHEMA_VERSION,
+            "row_count": len(rows),
+            "pair_count": len({row["pair_id"] for row in rows}),
+            "artifact": "order-changing-clamped-rows.json",
+            "schema": "order-changing-clamped-rows-schema.json",
+            "fidelity_method_compatible": True,
+        },
+    }
+
+
+def _build_clamped_pair_exposure(
+    *,
+    output_root: Path,
+    completed: list[dict[str, object]],
+    stamps: dict[str, object],
+) -> dict[str, object]:
+    by_combo = {
+        (
+            str(row["arm"]),
+            str(row["cashflow_view"]),
+            str(row["data_view"]),
+        ): row
+        for row in completed
+    }
+    fields = (
+        "clamped_signal_rows",
+        "clamped_order_rows",
+        "clamped_fill_rows",
+        "clamped_fill_gross_notional",
+        "clamped_realized_pnl",
+        "clamped_view_terminal_nav",
+    )
+    rows: list[dict[str, object]] = []
+    for data_view in DataView:
+        for cashflow in CashflowView:
+            b0_meta = by_combo[(Arm.B0.value, cashflow.value, data_view.value)]
+            b0_metrics = _read_payload(
+                output_root / "runs" / str(b0_meta["run_id"]) / "metrics.json"
+            )
+            for arm in Arm:
+                arm_meta = by_combo[(arm.value, cashflow.value, data_view.value)]
+                arm_metrics = _read_payload(
+                    output_root / "runs" / str(arm_meta["run_id"]) / "metrics.json"
+                )
+                rows.append(
+                    {
+                        "arm": arm.value,
+                        "cashflow_view": cashflow.value,
+                        "data_view": data_view.value,
+                        "arm_run_id": arm_meta["run_id"],
+                        "b0_run_id": b0_meta["run_id"],
+                        "arm_exposure": {field: arm_metrics[field] for field in fields},
+                        "b0_exposure": {field: b0_metrics[field] for field in fields},
+                        "arm_minus_b0": {
+                            field: Decimal(str(arm_metrics[field]))
+                            - Decimal(str(b0_metrics[field]))
+                            for field in fields
+                        },
+                    }
+                )
+    _write_bytes(
+        output_root / "clamped-pair-exposure.json",
+        canonical_bytes(
+            {
+                "schema_version": PRIMARY_SCHEMA_VERSION,
+                "artifact_kind": "clamped-pair-exposure",
+                "stamps": stamps,
+                "rows": rows,
+            }
+        ),
+    )
+    return {
+        "artifact": "clamped-pair-exposure.json",
+        "row_count": len(rows),
+        "expected_row_count": 16,
+        "comparison": "arm-minus-B0 within cashflow and data view; diagnostic only",
+    }
+
+
+def _order_key(row: dict[str, object]) -> tuple[str, str, str, str, str]:
+    return (
+        str(row["symbol"]),
+        str(row["session_date"]),
+        str(row["side"]),
+        str(row["order_class"]),
+        str(row["rung_id"]),
+    )
+
+
+def _unique_order_index(
+    rows: list[dict[str, object]],
+) -> dict[tuple[str, str, str, str, str], dict[str, object]]:
+    result: dict[tuple[str, str, str, str, str], dict[str, object]] = {}
+    for row in rows:
+        key = _order_key(row)
+        if key in result:
+            raise PrimaryRunInvalid(f"duplicate fidelity order key:{key}")
+        result[key] = row
+    return result
+
+
+def _oc_codes(
+    original: dict[str, object] | None,
+    clamp: dict[str, object] | None,
+) -> list[str]:
+    codes: list[str] = []
+    original_submitted = (
+        original is not None and original["sim_outcome"] != "suppressed"
+    )
+    clamp_submitted = clamp is not None and clamp["sim_outcome"] != "suppressed"
+    if original_submitted != clamp_submitted:
+        codes.append("OC_SUBMIT_XOR")
+    original_filled = original is not None and original["sim_outcome"] == "filled"
+    clamp_filled = clamp is not None and clamp["sim_outcome"] == "filled"
+    if original_filled != clamp_filled:
+        codes.append("OC_FILL_XOR")
+    if original and clamp:
+        if original["limit_price"] != clamp["limit_price"]:
+            codes.append("OC_LIMIT_NE")
+        if original["quantity"] != clamp["quantity"]:
+            codes.append("OC_QTY_NE")
+        if original["sim_fill_price"] != clamp["sim_fill_price"]:
+            codes.append("OC_FILL_PX_NE")
+        if original["skip_reason"] != clamp["skip_reason"]:
+            codes.append("OC_SKIP_REASON_NE")
+    return codes
+
+
+def _paired_material(
+    row: dict[str, object] | None,
+    fallback: dict[str, object] | None,
+) -> dict[str, object]:
+    if fallback is None:
+        raise AssertionError("order-changing pair lacks both sides")
+    source = row or fallback
+    return {
+        "market": source.get("market"),
+        "symbol": source["symbol"],
+        "session_date": source["session_date"],
+        "side": source["side"],
+        "order_class": source["order_class"],
+        "rung_id": source["rung_id"],
+        "limit_price": row.get("limit_price") if row else None,
+        "quantity": row.get("quantity") if row else None,
+        "sim_outcome": row.get("sim_outcome") if row else "suppressed",
+        "sim_fill_price": row.get("sim_fill_price") if row else None,
+        "skip_reason": row.get("skip_reason") if row else "absent_in_view",
+        "current_bar_clamped": bool(row and row["current_bar_clamped"]),
+        "indicator_window_clamped_rows": (
+            int(row["indicator_window_clamped_rows"]) if row else 0
+        ),
+    }
+
+
+def _fidelity_unit_id(row: dict[str, object]) -> str:
+    limit = "" if row["limit_price"] is None else str(row["limit_price"])
+    material = "|".join(
+        (
+            "d3-fidelity-unit-v1",
+            str(row["arm"]),
+            str(row["cashflow_view"]),
+            str(row["symbol"]),
+            str(row["session_date"]),
+            str(row["side"]),
+            str(row["order_class"]),
+            str(row["rung_id"]),
+            limit,
+            str(row["sim_outcome"]),
+            ",".join(sorted(str(code) for code in row["oc_codes"])),
+        )
+    )
+    return hashlib.sha256(material.encode()).hexdigest()[:32]
+
+
+def _order_changing_schema() -> dict[str, object]:
+    return {
+        "record_key": ["unit_id", "data_view_role"],
+        "sampling_unit_id": "unit_id (role-free frozen literals.yaml algorithm)",
+        "pair_key": ["pair_id", "data_view_role"],
+        "comparison_key": [
+            "arm",
+            "cashflow_view",
+            "symbol",
+            "session_date",
+            "side",
+            "order_class",
+            "rung_id",
+        ],
+        "required_fields": [
+            "unit_id",
+            "pair_id",
+            "arm",
+            "cashflow_view",
+            "data_view_role",
+            "symbol",
+            "session_date",
+            "side",
+            "order_class",
+            "rung_id",
+            "limit_price",
+            "sim_outcome",
+            "sim_fill_price",
+            "oc_codes",
+            "source_artifact_sha",
+        ],
+        "enums": {
+            "data_view_role": ["orig_side", "clamp_side"],
+            "side": ["buy", "sell"],
+            "order_class": ["new", "add", "trim", "exit", "other"],
+            "sim_outcome": [
+                "submitted_unfilled",
+                "filled",
+                "expired",
+                "suppressed",
+            ],
+            "oc_codes": [
+                "OC_SUBMIT_XOR",
+                "OC_FILL_XOR",
+                "OC_LIMIT_NE",
+                "OC_QTY_NE",
+                "OC_FILL_PX_NE",
+                "OC_SKIP_REASON_NE",
+            ],
+        },
+        "fidelity_method_binding": {
+            "checksums_sha256": FIDELITY_METHOD_CHECKSUMS_SHA256,
+            "population": "METHOD.md §1.2 OC-1 AND OC-2",
+            "population_projection": (
+                "every OC-2 changed comparison emits orig_side and clamp_side; "
+                "identical dual-view order rows are excluded"
+            ),
+            "fidelity_unit_fields": "METHOD.md §1.4",
+            "unit_id_algorithm": "literals.yaml population.unit_id_algorithm",
+            "comparison": (
+                "required fidelity-unit fields are an exact field superset; compatible"
+            ),
+        },
+    }
+
+
+def measure_primary_run_executed(root: Path) -> dict[str, object]:
+    """Derive execution state from the completed, checksummed artifact bundle."""
+
+    manifest_path = root / "manifest.json"
+    if not manifest_path.is_file():
+        return {
+            "primary_run_executed": False,
+            "reason": "manifest_missing",
+            "physical_runs": 0,
+        }
+    try:
+        manifest = json.loads(manifest_path.read_bytes())
+        matrix = manifest["matrix"]
+        runs = matrix["runs"]
+    except (KeyError, TypeError, json.JSONDecodeError) as exc:
+        return {
+            "primary_run_executed": False,
+            "reason": f"manifest_invalid:{type(exc).__name__}",
+            "physical_runs": 0,
+        }
+    expected_ids = {run.run_id for run in primary_matrix()}
+    actual_ids = {str(row.get("run_id")) for row in runs}
+    verified = 0
+    for row in runs:
+        run_id = str(row.get("run_id"))
+        path = root / "runs" / run_id / "run.json"
+        if not path.is_file():
+            continue
+        raw = path.read_bytes()
+        if hashlib.sha256(raw).hexdigest() != row.get("run_json_sha256"):
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if (
+            payload.get("physical_run_completed") is True
+            and int(payload.get("engine_invocations_total", 0)) == 2
+            and row.get("deterministic_2runs") is True
+            and _verify_physical_run_bundle(path.parent, payload)
+            and _directory_bundle_sha(path.parent) == row.get("bundle_sha256")
+        ):
+            verified += 1
+    value = (
+        expected_ids == actual_ids
+        and verified == 16
+        and matrix.get("physical_runs") == 16
+        and matrix.get("deterministic_2runs") == 16
+    )
+    return {
+        "primary_run_executed": value,
+        "reason": "artifact_derived",
+        "physical_runs": len(runs),
+        "verified_engine_runs": verified,
+        "expected_matrix_match": expected_ids == actual_ids,
+    }
+
+
+def _load_delist_actions(
+    root: Path,
+    *,
+    market_sessions: tuple[date, ...],
+) -> tuple[tuple[CorporateAction, ...], dict[str, object]]:
+    checksums = root / "checksums.sha256"
+    audit = root / "audit_presence_endings.csv"
+    if sha256_file(checksums) != DELIST_CHECKSUMS_SHA256:
+        raise PrimaryRunInvalid("delist bundle checksum drift")
+    if sha256_file(audit) != DELIST_AUDIT_SHA256:
+        raise PrimaryRunInvalid("delist audit checksum drift")
+    reader = csv.DictReader(io.StringIO(audit.read_text(encoding="utf-8")))
+    by_symbol: dict[str, date] = {}
+    matched_rows = 0
+    for row in reader:
+        if row["audit_status"] != "MATCH_WITHIN_60_CALENDAR_DAYS":
+            continue
+        matched_rows += 1
+        symbol = row["symbol"]
+        last_presence = date.fromisoformat(row["last_presence_session"])
+        by_symbol[symbol] = max(by_symbol.get(symbol, last_presence), last_presence)
+    session_index = {session: index for index, session in enumerate(market_sessions)}
+    actions: list[CorporateAction] = []
+    for symbol, last_presence in sorted(by_symbol.items()):
+        position = session_index.get(last_presence)
+        if position is None or position + 1 >= len(market_sessions):
+            continue
+        actions.append(
+            CorporateAction(
+                session=market_sessions[position + 1],
+                symbol=symbol,
+                kind="delist_evidence_data_end",
+                data_ends_before_exploration_end=True,
+            )
+        )
+    return tuple(actions), {
+        "checksums_sha256": DELIST_CHECKSUMS_SHA256,
+        "audit_presence_endings_sha256": DELIST_AUDIT_SHA256,
+        "matched_audit_rows": matched_rows,
+        "unique_symbols_with_actions": len(actions),
+        "coverage_limit": "KOSDAQ DART decision evidence; KOSPI terminal partial scope",
+        "action_session": "first frozen XKRX session after last presence",
+    }
+
+
+def _read_completed_run(target: Path, physical: PhysicalRun) -> dict[str, object]:
+    raw = (target / "run.json").read_bytes()
+    payload = json.loads(raw)
+    if payload.get("run_id") != physical.run_id:
+        raise PrimaryRunInvalid(f"existing run id mismatch:{target}")
+    if payload.get("physical_run_completed") is not True:
+        raise PrimaryRunInvalid(f"existing run incomplete:{target}")
+    if not _verify_physical_run_bundle(target, payload):
+        raise PrimaryRunInvalid(f"existing run checksum/determinism invalid:{target}")
+    return {
+        "run_id": physical.run_id,
+        "arm": physical.arm.value,
+        "cashflow_view": physical.cashflow_view.value,
+        "data_view": physical.data_view.value,
+        "deterministic_2runs": True,
+        "run_json_sha256": hashlib.sha256(raw).hexdigest(),
+        "bundle_sha256": _directory_bundle_sha(target),
+    }
+
+
+def _demand_from_orders_file(path: Path) -> frozenset[tuple[date, str]]:
+    payload = json.loads(path.read_bytes())
+    pairs = payload["payload"]["counterfactual_demand_pairs"]
+    return frozenset(
+        (date.fromisoformat(row["session"]), str(row["symbol"])) for row in pairs
+    )
+
+
+def _publish_bundle(target: Path, bundle: dict[str, bytes]) -> None:
+    if target.exists():
+        raise PrimaryRunInvalid(f"refusing to overwrite existing run:{target}")
+    with tempfile.TemporaryDirectory(
+        prefix=f".{target.name}.", dir=target.parent
+    ) as raw_tmp:
+        temporary = Path(raw_tmp)
+        for name, raw in bundle.items():
+            _write_bytes(temporary / name, raw)
+        shutil.copytree(temporary, target)
+
+
+def _seal_determinism(
+    *,
+    physical: PhysicalRun,
+    first: dict[str, bytes],
+    second: dict[str, bytes],
+    stamps: dict[str, object],
+) -> dict[str, bytes]:
+    """Attach evidence only after two independently built core bundles match."""
+
+    first_sha = _bundle_sha(first)
+    second_sha = _bundle_sha(second)
+    if first != second or first_sha != second_sha:
+        raise PrimaryRunInvalid(f"non-deterministic bundle:{physical.run_id}")
+    first_run = json.loads(first["run.json"])
+    second_run = json.loads(second["run.json"])
+    first_content_checksums = first_run.get("content_checksums")
+    second_content_checksums = second_run.get("content_checksums")
+    if (
+        not isinstance(first_content_checksums, dict)
+        or first_content_checksums != second_content_checksums
+    ):
+        raise PrimaryRunInvalid(f"non-deterministic content map:{physical.run_id}")
+    finalized = dict(first)
+    finalized["determinism.json"] = canonical_bytes(
+        {
+            "schema_version": PRIMARY_SCHEMA_VERSION,
+            "artifact_kind": "determinism",
+            "run_id": physical.run_id,
+            "stamps": stamps,
+            "payload": {
+                "attempts_executed": 2,
+                "attempt_1_core_bundle_sha256": first_sha,
+                "attempt_2_core_bundle_sha256": second_sha,
+                "attempt_1_content_checksums": first_content_checksums,
+                "attempt_2_content_checksums": second_content_checksums,
+                "byte_identical": True,
+            },
+        }
+    )
+    run_payload = json.loads(finalized["run.json"])
+    content_checksums = {
+        name: hashlib.sha256(raw).hexdigest()
+        for name, raw in sorted(finalized.items())
+        if name != "run.json"
+    }
+    run_payload.update(
+        {
+            "content_checksums": content_checksums,
+            "artifact_count_excluding_run_json": len(content_checksums),
+            "attempts_executed": 2,
+            "engine_invocations_total": 2,
+            "deterministic_2runs": True,
+        }
+    )
+    finalized["run.json"] = canonical_bytes(run_payload)
+    return finalized
+
+
+def _verify_physical_run_bundle(root: Path, run_payload: dict[str, object]) -> bool:
+    checksums = run_payload.get("content_checksums")
+    if not isinstance(checksums, dict):
+        return False
+    actual_names = {
+        path.name for path in root.glob("*.json") if path.name != "run.json"
+    }
+    if actual_names != set(checksums):
+        return False
+    for name, expected in checksums.items():
+        path = root / str(name)
+        if not path.is_file() or sha256_file(path) != expected:
+            return False
+    try:
+        determinism = json.loads((root / "determinism.json").read_bytes())["payload"]
+    except (KeyError, TypeError, json.JSONDecodeError, OSError):
+        return False
+    first_content = determinism.get("attempt_1_content_checksums")
+    second_content = determinism.get("attempt_2_content_checksums")
+    if not isinstance(first_content, dict) or first_content != second_content:
+        return False
+    current_core_names = actual_names - {"determinism.json"}
+    if current_core_names != set(first_content):
+        return False
+    if any(
+        sha256_file(root / str(name)) != expected
+        for name, expected in first_content.items()
+    ):
+        return False
+    return bool(
+        run_payload.get("attempts_executed") == 2
+        and run_payload.get("engine_invocations_total") == 2
+        and run_payload.get("deterministic_2runs") is True
+        and determinism.get("attempts_executed") == 2
+        and determinism.get("byte_identical") is True
+        and determinism.get("attempt_1_core_bundle_sha256")
+        == determinism.get("attempt_2_core_bundle_sha256")
+    )
+
+
+def _write_bytes(path: Path, raw: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{path.name}.", dir=path.parent, delete=False
+    ) as handle:
+        temporary = Path(handle.name)
+        handle.write(raw)
+        handle.flush()
+    temporary.replace(path)
+
+
+def _bundle_sha(bundle: dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for name, raw in sorted(bundle.items()):
+        digest.update(name.encode())
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(raw).digest())
+    return digest.hexdigest()
+
+
+def _directory_bundle_sha(root: Path) -> str:
+    return _bundle_sha(
+        {path.name: path.read_bytes() for path in sorted(root.glob("*.json"))}
+    )
+
+
+def _read_rows(path: Path) -> list[dict[str, object]]:
+    payload = json.loads(path.read_bytes())
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        raise PrimaryRunInvalid(f"artifact rows missing:{path}")
+    return rows
+
+
+def _read_payload(path: Path) -> dict[str, object]:
+    envelope = json.loads(path.read_bytes())
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        raise PrimaryRunInvalid(f"artifact payload missing:{path}")
+    return payload
+
+
+def _key_list_sha(keys: list[tuple[date, str]]) -> str | None:
+    if not keys:
+        return None
+    return hashlib.sha256(canonical_bytes(sorted(keys))).hexdigest()
+
+
+def _time_trim_rung(order_id: str) -> str:
+    if "-TIME-" not in order_id:
+        return "FILL_ONLY"
+    return f"trim_{order_id.rsplit('-', 1)[-1]}"
+
+
+def _fidelity_order_class(value: object) -> str:
+    raw = _enum_value(value)
+    return {
+        "new": "new",
+        "add": "add",
+        "resistance_trim": "trim",
+        "time_trim": "trim",
+    }.get(raw, "other")
+
+
+def _enum_value(value: object) -> str:
+    return str(getattr(value, "value", value))

--- a/research/kr_corpus/d3_engine/primary.py
+++ b/research/kr_corpus/d3_engine/primary.py
@@ -164,13 +164,28 @@ class PrimaryPortfolioEngine(PortfolioEngine):
         self._trace_previous_contribution = Decimal(0)
         try:
             self._trace.engine_invocations += 1
-            result = super()._run(
-                run_input,
-                b0_demand_pairs=b0_demand_pairs,
-            )
+            gc_was_enabled = gc.isenabled()
+            if gc_was_enabled:
+                gc.disable()
+            try:
+                result = super()._run(
+                    run_input,
+                    b0_demand_pairs=b0_demand_pairs,
+                )
+            finally:
+                if gc_was_enabled:
+                    gc.enable()
         finally:
             self._capture = False
         return result, self._trace
+
+    @staticmethod
+    def _signal_history(
+        symbol_bars: list[Any], *, index: int, segment_start: int
+    ) -> list[Any]:
+        """The exact signal tape only needs t and its prior 120-bar association."""
+
+        return symbol_bars[max(segment_start, index - 120) : index + 1]
 
     def _signal_for_session(
         self, history: list[Any], decision_index: int
@@ -424,6 +439,12 @@ class PrimaryRunHarness:
             f"clamp rows={clamp.row_count} files={clamp.parquet_files} · "
             f"SEALED_ACCESS_MEASURED={access_evidence['sealed_access_spy']}\n"
         )
+        gc.collect()
+        gc.freeze()
+        self._append_progress(
+            f"\nEXECUTION_GC_HEAP_FROZEN = {gc.get_freeze_count()} objects · "
+            "semantics-neutral performance isolation\n"
+        )
 
         completed: list[dict[str, object]] = []
         b0_demand: dict[
@@ -563,6 +584,7 @@ class PrimaryRunHarness:
             "\nRUNS = 16/16 physical · DETERMINISTIC_2RUNS = 16/16 PASS · "
             "DUAL_VIEW_PAIRED = 8/8 · WINNER_SELECTED = NO\n"
         )
+        gc.unfreeze()
         return manifest
 
     def _preflight(self) -> None:
@@ -604,6 +626,10 @@ class PrimaryRunHarness:
                 "settlement": "T+2",
                 "same_bar": "buy-first same symbol",
                 "sensitivity": False,
+                "gc_isolation": (
+                    "long-lived corpus heap frozen; cyclic GC suspended per attempt; "
+                    "reference-count semantics unchanged"
+                ),
             },
         }
 

--- a/research/kr_corpus/d3_engine/primary_corpus.py
+++ b/research/kr_corpus/d3_engine/primary_corpus.py
@@ -1,0 +1,611 @@
+"""Measured, read-only corpus loader for the D3 primary exploration matrix."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, localcontext
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from research.kr_corpus.d3_engine.canonical import canonical_bytes
+from research.kr_corpus.d3_engine.constants import (
+    DECIMAL_PRECISION,
+    DECIMAL_ROUNDING,
+    RSI_THRESHOLD,
+)
+from research.kr_corpus.d3_engine.guards import SealedAccessGuard
+from research.kr_corpus.d3_engine.indicators import bollinger_bands, fib_levels
+from research.kr_corpus.d3_engine.models import DataView
+from research.kr_corpus.d3_engine.signals import (
+    PriceLevel,
+    choose_l2,
+    cluster_levels,
+    signal_is_eligible,
+)
+
+CORPUS_RUN_ID = "kr-corpus-v1-20260803-1001"
+
+CORPUS_BINDINGS = {
+    "original_manifest_sha256": (
+        "da1ca376ac6693e96d311eda07f9fe96f1cb69fa2e3e8f346ededf96c5d5c54b"
+    ),
+    "original_checksums_sha256": (
+        "9704cc72455bca8bc8bdea78506b16de4d0cdff697661d7ee8a349eb4b311a7f"
+    ),
+    "derived_manifest_sha256": (
+        "25e2e9a5af85d3389488e5b3464d6d69bfaa877abeae7754ce50b8d23d2fd827"
+    ),
+    "derived_checksums_sha256": (
+        "392a237d2614abd7f5df178d5c03f3c6c77a15af8f22e505fa2ca2ebe5ec2950"
+    ),
+}
+
+EXPECTED_ROWS = {
+    DataView.ORIGINAL_VALID_BAR: 5_525_302,
+    DataView.CLAMP_ADMIT_V1: 5_564_715,
+}
+
+_BASE_COLUMNS = (
+    "session",
+    "market",
+    "ticker",
+    "open",
+    "high",
+    "low",
+    "close",
+)
+_CLAMP_COLUMNS = (
+    "source_high",
+    "source_low",
+    "clamped",
+    "clamp_delta_high",
+    "clamp_delta_low",
+    "clamp_classification",
+    "admitted",
+)
+
+
+class PrimaryCorpusInvalid(ValueError):
+    code = "RUN_INVALID_PRIMARY_CORPUS"
+
+
+@dataclass(frozen=True, slots=True)
+class PrimaryCorpusPaths:
+    original_root: Path
+    derived_root: Path
+
+    @classmethod
+    def defaults(cls) -> PrimaryCorpusPaths:
+        root = Path.home() / "work" / "herdr-artifacts" / "kr-corpus-v1"
+        return cls(
+            original_root=root / "runs" / CORPUS_RUN_ID,
+            derived_root=root / "derived-views" / "clamp-admit-v1",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ClampRow:
+    market: str
+    session: date
+    symbol: str
+    source_high: int
+    source_low: int
+    high: int
+    low: int
+    delta_high: int
+    delta_low: int
+    classification: str
+    admitted: bool
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusBar:
+    """Compact bar whose Decimal properties satisfy the E1 engine surface."""
+
+    session: date
+    symbol: str
+    market: str
+    open_int: int
+    high_int: int
+    low_int: int
+    close_int: int
+
+    @property
+    def open(self) -> Decimal:
+        return Decimal(self.open_int)
+
+    @property
+    def high(self) -> Decimal:
+        return Decimal(self.high_int)
+
+    @property
+    def low(self) -> Decimal:
+        return Decimal(self.low_int)
+
+    @property
+    def close(self) -> Decimal:
+        return Decimal(self.close_int)
+
+
+@dataclass(frozen=True, slots=True)
+class SignalSnapshot:
+    rsi: Decimal
+    l2_price: Decimal
+    fib_high: Decimal
+    fib_low: Decimal
+    previous_close: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedCorpusView:
+    data_view: DataView
+    bars: tuple[CorpusBar, ...]
+    signals: dict[tuple[date, str], SignalSnapshot]
+    clamp_rows: dict[tuple[date, str], ClampRow]
+    market_periods: dict[str, tuple[tuple[date, date, str], ...]]
+    manifest_sha256: str
+    checksums_sha256: str
+    parquet_files: int
+    row_count: int
+    signal_tape_sha256: str
+    access_evidence: dict[str, int]
+
+
+@dataclass(slots=True)
+class _WilderState:
+    previous: Decimal | None = None
+    delta_count: int = 0
+    seed_gain: Decimal = Decimal(0)
+    seed_loss: Decimal = Decimal(0)
+    average_gain: Decimal | None = None
+    average_loss: Decimal | None = None
+    value: Decimal | None = None
+
+    def add(self, close: int) -> None:
+        current = Decimal(close)
+        if self.previous is None:
+            self.previous = current
+            return
+        change = current - self.previous
+        gain = max(change, Decimal(0))
+        loss = max(-change, Decimal(0))
+        self.delta_count += 1
+        if self.delta_count <= 14:
+            self.seed_gain += gain
+            self.seed_loss += loss
+            if self.delta_count == 14:
+                self.average_gain = self.seed_gain / Decimal(14)
+                self.average_loss = self.seed_loss / Decimal(14)
+                self.value = _rsi_from_averages(self.average_gain, self.average_loss)
+        else:
+            assert self.average_gain is not None
+            assert self.average_loss is not None
+            self.average_gain = (self.average_gain * Decimal(13) + gain) / Decimal(14)
+            self.average_loss = (self.average_loss * Decimal(13) + loss) / Decimal(14)
+            self.value = _rsi_from_averages(self.average_gain, self.average_loss)
+        self.previous = current
+
+
+def _rsi_from_averages(average_gain: Decimal, average_loss: Decimal) -> Decimal:
+    if average_loss == 0:
+        return Decimal(100) if average_gain > 0 else Decimal(50)
+    if average_gain == 0:
+        return Decimal(0)
+    return Decimal(100) - Decimal(100) / (Decimal(1) + average_gain / average_loss)
+
+
+class PrimaryCorpusLoader:
+    """Load only explicitly bound exploration roots through a measured guard."""
+
+    def __init__(
+        self,
+        *,
+        paths: PrimaryCorpusPaths | None = None,
+        guard: SealedAccessGuard | None = None,
+        bindings: dict[str, str] | None = None,
+        expected_rows: dict[DataView, int] | None = None,
+    ) -> None:
+        self.paths = paths or PrimaryCorpusPaths.defaults()
+        self.guard = guard or SealedAccessGuard()
+        self.bindings = bindings or dict(CORPUS_BINDINGS)
+        self.expected_rows = expected_rows or dict(EXPECTED_ROWS)
+
+    def load(
+        self,
+        data_view: DataView,
+        *,
+        market_sessions: tuple[date, ...],
+    ) -> LoadedCorpusView:
+        root, manifest_expected, checksums_expected = self._binding(data_view)
+        root = root.expanduser().resolve(strict=True)
+        dataset_root = (root / "dataset").resolve(strict=True)
+        if dataset_root.parent != root:
+            raise PrimaryCorpusInvalid("dataset root escaped bound corpus root")
+
+        manifest_path = root / "manifest.json"
+        manifest_raw = self.guard.read_manifest(
+            path=manifest_path, loader=manifest_path.read_bytes
+        )
+        manifest_sha = hashlib.sha256(manifest_raw).hexdigest()
+        if manifest_sha != manifest_expected:
+            raise PrimaryCorpusInvalid(
+                f"manifest sha drift:{manifest_sha}!={manifest_expected}"
+            )
+        if data_view is DataView.CLAMP_ADMIT_V1:
+            self._validate_derived_manifest(manifest_raw)
+
+        checksums_path = root / "checksums.sha256"
+        checksums_raw = self.guard.read_file(
+            path=checksums_path, loader=checksums_path.read_bytes
+        )
+        checksums_sha = hashlib.sha256(checksums_raw).hexdigest()
+        if checksums_sha != checksums_expected:
+            raise PrimaryCorpusInvalid(
+                f"checksums sha drift:{checksums_sha}!={checksums_expected}"
+            )
+        entries = self._dataset_entries(checksums_raw)
+
+        positions = {session: index for index, session in enumerate(market_sessions)}
+        if len(positions) != len(market_sessions):
+            raise PrimaryCorpusInvalid("market sessions must be unique")
+        by_symbol: dict[str, list[CorpusBar]] = defaultdict(list)
+        clamp_rows: dict[tuple[date, str], ClampRow] = {}
+        total_rows = 0
+        for expected_sha, relative in entries:
+            partition = self._partition(relative)
+            path = (root / relative).resolve(strict=True)
+            if path.parent.parent.parent != dataset_root:
+                raise PrimaryCorpusInvalid(f"dataset path escaped root:{relative}")
+            actual_sha = self.guard.read_file(
+                path=path, loader=lambda path=path: _sha256_stream(path)
+            )
+            if actual_sha != expected_sha:
+                raise PrimaryCorpusInvalid(
+                    f"parquet checksum drift:{relative}:{actual_sha}!={expected_sha}"
+                )
+            rows = self.guard.read_parquet(
+                path=path,
+                loader=lambda path=path, data_view=data_view: _read_parquet_rows(
+                    path, data_view
+                ),
+            )
+            for raw in rows:
+                try:
+                    decoded_session = date.fromisoformat(str(raw["session"]))
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise PrimaryCorpusInvalid(
+                        "invalid corpus parquet session"
+                    ) from exc
+                self.guard.record_bar_rows((decoded_session,))
+                bar, clamp = self._bar_from_row(
+                    raw,
+                    partition=partition,
+                    data_view=data_view,
+                    market_positions=positions,
+                    market_sessions=market_sessions,
+                )
+                by_symbol[bar.symbol].append(bar)
+                if clamp is not None:
+                    key = (bar.session, bar.symbol)
+                    if key in clamp_rows:
+                        raise PrimaryCorpusInvalid(f"duplicate clamped row:{key}")
+                    clamp_rows[key] = clamp
+            total_rows += len(rows)
+
+        expected_count = self.expected_rows[data_view]
+        if total_rows != expected_count:
+            raise PrimaryCorpusInvalid(
+                f"row count drift:{total_rows}!={expected_count}"
+            )
+
+        signals = _prepare_signal_tape(by_symbol, positions)
+        by_session: list[list[CorpusBar]] = [[] for _ in market_sessions]
+        market_periods: dict[str, tuple[tuple[date, date, str], ...]] = {}
+        for symbol, symbol_bars in sorted(by_symbol.items()):
+            symbol_bars.sort(key=lambda item: item.session)
+            previous: date | None = None
+            for bar in symbol_bars:
+                if previous == bar.session:
+                    raise PrimaryCorpusInvalid(
+                        f"duplicate symbol/session across market partitions:{symbol}:{bar.session}"
+                    )
+                previous = bar.session
+                by_session[positions[bar.session]].append(bar)
+            market_periods[symbol] = _market_periods(symbol_bars)
+        bars = tuple(
+            bar
+            for session_bars in by_session
+            for bar in sorted(session_bars, key=lambda item: item.symbol)
+        )
+        if len(bars) != total_rows:
+            raise AssertionError("bar materialization count drift")
+
+        return LoadedCorpusView(
+            data_view=data_view,
+            bars=bars,
+            signals=signals,
+            clamp_rows=clamp_rows,
+            market_periods=market_periods,
+            manifest_sha256=manifest_sha,
+            checksums_sha256=checksums_sha,
+            parquet_files=len(entries),
+            row_count=total_rows,
+            signal_tape_sha256=_signal_tape_sha(signals),
+            access_evidence=self.guard.spy.evidence(),
+        )
+
+    def _binding(self, data_view: DataView) -> tuple[Path, str, str]:
+        if data_view is DataView.ORIGINAL_VALID_BAR:
+            return (
+                self.paths.original_root,
+                self.bindings["original_manifest_sha256"],
+                self.bindings["original_checksums_sha256"],
+            )
+        if data_view is DataView.CLAMP_ADMIT_V1:
+            return (
+                self.paths.derived_root,
+                self.bindings["derived_manifest_sha256"],
+                self.bindings["derived_checksums_sha256"],
+            )
+        raise PrimaryCorpusInvalid(f"unsupported primary data view:{data_view}")
+
+    def _validate_derived_manifest(self, raw: bytes) -> None:
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PrimaryCorpusInvalid(
+                "derived manifest is not strict UTF-8 JSON"
+            ) from exc
+        required = {
+            "scope": "main_only",
+            "source_corpus_id": "kr-corpus-v1",
+            "source_run_id": CORPUS_RUN_ID,
+            "source_manifest_sha256": self.bindings["original_manifest_sha256"],
+            "checksums_sha256": self.bindings["derived_checksums_sha256"],
+            "source_valid_bar_view_unchanged": True,
+        }
+        for key, expected in required.items():
+            actual = self.guard.read_metadata(payload, key)
+            if actual != expected:
+                raise PrimaryCorpusInvalid(
+                    f"derived manifest field drift:{key}:{actual!r}!={expected!r}"
+                )
+
+    @staticmethod
+    def _dataset_entries(raw: bytes) -> tuple[tuple[str, PurePosixPath], ...]:
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise PrimaryCorpusInvalid("checksum list must be UTF-8") from exc
+        entries: list[tuple[str, PurePosixPath]] = []
+        seen: set[PurePosixPath] = set()
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            try:
+                expected, raw_relative = line.split(maxsplit=1)
+            except ValueError as exc:
+                raise PrimaryCorpusInvalid("malformed checksum row") from exc
+            relative = PurePosixPath(raw_relative.lstrip("*"))
+            if relative.parts and relative.parts[0] != "dataset":
+                continue
+            if (
+                len(expected) != 64
+                or any(character not in "0123456789abcdef" for character in expected)
+                or relative.is_absolute()
+                or ".." in relative.parts
+                or relative.suffix != ".parquet"
+            ):
+                raise PrimaryCorpusInvalid(f"invalid dataset checksum row:{line}")
+            if relative in seen:
+                raise PrimaryCorpusInvalid(f"duplicate dataset checksum:{relative}")
+            seen.add(relative)
+            entries.append((expected, relative))
+        if not entries:
+            raise PrimaryCorpusInvalid("checksum list contains no dataset parquet")
+        return tuple(sorted(entries, key=lambda item: str(item[1])))
+
+    @staticmethod
+    def _partition(relative: PurePosixPath) -> tuple[str, int, str]:
+        if len(relative.parts) != 4:
+            raise PrimaryCorpusInvalid(f"unexpected dataset partition:{relative}")
+        _, market_part, year_part, ticker_part = relative.parts
+        if not market_part.startswith("market=") or not year_part.startswith("year="):
+            raise PrimaryCorpusInvalid(f"malformed dataset partition:{relative}")
+        if not ticker_part.startswith("ticker=") or not ticker_part.endswith(
+            ".parquet"
+        ):
+            raise PrimaryCorpusInvalid(f"malformed ticker partition:{relative}")
+        market = market_part.removeprefix("market=")
+        year = int(year_part.removeprefix("year="))
+        ticker = ticker_part.removeprefix("ticker=").removesuffix(".parquet")
+        if market not in {"KOSPI", "KOSDAQ"}:
+            raise PrimaryCorpusInvalid(f"unsupported market partition:{market}")
+        if year < 2015 or year > 2024:
+            raise PrimaryCorpusInvalid(f"sealed/non-exploration year partition:{year}")
+        if re.fullmatch(r"[0-9]{5}[0-9A-Z]", ticker) is None:
+            raise PrimaryCorpusInvalid(f"invalid ticker partition:{ticker}")
+        return market, year, ticker
+
+    @staticmethod
+    def _bar_from_row(
+        raw: dict[str, Any],
+        *,
+        partition: tuple[str, int, str],
+        data_view: DataView,
+        market_positions: dict[date, int],
+        market_sessions: tuple[date, ...],
+    ) -> tuple[CorpusBar, ClampRow | None]:
+        market, year, ticker = partition
+        try:
+            session = date.fromisoformat(str(raw["session"]))
+            row_market = str(raw["market"])
+            row_ticker = str(raw["ticker"])
+            open_price = int(raw["open"])
+            high = int(raw["high"])
+            low = int(raw["low"])
+            close = int(raw["close"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PrimaryCorpusInvalid("invalid corpus parquet row") from exc
+        if (row_market, session.year, row_ticker) != (market, year, ticker):
+            raise PrimaryCorpusInvalid("parquet row/partition identity mismatch")
+        session_position = market_positions.get(session)
+        if session_position is None:
+            raise PrimaryCorpusInvalid(f"bar outside frozen XKRX axis:{session}")
+        session = market_sessions[session_position]
+        if min(open_price, high, low, close) <= 0:
+            raise PrimaryCorpusInvalid("bar prices must be positive")
+        if low > min(open_price, close) or high < max(open_price, close):
+            raise PrimaryCorpusInvalid("bar OHLC ordering invalid")
+        bar = CorpusBar(
+            session=session,
+            symbol=ticker,
+            market=market,
+            open_int=open_price,
+            high_int=high,
+            low_int=low,
+            close_int=close,
+        )
+        if data_view is DataView.ORIGINAL_VALID_BAR or not bool(raw["clamped"]):
+            return bar, None
+        clamp = ClampRow(
+            market=market,
+            session=session,
+            symbol=ticker,
+            source_high=int(raw["source_high"]),
+            source_low=int(raw["source_low"]),
+            high=high,
+            low=low,
+            delta_high=int(raw["clamp_delta_high"]),
+            delta_low=int(raw["clamp_delta_low"]),
+            classification=str(raw["clamp_classification"]),
+            admitted=bool(raw["admitted"]),
+        )
+        if not clamp.admitted or max(clamp.delta_high, clamp.delta_low) <= 0:
+            raise PrimaryCorpusInvalid("clamped row lacks admitted positive delta")
+        return bar, clamp
+
+
+def _sha256_stream(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_parquet_rows(path: Path, data_view: DataView) -> list[dict[str, Any]]:
+    import pyarrow.parquet as pq
+
+    columns = list(_BASE_COLUMNS)
+    if data_view is DataView.CLAMP_ADMIT_V1:
+        columns.extend(_CLAMP_COLUMNS)
+    table = pq.ParquetFile(path).read(columns=columns)
+    if table.column_names != columns:
+        raise PrimaryCorpusInvalid(f"parquet schema drift:{path.name}")
+    return table.to_pylist()
+
+
+def _prepare_signal_tape(
+    by_symbol: dict[str, list[CorpusBar]],
+    session_positions: dict[date, int],
+) -> dict[tuple[date, str], SignalSnapshot]:
+    signals: dict[tuple[date, str], SignalSnapshot] = {}
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        context.rounding = DECIMAL_ROUNDING
+        for symbol, unordered in sorted(by_symbol.items()):
+            bars = sorted(unordered, key=lambda item: item.session)
+            window: deque[CorpusBar] = deque(maxlen=120)
+            wilder = _WilderState()
+            previous_position: int | None = None
+            for bar in bars:
+                position = session_positions[bar.session]
+                if previous_position is not None and position != previous_position + 1:
+                    window.clear()
+                    wilder = _WilderState()
+                if len(window) == 120 and wilder.value is not None:
+                    rounded_rsi = wilder.value.quantize(
+                        Decimal("0.0001"), rounding=DECIMAL_ROUNDING
+                    )
+                    if rounded_rsi < RSI_THRESHOLD:
+                        prior_closes = tuple(Decimal(item.close_int) for item in window)
+                        bands = bollinger_bands(prior_closes)
+                        high = Decimal(max(item.high_int for item in window))
+                        low = Decimal(min(item.low_int for item in window))
+                        previous_close = prior_closes[-1]
+                        levels = [
+                            PriceLevel(price, "fib_family", f"fib_{ratio}")
+                            for ratio, price in fib_levels(low, high).items()
+                        ]
+                        levels.append(PriceLevel(bands.lower, "bb_lower", "bb_lower"))
+                        clusters = cluster_levels(levels, close=previous_close)
+                        if signal_is_eligible(
+                            rsi=rounded_rsi,
+                            clusters=clusters,
+                            close=previous_close,
+                        ):
+                            l2 = choose_l2(clusters, close=previous_close)
+                            if l2 is None:
+                                raise AssertionError("eligible primary signal lacks L2")
+                            signals[(bar.session, symbol)] = SignalSnapshot(
+                                rsi=rounded_rsi,
+                                l2_price=l2.representative,
+                                fib_high=high,
+                                fib_low=low,
+                                previous_close=previous_close,
+                            )
+                wilder.add(bar.close_int)
+                window.append(bar)
+                previous_position = position
+    return signals
+
+
+def _signal_tape_sha(
+    signals: dict[tuple[date, str], SignalSnapshot],
+) -> str:
+    digest = hashlib.sha256()
+    for (session, symbol), snapshot in sorted(signals.items()):
+        digest.update(
+            canonical_bytes(
+                {
+                    "session": session,
+                    "symbol": symbol,
+                    "rsi": snapshot.rsi,
+                    "l2_price": snapshot.l2_price,
+                    "fib_high": snapshot.fib_high,
+                    "fib_low": snapshot.fib_low,
+                    "previous_close": snapshot.previous_close,
+                }
+            )
+        )
+    return digest.hexdigest()
+
+
+def _market_periods(
+    bars: list[CorpusBar],
+) -> tuple[tuple[date, date, str], ...]:
+    periods: list[tuple[date, date, str]] = []
+    start = bars[0].session
+    end = start
+    market = bars[0].market
+    for bar in bars[1:]:
+        if bar.market != market:
+            periods.append((start, end, market))
+            start = bar.session
+            market = bar.market
+        end = bar.session
+    periods.append((start, end, market))
+    return tuple(periods)
+
+
+def market_for(view: LoadedCorpusView, *, symbol: str, session: date) -> str | None:
+    for start, end, market in view.market_periods.get(symbol, ()):
+        if start <= session <= end:
+            return market
+    return None

--- a/research/kr_corpus/d3_engine/signals.py
+++ b/research/kr_corpus/d3_engine/signals.py
@@ -164,7 +164,19 @@ def rank_candidates(
     )
     additions = [item for item in ordered if item.is_add]
     new_entries = [item for item in ordered if not item.is_add][:max_new]
-    return tuple(additions + new_entries)
+    selected = additions + new_entries
+    signal_ranks = {id(item): rank for rank, item in enumerate(ordered, start=1)}
+    return tuple(
+        sorted(
+            selected,
+            key=lambda item: order_class_sort_key(
+                is_add=item.is_add,
+                signal_rank=signal_ranks[id(item)],
+                symbol=item.symbol,
+                rung="L1",
+            ),
+        )
+    )
 
 
 def order_class_sort_key(

--- a/research/kr_corpus/d3_engine/sources.py
+++ b/research/kr_corpus/d3_engine/sources.py
@@ -58,6 +58,10 @@ def verify_start_gate(paths: ArtifactPaths) -> tuple[dict[str, str], ...]:
             paths.golden_root / "checksums.sha256",
             CONTRACT_SHA256["checksums.sha256"],
         ),
+        (
+            paths.amendment_a1,
+            CONTRACT_SHA256["d3-amendment-a1-20260807.md"],
+        ),
     )
     results: list[dict[str, str]] = []
     for path, expected in targets:

--- a/scripts/run_d3_primary.py
+++ b/scripts/run_d3_primary.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Execute the frozen D3-R1 16-physical primary matrix."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+
+from research.kr_corpus.d3_engine.canonical import canonical_bytes
+from research.kr_corpus.d3_engine.primary import (
+    PrimaryHarnessPaths,
+    PrimaryRunHarness,
+)
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ("git", *args),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path)
+    parser.add_argument("--progress-report", type=Path)
+    parser.add_argument(
+        "--harness-commit",
+        help="full committed SHA of this harness (default: current HEAD)",
+    )
+    args = parser.parse_args()
+
+    head = _git("rev-parse", "HEAD")
+    harness_commit = args.harness_commit or head
+    if harness_commit != head:
+        parser.error(f"--harness-commit {harness_commit} does not match HEAD {head}")
+    if _git("status", "--porcelain"):
+        parser.error(
+            "repository must be clean so the stamped commit identifies the code"
+        )
+
+    paths = PrimaryHarnessPaths.defaults()
+    paths = replace(
+        paths,
+        output_root=args.output_root or paths.output_root,
+        progress_report=args.progress_report or paths.progress_report,
+    )
+    result = PrimaryRunHarness(
+        harness_commit=harness_commit,
+        paths=paths,
+    ).run_all()
+    print(canonical_bytes(result).decode("utf-8"), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/kr_corpus/d3_engine/test_d3_engine_acceptance.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_engine_acceptance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from pathlib import Path
 
 import pytest
 
@@ -18,6 +19,7 @@ _REQUIRED = (
     _PATHS.golden_root / "CONTRACT.md",
     _PATHS.golden_root / "provenance.json",
     _PATHS.golden_root / "checksums.sha256",
+    _PATHS.amendment_a1,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -26,10 +28,14 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_d3_e1_full_local_acceptance() -> None:
-    result = run_acceptance()
+def test_d3_e1_full_local_acceptance(tmp_path: Path) -> None:
+    result = run_acceptance(primary_artifact_root=tmp_path / "not-executed")
 
-    assert result["sha_gate"]["passed"] == 9
+    assert result["sha_gate"] == {
+        "passed": 10,
+        "total": 10,
+        "rows": result["sha_gate"]["rows"],
+    }
     assert result["golden_files"] == {
         "vectors": 33,
         "expected": 33,
@@ -62,4 +68,5 @@ def test_d3_e1_full_local_acceptance() -> None:
     assert result["fib_window_excludes_t"] is True
     assert result["tick_source"]["source"] == "krx_tick_table_frozen.yaml"
     assert result["tick_source"]["python_import_count"] == 0
+    assert result["primary_run"]["reason"] == "manifest_missing"
     assert result["primary_run_executed"] is False

--- a/tests/research/kr_corpus/d3_engine/test_d3_engine_core.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_engine_core.py
@@ -481,6 +481,49 @@ def test_resistance_sell_orders_remain_available_for_c3_armed_position() -> None
     ]
 
 
+def test_resistance_orders_are_exact_with_only_the_required_121_bar_tail() -> None:
+    ticks = _sealed_tick_shape()
+    engine = PortfolioEngine(ticks)
+    sessions = [date(2014, 1, 1) + timedelta(days=index) for index in range(221)]
+    prefix = [
+        Bar(
+            session=session,
+            symbol="RESIST",
+            open=Decimal(5000),
+            high=Decimal(6000),
+            low=Decimal(4000),
+            close=Decimal(5000),
+        )
+        for session in sessions[:100]
+    ]
+    full = prefix + _resistance_probe_bars(sessions[100:])
+    position = Position(
+        symbol="RESIST",
+        quantity=10,
+        average_price=Decimal(9000),
+        invested_cost_basis=Decimal(90000),
+    )
+
+    full_orders = engine._resistance_orders(
+        symbol="RESIST",
+        session=sessions[-1],
+        history=full,
+        index=220,
+        position=position,
+        first_order_number=7,
+    )
+    tail_orders = engine._resistance_orders(
+        symbol="RESIST",
+        session=sessions[-1],
+        history=full[-121:],
+        index=120,
+        position=position,
+        first_order_number=7,
+    )
+
+    assert full_orders == tail_orders
+
+
 def test_day_order_expiry_returns_cash_and_c1_reservation() -> None:
     engine = PortfolioEngine(_sealed_tick_shape())
     session = date(2014, 1, 2)

--- a/tests/research/kr_corpus/d3_engine/test_d3_engine_core.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_engine_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import inspect
 from collections import defaultdict
 from datetime import date, timedelta
 from decimal import Decimal
@@ -9,6 +10,8 @@ from pathlib import Path
 import pytest
 
 from research.kr_corpus.d3_engine import engine as engine_module
+from research.kr_corpus.d3_engine import golden as golden_module
+from research.kr_corpus.d3_engine import signals as signals_module
 from research.kr_corpus.d3_engine.acceptance import (
     _contract_signal_bars,
     _resistance_probe_bars,
@@ -21,6 +24,7 @@ from research.kr_corpus.d3_engine.guards import (
     SealedAccessSpy,
 )
 from research.kr_corpus.d3_engine.indicators import OhlcPoint, scan_fib_window
+from research.kr_corpus.d3_engine.metrics import twr_returns
 from research.kr_corpus.d3_engine.models import (
     Arm,
     Bar,
@@ -38,6 +42,7 @@ from research.kr_corpus.d3_engine.policies import (
     c3_buy_suppressed,
     update_c3_close,
 )
+from research.kr_corpus.d3_engine.signals import SignalCandidate
 from research.kr_corpus.d3_engine.tick import (
     InvalidTickTable,
     TickTable,
@@ -76,6 +81,53 @@ def test_fib_window_is_prior_120_and_excludes_t() -> None:
     assert window.excluded_index == 120
     assert window.high == Decimal("120")
     assert window.low == Decimal("80")
+
+
+def test_v026_engine_candidate_publication_calls_frozen_order_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[bool, int, str, str]] = []
+    original = signals_module.order_class_sort_key
+
+    def recording_key(
+        *, is_add: bool, signal_rank: int, symbol: str, rung: str
+    ) -> tuple[int, int, str, int]:
+        calls.append((is_add, signal_rank, symbol, rung))
+        return original(
+            is_add=is_add,
+            signal_rank=signal_rank,
+            symbol=symbol,
+            rung=rung,
+        )
+
+    monkeypatch.setattr(signals_module, "order_class_sort_key", recording_key)
+    candidates = (
+        SignalCandidate("NEW", Decimal(10), Decimal("0.04"), Decimal(100), False),
+        SignalCandidate("ADD", Decimal(20), Decimal("0.05"), Decimal(90), True),
+    )
+
+    ranked = signals_module.rank_candidates(candidates)
+
+    assert [candidate.symbol for candidate in ranked] == ["ADD", "NEW"]
+    assert calls == [(True, 2, "ADD", "L1"), (False, 1, "NEW", "L1")]
+
+
+def test_v028_fee_golden_uses_the_single_engine_cost_path() -> None:
+    source = inspect.getsource(golden_module._v028)
+
+    assert "fee_amount(gross)" in source
+    assert "round_trip_basis_points()" in source
+    assert 'Decimal("0.00215")' not in source
+
+
+def test_twr_total_loss_is_represented_as_minus_one() -> None:
+    cumulative, annualized = twr_returns(
+        start_unit_price=Decimal(1),
+        end_unit_price=Decimal(0),
+        calendar_days=Decimal("365.2425"),
+    )
+
+    assert cumulative == annualized == Decimal(-1)
 
 
 def test_tick_table_rejects_gap_and_overlap() -> None:
@@ -369,7 +421,7 @@ def test_all_four_arms_execute_natural_contract_signal(arm: Arm) -> None:
     assert result.metrics["signals_submitted"] == 2
     assert result.metrics["terminal_nav"] == Decimal("10020402.57250")
     assert result.evidence["sealed_access_spy"] == 0
-    assert result.evidence["primary_run_executed"] is False
+    assert "primary_run_executed" not in result.evidence
 
 
 def test_sell_fill_and_unitized_mdd_contract_paths() -> None:

--- a/tests/research/kr_corpus/d3_engine/test_d3_primary.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_primary.py
@@ -23,6 +23,7 @@ from research.kr_corpus.d3_engine.indicators import rsi_wilder
 from research.kr_corpus.d3_engine.models import Arm, CashflowView, DataView
 from research.kr_corpus.d3_engine.primary import (
     PhysicalRun,
+    PrimaryPortfolioEngine,
     PrimaryRunInvalid,
     _funding_p05,
     _seal_determinism,
@@ -176,6 +177,19 @@ def test_precomputed_signal_tape_is_exact_engine_equivalent() -> None:
         )
         assert actual == expected
     assert len(tape) == 1
+
+
+def test_primary_signal_history_projection_keeps_exact_prior_120_and_t() -> None:
+    bars = list(range(300))
+
+    assert (
+        PrimaryPortfolioEngine._signal_history(bars, index=250, segment_start=17)
+        == bars[130:251]
+    )
+    assert (
+        PrimaryPortfolioEngine._signal_history(bars, index=40, segment_start=17)
+        == bars[17:41]
+    )
 
 
 def test_signal_tape_resets_at_missing_xkrx_session() -> None:

--- a/tests/research/kr_corpus/d3_engine/test_d3_primary.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_primary.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, timedelta
+from decimal import Decimal, localcontext
+from pathlib import Path, PurePosixPath
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from research.kr_corpus.d3_engine.acceptance import _contract_signal_bars
+from research.kr_corpus.d3_engine.canonical import canonical_bytes
+from research.kr_corpus.d3_engine.constants import DECIMAL_PRECISION, DECIMAL_ROUNDING
+from research.kr_corpus.d3_engine.engine import PortfolioEngine
+from research.kr_corpus.d3_engine.guards import (
+    SealedAccessBlocked,
+    SealedAccessGuard,
+    SealedAccessSpy,
+)
+from research.kr_corpus.d3_engine.indicators import rsi_wilder
+from research.kr_corpus.d3_engine.models import Arm, CashflowView, DataView
+from research.kr_corpus.d3_engine.primary import (
+    PhysicalRun,
+    PrimaryRunInvalid,
+    _funding_p05,
+    _seal_determinism,
+    measure_primary_run_executed,
+    primary_matrix,
+)
+from research.kr_corpus.d3_engine.primary_corpus import (
+    CORPUS_RUN_ID,
+    CorpusBar,
+    PrimaryCorpusLoader,
+    PrimaryCorpusPaths,
+    _prepare_signal_tape,
+    _WilderState,
+)
+from research.kr_corpus.d3_engine.tick import TickTable
+
+
+def _ticks() -> TickTable:
+    return TickTable.from_mapping(
+        {
+            "schema_version": "d3.krx_tick_table.v1",
+            "bands": [
+                {"lower_inclusive": 0, "upper_exclusive": 2000, "tick": 1},
+                {"lower_inclusive": 2000, "upper_exclusive": 5000, "tick": 5},
+                {"lower_inclusive": 5000, "upper_exclusive": 20000, "tick": 10},
+                {"lower_inclusive": 20000, "upper_exclusive": 50000, "tick": 50},
+                {
+                    "lower_inclusive": 50000,
+                    "upper_exclusive": 200000,
+                    "tick": 100,
+                },
+                {
+                    "lower_inclusive": 200000,
+                    "upper_exclusive": 500000,
+                    "tick": 500,
+                },
+                {"lower_inclusive": 500000, "upper_exclusive": None, "tick": 1000},
+            ],
+        }
+    )
+
+
+def _corpus_bar(raw: object, *, market: str = "KOSPI") -> CorpusBar:
+    return CorpusBar(
+        session=raw.session,  # type: ignore[attr-defined]
+        symbol=raw.symbol,  # type: ignore[attr-defined]
+        market=market,
+        open_int=int(raw.open),  # type: ignore[attr-defined]
+        high_int=int(raw.high),  # type: ignore[attr-defined]
+        low_int=int(raw.low),  # type: ignore[attr-defined]
+        close_int=int(raw.close),  # type: ignore[attr-defined]
+    )
+
+
+def test_primary_matrix_is_exactly_four_by_two_by_two() -> None:
+    matrix = primary_matrix()
+
+    assert len(matrix) == 16
+    assert len({run.run_id for run in matrix}) == 16
+    assert {run.arm for run in matrix} == set(Arm)
+    assert {run.cashflow_view for run in matrix} == set(CashflowView)
+    assert {run.data_view for run in matrix} == {
+        DataView.ORIGINAL_VALID_BAR,
+        DataView.CLAMP_ADMIT_V1,
+    }
+    assert len({(run.arm, run.cashflow_view) for run in matrix}) == 8
+
+
+def test_corpus_partition_accepts_frozen_krx_alphanumeric_issue_codes() -> None:
+    assert PrimaryCorpusLoader._partition(
+        PurePosixPath("dataset/market=KOSPI/year=2024/ticker=08537M.parquet")
+    ) == ("KOSPI", 2024, "08537M")
+
+
+def test_funding_p05_replays_without_future_contribution() -> None:
+    daily = [
+        {
+            "session": date(2015, 1, 31),
+            "session_index": 0,
+            "settled_orderable_cash": Decimal(100),
+            "reserved_orders": [],
+            "buy_payables": [],
+            "sell_receivables": [],
+        },
+        {
+            "session": date(2015, 3, 1),
+            "session_index": 1,
+            "settled_orderable_cash": Decimal(600),
+            "reserved_orders": [],
+            "buy_payables": [],
+            "sell_receivables": [],
+        },
+        {
+            "session": date(2015, 5, 1),
+            "session_index": 2,
+            "settled_orderable_cash": Decimal(600),
+            "reserved_orders": [],
+            "buy_payables": [],
+            "sell_receivables": [],
+        },
+    ]
+    events = [
+        {
+            "event": "monthly_contribution_pre_open",
+            "session": date(2015, 3, 1),
+            "amount": Decimal(1000),
+        },
+        {
+            "event": "order_submitted",
+            "session": date(2015, 3, 1),
+            "order_id": "BUY-1",
+            "symbol": "005930",
+            "side": "buy",
+            "class": "new",
+            "rung": "L1",
+            "limit": Decimal(500),
+            "quantity": 1,
+        },
+    ]
+
+    result = _funding_p05(daily, events)
+
+    assert result["p05_days"] == 29
+    assert result["complete_anchor_count"] == 1
+    assert result["right_censored_anchor_count"] == 2
+    assert result["anchors"][0]["first_cash_reject"] == date(2015, 3, 1)
+    assert result["anchors"][0]["missed_notional_at_first_reject"] == Decimal(500)
+
+
+def test_precomputed_signal_tape_is_exact_engine_equivalent() -> None:
+    sessions = tuple(date(2015, 1, 1) + timedelta(days=index) for index in range(121))
+    raw_bars = _contract_signal_bars(list(sessions), symbols=("005930",))
+    bars = [_corpus_bar(raw) for raw in raw_bars]
+    positions = {session: index for index, session in enumerate(sessions)}
+
+    tape = _prepare_signal_tape({"005930": bars}, positions)
+    engine = PortfolioEngine(_ticks())
+
+    for index, bar in enumerate(bars):
+        expected = engine._signal_for_session(bars, index)  # type: ignore[arg-type]
+        snapshot = tape.get((bar.session, bar.symbol))
+        actual = (
+            None
+            if snapshot is None
+            else (
+                snapshot.rsi,
+                snapshot.l2_price,
+                snapshot.fib_high,
+                snapshot.fib_low,
+            )
+        )
+        assert actual == expected
+    assert len(tape) == 1
+
+
+def test_signal_tape_resets_at_missing_xkrx_session() -> None:
+    sessions = tuple(date(2015, 1, 1) + timedelta(days=index) for index in range(260))
+    present = sessions[:121] + sessions[122:]
+    bars = [
+        CorpusBar(
+            session=session,
+            symbol="005930",
+            market="KOSPI",
+            open_int=10_000,
+            high_int=10_100,
+            low_int=9_900,
+            close_int=10_000 - (index % 50),
+        )
+        for index, session in enumerate(present)
+    ]
+    positions = {session: index for index, session in enumerate(sessions)}
+
+    tape = _prepare_signal_tape({"005930": bars}, positions)
+
+    assert not any(sessions[122] <= session <= sessions[241] for session, _ in tape)
+
+
+def test_incremental_wilder_state_is_exact_for_long_variable_history() -> None:
+    closes = [10_000 + ((index * 97) % 701) - index for index in range(400)]
+    state = _WilderState()
+    seen: list[Decimal] = []
+
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        context.rounding = DECIMAL_ROUNDING
+        for close in closes:
+            expected = rsi_wilder(seen)[-1] if seen else None
+            assert state.value == expected
+            state.add(close)
+            seen.append(Decimal(close))
+
+
+def _write_corpus_view(
+    root: Path,
+    *,
+    data_view: DataView,
+    session: str = "2015-01-02",
+) -> tuple[str, str]:
+    relative = Path("dataset/market=KOSPI/year=2015/ticker=005930.parquet")
+    path = root / relative
+    path.parent.mkdir(parents=True)
+    row: dict[str, object] = {
+        "session": session,
+        "market": "KOSPI",
+        "ticker": "005930",
+        "open": 100,
+        "high": 103,
+        "low": 98,
+        "close": 101,
+    }
+    if data_view is DataView.CLAMP_ADMIT_V1:
+        row.update(
+            {
+                "source_high": 105,
+                "source_low": 96,
+                "clamped": True,
+                "clamp_delta_high": 2,
+                "clamp_delta_low": 2,
+                "clamp_classification": "both",
+                "admitted": True,
+            }
+        )
+    pq.write_table(pa.Table.from_pylist([row]), path)
+    parquet_sha = hashlib.sha256(path.read_bytes()).hexdigest()
+    checksums_raw = f"{parquet_sha}  {relative.as_posix()}\n".encode()
+    (root / "checksums.sha256").write_bytes(checksums_raw)
+    checksums_sha = hashlib.sha256(checksums_raw).hexdigest()
+    manifest: dict[str, object] = {"scope": "main_only"}
+    if data_view is DataView.CLAMP_ADMIT_V1:
+        manifest.update(
+            {
+                "source_corpus_id": "kr-corpus-v1",
+                "source_run_id": CORPUS_RUN_ID,
+                "source_manifest_sha256": "ORIGINAL_MANIFEST_SHA",
+                "checksums_sha256": checksums_sha,
+                "source_valid_bar_view_unchanged": True,
+            }
+        )
+    manifest_raw = canonical_bytes(manifest)
+    (root / "manifest.json").write_bytes(manifest_raw)
+    return hashlib.sha256(manifest_raw).hexdigest(), checksums_sha
+
+
+def test_loader_measures_actual_safe_manifest_parquet_bar_and_metadata_reads(
+    tmp_path: Path,
+) -> None:
+    original_root = tmp_path / "kr-corpus-main"
+    derived_root = tmp_path / "derived-views" / "clamp-admit-v1"
+    original_manifest, original_checksums = _write_corpus_view(
+        original_root,
+        data_view=DataView.ORIGINAL_VALID_BAR,
+    )
+    derived_manifest, derived_checksums = _write_corpus_view(
+        derived_root,
+        data_view=DataView.CLAMP_ADMIT_V1,
+    )
+    derived_payload = json.loads((derived_root / "manifest.json").read_bytes())
+    derived_payload["source_manifest_sha256"] = original_manifest
+    derived_raw = canonical_bytes(derived_payload)
+    (derived_root / "manifest.json").write_bytes(derived_raw)
+    derived_manifest = hashlib.sha256(derived_raw).hexdigest()
+    spy = SealedAccessSpy()
+    loader = PrimaryCorpusLoader(
+        paths=PrimaryCorpusPaths(original_root, derived_root),
+        guard=SealedAccessGuard(spy),
+        bindings={
+            "original_manifest_sha256": original_manifest,
+            "original_checksums_sha256": original_checksums,
+            "derived_manifest_sha256": derived_manifest,
+            "derived_checksums_sha256": derived_checksums,
+        },
+        expected_rows={
+            DataView.ORIGINAL_VALID_BAR: 1,
+            DataView.CLAMP_ADMIT_V1: 1,
+        },
+    )
+    sessions = (date(2015, 1, 2),)
+
+    original = loader.load(DataView.ORIGINAL_VALID_BAR, market_sessions=sessions)
+    clamp = loader.load(DataView.CLAMP_ADMIT_V1, market_sessions=sessions)
+
+    assert original.row_count == clamp.row_count == 1
+    assert len(clamp.clamp_rows) == 1
+    assert spy.evidence() == {
+        "sealed_access_spy": 0,
+        "sealed_access_blocked_attempts": 0,
+        "sealed_access_path_checks": 8,
+        "sealed_access_date_checks": 2,
+        "sealed_access_metadata_key_checks": 6,
+        "measured_file_reads": 8,
+        "measured_manifest_reads": 2,
+        "measured_parquet_reads": 2,
+        "measured_bar_rows_read": 2,
+        "measured_metadata_key_reads": 6,
+        "sealed_file_reads": 0,
+        "sealed_manifest_reads": 0,
+        "sealed_parquet_reads": 0,
+        "sealed_bar_rows_read": 0,
+        "sealed_metadata_key_reads": 0,
+    }
+
+
+def test_loader_blocks_sealed_root_before_manifest_read(tmp_path: Path) -> None:
+    sealed = tmp_path / "holdout" / "corpus"
+    (sealed / "dataset").mkdir(parents=True)
+    (sealed / "manifest.json").write_bytes(b"{}")
+    (sealed / "checksums.sha256").write_bytes(b"")
+    spy = SealedAccessSpy()
+    loader = PrimaryCorpusLoader(
+        paths=PrimaryCorpusPaths(sealed, sealed),
+        guard=SealedAccessGuard(spy),
+        bindings={
+            "original_manifest_sha256": "0" * 64,
+            "original_checksums_sha256": "0" * 64,
+            "derived_manifest_sha256": "0" * 64,
+            "derived_checksums_sha256": "0" * 64,
+        },
+        expected_rows={
+            DataView.ORIGINAL_VALID_BAR: 0,
+            DataView.CLAMP_ADMIT_V1: 0,
+        },
+    )
+
+    with pytest.raises(SealedAccessBlocked):
+        loader.load(
+            DataView.ORIGINAL_VALID_BAR,
+            market_sessions=(date(2015, 1, 2),),
+        )
+
+    assert spy.sealed_reads == 0
+    assert spy.blocked_attempts == 1
+    assert spy.actual_file_reads == 0
+
+
+def test_loader_counts_a_decoded_sealed_bar_as_actual_access(tmp_path: Path) -> None:
+    root = tmp_path / "safe-named-main"
+    manifest, checksums = _write_corpus_view(
+        root,
+        data_view=DataView.ORIGINAL_VALID_BAR,
+        session="2025-01-02",
+    )
+    spy = SealedAccessSpy()
+    loader = PrimaryCorpusLoader(
+        paths=PrimaryCorpusPaths(root, root),
+        guard=SealedAccessGuard(spy),
+        bindings={
+            "original_manifest_sha256": manifest,
+            "original_checksums_sha256": checksums,
+            "derived_manifest_sha256": manifest,
+            "derived_checksums_sha256": checksums,
+        },
+        expected_rows={
+            DataView.ORIGINAL_VALID_BAR: 1,
+            DataView.CLAMP_ADMIT_V1: 1,
+        },
+    )
+
+    with pytest.raises(SealedAccessBlocked, match="sealed bar date observed"):
+        loader.load(
+            DataView.ORIGINAL_VALID_BAR,
+            market_sessions=(date(2025, 1, 2),),
+        )
+
+    assert spy.sealed_reads == 1
+    assert spy.sealed_bar_rows_read == 1
+    assert spy.parquet_reads == 1
+
+
+def test_primary_run_measurement_is_derived_from_all_verified_bundles(
+    tmp_path: Path,
+) -> None:
+    completed: list[dict[str, object]] = []
+    for physical in primary_matrix():
+        base = {
+            "payload.json": canonical_bytes(
+                {
+                    "schema_version": "d3.primary_run.v1",
+                    "artifact_kind": "payload",
+                    "run_id": physical.run_id,
+                    "stamps": {},
+                    "rows": [],
+                }
+            )
+        }
+        base["run.json"] = canonical_bytes(
+            {
+                "schema_version": "d3.primary_run.v1",
+                "artifact_kind": "physical_run",
+                "run_id": physical.run_id,
+                "stamps": {},
+                "content_checksums": {
+                    "payload.json": hashlib.sha256(base["payload.json"]).hexdigest()
+                },
+                "engine_invocations": 1,
+                "physical_run_completed": True,
+            }
+        )
+        bundle = _seal_determinism(
+            physical=physical,
+            first=base,
+            second=dict(base),
+            stamps={},
+        )
+        run_root = tmp_path / "runs" / physical.run_id
+        run_root.mkdir(parents=True)
+        for name, raw in bundle.items():
+            (run_root / name).write_bytes(raw)
+        run_raw = bundle["run.json"]
+        completed.append(
+            {
+                "run_id": physical.run_id,
+                "arm": physical.arm.value,
+                "cashflow_view": physical.cashflow_view.value,
+                "data_view": physical.data_view.value,
+                "deterministic_2runs": True,
+                "run_json_sha256": hashlib.sha256(run_raw).hexdigest(),
+                "bundle_sha256": _bundle_sha_for_test(bundle),
+            }
+        )
+    manifest = {
+        "matrix": {
+            "physical_runs": 16,
+            "deterministic_2runs": 16,
+            "runs": completed,
+        }
+    }
+    (tmp_path / "manifest.json").write_bytes(canonical_bytes(manifest))
+
+    measured = measure_primary_run_executed(tmp_path)
+
+    assert measured == {
+        "primary_run_executed": True,
+        "reason": "artifact_derived",
+        "physical_runs": 16,
+        "verified_engine_runs": 16,
+        "expected_matrix_match": True,
+    }
+
+    corrupted = tmp_path / "runs" / primary_matrix()[0].run_id / "payload.json"
+    corrupted.write_bytes(b"corrupt")
+    assert measure_primary_run_executed(tmp_path)["primary_run_executed"] is False
+
+
+def _bundle_sha_for_test(bundle: dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for name, raw in sorted(bundle.items()):
+        digest.update(name.encode())
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(raw).digest())
+    return digest.hexdigest()
+
+
+def test_determinism_seal_rejects_mismatched_attempts() -> None:
+    physical = PhysicalRun(
+        Arm.B0,
+        CashflowView.NO_CONTRIBUTION,
+        DataView.ORIGINAL_VALID_BAR,
+    )
+
+    with pytest.raises(PrimaryRunInvalid, match="non-deterministic bundle"):
+        _seal_determinism(
+            physical=physical,
+            first={"run.json": b"{}"},
+            second={"run.json": b'{"different":true}'},
+            stamps={},
+        )

--- a/tests/services/brokers/binance/test_ingest.py
+++ b/tests/services/brokers/binance/test_ingest.py
@@ -17,7 +17,7 @@ from app.services.brokers.binance.ws_client import KlineEvent
 
 def _mk_event(
     *,
-    symbol: str = "BTCUSDT",
+    symbol: str = "ROB285INGESTBTCUSDT",
     open_time: dt.datetime | None = None,
     is_closed: bool = True,
 ) -> KlineEvent:
@@ -47,7 +47,7 @@ async def test_ingest_closed_kline_persists_via_repository(
     inst = CryptoInstrument(
         venue="binance",
         product="spot",
-        venue_symbol="BTCUSDT",
+        venue_symbol="ROB285INGESTBTCUSDT",
         base_asset="BTC",
         quote_asset="USDT",
         status="active",
@@ -55,7 +55,7 @@ async def test_ingest_closed_kline_persists_via_repository(
     db_session.add(inst)
     await db_session.flush()
     ingester = BinanceCandleIngester(session=db_session)
-    persisted = await ingester.ingest(_mk_event(symbol="BTCUSDT"))
+    persisted = await ingester.ingest(_mk_event(symbol="ROB285INGESTBTCUSDT"))
     assert persisted is True
     row = (
         await db_session.execute(
@@ -91,7 +91,7 @@ async def test_ingest_idempotent_upsert(db_session: AsyncSession) -> None:
     inst = CryptoInstrument(
         venue="binance",
         product="spot",
-        venue_symbol="ETHUSDT",
+        venue_symbol="ROB285INGESTETHUSDT",
         base_asset="ETH",
         quote_asset="USDT",
         status="active",
@@ -99,7 +99,7 @@ async def test_ingest_idempotent_upsert(db_session: AsyncSession) -> None:
     db_session.add(inst)
     await db_session.flush()
     ingester = BinanceCandleIngester(session=db_session)
-    event = _mk_event(symbol="ETHUSDT")
+    event = _mk_event(symbol="ROB285INGESTETHUSDT")
     assert await ingester.ingest(event) is True
     assert await ingester.ingest(event) is True
     count = (
@@ -117,7 +117,9 @@ async def test_ingest_drops_in_progress_kline_defensively(
 ) -> None:
     """Even if a caller forgets to filter, the ingester drops non-closed klines."""
     ingester = BinanceCandleIngester(session=db_session)
-    persisted = await ingester.ingest(_mk_event(symbol="BTCUSDT", is_closed=False))
+    persisted = await ingester.ingest(
+        _mk_event(symbol="ROB285INGESTBTCUSDT", is_closed=False)
+    )
     assert persisted is False
 
 
@@ -129,7 +131,7 @@ async def test_ingest_caches_instrument_id_across_calls(
     inst = CryptoInstrument(
         venue="binance",
         product="spot",
-        venue_symbol="SOLUSDT",
+        venue_symbol="ROB285INGESTSOLUSDT",
         base_asset="SOL",
         quote_asset="USDT",
         status="active",
@@ -138,7 +140,7 @@ async def test_ingest_caches_instrument_id_across_calls(
     await db_session.flush()
     ingester = BinanceCandleIngester(session=db_session)
     # First call populates the cache.
-    await ingester.ingest(_mk_event(symbol="SOLUSDT"))
-    assert "SOLUSDT" in ingester._cache  # noqa: SLF001 — testing internal cache
-    cached_id = ingester._cache["SOLUSDT"]
+    await ingester.ingest(_mk_event(symbol="ROB285INGESTSOLUSDT"))
+    assert "ROB285INGESTSOLUSDT" in ingester._cache  # noqa: SLF001 — testing internal cache
+    cached_id = ingester._cache["ROB285INGESTSOLUSDT"]
     assert cached_id == inst.id

--- a/tests/services/daily_candles/test_crypto_candles_1d_migration.py
+++ b/tests/services/daily_candles/test_crypto_candles_1d_migration.py
@@ -183,7 +183,7 @@ async def test_daily_candle_orm_roundtrip(db_session: AsyncSession) -> None:
     inst = CryptoInstrument(
         venue="binance",
         product="spot",
-        venue_symbol="ETHUSDT",
+        venue_symbol="ROB2841DORMETHUSDT",
         base_asset="ETH",
         quote_asset="USDT",
         status="active",

--- a/tests/services/daily_candles/test_crypto_candles_1m.py
+++ b/tests/services/daily_candles/test_crypto_candles_1m.py
@@ -96,7 +96,7 @@ async def test_minute_repository_idempotent_upsert(db_session: AsyncSession) -> 
     inst = CryptoInstrument(
         venue="binance",
         product="spot",
-        venue_symbol="BTCUSDT",
+        venue_symbol="ROB284IDEMBTCUSDT",
         base_asset="BTC",
         quote_asset="USDT",
         status="active",
@@ -143,8 +143,8 @@ async def test_cross_venue_same_bucket_coexistence(db_session: AsyncSession) -> 
 
     instruments = [
         ("upbit", "spot", "KRW-BTC-COEXIST", "BTC", "KRW"),
-        ("binance", "spot", "BTCUSDT", "BTC", "USDT"),
-        ("binance", "usdm_futures", "BTCUSDT", "BTC", "USDT"),
+        ("binance", "spot", "ROB284COEXBTCUSDT", "BTC", "USDT"),
+        ("binance", "usdm_futures", "ROB284COEXBTCUSDT", "BTC", "USDT"),
         ("alpaca", "paper", "BTC/USD", "BTC", "USD"),
     ]
     ids = []

--- a/tests/services/daily_candles/test_crypto_instruments.py
+++ b/tests/services/daily_candles/test_crypto_instruments.py
@@ -80,7 +80,7 @@ async def test_crypto_instrument_orm_roundtrip(db_session: AsyncSession) -> None
     inst = CryptoInstrument(
         venue="binance",
         product="spot",
-        venue_symbol="BTCUSDT",
+        venue_symbol="ROB284ORMBTCUSDT",
         base_asset="BTC",
         quote_asset="USDT",
         status="active",

--- a/tests/services/daily_candles/test_repository_crypto_path.py
+++ b/tests/services/daily_candles/test_repository_crypto_path.py
@@ -23,7 +23,7 @@ async def test_crypto_upsert_writes_via_instrument_id(
     inst = CryptoInstrument(
         venue="upbit",
         product="spot",
-        venue_symbol="KRW-SOL",
+        venue_symbol="KRW-ROB284SOL",
         base_asset="SOL",
         quote_asset="KRW",
         status="active",
@@ -34,7 +34,7 @@ async def test_crypto_upsert_writes_via_instrument_id(
     repo = DailyCandlesRepository(session=db_session)
     row = DailyCandleRow(
         time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.UTC),
-        symbol="KRW-SOL",
+        symbol="KRW-ROB284SOL",
         partition="upbit_krw",
         open=100,
         high=110,
@@ -91,7 +91,7 @@ async def test_crypto_latest_time_utc_resolves_via_instrument(
     inst = CryptoInstrument(
         venue="upbit",
         product="spot",
-        venue_symbol="KRW-ETH",
+        venue_symbol="KRW-ROB284ETH",
         base_asset="ETH",
         quote_asset="KRW",
         status="active",
@@ -103,7 +103,7 @@ async def test_crypto_latest_time_utc_resolves_via_instrument(
     rows = [
         DailyCandleRow(
             time_utc=dt.datetime(2026, 5, 18, tzinfo=dt.UTC),
-            symbol="KRW-ETH",
+            symbol="KRW-ROB284ETH",
             partition="upbit_krw",
             open=100,
             high=101,
@@ -116,7 +116,7 @@ async def test_crypto_latest_time_utc_resolves_via_instrument(
         ),
         DailyCandleRow(
             time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.UTC),
-            symbol="KRW-ETH",
+            symbol="KRW-ROB284ETH",
             partition="upbit_krw",
             open=100,
             high=101,
@@ -131,7 +131,9 @@ async def test_crypto_latest_time_utc_resolves_via_instrument(
     await repo.upsert_rows(market=MarketKey.CRYPTO, rows=rows)
 
     latest = await repo.latest_time_utc(
-        market=MarketKey.CRYPTO, symbol="KRW-ETH", partition="upbit_krw"
+        market=MarketKey.CRYPTO,
+        symbol="KRW-ROB284ETH",
+        partition="upbit_krw",
     )
     assert latest is not None
     assert latest.date() == dt.date(2026, 5, 20)
@@ -144,7 +146,7 @@ async def test_crypto_fetch_recent_returns_rows_in_ascending_order(
     inst = CryptoInstrument(
         venue="upbit",
         product="spot",
-        venue_symbol="KRW-XRP",
+        venue_symbol="KRW-ROB284XRP",
         base_asset="XRP",
         quote_asset="KRW",
         status="active",
@@ -156,7 +158,7 @@ async def test_crypto_fetch_recent_returns_rows_in_ascending_order(
     rows = [
         DailyCandleRow(
             time_utc=dt.datetime(2026, 5, d, tzinfo=dt.UTC),
-            symbol="KRW-XRP",
+            symbol="KRW-ROB284XRP",
             partition="upbit_krw",
             open=100,
             high=101,
@@ -172,12 +174,12 @@ async def test_crypto_fetch_recent_returns_rows_in_ascending_order(
     await repo.upsert_rows(market=MarketKey.CRYPTO, rows=rows)
     recent = await repo.fetch_recent(
         market=MarketKey.CRYPTO,
-        symbol="KRW-XRP",
+        symbol="KRW-ROB284XRP",
         partition="upbit_krw",
         count=10,
     )
     assert [r.time_utc.day for r in recent] == [18, 19, 20]
-    assert all(r.symbol == "KRW-XRP" for r in recent)
+    assert all(r.symbol == "KRW-ROB284XRP" for r in recent)
     assert all(r.partition == "upbit_krw" for r in recent)
 
 
@@ -236,7 +238,7 @@ async def test_resolve_crypto_instrument_ids_returns_only_known_symbols(
     known = CryptoInstrument(
         venue="upbit",
         product="spot",
-        venue_symbol="KRW-SOL",
+        venue_symbol="KRW-ROB284KNOWN-SOL",
         base_asset="SOL",
         quote_asset="KRW",
         status="active",
@@ -247,8 +249,8 @@ async def test_resolve_crypto_instrument_ids_returns_only_known_symbols(
     resolved = await DailyCandlesRepository(
         session=db_session
     ).resolve_crypto_instrument_ids(
-        symbols=["KRW-SOL", "KRW-NOT-SEEDED"],
+        symbols=["KRW-ROB284KNOWN-SOL", "KRW-NOT-SEEDED"],
         partition="upbit_krw",
     )
 
-    assert resolved == {"KRW-SOL": known.id}
+    assert resolved == {"KRW-ROB284KNOWN-SOL": known.id}


### PR DESCRIPTION
## Summary

- add the scheduleless D3 primary corpus loader and 4-arm x 2-cashflow x 2-view execution harness
- emit deterministic per-run signals, submitted orders, fills, skips/rejects, cash/NAV/unit-price, open-lot/capital-day, clamped-exposure, metrics, and evidence artifacts
- extend the real corpus loader sealed-access spy across file, manifest, parquet, bar/date, and metadata-key reads
- route fees through the shared engine path and pin publication ordering before physical execution
- emit fidelity-compatible order-changing clamped-row pairs without selecting a winner or computing Pareto ranks

## Physical execution evidence

- artifacts: /Users/mgh3326/work/herdr-artifacts/d3-primary-run-v1
- implementation report: /Users/mgh3326/work/herdr-inbox/jobs/d3-r1-primary-20260807-0850/events/impl.md
- runs: 16/16 physical
- determinism: 16/16 byte-identical across two engine invocations
- dual-view pairs: 8/8
- sealed access: 0 measured across 95,632 path checks, 47,814 parquet reads, 11,090,017 bar/date checks, and 6 metadata-key checks
- order-changing fidelity population: 408,788 pairs / 817,576 rows
- sensitivity runs: 0
- winner selected: no
- Pareto computed: no

## Validation

- SHA gate: 10/10
- golden exact: 33/33
- acceptance: DETERMINISTIC_2RUNS=True, MUTANT_DIFFS=23/23, NEGATIVE_TESTS=5/5, SEALED_ACCESS_SPY=0, PRIMARY_RUN_EXECUTED=True
- D3 engine tests: 37 passed
- full unit suite: 5,231 passed, 13,046 deselected
- make lint: Ruff, format check, and ty passed
- git diff --check: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a deterministic 16-run primary exploration workflow with resumable, checksummed result bundles.
  - Added validated loading for market data, signals, adjustments, and delisting evidence.
  - Added transaction-cost calculations for fees, cash requirements, proceeds, and round trips.
  - Added stronger protection against unauthorized or sealed data access.
  - Added a command-line runner for executing the primary workflow.

- **Bug Fixes**
  - Improved resistance calculations, signal ordering, total-loss metrics, and trade-cost consistency.
  - Expanded acceptance checks to include the latest amendment and primary-run status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->