### PR TITLE
fix(research): replay D3 locked clock correction

### DIFF
--- a/research/kr_corpus/d3_engine/README.md
+++ b/research/kr_corpus/d3_engine/README.md
@@ -4,9 +4,11 @@ This package is the deterministic, research-only D3 engine for arms B0/C1/C2/C3.
 It is isolated from D2 Stage-B and from broker, order, account, database, scheduler,
 environment, and in-process LLM surfaces.
 
-The local acceptance command consumes the immutable external golden artifact as a
-read-only oracle. It never regenerates expected values and never imports the
-provenance-only `krx_tick_size_frozen.py` file.
+The local acceptance command consumes the immutable external 33-case golden
+artifact as a read-only oracle. It never regenerates expected values and never
+imports the provenance-only `krx_tick_size_frozen.py` file. The additive R1c
+correction suite executes three 180+ session arm-neutral clock cases and four
+mutants without changing any of the frozen 33 cases or 23 prior mutants.
 
 Production research callers provide the complete, ascending XKRX session axis in
 `PortfolioRunInput.market_sessions`; this makes missing symbol bars reset indicator
@@ -27,9 +29,13 @@ temporary omission. The engine then marks the run
 ```bash
 uv run python -m research.kr_corpus.d3_engine.acceptance
 uv run pytest tests/research/kr_corpus/d3_engine -v
+uv run python scripts/run_d3_primary.py
 ```
 
 The acceptance smoke runs a natural, non-vacuous indicator signal and exact L1/L2
 fills for all four arms, plus isolated engine contract probes. It does not run the
-primary 16 physical exploration jobs and does not access any 2025+ holdout or
-calibration input.
+primary 16 physical correction jobs and does not access any 2025+ holdout,
+calibration, or prospective input. The correction harness writes to
+`~/work/herdr-artifacts/d3-r1c-correction-replay-v1`, verifies the old/new
+bit-exact contract, and preserves the original `d3-primary-run-v1` tree with a
+`superseded-by.json` sidecar only after all acceptance gates pass.

--- a/research/kr_corpus/d3_engine/acceptance.py
+++ b/research/kr_corpus/d3_engine/acceptance.py
@@ -7,7 +7,6 @@ import ast
 import shutil
 import tempfile
 from collections import defaultdict
-from collections.abc import Iterator, Mapping
 from dataclasses import replace
 from datetime import date
 from decimal import Decimal
@@ -18,12 +17,13 @@ from research.kr_corpus.d3_engine import engine as engine_module
 from research.kr_corpus.d3_engine.canonical import canonical_bytes
 from research.kr_corpus.d3_engine.cash import CashLedger
 from research.kr_corpus.d3_engine.constants import ArtifactPaths, runtime_pins
+from research.kr_corpus.d3_engine.correction import correction_acceptance_payload
 from research.kr_corpus.d3_engine.engine import PortfolioEngine
 from research.kr_corpus.d3_engine.golden import GoldenSuite, GoldenSuiteResult
 from research.kr_corpus.d3_engine.guards import (
-    SealedAccessBlocked,
     SealedAccessGuard,
     SealedAccessSpy,
+    measure_sealed_fail_closed_probes,
 )
 from research.kr_corpus.d3_engine.models import (
     Arm,
@@ -378,21 +378,6 @@ def _engine_contract_probes(
     }
 
 
-class _MetadataSpy(Mapping[str, object]):
-    def __init__(self) -> None:
-        self.lookups = 0
-
-    def __getitem__(self, key: str) -> object:
-        self.lookups += 1
-        return {"D3_CALIBRATION_2025": "sealed"}[key]
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(("D3_CALIBRATION_2025",))
-
-    def __len__(self) -> int:
-        return 1
-
-
 def _negative_tests(
     paths: ArtifactPaths, tick_table: TickTable, index: FrozenKospiIndex
 ) -> tuple[dict[str, Any], dict[str, int]]:
@@ -454,50 +439,12 @@ def _negative_tests(
         "previous": previous,
     }
 
-    spy = SealedAccessSpy()
-    guard = SealedAccessGuard(spy)
-    loader_calls = 0
-
-    def loader() -> str:
-        nonlocal loader_calls
-        loader_calls += 1
-        return "forbidden"
-
-    blocked = 0
-    attempts = (
-        lambda: guard.read_bar(
-            path="/tmp/exploration/bars.parquet",
-            session=date(2025, 1, 2),
-            loader=loader,
-        ),
-        lambda: guard.read_manifest(path="/tmp/HOLDOUT/manifest.json", loader=loader),
-    )
-    for attempt in attempts:
-        try:
-            attempt()
-        except SealedAccessBlocked:
-            blocked += 1
-    metadata = _MetadataSpy()
-    try:
-        guard.read_metadata(metadata, "D3_CALIBRATION_2025")
-    except SealedAccessBlocked:
-        blocked += 1
+    sealed = measure_sealed_fail_closed_probes()
     results["sealed_access"] = {
-        "status": (
-            "PASS"
-            if blocked == 3
-            and loader_calls == 0
-            and metadata.lookups == 0
-            and spy.sealed_reads == 0
-            else "FAIL"
-        ),
-        "blocked_attempts": blocked,
-        "loader_calls": loader_calls,
-        "metadata_key_lookups": metadata.lookups,
-        "sealed_access_spy": spy.sealed_reads,
+        key: value for key, value in sealed.items() if key != "spy_evidence"
     }
     tick_table.validate()
-    return results, spy.evidence()
+    return results, sealed["spy_evidence"]  # type: ignore[return-value]
 
 
 def _prove_no_tick_python_import() -> dict[str, Any]:
@@ -553,6 +500,7 @@ def run_acceptance(
     )
 
     mutants = run_mutant_probes(paths.golden_root, ticks)
+    correction = correction_acceptance_payload(ticks)
     negatives, sealed_evidence = _negative_tests(paths, ticks, index)
     tick_proof = _prove_no_tick_python_import()
     all_excluded = sorted(
@@ -581,6 +529,10 @@ def run_acceptance(
         raise AssertionError("determinism check failed")
     if not all(probe.differs for probe in mutants):
         raise AssertionError("one or more mutant probes did not differ")
+    if correction["golden"]["passed"] != correction["golden"]["total"]:
+        raise AssertionError("one or more correction golden cases failed")
+    if correction["mutants"]["passed"] != correction["mutants"]["total"]:
+        raise AssertionError("one or more correction mutants survived")
     if any(result["status"] != "PASS" for result in negatives.values()):
         raise AssertionError("one or more negative tests failed")
     if tick_proof["python_import_count"] != 0:
@@ -639,6 +591,8 @@ def run_acceptance(
                 for probe in mutants
             ],
         },
+        "correction_golden": correction["golden"],
+        "correction_mutants": correction["mutants"],
         "negative_tests": negatives,
         "sealed_access_spy": sealed_evidence["sealed_access_spy"],
         "engine_input_explanation_keys": 0,
@@ -679,6 +633,12 @@ def main() -> int:
                     f"GOLDEN_EXACT={result['golden_exact']['passed']}/33",
                     f"DETERMINISTIC_2RUNS={result['deterministic_2runs']}",
                     f"MUTANT_DIFFS={result['mutant_diffs']['passed']}/23",
+                    "CORRECTION_GOLDEN="
+                    f"{result['correction_golden']['passed']}/"
+                    f"{result['correction_golden']['total']}",
+                    "CORRECTION_MUTANTS="
+                    f"{result['correction_mutants']['passed']}/"
+                    f"{result['correction_mutants']['total']}",
                     f"NEGATIVE_TESTS={negative_passed}/{negative_total}",
                     f"SEALED_ACCESS_SPY={result['sealed_access_spy']}",
                     f"PRIMARY_RUN_EXECUTED={result['primary_run_executed']}",

--- a/research/kr_corpus/d3_engine/correction.py
+++ b/research/kr_corpus/d3_engine/correction.py
@@ -1,0 +1,303 @@
+"""Additive locked-clock correction golden cases and executable mutants.
+
+The immutable external D3 golden remains 33/33.  These synthetic cases exercise
+the portfolio engine itself and cover the arm-scope hole found after D3-R1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+
+from research.kr_corpus.d3_engine.engine import PortfolioEngine
+from research.kr_corpus.d3_engine.models import (
+    Arm,
+    Bar,
+    CashflowView,
+    EngineResult,
+    Order,
+    OrderClass,
+    PortfolioRunInput,
+    Position,
+)
+from research.kr_corpus.d3_engine.policies import UnderwaterClockOutcome
+from research.kr_corpus.d3_engine.tick import TickTable
+
+_SYMBOL = "005930"
+_PRE_ENTRY_SESSIONS = 200
+_UNDERWATER_SESSIONS = 220
+_EXPECTED_LOCKED_MEAN = Decimal("0.18636363636363636363636363636363636363636363636364")
+
+
+@dataclass(frozen=True, slots=True)
+class CorrectionGoldenCase:
+    name: str
+    arm: Arm
+    passed: bool
+    expected: dict[str, object]
+    actual: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class CorrectionMutantProbe:
+    name: str
+    differs: bool
+    correct: dict[str, object]
+    mutant: dict[str, object]
+
+
+class _ClockSyntheticEngine(PortfolioEngine):
+    """Natural fill path with all unrelated signal/sell behavior held fixed."""
+
+    def __init__(self, tick_table: TickTable, *, entry_session: date) -> None:
+        super().__init__(tick_table)
+        self._entry_session = entry_session
+
+    def _signal_for_session(
+        self, history: list[Bar], decision_index: int
+    ) -> tuple[Decimal, Decimal, Decimal, Decimal] | None:
+        if history[decision_index].session != self._entry_session:
+            return None
+        return (
+            Decimal("40"),
+            Decimal("9500"),
+            Decimal("12000"),
+            Decimal("8000"),
+        )
+
+    def _resistance_orders(
+        self,
+        *,
+        symbol: str,
+        session: date,
+        history: list[Bar],
+        index: int,
+        position: Position,
+        first_order_number: int,
+    ) -> list[Order]:
+        del symbol, session, history, index, position, first_order_number
+        return []
+
+
+class _C3OnlyClockMutant(_ClockSyntheticEngine):
+    @staticmethod
+    def _underwater_clock_enabled(arm: Arm) -> bool:
+        return arm is Arm.C3
+
+
+class _MissingCloseCarryMutant(_ClockSyntheticEngine):
+    @staticmethod
+    def _reset_metric_close(position: Position) -> None:
+        del position
+
+
+class _B0TrimFiresMutant(_ClockSyntheticEngine):
+    @staticmethod
+    def _c3_time_trim_policy_enabled(arm: Arm) -> bool:
+        return arm in {Arm.B0, Arm.C3}
+
+
+class _EqualityCarryMutant(_ClockSyntheticEngine):
+    @staticmethod
+    def _update_metric_close(
+        position: Position, *, close: Decimal
+    ) -> UnderwaterClockOutcome:
+        if position.quantity == 0:
+            position.underwater_streak = 0
+            return UnderwaterClockOutcome(False, 0)
+        if close < position.average_price:
+            position.underwater_streak += 1
+            return UnderwaterClockOutcome(True, position.underwater_streak)
+        return UnderwaterClockOutcome(False, position.underwater_streak)
+
+
+def run_correction_golden(
+    tick_table: TickTable,
+) -> tuple[CorrectionGoldenCase, ...]:
+    expected = {
+        "fills": 2,
+        "terminal_underwater_streak": _UNDERWATER_SESSIONS,
+        "locked_share_tw_mean": _EXPECTED_LOCKED_MEAN,
+        "locked_share_p95": Decimal(1),
+        "locked_share_max": Decimal(1),
+        "time_trim_fills": 0,
+    }
+    cases: list[CorrectionGoldenCase] = []
+    for arm in (Arm.B0, Arm.C1, Arm.C2):
+        result = _run_synthetic(tick_table, arm=arm)
+        actual = _projection(result)
+        cases.append(
+            CorrectionGoldenCase(
+                name=f"{arm.value}_180_plus_underwater_locked_nonzero",
+                arm=arm,
+                passed=actual == expected,
+                expected=dict(expected),
+                actual=actual,
+            )
+        )
+    return tuple(cases)
+
+
+def run_correction_mutants(
+    tick_table: TickTable,
+) -> tuple[CorrectionMutantProbe, ...]:
+    correct_scope = _projection(_run_synthetic(tick_table, arm=Arm.B0))
+    mutant_scope = _projection(
+        _run_synthetic(tick_table, arm=Arm.B0, engine_type=_C3OnlyClockMutant)
+    )
+
+    correct_missing = _projection(
+        _run_synthetic(tick_table, arm=Arm.B0, missing_offset=100)
+    )
+    mutant_missing = _projection(
+        _run_synthetic(
+            tick_table,
+            arm=Arm.B0,
+            missing_offset=100,
+            engine_type=_MissingCloseCarryMutant,
+        )
+    )
+
+    correct_trim = _projection(_run_synthetic(tick_table, arm=Arm.B0))
+    mutant_trim = _projection(
+        _run_synthetic(tick_table, arm=Arm.B0, engine_type=_B0TrimFiresMutant)
+    )
+
+    correct_equality = _projection(
+        _run_synthetic(tick_table, arm=Arm.B0, equality_offset=100)
+    )
+    mutant_equality = _projection(
+        _run_synthetic(
+            tick_table,
+            arm=Arm.B0,
+            equality_offset=100,
+            engine_type=_EqualityCarryMutant,
+        )
+    )
+
+    return (
+        CorrectionMutantProbe(
+            "C3-only-clock", correct_scope != mutant_scope, correct_scope, mutant_scope
+        ),
+        CorrectionMutantProbe(
+            "missing-close-reset",
+            correct_missing != mutant_missing,
+            correct_missing,
+            mutant_missing,
+        ),
+        CorrectionMutantProbe(
+            "B0-trim-fires", correct_trim != mutant_trim, correct_trim, mutant_trim
+        ),
+        CorrectionMutantProbe(
+            "close-ge-average-keeps-streak",
+            correct_equality != mutant_equality,
+            correct_equality,
+            mutant_equality,
+        ),
+    )
+
+
+def _run_synthetic(
+    tick_table: TickTable,
+    *,
+    arm: Arm,
+    missing_offset: int | None = None,
+    equality_offset: int | None = None,
+    engine_type: type[_ClockSyntheticEngine] = _ClockSyntheticEngine,
+) -> EngineResult:
+    total = _PRE_ENTRY_SESSIONS + _UNDERWATER_SESSIONS
+    sessions = tuple(date(2014, 1, 1) + timedelta(days=index) for index in range(total))
+    entry_session = sessions[_PRE_ENTRY_SESSIONS]
+    bars: list[Bar] = []
+    for index, session in enumerate(sessions):
+        relative = index - _PRE_ENTRY_SESSIONS
+        if relative == missing_offset:
+            continue
+        if relative < 0:
+            open_price = high = close = Decimal("10000")
+            low = Decimal("9900")
+        elif relative == 0:
+            open_price = Decimal("9400")
+            high = Decimal("10000")
+            low = close = Decimal("9000")
+        elif relative == equality_offset:
+            open_price = Decimal("9000")
+            high = close = Decimal("9400")
+            low = Decimal("8900")
+        else:
+            open_price = close = Decimal("9000")
+            high = Decimal("9100")
+            low = Decimal("8900")
+        bars.append(
+            Bar(
+                session=session,
+                symbol=_SYMBOL,
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+            )
+        )
+    engine = engine_type(tick_table, entry_session=entry_session)
+    return engine.run(
+        PortfolioRunInput(
+            arm=arm,
+            cashflow_view=CashflowView.NO_CONTRIBUTION,
+            bars=tuple(bars),
+            market_sessions=sessions,
+            index_closes=tuple((session, Decimal("2000")) for session in sessions),
+            decision_start=entry_session,
+        )
+    )
+
+
+def _projection(result: EngineResult) -> dict[str, object]:
+    terminal = result.terminal_positions
+    if len(terminal) != 1:
+        raise AssertionError(f"synthetic correction terminal lot drift:{len(terminal)}")
+    return {
+        "fills": len(result.fills),
+        "terminal_underwater_streak": terminal[0]["underwater_streak"],
+        "locked_share_tw_mean": result.metrics["locked_share_tw_mean"],
+        "locked_share_p95": result.metrics["locked_share_p95"],
+        "locked_share_max": result.metrics["locked_share_max"],
+        "time_trim_fills": sum(
+            fill.order_class is OrderClass.TIME_TRIM for fill in result.fills
+        ),
+    }
+
+
+def correction_acceptance_payload(tick_table: TickTable) -> dict[str, Any]:
+    golden = run_correction_golden(tick_table)
+    mutants = run_correction_mutants(tick_table)
+    return {
+        "golden": {
+            "passed": sum(case.passed for case in golden),
+            "total": len(golden),
+            "cases": [
+                {
+                    "name": case.name,
+                    "arm": case.arm,
+                    "passed": case.passed,
+                    "expected": case.expected,
+                    "actual": case.actual,
+                }
+                for case in golden
+            ],
+        },
+        "mutants": {
+            "passed": sum(probe.differs for probe in mutants),
+            "total": len(mutants),
+            "cases": [
+                {
+                    "name": probe.name,
+                    "differs": probe.differs,
+                    "correct": probe.correct,
+                    "mutant": probe.mutant,
+                }
+                for probe in mutants
+            ],
+        },
+    }

--- a/research/kr_corpus/d3_engine/engine.py
+++ b/research/kr_corpus/d3_engine/engine.py
@@ -59,8 +59,10 @@ from research.kr_corpus.d3_engine.policies import (
     c3_trim_quantity,
     mark_c3_trim_filled,
     mark_c3_trim_skipped,
+    reset_underwater_close,
     unresolved_terminal_status,
     update_c3_close,
+    update_underwater_close,
 )
 from research.kr_corpus.d3_engine.signals import (
     PriceLevel,
@@ -91,6 +93,26 @@ class PortfolioEngine:
         tick_table.validate()
         self._ticks = tick_table
         self._guard = access_guard or SealedAccessGuard()
+
+    @staticmethod
+    def _underwater_clock_enabled(arm: Arm) -> bool:
+        """The locked-capital metric clock is defined for every arm."""
+
+        return True
+
+    @staticmethod
+    def _c3_time_trim_policy_enabled(arm: Arm) -> bool:
+        """Only C3 may turn clock thresholds into trim policy actions."""
+
+        return arm is Arm.C3
+
+    @staticmethod
+    def _update_metric_close(position: Position, *, close: Decimal) -> object:
+        return update_underwater_close(position, close=close)
+
+    @staticmethod
+    def _reset_metric_close(position: Position) -> None:
+        reset_underwater_close(position)
 
     def run(self, run_input: PortfolioRunInput) -> EngineResult:
         """Run one arm under the contract's fixed Decimal arithmetic context."""
@@ -281,7 +303,7 @@ class PortfolioEngine:
             )
 
             c3_time_trim_symbols: set[str] = set()
-            if run_input.arm is Arm.C3:
+            if self._c3_time_trim_policy_enabled(run_input.arm):
                 c3_time_trim_symbols = self._execute_armed_time_trims(
                     state=state,
                     cash=cash,
@@ -358,7 +380,7 @@ class PortfolioEngine:
             for rank, candidate in enumerate(ranked, start=1):
                 position = state.positions.get(candidate.symbol)
                 if (
-                    run_input.arm is Arm.C3
+                    self._c3_time_trim_policy_enabled(run_input.arm)
                     and position
                     and (
                         c3_buy_suppressed(position)
@@ -613,38 +635,42 @@ class PortfolioEngine:
                 if position.quantity == 0:
                     c1_cycles.pop(order.symbol, None)
 
-            if run_input.arm is Arm.C3:
+            if self._underwater_clock_enabled(run_input.arm):
                 for symbol in sorted(state.positions):
                     position = state.positions[symbol]
                     bar = by_session.get((session, symbol))
                     if bar is None:
                         if position.quantity > 0:
-                            position.underwater_streak = 0
-                            state.events.append(
-                                {
-                                    "event": "c3_close_clock",
-                                    "session": session,
-                                    "symbol": symbol,
-                                    "underwater": False,
-                                    "streak": 0,
-                                    "reset_reason": "missing_session_close",
-                                    "armed_90": False,
-                                    "armed_180": False,
-                                }
-                            )
+                            self._reset_metric_close(position)
+                            if self._c3_time_trim_policy_enabled(run_input.arm):
+                                state.events.append(
+                                    {
+                                        "event": "c3_close_clock",
+                                        "session": session,
+                                        "symbol": symbol,
+                                        "underwater": False,
+                                        "streak": 0,
+                                        "reset_reason": "missing_session_close",
+                                        "armed_90": False,
+                                        "armed_180": False,
+                                    }
+                                )
                         continue
-                    outcome = update_c3_close(position, close=bar.close)
-                    state.events.append(
-                        {
-                            "event": "c3_close_clock",
-                            "session": session,
-                            "symbol": symbol,
-                            "underwater": outcome.underwater,
-                            "streak": outcome.streak,
-                            "armed_90": outcome.armed_90,
-                            "armed_180": outcome.armed_180,
-                        }
-                    )
+                    if self._c3_time_trim_policy_enabled(run_input.arm):
+                        outcome = update_c3_close(position, close=bar.close)
+                        state.events.append(
+                            {
+                                "event": "c3_close_clock",
+                                "session": session,
+                                "symbol": symbol,
+                                "underwater": outcome.underwater,
+                                "streak": outcome.streak,
+                                "armed_90": outcome.armed_90,
+                                "armed_180": outcome.armed_180,
+                            }
+                        )
+                    else:
+                        self._update_metric_close(position, close=bar.close)
 
             self._finish_day(
                 state=state,

--- a/research/kr_corpus/d3_engine/guards.py
+++ b/research/kr_corpus/d3_engine/guards.py
@@ -180,3 +180,71 @@ class SealedAccessGuard:
                 f"sealed path resolved during measured read: {path.name}"
             )
         self.spy.actual_file_reads += 1
+
+
+def measure_sealed_fail_closed_probes() -> dict[str, object]:
+    """Exercise the three named sealed routes without completing a read."""
+
+    class MetadataProbe(Mapping[str, object]):
+        def __init__(self) -> None:
+            self.lookups = 0
+
+        def __getitem__(self, key: str) -> object:
+            self.lookups += 1
+            return {"D3_CALIBRATION_2025": "sealed"}[key]
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            return iter(("D3_CALIBRATION_2025",))
+
+        def __len__(self) -> int:
+            return 1
+
+    spy = SealedAccessSpy()
+    guard = SealedAccessGuard(spy)
+    loader_calls = 0
+
+    def loader() -> str:
+        nonlocal loader_calls
+        loader_calls += 1
+        return "forbidden"
+
+    metadata = MetadataProbe()
+    probes = {
+        "holdout": lambda: guard.read_manifest(
+            path="/tmp/HOLDOUT/manifest.json", loader=loader
+        ),
+        "D3_CALIBRATION_2025": lambda: guard.read_metadata(
+            metadata, "D3_CALIBRATION_2025"
+        ),
+        "prospective": lambda: guard.read_parquet(
+            path="/tmp/prospective/bars.parquet", loader=loader
+        ),
+    }
+    outcomes: dict[str, str] = {}
+    for name, probe in probes.items():
+        try:
+            probe()
+        except SealedAccessBlocked:
+            outcomes[name] = "PASS"
+        else:
+            outcomes[name] = "FAIL"
+
+    evidence = spy.evidence()
+    passed = (
+        all(value == "PASS" for value in outcomes.values())
+        and loader_calls == 0
+        and metadata.lookups == 0
+        and evidence["sealed_access_spy"] == 0
+        and evidence["sealed_access_blocked_attempts"] == 3
+        and evidence["measured_file_reads"] == 0
+        and evidence["measured_metadata_key_reads"] == 0
+    )
+    return {
+        "status": "PASS" if passed else "FAIL",
+        "paths": outcomes,
+        "loader_calls": loader_calls,
+        "metadata_key_lookups": metadata.lookups,
+        "sealed_access_measured": evidence["sealed_access_spy"],
+        "blocked_attempts": evidence["sealed_access_blocked_attempts"],
+        "spy_evidence": evidence,
+    }

--- a/research/kr_corpus/d3_engine/policies.py
+++ b/research/kr_corpus/d3_engine/policies.py
@@ -75,14 +75,35 @@ class C3CloseOutcome:
     armed_180: bool
 
 
-def update_c3_close(position: Position, *, close: Decimal) -> C3CloseOutcome:
-    """Evaluate with the post-fill average; equality resets the streak."""
+@dataclass(frozen=True, slots=True)
+class UnderwaterClockOutcome:
+    underwater: bool
+    streak: int
+
+
+def update_underwater_close(
+    position: Position, *, close: Decimal
+) -> UnderwaterClockOutcome:
+    """Advance the arm-neutral post-fill close metric clock."""
 
     if position.quantity == 0:
         position.underwater_streak = 0
-        return C3CloseOutcome(False, 0, False, False)
+        return UnderwaterClockOutcome(False, 0)
     underwater = close < position.average_price
     position.underwater_streak = position.underwater_streak + 1 if underwater else 0
+    return UnderwaterClockOutcome(underwater, position.underwater_streak)
+
+
+def reset_underwater_close(position: Position) -> None:
+    """Reset the metric clock when the session close is unavailable."""
+
+    position.underwater_streak = 0
+
+
+def update_c3_close(position: Position, *, close: Decimal) -> C3CloseOutcome:
+    """Advance the shared metric clock, then arm C3-only trim policy."""
+
+    clock = update_underwater_close(position, close=close)
     armed_90 = False
     armed_180 = False
     if position.underwater_streak >= 90 and not position.trim90_triggered:
@@ -100,8 +121,8 @@ def update_c3_close(position: Position, *, close: Decimal) -> C3CloseOutcome:
         position.trim180_armed = True
         armed_180 = True
     return C3CloseOutcome(
-        underwater,
-        position.underwater_streak,
+        clock.underwater,
+        clock.streak,
         armed_90,
         armed_180,
     )

--- a/research/kr_corpus/d3_engine/primary.py
+++ b/research/kr_corpus/d3_engine/primary.py
@@ -1,4 +1,4 @@
-"""Deterministic 16-physical D3 primary exploration harness.
+"""Deterministic 16-physical D3 locked-clock correction replay harness.
 
 This module adds only the corpus-to-E1-engine execution and artifact surface. It
 does not select a winner, compute Pareto dominance, run sensitivity variants, or
@@ -25,7 +25,11 @@ from research.kr_corpus.d3_engine.cash import CashLedger, Settlement
 from research.kr_corpus.d3_engine.constants import FEE_RATE, ArtifactPaths
 from research.kr_corpus.d3_engine.costs import cash_required
 from research.kr_corpus.d3_engine.engine import PortfolioEngine
-from research.kr_corpus.d3_engine.guards import SealedAccessGuard, SealedAccessSpy
+from research.kr_corpus.d3_engine.guards import (
+    SealedAccessGuard,
+    SealedAccessSpy,
+    measure_sealed_fail_closed_probes,
+)
 from research.kr_corpus.d3_engine.metrics import nearest_rank
 from research.kr_corpus.d3_engine.models import (
     Arm,
@@ -34,6 +38,7 @@ from research.kr_corpus.d3_engine.models import (
     DataView,
     EngineResult,
     Fill,
+    OrderClass,
     OrderSide,
     PortfolioRunInput,
     RunState,
@@ -70,10 +75,27 @@ STATE_PRIORITY_A1 = (
     "CALIBRATION_MISMATCH",
     "verdict",
 )
+TRIAL_COUNT = 0
+CORRECTION_REPLAY_COUNT = 1
+SUPERSEDED_MANIFEST_SHA256 = (
+    "30ae19f9d3892e76b848796f45df260741a120d23a8676d42bf914b78fc8f5d3"
+)
+CLAMPED_ROWS_SCHEMA_SHA256 = (
+    "57a55bfb41a0bbb70a36c098a9f561ca90e28098eca8f7845dee0a1d4ec7b5b2"
+)
+CLAMPED_ROWS_SHA256 = "a01cb786f7c7d6743473d42ee524de948995084e5af6fd93e372386d6abde28a"
+CLAMPED_ROWS_COUNT = 817_576
+CLAMPED_UNIT_IDS_SHA256 = (
+    "248fd8f3b0c03d76eaa803aff8e1b1d5fb971b5b5949c14327fa1dd957dcaf91"
+)
 
 
 class PrimaryRunInvalid(RuntimeError):
     code = "RUN_INVALID_PRIMARY_HARNESS"
+
+
+class ClampedRowsChanged(PrimaryRunInvalid):
+    code = "NEEDS_UPSTREAM(clamped_rows_changed_by_correction)"
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,6 +104,7 @@ class PrimaryHarnessPaths:
     corpus: PrimaryCorpusPaths
     delist_root: Path
     fidelity_root: Path
+    superseded_root: Path
     output_root: Path
     progress_report: Path
 
@@ -93,12 +116,13 @@ class PrimaryHarnessPaths:
             corpus=PrimaryCorpusPaths.defaults(),
             delist_root=work / "herdr-artifacts" / "kr-delist-events-v1",
             fidelity_root=work / "herdr-artifacts" / "d3-fidelity-method-v1",
-            output_root=work / "herdr-artifacts" / "d3-primary-run-v1",
+            superseded_root=work / "herdr-artifacts" / "d3-primary-run-v1",
+            output_root=work / "herdr-artifacts" / "d3-r1c-correction-replay-v1",
             progress_report=(
                 work
                 / "herdr-inbox"
                 / "jobs"
-                / "d3-r1-primary-20260807-0850"
+                / "d3-r1c-locked-clock-20260807-1700"
                 / "events"
                 / "impl.md"
             ),
@@ -529,16 +553,84 @@ class PrimaryRunHarness:
             gc.collect()
 
         completed.sort(key=lambda row: str(row["run_id"]))
+        comparison = _compare_correction_replay(
+            correction_root=self.paths.output_root,
+            superseded_root=self.paths.superseded_root,
+        )
+        _write_bytes(
+            self.paths.output_root / "bitexact-comparison.json",
+            canonical_bytes(
+                {
+                    "schema_version": PRIMARY_SCHEMA_VERSION,
+                    "artifact_kind": "locked-clock-bitexact-comparison",
+                    "stamps": self._stamps,
+                    "payload": comparison,
+                }
+            ),
+        )
+        if comparison["status"] != "PASS":
+            self._append_progress(
+                "\nRUN_INVALID = correction bit-exact mismatch · "
+                f"differences={comparison['unexpected_differences']}\n"
+            )
+            raise PrimaryRunInvalid("RUN_INVALID_CORRECTION_BITEXACT")
+
         clamped_pair_exposure = _build_clamped_pair_exposure(
             output_root=self.paths.output_root,
             completed=completed,
             stamps=self._stamps,
         )
+        superseded_manifest = json.loads(
+            (self.paths.superseded_root / "manifest.json").read_bytes()
+        )
         pairing = _build_order_changing_rows(
             output_root=self.paths.output_root,
             completed=completed,
             stamps=self._stamps,
+            frozen_source_shas={
+                str(row["run_id"]): str(row["run_json_sha256"])
+                for row in superseded_manifest["matrix"]["runs"]
+            },
+            binding_stamps=superseded_manifest["stamps"],
         )
+        clamped_invariance = _measure_clamped_rows_invariance(
+            root=self.paths.output_root,
+            row_count=int(pairing["summary"]["row_count"]),
+            unit_ids_sha256=str(pairing["summary"]["unit_ids_sha256"]),
+        )
+        comparison["root_artifacts"] = _compare_root_artifacts(
+            correction_root=self.paths.output_root,
+            superseded_root=self.paths.superseded_root,
+        )
+        comparison["clamped_rows"] = clamped_invariance
+        if not all(
+            bool(row["identical"]) for row in comparison["root_artifacts"].values()
+        ):
+            comparison["status"] = "FAIL"
+            comparison["unexpected_differences"].append("root_artifact_payload_changed")
+        _write_bytes(
+            self.paths.output_root / "bitexact-comparison.json",
+            canonical_bytes(
+                {
+                    "schema_version": PRIMARY_SCHEMA_VERSION,
+                    "artifact_kind": "locked-clock-bitexact-comparison",
+                    "stamps": self._stamps,
+                    "payload": comparison,
+                }
+            ),
+        )
+        if not clamped_invariance["unchanged"]:
+            self._append_progress(
+                "\nNEEDS_UPSTREAM(clamped_rows_changed_by_correction) = "
+                f"{clamped_invariance}\n"
+            )
+            raise ClampedRowsChanged(ClampedRowsChanged.code)
+        if comparison["status"] != "PASS":
+            raise PrimaryRunInvalid("RUN_INVALID_CORRECTION_ROOT_ARTIFACT")
+
+        fail_closed = measure_sealed_fail_closed_probes()
+        if fail_closed["status"] != "PASS":
+            raise PrimaryRunInvalid("sealed three-route fail-closed probe failed")
         sealed_payload = {
             "schema_version": PRIMARY_SCHEMA_VERSION,
             "stamps": self._stamps,
@@ -550,6 +642,7 @@ class PrimaryRunHarness:
                     "sealed_access_blocked_attempts"
                 ],
             },
+            "fail_closed_probes": fail_closed,
         }
         _write_bytes(
             self.paths.output_root / "sealed-access.json",
@@ -569,7 +662,13 @@ class PrimaryRunHarness:
             "dual_view_pairing": pairing["pairing"],
             "order_changing_clamped_rows": pairing["summary"],
             "clamped_pair_exposure": clamped_pair_exposure,
+            "bitexact_comparison_path": "bitexact-comparison.json",
+            "bitexact_invariants_passed": comparison["status"] == "PASS",
+            "clamped_rows_unchanged": clamped_invariance,
             "sealed_access_path": "sealed-access.json",
+            "supersedes": self._stamps["supersedes"],
+            "trial_count": TRIAL_COUNT,
+            "correction_replay_count": CORRECTION_REPLAY_COUNT,
             "winner_selected": False,
             "pareto_computed": False,
             "sensitivity_runs": 0,
@@ -580,9 +679,23 @@ class PrimaryRunHarness:
         measured = measure_primary_run_executed(self.paths.output_root)
         if not measured["primary_run_executed"]:
             raise PrimaryRunInvalid(f"primary measurement failed:{measured}")
+        _write_superseded_link(
+            superseded_root=self.paths.superseded_root,
+            correction_root=self.paths.output_root,
+        )
         self._append_progress(
             "\nRUNS = 16/16 physical · DETERMINISTIC_2RUNS = 16/16 PASS · "
             "DUAL_VIEW_PAIRED = 8/8 · WINNER_SELECTED = NO\n"
+            "\nBITEXACT_TABLE = PASS · C3_FULL_EXACT = YES · "
+            "B0_C1_C2_TRIM_FIRES = 0\n"
+            "\nCLAMPED_ROWS_UNCHANGED = YES · "
+            f"schema_sha={clamped_invariance['schema_after_sha256']} · "
+            f"rows_sha={clamped_invariance['rows_after_sha256']} · "
+            f"row_count={clamped_invariance['row_count_after']} · "
+            "unit_id_identical=YES\n"
+            "\nSEALED_ACCESS_MEASURED = 0 · "
+            "holdout/D3_CALIBRATION_2025/prospective fail-closed PASS\n"
+            "\ntrial_count = 0 · correction_replay_count = 1\n"
         )
         gc.unfreeze()
         return manifest
@@ -595,6 +708,26 @@ class PrimaryRunHarness:
             FIDELITY_METHOD_CHECKSUMS_SHA256
         ):
             raise PrimaryRunInvalid("fidelity method checksum drift")
+        if self.paths.output_root.resolve() == self.paths.superseded_root.resolve():
+            raise PrimaryRunInvalid(
+                "correction output cannot overwrite superseded root"
+            )
+        if sha256_file(self.paths.superseded_root / "manifest.json") != (
+            SUPERSEDED_MANIFEST_SHA256
+        ):
+            raise PrimaryRunInvalid("superseded primary manifest drift")
+        if (
+            sha256_file(
+                self.paths.superseded_root / "order-changing-clamped-rows-schema.json"
+            )
+            != CLAMPED_ROWS_SCHEMA_SHA256
+        ):
+            raise PrimaryRunInvalid("superseded clamped schema drift")
+        if (
+            sha256_file(self.paths.superseded_root / "order-changing-clamped-rows.json")
+            != CLAMPED_ROWS_SHA256
+        ):
+            raise PrimaryRunInvalid("superseded clamped rows drift")
         self.paths.progress_report.parent.mkdir(parents=True, exist_ok=True)
 
     def _build_stamps(
@@ -607,8 +740,19 @@ class PrimaryRunHarness:
     ) -> dict[str, object]:
         return {
             "input_sha256": {str(row["file"]): row["sha256"] for row in self._sha_gate},
-            "engine_commit": ENGINE_BASE_COMMIT,
+            "engine_base_commit": ENGINE_BASE_COMMIT,
+            "engine_commit": self.harness_commit,
             "harness_commit": self.harness_commit,
+            "trial_count": TRIAL_COUNT,
+            "correction_replay_count": CORRECTION_REPLAY_COUNT,
+            "supersedes": {
+                "artifact_root": str(self.paths.superseded_root.resolve()),
+                "manifest_sha256": SUPERSEDED_MANIFEST_SHA256,
+                "status": "RUN_INVALID_PENDING_LOCKED_CLOCK_CORRECTION",
+            },
+            "superseded_by_link": str(
+                (self.paths.superseded_root / "superseded-by.json").resolve()
+            ),
             "corpus": {
                 **CORPUS_BINDINGS,
                 "original_rows": original.row_count,
@@ -1279,6 +1423,8 @@ def _build_order_changing_rows(
     output_root: Path,
     completed: list[dict[str, object]],
     stamps: dict[str, object],
+    frozen_source_shas: dict[str, str] | None = None,
+    binding_stamps: dict[str, object] | None = None,
 ) -> dict[str, object]:
     by_combo = {
         (
@@ -1331,7 +1477,11 @@ def _build_order_changing_rows(
                         "data_view_role": role,
                         **material,
                         "oc_codes": codes,
-                        "source_artifact_sha": source["run_json_sha256"],
+                        "source_artifact_sha": (
+                            frozen_source_shas[str(source["run_id"])]
+                            if frozen_source_shas is not None
+                            else source["run_json_sha256"]
+                        ),
                     }
                     fidelity["unit_id"] = _fidelity_unit_id(fidelity)
                     rows.append(fidelity)
@@ -1347,13 +1497,14 @@ def _build_order_changing_rows(
             )
     rows.sort(key=lambda row: (row["pair_id"], row["data_view_role"]))
     schema = _order_changing_schema()
+    frozen_stamps = binding_stamps if binding_stamps is not None else stamps
     _write_bytes(
         output_root / "order-changing-clamped-rows.json",
         canonical_bytes(
             {
                 "schema_version": ORDER_CHANGING_SCHEMA_VERSION,
                 "artifact_kind": "order-changing-clamped-rows",
-                "stamps": stamps,
+                "stamps": frozen_stamps,
                 "rows": rows,
             }
         ),
@@ -1364,7 +1515,7 @@ def _build_order_changing_rows(
             {
                 "schema_version": ORDER_CHANGING_SCHEMA_VERSION,
                 "artifact_kind": "order-changing-clamped-rows-schema",
-                "stamps": stamps,
+                "stamps": frozen_stamps,
                 "payload": schema,
             }
         ),
@@ -1390,6 +1541,7 @@ def _build_order_changing_rows(
         "summary": {
             "schema_version": ORDER_CHANGING_SCHEMA_VERSION,
             "row_count": len(rows),
+            "unit_ids_sha256": _line_sha256([str(row["unit_id"]) for row in rows]),
             "pair_count": len({row["pair_id"] for row in rows}),
             "artifact": "order-changing-clamped-rows.json",
             "schema": "order-changing-clamped-rows-schema.json",
@@ -1749,6 +1901,306 @@ def _read_completed_run(target: Path, physical: PhysicalRun) -> dict[str, object
         "run_json_sha256": hashlib.sha256(raw).hexdigest(),
         "bundle_sha256": _directory_bundle_sha(target),
     }
+
+
+_RESULT_ARTIFACTS = (
+    "signals.json",
+    "submitted.json",
+    "fills.json",
+    "skips.json",
+    "policy-rejects.json",
+    "cash-rejects.json",
+    "clamped-exposure.json",
+    "open-lots.json",
+    "capital-days.json",
+    "cash-daily.json",
+    "nav-unit-price-daily.json",
+    "events.json",
+    "orders.json",
+    "metrics.json",
+    "evidence.json",
+)
+_NON_C3_EXACT_ARTIFACTS = (
+    "signals.json",
+    "submitted.json",
+    "fills.json",
+    "skips.json",
+    "policy-rejects.json",
+    "cash-rejects.json",
+    "clamped-exposure.json",
+    "cash-daily.json",
+    "events.json",
+    "orders.json",
+    "evidence.json",
+)
+_LOCKED_METRIC_KEYS = frozenset(
+    {"locked_share_tw_mean", "locked_share_p95", "locked_share_max"}
+)
+
+
+def _compare_correction_replay(
+    *, correction_root: Path, superseded_root: Path
+) -> dict[str, object]:
+    unexpected: list[str] = []
+    run_rows: list[dict[str, object]] = []
+    for physical in primary_matrix():
+        before_root = superseded_root / "runs" / physical.run_id
+        after_root = correction_root / "runs" / physical.run_id
+        exact: dict[str, dict[str, object]] = {}
+        if physical.arm is Arm.C3:
+            for name in _RESULT_ARTIFACTS:
+                row = _value_hash_comparison(before_root / name, after_root / name)
+                exact[name] = row
+                if not row["identical"]:
+                    unexpected.append(f"{physical.run_id}:{name}")
+            run_rows.append(
+                {
+                    "run_id": physical.run_id,
+                    "arm": physical.arm.value,
+                    "c3_full_bitexact": not any(
+                        not bool(row["identical"]) for row in exact.values()
+                    ),
+                    "exact_artifacts": exact,
+                    "allowed_locked_axis": None,
+                    "non_c3_time_trim_fills": None,
+                }
+            )
+            continue
+
+        for name in _NON_C3_EXACT_ARTIFACTS:
+            row = _value_hash_comparison(before_root / name, after_root / name)
+            exact[name] = row
+            if not row["identical"]:
+                unexpected.append(f"{physical.run_id}:{name}")
+
+        metrics_before = _read_wrapped_value(before_root / "metrics.json")
+        metrics_after = _read_wrapped_value(after_root / "metrics.json")
+        if not isinstance(metrics_before, dict) or not isinstance(metrics_after, dict):
+            raise PrimaryRunInvalid("metrics artifact payload malformed")
+        metric_differences = sorted(
+            key
+            for key in set(metrics_before) | set(metrics_after)
+            if metrics_before.get(key) != metrics_after.get(key)
+        )
+        unexpected_metrics = sorted(set(metric_differences) - _LOCKED_METRIC_KEYS)
+        if unexpected_metrics:
+            unexpected.extend(
+                f"{physical.run_id}:metrics:{key}" for key in unexpected_metrics
+            )
+
+        nav = _allowed_rows_comparison(
+            before_root / "nav-unit-price-daily.json",
+            after_root / "nav-unit-price-daily.json",
+            allowed_keys=frozenset({"locked_share"}),
+        )
+        lots = _allowed_rows_comparison(
+            before_root / "open-lots.json",
+            after_root / "open-lots.json",
+            allowed_keys=frozenset({"underwater_streak"}),
+        )
+        capital = _allowed_rows_comparison(
+            before_root / "capital-days.json",
+            after_root / "capital-days.json",
+            allowed_keys=frozenset({"locked_capital_days_krw"}),
+        )
+        for name, row in (
+            ("nav-unit-price-daily.json", nav),
+            ("open-lots.json", lots),
+            ("capital-days.json", capital),
+        ):
+            if not row["non_allowed_fields_identical"]:
+                unexpected.append(f"{physical.run_id}:{name}:non_allowed_fields")
+
+        fills_after = _read_wrapped_value(after_root / "fills.json")
+        if not isinstance(fills_after, list):
+            raise PrimaryRunInvalid("fills artifact rows malformed")
+        trim_fills = sum(
+            row.get("class") == OrderClass.TIME_TRIM.value for row in fills_after
+        )
+        if trim_fills:
+            unexpected.append(f"{physical.run_id}:time_trim_fills={trim_fills}")
+        locked_before = {
+            key: metrics_before[key] for key in sorted(_LOCKED_METRIC_KEYS)
+        }
+        locked_after = {key: metrics_after[key] for key in sorted(_LOCKED_METRIC_KEYS)}
+        if Decimal(str(locked_after["locked_share_tw_mean"])) <= 0:
+            unexpected.append(f"{physical.run_id}:locked_share_tw_mean_not_nonzero")
+        if Decimal(str(locked_after["locked_share_max"])) <= 0:
+            unexpected.append(f"{physical.run_id}:locked_share_max_not_nonzero")
+        run_rows.append(
+            {
+                "run_id": physical.run_id,
+                "arm": physical.arm.value,
+                "c3_full_bitexact": None,
+                "exact_artifacts": exact,
+                "allowed_locked_axis": {
+                    "metrics": {
+                        "before": locked_before,
+                        "after": locked_after,
+                        "changed_keys": metric_differences,
+                        "unexpected_keys": unexpected_metrics,
+                    },
+                    "nav_unit_price": nav,
+                    "open_lots": lots,
+                    "capital_days": capital,
+                },
+                "non_c3_time_trim_fills": trim_fills,
+            }
+        )
+
+    return {
+        "status": "PASS" if not unexpected else "FAIL",
+        "unexpected_differences": unexpected,
+        "runs": run_rows,
+        "summary": {
+            "B0_C1_C2_non_locked_fields_bitexact": not any(
+                item for item in unexpected if not item.startswith("C3__")
+            ),
+            "C3_full_bitexact": not any(
+                item for item in unexpected if item.startswith("C3__")
+            ),
+            "B0_C1_C2_time_trim_fills": sum(
+                int(row["non_c3_time_trim_fills"] or 0)
+                for row in run_rows
+                if row["arm"] != Arm.C3.value
+            ),
+        },
+    }
+
+
+def _compare_root_artifacts(
+    *, correction_root: Path, superseded_root: Path
+) -> dict[str, dict[str, object]]:
+    return {
+        name: _value_hash_comparison(
+            superseded_root / name,
+            correction_root / name,
+        )
+        for name in ("clamped-pair-exposure.json", "dual-view-pairing.json")
+    }
+
+
+def _value_hash_comparison(before: Path, after: Path) -> dict[str, object]:
+    before_sha = hashlib.sha256(_wrapped_value_bytes(before)).hexdigest()
+    after_sha = hashlib.sha256(_wrapped_value_bytes(after)).hexdigest()
+    return {
+        "before_sha256": before_sha,
+        "after_sha256": after_sha,
+        "identical": before_sha == after_sha,
+    }
+
+
+def _wrapped_value_bytes(path: Path) -> bytes:
+    raw = path.read_bytes().rstrip(b"\n")
+    positions = [
+        (raw.find(marker), marker)
+        for marker in (b'"payload":', b'"rows":')
+        if raw.find(marker) >= 0
+    ]
+    if not positions:
+        raise PrimaryRunInvalid(f"artifact lacks payload/rows wrapper:{path}")
+    marker_at, marker = min(positions, key=lambda item: item[0])
+    start = marker_at + len(marker)
+    end = raw.rfind(b',"run_id":')
+    if end < start:
+        end = raw.rfind(b',"schema_version":')
+    if end < start:
+        raise PrimaryRunInvalid(f"artifact wrapper boundary malformed:{path}")
+    return raw[start:end]
+
+
+def _read_wrapped_value(path: Path) -> object:
+    payload = json.loads(path.read_bytes())
+    if "payload" in payload:
+        return payload["payload"]
+    if "rows" in payload:
+        return payload["rows"]
+    raise PrimaryRunInvalid(f"artifact lacks payload/rows:{path}")
+
+
+def _allowed_rows_comparison(
+    before: Path, after: Path, *, allowed_keys: frozenset[str]
+) -> dict[str, object]:
+    before_rows = _read_wrapped_value(before)
+    after_rows = _read_wrapped_value(after)
+    if not isinstance(before_rows, list) or not isinstance(after_rows, list):
+        raise PrimaryRunInvalid("allowed-axis artifact rows malformed")
+
+    def projection(row: object) -> object:
+        if not isinstance(row, dict):
+            raise PrimaryRunInvalid("allowed-axis row malformed")
+        return {key: value for key, value in row.items() if key not in allowed_keys}
+
+    non_allowed_identical = len(before_rows) == len(after_rows) and [
+        projection(row) for row in before_rows
+    ] == [projection(row) for row in after_rows]
+    changed_rows = 0
+    if len(before_rows) == len(after_rows):
+        for old, new in zip(before_rows, after_rows, strict=True):
+            if not isinstance(old, dict) or not isinstance(new, dict):
+                raise PrimaryRunInvalid("allowed-axis row malformed")
+            if any(old.get(key) != new.get(key) for key in allowed_keys):
+                changed_rows += 1
+    return {
+        "row_count_before": len(before_rows),
+        "row_count_after": len(after_rows),
+        "allowed_keys": sorted(allowed_keys),
+        "allowed_field_changed_rows": changed_rows,
+        "non_allowed_fields_identical": non_allowed_identical,
+    }
+
+
+def _measure_clamped_rows_invariance(
+    *, root: Path, row_count: int, unit_ids_sha256: str
+) -> dict[str, object]:
+    schema_after = sha256_file(root / "order-changing-clamped-rows-schema.json")
+    rows_after = sha256_file(root / "order-changing-clamped-rows.json")
+    unchanged = (
+        schema_after == CLAMPED_ROWS_SCHEMA_SHA256
+        and rows_after == CLAMPED_ROWS_SHA256
+        and row_count == CLAMPED_ROWS_COUNT
+        and unit_ids_sha256 == CLAMPED_UNIT_IDS_SHA256
+    )
+    return {
+        "unchanged": unchanged,
+        "schema_before_sha256": CLAMPED_ROWS_SCHEMA_SHA256,
+        "schema_after_sha256": schema_after,
+        "rows_before_sha256": CLAMPED_ROWS_SHA256,
+        "rows_after_sha256": rows_after,
+        "row_count_before": CLAMPED_ROWS_COUNT,
+        "row_count_after": row_count,
+        "unit_ids_before_sha256": CLAMPED_UNIT_IDS_SHA256,
+        "unit_ids_after_sha256": unit_ids_sha256,
+        "unit_id_identical": unit_ids_sha256 == CLAMPED_UNIT_IDS_SHA256,
+    }
+
+
+def _line_sha256(values: list[str]) -> str:
+    digest = hashlib.sha256()
+    for value in values:
+        digest.update(value.encode())
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _write_superseded_link(*, superseded_root: Path, correction_root: Path) -> None:
+    correction_manifest = correction_root / "manifest.json"
+    payload = canonical_bytes(
+        {
+            "schema_version": PRIMARY_SCHEMA_VERSION,
+            "artifact_kind": "superseded-by",
+            "superseded_manifest_sha256": SUPERSEDED_MANIFEST_SHA256,
+            "superseded_by": str(correction_manifest.resolve()),
+            "superseded_by_manifest_sha256": sha256_file(correction_manifest),
+            "reason": "RUN_INVALID_PENDING_LOCKED_CLOCK_CORRECTION",
+            "trial_count": TRIAL_COUNT,
+            "correction_replay_count": CORRECTION_REPLAY_COUNT,
+        }
+    )
+    target = superseded_root / "superseded-by.json"
+    if target.exists() and target.read_bytes() != payload:
+        raise PrimaryRunInvalid(f"conflicting superseded_by link:{target}")
+    _write_bytes(target, payload)
 
 
 def _demand_from_orders_file(path: Path) -> frozenset[tuple[date, str]]:

--- a/scripts/run_d3_primary.py
+++ b/scripts/run_d3_primary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Execute the frozen D3-R1 16-physical primary matrix."""
+"""Execute the frozen D3-R1c 16-physical locked-clock correction replay."""
 
 from __future__ import annotations
 

--- a/tests/research/kr_corpus/d3_engine/test_d3_engine_acceptance.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_engine_acceptance.py
@@ -62,7 +62,25 @@ def test_d3_e1_full_local_acceptance(tmp_path: Path) -> None:
         "c3_buy_suppression_bound": True,
     }
     assert result["mutant_diffs"]["passed"] == 23
+    assert result["mutant_diffs"]["total"] == 23
+    assert result["correction_golden"]["passed"] == 3
+    assert result["correction_golden"]["total"] == 3
+    assert result["correction_mutants"]["passed"] == 4
+    assert result["correction_mutants"]["total"] == 4
+    assert {row["name"] for row in result["correction_mutants"]["cases"]} == {
+        "C3-only-clock",
+        "missing-close-reset",
+        "B0-trim-fires",
+        "close-ge-average-keeps-streak",
+    }
     assert all(row["status"] == "PASS" for row in result["negative_tests"].values())
+    assert result["negative_tests"]["sealed_access"]["paths"] == {
+        "holdout": "PASS",
+        "D3_CALIBRATION_2025": "PASS",
+        "prospective": "PASS",
+    }
+    assert result["negative_tests"]["sealed_access"]["loader_calls"] == 0
+    assert result["negative_tests"]["sealed_access"]["metadata_key_lookups"] == 0
     assert result["sealed_access_spy"] == 0
     assert result["engine_input_explanation_keys"] == 0
     assert result["fib_window_excludes_t"] is True

--- a/tests/research/kr_corpus/d3_engine/test_d3_engine_core.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_engine_core.py
@@ -41,6 +41,7 @@ from research.kr_corpus.d3_engine.policies import (
     C1Cycle,
     c3_buy_suppressed,
     update_c3_close,
+    update_underwater_close,
 )
 from research.kr_corpus.d3_engine.signals import SignalCandidate
 from research.kr_corpus.d3_engine.tick import (
@@ -215,6 +216,24 @@ def test_c3_uses_post_fill_average_and_suppresses_add_when_armed() -> None:
     armed = update_c3_close(position, close=Decimal("8900"))
     assert armed.armed_90
     assert c3_buy_suppressed(position)
+
+
+def test_arm_neutral_clock_does_not_arm_c3_trim_policy() -> None:
+    position = Position(
+        symbol="005930",
+        quantity=9,
+        average_price=Decimal("10000"),
+        invested_cost_basis=Decimal("90000"),
+        underwater_streak=179,
+    )
+
+    outcome = update_underwater_close(position, close=Decimal("9000"))
+
+    assert outcome.streak == 180
+    assert not position.trim90_triggered
+    assert not position.trim90_armed
+    assert not position.trim180_triggered
+    assert not position.trim180_armed
 
 
 def test_sealed_bar_manifest_and_metadata_block_before_access() -> None:

--- a/tests/research/kr_corpus/d3_engine/test_d3_primary.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_primary.py
@@ -23,10 +23,13 @@ from research.kr_corpus.d3_engine.indicators import rsi_wilder
 from research.kr_corpus.d3_engine.models import Arm, CashflowView, DataView
 from research.kr_corpus.d3_engine.primary import (
     PhysicalRun,
+    PrimaryHarnessPaths,
     PrimaryPortfolioEngine,
     PrimaryRunInvalid,
+    _allowed_rows_comparison,
     _funding_p05,
     _seal_determinism,
+    _value_hash_comparison,
     measure_primary_run_executed,
     primary_matrix,
 )
@@ -90,6 +93,77 @@ def test_primary_matrix_is_exactly_four_by_two_by_two() -> None:
         DataView.CLAMP_ADMIT_V1,
     }
     assert len({(run.arm, run.cashflow_view) for run in matrix}) == 8
+
+
+def test_correction_defaults_preserve_the_superseded_primary_root() -> None:
+    paths = PrimaryHarnessPaths.defaults()
+
+    assert paths.superseded_root.name == "d3-primary-run-v1"
+    assert paths.output_root.name == "d3-r1c-correction-replay-v1"
+    assert paths.output_root != paths.superseded_root
+
+
+def test_bitexact_wrapper_comparison_ignores_stamps_but_not_payload(
+    tmp_path: Path,
+) -> None:
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    before.write_bytes(
+        canonical_bytes(
+            {
+                "artifact_kind": "nav-unit-price-daily",
+                "run_id": "B0__no_contribution__original_valid_bar",
+                "schema_version": "d3.primary_run.v1",
+                "stamps": {"commit": "old"},
+                "rows": [
+                    {
+                        "session": "2015-01-02",
+                        "nav": "100",
+                        "locked_share": "0",
+                    }
+                ],
+            }
+        )
+    )
+    after.write_bytes(
+        canonical_bytes(
+            {
+                "artifact_kind": "nav-unit-price-daily",
+                "run_id": "B0__no_contribution__original_valid_bar",
+                "schema_version": "d3.primary_run.v1",
+                "stamps": {"commit": "new"},
+                "rows": [
+                    {
+                        "session": "2015-01-02",
+                        "nav": "100",
+                        "locked_share": "0",
+                    }
+                ],
+            }
+        )
+    )
+
+    assert _value_hash_comparison(before, after)["identical"] is True
+
+    payload = json.loads(after.read_bytes())
+    payload["rows"][0]["locked_share"] = "0.5"
+    after.write_bytes(canonical_bytes(payload))
+    allowed = _allowed_rows_comparison(
+        before,
+        after,
+        allowed_keys=frozenset({"locked_share"}),
+    )
+    assert allowed["non_allowed_fields_identical"] is True
+    assert allowed["allowed_field_changed_rows"] == 1
+
+    payload["rows"][0]["nav"] = "99"
+    after.write_bytes(canonical_bytes(payload))
+    disallowed = _allowed_rows_comparison(
+        before,
+        after,
+        allowed_keys=frozenset({"locked_share"}),
+    )
+    assert disallowed["non_allowed_fields_identical"] is False
 
 
 def test_corpus_partition_accepts_frozen_krx_alphanumeric_issue_codes() -> None:


### PR DESCRIPTION
## Summary
- advance the underwater metric clock for every D3 arm after same-session fills while retaining C3-only 90/180 trim policy firing
- add engine-running correction golden vectors and four executable mutants
- add fail-closed sealed-access probes and correction-replay primary evidence gates
- preserve the prior 16P artifacts with an additive superseded-by link

## Acceptance evidence
- SHA gate: 10/10
- existing golden: 33/33; existing mutants: 23/23
- correction golden: 3/3; correction mutants: 4/4
- physical replay: 16/16; two-run byte-identical: 16/16
- bit-exact: B0/C1/C2 non-locked fields PASS; C3 full PASS; non-C3 trim fills 0
- clamped rows: schema/817,576 rows/unit_id sequence byte-identical
- sealed access measured: 0; holdout, D3_CALIBRATION_2025, prospective fail-closed probes PASS
- trial_count=0; correction_replay_count=1; winner_selected=false; pareto_computed=false

## Tests
- make lint
- make test-unit (5,231 passed, 13,052 deselected)
- focused D3 tests (40 passed)
- artifact-bound acceptance entrypoint (PASS)

No merge, ranking, winner selection, sensitivity run, or sealed-data access is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locked-clock correction replay validation with golden cases and mutation checks.
  * Added verification that correction outputs remain separate from prior frozen results.
  * Added safeguards for sealed data access and bit-exact replay comparisons.
* **Bug Fixes**
  * Improved underwater-duration tracking across portfolio arms.
  * Corrected close-state resets for held positions and preserved arm-specific trim behavior.
* **Documentation**
  * Updated guidance for correction runs, acceptance checks, artifacts, and replay commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->