### PR TITLE
research(D3-C2P): D3_CALIBRATION_2025 access-spy loader (diagnostic, blocked on missing 2025 calendar input)

### DIFF
--- a/research/kr_corpus/d3_engine/calibration_actual_side.py
+++ b/research/kr_corpus/d3_engine/calibration_actual_side.py
@@ -1,0 +1,409 @@
+"""D3-C2P actual-side diagnostic extraction — operator real 2025 KR trading.
+
+Reconstructs KR trading "cycles" (flat -> buy -> ... -> flat) from the sealed
+`operator-trade-history-v1` archive under the GAP-02 selector
+(``kis_domestic`` in full UNION ``toss`` rows with ``currency == "KRW"``), and
+computes the closed-cycle-series metrics that do not require an XKRX
+session_seq axis: ``adds_per_cycle``, ``add_sizing_multiple``, ``trim_share``,
+``signed_realized_pnl_pct``, ``annualized_cycle_count``.
+
+This is runner/loader code only (``d3-calibration-gap-closure-20260807.md``
+repo policy): it does not touch the D3 engine, contract, or golden inputs,
+and it never opens the sealed ``kr-corpus-v1`` holdout/calibration corpus —
+that is ``calibration_corpus.py``'s exclusive concern.
+
+## GAP-03 censoring (fix-r1, replacing the R1 job's non-compliant output)
+
+GAP-03 requires classifying every reconstructed cycle against the calendar
+window [2025-01-01, 2025-12-31] using **full trade history**, not a
+window-filtered fill set:
+
+* **left-censored ("carry-in")**: the cycle's first buy predates the window.
+  Any such cycle that has *any* in-window event (a 2025-dated add or sell —
+  including the sell that closes it, or a partial trim of a still-open
+  position) is excluded from every closed-cycle-series metric below and
+  counted in ``carry_in_excluded_count``. A left-censored cycle with zero
+  in-window events never contributes to those metrics in the first place, so
+  it is not counted (it was never going to be included or excluded).
+* **right-censored**: the cycle is still open (position > 0) as of
+  2025-12-31, judged **as of that date** — a cycle that later fully closes
+  in 2026 is still right-censored at the 2025 window boundary. Every
+  right-censored cycle is excluded from the closed-cycle-series metrics and
+  counted in ``right_censored_count``, regardless of when it opened (a cycle
+  can be both left- and right-censored at once — see
+  ``carry_in_and_right_censored_overlap``).
+* The eligible universe for the four closed-cycle-series metrics is
+  therefore: cycles whose first buy falls on/after 2025-01-01 **and** that
+  fully closed (position hit exactly zero) on/before 2025-12-31.
+
+## Oversell-clamp convention (disclosed, unchanged from the R1 job)
+
+The archive contains sell rows whose quantity exceeds the reconstructed
+position for a handful of symbols (``022100``, ``253450``, ``003380``,
+``035720``) — recorded sells exceeding recorded buys, most plausibly because
+the true position predates the archive window (toss coverage starts
+2024-11-07, kis 2020-05-19) or reflects an external transfer. Consistent
+with the R1 job's convention, such a sell is **clamped**: the sell quantity
+used for cycle bookkeeping is ``min(sell_qty, position)``, which closes the
+cycle at that event. Every clamp is recorded in ``anomalies`` (also
+disclosed if a *further* sell then lands on an already-flat position — a
+"sell while flat" residual, also recorded rather than silently dropped).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date, timedelta, timezone
+from decimal import Decimal, getcontext
+from pathlib import Path
+from typing import Any
+
+getcontext().prec = 50
+
+KST = timezone(timedelta(hours=9))
+WINDOW_START = date(2025, 1, 1)
+WINDOW_END = date(2025, 12, 31)
+
+DEFAULT_TRADE_HISTORY_ROOT = Path(
+    "/Users/mgh3326/work/herdr-artifacts/operator-trade-history-v1/merged"
+)
+
+
+def _in_window(value: date | None) -> bool:
+    return value is not None and WINDOW_START <= value <= WINDOW_END
+
+
+@dataclass(slots=True)
+class Cycle:
+    symbol: str
+    first_buy_date: date
+    n_buys: int = 1
+    n_sells: int = 0
+    closed: bool = False
+    close_date: date | None = None
+
+    @property
+    def key(self) -> tuple[str, date]:
+        return (self.symbol, self.first_buy_date)
+
+    def open_at(self, as_of: date) -> bool:
+        """True iff position was still open as of ``as_of`` (right-censoring
+        check) -- a cycle that closes *after* ``as_of`` is still open as of
+        that date even though it is not open forever."""
+        if self.first_buy_date > as_of:
+            return False
+        return not self.closed or (
+            self.close_date is not None and self.close_date > as_of
+        )
+
+
+@dataclass(slots=True)
+class AddEvent:
+    cycle_key: tuple[str, date]
+    date: date
+    multiple: Decimal
+
+
+@dataclass(slots=True)
+class SellEvent:
+    cycle_key: tuple[str, date]
+    date: date
+    trim_share: Decimal
+    pnl_pct: Decimal
+
+
+@dataclass(slots=True)
+class Fill:
+    symbol: str
+    side: str  # "BUY" | "SELL"
+    qty: Decimal
+    price: Decimal
+    ts: Any  # pandas Timestamp, tz-aware
+    date_kst: date
+    account: str  # "kis_domestic" | "toss_krw"
+
+    @property
+    def amount(self) -> Decimal:
+        return self.qty * self.price
+
+
+def load_fills(root: Path = DEFAULT_TRADE_HISTORY_ROOT) -> list[Fill]:
+    """GAP-02 selector: kis_domestic (all filled rows) UNION toss (currency==KRW, filled)."""
+    import pandas as pd
+    import pyarrow.parquet as pq
+
+    kis = pq.read_table(str(root / "kis_domestic.parquet")).to_pandas()
+    kis_qty = kis["tot_ccld_qty"].map(lambda s: Decimal(str(s).strip() or "0"))
+    kis_price = kis["avg_prvs"].map(lambda s: Decimal(str(s).strip() or "0"))
+    kis = kis.assign(qty=kis_qty, price=kis_price)
+    kf = kis[kis["qty"] > 0].copy()
+    kf["ts"] = pd.to_datetime(
+        kf["ord_dt"] + kf["ord_tmd"], format="%Y%m%d%H%M%S"
+    ).dt.tz_localize(KST)
+    kf["symbol"] = kf["pdno"]
+    kf["side"] = kf["sll_buy_dvsn_cd"].map({"01": "SELL", "02": "BUY"})
+    if kf["side"].isna().any():
+        raise ValueError(
+            f"unrecognized sll_buy_dvsn_cd: {kf['sll_buy_dvsn_cd'].unique()}"
+        )
+
+    toss = pq.read_table(str(root / "toss.parquet")).to_pandas()
+    execs = toss["execution"].map(lambda s: eval(s, {"Decimal": Decimal}))  # noqa: S307
+    toss = toss.assign(
+        qty=execs.map(lambda d: d["filledQuantity"]),
+        price=execs.map(lambda d: d["averageFilledPrice"]),
+        filled_at=execs.map(lambda d: d["filledAt"]),
+    )
+    tf = toss[(toss["qty"] > 0) & (toss["currency"] == "KRW")].copy()
+    tf["ts"] = pd.to_datetime(tf["filled_at"])
+
+    fills: list[Fill] = []
+    for frame, account in ((kf, "kis_domestic"), (tf, "toss_krw")):
+        for row in frame.itertuples(index=False):
+            ts = row.ts
+            fills.append(
+                Fill(
+                    symbol=str(row.symbol),
+                    side=str(row.side),
+                    qty=Decimal(row.qty),
+                    price=Decimal(row.price),
+                    ts=ts,
+                    date_kst=ts.tz_convert(KST).date(),
+                    account=account,
+                )
+            )
+    fills.sort(key=lambda f: (f.ts, f.symbol))
+    return fills
+
+
+@dataclass(slots=True)
+class Reconstruction:
+    cycles: list[Cycle] = field(default_factory=list)
+    add_events: list[AddEvent] = field(default_factory=list)
+    sell_events: list[SellEvent] = field(default_factory=list)
+    anomalies: list[str] = field(default_factory=list)
+
+
+def reconstruct_cycles(fills: list[Fill]) -> Reconstruction:
+    """Full-history reconstruction, positions merged across accounts by
+    symbol (a KR economic position is one exposure regardless of which
+    broker leg executed it — GAP-02 already treats kis_domestic/toss as a
+    single combined KR universe)."""
+    by_symbol: dict[str, list[Fill]] = {}
+    for f in fills:
+        by_symbol.setdefault(f.symbol, []).append(f)
+
+    out = Reconstruction()
+    for symbol, symbol_fills in by_symbol.items():
+        pos = Decimal(0)
+        avg = Decimal(0)
+        cyc: Cycle | None = None
+        for f in symbol_fills:
+            if f.side == "BUY":
+                if pos == 0:
+                    cyc = Cycle(symbol=symbol, first_buy_date=f.date_kst)
+                    out.cycles.append(cyc)
+                    avg = f.price
+                    pos = f.qty
+                else:
+                    assert cyc is not None
+                    out.add_events.append(
+                        AddEvent(
+                            cycle_key=cyc.key,
+                            date=f.date_kst,
+                            multiple=f.amount / _first_buy_amount(symbol_fills, cyc),
+                        )
+                    )
+                    cyc.n_buys += 1
+                    avg = (pos * avg + f.qty * f.price) / (pos + f.qty)
+                    pos += f.qty
+            else:  # SELL
+                if pos <= 0:
+                    out.anomalies.append(
+                        f"SELL while flat: {symbol} {f.ts} qty={f.qty}"
+                    )
+                    continue
+                sell_qty = f.qty
+                if sell_qty > pos:
+                    out.anomalies.append(
+                        f"SELL qty>pos (clamped to position): {symbol} {f.ts} "
+                        f"qty={f.qty} pos={pos}"
+                    )
+                    sell_qty = pos
+                assert cyc is not None
+                out.sell_events.append(
+                    SellEvent(
+                        cycle_key=cyc.key,
+                        date=f.date_kst,
+                        trim_share=sell_qty / pos,
+                        pnl_pct=(f.price - avg) / avg * 100,
+                    )
+                )
+                cyc.n_sells += 1
+                pos -= sell_qty
+                if pos == 0:
+                    cyc.closed = True
+                    cyc.close_date = f.date_kst
+    return out
+
+
+def _first_buy_amount(symbol_fills: list[Fill], cyc: Cycle) -> Decimal:
+    for f in symbol_fills:
+        if f.side == "BUY" and f.date_kst == cyc.first_buy_date:
+            return f.amount
+    raise AssertionError("cycle first buy not found in its own fill list")
+
+
+@dataclass(slots=True)
+class Gap03Classification:
+    carry_in_closed: list[Cycle]
+    carry_in_open_with_activity: list[Cycle]
+    right_censored: list[Cycle]
+    eligible_closed: list[Cycle]  # the closed-cycle-series universe
+
+    @property
+    def carry_in_all(self) -> list[Cycle]:
+        return self.carry_in_closed + self.carry_in_open_with_activity
+
+    @property
+    def overlap_carry_in_and_right_censored(self) -> list[Cycle]:
+        rc = {c.key for c in self.right_censored}
+        return [c for c in self.carry_in_open_with_activity if c.key in rc]
+
+
+def classify_gap03(recon: Reconstruction) -> Gap03Classification:
+    closed_in_window = [
+        c for c in recon.cycles if c.closed and _in_window(c.close_date)
+    ]
+    right_censored = [c for c in recon.cycles if c.open_at(WINDOW_END)]
+
+    carry_in_closed = [c for c in closed_in_window if c.first_buy_date < WINDOW_START]
+
+    activity_keys: set[tuple[str, date]] = set()
+    for e in recon.add_events:
+        if _in_window(e.date):
+            activity_keys.add(e.cycle_key)
+    for e in recon.sell_events:
+        if _in_window(e.date):
+            activity_keys.add(e.cycle_key)
+
+    carry_in_open_with_activity = [
+        c
+        for c in right_censored
+        if c.first_buy_date < WINDOW_START and c.key in activity_keys
+    ]
+
+    eligible_closed = [c for c in closed_in_window if c.first_buy_date >= WINDOW_START]
+
+    return Gap03Classification(
+        carry_in_closed=carry_in_closed,
+        carry_in_open_with_activity=carry_in_open_with_activity,
+        right_censored=right_censored,
+        eligible_closed=eligible_closed,
+    )
+
+
+def _median(values: list[Decimal]) -> tuple[Decimal | None, int]:
+    values = sorted(values)
+    n = len(values)
+    if n == 0:
+        return None, 0
+    if n % 2:
+        return values[n // 2], n
+    return (values[n // 2 - 1] + values[n // 2]) / 2, n
+
+
+def compute_metrics(
+    recon: Reconstruction, gap03: Gap03Classification
+) -> dict[str, Any]:
+    eligible_keys = {c.key for c in gap03.eligible_closed}
+
+    adds = [Decimal(c.n_buys - 1) for c in gap03.eligible_closed]
+    adds_median, adds_n = _median(adds)
+
+    add_multiples = [
+        e.multiple for e in recon.add_events if e.cycle_key in eligible_keys
+    ]
+    add_median, add_n = _median(add_multiples)
+
+    sells = [e for e in recon.sell_events if e.cycle_key in eligible_keys]
+    trim_median, trim_n = _median([e.trim_share for e in sells])
+    pnl_median, pnl_n = _median([e.pnl_pct for e in sells])
+
+    window_days = (WINDOW_END - WINDOW_START).days + 1
+    annualized = Decimal(len(gap03.eligible_closed)) * Decimal("365.2425") / window_days
+
+    return {
+        "closed_cycle_count": len(gap03.eligible_closed),
+        "right_censored_count": len(gap03.right_censored),
+        "carry_in_excluded_count": len(gap03.carry_in_all),
+        "carry_in_excluded_breakdown": {
+            "closed_carry_in": sorted(c.symbol for c in gap03.carry_in_closed),
+            "open_carry_in_with_2025_activity": sorted(
+                c.symbol for c in gap03.carry_in_open_with_activity
+            ),
+        },
+        "carry_in_and_right_censored_overlap": sorted(
+            c.symbol for c in gap03.overlap_carry_in_and_right_censored
+        ),
+        "anomalies": list(recon.anomalies),
+        "metrics": {
+            "annualized_cycle_count": {
+                "median_decimal": str(annualized),
+                "n": 1,
+                "note": (
+                    "single window-level observation, GAP-01 calendar-day basis "
+                    "(365.2425/window_calendar_days); numerator = GAP-03-eligible "
+                    "closed_cycle_count"
+                ),
+            },
+            "adds_per_cycle": {
+                "median_decimal": str(adds_median) if adds_median is not None else None,
+                "n": adds_n,
+                "raw_observation_count": adds_n,
+            },
+            "add_sizing_multiple": {
+                "median_decimal": str(add_median) if add_median is not None else None,
+                "n": add_n,
+                "raw_observation_count": add_n,
+            },
+            "trim_share": {
+                "median_decimal": str(trim_median) if trim_median is not None else None,
+                "n": trim_n,
+                "raw_observation_count": trim_n,
+            },
+            "signed_realized_pnl_pct": {
+                "median_decimal": str(pnl_median) if pnl_median is not None else None,
+                "n": pnl_n,
+                "raw_observation_count": pnl_n,
+                "fee_basis": (
+                    "gross (GAP-05: actual fee data absent/unpopulated in source schema)"
+                ),
+            },
+        },
+    }
+
+
+def main(root: Path = DEFAULT_TRADE_HISTORY_ROOT) -> dict[str, Any]:
+    fills = load_fills(root)
+    window_fills = [f for f in fills if _in_window(f.date_kst)]
+    result = {
+        "schema_id": "d3.calibration.actual_side_diagnostic.v1",
+        "selector": "GAP-02: kis_domestic (all) UNION toss(currency==KRW)",
+        "window": "2025-01-01..2025-12-31 (calendar; GAP-03 full-history censoring applied)",
+        "fills_total_2025": len(window_fills),
+        "fills_kis_domestic_2025": sum(
+            1 for f in window_fills if f.account == "kis_domestic"
+        ),
+        "fills_toss_krw_2025": sum(1 for f in window_fills if f.account == "toss_krw"),
+        "symbols_with_activity": len({f.symbol for f in window_fills}),
+    }
+    recon = reconstruct_cycles(fills)
+    gap03 = classify_gap03(recon)
+    result.update(compute_metrics(recon, gap03))
+    return result
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2, ensure_ascii=False))

--- a/research/kr_corpus/d3_engine/calibration_corpus.py
+++ b/research/kr_corpus/d3_engine/calibration_corpus.py
@@ -25,10 +25,11 @@ import hashlib
 import json
 import re
 from collections import defaultdict
-from dataclasses import dataclass, field
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 from research.kr_corpus.backtest.holdout_guard import (
     HOLDOUT_DIR,
@@ -447,7 +448,7 @@ class CalibrationCorpusLoader:
             )
             sessions = [date.fromisoformat(str(row["session"])) for row in rows]
             self.guard.record_bar_rows(sessions)
-            for row, session in zip(rows, sessions):
+            for row, session in zip(rows, sessions, strict=True):
                 by_symbol[ticker].append(
                     CalibrationBar(
                         session=session,

--- a/research/kr_corpus/d3_engine/calibration_corpus.py
+++ b/research/kr_corpus/d3_engine/calibration_corpus.py
@@ -1,0 +1,603 @@
+"""D3_CALIBRATION_2025 access-spy loader — the sole authorized opener of the
+sealed kr-corpus-v1 holdout root, scoped exclusively to calendar year 2025.
+
+D3-C2P (`brief-D3-DIAG-calibration-fidelity-20260807.md`) is the first job
+ever authorized to open `D3_CALIBRATION_2025`. This module implements that
+one-time, narrowly-scoped open. It is new runner/loader code only:
+
+* it does not import, modify, or relax
+  ``research/kr_corpus/backtest/holdout_guard.py`` or
+  ``research/kr_corpus/d3_engine/guards.py`` — both continue to hard-block
+  holdout/calibration/prospective access for every other caller unchanged
+  (regression-pinned in ``tests/test_calibration_corpus_guard.py``);
+* it never resolves, opens, or decodes any byte range whose session date is
+  outside 2025-01-01..2025-12-31, even though the sealed holdout root mixes
+  2025 and 2026 ("prospective") data in the same manifest, checksum list, and
+  ``source-anomalies.jsonl`` file;
+* every gate is checked *before* the corresponding read, and every check and
+  every read is counted in ``CalibrationAccessSpy`` — no self-declared "zero
+  log" statement is treated as evidence (GAP-08).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, TypeVar
+
+from research.kr_corpus.backtest.holdout_guard import (
+    HOLDOUT_DIR,
+    HoldoutAccessError,
+    path_is_under_holdout,
+)
+
+T = TypeVar("T")
+
+CALIBRATION_YEAR = 2025
+CALIBRATION_WINDOW_START = date(2025, 1, 1)
+CALIBRATION_WINDOW_END = date(2025, 12, 31)
+
+HOLDOUT_RUN_ID = "kr-corpus-v1-20260803-1001"
+
+# Byte-level pre-check only: extract the "session":"YYYY-..." year without a
+# JSON decode. Used to skip 2026 ("prospective") JSONL lines before any of
+# their field values (open/high/low/close) ever reach a Python object.
+_SESSION_YEAR_RE = re.compile(rb'"session"\s*:\s*"(\d{4})-')
+
+
+class CalibrationCorpusInvalid(ValueError):
+    code = "RUN_INVALID_CALIBRATION_CORPUS"
+
+
+class CalibrationAccessBlocked(PermissionError):
+    code = "SEALED_ACCESS_BLOCKED"
+
+
+@dataclass(slots=True)
+class CalibrationAccessSpy:
+    """Counts every gate check and every completed read. Fail-closed only."""
+
+    # gates evaluated before any read
+    year_checks: int = 0
+    date_checks: int = 0
+    path_checks: int = 0
+    # authorized (year==2025) completed reads
+    manifest_reads: int = 0
+    checksums_reads: int = 0
+    parquet_files_read: int = 0
+    bar_rows_read: int = 0
+    gap_files_read: int = 0
+    gap_rows_read: int = 0
+    anomaly_lines_prechecked: int = 0
+    anomaly_lines_decoded_2025: int = 0
+    anomaly_lines_skipped_2026_undecoded: int = 0
+    # blocked attempts (must be >0 only in the dedicated fail-closed probes)
+    blocked_year_attempts: int = 0
+    blocked_date_attempts: int = 0
+    blocked_path_attempts: int = 0
+
+    def evidence(self) -> dict[str, int]:
+        return {
+            "calibration_year_checks": self.year_checks,
+            "calibration_date_checks": self.date_checks,
+            "calibration_path_checks": self.path_checks,
+            "calibration_manifest_reads": self.manifest_reads,
+            "calibration_checksums_reads": self.checksums_reads,
+            "calibration_parquet_files_read": self.parquet_files_read,
+            "calibration_bar_rows_read": self.bar_rows_read,
+            "calibration_gap_files_read": self.gap_files_read,
+            "calibration_gap_rows_read": self.gap_rows_read,
+            "calibration_anomaly_lines_prechecked": self.anomaly_lines_prechecked,
+            "calibration_anomaly_lines_decoded_2025": self.anomaly_lines_decoded_2025,
+            "calibration_anomaly_lines_skipped_2026_undecoded": (
+                self.anomaly_lines_skipped_2026_undecoded
+            ),
+            "blocked_year_attempts": self.blocked_year_attempts,
+            "blocked_date_attempts": self.blocked_date_attempts,
+            "blocked_path_attempts": self.blocked_path_attempts,
+        }
+
+
+class CalibrationAccessGuard:
+    """Authorize exactly ``D3_CALIBRATION_2025`` reads; block everything else.
+
+    This is a *narrow allow-list* guard, the inverse shape of
+    ``guards.SealedAccessGuard`` (which is a deny-list for exploration code).
+    Both can coexist because they gate disjoint callers: exploration code
+    never imports this module, and this module never imports
+    ``SealedAccessGuard``.
+    """
+
+    def __init__(self, spy: CalibrationAccessSpy | None = None) -> None:
+        self.spy = spy or CalibrationAccessSpy()
+
+    def assert_calibration_year(self, year: int) -> int:
+        self.spy.year_checks += 1
+        if year != CALIBRATION_YEAR:
+            self.spy.blocked_year_attempts += 1
+            raise CalibrationAccessBlocked(
+                f"year {year} is not the authorized D3_CALIBRATION_2025 year "
+                f"({CALIBRATION_YEAR}); holdout years outside this scope "
+                "(including 2026 prospective) remain BLOCKED"
+            )
+        return year
+
+    def assert_calibration_date(self, value: date) -> date:
+        self.spy.date_checks += 1
+        if not (CALIBRATION_WINDOW_START <= value <= CALIBRATION_WINDOW_END):
+            self.spy.blocked_date_attempts += 1
+            raise CalibrationAccessBlocked(
+                f"date {value.isoformat()} is outside the authorized "
+                f"D3_CALIBRATION_2025 window {CALIBRATION_WINDOW_START}.."
+                f"{CALIBRATION_WINDOW_END}"
+            )
+        return value
+
+    def assert_calibration_path(self, path: Path) -> Path:
+        """Path must resolve under HOLDOUT_DIR and its year=2025 partition.
+
+        Reuses ``holdout_guard.path_is_under_holdout`` as a *positive* check
+        (this loader must only ever touch the canonical holdout root) rather
+        than the negative deny-check every other caller uses it for.
+        """
+        self.spy.path_checks += 1
+        resolved = path.expanduser().resolve(strict=False)
+        if not path_is_under_holdout(resolved):
+            self.spy.blocked_path_attempts += 1
+            raise CalibrationAccessBlocked(
+                f"path {resolved} is not under the authorized holdout root "
+                f"{HOLDOUT_DIR}"
+            )
+        if "year=2026" in resolved.parts or resolved.parts[-2:-1] == ("2026",):
+            self.spy.blocked_path_attempts += 1
+            raise CalibrationAccessBlocked(
+                f"path {resolved} touches the 2026 prospective partition; "
+                "blocked outside D3_CALIBRATION_2025 scope"
+            )
+        return resolved
+
+    def read_manifest(self, *, path: Path, loader: Callable[[], T]) -> T:
+        self.assert_calibration_path(path)
+        result = loader()
+        self.spy.manifest_reads += 1
+        return result
+
+    def read_checksums(self, *, path: Path, loader: Callable[[], T]) -> T:
+        self.assert_calibration_path(path)
+        result = loader()
+        self.spy.checksums_reads += 1
+        return result
+
+    def read_year_partition_parquet(
+        self, *, year: int, path: Path, loader: Callable[[], T]
+    ) -> T:
+        self.assert_calibration_year(year)
+        self.assert_calibration_path(path)
+        result = loader()
+        self.spy.parquet_files_read += 1
+        return result
+
+    def read_year_partition_gap_file(
+        self, *, year: int, path: Path, loader: Callable[[], T]
+    ) -> T:
+        self.assert_calibration_year(year)
+        self.assert_calibration_path(path)
+        result = loader()
+        self.spy.gap_files_read += 1
+        return result
+
+    def record_bar_rows(self, sessions: list[date] | tuple[date, ...]) -> None:
+        for session in sessions:
+            self.assert_calibration_date(session)
+        self.spy.bar_rows_read += len(sessions)
+
+    def record_gap_rows(self, count: int) -> None:
+        self.spy.gap_rows_read += count
+
+    def precheck_anomaly_line(self, raw_line: bytes) -> bool:
+        """Byte-level year check with NO JSON decode. Returns True iff 2025.
+
+        This is the gate that lets the loader stream a single
+        ``source-anomalies.jsonl`` file that mixes 2025 (authorized) and 2026
+        (blocked) records without ever constructing a Python object from a
+        2026 line's field values (open/high/low/close/volume).
+        """
+        self.spy.anomaly_lines_prechecked += 1
+        match = _SESSION_YEAR_RE.search(raw_line)
+        if match is None:
+            raise CalibrationCorpusInvalid("anomaly line has no session field")
+        year = int(match.group(1))
+        if year != CALIBRATION_YEAR:
+            self.spy.anomaly_lines_skipped_2026_undecoded += 1
+            return False
+        self.spy.anomaly_lines_decoded_2025 += 1
+        return True
+
+
+def measure_calibration_fail_closed_probes() -> dict[str, object]:
+    """Prove the three non-calibration routes stay BLOCKED (GAP-08).
+
+    Mirrors ``guards.measure_sealed_fail_closed_probes``: every probe must
+    raise before its loader executes, and the shared, unmodified
+    ``holdout_guard`` regression pins (2025 AND 2026 dates) must still block.
+    """
+    spy = CalibrationAccessSpy()
+    guard = CalibrationAccessGuard(spy)
+    loader_calls = 0
+
+    def loader() -> bytes:
+        nonlocal loader_calls
+        loader_calls += 1
+        return b"forbidden"
+
+    outcomes: dict[str, str] = {}
+
+    # 1) holdout year=2026 (prospective) partition — BLOCKED
+    try:
+        guard.read_year_partition_parquet(
+            year=2026,
+            path=HOLDOUT_DIR
+            / "runs"
+            / HOLDOUT_RUN_ID
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2026"
+            / "ticker=005930.parquet",
+            loader=loader,
+        )
+    except CalibrationAccessBlocked:
+        outcomes["prospective_2026_partition"] = "PASS"
+    else:
+        outcomes["prospective_2026_partition"] = "FAIL"
+
+    # 2) a path outside the canonical holdout root, even if it says "2025" —
+    #    BLOCKED (path allow-list, not just a year check)
+    try:
+        guard.read_year_partition_parquet(
+            year=2025,
+            path=Path("/tmp/not-holdout/dataset/market=KOSPI/year=2025/x.parquet"),
+            loader=loader,
+        )
+    except CalibrationAccessBlocked:
+        outcomes["non_holdout_path"] = "PASS"
+    else:
+        outcomes["non_holdout_path"] = "FAIL"
+
+    # 3) a 2026-dated bar observed mid-stream — BLOCKED
+    try:
+        guard.record_bar_rows([date(2025, 6, 2), date(2026, 1, 5)])
+    except CalibrationAccessBlocked:
+        outcomes["prospective_2026_date_mid_stream"] = "PASS"
+    else:
+        outcomes["prospective_2026_date_mid_stream"] = "FAIL"
+
+    # 4) regression pin — the shared, unmodified holdout_guard must still
+    #    hard-block both in-window years for every *other* caller.
+    from research.kr_corpus.backtest import holdout_guard as _hg
+
+    holdout_guard_still_blocks = True
+    for probe_date in (date(2025, 6, 1), date(2026, 1, 5)):
+        try:
+            _hg.assert_date_not_holdout(probe_date)
+        except HoldoutAccessError:
+            pass
+        else:
+            holdout_guard_still_blocks = False
+    outcomes["holdout_guard_regression_unchanged"] = (
+        "PASS" if holdout_guard_still_blocks else "FAIL"
+    )
+
+    # 5) regression pin — SealedAccessGuard (exploration/primary code) must
+    #    still hard-block any 2025+ date, unaffected by this module existing.
+    from research.kr_corpus.d3_engine.guards import (
+        SealedAccessBlocked,
+        SealedAccessGuard,
+    )
+
+    sealed_guard = SealedAccessGuard()
+    try:
+        sealed_guard.assert_exploration_date(date(2025, 1, 2))
+    except SealedAccessBlocked:
+        outcomes["sealed_access_guard_regression_unchanged"] = "PASS"
+    else:
+        outcomes["sealed_access_guard_regression_unchanged"] = "FAIL"
+
+    evidence = spy.evidence()
+    passed = all(value == "PASS" for value in outcomes.values()) and loader_calls == 0
+    return {
+        "status": "PASS" if passed else "FAIL",
+        "outcomes": outcomes,
+        "loader_calls": loader_calls,
+        "spy_evidence": evidence,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bar / clamp materialization (year=2025 only)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationBar:
+    session: date
+    symbol: str
+    market: str
+    open: int
+    high: int
+    low: int
+    close: int
+    volume: int
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationClampRow:
+    session: date
+    symbol: str
+    market: str
+    source_high: int
+    source_low: int
+    high: int
+    low: int
+    delta_high: int
+    delta_low: int
+    classification: str
+    admitted: bool
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedCalibrationView:
+    view: str  # "original" | "clamp"
+    bars: tuple[CalibrationBar, ...]
+    clamp_rows: dict[tuple[date, str], CalibrationClampRow]
+    no_trade_count: int
+    manifest_sha256: str
+    parquet_files: int
+    row_count: int
+    access_evidence: dict[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationCorpusPaths:
+    holdout_root: Path
+
+    @classmethod
+    def defaults(cls) -> CalibrationCorpusPaths:
+        return cls(holdout_root=HOLDOUT_DIR / "runs" / HOLDOUT_RUN_ID)
+
+
+class CalibrationCorpusLoader:
+    """Load ONLY the year=2025 partition of the sealed holdout root."""
+
+    def __init__(
+        self,
+        *,
+        paths: CalibrationCorpusPaths | None = None,
+        guard: CalibrationAccessGuard | None = None,
+    ) -> None:
+        self.paths = paths or CalibrationCorpusPaths.defaults()
+        self.guard = guard or CalibrationAccessGuard()
+        root = self.paths.holdout_root.expanduser().resolve(strict=True)
+        if not path_is_under_holdout(root):
+            raise CalibrationCorpusInvalid(
+                f"configured root {root} is not the canonical holdout root"
+            )
+        self.root = root
+
+    def load_manifest(self) -> dict[str, Any]:
+        manifest_path = self.root / "manifest.json"
+        raw = self.guard.read_manifest(
+            path=manifest_path, loader=manifest_path.read_bytes
+        )
+        manifest = json.loads(raw)
+        if manifest.get("scope") != "holdout":
+            raise CalibrationCorpusInvalid("holdout manifest scope drift")
+        if manifest.get("corpus_id") != "kr-corpus-v1":
+            raise CalibrationCorpusInvalid("holdout manifest corpus_id drift")
+        return manifest
+
+    def _checksum_entries_for_2025(
+        self,
+    ) -> tuple[tuple[str, PurePosixPath], ...]:
+        checksums_path = self.root / "checksums.sha256"
+        raw = self.guard.read_checksums(
+            path=checksums_path, loader=checksums_path.read_bytes
+        )
+        text = raw.decode("utf-8")
+        entries: list[tuple[str, PurePosixPath]] = []
+        seen: set[PurePosixPath] = set()
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            expected, raw_relative = line.split(maxsplit=1)
+            relative = PurePosixPath(raw_relative.lstrip("*"))
+            if relative.parts and relative.parts[0] != "dataset":
+                continue
+            if "year=2025" not in relative.parts:
+                continue  # 2026 entries: path noted, bytes never opened below
+            if relative.suffix != ".parquet" or relative in seen:
+                raise CalibrationCorpusInvalid(f"invalid dataset checksum row:{line}")
+            seen.add(relative)
+            entries.append((expected, relative))
+        if not entries:
+            raise CalibrationCorpusInvalid("no year=2025 dataset entries found")
+        return tuple(sorted(entries, key=lambda item: str(item[1])))
+
+    def load_original(self) -> LoadedCalibrationView:
+        manifest = self.load_manifest()
+        entries = self._checksum_entries_for_2025()
+        by_symbol: dict[str, list[CalibrationBar]] = defaultdict(list)
+        total_rows = 0
+        for expected_sha, relative in entries:
+            market, year, ticker = _partition(relative)
+            path = (self.root / relative).resolve(strict=True)
+            actual_sha = self.guard.read_year_partition_parquet(
+                year=year, path=path, loader=lambda path=path: _sha256_stream(path)
+            )
+            if actual_sha != expected_sha:
+                raise CalibrationCorpusInvalid(
+                    f"parquet checksum drift:{relative}:{actual_sha}!={expected_sha}"
+                )
+            rows = self.guard.read_year_partition_parquet(
+                year=year, path=path, loader=lambda path=path: _read_parquet_rows(path)
+            )
+            sessions = [date.fromisoformat(str(row["session"])) for row in rows]
+            self.guard.record_bar_rows(sessions)
+            for row, session in zip(rows, sessions):
+                by_symbol[ticker].append(
+                    CalibrationBar(
+                        session=session,
+                        symbol=ticker,
+                        market=market,
+                        open=int(row["open"]),
+                        high=int(row["high"]),
+                        low=int(row["low"]),
+                        close=int(row["close"]),
+                        volume=int(row["volume"]),
+                    )
+                )
+            total_rows += len(rows)
+        bars = tuple(
+            bar
+            for symbol in sorted(by_symbol)
+            for bar in sorted(by_symbol[symbol], key=lambda b: b.session)
+        )
+        return LoadedCalibrationView(
+            view="original",
+            bars=bars,
+            clamp_rows={},
+            no_trade_count=0,
+            manifest_sha256=hashlib.sha256(
+                json.dumps(manifest, sort_keys=True).encode()
+            ).hexdigest(),
+            parquet_files=len(entries),
+            row_count=total_rows,
+            access_evidence=self.guard.spy.evidence(),
+        )
+
+    def load_clamp(self, original: LoadedCalibrationView) -> LoadedCalibrationView:
+        """Apply the frozen clamp formula (manifest-documented, deterministic)
+        to the 2025-scope OHLC anomalies only. Reimplemented here (not calling
+        ``clamp_admit.build_clamp_admit_view``, which hard-refuses any source
+        root containing "holdout" by design) because the frozen builder must
+        not be relaxed for this one-time authorized open.
+        """
+        clamp_rows: dict[tuple[date, str], CalibrationClampRow] = {}
+        no_trade_count = 0
+        clamp_count = 0
+        anomalies_path = self.root / "source-anomalies.jsonl"
+        self.guard.assert_calibration_path(anomalies_path)
+        with anomalies_path.open("rb") as stream:
+            for raw_line in stream:
+                if not raw_line.strip():
+                    continue
+                if not self.guard.precheck_anomaly_line(raw_line):
+                    continue  # 2026 line: never json.loads'd, never decoded
+                record = json.loads(raw_line)
+                if record.get("kind") != "ohlc_invariant_violation":
+                    continue
+                session = date.fromisoformat(str(record["session"]))
+                self.guard.assert_calibration_date(session)
+                ticker = str(record["ticker"])
+                detail = record["detail"]
+                open_price = int(detail["open"])
+                source_high = int(detail["high"])
+                source_low = int(detail["low"])
+                close_price = int(detail["close"])
+                is_no_trade = (
+                    open_price == 0
+                    and source_high == 0
+                    and source_low == 0
+                    and close_price > 0
+                )
+                if is_no_trade:
+                    no_trade_count += 1
+                    continue
+                clamped_high = max(source_high, open_price, close_price)
+                clamped_low = min(source_low, open_price, close_price)
+                delta_high = clamped_high - source_high
+                delta_low = source_low - clamped_low
+                if delta_high <= 0 and delta_low <= 0:
+                    raise CalibrationCorpusInvalid(
+                        "tradeable clamp row did not repair OHLC invariant"
+                    )
+                market = _market_for_ticker(ticker, self._market_lookup())
+                key = (session, ticker)
+                if key in clamp_rows:
+                    raise CalibrationCorpusInvalid(f"duplicate clamped row:{key}")
+                clamp_rows[key] = CalibrationClampRow(
+                    session=session,
+                    symbol=ticker,
+                    market=market,
+                    source_high=source_high,
+                    source_low=source_low,
+                    high=clamped_high,
+                    low=clamped_low,
+                    delta_high=delta_high,
+                    delta_low=delta_low,
+                    classification="tradeable_adjusted_rounding",
+                    admitted=True,
+                )
+                clamp_count += 1
+        self.guard.record_gap_rows(no_trade_count + clamp_count)
+        return LoadedCalibrationView(
+            view="clamp",
+            bars=original.bars,  # clamp_rows carries the corrected OHLC deltas
+            clamp_rows=clamp_rows,
+            no_trade_count=no_trade_count,
+            manifest_sha256=original.manifest_sha256,
+            parquet_files=original.parquet_files,
+            row_count=original.row_count + clamp_count,
+            access_evidence=self.guard.spy.evidence(),
+        )
+
+    def _market_lookup(self) -> dict[str, str]:
+        lookup: dict[str, str] = {}
+        for market in ("KOSPI", "KOSDAQ"):
+            partition_dir = self.root / "dataset" / f"market={market}" / "year=2025"
+            self.guard.assert_calibration_path(partition_dir)
+            for path in sorted(partition_dir.glob("ticker=*.parquet")):
+                ticker = path.stem.removeprefix("ticker=")
+                lookup[ticker] = market
+        return lookup
+
+
+def _partition(relative: PurePosixPath) -> tuple[str, int, str]:
+    if len(relative.parts) != 4:
+        raise CalibrationCorpusInvalid(f"unexpected dataset partition:{relative}")
+    _, market_part, year_part, ticker_part = relative.parts
+    market = market_part.removeprefix("market=")
+    year = int(year_part.removeprefix("year="))
+    ticker = ticker_part.removeprefix("ticker=").removesuffix(".parquet")
+    if market not in {"KOSPI", "KOSDAQ"}:
+        raise CalibrationCorpusInvalid(f"unsupported market partition:{market}")
+    if year != CALIBRATION_YEAR:
+        raise CalibrationCorpusInvalid(f"non-calibration year partition:{year}")
+    return market, year, ticker
+
+
+def _market_for_ticker(ticker: str, lookup: dict[str, str]) -> str:
+    market = lookup.get(ticker)
+    if market is None:
+        raise CalibrationCorpusInvalid(f"clamp anomaly ticker has no market:{ticker}")
+    return market
+
+
+def _sha256_stream(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_parquet_rows(path: Path) -> list[dict[str, Any]]:
+    import pyarrow.parquet as pq
+
+    columns = ["session", "market", "ticker", "open", "high", "low", "close", "volume"]
+    table = pq.ParquetFile(path).read(columns=columns)
+    return table.to_pylist()

--- a/research/kr_corpus/d3_engine/tests/test_calibration_corpus_guard.py
+++ b/research/kr_corpus/d3_engine/tests/test_calibration_corpus_guard.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from research.kr_corpus.backtest.holdout_guard import (
+    HoldoutAccessError,
+    assert_date_not_holdout,
+    assert_partition_year_not_holdout,
+)
+from research.kr_corpus.d3_engine.calibration_corpus import (
+    CalibrationAccessBlocked,
+    CalibrationAccessGuard,
+    CalibrationAccessSpy,
+    CalibrationCorpusInvalid,
+    measure_calibration_fail_closed_probes,
+)
+from research.kr_corpus.d3_engine.guards import SealedAccessBlocked, SealedAccessGuard
+
+
+def test_year_gate_authorizes_only_2025() -> None:
+    guard = CalibrationAccessGuard()
+    assert guard.assert_calibration_year(2025) == 2025
+    with pytest.raises(CalibrationAccessBlocked):
+        guard.assert_calibration_year(2026)
+    with pytest.raises(CalibrationAccessBlocked):
+        guard.assert_calibration_year(2024)
+    assert guard.spy.blocked_year_attempts == 2
+
+
+def test_date_gate_authorizes_only_calendar_2025() -> None:
+    guard = CalibrationAccessGuard()
+    assert guard.assert_calibration_date(date(2025, 12, 31)) == date(2025, 12, 31)
+    with pytest.raises(CalibrationAccessBlocked):
+        guard.assert_calibration_date(date(2026, 1, 1))
+    with pytest.raises(CalibrationAccessBlocked):
+        guard.assert_calibration_date(date(2024, 12, 31))
+    assert guard.spy.blocked_date_attempts == 2
+
+
+def test_path_gate_refuses_non_holdout_root(tmp_path: Path) -> None:
+    guard = CalibrationAccessGuard()
+    with pytest.raises(CalibrationAccessBlocked):
+        guard.assert_calibration_path(tmp_path / "dataset" / "year=2025" / "x.parquet")
+    assert guard.spy.blocked_path_attempts == 1
+
+
+def test_path_gate_refuses_2026_partition_even_under_holdout_root() -> None:
+    from research.kr_corpus.d3_engine.calibration_corpus import (
+        CalibrationCorpusPaths,
+    )
+
+    guard = CalibrationAccessGuard()
+    root = CalibrationCorpusPaths.defaults().holdout_root
+    with pytest.raises(CalibrationAccessBlocked):
+        guard.assert_calibration_path(
+            root / "dataset" / "market=KOSPI" / "year=2026" / "ticker=005930.parquet"
+        )
+
+
+def test_precheck_anomaly_line_never_decodes_2026_json() -> None:
+    guard = CalibrationAccessGuard()
+    line_2025 = json.dumps(
+        {"session": "2025-06-02", "detail": {"open": 1}}
+    ).encode()
+    line_2026 = json.dumps(
+        {"session": "2026-01-05", "detail": {"open": 999999}}
+    ).encode()
+
+    assert guard.precheck_anomaly_line(line_2025) is True
+    assert guard.precheck_anomaly_line(line_2026) is False
+    assert guard.spy.anomaly_lines_decoded_2025 == 1
+    assert guard.spy.anomaly_lines_skipped_2026_undecoded == 1
+    assert guard.spy.anomaly_lines_prechecked == 2
+
+
+def test_record_bar_rows_blocks_on_first_prospective_date() -> None:
+    guard = CalibrationAccessGuard()
+    with pytest.raises(CalibrationAccessBlocked):
+        guard.record_bar_rows([date(2025, 6, 2), date(2026, 1, 5)])
+    # the 2025 row is still counted before the blocking row is hit
+    assert guard.spy.bar_rows_read == 0 or guard.spy.date_checks >= 1
+
+
+def test_fail_closed_probe_suite_passes_and_leaves_zero_authorized_reads() -> None:
+    result = measure_calibration_fail_closed_probes()
+    assert result["status"] == "PASS", result
+    assert result["loader_calls"] == 0
+    evidence = result["spy_evidence"]
+    assert evidence["calibration_parquet_files_read"] == 0
+    assert evidence["calibration_manifest_reads"] == 0
+    assert evidence["blocked_year_attempts"] >= 1
+    assert evidence["blocked_path_attempts"] >= 1
+
+
+def test_holdout_guard_regression_unchanged_for_both_holdout_years() -> None:
+    """This module must not weaken holdout_guard for any other caller."""
+    with pytest.raises(HoldoutAccessError):
+        assert_date_not_holdout(date(2025, 6, 1))
+    with pytest.raises(HoldoutAccessError):
+        assert_date_not_holdout(date(2026, 1, 5))
+    with pytest.raises(HoldoutAccessError):
+        assert_partition_year_not_holdout(2025)
+    with pytest.raises(HoldoutAccessError):
+        assert_partition_year_not_holdout(2026)
+
+
+def test_sealed_access_guard_regression_unchanged() -> None:
+    """This module must not weaken guards.SealedAccessGuard for exploration code."""
+    guard = SealedAccessGuard()
+    with pytest.raises(SealedAccessBlocked):
+        guard.assert_exploration_date(date(2025, 1, 2))
+    with pytest.raises(SealedAccessBlocked):
+        guard.assert_exploration_path("/x/holdout/y")
+
+
+def test_spy_evidence_shape_is_stable() -> None:
+    spy = CalibrationAccessSpy()
+    evidence = spy.evidence()
+    assert evidence["calibration_year_checks"] == 0
+    assert evidence["blocked_year_attempts"] == 0
+    assert set(evidence) == {
+        "calibration_year_checks",
+        "calibration_date_checks",
+        "calibration_path_checks",
+        "calibration_manifest_reads",
+        "calibration_checksums_reads",
+        "calibration_parquet_files_read",
+        "calibration_bar_rows_read",
+        "calibration_gap_files_read",
+        "calibration_gap_rows_read",
+        "calibration_anomaly_lines_prechecked",
+        "calibration_anomaly_lines_decoded_2025",
+        "calibration_anomaly_lines_skipped_2026_undecoded",
+        "blocked_year_attempts",
+        "blocked_date_attempts",
+        "blocked_path_attempts",
+    }

--- a/research/kr_corpus/d3_engine/tests/test_calibration_corpus_guard.py
+++ b/research/kr_corpus/d3_engine/tests/test_calibration_corpus_guard.py
@@ -15,7 +15,6 @@ from research.kr_corpus.d3_engine.calibration_corpus import (
     CalibrationAccessBlocked,
     CalibrationAccessGuard,
     CalibrationAccessSpy,
-    CalibrationCorpusInvalid,
     measure_calibration_fail_closed_probes,
 )
 from research.kr_corpus.d3_engine.guards import SealedAccessBlocked, SealedAccessGuard
@@ -63,9 +62,7 @@ def test_path_gate_refuses_2026_partition_even_under_holdout_root() -> None:
 
 def test_precheck_anomaly_line_never_decodes_2026_json() -> None:
     guard = CalibrationAccessGuard()
-    line_2025 = json.dumps(
-        {"session": "2025-06-02", "detail": {"open": 1}}
-    ).encode()
+    line_2025 = json.dumps({"session": "2025-06-02", "detail": {"open": 1}}).encode()
     line_2026 = json.dumps(
         {"session": "2026-01-05", "detail": {"open": 999999}}
     ).encode()


### PR DESCRIPTION
## Summary
- Adds `research/kr_corpus/d3_engine/calibration_corpus.py`: the first authorized opener of the sealed `kr-corpus-v1` holdout, scoped exclusively to `D3_CALIBRATION_2025` (2025-01-01..2025-12-31). New runner/loader code only — does not modify `holdout_guard.py` or `guards.py`.
- Adds `research/kr_corpus/d3_engine/tests/test_calibration_corpus_guard.py`: 10 fail-closed + regression tests (2026 prospective partition blocked, non-holdout paths blocked, mid-stream prospective dates blocked, existing `holdout_guard`/`SealedAccessGuard` modules independently verified still-blocking and unmodified).
- **Job status: `CALIBRATION_INCOMPLETE` → `NEEDS_UPSTREAM(missing_2025_xkrx_session_and_index_calendar_input)`.** The frozen, SHA-gated `kospi_index_daily_2014_2024.csv` has zero 2025 rows, and `primary.py` derives the engine's entire `market_sessions`/`index_closes` axis exclusively from that file, so `PortfolioEngine` cannot be given a 2025 session axis under the current 12-gate contract input set. Zero physical B0 runs were produced. Full finding, evidence, and actual-side diagnostic numbers in `~/work/herdr-artifacts/d3-calibration-2p-v1/`.
- No engine, contract, golden, or sealed-input files touched. No winner selection, no economic re-ranking, no broker/order/account/scheduler mutation.

## Test plan
- [x] `uv run pytest research/kr_corpus/d3_engine/tests/test_calibration_corpus_guard.py -v` — 10/10 pass
- [x] `uv run pytest research/kr_corpus/ -q` — 157/157 pass (no regressions)
- [x] Independent recount cross-check: authorized 2025 dataset-file reads (2,862) match `checksums.sha256` year=2025 entry count exactly
- [x] Fail-closed probe suite: 2026 partition / non-holdout path / mid-stream prospective date all raise before their loader executes; `holdout_guard` and `SealedAccessGuard` regression-pinned unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a controlled calibration data workflow limited to the 2025 calendar year.
  * Added validation for dates, file locations, manifests, checksums, and partition data.
  * Added standardized OHLC bar output, including no-trade periods and anomaly filtering.
  * Added diagnostics for reconstructing trading cycles and reporting closed-cycle metrics.

* **Bug Fixes**
  * Prevented access to out-of-range data and unauthorized locations.
  * Ensured invalid or unexpected calibration inputs fail safely.

* **Tests**
  * Added coverage for access controls, validation, anomaly handling, and regression protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->