### PR TITLE
feat(research): A2 calibration carve-out + D3-C2G B0 2-physical runner

### DIFF
--- a/research/kr_corpus/d3_engine/calibration_acceptance.py
+++ b/research/kr_corpus/d3_engine/calibration_acceptance.py
@@ -1,0 +1,250 @@
+"""Measured acceptance probes for the A2 carve-out.
+
+Two independent obligations live here.
+
+1. :func:`measure_calibration_fail_closed_probes` — the three new fail-closed
+   routes A2 requires (2026 date, prospective path, file outside the
+   ``D3_CALIBRATION_2025`` manifest) plus regression pins proving the base
+   deny-list guards are unchanged. Every outcome is a measured counter, never a
+   statement.
+2. :func:`measure_primary_path_isolation` — the behavioural proof that the
+   *primary* runner never gains the carve-out. It instantiates the real
+   ``PrimaryPortfolioEngine`` and probes the guard that runner installs. The A2
+   mutant "inject the calibration guard into the primary runner" is killed by
+   this predicate: a calibration-scoped guard admits 2025 and the holdout root,
+   so the isolation status flips to FAIL.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from research.kr_corpus.backtest import holdout_guard as _holdout_guard
+from research.kr_corpus.backtest.holdout_guard import HoldoutAccessError
+from research.kr_corpus.d3_engine.calibration_guard import CalibrationAccessGuard
+from research.kr_corpus.d3_engine.constants import ArtifactPaths
+from research.kr_corpus.d3_engine.guards import (
+    SealedAccessBlocked,
+    SealedAccessGuard,
+    SealedAccessSpy,
+)
+from research.kr_corpus.d3_engine.models import DataView
+from research.kr_corpus.d3_engine.primary import PrimaryPortfolioEngine
+from research.kr_corpus.d3_engine.primary_corpus import LoadedCorpusView
+from research.kr_corpus.d3_engine.tick import TickTable, load_tick_table
+
+PROBE_PROSPECTIVE_DATE = date(2026, 1, 5)
+PROBE_PRIMARY_SEALED_DATE = date(2025, 1, 2)
+
+
+def clone_probe_guard(template: CalibrationAccessGuard) -> CalibrationAccessGuard:
+    """A fresh guard with the same A2 scope and its own spy.
+
+    ``type(template)`` — not the base class — so the probes exercise the exact
+    implementation the run uses. A mutated guard is probed as itself.
+    """
+
+    return template.fresh_clone()
+
+
+def measure_calibration_fail_closed_probes(
+    *,
+    template: CalibrationAccessGuard,
+    prospective_path: Path,
+    outside_manifest_path: Path,
+    authorized_path: Path,
+) -> dict[str, Any]:
+    """Exercise the three A2 blocked routes; no loader may ever execute."""
+
+    guard = clone_probe_guard(template)
+    loader_calls = 0
+
+    def loader() -> str:
+        nonlocal loader_calls
+        loader_calls += 1
+        return "forbidden"
+
+    outcomes: dict[str, str] = {}
+
+    # (1) a 2026 date, reached through the same read path a bar takes.
+    try:
+        guard.read_bar(
+            path=authorized_path, session=PROBE_PROSPECTIVE_DATE, loader=loader
+        )
+    except SealedAccessBlocked:
+        outcomes["prospective_2026_date"] = "PASS"
+    else:
+        outcomes["prospective_2026_date"] = "FAIL"
+
+    # (1b) the same date observed mid-stream, after its file gate already passed.
+    try:
+        guard.record_bar_rows([date(2025, 1, 2), PROBE_PROSPECTIVE_DATE])
+    except SealedAccessBlocked:
+        outcomes["prospective_2026_date_mid_stream"] = "PASS"
+    else:
+        outcomes["prospective_2026_date_mid_stream"] = "FAIL"
+
+    # (1c) a 2025 date that the sealed calendar does not carry (a KRX holiday).
+    try:
+        guard.assert_exploration_date(date(2025, 1, 1))
+    except SealedAccessBlocked:
+        outcomes["offcalendar_2025_date"] = "PASS"
+    else:
+        outcomes["offcalendar_2025_date"] = "FAIL"
+
+    # (2) a real, existing prospective partition file.
+    try:
+        guard.read_parquet(path=prospective_path, loader=loader)
+    except SealedAccessBlocked:
+        outcomes["prospective_partition_path"] = "PASS"
+    else:
+        outcomes["prospective_partition_path"] = "FAIL"
+
+    # (3) an in-scope-year holdout path the manifest does not enumerate. This
+    #     isolates the manifest membership check from the year check.
+    try:
+        guard.read_parquet(path=outside_manifest_path, loader=loader)
+    except SealedAccessBlocked:
+        outcomes["outside_manifest_file"] = "PASS"
+    else:
+        outcomes["outside_manifest_file"] = "FAIL"
+
+    # (3b) a sealed segment that is not under the holdout root at all.
+    try:
+        guard.read_file(path=Path("/tmp/prospective/bars.parquet"), loader=loader)
+    except SealedAccessBlocked:
+        outcomes["sealed_token_outside_holdout_root"] = "PASS"
+    else:
+        outcomes["sealed_token_outside_holdout_root"] = "FAIL"
+
+    # (4) regression pin: the base deny-list guard is unchanged for every
+    #     other caller — 2025 dates and holdout paths still hard-block.
+    base = SealedAccessGuard(SealedAccessSpy())
+    base_blocks = 0
+    for probe in (
+        lambda: base.assert_exploration_date(PROBE_PRIMARY_SEALED_DATE),
+        lambda: base.assert_exploration_path(prospective_path),
+        lambda: base.assert_exploration_path(authorized_path),
+    ):
+        try:
+            probe()
+        except SealedAccessBlocked:
+            base_blocks += 1
+    outcomes["sealed_access_guard_regression_unchanged"] = (
+        "PASS" if base_blocks == 3 else "FAIL"
+    )
+
+    # (5) regression pin: the shared holdout guard is unchanged.
+    holdout_blocks = 0
+    for probe_date in (date(2025, 6, 1), PROBE_PROSPECTIVE_DATE):
+        try:
+            _holdout_guard.assert_date_not_holdout(probe_date)
+        except HoldoutAccessError:
+            holdout_blocks += 1
+    outcomes["holdout_guard_regression_unchanged"] = (
+        "PASS" if holdout_blocks == 2 else "FAIL"
+    )
+
+    evidence = guard.spy.evidence()
+    passed = (
+        all(value == "PASS" for value in outcomes.values())
+        and loader_calls == 0
+        and evidence["sealed_access_spy"] == 0
+        and evidence["measured_file_reads"] == 0
+        and evidence["sealed_access_blocked_attempts"] == 6
+    )
+    return {
+        "status": "PASS" if passed else "FAIL",
+        "outcomes": outcomes,
+        "loader_calls": loader_calls,
+        "authorized_sealed_reads_during_probes": evidence["sealed_access_spy"],
+        "blocked_attempts": evidence["sealed_access_blocked_attempts"],
+        "probe_paths": {
+            "prospective": str(prospective_path),
+            "outside_manifest": str(outside_manifest_path),
+            "authorized_reference": str(authorized_path),
+        },
+        "spy_evidence": evidence,
+    }
+
+
+def _empty_corpus_view() -> LoadedCorpusView:
+    return LoadedCorpusView(
+        data_view=DataView.ORIGINAL_VALID_BAR,
+        bars=(),
+        signals={},
+        clamp_rows={},
+        market_periods={},
+        manifest_sha256="0" * 64,
+        checksums_sha256="0" * 64,
+        parquet_files=0,
+        row_count=0,
+        signal_tape_sha256="0" * 64,
+        access_evidence={},
+    )
+
+
+def measure_primary_path_isolation(
+    *,
+    tick_table: TickTable | None = None,
+    guard_override: object | None = None,
+) -> dict[str, Any]:
+    """Probe the guard the *primary* runner installs on its own engine.
+
+    ``guard_override`` is the mutant hook: passing a calibration-scoped guard
+    simulates the forbidden wiring, and every predicate below must then fail.
+    """
+
+    ticks = tick_table or load_tick_table(ArtifactPaths.defaults().tick_yaml)
+    engine = PrimaryPortfolioEngine(
+        ticks,
+        view=_empty_corpus_view(),
+        all_clamp_rows={},
+        market_sessions=(),
+    )
+    if guard_override is not None:
+        engine._guard = guard_override  # noqa: SLF001 - deliberate mutant injection
+    guard = engine._guard  # noqa: SLF001 - the property under test
+
+    exact_type = type(guard) is SealedAccessGuard
+
+    def _blocks(probe: Callable[[], object]) -> bool:
+        try:
+            probe()
+        except SealedAccessBlocked:
+            return True
+        except Exception:  # noqa: BLE001 - any other error is not a clean block
+            return False
+        return False
+
+    blocks_2025 = _blocks(
+        lambda: guard.assert_exploration_date(PROBE_PRIMARY_SEALED_DATE)
+    )
+    blocks_holdout = _blocks(
+        lambda: guard.assert_exploration_path(
+            _holdout_guard.HOLDOUT_DIR
+            / "runs"
+            / "kr-corpus-v1-20260803-1001"
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2025"
+            / "ticker=005930.parquet"
+        )
+    )
+    blocks_2026 = _blocks(lambda: guard.assert_exploration_date(PROBE_PROSPECTIVE_DATE))
+    passed = exact_type and blocks_2025 and blocks_holdout and blocks_2026
+    return {
+        "status": "PASS" if passed else "FAIL",
+        "primary_engine_class": type(engine).__name__,
+        "installed_guard_class": type(guard).__name__,
+        "guard_is_sealed_access_guard_exactly": exact_type,
+        "blocks_2025_date": blocks_2025,
+        "blocks_2026_date": blocks_2026,
+        "blocks_holdout_2025_partition_path": blocks_holdout,
+        "note": (
+            "primary.py is unedited; this reads the guard its own __init__ hard-codes"
+        ),
+    }

--- a/research/kr_corpus/d3_engine/calibration_actual_side.py
+++ b/research/kr_corpus/d3_engine/calibration_actual_side.py
@@ -1,0 +1,321 @@
+"""Actual-side extraction — the operator's real 2025 KR trading.
+
+Carries forward the GAP-02 selector and the GAP-03 censoring that the D3-C2P
+fix-r1 job established and an independent verifier passed
+(``carry_in_excluded_count = 4``, ``right_censored_count = 11``), and adds the
+two pieces that job could not reach:
+
+* the four session-derived metrics, now that the sealed 2025 XKRX calendar
+  exists (``kospi_index_daily_2025.csv``, ``17e95d0b30ade5e6...``);
+* ``capital_share``, whose GAP-04 definition needs a daily close mark per open
+  position.
+
+The cycle reconstruction, censoring, and medians all live in
+``calibration_metrics``; this module only builds the fill tape and the daily
+locked-share series. That is deliberate — the simulated side runs the exact
+same code over its own fills.
+
+GAP-05: the archive carries no usable fee. KIS domestic has no fee/tax column
+at all, and every one of the 2,120 Toss KRW rows reports ``tax = 0`` including
+188 executed sells, which KR transfer tax makes impossible. Fees are therefore
+neither imputed nor modelled; both sides are compared gross.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from research.kr_corpus.d3_engine.calibration_metrics import (
+    WINDOW_END,
+    WINDOW_START,
+    CycleFill,
+    Reconstruction,
+    SessionAxis,
+    capital_share_observation,
+    classify_gap03,
+    compute_cycle_metrics,
+    reconstruct_cycles,
+)
+
+KST = timezone(timedelta(hours=9))
+DEFAULT_TRADE_HISTORY_ROOT = (
+    Path.home() / "work" / "herdr-artifacts" / "operator-trade-history-v1" / "merged"
+)
+LOCKED_STREAK_SESSIONS = 180
+SELECTOR_ID = "GAP-02: kis_domestic (all filled) UNION toss(currency==KRW, filled)"
+CAPITAL_SHARE_DEFINITION_ID = "gap04_locked_share_daily_grain_time_weighted_mean"
+
+
+class ActualSideInvalid(ValueError):
+    code = "RUN_INVALID_CALIBRATION_ACTUAL_SIDE"
+
+
+@dataclass(frozen=True, slots=True)
+class ActualFill:
+    symbol: str
+    side: str
+    quantity: Decimal
+    price: Decimal
+    day: date
+    sequence: int
+    account: str
+
+
+def load_actual_fills(root: Path = DEFAULT_TRADE_HISTORY_ROOT) -> list[ActualFill]:
+    """GAP-02 selector over the frozen operator archive."""
+
+    import pandas as pd
+    import pyarrow.parquet as pq
+
+    kis = pq.read_table(str(root / "kis_domestic.parquet")).to_pandas()
+    kis = kis.assign(
+        qty=kis["tot_ccld_qty"].map(lambda value: Decimal(str(value).strip() or "0")),
+        price=kis["avg_prvs"].map(lambda value: Decimal(str(value).strip() or "0")),
+    )
+    filled_kis = kis[kis["qty"] > 0].copy()
+    filled_kis["ts"] = pd.to_datetime(
+        filled_kis["ord_dt"] + filled_kis["ord_tmd"], format="%Y%m%d%H%M%S"
+    ).dt.tz_localize(KST)
+    filled_kis["symbol"] = filled_kis["pdno"]
+    filled_kis["side"] = filled_kis["sll_buy_dvsn_cd"].map({"01": "SELL", "02": "BUY"})
+    if filled_kis["side"].isna().any():
+        raise ActualSideInvalid("unrecognized KIS sll_buy_dvsn_cd")
+
+    toss = pq.read_table(str(root / "toss.parquet")).to_pandas()
+    # The archive stores the execution block as a Python repr carrying Decimal
+    # literals; builtins are stripped so only Decimal construction can run.
+    executions = toss["execution"].map(
+        lambda text: eval(text, {"__builtins__": {}, "Decimal": Decimal})  # noqa: S307
+    )
+    toss = toss.assign(
+        qty=executions.map(lambda item: item["filledQuantity"]),
+        price=executions.map(lambda item: item["averageFilledPrice"]),
+        filled_at=executions.map(lambda item: item["filledAt"]),
+    )
+    filled_toss = toss[(toss["qty"] > 0) & (toss["currency"] == "KRW")].copy()
+    filled_toss["ts"] = pd.to_datetime(filled_toss["filled_at"])
+    filled_toss["side"] = filled_toss["side"].map(
+        lambda value: str(value).strip().upper()
+    )
+    unknown = set(filled_toss["side"].unique()) - {"BUY", "SELL"}
+    if unknown:
+        raise ActualSideInvalid(f"unrecognized Toss side:{sorted(unknown)}")
+
+    rows: list[tuple[Any, str, str, Decimal, Decimal, str]] = []
+    for frame, account in ((filled_kis, "kis_domestic"), (filled_toss, "toss_krw")):
+        for row in frame.itertuples(index=False):
+            rows.append(
+                (
+                    row.ts,
+                    str(row.symbol),
+                    str(row.side),
+                    Decimal(row.qty),
+                    Decimal(row.price),
+                    account,
+                )
+            )
+    rows.sort(key=lambda item: (item[0], item[1]))
+    return [
+        ActualFill(
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            price=price,
+            day=timestamp.tz_convert(KST).date(),
+            sequence=index,
+            account=account,
+        )
+        for index, (timestamp, symbol, side, quantity, price, account) in enumerate(
+            rows
+        )
+    ]
+
+
+def to_cycle_fills(fills: list[ActualFill]) -> list[CycleFill]:
+    return [
+        CycleFill(
+            symbol=fill.symbol,
+            side=fill.side,
+            quantity=fill.quantity,
+            price=fill.price,
+            day=fill.day,
+            sequence=fill.sequence,
+        )
+        for fill in fills
+    ]
+
+
+def daily_locked_share(
+    fills: list[ActualFill],
+    *,
+    sessions: tuple[date, ...],
+    closes: dict[str, dict[date, Decimal]],
+    window_sessions: tuple[date, ...],
+) -> tuple[list[Decimal], dict[str, Any]]:
+    """GAP-04 locked share for the operator book, on the engine's own clock.
+
+    Mirrors ``Position.apply_buy``/``apply_sell`` and
+    ``policies.update_underwater_close`` exactly: the streak advances once per
+    session on the session close, and resets whenever the close is missing or
+    the mark is at/above the average price. Cost basis is gross (GAP-05); the
+    simulated side's basis is ``gross * (1 + fee_rate)`` uniformly, so the two
+    ratios remain directly comparable.
+    """
+
+    by_day: dict[date, list[ActualFill]] = {}
+    for fill in fills:
+        by_day.setdefault(fill.day, []).append(fill)
+    for day_fills in by_day.values():
+        day_fills.sort(key=lambda item: (item.sequence, item.symbol))
+
+    quantity: dict[str, Decimal] = {}
+    average: dict[str, Decimal] = {}
+    cost_basis: dict[str, Decimal] = {}
+    streak: dict[str, int] = {}
+    unresolved: set[str] = set()
+    pending: dict[date, list[ActualFill]] = dict(by_day)
+
+    window = set(window_sessions)
+    ratios: list[Decimal] = []
+    observations: list[dict[str, object]] = []
+    off_session_fill_days: set[date] = set()
+
+    session_set = set(sessions)
+    for day in sorted(pending):
+        if day not in session_set:
+            off_session_fill_days.add(day)
+
+    for session in sessions:
+        for fill in pending.get(session, ()):
+            symbol = fill.symbol
+            held = quantity.get(symbol, Decimal(0))
+            if fill.side == "BUY":
+                gross = fill.quantity * fill.price
+                if held == 0:
+                    quantity[symbol] = fill.quantity
+                    average[symbol] = fill.price
+                    cost_basis[symbol] = gross
+                    streak[symbol] = 0
+                else:
+                    total = held + fill.quantity
+                    average[symbol] = (held * average[symbol] + gross) / total
+                    quantity[symbol] = total
+                    cost_basis[symbol] = cost_basis[symbol] + gross
+                continue
+            if held <= 0:
+                continue
+            sold = min(fill.quantity, held)
+            fraction = sold / held
+            cost_basis[symbol] = cost_basis[symbol] * (Decimal(1) - fraction)
+            quantity[symbol] = held - sold
+            if quantity[symbol] == 0:
+                average[symbol] = Decimal(0)
+                cost_basis[symbol] = Decimal(0)
+                streak[symbol] = 0
+
+        for symbol, held in quantity.items():
+            if held <= 0:
+                streak[symbol] = 0
+                continue
+            close = closes.get(symbol, {}).get(session)
+            if close is None:
+                streak[symbol] = 0
+                if symbol not in closes:
+                    unresolved.add(symbol)
+                continue
+            streak[symbol] = streak.get(symbol, 0) + 1 if close < average[symbol] else 0
+
+        if session not in window:
+            continue
+        invested = sum(
+            (value for symbol, value in cost_basis.items() if quantity[symbol] > 0),
+            Decimal(0),
+        )
+        locked = sum(
+            (
+                value
+                for symbol, value in cost_basis.items()
+                if quantity[symbol] > 0
+                and streak.get(symbol, 0) >= LOCKED_STREAK_SESSIONS
+            ),
+            Decimal(0),
+        )
+        ratio = locked / invested if invested else Decimal(0)
+        ratios.append(ratio)
+        observations.append(
+            {
+                "session": session.isoformat(),
+                "invested_cost_basis_krw": str(invested),
+                "locked_cost_basis_krw": str(locked),
+                "locked_share": str(ratio),
+                "open_positions": sum(1 for value in quantity.values() if value > 0),
+            }
+        )
+
+    diagnostics = {
+        "clock_start_session": sessions[0].isoformat(),
+        "observation_sessions": len(ratios),
+        "symbols_without_corpus_closes": sorted(unresolved),
+        "fill_days_off_xkrx_session": sorted(
+            day.isoformat() for day in off_session_fill_days
+        ),
+        "daily_observations": observations,
+    }
+    return ratios, diagnostics
+
+
+def build_actual_side(
+    *,
+    axis: SessionAxis,
+    clock_sessions: tuple[date, ...],
+    closes: dict[str, dict[date, Decimal]],
+    root: Path = DEFAULT_TRADE_HISTORY_ROOT,
+) -> dict[str, Any]:
+    """The nine actual-side metrics plus their census and exclusion evidence."""
+
+    fills = load_actual_fills(root)
+    window_fills = [fill for fill in fills if WINDOW_START <= fill.day <= WINDOW_END]
+    recon: Reconstruction = reconstruct_cycles(to_cycle_fills(fills))
+    gap03 = classify_gap03(recon)
+    metrics = compute_cycle_metrics(recon, gap03, axis)
+    ratios, capital_diagnostics = daily_locked_share(
+        fills,
+        sessions=clock_sessions,
+        closes=closes,
+        window_sessions=axis.sessions,
+    )
+    metrics["capital_share"] = capital_share_observation(
+        ratios,
+        definition_id=CAPITAL_SHARE_DEFINITION_ID,
+        note=(
+            "GAP-04 locked share on the operator book; gross cost basis "
+            "(GAP-05), clock seeded from the first fill of every position "
+            "including carry-in"
+        ),
+    )
+    census = metrics.pop("_census")
+    return {
+        "schema_id": "d3.calibration.actual_side.v2",
+        "selector": SELECTOR_ID,
+        "window": "2025-01-01..2025-12-31 (GAP-03 full-history censoring applied)",
+        "session_axis": "sealed XKRX 2025 calendar (kospi_index_daily_2025.csv)",
+        "fills_total_2025": len(window_fills),
+        "fills_kis_domestic_2025": sum(
+            1 for fill in window_fills if fill.account == "kis_domestic"
+        ),
+        "fills_toss_krw_2025": sum(
+            1 for fill in window_fills if fill.account == "toss_krw"
+        ),
+        "symbols_with_activity_2025": len({fill.symbol for fill in window_fills}),
+        "actual_fee_availability": {
+            "kis_domestic": "absent_in_schema",
+            "toss": "unpopulated",
+        },
+        "census": census,
+        "capital_share_diagnostics": capital_diagnostics,
+        "metrics": metrics,
+    }

--- a/research/kr_corpus/d3_engine/calibration_corpus.py
+++ b/research/kr_corpus/d3_engine/calibration_corpus.py
@@ -1,0 +1,505 @@
+"""Measured loader for ``D3_CALIBRATION_2025`` — the sealed 2025 partition.
+
+Every byte this module opens passes a :class:`CalibrationAccessGuard` check
+first, and the allow-list it binds is derived from the sealed manifest itself:
+``manifest.json`` pins ``checksums.sha256`` by digest, and ``checksums.sha256``
+enumerates every file. Only enumerated entries whose ``year=`` partition is
+2025 (plus the two enumerating documents) become readable; the 2026 rows in the
+same list stay closed.
+
+``source-anomalies.jsonl`` is one of the enumerated files, and it interleaves
+2025 and 2026 records. Its lines are screened by a byte-level year match
+*before* ``json.loads``, so a prospective record's OHLC values never become
+Python objects.
+
+The clamp view reproduces the frozen ``clamp-admit-v1`` contract exactly —
+``high = max(source_high, open, close)``, ``low = min(source_low, open, close)``,
+``no_trade`` (``open=high=low=0 and close>0``) excluded, everything else
+admitted. ``research/kr_corpus/clamp_admit.py`` cannot be reused directly: it
+refuses a holdout source root by design, and relaxing that refusal is exactly
+what A2 forbids.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from research.kr_corpus.d3_engine.calibration_guard import (
+    CALIBRATION_YEAR,
+    HOLDOUT_RUN_ID,
+    CalibrationAccessGuard,
+    partition_year,
+)
+from research.kr_corpus.d3_engine.primary_corpus import ClampRow, CorpusBar
+
+_SESSION_YEAR = re.compile(rb'"session"\s*:\s*"(\d{4})-')
+# The exploration corpus only ever saw ``[0-9]{5}[0-9A-Z]``. The 2025 partition
+# also carries KRX short codes whose fifth character is a letter (56 of 2,862:
+# 32 ``DDDDAD`` + 24 ``DDDDDA``), so the shape is widened by exactly that much
+# and no further.
+_TICKER = re.compile(r"[0-9]{4}[0-9A-Z]{2}")
+
+CALIBRATION_CORPUS_ID = "kr-corpus-v1"
+CALIBRATION_SCOPE = "holdout"
+CLAMP_CLASSIFICATION = "tradeable_adjusted_rounding"
+DATASET_COLUMNS = ("session", "market", "ticker", "open", "high", "low", "close")
+
+
+class CalibrationCorpusInvalid(ValueError):
+    code = "RUN_INVALID_CALIBRATION_CORPUS"
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationManifest:
+    run_root: Path
+    manifest_sha256: str
+    checksums_sha256: str
+    allowed_paths: tuple[Path, ...]
+    dataset_entries: tuple[tuple[str, PurePosixPath], ...]
+    gap_entries: tuple[tuple[str, PurePosixPath], ...]
+    anomalies_path: Path
+    anomalies_sha256_expected: str
+    enumerated_total: int
+    excluded_out_of_scope: int
+    prospective_example: Path
+
+    def evidence(self) -> dict[str, object]:
+        return {
+            "run_root": str(self.run_root),
+            "manifest_sha256": self.manifest_sha256,
+            "checksums_sha256": self.checksums_sha256,
+            "enumerated_files_total": self.enumerated_total,
+            "authorized_files_2025_scope": len(self.allowed_paths),
+            "excluded_out_of_scope_files": self.excluded_out_of_scope,
+            "dataset_parquet_2025": len(self.dataset_entries),
+            "gap_parquet_2025": len(self.gap_entries),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationCorpus:
+    bars_original: tuple[CorpusBar, ...]
+    bars_clamp: tuple[CorpusBar, ...]
+    clamp_rows: dict[tuple[date, str], ClampRow]
+    no_trade_excluded: int
+    anomaly_lines_prechecked: int
+    anomaly_lines_decoded_2025: int
+    anomaly_lines_skipped_prospective: int
+    manifest: CalibrationManifest
+
+    def evidence(self) -> dict[str, object]:
+        return {
+            **self.manifest.evidence(),
+            "original_valid_bar_rows_2025": len(self.bars_original),
+            "clamp_admit_rows_2025": len(self.bars_clamp),
+            "clamp_rows_admitted_2025": len(self.clamp_rows),
+            "no_trade_rows_excluded_2025": self.no_trade_excluded,
+            "anomaly_lines_prechecked": self.anomaly_lines_prechecked,
+            "anomaly_lines_decoded_2025": self.anomaly_lines_decoded_2025,
+            "anomaly_lines_skipped_prospective_undecoded": (
+                self.anomaly_lines_skipped_prospective
+            ),
+        }
+
+
+def load_calibration_manifest(
+    guard: CalibrationAccessGuard,
+    *,
+    holdout_root: Path,
+    run_id: str = HOLDOUT_RUN_ID,
+) -> CalibrationManifest:
+    """Read the two enumerating documents and bind the A2 path allow-list."""
+
+    run_root = (holdout_root / "runs" / run_id).expanduser().resolve(strict=True)
+    manifest_path = run_root / "manifest.json"
+    raw_manifest = guard.read_manifest(
+        path=manifest_path, loader=manifest_path.read_bytes
+    )
+    manifest_sha = hashlib.sha256(raw_manifest).hexdigest()
+    manifest = json.loads(raw_manifest)
+    if manifest.get("scope") != CALIBRATION_SCOPE:
+        raise CalibrationCorpusInvalid("sealed manifest scope drift")
+    if manifest.get("corpus_id") != CALIBRATION_CORPUS_ID:
+        raise CalibrationCorpusInvalid("sealed manifest corpus_id drift")
+    if manifest.get("files_list_location") != "checksums.sha256":
+        raise CalibrationCorpusInvalid(
+            "sealed manifest does not enumerate by checksums"
+        )
+
+    checksums_path = run_root / "checksums.sha256"
+    raw_checksums = guard.read_file(
+        path=checksums_path, loader=checksums_path.read_bytes
+    )
+    checksums_sha = hashlib.sha256(raw_checksums).hexdigest()
+    if checksums_sha != manifest.get("checksums_sha256"):
+        raise CalibrationCorpusInvalid(
+            f"enumerating checksum drift:{checksums_sha}!={manifest.get('checksums_sha256')}"
+        )
+
+    entries: list[tuple[str, PurePosixPath]] = []
+    seen: set[PurePosixPath] = set()
+    for line in raw_checksums.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            expected, raw_relative = line.split(maxsplit=1)
+        except ValueError as exc:
+            raise CalibrationCorpusInvalid("malformed checksum row") from exc
+        relative = PurePosixPath(raw_relative.lstrip("*"))
+        if (
+            len(expected) != 64
+            or any(character not in "0123456789abcdef" for character in expected)
+            or relative.is_absolute()
+            or ".." in relative.parts
+        ):
+            raise CalibrationCorpusInvalid(f"invalid checksum row:{line}")
+        if relative in seen:
+            raise CalibrationCorpusInvalid(f"duplicate checksum entry:{relative}")
+        seen.add(relative)
+        entries.append((expected, relative))
+    if not entries:
+        raise CalibrationCorpusInvalid("sealed manifest enumerates no files")
+
+    allowed: list[Path] = []
+    excluded = 0
+    prospective_example: Path | None = None
+    dataset: list[tuple[str, PurePosixPath]] = []
+    gaps: list[tuple[str, PurePosixPath]] = []
+    anomalies_expected: str | None = None
+    for expected, relative in entries:
+        absolute = (run_root / relative).resolve(strict=False)
+        year = partition_year(absolute)
+        if year is not None and year != CALIBRATION_YEAR:
+            excluded += 1
+            if prospective_example is None and relative.parts[0] == "dataset":
+                prospective_example = absolute
+            continue
+        allowed.append(absolute)
+        head = relative.parts[0]
+        if head == "dataset":
+            dataset.append((expected, relative))
+        elif head == "gaps":
+            gaps.append((expected, relative))
+        elif str(relative) == "source-anomalies.jsonl":
+            anomalies_expected = expected
+    if anomalies_expected is None:
+        raise CalibrationCorpusInvalid("sealed manifest does not enumerate anomalies")
+    if not dataset:
+        raise CalibrationCorpusInvalid("sealed manifest has no 2025 dataset partition")
+    if prospective_example is None:
+        raise CalibrationCorpusInvalid("sealed manifest has no prospective partition")
+
+    guard.bind_manifest_allowlist(allowed, excluded_out_of_scope=excluded)
+    return CalibrationManifest(
+        run_root=run_root,
+        manifest_sha256=manifest_sha,
+        checksums_sha256=checksums_sha,
+        allowed_paths=tuple(sorted(allowed)),
+        dataset_entries=tuple(sorted(dataset, key=lambda item: str(item[1]))),
+        gap_entries=tuple(sorted(gaps, key=lambda item: str(item[1]))),
+        anomalies_path=run_root / "source-anomalies.jsonl",
+        anomalies_sha256_expected=anomalies_expected,
+        enumerated_total=len(entries),
+        excluded_out_of_scope=excluded,
+        prospective_example=prospective_example,
+    )
+
+
+def _sha256_stream(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_parquet_rows(path: Path, columns: tuple[str, ...]) -> list[dict[str, Any]]:
+    import pyarrow.parquet as pq
+
+    table = pq.ParquetFile(path).read(columns=list(columns))
+    if tuple(table.column_names) != columns:
+        raise CalibrationCorpusInvalid(f"parquet schema drift:{path.name}")
+    return table.to_pylist()
+
+
+def _partition(relative: PurePosixPath) -> tuple[str, int, str]:
+    if len(relative.parts) != 4:
+        raise CalibrationCorpusInvalid(f"unexpected dataset partition:{relative}")
+    _, market_part, year_part, ticker_part = relative.parts
+    if not market_part.startswith("market=") or not year_part.startswith("year="):
+        raise CalibrationCorpusInvalid(f"malformed dataset partition:{relative}")
+    if not ticker_part.startswith("ticker=") or not ticker_part.endswith(".parquet"):
+        raise CalibrationCorpusInvalid(f"malformed ticker partition:{relative}")
+    market = market_part.removeprefix("market=")
+    year = int(year_part.removeprefix("year="))
+    ticker = ticker_part.removeprefix("ticker=").removesuffix(".parquet")
+    if market not in {"KOSPI", "KOSDAQ"}:
+        raise CalibrationCorpusInvalid(f"unsupported market partition:{market}")
+    if year != CALIBRATION_YEAR:
+        raise CalibrationCorpusInvalid(f"non-calibration year partition:{year}")
+    if _TICKER.fullmatch(ticker) is None:
+        raise CalibrationCorpusInvalid(f"invalid ticker partition:{ticker}")
+    return market, year, ticker
+
+
+def _bar(
+    raw: dict[str, Any],
+    *,
+    partition: tuple[str, int, str],
+    sessions: frozenset[date],
+) -> CorpusBar:
+    market, year, ticker = partition
+    try:
+        session = date.fromisoformat(str(raw["session"]))
+        row_market = str(raw["market"])
+        row_ticker = str(raw["ticker"])
+        open_price = int(raw["open"])
+        high = int(raw["high"])
+        low = int(raw["low"])
+        close = int(raw["close"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise CalibrationCorpusInvalid("invalid calibration parquet row") from exc
+    if (row_market, session.year, row_ticker) != (market, year, ticker):
+        raise CalibrationCorpusInvalid("parquet row/partition identity mismatch")
+    if session not in sessions:
+        raise CalibrationCorpusInvalid(f"bar outside the sealed 2025 axis:{session}")
+    if min(open_price, high, low, close) <= 0:
+        raise CalibrationCorpusInvalid("bar prices must be positive")
+    if low > min(open_price, close) or high < max(open_price, close):
+        raise CalibrationCorpusInvalid("bar OHLC ordering invalid")
+    return CorpusBar(
+        session=session,
+        symbol=ticker,
+        market=market,
+        open_int=open_price,
+        high_int=high,
+        low_int=low,
+        close_int=close,
+    )
+
+
+def _gap_market_by_key(
+    guard: CalibrationAccessGuard, manifest: CalibrationManifest
+) -> dict[tuple[str, str], str]:
+    result: dict[tuple[str, str], str] = {}
+    for expected, relative in manifest.gap_entries:
+        path = (manifest.run_root / relative).resolve(strict=True)
+        actual = guard.read_file(
+            path=path, loader=lambda path=path: _sha256_stream(path)
+        )
+        if actual != expected:
+            raise CalibrationCorpusInvalid(f"gap checksum drift:{relative}")
+        rows = guard.read_parquet(
+            path=path,
+            loader=lambda path=path: _read_parquet_rows(
+                path, ("session", "market", "ticker", "reason")
+            ),
+        )
+        for row in rows:
+            if row["reason"] != "ohlc_invariant_violation":
+                continue
+            key = (str(row["session"]), str(row["ticker"]))
+            market = str(row["market"])
+            if result.setdefault(key, market) != market:
+                raise CalibrationCorpusInvalid("anomaly key maps to two markets")
+    if not result:
+        raise CalibrationCorpusInvalid("no 2025 OHLC-invariant gap keys")
+    return result
+
+
+def load_calibration_corpus(
+    guard: CalibrationAccessGuard,
+    *,
+    holdout_root: Path,
+    run_id: str = HOLDOUT_RUN_ID,
+) -> CalibrationCorpus:
+    """Load the 2025 original and clamp bar sets under measured authorization."""
+
+    manifest = load_calibration_manifest(
+        guard, holdout_root=holdout_root, run_id=run_id
+    )
+    sessions = guard.calibration_sessions
+
+    original: list[CorpusBar] = []
+    for expected, relative in manifest.dataset_entries:
+        partition = _partition(relative)
+        path = (manifest.run_root / relative).resolve(strict=True)
+        actual = guard.read_file(
+            path=path, loader=lambda path=path: _sha256_stream(path)
+        )
+        if actual != expected:
+            raise CalibrationCorpusInvalid(
+                f"parquet checksum drift:{relative}:{actual}!={expected}"
+            )
+        rows = guard.read_parquet(
+            path=path,
+            loader=lambda path=path: _read_parquet_rows(path, DATASET_COLUMNS),
+        )
+        decoded = [_bar(raw, partition=partition, sessions=sessions) for raw in rows]
+        guard.record_bar_rows([bar.session for bar in decoded])
+        original.extend(decoded)
+
+    market_by_key = _gap_market_by_key(guard, manifest)
+
+    anomalies_path = manifest.anomalies_path.resolve(strict=True)
+    actual = guard.read_file(
+        path=anomalies_path, loader=lambda: _sha256_stream(anomalies_path)
+    )
+    if actual != manifest.anomalies_sha256_expected:
+        raise CalibrationCorpusInvalid("source-anomalies checksum drift")
+
+    clamp_rows: dict[tuple[date, str], ClampRow] = {}
+    clamp_bars: list[CorpusBar] = []
+    prechecked = 0
+    decoded_2025 = 0
+    skipped = 0
+    no_trade = 0
+    seen_keys: set[tuple[str, str]] = set()
+    guard.assert_exploration_path(anomalies_path)
+    with anomalies_path.open("rb") as stream:
+        for raw_line in stream:
+            if not raw_line.strip():
+                continue
+            prechecked += 1
+            match = _SESSION_YEAR.search(raw_line)
+            if match is None:
+                raise CalibrationCorpusInvalid("anomaly line lacks a session field")
+            if int(match.group(1)) != CALIBRATION_YEAR:
+                skipped += 1
+                continue
+            decoded_2025 += 1
+            record = json.loads(raw_line)
+            if record.get("kind") != "ohlc_invariant_violation":
+                continue
+            session_text = str(record["session"])
+            ticker = str(record["ticker"])
+            key = (session_text, ticker)
+            if key in seen_keys:
+                raise CalibrationCorpusInvalid("duplicate source anomaly key")
+            seen_keys.add(key)
+            session = date.fromisoformat(session_text)
+            guard.assert_exploration_date(session)
+            market = market_by_key.get(key)
+            if market is None:
+                raise CalibrationCorpusInvalid("OHLC anomaly has no matching gap row")
+            detail = record["detail"]
+            if not isinstance(detail, dict):
+                raise CalibrationCorpusInvalid("OHLC anomaly detail is not an object")
+            open_price = int(detail["open"])
+            source_high = int(detail["high"])
+            source_low = int(detail["low"])
+            close_price = int(detail["close"])
+            if (
+                open_price == 0
+                and source_high == 0
+                and source_low == 0
+                and close_price > 0
+            ):
+                no_trade += 1
+                continue
+            clamped_high = max(source_high, open_price, close_price)
+            clamped_low = min(source_low, open_price, close_price)
+            delta_high = clamped_high - source_high
+            delta_low = source_low - clamped_low
+            if not (
+                clamped_low <= min(open_price, close_price)
+                and max(open_price, close_price) <= clamped_high
+                and (delta_high > 0 or delta_low > 0)
+            ):
+                raise CalibrationCorpusInvalid(
+                    "tradeable clamp row did not repair the OHLC invariant"
+                )
+            if clamped_low <= 0:
+                raise CalibrationCorpusInvalid("clamped bar prices must be positive")
+            entry_key = (session, ticker)
+            if entry_key in clamp_rows:
+                raise CalibrationCorpusInvalid(f"duplicate clamped row:{entry_key}")
+            clamp_rows[entry_key] = ClampRow(
+                market=market,
+                session=session,
+                symbol=ticker,
+                source_high=source_high,
+                source_low=source_low,
+                high=clamped_high,
+                low=clamped_low,
+                delta_high=delta_high,
+                delta_low=delta_low,
+                classification=CLAMP_CLASSIFICATION,
+                admitted=True,
+            )
+            clamp_bars.append(
+                CorpusBar(
+                    session=session,
+                    symbol=ticker,
+                    market=market,
+                    open_int=open_price,
+                    high_int=clamped_high,
+                    low_int=clamped_low,
+                    close_int=close_price,
+                )
+            )
+    guard.record_bar_rows([bar.session for bar in clamp_bars])
+
+    gap_2025 = {
+        key for key in market_by_key if key[0].startswith(f"{CALIBRATION_YEAR}-")
+    }
+    if seen_keys != gap_2025:
+        raise CalibrationCorpusInvalid(
+            "2025 anomaly keys and 2025 ohlc_invariant gap keys differ"
+        )
+
+    original_keys = {(bar.session, bar.symbol) for bar in original}
+    overlap = original_keys & set(clamp_rows)
+    if overlap:
+        raise CalibrationCorpusInvalid(
+            f"clamped row collides with a valid bar:{sorted(overlap)[:3]}"
+        )
+
+    combined = sorted(
+        [*original, *clamp_bars], key=lambda bar: (bar.session, bar.symbol)
+    )
+    return CalibrationCorpus(
+        bars_original=tuple(
+            sorted(original, key=lambda bar: (bar.session, bar.symbol))
+        ),
+        bars_clamp=tuple(combined),
+        clamp_rows=clamp_rows,
+        no_trade_excluded=no_trade,
+        anomaly_lines_prechecked=prechecked,
+        anomaly_lines_decoded_2025=decoded_2025,
+        anomaly_lines_skipped_prospective=skipped,
+        manifest=manifest,
+    )
+
+
+def market_periods(bars: list[CorpusBar]) -> tuple[tuple[date, date, str], ...]:
+    """Contiguous market-membership periods for one symbol's ordered bars."""
+
+    periods: list[tuple[date, date, str]] = []
+    start = bars[0].session
+    end = start
+    market = bars[0].market
+    for bar in bars[1:]:
+        if bar.market != market:
+            periods.append((start, end, market))
+            start = bar.session
+            market = bar.market
+        end = bar.session
+    periods.append((start, end, market))
+    return tuple(periods)
+
+
+def group_by_symbol(bars: tuple[CorpusBar, ...]) -> dict[str, list[CorpusBar]]:
+    grouped: dict[str, list[CorpusBar]] = defaultdict(list)
+    for bar in bars:
+        grouped[bar.symbol].append(bar)
+    for symbol_bars in grouped.values():
+        symbol_bars.sort(key=lambda bar: bar.session)
+    return dict(grouped)

--- a/research/kr_corpus/d3_engine/calibration_engine.py
+++ b/research/kr_corpus/d3_engine/calibration_engine.py
@@ -1,0 +1,136 @@
+"""B0 replay engine for the calibration window.
+
+``PortfolioEngine._signal_for_session`` recomputes Wilder RSI over a symbol's
+whole contiguous history on every decision bar, which is quadratic and cannot
+finish a corpus-scale replay. ``primary.PrimaryPortfolioEngine`` solves this
+with a precomputed signal tape, but its ``__init__`` hard-codes the deny-list
+``SealedAccessGuard`` and A2 forbids editing that file. This class therefore
+repeats the same two overrides against the shared, unmodified tape builder
+(``primary_corpus._prepare_signal_tape``) while accepting an injected guard.
+
+The tape is exact, not an approximation: ``bollinger_bands`` reads only the
+last 20 closes and ``scan_fib_window`` only the prior 120, so a 120-bar history
+slice reproduces the base engine's fib/Bollinger inputs bit-for-bit, and the
+tape's running Wilder state reproduces its RSI over the full contiguous
+segment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from research.kr_corpus.d3_engine.calibration_guard import CalibrationAccessGuard
+from research.kr_corpus.d3_engine.engine import PortfolioEngine
+from research.kr_corpus.d3_engine.models import (
+    EngineResult,
+    PortfolioRunInput,
+    RunState,
+)
+from research.kr_corpus.d3_engine.primary_corpus import SignalSnapshot
+from research.kr_corpus.d3_engine.tick import TickTable
+
+
+@dataclass(slots=True)
+class CalibrationTrace:
+    """Daily capital-share observations, at the contract's locked-share grain."""
+
+    daily: list[dict[str, object]] = field(default_factory=list)
+    engine_invocations: int = 0
+
+
+class CalibrationPortfolioEngine(PortfolioEngine):
+    """E1 execution core over the calibration window with an injected guard."""
+
+    def __init__(
+        self,
+        tick_table: TickTable,
+        *,
+        access_guard: CalibrationAccessGuard,
+        signals: dict[tuple[date, str], SignalSnapshot],
+    ) -> None:
+        super().__init__(tick_table, access_guard=access_guard)
+        self._signals = signals
+        self._trace = CalibrationTrace()
+        self._capture = False
+
+    def execute(
+        self, run_input: PortfolioRunInput
+    ) -> tuple[EngineResult, CalibrationTrace]:
+        self._trace = CalibrationTrace()
+        self._capture = True
+        try:
+            self._trace.engine_invocations += 1
+            result = super()._run(run_input)
+        finally:
+            self._capture = False
+        return result, self._trace
+
+    @staticmethod
+    def _signal_history(
+        symbol_bars: list[Any], *, index: int, segment_start: int
+    ) -> list[Any]:
+        """The tape only needs t and its prior 120-bar association."""
+
+        return symbol_bars[max(segment_start, index - 120) : index + 1]
+
+    def _signal_for_session(
+        self, history: list[Any], decision_index: int
+    ) -> tuple[Decimal, Decimal, Decimal, Decimal] | None:
+        current = history[decision_index]
+        snapshot = self._signals.get((current.session, current.symbol))
+        if snapshot is None:
+            return None
+        return (
+            snapshot.rsi,
+            snapshot.l2_price,
+            snapshot.fib_high,
+            snapshot.fib_low,
+        )
+
+    def _finish_day(
+        self,
+        *,
+        state: RunState,
+        cash: Any,
+        by_session: dict[tuple[date, str], Any],
+        session: date,
+        cumulative_contribution: Decimal,
+        cumulative_contribution_series: list[Decimal],
+        daily_invested: list[Decimal],
+        daily_locked_ratios: list[Decimal],
+        nav_series: list[Decimal],
+        last_closes: dict[str, Decimal],
+        fee_rate: Decimal,
+        terminal: bool,
+    ) -> None:
+        PortfolioEngine._finish_day(
+            state=state,
+            cash=cash,
+            by_session=by_session,
+            session=session,
+            cumulative_contribution=cumulative_contribution,
+            cumulative_contribution_series=cumulative_contribution_series,
+            daily_invested=daily_invested,
+            daily_locked_ratios=daily_locked_ratios,
+            nav_series=nav_series,
+            last_closes=last_closes,
+            fee_rate=fee_rate,
+            terminal=terminal,
+        )
+        if not self._capture:
+            return
+        self._trace.daily.append(
+            {
+                "session": session,
+                "invested_cost_basis": daily_invested[-1],
+                "locked_cost_basis": daily_locked_ratios[-1] * daily_invested[-1],
+                "locked_share": daily_locked_ratios[-1],
+                "open_positions": sum(
+                    1 for position in state.positions.values() if position.quantity > 0
+                ),
+                "nav": nav_series[-1],
+            }
+        )

--- a/research/kr_corpus/d3_engine/calibration_engine.py
+++ b/research/kr_corpus/d3_engine/calibration_engine.py
@@ -13,6 +13,17 @@ last 20 closes and ``scan_fib_window`` only the prior 120, so a 120-bar history
 slice reproduces the base engine's fib/Bollinger inputs bit-for-bit, and the
 tape's running Wilder state reproduces its RSI over the full contiguous
 segment.
+
+Arithmetic context — measured, and a deliberate divergence from the primary
+harness. ``PortfolioEngine.run`` establishes the contract's pinned 50-digit
+``ROUND_HALF_UP`` context before delegating to ``_run``, but
+``PrimaryPortfolioEngine.execute`` calls ``_run`` directly, so the frozen
+primary artifacts' engine arithmetic ran at the interpreter default of 28
+digits. ``primary.py`` cannot be edited under A2, so that stays as it is; this
+runner instead follows the frozen contract literal (``DECIMAL_PRECISION = 50``)
+and wraps its own ``_run``. The divergence is published in the artifact
+stamps — a verifier should weigh whether the primary bypass needs an upstream
+ruling of its own.
 """
 
 from __future__ import annotations
@@ -23,6 +34,7 @@ from decimal import Decimal
 from typing import Any
 
 from research.kr_corpus.d3_engine.calibration_guard import CalibrationAccessGuard
+from research.kr_corpus.d3_engine.calibration_metrics import contract_context
 from research.kr_corpus.d3_engine.engine import PortfolioEngine
 from research.kr_corpus.d3_engine.models import (
     EngineResult,
@@ -63,7 +75,10 @@ class CalibrationPortfolioEngine(PortfolioEngine):
         self._capture = True
         try:
             self._trace.engine_invocations += 1
-            result = super()._run(run_input)
+            # The contract's fixed context, as PortfolioEngine.run establishes
+            # it — see the module docstring on the primary-harness divergence.
+            with contract_context():
+                result = super()._run(run_input)
         finally:
             self._capture = False
         return result, self._trace

--- a/research/kr_corpus/d3_engine/calibration_guard.py
+++ b/research/kr_corpus/d3_engine/calibration_guard.py
@@ -1,0 +1,341 @@
+"""Amendment A2 calibration-scoped sealed-access carve-out.
+
+`d3-amendment-a2-20260808.md` (sha256
+``37b3045cd20678815c49066862ddd89dfebd5e852c57d84dcd1ce062b69dc020``) opens
+exactly one key into the sealed corpus and nothing else. This module is that
+key. It is a *new* surface: ``guards.SealedAccessGuard`` and
+``primary.PrimaryPortfolioEngine`` are neither imported-for-mutation nor
+edited, and the primary runner keeps its hard-coded deny-list guard.
+
+A2 literal (the tables below map 1:1 onto :class:`CalibrationAccessGuard`):
+
+===========  ==========================================  ======================
+Axis         Allowed                                     Still blocked
+===========  ==========================================  ======================
+date         ``<= 2024`` (indicator warm-up) **and**      ``>= 2026`` entirely;
+             the 2025 dates present in the sealed        any 2025 date absent
+             calendar csv                                from that csv
+             (``17e95d0b30ade5e6...``)
+path         the exploration corpus **and** only the      prospective
+             files enumerated by the                     partitions; holdout
+             ``D3_CALIBRATION_2025`` manifest, scoped     files outside the
+             to its 2025 partition                       manifest; every other
+                                                         sealed segment
+spy          measured — every check and every completed   a self-declared
+             read is counted and serialized              statement
+===========  ==========================================  ======================
+
+Scope is the pre-approved 2P cell (``B0 x with_contribution x
+{original, clamp}``), one-shot. Any other arm, sensitivity, or prospective
+extension needs a new upstream signature.
+
+The manifest allow-list is *bootstrapped*: only ``manifest.json`` and
+``checksums.sha256`` are readable at construction, and the enumerated file set
+is bound exactly once from those two documents
+(:meth:`CalibrationAccessGuard.bind_manifest_allowlist`).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+from research.kr_corpus.backtest.holdout_guard import HOLDOUT_DIR
+from research.kr_corpus.d3_engine.guards import (
+    SealedAccessBlocked,
+    SealedAccessGuard,
+    SealedAccessSpy,
+)
+
+AMENDMENT_A2_SHA256 = "37b3045cd20678815c49066862ddd89dfebd5e852c57d84dcd1ce062b69dc020"
+CALIBRATION_INDEX_SHA256 = (
+    "17e95d0b30ade5e6fbd744cf719bc15224ef5177431cc51cfff8f2abb6930508"
+)
+CALIBRATION_YEAR = 2025
+WARMUP_LAST_YEAR = 2024
+HOLDOUT_RUN_ID = "kr-corpus-v1-20260803-1001"
+MANIFEST_DOCUMENT_NAMES = ("manifest.json", "checksums.sha256")
+
+_YEAR_PARTITION = re.compile(r"^year=(\d{4})$")
+
+
+class CalibrationScopeError(RuntimeError):
+    """The carve-out was configured outside its A2 scope."""
+
+    code = "RUN_INVALID_CALIBRATION_SCOPE"
+
+
+@dataclass(slots=True)
+class CalibrationAccessSpy(SealedAccessSpy):
+    """``SealedAccessSpy`` plus the A2 authorized/blocked breakdown.
+
+    Inherited counters keep their meaning. ``sealed_access_spy`` therefore
+    counts *authorized* sealed reads here instead of staying at zero: the
+    calibration path is the one path allowed to read sealed bytes, so a zero
+    there would mean the run never opened its own input.
+    """
+
+    warmup_date_checks: int = 0
+    calibration_date_checks: int = 0
+    blocked_prospective_date_attempts: int = 0
+    blocked_offcalendar_2025_date_attempts: int = 0
+    exploration_path_checks: int = 0
+    calibration_path_checks: int = 0
+    blocked_outside_manifest_attempts: int = 0
+    blocked_prospective_path_attempts: int = 0
+    blocked_sealed_token_attempts: int = 0
+    authorized_manifest_document_reads: int = 0
+    authorized_calibration_file_reads: int = 0
+    authorized_calibration_parquet_reads: int = 0
+    authorized_calibration_bar_rows: int = 0
+    manifest_allowlist_size: int = 0
+    manifest_excluded_out_of_scope: int = 0
+    calibration_sessions_authorized: int = 0
+
+    def evidence(self) -> dict[str, int]:
+        # Explicit base call: ``@dataclass(slots=True)`` rebuilds the class, so
+        # the zero-argument ``super()`` cell no longer matches this instance.
+        return {
+            **SealedAccessSpy.evidence(self),
+            "calibration_warmup_date_checks": self.warmup_date_checks,
+            "calibration_authorized_date_checks": self.calibration_date_checks,
+            "calibration_blocked_prospective_date_attempts": (
+                self.blocked_prospective_date_attempts
+            ),
+            "calibration_blocked_offcalendar_2025_date_attempts": (
+                self.blocked_offcalendar_2025_date_attempts
+            ),
+            "calibration_exploration_path_checks": self.exploration_path_checks,
+            "calibration_authorized_path_checks": self.calibration_path_checks,
+            "calibration_blocked_outside_manifest_attempts": (
+                self.blocked_outside_manifest_attempts
+            ),
+            "calibration_blocked_prospective_path_attempts": (
+                self.blocked_prospective_path_attempts
+            ),
+            "calibration_blocked_sealed_token_attempts": (
+                self.blocked_sealed_token_attempts
+            ),
+            "calibration_authorized_manifest_document_reads": (
+                self.authorized_manifest_document_reads
+            ),
+            "calibration_authorized_file_reads": self.authorized_calibration_file_reads,
+            "calibration_authorized_parquet_reads": (
+                self.authorized_calibration_parquet_reads
+            ),
+            "calibration_authorized_bar_rows": self.authorized_calibration_bar_rows,
+            "calibration_manifest_allowlist_size": self.manifest_allowlist_size,
+            "calibration_manifest_excluded_out_of_scope": (
+                self.manifest_excluded_out_of_scope
+            ),
+            "calibration_sessions_authorized": self.calibration_sessions_authorized,
+        }
+
+
+def partition_year(path: Path) -> int | None:
+    """Return the ``year=YYYY`` partition of ``path``, or ``None``."""
+
+    for part in path.parts:
+        match = _YEAR_PARTITION.fullmatch(part)
+        if match is not None:
+            return int(match.group(1))
+    return None
+
+
+class CalibrationAccessGuard(SealedAccessGuard):
+    """Widen ``SealedAccessGuard`` by exactly the A2 allow-list, nothing more.
+
+    Everything the base guard blocks stays blocked unless it is either a
+    ``<= 2024`` warm-up date, a 2025 date on the sealed calendar, or a file the
+    ``D3_CALIBRATION_2025`` manifest enumerates inside its 2025 partition.
+    """
+
+    def __init__(
+        self,
+        *,
+        calibration_sessions: Iterable[date],
+        spy: CalibrationAccessSpy | None = None,
+        holdout_root: Path | None = None,
+        run_id: str = HOLDOUT_RUN_ID,
+    ) -> None:
+        super().__init__(spy or CalibrationAccessSpy())
+        sessions = frozenset(calibration_sessions)
+        if not sessions:
+            raise CalibrationScopeError("calibration calendar is empty")
+        off_scope = sorted(day for day in sessions if day.year != CALIBRATION_YEAR)
+        if off_scope:
+            raise CalibrationScopeError(
+                f"calibration calendar carries non-2025 dates:{off_scope[:3]}"
+            )
+        self._sessions = sessions
+        self._holdout_root = (
+            (holdout_root or HOLDOUT_DIR).expanduser().resolve(strict=False)
+        )
+        self._run_root = (self._holdout_root / "runs" / run_id).resolve(strict=False)
+        self._manifest_documents = frozenset(
+            self._run_root / name for name in MANIFEST_DOCUMENT_NAMES
+        )
+        # Bootstrap: only the two enumerating documents are readable until the
+        # file set they enumerate has been bound.
+        self._allowed: frozenset[Path] = self._manifest_documents
+        self._bound = False
+        self.spy.calibration_sessions_authorized = len(sessions)
+
+    # -- allow-list binding -------------------------------------------------
+
+    @property
+    def manifest_documents(self) -> frozenset[Path]:
+        return self._manifest_documents
+
+    @property
+    def allowed_paths(self) -> frozenset[Path]:
+        return self._allowed
+
+    @property
+    def calibration_sessions(self) -> frozenset[date]:
+        return self._sessions
+
+    def bind_manifest_allowlist(
+        self, paths: Iterable[Path], *, excluded_out_of_scope: int
+    ) -> None:
+        """Bind the enumerated 2025 file set. Callable exactly once."""
+
+        if self._bound:
+            raise CalibrationScopeError("manifest allow-list is already bound")
+        resolved = frozenset(
+            Path(item).expanduser().resolve(strict=False) for item in paths
+        )
+        stray = sorted(
+            str(item) for item in resolved if not item.is_relative_to(self._run_root)
+        )
+        if stray:
+            raise CalibrationScopeError(f"allow-list escaped the run root:{stray[:3]}")
+        off_scope = sorted(
+            str(item)
+            for item in resolved
+            if (year := partition_year(item)) is not None and year != CALIBRATION_YEAR
+        )
+        if off_scope:
+            raise CalibrationScopeError(
+                f"allow-list carries a non-2025 partition:{off_scope[:3]}"
+            )
+        self._allowed = resolved | self._manifest_documents
+        self._bound = True
+        self.spy.manifest_allowlist_size = len(self._allowed)
+        self.spy.manifest_excluded_out_of_scope = excluded_out_of_scope
+
+    def fresh_clone(self) -> CalibrationAccessGuard:
+        """Same A2 scope, zeroed spy.
+
+        Each engine attempt needs its own counters: ``EngineResult.evidence``
+        embeds the guard's spy, so a shared accumulating spy would make two
+        otherwise identical attempts serialize differently and defeat the
+        byte-identical determinism check.
+        """
+
+        clone = type(self)(
+            calibration_sessions=self._sessions,
+            spy=type(self.spy)(),
+            holdout_root=self._holdout_root,
+        )
+        clone.bind_manifest_allowlist(
+            self._allowed - self._manifest_documents,
+            excluded_out_of_scope=self.spy.manifest_excluded_out_of_scope,
+        )
+        return clone
+
+    # -- A2 date axis -------------------------------------------------------
+
+    def assert_exploration_date(self, value: date | datetime) -> None:
+        self.spy.date_checks += 1
+        day = value.date() if isinstance(value, datetime) else value
+        if day.year <= WARMUP_LAST_YEAR:
+            self.spy.warmup_date_checks += 1
+            return
+        if day.year == CALIBRATION_YEAR and day in self._sessions:
+            self.spy.calibration_date_checks += 1
+            return
+        self.spy.blocked_attempts += 1
+        if day.year > CALIBRATION_YEAR:
+            self.spy.blocked_prospective_date_attempts += 1
+            reason = "prospective year"
+        else:
+            self.spy.blocked_offcalendar_2025_date_attempts += 1
+            reason = "2025 date absent from the sealed calendar"
+        raise SealedAccessBlocked(
+            f"calibration date blocked before read: {day} ({reason})"
+        )
+
+    # -- A2 path axis -------------------------------------------------------
+
+    def _has_sealed_token(self, path: Path) -> bool:
+        """Mirror the base deny-list predicate off the base token set."""
+
+        tokens = {part.casefold() for part in path.parts}
+        return bool(tokens & self._SEALED_SEGMENTS) or any(
+            "holdout" in token or "calibration" in token or "prospective" in token
+            for token in tokens
+        )
+
+    def _authorize_path(self, value: str | Path) -> tuple[Path, str]:
+        path = Path(value).expanduser().resolve(strict=False)
+        if path.is_relative_to(self._holdout_root):
+            if path in self._allowed:
+                return path, "calibration"
+            self.spy.blocked_attempts += 1
+            year = partition_year(path)
+            if year is not None and year != CALIBRATION_YEAR:
+                self.spy.blocked_prospective_path_attempts += 1
+                reason = f"non-calibration partition year={year}"
+            else:
+                self.spy.blocked_outside_manifest_attempts += 1
+                reason = "not enumerated by the D3_CALIBRATION_2025 manifest"
+            raise SealedAccessBlocked(
+                f"sealed path blocked before read: {path.name} ({reason})"
+            )
+        if self._has_sealed_token(path):
+            self.spy.blocked_attempts += 1
+            self.spy.blocked_sealed_token_attempts += 1
+            raise SealedAccessBlocked(f"sealed path blocked before read: {path.name}")
+        return path, "exploration"
+
+    def assert_exploration_path(self, value: str | Path) -> None:
+        self.spy.path_checks += 1
+        _, kind = self._authorize_path(value)
+        if kind == "calibration":
+            self.spy.calibration_path_checks += 1
+        else:
+            self.spy.exploration_path_checks += 1
+
+    def _record_actual_path_read(self, value: str | Path, *, read_kind: str) -> None:
+        """Post-read symlink recheck; authorized sealed reads are counted, not raised."""
+
+        path, kind = self._authorize_path(value)
+        if kind == "calibration":
+            self.spy.sealed_reads += 1
+            if path in self._manifest_documents:
+                self.spy.authorized_manifest_document_reads += 1
+                self.spy.sealed_manifest_reads += 1
+            elif read_kind == "parquet":
+                self.spy.authorized_calibration_parquet_reads += 1
+                self.spy.sealed_parquet_reads += 1
+            elif read_kind == "bar":
+                self.spy.sealed_bar_rows_read += 1
+            else:
+                self.spy.authorized_calibration_file_reads += 1
+                self.spy.sealed_file_reads += 1
+        self.spy.actual_file_reads += 1
+
+    def record_bar_rows(self, sessions: list[date] | tuple[date, ...]) -> None:
+        """Gate every decoded bar date; 2025 rows are authorized, not fatal."""
+
+        authorized_2025 = 0
+        for session in sessions:
+            self.assert_exploration_date(session)
+            if session.year == CALIBRATION_YEAR:
+                authorized_2025 += 1
+        self.spy.bar_rows_read += len(sessions)
+        self.spy.authorized_calibration_bar_rows += authorized_2025

--- a/research/kr_corpus/d3_engine/calibration_metrics.py
+++ b/research/kr_corpus/d3_engine/calibration_metrics.py
@@ -17,14 +17,43 @@ Frozen literals this module implements (no invention):
 * GAP-06 — an empty sample stays ``NOT_COMPUTABLE``; it never becomes 0.
 * GAP-07 — a fill dated outside the sealed XKRX session list is
   ``session_unassignable`` and excluded with its count published.
+
+All arithmetic runs inside :func:`contract_context`, the contract's pinned
+50-digit ``ROUND_HALF_UP`` Decimal context — the same one the engine wraps its
+own run in. Python's 28-digit default would silently truncate the actual-side
+values that the D3-C2P fix-r1 job published and an independent verifier passed.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from typing import Any
+
+from research.kr_corpus.d3_engine.constants import (
+    DECIMAL_PRECISION,
+    DECIMAL_ROUNDING,
+)
+
+
+@contextmanager
+def contract_context() -> Iterator[None]:
+    """The contract's fixed Decimal arithmetic context (prec 50, HALF_UP)."""
+
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        context.rounding = DECIMAL_ROUNDING
+        yield
+
+
+def decimal_text(value: Decimal) -> str:
+    """Fixed-notation Decimal text; an exponent-only zero renders as ``0``."""
+
+    return format(value, "f")
+
 
 WINDOW_START = date(2025, 1, 1)
 WINDOW_END = date(2025, 12, 31)
@@ -127,6 +156,12 @@ def reconstruct_cycles(fills: list[CycleFill]) -> Reconstruction:
         by_symbol.setdefault(fill.symbol, []).append(fill)
 
     out = Reconstruction()
+    with contract_context():
+        _walk_symbols(by_symbol, out)
+    return out
+
+
+def _walk_symbols(by_symbol: dict[str, list[CycleFill]], out: Reconstruction) -> None:
     for symbol, symbol_fills in sorted(by_symbol.items()):
         position = Decimal(0)
         average = Decimal(0)
@@ -191,7 +226,6 @@ def reconstruct_cycles(fills: list[CycleFill]) -> Reconstruction:
                 cycle.closed = True
                 cycle.close_day = fill.day
                 previous_buy_day = None
-    return out
 
 
 @dataclass(slots=True)
@@ -257,7 +291,8 @@ def median(values: list[Decimal]) -> tuple[Decimal | None, int]:
         return None, 0
     if count % 2:
         return ordered[count // 2], count
-    return (ordered[count // 2 - 1] + ordered[count // 2]) / Decimal(2), count
+    with contract_context():
+        return (ordered[count // 2 - 1] + ordered[count // 2]) / Decimal(2), count
 
 
 class SessionAxis:
@@ -284,8 +319,8 @@ def _observation(
     value, count = median(values)
     payload: dict[str, Any] = {
         "aggregate_kind": "median",
-        "aggregate_decimal": str(value) if value is not None else None,
-        "median_decimal": str(value) if value is not None else None,
+        "aggregate_decimal": decimal_text(value) if value is not None else None,
+        "median_decimal": decimal_text(value) if value is not None else None,
         "n": count,
         "raw_observation_count": raw,
         "excluded_observation_count": excluded,
@@ -306,11 +341,12 @@ def compute_cycle_metrics(
     unassignable = 0
 
     # annualized_cycle_count — one window-level observation (GAP-01).
-    annualized = (
-        Decimal(len(gap03.eligible_closed))
-        * ANNUALIZATION_CALENDAR_DAYS
-        / Decimal(WINDOW_CALENDAR_DAYS)
-    )
+    with contract_context():
+        annualized = (
+            Decimal(len(gap03.eligible_closed))
+            * ANNUALIZATION_CALENDAR_DAYS
+            / Decimal(WINDOW_CALENDAR_DAYS)
+        )
 
     # holding_period_sessions — eligible closed cycles only (GAP-03).
     holding: list[Decimal] = []
@@ -359,8 +395,8 @@ def compute_cycle_metrics(
     return {
         "annualized_cycle_count": {
             "aggregate_kind": "window_level_rate",
-            "aggregate_decimal": str(annualized),
-            "median_decimal": str(annualized),
+            "aggregate_decimal": decimal_text(annualized),
+            "median_decimal": decimal_text(annualized),
             "n": 1,
             "raw_observation_count": 1,
             "excluded_observation_count": 0,
@@ -464,19 +500,22 @@ def capital_share_observation(
     if any(value < 0 or value > 1 for value in daily_ratios):
         raise ValueError("locked ratios must be in [0,1]")
     ordered = sorted(daily_ratios)
-    tw_mean = sum(daily_ratios, Decimal(0)) / Decimal(len(daily_ratios))
+    with contract_context():
+        tw_mean = sum(daily_ratios, Decimal(0)) / Decimal(len(daily_ratios))
     rank = -(-95 * len(ordered) // 100)
     p95 = ordered[rank - 1]
     median_value, _ = median(daily_ratios)
     return {
         "aggregate_kind": "time_weighted_mean",
-        "aggregate_decimal": str(tw_mean),
-        "median_decimal": str(median_value) if median_value is not None else None,
+        "aggregate_decimal": decimal_text(tw_mean),
+        "median_decimal": (
+            decimal_text(median_value) if median_value is not None else None
+        ),
         "n": len(daily_ratios),
         "raw_observation_count": len(daily_ratios),
         "excluded_observation_count": 0,
-        "p95_decimal": str(p95),
-        "max_decimal": str(max(daily_ratios)),
+        "p95_decimal": decimal_text(p95),
+        "max_decimal": decimal_text(max(daily_ratios)),
         "capital_share_definition_id": definition_id,
         "note": note,
     }

--- a/research/kr_corpus/d3_engine/calibration_metrics.py
+++ b/research/kr_corpus/d3_engine/calibration_metrics.py
@@ -1,0 +1,482 @@
+"""One cycle-metric extractor, applied identically to both calibration sides.
+
+GAP-04's principle — "a different formula makes the comparison itself
+meaningless" — is enforced structurally here: the operator's real fills and the
+B0 replay's fills are reduced to the same :class:`CycleFill` record and run
+through the same reconstruction, the same GAP-03 censoring, the same GAP-07
+session assignment, and the same medians. The only thing that differs between
+the sides is the fill tape.
+
+Frozen literals this module implements (no invention):
+
+* GAP-01 — ``annualized_cycle_count = closed * 365.2425 / window_calendar_days``.
+* GAP-02 — selector lives in the caller; this module is source-agnostic.
+* GAP-03 — left-censored (carry-in) and right-censored cycles leave the
+  closed-cycle series and are counted, never silently dropped.
+* GAP-05 — gross-to-gross; no fee is imputed on either side.
+* GAP-06 — an empty sample stays ``NOT_COMPUTABLE``; it never becomes 0.
+* GAP-07 — a fill dated outside the sealed XKRX session list is
+  ``session_unassignable`` and excluded with its count published.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+WINDOW_START = date(2025, 1, 1)
+WINDOW_END = date(2025, 12, 31)
+WINDOW_CALENDAR_DAYS = (WINDOW_END - WINDOW_START).days + 1
+ANNUALIZATION_CALENDAR_DAYS = Decimal("365.2425")
+
+POSITIVE_SCALE = (
+    "annualized_cycle_count",
+    "holding_period_sessions",
+    "add_sizing_multiple",
+    "adds_per_cycle",
+    "add_interval_sessions",
+    "open_lot_age_sessions",
+)
+BOUNDED_SHARE = ("trim_share", "capital_share")
+SIGNED_PERCENTAGE_POINTS = ("signed_realized_pnl_pct",)
+METRIC_IDS = (*POSITIVE_SCALE, *BOUNDED_SHARE, *SIGNED_PERCENTAGE_POINTS)
+
+COMPARISON_KIND = {
+    **dict.fromkeys(POSITIVE_SCALE, "positive_scale"),
+    **dict.fromkeys(BOUNDED_SHARE, "bounded_share"),
+    **dict.fromkeys(SIGNED_PERCENTAGE_POINTS, "signed_percentage_points"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CycleFill:
+    """One filled buy or sell, gross-priced, on the shared record shape."""
+
+    symbol: str
+    side: str
+    quantity: Decimal
+    price: Decimal
+    day: date
+    sequence: int
+
+    @property
+    def amount(self) -> Decimal:
+        return self.quantity * self.price
+
+
+@dataclass(slots=True)
+class Cycle:
+    symbol: str
+    first_buy_day: date
+    first_buy_amount: Decimal
+    buy_count: int = 1
+    sell_count: int = 0
+    closed: bool = False
+    close_day: date | None = None
+
+    @property
+    def key(self) -> tuple[str, date, int]:
+        return (self.symbol, self.first_buy_day, self.buy_count_key)
+
+    buy_count_key: int = 0
+
+    def open_at(self, as_of: date) -> bool:
+        if self.first_buy_day > as_of:
+            return False
+        return not self.closed or (
+            self.close_day is not None and self.close_day > as_of
+        )
+
+
+@dataclass(slots=True)
+class AddEvent:
+    cycle_key: tuple[str, date, int]
+    day: date
+    previous_buy_day: date
+    multiple: Decimal
+
+
+@dataclass(slots=True)
+class SellEvent:
+    cycle_key: tuple[str, date, int]
+    day: date
+    trim_share: Decimal
+    pnl_pct: Decimal
+
+
+@dataclass(slots=True)
+class Reconstruction:
+    cycles: list[Cycle] = field(default_factory=list)
+    adds: list[AddEvent] = field(default_factory=list)
+    sells: list[SellEvent] = field(default_factory=list)
+    anomalies: list[str] = field(default_factory=list)
+
+
+def reconstruct_cycles(fills: list[CycleFill]) -> Reconstruction:
+    """flat -> buy -> ... -> flat cycles, positions merged per symbol.
+
+    An oversell (recorded sell larger than the reconstructed position, which
+    the operator archive contains where the true position predates its
+    coverage) is clamped to the position and disclosed, never dropped.
+    """
+
+    by_symbol: dict[str, list[CycleFill]] = {}
+    for fill in sorted(fills, key=lambda item: (item.day, item.sequence, item.symbol)):
+        by_symbol.setdefault(fill.symbol, []).append(fill)
+
+    out = Reconstruction()
+    for symbol, symbol_fills in sorted(by_symbol.items()):
+        position = Decimal(0)
+        average = Decimal(0)
+        cycle: Cycle | None = None
+        cycle_ordinal = 0
+        previous_buy_day: date | None = None
+        for fill in symbol_fills:
+            if fill.side == "BUY":
+                if position == 0:
+                    cycle_ordinal += 1
+                    cycle = Cycle(
+                        symbol=symbol,
+                        first_buy_day=fill.day,
+                        first_buy_amount=fill.amount,
+                        buy_count_key=cycle_ordinal,
+                    )
+                    out.cycles.append(cycle)
+                    average = fill.price
+                    position = fill.quantity
+                else:
+                    assert cycle is not None
+                    assert previous_buy_day is not None
+                    out.adds.append(
+                        AddEvent(
+                            cycle_key=cycle.key,
+                            day=fill.day,
+                            previous_buy_day=previous_buy_day,
+                            multiple=fill.amount / cycle.first_buy_amount,
+                        )
+                    )
+                    cycle.buy_count += 1
+                    average = (position * average + fill.amount) / (
+                        position + fill.quantity
+                    )
+                    position += fill.quantity
+                previous_buy_day = fill.day
+                continue
+            if position <= 0:
+                out.anomalies.append(
+                    f"SELL while flat: {symbol} {fill.day} qty={fill.quantity}"
+                )
+                continue
+            sell_quantity = fill.quantity
+            if sell_quantity > position:
+                out.anomalies.append(
+                    f"SELL qty>pos (clamped to position): {symbol} {fill.day} "
+                    f"qty={fill.quantity} pos={position}"
+                )
+                sell_quantity = position
+            assert cycle is not None
+            out.sells.append(
+                SellEvent(
+                    cycle_key=cycle.key,
+                    day=fill.day,
+                    trim_share=sell_quantity / position,
+                    pnl_pct=(fill.price - average) / average * Decimal(100),
+                )
+            )
+            cycle.sell_count += 1
+            position -= sell_quantity
+            if position == 0:
+                cycle.closed = True
+                cycle.close_day = fill.day
+                previous_buy_day = None
+    return out
+
+
+@dataclass(slots=True)
+class Gap03Classification:
+    carry_in_closed: list[Cycle]
+    carry_in_open_with_activity: list[Cycle]
+    right_censored: list[Cycle]
+    eligible_closed: list[Cycle]
+
+    @property
+    def carry_in_all(self) -> list[Cycle]:
+        return self.carry_in_closed + self.carry_in_open_with_activity
+
+    @property
+    def overlap(self) -> list[Cycle]:
+        censored = {cycle.key for cycle in self.right_censored}
+        return [
+            cycle for cycle in self.carry_in_open_with_activity if cycle.key in censored
+        ]
+
+
+def _in_window(value: date | None) -> bool:
+    return value is not None and WINDOW_START <= value <= WINDOW_END
+
+
+def classify_gap03(recon: Reconstruction) -> Gap03Classification:
+    closed_in_window = [
+        cycle for cycle in recon.cycles if cycle.closed and _in_window(cycle.close_day)
+    ]
+    right_censored = [cycle for cycle in recon.cycles if cycle.open_at(WINDOW_END)]
+    carry_in_closed = [
+        cycle for cycle in closed_in_window if cycle.first_buy_day < WINDOW_START
+    ]
+    activity: set[tuple[str, date, int]] = set()
+    for event in recon.adds:
+        if _in_window(event.day):
+            activity.add(event.cycle_key)
+    for event in recon.sells:
+        if _in_window(event.day):
+            activity.add(event.cycle_key)
+    carry_in_open_with_activity = [
+        cycle
+        for cycle in right_censored
+        if cycle.first_buy_day < WINDOW_START and cycle.key in activity
+    ]
+    eligible_closed = [
+        cycle for cycle in closed_in_window if cycle.first_buy_day >= WINDOW_START
+    ]
+    return Gap03Classification(
+        carry_in_closed=carry_in_closed,
+        carry_in_open_with_activity=carry_in_open_with_activity,
+        right_censored=right_censored,
+        eligible_closed=eligible_closed,
+    )
+
+
+def median(values: list[Decimal]) -> tuple[Decimal | None, int]:
+    """Exact Decimal median; no rounding before comparison."""
+
+    ordered = sorted(values)
+    count = len(ordered)
+    if count == 0:
+        return None, 0
+    if count % 2:
+        return ordered[count // 2], count
+    return (ordered[count // 2 - 1] + ordered[count // 2]) / Decimal(2), count
+
+
+class SessionAxis:
+    """GAP-07 session assignment against the sealed 2025 XKRX calendar."""
+
+    def __init__(self, sessions: tuple[date, ...]) -> None:
+        self._index = {session: position for position, session in enumerate(sessions)}
+        self.sessions = sessions
+        self.cutoff_index = len(sessions) - 1
+
+    def seq(self, day: date | None) -> int | None:
+        if day is None:
+            return None
+        return self._index.get(day)
+
+
+def _observation(
+    values: list[Decimal],
+    *,
+    raw: int,
+    excluded: int,
+    note: str | None = None,
+) -> dict[str, Any]:
+    value, count = median(values)
+    payload: dict[str, Any] = {
+        "aggregate_kind": "median",
+        "aggregate_decimal": str(value) if value is not None else None,
+        "median_decimal": str(value) if value is not None else None,
+        "n": count,
+        "raw_observation_count": raw,
+        "excluded_observation_count": excluded,
+    }
+    if note:
+        payload["note"] = note
+    return payload
+
+
+def compute_cycle_metrics(
+    recon: Reconstruction,
+    gap03: Gap03Classification,
+    axis: SessionAxis,
+) -> dict[str, Any]:
+    """The eight fill-derived metrics. ``capital_share`` is computed elsewhere."""
+
+    eligible = {cycle.key for cycle in gap03.eligible_closed}
+    unassignable = 0
+
+    # annualized_cycle_count — one window-level observation (GAP-01).
+    annualized = (
+        Decimal(len(gap03.eligible_closed))
+        * ANNUALIZATION_CALENDAR_DAYS
+        / Decimal(WINDOW_CALENDAR_DAYS)
+    )
+
+    # holding_period_sessions — eligible closed cycles only (GAP-03).
+    holding: list[Decimal] = []
+    holding_excluded = 0
+    for cycle in gap03.eligible_closed:
+        start = axis.seq(cycle.first_buy_day)
+        end = axis.seq(cycle.close_day)
+        if start is None or end is None:
+            holding_excluded += 1
+            unassignable += 1
+            continue
+        holding.append(Decimal(end - start))
+
+    # adds_per_cycle / add_sizing_multiple / add_interval_sessions.
+    adds_per_cycle = [Decimal(cycle.buy_count - 1) for cycle in gap03.eligible_closed]
+    add_events = [event for event in recon.adds if event.cycle_key in eligible]
+    add_multiples = [event.multiple for event in add_events]
+    intervals: list[Decimal] = []
+    interval_excluded = 0
+    for event in add_events:
+        start = axis.seq(event.previous_buy_day)
+        end = axis.seq(event.day)
+        if start is None or end is None:
+            interval_excluded += 1
+            unassignable += 1
+            continue
+        intervals.append(Decimal(end - start))
+
+    # open_lot_age_sessions — every cycle still open at cutoff (GAP-03 keeps
+    # right-censored cycles in this family).
+    ages: list[Decimal] = []
+    age_excluded = 0
+    for cycle in gap03.right_censored:
+        start = axis.seq(cycle.first_buy_day)
+        if start is None:
+            age_excluded += 1
+            unassignable += 1
+            continue
+        ages.append(Decimal(axis.cutoff_index - start))
+
+    sells = [event for event in recon.sells if event.cycle_key in eligible]
+    excluded_cycles = len(gap03.carry_in_all) + len(gap03.right_censored)
+    excluded_add_events = len(recon.adds) - len(add_events)
+    excluded_sell_events = len(recon.sells) - len(sells)
+
+    return {
+        "annualized_cycle_count": {
+            "aggregate_kind": "window_level_rate",
+            "aggregate_decimal": str(annualized),
+            "median_decimal": str(annualized),
+            "n": 1,
+            "raw_observation_count": 1,
+            "excluded_observation_count": 0,
+            "closed_cycle_count": len(gap03.eligible_closed),
+            "window_calendar_days": WINDOW_CALENDAR_DAYS,
+            "note": (
+                "GAP-01 calendar-day basis 365.2425/window_calendar_days; "
+                "numerator = the GAP-03-eligible closed cycle count"
+            ),
+        },
+        "holding_period_sessions": _observation(
+            holding,
+            raw=len(gap03.eligible_closed),
+            excluded=holding_excluded,
+            note="session_gap(first_fill, final_flat) on the sealed 2025 XKRX axis",
+        ),
+        "add_sizing_multiple": _observation(
+            add_multiples,
+            raw=len(add_events),
+            excluded=excluded_add_events,
+            note="add gross notional / the cycle's first filled buy gross notional",
+        ),
+        "adds_per_cycle": _observation(
+            adds_per_cycle,
+            raw=len(gap03.eligible_closed),
+            excluded=excluded_cycles,
+            note=(
+                "eligible closed cycles only — GAP-03 removes carry-in and "
+                "right-censored cycles from the closed-cycle series; the same "
+                "universe is applied to both sides"
+            ),
+        ),
+        "add_interval_sessions": _observation(
+            intervals,
+            raw=len(add_events),
+            excluded=excluded_add_events + interval_excluded,
+            note="session_gap(previous buy, add) on the sealed 2025 XKRX axis",
+        ),
+        "open_lot_age_sessions": _observation(
+            ages,
+            raw=len(gap03.right_censored),
+            excluded=age_excluded,
+            note=(
+                "cycles still open at cutoff; a carry-in cycle whose first fill "
+                "predates the 2025 axis has no session_seq and is excluded, not "
+                "clipped"
+            ),
+        ),
+        "trim_share": _observation(
+            [event.trim_share for event in sells],
+            raw=len(sells),
+            excluded=excluded_sell_events,
+            note="sell quantity / open quantity immediately before the sell",
+        ),
+        "signed_realized_pnl_pct": _observation(
+            [event.pnl_pct for event in sells],
+            raw=len(sells),
+            excluded=excluded_sell_events,
+            note=(
+                "GAP-05 gross-to-gross: 100*(sell price - average buy price)/"
+                "average buy price, no fee imputed on either side"
+            ),
+        ),
+        "_census": {
+            "closed_cycle_count": len(gap03.eligible_closed),
+            "right_censored_count": len(gap03.right_censored),
+            "carry_in_excluded_count": len(gap03.carry_in_all),
+            "carry_in_excluded_breakdown": {
+                "closed_carry_in": sorted(
+                    cycle.symbol for cycle in gap03.carry_in_closed
+                ),
+                "open_carry_in_with_2025_activity": sorted(
+                    cycle.symbol for cycle in gap03.carry_in_open_with_activity
+                ),
+            },
+            "carry_in_and_right_censored_overlap": sorted(
+                cycle.symbol for cycle in gap03.overlap
+            ),
+            "session_unassignable_observations": unassignable,
+            "anomalies": list(recon.anomalies),
+        },
+    }
+
+
+def capital_share_observation(
+    daily_ratios: list[Decimal], *, definition_id: str, note: str
+) -> dict[str, Any]:
+    """GAP-04 locked-share: daily grain, time-weighted mean, p95 and max beside it."""
+
+    if not daily_ratios:
+        return {
+            "aggregate_kind": "time_weighted_mean",
+            "aggregate_decimal": None,
+            "median_decimal": None,
+            "n": 0,
+            "raw_observation_count": 0,
+            "excluded_observation_count": 0,
+            "capital_share_definition_id": definition_id,
+            "note": note,
+        }
+    if any(value < 0 or value > 1 for value in daily_ratios):
+        raise ValueError("locked ratios must be in [0,1]")
+    ordered = sorted(daily_ratios)
+    tw_mean = sum(daily_ratios, Decimal(0)) / Decimal(len(daily_ratios))
+    rank = -(-95 * len(ordered) // 100)
+    p95 = ordered[rank - 1]
+    median_value, _ = median(daily_ratios)
+    return {
+        "aggregate_kind": "time_weighted_mean",
+        "aggregate_decimal": str(tw_mean),
+        "median_decimal": str(median_value) if median_value is not None else None,
+        "n": len(daily_ratios),
+        "raw_observation_count": len(daily_ratios),
+        "excluded_observation_count": 0,
+        "p95_decimal": str(p95),
+        "max_decimal": str(max(daily_ratios)),
+        "capital_share_definition_id": definition_id,
+        "note": note,
+    }

--- a/research/kr_corpus/d3_engine/calibration_result.py
+++ b/research/kr_corpus/d3_engine/calibration_result.py
@@ -22,6 +22,8 @@ from typing import Any
 from research.kr_corpus.d3_engine.calibration_metrics import (
     COMPARISON_KIND,
     METRIC_IDS,
+    contract_context,
+    decimal_text,
 )
 
 STATE_PRIORITY_A1 = (
@@ -73,9 +75,11 @@ def compare_view(
     simulated_value = _aggregate(simulated)
     detail: dict[str, Any] = {
         "comparison_kind": kind,
-        "actual_aggregate": str(actual_value) if actual_value is not None else None,
+        "actual_aggregate": (
+            decimal_text(actual_value) if actual_value is not None else None
+        ),
         "simulated_aggregate": (
-            str(simulated_value) if simulated_value is not None else None
+            decimal_text(simulated_value) if simulated_value is not None else None
         ),
         "zero_rule_applied": False,
     }
@@ -89,18 +93,21 @@ def compare_view(
         return ("PASS" if simulated_value == 0 else "FAIL"), detail
 
     if kind == "positive_scale":
-        ratio = simulated_value / actual_value
-        detail["ratio"] = str(ratio)
+        with contract_context():
+            ratio = simulated_value / actual_value
+        detail["ratio"] = decimal_text(ratio)
         detail["predicate"] = "0.5 <= simulated/actual <= 2.0"
         passed = POSITIVE_SCALE_LOW <= ratio <= POSITIVE_SCALE_HIGH
     elif kind == "bounded_share":
-        difference = abs(simulated_value - actual_value)
-        detail["absolute_difference"] = str(difference)
+        with contract_context():
+            difference = abs(simulated_value - actual_value)
+        detail["absolute_difference"] = decimal_text(difference)
         detail["predicate"] = "abs(simulated - actual) <= 0.20"
         passed = difference <= BOUNDED_SHARE_TOLERANCE
     else:
-        difference = abs(simulated_value - actual_value)
-        detail["absolute_difference_points"] = str(difference)
+        with contract_context():
+            difference = abs(simulated_value - actual_value)
+        detail["absolute_difference_points"] = decimal_text(difference)
         detail["predicate"] = "abs(simulated - actual) <= 5.0 percentage points"
         passed = difference <= SIGNED_POINT_TOLERANCE
     return ("PASS" if passed else "FAIL"), detail

--- a/research/kr_corpus/d3_engine/calibration_result.py
+++ b/research/kr_corpus/d3_engine/calibration_result.py
@@ -1,0 +1,235 @@
+"""Comparator and terminal-state resolution for the B0 calibration.
+
+Every predicate is a frozen literal from contract v3.1 §5 as closed by
+``d3-calibration-gap-closure-20260807.md``:
+
+* positive scale — ``0.5 <= simulated / actual <= 2.0``
+* bounded share — ``abs(simulated - actual) <= 0.20``
+* signed percentage points — ``abs(simulated - actual) <= 5.0``
+* exact-zero rule — **positive-scale only** (GAP-10 restores the contract
+  wording over the preparation packet's conservative extension)
+* an empty or invalid sample is ``NOT_COMPUTABLE`` and never coerced to 0,
+  PASS, or MISMATCH (GAP-06)
+
+None of these states selects a D3 winner or re-ranks anything economic.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from research.kr_corpus.d3_engine.calibration_metrics import (
+    COMPARISON_KIND,
+    METRIC_IDS,
+)
+
+STATE_PRIORITY_A1 = (
+    "RUN_INVALID",
+    "INCONCLUSIVE_DATA_BIAS",
+    "INCONCLUSIVE_UNRESOLVED_TERMINAL",
+    "CALIBRATION_DATA_BIAS",
+    "CALIBRATION_MISMATCH",
+    "verdict",
+)
+POSITIVE_SCALE_LOW = Decimal("0.5")
+POSITIVE_SCALE_HIGH = Decimal("2.0")
+BOUNDED_SHARE_TOLERANCE = Decimal("0.20")
+SIGNED_POINT_TOLERANCE = Decimal("5.0")
+
+TERMINAL_ORDER = (
+    "RUN_INVALID",
+    "INCONCLUSIVE_UNRESOLVED_TERMINAL",
+    "CALIBRATION_INCOMPLETE",
+    "CALIBRATION_DATA_BIAS",
+    "CALIBRATION_MISMATCH",
+    "CALIBRATION_PASS",
+)
+
+
+def _aggregate(side: dict[str, Any] | None) -> Decimal | None:
+    if not side:
+        return None
+    if int(side.get("n", 0)) <= 0:
+        return None
+    raw = side.get("aggregate_decimal")
+    if raw is None:
+        return None
+    value = Decimal(str(raw))
+    if not value.is_finite():
+        return None
+    return value
+
+
+def compare_view(
+    metric_id: str,
+    actual: dict[str, Any] | None,
+    simulated: dict[str, Any] | None,
+) -> tuple[str, dict[str, Any]]:
+    """One view's decision plus the exact numbers the decision used."""
+
+    kind = COMPARISON_KIND[metric_id]
+    actual_value = _aggregate(actual)
+    simulated_value = _aggregate(simulated)
+    detail: dict[str, Any] = {
+        "comparison_kind": kind,
+        "actual_aggregate": str(actual_value) if actual_value is not None else None,
+        "simulated_aggregate": (
+            str(simulated_value) if simulated_value is not None else None
+        ),
+        "zero_rule_applied": False,
+    }
+    if actual_value is None or simulated_value is None:
+        detail["reason"] = "empty_or_invalid_sample_on_at_least_one_side"
+        return "NOT_COMPUTABLE", detail
+
+    if kind == "positive_scale" and actual_value == 0:
+        detail["zero_rule_applied"] = True
+        detail["predicate"] = "contract exact-zero rule: simulated must be exactly 0"
+        return ("PASS" if simulated_value == 0 else "FAIL"), detail
+
+    if kind == "positive_scale":
+        ratio = simulated_value / actual_value
+        detail["ratio"] = str(ratio)
+        detail["predicate"] = "0.5 <= simulated/actual <= 2.0"
+        passed = POSITIVE_SCALE_LOW <= ratio <= POSITIVE_SCALE_HIGH
+    elif kind == "bounded_share":
+        difference = abs(simulated_value - actual_value)
+        detail["absolute_difference"] = str(difference)
+        detail["predicate"] = "abs(simulated - actual) <= 0.20"
+        passed = difference <= BOUNDED_SHARE_TOLERANCE
+    else:
+        difference = abs(simulated_value - actual_value)
+        detail["absolute_difference_points"] = str(difference)
+        detail["predicate"] = "abs(simulated - actual) <= 5.0 percentage points"
+        passed = difference <= SIGNED_POINT_TOLERANCE
+    return ("PASS" if passed else "FAIL"), detail
+
+
+def view_outcome(original: str, clamp: str) -> str:
+    if "NOT_COMPUTABLE" in (original, clamp):
+        return "NOT_COMPUTABLE"
+    if original == "PASS" and clamp == "PASS":
+        return "PASS"
+    if original == "FAIL" and clamp == "FAIL":
+        return "CALIBRATION_MISMATCH"
+    return "CALIBRATION_DATA_BIAS"
+
+
+def build_result(
+    *,
+    actual_metrics: dict[str, Any],
+    simulated_metrics: dict[str, dict[str, Any]],
+    engine_statuses: dict[str, str],
+    stamps: dict[str, Any],
+    census: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the per-metric matrix and resolve the terminal state."""
+
+    rows: list[dict[str, Any]] = []
+    for metric_id in METRIC_IDS:
+        actual = actual_metrics.get(metric_id)
+        original = simulated_metrics["original"].get(metric_id)
+        clamp = simulated_metrics["clamp"].get(metric_id)
+        original_decision, original_detail = compare_view(metric_id, actual, original)
+        clamp_decision, clamp_detail = compare_view(metric_id, actual, clamp)
+        outcome = view_outcome(original_decision, clamp_decision)
+        rows.append(
+            {
+                "metric_id": metric_id,
+                "comparison_kind": COMPARISON_KIND[metric_id],
+                "actual": actual,
+                "simulated": {"original": original, "clamp": clamp},
+                "zero_rule_applied": bool(original_detail["zero_rule_applied"]),
+                "original_decision": original_decision,
+                "clamp_decision": clamp_decision,
+                "view_outcome": outcome,
+                "original_comparison": original_detail,
+                "clamp_comparison": clamp_detail,
+                "not_computable_reason": (
+                    original_detail.get("reason") or clamp_detail.get("reason")
+                    if outcome == "NOT_COMPUTABLE"
+                    else None
+                ),
+            }
+        )
+
+    unresolved = sorted(
+        run_id for run_id, status in engine_statuses.items() if status != "OK"
+    )
+    not_computable = [
+        row["metric_id"] for row in rows if row["view_outcome"] == "NOT_COMPUTABLE"
+    ]
+    data_bias = [
+        row["metric_id"]
+        for row in rows
+        if row["view_outcome"] == "CALIBRATION_DATA_BIAS"
+    ]
+    mismatch = [
+        row["metric_id"]
+        for row in rows
+        if row["view_outcome"] == "CALIBRATION_MISMATCH"
+    ]
+
+    if unresolved:
+        terminal = "INCONCLUSIVE_UNRESOLVED_TERMINAL"
+        basis = f"engine status is not OK for {unresolved}"
+        routed = "NEEDS_UPSTREAM(unresolved_terminal_in_calibration_replay)"
+    elif not_computable:
+        terminal = "CALIBRATION_INCOMPLETE"
+        basis = (
+            "GAP-06: a required metric is NOT_COMPUTABLE and is neither read as "
+            f"0 nor promoted to a mismatch — {not_computable}"
+        )
+        routed = "NEEDS_UPSTREAM(empty_or_invalid_metric_input)"
+    elif data_bias:
+        terminal = "CALIBRATION_DATA_BIAS"
+        basis = f"the two views disagree on {data_bias}; a mismatch cannot be judged"
+        routed = "D3.1 design input — view disagreement"
+    elif mismatch:
+        terminal = "CALIBRATION_MISMATCH"
+        basis = (
+            f"both views fail the frozen acceptance band on {mismatch}; the "
+            "convention is not revised inside this run"
+        )
+        routed = "D3.1 branch"
+    else:
+        terminal = "CALIBRATION_PASS"
+        basis = "every metric passes the frozen band on both views"
+        routed = "D3.1 model-admission input"
+
+    per_view = {
+        view: {
+            "pass": sorted(
+                row["metric_id"] for row in rows if row[f"{view}_decision"] == "PASS"
+            ),
+            "fail": sorted(
+                row["metric_id"] for row in rows if row[f"{view}_decision"] == "FAIL"
+            ),
+            "not_computable": sorted(
+                row["metric_id"]
+                for row in rows
+                if row[f"{view}_decision"] == "NOT_COMPUTABLE"
+            ),
+        }
+        for view in ("original", "clamp")
+    }
+
+    return {
+        "schema_id": "d3.calibration.result.v2",
+        "label": "CALIBRATION_DIAGNOSTIC_ONLY",
+        "purpose": "D3.1_MODEL_INPUT_ONLY",
+        "cell": "B0 x with_contribution x {original, clamp} = 2 physical",
+        "state_priority_a1": STATE_PRIORITY_A1,
+        "terminal_state_evaluation_order": TERMINAL_ORDER,
+        "top_level_status": terminal,
+        "terminal_state_basis": basis,
+        "routed_to": routed,
+        "dual_view": per_view,
+        "winner_touched": False,
+        "economic_reranking": False,
+        "inconclusive_data_bias_released": False,
+        "stamps": stamps,
+        "census": census,
+        "metrics": rows,
+    }

--- a/research/kr_corpus/d3_engine/calibration_run.py
+++ b/research/kr_corpus/d3_engine/calibration_run.py
@@ -1,0 +1,672 @@
+"""D3-C2G calibration harness — the separate runner Amendment A2 authorizes.
+
+Two physical B0 replays (``with_contribution`` x ``{original, clamp}``) over
+``D3_CALIBRATION_2025``, each executed twice and required to be byte-identical,
+compared against the operator's real 2025 KR trading.
+
+Boundary this file keeps:
+
+* ``primary.py`` is untouched. The primary runner still hard-codes
+  ``SealedAccessGuard`` and still cannot process a 2025 bar. That isolation is
+  measured, not asserted — see
+  ``calibration_acceptance.measure_primary_path_isolation``.
+* The warm-up corpus (2015-2024) is loaded through an ordinary
+  ``SealedAccessGuard``, so the exploration path proves it is unchanged: its
+  spy must report zero sealed reads and zero blocked attempts.
+* Only the calibration engine receives ``CalibrationAccessGuard``, and only
+  after its allow-list has been bound from the sealed manifest.
+
+Nothing here selects a winner, computes Pareto dominance, runs a sensitivity
+variant, or releases ``INCONCLUSIVE_DATA_BIAS``.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from research.kr_corpus.backtest.holdout_guard import HOLDOUT_DIR
+from research.kr_corpus.d3_engine.calibration_acceptance import (
+    measure_calibration_fail_closed_probes,
+    measure_primary_path_isolation,
+)
+from research.kr_corpus.d3_engine.calibration_actual_side import build_actual_side
+from research.kr_corpus.d3_engine.calibration_corpus import (
+    CalibrationCorpus,
+    group_by_symbol,
+    load_calibration_corpus,
+)
+from research.kr_corpus.d3_engine.calibration_engine import CalibrationPortfolioEngine
+from research.kr_corpus.d3_engine.calibration_guard import (
+    AMENDMENT_A2_SHA256,
+    CALIBRATION_INDEX_SHA256,
+    CalibrationAccessGuard,
+    CalibrationAccessSpy,
+)
+from research.kr_corpus.d3_engine.calibration_metrics import (
+    CycleFill,
+    SessionAxis,
+    capital_share_observation,
+    classify_gap03,
+    compute_cycle_metrics,
+    reconstruct_cycles,
+)
+from research.kr_corpus.d3_engine.calibration_result import build_result
+from research.kr_corpus.d3_engine.canonical import canonical_bytes
+from research.kr_corpus.d3_engine.constants import ArtifactPaths
+from research.kr_corpus.d3_engine.guards import SealedAccessGuard, SealedAccessSpy
+from research.kr_corpus.d3_engine.models import (
+    Arm,
+    CashflowView,
+    DataView,
+    EngineResult,
+    OrderSide,
+    PortfolioRunInput,
+)
+from research.kr_corpus.d3_engine.primary_corpus import (
+    CORPUS_BINDINGS,
+    CorpusBar,
+    PrimaryCorpusLoader,
+    PrimaryCorpusPaths,
+    _prepare_signal_tape,
+)
+from research.kr_corpus.d3_engine.sources import (
+    FrozenKospiIndex,
+    sha256_file,
+    verify_start_gate,
+)
+from research.kr_corpus.d3_engine.tick import load_tick_table
+
+CALIBRATION_SCHEMA_VERSION = "d3.calibration_run.v1"
+ENGINE_BASE_COMMIT = "603cddc902af7a5c7a98a095efd25690c8b933df"
+GAP_CLOSURE_SHA256 = "b285acdd3f4971eaa50dbf5ecb2cad8043afb5c8b4b2cde2f71c65bd2aaef03b"
+FIDELITY_REFREEZE_SHA256 = (
+    "94623599a0b4b92b8a1c47623a47be827cc7bbd920e3a9df8ac6ee560e341a30"
+)
+SUPERSEDED_C2P_RESULT_SHA256 = (
+    "12cd2044ab13350046557d64d820554aacb0a0eb1d2fdf359f738eca4b4ede0f"
+)
+DECISION_START = date(2025, 1, 1)
+SHA_GATE_COUNT = 14
+VIEWS: tuple[tuple[str, DataView], ...] = (
+    ("original", DataView.ORIGINAL_VALID_BAR),
+    ("clamp", DataView.CLAMP_ADMIT_V1),
+)
+
+
+class CalibrationRunInvalid(RuntimeError):
+    code = "RUN_INVALID_CALIBRATION_HARNESS"
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationHarnessPaths:
+    artifacts: ArtifactPaths
+    corpus: PrimaryCorpusPaths
+    holdout_root: Path
+    index_2025_csv: Path
+    gap_closure: Path
+    fidelity_refreeze: Path
+    amendment_a2: Path
+    superseded_root: Path
+    output_root: Path
+    progress_report: Path
+
+    @classmethod
+    def defaults(cls) -> CalibrationHarnessPaths:
+        work = Path.home() / "work"
+        inbox = work / "herdr-inbox"
+        inputs = work / "herdr-artifacts" / "d3-contract-inputs-v1"
+        return cls(
+            artifacts=ArtifactPaths.defaults(),
+            corpus=PrimaryCorpusPaths.defaults(),
+            holdout_root=HOLDOUT_DIR,
+            index_2025_csv=inputs / "kospi_index_daily_2025.csv",
+            gap_closure=inbox / "d3-calibration-gap-closure-20260807.md",
+            fidelity_refreeze=inbox / "d3-fidelity-refreeze-all-arm-20260807.md",
+            amendment_a2=inbox / "d3-amendment-a2-20260808.md",
+            superseded_root=work / "herdr-artifacts" / "d3-calibration-2p-v1",
+            output_root=work / "herdr-artifacts" / "d3-calibration-2g-v1",
+            progress_report=(
+                work
+                / "herdr-inbox"
+                / "jobs"
+                / "d3-c2g-guard-20260808-0630"
+                / "events"
+                / "impl.md"
+            ),
+        )
+
+
+def _write_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _fill_tape(result: EngineResult) -> list[CycleFill]:
+    """Engine fills reduced onto the shared cycle-metric record (gross prices)."""
+
+    return [
+        CycleFill(
+            symbol=fill.symbol,
+            side="BUY" if fill.side is OrderSide.BUY else "SELL",
+            quantity=Decimal(fill.quantity),
+            price=fill.price,
+            day=fill.session,
+            sequence=index,
+        )
+        for index, fill in enumerate(result.fills)
+    ]
+
+
+class CalibrationRunHarness:
+    def __init__(
+        self,
+        *,
+        harness_commit: str,
+        paths: CalibrationHarnessPaths | None = None,
+    ) -> None:
+        if len(harness_commit) != 40:
+            raise ValueError("harness_commit must be a full Git SHA")
+        self.harness_commit = harness_commit
+        self.paths = paths or CalibrationHarnessPaths.defaults()
+        self._sha_gate: tuple[dict[str, str], ...] = ()
+        self._stamps: dict[str, Any] = {}
+
+    # -- preflight ----------------------------------------------------------
+
+    def _preflight(self) -> None:
+        base = verify_start_gate(self.paths.artifacts)
+        if len(base) != 10:
+            raise CalibrationRunInvalid(f"base SHA gate count drift:{len(base)}")
+        extra: list[dict[str, str]] = []
+        for path, expected in (
+            (self.paths.gap_closure, GAP_CLOSURE_SHA256),
+            (self.paths.fidelity_refreeze, FIDELITY_REFREEZE_SHA256),
+            (self.paths.index_2025_csv, CALIBRATION_INDEX_SHA256),
+            (self.paths.amendment_a2, AMENDMENT_A2_SHA256),
+        ):
+            if not path.is_file():
+                raise CalibrationRunInvalid(f"missing gate input:{path}")
+            actual = sha256_file(path)
+            if actual != expected:
+                raise CalibrationRunInvalid(
+                    f"sha gate drift:{path.name}:{actual}!={expected}"
+                )
+            extra.append({"file": path.name, "sha256": actual, "status": "PASS"})
+        self._sha_gate = (*base, *extra)
+        if len(self._sha_gate) != SHA_GATE_COUNT:
+            raise CalibrationRunInvalid(f"SHA gate count drift:{len(self._sha_gate)}")
+        if self.paths.output_root.resolve() == self.paths.superseded_root.resolve():
+            raise CalibrationRunInvalid(
+                "the C2P artifact root is preserved and must not be overwritten"
+            )
+        superseded_result = self.paths.superseded_root / "calibration-result.json"
+        if sha256_file(superseded_result) != SUPERSEDED_C2P_RESULT_SHA256:
+            raise CalibrationRunInvalid("preserved C2P result drifted before the run")
+        self.paths.progress_report.parent.mkdir(parents=True, exist_ok=True)
+
+    def _append_progress(self, text: str) -> None:
+        with self.paths.progress_report.open("a", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+
+    # -- execution ----------------------------------------------------------
+
+    def run_all(self) -> dict[str, Any]:
+        self._preflight()
+        self._append_progress(
+            f"\nSHA_GATE = {len(self._sha_gate)}/{SHA_GATE_COUNT} PASS "
+            "(recomputed at run start, A2 included)\n"
+        )
+
+        ticks = load_tick_table(self.paths.artifacts.tick_yaml)
+        exploration_index = FrozenKospiIndex.load(self.paths.artifacts.index_csv)
+        calibration_index = FrozenKospiIndex.load(
+            self.paths.index_2025_csv, expected_sha256=CALIBRATION_INDEX_SHA256
+        )
+        market_sessions = tuple(
+            row.session for row in (*exploration_index.rows, *calibration_index.rows)
+        )
+        if market_sessions != tuple(sorted(set(market_sessions))):
+            raise CalibrationRunInvalid("combined XKRX axis is not strict ascending")
+        index_closes = tuple(
+            (row.session, row.close)
+            for row in (*exploration_index.rows, *calibration_index.rows)
+        )
+        calibration_sessions = tuple(row.session for row in calibration_index.rows)
+        axis = SessionAxis(calibration_sessions)
+
+        run_guard = CalibrationAccessGuard(
+            calibration_sessions=calibration_sessions,
+            spy=CalibrationAccessSpy(),
+            holdout_root=self.paths.holdout_root,
+        )
+        calibration = load_calibration_corpus(
+            run_guard, holdout_root=self.paths.holdout_root
+        )
+        self._append_progress(
+            "\nCALIBRATION_CORPUS = "
+            f"original {len(calibration.bars_original)} rows · "
+            f"clamp {len(calibration.bars_clamp)} rows · "
+            f"authorized files {len(calibration.manifest.allowed_paths)} · "
+            f"excluded out-of-scope {calibration.manifest.excluded_out_of_scope}\n"
+        )
+
+        fail_closed = measure_calibration_fail_closed_probes(
+            template=run_guard,
+            prospective_path=calibration.manifest.prospective_example,
+            outside_manifest_path=(
+                calibration.manifest.run_root
+                / "dataset"
+                / "market=KOSPI"
+                / "year=2025"
+                / "ticker=999999.parquet"
+            ),
+            authorized_path=calibration.manifest.allowed_paths[0],
+        )
+        if fail_closed["status"] != "PASS":
+            raise CalibrationRunInvalid(f"fail-closed probes failed:{fail_closed}")
+        isolation = measure_primary_path_isolation(tick_table=ticks)
+        if isolation["status"] != "PASS":
+            raise CalibrationRunInvalid(f"primary path isolation failed:{isolation}")
+        self._append_progress(
+            f"\nFAILCLOSED_NEW = {fail_closed['outcomes']}\n"
+            f"PRIMARY_ISOLATION = {isolation['status']} "
+            f"(guard={isolation['installed_guard_class']})\n"
+        )
+
+        self._stamps = self._build_stamps(calibration=calibration)
+        self.paths.output_root.mkdir(parents=True, exist_ok=True)
+        (self.paths.output_root / "runs").mkdir(exist_ok=True)
+
+        completed: list[dict[str, Any]] = []
+        simulated_metrics: dict[str, dict[str, Any]] = {}
+        simulated_census: dict[str, Any] = {}
+        engine_statuses: dict[str, str] = {}
+        exploration_access: dict[str, dict[str, int]] = {}
+        engine_access: dict[str, dict[str, Any]] = {}
+        operator_closes: dict[str, dict[date, Decimal]] = {}
+        operator_symbols = self._operator_symbols()
+
+        for view_name, data_view in VIEWS:
+            run_id = f"B0__with_contribution__{data_view.value}"
+            loader_guard = SealedAccessGuard(SealedAccessSpy())
+            loader = PrimaryCorpusLoader(paths=self.paths.corpus, guard=loader_guard)
+            warmup = loader.load(data_view, market_sessions=market_sessions)
+            evidence = loader_guard.spy.evidence()
+            if evidence["sealed_access_spy"] != 0:
+                raise CalibrationRunInvalid("warm-up loader measured a sealed read")
+            if evidence["sealed_access_blocked_attempts"] != 0:
+                raise CalibrationRunInvalid("warm-up loader attempted a sealed access")
+            exploration_access[view_name] = evidence
+
+            calibration_bars = (
+                calibration.bars_original
+                if data_view is DataView.ORIGINAL_VALID_BAR
+                else calibration.bars_clamp
+            )
+            bars = tuple(
+                sorted(
+                    [*warmup.bars, *calibration_bars],
+                    key=lambda bar: (bar.session, bar.symbol),
+                )
+            )
+            if len({(bar.session, bar.symbol) for bar in bars}) != len(bars):
+                raise CalibrationRunInvalid("warm-up and 2025 bars collide")
+            if view_name == "original":
+                operator_closes = _collect_closes(bars, operator_symbols)
+
+            positions = {
+                session: index for index, session in enumerate(market_sessions)
+            }
+            tape = _prepare_signal_tape(group_by_symbol(bars), positions)
+            self._append_progress(
+                f"\nVIEW {view_name}: warm-up rows={warmup.row_count} · "
+                f"2025 rows={len(calibration_bars)} · combined={len(bars)} · "
+                f"signal tape={len(tape)}\n"
+            )
+            del warmup
+            gc.collect()
+
+            run_input = PortfolioRunInput(
+                arm=Arm.B0,
+                cashflow_view=CashflowView.WITH_CONTRIBUTION,
+                bars=bars,  # type: ignore[arg-type]
+                data_view=data_view,
+                market_sessions=market_sessions,
+                index_closes=index_closes,
+                corporate_actions=(),
+                decision_start=DECISION_START,
+            )
+            first_bundle, first_result, first_trace = self._execute_attempt(
+                ticks, run_guard, tape, run_input, run_id=run_id
+            )
+            second_bundle, _, _ = self._execute_attempt(
+                ticks, run_guard, tape, run_input, run_id=run_id
+            )
+            if first_bundle != second_bundle:
+                raise CalibrationRunInvalid(f"non-deterministic physical run:{run_id}")
+
+            for name, payload in first_bundle.items():
+                _write_bytes(self.paths.output_root / "runs" / run_id / name, payload)
+            bundle_sha = hashlib.sha256(
+                b"".join(first_bundle[name] for name in sorted(first_bundle))
+            ).hexdigest()
+            completed.append(
+                {
+                    "run_id": run_id,
+                    "arm": Arm.B0.value,
+                    "cashflow_view": CashflowView.WITH_CONTRIBUTION.value,
+                    "data_view": data_view.value,
+                    "deterministic_2runs": True,
+                    "bundle_sha256": bundle_sha,
+                    "fills": len(first_result.fills),
+                    "status": first_result.status,
+                }
+            )
+            engine_statuses[run_id] = first_result.status
+            engine_access[view_name] = {
+                key: value
+                for key, value in first_result.evidence.items()
+                if key.startswith(("sealed_", "measured_", "calibration_"))
+            }
+
+            recon = reconstruct_cycles(_fill_tape(first_result))
+            gap03 = classify_gap03(recon)
+            metrics = compute_cycle_metrics(recon, gap03, axis)
+            simulated_census[view_name] = metrics.pop("_census")
+            metrics["capital_share"] = capital_share_observation(
+                [Decimal(str(row["locked_share"])) for row in first_trace.daily],
+                definition_id="gap04_locked_share_daily_grain_time_weighted_mean",
+                note=(
+                    "GAP-04 locked share straight off the engine's own daily "
+                    "clock; cost basis includes the uniform 21.5bp buy fee, "
+                    "which cancels in the ratio"
+                ),
+            )
+            self._cross_check_locked_share(
+                metrics["capital_share"], first_result, run_id
+            )
+            simulated_metrics[view_name] = metrics
+            self._append_progress(
+                f"\nRUN_COMPLETE {run_id} · 2RUN_BYTE_IDENTICAL=PASS · "
+                f"fills={len(first_result.fills)} · bundle_sha256={bundle_sha}\n"
+            )
+            del bars, tape, first_bundle, second_bundle
+            gc.collect()
+
+        actual = build_actual_side(
+            axis=axis,
+            clock_sessions=market_sessions,
+            closes=operator_closes,
+        )
+        _write_bytes(
+            self.paths.output_root / "actual-side-metrics.json",
+            canonical_bytes({"stamps": self._stamps, "payload": actual}),
+        )
+
+        result = build_result(
+            actual_metrics=actual["metrics"],
+            simulated_metrics=simulated_metrics,
+            engine_statuses=engine_statuses,
+            stamps=self._stamps,
+            census={
+                "actual": actual["census"],
+                "simulated": simulated_census,
+            },
+        )
+        _write_bytes(
+            self.paths.output_root / "calibration-result.json", canonical_bytes(result)
+        )
+
+        sealed_payload = {
+            "schema_version": CALIBRATION_SCHEMA_VERSION,
+            "stamps": self._stamps,
+            "amendment": "d3-amendment-a2-20260808.md",
+            "amendment_sha256": AMENDMENT_A2_SHA256,
+            "authorized_scope": {
+                "dates": (
+                    "<=2024 warm-up, plus the 242 2025 sessions carried by "
+                    "kospi_index_daily_2025.csv"
+                ),
+                "paths": (
+                    "exploration corpus, plus the D3_CALIBRATION_2025 manifest "
+                    "entries whose partition year is 2025"
+                ),
+                "cell": "B0 x with_contribution x {original, clamp}, one-shot",
+            },
+            "calibration_loader_measurement": run_guard.spy.evidence(),
+            "calibration_engine_measurement_per_view": engine_access,
+            "exploration_loader_measurement": exploration_access,
+            "corpus_evidence": calibration.evidence(),
+            "fail_closed_probes": fail_closed,
+            "primary_path_isolation": isolation,
+        }
+        _write_bytes(
+            self.paths.output_root / "sealed-access.json",
+            canonical_bytes(sealed_payload),
+        )
+
+        manifest = {
+            "schema_version": CALIBRATION_SCHEMA_VERSION,
+            "artifact": self.paths.output_root.name,
+            "job_id": "D3-C2G",
+            "label": "CALIBRATION_DIAGNOSTIC_ONLY",
+            "purpose": "D3.1_MODEL_INPUT_ONLY",
+            "stamps": self._stamps,
+            "matrix": {
+                "physical_runs": len(completed),
+                "expected_physical_runs": 2,
+                "deterministic_2runs": sum(
+                    bool(row["deterministic_2runs"]) for row in completed
+                ),
+                "runs": completed,
+            },
+            "top_level_status": result["top_level_status"],
+            "terminal_state_basis": result["terminal_state_basis"],
+            "dual_view": result["dual_view"],
+            "sealed_access_path": "sealed-access.json",
+            "calibration_result_path": "calibration-result.json",
+            "actual_side_path": "actual-side-metrics.json",
+            "supersedes": {
+                "artifact_root": str(self.paths.superseded_root.resolve()),
+                "calibration_result_sha256": SUPERSEDED_C2P_RESULT_SHA256,
+                "status": "CALIBRATION_INCOMPLETE_PENDING_ENGINE_CARVE_OUT",
+                "preserved_untouched": True,
+            },
+            "winner_selected": False,
+            "pareto_computed": False,
+            "sensitivity_runs": 0,
+            "inconclusive_data_bias_released": False,
+            "limitations": [
+                "no 2025 corporate-action sidecar is a frozen input, so the "
+                "replay runs with corporate_actions=(); the exploration delist "
+                "sidecar covers 2015-2024 only and cannot reach 2025",
+                "an operator cycle whose first fill predates 2025 has no "
+                "session_seq on the sealed 2025 axis and is excluded from "
+                "open_lot_age_sessions rather than clipped",
+            ],
+        }
+        _write_bytes(
+            self.paths.output_root / "manifest.json", canonical_bytes(manifest)
+        )
+        self._write_checksums()
+        self._append_progress(
+            f"\nPHYSICAL_RUNS = {len(completed)}/2 · "
+            f"DETERMINISTIC_2RUNS = {len(completed)}/2 · "
+            f"TERMINAL_STATE = {result['top_level_status']} · "
+            "WINNER_TOUCHED = NO\n"
+        )
+        return manifest
+
+    # -- helpers ------------------------------------------------------------
+
+    def _execute_attempt(
+        self,
+        ticks: Any,
+        guard: CalibrationAccessGuard,
+        tape: dict[tuple[date, str], Any],
+        run_input: PortfolioRunInput,
+        *,
+        run_id: str,
+    ) -> tuple[dict[str, bytes], EngineResult, Any]:
+        # Each attempt gets its own spy: EngineResult.evidence embeds the guard
+        # counters, so a shared accumulating spy would break byte-identity.
+        engine = CalibrationPortfolioEngine(
+            ticks, access_guard=guard.fresh_clone(), signals=tape
+        )
+        gc_was_enabled = gc.isenabled()
+        if gc_was_enabled:
+            gc.disable()
+        try:
+            result, trace = engine.execute(run_input)
+        finally:
+            if gc_was_enabled:
+                gc.enable()
+        payloads: dict[str, Any] = {
+            "fills.json": [
+                {
+                    "order_id": fill.order_id,
+                    "session": fill.session,
+                    "symbol": fill.symbol,
+                    "side": fill.side,
+                    "class": fill.order_class,
+                    "quantity": fill.quantity,
+                    "price": fill.price,
+                    "gross": fill.gross,
+                    "fee": fill.fee,
+                }
+                for fill in result.fills
+            ],
+            "events.json": list(result.events),
+            "terminal-positions.json": list(result.terminal_positions),
+            "capital-share-daily.json": list(trace.daily),
+            "metrics.json": result.metrics,
+            "evidence.json": result.evidence,
+        }
+        bundle = {
+            name: canonical_bytes(
+                {
+                    "schema_version": CALIBRATION_SCHEMA_VERSION,
+                    "artifact_kind": name.removesuffix(".json"),
+                    "run_id": run_id,
+                    "stamps": self._stamps,
+                    "rows" if isinstance(payload, list) else "payload": payload,
+                }
+            )
+            for name, payload in payloads.items()
+        }
+        content_checksums = {
+            name: hashlib.sha256(raw).hexdigest()
+            for name, raw in sorted(bundle.items())
+        }
+        bundle["run.json"] = canonical_bytes(
+            {
+                "schema_version": CALIBRATION_SCHEMA_VERSION,
+                "artifact_kind": "physical_run",
+                "run_id": run_id,
+                "stamps": self._stamps,
+                "parameters": {
+                    "arm": run_input.arm,
+                    "cashflow_view": run_input.cashflow_view,
+                    "data_view": run_input.data_view,
+                    "decision_start": run_input.decision_start,
+                    "fee_rate": "0.00215",
+                    "monthly_contribution": "3500000",
+                    "settlement": "T+2",
+                    "same_bar": "buy-first same symbol",
+                    "corporate_actions": 0,
+                },
+                "result_status": result.status,
+                "content_checksums": content_checksums,
+                "engine_invocations": trace.engine_invocations,
+                "physical_run_completed": True,
+                "winner_selected": False,
+            }
+        )
+        return bundle, result, trace
+
+    def _cross_check_locked_share(
+        self, observation: dict[str, Any], result: EngineResult, run_id: str
+    ) -> None:
+        """The daily series must reproduce the engine's own locked-share metrics."""
+
+        engine_mean = Decimal(str(result.metrics["locked_share_tw_mean"]))
+        traced_mean = Decimal(str(observation["aggregate_decimal"]))
+        engine_max = Decimal(str(result.metrics["locked_share_max"]))
+        traced_max = Decimal(str(observation["max_decimal"]))
+        if engine_mean != traced_mean or engine_max != traced_max:
+            raise CalibrationRunInvalid(
+                f"locked-share trace disagrees with engine metrics:{run_id}"
+            )
+
+    def _operator_symbols(self) -> frozenset[str]:
+        from research.kr_corpus.d3_engine.calibration_actual_side import (
+            load_actual_fills,
+        )
+
+        return frozenset(fill.symbol for fill in load_actual_fills())
+
+    def _build_stamps(self, *, calibration: CalibrationCorpus) -> dict[str, Any]:
+        return {
+            "input_sha256": {str(row["file"]): row["sha256"] for row in self._sha_gate},
+            "input_sha_gate_count": len(self._sha_gate),
+            "engine_base_commit": ENGINE_BASE_COMMIT,
+            "harness_commit": self.harness_commit,
+            "label": "CALIBRATION_DIAGNOSTIC_ONLY",
+            "purpose": "D3.1_MODEL_INPUT_ONLY",
+            "amendment": {
+                "id": "A2",
+                "file": "d3-amendment-a2-20260808.md",
+                "sha256": AMENDMENT_A2_SHA256,
+            },
+            "corpus": {
+                **CORPUS_BINDINGS,
+                "calibration_manifest_sha256": calibration.manifest.manifest_sha256,
+                "calibration_checksums_sha256": calibration.manifest.checksums_sha256,
+            },
+            "execution_conventions": {
+                "fee": "43bp neutral: 21.5bp/side",
+                "cashflow": "3500000 KRW monthly",
+                "settlement": "T+2",
+                "same_bar": "buy-first same symbol",
+                "decision_start": DECISION_START.isoformat(),
+                "warmup": "2015-2024 exploration corpus, contiguous into 2025",
+                "sensitivity": False,
+            },
+        }
+
+    def _write_checksums(self) -> None:
+        lines: list[str] = []
+        for path in sorted(self.paths.output_root.rglob("*")):
+            if not path.is_file() or path.name == "checksums.sha256":
+                continue
+            digest = sha256_file(path)
+            lines.append(f"{digest}  {path.relative_to(self.paths.output_root)}")
+        _write_bytes(
+            self.paths.output_root / "checksums.sha256",
+            ("\n".join(lines) + "\n").encode("utf-8"),
+        )
+
+
+def _collect_closes(
+    bars: tuple[CorpusBar, ...], symbols: frozenset[str]
+) -> dict[str, dict[date, Decimal]]:
+    closes: dict[str, dict[date, Decimal]] = {symbol: {} for symbol in symbols}
+    for bar in bars:
+        series = closes.get(bar.symbol)
+        if series is not None:
+            series[bar.session] = Decimal(bar.close_int)
+    return {symbol: series for symbol, series in closes.items() if series}
+
+
+__all__ = [
+    "CalibrationHarnessPaths",
+    "CalibrationRunHarness",
+    "CalibrationRunInvalid",
+]

--- a/research/kr_corpus/d3_engine/calibration_run.py
+++ b/research/kr_corpus/d3_engine/calibration_run.py
@@ -490,6 +490,12 @@ class CalibrationRunHarness:
                 "an operator cycle whose first fill predates 2025 has no "
                 "session_seq on the sealed 2025 axis and is excluded from "
                 "open_lot_age_sessions rather than clipped",
+                "measured divergence: the frozen primary artifacts were "
+                "produced with the engine running at the interpreter default "
+                "prec=28 because PrimaryPortfolioEngine.execute bypasses "
+                "PortfolioEngine.run's localcontext; this calibration replay "
+                "uses the contract literal prec=50. primary.py is unedited "
+                "under A2, so the difference is disclosed, not fixed",
             ],
         }
         _write_bytes(
@@ -638,6 +644,18 @@ class CalibrationRunHarness:
                 "decision_start": DECISION_START.isoformat(),
                 "warmup": "2015-2024 exploration corpus, contiguous into 2025",
                 "sensitivity": False,
+                "decimal_context": (
+                    "contract literal: prec=50, ROUND_HALF_UP, established "
+                    "around _run as PortfolioEngine.run does"
+                ),
+                "decimal_context_divergence_from_primary": (
+                    "measured: PrimaryPortfolioEngine.execute calls _run "
+                    "directly instead of through PortfolioEngine.run, so the "
+                    "frozen primary artifacts' engine arithmetic ran at the "
+                    "interpreter default prec=28. primary.py is unedited under "
+                    "A2; this runner follows the frozen contract literal "
+                    "instead. Flagged for upstream — it is not resolved here."
+                ),
             },
         }
 

--- a/scripts/run_d3_calibration.py
+++ b/scripts/run_d3_calibration.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Execute the D3-C2G B0 calibration 2-physical replay (Amendment A2 scope)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+
+from research.kr_corpus.d3_engine.calibration_run import (
+    CalibrationHarnessPaths,
+    CalibrationRunHarness,
+)
+from research.kr_corpus.d3_engine.canonical import canonical_bytes
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ("git", *args),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path)
+    parser.add_argument("--progress-report", type=Path)
+    parser.add_argument(
+        "--harness-commit",
+        help="full committed SHA of this harness (default: current HEAD)",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="stamp the current HEAD while the tree is still dirty (rehearsal only)",
+    )
+    args = parser.parse_args()
+
+    head = _git("rev-parse", "HEAD")
+    harness_commit = args.harness_commit or head
+    if harness_commit != head:
+        parser.error(f"--harness-commit {harness_commit} does not match HEAD {head}")
+    if _git("status", "--porcelain") and not args.allow_dirty:
+        parser.error(
+            "repository must be clean so the stamped commit identifies the code"
+        )
+
+    paths = CalibrationHarnessPaths.defaults()
+    paths = replace(
+        paths,
+        output_root=args.output_root or paths.output_root,
+        progress_report=args.progress_report or paths.progress_report,
+    )
+    result = CalibrationRunHarness(
+        harness_commit=harness_commit,
+        paths=paths,
+    ).run_all()
+    print(canonical_bytes(result).decode("utf-8"), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py
@@ -1,0 +1,430 @@
+"""Amendment A2 acceptance: fail-closed routes, mutants, and regression pins.
+
+Hermetic — every probe runs against a synthetic holdout root under ``tmp_path``
+patched over ``HOLDOUT_DIR``. No sealed byte is opened here; the real run's
+measured access log lives in the artifact, not in this suite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from research.kr_corpus.backtest import holdout_guard
+from research.kr_corpus.d3_engine import calibration_acceptance, calibration_guard
+from research.kr_corpus.d3_engine.calibration_acceptance import (
+    measure_calibration_fail_closed_probes,
+    measure_primary_path_isolation,
+)
+from research.kr_corpus.d3_engine.calibration_corpus import (
+    CalibrationCorpusInvalid,
+    load_calibration_manifest,
+)
+from research.kr_corpus.d3_engine.calibration_guard import (
+    AMENDMENT_A2_SHA256,
+    CALIBRATION_INDEX_SHA256,
+    HOLDOUT_RUN_ID,
+    CalibrationAccessGuard,
+    CalibrationAccessSpy,
+    CalibrationScopeError,
+    partition_year,
+)
+from research.kr_corpus.d3_engine.guards import (
+    SealedAccessBlocked,
+    SealedAccessGuard,
+    SealedAccessSpy,
+)
+from research.kr_corpus.d3_engine.tick import TickTable
+
+SESSIONS = (date(2025, 1, 2), date(2025, 1, 3), date(2025, 6, 2), date(2025, 12, 30))
+
+
+def _ticks() -> TickTable:
+    return TickTable.from_mapping(
+        {
+            "schema_version": "d3.krx_tick_table.v1",
+            "bands": [
+                {"lower_inclusive": 0, "upper_exclusive": 2000, "tick": 1},
+                {"lower_inclusive": 2000, "upper_exclusive": 5000, "tick": 5},
+                {"lower_inclusive": 5000, "upper_exclusive": 20000, "tick": 10},
+                {"lower_inclusive": 20000, "upper_exclusive": 50000, "tick": 50},
+                {"lower_inclusive": 50000, "upper_exclusive": 200000, "tick": 100},
+                {"lower_inclusive": 200000, "upper_exclusive": 500000, "tick": 500},
+                {"lower_inclusive": 500000, "upper_exclusive": None, "tick": 1000},
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def sealed_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A synthetic sealed corpus: 2025 and 2026 partitions in one manifest."""
+
+    root = tmp_path / "kr-corpus-v1" / "holdout"
+    run_root = root / "runs" / HOLDOUT_RUN_ID
+    files = {
+        "dataset/market=KOSPI/year=2025/ticker=005930.parquet": b"authorized-2025",
+        "dataset/market=KOSDAQ/year=2025/ticker=0004Y0.parquet": b"authorized-2025-b",
+        "dataset/market=KOSPI/year=2026/ticker=005930.parquet": b"prospective",
+        "gaps/market=KOSPI/year=2025/missing.parquet": b"gap-2025",
+        "gaps/market=KOSPI/year=2026/missing.parquet": b"gap-2026",
+        "source-anomalies.jsonl": b'{"session":"2025-01-02"}\n{"session":"2026-01-05"}\n',
+        "coverage.json": b"{}",
+    }
+    rows = []
+    for relative, payload in files.items():
+        target = run_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+        rows.append(f"{hashlib.sha256(payload).hexdigest()}  {relative}")
+    checksums = ("\n".join(rows) + "\n").encode("utf-8")
+    (run_root / "checksums.sha256").write_bytes(checksums)
+    (run_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "scope": "holdout",
+                "corpus_id": "kr-corpus-v1",
+                "files_list_location": "checksums.sha256",
+                "checksums_sha256": hashlib.sha256(checksums).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    # A file that physically exists inside the 2025 partition but that the
+    # manifest never enumerates.
+    stray = (
+        run_root / "dataset" / "market=KOSPI" / "year=2025" / "ticker=999999.parquet"
+    )
+    stray.write_bytes(b"not-enumerated")
+    monkeypatch.setattr(holdout_guard, "HOLDOUT_DIR", root)
+    monkeypatch.setattr(calibration_guard, "HOLDOUT_DIR", root)
+    monkeypatch.setattr(
+        calibration_acceptance, "PROBE_PROSPECTIVE_DATE", date(2026, 1, 5)
+    )
+    return root
+
+
+def _bound_guard(sealed_root: Path) -> CalibrationAccessGuard:
+    guard = CalibrationAccessGuard(
+        calibration_sessions=SESSIONS,
+        spy=CalibrationAccessSpy(),
+        holdout_root=sealed_root,
+    )
+    load_calibration_manifest(guard, holdout_root=sealed_root)
+    return guard
+
+
+# -- allow-list construction ------------------------------------------------
+
+
+def test_manifest_allowlist_admits_only_the_2025_partition(sealed_root: Path) -> None:
+    guard = _bound_guard(sealed_root)
+    names = sorted(path.name for path in guard.allowed_paths)
+    assert names == [
+        "checksums.sha256",
+        "coverage.json",
+        "manifest.json",
+        "missing.parquet",
+        "source-anomalies.jsonl",
+        "ticker=0004Y0.parquet",
+        "ticker=005930.parquet",
+    ]
+    assert all(partition_year(path) in (None, 2025) for path in guard.allowed_paths)
+    assert guard.spy.manifest_excluded_out_of_scope == 2
+
+
+def test_allowlist_binds_exactly_once(sealed_root: Path) -> None:
+    guard = _bound_guard(sealed_root)
+    with pytest.raises(CalibrationScopeError):
+        guard.bind_manifest_allowlist([], excluded_out_of_scope=0)
+
+
+def test_guard_refuses_a_non_2025_calendar() -> None:
+    with pytest.raises(CalibrationScopeError):
+        CalibrationAccessGuard(calibration_sessions=[date(2026, 1, 5)])
+    with pytest.raises(CalibrationScopeError):
+        CalibrationAccessGuard(calibration_sessions=[])
+
+
+def test_checksums_drift_is_fatal(sealed_root: Path) -> None:
+    run_root = sealed_root / "runs" / HOLDOUT_RUN_ID
+    (run_root / "checksums.sha256").write_bytes(b"0" * 64 + b"  coverage.json\n")
+    guard = CalibrationAccessGuard(
+        calibration_sessions=SESSIONS, holdout_root=sealed_root
+    )
+    with pytest.raises(CalibrationCorpusInvalid):
+        load_calibration_manifest(guard, holdout_root=sealed_root)
+
+
+# -- the three A2 fail-closed routes ----------------------------------------
+
+
+def test_fail_closed_three_routes_are_measured(sealed_root: Path) -> None:
+    guard = _bound_guard(sealed_root)
+    run_root = sealed_root / "runs" / HOLDOUT_RUN_ID
+    report = measure_calibration_fail_closed_probes(
+        template=guard,
+        prospective_path=(
+            run_root
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2026"
+            / "ticker=005930.parquet"
+        ),
+        outside_manifest_path=(
+            run_root
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2025"
+            / "ticker=999999.parquet"
+        ),
+        authorized_path=(
+            run_root
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2025"
+            / "ticker=005930.parquet"
+        ),
+    )
+    assert report["status"] == "PASS"
+    assert report["outcomes"]["prospective_2026_date"] == "PASS"
+    assert report["outcomes"]["prospective_partition_path"] == "PASS"
+    assert report["outcomes"]["outside_manifest_file"] == "PASS"
+    # measured, not declared: nothing was read and every route was counted
+    assert report["loader_calls"] == 0
+    assert report["authorized_sealed_reads_during_probes"] == 0
+    assert report["blocked_attempts"] == 6
+    evidence = report["spy_evidence"]
+    assert evidence["calibration_blocked_prospective_date_attempts"] == 2
+    assert evidence["calibration_blocked_offcalendar_2025_date_attempts"] == 1
+    assert evidence["calibration_blocked_prospective_path_attempts"] == 1
+    assert evidence["calibration_blocked_outside_manifest_attempts"] == 1
+    assert evidence["calibration_blocked_sealed_token_attempts"] == 1
+
+
+def test_authorized_route_stays_open(sealed_root: Path) -> None:
+    guard = _bound_guard(sealed_root)
+    authorized = (
+        sealed_root
+        / "runs"
+        / HOLDOUT_RUN_ID
+        / "dataset"
+        / "market=KOSPI"
+        / "year=2025"
+        / "ticker=005930.parquet"
+    )
+    assert guard.read_parquet(path=authorized, loader=lambda: "ok") == "ok"
+    guard.assert_exploration_date(date(2024, 12, 30))
+    guard.assert_exploration_date(date(2025, 6, 2))
+    guard.record_bar_rows([date(2025, 1, 2), date(2019, 5, 5)])
+    evidence = guard.spy.evidence()
+    assert evidence["calibration_authorized_parquet_reads"] == 1
+    assert evidence["calibration_warmup_date_checks"] == 2
+    assert evidence["sealed_access_blocked_attempts"] == 0
+
+
+def test_datetime_input_is_gated_on_its_date(sealed_root: Path) -> None:
+    guard = _bound_guard(sealed_root)
+    guard.assert_exploration_date(datetime(2025, 6, 2, 15, 30))
+    with pytest.raises(SealedAccessBlocked):
+        guard.assert_exploration_date(datetime(2026, 1, 5, 9, 0))
+
+
+# -- mutant 1: injecting the carve-out into the primary runner --------------
+
+
+def test_primary_path_isolation_passes_unmutated() -> None:
+    report = measure_primary_path_isolation(tick_table=_ticks())
+    assert report["status"] == "PASS"
+    assert report["installed_guard_class"] == "SealedAccessGuard"
+    assert report["guard_is_sealed_access_guard_exactly"] is True
+    assert report["blocks_2025_date"] is True
+    assert report["blocks_2026_date"] is True
+    assert report["blocks_holdout_2025_partition_path"] is True
+
+
+def test_mutant_primary_injection_fails_acceptance(sealed_root: Path) -> None:
+    """A2 mutant: wiring the calibration guard into primary must be caught."""
+
+    mutant = measure_primary_path_isolation(
+        tick_table=_ticks(), guard_override=_bound_guard(sealed_root)
+    )
+    assert mutant["status"] == "FAIL"
+    assert mutant["installed_guard_class"] == "CalibrationAccessGuard"
+    assert mutant["guard_is_sealed_access_guard_exactly"] is False
+    assert mutant["blocks_2025_date"] is False
+
+
+# -- mutant 2: a guard that stops checking manifest membership --------------
+
+
+class _AllowsOutsideManifest(CalibrationAccessGuard):
+    """Mutant: keep the year gate, drop the manifest membership gate."""
+
+    def _authorize_path(self, value: str | Path) -> tuple[Path, str]:
+        path = Path(value).expanduser().resolve(strict=False)
+        if path.is_relative_to(self._holdout_root):
+            return path, "calibration"
+        return super()._authorize_path(path)
+
+
+def test_mutant_guard_allowing_outside_manifest_is_killed(sealed_root: Path) -> None:
+    guard = _AllowsOutsideManifest(
+        calibration_sessions=SESSIONS,
+        spy=CalibrationAccessSpy(),
+        holdout_root=sealed_root,
+    )
+    load_calibration_manifest(guard, holdout_root=sealed_root)
+    run_root = sealed_root / "runs" / HOLDOUT_RUN_ID
+    report = measure_calibration_fail_closed_probes(
+        template=guard,
+        prospective_path=(
+            run_root
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2026"
+            / "ticker=005930.parquet"
+        ),
+        outside_manifest_path=(
+            run_root
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2025"
+            / "ticker=999999.parquet"
+        ),
+        authorized_path=(
+            run_root
+            / "dataset"
+            / "market=KOSPI"
+            / "year=2025"
+            / "ticker=005930.parquet"
+        ),
+    )
+    assert report["status"] == "FAIL"
+    assert report["outcomes"]["outside_manifest_file"] == "FAIL"
+    assert report["outcomes"]["prospective_partition_path"] == "FAIL"
+    assert report["loader_calls"] > 0
+
+
+# -- regression pins: the base guards are untouched -------------------------
+
+
+def test_base_sealed_access_guard_still_blocks_everything_2025() -> None:
+    guard = SealedAccessGuard(SealedAccessSpy())
+    with pytest.raises(SealedAccessBlocked):
+        guard.assert_exploration_date(date(2025, 1, 2))
+    with pytest.raises(SealedAccessBlocked):
+        guard.assert_exploration_date(date(2026, 1, 5))
+    with pytest.raises(SealedAccessBlocked):
+        guard.assert_exploration_path("/tmp/holdout/dataset/x.parquet")
+    with pytest.raises(SealedAccessBlocked):
+        guard.assert_metadata_key("D3_CALIBRATION_2025")
+    assert guard.spy.evidence()["sealed_access_spy"] == 0
+
+
+def test_holdout_guard_still_blocks_both_in_window_years() -> None:
+    for probe in (date(2025, 6, 1), date(2026, 1, 5)):
+        with pytest.raises(holdout_guard.HoldoutAccessError):
+            holdout_guard.assert_date_not_holdout(probe)
+
+
+def test_amendment_and_calendar_digests_are_pinned() -> None:
+    assert AMENDMENT_A2_SHA256 == (
+        "37b3045cd20678815c49066862ddd89dfebd5e852c57d84dcd1ce062b69dc020"
+    )
+    assert CALIBRATION_INDEX_SHA256 == (
+        "17e95d0b30ade5e6fbd744cf719bc15224ef5177431cc51cfff8f2abb6930508"
+    )
+
+
+# -- shared metric extractor -------------------------------------------------
+
+
+def test_gap03_censoring_and_shared_extractor() -> None:
+    from research.kr_corpus.d3_engine.calibration_metrics import (
+        CycleFill,
+        SessionAxis,
+        classify_gap03,
+        compute_cycle_metrics,
+        reconstruct_cycles,
+    )
+
+    axis = SessionAxis(
+        (date(2025, 1, 2), date(2025, 1, 3), date(2025, 1, 6), date(2025, 12, 30))
+    )
+    fills = [
+        # carry-in cycle: opened 2024, trimmed inside the window -> excluded
+        CycleFill("AAA", "BUY", Decimal(10), Decimal(1000), date(2024, 12, 2), 0),
+        CycleFill("AAA", "SELL", Decimal(5), Decimal(1200), date(2025, 1, 3), 1),
+        # clean in-window cycle: buy, add, full exit -> eligible
+        CycleFill("BBB", "BUY", Decimal(10), Decimal(1000), date(2025, 1, 2), 2),
+        CycleFill("BBB", "BUY", Decimal(20), Decimal(500), date(2025, 1, 3), 3),
+        CycleFill("BBB", "SELL", Decimal(30), Decimal(1100), date(2025, 1, 6), 4),
+        # in-window cycle still open at cutoff -> right-censored
+        CycleFill("CCC", "BUY", Decimal(1), Decimal(9000), date(2025, 1, 6), 5),
+    ]
+    recon = reconstruct_cycles(fills)
+    gap03 = classify_gap03(recon)
+    assert len(gap03.eligible_closed) == 1
+    assert len(gap03.carry_in_all) == 1
+    assert len(gap03.right_censored) == 2
+
+    metrics = compute_cycle_metrics(recon, gap03, axis)
+    assert metrics["adds_per_cycle"]["median_decimal"] == "1"
+    assert metrics["add_sizing_multiple"]["median_decimal"] == "1"
+    assert metrics["holding_period_sessions"]["median_decimal"] == "2"
+    assert metrics["add_interval_sessions"]["median_decimal"] == "1"
+    assert metrics["trim_share"]["median_decimal"] == "1"
+    # the carry-in cycle's first fill has no 2025 session_seq: excluded, not clipped
+    assert metrics["open_lot_age_sessions"]["n"] == 1
+    assert metrics["open_lot_age_sessions"]["excluded_observation_count"] == 1
+    assert metrics["_census"]["carry_in_excluded_count"] == 1
+    assert metrics["_census"]["right_censored_count"] == 2
+
+
+def test_empty_sample_stays_not_computable() -> None:
+    from research.kr_corpus.d3_engine.calibration_result import compare_view
+
+    decision, detail = compare_view(
+        "adds_per_cycle",
+        {"n": 0, "aggregate_decimal": None},
+        {"n": 4, "aggregate_decimal": "2"},
+    )
+    assert decision == "NOT_COMPUTABLE"
+    assert detail["reason"] == "empty_or_invalid_sample_on_at_least_one_side"
+
+
+def test_zero_rule_is_positive_scale_only() -> None:
+    from research.kr_corpus.d3_engine.calibration_result import compare_view
+
+    decision, detail = compare_view(
+        "adds_per_cycle",
+        {"n": 5, "aggregate_decimal": "0"},
+        {"n": 5, "aggregate_decimal": "0.5"},
+    )
+    assert decision == "FAIL"
+    assert detail["zero_rule_applied"] is True
+
+    # GAP-10: bounded-share rows carry no extra zero condition
+    decision, detail = compare_view(
+        "trim_share",
+        {"n": 5, "aggregate_decimal": "0"},
+        {"n": 5, "aggregate_decimal": "0.1"},
+    )
+    assert decision == "PASS"
+    assert detail["zero_rule_applied"] is False
+
+
+def test_dual_view_disagreement_is_data_bias() -> None:
+    from research.kr_corpus.d3_engine.calibration_result import view_outcome
+
+    assert view_outcome("PASS", "PASS") == "PASS"
+    assert view_outcome("FAIL", "FAIL") == "CALIBRATION_MISMATCH"
+    assert view_outcome("PASS", "FAIL") == "CALIBRATION_DATA_BIAS"
+    assert view_outcome("FAIL", "PASS") == "CALIBRATION_DATA_BIAS"
+    assert view_outcome("PASS", "NOT_COMPUTABLE") == "NOT_COMPUTABLE"


### PR DESCRIPTION
## What

Amendment A2 (`d3-amendment-a2-20260808.md`, sha256 `37b3045c…`) authorizes one
narrow key into the sealed corpus so the pre-approved B0 calibration cell can
actually execute. The previous attempt ended at `PHYSICAL_RUNS = 0/2` because
`guards.py` blocks every `year >= 2025` date unconditionally and `primary.py`
hard-codes that guard — the lock worked as designed, the contract had no key.

This adds the key as a **new** surface plus a separate runner, exactly the shape
§22 approved, and runs the cell.

## Boundary

- **`primary.py` is not edited** — `git diff 603cddc9..HEAD -- primary.py` is 0
  lines. The primary runner still installs `SealedAccessGuard` and still cannot
  process a 2025 bar.
- The isolation is **measured, not asserted**: `measure_primary_path_isolation`
  instantiates the real `PrimaryPortfolioEngine` and probes the guard its own
  `__init__` installs. Injecting the calibration guard flips the predicate to
  FAIL — that is A2 mutant ①, and it is in the suite.
- The 2015–2024 warm-up corpus loads through an ordinary `SealedAccessGuard`, so
  the exploration path proves itself: both views measured `sealed_reads = 0`,
  `blocked_attempts = 0`, or the run aborts.

## A2 literal → code, 1:1

| Axis | Allowed | Blocked |
|---|---|---|
| date | `<= 2024` warm-up; the 242 2025 sessions in the sealed calendar csv (`17e95d0b…`) | `>= 2026`; any 2025 date absent from that csv |
| path | exploration corpus; only files the `D3_CALIBRATION_2025` manifest enumerates inside its 2025 partition | prospective partitions; holdout files outside the manifest; every other sealed segment |
| spy | every check and completed read counted and serialized | — |

The allow-list bootstraps from the sealed manifest itself — `manifest.json`
pins `checksums.sha256` by digest, that list enumerates every file, and the
2025-scoped subset is bound exactly once.

## Results

```
PHYSICAL_RUNS      = 2/2   DETERMINISTIC_2RUNS = 2/2 (bundle byte-identical)
SHA_GATE           = 14/14 (A2 included)
GOLDEN             = 33/33 · MUTANTS 23/23 — no regression
FAILCLOSED_NEW     = 2026 date / prospective path / outside-manifest file — all blocked, 0 loader calls
MUTANT_NEW         = primary-injection caught: Y · manifest-check-dropped killed: Y
TERMINAL_STATE     = CALIBRATION_INCOMPLETE (GAP-06)
```

Sealed access, measured: 6,412 enumerated → 3,352 authorized in 2025 scope,
3,060 out-of-scope refused; 2,864 parquet parses (2,862 dataset + 2 gaps);
648,954 authorized bar rows; **0 blocked attempts** on the authorized path. The
11,483 prospective lines in `source-anomalies.jsonl` are screened by a
byte-level year match before `json.loads`, so their OHLC values never become
Python objects.

### The finding

Six of nine metrics are `NOT_COMPUTABLE` for one shared reason: **the B0 arm
never closes a cycle.** 543 fills — 316 buys, 227 resistance trims — and
`closed_cycle_count = 0`, 125 positions still open at cutoff. Recounting the
frozen 10-year primary B0 artifact the same way gives the same shape: 1,270
cycles opened, 12,540 sell fills, **0 ever reaching flat**. So it is structural,
not an artifact of the one-year window. The operator closed 68 cycles over the
same 2025 window, which is why `annualized_cycle_count` lands at
`CALIBRATION_MISMATCH` (68.045 vs 0). `capital_share` and
`open_lot_age_sessions` pass on both views.

Both data views agree on every metric, so `CALIBRATION_DATA_BIAS` does not
arise. No winner selected, no economic re-ranking, `INCONCLUSIVE_DATA_BIAS`
untouched.

### Raised, not resolved

`PortfolioEngine.run` establishes the contract's `prec=50 ROUND_HALF_UP`
context, but `PrimaryPortfolioEngine.execute` calls `_run` directly — so the
frozen primary artifacts' engine arithmetic ran at the interpreter default
`prec=28`. `primary.py` is unedited under A2, so this runner follows the
contract literal instead and **publishes the divergence** in the artifact
stamps rather than absorbing it silently. Whether the primary bypass needs its
own upstream ruling is not decided here. The harness's own locked-share
cross-check is what surfaced it, by failing the first execution.

## Verification

Artifacts land in `herdr-artifacts/d3-calibration-2g-v1`; the previous C2P root
is preserved untouched and its digest re-checked at preflight. A separate
24-point recomputation from the artifacts alone — allow-list size, parquet
counts, checksums, preserved actual-side values, absence of any 2026 market
session — passes in full. The five previously computable actual-side values are
bit-identical to the independently verified fix-r1 output across all 50 digits;
the four that were `NOT_COMPUTABLE`, including `capital_share`, are now
unblocked.

Label `CALIBRATION_DIAGNOSTIC_ONLY`, purpose `D3.1_MODEL_INPUT_ONLY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)