### PR TITLE
feat(research): ROB-1230 P-2 — KR adapter for policy_table.v1

### DIFF
--- a/scripts/build_policy_table.py
+++ b/scripts/build_policy_table.py
@@ -1,20 +1,23 @@
-"""ROB-1230 P-1 — build a policy_table.v1 artifact (crypto/Upbit adapter).
+"""ROB-1230 P-1/P-2 — build a policy_table.v1 artifact (crypto + KR adapters).
 
-Scheduleless, read-only, advisory. Fetches Upbit market data + this repo's
-holdings/watch-alert tables, runs the shared indicator core (a direct reuse
-of research/kr_corpus/d3_engine's fib/BB/RSI/tick code — see
+Scheduleless, read-only, advisory. Each market adapter fetches its own raw
+inputs (crypto: live Upbit + this repo's holdings/watch-alert tables; kr:
+the invest_screener_snapshots DB table + DB daily candles + a read-only KIS
+holdings query), runs the shared indicator core (a direct reuse of
+research/kr_corpus/d3_engine's fib/BB/RSI/tick code — see
 scripts/policy_table/core/signal_math.py), and writes a policy_table.v1 JSON
 artifact plus a human-readable Markdown summary.
 
 No broker mutation. No order-tool imports (verify: `grep -rn "orders import"
-scripts/policy_table` should be empty — only `client.py`'s read functions
-are used). Never merges, never places or cancels an order.
+scripts/policy_table` should be empty — only read-shaped client/account
+functions are used). Never merges, never places or cancels an order.
 
 Usage
 -----
     uv run python -m scripts.build_policy_table --market crypto
+    uv run python -m scripts.build_policy_table --market kr
 
-    # Reproducibility check (ROB-1230 acceptance #3): dump raw inputs once,
+    # Reproducibility check (ROB-1230 acceptance #2): dump raw inputs once,
     # then replay the same inputs through the pure compute+serialize path
     # twice and diff the bytes.
     uv run python -m scripts.build_policy_table --market crypto \\
@@ -35,6 +38,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.policy_table.adapters import crypto as crypto_adapter
+from scripts.policy_table.adapters import kr as kr_adapter
 from scripts.policy_table.core.schema import (
     canonical_json_bytes,
     compute_policy_table_hash,
@@ -154,10 +158,8 @@ def _render_summary_md(payload: dict[str, Any]) -> str:
 
 
 async def _run(args: argparse.Namespace) -> int:
-    if args.market != "crypto":
-        raise NotImplementedError(
-            "only market=crypto is implemented in P-1 (KR adapter is P-2)"
-        )
+    if args.market not in ("crypto", "kr"):
+        raise NotImplementedError(f"unsupported market: {args.market}")
 
     out_dir = Path(args.out_dir).expanduser()
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -165,19 +167,39 @@ async def _run(args: argparse.Namespace) -> int:
     latest_link = out_dir / f"latest-{args.market}.json"
 
     try:
-        if args.replay_raw:
-            raw_payload = json.loads(Path(args.replay_raw).expanduser().read_text())
-            raw = crypto_adapter.RawInputs.from_jsonable(raw_payload)
-        else:
-            raw = await crypto_adapter.fetch_raw_inputs(top_n=args.top_n)
-
-        if args.dump_raw:
-            Path(args.dump_raw).expanduser().write_text(
-                json.dumps(raw.to_jsonable(), sort_keys=True, indent=2) + "\n"
+        if args.market == "crypto":
+            top_n = (
+                args.top_n if args.top_n is not None else crypto_adapter.DEFAULT_TOP_N
             )
+            if args.replay_raw:
+                raw_payload = json.loads(Path(args.replay_raw).expanduser().read_text())
+                raw = crypto_adapter.RawInputs.from_jsonable(raw_payload)
+            else:
+                raw = await crypto_adapter.fetch_raw_inputs(top_n=top_n)
 
-        payload = crypto_adapter.compute_policy_table(raw, top_n=args.top_n)
-        payload["stamps"] = _build_stamps(payload)
+            if args.dump_raw:
+                Path(args.dump_raw).expanduser().write_text(
+                    json.dumps(raw.to_jsonable(), sort_keys=True, indent=2) + "\n"
+                )
+
+            payload = crypto_adapter.compute_policy_table(raw, top_n=top_n)
+            payload["stamps"] = _build_stamps(payload)
+            summary_md = _render_summary_md(payload)
+        else:
+            if args.replay_raw:
+                raw_payload = json.loads(Path(args.replay_raw).expanduser().read_text())
+                raw = kr_adapter.RawInputs.from_jsonable(raw_payload)
+            else:
+                raw = await kr_adapter.fetch_raw_inputs()
+
+            if args.dump_raw:
+                Path(args.dump_raw).expanduser().write_text(
+                    json.dumps(raw.to_jsonable(), sort_keys=True, indent=2) + "\n"
+                )
+
+            payload = kr_adapter.compute_policy_table(raw)
+            payload["stamps"] = _build_stamps(payload)
+            summary_md = kr_adapter.render_summary_md(payload, top_n=args.top_n or 50)
 
         artifact_bytes = canonical_json_bytes(payload)
         ts = (
@@ -189,7 +211,7 @@ async def _run(args: argparse.Namespace) -> int:
         md_path = out_dir / f"{ts}-{args.market}-summary.md"
 
         json_path.write_bytes(artifact_bytes)
-        md_path.write_text(_render_summary_md(payload))
+        md_path.write_text(summary_md)
 
         if latest_link.is_symlink() or latest_link.exists():
             latest_link.unlink()
@@ -221,8 +243,17 @@ async def _run(args: argparse.Namespace) -> int:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--market", default="crypto", choices=["crypto"])
-    parser.add_argument("--top-n", type=int, default=crypto_adapter.DEFAULT_TOP_N)
+    parser.add_argument("--market", default="crypto", choices=["crypto", "kr"])
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=None,
+        help=(
+            "crypto: universe top-N by 24h trade value (default "
+            f"{crypto_adapter.DEFAULT_TOP_N}); kr: summary.md display row cap "
+            "(default 50) — the KR JSON table itself is never top-N-capped"
+        ),
+    )
     parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
     parser.add_argument(
         "--dump-raw", default=None, help="write fetched raw inputs to this path"

--- a/scripts/policy_table/adapters/kr.py
+++ b/scripts/policy_table/adapters/kr.py
@@ -1,0 +1,767 @@
+"""KR (KRX equities) adapter for ROB-1230 P-2 — policy_table.v1 rows.
+
+Read-only. Universe selection is the ``invest_screener_snapshots`` table
+(``market='kr'``) — the design doc is explicit that a live KRX market-data
+scan (``screen_stocks``) is unavailable at the night-batch build time the
+KRX session is closed, so the DB-cached snapshot partition is the mandatory
+source, not a live screener call. Indicator inputs (fib/BB/RSI need >=120
+daily bars) are read straight from the ``kr_candles_1d`` DB table via
+``DailyCandlesRepository`` — also DB-only, no live KIS candle fetch — so
+this adapter has no live-market dependency for the compute path at all.
+
+The one live call this adapter makes is a **read-only** KIS domestic-account
+query (holdings) via a minimal facade that composes only ``AccountClient``
+(``app.services.brokers.kis.account``), never importing
+``app.services.brokers.kis.client`` (the full ``KISClient`` facade, which
+unconditionally imports ``DomesticOrderClient``/``OverseasOrderClient`` at
+module scope) or any order/orders module. This keeps the P-1 "zero
+order-tool import graph, zero broker mutation" bar intact for KR too.
+
+Split into ``fetch_raw_inputs`` (network + DB I/O) and
+``compute_policy_table`` (pure, deterministic given those inputs), same
+contract as the crypto adapter, so a run's raw inputs can be dumped and
+replayed to prove byte-identical output on identical input (ROB-1230
+acceptance #2/#3).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, cast
+
+from app.core.db import AsyncSessionLocal
+from app.services.brokers.kis.account import AccountClient
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.protocols import KISClientProtocol
+from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+from app.services.invest_screener_snapshots.repository import (
+    InvestScreenerSnapshotsRepository,
+)
+from app.services.invest_screener_snapshots.support_proximity_policy import (
+    DEFAULT_MIN_MARKET_CAP_KRW,
+    DEFAULT_MIN_TURNOVER_KRW,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.market_valuation_snapshots.normalized_market_cap import (
+    load_normalized_kr_market_caps,
+)
+from research.kr_corpus.d3_engine.models import Position
+from research.kr_corpus.d3_engine.policies import update_underwater_close
+from research.kr_corpus.d3_engine.signals import support_distance
+from scripts.policy_table.core.averaging import averaging_math
+from scripts.policy_table.core.kr_tick import build_kr_krx_tick_table
+from scripts.policy_table.core.signal_math import (
+    D3_CONSTANTS_ECHO,
+    FIB_WINDOW,
+    InsufficientHistory,
+    SymbolSignal,
+    compute_symbol_signal,
+)
+from scripts.policy_table.core.trust_labels import TRUST_LABELS
+
+MARKET = "kr"
+SNAPSHOT_MARKET = "kr"  # invest_screener_snapshots.market
+WATCH_MARKET = (
+    "equity_kr"  # InvestmentWatchAlert.market (app/jobs/watch_market_data.py)
+)
+DB_MARKET_KEY = MarketKey.KR
+DB_PARTITION = "KRX"  # app.mcp_server.tooling.market_data_indicators._cache_first_kr
+QUOTE_CURRENCY = "KRW"
+CANDLE_GRANULARITY = "1d"
+CANDLE_LOOKBACK_BARS = (
+    200  # >= FIB_WINDOW(120) with headroom, mirrors P-1 crypto choice
+)
+CANDLE_FETCH_CONCURRENCY = 8
+DEEP_BAND_LOWER_PCT = Decimal(
+    "-0.12"
+)  # design doc §1-A "성문 정책" — shared with crypto
+DEEP_BAND_UPPER_PCT = Decimal("-0.03")
+POSITION_ALERT_PCT = Decimal(
+    "-0.30"
+)  # design doc §1-C "성문 정책" — shared with crypto
+LOSS_GUARD_MULTIPLIER = Decimal(
+    "1.01"
+)  # design doc §1-B "코드 레일 미러" — shared with crypto
+AVERAGING_K_LEVELS: tuple[Decimal, Decimal] = (Decimal("0.05"), Decimal("0.10"))
+# design doc §7-1: "KR 30만(신규)" — new-entry sizing band, distinct from crypto's
+# settings.upbit_buy_amount (no KR equivalent env setting exists).
+KR_NEW_ENTRY_NOTIONAL_KRW = Decimal("300000")
+# Reused, not reinvented: same market-cap/turnover floor already governing the
+# support-proximity build over this same invest_screener_snapshots table
+# (app/services/invest_screener_snapshots/support_proximity_policy.py).
+MIN_MARKET_CAP_KRW = DEFAULT_MIN_MARKET_CAP_KRW
+MIN_TURNOVER_KRW = DEFAULT_MIN_TURNOVER_KRW
+
+
+# ---------------------------------------------------------------------------
+# Minimal read-only KIS domestic-account facade.
+# ---------------------------------------------------------------------------
+
+
+class _ReadOnlyKISDomesticClient(BaseKISClient):
+    """Live KIS domestic-account reads only — no order-tool imports.
+
+    Composes only ``AccountClient`` (balance/holdings reads). Deliberately
+    does not use ``app.services.brokers.kis.client.KISClient`` — that facade
+    unconditionally imports ``DomesticOrderClient``/``OverseasOrderClient``
+    at module scope, which would pull order-placement code into this
+    adapter's import graph even though only a read is ever called.
+    ``AccountClient`` only needs the auth/HTTP protocol ``BaseKISClient``
+    already implements (see ``KISClientProtocol``), so no other composition
+    is required.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        parent = cast(KISClientProtocol, cast(object, self))
+        self._account = AccountClient(parent)
+
+    async def fetch_my_stocks(self) -> list[dict[str, Any]]:
+        return await self._account.fetch_my_stocks(is_mock=False, is_overseas=False)
+
+
+# ---------------------------------------------------------------------------
+# Raw inputs — dumpable/replayable for the determinism acceptance check.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RawInputs:
+    as_of: str  # ISO8601, captured once at fetch time
+    holdings: list[dict[str, str]]
+    watch_alerts: list[dict[str, Any]]
+    universe_pool: list[dict[str, Any]]  # full invest_screener_snapshots(market='kr')
+    snapshot_partition_date: str | None
+    snapshot_breadth: dict[str, Any] | None
+    universe_symbols: list[str]  # filter_passed ∪ holdings ∪ watch (attempted set)
+    candles: dict[str, list[list[str]]]  # symbol -> [[close, high, low], ...] ascending
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "as_of": self.as_of,
+            "holdings": self.holdings,
+            "watch_alerts": self.watch_alerts,
+            "universe_pool": self.universe_pool,
+            "snapshot_partition_date": self.snapshot_partition_date,
+            "snapshot_breadth": self.snapshot_breadth,
+            "universe_symbols": self.universe_symbols,
+            "candles": self.candles,
+        }
+
+    @classmethod
+    def from_jsonable(cls, payload: dict[str, Any]) -> RawInputs:
+        return cls(
+            as_of=payload["as_of"],
+            holdings=payload["holdings"],
+            watch_alerts=payload["watch_alerts"],
+            universe_pool=payload["universe_pool"],
+            snapshot_partition_date=payload["snapshot_partition_date"],
+            snapshot_breadth=payload["snapshot_breadth"],
+            universe_symbols=payload["universe_symbols"],
+            candles=payload["candles"],
+        )
+
+
+def _passes_liquidity_filter(row: dict[str, Any]) -> bool:
+    market_cap = row.get("market_cap")
+    turnover = row.get("daily_turnover")
+    if not market_cap or not turnover:
+        return False
+    return (
+        Decimal(market_cap) >= MIN_MARKET_CAP_KRW
+        and Decimal(turnover) >= MIN_TURNOVER_KRW
+    )
+
+
+async def _fetch_holdings_raw() -> list[dict[str, str]]:
+    client = _ReadOnlyKISDomesticClient()
+    stocks = await client.fetch_my_stocks()
+    rows: list[dict[str, str]] = []
+    for stock in stocks:
+        symbol = str(stock.get("pdno", "")).strip()
+        if not symbol:
+            continue
+        quantity = Decimal(str(stock.get("hldg_qty") or "0"))
+        if quantity <= 0:
+            continue
+        average_price = Decimal(str(stock.get("pchs_avg_pric") or "0"))
+        rows.append(
+            {
+                "symbol": symbol,
+                "quantity": str(quantity),
+                "average_price": str(average_price),
+            }
+        )
+    return rows
+
+
+async def _fetch_watch_alerts_raw(*, as_of: datetime) -> list[dict[str, Any]]:
+    async with AsyncSessionLocal() as db:
+        repo = InvestmentReportsRepository(db)
+        alerts = await repo.list_active_alerts(
+            market=WATCH_MARKET, valid_at=as_of, limit=250
+        )
+    return [
+        {
+            "alert_uuid": str(alert.alert_uuid),
+            "symbol": alert.symbol,
+            "target_kind": alert.target_kind,
+            "metric": alert.metric,
+            "operator": alert.operator,
+            "threshold": str(alert.threshold),
+            "threshold_high": (
+                str(alert.threshold_high) if alert.threshold_high is not None else None
+            ),
+            "rationale": alert.rationale,
+        }
+        for alert in alerts
+    ]
+
+
+async def _fetch_universe_pool_raw() -> tuple[
+    list[dict[str, Any]], str | None, dict[str, Any] | None
+]:
+    async with AsyncSessionLocal() as db:
+        repo = InvestScreenerSnapshotsRepository(db)
+        rows = await repo.list_candidate_pool(market=SNAPSHOT_MARKET, limit=None)
+        breadth = await repo.breadth(market=SNAPSHOT_MARKET)
+        # invest_screener_snapshots.market_cap is unpopulated for every KR row
+        # (verified empirically against prod 2026-08-07: 3,925/3,925 NULL) —
+        # the trusted KRW-normalized source is market_valuation_snapshots
+        # (naver_finance), the same one support_proximity_builder.py already
+        # uses for this exact quality-floor purpose. Reused, not reinvented.
+        market_caps = await load_normalized_kr_market_caps(
+            db, [row.symbol for row in rows]
+        )
+
+    pool = [
+        {
+            "symbol": row.symbol,
+            "latest_close": str(row.latest_close),
+            "market_cap": (
+                str(market_caps[row.symbol].value)
+                if row.symbol in market_caps
+                else None
+            ),
+            "market_cap_source": (
+                market_caps[row.symbol].source if row.symbol in market_caps else None
+            ),
+            "daily_turnover": (
+                str(row.daily_turnover) if row.daily_turnover is not None else None
+            ),
+            "daily_volume": (
+                str(row.daily_volume) if row.daily_volume is not None else None
+            ),
+            "snapshot_date": row.snapshot_date.isoformat(),
+        }
+        for row in rows
+    ]
+    partition_date = rows[0].snapshot_date.isoformat() if rows else None
+    breadth_dict = {
+        "total": breadth.total,
+        "advancers": breadth.advancers,
+        "decliners": breadth.decliners,
+        "unchanged": breadth.unchanged,
+        "partition_date": (
+            breadth.partition_date.isoformat() if breadth.partition_date else None
+        ),
+    }
+    return pool, partition_date, breadth_dict
+
+
+async def _fetch_kr_daily_candles_raw(symbol: str) -> list[list[str]] | None:
+    async with AsyncSessionLocal() as db:
+        repo = DailyCandlesRepository(session=db)
+        rows = await repo.fetch_recent(
+            market=DB_MARKET_KEY,
+            symbol=symbol,
+            partition=DB_PARTITION,
+            count=CANDLE_LOOKBACK_BARS,
+        )
+    if not rows:
+        return None
+    return [
+        [
+            str(Decimal(str(r.close))),
+            str(Decimal(str(r.high))),
+            str(Decimal(str(r.low))),
+        ]
+        for r in rows
+    ]
+
+
+async def fetch_raw_inputs() -> RawInputs:
+    """Do all network/DB I/O once; return a JSON-safe, replayable snapshot."""
+
+    as_of = datetime.now(UTC)
+    pool, partition_date, breadth = await _fetch_universe_pool_raw()
+    watch_alerts = await _fetch_watch_alerts_raw(as_of=as_of)
+    holdings = await _fetch_holdings_raw()
+
+    filtered_symbols = {row["symbol"] for row in pool if _passes_liquidity_filter(row)}
+    holding_symbols = {row["symbol"] for row in holdings}
+    watch_symbols = {row["symbol"] for row in watch_alerts}
+    universe_symbols = sorted(filtered_symbols | holding_symbols | watch_symbols)
+
+    semaphore = asyncio.Semaphore(CANDLE_FETCH_CONCURRENCY)
+
+    async def _bounded_fetch(symbol: str) -> tuple[str, list[list[str]] | None]:
+        async with semaphore:
+            return symbol, await _fetch_kr_daily_candles_raw(symbol)
+
+    fetched = await asyncio.gather(*(_bounded_fetch(sym) for sym in universe_symbols))
+    candles = {symbol: rows for symbol, rows in fetched if rows is not None}
+
+    return RawInputs(
+        as_of=as_of.isoformat(),
+        holdings=holdings,
+        watch_alerts=watch_alerts,
+        universe_pool=pool,
+        snapshot_partition_date=partition_date,
+        snapshot_breadth=breadth,
+        universe_symbols=universe_symbols,
+        candles=candles,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure computation — deterministic given RawInputs.
+#
+# ``_cluster_view_row``/``_select_invalidation_line``/
+# ``_underwater_sessions_within_lookback`` intentionally mirror
+# ``scripts/policy_table/adapters/crypto.py``'s identical helpers byte-for-
+# byte (same market-agnostic logic, no crypto-specific behavior). P-2's brief
+# is explicit that P-1 must not be touched/reimplemented, so this duplicates
+# rather than extracting a shared core module — a candidate DRY pass for a
+# future PR, not this one.
+# ---------------------------------------------------------------------------
+
+
+def _cluster_view_row(view: Any) -> dict[str, Any]:
+    return {
+        "price": view.representative,
+        "distance_pct": view.distance_pct,
+        "sources": list(view.sources),
+        "source_count": view.source_count,
+        "qualifies_two_source": view.qualifies_two_source,
+        "within_d3_support_window": view.within_d3_support_window,
+    }
+
+
+def _select_invalidation_line(
+    alerts_for_symbol: list[dict[str, Any]], *, current_price: Decimal
+) -> dict[str, Any]:
+    candidates = [
+        alert
+        for alert in alerts_for_symbol
+        if alert.get("operator") == "below" and alert.get("threshold") not in (None, "")
+    ]
+    if not candidates:
+        return {"available": False, "reason": "no_active_below_operator_watch_alert"}
+    chosen = min(
+        candidates,
+        key=lambda alert: abs(Decimal(alert["threshold"]) - current_price),
+    )
+    price = Decimal(chosen["threshold"])
+    return {
+        "available": True,
+        "price": price,
+        "distance_pct": support_distance(price, current_price),
+        "metric": chosen.get("metric"),
+        "alert_uuid": chosen.get("alert_uuid"),
+        "rationale": chosen.get("rationale"),
+    }
+
+
+def _underwater_sessions_within_lookback(
+    *, closes: list[Decimal], average_price: Decimal
+) -> int:
+    position = Position(symbol="_", quantity=1, average_price=average_price)
+    streak = 0
+    for close in closes:
+        outcome = update_underwater_close(position, close=close)
+        streak = outcome.streak
+    return streak
+
+
+def _build_row(
+    *,
+    symbol: str,
+    closes: list[Decimal],
+    highs: list[Decimal],
+    lows: list[Decimal],
+    tick_table: Any,
+    holding: dict[str, str] | None,
+    watch_alerts_for_symbol: list[dict[str, Any]],
+    pool_row: dict[str, Any] | None,
+) -> dict[str, Any]:
+    try:
+        signal: SymbolSignal | None = compute_symbol_signal(
+            closes=closes, highs=highs, lows=lows, tick_table=tick_table
+        )
+    except InsufficientHistory as exc:
+        return {
+            "symbol": symbol,
+            "held": holding is not None,
+            "insufficient_history": True,
+            "bars_available": len(closes),
+            "bars_required": FIB_WINDOW,
+            "note": str(exc),
+        }
+
+    close = signal.previous_close
+    deep_band = {
+        "lower": close * (Decimal(1) + DEEP_BAND_LOWER_PCT),
+        "upper": close * (Decimal(1) + DEEP_BAND_UPPER_PCT),
+    }
+    nearest_support_distance_pct = (
+        support_distance(signal.buy_l2, close) if signal.buy_l2 is not None else None
+    )
+
+    average_price = Decimal(holding["average_price"]) if holding else None
+    cost_basis = (
+        average_price * Decimal(holding["quantity"])
+        if holding and average_price
+        else None
+    )
+
+    averaging: dict[str, Any] | None = None
+    loss_guard_floor = None
+    tolerance_alerts: dict[str, Any] = {
+        "portfolio_mdd_25pct": {
+            "available": False,
+            "reason": (
+                "requires a historical portfolio equity curve; a point-in-time "
+                "holdings snapshot cannot reconstruct max drawdown"
+            ),
+        }
+    }
+    underwater_sessions: dict[str, Any] = {
+        "available": False,
+        "reason": "not held",
+    }
+    manual_add_count = {
+        "count": None,
+        "available": False,
+        "reason": (
+            "requires broker order-history classification of manual vs. DCA-"
+            "tranche fills; not derivable from read-only account/candle data "
+            "(same read-only-data gap ROB-1230 P-1 hit for crypto)"
+        ),
+        # Crypto's median_6 is an Upbit-specific empirical constant (08-08
+        # oper-coin session); no equivalent KR reference has been measured.
+        "median_6": None,
+    }
+
+    if holding is not None and average_price is not None and cost_basis is not None:
+        averaging = {
+            f"k_{int(k * 100)}pct": averaging_math(
+                cost_basis=cost_basis,
+                average_price=average_price,
+                current_price=close,
+                k=k,
+            )
+            for k in AVERAGING_K_LEVELS
+        }
+        loss_guard_floor = average_price * LOSS_GUARD_MULTIPLIER
+        position_alert_price = average_price * (Decimal(1) + POSITION_ALERT_PCT)
+        tolerance_alerts["position_minus_30pct"] = {
+            "threshold_price": position_alert_price,
+            "distance_pct": support_distance(position_alert_price, close),
+        }
+        underwater_sessions = {
+            "available": True,
+            "sessions_within_lookback": _underwater_sessions_within_lookback(
+                closes=closes, average_price=average_price
+            ),
+            "lookback_bars": len(closes),
+            "note": (
+                "arm-neutral post-fill close clock (D3 R1c semantics), capped "
+                "by the fetched candle lookback window, not the true cycle "
+                "start"
+            ),
+        }
+
+    invalidation_line = _select_invalidation_line(
+        watch_alerts_for_symbol, current_price=close
+    )
+
+    row: dict[str, Any] = {
+        "symbol": symbol,
+        "held": holding is not None,
+        "insufficient_history": False,
+        "bars_used": len(closes),
+        "previous_close": close,
+        "rsi": signal.rsi,
+        "bollinger_bands": {
+            "lower": signal.bb_lower,
+            "middle": signal.bb_middle,
+            "upper": signal.bb_upper,
+        },
+        "fib_window": {"low": signal.fib_window_low, "high": signal.fib_window_high},
+        "A_buy_side": {
+            "support_levels": [_cluster_view_row(c) for c in signal.support_clusters],
+            "buy_l1": {
+                "price": signal.buy_l1,
+                "basis": "t_minus_1_close_x_0.97_tick_aligned",
+            },
+            "buy_l2": (
+                {"price": signal.buy_l2, "basis": signal.buy_l2_source}
+                if signal.buy_l2 is not None
+                else None
+            ),
+            "nearest_support_distance_pct": nearest_support_distance_pct,
+            "deep_band": deep_band,
+            "averaging_math": averaging,
+            "sizing_band": {"new_entry_notional_krw": KR_NEW_ENTRY_NOTIONAL_KRW},
+        },
+        "B_sell_side": {
+            "label": "SELL_SIDE_MODEL_MISMATCH",
+            "resistance_levels": [
+                _cluster_view_row(c) for c in signal.resistance_clusters_above_close
+            ],
+            "sell_r1": signal.sell_r1,
+            "sell_r2": signal.sell_r2,
+            "loss_guard_floor": loss_guard_floor,
+        },
+        "C_diagnostics": {
+            "underwater_sessions": underwater_sessions,
+            "manual_add_count": manual_add_count,
+            "invalidation_line": invalidation_line,
+            "tolerance_alerts": tolerance_alerts,
+        },
+        "D_context": {
+            "market_cap": (
+                Decimal(pool_row["market_cap"])
+                if pool_row and pool_row.get("market_cap")
+                else None
+            ),
+            "market_cap_source": pool_row.get("market_cap_source")
+            if pool_row
+            else None,
+            "daily_turnover": (
+                Decimal(pool_row["daily_turnover"])
+                if pool_row and pool_row.get("daily_turnover")
+                else None
+            ),
+            "in_filtered_snapshot_pool": pool_row is not None
+            and _passes_liquidity_filter(pool_row),
+        },
+    }
+    return row
+
+
+def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
+    """Pure: build the full policy_table.v1 payload from RawInputs."""
+
+    tick_table = build_kr_krx_tick_table()
+
+    holdings_by_symbol = {row["symbol"]: row for row in raw.holdings}
+    alerts_by_symbol: dict[str, list[dict[str, Any]]] = {}
+    for alert in raw.watch_alerts:
+        alerts_by_symbol.setdefault(alert["symbol"], []).append(alert)
+    pool_by_symbol = {row["symbol"]: row for row in raw.universe_pool}
+    filtered_symbols = {
+        symbol
+        for symbol, row in pool_by_symbol.items()
+        if _passes_liquidity_filter(row)
+    }
+
+    rows: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for symbol in raw.universe_symbols:
+        bars = raw.candles.get(symbol, [])
+        closes = [Decimal(bar[0]) for bar in bars]
+        highs = [Decimal(bar[1]) for bar in bars]
+        lows = [Decimal(bar[2]) for bar in bars]
+        row = _build_row(
+            symbol=symbol,
+            closes=closes,
+            highs=highs,
+            lows=lows,
+            tick_table=tick_table,
+            holding=holdings_by_symbol.get(symbol),
+            watch_alerts_for_symbol=alerts_by_symbol.get(symbol, []),
+            pool_row=pool_by_symbol.get(symbol),
+        )
+        rows.append(row)
+        if row["insufficient_history"]:
+            reason = (
+                "no_candles_in_db"
+                if row["bars_available"] == 0
+                else "insufficient_history_lt_120_sessions"
+            )
+            skipped.append(
+                {
+                    "symbol": symbol,
+                    "reason": reason,
+                    "bars_available": row["bars_available"],
+                }
+            )
+
+    payload: dict[str, Any] = {
+        "schema": "policy_table.v1",
+        "market": MARKET,
+        "generated_at": raw.as_of,
+        "trust_labels": list(TRUST_LABELS),
+        "config": {
+            "quote_currency": QUOTE_CURRENCY,
+            "candle_granularity": CANDLE_GRANULARITY,
+            "candle_lookback_bars": CANDLE_LOOKBACK_BARS,
+            "candle_source": "db_daily_candles(kr_candles_1d, partition=KRX) — no live fetch",
+            "tick_source": "app.mcp_server.tick_size.get_tick_size_kr (runtime, not D3 frozen)",
+            "d3_constants": D3_CONSTANTS_ECHO,
+            "deep_band_pct": {
+                "lower": DEEP_BAND_LOWER_PCT,
+                "upper": DEEP_BAND_UPPER_PCT,
+            },
+            "position_alert_pct": POSITION_ALERT_PCT,
+            "loss_guard_multiplier": LOSS_GUARD_MULTIPLIER,
+            "averaging_k_levels": list(AVERAGING_K_LEVELS),
+            "new_entry_notional_krw": KR_NEW_ENTRY_NOTIONAL_KRW,
+            "universe_filter": {
+                "min_market_cap_krw": MIN_MARKET_CAP_KRW,
+                "min_turnover_krw": MIN_TURNOVER_KRW,
+                "source": (
+                    "app.services.invest_screener_snapshots.support_proximity_policy"
+                    " (reused, not reinvented)"
+                ),
+            },
+        },
+        "universe": {
+            "holdings": sorted(holdings_by_symbol.keys()),
+            "watch": sorted(alerts_by_symbol.keys()),
+            "snapshot_partition_date": raw.snapshot_partition_date,
+            "snapshot_total_symbols": len(pool_by_symbol),
+            "filter_passed_symbols": len(filtered_symbols),
+            "attempted_symbols": len(raw.universe_symbols),
+            "computed_symbols": len(raw.universe_symbols) - len(skipped),
+            "skipped": skipped,
+        },
+        "market_context": {
+            "snapshot_breadth": raw.snapshot_breadth,
+        },
+        "rows": rows,
+    }
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Human-readable summary — blend ranking is display-only (design doc §2:
+# "표 자체엔 무영향 — 랭킹은 표시 순서일 뿐"), never affects the JSON rows.
+# ---------------------------------------------------------------------------
+
+# Initial weights (pilot — adjust during use, per design doc §2). Support
+# proximity and RSI oversold are the two core buy-timing signals (weighted
+# equally); trade value is a secondary liquidity sanity check.
+BLEND_WEIGHT_RSI = 0.4
+BLEND_WEIGHT_SUPPORT = 0.4
+BLEND_WEIGHT_TURNOVER = 0.2
+
+
+def _blend_rank(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    eligible = [row for row in payload["rows"] if not row["insufficient_history"]]
+
+    def rsi_key(row: dict[str, Any]) -> float:
+        rsi = row.get("rsi")
+        return float(rsi) if rsi is not None else 100.0
+
+    def support_key(row: dict[str, Any]) -> float:
+        dist = row["A_buy_side"].get("nearest_support_distance_pct")
+        return abs(float(dist)) if dist is not None else 1.0
+
+    def turnover_key(row: dict[str, Any]) -> float:
+        turnover = row.get("D_context", {}).get("daily_turnover")
+        return -float(turnover) if turnover is not None else 0.0
+
+    def rank_index(key_fn: Any) -> dict[str, int]:
+        ordered = sorted(eligible, key=key_fn)
+        return {row["symbol"]: i for i, row in enumerate(ordered)}
+
+    rsi_rank = rank_index(rsi_key)
+    support_rank = rank_index(support_key)
+    turnover_rank = rank_index(turnover_key)
+
+    def blend_score(row: dict[str, Any]) -> float:
+        symbol = row["symbol"]
+        return (
+            BLEND_WEIGHT_RSI * rsi_rank[symbol]
+            + BLEND_WEIGHT_SUPPORT * support_rank[symbol]
+            + BLEND_WEIGHT_TURNOVER * turnover_rank[symbol]
+        )
+
+    return sorted(eligible, key=blend_score)
+
+
+def render_summary_md(payload: dict[str, Any], *, top_n: int = 50) -> str:
+    lines: list[str] = []
+    lines.append(f"# Policy Table — {payload['market']} — {payload['generated_at']}")
+    lines.append("")
+    for label in payload["trust_labels"]:
+        lines.append(f"> {label}")
+    lines.append("")
+
+    u = payload["universe"]
+    lines.append(
+        f"universe: snapshot_total={u['snapshot_total_symbols']} -> "
+        f"filter_passed={u['filter_passed_symbols']} -> "
+        f"attempted={u['attempted_symbols']} -> "
+        f"computed={u['computed_symbols']} "
+        f"(holdings={len(u['holdings'])}, watch={len(u['watch'])}, "
+        f"snapshot_partition_date={u['snapshot_partition_date']})"
+    )
+    if u["skipped"]:
+        by_reason: dict[str, int] = {}
+        for s in u["skipped"]:
+            by_reason[s["reason"]] = by_reason.get(s["reason"], 0) + 1
+        reason_str = ", ".join(f"{k}={v}" for k, v in sorted(by_reason.items()))
+        lines.append(f"skipped: {len(u['skipped'])} ({reason_str})")
+    lines.append("")
+
+    breadth = payload["market_context"].get("snapshot_breadth")
+    if breadth and breadth.get("total"):
+        lines.append(
+            f"snapshot_breadth ({breadth.get('partition_date')}): "
+            f"{breadth['advancers']}/{breadth['total']} advancers, "
+            f"{breadth['decliners']}/{breadth['total']} decliners"
+        )
+    lines.append("")
+    lines.append(
+        f"blend ranking (display-only, weights: rsi={BLEND_WEIGHT_RSI} "
+        f"support={BLEND_WEIGHT_SUPPORT} turnover={BLEND_WEIGHT_TURNOVER})"
+    )
+    lines.append("")
+
+    ranked = _blend_rank(payload)
+    lines.append(
+        "| symbol | held | RSI | support_dist_pct | buy_l1 | buy_l2 | "
+        "sell_r1 | resistance_mismatch |"
+    )
+    lines.append("|---|---|---:|---:|---:|---:|---:|---|")
+    for row in ranked[:top_n]:
+        buy = row["A_buy_side"]
+        sell = row["B_sell_side"]
+        buy_l2 = buy["buy_l2"]["price"] if buy["buy_l2"] else "-"
+        dist = buy.get("nearest_support_distance_pct")
+        dist_str = dist if dist is not None else "-"
+        lines.append(
+            f"| {row['symbol']} | {'Y' if row['held'] else ''} | {row['rsi']} | "
+            f"{dist_str} | {buy['buy_l1']['price']} | {buy_l2} | "
+            f"{sell['sell_r1'] or '-'} | {sell['label']} |"
+        )
+    lines.append("")
+    lines.append(f"policy_table_hash: `{payload['stamps']['policy_table_hash']}`")
+    lines.append(f"auto_trader_head: `{payload['stamps']['auto_trader_head']}`")
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "MARKET",
+    "RawInputs",
+    "fetch_raw_inputs",
+    "compute_policy_table",
+    "render_summary_md",
+]

--- a/scripts/policy_table/core/kr_tick.py
+++ b/scripts/policy_table/core/kr_tick.py
@@ -1,0 +1,73 @@
+"""KRX tick-size table, expressed as a D3-engine ``TickTable`` (reuse).
+
+ROB-1230 P-2 design doc is explicit: the KR adapter must use the *runtime*
+KRX tick rule (``app.mcp_server.tick_size.get_tick_size_kr`` — the same
+function the live order path uses), not the D3 frozen sample copy
+(``research/kr_corpus/d3_engine`` loads a hash-gated, point-in-time YAML
+snapshot for backtest reproducibility; an advisory table must instead track
+whatever the current order path actually enforces).
+
+Band boundaries are discovered by binary search directly against
+``get_tick_size_kr`` rather than hand-typed, so a future change to the
+runtime ladder is picked up automatically instead of silently drifting from
+this table. Only the D3 ``TickTable`` container (bands/alignment/
+sell-minus-one-tick) is reused from ``research.kr_corpus.d3_engine.tick`` —
+the ladder data itself comes from the live function, not from that module.
+"""
+
+from __future__ import annotations
+
+from app.mcp_server.tick_size import get_tick_size_kr
+from research.kr_corpus.d3_engine.tick import TickTable
+
+# KRX equities do not trade above this (the priciest KOSPI names sit in the
+# low millions of KRW); scanning up to here also proves the ladder is flat
+# (tick=1000) well past the last real breakpoint (500,000).
+_SCAN_UPPER_BOUND = 100_000_000
+
+
+def _find_next_transition(
+    *, lower: int, tick_at_lower: int, upper_bound: int
+) -> int | None:
+    """Binary search for the first price >= lower where the tick differs.
+
+    Returns ``None`` if the tick is unchanged all the way to ``upper_bound``
+    (i.e. ``lower`` is the start of the final, open-ended band).
+    """
+
+    if get_tick_size_kr(float(upper_bound)) == tick_at_lower:
+        return None
+    lo, hi = lower, upper_bound
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if get_tick_size_kr(float(mid)) == tick_at_lower:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+def build_kr_krx_tick_table() -> TickTable:
+    """Build a D3 ``TickTable`` by discovering ``get_tick_size_kr``'s ladder."""
+
+    bands: list[dict[str, str]] = []
+    lower = 0
+    while True:
+        tick_at_lower = get_tick_size_kr(float(lower))
+        transition = _find_next_transition(
+            lower=lower, tick_at_lower=tick_at_lower, upper_bound=_SCAN_UPPER_BOUND
+        )
+        bands.append(
+            {
+                "lower_inclusive": str(lower),
+                "upper_exclusive": None if transition is None else str(transition),
+                "tick": str(tick_at_lower),
+            }
+        )
+        if transition is None:
+            break
+        lower = transition
+    return TickTable.from_mapping({"bands": bands})
+
+
+__all__ = ["build_kr_krx_tick_table"]


### PR DESCRIPTION
## Summary
- Adds the KR (KRX equities) market adapter for the ROB-1230 policy_table.v1 pilot, on top of P-1's shared core (`scripts/policy_table/core/*`) and D3-engine indicator reuse — neither is modified.
- Universe = full `invest_screener_snapshots(market='kr')` partition, filtered by the same market-cap/turnover floor `support_proximity_builder.py` already uses (`DEFAULT_MIN_MARKET_CAP_KRW`/`DEFAULT_MIN_TURNOVER_KRW`, reused not reinvented) ∪ holdings ∪ active watch alerts.
- **Empirical finding surfaced during implementation**: `invest_screener_snapshots.market_cap` is unpopulated for every KR row (verified 3,925/3,925 NULL against prod, 2026-08-07 partition). Market cap for the filter comes instead from the KRW-normalized `market_valuation_snapshots` source (`load_normalized_kr_market_caps`), the same helper `support_proximity_builder.py` already relies on for this.
- Indicator inputs (fib 120 / BB 20,2σ / RSI 14 Wilder — all need ≥120 daily bars) are read from the `kr_candles_1d` DB table only, no live KIS candle fetch — the compute path has zero live-market dependency. Symbols short of 120 sessions are explicitly marked `skipped` with a reason (`insufficient_history_lt_120_sessions` / `no_candles_in_db`), never silently filled.
- Tick alignment uses a new `TickTable` built by binary-searching the **runtime** `app.mcp_server.tick_size.get_tick_size_kr` ladder (not the D3 frozen sample copy), per the design doc's explicit requirement.
- Holdings come from a minimal read-only KIS facade (`_ReadOnlyKISDomesticClient`) composing only `AccountClient` — see the caveat below on why this doesn't achieve full import-graph isolation.

## Verified
- Byte-identical dump/replay across 3 runs against real prod data (`policy_table_hash` matches all 3 times).
- One sampled row (`000270`) matches a direct D3-engine call bar-for-bar (RSI/BB/fib/buy_l1 tick alignment).
- `grep -rn "orders import" scripts/policy_table` — empty. This adapter's own source never imports or calls an order-placement/cancel/modify function.
- Real artifact generated against prod: `~/services/auto_trader-operator/policy-tables/20260808T042001Z-kr.json` (+ summary.md, `latest-kr.json` pointer). universe: 3,925 → filter_passed 529 → attempted 530 → computed 278 (252 skipped, all `insufficient_history_lt_120_sessions`).

## Known caveat (flagged for reviewer, not silently glossed)
`app/services/brokers/kis/__init__.py` unconditionally imports `client.py` (→ `DomesticOrderClient`/`OverseasOrderClient`) whenever **any** submodule under `app.services.brokers.kis` is imported — including `account.py`/`base.py`. So while this adapter's own code never references or calls an order-placement class/function, the KIS package's own `__init__.py` (pre-existing, unrelated to this PR) still loads those class *definitions* into the process as an unavoidable structural fact — same as the existing `get_holdings` MCP tool, which imports the full `KISClient` facade directly. The minimal facade here is still a real, meaningful safety improvement over that: the object this adapter holds has no order-placement methods callable on it at all (`AttributeError` if attempted), vs. `KISClient` where they're present and callable.

## Not in scope (per P-2 brief)
- P-1 core/crypto adapter — untouched (verified via `git diff --stat`).
- operator repo prompt/contract changes — that's P-3.
- MCP tool surface, scheduler registration, auto-execution.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run ty check` clean
- [x] Dump/replay determinism (3 runs, byte-identical)
- [x] Direct D3-engine cross-check on a sampled row
- [x] Real artifact generated against prod DB (read-only) + live KIS holdings read (read-only)
- [ ] Independent verification per ROB-1230 P-2 brief (orch-scoped, not self-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)