### PR TITLE
feat(research): ROB-1230 P-2-US — US policy_table.v1 adapter (B0-X U-1)

### DIFF
--- a/scripts/b0x/table_source.py
+++ b/scripts/b0x/table_source.py
@@ -1,8 +1,13 @@
 """Load + validate the ``policy_table.v1`` artifact B0-X derives orders from.
 
-Contract §2-2: **표가 없거나 ``STALE`` 이면 그 사이클은 주문 0** (조용한 재사용·
-재계산 금지, 사유 기록). This module is where that rule lives, and it is the
-only door through which a table reaches derivation.
+Contract v1.1 §2-2 (literal)::
+
+    표가 없거나 STALE 이거나 MAX_TABLE_AGE 초과면 그 사이클은 주문 0
+    (조용한 재사용·재계산 금지, 사유 기록).
+    MAX_TABLE_AGE: crypto 8h · KR 36h · US 36h
+
+This module is where that rule lives, and it is the only door through which a
+table reaches derivation.
 
 The table generator (``scripts/build_policy_table.py``) is read-only to B0-X:
 this module never invokes it, never writes into its output directory, and
@@ -16,12 +21,12 @@ reason code:
   ``schema_mismatch``      — not a ``policy_table.v1`` payload, or wrong market.
   ``hash_mismatch``        — recomputed ``policy_table_hash`` != the stamped one
                              (the artifact was edited after generation).
-  ``stale_by_age``         — ``generated_at`` older than the lane's max age.
+  ``stale_by_age``         — ``generated_at`` older than the market's
+                             ``MAX_TABLE_AGE`` (contract v1.1 §2-2 literal).
 
-``stale_by_age`` is B0-X's own addition, not the generator's: a table whose
-build failed *silently* (process killed before the STALE marker was written)
-would otherwise be replayed forever. It can only ever *reduce* the number of
-orders a cycle emits, never increase it.
+Ages are **not** worker-chosen — they come from
+``scripts.policy_table.core.max_table_age`` (contract sha256 stamped there).
+Exceeding age can only ever *reduce* the number of orders a cycle emits.
 """
 
 from __future__ import annotations
@@ -32,6 +37,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final
 
+from scripts.policy_table.core.max_table_age import (
+    CONTRACT_V11_SECTION_2_2,
+    MAX_TABLE_AGE,
+)
 from scripts.policy_table.core.schema import (
     SCHEMA_VERSION,
     compute_policy_table_hash,
@@ -43,11 +52,10 @@ DEFAULT_TABLE_DIR: Final[Path] = (
     Path.home() / "services" / "auto_trader-operator" / "policy-tables"
 )
 
-#: Contract §5: crypto tables are rebuilt on a 4h cadence. Two missed builds is
-#: the point at which a table stops describing "now" — locked, no CLI flag.
-MAX_TABLE_AGE: Final[dict[str, dt.timedelta]] = {
-    "crypto": dt.timedelta(hours=8),
-}
+# Re-export for callers/tests that import MAX_TABLE_AGE from this module.
+# Single source of truth = scripts.policy_table.core.max_table_age
+# (contract v1.1 §2-2: crypto 8h · kr 36h · us 36h).
+_ = CONTRACT_V11_SECTION_2_2  # keep import used for documentation linkage
 
 
 class TableReason:
@@ -213,11 +221,26 @@ def load_policy_table(
 
     age = now.astimezone(dt.UTC) - generated_at
     max_age = MAX_TABLE_AGE.get(market)
-    if max_age is not None and age > max_age:
+    if max_age is None:
+        # Unknown market must fail closed — do not silently skip the age gate.
+        return TableUnavailable(
+            market=market,
+            reason=TableReason.SCHEMA_MISMATCH,
+            detail=(
+                f"MAX_TABLE_AGE not defined for market={market!r} "
+                f"({CONTRACT_V11_SECTION_2_2})"
+            ),
+            path=latest,
+        )
+    if age > max_age:
         return TableUnavailable(
             market=market,
             reason=TableReason.STALE_BY_AGE,
-            detail=f"age={age} > max_age={max_age} (generated_at={generated_at.isoformat()})",
+            detail=(
+                f"age={age} > max_age={max_age} "
+                f"(generated_at={generated_at.isoformat()}; "
+                f"{CONTRACT_V11_SECTION_2_2})"
+            ),
             path=latest,
         )
     if age < -dt.timedelta(minutes=5):

--- a/scripts/build_policy_table.py
+++ b/scripts/build_policy_table.py
@@ -1,10 +1,11 @@
-"""ROB-1230 P-1/P-2 — build a policy_table.v1 artifact (crypto + KR adapters).
+"""ROB-1230 P-1/P-2 — build a policy_table.v1 artifact (crypto + KR + US).
 
 Scheduleless, read-only, advisory. Each market adapter fetches its own raw
 inputs (crypto: live Upbit + this repo's holdings/watch-alert tables; kr:
 the invest_screener_snapshots DB table + DB daily candles + a read-only KIS
-holdings query), runs the shared indicator core (a direct reuse of
-research/kr_corpus/d3_engine's fib/BB/RSI/tick code — see
+holdings query; us: invest_screener_snapshots US + DB daily candles + a
+read-only Alpaca paper lab positions query), runs the shared indicator core
+(a direct reuse of research/kr_corpus/d3_engine's fib/BB/RSI/tick code — see
 scripts/policy_table/core/signal_math.py), and writes a policy_table.v1 JSON
 artifact plus a human-readable Markdown summary.
 
@@ -16,6 +17,7 @@ Usage
 -----
     uv run python -m scripts.build_policy_table --market crypto
     uv run python -m scripts.build_policy_table --market kr
+    uv run python -m scripts.build_policy_table --market us
 
     # Reproducibility check (ROB-1230 acceptance #2): dump raw inputs once,
     # then replay the same inputs through the pure compute+serialize path
@@ -39,6 +41,7 @@ from typing import Any
 
 from scripts.policy_table.adapters import crypto as crypto_adapter
 from scripts.policy_table.adapters import kr as kr_adapter
+from scripts.policy_table.adapters import us as us_adapter
 from scripts.policy_table.core.schema import (
     canonical_json_bytes,
     compute_policy_table_hash,
@@ -158,7 +161,7 @@ def _render_summary_md(payload: dict[str, Any]) -> str:
 
 
 async def _run(args: argparse.Namespace) -> int:
-    if args.market not in ("crypto", "kr"):
+    if args.market not in ("crypto", "kr", "us"):
         raise NotImplementedError(f"unsupported market: {args.market}")
 
     out_dir = Path(args.out_dir).expanduser()
@@ -185,7 +188,7 @@ async def _run(args: argparse.Namespace) -> int:
             payload = crypto_adapter.compute_policy_table(raw, top_n=top_n)
             payload["stamps"] = _build_stamps(payload)
             summary_md = _render_summary_md(payload)
-        else:
+        elif args.market == "kr":
             if args.replay_raw:
                 raw_payload = json.loads(Path(args.replay_raw).expanduser().read_text())
                 raw = kr_adapter.RawInputs.from_jsonable(raw_payload)
@@ -200,6 +203,21 @@ async def _run(args: argparse.Namespace) -> int:
             payload = kr_adapter.compute_policy_table(raw)
             payload["stamps"] = _build_stamps(payload)
             summary_md = kr_adapter.render_summary_md(payload, top_n=args.top_n or 50)
+        else:
+            if args.replay_raw:
+                raw_payload = json.loads(Path(args.replay_raw).expanduser().read_text())
+                raw = us_adapter.RawInputs.from_jsonable(raw_payload)
+            else:
+                raw = await us_adapter.fetch_raw_inputs()
+
+            if args.dump_raw:
+                Path(args.dump_raw).expanduser().write_text(
+                    json.dumps(raw.to_jsonable(), sort_keys=True, indent=2) + "\n"
+                )
+
+            payload = us_adapter.compute_policy_table(raw)
+            payload["stamps"] = _build_stamps(payload)
+            summary_md = us_adapter.render_summary_md(payload, top_n=args.top_n or 50)
 
         artifact_bytes = canonical_json_bytes(payload)
         ts = (
@@ -243,15 +261,15 @@ async def _run(args: argparse.Namespace) -> int:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--market", default="crypto", choices=["crypto", "kr"])
+    parser.add_argument("--market", default="crypto", choices=["crypto", "kr", "us"])
     parser.add_argument(
         "--top-n",
         type=int,
         default=None,
         help=(
             "crypto: universe top-N by 24h trade value (default "
-            f"{crypto_adapter.DEFAULT_TOP_N}); kr: summary.md display row cap "
-            "(default 50) — the KR JSON table itself is never top-N-capped"
+            f"{crypto_adapter.DEFAULT_TOP_N}); kr/us: summary.md display row "
+            "cap (default 50) — the JSON table itself is never top-N-capped"
         ),
     )
     parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))

--- a/scripts/policy_table/adapters/crypto.py
+++ b/scripts/policy_table/adapters/crypto.py
@@ -35,6 +35,7 @@ from research.kr_corpus.d3_engine.models import Position
 from research.kr_corpus.d3_engine.policies import update_underwater_close
 from research.kr_corpus.d3_engine.signals import support_distance
 from scripts.policy_table.core.averaging import averaging_math
+from scripts.policy_table.core.max_table_age import max_table_age_stamp
 from scripts.policy_table.core.signal_math import (
     D3_CONSTANTS_ECHO,
     FIB_WINDOW,
@@ -522,6 +523,8 @@ def compute_policy_table(
             "loss_guard_multiplier": LOSS_GUARD_MULTIPLIER,
             "averaging_k_levels": list(AVERAGING_K_LEVELS),
             "manual_add_median_reference": MANUAL_ADD_MEDIAN_REFERENCE,
+            # Contract v1.1 §2-2 literal (crypto = 8h) — not a worker-chosen constant.
+            **max_table_age_stamp(MARKET),
         },
         "universe": {
             "holdings": sorted(holdings_by_symbol.keys()),

--- a/scripts/policy_table/adapters/kr.py
+++ b/scripts/policy_table/adapters/kr.py
@@ -53,6 +53,7 @@ from research.kr_corpus.d3_engine.policies import update_underwater_close
 from research.kr_corpus.d3_engine.signals import support_distance
 from scripts.policy_table.core.averaging import averaging_math
 from scripts.policy_table.core.kr_tick import build_kr_krx_tick_table
+from scripts.policy_table.core.max_table_age import max_table_age_stamp
 from scripts.policy_table.core.signal_math import (
     D3_CONSTANTS_ECHO,
     FIB_WINDOW,
@@ -630,6 +631,8 @@ def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
                     " (reused, not reinvented)"
                 ),
             },
+            # Contract v1.1 §2-2 literal (KR = 36h) — not a worker-chosen constant.
+            **max_table_age_stamp(MARKET),
         },
         "universe": {
             "holdings": sorted(holdings_by_symbol.keys()),

--- a/scripts/policy_table/adapters/us.py
+++ b/scripts/policy_table/adapters/us.py
@@ -1,0 +1,868 @@
+"""US equities adapter for ROB-1230 P-2-US / B0-X U-1 — policy_table.v1 rows.
+
+Read-only. Universe selection is the ``invest_screener_snapshots`` table
+(``market='us'``) — same DB-snapshot-forced pattern as the KR adapter (design
+doc §2: night batch cannot depend on a live session scan). Indicator inputs
+(fib/BB/RSI need ≥120 daily bars) are read from ``us_candles_1d`` via
+``DailyCandlesRepository`` (partition = exchange from ``us_symbol_universe``).
+
+Holdings come from **Alpaca paper lab** only
+(``account_mode=alpaca_paper_lab`` / profile ``lab``) — the B0-X US account
+per operator account map (``mock/CLAUDE.md`` §1). ``alpaca_paper`` (default
+identity) is deliberately never touched. The service is used for
+``list_positions`` (GET) only; this adapter never calls order placement /
+cancel / submit methods (U-1 scope: table only, no U-2 order adapter).
+
+Labels: base 3 trust labels + ``CROSS_MARKET_TRANSFER_UNVALIDATED`` (B0-X
+contract §1). Per-row sell side still carries ``SELL_SIDE_MODEL_MISMATCH``.
+
+Split into ``fetch_raw_inputs`` (network + DB I/O) and
+``compute_policy_table`` (pure, deterministic given those inputs), same
+contract as crypto/KR adapters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+
+from app.core.db import AsyncSessionLocal
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+from app.services.invest_screener_snapshots.repository import (
+    InvestScreenerSnapshotsRepository,
+)
+from app.services.invest_view_model.us_quality_guards import US_MIN_MARKET_CAP_USD
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from research.kr_corpus.d3_engine.models import Position
+from research.kr_corpus.d3_engine.policies import update_underwater_close
+from research.kr_corpus.d3_engine.signals import support_distance
+from scripts.policy_table.core.averaging import averaging_math
+from scripts.policy_table.core.signal_math import (
+    D3_CONSTANTS_ECHO,
+    FIB_WINDOW,
+    InsufficientHistory,
+    SymbolSignal,
+    compute_symbol_signal,
+)
+from scripts.policy_table.core.trust_labels import US_TRUST_LABELS
+from scripts.policy_table.core.us_tick import TICK_SOURCE, build_us_equity_tick_table
+
+MARKET = "us"
+SNAPSHOT_MARKET = "us"
+WATCH_MARKET = "equity_us"  # InvestmentWatchAlert.market
+DB_MARKET_KEY = MarketKey.US
+QUOTE_CURRENCY = "USD"
+CANDLE_GRANULARITY = "1d"
+CANDLE_LOOKBACK_BARS = 200  # >= FIB_WINDOW(120) with headroom
+CANDLE_FETCH_CONCURRENCY = 8
+DEFAULT_EXCHANGE_PARTITION = "NASD"
+DEEP_BAND_LOWER_PCT = Decimal("-0.12")
+DEEP_BAND_UPPER_PCT = Decimal("-0.03")
+POSITION_ALERT_PCT = Decimal("-0.30")
+LOSS_GUARD_MULTIPLIER = Decimal("1.01")
+AVERAGING_K_LEVELS: tuple[Decimal, Decimal] = (Decimal("0.05"), Decimal("0.10"))
+
+# B0-X contract §4 US column — "B0 규칙($150~450)".
+US_NEW_ENTRY_NOTIONAL_USD_MIN = Decimal("150")
+US_NEW_ENTRY_NOTIONAL_USD_MAX = Decimal("450")
+# Mid of the band for single-value sizing_band echo (range also stamped in config).
+US_NEW_ENTRY_NOTIONAL_USD = Decimal("300")
+
+# Reused US quality floor (app/services/invest_view_model/us_quality_guards.py).
+MIN_MARKET_CAP_USD = US_MIN_MARKET_CAP_USD  # $100M
+# US adapter liquidity floor (no pre-existing shared constant analogous to
+# DEFAULT_MIN_TURNOVER_KRW). $1M daily notional — conservative small-cap cut.
+MIN_TURNOVER_USD = Decimal("1000000")
+
+# Yahoo-backed valuation rows are the trusted US market-cap source (builder
+# stamps source='yahoo' for market='us'). invest_screener_snapshots.market_cap
+# is not filled by build_snapshot_for_symbol — same column often NULL for KR
+# and may be NULL for US; we join valuation and record which source won.
+US_VALUATION_MARKET_CAP_SOURCE = "yahoo"
+
+# B0-X US account only — never fall back to default alpaca_paper.
+ALPACA_HOLDINGS_PROFILE = "lab"
+ALPACA_ACCOUNT_MODE = "alpaca_paper_lab"
+
+
+# ---------------------------------------------------------------------------
+# Raw inputs — dumpable/replayable for the determinism acceptance check.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RawInputs:
+    as_of: str  # ISO8601, captured once at fetch time
+    holdings: list[dict[str, str]]
+    watch_alerts: list[dict[str, Any]]
+    universe_pool: list[dict[str, Any]]
+    snapshot_partition_date: str | None
+    snapshot_breadth: dict[str, Any] | None
+    universe_symbols: list[str]
+    candles: dict[str, list[list[str]]]  # symbol -> [[close, high, low], ...]
+    market_cap_fill_stats: dict[str, Any]
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "as_of": self.as_of,
+            "holdings": self.holdings,
+            "watch_alerts": self.watch_alerts,
+            "universe_pool": self.universe_pool,
+            "snapshot_partition_date": self.snapshot_partition_date,
+            "snapshot_breadth": self.snapshot_breadth,
+            "universe_symbols": self.universe_symbols,
+            "candles": self.candles,
+            "market_cap_fill_stats": self.market_cap_fill_stats,
+        }
+
+    @classmethod
+    def from_jsonable(cls, payload: dict[str, Any]) -> RawInputs:
+        return cls(
+            as_of=payload["as_of"],
+            holdings=payload["holdings"],
+            watch_alerts=payload["watch_alerts"],
+            universe_pool=payload["universe_pool"],
+            snapshot_partition_date=payload["snapshot_partition_date"],
+            snapshot_breadth=payload["snapshot_breadth"],
+            universe_symbols=payload["universe_symbols"],
+            candles=payload["candles"],
+            market_cap_fill_stats=payload.get("market_cap_fill_stats") or {},
+        )
+
+
+def _passes_liquidity_filter(row: dict[str, Any]) -> bool:
+    market_cap = row.get("market_cap")
+    turnover = row.get("daily_turnover")
+    if not market_cap or not turnover:
+        return False
+    # Common-stock gate: only True passes. None/False fail closed (US screener
+    # activation ROB-204 — preferred/warrant/unit noise).
+    if row.get("is_common_stock") is not True:
+        return False
+    return (
+        Decimal(market_cap) >= MIN_MARKET_CAP_USD
+        and Decimal(turnover) >= MIN_TURNOVER_USD
+    )
+
+
+async def _fetch_holdings_raw() -> list[dict[str, str]]:
+    """Read-only Alpaca paper lab positions. No order methods called."""
+
+    service = AlpacaPaperBrokerService(profile=ALPACA_HOLDINGS_PROFILE)
+    positions = await service.list_positions()
+    rows: list[dict[str, str]] = []
+    for pos in positions:
+        symbol = str(pos.symbol or "").strip().upper()
+        if not symbol:
+            continue
+        quantity = Decimal(str(pos.qty))
+        if quantity <= 0:
+            continue
+        rows.append(
+            {
+                "symbol": symbol,
+                "quantity": str(quantity),
+                "average_price": str(Decimal(str(pos.avg_entry_price))),
+            }
+        )
+    return rows
+
+
+async def _fetch_watch_alerts_raw(*, as_of: datetime) -> list[dict[str, Any]]:
+    async with AsyncSessionLocal() as db:
+        repo = InvestmentReportsRepository(db)
+        alerts = await repo.list_active_alerts(
+            market=WATCH_MARKET, valid_at=as_of, limit=250
+        )
+    return [
+        {
+            "alert_uuid": str(alert.alert_uuid),
+            "symbol": alert.symbol,
+            "target_kind": alert.target_kind,
+            "metric": alert.metric,
+            "operator": alert.operator,
+            "threshold": str(alert.threshold),
+            "threshold_high": (
+                str(alert.threshold_high) if alert.threshold_high is not None else None
+            ),
+            "rationale": alert.rationale,
+        }
+        for alert in alerts
+    ]
+
+
+async def _load_us_yahoo_market_caps(
+    session: Any, symbols: list[str]
+) -> dict[str, tuple[Decimal, str]]:
+    """Newest yahoo market_cap per symbol from market_valuation_snapshots."""
+
+    if not symbols:
+        return {}
+    result = await session.execute(
+        sa.select(
+            MarketValuationSnapshot.symbol,
+            MarketValuationSnapshot.market_cap,
+            MarketValuationSnapshot.source,
+        )
+        .where(
+            MarketValuationSnapshot.market == "us",
+            MarketValuationSnapshot.symbol.in_(symbols),
+            MarketValuationSnapshot.source == US_VALUATION_MARKET_CAP_SOURCE,
+            MarketValuationSnapshot.market_cap.is_not(None),
+            MarketValuationSnapshot.market_cap > 0,
+        )
+        .order_by(
+            MarketValuationSnapshot.symbol.asc(),
+            MarketValuationSnapshot.snapshot_date.desc(),
+            MarketValuationSnapshot.computed_at.desc(),
+        )
+    )
+    caps: dict[str, tuple[Decimal, str]] = {}
+    for row in result.all():
+        if row.symbol in caps:
+            continue
+        caps[row.symbol] = (Decimal(str(row.market_cap)), str(row.source))
+    return caps
+
+
+async def _load_us_symbol_meta(
+    session: Any, symbols: list[str]
+) -> dict[str, dict[str, Any]]:
+    """exchange + is_common_stock from us_symbol_universe."""
+
+    if not symbols:
+        return {}
+    result = await session.execute(
+        sa.select(
+            USSymbolUniverse.symbol,
+            USSymbolUniverse.exchange,
+            USSymbolUniverse.is_common_stock,
+        ).where(USSymbolUniverse.symbol.in_(symbols))
+    )
+    out: dict[str, dict[str, Any]] = {}
+    for row in result.all():
+        out[row.symbol] = {
+            "exchange": row.exchange or DEFAULT_EXCHANGE_PARTITION,
+            "is_common_stock": row.is_common_stock,
+        }
+    return out
+
+
+async def _fetch_universe_pool_raw() -> tuple[
+    list[dict[str, Any]], str | None, dict[str, Any] | None, dict[str, Any]
+]:
+    async with AsyncSessionLocal() as db:
+        repo = InvestScreenerSnapshotsRepository(db)
+        rows = await repo.list_candidate_pool(market=SNAPSHOT_MARKET, limit=None)
+        breadth = await repo.breadth(market=SNAPSHOT_MARKET)
+        symbols = [row.symbol for row in rows]
+        valuation_caps = await _load_us_yahoo_market_caps(db, symbols)
+        meta = await _load_us_symbol_meta(db, symbols)
+
+    # Empirical fill accounting for the report (MARKET_CAP_SOURCE).
+    snapshot_cap_filled = 0
+    valuation_cap_used = 0
+    neither = 0
+    pool: list[dict[str, Any]] = []
+    for row in rows:
+        snap_cap = row.market_cap
+        snap_src = row.market_cap_source
+        if snap_cap is not None:
+            snapshot_cap_filled += 1
+            market_cap = str(Decimal(str(snap_cap)))
+            market_cap_source = snap_src or "invest_screener_snapshots"
+        elif row.symbol in valuation_caps:
+            valuation_cap_used += 1
+            cap_val, cap_src = valuation_caps[row.symbol]
+            market_cap = str(cap_val)
+            market_cap_source = f"market_valuation_snapshots:{cap_src}"
+        else:
+            neither += 1
+            market_cap = None
+            market_cap_source = None
+
+        symbol_meta = meta.get(row.symbol, {})
+        pool.append(
+            {
+                "symbol": row.symbol,
+                "latest_close": str(row.latest_close),
+                "market_cap": market_cap,
+                "market_cap_source": market_cap_source,
+                "daily_turnover": (
+                    str(row.daily_turnover) if row.daily_turnover is not None else None
+                ),
+                "daily_volume": (
+                    str(row.daily_volume) if row.daily_volume is not None else None
+                ),
+                "snapshot_date": row.snapshot_date.isoformat(),
+                "exchange": symbol_meta.get("exchange", DEFAULT_EXCHANGE_PARTITION),
+                "is_common_stock": symbol_meta.get("is_common_stock"),
+            }
+        )
+
+    partition_date = rows[0].snapshot_date.isoformat() if rows else None
+    breadth_dict = {
+        "total": breadth.total,
+        "advancers": breadth.advancers,
+        "decliners": breadth.decliners,
+        "unchanged": breadth.unchanged,
+        "partition_date": (
+            breadth.partition_date.isoformat() if breadth.partition_date else None
+        ),
+    }
+    fill_stats = {
+        "snapshot_total": len(rows),
+        "snapshot_market_cap_non_null": snapshot_cap_filled,
+        "valuation_yahoo_fallback_used": valuation_cap_used,
+        "market_cap_missing": neither,
+        "note": (
+            "invest_screener_snapshots.builder does not write market_cap; "
+            "prefer snapshot column when present, else market_valuation_snapshots "
+            f"source={US_VALUATION_MARKET_CAP_SOURCE}."
+        ),
+    }
+    return pool, partition_date, breadth_dict, fill_stats
+
+
+async def _fetch_us_daily_candles_raw(
+    symbol: str, *, partition: str
+) -> list[list[str]] | None:
+    async with AsyncSessionLocal() as db:
+        repo = DailyCandlesRepository(session=db)
+        rows = await repo.fetch_recent(
+            market=DB_MARKET_KEY,
+            symbol=symbol,
+            partition=partition,
+            count=CANDLE_LOOKBACK_BARS,
+        )
+    if not rows:
+        return None
+    return [
+        [
+            str(Decimal(str(r.close))),
+            str(Decimal(str(r.high))),
+            str(Decimal(str(r.low))),
+        ]
+        for r in rows
+    ]
+
+
+async def fetch_raw_inputs() -> RawInputs:
+    """Do all network/DB I/O once; return a JSON-safe, replayable snapshot."""
+
+    as_of = datetime.now(UTC)
+    pool, partition_date, breadth, fill_stats = await _fetch_universe_pool_raw()
+    watch_alerts = await _fetch_watch_alerts_raw(as_of=as_of)
+    holdings = await _fetch_holdings_raw()
+
+    filtered_symbols = {row["symbol"] for row in pool if _passes_liquidity_filter(row)}
+    holding_symbols = {row["symbol"] for row in holdings}
+    watch_symbols = {row["symbol"] for row in watch_alerts}
+    universe_symbols = sorted(filtered_symbols | holding_symbols | watch_symbols)
+
+    partition_by_symbol = {
+        row["symbol"]: row.get("exchange") or DEFAULT_EXCHANGE_PARTITION for row in pool
+    }
+    # Holdings/watch outside the snapshot pool still need an exchange.
+    missing = [s for s in universe_symbols if s not in partition_by_symbol]
+    if missing:
+        async with AsyncSessionLocal() as db:
+            meta = await _load_us_symbol_meta(db, missing)
+        for sym in missing:
+            partition_by_symbol[sym] = meta.get(sym, {}).get(
+                "exchange", DEFAULT_EXCHANGE_PARTITION
+            )
+
+    semaphore = asyncio.Semaphore(CANDLE_FETCH_CONCURRENCY)
+
+    async def _bounded_fetch(symbol: str) -> tuple[str, list[list[str]] | None]:
+        async with semaphore:
+            partition = partition_by_symbol.get(symbol, DEFAULT_EXCHANGE_PARTITION)
+            return symbol, await _fetch_us_daily_candles_raw(
+                symbol, partition=partition
+            )
+
+    fetched = await asyncio.gather(*(_bounded_fetch(sym) for sym in universe_symbols))
+    candles = {symbol: rows for symbol, rows in fetched if rows is not None}
+
+    return RawInputs(
+        as_of=as_of.isoformat(),
+        holdings=holdings,
+        watch_alerts=watch_alerts,
+        universe_pool=pool,
+        snapshot_partition_date=partition_date,
+        snapshot_breadth=breadth,
+        universe_symbols=universe_symbols,
+        candles=candles,
+        market_cap_fill_stats=fill_stats,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure computation — deterministic given RawInputs.
+# Helpers mirror kr.py (market-agnostic); not extracted this PR (same note as KR).
+# ---------------------------------------------------------------------------
+
+
+def _cluster_view_row(view: Any) -> dict[str, Any]:
+    return {
+        "price": view.representative,
+        "distance_pct": view.distance_pct,
+        "sources": list(view.sources),
+        "source_count": view.source_count,
+        "qualifies_two_source": view.qualifies_two_source,
+        "within_d3_support_window": view.within_d3_support_window,
+    }
+
+
+def _select_invalidation_line(
+    alerts_for_symbol: list[dict[str, Any]], *, current_price: Decimal
+) -> dict[str, Any]:
+    candidates = [
+        alert
+        for alert in alerts_for_symbol
+        if alert.get("operator") == "below" and alert.get("threshold") not in (None, "")
+    ]
+    if not candidates:
+        return {"available": False, "reason": "no_active_below_operator_watch_alert"}
+    chosen = min(
+        candidates,
+        key=lambda alert: abs(Decimal(alert["threshold"]) - current_price),
+    )
+    price = Decimal(chosen["threshold"])
+    return {
+        "available": True,
+        "price": price,
+        "distance_pct": support_distance(price, current_price),
+        "metric": chosen.get("metric"),
+        "alert_uuid": chosen.get("alert_uuid"),
+        "rationale": chosen.get("rationale"),
+    }
+
+
+def _underwater_sessions_within_lookback(
+    *, closes: list[Decimal], average_price: Decimal
+) -> int:
+    position = Position(symbol="_", quantity=1, average_price=average_price)
+    streak = 0
+    for close in closes:
+        outcome = update_underwater_close(position, close=close)
+        streak = outcome.streak
+    return streak
+
+
+def _build_row(
+    *,
+    symbol: str,
+    closes: list[Decimal],
+    highs: list[Decimal],
+    lows: list[Decimal],
+    tick_table: Any,
+    holding: dict[str, str] | None,
+    watch_alerts_for_symbol: list[dict[str, Any]],
+    pool_row: dict[str, Any] | None,
+) -> dict[str, Any]:
+    try:
+        signal: SymbolSignal | None = compute_symbol_signal(
+            closes=closes, highs=highs, lows=lows, tick_table=tick_table
+        )
+    except InsufficientHistory as exc:
+        return {
+            "symbol": symbol,
+            "held": holding is not None,
+            "insufficient_history": True,
+            "bars_available": len(closes),
+            "bars_required": FIB_WINDOW,
+            "note": str(exc),
+        }
+
+    close = signal.previous_close
+    deep_band = {
+        "lower": close * (Decimal(1) + DEEP_BAND_LOWER_PCT),
+        "upper": close * (Decimal(1) + DEEP_BAND_UPPER_PCT),
+    }
+    nearest_support_distance_pct = (
+        support_distance(signal.buy_l2, close) if signal.buy_l2 is not None else None
+    )
+
+    average_price = Decimal(holding["average_price"]) if holding else None
+    cost_basis = (
+        average_price * Decimal(holding["quantity"])
+        if holding and average_price
+        else None
+    )
+
+    averaging: dict[str, Any] | None = None
+    loss_guard_floor = None
+    tolerance_alerts: dict[str, Any] = {
+        "portfolio_mdd_25pct": {
+            "available": False,
+            "reason": (
+                "requires a historical portfolio equity curve; a point-in-time "
+                "holdings snapshot cannot reconstruct max drawdown"
+            ),
+        }
+    }
+    underwater_sessions: dict[str, Any] = {
+        "available": False,
+        "reason": "not held",
+    }
+    manual_add_count = {
+        "count": None,
+        "available": False,
+        "reason": (
+            "requires broker order-history classification of manual vs. DCA-"
+            "tranche fills; not derivable from read-only account/candle data "
+            "(same read-only-data gap ROB-1230 P-1/P-2 hit)"
+        ),
+        "median_6": None,
+    }
+
+    if holding is not None and average_price is not None and cost_basis is not None:
+        averaging = {
+            f"k_{int(k * 100)}pct": averaging_math(
+                cost_basis=cost_basis,
+                average_price=average_price,
+                current_price=close,
+                k=k,
+            )
+            for k in AVERAGING_K_LEVELS
+        }
+        loss_guard_floor = average_price * LOSS_GUARD_MULTIPLIER
+        position_alert_price = average_price * (Decimal(1) + POSITION_ALERT_PCT)
+        tolerance_alerts["position_minus_30pct"] = {
+            "threshold_price": position_alert_price,
+            "distance_pct": support_distance(position_alert_price, close),
+        }
+        underwater_sessions = {
+            "available": True,
+            "sessions_within_lookback": _underwater_sessions_within_lookback(
+                closes=closes, average_price=average_price
+            ),
+            "lookback_bars": len(closes),
+            "note": (
+                "arm-neutral post-fill close clock (D3 R1c semantics), capped "
+                "by the fetched candle lookback window, not the true cycle "
+                "start"
+            ),
+        }
+
+    invalidation_line = _select_invalidation_line(
+        watch_alerts_for_symbol, current_price=close
+    )
+
+    row: dict[str, Any] = {
+        "symbol": symbol,
+        "held": holding is not None,
+        "insufficient_history": False,
+        "bars_used": len(closes),
+        "previous_close": close,
+        "rsi": signal.rsi,
+        "bollinger_bands": {
+            "lower": signal.bb_lower,
+            "middle": signal.bb_middle,
+            "upper": signal.bb_upper,
+        },
+        "fib_window": {"low": signal.fib_window_low, "high": signal.fib_window_high},
+        "A_buy_side": {
+            "support_levels": [_cluster_view_row(c) for c in signal.support_clusters],
+            "buy_l1": {
+                "price": signal.buy_l1,
+                "basis": "t_minus_1_close_x_0.97_tick_aligned",
+            },
+            "buy_l2": (
+                {"price": signal.buy_l2, "basis": signal.buy_l2_source}
+                if signal.buy_l2 is not None
+                else None
+            ),
+            "nearest_support_distance_pct": nearest_support_distance_pct,
+            "deep_band": deep_band,
+            "averaging_math": averaging,
+            "sizing_band": {
+                "new_entry_notional_usd": US_NEW_ENTRY_NOTIONAL_USD,
+                "new_entry_notional_usd_min": US_NEW_ENTRY_NOTIONAL_USD_MIN,
+                "new_entry_notional_usd_max": US_NEW_ENTRY_NOTIONAL_USD_MAX,
+                "account_mode": ALPACA_ACCOUNT_MODE,
+            },
+        },
+        "B_sell_side": {
+            "label": "SELL_SIDE_MODEL_MISMATCH",
+            "resistance_levels": [
+                _cluster_view_row(c) for c in signal.resistance_clusters_above_close
+            ],
+            "sell_r1": signal.sell_r1,
+            "sell_r2": signal.sell_r2,
+            "loss_guard_floor": loss_guard_floor,
+        },
+        "C_diagnostics": {
+            "underwater_sessions": underwater_sessions,
+            "manual_add_count": manual_add_count,
+            "invalidation_line": invalidation_line,
+            "tolerance_alerts": tolerance_alerts,
+        },
+        "D_context": {
+            "market_cap": (
+                Decimal(pool_row["market_cap"])
+                if pool_row and pool_row.get("market_cap")
+                else None
+            ),
+            "market_cap_source": pool_row.get("market_cap_source")
+            if pool_row
+            else None,
+            "daily_turnover": (
+                Decimal(pool_row["daily_turnover"])
+                if pool_row and pool_row.get("daily_turnover")
+                else None
+            ),
+            "is_common_stock": pool_row.get("is_common_stock") if pool_row else None,
+            "exchange": pool_row.get("exchange") if pool_row else None,
+            "in_filtered_snapshot_pool": pool_row is not None
+            and _passes_liquidity_filter(pool_row),
+        },
+    }
+    return row
+
+
+def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
+    """Pure: build the full policy_table.v1 payload from RawInputs."""
+
+    tick_table = build_us_equity_tick_table()
+
+    holdings_by_symbol = {row["symbol"]: row for row in raw.holdings}
+    alerts_by_symbol: dict[str, list[dict[str, Any]]] = {}
+    for alert in raw.watch_alerts:
+        alerts_by_symbol.setdefault(alert["symbol"], []).append(alert)
+    pool_by_symbol = {row["symbol"]: row for row in raw.universe_pool}
+    filtered_symbols = {
+        symbol
+        for symbol, row in pool_by_symbol.items()
+        if _passes_liquidity_filter(row)
+    }
+
+    rows: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for symbol in raw.universe_symbols:
+        bars = raw.candles.get(symbol, [])
+        closes = [Decimal(bar[0]) for bar in bars]
+        highs = [Decimal(bar[1]) for bar in bars]
+        lows = [Decimal(bar[2]) for bar in bars]
+        row = _build_row(
+            symbol=symbol,
+            closes=closes,
+            highs=highs,
+            lows=lows,
+            tick_table=tick_table,
+            holding=holdings_by_symbol.get(symbol),
+            watch_alerts_for_symbol=alerts_by_symbol.get(symbol, []),
+            pool_row=pool_by_symbol.get(symbol),
+        )
+        rows.append(row)
+        if row["insufficient_history"]:
+            reason = (
+                "no_candles_in_db"
+                if row["bars_available"] == 0
+                else "insufficient_history_lt_120_sessions"
+            )
+            skipped.append(
+                {
+                    "symbol": symbol,
+                    "reason": reason,
+                    "bars_available": row["bars_available"],
+                }
+            )
+
+    payload: dict[str, Any] = {
+        "schema": "policy_table.v1",
+        "market": MARKET,
+        "generated_at": raw.as_of,
+        "trust_labels": list(US_TRUST_LABELS),
+        "config": {
+            "quote_currency": QUOTE_CURRENCY,
+            "candle_granularity": CANDLE_GRANULARITY,
+            "candle_lookback_bars": CANDLE_LOOKBACK_BARS,
+            "candle_source": (
+                "db_daily_candles(us_candles_1d, partition=exchange from "
+                "us_symbol_universe) — no live fetch"
+            ),
+            "tick_source": TICK_SOURCE,
+            "account_mode": ALPACA_ACCOUNT_MODE,
+            "b0x_labels": [
+                "B0_UNVALIDATED",
+                "SELL_SIDE_MODEL_MISMATCH",
+                "FIDELITY_INCONCLUSIVE_COVERAGE",
+                "CROSS_MARKET_TRANSFER_UNVALIDATED",
+            ],
+            "d3_constants": D3_CONSTANTS_ECHO,
+            "deep_band_pct": {
+                "lower": DEEP_BAND_LOWER_PCT,
+                "upper": DEEP_BAND_UPPER_PCT,
+            },
+            "position_alert_pct": POSITION_ALERT_PCT,
+            "loss_guard_multiplier": LOSS_GUARD_MULTIPLIER,
+            "averaging_k_levels": list(AVERAGING_K_LEVELS),
+            "new_entry_notional_usd": US_NEW_ENTRY_NOTIONAL_USD,
+            "new_entry_notional_usd_min": US_NEW_ENTRY_NOTIONAL_USD_MIN,
+            "new_entry_notional_usd_max": US_NEW_ENTRY_NOTIONAL_USD_MAX,
+            "universe_filter": {
+                "min_market_cap_usd": MIN_MARKET_CAP_USD,
+                "min_turnover_usd": MIN_TURNOVER_USD,
+                "require_is_common_stock_true": True,
+                "market_cap_sources": [
+                    "invest_screener_snapshots.market_cap (if non-null)",
+                    f"market_valuation_snapshots source={US_VALUATION_MARKET_CAP_SOURCE}",
+                ],
+                "quality_floor_reused": (
+                    "app.services.invest_view_model.us_quality_guards."
+                    "US_MIN_MARKET_CAP_USD"
+                ),
+            },
+            "market_cap_fill_stats": raw.market_cap_fill_stats,
+        },
+        "universe": {
+            "holdings": sorted(holdings_by_symbol.keys()),
+            "watch": sorted(alerts_by_symbol.keys()),
+            "snapshot_partition_date": raw.snapshot_partition_date,
+            "snapshot_total_symbols": len(pool_by_symbol),
+            "filter_passed_symbols": len(filtered_symbols),
+            "attempted_symbols": len(raw.universe_symbols),
+            "computed_symbols": len(raw.universe_symbols) - len(skipped),
+            "skipped": skipped,
+        },
+        "market_context": {
+            "snapshot_breadth": raw.snapshot_breadth,
+        },
+        "rows": rows,
+    }
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Human-readable summary — blend ranking is display-only (design doc §2).
+# ---------------------------------------------------------------------------
+
+BLEND_WEIGHT_RSI = 0.4
+BLEND_WEIGHT_SUPPORT = 0.4
+BLEND_WEIGHT_TURNOVER = 0.2
+
+
+def _blend_rank(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    eligible = [row for row in payload["rows"] if not row["insufficient_history"]]
+
+    def rsi_key(row: dict[str, Any]) -> float:
+        rsi = row.get("rsi")
+        return float(rsi) if rsi is not None else 100.0
+
+    def support_key(row: dict[str, Any]) -> float:
+        dist = row["A_buy_side"].get("nearest_support_distance_pct")
+        return abs(float(dist)) if dist is not None else 1.0
+
+    def turnover_key(row: dict[str, Any]) -> float:
+        turnover = row.get("D_context", {}).get("daily_turnover")
+        return -float(turnover) if turnover is not None else 0.0
+
+    def rank_index(key_fn: Any) -> dict[str, int]:
+        ordered = sorted(eligible, key=key_fn)
+        return {row["symbol"]: i for i, row in enumerate(ordered)}
+
+    rsi_rank = rank_index(rsi_key)
+    support_rank = rank_index(support_key)
+    turnover_rank = rank_index(turnover_key)
+
+    def blend_score(row: dict[str, Any]) -> float:
+        symbol = row["symbol"]
+        return (
+            BLEND_WEIGHT_RSI * rsi_rank[symbol]
+            + BLEND_WEIGHT_SUPPORT * support_rank[symbol]
+            + BLEND_WEIGHT_TURNOVER * turnover_rank[symbol]
+        )
+
+    return sorted(eligible, key=blend_score)
+
+
+def render_summary_md(payload: dict[str, Any], *, top_n: int = 50) -> str:
+    lines: list[str] = []
+    lines.append(f"# Policy Table — {payload['market']} — {payload['generated_at']}")
+    lines.append("")
+    for label in payload["trust_labels"]:
+        lines.append(f"> {label}")
+    lines.append("")
+
+    u = payload["universe"]
+    lines.append(
+        f"universe: snapshot_total={u['snapshot_total_symbols']} -> "
+        f"filter_passed={u['filter_passed_symbols']} -> "
+        f"attempted={u['attempted_symbols']} -> "
+        f"computed={u['computed_symbols']} "
+        f"(holdings={len(u['holdings'])}, watch={len(u['watch'])}, "
+        f"snapshot_partition_date={u['snapshot_partition_date']})"
+    )
+    if u["skipped"]:
+        by_reason: dict[str, int] = {}
+        for s in u["skipped"]:
+            by_reason[s["reason"]] = by_reason.get(s["reason"], 0) + 1
+        reason_str = ", ".join(f"{k}={v}" for k, v in sorted(by_reason.items()))
+        lines.append(f"skipped: {len(u['skipped'])} ({reason_str})")
+    fill = payload.get("config", {}).get("market_cap_fill_stats") or {}
+    if fill:
+        lines.append(
+            "market_cap_fill: "
+            f"snapshot_non_null={fill.get('snapshot_market_cap_non_null')} / "
+            f"total={fill.get('snapshot_total')}; "
+            f"yahoo_fallback_used={fill.get('valuation_yahoo_fallback_used')}; "
+            f"missing={fill.get('market_cap_missing')}"
+        )
+    lines.append("")
+
+    breadth = payload["market_context"].get("snapshot_breadth")
+    if breadth and breadth.get("total"):
+        lines.append(
+            f"snapshot_breadth ({breadth.get('partition_date')}): "
+            f"{breadth['advancers']}/{breadth['total']} advancers, "
+            f"{breadth['decliners']}/{breadth['total']} decliners"
+        )
+    lines.append("")
+    lines.append(
+        f"blend ranking (display-only, weights: rsi={BLEND_WEIGHT_RSI} "
+        f"support={BLEND_WEIGHT_SUPPORT} turnover={BLEND_WEIGHT_TURNOVER})"
+    )
+    lines.append("")
+
+    ranked = _blend_rank(payload)
+    lines.append(
+        "| symbol | held | RSI | support_dist_pct | buy_l1 | buy_l2 | "
+        "sell_r1 | resistance_mismatch |"
+    )
+    lines.append("|---|---|---:|---:|---:|---:|---:|---|")
+    for row in ranked[:top_n]:
+        buy = row["A_buy_side"]
+        sell = row["B_sell_side"]
+        buy_l2 = buy["buy_l2"]["price"] if buy["buy_l2"] else "-"
+        dist = buy.get("nearest_support_distance_pct")
+        dist_str = dist if dist is not None else "-"
+        lines.append(
+            f"| {row['symbol']} | {'Y' if row['held'] else ''} | {row['rsi']} | "
+            f"{dist_str} | {buy['buy_l1']['price']} | {buy_l2} | "
+            f"{sell['sell_r1'] or '-'} | {sell['label']} |"
+        )
+    lines.append("")
+    lines.append(f"policy_table_hash: `{payload['stamps']['policy_table_hash']}`")
+    lines.append(f"auto_trader_head: `{payload['stamps']['auto_trader_head']}`")
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "MARKET",
+    "RawInputs",
+    "fetch_raw_inputs",
+    "compute_policy_table",
+    "render_summary_md",
+    "ALPACA_ACCOUNT_MODE",
+]

--- a/scripts/policy_table/adapters/us.py
+++ b/scripts/policy_table/adapters/us.py
@@ -45,6 +45,7 @@ from research.kr_corpus.d3_engine.models import Position
 from research.kr_corpus.d3_engine.policies import update_underwater_close
 from research.kr_corpus.d3_engine.signals import support_distance
 from scripts.policy_table.core.averaging import averaging_math
+from scripts.policy_table.core.max_table_age import max_table_age_stamp
 from scripts.policy_table.core.signal_math import (
     D3_CONSTANTS_ECHO,
     FIB_WINDOW,
@@ -725,6 +726,8 @@ def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
                 ),
             },
             "market_cap_fill_stats": raw.market_cap_fill_stats,
+            # Contract v1.1 §2-2 literal (US = 36h) — not a worker-chosen constant.
+            **max_table_age_stamp(MARKET),
         },
         "universe": {
             "holdings": sorted(holdings_by_symbol.keys()),

--- a/scripts/policy_table/core/max_table_age.py
+++ b/scripts/policy_table/core/max_table_age.py
@@ -1,0 +1,73 @@
+"""MAX_TABLE_AGE — B0-X experiment contract v1.1 §2-2 **literal** (not invented).
+
+Source of record
+----------------
+File: ``~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md``
+Contract sha256 (orch-measured 2026-08-08)::
+
+    97278b0e8b8000e2e663c936328686001af5850087897270bc80a95ebf8f6b2e
+
+§2-2 (verbatim, wrapped)::
+
+    표가 없거나 STALE 이거나 MAX_TABLE_AGE 초과면 그 사이클은 주문 0
+    (조용한 재사용·재계산 금지, 사유 기록).
+    MAX_TABLE_AGE (v1.1, 운영자 확정 2026-08-08): crypto 8h · KR 36h · US 36h
+    — X-C 검증 발 안전장치의 계약 승격, 3시장 공통 적용.
+
+Behavior when exceeded (order-cycle consumer, not this table generator):
+**that cycle emits zero orders**, records reason ``stale_by_age``, and must not
+quietly reuse or recompute the table.
+
+These hours are **not** worker-chosen. Do not change them without a contract
+revision that updates the sha256 above.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Final
+
+#: Contract citation stamped into every artifact / consumer path that uses the ages.
+CONTRACT_V11_SECTION_2_2: Final[str] = (
+    "b0x-experiment-contract-v1 §2-2 (v1.1, operator-confirmed 2026-08-08); "
+    "sha256:97278b0e8b8000e2e663c936328686001af5850087897270bc80a95ebf8f6b2e"
+)
+
+#: Hours by market — contract v1.1 §2-2 literal.
+MAX_TABLE_AGE_HOURS: Final[dict[str, int]] = {
+    "crypto": 8,
+    "kr": 36,
+    "us": 36,
+}
+
+#: Timedelta form used by the B0-X order-cycle table gate.
+MAX_TABLE_AGE: Final[dict[str, dt.timedelta]] = {
+    market: dt.timedelta(hours=hours) for market, hours in MAX_TABLE_AGE_HOURS.items()
+}
+
+
+def max_table_age_stamp(market: str) -> dict[str, str | int]:
+    """JSON-safe stamp for a policy_table.v1 ``config`` block."""
+
+    if market not in MAX_TABLE_AGE_HOURS:
+        raise KeyError(
+            f"MAX_TABLE_AGE not defined for market={market!r}; "
+            f"known={sorted(MAX_TABLE_AGE_HOURS)} ({CONTRACT_V11_SECTION_2_2})"
+        )
+    return {
+        "max_table_age_hours": MAX_TABLE_AGE_HOURS[market],
+        "max_table_age_source": CONTRACT_V11_SECTION_2_2,
+        "max_table_age_note": (
+            "Contract v1.1 §2-2: table missing / STALE marker / age > "
+            f"{MAX_TABLE_AGE_HOURS[market]}h → that order cycle emits 0 orders "
+            "(no quiet reuse/recompute). Consumer: scripts/b0x/table_source.py."
+        ),
+    }
+
+
+__all__ = [
+    "CONTRACT_V11_SECTION_2_2",
+    "MAX_TABLE_AGE",
+    "MAX_TABLE_AGE_HOURS",
+    "max_table_age_stamp",
+]

--- a/scripts/policy_table/core/trust_labels.py
+++ b/scripts/policy_table/core/trust_labels.py
@@ -5,6 +5,11 @@ Source of record: ~/work/herdr-inbox/rob1230-b0-policy-table-design-v1.md §0
 artifact carries all three, in this order, in its header. Never edit the
 wording here without updating the design doc first — the acceptance gate
 checks for exact-string presence (3/3).
+
+US (P-2-US / B0-X contract §1) additionally stamps
+``CROSS_MARKET_TRANSFER_UNVALIDATED`` — B0 was calibrated on KR scope; a US
+port is double-unvalidated. Crypto/KR adapters keep the original 3-label
+tuple; only the US adapter uses ``US_TRUST_LABELS``.
 """
 
 from __future__ import annotations
@@ -23,4 +28,18 @@ TRUST_LABELS: tuple[str, str, str] = (
     ),
 )
 
-__all__ = ["TRUST_LABELS"]
+# B0-X experiment contract §1 + design inheritance for US port.
+CROSS_MARKET_TRANSFER_UNVALIDATED = (
+    "CROSS_MARKET_TRANSFER_UNVALIDATED — B0 는 KR 스코프 계량 — US 이식은 이중 미검증."
+)
+
+US_TRUST_LABELS: tuple[str, str, str, str] = (
+    *TRUST_LABELS,
+    CROSS_MARKET_TRANSFER_UNVALIDATED,
+)
+
+__all__ = [
+    "TRUST_LABELS",
+    "CROSS_MARKET_TRANSFER_UNVALIDATED",
+    "US_TRUST_LABELS",
+]

--- a/scripts/policy_table/core/us_tick.py
+++ b/scripts/policy_table/core/us_tick.py
@@ -1,0 +1,51 @@
+"""US listed-equity tick-size table, expressed as a D3-engine ``TickTable``.
+
+US equities do not have a KRX-style multi-band ladder. The live order path
+documents overseas pricing as "decimal USD (no tick table)"
+(``app/mcp_server/README.md`` comparison table). For policy_table alignment
+(buy L1 floor / sell-target minus one tick) the D3 ``TickTable`` container
+still needs an explicit ladder, so this module encodes the Reg NMS Rule 612
+minimum price variation for NMS stocks:
+
+* price < $1.00  → tick $0.0001
+* price ≥ $1.00  → tick $0.01
+
+Source of record for this job (P-2-US / U-1): SEC Rule 612 (minimum pricing
+increments) as the standard US listed-equity quoting floor used by broker
+limit-order paths. Sub-penny quoting exceptions for dark pools / retail are
+out of scope — advisory table alignment only.
+"""
+
+from __future__ import annotations
+
+from research.kr_corpus.d3_engine.tick import TickTable
+
+TICK_SOURCE = (
+    "SEC Rule 612 NMS minimum price variation "
+    "($0.0001 under $1 / $0.01 at-or-above $1) — "
+    "scripts/policy_table/core/us_tick.py (no runtime US tick helper in app/)"
+)
+
+
+def build_us_equity_tick_table() -> TickTable:
+    """Build a D3 ``TickTable`` for standard US listed equity quoting."""
+
+    return TickTable.from_mapping(
+        {
+            "bands": [
+                {
+                    "lower_inclusive": "0",
+                    "upper_exclusive": "1",
+                    "tick": "0.0001",
+                },
+                {
+                    "lower_inclusive": "1",
+                    "upper_exclusive": None,
+                    "tick": "0.01",
+                },
+            ]
+        }
+    )
+
+
+__all__ = ["build_us_equity_tick_table", "TICK_SOURCE"]

--- a/tests/scripts/b0x/test_table_gate.py
+++ b/tests/scripts/b0x/test_table_gate.py
@@ -98,6 +98,55 @@ def test_table_exactly_at_max_age_still_passes(tmp_path: Path) -> None:
     )
 
 
+def test_max_table_age_is_contract_v11_literal() -> None:
+    """Contract v1.1 §2-2: crypto 8h · KR 36h · US 36h — not worker-chosen."""
+
+    assert MAX_TABLE_AGE["crypto"] == dt.timedelta(hours=8)
+    assert MAX_TABLE_AGE["kr"] == dt.timedelta(hours=36)
+    assert MAX_TABLE_AGE["us"] == dt.timedelta(hours=36)
+
+
+def test_us_table_older_than_36h_is_stale(tmp_path: Path) -> None:
+    """US order-cycle gate uses contract 36h (not crypto's 8h)."""
+
+    payload = make_payload(
+        rows=[
+            make_row(
+                symbol="AAPL",
+                previous_close="100",
+                buy_l1="97",
+                sell_r1="103",
+            )
+        ],
+        generated_at=NOW - MAX_TABLE_AGE["us"] - dt.timedelta(minutes=1),
+        market="us",
+    )
+    write_table(tmp_path, payload, market="us")
+    result = load_policy_table(market="us", now=NOW, table_dir=tmp_path)
+    assert isinstance(result, TableUnavailable)
+    assert result.reason == TableReason.STALE_BY_AGE
+    assert "v1.1" in result.detail or "§2-2" in result.detail or "36" in result.detail
+
+
+def test_us_table_at_exactly_36h_still_passes(tmp_path: Path) -> None:
+    payload = make_payload(
+        rows=[
+            make_row(
+                symbol="AAPL",
+                previous_close="100",
+                buy_l1="97",
+                sell_r1="103",
+            )
+        ],
+        generated_at=NOW - MAX_TABLE_AGE["us"],
+        market="us",
+    )
+    write_table(tmp_path, payload, market="us")
+    assert isinstance(
+        load_policy_table(market="us", now=NOW, table_dir=tmp_path), PolicyTable
+    )
+
+
 def test_future_stamped_table_is_refused(tmp_path: Path) -> None:
     write_table(tmp_path, _good_payload(generated_at=NOW + dt.timedelta(hours=3)))
     result = load_policy_table(market="crypto", now=NOW, table_dir=tmp_path)

--- a/tests/scripts/test_policy_table_us.py
+++ b/tests/scripts/test_policy_table_us.py
@@ -1,0 +1,318 @@
+"""Unit tests for ROB-1230 P-2-US / B0-X U-1 policy_table US adapter.
+
+Pure-compute path only (no DB/network). Covers labels, tick, determinism,
+D3 engine parity, and sell-side MISMATCH stamping.
+"""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from research.kr_corpus.d3_engine.indicators import (
+    OhlcPoint,
+    bollinger_bands,
+    rsi_wilder,
+    scan_fib_window,
+)
+from research.kr_corpus.d3_engine.tick import TickTable
+from scripts.policy_table.adapters import us as us_adapter
+from scripts.policy_table.core.schema import (
+    canonical_json_bytes,
+    compute_policy_table_hash,
+)
+from scripts.policy_table.core.signal_math import FIB_WINDOW, compute_symbol_signal
+from scripts.policy_table.core.trust_labels import (
+    CROSS_MARKET_TRANSFER_UNVALIDATED,
+    TRUST_LABELS,
+    US_TRUST_LABELS,
+)
+from scripts.policy_table.core.us_tick import TICK_SOURCE, build_us_equity_tick_table
+
+
+def _synthetic_bars(
+    n: int = 150, *, start: Decimal = Decimal("100")
+) -> list[list[str]]:
+    """Ascending OHLC with mild trend — enough history for fib 120."""
+
+    bars: list[list[str]] = []
+    price = start
+    for i in range(n):
+        # Deterministic mild oscillation so BB/RSI are well-defined.
+        delta = Decimal("0.5") if i % 5 else Decimal("-0.3")
+        close = (price + delta).quantize(Decimal("0.01"))
+        high = (close + Decimal("1.00")).quantize(Decimal("0.01"))
+        low = (close - Decimal("1.00")).quantize(Decimal("0.01"))
+        bars.append([str(close), str(high), str(low)])
+        price = close
+    return bars
+
+
+def _sample_raw(*, bars: list[list[str]] | None = None) -> us_adapter.RawInputs:
+    bars = bars if bars is not None else _synthetic_bars()
+    return us_adapter.RawInputs(
+        as_of="2026-08-08T12:00:00+00:00",
+        holdings=[
+            {
+                "symbol": "AAPL",
+                "quantity": "10",
+                "average_price": "150.00",
+            }
+        ],
+        watch_alerts=[],
+        universe_pool=[
+            {
+                "symbol": "AAPL",
+                "latest_close": bars[-1][0],
+                "market_cap": "3000000000000",
+                "market_cap_source": "market_valuation_snapshots:yahoo",
+                "daily_turnover": "5000000000",
+                "daily_volume": "50000000",
+                "snapshot_date": "2026-08-07",
+                "exchange": "NASD",
+                "is_common_stock": True,
+            },
+            {
+                "symbol": "TINY",
+                "latest_close": "2.00",
+                "market_cap": "1000000",  # below $100M floor
+                "market_cap_source": "market_valuation_snapshots:yahoo",
+                "daily_turnover": "5000",
+                "daily_volume": "2500",
+                "snapshot_date": "2026-08-07",
+                "exchange": "NASD",
+                "is_common_stock": True,
+            },
+            {
+                "symbol": "PREF",
+                "latest_close": "25.00",
+                "market_cap": "500000000",
+                "market_cap_source": "market_valuation_snapshots:yahoo",
+                "daily_turnover": "2000000",
+                "daily_volume": "80000",
+                "snapshot_date": "2026-08-07",
+                "exchange": "NYSE",
+                "is_common_stock": False,  # preferred — filter out
+            },
+        ],
+        snapshot_partition_date="2026-08-07",
+        snapshot_breadth={
+            "total": 3,
+            "advancers": 1,
+            "decliners": 1,
+            "unchanged": 1,
+            "partition_date": "2026-08-07",
+        },
+        # filter_passed(AAPL) ∪ holdings(AAPL) — TINY/PREF excluded by filter
+        universe_symbols=["AAPL"],
+        candles={"AAPL": bars},
+        market_cap_fill_stats={
+            "snapshot_total": 3,
+            "snapshot_market_cap_non_null": 0,
+            "valuation_yahoo_fallback_used": 3,
+            "market_cap_missing": 0,
+            "note": "unit-test fixture",
+        },
+    )
+
+
+@pytest.mark.unit
+def test_us_trust_labels_are_four_including_cross_market() -> None:
+    assert len(US_TRUST_LABELS) == 4
+    assert US_TRUST_LABELS[:3] == TRUST_LABELS
+    assert US_TRUST_LABELS[3] == CROSS_MARKET_TRANSFER_UNVALIDATED
+    assert "CROSS_MARKET_TRANSFER_UNVALIDATED" in US_TRUST_LABELS[3]
+    payload = us_adapter.compute_policy_table(_sample_raw())
+    assert payload["trust_labels"] == list(US_TRUST_LABELS)
+    assert payload["config"]["b0x_labels"] == [
+        "B0_UNVALIDATED",
+        "SELL_SIDE_MODEL_MISMATCH",
+        "FIDELITY_INCONCLUSIVE_COVERAGE",
+        "CROSS_MARKET_TRANSFER_UNVALIDATED",
+    ]
+
+
+@pytest.mark.unit
+def test_us_tick_table_reg_nms_rule_612() -> None:
+    table = build_us_equity_tick_table()
+    assert isinstance(table, TickTable)
+    assert table.align_buy(Decimal("10.234")) == Decimal("10.23")
+    assert table.align_sell(Decimal("10.231")) == Decimal("10.24")
+    assert table.align_buy(Decimal("0.55555")) == Decimal("0.5555")
+    assert "Rule 612" in TICK_SOURCE or "0.01" in TICK_SOURCE
+
+
+@pytest.mark.unit
+def test_sell_side_mismatch_label_per_computed_row() -> None:
+    payload = us_adapter.compute_policy_table(_sample_raw())
+    computed = [r for r in payload["rows"] if not r["insufficient_history"]]
+    assert computed
+    for row in computed:
+        assert row["B_sell_side"]["label"] == "SELL_SIDE_MODEL_MISMATCH"
+
+
+@pytest.mark.unit
+def test_filter_counts_and_skipped_reasons() -> None:
+    # AAPL has history; add a symbol with no candles to force skip accounting.
+    raw = _sample_raw()
+    raw = us_adapter.RawInputs(
+        as_of=raw.as_of,
+        holdings=raw.holdings,
+        watch_alerts=raw.watch_alerts,
+        universe_pool=raw.universe_pool,
+        snapshot_partition_date=raw.snapshot_partition_date,
+        snapshot_breadth=raw.snapshot_breadth,
+        universe_symbols=["AAPL", "NEWIPO"],
+        candles=raw.candles,  # NEWIPO absent → no candles
+        market_cap_fill_stats=raw.market_cap_fill_stats,
+    )
+    payload = us_adapter.compute_policy_table(raw)
+    u = payload["universe"]
+    assert u["snapshot_total_symbols"] == 3
+    assert u["filter_passed_symbols"] == 1  # AAPL only
+    assert u["attempted_symbols"] == 2
+    assert u["computed_symbols"] == 1
+    assert any(s["reason"] == "no_candles_in_db" for s in u["skipped"])
+
+
+@pytest.mark.unit
+def test_compute_deterministic_two_runs() -> None:
+    raw = _sample_raw()
+    p1 = us_adapter.compute_policy_table(raw)
+    p1["stamps"] = {
+        "policy_table_hash": compute_policy_table_hash(p1),
+        "auto_trader_head": "test",
+        "indicator_code_commit": "test",
+        "engine_module_sha256": {},
+        "input_as_of": p1["generated_at"],
+    }
+    p2 = us_adapter.compute_policy_table(raw)
+    p2["stamps"] = {
+        "policy_table_hash": compute_policy_table_hash(p2),
+        "auto_trader_head": "test",
+        "indicator_code_commit": "test",
+        "engine_module_sha256": {},
+        "input_as_of": p2["generated_at"],
+    }
+    b1 = canonical_json_bytes(p1)
+    b2 = canonical_json_bytes(p2)
+    assert b1 == b2
+    assert p1["stamps"]["policy_table_hash"] == p2["stamps"]["policy_table_hash"]
+
+
+@pytest.mark.unit
+def test_engine_match_rsi_bb_buy_l1() -> None:
+    """Table row values match a direct D3-engine call on the same bars."""
+
+    bars = _synthetic_bars(150)
+    closes = [Decimal(b[0]) for b in bars]
+    highs = [Decimal(b[1]) for b in bars]
+    lows = [Decimal(b[2]) for b in bars]
+    tick = build_us_equity_tick_table()
+    signal = compute_symbol_signal(
+        closes=closes, highs=highs, lows=lows, tick_table=tick
+    )
+
+    # Direct D3 pieces (same as signal_math).
+    points = [
+        OhlcPoint(high=highs[i], low=lows[i], close=closes[i])
+        for i in range(len(closes))
+    ]
+    points.append(points[-1])
+    window = scan_fib_window(points, decision_index=len(closes))
+    rsi_series = rsi_wilder(closes, period=14)
+    bands = bollinger_bands(closes, window=20, sigma=Decimal("2"))
+    expected_buy_l1 = tick.align_buy(closes[-1] * Decimal("0.97"))
+
+    assert signal.rsi == (
+        rsi_series[-1].quantize(Decimal("0.0001"))
+        if rsi_series[-1] is not None
+        else None
+    )
+    assert signal.bb_lower == bands.lower
+    assert signal.bb_upper == bands.upper
+    assert signal.fib_window_low == window.low
+    assert signal.fib_window_high == window.high
+    assert signal.buy_l1 == expected_buy_l1
+
+    raw = _sample_raw(bars=bars)
+    payload = us_adapter.compute_policy_table(raw)
+    row = next(r for r in payload["rows"] if r["symbol"] == "AAPL")
+    assert row["insufficient_history"] is False
+    assert row["rsi"] == signal.rsi
+    assert row["bollinger_bands"]["lower"] == signal.bb_lower
+    assert row["A_buy_side"]["buy_l1"]["price"] == signal.buy_l1
+    assert row["bars_used"] >= FIB_WINDOW
+
+
+@pytest.mark.unit
+def test_insufficient_history_is_explicit_not_silent_fill() -> None:
+    short = _synthetic_bars(50)
+    raw = _sample_raw(bars=short)
+    payload = us_adapter.compute_policy_table(raw)
+    row = payload["rows"][0]
+    assert row["insufficient_history"] is True
+    assert row["bars_available"] == 50
+    assert row["bars_required"] == 120
+    assert payload["universe"]["skipped"][0]["reason"] == (
+        "insufficient_history_lt_120_sessions"
+    )
+
+
+@pytest.mark.unit
+def test_alpaca_account_mode_is_lab_not_default_paper() -> None:
+    assert us_adapter.ALPACA_ACCOUNT_MODE == "alpaca_paper_lab"
+    payload = us_adapter.compute_policy_table(_sample_raw())
+    assert payload["config"]["account_mode"] == "alpaca_paper_lab"
+    row = next(r for r in payload["rows"] if not r["insufficient_history"])
+    assert row["A_buy_side"]["sizing_band"]["account_mode"] == "alpaca_paper_lab"
+
+
+@pytest.mark.unit
+def test_no_order_tool_imports_in_policy_table_tree() -> None:
+    """Static AST: scripts/policy_table must not import order placement modules."""
+
+    root = Path("scripts/policy_table")
+    forbidden_substrings = (
+        "orders",
+        "order_execution",
+        "place_order",
+        "submit_order",
+        "DomesticOrderClient",
+        "OverseasOrderClient",
+    )
+    offenders: list[str] = []
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    name = alias.name
+                    if any(f in name for f in forbidden_substrings):
+                        offenders.append(f"{path}:{name}")
+            elif isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if any(f in mod for f in forbidden_substrings):
+                    offenders.append(f"{path}:{mod}")
+                for alias in node.names:
+                    if any(f in alias.name for f in forbidden_substrings):
+                        offenders.append(f"{path}:{mod}.{alias.name}")
+    assert offenders == []
+
+
+@pytest.mark.unit
+def test_summary_md_includes_four_labels_and_universe_funnel() -> None:
+    payload = us_adapter.compute_policy_table(_sample_raw())
+    payload["stamps"] = {
+        "policy_table_hash": "sha256:test",
+        "auto_trader_head": "deadbeef",
+    }
+    md = us_adapter.render_summary_md(payload, top_n=10)
+    assert "CROSS_MARKET_TRANSFER_UNVALIDATED" in md
+    assert "B0_UNVALIDATED" in md
+    assert "snapshot_total=" in md
+    assert "filter_passed=" in md
+    assert "computed=" in md

--- a/tests/scripts/test_policy_table_us.py
+++ b/tests/scripts/test_policy_table_us.py
@@ -120,6 +120,23 @@ def _sample_raw(*, bars: list[list[str]] | None = None) -> us_adapter.RawInputs:
 
 
 @pytest.mark.unit
+def test_us_max_table_age_stamp_is_contract_v11_36h() -> None:
+    """US table stamps MAX_TABLE_AGE=36h from contract v1.1 §2-2 (not invented)."""
+
+    from scripts.policy_table.core.max_table_age import (
+        CONTRACT_V11_SECTION_2_2,
+        MAX_TABLE_AGE_HOURS,
+    )
+
+    assert MAX_TABLE_AGE_HOURS["us"] == 36
+    payload = us_adapter.compute_policy_table(_sample_raw())
+    assert payload["config"]["max_table_age_hours"] == 36
+    assert payload["config"]["max_table_age_source"] == CONTRACT_V11_SECTION_2_2
+    assert "§2-2" in payload["config"]["max_table_age_source"]
+    assert "97278b0e" in payload["config"]["max_table_age_source"]
+
+
+@pytest.mark.unit
 def test_us_trust_labels_are_four_including_cross_market() -> None:
     assert len(US_TRUST_LABELS) == 4
     assert US_TRUST_LABELS[:3] == TRUST_LABELS


### PR DESCRIPTION
## Summary

- Adds the **US equities** market adapter for ROB-1230 / B0-X **U-1** (policy table only — **U-2 order adapter not started**).
- Shared P-1/P-2 core reused as-is (`signal_math` / `averaging` / `schema` / D3 engine). **No reimplementation** of fib/BB/RSI.
- New code only: `scripts/policy_table/adapters/us.py`, `scripts/policy_table/core/us_tick.py`, additive `US_TRUST_LABELS`, CLI `--market us`, unit tests.

### Account map (read-only gate, pre-code)

| Check | Result |
|---|---|
| operator `local==origin/main` | `7f95897` |
| US account | **`alpaca_paper_lab`** (map canonical; not `alpaca_paper` / a6445d) |
| B0-X order exception | 3 surfaces including `alpaca_paper_lab` |
| Envelope | contract §4 US column (sizing band $150–450 stamped; no orders in U-1) |

### Labels (4/4 header + per-row sell)

`B0_UNVALIDATED` · `SELL_SIDE_MODEL_MISMATCH` · `FIDELITY_INCONCLUSIVE_COVERAGE` · **`CROSS_MARKET_TRANSFER_UNVALIDATED`**

Per computed row: `B_sell_side.label = SELL_SIDE_MODEL_MISMATCH` (observation target, not a bug).

### Data / filter

- Universe source: `invest_screener_snapshots(market='us')` full partition
- Filter: `is_common_stock is True` + `market_cap ≥ $100M` (`US_MIN_MARKET_CAP_USD` reused) + `daily_turnover ≥ $1M`
- Market cap join order: snapshot column if non-null → else `market_valuation_snapshots` (`market=us`, `source=yahoo`). Fill stats stamped in `config.market_cap_fill_stats` (builder does not write market_cap).
- Candles: `us_candles_1d` via exchange partition from `us_symbol_universe` (DB only; no live Yahoo fetch)
- Holdings: **read-only** `AlpacaPaperBrokerService(profile="lab").list_positions()` — never default `alpaca_paper`
- History < 120 sessions → explicit `skipped` reason (no silent fill)

### Tick

`us_tick.py` — SEC Rule 612 NMS MPV ($0.0001 under $1 / $0.01 ≥ $1) as D3 `TickTable` (no app runtime US tick helper).

### Verified

```
uv run pytest tests/scripts/test_policy_table_us.py -v   # 10 passed
uv run ruff check / format — clean
uv run ty check (changed modules) — All checks passed
CLI replay ×2 byte-identical policy_table_hash
sha256:335996c700a746a73bce126ed54784b608126602cdadfe9dad6c99d0f4bc5a96
```

- Engine match unit: RSI/BB/fib/buy_l1 vs direct D3 call
- AST: zero order-tool imports under `scripts/policy_table/`

### Not in scope

- U-2 Alpaca order adapter
- live accounts / real orders
- scheduler registration
- CR-S1 / D2/D3 / scoring / merge
- operator prompt contract (P-3)
- self-spawned verifier (`NEEDS_VERIFY` for orch)

### Live prod artifact

Local `DATABASE_URL` hosts empty screener tables (0 US rows). Operator should run against the real DB:

```bash
uv run python -m scripts.build_policy_table --market us
# → ~/services/auto_trader-operator/policy-tables/<ts>-us.json + latest-us.json
```

## Test plan

- [x] Unit tests (labels, tick, determinism, engine match, skip reasons, no order imports)
- [x] Ruff + ty on changed paths
- [x] CLI `--replay-raw` two-run byte identity
- [ ] Independent orch verification (`NEEDS_VERIFY`)
- [ ] Operator DB live build (empty locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating US equities policy tables.
  * Added market data analysis, technical signals, valuation metrics, risk diagnostics, and market context.
  * Added US-specific trust labels and SEC Rule 612-aligned pricing increments.
  * Added Markdown summaries with universe statistics, breadth, rankings, and skipped-symbol reporting.

* **Bug Fixes**
  * Enforced market-specific table-age limits and rejected stale or unknown-market tables.

* **Tests**
  * Added coverage for deterministic results, filtering, indicators, trust labels, pricing alignment, table freshness, and summary output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->