### PR TITLE
fix(b0x): dust-aware contamination gate — B0-X crypto sidecar arm 해소 (X-S2)

### DIFF
--- a/docs/runbooks/b0x-crypto-cycle.md
+++ b/docs/runbooks/b0x-crypto-cycle.md
@@ -145,7 +145,8 @@ writer lock → 표 게이트 → 계좌 상태 → kill switch → 파생 → �
 
 - [ ] `mock/CLAUDE.md` §1 Binance Demo 행이 여전히 B0-X 사이드카를 가리킨다
 - [ ] **CR-S1 TPR 이 재개되지 않았다** — 재개 시 TPR 우선권 (별개 계약)
-- [ ] fresh truth 가 `contaminated: false` — 공유 Demo 계정에 다른 writer 의 미체결/잔고 없음
+- [ ] fresh truth 가 `contaminated: false` — 공유 Demo 계정에 다른 writer 의 미체결/**매도
+      가능** 잔고 없음 (거래단위 미만 dust 는 예외 — §8-1)
 - [ ] dry-run 사이클의 `planned` 를 눈으로 검토했다 (심볼 3종 · notional ≤ 10 USDT)
 - [ ] 표가 fresh 하다 (`policy_table_age_seconds` 확인)
 
@@ -159,8 +160,26 @@ writer lock → 표 게이트 → 계좌 상태 → kill switch → 파생 → �
 - `writer_lock` — B0-X **프로세스 두 개**가 같은 레인을 동시에 파생하지 못한다
   (`flock`, non-blocking, 두 번째는 즉시 실패).
 - `foreign_*` — B0-X 가 만들지 않은 **베뉴 상태**. `clientOrderId` 가 `b0xc-` 로 시작하지
-  않는 미체결, 또는 0 이 아닌 base 자산 잔고가 있으면 그 사이클은 `CONTAMINATED` 이며
+  않는 미체결, 또는 **매도 가능한** base 자산 잔고가 있으면 그 사이클은 `CONTAMINATED` 이며
   관측은 계속하되 제출은 막힌다.
+
+### 8-1. dust 예외 — 계약 v1.2 (2026-08-08)
+
+잔고 판정 기준은 **"0 이 아니다"** 가 아니라 **"floor(LOT_SIZE) 후 매도 가능 수량 > 0"**
+이다 (`sidecar.sellable_qty`). 최소 거래단위(`LOT_SIZE.minQty`) 미만 잔고는 floor 후 정확히
+0 이 되어 **어떤 가격으로도 주문을 구성할 수 없다** — 청산도, 캡 우회도 불가능하다.
+
+🔴 **MIN_NOTIONAL 로 확대하지 말 것.** 이 3종의 MIN_NOTIONAL 은 5 USDT 로 §4 주문 캡
+(10 USDT) 과 같은 자릿수다. notional 기준 dust 판정은 **이 레인 자기 주문만 한 외부 재고를
+통과시키는 게이트**가 된다. 규칙은 "팔 수 없으니까 dust" 이지 "작으니까 dust" 가 아니다.
+`spot_demo.sizing.compute_close_qty` 와 `portfolio_overview_service` 는 같은 단어를 더 넓은
+뜻(= MIN_NOTIONAL 미만)으로 쓰므로 **여기서 재사용 금지**.
+
+경위: X-S(2026-08-08)가 ROB-298/ROB-307 왕복이 남긴 BTC `0.00000972`(minQty `0.00001`)·
+SOL `0.00094600`(minQty `0.001`)을 실측했다. 청산이 물리적으로 불가능한데 오염 판정은
+이를 봐준 적이 없어 `SIDECAR_ARMED=YES` 가 **영구 도달 불가**였다. 계약 v1.2 가 판정을
+정합 수정했다. dust 는 숨겨지지 않는다 — 관측 기록의
+`base_assets_with_nonzero_balance` 에 그대로 남고, `foreign_base_assets` 에서만 빠진다.
 
 다른 전략의 미체결은 **취소하지 않는다** (mock/CLAUDE.md §4). kill 시에도 `b0xc-` 접두
 주문만 취소한다.
@@ -177,7 +196,8 @@ writer lock → 표 게이트 → 계좌 상태 → kill switch → 파생 → �
 - **가상 시드 잔고 100만 KRW** (`SEED_CASH_KRW`) 는 계약 숫자가 아니라 가상 장부에 경계를
   주기 위한 고정값이다. 모든 산출물에 박제된다.
 - 🔴 **사이드카 v1 은 체결을 귀속 장부에 reconcile 하지 않는다.** B0-X 장부가 비어 있으므로
-  *어떤* base 잔고도 `foreign` 으로 읽히며, **B0-X 자기 체결이 만든 잔고도 그렇다.**
+  *매도 가능한* base 잔고는 전부 `foreign` 으로 읽히며, **B0-X 자기 체결이 만든 잔고도
+  그렇다** (§8-1 dust 예외는 이를 완화하지 않는다 — 체결된 주문은 정의상 minQty 이상이다).
   결과적으로 첫 체결 다음 사이클은 `CONTAMINATED` 로 제출을 거부한다 —
   **운영자 개입 1회당 왕복 1회**가 v1 의 실질 처리량이다.
   과보수적이지만 방향은 옳다: 귀속 안 된 잔고를 "내 것 아님, 계속 진행" 으로 처리하면

--- a/scripts/b0x/crypto/sidecar.py
+++ b/scripts/b0x/crypto/sidecar.py
@@ -34,10 +34,13 @@ Fail-closed layers before any order can reach the venue
 2. ``assert_envelope_locked`` — §4 caps cannot have been widened.
 3. Symbol must be in :data:`B0X_SIDECAR_SYMBOLS` (3 entries, frozen).
 4. Host re-asserted on every public read as well as every signed call.
-5. Account-wide fresh truth: any balance or open order this lane did not
-   create marks the cycle ``CONTAMINATED`` and blocks submission — a shared
-   Demo account is the ROB-993 §5 failure mode, and B0-X's per-symbol caps
-   are meaningless if someone else is trading the same book.
+5. Account-wide fresh truth: any open order, or any *sellable* balance, this
+   lane did not create marks the cycle ``CONTAMINATED`` and blocks submission
+   — a shared Demo account is the ROB-993 §5 failure mode, and B0-X's
+   per-symbol caps are meaningless if someone else is trading the same book.
+   "Sellable" = floor(LOT_SIZE) > 0 (contract v1.2 §8, :func:`sellable_qty`):
+   a balance under the venue's minimum trade unit cannot become an order, so
+   it can neither be liquidated nor used to bypass a cap.
 6. Post-floor notional re-check: LOT_SIZE flooring can move the realized
    notional, so the cap is verified against the *realized* value, not the
    requested one (ROB-993 R3).
@@ -47,9 +50,11 @@ Known limitation — v1 attribution is fail-closed, not fail-live
 ---------------------------------------------------------------
 This lane does not yet reconcile fills back into an attributed position book.
 The consequence is deliberate and safe rather than hidden: because B0-X's book
-starts empty, *any* non-zero base balance reads as ``foreign`` — including a
+starts empty, *any* sellable base balance reads as ``foreign`` — including a
 balance B0-X's own fill just created. So the cycle after a first fill marks the
-account ``CONTAMINATED`` and refuses to submit again.
+account ``CONTAMINATED`` and refuses to submit again. (The v1.2 dust rule does
+not soften this: a filled B0-X order is by construction above minQty, so it
+still halts the lane. Only unsellable residue is excused.)
 
 That is over-conservative (the lane halts itself after one round trip) but it
 is the correct direction to err: the alternative, treating an unattributed
@@ -197,6 +202,10 @@ class SymbolFilters:
     step_size: Decimal
     tick_size: Decimal
     min_notional: Decimal
+    #: ``LOT_SIZE.minQty`` — the venue's minimum trade unit. Read only by
+    #: :func:`sellable_qty` (the contamination judgment); sizing keeps using
+    #: ``step_size``/``min_notional`` exactly as before.
+    min_qty: Decimal = Decimal("0")
 
 
 def _parse_filters(body: dict[str, Any], symbol: str) -> SymbolFilters:
@@ -206,10 +215,12 @@ def _parse_filters(body: dict[str, Any], symbol: str) -> SymbolFilters:
     step_size: Decimal | None = None
     tick_size: Decimal | None = None
     min_notional: Decimal | None = None
+    min_qty: Decimal = Decimal("0")
     for entry in symbols[0].get("filters") or []:
         ftype = entry.get("filterType")
         if ftype == "LOT_SIZE":
             step_size = Decimal(str(entry.get("stepSize", "0")))
+            min_qty = Decimal(str(entry.get("minQty", "0")))
         elif ftype == "PRICE_FILTER":
             tick_size = Decimal(str(entry.get("tickSize", "0")))
         elif ftype in ("NOTIONAL", "MIN_NOTIONAL"):
@@ -225,6 +236,7 @@ def _parse_filters(body: dict[str, Any], symbol: str) -> SymbolFilters:
         tick_size=tick_size,
         # Conservative fallback matching the ROB-298 smoke CLI.
         min_notional=min_notional if min_notional is not None else Decimal("5"),
+        min_qty=min_qty,
     )
 
 
@@ -256,6 +268,46 @@ async def fetch_reference_price(*, base_url: str, symbol: str) -> Decimal:
 # ---------------------------------------------------------------------------
 # Fresh truth (read-only) — account map requirement before any assignment use.
 # ---------------------------------------------------------------------------
+
+
+def sellable_qty(balance: Decimal, *, filters: SymbolFilters) -> Decimal:
+    """Quantity of ``balance`` that could actually be turned into an order.
+
+    Floors to ``LOT_SIZE.stepSize`` and requires the result to clear
+    ``LOT_SIZE.minQty``. Never rounds up — same direction as
+    ``spot_demo.sizing``, where refusing to round up *is* the safety line.
+    A balance under the venue's minimum trade unit floors to exactly zero:
+    no SELL can be constructed from it at all, at any price.
+
+    This is the contamination predicate (contract v1.2 §8): a base balance is
+    foreign inventory when it is **sellable**, not merely when it is non-zero.
+    The previous ``free + locked > 0`` test deadlocked the lane — X-S measured
+    BTC ``0.00000972`` (minQty ``0.00001``) and SOL ``0.00094600``
+    (minQty ``0.001``) left by ROB-298/ROB-307 round trips, which are
+    physically impossible to liquidate, so ``contaminated`` could never clear.
+
+    🔴 ``MIN_NOTIONAL`` is deliberately **not** consulted here, and this is the
+    whole point of the rule's narrowness. MIN_NOTIONAL on these symbols is
+    5 USDT — the same order of magnitude as the §4 per-order cap (10 USDT).
+    A notional-based dust test would therefore wave through foreign inventory
+    as large as this lane's own orders, which is exactly the shared-book state
+    the gate exists to catch. "Too small to sell" is the rule; "small" is not.
+
+    Note the vocabulary clash with two neighbouring lanes, which use the *same
+    word* for a *wider* set and must not be reused here:
+    ``spot_demo.sizing.compute_close_qty`` and
+    ``portfolio_overview_service`` both call a below-min-notional balance
+    "dust". Under B0-X v1.2, a minQty-clearing balance is still contamination
+    however little it is worth.
+    """
+
+    step = filters.step_size
+    if step <= 0:
+        raise ValueError("step_size must be > 0 to judge sellability")
+    floored = (balance / step).quantize(Decimal("1"), rounding=ROUND_DOWN) * step
+    if floored <= 0 or floored < filters.min_qty:
+        return Decimal("0")
+    return floored
 
 
 @dataclass(frozen=True, slots=True)
@@ -303,8 +355,24 @@ class FreshTruth:
         }
 
 
-async def read_fresh_truth(client: BinanceSpotDemoExecutionClient) -> FreshTruth:
-    """Read-only positions/open-orders/balances across the whole lane surface."""
+async def read_fresh_truth(
+    client: BinanceSpotDemoExecutionClient,
+    *,
+    filters: dict[str, SymbolFilters] | None = None,
+) -> FreshTruth:
+    """Read-only positions/open-orders/balances across the whole lane surface.
+
+    ``filters`` (venue LOT_SIZE per symbol) is fetched from the public
+    ``exchangeInfo`` endpoint when not supplied; it is needed because the
+    contamination predicate is now sellability, not presence
+    (:func:`sellable_qty`). These are unsigned, host-asserted reads.
+    """
+
+    if filters is None:
+        filters = {
+            symbol: await fetch_symbol_filters(base_url=base_url(), symbol=symbol)
+            for symbol in sorted(B0X_SIDECAR_BASE_ASSETS)
+        }
 
     quote = await client.get_asset_balance(asset=QUOTE_ASSET)
     base_balances: dict[str, tuple[Decimal, Decimal]] = {}
@@ -321,12 +389,29 @@ async def read_fresh_truth(client: BinanceSpotDemoExecutionClient) -> FreshTruth
             if not str(order.client_order_id).startswith(CLIENT_ORDER_ID_PREFIX):
                 foreign_orders.append(f"{symbol}:{order.client_order_id}")
 
-    # A non-zero base balance on a lane that has never filled anything is, by
+    # A *sellable* base balance on a lane that has never filled anything is, by
     # definition, someone else's. The cycle records it and refuses to submit
     # rather than silently treating it as B0-X inventory.
-    foreign_assets = [
-        asset for asset, (free, locked) in base_balances.items() if free + locked > 0
-    ]
+    #
+    # Contract v1.2 §8: judged on floor(LOT_SIZE) sellable quantity, not on
+    # presence. Balances below the venue's minimum trade unit cannot be sold,
+    # cannot be grown into a position, and cannot bypass a cap — see
+    # :func:`sellable_qty` for why the threshold stops at minQty and does not
+    # reach MIN_NOTIONAL. Free + locked is used (not free alone) so a balance
+    # tied up in an order still counts toward the judgment.
+    asset_to_symbol = {
+        asset: symbol for symbol, asset in B0X_SIDECAR_BASE_ASSETS.items()
+    }
+    foreign_assets = []
+    for asset, (free, locked) in base_balances.items():
+        symbol_filters = filters.get(asset_to_symbol[asset])
+        if symbol_filters is None:
+            # No filters => sellability is unknown => fail closed, as before.
+            if free + locked > 0:
+                foreign_assets.append(asset)
+            continue
+        if sellable_qty(free + locked, filters=symbol_filters) > 0:
+            foreign_assets.append(asset)
 
     return FreshTruth(
         quote_free=quote.free,
@@ -668,6 +753,7 @@ __all__ = [
     "fetch_symbol_filters",
     "fetch_reference_price",
     "read_fresh_truth",
+    "sellable_qty",
     "align_price",
     "client_order_id_for",
     "plan_orders",

--- a/tests/scripts/b0x/test_sidecar.py
+++ b/tests/scripts/b0x/test_sidecar.py
@@ -421,6 +421,189 @@ def test_flat_account_is_recognized() -> None:
     assert _fresh(base={"BTC": (Decimal("1"), Decimal("0"))}).flat is False
 
 
+# ---------------------------------------------------------------------------
+# Contamination judgment — contract v1.2 §8 dust rule.
+#
+# The whole rule in one line: "too small to sell" is excused, "small" is not.
+# ---------------------------------------------------------------------------
+
+
+class _FakeBalance:
+    def __init__(self, free: str, locked: str = "0") -> None:
+        self.free = Decimal(free)
+        self.locked = Decimal(locked)
+
+
+class _FakeOpenOrders:
+    orders: list[Any] = []
+
+
+class _ReadOnlyClient:
+    """Read-only stand-in. Any mutation attempt fails the test loudly."""
+
+    def __init__(self, balances: dict[str, str]) -> None:
+        self._balances = balances
+
+    async def get_asset_balance(self, *, asset: str) -> _FakeBalance:
+        return _FakeBalance(self._balances.get(asset, "0"))
+
+    async def get_open_orders(self, *, symbol: str) -> _FakeOpenOrders:
+        return _FakeOpenOrders()
+
+    async def submit_order(self, **kwargs: Any) -> None:
+        raise AssertionError("read_fresh_truth must never submit an order")
+
+
+# BTCUSDT/SOLUSDT venue reality as measured by X-S on 2026-08-08.
+_VENUE_FILTERS = {
+    "BTCUSDT": sidecar.SymbolFilters(
+        step_size=Decimal("0.00001"),
+        tick_size=Decimal("0.01"),
+        min_notional=Decimal("5"),
+        min_qty=Decimal("0.00001"),
+    ),
+    "ETHUSDT": sidecar.SymbolFilters(
+        step_size=Decimal("0.0001"),
+        tick_size=Decimal("0.01"),
+        min_notional=Decimal("5"),
+        min_qty=Decimal("0.0001"),
+    ),
+    "SOLUSDT": sidecar.SymbolFilters(
+        step_size=Decimal("0.001"),
+        tick_size=Decimal("0.01"),
+        min_notional=Decimal("5"),
+        min_qty=Decimal("0.001"),
+    ),
+}
+
+
+async def _truth(balances: dict[str, str]) -> sidecar.FreshTruth:
+    return await sidecar.read_fresh_truth(
+        _ReadOnlyClient(balances), filters=_VENUE_FILTERS
+    )
+
+
+@pytest.mark.asyncio
+async def test_mutant_1_sellable_balance_under_min_notional_is_still_contamination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """🔴 The load-bearing case. A balance that clears minQty but is worth far
+    less than MIN_NOTIONAL (5 USDT) is foreign inventory and must block.
+
+    If this ever passes, the gate has been widened to a notional threshold and
+    foreign holdings the size of the lane's own 10 USDT cap would walk through.
+    """
+
+    # 0.00009 BTC ~= 5.6 USDT at the price X-S measured... but sizing does not
+    # matter: it is 9 steps of minQty, so it is sellable, so it is foreign.
+    fresh = await _truth({"BTC": "0.00009"})
+    assert fresh.foreign_base_assets == ("BTC",)
+    assert fresh.contaminated is True
+
+    # And the pathological version: exactly one minQty unit, worth ~0.6 USDT —
+    # an order of magnitude below MIN_NOTIONAL, still contamination.
+    one_unit = await _truth({"BTC": "0.00001"})
+    assert one_unit.foreign_base_assets == ("BTC",)
+    assert one_unit.contaminated is True
+
+    # ...and it still blocks submission at the last line before the venue.
+    monkeypatch.setenv("B0X_SIDECAR_ENABLED", "true")
+    with pytest.raises(sidecar.SidecarContaminated):
+        await sidecar.submit_planned(
+            _ReadOnlyClient({}), [], envelope=ENVELOPE, fresh_truth=fresh, confirm=False
+        )
+
+
+@pytest.mark.asyncio
+async def test_mutant_2_unsellable_dust_is_not_contamination() -> None:
+    """The X-S deadlock: residue that floors to zero cannot be liquidated, so
+    treating it as contamination made ``SIDECAR_ARMED=YES`` unreachable."""
+
+    fresh = await _truth({"BTC": "0.00000972", "SOL": "0.00094600"})
+    assert fresh.foreign_base_assets == ()
+    assert fresh.contaminated is False
+
+    # Not hidden, though — the dust stays visible in the observation record.
+    assert fresh.status_only()["base_assets_with_nonzero_balance"] == ["BTC", "SOL"]
+
+
+@pytest.mark.asyncio
+async def test_mutant_3_judgment_does_not_consult_min_notional() -> None:
+    """Kill the notional-based variant: with MIN_NOTIONAL mutated to absurd
+    values in both directions, the verdict must not move. Only LOT_SIZE counts.
+    """
+
+    sellable = {"BTC": "0.00009"}
+    dust = {"BTC": "0.00000972"}
+
+    for min_notional in ("0", "5", "1000000"):
+        mutated = {
+            symbol: replace(filters, min_notional=Decimal(min_notional))
+            for symbol, filters in _VENUE_FILTERS.items()
+        }
+        assert (
+            await sidecar.read_fresh_truth(_ReadOnlyClient(sellable), filters=mutated)
+        ).contaminated is True, (
+            f"min_notional={min_notional} changed a sellable verdict"
+        )
+        assert (
+            await sidecar.read_fresh_truth(_ReadOnlyClient(dust), filters=mutated)
+        ).contaminated is False, f"min_notional={min_notional} changed a dust verdict"
+
+
+@pytest.mark.asyncio
+async def test_locked_balance_counts_toward_the_judgment() -> None:
+    """Inventory parked in someone else's resting order is still inventory."""
+
+    assert (await _truth({})).contaminated is False
+
+    class _Locked(_ReadOnlyClient):
+        async def get_asset_balance(self, *, asset: str) -> _FakeBalance:
+            if asset == "SOL":
+                return _FakeBalance("0", "0.5")
+            return _FakeBalance("0")
+
+    locked = await sidecar.read_fresh_truth(_Locked({}), filters=_VENUE_FILTERS)
+    assert locked.foreign_base_assets == ("SOL",)
+
+
+@pytest.mark.asyncio
+async def test_missing_filters_fail_closed_to_the_old_presence_test() -> None:
+    """If sellability is unknowable, fall back to the stricter rule."""
+
+    fresh = await sidecar.read_fresh_truth(
+        _ReadOnlyClient({"BTC": "0.00000972"}), filters={}
+    )
+    assert fresh.foreign_base_assets == ("BTC",)
+    assert fresh.contaminated is True
+
+
+def test_sellable_qty_requires_min_qty_not_just_a_whole_step() -> None:
+    """On all three authorized symbols ``stepSize == minQty``, so the two
+    thresholds coincide and a step-only implementation looks identical. Pin the
+    intended rule on a venue where they differ: a balance that is a whole
+    number of steps but below minQty is still refused by the matching engine,
+    so it is unsellable — dust.
+    """
+
+    wide = sidecar.SymbolFilters(
+        step_size=Decimal("0.001"),
+        tick_size=Decimal("0.01"),
+        min_notional=Decimal("5"),
+        min_qty=Decimal("0.01"),
+    )
+    assert sidecar.sellable_qty(Decimal("0.005"), filters=wide) == Decimal("0")
+    assert sidecar.sellable_qty(Decimal("0.01"), filters=wide) == Decimal("0.01")
+
+
+def test_sellable_qty_floors_and_never_rounds_up() -> None:
+    filters = _VENUE_FILTERS["SOLUSDT"]
+    assert sidecar.sellable_qty(Decimal("0.0009"), filters=filters) == Decimal("0")
+    assert sidecar.sellable_qty(Decimal("0.001"), filters=filters) == Decimal("0.001")
+    assert sidecar.sellable_qty(Decimal("0.0019"), filters=filters) == Decimal("0.001")
+    assert sidecar.sellable_qty(Decimal("0"), filters=filters) == Decimal("0")
+
+
 def test_per_order_cap_bounds_buys_only_not_exits() -> None:
     """The §4 per-order cap bounds capital deployment. Capping a sell would
     strand inventory the lane is trying to reduce."""


### PR DESCRIPTION
## 무엇을 / 왜

B0-X 계약 **v1.2 §8** 정합 수정. 사이드카의 오염 판정이 `free + locked > 0` 이었다.
X-S 실측이 그 의미를 드러냈다 — 공유 Demo 계정의 BTC `0.00000972`(minQty `0.00001`) ·
SOL `0.00094600`(minQty `0.001`)은 ROB-298/ROB-307 왕복이 남긴 잔여다. **둘 다 floor 후
정확히 0** 이라 어떤 가격으로도 SELL 을 구성할 수 없다. 청산이 물리적으로 불가능한데
게이트는 이를 봐준 적이 없어 `SIDECAR_ARMED=YES` 가 **영구 도달 불가**였다.

판정을 **매도 가능성**으로 교체: `LOT_SIZE.stepSize` 로 floor → `LOT_SIZE.minQty` 통과
요구 (`sellable_qty`).

## 🔴 MIN_NOTIONAL 을 쓰지 않는 이유 (핵심)

이 3종의 MIN_NOTIONAL 은 **5 USDT** — §4 주문 캡 **10 USDT** 와 같은 자릿수다.
notional 기준 dust 판정은 **이 레인 자기 주문만 한 외부 재고를 통과시키는 게이트**가
되며, 그것이 정확히 이 게이트가 잡으려는 공유 장부 상태다.
규칙은 **"팔 수 없으니까 dust"** 이지 "작으니까 dust" 가 아니다.

`spot_demo.sizing.compute_close_qty` 와 `portfolio_overview_service` 는 같은 단어를 더
넓은 뜻(MIN_NOTIONAL 미만)으로 쓴다 — **재사용하지 않았고**, 코드 주석·런북에 기준 차이를
명기했다.

## 스코프

판정 함수만. **envelope · derivation · kill switch 는 diff 0** (`git diff` 로 증명 가능).
- filters 부재 시 기존 presence 판정으로 **fail closed** 유지
- `free + locked` 사용 (남의 주문에 묶인 재고도 재고)
- dust 는 숨겨지지 않음 — `base_assets_with_nonzero_balance` 에 그대로 남고
  `foreign_base_assets` 에서만 빠진다
- 체결된 B0-X 주문은 정의상 minQty 이상 → "개입 1회당 왕복 1회" 한계 **불변**

## mutant 격추 (전부 실측)

| mutant | 결과 |
|---|---|
| ① minQty 이상 · MIN_NOTIONAL 미만 잔고 → 여전히 오염 | ✅ 격추 (notional 판정 주입 시 FAIL) |
| ② floor 후 0 인 dust → 통과 | ✅ 격추 (presence 복원 시 FAIL) |
| ③ notional 기준 판정으로 변형 | ✅ 격추 (min_notional 0/5/1000000 무관하게 판정 불변) |
| ④ minQty 무시(step-only) | ✅ 격추 — 3종은 step==minQty 라 안 잡혀서 별도 테스트로 고정 |

## 검증

- `tests/scripts/b0x/` 164 passed · `tests/services/brokers/binance/` 포함 867 passed
- ruff / ty clean
- **실계좌 실측** (`demo-api.binance.com`): live 필터가 테스트 픽스처와 일치
  (BTC/ETH/SOL minQty = 0.00001/0.0001/0.001), `sellable` 3종 전부 `0`,
  `contaminated: false`, `foreign_base_assets: []`

## 첫 사이클 (별도 산출)

표 재생성 후 arm → 첫 사이클 1회 실행. 주문 2건 (BTCUSDT 9.4597 · ETHUSDT 9.8683 USDT,
둘 다 ≤ 10 캡) 제출·미체결 `NEW`. **매도 주문 0건 · 청산 0 · live 접촉 0.**
dry-run 과 confirm 런의 `derivation_hash` 동일 — 파생 결정성 유지.

🔴 머지 금지 — 검증 대기.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contamination detection to distinguish sellable balances from unsellable base-asset dust.
  * Sellable balances are still flagged even when below minimum notional thresholds.
  * Locked balances continue to be included in contamination checks.
  * Missing trading constraints now fail safely rather than allowing uncertain balances.

* **Documentation**
  * Clarified contamination rules, checklist guidance, and known boundaries.
  * Observation records continue to retain all nonzero balances, including exempt dust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->