### PR TITLE
test(d3-c2p): salvage two unique guard behaviours from PR #1807 before close

### DIFF
--- a/tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py
@@ -544,9 +544,7 @@ def test_anomaly_precheck_never_decodes_a_prospective_json_line(
         spy=CalibrationAccessSpy(),
         holdout_root=sealed_root_with_valid_corpus,
     )
-    corpus = load_calibration_corpus(
-        guard, holdout_root=sealed_root_with_valid_corpus
-    )
+    corpus = load_calibration_corpus(guard, holdout_root=sealed_root_with_valid_corpus)
     assert corpus.anomaly_lines_prechecked == 2
     assert corpus.anomaly_lines_decoded_2025 == 1
     assert corpus.anomaly_lines_skipped_prospective == 1

--- a/tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py
+++ b/tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py
@@ -13,6 +13,8 @@ from datetime import date, datetime
 from decimal import Decimal
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from research.kr_corpus.backtest import holdout_guard
@@ -23,6 +25,7 @@ from research.kr_corpus.d3_engine.calibration_acceptance import (
 )
 from research.kr_corpus.d3_engine.calibration_corpus import (
     CalibrationCorpusInvalid,
+    load_calibration_corpus,
     load_calibration_manifest,
 )
 from research.kr_corpus.d3_engine.calibration_guard import (
@@ -418,6 +421,184 @@ def test_zero_rule_is_positive_scale_only() -> None:
     )
     assert decision == "PASS"
     assert detail["zero_rule_applied"] is False
+
+
+# -- PR #1807 salvage: unique guard behaviours not otherwise pinned ---------
+#
+# ba3c1907c9 (research/kr_corpus/d3_engine/tests/test_calibration_corpus_guard.py)
+# predates the Amendment A2 manifest-scoped rewrite and cannot be merged
+# (2,911 lines of drift). These two tests port the two behaviours from that
+# suite that this file does not otherwise cover, rewritten against the
+# current CalibrationAccessGuard/load_calibration_corpus surface.
+
+
+@pytest.fixture
+def sealed_root_with_valid_corpus(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """A synthetic sealed corpus with a real dataset/gap parquet pair and an
+    anomalies.jsonl that interleaves one valid 2025 record with one
+    prospective 2026 record whose JSON body is deliberately malformed.
+
+    The 2026 record still matches the byte-level ``"session": "2026-`` regex
+    so it reaches the precheck; if the precheck's year gate were ever removed
+    and the line were handed to ``json.loads`` regardless, that call would
+    raise ``json.JSONDecodeError`` and ``load_calibration_corpus`` would blow
+    up instead of returning cleanly.
+    """
+
+    root = tmp_path / "kr-corpus-v1" / "holdout"
+    run_root = root / "runs" / HOLDOUT_RUN_ID
+
+    dataset_relative = "dataset/market=KOSPI/year=2025/ticker=005930.parquet"
+    dataset_path = run_root / dataset_relative
+    dataset_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {
+                    "session": "2025-01-02",
+                    "market": "KOSPI",
+                    "ticker": "005930",
+                    "open": 100,
+                    "high": 110,
+                    "low": 90,
+                    "close": 105,
+                }
+            ]
+        ),
+        dataset_path,
+    )
+
+    gap_relative = "gaps/market=KOSPI/year=2025/missing.parquet"
+    gap_path = run_root / gap_relative
+    gap_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {
+                    "session": "2025-06-02",
+                    "market": "KOSPI",
+                    "ticker": "005930",
+                    "reason": "ohlc_invariant_violation",
+                }
+            ]
+        ),
+        gap_path,
+    )
+
+    # A 2026 dataset entry so the manifest has its required prospective
+    # example; it is never read (excluded before any guard check runs).
+    prospective_relative = "dataset/market=KOSPI/year=2026/ticker=005930.parquet"
+    (run_root / prospective_relative).parent.mkdir(parents=True, exist_ok=True)
+    (run_root / prospective_relative).write_bytes(b"prospective")
+
+    anomalies_relative = "source-anomalies.jsonl"
+    valid_2025_line = json.dumps(
+        {
+            "session": "2025-06-02",
+            "kind": "ohlc_invariant_violation",
+            "ticker": "005930",
+            "detail": {"open": 100, "high": 105, "low": 95, "close": 110},
+        }
+    ).encode()
+    # Matches the byte-level session-year regex but is not valid JSON: if
+    # this were ever decoded, json.loads raises and the corpus load aborts.
+    malformed_2026_line = b'{"session": "2026-01-05", this is not json}'
+    anomalies_bytes = valid_2025_line + b"\n" + malformed_2026_line + b"\n"
+    (run_root / anomalies_relative).write_bytes(anomalies_bytes)
+
+    files = {
+        dataset_relative: dataset_path.read_bytes(),
+        gap_relative: gap_path.read_bytes(),
+        prospective_relative: (run_root / prospective_relative).read_bytes(),
+        anomalies_relative: anomalies_bytes,
+    }
+    rows = [
+        f"{hashlib.sha256(payload).hexdigest()}  {relative}"
+        for relative, payload in files.items()
+    ]
+    checksums = ("\n".join(rows) + "\n").encode("utf-8")
+    (run_root / "checksums.sha256").write_bytes(checksums)
+    (run_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "scope": "holdout",
+                "corpus_id": "kr-corpus-v1",
+                "files_list_location": "checksums.sha256",
+                "checksums_sha256": hashlib.sha256(checksums).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(holdout_guard, "HOLDOUT_DIR", root)
+    monkeypatch.setattr(calibration_guard, "HOLDOUT_DIR", root)
+    return root
+
+
+def test_anomaly_precheck_never_decodes_a_prospective_json_line(
+    sealed_root_with_valid_corpus: Path,
+) -> None:
+    guard = CalibrationAccessGuard(
+        calibration_sessions=SESSIONS,
+        spy=CalibrationAccessSpy(),
+        holdout_root=sealed_root_with_valid_corpus,
+    )
+    corpus = load_calibration_corpus(
+        guard, holdout_root=sealed_root_with_valid_corpus
+    )
+    assert corpus.anomaly_lines_prechecked == 2
+    assert corpus.anomaly_lines_decoded_2025 == 1
+    assert corpus.anomaly_lines_skipped_prospective == 1
+    assert len(corpus.clamp_rows) == 1
+
+
+def test_spy_evidence_shape_is_stable() -> None:
+    """Regression pin on the serialized evidence contract's key set.
+
+    ``EngineResult.evidence`` embeds this dict verbatim (see
+    ``CalibrationAccessGuard.fresh_clone``'s docstring on byte-identical
+    determinism); an accidental key rename or drop here would silently
+    reshape every downstream artifact.
+    """
+
+    spy = CalibrationAccessSpy()
+    evidence = spy.evidence()
+    assert evidence["calibration_authorized_date_checks"] == 0
+    assert evidence["calibration_blocked_prospective_date_attempts"] == 0
+    assert set(evidence) == {
+        "sealed_access_spy",
+        "sealed_access_blocked_attempts",
+        "sealed_access_path_checks",
+        "sealed_access_date_checks",
+        "sealed_access_metadata_key_checks",
+        "measured_file_reads",
+        "measured_manifest_reads",
+        "measured_parquet_reads",
+        "measured_bar_rows_read",
+        "measured_metadata_key_reads",
+        "sealed_file_reads",
+        "sealed_manifest_reads",
+        "sealed_parquet_reads",
+        "sealed_bar_rows_read",
+        "sealed_metadata_key_reads",
+        "calibration_warmup_date_checks",
+        "calibration_authorized_date_checks",
+        "calibration_blocked_prospective_date_attempts",
+        "calibration_blocked_offcalendar_2025_date_attempts",
+        "calibration_exploration_path_checks",
+        "calibration_authorized_path_checks",
+        "calibration_blocked_outside_manifest_attempts",
+        "calibration_blocked_prospective_path_attempts",
+        "calibration_blocked_sealed_token_attempts",
+        "calibration_authorized_manifest_document_reads",
+        "calibration_authorized_file_reads",
+        "calibration_authorized_parquet_reads",
+        "calibration_authorized_bar_rows",
+        "calibration_manifest_allowlist_size",
+        "calibration_manifest_excluded_out_of_scope",
+        "calibration_sessions_authorized",
+    }
 
 
 def test_dual_view_disagreement_is_data_bias() -> None:


### PR DESCRIPTION
## Summary
- PR #1807 (`d3c2p`, head `ba3c1907c9`) predates the Amendment A2 calibration-guard rewrite. `git diff --stat origin/main ba3c1907c9 -- research/kr_corpus/d3_engine/` shows 9 files, +1041/-2911 — merging it would delete 2,911 lines main currently has, so it is being closed rather than merged.
- Before closing it, its 10 guard tests (`test_calibration_corpus_guard.py`) were triaged one-by-one, by assertion behaviour rather than name, against the 17 tests already in `tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py`.
- 8 of 10 are `COVERED` (same failure caught by an existing main test) or `NOT_APPLICABLE` (the behaviour intentionally changed under Amendment A2 — e.g. `<=2024` dates are now authorized warm-up, not blocked). 2 are genuinely `UNIQUE` and are ported here, rewritten from scratch against the current `CalibrationAccessGuard` / `load_calibration_corpus` API (the old `test_calibration_corpus_guard.py` code was not reusable as-is).
- Both new tests are mutant-proven: the guarded behaviour was temporarily broken in the working tree, confirmed to make the new test fail, then reverted (mutation never committed — `git diff --stat` on production files is empty).

## Test plan
- [x] `uv run pytest tests/research/kr_corpus/d3_engine/test_d3_calibration_guard.py -v` — 19 passed (17 original + 2 new)
- [x] `uv run pytest tests/research/kr_corpus/ -q` — 74 passed (no regressions elsewhere)
- [x] Mutant proof: disabling the anomaly-precheck year gate in `calibration_corpus.py` → new test fails with `json.decoder.JSONDecodeError`; reverted via `git checkout`
- [x] Mutant proof: dropping `calibration_sessions_authorized` from `CalibrationAccessSpy.evidence()` in `calibration_guard.py` → new test fails with `AssertionError`; reverted via `git checkout`
- [x] `git diff --stat` on `research/**` (production code) is empty — test-only change

## Scope / safety
- No holdout data accessed — all fixtures are synthetic, under `tmp_path`, monkeypatching `HOLDOUT_DIR` (same pattern as the existing `sealed_root` fixture in this file).
- No corpus writes, no production code changes, no edits/deletes to the existing 17 tests (additions only).
- PR #1807 itself is untouched — not merged, not closed, branch not deleted (per job instructions, orchestrator closes it separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calibration data handling by safely skipping malformed prospective anomaly records instead of attempting to decode them.
  * Preserved the complete set of serialized evidence keys when calibration evidence is accessed.

* **Tests**
  * Added regression coverage for valid calibration corpora, partitioned data, malformed records, and evidence serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->