### PR TITLE
feat(b0x): 귀속 게이트 취소 경로 + 계약 v1.3 스탬프 (X-S3)

### DIFF
--- a/app/services/brokers/binance/spot_demo/execution_client.py
+++ b/app/services/brokers/binance/spot_demo/execution_client.py
@@ -472,6 +472,39 @@ class BinanceSpotDemoExecutionClient:
         ]
         return SpotDemoOpenOrdersResult(orders=orders)
 
+    async def get_all_open_orders(self) -> SpotDemoOpenOrdersResult:
+        """Account-wide open orders — every symbol, not just one.
+
+        Binance returns the whole account's resting orders when ``symbol``
+        is omitted from ``GET /api/v3/openOrders``. This is additive and
+        leaves :meth:`get_open_orders` byte-identical; it exists because a
+        symbol-scoped read cannot answer "is anything else resting on this
+        account?".
+
+        That question is not academic here. The Spot Demo credentials are
+        shared with other demo lanes (see the strategy-loop runbook §5), so
+        a caller that is about to cancel, or that is deciding whether the
+        book is clean, has to look at the whole account. Attribution is the
+        caller's job: this read reports every order and judges none.
+        """
+        params = {"recvWindow": str(BINANCE_SPOT_DEMO_RECV_WINDOW_MS)}
+        signed = _sign_request_params(params=params, api_secret=self._api_secret)
+        resp = await self._client.get(_OPEN_ORDERS_PATH, params=signed)
+        resp.raise_for_status()
+        body = resp.json()
+        orders = [
+            SpotDemoOpenOrder(
+                client_order_id=str(entry.get("clientOrderId", "")),
+                broker_order_id=str(entry.get("orderId", "")),
+                symbol=str(entry.get("symbol", "")),
+                side=str(entry.get("side", "")),
+                qty=Decimal(str(entry.get("origQty", "0"))),
+                status=str(entry.get("status", "")),
+            )
+            for entry in body
+        ]
+        return SpotDemoOpenOrdersResult(orders=orders)
+
     async def get_order_status(
         self, *, symbol: str, client_order_id: str
     ) -> dict[str, Any]:

--- a/docs/runbooks/b0x-crypto-cycle.md
+++ b/docs/runbooks/b0x-crypto-cycle.md
@@ -143,7 +143,13 @@ writer lock → 표 게이트 → 계좌 상태 → kill switch → 파생 → �
 
 `--confirm` 을 붙이기 전에 전부 확인한다.
 
-- [ ] `mock/CLAUDE.md` §1 Binance Demo 행이 여전히 B0-X 사이드카를 가리킨다
+- [ ] **`operator_contract.yaml` 이 B0-X 를 등재하고 있다** — 계좌맵 **기계판독 정본**
+      (계약 v1.3 ①). `account_lanes.binance_demo = B0-X-crypto-sidecar` ·
+      `reassignments.binance_demo.sidecar_scope = buy_side_fill_fidelity_sample_only` ·
+      `strategy_order_exceptions ∋ b0x-adapter-orders-20260808`
+- [ ] `mock/CLAUDE.md` §1 Binance Demo 행이 위와 **모순되지 않는다** (참조 표면 —
+      충돌 시 YAML 이 이긴다. 🔴 산문에만 등재된 레인은 검사기가 강제할 수 없어서, 그
+      상태로 나간 주문이 계약 v1.3 ① 의 취소 대상이 됐다)
 - [ ] **CR-S1 TPR 이 재개되지 않았다** — 재개 시 TPR 우선권 (별개 계약)
 - [ ] fresh truth 가 `contaminated: false` — 공유 Demo 계정에 다른 writer 의 미체결/**매도
       가능** 잔고 없음 (거래단위 미만 dust 는 예외 — §8-1)
@@ -184,6 +190,27 @@ SOL `0.00094600`(minQty `0.001`)을 실측했다. 청산이 물리적으로 불�
 다른 전략의 미체결은 **취소하지 않는다** (mock/CLAUDE.md §4). kill 시에도 `b0xc-` 접두
 주문만 취소한다.
 
+### 8-2. 잔여 주문 취소 — 자기 주문만 (계약 §2-4)
+
+kill switch 의 「잔여 주문 취소」와 계약 v1.3 ① 의 재등재 취소는 같은 도구를 쓴다.
+
+```bash
+# 스캔만 — 계좌 전체를 읽고 아무것도 취소하지 않는다. 항상 이걸 먼저 돌린다.
+B0X_SIDECAR_ENABLED=true BINANCE_SPOT_DEMO_ENABLED=true \
+  uv run python -m scripts.run_b0x_cancel --scan-only
+
+# 실제 취소 (운영자 게이트)
+... uv run python -m scripts.run_b0x_cancel --confirm
+```
+
+- 🔴 **읽기는 계좌 전체**(`get_all_open_orders`, symbol 생략)다. 심볼 3종만 훑으면
+  네 번째 심볼에 얹힌 남의 주문을 못 보고 "깨끗하다" 고 보고하게 된다.
+- 🔴 **취소 대상은 `b0xc-` 접두 주문뿐**이다. 그 외는 `NOT_MINE` 으로 출력만 하고 손대지
+  않으며, **취소하는 플래그는 존재하지 않는다.** 귀속 불가(=clientOrderId 없음)도 남의
+  것으로 친다(fail-closed).
+- 같은 심볼에 남의 주문이 얹혀 있어도 안전하다 — 판정 축은 심볼이 아니라 접두다.
+- foreign 주문이 하나라도 보이면 exit code 3 (실패가 아니라 **운영자가 봐야 할 사실**).
+
 ## 9. 알려진 경계 · 미해결
 
 - **KRW→USDT 이식은 미검증이다** (`CROSS_QUOTE_RATIO_TRANSFER`). 표는 KRW 호가고 Binance 는
@@ -198,11 +225,18 @@ SOL `0.00094600`(minQty `0.001`)을 실측했다. 청산이 물리적으로 불�
 - 🔴 **사이드카 v1 은 체결을 귀속 장부에 reconcile 하지 않는다.** B0-X 장부가 비어 있으므로
   *매도 가능한* base 잔고는 전부 `foreign` 으로 읽히며, **B0-X 자기 체결이 만든 잔고도
   그렇다** (§8-1 dust 예외는 이를 완화하지 않는다 — 체결된 주문은 정의상 minQty 이상이다).
-  결과적으로 첫 체결 다음 사이클은 `CONTAMINATED` 로 제출을 거부한다 —
-  **운영자 개입 1회당 왕복 1회**가 v1 의 실질 처리량이다.
+  결과적으로 첫 체결 다음 사이클은 `CONTAMINATED` 로 제출을 거부한다.
   과보수적이지만 방향은 옳다: 귀속 안 된 잔고를 "내 것 아님, 계속 진행" 으로 처리하면
   레인 자신의 재고가 §4 종목별·동시 포지션 캡을 우회하게 된다.
   체결 인식 reconcile 은 후속 작업이다.
+- 🔴 **그래서 이 레인의 지위는 「매수측 체결충실도 표본」으로 축소됐다**
+  (계약 v1.3 ②, 산출물에 `sidecar_scope=buy_side_fill_fidelity_sample_only` 로 박제).
+  🔵 이전 판(「운영자 개입 1회당 **왕복** 1회」)은 부정확했다 — 매도측 R1/R2 는 v1
+  자동 경로에서 **도달 불가**다. 이중 장벽이라 그렇다: ①파생 단계에서 B0-X 장부가 비어
+  `no_position_to_sell` 로 스킵되고, ②설령 매도가 파생돼도 그 잔고가 sellable 이라
+  `submit` 이 `SidecarContaminated` 로 막힌다. 이 레인이 실제로 산출하는 것은 **매수
+  지정가 안착 + 자기정지**이며, **매도측 관측은 본선(Upbit shadow, 왕복 가능)의 몫**이다.
+  귀속 기반 완화(자기 fill delta 분리 — ROB-993 선례)는 후속 **서명 후보**일 뿐 미승인.
 - 스케줄러 등록 없음 (v1 수동 kickoff). 연속 clean 사이클 N회 후 자동화는 별도 운영자 결정.
 
 ## 10. 테스트

--- a/scripts/b0x/contract.py
+++ b/scripts/b0x/contract.py
@@ -1,0 +1,106 @@
+"""B0-X contract identity stamped onto every observation artifact.
+
+One module so that a contract amendment is a one-file edit, and so a
+verifier has a single place to compare the running code against the
+signed document.
+
+Why the version string binds and the file digest does not
+--------------------------------------------------------
+An earlier revision identified the contract by its **whole-file sha256**.
+That reads like the strongest possible check and is in fact the weakest
+useful one: the contract is a living document, so every amendment — even
+one that does not touch this lane — changes the digest. A stamp that
+changes on every unrelated edit cannot distinguish "the code is running
+against the wrong contract" from "the contract gained a paragraph
+elsewhere", so the digest alone produced false drift reports (X-U
+verification) while proving nothing about the clauses this lane actually
+obeys.
+
+So the binding identity here is :data:`CONTRACT_VERSION` plus the verbatim
+clauses in :data:`CONTRACT_CLAUSES` — the text this code implements. The
+digest is retained as :data:`CONTRACT_FILE_SHA256_REFERENCE_ONLY`, named
+so it cannot be mistaken for the criterion: it is provenance for the
+reader, not a gate.
+
+Amending the contract therefore means editing the version and the quoted
+clause here, in the same commit as whatever behaviour changed — which is
+the coupling the digest was failing to provide.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+CONTRACT_PATH: Final[str] = "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md"
+
+#: Binding identity. Bump together with the clauses below.
+CONTRACT_VERSION: Final[str] = "v1.3"
+
+#: Provenance only — NOT a drift criterion. See the module docstring.
+CONTRACT_FILE_SHA256_REFERENCE_ONLY: Final[str] = (
+    "0125e2ea96b1a54cf0b0a50e6ed85ae1f3a72e7870abe727d2734dbe20e19b1f"
+)
+
+#: Verbatim §8 v1.3 clauses this package implements.
+CONTRACT_CLAUSES: Final[dict[str, str]] = {
+    "§8 v1.3 ①": (
+        "계좌맵 기계판독 정본 = operator_contract.yaml 확정 — B0-X 3곳 등재"
+        "(account_lanes·reassignments·strategy_order_exceptions "
+        "b0x-adapter-orders-20260808), MD 는 참조로 강등. 미등재 상태에서 나간 "
+        "매수 2건은 취소 후 등재 완료 상태에서 첫 사이클 재실행."
+    ),
+    "§8 v1.3 ②": (
+        "사이드카 지위 = 매수측 체결충실도 표본으로 축소(자기오염 v1 성문 한계 — "
+        "자기 매수 체결 시 오염 판정, 매도측 도달 불가). 매도측 관측은 본선"
+        "(Upbit shadow, 왕복 가능)이 담당."
+    ),
+}
+
+#: Account map — the machine-readable surface is canonical (v1.3 ①).
+ACCOUNT_MAP_REPO: Final[str] = "auto_trader-operator"
+ACCOUNT_MAP_COMMIT: Final[str] = "3f402919fca5b68bda187e8e521fc886aefb022a"
+ACCOUNT_MAP_CANONICAL_SURFACE: Final[str] = "operator_contract.yaml"
+ACCOUNT_MAP_REFERENCE_SURFACE: Final[str] = "mock/CLAUDE.md"
+
+#: Sidecar lane standing, narrowed by v1.3 ②. Stamped on sidecar artifacts so
+#: a reader cannot mistake a buy-side fill-fidelity sample for a round-trip
+#: strategy result: the sell side of B0-X is observed on the Upbit shadow lane,
+#: not here.
+SIDECAR_SCOPE: Final[str] = "buy_side_fill_fidelity_sample_only"
+
+
+def contract_stamp() -> dict[str, Any]:
+    """Contract identity block for an observation record."""
+
+    return {
+        "path": CONTRACT_PATH,
+        "version": CONTRACT_VERSION,
+        "clauses": dict(CONTRACT_CLAUSES),
+        "file_sha256_reference_only": CONTRACT_FILE_SHA256_REFERENCE_ONLY,
+    }
+
+
+def account_map_stamp() -> dict[str, Any]:
+    """Account-map identity block — canonical surface named explicitly."""
+
+    return {
+        "repo": ACCOUNT_MAP_REPO,
+        "commit": ACCOUNT_MAP_COMMIT,
+        "canonical_surface": ACCOUNT_MAP_CANONICAL_SURFACE,
+        "reference_surface": ACCOUNT_MAP_REFERENCE_SURFACE,
+    }
+
+
+__all__ = [
+    "ACCOUNT_MAP_CANONICAL_SURFACE",
+    "ACCOUNT_MAP_COMMIT",
+    "ACCOUNT_MAP_REFERENCE_SURFACE",
+    "ACCOUNT_MAP_REPO",
+    "CONTRACT_CLAUSES",
+    "CONTRACT_FILE_SHA256_REFERENCE_ONLY",
+    "CONTRACT_PATH",
+    "CONTRACT_VERSION",
+    "SIDECAR_SCOPE",
+    "account_map_stamp",
+    "contract_stamp",
+]

--- a/scripts/b0x/crypto/cancel.py
+++ b/scripts/b0x/crypto/cancel.py
@@ -1,0 +1,196 @@
+"""B0-X sidecar cancel — attribution-gated, account-wide, own-orders-only.
+
+Contract §2-4 gives the lane the duty to cancel *its* resting orders (kill
+switch: "신규 주문 중단 + 잔여 주문 취소"), and contract v1.3 ① exercises it:
+the two buys placed while B0-X was missing from the machine-readable account
+map are cancelled before the first cycle is re-run.
+
+The whole point of this module is the word *its*. These Spot Demo credentials
+are shared with other demo lanes (strategy-loop runbook §5), so "cancel the
+open orders" and "cancel our open orders" are different operations and only
+the second one is authorized. Three properties enforce that:
+
+1. **Account-wide read, symbol-scoped never.** :func:`scan` calls
+   ``get_all_open_orders`` — omitting the symbol — because an order this lane
+   must not touch is, by definition, one it would not think to ask about. A
+   per-symbol loop over the three allowlisted symbols would report a clean
+   book while another writer rests orders on a fourth.
+2. **Attribution is a prefix match, never an inference.** An order belongs to
+   B0-X iff its ``clientOrderId`` starts with ``b0xc``
+   (:data:`sidecar.CLIENT_ORDER_ID_PREFIX`). Everything else is *foreign* —
+   not "probably ours", not "ours if the symbol matches", not "ours because
+   nothing else should be running". :func:`partition` is pure and total, so
+   an order can never fall through into the cancel set by accident.
+3. **The prefix is re-checked at the call site.** :func:`cancel_own` asserts
+   attribution again on each order immediately before dispatching the DELETE,
+   so a future refactor that widens :func:`partition` still cannot reach a
+   foreign order without also defeating this second check.
+
+Foreign orders are *reported, never touched* — deciding what to do about
+another lane's book is an operator/owning-lane matter (mock/CLAUDE.md §4:
+"다른 전략의 보유·미체결·원장 행을 정리·청산·정정·취소하지 않는다").
+
+Like every other mutation in this package, the DELETE only happens under an
+explicit ``confirm=True``; the default is a dry run that dispatches zero
+mutation HTTP.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from scripts.b0x.crypto.sidecar import CLIENT_ORDER_ID_PREFIX
+
+
+class ForeignOrderCancelAttempt(RuntimeError):
+    """A cancel was attempted against an order B0-X did not create.
+
+    Raised by the call-site re-check in :func:`cancel_own`. Reaching this is
+    a bug, not an operational condition: it means the partition and the
+    dispatcher disagree about attribution.
+    """
+
+
+def is_b0x_order(client_order_id: str | None) -> bool:
+    """Attribution predicate — prefix match on ``clientOrderId``, nothing else.
+
+    ``None``/empty is **not** ours. An order the venue reports without a
+    client id cannot be attributed, and an unattributable order is foreign
+    by the fail-closed rule (contract §2-3 writer=1).
+
+    The separator is part of the prefix and something must follow it. A bare
+    ``"b0xc-"`` carries no order key, so it is not an id this lane can have
+    minted (:func:`sidecar.client_order_id_for` always appends one) — and a
+    prefix test loose enough to accept it is also loose enough to accept a
+    foreign id that merely begins the same way.
+    """
+
+    if not client_order_id:
+        return False
+    marker = f"{CLIENT_ORDER_ID_PREFIX}-"
+    text = str(client_order_id)
+    return text.startswith(marker) and len(text) > len(marker)
+
+
+@dataclass(frozen=True)
+class OrderPartition:
+    """Account-wide open orders split by attribution."""
+
+    mine: tuple[Any, ...]
+    foreign: tuple[Any, ...]
+
+    @property
+    def total(self) -> int:
+        return len(self.mine) + len(self.foreign)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "total_open_orders": self.total,
+            "mine": [_order_json(order) for order in self.mine],
+            "foreign": [_order_json(order) for order in self.foreign],
+        }
+
+
+def _order_json(order: Any) -> dict[str, Any]:
+    return {
+        "symbol": getattr(order, "symbol", ""),
+        "client_order_id": getattr(order, "client_order_id", ""),
+        "broker_order_id": getattr(order, "broker_order_id", ""),
+        "side": getattr(order, "side", ""),
+        "qty": str(getattr(order, "qty", "")),
+        "status": getattr(order, "status", ""),
+        "attribution": (
+            "b0x" if is_b0x_order(getattr(order, "client_order_id", "")) else "foreign"
+        ),
+    }
+
+
+def partition(orders: tuple[Any, ...] | list[Any]) -> OrderPartition:
+    """Split orders into B0-X's and everyone else's. Pure and total."""
+
+    mine = tuple(o for o in orders if is_b0x_order(getattr(o, "client_order_id", "")))
+    foreign = tuple(
+        o for o in orders if not is_b0x_order(getattr(o, "client_order_id", ""))
+    )
+    return OrderPartition(mine=mine, foreign=foreign)
+
+
+async def scan(client: Any) -> OrderPartition:
+    """Read every resting order on the account and partition by attribution."""
+
+    result = await client.get_all_open_orders()
+    return partition(tuple(result.orders))
+
+
+@dataclass(frozen=True)
+class CancelOutcome:
+    """What the cancel pass did — and, as loudly, what it left alone."""
+
+    partition: OrderPartition
+    cancelled: tuple[dict[str, Any], ...]
+    confirm: bool
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "confirm": self.confirm,
+            "open_orders": self.partition.to_json(),
+            "cancelled": list(self.cancelled),
+            "not_mine_untouched": [
+                _order_json(order) for order in self.partition.foreign
+            ],
+        }
+
+
+async def cancel_own(
+    client: Any,
+    *,
+    confirm: bool = False,
+) -> CancelOutcome:
+    """Cancel only the B0-X-attributed resting orders on this account.
+
+    Foreign orders are carried through to the outcome untouched so the
+    report can name them; no cancel is dispatched for them under any flag.
+    """
+
+    found = await scan(client)
+    cancelled: list[dict[str, Any]] = []
+    for order in found.mine:
+        client_order_id = getattr(order, "client_order_id", "")
+        # Defense in depth: the partition already filtered, and this asserts
+        # the same invariant at the point where the DELETE actually leaves.
+        if not is_b0x_order(client_order_id):
+            raise ForeignOrderCancelAttempt(
+                f"refusing to cancel {client_order_id!r}: not a "
+                f"{CLIENT_ORDER_ID_PREFIX}- order"
+            )
+        result = await client.cancel_order(
+            symbol=getattr(order, "symbol", ""),
+            client_order_id=client_order_id,
+            confirm=confirm,
+        )
+        cancelled.append(
+            {
+                "symbol": getattr(order, "symbol", ""),
+                "client_order_id": client_order_id,
+                "broker_order_id": getattr(order, "broker_order_id", ""),
+                "side": getattr(order, "side", ""),
+                "qty": str(getattr(order, "qty", "")),
+                "requested": True,
+                "dispatched": confirm,
+                "status": getattr(result, "status", "DRY_RUN" if not confirm else ""),
+            }
+        )
+    return CancelOutcome(partition=found, cancelled=tuple(cancelled), confirm=confirm)
+
+
+__all__ = [
+    "CLIENT_ORDER_ID_PREFIX",
+    "CancelOutcome",
+    "ForeignOrderCancelAttempt",
+    "OrderPartition",
+    "cancel_own",
+    "is_b0x_order",
+    "partition",
+    "scan",
+]

--- a/scripts/b0x/crypto/sidecar.py
+++ b/scripts/b0x/crypto/sidecar.py
@@ -1,8 +1,15 @@
 """Binance Spot Demo sidecar — B0-X crypto 체결 충실도 표본.
 
-Account map (operator repo ``mock/CLAUDE.md`` §1, SHA ``7f95897``):
-*Binance Demo = B0-X crypto 사이드카 (Spot Demo · 메이저 3종 BTC/ETH/SOL-USDT
-한정 · 체결충실도 표본 전용) … CR-S1 TPR 재개 시 TPR 우선권.*
+Account map — canonical surface is the machine-readable
+``operator_contract.yaml`` (operator repo ``3f40291``, contract v1.3 ①); the
+``mock/CLAUDE.md`` §1 prose is a *reference* surface and loses on conflict:
+``account_lanes.binance_demo = B0-X-crypto-sidecar`` ·
+``reassignments.binance_demo.sidecar_scope = buy_side_fill_fidelity_sample_only``
+· ``strategy_order_exceptions ∋ b0x-adapter-orders-20260808`` (surface
+``binance_spot_demo_sidecar_buy_side_only``, ``writer = b0x_adapter_single``).
+CR-S1 TPR 재개 시 TPR 우선권. The registration order matters: this lane's
+first cycle was re-run only after the YAML entries existed, because a lane
+listed in prose alone is a lane no checker can enforce.
 
 Why this lane exists: the Upbit shadow lane calls a level "filled" the moment
 a bar touches it (``scripts.b0x.crypto.shadow`` touch rule §4). Whether a real

--- a/scripts/b0x/cycle.py
+++ b/scripts/b0x/cycle.py
@@ -31,6 +31,11 @@ from app.services.brokers.binance.spot_demo.execution_client import (
     SpotDemoDryRunResult,
 )
 from scripts.b0x import kill_switch as kill_switch_module
+from scripts.b0x.contract import (
+    SIDECAR_SCOPE,
+    account_map_stamp,
+    contract_stamp,
+)
 from scripts.b0x.crypto import shadow as shadow_lane
 from scripts.b0x.crypto import sidecar as sidecar_lane
 from scripts.b0x.derivation import DerivationResult, derive_orders
@@ -92,22 +97,6 @@ def _table_or_reason(
     return result, None
 
 
-#: Binding = version string + section citation, NOT the whole-file sha (the
-#: file is amended in place as the operator signs off further sections;
-#: re-stamping every record on each amendment would be noise). The sha below
-#: is carried as a reference/reproducibility field only — see contract
-#: preamble: "결속 = 버전 문자열 v1.3 + 인용 절 (전체파일 sha … 는 참고값)".
-CONTRACT_CITATION = "b0x-experiment-contract-v1 v1.3 (2026-08-09, operator-confirmed)"
-CONTRACT_FILE = "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md"
-CONTRACT_FILE_SHA256_REFERENCE_ONLY = (
-    "0125e2ea96b1a54cf0b0a50e6ed85ae1f3a72e7870abe727d2734dbe20e19b1f"
-)
-#: operator_contract.yaml HEAD at last verification — PR #33 (B0-X 3-surface
-#: registration: kis_mock/alpaca_paper_lab/binance_demo). Update alongside
-#: any re-verification of the account-map gate.
-ACCOUNT_MAP_SHA = "3f402919fca5b68bda187e8e521fc886aefb022a"
-
-
 def base_record(
     *,
     market: str,
@@ -125,10 +114,8 @@ def base_record(
         "at": now.isoformat(),
         "labels": list(labels),
         "envelope": envelope.canonical(),
-        "contract": CONTRACT_CITATION,
-        "contract_file": CONTRACT_FILE,
-        "contract_file_sha256_reference_only": CONTRACT_FILE_SHA256_REFERENCE_ONLY,
-        "account_map_sha": ACCOUNT_MAP_SHA,
+        "contract": contract_stamp(),
+        "account_map": account_map_stamp(),
     }
 
 
@@ -146,7 +133,20 @@ def render_cycle_report(record: dict[str, Any], *, labels: tuple[str, ...]) -> s
             f"detail: {record.get('zero_order_detail', '')}",
             "",
         ]
+    contract = record.get("contract") or {}
+    account_map = record.get("account_map") or {}
     lines += [
+        f"contract: `{contract.get('version', '-')}` "
+        f"({', '.join(contract.get('clauses') or {}) or '-'}) · "
+        f"file sha256 (reference only): `{contract.get('file_sha256_reference_only', '-')}`",
+        f"account map: `{account_map.get('repo', '-')}@"
+        f"{account_map.get('commit', '-')}` "
+        f"canonical=`{account_map.get('canonical_surface', '-')}`",
+    ]
+    if record.get("sidecar_scope"):
+        lines.append(f"sidecar scope: `{record['sidecar_scope']}`")
+    lines += [
+        "",
         f"policy_table_hash: `{record.get('policy_table_hash', '-')}`",
         f"account_state_hash: `{record.get('account_state_hash', '-')}`",
         f"cycle_id: `{record.get('cycle_id', '-')}`",
@@ -405,6 +405,11 @@ async def run_sidecar_cycle(
         }
         record["symbols"] = dict(sidecar_lane.B0X_SIDECAR_SYMBOLS)
         record["confirm"] = confirm
+        # Contract v1.3 ②: this lane samples buy-side fill fidelity only. The
+        # sell side is unreachable here (the v1 attribution rule halts the lane
+        # on its own first fill), so it is observed on the Upbit shadow lane.
+        # Stamped per-cycle so no artifact can be read as a round-trip result.
+        record["sidecar_scope"] = SIDECAR_SCOPE
 
         owns_client = client is None
         base_url = sidecar_lane.base_url()

--- a/scripts/run_b0x_cancel.py
+++ b/scripts/run_b0x_cancel.py
@@ -1,0 +1,108 @@
+"""B0-X sidecar cancel runner — own resting orders only (contract §2-4, v1.3 ①).
+
+    # Scan only. Reads the whole account, cancels nothing, dispatches zero
+    # mutation HTTP. This is the default and the safe thing to run first.
+    B0X_SIDECAR_ENABLED=true BINANCE_SPOT_DEMO_ENABLED=true \\
+        uv run python -m scripts.run_b0x_cancel
+
+    # Actually cancel the b0xc- orders (operator gate, per call).
+    ... uv run python -m scripts.run_b0x_cancel --confirm
+
+The read is account-wide on purpose: these Demo credentials are shared with
+other demo lanes, so the only honest answer to "what is resting here?" comes
+from a symbol-less query. Whatever is *not* ``b0xc-`` prefixed is printed
+under NOT_MINE and left strictly alone — there is no flag that cancels it,
+by design (mock/CLAUDE.md §4).
+
+No scheduler registration exists for this script. It runs because an operator
+ran it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+)
+from scripts.b0x.crypto import cancel as cancel_module
+from scripts.b0x.crypto import sidecar as sidecar_lane
+
+
+def _print_outcome(outcome: cancel_module.CancelOutcome) -> None:
+    part = outcome.partition
+    print(
+        f"open_orders_total={part.total} mine={len(part.mine)} foreign={len(part.foreign)}"
+    )
+    for order in part.mine:
+        print(
+            f"  MINE     {order.symbol} {order.client_order_id} "
+            f"broker_order_id={order.broker_order_id} {order.side} "
+            f"qty={order.qty} status={order.status}"
+        )
+    for order in part.foreign:
+        print(
+            f"  NOT_MINE {order.symbol} {order.client_order_id} "
+            f"broker_order_id={order.broker_order_id} {order.side} "
+            f"qty={order.qty} status={order.status}  ← untouched"
+        )
+    if not outcome.confirm:
+        print("DRY RUN — zero cancel HTTP dispatched (pass --confirm to act)")
+    for row in outcome.cancelled:
+        print(
+            f"  CANCELLED {row['symbol']} {row['client_order_id']} "
+            f"dispatched={row['dispatched']} status={row['status']}"
+        )
+
+
+async def _run(args: argparse.Namespace) -> int:
+    sidecar_lane.assert_sidecar_enabled()
+    client = BinanceSpotDemoExecutionClient.from_env()
+    try:
+        if args.scan_only:
+            found = await cancel_module.scan(client)
+            outcome = cancel_module.CancelOutcome(
+                partition=found, cancelled=(), confirm=False
+            )
+        else:
+            outcome = await cancel_module.cancel_own(client, confirm=args.confirm)
+    finally:
+        await client.aclose()
+
+    _print_outcome(outcome)
+    if args.json:
+        print(json.dumps(outcome.to_json(), sort_keys=True, ensure_ascii=False))
+    # Foreign orders are not an error, but they are a fact the operator must
+    # see, so they get a distinct non-zero exit rather than a silent success.
+    return 3 if outcome.partition.foreign else 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="dispatch the cancels for b0xc- orders. Without it, nothing is sent.",
+    )
+    parser.add_argument(
+        "--scan-only",
+        action="store_true",
+        help="read and partition the account book; never enter the cancel path",
+    )
+    parser.add_argument("--json", action="store_true", help="also emit the raw record")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.scan_only and args.confirm:
+        print("--scan-only and --confirm are mutually exclusive", file=sys.stderr)
+        return 2
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/b0x/test_cancel.py
+++ b/tests/scripts/b0x/test_cancel.py
@@ -1,0 +1,212 @@
+"""B0-X sidecar cancel — attribution gate tests.
+
+The property under test is not "cancel works". It is **cancel does not reach
+another writer's order**, on a Demo account whose credentials are shared.
+Every test below is written so that the obvious wrong implementation (cancel
+everything the account has resting) fails.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from scripts.b0x.crypto import cancel as cancel_module
+
+
+@dataclass
+class _Order:
+    symbol: str
+    client_order_id: str
+    broker_order_id: str = "1"
+    side: str = "BUY"
+    qty: Decimal = Decimal("0.001")
+    status: str = "NEW"
+
+
+@dataclass
+class _OpenOrders:
+    orders: list[Any]
+
+
+class _FakeClient:
+    """Records every cancel it is asked to dispatch."""
+
+    def __init__(self, orders: list[_Order]) -> None:
+        self._orders = orders
+        self.cancel_calls: list[dict[str, Any]] = []
+        self.symbol_scoped_calls: list[str] = []
+
+    async def get_all_open_orders(self) -> _OpenOrders:
+        return _OpenOrders(orders=list(self._orders))
+
+    async def get_open_orders(self, *, symbol: str) -> _OpenOrders:
+        # Present so a regression to symbol-scoped scanning is visible rather
+        # than an AttributeError that could be misread as an unrelated bug.
+        self.symbol_scoped_calls.append(symbol)
+        return _OpenOrders(orders=[o for o in self._orders if o.symbol == symbol])
+
+    async def cancel_order(
+        self, *, symbol: str, client_order_id: str, confirm: bool = False
+    ) -> Any:
+        self.cancel_calls.append(
+            {"symbol": symbol, "client_order_id": client_order_id, "confirm": confirm}
+        )
+
+        class _Result:
+            status = "CANCELED" if confirm else "DRY_RUN"
+
+        return _Result()
+
+
+_MINE_BTC = _Order(symbol="BTCUSDT", client_order_id="b0xc-40f2525f66712ec0")
+_MINE_ETH = _Order(symbol="ETHUSDT", client_order_id="b0xc-612791b7a7e81b65")
+# A foreign order on an allowlisted symbol — the dangerous case, because a
+# symbol-based filter would happily cancel it.
+_FOREIGN_SAME_SYMBOL = _Order(symbol="BTCUSDT", client_order_id="scalp-7781")
+# A foreign order on a symbol B0-X does not even trade.
+_FOREIGN_OTHER_SYMBOL = _Order(symbol="XRPUSDT", client_order_id="x-1")
+
+
+# ---------------------------------------------------------------------------
+# Attribution predicate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "client_order_id,expected",
+    [
+        ("b0xc-40f2525f66712ec0", True),
+        ("b0xc-", False),  # prefix with no key is not a well-formed b0x id
+        ("scalp-7781", False),
+        ("", False),
+        (None, False),
+        # Near-misses that must not be read as ours.
+        ("xb0xc-1", False),
+        ("B0XC-1", False),
+        ("b0xcabc", False),
+    ],
+)
+def test_attribution_is_exact_prefix_match(
+    client_order_id: str | None, expected: bool
+) -> None:
+    assert cancel_module.is_b0x_order(client_order_id) is expected
+
+
+@pytest.mark.unit
+def test_unattributable_order_is_foreign_not_ours() -> None:
+    """Fail-closed: no client id means no attribution means hands off."""
+
+    part = cancel_module.partition([_Order(symbol="BTCUSDT", client_order_id="")])
+    assert part.mine == ()
+    assert len(part.foreign) == 1
+
+
+# ---------------------------------------------------------------------------
+# The cancel gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancels_only_b0x_orders_and_leaves_foreign_untouched() -> None:
+    client = _FakeClient(
+        [_MINE_BTC, _FOREIGN_SAME_SYMBOL, _MINE_ETH, _FOREIGN_OTHER_SYMBOL]
+    )
+
+    outcome = await cancel_module.cancel_own(client, confirm=True)
+
+    cancelled_ids = {call["client_order_id"] for call in client.cancel_calls}
+    assert cancelled_ids == {_MINE_BTC.client_order_id, _MINE_ETH.client_order_id}
+    # The foreign BTCUSDT order shares a symbol with one we cancelled; proving
+    # it survived is the point of this test.
+    assert _FOREIGN_SAME_SYMBOL.client_order_id not in cancelled_ids
+    assert _FOREIGN_OTHER_SYMBOL.client_order_id not in cancelled_ids
+    assert {o.client_order_id for o in outcome.partition.foreign} == {
+        _FOREIGN_SAME_SYMBOL.client_order_id,
+        _FOREIGN_OTHER_SYMBOL.client_order_id,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scan_is_account_wide_not_symbol_scoped() -> None:
+    """A symbol-scoped scan would miss the XRPUSDT order entirely."""
+
+    client = _FakeClient([_MINE_BTC, _FOREIGN_OTHER_SYMBOL])
+
+    found = await cancel_module.scan(client)
+
+    assert found.total == 2
+    assert any(o.symbol == "XRPUSDT" for o in found.foreign)
+    assert client.symbol_scoped_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dry_run_dispatches_no_mutation() -> None:
+    client = _FakeClient([_MINE_BTC, _MINE_ETH])
+
+    outcome = await cancel_module.cancel_own(client)
+
+    assert all(call["confirm"] is False for call in client.cancel_calls)
+    assert all(row["dispatched"] is False for row in outcome.cancelled)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_account_with_only_foreign_orders_cancels_nothing() -> None:
+    client = _FakeClient([_FOREIGN_SAME_SYMBOL, _FOREIGN_OTHER_SYMBOL])
+
+    outcome = await cancel_module.cancel_own(client, confirm=True)
+
+    assert client.cancel_calls == []
+    assert outcome.cancelled == ()
+    assert len(outcome.partition.foreign) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_call_site_recheck_blocks_a_widened_partition() -> None:
+    """Defense in depth: if partition regresses, the dispatcher still refuses.
+
+    Simulates the exact refactor risk — someone loosens the filter — by
+    handing ``cancel_own`` a partition that wrongly includes a foreign order.
+    """
+
+    client = _FakeClient([_FOREIGN_SAME_SYMBOL])
+    bad = cancel_module.OrderPartition(mine=(_FOREIGN_SAME_SYMBOL,), foreign=())
+
+    async def _widened(_client: Any) -> cancel_module.OrderPartition:
+        return bad
+
+    original = cancel_module.scan
+    cancel_module.scan = _widened  # type: ignore[assignment]
+    try:
+        with pytest.raises(cancel_module.ForeignOrderCancelAttempt):
+            await cancel_module.cancel_own(client, confirm=True)
+    finally:
+        cancel_module.scan = original  # type: ignore[assignment]
+
+    assert client.cancel_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_outcome_json_names_untouched_foreign_orders() -> None:
+    """The report must make 'what I did not touch' visible, not just implied."""
+
+    client = _FakeClient([_MINE_BTC, _FOREIGN_SAME_SYMBOL])
+
+    outcome = await cancel_module.cancel_own(client, confirm=True)
+    payload = outcome.to_json()
+
+    assert [row["client_order_id"] for row in payload["not_mine_untouched"]] == [
+        _FOREIGN_SAME_SYMBOL.client_order_id
+    ]
+    assert payload["open_orders"]["mine"][0]["attribution"] == "b0x"
+    assert payload["open_orders"]["foreign"][0]["attribution"] == "foreign"

--- a/tests/scripts/b0x/test_contract_stamp.py
+++ b/tests/scripts/b0x/test_contract_stamp.py
@@ -1,0 +1,79 @@
+"""Contract/account-map stamp — the identity every artifact carries.
+
+Contract v1.3 ④ (job brief): the binding identity is the **version string
+plus quoted clause**, and the whole-file digest is demoted to a reference
+field. These tests pin that shape, because the failure it prevents is silent:
+an artifact that looks stamped while naming a contract the code no longer
+implements.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.b0x import contract as contract_module
+
+
+@pytest.mark.unit
+def test_version_is_the_binding_identity() -> None:
+    assert contract_module.CONTRACT_VERSION == "v1.3"
+    stamp = contract_module.contract_stamp()
+    assert stamp["version"] == "v1.3"
+
+
+@pytest.mark.unit
+def test_digest_is_named_reference_only_and_is_not_the_criterion() -> None:
+    """The field name itself is the guard against re-promoting the digest."""
+
+    stamp = contract_module.contract_stamp()
+    assert "file_sha256_reference_only" in stamp
+    # No bare "sha"/"file_sha256" key that a reader could mistake for a gate.
+    assert "sha" not in stamp
+    assert "file_sha256" not in stamp
+    assert "contract_sha" not in stamp
+
+
+@pytest.mark.unit
+def test_clauses_are_quoted_verbatim_not_merely_referenced() -> None:
+    """A clause number with no text cannot be checked against the document."""
+
+    clauses = contract_module.contract_stamp()["clauses"]
+    assert set(clauses) == {"§8 v1.3 ①", "§8 v1.3 ②"}
+    for key, text in clauses.items():
+        assert len(text) > 40, f"{key} is a reference, not a quotation"
+    # ① is the re-registration decision this job executes.
+    assert "취소" in clauses["§8 v1.3 ①"]
+    assert "재실행" in clauses["§8 v1.3 ①"]
+    # ② is the narrowed sidecar standing.
+    assert "매수측" in clauses["§8 v1.3 ②"]
+
+
+@pytest.mark.unit
+def test_sidecar_scope_is_the_narrowed_v13_standing() -> None:
+    assert contract_module.SIDECAR_SCOPE == "buy_side_fill_fidelity_sample_only"
+
+
+@pytest.mark.unit
+def test_account_map_names_yaml_as_canonical_and_md_as_reference() -> None:
+    """v1.3 ①: the machine-readable surface wins; prose is a reference."""
+
+    stamp = contract_module.account_map_stamp()
+    assert stamp["canonical_surface"] == "operator_contract.yaml"
+    assert stamp["reference_surface"] == "mock/CLAUDE.md"
+    assert stamp["repo"] == "auto_trader-operator"
+    # The commit that actually carries the B0-X entries (PR #33).
+    assert stamp["commit"].startswith("3f40291")
+
+
+@pytest.mark.unit
+def test_stale_pre_registration_account_map_sha_is_gone() -> None:
+    """The old stamp pointed at a commit where B0-X was prose-only.
+
+    That commit is exactly the state contract v1.3 ① calls an editing
+    mistake, so no artifact may still claim it.
+    """
+
+    rendered = repr(contract_module.account_map_stamp()) + repr(
+        contract_module.contract_stamp()
+    )
+    assert "7f95897" not in rendered

--- a/tests/scripts/b0x/test_no_forbidden_imports.py
+++ b/tests/scripts/b0x/test_no_forbidden_imports.py
@@ -20,8 +20,13 @@ import pytest
 pytestmark = pytest.mark.unit
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[3] / "scripts" / "b0x"
-RUNNER = Path(__file__).resolve().parents[3] / "scripts" / "run_b0x_cycle.py"
-KR_RUNNER = Path(__file__).resolve().parents[3] / "scripts" / "run_b0x_kr_cycle.py"
+#: Every B0-X entry point outside the package directory. A runner that is not
+#: listed here is a runner the guard does not scan, so new CLIs go in this
+#: tuple in the same commit that adds them.
+RUNNERS = tuple(
+    Path(__file__).resolve().parents[3] / "scripts" / name
+    for name in ("run_b0x_cycle.py", "run_b0x_kr_cycle.py", "run_b0x_cancel.py")
+)
 
 #: In-process LLM providers — the ROB-501 runtime ownership boundary.
 FORBIDDEN_LLM = (
@@ -72,7 +77,7 @@ FORBIDDEN_SCHEDULER = (
 
 
 def _python_files() -> list[Path]:
-    return sorted([*PACKAGE_ROOT.rglob("*.py"), RUNNER, KR_RUNNER])
+    return sorted([*PACKAGE_ROOT.rglob("*.py"), *RUNNERS])
 
 
 def _imported_modules(path: Path) -> set[str]:

--- a/tests/services/brokers/binance/spot_demo/test_get_all_open_orders.py
+++ b/tests/services/brokers/binance/spot_demo/test_get_all_open_orders.py
@@ -51,9 +51,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> BinanceSpotDemoExecutionClient:
 
 @pytest.mark.asyncio
 async def test_returns_orders_across_every_symbol(client, httpx_mock):
-    httpx_mock.add_response(
-        method="GET", url=_OPEN_ORDERS_RE, json=_ACCOUNT_WIDE_JSON
-    )
+    httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=_ACCOUNT_WIDE_JSON)
 
     result = await client.get_all_open_orders()
 

--- a/tests/services/brokers/binance/spot_demo/test_get_all_open_orders.py
+++ b/tests/services/brokers/binance/spot_demo/test_get_all_open_orders.py
@@ -1,0 +1,111 @@
+"""Account-wide open-orders read (symbol omitted).
+
+Mirrors the ROB-993 futures precedent: ``get_open_orders(symbol=...)`` cannot
+answer "is anything else resting on this shared account?", so the additive
+symbol-less read exists alongside it. The existing symbol-scoped method must
+stay byte-identical.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+)
+
+_BASE = "https://demo-api.binance.com"
+_OPEN_ORDERS_RE = re.compile(r"^https://demo-api\.binance\.com/api/v3/openOrders\?.*$")
+
+_ACCOUNT_WIDE_JSON = [
+    {
+        "symbol": "BTCUSDT",
+        "orderId": 54962605151,
+        "clientOrderId": "b0xc-40f2525f66712ec0",
+        "side": "BUY",
+        "origQty": "0.00015000",
+        "status": "NEW",
+    },
+    {
+        "symbol": "XRPUSDT",
+        "orderId": 777,
+        "clientOrderId": "someone-else-1",
+        "side": "SELL",
+        "origQty": "10.00000000",
+        "status": "NEW",
+    },
+]
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> BinanceSpotDemoExecutionClient:
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "DUMMY_KEY")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "DUMMY_SECRET")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_BASE_URL", _BASE)
+    return BinanceSpotDemoExecutionClient.from_env()
+
+
+@pytest.mark.asyncio
+async def test_returns_orders_across_every_symbol(client, httpx_mock):
+    httpx_mock.add_response(
+        method="GET", url=_OPEN_ORDERS_RE, json=_ACCOUNT_WIDE_JSON
+    )
+
+    result = await client.get_all_open_orders()
+
+    assert [o.symbol for o in result.orders] == ["BTCUSDT", "XRPUSDT"]
+    assert result.orders[0].client_order_id == "b0xc-40f2525f66712ec0"
+    assert result.orders[0].broker_order_id == "54962605151"
+    assert result.orders[0].qty == Decimal("0.00015000")
+    assert result.orders[1].side == "SELL"
+
+
+@pytest.mark.asyncio
+async def test_request_omits_symbol_so_binance_returns_the_whole_account(
+    client, httpx_mock
+):
+    """A ``symbol`` param would silently narrow the answer to one market."""
+
+    httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
+
+    await client.get_all_open_orders()
+
+    request = httpx_mock.get_requests()[0]
+    assert "symbol=" not in str(request.url)
+    assert str(request.url).startswith(f"{_BASE}/api/v3/openOrders")
+
+
+@pytest.mark.asyncio
+async def test_empty_account_returns_no_orders(client, httpx_mock):
+    httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
+
+    result = await client.get_all_open_orders()
+
+    assert result.orders == []
+
+
+@pytest.mark.asyncio
+async def test_symbol_scoped_read_still_sends_its_symbol(client, httpx_mock):
+    """The additive method must not have changed the existing one."""
+
+    httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
+
+    await client.get_open_orders(symbol="BTCUSDT")
+
+    assert "symbol=BTCUSDT" in str(httpx_mock.get_requests()[0].url)
+
+
+@pytest.mark.asyncio
+async def test_read_is_signed_and_stays_on_the_demo_host(client, httpx_mock):
+    httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
+
+    await client.get_all_open_orders()
+
+    url = str(httpx_mock.get_requests()[0].url)
+    assert url.startswith("https://demo-api.binance.com/")
+    assert "signature=" in url
+    assert "timestamp=" in url


### PR DESCRIPTION
계약 v1.3 ① 실행 — B0-X 가 **기계판독 정본**(`operator_contract.yaml`)에 등재되기 전에
나간 매수 2건을 취소하고, 등재 완료 상태에서 첫 사이클을 재실행했다.

> 🔴 관측 산출물이지 검증이 아니다. `PROSPECTIVE_EXPERIMENT_ONLY` — 어떤 전략의 채점·승격 근거도 아니다.

## 실측 결과 (요약)

| | |
|---|---|
| 계좌 전체 미체결 (취소 전) | 2건 · **전부 `b0xc-` 귀속** · foreign **0** |
| 취소 | `b0xc-40f2525f66712ec0` · `b0xc-612791b7a7e81b65` → `CANCELED` |
| 손대지 않은 주문 | 없음 (foreign 0) |
| 부분체결 | **없음** — ETH 잔고 0, BTC/SOL dust 바이트 불변, USDT `4978.050 + 19.328 = 4997.378` 정확히 복원 |
| 새 표 | `sha256:0524e185…` · `generated_at 2026-08-08T21:56:19Z` · rows 35 |
| 첫 사이클 | `cycle_id b0x-421269ccf2941df42a3e` · orders 2 · skipped 6 · kill 미발화 |
| 결정성 | dry-run ≡ confirm — `cycle_id`·`derivation_hash` 동일 |

🔵 직전 표는 **8h03m55s** 경과로 `MAX_TABLE_AGE crypto 8h` 초과 → STALE 확정.
재생성이 선택이 아니라 필수였다 (그대로 뒀으면 사이클은 주문 0). 표 커밋 =
operator PR [#34](https://github.com/mgh3326/auto_trader-operator/pull/34) (`f361587`).

## 1. 취소 경로 — 계좌 전체를 읽고, 내 주문만 취소한다

계약 §2-4 는 kill 시 「잔여 주문 취소」를 요구하는데 **어댑터에 취소 수단이 없었다.**

이 Demo 자격증명은 다른 데모 레인과 공유된다(strategy-loop 런북 §5). 그래서
「미체결을 취소한다」와 「**내** 미체결을 취소한다」는 다른 연산이고 후자만 권한이 있다:

- **읽기는 계좌 전체** (`get_all_open_orders`, symbol 생략). 심볼 3종만 훑으면
  네 번째 심볼에 얹힌 남의 주문을 못 보고 "깨끗하다"고 보고하게 된다.
- **귀속은 `b0xc-` 접두 매칭이지 추정이 아니다.** 그 외는 전부 foreign — "아마 우리 것",
  "심볼이 같으니 우리 것" 없음. `clientOrderId` 부재도 foreign(fail-closed).
- **접두를 DELETE 직전에 재검사**한다 — `partition` 이 훗날 느슨해져도 dispatcher 가 막는다.
- foreign 주문은 **출력만 하고 손대지 않는다. 취소하는 플래그가 존재하지 않는다**
  (mock/CLAUDE.md §4).

`get_all_open_orders()` 는 additive read-only 추가 (ROB-993 futures 선례와 동형).
기존 `get_open_orders(symbol=...)` 는 무변경.

## 2. 계약 스탬프 — 버전+절이 결속하고, 파일 sha 는 참고로 강등

이전 스탬프는 계약을 **전체파일 sha** 로 식별했다. 가장 강해 보이지만 실은 가장 약하다:
계약은 살아있는 문서라 이 레인과 무관한 개정에도 digest 가 바뀌므로, 「잘못된 계약을 물고
있다」와 「다른 문단이 늘었다」를 구분하지 못한다. **X-U 검증이 잡은 드리프트 결함이
정확히 이것**이다.

`scripts/b0x/contract.py` 신설 — 결속 identity = `CONTRACT_VERSION` + **축자 인용 절**,
digest 는 `file_sha256_reference_only` 로 **이름부터** 게이트가 아님을 못박는다.

`account_map_sha` 는 등재 **이전** 커밋(`7f95897` — v1.3 ① 이 편집 실수라 부른 바로 그
상태)을 가리키고 있어, 정본 커밋 `3f40291` + canonical/reference 표면 이름으로 교체.

사이드카 산출물에 `sidecar_scope=buy_side_fill_fidelity_sample_only` 박제(v1.3 ②).
매도측은 v1 자동 경로에서 **도달 불가**(파생 `no_position_to_sell` + submit
`SidecarContaminated` 이중 장벽)라 본선(Upbit shadow)이 담당한다. 런북의 「왕복 1회」
표현도 이에 맞춰 정정 — **X-S2 검증 SHOULD 항목 해소**.

## 3. 판정 로직 무접촉 (diff 0줄)

```
$ git diff origin/main -- scripts/b0x/envelope.py scripts/b0x/derivation.py \
    scripts/b0x/kill_switch.py scripts/b0x/state.py scripts/b0x/table_source.py \
    scripts/b0x/ledger.py scripts/b0x/crypto/shadow.py scripts/run_b0x_cycle.py | wc -l
0
```
`cycle.py` 는 스탬프만, `sidecar.py` 는 **docstring 만** — 오염 판정
(`sellable_qty`/`read_fresh_truth`)은 바이트 불변. envelope 5상한 실측: 주문당
9.4585·9.8731 ≤ 10 · 종목총 ≤ 50 · 동시 2/3 · 일신규 **2/2 발화**(SOL 차단) · kill 미발화.

## 테스트

- `test_cancel.py` — **같은 심볼에 얹힌 남의 주문 생존**(위험 케이스) · 계좌 전체 스캔 ·
  접두 근사치(`xb0xc-`/`B0XC-`/`b0xcabc`/`b0xc-`) 전부 foreign · call-site 재검사
- `test_contract_stamp.py` — digest 가 criterion 으로 재승격되지 못하게 **필드명 자체**를
  단언 · 절은 참조번호가 아니라 축자 인용
- `test_get_all_open_orders.py` — 요청에 `symbol` 부재 · 기존 심볼 스코프 read 불변
- import 가드가 신규 러너까지 스캔하도록 확장 — **변형 주입으로 실효성 확인**
  (`apscheduler` 삽입 시 `test_no_scheduler_registration[run_b0x_cancel.py]` FAIL)

로컬: `tests/scripts/b0x` + `tests/services/brokers/binance` **902 passed** · ruff · ty clean

## 경계

`LIVE_CONTACT = 0` — 근거(상수 스탬프 아님): 전 호출 host `demo-api.binance.com` 단일이며
기록된 `base_url_host` 가 그 값이고, 셸에 export 한 자격증명은 `BINANCE_SPOT_DEMO_*` 뿐이다
(futures/live 변수 미노출). `FUTURES_DEMO = 0` — `demo-fapi.binance.com` 무접촉.
`TPR_CONTACT = 0` — CR-S1 트랙 무접촉. 매도·청산 주문 0 · dust 정의 무변경 ·
allowlist 3종 고정 · 스케줄러 등록 0 · in-process LLM 0.

**다음 상태 = 검증 대기. 머지하지 않는다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account-wide retrieval of open Binance Spot Demo orders across all symbols.
  * Added a cancellation tool that identifies B0-X orders by client ID and cancels only owned orders.
  * Scanning is read-only by default; cancellations require explicit confirmation.
  * Added JSON reporting for owned and foreign orders, with clear handling when unowned orders are present.

* **Documentation**
  * Updated operational guidance for order cleanup, contract registration, and sidecar scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->