### PR TITLE
feat(b0x): label shared account history on sidecar

### DIFF
--- a/scripts/b0x/contract.py
+++ b/scripts/b0x/contract.py
@@ -34,25 +34,22 @@ from typing import Any, Final
 CONTRACT_PATH: Final[str] = "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md"
 
 #: Binding identity. Bump together with the clauses below.
-CONTRACT_VERSION: Final[str] = "v1.3"
+CONTRACT_VERSION: Final[str] = "v1.4"
 
 #: Provenance only — NOT a drift criterion. See the module docstring.
 CONTRACT_FILE_SHA256_REFERENCE_ONLY: Final[str] = (
-    "0125e2ea96b1a54cf0b0a50e6ed85ae1f3a72e7870abe727d2734dbe20e19b1f"
+    "bce7104bd1a3f36a253baecc05d8bc960ad1c41a82de4c345d6659320ad1f5f8"
 )
 
-#: Verbatim §8 v1.3 clauses this package implements.
+#: Verbatim §8 v1.4 clauses this package implements.
 CONTRACT_CLAUSES: Final[dict[str, str]] = {
-    "§8 v1.3 ①": (
-        "계좌맵 기계판독 정본 = operator_contract.yaml 확정 — B0-X 3곳 등재"
-        "(account_lanes·reassignments·strategy_order_exceptions "
-        "b0x-adapter-orders-20260808), MD 는 참조로 강등. 미등재 상태에서 나간 "
-        "매수 2건은 취소 후 등재 완료 상태에서 첫 사이클 재실행."
+    "§8 v1.4 ②": (
+        "관측 산출물에 **`SHARED_ACCOUNT_HISTORY` 라벨** 부착(**과거 dust·사고 "
+        "이력 계좌**)."
     ),
-    "§8 v1.3 ②": (
-        "사이드카 지위 = 매수측 체결충실도 표본으로 축소(자기오염 v1 성문 한계 — "
-        "자기 매수 체결 시 오염 판정, 매도측 도달 불가). 매도측 관측은 본선"
-        "(Upbit shadow, 왕복 가능)이 담당."
+    "§8 v1.4 ③": (
+        "writer=1 문언 정합: 「B0-X 측 단일 writer + 계좌 배타성은 운영 "
+        "조치(disarm)로 확보, 방어는 오염 게이트의 fail-closed 관측」."
     ),
 }
 

--- a/scripts/b0x/cycle.py
+++ b/scripts/b0x/cycle.py
@@ -48,6 +48,7 @@ from scripts.b0x.envelope import (
 from scripts.b0x.labels import (
     CROSS_QUOTE_RATIO_TRANSFER,
     SHADOW_SYNTHETIC_FILL,
+    account_history_labels,
     header_labels,
     render_header,
 )
@@ -386,8 +387,10 @@ async def run_sidecar_cycle(
     assert_envelope_locked(envelope)
     sidecar_lane.assert_sidecar_enabled()
     policy = sidecar_lane.build_policy(envelope)
-    labels = header_labels(extra=(CROSS_QUOTE_RATIO_TRANSFER,))
     lane = sidecar_lane.LANE
+    labels = header_labels(
+        extra=(*account_history_labels(lane), CROSS_QUOTE_RATIO_TRANSFER)
+    )
     outcome = CycleOutcome(lane=lane, at=now)
 
     with writer_lock(lane=lane, root=Path(out_dir).expanduser()):

--- a/scripts/b0x/labels.py
+++ b/scripts/b0x/labels.py
@@ -10,6 +10,8 @@ on top; the three inherited ones always come first and always all three
 
 from __future__ import annotations
 
+from typing import Final
+
 from scripts.policy_table.core.trust_labels import TRUST_LABELS
 
 #: B0-X §1 identity — every artifact carries these after the inherited three.
@@ -19,10 +21,37 @@ B0X_IDENTITY_LABELS: tuple[str, ...] = (
         "어떤 전략의 채점·승격 근거도 아니며 D3 prospective confirmatory 가 아니다."
     ),
     (
-        "WRITER_SINGLETON — 이 계좌의 주문 생성 주체는 B0-X 어댑터 하나뿐이다. "
-        "수동·세션 주문이 감지되면 해당 구간은 CONTAMINATED 로 분리 표시된다."
+        "WRITER_SINGLETON — B0-X 측 주문 생성 주체는 B0-X 어댑터 하나다. "
+        "계좌 배타성은 프로덕션 데모 스캘핑 봇 disarm 운영 조치로 확보했으며, "
+        "방어는 오염 게이트의 fail-closed 관측에 둔다. 수동·외부 주문이 감지되면 "
+        "해당 구간은 CONTAMINATED 로 분리 표시된다."
     ),
 )
+
+#: Account-property caveat, deliberately not part of the fixed trust header.
+#: The value is a lane/account scope key so widening the scope is one explicit
+#: data change, not a change to the label-selection logic.
+SHARED_HISTORY_ACCOUNTS: Final[frozenset[str]] = frozenset(
+    {"binance_spot_demo_sidecar"}
+)
+
+SHARED_ACCOUNT_HISTORY: Final[str] = (
+    "SHARED_ACCOUNT_HISTORY — 이 계좌는 B0-X 이전에 다른 주체가 사용한 이력이 있다"
+    "(ROB-298 스모크가 남긴 BTC·SOL dust 및 2026-07-29 ROB-1150 사고 기록 4건). "
+    "프로덕션 데모 스캘핑 봇과 자격증명을 공유해 왔고 2026-08-09 disarm 됐다. "
+    "따라서 이 계좌의 체결·잔고 이력 전부를 B0-X 산출로 읽으면 안 된다."
+)
+
+
+def account_history_labels(
+    account: str, *, accounts: frozenset[str] = SHARED_HISTORY_ACCOUNTS
+) -> tuple[str, ...]:
+    """Return account-history caveats for the explicitly scoped account."""
+
+    if account in accounts:
+        return (SHARED_ACCOUNT_HISTORY,)
+    return ()
+
 
 #: Sidecar-only caveat. Kept out of the fixed header (which stays 3/3 + identity)
 #: and recorded in the artifact body, because it describes a venue transfer
@@ -55,6 +84,9 @@ def render_header(labels: tuple[str, ...]) -> str:
 __all__ = [
     "TRUST_LABELS",
     "B0X_IDENTITY_LABELS",
+    "SHARED_HISTORY_ACCOUNTS",
+    "SHARED_ACCOUNT_HISTORY",
+    "account_history_labels",
     "CROSS_QUOTE_RATIO_TRANSFER",
     "SHADOW_SYNTHETIC_FILL",
     "header_labels",

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 
 from scripts.b0x.kr.cycle import OUTSIDE_RTH_REASON, run_kr_cycle
-from scripts.b0x.labels import TRUST_LABELS
+from scripts.b0x.labels import SHARED_ACCOUNT_HISTORY, TRUST_LABELS
 from scripts.b0x.ledger import ObservationLedger
 from tests.scripts.b0x._table_fixtures import (
     make_payload,
@@ -194,6 +194,8 @@ async def test_dry_run_plans_but_never_dispatches(
     artifact_text = outcome.artifact_path.read_text(encoding="utf-8")
     for label in TRUST_LABELS:
         assert label in artifact_text
+    assert SHARED_ACCOUNT_HISTORY not in outcome.record["labels"]
+    assert "SHARED_ACCOUNT_HISTORY" not in artifact_text
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/test_contract_stamp.py
+++ b/tests/scripts/b0x/test_contract_stamp.py
@@ -1,6 +1,6 @@
 """Contract/account-map stamp — the identity every artifact carries.
 
-Contract v1.3 ④ (job brief): the binding identity is the **version string
+Contract v1.4 ②③ (job brief): the binding identity is the **version string
 plus quoted clause**, and the whole-file digest is demoted to a reference
 field. These tests pin that shape, because the failure it prevents is silent:
 an artifact that looks stamped while naming a contract the code no longer
@@ -16,9 +16,9 @@ from scripts.b0x import contract as contract_module
 
 @pytest.mark.unit
 def test_version_is_the_binding_identity() -> None:
-    assert contract_module.CONTRACT_VERSION == "v1.3"
+    assert contract_module.CONTRACT_VERSION == "v1.4"
     stamp = contract_module.contract_stamp()
-    assert stamp["version"] == "v1.3"
+    assert stamp["version"] == "v1.4"
 
 
 @pytest.mark.unit
@@ -38,14 +38,12 @@ def test_clauses_are_quoted_verbatim_not_merely_referenced() -> None:
     """A clause number with no text cannot be checked against the document."""
 
     clauses = contract_module.contract_stamp()["clauses"]
-    assert set(clauses) == {"§8 v1.3 ①", "§8 v1.3 ②"}
+    assert set(clauses) == {"§8 v1.4 ②", "§8 v1.4 ③"}
     for key, text in clauses.items():
         assert len(text) > 40, f"{key} is a reference, not a quotation"
-    # ① is the re-registration decision this job executes.
-    assert "취소" in clauses["§8 v1.3 ①"]
-    assert "재실행" in clauses["§8 v1.3 ①"]
-    # ② is the narrowed sidecar standing.
-    assert "매수측" in clauses["§8 v1.3 ②"]
+    assert "SHARED_ACCOUNT_HISTORY" in clauses["§8 v1.4 ②"]
+    assert "disarm" in clauses["§8 v1.4 ③"]
+    assert "fail-closed" in clauses["§8 v1.4 ③"]
 
 
 @pytest.mark.unit

--- a/tests/scripts/b0x/test_cycle.py
+++ b/tests/scripts/b0x/test_cycle.py
@@ -12,7 +12,11 @@ import pytest
 
 from scripts.b0x.crypto import shadow, sidecar
 from scripts.b0x.cycle import run_shadow_cycle, run_sidecar_cycle
-from scripts.b0x.labels import SHADOW_SYNTHETIC_FILL, TRUST_LABELS
+from scripts.b0x.labels import (
+    SHADOW_SYNTHETIC_FILL,
+    SHARED_ACCOUNT_HISTORY,
+    TRUST_LABELS,
+)
 from scripts.b0x.ledger import ObservationLedger
 from tests.scripts.b0x._table_fixtures import (
     make_payload,
@@ -232,6 +236,9 @@ async def test_sidecar_dry_run_plans_but_dispatches_nothing(
     assert all(row["dispatched"] is False for row in outcome.record["submitted"])
     assert all(call["confirm"] is False for call in client.submitted)
     assert outcome.record["base_url_host"] == "demo-api.binance.com"
+    assert SHARED_ACCOUNT_HISTORY in outcome.record["labels"]
+    artifact_text = outcome.artifact_path.read_text(encoding="utf-8")
+    assert f"> {SHARED_ACCOUNT_HISTORY}" in artifact_text
 
     # Only the three authorized symbols can appear.
     for row in outcome.record["planned"]:

--- a/tests/scripts/b0x/test_labels.py
+++ b/tests/scripts/b0x/test_labels.py
@@ -1,0 +1,64 @@
+"""B0-X v1.4 account-history label scope and wording guards."""
+
+from __future__ import annotations
+
+from scripts.b0x import contract as contract_module
+from scripts.b0x.kr.mock import LANE as KR_LANE
+from scripts.b0x.labels import (
+    B0X_IDENTITY_LABELS,
+    SHARED_ACCOUNT_HISTORY,
+    SHARED_HISTORY_ACCOUNTS,
+    account_history_labels,
+)
+
+
+def test_shared_history_scope_starts_with_binance_sidecar_only() -> None:
+    assert SHARED_HISTORY_ACCOUNTS == frozenset({"binance_spot_demo_sidecar"})
+    assert account_history_labels("binance_spot_demo_sidecar") == (
+        SHARED_ACCOUNT_HISTORY,
+    )
+
+
+def test_adding_an_account_key_is_the_only_scope_expansion() -> None:
+    expanded_scope = SHARED_HISTORY_ACCOUNTS | {KR_LANE}
+
+    assert account_history_labels(KR_LANE) == ()
+    assert account_history_labels(KR_LANE, accounts=expanded_scope) == (
+        SHARED_ACCOUNT_HISTORY,
+    )
+
+
+def test_kr_and_us_are_not_in_the_initial_scope() -> None:
+    assert account_history_labels(KR_LANE) == ()
+    assert account_history_labels("alpaca_paper_lab") == ()
+
+
+def test_writer_singleton_matches_v1_4_section_three() -> None:
+    writer_label = next(
+        label for label in B0X_IDENTITY_LABELS if label.startswith("WRITER_SINGLETON")
+    )
+
+    assert "B0-X 측 주문 생성 주체는 B0-X 어댑터 하나다" in writer_label
+    assert "disarm 운영 조치로 확보" in writer_label
+    assert "오염 게이트의 fail-closed 관측" in writer_label
+    assert "이 계좌의 주문 생성 주체는 B0-X 어댑터 하나뿐이다" not in writer_label
+
+
+def test_shared_history_wording_is_complete_and_non_exaggerated() -> None:
+    assert SHARED_ACCOUNT_HISTORY.startswith("SHARED_ACCOUNT_HISTORY —")
+    assert "B0-X 이전에 다른 주체가 사용한 이력" in SHARED_ACCOUNT_HISTORY
+    assert "BTC·SOL dust" in SHARED_ACCOUNT_HISTORY
+    assert "2026-07-29 ROB-1150 사고 기록 4건" in SHARED_ACCOUNT_HISTORY
+    assert "프로덕션 데모 스캘핑 봇과 자격증명을 공유" in SHARED_ACCOUNT_HISTORY
+    assert "2026-08-09 disarm" in SHARED_ACCOUNT_HISTORY
+    assert "체결·잔고 이력 전부를 B0-X 산출로 읽으면 안 된다" in SHARED_ACCOUNT_HISTORY
+    assert "이제 단독" not in SHARED_ACCOUNT_HISTORY
+
+
+def test_contract_stamp_points_to_v1_4_reference() -> None:
+    assert contract_module.CONTRACT_VERSION == "v1.4"
+    assert set(contract_module.CONTRACT_CLAUSES) == {"§8 v1.4 ②", "§8 v1.4 ③"}
+    assert (
+        contract_module.CONTRACT_FILE_SHA256_REFERENCE_ONLY
+        == "bce7104bd1a3f36a253baecc05d8bc960ad1c41a82de4c345d6659320ad1f5f8"
+    )


### PR DESCRIPTION
## Summary
- Add SHARED_ACCOUNT_HISTORY as an explicit sidecar-only account caveat.
- Render it in Binance Spot Demo sidecar observation headers/body while keeping KR/US out of scope.
- Align WRITER_SINGLETON wording and contract stamp with v1.4 §8 ②③.

## Verification
- B0-X suite: 272 passed.
- make lint: passed (Ruff + format + ty).
- ruff format --check .: 3842 files already formatted.
- make test: 3 pre-existing/unrelated failures in tests/research/test_kr_backfill_build_clients.py; 18576 passed, 10 skipped, 7 deselected.
- No order/cancel/broker/live-account calls; dry-run fake-client evidence only.

Merge is intentionally not performed.