### PR TITLE
fix(b0x): close follow-up guard and label gaps

### DIFF
--- a/scripts/b0x/crypto/shadow.py
+++ b/scripts/b0x/crypto/shadow.py
@@ -54,9 +54,10 @@ from typing import Any, Final
 
 from app.services.brokers.upbit.client import fetch_ohlcv
 from scripts.b0x.derivation import DerivedOrder
+from scripts.b0x.scope import UPBIT_SHADOW_SCOPE_KEY
 from scripts.b0x.state import B0XPosition, LaneAccountState
 
-LANE: Final[str] = "upbit_shadow"
+LANE: Final[str] = UPBIT_SHADOW_SCOPE_KEY
 QUOTE_CURRENCY: Final[str] = "KRW"
 
 #: Upbit KRW market fee, maker == taker == 0.05%.

--- a/scripts/b0x/crypto/sidecar.py
+++ b/scripts/b0x/crypto/sidecar.py
@@ -94,8 +94,9 @@ from app.services.brokers.binance.spot_demo.sizing import (
 )
 from scripts.b0x.derivation import DerivedOrder
 from scripts.b0x.envelope import Envelope, assert_envelope_locked
+from scripts.b0x.scope import BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY
 
-LANE: Final[str] = "binance_spot_demo_sidecar"
+LANE: Final[str] = BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY
 
 #: Table symbol -> Binance Spot symbol. Frozen: the account map authorizes
 #: exactly these three and nothing else. Adding a row here is an account-map

--- a/scripts/b0x/cycle.py
+++ b/scripts/b0x/cycle.py
@@ -198,7 +198,7 @@ async def run_shadow_cycle(
 
     envelope = load_envelope(MARKET)
     assert_envelope_locked(envelope)
-    labels = header_labels(extra=(SHADOW_SYNTHETIC_FILL,))
+    labels = header_labels(lane=shadow_lane.LANE, extra=(SHADOW_SYNTHETIC_FILL,))
     lane = shadow_lane.LANE
     outcome = CycleOutcome(lane=lane, at=now)
 
@@ -389,7 +389,8 @@ async def run_sidecar_cycle(
     policy = sidecar_lane.build_policy(envelope)
     lane = sidecar_lane.LANE
     labels = header_labels(
-        extra=(*account_history_labels(lane), CROSS_QUOTE_RATIO_TRANSFER)
+        lane=lane,
+        extra=(*account_history_labels(lane), CROSS_QUOTE_RATIO_TRANSFER),
     )
     outcome = CycleOutcome(lane=lane, at=now)
 

--- a/scripts/b0x/kr/cycle.py
+++ b/scripts/b0x/kr/cycle.py
@@ -54,7 +54,7 @@ from scripts.b0x.derivation import DerivationResult, derive_orders
 from scripts.b0x.envelope import assert_envelope_locked, load_envelope
 from scripts.b0x.kill_switch import evaluate as evaluate_kill_switch
 from scripts.b0x.kr import mock as kr_mock
-from scripts.b0x.labels import header_labels
+from scripts.b0x.labels import account_history_labels, header_labels
 from scripts.b0x.ledger import (
     DEFAULT_OBSERVATION_DIR,
     ObservationLedger,
@@ -184,7 +184,10 @@ async def run_kr_cycle(
 
     envelope = load_envelope(MARKET)
     assert_envelope_locked(envelope)
-    labels = header_labels()
+    # Keep the KR lane wired to the scope helper even while the initial scope
+    # remains sidecar-only. A future, explicit scope expansion must change the
+    # rendered KR artifact rather than disappear because this call was absent.
+    labels = header_labels(lane=LANE, extra=account_history_labels(LANE))
     outcome = KrCycleOutcome(lane=LANE, at=now)
 
     with writer_lock(lane=LANE, root=Path(out_dir).expanduser()):

--- a/scripts/b0x/kr/mock.py
+++ b/scripts/b0x/kr/mock.py
@@ -89,8 +89,9 @@ from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 from app.services.brokers.kis.protocols import KISClientProtocol
 from scripts.b0x.derivation import DerivedOrder
 from scripts.b0x.envelope import Envelope, assert_envelope_locked
+from scripts.b0x.scope import KIS_MOCK_SCOPE_KEY
 
-LANE = "kis_mock"
+LANE = KIS_MOCK_SCOPE_KEY
 MARKET = "kr"
 QUOTE_CURRENCY = "KRW"
 

--- a/scripts/b0x/labels.py
+++ b/scripts/b0x/labels.py
@@ -10,8 +10,16 @@ on top; the three inherited ones always come first and always all three
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from typing import Final
 
+from scripts.b0x.scope import (
+    ALPACA_PAPER_LAB_SCOPE_KEY,
+    BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY,
+    KIS_MOCK_SCOPE_KEY,
+    KNOWN_B0X_SCOPE_KEYS,
+    UPBIT_SHADOW_SCOPE_KEY,
+)
 from scripts.policy_table.core.trust_labels import TRUST_LABELS
 
 #: B0-X §1 identity — every artifact carries these after the inherited three.
@@ -22,17 +30,40 @@ B0X_IDENTITY_LABELS: tuple[str, ...] = (
     ),
     (
         "WRITER_SINGLETON — B0-X 측 주문 생성 주체는 B0-X 어댑터 하나다. "
-        "계좌 배타성은 프로덕션 데모 스캘핑 봇 disarm 운영 조치로 확보했으며, "
         "방어는 오염 게이트의 fail-closed 관측에 둔다. 수동·외부 주문이 감지되면 "
         "해당 구간은 CONTAMINATED 로 분리 표시된다."
     ),
 )
 
+# Account-specific evidence belongs in a lane-injected caveat, not in the
+# fixed identity header. In particular, the Binance disarm is not a KR or
+# shadow fact (contract v1.4 §3 and §8 v1.4 ③).
+WRITER_SINGLETON_SCOPE_CAVEATS: Final[dict[str, str]] = {
+    BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY: (
+        "WRITER_SINGLETON_SCOPE_CAVEAT — Binance Spot Demo 사이드카 계좌의 "
+        "배타성은 프로덕션 데모 스캘핑 봇 disarm 운영 조치(2026-08-09)로 확보됐다."
+    ),
+    KIS_MOCK_SCOPE_KEY: (
+        "WRITER_SINGLETON_SCOPE_CAVEAT — kis_mock(KR) 계좌 배타성의 근거는 "
+        "operator account map의 exclusive_lane 및 B0-X 단일 writer 할당이다. "
+        "posture-v1 shadow와 방향성 랩은 관측 전용으로 공존한다."
+    ),
+    UPBIT_SHADOW_SCOPE_KEY: (
+        "WRITER_SINGLETON_SCOPE_CAVEAT — Upbit shadow-sim은 실계좌가 아닌 "
+        "합성 체결이다. 이 레인에는 계좌 배타성 근거가 없으므로 계좌 배타성을 "
+        "주장하지 않는다."
+    ),
+    ALPACA_PAPER_LAB_SCOPE_KEY: (
+        "WRITER_SINGLETON_SCOPE_CAVEAT — Alpaca paper lab은 operator account "
+        "map에서 B0-X-US 점유자로 지정된 레인이다."
+    ),
+}
+
 #: Account-property caveat, deliberately not part of the fixed trust header.
 #: The value is a lane/account scope key so widening the scope is one explicit
 #: data change, not a change to the label-selection logic.
 SHARED_HISTORY_ACCOUNTS: Final[frozenset[str]] = frozenset(
-    {"binance_spot_demo_sidecar"}
+    {BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY}
 )
 
 SHARED_ACCOUNT_HISTORY: Final[str] = (
@@ -43,14 +74,38 @@ SHARED_ACCOUNT_HISTORY: Final[str] = (
 )
 
 
+def _unknown_scope_keys(accounts: Collection[str]) -> tuple[str, ...]:
+    return tuple(sorted(set(accounts) - KNOWN_B0X_SCOPE_KEYS))
+
+
+def _assert_known_scope_key(account: str) -> None:
+    if account not in KNOWN_B0X_SCOPE_KEYS:
+        known = ", ".join(sorted(KNOWN_B0X_SCOPE_KEYS))
+        raise ValueError(f"unknown B0-X scope key {account!r}; known keys: {known}")
+
+
 def account_history_labels(
-    account: str, *, accounts: frozenset[str] = SHARED_HISTORY_ACCOUNTS
+    account: str, *, accounts: Collection[str] | None = None
 ) -> tuple[str, ...]:
     """Return account-history caveats for the explicitly scoped account."""
 
-    if account in accounts:
+    _assert_known_scope_key(account)
+    active_accounts = SHARED_HISTORY_ACCOUNTS if accounts is None else accounts
+    unknown = _unknown_scope_keys(active_accounts)
+    if unknown:
+        raise ValueError(
+            "unknown B0-X shared-history scope key(s): " + ", ".join(unknown)
+        )
+    if account in active_accounts:
         return (SHARED_ACCOUNT_HISTORY,)
     return ()
+
+
+def writer_singleton_scope_labels(lane: str) -> tuple[str, ...]:
+    """Return the writer evidence that is true for exactly this lane."""
+
+    _assert_known_scope_key(lane)
+    return (WRITER_SINGLETON_SCOPE_CAVEATS[lane],)
 
 
 #: Sidecar-only caveat. Kept out of the fixed header (which stays 3/3 + identity)
@@ -69,10 +124,15 @@ SHADOW_SYNTHETIC_FILL = (
 )
 
 
-def header_labels(*, extra: tuple[str, ...] = ()) -> tuple[str, ...]:
-    """Return the fixed artifact header labels, inherited three first."""
+def header_labels(*, lane: str, extra: tuple[str, ...] = ()) -> tuple[str, ...]:
+    """Return fixed labels plus the lane-specific writer evidence."""
 
-    return (*TRUST_LABELS, *B0X_IDENTITY_LABELS, *extra)
+    return (
+        *TRUST_LABELS,
+        *B0X_IDENTITY_LABELS,
+        *writer_singleton_scope_labels(lane),
+        *extra,
+    )
 
 
 def render_header(labels: tuple[str, ...]) -> str:
@@ -91,4 +151,5 @@ __all__ = [
     "SHADOW_SYNTHETIC_FILL",
     "header_labels",
     "render_header",
+    "writer_singleton_scope_labels",
 ]

--- a/scripts/b0x/scope.py
+++ b/scripts/b0x/scope.py
@@ -1,0 +1,27 @@
+"""Canonical B0-X lane/account scope keys."""
+
+from __future__ import annotations
+
+from typing import Final
+
+BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY: Final[str] = "binance_spot_demo_sidecar"
+UPBIT_SHADOW_SCOPE_KEY: Final[str] = "upbit_shadow"
+KIS_MOCK_SCOPE_KEY: Final[str] = "kis_mock"
+ALPACA_PAPER_LAB_SCOPE_KEY: Final[str] = "alpaca_paper_lab"
+
+KNOWN_B0X_SCOPE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY,
+        UPBIT_SHADOW_SCOPE_KEY,
+        KIS_MOCK_SCOPE_KEY,
+        ALPACA_PAPER_LAB_SCOPE_KEY,
+    }
+)
+
+__all__ = [
+    "ALPACA_PAPER_LAB_SCOPE_KEY",
+    "BINANCE_SPOT_DEMO_SIDECAR_SCOPE_KEY",
+    "KIS_MOCK_SCOPE_KEY",
+    "KNOWN_B0X_SCOPE_KEYS",
+    "UPBIT_SHADOW_SCOPE_KEY",
+]

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pytest
 
+from scripts.b0x.kr.cycle import LANE as KR_LANE
 from scripts.b0x.kr.cycle import OUTSIDE_RTH_REASON, run_kr_cycle
 from scripts.b0x.labels import SHARED_ACCOUNT_HISTORY, TRUST_LABELS
 from scripts.b0x.ledger import ObservationLedger
@@ -196,6 +197,34 @@ async def test_dry_run_plans_but_never_dispatches(
         assert label in artifact_text
     assert SHARED_ACCOUNT_HISTORY not in outcome.record["labels"]
     assert "SHARED_ACCOUNT_HISTORY" not in artifact_text
+
+
+@pytest.mark.asyncio
+async def test_kr_dry_run_reacts_when_shared_history_scope_expands(
+    table_dir: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """KR wiring must become observable if an operator expands the scope."""
+
+    from scripts.b0x import labels as labels_module
+
+    monkeypatch.setattr(
+        labels_module,
+        "SHARED_HISTORY_ACCOUNTS",
+        labels_module.SHARED_HISTORY_ACCOUNTS | {KR_LANE},
+    )
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(orderable_cash="5000000"),
+    )
+
+    assert SHARED_ACCOUNT_HISTORY in outcome.record["labels"]
+    assert outcome.artifact_path is not None
+    assert f"> {SHARED_ACCOUNT_HISTORY}" in outcome.artifact_path.read_text(
+        encoding="utf-8"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/test_submission_ast_guard.py
+++ b/tests/scripts/b0x/kr/test_submission_ast_guard.py
@@ -116,12 +116,11 @@ FORBIDDEN_LIVE_MODULES = (
 #: any of these that omits the kwarg silently defaults to ``is_mock=False``
 #: (live). Named by attribute/function name (static, no type inference).
 #:
-#: ``fetch_my_stocks`` is deliberately excluded: this package's own
-#: ``ReadOnlyKISMockDomesticClient.fetch_my_stocks`` wrapper shares that name
-#: with the underlying ``AccountClient`` method it calls (with an explicit,
-#: guard-checked ``is_mock=True``) but itself takes no ``is_mock`` parameter
-#: at all — it is mock-only by construction. Including the name here would
-#: flag every *caller* of the wrapper as a false positive.
+#: ``fetch_my_stocks`` is handled by the scoped receiver check below rather
+#: than added here: this package's own ``ReadOnlyKISMockDomesticClient``
+#: wrapper shares that name with the underlying ``AccountClient`` method it
+#: calls, but the wrapper itself takes no ``is_mock`` parameter. A bare name
+#: match would flag every caller of the mock-only wrapper as a false positive.
 IS_MOCK_BEARING_CALLABLES = {
     "inquire_domestic_cash_balance",
     "fetch_domestic_balance_snapshot",
@@ -133,6 +132,26 @@ IS_MOCK_BEARING_CALLABLES = {
     "modify_korea_order",
     "inquire_daily_order_domestic",
 }
+
+
+def _is_account_client_fetch_my_stocks(func: ast.expr) -> bool:
+    """Identify the composed ``AccountClient`` call without matching our wrapper.
+
+    The only AccountClient composition in ``scripts/b0x/kr`` is
+    ``self._account = AccountClient(...)``. The wrapper call sites use
+    ``client.fetch_my_stocks()``; their receiver is not the exact
+    ``self._account`` shape below, so adding this targeted guard does not
+    resurrect the old false positive.
+    """
+
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "fetch_my_stocks"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "_account"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "self"
+    )
 
 
 def _python_files() -> list[Path]:
@@ -167,9 +186,12 @@ def find_is_mock_violations(tree: ast.AST) -> list[str]:
                     f"line {node.lineno}: is_mock kwarg is not the literal True "
                     f"({ast.dump(is_mock_kw.value)})"
                 )
-        elif callee in IS_MOCK_BEARING_CALLABLES:
+        elif callee in IS_MOCK_BEARING_CALLABLES or _is_account_client_fetch_my_stocks(
+            node.func
+        ):
             violations.append(
-                f"line {node.lineno}: call to {callee}(...) omits is_mock kwarg "
+                f"line {node.lineno}: call to {callee or 'AccountClient.fetch_my_stocks'}"
+                "(...) omits is_mock kwarg "
                 "— its default is False (live)"
             )
     return violations
@@ -277,6 +299,16 @@ def test_detector_catches_is_mock_expression() -> None:
 def test_detector_catches_is_mock_omitted_on_known_callable() -> None:
     tree = ast.parse("client.inquire_domestic_cash_balance()")
     assert find_is_mock_violations(tree) != []
+
+
+def test_detector_catches_account_client_fetch_my_stocks_omission() -> None:
+    tree = ast.parse("self._account.fetch_my_stocks(is_overseas=False)")
+    assert find_is_mock_violations(tree) != []
+
+
+def test_detector_allows_mock_wrapper_fetch_my_stocks_without_is_mock() -> None:
+    tree = ast.parse("client.fetch_my_stocks()")
+    assert find_is_mock_violations(tree) == []
 
 
 def test_detector_allows_is_mock_true_literal() -> None:

--- a/tests/scripts/b0x/test_labels.py
+++ b/tests/scripts/b0x/test_labels.py
@@ -2,21 +2,27 @@
 
 from __future__ import annotations
 
+import pytest
+
 from scripts.b0x import contract as contract_module
+from scripts.b0x import labels as labels_module
+from scripts.b0x.crypto import shadow, sidecar
 from scripts.b0x.kr.mock import LANE as KR_LANE
 from scripts.b0x.labels import (
     B0X_IDENTITY_LABELS,
+    SHADOW_SYNTHETIC_FILL,
     SHARED_ACCOUNT_HISTORY,
     SHARED_HISTORY_ACCOUNTS,
     account_history_labels,
+    header_labels,
+    render_header,
 )
+from scripts.b0x.scope import ALPACA_PAPER_LAB_SCOPE_KEY
 
 
 def test_shared_history_scope_starts_with_binance_sidecar_only() -> None:
-    assert SHARED_HISTORY_ACCOUNTS == frozenset({"binance_spot_demo_sidecar"})
-    assert account_history_labels("binance_spot_demo_sidecar") == (
-        SHARED_ACCOUNT_HISTORY,
-    )
+    assert SHARED_HISTORY_ACCOUNTS == frozenset({sidecar.LANE})
+    assert account_history_labels(sidecar.LANE) == (SHARED_ACCOUNT_HISTORY,)
 
 
 def test_adding_an_account_key_is_the_only_scope_expansion() -> None:
@@ -30,7 +36,24 @@ def test_adding_an_account_key_is_the_only_scope_expansion() -> None:
 
 def test_kr_and_us_are_not_in_the_initial_scope() -> None:
     assert account_history_labels(KR_LANE) == ()
-    assert account_history_labels("alpaca_paper_lab") == ()
+    assert account_history_labels(ALPACA_PAPER_LAB_SCOPE_KEY) == ()
+
+
+def test_unknown_scope_key_fails_closed_instead_of_disappearing() -> None:
+    with pytest.raises(ValueError, match="unknown B0-X scope key"):
+        account_history_labels("binance_spot_demo_sider")
+
+
+def test_typo_in_shared_history_scope_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        labels_module,
+        "SHARED_HISTORY_ACCOUNTS",
+        frozenset({"binance_spot_demo_sider"}),
+    )
+    with pytest.raises(ValueError, match="unknown B0-X shared-history scope key"):
+        account_history_labels(sidecar.LANE)
 
 
 def test_writer_singleton_matches_v1_4_section_three() -> None:
@@ -39,9 +62,47 @@ def test_writer_singleton_matches_v1_4_section_three() -> None:
     )
 
     assert "B0-X 측 주문 생성 주체는 B0-X 어댑터 하나다" in writer_label
-    assert "disarm 운영 조치로 확보" in writer_label
+    assert "disarm" not in writer_label
     assert "오염 게이트의 fail-closed 관측" in writer_label
     assert "이 계좌의 주문 생성 주체는 B0-X 어댑터 하나뿐이다" not in writer_label
+
+
+@pytest.mark.parametrize(
+    ("lane", "required", "forbidden"),
+    [
+        (
+            sidecar.LANE,
+            ("Binance Spot Demo", "disarm 운영 조치"),
+            ("operator account map", "실계좌가 아닌 합성 체결"),
+        ),
+        (
+            KR_LANE,
+            ("operator account map", "exclusive_lane", "관측 전용으로 공존"),
+            ("disarm 운영 조치", "실계좌가 아닌 합성 체결"),
+        ),
+        (
+            shadow.LANE,
+            ("실계좌가 아닌 합성 체결", "계좌 배타성 근거가 없으므로"),
+            ("disarm 운영 조치", "operator account map"),
+        ),
+    ],
+)
+def test_three_lane_headers_render_only_true_scope_facts(
+    lane: str,
+    required: tuple[str, ...],
+    forbidden: tuple[str, ...],
+) -> None:
+    if lane == sidecar.LANE:
+        extra = account_history_labels(lane)
+    elif lane == shadow.LANE:
+        extra = (SHADOW_SYNTHETIC_FILL,)
+    else:
+        extra = ()
+    rendered = render_header(header_labels(lane=lane, extra=extra))
+    for phrase in required:
+        assert phrase in rendered
+    for phrase in forbidden:
+        assert phrase not in rendered
 
 
 def test_shared_history_wording_is_complete_and_non_exaggerated() -> None:


### PR DESCRIPTION
## Summary

B0-X v1.4 follow-up for the four SHOULD/NICE verification findings from #1818/#1819.

- Scope the KIS AST guard to the AccountClient receiver shape so omitted `is_mock` is caught without flagging the mock-only wrapper.
- Move Binance Demo disarm evidence out of the common `WRITER_SINGLETON` identity label into lane-specific caveats.
- Centralize known B0-X scope keys and fail closed on unknown keys.
- Wire KR dry-run label selection to `account_history_labels`; initial shared-history scope remains sidecar-only.

## Safety

Code/tests only. No order, cancel, preview, broker, account, scheduler, operator-repo, holdout, or in-process LLM activity. No changes to derivation, envelope, kill switch, contamination, cancel, or MAX_TABLE_AGE surfaces.

## Verification

- B0-X tests: `313 passed`
- Unit suite: `5555 passed, 13087 deselected, 19 warnings`
- `make lint`: Ruff, format check, and ty passed
- Real mutants were injected and reverted for items 1–4; see job report.

Do not merge automatically; this PR is submitted for verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized scope identifiers for supported trading lanes.
  * Reports now include lane-specific account-history and writer-scope labels.
  * Added validation to prevent unknown or misspelled scope information from being silently accepted.

* **Bug Fixes**
  * Improved cycle report headers to accurately reflect their lane and account-history scope.
  * Strengthened safeguards around account data retrieval and mock trading flows.

* **Tests**
  * Expanded coverage for lane-specific labels, scope validation, report rendering, and account-history behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->