### PR TITLE
fix(b0x): kill switch currency validation — shadow lane USDT/KRW mismatch (ROB-1233)

### DIFF
--- a/scripts/b0x/cycle.py
+++ b/scripts/b0x/cycle.py
@@ -69,6 +69,18 @@ from scripts.b0x.table_source import (
 
 MARKET = "crypto"
 
+#: contract §4 assigns the shadow lane a synthetic, KRW-denominated book
+#: (``shadow.QUOTE_CURRENCY``), while the single "crypto" envelope column —
+#: shared with the sidecar — denominates ``daily_loss_kill`` in USDT
+#: (``CRYPTO_SIDECAR_ENVELOPE.quote_currency``). ``kill_switch.evaluate``
+#: fails closed on that mismatch (``CurrencyMismatchKill``) rather than
+#: silently comparing a KRW P&L against a USDT threshold — see
+#: ``scripts.b0x.kill_switch.CurrencyMismatchKill``. Until an operator
+#: defines a currency-correct kill threshold for this lane, every shadow
+#: cycle that reaches this point is, correctly, a zero-order cycle: this
+#: reason code makes that loud and observable instead of an unhandled crash.
+SHADOW_KILL_CURRENCY_MISMATCH_REASON: str = "kill_switch_currency_mismatch"
+
 
 @dataclass
 class CycleOutcome:
@@ -272,7 +284,28 @@ async def run_shadow_cycle(
         record["policy_table_age_seconds"] = int(table.age.total_seconds())
 
         state = portfolio.account_state()
-        decision = kill_switch_module.evaluate(state=state, envelope=envelope)
+        try:
+            decision = kill_switch_module.evaluate(state=state, envelope=envelope)
+        except kill_switch_module.CurrencyMismatchKill as exc:
+            record["zero_order_reason"] = SHADOW_KILL_CURRENCY_MISMATCH_REASON
+            record["zero_order_detail"] = str(exc)
+            record["orders"] = []
+            record["skipped"] = []
+            # Contract §2-2: no silent reuse. A kill decision this lane cannot
+            # safely evaluate is treated the same as an unusable table — the
+            # resting book from the last good cycle is cancelled rather than
+            # left working on intent nothing here re-validated.
+            record["cancelled_stale_orders"] = len(portfolio.open_orders)
+            portfolio.open_orders = []
+            outcome.zero_order_reason = SHADOW_KILL_CURRENCY_MISMATCH_REASON
+            store_json_state(portfolio_path, portfolio.to_json())
+            ledger.record_cycle(record)
+            outcome.record = record
+            outcome.artifact_path = ledger.write_artifact(
+                name=f"{now.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
+                content=render_cycle_report(record, labels=labels),
+            )
+            return outcome
         derivation = derive_orders(
             table=table,
             state=state,

--- a/scripts/b0x/kill_switch.py
+++ b/scripts/b0x/kill_switch.py
@@ -43,6 +43,26 @@ class MissingNavForRatioKill(ValueError):
     """
 
 
+class CurrencyMismatchKill(ValueError):
+    """``state.quote_currency`` and ``envelope.quote_currency`` disagree, or
+    either is empty (missing currency information is *not* treated as a
+    match).
+
+    ``realized_pnl_today`` is compared directly against an absolute
+    threshold derived from ``envelope.daily_loss_kill`` — that comparison is
+    meaningless, and silently dangerous, unless both sides are known to be
+    denominated in the same currency. This is the exact shape of the defect
+    X-C's verification found in the crypto shadow lane: a USDT-denominated
+    envelope constant (``CRYPTO_SIDECAR_ENVELOPE.daily_loss_kill``) compared
+    directly against a KRW-denominated ``realized_pnl_today`` (Upbit shadow
+    trades in KRW). Fails closed instead of silently comparing amounts in
+    different currencies, and instead of guessing an exchange rate to
+    reconcile them — an exchange rate is not this module's truth to assume,
+    and a wrong guess would only be forgiving in the direction that lets the
+    kill under-fire.
+    """
+
+
 @dataclass(frozen=True, slots=True)
 class KillSwitchDecision:
     """``allow_new_orders=False`` means: submit nothing, cancel everything."""
@@ -65,6 +85,16 @@ class KillSwitchDecision:
     daily_loss_kill_basis: str = "absolute"
     daily_loss_kill_config: Decimal = Decimal("0")
     nav_snapshot: Decimal | None = None
+    #: The currencies actually compared to reach this decision —
+    #: ``state.quote_currency`` and ``envelope.quote_currency`` respectively.
+    #: ``evaluate`` guarantees these are equal (and non-empty) by construction
+    #: for every ``KillSwitchDecision`` it returns — see
+    #: :class:`CurrencyMismatchKill`. Recording both, rather than a single
+    #: post-validation value, means an observation artifact shows exactly
+    #: what was compared without a reader having to trust that validation
+    #: ran at all.
+    state_quote_currency: str = ""
+    envelope_quote_currency: str = ""
 
     @property
     def tripped(self) -> bool:
@@ -82,6 +112,8 @@ class KillSwitchDecision:
             "nav_snapshot": (
                 None if self.nav_snapshot is None else format(self.nav_snapshot, "f")
             ),
+            "state_quote_currency": self.state_quote_currency,
+            "envelope_quote_currency": self.envelope_quote_currency,
         }
 
     def operator_notice(
@@ -127,7 +159,30 @@ def evaluate(*, state: LaneAccountState, envelope: Envelope) -> KillSwitchDecisi
     comparing a raw ratio, or an absolute value in the wrong currency, against
     ``realized_pnl_today`` is the currency-unit defect this function exists to
     make structurally impossible rather than merely style-guided against.
+
+    Before any of that: ``state.quote_currency`` and ``envelope.quote_currency``
+    must agree, and both must be non-empty — see :class:`CurrencyMismatchKill`.
+    This check runs unconditionally, regardless of ``daily_loss_kill_basis``,
+    because a ratio basis still ends up compared against
+    ``realized_pnl_today`` in whatever currency ``state`` claims once
+    multiplied by NAV, and an absolute basis is compared directly. Neither
+    path is safe without a currency match first. No conversion is ever
+    applied on a mismatch — this function does not know an exchange rate and
+    would not trust one it did not verify.
     """
+
+    if (
+        not state.quote_currency
+        or not envelope.quote_currency
+        or state.quote_currency != envelope.quote_currency
+    ):
+        raise CurrencyMismatchKill(
+            f"state.quote_currency={state.quote_currency!r} (lane={state.lane!r}) "
+            f"!= envelope.quote_currency={envelope.quote_currency!r} "
+            f"(market={envelope.market!r}) — the daily-loss kill cannot compare "
+            "realized_pnl_today against daily_loss_kill without both sides "
+            "denominated in the same, known currency."
+        )
 
     if envelope.daily_loss_kill_basis == "pct_of_nav":
         if state.nav is None:
@@ -167,6 +222,8 @@ def evaluate(*, state: LaneAccountState, envelope: Envelope) -> KillSwitchDecisi
         daily_loss_kill_basis=envelope.daily_loss_kill_basis,
         daily_loss_kill_config=envelope.daily_loss_kill,
         nav_snapshot=state.nav,
+        state_quote_currency=state.quote_currency,
+        envelope_quote_currency=envelope.quote_currency,
     )
 
 
@@ -175,5 +232,6 @@ __all__ = [
     "CapStatus",
     "KillSwitchDecision",
     "MissingNavForRatioKill",
+    "CurrencyMismatchKill",
     "evaluate",
 ]

--- a/tests/scripts/b0x/test_cycle.py
+++ b/tests/scripts/b0x/test_cycle.py
@@ -11,7 +11,12 @@ from typing import Any
 import pytest
 
 from scripts.b0x.crypto import shadow, sidecar
-from scripts.b0x.cycle import run_shadow_cycle, run_sidecar_cycle
+from scripts.b0x.cycle import (
+    SHADOW_KILL_CURRENCY_MISMATCH_REASON,
+    run_shadow_cycle,
+    run_sidecar_cycle,
+)
+from scripts.b0x.envelope import CRYPTO_SIDECAR_ENVELOPE
 from scripts.b0x.labels import (
     SHADOW_SYNTHETIC_FILL,
     SHARED_ACCOUNT_HISTORY,
@@ -67,12 +72,35 @@ def _no_real_candles(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(shadow, "fetch_ohlcv", _boom)
 
 
+@pytest.fixture
+def _shadow_currency_aligned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``shadow.account_state()`` report the same currency as the (shared,
+    crypto-market) envelope it is evaluated against.
+
+    Production wiring does *not* do this: the shadow lane's book is
+    genuinely KRW-denominated (Upbit) while ``CRYPTO_SIDECAR_ENVELOPE`` is
+    USDT — ``run_shadow_cycle`` now fails that comparison closed (see
+    ``test_shadow_cycle_blocked_by_kill_switch_currency_mismatch`` below,
+    which exercises the *real*, unpatched wiring). This fixture exists only
+    to decouple tests of unrelated shadow-cycle behaviour (order derivation,
+    idempotency, artifact structure) from that separate, tracked defect, the
+    same way the underlying determinism/sizing logic is independently
+    covered in ``tests/scripts/b0x/test_derivation.py`` without going
+    through ``run_shadow_cycle`` at all.
+    """
+
+    monkeypatch.setattr(
+        shadow, "QUOTE_CURRENCY", CRYPTO_SIDECAR_ENVELOPE.quote_currency
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shadow lane
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_first_shadow_cycle_derives_and_records(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -99,6 +127,7 @@ async def test_first_shadow_cycle_derives_and_records(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_shadow_cycle_is_idempotent_in_its_derivation(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -138,6 +167,7 @@ async def test_shadow_cycle_is_idempotent_in_its_derivation(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_stale_table_yields_zero_orders_and_cancels_the_book(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -170,13 +200,69 @@ async def test_missing_table_yields_zero_orders(tmp_path: Path, out_dir: Path) -
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_shadow_lane_uses_b0_sizing_not_the_usdt_envelope(
     table_dir: Path, out_dir: Path
 ) -> None:
     outcome = await run_shadow_cycle(now=NOW, table_dir=table_dir, out_dir=out_dir)
     assert outcome.record["envelope_application"].startswith("envelope_not_applied")
+    assert outcome.record["orders"], "fixture must actually derive orders"
     for order in outcome.record["orders"]:
         assert order["notional"] == "10000"  # sizing.new_entry_notional_krw
+
+
+@pytest.mark.asyncio
+async def test_shadow_cycle_blocked_by_kill_switch_currency_mismatch(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """The real, unpatched wiring: shadow's book is KRW, the shared crypto
+    envelope's kill threshold is USDT. ``kill_switch.evaluate`` fails that
+    comparison closed, and the cycle must not crash uncontrolled — it records
+    a zero-order cycle with a specific, auditable reason, exactly like an
+    unusable policy table.
+    """
+
+    outcome = await run_shadow_cycle(now=NOW, table_dir=table_dir, out_dir=out_dir)
+
+    assert outcome.zero_order_reason == SHADOW_KILL_CURRENCY_MISMATCH_REASON
+    assert outcome.order_count == 0
+    assert outcome.record["orders"] == []
+    assert "KRW" in outcome.record["zero_order_detail"]
+    assert "USDT" in outcome.record["zero_order_detail"]
+    assert outcome.artifact_path is not None and outcome.artifact_path.exists()
+
+    portfolio_path = (
+        ObservationLedger(lane=shadow.LANE, root=out_dir).lane_dir / "portfolio.json"
+    )
+    assert json.loads(portfolio_path.read_text())["open_orders"] == []
+
+
+@pytest.mark.asyncio
+async def test_shadow_cycle_currency_mismatch_cancels_a_resting_book(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """A resting virtual book from a currency-aligned cycle must still be
+    cancelled — not silently carried forward — once the mismatch is hit.
+    """
+
+    portfolio_path = (
+        ObservationLedger(lane=shadow.LANE, root=out_dir).lane_dir / "portfolio.json"
+    )
+    with pytest.MonkeyPatch.context() as aligned:
+        aligned.setattr(
+            shadow, "QUOTE_CURRENCY", CRYPTO_SIDECAR_ENVELOPE.quote_currency
+        )
+        seeded = await run_shadow_cycle(now=NOW, table_dir=table_dir, out_dir=out_dir)
+    assert seeded.order_count == 2
+    assert json.loads(portfolio_path.read_text())["open_orders"]
+
+    outcome = await run_shadow_cycle(
+        now=NOW + dt.timedelta(minutes=1), table_dir=table_dir, out_dir=out_dir
+    )
+
+    assert outcome.zero_order_reason == SHADOW_KILL_CURRENCY_MISMATCH_REASON
+    assert outcome.record["cancelled_stale_orders"] == 2
+    assert json.loads(portfolio_path.read_text())["open_orders"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/b0x/test_kill_switch_and_touch_rule.py
+++ b/tests/scripts/b0x/test_kill_switch_and_touch_rule.py
@@ -154,6 +154,107 @@ def test_all_tripped_reasons_are_reported_without_short_circuit() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Currency validation (ROB-1233) — the shadow lane's KRW-vs-USDT defect,
+# reproduced directly against ``evaluate`` rather than through a full cycle.
+# ---------------------------------------------------------------------------
+
+
+def test_defect_reproduced_krw_state_vs_usdt_envelope_used_to_pass_silently() -> None:
+    """DEFECT_REPRODUCED — this is exactly ``scripts.b0x.crypto.shadow``'s real
+    wiring: a KRW-denominated account state evaluated against the shared
+    crypto envelope, whose ``daily_loss_kill`` is a USDT amount. Before this
+    fix, ``state.realized_pnl_today <= -effective_kill`` compared these two
+    numbers with no unit check at all.
+    """
+
+    krw_state = _state(quote_currency="KRW", realized_pnl_today=Decimal("-9"))
+    assert ENVELOPE.quote_currency == "USDT"
+
+    with pytest.raises(kill_switch_module.CurrencyMismatchKill) as exc_info:
+        kill_switch_module.evaluate(state=krw_state, envelope=ENVELOPE)
+
+    assert "KRW" in str(exc_info.value)
+    assert "USDT" in str(exc_info.value)
+
+
+def test_currency_mismatch_is_not_bypassable_by_conversion() -> None:
+    """Mutant ③ — a "helpful" fix that converts instead of rejecting must
+    still fail this test. There is no rate this module may assume; -9 KRW
+    numerically satisfies ``<= -5`` (a plausible "converted" comparison a
+    unit-blind reviewer might wave through), so if mismatch handling were
+    changed to silently convert-and-compare instead of raising, this krw_state
+    would trip the kill "successfully" instead of raising — which is exactly
+    the silent-wrong-answer failure mode this test exists to catch.
+    """
+
+    krw_state = _state(quote_currency="KRW", realized_pnl_today=Decimal("-9"))
+    with pytest.raises(kill_switch_module.CurrencyMismatchKill):
+        kill_switch_module.evaluate(state=krw_state, envelope=ENVELOPE)
+
+
+def test_missing_currency_information_counts_as_mismatch_not_a_match() -> None:
+    """ "없음 ≠ 일치" — an empty/absent currency must not compare equal to
+    anything, including another empty string on the envelope side.
+    """
+
+    from dataclasses import replace
+
+    state = _state(quote_currency="", realized_pnl_today=Decimal("0"))
+    with pytest.raises(kill_switch_module.CurrencyMismatchKill):
+        kill_switch_module.evaluate(state=state, envelope=ENVELOPE)
+
+    # Even if *both* sides are empty, that is not a match either.
+    blank_envelope = replace(ENVELOPE, quote_currency="")
+    with pytest.raises(kill_switch_module.CurrencyMismatchKill):
+        kill_switch_module.evaluate(
+            state=_state(quote_currency="", realized_pnl_today=Decimal("0")),
+            envelope=blank_envelope,
+        )
+
+
+def test_matching_currency_decision_records_both_sides_for_audit() -> None:
+    """The success path must record what was actually compared — an
+    observation artifact should be verifiable without trusting that the
+    check silently ran."""
+
+    decision = kill_switch_module.evaluate(
+        state=_state(realized_pnl_today=Decimal("-1")), envelope=ENVELOPE
+    )
+    assert decision.state_quote_currency == "USDT"
+    assert decision.envelope_quote_currency == "USDT"
+    canonical = decision.canonical()
+    assert canonical["state_quote_currency"] == "USDT"
+    assert canonical["envelope_quote_currency"] == "USDT"
+
+
+def test_crypto_sidecar_and_kr_currency_checks_pass_unaffected() -> None:
+    """NO_REGRESSION — crypto sidecar (USDT/USDT) and KR (pct_of_nav, KRW/KRW)
+    both already have matching currencies; the new check must be a no-op for
+    both, leaving their existing kill behaviour exactly as before.
+    """
+
+    from scripts.b0x.envelope import KR_MOCK_ENVELOPE
+
+    crypto_decision = kill_switch_module.evaluate(
+        state=_state(realized_pnl_today=Decimal("-5")), envelope=ENVELOPE
+    )
+    assert crypto_decision.tripped
+
+    kr_state = LaneAccountState(
+        lane="kis_mock",
+        quote_currency="KRW",
+        cash=Decimal("5000000"),
+        broker_truth=BrokerTruth(position_symbols=(), own_pending=()),
+        realized_pnl_today=Decimal("-250000"),
+        nav=Decimal("10000000"),
+    )
+    kr_decision = kill_switch_module.evaluate(state=kr_state, envelope=KR_MOCK_ENVELOPE)
+    assert kr_decision.tripped
+    assert kr_decision.state_quote_currency == "KRW"
+    assert kr_decision.envelope_quote_currency == "KRW"
+
+
+# ---------------------------------------------------------------------------
 # Touch rule
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `kill_switch.evaluate` compared `state.realized_pnl_today` directly against `envelope.daily_loss_kill` with no currency check. Crypto sidecar (USDT/USDT) and KR (KRW/KRW, `pct_of_nav`) always matched, but the shadow lane's KRW-denominated book was silently compared against the shared crypto envelope's USDT `daily_loss_kill=5` threshold — a 9 KRW fee drag (~$0.006) could trip a "5 USDT" kill.
- New `CurrencyMismatchKill` (fails closed, same shape as `MissingNavForRatioKill` from #1815) fires whenever `state.quote_currency != envelope.quote_currency`, or either is empty. No exchange-rate conversion is ever applied on a mismatch.
- `KillSwitchDecision` now records `state_quote_currency`/`envelope_quote_currency` so an observation artifact shows what was actually compared.
- The shadow cycle's real, always-mismatched wiring (`shadow.QUOTE_CURRENCY="KRW"` vs the shared `CRYPTO_SIDECAR_ENVELOPE.quote_currency="USDT"`) is caught in `run_shadow_cycle` and routed through the existing "unusable table" zero-order + cancel-resting-book pattern instead of crashing uncontrolled, under a new `kill_switch_currency_mismatch` reason code.
- Crypto sidecar and KR call sites are untouched — currencies already match there, so behavior is unaffected (verified by test).

## Scope
- Touched: `scripts/b0x/kill_switch.py`, `scripts/b0x/cycle.py` (shadow call site only), their tests.
- Not touched: kill threshold values, `daily_loss_kill_basis` (KR), sidecar/KR call sites, derivation, envelope cap values, contamination/dust logic, cancellation tooling, labels, `MAX_TABLE_AGE`, contract stamp.
- No orders, no cancels, no broker calls, no account contact — code + tests only.

## Verification
- **Defect reproduced** on pre-fix code: a KRW state with `realized_pnl_today=-9` evaluated against `CRYPTO_SIDECAR_ENVELOPE` (USDT, `daily_loss_kill=5`) silently returned `tripped=True` — no currency check existed.
- **Mutant ① (state=KRW, envelope=USDT via `evaluate()`)**: killed — raises `CurrencyMismatchKill`.
- **Mutant ② (currency validation removed)**: injected, ran full suite → 5 new tests failed as expected, reverted.
- **Mutant ③ (mismatch bypassed via a fake KRW/USDT conversion)**: injected, same 5 tests failed as expected, reverted.
- **No regression**: crypto sidecar (USDT/USDT) and KR (`pct_of_nav`, KRW/KRW) kill behavior unchanged — dedicated regression test plus full existing suite green.

## Test plan
- [x] `uv run pytest tests/scripts/b0x/ -q` → 345 passed
- [x] `uv run pytest tests/scripts/ -q` → 873 passed
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run ruff format --check` on changed files → clean (after formatting)
- [x] `uv run ty check` (repo-wide) → All checks passed
- [x] Mutants 1–3 injected and killed, then reverted (not included in this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added fail-closed validation when quote currencies are missing or mismatched.
  * Prevented order derivation and placement when a currency mismatch is detected.
  * Existing virtual orders are now cancelled and the portfolio state is safely persisted.
  * Cycle artifacts and zero-order outcomes are recorded for halted shadow cycles.

* **Tests**
  * Added coverage for currency validation, order cancellation, artifact recording, and sizing behavior.
  * Confirmed existing kill-switch behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->