### PR TITLE
fix(b0x): KR 자기 미체결 출처 = kis_mock_order_ledger (X-E2, 계약 v1.6 ①~④)

### DIFF
--- a/docs/runbooks/b0x-kr-cycle.md
+++ b/docs/runbooks/b0x-kr-cycle.md
@@ -244,6 +244,12 @@ b0x-experiment-contract-v1-20260808.md`):
 
 ### 9.1 🔴 상한 입력 = 브로커 진실 (계약 v1.5 ①) — KR 은 한 입력이 조회 불가
 
+> 🔵 **이 절은 X-E1(계약 v1.5) 시점의 상태를 기술한다.** 자기 미체결 항목은
+> **계약 v1.6 ① 로 해소**됐다 — §9.2 를 먼저 읽어라. 아래 "왜 조회 불가인가"
+> 두 표면의 실측은 v1.6 이후에도 그대로 사실이며(브로커는 여전히 답하지 못한다),
+> `PendingUnreadable` 도 삭제되지 않고 **원장이 답하지 못할 때의 상태로 남아 있다**.
+> "매 사이클 파생 0건"만 v1.6 으로 대체된 서술이다.
+
 무엇이 틀렸었는지는 crypto 런북 §6.1 과 동일하다(상한이 사이클당으로만 구속, 상태 파일이
 한 번도 쓰이지 않음). KR 도 같은 코어(`scripts/b0x/broker_truth.py`)를 쓴다 — 레인별 복붙
 없음. 다만 **입력 하나가 KIS 모의투자에서 조회 불가**다.
@@ -279,11 +285,8 @@ skipped 표가 그대로 렌더링되므로 "무엇이 막혔는지"는 남는�
 로 구조적으로 막혀 있고(§10, §6), CLI 에 `--confirm` 이 없다. 즉 이 조치가 "되던 주문을
 막은" 것이 아니라 **되지 않던 이유가 하나 더 명시화**된 것에 가깝다.
 
-🔴 **미해결 (운영자/orch 판단 필요).** 자기 미체결의 대체 출처 후보는 `kis_mock_order_
-ledger`(`KISMockLifecycleService`) 다 — 레포가 이미 TTTC8036R 부재를 이 원장으로 대체하고
-있다(`resolve_mock_order_for_cancel`). 다만 그건 **브로커 진실이 아니라 자기 기록**이고,
-이 잡이 폐기한 `attributed_book` 과 같은 부류로 읽힐 수 있어 **이 PR 에서 채택하지
-않았다**. 채택 여부는 계약 판단이지 구현 판단이 아니다.
+🔵 **해소됨 — 계약 v1.6 ① (2026-08-09, 운영자 "승인이야").** X-E1 이 후보로만 등재했던
+`kis_mock_order_ledger` 가 조건부로 승인됐다. 상세 = **§9.2**.
 
 🔴 **realized P&L 입력도 없다.** 상태 파일 제거로 `realized_pnl_today` 의 출처가
 사라졌다(원래도 파일이 없어 항상 0이었다). 따라서 `−2.5% NAV` kill 은 발화할 수 없으며,
@@ -307,6 +310,75 @@ ledger`(`KISMockLifecycleService`) 다 — 레포가 이미 TTTC8036R 부재를 
 과거 투입액이 신규 진입에 보이지 않는다. 이건 브로커 진실 배선 이전부터 있던 설계 공백이며
 (어느 레인이든 동일), 이번 잡이 새로 만든 것이 아니다 — 후속 과제로 남긴다.
 
+### 9.2 🔴 KR 자기 미체결 출처 = `kis_mock_order_ledger` (계약 v1.6 ①, X-E2)
+
+**정본 모듈: `scripts/b0x/kr/pending_ledger.py`.** §9.1 이 「조회 불가」로 남겨 둔 세 번째
+입력(자기 `b0xk` 미체결)만 여기서 공급한다. 나머지 두 입력은 손대지 않았다.
+
+**왜 예외가 정당한가 — `attributed_book` 과 무엇이 다른가.** v1.5 가 `attributed_book.json`
+을 폐기한 사유는 「자기 기록」이라는 **개념**이 아니라 **쓰기 경로가 레포에 0건**이었다는
+사실이다(매 사이클 `None` 로드 → 카운터 상시 0). 이 원장은 반대로 **제출 chokepoint 가 매번
+강제로 쓴다**:
+
+- `app/mcp_server/tooling/order_execution.py` `_execute_and_record` 의 **첫 동작**이
+  `is_mock` 분기의 pre-submit 귀속 게이트다. 귀속 실패 → `MissingAttribution` → **브로커
+  read 조차 하기 전에** 반환. 귀속 성공 → `record_signal` 이 `review.kis_mock_signal_ledger`
+  행을 **전송 전에 커밋**하고, 그 쓰기가 실패하면 **주문 자체가 나가지 않는다**
+  (`error_code="signal_record_unavailable"`). `correlation_id`/`strategy`/`signal_source` 는
+  NOT NULL + 공백거부 CHECK.
+- 전송 후 `review.kis_mock_order_ledger` 행(계약이 지명한 표)이 같은 `correlation_id` 로 쓰인다.
+
+**두 표를 다 읽는다 — 넓힌 것은 예외가 아니라 차단이다.** 사후 order 행은 유실될 수 있고
+(`LedgerWriteError` → `ledger_id=None` → `ledger_tracking_unavailable`), 브로커에 존재하는
+주문의 원장 행이 없는 상태가 바로 v1.6 ③ 이 금지한 **관대한 방향(누락)** 이다. pre-submit
+signal 행은 유실되면 전송이 거부되므로 그 구멍을 닫는다. 둘 다 `kis_mock` 스코프이고 둘 다
+계약이 지명한 그 chokepoint 가 쓴다.
+
+**「미체결」의 정의 — 의도적 상위집합.** 🔴 이 모듈은 `lifecycle_state` 를 **보지 않는다**.
+어떤 상태 판정이든 「이미 체결/취소됐으니 풀어줘도 된다」는 추정이 되고, 추정이 틀리면
+아직 걸려 있는 주문을 푼다(= 관대한 방향). 그래서 **이 레인이 당일 그 심볼에 대해 남긴 행이
+하나라도 있으면 pending 이다.** 계약 v1.6 ③ 이 이 오류 방향을 문언으로 수용한다
+("체결·취소분이 pending 으로 보일 수 있음 — 안전한 실패로 수용").
+
+**유일한 경계 = KST 거래일.** KRX 주문은 당일 주문이다. ROB-671 분류기
+(`app/services/brokers/kis/live_order_expiry.py` — **인용만 하고 import 하지 않는다**;
+KR AST 가드가 금지 목록에 올려 뒀다)가 세션×매매구분 **전 조합의 최대 만료를 접수일 20:00
+KST** 로 못박는다(정규장 매도의 NXT 연장 포함). 즉 KST 일 *D* 에 접수된 주문이 *D+1* 까지
+걸려 있을 수 없다 — 시간 경과로 「체결됐겠지」를 추정하는 것이 아니라 **거래소의 주문 유효
+기간**이다. §4 일일 신규 캡의 경계와 동일하므로 두 규칙이 구조적으로 일치한다.
+
+**조회 실패 = 다시 unreadable (v1.6 ④).** 어떤 이유로든 조회가 실패하면
+`pending_ledger.ledger_unreadable(...)` 이 `PendingUnreadable`(reason=
+`kis_mock_ledger_pending_unreadable`) 을 돌려주고, `resubmit_block` 이 **다시 전 심볼을
+거부**한다. 실패를 `()` 로 접는 코드 경로는 이 모듈에 없다. detail 에는 예외 **타입 이름만**
+싣는다(DB 오류 메시지에 DSN·자격증명이 실릴 수 있고, 이 값은 산출물에 박제된다).
+X-E1 의 `KR_PENDING_UNREADABLE` 상수도 **삭제하지 않았고 여전히 기본값**이다 —
+`FreshTruth.broker_truth()` 를 인자 없이 부르면 v1.6 이전과 동일하게 fail-closed 다.
+
+**포지션 진실은 그대로 브로커 (v1.6 ②).** 원장은 미체결 dedup/캡 입력에만 들어간다.
+`positions` 는 계속 `fetch_my_stocks` 보유에서만 만들어지고, `broker_truth.position_symbols`
+는 `non_dust_position_symbols()` 뿐이다. AST 가드가 `positions=`/`position_symbols=` 인자에
+pending 파생 이름이 들어가는 것을 빌드 실패로 만든다.
+
+**kis_mock 한정 (v1.6 ① 🔴 crypto·US 확대 금지).** `scripts/b0x/kr/**` 밖의 어떤 b0x 모듈도
+`scripts.b0x.kr.pending_ledger`·`app.models.review`·kis_mock 원장 모듈을 import 할 수 없다
+(AST 가드). crypto 사이드카는 v1.5 그대로 venue 의 open-orders 를 `b0xc` 로 필터해 읽는다.
+
+**우회 제출 금지 (v1.6 ③ 신규 mutant).** 원장 기반 dedup 은 "나간 주문은 전부 원장에 있다"
+가 참일 때만 성립한다. AST 가드가 `scripts/b0x/kr/**` + 러너 안의 모든 제출 호출
+(`submit_buy`/`submit_exit_sell`/`_place_order_impl`/…) 이 **`kr.mock.submit_planned_order`
+안에만** 존재하도록 강제하고(그 함수만이 `KisMockBroker` → `order_execution` pre-submit
+게이트를 탄다), 그 안에서 `assert_resubmit_allowed` 가 제출보다 **앞줄**임을 확인한다.
+
+**귀결 — 월요일 첫 KR 사이클.** 이 레인은 아직 한 건도 제출한 적이 없으므로 원장이
+`b0xk-` 행을 0건으로 **답한다**(unreadable 아님) → 후보 행이 정상 파생된다. 같은 KST 일의
+2·3사이클차는 1사이클차가 남긴 행을 읽어 **파생 0**. 실측 = `test_kr_two_cycle_sim_the_
+same_symbol_is_never_submitted_twice` (고정 fixture, 실브로커 호출 0).
+
+🔵 §10 의 `PreSendFreshnessError`(BUY leg 실디스패치 구조적 차단)와 CLI `--confirm` 부재는
+**이 라운드에서도 그대로**다. 즉 v1.6 은 "파생이 되게" 만들었을 뿐 "실주문이 나가게" 만들지
+않았다.
+
 ## 10. 알려진 경계 · 미해결
 
 - **BUY leg 실 디스패치는 항상 `PreSendFreshnessError` 로 막힌다** — B0-X 용 실시간
@@ -317,6 +389,13 @@ ledger`(`KISMockLifecycleService`) 다 — 레포가 이미 TTTC8036R 부재를 
 - **오염(CONTAMINATED) 판정 미구현.** crypto 사이드카는 venue 의 `foreign_*` 잔고/미체결을
   탐지해 오염 시 제출을 막는다. KR 은 주문 읽기(order-history) 서피스를 아직 연결하지
   않았다 — 위 두 항목과 마찬가지로 KIS 모의투자의 미체결조회 API 한계와 같은 뿌리다.
+  🔴 §9.2 의 원장 출처는 **이 공백을 닫지 않는다**: 원장은 `b0xk-` 로 시작하는 **자기**
+  correlation_id 만 답하므로, 남이 이 계좌에 낸 주문은 여전히 보이지 않는다. v1.6 ① 의 예외
+  범위가 「자기 미체결」이라 넓히지 않았다.
+- **원장 조회는 DB 를 탄다.** §9.2 의 출처는 브로커 read 가 아니라 `DATABASE_URL` 로의
+  세션이다. DB 가 죽으면 사이클은 오류가 아니라 `own_pending_unreadable` 로 **전 심볼 차단**
+  하고 계속 진행한다(v1.6 ④). 파생 0 이 나왔는데 사유가 `own_pending_unreadable` +
+  reason=`kis_mock_ledger_pending_unreadable` 이면 **브로커가 아니라 DB 를 보라**.
 - **`B0X_KR_ENABLED`/`assert_kr_lane_enabled` 게이트가 `run_kr_cycle` 에서 호출되지
   않는다.** crypto 사이드카는 `run_sidecar_cycle` 진입 시 `assert_sidecar_enabled()` 를
   강제한다(대응 env: `B0X_SIDECAR_ENABLED`); KR 의 대응 함수는 정의만 되어 있고 아직
@@ -333,6 +412,16 @@ ledger`(`KISMockLifecycleService`) 다 — 레포가 이미 TTTC8036R 부재를 
 uv run pytest tests/scripts/b0x/ -q          # 코어 + crypto + kr 전부
 uv run pytest tests/scripts/b0x/kr/ -q       # kr 전용
 ```
+
+v1.6 ① 전용 (`tests/scripts/b0x/kr/test_ledger_pending_source.py`): KR 2사이클+ 시뮬
+(1사이클차 파생 2·제출 2 → 2·3사이클차 파생 0·제출 누계 2 → 익 KST 일 파생 2·누계 4) ·
+원장이 답한 심볼만 `own_pending_order_exists` 로 차단 · 조회 실패/세션 실패 → `()` 아닌
+`PendingUnreadable` (예외 **타입명만**, 메시지 비노출) · 상태 기반 해제 금지(모듈이
+`lifecycle_state`/`status` 를 참조하지 않음을 AST 로 고정) · KST 거래일 경계 · 원장이
+포지션이 되지 않음(행동 + AST) · 타 레인 import 금지(AST) · 원장 우회 제출 경로 금지(AST,
++ 제출보다 앞선 `assert_resubmit_allowed` 순서 확인). 각 detector 는 합성 소스로 자가검증.
+`tests/scripts/b0x/kr/conftest.py` 가 실 원장 리더 도달을 **AssertionError** 로 막는다
+(안 그러면 실수로 도달해도 `PendingUnreadable` 로 삼켜져 테스트가 조용히 무의미해진다).
 
 kr 전용 포함: tick 정렬(KRX 2023+ 표와 일치) · 매수/매도 사이징 whole-share floor ·
 NAV = cash + Σ evlu_amt · RTH 게이트(세션 밖 → zero-order, 표 I/O 전혀 없음) · 표 게이트

--- a/scripts/b0x/kr/cycle.py
+++ b/scripts/b0x/kr/cycle.py
@@ -30,10 +30,19 @@ pattern.
 
 Contract v1.5 ① lands here as ``broker_state`` (below): the §4 caps read this
 cycle's kis_mock account snapshot, and nothing is carried between cycles. The
-KR-specific consequence is that 자기 미체결 is unreadable on this venue
-(``kr_mock.KR_PENDING_UNREADABLE``) and therefore fails closed — the same
+KR-specific consequence was that 자기 미체결 is unreadable on this venue
+(``kr_mock.KR_PENDING_UNREADABLE``) and therefore failed closed — the same
 "시도조차 구조적으로 불가" posture the kill-trip cancellation note below already
 takes, applied to a second KIS mock limitation with the same root.
+
+Contract v1.6 ① supplies the missing input for that one field only, from the
+submission ledger (``scripts.b0x.kr.pending_ledger``, wired through the
+``pending_reader`` seam below). Everything else about the posture is unchanged:
+the reader can only *resolve* the unreadable state, never bypass it — a failed
+ledger read returns the same ``PendingUnreadable`` sentinel and every symbol is
+refused again. 포지션 진실 stays with the broker holdings read (v1.6 ②): the
+``positions`` this function builds come from ``fresh.positions`` and from
+nothing else, whatever the ledger says.
 
 Kill-trip cancellation asymmetry with the crypto sidecar, documented rather
 than silently matched: the crypto lanes cancel outstanding B0-X orders on a
@@ -56,11 +65,13 @@ from pathlib import Path
 from typing import Any
 
 from app.services.kis_mock_runner.session import is_krx_regular_session
+from scripts.b0x.broker_truth import PendingUnreadable
 from scripts.b0x.cycle import base_record, render_cycle_report
 from scripts.b0x.derivation import DerivationResult, derive_orders
 from scripts.b0x.envelope import assert_envelope_locked, load_envelope
 from scripts.b0x.kill_switch import evaluate as evaluate_kill_switch
 from scripts.b0x.kr import mock as kr_mock
+from scripts.b0x.kr import pending_ledger as kr_pending_ledger
 from scripts.b0x.labels import account_history_labels, header_labels
 from scripts.b0x.ledger import (
     DEFAULT_OBSERVATION_DIR,
@@ -139,7 +150,11 @@ KR_REALIZED_PNL_UNAVAILABLE = (
 )
 
 
-def broker_state(*, fresh: kr_mock.FreshTruth) -> LaneAccountState:
+def broker_state(
+    *,
+    fresh: kr_mock.FreshTruth,
+    own_pending: tuple[str, ...] | PendingUnreadable | None = None,
+) -> LaneAccountState:
     """kis_mock account state, derived entirely from this cycle's broker read.
 
     Contract v1.5 ①/③. Positions are the account's own holdings — "B0-X
@@ -158,6 +173,12 @@ def broker_state(*, fresh: kr_mock.FreshTruth) -> LaneAccountState:
     ``entry_count`` is reported as ``0``: how many separate entries built a
     holding is not in the snapshot, and derivation does not read it. Inventing
     a plausible number would put a fabricated value into the hashed state.
+
+    🔴 ``own_pending`` (contract v1.6 ①) reaches **only**
+    ``BrokerTruth.own_pending``. It is not read when building ``positions``
+    below, and it is not merged into ``broker_truth.position_symbols`` — v1.6
+    ② keeps 포지션 진실 on the broker. ``None`` (the default) leaves the lane
+    on ``KR_PENDING_UNREADABLE``.
     """
 
     positions = tuple(
@@ -175,7 +196,7 @@ def broker_state(*, fresh: kr_mock.FreshTruth) -> LaneAccountState:
         lane=LANE,
         quote_currency=kr_mock.QUOTE_CURRENCY,
         cash=fresh.cash,
-        broker_truth=fresh.broker_truth(),
+        broker_truth=fresh.broker_truth(own_pending),
         positions=positions,
         cumulative_deployment_readable=False,
         realized_pnl_today=Decimal("0"),
@@ -191,12 +212,19 @@ async def run_kr_cycle(
     confirm: bool = False,
     client: Any | None = None,
     broker: Any | None = None,
+    pending_reader: kr_pending_ledger.PendingReader | None = None,
 ) -> KrCycleOutcome:
     """One kis_mock cycle. ``broker`` mirrors the existing ``client`` DI seam
     (tests inject a fake broker; production leaves it ``None`` and this
     function builds ``kr_mock.build_kis_mock_broker()`` lazily, only when
     there is something to submit). See ``scripts.b0x.kr.mock`` module
     docstring for what submission wiring does and does not cover.
+
+    ``pending_reader`` is the contract v1.6 ① seam for 자기 미체결; production
+    leaves it ``None`` and gets
+    :func:`scripts.b0x.kr.pending_ledger.read_own_pending`. Whatever it
+    returns, a ``PendingUnreadable`` result still fails closed on every symbol
+    — the reader can resolve the tri-state, never remove it.
     """
 
     envelope = load_envelope(MARKET)
@@ -269,9 +297,18 @@ async def run_kr_cycle(
         if owns_client:
             client = kr_mock.ReadOnlyKISMockDomesticClient()
         fresh = await kr_mock.read_fresh_truth(client)
-        record["fresh_truth"] = fresh.status_only()
 
-        state = broker_state(fresh=fresh)
+        # Contract v1.6 ① — 자기 미체결 only. Read after the holdings snapshot
+        # and kept in its own variable so it can reach exactly one field
+        # (``BrokerTruth.own_pending``); positions below never see it.
+        reader = pending_reader or kr_pending_ledger.read_own_pending
+        own_pending = await reader(
+            now=now, correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
+        )
+        record["fresh_truth"] = fresh.status_only(own_pending)
+        record["own_pending_source"] = kr_mock.OWN_PENDING_SOURCE
+
+        state = broker_state(fresh=fresh, own_pending=own_pending)
         record["broker_truth"] = state.broker_truth.canonical()
         decision = evaluate_kill_switch(state=state, envelope=envelope)
         derivation = derive_orders(

--- a/scripts/b0x/kr/mock.py
+++ b/scripts/b0x/kr/mock.py
@@ -68,18 +68,33 @@ integration point, or a test double that deliberately leaves itself
 unwired). A "not yet built" state must never be mistaken for "submitted and
 confirmed zero".
 
-Contract v1.5 ① — the one KR asymmetry, stated rather than papered over
------------------------------------------------------------------------
-The §4 caps are now fed from the broker (:meth:`FreshTruth.broker_truth`)
-instead of a state file. Two of the three inputs read cleanly on kis_mock:
-holdings give 동시 포지션, and 일일 신규 unions them with this cycle's
-admissions. The third — 자기(``b0xk``) 미체결 — **cannot be read at all**; see
+Contract v1.5 ① / v1.6 ① — the one KR asymmetry, stated rather than papered over
+--------------------------------------------------------------------------------
+The §4 caps are fed from the broker (:meth:`FreshTruth.broker_truth`) instead
+of a state file. Two of the three inputs read cleanly on kis_mock: holdings
+give 동시 포지션, and 일일 신규 unions them with this cycle's admissions. The
+third — 자기(``b0xk``) 미체결 — **cannot be read from the broker at all**; see
 :data:`KR_PENDING_UNREADABLE` for the two surfaces that fail and how each was
-measured. That state fails closed, so while it holds this lane derives zero
-orders per cycle, every candidate row recorded as skipped with
-``own_pending_unreadable`` and its detail. The alternative — reading an
-unanswerable question as "nothing is resting" — is precisely how duplicate
-prevention gets silently disabled, which is the defect v1.5 ① exists to close.
+measured.
+
+Contract **v1.6 ①** grants one narrow exception for that third input only:
+``review.kis_mock_order_ledger`` (+ its pre-submit signal row) may stand in,
+because kis_mock offers no pending surface *and* the submission chokepoint
+writes that ledger on every send. :mod:`scripts.b0x.kr.pending_ledger` owns
+that read and carries the full argument. Two things did **not** change:
+
+* :data:`KR_PENDING_UNREADABLE` is still here and is still the **default** —
+  :meth:`FreshTruth.broker_truth` called without an explicit ``own_pending``
+  fails closed exactly as it did before v1.6. Only a caller that wires the
+  ledger reader gets a readable answer, and a ledger read that fails returns
+  the same tri-state sentinel (``PendingUnreadable``), never ``()``.
+* 포지션 진실 stays with the broker (v1.6 ②). The ledger feeds 미체결 dedup /
+  cap inputs only; :meth:`FreshTruth.non_dust_position_symbols` and
+  ``LaneAccountState.positions`` never read it.
+
+The alternative — reading an unanswerable question as "nothing is resting" —
+is precisely how duplicate prevention gets silently disabled, which is the
+defect v1.5 ① exists to close and v1.6 ③④ re-affirm.
 
 No orders were placed by writing this PR — see the runbook and
 ``docs/runbooks/b0x-kr-cycle.md`` §9 for the record of what was, and was
@@ -140,6 +155,14 @@ KRX_MIN_TRADE_UNIT_SHARES: Decimal = Decimal("1")
 #: :meth:`BrokerTruth.resubmit_block` fails closed on every symbol while it
 #: holds. Treating "조회 불가" as "미체결 없음" would silently disable duplicate
 #: prevention on the one lane whose venue cannot contradict it.
+#:
+#: 🔴 **Kept, and still the default** after contract v1.6 (which requires the
+#: state be retained — "``PendingUnreadable`` 상태는 유지"). v1.6 ① routes
+#: around the *broker's* silence with the submission ledger
+#: (:mod:`scripts.b0x.kr.pending_ledger`); it does not make either surface
+#: below answerable, and it does not remove this state. A ledger read that
+#: fails lands back on the same tri-state via
+#: :func:`scripts.b0x.kr.pending_ledger.ledger_unreadable`.
 KR_PENDING_UNREADABLE: PendingUnreadable = PendingUnreadable(
     reason="kis_mock_pending_inquiry_unsupported",
     detail=(
@@ -149,6 +172,11 @@ KR_PENDING_UNREADABLE: PendingUnreadable = PendingUnreadable(
         "조회할 수단이 없음"
     ),
 )
+
+#: Recorded on every cycle so an observation artifact names *where* 자기 미체결
+#: came from. Contract v1.6 ① is a kis_mock-only exception; making the source
+#: explicit in the record is what keeps it from quietly spreading.
+OWN_PENDING_SOURCE = "kis_mock_order_ledger+kis_mock_signal_ledger (계약 v1.6 ①)"
 
 #: Idempotency prefix mirroring the crypto sidecar's ``clientOrderId`` scheme
 #: (``b0xc-<order_key>``) — ``b0xk`` = B0-X KR. ``order.order_key`` (16 hex
@@ -261,25 +289,47 @@ class FreshTruth:
             )
         )
 
-    def broker_truth(self) -> BrokerTruth:
-        """Contract v1.5 ① cap inputs. Pending is unreadable on this venue."""
+    def broker_truth(
+        self, own_pending: tuple[str, ...] | PendingUnreadable | None = None
+    ) -> BrokerTruth:
+        """Contract v1.5 ① cap inputs.
+
+        ``own_pending`` is the contract v1.6 ① seam: a caller that wired
+        :func:`scripts.b0x.kr.pending_ledger.read_own_pending` passes its
+        result. Omitting it keeps the pre-v1.6 fail-closed behaviour — the
+        venue itself still cannot answer, so the default is
+        :data:`KR_PENDING_UNREADABLE`, not an empty tuple.
+
+        🔴 ``position_symbols`` is unaffected by ``own_pending`` in every
+        case: 포지션 진실 is the broker holdings read (v1.6 ②).
+        """
 
         return BrokerTruth(
             position_symbols=self.non_dust_position_symbols(),
-            own_pending=KR_PENDING_UNREADABLE,
+            own_pending=KR_PENDING_UNREADABLE if own_pending is None else own_pending,
         )
 
-    def status_only(self) -> dict[str, Any]:
+    def status_only(
+        self, own_pending: tuple[str, ...] | PendingUnreadable | None = None
+    ) -> dict[str, Any]:
         """Report-safe view: presence/counts, never raw balances."""
 
+        resolved = KR_PENDING_UNREADABLE if own_pending is None else own_pending
+        unreadable = resolved if isinstance(resolved, PendingUnreadable) else None
         return {
             "quote_currency": QUOTE_CURRENCY,
             "cash_present": bool(self.cash > 0),
             "nav_present": bool(self.nav > 0),
             "position_symbols": sorted(pos.symbol for pos in self.positions),
             "non_dust_position_symbols": list(self.non_dust_position_symbols()),
-            "own_pending_readable": False,
-            "own_pending_unreadable_reason": KR_PENDING_UNREADABLE.reason,
+            "own_pending_readable": unreadable is None,
+            "own_pending_unreadable_reason": (
+                None if unreadable is None else unreadable.reason
+            ),
+            "own_pending_source": OWN_PENDING_SOURCE,
+            "own_pending_symbol_count": (
+                None if unreadable is not None else len(resolved)
+            ),
         }
 
 
@@ -604,6 +654,7 @@ __all__ = [
     "CLIENT_ORDER_ID_PREFIX",
     "KRX_MIN_TRADE_UNIT_SHARES",
     "KR_PENDING_UNREADABLE",
+    "OWN_PENDING_SOURCE",
     "KrLaneDisabled",
     "KrMockSubmissionNotWired",
     "ReadOnlyKISMockDomesticClient",

--- a/scripts/b0x/kr/pending_ledger.py
+++ b/scripts/b0x/kr/pending_ledger.py
@@ -1,0 +1,219 @@
+"""KR 자기 미체결 출처 — ``review.kis_mock_order_ledger`` (계약 v1.6 ①).
+
+Why this module exists, and why it is *not* a re-run of ``attributed_book``
+---------------------------------------------------------------------------
+
+Contract v1.5 ① made the §4 caps read from the broker each cycle. Two of the
+three KR inputs read cleanly; the third — 자기(``b0xk``) 미체결 — cannot be read
+from ``kis_mock`` **at all**:
+
+* ``DomesticOrderClient.inquire_korea_orders`` (TR ``TTTC8036R``, 미체결 주문
+  조회) raises outright for ``is_mock=True``.
+* ``inquire_daily_order_domestic`` (daily-ccld) routes to a mock TR but ROB-341
+  measured it returning ``rt_cd=0`` with **empty rows even after same-day mock
+  order activity** — an empty answer proves nothing.
+
+X-E1 therefore carried :data:`scripts.b0x.kr.mock.KR_PENDING_UNREADABLE` and
+failed closed on every symbol, which is honest but leaves the lane deriving
+zero orders forever. Contract **v1.6 ①** grants one narrow exception:
+
+    ① kis_mock 한정 예외 — 브로커가 자기 미체결 조회 표면을 제공하지 않고
+       + 제출 chokepoint 가 매번 강제 기록하는 원장에 한함.
+       🔴 일반 원칙은 브로커 진실 유지. crypto·US 로 확대 금지.
+    ② 용도 = 미체결 dedup / 캡 입력 **만**. 🔴 포지션 진실은 계속 브로커 조회.
+    ③ 오류 방향 = 과잉 차단(체결·취소분이 pending 으로 보일 수 있음) — 안전한
+       실패로 수용. 🔴 관대한 방향(누락)으로 기울면 위반.
+    ④ ``PendingUnreadable`` 상태는 **유지**(원장 가용 시 해소).
+
+The distinction that makes this legitimate, stated precisely because it is the
+whole argument: ``attributed_book.json`` was rejected **not** because it was a
+self-record but because it had *read paths only and no write path anywhere in
+the repo* — every cycle loaded ``None``. This ledger is written by the
+submission chokepoint itself, on the ``is_mock`` branch that precedes the POST:
+
+* ``app/mcp_server/tooling/order_execution.py`` — ``_execute_and_record``
+  opens with the kis_mock pre-submit attribution gate. Unattributed →
+  ``MissingAttribution`` → the order never reaches the broker. Attributed →
+  ``record_signal`` commits a ``review.kis_mock_signal_ledger`` row **before**
+  the send, and a failure of *that* write also refuses the send
+  (``error_code="signal_record_unavailable"``). The row's ``correlation_id`` /
+  ``strategy`` / ``signal_source`` are NOT NULL with blank-rejecting CHECKs.
+* The post-send ``review.kis_mock_order_ledger`` row (contract v1.6's named
+  source) carries the same ``correlation_id``.
+
+Both tables are read here, and the union is deliberate rather than redundant:
+the *order* row can be lost (``LedgerWriteError`` → ``ledger_id=None`` →
+``ledger_tracking_unavailable``), and a lost order row for an order that does
+exist at the broker is exactly the 관대한 방향(누락) that v1.6 ③ forbids. The
+pre-submit signal row cannot be lost without the send being refused, so it
+closes that hole. Both are ``kis_mock``-scoped and written by the one chokepoint
+v1.6 ① names — this is a wider *block*, not a wider *exception*.
+
+What "pending" means here — a deliberate superset
+--------------------------------------------------
+
+🔴 This module does **not** inspect ``lifecycle_state`` and does not try to
+decide whether a given order filled, was cancelled, or is still resting.
+Inferring that would be the 관대한 방향: every such inference can release a
+symbol that is in fact still working. So a symbol counts as pending when this
+lane recorded *any* order-or-signal row for it inside the current KRX trading
+day, whatever became of it. v1.6 ③ names that exact error direction
+("체결·취소분이 pending 으로 보일 수 있음") and accepts it.
+
+The single bound is the trading day, and it is structural rather than inferred:
+KRX orders are day orders. ROB-671's classifier
+(``app/services/brokers/kis/live_order_expiry.py`` — cited, never imported; the
+KR AST guard forbids importing it) puts the *latest* possible expiry at 20:00
+KST **on the accept day**, for every session × side combination including the
+regular-session SELL that carries to NXT. An order accepted on KST day *D*
+therefore cannot still be resting on KST day *D+1*. That is the same boundary
+the §4 일일 신규 cap already uses, so the two agree by construction.
+
+Failure is unreadable, never empty
+-----------------------------------
+
+Any failure to read — DB down, schema drift, anything — returns
+:data:`scripts.b0x.kr.mock.KR_PENDING_UNREADABLE`'s sibling
+:func:`ledger_unreadable`, i.e. the v1.5 ① ``PendingUnreadable`` state, which
+:meth:`~scripts.b0x.broker_truth.BrokerTruth.resubmit_block` refuses every
+symbol under. The tri-state is preserved exactly as X-E1 built it: 원장이
+**가용할 때만** 해소된다. There is no code path in this module that turns a
+failed read into ``()``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Final, Protocol
+
+from sqlalchemy import select
+
+from app.core.db import AsyncSessionLocal
+from app.models.review import KISMockOrderLedger, KISMockSignalLedger
+from scripts.b0x.broker_truth import PendingUnreadable
+
+#: KST (UTC+9). Fixed offset — Korea observes no DST, and this module must not
+#: depend on the host's local zone.
+KST: Final[dt.timezone] = dt.timezone(dt.timedelta(hours=9))
+
+#: ``account_mode`` both ledgers pin with a CHECK constraint.
+ACCOUNT_MODE: Final[str] = "kis_mock"
+
+#: ``PendingUnreadable.reason`` for a ledger that could not be read. Distinct
+#: from ``kis_mock_pending_inquiry_unsupported`` (the broker-surface fact) so an
+#: observation record shows *which* source failed, not merely that one did.
+LEDGER_UNREADABLE_REASON: Final[str] = "kis_mock_ledger_pending_unreadable"
+
+
+class PendingReader(Protocol):
+    """The seam ``run_kr_cycle`` reads 자기 미체결 through."""
+
+    async def __call__(
+        self, *, now: dt.datetime, correlation_prefix: str
+    ) -> tuple[str, ...] | PendingUnreadable: ...
+
+
+def ledger_unreadable(cause: str) -> PendingUnreadable:
+    """The v1.6 ④ fallback — the ledger could not answer, so nothing is known.
+
+    ``cause`` must be an exception *type* name, never its message: a DB error
+    message can carry a DSN with credentials, and this value is written into a
+    durable observation record.
+    """
+
+    return PendingUnreadable(
+        reason=LEDGER_UNREADABLE_REASON,
+        detail=(
+            f"review.kis_mock_order_ledger 조회 실패({cause}) — 브로커 미체결 "
+            "표면은 이미 막혀 있다(TTTC8036R 는 is_mock=True 에서 raise, "
+            "daily-ccld 는 당일 주문이 있어도 빈 행 가능, ROB-341 실측)이라 "
+            "폴백이 없다. 「조회 불가」를 「미체결 없음」으로 취급하지 않는다 "
+            "(계약 v1.6 ③④)"
+        ),
+    )
+
+
+def kst_trading_day_start(now: dt.datetime) -> dt.datetime:
+    """Midnight KST of the trading day containing ``now`` (tz-aware, KST).
+
+    Naive input is read as UTC, matching ``app.core.timezone.trade_day_kst``'s
+    own rule for legacy timestamps, so a host-local zone can never move the
+    boundary.
+    """
+
+    moment = now.replace(tzinfo=dt.UTC) if now.tzinfo is None else now
+    return moment.astimezone(KST).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def kst_trading_day_label(now: dt.datetime) -> str:
+    """``YYYY-MM-DD`` in KST — the spelling ``kis_mock_signal_ledger.kst_date``
+    stores (``record_signal``: ``now_kst().strftime("%Y-%m-%d")``)."""
+
+    return kst_trading_day_start(now).strftime("%Y-%m-%d")
+
+
+async def read_own_pending(
+    *, now: dt.datetime, correlation_prefix: str
+) -> tuple[str, ...] | PendingUnreadable:
+    """자기 미체결 심볼 — contract v1.6 ①②, read-only.
+
+    Returns the deliberate superset described in the module docstring, or
+    :func:`ledger_unreadable` if either query fails for any reason. An empty
+    tuple means *the ledgers answered and named nothing* — a real, readable
+    "이 레인이 오늘 아무 주문도 넣지 않았다".
+
+    🔴 Nothing here reads or returns positions. Position truth stays with the
+    broker holdings read (``FreshTruth.non_dust_position_symbols``) per v1.6 ②.
+    """
+
+    since = kst_trading_day_start(now)
+    kst_date = kst_trading_day_label(now)
+    prefix = f"{correlation_prefix}%"
+
+    try:
+        async with AsyncSessionLocal() as db:
+            # The contract's named source. No lifecycle_state predicate: see
+            # the module docstring on why filtering by state is the forbidden
+            # 관대한 방향.
+            order_symbols = (
+                await db.execute(
+                    select(KISMockOrderLedger.symbol).where(
+                        KISMockOrderLedger.account_mode == ACCOUNT_MODE,
+                        KISMockOrderLedger.correlation_id.like(prefix),
+                        KISMockOrderLedger.trade_date >= since,
+                    )
+                )
+            ).scalars()
+            # The pre-submit chokepoint row, which cannot be lost without the
+            # send itself being refused — this is what closes the lost-native-
+            # write hole the order table alone would leave open.
+            signal_symbols = (
+                await db.execute(
+                    select(KISMockSignalLedger.symbol).where(
+                        KISMockSignalLedger.account_mode == ACCOUNT_MODE,
+                        KISMockSignalLedger.correlation_id.like(prefix),
+                        KISMockSignalLedger.kst_date == kst_date,
+                    )
+                )
+            ).scalars()
+            symbols = {
+                str(symbol).strip()
+                for symbol in [*order_symbols, *signal_symbols]
+                if str(symbol).strip()
+            }
+    except Exception as exc:  # noqa: BLE001 — any failure is "unreadable"
+        return ledger_unreadable(type(exc).__name__)
+
+    return tuple(sorted(symbols))
+
+
+__all__ = [
+    "ACCOUNT_MODE",
+    "KST",
+    "LEDGER_UNREADABLE_REASON",
+    "PendingReader",
+    "kst_trading_day_label",
+    "kst_trading_day_start",
+    "ledger_unreadable",
+    "read_own_pending",
+]

--- a/scripts/run_b0x_kr_cycle.py
+++ b/scripts/run_b0x_kr_cycle.py
@@ -67,6 +67,7 @@ async def _derivation_only(args: argparse.Namespace) -> int:
     from scripts.b0x import kill_switch as kill_switch_module
     from scripts.b0x.derivation import derive_orders
     from scripts.b0x.kr import mock as kr_mock
+    from scripts.b0x.kr import pending_ledger as kr_pending_ledger
     from scripts.b0x.kr.cycle import broker_state
     from scripts.b0x.table_source import TableUnavailable, load_policy_table
 
@@ -89,8 +90,13 @@ async def _derivation_only(args: argparse.Namespace) -> int:
 
     # Contract v1.5 ①: account state is the fresh broker read and nothing else
     # — there is no lane state file to load, and re-introducing one would put
-    # the per-cycle-reset defect straight back.
-    state = broker_state(fresh=fresh)
+    # the per-cycle-reset defect straight back. Contract v1.6 ① adds exactly
+    # one non-broker input, 자기 미체결, from the submission ledger; a failed
+    # read of it returns the same PendingUnreadable state, not an empty book.
+    own_pending = await kr_pending_ledger.read_own_pending(
+        now=now, correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
+    )
+    state = broker_state(fresh=fresh, own_pending=own_pending)
 
     hashes: list[str] = []
     result = None

--- a/tests/scripts/b0x/kr/_pending.py
+++ b/tests/scripts/b0x/kr/_pending.py
@@ -1,0 +1,106 @@
+"""Fake 자기 미체결 readers for the KR lane (contract v1.6 ①).
+
+None of these touch a database. :class:`StatefulPendingLedger` is the
+multi-cycle one: it models the single property the real ledger provides — the
+submission chokepoint writes a row for every order that goes out, and a later
+cycle reads those rows back — which is what makes the §4 caps bind *across*
+cycles rather than only within one.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from scripts.b0x.broker_truth import PendingUnreadable
+from scripts.b0x.kr import pending_ledger as kr_pending_ledger
+from scripts.b0x.kr.mock import KR_PENDING_UNREADABLE
+
+
+def readable_pending(*symbols: str):
+    """A reader whose ledger answers with exactly ``symbols``."""
+
+    async def _read(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> tuple[str, ...] | PendingUnreadable:
+        return tuple(sorted(symbols))
+
+    return _read
+
+
+def unreadable_pending(sentinel: PendingUnreadable = KR_PENDING_UNREADABLE):
+    """A reader that cannot answer — the v1.6 ④ tri-state."""
+
+    async def _read(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> tuple[str, ...] | PendingUnreadable:
+        return sentinel
+
+    return _read
+
+
+def exploding_pending(exc: Exception):
+    """A reader whose *underlying query* raises.
+
+    Wraps the real :func:`scripts.b0x.kr.pending_ledger.read_own_pending`
+    contract rather than short-circuiting it: the production function is the
+    thing that must convert a fault into ``PendingUnreadable``, so this helper
+    reproduces the fault and lets that conversion run.
+    """
+
+    async def _read(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> tuple[str, ...] | PendingUnreadable:
+        try:
+            raise exc
+        except Exception as caught:  # noqa: BLE001 — mirrors the real handler
+            return kr_pending_ledger.ledger_unreadable(type(caught).__name__)
+
+    return _read
+
+
+class StatefulPendingLedger:
+    """An in-memory stand-in for the ledger the submission path writes to.
+
+    ``record`` is what the chokepoint does after a send; ``read`` is what the
+    next cycle sees. Rows are stamped with the KST trading day, so the reader
+    reproduces the real one's single bound (a KRX day order cannot rest past
+    its accept day) without reproducing anything else — in particular it never
+    inspects a lifecycle state, because the production reader does not either.
+    """
+
+    def __init__(self) -> None:
+        #: ``(kst_day_label, symbol, correlation_id)`` — every recorded send.
+        self.rows: list[tuple[str, str, str]] = []
+        #: One entry per ``read`` call, for asserting the cycle actually asked.
+        self.reads: list[str] = []
+
+    def record(self, *, now: dt.datetime, symbol: str, correlation_id: str) -> None:
+        self.rows.append(
+            (kr_pending_ledger.kst_trading_day_label(now), symbol, correlation_id)
+        )
+
+    def symbols_on(self, now: dt.datetime) -> tuple[str, ...]:
+        day = kr_pending_ledger.kst_trading_day_label(now)
+        return tuple(
+            sorted({symbol for row_day, symbol, _ in self.rows if row_day == day})
+        )
+
+    def reader(self, prefix: str = "b0xk-"):
+        async def _read(
+            *, now: dt.datetime, correlation_prefix: str
+        ) -> tuple[str, ...] | PendingUnreadable:
+            assert correlation_prefix == prefix, (
+                f"cycle asked with prefix {correlation_prefix!r}, expected {prefix!r}"
+            )
+            self.reads.append(kr_pending_ledger.kst_trading_day_label(now))
+            return self.symbols_on(now)
+
+        return _read
+
+
+__all__ = [
+    "StatefulPendingLedger",
+    "exploding_pending",
+    "readable_pending",
+    "unreadable_pending",
+]

--- a/tests/scripts/b0x/kr/conftest.py
+++ b/tests/scripts/b0x/kr/conftest.py
@@ -1,0 +1,38 @@
+"""KR-lane test guards — no test may reach the real submission ledger.
+
+Contract v1.6 ① makes ``review.kis_mock_order_ledger`` a cap input, which puts
+a DB read on the KR cycle's hot path. The crypto lane already established the
+pattern for exactly this hazard (``tests/scripts/b0x/test_cycle.py`` replaces
+``fetch_ohlcv`` with an ``AssertionError`` autouse fixture): a test that forgets
+to inject must **fail loudly**, not quietly open a session against whatever
+``DATABASE_URL`` happens to be set.
+
+It matters more than convenience here. ``read_own_pending`` converts *any*
+failure into :class:`~scripts.b0x.broker_truth.PendingUnreadable`, so an
+un-injected test would not error — it would silently take the fail-closed
+branch and keep passing while proving nothing about the readable path.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from scripts.b0x.broker_truth import PendingUnreadable
+from scripts.b0x.kr import pending_ledger as kr_pending_ledger
+
+
+@pytest.fixture(autouse=True)
+def _forbid_real_pending_ledger_reads(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _refuse(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> tuple[str, ...] | PendingUnreadable:
+        raise AssertionError(
+            "a KR test reached the real kis_mock ledger reader "
+            f"(now={now.isoformat()} prefix={correlation_prefix!r}). Pass "
+            "pending_reader=... explicitly — an accidental read would be "
+            "swallowed into PendingUnreadable and prove nothing."
+        )
+
+    monkeypatch.setattr(kr_pending_ledger, "read_own_pending", _refuse)

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import pytest
 
-from scripts.b0x.broker_truth import BrokerTruth
 from scripts.b0x.kr.cycle import LANE as KR_LANE
 from scripts.b0x.kr.cycle import OUTSIDE_RTH_REASON, run_kr_cycle
 from scripts.b0x.labels import SHARED_ACCOUNT_HISTORY, TRUST_LABELS
@@ -24,6 +23,11 @@ from tests.scripts.b0x._table_fixtures import (
     make_row,
     write_stale_marker,
     write_table,
+)
+from tests.scripts.b0x.kr._pending import (
+    exploding_pending,
+    readable_pending,
+    unreadable_pending,
 )
 
 pytestmark = pytest.mark.unit
@@ -90,30 +94,12 @@ class _FakeKrClient:
         self.closed = True
 
 
-def _patch_readable_pending(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Substitute a *readable, empty* pending state at the state boundary.
-
-    The real kis_mock lane reports :data:`kr_mock.KR_PENDING_UNREADABLE`, which
-    correctly refuses every row — so any test of what happens *downstream* of
-    derivation needs a venue that can answer. Patching ``broker_state`` (not
-    the fail-close itself) keeps the production path honest: nothing here makes
-    the real lane readable.
-    """
-
-    from scripts.b0x.kr import cycle as kr_cycle_module
-
-    real_broker_state = kr_cycle_module.broker_state
-
-    def _readable(**kwargs: Any):
-        state = real_broker_state(**kwargs)
-        return replace(
-            state,
-            broker_truth=BrokerTruth(
-                position_symbols=state.broker_truth.position_symbols, own_pending=()
-            ),
-        )
-
-    monkeypatch.setattr(kr_cycle_module, "broker_state", _readable)
+#: Contract v1.6 ① made 자기 미체결 readable from the submission ledger, so the
+#: ordinary case for a lane that has not traded today is a readable **empty**
+#: answer. Tests that want the fail-closed tri-state ask for it explicitly with
+#: ``unreadable_pending()`` / ``exploding_pending(...)`` — the substitution is
+#: never implicit, and (per ``conftest.py``) never accidental.
+EMPTY_PENDING = readable_pending()
 
 
 @pytest.mark.asyncio
@@ -194,14 +180,16 @@ async def test_table_just_under_36h_still_derives_orders(
         table_dir=directory,
         out_dir=out_dir,
         client=_FakeKrClient(orderable_cash="5000000"),
+        pending_reader=EMPTY_PENDING,
     )
     assert outcome.zero_order_reason is None
-    # The age gate is not what stops this cycle — v1.5 ①'s unreadable-pending
-    # fail-close is (see test_kr_pending_is_unreadable_and_fails_closed). A
-    # 37h table would instead have set zero_order_reason=stale_by_age above.
-    assert {skip["reason"] for skip in outcome.record["skipped"]} == {
-        "own_pending_unreadable"
-    }
+    # Under contract v1.6 ① a lane that has not traded today reads a readable
+    # empty pending book, so this really does derive — before v1.6 the
+    # unreadable fail-close stopped every row here regardless of table age,
+    # which made the boundary check vacuous. A 37h table would instead have set
+    # zero_order_reason=stale_by_age above.
+    assert outcome.order_count > 0
+    assert outcome.record["broker_truth"]["own_pending_readable"] is True
 
 
 @pytest.mark.asyncio
@@ -215,8 +203,10 @@ async def test_dry_run_plans_but_never_dispatches(
         out_dir=out_dir,
         confirm=False,
         client=client,
+        pending_reader=EMPTY_PENDING,
     )
     assert outcome.zero_order_reason is None
+    assert outcome.record["planned"], "a readable-empty book must still plan"
     assert outcome.record["submitted"] == []
     assert outcome.record["submission_skipped"] == "confirm=False — preview only"
     # A caller-supplied client is caller-owned: the cycle must not close it.
@@ -234,13 +224,15 @@ async def test_dry_run_plans_but_never_dispatches(
 async def test_kr_pending_is_unreadable_and_fails_closed(
     table_dir: Path, out_dir: Path
 ) -> None:
-    """계약 v1.5 ①, KR column — 「조회 불가」 is not 「미체결 없음」.
+    """계약 v1.5 ① / v1.6 ④ — 「조회 불가」 is still not 「미체결 없음」.
 
-    kis_mock can answer neither of its two pending-order surfaces (TTTC8036R
-    raises for is_mock=True; daily-ccld can return empty rows even after
-    same-day mock activity, ROB-341). So every candidate row is refused with
-    ``own_pending_unreadable``, the refusal carries *why*, and the record says
-    plainly that pending is unreadable rather than reporting an empty book.
+    v1.6 ① gave this lane a *source* for 자기 미체결; it did not delete the
+    unreadable state. When the source cannot answer — this test drives the
+    kis_mock broker-surface sentinel directly — every candidate row is refused
+    with ``own_pending_unreadable``, the refusal carries *why*, and the record
+    says plainly that pending is unreadable rather than reporting an empty
+    book. ``test_a_failed_ledger_read_falls_back_to_unreadable`` covers the
+    other way into this state (the ledger query itself faulting).
     """
 
     outcome = await run_kr_cycle(
@@ -249,6 +241,7 @@ async def test_kr_pending_is_unreadable_and_fails_closed(
         out_dir=out_dir,
         confirm=False,
         client=_FakeKrClient(orderable_cash="5000000"),
+        pending_reader=unreadable_pending(),
     )
 
     assert outcome.record["broker_truth"]["own_pending_readable"] is False
@@ -270,6 +263,42 @@ async def test_kr_pending_is_unreadable_and_fails_closed(
 
 
 @pytest.mark.asyncio
+async def test_a_failed_ledger_read_falls_back_to_unreadable(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """계약 v1.6 ④ — 원장 조회 실패 → 다시 unreadable → 전 심볼 차단.
+
+    The v1.6 exception is conditional on the ledger *answering*. A fault must
+    not degrade to "nothing is resting"; it must land back on exactly the
+    tri-state X-E1 built, refusing every symbol.
+    """
+
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(orderable_cash="5000000"),
+        pending_reader=exploding_pending(OSError("connection refused")),
+    )
+
+    truth = outcome.record["broker_truth"]
+    assert truth["own_pending_readable"] is False
+    assert truth["own_pending"]["reason"] == "kis_mock_ledger_pending_unreadable"
+    # The record must say the *ledger* failed, not merely repeat the broker
+    # surface fact — and it must not leak the exception message (a DB error can
+    # carry a DSN with credentials), only its type name.
+    assert "OSError" in truth["own_pending"]["detail"]
+    assert "connection refused" not in truth["own_pending"]["detail"]
+
+    assert outcome.order_count == 0
+    assert outcome.record["planned"] == []
+    skipped = outcome.record["skipped"]
+    assert {skip["symbol"] for skip in skipped} == {"005930", "000660"}
+    assert all(skip["reason"] == "own_pending_unreadable" for skip in skipped)
+
+
+@pytest.mark.asyncio
 async def test_kr_records_that_realized_pnl_has_no_source(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -281,6 +310,7 @@ async def test_kr_records_that_realized_pnl_has_no_source(
         out_dir=out_dir,
         confirm=False,
         client=_FakeKrClient(orderable_cash="5000000"),
+        pending_reader=EMPTY_PENDING,
     )
     assert "Not a measured zero" in outcome.record["realized_pnl_source"]
     assert outcome.derivation is not None
@@ -306,6 +336,7 @@ async def test_kr_dry_run_reacts_when_shared_history_scope_expands(
         out_dir=out_dir,
         confirm=False,
         client=_FakeKrClient(orderable_cash="5000000"),
+        pending_reader=EMPTY_PENDING,
     )
 
     assert SHARED_ACCOUNT_HISTORY in outcome.record["labels"]
@@ -331,7 +362,11 @@ async def test_owns_client_path_constructs_and_closes_its_own_client(
     monkeypatch.setattr(kr_mock_module, "ReadOnlyKISMockDomesticClient", lambda: fake)
 
     outcome = await run_kr_cycle(
-        now=IN_SESSION_NOW, table_dir=table_dir, out_dir=out_dir, confirm=False
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        pending_reader=EMPTY_PENDING,
     )
     assert outcome.zero_order_reason is None
     assert fake.closed is True
@@ -372,6 +407,7 @@ async def test_confirm_true_dispatches_nothing_while_pending_is_unreadable(
         confirm=True,
         client=_FakeKrClient(orderable_cash="5000000"),
         broker=broker,
+        pending_reader=unreadable_pending(),
     )
     assert outcome.zero_order_reason is None
     assert outcome.record["planned"] == []
@@ -381,24 +417,20 @@ async def test_confirm_true_dispatches_nothing_while_pending_is_unreadable(
 
 @pytest.mark.asyncio
 async def test_confirm_true_routes_through_the_injected_broker_when_pending_reads(
-    table_dir: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
+    table_dir: Path, out_dir: Path
 ) -> None:
     """``confirm=True`` routes every planned order through the wired
     ``KisMockBroker`` integration point (contract v1.3 ③) — proven here with
     a fake broker so the assertion never touches a real kis_mock account.
 
-    The lane's own pending state is unreadable (see
-    ``test_kr_pending_is_unreadable_and_fails_closed``), which correctly stops
-    every row, so this test substitutes a *readable, empty* pending state to
-    exercise the submission wiring underneath. That keeps the wiring covered
-    without the test quietly asserting the fail-close away: the substitution is
-    at the state boundary, and the real lane still constructs the unreadable
-    state. ``unwired_submit_order``/``KrMockSubmissionNotWired`` is proven still
+    Before v1.6 this test had to reach past ``broker_state`` to fake a readable
+    book, because the lane had no readable source at all. It now uses the real
+    ``pending_reader`` seam with an empty ledger — the same code path
+    production takes on a day this lane has not yet traded.
+    ``unwired_submit_order``/``KrMockSubmissionNotWired`` is proven still
     intact (kept, not deleted) by ``test_unwired_submit_order_always_raises``
     in ``tests/scripts/b0x/kr/test_mock.py``.
     """
-
-    _patch_readable_pending(monkeypatch)
 
     client = _FakeKrClient(orderable_cash="5000000")
     broker = _FakeBroker()
@@ -409,6 +441,7 @@ async def test_confirm_true_routes_through_the_injected_broker_when_pending_read
         confirm=True,
         client=client,
         broker=broker,
+        pending_reader=EMPTY_PENDING,
     )
 
     assert outcome.zero_order_reason is None
@@ -455,6 +488,7 @@ async def test_kill_switch_trips_on_nav_ratio_and_blocks_all_new_orders(
         out_dir=out_dir,
         confirm=False,
         client=_FakeKrClient(orderable_cash="1000000"),
+        pending_reader=EMPTY_PENDING,
     )
     assert outcome.derivation is not None
     assert outcome.derivation.kill_switch.tripped
@@ -483,6 +517,7 @@ async def test_determinism_same_inputs_same_derivation_hash(
             out_dir=out_dir,
             confirm=False,
             client=_FakeKrClient(orderable_cash="5000000"),
+            pending_reader=EMPTY_PENDING,
         )
         assert outcome.derivation is not None
         hashes.append(outcome.derivation.derivation_hash())

--- a/tests/scripts/b0x/kr/test_ledger_pending_source.py
+++ b/tests/scripts/b0x/kr/test_ledger_pending_source.py
@@ -1,0 +1,814 @@
+"""KR 자기 미체결 = ``kis_mock_order_ledger`` — contract v1.6 ①~④.
+
+Four things have to hold at once, and each is easy to break in a way that
+still looks like it works:
+
+1. The ledger answer really becomes ``own_pending`` and really blocks the
+   symbol, across cycles — not just within one (the X-E1 lesson: 「상한이
+   발화했다 ≠ 그 상한이 의도한 기간 동안 구속한다」). ``KR_TWO_CYCLE_SIM``
+   below is the multi-cycle observation that can tell those apart.
+2. A ledger that cannot answer lands back on ``PendingUnreadable`` — v1.6 ④.
+   An empty tuple and a failed read must never be the same value.
+3. The ledger never becomes position truth — v1.6 ②.
+4. No submission path can exist that skips the ledger write — v1.6 ③'s new
+   mutant. A ledger-based dedup gate is only as good as the guarantee that
+   every order that goes out is in the ledger.
+
+(3) and (4) are static: a behavioural test can prove what today's code does,
+but only a source-level guard can catch *a new path* being added. Both styles
+are here, and each detector is self-tested against synthetic source so "the
+guard exists" is never mistaken for "the guard fires".
+"""
+
+from __future__ import annotations
+
+import ast
+import datetime as dt
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.b0x.broker_truth import PendingUnreadable
+from scripts.b0x.kr import pending_ledger as kr_pending_ledger
+from scripts.b0x.kr.cycle import broker_state, run_kr_cycle
+from scripts.b0x.kr.mock import KR_PENDING_UNREADABLE, FreshTruth, RawPosition
+from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
+from tests.scripts.b0x.kr._pending import StatefulPendingLedger, readable_pending
+
+pytestmark = pytest.mark.unit
+
+#: Captured at import time, before ``conftest.py``'s autouse fixture replaces
+#: the module attribute. The tests below that exercise the *real* reader's
+#: empty-vs-unreadable behaviour have to call the production function; every
+#: other test still goes through the guarded seam.
+REAL_READ_OWN_PENDING = kr_pending_ledger.read_own_pending
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+KR_PACKAGE = REPO_ROOT / "scripts" / "b0x" / "kr"
+KR_RUNNER = REPO_ROOT / "scripts" / "run_b0x_kr_cycle.py"
+B0X_PACKAGE = REPO_ROOT / "scripts" / "b0x"
+OTHER_RUNNERS = (
+    REPO_ROOT / "scripts" / "run_b0x_cycle.py",
+    REPO_ROOT / "scripts" / "run_b0x_cancel.py",
+)
+
+# 2026-08-10 Monday 02:00 UTC = 11:00 KST, inside the XKRX regular session.
+CYCLE_1 = dt.datetime(2026, 8, 10, 2, 0, tzinfo=dt.UTC)
+CYCLE_2 = dt.datetime(2026, 8, 10, 3, 0, tzinfo=dt.UTC)  # same KST day
+CYCLE_3 = dt.datetime(2026, 8, 10, 4, 30, tzinfo=dt.UTC)  # same KST day
+NEXT_DAY = dt.datetime(2026, 8, 11, 2, 0, tzinfo=dt.UTC)  # Tuesday, next KST day
+
+
+def _kr_files() -> list[Path]:
+    return sorted([*KR_PACKAGE.rglob("*.py"), KR_RUNNER])
+
+
+def _non_kr_b0x_files() -> list[Path]:
+    return sorted(
+        [
+            path
+            for path in [*B0X_PACKAGE.rglob("*.py"), *OTHER_RUNNERS]
+            if KR_PACKAGE not in path.parents and path != KR_PACKAGE
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def table_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "policy-tables"
+    write_table(
+        directory,
+        make_payload(
+            market="kr",
+            rows=[
+                make_row(symbol="005930", previous_close="97000", buy_l1="94090"),
+                make_row(symbol="000660", previous_close="200000", buy_l1="194000"),
+            ],
+            generated_at=CYCLE_1 - dt.timedelta(hours=1),
+        ),
+        market="kr",
+    )
+    return directory
+
+
+@pytest.fixture
+def out_dir(tmp_path: Path) -> Path:
+    return tmp_path / "observations"
+
+
+class _FakeKrClient:
+    """Flat kis_mock account: cash only, no holdings."""
+
+    def __init__(self, *, stocks: list[dict[str, Any]] | None = None) -> None:
+        self._stocks = stocks or []
+
+    async def inquire_cash_balance(self) -> dict[str, Any]:
+        return {"dnca_tot_amt": 5_000_000.0, "stck_cash_ord_psbl_amt": 5_000_000.0}
+
+    async def fetch_my_stocks(self) -> list[dict[str, Any]]:
+        return self._stocks
+
+    async def close(self) -> None:  # pragma: no cover — caller-owned here
+        pass
+
+
+class _RecordingBroker:
+    """``KisMockBroker`` stand-in that reports the ledger row it would cause.
+
+    The real broker's ``submit_buy`` reaches ``_place_order_impl(is_mock=True)``
+    → ``_execute_and_record``, whose first action on the mock branch is the
+    pre-submit attribution gate that commits the ``correlation_id`` row. This
+    fake models exactly that one property (a send produces a ledger row keyed
+    by correlation id) and nothing else — no HTTP, no DB, no reservation.
+    """
+
+    def __init__(self, ledger: StatefulPendingLedger, now: dt.datetime) -> None:
+        self._ledger = ledger
+        self._now = now
+        self.buy_calls: list[dict[str, Any]] = []
+        self.sell_calls: list[dict[str, Any]] = []
+
+    def at(self, now: dt.datetime) -> _RecordingBroker:
+        self._now = now
+        return self
+
+    async def submit_buy(self, **kwargs: Any) -> dict[str, Any]:
+        assert kwargs["confirm"] is True
+        self.buy_calls.append(kwargs)
+        self._ledger.record(
+            now=self._now,
+            symbol=kwargs["symbol"],
+            correlation_id=kwargs["correlation_id"],
+        )
+        return {"success": True, "odno": f"FAKE-BUY-{len(self.buy_calls)}"}
+
+    async def submit_exit_sell(self, **kwargs: Any) -> dict[str, Any]:
+        self.sell_calls.append(kwargs)
+        self._ledger.record(
+            now=self._now,
+            symbol=kwargs["symbol"],
+            correlation_id=kwargs["correlation_id"],
+        )
+        return {"success": True, "odno": f"FAKE-SELL-{len(self.sell_calls)}"}
+
+
+# ---------------------------------------------------------------------------
+# 1. The ledger answer is the dedup input (v1.6 ①②)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_ledger_named_symbol_is_refused_and_the_rest_still_derive(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """v1.6 ① — the exception supplies a *working* input, not a blanket block.
+
+    X-E1's fail-close refused every symbol because nothing could be known.
+    With the ledger answering, the refusal is symbol-scoped again: the named
+    symbol is blocked with ``own_pending_order_exists`` (not
+    ``own_pending_unreadable``), and every other row derives normally.
+    """
+
+    outcome = await run_kr_cycle(
+        now=CYCLE_1,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(),
+        pending_reader=readable_pending("005930"),
+    )
+
+    truth = outcome.record["broker_truth"]
+    assert truth["own_pending_readable"] is True
+    assert truth["own_pending"] == ["005930"]
+    assert outcome.record["own_pending_source"].startswith("kis_mock_order_ledger")
+
+    blocked = [s for s in outcome.record["skipped"] if s["symbol"] == "005930"]
+    assert blocked and all(s["reason"] == "own_pending_order_exists" for s in blocked)
+    assert {order["symbol"] for order in outcome.record["orders"]} == {"000660"}
+
+
+@pytest.mark.asyncio
+async def test_the_submission_boundary_also_refuses_a_ledger_named_symbol(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """The gate is at dispatch too, not only in derivation.
+
+    Derivation already drops the row, so this asserts the *second* check by
+    calling the submission helper directly with a plan derivation would never
+    have produced — the shape a future caller bug would take.
+    """
+
+    from scripts.b0x.broker_truth import OwnPendingResubmitBlocked
+    from scripts.b0x.kr import mock as kr_mock
+
+    fresh = FreshTruth(cash=Decimal("0"), nav=Decimal("0"), positions=())
+    truth = fresh.broker_truth(("005930",))
+    planned = kr_mock.PlannedOrder(
+        order_key="deadbeefdeadbeef",
+        client_order_id="b0xk-deadbeefdeadbeef",
+        symbol="005930",
+        side="buy",
+        leg="buy_l1",
+        price=94_000,
+        quantity=1,
+        notional=94_000,
+    )
+    broker = _RecordingBroker(StatefulPendingLedger(), CYCLE_1)
+
+    with pytest.raises(OwnPendingResubmitBlocked):
+        await kr_mock.submit_planned_order(
+            broker, planned=planned, confirm=True, broker_truth=truth
+        )
+    assert broker.buy_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 2. KR_TWO_CYCLE_SIM — the cap binds across cycles (v1.6 ①③)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """🔴 KR_TWO_CYCLE_SIM — fixed fixture, zero broker calls, zero network.
+
+    Cycle 1 derives and submits both rows; the submission chokepoint records
+    them. Cycle 2 and 3, on the same KRX trading day, read those rows back and
+    derive **nothing** — the venue never sees a second order for either symbol.
+    Cycle 4 crosses the KST day boundary (KRX day orders cannot survive it) and
+    derives again.
+
+    This is the observation X-E1 established is the only one that can tell
+    「상한이 발화했다」 from 「상한이 구속한다」: a single cycle looks identical
+    either way.
+    """
+
+    ledger = StatefulPendingLedger()
+    broker = _RecordingBroker(ledger, CYCLE_1)
+    reader = ledger.reader()
+    derived_per_cycle: list[list[str]] = []
+    submit_cum: list[int] = []
+
+    for index, now in enumerate((CYCLE_1, CYCLE_2, CYCLE_3, NEXT_DAY)):
+        # The table is regenerated each cycle so table age never becomes the
+        # reason a later cycle derives nothing.
+        write_table(
+            table_dir,
+            make_payload(
+                market="kr",
+                rows=[
+                    make_row(symbol="005930", previous_close="97000", buy_l1="94090"),
+                    make_row(symbol="000660", previous_close="200000", buy_l1="194000"),
+                ],
+                generated_at=now - dt.timedelta(hours=1),
+            ),
+            market="kr",
+        )
+        outcome = await run_kr_cycle(
+            now=now,
+            table_dir=table_dir,
+            out_dir=out_dir / f"cycle{index}",
+            confirm=True,
+            client=_FakeKrClient(),
+            broker=broker.at(now),
+            pending_reader=reader,
+        )
+        assert outcome.zero_order_reason is None
+        derived_per_cycle.append(
+            sorted(order["symbol"] for order in outcome.record["orders"])
+        )
+        submit_cum.append(len(broker.buy_calls))
+        if index == 1:
+            # Cycle 2's skipped table must name the ledger reason, per symbol.
+            reasons = {
+                skip["symbol"]: skip["reason"] for skip in outcome.record["skipped"]
+            }
+            assert reasons == {
+                "005930": "own_pending_order_exists",
+                "000660": "own_pending_order_exists",
+            }
+            assert outcome.record["broker_truth"]["own_pending"] == [
+                "000660",
+                "005930",
+            ]
+
+    assert derived_per_cycle == [
+        ["000660", "005930"],  # cycle 1 — nothing recorded yet
+        [],  # cycle 2 — both symbols held by the ledger
+        [],  # cycle 3 — still held; no drift, no re-derivation
+        ["000660", "005930"],  # next KST day — day orders cannot have survived
+    ]
+    assert submit_cum == [2, 2, 2, 4]
+    assert broker.sell_calls == []
+    # Every cycle past the table gate really consulted the ledger.
+    assert ledger.reads == ["2026-08-10", "2026-08-10", "2026-08-10", "2026-08-11"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Over-block direction (v1.6 ③) — nothing is released by inference
+# ---------------------------------------------------------------------------
+
+#: Names that could only appear in this module if it were trying to decide
+#: whether a recorded order is *still* resting. v1.6 ③ forbids that: every such
+#: inference can release a symbol that is in fact still working, which is the
+#: 관대한 방향(누락). Over-blocking (a filled/cancelled order reading as pending)
+#: is the sanctioned error.
+FORBIDDEN_RELEASE_PREDICATES = (
+    "lifecycle_state",
+    "reconciled_at",
+    "reconcile_attempts",
+    "net_pnl",
+    "order_no",
+    "scalping_role",
+    "outcome_state",
+    "suppressed_reason",
+)
+
+
+def test_the_pending_reader_never_inspects_order_state() -> None:
+    """v1.6 ③ — the reader must not filter on anything that could release."""
+
+    source = (KR_PACKAGE / "pending_ledger.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    referenced = {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    } | {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+    offenders = sorted(referenced & set(FORBIDDEN_RELEASE_PREDICATES))
+    assert offenders == [], (
+        "scripts/b0x/kr/pending_ledger.py references order-state fields "
+        f"{offenders} — filtering on them would release symbols by inference "
+        "(계약 v1.6 ③ 관대한 방향 금지)"
+    )
+    # `status` is the one shared word that also names something innocuous, so
+    # assert on the query text rather than the identifier set.
+    assert "status" not in source, (
+        "an order-status predicate is a release-by-inference path (v1.6 ③)"
+    )
+
+
+def test_the_only_bound_is_the_kst_trading_day() -> None:
+    """The window is structural (KRX day orders), not a guess about fills."""
+
+    # 2026-08-10 02:00 UTC == 11:00 KST → the KST day starts at 00:00 KST,
+    # which is 2026-08-09 15:00 UTC.
+    start = kr_pending_ledger.kst_trading_day_start(CYCLE_1)
+    assert start.utcoffset() == dt.timedelta(hours=9)
+    assert start.isoformat() == "2026-08-10T00:00:00+09:00"
+    assert kr_pending_ledger.kst_trading_day_label(CYCLE_1) == "2026-08-10"
+
+    # 23:30 UTC is already the next KST day — a UTC-based window would put
+    # these two instants on the same day and silently widen the release.
+    late = dt.datetime(2026, 8, 10, 23, 30, tzinfo=dt.UTC)
+    assert kr_pending_ledger.kst_trading_day_label(late) == "2026-08-11"
+
+    # A naive timestamp is read as UTC (never as host-local), matching
+    # app.core.timezone.trade_day_kst's own rule.
+    naive = dt.datetime(2026, 8, 10, 23, 30)
+    assert kr_pending_ledger.kst_trading_day_label(naive) == "2026-08-11"
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty vs unreadable, exercised on the real reader (v1.6 ④)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, rows: list[str]) -> None:
+        self._rows = rows
+
+    def scalars(self) -> list[str]:
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, results: list[list[str]] | Exception) -> None:
+        self._results = results
+        self.statements: list[Any] = []
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    async def execute(self, statement: Any) -> _FakeResult:
+        if isinstance(self._results, Exception):
+            raise self._results
+        self.statements.append(statement)
+        return _FakeResult(self._results[len(self.statements) - 1])
+
+
+@pytest.mark.asyncio
+async def test_a_ledger_that_answers_nothing_is_readable_and_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Monday-first-cycle case: both tables answer, and name nothing."""
+
+    session = _FakeSession([[], []])
+    monkeypatch.setattr(kr_pending_ledger, "AsyncSessionLocal", lambda: session)
+
+    result = await REAL_READ_OWN_PENDING(now=CYCLE_1, correlation_prefix="b0xk-")
+    assert result == ()
+    assert not isinstance(result, PendingUnreadable)
+    # Both ledgers were queried — the pre-submit signal row is what closes the
+    # lost-native-write hole, so dropping that query is a real regression.
+    assert len(session.statements) == 2
+
+
+@pytest.mark.asyncio
+async def test_both_ledgers_contribute_to_the_pending_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An order row alone is not enough — the order write can be lost."""
+
+    session = _FakeSession([["005930"], ["000660", "005930"]])
+    monkeypatch.setattr(kr_pending_ledger, "AsyncSessionLocal", lambda: session)
+
+    result = await REAL_READ_OWN_PENDING(now=CYCLE_1, correlation_prefix="b0xk-")
+    assert result == ("000660", "005930")
+
+
+@pytest.mark.asyncio
+async def test_a_failing_query_is_unreadable_never_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """v1.6 ④ on the real function — the fault path cannot produce ``()``."""
+
+    monkeypatch.setattr(
+        kr_pending_ledger,
+        "AsyncSessionLocal",
+        lambda: _FakeSession(RuntimeError("boom: postgres://user:secret@host/db")),
+    )
+
+    result = await REAL_READ_OWN_PENDING(now=CYCLE_1, correlation_prefix="b0xk-")
+    assert isinstance(result, PendingUnreadable)
+    assert result.reason == kr_pending_ledger.LEDGER_UNREADABLE_REASON
+    assert "RuntimeError" in result.detail
+    assert "secret" not in result.detail  # type name only, never the message
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_cannot_be_opened_is_also_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _explode() -> Any:
+        raise OSError("no database configured")
+
+    monkeypatch.setattr(kr_pending_ledger, "AsyncSessionLocal", _explode)
+    result = await REAL_READ_OWN_PENDING(now=CYCLE_1, correlation_prefix="b0xk-")
+    assert isinstance(result, PendingUnreadable)
+    assert "OSError" in result.detail
+
+
+def test_pending_unreadable_is_still_the_default_without_a_reader() -> None:
+    """v1.6 ④ — X-E1's state was kept, and it is what an un-wired caller gets."""
+
+    fresh = FreshTruth(cash=0, nav=0, positions=())
+    assert fresh.broker_truth().own_pending is KR_PENDING_UNREADABLE
+    assert fresh.broker_truth().pending_unreadable is not None
+    assert broker_state(fresh=fresh).broker_truth.pending_unreadable is not None
+    assert fresh.status_only()["own_pending_readable"] is False
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ② — the exception must not spread to other lanes
+# ---------------------------------------------------------------------------
+
+#: Modules whose import outside ``scripts/b0x/kr/**`` would mean the kis_mock
+#: self-record exception had leaked into a lane that can read its venue.
+KR_LEDGER_ONLY_MODULES = (
+    "scripts.b0x.kr.pending_ledger",
+    "app.models.review",
+    "app.mcp_server.tooling.kis_mock_ledger",
+    "app.services.brokers.kis.mock_scalping_exec.ledger_state",
+)
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+@pytest.mark.parametrize("path", _non_kr_b0x_files(), ids=lambda p: p.name)
+def test_no_other_lane_imports_the_kis_mock_ledger_source(path: Path) -> None:
+    """v1.6 ① 🔴 crypto·US 로 확대 금지 — enforced statically, not by habit."""
+
+    offenders = sorted(
+        module
+        for module in _imported_modules(path)
+        for forbidden in KR_LEDGER_ONLY_MODULES
+        if module == forbidden or module.startswith(f"{forbidden}.")
+    )
+    assert offenders == [], (
+        f"{path.relative_to(REPO_ROOT)} imports the kis_mock-only pending "
+        f"source {offenders} — 계약 v1.6 ① limits the self-record exception to "
+        "kis_mock; every other lane reads its venue"
+    )
+
+
+def test_the_non_kr_scan_actually_covers_the_crypto_lane() -> None:
+    """A guard over an empty file list passes vacuously."""
+
+    scanned = {path.name for path in _non_kr_b0x_files()}
+    assert {"sidecar.py", "shadow.py", "cycle.py", "broker_truth.py"} <= scanned
+
+
+def test_the_crypto_lane_still_reads_pending_from_its_venue() -> None:
+    """The sidecar's own-pending set must still come from the venue's own
+    open-orders answer keyed on ``b0xc`` — untouched by this round."""
+
+    sidecar = (B0X_PACKAGE / "crypto" / "sidecar.py").read_text(encoding="utf-8")
+    assert "own_order_symbols" in sidecar
+    assert "CLIENT_ORDER_ID_PREFIX" in sidecar
+    assert "kis_mock" not in sidecar
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ③ — the ledger must never become position truth
+# ---------------------------------------------------------------------------
+
+#: Every name by which a pending-ledger answer travels through this package.
+#: None of them may appear inside a position-valued argument.
+PENDING_DERIVED_NAMES = frozenset(
+    {
+        "own_pending",
+        "pending_reader",
+        "read_own_pending",
+        "pending_ledger",
+        "kr_pending_ledger",
+    }
+)
+
+#: Keywords whose value *is* position truth. v1.6 ②: 포지션 진실은 계속 브로커
+#: 조회 — so nothing pending-derived may be passed here, in any lane file.
+POSITION_KEYWORDS = frozenset({"positions", "position_symbols"})
+
+
+def find_pending_as_position_truth(tree: ast.AST) -> list[str]:
+    """v1.6 ② — a pending-derived value used where a position belongs."""
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg not in POSITION_KEYWORDS:
+                continue
+            names = {
+                inner.id
+                for inner in ast.walk(keyword.value)
+                if isinstance(inner, ast.Name)
+            } | {
+                inner.attr
+                for inner in ast.walk(keyword.value)
+                if isinstance(inner, ast.Attribute)
+            }
+            leaked = sorted(names & PENDING_DERIVED_NAMES)
+            if leaked:
+                violations.append(
+                    f"line {node.lineno}: {keyword.arg}= is fed by {leaked} — "
+                    "the ledger is a dedup input only (계약 v1.6 ②)"
+                )
+    return violations
+
+
+@pytest.mark.parametrize("path", _kr_files(), ids=lambda p: p.name)
+def test_the_ledger_is_never_passed_as_position_truth(path: Path) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    assert find_pending_as_position_truth(tree) == [], f"{path.name}: v1.6 ② violation"
+
+
+def test_detector_catches_pending_used_as_position_truth() -> None:
+    assert find_pending_as_position_truth(ast.parse("f(position_symbols=own_pending)"))
+    assert find_pending_as_position_truth(ast.parse("f(positions=own_pending)"))
+    assert find_pending_as_position_truth(
+        ast.parse("f(positions=tuple(sorted(set(own_pending))))")
+    )
+    assert find_pending_as_position_truth(
+        ast.parse("f(position_symbols=await read_own_pending(now=n))")
+    )
+
+
+def test_detector_allows_the_real_position_sources() -> None:
+    assert (
+        find_pending_as_position_truth(
+            ast.parse("BrokerTruth(position_symbols=self.non_dust_position_symbols())")
+        )
+        == []
+    )
+    assert find_pending_as_position_truth(ast.parse("f(positions=positions)")) == []
+
+
+def test_the_two_position_sources_are_the_broker_read_and_nothing_else() -> None:
+    """Pin the actual expressions, so a rename cannot quietly re-point them."""
+
+    mock_tree = ast.parse((KR_PACKAGE / "mock.py").read_text(encoding="utf-8"))
+    position_args = [
+        keyword.value
+        for node in ast.walk(mock_tree)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "position_symbols"
+    ]
+    assert position_args, "FreshTruth.broker_truth stopped naming position_symbols"
+    for value in position_args:
+        assert isinstance(value, ast.Call)
+        assert isinstance(value.func, ast.Attribute)
+        assert value.func.attr == "non_dust_position_symbols"
+
+    cycle_tree = ast.parse((KR_PACKAGE / "cycle.py").read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in ast.walk(cycle_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "broker_state"
+    )
+    iterated = {
+        inner.func.attr
+        for node in ast.walk(func)
+        if isinstance(node, ast.GeneratorExp)
+        for generator in node.generators
+        for inner in ast.walk(generator.iter)
+        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)
+    } | {
+        inner.attr
+        for node in ast.walk(func)
+        if isinstance(node, ast.GeneratorExp)
+        for generator in node.generators
+        for inner in ast.walk(generator.iter)
+        if isinstance(inner, ast.Attribute)
+    }
+    assert "positions" in iterated, (
+        "broker_state stopped building positions from the holdings snapshot"
+    )
+    assert not (iterated & PENDING_DERIVED_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_a_ledger_named_symbol_is_not_a_position(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """v1.6 ② behaviourally: the ledger cannot manufacture a holding.
+
+    A symbol the ledger names, with an account that holds nothing, must leave
+    the position count at zero — otherwise the 동시 포지션 cap (and averaging /
+    sell sizing, which read ``positions``) would be driven by self-record.
+    """
+
+    outcome = await run_kr_cycle(
+        now=CYCLE_1,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(stocks=[]),
+        pending_reader=readable_pending("005930", "000660"),
+    )
+
+    truth = outcome.record["broker_truth"]
+    assert truth["own_pending"] == ["000660", "005930"]
+    assert truth["position_symbols"] == []
+    assert outcome.record["fresh_truth"]["non_dust_position_symbols"] == []
+
+
+def test_positions_are_built_from_holdings_even_when_pending_disagrees() -> None:
+    """The two views stay independent in both directions."""
+
+    fresh = FreshTruth(
+        cash=1_000_000,
+        nav=1_100_000,
+        positions=(
+            RawPosition(
+                symbol="035720",
+                quantity=10,
+                average_price=50_000,
+                evaluation_amount=520_000,
+            ),
+        ),
+    )
+    state = broker_state(fresh=fresh, own_pending=("005930",))
+
+    assert [pos.symbol for pos in state.positions] == ["035720"]
+    assert state.broker_truth.position_symbols == ("035720",)
+    assert state.broker_truth.own_pending_symbols == ("005930",)
+    assert state.broker_truth.concurrent_position_count == 1
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ① — no submission path may bypass the ledger write (v1.6 ③ new)
+# ---------------------------------------------------------------------------
+
+#: Callables that put an order at a venue. If one of these is reached from
+#: anywhere but the single wired chokepoint, an order can leave without a
+#: ledger row — and a ledger-based dedup gate is only as strong as that.
+SUBMISSION_CALLEES = {
+    "submit_buy",
+    "submit_sell",
+    "submit_exit_sell",
+    "submit_order",
+    "submit_planned",
+    "place_order",
+    "send_order",
+    "_place_order_impl",
+    "order_korea_stock",
+    "sell_korea_stock",
+    "modify_korea_order",
+    "cancel_korea_order",
+}
+
+#: The one function allowed to contain them. It is in ``scripts/b0x/kr/mock.py``
+#: and it dispatches only through ``KisMockBroker``, whose every send path runs
+#: the ``order_execution`` pre-submit gate that writes the ledger.
+LEDGER_WRITING_CHOKEPOINT = "submit_planned_order"
+
+
+def find_submission_calls_outside_the_chokepoint(tree: ast.AST) -> list[str]:
+    sanctioned: set[int] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+            and node.name == LEDGER_WRITING_CHOKEPOINT
+        ):
+            sanctioned.update(id(inner) for inner in ast.walk(node))
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func.attr if isinstance(node.func, ast.Attribute) else None
+        if callee is None and isinstance(node.func, ast.Name):
+            callee = node.func.id
+        if callee in SUBMISSION_CALLEES and id(node) not in sanctioned:
+            violations.append(
+                f"line {node.lineno}: {callee}() outside "
+                f"{LEDGER_WRITING_CHOKEPOINT}() — a send that skips the ledger "
+                "write breaks the v1.6 ① dedup source"
+            )
+    return violations
+
+
+@pytest.mark.parametrize("path", _kr_files(), ids=lambda p: p.name)
+def test_no_submission_path_bypasses_the_ledger_writing_chokepoint(
+    path: Path,
+) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    assert find_submission_calls_outside_the_chokepoint(tree) == [], f"{path.name}"
+
+
+def test_detector_catches_a_bypassing_submission_path() -> None:
+    bypass = "async def sneak(b):\n    return await b.submit_buy(symbol='005930')\n"
+    assert find_submission_calls_outside_the_chokepoint(ast.parse(bypass)) != []
+
+
+def test_detector_allows_the_chokepoint_itself() -> None:
+    ok = (
+        "async def submit_planned_order(b):\n"
+        "    return await b.submit_buy(symbol='005930')\n"
+    )
+    assert find_submission_calls_outside_the_chokepoint(ast.parse(ok)) == []
+
+
+def test_the_chokepoint_rechecks_the_pending_gate_before_dispatching() -> None:
+    """Order matters: the re-check must precede every submit call in there."""
+
+    tree = ast.parse((KR_PACKAGE / "mock.py").read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == LEDGER_WRITING_CHOKEPOINT
+    )
+    gate_lines = [
+        node.lineno
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "assert_resubmit_allowed"
+    ]
+    submit_lines = [
+        node.lineno
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in SUBMISSION_CALLEES
+    ]
+    assert gate_lines, "the submission chokepoint dropped its resubmit re-check"
+    assert submit_lines, "the guard is scanning the wrong function"
+    assert max(gate_lines) < min(submit_lines)
+
+
+def test_the_kr_scan_actually_has_files() -> None:
+    assert len(_kr_files()) >= 4, _kr_files()


### PR DESCRIPTION
## 무엇을 · 왜

X-E1(#1821)이 확정했다: `kis_mock` 은 **자기 미체결을 조회할 브로커 표면이 없다**
(`inquire_korea_orders`/TTTC8036R 은 `is_mock=True` 에서 raise, `inquire_daily_order_domestic`
은 당일 주문이 있어도 `rt_cd=0` + 빈 행 — ROB-341 실측). 그래서 `PendingUnreadable` 로
**전 심볼을 차단**했고, 정직하지만 그 상태로는 **월요일 첫 KR 사이클이 파생 0** 이다.

계약 **v1.6 ①** 이 그 한 입력에 한해 조건부 예외를 승인했다. 이 PR 이 그 배선이다.

🔴 이건 "자기 기록도 괜찮다"가 아니다. v1.5 가 `attributed_book.json` 을 폐기한 사유는
「자기 기록」이라는 개념이 아니라 **쓰기 경로가 레포에 0건**이었다는 사실이다(매 사이클
`None` 로드 → 카운터 상시 0). 이 원장은 반대로 **제출 chokepoint 가 매번 강제로 쓴다**:
`order_execution._execute_and_record` 의 **첫 동작**이 `is_mock` pre-submit 귀속 게이트이고,
`record_signal` 이 전송 **전에** 커밋되며 그 쓰기가 실패하면 주문 자체가 나가지 않는다
(`error_code="signal_record_unavailable"`).

## 계약 v1.6 축자 대조

| 리터럴 | 구현 |
|---|---|
| ① kis_mock 한정 예외 · crypto·US 확대 금지 | `scripts/b0x/kr/pending_ledger.py`. `scripts/b0x/kr/**` 밖에서 import 하면 **AST 가드가 빌드 실패**로 만든다. crypto 는 v1.5 그대로 venue open-orders 를 `b0xc` 로 필터 |
| ② 용도 = dedup/캡 입력만 · 포지션 진실은 브로커 | 원장은 `BrokerTruth.own_pending` **한 필드**에만 닿는다. `positions`/`position_symbols` 는 계속 `fetch_my_stocks` 보유에서만 — AST 가드 + 행동 테스트 |
| ③ 오류 방향 = 과잉 차단 | 🔴 `lifecycle_state` 를 **보지 않는다**. 당일 그 심볼 행이 하나라도 있으면 pending. 상태 판정은 「체결/취소됐으니 풀어줘도 된다」는 **추정**이고 틀리면 아직 걸린 주문을 푼다 |
| ④ `PendingUnreadable` 유지 | `KR_PENDING_UNREADABLE` 삭제 안 함 + `broker_truth()` 무인자 호출의 **기본값**. 조회 실패 → `ledger_unreadable(...)` → 다시 전 심볼 차단 |

**두 표를 다 읽는다** (`kis_mock_order_ledger` + pre-submit `kis_mock_signal_ledger`):
사후 order 행은 유실될 수 있고(`LedgerWriteError` → `ledger_tracking_unavailable`), 브로커에
존재하는 주문의 원장 행이 없는 상태가 정확히 v1.6 ③ 이 금지한 **관대한 방향(누락)** 이다.
pre-submit 행은 유실되면 전송이 거부되므로 그 구멍을 닫는다. 둘 다 `kis_mock` 스코프,
둘 다 계약이 지명한 그 chokepoint 가 쓴다 — **예외를 넓힌 게 아니라 차단을 넓혔다.**

**유일한 경계 = KST 거래일.** KRX 당일주문의 최대 만료가 세션×매매구분 전 조합에서 접수일
20:00 KST(ROB-671 `live_order_expiry.py` — **인용만 하고 import 하지 않는다**, KR AST 가드가
금지 목록에 올려 뒀다)이므로 D 일 접수분이 D+1 까지 걸려 있을 수 없다. 시간 경과로
「체결됐겠지」를 추정하는 게 아니라 **거래소의 주문 유효기간**이고, §4 일일 신규 캡 경계와
동일하다.

## 필수 mutant 4/4 격추 (주입 → FAIL 확인 → 원복, 커밋 미포함)

| mutant | 주입 | FAIL |
|---|---|---|
| ① 원장 우회 제출 경로 신설 | `kr/cycle.py` 에서 sell leg 을 `active_broker.submit_exit_sell` 로 직접 | `test_no_submission_path_bypasses_the_ledger_writing_chokepoint[cycle.py]` |
| ② 타 레인 확대 | `crypto/sidecar.py` 에 `pending_ledger` import | `test_no_other_lane_imports_the_kis_mock_ledger_source[sidecar.py]` |
| ③ 포지션 진실로 사용 | `position_symbols` 에 pending 합집합 | AST 2 + 행동 2 = **4건** |
| ④ 조회 실패를 「없음」으로 접기 | `return ledger_unreadable(...)` → `return ()` | `test_a_failing_query_is_unreadable_never_empty`, `test_a_session_that_cannot_be_opened_is_also_unreadable` |

원복 확인: `grep -rn "MUTANT" scripts/` → none · 4파일 `diff -q` 백업 일치 · 395 passed.

## KR 2사이클+ 시뮬 (고정 fixture · 실브로커 호출 0 · 네트워크 0)

| | 1사이클 | 2사이클 (동일 KST일) | 3사이클 | 4사이클 (익 KST일) |
|---|---|---|---|---|
| 파생 | 2 | **0** | **0** | 2 |
| 제출 누계 | 2 | **2** | **2** | 4 |
| skipped 사유 | — | `own_pending_order_exists` ×2 | 동일 | — |

원장 망각 상태(= X-E1 이 지목한 결함 모양)에서는 **매 사이클 2건씩 적층해 8건**.

🔵 부수 관측: 표를 사이클마다 재생성하면 `policy_table_hash` → `cycle_id` → `order_key` 가
바뀌므로 **브로커측 `correlation_id` 멱등성은 사이클 간 재제출을 막지 못한다.** 실제 방어는
이 pending 게이트다.

## 스코프

- **무접촉(diff 0)**: `crypto/**` · `envelope.py`(상한 수치) · `labels.py` · `contract.py`
  (계약 스탬프) · `table_source.py`(MAX_TABLE_AGE SSOT) · `crypto/cancel.py` · `ledger.py` ·
  `scope.py` · `derivation.py` · `broker_truth.py` · KR kill 「구조적 불가」 문구 ·
  `invested_notional` 누적 의미
- 상태 파일 신설 0 (X-E1 의 `.json` AST 가드 그대로 통과) · 스케줄러 등록 없음 ·
  in-process LLM 0 · CLI `--confirm` 여전히 없음
- 🔴 **주문 0 · 취소 0 · preview 실호출 0 · 브로커 mutation 0 · 계좌 접촉 0**

## 새 운영 함의 (런북 §9.2, §10)

- 이 출처는 **DB 를 탄다**. DB 가 죽으면 사이클은 오류가 아니라 `own_pending_unreadable`
  (reason=`kis_mock_ledger_pending_unreadable`) 로 전 심볼 차단하고 진행한다 → 그 사유가
  보이면 **브로커가 아니라 DB 를 보라**.
- 오염(CONTAMINATED) 공백은 **닫히지 않는다**: 원장은 `b0xk-` 자기 correlation_id 만
  답하므로 남이 이 계좌에 낸 주문은 여전히 안 보인다. v1.6 ① 범위가 「자기 미체결」이라
  넓히지 않았다.
- `tests/scripts/b0x/kr/conftest.py` 가 실 원장 리더 도달을 `AssertionError` 로 막는다 —
  안 그러면 실수로 도달해도 `PendingUnreadable` 로 삼켜져 테스트가 조용히 무의미해진다.

## 테스트

```
uv run pytest tests/scripts/b0x/ -q -p no:randomly     # 395 passed
uv run pytest tests/scripts/ -q -p no:randomly         # 923 passed
uv run ruff check app/ tests/ research/ scripts/       # All checks passed!
uv run ruff format --check app/ tests/ research/ scripts/  # 3775 files already formatted
uv run ty check app/ --error-on-warning                # All checks passed!
```

false-green 확인: 2사이클 시뮬의 `submit_cum` 을 `[2,4,6,8]` 로 반전 → 즉시 FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)