### PR TITLE
feat(b0x): add US Alpaca paper lab adapter (X-U2)

### DIFF
--- a/app/services/paper_approval_packet.py
+++ b/app/services/paper_approval_packet.py
@@ -144,7 +144,7 @@ class PaperApprovalPacket(BaseModel):
     signal_source: str
     artifact_id: uuid.UUID
     signal_symbol: str
-    signal_venue: Literal["upbit", "binance_public_spot"]
+    signal_venue: Literal["upbit", "binance_public_spot", "policy_table_us"]
     execution_symbol: str
     execution_venue: Literal["alpaca_paper"]
     execution_asset_class: Literal["crypto", "us_equity"]

--- a/docs/runbooks/b0x-us-cycle.md
+++ b/docs/runbooks/b0x-us-cycle.md
@@ -1,0 +1,148 @@
+# B0-X US 사이클 런북 — `alpaca_paper_lab`
+
+> `B0_UNVALIDATED` · `SELL_SIDE_MODEL_MISMATCH` ·
+> `CROSS_MARKET_TRANSFER_UNVALIDATED`
+
+계약 정본은 `~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md`다.
+이 레인은 전체 파일 digest가 아니라 **버전 `v1.6` + 아래 인용 절**에 결속한다.
+
+- §1: US 이식은 `CROSS_MARKET_TRANSFER_UNVALIDATED`를 추가한다.
+- §2-2 v1.1: 표가 없거나 STALE이거나 36시간을 넘으면 주문 0이다.
+- §4 US: 신규 `$150~450`, 종목 총 신규×5, 동시 ≤10, 일 신규 ≤3,
+  일 손실 `−2.5% NAV`, US RTH.
+- §8 v1.5 ①: envelope 입력은 같은 사이클의 broker truth다.
+- §8 v1.6: `kis_mock`의 원장 미체결 예외만 허용한다. US에는 적용하지 않는다.
+
+## 0. 계좌맵 게이트
+
+기계판독 정본은 `~/services/auto_trader-operator/operator_contract.yaml`이다.
+매 사이클/운영 kickoff 전에 아래를 다시 대조한다. `mock/CLAUDE.md` §1은 참조
+표면일 뿐이고, 충돌하면 YAML의 더 보수적인 해석으로 멈춘다.
+
+```bash
+cd ~/services/auto_trader-operator
+git fetch --prune origin
+grep -n 'b0x-adapter-orders-20260808' operator_contract.yaml
+```
+
+확인할 정확한 사실은 다음과 같다.
+
+| YAML 사실 | 기대값 |
+|---|---|
+| `account_lanes.alpaca_paper_lab` | `B0-X-US` |
+| `strategy_order_exceptions.b0x-adapter-orders-20260808.surfaces` | `alpaca_paper_lab` 포함 |
+| 같은 예외의 `writer` | `b0x_adapter_single` |
+
+`alpaca_paper_lab`과 기본 운영 계좌 `alpaca_paper`는 별개다. 이 어댑터는
+`account_mode="alpaca_paper_lab"`을 모든 read에 명시하고, 기본 계좌로 fallback하지
+않는다. 계좌맵 충돌은 `NEEDS_UPSTREAM(account_map_conflict)`이며 주문 0이다.
+
+같은 YAML의 과거 `alpaca_account_cleanup_20260805`에는 lab suffix `a9e6cd`의
+`UBER qty=1`이 1회성 legacy cleanup으로 남아 있다. `reuse_after_execution` 및 scope
+확장이 금지돼 있으므로 이 사실을 B0-X 소유권·현재 잔고·새 cleanup 권한으로 해석하지
+않는다. 실제 잔여 여부와 귀속은 반드시 §2의 fresh truth로 다시 확인한다.
+
+## 1. 실행과 세션
+
+```bash
+# 수동·scheduleless 관측/계획 경로. --confirm 옵션은 없다.
+uv run python -m scripts.run_b0x_us_cycle
+```
+
+`app.mcp_server.tooling.market_session.us_market_session`의 `regular` 결과만 US
+RTH로 인정한다. 장외이면 표·계좌·원장 read 전에
+`outside_us_regular_session`으로 끝난다.
+
+US 표에는 `quote_currency="USD"` 및 `new_entry_notional_usd`가 반드시 있어야 하며,
+선택값은 signed `$150~450` 안이어야 한다. 누락·통화 불일치·범위 이탈은 계좌 read 전에
+`invalid_us_table_sizing`으로 주문 0이다. 공통 파생기의 legacy fallback을 US 표 누락의
+대체값으로 사용하지 않는다.
+
+이 CLI는 `confirm=False`만 전달한다. 따라서 preview, submit, cancel broker 호출은
+0건이다. 새 TaskIQ/cron/launchd 등록은 이 런북의 범위가 아니다.
+
+산출물은 기존 `scripts.b0x.ledger`의 append-only 관측 기록뿐이다. 레인 상태 파일은
+새로 만들지 않으며, `attributed_book.json`을 읽거나 쓰지 않는다.
+
+## 2. fresh truth와 잔여 귀속
+
+표가 유효한 뒤에만 다음 기존 read-only `alpaca_paper_*` 표면을 **lab 계좌로만** 같은
+사이클에 읽는다.
+
+1. 계좌 cash/NAV
+2. 계좌 전체 positions
+3. 계좌 전체 open orders (`status=open`)
+4. 기존 Alpaca ledger recent rows
+
+open-order 또는 bounded ledger 응답이 limit에 닿으면 완전성을 증명할 수 없으므로
+`lab_fresh_truth_unavailable`로 fail-closed 한다. lab 자격증명이 없거나 profile/응답의
+`account_mode`가 다르더라도 빈 계좌로 해석하지 않는다.
+
+귀속은 추정하지 않는다.
+
+- `lifecycle_correlation_id`가 `b0xu-`로 시작하는 lab execution evidence가 broker
+  order id와 정확히 하나로 연결될 때만 open order를 자기 것으로 본다.
+- position은 symbol별 b0xu fill의 순수량이 broker 수량과 정확히 일치할 때만 자기
+  position이다. fill이 없거나 수량 evidence가 불완전하면 foreign/linkage failure다.
+  매수가 fill price만 불완전한 경우에는 소유권을 꾸며 바꾸지 않고 cumulative deployment를
+  unreadable로 표시하여 추가매수를 막는다.
+- 그 밖의 open order/position은 foreign으로 기록하고 `CONTAMINATED`로 분리한다.
+  관측은 남기되 submit은 막으며, foreign 주문/포지션을 취소·청산하지 않는다.
+
+## 3. envelope와 broker truth
+
+`scripts.b0x.envelope.US_ALPACA_PAPER_LAB_ENVELOPE`는 변경 불가 상수다.
+
+| 항목 | 값 |
+|---|---:|
+| 종목당 신규 | `$150~450` (표의 선택점 `$300`) |
+| 종목당 총투입 | `$2,250` (`$450×5`) |
+| 동시 포지션 | `≤10` |
+| 일일 신규 진입 | `≤3` |
+| kill | 일 실현손실 `≤ −2.5% × fresh NAV` |
+
+NAV가 없거나 0 이하이면 `MissingNavForRatioKill`과 동등하게 주문 0이다. kill의 수치와
+실현손익은 모두 USD 절대값으로 비교하며, 산출물에는 원 비율·fresh NAV·계산된 USD 임계값을
+함께 기록한다.
+
+§8 v1.5 ①의 세 입력은 모두 현재 broker 응답에서 온다.
+
+| 계약 정의 | US 구현 |
+|---|---|
+| 동시 포지션 | full positions 중 `qty_available > 0`인 non-dust sellable symbol 수 |
+| 동일 심볼 재제출 | broker open orders 중 정확히 귀속된 `b0xu-` pending symbol은 side와 무관하게 차단 |
+| 일일 신규 | 자기 pending symbol ∪ account-wide sellable position symbol ∪ 이 사이클 새 symbol의 distinct 수 |
+
+Alpaca는 open-orders 조회 표면을 제공한다. 따라서 US는 `PendingUnreadable`이나
+`kis_mock_order_ledger` 예외로 빠지지 않으며, 그 응답을 빈 것으로 추정하지도 않는다.
+
+## 4. 제출 경계
+
+이 변경의 기본 production mutation seam은 **의도적으로 미배선**이다.
+
+- `submit_planned_order`/`cancel_own_open_orders`에 기본 broker callback은 없다.
+  승인되지 않은 호출은 `LabMutationNotWired`로 실패한다.
+- 테스트는 fake/stub callback을 명시 주입한다. 실제 broker preview/POST/DELETE가 아니다.
+- 향후 승인된 lab 전용 boundary가 연결되더라도 `B0X_US_ENABLED=true`와 호출별
+  `confirm=True`가 둘 다 필요하다. 그 boundary는 lab 자격증명, trusted quote evidence,
+  idempotency 및 broker read-back도 독립적으로 검증해야 한다.
+
+기존 automated Alpaca token 경로는 기본 `alpaca_paper`용 서버 보관 preview protocol이다.
+이를 adapter-local shortcut으로 `alpaca_paper_lab`에 재사용하지 않는다. 이 CLI에는
+`--confirm`도 없으므로 이번 라운드의 첫 US RTH 관측은 계획/기록만 수행한다.
+
+## 5. 라벨과 범위
+
+헤더에는 inherited table labels와 US 추가 라벨을 포함한다. 특히 아래 세 문구는 유지한다.
+
+- `B0_UNVALIDATED`
+- `SELL_SIDE_MODEL_MISMATCH`
+- `CROSS_MARKET_TRANSFER_UNVALIDATED`
+
+`SHARED_ACCOUNT_HISTORY`는 Binance sidecar 전용이므로 US `SHARED_HISTORY_ACCOUNTS`에
+추가하지 않는다. writer caveat은 추정 문구가 아니라 §0에서 대조한
+`account_lanes.alpaca_paper_lab=B0-X-US` 및 예외의 writer/surface 사실을 그대로 쓴다.
+
+이 패키지는 `scripts.b0x` 공통 envelope, kill switch, broker truth, derivation,
+table gate, writer lock, observation ledger를 재사용한다. crypto/KR 실행 경로, default
+`alpaca_paper`, live broker, scheduler는 변경하거나 호출하지 않는다.

--- a/scripts/b0x/derivation.py
+++ b/scripts/b0x/derivation.py
@@ -294,9 +294,14 @@ def derive_orders(
     loss_guard_multiplier = _decimal(config.get("loss_guard_multiplier")) or Decimal(
         "1"
     )
+    # The policy-table schema predates the US adapter, so the original KRW
+    # sizing field lives under ``sizing`` while the US builder stamps its
+    # signed USD band under ``config``.  Prefer the existing field unchanged
+    # for crypto/KR, then consume the US builder's explicit selected point.
+    # This is table evidence, not a new adapter-local default.
     new_entry_notional_table = _decimal(
         (table.sizing or {}).get("new_entry_notional_krw")
-    )
+    ) or _decimal(config.get("new_entry_notional_usd"))
 
     # Running budgets, consumed in lexicographic symbol order.
     #
@@ -784,6 +789,16 @@ def _size_buy(
     size = envelope.per_order_notional
     if requested is not None and requested < size:
         size = requested
+    elif (
+        envelope.market == "us"
+        and table_new_entry_notional is not None
+        and table_new_entry_notional < size
+    ):
+        # The US builder's signed $300 point is intentionally below its $450
+        # ceiling and must not be widened merely because the envelope is an
+        # upper bound.  Crypto/KR retain their existing envelope-first sizing:
+        # their fixture/schema values are not a US-style selected USD point.
+        size = table_new_entry_notional
     if symbol_headroom is not None and symbol_headroom < size:
         size = symbol_headroom
     if size <= 0:

--- a/scripts/b0x/envelope.py
+++ b/scripts/b0x/envelope.py
@@ -130,6 +130,28 @@ KR_MOCK_ENVELOPE: Final[Envelope] = Envelope(
     daily_loss_kill_basis="pct_of_nav",
 )
 
+# ---------------------------------------------------------------------------
+# Contract §4, US (alpaca_paper_lab) column, verbatim:
+#   종목당 신규 $150~450 · 종목당 총투입 = 신규×5 · 동시 포지션 ≤10 ·
+#   일 신규 진입 ≤3 · 일 손실 −2.5% NAV → kill · 세션 US RTH
+#
+# ``per_order_notional`` is the immutable *upper* bound.  The lower bound and
+# B0's selected $300 point inside the signed $150–450 band belong to the US
+# venue planner, because ``Envelope`` deliberately models caps rather than a
+# venue's lot/price-aware sizing rule.  Keeping that distinction explicit
+# prevents a caller from mistaking $450 for the requested order size.
+# ---------------------------------------------------------------------------
+US_ALPACA_PAPER_LAB_ENVELOPE: Final[Envelope] = Envelope(
+    market="us",
+    quote_currency="USD",
+    per_order_notional=Decimal("450"),
+    per_symbol_total_notional=Decimal("450") * 5,
+    max_concurrent_positions=10,
+    max_new_entries_per_utc_day=3,
+    daily_loss_kill=Decimal("0.025"),
+    daily_loss_kill_basis="pct_of_nav",
+)
+
 #: Contract §4 footnote — "Upbit shadow 는 합성이므로 envelope 미적용(기록만)".
 #: The shadow lane still *records* the sidecar envelope alongside every cycle so
 #: a reader can see what would have bound a real venue, but derivation does not
@@ -141,6 +163,7 @@ SHADOW_ENVELOPE_NOT_APPLIED: Final[str] = (
 _LOCKED_ENVELOPES: Final[dict[str, Envelope]] = {
     "crypto": CRYPTO_SIDECAR_ENVELOPE,
     "kr": KR_MOCK_ENVELOPE,
+    "us": US_ALPACA_PAPER_LAB_ENVELOPE,
 }
 
 
@@ -190,6 +213,7 @@ __all__ = [
     "EnvelopeNotLocked",
     "CRYPTO_SIDECAR_ENVELOPE",
     "KR_MOCK_ENVELOPE",
+    "US_ALPACA_PAPER_LAB_ENVELOPE",
     "SHADOW_ENVELOPE_NOT_APPLIED",
     "assert_envelope_locked",
     "load_envelope",

--- a/scripts/b0x/labels.py
+++ b/scripts/b0x/labels.py
@@ -54,8 +54,10 @@ WRITER_SINGLETON_SCOPE_CAVEATS: Final[dict[str, str]] = {
         "주장하지 않는다."
     ),
     ALPACA_PAPER_LAB_SCOPE_KEY: (
-        "WRITER_SINGLETON_SCOPE_CAVEAT — Alpaca paper lab은 operator account "
-        "map에서 B0-X-US 점유자로 지정된 레인이다."
+        "WRITER_SINGLETON_SCOPE_CAVEAT — operator_contract.yaml의 "
+        "account_lanes.alpaca_paper_lab=B0-X-US 이고, "
+        "strategy_order_exceptions.b0x-adapter-orders-20260808의 "
+        "writer=b0x_adapter_single 및 surfaces에 alpaca_paper_lab이 등재돼 있다."
     ),
 }
 

--- a/scripts/b0x/us/__init__.py
+++ b/scripts/b0x/us/__init__.py
@@ -1,0 +1,1 @@
+"""B0-X US lane for the dedicated ``alpaca_paper_lab`` account only."""

--- a/scripts/b0x/us/alpaca.py
+++ b/scripts/b0x/us/alpaca.py
@@ -1,0 +1,986 @@
+"""Dedicated Alpaca-paper-lab adapter primitives for B0-X US.
+
+This module deliberately has two sharply separated halves:
+
+* :func:`read_fresh_truth` uses the existing read-only ``alpaca_paper_*``
+  surfaces for the *lab* account only.  It reads the whole positions/open
+  order snapshot plus the existing Alpaca ledger, then attributes residual
+  state by an evidence-bearing ``b0xu-`` lifecycle correlation.  Nothing is
+  inferred from an account name, a client-order-id prefix, or a plausible
+  history.
+* planning/submission is pure.  There is deliberately no production mutation
+  default until an approved lab-aware automated boundary exists.  Tests inject
+  fakes/stubs at that seam; no test needs an Alpaca account, preview call,
+  POST, DELETE, or direct ledger SQL.
+
+Unlike ``kis_mock``, Alpaca exposes open orders.  Therefore this lane always
+uses the readable broker response for ``BrokerTruth.own_pending`` and never
+uses KR's unreadable-pending fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import os
+import uuid
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from decimal import ROUND_DOWN, ROUND_UP, Decimal
+from typing import Any, Final
+
+from app.core.symbol import to_db_symbol
+from app.mcp_server.tooling.alpaca_paper import (
+    alpaca_paper_get_account,
+    alpaca_paper_list_orders,
+    alpaca_paper_list_positions,
+)
+from app.mcp_server.tooling.alpaca_paper_ledger_read import (
+    alpaca_paper_ledger_list_recent,
+)
+from app.services.alpaca_paper_account_modes import ALPACA_PAPER_LAB_ACCOUNT_MODE
+from app.services.alpaca_paper_submit_service import (
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+)
+from app.services.paper_approval_packet import PaperApprovalPacket
+from scripts.b0x.broker_truth import BrokerTruth, assert_resubmit_allowed
+from scripts.b0x.derivation import DerivedOrder
+from scripts.b0x.envelope import Envelope, assert_envelope_locked
+from scripts.b0x.state import B0XPosition
+from scripts.b0x.table_source import PolicyTable
+from scripts.policy_table.core.us_tick import build_us_equity_tick_table
+
+LANE: Final[str] = ALPACA_PAPER_LAB_ACCOUNT_MODE
+MARKET: Final[str] = "us"
+QUOTE_CURRENCY: Final[str] = "USD"
+B0XU_CORRELATION_PREFIX: Final[str] = "b0xu-"
+
+# Contract §4 US column.  The locked envelope holds the $450 ceiling; these
+# two values are the signed lower edge and B0's selected point within the band.
+US_NEW_ENTRY_NOTIONAL_MIN: Final[Decimal] = Decimal("150")
+US_NEW_ENTRY_NOTIONAL_TARGET: Final[Decimal] = Decimal("300")
+_OPEN_ORDER_READ_LIMIT: Final[int] = 500
+_LEDGER_READ_LIMIT: Final[int] = 200
+_PACKET_TTL: Final[dt.timedelta] = dt.timedelta(minutes=5)
+US_LANE_ENABLED_ENV: Final[str] = "B0X_US_ENABLED"
+
+
+class LabTruthReadError(RuntimeError):
+    """The dedicated lab truth could not be read or proven complete.
+
+    The caller records a zero-order outcome.  This is intentionally distinct
+    from an empty account: incomplete/misrouted input cannot become a false
+    ``flat`` answer.
+    """
+
+
+class RealizedPnlUnavailable(RuntimeError):
+    """A B0-X execution exists today but no realized-P&L source is available."""
+
+
+class LabMutationNotWired(RuntimeError):
+    """No approved automated mutation boundary exists for the lab account.
+
+    The existing automated Alpaca boundary is a server-persisted preview-token
+    protocol for the default ``alpaca_paper`` account.  It must not be
+    repurposed for ``alpaca_paper_lab`` by an adapter-local shortcut.  Until a
+    separately reviewed lab-aware boundary exists, production calls fail
+    closed; unit tests may inject a fake/stub at this seam.
+    """
+
+
+class UsLabLaneDisabled(RuntimeError):
+    """``B0X_US_ENABLED`` is not truthy — the lab mutation lane is off."""
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def assert_us_lab_lane_enabled() -> None:
+    """Require the adapter-specific gate before an injected mutation seam.
+
+    The separate approved submit/cancel boundary must additionally validate its
+    own lab credentials and packet/quote evidence.  This gate is deliberately
+    independent from those broker-level checks so B0-X cannot be armed merely
+    because a general Alpaca tool happens to be configured.
+    """
+
+    if not _truthy(os.environ.get(US_LANE_ENABLED_ENV)):
+        raise UsLabLaneDisabled(
+            f"{US_LANE_ENABLED_ENV} is not truthy. The B0-X US lab lane is "
+            "default-disabled; set it explicitly to arm an approved mutation seam."
+        )
+
+
+def _decimal(value: Any, *, field: str) -> Decimal:
+    if value is None or value == "":
+        raise LabTruthReadError(f"missing numeric field {field}")
+    try:
+        parsed = Decimal(str(value))
+    except Exception as exc:  # noqa: BLE001 - malformed broker data must close the gate
+        raise LabTruthReadError(f"malformed numeric field {field}") from exc
+    if not parsed.is_finite():
+        raise LabTruthReadError(f"non-finite numeric field {field}")
+    return parsed
+
+
+def _optional_decimal(value: Any, *, field: str) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    return _decimal(value, field=field)
+
+
+def _symbol(value: Any, *, field: str) -> str:
+    text = str(value or "").strip().upper()
+    if not text:
+        raise LabTruthReadError(f"missing symbol field {field}")
+    # DB/table form is dot-delimited.  Never duplicate this normalisation with
+    # an adapter-local replace: all external spelling flows through core.symbol.
+    return to_db_symbol(text)
+
+
+def _account_mode(response: dict[str, Any], *, surface: str) -> None:
+    if response.get("success") is not True:
+        raise LabTruthReadError(f"{surface} did not report success")
+    if response.get("account_mode") != LANE:
+        raise LabTruthReadError(
+            f"{surface} returned a non-lab account_mode; default-account fallback refused"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RawPosition:
+    symbol: str
+    quantity: Decimal
+    quantity_available: Decimal
+    average_price: Decimal
+
+    @property
+    def sellable(self) -> bool:
+        """Alpaca's broker-owned availability is the US dust predicate.
+
+        Alpaca reports fractional availability, so adding a fabricated
+        whole-share or notional floor here would change the contract's
+        ``non-dust sellable`` definition.  A strictly positive broker value is
+        the only fact this adapter uses.
+        """
+
+        return self.quantity_available > 0
+
+
+@dataclass(frozen=True, slots=True)
+class RawOpenOrder:
+    broker_order_id: str
+    symbol: str
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerExecution:
+    correlation_id: str
+    client_order_id: str | None
+    broker_order_id: str | None
+    symbol: str
+    side: str
+    filled_qty: Decimal | None
+    filled_avg_price: Decimal | None
+    created_at: dt.datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class LabReaders:
+    """Injectable read-only tool bundle; production defaults remain lab-pinned."""
+
+    get_account: Callable[..., Awaitable[dict[str, Any]]]
+    list_positions: Callable[..., Awaitable[dict[str, Any]]]
+    list_orders: Callable[..., Awaitable[dict[str, Any]]]
+    list_recent_ledger: Callable[..., Awaitable[dict[str, Any]]]
+
+    @classmethod
+    def production(cls) -> LabReaders:
+        return cls(
+            get_account=alpaca_paper_get_account,
+            list_positions=alpaca_paper_list_positions,
+            list_orders=alpaca_paper_list_orders,
+            list_recent_ledger=alpaca_paper_ledger_list_recent,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FreshTruth:
+    """One complete read-only lab snapshot plus evidence-based attribution."""
+
+    cash: Decimal
+    nav: Decimal | None
+    positions: tuple[RawPosition, ...]
+    open_orders: tuple[RawOpenOrder, ...]
+    own_open_orders: tuple[RawOpenOrder, ...]
+    foreign_open_orders: tuple[RawOpenOrder, ...]
+    own_positions: tuple[B0XPosition, ...]
+    foreign_position_symbols: tuple[str, ...]
+    position_linkage_failures: tuple[str, ...]
+    sell_source_client_order_ids: dict[str, str]
+    cumulative_deployment_readable: bool
+    realized_pnl_today: Decimal | None
+
+    def non_dust_position_symbols(self) -> tuple[str, ...]:
+        """Contract v1.5 ① concurrent-position input, from broker availability."""
+
+        return tuple(sorted(pos.symbol for pos in self.positions if pos.sellable))
+
+    def broker_truth(self) -> BrokerTruth:
+        """All three §8 v1.5 ① inputs use the current broker response.
+
+        ``own_pending`` is a normal tuple even when empty because Alpaca's
+        open-orders endpoint answered.  KR's ledger-only exception is
+        intentionally absent from this lane.
+        """
+
+        return BrokerTruth(
+            position_symbols=self.non_dust_position_symbols(),
+            own_pending=tuple(order.symbol for order in self.own_open_orders),
+        )
+
+    def sellable_owned_quantities(self) -> dict[str, Decimal]:
+        raw_by_symbol = {position.symbol: position for position in self.positions}
+        out: dict[str, Decimal] = {}
+        for position in self.own_positions:
+            raw = raw_by_symbol[position.symbol]
+            if raw.quantity_available > 0:
+                out[position.symbol] = raw.quantity_available
+        return out
+
+    def invested_notional_by_symbol(self) -> dict[str, Decimal]:
+        return {
+            position.symbol: position.invested_notional
+            for position in self.own_positions
+        }
+
+    def status_only(self) -> dict[str, Any]:
+        """Observation-safe account state: identities/counts, never balances."""
+
+        return {
+            "account_mode": LANE,
+            "quote_currency": QUOTE_CURRENCY,
+            "cash_present": self.cash >= 0,
+            "nav_present": self.nav is not None,
+            "position_symbols": sorted(position.symbol for position in self.positions),
+            "non_dust_sellable_position_symbols": list(
+                self.non_dust_position_symbols()
+            ),
+            "open_order_symbols": sorted(order.symbol for order in self.open_orders),
+            "own_open_order_symbols": sorted(
+                order.symbol for order in self.own_open_orders
+            ),
+            "foreign_open_order_ids": sorted(
+                order.broker_order_id for order in self.foreign_open_orders
+            ),
+            "own_position_symbols": sorted(
+                position.symbol for position in self.own_positions
+            ),
+            "foreign_position_symbols": list(self.foreign_position_symbols),
+            "position_linkage_failures": list(self.position_linkage_failures),
+            "own_pending_readable": True,
+            "cumulative_deployment_readable": self.cumulative_deployment_readable,
+            "realized_pnl_source": (
+                "no B0-X US execution observed in the current UTC day in the "
+                "bounded, complete recent ledger snapshot"
+                if self.realized_pnl_today == Decimal("0")
+                else "unavailable: B0-X US execution exists today but no realized-P&L "
+                "read model is wired"
+            ),
+        }
+
+
+def _parse_datetime(value: Any) -> dt.datetime | None:
+    if value is None or value == "":
+        return None
+    text = str(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(dt.UTC)
+
+
+def _b0xu_executions(items: list[dict[str, Any]]) -> tuple[LedgerExecution, ...]:
+    parsed: list[LedgerExecution] = []
+    for row in items:
+        correlation = str(row.get("lifecycle_correlation_id") or "").strip()
+        if not correlation.startswith(B0XU_CORRELATION_PREFIX):
+            continue
+        if row.get("account_mode") != LANE:
+            raise LabTruthReadError("b0xu ledger row is not bound to alpaca_paper_lab")
+        if str(row.get("record_kind") or "") != "execution":
+            continue
+        side = str(row.get("side") or "").strip().lower()
+        if side not in {"buy", "sell"}:
+            raise LabTruthReadError("b0xu execution has an unknown side")
+        parsed.append(
+            LedgerExecution(
+                correlation_id=correlation,
+                client_order_id=(str(row.get("client_order_id")).strip() or None)
+                if row.get("client_order_id") is not None
+                else None,
+                broker_order_id=(str(row.get("broker_order_id")).strip() or None)
+                if row.get("broker_order_id") is not None
+                else None,
+                symbol=_symbol(row.get("execution_symbol"), field="execution_symbol"),
+                side=side,
+                filled_qty=_optional_decimal(
+                    row.get("filled_qty"), field="ledger.filled_qty"
+                ),
+                filled_avg_price=_optional_decimal(
+                    row.get("filled_avg_price"), field="ledger.filled_avg_price"
+                ),
+                created_at=_parse_datetime(row.get("created_at")),
+            )
+        )
+    return tuple(parsed)
+
+
+def _classify_open_orders(
+    orders: tuple[RawOpenOrder, ...], executions: tuple[LedgerExecution, ...]
+) -> tuple[tuple[RawOpenOrder, ...], tuple[RawOpenOrder, ...]]:
+    correlations_by_broker_id: dict[str, set[str]] = defaultdict(set)
+    for execution in executions:
+        if execution.broker_order_id:
+            correlations_by_broker_id[execution.broker_order_id].add(
+                execution.correlation_id
+            )
+
+    own: list[RawOpenOrder] = []
+    foreign: list[RawOpenOrder] = []
+    for order in orders:
+        correlations = correlations_by_broker_id.get(order.broker_order_id, set())
+        # Multiple B0-X lifecycle correlations attached to a live broker order
+        # are not ownership evidence.  Treat it as foreign/contaminated rather
+        # than guessing which writer owns it.
+        if len(correlations) == 1:
+            own.append(order)
+        else:
+            foreign.append(order)
+    return tuple(own), tuple(foreign)
+
+
+def _attribute_positions(
+    positions: tuple[RawPosition, ...],
+    executions: tuple[LedgerExecution, ...],
+) -> tuple[
+    tuple[B0XPosition, ...], tuple[str, ...], tuple[str, ...], dict[str, str], bool
+]:
+    events_by_symbol: dict[str, list[LedgerExecution]] = defaultdict(list)
+    for execution in executions:
+        events_by_symbol[execution.symbol].append(execution)
+
+    owned: list[B0XPosition] = []
+    foreign: list[str] = []
+    failures: list[str] = []
+    sell_sources: dict[str, str] = {}
+    cumulative_readable = True
+
+    for position in positions:
+        events = events_by_symbol.get(position.symbol, [])
+        if not events:
+            foreign.append(position.symbol)
+            failures.append(f"{position.symbol}: no b0xu execution correlation")
+            continue
+        if any(event.filled_qty is None for event in events):
+            foreign.append(position.symbol)
+            failures.append(f"{position.symbol}: b0xu fill quantity unavailable")
+            continue
+
+        signed_qty = sum(
+            (
+                event.filled_qty if event.side == "buy" else -event.filled_qty
+                for event in events
+                if event.filled_qty is not None
+            ),
+            Decimal("0"),
+        )
+        if signed_qty != position.quantity or signed_qty <= 0:
+            foreign.append(position.symbol)
+            failures.append(
+                f"{position.symbol}: broker quantity does not exactly match b0xu fills"
+            )
+            continue
+
+        buy_events = [event for event in events if event.side == "buy"]
+        missing_price = any(
+            event.filled_qty is None or event.filled_avg_price is None
+            for event in buy_events
+        )
+        if missing_price:
+            cumulative_readable = False
+            invested = Decimal("0")
+        else:
+            invested = sum(
+                (
+                    event.filled_qty * event.filled_avg_price
+                    for event in buy_events
+                    if event.filled_qty is not None
+                    and event.filled_avg_price is not None
+                ),
+                Decimal("0"),
+            )
+
+        owned.append(
+            B0XPosition(
+                symbol=position.symbol,
+                quantity=position.quantity,
+                average_price=position.average_price,
+                invested_notional=invested,
+                entry_count=len(buy_events),
+            )
+        )
+
+        # The Alpaca coordinator will only permit an automated sell with one
+        # exact native BUY authority.  A multi-buy/partial-sale position is
+        # still observed and can be derived, but submission is blocked instead
+        # of inventing a source allocation.
+        if (
+            len(buy_events) == 1
+            and len(events) == 1
+            and buy_events[0].filled_qty == position.quantity
+            and buy_events[0].client_order_id
+        ):
+            sell_sources[position.symbol] = buy_events[0].client_order_id
+
+    return (
+        tuple(sorted(owned, key=lambda position: position.symbol)),
+        tuple(sorted(set(foreign))),
+        tuple(sorted(failures)),
+        sell_sources,
+        cumulative_readable,
+    )
+
+
+def _realized_pnl_today(
+    executions: tuple[LedgerExecution, ...], *, now: dt.datetime
+) -> Decimal | None:
+    """Return a provable zero only when no B0-X execution exists today.
+
+    The current ledger exposes fills and positions, not a dedicated realized
+    P&L read model.  A made-up zero would disable a NAV-ratio kill.  The
+    bounded complete ledger snapshot can, however, prove the bootstrap case:
+    no B0-X execution at all means there is no B0-X realized P&L today.
+    """
+
+    if not executions:
+        return Decimal("0")
+    current_day = now.astimezone(dt.UTC).date()
+    for execution in executions:
+        if execution.created_at is None:
+            return None
+        if execution.created_at.date() == current_day:
+            return None
+    return Decimal("0")
+
+
+async def read_fresh_truth(
+    *, now: dt.datetime, readers: LabReaders | None = None
+) -> FreshTruth:
+    """Read the dedicated account's full, same-cycle broker truth.
+
+    Every call passes ``account_mode=alpaca_paper_lab`` explicitly.  The
+    tools themselves select ``profile='lab'`` and reject incomplete lab
+    configuration; this function never retries against default
+    ``alpaca_paper``.
+    """
+
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    active = readers or LabReaders.production()
+    (
+        account_response,
+        positions_response,
+        orders_response,
+        ledger_response,
+    ) = await asyncio.gather(
+        active.get_account(account_mode=LANE),
+        active.list_positions(account_mode=LANE),
+        active.list_orders(
+            status="open", limit=_OPEN_ORDER_READ_LIMIT, account_mode=LANE
+        ),
+        active.list_recent_ledger(limit=_LEDGER_READ_LIMIT, account_mode=LANE),
+    )
+    for response, surface in (
+        (account_response, "alpaca_paper_get_account"),
+        (positions_response, "alpaca_paper_list_positions"),
+        (orders_response, "alpaca_paper_list_orders"),
+        (ledger_response, "alpaca_paper_ledger_list_recent"),
+    ):
+        if not isinstance(response, dict):
+            raise LabTruthReadError(f"{surface} returned a malformed response")
+        _account_mode(response, surface=surface)
+
+    if int(orders_response.get("count", -1)) >= _OPEN_ORDER_READ_LIMIT:
+        raise LabTruthReadError(
+            "open-order read reached its limit; completeness unknown"
+        )
+    if int(ledger_response.get("count", -1)) >= _LEDGER_READ_LIMIT:
+        raise LabTruthReadError(
+            "ledger read reached its limit; b0xu attribution incomplete"
+        )
+
+    account = account_response.get("account")
+    if not isinstance(account, dict):
+        raise LabTruthReadError("account snapshot missing")
+    cash = _decimal(account.get("cash"), field="account.cash")
+    nav_raw = _optional_decimal(
+        account.get("portfolio_value"), field="account.portfolio_value"
+    )
+    nav = nav_raw if nav_raw is not None and nav_raw > 0 else None
+
+    raw_positions: list[RawPosition] = []
+    for item in positions_response.get("positions") or []:
+        if not isinstance(item, dict):
+            raise LabTruthReadError("position row malformed")
+        quantity = _decimal(item.get("qty"), field="position.qty")
+        if quantity <= 0:
+            raise LabTruthReadError("non-long Alpaca lab position cannot be attributed")
+        available = _optional_decimal(
+            item.get("qty_available"), field="position.qty_available"
+        )
+        if available is None or available < 0:
+            raise LabTruthReadError(
+                "position qty_available is required for broker truth"
+            )
+        raw_positions.append(
+            RawPosition(
+                symbol=_symbol(item.get("symbol"), field="position.symbol"),
+                quantity=quantity,
+                quantity_available=available,
+                average_price=_decimal(
+                    item.get("avg_entry_price"), field="position.avg_entry_price"
+                ),
+            )
+        )
+
+    raw_orders: list[RawOpenOrder] = []
+    for item in orders_response.get("orders") or []:
+        if not isinstance(item, dict):
+            raise LabTruthReadError("open-order row malformed")
+        order_id = str(item.get("id") or "").strip()
+        if not order_id:
+            raise LabTruthReadError("open-order id missing")
+        raw_orders.append(
+            RawOpenOrder(
+                broker_order_id=order_id,
+                symbol=_symbol(item.get("symbol"), field="open_order.symbol"),
+            )
+        )
+
+    ledger_items = ledger_response.get("items")
+    if not isinstance(ledger_items, list):
+        raise LabTruthReadError("ledger items malformed")
+    executions = _b0xu_executions(ledger_items)
+    positions = tuple(sorted(raw_positions, key=lambda position: position.symbol))
+    open_orders = tuple(sorted(raw_orders, key=lambda order: order.broker_order_id))
+    own_open_orders, foreign_open_orders = _classify_open_orders(
+        open_orders, executions
+    )
+    (
+        own_positions,
+        foreign_positions,
+        linkage_failures,
+        sell_sources,
+        cumulative_readable,
+    ) = _attribute_positions(positions, executions)
+
+    return FreshTruth(
+        cash=cash,
+        nav=nav,
+        positions=positions,
+        open_orders=open_orders,
+        own_open_orders=own_open_orders,
+        foreign_open_orders=foreign_open_orders,
+        own_positions=own_positions,
+        foreign_position_symbols=foreign_positions,
+        position_linkage_failures=linkage_failures,
+        sell_source_client_order_ids=sell_sources,
+        cumulative_deployment_readable=cumulative_readable,
+        realized_pnl_today=_realized_pnl_today(executions, now=now),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedOrder:
+    """A conservative, tick-aligned US-equity limit order, not yet submitted."""
+
+    order_key: str
+    lifecycle_correlation_id: str
+    symbol: str
+    side: str
+    leg: str
+    price: Decimal
+    quantity: Decimal
+    notional: Decimal
+    source_client_order_id: str | None = None
+
+    def to_json(self) -> dict[str, str | None]:
+        return {
+            "order_key": self.order_key,
+            "lifecycle_correlation_id": self.lifecycle_correlation_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "leg": self.leg,
+            "price": format(self.price, "f"),
+            "quantity": format(self.quantity, "f"),
+            "notional": format(self.notional, "f"),
+            "source_client_order_id": self.source_client_order_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BlockedOrder:
+    order_key: str
+    symbol: str
+    leg: str
+    reason: str
+    detail: str
+
+    def to_json(self) -> dict[str, str]:
+        return {
+            "order_key": self.order_key,
+            "symbol": self.symbol,
+            "leg": self.leg,
+            "reason": self.reason,
+            "detail": self.detail,
+        }
+
+
+def lifecycle_correlation_id_for(order_key: str) -> str:
+    return f"{B0XU_CORRELATION_PREFIX}{order_key}"
+
+
+def _planned_buy_quantity(
+    *,
+    desired_notional: Decimal,
+    price: Decimal,
+    headroom: Decimal,
+    cash: Decimal,
+    envelope: Envelope,
+) -> tuple[Decimal | None, str | None]:
+    if desired_notional <= 0:
+        return None, "missing_buy_notional"
+    minimum_qty = (US_NEW_ENTRY_NOTIONAL_MIN / price).to_integral_value(
+        rounding=ROUND_UP
+    )
+    desired_qty = (desired_notional / price).to_integral_value(rounding=ROUND_DOWN)
+    max_by_order = (envelope.per_order_notional / price).to_integral_value(
+        rounding=ROUND_DOWN
+    )
+    max_by_headroom = (headroom / price).to_integral_value(rounding=ROUND_DOWN)
+    max_by_cash = (cash / price).to_integral_value(rounding=ROUND_DOWN)
+    quantity = max(minimum_qty, desired_qty)
+    maximum = min(max_by_order, max_by_headroom, max_by_cash)
+    if quantity > maximum or maximum <= 0:
+        return None, "sizing_blocked"
+    notional = quantity * price
+    if not (US_NEW_ENTRY_NOTIONAL_MIN <= notional <= envelope.per_order_notional):
+        return None, "outside_signed_new_entry_band"
+    return quantity, None
+
+
+def plan_orders(
+    orders: tuple[DerivedOrder, ...],
+    *,
+    envelope: Envelope,
+    cash: Decimal,
+    held_quantities: dict[str, Decimal],
+    invested_notional_by_symbol: dict[str, Decimal],
+    sell_source_client_order_ids: dict[str, str],
+) -> tuple[list[PlannedOrder], list[BlockedOrder]]:
+    """Turn generic B0 legs into conservative US-equity limit orders.
+
+    The policy table supplies B0's selected $300 point.  Whole-share sizing is
+    intentionally conservative: it never assumes an asset is fractional
+    eligible, while the broker's ``qty_available`` remains authoritative for
+    recognizing a fractional *existing* sellable position.  Every realized
+    buy is independently checked against the signed $150–450 band and the
+    $450×5 per-symbol cap.
+    """
+
+    assert_envelope_locked(envelope)
+    tick_table = build_us_equity_tick_table()
+    planned: list[PlannedOrder] = []
+    blocked: list[BlockedOrder] = []
+    cash_remaining = cash
+    remaining_by_symbol = {
+        symbol: envelope.per_symbol_total_notional - invested
+        for symbol, invested in invested_notional_by_symbol.items()
+    }
+
+    for order in orders:
+        if order.table_price <= 0:
+            blocked.append(
+                BlockedOrder(
+                    order_key=order.order_key,
+                    symbol=order.symbol,
+                    leg=order.leg,
+                    reason="non_positive_price",
+                    detail=f"table_price={format(order.table_price, 'f')}",
+                )
+            )
+            continue
+
+        price = (
+            tick_table.align_buy(order.table_price)
+            if order.side == "buy"
+            else tick_table.align_sell(order.table_price)
+        )
+        if order.side == "buy":
+            desired = order.notional or US_NEW_ENTRY_NOTIONAL_TARGET
+            headroom = remaining_by_symbol.get(
+                order.symbol, envelope.per_symbol_total_notional
+            )
+            quantity, reason = _planned_buy_quantity(
+                desired_notional=desired,
+                price=price,
+                headroom=headroom,
+                cash=cash_remaining,
+                envelope=envelope,
+            )
+            if quantity is None:
+                blocked.append(
+                    BlockedOrder(
+                        order_key=order.order_key,
+                        symbol=order.symbol,
+                        leg=order.leg,
+                        reason=reason or "sizing_blocked",
+                        detail=(
+                            f"desired={format(desired, 'f')} price={format(price, 'f')} "
+                            f"headroom={format(headroom, 'f')} cash={format(cash_remaining, 'f')}"
+                        ),
+                    )
+                )
+                continue
+            notional = quantity * price
+            cash_remaining -= notional
+            remaining_by_symbol[order.symbol] = headroom - notional
+            planned.append(
+                PlannedOrder(
+                    order_key=order.order_key,
+                    lifecycle_correlation_id=lifecycle_correlation_id_for(
+                        order.order_key
+                    ),
+                    symbol=order.symbol,
+                    side="buy",
+                    leg=order.leg,
+                    price=price,
+                    quantity=quantity,
+                    notional=notional,
+                )
+            )
+            continue
+
+        if order.side != "sell":
+            blocked.append(
+                BlockedOrder(
+                    order_key=order.order_key,
+                    symbol=order.symbol,
+                    leg=order.leg,
+                    reason="unknown_side",
+                    detail=f"side={order.side!r}",
+                )
+            )
+            continue
+        held = held_quantities.get(order.symbol, Decimal("0"))
+        source_client_order_id = sell_source_client_order_ids.get(order.symbol)
+        if source_client_order_id is None:
+            blocked.append(
+                BlockedOrder(
+                    order_key=order.order_key,
+                    symbol=order.symbol,
+                    leg=order.leg,
+                    reason="source_authority_unavailable",
+                    detail="no single exact b0xu native BUY source can back this sell",
+                )
+            )
+            continue
+        quantity = held * (order.quantity_fraction or Decimal("0"))
+        if quantity <= 0:
+            blocked.append(
+                BlockedOrder(
+                    order_key=order.order_key,
+                    symbol=order.symbol,
+                    leg=order.leg,
+                    reason="sizing_blocked",
+                    detail=f"held={format(held, 'f')} produces non-positive sell quantity",
+                )
+            )
+            continue
+        planned.append(
+            PlannedOrder(
+                order_key=order.order_key,
+                lifecycle_correlation_id=lifecycle_correlation_id_for(order.order_key),
+                symbol=order.symbol,
+                side="sell",
+                leg=order.leg,
+                price=price,
+                quantity=quantity,
+                notional=quantity * price,
+                source_client_order_id=source_client_order_id,
+            )
+        )
+
+    return planned, blocked
+
+
+def build_submission_packet(
+    *, planned: PlannedOrder, table: PolicyTable
+) -> tuple[PaperApprovalPacket, dict[str, Any]]:
+    """Build one immutable coordinator packet from policy-table evidence only."""
+
+    canonical = build_canonical_payload(
+        symbol=planned.symbol,
+        side=planned.side,
+        type="limit",
+        time_in_force="day",
+        qty=planned.quantity,
+        notional=None,
+        limit_price=planned.price,
+        asset_class="us_equity",
+    )
+    client_order_id = derive_automated_key(
+        correlation_id=planned.lifecycle_correlation_id,
+        snapshot_id=table.policy_table_hash,
+        canonical=canonical,
+        account_mode=LANE,
+    )
+    packet = PaperApprovalPacket(
+        signal_source="b0x_policy_table_us",
+        artifact_id=uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"b0x-us/{table.policy_table_hash}/{planned.order_key}",
+        ),
+        signal_symbol=planned.symbol,
+        signal_venue="policy_table_us",
+        execution_symbol=planned.symbol,
+        execution_venue="alpaca_paper",
+        execution_asset_class="us_equity",
+        side=planned.side,
+        max_notional=planned.notional if planned.side == "buy" else None,
+        max_qty=planned.quantity if planned.side == "sell" else None,
+        qty_source=(
+            "policy_table_us_whole_share"
+            if planned.side == "buy"
+            else "verified_native_buy"
+        ),
+        expected_lifecycle_step="planned",
+        lifecycle_correlation_id=planned.lifecycle_correlation_id,
+        client_order_id=client_order_id,
+        expires_at=table.generated_at + _PACKET_TTL,
+        account_mode=LANE,
+        origin="automated",
+        market_data_asof=table.generated_at,
+        market_data_source="policy_table.v1/us",
+        preview_payload_hash=canonical_hash(canonical),
+        snapshot_id=table.policy_table_hash,
+        execution_order_type="limit",
+        execution_time_in_force="day",
+        reference_price=planned.price,
+        source_client_order_id=planned.source_client_order_id,
+        decision_identity_hash=(
+            canonical_hash(canonical) if planned.side == "sell" else None
+        ),
+    )
+    return packet, canonical
+
+
+async def submit_planned_order(
+    *,
+    planned: PlannedOrder,
+    table: PolicyTable,
+    confirm: bool,
+    broker_truth: BrokerTruth,
+    submitter: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Re-check readable broker truth, then use an explicitly injected seam.
+
+    There is intentionally no default broker submitter.  Wiring one here would
+    bypass the existing default-disabled, server-owned preview-token boundary
+    or accidentally target the baseline ``alpaca_paper`` account.
+    """
+
+    if submitter is None:
+        raise LabMutationNotWired(
+            "alpaca_paper_lab has no approved automated submit boundary"
+        )
+    if confirm is not True:
+        return {
+            "success": False,
+            "submitted": False,
+            "reason_code": "confirmation_required",
+            "account_mode": LANE,
+            "client_order_id": None,
+        }
+    assert_us_lab_lane_enabled()
+    assert_resubmit_allowed(broker_truth, symbol=planned.symbol, lane=LANE)
+    packet, canonical = build_submission_packet(planned=planned, table=table)
+    return await submitter(packet, submit_canonical=canonical, confirm=confirm)
+
+
+async def cancel_own_open_orders(
+    *,
+    fresh: FreshTruth,
+    confirm: bool,
+    canceler: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
+    """Cancel only broker orders linked to one ``b0xu-`` correlation.
+
+    A false confirmation does not even issue a dry cancellation call.  This
+    keeps ordinary runner previews free of broker-side mutation *and* avoids
+    treating a confirmation-required response as cancellation evidence.
+    """
+
+    if confirm is not True:
+        return []
+    if canceler is None:
+        raise LabMutationNotWired(
+            "alpaca_paper_lab has no approved automated cancellation boundary"
+        )
+    assert_us_lab_lane_enabled()
+    results: list[dict[str, Any]] = []
+    for order in fresh.own_open_orders:
+        results.append(
+            await canceler(order.broker_order_id, confirm=True, account_mode=LANE)
+        )
+    return results
+
+
+__all__ = [
+    "B0XU_CORRELATION_PREFIX",
+    "LANE",
+    "MARKET",
+    "QUOTE_CURRENCY",
+    "US_NEW_ENTRY_NOTIONAL_MIN",
+    "US_NEW_ENTRY_NOTIONAL_TARGET",
+    "US_LANE_ENABLED_ENV",
+    "BlockedOrder",
+    "FreshTruth",
+    "LabReaders",
+    "LabMutationNotWired",
+    "LabTruthReadError",
+    "LedgerExecution",
+    "PlannedOrder",
+    "RawOpenOrder",
+    "RawPosition",
+    "RealizedPnlUnavailable",
+    "UsLabLaneDisabled",
+    "assert_us_lab_lane_enabled",
+    "build_submission_packet",
+    "cancel_own_open_orders",
+    "lifecycle_correlation_id_for",
+    "plan_orders",
+    "read_fresh_truth",
+    "submit_planned_order",
+]

--- a/scripts/b0x/us/contract.py
+++ b/scripts/b0x/us/contract.py
@@ -1,0 +1,85 @@
+"""US-lane contract stamp: v1.6 plus the clauses this adapter implements.
+
+The shared B0-X package still carries older sidecar-oriented provenance.  The
+US adapter must not restamp that as its binding contract, so its record replaces
+the generic stamp with this lane-local v1.6 identity.  The whole-file digest is
+recorded for reference only: the signed binding is version + quoted clauses.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+CONTRACT_PATH: Final[str] = "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md"
+CONTRACT_VERSION: Final[str] = "v1.6"
+# Recorded for traceability only.  The binding is version + cited clauses;
+# this digest is deliberately not a substitute for checking those clauses.
+CONTRACT_FILE_SHA256_REFERENCE: Final[str] = (
+    "a3922894dcb91c2888daa2b33a9bfb9fab48a1c660ffc16deead09c530faea14"
+)
+
+CONTRACT_CLAUSES: Final[dict[str, str]] = {
+    "§1": (
+        "US 는 추가로 `CROSS_MARKET_TRANSFER_UNVALIDATED`(B0 는 KR 스코프 계량 — "
+        "US 이식은 이중 미검증)."
+    ),
+    "§2-2 v1.1": (
+        "표가 없거나 `STALE` 이거나 `MAX_TABLE_AGE` 초과면 그 사이클은 주문 0 … US 36h."
+    ),
+    "§4 US": (
+        "종목당 신규 $150~450 · 종목당 총 신규×5 · 동시 포지션 ≤10 · 일 신규 ≤3 · "
+        "일 손실 −2.5% NAV → kill · 세션 US RTH."
+    ),
+    "§8 v1.5 ①": (
+        "envelope 상한 = 브로커 진실 파생 — 동시 포지션/자기 미체결/일일 신규를 "
+        "브로커의 같은 사이클 응답에서 파생한다."
+    ),
+    "§8 v1.6": ("kis_mock 한정 원장 미체결 예외; 일반 원칙은 브로커 진실 유지."),
+}
+
+ACCOUNT_MAP_FACTS: Final[dict[str, str]] = {
+    "canonical_surface": "operator_contract.yaml",
+    "account_lane": "account_lanes.alpaca_paper_lab=B0-X-US",
+    "writer": (
+        "strategy_order_exceptions.b0x-adapter-orders-20260808."
+        "writer=b0x_adapter_single"
+    ),
+    "surface": (
+        "strategy_order_exceptions.b0x-adapter-orders-20260808.surfaces "
+        "contains alpaca_paper_lab"
+    ),
+    "legacy_lab_cleanup_constraint": (
+        "alpaca_account_cleanup_20260805 records alpaca_paper_lab suffix "
+        "a9e6cd / UBER qty=1 as a one-shot legacy cleanup; its forbidden list "
+        "includes reuse_after_execution and scope expansion. It is not B0-X "
+        "ownership evidence and must not be reused."
+    ),
+}
+
+
+def contract_stamp() -> dict[str, Any]:
+    """Return the v1.6/version-plus-clauses binding recorded by US cycles."""
+
+    return {
+        "path": CONTRACT_PATH,
+        "version": CONTRACT_VERSION,
+        "clauses": dict(CONTRACT_CLAUSES),
+        "file_sha256_reference_only": CONTRACT_FILE_SHA256_REFERENCE,
+    }
+
+
+def account_map_stamp() -> dict[str, Any]:
+    """Record the machine-readable account-map facts, not a guessed narrative."""
+
+    return dict(ACCOUNT_MAP_FACTS)
+
+
+__all__ = [
+    "ACCOUNT_MAP_FACTS",
+    "CONTRACT_FILE_SHA256_REFERENCE",
+    "CONTRACT_CLAUSES",
+    "CONTRACT_PATH",
+    "CONTRACT_VERSION",
+    "account_map_stamp",
+    "contract_stamp",
+]

--- a/scripts/b0x/us/cycle.py
+++ b/scripts/b0x/us/cycle.py
@@ -1,0 +1,348 @@
+"""One manual B0-X US cycle for the dedicated Alpaca paper lab.
+
+Safety order is deliberate:
+
+    writer lock → US RTH → table → lab fresh truth → ratio kill → derive
+                → plan → explicit-confirm submit/cancel → observation
+
+The RTH/table gates run before any account read.  The account read uses only
+``alpaca_paper_lab`` tooling; it has no default-account fallback.  A normal
+CLI invocation passes ``confirm=False`` and therefore never invokes an order
+preview, submit, or cancellation surface.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from app.mcp_server.tooling.market_session import US_SESSION_REGULAR, us_market_session
+from scripts.b0x.cycle import base_record, render_cycle_report
+from scripts.b0x.derivation import DerivationResult, derive_orders
+from scripts.b0x.envelope import Envelope, assert_envelope_locked, load_envelope
+from scripts.b0x.kill_switch import MissingNavForRatioKill, evaluate
+from scripts.b0x.labels import header_labels
+from scripts.b0x.ledger import DEFAULT_OBSERVATION_DIR, ObservationLedger, writer_lock
+from scripts.b0x.state import LaneAccountState
+from scripts.b0x.table_source import (
+    DEFAULT_TABLE_DIR,
+    PolicyTable,
+    TableUnavailable,
+    load_policy_table,
+)
+from scripts.b0x.us import alpaca
+from scripts.b0x.us.contract import account_map_stamp, contract_stamp
+from scripts.policy_table.core.trust_labels import CROSS_MARKET_TRANSFER_UNVALIDATED
+
+MARKET = "us"
+LANE = alpaca.LANE
+OUTSIDE_RTH_REASON = "outside_us_regular_session"
+FRESH_TRUTH_UNAVAILABLE_REASON = "lab_fresh_truth_unavailable"
+REALIZED_PNL_UNAVAILABLE_REASON = "realized_pnl_unavailable"
+MISSING_NAV_FOR_RATIO_KILL_REASON = "missing_nav_for_ratio_kill"
+INVALID_US_TABLE_SIZING_REASON = "invalid_us_table_sizing"
+
+US_REALIZED_PNL_UNAVAILABLE = (
+    "realized_pnl_today has no dedicated source when a b0xu execution exists "
+    "today; this cycle fails closed rather than treating it as a measured zero."
+)
+
+
+@dataclass
+class UsCycleOutcome:
+    lane: str
+    at: dt.datetime
+    zero_order_reason: str | None = None
+    table_hash: str | None = None
+    table_generated_at: str | None = None
+    table_age_seconds: int | None = None
+    derivation: DerivationResult | None = None
+    record: dict[str, Any] = field(default_factory=dict)
+    artifact_path: Path | None = None
+    exit_code: int = 0
+
+    @property
+    def order_count(self) -> int:
+        return 0 if self.derivation is None else len(self.derivation.orders)
+
+
+def _table_or_reason(
+    *, now: dt.datetime, table_dir: Path
+) -> tuple[PolicyTable | None, TableUnavailable | None]:
+    result = load_policy_table(market=MARKET, now=now, table_dir=table_dir)
+    if isinstance(result, TableUnavailable):
+        return None, result
+    return result, None
+
+
+def _us_table_sizing_error(*, table: PolicyTable, envelope: Envelope) -> str | None:
+    """Validate the table-owned USD selection before any lab account read.
+
+    The generic derivation core intentionally retains legacy market fallbacks.
+    This US lane must not silently take its envelope ceiling when the US table
+    omitted the explicitly generated ``new_entry_notional_usd`` selection.
+    """
+
+    config = table.config
+    if config.get("quote_currency") != alpaca.QUOTE_CURRENCY:
+        return (
+            "policy table quote_currency must be USD for alpaca_paper_lab; "
+            f"got {config.get('quote_currency')!r}"
+        )
+    raw_selected = config.get("new_entry_notional_usd")
+    try:
+        selected = Decimal(str(raw_selected))
+    except Exception:  # noqa: BLE001 - a malformed table must close the lane
+        return "policy table new_entry_notional_usd is missing or malformed"
+    if not selected.is_finite() or not (
+        alpaca.US_NEW_ENTRY_NOTIONAL_MIN <= selected <= envelope.per_order_notional
+    ):
+        return (
+            "policy table new_entry_notional_usd must be inside the signed "
+            f"${format(alpaca.US_NEW_ENTRY_NOTIONAL_MIN, 'f')}-${format(envelope.per_order_notional, 'f')} band"
+        )
+    return None
+
+
+def broker_state(*, fresh: alpaca.FreshTruth) -> LaneAccountState:
+    """Attribution-scoped state plus account-wide broker truth for US.
+
+    Positions and own pending orders are read from the same current lab
+    snapshot.  Foreign residue remains foreign and contaminates the cycle; it
+    is never repurposed as B0-X inventory.  The generic cap inputs are still
+    account-wide by contract, so foreign *sellable* positions consume a slot.
+    """
+
+    if fresh.realized_pnl_today is None:
+        raise alpaca.RealizedPnlUnavailable(US_REALIZED_PNL_UNAVAILABLE)
+    return LaneAccountState(
+        lane=LANE,
+        quote_currency=alpaca.QUOTE_CURRENCY,
+        cash=fresh.cash,
+        broker_truth=fresh.broker_truth(),
+        positions=fresh.own_positions,
+        realized_pnl_today=fresh.realized_pnl_today,
+        nav=fresh.nav,
+        cumulative_deployment_readable=fresh.cumulative_deployment_readable,
+        open_order_keys=tuple(order.broker_order_id for order in fresh.own_open_orders),
+        foreign_open_order_count=len(fresh.foreign_open_orders),
+        foreign_position_symbols=fresh.foreign_position_symbols,
+        notes=fresh.position_linkage_failures,
+    )
+
+
+async def run_us_cycle(
+    *,
+    now: dt.datetime,
+    table_dir: Path = DEFAULT_TABLE_DIR,
+    out_dir: Path = DEFAULT_OBSERVATION_DIR,
+    confirm: bool = False,
+    readers: alpaca.LabReaders | None = None,
+    submitter: Any = None,
+    canceler: Any = None,
+) -> UsCycleOutcome:
+    """Run one US observation cycle; mutation requires explicit internal confirm.
+
+    The command-line runner never passes ``confirm=True``.  The injection seams
+    exist for offline fake/stub tests and a separately authorized future
+    operator entrypoint, not to turn this module into an implicit broker call.
+    """
+
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    envelope = load_envelope(MARKET)
+    assert_envelope_locked(envelope)
+    labels = header_labels(lane=LANE, extra=(CROSS_MARKET_TRANSFER_UNVALIDATED,))
+    outcome = UsCycleOutcome(lane=LANE, at=now)
+
+    with writer_lock(lane=LANE, root=Path(out_dir).expanduser()):
+        ledger = ObservationLedger(lane=LANE, root=Path(out_dir).expanduser())
+        ledger.ensure()
+        record = base_record(
+            market=MARKET,
+            lane=LANE,
+            now=now,
+            envelope=envelope,
+            labels=labels,
+        )
+        # US binding is v1.6 + clauses, not the older generic sidecar stamp.
+        record["contract"] = contract_stamp()
+        record["account_map"] = account_map_stamp()
+        record["confirm"] = confirm
+
+        def finish_zero(reason: str, detail: str) -> UsCycleOutcome:
+            record["zero_order_reason"] = reason
+            record["zero_order_detail"] = detail
+            record["orders"] = []
+            record["skipped"] = []
+            record["planned"] = []
+            record["blocked"] = []
+            record["submitted"] = []
+            outcome.zero_order_reason = reason
+            ledger.record_cycle(record)
+            outcome.record = record
+            outcome.artifact_path = ledger.write_artifact(
+                name=f"{now.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
+                content=render_cycle_report(record, labels=labels),
+            )
+            return outcome
+
+        # Cheapest zero-order gate: no table or account/ledger/broker read
+        # happens outside XNYS regular session.
+        session = us_market_session(now)
+        record["us_market_session"] = session
+        if session != US_SESSION_REGULAR:
+            return finish_zero(
+                OUTSIDE_RTH_REASON,
+                f"now={now.isoformat()} session={session!r}; US RTH only",
+            )
+
+        table, unavailable = _table_or_reason(now=now, table_dir=Path(table_dir))
+        if table is None:
+            assert unavailable is not None
+            return finish_zero(unavailable.reason, unavailable.detail)
+        sizing_error = _us_table_sizing_error(table=table, envelope=envelope)
+        if sizing_error is not None:
+            return finish_zero(INVALID_US_TABLE_SIZING_REASON, sizing_error)
+
+        outcome.table_hash = table.policy_table_hash
+        outcome.table_generated_at = table.generated_at.isoformat()
+        outcome.table_age_seconds = int(table.age.total_seconds())
+        record.update(
+            {
+                "policy_table_hash": table.policy_table_hash,
+                "policy_table_path": str(table.path),
+                "policy_table_generated_at": table.generated_at.isoformat(),
+                "policy_table_age_seconds": int(table.age.total_seconds()),
+            }
+        )
+
+        try:
+            fresh = await alpaca.read_fresh_truth(now=now, readers=readers)
+        except Exception as exc:  # fail closed; never leak broker error bodies/secrets
+            return finish_zero(
+                FRESH_TRUTH_UNAVAILABLE_REASON,
+                f"{type(exc).__name__}: alpaca_paper_lab read-only truth unavailable",
+            )
+        record["fresh_truth"] = fresh.status_only()
+
+        try:
+            state = broker_state(fresh=fresh)
+        except alpaca.RealizedPnlUnavailable:
+            return finish_zero(
+                REALIZED_PNL_UNAVAILABLE_REASON, US_REALIZED_PNL_UNAVAILABLE
+            )
+        record["broker_truth"] = state.broker_truth.canonical()
+        record["contaminated"] = state.contaminated
+        record["contamination"] = {
+            "foreign_open_order_count": state.foreign_open_order_count,
+            "foreign_position_symbols": list(state.foreign_position_symbols),
+            "position_linkage_failures": list(state.notes),
+        }
+
+        try:
+            decision = evaluate(state=state, envelope=envelope)
+        except MissingNavForRatioKill:
+            return finish_zero(
+                MISSING_NAV_FOR_RATIO_KILL_REASON,
+                "portfolio_value unavailable/non-positive; NAV-ratio kill fails closed",
+            )
+
+        derivation = derive_orders(
+            table=table,
+            state=state,
+            envelope=envelope,
+            kill_switch=decision,
+            lane_universe=None,
+            apply_envelope=True,
+        )
+        outcome.derivation = derivation
+        record.update(
+            {
+                "cycle_id": derivation.cycle_id,
+                "account_state_hash": derivation.account_state_hash,
+                "derivation_hash": derivation.derivation_hash(),
+                "orders": [order.canonical() for order in derivation.orders],
+                "skipped": [skip.canonical() for skip in derivation.skipped],
+                "kill_switch": decision.canonical(),
+            }
+        )
+
+        if decision.tripped:
+            record["planned"] = []
+            record["blocked"] = []
+            record["submitted"] = []
+            if confirm is True and canceler is not None:
+                cancel_kwargs: dict[str, Any] = {"fresh": fresh, "confirm": True}
+                cancel_kwargs["canceler"] = canceler
+                record["cancelled"] = await alpaca.cancel_own_open_orders(
+                    **cancel_kwargs
+                )
+            else:
+                record["cancelled"] = []
+                record["cancellation_skipped"] = (
+                    "confirmation or approved injected lab canceler absent — "
+                    "no cancellation call issued"
+                )
+        else:
+            planned, blocked = alpaca.plan_orders(
+                derivation.orders,
+                envelope=envelope,
+                cash=state.cash,
+                held_quantities=fresh.sellable_owned_quantities(),
+                invested_notional_by_symbol=fresh.invested_notional_by_symbol(),
+                sell_source_client_order_ids=fresh.sell_source_client_order_ids,
+            )
+            record["planned"] = [order.to_json() for order in planned]
+            record["blocked"] = [order.to_json() for order in blocked]
+            submitted: list[dict[str, Any]] = []
+            if state.contaminated:
+                record["submission_skipped"] = (
+                    "contaminated lab account state — foreign/unlinked residue blocks submit"
+                )
+            elif confirm is not True:
+                record["submission_skipped"] = (
+                    "confirm=False — plan only; no preview or broker mutation call issued"
+                )
+            elif submitter is None:
+                record["submission_skipped"] = (
+                    "no approved injected alpaca_paper_lab submitter — "
+                    "no preview or broker mutation call issued"
+                )
+            else:
+                for planned_order in planned:
+                    submit_kwargs: dict[str, Any] = {
+                        "planned": planned_order,
+                        "table": table,
+                        "confirm": True,
+                        "broker_truth": state.broker_truth,
+                    }
+                    submit_kwargs["submitter"] = submitter
+                    submitted.append(await alpaca.submit_planned_order(**submit_kwargs))
+            record["submitted"] = submitted
+
+        ledger.record_cycle(record)
+        outcome.record = record
+        outcome.artifact_path = ledger.write_artifact(
+            name=f"{now.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
+            content=render_cycle_report(record, labels=labels),
+        )
+        return outcome
+
+
+__all__ = [
+    "FRESH_TRUTH_UNAVAILABLE_REASON",
+    "INVALID_US_TABLE_SIZING_REASON",
+    "LANE",
+    "MARKET",
+    "MISSING_NAV_FOR_RATIO_KILL_REASON",
+    "OUTSIDE_RTH_REASON",
+    "REALIZED_PNL_UNAVAILABLE_REASON",
+    "US_REALIZED_PNL_UNAVAILABLE",
+    "UsCycleOutcome",
+    "broker_state",
+    "run_us_cycle",
+]

--- a/scripts/run_b0x_us_cycle.py
+++ b/scripts/run_b0x_us_cycle.py
@@ -1,0 +1,98 @@
+"""B0-X US (``alpaca_paper_lab``) manual observation runner.
+
+The runner is deliberately scheduleless and exposes no ``--confirm`` option.
+It may derive/plan during US RTH after a fresh lab-only read, but it never
+invokes Alpaca preview, submit, or cancellation in this command path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+from scripts.b0x.ledger import DEFAULT_OBSERVATION_DIR, WriterLockUnavailable
+from scripts.b0x.table_source import DEFAULT_TABLE_DIR
+from scripts.b0x.us.cycle import UsCycleOutcome, run_us_cycle
+
+
+def _print_outcome(outcome: UsCycleOutcome) -> None:
+    print(f"lane={outcome.lane} at={outcome.at.isoformat()}")
+    if outcome.zero_order_reason:
+        print(f"ZERO ORDERS — reason={outcome.zero_order_reason}")
+    if outcome.table_hash:
+        print(
+            f"policy_table_hash={outcome.table_hash} age_s={outcome.table_age_seconds}"
+        )
+    if outcome.derivation is not None:
+        print(
+            f"cycle_id={outcome.derivation.cycle_id} "
+            f"derivation_hash={outcome.derivation.derivation_hash()}"
+        )
+        print(
+            f"orders={len(outcome.derivation.orders)} "
+            f"skipped={len(outcome.derivation.skipped)} "
+            f"kill_switch_tripped={outcome.derivation.kill_switch.tripped}"
+        )
+    if outcome.artifact_path:
+        print(f"artifact={outcome.artifact_path}")
+
+
+def _iso(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        raise argparse.ArgumentTypeError("--now must be timezone-aware ISO8601")
+    return parsed.astimezone(dt.UTC)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--table-dir",
+        default=str(DEFAULT_TABLE_DIR),
+        help="where the separate US table builder wrote latest-us.json (read-only)",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=str(DEFAULT_OBSERVATION_DIR),
+        help="append-only B0-X observation artifact root",
+    )
+    parser.add_argument(
+        "--now",
+        type=_iso,
+        default=None,
+        help="override the cycle clock for replay/tests; must be timezone-aware",
+    )
+    parser.add_argument("--json", action="store_true", help="also emit the raw record")
+    return parser.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    now = dt.datetime.now(dt.UTC) if args.now is None else args.now
+    try:
+        outcome = await run_us_cycle(
+            now=now,
+            table_dir=Path(args.table_dir).expanduser(),
+            out_dir=Path(args.out_dir).expanduser(),
+            confirm=False,
+        )
+    except WriterLockUnavailable as exc:
+        print(f"WRITER_LOCK_UNAVAILABLE — {exc}", file=sys.stderr)
+        return 2
+    _print_outcome(outcome)
+    if args.json:
+        print(
+            json.dumps(outcome.record, sort_keys=True, ensure_ascii=False, default=str)
+        )
+    return outcome.exit_code
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_run(_parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/b0x/us/__init__.py
+++ b/tests/scripts/b0x/us/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the B0-X US Alpaca-paper-lab lane."""

--- a/tests/scripts/b0x/us/test_alpaca.py
+++ b/tests/scripts/b0x/us/test_alpaca.py
@@ -1,0 +1,488 @@
+"""Offline tests for US lab fresh truth, planning, and mutation boundaries."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.b0x.broker_truth import (
+    OWN_PENDING_ORDER_EXISTS,
+    BrokerTruth,
+    OwnPendingResubmitBlocked,
+)
+from scripts.b0x.derivation import DerivedOrder
+from scripts.b0x.envelope import US_ALPACA_PAPER_LAB_ENVELOPE
+from scripts.b0x.table_source import PolicyTable
+from scripts.b0x.us import alpaca
+
+pytestmark = pytest.mark.unit
+
+NOW = dt.datetime(2026, 8, 10, 15, 0, tzinfo=dt.UTC)
+
+
+def _response(**payload: Any) -> dict[str, Any]:
+    return {"success": True, "account_mode": alpaca.LANE, **payload}
+
+
+def _readers(
+    *,
+    account: dict[str, Any] | None = None,
+    positions: list[dict[str, Any]] | None = None,
+    orders: list[dict[str, Any]] | None = None,
+    ledger: list[dict[str, Any]] | None = None,
+) -> tuple[alpaca.LabReaders, list[tuple[str, dict[str, Any]]]]:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def get_account(**kwargs: Any) -> dict[str, Any]:
+        calls.append(("account", kwargs))
+        return _response(
+            account=account
+            or {"cash": "5000", "portfolio_value": "5000", "status": "ACTIVE"}
+        )
+
+    async def list_positions(**kwargs: Any) -> dict[str, Any]:
+        calls.append(("positions", kwargs))
+        values = positions or []
+        return _response(count=len(values), positions=values)
+
+    async def list_orders(**kwargs: Any) -> dict[str, Any]:
+        calls.append(("orders", kwargs))
+        values = orders or []
+        return _response(count=len(values), orders=values)
+
+    async def list_recent_ledger(**kwargs: Any) -> dict[str, Any]:
+        calls.append(("ledger", kwargs))
+        values = ledger or []
+        return _response(count=len(values), items=values)
+
+    return (
+        alpaca.LabReaders(
+            get_account=get_account,
+            list_positions=list_positions,
+            list_orders=list_orders,
+            list_recent_ledger=list_recent_ledger,
+        ),
+        calls,
+    )
+
+
+def _derived(
+    *,
+    order_key: str,
+    symbol: str = "AAPL",
+    side: str = "buy",
+    price: str = "100",
+    notional: str | None = "300",
+    fraction: str | None = None,
+) -> DerivedOrder:
+    return DerivedOrder(
+        sequence=0,
+        symbol=symbol,
+        side=side,
+        leg="buy_l1" if side == "buy" else "sell_r1",
+        price_ratio=Decimal("0.97") if side == "buy" else Decimal("1.05"),
+        table_price=Decimal(price),
+        table_previous_close=Decimal("100"),
+        notional=Decimal(notional) if notional is not None else None,
+        quantity_fraction=Decimal(fraction) if fraction is not None else None,
+        basis="fixture",
+        labels=(),
+        detail={},
+        order_key=order_key,
+    )
+
+
+def _table() -> PolicyTable:
+    return PolicyTable(
+        market="us",
+        path=Path("/tmp/latest-us.json"),
+        payload={"config": {"new_entry_notional_usd": "300"}, "rows": []},
+        policy_table_hash="sha256:test-policy-table",
+        artifact_sha256="sha256:test-artifact",
+        generated_at=NOW,
+        age=dt.timedelta(0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_truth_uses_lab_only_and_attributes_by_b0xu_correlation() -> None:
+    readers, calls = _readers(
+        positions=[
+            {
+                "symbol": "AAPL",
+                "qty": "2",
+                "qty_available": "2",
+                "avg_entry_price": "100",
+            },
+            {
+                "symbol": "UBER",
+                "qty": "1",
+                "qty_available": "1",
+                "avg_entry_price": "20",
+            },
+            {
+                "symbol": "BRK-B",
+                "qty": "0.1",
+                "qty_available": "0.1",
+                "avg_entry_price": "400",
+            },
+        ],
+        orders=[
+            {"id": "b0xu-open", "symbol": "AAPL"},
+            {"id": "foreign-open", "symbol": "UBER"},
+        ],
+        ledger=[
+            {
+                "account_mode": alpaca.LANE,
+                "record_kind": "execution",
+                "lifecycle_correlation_id": "b0xu-aapl-buy",
+                "client_order_id": "dlab-rob842a-aapl",
+                "broker_order_id": "b0xu-open",
+                "execution_symbol": "AAPL",
+                "side": "buy",
+                "filled_qty": "2",
+                "filled_avg_price": "100",
+                "created_at": "2026-08-09T15:00:00+00:00",
+            }
+        ],
+    )
+
+    fresh = await alpaca.read_fresh_truth(now=NOW, readers=readers)
+
+    assert {name for name, _ in calls} == {"account", "positions", "orders", "ledger"}
+    assert all(kwargs["account_mode"] == alpaca.LANE for _, kwargs in calls)
+    orders_call = next(kwargs for name, kwargs in calls if name == "orders")
+    assert orders_call == {"status": "open", "limit": 500, "account_mode": alpaca.LANE}
+    truth = fresh.broker_truth()
+    assert truth.canonical() == {
+        "position_symbols": ["AAPL", "BRK.B", "UBER"],
+        "own_pending": ["AAPL"],
+        "own_pending_readable": True,
+    }
+    # All three contract v1.5 ① inputs are facts from the same broker snapshot:
+    # every positive sellable account position consumes concurrency/daily room,
+    # while the linked open order blocks AAPL regardless of its side.
+    assert truth.concurrent_position_count == 3
+    assert truth.daily_new_entry_seed() == {"AAPL", "BRK.B", "UBER"}
+    assert truth.resubmit_block("AAPL")[0] == OWN_PENDING_ORDER_EXISTS
+    assert [position.symbol for position in fresh.own_positions] == ["AAPL"]
+    assert fresh.foreign_position_symbols == ("BRK.B", "UBER")
+    assert [order.broker_order_id for order in fresh.own_open_orders] == ["b0xu-open"]
+    assert [order.broker_order_id for order in fresh.foreign_open_orders] == [
+        "foreign-open"
+    ]
+    # No b0xu execution exists on NOW's UTC day, which is a provable bootstrap
+    # zero—not an inferred P&L calculation.
+    assert fresh.realized_pnl_today == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_open_b0xu_order_is_own_pending_before_it_has_any_fill() -> None:
+    """A broker-resting B0-X order does not need fabricated fill evidence.
+
+    The submitted execution ledger row supplies the exact broker-order-id ↔
+    b0xu correlation.  It is sufficient ownership evidence for the readable
+    Alpaca open-orders response, and is intentionally distinct from a fill
+    used for position attribution.
+    """
+
+    readers, _ = _readers(
+        orders=[{"id": "pending-b0xu", "symbol": "AAPL"}],
+        ledger=[
+            {
+                "account_mode": alpaca.LANE,
+                "record_kind": "execution",
+                "lifecycle_state": "submitted",
+                "lifecycle_correlation_id": "b0xu-pending-aapl",
+                "client_order_id": "b0xu-client-aapl",
+                "broker_order_id": "pending-b0xu",
+                "execution_symbol": "AAPL",
+                "side": "buy",
+                "created_at": "2026-08-09T15:00:00+00:00",
+            }
+        ],
+    )
+
+    fresh = await alpaca.read_fresh_truth(now=NOW, readers=readers)
+
+    assert [order.broker_order_id for order in fresh.own_open_orders] == [
+        "pending-b0xu"
+    ]
+    assert fresh.foreign_open_orders == ()
+    assert fresh.broker_truth().resubmit_block("AAPL")[0] == (OWN_PENDING_ORDER_EXISTS)
+
+
+@pytest.mark.asyncio
+async def test_fresh_truth_rejects_account_mode_mismatch_instead_of_falling_back() -> (
+    None
+):
+    readers, _ = _readers()
+
+    async def wrong_account(**kwargs: Any) -> dict[str, Any]:
+        assert kwargs["account_mode"] == alpaca.LANE
+        return {
+            "success": True,
+            "account_mode": "alpaca_paper",
+            "account": {"cash": "1", "portfolio_value": "1"},
+        }
+
+    readers = alpaca.LabReaders(
+        get_account=wrong_account,
+        list_positions=readers.list_positions,
+        list_orders=readers.list_orders,
+        list_recent_ledger=readers.list_recent_ledger,
+    )
+    with pytest.raises(
+        alpaca.LabTruthReadError, match="default-account fallback refused"
+    ):
+        await alpaca.read_fresh_truth(now=NOW, readers=readers)
+
+
+@pytest.mark.asyncio
+async def test_fresh_truth_refuses_truncated_open_order_or_ledger_answers() -> None:
+    readers, _ = _readers()
+
+    async def full_orders(**kwargs: Any) -> dict[str, Any]:
+        return _response(count=500, orders=[])
+
+    too_many_orders = alpaca.LabReaders(
+        get_account=readers.get_account,
+        list_positions=readers.list_positions,
+        list_orders=full_orders,
+        list_recent_ledger=readers.list_recent_ledger,
+    )
+    with pytest.raises(alpaca.LabTruthReadError, match="open-order read reached"):
+        await alpaca.read_fresh_truth(now=NOW, readers=too_many_orders)
+
+    async def full_ledger(**kwargs: Any) -> dict[str, Any]:
+        return _response(count=200, items=[])
+
+    too_many_ledger = alpaca.LabReaders(
+        get_account=readers.get_account,
+        list_positions=readers.list_positions,
+        list_orders=readers.list_orders,
+        list_recent_ledger=full_ledger,
+    )
+    with pytest.raises(alpaca.LabTruthReadError, match="ledger read reached"):
+        await alpaca.read_fresh_truth(now=NOW, readers=too_many_ledger)
+
+
+def test_plan_orders_keeps_realized_buys_inside_signed_band_and_symbol_cap() -> None:
+    orders = tuple(
+        _derived(order_key=f"key-{index}", price="400") for index in range(7)
+    )
+    planned, blocked = alpaca.plan_orders(
+        orders,
+        envelope=US_ALPACA_PAPER_LAB_ENVELOPE,
+        cash=Decimal("10000"),
+        held_quantities={},
+        invested_notional_by_symbol={},
+        sell_source_client_order_ids={},
+    )
+
+    assert [order.notional for order in planned] == [Decimal("400")] * 5
+    assert all(
+        alpaca.US_NEW_ENTRY_NOTIONAL_MIN
+        <= order.notional
+        <= US_ALPACA_PAPER_LAB_ENVELOPE.per_order_notional
+        for order in planned
+    )
+    assert sum(order.notional for order in planned) <= Decimal("2250")
+    assert len(blocked) == 2
+    assert {block.reason for block in blocked} == {"sizing_blocked"}
+
+
+def test_plan_blocks_sell_without_exact_native_buy_authority() -> None:
+    planned, blocked = alpaca.plan_orders(
+        (
+            _derived(
+                order_key="sell",
+                side="sell",
+                price="110",
+                notional=None,
+                fraction="0.5",
+            ),
+        ),
+        envelope=US_ALPACA_PAPER_LAB_ENVELOPE,
+        cash=Decimal("0"),
+        held_quantities={"AAPL": Decimal("2")},
+        invested_notional_by_symbol={"AAPL": Decimal("200")},
+        sell_source_client_order_ids={},
+    )
+    assert planned == []
+    assert blocked[0].reason == "source_authority_unavailable"
+
+
+def test_packet_carries_b0xu_correlation_and_lab_only_binding() -> None:
+    planned = alpaca.PlannedOrder(
+        order_key="packet-key",
+        lifecycle_correlation_id="b0xu-packet-key",
+        symbol="AAPL",
+        side="buy",
+        leg="buy_l1",
+        price=Decimal("100"),
+        quantity=Decimal("3"),
+        notional=Decimal("300"),
+    )
+    packet, canonical = alpaca.build_submission_packet(planned=planned, table=_table())
+
+    assert packet.account_mode == alpaca.LANE
+    assert packet.lifecycle_correlation_id.startswith("b0xu-")
+    assert packet.signal_venue == "policy_table_us"
+    assert packet.max_notional == Decimal("300")
+    assert canonical["qty"] == "3"
+    assert canonical["notional"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_rechecks_readable_broker_pending_before_fake_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planned = alpaca.PlannedOrder(
+        order_key="submit-key",
+        lifecycle_correlation_id="b0xu-submit-key",
+        symbol="AAPL",
+        side="buy",
+        leg="buy_l1",
+        price=Decimal("100"),
+        quantity=Decimal("3"),
+        notional=Decimal("300"),
+    )
+    called: list[dict[str, Any]] = []
+
+    async def fake_submit(packet: Any, **kwargs: Any) -> dict[str, Any]:
+        called.append({"packet": packet, **kwargs})
+        return {"success": True, "submitted": True, "source": "fake"}
+
+    with pytest.raises(alpaca.UsLabLaneDisabled):
+        await alpaca.submit_planned_order(
+            planned=planned,
+            table=_table(),
+            confirm=True,
+            broker_truth=BrokerTruth(position_symbols=(), own_pending=()),
+            submitter=fake_submit,
+        )
+    assert called == []
+
+    confirmation_required = await alpaca.submit_planned_order(
+        planned=planned,
+        table=_table(),
+        confirm=False,
+        broker_truth=BrokerTruth(position_symbols=(), own_pending=()),
+        submitter=fake_submit,
+    )
+    assert confirmation_required["reason_code"] == "confirmation_required"
+    assert called == []
+    monkeypatch.setenv(alpaca.US_LANE_ENABLED_ENV, "true")
+
+    result = await alpaca.submit_planned_order(
+        planned=planned,
+        table=_table(),
+        confirm=True,
+        broker_truth=BrokerTruth(position_symbols=(), own_pending=()),
+        submitter=fake_submit,
+    )
+    assert result["submitted"] is True
+    assert called[0]["packet"].lifecycle_correlation_id == "b0xu-submit-key"
+    assert called[0]["confirm"] is True
+
+    with pytest.raises(OwnPendingResubmitBlocked):
+        await alpaca.submit_planned_order(
+            planned=planned,
+            table=_table(),
+            confirm=True,
+            broker_truth=BrokerTruth(position_symbols=(), own_pending=("AAPL",)),
+            submitter=fake_submit,
+        )
+    assert len(called) == 1
+
+
+@pytest.mark.asyncio
+async def test_production_mutation_defaults_are_unwired_and_fail_closed() -> None:
+    planned = alpaca.PlannedOrder(
+        order_key="unwired-key",
+        lifecycle_correlation_id="b0xu-unwired-key",
+        symbol="AAPL",
+        side="buy",
+        leg="buy_l1",
+        price=Decimal("100"),
+        quantity=Decimal("3"),
+        notional=Decimal("300"),
+    )
+
+    with pytest.raises(alpaca.LabMutationNotWired):
+        await alpaca.submit_planned_order(
+            planned=planned,
+            table=_table(),
+            confirm=True,
+            broker_truth=BrokerTruth(position_symbols=(), own_pending=()),
+        )
+
+    empty = alpaca.FreshTruth(
+        cash=Decimal("1"),
+        nav=Decimal("1"),
+        positions=(),
+        open_orders=(),
+        own_open_orders=(),
+        foreign_open_orders=(),
+        own_positions=(),
+        foreign_position_symbols=(),
+        position_linkage_failures=(),
+        sell_source_client_order_ids={},
+        realized_pnl_today=Decimal("0"),
+        cumulative_deployment_readable=True,
+    )
+    with pytest.raises(alpaca.LabMutationNotWired):
+        await alpaca.cancel_own_open_orders(fresh=empty, confirm=True)
+
+
+@pytest.mark.asyncio
+async def test_cancel_only_targets_b0xu_linked_open_orders_when_confirmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fresh = alpaca.FreshTruth(
+        cash=Decimal("1"),
+        nav=Decimal("1"),
+        positions=(),
+        open_orders=(
+            alpaca.RawOpenOrder(broker_order_id="own", symbol="AAPL"),
+            alpaca.RawOpenOrder(broker_order_id="foreign", symbol="UBER"),
+        ),
+        own_open_orders=(alpaca.RawOpenOrder(broker_order_id="own", symbol="AAPL"),),
+        foreign_open_orders=(
+            alpaca.RawOpenOrder(broker_order_id="foreign", symbol="UBER"),
+        ),
+        own_positions=(),
+        foreign_position_symbols=(),
+        position_linkage_failures=(),
+        sell_source_client_order_ids={},
+        cumulative_deployment_readable=True,
+        realized_pnl_today=Decimal("0"),
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def fake_cancel(order_id: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"order_id": order_id, **kwargs})
+        return {"cancelled_order_id": order_id}
+
+    assert (
+        await alpaca.cancel_own_open_orders(
+            fresh=fresh, confirm=False, canceler=fake_cancel
+        )
+        == []
+    )
+    assert calls == []
+    with pytest.raises(alpaca.UsLabLaneDisabled):
+        await alpaca.cancel_own_open_orders(
+            fresh=fresh, confirm=True, canceler=fake_cancel
+        )
+    assert calls == []
+    monkeypatch.setenv(alpaca.US_LANE_ENABLED_ENV, "true")
+    assert await alpaca.cancel_own_open_orders(
+        fresh=fresh, confirm=True, canceler=fake_cancel
+    ) == [{"cancelled_order_id": "own"}]
+    assert calls == [{"order_id": "own", "confirm": True, "account_mode": alpaca.LANE}]

--- a/tests/scripts/b0x/us/test_cycle.py
+++ b/tests/scripts/b0x/us/test_cycle.py
@@ -1,0 +1,288 @@
+"""Offline US-cycle safety tests: lab reads, RTH/table gates, and no mutation."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.mcp_server.tooling.market_session import US_SESSION_REGULAR
+from scripts.b0x.labels import SHARED_ACCOUNT_HISTORY, TRUST_LABELS
+from scripts.b0x.us import alpaca
+from scripts.b0x.us import cycle as us_cycle
+from scripts.policy_table.core.schema import compute_policy_table_hash
+from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
+
+pytestmark = pytest.mark.unit
+
+# Monday 11:00 EDT.  The cycle's session function is monkeypatched anyway so
+# these tests remain completely calendar/network independent.
+NOW = dt.datetime(2026, 8, 10, 15, 0, tzinfo=dt.UTC)
+
+
+def _table_dir(
+    tmp_path: Path,
+    *,
+    age: dt.timedelta = dt.timedelta(hours=1),
+    selected_usd: str | None = "300",
+) -> Path:
+    payload = make_payload(
+        market="us",
+        rows=[
+            make_row(
+                symbol="AAPL",
+                previous_close="100",
+                buy_l1="97",
+                sell_r1="105",
+                sell_r2="110",
+            )
+        ],
+        generated_at=NOW - age,
+    )
+    payload["config"] = {
+        **payload["config"],
+        "quote_currency": "USD",
+        "new_entry_notional_usd_min": "150",
+        "new_entry_notional_usd_max": "450",
+    }
+    if selected_usd is not None:
+        payload["config"]["new_entry_notional_usd"] = selected_usd
+    # The US builder stamps its selected amount in config, not the legacy KRW
+    # sizing field.  This fixture must exercise that real schema shape.
+    payload["sizing"] = {}
+    payload["stamps"]["policy_table_hash"] = compute_policy_table_hash(
+        {key: value for key, value in payload.items() if key != "stamps"}
+    )
+    directory = tmp_path / "policy-tables"
+    write_table(directory, payload, market="us")
+    return directory
+
+
+def _readers(
+    *,
+    portfolio_value: str = "5000",
+    positions: list[dict[str, Any]] | None = None,
+    orders: list[dict[str, Any]] | None = None,
+    ledger: list[dict[str, Any]] | None = None,
+) -> tuple[alpaca.LabReaders, list[str]]:
+    calls: list[str] = []
+
+    async def account(**kwargs: Any) -> dict[str, Any]:
+        calls.append("account")
+        assert kwargs == {"account_mode": alpaca.LANE}
+        return {
+            "success": True,
+            "account_mode": alpaca.LANE,
+            "account": {"cash": "5000", "portfolio_value": portfolio_value},
+        }
+
+    async def list_positions(**kwargs: Any) -> dict[str, Any]:
+        calls.append("positions")
+        assert kwargs == {"account_mode": alpaca.LANE}
+        values = positions or []
+        return {
+            "success": True,
+            "account_mode": alpaca.LANE,
+            "count": len(values),
+            "positions": values,
+        }
+
+    async def list_orders(**kwargs: Any) -> dict[str, Any]:
+        calls.append("orders")
+        assert kwargs == {"status": "open", "limit": 500, "account_mode": alpaca.LANE}
+        values = orders or []
+        return {
+            "success": True,
+            "account_mode": alpaca.LANE,
+            "count": len(values),
+            "orders": values,
+        }
+
+    async def list_ledger(**kwargs: Any) -> dict[str, Any]:
+        calls.append("ledger")
+        assert kwargs == {"limit": 200, "account_mode": alpaca.LANE}
+        values = ledger or []
+        return {
+            "success": True,
+            "account_mode": alpaca.LANE,
+            "count": len(values),
+            "items": values,
+        }
+
+    return (
+        alpaca.LabReaders(
+            get_account=account,
+            list_positions=list_positions,
+            list_orders=list_orders,
+            list_recent_ledger=list_ledger,
+        ),
+        calls,
+    )
+
+
+@pytest.mark.asyncio
+async def test_outside_rth_stops_before_table_or_lab_reads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readers, calls = _readers()
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: "closed")
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        readers=readers,
+    )
+
+    assert outcome.zero_order_reason == us_cycle.OUTSIDE_RTH_REASON
+    assert calls == []
+    assert "policy_table_hash" not in outcome.record
+
+
+@pytest.mark.asyncio
+async def test_lab_dry_run_plans_without_preview_submit_or_cancel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readers, read_calls = _readers()
+    submit_calls: list[dict[str, Any]] = []
+    cancel_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+
+    async def fake_submit(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        submit_calls.append(kwargs)
+        return {"submitted": True}
+
+    async def fake_cancel(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        cancel_calls.append(kwargs)
+        return {"cancelled": True}
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        confirm=False,
+        readers=readers,
+        submitter=fake_submit,
+        canceler=fake_cancel,
+    )
+
+    assert read_calls == ["account", "positions", "orders", "ledger"]
+    assert outcome.zero_order_reason is None
+    assert outcome.record["contract"]["version"] == "v1.6"
+    assert outcome.record["submitted"] == []
+    assert outcome.record["submission_skipped"].startswith("confirm=False")
+    assert submit_calls == []
+    assert cancel_calls == []
+    assert outcome.record["broker_truth"]["own_pending_readable"] is True
+    assert outcome.record["broker_truth"]["own_pending"] == []
+    assert outcome.record["planned"]
+    assert SHARED_ACCOUNT_HISTORY not in outcome.record["labels"]
+    for label in TRUST_LABELS:
+        assert label in outcome.record["labels"]
+    assert any(
+        "CROSS_MARKET_TRANSFER_UNVALIDATED" in label
+        for label in outcome.record["labels"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_confirm_without_approved_lab_mutation_seam_still_makes_no_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readers, read_calls = _readers()
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        confirm=True,
+        readers=readers,
+    )
+
+    assert read_calls == ["account", "positions", "orders", "ledger"]
+    assert outcome.record["submitted"] == []
+    assert (
+        "no approved injected alpaca_paper_lab submitter"
+        in outcome.record["submission_skipped"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_nav_for_ratio_kill_is_zero_order_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readers, _ = _readers(portfolio_value="0")
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        readers=readers,
+    )
+
+    assert outcome.zero_order_reason == us_cycle.MISSING_NAV_FOR_RATIO_KILL_REASON
+    assert "NAV-ratio kill fails closed" in outcome.record["zero_order_detail"]
+    assert outcome.record["fresh_truth"]["nav_present"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selected_usd", [None, "149", "451"])
+async def test_invalid_us_table_selection_stops_before_lab_reads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    selected_usd: str | None,
+) -> None:
+    readers, calls = _readers()
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path, selected_usd=selected_usd),
+        out_dir=tmp_path / "observations",
+        readers=readers,
+    )
+
+    assert outcome.zero_order_reason == us_cycle.INVALID_US_TABLE_SIZING_REASON
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_foreign_residual_blocks_confirmed_submit_but_is_not_relabelled_own(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    readers, _ = _readers(
+        positions=[
+            {
+                "symbol": "UBER",
+                "qty": "1",
+                "qty_available": "1",
+                "avg_entry_price": "20",
+            }
+        ]
+    )
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+
+    async def fake_submit(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"submitted": True}
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        confirm=True,
+        readers=readers,
+        submitter=fake_submit,
+    )
+
+    assert outcome.zero_order_reason is None
+    assert outcome.record["contaminated"] is True
+    assert outcome.record["fresh_truth"]["foreign_position_symbols"] == ["UBER"]
+    assert outcome.record["fresh_truth"]["own_position_symbols"] == []
+    assert "contaminated lab account state" in outcome.record["submission_skipped"]
+    assert calls == []

--- a/tests/scripts/b0x/us/test_guards.py
+++ b/tests/scripts/b0x/us/test_guards.py
@@ -1,0 +1,248 @@
+"""US contract constants and static safety guards."""
+
+from __future__ import annotations
+
+import ast
+import datetime as dt
+from dataclasses import replace
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from scripts.b0x.broker_truth import BrokerTruth
+from scripts.b0x.derivation import derive_orders
+from scripts.b0x.envelope import (
+    US_ALPACA_PAPER_LAB_ENVELOPE,
+    EnvelopeNotLocked,
+    assert_envelope_locked,
+)
+from scripts.b0x.kill_switch import MissingNavForRatioKill, evaluate
+from scripts.b0x.labels import SHARED_HISTORY_ACCOUNTS, header_labels
+from scripts.b0x.state import LaneAccountState
+from scripts.b0x.table_source import PolicyTable
+from scripts.b0x.us import alpaca
+from scripts.b0x.us.contract import (
+    CONTRACT_FILE_SHA256_REFERENCE,
+    CONTRACT_VERSION,
+    account_map_stamp,
+    contract_stamp,
+)
+from scripts.policy_table.core.trust_labels import (
+    CROSS_MARKET_TRANSFER_UNVALIDATED,
+    TRUST_LABELS,
+)
+
+pytestmark = pytest.mark.unit
+
+NOW = dt.datetime(2026, 8, 10, 15, 0, tzinfo=dt.UTC)
+ROOT = Path(__file__).resolve().parents[4]
+US_PACKAGE = ROOT / "scripts" / "b0x" / "us"
+RUNNER = ROOT / "scripts" / "run_b0x_us_cycle.py"
+
+
+def _state(*, pnl: Decimal, nav: Decimal | None) -> LaneAccountState:
+    return LaneAccountState(
+        lane=alpaca.LANE,
+        quote_currency="USD",
+        cash=Decimal("10000"),
+        broker_truth=BrokerTruth(position_symbols=(), own_pending=()),
+        realized_pnl_today=pnl,
+        nav=nav,
+    )
+
+
+def test_us_envelope_matches_section_4_and_is_locked() -> None:
+    envelope = US_ALPACA_PAPER_LAB_ENVELOPE
+    assert envelope.market == "us"
+    assert envelope.quote_currency == "USD"
+    assert envelope.per_order_notional == Decimal("450")
+    assert envelope.per_symbol_total_notional == Decimal("2250")
+    assert envelope.max_concurrent_positions == 10
+    assert envelope.max_new_entries_per_utc_day == 3
+    assert envelope.daily_loss_kill == Decimal("0.025")
+    assert envelope.daily_loss_kill_basis == "pct_of_nav"
+    assert_envelope_locked(envelope)
+    with pytest.raises(EnvelopeNotLocked):
+        assert_envelope_locked(replace(envelope, per_order_notional=Decimal("451")))
+
+
+def test_us_contract_stamp_is_v16_plus_quoted_clauses_with_reference_digest() -> None:
+    stamp = contract_stamp()
+    assert stamp["version"] == CONTRACT_VERSION == "v1.6"
+    assert stamp["file_sha256_reference_only"] == CONTRACT_FILE_SHA256_REFERENCE
+    assert {"§1", "§2-2 v1.1", "§4 US", "§8 v1.5 ①", "§8 v1.6"} <= set(stamp["clauses"])
+    assert account_map_stamp()["account_lane"] == (
+        "account_lanes.alpaca_paper_lab=B0-X-US"
+    )
+    assert (
+        "reuse_after_execution" in account_map_stamp()["legacy_lab_cleanup_constraint"]
+    )
+
+
+def test_us_ratio_kill_uses_nav_and_missing_nav_fails_closed() -> None:
+    with pytest.raises(MissingNavForRatioKill):
+        evaluate(
+            state=_state(pnl=Decimal("-1"), nav=None),
+            envelope=US_ALPACA_PAPER_LAB_ENVELOPE,
+        )
+
+    under = evaluate(
+        state=_state(pnl=Decimal("-24.99"), nav=Decimal("1000")),
+        envelope=US_ALPACA_PAPER_LAB_ENVELOPE,
+    )
+    at = evaluate(
+        state=_state(pnl=Decimal("-25"), nav=Decimal("1000")),
+        envelope=US_ALPACA_PAPER_LAB_ENVELOPE,
+    )
+    assert under.tripped is False
+    assert at.tripped is True
+    assert at.daily_loss_kill == Decimal("25")
+    assert at.daily_loss_kill_basis == "pct_of_nav"
+    assert at.nav_snapshot == Decimal("1000")
+
+
+def test_us_table_selected_usd_amount_reaches_generic_derivation() -> None:
+    table = PolicyTable(
+        market="us",
+        path=Path("/tmp/latest-us.json"),
+        payload={
+            "config": {
+                "new_entry_notional_usd": "300",
+                "averaging_k_levels": [],
+                "loss_guard_multiplier": "1",
+            },
+            "sizing": {},
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "insufficient_history": False,
+                    "previous_close": "100",
+                    "A_buy_side": {"buy_l1": {"price": "97"}, "buy_l2": None},
+                    "B_sell_side": {"sell_r1": None, "sell_r2": None},
+                }
+            ],
+        },
+        policy_table_hash="sha256:us",
+        artifact_sha256="sha256:artifact",
+        generated_at=NOW,
+        age=dt.timedelta(0),
+    )
+    state = _state(pnl=Decimal("0"), nav=Decimal("10000"))
+    result = derive_orders(
+        table=table,
+        state=state,
+        envelope=US_ALPACA_PAPER_LAB_ENVELOPE,
+        kill_switch=evaluate(state=state, envelope=US_ALPACA_PAPER_LAB_ENVELOPE),
+    )
+    assert len(result.orders) == 1
+    assert result.orders[0].notional == Decimal("300")
+
+
+def test_us_headers_have_exact_three_base_labels_plus_us_extra_but_not_shared_history() -> (
+    None
+):
+    labels = header_labels(lane=alpaca.LANE, extra=(CROSS_MARKET_TRANSFER_UNVALIDATED,))
+    assert labels[:3] == TRUST_LABELS
+    assert CROSS_MARKET_TRANSFER_UNVALIDATED in labels
+    assert all("SHARED_ACCOUNT_HISTORY" not in label for label in labels)
+    assert alpaca.LANE not in SHARED_HISTORY_ACCOUNTS
+
+
+def test_us_adapter_never_uses_kr_ledger_pending_exception_or_default_account_literal() -> (
+    None
+):
+    source = "\n".join(
+        path.read_text(encoding="utf-8") for path in US_PACKAGE.rglob("*.py")
+    )
+    assert "PendingUnreadable" not in source
+    assert "kis_mock_order_ledger" not in source
+    # The one literal ``alpaca_paper`` is the generic execution *venue* field
+    # required by the existing packet contract—not an account selector.  Every
+    # actual read/mutation call must still name the imported lab scope key.
+    tree = ast.parse(source)
+    default_account_mode_calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if (
+                keyword.arg == "account_mode"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value == "alpaca_paper"
+            ):
+                default_account_mode_calls.append(node.lineno)
+    assert default_account_mode_calls == []
+
+
+def test_us_ast_guard_allows_only_reviewed_alpaca_tooling_and_no_dynamic_bypass() -> (
+    None
+):
+    allowed = {
+        "app.core.symbol",
+        "app.mcp_server.tooling.alpaca_paper",
+        "app.mcp_server.tooling.alpaca_paper_ledger_read",
+        "app.services.alpaca_paper_account_modes",
+        "app.services.alpaca_paper_submit_service",
+        "app.services.paper_approval_packet",
+    }
+    guarded_prefixes = ("app.mcp_server.tooling.alpaca_paper", "app.services.alpaca")
+    files = [*US_PACKAGE.rglob("*.py"), RUNNER]
+    for path in files:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                modules = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                modules = [node.module]
+            else:
+                modules = []
+            for module in modules:
+                if module.startswith(guarded_prefixes):
+                    assert module in allowed, (
+                        f"{path}: unreviewed Alpaca import {module}"
+                    )
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Name) and node.func.id in {
+                "__import__",
+                "exec",
+                "eval",
+            }:
+                pytest.fail(f"{path}: dynamic bypass {node.func.id}()")
+            if (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "importlib"
+                and node.func.attr == "import_module"
+            ):
+                pytest.fail(f"{path}: dynamic import bypass")
+            if isinstance(node.func, ast.Name) and node.func.id == "getattr":
+                assert len(node.args) < 2 or isinstance(node.args[1], ast.Constant)
+
+
+def test_us_adapter_imports_only_read_only_alpaca_surfaces() -> None:
+    allowed_tool_imports = {
+        "app.mcp_server.tooling.alpaca_paper": {
+            "alpaca_paper_get_account",
+            "alpaca_paper_list_orders",
+            "alpaca_paper_list_positions",
+        },
+        "app.mcp_server.tooling.alpaca_paper_ledger_read": {
+            "alpaca_paper_ledger_list_recent",
+        },
+    }
+    for path in [*US_PACKAGE.rglob("*.py"), RUNNER]:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module is None:
+                continue
+            if node.module == "app.mcp_server.tooling.alpaca_paper_orders":
+                pytest.fail(f"{path}: US adapter may not import order mutation tooling")
+            allowed_names = allowed_tool_imports.get(node.module)
+            if allowed_names is not None:
+                imported = {alias.name for alias in node.names}
+                assert imported <= allowed_names, (
+                    f"{path}: non-read-only Alpaca tooling import "
+                    f"{sorted(imported - allowed_names)}"
+                )

--- a/tests/scripts/b0x/us/test_run_b0x_us_cycle_cli.py
+++ b/tests/scripts/b0x/us/test_run_b0x_us_cycle_cli.py
@@ -1,0 +1,22 @@
+"""US CLI cannot expose confirmation or envelope-shaped controls."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.b0x.envelope import US_ALPACA_PAPER_LAB_ENVELOPE, assert_envelope_locked
+from scripts.run_b0x_us_cycle import _parse_args
+
+pytestmark = pytest.mark.unit
+
+
+def test_us_cli_has_no_confirm_or_envelope_dial() -> None:
+    dests = set(vars(_parse_args([])))
+    assert "confirm" not in dests
+    envelope_fields = set(US_ALPACA_PAPER_LAB_ENVELOPE.canonical())
+    assert not (dests & envelope_fields)
+    forbidden = ("notional", "cap", "limit", "envelope", "max_", "loss")
+    assert [
+        dest for dest in dests if any(token in dest.lower() for token in forbidden)
+    ] == []
+    assert_envelope_locked(US_ALPACA_PAPER_LAB_ENVELOPE)


### PR DESCRIPTION
## Summary
- Adds a dedicated `alpaca_paper_lab` B0-X US cycle with US-RTH/table gates, v1.6 clause stamps, lab-only read truth, and evidence-based b0xu attribution.
- Enforces broker-derived envelope inputs (account-wide sellable positions, readable own open orders, daily distinct-symbol seed), USD sizing, NAV-ratio kill, and the US label/scope rules.
- Reuses existing read-only Alpaca tooling; production submit/cancel remains deliberately unwired and the scheduleless CLI has no confirmation flag.

## Safety
- No default `alpaca_paper` fallback, no KR ledger-pending exception, no `SHARED_ACCOUNT_HISTORY` US expansion, and no scheduler.
- Local fresh-truth attempt stopped at missing lab configuration before a broker response; it is recorded as unavailable rather than an empty account.
- This PR made no real order, preview call, cancellation, or broker mutation.

## Validation
- `uv run pytest -q tests/scripts/b0x/us` → 27 passed
- Related B0-X/policy-table/Alpaca boundary suite passed locally.
- `uv run ruff check app/ tests/ research/ scripts/`, `uv run ruff format --check app/ tests/ research/ scripts/`, and `uv run ty check app/ --error-on-warning` passed.