### PR TITLE
feat(research): DFC-2C-4H v2.2 contract golden (R3 BLOCKER close)

### DIFF
--- a/research_contracts/dfc_2c_4h_v21.py
+++ b/research_contracts/dfc_2c_4h_v21.py
@@ -1,0 +1,569 @@
+"""Immutable, offline-only DFC-2C-4H v2.1 re-registration.
+
+This is a new registration.  ``dfc_2c_4h_v2`` is intentionally not imported
+or modified: the 180-day v2 seal remains a historical predecessor.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final
+
+from research_contracts.canonical_hash import canonical_sha256
+
+__all__ = [
+    "CANONICAL_HASH",
+    "CONTRACT_ID",
+    "CONTRACT_SCHEMA_VERSION",
+    "MODULE_SOURCE_SHA256",
+    "B6_CONTROL",
+    "B7_RULE",
+    "IntegrityState",
+    "SymbolScore",
+    "BasketDecision",
+    "score_symbol",
+    "evaluate_basket",
+    "pit_rank",
+    "tail_threshold_q75",
+    "ofi_from_base_volumes",
+    "premium_index_close_from_complete_4h",
+    "select_universe",
+    "contract_as_machine_data",
+    "canonical_contract_hash",
+    "validate_evidence_manifest",
+    "OutcomeObservation",
+    "AdjudicationResult",
+    "absolute_log_return_bps",
+    "make_outcome_observation",
+    "stationary_block_bootstrap",
+    "adjudicate_outcomes",
+]
+
+# The literal is replaced by the source digest itself.  The verifier below
+# hashes the source with this one literal normalized, so the digest is not a
+# circular input.  Exactly one declaration is required.
+MODULE_SOURCE_SHA256: Final = (
+    "dbb8d9ec5c1004face8865b7324f946093084c4cb5be4aa99d8f62fc240c54c2"
+)
+HARNESS_SOURCE_SHA256: Final = (
+    "c081080e20b5a2d79e557f50d3fcd909c2a055e37f8e5291bf929c70b0fe46f4"
+)
+_SOURCE_DECLARATION = re.compile(
+    r'MODULE_SOURCE_SHA256: Final = \(\s*"([0-9a-f]{64})"\s*\)', re.DOTALL
+)
+
+CONTRACT_ID: Final = "DFC-2C-4H-v2.1"
+CONTRACT_SCHEMA_VERSION: Final = "dfc-2c-4h-v2.1.contract.v1"
+EPOCH_HOURS: Final = 4
+PIT_LOOKBACK: Final = 252
+TAIL_LOOKBACK: Final = 252
+TAIL_CONTEXT: Final = PIT_LOOKBACK + TAIL_LOOKBACK
+FIXED_QUANTILE_NUMERATOR: Final = 3
+FIXED_QUANTILE_DENOMINATOR: Final = 4
+EXPLORATION_WINDOW: Final = "2023-08-04T00:00:00Z/2026-08-03T00:00:00Z"
+BACKTEST_WINDOW: Final = "2021-05-02T00:00:00Z/2023-08-04T00:00:00Z"
+BACKTEST_CALENDAR_DAYS: Final = 824
+BACKTEST_SCHEDULED_EPOCHS: Final = 4_944
+WARMUP_START: Final = "2021-02-02T00:00:00Z"
+UNIVERSE_LOOKBACK_DAYS: Final = 30
+UNIVERSE_TOP_K: Final = 3
+SYMBOL_PRIORITY = MappingProxyType({})
+B6_CONTROL: Final = "A"
+B7_RULE: Final = {
+    "delta_threshold_bps": 5.0,
+    "bootstrap": "stationary_block_percentile",
+    "block_length_epochs": 24,
+    "repetitions": 10_000,
+    "confidence_level": 0.95,
+    "alpha": 0.05,
+    "minimum_candidate_epochs": 400,
+    "minimum_control_epochs": 400,
+    "power": {
+        "target": 0.80,
+        "planning_effect_bps": 5.0,
+        "planning_sd_bps": 25.0,
+        "groups": 2,
+        "epochs_per_group": 400,
+        "two_sided_alpha": 0.05,
+        "normal_approximation": True,
+    },
+    "success": "candidate_minus_matched_control CI lower bound > 5 bps and two-sided p < 0.05",
+    "failure": "CI upper bound <= 5 bps or two-sided p >= 0.05",
+    "indeterminate": "either arm has fewer than its minimum epochs",
+}
+
+
+def _assert_module_source_frozen() -> None:
+    source = inspect.getsource(inspect.getmodule(_assert_module_source_frozen))
+    matches = list(_SOURCE_DECLARATION.finditer(source))
+    if len(matches) != 1:
+        raise RuntimeError("v2.1 source digest declaration count must equal one")
+    declared = matches[0].group(1)
+    normalized = source[: matches[0].start(1)] + "0" * 64 + source[matches[0].end(1) :]
+    actual = hashlib.sha256(normalized.encode()).hexdigest()
+    if declared != actual:
+        raise RuntimeError(
+            f"DFC v2.1 implementation source hash mismatch: declared={declared}, actual={actual}"
+        )
+
+
+_assert_module_source_frozen()
+
+
+class IntegrityState(str):
+    COMPLETE = "complete"
+    GAP = "gap"
+    MISSING = "missing"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class _EvidenceBinding:
+    symbol: str
+    current_epoch_start_ms: int
+    kline_payload_hashes: tuple[str, ...]
+    premium_payload_hashes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _EpochFeatures:
+    symbol: str
+    integrity: str
+    current_ofi: float | None
+    current_premium_close: float | None
+    prior_ofi: tuple[float, ...]
+    prior_premium_close: tuple[float, ...]
+    prior_quote_volume_30d: float
+    evidence: _EvidenceBinding
+
+    def __post_init__(self) -> None:
+        if not self.symbol or self.symbol != self.symbol.upper():
+            raise ValueError("symbol must be a non-empty canonical uppercase symbol")
+        object.__setattr__(self, "prior_ofi", tuple(self.prior_ofi))
+        object.__setattr__(self, "prior_premium_close", tuple(self.prior_premium_close))
+        if not isinstance(self.evidence, _EvidenceBinding):
+            raise ValueError("features must carry an evidence binding")
+        if self.evidence.symbol != self.symbol or len(self.prior_ofi) != 504:
+            raise ValueError(
+                "features evidence binding does not match the feature window"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolScore:
+    symbol: str
+    composite: float
+    threshold: float
+    is_candidate: bool
+
+
+@dataclass(frozen=True, slots=True)
+class BasketDecision:
+    candidate_any: bool | None
+    winner: str | None
+    scores: tuple[SymbolScore, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeObservation:
+    candidate: bool
+    outcome_bps: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "outcome_bps", _finite("outcome_bps", self.outcome_bps)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AdjudicationResult:
+    status: str
+    delta_bps: float | None
+    ci_lower_bps: float | None
+    ci_upper_bps: float | None
+    p_value: float | None
+    bootstrap_deltas_bps: tuple[float, ...]
+
+
+def _finite(name: str, value: float | None) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(float(value))
+    ):
+        raise ValueError(f"{name} must be finite numeric")
+    return float(value)
+
+
+def _history(name: str, values: Sequence[float], expected: int) -> tuple[float, ...]:
+    if len(values) != expected:
+        raise ValueError(f"{name} must contain exactly {expected} values")
+    return tuple(_finite(f"{name}[{i}]", value) for i, value in enumerate(values))
+
+
+def ofi_from_base_volumes(
+    total_base_volume: float, taker_buy_base_volume: float
+) -> float:
+    total = _finite("total_base_volume", total_base_volume)
+    buy = _finite("taker_buy_base_volume", taker_buy_base_volume)
+    sell = total - buy
+    if total <= 0 or buy <= 0 or sell <= 0:
+        raise ValueError("complete Kline requires strictly positive base buy and sell")
+    return math.log(buy / sell)
+
+
+def premium_index_close_from_complete_4h(value: float, *, is_complete: bool) -> float:
+    if is_complete is not True:
+        raise ValueError("premium-index candle must be complete")
+    return _finite("premium_index_close", value)
+
+
+def pit_rank(current: float, prior_values: Sequence[float]) -> float:
+    current_value = _finite("current", current)
+    history = _history("prior_values", prior_values, 252)
+    return 2.0 * (sum(value <= current_value for value in history) / 252.0) - 1.0
+
+
+def _derived_prior_abs_composites(
+    prior_ofi: Sequence[float], prior_premium: Sequence[float]
+) -> tuple[float, ...]:
+    ofi = _history("prior_ofi", prior_ofi, 504)
+    premium = _history("prior_premium_close", prior_premium, 504)
+    result: list[float] = []
+    for index in range(252, 504):
+        result.append(
+            abs(
+                (
+                    pit_rank(ofi[index], ofi[index - 252 : index])
+                    + pit_rank(premium[index], premium[index - 252 : index])
+                )
+                / 2.0
+            )
+        )
+    return tuple(result)
+
+
+def tail_threshold_q75(
+    prior_ofi: Sequence[float], prior_premium_close: Sequence[float]
+) -> float:
+    ordered = sorted(_derived_prior_abs_composites(prior_ofi, prior_premium_close))
+    return ordered[188] + 0.25 * (ordered[189] - ordered[188])
+
+
+def score_symbol(inputs: _EpochFeatures) -> SymbolScore:
+    if not isinstance(inputs, _EpochFeatures) or not isinstance(
+        inputs.evidence, _EvidenceBinding
+    ):
+        raise TypeError("score_symbol accepts only evidence-bound epoch features")
+    if inputs.integrity != IntegrityState.COMPLETE:
+        raise ValueError("only complete symbol epochs can be scored")
+    ofi = _history("prior_ofi", inputs.prior_ofi, 504)
+    premium = _history("prior_premium_close", inputs.prior_premium_close, 504)
+    if inputs.current_ofi is None or inputs.current_premium_close is None:
+        raise ValueError("complete epoch is missing a current feature")
+    current_ofi = _finite("current_ofi", inputs.current_ofi)
+    current_premium = premium_index_close_from_complete_4h(
+        inputs.current_premium_close, is_complete=True
+    )
+    composite = (
+        pit_rank(current_ofi, ofi[-252:]) + pit_rank(current_premium, premium[-252:])
+    ) / 2.0
+    threshold = tail_threshold_q75(ofi, premium)
+    return SymbolScore(inputs.symbol, composite, threshold, abs(composite) >= threshold)
+
+
+def select_universe(prior_30d_quote_volume: Mapping[str, float]) -> tuple[str, ...]:
+    """Select top-K symbols using only the immediately prior 30 calendar days."""
+    if len(prior_30d_quote_volume) < 3:
+        raise ValueError("PIT universe requires at least three eligible symbols")
+    ranked = sorted(
+        (
+            (_finite(f"quote_volume[{symbol}]", volume), symbol)
+            for symbol, volume in prior_30d_quote_volume.items()
+        ),
+        key=lambda item: (-item[0], item[1]),
+    )
+    return tuple(symbol for _, symbol in ranked[:3])
+
+
+@dataclass(frozen=True, slots=True)
+class _PITBasket:
+    selected_symbols: tuple[str, ...]
+    inputs: tuple[_EpochFeatures, ...]
+
+
+def evaluate_basket(inputs: _PITBasket) -> BasketDecision:
+    if not isinstance(inputs, _PITBasket):
+        raise TypeError("evaluate_basket accepts only an evidence-bound PIT basket")
+    if len(inputs.selected_symbols) != 3 or len(inputs.inputs) != 3:
+        raise ValueError("basket requires exactly the three PIT-selected symbols")
+    if tuple(sorted(inputs.selected_symbols)) != tuple(
+        sorted(item.symbol for item in inputs.inputs)
+    ):
+        raise ValueError("basket symbols do not equal the PIT-selected universe")
+    if any(item.integrity != IntegrityState.COMPLETE for item in inputs.inputs):
+        return BasketDecision(None, None, ())
+    scores = tuple(
+        score_symbol(item)
+        for item in sorted(inputs.inputs, key=lambda item: item.symbol)
+    )
+    candidates = tuple(score for score in scores if score.is_candidate)
+    # Selection is identical in both arms: all symbols are eligible for the
+    # argmax, while candidate_any remains an arm label for the outcome layer.
+    winner = min(scores, key=lambda score: (-abs(score.composite), score.symbol))
+    return BasketDecision(bool(candidates), winner.symbol, scores)
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        raise ValueError("outcome arm must not be empty")
+    return sum(values) / len(values)
+
+
+def absolute_log_return_bps(entry_close: float, exit_close: float) -> float:
+    entry = _finite("entry_close", entry_close)
+    exit_value = _finite("exit_close", exit_close)
+    if entry <= 0 or exit_value <= 0:
+        raise ValueError("close prices must be strictly positive")
+    return abs(math.log(exit_value / entry)) * 10_000.0
+
+
+def make_outcome_observation(
+    candidate: bool, entry_close: float, exit_close: float
+) -> OutcomeObservation:
+    return OutcomeObservation(
+        candidate, absolute_log_return_bps(entry_close, exit_close)
+    )
+
+
+def stationary_block_bootstrap(
+    candidate_outcomes: Sequence[float],
+    control_outcomes: Sequence[float],
+    *,
+    repetitions: int = 10_000,
+    block_length_epochs: int = 24,
+    seed: int = 2_021_0502,
+) -> tuple[float, ...]:
+    """Deterministic circular stationary-block bootstrap of mean deltas."""
+    candidate = tuple(
+        _finite("candidate_outcome", value) for value in candidate_outcomes
+    )
+    control = tuple(_finite("control_outcome", value) for value in control_outcomes)
+    if not candidate or not control or repetitions <= 0 or block_length_epochs <= 0:
+        raise ValueError("bootstrap inputs must be positive and both arms non-empty")
+    import random
+
+    rng = random.Random(seed)
+    result: list[float] = []
+    probability = 1.0 / block_length_epochs
+    for _ in range(repetitions):
+        samples: list[float] = []
+        index = rng.randrange(len(candidate))
+        while len(samples) < len(candidate):
+            samples.append(candidate[index])
+            index = (
+                (index + 1) % len(candidate)
+                if rng.random() >= probability
+                else rng.randrange(len(candidate))
+            )
+        candidate_mean = _mean(samples)
+        samples = []
+        index = rng.randrange(len(control))
+        while len(samples) < len(control):
+            samples.append(control[index])
+            index = (
+                (index + 1) % len(control)
+                if rng.random() >= probability
+                else rng.randrange(len(control))
+            )
+        result.append(candidate_mean - _mean(samples))
+    return tuple(result)
+
+
+def adjudicate_outcomes(
+    observations: Sequence[OutcomeObservation],
+) -> AdjudicationResult:
+    candidate = tuple(item.outcome_bps for item in observations if item.candidate)
+    control = tuple(item.outcome_bps for item in observations if not item.candidate)
+    rule = B7_RULE
+    if (
+        len(candidate) < rule["minimum_candidate_epochs"]
+        or len(control) < rule["minimum_control_epochs"]
+    ):
+        return AdjudicationResult("indeterminate", None, None, None, None, ())
+    delta = _mean(candidate) - _mean(control)
+    bootstrap = stationary_block_bootstrap(
+        candidate,
+        control,
+        repetitions=rule["repetitions"],
+        block_length_epochs=rule["block_length_epochs"],
+    )
+    ordered = sorted(bootstrap)
+    lower = ordered[int((1.0 - rule["confidence_level"]) / 2.0 * len(ordered))]
+    upper = ordered[
+        int((1.0 - (1.0 - rule["confidence_level"]) / 2.0) * len(ordered)) - 1
+    ]
+    lower_tail = (sum(value <= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
+    upper_tail = (sum(value >= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
+    p_value = min(1.0, 2.0 * min(lower_tail, upper_tail))
+    status = (
+        "success"
+        if lower > rule["delta_threshold_bps"] and p_value < rule["alpha"]
+        else "failure"
+    )
+    return AdjudicationResult(status, delta, lower, upper, p_value, bootstrap)
+
+
+REQUIRED_EVIDENCE_FIELDS = frozenset(
+    {
+        "source_id",
+        "endpoint_host",
+        "endpoint_path",
+        "endpoint_version",
+        "symbol",
+        "interval",
+        "epoch_start_utc",
+        "epoch_end_utc",
+        "complete",
+        "gap_status",
+        "raw_payload_sha256",
+        "schema_version",
+    }
+)
+ALLOWED_SOURCE_IDS = frozenset(
+    {
+        "binance_usdm.klines_4h",
+        "binance_usdm.premium_index_klines_4h",
+    }
+)
+
+
+def validate_evidence_manifest(record: Mapping[str, Any]) -> None:
+    missing = sorted(
+        field for field in REQUIRED_EVIDENCE_FIELDS if record.get(field) in (None, "")
+    )
+    if missing:
+        raise ValueError(f"missing required evidence fields: {', '.join(missing)}")
+    if record["complete"] is not True or record["gap_status"] != "none":
+        raise ValueError("only complete, gap-free evidence is admissible")
+    if record["source_id"] not in ALLOWED_SOURCE_IDS:
+        raise ValueError("evidence source_id is not in the v2.1 allowlist")
+    digest = record["raw_payload_sha256"]
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(c not in "0123456789abcdef" for c in digest)
+    ):
+        raise ValueError("raw_payload_sha256 must be lowercase 64-character hex")
+
+
+def contract_as_machine_data() -> dict[str, Any]:
+    return {
+        "contract_schema_version": CONTRACT_SCHEMA_VERSION,
+        "contract_id": CONTRACT_ID,
+        "registration_mode": "independent_new_registration",
+        "predecessor_preservation": {
+            "v2_identity": "DFC-2C-4H-v2",
+            "v2_row_mutation": "forbidden",
+            "v2_seal_mutation": "forbidden",
+            "v2_supersede_or_hide": "forbidden",
+        },
+        "backtest_window": {
+            "warmup_start_utc": WARMUP_START,
+            "holdout_start_utc": BACKTEST_WINDOW.split("/")[0],
+            "holdout_end_utc_exclusive": BACKTEST_WINDOW.split("/")[1],
+            "calendar_days": BACKTEST_CALENDAR_DAYS,
+            "scheduled_epochs": BACKTEST_SCHEDULED_EPOCHS,
+            "selection_basis": "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop",
+        },
+        "exploration_isolation": {
+            "window": EXPLORATION_WINDOW,
+            "relationship": "no overlap remains in the adopted backtest window",
+            "excluded_overlap": "2023-08-04T00:00:00Z/2024-05-02T00:00:00Z",
+            "excluded_overlap_epochs": 1_632,
+            "excluded_overlap_percent_of_original_three_year_window": 24.817518248175183,
+            "exclusion_reason": "intentionally excluded to remove the design-validation feedback loop",
+            "artifact_use": "design_only_never_primary_or_promotion_evidence",
+        },
+        "universe": {
+            "rule": "At each UTC 4h epoch, rank all eligible USD-M perpetual symbols by quote volume summed over the immediately preceding 30 calendar days; select the top 3, ties by canonical uppercase symbol; use no future or exploration-selected symbol list",
+            "lookback_days": 30,
+            "top_k": 3,
+            "hardcoded_symbols": False,
+            "pit": True,
+        },
+        "features": {
+            "ofi": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume)) from complete Binance 4h Kline",
+            "premium": "complete Binance 4h premium-index candle close",
+            "deprecated": [
+                "quote_volume_proxy_as_signal",
+                "five_minute_premium_average",
+            ],
+            "complete_only": True,
+            "imputation": "forbidden",
+        },
+        "score": {
+            "pit_rank": "current-excluded 252-observation inclusive <= empirical rank",
+            "composite": "(ofi_rank + premium_rank) / 2",
+            "tail": "linear Q0.75 of 252 derived prior |C| values",
+            "tail_context_observations": 504,
+            "comparator": "abs(C) >= threshold",
+            "runtime_parameterization": "forbidden",
+        },
+        "basket": {
+            "candidate": "any",
+            "winner": "largest abs(C), ties by canonical symbol",
+            "maximum_events_per_epoch": 1,
+        },
+        "estimand": {
+            "name": "matched_selection_absolute_log_return_delta",
+            "outcome": "absolute_log_return_bps(entry_close, exit_close)",
+            "candidate_term": "mean outcome of argmax absolute composite on candidate epochs",
+            "control_term": "mean outcome of argmax absolute composite on non-candidate epochs",
+            "control_choice": "A",
+            "selection_symmetric": True,
+            "selection_implementation": "evaluate_basket argmax over all three scores",
+            "outcome_implementation": "make_outcome_observation",
+            "bootstrap_implementation": "stationary_block_bootstrap",
+            "adjudication_implementation": "adjudicate_outcomes",
+            "pnl_claim": False,
+        },
+        "adjudication": B7_RULE,
+        "implementation": {
+            "module": "research_contracts.dfc_2c_4h_v21",
+            "algorithm_version": "dfc-2c-4h-v2.1-algorithm.v1",
+            "module_source_sha256": MODULE_SOURCE_SHA256,
+            "harness_source_sha256": HARNESS_SOURCE_SHA256,
+            "io": "none",
+            "enforcement": "import-time source digest for contract and harness; edit causes RuntimeError",
+        },
+        "harness": {
+            "module": "research_contracts.dfc_2c_4h_v21_harness",
+            "read_only": True,
+            "alignment": "UTC 4h inner join",
+            "warmup": "504 prior observations plus current epoch",
+            "manifest_validation": "every epoch, fail-closed",
+            "forward_only": True,
+            "raw_payload_sha256": True,
+        },
+        "promotion_budget": {
+            "backtest_runs": 1,
+            "orders": 0,
+            "demo": 0,
+            "account": 0,
+            "automatic_promotion": False,
+        },
+    }
+
+
+def canonical_contract_hash() -> str:
+    return canonical_sha256(contract_as_machine_data())
+
+
+CANONICAL_HASH: Final = canonical_contract_hash()

--- a/research_contracts/dfc_2c_4h_v21_harness.py
+++ b/research_contracts/dfc_2c_4h_v21_harness.py
@@ -1,0 +1,389 @@
+"""Read-only PIT collection and alignment primitives for DFC v2.1.
+
+The harness is deliberately transport-agnostic: an operator supplies pages
+from the Binance read endpoints, and this module validates, hashes, sorts and
+aligns them.  It has no database, broker, scheduler, or order path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from research_contracts.dfc_2c_4h_v21 import (
+    IntegrityState,
+    _EpochFeatures,
+    _EvidenceBinding,
+    _PITBasket,
+    evaluate_basket,
+    ofi_from_base_volumes,
+    premium_index_close_from_complete_4h,
+    select_universe,
+    validate_evidence_manifest,
+)
+
+INTERVAL_MS = 4 * 60 * 60 * 1000
+REQUIRED_WARMUP_OBSERVATIONS = 504
+HARNESS_SOURCE_SHA256 = (
+    "c081080e20b5a2d79e557f50d3fcd909c2a055e37f8e5291bf929c70b0fe46f4"
+)
+_SOURCE_DECLARATION = re.compile(
+    r'HARNESS_SOURCE_SHA256 = \(\s*"([0-9a-f]{64})"\s*\)', re.DOTALL
+)
+
+
+class ForwardOnlyViolation(ValueError):
+    """Fail-closed timestamp violation with the shared #1774 reason code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+def _assert_harness_source_frozen() -> None:
+    source = inspect.getsource(inspect.getmodule(_assert_harness_source_frozen))
+    matches = list(_SOURCE_DECLARATION.finditer(source))
+    if len(matches) != 1:
+        raise RuntimeError("harness source digest declaration count must equal one")
+    declared = matches[0].group(1)
+    normalized = source[: matches[0].start(1)] + "0" * 64 + source[matches[0].end(1) :]
+    actual = hashlib.sha256(normalized.encode()).hexdigest()
+    if declared != actual:
+        raise RuntimeError(
+            f"DFC v2.1 harness source hash mismatch: declared={declared}, actual={actual}"
+        )
+
+
+_assert_harness_source_frozen()
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceCandle:
+    symbol: str
+    endpoint: str
+    epoch_start_ms: int
+    epoch_end_ms: int
+    payload: Sequence[Any] | Mapping[str, Any]
+    manifest: Mapping[str, Any]
+
+
+KLINE_MIN_FIELDS = 12
+KLINE_OPEN_TIME_INDEX = 0
+KLINE_CLOSE_INDEX = 4
+KLINE_CLOSE_TIME_INDEX = 6
+KLINE_QUOTE_VOLUME_INDEX = 7
+KLINE_TAKER_BUY_BASE_INDEX = 9
+PREMIUM_CLOSE_INDEX = 4
+
+
+def raw_payload_sha256(payload: Sequence[Any]) -> str:
+    if isinstance(payload, Mapping):
+        canonical_payload: Any = {
+            str(key): payload[key] for key in sorted(payload, key=str)
+        }
+    else:
+        canonical_payload = list(payload)
+    encoded = json.dumps(
+        canonical_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _numeric_payload_value(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"raw candle payload field {name} must be numeric")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"raw candle payload field {name} must be numeric") from exc
+    if not parsed == parsed or parsed in (float("inf"), float("-inf")):
+        raise ValueError(f"raw candle payload field {name} must be finite")
+    return parsed
+
+
+def validate_and_sort_candles(
+    candles: Iterable[EvidenceCandle],
+) -> tuple[EvidenceCandle, ...]:
+    materialized = tuple(candles)
+    for candle in materialized:
+        validate_evidence_manifest(candle.manifest)
+        if (
+            not isinstance(candle.payload, Mapping)
+            and len(candle.payload) < KLINE_MIN_FIELDS
+        ):
+            raise ValueError(
+                "raw candle payload has fewer than the required 12 Binance fields"
+            )
+        if candle.symbol != candle.manifest["symbol"]:
+            raise ValueError("candle symbol does not match evidence manifest")
+        if candle.epoch_end_ms - candle.epoch_start_ms != INTERVAL_MS:
+            raise ValueError("candle interval must be exactly one UTC 4h epoch")
+        if candle.manifest["raw_payload_sha256"] != raw_payload_sha256(candle.payload):
+            raise ValueError("raw payload hash does not match evidence manifest")
+        open_time = _actual_candle_value(
+            candle, mapping_key="open_time_ms", sequence_index=KLINE_OPEN_TIME_INDEX
+        )
+        close_time = _actual_candle_value(
+            candle, mapping_key="close_time_ms", sequence_index=KLINE_CLOSE_TIME_INDEX
+        )
+        if open_time != candle.epoch_start_ms:
+            raise ValueError("raw candle open time does not match epoch start")
+        if close_time != open_time + INTERVAL_MS - 1:
+            raise ValueError(
+                "raw candle closeTime must equal openTime + interval - 1ms"
+            )
+    ordered = tuple(
+        sorted(materialized, key=lambda c: (c.symbol, c.endpoint, c.epoch_start_ms))
+    )
+    for earlier, later in zip(ordered, ordered[1:], strict=False):
+        if (earlier.symbol, earlier.endpoint) == (
+            later.symbol,
+            later.endpoint,
+        ) and earlier.epoch_start_ms == later.epoch_start_ms:
+            raise ValueError("duplicate symbol/endpoint/epoch evidence")
+    return ordered
+
+
+def inner_align_4h(
+    klines: Iterable[EvidenceCandle], premium_klines: Iterable[EvidenceCandle]
+) -> tuple[tuple[str, int], ...]:
+    left = {(c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(klines)}
+    right = {
+        (c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(premium_klines)
+    }
+    return tuple(sorted(left & right))
+
+
+def assert_forward_only(
+    epoch_starts_ms: Sequence[int],
+    prior_windows: Mapping[int, Sequence[int]],
+    *,
+    prior_evidence: Mapping[int, Sequence[EvidenceCandle]],
+) -> None:
+    for epoch in epoch_starts_ms:
+        prior = tuple(prior_windows[epoch])
+        if len(prior) != REQUIRED_WARMUP_OBSERVATIONS:
+            raise ValueError("every epoch requires exactly 504 prior observations")
+        if any(previous >= epoch for previous in prior):
+            raise ValueError("prior window contains current or future epoch")
+        raw_prior = validate_and_sort_candles(prior_evidence[epoch])
+        starts = tuple(candle.epoch_start_ms for candle in raw_prior)
+        if starts != prior:
+            raise ValueError("prior window does not match raw evidence candle times")
+        if any(start >= epoch for start in starts):
+            raise ValueError("raw prior window contains current or future candle")
+
+
+def _actual_candle_value(
+    candle: EvidenceCandle, *, mapping_key: str, sequence_index: int
+) -> int:
+    """Read timestamps from the raw Binance candle payload, never the manifest."""
+    payload = candle.payload
+    if isinstance(payload, Mapping):
+        value = payload.get(mapping_key)
+    else:
+        if len(payload) < KLINE_MIN_FIELDS:
+            raise ValueError(
+                "raw candle payload has fewer than the required 12 Binance fields"
+            )
+        value = payload[sequence_index]
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"raw candle payload lacks numeric {mapping_key}")
+    return int(value)
+
+
+def assert_signal_execution_forward_only(
+    signal_bar: EvidenceCandle,
+    execution_bar: EvidenceCandle,
+    *,
+    declared_signal_close_time_ms: int,
+) -> None:
+    """Compare actual raw candle timestamps and fail closed on overlap.
+
+    Binance kline arrays use index 0 for open time and index 6 for close time.
+    Mapping payloads may use the corresponding explicit ``*_time_ms`` keys.
+    """
+    actual_signal_close = _actual_candle_value(
+        signal_bar, mapping_key="close_time_ms", sequence_index=6
+    )
+    actual_signal_end = actual_signal_close + 1
+    if (
+        actual_signal_close != declared_signal_close_time_ms
+        or actual_signal_end != signal_bar.epoch_end_ms
+    ):
+        raise ForwardOnlyViolation(
+            "SIGNAL_BAR_CLOSE_MISMATCH",
+            "declared/manifest signal close does not match the raw signal candle close_time",
+        )
+    actual_execution_start = _actual_candle_value(
+        execution_bar, mapping_key="open_time_ms", sequence_index=0
+    )
+    if actual_execution_start <= actual_signal_close:
+        raise ForwardOnlyViolation(
+            "NEXT_BAR_OVERLAPS_SIGNAL_BAR",
+            "execution candle starts before the raw signal candle closes",
+        )
+
+
+def build_epoch_manifest(
+    *,
+    source_id: str,
+    endpoint_host: str,
+    endpoint_path: str,
+    endpoint_version: str,
+    symbol: str,
+    epoch_start_utc: str,
+    epoch_end_utc: str,
+    payload: Sequence[Any],
+    schema_version: str,
+) -> dict[str, Any]:
+    """Create provenance only; this function performs no network or persistence."""
+    return {
+        "source_id": source_id,
+        "endpoint_host": endpoint_host,
+        "endpoint_path": endpoint_path,
+        "endpoint_version": endpoint_version,
+        "symbol": symbol,
+        "interval": "4h",
+        "epoch_start_utc": epoch_start_utc,
+        "epoch_end_utc": epoch_end_utc,
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": schema_version,
+    }
+
+
+def classify_alignment(ok: bool, *, missing: bool = False) -> IntegrityState:
+    if ok:
+        return IntegrityState.COMPLETE
+    return IntegrityState.MISSING if missing else IntegrityState.GAP
+
+
+def epoch_features_from_evidence(
+    *,
+    symbol: str,
+    current_kline: EvidenceCandle,
+    current_premium: EvidenceCandle,
+    prior_klines: Sequence[EvidenceCandle],
+    prior_premium: Sequence[EvidenceCandle],
+    prior_30d_quote_volume: float,
+) -> _EpochFeatures:
+    """Build scoring features exclusively from validated raw endpoint evidence."""
+    if current_kline.manifest.get("source_id") != "binance_usdm.klines_4h":
+        raise ValueError("current kline evidence has the wrong source")
+    if (
+        current_premium.manifest.get("source_id")
+        != "binance_usdm.premium_index_klines_4h"
+    ):
+        raise ValueError("current premium evidence has the wrong source")
+    if any(
+        c.manifest.get("source_id") != "binance_usdm.klines_4h" for c in prior_klines
+    ):
+        raise ValueError("prior kline evidence has the wrong source")
+    if any(
+        c.manifest.get("source_id") != "binance_usdm.premium_index_klines_4h"
+        for c in prior_premium
+    ):
+        raise ValueError("prior premium evidence has the wrong source")
+    klines = validate_and_sort_candles((*prior_klines, current_kline))
+    premiums = validate_and_sort_candles((*prior_premium, current_premium))
+    if len(klines) != 505 or len(premiums) != 505:
+        raise ValueError(
+            "feature construction requires exactly 504 prior candles and one current candle"
+        )
+    if any(c.symbol != symbol for c in (*klines, *premiums)):
+        raise ValueError("feature evidence symbol mismatch")
+    if current_kline.epoch_start_ms != current_premium.epoch_start_ms:
+        raise ValueError("current kline and premium candle are not aligned")
+    klines = tuple(sorted(klines, key=lambda candle: candle.epoch_start_ms))
+    premiums = tuple(sorted(premiums, key=lambda candle: candle.epoch_start_ms))
+    if klines[-1] != current_kline or premiums[-1] != current_premium:
+        raise ValueError(
+            "current evidence must be the latest candle in the feature window"
+        )
+    expected_starts = tuple(
+        current_kline.epoch_start_ms - INTERVAL_MS * offset
+        for offset in range(504, -1, -1)
+    )
+    if tuple(c.epoch_start_ms for c in klines) != expected_starts:
+        raise ValueError(
+            "kline feature window must be contiguous and strictly prior to current"
+        )
+    if tuple(c.epoch_start_ms for c in premiums) != expected_starts:
+        raise ValueError(
+            "premium feature window must be contiguous and strictly prior to current"
+        )
+    if tuple(c.epoch_start_ms for c in klines) != tuple(
+        c.epoch_start_ms for c in premiums
+    ):
+        raise ValueError("kline and premium prior windows are not aligned")
+    ofi: list[float] = []
+    premium: list[float] = []
+    for candle in klines:
+        payload = candle.payload
+        if isinstance(payload, Mapping):
+            total = payload.get("volume")
+            buy = payload.get("taker_buy_base_volume")
+        else:
+            total = payload[5]
+            buy = payload[KLINE_TAKER_BUY_BASE_INDEX]
+        ofi.append(
+            ofi_from_base_volumes(
+                _numeric_payload_value(total, name="volume"),
+                _numeric_payload_value(buy, name="taker_buy_base_volume"),
+            )
+        )
+    for candle in premiums:
+        value = (
+            candle.payload.get("close")
+            if isinstance(candle.payload, Mapping)
+            else candle.payload[PREMIUM_CLOSE_INDEX]
+        )
+        premium.append(
+            premium_index_close_from_complete_4h(
+                _numeric_payload_value(value, name="premium_close"), is_complete=True
+            )
+        )
+    return _EpochFeatures(
+        symbol=symbol,
+        integrity=IntegrityState.COMPLETE,
+        current_ofi=ofi[-1],
+        current_premium_close=premium[-1],
+        prior_ofi=tuple(ofi[:-1]),
+        prior_premium_close=tuple(premium[:-1]),
+        prior_quote_volume_30d=_numeric_payload_value(
+            prior_30d_quote_volume, name="prior_30d_quote_volume"
+        ),
+        evidence=_EvidenceBinding(
+            symbol=symbol,
+            current_epoch_start_ms=current_kline.epoch_start_ms,
+            kline_payload_hashes=tuple(
+                c.manifest["raw_payload_sha256"] for c in klines
+            ),
+            premium_payload_hashes=tuple(
+                c.manifest["raw_payload_sha256"] for c in premiums
+            ),
+        ),
+    )
+
+
+def evaluate_epoch_basket(
+    prior_30d_quote_volume: Mapping[str, float], inputs: Mapping[str, _EpochFeatures]
+):
+    """Wire the PIT universe selection into the basket scorer for every epoch."""
+    selected = select_universe(prior_30d_quote_volume)
+    if tuple(sorted(inputs)) != tuple(sorted(selected)):
+        raise ValueError("basket symbols do not equal the epoch PIT-selected universe")
+    return evaluate_basket(
+        _PITBasket(selected, tuple(inputs[symbol] for symbol in sorted(inputs)))
+    )

--- a/research_contracts/dfc_2c_4h_v22.py
+++ b/research_contracts/dfc_2c_4h_v22.py
@@ -1,0 +1,854 @@
+"""Immutable, offline-only DFC-2C-4H v2.2 re-registration.
+
+Closes the v2.1 R3 outcome-layer BLOCKER (free bool/price inputs) and unifies
+adjudication literals per NW-F7.  ``dfc_2c_4h_v21`` / ``dfc_2c_4h_v2`` are
+intentionally not imported or modified: both remain provenance predecessors.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final
+
+from research_contracts.canonical_hash import canonical_sha256
+
+__all__ = [
+    "CANONICAL_HASH",
+    "CONTRACT_ID",
+    "CONTRACT_SCHEMA_VERSION",
+    "MODULE_SOURCE_SHA256",
+    "B6_CONTROL",
+    "B7_RULE",
+    "IntegrityState",
+    "SymbolScore",
+    "BasketDecision",
+    "score_symbol",
+    "evaluate_basket",
+    "pit_rank",
+    "tail_threshold_q75",
+    "ofi_from_base_volumes",
+    "premium_index_close_from_complete_4h",
+    "select_universe",
+    "contract_as_machine_data",
+    "canonical_contract_hash",
+    "validate_evidence_manifest",
+    "OutcomeObservation",
+    "OutcomeEpochRecord",
+    "AdjudicationResult",
+    "absolute_log_return_bps",
+    "extract_kline_close_evidence",
+    "make_outcome_epoch_record",
+    "stationary_block_bootstrap",
+    "adjudicate_outcomes",
+    "INTERVAL_MS",
+    "RUN_INVALID_OUTCOME_EVIDENCE",
+    "STATUS_PASS",
+    "STATUS_INCONCLUSIVE",
+    "STATUS_FALSIFIED",
+    "STATUS_RUN_INVALID",
+]
+
+# The literal is replaced by the source digest itself.  The verifier below
+# hashes the source with this one literal normalized, so the digest is not a
+# circular input.  Exactly one declaration is required.
+MODULE_SOURCE_SHA256: Final = (
+    "86efaf3db506f77981622b490465ab91b13c08825ff25465c81af72c687d26e9"
+)
+HARNESS_SOURCE_SHA256: Final = (
+    "762b5884e0e1bba4dbd4b6270b17dfe695047b38d6bd1c5b3717f9fba25d9386"
+)
+_SOURCE_DECLARATION = re.compile(
+    r'MODULE_SOURCE_SHA256: Final = \(\s*"([0-9a-f]{64})"\s*\)', re.DOTALL
+)
+
+CONTRACT_ID: Final = "DFC-2C-4H-v2.2"
+CONTRACT_SCHEMA_VERSION: Final = "dfc-2c-4h-v2.2.contract.v1"
+EPOCH_HOURS: Final = 4
+INTERVAL_MS: Final = 4 * 60 * 60 * 1000
+PIT_LOOKBACK: Final = 252
+TAIL_LOOKBACK: Final = 252
+TAIL_CONTEXT: Final = PIT_LOOKBACK + TAIL_LOOKBACK
+FIXED_QUANTILE_NUMERATOR: Final = 3
+FIXED_QUANTILE_DENOMINATOR: Final = 4
+EXPLORATION_WINDOW: Final = "2023-08-04T00:00:00Z/2026-08-03T00:00:00Z"
+BACKTEST_WINDOW: Final = "2021-05-02T00:00:00Z/2023-08-04T00:00:00Z"
+BACKTEST_CALENDAR_DAYS: Final = 824
+BACKTEST_SCHEDULED_EPOCHS: Final = 4_944
+WARMUP_START: Final = "2021-02-02T00:00:00Z"
+UNIVERSE_LOOKBACK_DAYS: Final = 30
+UNIVERSE_TOP_K: Final = 3
+SYMBOL_PRIORITY = MappingProxyType({})
+B6_CONTROL: Final = "A"
+
+# NW-F7 verdict literals (exact).
+STATUS_PASS: Final = "PASS"
+STATUS_INCONCLUSIVE: Final = "INCONCLUSIVE"
+STATUS_FALSIFIED: Final = "FALSIFIED"
+STATUS_RUN_INVALID: Final = "RUN_INVALID"
+RUN_INVALID_OUTCOME_EVIDENCE: Final = "RUN_INVALID_OUTCOME_EVIDENCE"
+
+# NW-F7: power claim removed — planning_sd cannot be validated without data
+# contact; do not ship an unverifiable power claim.
+B7_RULE: Final = {
+    "delta_threshold_bps": 5.0,
+    "bootstrap": "stationary_block_percentile",
+    "block_length_epochs": 24,
+    "repetitions": 10_000,
+    "confidence_level": 0.95,
+    "alpha": 0.05,
+    "minimum_candidate_epochs": 400,
+    "minimum_control_epochs": 400,
+    "historical_validation_runs": 1,
+    "pass": (
+        "candidate_minus_control 95% CI lower bound > 5 bps AND two-sided p < 0.05"
+    ),
+    "falsified": "negation of PASS (when not INCONCLUSIVE and not RUN_INVALID)",
+    "inconclusive": "either arm has fewer than its minimum epochs",
+    "run_invalid": "input/evidence violation — highest precedence",
+    "pass_falsified_unification": "PASS condition negation = FALSIFIED",
+    "post_result_threshold_horizon_universe_change": "forbidden",
+}
+
+V21_PROVENANCE: Final = {
+    "identity": "DFC-2C-4H-v2.1",
+    "module": "research_contracts.dfc_2c_4h_v21",
+    "source_commit": "9f605139044605a5f31e5ee3da77133924126197",
+    "source_branch": "origin/feature/DFC-2C-4H-v21-pr",
+    "blob_port": "byte-identical; not whole-branch merge",
+    "mutation": "forbidden",
+}
+
+
+def _assert_module_source_frozen() -> None:
+    source = inspect.getsource(inspect.getmodule(_assert_module_source_frozen))
+    matches = list(_SOURCE_DECLARATION.finditer(source))
+    if len(matches) != 1:
+        raise RuntimeError("v2.2 source digest declaration count must equal one")
+    declared = matches[0].group(1)
+    normalized = source[: matches[0].start(1)] + "0" * 64 + source[matches[0].end(1) :]
+    actual = hashlib.sha256(normalized.encode()).hexdigest()
+    if declared != actual:
+        raise RuntimeError(
+            f"DFC v2.2 implementation source hash mismatch: declared={declared}, actual={actual}"
+        )
+
+
+_assert_module_source_frozen()
+
+
+class IntegrityState(str):
+    COMPLETE = "complete"
+    GAP = "gap"
+    MISSING = "missing"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class _EvidenceBinding:
+    symbol: str
+    current_epoch_start_ms: int
+    kline_payload_hashes: tuple[str, ...]
+    premium_payload_hashes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _EpochFeatures:
+    symbol: str
+    integrity: str
+    current_ofi: float | None
+    current_premium_close: float | None
+    prior_ofi: tuple[float, ...]
+    prior_premium_close: tuple[float, ...]
+    prior_quote_volume_30d: float
+    evidence: _EvidenceBinding
+
+    def __post_init__(self) -> None:
+        if not self.symbol or self.symbol != self.symbol.upper():
+            raise ValueError("symbol must be a non-empty canonical uppercase symbol")
+        object.__setattr__(self, "prior_ofi", tuple(self.prior_ofi))
+        object.__setattr__(self, "prior_premium_close", tuple(self.prior_premium_close))
+        if not isinstance(self.evidence, _EvidenceBinding):
+            raise ValueError("features must carry an evidence binding")
+        if self.evidence.symbol != self.symbol or len(self.prior_ofi) != 504:
+            raise ValueError(
+                "features evidence binding does not match the feature window"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolScore:
+    symbol: str
+    composite: float
+    threshold: float
+    is_candidate: bool
+
+
+@dataclass(frozen=True, slots=True)
+class BasketDecision:
+    candidate_any: bool | None
+    winner: str | None
+    scores: tuple[SymbolScore, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _KlineCloseEvidence:
+    """Close price bound to a validated raw kline payload (not a free float)."""
+
+    symbol: str
+    epoch_start_ms: int
+    close: float
+    payload_sha256: str
+    source_id: str
+    complete: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _OutcomeBinding:
+    """Proves an outcome was derived from BasketDecision + raw kline evidence."""
+
+    winner_symbol: str
+    signal_epoch_start_ms: int
+    entry_payload_sha256: str
+    exit_payload_sha256: str
+    decision_candidate_any: bool
+    decision_winner: str
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeObservation:
+    """Arm label and bps are never free inputs — only factory-produced bindings."""
+
+    candidate: bool
+    outcome_bps: float
+    binding: _OutcomeBinding
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding, _OutcomeBinding):
+            raise TypeError(
+                "OutcomeObservation requires an evidence binding from make_outcome_epoch_record"
+            )
+        object.__setattr__(
+            self, "outcome_bps", _finite("outcome_bps", self.outcome_bps)
+        )
+        if self.candidate != self.binding.decision_candidate_any:
+            raise ValueError("arm label must equal BasketDecision.candidate_any")
+        if self.binding.decision_winner != self.binding.winner_symbol:
+            raise ValueError("winner symbol must equal BasketDecision.winner")
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeEpochRecord:
+    """One signal-epoch outcome slot.
+
+    Missing/incomplete next bar is recorded as RUN_INVALID_OUTCOME_EVIDENCE —
+    rows must not be silently deleted.
+    """
+
+    status: str
+    observation: OutcomeObservation | None = None
+
+    def __post_init__(self) -> None:
+        if self.status == "ok":
+            if self.observation is None:
+                raise ValueError("ok outcome record requires an observation")
+            if not isinstance(self.observation, OutcomeObservation):
+                raise TypeError("observation must be OutcomeObservation")
+        elif self.status == RUN_INVALID_OUTCOME_EVIDENCE:
+            if self.observation is not None:
+                raise ValueError("invalid outcome record must not carry an observation")
+        else:
+            raise ValueError(f"unknown outcome epoch status: {self.status}")
+
+
+@dataclass(frozen=True, slots=True)
+class AdjudicationResult:
+    status: str
+    delta_bps: float | None
+    ci_lower_bps: float | None
+    ci_upper_bps: float | None
+    p_value: float | None
+    bootstrap_deltas_bps: tuple[float, ...]
+    reason_code: str | None = None
+
+
+def _finite(name: str, value: float | None) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not math.isfinite(float(value))
+    ):
+        raise ValueError(f"{name} must be finite numeric")
+    return float(value)
+
+
+def _history(name: str, values: Sequence[float], expected: int) -> tuple[float, ...]:
+    if len(values) != expected:
+        raise ValueError(f"{name} must contain exactly {expected} values")
+    return tuple(_finite(f"{name}[{i}]", value) for i, value in enumerate(values))
+
+
+def ofi_from_base_volumes(
+    total_base_volume: float, taker_buy_base_volume: float
+) -> float:
+    total = _finite("total_base_volume", total_base_volume)
+    buy = _finite("taker_buy_base_volume", taker_buy_base_volume)
+    sell = total - buy
+    if total <= 0 or buy <= 0 or sell <= 0:
+        raise ValueError("complete Kline requires strictly positive base buy and sell")
+    return math.log(buy / sell)
+
+
+def premium_index_close_from_complete_4h(value: float, *, is_complete: bool) -> float:
+    if is_complete is not True:
+        raise ValueError("premium-index candle must be complete")
+    return _finite("premium_index_close", value)
+
+
+def pit_rank(current: float, prior_values: Sequence[float]) -> float:
+    current_value = _finite("current", current)
+    history = _history("prior_values", prior_values, 252)
+    return 2.0 * (sum(value <= current_value for value in history) / 252.0) - 1.0
+
+
+def _derived_prior_abs_composites(
+    prior_ofi: Sequence[float], prior_premium: Sequence[float]
+) -> tuple[float, ...]:
+    ofi = _history("prior_ofi", prior_ofi, 504)
+    premium = _history("prior_premium_close", prior_premium, 504)
+    result: list[float] = []
+    for index in range(252, 504):
+        result.append(
+            abs(
+                (
+                    pit_rank(ofi[index], ofi[index - 252 : index])
+                    + pit_rank(premium[index], premium[index - 252 : index])
+                )
+                / 2.0
+            )
+        )
+    return tuple(result)
+
+
+def tail_threshold_q75(
+    prior_ofi: Sequence[float], prior_premium_close: Sequence[float]
+) -> float:
+    ordered = sorted(_derived_prior_abs_composites(prior_ofi, prior_premium_close))
+    return ordered[188] + 0.25 * (ordered[189] - ordered[188])
+
+
+def score_symbol(inputs: _EpochFeatures) -> SymbolScore:
+    if not isinstance(inputs, _EpochFeatures) or not isinstance(
+        inputs.evidence, _EvidenceBinding
+    ):
+        raise TypeError("score_symbol accepts only evidence-bound epoch features")
+    if inputs.integrity != IntegrityState.COMPLETE:
+        raise ValueError("only complete symbol epochs can be scored")
+    ofi = _history("prior_ofi", inputs.prior_ofi, 504)
+    premium = _history("prior_premium_close", inputs.prior_premium_close, 504)
+    if inputs.current_ofi is None or inputs.current_premium_close is None:
+        raise ValueError("complete epoch is missing a current feature")
+    current_ofi = _finite("current_ofi", inputs.current_ofi)
+    current_premium = premium_index_close_from_complete_4h(
+        inputs.current_premium_close, is_complete=True
+    )
+    composite = (
+        pit_rank(current_ofi, ofi[-252:]) + pit_rank(current_premium, premium[-252:])
+    ) / 2.0
+    threshold = tail_threshold_q75(ofi, premium)
+    return SymbolScore(inputs.symbol, composite, threshold, abs(composite) >= threshold)
+
+
+def select_universe(prior_30d_quote_volume: Mapping[str, float]) -> tuple[str, ...]:
+    """Select top-K symbols using only the immediately prior 30 calendar days."""
+    if len(prior_30d_quote_volume) < 3:
+        raise ValueError("PIT universe requires at least three eligible symbols")
+    ranked = sorted(
+        (
+            (_finite(f"quote_volume[{symbol}]", volume), symbol)
+            for symbol, volume in prior_30d_quote_volume.items()
+        ),
+        key=lambda item: (-item[0], item[1]),
+    )
+    return tuple(symbol for _, symbol in ranked[:3])
+
+
+@dataclass(frozen=True, slots=True)
+class _PITBasket:
+    selected_symbols: tuple[str, ...]
+    inputs: tuple[_EpochFeatures, ...]
+
+
+def evaluate_basket(inputs: _PITBasket) -> BasketDecision:
+    if not isinstance(inputs, _PITBasket):
+        raise TypeError("evaluate_basket accepts only an evidence-bound PIT basket")
+    if len(inputs.selected_symbols) != 3 or len(inputs.inputs) != 3:
+        raise ValueError("basket requires exactly the three PIT-selected symbols")
+    if tuple(sorted(inputs.selected_symbols)) != tuple(
+        sorted(item.symbol for item in inputs.inputs)
+    ):
+        raise ValueError("basket symbols do not equal the PIT-selected universe")
+    if any(item.integrity != IntegrityState.COMPLETE for item in inputs.inputs):
+        return BasketDecision(None, None, ())
+    scores = tuple(
+        score_symbol(item)
+        for item in sorted(inputs.inputs, key=lambda item: item.symbol)
+    )
+    candidates = tuple(score for score in scores if score.is_candidate)
+    # Selection is identical in both arms: all symbols are eligible for the
+    # argmax, while candidate_any remains an arm label for the outcome layer.
+    winner = min(scores, key=lambda score: (-abs(score.composite), score.symbol))
+    return BasketDecision(bool(candidates), winner.symbol, scores)
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        raise ValueError("outcome arm must not be empty")
+    return sum(values) / len(values)
+
+
+def absolute_log_return_bps(entry_close: float, exit_close: float) -> float:
+    entry = _finite("entry_close", entry_close)
+    exit_value = _finite("exit_close", exit_close)
+    if entry <= 0 or exit_value <= 0:
+        raise ValueError("close prices must be strictly positive")
+    return abs(math.log(exit_value / entry)) * 10_000.0
+
+
+def _payload_sha256(payload: Sequence[Any] | Mapping[str, Any]) -> str:
+    import json
+
+    if isinstance(payload, Mapping):
+        canonical_payload: Any = {
+            str(key): payload[key] for key in sorted(payload, key=str)
+        }
+    else:
+        canonical_payload = list(payload)
+    encoded = json.dumps(
+        canonical_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _numeric_payload_value(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"raw candle payload field {name} must be numeric")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"raw candle payload field {name} must be numeric") from exc
+    if not math.isfinite(parsed):
+        raise ValueError(f"raw candle payload field {name} must be finite")
+    return parsed
+
+
+def extract_kline_close_evidence(
+    *,
+    symbol: str,
+    epoch_start_ms: int,
+    payload: Sequence[Any] | Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> _KlineCloseEvidence:
+    """Bind a close price to raw kline evidence. Free float close is not accepted."""
+    validate_evidence_manifest(manifest)
+    if manifest.get("symbol") != symbol:
+        raise ValueError("kline close evidence symbol does not match manifest")
+    if manifest.get("source_id") != "binance_usdm.klines_4h":
+        raise ValueError("outcome close evidence requires binance_usdm.klines_4h")
+    digest = _payload_sha256(payload)
+    if manifest.get("raw_payload_sha256") != digest:
+        raise ValueError("raw payload hash does not match evidence manifest")
+    if isinstance(payload, Mapping):
+        close_raw = payload.get("close")
+        open_time_raw = payload.get("open_time_ms")
+    else:
+        if len(payload) < 12:
+            raise ValueError(
+                "raw candle payload has fewer than the required 12 Binance fields"
+            )
+        close_raw = payload[4]
+        open_time_raw = payload[0]
+    close = _numeric_payload_value(close_raw, name="close")
+    open_time = int(_numeric_payload_value(open_time_raw, name="open_time_ms"))
+    if open_time != epoch_start_ms:
+        raise ValueError("raw candle open time does not match epoch start")
+    if close <= 0:
+        raise ValueError("close prices must be strictly positive")
+    complete = manifest.get("complete") is True and manifest.get("gap_status") == "none"
+    return _KlineCloseEvidence(
+        symbol=symbol,
+        epoch_start_ms=epoch_start_ms,
+        close=close,
+        payload_sha256=digest,
+        source_id=str(manifest["source_id"]),
+        complete=complete,
+    )
+
+
+def make_outcome_epoch_record(
+    decision: BasketDecision,
+    *,
+    entry: _KlineCloseEvidence,
+    next_bar: _KlineCloseEvidence | None,
+) -> OutcomeEpochRecord:
+    """NW-F4: arm from decision.candidate_any, symbol from decision.winner.
+
+    Outcome bps = absolute log return of winner's completed t kline close to the
+    immediately next completed 4h kline close.  Both prices come only from
+    extract_kline_close_evidence (raw payload).  Free bool / free price inputs
+    are not accepted.  Missing or incomplete next bar → RUN_INVALID_OUTCOME_EVIDENCE
+    (row deletion is forbidden).
+    """
+    if not isinstance(decision, BasketDecision):
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    if not isinstance(entry, _KlineCloseEvidence):
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    if decision.candidate_any is None or decision.winner is None:
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    if not entry.complete or entry.source_id != "binance_usdm.klines_4h":
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    if entry.symbol != decision.winner:
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    if next_bar is None:
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    if not isinstance(next_bar, _KlineCloseEvidence):
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    if (
+        not next_bar.complete
+        or next_bar.source_id != "binance_usdm.klines_4h"
+        or next_bar.symbol != decision.winner
+        or next_bar.epoch_start_ms != entry.epoch_start_ms + INTERVAL_MS
+    ):
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    try:
+        bps = absolute_log_return_bps(entry.close, next_bar.close)
+    except ValueError:
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    observation = OutcomeObservation(
+        candidate=bool(decision.candidate_any),
+        outcome_bps=bps,
+        binding=_OutcomeBinding(
+            winner_symbol=decision.winner,
+            signal_epoch_start_ms=entry.epoch_start_ms,
+            entry_payload_sha256=entry.payload_sha256,
+            exit_payload_sha256=next_bar.payload_sha256,
+            decision_candidate_any=bool(decision.candidate_any),
+            decision_winner=decision.winner,
+        ),
+    )
+    return OutcomeEpochRecord(status="ok", observation=observation)
+
+
+def stationary_block_bootstrap(
+    candidate_outcomes: Sequence[float],
+    control_outcomes: Sequence[float],
+    *,
+    repetitions: int = 10_000,
+    block_length_epochs: int = 24,
+    seed: int = 2_021_0502,
+) -> tuple[float, ...]:
+    """Deterministic circular stationary-block bootstrap of mean deltas."""
+    candidate = tuple(
+        _finite("candidate_outcome", value) for value in candidate_outcomes
+    )
+    control = tuple(_finite("control_outcome", value) for value in control_outcomes)
+    if not candidate or not control or repetitions <= 0 or block_length_epochs <= 0:
+        raise ValueError("bootstrap inputs must be positive and both arms non-empty")
+    import random
+
+    rng = random.Random(seed)
+    result: list[float] = []
+    probability = 1.0 / block_length_epochs
+    for _ in range(repetitions):
+        samples: list[float] = []
+        index = rng.randrange(len(candidate))
+        while len(samples) < len(candidate):
+            samples.append(candidate[index])
+            index = (
+                (index + 1) % len(candidate)
+                if rng.random() >= probability
+                else rng.randrange(len(candidate))
+            )
+        candidate_mean = _mean(samples)
+        samples = []
+        index = rng.randrange(len(control))
+        while len(samples) < len(control):
+            samples.append(control[index])
+            index = (
+                (index + 1) % len(control)
+                if rng.random() >= probability
+                else rng.randrange(len(control))
+            )
+        result.append(candidate_mean - _mean(samples))
+    return tuple(result)
+
+
+def adjudicate_outcomes(
+    records: Sequence[OutcomeEpochRecord],
+) -> AdjudicationResult:
+    """NW-F7 adjudication with RUN_INVALID highest precedence.
+
+    Order (code-enforced):
+      1. any input/evidence violation → RUN_INVALID
+      2. sample shortfall → INCONCLUSIVE
+      3. PASS iff CI lower > 5bp AND two-sided p < 0.05; else FALSIFIED
+         (PASS condition negation = FALSIFIED)
+    """
+    # 1) RUN_INVALID first — type/evidence violations before any other verdict.
+    if not isinstance(records, Sequence) or isinstance(records, (str, bytes)):
+        return AdjudicationResult(
+            STATUS_RUN_INVALID, None, None, None, None, (), "RUN_INVALID_INPUT"
+        )
+    materialized = tuple(records)
+    for item in materialized:
+        if not isinstance(item, OutcomeEpochRecord):
+            return AdjudicationResult(
+                STATUS_RUN_INVALID,
+                None,
+                None,
+                None,
+                None,
+                (),
+                "RUN_INVALID_INPUT",
+            )
+        if item.status != "ok":
+            return AdjudicationResult(
+                STATUS_RUN_INVALID,
+                None,
+                None,
+                None,
+                None,
+                (),
+                item.status
+                if item.status.startswith("RUN_INVALID")
+                else RUN_INVALID_OUTCOME_EVIDENCE,
+            )
+        if item.observation is None or not isinstance(
+            item.observation, OutcomeObservation
+        ):
+            return AdjudicationResult(
+                STATUS_RUN_INVALID,
+                None,
+                None,
+                None,
+                None,
+                (),
+                RUN_INVALID_OUTCOME_EVIDENCE,
+            )
+        if not isinstance(item.observation.binding, _OutcomeBinding):
+            return AdjudicationResult(
+                STATUS_RUN_INVALID,
+                None,
+                None,
+                None,
+                None,
+                (),
+                RUN_INVALID_OUTCOME_EVIDENCE,
+            )
+
+    observations = tuple(item.observation for item in materialized)
+    assert all(obs is not None for obs in observations)
+    candidate = tuple(item.outcome_bps for item in observations if item.candidate)
+    control = tuple(item.outcome_bps for item in observations if not item.candidate)
+    rule = B7_RULE
+
+    # 2) INCONCLUSIVE on sample shortfall.
+    if (
+        len(candidate) < rule["minimum_candidate_epochs"]
+        or len(control) < rule["minimum_control_epochs"]
+    ):
+        return AdjudicationResult(
+            STATUS_INCONCLUSIVE, None, None, None, None, (), "SAMPLE_SHORTFALL"
+        )
+
+    # 3) PASS vs FALSIFIED (FALSIFIED = negation of PASS).
+    delta = _mean(candidate) - _mean(control)
+    bootstrap = stationary_block_bootstrap(
+        candidate,
+        control,
+        repetitions=rule["repetitions"],
+        block_length_epochs=rule["block_length_epochs"],
+    )
+    ordered = sorted(bootstrap)
+    lower = ordered[int((1.0 - rule["confidence_level"]) / 2.0 * len(ordered))]
+    upper = ordered[
+        int((1.0 - (1.0 - rule["confidence_level"]) / 2.0) * len(ordered)) - 1
+    ]
+    lower_tail = (sum(value <= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
+    upper_tail = (sum(value >= 0.0 for value in bootstrap) + 1) / (len(bootstrap) + 1)
+    p_value = min(1.0, 2.0 * min(lower_tail, upper_tail))
+    pass_condition = lower > rule["delta_threshold_bps"] and p_value < rule["alpha"]
+    status = STATUS_PASS if pass_condition else STATUS_FALSIFIED
+    return AdjudicationResult(status, delta, lower, upper, p_value, bootstrap, None)
+
+
+REQUIRED_EVIDENCE_FIELDS = frozenset(
+    {
+        "source_id",
+        "endpoint_host",
+        "endpoint_path",
+        "endpoint_version",
+        "symbol",
+        "interval",
+        "epoch_start_utc",
+        "epoch_end_utc",
+        "complete",
+        "gap_status",
+        "raw_payload_sha256",
+        "schema_version",
+    }
+)
+ALLOWED_SOURCE_IDS = frozenset(
+    {
+        "binance_usdm.klines_4h",
+        "binance_usdm.premium_index_klines_4h",
+    }
+)
+
+
+def validate_evidence_manifest(record: Mapping[str, Any]) -> None:
+    missing = sorted(
+        field for field in REQUIRED_EVIDENCE_FIELDS if record.get(field) in (None, "")
+    )
+    if missing:
+        raise ValueError(f"missing required evidence fields: {', '.join(missing)}")
+    if record["complete"] is not True or record["gap_status"] != "none":
+        raise ValueError("only complete, gap-free evidence is admissible")
+    if record["source_id"] not in ALLOWED_SOURCE_IDS:
+        raise ValueError("evidence source_id is not in the v2.2 allowlist")
+    digest = record["raw_payload_sha256"]
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(c not in "0123456789abcdef" for c in digest)
+    ):
+        raise ValueError("raw_payload_sha256 must be lowercase 64-character hex")
+
+
+def contract_as_machine_data() -> dict[str, Any]:
+    return {
+        "contract_schema_version": CONTRACT_SCHEMA_VERSION,
+        "contract_id": CONTRACT_ID,
+        "registration_mode": "independent_new_registration",
+        "predecessor_preservation": {
+            "v2_identity": "DFC-2C-4H-v2",
+            "v2_row_mutation": "forbidden",
+            "v2_seal_mutation": "forbidden",
+            "v2_supersede_or_hide": "forbidden",
+            "v21_identity": V21_PROVENANCE["identity"],
+            "v21_module": V21_PROVENANCE["module"],
+            "v21_source_commit": V21_PROVENANCE["source_commit"],
+            "v21_source_branch": V21_PROVENANCE["source_branch"],
+            "v21_blob_port": V21_PROVENANCE["blob_port"],
+            "v21_row_mutation": V21_PROVENANCE["mutation"],
+        },
+        "backtest_window": {
+            "warmup_start_utc": WARMUP_START,
+            "holdout_start_utc": BACKTEST_WINDOW.split("/")[0],
+            "holdout_end_utc_exclusive": BACKTEST_WINDOW.split("/")[1],
+            "calendar_days": BACKTEST_CALENDAR_DAYS,
+            "scheduled_epochs": BACKTEST_SCHEDULED_EPOCHS,
+            "selection_basis": "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop",
+        },
+        "exploration_isolation": {
+            "window": EXPLORATION_WINDOW,
+            "relationship": "no overlap remains in the adopted backtest window",
+            "excluded_overlap": "2023-08-04T00:00:00Z/2024-05-02T00:00:00Z",
+            "excluded_overlap_epochs": 1_632,
+            "excluded_overlap_percent_of_original_three_year_window": 24.817518248175183,
+            "exclusion_reason": "intentionally excluded to remove the design-validation feedback loop",
+            "artifact_use": "design_only_never_primary_or_promotion_evidence",
+        },
+        "universe": {
+            "rule": "At each UTC 4h epoch, rank all eligible USD-M perpetual symbols by quote volume summed over the immediately preceding 30 calendar days; select the top 3, ties by canonical uppercase symbol; use no future or exploration-selected symbol list",
+            "lookback_days": 30,
+            "top_k": 3,
+            "hardcoded_symbols": False,
+            "pit": True,
+        },
+        "features": {
+            "ofi": "log(taker_buy_base_volume / (total_base_volume - taker_buy_base_volume)) from complete Binance 4h Kline",
+            "premium": "complete Binance 4h premium-index candle close",
+            "deprecated": [
+                "quote_volume_proxy_as_signal",
+                "five_minute_premium_average",
+            ],
+            "complete_only": True,
+            "imputation": "forbidden",
+        },
+        "score": {
+            "pit_rank": "current-excluded 252-observation inclusive <= empirical rank",
+            "composite": "(ofi_rank + premium_rank) / 2",
+            "tail": "linear Q0.75 of 252 derived prior |C| values",
+            "tail_context_observations": 504,
+            "comparator": "abs(C) >= threshold",
+            "runtime_parameterization": "forbidden",
+        },
+        "basket": {
+            "candidate": "any",
+            "winner": "largest abs(C), ties by canonical symbol",
+            "maximum_events_per_epoch": 1,
+        },
+        "estimand": {
+            "name": "matched_selection_absolute_log_return_delta",
+            "outcome": (
+                "absolute_log_return_bps of BasketDecision.winner from completed "
+                "signal-epoch kline close to the immediately next completed 4h kline close"
+            ),
+            "arm_label": "BasketDecision.candidate_any (not a free bool)",
+            "symbol": "BasketDecision.winner (not a free symbol)",
+            "candidate_term": "mean outcome of argmax absolute composite on candidate epochs",
+            "control_term": "mean outcome of argmax absolute composite on non-candidate epochs",
+            "control_choice": "A",
+            "selection_symmetric": True,
+            "selection_implementation": "evaluate_basket argmax over all three scores",
+            "outcome_implementation": "make_outcome_epoch_record",
+            "outcome_free_bool_price": "forbidden",
+            "missing_next_bar": RUN_INVALID_OUTCOME_EVIDENCE,
+            "row_deletion_on_missing_next_bar": "forbidden",
+            "bootstrap_implementation": "stationary_block_bootstrap",
+            "adjudication_implementation": "adjudicate_outcomes",
+            "pnl_claim": False,
+        },
+        "adjudication": B7_RULE,
+        "implementation": {
+            "module": "research_contracts.dfc_2c_4h_v22",
+            "algorithm_version": "dfc-2c-4h-v2.2-algorithm.v1",
+            "module_source_sha256": MODULE_SOURCE_SHA256,
+            "harness_source_sha256": HARNESS_SOURCE_SHA256,
+            "io": "none",
+            "enforcement": "import-time source digest for contract and harness; edit causes RuntimeError",
+        },
+        "harness": {
+            "module": "research_contracts.dfc_2c_4h_v22_harness",
+            "read_only": True,
+            "alignment": "UTC 4h inner join",
+            "warmup": "504 prior observations plus current epoch",
+            "manifest_validation": "every epoch, fail-closed",
+            "forward_only": True,
+            "raw_payload_sha256": True,
+        },
+        "promotion_budget": {
+            "backtest_runs": 1,
+            "orders": 0,
+            "demo": 0,
+            "account": 0,
+            "automatic_promotion": False,
+        },
+    }
+
+
+def canonical_contract_hash() -> str:
+    return canonical_sha256(contract_as_machine_data())
+
+
+CANONICAL_HASH: Final = canonical_contract_hash()

--- a/research_contracts/dfc_2c_4h_v22.py
+++ b/research_contracts/dfc_2c_4h_v22.py
@@ -25,6 +25,15 @@ __all__ = [
     "MODULE_SOURCE_SHA256",
     "B6_CONTROL",
     "B7_RULE",
+    "ARM_CANDIDATE",
+    "ARM_CONTROL",
+    "ARM_LABELS",
+    "CANONICAL_SOURCE_PATH",
+    "CANONICAL_SOURCE_SHA256",
+    "NW_F4_VERBATIM",
+    "NW_F7_VERBATIM",
+    "NW_F7_PASS_FALSIFIED_UNIFICATION",
+    "require_arm_label",
     "IntegrityState",
     "SymbolScore",
     "BasketDecision",
@@ -58,7 +67,7 @@ __all__ = [
 # hashes the source with this one literal normalized, so the digest is not a
 # circular input.  Exactly one declaration is required.
 MODULE_SOURCE_SHA256: Final = (
-    "86efaf3db506f77981622b490465ab91b13c08825ff25465c81af72c687d26e9"
+    "750dd758c13ea42b93cff74b51d11bdd8be76e3282fa237472f790594685842d"
 )
 HARNESS_SOURCE_SHA256: Final = (
     "762b5884e0e1bba4dbd4b6270b17dfe695047b38d6bd1c5b3717f9fba25d9386"
@@ -92,6 +101,84 @@ STATUS_INCONCLUSIVE: Final = "INCONCLUSIVE"
 STATUS_FALSIFIED: Final = "FALSIFIED"
 STATUS_RUN_INVALID: Final = "RUN_INVALID"
 RUN_INVALID_OUTCOME_EVIDENCE: Final = "RUN_INVALID_OUTCOME_EVIDENCE"
+
+# --- Canonical upstream wording, verbatim ---------------------------------
+# The two clauses this registration implements are carried here byte-exactly,
+# in the language they were signed in.  They are quoted, not summarized and not
+# translated: an English restatement is a second contract, and the point of a
+# signed clause is that there is only one.  The canonical document lives outside
+# this repository, so what a test in here can pin is the transcript plus the
+# document's SHA-256.
+CANONICAL_SOURCE_PATH: Final = "~/work/herdr-inbox/answer-codexmock-next-wave-1630.md"
+CANONICAL_SOURCE_SHA256: Final = (
+    "df7aee908e50af42bb70dc48e09eee55dd30f881ced08e0145f8015269c36693"
+)
+CANONICAL_SOURCE_LINE_COUNT: Final = 137
+CANONICAL_BINDING_RECORD: Final = (
+    "~/work/herdr-inbox/operator-decisions-20260805-0830.md §25차"
+)
+
+NW_F4_TOPIC: Final = "outcome 의미론"
+NW_F4_VERBATIM: Final = "**“signal epoch t의 `BasketDecision.candidate_any`가 arm label, 같은 decision의 winner가 심볼이다. outcome은 그 심볼의 완결된 t kline close부터 즉시 다음 완결 4h kline close까지의 absolute log return bps다. 둘 모두 raw evidence에서만 생성한다. 다음 bar가 없거나 불완전하면 행을 임의 삭제하지 않고 `RUN_INVALID_OUTCOME_EVIDENCE`; 마지막 signal을 위해 corpus에는 한 개의 다음 4h bar를 추가한다. 이는 PnL/체결 가능성 주장이 아니다.”** 자유 bool·자유 가격 입력을 금지한다."
+
+NW_F7_TOPIC: Final = "역사검증 판정·예산"
+NW_F7_VERBATIM: Final = "**“역사검증은 정확히 1회다. candidate/control 각 ≥400, stationary block bootstrap 10,000회·block 24 epoch. `PASS`는 candidate−control 95% CI lower >5bp **AND** two-sided p<0.05; 표본 미달은 `INCONCLUSIVE`; 그 밖은 `FALSIFIED`; 입력/증거 위반 `RUN_INVALID`가 최우선이다. PASS/FALSIFIED 문언 불일치는 v2.2에서 `PASS 조건의 부정=FALSIFIED`로 단일화한다. 결과 열람 후 threshold·horizon·universe 변경 0.”** planning SD는 데이터 접촉 전 계약에 고정하거나 power claim을 제거한다."
+
+#: The single-verdict wording NW-F7 unifies on, quoted exactly as signed.
+NW_F7_PASS_FALSIFIED_UNIFICATION: Final = "PASS 조건의 부정=FALSIFIED"
+
+NW_VERBATIM_CLAUSES: Final = MappingProxyType(
+    {"NW-F4": NW_F4_VERBATIM, "NW-F7": NW_F7_VERBATIM}
+)
+
+# --- NW-F4 arm label ------------------------------------------------------
+# DFC v2.2 arm-label wire contract (shared; byte-identical in both registrations)
+# =============================================================================
+# NW-F4 says ``BasketDecision.candidate_any`` *is an arm label*.  It is therefore
+# carried as a label, never as a truth value, and the label domain is closed:
+#
+#     ARM_CANDIDATE = "candidate"
+#     ARM_CONTROL   = "control"
+#     ARM_LABELS    = ("candidate", "control")
+#
+# Counterpart declaration: ``research/dfc_v22_research_min/contract.py``
+# (PR #1826), which declares the same three literals in the same order and
+# validates the same closed domain on its outcome table.  Neither side coerces:
+# a value that is not exactly one of these two labels never becomes an arm, it
+# becomes ``RUN_INVALID_OUTCOME_EVIDENCE``.  ``bool`` is rejected explicitly and
+# ahead of the membership test, because ``bool`` is exactly the shape NW-F4
+# forbids ("자유 bool ... 입력을 금지한다") and exactly the shape a silent
+# ``bool(...)`` conversion would manufacture.
+ARM_CANDIDATE: Final = "candidate"
+ARM_CONTROL: Final = "control"
+ARM_LABELS: Final = (ARM_CANDIDATE, ARM_CONTROL)
+
+
+class ArmLabelViolation(ValueError):
+    """A value offered as an arm label that the closed domain refuses."""
+
+
+def require_arm_label(value: Any) -> str:
+    """Return ``value`` iff it is one of the two admissible arm labels.
+
+    There is no coercion path and no default.  ``bool`` is tested first, by
+    type, so ``True``/``False`` can never be read as an arm; an arbitrary
+    string is refused next, because a label the contract never defined is not
+    a label.  Callers that must not raise translate the exception into
+    ``RUN_INVALID_OUTCOME_EVIDENCE`` — never into a repaired value.
+    """
+    if isinstance(value, bool):
+        raise ArmLabelViolation(
+            f"arm label must be one of {list(ARM_LABELS)}; a free bool "
+            f"({value!r}) is not an arm label and is never coerced into one"
+        )
+    if not isinstance(value, str) or value not in ARM_LABELS:
+        raise ArmLabelViolation(
+            f"arm label {value!r} is not one of the admissible arm labels "
+            f"{list(ARM_LABELS)}; the arm-label domain is closed by contract"
+        )
+    return value
+
 
 # NW-F7: power claim removed — planning_sd cannot be validated without data
 # contact; do not ship an unverifiable power claim.
@@ -191,9 +278,19 @@ class SymbolScore:
 
 @dataclass(frozen=True, slots=True)
 class BasketDecision:
-    candidate_any: bool | None
+    """``candidate_any`` is the NW-F4 arm label, not a truth value.
+
+    ``None`` means *no decision was reached* for this epoch (an incomplete
+    basket); it is not a third arm, and the outcome layer refuses it.
+    """
+
+    candidate_any: str | None
     winner: str | None
     scores: tuple[SymbolScore, ...]
+
+    def __post_init__(self) -> None:
+        if self.candidate_any is not None:
+            require_arm_label(self.candidate_any)
 
 
 @dataclass(frozen=True, slots=True)
@@ -216,7 +313,7 @@ class _OutcomeBinding:
     signal_epoch_start_ms: int
     entry_payload_sha256: str
     exit_payload_sha256: str
-    decision_candidate_any: bool
+    decision_candidate_any: str
     decision_winner: str
 
 
@@ -224,7 +321,7 @@ class _OutcomeBinding:
 class OutcomeObservation:
     """Arm label and bps are never free inputs — only factory-produced bindings."""
 
-    candidate: bool
+    arm_label: str
     outcome_bps: float
     binding: _OutcomeBinding
 
@@ -236,7 +333,11 @@ class OutcomeObservation:
         object.__setattr__(
             self, "outcome_bps", _finite("outcome_bps", self.outcome_bps)
         )
-        if self.candidate != self.binding.decision_candidate_any:
+        # Both sides of the comparison are domain-checked first, so a bool that
+        # slipped into the binding cannot be matched by a bool on the label.
+        require_arm_label(self.arm_label)
+        require_arm_label(self.binding.decision_candidate_any)
+        if self.arm_label != self.binding.decision_candidate_any:
             raise ValueError("arm label must equal BasketDecision.candidate_any")
         if self.binding.decision_winner != self.binding.winner_symbol:
             raise ValueError("winner symbol must equal BasketDecision.winner")
@@ -401,9 +502,12 @@ def evaluate_basket(inputs: _PITBasket) -> BasketDecision:
     )
     candidates = tuple(score for score in scores if score.is_candidate)
     # Selection is identical in both arms: all symbols are eligible for the
-    # argmax, while candidate_any remains an arm label for the outcome layer.
+    # argmax, while candidate_any is the arm label the outcome layer reads.
+    # The label is chosen here, once, from the closed domain — the boolean
+    # ``candidates`` is a local predicate and is never itself the arm.
     winner = min(scores, key=lambda score: (-abs(score.composite), score.symbol))
-    return BasketDecision(bool(candidates), winner.symbol, scores)
+    arm_label = ARM_CANDIDATE if candidates else ARM_CONTROL
+    return BasketDecision(arm_label, winner.symbol, scores)
 
 
 def _mean(values: Sequence[float]) -> float:
@@ -507,12 +611,20 @@ def make_outcome_epoch_record(
     extract_kline_close_evidence (raw payload).  Free bool / free price inputs
     are not accepted.  Missing or incomplete next bar → RUN_INVALID_OUTCOME_EVIDENCE
     (row deletion is forbidden).
+
+    The arm label is carried through unchanged after a domain check.  There is
+    deliberately no ``bool(...)`` here: coercing an out-of-domain value into a
+    truth value is how a wrong input stops being detectable.
     """
     if not isinstance(decision, BasketDecision):
         return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
     if not isinstance(entry, _KlineCloseEvidence):
         return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
     if decision.candidate_any is None or decision.winner is None:
+        return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
+    try:
+        arm_label = require_arm_label(decision.candidate_any)
+    except ArmLabelViolation:
         return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
     if not entry.complete or entry.source_id != "binance_usdm.klines_4h":
         return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
@@ -534,14 +646,14 @@ def make_outcome_epoch_record(
     except ValueError:
         return OutcomeEpochRecord(status=RUN_INVALID_OUTCOME_EVIDENCE)
     observation = OutcomeObservation(
-        candidate=bool(decision.candidate_any),
+        arm_label=arm_label,
         outcome_bps=bps,
         binding=_OutcomeBinding(
             winner_symbol=decision.winner,
             signal_epoch_start_ms=entry.epoch_start_ms,
             entry_payload_sha256=entry.payload_sha256,
             exit_payload_sha256=next_bar.payload_sha256,
-            decision_candidate_any=bool(decision.candidate_any),
+            decision_candidate_any=arm_label,
             decision_winner=decision.winner,
         ),
     )
@@ -654,11 +766,29 @@ def adjudicate_outcomes(
                 (),
                 RUN_INVALID_OUTCOME_EVIDENCE,
             )
+        # An out-of-domain arm is an evidence violation, not a control epoch.
+        # ``not candidate`` would have silently swept it into the control arm.
+        try:
+            require_arm_label(item.observation.arm_label)
+        except ArmLabelViolation:
+            return AdjudicationResult(
+                STATUS_RUN_INVALID,
+                None,
+                None,
+                None,
+                None,
+                (),
+                RUN_INVALID_OUTCOME_EVIDENCE,
+            )
 
     observations = tuple(item.observation for item in materialized)
     assert all(obs is not None for obs in observations)
-    candidate = tuple(item.outcome_bps for item in observations if item.candidate)
-    control = tuple(item.outcome_bps for item in observations if not item.candidate)
+    candidate = tuple(
+        item.outcome_bps for item in observations if item.arm_label == ARM_CANDIDATE
+    )
+    control = tuple(
+        item.outcome_bps for item in observations if item.arm_label == ARM_CONTROL
+    )
     rule = B7_RULE
 
     # 2) INCONCLUSIVE on sample shortfall.
@@ -804,7 +934,12 @@ def contract_as_machine_data() -> dict[str, Any]:
                 "absolute_log_return_bps of BasketDecision.winner from completed "
                 "signal-epoch kline close to the immediately next completed 4h kline close"
             ),
-            "arm_label": "BasketDecision.candidate_any (not a free bool)",
+            "arm_label": "BasketDecision.candidate_any (a closed-domain arm label, not a free bool)",
+            "arm_labels": list(ARM_LABELS),
+            "arm_label_wire_type": "string",
+            "arm_label_domain": "closed",
+            "arm_label_coercion": "forbidden",
+            "arm_label_counterpart_module": "research.dfc_v22_research_min.contract",
             "symbol": "BasketDecision.winner (not a free symbol)",
             "candidate_term": "mean outcome of argmax absolute composite on candidate epochs",
             "control_term": "mean outcome of argmax absolute composite on non-candidate epochs",
@@ -818,6 +953,18 @@ def contract_as_machine_data() -> dict[str, Any]:
             "bootstrap_implementation": "stationary_block_bootstrap",
             "adjudication_implementation": "adjudicate_outcomes",
             "pnl_claim": False,
+        },
+        "canonical_wording": {
+            "source_path": CANONICAL_SOURCE_PATH,
+            "source_sha256": CANONICAL_SOURCE_SHA256,
+            "source_line_count": CANONICAL_SOURCE_LINE_COUNT,
+            "binding_record": CANONICAL_BINDING_RECORD,
+            "paraphrase": "forbidden",
+            "nw_f4_topic": NW_F4_TOPIC,
+            "nw_f4_verbatim": NW_F4_VERBATIM,
+            "nw_f7_topic": NW_F7_TOPIC,
+            "nw_f7_verbatim": NW_F7_VERBATIM,
+            "pass_falsified_unification_verbatim": NW_F7_PASS_FALSIFIED_UNIFICATION,
         },
         "adjudication": B7_RULE,
         "implementation": {

--- a/research_contracts/dfc_2c_4h_v22_harness.py
+++ b/research_contracts/dfc_2c_4h_v22_harness.py
@@ -1,0 +1,423 @@
+"""Read-only PIT collection and alignment primitives for DFC v2.2.
+
+The harness is deliberately transport-agnostic: an operator supplies pages
+from the Binance read endpoints, and this module validates, hashes, sorts and
+aligns them.  It has no database, broker, scheduler, or order path.
+
+Outcome construction binds BasketDecision to raw EvidenceCandle closes only
+(NW-F4). Free bool / free price surfaces are not exposed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from research_contracts.dfc_2c_4h_v22 import (
+    BasketDecision,
+    IntegrityState,
+    OutcomeEpochRecord,
+    _EpochFeatures,
+    _EvidenceBinding,
+    _PITBasket,
+    evaluate_basket,
+    extract_kline_close_evidence,
+    make_outcome_epoch_record,
+    ofi_from_base_volumes,
+    premium_index_close_from_complete_4h,
+    select_universe,
+    validate_evidence_manifest,
+)
+
+INTERVAL_MS = 4 * 60 * 60 * 1000
+REQUIRED_WARMUP_OBSERVATIONS = 504
+HARNESS_SOURCE_SHA256 = (
+    "762b5884e0e1bba4dbd4b6270b17dfe695047b38d6bd1c5b3717f9fba25d9386"
+)
+_SOURCE_DECLARATION = re.compile(
+    r'HARNESS_SOURCE_SHA256 = \(\s*"([0-9a-f]{64})"\s*\)', re.DOTALL
+)
+
+
+class ForwardOnlyViolation(ValueError):
+    """Fail-closed timestamp violation with the shared #1774 reason code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+def _assert_harness_source_frozen() -> None:
+    source = inspect.getsource(inspect.getmodule(_assert_harness_source_frozen))
+    matches = list(_SOURCE_DECLARATION.finditer(source))
+    if len(matches) != 1:
+        raise RuntimeError("harness source digest declaration count must equal one")
+    declared = matches[0].group(1)
+    normalized = source[: matches[0].start(1)] + "0" * 64 + source[matches[0].end(1) :]
+    actual = hashlib.sha256(normalized.encode()).hexdigest()
+    if declared != actual:
+        raise RuntimeError(
+            f"DFC v2.2 harness source hash mismatch: declared={declared}, actual={actual}"
+        )
+
+
+_assert_harness_source_frozen()
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceCandle:
+    symbol: str
+    endpoint: str
+    epoch_start_ms: int
+    epoch_end_ms: int
+    payload: Sequence[Any] | Mapping[str, Any]
+    manifest: Mapping[str, Any]
+
+
+KLINE_MIN_FIELDS = 12
+KLINE_OPEN_TIME_INDEX = 0
+KLINE_CLOSE_INDEX = 4
+KLINE_CLOSE_TIME_INDEX = 6
+KLINE_QUOTE_VOLUME_INDEX = 7
+KLINE_TAKER_BUY_BASE_INDEX = 9
+PREMIUM_CLOSE_INDEX = 4
+
+
+def raw_payload_sha256(payload: Sequence[Any]) -> str:
+    if isinstance(payload, Mapping):
+        canonical_payload: Any = {
+            str(key): payload[key] for key in sorted(payload, key=str)
+        }
+    else:
+        canonical_payload = list(payload)
+    encoded = json.dumps(
+        canonical_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _numeric_payload_value(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"raw candle payload field {name} must be numeric")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"raw candle payload field {name} must be numeric") from exc
+    if not parsed == parsed or parsed in (float("inf"), float("-inf")):
+        raise ValueError(f"raw candle payload field {name} must be finite")
+    return parsed
+
+
+def validate_and_sort_candles(
+    candles: Iterable[EvidenceCandle],
+) -> tuple[EvidenceCandle, ...]:
+    materialized = tuple(candles)
+    for candle in materialized:
+        validate_evidence_manifest(candle.manifest)
+        if (
+            not isinstance(candle.payload, Mapping)
+            and len(candle.payload) < KLINE_MIN_FIELDS
+        ):
+            raise ValueError(
+                "raw candle payload has fewer than the required 12 Binance fields"
+            )
+        if candle.symbol != candle.manifest["symbol"]:
+            raise ValueError("candle symbol does not match evidence manifest")
+        if candle.epoch_end_ms - candle.epoch_start_ms != INTERVAL_MS:
+            raise ValueError("candle interval must be exactly one UTC 4h epoch")
+        if candle.manifest["raw_payload_sha256"] != raw_payload_sha256(candle.payload):
+            raise ValueError("raw payload hash does not match evidence manifest")
+        open_time = _actual_candle_value(
+            candle, mapping_key="open_time_ms", sequence_index=KLINE_OPEN_TIME_INDEX
+        )
+        close_time = _actual_candle_value(
+            candle, mapping_key="close_time_ms", sequence_index=KLINE_CLOSE_TIME_INDEX
+        )
+        if open_time != candle.epoch_start_ms:
+            raise ValueError("raw candle open time does not match epoch start")
+        if close_time != open_time + INTERVAL_MS - 1:
+            raise ValueError(
+                "raw candle closeTime must equal openTime + interval - 1ms"
+            )
+    ordered = tuple(
+        sorted(materialized, key=lambda c: (c.symbol, c.endpoint, c.epoch_start_ms))
+    )
+    for earlier, later in zip(ordered, ordered[1:], strict=False):
+        if (earlier.symbol, earlier.endpoint) == (
+            later.symbol,
+            later.endpoint,
+        ) and earlier.epoch_start_ms == later.epoch_start_ms:
+            raise ValueError("duplicate symbol/endpoint/epoch evidence")
+    return ordered
+
+
+def inner_align_4h(
+    klines: Iterable[EvidenceCandle], premium_klines: Iterable[EvidenceCandle]
+) -> tuple[tuple[str, int], ...]:
+    left = {(c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(klines)}
+    right = {
+        (c.symbol, c.epoch_start_ms) for c in validate_and_sort_candles(premium_klines)
+    }
+    return tuple(sorted(left & right))
+
+
+def assert_forward_only(
+    epoch_starts_ms: Sequence[int],
+    prior_windows: Mapping[int, Sequence[int]],
+    *,
+    prior_evidence: Mapping[int, Sequence[EvidenceCandle]],
+) -> None:
+    for epoch in epoch_starts_ms:
+        prior = tuple(prior_windows[epoch])
+        if len(prior) != REQUIRED_WARMUP_OBSERVATIONS:
+            raise ValueError("every epoch requires exactly 504 prior observations")
+        if any(previous >= epoch for previous in prior):
+            raise ValueError("prior window contains current or future epoch")
+        raw_prior = validate_and_sort_candles(prior_evidence[epoch])
+        starts = tuple(candle.epoch_start_ms for candle in raw_prior)
+        if starts != prior:
+            raise ValueError("prior window does not match raw evidence candle times")
+        if any(start >= epoch for start in starts):
+            raise ValueError("raw prior window contains current or future candle")
+
+
+def _actual_candle_value(
+    candle: EvidenceCandle, *, mapping_key: str, sequence_index: int
+) -> int:
+    """Read timestamps from the raw Binance candle payload, never the manifest."""
+    payload = candle.payload
+    if isinstance(payload, Mapping):
+        value = payload.get(mapping_key)
+    else:
+        if len(payload) < KLINE_MIN_FIELDS:
+            raise ValueError(
+                "raw candle payload has fewer than the required 12 Binance fields"
+            )
+        value = payload[sequence_index]
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"raw candle payload lacks numeric {mapping_key}")
+    return int(value)
+
+
+def assert_signal_execution_forward_only(
+    signal_bar: EvidenceCandle,
+    execution_bar: EvidenceCandle,
+    *,
+    declared_signal_close_time_ms: int,
+) -> None:
+    """Compare actual raw candle timestamps and fail closed on overlap.
+
+    Binance kline arrays use index 0 for open time and index 6 for close time.
+    Mapping payloads may use the corresponding explicit ``*_time_ms`` keys.
+    """
+    actual_signal_close = _actual_candle_value(
+        signal_bar, mapping_key="close_time_ms", sequence_index=6
+    )
+    actual_signal_end = actual_signal_close + 1
+    if (
+        actual_signal_close != declared_signal_close_time_ms
+        or actual_signal_end != signal_bar.epoch_end_ms
+    ):
+        raise ForwardOnlyViolation(
+            "SIGNAL_BAR_CLOSE_MISMATCH",
+            "declared/manifest signal close does not match the raw signal candle close_time",
+        )
+    actual_execution_start = _actual_candle_value(
+        execution_bar, mapping_key="open_time_ms", sequence_index=0
+    )
+    if actual_execution_start <= actual_signal_close:
+        raise ForwardOnlyViolation(
+            "NEXT_BAR_OVERLAPS_SIGNAL_BAR",
+            "execution candle starts before the raw signal candle closes",
+        )
+
+
+def build_epoch_manifest(
+    *,
+    source_id: str,
+    endpoint_host: str,
+    endpoint_path: str,
+    endpoint_version: str,
+    symbol: str,
+    epoch_start_utc: str,
+    epoch_end_utc: str,
+    payload: Sequence[Any],
+    schema_version: str,
+) -> dict[str, Any]:
+    """Create provenance only; this function performs no network or persistence."""
+    return {
+        "source_id": source_id,
+        "endpoint_host": endpoint_host,
+        "endpoint_path": endpoint_path,
+        "endpoint_version": endpoint_version,
+        "symbol": symbol,
+        "interval": "4h",
+        "epoch_start_utc": epoch_start_utc,
+        "epoch_end_utc": epoch_end_utc,
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": schema_version,
+    }
+
+
+def classify_alignment(ok: bool, *, missing: bool = False) -> IntegrityState:
+    if ok:
+        return IntegrityState.COMPLETE
+    return IntegrityState.MISSING if missing else IntegrityState.GAP
+
+
+def epoch_features_from_evidence(
+    *,
+    symbol: str,
+    current_kline: EvidenceCandle,
+    current_premium: EvidenceCandle,
+    prior_klines: Sequence[EvidenceCandle],
+    prior_premium: Sequence[EvidenceCandle],
+    prior_30d_quote_volume: float,
+) -> _EpochFeatures:
+    """Build scoring features exclusively from validated raw endpoint evidence."""
+    if current_kline.manifest.get("source_id") != "binance_usdm.klines_4h":
+        raise ValueError("current kline evidence has the wrong source")
+    if (
+        current_premium.manifest.get("source_id")
+        != "binance_usdm.premium_index_klines_4h"
+    ):
+        raise ValueError("current premium evidence has the wrong source")
+    if any(
+        c.manifest.get("source_id") != "binance_usdm.klines_4h" for c in prior_klines
+    ):
+        raise ValueError("prior kline evidence has the wrong source")
+    if any(
+        c.manifest.get("source_id") != "binance_usdm.premium_index_klines_4h"
+        for c in prior_premium
+    ):
+        raise ValueError("prior premium evidence has the wrong source")
+    klines = validate_and_sort_candles((*prior_klines, current_kline))
+    premiums = validate_and_sort_candles((*prior_premium, current_premium))
+    if len(klines) != 505 or len(premiums) != 505:
+        raise ValueError(
+            "feature construction requires exactly 504 prior candles and one current candle"
+        )
+    if any(c.symbol != symbol for c in (*klines, *premiums)):
+        raise ValueError("feature evidence symbol mismatch")
+    if current_kline.epoch_start_ms != current_premium.epoch_start_ms:
+        raise ValueError("current kline and premium candle are not aligned")
+    klines = tuple(sorted(klines, key=lambda candle: candle.epoch_start_ms))
+    premiums = tuple(sorted(premiums, key=lambda candle: candle.epoch_start_ms))
+    if klines[-1] != current_kline or premiums[-1] != current_premium:
+        raise ValueError(
+            "current evidence must be the latest candle in the feature window"
+        )
+    expected_starts = tuple(
+        current_kline.epoch_start_ms - INTERVAL_MS * offset
+        for offset in range(504, -1, -1)
+    )
+    if tuple(c.epoch_start_ms for c in klines) != expected_starts:
+        raise ValueError(
+            "kline feature window must be contiguous and strictly prior to current"
+        )
+    if tuple(c.epoch_start_ms for c in premiums) != expected_starts:
+        raise ValueError(
+            "premium feature window must be contiguous and strictly prior to current"
+        )
+    if tuple(c.epoch_start_ms for c in klines) != tuple(
+        c.epoch_start_ms for c in premiums
+    ):
+        raise ValueError("kline and premium prior windows are not aligned")
+    ofi: list[float] = []
+    premium: list[float] = []
+    for candle in klines:
+        payload = candle.payload
+        if isinstance(payload, Mapping):
+            total = payload.get("volume")
+            buy = payload.get("taker_buy_base_volume")
+        else:
+            total = payload[5]
+            buy = payload[KLINE_TAKER_BUY_BASE_INDEX]
+        ofi.append(
+            ofi_from_base_volumes(
+                _numeric_payload_value(total, name="volume"),
+                _numeric_payload_value(buy, name="taker_buy_base_volume"),
+            )
+        )
+    for candle in premiums:
+        value = (
+            candle.payload.get("close")
+            if isinstance(candle.payload, Mapping)
+            else candle.payload[PREMIUM_CLOSE_INDEX]
+        )
+        premium.append(
+            premium_index_close_from_complete_4h(
+                _numeric_payload_value(value, name="premium_close"), is_complete=True
+            )
+        )
+    return _EpochFeatures(
+        symbol=symbol,
+        integrity=IntegrityState.COMPLETE,
+        current_ofi=ofi[-1],
+        current_premium_close=premium[-1],
+        prior_ofi=tuple(ofi[:-1]),
+        prior_premium_close=tuple(premium[:-1]),
+        prior_quote_volume_30d=_numeric_payload_value(
+            prior_30d_quote_volume, name="prior_30d_quote_volume"
+        ),
+        evidence=_EvidenceBinding(
+            symbol=symbol,
+            current_epoch_start_ms=current_kline.epoch_start_ms,
+            kline_payload_hashes=tuple(
+                c.manifest["raw_payload_sha256"] for c in klines
+            ),
+            premium_payload_hashes=tuple(
+                c.manifest["raw_payload_sha256"] for c in premiums
+            ),
+        ),
+    )
+
+
+def evaluate_epoch_basket(
+    prior_30d_quote_volume: Mapping[str, float], inputs: Mapping[str, _EpochFeatures]
+):
+    """Wire the PIT universe selection into the basket scorer for every epoch."""
+    selected = select_universe(prior_30d_quote_volume)
+    if tuple(sorted(inputs)) != tuple(sorted(selected)):
+        raise ValueError("basket symbols do not equal the epoch PIT-selected universe")
+    return evaluate_basket(
+        _PITBasket(selected, tuple(inputs[symbol] for symbol in sorted(inputs)))
+    )
+
+
+def make_outcome_epoch_record_from_candles(
+    decision: BasketDecision,
+    *,
+    entry_kline: EvidenceCandle,
+    next_kline: EvidenceCandle | None,
+) -> OutcomeEpochRecord:
+    """NW-F4 harness entry: bind decision arm/symbol to raw kline EvidenceCandles.
+
+    Missing next bar is recorded as RUN_INVALID_OUTCOME_EVIDENCE — never dropped.
+    """
+    entry = extract_kline_close_evidence(
+        symbol=entry_kline.symbol,
+        epoch_start_ms=entry_kline.epoch_start_ms,
+        payload=entry_kline.payload,
+        manifest=entry_kline.manifest,
+    )
+    next_bar = None
+    if next_kline is not None:
+        next_bar = extract_kline_close_evidence(
+            symbol=next_kline.symbol,
+            epoch_start_ms=next_kline.epoch_start_ms,
+            payload=next_kline.payload,
+            manifest=next_kline.manifest,
+        )
+    return make_outcome_epoch_record(decision, entry=entry, next_bar=next_bar)

--- a/tests/research_contracts/test_dfc_2c_4h_v21.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v21.py
@@ -1,0 +1,446 @@
+"""Adversarial contract tests for the v2.1 re-registration."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+
+import pytest
+
+from research_contracts import dfc_2c_4h_v21 as contract
+from research_contracts.dfc_2c_4h_v21_harness import (
+    EvidenceCandle,
+    assert_forward_only,
+    assert_signal_execution_forward_only,
+    build_epoch_manifest,
+    epoch_features_from_evidence,
+    evaluate_epoch_basket,
+    inner_align_4h,
+    raw_payload_sha256,
+    validate_and_sort_candles,
+)
+
+
+def _epoch(symbol: str, *, current: float = 1.0):
+    klines = []
+    premiums = []
+    for index in range(505):
+        start = index * 14_400_000
+        kline = (
+            start,
+            "1",
+            "1",
+            "1",
+            "1",
+            "2",
+            start + 14_399_999,
+            "10",
+            "1",
+            "1",
+            "1",
+            "0",
+        )
+        premium = (
+            start,
+            "0",
+            "0",
+            "0",
+            str(current if index == 504 else 0.0),
+            "0",
+            start + 14_399_999,
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+        )
+        klines.append(
+            EvidenceCandle(
+                symbol,
+                "kline",
+                start,
+                start + 14_400_000,
+                kline,
+                build_epoch_manifest(
+                    source_id="binance_usdm.klines_4h",
+                    endpoint_host="fapi.binance.com",
+                    endpoint_path="/fapi/v1/klines",
+                    endpoint_version="v1",
+                    symbol=symbol,
+                    epoch_start_utc="1970-01-01T00:00:00Z",
+                    epoch_end_utc="1970-01-01T04:00:00Z",
+                    payload=kline,
+                    schema_version="binance.v1",
+                ),
+            )
+        )
+        premiums.append(
+            EvidenceCandle(
+                symbol,
+                "premium",
+                start,
+                start + 14_400_000,
+                premium,
+                build_epoch_manifest(
+                    source_id="binance_usdm.premium_index_klines_4h",
+                    endpoint_host="fapi.binance.com",
+                    endpoint_path="/fapi/v1/premiumIndexKlines",
+                    endpoint_version="v1",
+                    symbol=symbol,
+                    epoch_start_utc="1970-01-01T00:00:00Z",
+                    epoch_end_utc="1970-01-01T04:00:00Z",
+                    payload=premium,
+                    schema_version="binance.v1",
+                ),
+            )
+        )
+    return epoch_features_from_evidence(
+        symbol=symbol,
+        current_kline=klines[-1],
+        current_premium=premiums[-1],
+        prior_klines=klines[:-1],
+        prior_premium=premiums[:-1],
+        prior_30d_quote_volume=100.0,
+    )
+
+
+def test_new_identity_and_v2_preservation_are_explicit() -> None:
+    payload = contract.contract_as_machine_data()
+    assert contract.CONTRACT_ID == "DFC-2C-4H-v2.1"
+    assert contract.CANONICAL_HASH == contract.canonical_contract_hash()
+    assert json.loads(json.dumps(payload, sort_keys=True)) == payload
+    assert payload["predecessor_preservation"]["v2_row_mutation"] == "forbidden"
+    assert (
+        payload["implementation"]["module_source_sha256"]
+        == contract.MODULE_SOURCE_SHA256
+    )
+    from research_contracts import dfc_2c_4h_v21_harness as harness
+
+    assert (
+        payload["implementation"]["harness_source_sha256"]
+        == harness.HARNESS_SOURCE_SHA256
+    )
+
+
+def test_import_time_source_freeze_is_present_and_runtime_hash_is_current() -> None:
+    source = inspect.getsource(contract)
+    assert "RuntimeError" in source
+    assert len(re.findall(r"^MODULE_SOURCE_SHA256: Final =", source, re.MULTILINE)) == 1
+    assert len(contract.MODULE_SOURCE_SHA256) == 64
+
+
+def test_composite_tail_is_derived_and_input_has_no_prior_composite_argument() -> None:
+    assert not hasattr(contract, "EpochFeatures")
+    assert list(inspect.signature(contract.tail_threshold_q75).parameters) == [
+        "prior_ofi",
+        "prior_premium_close",
+    ]
+    score = contract.score_symbol(_epoch("AAAUSDT"))
+    assert score.threshold == 1.0
+    with pytest.raises(TypeError):
+        contract.tail_threshold_q75((0.0,) * 504, (0.0,) * 504, 0.95)  # type: ignore[call-arg]
+
+
+def test_lookback_rebinding_cannot_change_runtime_windows() -> None:
+    original = contract.PIT_LOOKBACK
+    contract.PIT_LOOKBACK = 300  # type: ignore[misc]
+    try:
+        assert contract.pit_rank(1.0, (0.0,) * 252) == pytest.approx(1.0)
+        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+            contract.score_symbol(
+                _epoch("AAAUSDT").__class__(
+                    symbol="AAAUSDT",
+                    integrity=contract.IntegrityState.COMPLETE,
+                    current_ofi=1.0,
+                    current_premium_close=1.0,
+                    prior_ofi=(0.0,) * 300,
+                    prior_premium_close=(0.0,) * 300,
+                    prior_quote_volume_30d=100.0,
+                )
+            )
+    finally:
+        contract.PIT_LOOKBACK = original  # type: ignore[misc]
+
+
+def test_pit_universe_is_dynamic_and_no_symbols_are_hardcoded() -> None:
+    assert contract.select_universe(
+        {"SOLUSDT": 3.0, "XRPUSDT": 2.0, "DOGEUSDT": 1.0, "AAAUSDT": 4.0}
+    ) == ("AAAUSDT", "SOLUSDT", "XRPUSDT")
+    assert contract.contract_as_machine_data()["universe"]["hardcoded_symbols"] is False
+
+
+def test_control_a_is_symmetric_and_adjudication_is_fully_numeric() -> None:
+    payload = contract.contract_as_machine_data()
+    assert payload["estimand"]["control_choice"] == "A"
+    assert payload["estimand"]["selection_symmetric"] is True
+    assert (
+        payload["estimand"]["selection_implementation"]
+        == "evaluate_basket argmax over all three scores"
+    )
+    assert (
+        payload["estimand"]["bootstrap_implementation"] == "stationary_block_bootstrap"
+    )
+    rule = payload["adjudication"]
+    assert rule["delta_threshold_bps"] == 5.0
+    assert rule["bootstrap"] == "stationary_block_percentile"
+    assert rule["block_length_epochs"] == 24
+    assert rule["repetitions"] == 10_000
+    assert rule["confidence_level"] == 0.95
+    assert rule["alpha"] == 0.05
+    assert rule["minimum_candidate_epochs"] == 400
+    assert rule["minimum_control_epochs"] == 400
+    assert rule["power"]["target"] == 0.80
+
+
+def test_adopted_backtest_window_is_non_overlapping_and_warmup_is_recomputed() -> None:
+    payload = contract.contract_as_machine_data()
+    window = payload["backtest_window"]
+    assert window["holdout_start_utc"] == "2021-05-02T00:00:00Z"
+    assert window["holdout_end_utc_exclusive"] == "2023-08-04T00:00:00Z"
+    assert window["calendar_days"] == 824
+    assert window["scheduled_epochs"] == 4_944
+    assert window["warmup_start_utc"] == "2021-02-02T00:00:00Z"
+    assert window["selection_basis"] == (
+        "exclude the 1,632-epoch exploration overlap to remove the design-validation feedback loop"
+    )
+    isolation = payload["exploration_isolation"]
+    assert (
+        isolation["relationship"] == "no overlap remains in the adopted backtest window"
+    )
+    assert isolation["excluded_overlap_epochs"] == 1_632
+
+
+def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
+    payload = [0, 1, 2, 3, 4, 5, 14_399_999, 7, 8, 2, 1, 0]
+    manifest = {
+        "source_id": "binance_usdm.klines_4h",
+        "endpoint_host": "fapi.binance.com",
+        "endpoint_path": "/fapi/v1/klines",
+        "endpoint_version": "v1",
+        "symbol": "AAAUSDT",
+        "interval": "4h",
+        "epoch_start_utc": "2021-05-02T00:00:00Z",
+        "epoch_end_utc": "2021-05-02T04:00:00Z",
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": "binance.v1",
+    }
+    left = EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, tuple(payload), manifest)
+    right = EvidenceCandle(
+        "AAAUSDT",
+        "premium",
+        0,
+        14_400_000,
+        tuple(payload),
+        {
+            **manifest,
+            "endpoint_path": "/fapi/v1/premiumIndexKlines",
+            "source_id": "binance_usdm.premium_index_klines_4h",
+        },
+    )
+    assert inner_align_4h([left], [right]) == (("AAAUSDT", 0),)
+    assert validate_and_sort_candles([left]) == (left,)
+    with pytest.raises(ValueError, match="prior"):
+        assert_forward_only([100], {100: tuple(range(504))}, prior_evidence={100: ()})
+
+
+def test_harness_blocks_signal_close_execution_overlap_from_raw_payload_times() -> None:
+    signal = EvidenceCandle(
+        "AAAUSDT",
+        "kline",
+        0,
+        14_400_000,
+        (0, 0, 0, 0, 0, 0, 14_399_999, 0, 0, 0, 0, 0),
+        {},
+    )
+    execution = EvidenceCandle(
+        "AAAUSDT",
+        "kline",
+        10_800_000,
+        25_200_000,
+        (10_800_000, 0, 0, 0, 0, 0, 25_199_999, 0, 0, 0, 0, 0),
+        {},
+    )
+    with pytest.raises(ValueError, match="NEXT_BAR_OVERLAPS_SIGNAL_BAR"):
+        assert_signal_execution_forward_only(
+            signal, execution, declared_signal_close_time_ms=14_399_999
+        )
+
+    with pytest.raises(ValueError, match="SIGNAL_BAR_CLOSE_MISMATCH"):
+        assert_signal_execution_forward_only(
+            signal, execution, declared_signal_close_time_ms=14_400_000
+        )
+
+
+def test_control_arm_executes_same_selection_and_adjudication() -> None:
+    basket = evaluate_epoch_basket(
+        dict.fromkeys(("AAAUSDT", "BBBUSDT", "CCCUSDT"), 100.0),
+        {
+            symbol: _epoch(symbol, current=value)
+            for symbol, value in (("AAAUSDT", 0.2), ("BBBUSDT", 0.1), ("CCCUSDT", 0.0))
+        },
+    )
+    assert basket.winner == "AAAUSDT"
+    observations = tuple(
+        contract.OutcomeObservation(index % 2 == 0, 10.0 if index % 2 == 0 else 1.0)
+        for index in range(800)
+    )
+    result = contract.adjudicate_outcomes(observations)
+    assert result.status == "success"
+    assert result.delta_bps == pytest.approx(9.0)
+    assert contract.absolute_log_return_bps(100.0, 101.0) == pytest.approx(
+        99.5033, rel=1e-4
+    )
+    assert contract.make_outcome_observation(True, 100.0, 101.0).candidate is True
+
+
+def test_harness_rejects_short_raw_payload() -> None:
+    payload = (0, 1)
+    manifest = {
+        "source_id": "binance_usdm.klines_4h",
+        "endpoint_host": "fapi.binance.com",
+        "endpoint_path": "/fapi/v1/klines",
+        "endpoint_version": "v1",
+        "symbol": "AAAUSDT",
+        "interval": "4h",
+        "epoch_start_utc": "1970-01-01T00:00:00Z",
+        "epoch_end_utc": "1970-01-01T04:00:00Z",
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": "binance.v1",
+    }
+    with pytest.raises((ValueError, IndexError)):
+        validate_and_sort_candles(
+            [EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, payload, manifest)]
+        )
+
+
+def test_contract_remains_offline_only() -> None:
+    source = inspect.getsource(contract)
+    for forbidden in (
+        "import app",
+        "from app",
+        "httpx",
+        "requests",
+        "socket",
+        "subprocess",
+    ):
+        assert forbidden not in source
+
+
+def test_raw_mapping_values_are_bound_to_the_evidence_hash() -> None:
+    left = {"open_time_ms": 0, "close_time_ms": 14_399_999, "volume": 1000.0}
+    right = {"open_time_ms": 0, "close_time_ms": 14_399_999, "volume": 1.0}
+    assert raw_payload_sha256(left) != raw_payload_sha256(right)
+
+
+def test_feature_builder_rejects_future_prior_candle() -> None:
+    feature = _epoch("AAAUSDT")
+    # Rebuild the same clean window, but replace the first prior with a candle
+    # after the explicitly supplied current candle.
+    starts = [index * 14_400_000 for index in range(505)]
+    current_start = starts[-1]
+    future_start = starts[-1] + 14_400_000
+
+    def candle(start: int, source: str, payload: tuple[object, ...]) -> EvidenceCandle:
+        return EvidenceCandle(
+            "AAAUSDT",
+            source,
+            start,
+            start + 14_400_000,
+            payload,
+            build_epoch_manifest(
+                source_id="binance_usdm.klines_4h"
+                if source == "kline"
+                else "binance_usdm.premium_index_klines_4h",
+                endpoint_host="fapi.binance.com",
+                endpoint_path="/fapi/v1/klines"
+                if source == "kline"
+                else "/fapi/v1/premiumIndexKlines",
+                endpoint_version="v1",
+                symbol="AAAUSDT",
+                epoch_start_utc="1970-01-01T00:00:00Z",
+                epoch_end_utc="1970-01-01T04:00:00Z",
+                payload=payload,
+                schema_version="binance.v1",
+            ),
+        )
+
+    def kline(start: int) -> EvidenceCandle:
+        return candle(
+            start,
+            "kline",
+            (
+                start,
+                "1",
+                "1",
+                "1",
+                "1",
+                "2",
+                start + 14_399_999,
+                "10",
+                "1",
+                "1",
+                "1",
+                "0",
+            ),
+        )
+
+    def premium(start: int) -> EvidenceCandle:
+        return candle(
+            start,
+            "premium",
+            (
+                start,
+                "0",
+                "0",
+                "0",
+                "0",
+                "0",
+                start + 14_399_999,
+                "0",
+                "0",
+                "0",
+                "0",
+                "0",
+            ),
+        )
+
+    prior_kline = [kline(start) for start in starts[:-1]]
+    prior_premium = [premium(start) for start in starts[:-1]]
+    prior_kline[0] = kline(future_start)
+    with pytest.raises(ValueError, match="latest|contiguous|strictly prior"):
+        epoch_features_from_evidence(
+            symbol="AAAUSDT",
+            current_kline=kline(current_start),
+            current_premium=premium(current_start),
+            prior_klines=prior_kline,
+            prior_premium=prior_premium,
+            prior_30d_quote_volume=100.0,
+        )
+    assert feature.evidence.current_epoch_start_ms == current_start
+
+
+def test_feature_builder_rejects_cross_endpoint_roles() -> None:
+    feature = _epoch("AAAUSDT")
+    with pytest.raises(ValueError, match="wrong source"):
+        epoch_features_from_evidence(
+            symbol="AAAUSDT",
+            current_kline=EvidenceCandle(
+                "AAAUSDT", "kline", 0, 14_400_000, (0,) * 12, {}
+            ),
+            current_premium=EvidenceCandle(
+                "AAAUSDT", "premium", 0, 14_400_000, (0,) * 12, {}
+            ),
+            prior_klines=(),
+            prior_premium=(),
+            prior_30d_quote_volume=100.0,
+        )
+    with pytest.raises(TypeError, match="evidence-bound"):
+        contract.score_symbol({})  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="evidence-bound PIT"):
+        contract.evaluate_basket({})  # type: ignore[arg-type]
+    assert feature.symbol == "AAAUSDT"

--- a/tests/research_contracts/test_dfc_2c_4h_v22.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v22.py
@@ -1,0 +1,680 @@
+"""Adversarial contract tests for the DFC-2C-4H v2.2 registration.
+
+Covers NW-F3 provenance, NW-F4 outcome evidence binding, NW-F7 verdict
+unification, and the five required mutants (as permanent goldens).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import math
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from research_contracts import dfc_2c_4h_v22 as contract
+from research_contracts.dfc_2c_4h_v22_harness import (
+    EvidenceCandle,
+    assert_forward_only,
+    assert_signal_execution_forward_only,
+    build_epoch_manifest,
+    epoch_features_from_evidence,
+    evaluate_epoch_basket,
+    inner_align_4h,
+    make_outcome_epoch_record_from_candles,
+    raw_payload_sha256,
+    validate_and_sort_candles,
+)
+
+
+def _kline_payload(start: int, *, close: str = "100") -> tuple[object, ...]:
+    return (
+        start,
+        "1",
+        "1",
+        "1",
+        close,
+        "2",
+        start + 14_399_999,
+        "10",
+        "1",
+        "1",
+        "1",
+        "0",
+    )
+
+
+def _premium_payload(start: int, *, close: str = "0.0") -> tuple[object, ...]:
+    return (
+        start,
+        "0",
+        "0",
+        "0",
+        close,
+        "0",
+        start + 14_399_999,
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+    )
+
+
+def _candle(
+    symbol: str,
+    start: int,
+    *,
+    source: str,
+    payload: tuple[object, ...],
+) -> EvidenceCandle:
+    source_id = (
+        "binance_usdm.klines_4h"
+        if source == "kline"
+        else "binance_usdm.premium_index_klines_4h"
+    )
+    path = "/fapi/v1/klines" if source == "kline" else "/fapi/v1/premiumIndexKlines"
+    return EvidenceCandle(
+        symbol,
+        source,
+        start,
+        start + 14_400_000,
+        payload,
+        build_epoch_manifest(
+            source_id=source_id,
+            endpoint_host="fapi.binance.com",
+            endpoint_path=path,
+            endpoint_version="v1",
+            symbol=symbol,
+            epoch_start_utc="1970-01-01T00:00:00Z",
+            epoch_end_utc="1970-01-01T04:00:00Z",
+            payload=payload,
+            schema_version="binance.v1",
+        ),
+    )
+
+
+def _epoch(symbol: str, *, current: float = 1.0):
+    klines = []
+    premiums = []
+    for index in range(505):
+        start = index * 14_400_000
+        klines.append(
+            _candle(
+                symbol,
+                start,
+                source="kline",
+                payload=_kline_payload(start),
+            )
+        )
+        premiums.append(
+            _candle(
+                symbol,
+                start,
+                source="premium",
+                payload=_premium_payload(
+                    start, close=str(current if index == 504 else 0.0)
+                ),
+            )
+        )
+    return epoch_features_from_evidence(
+        symbol=symbol,
+        current_kline=klines[-1],
+        current_premium=premiums[-1],
+        prior_klines=klines[:-1],
+        prior_premium=premiums[:-1],
+        prior_30d_quote_volume=100.0,
+    )
+
+
+def _decision(*, candidate_any: bool, winner: str) -> contract.BasketDecision:
+    scores = (
+        contract.SymbolScore(winner, 1.0 if candidate_any else 0.0, 0.5, candidate_any),
+        contract.SymbolScore("BBBUSDT", 0.1, 0.5, False),
+        contract.SymbolScore("CCCUSDT", 0.0, 0.5, False),
+    )
+    return contract.BasketDecision(candidate_any, winner, scores)
+
+
+def _close_evidence(
+    symbol: str,
+    epoch_start_ms: int,
+    *,
+    close: str,
+) -> object:
+    payload = _kline_payload(epoch_start_ms, close=close)
+    manifest = build_epoch_manifest(
+        source_id="binance_usdm.klines_4h",
+        endpoint_host="fapi.binance.com",
+        endpoint_path="/fapi/v1/klines",
+        endpoint_version="v1",
+        symbol=symbol,
+        epoch_start_utc="1970-01-01T00:00:00Z",
+        epoch_end_utc="1970-01-01T04:00:00Z",
+        payload=payload,
+        schema_version="binance.v1",
+    )
+    return contract.extract_kline_close_evidence(
+        symbol=symbol,
+        epoch_start_ms=epoch_start_ms,
+        payload=payload,
+        manifest=manifest,
+    )
+
+
+def _ok_record(
+    *,
+    candidate: bool,
+    entry_close: str,
+    exit_close: str,
+    winner: str = "AAAUSDT",
+    epoch_start_ms: int = 0,
+) -> contract.OutcomeEpochRecord:
+    decision = _decision(candidate_any=candidate, winner=winner)
+    entry = _close_evidence(winner, epoch_start_ms, close=entry_close)
+    nxt = _close_evidence(
+        winner, epoch_start_ms + contract.INTERVAL_MS, close=exit_close
+    )
+    return contract.make_outcome_epoch_record(decision, entry=entry, next_bar=nxt)
+
+
+def _records_with_delta(
+    *,
+    n_candidate: int,
+    n_control: int,
+    candidate_exit: str,
+    control_exit: str,
+) -> tuple[contract.OutcomeEpochRecord, ...]:
+    records: list[contract.OutcomeEpochRecord] = []
+    for index in range(n_candidate):
+        records.append(
+            _ok_record(
+                candidate=True,
+                entry_close="100",
+                exit_close=candidate_exit,
+                epoch_start_ms=index * contract.INTERVAL_MS,
+            )
+        )
+    for index in range(n_control):
+        records.append(
+            _ok_record(
+                candidate=False,
+                entry_close="100",
+                exit_close=control_exit,
+                epoch_start_ms=(n_candidate + index) * contract.INTERVAL_MS,
+            )
+        )
+    return tuple(records)
+
+
+# ---------------------------------------------------------------------------
+# Identity / freeze / window (ported from v2.1 surface, v2.2 identity)
+# ---------------------------------------------------------------------------
+
+
+def test_new_identity_and_v21_provenance_are_explicit() -> None:
+    payload = contract.contract_as_machine_data()
+    assert contract.CONTRACT_ID == "DFC-2C-4H-v2.2"
+    assert contract.CANONICAL_HASH == contract.canonical_contract_hash()
+    assert len(contract.CANONICAL_HASH) == 64
+    assert json.loads(json.dumps(payload, sort_keys=True)) == payload
+    preservation = payload["predecessor_preservation"]
+    assert preservation["v2_row_mutation"] == "forbidden"
+    assert preservation["v21_identity"] == "DFC-2C-4H-v2.1"
+    assert (
+        preservation["v21_source_commit"] == "9f605139044605a5f31e5ee3da77133924126197"
+    )
+    assert preservation["v21_row_mutation"] == "forbidden"
+    assert (
+        payload["implementation"]["module_source_sha256"]
+        == contract.MODULE_SOURCE_SHA256
+    )
+    from research_contracts import dfc_2c_4h_v22_harness as harness
+
+    assert (
+        payload["implementation"]["harness_source_sha256"]
+        == harness.HARNESS_SOURCE_SHA256
+    )
+
+
+def test_import_time_source_freeze_is_present_and_runtime_hash_is_current() -> None:
+    source = inspect.getsource(contract)
+    assert "RuntimeError" in source
+    assert len(re.findall(r"^MODULE_SOURCE_SHA256: Final =", source, re.MULTILINE)) == 1
+    assert len(contract.MODULE_SOURCE_SHA256) == 64
+    assert contract.MODULE_SOURCE_SHA256 != "0" * 64
+
+
+def test_composite_tail_is_derived_and_input_has_no_prior_composite_argument() -> None:
+    assert not hasattr(contract, "EpochFeatures")
+    assert list(inspect.signature(contract.tail_threshold_q75).parameters) == [
+        "prior_ofi",
+        "prior_premium_close",
+    ]
+    score = contract.score_symbol(_epoch("AAAUSDT"))
+    assert score.threshold == 1.0
+    with pytest.raises(TypeError):
+        contract.tail_threshold_q75((0.0,) * 504, (0.0,) * 504, 0.95)  # type: ignore[call-arg]
+
+
+def test_pit_universe_is_dynamic_and_no_symbols_are_hardcoded() -> None:
+    assert contract.select_universe(
+        {"SOLUSDT": 3.0, "XRPUSDT": 2.0, "DOGEUSDT": 1.0, "AAAUSDT": 4.0}
+    ) == ("AAAUSDT", "SOLUSDT", "XRPUSDT")
+    assert contract.contract_as_machine_data()["universe"]["hardcoded_symbols"] is False
+
+
+def test_adopted_backtest_window_is_non_overlapping() -> None:
+    payload = contract.contract_as_machine_data()
+    window = payload["backtest_window"]
+    assert window["holdout_start_utc"] == "2021-05-02T00:00:00Z"
+    assert window["holdout_end_utc_exclusive"] == "2023-08-04T00:00:00Z"
+    assert window["calendar_days"] == 824
+    assert window["scheduled_epochs"] == 4_944
+    assert window["warmup_start_utc"] == "2021-02-02T00:00:00Z"
+    isolation = payload["exploration_isolation"]
+    assert isolation["excluded_overlap_epochs"] == 1_632
+
+
+def test_control_a_is_symmetric_and_verdict_literals_match_nw_f7() -> None:
+    payload = contract.contract_as_machine_data()
+    assert payload["estimand"]["control_choice"] == "A"
+    assert payload["estimand"]["selection_symmetric"] is True
+    assert payload["estimand"]["outcome_free_bool_price"] == "forbidden"
+    assert (
+        payload["estimand"]["missing_next_bar"] == contract.RUN_INVALID_OUTCOME_EVIDENCE
+    )
+    assert payload["estimand"]["row_deletion_on_missing_next_bar"] == "forbidden"
+    rule = payload["adjudication"]
+    assert rule["delta_threshold_bps"] == 5.0
+    assert rule["block_length_epochs"] == 24
+    assert rule["repetitions"] == 10_000
+    assert rule["minimum_candidate_epochs"] == 400
+    assert rule["minimum_control_epochs"] == 400
+    assert rule["historical_validation_runs"] == 1
+    assert "power" not in rule
+    assert rule["pass_falsified_unification"] == ("PASS condition negation = FALSIFIED")
+    assert contract.STATUS_PASS == "PASS"
+    assert contract.STATUS_INCONCLUSIVE == "INCONCLUSIVE"
+    assert contract.STATUS_FALSIFIED == "FALSIFIED"
+    assert contract.STATUS_RUN_INVALID == "RUN_INVALID"
+
+
+def test_power_claim_removed_from_machine_data() -> None:
+    rule = contract.contract_as_machine_data()["adjudication"]
+    assert "power" not in rule
+    assert "planning_sd_bps" not in rule
+    source = inspect.getsource(contract)
+    assert "planning_sd_bps" not in source
+    assert "power claim removed" in source
+
+
+def test_harness_hashes_validates_aligns_and_rejects_future_windows() -> None:
+    payload = [0, 1, 2, 3, 4, 5, 14_399_999, 7, 8, 2, 1, 0]
+    manifest = {
+        "source_id": "binance_usdm.klines_4h",
+        "endpoint_host": "fapi.binance.com",
+        "endpoint_path": "/fapi/v1/klines",
+        "endpoint_version": "v1",
+        "symbol": "AAAUSDT",
+        "interval": "4h",
+        "epoch_start_utc": "2021-05-02T00:00:00Z",
+        "epoch_end_utc": "2021-05-02T04:00:00Z",
+        "complete": True,
+        "gap_status": "none",
+        "raw_payload_sha256": raw_payload_sha256(payload),
+        "schema_version": "binance.v1",
+    }
+    left = EvidenceCandle("AAAUSDT", "kline", 0, 14_400_000, tuple(payload), manifest)
+    right = EvidenceCandle(
+        "AAAUSDT",
+        "premium",
+        0,
+        14_400_000,
+        tuple(payload),
+        {
+            **manifest,
+            "endpoint_path": "/fapi/v1/premiumIndexKlines",
+            "source_id": "binance_usdm.premium_index_klines_4h",
+        },
+    )
+    assert inner_align_4h([left], [right]) == (("AAAUSDT", 0),)
+    assert validate_and_sort_candles([left]) == (left,)
+    with pytest.raises(ValueError, match="prior"):
+        assert_forward_only([100], {100: tuple(range(504))}, prior_evidence={100: ()})
+
+
+def test_harness_blocks_signal_close_execution_overlap_from_raw_payload_times() -> None:
+    signal = EvidenceCandle(
+        "AAAUSDT",
+        "kline",
+        0,
+        14_400_000,
+        (0, 0, 0, 0, 0, 0, 14_399_999, 0, 0, 0, 0, 0),
+        {},
+    )
+    execution = EvidenceCandle(
+        "AAAUSDT",
+        "kline",
+        10_800_000,
+        25_200_000,
+        (10_800_000, 0, 0, 0, 0, 0, 25_199_999, 0, 0, 0, 0, 0),
+        {},
+    )
+    with pytest.raises(ValueError, match="NEXT_BAR_OVERLAPS_SIGNAL_BAR"):
+        assert_signal_execution_forward_only(
+            signal, execution, declared_signal_close_time_ms=14_399_999
+        )
+
+
+def test_control_arm_executes_same_selection() -> None:
+    basket = evaluate_epoch_basket(
+        dict.fromkeys(("AAAUSDT", "BBBUSDT", "CCCUSDT"), 100.0),
+        {
+            symbol: _epoch(symbol, current=value)
+            for symbol, value in (("AAAUSDT", 0.2), ("BBBUSDT", 0.1), ("CCCUSDT", 0.0))
+        },
+    )
+    assert basket.winner == "AAAUSDT"
+    assert basket.candidate_any is True
+
+
+def test_contract_remains_offline_only() -> None:
+    source = inspect.getsource(contract)
+    for forbidden in (
+        "import app",
+        "from app",
+        "httpx",
+        "requests",
+        "socket",
+        "subprocess",
+    ):
+        assert forbidden not in source
+
+
+def test_v21_port_blobs_are_importable_and_unmodified_identity() -> None:
+    from research_contracts import dfc_2c_4h_v21 as v21
+
+    assert v21.CONTRACT_ID == "DFC-2C-4H-v2.1"
+    assert v21.CONTRACT_ID != contract.CONTRACT_ID
+
+
+# ---------------------------------------------------------------------------
+# NW-F4 / R3: outcome evidence binding
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_from_decision_and_raw_kline_evidence() -> None:
+    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    entry = _close_evidence("AAAUSDT", 0, close="100")
+    nxt = _close_evidence("AAAUSDT", contract.INTERVAL_MS, close="101")
+    record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=nxt)
+    assert record.status == "ok"
+    assert record.observation is not None
+    assert record.observation.candidate is True
+    assert record.observation.outcome_bps == pytest.approx(
+        abs(math.log(101 / 100)) * 10_000.0
+    )
+    assert record.observation.binding.decision_winner == "AAAUSDT"
+
+
+def test_harness_outcome_from_candles_binds_decision() -> None:
+    decision = _decision(candidate_any=False, winner="AAAUSDT")
+    entry = _candle(
+        "AAAUSDT", 0, source="kline", payload=_kline_payload(0, close="100")
+    )
+    nxt = _candle(
+        "AAAUSDT",
+        contract.INTERVAL_MS,
+        source="kline",
+        payload=_kline_payload(contract.INTERVAL_MS, close="100.5"),
+    )
+    record = make_outcome_epoch_record_from_candles(
+        decision, entry_kline=entry, next_kline=nxt
+    )
+    assert record.status == "ok"
+    assert record.observation is not None
+    assert record.observation.candidate is False
+
+
+def test_absolute_log_return_bps_is_not_a_free_outcome_surface() -> None:
+    """absolute_log_return_bps remains a pure helper; adjudication only via records."""
+    assert contract.absolute_log_return_bps(100.0, 101.0) == pytest.approx(
+        99.5033, rel=1e-4
+    )
+    # Free bool+price factory must not exist (v2.1 R3 surface removed).
+    assert not hasattr(contract, "make_outcome_observation")
+    sig = inspect.signature(contract.make_outcome_epoch_record)
+    assert list(sig.parameters) == ["decision", "entry", "next_bar"]
+
+
+# ---------------------------------------------------------------------------
+# Mutant goldens ①–⑤ (permanent asserts; inject tests below)
+# ---------------------------------------------------------------------------
+
+
+def test_mutant1_free_bool_outcome_construction_is_rejected() -> None:
+    """① free bool injection → rejected."""
+    # Free (bool, bps) construction is missing the evidence binding argument.
+    with pytest.raises(TypeError, match="binding"):
+        contract.OutcomeObservation(True, 50.0)  # type: ignore[call-arg]
+    # Forged non-_OutcomeBinding binding is also rejected.
+    with pytest.raises(TypeError, match="evidence binding"):
+        contract.OutcomeObservation(  # type: ignore[arg-type]
+            candidate=True,
+            outcome_bps=50.0,
+            binding=SimpleNamespace(
+                winner_symbol="AAAUSDT",
+                signal_epoch_start_ms=0,
+                entry_payload_sha256="a" * 64,
+                exit_payload_sha256="b" * 64,
+                decision_candidate_any=True,
+                decision_winner="AAAUSDT",
+            ),
+        )
+
+
+def test_mutant2_free_price_outside_raw_evidence_is_rejected() -> None:
+    """② free price (outside raw evidence) → rejected."""
+    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    # Free floats are not accepted — entry/next_bar must be _KlineCloseEvidence.
+    record = contract.make_outcome_epoch_record(
+        decision,
+        entry=100.0,
+        next_bar=101.0,  # type: ignore[arg-type]
+    )
+    assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
+    # Free scalar "close" with empty manifest cannot become kline close evidence.
+    with pytest.raises((TypeError, ValueError)):
+        contract.extract_kline_close_evidence(
+            symbol="AAAUSDT",
+            epoch_start_ms=0,
+            payload=100.0,  # type: ignore[arg-type]
+            manifest={},
+        )
+    # Free close cannot be smuggled via a non-kline source_id either.
+    bad_payload = _kline_payload(0, close="99999")
+    bad_manifest = build_epoch_manifest(
+        source_id="binance_usdm.premium_index_klines_4h",
+        endpoint_host="fapi.binance.com",
+        endpoint_path="/fapi/v1/premiumIndexKlines",
+        endpoint_version="v1",
+        symbol="AAAUSDT",
+        epoch_start_utc="1970-01-01T00:00:00Z",
+        epoch_end_utc="1970-01-01T04:00:00Z",
+        payload=bad_payload,
+        schema_version="binance.v1",
+    )
+    with pytest.raises(ValueError, match="klines_4h"):
+        contract.extract_kline_close_evidence(
+            symbol="AAAUSDT",
+            epoch_start_ms=0,
+            payload=bad_payload,
+            manifest=bad_manifest,
+        )
+
+
+def test_mutant3_missing_next_bar_is_run_invalid_not_row_drop() -> None:
+    """③ missing next bar → RUN_INVALID_OUTCOME_EVIDENCE, not silent deletion."""
+    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    entry = _close_evidence("AAAUSDT", 0, close="100")
+    record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=None)
+    assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
+    assert record.observation is None
+    # Even when mixed with many valid PASS-capable rows, invalid is not dropped.
+    valid = _records_with_delta(
+        n_candidate=400,
+        n_control=400,
+        candidate_exit="100.6",
+        control_exit="100.1",
+    )
+    result = contract.adjudicate_outcomes((record, *valid))
+    assert result.status == contract.STATUS_RUN_INVALID
+    assert result.reason_code == contract.RUN_INVALID_OUTCOME_EVIDENCE
+
+
+def test_mutant4_sample_shortfall_is_inconclusive_not_pass_or_falsified() -> None:
+    """④ sample <400 → INCONCLUSIVE (never PASS/FALSIFIED)."""
+    # Strong effect but only 50/50 samples.
+    records = _records_with_delta(
+        n_candidate=50,
+        n_control=50,
+        candidate_exit="100.6",
+        control_exit="100.1",
+    )
+    result = contract.adjudicate_outcomes(records)
+    assert result.status == contract.STATUS_INCONCLUSIVE
+    assert result.status not in {contract.STATUS_PASS, contract.STATUS_FALSIFIED}
+    assert result.reason_code == "SAMPLE_SHORTFALL"
+
+
+def test_mutant5_run_invalid_has_precedence_over_other_verdicts() -> None:
+    """⑤ input/evidence violation → RUN_INVALID before PASS/INCONCLUSIVE/FALSIFIED."""
+    invalid = contract.OutcomeEpochRecord(
+        status=contract.RUN_INVALID_OUTCOME_EVIDENCE, observation=None
+    )
+    # Enough samples that would otherwise be INCONCLUSIVE-or-better if invalid dropped.
+    short = _records_with_delta(
+        n_candidate=10,
+        n_control=10,
+        candidate_exit="100.6",
+        control_exit="100.1",
+    )
+    result_short = contract.adjudicate_outcomes((invalid, *short))
+    assert result_short.status == contract.STATUS_RUN_INVALID
+
+    full = _records_with_delta(
+        n_candidate=400,
+        n_control=400,
+        candidate_exit="100.6",
+        control_exit="100.1",
+    )
+    result_full = contract.adjudicate_outcomes((invalid, *full))
+    assert result_full.status == contract.STATUS_RUN_INVALID
+    assert result_full.reason_code == contract.RUN_INVALID_OUTCOME_EVIDENCE
+
+    # Non-record input is also RUN_INVALID (not crash, not other verdict).
+    result_bad = contract.adjudicate_outcomes(
+        [SimpleNamespace(candidate=True, outcome_bps=50.0)]  # type: ignore[list-item]
+    )
+    assert result_bad.status == contract.STATUS_RUN_INVALID
+    assert result_bad.reason_code == "RUN_INVALID_INPUT"
+
+
+def test_pass_vs_falsified_unification() -> None:
+    """PASS condition negation = FALSIFIED (no success/failure dual wording)."""
+    strong = _records_with_delta(
+        n_candidate=400,
+        n_control=400,
+        candidate_exit="100.6",
+        control_exit="100.1",
+    )
+    strong_result = contract.adjudicate_outcomes(strong)
+    assert strong_result.status == contract.STATUS_PASS
+    assert strong_result.ci_lower_bps is not None
+    assert strong_result.ci_lower_bps > 5.0
+    assert strong_result.p_value is not None
+    assert strong_result.p_value < 0.05
+
+    null = _records_with_delta(
+        n_candidate=400,
+        n_control=400,
+        candidate_exit="100.1",
+        control_exit="100.1",
+    )
+    null_result = contract.adjudicate_outcomes(null)
+    assert null_result.status == contract.STATUS_FALSIFIED
+    # Not the old v2.1 dual wording.
+    assert null_result.status not in {"success", "failure", "indeterminate"}
+
+
+def test_incomplete_next_bar_is_run_invalid() -> None:
+    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    entry = _close_evidence("AAAUSDT", 0, close="100")
+    # Wrong interval (not immediate next 4h bar).
+    far = _close_evidence("AAAUSDT", 2 * contract.INTERVAL_MS, close="101")
+    record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=far)
+    assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
+
+
+def test_winner_symbol_mismatch_is_run_invalid() -> None:
+    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    entry = _close_evidence("BBBUSDT", 0, close="100")
+    nxt = _close_evidence("BBBUSDT", contract.INTERVAL_MS, close="101")
+    record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=nxt)
+    assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
+
+
+# ---------------------------------------------------------------------------
+# False-green: flip core asserts would fail (structural check of goldens)
+# ---------------------------------------------------------------------------
+
+
+def test_false_green_guard_mutant_goldens_have_failing_negations() -> None:
+    """If core mutant asserts were inverted, they must not vacuously pass.
+
+    We re-evaluate the same predicates with inverted expectations and require
+    that the inverted form is False — proving the golden is load-bearing.
+    """
+    # ① free bool construction raises (inverted would expect no raise).
+    raised = False
+    try:
+        contract.OutcomeObservation(True, 50.0)  # type: ignore[call-arg]
+    except TypeError:
+        raised = True
+    assert raised is True
+    assert (not raised) is False  # inverted golden would fail
+
+    # ③ missing next bar is INVALID (inverted: status == "ok" is False).
+    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    entry = _close_evidence("AAAUSDT", 0, close="100")
+    record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=None)
+    assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
+    assert (record.status == "ok") is False
+
+    # ④ short sample is INCONCLUSIVE (inverted PASS is False).
+    short = _records_with_delta(
+        n_candidate=50,
+        n_control=50,
+        candidate_exit="100.6",
+        control_exit="100.1",
+    )
+    short_result = contract.adjudicate_outcomes(short)
+    assert short_result.status == contract.STATUS_INCONCLUSIVE
+    assert (short_result.status == contract.STATUS_PASS) is False
+
+    # ⑤ invalid first → RUN_INVALID even with PASS-capable bulk (inverted False).
+    invalid = contract.OutcomeEpochRecord(
+        status=contract.RUN_INVALID_OUTCOME_EVIDENCE, observation=None
+    )
+    bulk = _records_with_delta(
+        n_candidate=400,
+        n_control=400,
+        candidate_exit="100.6",
+        control_exit="100.1",
+    )
+    mixed = contract.adjudicate_outcomes((invalid, *bulk))
+    assert mixed.status == contract.STATUS_RUN_INVALID
+    assert (mixed.status == contract.STATUS_PASS) is False

--- a/tests/research_contracts/test_dfc_2c_4h_v22.py
+++ b/tests/research_contracts/test_dfc_2c_4h_v22.py
@@ -129,9 +129,10 @@ def _epoch(symbol: str, *, current: float = 1.0):
     )
 
 
-def _decision(*, candidate_any: bool, winner: str) -> contract.BasketDecision:
+def _decision(*, candidate_any: str, winner: str) -> contract.BasketDecision:
+    is_candidate = candidate_any == contract.ARM_CANDIDATE
     scores = (
-        contract.SymbolScore(winner, 1.0 if candidate_any else 0.0, 0.5, candidate_any),
+        contract.SymbolScore(winner, 1.0 if is_candidate else 0.0, 0.5, is_candidate),
         contract.SymbolScore("BBBUSDT", 0.1, 0.5, False),
         contract.SymbolScore("CCCUSDT", 0.0, 0.5, False),
     )
@@ -166,13 +167,13 @@ def _close_evidence(
 
 def _ok_record(
     *,
-    candidate: bool,
+    arm_label: str,
     entry_close: str,
     exit_close: str,
     winner: str = "AAAUSDT",
     epoch_start_ms: int = 0,
 ) -> contract.OutcomeEpochRecord:
-    decision = _decision(candidate_any=candidate, winner=winner)
+    decision = _decision(candidate_any=arm_label, winner=winner)
     entry = _close_evidence(winner, epoch_start_ms, close=entry_close)
     nxt = _close_evidence(
         winner, epoch_start_ms + contract.INTERVAL_MS, close=exit_close
@@ -191,7 +192,7 @@ def _records_with_delta(
     for index in range(n_candidate):
         records.append(
             _ok_record(
-                candidate=True,
+                arm_label=contract.ARM_CANDIDATE,
                 entry_close="100",
                 exit_close=candidate_exit,
                 epoch_start_ms=index * contract.INTERVAL_MS,
@@ -200,7 +201,7 @@ def _records_with_delta(
     for index in range(n_control):
         records.append(
             _ok_record(
-                candidate=False,
+                arm_label=contract.ARM_CONTROL,
                 entry_close="100",
                 exit_close=control_exit,
                 epoch_start_ms=(n_candidate + index) * contract.INTERVAL_MS,
@@ -378,7 +379,10 @@ def test_control_arm_executes_same_selection() -> None:
         },
     )
     assert basket.winner == "AAAUSDT"
-    assert basket.candidate_any is True
+    assert basket.candidate_any == contract.ARM_CANDIDATE
+    # The arm is a label, not a truth value: `is True` must no longer hold.
+    assert basket.candidate_any is not True
+    assert not isinstance(basket.candidate_any, bool)
 
 
 def test_contract_remains_offline_only() -> None:
@@ -407,13 +411,13 @@ def test_v21_port_blobs_are_importable_and_unmodified_identity() -> None:
 
 
 def test_outcome_from_decision_and_raw_kline_evidence() -> None:
-    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    decision = _decision(candidate_any=contract.ARM_CANDIDATE, winner="AAAUSDT")
     entry = _close_evidence("AAAUSDT", 0, close="100")
     nxt = _close_evidence("AAAUSDT", contract.INTERVAL_MS, close="101")
     record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=nxt)
     assert record.status == "ok"
     assert record.observation is not None
-    assert record.observation.candidate is True
+    assert record.observation.arm_label == contract.ARM_CANDIDATE
     assert record.observation.outcome_bps == pytest.approx(
         abs(math.log(101 / 100)) * 10_000.0
     )
@@ -421,7 +425,7 @@ def test_outcome_from_decision_and_raw_kline_evidence() -> None:
 
 
 def test_harness_outcome_from_candles_binds_decision() -> None:
-    decision = _decision(candidate_any=False, winner="AAAUSDT")
+    decision = _decision(candidate_any=contract.ARM_CONTROL, winner="AAAUSDT")
     entry = _candle(
         "AAAUSDT", 0, source="kline", payload=_kline_payload(0, close="100")
     )
@@ -436,7 +440,7 @@ def test_harness_outcome_from_candles_binds_decision() -> None:
     )
     assert record.status == "ok"
     assert record.observation is not None
-    assert record.observation.candidate is False
+    assert record.observation.arm_label == contract.ARM_CONTROL
 
 
 def test_absolute_log_return_bps_is_not_a_free_outcome_surface() -> None:
@@ -448,6 +452,164 @@ def test_absolute_log_return_bps_is_not_a_free_outcome_surface() -> None:
     assert not hasattr(contract, "make_outcome_observation")
     sig = inspect.signature(contract.make_outcome_epoch_record)
     assert list(sig.parameters) == ["decision", "entry", "next_bar"]
+
+
+def _forged_decision(arm: object, winner: str = "AAAUSDT") -> contract.BasketDecision:
+    """Build a BasketDecision past its own validator.
+
+    The dataclass refuses a bad arm, which is the first line of defence.  This
+    bypass exists so the *second* line — the factory and the adjudicator — is
+    tested on its own: a guard that only works because another guard already
+    ran is not a guard.
+    """
+    forged = object.__new__(contract.BasketDecision)
+    object.__setattr__(forged, "candidate_any", arm)
+    object.__setattr__(forged, "winner", winner)
+    object.__setattr__(forged, "scores", ())
+    return forged
+
+
+# ---------------------------------------------------------------------------
+# NW-F4 arm label: closed domain, no coercion
+# ---------------------------------------------------------------------------
+
+
+def test_arm_label_domain_is_the_shared_closed_set() -> None:
+    """Pin the wire contract v2.2 shares with the A2 registration (PR #1826).
+
+    The two registrations live on disjoint paths and cannot import each other,
+    so the only thing keeping them from drifting is that both pin this exact
+    literal.  Changing it here without changing it there is the split this test
+    exists to make loud.
+    """
+    assert contract.ARM_LABELS == ("candidate", "control")
+    assert (contract.ARM_CANDIDATE, contract.ARM_CONTROL) == contract.ARM_LABELS
+    assert all(isinstance(label, str) for label in contract.ARM_LABELS)
+    assert not any(isinstance(label, bool) for label in contract.ARM_LABELS)
+    estimand = contract.contract_as_machine_data()["estimand"]
+    assert estimand["arm_labels"] == list(contract.ARM_LABELS)
+    assert estimand["arm_label_domain"] == "closed"
+    assert estimand["arm_label_coercion"] == "forbidden"
+    assert estimand["arm_label_wire_type"] == "string"
+    assert (
+        estimand["arm_label_counterpart_module"]
+        == "research.dfc_v22_research_min.contract"
+    )
+    assert "research/dfc_v22_research_min/contract.py" in inspect.getsource(contract)
+
+
+def test_arbitrary_string_arm_is_rejected_at_every_layer() -> None:
+    """The v1 split: A2 admitted this string while v2.2 coerced it to True."""
+    arbitrary = "arbitrary-nonboolean-arm"
+    with pytest.raises(contract.ArmLabelViolation, match="admissible arm labels"):
+        contract.require_arm_label(arbitrary)
+    with pytest.raises(contract.ArmLabelViolation, match="admissible arm labels"):
+        contract.BasketDecision(arbitrary, "AAAUSDT", ())  # type: ignore[arg-type]
+
+    # Past the dataclass, the factory still refuses — and does not coerce.
+    entry = _close_evidence("AAAUSDT", 0, close="100")
+    nxt = _close_evidence("AAAUSDT", contract.INTERVAL_MS, close="101")
+    record = contract.make_outcome_epoch_record(
+        _forged_decision(arbitrary), entry=entry, next_bar=nxt
+    )
+    assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
+    assert record.observation is None
+
+
+def test_free_bool_arm_is_rejected_and_never_coerced() -> None:
+    entry = _close_evidence("AAAUSDT", 0, close="100")
+    nxt = _close_evidence("AAAUSDT", contract.INTERVAL_MS, close="101")
+    for value in (True, False):
+        with pytest.raises(contract.ArmLabelViolation, match="free bool"):
+            contract.require_arm_label(value)
+        record = contract.make_outcome_epoch_record(
+            _forged_decision(value), entry=entry, next_bar=nxt
+        )
+        assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
+        assert record.observation is None
+
+
+def test_out_of_domain_arm_is_run_invalid_not_swept_into_control() -> None:
+    """`not candidate` used to make every non-True value a control epoch."""
+    good = _records_with_delta(
+        n_candidate=400, n_control=400, candidate_exit="100.6", control_exit="100.1"
+    )
+    forged = object.__new__(contract.OutcomeObservation)
+    object.__setattr__(forged, "arm_label", "arbitrary-nonboolean-arm")
+    object.__setattr__(forged, "outcome_bps", 12.5)
+    object.__setattr__(forged, "binding", good[0].observation.binding)
+    holder = object.__new__(contract.OutcomeEpochRecord)
+    object.__setattr__(holder, "status", "ok")
+    object.__setattr__(holder, "observation", forged)
+
+    result = contract.adjudicate_outcomes((holder, *good))
+    assert result.status == contract.STATUS_RUN_INVALID
+    assert result.reason_code == contract.RUN_INVALID_OUTCOME_EVIDENCE
+
+
+def test_no_silent_bool_coercion_of_the_arm_remains_in_source() -> None:
+    """Static guard against reintroducing the coercion this round removed."""
+    source = inspect.getsource(contract)
+    for forbidden in (
+        "bool(decision.candidate_any)",
+        "bool(candidates)",
+        "if item.candidate",
+        "if not item.candidate",
+    ):
+        assert forbidden not in source, forbidden
+    assert "arm_label = ARM_CANDIDATE if candidates else ARM_CONTROL" in source
+
+
+# ---------------------------------------------------------------------------
+# Verbatim upstream wording (NW-F4, NW-F7)
+# ---------------------------------------------------------------------------
+
+
+def test_nw_f4_and_nw_f7_are_carried_verbatim() -> None:
+    """No paraphrase, no translation, no summary — the signed text itself."""
+    assert contract.CANONICAL_SOURCE_SHA256.startswith("df7aee908e50af42")
+    assert len(contract.CANONICAL_SOURCE_SHA256) == 64
+    assert contract.CANONICAL_SOURCE_LINE_COUNT == 137
+
+    assert contract.NW_F4_VERBATIM == (
+        "**“signal epoch t의 `BasketDecision.candidate_any`가 arm label, 같은 "
+        "decision의 winner가 심볼이다. outcome은 그 심볼의 완결된 t kline close부터 "
+        "즉시 다음 완결 4h kline close까지의 absolute log return bps다. 둘 모두 raw "
+        "evidence에서만 생성한다. 다음 bar가 없거나 불완전하면 행을 임의 삭제하지 않고 "
+        "`RUN_INVALID_OUTCOME_EVIDENCE`; 마지막 signal을 위해 corpus에는 한 개의 다음 "
+        "4h bar를 추가한다. 이는 PnL/체결 가능성 주장이 아니다.”** 자유 bool·자유 가격 "
+        "입력을 금지한다."
+    )
+    assert contract.NW_F7_VERBATIM == (
+        "**“역사검증은 정확히 1회다. candidate/control 각 ≥400, stationary block "
+        "bootstrap 10,000회·block 24 epoch. `PASS`는 candidate−control 95% CI lower "
+        ">5bp **AND** two-sided p<0.05; 표본 미달은 `INCONCLUSIVE`; 그 밖은 "
+        "`FALSIFIED`; 입력/증거 위반 `RUN_INVALID`가 최우선이다. PASS/FALSIFIED 문언 "
+        "불일치는 v2.2에서 `PASS 조건의 부정=FALSIFIED`로 단일화한다. 결과 열람 후 "
+        "threshold·horizon·universe 변경 0.”** planning SD는 데이터 접촉 전 계약에 "
+        "고정하거나 power claim을 제거한다."
+    )
+    # The unification clause specifically, as its own quotable literal.
+    assert contract.NW_F7_PASS_FALSIFIED_UNIFICATION == "PASS 조건의 부정=FALSIFIED"
+    assert contract.NW_F7_PASS_FALSIFIED_UNIFICATION in contract.NW_F7_VERBATIM
+    assert "`BasketDecision.candidate_any`가 arm label" in contract.NW_F4_VERBATIM
+
+    # Carried in the source, and inside the canonical contract hash.
+    source = inspect.getsource(contract)
+    assert contract.NW_F4_VERBATIM in source
+    assert contract.NW_F7_VERBATIM in source
+    wording = contract.contract_as_machine_data()["canonical_wording"]
+    assert wording["nw_f4_verbatim"] == contract.NW_F4_VERBATIM
+    assert wording["nw_f7_verbatim"] == contract.NW_F7_VERBATIM
+    assert wording["pass_falsified_unification_verbatim"] == (
+        contract.NW_F7_PASS_FALSIFIED_UNIFICATION
+    )
+    assert wording["paraphrase"] == "forbidden"
+    assert wording["source_sha256"] == contract.CANONICAL_SOURCE_SHA256
+    assert dict(contract.NW_VERBATIM_CLAUSES) == {
+        "NW-F4": contract.NW_F4_VERBATIM,
+        "NW-F7": contract.NW_F7_VERBATIM,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -463,22 +625,41 @@ def test_mutant1_free_bool_outcome_construction_is_rejected() -> None:
     # Forged non-_OutcomeBinding binding is also rejected.
     with pytest.raises(TypeError, match="evidence binding"):
         contract.OutcomeObservation(  # type: ignore[arg-type]
-            candidate=True,
+            arm_label=contract.ARM_CANDIDATE,
             outcome_bps=50.0,
             binding=SimpleNamespace(
                 winner_symbol="AAAUSDT",
                 signal_epoch_start_ms=0,
                 entry_payload_sha256="a" * 64,
                 exit_payload_sha256="b" * 64,
-                decision_candidate_any=True,
+                decision_candidate_any=contract.ARM_CANDIDATE,
                 decision_winner="AAAUSDT",
             ),
         )
+    # A real binding does not make a bool an arm: True/False are refused on
+    # both the observation and the binding, so a self-consistent pair of bools
+    # cannot slip past the equality check.
+    with pytest.raises(contract.ArmLabelViolation, match="free bool"):
+        contract.OutcomeObservation(  # type: ignore[arg-type]
+            arm_label=True,
+            outcome_bps=50.0,
+            binding=contract._OutcomeBinding(
+                winner_symbol="AAAUSDT",
+                signal_epoch_start_ms=0,
+                entry_payload_sha256="a" * 64,
+                exit_payload_sha256="b" * 64,
+                decision_candidate_any=True,  # type: ignore[arg-type]
+                decision_winner="AAAUSDT",
+            ),
+        )
+    # A BasketDecision cannot even be built with a bool arm.
+    with pytest.raises(contract.ArmLabelViolation, match="free bool"):
+        contract.BasketDecision(True, "AAAUSDT", ())  # type: ignore[arg-type]
 
 
 def test_mutant2_free_price_outside_raw_evidence_is_rejected() -> None:
     """② free price (outside raw evidence) → rejected."""
-    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    decision = _decision(candidate_any=contract.ARM_CANDIDATE, winner="AAAUSDT")
     # Free floats are not accepted — entry/next_bar must be _KlineCloseEvidence.
     record = contract.make_outcome_epoch_record(
         decision,
@@ -518,7 +699,7 @@ def test_mutant2_free_price_outside_raw_evidence_is_rejected() -> None:
 
 def test_mutant3_missing_next_bar_is_run_invalid_not_row_drop() -> None:
     """③ missing next bar → RUN_INVALID_OUTCOME_EVIDENCE, not silent deletion."""
-    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    decision = _decision(candidate_any=contract.ARM_CANDIDATE, winner="AAAUSDT")
     entry = _close_evidence("AAAUSDT", 0, close="100")
     record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=None)
     assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE
@@ -611,7 +792,7 @@ def test_pass_vs_falsified_unification() -> None:
 
 
 def test_incomplete_next_bar_is_run_invalid() -> None:
-    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    decision = _decision(candidate_any=contract.ARM_CANDIDATE, winner="AAAUSDT")
     entry = _close_evidence("AAAUSDT", 0, close="100")
     # Wrong interval (not immediate next 4h bar).
     far = _close_evidence("AAAUSDT", 2 * contract.INTERVAL_MS, close="101")
@@ -620,7 +801,7 @@ def test_incomplete_next_bar_is_run_invalid() -> None:
 
 
 def test_winner_symbol_mismatch_is_run_invalid() -> None:
-    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    decision = _decision(candidate_any=contract.ARM_CANDIDATE, winner="AAAUSDT")
     entry = _close_evidence("BBBUSDT", 0, close="100")
     nxt = _close_evidence("BBBUSDT", contract.INTERVAL_MS, close="101")
     record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=nxt)
@@ -648,7 +829,7 @@ def test_false_green_guard_mutant_goldens_have_failing_negations() -> None:
     assert (not raised) is False  # inverted golden would fail
 
     # ③ missing next bar is INVALID (inverted: status == "ok" is False).
-    decision = _decision(candidate_any=True, winner="AAAUSDT")
+    decision = _decision(candidate_any=contract.ARM_CANDIDATE, winner="AAAUSDT")
     entry = _close_evidence("AAAUSDT", 0, close="100")
     record = contract.make_outcome_epoch_record(decision, entry=entry, next_bar=None)
     assert record.status == contract.RUN_INVALID_OUTCOME_EVIDENCE


### PR DESCRIPTION
## Summary

- Port DFC v2.1 **3 blobs byte-identical** from `origin/feature/DFC-2C-4H-v21-pr@9f605139` (NW-F3: **no whole-branch merge**, branch preserved as provenance).
- Register **new** contract `DFC-2C-4H-v2.2` with new canonical SHA (does not overwrite v2.1).
- Close R3 outcome BLOCKER (NW-F4): arm/symbol/outcome only from `BasketDecision` + raw kline evidence; free bool/price surfaces removed; missing next bar → `RUN_INVALID_OUTCOME_EVIDENCE` (no row drop).
- Unify NW-F7 verdicts: `PASS` / `INCONCLUSIVE` / `FALSIFIED` / `RUN_INVALID` with **RUN_INVALID highest precedence**; `PASS` condition negation = `FALSIFIED`.
- Remove unverifiable `planning_sd` power claim (data-contact-free choice per NW-F7).

## Scope / safety

- **Data contact 0** (no public API / S3 / corpus / backtest execution).
- DB write 0 · broker 0 · env 0 · account 0 · order 0 · scheduler 0 · merge 0.
- v2.1 branch untouched; only 3 blobs cherry-ported.

## Test plan

- [x] `uv run pytest tests/research_contracts/test_dfc_2c_4h_v22.py tests/research_contracts/test_dfc_2c_4h_v21.py -v` → 39 passed
- [x] Mutants ①–⑤ inject → golden FAIL → restore (byte-identical restore)
- [x] `ruff format --check` + `ruff check` on research_contracts + tests
- [ ] CI green on PR

## Verdict literals (NW-F7)

| Status | Meaning |
|---|---|
| PASS | CI lower > 5bp AND two-sided p < 0.05 |
| INCONCLUSIVE | candidate or control n < 400 |
| FALSIFIED | negation of PASS |
| RUN_INVALID | input/evidence violation — **first** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable, offline DFC-2C-4H v2.1 and v2.2 contract registrations.
  * Added evidence processing for 4-hour market data, including source verification, timestamp alignment, forward-only safeguards, and feature construction.
  * Added deterministic basket scoring, outcome evaluation, bootstrap analysis, and machine-readable contract records.
  * Added explicit adjudication statuses, including pass, inconclusive, falsified, and invalid outcome evidence.

* **Bug Fixes**
  * Invalid, incomplete, mismatched, or non-finite evidence is now rejected safely.

* **Tests**
  * Added extensive adversarial coverage for integrity, provenance, validation, and false-positive prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->