### PR TITLE
feat(dfc): DFC_V22_RESEARCH_MIN (A2) 계약 신설 — 문서·schema·golden

### DIFF
--- a/research/dfc_v22_research_min/__init__.py
+++ b/research/dfc_v22_research_min/__init__.py
@@ -1,0 +1,20 @@
+"""``DFC_V22_RESEARCH_MIN`` (A2) — contract, schema and fail-closed validators.
+
+This package is documentation-and-schema only.  It never fetches, lists or
+downloads anything: the A2 *measurement* job is a separate relay unit, and this
+package exists so that measurement can be judged against literals that were
+frozen **before** any data was touched.
+
+Modules:
+
+``nw_verbatim``
+    Byte-exact upstream clause text (NW-F2/F4/F5/F6).  Generated, never edited.
+``contract``
+    Frozen literals and clause IDs derived from that text.
+``schema``
+    Canonical parquet schemas and manifest key sets.
+``validation``
+    Fail-closed validators that raise :class:`~.validation.ContractViolation`.
+"""
+
+from __future__ import annotations

--- a/research/dfc_v22_research_min/contract.py
+++ b/research/dfc_v22_research_min/contract.py
@@ -33,6 +33,9 @@ from .nw_verbatim import (
 __all__ = [
     "A1_READINESS_IDS",
     "A2_JUDGED_DIMENSIONS",
+    "ARM_CANDIDATE",
+    "ARM_CONTROL",
+    "ARM_LABELS",
     "BAR_INTERVAL_MS",
     "CANONICAL_SOURCE_PATH",
     "CANONICAL_SOURCE_SHA256",
@@ -144,6 +147,27 @@ IMPUTED_ROW_COUNT_MAX = 0
 
 
 # --- A2-C4 (NW-F4): outcome semantics -------------------------------------
+
+# DFC v2.2 arm-label wire contract (shared; byte-identical in both registrations)
+# =============================================================================
+# NW-F4 says ``BasketDecision.candidate_any`` *is an arm label*.  It is therefore
+# carried as a label, never as a truth value, and the label domain is closed:
+#
+#     ARM_CANDIDATE = "candidate"
+#     ARM_CONTROL   = "control"
+#     ARM_LABELS    = ("candidate", "control")
+#
+# Counterpart declaration: ``research_contracts/dfc_2c_4h_v22.py`` (PR #1825),
+# which declares the same three literals in the same order.  Both sides reject
+# anything outside this set and neither side coerces: a value that is not
+# exactly one of these two labels never becomes an arm, it becomes
+# ``RUN_INVALID_OUTCOME_EVIDENCE``.  A bare ``bool`` is rejected explicitly and
+# ahead of the membership test, because ``bool`` is precisely the shape NW-F4
+# forbids ("자유 bool ... 입력을 금지한다") and precisely the shape a silent
+# ``bool(...)`` coercion would manufacture.
+ARM_CANDIDATE = "candidate"
+ARM_CONTROL = "control"
+ARM_LABELS: tuple[str, ...] = (ARM_CANDIDATE, ARM_CONTROL)
 
 #: ``candidate_any`` of the ``BasketDecision`` at signal epoch ``t``.
 OUTCOME_ARM_LABEL_FIELD = "candidate_any"

--- a/research/dfc_v22_research_min/contract.py
+++ b/research/dfc_v22_research_min/contract.py
@@ -1,0 +1,211 @@
+"""Frozen literals for the ``DFC_V22_RESEARCH_MIN`` (A2) contract.
+
+Every literal here is a mechanical transcription of one of the four verbatim
+upstream clauses in :mod:`research.dfc_v22_research_min.nw_verbatim`.  Nothing
+here may be relaxed, widened or re-derived after corpus results are read; the
+whole point of registering this file before data contact is that the gate is
+signed blind.
+
+Clause IDs used across the contract document, the schemas and the golden cases:
+
+============  ================  =========================================
+Clause        Upstream source   Subject
+============  ================  =========================================
+``A2-C1``     NW-F2             Scope separation from FUT-DATA-A1
+``A2-C2``     NW-F5             Corpus identity, windows and universe rule
+``A2-C3``     NW-F5             Required / forbidden source material
+``A2-C4``     NW-F4             Outcome semantics
+``A2-C5``     NW-F6             Authenticity and freeze procedure
+============  ================  =========================================
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import MappingProxyType
+
+from .nw_verbatim import (
+    CANONICAL_SOURCE_PATH,
+    CANONICAL_SOURCE_SHA256,
+    VERBATIM_CLAUSES,
+)
+
+__all__ = [
+    "A1_READINESS_IDS",
+    "A2_JUDGED_DIMENSIONS",
+    "BAR_INTERVAL_MS",
+    "CANONICAL_SOURCE_PATH",
+    "CANONICAL_SOURCE_SHA256",
+    "CLAUSE_SOURCES",
+    "CONTRACT_DOC_RELPATH",
+    "CONTRACT_ID",
+    "CORPUS_ID",
+    "CORPUS_ROOT",
+    "FORBIDDEN_SOURCE_KINDS",
+    "IMPUTED_ROW_COUNT_MAX",
+    "JUDGMENT_END",
+    "JUDGMENT_START",
+    "OUTCOME_HORIZON_BARS",
+    "OUTCOME_TAIL_BARS",
+    "OUTCOME_UNIT",
+    "REQUIRED_SOURCE_KINDS",
+    "UNIVERSE_LOOKBACK_CALENDAR_DAYS",
+    "UNIVERSE_RANKING_METRIC",
+    "UNIVERSE_TIE_BREAK",
+    "UNIVERSE_TOP_N",
+    "VERBATIM_CLAUSES",
+    "WARMUP_END",
+    "WARMUP_START",
+]
+
+
+def _utc(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=UTC)
+
+
+# --- A2-C1 (NW-F2): scope separation -------------------------------------
+
+CONTRACT_ID = "DFC_V22_RESEARCH_MIN"
+CONTRACT_DOC_RELPATH = "research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md"
+
+#: The only dimensions A2 judges.  A manifest that claims readiness on
+#: anything else is not this contract.
+A2_JUDGED_DIMENSIONS: tuple[str, ...] = (
+    "kline_ofi",
+    "premium_index",
+    "pit_universe",
+    "outcome_evidence",
+)
+
+#: FUT-DATA-A1 stays on the record as its own (``UNDETERMINED``) readiness
+#: statement.  It is preserved, and it is *not* a prerequisite of DFC-v2.x.
+A1_READINESS_IDS: frozenset[str] = frozenset(
+    {"FUT-DATA-A1", "FUT_DATA_A1", "fut-data-a1", "fut_data_a1"}
+)
+
+
+# --- A2-C2 (NW-F5): corpus identity, windows, universe --------------------
+
+CORPUS_ID = "dfc-2c-4h-v22-corpus-v1"
+CORPUS_ROOT = "/Users/mgh3326/work/herdr-artifacts/dfc-2c-4h-v22-corpus-v1/"
+
+#: Half-open ``[start, end)`` in UTC, exactly as signed.
+WARMUP_START = _utc(2021, 2, 2)
+WARMUP_END = _utc(2021, 5, 2)
+JUDGMENT_START = _utc(2021, 5, 2)
+JUDGMENT_END = _utc(2023, 8, 4)
+
+#: One extra completed 4h bar past ``JUDGMENT_END`` so the last signal epoch
+#: has an outcome.  Not a widening of the judgment window.
+OUTCOME_TAIL_BARS = 1
+
+BAR_INTERVAL_MS = 4 * 60 * 60 * 1000
+
+UNIVERSE_LOOKBACK_CALENDAR_DAYS = 30
+UNIVERSE_RANKING_METRIC = "quote_volume"
+UNIVERSE_TOP_N = 3
+UNIVERSE_TIE_BREAK = "canonical_symbol_ascending"
+UNIVERSE_INSTRUMENT_CLASS = "usdm_perpetual"
+
+
+# --- A2-C3 (NW-F5): required and forbidden source material ----------------
+
+REQUIRED_SOURCE_KINDS: tuple[str, ...] = (
+    "usdm_kline_4h",
+    "premium_index_4h",
+    "contract_lifecycle_eligibility",
+)
+
+#: Explicitly excluded from this corpus.  DFC-v2.2 signals do not read them,
+#: so their presence means the corpus is not the one that was signed.
+FORBIDDEN_SOURCE_KINDS: frozenset[str] = frozenset(
+    {
+        "funding_rate",
+        "funding",
+        "open_interest",
+        "open_interest_hist",
+        "mark_price",
+        "index_price",
+    }
+)
+
+#: Column-name tokens that betray a forbidden source smuggled into a table.
+FORBIDDEN_COLUMN_TOKENS: tuple[str, ...] = (
+    "funding",
+    "open_interest",
+    "openinterest",
+    "mark_price",
+    "markprice",
+    "index_price",
+    "indexprice",
+)
+
+IMPUTED_ROW_COUNT_MAX = 0
+
+
+# --- A2-C4 (NW-F4): outcome semantics -------------------------------------
+
+#: ``candidate_any`` of the ``BasketDecision`` at signal epoch ``t``.
+OUTCOME_ARM_LABEL_FIELD = "candidate_any"
+#: The winner of that same decision.
+OUTCOME_SYMBOL_FIELD = "winner_symbol"
+
+OUTCOME_UNIT = "absolute_log_return_bps"
+#: ``t`` close to the immediately next completed 4h close — one bar, never two.
+OUTCOME_HORIZON_BARS = 1
+#: Recomputation tolerance in bps; wider tolerances hide fabricated outcomes.
+OUTCOME_BPS_TOLERANCE = 1e-6
+
+#: The single terminal code for outcome-evidence failure.  Silent row removal
+#: is the failure this code exists to make impossible.
+RUN_INVALID_OUTCOME_EVIDENCE = "RUN_INVALID_OUTCOME_EVIDENCE"
+
+#: An outcome row must be fully reconstructible from referenced raw bars.  No
+#: operator-supplied booleans, no operator-supplied prices.
+OUTCOME_EVIDENCE_STATUS = "raw_evidence_complete"
+OUTCOME_FREE_PRICE_TOKENS: tuple[str, ...] = (
+    "price",
+    "entry",
+    "exit",
+    "fill",
+    "pnl",
+    "return_pct",
+    "notional",
+)
+
+
+# --- A2-C5 (NW-F6): authenticity and freeze procedure ---------------------
+
+#: Recorded on every original object/response.
+REQUIRED_PROVENANCE_FIELDS: tuple[str, ...] = (
+    "endpoint",
+    "query",
+    "retrieved_at",
+    "schema",
+    "object_sha256",
+    "payload_sha256_by_epoch",
+)
+
+#: Admissibility is decided by an independent verifier re-collecting the same
+#: public object and comparing these keys.  Self-consistency is not a basis.
+ADMISSIBILITY_BASIS = "independent_recollection"
+ADMISSIBILITY_FORBIDDEN_BASES: frozenset[str] = frozenset(
+    {"self_consistency", "self-consistency", "internal_check"}
+)
+ADMISSIBILITY_COMPARISON_KEYS: tuple[str, ...] = (
+    "object_sha256",
+    "row_count",
+    "time_bounds",
+    "raw_payload_sha256",
+)
+
+
+CLAUSE_SOURCES: MappingProxyType[str, str] = MappingProxyType(
+    {
+        "A2-C1": "NW-F2",
+        "A2-C2": "NW-F5",
+        "A2-C3": "NW-F5",
+        "A2-C4": "NW-F4",
+        "A2-C5": "NW-F6",
+    }
+)

--- a/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
+++ b/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
@@ -1,0 +1,175 @@
+# DFC_V22_RESEARCH_MIN — A2 contract
+
+Status: signed **before** any data contact. Registered as a new ID/SHA per NW-F2.
+Scope: documentation, schema and golden fixtures only. This contract performs no
+collection, no listing, no download and no backtest.
+
+| | |
+|---|---|
+| Contract ID | `DFC_V22_RESEARCH_MIN` |
+| Judged dimensions | kline OFI · premium-index · PIT universe · outcome evidence |
+| Upstream wording (canonical) | `~/work/herdr-inbox/answer-codexmock-next-wave-1630.md`, sha256 `df7aee908e50af42…` (137 lines) |
+| Binding record | `~/work/herdr-inbox/operator-decisions-20260805-0830.md` §25차 |
+| Schema | `research/dfc_v22_research_min/schema.py` |
+| Validators | `research/dfc_v22_research_min/validation.py` |
+| Golden cases | `tests/research/dfc_v22_research_min/golden/violation_cases.json` |
+
+The four upstream clauses are reproduced below **verbatim**, in the language they
+were signed in. They are also carried byte-for-byte in
+`research/dfc_v22_research_min/nw_verbatim.py`, and a test asserts that this
+document and that module agree, so no later edit can quietly paraphrase a clause.
+Everything outside the quote blocks is transcription into schema — it adds
+enforcement, never scope.
+
+## Why this contract exists (A2 vs A1)
+
+FUT-DATA-A1 is final at `UNDETERMINED`. It is a readiness statement about a wider
+futures research corpus — funding, open interest, mark and index — and DFC-v2.2
+signals read none of those: they read 4h kline OFI and the premium index. Making
+A1 the gate for DFC would gate the work on evidence the strategy never touches,
+in both directions. A1 is therefore preserved as-is and A2 is registered
+separately. This is not a post-hoc relaxation: zero backtests have been run, and
+the numbers being frozen here are frozen blind.
+
+---
+
+## A2-C1 — Scope separation (NW-F2)
+
+> **NW-F2 — A1과 DFC 최소 corpus의 범위 분리** (원문 축자 인용)
+>
+> **“A1의 funding/OI/mark/index 종합 readiness는 보존하되 DFC-v2.x의 선행조건으로 쓰지 않는다. 데이터 접촉 전에 `DFC_V22_RESEARCH_MIN` A2 계약을 새 ID/SHA로 등록한다. A2는 kline OFI·premium-index·PIT universe·outcome evidence만 판정한다.”** 이는 결과를 본 뒤 게이트를 완화하는 것이 아니라, 아직 백테스트 0회인 상태에서 계약-데이터 불일치를 교정하는 것이다.
+
+
+**Enforced as.** `validate_manifest` requires
+`prerequisite_readiness.contract_id == "DFC_V22_RESEARCH_MIN"` and
+`prerequisite_readiness.dimensions` to equal exactly
+`("kline_ofi", "premium_index", "pit_universe", "outcome_evidence")`. Naming
+FUT-DATA-A1 as the prerequisite raises `RUN_INVALID_SCOPE_SEPARATION`. A1's own
+record is untouched by this contract.
+
+---
+
+## A2-C2 / A2-C3 — Corpus freeze literals and source material (NW-F5)
+
+> **NW-F5 — corpus 동결 리터럴** (원문 축자 인용)
+>
+> **“corpus ID=`dfc-2c-4h-v22-corpus-v1`, root=`/Users/mgh3326/work/herdr-artifacts/dfc-2c-4h-v22-corpus-v1/`; warmup `[2021-02-02T00:00Z,2021-05-02T00:00Z)`, 판정창 `[2021-05-02T00:00Z,2023-08-04T00:00Z)`, 마지막 outcome용 다음 4h bar 포함. 매 epoch 직전 30 calendar day quote-volume으로 당시 eligible USD-M perpetual 전수를 순위화해 top 3, 동률은 canonical symbol 오름차순. 필수 원문은 Binance USD-M 4h kline 12필드와 premiumIndex 4h close, contract lifecycle/eligibility evidence다. funding/OI/mark/index는 이 corpus에 넣지 않는다. imputation 0.”**
+
+
+**Enforced as.** `contract.py` freezes each literal, and `validate_manifest`
+compares them for equality — not for containment, not for "at least":
+
+| Literal | Frozen value |
+|---|---|
+| `corpus_id` | `dfc-2c-4h-v22-corpus-v1` |
+| `root` | `/Users/mgh3326/work/herdr-artifacts/dfc-2c-4h-v22-corpus-v1/` |
+| warmup | `[2021-02-02T00:00:00Z, 2021-05-02T00:00:00Z)` |
+| judgment window | `[2021-05-02T00:00:00Z, 2023-08-04T00:00:00Z)` |
+| outcome tail | exactly 1 further completed 4h bar |
+| universe | rank all then-eligible USD-M perpetuals by the preceding 30 calendar days of quote volume, take top 3, ties broken by canonical symbol ascending |
+| required source material | Binance USD-M 4h kline (all 12 fields) · premiumIndex 4h close · contract lifecycle/eligibility evidence |
+| excluded source material | funding · open interest · mark price · index price |
+| imputation | `policy = "forbidden"`, `imputed_row_count = 0` |
+
+A scratch path is not the corpus: `root` must match the frozen literal, so a
+`/private/tmp` build cannot be presented as the frozen artifact.
+
+Exclusion is checked twice, because a forbidden source can arrive either as a
+declared manifest source or as a column smuggled into a canonical table. A
+`kind` in the forbidden set, and any column or endpoint whose name contains
+`funding`, `open_interest`, `mark_price` or `index_price`, both raise
+`RUN_INVALID_FORBIDDEN_SOURCE`.
+
+The canonical tables are **closed schemas** — exact column set, exact order,
+exact types, no extra columns. Decimal fields (`open`/`high`/`low`/`close`/
+volumes/`premium_index_close`) are typed `string` and carry the raw payload token
+unchanged, because A2-C5 admissibility is decided by comparing raw payload
+hashes and a float round-trip destroys precisely those bytes.
+
+---
+
+## A2-C4 — Outcome semantics (NW-F4)
+
+> **NW-F4 — outcome 의미론** (원문 축자 인용)
+>
+> **“signal epoch t의 `BasketDecision.candidate_any`가 arm label, 같은 decision의 winner가 심볼이다. outcome은 그 심볼의 완결된 t kline close부터 즉시 다음 완결 4h kline close까지의 absolute log return bps다. 둘 모두 raw evidence에서만 생성한다. 다음 bar가 없거나 불완전하면 행을 임의 삭제하지 않고 `RUN_INVALID_OUTCOME_EVIDENCE`; 마지막 signal을 위해 corpus에는 한 개의 다음 4h bar를 추가한다. 이는 PnL/체결 가능성 주장이 아니다.”** 자유 bool·자유 가격 입력을 금지한다.
+
+
+**Enforced as.** `validate_outcomes(outcomes, klines, decisions)` takes the
+decision record as a separate input, and:
+
+1. **Closed outcome schema.** Any column outside the eleven declared ones raises
+   `RUN_INVALID_OUTCOME_EVIDENCE`. A boolean-typed extra column and a
+   price/PnL-named extra column are reported with their own wording, because
+   those are the two shapes the forbidden free inputs actually take.
+2. **No deletion.** Every `signal_epoch_open_time` in `decisions` must have
+   exactly one outcome row. A shorter outcome table is the deletion this clause
+   forbids, and it fails as `RUN_INVALID_OUTCOME_EVIDENCE` — never as a silent
+   pass on the surviving rows.
+3. **Next bar is the next bar.** `next_kline_open_time` must equal
+   `t_kline_open_time + 4h`, and that bar must be present in `klines_4h` with a
+   matching `close_time`. Absent or mismatched ⇒ `RUN_INVALID_OUTCOME_EVIDENCE`.
+4. **Raw evidence only.** The arm label and the winner must equal the decision's
+   `candidate_any` and winner; both referenced closes must match the
+   `payload_sha256` of the raw bars they claim to come from; and
+   `outcome_abs_log_return_bps` is recomputed from those two raw close tokens and
+   compared within 1e-6 bps. A hand-written outcome number cannot survive this.
+
+`outcome_abs_log_return_bps = |ln(next_close / t_close)| × 10000`. This is a
+measurement of bar-to-bar movement. It is **not** a PnL claim and **not** a
+fill-feasibility claim; no fee, slippage, spread or queue model is present, and
+none may be added to this table.
+
+---
+
+## A2-C5 — Authenticity and freeze procedure (NW-F6)
+
+> **NW-F6 — corpus 진정성·동결 절차** (원문 축자 인용)
+>
+> **“모든 원본 object/response에 endpoint·query·retrieved_at·schema·object/ZIP SHA-256·epoch별 payload SHA를 기록한다. manifest와 canonical parquet를 동결하고, 독립 검증자가 동일 public object를 재수집해 object SHA/행수/시각경계/원시 payload hash를 대조해야 admissible이다. 자기 일관성 검사만으로 Binance 진정성을 주장하지 않는다.”**
+
+
+**Enforced as.** Every manifest source entry must carry `endpoint`, `query`,
+`retrieved_at`, `schema`, `object_kind`, `object_sha256`, a non-empty
+`payload_sha256_by_epoch` mapping, `byte_size` and `row_count`; every canonical
+table entry must carry `path`, `sha256`, `row_count` and `byte_size`; and the
+manifest must declare `frozen = true`. Any missing or empty provenance field
+raises `RUN_INVALID_AUTHENTICITY_EVIDENCE`.
+
+Admissibility is a separate, explicit declaration:
+`admissibility.basis` must be `independent_recollection`,
+`independent_recollection_required` must be `true`, and `comparison_keys` must be
+exactly `("object_sha256", "row_count", "time_bounds", "raw_payload_sha256")`.
+A basis of `self_consistency` is rejected by name. Internal consistency of this
+corpus with itself is not evidence that Binance produced it; only a verifier who
+re-fetches the same public object and matches those four keys makes it
+admissible.
+
+---
+
+## Terminal codes
+
+| Code | Raised when |
+|---|---|
+| `RUN_INVALID_SCOPE_SEPARATION` | A1 (or anything else) declared as the DFC prerequisite (A2-C1) |
+| `RUN_INVALID_CORPUS_LITERALS` | a frozen id, path, window, universe rule or imputation literal was changed (A2-C2) |
+| `RUN_INVALID_FORBIDDEN_SOURCE` | funding / open interest / mark / index material present (A2-C3) |
+| `RUN_INVALID_TABLE_SCHEMA` | canonical table column set, order, type or nullability violated (A2-C3) |
+| `RUN_INVALID_MANIFEST_SCHEMA` | manifest key set wrong, or required source kind / canonical table absent |
+| `RUN_INVALID_OUTCOME_EVIDENCE` | any outcome-semantics violation, including a deleted row (A2-C4) |
+| `RUN_INVALID_AUTHENTICITY_EVIDENCE` | provenance missing, freeze evidence missing, or a self-consistency admissibility claim (A2-C5) |
+
+No code is downgradable to a warning, and no validator repairs its input.
+
+## Out of scope
+
+This contract fixes *what the corpus must be*. It does not fix, and must not be
+read as fixing:
+
+- the A2 measurement itself (`READY` / `NOT_READY` / `UNDETERMINED`) — separate job;
+- the DFC-2C-4H-v2.2 strategy contract, its harness or its pass rule — separate job;
+- corpus collection, the historical run, or any Futures Demo execution decision.
+
+Nothing here may be revised after A2 measurement results or backtest results are
+read. Changing a literal in this file after that point is not a correction; it is
+a different contract, and it needs a new ID and a new signature.

--- a/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
+++ b/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
@@ -114,6 +114,29 @@ decision record as a separate input, and:
    `payload_sha256` of the raw bars they claim to come from; and
    `outcome_abs_log_return_bps` is recomputed from those two raw close tokens and
    compared within 1e-6 bps. A hand-written outcome number cannot survive this.
+5. **Closed arm-label domain.** `candidate_any` is a *label*, and the label set
+   is exactly two values — `candidate` and `control`, in that order. The wire
+   type is `string`, so the type alone cannot pin the domain; the validator
+   does, on both the decision side and the row side, before any comparison.
+
+### The arm label (`candidate_any`)
+
+NW-F4 says `BasketDecision.candidate_any` **is an arm label**. It is therefore
+carried as a label and not as a truth value, and its domain is closed:
+
+| | |
+|---|---|
+| Admissible values | `candidate`, `control` — exactly these two, in this order |
+| Wire type | `string` (a label is a name; `pa.bool_()` would re-introduce the free bool NW-F4 forbids) |
+| Counterpart declaration | `research_contracts/dfc_2c_4h_v22.py` — `ARM_LABELS`, the same three literals in the same order |
+| Rejected | any other string, any `bool`, any non-string — all as `RUN_INVALID_OUTCOME_EVIDENCE` |
+| Coercion | none. There is no `bool(...)`, no `str(...)`, no default. A value that is not exactly one of the two labels is refused, never converted |
+
+Both halves of the DFC v2.2 work — this corpus contract and the strategy
+contract registration — declare that same literal set and enforce it the same
+way, so an arm value admitted here means the same thing when it reaches the
+adjudication side. Admitting an arbitrary string here while the other side
+coerced it to `True` is precisely the split this clause closes.
 
 `outcome_abs_log_return_bps = |ln(next_close / t_close)| × 10000`. This is a
 measurement of bar-to-bar movement. It is **not** a PnL claim and **not** a

--- a/research/dfc_v22_research_min/nw_verbatim.py
+++ b/research/dfc_v22_research_min/nw_verbatim.py
@@ -1,0 +1,46 @@
+"""Verbatim upstream clause text for the ``DFC_V22_RESEARCH_MIN`` (A2) contract.
+
+Generated from the canonical upstream answer document; do not hand-edit, do not
+summarize, do not paraphrase.  Every string below is a byte-exact copy of one
+table cell of the canonical document, so any downstream drift is detectable by
+comparing against that document's SHA-256.
+
+The canonical document lives outside this repository (operator inbox), so tests
+in this repository can only pin the *transcript*: they assert that the contract
+document and the frozen literals quote these strings unchanged.
+"""
+
+from __future__ import annotations
+
+CANONICAL_SOURCE_PATH = "~/work/herdr-inbox/answer-codexmock-next-wave-1630.md"
+CANONICAL_SOURCE_SHA256 = (
+    "df7aee908e50af42bb70dc48e09eee55dd30f881ced08e0145f8015269c36693"
+)
+CANONICAL_SOURCE_LINE_COUNT = 137
+BINDING_RECORD = "~/work/herdr-inbox/operator-decisions-20260805-0830.md \u00a725\ucc28"
+
+NW_F2_TOPIC = "A1과 DFC 최소 corpus의 범위 분리"
+NW_F2_VERBATIM = "**“A1의 funding/OI/mark/index 종합 readiness는 보존하되 DFC-v2.x의 선행조건으로 쓰지 않는다. 데이터 접촉 전에 `DFC_V22_RESEARCH_MIN` A2 계약을 새 ID/SHA로 등록한다. A2는 kline OFI·premium-index·PIT universe·outcome evidence만 판정한다.”** 이는 결과를 본 뒤 게이트를 완화하는 것이 아니라, 아직 백테스트 0회인 상태에서 계약-데이터 불일치를 교정하는 것이다."
+
+NW_F4_TOPIC = "outcome 의미론"
+NW_F4_VERBATIM = "**“signal epoch t의 `BasketDecision.candidate_any`가 arm label, 같은 decision의 winner가 심볼이다. outcome은 그 심볼의 완결된 t kline close부터 즉시 다음 완결 4h kline close까지의 absolute log return bps다. 둘 모두 raw evidence에서만 생성한다. 다음 bar가 없거나 불완전하면 행을 임의 삭제하지 않고 `RUN_INVALID_OUTCOME_EVIDENCE`; 마지막 signal을 위해 corpus에는 한 개의 다음 4h bar를 추가한다. 이는 PnL/체결 가능성 주장이 아니다.”** 자유 bool·자유 가격 입력을 금지한다."
+
+NW_F5_TOPIC = "corpus 동결 리터럴"
+NW_F5_VERBATIM = "**“corpus ID=`dfc-2c-4h-v22-corpus-v1`, root=`/Users/mgh3326/work/herdr-artifacts/dfc-2c-4h-v22-corpus-v1/`; warmup `[2021-02-02T00:00Z,2021-05-02T00:00Z)`, 판정창 `[2021-05-02T00:00Z,2023-08-04T00:00Z)`, 마지막 outcome용 다음 4h bar 포함. 매 epoch 직전 30 calendar day quote-volume으로 당시 eligible USD-M perpetual 전수를 순위화해 top 3, 동률은 canonical symbol 오름차순. 필수 원문은 Binance USD-M 4h kline 12필드와 premiumIndex 4h close, contract lifecycle/eligibility evidence다. funding/OI/mark/index는 이 corpus에 넣지 않는다. imputation 0.”**"
+
+NW_F6_TOPIC = "corpus 진정성·동결 절차"
+NW_F6_VERBATIM = "**“모든 원본 object/response에 endpoint·query·retrieved_at·schema·object/ZIP SHA-256·epoch별 payload SHA를 기록한다. manifest와 canonical parquet를 동결하고, 독립 검증자가 동일 public object를 재수집해 object SHA/행수/시각경계/원시 payload hash를 대조해야 admissible이다. 자기 일관성 검사만으로 Binance 진정성을 주장하지 않는다.”**"
+
+VERBATIM_CLAUSES: dict[str, str] = {
+    "NW-F2": NW_F2_VERBATIM,
+    "NW-F4": NW_F4_VERBATIM,
+    "NW-F5": NW_F5_VERBATIM,
+    "NW-F6": NW_F6_VERBATIM,
+}
+
+VERBATIM_TOPICS: dict[str, str] = {
+    "NW-F2": NW_F2_TOPIC,
+    "NW-F4": NW_F4_TOPIC,
+    "NW-F5": NW_F5_TOPIC,
+    "NW-F6": NW_F6_TOPIC,
+}

--- a/research/dfc_v22_research_min/schema.py
+++ b/research/dfc_v22_research_min/schema.py
@@ -1,0 +1,176 @@
+"""Canonical parquet schemas and manifest key sets for ``DFC_V22_RESEARCH_MIN``.
+
+Decimal-bearing fields are typed ``string`` on purpose.  The admissibility test
+(A2-C5) is an independent verifier re-collecting the same public object and
+comparing raw payload hashes; a float round-trip destroys exactly the bytes that
+comparison depends on, so the raw token is carried through unchanged and any
+arithmetic happens at read time.
+
+The schemas are exact: a table may carry neither fewer nor more columns than the
+schema declares, and every column's type must match.  "Extra column" is the shape
+that both a smuggled forbidden source (A2-C3) and a free bool/price input
+(A2-C4) take, so the closed schema is load-bearing rather than tidy.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pyarrow as pa
+
+__all__ = [
+    "CANONICAL_TABLES",
+    "KLINES_4H_SCHEMA",
+    "MANIFEST_REQUIRED_KEYS",
+    "MANIFEST_SOURCE_REQUIRED_KEYS",
+    "MANIFEST_TABLE_REQUIRED_KEYS",
+    "OUTCOMES_SCHEMA",
+    "PIT_UNIVERSE_SCHEMA",
+    "PREMIUM_INDEX_4H_SCHEMA",
+    "RAW_KLINE_FIELD_NAMES",
+]
+
+_TS = pa.timestamp("us", tz="UTC")
+
+
+def _provenance_fields() -> list[pa.Field]:
+    """Per-row link back to the object the row was parsed out of (A2-C5)."""
+    return [
+        pa.field("endpoint", pa.string(), nullable=False),
+        pa.field("query", pa.string(), nullable=False),
+        pa.field("retrieved_at", _TS, nullable=False),
+        pa.field("source_schema", pa.string(), nullable=False),
+        pa.field("object_sha256", pa.string(), nullable=False),
+        pa.field("payload_sha256", pa.string(), nullable=False),
+    ]
+
+
+#: The twelve fields of a Binance USD-M kline, in wire order, under their
+#: canonical names.  Required source material per A2-C3 — none may be dropped,
+#: not even the unused trailing ``ignore`` element.
+RAW_KLINE_FIELD_NAMES: tuple[str, ...] = (
+    "open_time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "close_time",
+    "quote_asset_volume",
+    "number_of_trades",
+    "taker_buy_base_asset_volume",
+    "taker_buy_quote_asset_volume",
+    "ignore",
+)
+
+KLINES_4H_SCHEMA = pa.schema(
+    [
+        pa.field("symbol", pa.string(), nullable=False),
+        pa.field("open_time", pa.int64(), nullable=False),
+        pa.field("open", pa.string(), nullable=False),
+        pa.field("high", pa.string(), nullable=False),
+        pa.field("low", pa.string(), nullable=False),
+        pa.field("close", pa.string(), nullable=False),
+        pa.field("volume", pa.string(), nullable=False),
+        pa.field("close_time", pa.int64(), nullable=False),
+        pa.field("quote_asset_volume", pa.string(), nullable=False),
+        pa.field("number_of_trades", pa.int64(), nullable=False),
+        pa.field("taker_buy_base_asset_volume", pa.string(), nullable=False),
+        pa.field("taker_buy_quote_asset_volume", pa.string(), nullable=False),
+        pa.field("ignore", pa.string(), nullable=False),
+        *_provenance_fields(),
+    ]
+)
+
+PREMIUM_INDEX_4H_SCHEMA = pa.schema(
+    [
+        pa.field("symbol", pa.string(), nullable=False),
+        pa.field("open_time", pa.int64(), nullable=False),
+        pa.field("close_time", pa.int64(), nullable=False),
+        pa.field("premium_index_close", pa.string(), nullable=False),
+        *_provenance_fields(),
+    ]
+)
+
+#: Point-in-time universe.  Eligibility is carried as a hash of the lifecycle
+#: evidence that decided it, never as a bare boolean somebody could set by hand.
+PIT_UNIVERSE_SCHEMA = pa.schema(
+    [
+        pa.field("epoch_open_time", pa.int64(), nullable=False),
+        pa.field("rank", pa.int32(), nullable=False),
+        pa.field("symbol", pa.string(), nullable=False),
+        pa.field("quote_volume_lookback", pa.string(), nullable=False),
+        pa.field("lookback_start_time", pa.int64(), nullable=False),
+        pa.field("lookback_end_time", pa.int64(), nullable=False),
+        pa.field("lifecycle_evidence_sha256", pa.string(), nullable=False),
+        pa.field("eligibility_evidence_sha256", pa.string(), nullable=False),
+        *_provenance_fields(),
+    ]
+)
+
+#: One row per ``BasketDecision``.  Every column is either an identifier, a
+#: reference into ``klines_4h``, or the single derived outcome number.
+OUTCOMES_SCHEMA = pa.schema(
+    [
+        pa.field("signal_epoch_open_time", pa.int64(), nullable=False),
+        pa.field("signal_epoch_close_time", pa.int64(), nullable=False),
+        pa.field("candidate_any", pa.string(), nullable=False),
+        pa.field("winner_symbol", pa.string(), nullable=False),
+        pa.field("t_kline_open_time", pa.int64(), nullable=False),
+        pa.field("t_close_payload_sha256", pa.string(), nullable=False),
+        pa.field("next_kline_open_time", pa.int64(), nullable=False),
+        pa.field("next_kline_close_time", pa.int64(), nullable=False),
+        pa.field("next_close_payload_sha256", pa.string(), nullable=False),
+        pa.field("outcome_abs_log_return_bps", pa.float64(), nullable=False),
+        pa.field("evidence_status", pa.string(), nullable=False),
+    ]
+)
+
+CANONICAL_TABLES: MappingProxyType[str, pa.Schema] = MappingProxyType(
+    {
+        "klines_4h": KLINES_4H_SCHEMA,
+        "premium_index_4h": PREMIUM_INDEX_4H_SCHEMA,
+        "pit_universe": PIT_UNIVERSE_SCHEMA,
+        "outcomes": OUTCOMES_SCHEMA,
+    }
+)
+
+
+MANIFEST_REQUIRED_KEYS: tuple[str, ...] = (
+    "contract_id",
+    "contract_doc_sha256",
+    "corpus_id",
+    "root",
+    "frozen",
+    "warmup",
+    "judgment_window",
+    "outcome_tail_bars",
+    "universe",
+    "imputation",
+    "prerequisite_readiness",
+    "sources",
+    "tables",
+    "admissibility",
+)
+
+MANIFEST_SOURCE_REQUIRED_KEYS: tuple[str, ...] = (
+    "name",
+    "kind",
+    "endpoint",
+    "query",
+    "retrieved_at",
+    "schema",
+    "object_kind",
+    "object_sha256",
+    "payload_sha256_by_epoch",
+    "byte_size",
+    "row_count",
+)
+
+MANIFEST_TABLE_REQUIRED_KEYS: tuple[str, ...] = (
+    "name",
+    "path",
+    "sha256",
+    "row_count",
+    "byte_size",
+)

--- a/research/dfc_v22_research_min/schema.py
+++ b/research/dfc_v22_research_min/schema.py
@@ -110,6 +110,12 @@ PIT_UNIVERSE_SCHEMA = pa.schema(
 
 #: One row per ``BasketDecision``.  Every column is either an identifier, a
 #: reference into ``klines_4h``, or the single derived outcome number.
+#:
+#: ``candidate_any`` is the NW-F4 *arm label*.  The wire type is ``string``
+#: because a label is a name, and it is a **closed** domain: the only two
+#: admissible values are ``contract.ARM_LABELS``.  Arrow can pin the type but
+#: not the domain, so ``validation._require_arm_label`` pins the domain — an
+#: arbitrary string is as inadmissible here as a boolean is.
 OUTCOMES_SCHEMA = pa.schema(
     [
         pa.field("signal_epoch_open_time", pa.int64(), nullable=False),

--- a/research/dfc_v22_research_min/validation.py
+++ b/research/dfc_v22_research_min/validation.py
@@ -1,0 +1,663 @@
+"""Fail-closed validators for ``DFC_V22_RESEARCH_MIN`` (A2).
+
+Every validator raises :class:`ContractViolation` and returns ``None`` on
+success.  There is deliberately no "warn" mode and no repair mode: a corpus that
+does not satisfy the contract is not a corpus that may be measured, and the one
+failure this design is built against is a builder quietly *fixing* its input
+(dropping a row, imputing a bar, defaulting a missing hash) so that the run looks
+clean.
+
+These validators read in-memory objects only.  Nothing in this module opens a
+socket, and nothing decides *what* to collect — collection is a separate relay
+unit that runs after this contract is signed.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+import pyarrow as pa
+
+from . import contract as c
+from .schema import (
+    CANONICAL_TABLES,
+    MANIFEST_REQUIRED_KEYS,
+    MANIFEST_SOURCE_REQUIRED_KEYS,
+    MANIFEST_TABLE_REQUIRED_KEYS,
+)
+
+__all__ = [
+    "ContractViolation",
+    "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+    "RUN_INVALID_CORPUS_LITERALS",
+    "RUN_INVALID_FORBIDDEN_SOURCE",
+    "RUN_INVALID_MANIFEST_SCHEMA",
+    "RUN_INVALID_OUTCOME_EVIDENCE",
+    "RUN_INVALID_SCOPE_SEPARATION",
+    "RUN_INVALID_TABLE_SCHEMA",
+    "validate_manifest",
+    "validate_outcomes",
+    "validate_table",
+]
+
+RUN_INVALID_MANIFEST_SCHEMA = "RUN_INVALID_MANIFEST_SCHEMA"
+RUN_INVALID_CORPUS_LITERALS = "RUN_INVALID_CORPUS_LITERALS"
+RUN_INVALID_FORBIDDEN_SOURCE = "RUN_INVALID_FORBIDDEN_SOURCE"
+RUN_INVALID_AUTHENTICITY_EVIDENCE = "RUN_INVALID_AUTHENTICITY_EVIDENCE"
+RUN_INVALID_SCOPE_SEPARATION = "RUN_INVALID_SCOPE_SEPARATION"
+RUN_INVALID_TABLE_SCHEMA = "RUN_INVALID_TABLE_SCHEMA"
+RUN_INVALID_OUTCOME_EVIDENCE = c.RUN_INVALID_OUTCOME_EVIDENCE
+
+
+class ContractViolation(Exception):
+    """A corpus artifact that the A2 contract refuses.
+
+    ``code`` is the terminal run status the caller must report; it is never
+    downgraded to a warning and never repaired in place.
+    """
+
+    def __init__(self, code: str, detail: str, *, clause: str) -> None:
+        super().__init__(f"[{code}] {clause}: {detail}")
+        self.code = code
+        self.detail = detail
+        self.clause = clause
+
+
+def _fail(code: str, clause: str, detail: str) -> None:
+    raise ContractViolation(code, detail, clause=clause)
+
+
+def _iso_utc(value: Any) -> str:
+    return str(value)
+
+
+# --- A2-C3: forbidden source material -------------------------------------
+
+
+def _reject_forbidden_tokens(code: str, clause: str, names: Iterable[str]) -> None:
+    for name in names:
+        lowered = str(name).lower()
+        for token in c.FORBIDDEN_COLUMN_TOKENS:
+            if token in lowered:
+                _fail(
+                    code,
+                    clause,
+                    f"forbidden source material referenced by {name!r} "
+                    f"(matched {token!r}); funding/OI/mark/index are excluded "
+                    "from this corpus",
+                )
+
+
+# --- table validation ------------------------------------------------------
+
+
+def validate_table(name: str, table: pa.Table) -> None:
+    """Validate one canonical parquet table against its frozen schema.
+
+    Args:
+        name: Canonical table name, e.g. ``"klines_4h"``.
+        table: The table as loaded from parquet.
+
+    Raises:
+        ContractViolation: With ``RUN_INVALID_TABLE_SCHEMA`` for an unknown
+            table, a missing/extra column or a type mismatch; with
+            ``RUN_INVALID_FORBIDDEN_SOURCE`` when a column name carries
+            funding/open-interest/mark/index material (A2-C3).
+    """
+    expected = CANONICAL_TABLES.get(name)
+    if expected is None:
+        _fail(
+            RUN_INVALID_TABLE_SCHEMA,
+            "A2-C3",
+            f"unknown canonical table {name!r}; allowed: {sorted(CANONICAL_TABLES)}",
+        )
+        return
+
+    actual_names = list(table.schema.names)
+    _reject_forbidden_tokens(RUN_INVALID_FORBIDDEN_SOURCE, "A2-C3", actual_names)
+
+    expected_names = list(expected.names)
+    missing = [n for n in expected_names if n not in actual_names]
+    extra = [n for n in actual_names if n not in expected_names]
+    if missing or extra:
+        _fail(
+            RUN_INVALID_TABLE_SCHEMA,
+            "A2-C3",
+            f"table {name!r} column set mismatch; missing={missing} extra={extra}",
+        )
+
+    if actual_names != expected_names:
+        _fail(
+            RUN_INVALID_TABLE_SCHEMA,
+            "A2-C3",
+            f"table {name!r} column order mismatch; "
+            f"expected={expected_names} actual={actual_names}",
+        )
+
+    for field in expected:
+        actual = table.schema.field(field.name)
+        if not actual.type.equals(field.type):
+            _fail(
+                RUN_INVALID_TABLE_SCHEMA,
+                "A2-C3",
+                f"table {name!r} column {field.name!r} type mismatch; "
+                f"expected={field.type} actual={actual.type}",
+            )
+
+    for field in expected:
+        if field.nullable:
+            continue
+        if table.column(field.name).null_count:
+            _fail(
+                RUN_INVALID_TABLE_SCHEMA,
+                "A2-C3",
+                f"table {name!r} column {field.name!r} is non-nullable but "
+                "carries nulls; imputation and placeholders are forbidden",
+            )
+
+
+# --- A2-C4: outcome semantics ---------------------------------------------
+
+
+def _outcome_column_guard(table: pa.Table) -> None:
+    """Reject free booleans and free prices before anything else (A2-C4)."""
+    allowed = set(CANONICAL_TABLES["outcomes"].names)
+    for field in table.schema:
+        if field.name in allowed:
+            continue
+        if pa.types.is_boolean(field.type):
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"free boolean column {field.name!r} in outcomes; outcome rows "
+                "are generated from raw evidence only",
+            )
+        lowered = field.name.lower()
+        for token in c.OUTCOME_FREE_PRICE_TOKENS:
+            if token in lowered:
+                _fail(
+                    RUN_INVALID_OUTCOME_EVIDENCE,
+                    "A2-C4",
+                    f"free price/PnL column {field.name!r} in outcomes; the "
+                    "only permitted number is the derived "
+                    f"{c.OUTCOME_UNIT}",
+                )
+        _fail(
+            RUN_INVALID_OUTCOME_EVIDENCE,
+            "A2-C4",
+            f"unknown outcomes column {field.name!r}; the outcome schema is "
+            "closed so that no hand-supplied input can enter",
+        )
+
+
+def _kline_index(klines: pa.Table) -> dict[tuple[str, int], dict[str, Any]]:
+    rows = klines.to_pylist()
+    return {(row["symbol"], row["open_time"]): row for row in rows}
+
+
+def validate_outcomes(
+    outcomes: pa.Table,
+    klines: pa.Table,
+    decisions: Sequence[Mapping[str, Any]],
+) -> None:
+    """Validate the outcome table against the decisions and the raw bars.
+
+    ``decisions`` is the independent record of which signal epochs exist — one
+    entry per ``BasketDecision``, carrying ``signal_epoch_open_time``,
+    ``candidate_any`` and ``winner_symbol``.  Passing it in is what makes a
+    silently deleted outcome row detectable: the contract says a missing or
+    incomplete next bar is reported as ``RUN_INVALID_OUTCOME_EVIDENCE``, not
+    dropped, so an outcome table that is simply *shorter* than the decision set
+    is the exact failure mode being guarded.
+
+    Raises:
+        ContractViolation: Always with ``RUN_INVALID_OUTCOME_EVIDENCE``.
+    """
+    _outcome_column_guard(outcomes)
+    validate_table("outcomes", outcomes)
+
+    bars = _kline_index(klines)
+    rows = outcomes.to_pylist()
+
+    by_epoch: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        epoch = row["signal_epoch_open_time"]
+        if epoch in by_epoch:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"duplicate outcome row for signal epoch {epoch}",
+            )
+        by_epoch[epoch] = row
+
+    expected_epochs = [d["signal_epoch_open_time"] for d in decisions]
+    missing = [e for e in expected_epochs if e not in by_epoch]
+    if missing:
+        _fail(
+            RUN_INVALID_OUTCOME_EVIDENCE,
+            "A2-C4",
+            f"{len(missing)} decision epoch(s) have no outcome row "
+            f"(first={missing[0]}); rows may not be deleted — an unavailable "
+            "or incomplete next bar is reported, not removed",
+        )
+    unexpected = [e for e in by_epoch if e not in set(expected_epochs)]
+    if unexpected:
+        _fail(
+            RUN_INVALID_OUTCOME_EVIDENCE,
+            "A2-C4",
+            f"outcome rows without a decision: {sorted(unexpected)}",
+        )
+
+    for decision in decisions:
+        epoch = decision["signal_epoch_open_time"]
+        row = by_epoch[epoch]
+
+        if row["candidate_any"] != decision[c.OUTCOME_ARM_LABEL_FIELD]:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: arm label {row['candidate_any']!r} does not "
+                f"match the decision's {c.OUTCOME_ARM_LABEL_FIELD} "
+                f"{decision[c.OUTCOME_ARM_LABEL_FIELD]!r}",
+            )
+        if row["winner_symbol"] != decision[c.OUTCOME_SYMBOL_FIELD]:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: winner {row['winner_symbol']!r} does not match "
+                f"the decision's winner {decision[c.OUTCOME_SYMBOL_FIELD]!r}",
+            )
+        if row["evidence_status"] != c.OUTCOME_EVIDENCE_STATUS:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: evidence_status {row['evidence_status']!r} is "
+                f"not {c.OUTCOME_EVIDENCE_STATUS!r}",
+            )
+
+        symbol = row["winner_symbol"]
+        t_bar = bars.get((symbol, row["t_kline_open_time"]))
+        if t_bar is None:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: no raw kline for {symbol} at "
+                f"{row['t_kline_open_time']}",
+            )
+            return
+
+        expected_next_open = t_bar["open_time"] + c.BAR_INTERVAL_MS
+        if row["next_kline_open_time"] != expected_next_open:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: next bar must be the immediately next 4h bar "
+                f"({expected_next_open}), got {row['next_kline_open_time']}",
+            )
+
+        next_bar = bars.get((symbol, expected_next_open))
+        if next_bar is None:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: the next 4h bar for {symbol} at "
+                f"{expected_next_open} is absent from the corpus",
+            )
+            return
+        if next_bar["close_time"] != row["next_kline_close_time"]:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: next bar close_time "
+                f"{row['next_kline_close_time']} does not match the raw bar "
+                f"({next_bar['close_time']})",
+            )
+
+        if t_bar["payload_sha256"] != row["t_close_payload_sha256"]:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: t close payload hash does not match the raw "
+                "bar it claims to come from",
+            )
+        if next_bar["payload_sha256"] != row["next_close_payload_sha256"]:
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: next close payload hash does not match the raw "
+                "bar it claims to come from",
+            )
+
+        recomputed = _abs_log_return_bps(t_bar["close"], next_bar["close"])
+        if abs(recomputed - row["outcome_abs_log_return_bps"]) > (
+            c.OUTCOME_BPS_TOLERANCE
+        ):
+            _fail(
+                RUN_INVALID_OUTCOME_EVIDENCE,
+                "A2-C4",
+                f"epoch {epoch}: recorded outcome "
+                f"{row['outcome_abs_log_return_bps']} bps is not the value "
+                f"derived from the referenced raw closes ({recomputed} bps)",
+            )
+
+
+def _abs_log_return_bps(t_close: str, next_close: str) -> float:
+    try:
+        start = float(t_close)
+        end = float(next_close)
+    except (TypeError, ValueError):
+        _fail(
+            RUN_INVALID_OUTCOME_EVIDENCE,
+            "A2-C4",
+            f"unparsable raw close token(s): {t_close!r} -> {next_close!r}",
+        )
+        raise
+    if start <= 0.0 or end <= 0.0:
+        _fail(
+            RUN_INVALID_OUTCOME_EVIDENCE,
+            "A2-C4",
+            f"non-positive raw close(s): {t_close!r} -> {next_close!r}",
+        )
+    return abs(math.log(end / start)) * 10_000.0
+
+
+# --- manifest validation ---------------------------------------------------
+
+
+def validate_manifest(manifest: Mapping[str, Any]) -> None:
+    """Validate the frozen corpus manifest.
+
+    Raises:
+        ContractViolation: With ``RUN_INVALID_MANIFEST_SCHEMA`` for structural
+            problems, ``RUN_INVALID_CORPUS_LITERALS`` when a frozen literal was
+            changed, ``RUN_INVALID_SCOPE_SEPARATION`` when FUT-DATA-A1 is
+            declared a prerequisite (A2-C1), ``RUN_INVALID_FORBIDDEN_SOURCE``
+            for funding/OI/mark/index material (A2-C3) and
+            ``RUN_INVALID_AUTHENTICITY_EVIDENCE`` for missing provenance or a
+            self-consistency admissibility claim (A2-C5).
+    """
+    missing = [k for k in MANIFEST_REQUIRED_KEYS if k not in manifest]
+    if missing:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C2",
+            f"manifest is missing required key(s): {missing}",
+        )
+    unknown = [k for k in manifest if k not in MANIFEST_REQUIRED_KEYS]
+    if unknown:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C2",
+            f"manifest carries unknown key(s): {sorted(unknown)}",
+        )
+
+    _validate_scope_separation(manifest)
+    _validate_literals(manifest)
+    _validate_sources(manifest["sources"])
+    _validate_tables(manifest["tables"])
+    _validate_admissibility(manifest["admissibility"])
+
+
+def _validate_scope_separation(manifest: Mapping[str, Any]) -> None:
+    prereq = manifest["prerequisite_readiness"]
+    if not isinstance(prereq, Mapping):
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C1",
+            "prerequisite_readiness must be an object",
+        )
+        return
+
+    declared = str(prereq.get("contract_id", ""))
+    if declared in c.A1_READINESS_IDS:
+        _fail(
+            RUN_INVALID_SCOPE_SEPARATION,
+            "A2-C1",
+            f"{declared} is preserved as its own readiness statement and is "
+            "not a prerequisite of DFC-v2.x; the prerequisite is "
+            f"{c.CONTRACT_ID}",
+        )
+    if declared != c.CONTRACT_ID:
+        _fail(
+            RUN_INVALID_SCOPE_SEPARATION,
+            "A2-C1",
+            f"prerequisite readiness contract must be {c.CONTRACT_ID!r}, "
+            f"got {declared!r}",
+        )
+
+    dimensions = tuple(prereq.get("dimensions", ()))
+    if dimensions != c.A2_JUDGED_DIMENSIONS:
+        _fail(
+            RUN_INVALID_SCOPE_SEPARATION,
+            "A2-C1",
+            f"A2 judges exactly {list(c.A2_JUDGED_DIMENSIONS)}, got {list(dimensions)}",
+        )
+
+
+def _validate_literals(manifest: Mapping[str, Any]) -> None:
+    if manifest["contract_id"] != c.CONTRACT_ID:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C2",
+            f"contract_id must be {c.CONTRACT_ID!r}, got {manifest['contract_id']!r}",
+        )
+    if manifest["corpus_id"] != c.CORPUS_ID:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C2",
+            f"corpus_id must be {c.CORPUS_ID!r}, got {manifest['corpus_id']!r}",
+        )
+    if manifest["root"] != c.CORPUS_ROOT:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C2",
+            f"root must be {c.CORPUS_ROOT!r}, got {manifest['root']!r}; a "
+            "scratch directory is not the frozen corpus",
+        )
+    if manifest["frozen"] is not True:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C5",
+            "manifest must declare frozen=true",
+        )
+
+    _expect_window(manifest["warmup"], c.WARMUP_START, c.WARMUP_END, "warmup")
+    _expect_window(
+        manifest["judgment_window"],
+        c.JUDGMENT_START,
+        c.JUDGMENT_END,
+        "judgment_window",
+    )
+
+    if manifest["outcome_tail_bars"] != c.OUTCOME_TAIL_BARS:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C2",
+            f"outcome_tail_bars must be {c.OUTCOME_TAIL_BARS}, "
+            f"got {manifest['outcome_tail_bars']!r}",
+        )
+
+    universe = manifest["universe"]
+    expected_universe = {
+        "lookback_calendar_days": c.UNIVERSE_LOOKBACK_CALENDAR_DAYS,
+        "ranking_metric": c.UNIVERSE_RANKING_METRIC,
+        "top_n": c.UNIVERSE_TOP_N,
+        "tie_break": c.UNIVERSE_TIE_BREAK,
+        "instrument_class": c.UNIVERSE_INSTRUMENT_CLASS,
+    }
+    if dict(universe) != expected_universe:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C2",
+            f"universe rule must be exactly {expected_universe}, got {dict(universe)}",
+        )
+
+    imputation = manifest["imputation"]
+    if imputation.get("policy") != "forbidden":
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C3",
+            "imputation policy must be 'forbidden'",
+        )
+    if imputation.get("imputed_row_count", -1) != c.IMPUTED_ROW_COUNT_MAX:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C3",
+            "imputed_row_count must be "
+            f"{c.IMPUTED_ROW_COUNT_MAX}, got "
+            f"{imputation.get('imputed_row_count')!r}",
+        )
+
+
+def _expect_window(
+    window: Mapping[str, Any],
+    start: Any,
+    end: Any,
+    label: str,
+) -> None:
+    expected_start = start.isoformat().replace("+00:00", "Z")
+    expected_end = end.isoformat().replace("+00:00", "Z")
+    actual_start = _iso_utc(window.get("start"))
+    actual_end = _iso_utc(window.get("end"))
+    if actual_start != expected_start or actual_end != expected_end:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C2",
+            f"{label} must be [{expected_start}, {expected_end}), got "
+            f"[{actual_start}, {actual_end})",
+        )
+
+
+def _validate_sources(sources: Sequence[Mapping[str, Any]]) -> None:
+    if not sources:
+        _fail(
+            RUN_INVALID_AUTHENTICITY_EVIDENCE,
+            "A2-C5",
+            "manifest declares no source objects",
+        )
+
+    kinds: set[str] = set()
+    for index, source in enumerate(sources):
+        label = f"sources[{index}]"
+        kind = str(source.get("kind", ""))
+        if kind.lower() in c.FORBIDDEN_SOURCE_KINDS:
+            _fail(
+                RUN_INVALID_FORBIDDEN_SOURCE,
+                "A2-C3",
+                f"{label}: source kind {kind!r} is excluded from this corpus; "
+                "DFC-v2.2 signals read kline OFI and premium index only",
+            )
+        _reject_forbidden_tokens(
+            RUN_INVALID_FORBIDDEN_SOURCE,
+            "A2-C3",
+            [source.get("name", ""), source.get("endpoint", "")],
+        )
+
+        missing = [k for k in MANIFEST_SOURCE_REQUIRED_KEYS if k not in source]
+        if missing:
+            _fail(
+                RUN_INVALID_AUTHENTICITY_EVIDENCE,
+                "A2-C5",
+                f"{label}: missing provenance field(s) {missing}; every "
+                "original object records endpoint, query, retrieved_at, "
+                "schema, object SHA-256 and per-epoch payload SHA",
+            )
+        for field in c.REQUIRED_PROVENANCE_FIELDS:
+            if not source.get(field):
+                _fail(
+                    RUN_INVALID_AUTHENTICITY_EVIDENCE,
+                    "A2-C5",
+                    f"{label}: provenance field {field!r} is empty",
+                )
+        payload_hashes = source["payload_sha256_by_epoch"]
+        if not isinstance(payload_hashes, Mapping) or not payload_hashes:
+            _fail(
+                RUN_INVALID_AUTHENTICITY_EVIDENCE,
+                "A2-C5",
+                f"{label}: payload_sha256_by_epoch must be a non-empty mapping",
+            )
+        if kind not in c.REQUIRED_SOURCE_KINDS:
+            _fail(
+                RUN_INVALID_MANIFEST_SCHEMA,
+                "A2-C3",
+                f"{label}: unknown source kind {kind!r}; allowed: "
+                f"{list(c.REQUIRED_SOURCE_KINDS)}",
+            )
+        kinds.add(kind)
+
+    absent = [k for k in c.REQUIRED_SOURCE_KINDS if k not in kinds]
+    if absent:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C3",
+            f"required source material absent: {absent}",
+        )
+
+
+def _validate_tables(tables: Sequence[Mapping[str, Any]]) -> None:
+    seen: set[str] = set()
+    for index, entry in enumerate(tables):
+        label = f"tables[{index}]"
+        missing = [k for k in MANIFEST_TABLE_REQUIRED_KEYS if k not in entry]
+        if missing:
+            _fail(
+                RUN_INVALID_AUTHENTICITY_EVIDENCE,
+                "A2-C5",
+                f"{label}: missing freeze evidence {missing}",
+            )
+        name = str(entry["name"])
+        if name not in CANONICAL_TABLES:
+            _fail(
+                RUN_INVALID_MANIFEST_SCHEMA,
+                "A2-C3",
+                f"{label}: unknown canonical table {name!r}",
+            )
+        if not entry["sha256"]:
+            _fail(
+                RUN_INVALID_AUTHENTICITY_EVIDENCE,
+                "A2-C5",
+                f"{label}: canonical parquet must be frozen under a SHA-256",
+            )
+        seen.add(name)
+
+    absent = [n for n in CANONICAL_TABLES if n not in seen]
+    if absent:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C3",
+            f"canonical table(s) absent from manifest: {absent}",
+        )
+
+
+def _validate_admissibility(admissibility: Mapping[str, Any]) -> None:
+    basis = str(admissibility.get("basis", ""))
+    if basis.lower() in c.ADMISSIBILITY_FORBIDDEN_BASES:
+        _fail(
+            RUN_INVALID_AUTHENTICITY_EVIDENCE,
+            "A2-C5",
+            f"admissibility basis {basis!r} is a self-consistency claim; "
+            "Binance authenticity is asserted only by independent "
+            "re-collection of the same public object",
+        )
+    if basis != c.ADMISSIBILITY_BASIS:
+        _fail(
+            RUN_INVALID_AUTHENTICITY_EVIDENCE,
+            "A2-C5",
+            f"admissibility basis must be {c.ADMISSIBILITY_BASIS!r}, got {basis!r}",
+        )
+    if admissibility.get("independent_recollection_required") is not True:
+        _fail(
+            RUN_INVALID_AUTHENTICITY_EVIDENCE,
+            "A2-C5",
+            "independent_recollection_required must be true",
+        )
+    keys = tuple(admissibility.get("comparison_keys", ()))
+    if keys != c.ADMISSIBILITY_COMPARISON_KEYS:
+        _fail(
+            RUN_INVALID_AUTHENTICITY_EVIDENCE,
+            "A2-C5",
+            "the independent verifier compares exactly "
+            f"{list(c.ADMISSIBILITY_COMPARISON_KEYS)}, got {list(keys)}",
+        )

--- a/research/dfc_v22_research_min/validation.py
+++ b/research/dfc_v22_research_min/validation.py
@@ -29,6 +29,7 @@ from .schema import (
 )
 
 __all__ = [
+    "ARM_LABELS",
     "ContractViolation",
     "RUN_INVALID_AUTHENTICITY_EVIDENCE",
     "RUN_INVALID_CORPUS_LITERALS",
@@ -49,6 +50,10 @@ RUN_INVALID_AUTHENTICITY_EVIDENCE = "RUN_INVALID_AUTHENTICITY_EVIDENCE"
 RUN_INVALID_SCOPE_SEPARATION = "RUN_INVALID_SCOPE_SEPARATION"
 RUN_INVALID_TABLE_SCHEMA = "RUN_INVALID_TABLE_SCHEMA"
 RUN_INVALID_OUTCOME_EVIDENCE = c.RUN_INVALID_OUTCOME_EVIDENCE
+
+#: Re-exported so a reader of the validator sees the closed arm-label domain
+#: it enforces without following an import (A2-C4 / NW-F4).
+ARM_LABELS = c.ARM_LABELS
 
 
 class ContractViolation(Exception):
@@ -192,6 +197,35 @@ def _outcome_column_guard(table: pa.Table) -> None:
         )
 
 
+def _require_arm_label(value: Any, *, origin: str, epoch: Any) -> str:
+    """Return ``value`` iff it is one of the two admissible arm labels (A2-C4).
+
+    There is no coercion path.  ``bool`` is checked first and by type, because
+    ``bool`` is what a silent ``bool(...)`` conversion produces and what NW-F4
+    names as forbidden free input; an arbitrary string is rejected right after,
+    because an arm label the contract never defined is not an arm label at all.
+    Either way the caller gets ``RUN_INVALID_OUTCOME_EVIDENCE`` — never a
+    repaired value.
+    """
+    if isinstance(value, bool):
+        _fail(
+            RUN_INVALID_OUTCOME_EVIDENCE,
+            "A2-C4",
+            f"epoch {epoch}: {origin} arm label is a free bool ({value!r}); "
+            f"candidate_any is an arm label, one of {list(c.ARM_LABELS)}, and "
+            "is never coerced from a truth value",
+        )
+    if not isinstance(value, str) or value not in c.ARM_LABELS:
+        _fail(
+            RUN_INVALID_OUTCOME_EVIDENCE,
+            "A2-C4",
+            f"epoch {epoch}: {origin} arm label {value!r} is not one of the "
+            f"admissible arm labels {list(c.ARM_LABELS)}; the arm-label domain "
+            "is closed by contract",
+        )
+    return str(value)
+
+
 def _kline_index(klines: pa.Table) -> dict[tuple[str, int], dict[str, Any]]:
     rows = klines.to_pylist()
     return {(row["symbol"], row["open_time"]): row for row in rows}
@@ -254,7 +288,13 @@ def validate_outcomes(
         epoch = decision["signal_epoch_open_time"]
         row = by_epoch[epoch]
 
-        if row["candidate_any"] != decision[c.OUTCOME_ARM_LABEL_FIELD]:
+        decision_arm = _require_arm_label(
+            decision[c.OUTCOME_ARM_LABEL_FIELD], origin="decision", epoch=epoch
+        )
+        row_arm = _require_arm_label(
+            row["candidate_any"], origin="outcome row", epoch=epoch
+        )
+        if row_arm != decision_arm:
             _fail(
                 RUN_INVALID_OUTCOME_EVIDENCE,
                 "A2-C4",

--- a/tests/research/dfc_v22_research_min/golden/violation_cases.json
+++ b/tests/research/dfc_v22_research_min/golden/violation_cases.json
@@ -1,0 +1,169 @@
+{
+  "contract_id": "DFC_V22_RESEARCH_MIN",
+  "canonical_source_sha256_prefix": "df7aee908e50af42",
+  "note": "Expected rejections, frozen with the contract. Each case_id has a builder in test_a2_golden.py that feeds one bad artifact to a validator; the test asserts the code AND the wording, so a validator that fails for a different reason does not count as a pass.",
+  "cases": [
+    {
+      "case_id": "outcomes_free_bool_column",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "free boolean column"
+    },
+    {
+      "case_id": "outcomes_free_price_column",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "free price/PnL column"
+    },
+    {
+      "case_id": "outcomes_unknown_column",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "unknown outcomes column"
+    },
+    {
+      "case_id": "outcomes_row_deleted_for_missing_next_bar",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "rows may not be deleted"
+    },
+    {
+      "case_id": "outcomes_next_bar_absent_from_corpus",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "is absent from the corpus"
+    },
+    {
+      "case_id": "outcomes_next_bar_not_immediately_next",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "immediately next 4h bar"
+    },
+    {
+      "case_id": "outcomes_hand_written_return",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "is not the value derived from the referenced raw closes"
+    },
+    {
+      "case_id": "outcomes_close_payload_hash_mismatch",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "payload hash does not match the raw"
+    },
+    {
+      "case_id": "outcomes_arm_label_not_from_decision",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "does not match the decision's candidate_any"
+    },
+    {
+      "case_id": "manifest_funding_source_kind",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_FORBIDDEN_SOURCE",
+      "expected_detail_contains": "excluded from this corpus"
+    },
+    {
+      "case_id": "manifest_open_interest_endpoint",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_FORBIDDEN_SOURCE",
+      "expected_detail_contains": "forbidden source material referenced by"
+    },
+    {
+      "case_id": "table_klines_open_interest_column",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_FORBIDDEN_SOURCE",
+      "expected_detail_contains": "forbidden source material referenced by"
+    },
+    {
+      "case_id": "table_klines_missing_ignore_field",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_TABLE_SCHEMA",
+      "expected_detail_contains": "column set mismatch"
+    },
+    {
+      "case_id": "table_klines_float_close",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_TABLE_SCHEMA",
+      "expected_detail_contains": "type mismatch"
+    },
+    {
+      "case_id": "table_pit_universe_free_bool_eligible",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_TABLE_SCHEMA",
+      "expected_detail_contains": "column set mismatch"
+    },
+    {
+      "case_id": "manifest_missing_object_sha256",
+      "clause": "A2-C5",
+      "expected_code": "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+      "expected_detail_contains": "missing provenance field"
+    },
+    {
+      "case_id": "manifest_missing_retrieved_at",
+      "clause": "A2-C5",
+      "expected_code": "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+      "expected_detail_contains": "missing provenance field"
+    },
+    {
+      "case_id": "manifest_payload_sha_not_keyed_by_epoch",
+      "clause": "A2-C5",
+      "expected_code": "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+      "expected_detail_contains": "payload_sha256_by_epoch must be a non-empty mapping"
+    },
+    {
+      "case_id": "manifest_table_missing_freeze_sha",
+      "clause": "A2-C5",
+      "expected_code": "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+      "expected_detail_contains": "missing freeze evidence"
+    },
+    {
+      "case_id": "manifest_self_consistency_admissibility",
+      "clause": "A2-C5",
+      "expected_code": "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+      "expected_detail_contains": "self-consistency claim"
+    },
+    {
+      "case_id": "manifest_not_frozen",
+      "clause": "A2-C5",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "must declare frozen=true"
+    },
+    {
+      "case_id": "manifest_a1_as_prerequisite",
+      "clause": "A2-C1",
+      "expected_code": "RUN_INVALID_SCOPE_SEPARATION",
+      "expected_detail_contains": "not a prerequisite of DFC-v2.x"
+    },
+    {
+      "case_id": "manifest_scratch_root",
+      "clause": "A2-C2",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "a scratch directory is not the frozen corpus"
+    },
+    {
+      "case_id": "manifest_widened_judgment_window",
+      "clause": "A2-C2",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "judgment_window must be"
+    },
+    {
+      "case_id": "manifest_universe_top_five",
+      "clause": "A2-C2",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "universe rule must be exactly"
+    },
+    {
+      "case_id": "manifest_imputed_rows_present",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "imputed_row_count must be 0"
+    },
+    {
+      "case_id": "manifest_missing_required_source_kind",
+      "clause": "A2-C3",
+      "expected_code": "RUN_INVALID_MANIFEST_SCHEMA",
+      "expected_detail_contains": "required source material absent"
+    }
+  ]
+}

--- a/tests/research/dfc_v22_research_min/golden/violation_cases.json
+++ b/tests/research/dfc_v22_research_min/golden/violation_cases.json
@@ -58,6 +58,24 @@
       "expected_detail_contains": "does not match the decision's candidate_any"
     },
     {
+      "case_id": "outcomes_arbitrary_string_arm_label",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "is not one of the admissible arm labels"
+    },
+    {
+      "case_id": "outcomes_row_arm_label_outside_domain",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "is not one of the admissible arm labels"
+    },
+    {
+      "case_id": "outcomes_free_bool_arm_label",
+      "clause": "A2-C4",
+      "expected_code": "RUN_INVALID_OUTCOME_EVIDENCE",
+      "expected_detail_contains": "arm label is a free bool"
+    },
+    {
       "case_id": "manifest_funding_source_kind",
       "clause": "A2-C3",
       "expected_code": "RUN_INVALID_FORBIDDEN_SOURCE",

--- a/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
+++ b/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
@@ -65,6 +65,27 @@ def test_canonical_source_is_pinned() -> None:
 
 
 @pytest.mark.unit
+def test_arm_label_domain_is_the_shared_closed_set() -> None:
+    """Pin the wire contract A2 shares with the v2.2 registration (PR #1825).
+
+    The two registrations live on disjoint paths and cannot import each other,
+    so the only thing that keeps them from drifting is that both pin this exact
+    literal.  Changing it here without changing it there is the split this test
+    exists to make loud.
+    """
+    assert c.ARM_LABELS == ("candidate", "control")
+    assert (c.ARM_CANDIDATE, c.ARM_CONTROL) == c.ARM_LABELS
+    assert all(isinstance(label, str) for label in c.ARM_LABELS)
+    assert not any(isinstance(label, bool) for label in c.ARM_LABELS)
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    for label in c.ARM_LABELS:
+        assert f"`{label}`" in doc, f"arm label {label!r} is undocumented"
+    assert "research_contracts/dfc_2c_4h_v22.py" in (
+        (PACKAGE_DIR / "contract.py").read_text(encoding="utf-8")
+    ), "the counterpart declaration must be named at the point of declaration"
+
+
+@pytest.mark.unit
 def test_frozen_literals_appear_in_the_document() -> None:
     doc = DOC_PATH.read_text(encoding="utf-8")
     for literal in (

--- a/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
+++ b/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
@@ -1,0 +1,120 @@
+"""Transcription and network-zero guards for the A2 contract.
+
+The upstream wording lives outside this repository, so nothing here can prove
+the repo copy matches it byte-for-byte at test time.  What these tests *can*
+pin is everything downstream of that copy: the contract document must quote the
+frozen strings unchanged, the frozen literals must be the ones the document
+claims, and the package must remain incapable of reaching the network.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from research.dfc_v22_research_min import contract as c
+from research.dfc_v22_research_min import nw_verbatim
+
+PACKAGE_DIR = Path(__file__).resolve().parents[3] / "research" / "dfc_v22_research_min"
+DOC_PATH = PACKAGE_DIR / "contracts" / "DFC_V22_RESEARCH_MIN.md"
+
+#: Anything that could fetch, list or download.  A2 measurement is a separate
+#: job; this package is signed *before* data contact and must stay that way.
+FORBIDDEN_IMPORT_ROOTS = frozenset(
+    {
+        "aiohttp",
+        "boto3",
+        "botocore",
+        "ftplib",
+        "http",
+        "httpx",
+        "requests",
+        "s3fs",
+        "socket",
+        "urllib",
+        "websocket",
+        "websockets",
+    }
+)
+
+
+def _package_sources() -> list[Path]:
+    return sorted(PACKAGE_DIR.glob("*.py"))
+
+
+@pytest.mark.unit
+def test_contract_document_quotes_every_clause_verbatim() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    for key, text in nw_verbatim.VERBATIM_CLAUSES.items():
+        assert text in doc, f"{key} is paraphrased or missing in {DOC_PATH.name}"
+
+
+@pytest.mark.unit
+def test_canonical_source_is_pinned() -> None:
+    assert nw_verbatim.CANONICAL_SOURCE_SHA256.startswith("df7aee908e50af42")
+    assert len(nw_verbatim.CANONICAL_SOURCE_SHA256) == 64
+    assert nw_verbatim.CANONICAL_SOURCE_LINE_COUNT == 137
+    assert set(nw_verbatim.VERBATIM_CLAUSES) == {
+        "NW-F2",
+        "NW-F4",
+        "NW-F5",
+        "NW-F6",
+    }
+
+
+@pytest.mark.unit
+def test_frozen_literals_appear_in_the_document() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    for literal in (
+        c.CONTRACT_ID,
+        c.CORPUS_ID,
+        c.CORPUS_ROOT,
+        "2021-02-02T00:00:00Z",
+        "2021-05-02T00:00:00Z",
+        "2023-08-04T00:00:00Z",
+    ):
+        assert literal in doc, f"{literal!r} is not stated in the contract document"
+
+
+@pytest.mark.unit
+def test_clause_ids_map_to_upstream_clauses() -> None:
+    assert set(c.CLAUSE_SOURCES.values()) == set(nw_verbatim.VERBATIM_CLAUSES)
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    for clause_id in c.CLAUSE_SOURCES:
+        assert clause_id in doc, f"clause {clause_id} is undocumented"
+
+
+@pytest.mark.unit
+def test_package_cannot_reach_the_network() -> None:
+    offenders: list[str] = []
+    for path in _package_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [node.module or ""]
+            else:
+                continue
+            for name in names:
+                if name.split(".")[0] in FORBIDDEN_IMPORT_ROOTS:
+                    offenders.append(f"{path.name}:{node.lineno} imports {name}")
+    assert not offenders, offenders
+
+
+@pytest.mark.unit
+def test_package_does_not_write_files() -> None:
+    """No collection, no freeze: this package only judges objects handed to it."""
+    offenders: list[str] = []
+    for path in _package_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "attr", None) or getattr(func, "id", None)
+            if name in {"write_text", "write_bytes", "open", "mkdir", "write_table"}:
+                offenders.append(f"{path.name}:{node.lineno} calls {name}")
+    assert not offenders, offenders

--- a/tests/research/dfc_v22_research_min/test_a2_golden.py
+++ b/tests/research/dfc_v22_research_min/test_a2_golden.py
@@ -80,15 +80,16 @@ _KLINE_ROWS: list[dict[str, Any]] = [
     _kline_row("SOLUSDT", T1 + BAR, "1.9800", "p-sol-t1n"),
 ]
 
+#: One epoch on each arm, so the baseline exercises both admissible labels.
 _DECISIONS: list[dict[str, Any]] = [
     {
         "signal_epoch_open_time": T0,
-        "candidate_any": "arm_dfc_2c_4h",
+        "candidate_any": c.ARM_CANDIDATE,
         "winner_symbol": "XRPUSDT",
     },
     {
         "signal_epoch_open_time": T1,
-        "candidate_any": "arm_dfc_2c_4h",
+        "candidate_any": c.ARM_CONTROL,
         "winner_symbol": "SOLUSDT",
     },
 ]
@@ -105,11 +106,12 @@ def _outcome_row(
     next_payload: str,
     t_close: str,
     next_close: str,
+    arm: str,
 ) -> dict[str, Any]:
     return {
         "signal_epoch_open_time": epoch,
         "signal_epoch_close_time": epoch + BAR - 1,
-        "candidate_any": "arm_dfc_2c_4h",
+        "candidate_any": arm,
         "winner_symbol": symbol,
         "t_kline_open_time": epoch,
         "t_close_payload_sha256": t_payload,
@@ -122,8 +124,12 @@ def _outcome_row(
 
 
 _OUTCOME_ROWS: list[dict[str, Any]] = [
-    _outcome_row(T0, "XRPUSDT", "p-xrp-t0", "p-xrp-t0n", "1.0000", "1.0100"),
-    _outcome_row(T1, "SOLUSDT", "p-sol-t1", "p-sol-t1n", "2.0000", "1.9800"),
+    _outcome_row(
+        T0, "XRPUSDT", "p-xrp-t0", "p-xrp-t0n", "1.0000", "1.0100", c.ARM_CANDIDATE
+    ),
+    _outcome_row(
+        T1, "SOLUSDT", "p-sol-t1", "p-sol-t1n", "2.0000", "1.9800", c.ARM_CONTROL
+    ),
 ]
 
 
@@ -283,9 +289,37 @@ def _case_outcomes_close_payload_hash_mismatch() -> None:
 
 
 def _case_outcomes_arm_label_not_from_decision() -> None:
+    # An *admissible* label, but not the one this decision carries: the row was
+    # relabelled from candidate to control by hand.
     rows = [dict(r) for r in _OUTCOME_ROWS]
-    rows[0]["candidate_any"] = "arm_relabelled_by_hand"
+    rows[0]["candidate_any"] = c.ARM_CONTROL
     v.validate_outcomes(outcomes(rows), klines(), _DECISIONS)
+
+
+def _case_outcomes_arbitrary_string_arm_label() -> None:
+    # The v1 defect: an arm value outside the contract's label set was
+    # admissible on this side while the v2.2 side silently coerced it to True.
+    # Decision and row agree, so only the closed domain can shoot it down.
+    decisions = [dict(d) for d in _DECISIONS]
+    decisions[0]["candidate_any"] = "arbitrary-nonboolean-arm"
+    rows = [dict(r) for r in _OUTCOME_ROWS]
+    rows[0]["candidate_any"] = "arbitrary-nonboolean-arm"
+    v.validate_outcomes(outcomes(rows), klines(), decisions)
+
+
+def _case_outcomes_row_arm_label_outside_domain() -> None:
+    # Same defect reached from the row side only.
+    rows = [dict(r) for r in _OUTCOME_ROWS]
+    rows[0]["candidate_any"] = "arm_dfc_2c_4h"
+    v.validate_outcomes(outcomes(rows), klines(), _DECISIONS)
+
+
+def _case_outcomes_free_bool_arm_label() -> None:
+    # A truth value is not an arm label.  This is the shape a ``bool(...)``
+    # coercion produces, so it must fail before any comparison.
+    decisions = [dict(d) for d in _DECISIONS]
+    decisions[0]["candidate_any"] = True
+    v.validate_outcomes(outcomes(), klines(), decisions)
 
 
 def _case_manifest_funding_source_kind() -> None:
@@ -445,6 +479,9 @@ CASE_BUILDERS: dict[str, Callable[[], None]] = {
     "outcomes_hand_written_return": _case_outcomes_hand_written_return,
     "outcomes_close_payload_hash_mismatch": _case_outcomes_close_payload_hash_mismatch,
     "outcomes_arm_label_not_from_decision": _case_outcomes_arm_label_not_from_decision,
+    "outcomes_arbitrary_string_arm_label": _case_outcomes_arbitrary_string_arm_label,
+    "outcomes_row_arm_label_outside_domain": _case_outcomes_row_arm_label_outside_domain,
+    "outcomes_free_bool_arm_label": _case_outcomes_free_bool_arm_label,
     "manifest_funding_source_kind": _case_manifest_funding_source_kind,
     "manifest_open_interest_endpoint": _case_manifest_open_interest_endpoint,
     "table_klines_open_interest_column": _case_table_klines_open_interest_column,

--- a/tests/research/dfc_v22_research_min/test_a2_golden.py
+++ b/tests/research/dfc_v22_research_min/test_a2_golden.py
@@ -1,0 +1,534 @@
+"""Golden rejections for the ``DFC_V22_RESEARCH_MIN`` (A2) contract.
+
+The point of these tests is not that a well-formed corpus validates — that is the
+easy half, and it is covered once by ``test_baseline_artifacts_validate``.  The
+point is that each *specific* bad input the contract names is actually shot down,
+with the right terminal code and for the right reason.  Every case therefore
+asserts the wording too: a validator that rejects an input for an unrelated
+reason is not enforcing the clause it was supposed to enforce.
+
+Network-zero by construction: everything here is built in memory.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from research.dfc_v22_research_min import contract as c
+from research.dfc_v22_research_min import validation as v
+from research.dfc_v22_research_min.schema import (
+    KLINES_4H_SCHEMA,
+    OUTCOMES_SCHEMA,
+    PIT_UNIVERSE_SCHEMA,
+)
+
+GOLDEN_PATH = Path(__file__).parent / "golden" / "violation_cases.json"
+
+T0 = int(datetime(2021, 5, 2, tzinfo=UTC).timestamp() * 1000)
+T1 = T0 + c.BAR_INTERVAL_MS
+BAR = c.BAR_INTERVAL_MS
+
+
+# --------------------------------------------------------------------------
+# baseline artifacts
+# --------------------------------------------------------------------------
+
+
+def _provenance(payload_sha: str) -> dict[str, Any]:
+    return {
+        "endpoint": "https://fapi.binance.com/fapi/v1/klines",
+        "query": "symbol=XRPUSDT&interval=4h&startTime=...",
+        "retrieved_at": datetime(2026, 8, 9, 17, 0, tzinfo=UTC),
+        "source_schema": "binance-usdm-kline-v1",
+        "object_sha256": "0" * 64,
+        "payload_sha256": payload_sha,
+    }
+
+
+def _kline_row(symbol: str, open_time: int, close: str, payload: str) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "open_time": open_time,
+        "open": "1.0000",
+        "high": "1.0000",
+        "low": "1.0000",
+        "close": close,
+        "volume": "10.0",
+        "close_time": open_time + BAR - 1,
+        "quote_asset_volume": "10.0",
+        "number_of_trades": 7,
+        "taker_buy_base_asset_volume": "5.0",
+        "taker_buy_quote_asset_volume": "5.0",
+        "ignore": "0",
+        **_provenance(payload),
+    }
+
+
+#: Four bars: the two signal epochs and their two immediately-next bars.
+_KLINE_ROWS: list[dict[str, Any]] = [
+    _kline_row("XRPUSDT", T0, "1.0000", "p-xrp-t0"),
+    _kline_row("XRPUSDT", T0 + BAR, "1.0100", "p-xrp-t0n"),
+    _kline_row("SOLUSDT", T1, "2.0000", "p-sol-t1"),
+    _kline_row("SOLUSDT", T1 + BAR, "1.9800", "p-sol-t1n"),
+]
+
+_DECISIONS: list[dict[str, Any]] = [
+    {
+        "signal_epoch_open_time": T0,
+        "candidate_any": "arm_dfc_2c_4h",
+        "winner_symbol": "XRPUSDT",
+    },
+    {
+        "signal_epoch_open_time": T1,
+        "candidate_any": "arm_dfc_2c_4h",
+        "winner_symbol": "SOLUSDT",
+    },
+]
+
+
+def _bps(start: str, end: str) -> float:
+    return abs(math.log(float(end) / float(start))) * 10_000.0
+
+
+def _outcome_row(
+    epoch: int,
+    symbol: str,
+    t_payload: str,
+    next_payload: str,
+    t_close: str,
+    next_close: str,
+) -> dict[str, Any]:
+    return {
+        "signal_epoch_open_time": epoch,
+        "signal_epoch_close_time": epoch + BAR - 1,
+        "candidate_any": "arm_dfc_2c_4h",
+        "winner_symbol": symbol,
+        "t_kline_open_time": epoch,
+        "t_close_payload_sha256": t_payload,
+        "next_kline_open_time": epoch + BAR,
+        "next_kline_close_time": epoch + BAR + BAR - 1,
+        "next_close_payload_sha256": next_payload,
+        "outcome_abs_log_return_bps": _bps(t_close, next_close),
+        "evidence_status": c.OUTCOME_EVIDENCE_STATUS,
+    }
+
+
+_OUTCOME_ROWS: list[dict[str, Any]] = [
+    _outcome_row(T0, "XRPUSDT", "p-xrp-t0", "p-xrp-t0n", "1.0000", "1.0100"),
+    _outcome_row(T1, "SOLUSDT", "p-sol-t1", "p-sol-t1n", "2.0000", "1.9800"),
+]
+
+
+def klines(rows: list[dict[str, Any]] | None = None) -> pa.Table:
+    return pa.Table.from_pylist(rows or _KLINE_ROWS, schema=KLINES_4H_SCHEMA)
+
+
+def outcomes(
+    rows: list[dict[str, Any]] | None = None,
+    *,
+    extra: tuple[str, pa.DataType, list[Any]] | None = None,
+) -> pa.Table:
+    rows = rows if rows is not None else _OUTCOME_ROWS
+    table = pa.Table.from_pylist(rows, schema=OUTCOMES_SCHEMA)
+    if extra is not None:
+        name, dtype, values = extra
+        table = table.append_column(
+            pa.field(name, dtype, nullable=False), pa.array(values, type=dtype)
+        )
+    return table
+
+
+def _source(kind: str, **overrides: Any) -> dict[str, Any]:
+    source = {
+        "name": f"{kind}-object",
+        "kind": kind,
+        "endpoint": f"https://fapi.binance.com/fapi/v1/{kind}",
+        "query": "symbol=XRPUSDT&interval=4h",
+        "retrieved_at": "2026-08-09T17:00:00Z",
+        "schema": f"binance-{kind}-v1",
+        "object_kind": "http_response",
+        "object_sha256": "a" * 64,
+        "payload_sha256_by_epoch": {str(T0): "b" * 64},
+        "byte_size": 4096,
+        "row_count": 4,
+    }
+    source.update(overrides)
+    return source
+
+
+def manifest(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "contract_id": c.CONTRACT_ID,
+        "contract_doc_sha256": "c" * 64,
+        "corpus_id": c.CORPUS_ID,
+        "root": c.CORPUS_ROOT,
+        "frozen": True,
+        "warmup": {"start": "2021-02-02T00:00:00Z", "end": "2021-05-02T00:00:00Z"},
+        "judgment_window": {
+            "start": "2021-05-02T00:00:00Z",
+            "end": "2023-08-04T00:00:00Z",
+        },
+        "outcome_tail_bars": c.OUTCOME_TAIL_BARS,
+        "universe": {
+            "lookback_calendar_days": c.UNIVERSE_LOOKBACK_CALENDAR_DAYS,
+            "ranking_metric": c.UNIVERSE_RANKING_METRIC,
+            "top_n": c.UNIVERSE_TOP_N,
+            "tie_break": c.UNIVERSE_TIE_BREAK,
+            "instrument_class": c.UNIVERSE_INSTRUMENT_CLASS,
+        },
+        "imputation": {"policy": "forbidden", "imputed_row_count": 0},
+        "prerequisite_readiness": {
+            "contract_id": c.CONTRACT_ID,
+            "dimensions": list(c.A2_JUDGED_DIMENSIONS),
+        },
+        "sources": [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS],
+        "tables": [
+            {
+                "name": name,
+                "path": f"canonical/{name}.parquet",
+                "sha256": "d" * 64,
+                "row_count": 4,
+                "byte_size": 2048,
+            }
+            for name in ("klines_4h", "premium_index_4h", "pit_universe", "outcomes")
+        ],
+        "admissibility": {
+            "basis": c.ADMISSIBILITY_BASIS,
+            "independent_recollection_required": True,
+            "comparison_keys": list(c.ADMISSIBILITY_COMPARISON_KEYS),
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def pit_universe_row() -> dict[str, Any]:
+    return {
+        "epoch_open_time": T0,
+        "rank": 1,
+        "symbol": "XRPUSDT",
+        "quote_volume_lookback": "123456.7",
+        "lookback_start_time": T0 - 30 * 24 * 60 * 60 * 1000,
+        "lookback_end_time": T0,
+        "lifecycle_evidence_sha256": "e" * 64,
+        "eligibility_evidence_sha256": "f" * 64,
+        **_provenance("p-univ-t0"),
+    }
+
+
+# --------------------------------------------------------------------------
+# case builders — each one feeds exactly one bad artifact to a validator
+# --------------------------------------------------------------------------
+
+
+def _case_outcomes_free_bool_column() -> None:
+    v.validate_outcomes(
+        outcomes(extra=("next_bar_present", pa.bool_(), [True, True])),
+        klines(),
+        _DECISIONS,
+    )
+
+
+def _case_outcomes_free_price_column() -> None:
+    v.validate_outcomes(
+        outcomes(extra=("entry_price", pa.float64(), [1.0, 2.0])),
+        klines(),
+        _DECISIONS,
+    )
+
+
+def _case_outcomes_unknown_column() -> None:
+    v.validate_outcomes(
+        outcomes(extra=("analyst_note", pa.string(), ["ok", "ok"])),
+        klines(),
+        _DECISIONS,
+    )
+
+
+def _case_outcomes_row_deleted_for_missing_next_bar() -> None:
+    # The second decision's next bar is unavailable, so the builder "solved" it
+    # by dropping the row.  That is precisely what NW-F4 forbids.
+    v.validate_outcomes(outcomes(_OUTCOME_ROWS[:1]), klines(), _DECISIONS)
+
+
+def _case_outcomes_next_bar_absent_from_corpus() -> None:
+    truncated = [r for r in _KLINE_ROWS if not (r["open_time"] == T1 + BAR)]
+    v.validate_outcomes(outcomes(), klines(truncated), _DECISIONS)
+
+
+def _case_outcomes_next_bar_not_immediately_next() -> None:
+    rows = [dict(r) for r in _OUTCOME_ROWS]
+    rows[0]["next_kline_open_time"] = T0 + 2 * BAR
+    v.validate_outcomes(outcomes(rows), klines(), _DECISIONS)
+
+
+def _case_outcomes_hand_written_return() -> None:
+    rows = [dict(r) for r in _OUTCOME_ROWS]
+    rows[0]["outcome_abs_log_return_bps"] = 250.0
+    v.validate_outcomes(outcomes(rows), klines(), _DECISIONS)
+
+
+def _case_outcomes_close_payload_hash_mismatch() -> None:
+    rows = [dict(r) for r in _OUTCOME_ROWS]
+    rows[0]["t_close_payload_sha256"] = "p-not-the-bar"
+    v.validate_outcomes(outcomes(rows), klines(), _DECISIONS)
+
+
+def _case_outcomes_arm_label_not_from_decision() -> None:
+    rows = [dict(r) for r in _OUTCOME_ROWS]
+    rows[0]["candidate_any"] = "arm_relabelled_by_hand"
+    v.validate_outcomes(outcomes(rows), klines(), _DECISIONS)
+
+
+def _case_manifest_funding_source_kind() -> None:
+    sources = [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS]
+    sources.append(
+        _source("funding_rate", name="extra-object", endpoint="https://x/fr")
+    )
+    v.validate_manifest(manifest(sources=sources))
+
+
+def _case_manifest_open_interest_endpoint() -> None:
+    sources = [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS]
+    sources[0] = _source(
+        "usdm_kline_4h",
+        name="oi-relabelled-as-kline",
+        endpoint="https://fapi.binance.com/futures/data/openInterestHist",
+    )
+    v.validate_manifest(manifest(sources=sources))
+
+
+def _case_table_klines_open_interest_column() -> None:
+    rows = [dict(r) for r in _KLINE_ROWS]
+    for row in rows:
+        row["open_interest"] = "42.0"
+    fields = list(KLINES_4H_SCHEMA) + [
+        pa.field("open_interest", pa.string(), nullable=False)
+    ]
+    v.validate_table("klines_4h", pa.Table.from_pylist(rows, schema=pa.schema(fields)))
+
+
+def _case_table_klines_missing_ignore_field() -> None:
+    rows = [{k: val for k, val in r.items() if k != "ignore"} for r in _KLINE_ROWS]
+    fields = [f for f in KLINES_4H_SCHEMA if f.name != "ignore"]
+    v.validate_table("klines_4h", pa.Table.from_pylist(rows, schema=pa.schema(fields)))
+
+
+def _case_table_klines_float_close() -> None:
+    rows = [dict(r) for r in _KLINE_ROWS]
+    for row in rows:
+        row["close"] = float(row["close"])
+    fields = [
+        pa.field("close", pa.float64(), nullable=False) if f.name == "close" else f
+        for f in KLINES_4H_SCHEMA
+    ]
+    v.validate_table("klines_4h", pa.Table.from_pylist(rows, schema=pa.schema(fields)))
+
+
+def _case_table_pit_universe_free_bool_eligible() -> None:
+    row = pit_universe_row()
+    row["eligible"] = True
+    fields = list(PIT_UNIVERSE_SCHEMA) + [
+        pa.field("eligible", pa.bool_(), nullable=False)
+    ]
+    v.validate_table(
+        "pit_universe", pa.Table.from_pylist([row], schema=pa.schema(fields))
+    )
+
+
+def _case_manifest_missing_object_sha256() -> None:
+    sources = [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS]
+    sources[0] = {k: val for k, val in sources[0].items() if k != "object_sha256"}
+    v.validate_manifest(manifest(sources=sources))
+
+
+def _case_manifest_missing_retrieved_at() -> None:
+    sources = [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS]
+    sources[0] = {k: val for k, val in sources[0].items() if k != "retrieved_at"}
+    v.validate_manifest(manifest(sources=sources))
+
+
+def _case_manifest_payload_sha_not_keyed_by_epoch() -> None:
+    # A bare list of hashes loses the epoch binding, so no verifier can tell
+    # which 4h payload a hash belongs to.
+    sources = [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS]
+    sources[0] = _source(sources[0]["kind"], payload_sha256_by_epoch=["b" * 64])
+    v.validate_manifest(manifest(sources=sources))
+
+
+def _case_manifest_table_missing_freeze_sha() -> None:
+    tables = [dict(t) for t in manifest()["tables"]]
+    tables[0] = {k: val for k, val in tables[0].items() if k != "sha256"}
+    v.validate_manifest(manifest(tables=tables))
+
+
+def _case_manifest_self_consistency_admissibility() -> None:
+    v.validate_manifest(
+        manifest(
+            admissibility={
+                "basis": "self_consistency",
+                "independent_recollection_required": False,
+                "comparison_keys": list(c.ADMISSIBILITY_COMPARISON_KEYS),
+            }
+        )
+    )
+
+
+def _case_manifest_not_frozen() -> None:
+    v.validate_manifest(manifest(frozen=False))
+
+
+def _case_manifest_a1_as_prerequisite() -> None:
+    v.validate_manifest(
+        manifest(
+            prerequisite_readiness={
+                "contract_id": "FUT-DATA-A1",
+                "dimensions": list(c.A2_JUDGED_DIMENSIONS),
+            }
+        )
+    )
+
+
+def _case_manifest_scratch_root() -> None:
+    v.validate_manifest(manifest(root="/private/tmp/dfc-a1-scratch/"))
+
+
+def _case_manifest_widened_judgment_window() -> None:
+    v.validate_manifest(
+        manifest(
+            judgment_window={
+                "start": "2021-05-02T00:00:00Z",
+                "end": "2024-08-04T00:00:00Z",
+            }
+        )
+    )
+
+
+def _case_manifest_universe_top_five() -> None:
+    universe = dict(manifest()["universe"])
+    universe["top_n"] = 5
+    v.validate_manifest(manifest(universe=universe))
+
+
+def _case_manifest_imputed_rows_present() -> None:
+    v.validate_manifest(
+        manifest(imputation={"policy": "forbidden", "imputed_row_count": 12})
+    )
+
+
+def _case_manifest_missing_required_source_kind() -> None:
+    sources = [
+        _source(kind) for kind in c.REQUIRED_SOURCE_KINDS if kind != "premium_index_4h"
+    ]
+    v.validate_manifest(manifest(sources=sources))
+
+
+CASE_BUILDERS: dict[str, Callable[[], None]] = {
+    "outcomes_free_bool_column": _case_outcomes_free_bool_column,
+    "outcomes_free_price_column": _case_outcomes_free_price_column,
+    "outcomes_unknown_column": _case_outcomes_unknown_column,
+    "outcomes_row_deleted_for_missing_next_bar": (
+        _case_outcomes_row_deleted_for_missing_next_bar
+    ),
+    "outcomes_next_bar_absent_from_corpus": _case_outcomes_next_bar_absent_from_corpus,
+    "outcomes_next_bar_not_immediately_next": (
+        _case_outcomes_next_bar_not_immediately_next
+    ),
+    "outcomes_hand_written_return": _case_outcomes_hand_written_return,
+    "outcomes_close_payload_hash_mismatch": _case_outcomes_close_payload_hash_mismatch,
+    "outcomes_arm_label_not_from_decision": _case_outcomes_arm_label_not_from_decision,
+    "manifest_funding_source_kind": _case_manifest_funding_source_kind,
+    "manifest_open_interest_endpoint": _case_manifest_open_interest_endpoint,
+    "table_klines_open_interest_column": _case_table_klines_open_interest_column,
+    "table_klines_missing_ignore_field": _case_table_klines_missing_ignore_field,
+    "table_klines_float_close": _case_table_klines_float_close,
+    "table_pit_universe_free_bool_eligible": _case_table_pit_universe_free_bool_eligible,
+    "manifest_missing_object_sha256": _case_manifest_missing_object_sha256,
+    "manifest_missing_retrieved_at": _case_manifest_missing_retrieved_at,
+    "manifest_payload_sha_not_keyed_by_epoch": (
+        _case_manifest_payload_sha_not_keyed_by_epoch
+    ),
+    "manifest_table_missing_freeze_sha": _case_manifest_table_missing_freeze_sha,
+    "manifest_self_consistency_admissibility": (
+        _case_manifest_self_consistency_admissibility
+    ),
+    "manifest_not_frozen": _case_manifest_not_frozen,
+    "manifest_a1_as_prerequisite": _case_manifest_a1_as_prerequisite,
+    "manifest_scratch_root": _case_manifest_scratch_root,
+    "manifest_widened_judgment_window": _case_manifest_widened_judgment_window,
+    "manifest_universe_top_five": _case_manifest_universe_top_five,
+    "manifest_imputed_rows_present": _case_manifest_imputed_rows_present,
+    "manifest_missing_required_source_kind": _case_manifest_missing_required_source_kind,
+}
+
+
+def _golden() -> dict[str, Any]:
+    return json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+
+
+GOLDEN_CASES: list[dict[str, Any]] = _golden()["cases"]
+
+
+# --------------------------------------------------------------------------
+# tests
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_baseline_artifacts_validate() -> None:
+    """A well-formed corpus passes — otherwise the rejections prove nothing."""
+    v.validate_manifest(manifest())
+    v.validate_table("klines_4h", klines())
+    v.validate_table(
+        "pit_universe",
+        pa.Table.from_pylist([pit_universe_row()], schema=PIT_UNIVERSE_SCHEMA),
+    )
+    v.validate_outcomes(outcomes(), klines(), _DECISIONS)
+
+
+@pytest.mark.unit
+def test_golden_registry_and_builders_agree() -> None:
+    """Neither side may drift: no orphan case, no unexercised builder."""
+    registry = {case["case_id"] for case in GOLDEN_CASES}
+    assert registry == set(CASE_BUILDERS), {
+        "in_registry_only": sorted(registry - set(CASE_BUILDERS)),
+        "in_builders_only": sorted(set(CASE_BUILDERS) - registry),
+    }
+    assert len(GOLDEN_CASES) == len(registry), "duplicate case_id in golden registry"
+
+
+@pytest.mark.unit
+def test_golden_registry_pins_canonical_source() -> None:
+    golden = _golden()
+    assert golden["contract_id"] == c.CONTRACT_ID
+    assert c.CANONICAL_SOURCE_SHA256.startswith(
+        golden["canonical_source_sha256_prefix"]
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "case", GOLDEN_CASES, ids=[case["case_id"] for case in GOLDEN_CASES]
+)
+def test_bad_input_is_rejected(case: dict[str, Any]) -> None:
+    builder = CASE_BUILDERS[case["case_id"]]
+    with pytest.raises(v.ContractViolation) as excinfo:
+        builder()
+    violation = excinfo.value
+    assert violation.code == case["expected_code"]
+    assert violation.clause == case["clause"]
+    assert case["expected_detail_contains"] in violation.detail, violation.detail
+
+
+@pytest.mark.unit
+def test_every_clause_has_at_least_one_golden_rejection() -> None:
+    covered = {case["clause"] for case in GOLDEN_CASES}
+    assert covered == set(c.CLAUSE_SOURCES), sorted(set(c.CLAUSE_SOURCES) - covered)


### PR DESCRIPTION
## 무엇

DFC-v2.2 의 선행 readiness 를 **FUT-DATA-A1 에서 분리**해 신규 A2 계약
`DFC_V22_RESEARCH_MIN` 으로 등록한다. NW-F2 서명 이행.

🔴 **데이터 조회 0** — public API 호출·S3 리스팅·다운로드·corpus 수집·백테스트 전부 없음.
수집/측정은 별도 relay 단위(`DFC-A2-MEASURE`)다. 이 PR 은 문서·schema·golden 뿐이다.

## 왜 지금

A1 은 `UNDETERMINED` 로 확정됐고, DFC-v2.2 신호는 **4h kline OFI + premium-index** 만
읽는다 — funding/OI/mark/index 를 쓰지 않는다. A1 을 DFC 게이트로 쓰면 전략이 만지지도
않는 증거로 양방향 오판이 난다. A1 은 그대로 보존하고 A2 를 새 ID/SHA 로 분리한다.

**이 계약은 결과 열람 전에 서명된다.** 백테스트 0회 상태에서 숫자를 고정하는 것이 요점이다.

## 담긴 것

| | |
|---|---|
| 계약 문서 | `research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md` |
| 축자 원문 | `research/dfc_v22_research_min/nw_verbatim.py` (정본 sha256 `df7aee908e50af42…`, 137줄) |
| frozen literals | `research/dfc_v22_research_min/contract.py` |
| canonical schema | `research/dfc_v22_research_min/schema.py` |
| fail-closed validators | `research/dfc_v22_research_min/validation.py` |
| golden 27 케이스 | `tests/research/dfc_v22_research_min/golden/violation_cases.json` |

### 축자 보존

NW-F2 / F4 / F5 / F6 네 조항은 서명된 언어 그대로 `nw_verbatim.py` 에 담기고, 계약 문서가
그 문자열을 **그대로 인용**한다. `test_contract_document_quotes_every_clause_verbatim`
이 substring 일치를 강제하므로 나중에 조용히 의역하면 CI 가 격추한다.
(정본 4조항이 canonical 파일의 substring 임을 별도 실측 확인 — 보고서 참조.)

### golden 은 「형태가 맞다」가 아니라 「틀린 입력이 격추된다」

각 케이스는 **terminal code 와 문구까지** 대조한다. 다른 이유로 우연히 거절되는 것은
해당 조항을 강제한 증거가 아니기 때문이다. 정상 corpus 1건도 통과 확인
(`test_baseline_artifacts_validate`) — 그래야 거절이 의미를 가진다.

## 필수 mutant 4종 — 전부 격추

주입 후 원복, **커밋 미포함**(`git diff` clean 확인):

| mutant | 격추한 테스트 |
|---|---|
| ① outcome 에 자유 bool 허용 | `outcomes_free_bool_column` |
| ② 다음 bar 부재를 행 삭제로 처리 | `outcomes_row_deleted_for_missing_next_bar` |
| ③ funding/OI 혼입 허용 | `manifest_funding_source_kind`, `manifest_open_interest_endpoint`, `table_klines_open_interest_column` |
| ④ 진정성 증거 optional | `manifest_missing_object_sha256`, `manifest_missing_retrieved_at` |

②가 성립하는 이유: `validate_outcomes` 가 decision 기록을 **별도 입력**으로 받는다.
행을 지우면 outcome 표가 decision 집합보다 짧아지고, 그게 곧 격추 신호다.

## 설계 메모

- **closed schema.** canonical table 은 컬럼 집합·순서·타입이 정확 일치여야 한다.
  "extra column" 은 forbidden source 밀반입(A2-C3)과 자유 bool/가격 입력(A2-C4)이
  실제로 취하는 형태라, 닫힌 schema 가 장식이 아니라 강제 장치다.
- **decimal 은 string.** A2-C5 admissibility 가 raw payload hash 대조로 판정되는데
  float 왕복은 바로 그 바이트를 파괴한다. raw token 을 그대로 나른다.
- **eligibility 는 bool 이 아니다.** PIT universe 는 `lifecycle_evidence_sha256` /
  `eligibility_evidence_sha256` 을 요구한다 — 손으로 세울 수 있는 맨 bool 을 두지 않는다.
- **자기 일관성 ≠ 진정성.** `admissibility.basis = "self_consistency"` 는 이름으로 거절된다.

## 범위 밖 (이 PR 이 고정하지 않는 것)

A2 측정 결과 자체 · DFC-2C-4H-v2.2 전략 계약/harness/pass rule · corpus 수집 ·
역사검증 1회 · Futures Demo 실행 판단. 전부 별도 job.

## 검증

```
uv run pytest tests/research/dfc_v22_research_min/ -q   # 37 passed
uv run ruff check   app/ tests/ research/ scripts/      # All checks passed
uv run ruff format --check app/ tests/ research/ scripts/  # 3792 already formatted
uv run ty check app/ --error-on-warning                 # All checks passed
```

`tests/research/` 전체에서 `test_kr_backfill_build_clients.py` 3건이 실패하나 **선행 실패**다
— 이 PR 파일을 전부 치우고 돌려도 동일하게 실패한다. 원인은 worktree `.env` 심링크가
"env 없는" 서브프로세스에 자격증명을 흘리는 로컬 환경 조건.

## 안전 경계

DB write 0 · broker 0 · env 0 · 계좌 0 · 주문 0 · 스케줄러 등록 0 · in-process LLM 0.
`test_package_cannot_reach_the_network` 가 네트워크 import 를,
`test_package_does_not_write_files` 가 파일 쓰기를 AST 로 차단한다.

결속 기록: `operator-decisions-20260805-0830.md` §25차

🤖 Generated with [Claude Code](https://claude.com/claude-code)