### PR TITLE
feat(b0x): wire guarded KR mock confirmation

### DIFF
--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -25,7 +25,7 @@ import logging
 import math
 import time
 from collections.abc import Awaitable, Callable, Mapping
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from app.core.symbol import to_db_symbol
@@ -66,6 +66,7 @@ from app.services.brokers.kis.mock_scalping_exec.reservation import (
     release_entry,
     reserve_entry,
 )
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import OrderBookSnapshot
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 from app.services.brokers.kis.pre_send import PreSendFreshnessError
 from app.services.brokers.kis.send_outcome import (
@@ -97,7 +98,7 @@ def _to_decimal(value: Any) -> Decimal | None:
         return None
     try:
         return Decimal(str(value))
-    except (TypeError, ValueError):
+    except (InvalidOperation, TypeError, ValueError):
         return None
 
 
@@ -124,6 +125,24 @@ class KisMockBroker:
         self._limits = limits or ScalpingRiskLimits()
         self._clock = clock
         self._mock_client: KISClient | None = None
+        # A one-shot REST snapshot is only a supplement for callers that do
+        # not own the scalping WebSocket supervisor (B0-X KR is one).  The
+        # injected live state remains the first-class source; every snapshot
+        # still ages under the same pre-send hook below.
+        self._refreshed_states: dict[str, MarketState] = {}
+
+    def _current_state(self, symbol: str) -> MarketState | None:
+        """Return a caller-owned live state, or a just-read mock orderbook.
+
+        The fallback is intentionally stored by normalized symbol and is not
+        a fabricated quote: :meth:`refresh_market_state` populates it only
+        from the existing mock-host ``inquire_orderbook`` read.  If neither
+        source exists, the established pre-send guard still blocks the POST.
+        """
+
+        return self._get_state(symbol) or self._refreshed_states.get(
+            to_db_symbol(symbol)
+        )
 
     def _make_pre_send_hook(self, symbol: str):
         """A pre-send freshness re-check bound to ``symbol`` (ROB-843 P1-1).
@@ -136,7 +155,7 @@ class KisMockBroker:
 
         async def _hook() -> None:
             assert_market_fresh_for_send(
-                self._get_state(symbol),
+                self._current_state(symbol),
                 now=self._clock(),
                 max_data_age_seconds=self._limits.max_data_age_seconds,
                 max_spread_bps=self._limits.max_spread_bps,
@@ -213,6 +232,46 @@ class KisMockBroker:
                 await self._safe_release_reservation(correlation_id, side)
         # UNKNOWN or accepted-but-untracked: KEEP until explicit reconciliation.
         return result
+
+    async def refresh_market_state(
+        self,
+        *,
+        symbol: str,
+        market: str = "J",
+    ) -> MarketState:
+        """Refresh one mock-host orderbook for a non-WebSocket caller.
+
+        This is deliberately a narrow read-only bridge, not a second order
+        client or an alternate send path.  It feeds the adapter's existing
+        ``MarketState`` pre-send guard with an actual KIS mock orderbook and
+        leaves the guard's age/spread validation unchanged.
+        """
+
+        payload = await self._get_mock_client().inquire_orderbook(symbol, market)
+        bid = _to_decimal(payload.get("bidp1"))
+        ask = _to_decimal(payload.get("askp1"))
+        bid_qty = _to_decimal(payload.get("bidp_rsqn1")) or Decimal("0")
+        ask_qty = _to_decimal(payload.get("askp_rsqn1")) or Decimal("0")
+        last = _to_decimal(payload.get("stck_prpr"))
+
+        if bid is None or ask is None or bid <= 0 or ask <= 0:
+            raise PreSendFreshnessError(("invalid_orderbook",))
+
+        state = MarketState(symbol=symbol)
+        state.update_from_book(
+            OrderBookSnapshot(
+                symbol=symbol,
+                bid=float(bid),
+                ask=float(ask),
+                bid_qty=float(bid_qty),
+                ask_qty=float(ask_qty),
+            ),
+            now=self._clock(),
+        )
+        if last is not None and last > 0:
+            state.last_price = float(last)
+        self._refreshed_states[to_db_symbol(symbol)] = state
+        return state
 
     async def submit_buy(
         self,
@@ -456,7 +515,7 @@ class KisMockBroker:
         return classify_fill_evidence(order_no=str(order_no), rows=rows)
 
     def quote(self, symbol: str) -> Quote | None:
-        state = self._get_state(symbol)
+        state = self._current_state(symbol)
         if state is None:
             return None
         return Quote(

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -98,7 +98,7 @@ def _to_decimal(value: Any) -> Decimal | None:
         return None
     try:
         return Decimal(str(value))
-    except (InvalidOperation, TypeError, ValueError):
+    except (TypeError, ValueError):
         return None
 
 
@@ -248,11 +248,17 @@ class KisMockBroker:
         """
 
         payload = await self._get_mock_client().inquire_orderbook(symbol, market)
-        bid = _to_decimal(payload.get("bidp1"))
-        ask = _to_decimal(payload.get("askp1"))
-        bid_qty = _to_decimal(payload.get("bidp_rsqn1")) or Decimal("0")
-        ask_qty = _to_decimal(payload.get("askp_rsqn1")) or Decimal("0")
-        last = _to_decimal(payload.get("stck_prpr"))
+        try:
+            bid = _to_decimal(payload.get("bidp1"))
+            ask = _to_decimal(payload.get("askp1"))
+            bid_qty = _to_decimal(payload.get("bidp_rsqn1")) or Decimal("0")
+            ask_qty = _to_decimal(payload.get("askp_rsqn1")) or Decimal("0")
+            last = _to_decimal(payload.get("stck_prpr"))
+        except InvalidOperation:
+            # Keep malformed mock-host orderbooks on the existing local
+            # pre-send fail-closed path. Shared holdings parsing must still
+            # surface this error to preserve fill-evidence and risk-gate guards.
+            raise PreSendFreshnessError(("invalid_orderbook",)) from None
 
         if bid is None or ask is None or bid <= 0 or ask <= 0:
             raise PreSendFreshnessError(("invalid_orderbook",))

--- a/app/services/kis_mock_runner/singleton.py
+++ b/app/services/kis_mock_runner/singleton.py
@@ -28,6 +28,10 @@ MUTATION_WRITER_SURFACES = frozenset(
         "watch_auto_execute",
         "smoke_cli",
         "manual_mcp_mutation",
+        # B0-X KR is a separately approved, manual-only adapter path.  It
+        # acquires this same account-wide lease before its confirm preflight so
+        # it cannot overlap any catalogued kis_mock writer.
+        "b0x_adapter",
     }
 )
 _ACTIVE_WRITER_LEASE: ContextVar[bool] = ContextVar(

--- a/docs/runbooks/b0x-kr-cycle.md
+++ b/docs/runbooks/b0x-kr-cycle.md
@@ -2,41 +2,43 @@
 
 > `B0_UNVALIDATED` · `SELL_SIDE_MODEL_MISMATCH` · `FIDELITY_INCONCLUSIVE_COVERAGE`
 
-계약 정본: `~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md` — 결속은
-**버전 문자열(v1.3) + 절 인용**이며, 전체파일 sha256 은 참고 필드일 뿐이다(계약 본문
-"결속 = 버전 문자열 v1.3 + 인용 절"). 현재 참고 sha256 =
-`0125e2ea96b1a54cf0b0a50e6ed85ae1f3a72e7870abe727d2734dbe20e19b1f`.
+계약 정본: `~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md` — **v1.6**,
+§25차 결속. v1.6의 KR 예외는 `kis_mock_order_ledger`/signal ledger를 자기 미체결
+dedup에만 쓰는 것이며, 포지션 진실은 계속 브로커 조회다.
 계좌맵 정본: **`~/services/auto_trader-operator/operator_contract.yaml`**
-(기계판독, 2026-08-09 확정 — `mock/CLAUDE.md` §1 은 이제 참조 서술일 뿐이며 충돌 시
-YAML 이 이긴다). HEAD `3f40291`(PR #33) 에서 검증 — 아래 §0.
+(기계판독, 2026-08-09 PR #36 `e93349e` — `mock/CLAUDE.md` §1 은 참조 서술이며 충돌 시
+YAML 이 이긴다). 아래 §0의 두 표면 게이트를 매 실행 창에 다시 대조한다.
 코어 정본: `scripts/b0x/{envelope,kill_switch,state,derivation,ledger,labels,cycle}.py`
 (X-C, crypto, PR #1814 이 세웠다 — 이 잡은 코어를 재구현하지 않고 승계한다. 아래 §5)
 
-## 0. 계좌맵 게이트 — 2026-08-09 해소, 제출 배선 — 계약 v1.3 ③
+## 0. 계좌맵 게이트 — 전 계좌 배타, 제출 배선 — 계약 v1.3 ③ / v1.6
 
-**두 조건이 R1(첫 라운드) 시점엔 둘 다 열려 있었고, 이 라운드(R2) 시점엔 둘 다 닫혔다.**
+두 표면을 대조한다. 값이 다르면 더 보수적인 쪽으로 멈추고
+`NEEDS_UPSTREAM(account_map_conflict)` 이다.
 
-1. **계좌맵 게이트.** `operator_contract.yaml`
-   `mock_account_strategy_exclusive.strategy_order_exceptions` 에
-   `b0x-adapter-orders-20260808` 가 등재됐고, 그 예외의
-   `b0x_adapter_orders_20260808.surfaces` 에 `kis_mock` 이 포함된다.
-   `resolved_account_reassignments.kis_mock.mutation_policy` 는 더 이상
-   `no_new_orders` 가 아니라 `b0x_adapter_orders_only_within_envelope` 다.
-   `mock/CLAUDE.md` §1 kis_mock 행은 이와 모순되지 않는다(참조 표면, YAML 이 정본).
+1. **계좌맵 게이트.** YAML의 `account_lanes.kis_mock=B0-X-KR`,
+   `resolved_account_reassignments.kis_mock.exclusive_lane=B0-X-KR`,
+   `active_ordering_strategy=B0-X-adapter-single-writer`,
+   `strategy_order_exceptions`의 `b0x-adapter-orders-20260808`, 그리고
+   `surfaces ∋ kis_mock`를 확인한다. MD의 `B0-X KR` 표기는 사람이 읽는 표시일 뿐
+   YAML과 모순되지 않는다.
+   **계좌 전면 배타**는 MCP 도구만의 규칙이 아니다. 스크립트 직접 호출·스케줄러·세션·다른
+   프로세스를 포함한 모든 mutation writer를 운영 조치로 disarm해야 하며, 방어는 자기
+   correlation 외 흔적을 `CONTAMINATED`로 막는 fresh-truth gate다.
 2. **제출 통합점.** 계약 v1.3 ③ 이 `app.services.brokers.kis.mock_scalping_exec.
    adapters.KisMockBroker`(ROB-321/341) 를 지정했다 — 재구현이 아니라 기존 표면
    재사용. 아래 §6.
 
-**그럼에도 이 PR(R2) 은 실주문 0 이다** — 계좌맵/통합점이 풀렸다고 해서 이 라운드가
-실제로 kis_mock 을 향해 발사한다는 뜻은 아니다. §0.1 이 그 경계를 정확히 그린다.
+**상태 라벨은 바뀌지 않는다.** KR은 계속 `OBSERVATION_DERIVATION_ONLY`다. 이 경로는
+scheduleless 수동 acceptance lever일 뿐, “모의 자동매매 가동” 표기가 아니다.
 
 ### 0.1 이 PR 이 실제로 한 것과 하지 않은 것
 
-- **한 것**: `run_kr_cycle(confirm=True)` 가 이제 `KisMockBroker` 로 실제로 라우팅된다
-  (fake/stub 브로커로 오프라인 증명, §11).
-- **하지 않은 것**: `scripts/run_b0x_kr_cycle.py` CLI 에 `--confirm` 플래그가 없다
-  (여전히). 이 세션 동안 실 kis_mock 계정에 대한 preview/place 호출 0. 첫 실사이클은
-  월요일 KRX 세션, 별도 job.
+- **한 것**: `--confirm`은 기존 `KisMockBroker` 경로로 한 번만 dispatch할 수 있다.
+  환경 게이트, account-wide writer lease, NW-B4 preflight, v1.6 mutation-boundary
+  dedup, adapter의 mock-host 오더북 freshness check를 모두 통과해야 한다.
+- **하지 않는 것**: live 계좌 접촉, 스케줄러 등록, envelope override, KR 취소 성공 위장,
+  US/crypto 배선, 또는 상태 라벨 변경.
 
 ## 1. 이것이 무엇이 아닌가
 
@@ -64,7 +66,8 @@ RTH 밖이면 표·계좌 I/O **전혀 없이** `zero_order_reason=outside_krx_r
    출력 위치 = `~/services/auto_trader-operator/policy-tables/latest-kr.json`.
    B0-X 는 이 디렉토리를 **읽기만** 한다.
 2. `KIS_MOCK_ENABLED=true` + `KIS_MOCK_APP_KEY/APP_SECRET/ACCOUNT_NO` — read-only 계좌
-   조회(잔고·보유)에 필요하다. 주문 제출용이 아니다 (§0).
+   조회(잔고·보유)에 필요하다. 확인 경로는 여기에 `B0X_KR_ENABLED=true`와 per-call
+   `--confirm`을 추가로 요구한다. 어떤 값도 출력하지 않는다.
 
 ## 4. 실행
 
@@ -75,10 +78,14 @@ uv run python -m scripts.run_b0x_kr_cycle
 # 결정성 증명 (아무것도 쓰지 않음, fresh 계좌 스냅샷은 1회 읽는다)
 uv run python -m scripts.run_b0x_kr_cycle --derivation-only --repeat 2
 # → DERIVATION_DETERMINISM=IDENTICAL 이어야 한다
+
+# 수동 mock acceptance 1회. 실제 현재 시각만 사용하며 KRX RTH 밖이면 zero-order다.
+uv run python -m scripts.run_b0x_kr_cycle --confirm
 ```
 
-🔴 **`--confirm` 플래그가 없다.** 제출은 §6 대로 배선됐지만(계약 v1.3 ③), 이 CLI 는
-그 배선을 노출하지 않는다 — 실사이클은 별도 job(§0.1).
+`--confirm`은 `--now`·`--derivation-only`와 함께 쓸 수 없다. 시계 재생으로 제출 창을
+만드는 우회를 막고, 확인 경로는 한 제출만 허용한다. RTH·stale table·gate·lease·preflight
+중 하나라도 실패하면 제출 0과 사유만 기록한다.
 
 산출물: `~/work/herdr-artifacts/b0x/kis_mock/` 아래
 `cycles.jsonl`(append-only) · `<ts>-cycle.md` · `operator-notices.jsonl`
@@ -111,22 +118,18 @@ adapters.KisMockBroker`(ROB-321/341): `_place_order_impl(is_mock=True, ...)` 이
 그대로 재사용한다 — `scripts.b0x.kr.mock.build_kis_mock_broker`/`submit_planned_order`
 가 얇은 배선 레이어일 뿐, `KisMockBroker` 자체는 서브클래싱도 몽키패치도 하지 않는다.
 
-**하나의 문서화된 불일치, 덮지 않고 그대로 보고한다.** `KisMockBroker` 의 매수(BUY) leg
-는 실 POST 직전 살아있는 오더북(bid/ask/spread/age) 을 `get_state` 콜백으로 재검증한다
-(ROB-843 P1-1) — 이건 그 어댑터 자신의 라이브 WS 피드(`mock_scalping_ws`) 를 전제로 설계된
-freshness 모델이다. B0-X 는 그런 피드가 없다 — `policy_table.v1` 스냅샷에서 파생할 뿐, 실시간
-오더북을 보지 않는다. 가짜 호가를 지어내 안전장치를 통과시키는 대신,
-`build_kis_mock_broker` 는 `get_state` 가 **항상 `None`** 을 반환하게 한다. 결과: 실제
-BUY 디스패치(`confirm=True`) 는 실 HTTP POST **이전에** 그 어댑터 자신의
-`PreSendFreshnessError(("no_market_state",))` 로 fail-closed 한다 — 정직하고, 특별히
-새로 만든 차단이 아니라 어댑터 자신의 기존 예외다. SELL leg(`submit_exit_sell`) 는 ROB-321
-자체 설계상("포지션을 닫는 매도는 항상 허용돼야 한다") 이 훅이 없어 영향받지 않는다. B0-X 용
-실 시세 피드를 배선해 BUY 쪽 차단을 푸는 일은 이 PR 스코프 밖이다.
+**호가 보완은 재구현이 아니다.** B0-X에는 WebSocket supervisor가 없으므로
+`build_kis_mock_broker`의 injected `get_state`는 `None`일 수 있다. BUY 직전 얇은
+`submit_planned_order` chokepoint가 같은 `KisMockBroker.refresh_market_state()`를 호출해
+기존 mock-host `inquire_orderbook` 응답만 adapter의 `MarketState`로 넣는다. 정책표 가격을
+호가로 꾸미지 않으며, malformed/stale/wide/crossed book은 기존 pre-send guard가 POST 전에
+막는다. SELL leg에는 기존 설계대로 freshness hook이 없다.
 
-`confirm=False`(기본, CLI 가 유일하게 노출하는 경로)는 브로커를 아예 구성하지 않고 계획까지만
-한다. `confirm=True` 는 실제로 `KisMockBroker.submit_buy`/`submit_exit_sell` 을 호출한다 —
-"아직 안 만듦"이 "제출해서 0건 확인함"으로 둔갑하지 않도록, `KrCycleOutcome.record["submitted"]`
-는 실제 호출 결과를 그대로 담는다.
+`confirm=False`는 브로커를 구성하지 않고 계획까지만 한다. `confirm=True`는 성공한 preflight
+뒤에만 `KisMockBroker.submit_buy`/`submit_exit_sell`로 간다. 제출 직전 v1.6 원장을 다시 읽고,
+성공 응답 뒤에는 signal/order ledger union에서 자기 trace가 보이는지 확인한 뒤에만 체결
+관측을 남긴다. `KrCycleOutcome.record["submitted"]`는 실제 호출 결과이며, 차단은 별도
+`submission_dedup_blocked`/`submission_stopped`로 남긴다.
 
 **`unwired_submit_order`/`KrMockSubmissionNotWired` 는 삭제하지 않았다.** 주 경로는 더 이상
 그것을 부르지 않지만, `build_kis_mock_broker`/`submit_planned_order` 를 우회해 제출을
@@ -174,8 +177,9 @@ crypto 사이드카는 kill 발화 시 venue 의 open-orders 읽기를 이용해
 notice 문구를 lane 별로 분리했다(`KillSwitchDecision.operator_notice(remaining_orders_
 note=...)`). KR 은 crypto 의 "잔여 주문 취소 완료" 문구를 쓰지 않고
 `scripts.b0x.kr.cycle.KILL_CANCEL_UNSUPPORTED_NOTE` 로 사실대로 "취소는 구조적으로
-시도 불가"라고 말한다. `record["cancelled"] = []` + `record["cancellation_unsupported"]`
-로 "시도해서 실패"와 "애초에 시도 안 함"을 구분해 기록한다.
+시도 불가"라고 말한다. `record["cancelled"] = []`,
+`cancel_status="KILL_TRIPPED_CANCEL_UNSUPPORTED"`, `cancel_attempted=false`,
+`cancel_confirmed=false`로 "시도해서 실패"와 "애초에 시도 안 함"을 구분해 기록한다.
 
 ## 7. NAV 상대 kill switch — 통화 단위 정합성
 
@@ -281,9 +285,9 @@ b0x-experiment-contract-v1-20260808.md`):
 skipped 표가 그대로 렌더링되므로 "무엇이 막혔는지"는 남는다). 검사는 파생과
 `submit_planned_order`(디스패치 직전) **두 곳**에 있다.
 
-🔵 운영상 영향은 오늘 기준 크지 않다: KR 매수 디스패치는 이미 `PreSendFreshnessError`
-로 구조적으로 막혀 있고(§10, §6), CLI 에 `--confirm` 이 없다. 즉 이 조치가 "되던 주문을
-막은" 것이 아니라 **되지 않던 이유가 하나 더 명시화**된 것에 가깝다.
+🔵 이 브로커 한계 자체는 남아 있지만, v1.6 원장과 §6의 mock-host orderbook bridge는
+그 한계를 빈 미체결·가짜 호가로 덮지 않는다. 읽을 수 없으면 차단하고, 읽을 수 있으면 기존
+adapter guard를 그대로 통과시킨다.
 
 🔵 **해소됨 — 계약 v1.6 ① (2026-08-09, 운영자 "승인이야").** X-E1 이 후보로만 등재했던
 `kis_mock_order_ledger` 가 조건부로 승인됐다. 상세 = **§9.2**.
@@ -370,41 +374,27 @@ pending 파생 이름이 들어가는 것을 빌드 실패로 만든다.
 안에만** 존재하도록 강제하고(그 함수만이 `KisMockBroker` → `order_execution` pre-submit
 게이트를 탄다), 그 안에서 `assert_resubmit_allowed` 가 제출보다 **앞줄**임을 확인한다.
 
-**귀결 — 월요일 첫 KR 사이클.** 이 레인은 아직 한 건도 제출한 적이 없으므로 원장이
-`b0xk-` 행을 0건으로 **답한다**(unreadable 아님) → 후보 행이 정상 파생된다. 같은 KST 일의
-2·3사이클차는 1사이클차가 남긴 행을 읽어 **파생 0**. 실측 = `test_kr_two_cycle_sim_the_
-same_symbol_is_never_submitted_twice` (고정 fixture, 실브로커 호출 0).
+**귀결 — 첫 clean confirm.** 이 레인은 원장이 자기 `b0xk-` 행 0건을 읽고, 다른
+correlation trace·예상 밖 보유가 없고, writer lease가 확보될 때만 한 제출을 시도한다. 같은
+KST일에 자기 trace가 남으면 다음 confirm preflight는 `ledger_pending_present`로 zero-order다.
+`test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice`는 v1.6 KST-day dedup을,
+`test_confirm_route_rechecks_and_observes_post_submit_dedup`은 제출 직전/직후의 실제
+mutation-boundary 순서를 오프라인으로 고정한다.
 
-🔵 §10 의 `PreSendFreshnessError`(BUY leg 실디스패치 구조적 차단)와 CLI `--confirm` 부재는
-**이 라운드에서도 그대로**다. 즉 v1.6 은 "파생이 되게" 만들었을 뿐 "실주문이 나가게" 만들지
-않았다.
+## 10. 알려진 경계 · fail-closed 처리
 
-## 10. 알려진 경계 · 미해결
-
-- **BUY leg 실 디스패치는 항상 `PreSendFreshnessError` 로 막힌다** — B0-X 용 실시간
-  시세 피드가 없어서다(§6). SELL leg 는 이 훅이 없어 영향받지 않는다 — 비대칭이며,
-  의도적으로 덮지 않고 문서화했다.
-- **kill 시 잔여 주문 취소가 구조적으로 불가능하다**(§6.6) — KIS 모의투자 미체결조회
-  API 자체가 `is_mock=True` 를 지원하지 않는다. crypto 패턴을 그대로 옮길 수 없다.
-- **오염(CONTAMINATED) 판정 미구현.** crypto 사이드카는 venue 의 `foreign_*` 잔고/미체결을
-  탐지해 오염 시 제출을 막는다. KR 은 주문 읽기(order-history) 서피스를 아직 연결하지
-  않았다 — 위 두 항목과 마찬가지로 KIS 모의투자의 미체결조회 API 한계와 같은 뿌리다.
-  🔴 §9.2 의 원장 출처는 **이 공백을 닫지 않는다**: 원장은 `b0xk-` 로 시작하는 **자기**
-  correlation_id 만 답하므로, 남이 이 계좌에 낸 주문은 여전히 보이지 않는다. v1.6 ① 의 예외
-  범위가 「자기 미체결」이라 넓히지 않았다.
-- **원장 조회는 DB 를 탄다.** §9.2 의 출처는 브로커 read 가 아니라 `DATABASE_URL` 로의
-  세션이다. DB 가 죽으면 사이클은 오류가 아니라 `own_pending_unreadable` 로 **전 심볼 차단**
-  하고 계속 진행한다(v1.6 ④). 파생 0 이 나왔는데 사유가 `own_pending_unreadable` +
-  reason=`kis_mock_ledger_pending_unreadable` 이면 **브로커가 아니라 DB 를 보라**.
-- **`B0X_KR_ENABLED`/`assert_kr_lane_enabled` 게이트가 `run_kr_cycle` 에서 호출되지
-  않는다.** crypto 사이드카는 `run_sidecar_cycle` 진입 시 `assert_sidecar_enabled()` 를
-  강제한다(대응 env: `B0X_SIDECAR_ENABLED`); KR 의 대응 함수는 정의만 되어 있고 아직
-  배선되지 않았다(R1 부터의 기존 갭, 이 라운드가 새로 만들지 않았다) — 배선하려면 기존
-  preview 테스트 다수가 이 env 를 설정하도록 함께 바뀌어야 해서 이번 스코프(제출 경로)
-  밖에 남겼다.
-- **NXT/시간외는 완전 배제.** 정규장 매도의 NXT 연장(ROB-671) 같은 다른 레인의 규칙은
-  B0-X 에 적용하지 않는다 — 계약이 "정규장만" 이라고 명시했다.
-- 스케줄러 등록 없음 (v1 수동 kickoff, crypto 와 동일). CLI 에 `--confirm` 없음(§0.1).
+- **KIS mock native open-orders는 unavailable이다.** `TTTC8036R`은 `is_mock=True`에서
+  구조적으로 raise하므로 native open-order=0이라고 주장하지 않는다. NW-B4 record에는 이
+  사실과 함께 v1.6 signal/order ledger shadow를 분리해 남긴다. shadow가 unreadable이거나
+  foreign correlation trace가 하나라도 있으면 `preflight_not_clean` zero-order다.
+- **예상 밖 포지션·cash 비정상·stale table·writer lease 불명확도 zero-order다.** 취소·청산·계좌
+  reset 같은 임의 정리는 하지 않는다.
+- **kill 시 잔여 주문 취소가 구조적으로 불가능하다**(§6.6). 성공 취소나 reconcile을 꾸미지
+  않고 `KILL_TRIPPED_CANCEL_UNSUPPORTED`와 false attempted/confirmed를 기록한다.
+- **원장 조회는 DB를 탄다.** own/foreign ledger 중 하나라도 읽을 수 없으면 preflight는
+  fail-closed다. 오류 detail에는 예외 타입만 남기며 DSN/credential 메시지는 남기지 않는다.
+- **NXT/시간외는 완전 배제.** `--confirm`은 실제 현재 시각만 쓰며 KRX RTH 밖이면 계좌 I/O
+  전에 zero-order다. 스케줄러 등록은 없고, 이 경로는 `OBSERVATION_DERIVATION_ONLY`를 유지한다.
 
 ## 11. 테스트
 
@@ -413,23 +403,19 @@ uv run pytest tests/scripts/b0x/ -q          # 코어 + crypto + kr 전부
 uv run pytest tests/scripts/b0x/kr/ -q       # kr 전용
 ```
 
-v1.6 ① 전용 (`tests/scripts/b0x/kr/test_ledger_pending_source.py`): KR 2사이클+ 시뮬
-(1사이클차 파생 2·제출 2 → 2·3사이클차 파생 0·제출 누계 2 → 익 KST 일 파생 2·누계 4) ·
-원장이 답한 심볼만 `own_pending_order_exists` 로 차단 · 조회 실패/세션 실패 → `()` 아닌
-`PendingUnreadable` (예외 **타입명만**, 메시지 비노출) · 상태 기반 해제 금지(모듈이
-`lifecycle_state`/`status` 를 참조하지 않음을 AST 로 고정) · KST 거래일 경계 · 원장이
-포지션이 되지 않음(행동 + AST) · 타 레인 import 금지(AST) · 원장 우회 제출 경로 금지(AST,
-+ 제출보다 앞선 `assert_resubmit_allowed` 순서 확인). 각 detector 는 합성 소스로 자가검증.
-`tests/scripts/b0x/kr/conftest.py` 가 실 원장 리더 도달을 **AssertionError** 로 막는다
-(안 그러면 실수로 도달해도 `PendingUnreadable` 로 삼켜져 테스트가 조용히 무의미해진다).
+v1.6 ① 전용 (`tests/scripts/b0x/kr/test_ledger_pending_source.py`): KST day 경계의
+자기-pending dedup, signal/order 양쪽 union, reader failure → `PendingUnreadable`(예외
+**타입명만**), lifecycle/state 추론 금지, position truth 분리, 타 레인 import 금지, 제출
+chokepoint AST guard, foreign correlation trace contamination, 그리고 confirm의 pre/post
+dedup observation을 고정한다. 각 detector는 합성 소스로 자가검증한다.
+`tests/scripts/b0x/kr/conftest.py`는 실 own/foreign ledger reader 도달을
+**AssertionError**로 막는다.
 
 kr 전용 포함: tick 정렬(KRX 2023+ 표와 일치) · 매수/매도 사이징 whole-share floor ·
 NAV = cash + Σ evlu_amt · RTH 게이트(세션 밖 → zero-order, 표 I/O 전혀 없음) · 표 게이트
 5경로 재사용 · `MAX_TABLE_AGE["kr"]=36h`(main SSOT `scripts.policy_table.core.
 max_table_age` 재수출, crypto 8h·us 36h 동반 확인) 값 고정 + 37h/35h59m 경계
 사이클 종단 동작 · NAV 비율 kill(단위 정합성, 재계산됨을 증명) · 결정성(2회 동일 해시) ·
-CLI 에 envelope 필드/`--confirm` 플래그 없음 · KIS 주문 서피스 금지 import 정적 가드
-(denylist, R1) · `submit_planned_order` 가 fake 브로커로 buy/sell 을 올바른 메서드에
-라우팅함(correlation_id/가격/수량 스레딩 포함) · `confirm=True` 가 fake 브로커를 통해
-실제로 디스패치됨(더 이상 무조건 raise 아님) · `unwired_submit_order` 가 여전히 raise
-함(kept, not deleted) · AST 가드(allowlist, R2) 3 금지 + 자체 detector self-test.
+CLI default-disabled `--confirm`과 replay clock 거부 · NW-B4 5분 preflight/lease/
+contamination/zero-order · 단일 제출 상한 · `KILL_TRIPPED_CANCEL_UNSUPPORTED` · mock-host
+orderbook→기존 pre-send guard · KIS 주문 서피스 금지 import 및 AST 3금지 self-test를 포함한다.

--- a/scripts/b0x/kr/cycle.py
+++ b/scripts/b0x/kr/cycle.py
@@ -18,15 +18,13 @@ holidays.
                  →  kill switch  →  derive  →  plan  →  submit  →  record
 
 ``submit`` is wired to ``kr_mock.build_kis_mock_broker`` /
-``kr_mock.submit_planned_order`` (contract v1.3 ③) — see
-``scripts.b0x.kr.mock``'s module docstring for the one documented mismatch
-(BUY-leg freshness re-check with no live feed). No CLI path exercises it
-this PR: ``scripts/run_b0x_kr_cycle.py`` has no ``--confirm`` flag, so a
-cycle only ever reaches ``confirm=True`` when a caller (a test, or a future
-operator entrypoint) passes it explicitly. ``KrCycleOutcome.submitted``
-always records exactly what happened, never a stamped ``real_orders=0``
-constant. orch's relayed X-C lesson was explicit about not repeating that
-pattern.
+``kr_mock.submit_planned_order`` (contract v1.3 ③).  The manual CLI exposes
+the otherwise default-disabled confirm path only with an explicit
+``--confirm`` lever.  Before it can dispatch, that path must hold the
+account-wide kis_mock writer lease and pass the NW-B4 fresh-truth preflight;
+its one mock-host orderbook read then feeds the existing adapter pre-send
+guard.  ``KrCycleOutcome.submitted`` always records exactly what happened,
+never a stamped ``real_orders=0`` constant.
 
 Contract v1.5 ① lands here as ``broker_state`` (below): the §4 caps read this
 cycle's kis_mock account snapshot, and nothing is carried between cycles. The
@@ -62,13 +60,18 @@ import datetime as dt
 from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from app.services.kis_mock_runner.session import is_krx_regular_session
-from scripts.b0x.broker_truth import PendingUnreadable
+from app.services.kis_mock_runner.singleton import (
+    KISMockWriterLease,
+    WriterSingletonContended,
+    WriterSingletonUnavailable,
+)
+from scripts.b0x.broker_truth import OwnPendingResubmitBlocked, PendingUnreadable
 from scripts.b0x.cycle import base_record, render_cycle_report
 from scripts.b0x.derivation import DerivationResult, derive_orders
-from scripts.b0x.envelope import assert_envelope_locked, load_envelope
+from scripts.b0x.envelope import Envelope, assert_envelope_locked, load_envelope
 from scripts.b0x.kill_switch import evaluate as evaluate_kill_switch
 from scripts.b0x.kr import mock as kr_mock
 from scripts.b0x.kr import pending_ledger as kr_pending_ledger
@@ -89,6 +92,33 @@ from scripts.b0x.table_source import (
 MARKET = "kr"
 LANE = kr_mock.LANE
 
+# These provenance blocks are intentionally local to KR.  The shared
+# ``scripts.b0x.contract`` stamp is still v1.4 / the older account-map commit
+# for the untouched US and crypto lanes; letting it leak into a KR artifact
+# would make this v1.6 execution surface report the wrong governing facts.
+# Do not update the shared stamp as part of this KR-only job.
+KR_CONTRACT_VERSION: Final[str] = "v1.6"
+KR_CONTRACT_FILE_SHA256_REFERENCE_ONLY: Final[str] = (
+    "a3922894dcb91c2888daa2b33a9bfb9fab48a1c660ffc16deead09c530faea14"
+)
+KR_CONTRACT_CLAUSES: Final[dict[str, str]] = {
+    "§8 v1.6": (
+        "KR 자기 미체결은 kis_mock_order_ledger 조건부 예외이며, "
+        "미체결 dedup/캡 입력에만 쓴다. 포지션 진실은 계속 브로커 조회다."
+    ),
+}
+KR_ACCOUNT_MAP_COMMIT: Final[str] = "e93349e7ab9b1db414b1fba619e462cf84da1fa7"
+KR_ACCOUNT_MAP_VALUES: Final[dict[str, str]] = {
+    "account_lanes.kis_mock": "B0-X-KR",
+    "exclusive_lane": "B0-X-KR",
+    "active_ordering_strategy": "B0-X-adapter-single-writer",
+    "surface": "kis_mock",
+}
+KR_STATUS_LABEL: Final[str] = (
+    "OBSERVATION_DERIVATION_ONLY — KR cycle 지위는 유지된다. 이 수동 mock "
+    "acceptance lever는 모의 자동매매 가동 선언이나 스케줄러가 아니다."
+)
+
 #: KR's ``table_source.MAX_TABLE_AGE`` entry is 36h — contract §2-2 v1.1
 #: (operator-confirmed 2026-08-08, sha256 ``97278b0e8b8000e2e663c936328686001
 #: af5850087897270bc80a95ebf8f6b2e``), not a value this adapter chose. See
@@ -98,13 +128,28 @@ ZeroOrderReason = str
 
 OUTSIDE_RTH_REASON: ZeroOrderReason = "outside_krx_regular_session"
 
+#: NW-B4: every account/ledger observation used to authorize a confirmed
+#: dispatch must be taken in this bounded interval.  The value is a contract
+#: requirement, not a tunable CLI parameter.
+PREFLIGHT_MAX_AGE_SECONDS = 5 * 60
+
+#: This job exposes a one-shot, manual acceptance lever only.  It is a
+#: restrictive operational bound (not an envelope dial) and deliberately has
+#: no CLI or environment override.
+MANUAL_CONFIRM_SUBMISSION_LIMIT = 1
+
+#: NW-B6: KIS mock cannot discover a cancellable order while ``is_mock=True``.
+#: This literal distinguishes structural non-attempt from a failed attempt or
+#: an invented successful cancellation.
+KILL_TRIPPED_CANCEL_UNSUPPORTED = "KILL_TRIPPED_CANCEL_UNSUPPORTED"
+
 #: Overrides ``KillSwitchDecision.operator_notice``'s default "잔여 주문 취소
 #: 완료" clause — kis_mock has no pending-order inquiry to discover, let
 #: alone cancel, what is still resting (see the module docstring). Stating
 #: "취소 완료" here would be a false claim from the moment submission is
 #: wired, not merely an untested one.
 KILL_CANCEL_UNSUPPORTED_NOTE = (
-    "신규 주문 중단. 잔여 주문 취소는 구조적으로 시도 불가 — KIS 모의투자 "
+    f"{KILL_TRIPPED_CANCEL_UNSUPPORTED}: 신규 주문 중단. 잔여 주문 취소는 구조적으로 시도 불가 — KIS 모의투자 "
     "미체결조회(TTTC8036R)가 is_mock=True 에 대해 지원되지 않아 "
     "(DomesticOrderClient.inquire_korea_orders) 취소 대상을 조회할 수단이 "
     "없음. 재개는 운영자 결정 (계약 §2-4)."
@@ -136,6 +181,25 @@ def _table_or_reason(
     if isinstance(result, TableUnavailable):
         return None, result
     return result, None
+
+
+def _stamp_kr_contract_and_account_map(record: dict[str, Any]) -> None:
+    """Replace only KR's inherited generic provenance with current facts."""
+
+    record["contract"] = {
+        "path": "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md",
+        "version": KR_CONTRACT_VERSION,
+        "clauses": dict(KR_CONTRACT_CLAUSES),
+        "file_sha256_reference_only": KR_CONTRACT_FILE_SHA256_REFERENCE_ONLY,
+    }
+    record["account_map"] = {
+        "repo": "auto_trader-operator",
+        "commit": KR_ACCOUNT_MAP_COMMIT,
+        "canonical_surface": "operator_contract.yaml",
+        "reference_surface": "mock/CLAUDE.md",
+        "gate_values": dict(KR_ACCOUNT_MAP_VALUES),
+    }
+    record["cycle_status"] = "OBSERVATION_DERIVATION_ONLY"
 
 
 #: Contract v1.5 ①: like the crypto sidecar, the KR lane has no realized-P&L
@@ -204,109 +268,259 @@ def broker_state(
     )
 
 
-async def run_kr_cycle(
+def _persist_outcome(
     *,
-    now: dt.datetime,
-    table_dir: Path = DEFAULT_TABLE_DIR,
-    out_dir: Path = DEFAULT_OBSERVATION_DIR,
-    confirm: bool = False,
-    client: Any | None = None,
-    broker: Any | None = None,
-    pending_reader: kr_pending_ledger.PendingReader | None = None,
+    outcome: KrCycleOutcome,
+    ledger: ObservationLedger,
+    record: dict[str, Any],
+    labels: tuple[str, ...],
 ) -> KrCycleOutcome:
-    """One kis_mock cycle. ``broker`` mirrors the existing ``client`` DI seam
-    (tests inject a fake broker; production leaves it ``None`` and this
-    function builds ``kr_mock.build_kis_mock_broker()`` lazily, only when
-    there is something to submit). See ``scripts.b0x.kr.mock`` module
-    docstring for what submission wiring does and does not cover.
+    """Append one immutable cycle record and render its matching artifact."""
 
-    ``pending_reader`` is the contract v1.6 ① seam for 자기 미체결; production
-    leaves it ``None`` and gets
-    :func:`scripts.b0x.kr.pending_ledger.read_own_pending`. Whatever it
-    returns, a ``PendingUnreadable`` result still fails closed on every symbol
-    — the reader can resolve the tri-state, never remove it.
+    ledger.record_cycle(record)
+    outcome.record = record
+    outcome.artifact_path = ledger.write_artifact(
+        name=f"{outcome.at.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
+        content=render_cycle_report(record, labels=labels),
+    )
+    return outcome
+
+
+def _finish_zero_order(
+    *,
+    outcome: KrCycleOutcome,
+    ledger: ObservationLedger,
+    record: dict[str, Any],
+    labels: tuple[str, ...],
+    reason: str,
+    detail: str,
+) -> KrCycleOutcome:
+    """Record a fail-closed, no-dispatch terminal outcome."""
+
+    record["zero_order_reason"] = reason
+    record["zero_order_detail"] = detail
+    record["orders"] = []
+    record["skipped"] = []
+    record["planned"] = []
+    record["blocked"] = []
+    record["submitted"] = []
+    outcome.zero_order_reason = reason
+    return _persist_outcome(
+        outcome=outcome, ledger=ledger, record=record, labels=labels
+    )
+
+
+def _confirm_preflight_record(
+    *,
+    started_at: dt.datetime,
+    completed_at: dt.datetime,
+    account_identity: dict[str, str],
+    fresh: kr_mock.FreshTruth,
+    own_pending: tuple[str, ...] | PendingUnreadable,
+    foreign_traces: kr_pending_ledger.ForeignLedgerTraces | PendingUnreadable,
+) -> dict[str, Any]:
+    """NW-B4 account truth, rendered without balances or account numbers.
+
+    KIS mock's native pending-order query is structurally unavailable.  The
+    v1.6-approved same-day signal/order-ledger union is therefore named as a
+    **ledger shadow** rather than misreported as a native open-order response.
+    A non-B0-X trace is contamination; an unreadable trace source is also a
+    failure because exclusive truth was not established.
     """
 
-    envelope = load_envelope(MARKET)
-    assert_envelope_locked(envelope)
-    # Keep the KR lane wired to the scope helper even while the initial scope
-    # remains sidecar-only. A future, explicit scope expansion must change the
-    # rendered KR artifact rather than disappear because this call was absent.
-    labels = header_labels(lane=LANE, extra=account_history_labels(LANE))
-    outcome = KrCycleOutcome(lane=LANE, at=now)
+    elapsed_seconds = (completed_at - started_at).total_seconds()
+    own_unreadable = own_pending if isinstance(own_pending, PendingUnreadable) else None
+    foreign_unreadable = (
+        foreign_traces if isinstance(foreign_traces, PendingUnreadable) else None
+    )
+    own_symbols = () if own_unreadable is not None else own_pending
+    foreign = None if foreign_unreadable is not None else foreign_traces
+    position_symbols = fresh.non_dust_position_symbols()
+    reasons: list[str] = []
 
-    with writer_lock(lane=LANE, root=Path(out_dir).expanduser()):
-        ledger = ObservationLedger(lane=LANE, root=Path(out_dir).expanduser())
-        ledger.ensure()
+    if elapsed_seconds > PREFLIGHT_MAX_AGE_SECONDS:
+        reasons.append("preflight_exceeded_5_minutes")
+    if fresh.cash <= 0:
+        reasons.append("cash_not_positive")
+    if position_symbols:
+        reasons.append("unexpected_positions")
+    if own_unreadable is not None:
+        reasons.append("ledger_pending_unreadable")
+    elif own_symbols:
+        reasons.append("ledger_pending_present")
+    if foreign_unreadable is not None:
+        reasons.append("foreign_trace_unreadable")
+    elif foreign is not None and foreign.trace_count:
+        reasons.append("CONTAMINATED_foreign_correlation_trace")
 
-        record = base_record(
-            market=MARKET, lane=LANE, now=now, envelope=envelope, labels=labels
-        )
-        record["confirm"] = confirm
-        record["realized_pnl_source"] = KR_REALIZED_PNL_UNAVAILABLE
+    return {
+        "started_at": started_at.isoformat(),
+        "completed_at": completed_at.isoformat(),
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "max_age_seconds": PREFLIGHT_MAX_AGE_SECONDS,
+        "account": account_identity,
+        "cash": {"present": bool(fresh.cash > 0)},
+        "positions": {
+            "non_dust_symbols": list(position_symbols),
+            "count": len(position_symbols),
+        },
+        "open_orders": {
+            "native_broker": {
+                "available": False,
+                "reason": "TTTC8036R is unsupported for is_mock=True",
+            },
+            "ledger_shadow": {
+                "own_pending_symbols": list(own_symbols),
+                "foreign_traces": (
+                    foreign_unreadable.canonical()
+                    if foreign_unreadable is not None
+                    else foreign.canonical()
+                    if foreign is not None
+                    else None
+                ),
+            },
+        },
+        "ledger_pending": (
+            own_unreadable.canonical()
+            if own_unreadable is not None
+            else {"symbols": list(own_symbols), "count": len(own_symbols)}
+        ),
+        "writer_lease": {"acquired": True, "surface": "b0x_adapter"},
+        "passed": not reasons,
+        "reasons": reasons,
+    }
 
-        # --- RTH gate: cheapest check, before any table/account I/O ---
-        in_session = is_krx_regular_session(now)
-        record["krx_regular_session"] = in_session
-        if not in_session:
-            record["zero_order_reason"] = OUTSIDE_RTH_REASON
-            record["zero_order_detail"] = (
-                f"now={now.isoformat()} is outside the XKRX regular session "
-                "(contract: KRX RTH v1 — 정규장만, NXT/시간외 금지)"
+
+def _preflight_truth_unavailable_record(
+    *,
+    started_at: dt.datetime,
+    completed_at: dt.datetime,
+    account_identity: dict[str, str],
+    error: Exception,
+) -> dict[str, Any]:
+    """Record an unreadable account snapshot without exposing exception text."""
+
+    elapsed_seconds = (completed_at - started_at).total_seconds()
+    return {
+        "started_at": started_at.isoformat(),
+        "completed_at": completed_at.isoformat(),
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "max_age_seconds": PREFLIGHT_MAX_AGE_SECONDS,
+        "account": account_identity,
+        "cash": {"present": None},
+        "positions": {"non_dust_symbols": None, "count": None},
+        "open_orders": {
+            "native_broker": {
+                "available": False,
+                "reason": "account truth unavailable before pending check",
+            },
+            "ledger_shadow": None,
+        },
+        "ledger_pending": None,
+        "writer_lease": {"acquired": True, "surface": "b0x_adapter"},
+        "passed": False,
+        "reasons": ["account_truth_unavailable"],
+        "error_type": type(error).__name__,
+    }
+
+
+async def _run_prepared_cycle(
+    *,
+    now: dt.datetime,
+    table: PolicyTable,
+    envelope: Envelope,
+    labels: tuple[str, ...],
+    outcome: KrCycleOutcome,
+    ledger: ObservationLedger,
+    record: dict[str, Any],
+    confirm: bool,
+    client: Any | None,
+    broker: Any | None,
+    pending_reader: kr_pending_ledger.PendingReader | None,
+    foreign_trace_reader: kr_pending_ledger.ForeignTraceReader | None,
+    account_identity: dict[str, str] | None,
+) -> KrCycleOutcome:
+    """Account truth → derive → plan → bounded confirm dispatch.
+
+    The caller holds the B0-X artifact lock and, on the confirm path, the
+    account-wide kis_mock writer lease.  Keeping the two locks separate is
+    deliberate: the local artifact lock protects B0-X's own records while the
+    durable lease checks every catalogued kis_mock mutation surface.
+    """
+
+    owns_client = client is None
+    if owns_client:
+        client = kr_mock.ReadOnlyKISMockDomesticClient()
+
+    try:
+        preflight_started_at = dt.datetime.now(dt.UTC) if confirm else None
+        try:
+            fresh = await kr_mock.read_fresh_truth(client)
+        except Exception as exc:
+            if not confirm:
+                raise
+            assert preflight_started_at is not None
+            assert account_identity is not None
+            completed_at = dt.datetime.now(dt.UTC)
+            record["preflight"] = _preflight_truth_unavailable_record(
+                started_at=preflight_started_at,
+                completed_at=completed_at,
+                account_identity=account_identity,
+                error=exc,
             )
-            record["orders"] = []
-            record["skipped"] = []
-            record["submitted"] = []
-            outcome.zero_order_reason = OUTSIDE_RTH_REASON
-            ledger.record_cycle(record)
-            outcome.record = record
-            outcome.artifact_path = ledger.write_artifact(
-                name=f"{now.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
-                content=render_cycle_report(record, labels=labels),
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="preflight_not_clean",
+                detail="account_truth_unavailable",
             )
-            return outcome
 
-        # --- table gate ---
-        table, unavailable = _table_or_reason(now=now, table_dir=Path(table_dir))
-        if table is None:
-            assert unavailable is not None
-            record["zero_order_reason"] = unavailable.reason
-            record["zero_order_detail"] = unavailable.detail
-            record["orders"] = []
-            record["skipped"] = []
-            record["submitted"] = []
-            outcome.zero_order_reason = unavailable.reason
-            ledger.record_cycle(record)
-            outcome.record = record
-            outcome.artifact_path = ledger.write_artifact(
-                name=f"{now.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
-                content=render_cycle_report(record, labels=labels),
-            )
-            return outcome
-
-        outcome.table_hash = table.policy_table_hash
-        outcome.table_generated_at = table.generated_at.isoformat()
-        outcome.table_age_seconds = int(table.age.total_seconds())
-        record["policy_table_hash"] = table.policy_table_hash
-        record["policy_table_path"] = str(table.path)
-        record["policy_table_generated_at"] = table.generated_at.isoformat()
-        record["policy_table_age_seconds"] = int(table.age.total_seconds())
-
-        # --- account state (read-only) ---
-        owns_client = client is None
-        if owns_client:
-            client = kr_mock.ReadOnlyKISMockDomesticClient()
-        fresh = await kr_mock.read_fresh_truth(client)
-
-        # Contract v1.6 ① — 자기 미체결 only. Read after the holdings snapshot
-        # and kept in its own variable so it can reach exactly one field
-        # (``BrokerTruth.own_pending``); positions below never see it.
         reader = pending_reader or kr_pending_ledger.read_own_pending
-        own_pending = await reader(
-            now=now, correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
-        )
+        pending_now = preflight_started_at if preflight_started_at is not None else now
+        try:
+            own_pending = await reader(
+                now=pending_now, correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
+            )
+        except Exception as exc:
+            if not confirm:
+                raise
+            own_pending = kr_pending_ledger.ledger_unreadable(type(exc).__name__)
         record["fresh_truth"] = fresh.status_only(own_pending)
         record["own_pending_source"] = kr_mock.OWN_PENDING_SOURCE
+
+        if confirm:
+            foreign_reader = (
+                foreign_trace_reader or kr_pending_ledger.read_foreign_traces
+            )
+            try:
+                foreign_traces = await foreign_reader(
+                    now=pending_now,
+                    correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-",
+                )
+            except Exception as exc:
+                foreign_traces = kr_pending_ledger.ledger_unreadable(type(exc).__name__)
+            assert preflight_started_at is not None
+            assert account_identity is not None
+            preflight = _confirm_preflight_record(
+                started_at=preflight_started_at,
+                completed_at=dt.datetime.now(dt.UTC),
+                account_identity=account_identity,
+                fresh=fresh,
+                own_pending=own_pending,
+                foreign_traces=foreign_traces,
+            )
+            record["preflight"] = preflight
+            if not preflight["passed"]:
+                return _finish_zero_order(
+                    outcome=outcome,
+                    ledger=ledger,
+                    record=record,
+                    labels=labels,
+                    reason="preflight_not_clean",
+                    detail=", ".join(preflight["reasons"]),
+                )
 
         state = broker_state(fresh=fresh, own_pending=own_pending)
         record["broker_truth"] = state.broker_truth.canonical()
@@ -342,11 +556,10 @@ async def run_kr_cycle(
             record["blocked"] = []
             record["submitted"] = []
             record["cancelled"] = []
-            record["cancellation_unsupported"] = (
-                "kis_mock has no pending-order inquiry for is_mock=True "
-                "(DomesticOrderClient.inquire_korea_orders raises); cancel "
-                "was not attempted, not attempted-and-failed"
-            )
+            record["cancel_status"] = KILL_TRIPPED_CANCEL_UNSUPPORTED
+            record["cancel_attempted"] = False
+            record["cancel_confirmed"] = False
+            record["cancellation_unsupported"] = KILL_CANCEL_UNSUPPORTED_NOTE
         else:
             held = {pos.symbol: pos.quantity for pos in state.positions}
             planned, blocked = kr_mock.plan_orders(
@@ -356,49 +569,290 @@ async def run_kr_cycle(
             record["blocked"] = [order.to_json() for order in blocked]
 
             submitted: list[dict[str, Any]] = []
+            fill_confirmation: list[dict[str, Any]] = []
             if not confirm:
-                # Preview only, like the crypto sidecar's confirm=False: zero
-                # dispatch attempts, planned orders are still fully recorded
-                # above. Does NOT construct a broker or call submit_planned_
-                # order — a dry preview must not depend on submission wiring
-                # at all.
                 record["submission_skipped"] = "confirm=False — preview only"
             else:
-                # contract v1.3 ③: KisMockBroker (ROB-321/341), reused as-is.
-                # See scripts.b0x.kr.mock module docstring for the one
-                # documented mismatch (BUY-leg freshness re-check with no
-                # live feed) and why it fails closed rather than fabricates
-                # a quote.
                 active_broker = (
-                    broker if broker is not None else (kr_mock.build_kis_mock_broker())
+                    broker if broker is not None else kr_mock.build_kis_mock_broker()
                 )
-                for order in planned:
-                    result = await kr_mock.submit_planned_order(
-                        active_broker,
-                        planned=order,
-                        confirm=confirm,
-                        broker_truth=state.broker_truth,
-                    )
-                    submitted.append(result)
-            record["submitted"] = submitted
+                for index, order in enumerate(planned):
+                    if index >= MANUAL_CONFIRM_SUBMISSION_LIMIT:
+                        record["submission_stopped"] = (
+                            "acceptance_submission_limit="
+                            f"{MANUAL_CONFIRM_SUBMISSION_LIMIT}"
+                        )
+                        break
+                    submitted_at = dt.datetime.now(dt.UTC)
+                    if (
+                        preflight_started_at is None
+                        or (submitted_at - preflight_started_at).total_seconds()
+                        > PREFLIGHT_MAX_AGE_SECONDS
+                    ):
+                        record["submission_stopped"] = "preflight_expired"
+                        break
 
-        ledger.record_cycle(record)
-        outcome.record = record
-        outcome.artifact_path = ledger.write_artifact(
-            name=f"{now.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
-            content=render_cycle_report(record, labels=labels),
+                    # v1.6's dedup is re-read immediately before every real
+                    # dispatch.  The artifact's first snapshot is evidence;
+                    # this re-read is the mutation boundary.
+                    try:
+                        current_pending = await reader(
+                            now=submitted_at,
+                            correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-",
+                        )
+                    except Exception as exc:
+                        current_pending = kr_pending_ledger.ledger_unreadable(
+                            type(exc).__name__
+                        )
+                    current_truth = broker_state(
+                        fresh=fresh, own_pending=current_pending
+                    ).broker_truth
+                    try:
+                        result = await kr_mock.submit_planned_order(
+                            active_broker,
+                            planned=order,
+                            confirm=True,
+                            broker_truth=current_truth,
+                        )
+                    except OwnPendingResubmitBlocked:
+                        record.setdefault("submission_dedup_blocked", []).append(
+                            {
+                                "symbol": order.symbol,
+                                "correlation_id": order.client_order_id,
+                                "reason": "v1_6_pending_recheck_blocked",
+                            }
+                        )
+                        record["submission_stopped"] = "v1_6_dedup_blocked"
+                        break
+                    submitted.append(result)
+
+                    # Prove the mandatory pre-submit trace is visible after a
+                    # successful dispatch. The signal ledger is authoritative
+                    # for this check even if the post-send order-ledger insert
+                    # is unavailable, so it does not depend on ``ledger_id``.
+                    if result.get("success"):
+                        post_pending = await reader(
+                            now=dt.datetime.now(dt.UTC),
+                            correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-",
+                        )
+                        observed = (
+                            not isinstance(post_pending, PendingUnreadable)
+                            and order.symbol in post_pending
+                        )
+                        record.setdefault("post_submit_dedup", []).append(
+                            {
+                                "symbol": order.symbol,
+                                "correlation_id": order.client_order_id,
+                                "observed": observed,
+                            }
+                        )
+                        if not observed:
+                            record["submission_stopped"] = "post_submit_dedup_unproven"
+                            break
+
+                    if result.get("success") and isinstance(
+                        active_broker, kr_mock.KisMockBroker
+                    ):
+                        try:
+                            fill = await active_broker.confirm_fill(result)
+                        except Exception as exc:  # noqa: BLE001 — observation only
+                            fill_confirmation.append(
+                                {
+                                    "symbol": order.symbol,
+                                    "correlation_id": order.client_order_id,
+                                    "confirmed": False,
+                                    "error_type": type(exc).__name__,
+                                }
+                            )
+                        else:
+                            fill_confirmation.append(
+                                {
+                                    "symbol": order.symbol,
+                                    "correlation_id": order.client_order_id,
+                                    "confirmed": fill is not None,
+                                    "quantity": (
+                                        None if fill is None else str(fill.quantity)
+                                    ),
+                                    "price": None if fill is None else str(fill.price),
+                                }
+                            )
+
+            record["submitted"] = submitted
+            if fill_confirmation:
+                record["fill_confirmation"] = fill_confirmation
+
+        return _persist_outcome(
+            outcome=outcome, ledger=ledger, record=record, labels=labels
         )
+    finally:
         if owns_client:
             close = getattr(client, "close", None)
             if callable(close):
                 await close()
-        return outcome
+
+
+async def run_kr_cycle(
+    *,
+    now: dt.datetime,
+    table_dir: Path = DEFAULT_TABLE_DIR,
+    out_dir: Path = DEFAULT_OBSERVATION_DIR,
+    confirm: bool = False,
+    client: Any | None = None,
+    broker: Any | None = None,
+    pending_reader: kr_pending_ledger.PendingReader | None = None,
+    foreign_trace_reader: kr_pending_ledger.ForeignTraceReader | None = None,
+) -> KrCycleOutcome:
+    """One manual kis_mock B0-X cycle.
+
+    ``confirm=False`` remains the ordinary observation/derivation path.  A
+    confirm call is a separate, default-disabled manual surface: it requires
+    the B0-X env gate, the per-call ``confirm=True`` argument, the
+    account-wide kis_mock writer lease, and a fresh clean NW-B4 preflight
+    before it reaches the existing ``KisMockBroker`` adapter.
+
+    ``pending_reader`` is the v1.6 own-pending seam.  ``foreign_trace_reader``
+    is intentionally separate: it never becomes position/cap truth and is
+    only the exclusive-account contamination check for a confirm preflight.
+    """
+
+    envelope = load_envelope(MARKET)
+    assert_envelope_locked(envelope)
+    # Keep the KR lane wired to the scope helper even while the initial scope
+    # remains sidecar-only. A future, explicit scope expansion must change the
+    # rendered KR artifact rather than disappear because this call was absent.
+    labels = header_labels(
+        lane=LANE,
+        extra=(*account_history_labels(LANE), KR_STATUS_LABEL),
+    )
+    outcome = KrCycleOutcome(lane=LANE, at=now)
+
+    with writer_lock(lane=LANE, root=Path(out_dir).expanduser()):
+        ledger = ObservationLedger(lane=LANE, root=Path(out_dir).expanduser())
+        ledger.ensure()
+
+        record = base_record(
+            market=MARKET, lane=LANE, now=now, envelope=envelope, labels=labels
+        )
+        _stamp_kr_contract_and_account_map(record)
+        record["confirm"] = confirm
+        record["realized_pnl_source"] = KR_REALIZED_PNL_UNAVAILABLE
+
+        # --- RTH gate: cheapest check, before any table/account I/O ---
+        in_session = is_krx_regular_session(now)
+        record["krx_regular_session"] = in_session
+        if not in_session:
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason=OUTSIDE_RTH_REASON,
+                detail=(
+                    f"now={now.isoformat()} is outside the XKRX regular session "
+                    "(contract: KRX RTH v1 — 정규장만, NXT/시간외 금지)"
+                ),
+            )
+
+        # --- table gate ---
+        table, unavailable = _table_or_reason(now=now, table_dir=Path(table_dir))
+        if table is None:
+            assert unavailable is not None
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason=unavailable.reason,
+                detail=unavailable.detail,
+            )
+
+        outcome.table_hash = table.policy_table_hash
+        outcome.table_generated_at = table.generated_at.isoformat()
+        outcome.table_age_seconds = int(table.age.total_seconds())
+        record["policy_table_hash"] = table.policy_table_hash
+        record["policy_table_path"] = str(table.path)
+        record["policy_table_generated_at"] = table.generated_at.isoformat()
+        record["policy_table_age_seconds"] = int(table.age.total_seconds())
+
+        if not confirm:
+            return await _run_prepared_cycle(
+                now=now,
+                table=table,
+                envelope=envelope,
+                labels=labels,
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                confirm=False,
+                client=client,
+                broker=broker,
+                pending_reader=pending_reader,
+                foreign_trace_reader=foreign_trace_reader,
+                account_identity=None,
+            )
+
+        try:
+            kr_mock.assert_kr_lane_enabled()
+            # Validate the configured account identity before any broker/DB
+            # truth read.  Only its one-way fingerprint enters the artifact.
+            account_identity = kr_mock.account_identity_summary()
+        except kr_mock.KrLaneDisabled as exc:
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="confirm_gate_not_armed",
+                detail=str(exc),
+            )
+
+        try:
+            async with KISMockWriterLease(writer_surface="b0x_adapter"):
+                return await _run_prepared_cycle(
+                    now=now,
+                    table=table,
+                    envelope=envelope,
+                    labels=labels,
+                    outcome=outcome,
+                    ledger=ledger,
+                    record=record,
+                    confirm=True,
+                    client=client,
+                    broker=broker,
+                    pending_reader=pending_reader,
+                    foreign_trace_reader=foreign_trace_reader,
+                    account_identity=account_identity,
+                )
+        except WriterSingletonContended as exc:
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="preflight_writer_contended",
+                detail=str(exc),
+            )
+        except WriterSingletonUnavailable as exc:
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="preflight_writer_unavailable",
+                detail=str(exc),
+            )
 
 
 __all__ = [
     "MARKET",
     "LANE",
     "OUTSIDE_RTH_REASON",
+    "PREFLIGHT_MAX_AGE_SECONDS",
+    "MANUAL_CONFIRM_SUBMISSION_LIMIT",
+    "KILL_TRIPPED_CANCEL_UNSUPPORTED",
+    "KR_CONTRACT_VERSION",
+    "KR_ACCOUNT_MAP_COMMIT",
+    "KR_STATUS_LABEL",
     "KR_REALIZED_PNL_UNAVAILABLE",
     "KrCycleOutcome",
     "broker_state",

--- a/scripts/b0x/kr/mock.py
+++ b/scripts/b0x/kr/mock.py
@@ -1,12 +1,12 @@
 """``kis_mock`` lane — B0-X KRX equities read/plan surface.
 
 Account map (operator repo ``operator_contract.yaml``, canonical per contract
-v1.3 ①; HEAD ``3f40291`` at wiring time, PR #33): *kis_mock exclusive_lane =
-B0-X-KR, mutation_policy = b0x_adapter_orders_only_within_envelope,
-strategy_order_exceptions ∋ b0x-adapter-orders-20260808 with kis_mock in its
-surfaces* — 주문 writer 는 B0-X 어댑터 하나뿐. ``mock/CLAUDE.md`` §1 is the
-human-readable reference row and defers to the YAML on conflict (its own
-§0/§4 rule).
+v1.3 ① / v1.6; HEAD ``e93349e``, PR #36): *account_lanes.kis_mock = B0-X-KR,
+exclusive_lane = B0-X-KR, active_ordering_strategy =
+B0-X-adapter-single-writer, strategy_order_exceptions ∋
+b0x-adapter-orders-20260808 with kis_mock in its surfaces* — 주문 writer 는
+B0-X 어댑터 하나뿐. ``mock/CLAUDE.md`` §1 is the human-readable reference row
+and defers to the YAML on conflict (its own §0/§4 rule).
 
 What is reused, unchanged
 --------------------------
@@ -52,13 +52,14 @@ freshness model built for its own live WebSocket feed
 ``policy_table.v1`` snapshot, not a live book. Rather than fabricate a
 synthetic quote (which would make a real safety check pass on invented
 data), ``build_kis_mock_broker`` supplies a ``get_state`` that always
-returns ``None``. Consequence: a real BUY dispatch (``confirm=True``) fails
-closed with ``PreSendFreshnessError(("no_market_state",))`` *before any
-HTTP POST* — safe, honest, and it is the adapter's own existing exception,
-not a special-cased block. SELL legs (``submit_exit_sell``) carry no such
-hook by ROB-321's own design ("a live position remains closable") and are
-unaffected. Wiring a real B0-X market-data feed to lift the BUY-side block
-is out of this PR's scope.
+returns ``None``. The thin submission chokepoint then asks the reused
+``KisMockBroker`` for one fresh **mock-host** orderbook snapshot immediately
+before a BUY. The adapter converts that broker response to its existing
+``MarketState`` and still applies the same pre-send age/spread hook at the
+HTTP boundary. If that read is missing, malformed, stale, or too wide, the
+BUY fails closed with zero POSTs; no policy-table price is ever presented as
+a quote. SELL legs (``submit_exit_sell``) carry no such hook by ROB-321's own
+design ("a live position remains closable") and are unaffected.
 
 ``KrMockSubmissionNotWired`` (below) is kept, not deleted, even though the
 main path no longer raises it: it is still the honest signal for any caller
@@ -103,12 +104,13 @@ not, exercised.
 
 from __future__ import annotations
 
+import hashlib
 import os
 from dataclasses import dataclass
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
 from typing import Any, Protocol, cast
 
-from app.core.config import validate_kis_mock_config
+from app.core.config import settings, validate_kis_mock_config
 from app.mcp_server.tick_size import get_tick_size_kr
 from app.services.brokers.kis.account import AccountClient
 from app.services.brokers.kis.base import BaseKISClient
@@ -220,6 +222,23 @@ def assert_kr_lane_enabled() -> None:
     missing = validate_kis_mock_config()
     if missing:
         raise KrLaneDisabled(f"KIS mock config incomplete, missing env: {missing}")
+
+
+def account_identity_summary() -> dict[str, str]:
+    """Return a report-safe fingerprint for the configured mock account.
+
+    The KIS balance response does not echo the full account number.  Confirm
+    preflight therefore records a stable one-way fingerprint plus only the
+    two-character product suffix; it never emits the account number itself.
+    """
+
+    compact = str(settings.kis_mock_account_no or "").replace("-", "").strip()
+    if len(compact) < 10:
+        raise KrLaneDisabled("KIS mock account identifier is unavailable or malformed")
+    return {
+        "fingerprint": f"sha256:{hashlib.sha256(compact.encode()).hexdigest()[:16]}",
+        "product_suffix": compact[-2:],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -569,7 +588,7 @@ async def unwired_submit_order(
     """
 
     raise KrMockSubmissionNotWired(
-        "scripts.b0x.kr.mock has no wired kis_mock order-submission function "
+        "this caller bypassed the wired kis_mock order-submission function "
         f"(order_key={planned.order_key} symbol={planned.symbol} "
         f"side={planned.side} confirm={confirm}). See the module docstring "
         "for why this is a deliberate PR-scope boundary, not a bug."
@@ -577,10 +596,12 @@ async def unwired_submit_order(
 
 
 def _b0x_get_state(symbol: str) -> MarketState | None:
-    """B0-X has no live WS book (unlike ROB-321's scalping engine) — always
-    ``None``. See the module docstring: this makes a real BUY dispatch fail
-    closed via the adapter's own ``PreSendFreshnessError``, honestly, rather
-    than fabricate a quote to satisfy a check built for a different feed.
+    """B0-X has no WebSocket supervisor, so its injected state is absent.
+
+    :func:`submit_planned_order` compensates only by asking the sanctioned
+    adapter for a just-read mock-host orderbook.  It never uses a policy-table
+    value as a quote, and the adapter's normal pre-send guard remains the
+    final decision point.
     """
 
     return None
@@ -627,6 +648,23 @@ async def submit_planned_order(
     price = Decimal(planned.price)
     quantity = Decimal(planned.quantity)
     if planned.side == "buy":
+        # B0-X owns no WebSocket supervisor.  The sanctioned adapter therefore
+        # refreshes its *own* mock-host orderbook state here; this is a
+        # read-only bridge into the adapter's existing freshness guard, not a
+        # substitute quote or a second order path.  Do it before the adapter's
+        # pre-submit attribution/ledger write so a failed quote read leaves no
+        # synthetic pending trace behind.
+        if isinstance(broker, KisMockBroker):
+            try:
+                await broker.refresh_market_state(symbol=planned.symbol)
+            except Exception as exc:  # noqa: BLE001 — fresh quote is mandatory
+                return {
+                    "success": False,
+                    "pre_send_blocked": True,
+                    "reason_codes": ["mock_orderbook_unavailable"],
+                    "detail": f"{type(exc).__name__}: mock orderbook refresh failed",
+                    "dry_run": not confirm,
+                }
         return await broker.submit_buy(
             symbol=planned.symbol,
             price=price,
@@ -664,6 +702,7 @@ __all__ = [
     "BlockedOrder",
     "SubmitOrderFn",
     "assert_kr_lane_enabled",
+    "account_identity_summary",
     "read_fresh_truth",
     "align_price_kr",
     "client_order_id_for",

--- a/scripts/b0x/kr/pending_ledger.py
+++ b/scripts/b0x/kr/pending_ledger.py
@@ -84,6 +84,7 @@ failed read into ``()``.
 from __future__ import annotations
 
 import datetime as dt
+from dataclasses import dataclass
 from typing import Final, Protocol
 
 from sqlalchemy import select
@@ -111,6 +112,44 @@ class PendingReader(Protocol):
     async def __call__(
         self, *, now: dt.datetime, correlation_prefix: str
     ) -> tuple[str, ...] | PendingUnreadable: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ForeignLedgerTraces:
+    """Same-day non-B0-X ledger traces observed during confirm preflight.
+
+    KIS mock cannot answer its native pending-order query.  This is therefore
+    deliberately a *ledger-trace* contamination signal, not a claim that the
+    broker returned an open-order book.  A trace whose correlation id is not
+    this lane's prefix (including a missing id) is evidence of another writer
+    touching the exclusive account and must stop a confirmed B0-X dispatch.
+    """
+
+    symbols: tuple[str, ...]
+    order_trace_count: int
+    signal_trace_count: int
+
+    @property
+    def trace_count(self) -> int:
+        return self.order_trace_count + self.signal_trace_count
+
+    def canonical(self) -> dict[str, object]:
+        """Report-safe evidence: symbols/counts, never another writer's id."""
+
+        return {
+            "symbols": list(self.symbols),
+            "order_trace_count": self.order_trace_count,
+            "signal_trace_count": self.signal_trace_count,
+            "trace_count": self.trace_count,
+        }
+
+
+class ForeignTraceReader(Protocol):
+    """Confirm-preflight seam for non-B0-X traces on the exclusive lane."""
+
+    async def __call__(
+        self, *, now: dt.datetime, correlation_prefix: str
+    ) -> ForeignLedgerTraces | PendingUnreadable: ...
 
 
 def ledger_unreadable(cause: str) -> PendingUnreadable:
@@ -207,13 +246,99 @@ async def read_own_pending(
     return tuple(sorted(symbols))
 
 
+async def read_foreign_traces(
+    *, now: dt.datetime, correlation_prefix: str
+) -> ForeignLedgerTraces | PendingUnreadable:
+    """Read current-KST-day traces that do not belong to this B0-X lane.
+
+    The v1.6 own-pending reader remains the only cap/dedup input.  This
+    additional read exists solely for NW-B4's exclusive-account contamination
+    gate: any other correlation trace is a fail-closed preflight finding.  It
+    intentionally reads both the post-send order ledger and the durable
+    pre-send signal ledger, so a failed native-order write cannot hide another
+    writer's send attempt.
+
+    As with :func:`read_own_pending`, every query failure returns
+    :class:`PendingUnreadable`; confirm preflight treats it as an inability to
+    establish clean exclusive truth and submits zero orders.
+    """
+
+    since = kst_trading_day_start(now)
+    kst_date = kst_trading_day_label(now)
+
+    try:
+        async with AsyncSessionLocal() as db:
+            order_rows = (
+                await db.execute(
+                    select(
+                        KISMockOrderLedger.symbol, KISMockOrderLedger.correlation_id
+                    ).where(
+                        KISMockOrderLedger.account_mode == ACCOUNT_MODE,
+                        KISMockOrderLedger.trade_date >= since,
+                    )
+                )
+            ).all()
+            signal_rows = (
+                await db.execute(
+                    select(
+                        KISMockSignalLedger.symbol,
+                        KISMockSignalLedger.correlation_id,
+                    ).where(
+                        KISMockSignalLedger.account_mode == ACCOUNT_MODE,
+                        KISMockSignalLedger.kst_date == kst_date,
+                    )
+                )
+            ).all()
+    except Exception as exc:  # noqa: BLE001 — unavailable truth is fail-closed
+        return ledger_unreadable(type(exc).__name__)
+
+    def _is_foreign(row: object) -> bool:
+        correlation_id = getattr(row, "correlation_id", None)
+        if correlation_id is None:
+            # SQLAlchemy's row mapping also exposes labelled columns through
+            # the mapping.  Keep this fallback literal/static rather than a
+            # dynamic attribute lookup so the KR AST guard remains meaningful.
+            mapping = getattr(row, "_mapping", None)
+            correlation_id = (
+                mapping.get("correlation_id") if mapping is not None else None
+            )
+        return not str(correlation_id or "").startswith(correlation_prefix)
+
+    def _symbol(row: object) -> str:
+        symbol = getattr(row, "symbol", None)
+        if symbol is None:
+            mapping = getattr(row, "_mapping", None)
+            symbol = mapping.get("symbol") if mapping is not None else None
+        return str(symbol or "").strip()
+
+    foreign_order_rows = [row for row in order_rows if _is_foreign(row)]
+    foreign_signal_rows = [row for row in signal_rows if _is_foreign(row)]
+    symbols = tuple(
+        sorted(
+            {
+                symbol
+                for row in [*foreign_order_rows, *foreign_signal_rows]
+                if (symbol := _symbol(row))
+            }
+        )
+    )
+    return ForeignLedgerTraces(
+        symbols=symbols,
+        order_trace_count=len(foreign_order_rows),
+        signal_trace_count=len(foreign_signal_rows),
+    )
+
+
 __all__ = [
     "ACCOUNT_MODE",
     "KST",
     "LEDGER_UNREADABLE_REASON",
     "PendingReader",
+    "ForeignLedgerTraces",
+    "ForeignTraceReader",
     "kst_trading_day_label",
     "kst_trading_day_start",
     "ledger_unreadable",
     "read_own_pending",
+    "read_foreign_traces",
 ]

--- a/scripts/run_b0x_kr_cycle.py
+++ b/scripts/run_b0x_kr_cycle.py
@@ -1,4 +1,4 @@
-"""B0-X kis_mock (KR) cycle runner — manual kickoff only (contract §5, v1).
+"""B0-X kis_mock (KR) cycle runner — scheduleless manual kickoff only.
 
     # Preview: derive + plan, dispatch nothing. Safe outside session too (the
     # RTH gate just produces a zero-order cycle with a recorded reason).
@@ -7,13 +7,18 @@
     # Determinism proof: derive twice, compare bytes (no writes, no venue).
     uv run python -m scripts.run_b0x_kr_cycle --derivation-only --repeat 2
 
-There is deliberately no ``--confirm`` flag that reaches a submission. Passing
-one would only ever raise ``KrMockSubmissionNotWired`` — see
-``scripts.b0x.kr.mock``'s module docstring for why order submission is an
-unwired, explicitly-out-of-scope extension point in this PR, not a working
-integration. There is also no flag that can move an envelope value — the §4
-caps live in ``scripts.b0x.envelope`` as module constants, re-asserted before
-every account read.
+    # One manually requested mock acceptance attempt.  It is default-disabled,
+    # is bounded to one submission, and fails closed unless the KR env gate,
+    # writer lease, and NW-B4 preflight all pass during KRX RTH.
+    uv run python -m scripts.run_b0x_kr_cycle --confirm
+
+``--confirm`` is not a status change: KR remains
+``OBSERVATION_DERIVATION_ONLY`` until an upstream decision says otherwise.
+It cannot be combined with ``--now`` or ``--derivation-only``, so an operator
+cannot replay an artificial session timestamp into the mutation path. There is
+also no flag that can move an envelope value — the §4 caps live in
+``scripts.b0x.envelope`` as module constants, re-asserted before every account
+read.
 
 No scheduler registration exists for this script — not TaskIQ, not Prefect,
 not launchd. A cycle happens because an operator ran it.
@@ -61,7 +66,7 @@ async def _derivation_only(args: argparse.Namespace) -> int:
 
     Reads the table and a fresh kis_mock account snapshot, then re-derives
     ``args.repeat`` times against the *same* in-memory state and compares
-    hashes. Writes nothing, submits nothing (submission is unwired anyway).
+    hashes. Writes nothing and submits nothing.
     """
 
     from scripts.b0x import kill_switch as kill_switch_module
@@ -124,6 +129,13 @@ async def _derivation_only(args: argparse.Namespace) -> int:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    if args.confirm and args.derivation_only:
+        print("--confirm cannot be combined with --derivation-only", file=sys.stderr)
+        return 2
+    if args.confirm and args.now is not None:
+        print("--confirm cannot be combined with --now", file=sys.stderr)
+        return 2
+
     now = dt.datetime.now(dt.UTC) if args.now is None else args.now
 
     if args.derivation_only:
@@ -134,7 +146,7 @@ async def _run(args: argparse.Namespace) -> int:
             now=now,
             table_dir=Path(args.table_dir).expanduser(),
             out_dir=Path(args.out_dir).expanduser(),
-            confirm=False,
+            confirm=args.confirm,
         )
     except WriterLockUnavailable as exc:
         print(f"WRITER_LOCK_UNAVAILABLE — {exc}", file=sys.stderr)
@@ -173,6 +185,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "derive and print hashes; write nothing, contact no venue "
             "(still reads a fresh kis_mock account snapshot for account state)"
+        ),
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help=(
+            "one manual kis_mock acceptance attempt; default-disabled and "
+            "fail-closed on every preflight gate (KRX RTH only)"
         ),
     )
     parser.add_argument(

--- a/tests/brokers/kis/mock_scalping_exec/test_adapters.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_adapters.py
@@ -74,6 +74,52 @@ async def test_submit_exit_sell_uses_scalping_exit(mocker) -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_refresh_market_state_uses_mock_orderbook_for_existing_guard(
+    mocker,
+) -> None:
+    """A non-WebSocket caller gets a real mock-host book, not a synthetic quote."""
+
+    broker = KisMockBroker(get_state=lambda _s: None, clock=lambda: 100.0)
+    client = mocker.MagicMock()
+    client.inquire_orderbook = AsyncMock(
+        return_value={
+            "bidp1": "70000",
+            "askp1": "70100",
+            "bidp_rsqn1": "12",
+            "askp_rsqn1": "10",
+            "stck_prpr": "70050",
+        }
+    )
+    mocker.patch.object(broker, "_get_mock_client", return_value=client)
+
+    state = await broker.refresh_market_state(symbol="005930")
+
+    client.inquire_orderbook.assert_awaited_once_with("005930", "J")
+    assert state.bid == 70000.0
+    assert state.ask == 70100.0
+    assert broker.quote("005930") == Quote(
+        bid=Decimal("70000.0"), ask=Decimal("70100.0"), last=Decimal("70050.0")
+    )
+    await broker._make_pre_send_hook("005930")()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_refresh_market_state_rejects_malformed_orderbook(mocker) -> None:
+    broker = KisMockBroker(get_state=lambda _s: None)
+    client = mocker.MagicMock()
+    client.inquire_orderbook = AsyncMock(return_value={"bidp1": "0", "askp1": ""})
+    mocker.patch.object(broker, "_get_mock_client", return_value=client)
+
+    with pytest.raises(mod.PreSendFreshnessError) as exc_info:
+        await broker.refresh_market_state(symbol="005930")
+
+    assert exc_info.value.reason_codes == ("invalid_orderbook",)
+    assert broker.quote("005930") is None
+
+
+@pytest.mark.unit
 def test_quote_maps_market_state_to_decimal() -> None:
     state = MarketState(symbol="005930")
     state.bid, state.ask, state.last_price = 70000.0, 70100.0, 70050.0

--- a/tests/brokers/kis/mock_scalping_exec/test_adapters.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_adapters.py
@@ -120,6 +120,39 @@ async def test_refresh_market_state_rejects_malformed_orderbook(mocker) -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_malformed_holding_qty_makes_confirm_fill_fail_closed(mocker) -> None:
+    """A malformed baseline must remain unknown, never become a zero holding."""
+
+    broker = KisMockBroker(get_state=lambda _s: None)
+    client = mocker.MagicMock()
+    client.fetch_domestic_balance_snapshot = AsyncMock(
+        side_effect=[
+            {
+                "holdings": [{"pdno": "005930", "hldg_qty": "N/A"}],
+                "cash": {"dnca_tot_amt": "1000000"},
+            },
+            {
+                "holdings": [{"pdno": "005930", "hldg_qty": "1"}],
+                "cash": {"dnca_tot_amt": "930000"},
+            },
+        ]
+    )
+    mocker.patch.object(broker, "_get_mock_client", return_value=client)
+
+    baseline = await broker._capture_baseline(
+        symbol="005930",
+        side="buy",
+        qty=Decimal("1"),
+        limit_price=Decimal("70000"),
+    )
+
+    assert baseline["holdings_qty"] is None
+    assert await broker.confirm_fill({"_baseline": baseline}) is None
+    client.fetch_domestic_balance_snapshot.assert_awaited_once_with(is_mock=True)
+
+
+@pytest.mark.unit
 def test_quote_maps_market_state_to_decimal() -> None:
     state = MarketState(symbol="005930")
     state.bid, state.ask, state.last_price = 70000.0, 70100.0, 70050.0

--- a/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import pytest
@@ -178,6 +178,17 @@ async def test_holdings_read_failure_fail_closes() -> None:
 
     with pytest.raises(RuntimeError):
         await _gate(_FakeState(), holdings=_boom).load(symbol="005930", side="BUY")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_malformed_holding_qty_fail_closes_reentry_gate() -> None:
+    """An unreadable holding must block the production re-entry decision."""
+
+    gate = _gate(_FakeState(), holdings=_holdings(("005930", "N/A")))
+
+    with pytest.raises(InvalidOperation):
+        await gate.load(symbol="005930", side="BUY")
 
 
 @pytest.mark.unit

--- a/tests/scripts/b0x/kr/_pending.py
+++ b/tests/scripts/b0x/kr/_pending.py
@@ -58,6 +58,40 @@ def exploding_pending(exc: Exception):
     return _read
 
 
+def foreign_traces(
+    *symbols: str,
+    order_trace_count: int = 0,
+    signal_trace_count: int = 0,
+):
+    """A confirm-preflight reader with explicitly controlled foreign traces."""
+
+    traces = kr_pending_ledger.ForeignLedgerTraces(
+        symbols=tuple(sorted(symbols)),
+        order_trace_count=order_trace_count,
+        signal_trace_count=signal_trace_count,
+    )
+
+    async def _read(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> kr_pending_ledger.ForeignLedgerTraces | PendingUnreadable:
+        return traces
+
+    return _read
+
+
+def unreadable_foreign_traces(
+    sentinel: PendingUnreadable = KR_PENDING_UNREADABLE,
+):
+    """A foreign-trace reader that cannot establish exclusive account truth."""
+
+    async def _read(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> kr_pending_ledger.ForeignLedgerTraces | PendingUnreadable:
+        return sentinel
+
+    return _read
+
+
 class StatefulPendingLedger:
     """An in-memory stand-in for the ledger the submission path writes to.
 
@@ -101,6 +135,8 @@ class StatefulPendingLedger:
 __all__ = [
     "StatefulPendingLedger",
     "exploding_pending",
+    "foreign_traces",
     "readable_pending",
+    "unreadable_foreign_traces",
     "unreadable_pending",
 ]

--- a/tests/scripts/b0x/kr/conftest.py
+++ b/tests/scripts/b0x/kr/conftest.py
@@ -20,6 +20,8 @@ import datetime as dt
 import pytest
 
 from scripts.b0x.broker_truth import PendingUnreadable
+from scripts.b0x.kr import cycle as kr_cycle
+from scripts.b0x.kr import mock as kr_mock
 from scripts.b0x.kr import pending_ledger as kr_pending_ledger
 
 
@@ -36,3 +38,48 @@ def _forbid_real_pending_ledger_reads(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     monkeypatch.setattr(kr_pending_ledger, "read_own_pending", _refuse)
+
+    async def _refuse_foreign(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> kr_pending_ledger.ForeignLedgerTraces | PendingUnreadable:
+        raise AssertionError(
+            "a KR test reached the real foreign-trace ledger reader "
+            f"(now={now.isoformat()} prefix={correlation_prefix!r}). Pass "
+            "foreign_trace_reader=... explicitly — confirm-preflight tests "
+            "must prove their contamination input."
+        )
+
+    monkeypatch.setattr(kr_pending_ledger, "read_foreign_traces", _refuse_foreign)
+
+
+@pytest.fixture
+def armed_confirm(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Arm only the confirm gates needed by an offline unit test.
+
+    The production env/config and PostgreSQL advisory lease are deliberately
+    not exercised in a unit test.  Tests request this fixture explicitly, so
+    a confirm test cannot accidentally prove a route that skipped either gate.
+    """
+
+    lease_events: list[str] = []
+
+    class _Lease:
+        def __init__(self, *, writer_surface: str) -> None:
+            assert writer_surface == "b0x_adapter"
+
+        async def __aenter__(self) -> _Lease:
+            lease_events.append("acquired")
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            del exc
+            lease_events.append("released")
+
+    monkeypatch.setattr(kr_mock, "assert_kr_lane_enabled", lambda: None)
+    monkeypatch.setattr(
+        kr_mock,
+        "account_identity_summary",
+        lambda: {"fingerprint": "sha256:test-account", "product_suffix": "01"},
+    )
+    monkeypatch.setattr(kr_cycle, "KISMockWriterLease", _Lease)
+    return lease_events

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -15,8 +15,16 @@ from typing import Any
 
 import pytest
 
+from scripts.b0x.kr.cycle import (
+    KILL_TRIPPED_CANCEL_UNSUPPORTED,
+    KR_ACCOUNT_MAP_COMMIT,
+    KR_CONTRACT_VERSION,
+    KR_STATUS_LABEL,
+    MANUAL_CONFIRM_SUBMISSION_LIMIT,
+    OUTSIDE_RTH_REASON,
+    run_kr_cycle,
+)
 from scripts.b0x.kr.cycle import LANE as KR_LANE
-from scripts.b0x.kr.cycle import OUTSIDE_RTH_REASON, run_kr_cycle
 from scripts.b0x.labels import SHARED_ACCOUNT_HISTORY, TRUST_LABELS
 from tests.scripts.b0x._table_fixtures import (
     make_payload,
@@ -26,6 +34,7 @@ from tests.scripts.b0x._table_fixtures import (
 )
 from tests.scripts.b0x.kr._pending import (
     exploding_pending,
+    foreign_traces,
     readable_pending,
     unreadable_pending,
 )
@@ -216,8 +225,19 @@ async def test_dry_run_plans_but_never_dispatches(
     artifact_text = outcome.artifact_path.read_text(encoding="utf-8")
     for label in TRUST_LABELS:
         assert label in artifact_text
+    assert KR_STATUS_LABEL in outcome.record["labels"]
+    assert KR_STATUS_LABEL in artifact_text
     assert SHARED_ACCOUNT_HISTORY not in outcome.record["labels"]
     assert "SHARED_ACCOUNT_HISTORY" not in artifact_text
+    assert outcome.record["cycle_status"] == "OBSERVATION_DERIVATION_ONLY"
+    assert outcome.record["contract"]["version"] == KR_CONTRACT_VERSION
+    assert outcome.record["account_map"]["commit"] == KR_ACCOUNT_MAP_COMMIT
+    assert outcome.record["account_map"]["gate_values"] == {
+        "account_lanes.kis_mock": "B0-X-KR",
+        "exclusive_lane": "B0-X-KR",
+        "active_ordering_strategy": "B0-X-adapter-single-writer",
+        "surface": "kis_mock",
+    }
 
 
 @pytest.mark.asyncio
@@ -395,7 +415,7 @@ class _FakeBroker:
 
 @pytest.mark.asyncio
 async def test_confirm_true_dispatches_nothing_while_pending_is_unreadable(
-    table_dir: Path, out_dir: Path
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
 ) -> None:
     """The v1.5 ① fail-close reaches the dispatch path, not just derivation."""
 
@@ -408,16 +428,20 @@ async def test_confirm_true_dispatches_nothing_while_pending_is_unreadable(
         client=_FakeKrClient(orderable_cash="5000000"),
         broker=broker,
         pending_reader=unreadable_pending(),
+        foreign_trace_reader=foreign_traces(),
     )
-    assert outcome.zero_order_reason is None
+    assert outcome.zero_order_reason == "preflight_not_clean"
+    assert outcome.record["preflight"]["passed"] is False
+    assert "ledger_pending_unreadable" in outcome.record["preflight"]["reasons"]
     assert outcome.record["planned"] == []
     assert outcome.record["submitted"] == []
     assert broker.buy_calls == [] and broker.sell_calls == []
+    assert armed_confirm == ["acquired", "released"]
 
 
 @pytest.mark.asyncio
 async def test_confirm_true_routes_through_the_injected_broker_when_pending_reads(
-    table_dir: Path, out_dir: Path
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
 ) -> None:
     """``confirm=True`` routes every planned order through the wired
     ``KisMockBroker`` integration point (contract v1.3 ③) — proven here with
@@ -442,20 +466,166 @@ async def test_confirm_true_routes_through_the_injected_broker_when_pending_read
         client=client,
         broker=broker,
         pending_reader=EMPTY_PENDING,
+        foreign_trace_reader=foreign_traces(),
     )
 
     assert outcome.zero_order_reason is None
+    assert outcome.record["preflight"]["passed"] is True
+    assert outcome.record["preflight"]["reasons"] == []
+    assert outcome.record["preflight"]["account"] == {
+        "fingerprint": "sha256:test-account",
+        "product_suffix": "01",
+    }
+    assert outcome.record["preflight"]["cash"] == {"present": True}
+    assert outcome.record["preflight"]["positions"] == {
+        "non_dust_symbols": [],
+        "count": 0,
+    }
+    assert (
+        outcome.record["preflight"]["open_orders"]["native_broker"]["available"]
+        is False
+    )
+    assert outcome.record["preflight"]["writer_lease"] == {
+        "acquired": True,
+        "surface": "b0x_adapter",
+    }
     planned = outcome.record["planned"]
     assert planned, "fixture table must derive at least one planned order"
-    assert len(broker.buy_calls) == len([p for p in planned if p["side"] == "buy"])
+    assert len(broker.buy_calls) == MANUAL_CONFIRM_SUBMISSION_LIMIT
     assert not broker.sell_calls  # flat account, fixture table has no sells
     submitted = outcome.record["submitted"]
-    assert len(submitted) == len(planned)
+    assert len(submitted) == MANUAL_CONFIRM_SUBMISSION_LIMIT
     assert all(row.get("success") is True for row in submitted)
-    for order, call in zip(planned, broker.buy_calls, strict=True):
+    for order, call in zip(
+        planned[:MANUAL_CONFIRM_SUBMISSION_LIMIT], broker.buy_calls, strict=True
+    ):
         assert call["symbol"] == order["symbol"]
         assert call["correlation_id"] == order["client_order_id"]
         assert call["confirm"] is True
+    assert outcome.record["submission_stopped"] == "post_submit_dedup_unproven"
+    assert outcome.record["post_submit_dedup"] == [
+        {
+            "symbol": planned[0]["symbol"],
+            "correlation_id": planned[0]["client_order_id"],
+            "observed": False,
+        }
+    ]
+    assert armed_confirm == ["acquired", "released"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_preflight_contamination_stops_zero_orders(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    """NW-B4: any other writer's trace is contamination, never a cleanup cue."""
+
+    broker = _FakeBroker()
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(orderable_cash="5000000"),
+        broker=broker,
+        pending_reader=EMPTY_PENDING,
+        foreign_trace_reader=foreign_traces(
+            "005930", order_trace_count=1, signal_trace_count=1
+        ),
+    )
+
+    assert outcome.zero_order_reason == "preflight_not_clean"
+    assert outcome.record["preflight"]["passed"] is False
+    assert (
+        "CONTAMINATED_foreign_correlation_trace"
+        in outcome.record["preflight"]["reasons"]
+    )
+    assert outcome.record["submitted"] == []
+    assert broker.buy_calls == [] and broker.sell_calls == []
+    assert armed_confirm == ["acquired", "released"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_rechecks_v1_6_dedup_at_the_mutation_boundary(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    """A trace that appears after preflight still blocks before broker submit."""
+
+    reads = 0
+
+    async def _pending_after_preflight(
+        *, now: dt.datetime, correlation_prefix: str
+    ) -> tuple[str, ...]:
+        del now
+        assert correlation_prefix == "b0xk-"
+        nonlocal reads
+        reads += 1
+        return () if reads == 1 else ("000660", "005930")
+
+    broker = _FakeBroker()
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(orderable_cash="5000000"),
+        broker=broker,
+        pending_reader=_pending_after_preflight,
+        foreign_trace_reader=foreign_traces(),
+    )
+
+    assert outcome.zero_order_reason is None
+    assert outcome.record["preflight"]["passed"] is True
+    assert outcome.record["submitted"] == []
+    assert outcome.record["submission_stopped"] == "v1_6_dedup_blocked"
+    assert outcome.record["submission_dedup_blocked"] == [
+        {
+            "symbol": outcome.record["planned"][0]["symbol"],
+            "correlation_id": outcome.record["planned"][0]["client_order_id"],
+            "reason": "v1_6_pending_recheck_blocked",
+        }
+    ]
+    assert broker.buy_calls == [] and broker.sell_calls == []
+    assert reads == 2
+    assert armed_confirm == ["acquired", "released"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_preflight_unexpected_position_stops_zero_orders(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    """NW-B4 anomaly gate: report the position; never clean it up or submit."""
+
+    broker = _FakeBroker()
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(
+            orderable_cash="5000000",
+            stocks=[
+                {
+                    "pdno": "005930",
+                    "hldg_qty": "1",
+                    "pchs_avg_pric": "70000",
+                    "evlu_amt": "70000",
+                }
+            ],
+        ),
+        broker=broker,
+        pending_reader=EMPTY_PENDING,
+        foreign_trace_reader=foreign_traces(),
+    )
+
+    assert outcome.zero_order_reason == "preflight_not_clean"
+    assert outcome.record["preflight"]["positions"] == {
+        "non_dust_symbols": ["005930"],
+        "count": 1,
+    }
+    assert outcome.record["preflight"]["reasons"] == ["unexpected_positions"]
+    assert outcome.record["submitted"] == []
+    assert broker.buy_calls == [] and broker.sell_calls == []
+    assert armed_confirm == ["acquired", "released"]
 
 
 @pytest.mark.asyncio
@@ -494,6 +664,10 @@ async def test_kill_switch_trips_on_nav_ratio_and_blocks_all_new_orders(
     assert outcome.derivation.kill_switch.tripped
     assert outcome.record["planned"] == []
     assert outcome.record["submitted"] == []
+    assert outcome.record["cancelled"] == []
+    assert outcome.record["cancel_status"] == KILL_TRIPPED_CANCEL_UNSUPPORTED
+    assert outcome.record["cancel_attempted"] is False
+    assert outcome.record["cancel_confirmed"] is False
     assert all(
         skip["reason"] == "kill_switch_active" for skip in outcome.record["skipped"]
     )

--- a/tests/scripts/b0x/kr/test_ledger_pending_source.py
+++ b/tests/scripts/b0x/kr/test_ledger_pending_source.py
@@ -35,7 +35,11 @@ from scripts.b0x.kr import pending_ledger as kr_pending_ledger
 from scripts.b0x.kr.cycle import broker_state, run_kr_cycle
 from scripts.b0x.kr.mock import KR_PENDING_UNREADABLE, FreshTruth, RawPosition
 from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
-from tests.scripts.b0x.kr._pending import StatefulPendingLedger, readable_pending
+from tests.scripts.b0x.kr._pending import (
+    StatefulPendingLedger,
+    foreign_traces,
+    readable_pending,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -44,6 +48,7 @@ pytestmark = pytest.mark.unit
 #: empty-vs-unreadable behaviour have to call the production function; every
 #: other test still goes through the guarded seam.
 REAL_READ_OWN_PENDING = kr_pending_ledger.read_own_pending
+REAL_READ_FOREIGN_TRACES = kr_pending_ledger.read_foreign_traces
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 KR_PACKAGE = REPO_ROOT / "scripts" / "b0x" / "kr"
@@ -147,7 +152,11 @@ class _RecordingBroker:
             symbol=kwargs["symbol"],
             correlation_id=kwargs["correlation_id"],
         )
-        return {"success": True, "odno": f"FAKE-BUY-{len(self.buy_calls)}"}
+        return {
+            "success": True,
+            "odno": f"FAKE-BUY-{len(self.buy_calls)}",
+            "ledger_id": len(self.buy_calls),
+        }
 
     async def submit_exit_sell(self, **kwargs: Any) -> dict[str, Any]:
         self.sell_calls.append(kwargs)
@@ -156,7 +165,11 @@ class _RecordingBroker:
             symbol=kwargs["symbol"],
             correlation_id=kwargs["correlation_id"],
         )
-        return {"success": True, "odno": f"FAKE-SELL-{len(self.sell_calls)}"}
+        return {
+            "success": True,
+            "odno": f"FAKE-SELL-{len(self.sell_calls)}",
+            "ledger_id": len(self.sell_calls),
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -241,11 +254,13 @@ async def test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice(
 ) -> None:
     """🔴 KR_TWO_CYCLE_SIM — fixed fixture, zero broker calls, zero network.
 
-    Cycle 1 derives and submits both rows; the submission chokepoint records
-    them. Cycle 2 and 3, on the same KRX trading day, read those rows back and
-    derive **nothing** — the venue never sees a second order for either symbol.
-    Cycle 4 crosses the KST day boundary (KRX day orders cannot survive it) and
-    derives again.
+    Cycle 1 derives both rows, then this test models the pre-submit signal rows
+    that the real chokepoint commits before a send. Cycle 2 and 3, on the same
+    KRX trading day, read those rows back and derive **nothing**. Cycle 4
+    crosses the KST day boundary (KRX day orders cannot survive it) and derives
+    again. The confirm-path mutation-boundary re-read is covered separately
+    below because confirmed production code intentionally uses wall-clock time
+    rather than this deterministic replay clock.
 
     This is the observation X-E1 established is the only one that can tell
     「상한이 발화했다」 from 「상한이 구속한다」: a single cycle looks identical
@@ -253,10 +268,8 @@ async def test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice(
     """
 
     ledger = StatefulPendingLedger()
-    broker = _RecordingBroker(ledger, CYCLE_1)
     reader = ledger.reader()
     derived_per_cycle: list[list[str]] = []
-    submit_cum: list[int] = []
 
     for index, now in enumerate((CYCLE_1, CYCLE_2, CYCLE_3, NEXT_DAY)):
         # The table is regenerated each cycle so table age never becomes the
@@ -277,29 +290,21 @@ async def test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice(
             now=now,
             table_dir=table_dir,
             out_dir=out_dir / f"cycle{index}",
-            confirm=True,
+            confirm=False,
             client=_FakeKrClient(),
-            broker=broker.at(now),
             pending_reader=reader,
         )
         assert outcome.zero_order_reason is None
         derived_per_cycle.append(
             sorted(order["symbol"] for order in outcome.record["orders"])
         )
-        submit_cum.append(len(broker.buy_calls))
-        if index == 1:
-            # Cycle 2's skipped table must name the ledger reason, per symbol.
-            reasons = {
-                skip["symbol"]: skip["reason"] for skip in outcome.record["skipped"]
-            }
-            assert reasons == {
-                "005930": "own_pending_order_exists",
-                "000660": "own_pending_order_exists",
-            }
-            assert outcome.record["broker_truth"]["own_pending"] == [
-                "000660",
-                "005930",
-            ]
+        if index == 0:
+            for planned in outcome.record["planned"]:
+                ledger.record(
+                    now=now,
+                    symbol=planned["symbol"],
+                    correlation_id=planned["client_order_id"],
+                )
 
     assert derived_per_cycle == [
         ["000660", "005930"],  # cycle 1 — nothing recorded yet
@@ -307,10 +312,46 @@ async def test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice(
         [],  # cycle 3 — still held; no drift, no re-derivation
         ["000660", "005930"],  # next KST day — day orders cannot have survived
     ]
-    assert submit_cum == [2, 2, 2, 4]
-    assert broker.sell_calls == []
-    # Every cycle past the table gate really consulted the ledger.
     assert ledger.reads == ["2026-08-10", "2026-08-10", "2026-08-10", "2026-08-11"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_route_rechecks_and_observes_post_submit_dedup(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    """The actual confirm boundary observes its forced pre-submit trace.
+
+    Confirm uses a real wall clock for the five-minute preflight window, so
+    the fake ledger records on that same wall-clock day. No network or DB is
+    involved; ``_RecordingBroker`` models only the durable correlation row the
+    sanctioned adapter creates before its mock POST.
+    """
+
+    ledger = StatefulPendingLedger()
+    broker = _RecordingBroker(ledger, dt.datetime.now(dt.UTC))
+    outcome = await run_kr_cycle(
+        now=CYCLE_1,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(),
+        broker=broker,
+        pending_reader=ledger.reader(),
+        foreign_trace_reader=foreign_traces(),
+    )
+
+    assert outcome.zero_order_reason is None
+    assert len(broker.buy_calls) == 1
+    assert outcome.record["post_submit_dedup"] == [
+        {
+            "symbol": outcome.record["planned"][0]["symbol"],
+            "correlation_id": outcome.record["planned"][0]["client_order_id"],
+            "observed": True,
+        }
+    ]
+    assert outcome.record["submission_stopped"] == "acceptance_submission_limit=1"
+    assert len(ledger.reads) == 3  # preflight, mutation boundary, post-submit
+    assert armed_confirm == ["acquired", "released"]
 
 
 # ---------------------------------------------------------------------------
@@ -382,15 +423,18 @@ def test_the_only_bound_is_the_kst_trading_day() -> None:
 
 
 class _FakeResult:
-    def __init__(self, rows: list[str]) -> None:
+    def __init__(self, rows: list[Any]) -> None:
         self._rows = rows
 
     def scalars(self) -> list[str]:
         return list(self._rows)
 
+    def all(self) -> list[Any]:
+        return list(self._rows)
+
 
 class _FakeSession:
-    def __init__(self, results: list[list[str]] | Exception) -> None:
+    def __init__(self, results: list[list[Any]] | Exception) -> None:
         self._results = results
         self.statements: list[Any] = []
 
@@ -467,6 +511,62 @@ async def test_a_session_that_cannot_be_opened_is_also_unreadable(
     result = await REAL_READ_OWN_PENDING(now=CYCLE_1, correlation_prefix="b0xk-")
     assert isinstance(result, PendingUnreadable)
     assert "OSError" in result.detail
+
+
+class _LedgerTraceRow:
+    def __init__(self, *, symbol: str, correlation_id: str | None) -> None:
+        self.symbol = symbol
+        self.correlation_id = correlation_id
+
+
+@pytest.mark.asyncio
+async def test_foreign_trace_reader_separates_b0x_from_other_writers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NW-B4: only another correlation is contamination; values stay redacted."""
+
+    session = _FakeSession(
+        [
+            [
+                _LedgerTraceRow(symbol="005930", correlation_id="b0xk-own"),
+                _LedgerTraceRow(symbol="000660", correlation_id="other-order"),
+            ],
+            [
+                _LedgerTraceRow(symbol="005930", correlation_id=None),
+                _LedgerTraceRow(symbol="035420", correlation_id="b0xk-other"),
+            ],
+        ]
+    )
+    monkeypatch.setattr(kr_pending_ledger, "AsyncSessionLocal", lambda: session)
+
+    result = await REAL_READ_FOREIGN_TRACES(now=CYCLE_1, correlation_prefix="b0xk-")
+
+    assert not isinstance(result, PendingUnreadable)
+    assert result.canonical() == {
+        "symbols": ["000660", "005930"],
+        "order_trace_count": 1,
+        "signal_trace_count": 1,
+        "trace_count": 2,
+    }
+    assert len(session.statements) == 2
+
+
+@pytest.mark.asyncio
+async def test_foreign_trace_reader_failure_is_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        kr_pending_ledger,
+        "AsyncSessionLocal",
+        lambda: _FakeSession(RuntimeError("boom: postgres://user:secret@host/db")),
+    )
+
+    result = await REAL_READ_FOREIGN_TRACES(now=CYCLE_1, correlation_prefix="b0xk-")
+
+    assert isinstance(result, PendingUnreadable)
+    assert result.reason == kr_pending_ledger.LEDGER_UNREADABLE_REASON
+    assert "RuntimeError" in result.detail
+    assert "secret" not in result.detail
 
 
 def test_pending_unreadable_is_still_the_default_without_a_reader() -> None:

--- a/tests/scripts/b0x/kr/test_mock.py
+++ b/tests/scripts/b0x/kr/test_mock.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import replace
 from decimal import Decimal
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -295,6 +296,84 @@ async def test_submit_planned_order_routes_buy_to_submit_buy() -> None:
         }
     ]
     assert broker.sell_calls == []
+
+
+@pytest.mark.asyncio
+async def test_submit_planned_order_refreshes_the_reused_broker_before_buy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B0-X supplies a real mock-host book to the existing pre-send hook.
+
+    The test uses the actual sanctioned adapter type but replaces its network
+    methods, proving the thin B0-X chokepoint orders the read before submit
+    without creating another order implementation.
+    """
+
+    broker = kr_mock.build_kis_mock_broker()
+    events: list[str] = []
+
+    async def _refresh(*, symbol: str) -> object:
+        assert symbol == "005930"
+        events.append("refresh")
+        return object()
+
+    async def _submit_buy(**kwargs: Any) -> dict[str, Any]:
+        events.append("submit")
+        return {"success": True, "odno": "FAKE-BUY-1"}
+
+    monkeypatch.setattr(broker, "refresh_market_state", _refresh)
+    monkeypatch.setattr(broker, "submit_buy", _submit_buy)
+    planned = kr_mock.PlannedOrder(
+        order_key="abc123",
+        client_order_id="b0xk-abc123",
+        symbol="005930",
+        side="buy",
+        leg="buy_l1",
+        price=97000,
+        quantity=3,
+        notional=Decimal("291000"),
+    )
+
+    result = await kr_mock.submit_planned_order(
+        broker, planned=planned, confirm=True, broker_truth=_READABLE_EMPTY
+    )
+
+    assert result["success"] is True
+    assert events == ["refresh", "submit"]
+
+
+@pytest.mark.asyncio
+async def test_submit_planned_order_blocks_before_buy_when_mock_book_is_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker = kr_mock.build_kis_mock_broker()
+    refresh = AsyncMock(side_effect=RuntimeError("mock quote unavailable"))
+    submit = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(broker, "refresh_market_state", refresh)
+    monkeypatch.setattr(broker, "submit_buy", submit)
+    planned = kr_mock.PlannedOrder(
+        order_key="abc123",
+        client_order_id="b0xk-abc123",
+        symbol="005930",
+        side="buy",
+        leg="buy_l1",
+        price=97000,
+        quantity=3,
+        notional=Decimal("291000"),
+    )
+
+    result = await kr_mock.submit_planned_order(
+        broker, planned=planned, confirm=True, broker_truth=_READABLE_EMPTY
+    )
+
+    assert result == {
+        "success": False,
+        "pre_send_blocked": True,
+        "reason_codes": ["mock_orderbook_unavailable"],
+        "detail": "RuntimeError: mock orderbook refresh failed",
+        "dry_run": False,
+    }
+    submit.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/test_run_b0x_kr_cycle_cli.py
+++ b/tests/scripts/b0x/kr/test_run_b0x_kr_cycle_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from scripts.b0x.envelope import KR_MOCK_ENVELOPE, assert_envelope_locked, load_envelope
-from scripts.run_b0x_kr_cycle import _parse_args
+from scripts.run_b0x_kr_cycle import _parse_args, _run
 
 pytestmark = pytest.mark.unit
 
@@ -26,14 +26,23 @@ def test_no_cli_flag_can_reach_an_envelope_value() -> None:
     assert offenders == [], f"CLI exposes cap-shaped flags: {offenders}"
 
 
-def test_cli_exposes_no_confirm_flag() -> None:
-    """Unlike the crypto sidecar CLI, this one has no ``--confirm`` at all —
-    submission is unwired (scripts.b0x.kr.mock), so a flag that implied
-    "dispatch this" would be misleading.
-    """
+def test_cli_confirm_is_explicit_and_default_disabled() -> None:
+    """The only mutation lever is opt-in and carries no envelope override."""
 
-    dests = set(vars(_parse_args([])))
-    assert "confirm" not in dests
+    assert _parse_args([]).confirm is False
+    assert _parse_args(["--confirm"]).confirm is True
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_replay_clock_before_any_cycle_work() -> None:
+    args = _parse_args(["--confirm", "--now", "2026-08-10T02:00:00+00:00"])
+    assert await _run(args) == 2
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_derivation_only_before_any_cycle_work() -> None:
+    args = _parse_args(["--confirm", "--derivation-only"])
+    assert await _run(args) == 2
 
 
 def test_environment_variables_cannot_move_the_kr_envelope(

--- a/tests/scripts/b0x/kr/test_submission_ast_guard.py
+++ b/tests/scripts/b0x/kr/test_submission_ast_guard.py
@@ -78,6 +78,7 @@ ALLOWED_KIS_SURFACE = {
     "app.services.brokers.kis.mock_scalping_exec.adapters",
     "app.services.brokers.kis.mock_scalping_ws.state",
     "app.services.kis_mock_runner.session",
+    "app.services.kis_mock_runner.singleton",
 }
 
 #: Prefixes treated as "the KIS/order surface" for the allowlist check.

--- a/tests/services/kis_mock_runner/test_singleton.py
+++ b/tests/services/kis_mock_runner/test_singleton.py
@@ -133,4 +133,5 @@ def test_writer_catalog_enumerates_all_approved_kis_mock_surfaces() -> None:
         "watch_auto_execute",
         "smoke_cli",
         "manual_mcp_mutation",
+        "b0x_adapter",
     }


### PR DESCRIPTION
## Summary

- Adds an explicit, default-disabled one-shot KR kis_mock confirm lever backed by the existing KisMockBroker.
- Gates dispatch on KRX RTH, KR env/config, account-wide writer lease, NW-B4 preflight, contamination checks, and v1.6 mutation-boundary dedup.
- Preserves KIS mock-only AST constraints, locked envelope caps, OBSERVATION_DERIVATION_ONLY status, and KR cancel-unavailable semantics.
- Records KR-specific v1.6 and e93349e provenance without modifying US or crypto shared behavior.

## Acceptance

- A real-current --confirm invocation on 2026-08-09 exited zero-order before table/account/broker I/O because it was outside KRX RTH. No live or mock account contact occurred.
- The actual mock submit/fill roundtrip remains correctly deferred to the next authorized KRX RTH window; no clock replay was used.

## Validation

- make lint
- uv run pytest tests/ -q -ra -m unit and not integration and not slow and not live
- KR AST, dedup, preflight, kill, envelope, and no-internal-LLM regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicitly confirmed manual submission mode for KR cycles, with safety gates and a one-order limit.
  * Added account identity checks, writer leasing, freshness validation, deduplication, and foreign-activity detection.
  * Added automatic mock orderbook refreshes before BUY submissions.
  * Added optional fill confirmation and structured execution status records.

* **Bug Fixes**
  * Malformed market data or holdings now fail safely without submitting orders or recording side effects.

* **Documentation**
  * Updated the KR operations runbook for the latest confirmation, ledger, preflight, and orderbook workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->