### PR TITLE
feat(dfc): A2 gap closure — lifecycle authority absence + premium-index gap verdict (§26차 Job A)

### DIFF
--- a/research/dfc_v22_research_min/contract.py
+++ b/research/dfc_v22_research_min/contract.py
@@ -16,6 +16,8 @@ Clause        Upstream source   Subject
 ``A2-C3``     NW-F5             Required / forbidden source material
 ``A2-C4``     NW-F4             Outcome semantics
 ``A2-C5``     NW-F6             Authenticity and freeze procedure
+``A2-C6``     OD-26             Lifecycle authority absence and substitute
+``A2-C7``     OD-26             Premium-index archive gap and epoch verdict
 ============  ================  =========================================
 """
 
@@ -44,14 +46,22 @@ __all__ = [
     "CONTRACT_ID",
     "CORPUS_ID",
     "CORPUS_ROOT",
+    "ELIGIBILITY_EVIDENCE_KIND",
     "FORBIDDEN_SOURCE_KINDS",
+    "GAP_EPOCH_VERDICTS",
+    "GAP_EXCLUSION_REASONS",
     "IMPUTED_ROW_COUNT_MAX",
     "JUDGMENT_END",
     "JUDGMENT_START",
+    "LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE",
+    "LIFECYCLE_PROXY_LIMITS",
+    "NO_IMPACT",
     "OUTCOME_HORIZON_BARS",
     "OUTCOME_TAIL_BARS",
     "OUTCOME_UNIT",
     "REQUIRED_SOURCE_KINDS",
+    "RUN_INVALID_INPUT_EVIDENCE",
+    "TERMINAL_CODE_PRIORITY",
     "UNIVERSE_LOOKBACK_CALENDAR_DAYS",
     "UNIVERSE_RANKING_METRIC",
     "UNIVERSE_TIE_BREAK",
@@ -224,6 +234,95 @@ ADMISSIBILITY_COMPARISON_KEYS: tuple[str, ...] = (
 )
 
 
+# --- A2-C6 (OD-26): lifecycle authority absence and substitute evidence ---
+
+#: There is no single authoritative public Binance source for contract
+#: lifecycle / eligibility.  This is a measured absence, not a gap in the
+#: search: A2-MEASURE looked and found two partial, non-identical proxies and
+#: one corroborated historical case.  The value is ``None`` because writing a
+#: source name here would be inventing one.
+LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE: str | None = None
+
+#: The two proxies that do exist, each with the question it cannot answer.
+#: They are recorded so that a later reader cannot mistake either for the
+#: authority that A2-MEASURE established does not exist.
+LIFECYCLE_PROXY_LIMITS: MappingProxyType[str, str] = MappingProxyType(
+    {
+        "exchange_info_onboard_date": (
+            "covers only contracts that are currently trading; delisted and "
+            "settled contracts are absent from the endpoint entirely, so the "
+            "historical universe cannot be reconstructed from it. Its "
+            "onboardDate is also not the first tradable epoch — UNFIUSDT's "
+            "first 4h kline is 10 days after its onboardDate."
+        ),
+        "archive_month_range": (
+            "first/last monthly object per symbol is an inference from data "
+            "presence, not a lifecycle record Binance publishes and stands "
+            "behind; it was corroborated against exactly one real event "
+            "(LUNAUSDT, 2022-05) and says nothing about intra-month halts."
+        ),
+    }
+)
+
+#: The substitute defined by OD-26.  This is a *different kind of evidence*
+#: from a lifecycle record, not an approximation of one: a completed 4h kline
+#: carrying non-zero traded volume is direct evidence that the contract was
+#: tradable in that bar, whereas a lifecycle record would be a statement about
+#: listing status.  Neither substitutes for the other in general; OD-26 rules
+#: that for ranking-window eligibility, the direct evidence is what this
+#: corpus uses.
+ELIGIBILITY_EVIDENCE_KIND = "kline_archive_direct"
+ELIGIBILITY_REQUIRES_COMPLETE_KLINES = True
+ELIGIBILITY_REQUIRES_NONZERO_VOLUME = True
+
+#: A proxy may be recorded as context, never declared as the eligibility
+#: evidence kind, and never declared authoritative.
+LIFECYCLE_PROXY_KINDS: frozenset[str] = frozenset(LIFECYCLE_PROXY_LIMITS)
+
+ELIGIBLE = "eligible"
+NOT_ELIGIBLE = "not_eligible"
+ELIGIBILITY_STATUSES: tuple[str, ...] = (ELIGIBLE, NOT_ELIGIBLE)
+
+
+# --- A2-C7 (OD-26): premium-index archive gap and the per-epoch verdict ---
+
+#: The two literal outcomes of the gap/pool intersection, per epoch.
+NO_IMPACT = "NO_IMPACT"
+RUN_INVALID_INPUT_EVIDENCE = "RUN_INVALID_INPUT_EVIDENCE"
+GAP_EPOCH_VERDICTS: tuple[str, ...] = (NO_IMPACT, RUN_INVALID_INPUT_EVIDENCE)
+
+#: Why a symbol in the archive diff needs no per-epoch audit row.  Closed set:
+#: every gap symbol must be accounted for by one of these, with evidence.
+#: "It did not look relevant" is not on the list.
+GAP_EXCLUSION_REASONS: tuple[str, ...] = (
+    # dated delivery contract — outside UNIVERSE_INSTRUMENT_CLASS, and no
+    # premium index exists for a non-perpetual in the first place
+    "not_perpetual",
+    # no kline evidence anywhere in the corpus span, so never eligible in it
+    "no_kline_evidence_in_corpus_span",
+    # an archive rename artifact of an instrument that also appears under its
+    # base symbol, which does carry premium-index material
+    "same_instrument_as_base",
+)
+#: ``same_instrument_as_base`` is the only reason that leans on a second
+#: symbol, so it must name it and show the row-identity evidence.
+GAP_EXCLUSION_BASE_SYMBOL_REASON = "same_instrument_as_base"
+
+#: Terminal codes in adjudication order.  Input evidence is decided first: if
+#: the corpus was built on material the contract refuses, every later verdict
+#: is a statement about the wrong artifact.
+TERMINAL_CODE_PRIORITY: tuple[str, ...] = (
+    "RUN_INVALID_INPUT_EVIDENCE",
+    "RUN_INVALID_SCOPE_SEPARATION",
+    "RUN_INVALID_CORPUS_LITERALS",
+    "RUN_INVALID_FORBIDDEN_SOURCE",
+    "RUN_INVALID_MANIFEST_SCHEMA",
+    "RUN_INVALID_TABLE_SCHEMA",
+    "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+    "RUN_INVALID_OUTCOME_EVIDENCE",
+)
+
+
 CLAUSE_SOURCES: MappingProxyType[str, str] = MappingProxyType(
     {
         "A2-C1": "NW-F2",
@@ -231,5 +330,7 @@ CLAUSE_SOURCES: MappingProxyType[str, str] = MappingProxyType(
         "A2-C3": "NW-F5",
         "A2-C4": "NW-F4",
         "A2-C5": "NW-F6",
+        "A2-C6": "OD-26",
+        "A2-C7": "OD-26",
     }
 )

--- a/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
+++ b/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
@@ -317,7 +317,8 @@ timing the paragraph above is suspicious of, so the record is:
   outcome tail, universe rule (30 days · top 3 · canonical-ascending ties),
   required and forbidden source material, imputation 0, the arm-label set and
   every A2-C1..A2-C5 terminal code are unchanged. The amendment is additive: two
-  clauses, one terminal code, one canonical table, three manifest keys.
+  clauses, one terminal code, one canonical table (`premium_index_gap_audit`),
+  and two manifest keys (`lifecycle_eligibility`, `premium_index_gap`).
 - **It tightens; it cannot relax.** Every added rule can only reject corpora the
   previous text would have accepted. No gate widened, no threshold moved.
 - **What was read did not move a number.** A2-MEASURE returned `UNDETERMINED`

--- a/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
+++ b/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
@@ -10,11 +10,12 @@ collection, no listing, no download and no backtest.
 | Judged dimensions | kline OFI · premium-index · PIT universe · outcome evidence |
 | Upstream wording (canonical) | `~/work/herdr-inbox/answer-codexmock-next-wave-1630.md`, sha256 `df7aee908e50af42…` (137 lines) |
 | Binding record | `~/work/herdr-inbox/operator-decisions-20260805-0830.md` §25차 |
+| Amendment binding record | same file, §26차 (A2-C6 · A2-C7) |
 | Schema | `research/dfc_v22_research_min/schema.py` |
 | Validators | `research/dfc_v22_research_min/validation.py` |
 | Golden cases | `tests/research/dfc_v22_research_min/golden/violation_cases.json` |
 
-The four upstream clauses are reproduced below **verbatim**, in the language they
+The five upstream clauses are reproduced below **verbatim**, in the language they
 were signed in. They are also carried byte-for-byte in
 `research/dfc_v22_research_min/nw_verbatim.py`, and a test asserts that this
 document and that module agree, so no later edit can quietly paraphrase a clause.
@@ -170,10 +171,119 @@ admissible.
 
 ---
 
+## A2-C6 / A2-C7 — Lifecycle authority, substitute evidence, archive gap (OD-26)
+
+> **§26차 Job A** (원문 축자 인용)
+>
+> **Job A (②+①)**: ②contract lifecycle 권위 소스 = 「없다」를 계약에 명시, 대체 증거 정의 — eligibility = kline 아카이브 자체(랭킹 창 내 완전한 4h kline + 비zero 거래량 = 거래가능의 직접 증거), 프록시 한계 명기. ①premiumIndexKlines ~70 심볼 격차 전수 diff(read-only) → epoch별 top-3 후보 pool 과 교집합: 0 이면 `NO_IMPACT` 리터럴 종결, 비어있지 않으면 해당 epoch = `RUN_INVALID_INPUT_EVIDENCE` (조용한 재랭킹 금지) 를 계약에 추가.
+
+A2-C2/A2-C3 list `contract lifecycle/eligibility evidence` among the required
+source material. These two clauses say what that material *is*, now that
+A2-MEASURE has looked for it.
+
+### A2-C6 — There is no authoritative public lifecycle source
+
+**There is no single authoritative public Binance source for contract lifecycle
+or eligibility.** This is a measured absence, not an unfinished search:
+A2-MEASURE looked, found two partial and non-identical proxies, and corroborated
+one of them against exactly one historical event. `contract.py` therefore freezes
+`LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE = None`, and `validate_manifest` rejects
+any corpus that names one.
+
+The two proxies, and what each **cannot** answer:
+
+| Proxy | Answers | Does not answer |
+|---|---|---|
+| `exchangeInfo.symbols[].onboardDate` | when a **currently trading** contract was onboarded | anything about delisted or settled contracts, which are absent from the endpoint entirely, so the historical universe cannot be reconstructed from it. It is also not the first tradable epoch: UNFIUSDT's first 4h kline is 10 days after its `onboardDate` |
+| first/last monthly archive object per symbol | a coarse outer bound on when data exists | whether the contract was *listed and tradable*, since this is an inference from data presence rather than a record Binance publishes and stands behind. Corroborated against one real event (LUNAUSDT, 2022-05); silent about intra-month halts |
+
+Neither proxy may be declared as the eligibility evidence kind, and neither may
+be recorded as authoritative. `proxy_limits` must carry both limitation texts
+unchanged, so that a later reader cannot find a softened version of them.
+
+**Substitute evidence (the definition OD-26 signs).** Eligibility is decided by
+the **kline archive itself**: a symbol is eligible at an epoch when the ranking
+window holds **complete 4h klines with non-zero traded volume**. A completed bar
+with volume in it is direct evidence that the contract was tradable in that bar.
+
+This is **a different kind of evidence, not an approximation of the missing
+authority.** A lifecycle record would be a statement about listing status; this
+is a trace of trading having happened. They answer different questions, and
+neither stands in for the other in general. What OD-26 rules is narrower: for
+*ranking-window eligibility in this corpus*, the direct evidence is what is used.
+Nothing here claims the two are interchangeable, and the contract is not to be
+read as having recovered the authority it says does not exist.
+
+**Enforced as.** `manifest.lifecycle_eligibility` must declare
+`authoritative_public_source = null`, `evidence_kind = "kline_archive_direct"`,
+and `proxy_limits` equal to the frozen texts. Naming a source, or promoting
+either proxy to the evidence kind, raises `RUN_INVALID_INPUT_EVIDENCE`.
+
+### A2-C7 — The premium-index archive gap, and the per-epoch verdict
+
+The `klines` and `premiumIndexKlines` monthly archives do not carry the same
+symbol set. Every symbol in the difference is accounted for; the corpus does not
+get to treat the difference as empty.
+
+**The verdict literals.** Per epoch, the intersection of the gap set with that
+epoch's top-3 candidate pool is either empty or not:
+
+| Intersection | Epoch verdict |
+|---|---|
+| empty | `NO_IMPACT` |
+| non-empty | `RUN_INVALID_INPUT_EVIDENCE` |
+
+**Silent re-ranking is forbidden, and this is the failure OD-26 names first.**
+When a gap symbol belongs in an epoch's top 3, the epoch is marked invalid. It
+is **not** repaired by dropping that symbol and promoting the next-ranked one:
+that would convert an input-evidence failure into a clean-looking ranking, and
+the resulting corpus would carry no trace that anything was wrong. There is no
+substitution path in the contract and none in the code —
+`validate_premium_index_gap` returns nothing, names no replacement, and hands
+back no pool.
+
+**Enforced as.**
+
+1. `manifest.premium_index_gap` records the full diff (`symbols`), the subset
+   requiring per-epoch audit (`in_window_symbols`), the listing endpoint and
+   retrieval time, and the measurement's SHA-256.
+2. Every symbol in `symbols - in_window_symbols` carries an exclusion with
+   evidence and a reason from a **closed** set — `not_perpetual`,
+   `no_kline_evidence_in_corpus_span`, `same_instrument_as_base`. An unaccounted
+   gap symbol is a violation, so "it did not look relevant" cannot be silent.
+   `same_instrument_as_base` must name the base symbol, and that base may not
+   itself be in the gap set.
+3. The `premium_index_gap_audit` table carries one row per (epoch, in-window gap
+   symbol). A missing row is a violation: a gap symbol is accounted for at every
+   epoch, never omitted.
+4. The declared pool is checked to *be* the ranking it claims — ranks exactly
+   `1..3`, no duplicate symbol, and the declared order equal to the
+   `quote_volume` ordering with `canonical_symbol_ascending` ties. A pool
+   quietly re-ordered around a dropped symbol fails here.
+5. Each audit row's `verdict` is **recomputed** from its recorded lookback
+   volume against the rank-3 cut and compared, exactly as outcome numbers are in
+   A2-C4. A recorded `NO_IMPACT` that the evidence does not support fails; so
+   does a gap symbol found inside the pool.
+
+Recomputation binds the verdict to the recorded volume; the *volume itself* is
+held to the same standard as every other number in this corpus — A2-C5
+independent re-collection — and to nothing stronger. This clause does not claim
+to detect a builder that misreports a gap symbol's volume and its evidence hash
+consistently.
+
+---
+
 ## Terminal codes
+
+Adjudicated in this order — `contract.TERMINAL_CODE_PRIORITY`, enforced by
+`validate_corpus`. `RUN_INVALID_INPUT_EVIDENCE` is decided **first and
+unconditionally**: a corpus built on material the contract refuses is the wrong
+artifact, so any downstream code reported for it would name a symptom and hide
+the cause.
 
 | Code | Raised when |
 |---|---|
+| `RUN_INVALID_INPUT_EVIDENCE` | lifecycle authority claimed, proxy promoted to evidence kind, gap symbol unaccounted for, gap symbol inside or outranking the candidate pool, or a recorded epoch verdict the evidence does not support (A2-C6 / A2-C7) |
 | `RUN_INVALID_SCOPE_SEPARATION` | A1 (or anything else) declared as the DFC prerequisite (A2-C1) |
 | `RUN_INVALID_CORPUS_LITERALS` | a frozen id, path, window, universe rule or imputation literal was changed (A2-C2) |
 | `RUN_INVALID_FORBIDDEN_SOURCE` | funding / open interest / mark / index material present (A2-C3) |
@@ -196,3 +306,27 @@ read as fixing:
 Nothing here may be revised after A2 measurement results or backtest results are
 read. Changing a literal in this file after that point is not a correction; it is
 a different contract, and it needs a new ID and a new signature.
+
+## Amendment provenance (A2-C6 / A2-C7)
+
+That clause has to be applied to the amendment itself, in the open: **A2-C6 and
+A2-C7 were written after the A2-MEASURE verdict was read.** That is exactly the
+timing the paragraph above is suspicious of, so the record is:
+
+- **No frozen literal changed.** Corpus id, root, warmup and judgment windows,
+  outcome tail, universe rule (30 days · top 3 · canonical-ascending ties),
+  required and forbidden source material, imputation 0, the arm-label set and
+  every A2-C1..A2-C5 terminal code are unchanged. The amendment is additive: two
+  clauses, one terminal code, one canonical table, three manifest keys.
+- **It tightens; it cannot relax.** Every added rule can only reject corpora the
+  previous text would have accepted. No gate widened, no threshold moved.
+- **What was read did not move a number.** A2-MEASURE returned `UNDETERMINED`
+  and named two gaps. The amendment answers "which evidence does the contract
+  accept here", which the signed text left unspecified. It does not adjust any
+  criterion toward a result, because there is no result to adjust toward — the
+  backtest count is still zero.
+- **Signed separately.** §26차 of the binding record authorises it, after the
+  measurement, as its own decision.
+
+Should a *literal* ever need to change, the paragraph above still governs: new
+ID, new signature.

--- a/research/dfc_v22_research_min/nw_verbatim.py
+++ b/research/dfc_v22_research_min/nw_verbatim.py
@@ -8,6 +8,13 @@ comparing against that document's SHA-256.
 The canonical document lives outside this repository (operator inbox), so tests
 in this repository can only pin the *transcript*: they assert that the contract
 document and the frozen literals quote these strings unchanged.
+
+``OD_26_JOB_A_VERBATIM`` comes from the binding record rather than the answer
+document, and it is stored de-wrapped: the source bullet is hard-wrapped across
+five lines, so the lines are joined with a single space and the leading list
+marker is dropped.  Nothing else about it is altered.  Its file is an
+append-only decisions log, so no whole-file SHA is pinned for it — the clause
+text itself is the pin.
 """
 
 from __future__ import annotations
@@ -18,6 +25,11 @@ CANONICAL_SOURCE_SHA256 = (
 )
 CANONICAL_SOURCE_LINE_COUNT = 137
 BINDING_RECORD = "~/work/herdr-inbox/operator-decisions-20260805-0830.md \u00a725\ucc28"
+#: The A2 gap-closure amendment (this file's A2-C6 / A2-C7) is bound by \u00a726\ucc28 of
+#: the same record, not by the answer document above.
+BINDING_RECORD_AMENDMENT = (
+    "~/work/herdr-inbox/operator-decisions-20260805-0830.md \u00a726\ucc28"
+)
 
 NW_F2_TOPIC = "A1과 DFC 최소 corpus의 범위 분리"
 NW_F2_VERBATIM = "**“A1의 funding/OI/mark/index 종합 readiness는 보존하되 DFC-v2.x의 선행조건으로 쓰지 않는다. 데이터 접촉 전에 `DFC_V22_RESEARCH_MIN` A2 계약을 새 ID/SHA로 등록한다. A2는 kline OFI·premium-index·PIT universe·outcome evidence만 판정한다.”** 이는 결과를 본 뒤 게이트를 완화하는 것이 아니라, 아직 백테스트 0회인 상태에서 계약-데이터 불일치를 교정하는 것이다."
@@ -31,11 +43,15 @@ NW_F5_VERBATIM = "**“corpus ID=`dfc-2c-4h-v22-corpus-v1`, root=`/Users/mgh3326
 NW_F6_TOPIC = "corpus 진정성·동결 절차"
 NW_F6_VERBATIM = "**“모든 원본 object/response에 endpoint·query·retrieved_at·schema·object/ZIP SHA-256·epoch별 payload SHA를 기록한다. manifest와 canonical parquet를 동결하고, 독립 검증자가 동일 public object를 재수집해 object SHA/행수/시각경계/원시 payload hash를 대조해야 admissible이다. 자기 일관성 검사만으로 Binance 진정성을 주장하지 않는다.”**"
 
+OD_26_JOB_A_TOPIC = "A2 공백 ②+① 폐쇄 경로"
+OD_26_JOB_A_VERBATIM = "**Job A (②+①)**: ②contract lifecycle 권위 소스 = 「없다」를 계약에 명시, 대체 증거 정의 — eligibility = kline 아카이브 자체(랭킹 창 내 완전한 4h kline + 비zero 거래량 = 거래가능의 직접 증거), 프록시 한계 명기. ①premiumIndexKlines ~70 심볼 격차 전수 diff(read-only) → epoch별 top-3 후보 pool 과 교집합: 0 이면 `NO_IMPACT` 리터럴 종결, 비어있지 않으면 해당 epoch = `RUN_INVALID_INPUT_EVIDENCE` (조용한 재랭킹 금지) 를 계약에 추가."
+
 VERBATIM_CLAUSES: dict[str, str] = {
     "NW-F2": NW_F2_VERBATIM,
     "NW-F4": NW_F4_VERBATIM,
     "NW-F5": NW_F5_VERBATIM,
     "NW-F6": NW_F6_VERBATIM,
+    "OD-26": OD_26_JOB_A_VERBATIM,
 }
 
 VERBATIM_TOPICS: dict[str, str] = {
@@ -43,4 +59,5 @@ VERBATIM_TOPICS: dict[str, str] = {
     "NW-F4": NW_F4_TOPIC,
     "NW-F5": NW_F5_TOPIC,
     "NW-F6": NW_F6_TOPIC,
+    "OD-26": OD_26_JOB_A_TOPIC,
 }

--- a/research/dfc_v22_research_min/schema.py
+++ b/research/dfc_v22_research_min/schema.py
@@ -20,13 +20,17 @@ import pyarrow as pa
 
 __all__ = [
     "CANONICAL_TABLES",
+    "GAP_EXCLUSION_REQUIRED_KEYS",
     "KLINES_4H_SCHEMA",
+    "MANIFEST_GAP_REQUIRED_KEYS",
+    "MANIFEST_LIFECYCLE_REQUIRED_KEYS",
     "MANIFEST_REQUIRED_KEYS",
     "MANIFEST_SOURCE_REQUIRED_KEYS",
     "MANIFEST_TABLE_REQUIRED_KEYS",
     "OUTCOMES_SCHEMA",
     "PIT_UNIVERSE_SCHEMA",
     "PREMIUM_INDEX_4H_SCHEMA",
+    "PREMIUM_INDEX_GAP_AUDIT_SCHEMA",
     "RAW_KLINE_FIELD_NAMES",
 ]
 
@@ -132,11 +136,34 @@ OUTCOMES_SCHEMA = pa.schema(
     ]
 )
 
+#: One row per (epoch, in-window gap symbol) — A2-C7.  A symbol whose premium
+#: index the archive does not carry has to be *accounted for* at every epoch it
+#: could have ranked in, so that dropping it from the pool is a visible act
+#: rather than an absence.
+#:
+#: ``quote_volume_lookback`` is the one nullable column in the corpus, and the
+#: validator pins it both ways: present exactly when the row claims the symbol
+#: was eligible, absent exactly when it claims it was not.  A placeholder zero
+#: would read as "ranked last" rather than "not ranked", which is the confusion
+#: this column exists to prevent.
+PREMIUM_INDEX_GAP_AUDIT_SCHEMA = pa.schema(
+    [
+        pa.field("epoch_open_time", pa.int64(), nullable=False),
+        pa.field("symbol", pa.string(), nullable=False),
+        pa.field("eligibility_status", pa.string(), nullable=False),
+        pa.field("eligibility_evidence_sha256", pa.string(), nullable=False),
+        pa.field("quote_volume_lookback", pa.string(), nullable=True),
+        pa.field("verdict", pa.string(), nullable=False),
+        *_provenance_fields(),
+    ]
+)
+
 CANONICAL_TABLES: MappingProxyType[str, pa.Schema] = MappingProxyType(
     {
         "klines_4h": KLINES_4H_SCHEMA,
         "premium_index_4h": PREMIUM_INDEX_4H_SCHEMA,
         "pit_universe": PIT_UNIVERSE_SCHEMA,
+        "premium_index_gap_audit": PREMIUM_INDEX_GAP_AUDIT_SCHEMA,
         "outcomes": OUTCOMES_SCHEMA,
     }
 )
@@ -154,9 +181,37 @@ MANIFEST_REQUIRED_KEYS: tuple[str, ...] = (
     "universe",
     "imputation",
     "prerequisite_readiness",
+    "lifecycle_eligibility",
+    "premium_index_gap",
     "sources",
     "tables",
     "admissibility",
+)
+
+#: A2-C6 / A2-C7.  ``symbols`` is the full archive diff; ``in_window_symbols``
+#: is the subset that gets a per-epoch audit row; ``exclusions`` must account
+#: for every symbol in the difference between the two.
+MANIFEST_GAP_REQUIRED_KEYS: tuple[str, ...] = (
+    "symbols",
+    "in_window_symbols",
+    "exclusions",
+    "listing_endpoint",
+    "listing_retrieved_at",
+    "measurement_sha256",
+)
+
+GAP_EXCLUSION_REQUIRED_KEYS: tuple[str, ...] = (
+    "symbol",
+    "reason",
+    "evidence_sha256",
+)
+
+#: A2-C6.  The corpus states the authority situation rather than leaving it
+#: implicit, so a later reader cannot assume one was found.
+MANIFEST_LIFECYCLE_REQUIRED_KEYS: tuple[str, ...] = (
+    "authoritative_public_source",
+    "evidence_kind",
+    "proxy_limits",
 )
 
 MANIFEST_SOURCE_REQUIRED_KEYS: tuple[str, ...] = (

--- a/research/dfc_v22_research_min/validation.py
+++ b/research/dfc_v22_research_min/validation.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable, Mapping, Sequence
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import pyarrow as pa
@@ -23,6 +24,9 @@ import pyarrow as pa
 from . import contract as c
 from .schema import (
     CANONICAL_TABLES,
+    GAP_EXCLUSION_REQUIRED_KEYS,
+    MANIFEST_GAP_REQUIRED_KEYS,
+    MANIFEST_LIFECYCLE_REQUIRED_KEYS,
     MANIFEST_REQUIRED_KEYS,
     MANIFEST_SOURCE_REQUIRED_KEYS,
     MANIFEST_TABLE_REQUIRED_KEYS,
@@ -34,12 +38,16 @@ __all__ = [
     "RUN_INVALID_AUTHENTICITY_EVIDENCE",
     "RUN_INVALID_CORPUS_LITERALS",
     "RUN_INVALID_FORBIDDEN_SOURCE",
+    "RUN_INVALID_INPUT_EVIDENCE",
     "RUN_INVALID_MANIFEST_SCHEMA",
     "RUN_INVALID_OUTCOME_EVIDENCE",
     "RUN_INVALID_SCOPE_SEPARATION",
     "RUN_INVALID_TABLE_SCHEMA",
+    "validate_corpus",
+    "validate_input_evidence",
     "validate_manifest",
     "validate_outcomes",
+    "validate_premium_index_gap",
     "validate_table",
 ]
 
@@ -50,6 +58,7 @@ RUN_INVALID_AUTHENTICITY_EVIDENCE = "RUN_INVALID_AUTHENTICITY_EVIDENCE"
 RUN_INVALID_SCOPE_SEPARATION = "RUN_INVALID_SCOPE_SEPARATION"
 RUN_INVALID_TABLE_SCHEMA = "RUN_INVALID_TABLE_SCHEMA"
 RUN_INVALID_OUTCOME_EVIDENCE = c.RUN_INVALID_OUTCOME_EVIDENCE
+RUN_INVALID_INPUT_EVIDENCE = c.RUN_INVALID_INPUT_EVIDENCE
 
 #: Re-exported so a reader of the validator sees the closed arm-label domain
 #: it enforces without following an import (A2-C4 / NW-F4).
@@ -416,8 +425,12 @@ def validate_manifest(manifest: Mapping[str, Any]) -> None:
             declared a prerequisite (A2-C1), ``RUN_INVALID_FORBIDDEN_SOURCE``
             for funding/OI/mark/index material (A2-C3) and
             ``RUN_INVALID_AUTHENTICITY_EVIDENCE`` for missing provenance or a
-            self-consistency admissibility claim (A2-C5).
+            self-consistency admissibility claim (A2-C5), and
+            ``RUN_INVALID_INPUT_EVIDENCE`` for a lifecycle-authority or
+            archive-gap declaration the contract refuses (A2-C6 / A2-C7).
     """
+    validate_input_evidence(manifest)
+
     missing = [k for k in MANIFEST_REQUIRED_KEYS if k not in manifest]
     if missing:
         _fail(
@@ -669,6 +682,421 @@ def _validate_tables(tables: Sequence[Mapping[str, Any]]) -> None:
             "A2-C3",
             f"canonical table(s) absent from manifest: {absent}",
         )
+
+
+# --- A2-C6: lifecycle authority absence and substitute evidence -----------
+
+
+def _validate_lifecycle_eligibility(manifest: Mapping[str, Any]) -> None:
+    """The corpus must state that no authority exists, and use the substitute.
+
+    The failure this guards is not a builder inventing a Binance endpoint out
+    of nothing — it is a builder quietly promoting one of the two known proxies
+    to "the lifecycle source", which would make an inference from data presence
+    read as a record Binance stands behind.
+    """
+    declared = manifest.get("lifecycle_eligibility")
+    if not isinstance(declared, Mapping):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C6",
+            "manifest does not declare lifecycle_eligibility; the absence of "
+            "an authoritative public lifecycle source is stated by this "
+            "corpus, never left to be assumed either way",
+        )
+        return
+
+    missing = [k for k in MANIFEST_LIFECYCLE_REQUIRED_KEYS if k not in declared]
+    if missing:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C6",
+            f"lifecycle_eligibility is missing {missing}",
+        )
+
+    authoritative = declared["authoritative_public_source"]
+    if authoritative is not c.LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C6",
+            f"authoritative_public_source must be "
+            f"{c.LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE!r}: A2-MEASURE "
+            f"established that none exists, so naming {authoritative!r} "
+            "asserts an authority that was looked for and not found",
+        )
+
+    kind = declared["evidence_kind"]
+    if kind in c.LIFECYCLE_PROXY_KINDS:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C6",
+            f"evidence_kind {kind!r} is a proxy, not the eligibility evidence; "
+            f"{c.LIFECYCLE_PROXY_LIMITS[kind]}",
+        )
+    if kind != c.ELIGIBILITY_EVIDENCE_KIND:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C6",
+            f"evidence_kind must be {c.ELIGIBILITY_EVIDENCE_KIND!r} — a "
+            "completed 4h kline with non-zero traded volume across the "
+            f"ranking window — got {kind!r}",
+        )
+
+    limits = declared["proxy_limits"]
+    if not isinstance(limits, Mapping) or set(limits) != set(c.LIFECYCLE_PROXY_LIMITS):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C6",
+            "proxy_limits must record exactly the known proxies "
+            f"{sorted(c.LIFECYCLE_PROXY_LIMITS)}; dropping one loses the "
+            "record of what it cannot answer",
+        )
+    for name, text in c.LIFECYCLE_PROXY_LIMITS.items():
+        if limits.get(name) != text:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C6",
+                f"proxy_limits[{name!r}] does not carry the frozen limitation "
+                "text; a proxy's limits may not be softened",
+            )
+
+
+# --- A2-C7: premium-index archive gap -------------------------------------
+
+
+def _decimal(value: Any, *, label: str) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"{label}: {value!r} is not a parsable quote volume",
+        )
+        raise
+
+
+def _validate_gap_section(manifest: Mapping[str, Any]) -> tuple[str, ...]:
+    """Validate the manifest's gap declaration; return the in-window subset."""
+    gap = manifest.get("premium_index_gap")
+    if not isinstance(gap, Mapping):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            "manifest does not declare premium_index_gap; the klines vs "
+            "premiumIndexKlines archive diff is an input to this corpus and "
+            "is recorded, not assumed empty",
+        )
+        return ()
+
+    missing = [k for k in MANIFEST_GAP_REQUIRED_KEYS if k not in gap]
+    if missing:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"premium_index_gap is missing {missing}",
+        )
+
+    symbols = tuple(gap["symbols"])
+    in_window = tuple(gap["in_window_symbols"])
+    stray = [s for s in in_window if s not in symbols]
+    if stray:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"in_window_symbols are not part of the measured diff: {stray}",
+        )
+
+    exclusions = gap["exclusions"]
+    by_symbol: dict[str, Mapping[str, Any]] = {}
+    for index, entry in enumerate(exclusions):
+        label = f"exclusions[{index}]"
+        absent = [k for k in GAP_EXCLUSION_REQUIRED_KEYS if k not in entry]
+        if absent:
+            _fail(RUN_INVALID_INPUT_EVIDENCE, "A2-C7", f"{label}: missing {absent}")
+        reason = entry["reason"]
+        if reason not in c.GAP_EXCLUSION_REASONS:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C7",
+                f"{label}: reason {reason!r} is not one of "
+                f"{list(c.GAP_EXCLUSION_REASONS)}; the reason set is closed so "
+                "that no gap symbol is dropped on an unstated ground",
+            )
+        if not entry["evidence_sha256"]:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C7",
+                f"{label}: excluding a gap symbol requires evidence",
+            )
+        if reason == c.GAP_EXCLUSION_BASE_SYMBOL_REASON:
+            base = entry.get("base_symbol")
+            if not base:
+                _fail(
+                    RUN_INVALID_INPUT_EVIDENCE,
+                    "A2-C7",
+                    f"{label}: reason {reason!r} must name the base_symbol it "
+                    "claims the rows are identical to",
+                )
+            if base in symbols:
+                _fail(
+                    RUN_INVALID_INPUT_EVIDENCE,
+                    "A2-C7",
+                    f"{label}: base_symbol {base!r} is itself in the gap set, "
+                    "so it carries no premium-index material either",
+                )
+        by_symbol[str(entry["symbol"])] = entry
+
+    unaccounted = [s for s in symbols if s not in in_window and s not in by_symbol]
+    if unaccounted:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"{len(unaccounted)} gap symbol(s) are neither audited per epoch "
+            f"nor excluded with a reason (first={unaccounted[0]!r}); every "
+            "symbol in the diff is accounted for",
+        )
+    both = [s for s in in_window if s in by_symbol]
+    if both:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"gap symbol(s) both audited and excluded: {both}",
+        )
+    return in_window
+
+
+def validate_premium_index_gap(
+    gap_audit: pa.Table,
+    pit_universe: pa.Table,
+    in_window_symbols: Sequence[str],
+) -> None:
+    """Decide, per epoch, whether the archive gap touches the candidate pool.
+
+    The verdict is recorded by the builder and *recomputed* here, exactly as
+    outcome numbers are (A2-C4).  Nothing in this function returns a pool, edits
+    a pool, or names a replacement symbol: when a gap symbol outranks the
+    declared top 3, the epoch is reported ``RUN_INVALID_INPUT_EVIDENCE`` and
+    that is the whole of the response.  Promoting the next-ranked symbol into
+    the vacancy would turn an input-evidence failure into a clean-looking
+    ranking, which is the failure OD-26 names first.
+
+    Args:
+        gap_audit: The ``premium_index_gap_audit`` table.
+        pit_universe: The ``pit_universe`` table, carrying the declared ranks.
+        in_window_symbols: Gap symbols that require a per-epoch audit row.
+
+    Raises:
+        ContractViolation: Always with ``RUN_INVALID_INPUT_EVIDENCE``.
+    """
+    validate_table("premium_index_gap_audit", gap_audit)
+    validate_table("pit_universe", pit_universe)
+
+    pools: dict[int, list[dict[str, Any]]] = {}
+    for row in pit_universe.to_pylist():
+        pools.setdefault(row["epoch_open_time"], []).append(row)
+
+    audit: dict[tuple[int, str], dict[str, Any]] = {}
+    for row in gap_audit.to_pylist():
+        key = (row["epoch_open_time"], row["symbol"])
+        if key in audit:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C7",
+                f"duplicate gap audit row for {key}",
+            )
+        audit[key] = row
+
+    expected = frozenset(in_window_symbols)
+    for epoch, symbol in audit:
+        if symbol not in expected:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C7",
+                f"gap audit row for {symbol!r} at epoch {epoch}, which is not "
+                "declared as an in-window gap symbol",
+            )
+        if epoch not in pools:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C7",
+                f"gap audit row at epoch {epoch}, which has no pit_universe pool",
+            )
+
+    for epoch in sorted(pools):
+        pool = _ranked_pool(epoch, pools[epoch])
+        cut_symbol = pool[-1]["symbol"]
+        cut_volume = _decimal(
+            pool[-1]["quote_volume_lookback"], label=f"epoch {epoch} rank cut"
+        )
+        pool_symbols = {row["symbol"] for row in pool}
+
+        for symbol in in_window_symbols:
+            if symbol in pool_symbols:
+                _fail(
+                    RUN_INVALID_INPUT_EVIDENCE,
+                    "A2-C7",
+                    f"epoch {epoch}: {symbol!r} is in the candidate pool but "
+                    "the archive carries no premium index for it; the epoch is "
+                    "invalid, and the pool is not re-ranked around it",
+                )
+            row = audit.get((epoch, symbol))
+            if row is None:
+                _fail(
+                    RUN_INVALID_INPUT_EVIDENCE,
+                    "A2-C7",
+                    f"epoch {epoch}: in-window gap symbol {symbol!r} has no "
+                    "audit row; a gap symbol is accounted for at every epoch, "
+                    "never omitted",
+                )
+                continue
+            _check_gap_row(epoch, row, cut_symbol=cut_symbol, cut_volume=cut_volume)
+
+
+def _ranked_pool(epoch: int, rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return the pool in declared rank order, having checked it *is* the ranking."""
+    pool = sorted((dict(r) for r in rows), key=lambda r: r["rank"])
+    ranks = [r["rank"] for r in pool]
+    if ranks != list(range(1, c.UNIVERSE_TOP_N + 1)):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"epoch {epoch}: pit_universe ranks are {ranks}, expected exactly "
+            f"1..{c.UNIVERSE_TOP_N}",
+        )
+    symbols = [r["symbol"] for r in pool]
+    if len(set(symbols)) != len(symbols):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"epoch {epoch}: duplicate symbol in the candidate pool {symbols}",
+        )
+    reordered = sorted(
+        pool,
+        key=lambda r: (
+            -_decimal(r["quote_volume_lookback"], label=f"epoch {epoch} {r['symbol']}"),
+            r["symbol"],
+        ),
+    )
+    if [r["symbol"] for r in reordered] != symbols:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"epoch {epoch}: the declared pool order {symbols} is not the "
+            f"{c.UNIVERSE_RANKING_METRIC} ranking it claims to be "
+            f"({[r['symbol'] for r in reordered]}, ties broken "
+            f"{c.UNIVERSE_TIE_BREAK})",
+        )
+    return pool
+
+
+def _check_gap_row(
+    epoch: int,
+    row: Mapping[str, Any],
+    *,
+    cut_symbol: str,
+    cut_volume: Decimal,
+) -> None:
+    status = row["eligibility_status"]
+    if status not in c.ELIGIBILITY_STATUSES:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"epoch {epoch}: eligibility_status {status!r} is not one of "
+            f"{list(c.ELIGIBILITY_STATUSES)}",
+        )
+    if not row["eligibility_evidence_sha256"]:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C6",
+            f"epoch {epoch}: {row['symbol']!r} carries no eligibility evidence; "
+            f"eligibility is decided by {c.ELIGIBILITY_EVIDENCE_KIND}, and the "
+            "evidence it was decided from is recorded",
+        )
+
+    volume = row["quote_volume_lookback"]
+    if status == c.NOT_ELIGIBLE:
+        if volume is not None:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C7",
+                f"epoch {epoch}: {row['symbol']!r} is recorded not_eligible yet "
+                f"carries a lookback volume ({volume!r})",
+            )
+        recomputed = c.NO_IMPACT
+    else:
+        if volume is None:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C7",
+                f"epoch {epoch}: {row['symbol']!r} is recorded eligible with no "
+                "lookback volume, so it cannot be ranked against the pool",
+            )
+        value = _decimal(volume, label=f"epoch {epoch} {row['symbol']}")
+        outranks = value > cut_volume or (
+            value == cut_volume and str(row["symbol"]) < cut_symbol
+        )
+        recomputed = c.RUN_INVALID_INPUT_EVIDENCE if outranks else c.NO_IMPACT
+
+    verdict = row["verdict"]
+    if verdict not in c.GAP_EPOCH_VERDICTS:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"epoch {epoch}: verdict {verdict!r} is not one of "
+            f"{list(c.GAP_EPOCH_VERDICTS)}",
+        )
+    if verdict != recomputed:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"epoch {epoch}: {row['symbol']!r} is recorded {verdict} but the "
+            f"evidence supports {recomputed} (lookback volume {volume!r} "
+            f"against the rank-{c.UNIVERSE_TOP_N} cut {cut_symbol} "
+            f"{cut_volume}); the verdict is recomputed, not accepted",
+        )
+    if recomputed == c.RUN_INVALID_INPUT_EVIDENCE:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C7",
+            f"epoch {epoch}: gap symbol {row['symbol']!r} outranks the "
+            f"rank-{c.UNIVERSE_TOP_N} candidate {cut_symbol!r}, so the archive "
+            "gap intersects this epoch's pool. The epoch is invalid; it is not "
+            "repaired by promoting the next-ranked symbol",
+        )
+
+
+def validate_input_evidence(manifest: Mapping[str, Any]) -> tuple[str, ...]:
+    """Run the A2-C6 / A2-C7 manifest half and return the in-window gap subset."""
+    _validate_lifecycle_eligibility(manifest)
+    return _validate_gap_section(manifest)
+
+
+def validate_corpus(
+    manifest: Mapping[str, Any],
+    *,
+    pit_universe: pa.Table,
+    gap_audit: pa.Table,
+    klines: pa.Table,
+    outcomes: pa.Table,
+    decisions: Sequence[Mapping[str, Any]],
+) -> None:
+    """Validate a corpus in ``TERMINAL_CODE_PRIORITY`` order.
+
+    Input evidence is adjudicated first and unconditionally.  A corpus built on
+    material the contract refuses is the wrong artifact, so reporting some
+    downstream code for it would name a symptom and hide the cause — and it
+    would let a run whose ranking input is inadmissible be written up as an
+    outcome-level problem instead.
+
+    Raises:
+        ContractViolation: The highest-priority code the artifacts violate.
+    """
+    in_window = validate_input_evidence(manifest)
+    validate_premium_index_gap(gap_audit, pit_universe, in_window)
+    validate_manifest(manifest)  # re-runs the pure input-evidence half; idempotent
+    validate_table("klines_4h", klines)
+    validate_outcomes(outcomes, klines, decisions)
 
 
 def _validate_admissibility(admissibility: Mapping[str, Any]) -> None:

--- a/research/dfc_v22_research_min/validation.py
+++ b/research/dfc_v22_research_min/validation.py
@@ -1078,6 +1078,7 @@ def validate_corpus(
     pit_universe: pa.Table,
     gap_audit: pa.Table,
     klines: pa.Table,
+    premium_index: pa.Table,
     outcomes: pa.Table,
     decisions: Sequence[Mapping[str, Any]],
 ) -> None:
@@ -1089,6 +1090,9 @@ def validate_corpus(
     would let a run whose ranking input is inadmissible be written up as an
     outcome-level problem instead.
 
+    Every canonical table is checked here, so that this function is the whole
+    entry point: a table left out would be a schema nobody validates.
+
     Raises:
         ContractViolation: The highest-priority code the artifacts violate.
     """
@@ -1096,6 +1100,7 @@ def validate_corpus(
     validate_premium_index_gap(gap_audit, pit_universe, in_window)
     validate_manifest(manifest)  # re-runs the pure input-evidence half; idempotent
     validate_table("klines_4h", klines)
+    validate_table("premium_index_4h", premium_index)
     validate_outcomes(outcomes, klines, decisions)
 
 

--- a/tests/research/dfc_v22_research_min/golden/violation_cases.json
+++ b/tests/research/dfc_v22_research_min/golden/violation_cases.json
@@ -178,6 +178,96 @@
       "expected_detail_contains": "imputed_row_count must be 0"
     },
     {
+      "case_id": "lifecycle_authority_invented",
+      "clause": "A2-C6",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "asserts an authority that was looked for and not found"
+    },
+    {
+      "case_id": "lifecycle_proxy_promoted_to_evidence",
+      "clause": "A2-C6",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "is a proxy, not the eligibility evidence"
+    },
+    {
+      "case_id": "lifecycle_proxy_limit_softened",
+      "clause": "A2-C6",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "a proxy's limits may not be softened"
+    },
+    {
+      "case_id": "gap_symbol_missing_eligibility_evidence",
+      "clause": "A2-C6",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "carries no eligibility evidence"
+    },
+    {
+      "case_id": "gap_symbol_unaccounted_for",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "neither audited per epoch nor excluded with a reason"
+    },
+    {
+      "case_id": "gap_exclusion_unknown_reason",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "the reason set is closed"
+    },
+    {
+      "case_id": "gap_exclusion_base_symbol_also_in_gap",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "is itself in the gap set"
+    },
+    {
+      "case_id": "gap_symbol_inside_candidate_pool",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "the pool is not re-ranked around it"
+    },
+    {
+      "case_id": "gap_epoch_audit_row_omitted",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "accounted for at every epoch, never omitted"
+    },
+    {
+      "case_id": "gap_outranking_symbol_reported_no_impact",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "the verdict is recomputed, not accepted"
+    },
+    {
+      "case_id": "gap_outranking_symbol_silently_reranked",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "not repaired by promoting the next-ranked symbol"
+    },
+    {
+      "case_id": "gap_pool_order_is_not_the_ranking",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "is not the quote_volume ranking it claims to be"
+    },
+    {
+      "case_id": "gap_pool_shorter_than_top_n",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "expected exactly 1..3"
+    },
+    {
+      "case_id": "gap_not_eligible_row_carries_volume",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "recorded not_eligible yet carries a lookback volume"
+    },
+    {
+      "case_id": "gap_declaration_absent",
+      "clause": "A2-C7",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "recorded, not assumed empty"
+    },
+    {
       "case_id": "manifest_missing_required_source_kind",
       "clause": "A2-C3",
       "expected_code": "RUN_INVALID_MANIFEST_SCHEMA",

--- a/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
+++ b/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
@@ -61,7 +61,9 @@ def test_canonical_source_is_pinned() -> None:
         "NW-F4",
         "NW-F5",
         "NW-F6",
+        "OD-26",
     }
+    assert "§26차" in nw_verbatim.BINDING_RECORD_AMENDMENT
 
 
 @pytest.mark.unit
@@ -105,6 +107,73 @@ def test_clause_ids_map_to_upstream_clauses() -> None:
     doc = DOC_PATH.read_text(encoding="utf-8")
     for clause_id in c.CLAUSE_SOURCES:
         assert clause_id in doc, f"clause {clause_id} is undocumented"
+
+
+#: MUTANT ③ target.  The substitute evidence (A2-C6) is a *different kind* of
+#: evidence from the lifecycle authority that does not exist.  Any wording that
+#: closes that distance turns a stated absence back into a quiet claim, so the
+#: distance is pinned in text as well as in the literals.
+FORBIDDEN_EQUIVALENCE_PHRASES = (
+    "effectively equivalent",
+    "equally authoritative",
+    "as authoritative as",
+    "authoritative substitute",
+    "equivalent to a lifecycle record",
+    "equivalent to the authoritative",
+    "사실상 동등",
+    "사실상 권위",
+)
+
+REQUIRED_A2_C6_WORDING = (
+    "There is no single authoritative public Binance source for contract "
+    "lifecycle\nor eligibility.",
+    "a different kind of evidence, not an approximation of the missing\nauthority",
+    "Nothing here claims the two are interchangeable",
+)
+
+REQUIRED_A2_C7_WORDING = (
+    "Silent re-ranking is forbidden",
+    "promoting the next-ranked one",
+    "`NO_IMPACT`",
+    "`RUN_INVALID_INPUT_EVIDENCE`",
+)
+
+
+@pytest.mark.unit
+def test_substitute_evidence_is_never_called_equivalent_to_an_authority() -> None:
+    haystacks = {DOC_PATH.name: DOC_PATH.read_text(encoding="utf-8")}
+    for path in _package_sources():
+        haystacks[path.name] = path.read_text(encoding="utf-8")
+
+    offenders = [
+        f"{name}: {phrase!r}"
+        for name, text in haystacks.items()
+        for phrase in FORBIDDEN_EQUIVALENCE_PHRASES
+        if phrase in text.lower()
+    ]
+    assert not offenders, offenders
+
+
+@pytest.mark.unit
+def test_gap_closure_clauses_state_their_load_bearing_sentences() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    for wording in REQUIRED_A2_C6_WORDING + REQUIRED_A2_C7_WORDING:
+        assert wording in doc, f"missing from the contract document: {wording!r}"
+
+
+@pytest.mark.unit
+def test_no_authoritative_lifecycle_source_is_frozen_as_absent() -> None:
+    assert c.LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE is None
+    assert set(c.LIFECYCLE_PROXY_KINDS) == {
+        "exchange_info_onboard_date",
+        "archive_month_range",
+    }
+    assert c.ELIGIBILITY_EVIDENCE_KIND not in c.LIFECYCLE_PROXY_KINDS
+    assert c.GAP_EPOCH_VERDICTS == ("NO_IMPACT", "RUN_INVALID_INPUT_EVIDENCE")
+    assert c.TERMINAL_CODE_PRIORITY[0] == "RUN_INVALID_INPUT_EVIDENCE"
+    # Every proxy carries a stated limitation, not an empty placeholder.
+    for name, limit in c.LIFECYCLE_PROXY_LIMITS.items():
+        assert len(limit) > 80, f"{name} has no meaningful limitation text"
 
 
 @pytest.mark.unit

--- a/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
+++ b/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
@@ -124,10 +124,12 @@ FORBIDDEN_EQUIVALENCE_PHRASES = (
     "사실상 권위",
 )
 
+#: Compared against the document with whitespace collapsed, so re-wrapping a
+#: paragraph does not fail a test about what the paragraph *says*.
 REQUIRED_A2_C6_WORDING = (
     "There is no single authoritative public Binance source for contract "
-    "lifecycle\nor eligibility.",
-    "a different kind of evidence, not an approximation of the missing\nauthority",
+    "lifecycle or eligibility.",
+    "a different kind of evidence, not an approximation of the missing authority",
     "Nothing here claims the two are interchangeable",
 )
 
@@ -156,7 +158,7 @@ def test_substitute_evidence_is_never_called_equivalent_to_an_authority() -> Non
 
 @pytest.mark.unit
 def test_gap_closure_clauses_state_their_load_bearing_sentences() -> None:
-    doc = DOC_PATH.read_text(encoding="utf-8")
+    doc = " ".join(DOC_PATH.read_text(encoding="utf-8").split())
     for wording in REQUIRED_A2_C6_WORDING + REQUIRED_A2_C7_WORDING:
         assert wording in doc, f"missing from the contract document: {wording!r}"
 

--- a/tests/research/dfc_v22_research_min/test_a2_golden.py
+++ b/tests/research/dfc_v22_research_min/test_a2_golden.py
@@ -26,9 +26,11 @@ import pytest
 from research.dfc_v22_research_min import contract as c
 from research.dfc_v22_research_min import validation as v
 from research.dfc_v22_research_min.schema import (
+    CANONICAL_TABLES,
     KLINES_4H_SCHEMA,
     OUTCOMES_SCHEMA,
     PIT_UNIVERSE_SCHEMA,
+    PREMIUM_INDEX_4H_SCHEMA,
     PREMIUM_INDEX_GAP_AUDIT_SCHEMA,
 )
 
@@ -317,6 +319,24 @@ def gap_audit_row(
         "verdict": verdict,
         **_provenance("p-gap-t0"),
     }
+
+
+def premium_index(rows: list[dict[str, Any]] | None = None) -> pa.Table:
+    rows = (
+        rows
+        if rows is not None
+        else [
+            {
+                "symbol": row["symbol"],
+                "open_time": row["open_time"],
+                "close_time": row["close_time"],
+                "premium_index_close": "0.00012",
+                **_provenance(f"pi-{row['payload_sha256']}"),
+            }
+            for row in _KLINE_ROWS
+        ]
+    )
+    return pa.Table.from_pylist(rows, schema=PREMIUM_INDEX_4H_SCHEMA)
 
 
 def gap_audit(rows: list[dict[str, Any]] | None = None) -> pa.Table:
@@ -784,9 +804,45 @@ def test_baseline_artifacts_validate() -> None:
         pit_universe=pit_universe(),
         gap_audit=gap_audit(),
         klines=klines(),
+        premium_index=premium_index(),
         outcomes=outcomes(),
         decisions=_DECISIONS,
     )
+
+
+@pytest.mark.unit
+def test_validate_corpus_covers_every_canonical_table() -> None:
+    """A canonical table absent from the orchestrator is a schema nobody checks.
+
+    ``validate_corpus`` is the whole entry point, so the set of tables it reaches
+    has to equal ``CANONICAL_TABLES`` — otherwise adding a table to the contract
+    silently adds one that no run validates.
+    """
+    reached: set[str] = set()
+    original = v.validate_table
+
+    def spy(name: str, table: pa.Table) -> None:
+        reached.add(name)
+        original(name, table)
+
+    v.validate_table = spy  # type: ignore[assignment]
+    try:
+        v.validate_corpus(
+            manifest(),
+            pit_universe=pit_universe(),
+            gap_audit=gap_audit(),
+            klines=klines(),
+            premium_index=premium_index(),
+            outcomes=outcomes(),
+            decisions=_DECISIONS,
+        )
+    finally:
+        v.validate_table = original  # type: ignore[assignment]
+
+    assert reached == set(CANONICAL_TABLES), {
+        "unvalidated": sorted(set(CANONICAL_TABLES) - reached),
+        "unexpected": sorted(reached - set(CANONICAL_TABLES)),
+    }
 
 
 @pytest.mark.unit
@@ -817,6 +873,7 @@ def test_input_evidence_outranks_every_other_terminal_code() -> None:
             pit_universe=pit_universe(),
             gap_audit=gap_audit([gap_audit_row(quote_volume="250.0")]),
             klines=klines(),
+            premium_index=premium_index(),
             outcomes=outcomes(bad_outcomes),
             decisions=_DECISIONS,
         )

--- a/tests/research/dfc_v22_research_min/test_a2_golden.py
+++ b/tests/research/dfc_v22_research_min/test_a2_golden.py
@@ -12,6 +12,7 @@ Network-zero by construction: everything here is built in memory.
 
 from __future__ import annotations
 
+import ast
 import json
 import math
 from collections.abc import Callable
@@ -28,6 +29,7 @@ from research.dfc_v22_research_min.schema import (
     KLINES_4H_SCHEMA,
     OUTCOMES_SCHEMA,
     PIT_UNIVERSE_SCHEMA,
+    PREMIUM_INDEX_GAP_AUDIT_SCHEMA,
 )
 
 GOLDEN_PATH = Path(__file__).parent / "golden" / "violation_cases.json"
@@ -170,6 +172,49 @@ def _source(kind: str, **overrides: Any) -> dict[str, Any]:
     return source
 
 
+#: One gap symbol per disposition: audited per epoch, and one excluded under
+#: each of the two exclusion reasons that need no base symbol / need one.
+GAP_SYMBOLS = ("GAPUSDT", "BTCUSDT_210625", "LEGACYUSDTSETTLED")
+IN_WINDOW_GAP_SYMBOLS = ("GAPUSDT",)
+
+
+def lifecycle_eligibility(**overrides: Any) -> dict[str, Any]:
+    declared: dict[str, Any] = {
+        "authoritative_public_source": None,
+        "evidence_kind": c.ELIGIBILITY_EVIDENCE_KIND,
+        "proxy_limits": dict(c.LIFECYCLE_PROXY_LIMITS),
+    }
+    declared.update(overrides)
+    return declared
+
+
+def premium_index_gap(**overrides: Any) -> dict[str, Any]:
+    gap: dict[str, Any] = {
+        "symbols": list(GAP_SYMBOLS),
+        "in_window_symbols": list(IN_WINDOW_GAP_SYMBOLS),
+        "exclusions": [
+            {
+                "symbol": "BTCUSDT_210625",
+                "reason": "not_perpetual",
+                "evidence_sha256": "1" * 64,
+            },
+            {
+                "symbol": "LEGACYUSDTSETTLED",
+                "reason": "same_instrument_as_base",
+                "base_symbol": "LEGACYUSDT",
+                "evidence_sha256": "2" * 64,
+            },
+        ],
+        "listing_endpoint": (
+            "https://s3-ap-northeast-1.amazonaws.com/data.binance.vision"
+        ),
+        "listing_retrieved_at": "2026-08-10T05:00:00Z",
+        "measurement_sha256": "3" * 64,
+    }
+    gap.update(overrides)
+    return gap
+
+
 def manifest(**overrides: Any) -> dict[str, Any]:
     base: dict[str, Any] = {
         "contract_id": c.CONTRACT_ID,
@@ -195,6 +240,8 @@ def manifest(**overrides: Any) -> dict[str, Any]:
             "contract_id": c.CONTRACT_ID,
             "dimensions": list(c.A2_JUDGED_DIMENSIONS),
         },
+        "lifecycle_eligibility": lifecycle_eligibility(),
+        "premium_index_gap": premium_index_gap(),
         "sources": [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS],
         "tables": [
             {
@@ -204,7 +251,13 @@ def manifest(**overrides: Any) -> dict[str, Any]:
                 "row_count": 4,
                 "byte_size": 2048,
             }
-            for name in ("klines_4h", "premium_index_4h", "pit_universe", "outcomes")
+            for name in (
+                "klines_4h",
+                "premium_index_4h",
+                "pit_universe",
+                "premium_index_gap_audit",
+                "outcomes",
+            )
         ],
         "admissibility": {
             "basis": c.ADMISSIBILITY_BASIS,
@@ -216,18 +269,59 @@ def manifest(**overrides: Any) -> dict[str, Any]:
     return base
 
 
-def pit_universe_row() -> dict[str, Any]:
+def pit_universe_row(
+    rank: int = 1,
+    symbol: str = "XRPUSDT",
+    quote_volume: str = "123456.7",
+) -> dict[str, Any]:
     return {
         "epoch_open_time": T0,
-        "rank": 1,
-        "symbol": "XRPUSDT",
-        "quote_volume_lookback": "123456.7",
+        "rank": rank,
+        "symbol": symbol,
+        "quote_volume_lookback": quote_volume,
         "lookback_start_time": T0 - 30 * 24 * 60 * 60 * 1000,
         "lookback_end_time": T0,
         "lifecycle_evidence_sha256": "e" * 64,
         "eligibility_evidence_sha256": "f" * 64,
         **_provenance("p-univ-t0"),
     }
+
+
+#: A full pool: three ranks, strictly descending quote volume.  The rank-3 row
+#: is the cut every gap symbol is measured against.
+_POOL_ROWS: list[dict[str, Any]] = [
+    pit_universe_row(1, "XRPUSDT", "300.0"),
+    pit_universe_row(2, "SOLUSDT", "200.0"),
+    pit_universe_row(3, "ADAUSDT", "100.0"),
+]
+
+
+def pit_universe(rows: list[dict[str, Any]] | None = None) -> pa.Table:
+    return pa.Table.from_pylist(rows or _POOL_ROWS, schema=PIT_UNIVERSE_SCHEMA)
+
+
+def gap_audit_row(
+    symbol: str = "GAPUSDT",
+    *,
+    status: str = c.ELIGIBLE,
+    quote_volume: str | None = "50.0",
+    verdict: str = c.NO_IMPACT,
+    epoch: int = T0,
+) -> dict[str, Any]:
+    return {
+        "epoch_open_time": epoch,
+        "symbol": symbol,
+        "eligibility_status": status,
+        "eligibility_evidence_sha256": "9" * 64,
+        "quote_volume_lookback": quote_volume,
+        "verdict": verdict,
+        **_provenance("p-gap-t0"),
+    }
+
+
+def gap_audit(rows: list[dict[str, Any]] | None = None) -> pa.Table:
+    rows = rows if rows is not None else [gap_audit_row()]
+    return pa.Table.from_pylist(rows, schema=PREMIUM_INDEX_GAP_AUDIT_SCHEMA)
 
 
 # --------------------------------------------------------------------------
@@ -465,6 +559,140 @@ def _case_manifest_missing_required_source_kind() -> None:
     v.validate_manifest(manifest(sources=sources))
 
 
+# --- A2-C6: lifecycle authority absence ------------------------------------
+
+
+def _case_lifecycle_authority_invented() -> None:
+    # The endpoint does not publish lifecycle state; naming it asserts an
+    # authority A2-MEASURE looked for and did not find.
+    v.validate_manifest(
+        manifest(
+            lifecycle_eligibility=lifecycle_eligibility(
+                authoritative_public_source="GET /fapi/v1/exchangeInfo"
+            )
+        )
+    )
+
+
+def _case_lifecycle_proxy_promoted_to_evidence() -> None:
+    v.validate_manifest(
+        manifest(
+            lifecycle_eligibility=lifecycle_eligibility(
+                evidence_kind="exchange_info_onboard_date"
+            )
+        )
+    )
+
+
+def _case_lifecycle_proxy_limit_softened() -> None:
+    limits = dict(c.LIFECYCLE_PROXY_LIMITS)
+    limits["archive_month_range"] = "effectively equivalent to a lifecycle record"
+    v.validate_manifest(
+        manifest(lifecycle_eligibility=lifecycle_eligibility(proxy_limits=limits))
+    )
+
+
+def _case_gap_symbol_missing_eligibility_evidence() -> None:
+    row = gap_audit_row()
+    row["eligibility_evidence_sha256"] = ""
+    v.validate_premium_index_gap(
+        gap_audit([row]), pit_universe(), IN_WINDOW_GAP_SYMBOLS
+    )
+
+
+# --- A2-C7: the archive gap and the per-epoch verdict -----------------------
+
+
+def _case_gap_symbol_unaccounted_for() -> None:
+    # Present in the measured diff, neither audited nor excluded: the silent
+    # disappearance the closed reason set exists to prevent.
+    gap = premium_index_gap(exclusions=premium_index_gap()["exclusions"][:1])
+    v.validate_manifest(manifest(premium_index_gap=gap))
+
+
+def _case_gap_exclusion_unknown_reason() -> None:
+    exclusions = [dict(e) for e in premium_index_gap()["exclusions"]]
+    exclusions[0]["reason"] = "not_relevant"
+    v.validate_manifest(
+        manifest(premium_index_gap=premium_index_gap(exclusions=exclusions))
+    )
+
+
+def _case_gap_exclusion_base_symbol_also_in_gap() -> None:
+    # "Same instrument as base" is worthless if the base has no premium index
+    # either — it just moves the gap one symbol along.
+    exclusions = [dict(e) for e in premium_index_gap()["exclusions"]]
+    exclusions[1]["base_symbol"] = "GAPUSDT"
+    v.validate_manifest(
+        manifest(premium_index_gap=premium_index_gap(exclusions=exclusions))
+    )
+
+
+def _case_gap_symbol_inside_candidate_pool() -> None:
+    pool = [dict(r) for r in _POOL_ROWS]
+    pool[2]["symbol"] = "GAPUSDT"
+    v.validate_premium_index_gap(
+        gap_audit([gap_audit_row(quote_volume="100.0")]),
+        pit_universe(pool),
+        IN_WINDOW_GAP_SYMBOLS,
+    )
+
+
+def _case_gap_epoch_audit_row_omitted() -> None:
+    v.validate_premium_index_gap(gap_audit([]), pit_universe(), IN_WINDOW_GAP_SYMBOLS)
+
+
+def _case_gap_outranking_symbol_reported_no_impact() -> None:
+    # MUTANT ②: the gap symbol beats the rank-3 cut, but the epoch is written
+    # up as clean.  The verdict is recomputed, so the claim does not survive.
+    v.validate_premium_index_gap(
+        gap_audit([gap_audit_row(quote_volume="250.0", verdict=c.NO_IMPACT)]),
+        pit_universe(),
+        IN_WINDOW_GAP_SYMBOLS,
+    )
+
+
+def _case_gap_outranking_symbol_silently_reranked() -> None:
+    # MUTANT ①: the gap symbol outranks the pool and the builder resolved it by
+    # promoting the next-ranked symbol into the vacancy, then recording the
+    # honest verdict for the symbol it dropped.  The epoch must still be
+    # RUN_INVALID_INPUT_EVIDENCE — a re-ranked pool is not a repair.
+    v.validate_premium_index_gap(
+        gap_audit(
+            [gap_audit_row(quote_volume="250.0", verdict=c.RUN_INVALID_INPUT_EVIDENCE)]
+        ),
+        pit_universe(),
+        IN_WINDOW_GAP_SYMBOLS,
+    )
+
+
+def _case_gap_pool_order_is_not_the_ranking() -> None:
+    # The pool was re-ordered so the promoted symbol looks like rank 3.
+    pool = [dict(r) for r in _POOL_ROWS]
+    pool[1]["quote_volume_lookback"] = "50.0"
+    v.validate_premium_index_gap(gap_audit(), pit_universe(pool), IN_WINDOW_GAP_SYMBOLS)
+
+
+def _case_gap_pool_shorter_than_top_n() -> None:
+    v.validate_premium_index_gap(
+        gap_audit(), pit_universe(_POOL_ROWS[:2]), IN_WINDOW_GAP_SYMBOLS
+    )
+
+
+def _case_gap_not_eligible_row_carries_volume() -> None:
+    v.validate_premium_index_gap(
+        gap_audit([gap_audit_row(status=c.NOT_ELIGIBLE, quote_volume="10.0")]),
+        pit_universe(),
+        IN_WINDOW_GAP_SYMBOLS,
+    )
+
+
+def _case_gap_declaration_absent() -> None:
+    base = manifest()
+    del base["premium_index_gap"]
+    v.validate_manifest(base)
+
+
 CASE_BUILDERS: dict[str, Callable[[], None]] = {
     "outcomes_free_bool_column": _case_outcomes_free_bool_column,
     "outcomes_free_price_column": _case_outcomes_free_price_column,
@@ -504,6 +732,27 @@ CASE_BUILDERS: dict[str, Callable[[], None]] = {
     "manifest_universe_top_five": _case_manifest_universe_top_five,
     "manifest_imputed_rows_present": _case_manifest_imputed_rows_present,
     "manifest_missing_required_source_kind": _case_manifest_missing_required_source_kind,
+    "lifecycle_authority_invented": _case_lifecycle_authority_invented,
+    "lifecycle_proxy_promoted_to_evidence": _case_lifecycle_proxy_promoted_to_evidence,
+    "lifecycle_proxy_limit_softened": _case_lifecycle_proxy_limit_softened,
+    "gap_symbol_missing_eligibility_evidence": (
+        _case_gap_symbol_missing_eligibility_evidence
+    ),
+    "gap_symbol_unaccounted_for": _case_gap_symbol_unaccounted_for,
+    "gap_exclusion_unknown_reason": _case_gap_exclusion_unknown_reason,
+    "gap_exclusion_base_symbol_also_in_gap": _case_gap_exclusion_base_symbol_also_in_gap,
+    "gap_symbol_inside_candidate_pool": _case_gap_symbol_inside_candidate_pool,
+    "gap_epoch_audit_row_omitted": _case_gap_epoch_audit_row_omitted,
+    "gap_outranking_symbol_reported_no_impact": (
+        _case_gap_outranking_symbol_reported_no_impact
+    ),
+    "gap_outranking_symbol_silently_reranked": (
+        _case_gap_outranking_symbol_silently_reranked
+    ),
+    "gap_pool_order_is_not_the_ranking": _case_gap_pool_order_is_not_the_ranking,
+    "gap_pool_shorter_than_top_n": _case_gap_pool_shorter_than_top_n,
+    "gap_not_eligible_row_carries_volume": _case_gap_not_eligible_row_carries_volume,
+    "gap_declaration_absent": _case_gap_declaration_absent,
 }
 
 
@@ -529,6 +778,97 @@ def test_baseline_artifacts_validate() -> None:
         pa.Table.from_pylist([pit_universe_row()], schema=PIT_UNIVERSE_SCHEMA),
     )
     v.validate_outcomes(outcomes(), klines(), _DECISIONS)
+    v.validate_premium_index_gap(gap_audit(), pit_universe(), IN_WINDOW_GAP_SYMBOLS)
+    v.validate_corpus(
+        manifest(),
+        pit_universe=pit_universe(),
+        gap_audit=gap_audit(),
+        klines=klines(),
+        outcomes=outcomes(),
+        decisions=_DECISIONS,
+    )
+
+
+@pytest.mark.unit
+def test_not_eligible_gap_symbol_is_no_impact() -> None:
+    """The other admissible baseline: no kline evidence, so nothing to rank."""
+    v.validate_premium_index_gap(
+        gap_audit([gap_audit_row(status=c.NOT_ELIGIBLE, quote_volume=None)]),
+        pit_universe(),
+        IN_WINDOW_GAP_SYMBOLS,
+    )
+
+
+@pytest.mark.unit
+def test_input_evidence_outranks_every_other_terminal_code() -> None:
+    """MUTANT ④: an artifact bad in two ways reports the input-evidence code.
+
+    The outcome table here is *also* broken (a hand-written return), so a
+    validator that adjudicated in declaration order would report
+    ``RUN_INVALID_OUTCOME_EVIDENCE`` and the operator would go looking at
+    outcome arithmetic for a corpus whose ranking input was never admissible.
+    """
+    bad_outcomes = [dict(r) for r in _OUTCOME_ROWS]
+    bad_outcomes[0]["outcome_abs_log_return_bps"] = 250.0
+
+    with pytest.raises(v.ContractViolation) as excinfo:
+        v.validate_corpus(
+            manifest(),
+            pit_universe=pit_universe(),
+            gap_audit=gap_audit([gap_audit_row(quote_volume="250.0")]),
+            klines=klines(),
+            outcomes=outcomes(bad_outcomes),
+            decisions=_DECISIONS,
+        )
+    assert excinfo.value.code == v.RUN_INVALID_INPUT_EVIDENCE
+
+    # ...and the outcome defect really is there, so the assertion above is
+    # about precedence and not about the second defect being absent.
+    with pytest.raises(v.ContractViolation) as outcome_only:
+        v.validate_outcomes(outcomes(bad_outcomes), klines(), _DECISIONS)
+    assert outcome_only.value.code == v.RUN_INVALID_OUTCOME_EVIDENCE
+
+    assert c.TERMINAL_CODE_PRIORITY[0] == v.RUN_INVALID_INPUT_EVIDENCE
+
+
+@pytest.mark.unit
+def test_gap_validator_offers_no_substitution_path() -> None:
+    """MUTANT ①: there is nowhere for a replacement symbol to come out.
+
+    The validator returns ``None`` and leaves its inputs alone, so a caller
+    cannot obtain a "repaired" pool from it even by accident.
+    """
+    pool = pit_universe()
+    before = pool.to_pylist()
+    assert (
+        v.validate_premium_index_gap(gap_audit(), pool, IN_WINDOW_GAP_SYMBOLS) is None
+    )
+    assert pool.to_pylist() == before
+
+    tree = ast.parse(Path(v.__file__).read_text(encoding="utf-8"))
+    functions = {
+        node.name: node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+
+    entry = functions["validate_premium_index_gap"]
+    assert isinstance(entry.returns, ast.Constant) and entry.returns.value is None
+    returned = [
+        node
+        for node in ast.walk(entry)
+        if isinstance(node, ast.Return) and node.value is not None
+    ]
+    assert not returned, "the gap validator hands something back to its caller"
+
+    # ``_ranked_pool`` computes the true ranking in order to *compare* it with
+    # the declared one.  Handing that recomputed order back would be the
+    # re-ranking itself, one call site away.
+    ranker = functions["_ranked_pool"]
+    handed_back = {
+        node.value.id
+        for node in ast.walk(ranker)
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Name)
+    }
+    assert handed_back == {"pool"}, handed_back
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes the two gaps `DFC-A2-MEASURE` left open (§26차 Job A), as **two additive clauses** on `DFC_V22_RESEARCH_MIN`. ③ (coverage re-measurement) is Job B and is untouched here.

## No frozen literal changed

The corpus id/root, warmup and judgment windows, outcome tail, universe rule (30d · top 3 · canonical-ascending), required/forbidden source material, imputation 0, the arm-label set and every A2-C1..A2-C5 terminal code are byte-identical to the signed version. The whole diff contains **7 deleted lines**, all prose or fixture signatures. Every added rule can only reject corpora the previous text accepted.

The amendment was written *after* the A2-MEASURE verdict was read, which the contract's own closing paragraph is suspicious of — so the document now carries an **Amendment provenance** section stating that in the open, rather than letting it pass unremarked.

## A2-C6 — the lifecycle authority does not exist

`LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE = None`, frozen, and a manifest naming one is refused. Both known proxies are recorded with the question each cannot answer, and neither may be promoted to the evidence kind or have its limitation text softened.

Eligibility is decided by the **kline archive itself** — complete 4h klines with non-zero traded volume across the ranking window. The contract states this as *a different kind of evidence, not an approximation of the missing authority*, and a test forbids equivalence phrasing across the document and the package.

## A2-C7 — the archive gap, and the per-epoch verdict

Per epoch: intersection empty → `NO_IMPACT`; non-empty → `RUN_INVALID_INPUT_EVIDENCE`.

**Silent re-ranking is blocked from both sides.** The declared pool is checked to *be* the ranking it claims (ranks 1..3, no duplicates, order equal to the quote-volume ranking with the contract's tie-break); every gap symbol is accounted for at every epoch or excluded with evidence and a reason from a closed set; and each recorded verdict is **recomputed** against the rank-3 cut rather than accepted. `validate_premium_index_gap` returns nothing, names no replacement, and hands back no pool — checked structurally by AST, including that `_ranked_pool` returns the *declared* pool and never the recomputed order.

`RUN_INVALID_INPUT_EVIDENCE` is adjudicated first (`TERMINAL_CODE_PRIORITY`, enforced by the new `validate_corpus`), so a corpus whose ranking input was never admissible cannot be reported as an outcome-level problem.

## Measurement — `NO_IMPACT`

Public **unsigned GET** only; no signed call, account, order, env change, DB write or backtest. Corpus root never created or touched.

The diff reproduces 986 vs 916 exactly: **70 symbols, one-directional**, and all 70 are accounted for.

| Category | n | Disposition |
|---|---|---|
| dated delivery contracts | 50 | premium index is a perpetual-funding construct; `contractType` is `CURRENT_QUARTER`/`NEXT_QUARTER`, never `PERPETUAL`, and A2-C2 fixes the universe to `usdm_perpetual` |
| `*SETTLED` rename artifacts | 17 | same instrument as the base symbol — **0 conflicting rows across 25 month-comparisons**; 13 have no in-window month at all |
| novelty listings | 3 | first archive month 2025-10 or later, entirely after `JUDGMENT_END` |

No epoch's top-3 was computed — that is the 5,494-epoch sweep §26차 rejected. A strictly stronger bound was measured instead (top-3 ⊆ eligible): an upper bound on each candidate's trailing-30-day quote volume, with unobserved interior days charged at its own maximum daily volume, against a lower bound on the 3rd-highest among five continuously-listed references. **0 of 913 epoch-days** fail the exclusion, under both the same-instrument reading and the paranoid reading that treats each `*SETTLED` path as its own universe member — so the verdict does not rest on the one thing this job could not establish (whether `*SETTLED` was ever an exchange ticker).

## Newly discovered, deliberately left open

The directory-level diff cannot see **month-level** premium-index holes inside symbols that do have a premium directory. Three were hit incidentally (`ICPUSDT` 2022-08, `TLMUSDT` 2022-08 and 2023-02), plus base-directory kline holes in `BNXUSDT`. This is **not** covered by ①'s `NO_IMPACT` and is not closed here. It is mitigated structurally — A2-C7 keys on symbol × epoch evidence presence, not directory presence, so such a hole in a pool member fails closed at freeze time — and it is an input to Job B's sampling, not a result of Job A.

## Verification

- 62 tests pass; 15 new golden rejections plus 4 bespoke tests.
- **Required mutants ①–④ all killed**: silent re-rank (2 tests), `NO_IMPACT` despite a non-empty intersection (3), substitute described as equivalent to an authority (2), inverted terminal-code priority (1).
- **False-green sweep**: all 15 new goldens fail when `expected_code` is flipped *and* when `expected_detail_contains` is flipped, and all 4 bespoke assertions fail when inverted — 34/34 bite.
- `ruff check` + `ruff format --check` over the CI scope (`app/ tests/ research/ scripts/`) clean.
- 3 failures in `tests/research/test_kr_backfill_build_clients.py` are **pre-existing** — reproduced on a clean stashed tree at the same base.

Artifacts: `~/work/herdr-artifacts/dfc-v22-readiness-v1/gap-closure-job-a/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added lifecycle eligibility evidence requirements, including kline completeness and nonzero-volume checks.
  - Added premium-index archive-gap auditing with exclusion reasons, impact verdicts, and terminal-code prioritization.
  - Added support for the A2-C6 and A2-C7 contract clauses and their amendment provenance.

- **Bug Fixes**
  - Invalid lifecycle evidence or ranking-impacting data gaps now fail validation instead of being substituted or silently accepted.

- **Tests**
  - Added comprehensive rejection cases and contract-verification coverage for lifecycle and archive-gap scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->