### PR TITLE
feat(dfc): A2-C8 pre-registered sample readiness protocol (§26차 Job B)

### DIFF
--- a/research/dfc_v22_research_min/contract.py
+++ b/research/dfc_v22_research_min/contract.py
@@ -18,11 +18,13 @@ Clause        Upstream source   Subject
 ``A2-C5``     NW-F6             Authenticity and freeze procedure
 ``A2-C6``     OD-26             Lifecycle authority absence and substitute
 ``A2-C7``     OD-26             Premium-index archive gap and epoch verdict
+``A2-C8``     OD-26 (Job B)     Pre-registered sample readiness protocol
 ============  ================  =========================================
 """
 
 from __future__ import annotations
 
+import hashlib
 from datetime import UTC, datetime
 from types import MappingProxyType
 
@@ -56,11 +58,19 @@ __all__ = [
     "LIFECYCLE_AUTHORITATIVE_PUBLIC_SOURCE",
     "LIFECYCLE_PROXY_LIMITS",
     "NO_IMPACT",
+    "NOT_READY",
     "OUTCOME_HORIZON_BARS",
     "OUTCOME_TAIL_BARS",
     "OUTCOME_UNIT",
+    "READY",
     "REQUIRED_SOURCE_KINDS",
     "RUN_INVALID_INPUT_EVIDENCE",
+    "SAMPLE_COMPLETENESS_DIMENSIONS",
+    "SAMPLE_EPOCHS_PER_QUARTER",
+    "SAMPLE_QUARTER_DEFINITION",
+    "SAMPLE_RULE",
+    "SAMPLE_SEED",
+    "SAMPLE_VERDICTS",
     "TERMINAL_CODE_PRIORITY",
     "UNIVERSE_LOOKBACK_CALENDAR_DAYS",
     "UNIVERSE_RANKING_METRIC",
@@ -69,6 +79,10 @@ __all__ = [
     "VERBATIM_CLAUSES",
     "WARMUP_END",
     "WARMUP_START",
+    "quarter_key",
+    "quarter_windows",
+    "sample_epoch_open_times",
+    "sample_plan",
 ]
 
 
@@ -323,6 +337,116 @@ TERMINAL_CODE_PRIORITY: tuple[str, ...] = (
 )
 
 
+# --- A2-C8 (OD-26 Job B): pre-registered sample readiness protocol -------
+
+#: Registered *before* any sample measurement (Job B).  Nothing here may be
+#: tuned after a completeness result is read; that is exactly the sequencing
+#: violation this clause exists to make impossible, and the enforcement is a
+#: recomputation, not a re-declaration: ``sample_epoch_open_times`` is a pure
+#: function of these three literals plus the quarter key, so a report's
+#: claimed sample either reproduces byte-for-byte or it is rejected.
+SAMPLE_SEED = 26
+SAMPLE_EPOCHS_PER_QUARTER = 12
+#: UTC calendar quarters (Jan-Mar/Apr-Jun/Jul-Sep/Oct-Dec), clipped to
+#: ``[JUDGMENT_START, JUDGMENT_END)``.  This is the standard meaning of
+#: "quarter"; it is not anchored to ``JUDGMENT_START`` and it is not a
+#: window-length division, so the boundaries are checkable against a
+#: calendar without reference to this corpus at all.
+SAMPLE_QUARTER_DEFINITION = "utc_calendar_quarter_clipped_to_judgment_window"
+#: The two dimensions checked for each sampled epoch's top-3 pool.  Outcome
+#: evidence (A2-C4) and lifecycle/gap evidence (A2-C6/A2-C7) are unchanged by
+#: this clause; it narrows *which epochs* get audited, not what "complete"
+#: means for kline/premium-index rows.
+SAMPLE_COMPLETENESS_DIMENSIONS: tuple[str, ...] = ("kline_4h", "premium_index_4h")
+
+#: The sample-readiness verdict is a closed two-way choice.  A1's own
+#: ``UNDETERMINED`` precedent is not reused here: §26차 rules that for this
+#: specific sample-adequacy question there is no third outcome, because the
+#: measurement either found the sample intact or it did not.
+READY = "READY"
+NOT_READY = "NOT_READY"
+SAMPLE_VERDICTS: tuple[str, ...] = (READY, NOT_READY)
+
+#: The frozen rule record a sample-readiness report must reproduce exactly.
+SAMPLE_RULE: MappingProxyType[str, object] = MappingProxyType(
+    {
+        "seed": SAMPLE_SEED,
+        "epochs_per_quarter": SAMPLE_EPOCHS_PER_QUARTER,
+        "quarter_definition": SAMPLE_QUARTER_DEFINITION,
+        "selection_algorithm": (
+            "sha256(f'{seed}:{quarter_key}:{epoch_open_time_ms}') ascending, "
+            "take the first epochs_per_quarter (or all, if fewer exist)"
+        ),
+        "completeness_dimensions": SAMPLE_COMPLETENESS_DIMENSIONS,
+    }
+)
+
+
+def _quarter_start(year: int, quarter: int) -> datetime:
+    return _utc(year, (quarter - 1) * 3 + 1, 1)
+
+
+def quarter_windows() -> tuple[tuple[datetime, datetime], ...]:
+    """UTC calendar-quarter windows intersecting the judgment window.
+
+    Each window is half-open ``[start, end)`` and clipped to
+    ``[JUDGMENT_START, JUDGMENT_END)``; the first and last windows are
+    typically partial quarters. Order is chronological.
+    """
+    out: list[tuple[datetime, datetime]] = []
+    year, quarter = JUDGMENT_START.year, (JUDGMENT_START.month - 1) // 3 + 1
+    while True:
+        start = _quarter_start(year, quarter)
+        year, quarter = (year, quarter + 1) if quarter < 4 else (year + 1, 1)
+        end = _quarter_start(year, quarter)
+        if start >= JUDGMENT_END:
+            break
+        clipped_start = max(start, JUDGMENT_START)
+        clipped_end = min(end, JUDGMENT_END)
+        out.append((clipped_start, clipped_end))
+        if end >= JUDGMENT_END:
+            break
+    return tuple(out)
+
+
+def quarter_key(window: tuple[datetime, datetime]) -> str:
+    """Deterministic label for a quarter window, e.g. ``"2021Q2"``."""
+    start = window[0]
+    return f"{start.year}Q{(start.month - 1) // 3 + 1}"
+
+
+def sample_epoch_open_times(
+    quarter_start: datetime, quarter_end: datetime, key: str
+) -> tuple[int, ...]:
+    """Deterministically select up to ``SAMPLE_EPOCHS_PER_QUARTER`` epochs.
+
+    Every 4h epoch open-time in ``[quarter_start, quarter_end)`` is ranked by
+    ``sha256(f"{SAMPLE_SEED}:{key}:{epoch_ms}")`` and the smallest
+    ``SAMPLE_EPOCHS_PER_QUARTER`` are kept, sorted ascending. SHA-256 is a pure
+    function of these inputs, so the result is stable across processes,
+    machines and Python versions — no PRNG state to pin.
+    """
+    start_ms = int(quarter_start.timestamp() * 1000)
+    end_ms = int(quarter_end.timestamp() * 1000)
+    all_epochs = list(range(start_ms, end_ms, BAR_INTERVAL_MS))
+
+    def _rank(epoch_ms: int) -> str:
+        digest = f"{SAMPLE_SEED}:{key}:{epoch_ms}".encode()
+        return hashlib.sha256(digest).hexdigest()
+
+    chosen = sorted(all_epochs, key=_rank)[:SAMPLE_EPOCHS_PER_QUARTER]
+    return tuple(sorted(chosen))
+
+
+def sample_plan() -> MappingProxyType[str, tuple[int, ...]]:
+    """The full pre-registered sample: quarter key -> chosen epoch open-times."""
+    plan = {}
+    for window in quarter_windows():
+        key = quarter_key(window)
+        plan[key] = sample_epoch_open_times(window[0], window[1], key)
+    return MappingProxyType(plan)
+
+
 CLAUSE_SOURCES: MappingProxyType[str, str] = MappingProxyType(
     {
         "A2-C1": "NW-F2",
@@ -332,5 +456,6 @@ CLAUSE_SOURCES: MappingProxyType[str, str] = MappingProxyType(
         "A2-C5": "NW-F6",
         "A2-C6": "OD-26",
         "A2-C7": "OD-26",
+        "A2-C8": "OD-26-JOB-B",
     }
 )

--- a/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
+++ b/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
@@ -273,6 +273,75 @@ consistently.
 
 ---
 
+## A2-C8 — Pre-registered sample readiness protocol (OD-26 Job B)
+
+> **§26차 Job B** (원문 축자 인용)
+>
+> **Job B (③)**: 측정 **전** 표본 규칙 사전등록 — 판정창 분기별 고정 seed 층화표본 epoch 12 (총 ~108), 각 표본 epoch 의 top-3 후보 심볼 kline+premiumIndex 완전성 검사. **READY = 표본 100% 무결 / 미달 = NOT_READY** (UNDETERMINED 재판정 없음 — 이지선다). 전수 검증은 FREEZE 가 fail-closed 수행 — READY 는 동결 노력 투입 결정일 뿐.
+
+Job A closed two of A2-MEASURE's three open items (lifecycle authority, the
+premium-index archive-directory gap). The third — coverage was only
+spot-checked, not measured across the corpus's actual shape — is what this
+clause closes, without re-litigating the full 5,494-epoch sweep that §26차
+explicitly rejected as duplicating the FREEZE job at no informational gain.
+
+**The literals, frozen before any sample is drawn:**
+
+| Literal | Frozen value |
+|---|---|
+| `seed` | `26` |
+| `epochs_per_quarter` | `12` |
+| `quarter_definition` | UTC calendar quarter (Jan–Mar / Apr–Jun / Jul–Sep / Oct–Dec), clipped to `[JUDGMENT_START, JUDGMENT_END)` |
+| `selection_algorithm` | `sha256(f"{seed}:{quarter_key}:{epoch_open_time_ms}")` ascending, take the first `epochs_per_quarter` (or all, if fewer exist in that quarter) |
+| `completeness_dimensions` | `kline_4h`, `premium_index_4h` |
+| verdict domain | `READY`, `NOT_READY` — closed, two members, no third |
+
+`contract.quarter_windows()` computes the quarter boundaries purely from
+`JUDGMENT_START`/`JUDGMENT_END` — a calendar fact, checkable without reference
+to this corpus. `contract.sample_epoch_open_times()` is a pure function of the
+seed, the quarter key and the quarter boundaries: SHA-256 has no version-
+dependent PRNG state to drift, so the same three inputs reproduce the same
+epoch set on any machine, in any process, indefinitely. This is what makes
+"the sample was drawn before the rule was edited" checkable after the fact,
+rather than merely asserted: `validate_sample_readiness` recomputes
+`contract.sample_plan()` and rejects a report whose `quarters` do not match it
+byte-for-byte (A2-C8, `RUN_INVALID_CORPUS_LITERALS`).
+
+**Completeness, defined.** For a sampled epoch's top-3 candidate pool (decided
+by the same universe rule as A2-C2/A2-C7 — trailing 30-calendar-day quote
+volume, ties broken canonical-symbol-ascending, over the then-eligible
+`usdm_perpetual` universe under the A2-C6 substitute eligibility evidence), a
+row is complete when both:
+
+1. `kline_4h`: a schema-conformant `usdm_kline_4h` bar exists for that symbol
+   at the epoch's `open_time`, with a matching `close_time` and no null field.
+2. `premium_index_4h`: a schema-conformant `premiumIndexKlines` bar exists for
+   that symbol at the same `open_time`, carrying `premium_index_close`.
+
+A gap symbol (A2-C7) landing inside a sampled epoch's top-3 is **not** scored
+as an incomplete row and is **not** silently re-ranked around: the epoch is
+recorded in `run_invalid_epochs` and disqualifies `READY` on its own, exactly
+as A2-C7 already rules for the full corpus.
+
+**The verdict rule.** `READY` iff every row in the sample reports both
+dimensions complete *and* `run_invalid_epochs` is empty; otherwise `NOT_READY`,
+with the failing epoch/symbol/dimension named. There is no `UNDETERMINED` exit
+from this specific protocol — §26차 rules it a two-way choice, and one broken
+row anywhere in the sample is enough for `NOT_READY`.
+
+**`READY` does not mean the whole corpus is clean.** It means the stratified
+sample the frozen rule drew is intact — a decision to invest in building the
+frozen corpus, not a claim that every one of the ~5,494 epochs will validate.
+The FREEZE job still validates the full corpus, fail-closed, independently of
+what this sample found.
+
+**Enforced as.** `validation.validate_sample_readiness` requires the report's
+`sample_rule` to equal `contract.SAMPLE_RULE` exactly, its `quarters` to equal
+`contract.sample_plan()` exactly, every row's `epoch_open_time` to be a member
+of that plan, the declared `verdict` to be one of `READY`/`NOT_READY`, and that
+declared verdict to equal the value recomputed from the row evidence and
+`run_invalid_epochs` — never accepted merely because it was declared.
+
 ## Terminal codes
 
 Adjudicated in this order — `contract.TERMINAL_CODE_PRIORITY`, enforced by
@@ -285,7 +354,7 @@ the cause.
 |---|---|
 | `RUN_INVALID_INPUT_EVIDENCE` | lifecycle authority claimed, proxy promoted to evidence kind, gap symbol unaccounted for, gap symbol inside or outranking the candidate pool, or a recorded epoch verdict the evidence does not support (A2-C6 / A2-C7) |
 | `RUN_INVALID_SCOPE_SEPARATION` | A1 (or anything else) declared as the DFC prerequisite (A2-C1) |
-| `RUN_INVALID_CORPUS_LITERALS` | a frozen id, path, window, universe rule or imputation literal was changed (A2-C2) |
+| `RUN_INVALID_CORPUS_LITERALS` | a frozen id, path, window, universe rule or imputation literal was changed (A2-C2), or a sample-readiness report's rule/epochs/verdict do not reproduce the frozen protocol (A2-C8) |
 | `RUN_INVALID_FORBIDDEN_SOURCE` | funding / open interest / mark / index material present (A2-C3) |
 | `RUN_INVALID_TABLE_SCHEMA` | canonical table column set, order, type or nullability violated (A2-C3) |
 | `RUN_INVALID_MANIFEST_SCHEMA` | manifest key set wrong, or required source kind / canonical table absent |
@@ -331,3 +400,24 @@ timing the paragraph above is suspicious of, so the record is:
 
 Should a *literal* ever need to change, the paragraph above still governs: new
 ID, new signature.
+
+## Amendment provenance (A2-C8)
+
+This amendment is the opposite timing from A2-C6/A2-C7, and the record says so:
+
+- **Written before the sample was drawn.** A2-C8 is committed to this document
+  and to `contract.py` before `DFC-A2-REMEASURE` (Job B) makes its first public
+  GET call. The job's own report is required to state the pre-registration
+  commit SHA and the measurement start time, in that order, so the sequencing
+  is checkable after the fact rather than merely asserted.
+- **No frozen literal changed.** Every A2-C1..A2-C7 literal, terminal code and
+  table is unchanged. The amendment is additive: one clause, one closed
+  verdict domain, three frozen sampling literals, and one validator
+  (`validate_sample_readiness`) that reads a report handed to it — it collects
+  nothing and repairs nothing.
+- **It cannot be loosened by what it finds.** The seed, the quarter
+  definition and the epochs-per-quarter count are fixed here, before
+  measurement; `validate_sample_readiness` recomputes the sample and the
+  verdict from the frozen rule and rejects any report that disagrees, so
+  neither a wider sample nor a softer verdict rule can be substituted after
+  the fact without failing this validator.

--- a/research/dfc_v22_research_min/nw_verbatim.py
+++ b/research/dfc_v22_research_min/nw_verbatim.py
@@ -46,12 +46,19 @@ NW_F6_VERBATIM = "**“모든 원본 object/response에 endpoint·query·retriev
 OD_26_JOB_A_TOPIC = "A2 공백 ②+① 폐쇄 경로"
 OD_26_JOB_A_VERBATIM = "**Job A (②+①)**: ②contract lifecycle 권위 소스 = 「없다」를 계약에 명시, 대체 증거 정의 — eligibility = kline 아카이브 자체(랭킹 창 내 완전한 4h kline + 비zero 거래량 = 거래가능의 직접 증거), 프록시 한계 명기. ①premiumIndexKlines ~70 심볼 격차 전수 diff(read-only) → epoch별 top-3 후보 pool 과 교집합: 0 이면 `NO_IMPACT` 리터럴 종결, 비어있지 않으면 해당 epoch = `RUN_INVALID_INPUT_EVIDENCE` (조용한 재랭킹 금지) 를 계약에 추가."
 
+#: §26차 확정 문단의 두 번째 항목, Job B(③).  Job A와 같은 이유로 이 문서의 소스가
+#: 아니라 바인딩 레코드 자체가 소스이고, 하드랩된 원문 두 줄을 공백 하나로 합치고
+#: 목록 마커만 제거했을 뿐 그 외에는 손대지 않았다.
+OD_26_JOB_B_TOPIC = "A2 공백 ③ 폐쇄 경로(사전등록 표본 프로토콜)"
+OD_26_JOB_B_VERBATIM = "**Job B (③)**: 측정 **전** 표본 규칙 사전등록 — 판정창 분기별 고정 seed 층화표본 epoch 12 (총 ~108), 각 표본 epoch 의 top-3 후보 심볼 kline+premiumIndex 완전성 검사. **READY = 표본 100% 무결 / 미달 = NOT_READY** (UNDETERMINED 재판정 없음 — 이지선다). 전수 검증은 FREEZE 가 fail-closed 수행 — READY 는 동결 노력 투입 결정일 뿐."
+
 VERBATIM_CLAUSES: dict[str, str] = {
     "NW-F2": NW_F2_VERBATIM,
     "NW-F4": NW_F4_VERBATIM,
     "NW-F5": NW_F5_VERBATIM,
     "NW-F6": NW_F6_VERBATIM,
     "OD-26": OD_26_JOB_A_VERBATIM,
+    "OD-26-JOB-B": OD_26_JOB_B_VERBATIM,
 }
 
 VERBATIM_TOPICS: dict[str, str] = {
@@ -60,4 +67,5 @@ VERBATIM_TOPICS: dict[str, str] = {
     "NW-F5": NW_F5_TOPIC,
     "NW-F6": NW_F6_TOPIC,
     "OD-26": OD_26_JOB_A_TOPIC,
+    "OD-26-JOB-B": OD_26_JOB_B_TOPIC,
 }

--- a/research/dfc_v22_research_min/schema.py
+++ b/research/dfc_v22_research_min/schema.py
@@ -32,6 +32,8 @@ __all__ = [
     "PREMIUM_INDEX_4H_SCHEMA",
     "PREMIUM_INDEX_GAP_AUDIT_SCHEMA",
     "RAW_KLINE_FIELD_NAMES",
+    "SAMPLE_REPORT_REQUIRED_KEYS",
+    "SAMPLE_ROW_REQUIRED_KEYS",
 ]
 
 _TS = pa.timestamp("us", tz="UTC")
@@ -234,4 +236,33 @@ MANIFEST_TABLE_REQUIRED_KEYS: tuple[str, ...] = (
     "sha256",
     "row_count",
     "byte_size",
+)
+
+#: A2-C8 (Job B).  One row per (sampled epoch, ranked candidate symbol). This
+#: is a *readiness report*, not a corpus table — it is judged before any
+#: corpus manifest exists, so it carries no ``CANONICAL_TABLES`` entry.
+SAMPLE_ROW_REQUIRED_KEYS: tuple[str, ...] = (
+    "quarter",
+    "epoch_open_time",
+    "rank",
+    "symbol",
+    "kline_complete",
+    "premium_index_complete",
+    "missing_detail",
+    "provenance_sha256",
+)
+
+#: Top-level readiness report a Job-B measurement must produce. ``sample_rule``
+#: is compared against ``contract.SAMPLE_RULE`` verbatim; ``quarters`` is
+#: compared against ``contract.sample_plan()`` verbatim — both recomputed, not
+#: merely schema-checked, so a report cannot claim a sample it did not draw.
+SAMPLE_REPORT_REQUIRED_KEYS: tuple[str, ...] = (
+    "contract_id",
+    "contract_doc_sha256",
+    "sample_rule",
+    "quarters",
+    "rows",
+    "run_invalid_epochs",
+    "verdict",
+    "measured_at",
 )

--- a/research/dfc_v22_research_min/validation.py
+++ b/research/dfc_v22_research_min/validation.py
@@ -30,6 +30,8 @@ from .schema import (
     MANIFEST_REQUIRED_KEYS,
     MANIFEST_SOURCE_REQUIRED_KEYS,
     MANIFEST_TABLE_REQUIRED_KEYS,
+    SAMPLE_REPORT_REQUIRED_KEYS,
+    SAMPLE_ROW_REQUIRED_KEYS,
 )
 
 __all__ = [
@@ -48,6 +50,7 @@ __all__ = [
     "validate_manifest",
     "validate_outcomes",
     "validate_premium_index_gap",
+    "validate_sample_readiness",
     "validate_table",
 ]
 
@@ -1133,4 +1136,162 @@ def _validate_admissibility(admissibility: Mapping[str, Any]) -> None:
             "A2-C5",
             "the independent verifier compares exactly "
             f"{list(c.ADMISSIBILITY_COMPARISON_KEYS)}, got {list(keys)}",
+        )
+
+
+# --- A2-C8 (OD-26 Job B): pre-registered sample readiness protocol --------
+
+
+def validate_sample_readiness(report: Mapping[str, Any]) -> None:
+    """Validate a Job-B sample-readiness report against the frozen A2-C8 rule.
+
+    The sample is not merely schema-checked: ``sample_rule`` and ``quarters``
+    are recomputed from :mod:`contract` and compared for equality, so a report
+    cannot claim a different rule or a hand-picked epoch set and still pass.
+    The verdict is likewise recomputed from the row-level completeness flags
+    and the reported ``run_invalid_epochs``, and it must be one of the two
+    closed outcomes — ``UNDETERMINED`` is not a re-judgeable third option here.
+
+    Raises:
+        ContractViolation: With ``RUN_INVALID_MANIFEST_SCHEMA`` for structural
+            problems or a verdict outside the closed domain, and
+            ``RUN_INVALID_CORPUS_LITERALS`` when the sample rule, the drawn
+            epochs, or the recomputed verdict do not match what the frozen
+            protocol requires.
+    """
+    missing = [k for k in SAMPLE_REPORT_REQUIRED_KEYS if k not in report]
+    if missing:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C8",
+            f"sample readiness report is missing required key(s): {missing}",
+        )
+    unknown = [k for k in report if k not in SAMPLE_REPORT_REQUIRED_KEYS]
+    if unknown:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C8",
+            f"sample readiness report carries unknown key(s): {sorted(unknown)}",
+        )
+
+    if report["contract_id"] != c.CONTRACT_ID:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C8",
+            f"contract_id must be {c.CONTRACT_ID!r}, got {report['contract_id']!r}",
+        )
+
+    declared_rule = dict(report["sample_rule"])
+    frozen_rule = dict(c.SAMPLE_RULE)
+    if declared_rule != frozen_rule:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C8",
+            f"sample_rule must be exactly {frozen_rule}, got {declared_rule}; "
+            "the sample rule is pre-registered and may not be tuned after "
+            "measurement results are read",
+        )
+
+    expected_plan = {k: list(v) for k, v in c.sample_plan().items()}
+    declared_plan = {k: list(v) for k, v in report["quarters"].items()}
+    if declared_plan != expected_plan:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C8",
+            "declared sample epochs do not reproduce "
+            "contract.sample_plan(); the extraction algorithm is a pure "
+            "function of the frozen seed and quarter boundaries, so any "
+            "mismatch means the sample was drawn, then edited, or drawn "
+            "differently from the registered algorithm",
+        )
+
+    known_epochs: set[int] = set()
+    for epochs in expected_plan.values():
+        known_epochs.update(epochs)
+
+    rows = report["rows"]
+    if not rows:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C8",
+            "sample readiness report carries no rows",
+        )
+
+    seen_keys: set[tuple[int, int]] = set()
+    all_complete = True
+    for index, row in enumerate(rows):
+        label = f"rows[{index}]"
+        row_missing = [k for k in SAMPLE_ROW_REQUIRED_KEYS if k not in row]
+        if row_missing:
+            _fail(
+                RUN_INVALID_MANIFEST_SCHEMA,
+                "A2-C8",
+                f"{label}: missing key(s) {row_missing}",
+            )
+        epoch = row["epoch_open_time"]
+        if epoch not in known_epochs:
+            _fail(
+                RUN_INVALID_CORPUS_LITERALS,
+                "A2-C8",
+                f"{label}: epoch_open_time {epoch} is not part of the "
+                "pre-registered sample; rows may only cover drawn epochs",
+            )
+        rank = row["rank"]
+        if rank not in (1, 2, 3):
+            _fail(
+                RUN_INVALID_MANIFEST_SCHEMA,
+                "A2-C8",
+                f"{label}: rank must be 1, 2 or 3 (top-{c.UNIVERSE_TOP_N}), "
+                f"got {rank!r}",
+            )
+        key = (epoch, rank)
+        if key in seen_keys:
+            _fail(
+                RUN_INVALID_MANIFEST_SCHEMA,
+                "A2-C8",
+                f"{label}: duplicate row for epoch {epoch} rank {rank}",
+            )
+        seen_keys.add(key)
+        if not row["provenance_sha256"]:
+            _fail(
+                RUN_INVALID_AUTHENTICITY_EVIDENCE,
+                "A2-C5",
+                f"{label}: provenance_sha256 is empty; every completeness "
+                "check must be traceable to the object it was decided from",
+            )
+        if not (row["kline_complete"] and row["premium_index_complete"]):
+            all_complete = False
+
+    invalid_epochs = tuple(report["run_invalid_epochs"])
+    for epoch in invalid_epochs:
+        if epoch not in known_epochs:
+            _fail(
+                RUN_INVALID_CORPUS_LITERALS,
+                "A2-C8",
+                f"run_invalid_epochs carries {epoch}, which is not part of "
+                "the pre-registered sample",
+            )
+
+    recomputed_verdict = (
+        c.READY if (all_complete and not invalid_epochs) else c.NOT_READY
+    )
+
+    verdict = report["verdict"]
+    if verdict not in c.SAMPLE_VERDICTS:
+        _fail(
+            RUN_INVALID_MANIFEST_SCHEMA,
+            "A2-C8",
+            f"verdict must be one of {list(c.SAMPLE_VERDICTS)}, got "
+            f"{verdict!r}; §26차 closed this to a two-way choice — "
+            "UNDETERMINED is not a re-judgeable outcome of this protocol",
+        )
+    if verdict != recomputed_verdict:
+        _fail(
+            RUN_INVALID_CORPUS_LITERALS,
+            "A2-C8",
+            f"declared verdict {verdict!r} does not match the recomputed "
+            f"verdict {recomputed_verdict!r} (all_rows_complete="
+            f"{all_complete}, run_invalid_epochs={list(invalid_epochs)}); "
+            "the verdict is derived from the row evidence, never accepted "
+            "as declared",
         )

--- a/tests/research/dfc_v22_research_min/golden/violation_cases.json
+++ b/tests/research/dfc_v22_research_min/golden/violation_cases.json
@@ -272,6 +272,30 @@
       "clause": "A2-C3",
       "expected_code": "RUN_INVALID_MANIFEST_SCHEMA",
       "expected_detail_contains": "required source material absent"
+    },
+    {
+      "case_id": "sample_verdict_undetermined",
+      "clause": "A2-C8",
+      "expected_code": "RUN_INVALID_MANIFEST_SCHEMA",
+      "expected_detail_contains": "UNDETERMINED is not a re-judgeable"
+    },
+    {
+      "case_id": "sample_rule_tampered",
+      "clause": "A2-C8",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "pre-registered and may not be tuned"
+    },
+    {
+      "case_id": "sample_verdict_not_recomputed",
+      "clause": "A2-C8",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "does not match the recomputed verdict"
+    },
+    {
+      "case_id": "sample_epoch_outside_registered_plan",
+      "clause": "A2-C8",
+      "expected_code": "RUN_INVALID_CORPUS_LITERALS",
+      "expected_detail_contains": "is not part of the pre-registered sample"
     }
   ]
 }

--- a/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
+++ b/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
@@ -62,6 +62,7 @@ def test_canonical_source_is_pinned() -> None:
         "NW-F5",
         "NW-F6",
         "OD-26",
+        "OD-26-JOB-B",
     }
     assert "§26차" in nw_verbatim.BINDING_RECORD_AMENDMENT
 

--- a/tests/research/dfc_v22_research_min/test_a2_golden.py
+++ b/tests/research/dfc_v22_research_min/test_a2_golden.py
@@ -713,6 +713,64 @@ def _case_gap_declaration_absent() -> None:
     v.validate_manifest(base)
 
 
+# --------------------------------------------------------------------------
+# A2-C8: pre-registered sample readiness protocol
+# --------------------------------------------------------------------------
+
+
+def _sample_report(**overrides: Any) -> dict[str, Any]:
+    plan = c.sample_plan()
+    first_quarter = next(iter(plan))
+    first_epoch = plan[first_quarter][0]
+    base: dict[str, Any] = {
+        "contract_id": c.CONTRACT_ID,
+        "contract_doc_sha256": "0" * 64,
+        "sample_rule": dict(c.SAMPLE_RULE),
+        "quarters": {k: list(v_) for k, v_ in plan.items()},
+        "rows": [
+            {
+                "quarter": first_quarter,
+                "epoch_open_time": first_epoch,
+                "rank": 1,
+                "symbol": "BTCUSDT",
+                "kline_complete": True,
+                "premium_index_complete": True,
+                "missing_detail": None,
+                "provenance_sha256": "a" * 64,
+            }
+        ],
+        "run_invalid_epochs": [],
+        "verdict": c.READY,
+        "measured_at": "2026-08-10T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _case_sample_verdict_undetermined() -> None:
+    v.validate_sample_readiness(_sample_report(verdict="UNDETERMINED"))
+
+
+def _case_sample_rule_tampered() -> None:
+    tampered = dict(c.SAMPLE_RULE)
+    tampered["seed"] = 99
+    v.validate_sample_readiness(_sample_report(sample_rule=tampered))
+
+
+def _case_sample_verdict_not_recomputed() -> None:
+    report = _sample_report()
+    report["rows"][0]["kline_complete"] = False
+    report["rows"][0]["missing_detail"] = "kline absent"
+    # verdict is left as READY even though the only row is incomplete.
+    v.validate_sample_readiness(report)
+
+
+def _case_sample_epoch_outside_registered_plan() -> None:
+    report = _sample_report()
+    report["rows"][0]["epoch_open_time"] = report["rows"][0]["epoch_open_time"] + 1
+    v.validate_sample_readiness(report)
+
+
 CASE_BUILDERS: dict[str, Callable[[], None]] = {
     "outcomes_free_bool_column": _case_outcomes_free_bool_column,
     "outcomes_free_price_column": _case_outcomes_free_price_column,
@@ -773,6 +831,10 @@ CASE_BUILDERS: dict[str, Callable[[], None]] = {
     "gap_pool_shorter_than_top_n": _case_gap_pool_shorter_than_top_n,
     "gap_not_eligible_row_carries_volume": _case_gap_not_eligible_row_carries_volume,
     "gap_declaration_absent": _case_gap_declaration_absent,
+    "sample_verdict_undetermined": _case_sample_verdict_undetermined,
+    "sample_rule_tampered": _case_sample_rule_tampered,
+    "sample_verdict_not_recomputed": _case_sample_verdict_not_recomputed,
+    "sample_epoch_outside_registered_plan": _case_sample_epoch_outside_registered_plan,
 }
 
 


### PR DESCRIPTION
## Summary
- Pre-registers the DFC-A2-REMEASURE (Job B) stratified sample readiness protocol in `DFC_V22_RESEARCH_MIN` **before** any sample measurement: fixed seed `26`, UTC calendar quarters clipped to the judgment window (10 quarters, 120 total sample epochs), a pure SHA-256 epoch-selection algorithm (`contract.sample_epoch_open_times`/`sample_plan`), a kline+premium-index completeness definition, and a closed `READY`/`NOT_READY` verdict domain (no `UNDETERMINED` re-judgement, per §26차).
- `validation.validate_sample_readiness` recomputes the sample rule, the drawn epochs, and the verdict from the frozen literals and row evidence — a report cannot claim a rule, sample, or verdict it did not actually reproduce.
- No frozen A2-C1..A2-C7 literal changed; this is additive (one clause, one validator, golden coverage).

## Measurement (separate from this PR's diff, output in `~/work/herdr-artifacts/dfc-v22-readiness-v1/job-b-remeasure-20260810/`)
Ran the pre-registered protocol against Binance's public unsigned REST (765 GETs, 0 errors): 357/360 sampled top-3 rows are complete; 3 rows (all `LUNAUSDT`, all 2022Q2, rank 3) have no kline evidence at their signal epoch — confirmed via both REST (`[]`) and the S3 archive (kline archive for `LUNAUSDT` ends 2022-05-13, while its premiumIndexKlines archive continues through 2022-07). **Verdict: `NOT_READY`**, per A2-C8's 100%-intact bar. Full report: `VERDICT.md` in that directory.

## Test plan
- [x] `uv run pytest tests/research/dfc_v22_research_min/ -q` — 67 passed
- [x] `uv run ruff check research/dfc_v22_research_min tests/research/dfc_v22_research_min` — clean
- [x] `validate_sample_readiness` self-check against the actual measurement report — accepted as internally consistent, recomputed verdict matches declared `NOT_READY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a pre-registered sample-readiness protocol with quarterly sampling and up to 12 deterministic four-hour epochs per quarter.
  - Added readiness reporting with `READY` or `NOT_READY` outcomes based on sampled data completeness and validity.
  - Added provenance, completeness, invalid-epoch, and measurement-time details to readiness reports.
  - Added the Job B contract text and associated reporting requirements.

- **Validation**
  - Added comprehensive checks for sampling plans, report structure, authenticity, and verdict consistency.
  - Added rejection coverage for tampered rules, invalid epochs, and stale or indeterminate verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->