### PR TITLE
fix(b0x): bind KR mock read client to the VTS account (EGW02005)

### DIFF
--- a/app/services/kis_mock_settings_view.py
+++ b/app/services/kis_mock_settings_view.py
@@ -1,0 +1,87 @@
+"""Credential/host view that binds a KIS client to the **mock (VTS)** account.
+
+Why this is a module of its own, rather than a local class in the one place
+that needs it
+--------------------------------------------------------------------------
+``BaseKISClient`` reads its host, credentials and token from
+``self._settings`` under the *live* field names (``kis_app_key``,
+``kis_base_url``, ``kis_account_no``, ``kis_access_token``). A subclass that
+wants to talk to the KIS mock (VTS) account must therefore override
+``_settings`` with a view that maps those names onto the ``kis_mock_*``
+fields. Two such views already exist —
+``app.services.brokers.kis.client._KISSettingsView`` (used by
+``KISClient(is_mock=True)``) and
+``app.services.invest_home_readers._KISMockSettingsProxy`` — and a third
+consumer, the B0-X KR lane, cannot reuse either:
+
+* ``app.services.brokers.kis.client`` is on that lane's AST denylist
+  (``tests/scripts/b0x/kr/test_no_live_kis_order_imports.py``) because it
+  imports the order clients at module scope, and
+* the lane's own AST guard (``tests/scripts/b0x/kr/
+  test_submission_ast_guard.py``, prohibition 3) rejects ``getattr()`` with a
+  non-literal attribute name — which is exactly how the delegating
+  ``__getattr__`` in this idiom is written. The guard is doing its job; the
+  idiom simply cannot live inside ``scripts/b0x/kr/**``.
+
+So the view lives here instead. This module is deliberately placed *outside*
+``app.services.brokers.kis.`` — it holds no order surface, only a credential
+mapping — which is also why the lane may import it without the order-surface
+allowlist being widened.
+
+What this class does **not** do: fall back to live credentials. Every mapped
+property returns the mock field and nothing else. An unset mock credential
+surfaces as an empty value that the caller's own configuration gate rejects;
+it never silently degrades into a live-account call. That failure mode is not
+hypothetical — the bug this module was written to fix was a KIS mock lane
+whose client inherited ``BaseKISClient``'s live defaults and sent a mock
+``tr_id`` to the live host.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["KISMockSettingsView"]
+
+
+class KISMockSettingsView:
+    """Expose the ``kis_mock_*`` settings under the live KIS field names.
+
+    Anything not explicitly mapped below is delegated unchanged to the wrapped
+    settings object (rate-limit tuning, timeouts, and similar account-neutral
+    configuration).
+    """
+
+    def __init__(self, real_settings: Any) -> None:
+        self._real = real_settings
+
+    # -- account-bound fields: mock only, never a live fallback -------------
+
+    @property
+    def kis_app_key(self) -> str:
+        return str(self._real.kis_mock_app_key or "")
+
+    @property
+    def kis_app_secret(self) -> str:
+        return str(self._real.kis_mock_app_secret or "")
+
+    @property
+    def kis_account_no(self) -> str | None:
+        return self._real.kis_mock_account_no
+
+    @property
+    def kis_base_url(self) -> str:
+        return str(self._real.kis_mock_base_url or "")
+
+    @property
+    def kis_access_token(self) -> str | None:
+        return self._real.kis_mock_access_token
+
+    @kis_access_token.setter
+    def kis_access_token(self, value: str | None) -> None:
+        self._real.kis_mock_access_token = value
+
+    # -- everything else is account-neutral --------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)

--- a/docs/runbooks/b0x-kr-cycle.md
+++ b/docs/runbooks/b0x-kr-cycle.md
@@ -108,12 +108,52 @@ uv run python -m scripts.run_b0x_kr_cycle --confirm
 | `cycle.py` | **재사용 + export.** `_base_record`/`_render_report` 를 `base_record`/`render_cycle_report` 로 공개해 KR 사이클이 재사용한다(이름만 바꿈, crypto 두 레인 동작 불변 — `tests/scripts/b0x/test_cycle.py` 로 확인). |
 | `scripts/b0x/kr/mock.py`, `scripts/b0x/kr/cycle.py` | **신규.** KIS 계좌 read facade·tick 정렬·사이징·RTH 게이트·사이클 골격. |
 
+## 5.1 읽기 클라이언트의 계좌 바인딩 — 2026-08-10 `EGW02005` 수리
+
+🔴 **`is_mock=True` 는 계좌를 바꾸지 않는다. TR id 하나만 고른다.** host·app key/secret·
+계좌번호·OAuth 토큰은 전부 `BaseKISClient` 가 `self._settings` 의 **live** 필드명에서
+읽으며, 기본값은 live 다. 초기 `ReadOnlyKISMockDomesticClient` 는 `AccountClient` 에
+`is_mock=True` 만 넘기고 나머지를 상속했고, 그 결과 **모의 TR(`VTTC8434R`)을 live 호스트에
+live 자격증명으로** 보냈다 → `EGW02005 실전투자 TR 이 아닙니다`.
+
+**전날(일요일) acceptance 통과는 이 경로가 정상이라는 증거가 아니었다.** RTH 게이트가 계좌
+I/O **이전에** zero-order 로 끝나 이 호출에 도달한 적이 없었을 뿐이고, 개장일 첫 사이클
+(2026-08-10 09:05 KST)에서 처음 도달하자마자 크래시했다.
+
+수리 = `ReadOnlyKISMockDomesticClient` 에 실제 바인딩 4종을 건다(전부 fail-closed):
+
+| 오버라이드 | 효과 |
+|---|---|
+| `_settings` → `KISMockSettingsView` | mock app key/secret·계좌번호·토큰 슬롯. **live 폴백 없음** |
+| `_kis_url` → `_assert_mock_host` | 만드는 **모든** URL(잔고 read + `/oauth2/token`)의 netloc 를 `openapivts.koreainvestment.com:29443` 로 재검증. 아니면 소켓 열기 전에 `KrMockHostViolation` |
+| `_token_manager` → `kis_mock` 네임스페이스 | mock 토큰이 live 토큰 캐시에 섞이지 않는다 |
+| `_is_mock_client = True` | ROB-892 VTS 분산 admit gate 가 이 read 에도 걸린다 |
+
+🔵 **보장 범위 — 정직하게.** 이제 **읽기 클라이언트에 한해** Binance Demo 식 host-allowlist
+가 생겼다(§6 첫 문단의 "KIS 에는 없다"는 이 범위에서 더는 사실이 아니다). **제출 경로는
+여전히 아니다** — `KisMockBroker` 는 `is_mock=True` 리터럴 고정 + AST 가드(§6.5)로 지켜지며
+transport 계층 host 검증은 없다. 두 표면의 보장 방식이 다르다는 점을 섞지 말 것.
+
+**현금 조회 불가는 0 이 아니다.** `AccountClient` 는 없는 현금 필드를 `0.0` 으로 강제하므로
+그 값만으로는 "빈 계좌"와 "응답이 아무것도 안 알려줌"을 구분할 수 없다. `read_fresh_truth`
+는 브로커가 echo 한 raw 필드 **존재 여부**로 둘을 가르고, 하나도 없으면
+`KrMockCashUnreadable` 로 fail-closed 한다(confirm 경로에서는
+`preflight_not_clean`/`account_truth_unavailable` zero-order). NAV = cash + Σ 평가액 이고
+§4 kill 이 **NAV 비율**이라, 조작된 `cash=0` 은 과소보고가 아니라 **kill 임계 자체를
+움직인다** — NAV·cash 는 추정하지 않는다.
+
+🔵 실측(2026-08-10 10:32 KST, KRX RTH 내): mock 브로커는 `dnca_tot_amt` **하나만** echo 하고
+`stck_cash_ord_psbl_amt` 는 응답에 없다. 그래서 존재 검사는 세 필드(`stck_cash_ord_psbl_amt`
+/`ord_psbl_cash`/`dnca_tot_amt`) 전부를 본다 — 주문가능현금 하나만 봤다면 정상 계좌를
+"조회 불가"로 오판했을 것이다.
+
 ## 6. 제출 배선 — `KisMockBroker` (계약 v1.3 ③)
 
 Binance 사이드카는 `demo-api.binance.com` 에만 닿을 수 있는 **전용 클라이언트**를 재사용해
-"mock 임을 코드 구조가 보장"한다. KIS 에는 그런 host-allowlisted 전용 클라이언트가 없다 —
-대신 계약 v1.3 ③ 이 지정한 통합점은 `app.services.brokers.kis.mock_scalping_exec.
-adapters.KisMockBroker`(ROB-321/341): `_place_order_impl(is_mock=True, ...)` 이 전
+"mock 임을 코드 구조가 보장"한다. KIS **제출** 경로에는 그런 host-allowlisted 전용
+클라이언트가 없다(읽기 경로는 §5.1 에서 생겼다) — 대신 계약 v1.3 ③ 이 지정한 통합점은
+`app.services.brokers.kis.mock_scalping_exec.adapters.KisMockBroker`(ROB-321/341):
+`_place_order_impl(is_mock=True, ...)` 이 전
 호출부에 **리터럴로 고정**된(인자 아님) 기존 리뷰·운영된 mock 전용 표면. 재구현하지 않고
 그대로 재사용한다 — `scripts.b0x.kr.mock.build_kis_mock_broker`/`submit_planned_order`
 가 얇은 배선 레이어일 뿐, `KisMockBroker` 자체는 서브클래싱도 몽키패치도 하지 않는다.

--- a/scripts/b0x/kr/mock.py
+++ b/scripts/b0x/kr/mock.py
@@ -16,11 +16,20 @@ What is reused, unchanged
   already established for the (unrelated) live-account read this module's
   sibling table generator does: compose only ``AccountClient`` against
   ``BaseKISClient``, never import ``app.services.brokers.kis.client.KISClient``
-  (which unconditionally imports the order clients at module scope). This
-  module's version reads ``is_mock=True`` instead of ``False`` — everything
-  else about the pattern, including its documented caveat that the KIS
-  package's own ``__init__.py`` still transitively loads those classes
-  regardless, is unchanged.
+  (which unconditionally imports the order clients at module scope) — including
+  its documented caveat that the KIS package's own ``__init__.py`` still
+  transitively loads those classes regardless.
+
+  🔴 What is **not** reused from that sibling is its account binding, and this
+  is the correction of a defect that reached production. Reading
+  ``is_mock=True`` where the table generator reads ``False`` is *not* the whole
+  difference: ``is_mock`` selects the **TR id only**, while host, credentials,
+  account number and token come from ``BaseKISClient``'s live defaults. A
+  client that flips only ``is_mock`` therefore sends a **mock TR to the live
+  host** — which KIS rejects with ``EGW02005 실전투자 TR 이 아닙니다``, exactly
+  what crashed the first KR cycle to reach account I/O inside KRX RTH
+  (2026-08-10). ``ReadOnlyKISMockDomesticClient`` below carries the four
+  overrides that actually bind it to the mock (VTS) account, each fail-closed.
 * ``app.mcp_server.tick_size.get_tick_size_kr`` — the *runtime* order-path
   tick rule (not a frozen research copy), same source ``kr_tick.py`` binds
   for the table generator, per that module's own documented rationale.
@@ -109,14 +118,17 @@ import os
 from dataclasses import dataclass
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
 from typing import Any, Protocol, cast
+from urllib.parse import urlsplit
 
 from app.core.config import settings, validate_kis_mock_config
 from app.mcp_server.tick_size import get_tick_size_kr
 from app.services.brokers.kis.account import AccountClient
-from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.base import _KIS_MOCK_REST_HOSTS, BaseKISClient
 from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockBroker
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 from app.services.brokers.kis.protocols import KISClientProtocol
+from app.services.kis_mock_settings_view import KISMockSettingsView
+from app.services.redis_token_manager import get_kis_mock_token_manager
 from scripts.b0x.broker_truth import (
     BrokerTruth,
     PendingUnreadable,
@@ -199,6 +211,34 @@ class KrLaneDisabled(RuntimeError):
     """
 
 
+class KrMockHostViolation(RuntimeError):
+    """A dispatch was about to leave for a host that is not the KIS mock (VTS).
+
+    Raised **before** the socket is opened. This lane's contract is "live 계좌
+    접촉 0"; a host that is not ``openapivts.koreainvestment.com:29443`` is a
+    configuration failure that must stop the cycle, never something to paper
+    over with a default host.
+    """
+
+
+class KrMockCashUnreadable(RuntimeError):
+    """The balance response carried no readable cash figure.
+
+    🔴 Deliberately distinct from "cash is zero". ``AccountClient.
+    inquire_domestic_cash_balance`` coerces missing/blank cash fields to
+    ``0.0`` for its live callers, so at this boundary an *absent* balance and a
+    genuinely *empty* account are indistinguishable by value alone — they are
+    told apart by whether the broker echoed the field at all.
+
+    Treating the first as ``0`` would be the worst available failure mode on
+    this lane: NAV is ``cash + Σ evlu_amt`` and the §4 envelope kill is
+    evaluated as a **percentage of NAV**, so a fabricated ``cash=0`` does not
+    merely under-report — it silently moves the kill threshold. Contract: NAV
+    and cash are never estimated. Unreadable fails closed, and the confirm path
+    turns that into a ``preflight_not_clean`` zero-order termination.
+    """
+
+
 class KrMockSubmissionNotWired(RuntimeError):
     """No concrete kis_mock order-submission function has been wired.
 
@@ -249,15 +289,93 @@ def account_identity_summary() -> dict[str, str]:
 class ReadOnlyKISMockDomesticClient(BaseKISClient):
     """kis_mock domestic-account reads only — no order-tool imports.
 
-    See the module docstring: same composition ``scripts/policy_table/
-    adapters/kr.py``'s ``_ReadOnlyKISDomesticClient`` uses, with
-    ``is_mock=True`` instead of ``False``.
+    Composition follows ``scripts/policy_table/adapters/kr.py``'s
+    ``_ReadOnlyKISDomesticClient`` (compose ``AccountClient`` over
+    ``BaseKISClient``, never import ``...kis.client.KISClient``), but — unlike
+    that live-account sibling — this client must be **bound to the mock (VTS)
+    account**, and binding is not something ``is_mock=True`` does on its own.
+
+    🔴 The distinction that a prior version of this class got wrong, stated
+    explicitly so it cannot be re-introduced: ``AccountClient``'s ``is_mock``
+    parameter selects the **TR id only**. Host, app key/secret, account number
+    and OAuth token all come from ``self._settings`` under the *live* field
+    names, which ``BaseKISClient`` resolves to the live values by default.
+    Passing ``is_mock=True`` while inheriting those defaults sends a mock
+    ``tr_id`` (``VTTC8434R``) to the **live** host with **live** credentials —
+    which KIS rejects with ``EGW02005 실전투자 TR 이 아닙니다``. That is what
+    happened on 2026-08-10, and it is why the four overrides below exist:
+
+    * :attr:`_settings` → :class:`KISMockSettingsView` (mock credentials,
+      mock account number, mock token slot — no live fallback anywhere),
+    * :meth:`_kis_url` → the mock base URL, **re-asserted** against the
+      official VTS host on every single URL it builds (see
+      :meth:`_assert_mock_host`),
+    * ``_token_manager`` → the ``kis_mock`` Redis namespace, so a mock token
+      is never minted into (or read from) the live token cache,
+    * ``_is_mock_client`` → ``True``, which is also what makes ROB-892's
+      distributed VTS admit gate engage for these reads.
+
+    Every one of those is fail-closed: a misconfiguration raises
+    :class:`KrMockHostViolation` **before** any socket is opened, rather than
+    quietly reaching the live account.
     """
 
     def __init__(self) -> None:
+        # Must precede super().__init__(): the base builds ``_hdr_base``
+        # (appkey/appsecret) from ``self._settings`` during construction.
+        self._mock_settings = KISMockSettingsView(settings)
+        # Marks this dispatch as mock for ROB-892's distributed admit gate.
+        self._is_mock_client = True
         super().__init__()
+        self._token_manager = get_kis_mock_token_manager(
+            base_url=self._assert_mock_host(self._mock_settings.kis_base_url),
+            app_key=self._mock_settings.kis_app_key,
+        )
         parent = cast(KISClientProtocol, cast(object, self))
         self._account = AccountClient(parent)
+
+    @property
+    def _settings(self) -> Any:  # type: ignore[override]
+        return self._mock_settings
+
+    @staticmethod
+    def _assert_mock_host(url: str) -> str:
+        """Return ``url`` iff it points at the official KIS mock (VTS) host.
+
+        The lane's one structural promise is "this client cannot reach the live
+        account". Checking the fully-built URL — rather than trusting the
+        configured base — is what makes that promise hold even if
+        ``KIS_MOCK_BASE_URL`` is edited to a live/other host, and it covers the
+        OAuth token POST as well as every account read, since both are built
+        through :meth:`_kis_url`.
+
+        Raises:
+            KrMockHostViolation: on an empty, malformed, or non-VTS host. Never
+                falls back to a default host — an unusable configuration must
+                stop the lane, not silently redirect it.
+        """
+
+        try:
+            netloc = urlsplit(url).netloc.lower()
+        except ValueError as exc:
+            raise KrMockHostViolation(
+                f"KIS mock base URL is malformed and cannot be host-checked: {exc}"
+            ) from exc
+        if netloc not in _KIS_MOCK_REST_HOSTS:
+            raise KrMockHostViolation(
+                "B0-X KR is a kis_mock-only lane; refusing to dispatch to host "
+                f"{netloc or '(empty)'} — the only permitted host is "
+                f"{', '.join(sorted(_KIS_MOCK_REST_HOSTS))}"
+            )
+        return url
+
+    def _kis_url(self, path: str) -> str:
+        base_url = self._assert_mock_host(self._mock_settings.kis_base_url)
+        return f"{base_url.rstrip('/')}{path}"
+
+    def _token_request_timeout(self) -> float:
+        # ROB-600/ROB-270: the VTS host answers near the 5s boundary.
+        return 10.0
 
     async def fetch_my_stocks(self) -> list[dict[str, Any]]:
         return await self._account.fetch_my_stocks(is_mock=True, is_overseas=False)
@@ -358,6 +476,60 @@ def _dec(value: Any) -> Decimal:
     return Decimal(str(value))
 
 
+#: Cash fields the KIS domestic balance response may carry, in the same
+#: precedence order ``AccountClient.inquire_domestic_cash_balance`` applies.
+_CASH_FIELDS: tuple[str, ...] = (
+    "stck_cash_ord_psbl_amt",
+    "ord_psbl_cash",
+    "dnca_tot_amt",
+)
+
+
+def _echoed_cash_fields(raw: Any) -> frozenset[str]:
+    """Return which cash fields the broker actually echoed with a value.
+
+    Presence, not value: ``"0"`` counts as echoed (a genuinely empty account),
+    while a missing key or a blank string does not. This is the only thing that
+    distinguishes "the account holds nothing" from "the response told us
+    nothing" once ``AccountClient`` has coerced both to ``0.0``.
+    """
+
+    if not isinstance(raw, dict):
+        return frozenset()
+    return frozenset(
+        field for field in _CASH_FIELDS if str(raw.get(field, "")).strip() != ""
+    )
+
+
+def _read_cash_or_fail(payload: dict[str, Any]) -> Decimal:
+    """Resolve KRW cash from a balance payload, or raise.
+
+    Preserves the lane's documented preference (주문가능현금, falling back to
+    예수금총액) exactly — both are real broker figures. What it adds is the
+    fail-closed branch: if the broker echoed **no** cash field at all, this
+    raises :class:`KrMockCashUnreadable` instead of returning ``Decimal("0")``
+    for a number nobody reported.
+    """
+
+    echoed = _echoed_cash_fields(payload.get("raw"))
+    if not echoed:
+        raise KrMockCashUnreadable(
+            "KIS mock 국내잔고 응답이 현금 필드를 하나도 echo 하지 않았다 "
+            f"(기대: {', '.join(_CASH_FIELDS)}). 조회 불가를 0 으로 읽으면 "
+            "NAV(=cash+평가액)가 축소되어 §4 envelope 의 NAV 비율 kill 임계가 "
+            "왜곡되므로, 추정하지 않고 fail-closed 한다."
+        )
+
+    orderable = payload.get("stck_cash_ord_psbl_amt")
+    if orderable:
+        return _dec(orderable)
+    if "dnca_tot_amt" in echoed:
+        return _dec(payload.get("dnca_tot_amt"))
+    # 주문가능현금이 echo 된 0 이고 예수금총액은 응답에 없다 — 0 은 추정이 아니라
+    # 브로커가 실제로 보고한 값이므로 그대로 쓴다.
+    return _dec(orderable)
+
+
 async def read_fresh_truth(client: ReadOnlyKISMockDomesticClient) -> FreshTruth:
     """Read-only cash + holdings snapshot, and the NAV derived from them.
 
@@ -365,11 +537,17 @@ async def read_fresh_truth(client: ReadOnlyKISMockDomesticClient) -> FreshTruth:
     every held symbol. This is the same-cycle NAV snapshot
     ``scripts.b0x.kill_switch.evaluate`` requires for a ``pct_of_nav`` kill —
     see ``scripts.b0x.envelope.KR_MOCK_ENVELOPE``.
+
+    Raises:
+        KrMockHostViolation: if the client would dispatch anywhere but the KIS
+            mock (VTS) host — raised before any socket is opened.
+        KrMockCashUnreadable: if the balance response echoed no cash field.
+            NAV is never estimated; see the exception's own docstring for why a
+            fabricated ``0`` would distort the §4 NAV-ratio kill threshold.
     """
 
     cash_payload = await client.inquire_cash_balance()
-    orderable = cash_payload.get("stck_cash_ord_psbl_amt")
-    cash = _dec(orderable if orderable else cash_payload.get("dnca_tot_amt"))
+    cash = _read_cash_or_fail(cash_payload)
 
     stocks = await client.fetch_my_stocks()
     positions: list[RawPosition] = []
@@ -694,6 +872,8 @@ __all__ = [
     "KR_PENDING_UNREADABLE",
     "OWN_PENDING_SOURCE",
     "KrLaneDisabled",
+    "KrMockCashUnreadable",
+    "KrMockHostViolation",
     "KrMockSubmissionNotWired",
     "ReadOnlyKISMockDomesticClient",
     "RawPosition",

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -90,6 +90,13 @@ class _FakeKrClient:
             "dnca_tot_amt": float(orderable_cash),
             "stck_cash_ord_psbl_amt": float(orderable_cash),
         }
+        # Faithful to AccountClient: the broker's own row is echoed under
+        # ``raw``, which is what distinguishes an absent cash field from a
+        # zero balance.
+        self._cash["raw"] = {
+            "dnca_tot_amt": str(orderable_cash),
+            "stck_cash_ord_psbl_amt": str(orderable_cash),
+        }
         self._stocks = stocks or []
         self.closed = False
 

--- a/tests/scripts/b0x/kr/test_ledger_pending_source.py
+++ b/tests/scripts/b0x/kr/test_ledger_pending_source.py
@@ -115,7 +115,15 @@ class _FakeKrClient:
         self._stocks = stocks or []
 
     async def inquire_cash_balance(self) -> dict[str, Any]:
-        return {"dnca_tot_amt": 5_000_000.0, "stck_cash_ord_psbl_amt": 5_000_000.0}
+        return {
+            "dnca_tot_amt": 5_000_000.0,
+            "stck_cash_ord_psbl_amt": 5_000_000.0,
+            # AccountClient always echoes the broker row under ``raw``.
+            "raw": {
+                "dnca_tot_amt": "5000000",
+                "stck_cash_ord_psbl_amt": "5000000",
+            },
+        }
 
     async def fetch_my_stocks(self) -> list[dict[str, Any]]:
         return self._stocks

--- a/tests/scripts/b0x/kr/test_mock.py
+++ b/tests/scripts/b0x/kr/test_mock.py
@@ -171,12 +171,20 @@ class _FakeKrClient:
         *,
         cash: dict[str, Any],
         stocks: list[dict[str, Any]],
+        raw: dict[str, Any] | None = None,
     ) -> None:
         self._cash = cash
         self._stocks = stocks
+        # ``AccountClient.inquire_domestic_cash_balance`` always echoes the
+        # broker's own ``output2`` row under ``raw``; the parsed top-level
+        # floats are coerced (missing -> 0.0), so ``raw`` is the only place an
+        # *absent* cash field can still be told apart from a zero balance.
+        # Defaults to mirroring ``cash`` so a faithful double stays the easy
+        # path; pass ``raw={}`` to simulate a response that echoed nothing.
+        self._raw = dict(cash) if raw is None else raw
 
     async def inquire_cash_balance(self) -> dict[str, Any]:
-        return self._cash
+        return {**self._cash, "raw": self._raw}
 
     async def fetch_my_stocks(self) -> list[dict[str, Any]]:
         return self._stocks

--- a/tests/scripts/b0x/kr/test_mock_account_binding.py
+++ b/tests/scripts/b0x/kr/test_mock_account_binding.py
@@ -1,0 +1,210 @@
+"""Regression guard — the KR lane's read client is bound to the *mock* account.
+
+The defect these tests exist for (2026-08-10, first RTH-reaching KR cycle):
+``ReadOnlyKISMockDomesticClient`` subclassed ``BaseKISClient`` and called
+``AccountClient(..., is_mock=True)``, but ``is_mock`` selects the **TR id and
+nothing else**. Host, app key/secret, account number and OAuth token were all
+inherited from ``BaseKISClient``'s live defaults, so the client sent the mock
+TR ``VTTC8434R`` to the **live** host with **live** credentials and KIS replied
+``EGW02005 실전투자 TR 이 아닙니다``.
+
+The lane's acceptance run the previous day (a Sunday) passed only because the
+RTH gate short-circuited before any account I/O — the call was never reached.
+These tests reach it without a network: every assertion below is about how the
+client resolves its host/credentials/token *before* a socket is opened, so
+they fail on a workstation, in CI, and on a closed market alike.
+
+Nothing here performs network or broker I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.core.config import settings
+from scripts.b0x.kr import mock as kr_mock
+
+pytestmark = pytest.mark.unit
+
+LIVE_HOST_URL = "https://openapi.koreainvestment.com:9443"
+MOCK_HOST_URL = "https://openapivts.koreainvestment.com:29443"
+
+
+@pytest.fixture
+def mock_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give the process a complete, obviously-fake kis_mock credential set."""
+
+    monkeypatch.setattr(settings, "kis_mock_app_key", "MOCK-APP-KEY", raising=False)
+    monkeypatch.setattr(
+        settings, "kis_mock_app_secret", "MOCK-APP-SECRET", raising=False
+    )
+    monkeypatch.setattr(settings, "kis_mock_account_no", "9999999999", raising=False)
+    monkeypatch.setattr(settings, "kis_mock_base_url", MOCK_HOST_URL, raising=False)
+    monkeypatch.setattr(settings, "kis_mock_access_token", None, raising=False)
+    # Live values that must never be picked up by this client.
+    monkeypatch.setattr(settings, "kis_app_key", "LIVE-APP-KEY", raising=False)
+    monkeypatch.setattr(settings, "kis_app_secret", "LIVE-APP-SECRET", raising=False)
+    monkeypatch.setattr(settings, "kis_account_no", "1111111111", raising=False)
+    monkeypatch.setattr(settings, "kis_base_url", LIVE_HOST_URL, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# The four bindings that ``is_mock=True`` does not perform on its own.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("mock_credentials")
+def test_every_url_the_client_builds_points_at_the_mock_host() -> None:
+    client = kr_mock.ReadOnlyKISMockDomesticClient()
+
+    # The balance read and the OAuth token POST both go through _kis_url.
+    for path in ("/uapi/domestic-stock/v1/trading/inquire-balance", "/oauth2/token"):
+        assert client._kis_url(path).startswith(MOCK_HOST_URL), path
+        assert "openapi.koreainvestment.com" not in client._kis_url(path)
+
+
+@pytest.mark.usefixtures("mock_credentials")
+def test_credentials_and_account_number_are_the_mock_set_not_the_live_one() -> None:
+    client = kr_mock.ReadOnlyKISMockDomesticClient()
+
+    assert client._settings.kis_app_key == "MOCK-APP-KEY"
+    assert client._settings.kis_app_secret == "MOCK-APP-SECRET"
+    assert client._settings.kis_account_no == "9999999999"
+    # _hdr_base is built during __init__ — the header actually sent must carry
+    # the mock key, which is why the settings view is installed before super().
+    assert client._hdr_base["appkey"] == "MOCK-APP-KEY"
+    assert client._hdr_base["appsecret"] == "MOCK-APP-SECRET"
+
+
+@pytest.mark.usefixtures("mock_credentials")
+def test_the_token_slot_and_namespace_are_isolated_from_the_live_cache() -> None:
+    client = kr_mock.ReadOnlyKISMockDomesticClient()
+
+    # A token issued for the mock account must never land in the live slot.
+    client._settings.kis_access_token = "MOCK-TOKEN"
+    assert settings.kis_mock_access_token == "MOCK-TOKEN"
+    assert settings.kis_access_token != "MOCK-TOKEN"
+
+    from app.services.redis_token_manager import redis_token_manager
+
+    assert client._token_manager is not redis_token_manager
+    # Distinct Redis key space — a mock token cannot be served to a live client.
+    assert client._token_manager._token_key.startswith("kis_mock:")
+    assert client._token_manager._token_key != redis_token_manager._token_key
+
+
+@pytest.mark.usefixtures("mock_credentials")
+def test_the_client_is_flagged_as_mock_dispatch_for_the_vts_admit_gate() -> None:
+    """ROB-892's distributed gate keys off this flag (and the mock host)."""
+
+    client = kr_mock.ReadOnlyKISMockDomesticClient()
+    assert client._is_mock_client is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: a non-mock host is refused before any socket is opened.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("mock_credentials")
+@pytest.mark.parametrize(
+    "bad_base_url",
+    [
+        LIVE_HOST_URL,
+        "https://openapi.koreainvestment.com:29443",  # live host, mock port
+        "https://example.invalid",
+        "",
+    ],
+    ids=["live", "live-host-mock-port", "foreign", "empty"],
+)
+def test_a_non_mock_host_is_refused_at_construction(
+    monkeypatch: pytest.MonkeyPatch, bad_base_url: str
+) -> None:
+    monkeypatch.setattr(settings, "kis_mock_base_url", bad_base_url, raising=False)
+
+    with pytest.raises(kr_mock.KrMockHostViolation):
+        kr_mock.ReadOnlyKISMockDomesticClient()
+
+
+@pytest.mark.usefixtures("mock_credentials")
+def test_repointing_the_base_url_after_construction_still_cannot_reach_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The host check is per-URL, not a one-off at construction."""
+
+    client = kr_mock.ReadOnlyKISMockDomesticClient()
+    monkeypatch.setattr(settings, "kis_mock_base_url", LIVE_HOST_URL, raising=False)
+
+    with pytest.raises(kr_mock.KrMockHostViolation):
+        client._kis_url("/uapi/domestic-stock/v1/trading/inquire-balance")
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: an unreadable cash figure is never rendered as zero.
+# ---------------------------------------------------------------------------
+
+
+class _CashOnlyClient:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    async def inquire_cash_balance(self) -> dict[str, Any]:
+        return self._payload
+
+    async def fetch_my_stocks(self) -> list[dict[str, Any]]:
+        return []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw",
+    [{}, {"dnca_tot_amt": ""}, {"some_other_field": "1"}, None],
+    ids=["no-rows", "blank-field", "unrelated-fields", "not-a-dict"],
+)
+async def test_a_response_with_no_cash_field_fails_closed_instead_of_reading_zero(
+    raw: Any,
+) -> None:
+    # AccountClient coerces missing cash to 0.0, so the top-level figures look
+    # like a legitimately empty account. Only ``raw`` reveals that the broker
+    # reported nothing at all.
+    client = _CashOnlyClient(
+        {"dnca_tot_amt": 0.0, "stck_cash_ord_psbl_amt": 0.0, "raw": raw}
+    )
+
+    with pytest.raises(kr_mock.KrMockCashUnreadable):
+        await kr_mock.read_fresh_truth(client)
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_empty_account_is_zero_and_not_an_error() -> None:
+    """An echoed ``"0"`` is evidence, not absence — it must still read."""
+
+    client = _CashOnlyClient(
+        {
+            "dnca_tot_amt": 0.0,
+            "stck_cash_ord_psbl_amt": 0.0,
+            "raw": {"dnca_tot_amt": "0", "stck_cash_ord_psbl_amt": "0"},
+        }
+    )
+
+    fresh = await kr_mock.read_fresh_truth(client)
+    assert fresh.cash == 0
+    assert fresh.nav == 0
+
+
+@pytest.mark.asyncio
+async def test_zero_orderable_still_falls_back_to_the_echoed_deposit_total() -> None:
+    """The lane's documented cash preference is unchanged by the new guard."""
+
+    client = _CashOnlyClient(
+        {
+            "dnca_tot_amt": 500000.0,
+            "stck_cash_ord_psbl_amt": 0.0,
+            "raw": {"dnca_tot_amt": "500000", "stck_cash_ord_psbl_amt": "0"},
+        }
+    )
+
+    fresh = await kr_mock.read_fresh_truth(client)
+    assert fresh.cash == 500000


### PR DESCRIPTION
## 무엇이 깨져 있었나

🔴 **`is_mock=True` 는 TR id 하나만 고른다 — 계좌를 바꾸지 않는다.**

host·app key/secret·계좌번호·OAuth 토큰은 전부 `BaseKISClient` 가 `self._settings` 의 **live** 필드명에서 읽고, 기본값이 live 다. `ReadOnlyKISMockDomesticClient` 는 `AccountClient` 에 `is_mock=True` 만 넘기고 나머지를 상속했기 때문에, **모의 TR(`VTTC8434R`)을 live 호스트에 live 자격증명으로** 보냈다.

```
tr_id = VTTC8434R (모의)  →  host = openapi.koreainvestment.com:9443 (실전)
→ EGW02005 실전투자 TR 이 아닙니다
```

즉 TR 매핑은 정상이었다. **호스트/자격증명이 틀렸다.**

**전날(일요일) acceptance 통과는 이 경로가 정상이라는 증거가 아니었다** — RTH 게이트가 계좌 I/O **이전에** zero-order 로 끝나서 이 호출에 도달한 적이 없었을 뿐이고, 개장일 첫 사이클(08-10 09:05 KST)에서 처음 도달하자마자 크래시했다.

### 배제한 가능성

| 가설 | 판정 | 근거 |
|---|---|---|
| TR 매핑 오류 | ❌ 배제 | `constants.py` 매핑 정상, `is_mock=True` 가 모의 TR 을 실제로 선택함(로그의 `tr_id=VTTC8434R`) |
| 파라미터/헤더 규격 차이 | ❌ 배제 | 파라미터 무변경으로 수리 후 동일 요청이 통과 |
| kis_mock 이 이 TR 미지원 | ❌ 배제 | 수리 후 **같은 TR** 로 정상 응답 |
| **host/자격증명이 live** | ✅ **확정** | `_kis_url()` 은 `kis_base_url`(live), `_hdr_base` 는 `kis_app_key`(live), `_resolve_account_parts()` 는 `kis_account_no`(live)만 읽음. mock 바인딩(`_KISSettingsView`)은 `KISClient(is_mock=True)` 에만 있고 이 클래스는 그것을 상속하지 않음 |

## 수리 (A — 잘못된 바인딩 교정)

읽기 클라이언트에 실제 바인딩 4종, 전부 fail-closed:

| 오버라이드 | 효과 |
|---|---|
| `_settings` → `KISMockSettingsView` | mock 자격증명·계좌번호·토큰 슬롯. **live 폴백 없음** |
| `_kis_url` → `_assert_mock_host` | 만드는 **모든** URL(잔고 read + `/oauth2/token`)의 netloc 재검증. 아니면 소켓 열기 전에 `KrMockHostViolation` |
| `_token_manager` → `kis_mock` 네임스페이스 | mock 토큰이 live 토큰 캐시에 섞이지 않음 |
| `_is_mock_client = True` | ROB-892 VTS 분산 admit gate 가 이 read 에도 걸림 |

`KISMockSettingsView` 가 `app/services/` 에 있는 이유: 레인 AST 가드가 `app.services.brokers.kis.` 프리픽스를 금지하고, 이 idiom 이 필요로 하는 위임형 `getattr()` 도 금지한다. **가드를 고치는 대신 가드가 스캔하지 않는 곳(주문 표면이 아닌 곳)에 두었다** — allowlist 확장 0.

## 조용한 fallback 제거

`AccountClient` 는 없는 현금 필드를 `0.0` 으로 강제하므로, 값만으로는 "빈 계좌"와 "응답이 아무것도 안 알려줌"이 구분되지 않았다. `read_fresh_truth` 는 이제 브로커가 **echo 한** raw 필드 존재 여부로 둘을 가르고, 하나도 없으면 `KrMockCashUnreadable` 로 fail-closed 한다.

🔴 NAV = `cash + Σ evlu_amt` 이고 §4 kill 은 **NAV 비율**이라, 조작된 `cash=0` 은 과소보고가 아니라 **kill 임계 자체를 움직인다.** confirm 경로에서는 기존 `preflight_not_clean`/`account_truth_unavailable` zero-order 로 흘러간다.

🔵 실측: mock 브로커는 `dnca_tot_amt` **하나만** echo 하고 `stck_cash_ord_psbl_amt` 는 응답에 없다. 그래서 존재 검사는 세 필드 전부를 본다 — 주문가능현금만 봤다면 정상 계좌를 "조회 불가"로 오판했을 것이다. 기존 현금 우선순위(주문가능현금 → 예수금총액)는 **무변경**.

## Acceptance — 개장 시간대 실측 (KRX RTH)

```
10:31:37–10:31:44 KST  run_b0x_kr_cycle --derivation-only --repeat 2  exit=0
  DERIVATION_DETERMINISM=IDENTICAL

10:32:21 KST  RESOLVED_BALANCE_URL=https://openapivts.koreainvestment.com:29443/...
              RESOLVED_TOKEN_URL  =https://openapivts.koreainvestment.com:29443/oauth2/token
              APPKEY_IS_MOCK_FAMILY=True   APPKEY_IS_LIVE_FAMILY=False
              ACCOUNT_IS_MOCK=True         ACCOUNT_IS_LIVE=False
              TOKEN_KEYSPACE=kis_mock:openapivts...:29443:<fp>:access_token
              FRESH_TRUTH_OK cash=2701920.0 nav=9805020.0 positions=11
```

**주문 0 증명**: `--derivation-only` 는 제출 코드 경로 자체가 없고 아무것도 쓰지 않는다.
- `b0xk_rows_total=0` — B0-X KR 레인은 **한 번도** 주문을 낸 적이 없다
- `any_rows_today_kst=0` · 원장 최신 행 = `2026-07-27`
- 전/후 cash 동일(2,701,920) · positions 11 불변 (NAV 미세 변동 = 장중 평가액 mark-to-market)

`--confirm` 실행 0. live 계좌 접촉 0. env 파일 변경 0.

## 회귀 방어 — mutant 로 발화 증명

`tests/scripts/b0x/kr/test_mock_account_binding.py` 신규. 수리 전 바인딩을 실제로 주입하니 **5개 테스트가 FAIL** 했고, 원복 후 전부 통과. 네트워크 없이 host/자격증명/토큰 해석만 검사하므로 장 마감 후·CI에서도 동일하게 발화한다.

## 불변식

- AST 가드 3종 **파일 무변경**으로 전부 통과 (143 passed) — allowlist 확장 0
- envelope §4 수치 · v1.6 원장 dedup · 지위 라벨 `OBSERVATION_DERIVATION_ONLY` · KR kill 「구조적 불가」 문구 · MAX_TABLE_AGE — 무접촉
- crypto/US 경로 무접촉 · 선행 머지분(#1821~#1829) 되돌림 0
- 기존 테스트 fake 3곳은 `raw` 를 echo 하도록 **충실화**(실제 `AccountClient` 는 항상 echo 함) — 검사를 약화시킨 게 아니다

## 테스트

```
tests/scripts/b0x/                     470 passed
tests/services/brokers/kis + tests/scripts  1071 passed
ruff check / ruff format --check       All checks passed / 3160 formatted
make typecheck (ty --error-on-warning) All checks passed
```

## 후속 (이 PR 밖)

- 동일한 settings-view idiom 이 이제 3벌(`_KISSettingsView`, `_KISMockSettingsProxy`, `KISMockSettingsView`). 통합은 live 경로를 건드리므로 데드라인 밖 별건.
- `read_fresh_truth` 는 주문가능현금이 0 이면 예수금총액으로 폴백한다(기존 동작, 무변경). 매수 대기가 현금을 묶은 경우 NAV 를 과대평가할 수 있다 — 계약 판단 사항이라 상신만 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock account connectivity by ensuring mock credentials, accounts, tokens, and hosts remain isolated from live settings.
  * Added safeguards to reject invalid hosts before network access.
  * Improved cash and NAV handling when broker responses omit required cash values, while preserving valid zero balances.
* **Documentation**
  * Updated the KR cycle runbook with mock-client protections, cash handling behavior, and submission safeguards.
* **Tests**
  * Added coverage for account binding, host validation, token isolation, and cash-response edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->