### PR TITLE
fix(analyze): stop reporting halted symbols as fresh (ROB-1236)

### DIFF
--- a/.smoke-out/rob179-feed-research-evidence.json
+++ b/.smoke-out/rob179-feed-research-evidence.json
@@ -1,7 +1,7 @@
 {
   "smoke": "rob-179-invest-research-api",
-  "captured_at": "2026-07-06T04:59:44.839410+00:00",
-  "source_used": "rob179-smoke-1bedb344",
+  "captured_at": "2026-08-10T08:13:13.971815+00:00",
+  "source_used": "rob179-smoke-18adacff",
   "invariants_ok": true,
   "samples": {
     "top": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,32 @@ set-difference upsert하고 DB 상태로 응답한다 (excluded만 제외, pendi
   `FINNHUB_NEWS_TIMEOUT_S`×`FINNHUB_NEWS_MAX_ATTEMPTS` 재시도, 전 실패 시
   degraded + DB stale 폴백.
 
+### 정지 종목 오염 차단 — `halted_suspect` (ROB-1236)
+
+일봉이 **3거래일 연속 죽어 있으면**(`volume=0` **또는** `high==low==close` 이면서
+직전 close 와 동일) `data_state: "halted_suspect"`. 🔴 **`fresh` 금지 · 지표 null ·
+스크리너/정책표에서 제외.** 실사례 = 000880 한화(8거래일 동결인데 `fresh` + RSI 35.40 로
+매수 후보 rank 2 랭킹).
+
+- **판정기**: `app/services/halt_detection.py` (순수·stdlib, DB/네트워크/시계 없음)
+- **소비자 3곳**: `analyze_stock_impl::_apply_halt_suspect`(indicators·support_resistance
+  = None, quote/top-level 양쪽 data_state 덮어씀) · `screening/halt_filter.py`
+  (`screen_stocks_unified` 단일 깔때기) · `scripts/policy_table/adapters/{kr,us,crypto}.py`
+- **런북**: `docs/runbooks/halted-suspect-data-state.md`
+
+**주의**:
+- 🔴 **`halted_suspect` 는 확정이 아니라 의심.** KRX 거래정지 마스터가 레포에 **없다**
+  (`krx_halt_master: "unavailable"` 를 응답에 명시). 확정 정지로 단정 금지.
+- 🔴 **N=3 은 양방향 오차를 감수한 값** — 1~2일 정지는 못 잡고(위음성), 3일 연속 무거래
+  초저유동 종목은 잡힌다(위양성). 그래서 **제외는 항상 심볼·근거와 함께 보고**된다
+  (`meta.halted_suspect_excluded` / `universe.halted_suspect`). 조용한 삭제 금지.
+- **상한가/하한가 잠김**은 `open=high=low=close` 지만 직전 close 와 가격이 다르므로
+  잡히지 않는다 — 0-변동 조건의 "직전 close 동일" 절을 제거하지 말 것.
+- 봉 이력 조회 실패는 **fail-open**(행 유지 + warning). DB 장애는 정지의 증거가 아니다.
+- 🔴 스크리너는 **최신봉 거래량 > 0 이면 이력 조회를 건너뛴다**(장중 일봉 캐시 우회 →
+  100행 스크린이 KIS 라이브 100회를 때리는 것 방지). 감수하는 구멍 = 거래량 있는
+  0-변동 구간. analyze/정책표는 이력을 무조건 읽으므로 그쪽에서 잡힌다.
+
 ### 데이터베이스 정규화 구조
 
 **주식 정보와 분석 결과 분리:**

--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -51,6 +51,11 @@ from app.mcp_server.tooling.shared import (
 )
 from app.mcp_server.tooling.shared import resolve_market_type as _resolve_market_type
 from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
+from app.services.halt_detection import (
+    HALTED_SUSPECT_DATA_STATE,
+    HaltSuspicion,
+    classify_ohlcv_frame,
+)
 from app.services.kr_symbol_universe_service import get_kr_nxt_tradability
 from app.services.symbol_analysis.floor import floored_action, insufficient_inputs
 
@@ -920,6 +925,44 @@ def _consensus_rows_present(consensus: Any) -> bool:
         return False
 
 
+#: Analysis fields derived from the daily bar series. When the series is inert
+#: every one of them is arithmetic over dead candles, so they are withheld —
+#: never estimated, interpolated, or carried over from an earlier session.
+_HALT_SUPPRESSED_ANALYSIS_FIELDS = ("indicators", "support_resistance")
+
+
+def _apply_halt_suspect(analysis: dict[str, Any], suspicion: HaltSuspicion) -> None:
+    """ROB-1236: stamp ``halted_suspect`` and null out bar-derived signals.
+
+    Runs after ``_apply_fetch_cache_metadata`` (so it overrides the freshness
+    verdict, which only ever looked at bar *existence*) and before
+    ``_apply_recommendation`` (so the recommendation is floored by its own
+    ``insufficient_inputs`` path off the nulled RSI rather than by a second,
+    parallel rule).
+
+    ``halted_suspect`` outranks ``fresh``/``stale``/``degraded``: an inert
+    series is not made trustworthy by being recently fetched.
+    """
+    if not suspicion.suspected:
+        return
+
+    for field in _HALT_SUPPRESSED_ANALYSIS_FIELDS:
+        analysis[field] = None
+
+    analysis["data_state"] = HALTED_SUSPECT_DATA_STATE
+    analysis["halt_suspect"] = suspicion.to_dict()
+
+    # The compact batch summary reads ``data_state`` off the quote, not off the
+    # top-level analysis — that is the field the 000880 session actually saw as
+    # "fresh". Both surfaces have to say the same thing.
+    quote = analysis.get("quote")
+    if isinstance(quote, dict):
+        quote["data_state"] = HALTED_SUSPECT_DATA_STATE
+        quote["data_state_reason"] = "halted_suspect_frozen_bars"
+        quote["price_usable"] = False
+        quote["is_stale_price"] = True
+
+
 def _apply_recommendation(
     analysis: dict[str, Any],
     market_type: str,
@@ -992,6 +1035,9 @@ async def analyze_stock_impl(
             normalized_symbol, market_type, count=250
         )
     ohlcv_60d = ohlcv_df.tail(60) if len(ohlcv_df) >= 60 else ohlcv_df
+    # ROB-1236 — judged on the same frame the indicators are computed from, so
+    # the verdict and the suppressed values can never disagree about the input.
+    halt_suspicion = classify_ohlcv_frame(ohlcv_df)
 
     preloaded_quote, named_tasks = _prepare_quote_tasks(
         normalized_symbol,
@@ -1032,6 +1078,9 @@ async def analyze_stock_impl(
             task_failures,
             market_type,
         )
+        # ROB-1236 — must follow the freshness stamp (it overrides it) and
+        # precede the recommendation (which then floors itself off null RSI).
+        _apply_halt_suspect(analysis, halt_suspicion)
         analysis["errors"] = []
         _apply_recommendation(analysis, market_type)
 

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -943,6 +943,15 @@ def _summarize_analysis_result(
         if _px_key in quote:
             summary[_px_key] = quote[_px_key]
 
+    # ROB-1236: an inert daily series (consecutive zero-volume / zero-variation
+    # sessions) makes every bar-derived number above meaningless, so the
+    # suspicion travels with the compact summary instead of being visible only
+    # in the full payload. ``data_state`` is already overridden on the quote.
+    halt_suspect = analysis.get("halt_suspect")
+    if isinstance(halt_suspect, dict):
+        summary["halt_suspect"] = halt_suspect
+        summary["data_state"] = analysis.get("data_state")
+
     if position_index is not None:
         summary["position"] = _lookup_position_for_symbol(
             symbol=symbol,

--- a/app/mcp_server/tooling/screening/entrypoint.py
+++ b/app/mcp_server/tooling/screening/entrypoint.py
@@ -14,6 +14,7 @@ from app.mcp_server.tooling.screening.crypto import _screen_crypto_with_fallback
 from app.mcp_server.tooling.screening.enrichment import (
     _decorate_screen_response_with_equity_enrichment,
 )
+from app.mcp_server.tooling.screening.halt_filter import exclude_halt_suspect_rows
 from app.mcp_server.tooling.screening.kr import _screen_kr_with_fallback
 from app.mcp_server.tooling.screening.us import _screen_us_with_fallback
 
@@ -286,6 +287,11 @@ async def screen_stocks_unified(
         min_dividend_yield=normalized_min_dividend_yield,
         apply_post_filters=apply_post_enrichment_filters,
     )
+
+    # ROB-1236 — last gate before the rows leave the screener: a symbol whose
+    # daily series has gone inert must not reach a ranking. Exclusions are
+    # reported in meta.halted_suspect_excluded, never dropped silently.
+    response = await exclude_halt_suspect_rows(response, market=normalized_market)
 
     filters_applied = response.get("filters_applied")
     normalized_filters_applied = (

--- a/app/mcp_server/tooling/screening/halt_filter.py
+++ b/app/mcp_server/tooling/screening/halt_filter.py
@@ -62,20 +62,35 @@ _MARKET_TYPE_BY_SCREEN_MARKET = {
 }
 
 
-def _latest_bar_traded(row: dict[str, Any]) -> bool:
-    """True when the row's own newest bar shows real volume.
+#: Per-market names for "how much traded on the newest bar". Turnover counts
+#: as well as share volume — either being positive proves the bar traded.
+_TRADED_FIELDS = (
+    "volume",
+    "volume_24h",
+    "daily_volume",
+    "trade_amount",
+    "trade_amount_24h",
+    "daily_turnover",
+)
 
-    Missing or unparseable volume returns ``False`` so the row still gets the
-    full history read — the cheap gate must never be the reason a halt slips
-    through.
+
+def _latest_bar_traded(row: dict[str, Any]) -> bool:
+    """True when the row's own newest bar shows real volume or turnover.
+
+    A row carrying none of the known fields, or only unparseable ones, returns
+    ``False`` so it still gets the full history read — the cheap gate must
+    never be the reason a halt slips through.
     """
-    raw = row.get("volume")
-    if raw is None:
-        return False
-    try:
-        return float(raw) > 0
-    except (TypeError, ValueError):
-        return False
+    for field in _TRADED_FIELDS:
+        raw = row.get(field)
+        if raw is None:
+            continue
+        try:
+            if float(raw) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
 
 
 async def _classify_row(
@@ -130,10 +145,15 @@ async def exclude_halt_suspect_rows(
 
     kept: list[dict[str, Any]] = []
     excluded: list[dict[str, Any]] = []
+    check_skipped: list[str] = []
     warnings: list[str] = []
-    for row, (symbol, suspicion, warning) in zip(rows, verdicts, strict=True):
-        if warning:
-            warnings.append(warning)
+    for row, (symbol, suspicion, skip_reason) in zip(rows, verdicts, strict=True):
+        if skip_reason:
+            # Diagnostics, not an operator warning: ``warnings`` is a contract
+            # some callers assert on exactly, and a transient candle-store
+            # error is not something an operator acts on. Only an actual
+            # exclusion earns a warning.
+            check_skipped.append(skip_reason)
         if suspicion is None or not suspicion.suspected:
             kept.append(row)
             continue
@@ -146,7 +166,13 @@ async def exclude_halt_suspect_rows(
             "confirmed halt; verify before overriding"
         )
 
-    if not excluded and not warnings:
+    if check_skipped:
+        logger.warning(
+            "halt check skipped for %d screener row(s): %s",
+            len(check_skipped),
+            "; ".join(check_skipped[:5]),
+        )
+    if not excluded and not check_skipped:
         return response
 
     dropped = len(rows) - len(kept)
@@ -162,7 +188,10 @@ async def exclude_halt_suspect_rows(
     )
 
     meta = dict(response.get("meta") or {})
-    meta["halted_suspect_excluded"] = excluded
+    if excluded:
+        meta["halted_suspect_excluded"] = excluded
+    if check_skipped:
+        meta["halted_suspect_check_skipped"] = check_skipped
 
     merged_warnings = list(response.get("warnings") or [])
     merged_warnings.extend(warnings)

--- a/app/mcp_server/tooling/screening/halt_filter.py
+++ b/app/mcp_server/tooling/screening/halt_filter.py
@@ -1,0 +1,182 @@
+"""ROB-1236 — drop halt-suspect symbols out of screener results.
+
+The screener ranks on the same daily bars ``analyze_stock_batch`` reads, so a
+symbol whose series has gone inert (consecutive zero-volume / zero-variation
+sessions) can surface as a normal candidate with an RSI, a "support", and a
+change rate — all arithmetic over dead candles. It happened: 000880 한화 was
+ranked buy candidate #2 during an eight-session 매매거래정지.
+
+Exclusion here is deliberately **not silent**. Every dropped symbol is listed
+in ``meta.halted_suspect_excluded`` with its evidence and echoed as a warning,
+because a false positive removes a real buy candidate and an operator has to be
+able to see that happen and overrule it.
+
+Detection failure is fail-*open*: if the bar history cannot be read the row is
+kept and a warning is recorded. A DB hiccup is not evidence of a halt, and
+silently deleting candidates on infrastructure noise is the opposite mistake.
+
+Cost gate
+---------
+Reading history per row is not free: ``_fetch_ohlcv_for_indicators`` is
+cache-first, but during a live KRX session the daily cache is deliberately
+bypassed (today's bar is still forming), so a naive check on a 100-row screen
+would fire 100 live KIS candle fetches at exactly the hour an operating session
+runs. So the history read is gated on the row's own latest-bar volume: a
+detection requires the frozen run to end at the newest bar, and a newest bar
+that traded is not zero-volume-frozen. In practice that leaves a handful of
+rows per screen.
+
+🔴 Known gap this gate accepts: a run frozen purely by *zero variation* while
+still printing volume (three straight sessions with no intraday range at all,
+closing unchanged) is skipped here. ``analyze_stock_batch`` and the policy-table
+builders read full history unconditionally and still catch it — this shortcut
+exists only on the screener's per-row hot path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from app.mcp_server.tooling.market_data_indicators import _fetch_ohlcv_for_indicators
+from app.mcp_server.tooling.screening.enrichment import _streak_symbol
+from app.services.halt_detection import HaltSuspicion, classify_ohlcv_frame
+
+logger = logging.getLogger(__name__)
+
+#: Enough history to see the frozen run with room to spare; the read is
+#: cache-first against the daily-candle store, not a broker call.
+_HALT_LOOKBACK_BARS = 20
+_HALT_CONCURRENCY = 8
+
+#: Screener market key -> the ``market_type`` the OHLCV fetchers expect.
+_MARKET_TYPE_BY_SCREEN_MARKET = {
+    "kr": "equity_kr",
+    "kospi": "equity_kr",
+    "kosdaq": "equity_kr",
+    "konex": "equity_kr",
+    "all": "equity_kr",
+    "us": "equity_us",
+    "crypto": "crypto",
+}
+
+
+def _latest_bar_traded(row: dict[str, Any]) -> bool:
+    """True when the row's own newest bar shows real volume.
+
+    Missing or unparseable volume returns ``False`` so the row still gets the
+    full history read — the cheap gate must never be the reason a halt slips
+    through.
+    """
+    raw = row.get("volume")
+    if raw is None:
+        return False
+    try:
+        return float(raw) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+async def _classify_row(
+    row: dict[str, Any],
+    *,
+    market_type: str,
+    semaphore: asyncio.Semaphore,
+) -> tuple[str | None, HaltSuspicion | None, str | None]:
+    symbol = _streak_symbol(row)
+    if not symbol:
+        return None, None, None
+    if _latest_bar_traded(row):
+        return symbol, None, None
+    async with semaphore:
+        try:
+            frame = await _fetch_ohlcv_for_indicators(
+                symbol, market_type, count=_HALT_LOOKBACK_BARS
+            )
+        except Exception as exc:  # noqa: BLE001 — fail open, never drop the row
+            return (
+                symbol,
+                None,
+                f"{symbol}: halt check skipped ({type(exc).__name__}: {exc})",
+            )
+    return symbol, classify_ohlcv_frame(frame), None
+
+
+async def exclude_halt_suspect_rows(
+    response: dict[str, Any],
+    *,
+    market: str,
+) -> dict[str, Any]:
+    """Return ``response`` with halt-suspect rows removed and accounted for."""
+    market_type = _MARKET_TYPE_BY_SCREEN_MARKET.get(market)
+    if market_type is None:
+        return response
+
+    raw_results = response.get("results")
+    if not isinstance(raw_results, list):
+        return response
+    rows = [row for row in raw_results if isinstance(row, dict)]
+    if not rows:
+        return response
+
+    semaphore = asyncio.Semaphore(_HALT_CONCURRENCY)
+    verdicts = await asyncio.gather(
+        *(
+            _classify_row(row, market_type=market_type, semaphore=semaphore)
+            for row in rows
+        )
+    )
+
+    kept: list[dict[str, Any]] = []
+    excluded: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for row, (symbol, suspicion, warning) in zip(rows, verdicts, strict=True):
+        if warning:
+            warnings.append(warning)
+        if suspicion is None or not suspicion.suspected:
+            kept.append(row)
+            continue
+        evidence = suspicion.to_dict()
+        excluded.append({"symbol": symbol, **evidence})
+        warnings.append(
+            f"{symbol}: excluded as halted_suspect "
+            f"({suspicion.frozen_sessions} consecutive inert sessions, "
+            f"reasons={'+'.join(suspicion.reasons)}) — suspicion, not a "
+            "confirmed halt; verify before overriding"
+        )
+
+    if not excluded and not warnings:
+        return response
+
+    dropped = len(rows) - len(kept)
+    # ``total_count`` may describe the whole matching set while ``results`` is
+    # one page of it, so this only subtracts what was seen on this page. It can
+    # under-report how many halted names exist overall; it never over-reports
+    # how many rows were returned.
+    previous_total = response.get("total_count")
+    total_count = (
+        max(0, int(previous_total) - dropped)
+        if isinstance(previous_total, int)
+        else len(kept)
+    )
+
+    meta = dict(response.get("meta") or {})
+    meta["halted_suspect_excluded"] = excluded
+
+    merged_warnings = list(response.get("warnings") or [])
+    merged_warnings.extend(warnings)
+
+    updated = {
+        **response,
+        "results": kept,
+        "total_count": total_count,
+        "returned_count": len(kept),
+        "meta": meta,
+    }
+    if merged_warnings:
+        updated["warnings"] = merged_warnings
+    return updated
+
+
+__all__ = ["exclude_halt_suspect_rows"]

--- a/app/monitoring/sentry.py
+++ b/app/monitoring/sentry.py
@@ -542,7 +542,12 @@ _FRESHNESS_FIELD_NAMES = (
     "fallback_source",
     "provider_provenance",
 )
-_FRESHNESS_DATA_STATES = frozenset({"fresh", "stale", "degraded", "missing"})
+# ROB-1236 added "halted_suspect": a series of inert daily bars. It is a valid
+# classification, not an invalid envelope — but it is never a success state.
+_FRESHNESS_DATA_STATES = frozenset(
+    {"fresh", "stale", "degraded", "missing", "halted_suspect"}
+)
+_NON_FRESH_DATA_STATES = frozenset({"stale", "degraded", "missing", "halted_suspect"})
 _PROVENANCE_FIELD_NAMES = frozenset(
     {"provider", "served_by", "mode", "status", "error_code"}
 )
@@ -1144,7 +1149,7 @@ def _extract_error_code(
     if semantic_success:
         return None
     data_state = freshness.get("data_state")
-    if data_state in {"stale", "degraded", "missing"}:
+    if data_state in _NON_FRESH_DATA_STATES:
         return f"{data_state}_data"
     if _has_true_flag(envelope, frozenset({"stale", "is_stale"})):
         return "stale_data"

--- a/app/services/halt_detection.py
+++ b/app/services/halt_detection.py
@@ -1,0 +1,293 @@
+"""ROB-1236 — trading-halt *suspicion* detector for daily OHLCV series.
+
+Why this exists
+---------------
+``analyze_stock_batch`` classified ``data_state`` purely from *whether a latest
+bar exists*, never from whether that bar was **alive**. On 2026-08-10 a KRX
+symbol under a 인적분할 매매거래정지 (000880 한화) had eight consecutive daily
+bars with ``volume == 0`` and OHLC frozen at 83,800. The tool returned
+``data_state: "fresh"``, a normal-looking current price, and RSI / support /
+resistance / upside all computed from those dead candles. A live session ranked
+it as buy candidate #2; only a later session's manual OHLCV cross-check caught
+it before a real-account proposal went out.
+
+What this module is — and is not
+--------------------------------
+It answers one narrow question: *do the most recent N daily bars look inert?*
+That is **suspicion, not confirmation** — hence ``halted_suspect``. This
+repository has **no KRX 거래정지 master feed**: there is no halt table, no halt
+service, and no ingestion CLI for one, so nothing here can assert that a symbol
+is actually halted. The only evidence available is the shape of the bars, and
+the naming, the payload field (``krx_halt_master: "unavailable"``) and the
+consumer wording all keep that distinction visible. Do not restate a verdict
+from this module as a confirmed halt.
+
+Detection rule
+--------------
+A daily bar is **frozen** when either:
+
+* its volume is known and is exactly ``0``; or
+* it has no intraday range at all (``high == low == close``, and ``open ==
+  close`` when open is known) **and** its close equals the prior bar's close.
+
+The second clause deliberately requires the unchanged-vs-prior-close check: a
+limit-up / limit-down lock also prints ``open == high == low == close``, but at
+a price that by construction differs from the prior close. Without that check
+every 상한가 잠김 day would be misread as a halt.
+
+A symbol is ``halted_suspect`` when the run of frozen bars **ending at the most
+recent bar** reaches :data:`MIN_FROZEN_SESSIONS`.
+
+Choosing N (= 3)
+----------------
+``MIN_FROZEN_SESSIONS = 3`` — see the constant's own docstring for the full
+both-directions error argument.
+
+The module is pure: stdlib + optional pandas duck-typing, no DB, no network, no
+broker, no clock. It is imported by both ``app/`` and ``scripts/`` consumers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any, NamedTuple
+
+#: The ``data_state`` value consumers must emit instead of ``"fresh"`` when a
+#: series looks inert. Named "suspect" on purpose — it is never a confirmation.
+HALTED_SUSPECT_DATA_STATE = "halted_suspect"
+
+#: Number of consecutive frozen sessions (ending at the newest bar) required
+#: before a symbol is flagged.
+#:
+#: **Why 3.**
+#:
+#: *Too large.* The 000880 incident ran eight sessions, but the contaminated
+#: buy ranking happened *mid-halt*, not on day 8 — a threshold tuned to the
+#: observed run length (N=8) would have fired only on the final day and would
+#: have let the actual incident through. It would also miss every short KRX
+#: halt outright: 조회공시 요구, 불성실공시 지정예고, and 단일가 조치 routinely
+#: last one to three sessions, which is the bulk of real halts by count.
+#:
+#: *Too small.* At N=1 a single zero-volume print flags the symbol, and a
+#: single zero-volume print is ordinary: genuinely illiquid microcaps trade
+#: nothing on some days, and a candle row whose volume simply failed to ingest
+#: is indistinguishable from a real zero. N=2 still fires on a two-row
+#: ingestion gap, which is a plausible batch failure mode.
+#:
+#: *Residual error accepted at N=3.* False negatives — a one- or two-session
+#: halt is not flagged; that window still reaches consumers, and the
+#: cross-check in the operating session remains the backstop for it. False
+#: positives — an ultra-thin symbol with three genuinely zero-volume sessions
+#: is flagged; the blast radius is bounded because the screener and the policy
+#: table both already apply a turnover floor that excludes such names, and
+#: because every exclusion is reported with its symbol and reason rather than
+#: silently dropped.
+MIN_FROZEN_SESSIONS = 3
+
+#: Reason codes attached to a suspicion. Both may be present in one run.
+REASON_ZERO_VOLUME = "zero_volume"
+REASON_ZERO_VARIATION = "zero_variation"
+
+#: Recorded on every verdict. There is no KRX halt master in this repository;
+#: stating so explicitly is preferable to leaving the reader to assume one was
+#: consulted.
+KRX_HALT_MASTER_STATUS = "unavailable"
+
+_SUSPICION_NOTE = (
+    "halted_suspect is a suspicion derived from inert daily bars "
+    "(consecutive zero-volume or zero-variation sessions), not a confirmed "
+    "trading halt — no KRX halt master is available to this service. "
+    "Indicators are withheld rather than estimated."
+)
+
+
+class HaltBar(NamedTuple):
+    """One daily bar. ``open``/``volume`` are optional evidence."""
+
+    close: Decimal
+    high: Decimal | None = None
+    low: Decimal | None = None
+    volume: Decimal | None = None
+    open: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class HaltSuspicion:
+    """Verdict for one symbol's daily series."""
+
+    suspected: bool
+    frozen_sessions: int
+    reasons: tuple[str, ...]
+    bars_examined: int
+    min_sessions: int = MIN_FROZEN_SESSIONS
+
+    @property
+    def insufficient_bars(self) -> bool:
+        """True when the series is too short to reach a verdict either way."""
+        return self.bars_examined < self.min_sessions
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe evidence block for MCP responses and policy-table payloads."""
+        return {
+            "suspected": self.suspected,
+            "frozen_sessions": self.frozen_sessions,
+            "min_sessions": self.min_sessions,
+            "reasons": list(self.reasons),
+            "bars_examined": self.bars_examined,
+            "krx_halt_master": KRX_HALT_MASTER_STATUS,
+            "note": _SUSPICION_NOTE,
+        }
+
+
+_NOT_SUSPECT_EMPTY = HaltSuspicion(
+    suspected=False, frozen_sessions=0, reasons=(), bars_examined=0
+)
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        # str() first so binary floats round-trip to their printed form; a
+        # frozen bar stores byte-identical values, which stay equal here.
+        parsed = value if isinstance(value, Decimal) else Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    # NaN would silently poison every equality check below.
+    return None if parsed.is_nan() else parsed
+
+
+def _is_nan(value: Any) -> bool:
+    return value != value  # noqa: PLR0124 — NaN is the only self-unequal value
+
+
+def _bar_frozen_reason(bar: HaltBar, prev_close: Decimal | None) -> str | None:
+    """Return why ``bar`` looks inert, or ``None`` if it looks alive."""
+    if bar.volume is not None and bar.volume == 0:
+        return REASON_ZERO_VOLUME
+
+    if bar.high is None or bar.low is None:
+        return None
+    if not (bar.high == bar.low == bar.close):
+        return None
+    if bar.open is not None and bar.open != bar.close:
+        return None
+    # A limit-up/limit-down lock is also range-less, but never at the prior
+    # close. Requiring the unchanged close is what separates the two.
+    if prev_close is None or bar.close != prev_close:
+        return None
+    return REASON_ZERO_VARIATION
+
+
+def classify_bars(bars: Sequence[HaltBar]) -> HaltSuspicion:
+    """Classify an **ascending** (oldest → newest) sequence of daily bars."""
+    if not bars:
+        return _NOT_SUSPECT_EMPTY
+
+    frozen_sessions = 0
+    reasons: list[str] = []
+    for index in range(len(bars) - 1, -1, -1):
+        prev_close = bars[index - 1].close if index > 0 else None
+        reason = _bar_frozen_reason(bars[index], prev_close)
+        if reason is None:
+            break
+        frozen_sessions += 1
+        if reason not in reasons:
+            reasons.append(reason)
+
+    return HaltSuspicion(
+        suspected=frozen_sessions >= MIN_FROZEN_SESSIONS,
+        frozen_sessions=frozen_sessions,
+        reasons=tuple(sorted(reasons)),
+        bars_examined=len(bars),
+    )
+
+
+def classify_ohlcv_rows(rows: Iterable[Sequence[Any]]) -> HaltSuspicion:
+    """Classify ``[close, high, low, volume?]`` rows, ascending.
+
+    This is the ``scripts/policy_table`` raw-candle shape. ``volume`` is a
+    later addition, so three-element rows from an older replay dump are still
+    accepted — they simply fall back to the zero-variation rule alone.
+    """
+    bars: list[HaltBar] = []
+    for row in rows:
+        if len(row) < 3:
+            continue
+        close = _to_decimal(row[0])
+        if close is None:
+            continue
+        bars.append(
+            HaltBar(
+                close=close,
+                high=_to_decimal(row[1]),
+                low=_to_decimal(row[2]),
+                volume=_to_decimal(row[3]) if len(row) > 3 else None,
+            )
+        )
+    return classify_bars(bars)
+
+
+def classify_ohlcv_frame(frame: Any) -> HaltSuspicion:
+    """Classify a canonical OHLCV ``DataFrame`` (ascending by date).
+
+    Accepts any frame exposing ``empty``/``columns``/column indexing, which is
+    what every ``_fetch_ohlcv_for_indicators`` path returns. Missing columns or
+    an unreadable frame yield "not suspected" rather than an exception — this
+    detector must never be the thing that breaks an analysis call.
+    """
+    if frame is None:
+        return _NOT_SUSPECT_EMPTY
+    try:
+        if getattr(frame, "empty", True):
+            return _NOT_SUSPECT_EMPTY
+        columns = set(frame.columns)
+        if "close" not in columns:
+            return _NOT_SUSPECT_EMPTY
+
+        def column(name: str) -> list[Any]:
+            if name not in columns:
+                return [None] * len(frame)
+            return list(frame[name])
+
+        closes = column("close")
+        highs = column("high")
+        lows = column("low")
+        volumes = column("volume")
+        opens = column("open")
+    except Exception:  # noqa: BLE001 — never let detection break the caller
+        return _NOT_SUSPECT_EMPTY
+
+    bars: list[HaltBar] = []
+    for index, raw_close in enumerate(closes):
+        if raw_close is None or _is_nan(raw_close):
+            continue
+        close = _to_decimal(raw_close)
+        if close is None:
+            continue
+        bars.append(
+            HaltBar(
+                close=close,
+                high=_to_decimal(highs[index]),
+                low=_to_decimal(lows[index]),
+                volume=_to_decimal(volumes[index]),
+                open=_to_decimal(opens[index]),
+            )
+        )
+    return classify_bars(bars)
+
+
+__all__ = [
+    "HALTED_SUSPECT_DATA_STATE",
+    "KRX_HALT_MASTER_STATUS",
+    "MIN_FROZEN_SESSIONS",
+    "REASON_ZERO_VARIATION",
+    "REASON_ZERO_VOLUME",
+    "HaltBar",
+    "HaltSuspicion",
+    "classify_bars",
+    "classify_ohlcv_frame",
+    "classify_ohlcv_rows",
+]

--- a/docs/runbooks/halted-suspect-data-state.md
+++ b/docs/runbooks/halted-suspect-data-state.md
@@ -1,0 +1,98 @@
+# `halted_suspect` — 정지 의심 종목 (ROB-1236)
+
+## 0. 한 줄
+
+최근 **N=3 거래일 연속** 봉이 죽어 있으면(`volume=0` **또는** 0-변동) 그 종목은
+`data_state: "halted_suspect"` 로 표시되고, **지표는 null 이 되며**, 스크리너·정책표에서
+**제외**된다. 🔴 **이건 "의심"이지 확정 정지가 아니다.**
+
+## 1. 왜 생겼나 (실사례)
+
+`000880` 한화 — 인적분할 매매거래정지로 8거래일 연속 `volume=0`, OHLC 83,800 동결.
+그런데 `analyze_stock_batch` 는 `data_state: "fresh"` + 정상 현재가 83,800 을 반환했고,
+RSI 35.40 · 지지/저항 · upside +84% 가 **전부 0-변동 캔들 위에서 계산**됐다.
+11:30 live 세션이 이 종목을 매수 후보 rank 2 로 랭킹했고, 13:05 후속 세션이 OHLCV 를
+직접 교차확인해서야 정지를 발견해 **제안 직전에 차단**했다.
+
+원인: `data_state` 판정이 「최신 봉이 있느냐」만 보고 **봉이 살아 있느냐**를 안 봤다.
+
+## 2. 판정 규칙
+
+한 봉이 **frozen** 인 조건 (둘 중 하나):
+
+| 조건 | reason 코드 |
+|---|---|
+| `volume` 을 알 수 있고 정확히 `0` | `zero_volume` |
+| `high == low == close` (open 이 있으면 `open == close`) **그리고** `close == 직전봉 close` | `zero_variation` |
+
+**가장 최근 봉에서 끝나는** frozen 연속 구간이 **3개 이상**이면 `halted_suspect`.
+
+- 🔴 두 번째 조건이 "직전 close 와 같을 것"을 요구하는 이유 = **상한가/하한가 잠김**도
+  `open=high=low=close` 로 찍히지만 **직전 close 와는 반드시 다른 가격**이기 때문. 이 절이
+  없으면 잠김 종목이 전부 정지로 오판된다.
+- 이미 거래가 재개된 종목은 과거에 frozen 구간이 있어도 잡히지 않는다(최신 봉 기준).
+
+### N=3 의 근거 (양쪽 오차)
+
+- **N 이 크면**: 000880 은 8거래일이었지만 **오염된 매수 랭킹은 정지 중간에** 일어났다.
+  실측치(8)에 맞추면 마지막 날에만 발화해 **실사례 자체를 못 막는다.** 게다가 조회공시 요구·
+  불성실공시 지정예고·단일가 조치 같은 **1~3일짜리 짧은 정지는 전부 놓친다**(건수로는 이쪽이 다수).
+- **N 이 작으면**: `N=1` 은 거래 한산한 초소형주의 하루 무거래, 그리고 **volume 적재 실패로
+  0 이 들어간 행**까지 전부 잡는다. `N=2` 도 2행짜리 적재 갭에 발화한다.
+- **N=3 에서 남는 오차**:
+  - 위음성 — **1~2일 정지는 안 잡힌다.** 그 구간은 여전히 세션까지 흘러가고, 운영 세션의
+    OHLCV 교차확인이 계속 백스톱이다.
+  - 위양성 — 정말로 3일 연속 무거래인 초저유동 종목은 잡힌다. 스크리너·정책표는 이미
+    turnover 하한을 걸어 이런 종목을 거르고, **제외는 전부 심볼·근거와 함께 보고**되므로
+    조용히 사라지지 않는다.
+
+## 3. KRX 거래정지 마스터
+
+🔴 **없다.** 이 레포에는 거래정지 마스터 테이블도, 서비스도, 수집 CLI 도 없다. 따라서
+판정은 **봉의 모양만** 근거로 하며, 응답에 `krx_halt_master: "unavailable"` 를 항상 적어
+"마스터를 봤다"는 오해를 차단한다. 🔴 **확정 정지로 단정해서 보고하지 말 것.**
+
+## 4. 소비자별 동작
+
+| 소비자 | 동작 |
+|---|---|
+| `analyze_stock_batch` / `analyze_stock` | `data_state` = `halted_suspect` (top-level + quote 양쪽). `indicators` · `support_resistance` = **null** (추정·보간 없음). recommendation 은 RSI 부재로 `hold`/`low` + `insufficient_inputs` 로 자동 하한. 근거는 `halt_suspect` 블록. compact 요약에도 실린다 |
+| `screen_stocks` | 행 **제외**. 제외분은 `meta.halted_suspect_excluded` + `warnings` 로 보고. 🔴 봉 이력 조회 실패는 **제외하지 않고**(fail-open) warning 만 남긴다 — DB 장애는 정지의 증거가 아니다. 🔴 비용 게이트 = §4-1 |
+| `scripts/policy_table` (kr/us/crypto) | `rows` 에서 **제외**. `universe.halted_suspect` 에 심볼·근거 보존, KR/US 는 `universe.skipped` 에 `reason="halted_suspect"` 로도 계상. 요약 md 에 심볼이 그대로 찍힌다 |
+
+B0-X 는 `policy_table.v1` 의 `rows` 만 읽으므로 별도 변경 없이 오염이 차단된다
+(`universe.halted_suspect` 는 additive, `schema` 값 불변).
+
+### 4-1. 스크리너 비용 게이트 (🔴 알려진 한계)
+
+봉 이력 조회는 cache-first 이지만 **KRX 장중에는 일봉 캐시를 일부러 우회**한다(오늘 봉이
+형성 중이라). 그대로 두면 100행 스크린이 장중에 **KIS 라이브 캔들 100회**를 때린다 —
+운영 세션이 도는 바로 그 시간대에. 그래서 이력 조회는 **행 자신의 최신봉 거래량**으로
+먼저 거른다: 판정은 "최신봉에서 끝나는" 연속 구간을 요구하므로, 최신봉이 거래됐다면
+`zero_volume` 정지는 성립할 수 없다. `volume` 이 없거나 파싱 불가면 **거르지 않고
+이력을 읽는다**(게이트가 정지를 놓치는 원인이 되면 안 되므로).
+
+🔴 **이 게이트가 감수하는 구멍**: 거래량은 있는데 **0-변동만으로** 얼어붙은 구간
+(3일 연속 장중 변동폭 0 + 종가 불변)은 스크리너에서 건너뛴다.
+`analyze_stock_batch` 와 정책표 빌더는 이력을 **무조건** 읽으므로 그쪽에서는 잡힌다 —
+이 단축은 스크리너 행별 hot path 에만 있다.
+
+## 5. 운영자 대응
+
+1. `halted_suspect` 가 뜨면 **먼저 실제 정지 여부를 직접 확인**한다(KRX/증권사 공시).
+2. 진짜 정지 → 그대로 두고 매매 대상에서 뺀다.
+3. **오탐이면(거래는 되는데 3일 연속 무거래·무변동)** → 표·스크리너에서 빠진 게 맞는지
+   `meta.halted_suspect_excluded` / `universe.halted_suspect` 로 확인하고, 필요하면 해당
+   종목만 수동으로 다시 검토한다. 🔴 임계값을 낮추기 전에 오탐 사례를 먼저 기록할 것.
+
+## 6. 코드 위치
+
+- 판정기(순수, stdlib): `app/services/halt_detection.py`
+- analyze 배선: `app/mcp_server/tooling/analysis_analyze.py::_apply_halt_suspect`
+- 스크리너 게이트: `app/mcp_server/tooling/screening/halt_filter.py`
+  (`screen_stocks_unified` 단일 깔때기에서 호출)
+- 정책표: `scripts/policy_table/adapters/{kr,us,crypto}.py::compute_policy_table`
+- 테스트: `tests/services/test_halt_detection.py`,
+  `tests/mcp_server/test_analyze_halted_suspect.py`,
+  `tests/mcp_server/tooling/test_screen_stocks_halt_filter.py`,
+  `tests/scripts/test_policy_table_halt_suspect.py`

--- a/scripts/policy_table/adapters/crypto.py
+++ b/scripts/policy_table/adapters/crypto.py
@@ -30,6 +30,7 @@ from app.services.brokers.upbit.client import (
     fetch_top_traded_coins,
     parse_upbit_account_row,
 )
+from app.services.halt_detection import classify_ohlcv_rows
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from research.kr_corpus.d3_engine.models import Position
 from research.kr_corpus.d3_engine.policies import update_underwater_close
@@ -74,7 +75,10 @@ class RawInputs:
     watch_alerts: list[dict[str, Any]]
     top_traded: list[dict[str, str]]
     orderable_krw: str
-    candles: dict[str, list[list[str]]]  # symbol -> [[close, high, low], ...] ascending
+    # symbol -> [[close, high, low, volume], ...] ascending. ROB-1236 appended
+    # ``volume`` for halt detection; three-element rows from an older replay
+    # dump still classify (zero-variation rule only), so existing dumps replay.
+    candles: dict[str, list[list[str]]]
 
     def to_jsonable(self) -> dict[str, Any]:
         return {
@@ -154,6 +158,7 @@ async def _fetch_candles_raw(symbol: str) -> list[list[str]] | None:
                 str(Decimal(str(bar["close"]))),
                 str(Decimal(str(bar["high"]))),
                 str(Decimal(str(bar["low"]))),
+                str(Decimal(str(bar["volume"]))),
             ]
         )
     return rows
@@ -459,8 +464,24 @@ def compute_policy_table(
     )
 
     rows: list[dict[str, Any]] = []
+    halted_suspect: list[dict[str, Any]] = []
     for symbol in universe_symbols:
         bars = raw.candles[symbol]
+        # ROB-1236: an inert recent series (consecutive zero-volume or
+        # zero-variation sessions) is dropped from ``rows`` entirely rather
+        # than emitted with signals computed off dead candles. On an Upbit KRW
+        # market this reads as a dead or suspended feed rather than a KRX-style
+        # halt, but the contamination it causes downstream is identical.
+        halt = classify_ohlcv_rows(bars)
+        if halt.suspected:
+            halted_suspect.append(
+                {
+                    "symbol": symbol,
+                    "held": symbol in holdings_by_symbol,
+                    **halt.to_dict(),
+                }
+            )
+            continue
         closes = [Decimal(bar[0]) for bar in bars]
         highs = [Decimal(bar[1]) for bar in bars]
         lows = [Decimal(bar[2]) for bar in bars]
@@ -534,6 +555,9 @@ def compute_policy_table(
             "symbols_with_insufficient_history": sorted(
                 row["symbol"] for row in rows if row["insufficient_history"]
             ),
+            # ROB-1236 — excluded from ``rows``, kept visible here. Suspicion
+            # from inert bars, not a confirmed suspension.
+            "halted_suspect": halted_suspect,
         },
         "market_context": {
             "alt_breadth": {

--- a/scripts/policy_table/adapters/kr.py
+++ b/scripts/policy_table/adapters/kr.py
@@ -37,6 +37,7 @@ from app.services.brokers.kis.account import AccountClient
 from app.services.brokers.kis.base import BaseKISClient
 from app.services.brokers.kis.protocols import KISClientProtocol
 from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+from app.services.halt_detection import classify_ohlcv_rows
 from app.services.invest_screener_snapshots.repository import (
     InvestScreenerSnapshotsRepository,
 )
@@ -138,7 +139,10 @@ class RawInputs:
     snapshot_partition_date: str | None
     snapshot_breadth: dict[str, Any] | None
     universe_symbols: list[str]  # filter_passed ∪ holdings ∪ watch (attempted set)
-    candles: dict[str, list[list[str]]]  # symbol -> [[close, high, low], ...] ascending
+    # symbol -> [[close, high, low, volume], ...] ascending. ROB-1236 appended
+    # ``volume`` for halt detection; three-element rows from an older replay
+    # dump still classify (zero-variation rule only), so existing dumps replay.
+    candles: dict[str, list[list[str]]]
 
     def to_jsonable(self) -> dict[str, Any]:
         return {
@@ -289,6 +293,7 @@ async def _fetch_kr_daily_candles_raw(symbol: str) -> list[list[str]] | None:
             str(Decimal(str(r.close))),
             str(Decimal(str(r.high))),
             str(Decimal(str(r.low))),
+            str(Decimal(str(r.volume))),
         ]
         for r in rows
     ]
@@ -573,8 +578,33 @@ def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
 
     rows: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
+    halted_suspect: list[dict[str, Any]] = []
     for symbol in raw.universe_symbols:
         bars = raw.candles.get(symbol, [])
+        # ROB-1236: a symbol whose recent bars are inert (consecutive
+        # zero-volume or zero-variation sessions) is dropped from ``rows``
+        # entirely rather than emitted with signals computed off dead candles.
+        # Dropping is fail-closed for every downstream consumer of this payload
+        # (B0-X reads these rows) and needs no change on their side; the
+        # symbol stays visible under ``universe.halted_suspect`` so the removal
+        # is auditable and can be overruled.
+        halt = classify_ohlcv_rows(bars)
+        if halt.suspected:
+            halted_suspect.append(
+                {
+                    "symbol": symbol,
+                    "held": symbol in holdings_by_symbol,
+                    **halt.to_dict(),
+                }
+            )
+            skipped.append(
+                {
+                    "symbol": symbol,
+                    "reason": "halted_suspect",
+                    "bars_available": len(bars),
+                }
+            )
+            continue
         closes = [Decimal(bar[0]) for bar in bars]
         highs = [Decimal(bar[1]) for bar in bars]
         lows = [Decimal(bar[2]) for bar in bars]
@@ -643,6 +673,9 @@ def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
             "attempted_symbols": len(raw.universe_symbols),
             "computed_symbols": len(raw.universe_symbols) - len(skipped),
             "skipped": skipped,
+            # ROB-1236 — excluded from ``rows``, kept visible here. Suspicion
+            # from inert bars, not a confirmed halt (no KRX halt master).
+            "halted_suspect": halted_suspect,
         },
         "market_context": {
             "snapshot_breadth": raw.snapshot_breadth,
@@ -722,6 +755,15 @@ def render_summary_md(payload: dict[str, Any], *, top_n: int = 50) -> str:
             by_reason[s["reason"]] = by_reason.get(s["reason"], 0) + 1
         reason_str = ", ".join(f"{k}={v}" for k, v in sorted(by_reason.items()))
         lines.append(f"skipped: {len(u['skipped'])} ({reason_str})")
+    # ROB-1236 — name the excluded symbols; a silent drop of a real candidate
+    # is the failure mode of this filter, so it has to be readable.
+    for entry in u.get("halted_suspect") or []:
+        lines.append(
+            f"halted_suspect (excluded, NOT a confirmed halt): {entry['symbol']}"
+            f"{' [held]' if entry.get('held') else ''} — "
+            f"{entry['frozen_sessions']} inert sessions, "
+            f"reasons={'+'.join(entry['reasons'])}"
+        )
     lines.append("")
 
     breadth = payload["market_context"].get("snapshot_breadth")

--- a/scripts/policy_table/adapters/us.py
+++ b/scripts/policy_table/adapters/us.py
@@ -36,6 +36,7 @@ from app.models.market_valuation_snapshot import MarketValuationSnapshot
 from app.models.us_symbol_universe import USSymbolUniverse
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
 from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+from app.services.halt_detection import classify_ohlcv_rows
 from app.services.invest_screener_snapshots.repository import (
     InvestScreenerSnapshotsRepository,
 )
@@ -108,7 +109,10 @@ class RawInputs:
     snapshot_partition_date: str | None
     snapshot_breadth: dict[str, Any] | None
     universe_symbols: list[str]
-    candles: dict[str, list[list[str]]]  # symbol -> [[close, high, low], ...]
+    # symbol -> [[close, high, low, volume], ...] ascending. ROB-1236 appended
+    # ``volume`` for halt detection; three-element rows from an older replay
+    # dump still classify (zero-variation rule only), so existing dumps replay.
+    candles: dict[str, list[list[str]]]
     market_cap_fill_stats: dict[str, Any]
 
     def to_jsonable(self) -> dict[str, Any]:
@@ -351,6 +355,7 @@ async def _fetch_us_daily_candles_raw(
             str(Decimal(str(r.close))),
             str(Decimal(str(r.high))),
             str(Decimal(str(r.low))),
+            str(Decimal(str(r.volume))),
         ]
         for r in rows
     ]
@@ -650,8 +655,32 @@ def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
 
     rows: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
+    halted_suspect: list[dict[str, Any]] = []
     for symbol in raw.universe_symbols:
         bars = raw.candles.get(symbol, [])
+        # ROB-1236: an inert recent series (consecutive zero-volume or
+        # zero-variation sessions) is dropped from ``rows`` entirely rather
+        # than emitted with signals computed off dead candles. Dropping is
+        # fail-closed for every consumer of this payload and needs no change
+        # on their side; the symbol stays visible under
+        # ``universe.halted_suspect`` so the removal is auditable.
+        halt = classify_ohlcv_rows(bars)
+        if halt.suspected:
+            halted_suspect.append(
+                {
+                    "symbol": symbol,
+                    "held": symbol in holdings_by_symbol,
+                    **halt.to_dict(),
+                }
+            )
+            skipped.append(
+                {
+                    "symbol": symbol,
+                    "reason": "halted_suspect",
+                    "bars_available": len(bars),
+                }
+            )
+            continue
         closes = [Decimal(bar[0]) for bar in bars]
         highs = [Decimal(bar[1]) for bar in bars]
         lows = [Decimal(bar[2]) for bar in bars]
@@ -738,6 +767,9 @@ def compute_policy_table(raw: RawInputs) -> dict[str, Any]:
             "attempted_symbols": len(raw.universe_symbols),
             "computed_symbols": len(raw.universe_symbols) - len(skipped),
             "skipped": skipped,
+            # ROB-1236 — excluded from ``rows``, kept visible here. Suspicion
+            # from inert bars, not a confirmed halt (no halt master feed).
+            "halted_suspect": halted_suspect,
         },
         "market_context": {
             "snapshot_breadth": raw.snapshot_breadth,
@@ -813,6 +845,15 @@ def render_summary_md(payload: dict[str, Any], *, top_n: int = 50) -> str:
             by_reason[s["reason"]] = by_reason.get(s["reason"], 0) + 1
         reason_str = ", ".join(f"{k}={v}" for k, v in sorted(by_reason.items()))
         lines.append(f"skipped: {len(u['skipped'])} ({reason_str})")
+    # ROB-1236 — name the excluded symbols; a silent drop of a real candidate
+    # is the failure mode of this filter, so it has to be readable.
+    for entry in u.get("halted_suspect") or []:
+        lines.append(
+            f"halted_suspect (excluded, NOT a confirmed halt): {entry['symbol']}"
+            f"{' [held]' if entry.get('held') else ''} — "
+            f"{entry['frozen_sessions']} inert sessions, "
+            f"reasons={'+'.join(entry['reasons'])}"
+        )
     fill = payload.get("config", {}).get("market_cap_fill_stats") or {}
     if fill:
         lines.append(

--- a/tests/mcp_server/test_analyze_halted_suspect.py
+++ b/tests/mcp_server/test_analyze_halted_suspect.py
@@ -1,0 +1,204 @@
+"""ROB-1236 — ``analyze_stock_impl`` must not call an inert series "fresh".
+
+Incident: 000880 한화 sat in a 인적분할 매매거래정지 for eight sessions with
+``volume == 0`` and OHLC frozen at 83,800. ``analyze_stock_batch`` returned
+``data_state: "fresh"`` plus RSI 35.40, supports/resistances and an +84% upside
+— every one of them arithmetic over dead candles — and a live session ranked it
+buy candidate #2.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling.analysis_analyze import analyze_stock_impl
+from app.mcp_server.tooling.analysis_tool_handlers import _summarize_analysis_result
+
+pytestmark = pytest.mark.unit
+
+FROZEN_PRICE = 83800.0
+SYMBOL = "000880"
+
+
+def _frame(*, frozen_sessions: int, live_sessions: int = 190) -> pd.DataFrame:
+    """Live history, then ``frozen_sessions`` zero-volume frozen bars."""
+    opens, highs, lows, closes, volumes = [], [], [], [], []
+    price = 78000.0
+    for i in range(live_sessions):
+        price += 150.0 if i % 3 else -100.0
+        opens.append(price - 50.0)
+        highs.append(price + 400.0)
+        lows.append(price - 350.0)
+        closes.append(price)
+        volumes.append(120000.0)
+    if live_sessions:
+        # The final live session closes exactly where the halt freezes.
+        opens[-1] = FROZEN_PRICE - 200.0
+        highs[-1] = FROZEN_PRICE + 900.0
+        lows[-1] = FROZEN_PRICE - 700.0
+        closes[-1] = FROZEN_PRICE
+    for _ in range(frozen_sessions):
+        opens.append(FROZEN_PRICE)
+        highs.append(FROZEN_PRICE)
+        lows.append(FROZEN_PRICE)
+        closes.append(FROZEN_PRICE)
+        volumes.append(0.0)
+    return pd.DataFrame(
+        {
+            "open": opens,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": volumes,
+            "value": [c * 1000 for c in closes],
+        }
+    )
+
+
+async def _analyze(frame: pd.DataFrame) -> dict:
+    """Run the KR analyze pipeline against ``frame`` with everything else stubbed.
+
+    Every stub is deliberately *healthy* — populated indicators, populated
+    support/resistance, a provider envelope with real evidence and a current
+    timestamp — so the baseline freshness verdict is literally ``"fresh"``.
+    That is what the 000880 session saw, and it is what makes these tests fail
+    loudly if the halt gate is removed rather than merely shifting the state.
+    """
+    with (
+        patch(
+            "app.mcp_server.tooling.analysis_analyze._fetch_ohlcv_for_indicators",
+            new_callable=AsyncMock,
+            return_value=frame,
+        ),
+        patch(
+            "app.mcp_server.tooling.analysis_analyze._resolve_kr_quote",
+            new_callable=AsyncMock,
+            return_value={
+                "symbol": SYMBOL,
+                "instrument_type": "equity_kr",
+                "price": FROZEN_PRICE,
+                "source": "kis",
+                "data_state": "fresh",
+                "price_usable": True,
+                "is_stale_price": False,
+            },
+        ),
+        patch(
+            "app.mcp_server.tooling.analysis_analyze._get_indicators_impl",
+            new_callable=AsyncMock,
+            return_value={"rsi": {"14": 35.4}, "bb": {"upper": 1.0, "lower": 0.5}},
+        ),
+        patch(
+            "app.mcp_server.tooling.analysis_analyze._get_support_resistance_impl",
+            new_callable=AsyncMock,
+            return_value={
+                "supports": [{"price": 80000.0}],
+                "resistances": [{"price": 90000.0}],
+            },
+        ),
+        patch(
+            "app.mcp_server.tooling.analysis_analyze._fetch_kr_snapshot_cached",
+            new_callable=AsyncMock,
+            return_value={
+                "payload": {},
+                "evidence_present": True,
+                "status": "ok",
+                "cache_hit": False,
+                "fetched_at": datetime.now(UTC).isoformat(),
+            },
+        ),
+    ):
+        return await analyze_stock_impl(SYMBOL, market="kr")
+
+
+# ---------------------------------------------------------------------------
+# The incident fixture: before the fix this returned data_state "fresh"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_000880_frozen_series_is_not_fresh():
+    analysis = await _analyze(_frame(frozen_sessions=8))
+
+    # Identical stubs to the healthy-symbol test below, which asserts "fresh" —
+    # the only difference is the eight inert bars.
+    assert analysis["data_state"] == "halted_suspect"
+    assert analysis["data_state"] != "fresh"
+    assert analysis["quote"]["data_state"] == "halted_suspect"
+    assert analysis["quote"]["data_state"] != "fresh"
+    assert analysis["quote"]["price_usable"] is False
+
+
+@pytest.mark.asyncio
+async def test_000880_bar_derived_indicators_are_null_not_estimated():
+    analysis = await _analyze(_frame(frozen_sessions=8))
+
+    assert analysis["indicators"] is None
+    assert analysis["support_resistance"] is None
+
+
+@pytest.mark.asyncio
+async def test_000880_recommendation_is_floored_and_carries_no_rsi():
+    analysis = await _analyze(_frame(frozen_sessions=8))
+
+    recommendation = analysis["recommendation"]
+    assert recommendation["rsi14"] is None
+    assert recommendation["action"] == "hold"
+    assert recommendation["confidence"] == "low"
+    assert recommendation["insufficient_inputs"]
+
+
+@pytest.mark.asyncio
+async def test_000880_evidence_is_attached_as_a_suspicion():
+    analysis = await _analyze(_frame(frozen_sessions=8))
+
+    evidence = analysis["halt_suspect"]
+    assert evidence["suspected"] is True
+    assert evidence["frozen_sessions"] == 8
+    assert evidence["krx_halt_master"] == "unavailable"
+    assert "not a confirmed trading halt" in evidence["note"]
+
+
+@pytest.mark.asyncio
+async def test_000880_compact_batch_summary_carries_the_suspicion():
+    """The batch contract is what the live session actually read."""
+    analysis = await _analyze(_frame(frozen_sessions=8))
+
+    summary = _summarize_analysis_result(SYMBOL, analysis)
+
+    assert summary["data_state"] == "halted_suspect"
+    assert summary["halt_suspect"]["suspected"] is True
+    assert summary["rsi_14"] is None
+    assert summary["supports"] == []
+    assert summary["resistances"] == []
+
+
+# ---------------------------------------------------------------------------
+# No false positives — a flagged live symbol is silently un-buyable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_actively_traded_symbol_stays_fresh_with_indicators():
+    analysis = await _analyze(_frame(frozen_sessions=0))
+
+    assert analysis["data_state"] == "fresh"
+    assert "halt_suspect" not in analysis
+    assert analysis["indicators"] is not None
+    assert analysis["support_resistance"] is not None
+
+    summary = _summarize_analysis_result(SYMBOL, analysis)
+    assert summary["rsi_14"] == 35.4
+    assert [level["price"] for level in summary["supports"]] == [80000.0]
+
+
+@pytest.mark.asyncio
+async def test_two_frozen_sessions_are_below_the_threshold():
+    analysis = await _analyze(_frame(frozen_sessions=2))
+
+    assert analysis["data_state"] == "fresh"
+    assert analysis["indicators"] is not None

--- a/tests/mcp_server/tooling/test_screen_stocks_halt_filter.py
+++ b/tests/mcp_server/tooling/test_screen_stocks_halt_filter.py
@@ -126,6 +126,35 @@ async def test_zero_volume_row_still_gets_the_full_history_read():
 
 
 @pytest.mark.asyncio
+async def test_crypto_rows_are_gated_on_their_own_field_names():
+    """Crypto rows carry volume_24h / trade_amount_24h, not ``volume``."""
+    response = {
+        "results": [
+            {
+                "symbol": "KRW-BTC",
+                "market": "crypto",
+                "volume_24h": 1200.0,
+                "trade_amount_24h": 900_000_000_000.0,
+            }
+        ],
+        "total_count": 1,
+        "returned_count": 1,
+        "market": "crypto",
+        "meta": {},
+    }
+
+    fetch = AsyncMock(side_effect=AssertionError("history must not be read"))
+    with patch(
+        "app.mcp_server.tooling.screening.halt_filter._fetch_ohlcv_for_indicators",
+        new=fetch,
+    ):
+        result = await exclude_halt_suspect_rows(response, market="crypto")
+
+    assert fetch.await_count == 0
+    assert result is response
+
+
+@pytest.mark.asyncio
 async def test_unparseable_volume_falls_through_to_the_history_read():
     """The cheap gate must never be the reason a halt slips through."""
     response = _response()
@@ -201,7 +230,13 @@ async def test_history_read_failure_keeps_the_row_and_warns():
         "000880",
         "000660",
     ]
-    assert any("halt check skipped" in w for w in result["warnings"])
+    # Diagnostics only — ``warnings`` is a contract callers assert on exactly,
+    # and a transient candle-store error is not an operator action item.
+    assert any(
+        "halt check skipped" in entry
+        for entry in result["meta"]["halted_suspect_check_skipped"]
+    )
+    assert "warnings" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_server/tooling/test_screen_stocks_halt_filter.py
+++ b/tests/mcp_server/tooling/test_screen_stocks_halt_filter.py
@@ -1,0 +1,222 @@
+"""ROB-1236 — ``screen_stocks`` must not rank a symbol whose bars have gone inert.
+
+The screener consumes the same daily candles ``analyze_stock_batch`` does, so
+the 000880 contamination reaches a buy ranking through this path too. Exclusion
+must also be *visible*: a false positive removes a real candidate, and an
+operator has to be able to see it happen.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling.screening.halt_filter import exclude_halt_suspect_rows
+
+pytestmark = pytest.mark.unit
+
+FROZEN_PRICE = 83800.0
+
+
+def _frame(*, frozen_sessions: int, live_sessions: int = 15) -> pd.DataFrame:
+    opens, highs, lows, closes, volumes = [], [], [], [], []
+    price = 78000.0
+    for i in range(live_sessions):
+        price += 150.0 if i % 3 else -100.0
+        opens.append(price - 50.0)
+        highs.append(price + 400.0)
+        lows.append(price - 350.0)
+        closes.append(price)
+        volumes.append(120000.0)
+    if live_sessions:
+        opens[-1] = FROZEN_PRICE - 200.0
+        highs[-1] = FROZEN_PRICE + 900.0
+        lows[-1] = FROZEN_PRICE - 700.0
+        closes[-1] = FROZEN_PRICE
+    for _ in range(frozen_sessions):
+        opens.append(FROZEN_PRICE)
+        highs.append(FROZEN_PRICE)
+        lows.append(FROZEN_PRICE)
+        closes.append(FROZEN_PRICE)
+        volumes.append(0.0)
+    return pd.DataFrame(
+        {
+            "open": opens,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": volumes,
+        }
+    )
+
+
+def _response() -> dict:
+    return {
+        "results": [
+            {"symbol": "005930", "market": "kr", "close": 70000.0},
+            {"symbol": "000880", "market": "kr", "close": FROZEN_PRICE},
+            {"symbol": "000660", "market": "kr", "close": 190000.0},
+        ],
+        "total_count": 3,
+        "returned_count": 3,
+        "market": "kr",
+        "meta": {"rsi_enrichment": {}},
+    }
+
+
+def _patch_frames(frames: dict[str, pd.DataFrame]):
+    async def fake_fetch(symbol, market_type, count=250, **kwargs):
+        return frames[symbol]
+
+    return patch(
+        "app.mcp_server.tooling.screening.halt_filter._fetch_ohlcv_for_indicators",
+        new=AsyncMock(side_effect=fake_fetch),
+    )
+
+
+DEFAULT_FRAMES = {
+    "005930": _frame(frozen_sessions=0),
+    "000880": _frame(frozen_sessions=8),
+    "000660": _frame(frozen_sessions=0),
+}
+
+
+# ---------------------------------------------------------------------------
+# Cost gate — the history read must not fan out across a whole screen page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rows_whose_latest_bar_traded_skip_the_history_read():
+    """A newest bar with volume cannot be the end of a zero-volume frozen run.
+
+    Without this gate a 100-row intraday screen fires 100 live KIS candle
+    fetches, because the daily cache is deliberately bypassed while a KRX
+    session is open.
+    """
+    response = _response()
+    for row in response["results"]:
+        row["volume"] = 1_500_000
+
+    fetch = AsyncMock(side_effect=AssertionError("history must not be read"))
+    with patch(
+        "app.mcp_server.tooling.screening.halt_filter._fetch_ohlcv_for_indicators",
+        new=fetch,
+    ):
+        result = await exclude_halt_suspect_rows(response, market="kr")
+
+    assert fetch.await_count == 0
+    assert len(result["results"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_zero_volume_row_still_gets_the_full_history_read():
+    response = _response()
+    response["results"][0]["volume"] = 1_500_000  # traded — gated out
+    response["results"][1]["volume"] = 0  # halted — must be checked
+    response["results"][2]["volume"] = 900_000  # traded — gated out
+
+    with _patch_frames(DEFAULT_FRAMES) as fetch:
+        result = await exclude_halt_suspect_rows(response, market="kr")
+
+    assert fetch.await_count == 1
+    assert [row["symbol"] for row in result["results"]] == ["005930", "000660"]
+
+
+@pytest.mark.asyncio
+async def test_unparseable_volume_falls_through_to_the_history_read():
+    """The cheap gate must never be the reason a halt slips through."""
+    response = _response()
+    for row in response["results"]:
+        row["volume"] = "n/a"
+
+    with _patch_frames(DEFAULT_FRAMES) as fetch:
+        result = await exclude_halt_suspect_rows(response, market="kr")
+
+    assert fetch.await_count == 3
+    assert [row["symbol"] for row in result["results"]] == ["005930", "000660"]
+
+
+@pytest.mark.asyncio
+async def test_halted_symbol_is_removed_from_screener_results():
+    with _patch_frames(DEFAULT_FRAMES):
+        result = await exclude_halt_suspect_rows(_response(), market="kr")
+
+    assert [row["symbol"] for row in result["results"]] == ["005930", "000660"]
+    assert result["returned_count"] == 2
+    assert result["total_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_exclusion_is_reported_not_silent():
+    with _patch_frames(DEFAULT_FRAMES):
+        result = await exclude_halt_suspect_rows(_response(), market="kr")
+
+    excluded = result["meta"]["halted_suspect_excluded"]
+    assert [entry["symbol"] for entry in excluded] == ["000880"]
+    assert excluded[0]["frozen_sessions"] == 8
+    assert excluded[0]["krx_halt_master"] == "unavailable"
+
+    warnings = result["warnings"]
+    assert any("000880" in w and "halted_suspect" in w for w in warnings)
+    # Never restated as a confirmation.
+    assert any("not a\nconfirmed halt".replace("\n", " ") in w for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_actively_traded_rows_are_all_kept():
+    frames = {symbol: _frame(frozen_sessions=0) for symbol in DEFAULT_FRAMES}
+
+    with _patch_frames(frames):
+        result = await exclude_halt_suspect_rows(_response(), market="kr")
+
+    assert [row["symbol"] for row in result["results"]] == [
+        "005930",
+        "000880",
+        "000660",
+    ]
+    assert result["total_count"] == 3
+    assert "halted_suspect_excluded" not in result.get("meta", {})
+
+
+@pytest.mark.asyncio
+async def test_history_read_failure_keeps_the_row_and_warns():
+    """A DB hiccup is not evidence of a halt — never delete a candidate on it."""
+
+    async def boom(symbol, market_type, count=250, **kwargs):
+        if symbol == "000880":
+            raise TimeoutError("candle store unreachable")
+        return _frame(frozen_sessions=0)
+
+    with patch(
+        "app.mcp_server.tooling.screening.halt_filter._fetch_ohlcv_for_indicators",
+        new=AsyncMock(side_effect=boom),
+    ):
+        result = await exclude_halt_suspect_rows(_response(), market="kr")
+
+    assert [row["symbol"] for row in result["results"]] == [
+        "005930",
+        "000880",
+        "000660",
+    ]
+    assert any("halt check skipped" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_unsupported_market_is_passed_through_untouched():
+    response = _response()
+
+    result = await exclude_halt_suspect_rows(response, market="forex")
+
+    assert result is response
+
+
+@pytest.mark.asyncio
+async def test_screen_stocks_unified_wires_the_halt_gate():
+    """The gate has to sit on the single funnel, not on one dispatch branch."""
+    import app.mcp_server.tooling.screening.entrypoint as entrypoint
+
+    source = entrypoint.screen_stocks_unified.__code__.co_names
+    assert "exclude_halt_suspect_rows" in source

--- a/tests/scripts/test_policy_table_halt_suspect.py
+++ b/tests/scripts/test_policy_table_halt_suspect.py
@@ -1,0 +1,291 @@
+"""ROB-1236 — policy-table adapters must not emit rows for inert series.
+
+The B0-X observation tables are built from these payloads, so a symbol under a
+trading halt that still gets a row contaminates everything derived from it.
+Halt-suspect symbols are dropped from ``rows`` and surfaced under
+``universe.halted_suspect`` instead — excluded, but never silently.
+
+Pure-compute path only: every test builds ``RawInputs`` directly, no DB and no
+network.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from scripts.policy_table.adapters import crypto as crypto_adapter
+from scripts.policy_table.adapters import kr as kr_adapter
+from scripts.policy_table.adapters import us as us_adapter
+
+pytestmark = pytest.mark.unit
+
+FROZEN_PRICE = Decimal("83800")
+
+
+def _bars(
+    n: int = 150,
+    *,
+    start: Decimal = Decimal("80000"),
+    step: Decimal = Decimal("100"),
+    frozen_sessions: int = 0,
+    frozen_price: Decimal = FROZEN_PRICE,
+) -> list[list[str]]:
+    """Ascending ``[close, high, low, volume]`` bars, optionally frozen at the end."""
+    bars: list[list[str]] = []
+    price = start
+    for i in range(n):
+        price = price + (step if i % 5 else -step * 2 // 3)
+        bars.append(
+            [
+                str(price),
+                str(price + step * 4),
+                str(price - step * 3),
+                "120000",
+            ]
+        )
+    if frozen_sessions:
+        # Final live bar closes exactly where the halt freezes.
+        bars[-1] = [
+            str(frozen_price),
+            str(frozen_price + step * 4),
+            str(frozen_price - step * 3),
+            "310000",
+        ]
+        bars.extend(
+            [str(frozen_price), str(frozen_price), str(frozen_price), "0"]
+            for _ in range(frozen_sessions)
+        )
+    return bars
+
+
+# ---------------------------------------------------------------------------
+# KR
+# ---------------------------------------------------------------------------
+
+
+def _kr_raw(candles: dict[str, list[list[str]]]) -> kr_adapter.RawInputs:
+    symbols = sorted(candles)
+    return kr_adapter.RawInputs(
+        as_of="2026-08-10T09:00:00+00:00",
+        holdings=[],
+        watch_alerts=[],
+        universe_pool=[
+            {
+                "symbol": symbol,
+                "latest_close": candles[symbol][-1][0],
+                "market_cap": "5000000000000",
+                "market_cap_source": "market_valuation_snapshots:naver_finance",
+                "daily_turnover": "50000000000",
+                "daily_volume": "500000",
+                "snapshot_date": "2026-08-09",
+            }
+            for symbol in symbols
+        ],
+        snapshot_partition_date="2026-08-09",
+        snapshot_breadth=None,
+        universe_symbols=symbols,
+        candles=candles,
+    )
+
+
+def test_kr_halted_symbol_gets_no_row():
+    raw = _kr_raw(
+        {
+            "000880": _bars(frozen_sessions=8),
+            "005930": _bars(),
+        }
+    )
+
+    payload = kr_adapter.compute_policy_table(raw)
+
+    assert [row["symbol"] for row in payload["rows"]] == ["005930"]
+    assert "000880" not in {row["symbol"] for row in payload["rows"]}
+
+
+def test_kr_halted_symbol_is_recorded_not_silently_dropped():
+    raw = _kr_raw({"000880": _bars(frozen_sessions=8), "005930": _bars()})
+
+    payload = kr_adapter.compute_policy_table(raw)
+
+    halted = payload["universe"]["halted_suspect"]
+    assert [entry["symbol"] for entry in halted] == ["000880"]
+    assert halted[0]["frozen_sessions"] == 8
+    assert halted[0]["krx_halt_master"] == "unavailable"
+    assert "not a confirmed trading halt" in halted[0]["note"]
+
+    skipped = {
+        entry["symbol"]: entry["reason"] for entry in payload["universe"]["skipped"]
+    }
+    assert skipped["000880"] == "halted_suspect"
+    assert payload["universe"]["computed_symbols"] == 1
+
+
+def test_kr_halted_symbol_named_in_the_rendered_summary():
+    raw = _kr_raw({"000880": _bars(frozen_sessions=8), "005930": _bars()})
+
+    summary = kr_adapter.render_summary_md(
+        {
+            **kr_adapter.compute_policy_table(raw),
+            "stamps": {"policy_table_hash": "x", "auto_trader_head": "y"},
+        }
+    )
+
+    assert "000880" in summary
+    assert "NOT a confirmed halt" in summary
+
+
+def test_kr_actively_traded_symbols_all_keep_their_rows():
+    raw = _kr_raw({"005930": _bars(), "000660": _bars(start=Decimal("190000"))})
+
+    payload = kr_adapter.compute_policy_table(raw)
+
+    assert sorted(row["symbol"] for row in payload["rows"]) == ["000660", "005930"]
+    assert payload["universe"]["halted_suspect"] == []
+
+
+def test_kr_two_frozen_sessions_stay_below_the_threshold():
+    raw = _kr_raw({"000880": _bars(frozen_sessions=2)})
+
+    payload = kr_adapter.compute_policy_table(raw)
+
+    assert [row["symbol"] for row in payload["rows"]] == ["000880"]
+    assert payload["universe"]["halted_suspect"] == []
+
+
+# ---------------------------------------------------------------------------
+# US
+# ---------------------------------------------------------------------------
+
+
+def _us_raw(candles: dict[str, list[list[str]]]) -> us_adapter.RawInputs:
+    symbols = sorted(candles)
+    return us_adapter.RawInputs(
+        as_of="2026-08-10T09:00:00+00:00",
+        holdings=[],
+        watch_alerts=[],
+        universe_pool=[
+            {
+                "symbol": symbol,
+                "latest_close": candles[symbol][-1][0],
+                "market_cap": "3000000000000",
+                "market_cap_source": "market_valuation_snapshots:yahoo",
+                "daily_turnover": "5000000000",
+                "daily_volume": "50000000",
+                "snapshot_date": "2026-08-09",
+                "exchange": "NASD",
+                "is_common_stock": True,
+            }
+            for symbol in symbols
+        ],
+        snapshot_partition_date="2026-08-09",
+        snapshot_breadth=None,
+        universe_symbols=symbols,
+        candles=candles,
+        market_cap_fill_stats={"note": "unit-test fixture"},
+    )
+
+
+def test_us_halted_symbol_gets_no_row_and_is_recorded():
+    raw = _us_raw(
+        {
+            "AAPL": _bars(start=Decimal("200"), step=Decimal("1")),
+            "HALT": _bars(
+                start=Decimal("50"),
+                step=Decimal("1"),
+                frozen_sessions=5,
+                frozen_price=Decimal("47"),
+            ),
+        }
+    )
+
+    payload = us_adapter.compute_policy_table(raw)
+
+    assert [row["symbol"] for row in payload["rows"]] == ["AAPL"]
+    halted = payload["universe"]["halted_suspect"]
+    assert [entry["symbol"] for entry in halted] == ["HALT"]
+    assert halted[0]["frozen_sessions"] == 5
+
+
+def test_us_actively_traded_symbol_keeps_its_row():
+    raw = _us_raw({"AAPL": _bars(start=Decimal("200"), step=Decimal("1"))})
+
+    payload = us_adapter.compute_policy_table(raw)
+
+    assert [row["symbol"] for row in payload["rows"]] == ["AAPL"]
+    assert payload["universe"]["halted_suspect"] == []
+
+
+# ---------------------------------------------------------------------------
+# Crypto
+# ---------------------------------------------------------------------------
+
+
+def _crypto_raw(candles: dict[str, list[list[str]]]) -> crypto_adapter.RawInputs:
+    return crypto_adapter.RawInputs(
+        as_of="2026-08-10T09:00:00+00:00",
+        holdings=[],
+        watch_alerts=[],
+        top_traded=[
+            {
+                "market": symbol,
+                "trade_price": candles[symbol][-1][0],
+                "acc_trade_price_24h": "1000000000",
+                "signed_change_rate": "0.01",
+            }
+            for symbol in sorted(candles)
+        ],
+        orderable_krw="1000000",
+        candles=candles,
+    )
+
+
+def test_crypto_dead_feed_symbol_gets_no_row_and_is_recorded():
+    raw = _crypto_raw(
+        {
+            "KRW-BTC": _bars(start=Decimal("100000000"), step=Decimal("100000")),
+            "KRW-DEAD": _bars(
+                start=Decimal("1000"),
+                step=Decimal("10"),
+                frozen_sessions=4,
+                frozen_price=Decimal("980"),
+            ),
+        }
+    )
+
+    payload = crypto_adapter.compute_policy_table(raw)
+
+    assert [row["symbol"] for row in payload["rows"]] == ["KRW-BTC"]
+    halted = payload["universe"]["halted_suspect"]
+    assert [entry["symbol"] for entry in halted] == ["KRW-DEAD"]
+    assert halted[0]["frozen_sessions"] == 4
+
+
+def test_crypto_actively_traded_symbols_all_keep_their_rows():
+    raw = _crypto_raw(
+        {
+            "KRW-BTC": _bars(start=Decimal("100000000"), step=Decimal("100000")),
+            "KRW-ETH": _bars(start=Decimal("5000000"), step=Decimal("10000")),
+        }
+    )
+
+    payload = crypto_adapter.compute_policy_table(raw)
+
+    assert sorted(row["symbol"] for row in payload["rows"]) == ["KRW-BTC", "KRW-ETH"]
+    assert payload["universe"]["halted_suspect"] == []
+
+
+# ---------------------------------------------------------------------------
+# Replay compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_three_element_replay_dumps_still_classify():
+    """Pre-ROB-1236 raw dumps carry no volume — the frozen OHLC still shows."""
+    legacy = {"000880": [bar[:3] for bar in _bars(frozen_sessions=8)]}
+
+    payload = kr_adapter.compute_policy_table(_kr_raw(legacy))
+
+    assert payload["rows"] == []
+    assert payload["universe"]["halted_suspect"][0]["reasons"] == ["zero_variation"]

--- a/tests/services/test_halt_detection.py
+++ b/tests/services/test_halt_detection.py
@@ -1,0 +1,252 @@
+"""ROB-1236 — unit tests for the halt-*suspicion* detector.
+
+The acceptance fixture is the real incident: 000880 한화 under a 인적분할
+매매거래정지, eight consecutive daily bars with ``volume == 0`` and OHLC frozen
+at 83,800, which ``analyze_stock_batch`` reported as ``data_state: "fresh"``.
+
+The other half of these tests is the opposite failure: a normally-traded symbol
+must never be flagged, because a false positive silently deletes a real buy
+candidate.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from app.services.halt_detection import (
+    HALTED_SUSPECT_DATA_STATE,
+    KRX_HALT_MASTER_STATUS,
+    MIN_FROZEN_SESSIONS,
+    REASON_ZERO_VARIATION,
+    REASON_ZERO_VOLUME,
+    HaltBar,
+    classify_bars,
+    classify_ohlcv_frame,
+    classify_ohlcv_rows,
+)
+
+pytestmark = pytest.mark.unit
+
+FROZEN_PRICE = Decimal("83800")
+
+
+def active_bars(n: int = 60, *, start: Decimal = Decimal("80000")) -> list[HaltBar]:
+    """A normally-traded KRX series: real range, real volume, moving close."""
+    bars: list[HaltBar] = []
+    price = start
+    for i in range(n):
+        price = price + (Decimal("150") if i % 3 else Decimal("-100"))
+        bars.append(
+            HaltBar(
+                close=price,
+                high=price + Decimal("400"),
+                low=price - Decimal("350"),
+                volume=Decimal("120000"),
+                open=price - Decimal("50"),
+            )
+        )
+    return bars
+
+
+def frozen_bars(n: int, *, price: Decimal = FROZEN_PRICE) -> list[HaltBar]:
+    """``n`` halted sessions: zero volume, OHLC pinned to one price."""
+    return [
+        HaltBar(close=price, high=price, low=price, volume=Decimal("0"), open=price)
+        for _ in range(n)
+    ]
+
+
+def rob1236_000880_series() -> list[HaltBar]:
+    """The incident series: normal history, then 8 frozen sessions."""
+    history = active_bars(192)
+    # The last live session closes exactly at the price the halt freezes on.
+    history[-1] = HaltBar(
+        close=FROZEN_PRICE,
+        high=FROZEN_PRICE + Decimal("900"),
+        low=FROZEN_PRICE - Decimal("700"),
+        volume=Decimal("310000"),
+        open=FROZEN_PRICE - Decimal("200"),
+    )
+    return [*history, *frozen_bars(8)]
+
+
+# ---------------------------------------------------------------------------
+# The incident fixture
+# ---------------------------------------------------------------------------
+
+
+def test_000880_eight_frozen_sessions_is_halted_suspect():
+    verdict = classify_bars(rob1236_000880_series())
+
+    assert verdict.suspected is True
+    assert verdict.frozen_sessions == 8
+    assert REASON_ZERO_VOLUME in verdict.reasons
+    assert verdict.bars_examined == 200
+
+
+def test_000880_evidence_block_never_claims_a_confirmed_halt():
+    evidence = classify_bars(rob1236_000880_series()).to_dict()
+
+    assert evidence["suspected"] is True
+    assert evidence["krx_halt_master"] == KRX_HALT_MASTER_STATUS == "unavailable"
+    assert "not a confirmed trading halt" in evidence["note"]
+    assert HALTED_SUSPECT_DATA_STATE == "halted_suspect"
+
+
+def test_incident_is_caught_well_before_the_run_reaches_eight():
+    """N=8 would have fired only on the final day; N=3 catches it mid-halt."""
+    history = rob1236_000880_series()[:-8]
+
+    at_two = classify_bars([*history, *frozen_bars(2)])
+    at_three = classify_bars([*history, *frozen_bars(3)])
+
+    assert at_two.suspected is False
+    assert at_three.suspected is True
+    assert MIN_FROZEN_SESSIONS == 3
+
+
+# ---------------------------------------------------------------------------
+# No false positives — the opposite-direction accident
+# ---------------------------------------------------------------------------
+
+
+def test_actively_traded_symbol_is_not_flagged():
+    verdict = classify_bars(active_bars())
+
+    assert verdict.suspected is False
+    assert verdict.frozen_sessions == 0
+    assert verdict.reasons == ()
+
+
+def test_two_frozen_sessions_below_threshold_are_not_flagged():
+    verdict = classify_bars([*active_bars(), *frozen_bars(MIN_FROZEN_SESSIONS - 1)])
+
+    assert verdict.suspected is False
+    assert verdict.frozen_sessions == MIN_FROZEN_SESSIONS - 1
+
+
+def test_old_frozen_run_that_has_since_resumed_is_not_flagged():
+    """Only a run ending at the newest bar counts — a resumed symbol is alive."""
+    series = [*active_bars(50), *frozen_bars(8), *active_bars(5)]
+
+    verdict = classify_bars(series)
+
+    assert verdict.suspected is False
+    assert verdict.frozen_sessions == 0
+
+
+def test_limit_lock_days_are_not_mistaken_for_a_halt():
+    """상한가 잠김 prints open==high==low==close with real volume.
+
+    It is range-less but never at the prior close, which is exactly what the
+    unchanged-close clause exists to separate.
+    """
+    series = active_bars(40)
+    price = series[-1].close
+    for _ in range(MIN_FROZEN_SESSIONS + 2):
+        price = price + Decimal("2000")  # locked limit up, new price each day
+        series.append(
+            HaltBar(
+                close=price,
+                high=price,
+                low=price,
+                volume=Decimal("450000"),
+                open=price,
+            )
+        )
+
+    verdict = classify_bars(series)
+
+    assert verdict.suspected is False
+
+
+def test_zero_variation_alone_flags_when_volume_is_unavailable():
+    """Replay dumps without a volume column still catch a frozen series."""
+    series = active_bars(30)
+    price = series[-1].close
+    series.extend(
+        HaltBar(close=price, high=price, low=price, volume=None, open=price)
+        for _ in range(MIN_FROZEN_SESSIONS)
+    )
+
+    verdict = classify_bars(series)
+
+    assert verdict.suspected is True
+    assert verdict.reasons == (REASON_ZERO_VARIATION,)
+
+
+# ---------------------------------------------------------------------------
+# Series too short to judge
+# ---------------------------------------------------------------------------
+
+
+def test_empty_series_is_not_suspected():
+    verdict = classify_bars([])
+
+    assert verdict.suspected is False
+    assert verdict.bars_examined == 0
+    assert verdict.insufficient_bars is True
+
+
+def test_series_shorter_than_the_threshold_cannot_be_suspected():
+    verdict = classify_bars(frozen_bars(MIN_FROZEN_SESSIONS - 1))
+
+    assert verdict.suspected is False
+    assert verdict.insufficient_bars is True
+
+
+# ---------------------------------------------------------------------------
+# Input adapters
+# ---------------------------------------------------------------------------
+
+
+def test_classify_ohlcv_rows_matches_the_bar_classifier():
+    rows = [
+        [str(bar.close), str(bar.high), str(bar.low), str(bar.volume)]
+        for bar in rob1236_000880_series()
+    ]
+
+    verdict = classify_ohlcv_rows(rows)
+
+    assert verdict.suspected is True
+    assert verdict.frozen_sessions == 8
+
+
+def test_classify_ohlcv_rows_accepts_legacy_three_element_rows():
+    """Pre-ROB-1236 replay dumps have no volume — they must still classify."""
+    rows = [
+        [str(bar.close), str(bar.high), str(bar.low)] for bar in rob1236_000880_series()
+    ]
+
+    verdict = classify_ohlcv_rows(rows)
+
+    # Zero-volume evidence is gone, but the frozen OHLC still gives it away.
+    assert verdict.suspected is True
+    assert verdict.reasons == (REASON_ZERO_VARIATION,)
+
+
+def test_classify_ohlcv_frame_reads_the_canonical_dataframe():
+    bars = rob1236_000880_series()
+    frame = pd.DataFrame(
+        {
+            "open": [float(b.open) for b in bars],
+            "high": [float(b.high) for b in bars],
+            "low": [float(b.low) for b in bars],
+            "close": [float(b.close) for b in bars],
+            "volume": [float(b.volume) for b in bars],
+        }
+    )
+
+    verdict = classify_ohlcv_frame(frame)
+
+    assert verdict.suspected is True
+    assert verdict.frozen_sessions == 8
+
+
+def test_classify_ohlcv_frame_tolerates_missing_and_empty_input():
+    assert classify_ohlcv_frame(None).suspected is False
+    assert classify_ohlcv_frame(pd.DataFrame()).suspected is False
+    assert classify_ohlcv_frame(pd.DataFrame({"foo": [1, 2]})).suspected is False


### PR DESCRIPTION
## 실사례 (ROB-1236)

`000880` 한화 — 인적분할 매매거래정지로 **8거래일 연속 `volume=0`, OHLC 83,800 동결**.
그런데 `analyze_stock_batch` 는 `data_state: "fresh"` + 정상 현재가 83,800 을 반환했고,
RSI 35.40 · 지지/저항 · upside +84% 가 **전부 0-변동 캔들 위에서 계산**됐다.
→ 11:30 live 세션이 **매수 후보 rank 2** 로 랭킹 → 13:05 후속 세션이 OHLCV 교차확인으로
정지를 발견해 **실계좌 매수 proposal 직전에 차단**.

**루트커즈**: `data_state` 판정이 「최신 봉이 **있느냐**」만 보고 **봉이 살아 있느냐**를 안 봤다.
지표 계산도 동결 시계열을 거부하지 않았다.

## 판정 규칙

한 봉이 **frozen**: `volume==0` **또는** (`high==low==close`, open 있으면 `open==close`) **그리고** `close == 직전 close`.
**최신 봉에서 끝나는** frozen 연속 구간이 **N=3** 이상 → `data_state: "halted_suspect"`.

🔴 두 번째 조건의 "직전 close 동일" 절이 **상한가/하한가 잠김**(`open=high=low=close` 이지만
직전 close 와 반드시 다른 가격)을 오탐에서 제외한다. 제거 금지.

### N=3 근거 — 양쪽 오차

| | 놓치는 것 |
|---|---|
| **N 이 크면** (예: 실측치 8) | 000880 의 **오염된 랭킹은 정지 중간**에 일어났다 → 마지막 날에만 발화해 **실사례 자체를 못 막는다**. 조회공시 요구·불성실공시 지정예고·단일가 조치 등 **1~3일 정지는 전부 놓친다**(건수로는 이쪽이 다수) |
| **N 이 작으면** (1~2) | 초저유동 종목의 하루 무거래, **volume 적재 실패로 0 이 들어간 행**, 2행짜리 적재 갭에 발화 |
| **N=3 잔여 오차** | 위음성 = 1~2일 정지 미검출(운영 세션 교차확인이 백스톱). 위양성 = 3일 연속 진짜 무거래 초저유동 종목(스크리너·정책표의 turnover 하한이 이미 거르며, **제외는 전부 심볼·근거와 함께 보고**) |

## 🔴 KRX 거래정지 마스터 — **없음**

레포에 거래정지 마스터 테이블·서비스·수집 CLI가 **존재하지 않는다**. 판정은 **봉의 모양만**
근거로 하며, 응답에 `krx_halt_master: "unavailable"` 를 항상 실어 "마스터를 봤다"는 오해를 차단한다.
🔴 `halted_suspect` 는 **의심**이지 확정 정지가 아니다 — 이름·노트·문서 전부에서 유지.

## 소비자 3곳

| 소비자 | 동작 |
|---|---|
| `analyze_stock_batch` / `analyze_stock` | `data_state` = `halted_suspect` (**top-level + quote 양쪽** — compact 요약이 읽는 건 quote 쪽이고, 그게 사고 세션이 실제로 본 필드다). `indicators`·`support_resistance` = **null**(추정·보간 0). recommendation 은 RSI 부재로 `hold`/`low`+`insufficient_inputs` 자동 하한. 근거 = `halt_suspect` 블록 |
| `screen_stocks` | `screen_stocks_unified` 단일 깔때기에서 행 **제외**. `meta.halted_suspect_excluded` + `warnings` 로 보고 — 🔴 조용한 삭제 없음(위양성이 실매수 후보를 지우므로). 이력 조회 실패는 **fail-open**(행 유지 + warning) |
| `scripts/policy_table` (kr/us/crypto) | `rows` 에서 **제외**, `universe.halted_suspect` 에 근거 보존(KR/US 는 `skipped` 에도 `reason="halted_suspect"`). 요약 md 에 심볼 표기 |

**B0-X 무변경으로 차단**: `scripts/b0x/**` 는 `policy_table.v1` 의 `rows` 와 `schema` 값만 읽는다.
`universe.halted_suspect` 는 additive, `schema` 불변 → B0-X 쪽 수정 없이 fail-closed.

## 🔴 스크리너 비용 게이트 (알려진 한계)

이력 조회는 cache-first 이지만 **KRX 장중에는 일봉 캐시를 일부러 우회**한다(오늘 봉 형성 중).
그대로 두면 100행 스크린이 **장중에 KIS 라이브 캔들 100회** — 운영 세션이 도는 그 시간대에.
그래서 행 자신의 **최신봉 거래량**으로 먼저 거른다(판정은 최신봉에서 끝나는 구간을 요구하므로
최신봉이 거래됐다면 `zero_volume` 정지는 성립 불가). `volume` 없거나 파싱 불가면 **거르지 않고 이력을 읽는다**.

🔴 **감수한 구멍**: 거래량은 있는데 0-변동만으로 얼어붙은 구간은 스크리너에서 건너뛴다.
`analyze_stock_batch` 와 정책표는 이력을 **무조건** 읽으므로 그쪽에서 잡힌다.

## 검증

- **mutant 4종 전부 격추** (주입 → 실패 확인 → 원복, 커밋 미포함)
  - ① `data_state` 오버라이드 제거 → `halted_suspect` 대신 **`fresh`** 반환 → 2건 FAIL (사고 증상 그대로 재현)
  - ② 지표 null 처리 제거 → 3건 FAIL
  - ③ 스크리너가 halted 포함(a: 필터 무력화 2건 FAIL / b: 깔때기에서 게이트 제거 1건 FAIL)
  - ④ 정책표 로더 3개가 halted 포함 → 6건 FAIL
- **false-green**: 각 스위트 핵심 assert 반전 → 4건 전부 FAIL (고정 확인)
- **오탐 회귀 고정**: 활발히 거래되는 종목이 `halted_suspect` 로 안 잡히는 테스트 + baseline 이 **문자 그대로 `"fresh"`** 가 되도록 스텁을 건강하게 구성(halted 테스트와 **동일 스텁, 차이는 8개 동결봉뿐**)
- 신규 테스트 40건 + 기존 `tests/mcp_server`(723) · `tests/services` · `tests/scripts/b0x`(481) · `tests/monitoring` 전부 통과
- `ruff format --check` / `ruff check` / `ty check` (CI 동일 전 스코프) 통과

## 안전

주문 0 · 계좌 mutation 0 · env 변경 0 · live 주문 경로 무접촉 · 스케줄러 등록 0 · in-process LLM 0.
B0-X 런타임(`scripts/b0x/**`) diff 0. 선행 머지분(#1821~#1830) 되돌림 0.

런북: `docs/runbooks/halted-suspect-data-state.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)