### PR TITLE
feat(dfc): A2-C9 ranking-input deficit clause (§31차 명시 개정)

### DIFF
--- a/research/dfc_v22_research_min/contract.py
+++ b/research/dfc_v22_research_min/contract.py
@@ -19,6 +19,7 @@ Clause        Upstream source   Subject
 ``A2-C6``     OD-26             Lifecycle authority absence and substitute
 ``A2-C7``     OD-26             Premium-index archive gap and epoch verdict
 ``A2-C8``     OD-26 (Job B)     Pre-registered sample readiness protocol
+``A2-C9``     OD-31             Ranking-input deficit epochs (enumerated)
 ============  ================  =========================================
 """
 
@@ -62,6 +63,12 @@ __all__ = [
     "OUTCOME_HORIZON_BARS",
     "OUTCOME_TAIL_BARS",
     "OUTCOME_UNIT",
+    "RANKING_INPUT_DEFICIT_ENUMERATION_PATH",
+    "RANKING_INPUT_DEFICIT_ENUMERATION_SHA256",
+    "RANKING_INPUT_DEFICIT_EPOCHS",
+    "RANKING_INPUT_DEFICIT_ROWS",
+    "RANKING_INPUT_DEFICIT_UNCHANGED_HEAD",
+    "RANKING_INPUT_DEFICIT_VERDICT",
     "READY",
     "REQUIRED_SOURCE_KINDS",
     "RUN_INVALID_INPUT_EVIDENCE",
@@ -337,6 +344,93 @@ TERMINAL_CODE_PRIORITY: tuple[str, ...] = (
 )
 
 
+# --- A2-C9 (OD-31): ranking-input deficit epochs, enumerated and frozen ---
+
+# §26차's A2-C7 trigger fires in one direction only: a gap symbol that is
+# **inside** an epoch's top-3 pool.  §31차 measured the opposite direction — a
+# ranking *input* deficit that kept a symbol **out** of the pool it belonged in
+# — and ruled that reading A2-C7 as covering it would be widening a clause by
+# interpretation.  So this is a separate clause with its own literal, and the
+# set of epochs it applies to is an enumeration, not a rule: the list was fixed
+# by a measurement that has already been read, and re-deriving it here would
+# destroy the pre-registration it exists to preserve.
+
+#: The measurement the enumeration is transcribed from.  Recorded as a path and
+#: a digest, never opened: this package does not read files (see
+#: ``test_package_does_not_write_files`` / ``..._cannot_reach_the_network``), so
+#: the pin is what makes a changed enumeration visible rather than silent.
+RANKING_INPUT_DEFICIT_ENUMERATION_PATH = (
+    "~/work/herdr-artifacts/dfc-v22-readiness-v1/gap-impact/flipped_epochs.json"
+)
+RANKING_INPUT_DEFICIT_ENUMERATION_SHA256 = (
+    "2a04dd6d0c666b683cc099132d0dca5ebb5a40fe8e573c6a7ef2da54c3b7112f"
+)
+
+#: Ranks 1 and 2 are the same two symbols at every one of the 38 epochs — a
+#: measured property of the enumeration, not an assumption: only the rank-3
+#: slot moves, which is why the rows below carry that slot alone.
+RANKING_INPUT_DEFICIT_UNCHANGED_HEAD: tuple[str, ...] = ("BTCUSDT", "ETHUSDT")
+
+#: ``(epoch_open_time_ms, as_archived_rank3, would_have_been_rank3)``.
+#:
+#: ``as_archived_rank3`` is what the archive's own (deficient) ranking input
+#: produces and therefore what the corpus records; ``would_have_been_rank3`` is
+#: what the same rule produces once the deficit is made good.  The second column
+#: is carried so the substitution can be *detected*, not so it can be performed:
+#: writing it into the pool is the silent re-ranking §31차 forbids, and
+#: ``validate_ranking_input_deficit`` rejects exactly that.
+RANKING_INPUT_DEFICIT_ROWS: tuple[tuple[int, str, str], ...] = (
+    (1646193600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-02T04:00:00Z
+    (1646208000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-02T08:00:00Z
+    (1646222400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-02T12:00:00Z
+    (1646236800000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-02T16:00:00Z
+    (1646251200000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-02T20:00:00Z
+    (1646265600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-03T00:00:00Z
+    (1646280000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-03T04:00:00Z
+    (1646294400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-03T08:00:00Z
+    (1646308800000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-03T12:00:00Z
+    (1646323200000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-03T16:00:00Z
+    (1646337600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-03T20:00:00Z
+    (1646352000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-04T00:00:00Z
+    (1646366400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-04T04:00:00Z
+    (1646380800000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-04T08:00:00Z
+    (1646395200000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-04T12:00:00Z
+    (1646409600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-04T16:00:00Z
+    (1646424000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-04T20:00:00Z
+    (1646438400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-05T00:00:00Z
+    (1646452800000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-05T04:00:00Z
+    (1646467200000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-05T08:00:00Z
+    (1646481600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-05T12:00:00Z
+    (1646496000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-05T16:00:00Z
+    (1646510400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-05T20:00:00Z
+    (1646524800000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-06T00:00:00Z
+    (1646539200000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-06T04:00:00Z
+    (1646553600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-06T08:00:00Z
+    (1646568000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-06T12:00:00Z
+    (1646582400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-06T16:00:00Z
+    (1646596800000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-06T20:00:00Z
+    (1646611200000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-07T00:00:00Z
+    (1646625600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-07T04:00:00Z
+    (1646640000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-07T08:00:00Z
+    (1646654400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-07T12:00:00Z
+    (1646668800000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-07T16:00:00Z
+    (1646683200000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-07T20:00:00Z
+    (1646697600000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-08T00:00:00Z
+    (1646712000000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-08T04:00:00Z
+    (1646726400000, "GALAUSDT", "LUNAUSDT"),  # 2022-03-08T08:00:00Z
+)
+
+#: The enumeration itself — the 38 epochs, in ascending order.
+RANKING_INPUT_DEFICIT_EPOCHS: tuple[int, ...] = tuple(
+    row[0] for row in RANKING_INPUT_DEFICIT_ROWS
+)
+
+#: The verdict §31차 assigns them: the same terminal code A2-C7 assigns to the
+#: other direction.  A deficit epoch is recorded with its reason and is not
+#: scored, not deleted, and not re-ranked.
+RANKING_INPUT_DEFICIT_VERDICT = RUN_INVALID_INPUT_EVIDENCE
+
+
 # --- A2-C8 (OD-26 Job B): pre-registered sample readiness protocol -------
 
 #: Registered *before* any sample measurement (Job B).  Nothing here may be
@@ -457,5 +551,6 @@ CLAUSE_SOURCES: MappingProxyType[str, str] = MappingProxyType(
         "A2-C6": "OD-26",
         "A2-C7": "OD-26",
         "A2-C8": "OD-26-JOB-B",
+        "A2-C9": "OD-31",
     }
 )

--- a/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
+++ b/research/dfc_v22_research_min/contracts/DFC_V22_RESEARCH_MIN.md
@@ -10,7 +10,8 @@ collection, no listing, no download and no backtest.
 | Judged dimensions | kline OFI · premium-index · PIT universe · outcome evidence |
 | Upstream wording (canonical) | `~/work/herdr-inbox/answer-codexmock-next-wave-1630.md`, sha256 `df7aee908e50af42…` (137 lines) |
 | Binding record | `~/work/herdr-inbox/operator-decisions-20260805-0830.md` §25차 |
-| Amendment binding record | same file, §26차 (A2-C6 · A2-C7) |
+| Amendment binding record | same file, §26차 (A2-C6 · A2-C7 · A2-C8) |
+| Amendment binding record | same file, §31차 (A2-C9) |
 | Schema | `research/dfc_v22_research_min/schema.py` |
 | Validators | `research/dfc_v22_research_min/validation.py` |
 | Golden cases | `tests/research/dfc_v22_research_min/golden/violation_cases.json` |
@@ -342,6 +343,82 @@ of that plan, the declared `verdict` to be one of `READY`/`NOT_READY`, and that
 declared verdict to equal the value recomputed from the row evidence and
 `run_invalid_epochs` — never accepted merely because it was declared.
 
+---
+
+## A2-C9 — The ranking-input deficit, and the enumerated epochs (OD-31)
+
+> **§31차** (원문 축자 인용)
+>
+> 유형③: 랭킹 입력 결손으로 top-3 구성이 달라졌을 것으로 전수 증명된 epoch(열거 목록 고정)도 동일하게 RUN_INVALID_INPUT_EVIDENCE, 재랭킹 금지
+
+A2-C7 fires in one direction: a gap symbol that is **inside** an epoch's top-3
+pool. A2-MEASURE's successor measurement found the opposite direction. Some
+symbols' `klines` archive objects carry silent internal holes — bars missing
+from the middle of an actively-trading history, contradicted by the public REST
+endpoint — and a missing bar is read by the trailing-30-day ranking sum as zero
+volume. A symbol whose input is short that way ranks lower than its own traded
+volume warrants, and can be pushed **out** of a top 3 it belonged in.
+
+Read literally, A2-C7 does not reach this: the affected symbol is not in the
+pool, which is precisely the complaint. §31차 declined to stretch the existing
+wording over it — an interpretation that wide would also cover cases nobody
+measured — and wrote this clause instead. It is the same verdict for a
+different mechanism, arrived at explicitly.
+
+**The epochs are an enumeration, not a rule.** The measurement that produced
+them has already been read. Re-deriving the list from the corpus at validation
+time would therefore be re-running a decision procedure *after* seeing its
+inputs, which is the sequencing every other clause in this document exists to
+prevent. So the list is frozen as a literal, and the file it was transcribed
+from is pinned by digest:
+
+| Literal | Frozen value |
+|---|---|
+| `enumeration_path` | `~/work/herdr-artifacts/dfc-v22-readiness-v1/gap-impact/flipped_epochs.json` |
+| `enumeration_sha256` | `2a04dd6d0c666b683cc099132d0dca5ebb5a40fe8e573c6a7ef2da54c3b7112f` |
+| epoch count | 38 |
+| span | `2022-03-02T04:00:00Z` … `2022-03-08T08:00:00Z`, contiguous on the 4h grid |
+| shape | ranks 1–2 unchanged (`BTCUSDT`, `ETHUSDT`); rank 3 `GALAUSDT` as archived, `LUNAUSDT` under complete input |
+| verdict | `RUN_INVALID_INPUT_EVIDENCE` |
+
+The digest is not decoration. `contract.py` never opens that file — this package
+cannot read files at all — so the digest is what makes an enumeration that moved
+*visible* instead of silent: a manifest built against a changed list declares a
+different `enumeration_sha256`, and the validator rejects it by name.
+
+**Re-ranking is forbidden here too, and here it is the more tempting
+direction.** In A2-C7 the repair would be to drop a symbol; here it would be to
+*promote* one — to record the ranking complete input would have produced, which
+looks more accurate than the one the archive supports. It is still a ranking no
+reader can reproduce from the recorded evidence, and it would leave the corpus
+carrying no trace that the input was ever short. So the corpus records the
+as-archived pool, marks the epoch invalid, and stops there.
+
+**Enforced as.**
+
+1. `manifest.ranking_input_deficit` restates the enumeration —
+   `enumeration_path`, `enumeration_sha256`, `epochs`, `verdict` and one `rows`
+   entry per epoch — and every one of those is compared against the frozen
+   literal rather than merely type-checked.
+2. Every enumerated epoch is **present** in `pit_universe`. An absent pool is a
+   deleted row, which is how a deficit disappears without a trace.
+3. Every enumerated epoch's declared pool equals the as-archived ranking. If
+   `would_have_been_rank3` appears in the pool, that is the silent re-ranking
+   this clause forbids, and it is rejected under its own message.
+4. No enumerated epoch carries a decision or an outcome row.
+   `RUN_INVALID_INPUT_EVIDENCE` is terminal, so an epoch that was scored was
+   processed as if its ranking input had been complete.
+
+`validate_ranking_input_deficit` returns nothing and edits nothing, for the same
+reason `validate_premium_index_gap` does: there is nowhere for a repaired pool
+to come out.
+
+**What this clause does not cover.** It covers exactly the 38 enumerated epochs.
+Any other archive gap — a different symbol, a different window, a deficit whose
+ranking impact was never measured — is *not* absorbed by it, and a FREEZE that
+meets one is a fail-closed stop, not a case for this clause.
+
+
 ## Terminal codes
 
 Adjudicated in this order — `contract.TERMINAL_CODE_PRIORITY`, enforced by
@@ -352,7 +429,7 @@ the cause.
 
 | Code | Raised when |
 |---|---|
-| `RUN_INVALID_INPUT_EVIDENCE` | lifecycle authority claimed, proxy promoted to evidence kind, gap symbol unaccounted for, gap symbol inside or outranking the candidate pool, or a recorded epoch verdict the evidence does not support (A2-C6 / A2-C7) |
+| `RUN_INVALID_INPUT_EVIDENCE` | lifecycle authority claimed, proxy promoted to evidence kind, gap symbol unaccounted for, gap symbol inside or outranking the candidate pool, or a recorded epoch verdict the evidence does not support (A2-C6 / A2-C7); an enumerated ranking-input-deficit epoch deleted, re-ranked, scored, or declared against a changed enumeration (A2-C9) |
 | `RUN_INVALID_SCOPE_SEPARATION` | A1 (or anything else) declared as the DFC prerequisite (A2-C1) |
 | `RUN_INVALID_CORPUS_LITERALS` | a frozen id, path, window, universe rule or imputation literal was changed (A2-C2), or a sample-readiness report's rule/epochs/verdict do not reproduce the frozen protocol (A2-C8) |
 | `RUN_INVALID_FORBIDDEN_SOURCE` | funding / open interest / mark / index material present (A2-C3) |
@@ -400,6 +477,36 @@ timing the paragraph above is suspicious of, so the record is:
 
 Should a *literal* ever need to change, the paragraph above still governs: new
 ID, new signature.
+
+## Amendment provenance (A2-C9)
+
+A2-C9 has the same suspicious timing as A2-C6/A2-C7 — the list of epochs it
+freezes *is* a measurement result, and it was read before the clause was
+written. The record, in the open:
+
+- **No frozen literal changed.** The judgment window is not narrowed (that
+  option was on the table as "B" and was refused: shortening the window hides
+  the problem without recording it). The universe rule, the lookback, the
+  tie-break, `imputation 0`, the required and forbidden source kinds, NW-F5's
+  corpus literals, NW-F6's authenticity definition and the
+  candidate/control ≥400 sample requirement are all untouched. The amendment is
+  additive: one clause, one manifest key (`ranking_input_deficit`), one
+  validator, and no new terminal code.
+- **It tightens; it cannot relax.** Every corpus A2-C9 rejects would have been
+  accepted before it. The 38 epochs move from scored to `RUN_INVALID`, never
+  the other way.
+- **The alternative that would have relaxed it was refused.** Back-filling the
+  missing bars from REST ("A") would have made the corpus *look* complete while
+  promoting the single worst-provenanced symbol in the span — `LUNAUSDT`, the
+  same symbol carrying the delisting tail and its own archive hole — into the
+  top 3. §31차 refused it, and refused the NW-F6 authenticity re-definition it
+  would have required.
+- **The enumeration cannot grow to fit what FREEZE finds.** It is pinned by
+  digest and compared row by row. A gap outside it is a stop, not an
+  extension — see the last paragraph of A2-C9.
+- **Signed separately.** §31차 of the binding record authorises it as its own
+  decision, with the backtest count still zero.
+
 
 ## Amendment provenance (A2-C8)
 

--- a/research/dfc_v22_research_min/nw_verbatim.py
+++ b/research/dfc_v22_research_min/nw_verbatim.py
@@ -30,6 +30,12 @@ BINDING_RECORD = "~/work/herdr-inbox/operator-decisions-20260805-0830.md \u00a72
 BINDING_RECORD_AMENDMENT = (
     "~/work/herdr-inbox/operator-decisions-20260805-0830.md \u00a726\ucc28"
 )
+#: A2-C9 is bound by \u00a731\ucc28 of the same record.  It is a *separate* amendment
+#: from \u00a726\ucc28: \u00a726\ucc28 closed the direction where a gap symbol is **in** the pool,
+#: \u00a731\ucc28 closes the opposite direction, where the deficit kept a symbol **out**.
+BINDING_RECORD_AMENDMENT_C9 = (
+    "~/work/herdr-inbox/operator-decisions-20260805-0830.md \u00a731\ucc28"
+)
 
 NW_F2_TOPIC = "A1과 DFC 최소 corpus의 범위 분리"
 NW_F2_VERBATIM = "**“A1의 funding/OI/mark/index 종합 readiness는 보존하되 DFC-v2.x의 선행조건으로 쓰지 않는다. 데이터 접촉 전에 `DFC_V22_RESEARCH_MIN` A2 계약을 새 ID/SHA로 등록한다. A2는 kline OFI·premium-index·PIT universe·outcome evidence만 판정한다.”** 이는 결과를 본 뒤 게이트를 완화하는 것이 아니라, 아직 백테스트 0회인 상태에서 계약-데이터 불일치를 교정하는 것이다."
@@ -52,6 +58,15 @@ OD_26_JOB_A_VERBATIM = "**Job A (②+①)**: ②contract lifecycle 권위 소스
 OD_26_JOB_B_TOPIC = "A2 공백 ③ 폐쇄 경로(사전등록 표본 프로토콜)"
 OD_26_JOB_B_VERBATIM = "**Job B (③)**: 측정 **전** 표본 규칙 사전등록 — 판정창 분기별 고정 seed 층화표본 epoch 12 (총 ~108), 각 표본 epoch 의 top-3 후보 심볼 kline+premiumIndex 완전성 검사. **READY = 표본 100% 무결 / 미달 = NOT_READY** (UNDETERMINED 재판정 없음 — 이지선다). 전수 검증은 FREEZE 가 fail-closed 수행 — READY 는 동결 노력 투입 결정일 뿐."
 
+#: §31차 확정 문단의 「명시 개정 한 줄」.  §26차 항목들과 같은 이유로 이 파일의
+#: 답변 문서가 아니라 바인딩 레코드 자체가 소스이고, 하드랩된 원문 세 줄을 공백
+#: 하나로 합치고 굵은따옴표 마커만 벗겼을 뿐 그 외에는 손대지 않았다.  §31차가
+#: 명시 개정을 고른 이유가 이 한 줄 안에 들어 있다: 기존 트리거는 격차 심볼이
+#: 후보 pool 에 **든** 방향이라 결손으로 **빠진** 반대 방향에는 문언 그대로는
+#: 발동하지 않으므로, 해석으로 넓히지 않고 조항을 하나 더 쓴다.
+OD_31_TOPIC = "A2 공백 유형③ 폐쇄 경로(랭킹 입력 결손 epoch 열거)"
+OD_31_VERBATIM = "유형③: 랭킹 입력 결손으로 top-3 구성이 달라졌을 것으로 전수 증명된 epoch(열거 목록 고정)도 동일하게 RUN_INVALID_INPUT_EVIDENCE, 재랭킹 금지"
+
 VERBATIM_CLAUSES: dict[str, str] = {
     "NW-F2": NW_F2_VERBATIM,
     "NW-F4": NW_F4_VERBATIM,
@@ -59,6 +74,7 @@ VERBATIM_CLAUSES: dict[str, str] = {
     "NW-F6": NW_F6_VERBATIM,
     "OD-26": OD_26_JOB_A_VERBATIM,
     "OD-26-JOB-B": OD_26_JOB_B_VERBATIM,
+    "OD-31": OD_31_VERBATIM,
 }
 
 VERBATIM_TOPICS: dict[str, str] = {
@@ -68,4 +84,5 @@ VERBATIM_TOPICS: dict[str, str] = {
     "NW-F6": NW_F6_TOPIC,
     "OD-26": OD_26_JOB_A_TOPIC,
     "OD-26-JOB-B": OD_26_JOB_B_TOPIC,
+    "OD-31": OD_31_TOPIC,
 }

--- a/research/dfc_v22_research_min/schema.py
+++ b/research/dfc_v22_research_min/schema.py
@@ -24,6 +24,7 @@ __all__ = [
     "KLINES_4H_SCHEMA",
     "MANIFEST_GAP_REQUIRED_KEYS",
     "MANIFEST_LIFECYCLE_REQUIRED_KEYS",
+    "MANIFEST_RANKING_INPUT_DEFICIT_REQUIRED_KEYS",
     "MANIFEST_REQUIRED_KEYS",
     "MANIFEST_SOURCE_REQUIRED_KEYS",
     "MANIFEST_TABLE_REQUIRED_KEYS",
@@ -31,6 +32,7 @@ __all__ = [
     "PIT_UNIVERSE_SCHEMA",
     "PREMIUM_INDEX_4H_SCHEMA",
     "PREMIUM_INDEX_GAP_AUDIT_SCHEMA",
+    "RANKING_INPUT_DEFICIT_ROW_REQUIRED_KEYS",
     "RAW_KLINE_FIELD_NAMES",
     "SAMPLE_REPORT_REQUIRED_KEYS",
     "SAMPLE_ROW_REQUIRED_KEYS",
@@ -185,6 +187,7 @@ MANIFEST_REQUIRED_KEYS: tuple[str, ...] = (
     "prerequisite_readiness",
     "lifecycle_eligibility",
     "premium_index_gap",
+    "ranking_input_deficit",
     "sources",
     "tables",
     "admissibility",
@@ -206,6 +209,27 @@ GAP_EXCLUSION_REQUIRED_KEYS: tuple[str, ...] = (
     "symbol",
     "reason",
     "evidence_sha256",
+)
+
+#: A2-C9 (OD-31).  The manifest restates the frozen enumeration rather than
+#: pointing at it, and both the source digest and the epoch list are compared
+#: against ``contract`` — a corpus that quietly widened, narrowed or re-derived
+#: the list has to say so here, where the comparison happens.
+MANIFEST_RANKING_INPUT_DEFICIT_REQUIRED_KEYS: tuple[str, ...] = (
+    "enumeration_path",
+    "enumeration_sha256",
+    "epochs",
+    "verdict",
+    "rows",
+)
+
+#: One entry per enumerated epoch: the epoch, the rank-3 symbol the deficient
+#: archive input actually ranks (which the corpus records), and the rank-3
+#: symbol complete input would have ranked (which it must not).
+RANKING_INPUT_DEFICIT_ROW_REQUIRED_KEYS: tuple[str, ...] = (
+    "epoch_open_time",
+    "as_archived_rank3",
+    "would_have_been_rank3",
 )
 
 #: A2-C6.  The corpus states the authority situation rather than leaving it

--- a/research/dfc_v22_research_min/validation.py
+++ b/research/dfc_v22_research_min/validation.py
@@ -27,9 +27,11 @@ from .schema import (
     GAP_EXCLUSION_REQUIRED_KEYS,
     MANIFEST_GAP_REQUIRED_KEYS,
     MANIFEST_LIFECYCLE_REQUIRED_KEYS,
+    MANIFEST_RANKING_INPUT_DEFICIT_REQUIRED_KEYS,
     MANIFEST_REQUIRED_KEYS,
     MANIFEST_SOURCE_REQUIRED_KEYS,
     MANIFEST_TABLE_REQUIRED_KEYS,
+    RANKING_INPUT_DEFICIT_ROW_REQUIRED_KEYS,
     SAMPLE_REPORT_REQUIRED_KEYS,
     SAMPLE_ROW_REQUIRED_KEYS,
 )
@@ -50,6 +52,7 @@ __all__ = [
     "validate_manifest",
     "validate_outcomes",
     "validate_premium_index_gap",
+    "validate_ranking_input_deficit",
     "validate_sample_readiness",
     "validate_table",
 ]
@@ -1069,10 +1072,229 @@ def _check_gap_row(
         )
 
 
+# --- A2-C9 (OD-31): ranking-input deficit epochs ---------------------------
+
+
+def _validate_ranking_input_deficit_section(
+    manifest: Mapping[str, Any],
+) -> tuple[int, ...]:
+    """Check the manifest's A2-C9 declaration against the frozen enumeration.
+
+    The enumeration is *restated* here and compared, not referenced: the frozen
+    list was fixed by a measurement that has already been read, so the only
+    thing standing between it and a quiet edit is that both the source digest
+    and the epochs themselves have to match ``contract`` exactly.
+    """
+    section = manifest.get("ranking_input_deficit")
+    if not isinstance(section, Mapping):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            "manifest does not declare ranking_input_deficit; the enumerated "
+            "epochs whose top-3 a ranking-input deficit changed are an input to "
+            "this corpus and are recorded, not assumed empty",
+        )
+        return ()
+
+    missing = [
+        k for k in MANIFEST_RANKING_INPUT_DEFICIT_REQUIRED_KEYS if k not in section
+    ]
+    if missing:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            f"ranking_input_deficit is missing {missing}",
+        )
+    unknown = [
+        k for k in section if k not in MANIFEST_RANKING_INPUT_DEFICIT_REQUIRED_KEYS
+    ]
+    if unknown:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            f"ranking_input_deficit carries unknown key(s): {sorted(unknown)}",
+        )
+
+    if section["enumeration_path"] != c.RANKING_INPUT_DEFICIT_ENUMERATION_PATH:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            "ranking_input_deficit.enumeration_path must be "
+            f"{c.RANKING_INPUT_DEFICIT_ENUMERATION_PATH!r}, got "
+            f"{section['enumeration_path']!r}",
+        )
+    if section["enumeration_sha256"] != c.RANKING_INPUT_DEFICIT_ENUMERATION_SHA256:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            "the enumeration list changed: declared enumeration_sha256 "
+            f"{section['enumeration_sha256']!r} is not the frozen "
+            f"{c.RANKING_INPUT_DEFICIT_ENUMERATION_SHA256!r}. The list was fixed "
+            "by a measurement that has already been read, so a list that moves "
+            "afterwards is a pre-registration that was rewritten, not a "
+            "correction",
+        )
+    if section["verdict"] != c.RANKING_INPUT_DEFICIT_VERDICT:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            f"ranking_input_deficit.verdict must be "
+            f"{c.RANKING_INPUT_DEFICIT_VERDICT!r}, got {section['verdict']!r}; a "
+            "deficit epoch carries the same terminal code as the other "
+            "direction, never a softer one",
+        )
+
+    epochs = tuple(section["epochs"])
+    if epochs != c.RANKING_INPUT_DEFICIT_EPOCHS:
+        extra = sorted(set(epochs) - set(c.RANKING_INPUT_DEFICIT_EPOCHS))
+        absent = sorted(set(c.RANKING_INPUT_DEFICIT_EPOCHS) - set(epochs))
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            f"declared deficit epochs are not the frozen enumeration of "
+            f"{len(c.RANKING_INPUT_DEFICIT_EPOCHS)} (extra={extra}, "
+            f"absent={absent}); the enumeration is fixed, not recomputed",
+        )
+
+    rows = list(section["rows"])
+    if len(rows) != len(c.RANKING_INPUT_DEFICIT_ROWS):
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            f"ranking_input_deficit.rows carries {len(rows)} row(s), the frozen "
+            f"enumeration has {len(c.RANKING_INPUT_DEFICIT_ROWS)}",
+        )
+    for index, (row, frozen) in enumerate(
+        zip(rows, c.RANKING_INPUT_DEFICIT_ROWS, strict=True)
+    ):
+        label = f"ranking_input_deficit.rows[{index}]"
+        absent_keys = [
+            k for k in RANKING_INPUT_DEFICIT_ROW_REQUIRED_KEYS if k not in row
+        ]
+        if absent_keys:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE, "A2-C9", f"{label}: missing {absent_keys}"
+            )
+        declared = (
+            row["epoch_open_time"],
+            row["as_archived_rank3"],
+            row["would_have_been_rank3"],
+        )
+        if declared != frozen:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C9",
+                f"{label}: declared {declared} is not the frozen enumeration row "
+                f"{frozen}",
+            )
+    return epochs
+
+
+def validate_ranking_input_deficit(
+    manifest: Mapping[str, Any],
+    pit_universe: pa.Table,
+    outcomes: pa.Table | None = None,
+    decisions: Sequence[Mapping[str, Any]] = (),
+) -> None:
+    """Enforce A2-C9 on the frozen artifacts.
+
+    Three things have to hold at every enumerated epoch, and each is one of the
+    ways the clause could be evaded:
+
+    1. The epoch is still **there**.  Deleting it is how a deficit disappears
+       without leaving a trace, so an absent pool is a violation rather than a
+       tidy corpus.
+    2. The pool is the one the archive's own (deficient) input ranks.  Writing
+       ``would_have_been_rank3`` into it is the silent re-ranking §31차 names —
+       and it is the *more* tempting direction here, because the corrected
+       ranking looks more accurate.  It is still a ranking nobody can reproduce
+       from the recorded input.
+    3. The epoch is not **scored**.  ``RUN_INVALID_INPUT_EVIDENCE`` is a
+       terminal code, so an enumerated epoch that carries a decision or an
+       outcome row was processed as if it were clean.
+
+    Nothing here returns a pool or names a replacement, for the same reason
+    :func:`validate_premium_index_gap` does not.
+
+    Raises:
+        ContractViolation: Always with ``RUN_INVALID_INPUT_EVIDENCE``.
+    """
+    epochs = _validate_ranking_input_deficit_section(manifest)
+    if not epochs:
+        return
+
+    validate_table("pit_universe", pit_universe)
+
+    pools: dict[int, list[dict[str, Any]]] = {}
+    for row in pit_universe.to_pylist():
+        pools.setdefault(row["epoch_open_time"], []).append(row)
+
+    frozen_by_epoch = {row[0]: row for row in c.RANKING_INPUT_DEFICIT_ROWS}
+    head = c.RANKING_INPUT_DEFICIT_UNCHANGED_HEAD
+
+    #: Presence is required *within the table's own covered range* only.  An
+    #: enumerated epoch outside ``[min, max]`` was never in this table's scope
+    #: and nothing is claimed about it; one inside the range and missing is a
+    #: hole, which is exactly how a deficit epoch would be made to disappear.
+    #: Interior deletion cannot shrink the range, so the bound cannot be gamed
+    #: by deleting the rows the check is looking for.
+    covered_from, covered_to = (min(pools), max(pools)) if pools else (1, 0)
+
+    for epoch in epochs:
+        _, as_archived_rank3, would_have_been_rank3 = frozen_by_epoch[epoch]
+        rows = pools.get(epoch)
+        if not rows:
+            if covered_from <= epoch <= covered_to:
+                _fail(
+                    RUN_INVALID_INPUT_EVIDENCE,
+                    "A2-C9",
+                    f"epoch {epoch} is enumerated as a ranking-input deficit and "
+                    f"falls inside the pit_universe range "
+                    f"[{covered_from}, {covered_to}] but has no pool; the epoch "
+                    "is recorded with its reason, not removed",
+                )
+            continue
+        declared = tuple(row["symbol"] for row in sorted(rows, key=lambda r: r["rank"]))
+        if would_have_been_rank3 in declared:
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C9",
+                f"epoch {epoch}: {would_have_been_rank3!r} is in the declared "
+                f"pool {list(declared)}, which is the ranking complete input "
+                "would have produced, not the one the recorded input produces "
+                f"({[*head, as_archived_rank3]}). The epoch is invalid; it "
+                "is not repaired by ranking it as if the deficit were not there",
+            )
+        if declared != (*head, as_archived_rank3):
+            _fail(
+                RUN_INVALID_INPUT_EVIDENCE,
+                "A2-C9",
+                f"epoch {epoch}: declared pool {list(declared)} is not the "
+                f"as-archived ranking {[*head, as_archived_rank3]} the "
+                "enumeration recorded for it",
+            )
+
+    scored: set[int] = {d["signal_epoch_open_time"] for d in decisions}
+    if outcomes is not None:
+        scored |= {row["signal_epoch_open_time"] for row in outcomes.to_pylist()}
+    processed = sorted(scored & set(epochs))
+    if processed:
+        _fail(
+            RUN_INVALID_INPUT_EVIDENCE,
+            "A2-C9",
+            f"{len(processed)} enumerated deficit epoch(s) carry a decision or "
+            f"an outcome row (first={processed[0]}); "
+            f"{c.RANKING_INPUT_DEFICIT_VERDICT} is terminal, so a deficit epoch "
+            "is not scored as if its ranking input were complete",
+        )
+
+
 def validate_input_evidence(manifest: Mapping[str, Any]) -> tuple[str, ...]:
-    """Run the A2-C6 / A2-C7 manifest half and return the in-window gap subset."""
+    """Run the A2-C6 / A2-C7 / A2-C9 manifest half; return the in-window subset."""
     _validate_lifecycle_eligibility(manifest)
-    return _validate_gap_section(manifest)
+    in_window = _validate_gap_section(manifest)
+    _validate_ranking_input_deficit_section(manifest)
+    return in_window
 
 
 def validate_corpus(
@@ -1101,6 +1323,7 @@ def validate_corpus(
     """
     in_window = validate_input_evidence(manifest)
     validate_premium_index_gap(gap_audit, pit_universe, in_window)
+    validate_ranking_input_deficit(manifest, pit_universe, outcomes, decisions)
     validate_manifest(manifest)  # re-runs the pure input-evidence half; idempotent
     validate_table("klines_4h", klines)
     validate_table("premium_index_4h", premium_index)

--- a/tests/research/dfc_v22_research_min/golden/violation_cases.json
+++ b/tests/research/dfc_v22_research_min/golden/violation_cases.json
@@ -296,6 +296,54 @@
       "clause": "A2-C8",
       "expected_code": "RUN_INVALID_CORPUS_LITERALS",
       "expected_detail_contains": "is not part of the pre-registered sample"
+    },
+    {
+      "case_id": "deficit_epoch_processed_normally",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "carry a decision or an outcome row"
+    },
+    {
+      "case_id": "deficit_epoch_scored_in_outcomes",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "is terminal, so a deficit epoch"
+    },
+    {
+      "case_id": "deficit_epoch_silently_reranked",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "not repaired by ranking it as if the deficit were not there"
+    },
+    {
+      "case_id": "deficit_enumeration_list_changed",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "the enumeration list changed"
+    },
+    {
+      "case_id": "deficit_epochs_narrowed",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "the enumeration is fixed, not recomputed"
+    },
+    {
+      "case_id": "deficit_row_disagrees_with_enumeration",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "is not the frozen enumeration row"
+    },
+    {
+      "case_id": "deficit_epoch_row_deleted",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "but has no pool; the epoch is recorded with its reason, not removed"
+    },
+    {
+      "case_id": "deficit_declaration_absent",
+      "clause": "A2-C9",
+      "expected_code": "RUN_INVALID_INPUT_EVIDENCE",
+      "expected_detail_contains": "recorded, not assumed empty"
     }
   ]
 }

--- a/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
+++ b/tests/research/dfc_v22_research_min/test_a2_contract_transcription.py
@@ -63,8 +63,10 @@ def test_canonical_source_is_pinned() -> None:
         "NW-F6",
         "OD-26",
         "OD-26-JOB-B",
+        "OD-31",
     }
     assert "§26차" in nw_verbatim.BINDING_RECORD_AMENDMENT
+    assert "§31차" in nw_verbatim.BINDING_RECORD_AMENDMENT_C9
 
 
 @pytest.mark.unit
@@ -141,6 +143,16 @@ REQUIRED_A2_C7_WORDING = (
     "`RUN_INVALID_INPUT_EVIDENCE`",
 )
 
+#: A2-C9 has two sentences that carry the whole clause: the list may not be
+#: re-derived, and a gap outside it is a stop rather than an extension.  Both
+#: are the kind of sentence a later edit would soften first.
+REQUIRED_A2_C9_WORDING = (
+    "The epochs are an enumeration, not a rule.",
+    "It covers exactly the 38 enumerated epochs.",
+    "a FREEZE that meets one is a fail-closed stop, not a case for this clause",
+    "The enumeration cannot grow to fit what FREEZE finds.",
+)
+
 
 @pytest.mark.unit
 def test_substitute_evidence_is_never_called_equivalent_to_an_authority() -> None:
@@ -160,7 +172,9 @@ def test_substitute_evidence_is_never_called_equivalent_to_an_authority() -> Non
 @pytest.mark.unit
 def test_gap_closure_clauses_state_their_load_bearing_sentences() -> None:
     doc = " ".join(DOC_PATH.read_text(encoding="utf-8").split())
-    for wording in REQUIRED_A2_C6_WORDING + REQUIRED_A2_C7_WORDING:
+    for wording in (
+        REQUIRED_A2_C6_WORDING + REQUIRED_A2_C7_WORDING + REQUIRED_A2_C9_WORDING
+    ):
         assert wording in doc, f"missing from the contract document: {wording!r}"
 
 
@@ -211,3 +225,171 @@ def test_package_does_not_write_files() -> None:
             if name in {"write_text", "write_bytes", "open", "mkdir", "write_table"}:
                 offenders.append(f"{path.name}:{node.lineno} calls {name}")
     assert not offenders, offenders
+
+
+# --- A2-C9 (OD-31): the amendment's own scope ------------------------------
+
+#: Every literal §31차 explicitly ruled unchanged.  A2-C9 adds a clause; if any
+#: value below moved, what shipped is a different contract wearing the same ID,
+#: and this test is the thing that says so out loud.
+FROZEN_ACROSS_THE_C9_AMENDMENT = {
+    "CORPUS_ID": "dfc-2c-4h-v22-corpus-v1",
+    "CORPUS_ROOT": "/Users/mgh3326/work/herdr-artifacts/dfc-2c-4h-v22-corpus-v1/",
+    "UNIVERSE_LOOKBACK_CALENDAR_DAYS": 30,
+    "UNIVERSE_RANKING_METRIC": "quote_volume",
+    "UNIVERSE_TOP_N": 3,
+    "UNIVERSE_TIE_BREAK": "canonical_symbol_ascending",
+    "UNIVERSE_INSTRUMENT_CLASS": "usdm_perpetual",
+    "OUTCOME_TAIL_BARS": 1,
+    "OUTCOME_HORIZON_BARS": 1,
+    "OUTCOME_UNIT": "absolute_log_return_bps",
+    "IMPUTED_ROW_COUNT_MAX": 0,
+    "ADMISSIBILITY_BASIS": "independent_recollection",
+    "SAMPLE_SEED": 26,
+    "SAMPLE_EPOCHS_PER_QUARTER": 12,
+}
+
+
+@pytest.mark.unit
+def test_c9_amendment_moved_no_frozen_literal() -> None:
+    """NW-F5 · NW-F6 · the universe rule · the sample protocol are untouched."""
+    for name, expected in FROZEN_ACROSS_THE_C9_AMENDMENT.items():
+        assert getattr(c, name) == expected, name
+
+    # The judgment window was *not* narrowed around the deficit epochs — that
+    # was §31차's option "B" and it was refused, because a shorter window hides
+    # the problem instead of recording it.
+    assert c.WARMUP_START.isoformat() == "2021-02-02T00:00:00+00:00"
+    assert c.WARMUP_END.isoformat() == "2021-05-02T00:00:00+00:00"
+    assert c.JUDGMENT_START.isoformat() == "2021-05-02T00:00:00+00:00"
+    assert c.JUDGMENT_END.isoformat() == "2023-08-04T00:00:00+00:00"
+
+    assert c.REQUIRED_SOURCE_KINDS == (
+        "usdm_kline_4h",
+        "premium_index_4h",
+        "contract_lifecycle_eligibility",
+    )
+    # No new terminal code: A2-C9 reuses the one A2-C7 already raises.
+    assert c.RANKING_INPUT_DEFICIT_VERDICT == c.RUN_INVALID_INPUT_EVIDENCE
+    assert c.TERMINAL_CODE_PRIORITY == (
+        "RUN_INVALID_INPUT_EVIDENCE",
+        "RUN_INVALID_SCOPE_SEPARATION",
+        "RUN_INVALID_CORPUS_LITERALS",
+        "RUN_INVALID_FORBIDDEN_SOURCE",
+        "RUN_INVALID_MANIFEST_SCHEMA",
+        "RUN_INVALID_TABLE_SCHEMA",
+        "RUN_INVALID_AUTHENTICITY_EVIDENCE",
+        "RUN_INVALID_OUTCOME_EVIDENCE",
+    )
+
+
+@pytest.mark.unit
+def test_c9_enumeration_is_a_literal_the_package_cannot_recompute() -> None:
+    """MUTANT ③, structural half.
+
+    The enumeration is a measurement result that has already been read, so the
+    package must not be able to re-derive it — a re-derivation would be a
+    decision procedure re-run after seeing its inputs. The only permitted
+    computation over the frozen rows is projecting out their first column.
+    """
+    assert len(c.RANKING_INPUT_DEFICIT_ROWS) == 38
+    assert len(c.RANKING_INPUT_DEFICIT_EPOCHS) == 38
+    assert list(c.RANKING_INPUT_DEFICIT_EPOCHS) == sorted(
+        c.RANKING_INPUT_DEFICIT_EPOCHS
+    )
+    assert len(set(c.RANKING_INPUT_DEFICIT_EPOCHS)) == 38
+    assert c.RANKING_INPUT_DEFICIT_EPOCHS[0] == 1646193600000
+    assert c.RANKING_INPUT_DEFICIT_EPOCHS[-1] == 1646726400000
+    step = c.BAR_INTERVAL_MS
+    assert all(
+        b - a == step
+        for a, b in zip(
+            c.RANKING_INPUT_DEFICIT_EPOCHS,
+            c.RANKING_INPUT_DEFICIT_EPOCHS[1:],
+            strict=False,
+        )
+    )
+    assert len(c.RANKING_INPUT_DEFICIT_ENUMERATION_SHA256) == 64
+    assert c.RANKING_INPUT_DEFICIT_ENUMERATION_SHA256.startswith("2a04dd6d0c666b68")
+    assert c.RANKING_INPUT_DEFICIT_ENUMERATION_PATH.endswith("flipped_epochs.json")
+
+    source = (PACKAGE_DIR / "contract.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AnnAssign | ast.Assign)
+        for target in (
+            [node.target] if isinstance(node, ast.AnnAssign) else node.targets
+        )
+        if isinstance(target, ast.Name)
+        and target.id.startswith("RANKING_INPUT_DEFICIT")
+    ]
+    assert len(assignments) == 6, [ast.unparse(a).split("=")[0] for a in assignments]
+    for node in assignments:
+        value = node.value
+        if value is None:
+            continue
+        # Literal tuples/strings are fine.  The single generator is the epochs
+        # projection, and it may only read column 0 of the frozen rows.
+        for call in ast.walk(value):
+            if isinstance(call, ast.Call):
+                assert getattr(call.func, "id", None) == "tuple", (
+                    f"unexpected call in a frozen enumeration literal: {ast.unparse(call)}"
+                )
+
+
+@pytest.mark.unit
+def test_c9_validator_offers_no_substitution_path() -> None:
+    """MUTANT ②, structural half: no repaired pool can come out of A2-C9."""
+    from research.dfc_v22_research_min import validation as val
+
+    tree = ast.parse(Path(val.__file__).read_text(encoding="utf-8"))
+    functions = {
+        node.name: node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    entry = functions["validate_ranking_input_deficit"]
+    assert isinstance(entry.returns, ast.Constant) and entry.returns.value is None
+    returned = [
+        node
+        for node in ast.walk(entry)
+        if isinstance(node, ast.Return) and node.value is not None
+    ]
+    assert not returned, "the deficit validator hands something back to its caller"
+
+
+#: The enumeration source lives outside the repository (operator artifacts), so
+#: this check runs where that tree is present and skips where it is not — the
+#: same posture as the canonical answer document, which is pinned by digest for
+#: the same reason.  Where it *does* run it is the sharpest form of MUTANT ③:
+#: the frozen rows are re-read from the file and compared row by row, so an
+#: enumeration that moved on disk fails here even if every literal in this repo
+#: is self-consistent.
+ENUMERATION_FILE = Path(
+    c.RANKING_INPUT_DEFICIT_ENUMERATION_PATH.replace("~", str(Path.home()), 1)
+)
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(
+    not ENUMERATION_FILE.is_file(), reason="operator artifact tree not present"
+)
+def test_c9_frozen_rows_reproduce_the_pinned_enumeration_file() -> None:
+    import hashlib
+    import json
+
+    raw = ENUMERATION_FILE.read_bytes()
+    assert (
+        hashlib.sha256(raw).hexdigest() == c.RANKING_INPUT_DEFICIT_ENUMERATION_SHA256
+    ), "the pinned enumeration file changed on disk"
+
+    rows = json.loads(raw)
+    assert len(rows) == len(c.RANKING_INPUT_DEFICIT_ROWS)
+    head = list(c.RANKING_INPUT_DEFICIT_UNCHANGED_HEAD)
+    for row, (epoch, as_archived, would_have_been) in zip(
+        rows, c.RANKING_INPUT_DEFICIT_ROWS, strict=True
+    ):
+        assert row["epoch_open_time"] == epoch
+        assert row["current_top3"] == [*head, as_archived]
+        assert row["corrected_top3"] == [*head, would_have_been]
+        assert row["membership_changed"] is True

--- a/tests/research/dfc_v22_research_min/test_a2_golden.py
+++ b/tests/research/dfc_v22_research_min/test_a2_golden.py
@@ -217,6 +217,53 @@ def premium_index_gap(**overrides: Any) -> dict[str, Any]:
     return gap
 
 
+#: A2-C9.  The baseline restates the frozen enumeration exactly, so every
+#: mutant below is a *single* deviation from a manifest that otherwise passes.
+def ranking_input_deficit(**overrides: Any) -> dict[str, Any]:
+    section: dict[str, Any] = {
+        "enumeration_path": c.RANKING_INPUT_DEFICIT_ENUMERATION_PATH,
+        "enumeration_sha256": c.RANKING_INPUT_DEFICIT_ENUMERATION_SHA256,
+        "epochs": list(c.RANKING_INPUT_DEFICIT_EPOCHS),
+        "verdict": c.RANKING_INPUT_DEFICIT_VERDICT,
+        "rows": [
+            {
+                "epoch_open_time": epoch,
+                "as_archived_rank3": as_archived,
+                "would_have_been_rank3": would_have_been,
+            }
+            for epoch, as_archived, would_have_been in c.RANKING_INPUT_DEFICIT_ROWS
+        ],
+    }
+    section.update(overrides)
+    return section
+
+
+#: The pool the corpus must record at a deficit epoch: the ranking the archive's
+#: own (short) input produces.  ``DEFICIT_EPOCH`` is the first enumerated one.
+DEFICIT_EPOCH = c.RANKING_INPUT_DEFICIT_EPOCHS[0]
+DEFICIT_AS_ARCHIVED = (
+    *c.RANKING_INPUT_DEFICIT_UNCHANGED_HEAD,
+    c.RANKING_INPUT_DEFICIT_ROWS[0][1],
+)
+DEFICIT_WOULD_HAVE_BEEN = (
+    *c.RANKING_INPUT_DEFICIT_UNCHANGED_HEAD,
+    c.RANKING_INPUT_DEFICIT_ROWS[0][2],
+)
+
+
+def deficit_pool_rows(
+    symbols: tuple[str, ...] = DEFICIT_AS_ARCHIVED,
+) -> list[dict[str, Any]]:
+    """A three-rank pool at the first enumerated deficit epoch."""
+    return [
+        {
+            **pit_universe_row(rank, symbol, str(300 - 100 * (rank - 1)) + ".0"),
+            "epoch_open_time": DEFICIT_EPOCH,
+        }
+        for rank, symbol in enumerate(symbols, start=1)
+    ]
+
+
 def manifest(**overrides: Any) -> dict[str, Any]:
     base: dict[str, Any] = {
         "contract_id": c.CONTRACT_ID,
@@ -244,6 +291,7 @@ def manifest(**overrides: Any) -> dict[str, Any]:
         },
         "lifecycle_eligibility": lifecycle_eligibility(),
         "premium_index_gap": premium_index_gap(),
+        "ranking_input_deficit": ranking_input_deficit(),
         "sources": [_source(kind) for kind in c.REQUIRED_SOURCE_KINDS],
         "tables": [
             {
@@ -771,6 +819,113 @@ def _case_sample_epoch_outside_registered_plan() -> None:
     v.validate_sample_readiness(report)
 
 
+# --- A2-C9 (OD-31) — the three mutants the amendment must shoot down --------
+
+
+def _deficit_decisions(epoch: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "signal_epoch_open_time": epoch,
+            "candidate_any": c.ARM_CANDIDATE,
+            "winner_symbol": DEFICIT_AS_ARCHIVED[0],
+        }
+    ]
+
+
+def _case_deficit_epoch_processed_normally() -> None:
+    # MUTANT ①: an enumerated epoch is scored as if its ranking input had been
+    # complete.  Everything else about the corpus is well-formed, so only the
+    # terminal-code check can catch it.
+    v.validate_ranking_input_deficit(
+        manifest(),
+        pit_universe(deficit_pool_rows()),
+        None,
+        _deficit_decisions(DEFICIT_EPOCH),
+    )
+
+
+def _case_deficit_epoch_scored_in_outcomes() -> None:
+    # Same mutant reached from the outcomes table rather than the decision set:
+    # a builder that never registered the decision but still emitted a row.
+    rows = [
+        _outcome_row(
+            DEFICIT_EPOCH,
+            "XRPUSDT",
+            "p-xrp-t0",
+            "p-xrp-t0n",
+            "1.0000",
+            "1.0100",
+            c.ARM_CANDIDATE,
+        )
+    ]
+    v.validate_ranking_input_deficit(
+        manifest(), pit_universe(deficit_pool_rows()), outcomes(rows), ()
+    )
+
+
+def _case_deficit_epoch_silently_reranked() -> None:
+    # MUTANT ②: the pool records the ranking *complete* input would have
+    # produced.  It looks more accurate, and it is exactly what §31차 forbids —
+    # no reader can reproduce it from the evidence the corpus carries.
+    v.validate_ranking_input_deficit(
+        manifest(), pit_universe(deficit_pool_rows(DEFICIT_WOULD_HAVE_BEEN)), None, ()
+    )
+
+
+def _case_deficit_enumeration_list_changed() -> None:
+    # MUTANT ③: the enumeration file moved after the list was pre-registered.
+    # The manifest is internally consistent; only the pinned digest exposes it.
+    v.validate_manifest(
+        manifest(
+            ranking_input_deficit=ranking_input_deficit(
+                enumeration_sha256="9" * 64,
+            )
+        )
+    )
+
+
+def _case_deficit_epochs_narrowed() -> None:
+    # The same edit reached from the list itself: drop the inconvenient epochs
+    # and re-hash nothing.
+    v.validate_manifest(
+        manifest(
+            ranking_input_deficit=ranking_input_deficit(
+                epochs=list(c.RANKING_INPUT_DEFICIT_EPOCHS[:-1]),
+            )
+        )
+    )
+
+
+def _case_deficit_row_disagrees_with_enumeration() -> None:
+    rows = [dict(r) for r in ranking_input_deficit()["rows"]]
+    rows[0]["would_have_been_rank3"] = rows[0]["as_archived_rank3"]
+    v.validate_manifest(
+        manifest(ranking_input_deficit=ranking_input_deficit(rows=rows))
+    )
+
+
+def _case_deficit_epoch_row_deleted() -> None:
+    # Deleting the epoch is how a deficit disappears without leaving a trace.
+    # The first and last enumerated epochs are kept so the table's covered range
+    # still spans the whole enumeration — the deletion is an interior hole,
+    # which is the only shape this can actually take.
+    kept: list[dict[str, Any]] = []
+    for epoch, as_archived, _ in (
+        c.RANKING_INPUT_DEFICIT_ROWS[0],
+        c.RANKING_INPUT_DEFICIT_ROWS[-1],
+    ):
+        symbols = (*c.RANKING_INPUT_DEFICIT_UNCHANGED_HEAD, as_archived)
+        kept.extend(
+            {**row, "epoch_open_time": epoch} for row in deficit_pool_rows(symbols)
+        )
+    v.validate_ranking_input_deficit(manifest(), pit_universe(kept), None, ())
+
+
+def _case_deficit_declaration_absent() -> None:
+    bare = {k: val for k, val in manifest().items() if k != "ranking_input_deficit"}
+    v.validate_input_evidence(bare)
+
+
 CASE_BUILDERS: dict[str, Callable[[], None]] = {
     "outcomes_free_bool_column": _case_outcomes_free_bool_column,
     "outcomes_free_price_column": _case_outcomes_free_price_column,
@@ -835,6 +990,16 @@ CASE_BUILDERS: dict[str, Callable[[], None]] = {
     "sample_rule_tampered": _case_sample_rule_tampered,
     "sample_verdict_not_recomputed": _case_sample_verdict_not_recomputed,
     "sample_epoch_outside_registered_plan": _case_sample_epoch_outside_registered_plan,
+    "deficit_epoch_processed_normally": _case_deficit_epoch_processed_normally,
+    "deficit_epoch_scored_in_outcomes": _case_deficit_epoch_scored_in_outcomes,
+    "deficit_epoch_silently_reranked": _case_deficit_epoch_silently_reranked,
+    "deficit_enumeration_list_changed": _case_deficit_enumeration_list_changed,
+    "deficit_epochs_narrowed": _case_deficit_epochs_narrowed,
+    "deficit_row_disagrees_with_enumeration": (
+        _case_deficit_row_disagrees_with_enumeration
+    ),
+    "deficit_epoch_row_deleted": _case_deficit_epoch_row_deleted,
+    "deficit_declaration_absent": _case_deficit_declaration_absent,
 }
 
 


### PR DESCRIPTION
## What

§31차's explicit amendment, transcribed: a new clause **A2-C9**, its verbatim
source line, the 38-epoch enumeration frozen as a literal with its source file
pinned by digest, and a fail-closed validator.

```
유형③: 랭킹 입력 결손으로 top-3 구성이 달라졌을 것으로 전수 증명된
epoch(열거 목록 고정)도 동일하게 RUN_INVALID_INPUT_EVIDENCE, 재랭킹 금지
```

A2-C7 fires in one direction only — a gap symbol *inside* an epoch's top-3
pool. Silent internal holes in the `klines` monthly archive push a symbol the
other way: the trailing-30-day sum reads a missing bar as zero volume, so a
symbol can be pushed **out** of a top 3 it belonged in. Read literally A2-C7
does not reach that. §31차 declined to stretch it by interpretation and signed
one more clause; this PR is that clause and nothing else.

## Scope

Additive. No new terminal code (A2-C9 reuses `RUN_INVALID_INPUT_EVIDENCE`), and
`test_c9_amendment_moved_no_frozen_literal` pins every literal §31차 ruled
unchanged: NW-F5's corpus id/root/windows — the judgment window is explicitly
**not** narrowed, which was option "B" and was refused — the universe rule,
required/forbidden source kinds, `imputation 0`, NW-F6 authenticity, and the
A2-C8 sample protocol. The whole diff removes 4 lines, all cosmetic.

## Why the epochs are a literal and not a rule

The measurement that produced them has already been read, so re-deriving the
list at validation time would be re-running a decision procedure after seeing
its inputs. The list is frozen in `contract.py`, and its source
(`gap-impact/flipped_epochs.json`, sha256 `2a04dd6d…`) is pinned by digest —
this package cannot open files or sockets, so the digest is what makes a moved
enumeration visible rather than silent.

## Mutants killed

8 golden cases, all `A2-C9` / `RUN_INVALID_INPUT_EVIDENCE`, each asserting the
wording as well as the code:

| mutant | case |
|---|---|
| ① enumerated epoch processed normally | `deficit_epoch_processed_normally`, `deficit_epoch_scored_in_outcomes` |
| ② re-ranked to the corrected symbol | `deficit_epoch_silently_reranked` |
| ③ enumeration changed | `deficit_enumeration_list_changed`, `deficit_epochs_narrowed`, `deficit_row_disagrees_with_enumeration` |
| (row deletion / omission) | `deficit_epoch_row_deleted`, `deficit_declaration_absent` |

Plus structural guards: the enumeration cannot be recomputed inside the
package (AST), `validate_ranking_input_deficit` has no return path, and where
the operator artifact tree is present the frozen rows are re-read from the
pinned file and compared row by row.

`uv run pytest tests/research/dfc_v22_research_min/ -q` → 79 passed. Ruff clean.

## What this PR does *not* do

No corpus was frozen. FREEZE was re-attempted after this amendment and **halted
fail-closed**: an exhaustive re-adjudication of all 105 archive-internal gaps
found 11 membership flips outside the enumerated 38
(2022-04-05T00:00Z…2022-04-06T16:00Z, rank 3 `LUNAUSDT` → `GMTUSDT`), caused by
a second 50-symbol cluster (2022-03-31→04-03) that was never impact-quantified.
Per A2-C9's own last paragraph that is a stop, not an extension of the
enumeration. Details in the job report; the decision is upstream's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)