### PR TITLE
fix(b0x): give the crypto shadow lane its own KRW envelope (SHADOW-ALIGN)

### DIFF
--- a/scripts/b0x/cycle.py
+++ b/scripts/b0x/cycle.py
@@ -40,6 +40,7 @@ from scripts.b0x.crypto import shadow as shadow_lane
 from scripts.b0x.crypto import sidecar as sidecar_lane
 from scripts.b0x.derivation import DerivationResult, derive_orders
 from scripts.b0x.envelope import (
+    CRYPTO_SHADOW_MARKET_KEY,
     SHADOW_ENVELOPE_NOT_APPLIED,
     Envelope,
     assert_envelope_locked,
@@ -70,15 +71,22 @@ from scripts.b0x.table_source import (
 MARKET = "crypto"
 
 #: contract §4 assigns the shadow lane a synthetic, KRW-denominated book
-#: (``shadow.QUOTE_CURRENCY``), while the single "crypto" envelope column —
-#: shared with the sidecar — denominates ``daily_loss_kill`` in USDT
-#: (``CRYPTO_SIDECAR_ENVELOPE.quote_currency``). ``kill_switch.evaluate``
-#: fails closed on that mismatch (``CurrencyMismatchKill``) rather than
-#: silently comparing a KRW P&L against a USDT threshold — see
-#: ``scripts.b0x.kill_switch.CurrencyMismatchKill``. Until an operator
-#: defines a currency-correct kill threshold for this lane, every shadow
-#: cycle that reaches this point is, correctly, a zero-order cycle: this
-#: reason code makes that loud and observable instead of an unhandled crash.
+#: (``shadow.QUOTE_CURRENCY``). Before SHADOW-ALIGN (2026-08-11), this lane
+#: was evaluated against the single "crypto" envelope column shared with the
+#: sidecar, whose ``daily_loss_kill`` is USDT-denominated
+#: (``CRYPTO_SIDECAR_ENVELOPE.quote_currency``) — ``kill_switch.evaluate``
+#: correctly failed that comparison closed (``CurrencyMismatchKill``, see
+#: ``scripts.b0x.kill_switch.CurrencyMismatchKill``) rather than silently
+#: comparing a KRW P&L against a USDT threshold, but the practical effect was
+#: that *every* shadow cycle hit this reason code (confirmed against the
+#: real environment 2026-08-10T19:02Z). The lane now loads
+#: ``envelope.CRYPTO_SHADOW_ENVELOPE`` (``quote_currency="KRW"``,
+#: SHADOW-ALIGN) instead, so this exception branch should no longer fire in
+#: normal operation — it stays as the same fail-closed backstop
+#: ``CurrencyMismatchKill`` always was, not dead code: if the two currencies
+#: are ever misaligned again (e.g. a future edit hands this lane the wrong
+#: envelope), the cycle still degrades to zero orders with an auditable
+#: reason instead of crashing or silently miscomparing.
 SHADOW_KILL_CURRENCY_MISMATCH_REASON: str = "kill_switch_currency_mismatch"
 
 
@@ -208,7 +216,14 @@ async def run_shadow_cycle(
 ) -> CycleOutcome:
     """One Upbit shadow-sim cycle. Places zero real orders on any venue."""
 
-    envelope = load_envelope(MARKET)
+    # SHADOW-ALIGN: the shadow lane's own KRW-denominated envelope, not the
+    # sidecar's USDT one — see the note above ``CRYPTO_SHADOW_ENVELOPE`` in
+    # ``scripts.b0x.envelope`` for the conversion. ``MARKET`` ("crypto")
+    # remains the *policy table* market key (both lanes read the same table)
+    # and the record's ``market`` field — unrelated to which envelope binds
+    # the kill switch, so it is deliberately left unchanged everywhere else
+    # in this function.
+    envelope = load_envelope(CRYPTO_SHADOW_MARKET_KEY)
     assert_envelope_locked(envelope)
     labels = header_labels(lane=shadow_lane.LANE, extra=(SHADOW_SYNTHETIC_FILL,))
     lane = shadow_lane.LANE

--- a/scripts/b0x/envelope.py
+++ b/scripts/b0x/envelope.py
@@ -107,6 +107,63 @@ CRYPTO_SIDECAR_ENVELOPE: Final[Envelope] = Envelope(
 )
 
 # ---------------------------------------------------------------------------
+# Contract §4, crypto **본선** (Upbit shadow-sim) — SHADOW-ALIGN (2026-08-11).
+#
+# §4's table has no numeric column for this lane at all — only the footnote
+# "Upbit shadow 는 합성이므로 envelope 미적용(기록만)". ``derive_orders`` already
+# honours that (shadow calls it with ``apply_envelope=False``, so none of these
+# notional/count fields ever bind a shadow order). But ``kill_switch.evaluate``
+# runs unconditionally regardless of ``apply_envelope``, and it compares
+# ``state.quote_currency`` against ``envelope.quote_currency`` before doing
+# anything else (``CurrencyMismatchKill``, ROB-1233/#1822) — shadow's account
+# state is genuinely KRW (Upbit), so handing it the USDT-denominated
+# ``CRYPTO_SIDECAR_ENVELOPE`` trips that guard on *every* cycle (X-C's
+# real-environment observation, 2026-08-10T19:02Z). #1822's fail-closed
+# behaviour is correct; the fix here is to give the shadow lane its own,
+# correctly-denominated envelope rather than to touch that guard.
+#
+# No KRW literal exists in the contract to reuse, so this is a conversion of
+# the sidecar's USDT literal — done at MODULE-IMPORT TIME from fixed Decimal
+# constants only (no FX service call, no env var, no network — see
+# ``test_envelope_module_reads_no_environment`` and the shadow-specific AST
+# guard in ``tests/scripts/b0x/test_envelope_and_locks.py``).
+#
+# Rate literal source: this repo's own USD/KRW spot lookup
+# (``mcp__auto_trader_readonly__get_fx_rate``, source=toss) returned
+# mid_rate=1420.84 KRW/USD, valid_from=2026-08-10T19:13:23Z. USDT is treated
+# 1:1 with USD (its dollar peg) — an approximation, not a USDT/KRW market
+# quote. Floored to a round **1400 KRW/USDT**, deliberately BELOW the
+# observed 1420.84: every field below is therefore an UNDERSTATEMENT of its
+# USDT-equivalent, never an overstatement, which is the only direction that
+# cannot widen a §4 cap. Concretely, converted back at the observed rate:
+#   daily_loss_kill  7000 KRW / 1420.84 ≈ 4.93 USDT  (<= 5 USDT — tighter, not wider)
+#   per_order_notional      14000 KRW / 1420.84 ≈  9.85 USDT (<= 10 USDT)
+#   per_symbol_total_notional 70000 KRW / 1420.84 ≈ 49.27 USDT (<= 50 USDT)
+# The rate is a fixed literal: it does not move if the market rate moves, by
+# design (a cap that re-prices itself every cycle is not a locked cap).
+# ``max_concurrent_positions``/``max_new_entries_per_utc_day`` are unit-less
+# counts, not currency amounts, and are carried over unconverted.
+# ---------------------------------------------------------------------------
+CRYPTO_SHADOW_MARKET_KEY: Final[str] = "crypto_shadow"
+
+#: KRW per 1 USDT — see the derivation note above. Fixed literal; nothing in
+#: this module or its callers may read this from config/env/network.
+CRYPTO_SHADOW_FX_KRW_PER_USDT: Final[Decimal] = Decimal("1400")
+
+CRYPTO_SHADOW_ENVELOPE: Final[Envelope] = Envelope(
+    market=CRYPTO_SHADOW_MARKET_KEY,
+    quote_currency="KRW",
+    per_order_notional=CRYPTO_SIDECAR_ENVELOPE.per_order_notional
+    * CRYPTO_SHADOW_FX_KRW_PER_USDT,
+    per_symbol_total_notional=CRYPTO_SIDECAR_ENVELOPE.per_symbol_total_notional
+    * CRYPTO_SHADOW_FX_KRW_PER_USDT,
+    max_concurrent_positions=CRYPTO_SIDECAR_ENVELOPE.max_concurrent_positions,
+    max_new_entries_per_utc_day=CRYPTO_SIDECAR_ENVELOPE.max_new_entries_per_utc_day,
+    daily_loss_kill=CRYPTO_SIDECAR_ENVELOPE.daily_loss_kill
+    * CRYPTO_SHADOW_FX_KRW_PER_USDT,
+)
+
+# ---------------------------------------------------------------------------
 # Contract §4, KR (kis_mock) column, verbatim:
 #   종목당 신규 30만 KRW · 물타기 회차 상한 없음 단 종목당 총투입 ≤ 신규×5 ·
 #   동시 포지션 ≤ 10 · 일 신규 진입 ≤ 3 · 일 손실 −2.5% NAV → kill
@@ -162,6 +219,7 @@ SHADOW_ENVELOPE_NOT_APPLIED: Final[str] = (
 
 _LOCKED_ENVELOPES: Final[dict[str, Envelope]] = {
     "crypto": CRYPTO_SIDECAR_ENVELOPE,
+    CRYPTO_SHADOW_MARKET_KEY: CRYPTO_SHADOW_ENVELOPE,
     "kr": KR_MOCK_ENVELOPE,
     "us": US_ALPACA_PAPER_LAB_ENVELOPE,
 }
@@ -212,6 +270,9 @@ __all__ = [
     "Envelope",
     "EnvelopeNotLocked",
     "CRYPTO_SIDECAR_ENVELOPE",
+    "CRYPTO_SHADOW_ENVELOPE",
+    "CRYPTO_SHADOW_MARKET_KEY",
+    "CRYPTO_SHADOW_FX_KRW_PER_USDT",
     "KR_MOCK_ENVELOPE",
     "US_ALPACA_PAPER_LAB_ENVELOPE",
     "SHADOW_ENVELOPE_NOT_APPLIED",

--- a/scripts/run_b0x_cycle.py
+++ b/scripts/run_b0x_cycle.py
@@ -36,7 +36,7 @@ from scripts.b0x.cycle import (
     run_shadow_cycle,
     run_sidecar_cycle,
 )
-from scripts.b0x.envelope import load_envelope
+from scripts.b0x.envelope import CRYPTO_SHADOW_MARKET_KEY, load_envelope
 from scripts.b0x.ledger import DEFAULT_OBSERVATION_DIR, WriterLockUnavailable
 from scripts.b0x.table_source import DEFAULT_TABLE_DIR
 
@@ -84,7 +84,12 @@ async def _derivation_only(args: argparse.Namespace) -> int:
     from scripts.b0x.table_source import TableUnavailable, load_policy_table
 
     now = _dt.datetime.now(_dt.UTC) if args.now is None else args.now
-    envelope = load_envelope(MARKET)
+    # SHADOW-ALIGN: this path always runs the shadow lane's pure derivation
+    # (see the docstring above), so it must load the shadow lane's own
+    # KRW-denominated envelope — matching ``run_shadow_cycle`` in
+    # ``scripts.b0x.cycle`` — not the USDT sidecar envelope ``MARKET``
+    # ("crypto") resolves to. ``MARKET`` itself stays the policy-table key.
+    envelope = load_envelope(CRYPTO_SHADOW_MARKET_KEY)
     table = load_policy_table(
         market=MARKET, now=now, table_dir=Path(args.table_dir).expanduser()
     )

--- a/tests/scripts/b0x/test_cycle.py
+++ b/tests/scripts/b0x/test_cycle.py
@@ -16,7 +16,7 @@ from scripts.b0x.cycle import (
     run_shadow_cycle,
     run_sidecar_cycle,
 )
-from scripts.b0x.envelope import CRYPTO_SIDECAR_ENVELOPE
+from scripts.b0x.envelope import CRYPTO_SHADOW_ENVELOPE, CRYPTO_SIDECAR_ENVELOPE
 from scripts.b0x.labels import (
     SHADOW_SYNTHETIC_FILL,
     SHARED_ACCOUNT_HISTORY,
@@ -73,20 +73,16 @@ def _no_real_candles(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def _shadow_currency_aligned(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make ``shadow.account_state()`` report the same currency as the (shared,
-    crypto-market) envelope it is evaluated against.
+def _shadow_currency_misaligned_mutant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reintroduce the pre-SHADOW-ALIGN defect on purpose (mutant ①).
 
-    Production wiring does *not* do this: the shadow lane's book is
-    genuinely KRW-denominated (Upbit) while ``CRYPTO_SIDECAR_ENVELOPE`` is
-    USDT — ``run_shadow_cycle`` now fails that comparison closed (see
-    ``test_shadow_cycle_blocked_by_kill_switch_currency_mismatch`` below,
-    which exercises the *real*, unpatched wiring). This fixture exists only
-    to decouple tests of unrelated shadow-cycle behaviour (order derivation,
-    idempotency, artifact structure) from that separate, tracked defect, the
-    same way the underlying determinism/sizing logic is independently
-    covered in ``tests/scripts/b0x/test_derivation.py`` without going
-    through ``run_shadow_cycle`` at all.
+    Production wiring (``run_shadow_cycle`` loading
+    ``envelope.CRYPTO_SHADOW_ENVELOPE``, ``quote_currency="KRW"``) does not
+    do this any more. This fixture exists only for
+    ``test_shadow_cycle_currency_mismatch_backstop_still_cancels_a_resting_book``
+    below, which proves the ``CurrencyMismatchKill`` fail-closed backstop
+    (#1822/ROB-1233) still fires — and still cancels a resting book — if a
+    future edit ever hands this lane a mismatched envelope again.
     """
 
     monkeypatch.setattr(
@@ -100,7 +96,6 @@ def _shadow_currency_aligned(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_first_shadow_cycle_derives_and_records(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -127,7 +122,6 @@ async def test_first_shadow_cycle_derives_and_records(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_shadow_cycle_is_idempotent_in_its_derivation(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -167,7 +161,6 @@ async def test_shadow_cycle_is_idempotent_in_its_derivation(
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_stale_table_yields_zero_orders_and_cancels_the_book(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -200,7 +193,6 @@ async def test_missing_table_yields_zero_orders(tmp_path: Path, out_dir: Path) -
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_shadow_currency_aligned")
 async def test_shadow_lane_uses_b0_sizing_not_the_usdt_envelope(
     table_dir: Path, out_dir: Path
 ) -> None:
@@ -212,55 +204,73 @@ async def test_shadow_lane_uses_b0_sizing_not_the_usdt_envelope(
 
 
 @pytest.mark.asyncio
-async def test_shadow_cycle_blocked_by_kill_switch_currency_mismatch(
+async def test_shadow_cycle_is_currency_aligned_by_default_after_shadow_align(
     table_dir: Path, out_dir: Path
 ) -> None:
-    """The real, unpatched wiring: shadow's book is KRW, the shared crypto
-    envelope's kill threshold is USDT. ``kill_switch.evaluate`` fails that
-    comparison closed, and the cycle must not crash uncontrolled — it records
-    a zero-order cycle with a specific, auditable reason, exactly like an
-    unusable policy table.
+    """SHADOW-ALIGN regression: the real, unpatched wiring used to hit
+    ``kill_switch_currency_mismatch`` on *every* shadow cycle (shadow's book
+    is KRW, the shared crypto sidecar envelope's kill threshold was USDT —
+    see ``test_shadow_cycle_currency_mismatch_backstop_still_cancels_a_resting_book``
+    below for proof the fail-closed guard itself still works). ``run_shadow_cycle``
+    now loads ``envelope.CRYPTO_SHADOW_ENVELOPE`` (KRW), which matches
+    ``shadow.QUOTE_CURRENCY`` — so a normal cycle must derive orders, not zero
+    out on a currency reason.
     """
 
     outcome = await run_shadow_cycle(now=NOW, table_dir=table_dir, out_dir=out_dir)
 
-    assert outcome.zero_order_reason == SHADOW_KILL_CURRENCY_MISMATCH_REASON
-    assert outcome.order_count == 0
-    assert outcome.record["orders"] == []
-    assert "KRW" in outcome.record["zero_order_detail"]
-    assert "USDT" in outcome.record["zero_order_detail"]
-    assert outcome.artifact_path is not None and outcome.artifact_path.exists()
+    assert outcome.zero_order_reason is None
+    assert outcome.zero_order_reason != SHADOW_KILL_CURRENCY_MISMATCH_REASON
+    assert outcome.order_count == 2
+    assert outcome.record["orders"] != []
+
+    kill_switch = outcome.record["kill_switch"]
+    assert kill_switch["state_quote_currency"] == "KRW"
+    assert kill_switch["envelope_quote_currency"] == "KRW"
+    assert kill_switch["allow_new_orders"] is True
+
+    assert outcome.record["envelope"]["market"] == CRYPTO_SHADOW_ENVELOPE.market
+    assert outcome.record["envelope"]["quote_currency"] == "KRW"
 
     portfolio_path = (
         ObservationLedger(lane=shadow.LANE, root=out_dir).lane_dir / "portfolio.json"
     )
-    assert json.loads(portfolio_path.read_text())["open_orders"] == []
+    assert json.loads(portfolio_path.read_text())["open_orders"]
 
 
 @pytest.mark.asyncio
-async def test_shadow_cycle_currency_mismatch_cancels_a_resting_book(
+@pytest.mark.usefixtures("_shadow_currency_misaligned_mutant")
+async def test_shadow_cycle_currency_mismatch_backstop_still_cancels_a_resting_book(
     table_dir: Path, out_dir: Path
 ) -> None:
-    """A resting virtual book from a currency-aligned cycle must still be
-    cancelled — not silently carried forward — once the mismatch is hit.
+    """Mutant ① made permanent: if a future edit ever hands this lane a
+    mismatched envelope again (here simulated by patching
+    ``shadow.QUOTE_CURRENCY`` back to USDT, reproducing the pre-SHADOW-ALIGN
+    wiring), ``CurrencyMismatchKill`` (#1822/ROB-1233) must still fire, the
+    cycle must still degrade to a recorded zero-order cycle rather than
+    crash or silently miscompare, and a resting virtual book from an earlier,
+    genuinely-aligned cycle must still be cancelled rather than carried
+    forward.
     """
 
     portfolio_path = (
         ObservationLedger(lane=shadow.LANE, root=out_dir).lane_dir / "portfolio.json"
     )
     with pytest.MonkeyPatch.context() as aligned:
-        aligned.setattr(
-            shadow, "QUOTE_CURRENCY", CRYPTO_SIDECAR_ENVELOPE.quote_currency
-        )
+        aligned.setattr(shadow, "QUOTE_CURRENCY", CRYPTO_SHADOW_ENVELOPE.quote_currency)
         seeded = await run_shadow_cycle(now=NOW, table_dir=table_dir, out_dir=out_dir)
     assert seeded.order_count == 2
     assert json.loads(portfolio_path.read_text())["open_orders"]
 
+    # Fixture is active again here (outside the aligned context) — back to
+    # the mismatched wiring for this second cycle.
     outcome = await run_shadow_cycle(
         now=NOW + dt.timedelta(minutes=1), table_dir=table_dir, out_dir=out_dir
     )
 
     assert outcome.zero_order_reason == SHADOW_KILL_CURRENCY_MISMATCH_REASON
+    assert "KRW" in outcome.record["zero_order_detail"]
+    assert "USDT" in outcome.record["zero_order_detail"]
     assert outcome.record["cancelled_stale_orders"] == 2
     assert json.loads(portfolio_path.read_text())["open_orders"] == []
 

--- a/tests/scripts/b0x/test_envelope_and_locks.py
+++ b/tests/scripts/b0x/test_envelope_and_locks.py
@@ -12,6 +12,9 @@ from pathlib import Path
 import pytest
 
 from scripts.b0x.envelope import (
+    CRYPTO_SHADOW_ENVELOPE,
+    CRYPTO_SHADOW_FX_KRW_PER_USDT,
+    CRYPTO_SHADOW_MARKET_KEY,
     CRYPTO_SIDECAR_ENVELOPE,
     EnvelopeNotLocked,
     assert_envelope_locked,
@@ -33,6 +36,193 @@ def test_crypto_envelope_matches_contract_section_4() -> None:
     assert envelope.max_concurrent_positions == 3
     assert envelope.max_new_entries_per_utc_day == 2
     assert envelope.daily_loss_kill == Decimal("5")
+
+
+# ---------------------------------------------------------------------------
+# crypto 본선 (shadow) envelope — SHADOW-ALIGN
+# ---------------------------------------------------------------------------
+
+
+def test_crypto_shadow_envelope_is_krw_denominated_and_distinct_from_the_sidecar() -> (
+    None
+):
+    """Lane separation (mutant ③): the shadow lane gets its own market key
+    and currency, and the sidecar's USDT envelope is completely untouched.
+    """
+
+    assert CRYPTO_SHADOW_ENVELOPE.quote_currency == "KRW"
+    assert CRYPTO_SHADOW_ENVELOPE.market == CRYPTO_SHADOW_MARKET_KEY
+    assert CRYPTO_SHADOW_ENVELOPE.market != CRYPTO_SIDECAR_ENVELOPE.market
+
+    # The sidecar column is unaffected by the shadow lane gaining its own.
+    assert CRYPTO_SIDECAR_ENVELOPE.quote_currency == "USDT"
+    assert CRYPTO_SIDECAR_ENVELOPE.market == "crypto"
+    assert load_envelope("crypto") == CRYPTO_SIDECAR_ENVELOPE
+    assert load_envelope(CRYPTO_SHADOW_MARKET_KEY) == CRYPTO_SHADOW_ENVELOPE
+
+
+def test_crypto_shadow_envelope_matches_the_documented_krw_literals() -> None:
+    """Fixed literals: 10/50/5 USDT x 1400 KRW/USDT = 14000/70000/7000 KRW.
+    Position/entry counts are unit-less and carry over unconverted.
+    """
+
+    assert CRYPTO_SHADOW_FX_KRW_PER_USDT == Decimal("1400")
+    assert CRYPTO_SHADOW_ENVELOPE.per_order_notional == Decimal("14000")
+    assert CRYPTO_SHADOW_ENVELOPE.per_symbol_total_notional == Decimal("70000")
+    assert CRYPTO_SHADOW_ENVELOPE.daily_loss_kill == Decimal("7000")
+    assert (
+        CRYPTO_SHADOW_ENVELOPE.max_concurrent_positions
+        == CRYPTO_SIDECAR_ENVELOPE.max_concurrent_positions
+    )
+    assert (
+        CRYPTO_SHADOW_ENVELOPE.max_new_entries_per_utc_day
+        == CRYPTO_SIDECAR_ENVELOPE.max_new_entries_per_utc_day
+    )
+    assert CRYPTO_SHADOW_ENVELOPE.daily_loss_kill_basis == "absolute"
+
+
+def test_crypto_shadow_envelope_cap_meaning_is_not_widened() -> None:
+    """CAP_MEANING_PRESERVED: converting every currency-denominated field back
+    to USDT at the real, observed rate this literal was floored from
+    (1420.84 KRW/USD, 2026-08-10T19:13:23Z, source=toss, USDT~=USD) must land
+    at-or-below the original sidecar figure it replaces — never above. A
+    fixed conservative (understating) rate is what makes this an invariant
+    of the literals themselves, not a property that depends on where the
+    market rate wanders after the fact.
+    """
+
+    observed_rate = Decimal("1420.84")
+    assert CRYPTO_SHADOW_FX_KRW_PER_USDT < observed_rate
+
+    pairs = (
+        (
+            CRYPTO_SHADOW_ENVELOPE.daily_loss_kill,
+            CRYPTO_SIDECAR_ENVELOPE.daily_loss_kill,
+        ),
+        (
+            CRYPTO_SHADOW_ENVELOPE.per_order_notional,
+            CRYPTO_SIDECAR_ENVELOPE.per_order_notional,
+        ),
+        (
+            CRYPTO_SHADOW_ENVELOPE.per_symbol_total_notional,
+            CRYPTO_SIDECAR_ENVELOPE.per_symbol_total_notional,
+        ),
+    )
+    for krw_value, usdt_original in pairs:
+        usdt_equivalent_at_observed_rate = krw_value / observed_rate
+        assert usdt_equivalent_at_observed_rate <= usdt_original, (
+            f"{krw_value} KRW converts back to "
+            f"{usdt_equivalent_at_observed_rate} USDT at the observed rate, "
+            f"which exceeds the original {usdt_original} USDT cap — widened"
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("per_order_notional", Decimal("14001")),
+        ("per_symbol_total_notional", Decimal("700000")),
+        ("max_concurrent_positions", 4),
+        ("max_new_entries_per_utc_day", 3),
+        ("daily_loss_kill", Decimal("7001")),
+    ],
+)
+def test_widened_shadow_envelope_fails_closed(field: str, value: object) -> None:
+    """Mutant ② made permanent: any single-field widening of the shadow
+    envelope — including the tiniest possible increase to
+    ``daily_loss_kill`` — must be rejected by the same lock every other
+    market envelope is held to.
+    """
+
+    widened = replace(CRYPTO_SHADOW_ENVELOPE, **{field: value})
+    assert widened != CRYPTO_SHADOW_ENVELOPE
+    with pytest.raises(EnvelopeNotLocked):
+        assert_envelope_locked(widened)
+
+
+def test_envelope_module_has_no_runtime_fx_dependency() -> None:
+    """Mutant ④ made permanent: the shadow envelope's KRW figures must be
+    literal Decimal arithmetic evaluated once at import time — not a call to
+    any FX/network/env source. Extends the existing no-environment AST guard
+    with network- and FX-shaped names specific to this literal's derivation.
+    """
+
+    import scripts.b0x.envelope as envelope_module
+
+    tree = ast.parse(Path(envelope_module.__file__).read_text(encoding="utf-8"))
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    forbidden_imports = {"httpx", "requests", "aiohttp", "asyncio"}
+    assert not forbidden_imports & imported, (
+        f"envelope module must not import network/async machinery: "
+        f"{forbidden_imports & imported}"
+    )
+
+    forbidden_names = {
+        "get_fx_rate",
+        "fetch_ohlcv",
+        "exchange_rate",
+        "ExchangeRateService",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            assert node.id not in forbidden_names, (
+                f"envelope module references a live FX lookup: {node.id}"
+            )
+        if isinstance(node, ast.Attribute):
+            assert node.attr not in forbidden_names, (
+                f"envelope module references a live FX lookup: {node.attr}"
+            )
+
+    # The rate assignment's RHS must be exactly ``Decimal("<literal>")`` — a
+    # call to *any other* name (a helper function, a service client, an
+    # os.environ-backed wrapper) is what "computed at runtime" looks like in
+    # the AST, regardless of what it is named. This is deliberately shape-
+    # based rather than name-based, so it cannot be dodged by picking an
+    # innocuous-sounding helper name.
+    assign_values = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name)
+            and target.id == "CRYPTO_SHADOW_FX_KRW_PER_USDT"
+            for target in node.targets
+        )
+    ] + [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "CRYPTO_SHADOW_FX_KRW_PER_USDT"
+        and node.value is not None
+    ]
+    assert len(assign_values) == 1, (
+        "expected exactly one module-level assignment to "
+        f"CRYPTO_SHADOW_FX_KRW_PER_USDT, found {len(assign_values)}"
+    )
+    value_node = assign_values[0]
+    assert isinstance(value_node, ast.Call), (
+        "CRYPTO_SHADOW_FX_KRW_PER_USDT must be assigned directly from a "
+        f"call expression, got {ast.dump(value_node)}"
+    )
+    assert isinstance(value_node.func, ast.Name) and value_node.func.id == "Decimal", (
+        "CRYPTO_SHADOW_FX_KRW_PER_USDT must be assigned via Decimal(...) "
+        f"directly, not {ast.dump(value_node.func)}"
+    )
+    assert len(value_node.args) == 1 and isinstance(value_node.args[0], ast.Constant), (
+        "Decimal(...) must be called with a single literal constant argument, "
+        f"got {[ast.dump(a) for a in value_node.args]}"
+    )
+
+    # And the runtime value matches — the rate is a bare Decimal literal, not
+    # the output of a function call.
+    assert isinstance(CRYPTO_SHADOW_FX_KRW_PER_USDT, Decimal)
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/b0x/test_kill_switch_and_touch_rule.py
+++ b/tests/scripts/b0x/test_kill_switch_and_touch_rule.py
@@ -227,6 +227,31 @@ def test_matching_currency_decision_records_both_sides_for_audit() -> None:
     assert canonical["envelope_quote_currency"] == "USDT"
 
 
+def test_shadow_krw_state_against_the_shadow_envelope_passes_unaffected() -> None:
+    """SHADOW-ALIGN NO_REGRESSION: shadow's KRW state, evaluated against its
+    own ``CRYPTO_SHADOW_ENVELOPE`` (also KRW), must clear the currency check
+    cleanly — this is exactly the comparison that used to raise
+    ``CurrencyMismatchKill`` against the shared USDT sidecar envelope.
+    """
+
+    from scripts.b0x.envelope import CRYPTO_SHADOW_ENVELOPE
+
+    assert CRYPTO_SHADOW_ENVELOPE.quote_currency == "KRW"
+    shadow_state = _state(quote_currency="KRW", realized_pnl_today=Decimal("-1"))
+    decision = kill_switch_module.evaluate(
+        state=shadow_state, envelope=CRYPTO_SHADOW_ENVELOPE
+    )
+    assert decision.allow_new_orders is True
+    assert decision.state_quote_currency == "KRW"
+    assert decision.envelope_quote_currency == "KRW"
+
+    at_limit = kill_switch_module.evaluate(
+        state=_state(quote_currency="KRW", realized_pnl_today=Decimal("-7000")),
+        envelope=CRYPTO_SHADOW_ENVELOPE,
+    )
+    assert at_limit.tripped
+
+
 def test_crypto_sidecar_and_kr_currency_checks_pass_unaffected() -> None:
     """NO_REGRESSION — crypto sidecar (USDT/USDT) and KR (pct_of_nav, KRW/KRW)
     both already have matching currencies; the new check must be a no-op for


### PR DESCRIPTION
## Summary
- 🔴 Zero orders · zero account mutation · zero permanent env changes · zero live contact.
- #1822's `CurrencyMismatchKill` fails closed correctly, but the shadow lane's KRW account state was still evaluated against the sidecar's USDT envelope, so **every** real shadow cycle hit `kill_switch_currency_mismatch` (confirmed 2026-08-10T19:02Z, artifact `20260810T190200Z-cycle.md`). `scripts/run_b0x_cycle.py --derivation-only` had it worse: an **uncaught** `CurrencyMismatchKill` crash.
- Adds `envelope.CRYPTO_SHADOW_ENVELOPE` (`market="crypto_shadow"`, `quote_currency="KRW"`) and wires it into `run_shadow_cycle` and the CLI's `--derivation-only` path. The sidecar cycle (`market="crypto"`, USDT) is untouched — lane separation preserved.
- Contract §4 has no numeric literal for the Upbit shadow ("본선") column — only the footnote "envelope 미적용(기록만)". The KRW figures are a documented conversion of the sidecar's USDT literal at a **fixed, conservative** rate (1400 KRW/USDT, floored below the observed 1420.84 mid-rate on 2026-08-10T19:13:23Z, source=toss) so no field's USDT-equivalent ever widens past the original sidecar cap.
- `CurrencyMismatchKill` itself is untouched and still guards — if this lane is ever handed a mismatched envelope again, it still fails closed (verified via live mutation testing, see below).

## Verification
- 4 required mutants injected into source, confirmed RED, then reverted (not committed):
  1. Revive `state=KRW` vs `envelope=USDT` → 5 tests fail (`CurrencyMismatchKill` still guards).
  2. Widen `daily_loss_kill` (×2) → 2 tests fail (literal + cap-not-widened checks).
  3. Cross-contaminate the sidecar cycle with the shadow/KRW envelope → 4 sidecar tests fail with an uncaught `CurrencyMismatchKill` (lane separation).
  4. Compute the FX rate via a function call instead of a bare `Decimal(...)` literal → AST-shape guard fails (name-agnostic, can't be dodged by renaming the helper).
- Real shadow cycle run against the actual production ledger (`~/work/herdr-artifacts/b0x/upbit_shadow/`) and policy table: `kill_switch_tripped=False`, 34 orders derived, `zero_order_reason=None`, `real_orders=0`, `live_contact=0`, kill switch shows `KRW`/`KRW` on both sides. Artifact: `20260810T192238Z-cycle.md`.
- `--derivation-only` path also verified clean (`DERIVATION_DETERMINISM=IDENTICAL`), and separately proven to have crashed uncaught before the fix.

## Test plan
- [x] `uv run pytest tests/scripts/b0x/ -q -m unit` — 469 passed
- [x] `uv run pytest tests/scripts/ -q -m unit` — 546 passed (no regressions elsewhere)
- [x] `uv run ruff check` / `uv run ruff format --check` on touched files — clean
- [x] `uv run ty check` on touched files — 1 pre-existing, unrelated warning only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected crypto shadow-market evaluation to use a KRW-denominated envelope.
  * Preserved fail-closed behavior when currencies do not match.
  * Ensured policy and record market identification remains consistent.
  * Maintained existing sidecar envelope behavior.

* **Tests**
  * Added coverage for KRW envelope limits, identity, and conservative conversions.
  * Added regression checks for successful KRW evaluation and kill-switch activation.
  * Verified widened or mismatched configurations are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->