### PR TITLE
fix(b0x): KR preflight flat 요구 → 자기 원장(fill) 귀속 게이트 (§36차 2항)

### DIFF
--- a/docs/runbooks/b0x-kr-cycle.md
+++ b/docs/runbooks/b0x-kr-cycle.md
@@ -415,11 +415,55 @@ pending 파생 이름이 들어가는 것을 빌드 실패로 만든다.
 게이트를 탄다), 그 안에서 `assert_resubmit_allowed` 가 제출보다 **앞줄**임을 확인한다.
 
 **귀결 — 첫 clean confirm.** 이 레인은 원장이 자기 `b0xk-` 행 0건을 읽고, 다른
-correlation trace·예상 밖 보유가 없고, writer lease가 확보될 때만 한 제출을 시도한다. 같은
+correlation trace가 없고, **legacy/자기 보유를 귀속으로 가를 수 있고**(§9.3), writer lease가
+확보될 때만 한 제출을 시도한다. 같은
 KST일에 자기 trace가 남으면 다음 confirm preflight는 `ledger_pending_present`로 zero-order다.
 `test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice`는 v1.6 KST-day dedup을,
 `test_confirm_route_rechecks_and_observes_post_submit_dedup`은 제출 직전/직후의 실제
 mutation-boundary 순서를 오프라인으로 고정한다.
+
+### 9.3 🔴 legacy 보유와의 공존 — 자기 원장(fill) 귀속 게이트 (§36차 2항, 2026-08-11)
+
+이 계좌에는 **B0-X 가 만들지 않은 legacy 보유 11종목**이 있다(2026-08-11 실측: 계좌 non-dust
+보유 11 · `b0xk-` 원장 행 **0**). 종전 confirm preflight 는 「보유가 하나라도 있으면
+`unexpected_positions`」였으므로 두 가지가 동시에 참이었다:
+
+1. 이 계좌에서는 **영구히** 한 건도 제출할 수 없다(2026-08-11 04:30 job 이 실측한 정지 사유).
+2. 계약 v1.5 ③(「B0-X 물타기/매도 = 자기 보유에서만 파생」)과 **모순**이다 — 매도가 파생되려면
+   보유가 있어야 하는데, 보유가 있으면 preflight 가 막는다.
+
+운영자 결정(§36차 2항)은 **flatten 기각 · 귀속 기반 공존**이다. 임의 청산은 여전히 금지이며,
+대신 `scripts/b0x/kr/attribution.py` 가 **자기 원장 fill 로 own/legacy 를 가른다**.
+
+**증거 규칙 (비대칭이 요점이다).** 과소 귀속 = 매도 못 함 = 안전. 과대 귀속 = **legacy 매도 =
+남의 포지션 처분**. 그래서:
+
+| 방향 | 증거 기준 | 오차 방향 |
+|---|---|---|
+| 매수(귀속 +) | `lifecycle_state ∈ {fill, reconciled}` 인 자기 `b0xk-` 행만 | 과소(안전) |
+| 매도(귀속 −) | 자기 `b0xk-` sell 행 **전부**(상태 무관) | 과소(안전) |
+| 상한 | 귀속 수량 ≤ **브로커 보유 수량** | 계좌에 없는 주식은 우리 것이 아니다 |
+
+**legacy 는 무엇에 들어가고 무엇에서 빠지는가** (§36차 2항이 판정을 위임한 항목):
+
+| 항목 | legacy 포함? | 근거 |
+|---|---|---|
+| 매도·물타기 파생 | ❌ 제외 | §36차 2항 리터럴. legacy 는 후보로 올라오지 않는다 |
+| §4 동시포지션 / 일일신규 상한 | ❌ 제외(자기 귀속만 계수) | 11 ≥ cap 10 이라 포함하면 신규 진입이 **영구 0** — 공존 결정이 무의미해진다. 🔴 대가 = 계좌는 legacy + 최대 10 B0-X 를 함께 지닐 수 있다. §4 **수치는 무변경** |
+| NAV(= kill 임계 기준) | ❌ 제외(지분 비례) | kill 이 `pct_of_nav` 이므로 legacy 평가액을 넣으면 발화 손실 절대액이 **커진다**. 넓히지 않는 방향을 택했다. 귀속 불가면 `nav = cash` 로 더 좁아진다 |
+| 계좌 진실·아티팩트 기록 | ✅ 포함 | `positions.legacy_symbols` 로 **이름까지** 남는다. 「무시」는 「삭제」가 아니다 |
+| CONTAMINATED 판정 | — 무변경 | 오염은 **다른 writer**(비-`b0xk` correlation trace)이며, 승인된 공존 보유는 다른 writer 가 아니다 |
+
+**두 겹의 매도 방어.** ① 파생: legacy 는 `LaneAccountState.positions` 에 없으므로 매도 레그가
+만들어지지 않는다. ② 제출 경계: `attribution.assert_sell_is_own` 이 자기 귀속 수량을 넘는
+매도를 `LegacyPositionSellBlocked` 로 죽인다. 같은 심볼을 legacy 와 공유해도 **자기 수량까지만**
+팔 수 있다.
+
+**fail-closed.** 귀속 조회가 실패하면 「자기 것 없음」이 아니라 「알 수 없음」이다: 자기 포지션 0
+(매도/물타기 0) **그리고** §4 상한 입력이 계좌 전체로 되돌아가(신규 진입도 0) 양쪽이 닫히며,
+confirm preflight 는 `attribution_unreadable` 로 zero-order 다.
+
+테스트: `tests/scripts/b0x/kr/test_attribution_gate.py` (필수 mutant ①~⑤ 각각 격추 확인).
 
 ## 10. 알려진 경계 · fail-closed 처리
 
@@ -427,8 +471,10 @@ mutation-boundary 순서를 오프라인으로 고정한다.
   구조적으로 raise하므로 native open-order=0이라고 주장하지 않는다. NW-B4 record에는 이
   사실과 함께 v1.6 signal/order ledger shadow를 분리해 남긴다. shadow가 unreadable이거나
   foreign correlation trace가 하나라도 있으면 `preflight_not_clean` zero-order다.
-- **예상 밖 포지션·cash 비정상·stale table·writer lease 불명확도 zero-order다.** 취소·청산·계좌
-  reset 같은 임의 정리는 하지 않는다.
+- **cash 비정상·stale table·writer lease 불명확·귀속 조회 불가는 zero-order다.** 취소·청산·계좌
+  reset 같은 임의 정리는 하지 않는다. 🔴 **보유가 있다는 사실 자체는 더 이상 실패 사유가
+  아니다**(§9.3, §36차 2항) — 실패 사유는 「누구 것인지 모른다」(`attribution_unreadable`)로
+  옮겨갔다.
 - **kill 시 잔여 주문 취소가 구조적으로 불가능하다**(§6.6). 성공 취소나 reconcile을 꾸미지
   않고 `KILL_TRIPPED_CANCEL_UNSUPPORTED`와 false attempted/confirmed를 기록한다.
 - **원장 조회는 DB를 탄다.** own/foreign ledger 중 하나라도 읽을 수 없으면 preflight는
@@ -448,8 +494,15 @@ v1.6 ① 전용 (`tests/scripts/b0x/kr/test_ledger_pending_source.py`): KST day 
 **타입명만**), lifecycle/state 추론 금지, position truth 분리, 타 레인 import 금지, 제출
 chokepoint AST guard, foreign correlation trace contamination, 그리고 confirm의 pre/post
 dedup observation을 고정한다. 각 detector는 합성 소스로 자가검증한다.
-`tests/scripts/b0x/kr/conftest.py`는 실 own/foreign ledger reader 도달을
+`tests/scripts/b0x/kr/conftest.py`는 실 own/foreign ledger reader **및 귀속 reader** 도달을
 **AssertionError**로 막는다.
+
+§36차 2항 전용 (`tests/scripts/b0x/kr/test_attribution_gate.py`): legacy 보유가 매도(①)·
+물타기(②) 후보가 되지 않음, 귀속 없는 보유가 자기 것으로 분류되지 않음(③ — 미체결 매수 불산입·
+미체결 매도 선차감·브로커 보유 상한·control 행 배제·미배선 호출자 fail-closed), preflight 의
+flat 요구 회귀 금지(④)와 그럼에도 `attribution_unreadable`·CONTAMINATED 는 여전히 fail-closed,
+v1.6 dedup 우회 금지(⑤), NAV 기준이 kill 임계를 넓히지 않음, 그리고 **자기 귀속 포지션은 실제로
+매도 사다리를 파생한다**(v1.5 ③ 가 처음으로 도달 가능해졌다는 증명)를 고정한다.
 
 kr 전용 포함: tick 정렬(KRX 2023+ 표와 일치) · 매수/매도 사이징 whole-share floor ·
 NAV = cash + Σ evlu_amt · RTH 게이트(세션 밖 → zero-order, 표 I/O 전혀 없음) · 표 게이트

--- a/scripts/b0x/kr/attribution.py
+++ b/scripts/b0x/kr/attribution.py
@@ -1,0 +1,510 @@
+"""KR 자기 원장(fill) 귀속 — legacy 보유와 B0-X 보유를 가르는 단 하나의 경계.
+
+왜 이 모듈이 생겼는가 (§36차 2항)
+-----------------------------------
+
+``kis_mock`` 계좌에는 B0-X 가 만들지 않은 **legacy 보유 11종목**이 있다
+(2026-08-11 실측: ``b0xk-`` 원장 행 total 0 인데 non-dust 보유 11). X-E2 까지의
+confirm preflight 는 「보유가 하나라도 있으면 이상」(``unexpected_positions``)
+이었으므로 이 계좌에서는 **영구히** 한 건도 제출할 수 없었고, 동시에 계약 v1.5 ③
+(「B0-X 물타기/매도 = 자기(mock) 보유에서만 파생」)과도 충돌했다 — 보유가 있어야
+매도가 파생되는데 보유가 있으면 preflight 가 막았다.
+
+운영자 결정(§36차 2항)은 flatten **기각**, **귀속 기반 공존**이다:
+
+    B0-X KR 의 매도/물타기 파생 = 자기 원장(fill) 귀속 포지션 한정
+    legacy 11종 = 불가침 무시 — 관측 전용 공존 레인 소유
+    preflight 의 flat 요구를 귀속 게이트로 교체
+    근거 선례 = US lane correlation 분리 귀속 · 계약 v1.5 ③ 정합
+
+선례는 US 랩(``scripts/b0x/us/alpaca.py::_attribute_positions``)이다: 브로커
+포지션을 **자기 correlation 이 붙은 실행 증거**와 대조해 own/foreign 으로 가른
+뒤, ``LaneAccountState.positions`` 에는 own 만 넣는다. KR 은 브로커가 체결이력을
+주지 않으므로(아래) 증거 원천이 원장이라는 점만 다르다.
+
+증거 원천 — 왜 원장이고, 왜 이것이 v1.6 ① 의 확대가 아닌가
+--------------------------------------------------------------
+
+``review.kis_mock_order_ledger`` (+ pre-submit ``kis_mock_signal_ledger``)는
+v1.6 ① 이 이미 이름을 붙인, **제출 chokepoint 가 매번 강제로 쓰는** 원장이다.
+v1.6 ② 의 「포지션 진실은 계속 브로커 조회」는 그대로다: 이 모듈은 **포지션을
+만들지 않는다**. 브로커가 보고한 보유 수량이 여전히 유일한 포지션 진실이고,
+원장은 그 수량 중 **얼마가 우리 것인가**만 답한다(귀속). 브로커가 보고하지 않은
+심볼은 원장에 무슨 행이 있든 포지션이 되지 않는다.
+
+오차 방향 — 비대칭이며, 비대칭이 요점이다
+--------------------------------------------
+
+🔴 과소 귀속(우리 것을 남의 것으로 봄) = 매도 못 함 = 안전.
+🔴 과대 귀속(남의 것을 우리 것으로 봄) = **legacy 매도** = 남의 포지션 처분.
+
+그래서 매수·매도 쪽 증거 기준을 **일부러 다르게** 둔다:
+
+* **매수(귀속 +)** 는 **체결 증거**가 있는 행만 센다
+  (``lifecycle_state ∈ {fill, reconciled}``). ``accepted``/``pending`` 는
+  체결 증거가 아니므로 세지 않는다 → 우리 수량을 **과소**하게 만든다.
+* **매도(귀속 −)** 는 **자기 correlation 의 모든 sell 행**을 뺀다(상태 무관).
+  체결 여부를 따져 빼기를 미루면, 이미 팔아치운 수량이 우리 것으로 남아 있다가
+  **legacy 주식을 대상으로 한 매도**로 이어질 수 있다 — 이 모듈이 존재하는
+  이유와 정면으로 반대되는 방향이다.
+
+두 규칙 모두 계약 v1.6 ③ 이 명시한 「오차 방향 = 과잉 차단, 관대한 방향(누락)은
+위반」과 같은 방향이다. 마지막으로 귀속 수량은 **브로커 보유 수량으로 상한**을
+둔다: 원장이 뭐라 하든 계좌에 없는 주식은 우리 것이 아니다.
+
+읽기 실패 = 「귀속 없음」이 아니라 「알 수 없음」
+------------------------------------------------
+
+DB 장애·스키마 드리프트 등 어떤 실패든 :class:`AttributionUnreadable` 을
+돌려준다. 소비자(``scripts.b0x.kr.cycle``)는 그 상태에서
+
+* 자기 포지션 = 없음 → 매도/물타기 파생 0, 그리고
+* §4 동시포지션 상한 입력 = **계좌 전체**(= 보수적, 신규 진입도 막힘), 그리고
+* confirm preflight = ``attribution_unreadable`` zero-order
+
+로 **양쪽 다 닫는다**. 「조회 불가」가 「legacy 없음」으로도 「자기 것 없음」으로도
+읽히지 않게 하는 것이 tri-state 를 유지하는 이유다(v1.6 ④ 와 같은 자세).
+
+이 모듈은 DB 를 **읽기만** 한다. 쓰기 경로도, 브로커/네트워크 경로도 없다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Final, Protocol
+
+from sqlalchemy import select
+
+from app.core.db import AsyncSessionLocal
+from app.models.review import KISMockOrderLedger
+from scripts.b0x.state import B0XPosition
+
+#: ``account_mode`` both kis_mock ledgers pin with a CHECK constraint.
+ACCOUNT_MODE: Final[str] = "kis_mock"
+
+#: 🔴 매수 귀속(+)으로 셀 수 있는 lifecycle 상태 — **체결 증거가 있는 것만**.
+#: ``app.services.brokers.kis.mock_scalping_exec.adapters.KisMockLedgerWriter``
+#: 가 진입 체결을 ``fill``, 청산 확정을 ``reconciled`` 로 쓴다(인용만; 이 패키지
+#: 의 AST 가드 allowlist 를 넓히지 않으려고 import 하지 않는다).
+#: ``accepted``/``pending``/``submitted`` 는 「나갔다」일 뿐 「받았다」가 아니다.
+OWN_FILL_EVIDENCE_STATES: Final[frozenset[str]] = frozenset({"fill", "reconciled"})
+
+#: ROB-843 P2 control/reservation 행 — 거래가 아니다. ``ledger_state.
+#: real_order_filter`` 의 술어를 **인용해 그대로** 적어 둔다(같은 이유로 import
+#: 하지 않는다). 이 심볼은 브로커 보유 심볼과 절대 겹치지 않지만, 원장 소비자는
+#: 전부 이 행을 걸러야 한다는 규칙을 이 레인에서도 깨지 않는다.
+CONTROL_SYMBOL: Final[str] = "__ledger_tracking__"
+CONTROL_ROLES: Final[frozenset[str]] = frozenset(
+    {"tracking_degraded", "native_fallback"}
+)
+CONTROL_REASONS: Final[frozenset[str]] = frozenset(
+    {"ledger_tracking_degraded", "ledger_tracking_fallback"}
+)
+
+#: 관측 기록에 남는 출처 문자열 — 「어디서 귀속을 판정했는가」가 아티팩트에서
+#: 보이지 않으면 이 게이트는 검증 불가능한 주장이 된다.
+ATTRIBUTION_SOURCE: Final[str] = (
+    "review.kis_mock_order_ledger (correlation_id LIKE 'b0xk-%'): "
+    "buy=fill|reconciled 체결증거만 가산, sell=상태무관 전량 차감, "
+    "브로커 보유수량 상한 (§36차 2항 귀속 게이트)"
+)
+
+#: ``AttributionUnreadable.reason`` — v1.6 ④ 의 ``PendingUnreadable`` 과 같은
+#: 자세이나 **다른 질문**(미체결이 아니라 귀속)이라 코드가 다르다.
+ATTRIBUTION_UNREADABLE_REASON: Final[str] = "kis_mock_own_fill_attribution_unreadable"
+
+
+class HeldPosition(Protocol):
+    """브로커가 보고한 보유 한 줄 — ``scripts.b0x.kr.mock.RawPosition`` 모양.
+
+    구조적 타이핑으로 받는다: 이 모듈이 ``mock`` 을 import 하면 순환이 되고,
+    무엇보다 이 계산은 브로커 클라이언트 없이 순수하게 검증돼야 한다.
+    """
+
+    @property
+    def symbol(self) -> str: ...
+
+    @property
+    def quantity(self) -> Decimal: ...
+
+    @property
+    def average_price(self) -> Decimal: ...
+
+    @property
+    def evaluation_amount(self) -> Decimal: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AttributionUnreadable:
+    """귀속 원장이 답하지 못했다 — 「귀속 없음」이 아니라 「알 수 없음」."""
+
+    reason: str
+    detail: str
+
+    def canonical(self) -> dict[str, str]:
+        return {"reason": self.reason, "detail": self.detail}
+
+
+@dataclass(frozen=True, slots=True)
+class AttributedLot:
+    """한 심볼에 대해 자기 원장이 증거하는 순수량과 자기 취득단가."""
+
+    symbol: str
+    #: Σ(체결증거 있는 자기 매수) − Σ(자기 매도 전량). 0 미만은 0 으로 바닥.
+    quantity: Decimal
+    #: 위 매수 행들의 수량가중 평균가. 매도로 수량이 줄어도 내리지 않는다
+    #: (원가 개념).
+    average_price: Decimal
+    buy_fill_rows: int
+    sell_rows: int
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "quantity": format(self.quantity, "f"),
+            "buy_fill_rows": self.buy_fill_rows,
+            "sell_rows": self.sell_rows,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class OwnFillAttribution:
+    """원장이 답한 자기 귀속 — 심볼별 순수량. 포지션 자체는 아니다."""
+
+    lots: tuple[AttributedLot, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "lots", tuple(sorted(self.lots, key=lambda lot: lot.symbol))
+        )
+
+    @property
+    def symbols(self) -> tuple[str, ...]:
+        return tuple(lot.symbol for lot in self.lots if lot.quantity > 0)
+
+    def lot(self, symbol: str) -> AttributedLot | None:
+        for lot in self.lots:
+            if lot.symbol == symbol:
+                return lot
+        return None
+
+    def quantity(self, symbol: str) -> Decimal:
+        lot = self.lot(symbol)
+        return Decimal("0") if lot is None else lot.quantity
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "source": ATTRIBUTION_SOURCE,
+            "readable": True,
+            "lots": [lot.canonical() for lot in self.lots],
+        }
+
+
+class LegacyPositionSellBlocked(RuntimeError):
+    """제출 직전에 잡힌, 귀속 없는 수량에 대한 매도 시도.
+
+    🔴 이 예외가 발생한다는 것은 파생/계획 단계 어딘가가 이미 실패했다는 뜻이다.
+    그래도 여기서 다시 본다: legacy 매도는 **남의 포지션 처분**이고, 이 레인에서
+    되돌릴 수 없는 유일한 사고다. 크립토 사이드카가 제출 경계에서 자기 게이트를
+    재검사하는 것과 같은 자세(계약 v1.5 ①, ``assert_resubmit_allowed``).
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ScopedPositions:
+    """브로커 보유를 귀속으로 가른 결과 — 파생이 볼 수 있는 전부."""
+
+    #: 🔴 파생 입력. 자기 귀속 수량만, non-dust 만.
+    own_positions: tuple[B0XPosition, ...]
+    #: 🔴 관측 전용 공존 레인 소유. 어떤 파생 입력에도 들어가지 않는다.
+    legacy_symbols: tuple[str, ...]
+    #: §4 동시포지션/일일신규 상한의 입력 심볼 집합.
+    cap_position_symbols: tuple[str, ...]
+    #: 자기 귀속분 평가금액 합 — NAV 기준(아래 ``nav_basis`` 참고).
+    attributed_evaluation: Decimal
+    #: 귀속 불가 상태(있으면 위 세 값은 전부 fail-closed 쪽으로 채워진다).
+    unreadable: AttributionUnreadable | None
+
+    @property
+    def cap_basis(self) -> str:
+        return (
+            "account_wide_fail_closed"
+            if self.unreadable is not None
+            else "attributed_own_positions"
+        )
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "own_symbols": [pos.symbol for pos in self.own_positions],
+            "own_position_count": len(self.own_positions),
+            "legacy_symbols": list(self.legacy_symbols),
+            "legacy_position_count": len(self.legacy_symbols),
+            "cap_position_symbols": list(self.cap_position_symbols),
+            "cap_basis": self.cap_basis,
+            "unreadable": None
+            if self.unreadable is None
+            else self.unreadable.canonical(),
+        }
+
+
+def attribution_unreadable(cause: str) -> AttributionUnreadable:
+    """읽기 실패 → tri-state. ``cause`` 는 예외 **타입 이름**만 (메시지는 DSN 을
+    실어 나를 수 있고 이 값은 durable 기록에 들어간다)."""
+
+    return AttributionUnreadable(
+        reason=ATTRIBUTION_UNREADABLE_REASON,
+        detail=(
+            f"review.kis_mock_order_ledger 귀속 조회 실패({cause}) — 어떤 보유가 "
+            "자기 것인지 증명할 수 없으므로 자기 포지션 0(매도/물타기 파생 없음) "
+            "+ §4 상한 입력은 계좌 전체(신규 진입도 차단)로 양쪽을 닫는다. "
+            "「조회 불가」를 「legacy 없음」으로도 「자기 것 없음」으로도 읽지 "
+            "않는다 (§36차 2항 · 계약 v1.6 ③④)"
+        ),
+    )
+
+
+def scope_positions(
+    *,
+    positions: tuple[HeldPosition, ...],
+    attribution: OwnFillAttribution | AttributionUnreadable,
+    account_wide_non_dust: tuple[str, ...],
+    min_trade_unit: Decimal,
+) -> ScopedPositions:
+    """브로커 보유 × 자기 원장 귀속 → 파생이 볼 포지션. 순수 함수.
+
+    ``account_wide_non_dust`` 는 브로커 진실(``FreshTruth.
+    non_dust_position_symbols``)이고, ``min_trade_unit`` 은 KRX 1주 — dust 정의를
+    이 모듈이 **다시 만들지 않기 위해** 둘 다 주입받는다(계약 v1.2, dust 재정의
+    금지).
+
+    귀속 불가면 자기 포지션은 비고, §4 상한 입력은 계좌 전체가 된다 — 「모르면
+    아무것도 못 한다」가 되도록 두 방향을 동시에 닫는다.
+    """
+
+    if isinstance(attribution, AttributionUnreadable):
+        return ScopedPositions(
+            own_positions=(),
+            legacy_symbols=tuple(sorted(account_wide_non_dust)),
+            cap_position_symbols=tuple(sorted(account_wide_non_dust)),
+            # 🔴 자기 평가금액을 모르면 0 으로 둔다 — NAV 를 키우는 방향(= kill
+            # 임계를 넓히는 방향)으로 추정하지 않는다.
+            attributed_evaluation=Decimal("0"),
+            unreadable=attribution,
+        )
+
+    own: list[B0XPosition] = []
+    legacy: list[str] = []
+    attributed_evaluation = Decimal("0")
+    non_dust = set(account_wide_non_dust)
+
+    for held in sorted(positions, key=lambda pos: pos.symbol):
+        symbol = held.symbol
+        if symbol not in non_dust:
+            # dust 는 어느 쪽 장부도 아니다 — 매도 불가 잔량.
+            continue
+        # 🔴 브로커 보유 수량이 상한이다. 원장이 더 많다고 말해도 계좌에 없는
+        # 주식은 우리 것이 아니다.
+        owned = min(attribution.quantity(symbol), held.quantity)
+        if owned <= 0 or (owned // min_trade_unit) < 1:
+            legacy.append(symbol)
+            continue
+        lot = attribution.lot(symbol)
+        assert lot is not None  # owned > 0 이면 lot 이 있다
+        own.append(
+            B0XPosition(
+                symbol=symbol,
+                quantity=owned,
+                average_price=lot.average_price,
+                # 🔴 cost basis 이지 누적 투입액이 아니다 — 그래서 이 레인은
+                # ``cumulative_deployment_readable=False`` 를 유지하고 파생은
+                # 기존 포지션에 대한 **추가(물타기)를 계속 거부**한다.
+                invested_notional=owned * lot.average_price,
+                entry_count=0,
+            )
+        )
+        if held.quantity > 0:
+            # 같은 심볼을 legacy 와 공유할 수 있으므로 평가금액도 지분 비례로만
+            # 가져온다. 브로커가 준 평가금액 자체는 손대지 않는다.
+            attributed_evaluation += held.evaluation_amount * (owned / held.quantity)
+
+    own_symbols = tuple(pos.symbol for pos in own)
+    return ScopedPositions(
+        own_positions=tuple(own),
+        legacy_symbols=tuple(sorted(legacy)),
+        cap_position_symbols=own_symbols,
+        attributed_evaluation=attributed_evaluation,
+        unreadable=None,
+    )
+
+
+def assert_sell_is_own(
+    scoped: ScopedPositions, *, symbol: str, quantity: Decimal, lane: str
+) -> None:
+    """제출 직전 재검사 — 이 매도가 자기 귀속 수량 안에 있는가.
+
+    🔴 legacy 종목은 여기서 ``LegacyPositionSellBlocked`` 로 죽는다. 파생이
+    이미 legacy 를 후보에서 뺐더라도(그것이 1차 방어) 이 두 번째 선은 지운다고
+    비용이 들지 않고, 없애면 파생 한 줄의 회귀가 곧바로 남의 주식 매도가 된다.
+    """
+
+    for position in scoped.own_positions:
+        if position.symbol != symbol:
+            continue
+        if quantity <= position.quantity:
+            return
+        raise LegacyPositionSellBlocked(
+            f"lane={lane} symbol={symbol}: 매도 수량 {format(quantity, 'f')} 가 "
+            f"자기 귀속 수량 {format(position.quantity, 'f')} 를 초과한다 — "
+            "초과분은 legacy(공존 레인) 보유다 (§36차 2항)"
+        )
+    raise LegacyPositionSellBlocked(
+        f"lane={lane} symbol={symbol}: 자기 원장 귀속 포지션이 없다 — legacy "
+        "보유에 대한 매도는 남의 포지션 처분이므로 제출 경계에서 차단한다 "
+        "(§36차 2항)"
+    )
+
+
+def _is_control_row(symbol: str, scalping_role: str | None, reason: str | None) -> bool:
+    return (
+        symbol == CONTROL_SYMBOL
+        or (scalping_role or "") in CONTROL_ROLES
+        or (reason or "") in CONTROL_REASONS
+    )
+
+
+async def read_own_attribution(
+    *, correlation_prefix: str
+) -> OwnFillAttribution | AttributionUnreadable:
+    """자기 원장 귀속 수량 — read-only, 계좌 전 기간.
+
+    미체결 리더(``pending_ledger.read_own_pending``)와 달리 **거래일 경계가
+    없다**: 포지션은 거래일을 넘어 남고, 어제 산 주식은 오늘도 우리 것이다.
+    (미체결 쪽은 KRX 일중주문이라는 구조적 이유로 당일 경계를 갖는다 — 같은
+    경계를 여기에 복사하면 어제 산 자기 포지션이 legacy 로 오분류된다.)
+
+    어떤 실패든 :func:`attribution_unreadable` 로 떨어진다. 빈 결과(``lots=()``)
+    는 「원장이 답했고 아무 것도 없다」이며, 실패와 구분된다.
+    """
+
+    prefix = f"{correlation_prefix}%"
+    try:
+        async with AsyncSessionLocal() as db:
+            rows = (
+                await db.execute(
+                    select(
+                        KISMockOrderLedger.symbol,
+                        KISMockOrderLedger.side,
+                        KISMockOrderLedger.quantity,
+                        KISMockOrderLedger.price,
+                        KISMockOrderLedger.lifecycle_state,
+                        KISMockOrderLedger.scalping_role,
+                        KISMockOrderLedger.reason,
+                    ).where(
+                        KISMockOrderLedger.account_mode == ACCOUNT_MODE,
+                        KISMockOrderLedger.correlation_id.like(prefix),
+                    )
+                )
+            ).all()
+    except Exception as exc:  # noqa: BLE001 — 어떤 실패든 「알 수 없음」
+        return attribution_unreadable(type(exc).__name__)
+
+    return build_attribution(rows)
+
+
+def build_attribution(rows: object) -> OwnFillAttribution:
+    """원장 행 → 귀속. 순수 함수(쿼리 결과 모양만 알면 되고 DB 는 모른다).
+
+    행은 ``(symbol, side, quantity, price, lifecycle_state, scalping_role,
+    reason)`` 순서의 시퀀스면 된다.
+    """
+
+    bought: dict[str, Decimal] = {}
+    bought_notional: dict[str, Decimal] = {}
+    sold: dict[str, Decimal] = {}
+    buy_rows: dict[str, int] = {}
+    sell_rows: dict[str, int] = {}
+
+    for row in rows:  # type: ignore[union-attr]
+        symbol_raw, side, quantity_raw, price_raw, state, role, reason = row
+        symbol = str(symbol_raw or "").strip()
+        if not symbol or _is_control_row(symbol, role, reason):
+            continue
+        quantity = _decimal(quantity_raw)
+        if quantity <= 0:
+            continue
+        side_text = str(side or "").strip().lower()
+        if side_text == "sell":
+            # 🔴 상태를 보지 않는다 — 아직 안 채워진 매도까지 미리 뺀다.
+            sold[symbol] = sold.get(symbol, Decimal("0")) + quantity
+            sell_rows[symbol] = sell_rows.get(symbol, 0) + 1
+            continue
+        if side_text != "buy":
+            continue
+        if str(state or "").strip() not in OWN_FILL_EVIDENCE_STATES:
+            # 체결 증거 없는 매수는 아직 우리 수량이 아니다.
+            continue
+        bought[symbol] = bought.get(symbol, Decimal("0")) + quantity
+        bought_notional[symbol] = bought_notional.get(symbol, Decimal("0")) + (
+            quantity * _decimal(price_raw)
+        )
+        buy_rows[symbol] = buy_rows.get(symbol, 0) + 1
+
+    lots: list[AttributedLot] = []
+    for symbol in sorted(set(bought) | set(sold)):
+        gross_bought = bought.get(symbol, Decimal("0"))
+        net = gross_bought - sold.get(symbol, Decimal("0"))
+        if net < 0:
+            net = Decimal("0")
+        average = (
+            (bought_notional.get(symbol, Decimal("0")) / gross_bought)
+            if gross_bought > 0
+            else Decimal("0")
+        )
+        lots.append(
+            AttributedLot(
+                symbol=symbol,
+                quantity=net,
+                average_price=average,
+                buy_fill_rows=buy_rows.get(symbol, 0),
+                sell_rows=sell_rows.get(symbol, 0),
+            )
+        )
+    return OwnFillAttribution(lots=tuple(lots))
+
+
+def _decimal(value: object) -> Decimal:
+    if value is None or value == "":
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except Exception:  # noqa: BLE001 — 해석 불가한 수치는 0 (과소 귀속 방향)
+        return Decimal("0")
+
+
+class AttributionReader(Protocol):
+    """``run_kr_cycle`` 이 귀속을 읽는 seam (테스트 주입점)."""
+
+    async def __call__(
+        self, *, correlation_prefix: str
+    ) -> OwnFillAttribution | AttributionUnreadable: ...
+
+
+__all__ = [
+    "ACCOUNT_MODE",
+    "ATTRIBUTION_SOURCE",
+    "ATTRIBUTION_UNREADABLE_REASON",
+    "OWN_FILL_EVIDENCE_STATES",
+    "AttributedLot",
+    "AttributionReader",
+    "AttributionUnreadable",
+    "HeldPosition",
+    "LegacyPositionSellBlocked",
+    "OwnFillAttribution",
+    "ScopedPositions",
+    "assert_sell_is_own",
+    "attribution_unreadable",
+    "build_attribution",
+    "read_own_attribution",
+    "scope_positions",
+]

--- a/scripts/b0x/kr/attribution.py
+++ b/scripts/b0x/kr/attribution.py
@@ -70,6 +70,7 @@ DB 장애·스키마 드리프트 등 어떤 실패든 :class:`AttributionUnread
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Final, Protocol
@@ -412,7 +413,7 @@ async def read_own_attribution(
     return build_attribution(rows)
 
 
-def build_attribution(rows: object) -> OwnFillAttribution:
+def build_attribution(rows: Iterable[Sequence[Any]]) -> OwnFillAttribution:
     """원장 행 → 귀속. 순수 함수(쿼리 결과 모양만 알면 되고 DB 는 모른다).
 
     행은 ``(symbol, side, quantity, price, lifecycle_state, scalping_role,
@@ -425,7 +426,7 @@ def build_attribution(rows: object) -> OwnFillAttribution:
     buy_rows: dict[str, int] = {}
     sell_rows: dict[str, int] = {}
 
-    for row in rows:  # type: ignore[union-attr]
+    for row in rows:
         symbol_raw, side, quantity_raw, price_raw, state, role, reason = row
         symbol = str(symbol_raw or "").strip()
         if not symbol or _is_control_row(symbol, role, reason):
@@ -441,7 +442,7 @@ def build_attribution(rows: object) -> OwnFillAttribution:
             continue
         if side_text != "buy":
             continue
-        if str(state or "").strip() not in OWN_FILL_EVIDENCE_STATES:
+        if str(state or "").strip().lower() not in OWN_FILL_EVIDENCE_STATES:
             # 체결 증거 없는 매수는 아직 우리 수량이 아니다.
             continue
         bought[symbol] = bought.get(symbol, Decimal("0")) + quantity

--- a/scripts/b0x/kr/cycle.py
+++ b/scripts/b0x/kr/cycle.py
@@ -645,6 +645,11 @@ async def _run_prepared_cycle(
             attribution = await attribution_read(
                 correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
             )
+        except AssertionError:
+            # 🔴 깨진 불변식은 「조회 불가」가 아니다. 이것을 삼키면 테스트 conftest
+            # 의 AssertionError 가드까지 무력화되어, 귀속 리더 주입을 잊은 테스트가
+            # 조용히 fail-closed 분기로 통과한다 — 게이트를 증명하지 않은 채.
+            raise
         except Exception as exc:  # noqa: BLE001 — 어떤 실패든 「알 수 없음」
             attribution = kr_attribution.attribution_unreadable(type(exc).__name__)
         scoped = scoped_positions(fresh=fresh, attribution=attribution)

--- a/scripts/b0x/kr/cycle.py
+++ b/scripts/b0x/kr/cycle.py
@@ -42,6 +42,18 @@ refused again. 포지션 진실 stays with the broker holdings read (v1.6 ②): 
 ``positions`` this function builds come from ``fresh.positions`` and from
 nothing else, whatever the ledger says.
 
+§36차 2항 (2026-08-11) — 귀속 게이트가 flat 요구를 대체한다
+------------------------------------------------------------
+
+이 계좌에는 B0-X 가 만들지 않은 **legacy 보유**가 있다. 이전 confirm preflight 는
+「보유가 하나라도 있으면 이상」이었고, 그래서 (a) 한 건도 제출할 수 없었으며
+(b) 계약 v1.5 ③ 의 「매도는 자기 보유에서 파생」과 모순이었다(보유가 있어야
+매도가 나오는데 보유가 있으면 막혔다). 운영자 결정은 flatten 기각 · 귀속 기반
+공존이다: :mod:`scripts.b0x.kr.attribution` 이 자기 원장 fill 로 own/legacy 를
+가르고, legacy 는 **읽히되 파생 입력에서 빠지며 매도 경로에 도달하지 못한다**.
+무엇이 어디에 포함/제외되는지와 그 근거는 :func:`broker_state` 의 docstring 에
+있다(이 판정은 §36차 2항 이 명시적으로 위임한 것이다).
+
 Kill-trip cancellation asymmetry with the crypto sidecar, documented rather
 than silently matched: the crypto lanes cancel outstanding B0-X orders on a
 kill trip (``scripts.b0x.cycle._cancel_b0x_open_orders``) because their
@@ -68,11 +80,16 @@ from app.services.kis_mock_runner.singleton import (
     WriterSingletonContended,
     WriterSingletonUnavailable,
 )
-from scripts.b0x.broker_truth import OwnPendingResubmitBlocked, PendingUnreadable
+from scripts.b0x.broker_truth import (
+    BrokerTruth,
+    OwnPendingResubmitBlocked,
+    PendingUnreadable,
+)
 from scripts.b0x.cycle import base_record, render_cycle_report
 from scripts.b0x.derivation import DerivationResult, derive_orders
 from scripts.b0x.envelope import Envelope, assert_envelope_locked, load_envelope
 from scripts.b0x.kill_switch import evaluate as evaluate_kill_switch
+from scripts.b0x.kr import attribution as kr_attribution
 from scripts.b0x.kr import mock as kr_mock
 from scripts.b0x.kr import pending_ledger as kr_pending_ledger
 from scripts.b0x.labels import account_history_labels, header_labels
@@ -81,7 +98,7 @@ from scripts.b0x.ledger import (
     ObservationLedger,
     writer_lock,
 )
-from scripts.b0x.state import B0XPosition, LaneAccountState
+from scripts.b0x.state import LaneAccountState
 from scripts.b0x.table_source import (
     DEFAULT_TABLE_DIR,
     PolicyTable,
@@ -214,17 +231,85 @@ KR_REALIZED_PNL_UNAVAILABLE = (
 )
 
 
+#: 🔴 귀속 리더를 배선하지 않은 호출자가 받는 상태. 「자기 것이 없다」가 아니라
+#: 「자기 것이 무엇인지 확인하지 않았다」이며, 두 방향 모두 닫힌다(자기 포지션 0
+#: + §4 상한 입력 = 계좌 전체). ``KR_PENDING_UNREADABLE`` 이 미배선 호출자에게
+#: 하는 일과 같은 자세다.
+ATTRIBUTION_NOT_WIRED: Final[kr_attribution.AttributionUnreadable] = (
+    kr_attribution.AttributionUnreadable(
+        reason="kis_mock_own_fill_attribution_not_wired",
+        detail=(
+            "호출자가 자기 원장 귀속 리더를 배선하지 않았다 — 어떤 보유가 자기 "
+            "것인지 확인되지 않았으므로 legacy 로 취급한다(매도/물타기 파생 0) "
+            "+ §4 상한은 계좌 전체 기준. 「미배선」을 「귀속 없음」으로도 "
+            "「legacy 없음」으로도 읽지 않는다 (§36차 2항)"
+        ),
+    )
+)
+
+
+#: 🔴 §36차 2항 이 판정을 위임한 항목 중 하나 — legacy 평가금액의 NAV 포함 여부.
+#: 기록에 남겨 두는 이유: pct_of_nav kill 의 절대 임계는 NAV 에 비례하므로, 이
+#: 선택은 「어느 방향으로 틀릴 것인가」의 선택이다.
+KR_ATTRIBUTED_NAV_BASIS: Final[str] = (
+    "nav = cash + 자기 귀속 평가금액(지분 비례). legacy 평가금액은 제외 — §4 "
+    "daily_loss_kill 이 pct_of_nav 이므로 legacy 를 포함하면 kill 이 발화하는 "
+    "절대 손실액이 커진다(임계가 넓어진다). 귀속 불가면 자기 평가금액 0 → "
+    "nav = cash 로 더 좁아진다. 어느 경우에도 넓어지지 않는다."
+)
+
+
 def broker_state(
     *,
     fresh: kr_mock.FreshTruth,
     own_pending: tuple[str, ...] | PendingUnreadable | None = None,
+    attribution: (
+        kr_attribution.OwnFillAttribution | kr_attribution.AttributionUnreadable | None
+    ) = None,
 ) -> LaneAccountState:
     """kis_mock account state, derived entirely from this cycle's broker read.
 
-    Contract v1.5 ①/③. Positions are the account's own holdings — "B0-X
-    물타기/매도 = 자기(mock) 보유에서만 파생" (v1.5 ③), and under the account
-    map kis_mock is B0-X's exclusive order lane, so a mock holding *is* B0-X's
-    book. ``average_price`` is the broker's own 매입평균가.
+    Contract v1.5 ①/③, **as amended by §36차 2항 (귀속 기반 공존)**. Positions
+    are no longer "every mock holding": the account carries legacy holdings
+    B0-X did not create, and those belong to an observation-only coexisting
+    lane. ``attribution`` (자기 원장 fill 귀속) is what separates the two —
+    see :mod:`scripts.b0x.kr.attribution` for the evidence rules and the
+    deliberately asymmetric error direction. Omitting it is fail-closed
+    (:data:`ATTRIBUTION_NOT_WIRED`), never "everything is mine".
+
+    ``average_price`` for an attributed position is the weighted average of
+    **B0-X's own fills**, not the broker's 매입평균가: on a symbol shared with
+    a legacy holding the broker's average blends someone else's cost in.
+
+    🔴 What legacy holdings are excluded from, and why (§36차 2항 delegates
+    this judgement, so it is stated here rather than left implicit):
+
+    * **매도/물타기 파생** — excluded. This is the literal instruction, and
+      the whole reason the gate exists: a legacy symbol must never become a
+      sell or an averaging candidate.
+    * **§4 동시포지션 / 일일신규 상한 입력** — excluded (``cap_position_
+      symbols`` = attributed only). This diverges from the shared
+      ``broker_truth`` docstring's "account-wide" reading and from the US
+      lane's comment that foreign sellable positions consume a slot, and the
+      divergence is deliberate: with 11 legacy holdings against a cap of 10,
+      an account-wide count means this lane derives **zero** new entries
+      forever, which is exactly the coexistence the operator's (b) decision
+      replaced flatten with. The §4 *numbers* are untouched; what changed is
+      whose positions they count. 🔴 The cost, stated plainly: the account can
+      now carry legacy + up to 10 B0-X positions, so account-level exposure is
+      wider than the cap alone suggests.
+    * **NAV (kill 임계 기준)** — excluded, pro-rated by attributed share.
+      The §4 kill is ``pct_of_nav``, so a *larger* NAV means a *larger*
+      absolute loss is tolerated before it fires. Including legacy market
+      value would therefore widen the threshold; excluding it can only
+      narrow it. Where a judgement was free, it was made in the direction
+      that never widens the kill (unreadable attribution → attributed
+      evaluation 0 → NAV = cash, the tightest defensible basis).
+    * **계좌 진실 · 오염 판정 · preflight 기록** — *included*. Legacy holdings
+      are read, counted and named in the artifact (``positions.legacy_
+      symbols``); the CONTAMINATED judgement stays exactly what it was
+      (non-``b0xk`` correlation *traces*, i.e. another **writer**), because a
+      sanctioned coexisting holding is not another writer.
 
     🔴 ``invested_notional`` is the **cost basis**, not cumulative deployment,
     because a single broker snapshot carries no cumulative figure — and a
@@ -243,28 +328,48 @@ def broker_state(
     below, and it is not merged into ``broker_truth.position_symbols`` — v1.6
     ② keeps 포지션 진실 on the broker. ``None`` (the default) leaves the lane
     on ``KR_PENDING_UNREADABLE``.
+
+    🔴 v1.6 ② still holds under the attribution gate: the broker holdings read
+    remains the only source of *whether* a position exists and how large it
+    is. The ledger answers only *whose* it is, and can never conjure a
+    position the broker did not report (``scope_positions`` iterates the
+    broker's rows and caps every attributed quantity by the held quantity).
     """
 
-    positions = tuple(
-        B0XPosition(
-            symbol=pos.symbol,
-            quantity=pos.quantity,
-            average_price=pos.average_price,
-            invested_notional=pos.quantity * pos.average_price,
-            entry_count=0,
-        )
-        for pos in sorted(fresh.positions, key=lambda p: p.symbol)
-        if pos.symbol in set(fresh.non_dust_position_symbols())
-    )
+    scoped = scoped_positions(fresh=fresh, attribution=attribution)
     return LaneAccountState(
         lane=LANE,
         quote_currency=kr_mock.QUOTE_CURRENCY,
         cash=fresh.cash,
-        broker_truth=fresh.broker_truth(own_pending),
-        positions=positions,
+        broker_truth=BrokerTruth(
+            position_symbols=scoped.cap_position_symbols,
+            own_pending=(
+                kr_mock.KR_PENDING_UNREADABLE if own_pending is None else own_pending
+            ),
+        ),
+        positions=scoped.own_positions,
         cumulative_deployment_readable=False,
         realized_pnl_today=Decimal("0"),
-        nav=fresh.nav,
+        # 🔴 NAV = cash + 자기 귀속 평가금액. legacy 평가금액을 넣으면 pct_of_nav
+        # kill 의 절대 임계가 커진다 — 넓히지 않는 방향을 고른다(위 docstring).
+        nav=fresh.cash + scoped.attributed_evaluation,
+    )
+
+
+def scoped_positions(
+    *,
+    fresh: kr_mock.FreshTruth,
+    attribution: (
+        kr_attribution.OwnFillAttribution | kr_attribution.AttributionUnreadable | None
+    ),
+) -> kr_attribution.ScopedPositions:
+    """One place where 자기 보유 / legacy 보유 is decided for this lane."""
+
+    return kr_attribution.scope_positions(
+        positions=fresh.positions,
+        attribution=ATTRIBUTION_NOT_WIRED if attribution is None else attribution,
+        account_wide_non_dust=fresh.non_dust_position_symbols(),
+        min_trade_unit=kr_mock.KRX_MIN_TRADE_UNIT_SHARES,
     )
 
 
@@ -316,6 +421,7 @@ def _confirm_preflight_record(
     completed_at: dt.datetime,
     account_identity: dict[str, str],
     fresh: kr_mock.FreshTruth,
+    scoped: kr_attribution.ScopedPositions,
     own_pending: tuple[str, ...] | PendingUnreadable,
     foreign_traces: kr_pending_ledger.ForeignLedgerTraces | PendingUnreadable,
 ) -> dict[str, Any]:
@@ -326,6 +432,17 @@ def _confirm_preflight_record(
     **ledger shadow** rather than misreported as a native open-order response.
     A non-B0-X trace is contamination; an unreadable trace source is also a
     failure because exclusive truth was not established.
+
+    🔴 §36차 2항 — the flat-account requirement is **gone**, replaced by the
+    attribution gate. Until 2026-08-11 this record failed on
+    ``unexpected_positions`` whenever the account carried *any* non-dust
+    holding, which on this account (11 legacy holdings B0-X never created)
+    meant the confirm path could never dispatch, and which also contradicted
+    contract v1.5 ③ (매도는 자기 보유에서 파생되는데 보유가 있으면 막혔다).
+    Legacy holdings are now recorded as a named, coexisting fact instead of an
+    anomaly; what still fails closed is being unable to *tell them apart*
+    (``attribution_unreadable``), because that is the state in which a sell
+    could reach someone else's shares.
     """
 
     elapsed_seconds = (completed_at - started_at).total_seconds()
@@ -342,8 +459,9 @@ def _confirm_preflight_record(
         reasons.append("preflight_exceeded_5_minutes")
     if fresh.cash <= 0:
         reasons.append("cash_not_positive")
-    if position_symbols:
-        reasons.append("unexpected_positions")
+    if scoped.unreadable is not None:
+        # 🔴 「보유가 있다」가 아니라 「누구 것인지 모른다」가 실패 사유다.
+        reasons.append("attribution_unreadable")
     if own_unreadable is not None:
         reasons.append("ledger_pending_unreadable")
     elif own_symbols:
@@ -363,7 +481,27 @@ def _confirm_preflight_record(
         "positions": {
             "non_dust_symbols": list(position_symbols),
             "count": len(position_symbols),
+            # 🔴 계좌 전체(위)와 귀속 분리(아래)를 같은 블록에 나란히 둔다 —
+            # legacy 를 조용히 지우지 않는다 (§36차 2항 「무시」 ≠ 「삭제」).
+            "own_attributed_symbols": [pos.symbol for pos in scoped.own_positions],
+            "own_attributed_count": len(scoped.own_positions),
+            "legacy_symbols": list(scoped.legacy_symbols),
+            "legacy_count": len(scoped.legacy_symbols),
         },
+        "attribution": (
+            {
+                "source": kr_attribution.ATTRIBUTION_SOURCE,
+                "readable": False,
+                "unreadable": scoped.unreadable.canonical(),
+                "cap_basis": scoped.cap_basis,
+            }
+            if scoped.unreadable is not None
+            else {
+                "source": kr_attribution.ATTRIBUTION_SOURCE,
+                "readable": True,
+                "cap_basis": scoped.cap_basis,
+            }
+        ),
         "open_orders": {
             "native_broker": {
                 "available": False,
@@ -408,7 +546,15 @@ def _preflight_truth_unavailable_record(
         "max_age_seconds": PREFLIGHT_MAX_AGE_SECONDS,
         "account": account_identity,
         "cash": {"present": None},
-        "positions": {"non_dust_symbols": None, "count": None},
+        "positions": {
+            "non_dust_symbols": None,
+            "count": None,
+            "own_attributed_symbols": None,
+            "own_attributed_count": None,
+            "legacy_symbols": None,
+            "legacy_count": None,
+        },
+        "attribution": None,
         "open_orders": {
             "native_broker": {
                 "available": False,
@@ -438,6 +584,7 @@ async def _run_prepared_cycle(
     broker: Any | None,
     pending_reader: kr_pending_ledger.PendingReader | None,
     foreign_trace_reader: kr_pending_ledger.ForeignTraceReader | None,
+    attribution_reader: kr_attribution.AttributionReader | None,
     account_identity: dict[str, str] | None,
 ) -> KrCycleOutcome:
     """Account truth → derive → plan → bounded confirm dispatch.
@@ -490,6 +637,23 @@ async def _run_prepared_cycle(
         record["fresh_truth"] = fresh.status_only(own_pending)
         record["own_pending_source"] = kr_mock.OWN_PENDING_SOURCE
 
+        # §36차 2항 — 자기 원장 귀속.  Read inside the same NW-B4 window as the
+        # account snapshot: the two are compared against each other, so a stale
+        # attribution against a fresh holdings read is not a usable answer.
+        attribution_read = attribution_reader or kr_attribution.read_own_attribution
+        try:
+            attribution = await attribution_read(
+                correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
+            )
+        except Exception as exc:  # noqa: BLE001 — 어떤 실패든 「알 수 없음」
+            attribution = kr_attribution.attribution_unreadable(type(exc).__name__)
+        scoped = scoped_positions(fresh=fresh, attribution=attribution)
+        record["attribution"] = {
+            **scoped.canonical(),
+            "source": kr_attribution.ATTRIBUTION_SOURCE,
+            "nav_basis": KR_ATTRIBUTED_NAV_BASIS,
+        }
+
         if confirm:
             foreign_reader = (
                 foreign_trace_reader or kr_pending_ledger.read_foreign_traces
@@ -508,6 +672,7 @@ async def _run_prepared_cycle(
                 completed_at=dt.datetime.now(dt.UTC),
                 account_identity=account_identity,
                 fresh=fresh,
+                scoped=scoped,
                 own_pending=own_pending,
                 foreign_traces=foreign_traces,
             )
@@ -522,7 +687,9 @@ async def _run_prepared_cycle(
                     detail=", ".join(preflight["reasons"]),
                 )
 
-        state = broker_state(fresh=fresh, own_pending=own_pending)
+        state = broker_state(
+            fresh=fresh, own_pending=own_pending, attribution=attribution
+        )
         record["broker_truth"] = state.broker_truth.canonical()
         decision = evaluate_kill_switch(state=state, envelope=envelope)
         derivation = derive_orders(
@@ -592,6 +759,35 @@ async def _run_prepared_cycle(
                         record["submission_stopped"] = "preflight_expired"
                         break
 
+                    # 🔴 §36차 2항, at the mutation boundary: a SELL may only
+                    # ever reach shares this lane's own fills paid for. The
+                    # derivation already refused legacy symbols (they are not
+                    # in ``state.positions`` at all), and this second line is
+                    # deliberately redundant — a one-line regression there
+                    # would otherwise become a sale of someone else's shares,
+                    # the one irreversible mistake available on this lane.
+                    if order.side == "sell":
+                        try:
+                            kr_attribution.assert_sell_is_own(
+                                scoped,
+                                symbol=order.symbol,
+                                quantity=Decimal(order.quantity),
+                                lane=LANE,
+                            )
+                        except kr_attribution.LegacyPositionSellBlocked as exc:
+                            record.setdefault("submission_blocked", []).append(
+                                {
+                                    "symbol": order.symbol,
+                                    "correlation_id": order.client_order_id,
+                                    "reason": "legacy_position_sell_blocked",
+                                    "detail": str(exc),
+                                }
+                            )
+                            record["submission_stopped"] = (
+                                "legacy_position_sell_blocked"
+                            )
+                            break
+
                     # v1.6's dedup is re-read immediately before every real
                     # dispatch.  The artifact's first snapshot is evidence;
                     # this re-read is the mutation boundary.
@@ -605,7 +801,9 @@ async def _run_prepared_cycle(
                             type(exc).__name__
                         )
                     current_truth = broker_state(
-                        fresh=fresh, own_pending=current_pending
+                        fresh=fresh,
+                        own_pending=current_pending,
+                        attribution=attribution,
                     ).broker_truth
                     try:
                         result = await kr_mock.submit_planned_order(
@@ -701,6 +899,7 @@ async def run_kr_cycle(
     broker: Any | None = None,
     pending_reader: kr_pending_ledger.PendingReader | None = None,
     foreign_trace_reader: kr_pending_ledger.ForeignTraceReader | None = None,
+    attribution_reader: kr_attribution.AttributionReader | None = None,
 ) -> KrCycleOutcome:
     """One manual kis_mock B0-X cycle.
 
@@ -788,6 +987,7 @@ async def run_kr_cycle(
                 broker=broker,
                 pending_reader=pending_reader,
                 foreign_trace_reader=foreign_trace_reader,
+                attribution_reader=attribution_reader,
                 account_identity=None,
             )
 
@@ -821,6 +1021,7 @@ async def run_kr_cycle(
                     broker=broker,
                     pending_reader=pending_reader,
                     foreign_trace_reader=foreign_trace_reader,
+                    attribution_reader=attribution_reader,
                     account_identity=account_identity,
                 )
         except WriterSingletonContended as exc:
@@ -854,6 +1055,9 @@ __all__ = [
     "KR_ACCOUNT_MAP_COMMIT",
     "KR_STATUS_LABEL",
     "KR_REALIZED_PNL_UNAVAILABLE",
+    "KR_ATTRIBUTED_NAV_BASIS",
+    "ATTRIBUTION_NOT_WIRED",
+    "scoped_positions",
     "KrCycleOutcome",
     "broker_state",
     "run_kr_cycle",

--- a/scripts/run_b0x_kr_cycle.py
+++ b/scripts/run_b0x_kr_cycle.py
@@ -71,9 +71,11 @@ async def _derivation_only(args: argparse.Namespace) -> int:
 
     from scripts.b0x import kill_switch as kill_switch_module
     from scripts.b0x.derivation import derive_orders
+    from scripts.b0x.kr import attribution as kr_attribution
     from scripts.b0x.kr import mock as kr_mock
     from scripts.b0x.kr import pending_ledger as kr_pending_ledger
     from scripts.b0x.kr.cycle import broker_state
+    from scripts.b0x.kr.cycle import scoped_positions as kr_cycle_scope
     from scripts.b0x.table_source import TableUnavailable, load_policy_table
 
     now = dt.datetime.now(dt.UTC) if args.now is None else args.now
@@ -101,7 +103,13 @@ async def _derivation_only(args: argparse.Namespace) -> int:
     own_pending = await kr_pending_ledger.read_own_pending(
         now=now, correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
     )
-    state = broker_state(fresh=fresh, own_pending=own_pending)
+    # §36차 2항: legacy 보유(B0-X 가 만들지 않은 것)를 자기 원장 fill 귀속으로
+    # 갈라 낸다. 읽기 실패는 「자기 것 없음」이 아니라 tri-state 로 떨어지고,
+    # 그 상태에서는 자기 포지션 0 + §4 상한 입력 = 계좌 전체가 된다.
+    attribution = await kr_attribution.read_own_attribution(
+        correlation_prefix=f"{kr_mock.CLIENT_ORDER_ID_PREFIX}-"
+    )
+    state = broker_state(fresh=fresh, own_pending=own_pending, attribution=attribution)
 
     hashes: list[str] = []
     result = None
@@ -117,8 +125,15 @@ async def _derivation_only(args: argparse.Namespace) -> int:
         )
         hashes.append(result.derivation_hash())
 
+    scoped = kr_cycle_scope(fresh=fresh, attribution=attribution)
     print(f"policy_table_hash={table.policy_table_hash}")
     print(f"account_state_hash={state.state_hash()}")
+    print(
+        f"attribution_readable={scoped.unreadable is None} "
+        f"own_positions={len(scoped.own_positions)} "
+        f"legacy_positions={len(scoped.legacy_symbols)} "
+        f"cap_basis={scoped.cap_basis}"
+    )
     for index, digest in enumerate(hashes):
         print(f"run[{index}] derivation_hash={digest}")
     identical = len(set(hashes)) == 1

--- a/tests/scripts/b0x/kr/_attribution.py
+++ b/tests/scripts/b0x/kr/_attribution.py
@@ -1,0 +1,95 @@
+"""Fake 자기 원장 귀속 readers for the KR lane (§36차 2항).
+
+None of these touch a database. They exist for the same reason
+``_pending.py`` does: ``read_own_attribution`` converts *any* failure into
+:class:`~scripts.b0x.kr.attribution.AttributionUnreadable`, so a test that
+forgot to inject would not error — it would quietly take the fail-closed
+branch (자기 포지션 0 · §4 상한 = 계좌 전체) and keep passing while proving
+nothing about the readable path.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from scripts.b0x.kr import attribution as kr_attribution
+
+
+def attributed(**quantities: object):
+    """A reader whose ledger attributes exactly ``symbol=quantity`` to B0-X.
+
+    ``quantity`` may be a plain int/str; ``average_price`` defaults to a
+    single fill at 1 KRW unless given as a ``(quantity, average_price)`` pair.
+    """
+
+    lots: list[kr_attribution.AttributedLot] = []
+    for symbol, value in quantities.items():
+        if isinstance(value, tuple):
+            quantity, average_price = value
+        else:
+            quantity, average_price = value, 1
+        lots.append(
+            kr_attribution.AttributedLot(
+                symbol=symbol,
+                quantity=Decimal(str(quantity)),
+                average_price=Decimal(str(average_price)),
+                buy_fill_rows=1,
+                sell_rows=0,
+            )
+        )
+    resolved = kr_attribution.OwnFillAttribution(lots=tuple(lots))
+
+    async def _read(
+        *, correlation_prefix: str
+    ) -> kr_attribution.OwnFillAttribution | kr_attribution.AttributionUnreadable:
+        assert correlation_prefix == "b0xk-", (
+            f"cycle asked with prefix {correlation_prefix!r}, expected 'b0xk-'"
+        )
+        return resolved
+
+    return _read
+
+
+def no_attribution():
+    """원장이 답했고, 이 레인 소유는 하나도 없다 — legacy-only 계좌.
+
+    🔴 「읽지 못했다」와 구분된다: 이것은 **readable** 이므로 preflight 를
+    통과해야 하고(§36차 2항, mutant ④), 그런데도 매도/물타기 후보는 0 이어야
+    한다(mutant ①②).
+    """
+
+    return attributed()
+
+
+def unreadable_attribution(cause: str = "RuntimeError"):
+    """귀속 원장이 답하지 못한 상태 — 양방향 fail-closed 를 증명하는 입력."""
+
+    resolved = kr_attribution.attribution_unreadable(cause)
+
+    async def _read(
+        *, correlation_prefix: str
+    ) -> kr_attribution.OwnFillAttribution | kr_attribution.AttributionUnreadable:
+        del correlation_prefix
+        return resolved
+
+    return _read
+
+
+def exploding_attribution(exc: Exception):
+    """A reader that raises — the cycle itself must convert it, not the test."""
+
+    async def _read(
+        *, correlation_prefix: str
+    ) -> kr_attribution.OwnFillAttribution | kr_attribution.AttributionUnreadable:
+        del correlation_prefix
+        raise exc
+
+    return _read
+
+
+__all__ = [
+    "attributed",
+    "exploding_attribution",
+    "no_attribution",
+    "unreadable_attribution",
+]

--- a/tests/scripts/b0x/kr/conftest.py
+++ b/tests/scripts/b0x/kr/conftest.py
@@ -20,6 +20,7 @@ import datetime as dt
 import pytest
 
 from scripts.b0x.broker_truth import PendingUnreadable
+from scripts.b0x.kr import attribution as kr_attribution
 from scripts.b0x.kr import cycle as kr_cycle
 from scripts.b0x.kr import mock as kr_mock
 from scripts.b0x.kr import pending_ledger as kr_pending_ledger
@@ -50,6 +51,19 @@ def _forbid_real_pending_ledger_reads(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     monkeypatch.setattr(kr_pending_ledger, "read_foreign_traces", _refuse_foreign)
+
+    async def _refuse_attribution(
+        *, correlation_prefix: str
+    ) -> kr_attribution.OwnFillAttribution | kr_attribution.AttributionUnreadable:
+        raise AssertionError(
+            "a KR test reached the real kis_mock 귀속 reader "
+            f"(prefix={correlation_prefix!r}). Pass attribution_reader=... "
+            "explicitly — an accidental read would be swallowed into "
+            "AttributionUnreadable, which silently means 'legacy 취급, 자기 "
+            "포지션 0' and proves nothing about the §36차 2항 gate."
+        )
+
+    monkeypatch.setattr(kr_attribution, "read_own_attribution", _refuse_attribution)
 
 
 @pytest.fixture

--- a/tests/scripts/b0x/kr/test_attribution_gate.py
+++ b/tests/scripts/b0x/kr/test_attribution_gate.py
@@ -197,11 +197,13 @@ async def test_mutant_1_legacy_holdings_never_become_sell_candidates(
     assert sells == [], "legacy 보유가 매도 후보로 파생됐다 — §36차 2항 위반 (mutant ①)"
     # 이유가 「매도할 포지션이 없다」로 남아야 한다: 조용히 사라지는 것이 아니라
     # 자기 장부에 없다는 기록이다.
+    # 🔴 부분집합이 아니라 등호다 — sell skip 행이 통째로 사라져도 통과하는
+    # 공허한 assert 는 mutant 를 잡지 못한다.
     assert {
         skip["reason"]
         for skip in outcome.record["skipped"]
         if skip["leg"].startswith("sell")
-    } <= {"no_position_to_sell"}
+    } == {"no_position_to_sell"}
     # 그러면서 계좌 진실은 지워지지 않는다.
     assert outcome.record["fresh_truth"]["non_dust_position_symbols"] == [
         "000660",
@@ -281,11 +283,9 @@ async def test_mutant_2_legacy_holdings_never_become_averaging_candidates(
     ] == [], "legacy 보유에 물타기가 파생됐다 (mutant ②)"
     # legacy 는 자기 포지션이 아니므로 「신규 진입」 경로로 들어오고, 물타기
     # 경로(기존 포지션에 대한 추가)는 애초에 열리지 않는다.
-    assert all(
-        order["leg"] in {"buy_l1", "buy_l2"}
-        for order in outcome.record["orders"]
-        if order["side"] == "buy"
-    )
+    buys = [order for order in outcome.record["orders"] if order["side"] == "buy"]
+    assert buys, "매수 후보가 0 이면 아래 assert 가 공허해진다"
+    assert all(order["leg"] in {"buy_l1", "buy_l2"} for order in buys)
 
 
 def test_mutant_2_additions_stay_refused_even_for_attributed_positions() -> None:
@@ -544,6 +544,29 @@ def test_mutant_5_the_attribution_module_cannot_reach_the_pending_reader() -> No
     assert "scripts.b0x.kr.pending_ledger" not in imported
 
 
+@pytest.mark.asyncio
+async def test_a_forgotten_reader_injection_fails_loudly_instead_of_silently(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """🔴 conftest 의 AssertionError 가드는 사이클에 삼켜지면 안 된다.
+
+    사이클은 귀속 리더의 어떤 실패든 ``attribution_unreadable`` 로 바꾼다. 그 절이
+    ``AssertionError`` 까지 삼키면, 리더 주입을 잊은 테스트가 조용히 fail-closed
+    분기로 통과하면서 게이트를 하나도 증명하지 않는다 — 테스트 가드가 있으나 마나가
+    된다. 깨진 불변식은 「조회 불가」가 아니다.
+    """
+
+    with pytest.raises(AssertionError, match="귀속 reader"):
+        await run_kr_cycle(
+            now=IN_SESSION_NOW,
+            table_dir=table_dir,
+            out_dir=out_dir,
+            confirm=False,
+            client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+            pending_reader=EMPTY_PENDING,
+        )
+
+
 # ---------------------------------------------------------------------------
 # NAV — 판정된 항목이고, 넓어지지 않는 방향이다
 # ---------------------------------------------------------------------------
@@ -614,7 +637,9 @@ async def test_an_attributed_position_does_derive_its_sell_ladder(
     assert "000660" not in {order["symbol"] for order in sells}
 
 
-def _static_attribution(attribution: kr_attribution.OwnFillAttribution):
+def _static_attribution(
+    attribution: kr_attribution.OwnFillAttribution,
+) -> kr_attribution.AttributionReader:
     async def _read(*, correlation_prefix: str) -> kr_attribution.OwnFillAttribution:
         assert correlation_prefix == "b0xk-"
         return attribution

--- a/tests/scripts/b0x/kr/test_attribution_gate.py
+++ b/tests/scripts/b0x/kr/test_attribution_gate.py
@@ -1,0 +1,658 @@
+"""§36차 2항 — 자기 원장(fill) 귀속 게이트. legacy 보유는 불가침이다.
+
+이 파일이 지키는 다섯 가지(브리프의 필수 mutant 5종). 각 테스트 이름 옆의
+번호가 그것이다:
+
+    ① legacy 종목이 **매도 후보**로 파생됨              → 격추
+    ② legacy 종목이 **물타기 후보**로 파생됨            → 격추
+    ③ 귀속 없는 포지션이 자기 것으로 분류됨             → 격추
+    ④ preflight 이 flat 요구로 되돌아감(legacy 로 차단)  → 격추
+    ⑤ v1.6 원장 dedup 우회                              → 격추
+
+🔴 ①이 최우선이다 — legacy 매도는 **남의 포지션 처분**이며 이 레인에서 되돌릴
+수 없는 유일한 사고다. 그래서 ①은 파생 단계(자기 포지션이 아니면 매도 레그가
+만들어지지 않는다)와 제출 경계(``assert_sell_is_own``) 양쪽에서 검사한다.
+"""
+
+from __future__ import annotations
+
+import ast
+import datetime as dt
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.b0x.kr import attribution as kr_attribution
+from scripts.b0x.kr import cycle as kr_cycle
+from scripts.b0x.kr import mock as kr_mock
+from scripts.b0x.kr.cycle import broker_state, run_kr_cycle
+from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
+from tests.scripts.b0x.kr._attribution import (
+    exploding_attribution,
+    no_attribution,
+    unreadable_attribution,
+)
+from tests.scripts.b0x.kr._pending import foreign_traces, readable_pending
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+KR_PACKAGE = REPO_ROOT / "scripts" / "b0x" / "kr"
+
+#: 2026-08-10 11:00 KST — a Monday inside KRX RTH.
+IN_SESSION_NOW = dt.datetime(2026, 8, 10, 2, 0, tzinfo=dt.UTC)
+
+EMPTY_PENDING = readable_pending()
+
+#: 실측 legacy 보유(2026-08-11 preflight record)의 축약판 — B0-X 가 만들지 않은
+#: 보유이며 원장에 ``b0xk-`` 행이 하나도 없다.
+LEGACY_HOLDINGS: list[dict[str, Any]] = [
+    {
+        "pdno": "005930",
+        "hldg_qty": "100",
+        "pchs_avg_pric": "70000",
+        "evlu_amt": "9700000",
+    },
+    {
+        "pdno": "000660",
+        "hldg_qty": "10",
+        "pchs_avg_pric": "180000",
+        "evlu_amt": "2000000",
+    },
+]
+
+
+@pytest.fixture
+def table_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "policy-tables"
+    write_table(
+        directory,
+        make_payload(
+            market="kr",
+            rows=[
+                # 두 종목 모두 매도 레벨이 있는 행 — 자기 보유였다면 R1/R2 가
+                # 파생되었을 입력이다. legacy 라서 파생되지 않아야 한다.
+                make_row(
+                    symbol="005930",
+                    previous_close="97000",
+                    buy_l1="94090",
+                    buy_l2="92000",
+                    sell_r1="102000",
+                    sell_r2="105000",
+                ),
+                make_row(
+                    symbol="000660",
+                    previous_close="200000",
+                    buy_l1="194000",
+                    sell_r1="210000",
+                    sell_r2="220000",
+                ),
+            ],
+            generated_at=IN_SESSION_NOW - dt.timedelta(hours=1),
+        ),
+        market="kr",
+    )
+    return directory
+
+
+@pytest.fixture
+def out_dir(tmp_path: Path) -> Path:
+    return tmp_path / "observations"
+
+
+class _FakeKrClient:
+    def __init__(self, *, stocks: list[dict[str, Any]] | None = None) -> None:
+        self._stocks = stocks or []
+
+    async def inquire_cash_balance(self) -> dict[str, Any]:
+        return {
+            "dnca_tot_amt": 5_000_000.0,
+            "stck_cash_ord_psbl_amt": 5_000_000.0,
+            "raw": {
+                "dnca_tot_amt": "5000000",
+                "stck_cash_ord_psbl_amt": "5000000",
+            },
+        }
+
+    async def fetch_my_stocks(self) -> list[dict[str, Any]]:
+        return self._stocks
+
+    async def close(self) -> None:  # pragma: no cover — caller-owned here
+        pass
+
+
+class _FakeBroker:
+    def __init__(self) -> None:
+        self.buy_calls: list[dict[str, Any]] = []
+        self.sell_calls: list[dict[str, Any]] = []
+
+    async def submit_buy(self, **kwargs: Any) -> dict[str, Any]:
+        self.buy_calls.append(kwargs)
+        return {"success": True, "odno": "FAKE-BUY", "ledger_id": 1}
+
+    async def submit_exit_sell(self, **kwargs: Any) -> dict[str, Any]:
+        self.sell_calls.append(kwargs)
+        return {"success": True, "odno": "FAKE-SELL", "ledger_id": 2}
+
+
+def _fresh(*holdings: dict[str, Any]) -> kr_mock.FreshTruth:
+    positions = tuple(
+        kr_mock.RawPosition(
+            symbol=str(holding["pdno"]),
+            quantity=Decimal(str(holding["hldg_qty"])),
+            average_price=Decimal(str(holding["pchs_avg_pric"])),
+            evaluation_amount=Decimal(str(holding["evlu_amt"])),
+        )
+        for holding in holdings
+    )
+    evaluation = sum(
+        (position.evaluation_amount for position in positions), Decimal("0")
+    )
+    return kr_mock.FreshTruth(
+        cash=Decimal("5000000"),
+        nav=Decimal("5000000") + evaluation,
+        positions=positions,
+    )
+
+
+def _own(**quantities: str) -> kr_attribution.OwnFillAttribution:
+    return kr_attribution.OwnFillAttribution(
+        lots=tuple(
+            kr_attribution.AttributedLot(
+                symbol=symbol,
+                quantity=Decimal(quantity),
+                average_price=Decimal("70000"),
+                buy_fill_rows=1,
+                sell_rows=0,
+            )
+            for symbol, quantity in quantities.items()
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ① — legacy 는 매도 후보가 되지 않는다 (파생 + 제출 경계)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mutant_1_legacy_holdings_never_become_sell_candidates(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """🔴 legacy 매도 = 남의 포지션 처분. 표에 매도 레벨이 있어도 파생 0."""
+
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        pending_reader=EMPTY_PENDING,
+        attribution_reader=no_attribution(),
+    )
+
+    sells = [order for order in outcome.record["orders"] if order["side"] == "sell"]
+    assert sells == [], "legacy 보유가 매도 후보로 파생됐다 — §36차 2항 위반 (mutant ①)"
+    # 이유가 「매도할 포지션이 없다」로 남아야 한다: 조용히 사라지는 것이 아니라
+    # 자기 장부에 없다는 기록이다.
+    assert {
+        skip["reason"]
+        for skip in outcome.record["skipped"]
+        if skip["leg"].startswith("sell")
+    } <= {"no_position_to_sell"}
+    # 그러면서 계좌 진실은 지워지지 않는다.
+    assert outcome.record["fresh_truth"]["non_dust_position_symbols"] == [
+        "000660",
+        "005930",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mutant_1_submission_boundary_refuses_a_sell_of_legacy_shares(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """파생이 뚫려도 제출 경계가 막는다 — 두 번째 선의 존재 증명."""
+
+    scoped = kr_cycle.scoped_positions(
+        fresh=_fresh(*LEGACY_HOLDINGS),
+        attribution=kr_attribution.OwnFillAttribution(lots=()),
+    )
+    with pytest.raises(kr_attribution.LegacyPositionSellBlocked):
+        kr_attribution.assert_sell_is_own(
+            scoped, symbol="005930", quantity=Decimal("1"), lane=kr_mock.LANE
+        )
+
+
+def test_mutant_1_a_sell_beyond_the_attributed_quantity_is_refused() -> None:
+    """같은 심볼을 legacy 와 공유해도, 팔 수 있는 것은 자기 수량까지다."""
+
+    scoped = kr_cycle.scoped_positions(
+        fresh=_fresh(*LEGACY_HOLDINGS), attribution=_own(**{"005930": "5"})
+    )
+    kr_attribution.assert_sell_is_own(
+        scoped, symbol="005930", quantity=Decimal("5"), lane=kr_mock.LANE
+    )
+    with pytest.raises(kr_attribution.LegacyPositionSellBlocked):
+        kr_attribution.assert_sell_is_own(
+            scoped, symbol="005930", quantity=Decimal("6"), lane=kr_mock.LANE
+        )
+
+
+def test_mutant_1_the_submission_loop_still_carries_the_sell_guard() -> None:
+    """제출 루프에서 ``assert_sell_is_own`` 호출이 사라지면 실패한다."""
+
+    tree = ast.parse((KR_PACKAGE / "cycle.py").read_text(encoding="utf-8"))
+    guarded = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "assert_sell_is_own"
+    ]
+    assert guarded, (
+        "제출 경계의 legacy 매도 가드가 사라졌다 — 파생 한 줄의 회귀가 곧바로 "
+        "남의 주식 매도가 된다 (mutant ①)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ② — legacy 는 물타기 후보가 되지 않는다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mutant_2_legacy_holdings_never_become_averaging_candidates(
+    table_dir: Path, out_dir: Path
+) -> None:
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        pending_reader=EMPTY_PENDING,
+        attribution_reader=no_attribution(),
+    )
+
+    assert [
+        order for order in outcome.record["orders"] if order["leg"] == "averaging"
+    ] == [], "legacy 보유에 물타기가 파생됐다 (mutant ②)"
+    # legacy 는 자기 포지션이 아니므로 「신규 진입」 경로로 들어오고, 물타기
+    # 경로(기존 포지션에 대한 추가)는 애초에 열리지 않는다.
+    assert all(
+        order["leg"] in {"buy_l1", "buy_l2"}
+        for order in outcome.record["orders"]
+        if order["side"] == "buy"
+    )
+
+
+def test_mutant_2_additions_stay_refused_even_for_attributed_positions() -> None:
+    """자기 포지션이어도 누적 투입액을 못 읽으면 추가는 거부된다(무변경)."""
+
+    state = broker_state(
+        fresh=_fresh(*LEGACY_HOLDINGS), attribution=_own(**{"005930": "10"})
+    )
+    assert state.cumulative_deployment_readable is False
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ③ — 귀속 없는 포지션은 자기 것이 아니다
+# ---------------------------------------------------------------------------
+
+
+def test_mutant_3_an_unattributed_holding_is_legacy_not_own() -> None:
+    scoped = kr_cycle.scoped_positions(
+        fresh=_fresh(*LEGACY_HOLDINGS),
+        attribution=kr_attribution.OwnFillAttribution(lots=()),
+    )
+    assert scoped.own_positions == ()
+    assert scoped.legacy_symbols == ("000660", "005930")
+
+
+def test_mutant_3_an_accepted_but_unfilled_buy_is_not_attribution() -> None:
+    """🔴 「나갔다」는 「받았다」가 아니다 — 체결 증거만 귀속(+)이 된다."""
+
+    attribution = kr_attribution.build_attribution(
+        [
+            ("005930", "buy", "10", "70000", "accepted", None, None),
+            ("005930", "buy", "3", "70000", "pending", None, None),
+        ]
+    )
+    assert attribution.quantity("005930") == Decimal("0")
+
+    filled = kr_attribution.build_attribution(
+        [("005930", "buy", "10", "70000", "fill", "entry", "scalp_entry")]
+    )
+    assert filled.quantity("005930") == Decimal("10")
+
+
+def test_mutant_3_the_ledger_cannot_claim_more_than_the_broker_holds() -> None:
+    """원장이 뭐라 하든 계좌에 없는 주식은 우리 것이 아니다."""
+
+    scoped = kr_cycle.scoped_positions(
+        fresh=_fresh(LEGACY_HOLDINGS[1]),  # 000660 10주
+        attribution=_own(**{"000660": "999"}),
+    )
+    assert [position.quantity for position in scoped.own_positions] == [Decimal("10")]
+
+
+def test_mutant_3_a_pending_sell_is_deducted_before_it_fills() -> None:
+    """매도는 상태 무관 전량 차감 — 미체결 매도가 자기 수량으로 남으면 그것이
+    바로 legacy 주식을 향한 다음 매도가 된다."""
+
+    attribution = kr_attribution.build_attribution(
+        [
+            ("005930", "buy", "10", "70000", "fill", "entry", None),
+            ("005930", "sell", "10", "72000", "accepted", "exit", None),
+        ]
+    )
+    assert attribution.quantity("005930") == Decimal("0")
+
+
+def test_mutant_3_control_rows_are_never_attribution() -> None:
+    attribution = kr_attribution.build_attribution(
+        [
+            (
+                kr_attribution.CONTROL_SYMBOL,
+                "buy",
+                "1",
+                "1",
+                "fill",
+                "tracking_degraded",
+                "ledger_tracking_degraded",
+            ),
+            ("005930", "buy", "5", "70000", "fill", "tracking_degraded", None),
+        ]
+    )
+    assert attribution.lots == ()
+
+
+def test_mutant_3_an_unwired_caller_gets_nothing_attributed() -> None:
+    """호출자가 귀속을 배선하지 않으면 「전부 내 것」이 아니라 fail-closed."""
+
+    state = broker_state(fresh=_fresh(*LEGACY_HOLDINGS))
+    assert state.positions == ()
+    # 그리고 §4 상한 입력은 계좌 전체로 되돌아간다 — 신규 진입도 막힌다.
+    assert state.broker_truth.position_symbols == ("000660", "005930")
+
+
+@pytest.mark.asyncio
+async def test_mutant_3_a_raising_reader_becomes_unreadable_not_empty(
+    table_dir: Path, out_dir: Path
+) -> None:
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        pending_reader=EMPTY_PENDING,
+        attribution_reader=exploding_attribution(RuntimeError("db down")),
+    )
+
+    attribution = outcome.record["attribution"]
+    assert attribution["unreadable"] is not None
+    assert attribution["cap_basis"] == "account_wide_fail_closed"
+    assert "RuntimeError" in attribution["unreadable"]["detail"]
+    # 🔴 읽지 못한 상태에서는 신규 진입도 나오지 않는다(계좌 전체가 상한 입력).
+    assert outcome.record["broker_truth"]["position_symbols"] == [
+        "000660",
+        "005930",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ④ — preflight 은 flat 을 요구하지 않는다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mutant_4_legacy_holdings_do_not_fail_confirm_preflight(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    broker = _FakeBroker()
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        broker=broker,
+        pending_reader=EMPTY_PENDING,
+        foreign_trace_reader=foreign_traces(),
+        attribution_reader=no_attribution(),
+    )
+
+    preflight = outcome.record["preflight"]
+    assert preflight["passed"] is True, (
+        "legacy 보유가 다시 preflight 를 막았다 — flat 요구로의 회귀 (mutant ④)"
+    )
+    assert "unexpected_positions" not in preflight["reasons"]
+    assert preflight["positions"]["legacy_symbols"] == ["000660", "005930"]
+    assert preflight["positions"]["own_attributed_symbols"] == []
+    assert broker.sell_calls == []
+    assert armed_confirm == ["acquired", "released"]
+
+
+def test_mutant_4_the_flat_account_requirement_is_gone_from_the_source() -> None:
+    source = (KR_PACKAGE / "cycle.py").read_text(encoding="utf-8")
+    assert 'reasons.append("unexpected_positions")' not in source
+    assert 'reasons.append("attribution_unreadable")' in source
+
+
+@pytest.mark.asyncio
+async def test_mutant_4_unreadable_attribution_still_fails_closed(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    """게이트를 「무조건 통과」로 바꾼 것이 아니다 — 실패 조건이 옮겨갔다."""
+
+    broker = _FakeBroker()
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        broker=broker,
+        pending_reader=EMPTY_PENDING,
+        foreign_trace_reader=foreign_traces(),
+        attribution_reader=unreadable_attribution(),
+    )
+
+    assert outcome.zero_order_reason == "preflight_not_clean"
+    assert outcome.record["preflight"]["reasons"] == ["attribution_unreadable"]
+    assert broker.buy_calls == [] and broker.sell_calls == []
+
+
+@pytest.mark.asyncio
+async def test_mutant_4_foreign_correlation_traces_still_contaminate(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    """🔴 오염 판정은 그대로다 — legacy 보유(공존)와 다른 **writer**(오염)는
+    다른 것이며, 이 job 은 후자를 건드리지 않았다."""
+
+    broker = _FakeBroker()
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        broker=broker,
+        pending_reader=EMPTY_PENDING,
+        foreign_trace_reader=foreign_traces("005930", order_trace_count=1),
+        attribution_reader=no_attribution(),
+    )
+
+    assert outcome.zero_order_reason == "preflight_not_clean"
+    assert outcome.record["preflight"]["reasons"] == [
+        "CONTAMINATED_foreign_correlation_trace"
+    ]
+    assert broker.buy_calls == []
+
+
+# ---------------------------------------------------------------------------
+# MUTANT ⑤ — v1.6 원장 dedup 은 우회되지 않는다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mutant_5_own_pending_still_blocks_a_symbol_after_the_gate(
+    table_dir: Path, out_dir: Path
+) -> None:
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        pending_reader=readable_pending("005930"),
+        attribution_reader=_static_attribution(_own(**{"005930": "10"})),
+    )
+
+    assert "005930" not in {order["symbol"] for order in outcome.record["orders"]}
+    assert "own_pending_order_exists" in {
+        skip["reason"] for skip in outcome.record["skipped"]
+    }
+
+
+def test_mutant_5_the_attribution_gate_never_writes_own_pending() -> None:
+    """귀속 리더가 미체결 입력을 대신하지 않는다 — 두 질문은 따로다."""
+
+    state = broker_state(
+        fresh=_fresh(*LEGACY_HOLDINGS), attribution=_own(**{"005930": "10"})
+    )
+    assert state.broker_truth.pending_unreadable is not None, (
+        "귀속을 읽었다고 미체결이 읽힌 것으로 취급되면 v1.6 dedup 우회다"
+    )
+
+
+def test_mutant_5_the_attribution_module_cannot_reach_the_pending_reader() -> None:
+    tree = ast.parse((KR_PACKAGE / "attribution.py").read_text(encoding="utf-8"))
+    imported = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    } | {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    assert "scripts.b0x.kr.pending_ledger" not in imported
+
+
+# ---------------------------------------------------------------------------
+# NAV — 판정된 항목이고, 넓어지지 않는 방향이다
+# ---------------------------------------------------------------------------
+
+
+def test_attributed_nav_excludes_legacy_and_never_widens_the_kill() -> None:
+    """§4 kill 은 pct_of_nav 다 — NAV 가 크면 허용 손실 절대액이 커진다."""
+
+    fresh = _fresh(*LEGACY_HOLDINGS)
+    account_wide_nav = fresh.nav
+
+    legacy_only = broker_state(
+        fresh=fresh, attribution=kr_attribution.OwnFillAttribution(lots=())
+    )
+    assert legacy_only.nav == fresh.cash
+    assert legacy_only.nav < account_wide_nav
+
+    # 자기 지분만큼만 들어온다: 005930 100주 중 5주 = 평가액의 5%.
+    partial = broker_state(fresh=fresh, attribution=_own(**{"005930": "5"}))
+    assert partial.nav == fresh.cash + (
+        Decimal("9700000") * Decimal("5") / Decimal("100")
+    )
+    assert partial.nav < account_wide_nav
+
+    # 귀속 불가면 가장 좁은(가장 보수적인) 기준으로 떨어진다.
+    unreadable = broker_state(
+        fresh=fresh, attribution=kr_attribution.attribution_unreadable("RuntimeError")
+    )
+    assert unreadable.nav == fresh.cash
+
+
+def test_the_nav_basis_is_recorded_not_implicit() -> None:
+    assert "pct_of_nav" in kr_cycle.KR_ATTRIBUTED_NAV_BASIS
+    assert "legacy 평가금액은 제외" in kr_cycle.KR_ATTRIBUTED_NAV_BASIS
+
+
+# ---------------------------------------------------------------------------
+# 자기 귀속 포지션은 실제로 매도 후보가 된다 — 게이트가 레인을 죽이지 않았다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_attributed_position_does_derive_its_sell_ladder(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """계약 v1.5 ③ 이 처음으로 도달 가능해진다 — 자기 보유에서 매도가 나온다."""
+
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=False,
+        client=_FakeKrClient(stocks=LEGACY_HOLDINGS),
+        pending_reader=EMPTY_PENDING,
+        attribution_reader=_static_attribution(_own(**{"005930": "10"})),
+    )
+
+    sells = [order for order in outcome.record["orders"] if order["side"] == "sell"]
+    assert {order["symbol"] for order in sells} == {"005930"}
+    # 🔴 그리고 매도 수량은 자기 귀속 10주에서만 나온다 — 브로커 보유 100주가
+    # 아니다 (R1/R2 = 50/50 → 5주씩).
+    assert [
+        order["quantity"]
+        for order in outcome.record["planned"]
+        if order["side"] == "sell"
+    ] == [5, 5]
+    # 000660(legacy) 은 여전히 매도 후보가 아니다.
+    assert "000660" not in {order["symbol"] for order in sells}
+
+
+def _static_attribution(attribution: kr_attribution.OwnFillAttribution):
+    async def _read(*, correlation_prefix: str) -> kr_attribution.OwnFillAttribution:
+        assert correlation_prefix == "b0xk-"
+        return attribution
+
+    return _read
+
+
+# ---------------------------------------------------------------------------
+# 불변식 — 이 job 이 건드리지 않았어야 하는 것
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_numbers_are_untouched() -> None:
+    from scripts.b0x.envelope import load_envelope
+
+    envelope = load_envelope("kr")
+    assert envelope.per_order_notional == Decimal("300000")
+    assert envelope.per_symbol_total_notional == Decimal("1500000")
+    assert envelope.max_concurrent_positions == 10
+    assert envelope.max_new_entries_per_utc_day == 3
+    assert envelope.daily_loss_kill == Decimal("0.025")
+    assert envelope.daily_loss_kill_basis == "pct_of_nav"
+
+
+def test_the_status_label_is_still_observation_only() -> None:
+    assert kr_cycle.KR_STATUS_LABEL.startswith("OBSERVATION_DERIVATION_ONLY")
+
+
+def test_the_attribution_module_has_no_write_or_broker_path() -> None:
+    """읽기 전용임을 소스로 증명 — 원장에 쓰는 경로가 있으면 순환 논증이 된다."""
+
+    source = (KR_PACKAGE / "attribution.py").read_text(encoding="utf-8")
+    for forbidden in ("db.add", "db.commit", "insert(", "update(", "delete("):
+        assert forbidden not in source, f"귀속 모듈에 쓰기 경로가 생겼다: {forbidden}"
+    tree = ast.parse(source)
+    called = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert "execute" in called and "commit" not in called

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -32,6 +32,10 @@ from tests.scripts.b0x._table_fixtures import (
     write_stale_marker,
     write_table,
 )
+from tests.scripts.b0x.kr._attribution import (
+    no_attribution,
+    unreadable_attribution,
+)
 from tests.scripts.b0x.kr._pending import (
     exploding_pending,
     foreign_traces,
@@ -117,13 +121,22 @@ class _FakeKrClient:
 #: never implicit, and (per ``conftest.py``) never accidental.
 EMPTY_PENDING = readable_pending()
 
+#: 🔴 §36차 2항 기본값 — 「원장이 답했고 이 레인 소유는 없다」. 계좌 보유가
+#: 있어도 그것은 legacy 이며, 매도/물타기 후보가 되어서는 안 된다. 자기 귀속을
+#: 증명해야 하는 테스트는 ``attributed(...)`` 를 명시적으로 주입한다.
+NO_ATTRIBUTION = no_attribution()
+
 
 @pytest.mark.asyncio
 async def test_outside_regular_session_derives_zero_orders(
     table_dir: Path, out_dir: Path
 ) -> None:
     outcome = await run_kr_cycle(
-        now=WEEKEND_NOW, table_dir=table_dir, out_dir=out_dir, client=_FakeKrClient()
+        now=WEEKEND_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        client=_FakeKrClient(),
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.zero_order_reason == OUTSIDE_RTH_REASON
     assert outcome.order_count == 0
@@ -140,7 +153,11 @@ async def test_stale_table_derives_zero_orders_even_inside_session(
 ) -> None:
     write_stale_marker(table_dir, market="kr")
     outcome = await run_kr_cycle(
-        now=IN_SESSION_NOW, table_dir=table_dir, out_dir=out_dir, client=_FakeKrClient()
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        client=_FakeKrClient(),
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.zero_order_reason == "stale_marker_present"
     assert outcome.order_count == 0
@@ -167,7 +184,11 @@ async def test_table_older_than_36h_derives_zero_orders_with_reason(
         market="kr",
     )
     outcome = await run_kr_cycle(
-        now=IN_SESSION_NOW, table_dir=directory, out_dir=out_dir, client=_FakeKrClient()
+        now=IN_SESSION_NOW,
+        table_dir=directory,
+        out_dir=out_dir,
+        client=_FakeKrClient(),
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.zero_order_reason == "stale_by_age"
     assert outcome.order_count == 0
@@ -197,6 +218,7 @@ async def test_table_just_under_36h_still_derives_orders(
         out_dir=out_dir,
         client=_FakeKrClient(orderable_cash="5000000"),
         pending_reader=EMPTY_PENDING,
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.zero_order_reason is None
     # Under contract v1.6 ① a lane that has not traded today reads a readable
@@ -220,6 +242,7 @@ async def test_dry_run_plans_but_never_dispatches(
         confirm=False,
         client=client,
         pending_reader=EMPTY_PENDING,
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.zero_order_reason is None
     assert outcome.record["planned"], "a readable-empty book must still plan"
@@ -269,6 +292,7 @@ async def test_kr_pending_is_unreadable_and_fails_closed(
         confirm=False,
         client=_FakeKrClient(orderable_cash="5000000"),
         pending_reader=unreadable_pending(),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     assert outcome.record["broker_truth"]["own_pending_readable"] is False
@@ -307,6 +331,7 @@ async def test_a_failed_ledger_read_falls_back_to_unreadable(
         confirm=False,
         client=_FakeKrClient(orderable_cash="5000000"),
         pending_reader=exploding_pending(OSError("connection refused")),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     truth = outcome.record["broker_truth"]
@@ -338,6 +363,7 @@ async def test_kr_records_that_realized_pnl_has_no_source(
         confirm=False,
         client=_FakeKrClient(orderable_cash="5000000"),
         pending_reader=EMPTY_PENDING,
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert "Not a measured zero" in outcome.record["realized_pnl_source"]
     assert outcome.derivation is not None
@@ -364,6 +390,7 @@ async def test_kr_dry_run_reacts_when_shared_history_scope_expands(
         confirm=False,
         client=_FakeKrClient(orderable_cash="5000000"),
         pending_reader=EMPTY_PENDING,
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     assert SHARED_ACCOUNT_HISTORY in outcome.record["labels"]
@@ -394,6 +421,7 @@ async def test_owns_client_path_constructs_and_closes_its_own_client(
         out_dir=out_dir,
         confirm=False,
         pending_reader=EMPTY_PENDING,
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.zero_order_reason is None
     assert fake.closed is True
@@ -436,6 +464,7 @@ async def test_confirm_true_dispatches_nothing_while_pending_is_unreadable(
         broker=broker,
         pending_reader=unreadable_pending(),
         foreign_trace_reader=foreign_traces(),
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.zero_order_reason == "preflight_not_clean"
     assert outcome.record["preflight"]["passed"] is False
@@ -474,6 +503,7 @@ async def test_confirm_true_routes_through_the_injected_broker_when_pending_read
         broker=broker,
         pending_reader=EMPTY_PENDING,
         foreign_trace_reader=foreign_traces(),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     assert outcome.zero_order_reason is None
@@ -487,6 +517,10 @@ async def test_confirm_true_routes_through_the_injected_broker_when_pending_read
     assert outcome.record["preflight"]["positions"] == {
         "non_dust_symbols": [],
         "count": 0,
+        "own_attributed_symbols": [],
+        "own_attributed_count": 0,
+        "legacy_symbols": [],
+        "legacy_count": 0,
     }
     assert (
         outcome.record["preflight"]["open_orders"]["native_broker"]["available"]
@@ -538,6 +572,7 @@ async def test_confirm_preflight_contamination_stops_zero_orders(
         foreign_trace_reader=foreign_traces(
             "005930", order_trace_count=1, signal_trace_count=1
         ),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     assert outcome.zero_order_reason == "preflight_not_clean"
@@ -578,6 +613,7 @@ async def test_confirm_rechecks_v1_6_dedup_at_the_mutation_boundary(
         broker=broker,
         pending_reader=_pending_after_preflight,
         foreign_trace_reader=foreign_traces(),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     assert outcome.zero_order_reason is None
@@ -597,10 +633,16 @@ async def test_confirm_rechecks_v1_6_dedup_at_the_mutation_boundary(
 
 
 @pytest.mark.asyncio
-async def test_confirm_preflight_unexpected_position_stops_zero_orders(
+async def test_legacy_holdings_do_not_block_confirm_preflight(
     table_dir: Path, out_dir: Path, armed_confirm: list[str]
 ) -> None:
-    """NW-B4 anomaly gate: report the position; never clean it up or submit."""
+    """🔴 §36차 2항 (mutant ④) — flat 요구는 사라졌고 귀속 게이트가 대신한다.
+
+    이 계좌에는 B0-X 가 만들지 않은 legacy 보유가 있다. 예전 게이트는
+    ``unexpected_positions`` 로 **영구히** 제출을 막았고, 그 상태로는 계약
+    v1.5 ③ 의 매도 파생도 도달 불가였다. 이제 legacy 는 이름이 적히고 공존하되,
+    파생 입력에서는 빠진다.
+    """
 
     broker = _FakeBroker()
     outcome = await run_kr_cycle(
@@ -622,14 +664,64 @@ async def test_confirm_preflight_unexpected_position_stops_zero_orders(
         broker=broker,
         pending_reader=EMPTY_PENDING,
         foreign_trace_reader=foreign_traces(),
+        attribution_reader=NO_ATTRIBUTION,
+    )
+
+    preflight = outcome.record["preflight"]
+    assert preflight["reasons"] == []
+    assert preflight["passed"] is True
+    assert outcome.zero_order_reason != "preflight_not_clean"
+    # 🔴 조용히 지워지지 않는다: 계좌 진실과 귀속 분리가 나란히 기록된다.
+    assert preflight["positions"] == {
+        "non_dust_symbols": ["005930"],
+        "count": 1,
+        "own_attributed_symbols": [],
+        "own_attributed_count": 0,
+        "legacy_symbols": ["005930"],
+        "legacy_count": 1,
+    }
+    assert preflight["attribution"]["readable"] is True
+    assert preflight["attribution"]["cap_basis"] == "attributed_own_positions"
+    assert armed_confirm == ["acquired", "released"]
+    # 🔴 그리고 legacy 는 매도 후보가 되지 않는다 (mutant ①).
+    assert [order["symbol"] for order in outcome.record["orders"]] == [
+        order["symbol"] for order in outcome.record["orders"] if order["side"] == "buy"
+    ]
+    assert broker.sell_calls == []
+
+
+@pytest.mark.asyncio
+async def test_confirm_preflight_stops_when_attribution_is_unreadable(
+    table_dir: Path, out_dir: Path, armed_confirm: list[str]
+) -> None:
+    """🔴 「보유가 있다」가 아니라 「누구 것인지 모른다」가 fail-closed 사유다."""
+
+    broker = _FakeBroker()
+    outcome = await run_kr_cycle(
+        now=IN_SESSION_NOW,
+        table_dir=table_dir,
+        out_dir=out_dir,
+        confirm=True,
+        client=_FakeKrClient(
+            orderable_cash="5000000",
+            stocks=[
+                {
+                    "pdno": "005930",
+                    "hldg_qty": "1",
+                    "pchs_avg_pric": "70000",
+                    "evlu_amt": "70000",
+                }
+            ],
+        ),
+        broker=broker,
+        pending_reader=EMPTY_PENDING,
+        foreign_trace_reader=foreign_traces(),
+        attribution_reader=unreadable_attribution(),
     )
 
     assert outcome.zero_order_reason == "preflight_not_clean"
-    assert outcome.record["preflight"]["positions"] == {
-        "non_dust_symbols": ["005930"],
-        "count": 1,
-    }
-    assert outcome.record["preflight"]["reasons"] == ["unexpected_positions"]
+    assert outcome.record["preflight"]["reasons"] == ["attribution_unreadable"]
+    assert outcome.record["preflight"]["attribution"]["readable"] is False
     assert outcome.record["submitted"] == []
     assert broker.buy_calls == [] and broker.sell_calls == []
     assert armed_confirm == ["acquired", "released"]
@@ -666,6 +758,7 @@ async def test_kill_switch_trips_on_nav_ratio_and_blocks_all_new_orders(
         confirm=False,
         client=_FakeKrClient(orderable_cash="1000000"),
         pending_reader=EMPTY_PENDING,
+        attribution_reader=NO_ATTRIBUTION,
     )
     assert outcome.derivation is not None
     assert outcome.derivation.kill_switch.tripped
@@ -699,6 +792,7 @@ async def test_determinism_same_inputs_same_derivation_hash(
             confirm=False,
             client=_FakeKrClient(orderable_cash="5000000"),
             pending_reader=EMPTY_PENDING,
+            attribution_reader=NO_ATTRIBUTION,
         )
         assert outcome.derivation is not None
         hashes.append(outcome.derivation.derivation_hash())

--- a/tests/scripts/b0x/kr/test_ledger_pending_source.py
+++ b/tests/scripts/b0x/kr/test_ledger_pending_source.py
@@ -753,16 +753,28 @@ def test_the_two_position_sources_are_the_broker_read_and_nothing_else() -> None
         (KR_PACKAGE / "attribution.py").read_text(encoding="utf-8")
     )
     scope = next(
-        node
-        for node in ast.walk(attribution_tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "scope_positions"
+        (
+            node
+            for node in ast.walk(attribution_tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "scope_positions"
+        ),
+        None,
     )
+    assert scope is not None, "scope_positions 가 사라졌거나 이름이 바뀌었다"
     iterated = {
         name.id
         for node in ast.walk(scope)
         if isinstance(node, ast.For)
         for name in ast.walk(node.iter)
         if isinstance(name, ast.Name)
+    } | {
+        # 속성 접근으로 순회해도 잡아야 한다 — ``for row in truth.own_pending``
+        # 같은 형태가 아래 PENDING_DERIVED_NAMES 검사를 통과하면 가드가 아니다.
+        attribute.attr
+        for node in ast.walk(scope)
+        if isinstance(node, ast.For)
+        for attribute in ast.walk(node.iter)
+        if isinstance(attribute, ast.Attribute)
     }
     assert "positions" in iterated, (
         "scope_positions stopped iterating the broker holdings snapshot"
@@ -789,10 +801,14 @@ def test_the_two_position_sources_are_the_broker_read_and_nothing_else() -> None
     # cycle.broker_state 는 그 결과만 §4 상한 입력으로 쓴다.
     cycle_tree = ast.parse((KR_PACKAGE / "cycle.py").read_text(encoding="utf-8"))
     func = next(
-        node
-        for node in ast.walk(cycle_tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "broker_state"
+        (
+            node
+            for node in ast.walk(cycle_tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "broker_state"
+        ),
+        None,
     )
+    assert func is not None, "broker_state 가 사라졌거나 이름이 바뀌었다"
     cap_inputs = [
         keyword.value
         for node in ast.walk(func)

--- a/tests/scripts/b0x/kr/test_ledger_pending_source.py
+++ b/tests/scripts/b0x/kr/test_ledger_pending_source.py
@@ -31,15 +31,19 @@ from typing import Any
 import pytest
 
 from scripts.b0x.broker_truth import PendingUnreadable
+from scripts.b0x.kr import attribution as kr_attribution
 from scripts.b0x.kr import pending_ledger as kr_pending_ledger
 from scripts.b0x.kr.cycle import broker_state, run_kr_cycle
 from scripts.b0x.kr.mock import KR_PENDING_UNREADABLE, FreshTruth, RawPosition
 from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
+from tests.scripts.b0x.kr._attribution import no_attribution
 from tests.scripts.b0x.kr._pending import (
     StatefulPendingLedger,
     foreign_traces,
     readable_pending,
 )
+
+NO_ATTRIBUTION = no_attribution()
 
 pytestmark = pytest.mark.unit
 
@@ -204,6 +208,7 @@ async def test_a_ledger_named_symbol_is_refused_and_the_rest_still_derive(
         confirm=False,
         client=_FakeKrClient(),
         pending_reader=readable_pending("005930"),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     truth = outcome.record["broker_truth"]
@@ -301,6 +306,7 @@ async def test_kr_two_cycle_sim_the_same_symbol_is_never_submitted_twice(
             confirm=False,
             client=_FakeKrClient(),
             pending_reader=reader,
+            attribution_reader=NO_ATTRIBUTION,
         )
         assert outcome.zero_order_reason is None
         derived_per_cycle.append(
@@ -346,6 +352,7 @@ async def test_confirm_route_rechecks_and_observes_post_submit_dedup(
         broker=broker,
         pending_reader=ledger.reader(),
         foreign_trace_reader=foreign_traces(),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     assert outcome.zero_order_reason is None
@@ -739,31 +746,65 @@ def test_the_two_position_sources_are_the_broker_read_and_nothing_else() -> None
         assert isinstance(value.func, ast.Attribute)
         assert value.func.attr == "non_dust_position_symbols"
 
+    # §36차 2항 이후 포지션 조립은 ``attribution.scope_positions`` 로 옮겨갔다.
+    # 옮겨간 곳에서도 **브로커 보유 행**을 순회해야 한다 — 귀속 원장은 「누구
+    # 것인가」만 답하고 포지션을 만들어 내지 못한다 (v1.6 ②).
+    attribution_tree = ast.parse(
+        (KR_PACKAGE / "attribution.py").read_text(encoding="utf-8")
+    )
+    scope = next(
+        node
+        for node in ast.walk(attribution_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "scope_positions"
+    )
+    iterated = {
+        name.id
+        for node in ast.walk(scope)
+        if isinstance(node, ast.For)
+        for name in ast.walk(node.iter)
+        if isinstance(name, ast.Name)
+    }
+    assert "positions" in iterated, (
+        "scope_positions stopped iterating the broker holdings snapshot"
+    )
+    assert not (iterated & PENDING_DERIVED_NAMES)
+
+    # 그리고 귀속 수량은 반드시 브로커 보유 수량으로 상한이 걸려야 한다.
+    capped = [
+        node
+        for node in ast.walk(scope)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "min"
+        and any(
+            isinstance(arg, ast.Attribute) and arg.attr == "quantity"
+            for arg in node.args
+        )
+    ]
+    assert capped, (
+        "scope_positions stopped capping the attributed quantity by the "
+        "broker-held quantity — 원장이 계좌에 없는 주식을 만들어 낼 수 있다"
+    )
+
+    # cycle.broker_state 는 그 결과만 §4 상한 입력으로 쓴다.
     cycle_tree = ast.parse((KR_PACKAGE / "cycle.py").read_text(encoding="utf-8"))
     func = next(
         node
         for node in ast.walk(cycle_tree)
         if isinstance(node, ast.FunctionDef) and node.name == "broker_state"
     )
-    iterated = {
-        inner.func.attr
+    cap_inputs = [
+        keyword.value
         for node in ast.walk(func)
-        if isinstance(node, ast.GeneratorExp)
-        for generator in node.generators
-        for inner in ast.walk(generator.iter)
-        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)
-    } | {
-        inner.attr
-        for node in ast.walk(func)
-        if isinstance(node, ast.GeneratorExp)
-        for generator in node.generators
-        for inner in ast.walk(generator.iter)
-        if isinstance(inner, ast.Attribute)
-    }
-    assert "positions" in iterated, (
-        "broker_state stopped building positions from the holdings snapshot"
-    )
-    assert not (iterated & PENDING_DERIVED_NAMES)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "position_symbols"
+    ]
+    assert cap_inputs, "broker_state stopped naming position_symbols"
+    for value in cap_inputs:
+        assert isinstance(value, ast.Attribute)
+        assert value.attr == "cap_position_symbols"
+        assert isinstance(value.value, ast.Name) and value.value.id == "scoped"
 
 
 @pytest.mark.asyncio
@@ -784,6 +825,7 @@ async def test_a_ledger_named_symbol_is_not_a_position(
         confirm=False,
         client=_FakeKrClient(stocks=[]),
         pending_reader=readable_pending("005930", "000660"),
+        attribution_reader=NO_ATTRIBUTION,
     )
 
     truth = outcome.record["broker_truth"]
@@ -807,7 +849,27 @@ def test_positions_are_built_from_holdings_even_when_pending_disagrees() -> None
             ),
         ),
     )
-    state = broker_state(fresh=fresh, own_pending=("005930",))
+    attribution = kr_attribution.OwnFillAttribution(
+        lots=(
+            kr_attribution.AttributedLot(
+                symbol="035720",
+                quantity=Decimal("10"),
+                average_price=Decimal("50000"),
+                buy_fill_rows=1,
+                sell_rows=0,
+            ),
+            # 🔴 원장이 이름을 대도 브로커가 보유를 보고하지 않은 심볼은 포지션이
+            # 되지 않는다 — v1.6 ② 는 귀속 게이트 이후에도 그대로다.
+            kr_attribution.AttributedLot(
+                symbol="005930",
+                quantity=Decimal("99"),
+                average_price=Decimal("70000"),
+                buy_fill_rows=1,
+                sell_rows=0,
+            ),
+        )
+    )
+    state = broker_state(fresh=fresh, own_pending=("005930",), attribution=attribution)
 
     assert [pos.symbol for pos in state.positions] == ["035720"]
     assert state.broker_truth.position_symbols == ("035720",)

--- a/tests/scripts/b0x/test_broker_truth_envelope.py
+++ b/tests/scripts/b0x/test_broker_truth_envelope.py
@@ -605,6 +605,7 @@ def test_kr_declares_its_deployment_figure_unreadable() -> None:
 
     from decimal import Decimal as D
 
+    from scripts.b0x.kr import attribution as kr_attribution
     from scripts.b0x.kr import mock as kr_mock
     from scripts.b0x.kr.cycle import broker_state
 
@@ -622,8 +623,6 @@ def test_kr_declares_its_deployment_figure_unreadable() -> None:
     )
     # §36차 2항: 보유가 자동으로 B0-X 것이 되지는 않는다 — 자기 원장 귀속이
     # 있어야 포지션이 된다. 귀속 10주 × 자기 체결단가 70,000.
-    from scripts.b0x.kr import attribution as kr_attribution
-
     attribution = kr_attribution.OwnFillAttribution(
         lots=(
             kr_attribution.AttributedLot(

--- a/tests/scripts/b0x/test_broker_truth_envelope.py
+++ b/tests/scripts/b0x/test_broker_truth_envelope.py
@@ -620,7 +620,25 @@ def test_kr_declares_its_deployment_figure_unreadable() -> None:
             ),
         ),
     )
-    state = broker_state(fresh=fresh)
+    # §36차 2항: 보유가 자동으로 B0-X 것이 되지는 않는다 — 자기 원장 귀속이
+    # 있어야 포지션이 된다. 귀속 10주 × 자기 체결단가 70,000.
+    from scripts.b0x.kr import attribution as kr_attribution
+
+    attribution = kr_attribution.OwnFillAttribution(
+        lots=(
+            kr_attribution.AttributedLot(
+                symbol="005930",
+                quantity=D("10"),
+                average_price=D("70000"),
+                buy_fill_rows=1,
+                sell_rows=0,
+            ),
+        )
+    )
+    assert broker_state(fresh=fresh).positions == (), (
+        "귀속 리더 미배선은 「전부 내 것」이 아니라 fail-closed 여야 한다"
+    )
+    state = broker_state(fresh=fresh, attribution=attribution)
     assert state.cumulative_deployment_readable is False
     # It is the cost basis, exactly — no fabricated cumulative figure.
     assert state.positions[0].invested_notional == D("700000")


### PR DESCRIPTION
## 왜

`kis_mock` 계좌에는 **B0-X 가 만들지 않은 legacy 보유 11종목**이 있다(2026-08-11 실측: non-dust 보유 11 · `b0xk-` 원장 행 **0**). 종전 confirm preflight 는 「보유가 하나라도 있으면 `unexpected_positions`」였고, 그래서 두 가지가 동시에 참이었다:

1. 이 계좌에서는 **영구히** 한 건도 제출할 수 없다 (2026-08-11 04:30 acceptance job 의 정지 사유 = `preflight_not_clean / unexpected_positions`).
2. 계약 v1.5 ③(「B0-X 물타기/매도 = 자기 보유에서만 파생」)과 **모순**이다 — 매도가 파생되려면 보유가 있어야 하는데, 보유가 있으면 preflight 가 막는다. 즉 매도측 confirm 은 첫 사이클뿐 아니라 영구히 도달 불가였다.

운영자 결정(§36차 2항) = **flatten 기각 · 귀속 기반 공존**. 선례 = US 랩의 correlation 분리 귀속(#1824).

## 무엇을

- **신규** `scripts/b0x/kr/attribution.py` — `review.kis_mock_order_ledger` 의 자기(`b0xk-`) **체결 증거**로 own/legacy 를 가른다. read-only, 쓰기 경로 없음.
- `_confirm_preflight_record` 의 `unexpected_positions` 제거 → 실패 사유는 **`attribution_unreadable`**(누구 것인지 모를 때)로 이동.
- `broker_state` 가 귀속 결과만 파생 입력으로 넘긴다. legacy 는 아티팩트에 **이름까지** 남지만(`positions.legacy_symbols`) 어떤 파생 입력에도 들어가지 않는다.
- 제출 경계 2차 방어 `assert_sell_is_own` — 자기 귀속 수량을 넘는 매도는 `LegacyPositionSellBlocked`.

### 오차 방향이 비대칭인 이유

과소 귀속 = 매도 못 함(안전) · 과대 귀속 = **legacy 매도 = 남의 포지션 처분**. 그래서 매수는 `lifecycle_state ∈ {fill, reconciled}` 만 가산, 매도는 **상태 무관 전량 차감**, 귀속 수량은 **브로커 보유 수량 상한**. 계약 v1.6 ③ 의 「과잉 차단 방향」과 같다.

### legacy 가 무엇에 들어가고 무엇에서 빠지는가 (§36차 2항이 위임한 판정)

| 항목 | 포함? | 근거 |
|---|---|---|
| 매도·물타기 파생 | ❌ | §36차 2항 리터럴 |
| §4 동시포지션·일일신규 상한 | ❌ | 11 ≥ cap 10 이라 포함하면 신규 진입 **영구 0** — 공존 결정이 무의미해진다. 🔴 대가 = 계좌는 legacy + 최대 10 B0-X 를 함께 진다. **§4 수치는 무변경** |
| NAV(kill 임계 기준) | ❌ (지분 비례 제외) | kill 이 `pct_of_nav` 이므로 legacy 를 넣으면 임계가 **넓어진다**. 귀속 불가 시 `nav = cash` 로 더 좁아진다 |
| 계좌 진실·아티팩트 | ✅ | 「무시」는 「삭제」가 아니다 |
| CONTAMINATED 판정 | 무변경 | 오염 = 다른 **writer**(비-`b0xk` correlation trace). 승인된 공존 보유는 다른 writer 가 아니다 |

## 검증

- `tests/scripts/b0x/kr/test_attribution_gate.py` — 필수 mutant 5종을 각각 주입해 격추 확인(①4 failed ②2 ③1 ④4 ⑤2, 원복 후 baseline green). 핵심 assert 반전 4건 전부 FAIL(= false-green 아님).
- `uv run pytest tests/scripts/b0x tests/services/kis_mock_runner -q` → **559 passed**.
- 🔴 **실환경 acceptance (2026-08-11 13:52 KST, KRX RTH 내, kis_mock)**: preflight **PASS**(legacy 11 보유가 있는 채로 — 게이트 교체가 실제로 동작), 신규 매수 1건 제출(000100 · 3주 · 79,500 KRW · 238,500 KRW ≤ §4 캡 300,000). 브로커가 `40910000 모의투자 주문이 불가한 계좌입니다` 로 **거절**(체결 없음, success=false). 제출 전 signal 원장 행 1건 기록됨.
- 🔴 **v1.6 dedup 실환경 최초 발화**: 제출 후 read-only 재파생에서 000100 이 `own_pending_order_exists` 로 차단됨(두 번째 제출 없음 — 두 번째 `--confirm` 은 *다른* 종목을 내보내므로 실행하지 않았다).

## 범위 밖 / 남는 것

- 🔴 `40910000` 은 계좌 자체가 모의주문 불가 상태라는 **브로커 증거**이며 코드 문제가 아니다 — 운영자 확인 필요(모의투자 참가 기간 등).
- envelope §4 수치 · AST 가드 · v1.6 dedup 로직 · MAX_TABLE_AGE · 라벨 · 지위 라벨(`OBSERVATION_DERIVATION_ONLY`) · crypto/US 경로 전부 무변경. live 계좌 접촉 0. 스케줄러 등록 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added position attribution for Korean-market holdings, distinguishing B0-X-owned shares from legacy holdings.
  * Added reporting for attribution status, owned and legacy position counts, and cap basis.
* **Risk Controls**
  * Prevented selling or averaging legacy or unattributed holdings.
  * Added safeguards limiting sells to attributed quantities.
  * Trading now fails closed when attribution data is unavailable or unreadable.
* **Documentation**
  * Updated Korean-market runbook guidance for coexistence of legacy and B0-X holdings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->