### PR TITLE
fix(order-proposals): scope order_proposal_void authority + atomic dispatch recheck (ROB-1238)

### DIFF
--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
+from app.mcp_server.caller_identity import get_caller_agent_id
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.alerts import send_approval_dispatch_alert
 from app.services.order_proposals.approval_window import ApprovalWindowDecision
@@ -48,6 +49,7 @@ from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalNotFound,
     OrderProposalUnsupportedTargetAction,
+    OrderProposalVoidNotAuthorized,
 )
 from app.services.order_proposals.redispatch import validate_proposal_redispatch
 from app.services.order_proposals.service import RungInput, check_action_capability
@@ -566,6 +568,10 @@ async def order_proposal_create(
                 retrospective_id=retrospective_id,
                 approval_issue_id=approval_issue_id,
                 supersedes_proposal_id=sup,
+                # ROB-1238: server-resolved caller identity, so `order_proposal_void`
+                # can later tell "the session that created this" from "some other
+                # lane". Never taken from a tool argument.
+                creator_agent_id=get_caller_agent_id(),
                 action=normalized_action,
                 target_broker_order_id=target_broker_order_id,
                 target_order_snapshot=(
@@ -667,6 +673,23 @@ async def order_proposal_list(
 
 
 async def order_proposal_void(proposal_id: str, reason: str) -> dict[str, Any]:
+    """Retire a proposal you created, or one the server confirms is dead.
+
+    Authorization is narrow by design (ROB-1238) -- proposals are a surface every
+    lane shares, so a broad void would let one session cancel another lane's live
+    proposal. Exactly three authorities are accepted:
+
+    * ``self_created`` -- the calling agent created this proposal. Ownership uses
+      the server-recorded MCP caller identity, not the ``proposer`` text field.
+    * ``server_loss_guard_invalid`` -- the server itself observed the loss-sell
+      guard reject this proposal during revalidation.
+    * ``server_expired`` -- ``valid_until`` has elapsed. Rungs converge to
+      ``expired`` (not ``voided``) here, because expiry is what was proven.
+
+    Anything else returns ``success=False`` with ``error="void_not_authorized"``
+    and the evidence that was considered. Retiring always clears the approval
+    nonce, so the Telegram approval button dies with the proposal.
+    """
     try:
         pid = uuid.UUID(proposal_id)
         normalized_reason = reason.strip()
@@ -679,6 +702,7 @@ async def order_proposal_void(proposal_id: str, reason: str) -> dict[str, Any]:
                 pid,
                 reason=normalized_reason,
                 now=now,
+                requester_agent_id=get_caller_agent_id(),
                 broker_evidence=_fetch_void_evidence,
             )
             group, rungs = await service.get_proposal(pid)
@@ -699,6 +723,13 @@ async def order_proposal_void(proposal_id: str, reason: str) -> dict[str, Any]:
             void_reason=result["void_reason"],
         )
         return result
+    except OrderProposalVoidNotAuthorized as exc:
+        return {
+            "success": False,
+            "error": exc.decision.reason_code,
+            "proposal_id": proposal_id,
+            "authorization": exc.decision.to_dict(),
+        }
     except (ValueError, OrderProposalError) as exc:
         return {"success": False, "error": str(exc)}
 

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -404,6 +404,24 @@ LANE_RECONCILE_ALLOWED: dict[str, frozenset[str]] = {
     "sell": RECONCILE_TOOLS,
 }
 
+# ROB-1238. `order_proposal_void` sits in PROPOSAL_LIFECYCLE_TOOLS, which is
+# unioned into MUTATION_TOOLS, but it was never in any lane's allowed set -- so
+# `blocked_actions` listed it in *every* lane and no session could retire a dead
+# proposal. Phantoms accumulated (8 rows on 07-27, 27 by 08-10), including a
+# loss-guard-violating BSX proposal still carrying a live approval button.
+#
+# The fix is scoped, not wholesale: only the proposal-led lanes get it, because
+# only they own proposals. discovery/bootstrap stay blocked.
+#
+# This is a *surface* allowance and nothing more. It does not decide what may be
+# voided -- `OrderProposalsService.void_proposal` fails closed unless the caller
+# created the proposal or the server itself confirmed expiry / a loss-guard
+# violation (see void_authorization.py). Widening this map cannot widen that.
+LANE_PROPOSAL_LIFECYCLE_ALLOWED: dict[str, frozenset[str]] = {
+    "buy": frozenset({"order_proposal_void"}),
+    "sell": frozenset({"order_proposal_void"}),
+}
+
 # Purpose text for discovery's legacy market execution injection.
 _MARKET_EXEC_PURPOSE: dict[str, str] = {
     "discovery": "execute buy on ranked winners via generic place_order (crypto/US limit)",
@@ -777,6 +795,7 @@ def build_route_plan(
     lane_preview = PREVIEW_TOOLS if lane == "discovery" else frozenset()
     lane_extra = LANE_EXTRA_ALLOWED.get(lane, frozenset())
     lane_reconcile = LANE_RECONCILE_ALLOWED.get(lane, frozenset())
+    lane_lifecycle = LANE_PROPOSAL_LIFECYCLE_ALLOWED.get(lane, frozenset())
     safe_lane_tools = (
         lane_tools - DIRECT_BROKER_MUTATION_TOOLS if proposal_led else lane_tools
     )
@@ -786,6 +805,7 @@ def build_route_plan(
         | lane_preview
         | lane_extra
         | lane_reconcile
+        | lane_lifecycle
         | set(READ_ONLY_ADVISORY_TOOLS)
     )
     allowed = allowed_candidates & registered_tools
@@ -836,6 +856,7 @@ __all__ = [
     "DIRECT_BROKER_MUTATION_TOOLS",
     "PROPOSAL_LED_TOOLS",
     "PROPOSAL_LIFECYCLE_TOOLS",
+    "LANE_PROPOSAL_LIFECYCLE_ALLOWED",
     "ORDER_PROPOSAL_READ_TOOLS",
     "PREVIEW_REVALIDATION_TOOLS",
     "RECONCILE_TOOLS",

--- a/app/services/order_proposals/errors.py
+++ b/app/services/order_proposals/errors.py
@@ -5,6 +5,13 @@ All writes go through OrderProposalsService; these are the domain errors it rais
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.services.order_proposals.void_authorization import (
+        VoidAuthorizationDecision,
+    )
+
 
 class OrderProposalError(Exception):
     """Base for all order_proposals domain errors."""
@@ -38,6 +45,35 @@ class OrderProposalNotFound(OrderProposalError):
 
 class OrderProposalDuplicate(OrderProposalError):
     """A proposal with the same proposal_id already exists."""
+
+
+class OrderProposalVoidNotAuthorized(OrderProposalError):
+    """The requester may not retire this proposal (ROB-1238).
+
+    Carries the pure ``VoidAuthorizationDecision`` so the MCP surface can return
+    a structured ``reason_code``/``detail`` instead of a bare string. Raised
+    whenever the requester neither created the proposal nor can point at a
+    server-confirmed expiry or loss-guard violation -- i.e. every attempt to
+    void another lane's live proposal.
+    """
+
+    def __init__(self, decision: VoidAuthorizationDecision) -> None:
+        super().__init__(decision.reason_code)
+        self.decision = decision
+
+
+class OrderProposalDispatchNoLongerAuthorized(OrderProposalError):
+    """The proposal stopped being dispatchable between recheck and submit.
+
+    Raised by the atomic pre-submit gate (ROB-1238) when a re-read under the
+    proposal row lock shows the proposal was voided, expired, superseded, or
+    marked ``no_resubmit`` after the approval token was minted. The approval
+    token is invalidated on this path so a stale Telegram button cannot retry.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 class OrderProposalUnsupportedTargetAction(OrderProposalError):

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -60,7 +60,11 @@ from app.services.order_proposals.buying_power import (
     default_buying_power_releaser,
     required_cash,
 )
-from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.errors import (
+    OrderProposalDispatchNoLongerAuthorized,
+    OrderProposalError,
+    OrderProposalInvalidStateTransition,
+)
 from app.services.order_proposals.service import (
     OrderProposalsService,
     proposal_approval_block_reason,
@@ -185,6 +189,60 @@ async def _pre_mutation_window_gate(
     )
 
 
+async def _pre_submit_lifecycle_gate(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    now_fn: Clock,
+) -> RungOutcome | None:
+    """Atomic last look at the proposal row before any broker mutation (ROB-1238).
+
+    ``revalidate_and_submit`` reads the group once and then awaits preview,
+    eligibility, buying-power and calendar I/O for every rung. ``group`` is a
+    snapshot from before all of that. A concurrent ``order_proposal_void`` --
+    a different session, a different transaction -- can retire the proposal in
+    that gap, and nothing downstream would notice: the submit would proceed off
+    the stale snapshot.
+
+    This re-reads the row ``FOR UPDATE`` and keeps that lock for the remainder
+    of the transaction, i.e. across the submit itself. So the check is not
+    merely "recent": no writer can interleave between the verdict and the send.
+    ``assert_dispatch_still_authorized`` also burns the approval nonce when it
+    refuses, so a stale Telegram card cannot be tapped into a retry.
+    """
+    try:
+        await service.assert_dispatch_still_authorized(
+            group.proposal_id,
+            now=now_fn(),
+            expected_nonce=group.approval_nonce,
+        )
+    except OrderProposalDispatchNoLongerAuthorized as exc:
+        try:
+            await service.transition_rung(
+                group.proposal_id, rung.rung_index, new_state="pending_approval"
+            )
+        except OrderProposalInvalidStateTransition:
+            # The concurrent writer that retired the proposal already moved this
+            # rung to a terminal state (voided/expired). That is the durable
+            # outcome we want; do not fight it back to pending_approval.
+            logger.info(
+                "proposal %s rung %s already terminal at lifecycle recheck (%s)",
+                group.proposal_id,
+                rung.rung_index,
+                exc.reason,
+            )
+        return RungOutcome(
+            rung.rung_index,
+            "guard_blocked",
+            {
+                "error": f"dispatch_no_longer_authorized:{exc.reason}",
+                "lifecycle_recheck": exc.reason,
+            },
+        )
+    return None
+
+
 async def _post_cancel_replace_window_gate(
     *,
     service: OrderProposalsService,
@@ -295,6 +353,26 @@ def _is_guard_blocked_preview(preview: dict[str, Any]) -> bool:
     error = str(preview.get("error") or "").lower()
     return error_code in _GUARD_ERROR_CODES or any(
         marker in error for marker in _GUARD_ERROR_MARKERS
+    )
+
+
+# ROB-1238: the strict subset of guard blocks that mean "this proposal's price
+# violates the avg-cost loss guard". Deliberately narrower than
+# _GUARD_ERROR_MARKERS -- insufficient balance, opposite-pending and stop-loss
+# cooldown are guard blocks too, but they are transient account conditions, not
+# proof that the proposal itself is invalid, and must not grant void authority.
+# Both messages this matches are emitted by evaluate_limit_sell_price_guard /
+# evaluate_market_sell_loss_guard, the single source of truth for the threshold
+# (order_validation.py); nothing here re-derives avg x 1.01.
+_LOSS_GUARD_ERROR_CODES = frozenset({"loss_sell_blocked"})
+_LOSS_GUARD_ERROR_MARKERS = ("avg_buy_price * 1.01",)
+
+
+def _is_loss_guard_preview(preview: dict[str, Any]) -> bool:
+    error_code = str(preview.get("error_code") or "").lower()
+    error = str(preview.get("error") or "").lower()
+    return error_code in _LOSS_GUARD_ERROR_CODES or any(
+        marker in error for marker in _LOSS_GUARD_ERROR_MARKERS
     )
 
 
@@ -1007,9 +1085,21 @@ async def _revalidate_place_rung(
         await service.transition_rung(
             proposal_id, rung_index, new_state="pending_approval"
         )
+        guard_blocked = _is_guard_blocked_preview(preview)
+        if guard_blocked and _is_loss_guard_preview(preview):
+            # ROB-1238: the server just proved this proposal violates the
+            # loss-sell guard. Record it so the row becomes retirable via the
+            # ``server_loss_guard_invalid`` void authority instead of surviving
+            # as a phantom behind a live approval button (BSX dd7a68d7).
+            await service.record_loss_guard_verdict(
+                proposal_id,
+                rung_index=rung_index,
+                error=str(preview.get("error") or ""),
+                now=now_fn(),
+            )
         return RungOutcome(
             rung_index,
-            "guard_blocked" if _is_guard_blocked_preview(preview) else "error",
+            "guard_blocked" if guard_blocked else "error",
             {"error": preview.get("error"), "preview": preview},
         )
 
@@ -1147,6 +1237,20 @@ async def _revalidate_place_rung(
             reservation=buying_power_reservation,
         )
         return window_outcome
+
+    lifecycle_outcome = await _pre_submit_lifecycle_gate(
+        service=service,
+        group=group,
+        rung=rung,
+        now_fn=now_fn,
+    )
+    if lifecycle_outcome is not None:
+        await _release_after_rejection(
+            buying_power_releaser=buying_power_releaser,
+            group=group,
+            reservation=buying_power_reservation,
+        )
+        return lifecycle_outcome
 
     await service.transition_rung(proposal_id, rung_index, new_state="approved")
     await service.transition_rung(proposal_id, rung_index, new_state="submitting")

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -47,9 +47,11 @@ from app.services.order_proposals.dispatch_contract import (
     build_membership_digest,
 )
 from app.services.order_proposals.errors import (
+    OrderProposalDispatchNoLongerAuthorized,
     OrderProposalError,
     OrderProposalNotFound,
     OrderProposalUnsupportedTargetAction,
+    OrderProposalVoidNotAuthorized,
 )
 from app.services.order_proposals.payload import (
     ProposalRungSpec,
@@ -59,6 +61,14 @@ from app.services.order_proposals.repository import OrderProposalRepository
 from app.services.order_proposals.target_order import (
     TargetOrderSnapshot,
     canonical_decimal,
+)
+from app.services.order_proposals.void_authorization import (
+    CREATOR_AGENT_ID_KEY,
+    LOSS_GUARD_VERDICT_KEY,
+    SERVER_LOSS_GUARD_SOURCE,
+    authorize_void,
+    extract_creator_agent_id,
+    extract_loss_guard_violation,
 )
 from app.services.trade_journal.trade_retrospective_service import (
     get_retrospective_by_id,
@@ -457,6 +467,7 @@ class OrderProposalsService:
         approval_issue_id: str | None = None,
         correlation_id: str | None = None,
         source_asof: dict | None = None,
+        creator_agent_id: str | None = None,
         supersedes_proposal_id: uuid.UUID | None = None,
         action: str | None = None,
         target_broker_order_id: str | None = None,
@@ -482,6 +493,15 @@ class OrderProposalsService:
         merged_source_asof = dict(source_asof or {})
         if normalized_target_snapshot is not None:
             merged_source_asof["target_order_snapshot"] = normalized_target_snapshot
+        # ROB-1238: ownership for the void authorization gate. Written here from
+        # the server-resolved MCP caller identity, never from a tool argument,
+        # and unconditionally overwritten so a caller-supplied ``source_asof``
+        # cannot pre-seed someone else's id. An unknown caller stores nothing,
+        # which leaves the row voidable only by a server-confirmed authority.
+        merged_source_asof.pop(CREATOR_AGENT_ID_KEY, None)
+        normalized_creator = (creator_agent_id or "").strip()
+        if normalized_creator:
+            merged_source_asof[CREATOR_AGENT_ID_KEY] = normalized_creator
         now = now or datetime.now(UTC)
         self._require_timezone_aware(now)
         defensive_floor = (
@@ -910,8 +930,17 @@ class OrderProposalsService:
         *,
         reason: str,
         now: datetime,
+        requester_agent_id: str | None,
         broker_evidence: Callable[..., Any] | None = None,
     ) -> list[OrderProposalRung]:
+        """Retire a proposal the requester is authorized to retire (ROB-1238).
+
+        ``requester_agent_id`` is keyword-required (pass ``None`` explicitly for
+        an unidentified caller) so no existing call site silently inherits
+        owner-level authority. See ``void_authorization`` for the rule; the
+        authority chosen there also decides whether rungs converge to
+        ``voided`` or to ``expired``.
+        """
         self._require_timezone_aware(now)
         reason = reason.strip()
         if not reason:
@@ -920,6 +949,18 @@ class OrderProposalsService:
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
+        # Authorize under the same row lock that the mutation below runs in, so
+        # the valid_until / loss-guard / ownership evidence cannot change between
+        # the decision and the writes it authorizes.
+        decision = authorize_void(
+            requester_agent_id=requester_agent_id,
+            creator_agent_id=extract_creator_agent_id(group.source_asof),
+            valid_until=group.valid_until,
+            now=now,
+            loss_guard_violation=extract_loss_guard_violation(group.source_asof),
+        )
+        if not decision.allowed:
+            raise OrderProposalVoidNotAuthorized(decision)
         rungs = await self._repo.list_rungs(group.id)
         allowed_states = _VOIDABLE_RUNG_STATES | {"unverified"}
         invalid_rung = next(
@@ -1065,12 +1106,17 @@ class OrderProposalsService:
                 )
             evidence_summary = " | broker_evidence: " + "; ".join(summaries)
 
-        audit_reason = reason + evidence_summary
+        audit_reason = f"{reason} [authority={decision.authority}]{evidence_summary}"
 
         voided_rungs = []
         for rung in rungs:
+            # ``unverified`` keeps ``voided_local_stale`` under every authority:
+            # that state records "the server proved the broker holds no order",
+            # which the authority does not change.
             target_state = (
-                "voided_local_stale" if rung.state == "unverified" else "voided"
+                "voided_local_stale"
+                if rung.state == "unverified"
+                else str(decision.terminal_state)
             )
             sm.assert_rung_transition(rung.state, target_state)
             audit_fields: dict[str, Any] = {
@@ -1089,6 +1135,91 @@ class OrderProposalsService:
             approval_nonce_used_at=now,
         )
         return voided_rungs
+
+    # -- ROB-1238 lifecycle safety ------------------------------------------
+    async def record_loss_guard_verdict(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        rung_index: int,
+        error: str | None,
+        now: datetime,
+    ) -> OrderProposal:
+        """Durably record that the server's own revalidation hit the loss guard.
+
+        This is the only writer of the ``loss_guard_verdict`` envelope that
+        ``authorize_void`` will accept, which is what makes
+        ``server_loss_guard_invalid`` a server-confirmed authority rather than a
+        caller assertion. Called from the revalidation guard-blocked branch: a
+        proposal like BSX dd7a68d7 (limit below avg x 1.01) becomes retirable
+        the moment the server observes the violation, instead of sitting
+        ``proposed`` behind a live approval button.
+        """
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        source_asof = dict(group.source_asof or {})
+        source_asof[LOSS_GUARD_VERDICT_KEY] = {
+            "violated": True,
+            "source": SERVER_LOSS_GUARD_SOURCE,
+            "observed_at": now.isoformat(),
+            "rung_index": rung_index,
+            "error": (str(error) if error is not None else "")[:500],
+        }
+        return await self._repo.update_group(group, source_asof=source_asof)
+
+    async def assert_dispatch_still_authorized(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        now: datetime,
+        expected_nonce: str | None = None,
+    ) -> OrderProposal:
+        """Re-read under the row lock and refuse a no-longer-dispatchable send.
+
+        ``revalidate_and_submit`` loads the group once and then walks its rungs
+        through preview, eligibility, buying-power and window gates -- each of
+        which awaits I/O. A concurrent ``order_proposal_void`` (its own session,
+        its own transaction) can land in that gap, so the in-memory group the
+        submit path is about to act on may already be retired. This re-reads the
+        row ``FOR UPDATE`` immediately before the broker mutation and holds that
+        lock through the submit, which is what makes the recheck atomic with
+        respect to the send rather than merely recent.
+
+        Failing here also clears the approval nonce, so the stale Telegram card
+        cannot be tapped into a second attempt.
+        """
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        reason = proposal_approval_block_reason(group)
+        if reason is None and group.no_resubmit:
+            reason = "proposal_no_resubmit"
+        if reason is None:
+            # Reuse the shared validity contract rather than a second expiry
+            # rule, so this gate can never disagree with the approval window
+            # about what "expired" means. The value it reads is the freshly
+            # locked row, which is the part the window gate could not see.
+            validity_block = valid_until_block(group.valid_until, now=now)
+            if validity_block is not None:
+                reason = f"proposal_{validity_block[1]}"
+        if reason is None and extract_loss_guard_violation(group.source_asof):
+            reason = "proposal_loss_guard_invalid"
+        if reason is None and expected_nonce is not None:
+            if group.approval_nonce != expected_nonce:
+                reason = "approval_nonce_superseded"
+        if reason is not None:
+            # Burn the approval surface before surfacing the refusal so the
+            # same token cannot be replayed into another dispatch attempt.
+            await self._repo.update_group(
+                group,
+                approval_nonce=None,
+                approval_nonce_used_at=now,
+            )
+            raise OrderProposalDispatchNoLongerAuthorized(reason)
+        return group
 
     # -- PR-2 helpers -------------------------------------------------------
     async def set_approval_nonce(

--- a/app/services/order_proposals/void_authorization.py
+++ b/app/services/order_proposals/void_authorization.py
@@ -1,0 +1,223 @@
+"""Pure void/expire authorization classifier for order proposals (ROB-1238).
+
+stdlib only — no broker/DB/network/clock imports. ``void_proposal`` calls
+``authorize_void`` before it mutates any rung; the caller supplies every input
+and the decision is a pure function of them, so the rule is testable without a
+session.
+
+Why this exists
+---------------
+``order_proposal_void`` was blocked in every ``route_request`` lane, so nobody
+could retire a phantom proposal (27 stale rows by 2026-08-10). The fix is NOT
+to open void wholesale: proposals are a lane-shared surface, and a broad
+allowance would let one session void another lane's live proposal.
+
+Authorization is therefore narrowed to three disjoint authorities, in
+precedence order:
+
+``self_created``
+    The requester is the agent that created the proposal. Ownership is compared
+    against ``source_asof["creator_agent_id"]``, which the *server* records from
+    the MCP caller-identity middleware at create time — never from a tool
+    argument, so a caller cannot assert someone else's identity.
+
+``server_loss_guard_invalid``
+    The server itself observed the proposal fail the loss-sell guard during a
+    dispatch-time revalidation and durably recorded that verdict. Caller-supplied
+    evidence (e.g. ``lot_context``) never grants this authority.
+
+``server_expired``
+    The server compares ``valid_until`` against ``now``. This is the lazy
+    convergence path that replaces a sweep scheduler: an operator (or any
+    session) touching a long-dead proposal retires it, and the retirement state
+    is ``expired`` rather than ``voided`` because expiry is what the server
+    actually proved.
+
+Anything else is refused. A live proposal belonging to another lane has no
+authority and stays untouchable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+VoidAuthority = Literal[
+    "self_created",
+    "server_loss_guard_invalid",
+    "server_expired",
+]
+
+#: Terminal rung/group state each authority converges to.
+_AUTHORITY_TERMINAL_STATE: dict[str, str] = {
+    "self_created": "voided",
+    "server_loss_guard_invalid": "voided",
+    "server_expired": "expired",
+}
+
+#: The only ``source`` value that makes a recorded loss-guard verdict
+#: server-confirmed. Anything else (including a caller-injected payload that
+#: guesses at the key name) is treated as absent.
+SERVER_LOSS_GUARD_SOURCE = "server_revalidation"
+
+#: ``source_asof`` keys this module reads. Kept here so the service and the
+#: tests agree on one spelling.
+CREATOR_AGENT_ID_KEY = "creator_agent_id"
+LOSS_GUARD_VERDICT_KEY = "loss_guard_verdict"
+
+
+@dataclass(frozen=True)
+class VoidAuthorizationDecision:
+    """Outcome of the void authorization check."""
+
+    allowed: bool
+    authority: VoidAuthority | None
+    terminal_state: str | None
+    reason_code: str
+    detail: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "allowed": self.allowed,
+            "authority": self.authority,
+            "terminal_state": self.terminal_state,
+            "reason_code": self.reason_code,
+            "detail": dict(self.detail),
+        }
+
+
+def _clean(value: object) -> str | None:
+    """Normalize an identity to a comparable, non-empty string."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def extract_creator_agent_id(source_asof: object) -> str | None:
+    """Read the server-recorded creator identity out of ``source_asof``."""
+    if not isinstance(source_asof, dict):
+        return None
+    return _clean(source_asof.get(CREATOR_AGENT_ID_KEY))
+
+
+def extract_loss_guard_violation(source_asof: object) -> dict[str, str] | None:
+    """Return the server-recorded loss-guard violation, if there is one.
+
+    Returns ``None`` unless the stored envelope is a dict that both marks
+    ``violated is True`` and carries the server's own ``source`` marker. A
+    truthy-but-not-``True`` value (``"yes"``, ``1``) does not count: this
+    authority permits a mutation, so it fails closed on anything ambiguous.
+    """
+    if not isinstance(source_asof, dict):
+        return None
+    envelope = source_asof.get(LOSS_GUARD_VERDICT_KEY)
+    if not isinstance(envelope, dict):
+        return None
+    if envelope.get("violated") is not True:
+        return None
+    if _clean(envelope.get("source")) != SERVER_LOSS_GUARD_SOURCE:
+        return None
+    detail = {"loss_guard_source": SERVER_LOSS_GUARD_SOURCE}
+    for key in ("observed_at", "rung_index", "error"):
+        value = envelope.get(key)
+        if value is not None:
+            detail[f"loss_guard_{key}"] = str(value)
+    return detail
+
+
+def is_server_confirmed_expired(
+    valid_until: datetime | None,
+    *,
+    now: datetime,
+) -> bool:
+    """True when the server can prove the approval window has elapsed.
+
+    A proposal with no ``valid_until`` is never expired by this rule — absence
+    of a deadline is not evidence that one passed.
+    """
+    if valid_until is None:
+        return False
+    if valid_until.tzinfo is None or now.tzinfo is None:
+        raise ValueError("valid_until and now must be timezone-aware")
+    return now >= valid_until
+
+
+def authorize_void(
+    *,
+    requester_agent_id: str | None,
+    creator_agent_id: str | None,
+    valid_until: datetime | None,
+    now: datetime,
+    loss_guard_violation: dict[str, str] | None = None,
+) -> VoidAuthorizationDecision:
+    """Decide whether this requester may retire this proposal.
+
+    ``requester_agent_id`` and ``creator_agent_id`` must both be server-resolved.
+    When either is unknown, ownership cannot be established and only the
+    server-confirmed authorities remain — an unauthenticated caller can still
+    retire provably-dead rows but can never touch a live one.
+    """
+    requester = _clean(requester_agent_id)
+    creator = _clean(creator_agent_id)
+
+    if requester is not None and creator is not None and requester == creator:
+        return _allow(
+            "self_created",
+            {"requester_agent_id": requester, "creator_agent_id": creator},
+        )
+
+    if loss_guard_violation:
+        return _allow("server_loss_guard_invalid", dict(loss_guard_violation))
+
+    if is_server_confirmed_expired(valid_until, now=now):
+        return _allow(
+            "server_expired",
+            {
+                "valid_until": valid_until.isoformat() if valid_until else "",
+                "observed_at": now.isoformat(),
+            },
+        )
+
+    return VoidAuthorizationDecision(
+        allowed=False,
+        authority=None,
+        terminal_state=None,
+        reason_code="void_not_authorized",
+        detail={
+            "requester_agent_id": requester or "unknown",
+            "creator_agent_id": creator or "unknown",
+            "valid_until": valid_until.isoformat() if valid_until else "none",
+            "observed_at": now.isoformat(),
+            "hint": (
+                "void is limited to a proposal you created, or one the server "
+                "has itself confirmed expired or loss-guard-invalid"
+            ),
+        },
+    )
+
+
+def _allow(
+    authority: VoidAuthority, detail: dict[str, str]
+) -> VoidAuthorizationDecision:
+    return VoidAuthorizationDecision(
+        allowed=True,
+        authority=authority,
+        terminal_state=_AUTHORITY_TERMINAL_STATE[authority],
+        reason_code=f"authorized:{authority}",
+        detail=detail,
+    )
+
+
+__all__ = [
+    "CREATOR_AGENT_ID_KEY",
+    "LOSS_GUARD_VERDICT_KEY",
+    "SERVER_LOSS_GUARD_SOURCE",
+    "VoidAuthority",
+    "VoidAuthorizationDecision",
+    "authorize_void",
+    "extract_creator_agent_id",
+    "extract_loss_guard_violation",
+    "is_server_confirmed_expired",
+]

--- a/docs/runbooks/order-proposal-void-authorization.md
+++ b/docs/runbooks/order-proposal-void-authorization.md
@@ -1,0 +1,156 @@
+# order_proposal_void 권한 계약 (ROB-1238)
+
+`order_proposal_void` 는 **전 lane 에서 blocked** 였다. 그래서 세션이 죽은 제안을 하나도
+정리하지 못했고, 유령 proposed/resting 제안이 **07-27 8건 → 08-10 27건** 으로 누적됐다.
+그중 BSX 제안 `dd7a68d7` 은 loss guard 위반가(평단×1.01 = 48.48 인데 48.40)인데도
+`proposed` 로 3주를 생존했고 **텔레그램 승인 버튼이 살아 있었다**.
+
+이 문서는 그 수리의 계약이다. 🔴 **수리는 "void 전면 개방"이 아니다.**
+
+## 1. 왜 전 lane 이 막혔나 (근본 원인)
+
+`order_proposal_void` ∈ `PROPOSAL_LIFECYCLE_TOOLS` → `MUTATION_TOOLS` 에 union 된다.
+그런데 `build_route_plan` 의 `allowed_candidates` 어디에도 들어 있지 않았다:
+
+```
+blocked = (MUTATION_TOOLS & registered_tools) - allowed
+```
+
+→ 모든 lane 의 `blocked_actions` 에 등장. 수렴 경로가 아예 없었다.
+
+## 2. 무엇을 열었나 — 표면 vs 권한
+
+두 층을 분리해서 읽어야 한다.
+
+| 층 | 파일 | 역할 |
+|---|---|---|
+| **표면** | `route_request_lanes.LANE_PROPOSAL_LIFECYCLE_ALLOWED` | buy/sell(proposal-led) lane 에서만 도구 노출. discovery/bootstrap 은 여전히 blocked |
+| **권한** | `order_proposals/void_authorization.py` + `service.void_proposal` | 🔴 **무엇을 void 할 수 있는지의 fail-closed 판정** |
+
+🔴 **표면을 넓혀도 권한은 넓어지지 않는다.** `LANE_PROPOSAL_LIFECYCLE_ALLOWED` 를 전 lane 으로
+바꿔도 남의 lane 제안은 여전히 못 건드린다. 권한은 서비스 레이어가 단독으로 판정한다.
+
+## 3. 권한 3종 (이외 전부 거부)
+
+`authorize_void` 는 순수 함수(stdlib only, DB/네트워크/시계 없음)다. 우선순위 순:
+
+| authority | 조건 | 종착 상태 |
+|---|---|---|
+| `self_created` | 요청자 == 제안 생성자 | `voided` |
+| `server_loss_guard_invalid` | 서버 자신의 revalidation 이 loss-sell guard 위반을 관측·기록 | `voided` |
+| `server_expired` | `now >= valid_until` (`valid_until_block` 과 동일 규칙) | 🔴 `expired` |
+
+`server_expired` 가 `voided` 가 아니라 **`expired`** 로 가는 이유: 서버가 증명한 것은 만료다.
+`voided` 로 기록하면 죽은 이유를 오보한다.
+
+**그 외 = `void_not_authorized`.** 남의 lane 의 **살아 있는** 제안은 불가침이다.
+
+### 소유권은 위조 불가
+
+- 생성자 id 는 `source_asof["creator_agent_id"]` 에 **서버가** 기록한다. 출처는
+  `CallerIdentityMiddleware` 가 푼 MCP caller identity 이며, **도구 인자가 아니다**.
+- `create_proposal` 은 호출자가 넘긴 `source_asof` 의 `creator_agent_id` 를 **먼저 제거**한 뒤
+  서버 값을 넣는다 → pre-seed 위조 차단.
+- 🔴 `proposer` 텍스트 필드는 소유권 근거가 **아니다** (자유 입력).
+- 요청자 id 가 `None` 이면 self 권한 없음. 생성자 id 가 `None`(유령 27건 등 legacy 행)이어도
+  `None == None` 로 소유권이 성립하지 않는다.
+
+### loss guard 판정은 재구현이 아니다
+
+임계값(평단×1.01)은 `order_validation.evaluate_limit_sell_price_guard` /
+`evaluate_market_sell_loss_guard` 단일 소스에 남아 있다. ROB-1238 은 **그 결과를 기록만** 한다:
+revalidation 이 preview 실패를 loss-guard 로 분류하면
+`service.record_loss_guard_verdict` 가 `source_asof["loss_guard_verdict"]` 에
+`{violated: true, source: "server_revalidation", ...}` 를 남긴다.
+
+🔴 `extract_loss_guard_violation` 은 `violated is True` **그리고** `source ==
+"server_revalidation"` 일 때만 인정한다. 호출자가 주입한 payload·`"yes"` 같은 truthy 값은
+전부 무시(fail-closed).
+
+🔴 잔고부족·opposite-pending·stop-loss cooldown 은 guard block 이지만 **loss guard 가 아니다**
+(`_LOSS_GUARD_ERROR_MARKERS` 는 `_GUARD_ERROR_MARKERS` 보다 좁다). 계좌 상태이지 제안 자체의
+무효 증거가 아니므로 void 권한을 주지 않는다.
+
+## 4. lazy 설계 — 🔴 스케줄러 0
+
+수렴은 **조회·dispatch 시점 판정**으로만 이뤄진다. cron·launchd·TaskIQ·Prefect·APScheduler
+**등록이 없다**.
+
+- 만료 제안은 누군가 `order_proposal_void` 를 호출하는 순간 `server_expired` 권한으로 `expired` 전이.
+- dispatch 시점에는 `assert_dispatch_still_authorized` 가 판정.
+- 기존 `app/tasks/order_proposal_expiry_tasks.py`(ROB-897)는 **그대로 scheduleless** — 이 PR 은
+  건드리지 않았다.
+
+`tests/services/order_proposals/test_void_authorization.py::test_no_scheduler_registration_in_lifecycle_modules`
+가 4개 lifecycle 모듈의 import 를 AST 로 스캔해 이를 고정한다.
+
+## 5. dispatch 직전 원자적 재검증
+
+`revalidate_and_submit` 은 group 을 **한 번** 읽고, 그 스냅샷으로 rung 별 preview·eligibility·
+buying-power·calendar I/O 를 전부 await 한다. 그 사이에 다른 세션의 `order_proposal_void`
+(별도 session·별도 트랜잭션)가 끼어들 수 있고, 기존 코드는 그걸 **보지 못한 채** 전송했다.
+
+`_pre_submit_lifecycle_gate` 를 마지막 window gate 와 submit 사이에 넣었다:
+
+```
+… preview → eligibility → buying power → window gate
+  → [assert_dispatch_still_authorized: SELECT … FOR UPDATE]   ← 여기
+  → approved → submitting → 브로커 전송
+```
+
+🔴 **원자성 근거**: `assert_dispatch_still_authorized` 는 행을 `FOR UPDATE` 로 다시 읽고,
+그 락은 **트랜잭션 끝까지**(= submit 을 넘어서) 유지된다. 판정과 전송 사이에 다른 writer 가
+끼어들 수 없다. "최근에 확인했다"가 아니라 "확인 이후 바뀔 수 없다"이다.
+
+재검증 항목 4종 (하나라도 걸리면 fail-closed):
+
+1. `proposal_approval_block_reason` — voided/expired/superseded/terminal
+2. `no_resubmit`
+3. `valid_until` — 🔴 **새 규칙을 만들지 않고** 공용 `valid_until_block` 재사용
+4. 소유권 = 승인 토큰 동일성 (`approval_nonce`)
+5. 서버 확정 loss-guard 위반
+
+🔴 **거부 시 승인 토큰 무효화**: `approval_nonce=None`, `approval_nonce_used_at=now`.
+그래서 낡은 텔레그램 카드를 다시 눌러도 재시도가 되지 않는다. `void_proposal` 도 동일하게
+nonce 를 지운다 → 제안이 죽으면 승인 버튼도 같이 죽는다.
+
+## 6. 운영 절차
+
+### 유령 제안 정리
+
+```
+order_proposal_list(lifecycle_state="proposed")     # read-only, 후보 확인
+order_proposal_void(proposal_id=..., reason="phantom cleanup")
+```
+
+- 만료분은 `expired` 로 수렴하고 `void_reason` 에 `[authority=server_expired]` 가 남는다.
+- 살아 있는 남의 lane 제안은 `success=false, error="void_not_authorized"` +
+  `authorization.detail`(고려된 증거)로 거부된다. 🔴 **우회 금지** — 소유 세션에 릴레이하라.
+
+### BSX 류(loss guard 위반) 정리
+
+승인 탭이 한 번이라도 revalidation 을 돌렸다면 verdict 가 기록되어 즉시 void 가능하다.
+아직 아니라면 `valid_until` 경과를 기다리거나 소유 세션이 직접 void 한다.
+🔴 dispatch 는 verdict 기록 시점부터 이미 fail-closed 이므로 **오탭해도 주문은 안 나간다**.
+
+## 7. 불변
+
+- 🔴 브로커/계좌 mutation **0** — 이 경로는 로컬 DB 상태 전이만 한다.
+  `void_proposal` 의 `unverified` 분기는 기존 broker-absence **read** 증거 규약을 그대로 유지한다.
+- 🔴 스케줄러 등록 **0**.
+- `scripts/b0x/**` 무접촉. B0-X 관측 수치 불변.
+- migration **0** — `source_asof`(기존 JSONB) 만 사용, 신규 컬럼 없음.
+
+## 8. 감수한 구멍 (정직하게)
+
+- 🔴 `valid_until` 이 `None` 인 행은 `server_expired` 로 수렴하지 않는다. 마감이 없다는 사실은
+  마감이 지났다는 증거가 아니다. 그런 행은 소유 세션만 정리할 수 있다.
+- 🔴 legacy 유령 행에는 `creator_agent_id` 가 없다. 만료됐다면 누구나 정리할 수 있지만,
+  만료도 안 됐고 loss-guard 위반도 아니면 **아무도 못 지운다**(설계상 의도 — 살아 있을지도
+  모르는 남의 제안을 함부로 죽이지 않는다).
+- 🔴 `_pre_submit_lifecycle_gate` 는 place 경로에 배선돼 있다. cancel/replace 경로는 브로커
+  target 대조(`acquire_target_mutation_lock` + target snapshot)로 방어되지만 동일 gate 는
+  타지 않는다 — 후속 작업.
+- 🔴 caller identity 는 HTTP 헤더(`x-paperclip-agent-id`) 또는 env fallback 이다. 같은
+  fallback 을 공유하는 두 세션은 서로를 소유자로 본다. 세션 분리가 필요하면 헤더를 세션별로
+  줘야 한다.

--- a/tests/services/order_proposals/test_approval_window.py
+++ b/tests/services/order_proposals/test_approval_window.py
@@ -23,6 +23,7 @@ from app.services.order_proposals.approval_window import (
     evaluate_approval_window,
     evaluate_approval_window_boundary,
 )
+from app.services.order_proposals.approval_window_contract import valid_until_block
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
     ApprovalDispatchState,
@@ -31,10 +32,22 @@ from app.services.order_proposals.dispatch_contract import (
     build_membership_digest,
     build_proposal_dispatch_binding,
 )
-from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.errors import (
+    OrderProposalDispatchNoLongerAuthorized,
+    OrderProposalError,
+)
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
-from app.services.order_proposals.service import OrderProposalsService
+from app.services.order_proposals.service import (
+    OrderProposalsService,
+    proposal_approval_block_reason,
+)
 from app.services.order_proposals.target_order import TargetOrderSnapshot
+from app.services.order_proposals.void_authorization import (
+    LOSS_GUARD_VERDICT_KEY,
+    SERVER_LOSS_GUARD_SOURCE,
+    extract_loss_guard_violation,
+)
+from tests.services.order_proposals.window_fakes import allow_known_session
 
 
 def _group(
@@ -886,6 +899,7 @@ class _FakeRevalidationService:
             approved_by_telegram_user_id=None,
             approved_at=None,
             commit_lease_until=None,
+            no_resubmit=False,
         )
         self.rung = SimpleNamespace(
             rung_index=0,
@@ -900,6 +914,8 @@ class _FakeRevalidationService:
         self.cancelled_calls = 0
         self.nonce_consumes = 0
         self.allow_nonce_consume = False
+        self.lifecycle_recheck_calls = 0
+        self.no_resubmit = False
 
     async def get_proposal(self, proposal_id):
         assert proposal_id == self.group.proposal_id
@@ -949,6 +965,52 @@ class _FakeRevalidationService:
 
     async def acquire_target_mutation_lock(self, group):
         assert group is self.group
+
+    async def record_loss_guard_verdict(self, proposal_id, *, rung_index, error, now):
+        assert proposal_id == self.group.proposal_id
+        self.group.source_asof = {
+            **(self.group.source_asof or {}),
+            LOSS_GUARD_VERDICT_KEY: {
+                "violated": True,
+                "source": SERVER_LOSS_GUARD_SOURCE,
+                "observed_at": now.isoformat(),
+                "rung_index": rung_index,
+                "error": str(error or ""),
+            },
+        }
+        return self.group
+
+    async def assert_dispatch_still_authorized(
+        self, proposal_id, *, now, expected_nonce=None
+    ):
+        """Mirror the real gate against this fake's mutable group (ROB-1238).
+
+        Deliberately re-reads ``self.group`` at call time rather than closing
+        over a snapshot, so a test that retires the proposal mid-flight
+        reproduces the production race.
+        """
+        assert proposal_id == self.group.proposal_id
+        self.lifecycle_recheck_calls += 1
+        reason = proposal_approval_block_reason(self.group)
+        if reason is None and getattr(self.group, "no_resubmit", False):
+            reason = "proposal_no_resubmit"
+        if reason is None:
+            validity_block = valid_until_block(self.group.valid_until, now=now)
+            if validity_block is not None:
+                reason = f"proposal_{validity_block[1]}"
+        if reason is None and extract_loss_guard_violation(self.group.source_asof):
+            reason = "proposal_loss_guard_invalid"
+        if (
+            reason is None
+            and expected_nonce is not None
+            and self.group.approval_nonce != expected_nonce
+        ):
+            reason = "approval_nonce_superseded"
+        if reason is not None:
+            self.group.approval_nonce = None
+            self.group.approval_nonce_used_at = now
+            raise OrderProposalDispatchNoLongerAuthorized(reason)
+        return self.group
 
     async def preflight_published_proposal_callback(self, proposal_id, *, callback):
         assert proposal_id == self.group.proposal_id
@@ -1952,7 +2014,10 @@ async def test_transport_hook_rechecks_after_all_preview_work_before_http():
 
     initial = await evaluator(service.group, now=started)
     service.group.source_asof = {"approval_window_policy_stamp": initial.policy_stamp}
-    clock_values = iter((*([started] * 9), boundary))
+    # ROB-1238 added one clock read: the pre-submit lifecycle recheck samples
+    # `now_fn()` between the last window gate and the submit. The boundary value
+    # still has to land on the transport pre-send hook, so shift by one.
+    clock_values = iter((*([started] * 10), boundary))
     outcomes = await revalidate_and_submit(
         service=service,
         proposal_id=service.group.proposal_id,
@@ -2511,3 +2576,163 @@ async def test_default_execution_adapter_threads_transport_hook(
         )
 
     assert transport_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# ROB-1238: pre-submit lifecycle recheck + loss-guard verdict recording
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_void_between_preview_and_submit_aborts_the_send():
+    """MUTANT atomicity: retire the proposal mid-flight; nothing may reach the broker.
+
+    `revalidate_and_submit` snapshots the group once, then awaits preview,
+    eligibility and calendar work per rung. Without a re-read under the row lock
+    a void landing in that gap is invisible and the submit proceeds anyway.
+    """
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    service = _FakeRevalidationService(valid_until=now + timedelta(days=2))
+    broker_http_calls = 0
+
+    async def place(**kwargs):
+        nonlocal broker_http_calls
+        if kwargs["dry_run"]:
+            # A concurrent `order_proposal_void` commits while the preview is
+            # still in flight.
+            service.group.lifecycle_state = "voided"
+            service.group.no_resubmit = True
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "100",
+                "quantity": "1",
+            }
+        broker_http_calls += 1
+        raise AssertionError("submit must not run after a concurrent void")
+
+    initial = await allow_known_session(service.group, now=now)
+    service.group.source_asof = {"approval_window_policy_stamp": initial.policy_stamp}
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=now,
+        place_order_fn=place,
+        correlation_mint=lambda **kwargs: "corr-never-sent",
+        window_evaluator=allow_known_session,
+        expected_policy_stamp=initial.policy_stamp,
+        now_fn=lambda: now,
+    )
+
+    assert broker_http_calls == 0
+    assert [outcome.result for outcome in outcomes] == ["guard_blocked"]
+    assert outcomes[0].detail["lifecycle_recheck"] == "proposal_terminal:voided"
+    assert service.lifecycle_recheck_calls == 1
+    # The approval token is burned, so the stale card cannot be tapped again.
+    assert service.group.approval_nonce is None
+    assert "submitting" not in service.transitions
+
+
+@pytest.mark.asyncio
+async def test_healthy_proposal_still_submits_through_the_lifecycle_gate():
+    """The new gate must not block the happy path."""
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    service = _FakeRevalidationService(valid_until=now + timedelta(days=2))
+    submits = 0
+
+    async def place(**kwargs):
+        nonlocal submits
+        if kwargs["dry_run"]:
+            return {
+                "success": True,
+                "approval_hash": "fresh",
+                "price": "100",
+                "quantity": "1",
+            }
+        submits += 1
+        return {
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "broker-1",
+            "correlation_id": "corr-1",
+            "idempotency_key": "idem-1",
+            "approval_hash_digest": "digest-1",
+        }
+
+    initial = await allow_known_session(service.group, now=now)
+    service.group.source_asof = {"approval_window_policy_stamp": initial.policy_stamp}
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=now,
+        place_order_fn=place,
+        correlation_mint=lambda **kwargs: "corr-1",
+        window_evaluator=allow_known_session,
+        expected_policy_stamp=initial.policy_stamp,
+        now_fn=lambda: now,
+    )
+
+    assert submits == 1
+    assert service.lifecycle_recheck_calls == 1
+    assert [outcome.result for outcome in outcomes] != ["guard_blocked"]
+
+
+@pytest.mark.asyncio
+async def test_loss_guard_preview_records_a_server_confirmed_verdict():
+    """MUTANT BSX: the server must durably record the violation it just observed."""
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    service = _FakeRevalidationService(valid_until=now + timedelta(days=2))
+
+    async def place(**kwargs):
+        assert kwargs["dry_run"] is True
+        return {
+            "success": False,
+            "error": "Sell price 48.4 below minimum (avg_buy_price * 1.01 = 48.48)",
+        }
+
+    initial = await allow_known_session(service.group, now=now)
+    service.group.source_asof = {"approval_window_policy_stamp": initial.policy_stamp}
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=now,
+        place_order_fn=place,
+        correlation_mint=lambda **kwargs: "corr-never-sent",
+        window_evaluator=allow_known_session,
+        expected_policy_stamp=initial.policy_stamp,
+        now_fn=lambda: now,
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["guard_blocked"]
+    assert extract_loss_guard_violation(service.group.source_asof) is not None
+
+
+@pytest.mark.asyncio
+async def test_transient_guard_preview_records_no_loss_guard_verdict():
+    """A non-loss-guard block must not mint void authority."""
+    now = datetime(2026, 7, 22, 14, 0, tzinfo=UTC)
+    service = _FakeRevalidationService(valid_until=now + timedelta(days=2))
+
+    async def place(**kwargs):
+        assert kwargs["dry_run"] is True
+        return {"success": False, "error": "opposite pending order exists"}
+
+    initial = await allow_known_session(service.group, now=now)
+    service.group.source_asof = {"approval_window_policy_stamp": initial.policy_stamp}
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=service.group.proposal_id,
+        now=now,
+        place_order_fn=place,
+        correlation_mint=lambda **kwargs: "corr-never-sent",
+        window_evaluator=allow_known_session,
+        expected_policy_stamp=initial.policy_stamp,
+        now_fn=lambda: now,
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["guard_blocked"]
+    assert extract_loss_guard_violation(service.group.source_asof) is None

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -112,6 +112,12 @@ def _target_snapshot_payload(**overrides):
     return payload
 
 
+# ROB-1238: void authority requires a server-recorded creator identity. These
+# fixtures create as the owner so the existing void tests keep exercising the
+# broker-evidence branch rather than tripping the new authorization gate.
+_TEST_OWNER_AGENT = "test-owner-agent"
+
+
 def _target_action_create_kwargs(action: str, **overrides):
     kwargs = {
         "symbol": "KRW-AVAX",
@@ -124,6 +130,7 @@ def _target_action_create_kwargs(action: str, **overrides):
         "target_broker_order_id": "manual-upbit-1",
         "target_order_snapshot": _target_snapshot_payload(),
         "rungs": [RungInput(0, "sell", Decimal("3.5"), Decimal("42000"), None)],
+        "creator_agent_id": _TEST_OWNER_AGENT,
     }
     kwargs.update(overrides)
     return kwargs
@@ -374,6 +381,8 @@ async def test_replace_persists_target_snapshot_and_allows_independent_proposals
     assert first.source_asof == {
         "origin": "manual",
         "target_order_snapshot": _target_snapshot_payload(),
+        # ROB-1238: server-recorded ownership for the void authorization gate.
+        "creator_agent_id": _TEST_OWNER_AGENT,
     }
     assert first.payload_hash != second.payload_hash
 
@@ -394,6 +403,7 @@ async def _create_single_rung(
         order_type="limit",
         proposer="p",
         rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        creator_agent_id=_TEST_OWNER_AGENT,
     )
     await db_session.commit()
     return service, group
@@ -1059,6 +1069,7 @@ async def test_terminal_group_blocks_both_approval_nonce_consumers(db_session):
     await svc.void_proposal(
         group.proposal_id,
         reason="operator void",
+        requester_agent_id=_TEST_OWNER_AGENT,
         now=terminalized_at,
     )
 
@@ -1227,7 +1238,10 @@ async def test_void_refuses_unverified_rung_without_partial_mutation(db_session)
     )
     with pytest.raises(OrderProposalError, match="cannot void"):
         await service.void_proposal(
-            group.proposal_id, reason="operator cleanup", now=datetime.now(UTC)
+            group.proposal_id,
+            reason="operator cleanup",
+            now=datetime.now(UTC),
+            requester_agent_id=_TEST_OWNER_AGENT,
         )
 
 
@@ -1267,6 +1281,7 @@ async def test_void_unverified_with_absent_broker_evidence_records_audit(db_sess
     rows = await service.void_proposal(
         group.proposal_id,
         reason="operator cleanup",
+        requester_agent_id=_TEST_OWNER_AGENT,
         now=now,
         broker_evidence=broker_evidence,
     )
@@ -1326,6 +1341,7 @@ async def test_void_unverified_refuses_when_accepted_toss_ledger_row_exists(db_s
         await service.void_proposal(
             group.proposal_id,
             reason="operator cleanup",
+            requester_agent_id=_TEST_OWNER_AGENT,
             now=now,
             broker_evidence=broker_evidence,
         )
@@ -1376,6 +1392,7 @@ async def test_void_unverified_ignores_rejected_toss_ledger_without_order_id(
     rows = await service.void_proposal(
         group.proposal_id,
         reason="operator cleanup",
+        requester_agent_id=_TEST_OWNER_AGENT,
         now=now,
         broker_evidence=broker_evidence,
     )
@@ -1412,6 +1429,7 @@ async def test_void_unverified_refuses_existing_broker_order(db_session, broker_
         await service.void_proposal(
             group.proposal_id,
             reason="operator cleanup",
+            requester_agent_id=_TEST_OWNER_AGENT,
             now=now,
             broker_evidence=broker_evidence,
         )
@@ -1439,6 +1457,7 @@ async def test_void_unverified_refuses_broker_lookup_failure(db_session, error):
         await service.void_proposal(
             group.proposal_id,
             reason="operator cleanup",
+            requester_agent_id=_TEST_OWNER_AGENT,
             now=now,
             broker_evidence=broker_evidence,
         )
@@ -1466,6 +1485,7 @@ async def test_void_unverified_refuses_during_broker_settlement_grace(db_session
         await service.void_proposal(
             group.proposal_id,
             reason="operator cleanup",
+            requester_agent_id=_TEST_OWNER_AGENT,
             now=now,
             broker_evidence=broker_evidence,
         )
@@ -1486,7 +1506,10 @@ async def test_void_terminal_rung_still_refused(db_session, terminal_state):
 
     with pytest.raises(OrderProposalError, match="cannot void proposal"):
         await service.void_proposal(
-            group.proposal_id, reason="operator cleanup", now=now
+            group.proposal_id,
+            reason="operator cleanup",
+            now=now,
+            requester_agent_id=_TEST_OWNER_AGENT,
         )
 
 
@@ -1504,16 +1527,21 @@ async def test_void_multi_rung_sets_audit_and_invalidates_nonce(db_session):
             RungInput(0, "buy", Decimal("1"), Decimal("70000"), None),
             RungInput(1, "buy", Decimal("1"), Decimal("69000"), None),
         ],
+        creator_agent_id=_TEST_OWNER_AGENT,
     )
     await service.set_approval_nonce(group.proposal_id, "nonce")
     rows = await service.void_proposal(
-        group.proposal_id, reason="thesis invalidated", now=datetime.now(UTC)
+        group.proposal_id,
+        reason="thesis invalidated",
+        now=datetime.now(UTC),
+        requester_agent_id=_TEST_OWNER_AGENT,
     )
     refreshed, _ = await service.get_proposal(group.proposal_id)
     assert [row.state for row in rows] == ["voided", "voided"]
     assert refreshed.lifecycle_state == "voided"
     assert refreshed.no_resubmit is True
-    assert refreshed.void_reason == "thesis invalidated"
+    # ROB-1238: the audit trail now records which authority permitted the void.
+    assert refreshed.void_reason == "thesis invalidated [authority=self_created]"
     assert refreshed.approval_nonce is None
 
 
@@ -3169,10 +3197,14 @@ async def test_expired_defensive_handoff_includes_voided_loss_cut(
         exit_reason="stop_loss",
         retrospective_id=42,
         now=_HANDOFF_RECENT,
+        creator_agent_id=_TEST_OWNER_AGENT,
     )
     await db_session.commit()
     await service.void_proposal(
-        group.proposal_id, reason="operator abort", now=_HANDOFF_RECENT
+        group.proposal_id,
+        reason="operator abort",
+        now=_HANDOFF_RECENT,
+        requester_agent_id=_TEST_OWNER_AGENT,
     )
     group.updated_at = _HANDOFF_RECENT
     await db_session.commit()

--- a/tests/services/order_proposals/test_void_authorization.py
+++ b/tests/services/order_proposals/test_void_authorization.py
@@ -1,0 +1,595 @@
+"""ROB-1238 proposal lifecycle safety.
+
+Named mutants, each with the change it is meant to catch:
+
+* ``BSX`` -- a loss-guard-violating proposal survives ``proposed`` behind a live
+  approval button and cannot be retired.
+* ``phantom-27`` -- dead proposals block, or are blocked by, a healthy one.
+* ``cross-lane`` -- one session voids another lane's live proposal. Highest
+  severity: proposals are a shared surface.
+* ``atomicity`` -- the proposal is retired between the last gate and the submit,
+  and the submit proceeds anyway off the stale snapshot.
+* ``scheduler`` -- convergence is implemented by registering a recurring job.
+"""
+
+from __future__ import annotations
+
+import ast
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.errors import (
+    OrderProposalDispatchNoLongerAuthorized,
+    OrderProposalVoidNotAuthorized,
+)
+from app.services.order_proposals.service import RungInput
+from app.services.order_proposals.void_authorization import (
+    LOSS_GUARD_VERDICT_KEY,
+    SERVER_LOSS_GUARD_SOURCE,
+    authorize_void,
+    extract_creator_agent_id,
+    extract_loss_guard_violation,
+    is_server_confirmed_expired,
+)
+
+_OWNER = "agent-owner"
+_OTHER_LANE = "agent-other-lane"
+_NOW = datetime(2026, 8, 11, 5, 0, tzinfo=UTC)
+
+
+async def _create(
+    db_session,
+    *,
+    creator_agent_id: str | None = _OWNER,
+    valid_until: datetime | None = None,
+    symbol: str = "BSX",
+    side: str = "sell",
+    now: datetime = _NOW,
+):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol=symbol,
+        market="equity_us",
+        account_mode="kis_live",
+        side=side,
+        order_type="limit",
+        proposer="session",
+        rungs=[RungInput(0, side, Decimal("3"), Decimal("48.40"), None)],
+        valid_until=valid_until or (now + timedelta(days=1)),
+        creator_agent_id=creator_agent_id,
+        now=now,
+    )
+    await db_session.commit()
+    return service, group
+
+
+# --------------------------------------------------------------------------
+# mutant: cross-lane (highest severity)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_other_lane_cannot_void_a_live_proposal(db_session):
+    """MUTANT cross-lane: another agent must not retire a live proposal."""
+    service, group = await _create(db_session)
+
+    with pytest.raises(OrderProposalVoidNotAuthorized) as excinfo:
+        await service.void_proposal(
+            group.proposal_id,
+            reason="cleaning up someone else's row",
+            now=_NOW,
+            requester_agent_id=_OTHER_LANE,
+        )
+
+    assert excinfo.value.decision.reason_code == "void_not_authorized"
+    assert excinfo.value.decision.authority is None
+    refreshed, rungs = await service.get_proposal(group.proposal_id)
+    # Untouched: still live, still approvable, nonce intact.
+    assert refreshed.lifecycle_state == "proposed"
+    assert refreshed.no_resubmit is False
+    assert refreshed.void_reason is None
+    assert [rung.state for rung in rungs] == ["pending_approval"]
+
+
+@pytest.mark.asyncio
+async def test_unidentified_caller_cannot_void_a_live_proposal(db_session):
+    """MUTANT cross-lane: no caller identity must not mean owner identity."""
+    service, group = await _create(db_session)
+
+    with pytest.raises(OrderProposalVoidNotAuthorized):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="anonymous cleanup",
+            now=_NOW,
+            requester_agent_id=None,
+        )
+
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.lifecycle_state == "proposed"
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_without_creator_is_not_owned_by_anyone(db_session):
+    """MUTANT cross-lane: a missing creator must not match a missing requester.
+
+    The 27 phantom rows predate ownership recording. ``None == None`` must not
+    hand every agent owner authority over all of them.
+    """
+    service, group = await _create(db_session, creator_agent_id=None)
+
+    with pytest.raises(OrderProposalVoidNotAuthorized):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="legacy cleanup",
+            now=_NOW,
+            requester_agent_id=None,
+        )
+    assert extract_creator_agent_id(group.source_asof) is None
+
+
+@pytest.mark.asyncio
+async def test_owner_may_void_its_own_live_proposal(db_session):
+    service, group = await _create(db_session)
+
+    rows = await service.void_proposal(
+        group.proposal_id,
+        reason="thesis invalidated",
+        now=_NOW,
+        requester_agent_id=_OWNER,
+    )
+
+    assert [row.state for row in rows] == ["voided"]
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.lifecycle_state == "voided"
+    assert "authority=self_created" in refreshed.void_reason
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_creator_id_cannot_forge_ownership(db_session):
+    """A caller-injected ``source_asof`` must not pre-seed someone else's id."""
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="BSX",
+        market="equity_us",
+        account_mode="kis_live",
+        side="sell",
+        order_type="limit",
+        proposer="session",
+        rungs=[RungInput(0, "sell", Decimal("3"), Decimal("48.40"), None)],
+        valid_until=_NOW + timedelta(days=1),
+        source_asof={"creator_agent_id": _OWNER},
+        creator_agent_id=None,
+        now=_NOW,
+    )
+    await db_session.commit()
+
+    assert extract_creator_agent_id(group.source_asof) is None
+    with pytest.raises(OrderProposalVoidNotAuthorized):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="forged ownership",
+            now=_NOW,
+            requester_agent_id=_OWNER,
+        )
+
+
+# --------------------------------------------------------------------------
+# mutant: BSX
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bsx_loss_guard_violation_makes_proposal_retirable(db_session):
+    """MUTANT BSX: a server-confirmed loss-guard violation must be retirable.
+
+    Reproduces dd7a68d7 -- a sell limit below avg x 1.01 that stayed ``proposed``
+    for three weeks with a tappable approval button while the session could only
+    leave a warning.
+    """
+    service, group = await _create(db_session)
+    await service.set_approval_nonce(group.proposal_id, "bsx-nonce")
+
+    # Before the server sees the violation, another session still cannot touch it.
+    with pytest.raises(OrderProposalVoidNotAuthorized):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="looks wrong",
+            now=_NOW,
+            requester_agent_id=_OTHER_LANE,
+        )
+
+    await service.record_loss_guard_verdict(
+        group.proposal_id,
+        rung_index=0,
+        error="Sell price 48.40 below minimum (avg_buy_price * 1.01 = 48.48)",
+        now=_NOW,
+    )
+
+    rows = await service.void_proposal(
+        group.proposal_id,
+        reason="loss guard violation",
+        now=_NOW,
+        requester_agent_id=_OTHER_LANE,
+    )
+
+    assert [row.state for row in rows] == ["voided"]
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert "authority=server_loss_guard_invalid" in refreshed.void_reason
+    # The approval button is dead: no nonce survives the retirement.
+    assert refreshed.approval_nonce is None
+    assert refreshed.no_resubmit is True
+
+
+@pytest.mark.asyncio
+async def test_bsx_loss_guard_violation_blocks_a_late_dispatch(db_session):
+    """MUTANT BSX: a late approval tap must not dispatch the violating order."""
+    service, group = await _create(db_session)
+    await service.set_approval_nonce(group.proposal_id, "bsx-nonce")
+    await service.record_loss_guard_verdict(
+        group.proposal_id,
+        rung_index=0,
+        error="Sell price 48.40 below minimum (avg_buy_price * 1.01 = 48.48)",
+        now=_NOW,
+    )
+
+    with pytest.raises(OrderProposalDispatchNoLongerAuthorized) as excinfo:
+        await service.assert_dispatch_still_authorized(
+            group.proposal_id,
+            now=_NOW,
+            expected_nonce="bsx-nonce",
+        )
+
+    assert excinfo.value.reason == "proposal_loss_guard_invalid"
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce is None
+
+
+@pytest.mark.asyncio
+async def test_transient_guard_blocks_do_not_grant_void_authority(db_session):
+    """A guard block that is not the loss guard must not open the void path.
+
+    Insufficient balance / opposite-pending / cooldown are account conditions,
+    not proof that the proposal itself is invalid.
+    """
+    service, group = await _create(db_session)
+    for envelope in (
+        {"violated": False, "source": SERVER_LOSS_GUARD_SOURCE},
+        {"violated": True, "source": "caller_supplied"},
+        {"violated": "yes", "source": SERVER_LOSS_GUARD_SOURCE},
+        {"source": SERVER_LOSS_GUARD_SOURCE},
+        "insufficient balance",
+    ):
+        assert extract_loss_guard_violation({LOSS_GUARD_VERDICT_KEY: envelope}) is None
+
+    with pytest.raises(OrderProposalVoidNotAuthorized):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="transient guard",
+            now=_NOW,
+            requester_agent_id=_OTHER_LANE,
+        )
+
+
+# --------------------------------------------------------------------------
+# mutant: phantom-27
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expired_phantom_converges_to_expired_not_voided(db_session):
+    """MUTANT phantom-27: the lazy convergence path retires dead rows.
+
+    Expiry is what the server proved, so the rungs land in ``expired``. Calling
+    them ``voided`` would misreport why they died.
+    """
+    created_at = _NOW - timedelta(days=21)
+    service, group = await _create(
+        db_session,
+        valid_until=created_at + timedelta(days=1),
+        now=created_at,
+    )
+    await service.set_approval_nonce(group.proposal_id, "phantom-nonce")
+
+    rows = await service.void_proposal(
+        group.proposal_id,
+        reason="phantom cleanup",
+        now=_NOW,
+        requester_agent_id=_OTHER_LANE,
+    )
+
+    assert [row.state for row in rows] == ["expired"]
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.lifecycle_state == "expired"
+    assert "authority=server_expired" in refreshed.void_reason
+    assert refreshed.approval_nonce is None
+
+
+@pytest.mark.asyncio
+async def test_phantoms_do_not_block_a_healthy_proposal_dispatch(db_session):
+    """MUTANT phantom-27: dead rows must not gate an unrelated live proposal."""
+    stale_at = _NOW - timedelta(days=21)
+    service, phantom = await _create(
+        db_session,
+        valid_until=stale_at + timedelta(days=1),
+        now=stale_at,
+        symbol="PHANTOM",
+    )
+    _, healthy = await _create(db_session, symbol="LIVE")
+    await service.set_approval_nonce(healthy.proposal_id, "healthy-nonce")
+
+    await service.void_proposal(
+        phantom.proposal_id,
+        reason="phantom cleanup",
+        now=_NOW,
+        requester_agent_id=_OTHER_LANE,
+    )
+
+    # The healthy proposal is untouched and still dispatchable.
+    group = await service.assert_dispatch_still_authorized(
+        healthy.proposal_id,
+        now=_NOW,
+        expected_nonce="healthy-nonce",
+    )
+    assert group.lifecycle_state == "proposed"
+    assert group.approval_nonce == "healthy-nonce"
+
+
+# --------------------------------------------------------------------------
+# mutant: atomicity
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_gate_refuses_after_a_concurrent_void(db_session):
+    """MUTANT atomicity: a retirement landing after the last gate must abort."""
+    service, group = await _create(db_session)
+    await service.set_approval_nonce(group.proposal_id, "race-nonce")
+
+    # Passes while the proposal is live...
+    await service.assert_dispatch_still_authorized(
+        group.proposal_id, now=_NOW, expected_nonce="race-nonce"
+    )
+    # ...then the owner retires it in the gap before the submit.
+    await service.void_proposal(
+        group.proposal_id,
+        reason="pulled",
+        now=_NOW,
+        requester_agent_id=_OWNER,
+    )
+
+    with pytest.raises(OrderProposalDispatchNoLongerAuthorized) as excinfo:
+        await service.assert_dispatch_still_authorized(
+            group.proposal_id, now=_NOW, expected_nonce="race-nonce"
+        )
+    assert excinfo.value.reason == "proposal_terminal:voided"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_gate_refuses_when_valid_until_elapsed(db_session):
+    service, group = await _create(db_session)
+    await service.set_approval_nonce(group.proposal_id, "late-nonce")
+
+    with pytest.raises(OrderProposalDispatchNoLongerAuthorized) as excinfo:
+        await service.assert_dispatch_still_authorized(
+            group.proposal_id,
+            now=_NOW + timedelta(days=2),
+            expected_nonce="late-nonce",
+        )
+    assert excinfo.value.reason == "proposal_now_at_or_after_valid_until"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_gate_refuses_a_superseded_approval_token(db_session):
+    service, group = await _create(db_session)
+    await service.set_approval_nonce(group.proposal_id, "current-nonce")
+
+    with pytest.raises(OrderProposalDispatchNoLongerAuthorized) as excinfo:
+        await service.assert_dispatch_still_authorized(
+            group.proposal_id, now=_NOW, expected_nonce="stale-nonce"
+        )
+    assert excinfo.value.reason == "approval_nonce_superseded"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_gate_burns_the_token_when_it_refuses(db_session):
+    """A refused dispatch must not leave a replayable approval token behind."""
+    service, group = await _create(db_session)
+    await service.set_approval_nonce(group.proposal_id, "burn-nonce")
+    await service.record_loss_guard_verdict(
+        group.proposal_id,
+        rung_index=0,
+        error="Sell price 48.40 below minimum (avg_buy_price * 1.01 = 48.48)",
+        now=_NOW,
+    )
+
+    with pytest.raises(OrderProposalDispatchNoLongerAuthorized):
+        await service.assert_dispatch_still_authorized(
+            group.proposal_id, now=_NOW, expected_nonce="burn-nonce"
+        )
+
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce is None
+    assert refreshed.approval_nonce_used_at is not None
+
+
+# --------------------------------------------------------------------------
+# mutant: scheduler
+# --------------------------------------------------------------------------
+
+
+_ROB1238_MODULES = (
+    "app/services/order_proposals/void_authorization.py",
+    "app/services/order_proposals/service.py",
+    "app/services/order_proposals/revalidation.py",
+    "app/mcp_server/tooling/order_proposal_tools.py",
+)
+_SCHEDULER_TOKENS = (
+    "schedule",
+    "crontab",
+    "cron",
+    "apscheduler",
+    "prefect",
+    "launchd",
+    "taskiq",
+    "AsyncIOScheduler",
+    "BackgroundScheduler",
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize("relative_path", _ROB1238_MODULES)
+def test_no_scheduler_registration_in_lifecycle_modules(relative_path):
+    """MUTANT scheduler: convergence must stay lazy, never a recurring job.
+
+    The design is dispatch-time / on-demand: nothing here may register a cron,
+    launchd job, Prefect deployment or APScheduler trigger. Import lines are
+    what would wire one up, so those are what we scan.
+    """
+    source = (_repo_root() / relative_path).read_text()
+    tree = ast.parse(source)
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+
+    offenders = [
+        name
+        for name in imported
+        for token in _SCHEDULER_TOKENS
+        if token.lower() in name.lower()
+    ]
+    assert offenders == [], f"{relative_path} imports a scheduler: {offenders}"
+
+
+def test_void_authorization_is_pure_stdlib():
+    """The authorization rule must stay testable without DB, clock or broker."""
+    source = (
+        _repo_root() / "app/services/order_proposals/void_authorization.py"
+    ).read_text()
+    tree = ast.parse(source)
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+
+    assert all(not name.startswith("app.") for name in imported), imported
+    forbidden = ("sqlalchemy", "httpx", "redis", "requests", "aiohttp")
+    assert not [n for n in imported if n.split(".")[0] in forbidden], imported
+
+
+# --------------------------------------------------------------------------
+# pure-rule coverage
+# --------------------------------------------------------------------------
+
+
+def test_authorize_void_precedence_and_terminal_states():
+    expired_at = _NOW - timedelta(hours=1)
+
+    owner = authorize_void(
+        requester_agent_id=_OWNER,
+        creator_agent_id=_OWNER,
+        valid_until=expired_at,
+        now=_NOW,
+    )
+    assert (owner.authority, owner.terminal_state) == ("self_created", "voided")
+
+    guard = authorize_void(
+        requester_agent_id=_OTHER_LANE,
+        creator_agent_id=_OWNER,
+        valid_until=_NOW + timedelta(hours=1),
+        now=_NOW,
+        loss_guard_violation={"loss_guard_source": SERVER_LOSS_GUARD_SOURCE},
+    )
+    assert (guard.authority, guard.terminal_state) == (
+        "server_loss_guard_invalid",
+        "voided",
+    )
+
+    expired = authorize_void(
+        requester_agent_id=_OTHER_LANE,
+        creator_agent_id=_OWNER,
+        valid_until=expired_at,
+        now=_NOW,
+    )
+    assert (expired.authority, expired.terminal_state) == ("server_expired", "expired")
+
+    blocked = authorize_void(
+        requester_agent_id=_OTHER_LANE,
+        creator_agent_id=_OWNER,
+        valid_until=_NOW + timedelta(hours=1),
+        now=_NOW,
+    )
+    assert blocked.allowed is False
+    assert blocked.authority is None
+
+
+def test_missing_valid_until_is_not_evidence_of_expiry():
+    assert is_server_confirmed_expired(None, now=_NOW) is False
+    decision = authorize_void(
+        requester_agent_id=_OTHER_LANE,
+        creator_agent_id=_OWNER,
+        valid_until=None,
+        now=_NOW,
+    )
+    assert decision.allowed is False
+
+
+def test_valid_until_boundary_is_inclusive():
+    """``now == valid_until`` counts as expired, matching valid_until_block."""
+    assert is_server_confirmed_expired(_NOW, now=_NOW) is True
+    assert is_server_confirmed_expired(_NOW + timedelta(microseconds=1), now=_NOW) is (
+        False
+    )
+
+
+def test_ownership_comparison_is_exact_after_stripping():
+    assert (
+        authorize_void(
+            requester_agent_id=f"  {_OWNER} ",
+            creator_agent_id=_OWNER,
+            valid_until=_NOW + timedelta(hours=1),
+            now=_NOW,
+        ).authority
+        == "self_created"
+    )
+    for impostor in (f"{_OWNER}-2", _OWNER.upper(), "", "   "):
+        assert (
+            authorize_void(
+                requester_agent_id=impostor,
+                creator_agent_id=_OWNER,
+                valid_until=_NOW + timedelta(hours=1),
+                now=_NOW,
+            ).allowed
+            is False
+        ), impostor
+
+
+def test_naive_datetimes_are_rejected_rather_than_silently_compared():
+    with pytest.raises(ValueError):
+        is_server_confirmed_expired(datetime(2026, 8, 11, 5, 0), now=_NOW)
+
+
+@pytest.mark.asyncio
+async def test_void_of_unknown_proposal_still_raises_not_found(db_session):
+    from app.services.order_proposals.errors import OrderProposalNotFound
+
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalNotFound):
+        await service.void_proposal(
+            uuid.uuid4(),
+            reason="missing",
+            now=_NOW,
+            requester_agent_id=_OWNER,
+        )

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -10,6 +10,7 @@ import pytest
 
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
+from app.mcp_server.caller_identity import caller_agent_id_var
 from app.mcp_server.tooling import order_proposal_tools as opt
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals import dispatch as dispatch_module
@@ -22,6 +23,21 @@ from app.services.order_proposals.redispatch import RedispatchValidation
 from app.services.order_proposals.target_order import TargetOrderSnapshot
 from app.telegram_contract import TelegramMethodResult, telegram_text_length
 from tests.services.order_proposals.window_fakes import allow_known_session
+
+# ROB-1238: production always runs these tools behind CallerIdentityMiddleware,
+# which resolves one agent id per call. Pin the same identity here so create and
+# void share an owner and the existing void tests keep testing what they were
+# written to test rather than the new authorization gate.
+_TOOL_CALLER_AGENT = "test-mcp-agent"
+
+
+@pytest.fixture(autouse=True)
+def _mcp_caller_identity():
+    token = caller_agent_id_var.set(_TOOL_CALLER_AGENT)
+    try:
+        yield _TOOL_CALLER_AGENT
+    finally:
+        caller_agent_id_var.reset(token)
 
 
 @pytest.fixture(autouse=True)
@@ -910,7 +926,7 @@ async def test_void_requires_reason_and_terminalizes_proposal():
     result = await opt.order_proposal_void(created["proposal_id"], "superseded thesis")
     assert result["success"] is True
     assert result["lifecycle_state"] == "voided"
-    assert result["void_reason"] == "superseded thesis"
+    assert result["void_reason"] == "superseded thesis [authority=self_created]"
 
 
 @pytest.mark.asyncio
@@ -993,7 +1009,8 @@ async def test_void_unverified_uses_broker_evidence_and_disables_telegram_button
         (
             chat,
             4242,
-            "🗑️ 제안 무효화됨\n사유: " + result["void_reason"].replace("_", "\\_"),
+            "🗑️ 제안 무효화됨\n사유: "
+            + opt._escape_telegram_markdown(result["void_reason"]),
             {"inline_keyboard": []},
         )
     ]

--- a/tests/test_route_request_lanes.py
+++ b/tests/test_route_request_lanes.py
@@ -334,3 +334,53 @@ def test_buy_discovery_have_negative_class_constraint():
         assert "confidence" in joined
         assert "forecast" in joined
         assert "outcome_rule_version='window-touch-v1-high-gte-low-lte'" in joined
+
+
+# ---------------------------------------------------------------------------
+# ROB-1238: order_proposal_void lane surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("intent", ["buy_analysis", "profit_taking"])
+def test_proposal_lanes_unblock_order_proposal_void(intent: str):
+    """The lane that owns proposals must be able to retire one.
+
+    `order_proposal_void` is in PROPOSAL_LIFECYCLE_TOOLS -> MUTATION_TOOLS but
+    was in no lane's allowed set, so every lane reported it blocked and phantom
+    proposals accumulated with nothing able to clear them.
+    """
+    plan = _plan(intent, "kr")
+    allowed = set(plan["allowed_tools"])
+    blocked = set(plan["blocked_actions"])
+    steps = set(_step_tools(plan))
+
+    assert "order_proposal_void" in allowed
+    assert "order_proposal_void" not in blocked
+    # A cleanup lever, not a workflow step: it must not enter the sequence.
+    assert "order_proposal_void" not in steps
+
+
+@pytest.mark.parametrize("intent", ["discovery", "market_brief"])
+def test_non_proposal_lanes_keep_order_proposal_void_blocked(intent: str):
+    """MUTANT cross-lane: the unblock is scoped, not a wholesale opening."""
+    plan = _plan(intent, "kr")
+
+    assert "order_proposal_void" not in set(plan["allowed_tools"])
+    if "order_proposal_void" in _ALL:
+        assert "order_proposal_void" in set(plan["blocked_actions"])
+
+
+def test_lifecycle_allowance_never_widens_beyond_void():
+    """The other lifecycle tools stay blocked everywhere.
+
+    `order_proposal_expire_sweep` and `order_proposal_redispatch` were not part
+    of the ROB-1238 incident; widening this map is a deliberate act, not a
+    side effect of the void fix.
+    """
+    granted = set().union(*L.LANE_PROPOSAL_LIFECYCLE_ALLOWED.values())
+    assert granted == {"order_proposal_void"}
+    assert granted <= L.PROPOSAL_LIFECYCLE_TOOLS
+    assert set(L.LANE_PROPOSAL_LIFECYCLE_ALLOWED) == set(L.PROPOSAL_LED_LANES)
+    for intent in ("discovery", "market_brief"):
+        plan = _plan(intent, "kr")
+        assert (L.PROPOSAL_LIFECYCLE_TOOLS & _ALL).isdisjoint(plan["allowed_tools"])


### PR DESCRIPTION
## 문제

`order_proposal_void` 가 **전 lane 에서 blocked** 였다. `PROPOSAL_LIFECYCLE_TOOLS` → `MUTATION_TOOLS` 에 union 되는데 어떤 lane 의 `allowed_candidates` 에도 없어서 `build_route_plan` 이 모든 lane 의 `blocked_actions` 에 넣었다. 죽은 제안을 정리할 수단이 없어 유령 제안이 **07-27 8건 → 08-10 27건** 누적됐고, 그중 BSX `dd7a68d7`(평단×1.01 = 48.48 인데 48.40 매도)은 3주간 `proposed` 로 살아남아 **텔레그램 승인 버튼이 눌리는 상태**였다.

## 수리 — 🔴 전면 개방이 아니다

두 층으로 분리했다.

**표면** — `LANE_PROPOSAL_LIFECYCLE_ALLOWED`: proposal-led lane(buy/sell)에만 노출. discovery/bootstrap 은 계속 blocked, 나머지 lifecycle 도구는 미개방.

**권한** — `order_proposals/void_authorization.py` (순수 stdlib, DB/네트워크/시계 없음). 표면과 무관하게 fail-closed. 권한 3종뿐:

| authority | 종착 상태 |
|---|---|
| `self_created` | `voided` |
| `server_loss_guard_invalid` | `voided` |
| `server_expired` | 🔴 `expired` (서버가 증명한 건 만료지 무효가 아니므로) |

- 소유권 = `source_asof["creator_agent_id"]`. `CallerIdentityMiddleware` 가 푼 값을 **서버가** create 시점에 기록하고, 호출자가 넘긴 `source_asof` 의 동일 키는 **먼저 제거**한다 → 도구 인자로 위조 불가. `proposer` 자유 텍스트는 근거가 아니다.
- loss-guard verdict 는 서버 자신의 revalidation 이 기록했을 때(`source == "server_revalidation"`)만 인정. 호출자 주입 payload·truthy 값·잔고부족/opposite-pending/cooldown 같은 일시적 guard block 은 권한을 주지 않는다.
- 🔴 **남의 lane 의 살아 있는 제안은 불가침.**
- 임계값(평단×1.01)은 재구현하지 않았다 — `order_validation` 단일 소스의 판정을 **기록·조회만** 한다.

## lazy 설계 — 스케줄러 0

cron·launchd·TaskIQ·Prefect·APScheduler 등록 **없음**. 수렴은 조회·dispatch 시점 판정으로만. 기존 ROB-897 sweep task 는 무접촉. lifecycle 모듈 4개의 import 를 AST 로 스캔하는 테스트가 이를 고정한다.

## dispatch 직전 원자적 재검증

`revalidate_and_submit` 은 group 을 한 번 읽고 rung 별 preview/eligibility/buying-power/calendar I/O 를 전부 await 했다. 그 사이 다른 세션의 void(별도 트랜잭션)가 커밋돼도 **보이지 않고 그대로 전송**됐다.

`_pre_submit_lifecycle_gate` 를 마지막 window gate 와 submit 사이에 배치. 행을 `FOR UPDATE` 로 재독하고 **그 락을 submit 을 넘어 트랜잭션 끝까지 유지** — "최근에 확인"이 아니라 "확인 후 변경 불가"다. 재검증: terminal state · `no_resubmit` · `valid_until`(🔴 새 규칙 없이 공용 `valid_until_block` 재사용) · 승인 토큰 · loss-guard verdict. **거부 시 nonce 무효화** → 낡은 카드 재탭 불가. `void_proposal` 도 nonce 를 지운다.

## mutant 격추 (전부 Y)

| mutant | 격추 테스트 |
|---|---|
| ① BSX 재현 | `test_bsx_loss_guard_violation_makes_proposal_retirable` · `..._blocks_a_late_dispatch` · `test_loss_guard_preview_records_a_server_confirmed_verdict` |
| ② 유령 27건 무브로킹 | `test_expired_phantom_converges_to_expired_not_voided` · `test_phantoms_do_not_block_a_healthy_proposal_dispatch` |
| ③ 타 lane 불가침 🔴 | `test_other_lane_cannot_void_a_live_proposal` · `test_unidentified_caller_...` · `test_legacy_row_without_creator_is_not_owned_by_anyone` · `test_caller_supplied_creator_id_cannot_forge_ownership` · `test_non_proposal_lanes_keep_order_proposal_void_blocked` |
| ④ 원자성 | `test_concurrent_void_between_preview_and_submit_aborts_the_send` · `test_dispatch_gate_refuses_after_a_concurrent_void` · `..._burns_the_token_when_it_refuses` |
| ⑤ scheduler 도입 | `test_no_scheduler_registration_in_lifecycle_modules` (4모듈 AST) |

## false-green 검증

assert 반전이 아니라 **프로덕션 코드를 역변형**해 테스트가 동작에 결속됐는지 확인 — 6/6 전부 적발:

| 변형 | 결과 |
|---|---|
| void 권한 게이트 제거 | 7 failed |
| pre-submit lifecycle gate no-op | 3 failed |
| lane 허용 제거 | 3 failed |
| loss-guard `source` 검사 제거 | 1 failed |
| lifecycle 모듈에 scheduler import 추가 | 1 failed |
| caller-supplied `creator_agent_id` strip 제거 | 1 failed |

## 회귀

proposal 소비자 전수 **1299 passed**. `make lint` 3종(ruff check / ruff format --check / ty --error-on-warning) 전 스코프 통과.

## 불변

- 🔴 브로커/계좌 mutation **0** (로컬 DB 상태 전이만). `unverified` 분기의 broker-absence read 증거 규약은 그대로.
- 🔴 스케줄러 등록 **0** · migration **0**(기존 `source_asof` JSONB 만 사용)
- 🔴 `scripts/b0x/**` 무접촉 · B0-X 관측 수치 불변 · envelope/AST 가드/원장 dedup/라벨 무접촉

## 감수한 구멍 (런북 §8)

- `valid_until=None` 행은 `server_expired` 로 수렴 안 함 — 마감 부재는 만료 증거가 아니다. 소유 세션만 정리 가능.
- legacy 유령 행은 `creator_agent_id` 가 없다 → 만료도 loss-guard 위반도 아니면 아무도 못 지운다(의도된 fail-closed).
- `_pre_submit_lifecycle_gate` 는 place 경로 배선. cancel/replace 는 기존 target 대조로 방어되나 동일 gate 미적용 — 후속.
- caller identity 는 헤더 또는 env fallback — 같은 fallback 공유 세션은 서로를 소유자로 본다.

런북: `docs/runbooks/order-proposal-void-authorization.md`

Linear: ROB-1238 (읽기만, 상태 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)