### PR TITLE
feat(order-proposals): §40차 auto-approve classification behind a default-off mode

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -839,6 +839,18 @@ class Settings(BaseSettings):
     # ROB-871 — master gate for resting-class automatic submission. Telegram
     # approvals remain the fallback whenever this is off or eligibility fails.
     ORDER_PROPOSALS_AUTO_APPROVE: bool = False
+    # AUTO-APPROVE-EXPAND (§40차) — selects which eligibility classification
+    # `evaluate_auto_approve_eligibility` applies. Subordinate to
+    # ORDER_PROPOSALS_AUTO_APPROVE: with that master gate off, nothing here runs.
+    #   "off"      (default) ROB-871 resting-class rules, unchanged.
+    #   "expanded" §40차: buys and *proven* profit-take sells drop the
+    #              min_distance_pct floor (they must still be non-marketable so
+    #              the veto button has an order left to cancel). Loss cuts, sells
+    #              whose fee-netted expected P&L is <= 0, the ±1% break-even band,
+    #              tagged proposals and anything unclassifiable stay
+    #              approval-required.
+    # Turning this to "expanded" is an operator decision; this repo ships "off".
+    ORDER_PROPOSALS_AUTO_APPROVE_MODE: Literal["off", "expanded"] = "off"
     # ROB-816 PR 2 — Telegram approval flow (default off)
     ORDER_PROPOSALS_TELEGRAM_ENABLED: bool = False
     ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN: str = ""

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -281,6 +281,13 @@ class OrderProposalAutoApprovePolicy(BaseModel):
 
     Caps are denominated in each market's settlement currency: KRW for KR
     equities and crypto, USD for US equities.
+
+    ``breakeven_band_pct`` and ``round_trip_cost_bps`` are the operator-owned
+    inputs to the expanded classification (see
+    ``order_proposals/auto_approve.py``). They are optional so a deployment
+    pinned to an older YAML still loads; the defaults are the same conservative
+    values the code floor enforces, and the code floor means a policy edit can
+    only ever make the profit-take classification *narrower*, never wider.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -288,6 +295,10 @@ class OrderProposalAutoApprovePolicy(BaseModel):
     min_distance_pct: float = Field(gt=0, le=100)
     per_order_cap: dict[Market, float]
     daily_cap: dict[Market, float]
+    breakeven_band_pct: float = Field(default=1.0, gt=0, le=100)
+    round_trip_cost_bps: dict[Market, float] = Field(
+        default_factory=lambda: {"kr": 47.4, "us": 90.0, "crypto": 10.0}
+    )
 
     @field_validator("per_order_cap", "daily_cap")
     @classmethod
@@ -297,6 +308,20 @@ class OrderProposalAutoApprovePolicy(BaseModel):
             raise ValueError(f"market caps must contain exactly {sorted(required)}")
         if any(cap <= 0 for cap in value.values()):
             raise ValueError("market caps must be positive")
+        return value
+
+    @field_validator("round_trip_cost_bps")
+    @classmethod
+    def validate_round_trip_cost(
+        cls, value: dict[Market, float]
+    ) -> dict[Market, float]:
+        required = {"kr", "us", "crypto"}
+        if set(value) != required:
+            raise ValueError(
+                f"round_trip_cost_bps must contain exactly {sorted(required)}"
+            )
+        if any(bps < 0 for bps in value.values()):
+            raise ValueError("round_trip_cost_bps must be non-negative")
         return value
 
     @model_validator(mode="after")

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -28,8 +28,10 @@ Two classifications live here, selected by ``AutoApproveLimits.mode``
     ``expanded`` drops ``min_distance_pct`` but NOT the requirement that the
     rung actually rest: a marketable order can fill before the operator sees
     the card, which would make the veto button (§40차 safety invariant ①) a
-    lie. That is narrower than the §40차 literal, which is the permitted
-    direction -- see docs/runbooks/order-proposal-auto-approve-expand.md §3.
+    lie. A buy must price strictly below the market and a sell strictly above
+    it -- a limit exactly ON the market is marketable and is rejected. That is
+    narrower than the §40차 literal, which is the permitted direction -- see
+    docs/runbooks/order-proposal-auto-approve-expand.md §3.
 """
 
 from __future__ import annotations
@@ -335,35 +337,35 @@ def evaluate_auto_approve_eligibility(
 
     # `expanded` drops the min_distance_pct floor but still requires the rung
     # to rest: a buy at or above the market (a sell at or below it) can fill
-    # before the operator ever sees the veto card.
+    # before the operator ever sees the veto card. Hence the strict comparison
+    # in `expanded` -- a limit exactly ON the market is marketable. `off` keeps
+    # ROB-871's non-strict boundary (a rung exactly `min_distance_pct` away is
+    # eligible), so this cannot change any verdict the shipped mode reaches.
+    expanded = mode == "expanded"
     min_fraction = (
-        Decimal("0") if mode == "expanded" else limits.min_distance_pct / Decimal("100")
+        Decimal("0") if expanded else limits.min_distance_pct / Decimal("100")
     )
     profit_details: dict[str, str] = {}
     if side == "buy":
         threshold = current_price * (Decimal("1") - min_fraction)
         distance_pct = (current_price - limit_price) / current_price * Decimal("100")
-        if limit_price > threshold:
+        if (limit_price >= threshold) if expanded else (limit_price > threshold):
             return reject(
-                "marketable_not_resting"
-                if mode == "expanded"
-                else "distance_below_minimum"
+                "marketable_not_resting" if expanded else "distance_below_minimum"
             )
         loss_guard = "not_applicable"
     else:
         threshold = current_price * (Decimal("1") + min_fraction)
         distance_pct = (limit_price - current_price) / current_price * Decimal("100")
-        if limit_price < threshold:
+        if (limit_price <= threshold) if expanded else (limit_price < threshold):
             return reject(
-                "marketable_not_resting"
-                if mode == "expanded"
-                else "distance_below_minimum"
+                "marketable_not_resting" if expanded else "distance_below_minimum"
             )
         # A successful fresh sell preview means the existing avg-cost loss
         # guard ran and passed. We record that provenance instead of
         # reimplementing the guard with a potentially different threshold.
         loss_guard = "preview_passed"
-        if mode == "expanded":
+        if expanded:
             # ...but the preview guard fails open on unknown cost basis and is
             # bypassable (defensive_trim / loss_cut / mock), so `expanded`
             # proves the profit itself rather than inheriting that verdict.

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -1,16 +1,45 @@
-"""Resting-class auto-approval eligibility policy (ROB-871).
+"""Resting-class auto-approval eligibility policy (ROB-871, §40차).
 
 This module is deliberately pure: it classifies one freshly previewed rung
 and never reads the database or calls a broker. The dispatch/revalidation
 boundary supplies the account's same-day cumulative auto-approved notional.
+
+Two classifications live here, selected by ``AutoApproveLimits.mode``
+(``settings.ORDER_PROPOSALS_AUTO_APPROVE_MODE``, default ``"off"``):
+
+``off``
+    ROB-871 as shipped: a rung must rest at least ``min_distance_pct`` away
+    from the market on either side.
+
+``expanded`` (§40차)
+    Auto-approve, veto afterwards:
+      1. buy rungs (their envelope / sizing / funding gates ran at create time), and
+      2. profit-take sells whose expected realized P&L at the limit price is
+         strictly positive *after* round-trip costs.
+    Everything else goes to a human, fail-closed:
+      * ``loss_cut`` exit intent (or any other exit intent),
+      * expected realized P&L <= 0 -- exactly zero is not "> 0",
+      * the ±``breakeven_band_pct`` break-even band around avg cost, whatever
+        the sign of the P&L,
+      * a ``policy_deviation`` / ``table_disagreement`` tag anywhere on the
+        proposal,
+      * anything that cannot be classified from the fresh preview.
+
+    ``expanded`` drops ``min_distance_pct`` but NOT the requirement that the
+    rung actually rest: a marketable order can fill before the operator sees
+    the card, which would make the veto button (§40차 safety invariant ①) a
+    lie. That is narrower than the §40차 literal, which is the permitted
+    direction -- see docs/runbooks/order-proposal-auto-approve-expand.md §3.
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
+from app.core.config import settings
 from app.services.order_proposals.approval_message import (
     _escape_inline_code,
     _escape_markdown,
@@ -45,6 +74,37 @@ _VETO_CAPABLE_ACCOUNT_MARKETS = frozenset(
     }
 )
 
+# §40차: a proposal carrying either tag is a human's call regardless of how it
+# prices. The tags have no column of their own, so the scan is deliberately
+# over-inclusive -- it walks every free-text and JSON field a proposer can
+# write to and matches the bare token anywhere inside. A false positive costs
+# one Telegram tap; a false negative auto-submits an order the operator wanted
+# to see.
+_APPROVAL_REQUIRED_TAGS = frozenset({"policy_deviation", "table_disagreement"})
+_TAG_SCAN_FIELDS = (
+    "rationale",
+    "source_asof",
+    "lot_context",
+    "thesis",
+    "strategy",
+    "exit_reason",
+    "void_reason",
+)
+
+# Both-leg cost floor in basis points, per market. NOT measured rates: the two
+# veto-capable ledgers (review.kis_live_order_ledger, review.live_order_ledger)
+# carry no commission/tax columns, so this repo holds no realized fee evidence
+# for kis_live or upbit to derive one from. Until it does, these are the
+# conservative maximum of the rates the repo already declares -- see the
+# provenance comment on `order_proposals.auto_approve.round_trip_cost_bps` in
+# config/trading_policy.yaml. The policy value is raised to this floor, so an
+# operator edit can only ever narrow the profit-take test, never widen it.
+_ROUND_TRIP_COST_BPS_FLOOR = {
+    "equity_kr": Decimal("47.4"),
+    "equity_us": Decimal("90"),
+    "crypto": Decimal("10"),
+}
+
 
 @dataclass(frozen=True)
 class AutoApproveLimits:
@@ -52,6 +112,12 @@ class AutoApproveLimits:
     per_order_cap: Decimal
     daily_cap: Decimal
     policy_version: str
+    # Defaults keep every existing construction site on ROB-871 behaviour.
+    # `round_trip_cost_bps` defaults to the widest floor so a limits object
+    # built without one still classifies conservatively.
+    mode: str = "off"
+    breakeven_band_pct: Decimal = Decimal("1")
+    round_trip_cost_bps: Decimal = Decimal("90")
 
 
 @dataclass(frozen=True)
@@ -80,12 +146,112 @@ def limits_for_market(market: str) -> AutoApproveLimits | None:
         return None
     document = load_trading_policy()
     policy = document.order_proposals.auto_approve
+    declared_cost = Decimal(str(policy.round_trip_cost_bps[policy_market]))
     return AutoApproveLimits(
         min_distance_pct=Decimal(str(policy.min_distance_pct)),
         per_order_cap=Decimal(str(policy.per_order_cap[policy_market])),
         daily_cap=Decimal(str(policy.daily_cap[policy_market])),
         policy_version=document.version,
+        mode=str(settings.ORDER_PROPOSALS_AUTO_APPROVE_MODE),
+        breakeven_band_pct=Decimal(str(policy.breakeven_band_pct)),
+        # The floor wins whenever the policy is cheaper than it.
+        round_trip_cost_bps=max(
+            declared_cost,
+            _ROUND_TRIP_COST_BPS_FLOOR.get(
+                market, max(_ROUND_TRIP_COST_BPS_FLOOR.values())
+            ),
+        ),
     )
+
+
+def find_approval_required_tags(group: Any) -> tuple[str, ...]:
+    """Return the §40차 approval-required tags carried anywhere on ``group``.
+
+    Fails closed: if any field resists serialization the proposal is treated
+    as carrying every tag, which routes it to a human.
+    """
+    parts: list[str] = []
+    try:
+        for field in _TAG_SCAN_FIELDS:
+            value = getattr(group, field, None)
+            if value is None:
+                continue
+            parts.append(
+                value
+                if isinstance(value, str)
+                else json.dumps(value, default=str, ensure_ascii=False)
+            )
+    except Exception:  # noqa: BLE001 - unreadable metadata is not a clearance
+        return tuple(sorted(_APPROVAL_REQUIRED_TAGS))
+    haystack = "\n".join(parts).lower()
+    return tuple(sorted(tag for tag in _APPROVAL_REQUIRED_TAGS if tag in haystack))
+
+
+@dataclass(frozen=True)
+class SellProfitVerdict:
+    """Fee-netted profit-take classification for one sell rung (§40차 ②)."""
+
+    verdict: str  # take_profit | breakeven_band | not_profitable | unclassifiable
+    details: dict[str, str]
+
+
+def classify_sell_profit(
+    *,
+    limit_price: Decimal,
+    quantity: Decimal,
+    preview: dict[str, Any],
+    limits: AutoApproveLimits,
+) -> SellProfitVerdict:
+    """Decide whether a sell is a *proven* profit-take, failing closed.
+
+    Order matters: the break-even band is checked before the P&L sign, because
+    §40차 sends the band to a human "whatever the sign" -- a sell 0.5% above
+    avg cost is inside the band even though its gross P&L is positive.
+    """
+    avg_buy_price = _decimal(preview.get("avg_buy_price"))
+    if avg_buy_price is None or avg_buy_price <= 0:
+        # No cost basis => no P&L => no classification. The avg*1.01 preview
+        # guard fails open on unknown cost basis (order_validation), so a
+        # passing preview is not evidence of profit here.
+        return SellProfitVerdict("unclassifiable", {"avg_buy_price": "unavailable"})
+
+    band = avg_buy_price * limits.breakeven_band_pct / Decimal("100")
+    distance_from_avg = limit_price - avg_buy_price
+    base = {
+        "avg_buy_price": _text(avg_buy_price),
+        "breakeven_band_pct": _text(limits.breakeven_band_pct),
+        "round_trip_cost_bps": _text(limits.round_trip_cost_bps),
+    }
+    if abs(distance_from_avg) <= band:
+        return SellProfitVerdict(
+            "breakeven_band",
+            {**base, "distance_from_avg": _text(distance_from_avg)},
+        )
+
+    # Charge the whole round trip against the larger of the two legs. Both legs
+    # are charged at the same rate rather than split, which overstates the cost
+    # -- the direction that narrows the profit-take test.
+    cost = (
+        max(limit_price, avg_buy_price)
+        * quantity
+        * limits.round_trip_cost_bps
+        / Decimal("10000")
+    )
+    gross = distance_from_avg * quantity
+    # The preview computes its own gross P&L from the same avg cost. If it is
+    # more pessimistic than ours, believe it.
+    preview_gross = _decimal(preview.get("realized_pnl"))
+    if preview_gross is not None:
+        gross = min(gross, preview_gross)
+    net = gross - cost
+    details = {
+        **base,
+        "gross_pnl": _text(gross),
+        "round_trip_cost": _text(cost),
+        "net_pnl": _text(net),
+    }
+    # Strictly greater than zero: exactly break-even is not a profit.
+    return SellProfitVerdict("take_profit" if net > 0 else "not_profitable", details)
 
 
 def evaluate_auto_approve_eligibility(
@@ -103,17 +269,33 @@ def evaluate_auto_approve_eligibility(
     def reject(reason: str, **details: str) -> AutoApproveDecision:
         return AutoApproveDecision(False, reason, {**base, **details})
 
+    mode = limits.mode
+    if mode not in ("off", "expanded"):
+        # An unrecognised mode is not a licence to submit.
+        return reject("unknown_auto_approve_mode", mode=str(mode))
+    base["mode"] = mode
+
     if (getattr(group, "action", None) or "place") != "place":
         return reject("action_not_place")
     if getattr(group, "order_type", None) != "limit":
         return reject("order_type_not_limit")
-    if getattr(group, "exit_intent", None) is not None:
-        return reject("exit_intent_present")
+    exit_intent = getattr(group, "exit_intent", None)
+    if exit_intent == "loss_cut":
+        # §40차: a loss cut is always a human's call. Kept as its own reason so
+        # the audit row says why, and so a future exit-intent vocabulary cannot
+        # dilute this branch.
+        return reject("loss_cut_intent")
+    if exit_intent is not None:
+        return reject("exit_intent_present", exit_intent=str(exit_intent))
     if (
         getattr(group, "account_mode", None),
         getattr(group, "market", None),
     ) not in _VETO_CAPABLE_ACCOUNT_MARKETS:
         return reject("account_not_veto_capable")
+    # Applied in both modes: this can only ever reject.
+    tags = find_approval_required_tags(group)
+    if tags:
+        return reject("approval_required_tag", tags=",".join(tags))
     if preview.get("success") is not True:
         return reject("preview_guard_failed")
 
@@ -147,25 +329,61 @@ def evaluate_auto_approve_eligibility(
             daily_cap=_text(limits.daily_cap),
         )
 
-    min_fraction = limits.min_distance_pct / Decimal("100")
     side = getattr(rung, "side", None)
+    if side not in ("buy", "sell"):
+        return reject("side_not_supported")
+
+    # `expanded` drops the min_distance_pct floor but still requires the rung
+    # to rest: a buy at or above the market (a sell at or below it) can fill
+    # before the operator ever sees the veto card.
+    min_fraction = (
+        Decimal("0") if mode == "expanded" else limits.min_distance_pct / Decimal("100")
+    )
+    profit_details: dict[str, str] = {}
     if side == "buy":
         threshold = current_price * (Decimal("1") - min_fraction)
         distance_pct = (current_price - limit_price) / current_price * Decimal("100")
         if limit_price > threshold:
-            return reject("distance_below_minimum")
+            return reject(
+                "marketable_not_resting"
+                if mode == "expanded"
+                else "distance_below_minimum"
+            )
         loss_guard = "not_applicable"
-    elif side == "sell":
+    else:
         threshold = current_price * (Decimal("1") + min_fraction)
         distance_pct = (limit_price - current_price) / current_price * Decimal("100")
         if limit_price < threshold:
-            return reject("distance_below_minimum")
+            return reject(
+                "marketable_not_resting"
+                if mode == "expanded"
+                else "distance_below_minimum"
+            )
         # A successful fresh sell preview means the existing avg-cost loss
         # guard ran and passed. We record that provenance instead of
         # reimplementing the guard with a potentially different threshold.
         loss_guard = "preview_passed"
-    else:
-        return reject("side_not_supported")
+        if mode == "expanded":
+            # ...but the preview guard fails open on unknown cost basis and is
+            # bypassable (defensive_trim / loss_cut / mock), so `expanded`
+            # proves the profit itself rather than inheriting that verdict.
+            verdict = classify_sell_profit(
+                limit_price=limit_price,
+                quantity=quantity,
+                preview=preview,
+                limits=limits,
+            )
+            profit_details = verdict.details
+            if verdict.verdict != "take_profit":
+                return reject(
+                    {
+                        "breakeven_band": "breakeven_band",
+                        "not_profitable": "expected_pnl_not_positive",
+                        "unclassifiable": "sell_classification_unavailable",
+                    }[verdict.verdict],
+                    **verdict.details,
+                )
+            loss_guard = "net_profit_proven"
 
     return AutoApproveDecision(
         True,
@@ -182,6 +400,7 @@ def evaluate_auto_approve_eligibility(
             "per_order_cap": _text(limits.per_order_cap),
             "daily_cap": _text(limits.daily_cap),
             "loss_guard": loss_guard,
+            **profit_details,
         },
     )
 
@@ -227,7 +446,10 @@ def build_auto_approved_message(
 __all__ = [
     "AutoApproveDecision",
     "AutoApproveLimits",
-    "evaluate_auto_approve_eligibility",
+    "SellProfitVerdict",
     "build_auto_approved_message",
+    "classify_sell_profit",
+    "evaluate_auto_approve_eligibility",
+    "find_approval_required_tags",
     "limits_for_market",
 ]

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-08-08.1"
+version: "2026-08-12.1"
 captured_as_of: "2026-08-08"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner)"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off)"
 
 authority:
   scope: judgment_policy_only
@@ -45,6 +45,37 @@ order_proposals:
       kr: 500000
       us: 400
       crypto: 300000
+    # AUTO-APPROVE-EXPAND (§40차) — inputs to the profit-take classification,
+    # consumed only when ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded.
+    #
+    # breakeven_band_pct: the ±% band around avg_buy_price inside which a sell
+    # is treated as a break-even boundary case and must go to a human, whatever
+    # the sign of the P&L. §40차 fixes this at 1%.
+    breakeven_band_pct: 1
+    #
+    # round_trip_cost_bps: total both-leg cost (commission + transaction tax +
+    # FX spread where applicable), used to net down expected realized P&L
+    # before the "> 0" test.
+    #
+    # These are NOT measured rates. The veto-capable ledgers
+    # (review.kis_live_order_ledger, review.live_order_ledger) have no
+    # commission/tax columns, so this repo has no realized fee evidence for
+    # kis_live or upbit to derive a rate from — only review.toss_live_order_ledger
+    # records commission/tax, and toss_live is not veto-capable. Until a measured
+    # rate exists these are the CONSERVATIVE MAXIMUM of the rates this repo
+    # already declares, so the profit-take test is narrower than reality:
+    #   kr     47.4 = 14.7bp x 2 legs (account_routing kis_domestic commission_bps)
+    #                 + 18bp sell tax (paper_trading FEE_RATES equity_kr tax_sell)
+    #                 vs the 21bp the paper_trading commission alone implies.
+    #   us     90.0 = (25bp commission + 20bp fx spread) x 2 legs
+    #                 (account_routing kis_overseas) vs 14bp from paper_trading.
+    #   crypto 10.0 = 5bp x 2 legs (paper_trading FEE_RATES crypto).
+    # auto_approve.py enforces the same values as a floor, so lowering a number
+    # here cannot widen auto-approval — only raising one has any effect.
+    round_trip_cost_bps:
+      kr: 47.4
+      us: 90
+      crypto: 10
 
 # Raw-sector -> cluster grouping for the concentration cap. A member matches a
 # symbol's symbol_sectors label (name_kr / name_en / source_key) when the member

--- a/docs/runbooks/order-proposal-auto-approve-expand.md
+++ b/docs/runbooks/order-proposal-auto-approve-expand.md
@@ -1,0 +1,137 @@
+# Auto-approve eligibility expansion (§40차)
+
+Extends ROB-871 resting-class auto-approval with the §40차 classification:
+**auto-submit, then veto**, for buys and for *proven* profit-take sells.
+
+Ships inert. `ORDER_PROPOSALS_AUTO_APPROVE_MODE` defaults to `off`, which is
+ROB-871 behaviour unchanged. Arming it is an operator decision and is not part
+of the change that introduced this document.
+
+---
+
+## 1. Where the decision is made
+
+`app/services/order_proposals/auto_approve.py :: evaluate_auto_approve_eligibility`
+— pure, no DB, no broker. The dispatch boundary
+(`order_proposals/dispatch.py :: dispatch_proposal`) supplies the day's
+cumulative auto-approved notional and hands each rung's fresh submit-time
+preview to the classifier through `revalidation._apply_eligibility_gate`.
+
+Two gates sit above it and neither moved:
+
+| gate | effect |
+| --- | --- |
+| `settings.ORDER_PROPOSALS_AUTO_APPROVE` (ROB-871) | master. Off ⇒ every proposal goes to Telegram. |
+| `settings.ORDER_PROPOSALS_AUTO_APPROVE_MODE` (§40차) | selects the classification. `off` ⇒ ROB-871 rules. |
+
+## 2. The classification
+
+Structural gates, applied in both modes, in this order — the first that fires
+wins and the proposal goes to a human:
+
+1. `action != place` → `action_not_place`
+2. `order_type != limit` → `order_type_not_limit`
+3. `exit_intent == "loss_cut"` → **`loss_cut_intent`**
+4. any other `exit_intent` → `exit_intent_present`
+5. account/market not in `_VETO_CAPABLE_ACCOUNT_MARKETS` → `account_not_veto_capable`
+6. `policy_deviation` / `table_disagreement` tag → **`approval_required_tag`**
+7. preview did not succeed → `preview_guard_failed`
+8. missing/non-positive price or quantity → `price_or_quantity_missing`
+9. per-order cap → `per_order_cap_exceeded`
+10. daily cap → `daily_cap_exceeded`
+
+Then, per mode:
+
+| | `off` | `expanded` |
+| --- | --- | --- |
+| buy | limit ≤ market × (1 − `min_distance_pct`) | limit ≤ market |
+| sell | limit ≥ market × (1 + `min_distance_pct`) | limit ≥ market **and** proven profit-take |
+
+"Proven profit-take" (`classify_sell_profit`), evaluated in this order:
+
+1. **break-even band first.** `|limit − avg_buy_price| ≤ avg_buy_price × breakeven_band_pct`
+   → `breakeven_band`. Checked before the sign test on purpose: §40차 sends the
+   band to a human *whatever the sign*, so a sell 0.5% above cost is still a
+   human's call. The band is inclusive — exactly ±1% is inside it.
+2. **net P&L strictly positive.**
+   `net = (limit − avg) × qty − max(limit, avg) × qty × round_trip_cost_bps / 10000`.
+   `net > 0` → `take_profit`; `net == 0` → `expected_pnl_not_positive`. Exactly
+   zero is not "> 0".
+3. **no cost basis, no verdict.** A missing, zero or unparseable
+   `avg_buy_price` → `sell_classification_unavailable`. The preview's own
+   avg×1.01 guard fails *open* on unknown cost basis and is bypassable
+   (`defensive_trim` / `loss_cut` / mock), so a passing preview is not evidence
+   of profit and `expanded` proves it independently.
+
+## 3. Deliberately narrower than the §40차 literal
+
+`expanded` drops `min_distance_pct` but still requires the rung to **rest** —
+a buy at or above the market, or a sell at or below it, can fill before the
+operator ever sees the card, which would make the veto button that §40차 safety
+invariant ① depends on a lie. §40차 forbids being *broader* than its literal;
+this is narrower, which is the permitted direction. Relaxing it is an operator
+decision, not a code cleanup.
+
+The tag gate (step 6) also applies in `off` mode. It can only reject, so it is
+a tightening of ROB-871, not a widening.
+
+## 4. Fee rate provenance
+
+`round_trip_cost_bps` is **not a measured rate**, and there is currently no way
+to make it one from inside this repo: the two veto-capable ledgers
+(`review.kis_live_order_ledger`, `review.live_order_ledger`) have no
+`commission`/`tax` columns, so no realized fee evidence exists for `kis_live`
+or `upbit`. Only `review.toss_live_order_ledger` records commission and tax,
+and `toss_live` is not veto-capable.
+
+Until that changes, the values are the **conservative maximum of the rates this
+repo already declares**, so the profit-take test is narrower than reality:
+
+| market | bps | derivation |
+| --- | --- | --- |
+| kr | 47.4 | 14.7bp × 2 legs (`account_routing` `kis_domestic.commission_bps`) + 18bp sell tax (`paper_trading.FEE_RATES["equity_kr"]["tax_sell"]`). The `paper_trading` commission alone would give 21bp. |
+| us | 90.0 | (25bp commission + 20bp FX spread) × 2 legs (`account_routing` `kis_overseas`). `paper_trading` alone would give 14bp. |
+| crypto | 10.0 | 5bp × 2 legs (`paper_trading.FEE_RATES["crypto"]`). |
+
+The rate lives in `config/trading_policy.yaml` (operator-owned, PR-only), and
+`_ROUND_TRIP_COST_BPS_FLOOR` in `auto_approve.py` enforces the same numbers as
+a floor. **Lowering a number in the YAML has no effect** — only raising one
+does. Replacing these with a measured rate means adding fee columns to the
+kis_live / live ledgers first; that is a separate change.
+
+Both legs are charged at the full round-trip rate against the larger leg, which
+overstates the cost. That is the direction that narrows the test.
+
+## 5. Atomic dispatch recheck (#1836 / ROB-1238)
+
+Auto-approved rungs are **not** on a shortcut path. Eligibility runs inside
+`_revalidate_place_rung`, and every rung it clears then continues through the
+same sequence as a Telegram-approved rung:
+
+```
+_apply_eligibility_gate        revalidation.py:1149   <- auto-approve verdict
+_pre_mutation_window_gate      revalidation.py:1160
+buying-power claim             revalidation.py:1171
+_pre_mutation_window_gate      revalidation.py:1225
+_pre_submit_lifecycle_gate     revalidation.py:1241   <- ROB-1238 atomic recheck
+place_order(dry_run=False)     revalidation.py:1267
+```
+
+`_pre_submit_lifecycle_gate` re-reads the proposal row `FOR UPDATE` and holds
+that lock across the submit, rechecking terminal state, `no_resubmit`,
+`valid_until`, the approval token and the loss-guard verdict. There is no code
+path on which an auto-approved rung reaches the broker without it.
+
+## 6. Arming it (operator)
+
+Not part of the introducing change. When the time comes:
+
+1. Confirm `ORDER_PROPOSALS_AUTO_APPROVE=true` is already the intended state —
+   the mode is subordinate to it.
+2. Set `ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded` for one account lane and
+   watch `source_asof.auto_approved.eligibility[]` on the resulting proposals:
+   every rung records its reason and, for sells, `gross_pnl`,
+   `round_trip_cost` and `net_pnl`.
+3. Roll back by setting the mode back to `off`. Orders already submitted are
+   unaffected — cancel those through the veto button or
+   `order_proposal_cancel`.

--- a/docs/runbooks/order-proposal-auto-approve-expand.md
+++ b/docs/runbooks/order-proposal-auto-approve-expand.md
@@ -44,33 +44,41 @@ Then, per mode:
 
 | | `off` | `expanded` |
 | --- | --- | --- |
-| buy | limit ≤ market × (1 − `min_distance_pct`) | limit ≤ market |
-| sell | limit ≥ market × (1 + `min_distance_pct`) | limit ≥ market **and** proven profit-take |
+| buy | limit ≤ market × (1 − `min_distance_pct`) | limit **<** market |
+| sell | limit ≥ market × (1 + `min_distance_pct`) | limit **>** market **and** proven profit-take |
+
+The `expanded` comparison is strict on purpose: a limit priced exactly *on* the
+market is marketable. `off` keeps ROB-871's non-strict boundary (a rung exactly
+`min_distance_pct` away stays eligible), so the strictness cannot change any
+verdict the shipped mode reaches.
 
 "Proven profit-take" (`classify_sell_profit`), evaluated in this order:
 
-1. **break-even band first.** `|limit − avg_buy_price| ≤ avg_buy_price × breakeven_band_pct`
-   → `breakeven_band`. Checked before the sign test on purpose: §40차 sends the
-   band to a human *whatever the sign*, so a sell 0.5% above cost is still a
-   human's call. The band is inclusive — exactly ±1% is inside it.
-2. **net P&L strictly positive.**
+1. **no cost basis, no verdict.** A missing, zero or unparseable
+   `avg_buy_price` → `sell_classification_unavailable`, ahead of both tests
+   below — an unpriceable sell never reports a band or a P&L verdict. The
+   preview's own avg×1.01 guard fails *open* on unknown cost basis and is
+   bypassable (`defensive_trim` / `loss_cut` / mock), so a passing preview is
+   not evidence of profit and `expanded` proves it independently.
+2. **break-even band before the sign test.**
+   `|limit − avg_buy_price| ≤ avg_buy_price × breakeven_band_pct`
+   → `breakeven_band`. Ahead of the sign test on purpose: §40차 sends the band
+   to a human *whatever the sign*, so a sell 0.5% above cost is still a human's
+   call. The band is inclusive — exactly ±1% is inside it.
+3. **net P&L strictly positive.**
    `net = (limit − avg) × qty − max(limit, avg) × qty × round_trip_cost_bps / 10000`.
    `net > 0` → `take_profit`; `net == 0` → `expected_pnl_not_positive`. Exactly
    zero is not "> 0".
-3. **no cost basis, no verdict.** A missing, zero or unparseable
-   `avg_buy_price` → `sell_classification_unavailable`. The preview's own
-   avg×1.01 guard fails *open* on unknown cost basis and is bypassable
-   (`defensive_trim` / `loss_cut` / mock), so a passing preview is not evidence
-   of profit and `expanded` proves it independently.
 
 ## 3. Deliberately narrower than the §40차 literal
 
 `expanded` drops `min_distance_pct` but still requires the rung to **rest** —
 a buy at or above the market, or a sell at or below it, can fill before the
 operator ever sees the card, which would make the veto button that §40차 safety
-invariant ① depends on a lie. §40차 forbids being *broader* than its literal;
-this is narrower, which is the permitted direction. Relaxing it is an operator
-decision, not a code cleanup.
+invariant ① depends on a lie. "At" counts: a limit exactly on the market is
+rejected as `marketable_not_resting`. §40차 forbids being *broader* than its
+literal; this is narrower, which is the permitted direction. Relaxing it is an
+operator decision, not a code cleanup.
 
 The tag gate (step 6) also applies in `off` mode. It can only reject, so it is
 a tightening of ROB-871, not a widening.

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -226,6 +226,44 @@ def test_expanded_marketable_orders_keep_the_veto_button_meaningful():
     assert (sell.eligible, sell.reason) == (False, "marketable_not_resting")
 
 
+def test_expanded_limit_exactly_on_the_market_is_marketable():
+    """A limit priced ON the market can fill before the card is seen."""
+    buy = _evaluate(
+        limit_price=Decimal("100000"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+    sell = _evaluate(
+        side="sell",
+        limit_price=Decimal("100000"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(),
+    )
+
+    assert (buy.eligible, buy.reason) == (False, "marketable_not_resting")
+    assert (sell.eligible, sell.reason) == (False, "marketable_not_resting")
+
+
+def test_off_mode_keeps_its_non_strict_distance_boundary():
+    """ROB-871 boundary unchanged: exactly min_distance_pct away stays eligible."""
+    buy = _evaluate(
+        limits=_LIMITS,
+        limit_price=Decimal("97000"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+    sell = _evaluate(
+        limits=_LIMITS,
+        side="sell",
+        limit_price=Decimal("103000"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+
+    assert buy.eligible is True
+    assert sell.eligible is True
+
+
 def test_expanded_take_profit_sell_is_eligible():
     """§40차 ② — profit proven at the limit price, net of round-trip cost."""
     decision = _evaluate(

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -11,6 +11,8 @@ from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.auto_approve import (
     AutoApproveLimits,
     evaluate_auto_approve_eligibility,
+    find_approval_required_tags,
+    limits_for_market,
 )
 from app.services.order_proposals.service import RungInput
 
@@ -94,7 +96,12 @@ def test_sell_requires_distance_and_previewed_loss_guard():
         ({"order_type": "market"}, {}, "order_type_not_limit"),
         ({"action": "replace"}, {}, "action_not_place"),
         ({"action": "cancel"}, {}, "action_not_place"),
-        ({"exit_intent": "loss_cut"}, {"side": "sell"}, "exit_intent_present"),
+        ({"exit_intent": "loss_cut"}, {"side": "sell"}, "loss_cut_intent"),
+        (
+            {"exit_intent": "unknown_future_intent"},
+            {"side": "sell"},
+            "exit_intent_present",
+        ),
         ({"account_mode": "toss_live"}, {}, "account_not_veto_capable"),
         ({}, {"limit_price": Decimal("98000")}, "distance_below_minimum"),
         ({}, {"quantity": Decimal("3")}, "per_order_cap_exceeded"),
@@ -126,6 +133,373 @@ def test_daily_cap_one_unit_over_boundary_is_ineligible():
 
     assert decision.eligible is False
     assert decision.reason == "daily_cap_exceeded"
+
+
+# ---------------------------------------------------------------------------
+# AUTO-APPROVE-EXPAND (§40차) — expanded-mode classification
+# ---------------------------------------------------------------------------
+
+# Cost rate deliberately 200bps so the "net P&L exactly zero" boundary lands on
+# round numbers: net == 0 <=> limit * (1 - 0.02) == avg_buy_price.
+_EXPANDED = AutoApproveLimits(
+    min_distance_pct=Decimal("3"),
+    per_order_cap=Decimal("200000"),
+    daily_cap=Decimal("500000"),
+    policy_version="test-policy",
+    mode="expanded",
+    breakeven_band_pct=Decimal("1"),
+    round_trip_cost_bps=Decimal("200"),
+)
+
+
+def _evaluate(
+    *, limits=_EXPANDED, group_overrides=None, preview=None, **rung_overrides
+):
+    return evaluate_auto_approve_eligibility(
+        group=_group(**(group_overrides or {})),
+        rung=_rung(**rung_overrides),
+        preview=preview if preview is not None else {"success": True},
+        limits=limits,
+        daily_notional=Decimal("0"),
+    )
+
+
+def _sell_preview(*, current_price="100000", avg_buy_price="98000", **extra):
+    preview = {
+        "success": True,
+        "current_price": current_price,
+        "avg_buy_price": avg_buy_price,
+    }
+    preview.update(extra)
+    return preview
+
+
+def test_expanded_buy_inside_min_distance_is_eligible():
+    """§40차 ① — a buy no longer has to rest 3% away, only below the market."""
+    decision = _evaluate(
+        limit_price=Decimal("99500"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+
+    assert decision.eligible is True
+    assert decision.details["mode"] == "expanded"
+
+
+def test_off_mode_rejects_what_expanded_would_allow():
+    """Mutant ⑧ — the §40차 rules must not leak into the default mode."""
+    near_market_buy = {
+        "limit_price": Decimal("99500"),
+        "quantity": Decimal("1"),
+        "preview": {"success": True, "current_price": "100000"},
+    }
+    profitable_near_market_sell = {
+        "side": "sell",
+        "limit_price": Decimal("100500"),
+        "quantity": Decimal("1"),
+        "preview": _sell_preview(),
+    }
+
+    for kwargs in (near_market_buy, profitable_near_market_sell):
+        off = _evaluate(limits=_LIMITS, **kwargs)
+        expanded = _evaluate(**kwargs)
+
+        assert off.eligible is False
+        assert off.reason == "distance_below_minimum"
+        assert expanded.eligible is True
+
+
+def test_expanded_marketable_orders_keep_the_veto_button_meaningful():
+    buy = _evaluate(
+        limit_price=Decimal("100001"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+    sell = _evaluate(
+        side="sell",
+        limit_price=Decimal("99999"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(),
+    )
+
+    assert (buy.eligible, buy.reason) == (False, "marketable_not_resting")
+    assert (sell.eligible, sell.reason) == (False, "marketable_not_resting")
+
+
+def test_expanded_take_profit_sell_is_eligible():
+    """§40차 ② — profit proven at the limit price, net of round-trip cost."""
+    decision = _evaluate(
+        side="sell",
+        limit_price=Decimal("105000"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(),
+    )
+
+    assert decision.eligible is True
+    assert decision.details["loss_guard"] == "net_profit_proven"
+    # gross 7000 - 105000 * 2% = 4900
+    assert decision.details["gross_pnl"] == "7000"
+    assert decision.details["round_trip_cost"] == "2100"
+    assert decision.details["net_pnl"] == "4900"
+
+
+def test_expanded_loss_cut_intent_never_auto_submits():
+    """Mutant ① — the highest-priority leak."""
+    decision = _evaluate(
+        group_overrides={"exit_intent": "loss_cut"},
+        side="sell",
+        limit_price=Decimal("105000"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(),
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == "loss_cut_intent"
+
+
+def test_expanded_sell_below_cost_is_not_auto_approved():
+    """Mutant ② — negative expected P&L, even with a passing preview."""
+    decision = _evaluate(
+        side="sell",
+        limit_price=Decimal("105000"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(avg_buy_price="110000"),
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == "expected_pnl_not_positive"
+
+
+def test_expanded_net_pnl_exactly_zero_requires_approval():
+    """Mutant ③ — "> 0" excludes 0. 100000 * (1 - 2%) == 98000."""
+    at_zero = _evaluate(
+        side="sell",
+        limit_price=Decimal("100000"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(current_price="99000"),
+    )
+    one_tick_above = _evaluate(
+        side="sell",
+        limit_price=Decimal("100001"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(current_price="99000"),
+    )
+
+    assert at_zero.details["net_pnl"] == "0"
+    assert at_zero.eligible is False
+    assert at_zero.reason == "expected_pnl_not_positive"
+    assert one_tick_above.eligible is True
+
+
+def test_expanded_fee_rate_is_charged_before_the_sign_test():
+    """A gross-positive sell that round-trip cost drags to <= 0 is not a profit."""
+    gross_only = (Decimal("100000") - Decimal("98000")) * Decimal("1")
+    decision = _evaluate(
+        side="sell",
+        limit_price=Decimal("100000"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(current_price="99000"),
+    )
+
+    assert gross_only > 0
+    assert Decimal(decision.details["round_trip_cost"]) >= gross_only
+    assert decision.eligible is False
+
+
+def test_expanded_trusts_the_more_pessimistic_preview_pnl():
+    decision = _evaluate(
+        side="sell",
+        limit_price=Decimal("105000"),
+        quantity=Decimal("1"),
+        preview=_sell_preview(realized_pnl="1000"),
+    )
+
+    assert decision.details["gross_pnl"] == "1000"
+    assert decision.eligible is False
+    assert decision.reason == "expected_pnl_not_positive"
+
+
+@pytest.mark.parametrize(
+    ("limit_price", "current_price", "avg_buy_price"),
+    [
+        # +1% exactly above avg cost — the avg*1.01 guard's own boundary.
+        (Decimal("101000"), Decimal("100000"), "100000"),
+        # -1% exactly below avg cost, still resting above the market.
+        (Decimal("99000"), Decimal("98000"), "100000"),
+    ],
+)
+def test_expanded_breakeven_band_requires_approval(
+    limit_price, current_price, avg_buy_price
+):
+    """Mutant ④ — ±1% around cost is a human's call whatever the P&L sign."""
+    decision = _evaluate(
+        side="sell",
+        limit_price=limit_price,
+        quantity=Decimal("1"),
+        preview=_sell_preview(current_price=current_price, avg_buy_price=avg_buy_price),
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == "breakeven_band"
+
+
+@pytest.mark.parametrize("mode_limits", [_LIMITS, _EXPANDED])
+@pytest.mark.parametrize(
+    "group_overrides",
+    [
+        {"rationale": {"tags": ["policy_deviation"]}},
+        {"rationale": {"decision": {"flags": ["table_disagreement"]}}},
+        {"thesis": "reviewed under Policy_Deviation waiver"},
+        {"source_asof": {"table_disagreement": True}},
+        {"lot_context": {"notes": ["table_disagreement"]}},
+    ],
+)
+def test_tagged_proposals_require_approval_in_every_mode(mode_limits, group_overrides):
+    """Mutant ⑤ — no pricing can buy a tagged proposal past the operator."""
+    decision = _evaluate(
+        limits=mode_limits,
+        group_overrides=group_overrides,
+        limit_price=Decimal("97000"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == "approval_required_tag"
+
+
+def test_untagged_proposal_is_not_falsely_flagged():
+    assert find_approval_required_tags(_group(thesis="ordinary support retest")) == ()
+
+
+def test_unserializable_metadata_is_treated_as_tagged():
+    class _Hostile:
+        def __getattr__(self, name):
+            raise RuntimeError("metadata unavailable")
+
+    assert find_approval_required_tags(_Hostile()) == (
+        "policy_deviation",
+        "table_disagreement",
+    )
+
+
+@pytest.mark.parametrize(
+    ("preview_overrides", "expected_reason"),
+    [
+        ({"avg_buy_price": None}, "sell_classification_unavailable"),
+        ({"avg_buy_price": "0"}, "sell_classification_unavailable"),
+        ({"avg_buy_price": "not-a-number"}, "sell_classification_unavailable"),
+    ],
+)
+def test_expanded_unclassifiable_sell_fails_closed(preview_overrides, expected_reason):
+    """Mutant ⑥ — an unknown cost basis is not a clearance."""
+    preview = _sell_preview()
+    preview.update(preview_overrides)
+    decision = _evaluate(
+        side="sell",
+        limit_price=Decimal("105000"),
+        quantity=Decimal("1"),
+        preview=preview,
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == expected_reason
+
+
+def test_expanded_does_not_widen_the_eligible_account_set():
+    """Mutant ⑦ — §40차 must not hand auto-approval to a non-cancellable lane."""
+    for account_mode, market in (
+        ("toss_live", "equity_kr"),
+        ("kis_mock", "equity_kr"),
+        ("kiwoom_mock", "equity_kr"),
+        ("alpaca_paper", "equity_us"),
+    ):
+        decision = _evaluate(
+            group_overrides={"account_mode": account_mode, "market": market},
+            limit_price=Decimal("99500"),
+            quantity=Decimal("1"),
+            preview={"success": True, "current_price": "100000"},
+        )
+
+        assert decision.eligible is False
+        assert decision.reason == "account_not_veto_capable"
+
+
+def test_unknown_mode_fails_closed():
+    decision = _evaluate(
+        limits=AutoApproveLimits(
+            min_distance_pct=Decimal("3"),
+            per_order_cap=Decimal("200000"),
+            daily_cap=Decimal("500000"),
+            policy_version="test-policy",
+            mode="on",
+        ),
+        limit_price=Decimal("97000"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == "unknown_auto_approve_mode"
+
+
+def test_expanded_still_honours_the_existing_caps():
+    per_order = _evaluate(
+        limit_price=Decimal("99000"),
+        quantity=Decimal("3"),
+        preview={"success": True, "current_price": "100000"},
+    )
+    daily = evaluate_auto_approve_eligibility(
+        group=_group(),
+        rung=_rung(limit_price=Decimal("99000"), quantity=Decimal("1")),
+        preview={"success": True, "current_price": "100000"},
+        limits=_EXPANDED,
+        daily_notional=Decimal("401001"),
+    )
+
+    assert per_order.reason == "per_order_cap_exceeded"
+    assert daily.reason == "daily_cap_exceeded"
+
+
+def test_shipped_default_mode_is_off(monkeypatch):
+    """ENV_GATE — the repo ships the expansion inert."""
+    from app.core.config import Settings
+
+    assert Settings.model_fields["ORDER_PROPOSALS_AUTO_APPROVE_MODE"].default == "off"
+    assert limits_for_market("equity_kr").mode == "off"
+
+
+def test_policy_cost_rate_cannot_be_edited_below_the_code_floor(monkeypatch):
+    """FEE_RATE — a cheaper YAML must not widen the profit-take test."""
+    from app.services.order_proposals import auto_approve as module
+
+    cheap = SimpleNamespace(
+        version="probe",
+        order_proposals=SimpleNamespace(
+            auto_approve=SimpleNamespace(
+                min_distance_pct=3,
+                per_order_cap={"kr": 200000, "us": 150, "crypto": 100000},
+                daily_cap={"kr": 500000, "us": 400, "crypto": 300000},
+                breakeven_band_pct=1,
+                round_trip_cost_bps={"kr": 0, "us": 0, "crypto": 0},
+            )
+        ),
+    )
+    monkeypatch.setattr(module, "load_trading_policy", lambda: cheap)
+
+    assert limits_for_market("equity_kr").round_trip_cost_bps == Decimal("47.4")
+    assert limits_for_market("equity_us").round_trip_cost_bps == Decimal("90")
+    assert limits_for_market("crypto").round_trip_cost_bps == Decimal("10")
+
+
+def test_expanded_mode_flows_from_settings(monkeypatch):
+    from app.services.order_proposals import auto_approve as module
+
+    monkeypatch.setattr(
+        module.settings, "ORDER_PROPOSALS_AUTO_APPROVE_MODE", "expanded"
+    )
+
+    assert limits_for_market("equity_kr").mode == "expanded"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

ROB-871 auto-approves only rungs resting `min_distance_pct` (3%) away from the market, and rejects anything carrying an `exit_intent`. §40차 widens that to **submit, then veto**: buys, plus sells whose expected realized P&L at the limit price is provably positive.

The classification lives in the existing pure module (`order_proposals/auto_approve.py`) and is selected by a new env gate, `ORDER_PROPOSALS_AUTO_APPROVE_MODE`, **default `off`**. `off` is ROB-871 unchanged. **The expansion ships inert — arming it is an operator decision and is not part of this PR.**

## Approval stays mandatory, fail-closed

| condition | reason code |
| --- | --- |
| `exit_intent="loss_cut"` | `loss_cut_intent` |
| any other `exit_intent` | `exit_intent_present` |
| expected realized P&L ≤ 0 after round-trip cost | `expected_pnl_not_positive` |
| ±1% break-even band around avg cost | `breakeven_band` |
| `policy_deviation` / `table_disagreement` tag | `approval_required_tag` |
| missing / zero / unparseable cost basis | `sell_classification_unavailable` |
| unrecognised mode | `unknown_auto_approve_mode` |

Exactly zero P&L is **not** "> 0". The band is checked **before** the sign test, because §40차 sends the band to a human whatever the sign — a sell 0.5% above cost is still a human's call. The band is inclusive: exactly ±1% is inside it.

The tag gate applies in **both** modes; it can only reject, so it is a tightening of ROB-871, not a widening.

## Deliberately narrower than the §40차 literal

`expanded` drops `min_distance_pct` but still requires the rung to **rest**. A marketable order can fill before the operator sees the card, which would make the veto button that §40차 safety invariant ① depends on a lie. §40차 forbids being *broader* than its literal; this is narrower, which is the permitted direction. Flagged for the operator — relaxing it is a decision, not a cleanup.

## Fee rate provenance

`round_trip_cost_bps` is **not a measured rate**, and cannot be one from inside this repo: `review.kis_live_order_ledger` and `review.live_order_ledger` have no `commission`/`tax` columns, so no realized fee evidence exists for `kis_live` or `upbit`. Only `review.toss_live_order_ledger` records them, and `toss_live` is not veto-capable.

The values are the **conservative maximum of the rates this repo already declares**:

| market | bps | derivation |
| --- | --- | --- |
| kr | 47.4 | 14.7bp × 2 legs (`account_routing` kis_domestic) + 18bp sell tax (`paper_trading` FEE_RATES). `paper_trading` commission alone would give 21bp. |
| us | 90.0 | (25bp + 20bp FX) × 2 legs (`account_routing` kis_overseas) vs 14bp from `paper_trading`. |
| crypto | 10.0 | 5bp × 2 legs (`paper_trading` FEE_RATES crypto). |

The rate lives in `config/trading_policy.yaml` (operator-owned, PR-only) and `auto_approve.py` enforces the same numbers as a **floor** — lowering the YAML has no effect, only raising it does. Cost is charged at the full round-trip rate against the larger leg, which overstates it: the direction that narrows the test.

## Unchanged

- **Veto-capable account set** — `_VETO_CAPABLE_ACCOUNT_MARKETS` is byte-identical. No account gains auto-approval.
- **Daily / per-order cap** — `service.auto_approved_daily_notional` reused as-is; no new aggregation.
- **ROB-1238 atomic recheck (#1836)** — eligibility runs at `revalidation.py:1149`; every rung it clears still passes `_pre_submit_lifecycle_gate` at `:1241` (row re-read `FOR UPDATE`, lock held across the submit) before `place_order(dry_run=False)` at `:1267`. There is no auto-approve shortcut path.

## Verification

- `tests/services/order_proposals/test_auto_approve.py` — 44 passed (was 15).
- Whole `tests/services/order_proposals/` suite — 716 passed.
- All 10 policy-consuming test modules — 255 passed.
- **False-green probe**: 10 source mutations (each flipping one assertion-critical line: `net > 0` → `>=`, loss-cut branch removed, band `<=` → `<`, tag gate removed, unknown cost basis → profit, `toss_live` added to the veto set, expanded rules leaked into `off`, unknown mode allowed, cost floor `max` → `min`, marketable check widened). **All 10 went red.**
- `ruff check` / `ruff format --check` / `ty check app/ --error-on-warning` — clean.

No broker or account contact, no scheduler registration, no migration, no `env` actually turned on.

Runbook: `docs/runbooks/order-proposal-auto-approve-expand.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional expanded mode for automatically approving eligible order proposals.
  * Added configurable break-even bands and market-specific transaction-cost thresholds.
  * Proven profitable sells may be auto-approved, while uncertain, loss-making, tagged, or break-even proposals still require approval.
  * Automatic approval remains disabled by default.

* **Documentation**
  * Added an operator runbook covering configuration, safeguards, activation, and rollback procedures.

* **Bug Fixes**
  * Improved conservative handling of unknown costs, invalid metadata, and non-positive net returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->