### PR TITLE
docs(mcp): document route_request advisory/enforcement dual structure (ROB-1239)

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -2084,6 +2084,10 @@ MCP session state resets on reconnect — ROB-469) is a separate follow-up issue
 In particular, the contract below cannot physically prevent an enabled
 auto-approval path.
 
+**ROB-1239:** the canonical statement of what a `blocked_actions` verdict
+does and does not mean is the `route_request` tool `description=` string in
+`app/mcp_server/tooling/route_request_registration.py`, not this section.
+
 Lane definitions come from the machine-readable `lanes:` blocks in
 `docs/playbooks/trading-decision-playbook.md`; `route_request_lanes.LANE_SEQUENCES`
 is kept in exact order by `tests/test_route_request_registry_diff.py`. Every

--- a/app/mcp_server/profiles.py
+++ b/app/mcp_server/profiles.py
@@ -2,6 +2,13 @@
 
 Profiles gate which tool subsets are registered at startup.
 Profile selection is driven by the MCP_PROFILE env var (default: "default").
+
+ROB-1239: this registration step is the physical enforcement half of the
+route_request advisory/enforcement dual structure — see the module docstring
+in `app/mcp_server/tooling/route_request_registration.py` for the full
+statement. A tool `route_request` lists as blocked is still callable if it is
+registered here; only omitting it from a profile's tool surface is a real
+access-control boundary.
 """
 
 from __future__ import annotations

--- a/app/mcp_server/profiles.py
+++ b/app/mcp_server/profiles.py
@@ -3,12 +3,10 @@
 Profiles gate which tool subsets are registered at startup.
 Profile selection is driven by the MCP_PROFILE env var (default: "default").
 
-ROB-1239: this registration step is the physical enforcement half of the
-route_request advisory/enforcement dual structure — see the module docstring
-in `app/mcp_server/tooling/route_request_registration.py` for the full
-statement. A tool `route_request` lists as blocked is still callable if it is
-registered here; only omitting it from a profile's tool surface is a real
-access-control boundary.
+ROB-1239: for what `route_request`'s `blocked_actions` does and does not mean
+relative to this file's registration, see the canonical statement in
+`app/mcp_server/tooling/route_request_registration.py`'s `route_request` tool
+`description=` string.
 """
 
 from __future__ import annotations

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -1,17 +1,15 @@
 """Tool registration orchestration for MCP server.
 
-ROB-1239: registration below is the physical enforcement half of the
-route_request advisory/enforcement dual structure (see
-`app/mcp_server/tooling/route_request_registration.py` module docstring). A
-tool `route_request` lists in `blocked_actions` for a lane may still be
-callable here if this file registers it on the caller's profile — e.g. the
-five KR `*_mock_get_order_*` / `*_mock_get_positions` / `*_mock_get_orderable_cash`
-read tools are route-BLOCK on every lane yet physically registered on
-McpProfile.DEFAULT (below) because DEFAULT unconditionally registers
-`register_kis_mock_order_tools` and, when `settings.kiwoom_mock_enabled`,
-`orders_kiwoom_variants.register`. Removing a tool from *this* mapping is
-what actually removes it from a session's callable surface; changing its
-`route_request` lane classification does not.
+ROB-1239: for what a `route_request` `blocked_actions` verdict does and does
+not mean relative to what this file registers, see the canonical statement in
+`app/mcp_server/tooling/route_request_registration.py`'s `route_request` tool
+`description=` string. Concrete anchor, McpProfile.DEFAULT (below):
+`kis_mock_get_order_history` is route-BLOCK on every lane and registers
+unconditionally (`register_kis_mock_order_tools`); the other four route-BLOCK
+KR mock reads (`kiwoom_mock_get_order_history`, `kiwoom_mock_get_order_detail`,
+`kiwoom_mock_get_positions`, `kiwoom_mock_get_orderable_cash`) register only
+when `settings.kiwoom_mock_enabled` is true (`orders_kiwoom_variants.register`)
+— code default False (`app/core/config.py:250`, `env.example:39`).
 
 Profile → tool surface mapping
 ────────────────────────────────────────────────────────────────────────────

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -1,5 +1,18 @@
 """Tool registration orchestration for MCP server.
 
+ROB-1239: registration below is the physical enforcement half of the
+route_request advisory/enforcement dual structure (see
+`app/mcp_server/tooling/route_request_registration.py` module docstring). A
+tool `route_request` lists in `blocked_actions` for a lane may still be
+callable here if this file registers it on the caller's profile — e.g. the
+five KR `*_mock_get_order_*` / `*_mock_get_positions` / `*_mock_get_orderable_cash`
+read tools are route-BLOCK on every lane yet physically registered on
+McpProfile.DEFAULT (below) because DEFAULT unconditionally registers
+`register_kis_mock_order_tools` and, when `settings.kiwoom_mock_enabled`,
+`orders_kiwoom_variants.register`. Removing a tool from *this* mapping is
+what actually removes it from a session's callable surface; changing its
+`route_request` lane classification does not.
+
 Profile → tool surface mapping
 ────────────────────────────────────────────────────────────────────────────
 "default" (McpProfile.DEFAULT):

--- a/app/mcp_server/tooling/route_request_registration.py
+++ b/app/mcp_server/tooling/route_request_registration.py
@@ -7,18 +7,9 @@ middleware is a separate follow-up issue (mutation tools only; reads
 unrestricted; caller-header-keyed because MCP session state resets on
 reconnect — ROB-469).
 
-ROB-1239 — advisory/enforcement dual structure. `blocked_actions` in the
-response is advice, not access control: nothing here reads it to refuse a
-tool call, and a tool it names as blocked may still be physically callable if
-it is registered on the caller's MCP profile (`app/mcp_server/profiles.py`,
-`app/mcp_server/tooling/registry.py::register_all_tools`) — that registration
-step is the only layer that removes a tool from the surface a session can
-even see. The two facts are not in tension: the caller MUST still treat
-`blocked_actions` as binding session discipline (this is the operator's
-standing decision — compliance is not optional just because the call would
-succeed); a session that calls a `blocked_actions` tool because it noticed
-the call was technically possible is violating that discipline, not finding
-a loophole.
+ROB-1239: the canonical statement of what `blocked_actions` does and does
+not mean is the `route_request` tool `description=` string below — read
+there, not here.
 """
 
 from __future__ import annotations

--- a/app/mcp_server/tooling/route_request_registration.py
+++ b/app/mcp_server/tooling/route_request_registration.py
@@ -6,6 +6,19 @@ exposes a DIRECT lane->tool ADVISORY tool with NO enforcement. Blocking
 middleware is a separate follow-up issue (mutation tools only; reads
 unrestricted; caller-header-keyed because MCP session state resets on
 reconnect — ROB-469).
+
+ROB-1239 — advisory/enforcement dual structure. `blocked_actions` in the
+response is advice, not access control: nothing here reads it to refuse a
+tool call, and a tool it names as blocked may still be physically callable if
+it is registered on the caller's MCP profile (`app/mcp_server/profiles.py`,
+`app/mcp_server/tooling/registry.py::register_all_tools`) — that registration
+step is the only layer that removes a tool from the surface a session can
+even see. The two facts are not in tension: the caller MUST still treat
+`blocked_actions` as binding session discipline (this is the operator's
+standing decision — compliance is not optional just because the call would
+succeed); a session that calls a `blocked_actions` tool because it noticed
+the call was technically possible is violating that discipline, not finding
+a loophole.
 """
 
 from __future__ import annotations
@@ -172,7 +185,12 @@ def register_route_request_tools(mcp: FastMCP) -> None:
             "profit_taking: it exposes a read -> preflight -> exact reducing "
             "Alpaca Paper sell sequence, while keeping every other direct broker "
             "mutation blocked. Deterministic (same input -> same "
-            "output). ADVISORY ONLY — it does not block anything; it echoes "
+            "output). ADVISORY ONLY — it does not block anything; a tool listed "
+            "in blocked_actions may still be physically callable if your MCP "
+            "profile has it registered (physical enforcement, when it exists, "
+            "lives at profile tool-registration, a separate layer from this "
+            "response). Comply with blocked_actions as session discipline "
+            "regardless — callability is not authorization. It echoes "
             "get_trading_policy (ROB-646) with policy_version so a verdict can "
             "cite the criteria. Buy/sell use the proposal-led-v1 contract: "
             "order_proposal_create is the only order-intent surface, Telegram "

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -126,7 +126,9 @@ lanes:
    fresh preview/revalidation and broker submit belong to the proposal approval
    subsystem. `route_request` is advisory, so it cannot override a deployment's
    auto-approval configuration; the create response's `approval_dispatch` is
-   the runtime truth.
+   the runtime truth. (ROB-1239: canonical semantics for "advisory" — the
+   `route_request` tool `description=` string in
+   `app/mcp_server/tooling/route_request_registration.py`.)
 6. Broker acceptance/resting is not a fill. Converge fill/cancel state through
    the registered broker/account reconcile helper and broker evidence; the
    route has no `account_mode`, so it does not choose one reconcile tool.
@@ -204,8 +206,11 @@ lanes:
 6. Fresh broker preview/revalidation and submit belong to the proposal approval
    subsystem. `route_request` is advisory and cannot override auto-approval
    configuration; `approval_dispatch` in the create response is the runtime
-   truth. Broker acceptance/resting is not a fill, so converge the result with
-   the registered broker/account reconcile helper and broker evidence.
+   truth. (ROB-1239: canonical semantics for "advisory" — the `route_request`
+   tool `description=` string in
+   `app/mcp_server/tooling/route_request_registration.py`.) Broker
+   acceptance/resting is not a fill, so converge the result with the
+   registered broker/account reconcile helper and broker evidence.
 7. WATCH items are recorded as conditional trigger text (e.g. "when in-the-money
    AND resistance reached, place at <price>"). Today this depends on session
    memory / journal — [ROB-637](https://linear.app/mgh3326/issue/ROB-637)

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -46,6 +46,11 @@ for the procedure-contract vs. operator-instruction boundary.
 
 All tool names below are registered in the **DEFAULT** MCP profile.
 
+> **ROB-1239 pointer.** The canonical statement of what "route_request is
+> advisory" means (below, e.g. §1 step 5, §2 step 6) is the `route_request`
+> tool `description=` string in
+> `app/mcp_server/tooling/route_request_registration.py`.
+
 ---
 
 ## 0) Common frame (precedes every decision)


### PR DESCRIPTION
## Summary
- `route_request`'s `blocked_actions` is advisory only — no code path reads it to refuse a tool call. Physical enforcement (fail-closed) happens one layer down, at MCP profile tool-registration (`app/mcp_server/profiles.py`, `app/mcp_server/tooling/registry.py::register_all_tools`).
- Documents both facts together — in the runtime tool `description` string a session actually reads at call time, and in the module docstrings of the two files that own each layer — so a BLOCK verdict is never misread as either "ignorable because it's not enforced" or "physically impossible."
- Concrete anchor: the 5 KR mock read tools (`kis_mock_get_order_history`, `kiwoom_mock_get_order_history`, `kiwoom_mock_get_order_detail`, `kiwoom_mock_get_positions`, `kiwoom_mock_get_orderable_cash`) are route-BLOCK on every lane yet physically registered on `McpProfile.DEFAULT` — real-world proof the two layers diverge.
- Docs/comments only. No branch, condition, or return value changed.

## Test plan
- [x] `uv run pytest tests/ -q -k "route or profile or registry"` — 1080 passed
- [x] `git diff` reviewed — string/comment additions only, no logic touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between advisory action restrictions and enforced tool access.
  * Documented that profile registration determines which tools are available in callable sessions.
  * Added guidance that blocked actions must still be treated as binding session rules.
  * Identified the canonical guidance for interpreting blocked-action decisions across related documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->