### PR TITLE
policy: add breakeven reserve trim advisory tier

### DIFF
--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-08-12.3"
+version: "2026-08-12.4"
 captured_as_of: "2026-08-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change)"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change)"
 
 authority:
   scope: judgment_policy_only
@@ -350,7 +350,9 @@ decision_rules:
       spike candidate from the RSI gate and remains profit-zone-only. When
       resistance-near favors PLACE but upside-rich would otherwise allow WATCH,
       resistance proximity can pre-place only a small trim; upside richness
-      limits size, not eligibility.
+      limits size, not eligibility. sell.breakeven_reserve_trim is an advisory
+      pre-guard reserve-trim contract: calculate its guard-and-D7 anchor before
+      consumption, and use WATCH only when that anchor cannot be calculated.
     tiers:
       - id: de_minimis_trim_watch
         conditions:
@@ -359,6 +361,29 @@ decision_rules:
           expected_net_realized_gain_krw_below_policy_key: sell.trim_min_expected_net_realized_gain_krw
         action: register_watch_instead_of_trim
         sizing: no_preplaced_trim
+      # §44차. Parameter status: no new numeric threshold; every value below
+      # references an existing operator-reviewed policy key and is not
+      # session-adjustable. This is advisory judgment metadata only.
+      - id: sell.breakeven_reserve_trim
+        conditions:
+          markets: [kr, us, crypto]
+          lot_pnl_basis: current_price_vs_average_cost
+          lot_pnl_pct_min_inclusive_negated_policy_key: sell.breakeven_near_pct
+          lot_pre_guard_average_cost_multiple_max_exclusive_policy_key: sell.loss_guard_min_multiple
+          anchor_operator: max
+          anchor_operands: [average_cost_times_loss_guard, d7_compliant_lowest_price]
+          anchor_guard_policy_key: sell.loss_guard_min_multiple
+          d7_min_expected_net_realized_gain_krw_policy_key: sell.trim_min_expected_net_realized_gain_krw
+          d7_minimum_price_basis: one_share_expected_net_realized_gain_after_estimated_fees_and_taxes
+          resting_limit_order: true
+          time_in_force: DAY
+          regeneration: daily_rep
+          day_expiry_policy_key: order.day_expiry_kst
+          submission_contract: section_40_auto_approve_with_veto
+          watch_fallback: anchor_uncomputable_only
+          advisory: true
+        action: preplace_resting_breakeven_reserve_trim
+        sizing: existing_trim_rule
       - id: single_share_full_exit_review
         conditions:
           markets: [kr, us]
@@ -401,7 +426,7 @@ decision_rules:
         action: register_watch
         sizing: no_preplaced_trim
     tie_breaks:
-      tier_priority: "de_minimis_trim_watch > single_share_full_exit_review > momentum_spike_profit_ladder > rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
+      tier_priority: "de_minimis_trim_watch > sell.breakeven_reserve_trim > single_share_full_exit_review > momentum_spike_profit_ladder > rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
       multiple_tiers_matched: first_matching_tier_wins
       sell.upside_place_max_pct: size_limit_only
       momentum_spike_rsi_exception: matched_tier_only

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-08-12.4"
+version: "2026-08-12.5"
 captured_as_of: "2026-08-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change)"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits)"
 
 authority:
   scope: judgment_policy_only
@@ -375,6 +375,9 @@ decision_rules:
           anchor_guard_policy_key: sell.loss_guard_min_multiple
           d7_min_expected_net_realized_gain_krw_policy_key: sell.trim_min_expected_net_realized_gain_krw
           d7_minimum_price_basis: one_share_expected_net_realized_gain_after_estimated_fees_and_taxes
+          d7_scope_semantics: one_share_net_realized_gain_not_total_trim
+          d7_estimation_limit_semantics: consumer_estimated_fees_and_taxes_required_no_fee_or_tax_model_added_by_this_tier
+          post_max_tick_snap_direction: ceil
           resting_limit_order: true
           time_in_force: DAY
           regeneration: daily_rep

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -266,9 +266,13 @@ lanes:
      price)`, where the D7 price is the lowest price at which **one share** has
      expected net realized gain at or above
      `sell.trim_min_expected_net_realized_gain_krw` after estimated fees and
-     taxes. Use the existing trim sizing rule unchanged. The resulting DAY limit
-     is the §40 auto-submit + veto-card contract for this advisory tier; actual
-     dispatch still follows the runtime `approval_dispatch` truth.
+     taxes. For this tier, that is a one-share value, not a total-trim value;
+     it relies on the consumer's estimated fees and taxes and adds no fee or tax
+     model. After the `max`, snap the anchor **upward (`ceil`)** to the applicable
+     market tick; never floor it below the guard. Use the existing trim sizing
+     rule unchanged. The resulting DAY limit is the §40 auto-submit + veto-card
+     contract for this advisory tier; actual dispatch still follows the runtime
+     `approval_dispatch` truth.
    - If either anchor operand cannot be calculated, register the tier's WATCH
      fallback only; do not invent a local anchor or use WATCH as a substitute
      for a calculated reserve trim. Regenerate the eligible resting DAY limit
@@ -304,6 +308,21 @@ lanes:
     steps:
       - tool: toss_get_positions
       - tool: analyze_stock_batch
+      - policy_tier: sell.breakeven_reserve_trim
+        advisory: true
+        priority_source: decision_rules.sell.trim_preplace.tie_breaks.tier_priority
+        trigger:
+          pnl_pct_min_inclusive_negated_policy_key: sell.breakeven_near_pct
+          pre_guard_average_cost_multiple_max_exclusive_policy_key: sell.loss_guard_min_multiple
+        anchor:
+          operator: max
+          operands: [average_cost_times_loss_guard, d7_compliant_lowest_price]
+          post_max_tick_snap_direction: ceil
+        sizing: existing_trim_rule
+        time_in_force: DAY
+        regeneration: daily_rep
+        submission_contract: section_40_auto_approve_with_veto
+        watch_fallback: anchor_uncomputable_only
       - tool: sell_ladder_fill_preview  # ROB-477 bottom-anchor rung, fill-safety
       - tool: order_proposal_create
         actions: [place, cancel, replace]

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -257,6 +257,24 @@ lanes:
      RSI-neutral 2-6% resistance becomes a system watch. In this conflict,
      `sell.upside_place_max_pct` limits trim size rather than blocking
      pre-placement eligibility.
+   - **Breakeven reserve trim (§44차)** = before the regular resistance tiers,
+     consume `sell.breakeven_reserve_trim` for a lot whose P&L (current price
+     versus average cost) is at or above
+     `-sell.breakeven_near_pct` and whose current-price multiple is strictly
+     below `sell.loss_guard_min_multiple`. Calculate the resting-limit anchor as
+     `max(average_cost × sell.loss_guard_min_multiple, D7-compliant lowest
+     price)`, where the D7 price is the lowest price at which **one share** has
+     expected net realized gain at or above
+     `sell.trim_min_expected_net_realized_gain_krw` after estimated fees and
+     taxes. Use the existing trim sizing rule unchanged. The resulting DAY limit
+     is the §40 auto-submit + veto-card contract for this advisory tier; actual
+     dispatch still follows the runtime `approval_dispatch` truth.
+   - If either anchor operand cannot be calculated, register the tier's WATCH
+     fallback only; do not invent a local anchor or use WATCH as a substitute
+     for a calculated reserve trim. Regenerate the eligible resting DAY limit
+     on **every daily rep** so a prior day's expiry never leaves the reserve net
+     dead. The lower P&L boundary (exactly −2% at the current policy value) is
+     included; the exact loss-guard multiple is excluded.
 4. Build the sell-into-strength **split ladder** just under resistance.
    [ROB-477](https://linear.app/mgh3326/issue/ROB-477) requires a bottom-anchor
    rung; run the pure `sell_ladder_fill_preview` fill-safety check **before**

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -110,6 +110,15 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
         reserve_trim["conditions"]["d7_min_expected_net_realized_gain_krw_policy_key"]
         == "sell.trim_min_expected_net_realized_gain_krw"
     )
+    assert (
+        reserve_trim["conditions"]["d7_scope_semantics"]
+        == "one_share_net_realized_gain_not_total_trim"
+    )
+    assert (
+        reserve_trim["conditions"]["d7_estimation_limit_semantics"]
+        == "consumer_estimated_fees_and_taxes_required_no_fee_or_tax_model_added_by_this_tier"
+    )
+    assert reserve_trim["conditions"]["post_max_tick_snap_direction"] == "ceil"
     assert reserve_trim["conditions"]["regeneration"] == "daily_rep"
     assert (
         reserve_trim["conditions"]["submission_contract"]

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -100,6 +100,28 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     )
     assert tiers["ultra_near_resistance"]["conditions"]["resistance_near_pct_max"] == 2
     assert tiers["watch_zone"]["action"] == "register_watch"
+    reserve_trim = tiers["sell.breakeven_reserve_trim"]
+    assert reserve_trim["conditions"]["anchor_operator"] == "max"
+    assert reserve_trim["conditions"]["anchor_operands"] == [
+        "average_cost_times_loss_guard",
+        "d7_compliant_lowest_price",
+    ]
+    assert (
+        reserve_trim["conditions"]["d7_min_expected_net_realized_gain_krw_policy_key"]
+        == "sell.trim_min_expected_net_realized_gain_krw"
+    )
+    assert reserve_trim["conditions"]["regeneration"] == "daily_rep"
+    assert (
+        reserve_trim["conditions"]["submission_contract"]
+        == "section_40_auto_approve_with_veto"
+    )
+    assert reserve_trim["conditions"]["watch_fallback"] == "anchor_uncomputable_only"
+    assert reserve_trim["conditions"]["advisory"] is True
+    assert reserve_trim["action"] == "preplace_resting_breakeven_reserve_trim"
+    assert reserve_trim["sizing"] == "existing_trim_rule"
+    assert rule["tie_breaks"]["tier_priority"].startswith(
+        "de_minimis_trim_watch > sell.breakeven_reserve_trim >"
+    )
     assert "single_share_position" not in rule["exclusions"]
     single_share = out["decision_rules"]["sell.single_share_exit"]
     assert single_share["activation_state"] == "shadow"

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -20,6 +20,64 @@ def _raw() -> dict:
     return yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
 
 
+def _breakeven_reserve_trim_tier():
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "sell.trim_preplace"
+    ]
+    return next(tier for tier in rule.tiers if tier.id == "sell.breakeven_reserve_trim")
+
+
+def _threshold_decimal(doc: TradingPolicyDocument, key: str) -> Decimal:
+    return Decimal(str(doc.thresholds[key].value))
+
+
+def _breakeven_reserve_trim_anchor(
+    tier,
+    *,
+    average_cost: Decimal,
+    d7_compliant_lowest_price: Decimal,
+) -> Decimal:
+    """Test-only interpreter for the declarative advisory anchor contract."""
+
+    conditions = tier.conditions
+    guard = _threshold_decimal(
+        TradingPolicyDocument.model_validate(_raw()),
+        str(conditions["anchor_guard_policy_key"]),
+    )
+    operands = {
+        "average_cost_times_loss_guard": average_cost * guard,
+        "d7_compliant_lowest_price": d7_compliant_lowest_price,
+    }
+    resolved = [operands[str(name)] for name in conditions["anchor_operands"]]
+    operator = conditions["anchor_operator"]
+    if operator == "max":
+        return max(resolved)
+    if operator == "min":
+        return min(resolved)
+    raise AssertionError(f"unsupported advisory anchor operator: {operator!r}")
+
+
+def _breakeven_reserve_trim_triggered(
+    tier,
+    *,
+    pnl_pct: Decimal,
+    current_price_multiple: Decimal,
+) -> bool:
+    """Test-only interpreter for the declarative pre-guard trigger band."""
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    conditions = tier.conditions
+    lower_bound = -_threshold_decimal(
+        doc,
+        str(conditions["lot_pnl_pct_min_inclusive_negated_policy_key"]),
+    )
+    guard = _threshold_decimal(
+        doc,
+        str(conditions["lot_pre_guard_average_cost_multiple_max_exclusive_policy_key"]),
+    )
+    return pnl_pct >= lower_bound and current_price_multiple < guard
+
+
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
@@ -61,6 +119,7 @@ def test_shipped_config_validates():
     assert trim_rule.lanes == ["sell"]
     assert [tier.id for tier in trim_rule.tiers] == [
         "de_minimis_trim_watch",
+        "sell.breakeven_reserve_trim",
         "single_share_full_exit_review",
         "momentum_spike_profit_ladder",
         "rsi_confirmed_resistance",
@@ -68,10 +127,11 @@ def test_shipped_config_validates():
         "watch_zone",
     ]
     assert trim_rule.tiers[0].action == "register_watch_instead_of_trim"
-    assert trim_rule.tiers[1].sizing == "full_position"
-    assert trim_rule.tiers[2].conditions["rsi_gate_exempt"] is True
-    assert trim_rule.tiers[2].conditions["ladder_total_position_pct_max"] == 33.3333
-    assert trim_rule.tiers[4].conditions["resistance_near_pct_max"] == 2
+    assert trim_rule.tiers[1].sizing == "existing_trim_rule"
+    assert trim_rule.tiers[2].sizing == "full_position"
+    assert trim_rule.tiers[3].conditions["rsi_gate_exempt"] is True
+    assert trim_rule.tiers[3].conditions["ladder_total_position_pct_max"] == 33.3333
+    assert trim_rule.tiers[5].conditions["resistance_near_pct_max"] == 2
     assert trim_rule.tie_breaks["multiple_tiers_matched"] == (
         "first_matching_tier_wins"
     )
@@ -322,6 +382,117 @@ def test_support_reserve_net_keeps_toss_outside_auto_veto_capable_combinations()
     assert all(
         account_mode != "toss_live" for account_mode, _ in _VETO_CAPABLE_ACCOUNT_MARKETS
     )
+
+
+
+
+def test_breakeven_reserve_trim_policy_contract_is_machine_readable():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    rule = doc.decision_rules["sell.trim_preplace"]
+    tier = _breakeven_reserve_trim_tier()
+
+    assert [candidate.id for candidate in rule.tiers] == [
+        "de_minimis_trim_watch",
+        "sell.breakeven_reserve_trim",
+        "single_share_full_exit_review",
+        "momentum_spike_profit_ladder",
+        "rsi_confirmed_resistance",
+        "ultra_near_resistance",
+        "watch_zone",
+    ]
+    assert tier.conditions == {
+        "markets": ["kr", "us", "crypto"],
+        "lot_pnl_basis": "current_price_vs_average_cost",
+        "lot_pnl_pct_min_inclusive_negated_policy_key": ("sell.breakeven_near_pct"),
+        "lot_pre_guard_average_cost_multiple_max_exclusive_policy_key": (
+            "sell.loss_guard_min_multiple"
+        ),
+        "anchor_operator": "max",
+        "anchor_operands": [
+            "average_cost_times_loss_guard",
+            "d7_compliant_lowest_price",
+        ],
+        "anchor_guard_policy_key": "sell.loss_guard_min_multiple",
+        "d7_min_expected_net_realized_gain_krw_policy_key": (
+            "sell.trim_min_expected_net_realized_gain_krw"
+        ),
+        "d7_minimum_price_basis": (
+            "one_share_expected_net_realized_gain_after_estimated_fees_and_taxes"
+        ),
+        "resting_limit_order": True,
+        "time_in_force": "DAY",
+        "regeneration": "daily_rep",
+        "day_expiry_policy_key": "order.day_expiry_kst",
+        "submission_contract": "section_40_auto_approve_with_veto",
+        "watch_fallback": "anchor_uncomputable_only",
+        "advisory": True,
+    }
+    assert tier.action == "preplace_resting_breakeven_reserve_trim"
+    assert tier.sizing == "existing_trim_rule"
+    assert rule.tie_breaks["tier_priority"] == (
+        "de_minimis_trim_watch > sell.breakeven_reserve_trim > "
+        "single_share_full_exit_review > momentum_spike_profit_ladder > "
+        "rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
+    )
+    assert _threshold_decimal(doc, "sell.loss_guard_min_multiple") == Decimal("1.01")
+    assert _threshold_decimal(doc, "sell.breakeven_near_pct") == Decimal("2")
+    assert _threshold_decimal(
+        doc, "sell.trim_min_expected_net_realized_gain_krw"
+    ) == Decimal("5000")
+
+
+def test_breakeven_reserve_trim_trigger_band_is_lower_inclusive_and_pre_guard():
+    tier = _breakeven_reserve_trim_tier()
+
+    assert _breakeven_reserve_trim_triggered(
+        tier,
+        pnl_pct=Decimal("-2"),
+        current_price_multiple=Decimal("0.98"),
+    )
+    assert _breakeven_reserve_trim_triggered(
+        tier,
+        pnl_pct=Decimal("0.9999"),
+        current_price_multiple=Decimal("1.009999"),
+    )
+    assert not _breakeven_reserve_trim_triggered(
+        tier,
+        pnl_pct=Decimal("-2.0001"),
+        current_price_multiple=Decimal("0.979999"),
+    )
+    assert not _breakeven_reserve_trim_triggered(
+        tier,
+        pnl_pct=Decimal("1"),
+        current_price_multiple=Decimal("1.01"),
+    )
+
+
+def test_breakeven_reserve_trim_anchor_never_below_guard_floor():
+    tier = _breakeven_reserve_trim_tier()
+    average_cost = Decimal("100")
+    guard_floor = Decimal("101")
+
+    anchor = _breakeven_reserve_trim_anchor(
+        tier,
+        average_cost=average_cost,
+        d7_compliant_lowest_price=Decimal("100.50"),
+    )
+
+    assert anchor >= guard_floor
+    assert anchor == guard_floor
+
+
+def test_breakeven_reserve_trim_anchor_never_below_d7_floor():
+    tier = _breakeven_reserve_trim_tier()
+    d7_compliant_lowest_price = Decimal("105")
+
+    anchor = _breakeven_reserve_trim_anchor(
+        tier,
+        average_cost=Decimal("100"),
+        d7_compliant_lowest_price=d7_compliant_lowest_price,
+    )
+
+    assert anchor >= d7_compliant_lowest_price
+    assert anchor == d7_compliant_lowest_price
 
 
 def test_single_share_exit_rule_is_provisional_shadow_only():

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -1,4 +1,5 @@
-from decimal import ROUND_CEILING, Decimal
+import re
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal
 from pathlib import Path
 
 import pytest

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -14,6 +14,12 @@ from app.services.order_proposals.auto_approve import _VETO_CAPABLE_ACCOUNT_MARK
 from app.services.trading_policy_service import load_trading_policy
 
 _CONFIG = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
+_PLAYBOOK = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "playbooks"
+    / "trading-decision-playbook.md"
+)
 
 
 def _raw() -> dict:
@@ -29,6 +35,15 @@ def _breakeven_reserve_trim_tier():
 
 def _threshold_decimal(doc: TradingPolicyDocument, key: str) -> Decimal:
     return Decimal(str(doc.thresholds[key].value))
+
+
+def _sell_lane_machine_block() -> dict:
+    text = _PLAYBOOK.read_text(encoding="utf-8")
+    for block in re.findall(r"```yaml\n(.*?)```", text, re.DOTALL):
+        if "# playbook-machine-readable: sell lane" in block:
+            parsed = yaml.safe_load(block)
+            return parsed["lanes"]["sell"]
+    raise AssertionError("sell lane machine-readable block missing")
 
 
 def _breakeven_reserve_trim_anchor(
@@ -55,6 +70,21 @@ def _breakeven_reserve_trim_anchor(
     if operator == "min":
         return min(resolved)
     raise AssertionError(f"unsupported advisory anchor operator: {operator!r}")
+
+
+def _breakeven_reserve_trim_post_max_tick_snap(
+    tier,
+    *,
+    anchor: Decimal,
+    tick_size: Decimal,
+) -> Decimal:
+    """Test-only interpreter for the declarative post-max tick direction."""
+
+    direction = tier.conditions["post_max_tick_snap_direction"]
+    rounding = {"ceil": ROUND_CEILING, "floor": ROUND_FLOOR}.get(direction)
+    if rounding is None:
+        raise AssertionError(f"unsupported post-max tick direction: {direction!r}")
+    return (anchor / tick_size).to_integral_value(rounding=rounding) * tick_size
 
 
 def _breakeven_reserve_trim_triggered(
@@ -419,6 +449,11 @@ def test_breakeven_reserve_trim_policy_contract_is_machine_readable():
         "d7_minimum_price_basis": (
             "one_share_expected_net_realized_gain_after_estimated_fees_and_taxes"
         ),
+        "d7_scope_semantics": "one_share_net_realized_gain_not_total_trim",
+        "d7_estimation_limit_semantics": (
+            "consumer_estimated_fees_and_taxes_required_no_fee_or_tax_model_added_by_this_tier"
+        ),
+        "post_max_tick_snap_direction": "ceil",
         "resting_limit_order": True,
         "time_in_force": "DAY",
         "regeneration": "daily_rep",
@@ -493,6 +528,70 @@ def test_breakeven_reserve_trim_anchor_never_below_d7_floor():
 
     assert anchor >= d7_compliant_lowest_price
     assert anchor == d7_compliant_lowest_price
+
+
+def test_breakeven_reserve_trim_post_max_tick_snap_ceil_preserves_guard_floor():
+    tier = _breakeven_reserve_trim_tier()
+    guard_exact = Decimal("256875") * Decimal("1.01")
+    tick_size = Decimal("500")
+    floor_snap = (guard_exact / tick_size).to_integral_value(
+        rounding=ROUND_FLOOR
+    ) * tick_size
+
+    snapped_anchor = _breakeven_reserve_trim_post_max_tick_snap(
+        tier,
+        anchor=guard_exact,
+        tick_size=tick_size,
+    )
+
+    assert guard_exact == Decimal("259443.75")
+    assert floor_snap == Decimal("259000")
+    assert floor_snap < guard_exact
+    assert snapped_anchor == Decimal("259500")
+    assert snapped_anchor >= guard_exact
+
+
+def test_sell_lane_machine_block_adds_breakeven_reserve_trim_without_tool_or_gate_drift():
+    sell = _sell_lane_machine_block()
+    policy_tier = next(
+        step
+        for step in sell["steps"]
+        if step.get("policy_tier") == "sell.breakeven_reserve_trim"
+    )
+
+    assert [step["tool"] for step in sell["steps"] if "tool" in step] == [
+        "toss_get_positions",
+        "analyze_stock_batch",
+        "sell_ladder_fill_preview",
+        "order_proposal_create",
+    ]
+    assert sell["gates"] == ["loss_guard", "tick_rule", "toss_two_sided"]
+    assert policy_tier == {
+        "policy_tier": "sell.breakeven_reserve_trim",
+        "advisory": True,
+        "priority_source": (
+            "decision_rules.sell.trim_preplace.tie_breaks.tier_priority"
+        ),
+        "trigger": {
+            "pnl_pct_min_inclusive_negated_policy_key": ("sell.breakeven_near_pct"),
+            "pre_guard_average_cost_multiple_max_exclusive_policy_key": (
+                "sell.loss_guard_min_multiple"
+            ),
+        },
+        "anchor": {
+            "operator": "max",
+            "operands": [
+                "average_cost_times_loss_guard",
+                "d7_compliant_lowest_price",
+            ],
+            "post_max_tick_snap_direction": "ceil",
+        },
+        "sizing": "existing_trim_rule",
+        "time_in_force": "DAY",
+        "regeneration": "daily_rep",
+        "submission_contract": "section_40_auto_approve_with_veto",
+        "watch_fallback": "anchor_uncomputable_only",
+    }
 
 
 def test_single_share_exit_rule_is_provisional_shadow_only():

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -432,8 +432,6 @@ def test_support_reserve_net_keeps_toss_auto_veto_behind_dedicated_gate(monkeypa
         assert auto_approve._is_veto_capable_account_market("toss_live", market)
 
 
-
-
 def test_breakeven_reserve_trim_policy_contract_is_machine_readable():
     doc = TradingPolicyDocument.model_validate(_raw())
     rule = doc.decision_rules["sell.trim_preplace"]

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -83,6 +83,7 @@ def test_trim_preplace_exposes_d2_d5_d7_advisory_contracts():
 
     assert list(tiers) == [
         "de_minimis_trim_watch",
+        "sell.breakeven_reserve_trim",
         "single_share_full_exit_review",
         "momentum_spike_profit_ladder",
         "rsi_confirmed_resistance",


### PR DESCRIPTION
## Summary
- Add the advisory sell.breakeven_reserve_trim tier with machine-readable trigger, max-anchor operands, existing trim sizing, daily DAY regeneration, §40 auto-submit + veto contract, anchor-only WATCH fallback, and advisory status.
- Reuse the existing loss guard, near-breakeven, and D7 policy keys without changing their values.
- Document §2 consumption and pin the three anchor/trigger invariants with mutation-killing tests.

## Closeout
- Explicitly snap the post-max advisory anchor upward with ceil for the applicable market tick; a floor snap that would breach the guard is mutation-tested.
- Add the advisory policy tier to the machine-readable sell-lane steps without changing the existing tool steps or gates.
- State the tier-local D7 one-share scope and that it relies on consumer fee/tax estimates; no fee/tax model is added.

## Safety scope
- No app changes, broker/account/DB access, scheduler registration, or runtime enforcement changes.
- The tier is policy metadata under authority.scope: judgment_policy_only.

## Validation
- uv run pytest tests/schemas/test_trading_policy_schema.py tests/mcp_server/test_trading_policy_tool.py tests/test_route_request_registry_diff.py -q (55 passed)
- make lint (passed)
- Original three specified mutants, floor tick mutation, and inverted core asserts each failed, then were reverted.

## Merge-conflict note
PR #1839 is editing the sell playbook near original lines 204–211. This PR changes prior prose and inserts the machine-tier step only; git diff --unified=0 shows no modification hunk for original lines 204–211.