### PR TITLE
feat(policy): add support reserve net contract

### DIFF
--- a/.claude/commands/fill-event-triage.md
+++ b/.claude/commands/fill-event-triage.md
@@ -42,6 +42,37 @@ description: 체결(fill) 이벤트, 특히 매도 체결 후 현금 재배치 �
 - 남은 rung(미체결 주문) 가정이 여전히 유효한가? (지정가, 노트, 손절선, max_action)
 - 운영자가 남은 주문을 **pause / tighten / leave** 중 어떻게 해야 하는가? 그 근거는 무엇인가?
 
+### 분기 C — `buy.support_reserve_net` confirmed fill (operator §45/§46)
+
+이 분기는 **confirmed broker fill** 이고, 해당 주문이 동일 policy version의
+`buy.support_reserve_net` 티어였다는 주문/제안 증거가 있을 때만 적용한다. 가격 모양,
+심볼, 또는 추정 RSI로 티어를 추론하지 않는다. 귀속 증거가 없거나 주문 상태가
+unknown/ambiguous이면 `KEEP_RESERVED_AND_BLOCK`으로 결론 내리고 취소 대상이나 가용
+현금을 만들어내지 않는다.
+
+상태기계는 다음 순서를 바꾸지 않는다.
+
+```text
+confirmed broker fill
+→ account×currency triage lock (logical triage state only)
+→ support_reserve_net 신규 submit/rearm 즉시 FREEZE_NEW_SUBMITS
+→ 같은 reconcile batch의 연쇄 fill을 burst_key=[broker_account_id, currency, market_session]로 coalesce
+→ fresh positions/cash/open-orders 재조회
+→ 남은 reserve-net 주문별 cancel proposal draft 작성 (PROPOSAL_REQUIRES_APPROVAL)
+→ 운영자 승인
+→ broker CANCELLED/terminal 증거 확인
+→ 다음 거래 세션 + fresh policy table에서만 DAY 후보 재생성
+```
+
+- 이 커맨드는 lock을 DB에 쓰거나 broker 상태를 바꾸지 않는다. `FREEZE_NEW_SUBMITS` /
+  `KEEP_RESERVED_AND_BLOCK`은 다음 승인·제안 소비자에게 남기는 명시적 트리아지 결론이다.
+- draft마다 broker account, currency, market session, target order, `required_cash`,
+  fresh-read timestamp, policy version/content hash, 그리고 `cash_reservation=KEEP`을
+  적는다. **cancel proposal은 broker cancellation이 아니다.** 운영자 승인 뒤에도
+  broker terminal 증거 전에는 현금을 풀지 않는다.
+- 자동 취소, same-session rearm, cancel proposal을 이유로 한 cash release는 모두 금지다.
+  Toss도 veto wiring 전에는 전량 사람 승인이다.
+
 ## 3. dry_run 미리보기 (read-only)
 
 - 체결 후 현금/포지션 변화를 위 기조 도구(get_cash_balance, get_portfolio_allocation) 데이터 기반으로 **머릿속에서** 시뮬레이션한다. 별도 시뮬레이션 도구 호출 없이 제안만 작성한다.
@@ -60,3 +91,6 @@ description: 체결(fill) 이벤트, 특히 매도 체결 후 현금 재배치 �
 
 - READ-ONLY 분석 + dry_run 제안까지만. place/modify/cancel/reconcile/report/watch mutation 금지(권한 차단됨).
 - 불확실하면 보수적으로(no-action) 제안하고 그 이유를 적는다. 현금 비중이 명확하면 redeploy 후보를 같이 제시하되, 마지막 결정은 운영자 몫으로 남긴다.
+- `buy.support_reserve_net`의 cancel proposal은 이 커맨드가 호출·저장하는 주문 제안이 아니라
+  approval-gated **draft**다. 자동 broker cancellation 및 현금 해제 구현은 이 ROB-755
+  read-only 계약의 범위 밖이다.

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -140,6 +140,7 @@ class SupportReserveNetAddCandidatePolicy(BaseModel):
     policy_table_max_age_hours: Literal[36]
     k_used: float
     sizing_price: Literal["proposed_limit_price"]
+    a_limit_lte_zero: Literal["NO_ORDER"]
     partial_A_limit_fill: Literal["FORBIDDEN"]
     max_add_symbols_per_market: Literal[1]
     max_reserve_net_add_fills_per_symbol_per_policy_version: Literal[1]
@@ -151,6 +152,52 @@ class SupportReserveNetAddCandidatePolicy(BaseModel):
     def validate_k_used(cls, value: float) -> float:
         if value != 0.10:
             raise ValueError("k_used must be 0.10")
+        return value
+
+
+class SupportReserveNetPriorityRules(BaseModel):
+    """Deterministic allocation order for the constrained reserve-net slots.
+
+    This remains a consumer contract only. A later authorized consumer must use
+    this order when selecting among otherwise eligible candidates.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    allocation_order: list[str]
+    same_symbol_active_or_resting: Literal["DEDUPE_FIRST"]
+    first_slot: Literal["ELIGIBLE_NEW_CANDIDATE_FIRST"]
+    add_candidate_rank: Literal["SECONDARY_CANDIDATE_POOL"]
+    add_candidate_r931_review_required: Literal["PASS"]
+    add_candidate_a_limit_10: Literal["FULLY_SATISFIED"]
+    max_add_symbols_per_market: Literal[1]
+    same_intent_class_sort_order: list[str]
+    exact_tie_break: Literal["NEW_BEFORE_ADD"]
+
+    @field_validator("allocation_order")
+    @classmethod
+    def validate_allocation_order(cls, value: list[str]) -> list[str]:
+        required = [
+            "dedupe_active_or_resting_same_symbol",
+            "first_slot_eligible_new_candidate",
+            "add_secondary_pool_only_after_r931_pass_and_full_a_limit_10",
+        ]
+        if value != required:
+            raise ValueError(f"allocation_order must be exactly {required}")
+        return value
+
+    @field_validator("same_intent_class_sort_order")
+    @classmethod
+    def validate_same_intent_class_sort_order(cls, value: list[str]) -> list[str]:
+        required = [
+            "support_strength_desc",
+            "independent_support_source_count_desc",
+            "honest_upside_pct_desc",
+            "post_fill_sector_increase_asc",
+            "required_cash_asc",
+        ]
+        if value != required:
+            raise ValueError(f"same_intent_class_sort_order must be exactly {required}")
         return value
 
 
@@ -211,6 +258,7 @@ class SupportReserveNetDecisionRule(BaseModel):
     cash_reservation: SupportReserveNetCashReservation
     fill_triage: SupportReserveNetFillTriagePolicy
     add_candidate: SupportReserveNetAddCandidatePolicy
+    priority_rules: SupportReserveNetPriorityRules
     prohibitions: SupportReserveNetProhibitions
     toss_live_approval: Literal["HUMAN_APPROVAL_REQUIRED_UNTIL_VETO_WIRING"]
 

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -79,6 +79,177 @@ class PolicyDecisionRule(BaseModel):
     exclusions: list[str] = Field(default_factory=list)
 
 
+class SupportReserveNetAutoSubmitNotional(BaseModel):
+    """The existing, unchanged auto-submit ceiling by settlement currency."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    krw: Literal[200000]
+    usd: Literal[150]
+
+
+class SupportReserveNetCashReservation(BaseModel):
+    """Reserve-net cash accounting contract; advisory until a future consumer.
+
+    This schema deliberately describes the fail-closed accounting boundary but
+    does not implement it in an order-proposal or broker service.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    net_orderable: Literal[
+        "fresh_broker_orderable_cash_minus_same_account_currency_pending_required_cash"
+    ]
+    pending_required_cash_scope: Literal["not_yet_reached_broker"]
+    required_cash_primary: Literal["preview_estimated_value_plus_fee"]
+    required_cash_fallback: Literal["quantity_times_limit_price"]
+    broker_orderable_unavailable_or_error: Literal["FAIL_CLOSED"]
+    cancel_proposal_cash_reservation: Literal[
+        "KEEP_RESERVED_UNTIL_BROKER_TERMINAL_CONFIRMATION"
+    ]
+
+
+class SupportReserveNetFillTriagePolicy(BaseModel):
+    """ROB-755 consumer contract; no broker mutation is enabled here."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    on_first_confirmed_fill: Literal["FREEZE_NEW_SUBMITS"]
+    cancellation_mode: Literal["PROPOSAL_REQUIRES_APPROVAL"]
+    broker_cancel_confirmation_required_before_releasing_cash: Literal[True]
+    same_session_rearm: Literal[False]
+    unknown_or_ambiguous_order_state: Literal["KEEP_RESERVED_AND_BLOCK"]
+    burst_key: list[str]
+
+    @field_validator("burst_key")
+    @classmethod
+    def validate_burst_key(cls, value: list[str]) -> list[str]:
+        required = ["broker_account_id", "currency", "market_session"]
+        if value != required:
+            raise ValueError(f"burst_key must be exactly {required}")
+        return value
+
+
+class SupportReserveNetAddCandidatePolicy(BaseModel):
+    """Averaging-down feasibility contract for the reserve-net tier."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    r931_review_required: Literal["PASS"]
+    r931_review_max_age_days: Literal[7]
+    policy_table_max_age_hours: Literal[36]
+    k_used: float
+    sizing_price: Literal["proposed_limit_price"]
+    partial_A_limit_fill: Literal["FORBIDDEN"]
+    max_add_symbols_per_market: Literal[1]
+    max_reserve_net_add_fills_per_symbol_per_policy_version: Literal[1]
+    same_day_rearm_after_fill: Literal[False]
+    crash_day_averaging_exemption: Literal[False]
+
+    @field_validator("k_used")
+    @classmethod
+    def validate_k_used(cls, value: float) -> float:
+        if value != 0.10:
+            raise ValueError("k_used must be 0.10")
+        return value
+
+
+class SupportReserveNetProhibitions(BaseModel):
+    """One-to-one encoding of the eight §Q4 prohibitions."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    no_new_add_or_deep_limit_rung_overlap: Literal[True]
+    aggregate_active_buy_by_beneficial_owner_across_accounts: Literal[True]
+    fresh_cost_basis_quantity_and_A_limit_before_next_day_reissue: Literal[True]
+    partial_A_limit_fill: Literal["FORBIDDEN"]
+    candidate_zero_runtime_gate_relaxation: Literal["FORBIDDEN"]
+    crash_day_averaging_exemption: Literal[False]
+    cancel_proposal_is_not_broker_cancellation: Literal[True]
+    unconfirmed_cancel_keeps_required_cash_reserved: Literal[True]
+    market_order: Literal["FORBIDDEN"]
+    gtc: Literal["FORBIDDEN"]
+    multi_rung: Literal["FORBIDDEN"]
+    daily_regeneration: Literal["REQUIRED"]
+
+
+class SupportReserveNetDecisionRule(BaseModel):
+    """Operator-owned support reserve net contract (operator §45/§46).
+
+    It is intentionally a policy/consumer contract only.  It does not route a
+    proposal, write a ledger row, invoke an MCP tool, or mutate a broker.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Literal["buy"]]
+    semantics: str
+    regular_discovery_precedence: Literal[True]
+    eligible_only_when_regular_gate_failure: Literal["RSI_ONLY"]
+    rsi_gate: Literal["omitted_for_this_tier_only"]
+    support_strength_min: Literal["moderate"]
+    independent_support_source_count_min: Literal[2]
+    independent_support_source_families: list[str]
+    support_within_current_pct_max: Literal[8]
+    honest_upside_pct_min: Literal[40]
+    honest_upside_reference: Literal["decision_time_current_price"]
+    discount_below_support_pct_range: list[int]
+    final_limit_distance_from_current_pct_range: list[int]
+    anchor_price_formula: Literal["tick_floor(S × (1-d))"]
+    final_limit_distance_out_of_range: Literal["EXCLUDE"]
+    order_type: Literal["limit"]
+    tif: Literal["DAY"]
+    all_pending_buy_required_cash_hard_cap_pct: Literal[90]
+    tier_armed_required_cash_cap_pct: Literal[50]
+    max_owned_or_open_symbols_per_market: Literal[2]
+    max_active_orders_per_symbol: Literal[1]
+    max_symbols_per_sector_cluster: Literal[1]
+    unknown_sector: Literal["INELIGIBLE"]
+    auto_submit_notional: SupportReserveNetAutoSubmitNotional
+    larger_notional_within_existing_band: Literal["HUMAN_APPROVAL_REQUIRED"]
+    daily_auto_cap_includes_all_buy_tiers: Literal[True]
+    cash_reservation: SupportReserveNetCashReservation
+    fill_triage: SupportReserveNetFillTriagePolicy
+    add_candidate: SupportReserveNetAddCandidatePolicy
+    prohibitions: SupportReserveNetProhibitions
+    toss_live_approval: Literal["HUMAN_APPROVAL_REQUIRED_UNTIL_VETO_WIRING"]
+
+    @field_validator("lanes")
+    @classmethod
+    def validate_buy_lane_only(
+        cls, value: list[Literal["buy"]]
+    ) -> list[Literal["buy"]]:
+        if value != ["buy"]:
+            raise ValueError("support_reserve_net applies to the buy lane only")
+        return value
+
+    @field_validator("independent_support_source_families")
+    @classmethod
+    def validate_independent_support_families(cls, value: list[str]) -> list[str]:
+        required = ["fib", "bb_lower", "volume_profile"]
+        if value != required:
+            raise ValueError(
+                f"independent_support_source_families must be exactly {required}"
+            )
+        return value
+
+    @field_validator("discount_below_support_pct_range")
+    @classmethod
+    def validate_discount_below_support_range(cls, value: list[int]) -> list[int]:
+        if value != [5, 10]:
+            raise ValueError("discount_below_support_pct_range must be [5, 10]")
+        return value
+
+    @field_validator("final_limit_distance_from_current_pct_range")
+    @classmethod
+    def validate_final_distance_range(cls, value: list[int]) -> list[int]:
+        if value != [-15, -5]:
+            raise ValueError(
+                "final_limit_distance_from_current_pct_range must be [-15, -5]"
+            )
+        return value
+
+
 class SingleShareExitScope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -408,9 +579,12 @@ class TradingPolicyDocument(BaseModel):
     order_proposals: OrderProposalsPolicy
     sector_clusters: dict[str, list[str]]
     thresholds: dict[str, PolicyThreshold]
-    decision_rules: dict[str, PolicyDecisionRule | SingleShareExitDecisionRule] = Field(
-        default_factory=dict
-    )
+    decision_rules: dict[
+        str,
+        PolicyDecisionRule
+        | SingleShareExitDecisionRule
+        | SupportReserveNetDecisionRule,
+    ] = Field(default_factory=dict)
     market_rules: dict[Literal["crypto"], CryptoMarketRules]
     market_overrides: dict[Market, dict[str, ThresholdValue]]
     crash_day: CrashDayPolicy

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-08-12.2"
+version: "2026-08-12.3"
 captured_as_of: "2026-08-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation)"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change)"
 
 authority:
   scope: judgment_policy_only
@@ -298,11 +298,32 @@ decision_rules:
       policy_table_max_age_hours: 36
       k_used: 0.10
       sizing_price: proposed_limit_price
+      a_limit_lte_zero: NO_ORDER
       partial_A_limit_fill: FORBIDDEN
       max_add_symbols_per_market: 1
       max_reserve_net_add_fills_per_symbol_per_policy_version: 1
       same_day_rearm_after_fill: false
       crash_day_averaging_exemption: false
+    # §Q2 lines 82–87 — allocation order for constrained armed cash. This
+    # fixes new-entry precedence before an add can consume the first slot.
+    priority_rules:
+      allocation_order:
+        - dedupe_active_or_resting_same_symbol
+        - first_slot_eligible_new_candidate
+        - add_secondary_pool_only_after_r931_pass_and_full_a_limit_10
+      same_symbol_active_or_resting: DEDUPE_FIRST
+      first_slot: ELIGIBLE_NEW_CANDIDATE_FIRST
+      add_candidate_rank: SECONDARY_CANDIDATE_POOL
+      add_candidate_r931_review_required: PASS
+      add_candidate_a_limit_10: FULLY_SATISFIED
+      max_add_symbols_per_market: 1
+      same_intent_class_sort_order:
+        - support_strength_desc
+        - independent_support_source_count_desc
+        - honest_upside_pct_desc
+        - post_fill_sector_increase_asc
+        - required_cash_asc
+      exact_tie_break: NEW_BEFORE_ADD
     # §Q4 "must not" items 1–8, made machine-checkable as a contract.
     prohibitions:
       no_new_add_or_deep_limit_rung_overlap: true

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-08-12.1"
-captured_as_of: "2026-08-08"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off)"
+version: "2026-08-12.2"
+captured_as_of: "2026-08-12"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation)"
 
 authority:
   scope: judgment_policy_only
@@ -233,6 +233,92 @@ thresholds:
     semantics: minimum honest upside for a candidate
 
 decision_rules:
+  # Operator §45/§46. This is a policy/consumer contract only: it neither
+  # creates a proposal nor calls a broker. The Q1/Q2/Q3/Q4 literals below are
+  # intentionally kept field-for-field, with supporting accounting and
+  # prohibition fields making their non-negotiable semantics explicit.
+  buy.support_reserve_net:
+    lanes: [buy]
+    semantics: >-
+      Advisory reserve-net tier for candidates that pass every regular discovery
+      condition except RSI failure or absence. Existing regular-discovery
+      candidates retain buy.deep_limit_pct_range; no candidate may receive both
+      tiers. No runtime relaxation is permitted when the candidate set is empty.
+    # Q1 — deep-only relaxation gate (literal)
+    regular_discovery_precedence: true
+    eligible_only_when_regular_gate_failure: RSI_ONLY
+    rsi_gate: omitted_for_this_tier_only
+    support_strength_min: moderate
+    independent_support_source_count_min: 2
+    independent_support_source_families: [fib, bb_lower, volume_profile]
+    support_within_current_pct_max: 8
+    honest_upside_pct_min: 40
+    honest_upside_reference: decision_time_current_price
+    discount_below_support_pct_range: [5, 10]
+    final_limit_distance_from_current_pct_range: [-15, -5]
+    order_type: limit
+    tif: DAY
+    # Q1 supporting anchor contract: tick floor is calculated below support;
+    # a final current-price distance outside the inclusive band is excluded,
+    # never clamped into it.
+    anchor_price_formula: "tick_floor(S × (1-d))"
+    final_limit_distance_out_of_range: EXCLUDE
+    # Q2 — budget/concurrency (literal)
+    all_pending_buy_required_cash_hard_cap_pct: 90
+    tier_armed_required_cash_cap_pct: 50
+    max_owned_or_open_symbols_per_market: 2
+    max_active_orders_per_symbol: 1
+    max_symbols_per_sector_cluster: 1
+    unknown_sector: INELIGIBLE
+    auto_submit_notional:
+      krw: 200000
+      usd: 150
+    larger_notional_within_existing_band: HUMAN_APPROVAL_REQUIRED
+    daily_auto_cap_includes_all_buy_tiers: true
+    cash_reservation:
+      net_orderable: fresh_broker_orderable_cash_minus_same_account_currency_pending_required_cash
+      pending_required_cash_scope: not_yet_reached_broker
+      required_cash_primary: preview_estimated_value_plus_fee
+      required_cash_fallback: quantity_times_limit_price
+      broker_orderable_unavailable_or_error: FAIL_CLOSED
+      cancel_proposal_cash_reservation: KEEP_RESERVED_UNTIL_BROKER_TERMINAL_CONFIRMATION
+    # Q3 — confirmed-fill triage (literal). A future consumer may create the
+    # approval-gated proposal; this policy never authorizes automatic cancel.
+    fill_triage:
+      on_first_confirmed_fill: FREEZE_NEW_SUBMITS
+      cancellation_mode: PROPOSAL_REQUIRES_APPROVAL
+      broker_cancel_confirmation_required_before_releasing_cash: true
+      same_session_rearm: false
+      unknown_or_ambiguous_order_state: KEEP_RESERVED_AND_BLOCK
+      burst_key: [broker_account_id, currency, market_session]
+    # Q4 — add-candidate constraints (literal)
+    add_candidate:
+      r931_review_required: PASS
+      r931_review_max_age_days: 7
+      policy_table_max_age_hours: 36
+      k_used: 0.10
+      sizing_price: proposed_limit_price
+      partial_A_limit_fill: FORBIDDEN
+      max_add_symbols_per_market: 1
+      max_reserve_net_add_fills_per_symbol_per_policy_version: 1
+      same_day_rearm_after_fill: false
+      crash_day_averaging_exemption: false
+    # §Q4 "must not" items 1–8, made machine-checkable as a contract.
+    prohibitions:
+      no_new_add_or_deep_limit_rung_overlap: true
+      aggregate_active_buy_by_beneficial_owner_across_accounts: true
+      fresh_cost_basis_quantity_and_A_limit_before_next_day_reissue: true
+      partial_A_limit_fill: FORBIDDEN
+      candidate_zero_runtime_gate_relaxation: FORBIDDEN
+      crash_day_averaging_exemption: false
+      cancel_proposal_is_not_broker_cancellation: true
+      unconfirmed_cancel_keeps_required_cash_reserved: true
+      market_order: FORBIDDEN
+      gtc: FORBIDDEN
+      multi_rung: FORBIDDEN
+      daily_regeneration: REQUIRED
+    toss_live_approval: HUMAN_APPROVAL_REQUIRED_UNTIL_VETO_WIRING
+
   sell.trim_preplace:
     lanes: [sell]
     semantics: >-

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -127,6 +127,13 @@ lanes:
    route has no `account_mode`, so it does not choose one reconcile tool.
 7. Foreign-cascade names (e.g. semis): no market order until **price band
    reached AND foreign selling stops** — until both, only a small deep rung.
+8. **Negative-class recording (ROB-712):** every reviewed-but-rejected candidate
+   leaves a `decision_bucket=deferred_no_action` item with `confidence` +
+   rejection reason, plus a resolvable `forecast_save(kind="price_target",
+   outcome_rule_version="window-touch-v1-high-gte-low-lte", …)`
+   (e.g. "no +X% within N days") so calibration isn't censored. The
+   `investment_report_create` response surfaces a `warnings` advisory when an
+   item is missing `confidence`.
 
 ### 1.1 `buy.support_reserve_net` — support reserve net consumer rules (operator §45/§46)
 
@@ -163,15 +170,22 @@ separately authorized runtime consumer exists.
    **fail-closed** for this tier. A cancel *proposal* leaves its cash reserved
    until broker terminal cancellation evidence exists. Automatic notional remains
    KRW 200,000 / USD 150; a larger amount in the existing band needs a human.
-4. **Add candidate:** only an R-931 `PASS` review no older than seven days and a
+4. **Allocation priority and tie-break:** apply this exact order.
+   1. 이미 active/resting인 동일 symbol을 먼저 dedupe한다.
+   2. 첫 슬롯은 eligible 신규 후보에 우선 배정한다.
+   3. 물타기는 R-931 재심사 PASS와 Q4의 `A_limit(10%)` 완전충족 조건을 모두 만족할 때만 두 번째 후보군에 들어간다. 시장당 물타기 심볼은 최대 1개다.
+   4. 같은 intent class 안에서는 `strong > moderate`, `3-source > 2-source`, 더 큰 honest upside, 더 작은 post-fill sector 증가, 더 작은 required cash 순으로 정렬한다. 완전 동률이면 신규가 물타기보다 먼저다.
+5. **Add candidate:** only an R-931 `PASS` review no older than seven days and a
    policy table no older than 36 hours may enter. Recalculate `A_limit(10%)` at
    `proposed_limit_price` with `k=0.10`; a partial `A_limit` fill is forbidden,
    as are a second add symbol in one market or a second reserve-net add fill for
-   the same symbol/policy version. Do not inherit the ordinary crash-day
+   the same symbol/policy version. `A_limit<=0` (already target met) is
+   **NO_ORDER**: never turn `ceil(0 / proposed_limit_price)=0` into a zero-quantity
+   order. Do not inherit the ordinary crash-day
    averaging exemption. Do not reissue next-day adds until fresh cost basis,
    quantity, and `A_limit` are available, and aggregate active buys across
    accounts by beneficial owner.
-5. **Confirmed-fill triage:** a confirmed broker fill takes an
+6. **Confirmed-fill triage:** a confirmed broker fill takes an
    account×currency triage lock, blocks every new reserve-net submit/rearm,
    coalesces same-batch fills by `[broker_account_id, currency, market_session]`,
    then rereads positions/cash/open orders. It emits approval-gated cancel
@@ -180,7 +194,7 @@ separately authorized runtime consumer exists.
    `unknown_or_ambiguous_order_state = KEEP_RESERVED_AND_BLOCK`; same-session
    rearm remains false. The ROB-755 command records this as a read-only proposal
    draft and does not persist or execute it.
-6. **Toss approval boundary:** until veto wiring and the two separate Toss
+7. **Toss approval boundary:** until veto wiring and the two separate Toss
    acceptance tests exist, **Toss 는 승인 카드 경유** only. `toss_live` is outside
    the auto-veto-capable combination list; do not treat this policy as an
    auto-approve expansion.
@@ -193,14 +207,6 @@ separately authorized runtime consumer exists.
 - sizing: 자동은 현행 20만원/$150만; 그 이상은 사람 승인. Toss는 veto wiring 전 전량 사람 승인.
 - fill: confirmed fill 즉시 신규 동결, cancel proposal 승인 경유, broker terminal 전 현금 해제 금지, same-session rearm 금지.
 - add: R-931 PASS, `A_limit(10%)` 완전충족, 부분 A 금지, policy version당 symbol 1회, crash-day 예외 없음.
-
-8. **Negative-class recording (ROB-712):** every reviewed-but-rejected candidate
-   leaves a `decision_bucket=deferred_no_action` item with `confidence` +
-   rejection reason, plus a resolvable `forecast_save(kind="price_target",
-   outcome_rule_version="window-touch-v1-high-gte-low-lte", …)`
-   (e.g. "no +X% within N days") so calibration isn't censored. The
-   `investment_report_create` response surfaces a `warnings` advisory when an
-   item is missing `confidence`.
 
 ```yaml
 # playbook-machine-readable: buy lane (ROB-649 source)

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -128,6 +128,72 @@ lanes:
 7. Foreign-cascade names (e.g. semis): no market order until **price band
    reached AND foreign selling stops** — until both, only a small deep rung.
 
+### 1.1 `buy.support_reserve_net` — support reserve net consumer rules (operator §45/§46)
+
+This is a separately named consumer tier of
+`decision_rules.buy.support_reserve_net`, not a rewrite of the regular discovery
+or `buy.deep_limit_pct_range` path. It remains proposal-led and advisory until a
+separately authorized runtime consumer exists.
+
+1. **Eligibility and evidence:** regular discovery has precedence. A candidate is
+   eligible only when all regular gates except RSI pass and the only failure (or
+   missing input) is RSI; an ordinary discovery survivor stays on the existing
+   deep-limit tier, and a symbol cannot receive both tiers. Require `moderate`+
+   support within 8% of current price and at least two distinct families from
+   `fib`, `bb_lower`, and `volume_profile` (two levels from one family still count
+   as one). Honest upside is at least 40%, measured once against the
+   **decision-time current price**; never recalculate it against the proposed
+   limit price. Candidate count zero is not permission to relax any of those
+   gates at runtime.
+2. **Anchor and order form:** derive the candidate limit as
+   `tick_floor(S × (1-d))`, with `d` in 5–10% below support. Its final distance
+   from the decision-time current price must remain within the inclusive
+   `[-15%, -5%]` band. A value outside that band is **excluded**; it is never
+   clamped. The only form is one `limit` + `DAY` order (no market/GTC/multi-rung
+   substitution). It may be **매일 재생성** only on the next trading session with a
+   fresh policy table, never as a same-session rearm.
+3. **Budget, cash, and concentration:** the whole-account pending-buy
+   `required_cash` ceiling is 90%; this tier's simultaneously armed
+   `required_cash` ceiling is 50%. Cap at two owned-or-open symbols per market,
+   one per sector cluster, and one active order per symbol; `unknown_sector` is
+   `INELIGIBLE`. Use `net_orderable = fresh broker orderable cash − not-yet-
+   reached-broker pending required_cash` for the same account and currency.
+   `required_cash` is preview `estimated_value + fee`, falling back only to
+   `quantity × limit_price`. Missing/error broker orderable data is
+   **fail-closed** for this tier. A cancel *proposal* leaves its cash reserved
+   until broker terminal cancellation evidence exists. Automatic notional remains
+   KRW 200,000 / USD 150; a larger amount in the existing band needs a human.
+4. **Add candidate:** only an R-931 `PASS` review no older than seven days and a
+   policy table no older than 36 hours may enter. Recalculate `A_limit(10%)` at
+   `proposed_limit_price` with `k=0.10`; a partial `A_limit` fill is forbidden,
+   as are a second add symbol in one market or a second reserve-net add fill for
+   the same symbol/policy version. Do not inherit the ordinary crash-day
+   averaging exemption. Do not reissue next-day adds until fresh cost basis,
+   quantity, and `A_limit` are available, and aggregate active buys across
+   accounts by beneficial owner.
+5. **Confirmed-fill triage:** a confirmed broker fill takes an
+   account×currency triage lock, blocks every new reserve-net submit/rearm,
+   coalesces same-batch fills by `[broker_account_id, currency, market_session]`,
+   then rereads positions/cash/open orders. It emits approval-gated cancel
+   proposals for remaining reserve-net orders; no automatic broker cancellation
+   is allowed. Cash remains reserved until a broker `CANCELLED`/terminal proof.
+   `unknown_or_ambiguous_order_state = KEEP_RESERVED_AND_BLOCK`; same-session
+   rearm remains false. The ROB-755 command records this as a read-only proposal
+   draft and does not persist or execute it.
+6. **Toss approval boundary:** until veto wiring and the two separate Toss
+   acceptance tests exist, **Toss 는 승인 카드 경유** only. `toss_live` is outside
+   the auto-veto-capable combination list; do not treat this policy as an
+   auto-approve expansion.
+
+#### 최종 권고 리터럴 요약
+
+- gate: RSI-only relaxation, 2 independent support families, moderate+, support within 8%, honest upside 40% 유지.
+- anchor: support 아래 5~10%, 동시에 현재가 대비 5~15% 아래; 범위 밖은 제외, clamp 금지.
+- budget: global 90% hard ceiling 유지, 이 티어 armed 50%, 시장당 2종목·섹터당 1·종목당 1주문.
+- sizing: 자동은 현행 20만원/$150만; 그 이상은 사람 승인. Toss는 veto wiring 전 전량 사람 승인.
+- fill: confirmed fill 즉시 신규 동결, cancel proposal 승인 경유, broker terminal 전 현금 해제 금지, same-session rearm 금지.
+- add: R-931 PASS, `A_limit(10%)` 완전충족, 부분 A 금지, policy version당 symbol 1회, crash-day 예외 없음.
+
 8. **Negative-class recording (ROB-712):** every reviewed-but-rejected candidate
    leaves a `decision_bucket=deferred_no_action` item with `confidence` +
    rejection reason, plus a resolvable `forecast_save(kind="price_target",

--- a/docs/runbooks/fill-event-claude-triage.md
+++ b/docs/runbooks/fill-event-claude-triage.md
@@ -130,6 +130,12 @@ broker cancellation. **Broker terminal confirmation is required before releasing
 cash.** Same-session rearm is false; a later observed fill while approval is
 pending remains in the same burst and keeps the block in place.
 
+> **TODO — future consumer job:** Before any automatic `support_reserve_net`
+> submit/rearm consumer is authorized, promote the account×currency triage lock
+> to a durable lock. This contract deliberately does not implement that
+> persistence: no automatic submission consumer exists today, so this logical
+> lock's non-durability cannot open an automated live-submission path.
+
 Toss is human approval only until veto wiring exists: **Toss 는 승인 카드 경유**.
 The two separate Toss acceptance tests — veto-to-real-cancel smoke and
 fill→freeze→cancel-proposal→approval→terminal E2E — are intentionally **not** in

--- a/docs/runbooks/fill-event-claude-triage.md
+++ b/docs/runbooks/fill-event-claude-triage.md
@@ -96,6 +96,47 @@ scripts/list_recent_fill_events.py  (레포 내, read-only DB 조회)
 
 ---
 
+## 2.1 `buy.support_reserve_net` fill-triage contract (operator §45/§46)
+
+This is a **contract/specification extension only**. It does not alter this
+poller, add a launchd registration, persist an order proposal, invoke a broker
+cancel, or release cash. The command remains ROB-755 read-only; its output is an
+approval-gated cancel-proposal **draft** for a later authorized consumer.
+
+Apply the state machine only after both conditions are evidenced: (a) a confirmed
+broker fill and (b) durable attribution of the filled order to
+`buy.support_reserve_net` plus its policy version/content hash. Do not infer the
+tier from price, symbol, or current indicators. Missing attribution or an
+unknown/ambiguous broker state is `KEEP_RESERVED_AND_BLOCK`: no target is guessed
+and no reservation is released.
+
+```text
+confirmed broker fill
+→ account×currency triage lock
+→ FREEZE_NEW_SUBMITS for support_reserve_net
+→ coalesce same-batch fills by [broker_account_id, currency, market_session]
+→ fresh positions/cash/open-orders reread
+→ remaining reserve-net orders receive cancel-proposal drafts
+→ operator approval
+→ broker CANCELLED/terminal evidence
+→ only next trading session + fresh policy table may regenerate DAY candidates
+```
+
+The lock is a logical triage state in this contract, not a database write made by
+the ROB-755 command. Each draft must retain its same-account/currency
+`required_cash` reservation and identify its target order, burst key, fresh-read
+timestamp, and policy version/content hash. `cancel proposal` is never treated as
+broker cancellation. **Broker terminal confirmation is required before releasing
+cash.** Same-session rearm is false; a later observed fill while approval is
+pending remains in the same burst and keeps the block in place.
+
+Toss is human approval only until veto wiring exists: **Toss 는 승인 카드 경유**.
+The two separate Toss acceptance tests — veto-to-real-cancel smoke and
+fill→freeze→cancel-proposal→approval→terminal E2E — are intentionally **not** in
+this job. Nor is automatic cancellation implemented here.
+
+---
+
 ## 3. Poller 스크립트
 
 운영자 머신 `~/ops/fill-event-triage/poller.sh` 에 저장. **레포에 커밋하지 않음** — 다만

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -36,6 +36,28 @@ async def test_get_trading_policy_returns_thresholds_and_version():
         "unknown_or_ambiguous_order_state": "KEEP_RESERVED_AND_BLOCK",
         "burst_key": ["broker_account_id", "currency", "market_session"],
     }
+    assert reserve["priority_rules"] == {
+        "allocation_order": [
+            "dedupe_active_or_resting_same_symbol",
+            "first_slot_eligible_new_candidate",
+            "add_secondary_pool_only_after_r931_pass_and_full_a_limit_10",
+        ],
+        "same_symbol_active_or_resting": "DEDUPE_FIRST",
+        "first_slot": "ELIGIBLE_NEW_CANDIDATE_FIRST",
+        "add_candidate_rank": "SECONDARY_CANDIDATE_POOL",
+        "add_candidate_r931_review_required": "PASS",
+        "add_candidate_a_limit_10": "FULLY_SATISFIED",
+        "max_add_symbols_per_market": 1,
+        "same_intent_class_sort_order": [
+            "support_strength_desc",
+            "independent_support_source_count_desc",
+            "honest_upside_pct_desc",
+            "post_fill_sector_increase_asc",
+            "required_cash_asc",
+        ],
+        "exact_tie_break": "NEW_BEFORE_ADD",
+    }
+    assert reserve["add_candidate"]["a_limit_lte_zero"] == "NO_ORDER"
     assert reserve["add_candidate"]["partial_A_limit_fill"] == "FORBIDDEN"
     assert reserve["toss_live_approval"] == (
         "HUMAN_APPROVAL_REQUIRED_UNTIL_VETO_WIRING"

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -16,7 +16,30 @@ async def test_get_trading_policy_returns_thresholds_and_version():
     assert out["version"] == policy_version_stamp()["version"]
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
-    assert set(out["decision_rules"]) == set()
+    assert set(out["decision_rules"]) == {"buy.support_reserve_net"}
+    reserve = out["decision_rules"]["buy.support_reserve_net"]
+    assert reserve["eligible_only_when_regular_gate_failure"] == "RSI_ONLY"
+    assert reserve["honest_upside_reference"] == "decision_time_current_price"
+    assert reserve["discount_below_support_pct_range"] == [5, 10]
+    assert reserve["final_limit_distance_from_current_pct_range"] == [-15, -5]
+    assert reserve["final_limit_distance_out_of_range"] == "EXCLUDE"
+    assert reserve["tier_armed_required_cash_cap_pct"] == 50
+    assert reserve["unknown_sector"] == "INELIGIBLE"
+    assert reserve["cash_reservation"]["broker_orderable_unavailable_or_error"] == (
+        "FAIL_CLOSED"
+    )
+    assert reserve["fill_triage"] == {
+        "on_first_confirmed_fill": "FREEZE_NEW_SUBMITS",
+        "cancellation_mode": "PROPOSAL_REQUIRES_APPROVAL",
+        "broker_cancel_confirmation_required_before_releasing_cash": True,
+        "same_session_rearm": False,
+        "unknown_or_ambiguous_order_state": "KEEP_RESERVED_AND_BLOCK",
+        "burst_key": ["broker_account_id", "currency", "market_session"],
+    }
+    assert reserve["add_candidate"]["partial_A_limit_fill"] == "FORBIDDEN"
+    assert reserve["toss_live_approval"] == (
+        "HUMAN_APPROVAL_REQUIRED_UNTIL_VETO_WIRING"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -1,3 +1,4 @@
+from decimal import ROUND_CEILING, Decimal
 from pathlib import Path
 
 import pytest
@@ -147,11 +148,34 @@ def test_support_reserve_net_literal_policy_blocks_are_frozen():
     assert add.policy_table_max_age_hours == 36
     assert add.k_used == 0.10
     assert add.sizing_price == "proposed_limit_price"
+    assert add.a_limit_lte_zero == "NO_ORDER"
     assert add.partial_A_limit_fill == "FORBIDDEN"
     assert add.max_add_symbols_per_market == 1
     assert add.max_reserve_net_add_fills_per_symbol_per_policy_version == 1
     assert add.same_day_rearm_after_fill is False
     assert add.crash_day_averaging_exemption is False
+
+    # §Q2 lines 82–87: constrained cash is assigned in this exact order.
+    priority = rule.priority_rules
+    assert priority.allocation_order == [
+        "dedupe_active_or_resting_same_symbol",
+        "first_slot_eligible_new_candidate",
+        "add_secondary_pool_only_after_r931_pass_and_full_a_limit_10",
+    ]
+    assert priority.same_symbol_active_or_resting == "DEDUPE_FIRST"
+    assert priority.first_slot == "ELIGIBLE_NEW_CANDIDATE_FIRST"
+    assert priority.add_candidate_rank == "SECONDARY_CANDIDATE_POOL"
+    assert priority.add_candidate_r931_review_required == "PASS"
+    assert priority.add_candidate_a_limit_10 == "FULLY_SATISFIED"
+    assert priority.max_add_symbols_per_market == 1
+    assert priority.same_intent_class_sort_order == [
+        "support_strength_desc",
+        "independent_support_source_count_desc",
+        "honest_upside_pct_desc",
+        "post_fill_sector_increase_asc",
+        "required_cash_asc",
+    ]
+    assert priority.exact_tie_break == "NEW_BEFORE_ADD"
 
     prohibitions = rule.prohibitions
     assert prohibitions.no_new_add_or_deep_limit_rung_overlap is True
@@ -217,6 +241,67 @@ def test_support_reserve_net_rejects_partial_A_limit_fill():
     raw["decision_rules"]["buy.support_reserve_net"]["add_candidate"][
         "partial_A_limit_fill"
     ] = "ALLOWED"
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_support_reserve_net_a_limit_exactly_zero_is_no_order():
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "buy.support_reserve_net"
+    ]
+    assert isinstance(rule, SupportReserveNetDecisionRule)
+
+    a_limit = Decimal("0")
+    proposed_limit_price = Decimal("12345")
+    quantity_from_ceiling = (a_limit / proposed_limit_price).to_integral_value(
+        rounding=ROUND_CEILING
+    )
+    outcome = "NO_ORDER" if a_limit <= Decimal("0") else "ELIGIBLE_TO_SIZE"
+    proposed_order_quantity: Decimal | None = (
+        None if a_limit <= Decimal("0") else quantity_from_ceiling
+    )
+
+    # `ceil(0 / price) == 0` must never become a zero-quantity order.
+    assert quantity_from_ceiling == Decimal("0")
+    assert outcome == rule.add_candidate.a_limit_lte_zero
+    assert proposed_order_quantity is None
+
+
+@pytest.mark.parametrize(
+    ("path", "mutant_value"),
+    [
+        (("add_candidate", "a_limit_lte_zero"), "ALLOW_ZERO_QUANTITY_ORDER"),
+        (
+            ("priority_rules", "allocation_order"),
+            [
+                "first_slot_eligible_new_candidate",
+                "dedupe_active_or_resting_same_symbol",
+                "add_secondary_pool_only_after_r931_pass_and_full_a_limit_10",
+            ],
+        ),
+        (("priority_rules", "first_slot"), "ADD_CANDIDATE_FIRST"),
+        (
+            ("priority_rules", "same_intent_class_sort_order"),
+            [
+                "independent_support_source_count_desc",
+                "support_strength_desc",
+                "honest_upside_pct_desc",
+                "post_fill_sector_increase_asc",
+                "required_cash_asc",
+            ],
+        ),
+        (("priority_rules", "exact_tie_break"), "ADD_BEFORE_NEW"),
+    ],
+)
+def test_support_reserve_net_rejects_priority_or_zero_order_contract_mutation(
+    path: tuple[str, ...], mutant_value: object
+):
+    raw = _raw()
+    target = raw["decision_rules"]["buy.support_reserve_net"]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = mutant_value
 
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -5,7 +5,11 @@ import yaml
 from pydantic import ValidationError
 
 import app.schemas.trading_policy as policy_schema
-from app.schemas.trading_policy import TradingPolicyDocument
+from app.schemas.trading_policy import (
+    SupportReserveNetDecisionRule,
+    TradingPolicyDocument,
+)
+from app.services.order_proposals.auto_approve import _VETO_CAPABLE_ACCOUNT_MARKETS
 from app.services.trading_policy_service import load_trading_policy
 
 _CONFIG = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
@@ -72,6 +76,167 @@ def test_shipped_config_validates():
     )
     assert trim_rule.tie_breaks["sell.upside_place_max_pct"] == "size_limit_only"
     assert "single_share_position" not in trim_rule.exclusions
+
+
+def test_support_reserve_net_literal_policy_blocks_are_frozen():
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "buy.support_reserve_net"
+    ]
+
+    assert isinstance(rule, SupportReserveNetDecisionRule)
+    assert rule.lanes == ["buy"]
+
+    # §Q1 literal: reserve-net is an RSI-only exception, never a wider gate.
+    assert rule.regular_discovery_precedence is True
+    assert rule.eligible_only_when_regular_gate_failure == "RSI_ONLY"
+    assert rule.rsi_gate == "omitted_for_this_tier_only"
+    assert rule.support_strength_min == "moderate"
+    assert rule.independent_support_source_count_min == 2
+    assert rule.independent_support_source_families == [
+        "fib",
+        "bb_lower",
+        "volume_profile",
+    ]
+    assert rule.support_within_current_pct_max == 8
+    assert rule.honest_upside_pct_min == 40
+    assert rule.honest_upside_reference == "decision_time_current_price"
+    assert rule.discount_below_support_pct_range == [5, 10]
+    assert rule.final_limit_distance_from_current_pct_range == [-15, -5]
+    assert rule.anchor_price_formula == "tick_floor(S × (1-d))"
+    assert rule.final_limit_distance_out_of_range == "EXCLUDE"
+    assert rule.order_type == "limit"
+    assert rule.tif == "DAY"
+
+    # §Q2 literal plus its accounting contract.
+    assert rule.all_pending_buy_required_cash_hard_cap_pct == 90
+    assert rule.tier_armed_required_cash_cap_pct == 50
+    assert rule.max_owned_or_open_symbols_per_market == 2
+    assert rule.max_active_orders_per_symbol == 1
+    assert rule.max_symbols_per_sector_cluster == 1
+    assert rule.unknown_sector == "INELIGIBLE"
+    assert rule.auto_submit_notional.krw == 200000
+    assert rule.auto_submit_notional.usd == 150
+    assert rule.larger_notional_within_existing_band == "HUMAN_APPROVAL_REQUIRED"
+    assert rule.daily_auto_cap_includes_all_buy_tiers is True
+    assert rule.cash_reservation.net_orderable == (
+        "fresh_broker_orderable_cash_minus_same_account_currency_pending_required_cash"
+    )
+    assert rule.cash_reservation.pending_required_cash_scope == "not_yet_reached_broker"
+    assert rule.cash_reservation.required_cash_primary == (
+        "preview_estimated_value_plus_fee"
+    )
+    assert rule.cash_reservation.required_cash_fallback == "quantity_times_limit_price"
+    assert rule.cash_reservation.broker_orderable_unavailable_or_error == "FAIL_CLOSED"
+    assert rule.cash_reservation.cancel_proposal_cash_reservation == (
+        "KEEP_RESERVED_UNTIL_BROKER_TERMINAL_CONFIRMATION"
+    )
+
+    # §Q3 literal: the read-only triage consumer cannot release or rearm.
+    triage = rule.fill_triage
+    assert triage.on_first_confirmed_fill == "FREEZE_NEW_SUBMITS"
+    assert triage.cancellation_mode == "PROPOSAL_REQUIRES_APPROVAL"
+    assert triage.broker_cancel_confirmation_required_before_releasing_cash is True
+    assert triage.same_session_rearm is False
+    assert triage.unknown_or_ambiguous_order_state == "KEEP_RESERVED_AND_BLOCK"
+    assert triage.burst_key == ["broker_account_id", "currency", "market_session"]
+
+    # §Q4 literal: an add is full A_limit feasibility, not an undersized buy.
+    add = rule.add_candidate
+    assert add.r931_review_required == "PASS"
+    assert add.r931_review_max_age_days == 7
+    assert add.policy_table_max_age_hours == 36
+    assert add.k_used == 0.10
+    assert add.sizing_price == "proposed_limit_price"
+    assert add.partial_A_limit_fill == "FORBIDDEN"
+    assert add.max_add_symbols_per_market == 1
+    assert add.max_reserve_net_add_fills_per_symbol_per_policy_version == 1
+    assert add.same_day_rearm_after_fill is False
+    assert add.crash_day_averaging_exemption is False
+
+    prohibitions = rule.prohibitions
+    assert prohibitions.no_new_add_or_deep_limit_rung_overlap is True
+    assert prohibitions.aggregate_active_buy_by_beneficial_owner_across_accounts is True
+    assert prohibitions.fresh_cost_basis_quantity_and_A_limit_before_next_day_reissue
+    assert prohibitions.partial_A_limit_fill == "FORBIDDEN"
+    assert prohibitions.candidate_zero_runtime_gate_relaxation == "FORBIDDEN"
+    assert prohibitions.crash_day_averaging_exemption is False
+    assert prohibitions.cancel_proposal_is_not_broker_cancellation is True
+    assert prohibitions.unconfirmed_cancel_keeps_required_cash_reserved is True
+    assert prohibitions.market_order == "FORBIDDEN"
+    assert prohibitions.gtc == "FORBIDDEN"
+    assert prohibitions.multi_rung == "FORBIDDEN"
+    assert prohibitions.daily_regeneration == "REQUIRED"
+    assert rule.toss_live_approval == "HUMAN_APPROVAL_REQUIRED_UNTIL_VETO_WIRING"
+
+
+@pytest.mark.parametrize(
+    ("path", "mutant_value"),
+    [
+        (("honest_upside_pct_min",), 39),
+        (("independent_support_source_count_min",), 1),
+        (("final_limit_distance_from_current_pct_range",), [-15, -4]),
+        (("prohibitions", "candidate_zero_runtime_gate_relaxation"), "ALLOWED"),
+    ],
+)
+def test_support_reserve_net_rejects_candidate_zero_gate_relaxation(
+    path: tuple[str, ...], mutant_value: object
+):
+    """§Q4-5: candidate count zero never makes a runtime gate looser."""
+    raw = _raw()
+    target = raw["decision_rules"]["buy.support_reserve_net"]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = mutant_value
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_support_reserve_net_rejects_armed_cap_above_50_percent():
+    raw = _raw()
+    raw["decision_rules"]["buy.support_reserve_net"][
+        "tier_armed_required_cash_cap_pct"
+    ] = 51
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_support_reserve_net_rejects_clamping_an_out_of_band_anchor():
+    raw = _raw()
+    raw["decision_rules"]["buy.support_reserve_net"][
+        "final_limit_distance_out_of_range"
+    ] = "CLAMP"
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_support_reserve_net_rejects_partial_A_limit_fill():
+    raw = _raw()
+    raw["decision_rules"]["buy.support_reserve_net"]["add_candidate"][
+        "partial_A_limit_fill"
+    ] = "ALLOWED"
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_support_reserve_net_boundary_values_are_inclusive_and_exact():
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "buy.support_reserve_net"
+    ]
+    assert isinstance(rule, SupportReserveNetDecisionRule)
+    assert rule.tier_armed_required_cash_cap_pct == 50
+    assert rule.final_limit_distance_from_current_pct_range[0] == -15
+    assert rule.final_limit_distance_from_current_pct_range[1] == -5
+    assert rule.honest_upside_pct_min == 40
+
+
+def test_support_reserve_net_keeps_toss_outside_auto_veto_capable_combinations():
+    assert all(
+        account_mode != "toss_live" for account_mode, _ in _VETO_CAPABLE_ACCOUNT_MARKETS
+    )
 
 
 def test_single_share_exit_rule_is_provisional_shadow_only():

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -27,6 +27,20 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
     assert reserve["discount_below_support_pct_range"] == [5, 10]
     assert reserve["final_limit_distance_from_current_pct_range"] == [-15, -5]
     assert reserve["fill_triage"]["same_session_rearm"] is False
+    assert reserve["priority_rules"]["allocation_order"] == [
+        "dedupe_active_or_resting_same_symbol",
+        "first_slot_eligible_new_candidate",
+        "add_secondary_pool_only_after_r931_pass_and_full_a_limit_10",
+    ]
+    assert reserve["priority_rules"]["same_intent_class_sort_order"] == [
+        "support_strength_desc",
+        "independent_support_source_count_desc",
+        "honest_upside_pct_desc",
+        "post_fill_sector_increase_asc",
+        "required_cash_asc",
+    ]
+    assert reserve["priority_rules"]["exact_tie_break"] == "NEW_BEFORE_ADD"
+    assert reserve["add_candidate"]["a_limit_lte_zero"] == "NO_ORDER"
 
 
 def test_get_policy_for_sell_lane_filters_thresholds():

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -22,7 +22,11 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
     assert view["thresholds"]["portfolio.max_symbols_per_theme"]["value"] == 2
     assert view["thresholds"]["sell.loss_guard_min_multiple"]["value"] == 1.01
     assert "sell.rsi_place_min" not in view["thresholds"]
-    assert set(view["decision_rules"]) == set()
+    assert set(view["decision_rules"]) == {"buy.support_reserve_net"}
+    reserve = view["decision_rules"]["buy.support_reserve_net"]
+    assert reserve["discount_below_support_pct_range"] == [5, 10]
+    assert reserve["final_limit_distance_from_current_pct_range"] == [-15, -5]
+    assert reserve["fill_triage"]["same_session_rearm"] is False
 
 
 def test_get_policy_for_sell_lane_filters_thresholds():

--- a/tests/test_fill_event_triage_command.py
+++ b/tests/test_fill_event_triage_command.py
@@ -64,6 +64,9 @@ def test_runbook_keeps_reserve_net_triage_contract_only_and_toss_human_gated():
         "Toss 는 승인 카드 경유",
         "intentionally **not** in\nthis job",
         "automatic cancellation implemented here",
+        "TODO — future consumer job",
+        "promote the account×currency triage lock\n> to a durable lock",
+        "no automatic submission consumer exists today",
     ):
         assert token in body, f"runbook reserve-net 계약에 {token} 누락"
 

--- a/tests/test_fill_event_triage_command.py
+++ b/tests/test_fill_event_triage_command.py
@@ -6,6 +6,7 @@ import pytest
 
 REPO = pathlib.Path(__file__).resolve().parents[1]
 CMD = REPO / ".claude" / "commands" / "fill-event-triage.md"
+RUNBOOK = REPO / "docs" / "runbooks" / "fill-event-claude-triage.md"
 pytestmark = pytest.mark.unit
 
 
@@ -34,6 +35,37 @@ def test_command_covers_sell_and_redeploy():
 def test_command_states_readonly_contract():
     body = CMD.read_text(encoding="utf-8").lower()
     assert ("read-only" in body) or ("주문" in body and "금지" in body)
+
+
+def test_command_encodes_support_reserve_net_fill_state_machine():
+    body = CMD.read_text(encoding="utf-8")
+    for token in (
+        "buy.support_reserve_net",
+        "confirmed broker fill",
+        "FREEZE_NEW_SUBMITS",
+        "PROPOSAL_REQUIRES_APPROVAL",
+        "KEEP_RESERVED_AND_BLOCK",
+        "broker CANCELLED/terminal",
+        "same-session rearm",
+        "cash_reservation=KEEP",
+        "cancel proposal은 broker cancellation이 아니다",
+    ):
+        assert token in body, f"reserve-net fill 계약에 {token} 누락"
+
+
+def test_runbook_keeps_reserve_net_triage_contract_only_and_toss_human_gated():
+    body = RUNBOOK.read_text(encoding="utf-8")
+    for token in (
+        "contract/specification extension only",
+        "does not alter this\npoller",
+        "approval-gated cancel-proposal **draft**",
+        "KEEP_RESERVED_AND_BLOCK",
+        "Broker terminal confirmation is required before releasing\ncash.",
+        "Toss 는 승인 카드 경유",
+        "intentionally **not** in\nthis job",
+        "automatic cancellation implemented here",
+    ):
+        assert token in body, f"runbook reserve-net 계약에 {token} 누락"
 
 
 def test_command_does_not_reference_denied_tools():

--- a/tests/test_playbook_tool_names.py
+++ b/tests/test_playbook_tool_names.py
@@ -115,3 +115,29 @@ def test_playbook_covers_core_lanes() -> None:
     assert {"bootstrap", "buy", "sell", "discovery"} <= lane_names, (
         f"playbook must define bootstrap/buy/sell/discovery lanes; found {sorted(lane_names)}"
     )
+
+
+def test_buy_pipeline_negative_recording_precedes_reserve_net_subsection() -> None:
+    text = _PLAYBOOK_PATH.read_text(encoding="utf-8")
+    negative_recording = text.index("8. **Negative-class recording (ROB-712):")
+    reserve_net = text.index("### 1.1 `buy.support_reserve_net`")
+    buy_lane_yaml = text.index("# playbook-machine-readable: buy lane")
+
+    assert negative_recording < reserve_net < buy_lane_yaml
+
+
+def test_reserve_net_playbook_repeats_machine_policy_priority_contract() -> None:
+    text = _PLAYBOOK_PATH.read_text(encoding="utf-8")
+    reserve_net = text.index("### 1.1 `buy.support_reserve_net`")
+    buy_lane_yaml = text.index("# playbook-machine-readable: buy lane")
+    section = text[reserve_net:buy_lane_yaml]
+
+    for requirement in (
+        "이미 active/resting인 동일 symbol을 먼저 dedupe한다.",
+        "첫 슬롯은 eligible 신규 후보에 우선 배정한다.",
+        "R-931 재심사 PASS와 Q4의 `A_limit(10%)` 완전충족",
+        "`strong > moderate`, `3-source > 2-source`",
+        "완전 동률이면 신규가 물타기보다 먼저다.",
+        "`A_limit<=0` (already target met) is\n   **NO_ORDER**",
+    ):
+        assert requirement in section


### PR DESCRIPTION
## Summary
- add the literal `buy.support_reserve_net` policy tier with strict schema validation and version stamp `2026-08-12.2`
- document the §1 buy consumer rules and ROB-755 read-only fill freeze/cancel-proposal-draft state machine
- add policy, MCP, triage-command, and auto-veto regression coverage including mutation-resistant invariants

## Safety scope
- no broker, order-proposal service, ledger, MCP invocation, scheduler, automatic-cancel, or Toss auto-approval change
- Toss remains human approval only pending separate veto/E2E acceptance work

## Verification
- `make lint`
- `uv run pytest tests/schemas/test_trading_policy_schema.py tests/mcp_server/test_trading_policy_tool.py tests/services/test_trading_policy_service.py tests/services/test_single_share_exit_snapshot_service.py tests/test_fill_event_triage_command.py tests/services/order_proposals/test_auto_approve.py tests/test_playbook_tool_names.py -q` (194 passed)
- four required configuration mutants rejected; assertion inversion rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `buy.support_reserve_net` trading policy with eligibility, pricing, cash-reservation, concentration, prioritization, and approval requirements.
  * Added read-only fill-triage workflows for confirmed fills, including reservation blocking, broker-state verification, and approval-gated cancellation proposals.
  * Added Korean-language guidance for the new trading policy.

* **Documentation**
  * Updated policy metadata, operational playbooks, and runbooks with the new rules, safety constraints, and human-approval boundaries.

* **Tests**
  * Added comprehensive validation for policy boundaries, fill handling, approval gates, prioritization, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->