### PR TITLE
fix(b0x): repair provenance stamps

### DIFF
--- a/docs/runbooks/b0x-crypto-cycle.md
+++ b/docs/runbooks/b0x-crypto-cycle.md
@@ -34,6 +34,9 @@
    uv run python -m scripts.build_policy_table --market crypto
    ```
    출력 위치 = `~/services/auto_trader-operator/policy-tables/latest-crypto.json`.
+   이 기본 경로는 §47 Prefect가 `policy-tables/`만 직접 커밋하는 정상 경로라 CLI가
+   stderr에 공유 체크아웃 경고를 남긴다. 수동·격리 빌드는 반드시 별도
+   `--out-dir /안전한/개인/경로`를 명시한다.
    B0-X 는 이 디렉토리를 **읽기만** 한다 (생성기를 호출하지 않는다).
 2. 사이드카를 쓸 경우에만: `B0X_SIDECAR_ENABLED=true` + `BINANCE_SPOT_DEMO_ENABLED=true`
    + `BINANCE_SPOT_DEMO_API_KEY/SECRET` (또는 canonical `BINANCE_DEMO_API_*`).

--- a/docs/runbooks/b0x-kr-cycle.md
+++ b/docs/runbooks/b0x-kr-cycle.md
@@ -64,6 +64,9 @@ RTH 밖이면 표·계좌 I/O **전혀 없이** `zero_order_reason=outside_krx_r
    uv run python -m scripts.build_policy_table --market kr
    ```
    출력 위치 = `~/services/auto_trader-operator/policy-tables/latest-kr.json`.
+   이 기본 경로는 §47 Prefect가 `policy-tables/`만 직접 커밋하는 정상 경로라 CLI가
+   stderr에 공유 체크아웃 경고를 남긴다. 수동·격리 빌드는 반드시 별도
+   `--out-dir /안전한/개인/경로`를 명시한다.
    B0-X 는 이 디렉토리를 **읽기만** 한다.
 2. `KIS_MOCK_ENABLED=true` + `KIS_MOCK_APP_KEY/APP_SECRET/ACCOUNT_NO` — read-only 계좌
    조회(잔고·보유)에 필요하다. 확인 경로는 여기에 `B0X_KR_ENABLED=true`와 per-call

--- a/scripts/b0x/contract.py
+++ b/scripts/b0x/contract.py
@@ -57,7 +57,6 @@ CONTRACT_CLAUSES: Final[dict[str, str]] = {
 
 #: Account map — the machine-readable surface is canonical (v1.3 ①).
 ACCOUNT_MAP_REPO: Final[str] = "auto_trader-operator"
-ACCOUNT_MAP_REPO_PATH: Final[Path] = Path.home() / "services" / ACCOUNT_MAP_REPO
 ACCOUNT_MAP_COMMIT_UNAVAILABLE: Final[str] = "UNAVAILABLE"
 ACCOUNT_MAP_CANONICAL_SURFACE: Final[str] = "operator_contract.yaml"
 ACCOUNT_MAP_REFERENCE_SURFACE: Final[str] = "mock/CLAUDE.md"
@@ -81,48 +80,137 @@ def contract_stamp() -> dict[str, Any]:
     }
 
 
-def _resolve_account_map_head() -> tuple[str, str | None]:
-    """Read the exact operator-repo HEAD used for this account-map stamp.
-
-    The operator repository is a read-only dependency here.  A missing or
-    unreadable checkout is observation degradation, not evidence for a
-    historical commit, so callers receive an explicit unavailable marker
-    instead of a stale fallback.
-    """
+def _run_git(
+    command: list[str], *, cwd: Path
+) -> subprocess.CompletedProcess[str] | None:
+    """Run a bounded, read-only Git query without raising into a cycle."""
 
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=ACCOUNT_MAP_REPO_PATH,
+        return subprocess.run(
+            ["git", *command],
+            cwd=cwd,
             check=False,
             capture_output=True,
             text=True,
             timeout=5,
         )
     except OSError:
-        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_unavailable"
+        return None
     except subprocess.SubprocessError:
-        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_query_failed"
+        return None
 
-    if result.returncode != 0:
-        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_query_failed"
 
-    commit = result.stdout.strip()
+def _unavailable_account_map_stamp(
+    *,
+    source_path: Path | None,
+    reason: str,
+    repository_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return an explicit unknown rather than inventing a historic commit."""
+
+    return {
+        "repo": ACCOUNT_MAP_REPO,
+        "commit": ACCOUNT_MAP_COMMIT_UNAVAILABLE,
+        "commit_status": "unavailable",
+        "commit_reason": reason,
+        "source_path": None if source_path is None else str(source_path),
+        "repository_path": (None if repository_path is None else str(repository_path)),
+        "branch": ACCOUNT_MAP_COMMIT_UNAVAILABLE,
+        "branch_reason": reason,
+        "reachable_from_origin_main": None,
+        "canonical_surface": ACCOUNT_MAP_CANONICAL_SURFACE,
+        "reference_surface": ACCOUNT_MAP_REFERENCE_SURFACE,
+    }
+
+
+def account_map_stamp(*, account_map_path: Path | None) -> dict[str, Any]:
+    """Stamp the account-map worktree that supplied this cycle's table path.
+
+    `account_map_path` is injected by the cycle from its actual
+    ``--table-dir`` value. The resolver never consults a separate shared
+    checkout: using one would let a later branch switch rewrite provenance for
+    a table the cycle did not consume.
+    """
+
+    if account_map_path is None:
+        return _unavailable_account_map_stamp(
+            source_path=None, reason="account_map_source_not_supplied"
+        )
+
+    source_path = Path(account_map_path).expanduser()
+    root_result = _run_git(["rev-parse", "--show-toplevel"], cwd=source_path)
+    if root_result is None:
+        return _unavailable_account_map_stamp(
+            source_path=source_path, reason="account_map_source_query_unavailable"
+        )
+    if root_result.returncode != 0:
+        return _unavailable_account_map_stamp(
+            source_path=source_path, reason="account_map_source_not_git_repository"
+        )
+
+    root_text = root_result.stdout.strip()
+    if not root_text:
+        return _unavailable_account_map_stamp(
+            source_path=source_path, reason="account_map_repository_path_invalid"
+        )
+    repository_path = Path(root_text)
+    if not (repository_path / ACCOUNT_MAP_CANONICAL_SURFACE).is_file():
+        return _unavailable_account_map_stamp(
+            source_path=source_path,
+            repository_path=repository_path,
+            reason="account_map_canonical_surface_missing",
+        )
+
+    head_result = _run_git(["rev-parse", "HEAD"], cwd=repository_path)
+    if head_result is None or head_result.returncode != 0:
+        return _unavailable_account_map_stamp(
+            source_path=source_path,
+            repository_path=repository_path,
+            reason="account_map_head_query_failed",
+        )
+    commit = head_result.stdout.strip()
     if not _GIT_COMMIT_RE.fullmatch(commit):
-        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_invalid"
-    return commit, None
+        return _unavailable_account_map_stamp(
+            source_path=source_path,
+            repository_path=repository_path,
+            reason="account_map_head_invalid",
+        )
 
+    branch_result = _run_git(["branch", "--show-current"], cwd=repository_path)
+    if branch_result is None or branch_result.returncode != 0:
+        branch = ACCOUNT_MAP_COMMIT_UNAVAILABLE
+        branch_reason: str | None = "account_map_branch_query_failed"
+    else:
+        branch = branch_result.stdout.strip() or "detached"
+        branch_reason = None
 
-def account_map_stamp() -> dict[str, Any]:
-    """Account-map identity block — canonical surface and actual HEAD."""
-
-    commit, reason = _resolve_account_map_head()
+    reachability_result = _run_git(
+        ["merge-base", "--is-ancestor", commit, "origin/main"],
+        cwd=repository_path,
+    )
+    if reachability_result is not None and reachability_result.returncode == 0:
+        reachable_from_origin_main: bool | None = True
+        commit_status = "available"
+        commit_reason: str | None = None
+    elif reachability_result is not None and reachability_result.returncode == 1:
+        reachable_from_origin_main = False
+        commit_status = "unpublished"
+        commit_reason = "account_map_head_not_reachable_from_origin_main"
+    else:
+        reachable_from_origin_main = None
+        commit_status = "reachability_unavailable"
+        commit_reason = "account_map_origin_main_query_failed"
 
     return {
         "repo": ACCOUNT_MAP_REPO,
         "commit": commit,
-        "commit_status": "available" if reason is None else "unavailable",
-        "commit_reason": reason,
+        "commit_status": commit_status,
+        "commit_reason": commit_reason,
+        "source_path": str(source_path),
+        "repository_path": str(repository_path),
+        "branch": branch,
+        "branch_reason": branch_reason,
+        "reachable_from_origin_main": reachable_from_origin_main,
         "canonical_surface": ACCOUNT_MAP_CANONICAL_SURFACE,
         "reference_surface": ACCOUNT_MAP_REFERENCE_SURFACE,
     }
@@ -133,7 +221,6 @@ __all__ = [
     "ACCOUNT_MAP_COMMIT_UNAVAILABLE",
     "ACCOUNT_MAP_REFERENCE_SURFACE",
     "ACCOUNT_MAP_REPO",
-    "ACCOUNT_MAP_REPO_PATH",
     "CONTRACT_CLAUSES",
     "CONTRACT_FILE_SHA256_REFERENCE_ONLY",
     "CONTRACT_PATH",

--- a/scripts/b0x/contract.py
+++ b/scripts/b0x/contract.py
@@ -29,35 +29,39 @@ the coupling the digest was failing to provide.
 
 from __future__ import annotations
 
+import re
+import subprocess
+from pathlib import Path
 from typing import Any, Final
 
 CONTRACT_PATH: Final[str] = "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md"
 
 #: Binding identity. Bump together with the clauses below.
-CONTRACT_VERSION: Final[str] = "v1.4"
+CONTRACT_VERSION: Final[str] = "v1.7"
 
 #: Provenance only — NOT a drift criterion. See the module docstring.
 CONTRACT_FILE_SHA256_REFERENCE_ONLY: Final[str] = (
-    "bce7104bd1a3f36a253baecc05d8bc960ad1c41a82de4c345d6659320ad1f5f8"
+    "0d09e1ce4d175da75de17958880491965ea6cae8d13764853f23fbc0348f596a"
 )
 
-#: Verbatim §8 v1.4 clauses this package implements.
+#: Verbatim §8 v1.7 amendment this package records.
 CONTRACT_CLAUSES: Final[dict[str, str]] = {
-    "§8 v1.4 ②": (
-        "관측 산출물에 **`SHARED_ACCOUNT_HISTORY` 라벨** 부착(**과거 dust·사고 "
-        "이력 계좌**)."
-    ),
-    "§8 v1.4 ③": (
-        "writer=1 문언 정합: 「B0-X 측 단일 writer + 계좌 배타성은 운영 "
-        "조치(disarm)로 확보, 방어는 오염 게이트의 fail-closed 관측」."
+    "§8 v1.7": (
+        "「스케줄러 등록 없음」 개정 — **스케줄러 (Prefect)는 시각만 소유한다**: "
+        "표 빌드 실행(KR 07:45·US 22:00)과 orch 기상 nudge(사이클 슬롯)에 한정. "
+        "전략 판단·주문 파생·dispatch·워커 실행은 불변(orch/워커 소유, "
+        "harvest-before-dispatch 유지). 근거 = 수동 원샷 장전 누락 4회 실측. "
+        "실행 표면·envelope·승격 절차 무변경."
     ),
 }
 
 #: Account map — the machine-readable surface is canonical (v1.3 ①).
 ACCOUNT_MAP_REPO: Final[str] = "auto_trader-operator"
-ACCOUNT_MAP_COMMIT: Final[str] = "3f402919fca5b68bda187e8e521fc886aefb022a"
+ACCOUNT_MAP_REPO_PATH: Final[Path] = Path.home() / "services" / ACCOUNT_MAP_REPO
+ACCOUNT_MAP_COMMIT_UNAVAILABLE: Final[str] = "UNAVAILABLE"
 ACCOUNT_MAP_CANONICAL_SURFACE: Final[str] = "operator_contract.yaml"
 ACCOUNT_MAP_REFERENCE_SURFACE: Final[str] = "mock/CLAUDE.md"
+_GIT_COMMIT_RE: Final[re.Pattern[str]] = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 #: Sidecar lane standing, narrowed by v1.3 ②. Stamped on sidecar artifacts so
 #: a reader cannot mistake a buy-side fill-fidelity sample for a round-trip
@@ -77,12 +81,48 @@ def contract_stamp() -> dict[str, Any]:
     }
 
 
+def _resolve_account_map_head() -> tuple[str, str | None]:
+    """Read the exact operator-repo HEAD used for this account-map stamp.
+
+    The operator repository is a read-only dependency here.  A missing or
+    unreadable checkout is observation degradation, not evidence for a
+    historical commit, so callers receive an explicit unavailable marker
+    instead of a stale fallback.
+    """
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ACCOUNT_MAP_REPO_PATH,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except OSError:
+        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_unavailable"
+    except subprocess.SubprocessError:
+        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_query_failed"
+
+    if result.returncode != 0:
+        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_query_failed"
+
+    commit = result.stdout.strip()
+    if not _GIT_COMMIT_RE.fullmatch(commit):
+        return ACCOUNT_MAP_COMMIT_UNAVAILABLE, "account_map_head_invalid"
+    return commit, None
+
+
 def account_map_stamp() -> dict[str, Any]:
-    """Account-map identity block — canonical surface named explicitly."""
+    """Account-map identity block — canonical surface and actual HEAD."""
+
+    commit, reason = _resolve_account_map_head()
 
     return {
         "repo": ACCOUNT_MAP_REPO,
-        "commit": ACCOUNT_MAP_COMMIT,
+        "commit": commit,
+        "commit_status": "available" if reason is None else "unavailable",
+        "commit_reason": reason,
         "canonical_surface": ACCOUNT_MAP_CANONICAL_SURFACE,
         "reference_surface": ACCOUNT_MAP_REFERENCE_SURFACE,
     }
@@ -90,9 +130,10 @@ def account_map_stamp() -> dict[str, Any]:
 
 __all__ = [
     "ACCOUNT_MAP_CANONICAL_SURFACE",
-    "ACCOUNT_MAP_COMMIT",
+    "ACCOUNT_MAP_COMMIT_UNAVAILABLE",
     "ACCOUNT_MAP_REFERENCE_SURFACE",
     "ACCOUNT_MAP_REPO",
+    "ACCOUNT_MAP_REPO_PATH",
     "CONTRACT_CLAUSES",
     "CONTRACT_FILE_SHA256_REFERENCE_ONLY",
     "CONTRACT_PATH",

--- a/scripts/b0x/cycle.py
+++ b/scripts/b0x/cycle.py
@@ -156,13 +156,18 @@ def render_cycle_report(record: dict[str, Any], *, labels: tuple[str, ...]) -> s
         ]
     contract = record.get("contract") or {}
     account_map = record.get("account_map") or {}
+    account_map_line = (
+        f"account map: `{account_map.get('repo', '-')}@"
+        f"{account_map.get('commit', '-')}` "
+        f"canonical=`{account_map.get('canonical_surface', '-')}`"
+    )
+    if reason := account_map.get("commit_reason"):
+        account_map_line += f" reason=`{reason}`"
     lines += [
         f"contract: `{contract.get('version', '-')}` "
         f"({', '.join(contract.get('clauses') or {}) or '-'}) · "
         f"file sha256 (reference only): `{contract.get('file_sha256_reference_only', '-')}`",
-        f"account map: `{account_map.get('repo', '-')}@"
-        f"{account_map.get('commit', '-')}` "
-        f"canonical=`{account_map.get('canonical_surface', '-')}`",
+        account_map_line,
     ]
     if record.get("sidecar_scope"):
         lines.append(f"sidecar scope: `{record['sidecar_scope']}`")

--- a/scripts/b0x/cycle.py
+++ b/scripts/b0x/cycle.py
@@ -125,8 +125,14 @@ def base_record(
     now: dt.datetime,
     envelope: Envelope,
     labels: tuple[str, ...],
+    account_map_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Market-agnostic observation-record skeleton, shared by every lane."""
+    """Market-agnostic observation-record skeleton, shared by every lane.
+
+    The crypto runners pass the exact table directory they read. Other lanes
+    overwrite this generic block with their own lane-local provenance until
+    their contract-stamp repair is separately authorized.
+    """
 
     return {
         "schema": "b0x.observation.v1",
@@ -136,7 +142,7 @@ def base_record(
         "labels": list(labels),
         "envelope": envelope.canonical(),
         "contract": contract_stamp(),
-        "account_map": account_map_stamp(),
+        "account_map": account_map_stamp(account_map_path=account_map_path),
     }
 
 
@@ -163,6 +169,16 @@ def render_cycle_report(record: dict[str, Any], *, labels: tuple[str, ...]) -> s
     )
     if reason := account_map.get("commit_reason"):
         account_map_line += f" reason=`{reason}`"
+    if source_path := account_map.get("source_path"):
+        account_map_line += f" source=`{source_path}`"
+    if branch := account_map.get("branch"):
+        account_map_line += f" branch=`{branch}`"
+    if "reachable_from_origin_main" in account_map:
+        reachable = account_map["reachable_from_origin_main"]
+        rendered_reachability = (
+            "unknown" if reachable is None else str(bool(reachable)).lower()
+        )
+        account_map_line += f" origin/main-reachable=`{rendered_reachability}`"
     lines += [
         f"contract: `{contract.get('version', '-')}` "
         f"({', '.join(contract.get('clauses') or {}) or '-'}) · "
@@ -233,6 +249,7 @@ async def run_shadow_cycle(
     labels = header_labels(lane=shadow_lane.LANE, extra=(SHADOW_SYNTHETIC_FILL,))
     lane = shadow_lane.LANE
     outcome = CycleOutcome(lane=lane, at=now)
+    table_dir = Path(table_dir).expanduser()
 
     with writer_lock(lane=lane, root=Path(out_dir).expanduser()):
         ledger = ObservationLedger(lane=lane, root=Path(out_dir).expanduser())
@@ -248,7 +265,12 @@ async def run_shadow_cycle(
         day_rolled = portfolio.roll_utc_day(now=now)
 
         record = base_record(
-            market=MARKET, lane=lane, now=now, envelope=envelope, labels=labels
+            market=MARKET,
+            lane=lane,
+            now=now,
+            envelope=envelope,
+            labels=labels,
+            account_map_path=table_dir,
         )
         record["envelope_application"] = SHADOW_ENVELOPE_NOT_APPLIED
         record["touch_rule"] = {
@@ -274,7 +296,7 @@ async def run_shadow_cycle(
         }
 
         # --- table gate ---
-        table, unavailable = _table_or_reason(now=now, table_dir=Path(table_dir))
+        table, unavailable = _table_or_reason(now=now, table_dir=table_dir)
         if table is None:
             assert unavailable is not None
             record["zero_order_reason"] = unavailable.reason
@@ -444,13 +466,19 @@ async def run_sidecar_cycle(
         extra=(*account_history_labels(lane), CROSS_QUOTE_RATIO_TRANSFER),
     )
     outcome = CycleOutcome(lane=lane, at=now)
+    table_dir = Path(table_dir).expanduser()
 
     with writer_lock(lane=lane, root=Path(out_dir).expanduser()):
         ledger = ObservationLedger(lane=lane, root=Path(out_dir).expanduser())
         ledger.ensure()
 
         record = base_record(
-            market=MARKET, lane=lane, now=now, envelope=envelope, labels=labels
+            market=MARKET,
+            lane=lane,
+            now=now,
+            envelope=envelope,
+            labels=labels,
+            account_map_path=table_dir,
         )
         record["realized_pnl_source"] = SIDECAR_REALIZED_PNL_UNAVAILABLE
         record["policy"] = {
@@ -479,7 +507,7 @@ async def run_sidecar_cycle(
             if fresh.contaminated:
                 record["contaminated"] = True
 
-            table, unavailable = _table_or_reason(now=now, table_dir=Path(table_dir))
+            table, unavailable = _table_or_reason(now=now, table_dir=table_dir)
             if table is None:
                 assert unavailable is not None
                 record["zero_order_reason"] = unavailable.reason

--- a/scripts/build_policy_table.py
+++ b/scripts/build_policy_table.py
@@ -15,9 +15,9 @@ functions are used). Never merges, never places or cancels an order.
 
 Usage
 -----
-    uv run python -m scripts.build_policy_table --market crypto
-    uv run python -m scripts.build_policy_table --market kr
-    uv run python -m scripts.build_policy_table --market us
+    uv run python -m scripts.build_policy_table --market crypto --out-dir /path/to/policy-tables
+    uv run python -m scripts.build_policy_table --market kr --out-dir /path/to/policy-tables
+    uv run python -m scripts.build_policy_table --market us --out-dir /path/to/policy-tables
 
     # Reproducibility check (ROB-1230 acceptance #2): dump raw inputs once,
     # then replay the same inputs through the pure compute+serialize path
@@ -48,7 +48,12 @@ from scripts.policy_table.core.schema import (
     sha256_of_bytes,
 )
 
-DEFAULT_OUT_DIR = Path.home() / "services" / "auto_trader-operator" / "policy-tables"
+#: The canonical path used by the Prefect table-build flows.  It is deliberately
+#: not a CLI default: writing into the shared operator checkout requires an
+#: explicit ``--out-dir`` at each invocation.
+OPERATOR_POLICY_TABLE_DIR = (
+    Path.home() / "services" / "auto_trader-operator" / "policy-tables"
+)
 
 # The exact D3 engine module files this job reuses (not reimplements). Their
 # content hashes are stamped into every artifact so a reviewer can confirm
@@ -272,7 +277,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "cap (default 50) — the JSON table itself is never top-N-capped"
         ),
     )
-    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help=(
+            "output directory (required; pass the Prefect-owned "
+            f"{OPERATOR_POLICY_TABLE_DIR} explicitly when that shared checkout "
+            "is the intended destination)"
+        ),
+    )
     parser.add_argument(
         "--dump-raw", default=None, help="write fetched raw inputs to this path"
     )

--- a/scripts/build_policy_table.py
+++ b/scripts/build_policy_table.py
@@ -15,9 +15,12 @@ functions are used). Never merges, never places or cancels an order.
 
 Usage
 -----
-    uv run python -m scripts.build_policy_table --market crypto --out-dir /path/to/policy-tables
-    uv run python -m scripts.build_policy_table --market kr --out-dir /path/to/policy-tables
-    uv run python -m scripts.build_policy_table --market us --out-dir /path/to/policy-tables
+    # §47 Prefect caller: uses the shared, commit-owned destination and emits
+    # an explicit warning to stderr.
+    uv run python -m scripts.build_policy_table --market crypto
+
+    # Manual/isolated invocation: name a non-shared output directory.
+    uv run python -m scripts.build_policy_table --market kr --out-dir /tmp/policy-tables
 
     # Reproducibility check (ROB-1230 acceptance #2): dump raw inputs once,
     # then replay the same inputs through the pure compute+serialize path
@@ -37,7 +40,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from scripts.policy_table.adapters import crypto as crypto_adapter
 from scripts.policy_table.adapters import kr as kr_adapter
@@ -48,11 +51,17 @@ from scripts.policy_table.core.schema import (
     sha256_of_bytes,
 )
 
-#: The canonical path used by the Prefect table-build flows.  It is deliberately
-#: not a CLI default: writing into the shared operator checkout requires an
-#: explicit ``--out-dir`` at each invocation.
-OPERATOR_POLICY_TABLE_DIR = (
+#: §47's existing Prefect caller omits ``--out-dir`` and commits this directory.
+#: Keep that compatible default; `_warn_if_shared_operator_out_dir` makes the
+#: otherwise hazardous shared-checkout write explicit on stderr.
+DEFAULT_OUT_DIR: Final[Path] = (
     Path.home() / "services" / "auto_trader-operator" / "policy-tables"
+)
+OPERATOR_POLICY_TABLE_DIR: Final[Path] = DEFAULT_OUT_DIR
+_SHARED_OPERATOR_OUT_DIR_WARNING: Final[str] = (
+    "WARNING: --out-dir is using the shared operator checkout "
+    f"({DEFAULT_OUT_DIR}); this is the Prefect-owned policy-tables destination. "
+    "Pass an explicit isolated --out-dir for manual builds."
 )
 
 # The exact D3 engine module files this job reuses (not reimplements). Their
@@ -279,11 +288,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--out-dir",
-        required=True,
+        default=str(DEFAULT_OUT_DIR),
         help=(
-            "output directory (required; pass the Prefect-owned "
-            f"{OPERATOR_POLICY_TABLE_DIR} explicitly when that shared checkout "
-            "is the intended destination)"
+            "output directory (default: the shared Prefect-owned "
+            f"{OPERATOR_POLICY_TABLE_DIR}; emits a warning when used)"
         ),
     )
     parser.add_argument(
@@ -299,7 +307,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="use this filename timestamp instead of now() (testing only)",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    _warn_if_shared_operator_out_dir(args.out_dir)
+    return args
+
+
+def _warn_if_shared_operator_out_dir(out_dir: str) -> None:
+    """Make a shared operator-checkout write visible without breaking Prefect."""
+
+    if Path(out_dir).expanduser() == DEFAULT_OUT_DIR:
+        print(_SHARED_OPERATOR_OUT_DIR_WARNING, file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/scripts/b0x/test_contract_stamp.py
+++ b/tests/scripts/b0x/test_contract_stamp.py
@@ -10,7 +10,7 @@ implements.
 from __future__ import annotations
 
 import subprocess
-from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +27,35 @@ V17_SCHEDULER_CLAUSE = (
 V17_CONTRACT_FILE_SHA256 = (
     "0d09e1ce4d175da75de17958880491965ea6cae8d13764853f23fbc0348f596a"
 )
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_operator_table_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Make an isolated operator worktree with a local origin/main reference."""
+
+    repository_path = tmp_path / "operator.tbl"
+    repository_path.mkdir()
+    _git(repository_path, "init", "-q")
+    _git(repository_path, "config", "user.email", "test@example.invalid")
+    _git(repository_path, "config", "user.name", "B0-X test")
+    (repository_path / "operator_contract.yaml").write_text("contract: test\n")
+    _git(repository_path, "add", "operator_contract.yaml")
+    _git(repository_path, "commit", "-q", "-m", "operator contract")
+    _git(repository_path, "branch", "-M", "main")
+    _git(repository_path, "update-ref", "refs/remotes/origin/main", "HEAD")
+    table_dir = repository_path / "policy-tables"
+    table_dir.mkdir()
+    return repository_path, table_dir
 
 
 @pytest.mark.unit
@@ -71,84 +100,87 @@ def test_sidecar_scope_is_the_narrowed_v13_standing() -> None:
 
 
 @pytest.mark.unit
-def test_account_map_stamp_is_the_exact_head_read_by_the_gate(
-    monkeypatch: pytest.MonkeyPatch,
+def test_account_map_stamp_uses_the_injected_table_worktree(
+    tmp_path: Path,
 ) -> None:
-    """A stamp cannot name a different commit than the account-map gate used."""
+    """The stamped commit comes from the table directory the cycle supplied."""
 
-    gate_head = "a" * 40
-    monkeypatch.setattr(
-        contract_module, "_resolve_account_map_head", lambda: (gate_head, None)
-    )
+    repository_path, table_dir = _make_operator_table_repo(tmp_path)
+    expected_head = _git(repository_path, "rev-parse", "HEAD")
 
-    stamp = contract_module.account_map_stamp()
+    stamp = contract_module.account_map_stamp(account_map_path=table_dir)
+
     assert stamp["canonical_surface"] == "operator_contract.yaml"
     assert stamp["reference_surface"] == "mock/CLAUDE.md"
     assert stamp["repo"] == "auto_trader-operator"
-    assert stamp["commit"] == gate_head
+    assert stamp["source_path"] == str(table_dir)
+    assert stamp["repository_path"] == str(repository_path)
+    assert stamp["commit"] == expected_head
+    assert stamp["branch"] == "main"
+    assert stamp["reachable_from_origin_main"] is True
     assert stamp["commit_status"] == "available"
     assert stamp["commit_reason"] is None
 
 
 @pytest.mark.unit
-def test_account_map_head_lookup_queries_the_operator_repo_head(
-    monkeypatch: pytest.MonkeyPatch,
+def test_detached_orphan_account_map_head_is_marked_unpublished(
+    tmp_path: Path,
 ) -> None:
-    """The provenance source is exactly ``git rev-parse HEAD`` in that repo."""
+    """A local-only detached commit is visible, not silently presented as main."""
 
-    expected_head = "b" * 40
-    captured: dict[str, Any] = {}
+    repository_path, table_dir = _make_operator_table_repo(tmp_path)
+    _git(repository_path, "checkout", "-q", "--detach", "HEAD")
+    (repository_path / "orphan.txt").write_text("not on origin/main\n")
+    _git(repository_path, "add", "orphan.txt")
+    _git(repository_path, "commit", "-q", "-m", "detached orphan")
+    orphan_head = _git(repository_path, "rev-parse", "HEAD")
 
-    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        captured["command"] = command
-        captured.update(kwargs)
-        return subprocess.CompletedProcess(command, 0, stdout=f"{expected_head}\n")
+    stamp = contract_module.account_map_stamp(account_map_path=table_dir)
 
-    monkeypatch.setattr(contract_module.subprocess, "run", fake_run)
-
-    commit, reason = contract_module._resolve_account_map_head()
-
-    assert commit == expected_head
-    assert reason is None
-    assert captured["command"] == ["git", "rev-parse", "HEAD"]
-    assert captured["cwd"] == contract_module.ACCOUNT_MAP_REPO_PATH
+    assert stamp["commit"] == orphan_head
+    assert stamp["branch"] == "detached"
+    assert stamp["reachable_from_origin_main"] is False
+    assert stamp["commit_status"] == "unpublished"
+    assert stamp["commit_reason"] == ("account_map_head_not_reachable_from_origin_main")
 
 
 @pytest.mark.unit
-def test_failed_account_map_lookup_is_honestly_stamped_unavailable(
-    monkeypatch: pytest.MonkeyPatch,
+def test_non_git_account_map_source_is_honestly_stamped_unavailable(
+    tmp_path: Path,
 ) -> None:
-    """A failed lookup cannot silently revive a historic hard-coded commit."""
+    """An invalid table path cannot silently revive a historic hard-coded SHA."""
 
-    def fail_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        raise OSError("operator checkout unavailable")
-
-    monkeypatch.setattr(contract_module.subprocess, "run", fail_run)
-
-    stamp = contract_module.account_map_stamp()
+    source_path = tmp_path / "not-an-operator-worktree"
+    source_path.mkdir()
+    stamp = contract_module.account_map_stamp(account_map_path=source_path)
 
     assert stamp["commit"] == "UNAVAILABLE"
     assert stamp["commit_status"] == "unavailable"
-    assert stamp["commit_reason"] == "account_map_head_unavailable"
+    assert stamp["commit_reason"] == "account_map_source_not_git_repository"
+    assert stamp["source_path"] == str(source_path)
+    assert stamp["reachable_from_origin_main"] is None
     assert "3f402919fca5b68bda187e8e521fc886aefb022a" not in repr(stamp)
 
 
 @pytest.mark.unit
-def test_unavailable_account_map_reason_is_visible_in_the_artifact_header() -> None:
+def test_unavailable_account_map_reason_is_visible_in_the_artifact_header(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "not-an-operator-worktree"
+    source_path.mkdir()
+    stamp = contract_module.account_map_stamp(account_map_path=source_path)
     report = render_cycle_report(
         {
             "lane": "binance_spot_demo_sidecar_buy_side_only",
             "at": "2026-08-13T00:00:00+00:00",
             "contract": contract_module.contract_stamp(),
-            "account_map": {
-                "repo": "auto_trader-operator",
-                "commit": "UNAVAILABLE",
-                "canonical_surface": "operator_contract.yaml",
-                "commit_reason": "account_map_head_unavailable",
-            },
+            "account_map": stamp,
         },
         labels=(),
     )
 
     assert "auto_trader-operator@UNAVAILABLE" in report
-    assert "reason=`account_map_head_unavailable`" in report
+    assert "reason=`account_map_source_not_git_repository`" in report
+    assert f"source=`{source_path}`" in report
+    assert "branch=`UNAVAILABLE`" in report
+    assert "origin/main-reachable=`unknown`" in report

--- a/tests/scripts/b0x/test_contract_stamp.py
+++ b/tests/scripts/b0x/test_contract_stamp.py
@@ -1,24 +1,39 @@
 """Contract/account-map stamp — the identity every artifact carries.
 
-Contract v1.4 ②③ (job brief): the binding identity is the **version string
-plus quoted clause**, and the whole-file digest is demoted to a reference
-field. These tests pin that shape, because the failure it prevents is silent:
-an artifact that looks stamped while naming a contract the code no longer
+Contract v1.7 (job brief): the binding identity is the **version string plus
+quoted clause**, and the whole-file digest is demoted to a reference field.
+These tests pin that shape, because the failure it prevents is silent: an
+artifact that looks stamped while naming a contract the code no longer
 implements.
 """
 
 from __future__ import annotations
 
+import subprocess
+from typing import Any
+
 import pytest
 
 from scripts.b0x import contract as contract_module
+from scripts.b0x.cycle import render_cycle_report
+
+V17_SCHEDULER_CLAUSE = (
+    "「스케줄러 등록 없음」 개정 — **스케줄러 (Prefect)는 시각만 소유한다**: "
+    "표 빌드 실행(KR 07:45·US 22:00)과 orch 기상 nudge(사이클 슬롯)에 한정. "
+    "전략 판단·주문 파생·dispatch·워커 실행은 불변(orch/워커 소유, "
+    "harvest-before-dispatch 유지). 근거 = 수동 원샷 장전 누락 4회 실측. "
+    "실행 표면·envelope·승격 절차 무변경."
+)
+V17_CONTRACT_FILE_SHA256 = (
+    "0d09e1ce4d175da75de17958880491965ea6cae8d13764853f23fbc0348f596a"
+)
 
 
 @pytest.mark.unit
 def test_version_is_the_binding_identity() -> None:
-    assert contract_module.CONTRACT_VERSION == "v1.4"
+    assert contract_module.CONTRACT_VERSION == "v1.7"
     stamp = contract_module.contract_stamp()
-    assert stamp["version"] == "v1.4"
+    assert stamp["version"] == "v1.7"
 
 
 @pytest.mark.unit
@@ -38,12 +53,16 @@ def test_clauses_are_quoted_verbatim_not_merely_referenced() -> None:
     """A clause number with no text cannot be checked against the document."""
 
     clauses = contract_module.contract_stamp()["clauses"]
-    assert set(clauses) == {"§8 v1.4 ②", "§8 v1.4 ③"}
-    for key, text in clauses.items():
-        assert len(text) > 40, f"{key} is a reference, not a quotation"
-    assert "SHARED_ACCOUNT_HISTORY" in clauses["§8 v1.4 ②"]
-    assert "disarm" in clauses["§8 v1.4 ③"]
-    assert "fail-closed" in clauses["§8 v1.4 ③"]
+    assert clauses == {"§8 v1.7": V17_SCHEDULER_CLAUSE}
+
+
+@pytest.mark.unit
+def test_contract_file_digest_is_the_current_reference_value() -> None:
+    stamp = contract_module.contract_stamp()
+    assert contract_module.CONTRACT_FILE_SHA256_REFERENCE_ONLY == (
+        V17_CONTRACT_FILE_SHA256
+    )
+    assert stamp["file_sha256_reference_only"] == V17_CONTRACT_FILE_SHA256
 
 
 @pytest.mark.unit
@@ -52,26 +71,84 @@ def test_sidecar_scope_is_the_narrowed_v13_standing() -> None:
 
 
 @pytest.mark.unit
-def test_account_map_names_yaml_as_canonical_and_md_as_reference() -> None:
-    """v1.3 ①: the machine-readable surface wins; prose is a reference."""
+def test_account_map_stamp_is_the_exact_head_read_by_the_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stamp cannot name a different commit than the account-map gate used."""
+
+    gate_head = "a" * 40
+    monkeypatch.setattr(
+        contract_module, "_resolve_account_map_head", lambda: (gate_head, None)
+    )
 
     stamp = contract_module.account_map_stamp()
     assert stamp["canonical_surface"] == "operator_contract.yaml"
     assert stamp["reference_surface"] == "mock/CLAUDE.md"
     assert stamp["repo"] == "auto_trader-operator"
-    # The commit that actually carries the B0-X entries (PR #33).
-    assert stamp["commit"].startswith("3f40291")
+    assert stamp["commit"] == gate_head
+    assert stamp["commit_status"] == "available"
+    assert stamp["commit_reason"] is None
 
 
 @pytest.mark.unit
-def test_stale_pre_registration_account_map_sha_is_gone() -> None:
-    """The old stamp pointed at a commit where B0-X was prose-only.
+def test_account_map_head_lookup_queries_the_operator_repo_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The provenance source is exactly ``git rev-parse HEAD`` in that repo."""
 
-    That commit is exactly the state contract v1.3 ① calls an editing
-    mistake, so no artifact may still claim it.
-    """
+    expected_head = "b" * 40
+    captured: dict[str, Any] = {}
 
-    rendered = repr(contract_module.account_map_stamp()) + repr(
-        contract_module.contract_stamp()
+    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, stdout=f"{expected_head}\n")
+
+    monkeypatch.setattr(contract_module.subprocess, "run", fake_run)
+
+    commit, reason = contract_module._resolve_account_map_head()
+
+    assert commit == expected_head
+    assert reason is None
+    assert captured["command"] == ["git", "rev-parse", "HEAD"]
+    assert captured["cwd"] == contract_module.ACCOUNT_MAP_REPO_PATH
+
+
+@pytest.mark.unit
+def test_failed_account_map_lookup_is_honestly_stamped_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed lookup cannot silently revive a historic hard-coded commit."""
+
+    def fail_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise OSError("operator checkout unavailable")
+
+    monkeypatch.setattr(contract_module.subprocess, "run", fail_run)
+
+    stamp = contract_module.account_map_stamp()
+
+    assert stamp["commit"] == "UNAVAILABLE"
+    assert stamp["commit_status"] == "unavailable"
+    assert stamp["commit_reason"] == "account_map_head_unavailable"
+    assert "3f402919fca5b68bda187e8e521fc886aefb022a" not in repr(stamp)
+
+
+@pytest.mark.unit
+def test_unavailable_account_map_reason_is_visible_in_the_artifact_header() -> None:
+    report = render_cycle_report(
+        {
+            "lane": "binance_spot_demo_sidecar_buy_side_only",
+            "at": "2026-08-13T00:00:00+00:00",
+            "contract": contract_module.contract_stamp(),
+            "account_map": {
+                "repo": "auto_trader-operator",
+                "commit": "UNAVAILABLE",
+                "canonical_surface": "operator_contract.yaml",
+                "commit_reason": "account_map_head_unavailable",
+            },
+        },
+        labels=(),
     )
-    assert "7f95897" not in rendered
+
+    assert "auto_trader-operator@UNAVAILABLE" in report
+    assert "reason=`account_map_head_unavailable`" in report

--- a/tests/scripts/b0x/test_cycle.py
+++ b/tests/scripts/b0x/test_cycle.py
@@ -122,6 +122,23 @@ async def test_first_shadow_cycle_derives_and_records(
 
 
 @pytest.mark.asyncio
+async def test_shadow_cycle_stamps_the_exact_table_directory_it_consumed(
+    table_dir: Path, out_dir: Path
+) -> None:
+    """The cycle forwards its actual table source into account-map provenance."""
+
+    outcome = await run_shadow_cycle(now=NOW, table_dir=table_dir, out_dir=out_dir)
+
+    account_map = outcome.record["account_map"]
+    assert account_map["source_path"] == str(table_dir)
+    # This test table is intentionally not a Git worktree, so the cycle must
+    # record an honest unknown instead of consulting any unrelated checkout.
+    assert account_map["commit"] == "UNAVAILABLE"
+    assert account_map["commit_status"] == "unavailable"
+    assert account_map["commit_reason"] == "account_map_source_not_git_repository"
+
+
+@pytest.mark.asyncio
 async def test_shadow_cycle_is_idempotent_in_its_derivation(
     table_dir: Path, out_dir: Path
 ) -> None:

--- a/tests/scripts/b0x/test_labels.py
+++ b/tests/scripts/b0x/test_labels.py
@@ -1,4 +1,4 @@
-"""B0-X v1.4 account-history label scope and wording guards."""
+"""B0-X account-history label scope and contract-stamp wording guards."""
 
 from __future__ import annotations
 
@@ -116,10 +116,10 @@ def test_shared_history_wording_is_complete_and_non_exaggerated() -> None:
     assert "이제 단독" not in SHARED_ACCOUNT_HISTORY
 
 
-def test_contract_stamp_points_to_v1_4_reference() -> None:
-    assert contract_module.CONTRACT_VERSION == "v1.4"
-    assert set(contract_module.CONTRACT_CLAUSES) == {"§8 v1.4 ②", "§8 v1.4 ③"}
+def test_contract_stamp_points_to_v1_7_reference() -> None:
+    assert contract_module.CONTRACT_VERSION == "v1.7"
+    assert set(contract_module.CONTRACT_CLAUSES) == {"§8 v1.7"}
     assert (
         contract_module.CONTRACT_FILE_SHA256_REFERENCE_ONLY
-        == "bce7104bd1a3f36a253baecc05d8bc960ad1c41a82de4c345d6659320ad1f5f8"
+        == "0d09e1ce4d175da75de17958880491965ea6cae8d13764853f23fbc0348f596a"
     )

--- a/tests/scripts/test_build_policy_table_out_dir.py
+++ b/tests/scripts/test_build_policy_table_out_dir.py
@@ -10,21 +10,42 @@ from scripts import build_policy_table
 
 
 @pytest.mark.unit
-def test_shared_operator_checkout_is_never_a_silent_cli_default(
+def test_prefect_caller_form_keeps_its_default_output_and_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """An omitted destination must abort before the builder can write anything."""
+    """The deployed caller's exact module argv remains compatible.
 
-    with pytest.raises(SystemExit) as excinfo:
-        build_policy_table._parse_args(["--market", "kr"])
+    The fake async body deliberately performs no table generation; this test
+    proves parsing, warning, and the return status for the exact argv used by
+    robin_automation.b0x_kickoff.build_policy_table.
+    """
 
-    assert excinfo.value.code == 2
-    assert "--out-dir" in capsys.readouterr().err
+    captured: dict[str, str] = {}
+
+    async def fake_run(args) -> int:  # noqa: ANN001
+        captured["market"] = args.market
+        captured["out_dir"] = args.out_dir
+        return 0
+
+    monkeypatch.setattr(build_policy_table, "_run", fake_run)
+
+    assert build_policy_table.main(["--market", "kr"]) == 0
+    assert captured == {
+        "market": "kr",
+        "out_dir": str(build_policy_table.DEFAULT_OUT_DIR),
+    }
+    stderr = capsys.readouterr().err
+    assert "WARNING:" in stderr
+    assert "shared operator checkout" in stderr
+    assert str(build_policy_table.DEFAULT_OUT_DIR) in stderr
 
 
 @pytest.mark.unit
-def test_prefect_can_still_name_its_canonical_table_directory_explicitly() -> None:
-    """§47's direct ``policy-tables/`` write path remains a valid invocation."""
+def test_explicit_prefect_destination_is_warned_not_rejected(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """§47's direct ``policy-tables/`` path remains valid and visible."""
 
     args = build_policy_table._parse_args(
         [
@@ -38,3 +59,17 @@ def test_prefect_can_still_name_its_canonical_table_directory_explicitly() -> No
     assert (
         Path(args.out_dir).expanduser() == build_policy_table.OPERATOR_POLICY_TABLE_DIR
     )
+    assert "WARNING:" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_explicit_isolated_destination_does_not_emit_shared_checkout_warning(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = build_policy_table._parse_args(
+        ["--market", "kr", "--out-dir", str(tmp_path / "isolated-tables")]
+    )
+
+    assert Path(args.out_dir) == tmp_path / "isolated-tables"
+    assert capsys.readouterr().err == ""

--- a/tests/scripts/test_build_policy_table_out_dir.py
+++ b/tests/scripts/test_build_policy_table_out_dir.py
@@ -1,0 +1,40 @@
+"""Output-path guard for the policy-table builder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import build_policy_table
+
+
+@pytest.mark.unit
+def test_shared_operator_checkout_is_never_a_silent_cli_default(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An omitted destination must abort before the builder can write anything."""
+
+    with pytest.raises(SystemExit) as excinfo:
+        build_policy_table._parse_args(["--market", "kr"])
+
+    assert excinfo.value.code == 2
+    assert "--out-dir" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+def test_prefect_can_still_name_its_canonical_table_directory_explicitly() -> None:
+    """§47's direct ``policy-tables/`` write path remains a valid invocation."""
+
+    args = build_policy_table._parse_args(
+        [
+            "--market",
+            "kr",
+            "--out-dir",
+            str(build_policy_table.OPERATOR_POLICY_TABLE_DIR),
+        ]
+    )
+
+    assert (
+        Path(args.out_dir).expanduser() == build_policy_table.OPERATOR_POLICY_TABLE_DIR
+    )


### PR DESCRIPTION
## Summary
- Stamp B0-X observations with the v1.7 contract, verbatim §8 citation, and current reference digest.
- Derive the account-map stamp from the operator repository HEAD; record UNAVAILABLE plus a reason if it cannot be read.
- Require an explicit policy-table output directory while preserving the explicit Prefect policy-tables destination.

## Validation
- 22 focused stamp/output-dir tests passed.
- B0-X suite: 700 passed, 3 skipped, 2 date-sensitive Kiwoom failures outside this change; excluding those two, 700 passed, 3 skipped, 2 deselected.
- All four requested mutants and a core-assert inversion failed, then were reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the default policy-table output path is shared and may produce a checkout warning.
  - Added guidance to use a separate `--out-dir` for manual or isolated builds.

- **New Features**
  - Updated contract metadata to version 1.7.
  - Added account-map provenance details, including source path, commit status, branch, and repository reachability.
  - Added warnings when using the shared default output directory.

- **Bug Fixes**
  - Improved handling and reporting of unavailable or unpublished account-map sources.
  - Ensured cycle reports consistently reference the exact policy-table directory used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->