### PR TITLE
B0X KR: explicit kiwoom interim DAY ordering

### DIFF
--- a/docs/runbooks/b0x-kr-kiwoom-cycle.md
+++ b/docs/runbooks/b0x-kr-kiwoom-cycle.md
@@ -3,8 +3,10 @@
 `scripts/run_b0x_kr_kiwoom_cycle.py` — 수동 kickoff 전용. **스케줄러 등록 없음**
 (TaskIQ·Prefect·launchd 어디에도 없다). 사이클은 운영자가 실행해서 일어난다.
 
-지위: **`OBSERVATION_DERIVATION_ONLY`**. `--confirm` 은 지위 변경이 아니라,
-실행 표면이 끝까지 동작하는지 증명하는 **1건 한정 acceptance 레버**다.
+기본 지위는 **`OBSERVATION_DERIVATION_ONLY`**(preview)다. `--confirm` 단독은
+**`ACCEPTANCE_ONLY`** — 기존의 1건 submit→cancel→reconcile 검증 레버다.
+`--interim-ordering --confirm` 을 함께 명시한 경우만 **`INTERIM_ORDERING`** 으로
+전환해 envelope 파생 전건을 DAY 주문으로 남긴다. 위험한 쪽은 기본값이 아니다.
 
 ---
 
@@ -47,8 +49,10 @@
 | KRX only | 주문 클라이언트가 `NXT`/`SOR` 를 네트워크 호출 **전에** 거부. 레인은 `exchange` 파라미터를 아예 노출하지 않는다 |
 | 세션 | KRX 정규장만 (`is_krx_regular_session`, XKRX 캘린더) |
 | envelope | §4 KR 열 **그대로 재사용** (`load_envelope("kr")`). 레인 전용 envelope 상수 없음 — 테스트가 강제 |
-| 1건 한정 | `MANUAL_CONFIRM_SUBMISSION_LIMIT = 1`, CLI/env override 없음 |
-| 왕복 강제 | `--no-cancel` 같은 플래그가 **존재하지 않는다**. 취소 미확인 = `RoundTripIncomplete` + exit 2 |
+| Acceptance 1건 한정 | `ACCEPTANCE_SUBMISSION_LIMIT = 1`, CLI/env override 없음. `--confirm` 단독에만 적용 |
+| Interim 전건 제출 | `--interim-ordering --confirm` 에서만 envelope 파생 전건 제출. 별도 제출 상한/CLI/env override 없음 — §4 30만·동시 10·일신규 3이 파생 단계에서 계속 강제 |
+| Acceptance 왕복 강제 | `--no-cancel` 같은 플래그가 **존재하지 않는다**. `ACCEPTANCE_ONLY` 취소 미확인 = `RoundTripIncomplete` + exit 2 |
+| DAY 주문 잔존 | `INTERIM_ORDERING` 은 즉시 취소하지 않는다. `submitted` 는 접수/주문번호 증거만 뜻하고 filled를 뜻하지 않는다 |
 | halted | 표가 이미 제외(ROB-1236). 레인이 `universe.halted_suspect` 를 두 번째 선으로 재검사 |
 
 ## 4. 🔴 자기 미체결 = 브로커 직접 조회, 원장 예외 **미사용**
@@ -102,9 +106,11 @@ v1.5 ① 이 실격시키는 성질이고, ROB-341 이 KIS 일별체결조회를
 ### 5.1 저널 = 「이 ord_no 는 우리 것이다」
 
 `<out-dir>/kiwoom_mock/own-orders.jsonl`, append-only.
-🔴 **취소도 자기 주문번호를 갖는다** (실측: 매수 `0107387` → 취소 `0107388`).
-취소 ord_no 를 기록하지 않으면 다음 사이클의 당일 외부흔적 게이트가 **자기 취소를
-제2 writer 로 오인**해 정지한다 — 2026-08-12 12:13 KST 에 실제로 발생했다.
+🔴 제출 직후의 자기 주문번호는 즉시 저널한다. `INTERIM_ORDERING` 의 DAY 주문도
+다음 사이클의 당일 외부흔적 게이트가 자기 주문으로 식별할 수 있어야 한다.
+`ACCEPTANCE_ONLY` 에서는 **취소도** 자기 주문번호를 갖는다(실측: 매수 `0107387` →
+취소 `0107388`). 취소 ord_no 를 기록하지 않으면 다음 사이클의 당일 외부흔적 게이트가
+자기 취소를 제2 writer 로 오인해 정지한다 — 2026-08-12 12:13 KST 에 실제로 발생했다.
 그래서 취소도 `side="cancel"` 로 저널한다(귀속 수량에는 영향 없음).
 
 ## 6. Rate limit — 페이싱은 안전 속성이다
@@ -135,14 +141,20 @@ B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle --re
 uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
     --table-dir ~/services/auto_trader-operator/policy-tables
 
-# ③ acceptance 왕복 1건 (KRX 정규장 안에서만)
+# ③ acceptance 왕복 1건 (KRX 정규장 안에서만, 기본 안전 mutation 모드)
 B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
     --table-dir ~/services/auto_trader-operator/policy-tables --confirm
+
+# ④ INTERIM_ORDERING — 이중 명시가 있어야만 DAY 주문을 남긴다.
+#    §4 envelope 파생 전건만 제출하며, 자동 취소하지 않는다.
+B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
+    --table-dir ~/services/auto_trader-operator/policy-tables \
+    --interim-ordering --confirm
 ```
 
-exit code: `0` 정상 · `2` writer lock 경합 **또는 왕복 미완(취소 미확인)**.
-🔴 `2` 를 보면 계좌에 미회수 주문이 남았을 수 있다 — `--readiness` 로 즉시
-`pending` 을 확인하고, 남아 있으면 운영자가 직접 취소한다.
+exit code: `0` 정상 · `2` writer lock 경합, acceptance 왕복 미완(취소 미확인),
+또는 interim 제출 증거 미확인. 🔴 `2` 를 보면 계좌에 미회수 주문이 남았을 수 있다 —
+`--readiness` 로 즉시 `pending` 을 확인하고, 남아 있으면 운영자가 직접 취소한다.
 
 ## 8. 아티팩트
 
@@ -161,9 +173,11 @@ exit code: `0` 정상 · `2` writer lock 경합 **또는 왕복 미완(취소 �
 2. **legacy 귀속 게이트는 2026-08-12 실환경에서 *증명되지 않았다*.** 그날
    kiwoom_mock 계좌의 보유가 **0종목**이라 legacy 분기에 도달할 입력이 없었다.
    단위 테스트로만 증명된 상태다(보유가 생기는 첫 사이클이 첫 실환경 검증 기회).
-3. **dedup(동일 심볼 재제출 차단)도 실환경 미증명.** 이 레인은 같은 사이클 안에서
-   항상 취소하므로 재제출 시점에 자기 미체결이 남아 있지 않다. 단위 테스트 +
-   preflight 의 `account_has_resting_orders` 사유가 코드 경로를 덮는다.
+3. **dedup(동일 심볼 재제출 차단)도 실환경 미증명.** `ACCEPTANCE_ONLY` 는 같은
+   사이클 안에서 취소하므로 재제출 시점에 자기 미체결이 남아 있지 않다.
+   `INTERIM_ORDERING` 은 DAY 주문을 남기므로 kt00007 재조회가 같은 심볼 재제출을
+   막아야 한다. 단위 테스트 + preflight 의 `account_has_resting_orders` 사유가 코드
+   경로를 덮는다.
 4. **kill switch 는 발화 입력이 없다.** `realized_pnl_today` 소스가 이 레인에도
    없으므로 −2.5% NAV kill 은 발화할 수 없다. 구조적 부재이지 측정된 0 이 아니다.
 5. **저널 유실 방향은 안전하다** (과소 귀속 → 매도 못 함). 다만 저널이 사라지면

--- a/docs/runbooks/b0x-kr-kiwoom-cycle.md
+++ b/docs/runbooks/b0x-kr-kiwoom-cycle.md
@@ -6,7 +6,8 @@
 기본 지위는 **`OBSERVATION_DERIVATION_ONLY`**(preview)다. `--confirm` 단독은
 **`ACCEPTANCE_ONLY`** — 기존의 1건 submit→cancel→reconcile 검증 레버다.
 `--interim-ordering --confirm` 을 함께 명시한 경우만 **`INTERIM_ORDERING`** 으로
-전환해 envelope 파생 전건을 DAY 주문으로 남긴다. 위험한 쪽은 기본값이 아니다.
+전환해 envelope 파생 **매수** 전건을 DAY 주문으로 남긴다. 매도는 기본 ON인
+매수 전용 게이트가 제출 경계에서 차단한다. 위험한 쪽은 기본값이 아니다.
 
 ---
 
@@ -50,7 +51,8 @@
 | 세션 | KRX 정규장만 (`is_krx_regular_session`, XKRX 캘린더) |
 | envelope | §4 KR 열 **그대로 재사용** (`load_envelope("kr")`). 레인 전용 envelope 상수 없음 — 테스트가 강제 |
 | Acceptance 1건 한정 | `ACCEPTANCE_SUBMISSION_LIMIT = 1`, CLI/env override 없음. `--confirm` 단독에만 적용 |
-| Interim 전건 제출 | `--interim-ordering --confirm` 에서만 envelope 파생 전건 제출. 별도 제출 상한/CLI/env override 없음 — §4 30만·동시 10·일신규 3이 파생 단계에서 계속 강제 |
+| Interim 매수 전건 제출 | `--interim-ordering --confirm` 에서만 envelope 파생 매수 leg 전건 제출. 별도 제출 상한/CLI/env override 없음 — §4 30만·동시 10·일신규 3이 파생 단계에서 계속 강제 |
+| Interim 매수 전용 | 매도 leg는 파생되더라도 제출 경계의 `interim_buy_only_sell_gate`가 차단하고 artifact에 사유를 남긴다. 기본 ON이며 CLI/env 해제 경로 없음; 명시 운영자 승인 또는 B-track merge 전까지 유지 |
 | Acceptance 왕복 강제 | `--no-cancel` 같은 플래그가 **존재하지 않는다**. `ACCEPTANCE_ONLY` 취소 미확인 = `RoundTripIncomplete` + exit 2 |
 | DAY 주문 잔존 | `INTERIM_ORDERING` 은 즉시 취소하지 않는다. `submitted` 는 접수/주문번호 증거만 뜻하고 filled를 뜻하지 않는다 |
 | halted | 표가 이미 제외(ROB-1236). 레인이 `universe.halted_suspect` 를 두 번째 선으로 재검사 |
@@ -146,7 +148,8 @@ B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
     --table-dir ~/services/auto_trader-operator/policy-tables --confirm
 
 # ④ INTERIM_ORDERING — 이중 명시가 있어야만 DAY 주문을 남긴다.
-#    §4 envelope 파생 전건만 제출하며, 자동 취소하지 않는다.
+#    §4 envelope 파생 매수 leg 전건만 제출하며, 자동 취소하지 않는다.
+#    매도 leg는 기본 ON 매수 전용 게이트가 명시 사유와 함께 차단한다.
 B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
     --table-dir ~/services/auto_trader-operator/policy-tables \
     --interim-ordering --confirm

--- a/scripts/b0x/kr/kiwoom.py
+++ b/scripts/b0x/kr/kiwoom.py
@@ -70,15 +70,20 @@ absolute loss tolerated before the kill fires. Excluding it can only narrow the
 threshold, never widen it, and an unreadable attribution narrows it further
 (attributed evaluation 0 → ``nav = cash``).
 
-Round trip is mandatory, not optional
----------------------------------------
+Two explicitly separate mutation modes
+--------------------------------------
 
-The confirm path submits **one** order and then always tries to take it back:
+``ACCEPTANCE_ONLY`` submits **one** order and always tries to take it back:
 submit → broker pending re-read → cancel → reconcile. There is no flag that
-skips the cancel. This lane's status is ``OBSERVATION_DERIVATION_ONLY``; it
-exists to prove the execution surface works end to end, not to hold inventory.
-A cancel that fails is recorded as a failure and exits non-zero — never
-laundered into a clean success (see :class:`RoundTripIncomplete`).
+skips the cancel. It exists to prove the execution surface works end to end,
+not to hold inventory. A cancel that fails is recorded as a failure and exits
+non-zero — never laundered into a clean success (see
+:class:`RoundTripIncomplete`).
+
+``INTERIM_ORDERING`` uses :func:`submit_day_order` instead. That function
+records only broker acceptance and the assigned order number; it deliberately
+does not claim a fill and never invokes cancellation. The caller is responsible
+for the stricter preflight and for choosing that non-default mode.
 """
 
 from __future__ import annotations
@@ -596,7 +601,7 @@ class ReadOnlyKiwoomMockAccount:
         )
         return normalize_order_detail(payload)
 
-    # -- the one mutation surface -----------------------------------------
+    # -- mutation surfaces -------------------------------------------------
 
     async def place_limit_buy(
         self, *, symbol: str, quantity: int, price: int
@@ -614,6 +619,24 @@ class ReadOnlyKiwoomMockAccount:
                 symbol=symbol, quantity=quantity, price=price
             ),
             api="kt10000",
+        )
+
+    async def place_limit_sell(
+        self, *, symbol: str, quantity: int, price: int
+    ) -> dict[str, Any]:
+        """kt10001. ``exchange`` remains fixed to the KRX default.
+
+        This is reachable only after the cycle's attributed-holding boundary;
+        exposing no exchange parameter keeps the NXT/SOR prohibition structural
+        for both sides of an INTERIM_ORDERING day order.
+        """
+
+        await self._pace()
+        return assert_broker_ok(
+            await self._orders.place_sell_order(
+                symbol=symbol, quantity=quantity, price=price
+            ),
+            api="kt10001",
         )
 
     async def cancel(
@@ -948,11 +971,47 @@ def plan_orders(
 
 
 # ---------------------------------------------------------------------------
-# Submission + mandatory cancel round trip.
+# Submission: DAY retention or mandatory acceptance cancel round trip.
 # ---------------------------------------------------------------------------
 
 #: Kiwoom's order response field carrying the assigned order number.
 ORDER_NO_FIELD: Final[str] = "ord_no"
+
+
+@dataclass
+class DayOrderResult:
+    """Broker-accepted KRX DAY order retained for ``INTERIM_ORDERING``.
+
+    This records only what the submit response establishes: the request was
+    accepted and assigned an order number. It is intentionally not a fill
+    record, and its ``automatic_cancel`` field is a literal guard against
+    accidentally reusing acceptance-round-trip semantics here.
+    """
+
+    correlation_id: str
+    symbol: str
+    side: str
+    price: int
+    quantity: int
+    submitted: bool = False
+    order_no: str | None = None
+    submit_response: dict[str, Any] = field(default_factory=dict)
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "correlation_id": self.correlation_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "price": self.price,
+            "quantity": self.quantity,
+            "notional_krw": self.price * self.quantity,
+            "submitted": self.submitted,
+            "order_no": self.order_no,
+            "submit_response": self.submit_response,
+            "time_in_force": "DAY",
+            "automatic_cancel": False,
+            "fill_status": "unverified",
+        }
 
 
 @dataclass
@@ -1037,6 +1096,52 @@ def assert_resting_echo(
             "kt00009 resting row does not echo the submitted order: "
             + "; ".join(problems)
         )
+
+
+async def submit_day_order(
+    account: ReadOnlyKiwoomMockAccount,
+    *,
+    planned: PlannedOrder,
+    broker_truth: BrokerTruth,
+    record_order_no: Any,
+    now: dt.datetime,
+) -> DayOrderResult:
+    """Submit one KRX limit order and deliberately leave its DAY lifecycle open.
+
+    The pre-dispatch resubmit gate and immediate journal append are identical
+    to the acceptance path. What differs is deliberate: no post-submit
+    cancellation, no inferred fill, and no claim that a still-open order is a
+    successful reconciliation.
+    """
+
+    assert_resubmit_allowed(broker_truth, symbol=planned.symbol, lane=LANE)
+    result = DayOrderResult(
+        correlation_id=planned.client_order_id,
+        symbol=planned.symbol,
+        side=planned.side,
+        price=planned.price,
+        quantity=planned.quantity,
+    )
+
+    if planned.side == "buy":
+        submit_payload = await account.place_limit_buy(
+            symbol=planned.symbol, quantity=planned.quantity, price=planned.price
+        )
+    elif planned.side == "sell":
+        submit_payload = await account.place_limit_sell(
+            symbol=planned.symbol, quantity=planned.quantity, price=planned.price
+        )
+    else:
+        raise ValueError(f"kiwoom day order has unsupported side: {planned.side}")
+
+    result.submitted = True
+    result.submit_response = dict(submit_payload)
+    order_no = _extract_order_no(submit_payload)
+    result.order_no = order_no
+    # A later same-day foreign-trace check must know that this broker order is
+    # ours even while it remains resting; write before returning to the caller.
+    record_order_no(order_no=order_no, planned=planned, at=now)
+    return result
 
 
 async def submit_and_cancel(
@@ -1195,6 +1300,7 @@ __all__ = [
     "BlockedOrder",
     "BrokerEchoMismatch",
     "BrokerPending",
+    "DayOrderResult",
     "FreshTruth",
     "KiwoomBrokerRejected",
     "KiwoomCashUnreadable",
@@ -1219,5 +1325,6 @@ __all__ = [
     "plan_orders",
     "read_broker_pending",
     "read_fresh_truth",
+    "submit_day_order",
     "submit_and_cancel",
 ]

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -116,6 +116,17 @@ PREVIEW_STATUS: Final[str] = "OBSERVATION_DERIVATION_ONLY"
 ACCEPTANCE_ONLY_STATUS: Final[str] = "ACCEPTANCE_ONLY"
 INTERIM_ORDERING_STATUS: Final[str] = "INTERIM_ORDERING"
 
+#: §50차 2항: first INTERIM sessions are deliberately buy-only. This is a
+#: code-level default, not a CLI/environment dial; lifting it needs explicit
+#: operator approval or the B-track's proper sell path.
+INTERIM_BUY_ONLY_SELL_GATE_ENABLED: Final[bool] = True
+INTERIM_BUY_ONLY_SELL_GATE_REASON: Final[str] = "interim_buy_only_sell_gate"
+INTERIM_BUY_ONLY_SELL_GATE_DETAIL: Final[str] = (
+    "INTERIM_ORDERING first sessions are buy-only; sell submission is blocked "
+    "until explicit operator approval or B-track merge"
+)
+INTERIM_BUY_ONLY_CONSTRAINT: Final[str] = "매수 전용(매도 게이트 ON)"
+
 PREVIEW_STATUS_LABEL: Final[str] = (
     "OBSERVATION_DERIVATION_ONLY — kiwoom_mock cycle 지위는 유지된다. 이 수동 mock "
     "acceptance lever는 모의 자동매매 가동 선언이나 스케줄러가 아니다."
@@ -137,7 +148,7 @@ INTERIM_ORDERING_STATUS_LABEL: Final[str] = (
     "INTERIM_ORDERING — kiwoom_mock 한시 DAY 주문 잔존 모드. 제약: 일손실 kill "
     "미배선(realized_pnl_today 소스 없음 → −2.5% NAV kill 발화 불가); 공존 계좌 "
     "TOCTOU 잔존(KR-B1 foreign trace는 착수 preflight 1회); kiwoom 한정; "
-    "KRX RTH only."
+    "KRX RTH only; 매수 전용(매도 게이트 ON)."
 )
 
 INTERIM_ORDERING_CONSTRAINTS: Final[dict[str, str]] = {
@@ -149,6 +160,7 @@ INTERIM_ORDERING_CONSTRAINTS: Final[dict[str, str]] = {
     ),
     "venue": "kiwoom 한정",
     "session": "KRX RTH only",
+    "buy_only": INTERIM_BUY_ONLY_CONSTRAINT,
 }
 
 #: This account is not B0-X's alone, and the artifact must say so every time.
@@ -815,6 +827,22 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
                 )
                 record["submission_stopped"] = "sell_leg_not_wired"
                 break
+            if INTERIM_BUY_ONLY_SELL_GATE_ENABLED:
+                # §50차 2항: preserve the sell wiring and its own-attribution
+                # check above, but keep first INTERIM sessions buy-only at the
+                # final submission boundary. The artifact must name every
+                # suppressed sell; a quiet ``continue`` would be unauditable.
+                record.setdefault("submission_blocked", []).append(
+                    {
+                        "symbol": order.symbol,
+                        "correlation_id": order.client_order_id,
+                        "side": order.side,
+                        "leg": order.leg,
+                        "reason": INTERIM_BUY_ONLY_SELL_GATE_REASON,
+                        "detail": INTERIM_BUY_ONLY_SELL_GATE_DETAIL,
+                    }
+                )
+                continue
 
         if order.symbol in halted:
             record.setdefault("submission_blocked", []).append(
@@ -970,6 +998,13 @@ def _stamp_contract_and_account_map(
     record["cycle_status_label"] = status_label
     if cycle_status == INTERIM_ORDERING_STATUS:
         record["interim_ordering_constraints"] = dict(INTERIM_ORDERING_CONSTRAINTS)
+        record["interim_buy_only_sell_gate"] = {
+            "enabled": INTERIM_BUY_ONLY_SELL_GATE_ENABLED,
+            "reason_code": INTERIM_BUY_ONLY_SELL_GATE_REASON,
+            "scope": "submission_stage_sell_legs",
+            "cli_disable_available": False,
+            "release": "explicit_operator_approval_or_b_track_merge",
+        }
 
 
 async def run_kiwoom_cycle(
@@ -1128,6 +1163,10 @@ __all__ = [
     "PREVIEW_STATUS",
     "ACCEPTANCE_ONLY_STATUS",
     "INTERIM_ORDERING_STATUS",
+    "INTERIM_BUY_ONLY_SELL_GATE_ENABLED",
+    "INTERIM_BUY_ONLY_SELL_GATE_REASON",
+    "INTERIM_BUY_ONLY_SELL_GATE_DETAIL",
+    "INTERIM_BUY_ONLY_CONSTRAINT",
     "OUTSIDE_RTH_REASON",
     "PREFLIGHT_MAX_AGE_SECONDS",
     "ACCEPTANCE_SUBMISSION_LIMIT",

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -4,16 +4,15 @@ Same skeleton as :mod:`scripts.b0x.kr.cycle`, with three deliberate divergences
 that all come from the venue being *stronger*, not weaker:
 
     writer lock → RTH gate → table (or zero orders) → account truth
-                → 귀속 → kill switch → derive → plan → submit → cancel → reconcile
+                → 귀속 → kill switch → derive → plan → mode-specific submit
 
 1. **자기 미체결 = 브로커 직접 조회** (``kt00007``). The kis lane's contract
    v1.6 ① ledger exception is *not* used and must not be — it is scoped to a
    venue with no pending surface. See :mod:`scripts.b0x.kr.kiwoom`.
-2. **취소가 실제로 가능하다.** The kis lane records
-   ``KILL_TRIPPED_CANCEL_UNSUPPORTED`` because ``TTTC8036R`` cannot even
-   discover what is resting. Kiwoom can, so this lane cancels — and the confirm
-   path's round trip is *mandatory*, not conditional (see
-   :data:`ROUND_TRIP_MANDATORY_NOTE`).
+2. **Two mutation modes are deliberately separate.** ``ACCEPTANCE_ONLY``
+   remains one submit → cancel → reconcile round trip. ``INTERIM_ORDERING``
+   submits every envelope-derived DAY order and deliberately leaves it at the
+   broker; it is never the default and it never inherits the acceptance cancel.
 3. **No account-wide durable lease exists for this account.** The kis lane
    holds ``KISMockWriterLease``; there is no kiwoom equivalent in this repo and
    this module does not invent one. What it does instead is check the account's
@@ -50,7 +49,7 @@ import datetime as dt
 from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 from app.services.kis_mock_runner.session import is_krx_regular_session
 from scripts.b0x.broker_truth import (
@@ -93,7 +92,8 @@ KR_CONTRACT_CLAUSES: Final[dict[str, str]] = {
     ),
     "§39차 ①②③④⑤": (
         "별도 모듈 · 브로커 직접 미체결 · legacy 불가침 귀속 게이트 · "
-        "§4 KR 열 수치 불변 + KRX RTH only · 제출→조회→취소→reconcile 완전 왕복."
+        "§4 KR 열 수치 불변 + KRX RTH only · ACCEPTANCE_ONLY 제출→조회→취소→"
+        "reconcile 보존 + INTERIM_ORDERING DAY 주문 잔존."
     ),
 }
 KR_ACCOUNT_MAP_COMMIT: Final[str] = "09c3fc16fcacbc47060e8aa1aa3e8beed0a74028"
@@ -107,10 +107,49 @@ KR_ACCOUNT_MAP_VALUES: Final[dict[str, str]] = {
     ),
     "surface": "kiwoom_mock",
 }
-KR_STATUS_LABEL: Final[str] = (
+type CycleMode = Literal["acceptance", "interim_ordering"]
+
+ACCEPTANCE_MODE: Final[CycleMode] = "acceptance"
+INTERIM_ORDERING_MODE: Final[CycleMode] = "interim_ordering"
+
+PREVIEW_STATUS: Final[str] = "OBSERVATION_DERIVATION_ONLY"
+ACCEPTANCE_ONLY_STATUS: Final[str] = "ACCEPTANCE_ONLY"
+INTERIM_ORDERING_STATUS: Final[str] = "INTERIM_ORDERING"
+
+PREVIEW_STATUS_LABEL: Final[str] = (
     "OBSERVATION_DERIVATION_ONLY — kiwoom_mock cycle 지위는 유지된다. 이 수동 mock "
     "acceptance lever는 모의 자동매매 가동 선언이나 스케줄러가 아니다."
 )
+
+#: Backward-compatible name for the preview-only label. Mutation paths select
+#: their own literal below; no order-capable artifact may inherit this label.
+KR_STATUS_LABEL: Final[str] = PREVIEW_STATUS_LABEL
+
+ACCEPTANCE_ONLY_STATUS_LABEL: Final[str] = (
+    "ACCEPTANCE_ONLY — 기존 1건 submit → cancel → reconcile 검증 경로. "
+    "기본값은 preview 이며, 이 경로는 DAY 주문 잔존을 만들지 않는다."
+)
+
+#: §49차 A's exact, deliberately non-clean status. Keep all accepted residual
+#: constraints in the visible artifact label, rather than implying a completed
+#: production-quality ordering surface.
+INTERIM_ORDERING_STATUS_LABEL: Final[str] = (
+    "INTERIM_ORDERING — kiwoom_mock 한시 DAY 주문 잔존 모드. 제약: 일손실 kill "
+    "미배선(realized_pnl_today 소스 없음 → −2.5% NAV kill 발화 불가); 공존 계좌 "
+    "TOCTOU 잔존(KR-B1 foreign trace는 착수 preflight 1회); kiwoom 한정; "
+    "KRX RTH only."
+)
+
+INTERIM_ORDERING_CONSTRAINTS: Final[dict[str, str]] = {
+    "daily_loss_kill": (
+        "일손실 kill 미배선 — realized_pnl_today 소스가 없어 −2.5% NAV kill은 발화 불가"
+    ),
+    "coexisting_account_toctou": (
+        "공존 계좌 TOCTOU 잔존 — KR-B1 foreign trace는 착수 preflight 1회 관측"
+    ),
+    "venue": "kiwoom 한정",
+    "session": "KRX RTH only",
+}
 
 #: This account is not B0-X's alone, and the artifact must say so every time.
 COEXISTENCE_LABEL: Final[str] = (
@@ -128,14 +167,15 @@ OUTSIDE_RTH_REASON: ZeroOrderReason = "outside_krx_regular_session"
 #: this bounded interval. A contract requirement, not a CLI parameter.
 PREFLIGHT_MAX_AGE_SECONDS = 5 * 60
 
-#: One-shot manual acceptance lever. Restrictive operational bound with no CLI
-#: or environment override.
-MANUAL_CONFIRM_SUBMISSION_LIMIT = 1
+#: The legacy acceptance lever stays intentionally bounded. This constant is
+#: never consulted by ``INTERIM_ORDERING``; that mode submits the full,
+#: already-envelope-limited derivation.
+ACCEPTANCE_SUBMISSION_LIMIT = 1
 
-#: 🔴 There is no flag that skips the cancel. Recorded on every confirm cycle so
-#: a reader cannot mistake a resting order for an intended position.
+#: 🔴 There is no flag that skips the cancel on ACCEPTANCE_ONLY. Its record
+#: makes the retained DAY-order behavior unavailable by accident.
 ROUND_TRIP_MANDATORY_NOTE: Final[str] = (
-    "ROUND_TRIP_MANDATORY — confirm 경로는 제출 후 반드시 취소를 시도하고 "
+    "ROUND_TRIP_MANDATORY — ACCEPTANCE_ONLY 경로는 제출 후 반드시 취소를 시도하고 "
     "브로커 재조회로 확인한다. 취소를 건너뛰는 플래그는 존재하지 않으며, 취소 "
     "미확인은 실패(RoundTripIncomplete)로 기록되고 exit code 2 로 나간다."
 )
@@ -145,9 +185,15 @@ ROUND_TRIP_MANDATORY_NOTE: Final[str] = (
 KILL_CANCEL_SUPPORTED_NOTE: Final[str] = (
     "신규 주문 중단. 🔴 kiwoom 은 kt00007 미체결조회와 kt10003 취소를 지원하므로 "
     "kis_mock 의 「구조적 시도 불가」가 여기서는 성립하지 않는다. 다만 이 사이클은 "
-    "kill 발화로 파생 자체가 0 이라 취소 대상이 생기지 않았다 — 이 레인은 confirm "
-    "경로에서 자기 주문을 항상 같은 사이클 안에서 회수한다(ROUND_TRIP_MANDATORY). "
-    "재개는 운영자 결정 (계약 §2-4)."
+    "kill 발화로 파생 자체가 0 이라 취소 대상이 생기지 않았다. ACCEPTANCE_ONLY 는 "
+    "자기 주문을 같은 사이클 안에서 회수하지만, INTERIM_ORDERING 은 DAY 주문을 "
+    "자동 취소하지 않는다. 재개는 운영자 결정 (계약 §2-4)."
+)
+
+DAY_ORDER_RETAINED_NOTE: Final[str] = (
+    "DAY_ORDER_RETAINED — INTERIM_ORDERING 은 envelope 파생 전건을 broker에 "
+    "제출하고 즉시 취소하지 않는다. submitted는 접수/주문번호 증거만 뜻하며 "
+    "filled를 뜻하지 않는다."
 )
 
 #: Realized P&L has no source on this lane either — stated so a reader does not
@@ -398,6 +444,8 @@ def _confirm_preflight_record(
     pending_unreadable = pending if isinstance(pending, PendingUnreadable) else None
     foreign_unreadable = foreign if isinstance(foreign, PendingUnreadable) else None
     position_symbols = fresh.non_dust_position_symbols()
+    foreign_trace_readable = foreign_unreadable is None
+    foreign_trace_count = None if foreign_unreadable is not None else foreign.count
     reasons: list[str] = []
 
     if elapsed_seconds > PREFLIGHT_MAX_AGE_SECONDS:
@@ -465,6 +513,18 @@ def _confirm_preflight_record(
             if foreign_unreadable is not None
             else foreign.canonical()  # type: ignore[union-attr]
         ),
+        "kr_b1_inactive_gate": {
+            "required": True,
+            "source": "kt00007 same-day rows not authored by b0xkw journal",
+            "foreign_trace_readable": foreign_trace_readable,
+            "foreign_trace_count": foreign_trace_count,
+            "passed": foreign_trace_readable and foreign_trace_count == 0,
+            "fail_closed": (
+                "foreign trace read failure is not clean; any unreadable answer "
+                "or non-zero foreign trace produces zero orders"
+            ),
+            "residual_toctou": "preflight_once_before_submission",
+        },
         "writer_lease": {
             "acquired": False,
             "surface": "b0x_adapter",
@@ -506,6 +566,15 @@ def _preflight_truth_unavailable_record(
         "attribution": None,
         "open_orders": {"native_broker": None, "ledger_shadow": None},
         "foreign_same_day_orders": None,
+        "kr_b1_inactive_gate": {
+            "required": True,
+            "source": "kt00007 same-day rows not authored by b0xkw journal",
+            "foreign_trace_readable": False,
+            "foreign_trace_count": None,
+            "passed": False,
+            "fail_closed": "account truth unavailable before KR-B1 inactive check",
+            "residual_toctou": "preflight_once_before_submission",
+        },
         "writer_lease": {"acquired": False, "surface": "b0x_adapter"},
         "passed": False,
         "reasons": ["account_truth_unavailable"],
@@ -523,11 +592,12 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
     ledger: ObservationLedger,
     record: dict[str, Any],
     confirm: bool,
+    mode: CycleMode,
     account: kiwoom_lane.ReadOnlyKiwoomMockAccount | None,
     journal: kiwoom_attr.OwnOrderJournal,
     account_identity: dict[str, str] | None,
 ) -> KiwoomCycleOutcome:
-    """Account truth → 귀속 → derive → plan → bounded confirm round trip."""
+    """Account truth → 귀속 → derive → plan → explicitly selected mutation mode."""
 
     if account is None:
         account = kiwoom_lane.ReadOnlyKiwoomMockAccount()
@@ -673,21 +743,26 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
     record["blocked"] = [order.to_json() for order in blocked]
 
     round_trips: list[dict[str, Any]] = []
+    day_orders: list[dict[str, Any]] = []
     if not confirm:
         record["submission_skipped"] = "confirm=False — preview only"
         record["submitted"] = []
         record["round_trip"] = []
+        record["day_orders"] = []
         return _persist_outcome(
             outcome=outcome, ledger=ledger, record=record, labels=labels
         )
 
-    record["round_trip_policy"] = ROUND_TRIP_MANDATORY_NOTE
+    if mode == ACCEPTANCE_MODE:
+        record["round_trip_policy"] = ROUND_TRIP_MANDATORY_NOTE
+    else:
+        record["day_order_policy"] = DAY_ORDER_RETAINED_NOTE
     incomplete: kiwoom_lane.RoundTripIncomplete | None = None
 
     for index, order in enumerate(planned):
-        if index >= MANUAL_CONFIRM_SUBMISSION_LIMIT:
+        if mode == ACCEPTANCE_MODE and index >= ACCEPTANCE_SUBMISSION_LIMIT:
             record["submission_stopped"] = (
-                f"acceptance_submission_limit={MANUAL_CONFIRM_SUBMISSION_LIMIT}"
+                f"acceptance_submission_limit={ACCEPTANCE_SUBMISSION_LIMIT}"
             )
             break
         submitted_at = dt.datetime.now(dt.UTC)
@@ -721,20 +796,25 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
                         "detail": str(exc),
                     }
                 )
+                if mode == INTERIM_ORDERING_MODE:
+                    # A foreign/legacy SELL cannot prevent independently safe
+                    # envelope-derived symbols from being considered.
+                    continue
                 record["submission_stopped"] = "legacy_position_sell_blocked"
                 break
-            # 🔴 The acceptance lever is buy-only. Even an attributed sell is
-            # refused here rather than silently executed, because a sell that
-            # fills cannot be taken back by the mandatory cancel.
-            record.setdefault("submission_blocked", []).append(
-                {
-                    "symbol": order.symbol,
-                    "correlation_id": order.client_order_id,
-                    "reason": "sell_leg_not_wired_on_acceptance_lever",
-                }
-            )
-            record["submission_stopped"] = "sell_leg_not_wired"
-            break
+            if mode == ACCEPTANCE_MODE:
+                # 🔴 The acceptance lever is buy-only. Even an attributed sell
+                # is refused here rather than silently executed, because a sell
+                # that fills cannot be taken back by the mandatory cancel.
+                record.setdefault("submission_blocked", []).append(
+                    {
+                        "symbol": order.symbol,
+                        "correlation_id": order.client_order_id,
+                        "reason": "sell_leg_not_wired_on_acceptance_lever",
+                    }
+                )
+                record["submission_stopped"] = "sell_leg_not_wired"
+                break
 
         if order.symbol in halted:
             record.setdefault("submission_blocked", []).append(
@@ -744,6 +824,10 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
                     "reason": "halted_suspect_symbol",
                 }
             )
+            if mode == INTERIM_ORDERING_MODE:
+                # A table-integrity backstop is scoped to this symbol; preserve
+                # the all-eligible-orders property for the remaining plan.
+                continue
             record["submission_stopped"] = "halted_suspect_symbol"
             break
 
@@ -756,13 +840,24 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
             position_symbols=scoped.cap_position_symbols, pending=current_pending
         )
         try:
-            trip = await kiwoom_lane.submit_and_cancel(
-                account,
-                planned=order,
-                broker_truth=current_truth,
-                record_order_no=_journal_writer(journal),
-                now=submitted_at,
-            )
+            if mode == ACCEPTANCE_MODE:
+                trip = await kiwoom_lane.submit_and_cancel(
+                    account,
+                    planned=order,
+                    broker_truth=current_truth,
+                    record_order_no=_journal_writer(journal),
+                    now=submitted_at,
+                )
+                round_trips.append(trip.canonical())
+            else:
+                day_order = await kiwoom_lane.submit_day_order(
+                    account,
+                    planned=order,
+                    broker_truth=current_truth,
+                    record_order_no=_journal_writer(journal),
+                    now=submitted_at,
+                )
+                day_orders.append(day_order.canonical())
         except OwnPendingResubmitBlocked as exc:
             record.setdefault("submission_dedup_blocked", []).append(
                 {
@@ -772,6 +867,11 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
                     "detail": str(exc),
                 }
             )
+            if mode == INTERIM_ORDERING_MODE:
+                # The broker's pending answer blocks this symbol only. Keep
+                # evaluating other envelope-derived symbols in this explicit
+                # all-eligible-orders mode.
+                continue
             record["submission_stopped"] = "dedup_blocked"
             break
         except kiwoom_lane.RoundTripIncomplete as exc:
@@ -779,18 +879,34 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
             record["submission_stopped"] = "round_trip_incomplete"
             record.setdefault("round_trip_failures", []).append(str(exc))
             break
-        round_trips.append(trip.canonical())
+        except (
+            kiwoom_lane.BrokerEchoMismatch,
+            kiwoom_lane.KiwoomBrokerRejected,
+        ) as exc:
+            # A submit response without usable acceptance evidence may have
+            # changed the external account. Stop immediately and preserve an
+            # auditable non-zero outcome instead of guessing about later legs.
+            if mode == ACCEPTANCE_MODE:
+                raise
+            outcome.exit_code = 2
+            record["submission_stopped"] = "day_order_submission_unverified"
+            record.setdefault("day_order_failures", []).append(str(exc))
+            break
 
     record["round_trip"] = round_trips
-    record["submitted"] = [
-        {
-            "correlation_id": trip["correlation_id"],
-            "symbol": trip["symbol"],
-            "order_no": trip["order_no"],
-            "submitted": trip["submitted"],
-        }
-        for trip in round_trips
-    ]
+    record["day_orders"] = day_orders
+    if mode == ACCEPTANCE_MODE:
+        record["submitted"] = [
+            {
+                "correlation_id": trip["correlation_id"],
+                "symbol": trip["symbol"],
+                "order_no": trip["order_no"],
+                "submitted": trip["submitted"],
+            }
+            for trip in round_trips
+        ]
+    else:
+        record["submitted"] = list(day_orders)
     if incomplete is not None:
         outcome.exit_code = 2
     return _persist_outcome(
@@ -799,7 +915,7 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
 
 
 def _journal_writer(journal: kiwoom_attr.OwnOrderJournal) -> Any:
-    """Return the append callback :func:`kiwoom.submit_and_cancel` invokes.
+    """Return the append callback both submission modes invoke.
 
     Kept as a tiny closure so the lane module owns *when* the journal is
     written (immediately after the broker returns an order number) while this
@@ -825,7 +941,19 @@ def _journal_writer(journal: kiwoom_attr.OwnOrderJournal) -> Any:
     return _record
 
 
-def _stamp_contract_and_account_map(record: dict[str, Any]) -> None:
+def _cycle_status(*, confirm: bool, mode: CycleMode) -> tuple[str, str]:
+    """Return the exact artifact literal for the behavior that actually ran."""
+
+    if not confirm:
+        return PREVIEW_STATUS, PREVIEW_STATUS_LABEL
+    if mode == ACCEPTANCE_MODE:
+        return ACCEPTANCE_ONLY_STATUS, ACCEPTANCE_ONLY_STATUS_LABEL
+    return INTERIM_ORDERING_STATUS, INTERIM_ORDERING_STATUS_LABEL
+
+
+def _stamp_contract_and_account_map(
+    record: dict[str, Any], *, cycle_status: str, status_label: str
+) -> None:
     record["contract"] = {
         "path": "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md",
         "version": KR_CONTRACT_VERSION,
@@ -838,7 +966,10 @@ def _stamp_contract_and_account_map(record: dict[str, Any]) -> None:
         "reference_surface": "mock/CLAUDE.md",
         "gate_values": dict(KR_ACCOUNT_MAP_VALUES),
     }
-    record["cycle_status"] = "OBSERVATION_DERIVATION_ONLY"
+    record["cycle_status"] = cycle_status
+    record["cycle_status_label"] = status_label
+    if cycle_status == INTERIM_ORDERING_STATUS:
+        record["interim_ordering_constraints"] = dict(INTERIM_ORDERING_CONSTRAINTS)
 
 
 async def run_kiwoom_cycle(
@@ -847,23 +978,28 @@ async def run_kiwoom_cycle(
     table_dir: Path = DEFAULT_TABLE_DIR,
     out_dir: Path = DEFAULT_OBSERVATION_DIR,
     confirm: bool = False,
+    interim_ordering: bool = False,
     account: kiwoom_lane.ReadOnlyKiwoomMockAccount | None = None,
     journal: kiwoom_attr.OwnOrderJournal | None = None,
 ) -> KiwoomCycleOutcome:
     """One manual kiwoom_mock B0-X cycle.
 
-    ``confirm=False`` is the ordinary observation/derivation path. A confirm
-    call is a separate, default-disabled manual surface requiring the B0-X env
-    gate, the per-call ``confirm=True`` argument and a clean NW-B4 preflight
-    inside KRX RTH — and it always completes the mandatory cancel round trip.
+    ``confirm=False`` is the ordinary observation/derivation path. A confirmed
+    call is default-disabled and requires the B0-X env gate plus a clean NW-B4
+    preflight inside KRX RTH. With ``interim_ordering=False`` (the safe default)
+    it remains the one-order ``ACCEPTANCE_ONLY`` cancel round trip. The caller
+    must additionally set ``interim_ordering=True`` to leave envelope-derived
+    DAY orders at the broker.
     """
 
     envelope = load_envelope(MARKET)
     assert_envelope_locked(envelope)
     kiwoom_lane.assert_correlation_prefixes_disjoint()
+    mode: CycleMode = INTERIM_ORDERING_MODE if interim_ordering else ACCEPTANCE_MODE
+    cycle_status, status_label = _cycle_status(confirm=confirm, mode=mode)
     labels = header_labels(
         lane=LANE,
-        extra=(*account_history_labels(LANE), COEXISTENCE_LABEL, KR_STATUS_LABEL),
+        extra=(*account_history_labels(LANE), COEXISTENCE_LABEL, status_label),
     )
     outcome = KiwoomCycleOutcome(lane=LANE, at=now)
     root = Path(out_dir).expanduser()
@@ -880,9 +1016,26 @@ async def run_kiwoom_cycle(
         record = base_record(
             market=MARKET, lane=LANE, now=now, envelope=envelope, labels=labels
         )
-        _stamp_contract_and_account_map(record)
+        _stamp_contract_and_account_map(
+            record, cycle_status=cycle_status, status_label=status_label
+        )
         record["confirm"] = confirm
+        record["interim_ordering"] = interim_ordering
+        record["execution_mode"] = "preview" if not confirm else mode
         record["realized_pnl_source"] = KR_REALIZED_PNL_UNAVAILABLE
+
+        if interim_ordering and not confirm:
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="interim_ordering_requires_confirm",
+                detail=(
+                    "INTERIM_ORDERING is not armed by its mode flag alone; "
+                    "the per-call confirm=True gate is required"
+                ),
+            )
 
         # --- RTH gate: cheapest check, before any table/account I/O ---
         in_session = is_krx_regular_session(now)
@@ -931,6 +1084,7 @@ async def run_kiwoom_cycle(
                 ledger=ledger,
                 record=record,
                 confirm=False,
+                mode=mode,
                 account=account,
                 journal=lane_journal,
                 account_identity=None,
@@ -958,6 +1112,7 @@ async def run_kiwoom_cycle(
             ledger=ledger,
             record=record,
             confirm=True,
+            mode=mode,
             account=account,
             journal=lane_journal,
             account_identity=account_identity,
@@ -967,15 +1122,26 @@ async def run_kiwoom_cycle(
 __all__ = [
     "MARKET",
     "LANE",
+    "CycleMode",
+    "ACCEPTANCE_MODE",
+    "INTERIM_ORDERING_MODE",
+    "PREVIEW_STATUS",
+    "ACCEPTANCE_ONLY_STATUS",
+    "INTERIM_ORDERING_STATUS",
     "OUTSIDE_RTH_REASON",
     "PREFLIGHT_MAX_AGE_SECONDS",
-    "MANUAL_CONFIRM_SUBMISSION_LIMIT",
+    "ACCEPTANCE_SUBMISSION_LIMIT",
     "ROUND_TRIP_MANDATORY_NOTE",
     "KILL_CANCEL_SUPPORTED_NOTE",
+    "DAY_ORDER_RETAINED_NOTE",
     "KR_CONTRACT_VERSION",
     "KR_ACCOUNT_MAP_COMMIT",
     "KR_ACCOUNT_MAP_VALUES",
     "KR_STATUS_LABEL",
+    "PREVIEW_STATUS_LABEL",
+    "ACCEPTANCE_ONLY_STATUS_LABEL",
+    "INTERIM_ORDERING_STATUS_LABEL",
+    "INTERIM_ORDERING_CONSTRAINTS",
     "COEXISTENCE_LABEL",
     "KR_REALIZED_PNL_UNAVAILABLE",
     "KR_ATTRIBUTED_NAV_BASIS",

--- a/scripts/run_b0x_kr_kiwoom_cycle.py
+++ b/scripts/run_b0x_kr_kiwoom_cycle.py
@@ -6,19 +6,24 @@
     # Read-only preflight probe: account truth + 귀속 + broker pending, no plan.
     uv run python -m scripts.run_b0x_kr_kiwoom_cycle --readiness
 
-    # One manually requested mock acceptance round trip.  Default-disabled,
+    # One manually requested mock acceptance round trip. Default-disabled,
     # bounded to one submission, and it ALWAYS cancels what it sent.
     uv run python -m scripts.run_b0x_kr_kiwoom_cycle --confirm
 
-``--confirm`` is not a status change: this lane remains
-``OBSERVATION_DERIVATION_ONLY``. It cannot be combined with ``--now``, so an
-operator cannot replay an artificial session timestamp into the mutation path,
-and there is no flag whose value can reach an envelope field — the §4 caps are
-module constants in ``scripts.b0x.envelope``, re-asserted before every read.
+    # Explicitly selected INTERIM DAY-order path. It is never the default and
+    # requires the same per-call confirmation gate.
+    uv run python -m scripts.run_b0x_kr_kiwoom_cycle --interim-ordering --confirm
 
-🔴 There is no ``--no-cancel``. The confirm path submits one order and then
-proves, from the broker's own answer, that it is gone. A cancellation that
-cannot be proven exits ``2``.
+``--confirm`` alone is ``ACCEPTANCE_ONLY``: one submit followed by broker-proven
+cancel. ``--interim-ordering --confirm`` is ``INTERIM_ORDERING``: it submits
+every envelope-derived DAY order and deliberately does not auto-cancel. Both
+are default-disabled, cannot be combined with ``--now``, and expose no envelope
+override. The §4 caps are module constants in ``scripts.b0x.envelope``,
+re-asserted before every read.
+
+🔴 There is no ``--no-cancel`` for acceptance. The cancellation it requires
+must be broker-proven or exits ``2``; that safe acceptance behavior is not
+silently transformed into the interim mode.
 
 No scheduler registration exists for this script — not TaskIQ, not Prefect,
 not launchd. A cycle happens because an operator ran it.
@@ -69,6 +74,14 @@ def _print_outcome(outcome) -> None:  # noqa: ANN001 — local formatting helper
         )
     for failure in outcome.record.get("round_trip_failures") or []:
         print(f"ROUND_TRIP_FAILURE — {failure}", file=sys.stderr)
+    for order in outcome.record.get("day_orders") or []:
+        print(
+            f"DAY_ORDER symbol={order['symbol']} order_no={order['order_no']} "
+            f"side={order['side']} qty={order['quantity']} "
+            f"price={order['price']} automatic_cancel={order['automatic_cancel']}"
+        )
+    for failure in outcome.record.get("day_order_failures") or []:
+        print(f"DAY_ORDER_FAILURE — {failure}", file=sys.stderr)
     if outcome.artifact_path:
         print(f"artifact={outcome.artifact_path}")
 
@@ -119,6 +132,9 @@ async def _readiness(args: argparse.Namespace) -> int:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    if args.interim_ordering and not args.confirm:
+        print("--interim-ordering requires --confirm", file=sys.stderr)
+        return 2
     if args.confirm and args.now is not None:
         print("--confirm cannot be combined with --now", file=sys.stderr)
         return 2
@@ -138,6 +154,7 @@ async def _run(args: argparse.Namespace) -> int:
             table_dir=Path(args.table_dir).expanduser(),
             out_dir=Path(args.out_dir).expanduser(),
             confirm=args.confirm,
+            interim_ordering=args.interim_ordering,
         )
     except WriterLockUnavailable as exc:
         print(f"WRITER_LOCK_UNAVAILABLE — {exc}", file=sys.stderr)
@@ -181,6 +198,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "arm the bounded acceptance round trip (submit 1 → verify resting → "
             "cancel → reconcile). Default-disabled; also needs B0X_KR_KIWOOM_ENABLED"
+        ),
+    )
+    parser.add_argument(
+        "--interim-ordering",
+        action="store_true",
+        help=(
+            "select INTERIM_ORDERING DAY-order retention; requires --confirm. "
+            "Without this flag, --confirm remains the one-order acceptance cancel"
         ),
     )
     parser.add_argument("--now", type=_iso, default=None, help="override cycle time")

--- a/scripts/run_b0x_kr_kiwoom_cycle.py
+++ b/scripts/run_b0x_kr_kiwoom_cycle.py
@@ -16,10 +16,11 @@
 
 ``--confirm`` alone is ``ACCEPTANCE_ONLY``: one submit followed by broker-proven
 cancel. ``--interim-ordering --confirm`` is ``INTERIM_ORDERING``: it submits
-every envelope-derived DAY order and deliberately does not auto-cancel. Both
-are default-disabled, cannot be combined with ``--now``, and expose no envelope
-override. The §4 caps are module constants in ``scripts.b0x.envelope``,
-re-asserted before every read.
+every eligible envelope-derived **buy** DAY order and deliberately does not
+auto-cancel. Sell wiring remains behind a default-on, non-CLI buy-only gate
+until explicit approval or B-track merge. Both are default-disabled, cannot be
+combined with ``--now``, and expose no envelope override. The §4 caps are
+module constants in ``scripts.b0x.envelope``, re-asserted before every read.
 
 🔴 There is no ``--no-cancel`` for acceptance. The cancellation it requires
 must be broker-proven or exits ``2``; that safe acceptance behavior is not

--- a/tests/scripts/b0x/kr/kiwoom/conftest.py
+++ b/tests/scripts/b0x/kr/kiwoom/conftest.py
@@ -84,6 +84,7 @@ class FakeAccount:
         self.resting_calls = 0
         self.diagnostic_calls = 0
         self.buy_calls: list[dict[str, Any]] = []
+        self.sell_calls: list[dict[str, Any]] = []
         self.cancel_calls: list[dict[str, Any]] = []
         self.detail_calls: list[dict[str, Any]] = []
 
@@ -124,6 +125,14 @@ class FakeAccount:
         self, *, symbol: str, quantity: int, price: int
     ) -> dict[str, Any]:
         self.buy_calls.append({"symbol": symbol, "quantity": quantity, "price": price})
+        if self._buy_error is not None:
+            raise self._buy_error
+        return dict(self._buy_response)
+
+    async def place_limit_sell(
+        self, *, symbol: str, quantity: int, price: int
+    ) -> dict[str, Any]:
+        self.sell_calls.append({"symbol": symbol, "quantity": quantity, "price": price})
         if self._buy_error is not None:
             raise self._buy_error
         return dict(self._buy_response)

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cli.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cli.py
@@ -20,6 +20,17 @@ def test_cli_defaults_to_preview_and_preserves_acceptance_form() -> None:
     assert acceptance.interim_ordering is False
     assert interim.confirm is True
     assert interim.interim_ordering is True
+    # A sell-gate override would necessarily add a parser destination. There
+    # is deliberately no CLI release path for the default-on INTERIM gate.
+    assert set(vars(interim)) == {
+        "table_dir",
+        "out_dir",
+        "readiness",
+        "confirm",
+        "interim_ordering",
+        "now",
+        "json",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cli.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cli.py
@@ -1,0 +1,46 @@
+"""CLI mode selection stays explicit and defaults to the non-mutating path."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.run_b0x_kr_kiwoom_cycle import _parse_args, _run
+
+pytestmark = pytest.mark.unit
+
+
+def test_cli_defaults_to_preview_and_preserves_acceptance_form() -> None:
+    preview = _parse_args([])
+    acceptance = _parse_args(["--confirm"])
+    interim = _parse_args(["--interim-ordering", "--confirm"])
+
+    assert preview.confirm is False
+    assert preview.interim_ordering is False
+    assert acceptance.confirm is True
+    assert acceptance.interim_ordering is False
+    assert interim.confirm is True
+    assert interim.interim_ordering is True
+
+
+@pytest.mark.asyncio
+async def test_cli_rejects_interim_ordering_without_per_call_confirmation() -> None:
+    """This returns before any cycle/account work, so it cannot reach a broker."""
+
+    assert await _run(_parse_args(["--interim-ordering"])) == 2
+
+
+@pytest.mark.asyncio
+async def test_cli_rejects_interim_replay_clock_before_any_cycle_work() -> None:
+    assert (
+        await _run(
+            _parse_args(
+                [
+                    "--interim-ordering",
+                    "--confirm",
+                    "--now",
+                    "2026-08-10T02:00:00+00:00",
+                ]
+            )
+        )
+        == 2
+    )

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -35,6 +35,8 @@ def _write_table(
     generated_at: dt.datetime,
     symbols: tuple[str, ...] = ("005930",),
     halted: list[str] | None = None,
+    buy_l1: str | None = "70000",
+    sell_r1: str | None = None,
 ) -> None:
     """Write a real, hash-valid ``policy_table.v1`` for the KR market.
 
@@ -45,7 +47,12 @@ def _write_table(
 
     payload = make_payload(
         rows=[
-            make_row(symbol=symbol, previous_close="72000.00", buy_l1="70000.00")
+            make_row(
+                symbol=symbol,
+                previous_close="72000.00",
+                buy_l1=buy_l1,
+                sell_r1=sell_r1,
+            )
             for symbol in symbols
         ],
         generated_at=generated_at,
@@ -445,6 +452,72 @@ async def test_interim_ordering_submits_every_envelope_derived_day_order_without
     )
     assert "acceptance_submission_limit" not in outcome.record
     assert outcome.record["day_order_policy"] == kiwoom_cycle.DAY_ORDER_RETAINED_NOTE
+
+
+@pytest.mark.asyncio
+async def test_interim_buy_only_sell_gate_blocks_derived_sell_with_audit_reason(
+    table_dir, out_dir, armed, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    """§50차 2항: a valid derived sell is visible but cannot reach Kiwoom."""
+
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l1=None,
+        sell_r1="80000.00",
+    )
+    own_attribution = kr_attribution.OwnFillAttribution(
+        lots=(
+            kr_attribution.AttributedLot(
+                symbol="005930",
+                quantity=Decimal("10"),
+                average_price=Decimal("70000"),
+                buy_fill_rows=1,
+                sell_rows=0,
+            ),
+        )
+    )
+
+    async def _read_own_attribution(**_kwargs):  # noqa: ANN003, ANN202
+        return own_attribution
+
+    monkeypatch.setattr(kiwoom_attr, "read_own_attribution", _read_own_attribution)
+    account = FakeAccount(positions=(position("005930", 10, average_price=70_000),))
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        interim_ordering=True,
+    )
+
+    assert outcome.exit_code == 0
+    assert outcome.derivation is not None
+    assert [order.side for order in outcome.derivation.orders] == ["sell"]
+    assert [order["side"] for order in outcome.record["planned"]] == ["sell"]
+    # Keep this assertion before the artifact checks: disabling the gate must
+    # prove that the sell reached the fake venue, rather than only changing a
+    # descriptive field.
+    assert account.sell_calls == []
+    assert account.buy_calls == []
+    assert outcome.record["day_orders"] == []
+    assert outcome.record["submitted"] == []
+    assert outcome.record["interim_buy_only_sell_gate"] == {
+        "enabled": True,
+        "reason_code": "interim_buy_only_sell_gate",
+        "scope": "submission_stage_sell_legs",
+        "cli_disable_available": False,
+        "release": "explicit_operator_approval_or_b_track_merge",
+    }
+    blocked = outcome.record["submission_blocked"]
+    assert [(item["side"], item["leg"], item["reason"]) for item in blocked] == [
+        ("sell", "sell_r1", "interim_buy_only_sell_gate")
+    ]
+    assert blocked[0]["detail"] == kiwoom_cycle.INTERIM_BUY_ONLY_SELL_GATE_DETAIL
+    assert kiwoom_cycle.INTERIM_BUY_ONLY_SELL_GATE_ENABLED is True
+    assert outcome.record["interim_ordering_constraints"]["buy_only"] == (
+        "매수 전용(매도 게이트 ON)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import datetime as dt
 from decimal import Decimal
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -66,9 +67,39 @@ def _write_table(
 
 
 @pytest.fixture
-def table_dir(tmp_path: Path) -> Path:
+def cycle_now(request: pytest.FixtureRequest) -> dt.datetime:
+    """A KRX-RTH test clock; parametrized callers exercise another trading day."""
+
+    return getattr(request, "param", IN_SESSION)
+
+
+@pytest.fixture
+def frozen_cycle_clock(
+    monkeypatch: pytest.MonkeyPatch, cycle_now: dt.datetime
+) -> dt.datetime:
+    """Bind the cycle's wall clock to the same instant passed as ``now``."""
+
+    class FrozenDateTime:
+        @classmethod
+        def now(cls, tz: dt.tzinfo | None = None) -> dt.datetime:  # noqa: ANN102
+            return (
+                cycle_now.astimezone(tz)
+                if tz is not None
+                else cycle_now.replace(tzinfo=None)
+            )
+
+    monkeypatch.setattr(
+        kiwoom_cycle,
+        "dt",
+        SimpleNamespace(datetime=FrozenDateTime, UTC=dt.UTC),
+    )
+    return cycle_now
+
+
+@pytest.fixture
+def table_dir(tmp_path: Path, cycle_now: dt.datetime) -> Path:
     directory = tmp_path / "policy-tables"
-    _write_table(directory, generated_at=IN_SESSION - dt.timedelta(hours=4))
+    _write_table(directory, generated_at=cycle_now - dt.timedelta(hours=4))
     return directory
 
 
@@ -193,20 +224,25 @@ async def test_interim_ordering_requires_confirm_and_keeps_preview_safe(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cycle_now", (IN_SESSION, IN_SESSION + dt.timedelta(days=1)))
 async def test_confirm_blocks_on_same_day_foreign_orders(
-    table_dir, out_dir, armed
+    table_dir, out_dir, armed, frozen_cycle_clock
 ) -> None:  # noqa: ANN001, ARG001
     """🔴 The empirical KR-B1-is-active gate."""
 
     account = FakeAccount(
         order_detail={
-            kiwoom_attr.kst_order_date(IN_SESSION): [
+            kiwoom_attr.kst_order_date(frozen_cycle_clock): [
                 {"order_id": "0000009999", "symbol": "005380", "filled_quantity": 1}
             ]
         }
     )
     outcome = await _run(
-        account=account, out_dir=out_dir, table_dir=table_dir, confirm=True
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        now=frozen_cycle_clock,
     )
     assert outcome.zero_order_reason == "preflight_not_clean"
     assert (
@@ -521,8 +557,9 @@ async def test_interim_buy_only_sell_gate_blocks_derived_sell_with_audit_reason(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cycle_now", (IN_SESSION, IN_SESSION + dt.timedelta(days=1)))
 async def test_confirm_writes_the_order_number_to_the_journal(
-    table_dir, out_dir, armed, tmp_path
+    table_dir, out_dir, armed, tmp_path, frozen_cycle_clock
 ) -> None:  # noqa: ANN001, ARG001
     journal = kiwoom_attr.OwnOrderJournal(path=tmp_path / "journal.jsonl")
     account = FakeAccount(
@@ -534,7 +571,7 @@ async def test_confirm_writes_the_order_number_to_the_journal(
         ]
     )
     await kiwoom_cycle.run_kiwoom_cycle(
-        now=IN_SESSION,
+        now=frozen_cycle_clock,
         table_dir=table_dir,
         out_dir=out_dir,
         confirm=True,
@@ -544,7 +581,7 @@ async def test_confirm_writes_the_order_number_to_the_journal(
     records = journal.read_all()
     assert [record.order_no for record in records] == ["0000123456"]
     assert records[0].correlation_id.startswith("b0xkw-")
-    assert records[0].order_date == kiwoom_attr.kst_order_date(IN_SESSION)
+    assert records[0].order_date == kiwoom_attr.kst_order_date(frozen_cycle_clock)
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.b0x.kr import attribution as kr_attribution
 from scripts.b0x.kr import kiwoom as kiwoom_lane
 from scripts.b0x.kr import kiwoom_attribution as kiwoom_attr
 from scripts.b0x.kr import kiwoom_cycle
@@ -87,6 +88,7 @@ async def _run(
     out_dir,
     table_dir,
     confirm=False,
+    interim_ordering=False,
     now=IN_SESSION,  # noqa: ANN001
 ):  # noqa: ANN202
     return await kiwoom_cycle.run_kiwoom_cycle(
@@ -94,6 +96,7 @@ async def _run(
         table_dir=table_dir,
         out_dir=out_dir,
         confirm=confirm,
+        interim_ordering=interim_ordering,
         account=account,
     )
 
@@ -158,6 +161,25 @@ async def test_record_carries_the_account_map_and_status_label(
     )
 
 
+@pytest.mark.asyncio
+async def test_interim_ordering_requires_confirm_and_keeps_preview_safe(
+    table_dir, out_dir
+) -> None:  # noqa: ANN001
+    account = FakeAccount()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        interim_ordering=True,
+    )
+
+    assert outcome.zero_order_reason == "interim_ordering_requires_confirm"
+    assert outcome.record["cycle_status"] == kiwoom_cycle.PREVIEW_STATUS
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+    assert account.cancel_calls == []
+
+
 # ---------------------------------------------------------------------------
 # Confirm preflight — each reason, each with zero venue calls.
 # ---------------------------------------------------------------------------
@@ -184,7 +206,46 @@ async def test_confirm_blocks_on_same_day_foreign_orders(
         "CONTAMINATED_foreign_same_day_orders_kr_b1_active_suspect"
         in outcome.record["preflight"]["reasons"]
     )
+    assert outcome.record["preflight"]["kr_b1_inactive_gate"]["passed"] is False
     assert account.buy_calls == []
+
+
+@pytest.mark.asyncio
+async def test_confirm_blocks_when_kr_b1_foreign_trace_read_fails(
+    table_dir, out_dir, armed, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    """🔴 Read failure is not a clean KR-B1-inactive observation."""
+
+    async def readable_empty_attribution(**_kwargs):  # noqa: ANN003, ANN202
+        return kr_attribution.OwnFillAttribution(lots=())
+
+    monkeypatch.setattr(kiwoom_attr, "read_own_attribution", readable_empty_attribution)
+
+    class ForeignTraceUnreadableAccount(FakeAccount):
+        async def read_order_detail(self, *, order_date=None, symbol=None):  # noqa: ANN001, ANN201, ARG002
+            raise RuntimeError("kt00007 foreign trace timeout")
+
+    account = ForeignTraceUnreadableAccount()
+    outcome = await _run(
+        account=account, out_dir=out_dir, table_dir=table_dir, confirm=True
+    )
+
+    assert outcome.zero_order_reason == "preflight_not_clean"
+    assert "foreign_same_day_trace_unreadable" in outcome.record["preflight"]["reasons"]
+    assert outcome.record["preflight"]["kr_b1_inactive_gate"] == {
+        "required": True,
+        "source": "kt00007 same-day rows not authored by b0xkw journal",
+        "foreign_trace_readable": False,
+        "foreign_trace_count": None,
+        "passed": False,
+        "fail_closed": (
+            "foreign trace read failure is not clean; any unreadable answer or "
+            "non-zero foreign trace produces zero orders"
+        ),
+        "residual_toctou": "preflight_once_before_submission",
+    }
+    assert account.buy_calls == []
+    assert account.sell_calls == []
 
 
 @pytest.mark.asyncio
@@ -305,6 +366,85 @@ async def test_confirm_submits_exactly_one_order_and_cancels_it(
         "acceptance_submission_limit="
     )
     assert outcome.record["round_trip_policy"] == kiwoom_cycle.ROUND_TRIP_MANDATORY_NOTE
+    assert outcome.record["cycle_status"] == kiwoom_cycle.ACCEPTANCE_ONLY_STATUS
+    assert outcome.record["cycle_status_label"] == (
+        kiwoom_cycle.ACCEPTANCE_ONLY_STATUS_LABEL
+    )
+    assert outcome.record["day_orders"] == []
+
+
+@pytest.mark.asyncio
+async def test_interim_ordering_submits_every_envelope_derived_day_order_without_cancel(
+    table_dir, out_dir, armed
+) -> None:  # noqa: ANN001, ARG001
+    """DAY retention replaces neither the derivation caps nor acceptance mode."""
+
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        symbols=("005930", "000660", "035420", "051910"),
+    )
+
+    class DistinctOrderNumbers(FakeAccount):
+        async def place_limit_buy(self, *, symbol, quantity, price):  # noqa: ANN001, ANN201
+            payload = await super().place_limit_buy(
+                symbol=symbol, quantity=quantity, price=price
+            )
+            payload["ord_no"] = f"{len(self.buy_calls):010d}"
+            return payload
+
+    account = DistinctOrderNumbers()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        interim_ordering=True,
+    )
+
+    assert outcome.exit_code == 0
+    assert outcome.record["cycle_status"] == "INTERIM_ORDERING"
+    assert outcome.record["cycle_status_label"] == (
+        kiwoom_cycle.INTERIM_ORDERING_STATUS_LABEL
+    )
+    assert outcome.record["interim_ordering_constraints"] == (
+        kiwoom_cycle.INTERIM_ORDERING_CONSTRAINTS
+    )
+    assert kiwoom_cycle.INTERIM_ORDERING_STATUS_LABEL in outcome.record["labels"]
+    for constraint in kiwoom_cycle.INTERIM_ORDERING_CONSTRAINTS.values():
+        assert constraint.split(" — ")[0] in kiwoom_cycle.INTERIM_ORDERING_STATUS_LABEL
+
+    # Four candidates reach derivation, but the locked daily-new cap admits
+    # exactly three. INTERIM_ORDERING sends all three, not the old one-order
+    # acceptance limit, and none reaches cancellation.
+    assert outcome.derivation is not None
+    assert len(outcome.derivation.orders) == 3
+    assert any(
+        skipped["reason"] == "daily_new_entry_cap_reached"
+        for skipped in outcome.record["skipped"]
+    )
+    assert len(account.buy_calls) == len(outcome.derivation.orders)
+    assert account.sell_calls == []
+    assert account.cancel_calls == []
+    assert outcome.record["round_trip"] == []
+    assert len(outcome.record["day_orders"]) == 3
+    assert outcome.record["submitted"] == outcome.record["day_orders"]
+    assert all(
+        order["time_in_force"] == "DAY" for order in outcome.record["day_orders"]
+    )
+    assert all(
+        order["automatic_cancel"] is False for order in outcome.record["day_orders"]
+    )
+    assert all(
+        order["fill_status"] == "unverified" for order in outcome.record["day_orders"]
+    )
+    assert all(
+        Decimal(order["notional_krw"])
+        <= Decimal(outcome.record["envelope"]["per_order_notional"])
+        for order in outcome.record["day_orders"]
+    )
+    assert "acceptance_submission_limit" not in outcome.record
+    assert outcome.record["day_order_policy"] == kiwoom_cycle.DAY_ORDER_RETAINED_NOTE
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_envelope_session_and_semantics.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_envelope_session_and_semantics.py
@@ -126,6 +126,7 @@ async def test_lane_order_surface_offers_no_exchange_parameter() -> None:
 
     for method in (
         kiwoom_lane.ReadOnlyKiwoomMockAccount.place_limit_buy,
+        kiwoom_lane.ReadOnlyKiwoomMockAccount.place_limit_sell,
         kiwoom_lane.ReadOnlyKiwoomMockAccount.cancel,
     ):
         params = set(inspect.signature(method).parameters)

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
@@ -51,6 +51,44 @@ def _sink():  # noqa: ANN202
 
 
 @pytest.mark.asyncio
+async def test_interim_day_submission_never_calls_cancel(now) -> None:  # noqa: ANN001
+    """INTERIM_ORDERING records acceptance, not a synthetic fill or cleanup."""
+
+    account = FakeAccount()
+    writer = _sink()
+
+    result = await kiwoom_lane.submit_day_order(
+        account,
+        planned=_planned(),
+        broker_truth=CLEAN_TRUTH,
+        record_order_no=writer,
+        now=now,
+    )
+
+    assert result.submitted is True
+    assert result.order_no == "0000123456"
+    assert account.buy_calls == [{"symbol": "005930", "quantity": 1, "price": 70_000}]
+    assert account.cancel_calls == []
+    assert result.canonical() == {
+        "correlation_id": "b0xkw-deadbeefdeadbeef",
+        "symbol": "005930",
+        "side": "buy",
+        "price": 70_000,
+        "quantity": 1,
+        "notional_krw": 70_000,
+        "submitted": True,
+        "order_no": "0000123456",
+        "submit_response": {"return_code": 0, "ord_no": "0000123456"},
+        "time_in_force": "DAY",
+        "automatic_cancel": False,
+        "fill_status": "unverified",
+    }
+    assert writer.written == [  # type: ignore[attr-defined]
+        {"order_no": "0000123456", "symbol": "005930", "at": now}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_happy_round_trip_confirms_cancellation_from_the_broker(now) -> None:  # noqa: ANN001
     planned = _planned()
     account = FakeAccount(


### PR DESCRIPTION
## Summary
- Preserve the default --confirm one-order acceptance submit/cancel/reconcile path as ACCEPTANCE_ONLY.
- Add explicit --interim-ordering --confirm for full envelope-derived KRX DAY submissions with no automatic cancel.
- Make the KR-B1 foreign same-day trace gate visibly fail-closed and record the accepted interim constraints.

## Verification
- make lint passed.
- uv run pytest tests/scripts/b0x/ -q: 704 passed, 3 skipped, 2 known date-fixed kiwoom failures.
- Mutant checks verified status impersonation, envelope bypass, and foreign-trace-read failure bypass are rejected and restored cleanly.

No cycle, CLI confirm execution, broker contact, or account mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit preview, acceptance-only, and interim-ordering modes.
  - Added optional DAY-order submission that records broker acceptance and retains orders without automatic cancellation.
  - Added buy-only safeguards and foreign-order verification before interim submissions.
  - Added reporting for retained orders, blocked sells, and submission failures.
- **Bug Fixes**
  - Improved handling of blocked individual orders while preserving fail-closed behavior for unverifiable broker responses.
- **Documentation**
  - Expanded operational guidance, command examples, confirmation requirements, cancellation behavior, and order journaling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->