### PR TITLE
TOSS-AUTO-FULL: guarded Toss auto-veto acceptance

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -851,6 +851,13 @@ class Settings(BaseSettings):
     #              approval-required.
     # Turning this to "expanded" is an operator decision; this repo ships "off".
     ORDER_PROPOSALS_AUTO_APPROVE_MODE: Literal["off", "expanded"] = "off"
+    # TOSS-AUTO-FULL (§51) — a separate, default-off expansion for the live
+    # Toss account.  It remains subordinate to ORDER_PROPOSALS_AUTO_APPROVE
+    # and requires the post-submit veto path to obtain both a broker-terminal
+    # cancellation snapshot and a Toss-ledger reconciliation result.  Keeping
+    # this false in code means a deployment cannot make Toss auto-submittable
+    # merely by enabling the pre-existing master/mode settings.
+    ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED: bool = False
     # ROB-816 PR 2 — Telegram approval flow (default off)
     ORDER_PROPOSALS_TELEGRAM_ENABLED: bool = False
     ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN: str = ""

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -390,6 +390,7 @@ async def _reconcile_one_toss_row(
     dry_run: bool,
     evidence_source: Any | None = None,
     fallback_client: Any | None = None,
+    project_proposal_rungs: bool = True,
 ) -> dict[str, Any]:
     base = {
         "ledger_id": row.id,
@@ -443,13 +444,19 @@ async def _reconcile_one_toss_row(
     if evidence.verdict == "none":
         base["action"] = f"marked_{evidence.local_status}"
         if not dry_run:
-            converged = await _converge_toss_proposal_rung(
-                row,
-                ledger_status=evidence.local_status,
-                filled_qty=row.filled_qty,
-            )
-            if converged is not None:
-                base["proposal_rung"] = converged
+            # The auto-veto path owns a locked proposal rung and uses this
+            # reconciler solely to close the independent Toss ledger.  Do not
+            # re-enter proposal-rung projection from a separate session there;
+            # the caller records cancellation only after this result confirms
+            # the original broker order's terminal status.
+            if project_proposal_rungs:
+                converged = await _converge_toss_proposal_rung(
+                    row,
+                    ledger_status=evidence.local_status,
+                    filled_qty=row.filled_qty,
+                )
+                if converged is not None:
+                    base["proposal_rung"] = converged
             async with _order_session_factory()() as db:
                 await TossLiveOrderLedgerService(db).update_reconcile_outcome(
                     ledger_id=row.id,
@@ -470,7 +477,7 @@ async def _reconcile_one_toss_row(
     base["avg_price"] = float(avg_price)
     base["delta_qty"] = float(delta)
 
-    if not dry_run:
+    if not dry_run and project_proposal_rungs:
         projection_status = (
             "cancelled" if evidence.local_status == "cancelled" else evidence.verdict
         )
@@ -757,9 +764,10 @@ async def toss_reconcile_orders_impl(
     market: str | None = None,
     dry_run: bool = True,
     limit: int = 100,
+    project_proposal_rungs: bool = True,
 ) -> dict[str, Any]:
     projection_repair = {"candidates": 0, "converged": 0, "failed": 0, "anomalies": {}}
-    if not dry_run:
+    if not dry_run and project_proposal_rungs:
         projection_repair = await _repair_terminal_toss_proposal_projections(
             symbol=symbol,
             order_id=order_id,
@@ -842,6 +850,7 @@ async def toss_reconcile_orders_impl(
                     dry_run=dry_run,
                     evidence_source=evidence_source,
                     fallback_client=shared_client,
+                    project_proposal_rungs=project_proposal_rungs,
                 )
             except Exception as exc:  # noqa: BLE001 — classified in the handler
                 outcome = await _handle_reconcile_row_error(row, exc, dry_run=dry_run)

--- a/app/monitoring/trade_notifier/formatters_discord.py
+++ b/app/monitoring/trade_notifier/formatters_discord.py
@@ -146,6 +146,37 @@ def format_cancel_notification(
     }
 
 
+def format_auto_veto_card_mirror(
+    *,
+    symbol: str,
+    quantities: list[str],
+    prices: list[str],
+    thesis_summary: str,
+    policy_version: str,
+) -> DiscordEmbed:
+    """Render the Discord mirror of a post-submit cancellation card.
+
+    The required fields deliberately remain separate rather than being packed
+    into one order-detail string: an operator must be able to see symbol,
+    quantity, price, and the decision thesis independently at a glance.
+    """
+    if not thesis_summary.strip():
+        raise ValueError("auto-veto mirror requires a thesis summary")
+    if not quantities or not prices or len(quantities) != len(prices):
+        raise ValueError("auto-veto mirror requires matched quantity and price")
+    return {
+        "title": "✅ 자동 접수됨 — 취소 가능",
+        "description": f"🕒 {format_datetime()}\n정책: {policy_version}",
+        "color": COLORS["buy"],
+        "fields": [
+            {"name": "종목", "value": symbol, "inline": True},
+            {"name": "수량", "value": "\n".join(quantities), "inline": True},
+            {"name": "가격", "value": "\n".join(prices), "inline": True},
+            {"name": "사유", "value": thesis_summary, "inline": False},
+        ],
+    }
+
+
 def _base_toss_fields(
     symbol: str,
     korean_name: str,

--- a/app/monitoring/trade_notifier/notifier.py
+++ b/app/monitoring/trade_notifier/notifier.py
@@ -358,6 +358,44 @@ class TradeNotifier:
         )
         return delivered
 
+    async def send_auto_veto_card_mirror(
+        self,
+        *,
+        symbol: str,
+        market: str,
+        quantities: list[str],
+        prices: list[str],
+        thesis_summary: str,
+        policy_version: str,
+    ) -> bool:
+        """Send a Discord-only mirror of the Telegram auto-veto card.
+
+        This uses the existing market-routed Discord transport (the mbp-server
+        notification route) and intentionally never falls back to Telegram:
+        Telegram already owns the action card and its single-use veto button.
+        """
+        if not self._enabled:
+            return False
+        webhook_url = self._get_webhook_for_market_type(market)
+        if webhook_url is None:
+            return False
+        try:
+            embed = fmt_discord.format_auto_veto_card_mirror(
+                symbol=symbol,
+                quantities=quantities,
+                prices=prices,
+                thesis_summary=thesis_summary,
+                policy_version=policy_version,
+            )
+            return await self._send_to_discord_embed_single(embed, webhook_url)
+        except Exception:
+            logger.exception(
+                "Auto-veto Discord mirror failed: market=%s symbol=%s",
+                market,
+                symbol,
+            )
+            return False
+
     # ── public notify methods ──────────────────────────────────────────
 
     async def notify_buy_order(

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -73,6 +73,18 @@ _VETO_CAPABLE_ACCOUNT_MARKETS = frozenset(
         ("kis_live", "equity_kr"),
         ("kis_live", "equity_us"),
         ("upbit", "crypto"),
+        # TOSS-AUTO-FULL: this membership is *not* sufficient by itself.
+        # ``_is_veto_capable_account_market`` keeps both Toss surfaces
+        # default-disabled behind the independently armed setting below.
+        ("toss_live", "equity_kr"),
+        ("toss_live", "equity_us"),
+    }
+)
+
+_TOSS_LIVE_VETO_ACCOUNT_MARKETS = frozenset(
+    {
+        ("toss_live", "equity_kr"),
+        ("toss_live", "equity_us"),
     }
 )
 
@@ -140,6 +152,34 @@ def _decimal(value: Any) -> Decimal | None:
 def _text(value: Decimal) -> str:
     normalized = format(value.normalize(), "f")
     return normalized.rstrip("0").rstrip(".") if "." in normalized else normalized
+
+
+def auto_veto_thesis_summary(group: Any) -> str | None:
+    """Return the mandatory, bounded thesis for an auto-veto card.
+
+    A strategy label is not a thesis: accepting it as a fallback would turn a
+    missing reason into a seemingly complete cancellation card.  The caller
+    must route the proposal to ordinary human approval whenever this returns
+    ``None``.
+    """
+    thesis = getattr(group, "thesis", None)
+    if not isinstance(thesis, str):
+        return None
+    normalized = " ".join(thesis.split())
+    if not normalized:
+        return None
+    return normalized[:119] + "…" if len(normalized) > 120 else normalized
+
+
+def _is_veto_capable_account_market(account_mode: Any, market: Any) -> bool:
+    candidate = (account_mode, market)
+    if candidate not in _VETO_CAPABLE_ACCOUNT_MARKETS:
+        return False
+    if candidate in _TOSS_LIVE_VETO_ACCOUNT_MARKETS:
+        # The live Toss expansion is explicitly a second gate.  The default is
+        # false, including when the master auto-approve gate is switched on.
+        return bool(settings.ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED)
+    return True
 
 
 def limits_for_market(market: str) -> AutoApproveLimits | None:
@@ -289,10 +329,10 @@ def evaluate_auto_approve_eligibility(
         return reject("loss_cut_intent")
     if exit_intent is not None:
         return reject("exit_intent_present", exit_intent=str(exit_intent))
-    if (
+    if not _is_veto_capable_account_market(
         getattr(group, "account_mode", None),
         getattr(group, "market", None),
-    ) not in _VETO_CAPABLE_ACCOUNT_MARKETS:
+    ):
         return reject("account_not_veto_capable")
     # Applied in both modes: this can only ever reject.
     tags = find_approval_required_tags(group)
@@ -387,6 +427,14 @@ def evaluate_auto_approve_eligibility(
                 )
             loss_guard = "net_profit_proven"
 
+    if auto_veto_thesis_summary(group) is None:
+        # The post-submit card must name the decision reason.  This sits after
+        # every existing safety classifier so missing prose never masks a
+        # stronger reason (loss-cut, cap, marketability, tag, or unknown
+        # classification), while an otherwise eligible order still cannot
+        # reach the broker with an unrenderable veto card.
+        return reject("thesis_required_for_veto_card")
+
     return AutoApproveDecision(
         True,
         "eligible",
@@ -429,13 +477,20 @@ def build_auto_approved_message(
         f"- 종목: `{_escape_inline_code(group.symbol)}`",
         f"- 방향: `{_escape_inline_code(group.side)}`",
     ]
-    for rung in sorted(rungs, key=lambda item: item.rung_index):
-        lines.append(f"- #{rung.rung_index + 1}: {rung.quantity} × {rung.limit_price}")
-    rationale = " ".join(str(group.thesis or group.strategy or "근거 미기재").split())
-    if len(rationale) > 120:
-        rationale = rationale[:119] + "…"
+    ordered_rungs = sorted(rungs, key=lambda item: item.rung_index)
+    quantities = ", ".join(
+        f"#{rung.rung_index + 1} {rung.quantity}" for rung in ordered_rungs
+    )
+    prices = ", ".join(
+        f"#{rung.rung_index + 1} {rung.limit_price}" for rung in ordered_rungs
+    )
+    rationale = auto_veto_thesis_summary(group)
+    if rationale is None:
+        raise ValueError("auto-veto card requires a non-empty thesis")
     lines.extend(
         [
+            f"- 수량: {quantities}",
+            f"- 가격: {prices}",
             f"- 근거: {_escape_markdown(rationale)}",
             f"- `auto:policy@{policy_version}`",
         ]
@@ -449,6 +504,7 @@ __all__ = [
     "AutoApproveDecision",
     "AutoApproveLimits",
     "SellProfitVerdict",
+    "auto_veto_thesis_summary",
     "build_auto_approved_message",
     "classify_sell_profit",
     "evaluate_auto_approve_eligibility",

--- a/app/services/order_proposals/auto_veto.py
+++ b/app/services/order_proposals/auto_veto.py
@@ -12,8 +12,84 @@ from app.services.order_proposals.service import OrderProposalsService
 
 TargetCancelFn = Callable[..., Any]
 TargetFetchFn = Callable[..., Any]
+TossVetoReconcileFn = Callable[..., Any]
 
 _CANCELLABLE_STATES = frozenset({"acked", "resting", "partially_filled", "unverified"})
+
+
+async def reconcile_toss_auto_veto_terminal(
+    *,
+    order_id: str,
+    symbol: str,
+    market: str,
+    account_mode: str,
+) -> dict[str, Any]:
+    """Reconcile a Toss veto only after the broker reports the original closed.
+
+    Toss's cancel acknowledgement is a *request* and carries a replacement
+    order id.  It is not terminal evidence for the original order.  This
+    helper intentionally asks the evidence-backed Toss reconciler to close the
+    original order in the ledger and only returns ``confirmed=True`` when the
+    reconciliation result itself names that original order as cancelled.
+
+    It is invoked by the runtime veto path, never by the offline fixtures.  A
+    failure to find this proof deliberately leaves the proposal rung open and
+    reports a cancellation failure to the operator.
+    """
+    if account_mode != "toss_live":
+        return {"confirmed": True, "skipped": "not_toss_live"}
+    toss_market = {"equity_kr": "kr", "equity_us": "us"}.get(market)
+    if toss_market is None:
+        return {
+            "confirmed": False,
+            "error": "toss_veto_market_unrecognized",
+        }
+
+    # Import inside the rare mutation path so normal proposal classification
+    # stays isolated from the Toss MCP-tool registration modules.
+    from app.mcp_server.tooling.toss_live_ledger import toss_reconcile_orders_impl
+
+    report = await toss_reconcile_orders_impl(
+        symbol=symbol,
+        order_id=order_id,
+        market=toss_market,
+        dry_run=False,
+        limit=10,
+        project_proposal_rungs=False,
+    )
+    matches = [
+        item
+        for item in report.get("reconciled", [])
+        if item.get("order_id") == order_id
+        and item.get("local_status") == "cancelled"
+        and item.get("action") in {"marked_cancelled", "booked", "noop_already_booked"}
+    ]
+    if not matches:
+        # A previous reconcile may already have closed the original ledger row,
+        # in which case it is no longer in the open-row worklist this targeted
+        # pass scans.  Read only the evidence-stamped original `place` row;
+        # a cancel replacement acknowledgement cannot satisfy this lookup.
+        from app.mcp_server.tooling.kis_live_ledger import _order_session_factory
+        from app.services.toss_live_order_ledger_service import (
+            TossLiveOrderLedgerService,
+        )
+
+        async with _order_session_factory()() as db:
+            terminal_status = await TossLiveOrderLedgerService(
+                db
+            ).reconciled_terminal_status_for_place_order(broker_order_id=order_id)
+        if terminal_status == "cancelled":
+            return {
+                "confirmed": True,
+                "reconciled_order_count": 1,
+                "confirmed_from": "existing_terminal_ledger_reconcile",
+                "error": None,
+            }
+    return {
+        "confirmed": bool(matches),
+        "reconciled_order_count": len(matches),
+        "error": None if matches else "toss_terminal_reconcile_unconfirmed",
+    }
 
 
 async def acquire_auto_veto_locks(
@@ -42,6 +118,7 @@ async def cancel_auto_submitted_rungs(
     now: datetime,
     cancel_fn: TargetCancelFn,
     fetch_fn: TargetFetchFn,
+    toss_reconcile_fn: TossVetoReconcileFn = reconcile_toss_auto_veto_terminal,
 ) -> list[dict[str, Any]]:
     """Request cancel, then converge each rung only from fresh broker status."""
     outcomes: list[dict[str, Any]] = []
@@ -92,13 +169,57 @@ async def cancel_auto_submitted_rungs(
             cancel_error = cancel_error or str(exc)
 
         if status == "cancelled":
+            # `fetch_fn` is the first required broker-terminal observation.
+            # Toss requires a second, independent ledger reconciliation for
+            # the *original* broker id before a local rung may say cancelled.
+            reconcile: dict[str, Any] | None = None
+            if group.account_mode == "toss_live":
+                try:
+                    raw_reconcile = await toss_reconcile_fn(
+                        order_id=rung.broker_order_id,
+                        symbol=group.symbol,
+                        market=group.market,
+                        account_mode=group.account_mode,
+                    )
+                    reconcile = (
+                        raw_reconcile
+                        if isinstance(raw_reconcile, dict)
+                        else {"confirmed": False, "error": "invalid_reconcile_result"}
+                    )
+                except Exception as exc:  # noqa: BLE001 - evidence is mandatory
+                    reconcile = {
+                        "confirmed": False,
+                        "error": str(exc) or exc.__class__.__name__,
+                    }
+                if reconcile.get("confirmed") is not True:
+                    outcomes.append(
+                        {
+                            "rung_index": rung.rung_index,
+                            "result": "cancel_failed",
+                            "broker_status": status,
+                            "terminal_confirmation": "toss_ledger_reconcile_required",
+                            "reconcile": reconcile,
+                            "error": "toss_terminal_reconcile_unconfirmed",
+                        }
+                    )
+                    continue
             await service.record_cancelled(
                 group.proposal_id,
                 rung.rung_index,
                 broker_order_id=rung.broker_order_id,
                 now=now,
             )
-            outcomes.append({"rung_index": rung.rung_index, "result": "cancelled"})
+            outcome: dict[str, Any] = {
+                "rung_index": rung.rung_index,
+                "result": "cancelled",
+                "terminal_confirmation": "broker_cancelled",
+            }
+            if reconcile is not None:
+                outcome["reconcile"] = reconcile
+                outcome["terminal_confirmation"] = (
+                    "broker_terminal_and_toss_ledger_reconciled"
+                )
+            outcomes.append(outcome)
         elif status == "filled":
             await service.transition_rung(
                 group.proposal_id,
@@ -125,6 +246,8 @@ async def cancel_auto_submitted_rungs(
 __all__ = [
     "TargetCancelFn",
     "TargetFetchFn",
+    "TossVetoReconcileFn",
     "acquire_auto_veto_locks",
     "cancel_auto_submitted_rungs",
+    "reconcile_toss_auto_veto_terminal",
 ]

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -43,6 +43,7 @@ from app.services.order_proposals.approval_window import (
     recheck_approval_window_decision,
 )
 from app.services.order_proposals.auto_approve import (
+    auto_veto_thesis_summary,
     build_auto_approved_message,
     evaluate_auto_approve_eligibility,
     limits_for_market,
@@ -50,8 +51,10 @@ from app.services.order_proposals.auto_approve import (
 from app.services.order_proposals.auto_veto import (
     TargetCancelFn,
     TargetFetchFn,
+    TossVetoReconcileFn,
     acquire_auto_veto_locks,
     cancel_auto_submitted_rungs,
+    reconcile_toss_auto_veto_terminal,
 )
 from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
@@ -82,6 +85,62 @@ logger = logging.getLogger(__name__)
 ServiceFactory = Callable[[], Any]
 RevalidateFn = Callable[..., Any]
 Clock = Callable[[], datetime]
+
+
+def _mirror_decimal_text(value: Any) -> str:
+    """Keep Discord card quantities/prices legible after DB numeric coercion."""
+    try:
+        normalized = format(Decimal(str(value)).normalize(), "f")
+    except Exception:  # noqa: BLE001 - display degradation must not raise
+        return str(value)
+    return normalized.rstrip("0").rstrip(".") if "." in normalized else normalized
+
+
+async def _mirror_auto_veto_card(
+    *,
+    notifier: Any,
+    group: Any,
+    rungs: list[Any],
+    policy_version: str,
+) -> bool:
+    """Mirror the already-published auto-veto card through TradeNotifier.
+
+    Telegram remains the action surface.  The Discord delivery is a best-effort
+    operational mirror and cannot turn an otherwise valid order into a false
+    cancellation state.  A missing thesis is treated as a failed mirror too,
+    although the eligibility gate prevents that case before broker submit.
+    """
+    thesis_summary = auto_veto_thesis_summary(group)
+    if thesis_summary is None:
+        logger.error(
+            "order_proposals.auto_veto_discord_mirror_skipped_missing_thesis",
+            extra={"proposal_id": str(group.proposal_id)},
+        )
+        return False
+    sender = getattr(notifier, "send_auto_veto_card_mirror", None)
+    if not callable(sender):
+        logger.warning(
+            "order_proposals.auto_veto_discord_mirror_unavailable",
+            extra={"proposal_id": str(group.proposal_id)},
+        )
+        return False
+    try:
+        return bool(
+            await sender(
+                symbol=group.symbol,
+                market=group.market,
+                quantities=[_mirror_decimal_text(rung.quantity) for rung in rungs],
+                prices=[_mirror_decimal_text(rung.limit_price) for rung in rungs],
+                thesis_summary=thesis_summary,
+                policy_version=policy_version,
+            )
+        )
+    except Exception:  # noqa: BLE001 - an alert mirror cannot roll back a card
+        logger.exception(
+            "order_proposals.auto_veto_discord_mirror_failed",
+            extra={"proposal_id": str(group.proposal_id)},
+        )
+        return False
 
 
 def _generate_nonce() -> str:
@@ -568,6 +627,7 @@ async def dispatch_proposal(
     revalidate_fn: RevalidateFn = revalidate_and_submit,
     cancel_target_fn: TargetCancelFn = cancel_target_order,
     fetch_target_fn: TargetFetchFn = fetch_target_order,
+    toss_veto_reconcile_fn: TossVetoReconcileFn = reconcile_toss_auto_veto_terminal,
     window_evaluator: WindowEvaluator | None = None,
     now_fn: Clock | None = None,
 ) -> TelegramDispatchResult | ApprovalWindowDecision:
@@ -586,6 +646,8 @@ async def dispatch_proposal(
     auto_submitted = False
     messages: ApprovalDispatchMessages | None = None
     attempt_id: uuid.UUID | None = None
+    mirror_card: tuple[Any, list[Any], str] | None = None
+    auto_policy_version: str | None = None
     async with service_factory() as session:
         service = OrderProposalsService(session)
         await service.acquire_auto_dispatch_lock(proposal_id)
@@ -617,6 +679,23 @@ async def dispatch_proposal(
             )
         limits = limits_for_market(group.market)
         decisions: list[dict[str, Any]] = []
+        if limits is not None and group.account_mode == "toss_live":
+            toss_freeze = await service.active_toss_auto_submission_freeze(
+                group, now=gate_now
+            )
+            if toss_freeze is not None:
+                # A verified Toss fill closes the same-session auto lane.  Do
+                # not even enter revalidation (which can reach a broker) here;
+                # the ordinary approval card is the intentional fail-closed
+                # continuation while the operator considers a cancel proposal.
+                limits = None
+        if limits is not None and auto_veto_thesis_summary(group) is None:
+            # This is deliberately outside the revalidation callback.  The
+            # production callback consults the same gate, but this second
+            # boundary prevents a future revalidation regression from
+            # submitting first and discovering an unrenderable veto card only
+            # after the broker accepted it.
+            limits = None
         if limits is not None:
             daily_notional = await service.auto_approved_daily_notional(group, now=now)
 
@@ -661,6 +740,7 @@ async def dispatch_proposal(
                 and all(outcome.result in submitted_results for outcome in outcomes)
             )
             if auto_submitted:
+                auto_policy_version = limits.policy_version
                 await service.record_auto_approval(
                     proposal_id,
                     policy_version=limits.policy_version,
@@ -751,6 +831,7 @@ async def dispatch_proposal(
                 now=now,
                 cancel_fn=cancel_target_fn,
                 fetch_fn=fetch_target_fn,
+                toss_reconcile_fn=toss_veto_reconcile_fn,
             )
             await service.record_auto_notification_failure(
                 proposal_id,
@@ -758,7 +839,22 @@ async def dispatch_proposal(
                 outcomes=outcomes,
                 now=now,
             )
+        elif result.state is ApprovalDispatchState.SENT_CURRENT:
+            group, rungs = await service.get_proposal(proposal_id)
+            # This branch is reachable only after `auto_submitted` above set
+            # the policy version.  Keep the guard defensive so a future
+            # refactor cannot emit an unversioned mirror card.
+            if auto_policy_version is not None:
+                mirror_card = (group, rungs, auto_policy_version)
         await session.commit()
+    if mirror_card is not None:
+        group, rungs, policy_version = mirror_card
+        await _mirror_auto_veto_card(
+            notifier=notifier,
+            group=group,
+            rungs=rungs,
+            policy_version=policy_version,
+        )
     return result
 
 

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -139,6 +139,22 @@ class OrderProposalRepository:
         value = (await self._session.execute(stmt)).scalar_one()
         return Decimal(value)
 
+    async def list_groups_for_toss_auto_submission_freeze(
+        self,
+        *,
+        broker_account_id: str | None,
+    ) -> list[OrderProposal]:
+        """Return one Toss account's auto groups for a same-day freeze."""
+        stmt = select(OrderProposal).where(
+            OrderProposal.account_mode == "toss_live",
+            OrderProposal.source_asof.op("?")("auto_approved"),
+        )
+        if broker_account_id is None:
+            stmt = stmt.where(OrderProposal.broker_account_id.is_(None))
+        else:
+            stmt = stmt.where(OrderProposal.broker_account_id == broker_account_id)
+        return list((await self._session.execute(stmt)).scalars().all())
+
     async def acquire_auto_approve_lock(self, lock_key: str) -> None:
         """Serialize an auto-approval critical section until transaction commit."""
         await self._session.execute(

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -76,6 +76,8 @@ from app.services.trade_journal.trade_retrospective_service import (
 
 logger = logging.getLogger(__name__)
 
+_TOSS_AUTO_SUBMISSION_FREEZE_KEY = "toss_auto_submission_freeze"
+
 
 def _log_dispatch_outcome(result: TelegramDispatchResult, *, surface: str) -> None:
     logger.log(
@@ -2524,6 +2526,84 @@ class OrderProposalsService:
         source_asof["auto_approved"] = auto
         return await self._repo.update_group(group, source_asof=source_asof)
 
+    @staticmethod
+    def _toss_auto_freeze_lock_key(group: OrderProposal, *, now: datetime) -> str:
+        account_key = group.broker_account_id or "default"
+        return (
+            "order_proposals:toss_auto_submission_freeze:"
+            f"{account_key}:{now.astimezone(KST).date()}"
+        )
+
+    async def active_toss_auto_submission_freeze(
+        self, group: OrderProposal, *, now: datetime
+    ) -> dict[str, Any] | None:
+        """Return a current-session fill freeze for this Toss account/market.
+
+        Any confirmed Toss fill blocks further automatic submission across the
+        account until the next KST session.  This is intentionally broader
+        than the separate KRW/USD cap lanes: an unresolved partial fill and
+        its cancellation proposal are an account-level operational event.
+        Human approval remains available.
+        """
+        self._require_timezone_aware(now)
+        if group.account_mode != "toss_live":
+            return None
+        await self._repo.acquire_auto_approve_lock(
+            self._toss_auto_freeze_lock_key(group, now=now)
+        )
+        session_date = now.astimezone(KST).date().isoformat()
+        candidates = await self._repo.list_groups_for_toss_auto_submission_freeze(
+            broker_account_id=group.broker_account_id,
+        )
+        for candidate in candidates:
+            auto = (candidate.source_asof or {}).get("auto_approved")
+            freeze = (
+                auto.get(_TOSS_AUTO_SUBMISSION_FREEZE_KEY)
+                if isinstance(auto, dict)
+                else None
+            )
+            if (
+                isinstance(freeze, dict)
+                and freeze.get("state") == "frozen"
+                and freeze.get("session_date") == session_date
+            ):
+                return dict(freeze)
+        return None
+
+    async def _freeze_toss_auto_submission_on_fill(
+        self,
+        group: OrderProposal,
+        *,
+        filled_qty: Decimal | None,
+        now: datetime,
+    ) -> None:
+        """Durably stop same-session Toss auto entries after verified fill proof."""
+        if group.account_mode != "toss_live" or filled_qty is None or filled_qty <= 0:
+            return
+        source_asof = dict(group.source_asof or {})
+        auto = source_asof.get("auto_approved")
+        if not isinstance(auto, dict):
+            # A human-approved Toss order must not mutate the auto-submission
+            # control plane merely because it filled.
+            return
+        await self._repo.acquire_auto_approve_lock(
+            self._toss_auto_freeze_lock_key(group, now=now)
+        )
+        auto = dict(auto)
+        existing = auto.get(_TOSS_AUTO_SUBMISSION_FREEZE_KEY)
+        if isinstance(existing, dict) and existing.get("state") == "frozen":
+            return
+        auto[_TOSS_AUTO_SUBMISSION_FREEZE_KEY] = {
+            "state": "frozen",
+            "reason": "broker_fill_evidence",
+            "filled_qty": str(filled_qty),
+            "frozen_at": now.isoformat(),
+            "session_date": now.astimezone(KST).date().isoformat(),
+            "market": group.market,
+        }
+        source_asof["auto_approved"] = auto
+        await self._repo.update_group(group, source_asof=source_asof)
+
     async def auto_approved_daily_notional(
         self, group: OrderProposal, *, now: datetime
     ) -> Decimal:
@@ -2718,6 +2798,11 @@ class OrderProposalsService:
         audit: dict[str, Any] = {"updated_at": now}
         if filled_qty is not None:
             audit["filled_qty"] = filled_qty
+        await self._freeze_toss_auto_submission_on_fill(
+            group,
+            filled_qty=filled_qty,
+            now=now,
+        )
         if locked.state == terminal_state:
             # Repeated non-terminal evidence (e.g. a larger partial fill on an
             # already-partially_filled rung): refresh audit fields in place
@@ -2864,6 +2949,11 @@ class OrderProposalsService:
         audit: dict[str, Any] = {"updated_at": now}
         if filled_qty is not None:
             audit["filled_qty"] = filled_qty
+        await self._freeze_toss_auto_submission_on_fill(
+            group,
+            filled_qty=filled_qty,
+            now=now,
+        )
         return await self._transition_locked_rung(
             group, locked, new_state=terminal_state, **audit
         )

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -78,8 +78,10 @@ from app.services.order_proposals.approval_window import (
 from app.services.order_proposals.auto_veto import (
     TargetCancelFn,
     TargetFetchFn,
+    TossVetoReconcileFn,
     acquire_auto_veto_locks,
     cancel_auto_submitted_rungs,
+    reconcile_toss_auto_veto_terminal,
 )
 from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
@@ -545,6 +547,7 @@ async def _handle_auto_veto(
     telegram_user_id: str,
     cancel_fn: TargetCancelFn,
     fetch_fn: TargetFetchFn,
+    toss_reconcile_fn: TossVetoReconcileFn = reconcile_toss_auto_veto_terminal,
 ) -> dict[str, Any]:
     """Cancel every still-open auto-submitted rung and converge evidence."""
     preflight_failure = await _preflight_proposal_callback(
@@ -577,6 +580,7 @@ async def _handle_auto_veto(
         now=now,
         cancel_fn=cancel_fn,
         fetch_fn=fetch_fn,
+        toss_reconcile_fn=toss_reconcile_fn,
     )
     saw_filled = any(outcome["result"] == "filled" for outcome in outcomes)
     saw_failure = any(
@@ -1626,6 +1630,7 @@ async def handle_callback_update(
     loss_cut_preview_fn: RevalidateFn | None = None,
     veto_cancel_fn: TargetCancelFn = cancel_target_order,
     veto_fetch_fn: TargetFetchFn = fetch_target_order,
+    veto_toss_reconcile_fn: TossVetoReconcileFn = reconcile_toss_auto_veto_terminal,
     window_evaluator: WindowEvaluator | None = None,
     now_fn: Clock | None = None,
 ) -> dict[str, Any]:
@@ -1702,6 +1707,7 @@ async def handle_callback_update(
                     ),
                     cancel_fn=veto_cancel_fn,
                     fetch_fn=veto_fetch_fn,
+                    toss_reconcile_fn=veto_toss_reconcile_fn,
                 )
             elif callback.action == "dn":
                 result = await _handle_deny(

--- a/app/services/toss_live_order_ledger_service.py
+++ b/app/services/toss_live_order_ledger_service.py
@@ -260,6 +260,31 @@ class TossLiveOrderLedgerService:
             self._db.expunge(row)
         return rows
 
+    async def reconciled_terminal_status_for_place_order(
+        self, *, broker_order_id: str
+    ) -> str | None:
+        """Return only evidence-backed terminal state for one original order.
+
+        A Toss cancel request creates a separate replacement ledger row and
+        leaves the original `place` row open.  This narrow read lets an
+        auto-veto caller recognize a prior completed reconciliation without
+        treating a cancel-request acknowledgement as a terminal result.
+        """
+        stmt = select(
+            TossLiveOrderLedger.status,
+            TossLiveOrderLedger.reconciled_at,
+        ).where(
+            TossLiveOrderLedger.broker_order_id == broker_order_id,
+            TossLiveOrderLedger.operation_kind == "place",
+        )
+        row = (await self._db.execute(stmt)).one_or_none()
+        if row is None:
+            return None
+        status, reconciled_at = row
+        if status != "cancelled" or reconciled_at is None:
+            return None
+        return str(status)
+
     async def list_terminal_projection_candidates(
         self,
         *,

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -34,16 +34,23 @@ posture:
 
 # ROB-871 — master-gated by ORDER_PROPOSALS_AUTO_APPROVE=false. Caps use the
 # settlement currency for each market (KRW for kr/crypto, USD for us).
+# TOSS-AUTO-FULL (§51): KR per-order uses the upper bound of
+# ``buy.per_symbol_notional_krw_range`` [200000, 400000]; US uses the upper
+# bound of ``buy.per_symbol_notional_usd_range`` [150, 450].  The daily cap is
+# that upper bound × the one-new-entry limit stated at
+# ``user_stances[0].implications[0]`` ("동시 신규 최대 1종목"), hence KRW
+# 400000 and USD 450.  This comment intentionally records the derivation
+# without touching the separately owned buy/sell policy tiers.
 order_proposals:
   auto_approve:
     min_distance_pct: 3
     per_order_cap:
-      kr: 200000
-      us: 150
+      kr: 400000
+      us: 450
       crypto: 100000
     daily_cap:
-      kr: 500000
-      us: 400
+      kr: 400000
+      us: 450
       crypto: 300000
     # AUTO-APPROVE-EXPAND (§40차) — inputs to the profit-take classification,
     # consumed only when ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded.

--- a/docs/runbooks/order-proposal-auto-approve-expand.md
+++ b/docs/runbooks/order-proposal-auto-approve-expand.md
@@ -86,11 +86,12 @@ a tightening of ROB-871, not a widening.
 ## 4. Fee rate provenance
 
 `round_trip_cost_bps` is **not a measured rate**, and there is currently no way
-to make it one from inside this repo: the two veto-capable ledgers
-(`review.kis_live_order_ledger`, `review.live_order_ledger`) have no
+to make it one from inside this repo: the two default-active veto-capable
+ledgers (`review.kis_live_order_ledger`, `review.live_order_ledger`) have no
 `commission`/`tax` columns, so no realized fee evidence exists for `kis_live`
-or `upbit`. Only `review.toss_live_order_ledger` records commission and tax,
-and `toss_live` is not veto-capable.
+or `upbit`. `review.toss_live_order_ledger` records commission and tax;
+`toss_live` remains non-veto-capable by default and is eligible only after the
+separate, default-off TOSS-AUTO-FULL gate and its acceptance procedure.
 
 Until that changes, the values are the **conservative maximum of the rates this
 repo already declares**, so the profit-take test is narrower than reality:
@@ -143,3 +144,8 @@ Not part of the introducing change. When the time comes:
 3. Roll back by setting the mode back to `off`. Orders already submitted are
    unaffected — cancel those through the veto button or
    `order_proposal_cancel`.
+
+These generic gates do not arm Toss. The separately default-off
+`ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED` gate, terminal-evidence acceptance,
+and rollback sequence are operator-only and documented in
+`docs/runbooks/toss-auto-acceptance.md`.

--- a/docs/runbooks/toss-auto-acceptance.md
+++ b/docs/runbooks/toss-auto-acceptance.md
@@ -1,0 +1,152 @@
+# Toss 자동 제출 acceptance — 운영자 전용
+
+> TOSS-AUTO-FULL의 live acceptance 절차다. 이 문서는 운영자만 실행한다.
+> 개발/검증 워커는 이 절차의 명령, MCP 도구, 계좌 읽기·주문·취소를 실행하지 않는다.
+
+## 범위와 중단 원칙
+
+이 acceptance는 Toss 실계좌에서 최소 1주 단위의 비시장성(limit) 주문을 사용한다. 자동
+매수와 post-submit 취소가 실제로 일어나므로, 아래의 **A와 B 모두** 독립 검증 서명 후에만
+Toss auto-veto 게이트를 상시 활성화할 수 있다. veto는 사전 승인이 아니라 사후 취소권이다.
+
+다음 중 하나라도 발생하면 즉시 더 이상의 자동 주문을 중단한다.
+
+- 원 주문 ID의 Toss broker terminal 상태가 `CANCELLED`로 확인되지 않는다.
+- `toss_reconcile_orders(order_id=<원 주문 ID>, dry_run=False)`가 원 주문을 `cancelled`로
+  수렴시키지 못한다.
+- Telegram 카드 또는 Discord 미러에서 종목·수량·가격·사유 중 하나라도 빠진다.
+- 예상 밖 체결, 부분 체결 수량 불일치, stale snapshot, ledger anomaly, Discord/Telegram
+  전달 실패가 발생한다.
+
+중단은 성공으로 해석하지 않는다. 원 주문과 cancel replacement ID, proposal ID, Telegram
+message ID, reconcile 원문을 보존하고 `NEEDS_VERIFY`로 올린다.
+
+## 사전 조건
+
+1. 이 PR의 오프라인 fixture를 먼저 실행한다.
+
+   ```bash
+   uv run python scripts/toss_auto_acceptance_fixture.py --offline-fixture
+   ```
+
+   이 명령은 pytest fixture만 실행하며 broker/account/MCP에 접촉하지 않는다.
+
+2. 독립 검증자가 A/B fixture, 손절·캡·terminal mutant 결과를 검토하고 서명한다. 새 scheduler,
+   cron, 배포 자동화는 이 절차의 일부가 아니다.
+
+3. 운영자만 기존 비밀 관리 경로에서 필요한 Toss/Telegram/Discord 설정을 확인한다. 값은 콘솔,
+   티켓, PR에 출력하지 않는다. 최소한 다음 gate가 의도적으로 arm되어 있어야 한다.
+
+   - `ORDER_PROPOSALS_ENABLED=true`
+   - `ORDER_PROPOSALS_TELEGRAM_ENABLED=true`
+   - `ORDER_PROPOSALS_AUTO_APPROVE=true`
+   - `ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded` (acceptance 목적일 때만)
+   - `ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED=true`
+   - `TOSS_API_ENABLED=true`, `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true`
+
+   마지막 Toss gate는 broker mutation을 허용한다. 이 작업 트리는 모두 기본 `false`이며,
+   운영자 외에는 arm하지 않는다.
+
+4. 실행 계좌/통화/세션을 한 개만 지정하고, 해당 Toss account에 이미
+   `toss_auto_submission_freeze`가 없는지 확인한다. 있으면 자동 acceptance를 시작하지 말고
+   기존 주문을 terminal/reconcile까지 처리한다. acceptance 주문은 반드시 사유(thesis)를
+   포함하며, 현재가보다 충분히 아래인 매수 또는 위인 매도 limit으로 둔다. 시장가·시장성
+   가격·손절(`loss_cut`)·본전 경계·`policy_deviation`/`table_disagreement` 태그는 사용하지
+   않는다.
+
+5. Discord mbp-server notification route의 해당 KR/US webhook을 확인한다. 이 구현은 새
+   webhook client를 만들지 않고 `app/monitoring/trade_notifier/`의 market-routed
+   `send_auto_veto_card_mirror`를 사용한다.
+
+## Acceptance A — post-submit veto의 실취소와 reconcile
+
+1. 지정 계좌에서 최소 금액의 **1주**, 비시장성 Toss limit `place` proposal을 생성한다.
+   thesis는 한 문장 이상으로 명시한다. 자동 접수 Telegram 카드와 Discord mirror가 모두
+   다음 필드를 보이는지 캡처한다.
+
+   - 종목
+   - 수량
+   - 가격
+   - 사유(thesis 요약)
+
+2. card의 `취소`를 한 번만 누른다. 반환되는 cancel replacement ID는 기록하되, 성공 근거로
+   쓰지 않는다. Toss cancel 응답은 **요청 수락**일 뿐 원 주문의 terminal 증거가 아니다.
+
+3. 원 주문 ID를 대상으로 Toss closed order evidence를 읽어 `CANCELLED`를 확인한다. 이어서
+   다음을 실행한다.
+
+   ```text
+   toss_reconcile_orders(order_id=<원 주문 ID>, dry_run=False)
+   ```
+
+   합격 기준은 결과가 **원 주문 ID**를 가리키며 `local_status=cancelled` 및
+   `action=marked_cancelled|booked|noop_already_booked`인 것이다. replacement ID만
+   `cancelled`인 결과, cancel 요청 success, 혹은 dry-run 결과는 불합격이다.
+
+4. proposal rung과 Toss live ledger가 모두 원 주문 terminal 상태로 닫혔는지 확인한다. 어느
+   하나라도 불명확하면 gate를 끄고 §원복으로 간다.
+
+## Acceptance B — fill → 동결 → 취소 제안 → 지연 중 2차 체결 → terminal
+
+이 절차는 부분 체결을 억지로 만들기 위해 시장성 주문을 내지 않는다. 관찰 가능한 자연
+부분 체결이 없으면 실패가 아니라 **미실행**이며, gate를 유지하지 않고 다음 적합한 세션으로
+재예약한다.
+
+1. 최소 금액 1주의 비시장성 auto proposal을 한 개만 제출한다. Toss evidence로 첫 부분 체결을
+   확인한 뒤 `toss_reconcile_orders(order_id=<원 주문 ID>, dry_run=False)`로 수렴시킨다.
+   해당 Toss account는 `toss_auto_submission_freeze` 상태가 되어야 하며, 새 자동 entry는
+   ordinary human-approval card로 fallback해야 한다.
+
+2. 현재 원 주문의 `remaining_quantity`를 fresh broker snapshot으로 읽어 `action="cancel"`
+   proposal을 생성한다. snapshot의 원 주문 ID·종목·side·limit price·remaining quantity가
+   proposal rung과 정확히 일치해야 한다. Telegram 승인 카드는 여기서 **누르지 않고 대기**한다.
+
+3. 승인 대기 중 원 주문의 **2차 체결**을 Toss broker evidence에서 관찰한다. 누적 체결 및
+   remaining quantity를 reconcile로 수렴시킨다. 이 단계가 없으면 B는 합격할 수 없다.
+
+4. 오래된 cancel card를 승인한다. stale `remaining_quantity` snapshot 때문에 cancellation
+   mutation 전에 거절되어야 한다. 원 주문을 취소한 것으로 기록하거나 자동 재시도하지 않는다.
+
+5. 2차 체결 후 fresh snapshot으로 새 cancel proposal을 만들고 사람이 승인한다. 원 주문의
+   terminal `CANCELLED` evidence를 얻은 뒤 다음 targeted reconcile을 실행한다.
+
+   ```text
+   toss_reconcile_orders(order_id=<원 주문 ID>, dry_run=False)
+   ```
+
+   proposal cancel rung과 original Toss ledger가 broker-terminal evidence로 닫혀야 B가
+   합격이다. 원 주문이 `FILLED`가 되면 취소 성공으로 바꾸지 말고 실제 체결 수량으로
+   수렴시켜 실패/재평가로 보고한다.
+
+## 캡 유도와 활성화 한계
+
+`config/trading_policy.yaml`의 `order_proposals.auto_approve` 블록은 다음 값을 사용한다.
+
+| 시장 | 주문당 상한 | 일일 상한 | 유도 |
+| --- | ---: | ---: | --- |
+| KR | KRW 400,000 | KRW 400,000 | `thresholds.buy.per_symbol_notional_krw_range.value=[200000,400000]`의 상단 × `user_stances[0].implications[0]`의 `동시 신규 최대 1종목` |
+| US | USD 450 | USD 450 | `thresholds.buy.per_symbol_notional_usd_range.value=[150,450]`의 상단 × `user_stances[0].implications[0]`의 `동시 신규 최대 1종목` |
+
+이는 정책 밴드의 상단과 일 신규 한도 1에서 기계적으로 나온 값이다. 다른 buy/sell tier를
+수정하거나 cap을 운영 중에 임의 조정하지 않는다. `loss_cut`, 예상 실현손익 `<= 0`, ±1%
+본전 경계, `policy_deviation`, `table_disagreement`, 분류 불가 항목은 계속 human approval
+전용이다.
+
+## 원복
+
+1. 자동 신규 제출을 먼저 끈다.
+
+   ```text
+   ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED=false
+   ORDER_PROPOSALS_AUTO_APPROVE=false
+   ```
+
+2. 아직 open인 원 주문은 기존 Toss 운영 절차로 broker terminal evidence를 확보한다. cancel
+   요청 성공만으로 local 상태를 `cancelled`로 쓰지 않는다.
+
+3. `toss_reconcile_orders(order_id=<원 주문 ID>, dry_run=False)`를 반복해 terminal ledger와
+   proposal rung을 수렴시킨다. evidence를 못 얻으면 local 상태를 열린/불확실로 유지하고
+   운영자 수동 검토로 넘긴다.
+
+4. acceptance artifacts와 실패 원문을 보존한다. Toss gate는 A와 B 모두 재검증될 때까지
+   기본 OFF로 둔다.

--- a/scripts/toss_auto_acceptance_fixture.py
+++ b/scripts/toss_auto_acceptance_fixture.py
@@ -1,0 +1,45 @@
+"""Run only the no-network TOSS-AUTO-FULL acceptance fixtures.
+
+This is deliberately *not* a live smoke command.  It has no broker imports,
+no account reads, and no mutation mode.  The separate operator runbook owns
+the two live acceptance procedures after independent verification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+
+_OFFLINE_TESTS = (
+    "tests/services/order_proposals/test_toss_auto_acceptance.py",
+    "tests/services/order_proposals/test_telegram_callback.py",
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--offline-fixture",
+        action="store_true",
+        help="run the injected, no-network acceptance fixtures",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.offline_fixture:
+        print(
+            "Refusing to run: this command has no live mode. "
+            "Pass --offline-fixture for the no-network test fixtures."
+        )
+        return 2
+    command = [sys.executable, "-m", "pytest", "-q", *_OFFLINE_TESTS]
+    print("Running offline-only TOSS-AUTO-FULL fixtures; no broker/account calls.")
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -74,6 +74,32 @@ async def _accepted(db_session, *, side: str = "buy", market: str = "us"):
     )
 
 
+async def test_original_place_terminal_lookup_requires_reconciled_cancel_evidence(
+    db_session,
+):
+    row = await _accepted(db_session, market="kr")
+    service = TossLiveOrderLedgerService(db_session)
+
+    assert (
+        await service.reconciled_terminal_status_for_place_order(
+            broker_order_id=row.broker_order_id
+        )
+        is None
+    )
+    await service.update_reconcile_outcome(
+        ledger_id=row.id,
+        status="cancelled",
+        broker_status="CANCELLED",
+    )
+
+    assert (
+        await service.reconciled_terminal_status_for_place_order(
+            broker_order_id=row.broker_order_id
+        )
+        == "cancelled"
+    )
+
+
 async def _seed_toss_resting_proposal(
     db_session, *, broker_order_id: str, correlation_id: str
 ):

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -10,9 +10,14 @@ import pytest
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.auto_approve import (
     AutoApproveLimits,
+    build_auto_approved_message,
     evaluate_auto_approve_eligibility,
     find_approval_required_tags,
     limits_for_market,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    build_proposal_dispatch_binding,
 )
 from app.services.order_proposals.service import RungInput
 
@@ -25,6 +30,7 @@ def _group(**overrides):
         "order_type": "limit",
         "action": "place",
         "exit_intent": None,
+        "thesis": "test thesis",
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -32,6 +38,7 @@ def _group(**overrides):
 
 def _rung(**overrides):
     values = {
+        "rung_index": 0,
         "side": "buy",
         "limit_price": Decimal("97000"),
         "quantity": Decimal("2"),
@@ -504,7 +511,112 @@ def test_shipped_default_mode_is_off(monkeypatch):
     from app.core.config import Settings
 
     assert Settings.model_fields["ORDER_PROPOSALS_AUTO_APPROVE_MODE"].default == "off"
+    assert (
+        Settings.model_fields["ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED"].default is False
+    )
     assert limits_for_market("equity_kr").mode == "off"
+
+
+def test_toss_live_requires_its_separate_default_off_veto_gate(monkeypatch):
+    from app.services.order_proposals import auto_approve as module
+
+    blocked = _evaluate(
+        group_overrides={"account_mode": "toss_live", "market": "equity_kr"},
+        limit_price=Decimal("99500"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+    monkeypatch.setattr(module.settings, "ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED", True)
+    allowed = _evaluate(
+        group_overrides={"account_mode": "toss_live", "market": "equity_kr"},
+        limit_price=Decimal("99500"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+
+    assert (blocked.eligible, blocked.reason) == (False, "account_not_veto_capable")
+    assert (allowed.eligible, allowed.reason) == (True, "eligible")
+
+
+def test_auto_veto_card_requires_a_thesis_not_a_strategy_fallback():
+    decision = _evaluate(
+        group_overrides={"thesis": "", "strategy": "mean_reversion"},
+        limit_price=Decimal("99500"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+
+    assert (decision.eligible, decision.reason) == (
+        False,
+        "thesis_required_for_veto_card",
+    )
+
+
+def test_auto_veto_card_has_symbol_quantity_price_and_thesis_fields():
+    group = _group(
+        proposal_id=uuid.uuid4(),
+        symbol="005930",
+        side="buy",
+        thesis="valuation dislocation",
+    )
+    binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce="fixture-nonce",
+        attempt_id=uuid.uuid4(),
+        card_kind=ApprovalCardKind.AUTO_VETO,
+        current_membership_revision=None,
+    )
+
+    text, _keyboard = build_auto_approved_message(
+        group=group,
+        rungs=[_rung(quantity=Decimal("2"), limit_price=Decimal("97000"))],
+        nonce="fixture-nonce",
+        policy_version="fixture-policy",
+        binding=binding,
+    )
+
+    assert "종목: `005930`" in text
+    assert "수량: #1 2" in text
+    assert "가격: #1 97000" in text
+    assert "근거: valuation dislocation" in text
+
+
+def test_auto_veto_card_raises_when_thesis_is_missing():
+    group = _group(
+        proposal_id=uuid.uuid4(),
+        symbol="005930",
+        side="buy",
+        thesis=" ",
+    )
+    binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce="fixture-nonce",
+        attempt_id=uuid.uuid4(),
+        card_kind=ApprovalCardKind.AUTO_VETO,
+        current_membership_revision=None,
+    )
+
+    with pytest.raises(ValueError, match="non-empty thesis"):
+        build_auto_approved_message(
+            group=group,
+            rungs=[_rung()],
+            nonce="fixture-nonce",
+            policy_version="fixture-policy",
+            binding=binding,
+        )
+
+
+def test_policy_caps_follow_the_declared_upper_bands_and_one_new_entry_limit():
+    kr = limits_for_market("equity_kr")
+    us = limits_for_market("equity_us")
+
+    assert kr is not None
+    assert us is not None
+    # policy buy.per_symbol_notional_krw_range=[200000,400000],
+    # buy.per_symbol_notional_usd_range=[150,450], and one concurrent new
+    # entry; see the ownership-minimal derivation comment in the cap block.
+    assert (kr.per_order_cap, kr.daily_cap) == (Decimal("400000"), Decimal("400000"))
+    assert (us.per_order_cap, us.daily_cap) == (Decimal("450"), Decimal("450"))
 
 
 def test_policy_cost_rate_cannot_be_edited_below_the_code_floor(monkeypatch):

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -57,6 +57,7 @@ class _FakeNotifier:
         self.sent_messages: list[tuple[str, dict | None, str]] = []
         self.parse_modes: list[str | None] = []
         self.edited_messages: list[tuple[str, int, str, dict | None]] = []
+        self.auto_veto_mirrors: list[dict] = []
         self._message_id = message_id
 
     async def send_approval_message(
@@ -92,6 +93,10 @@ class _FakeNotifier:
             error_classification=None,
             payload_chars=telegram_text_length(text),
         )
+
+    async def send_auto_veto_card_mirror(self, **kwargs):
+        self.auto_veto_mirrors.append(kwargs)
+        return True
 
 
 class _RaisingNotifier:
@@ -228,7 +233,7 @@ async def _seed_proposal(
     target_order_snapshot=None,
     rungs=None,
     broker_account_id=None,
-    thesis=None,
+    thesis="test thesis",
     strategy=None,
 ):
     service = OrderProposalsService(db_session)
@@ -803,6 +808,16 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     assert f"auto:policy@{loaded_policy_version}" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
+    assert notifier.auto_veto_mirrors == [
+        {
+            "symbol": "005930",
+            "market": "equity_kr",
+            "quantities": ["1"],
+            "prices": [str(limit_price)],
+            "thesis_summary": "resting entry",
+            "policy_version": loaded_policy_version,
+        }
+    ]
 
     async def duplicate_must_not_revalidate(**kwargs):
         raise AssertionError("an already-submitted proposal must not dispatch twice")
@@ -864,6 +879,43 @@ async def test_dispatch_auto_ineligible_degrades_to_human_approval(
         revalidate_fn=fake_revalidate,
     )
 
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "pending_approval"
+    assert "auto_approved" not in (refreshed.source_asof or {})
+
+
+@pytest.mark.asyncio
+async def test_missing_auto_veto_thesis_never_revalidates_or_submits(
+    monkeypatch, db_session
+):
+    """CARD_FIELDS: no thesis means manual approval before any broker edge."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(
+        db_session,
+        broker_account_id=f"missing-thesis-{uuid.uuid4()}",
+        thesis=" ",
+    )
+
+    async def must_not_revalidate(**_kwargs):
+        raise AssertionError("missing thesis must block before broker revalidation")
+
+    notifier = _FakeNotifier()
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=must_not_revalidate,
+    )
+
+    assert "주문 제안 승인" in notifier.sent_messages[-1][0]
     refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
         group.proposal_id
     )
@@ -1065,6 +1117,7 @@ async def test_auto_notify_failure_compensates_by_cancelling_live_order(
         side="buy",
         order_type="limit",
         proposer="p",
+        thesis="notification delivery compensation fixture",
         rungs=[RungInput(0, "buy", Decimal("1"), Decimal("97000"), None)],
     )
     await db_session.commit()

--- a/tests/services/order_proposals/test_dispatch_security_invariants.py
+++ b/tests/services/order_proposals/test_dispatch_security_invariants.py
@@ -1542,6 +1542,7 @@ async def test_auto_dispatch_compensates_only_current_failed_result(
         account_mode="kis_live",
         action="place",
         order_type="limit",
+        thesis="unit fixture thesis",
         valid_until=NOW + timedelta(minutes=5),
         approval_dispatch_membership_revision=None,
     )

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -1022,6 +1022,52 @@ async def test_toss_veto_terminal_reconcile_binds_the_original_order_id(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_toss_veto_terminal_reconcile_requires_cancelled_status_and_terminal_action(
+    monkeypatch, db_session
+):
+    """MUTANT-3b: original ID alone is not terminal cancellation proof."""
+    from app.mcp_server.tooling import kis_live_ledger, toss_live_ledger
+
+    order_id = f"nonterminal-original-{uuid.uuid4()}"
+
+    async def fake_impl(**_kwargs):
+        return {
+            "reconciled": [
+                {
+                    "order_id": order_id,
+                    "local_status": "resting",
+                    "action": "marked_cancelled",
+                },
+                {
+                    "order_id": order_id,
+                    "local_status": "cancelled",
+                    "action": "noop_pending",
+                },
+            ]
+        }
+
+    monkeypatch.setattr(toss_live_ledger, "toss_reconcile_orders_impl", fake_impl)
+    monkeypatch.setattr(
+        kis_live_ledger,
+        "_order_session_factory",
+        lambda: _session_factory(db_session),
+    )
+
+    result = await reconcile_toss_auto_veto_terminal(
+        order_id=order_id,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+    )
+
+    assert result == {
+        "confirmed": False,
+        "reconciled_order_count": 0,
+        "error": "toss_terminal_reconcile_unconfirmed",
+    }
+
+
+@pytest.mark.asyncio
 async def test_toss_veto_accepts_an_already_reconciled_original_terminal_row(
     monkeypatch, db_session
 ):

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -23,6 +23,7 @@ from app.services.order_proposals.approval_window import (
     SubmissionSessionEvidence,
     evaluate_approval_window,
 )
+from app.services.order_proposals.auto_veto import reconcile_toss_auto_veto_terminal
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
     ApprovalPublication,
@@ -249,16 +250,23 @@ async def _seed_proposal(db_session, *, nonce="nonce-abc123", symbol="A", rungs=
     return group
 
 
-async def _seed_auto_resting(db_session, *, nonce="veto-nonce"):
+async def _seed_auto_resting(
+    db_session,
+    *,
+    nonce="veto-nonce",
+    account_mode="kis_live",
+    market="equity_kr",
+):
     service = OrderProposalsService(db_session)
     now = datetime.now(UTC)
     group = await service.create_proposal(
         symbol="005930",
-        market="equity_kr",
-        account_mode="kis_live",
+        market=market,
+        account_mode=account_mode,
         side="buy",
         order_type="limit",
         proposer="p",
+        thesis="acceptance fixture thesis",
         rungs=[RungInput(0, "buy", Decimal("1"), Decimal("97000"), None)],
         source_asof={
             "auto_approved": {
@@ -864,6 +872,214 @@ async def test_auto_veto_cancel_failure_that_is_filled_edits_filled(
     )
     assert rungs[0].state == "filled"
     assert "체결됨" in notifier.edited[-1][2]
+
+
+@pytest.mark.asyncio
+async def test_acceptance_a_toss_veto_needs_broker_terminal_and_ledger_reconcile(
+    monkeypatch, db_session
+):
+    """Offline A fixture: request → original terminal → reconcile → local close."""
+    _allow_chat(monkeypatch)
+    group = await _seed_auto_resting(db_session, account_mode="toss_live")
+    notifier = _FakeNotifier()
+    calls: list[str] = []
+
+    async def cancel_fn(**kwargs):
+        calls.append(f"cancel:{kwargs['order_id']}")
+        # Deliberately only an acknowledgement: the test requires the next two
+        # proof steps before the local rung can close.
+        return {"success": True, "replacement_order_id": "cancel-request-1"}
+
+    async def fetch_fn(**kwargs):
+        calls.append(f"terminal:{kwargs['order_id']}")
+        return TargetOrderSnapshot(
+            broker_order_id="broker-auto-1",
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            limit_price="97000",
+            remaining_quantity="0",
+            status="cancelled",
+            observed_at=kwargs["now"].isoformat(),
+        )
+
+    async def reconcile_fn(**kwargs):
+        calls.append(f"reconcile:{kwargs['order_id']}")
+        return {"confirmed": True, "reconciled_order_count": 1}
+
+    result = await handle_callback_update(
+        _make_update(
+            data=_proposal_callback_data(group, action="vc", nonce="veto-nonce")
+        ),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        veto_cancel_fn=cancel_fn,
+        veto_fetch_fn=fetch_fn,
+        veto_toss_reconcile_fn=reconcile_fn,
+    )
+
+    assert result["reason"] == "auto_veto_cancelled"
+    assert calls == [
+        "cancel:broker-auto-1",
+        "terminal:broker-auto-1",
+        "reconcile:broker-auto-1",
+    ]
+    _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "cancelled"
+    outcome = result["outcomes"][0]
+    assert outcome["terminal_confirmation"] == (
+        "broker_terminal_and_toss_ledger_reconciled"
+    )
+    assert outcome["reconcile"]["confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_toss_auto_veto_never_marks_cancelled_without_reconcile_terminal(
+    monkeypatch, db_session
+):
+    """Mutant ③ guard: a cancel acknowledgement plus fetch is insufficient."""
+    _allow_chat(monkeypatch)
+    group = await _seed_auto_resting(db_session, account_mode="toss_live")
+
+    async def cancel_fn(**_kwargs):
+        return {"success": True}
+
+    async def fetch_fn(**kwargs):
+        return TargetOrderSnapshot(
+            broker_order_id="broker-auto-1",
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            limit_price="97000",
+            remaining_quantity="0",
+            status="cancelled",
+            observed_at=kwargs["now"].isoformat(),
+        )
+
+    async def unconfirmed_reconcile(**_kwargs):
+        return {"confirmed": False, "error": "original_order_not_terminal_in_ledger"}
+
+    result = await handle_callback_update(
+        _make_update(
+            data=_proposal_callback_data(group, action="vc", nonce="veto-nonce")
+        ),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=_FakeNotifier(),
+        veto_cancel_fn=cancel_fn,
+        veto_fetch_fn=fetch_fn,
+        veto_toss_reconcile_fn=unconfirmed_reconcile,
+    )
+
+    assert result["reason"] == "auto_veto_failed"
+    _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "resting"
+    assert result["outcomes"][0]["error"] == "toss_terminal_reconcile_unconfirmed"
+
+
+@pytest.mark.asyncio
+async def test_toss_veto_terminal_reconcile_binds_the_original_order_id(monkeypatch):
+    from app.mcp_server.tooling import toss_live_ledger
+
+    calls: list[dict] = []
+
+    async def fake_impl(**kwargs):
+        calls.append(kwargs)
+        return {
+            "reconciled": [
+                {
+                    "order_id": "original-order",
+                    "local_status": "cancelled",
+                    "action": "marked_cancelled",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(toss_live_ledger, "toss_reconcile_orders_impl", fake_impl)
+    result = await reconcile_toss_auto_veto_terminal(
+        order_id="original-order",
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+    )
+
+    assert result["confirmed"] is True
+    assert calls == [
+        {
+            "symbol": "005930",
+            "order_id": "original-order",
+            "market": "kr",
+            "dry_run": False,
+            "limit": 10,
+            "project_proposal_rungs": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_toss_veto_accepts_an_already_reconciled_original_terminal_row(
+    monkeypatch, db_session
+):
+    """A prior reconcile remains terminal proof; a cancel ACK alone does not."""
+    from app.mcp_server.tooling import kis_live_ledger, toss_live_ledger
+    from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
+
+    order_id = f"already-reconciled-{uuid.uuid4()}"
+    ledger = TossLiveOrderLedgerService(db_session)
+    row = await ledger.record_send(
+        operation_kind="place",
+        market="kr",
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        time_in_force="DAY",
+        quantity=Decimal("1"),
+        price=Decimal("97000"),
+        order_amount=None,
+        currency="KRW",
+        client_order_id=f"client-{uuid.uuid4()}",
+        broker_order_id=order_id,
+        original_order_id=None,
+        status="accepted",
+        broker_status=None,
+        response_code="0",
+        response_message=None,
+        raw_response={},
+    )
+    await ledger.update_reconcile_outcome(
+        ledger_id=row.id,
+        status="cancelled",
+        broker_status="CANCELED",
+    )
+
+    async def no_open_rows(**_kwargs):
+        return {"reconciled": []}
+
+    monkeypatch.setattr(toss_live_ledger, "toss_reconcile_orders_impl", no_open_rows)
+    monkeypatch.setattr(
+        kis_live_ledger,
+        "_order_session_factory",
+        lambda: _session_factory(db_session),
+    )
+
+    result = await reconcile_toss_auto_veto_terminal(
+        order_id=order_id,
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+    )
+
+    assert result == {
+        "confirmed": True,
+        "reconciled_order_count": 1,
+        "confirmed_from": "existing_terminal_ledger_reconcile",
+        "error": None,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_toss_auto_acceptance.py
+++ b/tests/services/order_proposals/test_toss_auto_acceptance.py
@@ -1,0 +1,400 @@
+"""Offline-only acceptance fixtures for TOSS-AUTO-FULL.
+
+These fixtures intentionally use only injected broker snapshots and a test
+database.  They are executable evidence for the state-machine boundaries, not
+permission to touch a Toss account; the live procedure is owned by the
+operator runbook.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.core.config import settings
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.approval_message import parse_callback_data
+from app.services.order_proposals.dispatch import (
+    dispatch_proposal,
+    send_proposal_for_approval,
+)
+from app.services.order_proposals.revalidation import revalidate_and_submit
+from app.services.order_proposals.service import RungInput
+from app.services.order_proposals.target_order import TargetOrderSnapshot
+from app.services.order_proposals.telegram_callback import handle_callback_update
+from app.telegram_contract import TelegramMethodResult, telegram_text_length
+from tests.services.order_proposals.window_fakes import allow_known_session
+
+
+class _FixtureNotifier:
+    """Telegram-shaped recorder; it deliberately has no network transport."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, dict | None, str, int]] = []
+        self.edited: list[tuple[str, int, str, dict | None]] = []
+        self._message_id = 7100
+
+    async def send_approval_message(
+        self, text, inline_keyboard, *, chat_id, parse_mode="Markdown"
+    ):
+        self._message_id += 1
+        self.sent.append((text, inline_keyboard, chat_id, self._message_id))
+        return TelegramMethodResult(
+            ok=True,
+            message_id=self._message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=telegram_text_length(text),
+        )
+
+    async def answer_callback(self, callback_query_id, text=None):
+        return True
+
+    async def edit_message(self, chat_id, message_id, text, reply_markup=None):
+        self.edited.append((chat_id, message_id, text, reply_markup))
+        return TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=telegram_text_length(text),
+        )
+
+
+def _session_factory(db_session):
+    @contextlib.asynccontextmanager
+    async def factory():
+        yield db_session
+
+    return factory
+
+
+def _callback_update(*, data: str, chat_id: str, message_id: int) -> dict:
+    return {
+        "callback_query": {
+            "id": "offline-fixture-callback",
+            "from": {"id": 7001},
+            "message": {"message_id": message_id, "chat": {"id": chat_id}},
+            "data": data,
+        }
+    }
+
+
+def _last_card(notifier: _FixtureNotifier) -> tuple[str, int]:
+    for _text, keyboard, _chat_id, message_id in reversed(notifier.sent):
+        if keyboard is None:
+            continue
+        callback = keyboard["inline_keyboard"][0][0]["callback_data"]
+        if parse_callback_data(callback).action == "op":
+            return callback, message_id
+    raise AssertionError("offline fixture did not publish an individual approval card")
+
+
+async def _seed_auto_resting_toss(db_session, *, account_id: str):
+    now = datetime.now(UTC)
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        broker_account_id=account_id,
+        side="buy",
+        order_type="limit",
+        proposer="offline-acceptance-fixture",
+        thesis="offline acceptance partial-fill fixture",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("97000"), None)],
+        source_asof={
+            "auto_approved": {
+                "policy_version": "offline-fixture",
+                "approved_at": now.isoformat(),
+                "eligibility": [],
+                "outcomes": ["submitted_resting"],
+            }
+        },
+    )
+    await service.transition_rung(group.proposal_id, 0, new_state="revalidating")
+    await service.transition_rung(group.proposal_id, 0, new_state="approved")
+    await service.transition_rung(group.proposal_id, 0, new_state="submitting")
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id="offline-original-order",
+        correlation_id="offline-correlation",
+        idempotency_key="offline-idempotency",
+        approval_hash_digest="offline-digest",
+        now=now,
+    )
+    await db_session.commit()
+    return group
+
+
+def _target_snapshot(*, remaining: str, now: datetime) -> TargetOrderSnapshot:
+    return TargetOrderSnapshot(
+        broker_order_id="offline-original-order",
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        limit_price="97000",
+        remaining_quantity=remaining,
+        status="open",
+        observed_at=now.isoformat(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_acceptance_b_fill_freeze_cancel_proposal_second_fill_then_terminal(
+    monkeypatch, db_session
+):
+    """B fixture: first fill freezes; delayed approval sees second fill safely.
+
+    Flow proved entirely offline:
+
+    1. broker evidence of a first partial fill freezes the same Toss lane;
+    2. a new automatic candidate falls back to a human card;
+    3. a cancel proposal is published, then a second partial fill arrives
+       before its click, so its stale remaining-quantity snapshot is rejected
+       without a cancel mutation;
+    4. a refreshed cancel proposal is approved and sees a terminal cancelled
+       broker snapshot before its proposal rung closes.
+    """
+    now = datetime(2026, 8, 13, 1, 0, tzinfo=UTC)
+    account_id = f"offline-toss-{uuid.uuid4()}"
+    chat_id = f"offline-toss-chat-{uuid.uuid4().hex}"
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat_id
+    )
+
+    original = await _seed_auto_resting_toss(db_session, account_id=account_id)
+    service = OrderProposalsService(db_session)
+
+    # First real-world event in the fixture: broker evidence, not a local
+    # optimistic write, moves the original rung into partial and freezes auto.
+    first_fill = await service.record_fill_evidence(
+        broker_order_id="offline-original-order",
+        correlation_id="offline-correlation",
+        idempotency_key="offline-idempotency",
+        filled_qty=Decimal("0.4"),
+        terminal_state="partially_filled",
+        now=now,
+        account_mode="toss_live",
+    )
+    await db_session.commit()
+    assert first_fill is not None
+    original_after_first_fill, original_rungs = await service.get_proposal(
+        original.proposal_id
+    )
+    assert original_rungs[0].state == "partially_filled"
+    assert (
+        original_after_first_fill.source_asof["auto_approved"][
+            "toss_auto_submission_freeze"
+        ]["state"]
+        == "frozen"
+    )
+
+    # The account-wide freeze blocks a *new US-market* auto path before it
+    # reaches revalidation.  It still produces a normal human card rather
+    # than dropping the proposal.
+    blocked_candidate = await service.create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="toss_live",
+        broker_account_id=account_id,
+        side="buy",
+        order_type="limit",
+        proposer="offline-acceptance-fixture",
+        thesis="would otherwise be auto-submitted",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("150"), None)],
+    )
+    await db_session.commit()
+
+    async def must_not_revalidate(**_kwargs):
+        raise AssertionError("Toss fill freeze must stop auto revalidation")
+
+    freeze_notifier = _FixtureNotifier()
+    await dispatch_proposal(
+        blocked_candidate.proposal_id,
+        notifier=freeze_notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+        revalidate_fn=must_not_revalidate,
+        window_evaluator=allow_known_session,
+        now_fn=lambda: now,
+    )
+    assert "주문 제안 승인" in freeze_notifier.sent[-1][0]
+
+    # The operator takes a fresh target snapshot after the first fill and
+    # creates a normal cancel proposal.  This is not auto-eligible: action
+    # cancel stays outside auto approval by the existing action gate.
+    first_snapshot = _target_snapshot(remaining="0.6", now=now)
+    stale_cancel = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        broker_account_id=account_id,
+        side="buy",
+        order_type="limit",
+        proposer="offline-acceptance-fixture",
+        thesis="cancel the unfilled remainder after partial fill",
+        action="cancel",
+        target_broker_order_id="offline-original-order",
+        target_order_snapshot=first_snapshot.to_payload(),
+        rungs=[RungInput(0, "buy", Decimal("0.6"), Decimal("97000"), None)],
+    )
+    await db_session.commit()
+    stale_notifier = _FixtureNotifier()
+    stale_dispatch = await send_proposal_for_approval(
+        stale_cancel.proposal_id,
+        notifier=stale_notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+        window_evaluator=allow_known_session,
+        now_fn=lambda: now,
+    )
+    assert stale_dispatch.ok is True
+    stale_callback, stale_message_id = _last_card(stale_notifier)
+    assert parse_callback_data(stale_callback).action == "op"
+
+    # Required adverse condition: a second fill happens while that first
+    # approval card is waiting.  It changes the executable remainder 0.6→0.4.
+    second_fill = await service.record_fill_evidence(
+        broker_order_id="offline-original-order",
+        correlation_id="offline-correlation",
+        idempotency_key="offline-idempotency",
+        filled_qty=Decimal("0.6"),
+        terminal_state="partially_filled",
+        now=now,
+        account_mode="toss_live",
+    )
+    await db_session.commit()
+    assert second_fill is not None
+    _original_after_second_fill, original_rungs = await service.get_proposal(
+        original.proposal_id
+    )
+    assert original_rungs[0].filled_qty == Decimal("0.6")
+
+    stale_cancel_calls: list[dict] = []
+
+    async def stale_fetch(**_kwargs):
+        return _target_snapshot(remaining="0.4", now=now)
+
+    async def must_not_cancel(**kwargs):
+        stale_cancel_calls.append(kwargs)
+        raise AssertionError("stale snapshot must reject before cancel mutation")
+
+    async def stale_revalidate(**kwargs):
+        return await revalidate_and_submit(
+            **kwargs,
+            fetch_target_fn=stale_fetch,
+            cancel_target_fn=must_not_cancel,
+            window_evaluator=allow_known_session,
+            now_fn=lambda: now,
+        )
+
+    stale_result = await handle_callback_update(
+        _callback_update(
+            data=stale_callback,
+            chat_id=chat_id,
+            message_id=stale_message_id,
+        ),
+        now=now,
+        service_factory=_session_factory(db_session),
+        notifier=stale_notifier,
+        revalidate_fn=stale_revalidate,
+        window_evaluator=allow_known_session,
+        now_fn=lambda: now,
+    )
+    assert stale_cancel_calls == []
+    assert stale_result["results"] == ["error"]
+    _stale_group, stale_rungs = await service.get_proposal(stale_cancel.proposal_id)
+    assert stale_rungs[0].state == "rejected"
+    assert stale_rungs[0].void_reason == "target_snapshot_mismatch:remaining_quantity"
+
+    # A refreshed proposal now carries the second-fill remainder.  Its click
+    # is allowed to call the injected cancellation edge, but only marks its
+    # rung cancelled after a fresh terminal broker snapshot says cancelled.
+    fresh_snapshot = _target_snapshot(remaining="0.4", now=now)
+    fresh_cancel = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        broker_account_id=account_id,
+        side="buy",
+        order_type="limit",
+        proposer="offline-acceptance-fixture",
+        thesis="cancel refreshed unfilled remainder",
+        action="cancel",
+        target_broker_order_id="offline-original-order",
+        target_order_snapshot=fresh_snapshot.to_payload(),
+        rungs=[RungInput(0, "buy", Decimal("0.4"), Decimal("97000"), None)],
+    )
+    await db_session.commit()
+    fresh_notifier = _FixtureNotifier()
+    fresh_dispatch = await send_proposal_for_approval(
+        fresh_cancel.proposal_id,
+        notifier=fresh_notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+        window_evaluator=allow_known_session,
+        now_fn=lambda: now,
+    )
+    assert fresh_dispatch.ok is True
+    fresh_callback, fresh_message_id = _last_card(fresh_notifier)
+
+    fetch_count = 0
+    terminal_cancel_calls: list[dict] = []
+
+    async def terminal_fetch(**_kwargs):
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            return fresh_snapshot
+        return TargetOrderSnapshot(
+            broker_order_id="offline-original-order",
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            limit_price="97000",
+            remaining_quantity="0",
+            status="cancelled",
+            observed_at=now.isoformat(),
+        )
+
+    async def terminal_cancel(**kwargs):
+        terminal_cancel_calls.append(kwargs)
+        return {"success": True, "replacement_order_id": "offline-cancel-request"}
+
+    async def fresh_revalidate(**kwargs):
+        return await revalidate_and_submit(
+            **kwargs,
+            fetch_target_fn=terminal_fetch,
+            cancel_target_fn=terminal_cancel,
+            window_evaluator=allow_known_session,
+            now_fn=lambda: now,
+        )
+
+    final_result = await handle_callback_update(
+        _callback_update(
+            data=fresh_callback,
+            chat_id=chat_id,
+            message_id=fresh_message_id,
+        ),
+        now=now,
+        service_factory=_session_factory(db_session),
+        notifier=fresh_notifier,
+        revalidate_fn=fresh_revalidate,
+        window_evaluator=allow_known_session,
+        now_fn=lambda: now,
+    )
+    assert final_result["results"] == ["cancelled"]
+    assert len(terminal_cancel_calls) == 1
+    assert fetch_count == 2  # fresh target validation, then broker terminal proof
+    _fresh_group, fresh_rungs = await service.get_proposal(fresh_cancel.proposal_id)
+    assert fresh_rungs[0].state == "cancelled"

--- a/tests/test_trade_notifier.py
+++ b/tests/test_trade_notifier.py
@@ -120,6 +120,68 @@ async def test_dispatch_discord_success(trade_notifier):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_auto_veto_card_mirror_reuses_market_routed_discord_transport(
+    trade_notifier,
+):
+    webhook_url = "https://discord.com/api/webhooks/kr"
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_kr=webhook_url,
+    )
+
+    with patch.object(
+        trade_notifier,
+        "_send_to_discord_embed_single",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as send:
+        delivered = await trade_notifier.send_auto_veto_card_mirror(
+            symbol="005930",
+            market="equity_kr",
+            quantities=["1"],
+            prices=["97000"],
+            thesis_summary="valuation dislocation",
+            policy_version="fixture-policy",
+        )
+
+    assert delivered is True
+    embed, actual_webhook = send.call_args.args
+    assert actual_webhook == webhook_url
+    fields = {field["name"]: field["value"] for field in embed["fields"]}
+    assert fields == {
+        "종목": "005930",
+        "수량": "1",
+        "가격": "97000",
+        "사유": "valuation dislocation",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_auto_veto_card_mirror_fails_closed_without_thesis(trade_notifier):
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_kr="https://discord.com/api/webhooks/kr",
+    )
+
+    delivered = await trade_notifier.send_auto_veto_card_mirror(
+        symbol="005930",
+        market="equity_kr",
+        quantities=["1"],
+        prices=["97000"],
+        thesis_summary=" ",
+        policy_version="fixture-policy",
+    )
+
+    assert delivered is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_dispatch_telegram_fallback(trade_notifier):
     """_dispatch falls back to Telegram when Discord fails."""
     trade_notifier.configure(


### PR DESCRIPTION
## Summary

- Adds a separately default-off Toss live auto-veto gate, mandatory thesis cards, and market-routed Discord mirror reuse.
- Requires both a fresh original-order broker terminal snapshot and targeted Toss ledger reconciliation before a Toss veto can mark a proposal rung cancelled.
- Adds account-wide same-KST-session auto-submission freeze after evidence-backed Toss fills, plus offline A/B acceptance fixtures and an operator-only runbook.

## Safety and scope

- No live Toss/account/MCP command was executed by this branch; the fixture script refuses any mode except --offline-fixture.
- loss_cut, break-even band, policy_deviation, table_disagreement, and unclassifiable paths remain human approval only.
- Toss capability is disabled by default via ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED=false and remains subordinate to the existing master gate.

## Offline verification

- 136 focused order-proposal tests passed.
- 304 service/revalidation/security tests passed.
- 171 Toss ledger/notifier/policy/LLM-boundary tests passed (one pre-existing pytest marker warning).
- Offline acceptance fixture: 59 passed; make lint passed.
- All three required mutants were injected, failed their guard tests, and were reverted.

## Ownership / merge order

- config/trading_policy.yaml intentionally changes only order_proposals.auto_approve per_order_cap/daily_cap and its derivation comment.
- This cap block may conflict with bxtrim PR #1840 and rsvnet PR #1841; merge ordering must resolve that block deliberately.
- docs/playbooks/trading-decision-playbook.md was intentionally not touched; app/schemas/trading_policy.py was intentionally not touched.

## Operator follow-up

- The live A/B acceptance procedures are operator-owned and documented in docs/runbooks/toss-auto-acceptance.md. Keep the PR draft pending an independent different-provider verification and operator live acceptance evidence.