### PR TITLE
feat(b0x): replace KR interim ordering with lifecycle mode

### DIFF
--- a/docs/runbooks/b0x-kr-kiwoom-cycle.md
+++ b/docs/runbooks/b0x-kr-kiwoom-cycle.md
@@ -5,9 +5,10 @@
 
 기본 지위는 **`OBSERVATION_DERIVATION_ONLY`**(preview)다. `--confirm` 단독은
 **`ACCEPTANCE_ONLY`** — 기존의 1건 submit→cancel→reconcile 검증 레버다.
-`--interim-ordering --confirm` 을 함께 명시한 경우만 **`INTERIM_ORDERING`** 으로
-전환해 envelope 파생 **매수** 전건을 DAY 주문으로 남긴다. 매도는 기본 ON인
-매수 전용 게이트가 제출 경계에서 차단한다. 위험한 쪽은 기본값이 아니다.
+`--ordering --confirm` 을 함께 명시한 경우만 독립 모드인 **`ORDERING`** 으로
+전환한다. 정책표가 결정적으로 파생한 주문만 §4 cap 안에서 DAY로 제출하고,
+`ACCEPTANCE_ONLY` 의 즉시취소를 상속하지 않는다. 매도는 fresh broker fill로
+증명된 자기 귀속 수량까지만 가능하다. 위험한 쪽은 기본값이 아니다.
 
 ---
 
@@ -20,7 +21,7 @@
 `scripts/b0x/kr/mock.py`(kis) 는 **무접촉**이다. kis_mock 계좌 참가가 복구되면
 그 레인은 이 PR 이전과 완전히 동일하게 동작해야 한다.
 
-## 2. 계좌맵 (operator `09c3fc1`, PR #37)
+## 2. 계좌맵 (operator `a43e36e`, PR #39; merge 대기)
 
 | 표면 | 키 | 값 |
 | --- | --- | --- |
@@ -36,9 +37,10 @@
 - 배타성 확보 = **운영 조치**(KR-B1 비활성 확인). 코드가 제공하는 것은
   *탐지*뿐이다: 당일 자기 외 주문 흔적이 있으면 preflight 가 fail-closed
   (`CONTAMINATED_foreign_same_day_orders_kr_b1_active_suspect`).
-- 이 계좌에는 `kis_mock` 의 `KISMockWriterLease` 같은 durable lease 가 **없다**.
-  아티팩트의 `writer_lease.acquired` 는 `false` 로 기록되며, 이 레인은 lease 를
-  가졌다고 주장하지 않는다.
+- ORDERING 은 redacted account fingerprint를 키로 한 host-local `fcntl` writer
+  lease를 추가로 잡는다. 이는 다른 host/외부 writer를 대신하지 않으므로, **매
+  mutation 직전** kt00007의 pending과 당일 foreign trace를 같은 답에서 다시
+  만들고, lease 상실·조회 실패·foreign 흔적이면 그 뒤 주문은 0이다.
 
 ## 3. 안전 경계
 
@@ -51,10 +53,13 @@
 | 세션 | KRX 정규장만 (`is_krx_regular_session`, XKRX 캘린더) |
 | envelope | §4 KR 열 **그대로 재사용** (`load_envelope("kr")`). 레인 전용 envelope 상수 없음 — 테스트가 강제 |
 | Acceptance 1건 한정 | `ACCEPTANCE_SUBMISSION_LIMIT = 1`, CLI/env override 없음. `--confirm` 단독에만 적용 |
-| Interim 매수 전건 제출 | `--interim-ordering --confirm` 에서만 envelope 파생 매수 leg 전건 제출. 별도 제출 상한/CLI/env override 없음 — §4 30만·동시 10·일신규 3이 파생 단계에서 계속 강제 |
-| Interim 매수 전용 | 매도 leg는 파생되더라도 제출 경계의 `interim_buy_only_sell_gate`가 차단하고 artifact에 사유를 남긴다. 기본 ON이며 CLI/env 해제 경로 없음; 명시 운영자 승인 또는 B-track merge 전까지 유지 |
+| ORDERING 별도 모드 | `--ordering --confirm` 에서만 policy-table 결정 파생 주문을 제출. 별도 cap/CLI/env override 없음 — §4 30만·동시 10·일신규 3이 파생 단계에서 계속 강제 |
+| 매도 귀속 | 매도 직전 fresh broker fill × own-order journal로 자기 수량을 다시 계산해 `assert_sell_is_own`으로 제한. 귀속 불명/부족은 sell 0 |
 | Acceptance 왕복 강제 | `--no-cancel` 같은 플래그가 **존재하지 않는다**. `ACCEPTANCE_ONLY` 취소 미확인 = `RoundTripIncomplete` + exit 2 |
-| DAY 주문 잔존 | `INTERIM_ORDERING` 은 즉시 취소하지 않는다. `submitted` 는 접수/주문번호 증거만 뜻하고 filled를 뜻하지 않는다 |
+| DAY 주문 잔존 | `ORDERING` 은 즉시 취소하지 않는다. `broker_ack`은 접수/주문번호 증거일 뿐 filled가 아니며 후속 kt00007 readback이 partial/fill/remaining/VWAP/slippage를 보존 |
+| Mutation boundary | 매 submit/cancel 직전 lease + kt00007 one-read에서 pending과 same-day foreign trace를 동시 재조회. 읽기 실패·foreign·lease 상실은 다음 mutation 0 |
+| 일손실 입력 | dedicated realized P&L 증거가 없으면 current-day own activity 없는 bootstrap만 0을 증명할 수 있다. 그 밖의 unreadable은 kill 0으로 치환하지 않고 주문 0 |
+| Kill | kill 발화 시 신규 주문 0, 자기 resting 전부 kt10003 cancel 시도, 각각과 최종 상태를 kt00007 재조회로 확인. cancel 응답만으로 성공 기록 금지 |
 | halted | 표가 이미 제외(ROB-1236). 레인이 `universe.halted_suspect` 를 두 번째 선으로 재검사 |
 
 ## 4. 🔴 자기 미체결 = 브로커 직접 조회, 원장 예외 **미사용**
@@ -108,12 +113,20 @@ v1.5 ① 이 실격시키는 성질이고, ROB-341 이 KIS 일별체결조회를
 ### 5.1 저널 = 「이 ord_no 는 우리 것이다」
 
 `<out-dir>/kiwoom_mock/own-orders.jsonl`, append-only.
-🔴 제출 직후의 자기 주문번호는 즉시 저널한다. `INTERIM_ORDERING` 의 DAY 주문도
+🔴 제출 직후의 자기 주문번호는 즉시 저널한다. `ORDERING` 의 DAY 주문도
 다음 사이클의 당일 외부흔적 게이트가 자기 주문으로 식별할 수 있어야 한다.
 `ACCEPTANCE_ONLY` 에서는 **취소도** 자기 주문번호를 갖는다(실측: 매수 `0107387` →
 취소 `0107388`). 취소 ord_no 를 기록하지 않으면 다음 사이클의 당일 외부흔적 게이트가
 자기 취소를 제2 writer 로 오인해 정지한다 — 2026-08-12 12:13 KST 에 실제로 발생했다.
 그래서 취소도 `side="cancel"` 로 저널한다(귀속 수량에는 영향 없음).
+
+### 5.2 ORDERING fidelity journal
+
+`<out-dir>/kiwoom_mock/ordering-events.jsonl`도 append-only다. 한 주문의 evidence
+path는 `table_price → intended_limit → broker_ack → broker_readback
+(partial/fill VWAP/remaining) → reconcile`로 보존된다. kill에서는 같은 저널에
+`cancel_ack → cancel_reconcile → final_reconcile`가 추가된다. cycle artifact는 이
+저널의 요약일 뿐, ack/fill/cancel의 유일한 증거가 아니다.
 
 ## 6. Rate limit — 페이싱은 안전 속성이다
 
@@ -147,41 +160,43 @@ uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
 B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
     --table-dir ~/services/auto_trader-operator/policy-tables --confirm
 
-# ④ INTERIM_ORDERING — 이중 명시가 있어야만 DAY 주문을 남긴다.
-#    §4 envelope 파생 매수 leg 전건만 제출하며, 자동 취소하지 않는다.
-#    매도 leg는 기본 ON 매수 전용 게이트가 명시 사유와 함께 차단한다.
+# ④ ORDERING — 이중 명시가 있어야만 DAY 주문을 남긴다.
+#    독립검증 PASS 및 배포 실증 전에는 이 명령을 실행하지 않는다.
+#    정책표 파생만, own-only sell, mutation-boundary 재조회, 자동취소 없음.
 B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle \
     --table-dir ~/services/auto_trader-operator/policy-tables \
-    --interim-ordering --confirm
+    --ordering --confirm
 ```
 
 exit code: `0` 정상 · `2` writer lock 경합, acceptance 왕복 미완(취소 미확인),
-또는 interim 제출 증거 미확인. 🔴 `2` 를 보면 계좌에 미회수 주문이 남았을 수 있다 —
+또는 ORDERING ack/readback/cancel 재확인 미완. 🔴 `2` 를 보면 계좌에 미회수 주문이 남았을 수 있다 —
 `--readiness` 로 즉시 `pending` 을 확인하고, 남아 있으면 운영자가 직접 취소한다.
 
 ## 8. 아티팩트
 
 `<out-dir>/kiwoom_mock/` — `cycles.jsonl`(append-only) ·
-`<ts>-cycle.md` · `own-orders.jsonl` · `operator-notices.jsonl`.
+`<ts>-cycle.md` · `own-orders.jsonl` · `ordering-events.jsonl` ·
+`operator-notices.jsonl`.
 
 모든 아티팩트에 `COEXISTING_ACCOUNT_LANE` 라벨이 붙는다: 이 계좌의 보유·체결
 이력 전부를 B0-X 산출로 읽으면 안 된다.
 
 ## 9. 알려진 경계 (조용히 넘어가지 않는 것들)
 
-1. **계좌 배타성은 코드가 보장하지 않는다.** flock writer lock 은 B0-X 프로세스
-   간 경합만 막는다. 계좌 단위 배타성은 운영 조치이고, 코드는 당일 외부 주문
-   흔적 탐지(fail-closed)만 제공한다. TOCTOU 는 완전히 제거되지 않았다 —
-   preflight 이후 제출 직전까지의 창이 남는다.
+1. **계좌 배타성은 여전히 운영 조치다.** account-keyed local lease는 같은 host의
+   B0-X writer만 배타화한다. 다른 host/KR-B1 writer는 broker foreign trace가
+   방어한다. ORDERING 은 preflight 1회에 의존하지 않고 매 mutation boundary에서
+   동일 kt00007 답으로 재검사하지만, broker 자체가 답한 뒤 발생한 외부 변화까지
+   원자적으로 잠글 수는 없다.
 2. **legacy 귀속 게이트는 2026-08-12 실환경에서 *증명되지 않았다*.** 그날
    kiwoom_mock 계좌의 보유가 **0종목**이라 legacy 분기에 도달할 입력이 없었다.
    단위 테스트로만 증명된 상태다(보유가 생기는 첫 사이클이 첫 실환경 검증 기회).
 3. **dedup(동일 심볼 재제출 차단)도 실환경 미증명.** `ACCEPTANCE_ONLY` 는 같은
    사이클 안에서 취소하므로 재제출 시점에 자기 미체결이 남아 있지 않다.
-   `INTERIM_ORDERING` 은 DAY 주문을 남기므로 kt00007 재조회가 같은 심볼 재제출을
-   막아야 한다. 단위 테스트 + preflight 의 `account_has_resting_orders` 사유가 코드
-   경로를 덮는다.
-4. **kill switch 는 발화 입력이 없다.** `realized_pnl_today` 소스가 이 레인에도
-   없으므로 −2.5% NAV kill 은 발화할 수 없다. 구조적 부재이지 측정된 0 이 아니다.
+   `ORDERING` 은 DAY 주문을 남기므로 매 mutation-boundary kt00007 재조회가 같은
+   심볼 재제출을 막아야 한다. 단위 테스트가 코드 경로를 덮는다.
+4. **dedicated realized P&L source는 아직 없다.** own-order journal이 current-day
+   activity 없음까지 증명하는 bootstrap에서만 0을 쓴다. activity·journal 오류·시간
+   정보 오류가 있으면 −2.5% NAV kill을 미발화로 꾸미지 않고 ORDERING 자체가 0이 된다.
 5. **저널 유실 방향은 안전하다** (과소 귀속 → 매도 못 함). 다만 저널이 사라지면
    자기 보유가 legacy 로 재분류되어 영영 팔 수 없게 된다 — 백업 대상이다.

--- a/scripts/b0x/kr/kiwoom.py
+++ b/scripts/b0x/kr/kiwoom.py
@@ -80,7 +80,7 @@ not to hold inventory. A cancel that fails is recorded as a failure and exits
 non-zero — never laundered into a clean success (see
 :class:`RoundTripIncomplete`).
 
-``INTERIM_ORDERING`` uses :func:`submit_day_order` instead. That function
+``ORDERING`` uses :func:`submit_day_order` instead. That function
 records only broker acceptance and the assigned order number; it deliberately
 does not claim a fill and never invokes cancellation. The caller is responsible
 for the stricter preflight and for choosing that non-default mode.
@@ -211,6 +211,16 @@ class BrokerEchoMismatch(RuntimeError):
     ROB-993 R3's lesson, reused: a submit or cancel response that does not echo
     the request is not evidence for the request. Fail closed rather than
     recording someone else's order as ours.
+    """
+
+
+class BrokerOrderReadbackUnavailable(RuntimeError):
+    """The broker did not provide a complete, echoing post-submit readback.
+
+    A successful ``kt10000``/``kt10001`` response is acknowledgement evidence,
+    not lifecycle evidence.  ORDERING therefore does not promote a DAY order
+    to any terminal state until the broker detail surface identifies the exact
+    order and supplies fill/remaining fields.
     """
 
 
@@ -363,7 +373,7 @@ class RestingOrder:
 
 @dataclass(frozen=True, slots=True)
 class BrokerPending:
-    """kt00009's answer, split into account-wide and own.
+    """kt00007's answer, split into account-wide and own.
 
     ``own_*`` is the intersection with the local order journal; ``account_*``
     is everything the broker reported. The gate consumes the account-wide set
@@ -407,6 +417,45 @@ class BrokerPending:
             "own_order_count": len(self.own_orders),
             "foreign_order_count": len(self.foreign_orders),
         }
+
+
+def resting_orders_from_detail_rows(
+    rows: list[dict[str, Any]],
+) -> tuple[RestingOrder, ...]:
+    """Derive the broker's current resting set from normalized ``kt00007`` rows.
+
+    Keeping this pure lets a mutation boundary take *one* full same-day
+    ``kt00007`` answer and derive both pending and foreign-trace gates from it;
+    the two facts cannot then accidentally be taken from different moments.
+    """
+
+    resting: list[RestingOrder] = []
+    for entry in rows:
+        remaining = int(entry.get("remaining_quantity") or 0)
+        if remaining <= 0:
+            continue
+        resting.append(
+            RestingOrder(
+                order_id=str(entry["order_id"]),
+                symbol=str(entry["symbol"]),
+                status=str(entry["status"]),
+                remaining_quantity=remaining,
+                ordered_price=int(entry.get("ordered_price") or 0),
+                unfilled_quantity=int(entry.get("unfilled_quantity") or 0),
+            )
+        )
+    return tuple(sorted(resting, key=lambda order: order.order_id))
+
+
+def broker_pending_from_detail_rows(
+    *, rows: list[dict[str, Any]], own_order_ids: frozenset[str]
+) -> BrokerPending:
+    """Build pending ownership facts from one normalized detail read."""
+
+    return BrokerPending(
+        account_orders=resting_orders_from_detail_rows(rows),
+        own_order_ids=own_order_ids,
+    )
 
 
 #: 🔴 Minimum spacing between consecutive Kiwoom calls from this lane.
@@ -539,22 +588,7 @@ class ReadOnlyKiwoomMockAccount:
         rows = await self.read_order_detail(
             order_date=order_date or kst_order_date(dt.datetime.now(dt.UTC))
         )
-        resting: list[RestingOrder] = []
-        for entry in rows:
-            remaining = int(entry.get("remaining_quantity") or 0)
-            if remaining <= 0:
-                continue
-            resting.append(
-                RestingOrder(
-                    order_id=str(entry["order_id"]),
-                    symbol=str(entry["symbol"]),
-                    status=str(entry["status"]),
-                    remaining_quantity=remaining,
-                    ordered_price=int(entry.get("ordered_price") or 0),
-                    unfilled_quantity=int(entry.get("unfilled_quantity") or 0),
-                )
-            )
-        return tuple(sorted(resting, key=lambda order: order.order_id))
+        return resting_orders_from_detail_rows(rows)
 
     async def read_order_status_diagnostic(self) -> dict[str, Any]:
         """kt00009, recorded but **never** used as a gate.
@@ -628,7 +662,7 @@ class ReadOnlyKiwoomMockAccount:
 
         This is reachable only after the cycle's attributed-holding boundary;
         exposing no exchange parameter keeps the NXT/SOR prohibition structural
-        for both sides of an INTERIM_ORDERING day order.
+        for both sides of an ORDERING DAY order.
         """
 
         await self._pace()
@@ -749,7 +783,7 @@ async def read_fresh_truth(account: ReadOnlyKiwoomMockAccount) -> FreshTruth:
 
 
 def pending_unreadable(cause: str) -> PendingUnreadable:
-    """Tri-state for a failed kt00009 read.
+    """Tri-state for a failed kt00007 read.
 
     🔴 Not the normal path on this lane. ``kis_mock`` is *structurally*
     unreadable; kiwoom answers, so landing here means the read genuinely
@@ -768,15 +802,18 @@ def pending_unreadable(cause: str) -> PendingUnreadable:
 
 
 async def read_broker_pending(
-    account: ReadOnlyKiwoomMockAccount, *, own_order_ids: frozenset[str]
+    account: ReadOnlyKiwoomMockAccount,
+    *,
+    own_order_ids: frozenset[str],
+    order_date: str | None = None,
 ) -> BrokerPending | PendingUnreadable:
     """자기 미체결 = 브로커 직접 조회 (§39차 ②). Any failure → tri-state."""
 
     try:
-        resting = await account.read_resting_orders()
+        rows = await account.read_order_detail(order_date=order_date)
     except Exception as exc:  # noqa: BLE001 — any failure is "unknown"
         return pending_unreadable(type(exc).__name__)
-    return BrokerPending(account_orders=resting, own_order_ids=own_order_ids)
+    return broker_pending_from_detail_rows(rows=rows, own_order_ids=own_order_ids)
 
 
 def broker_truth_from(
@@ -980,7 +1017,7 @@ ORDER_NO_FIELD: Final[str] = "ord_no"
 
 @dataclass
 class DayOrderResult:
-    """Broker-accepted KRX DAY order retained for ``INTERIM_ORDERING``.
+    """Broker-accepted KRX DAY order retained for ``ORDERING``.
 
     This records only what the submit response establishes: the request was
     accepted and assigned an order number. It is intentionally not a fill
@@ -1011,6 +1048,63 @@ class DayOrderResult:
             "time_in_force": "DAY",
             "automatic_cancel": False,
             "fill_status": "unverified",
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerOrderReadback:
+    """One exact broker-detail observation for an ORDERING DAY order.
+
+    ``filled_quantity`` / ``remaining_quantity`` stay broker-derived.  The
+    VWAP and slippage fields are only populated for an actual non-zero fill;
+    an unfilled acknowledgement is neither a synthetic fill nor a completed
+    lifecycle.
+    """
+
+    at: dt.datetime
+    order_no: str
+    symbol: str
+    side: str
+    intended_limit: int
+    ordered_quantity: int
+    filled_quantity: int
+    remaining_quantity: int
+    unfilled_quantity: int
+    status: str
+    fill_vwap: Decimal | None
+    slippage_krw: Decimal | None
+
+    @property
+    def complete(self) -> bool:
+        return (
+            self.filled_quantity == self.ordered_quantity
+            and self.remaining_quantity == 0
+        )
+
+    @property
+    def partial(self) -> bool:
+        return 0 < self.filled_quantity < self.ordered_quantity
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "at": self.at.isoformat(),
+            "order_no": self.order_no,
+            "symbol": self.symbol,
+            "side": self.side,
+            "intended_limit": self.intended_limit,
+            "ordered_quantity": self.ordered_quantity,
+            "filled_quantity": self.filled_quantity,
+            "remaining_quantity": self.remaining_quantity,
+            "unfilled_quantity": self.unfilled_quantity,
+            "status": self.status,
+            "fill_vwap": (
+                None if self.fill_vwap is None else format(self.fill_vwap, "f")
+            ),
+            "slippage_krw": (
+                None if self.slippage_krw is None else format(self.slippage_krw, "f")
+            ),
+            "complete": self.complete,
+            "partial": self.partial,
         }
 
 
@@ -1093,9 +1187,106 @@ def assert_resting_echo(
         problems.append(f"price {order.ordered_price} != {planned.price}")
     if problems:
         raise BrokerEchoMismatch(
-            "kt00009 resting row does not echo the submitted order: "
+            "kt00007 resting row does not echo the submitted order: "
             + "; ".join(problems)
         )
+
+
+def _readback_from_detail_row(
+    *,
+    row: dict[str, Any],
+    planned: PlannedOrder,
+    order_no: str,
+    at: dt.datetime,
+) -> BrokerOrderReadback:
+    """Validate and preserve one exact normalized ``kt00007`` row."""
+
+    problems: list[str] = []
+    if str(row.get("order_id") or "") != order_no:
+        problems.append(f"order_no {row.get('order_id')!r} != {order_no!r}")
+    if str(row.get("symbol") or "") != planned.symbol:
+        problems.append(f"symbol {row.get('symbol')!r} != {planned.symbol!r}")
+    if int(row.get("ordered_quantity") or 0) != planned.quantity:
+        problems.append(
+            f"ordered_quantity {row.get('ordered_quantity')!r} != {planned.quantity!r}"
+        )
+    if int(row.get("ordered_price") or 0) != planned.price:
+        problems.append(
+            f"ordered_price {row.get('ordered_price')!r} != {planned.price!r}"
+        )
+    filled = int(row.get("filled_quantity") or 0)
+    remaining = int(row.get("remaining_quantity") or 0)
+    unfilled = int(row.get("unfilled_quantity") or 0)
+    if filled < 0 or remaining < 0 or unfilled < 0:
+        problems.append("negative fill/remaining quantity")
+    if filled > planned.quantity:
+        problems.append(f"filled_quantity {filled} > submitted {planned.quantity}")
+    if remaining > unfilled:
+        problems.append(
+            f"remaining_quantity {remaining} > unfilled_quantity {unfilled}"
+        )
+    if problems:
+        raise BrokerEchoMismatch(
+            "kt00007 order detail does not echo the submitted ORDERING request: "
+            + "; ".join(problems)
+        )
+
+    fill_vwap: Decimal | None = None
+    slippage: Decimal | None = None
+    if filled > 0:
+        fill_vwap = Decimal(int(row.get("average_price") or 0))
+        if fill_vwap <= 0:
+            raise BrokerOrderReadbackUnavailable(
+                f"kt00007 reports filled_quantity={filled} for {order_no} but no "
+                "positive broker VWAP; fill fidelity cannot be conserved"
+            )
+        # Positive is adverse slippage for both directions.
+        slippage = (
+            fill_vwap - Decimal(planned.price)
+            if planned.side == "buy"
+            else Decimal(planned.price) - fill_vwap
+        )
+
+    return BrokerOrderReadback(
+        at=at,
+        order_no=order_no,
+        symbol=planned.symbol,
+        side=planned.side,
+        intended_limit=planned.price,
+        ordered_quantity=planned.quantity,
+        filled_quantity=filled,
+        remaining_quantity=remaining,
+        unfilled_quantity=unfilled,
+        status=str(row.get("status") or "unknown"),
+        fill_vwap=fill_vwap,
+        slippage_krw=slippage,
+    )
+
+
+async def read_order_readback(
+    account: ReadOnlyKiwoomMockAccount,
+    *,
+    planned: PlannedOrder,
+    order_no: str,
+    order_date: str,
+    at: dt.datetime,
+) -> BrokerOrderReadback:
+    """Read the exact broker row after acknowledgement; absence fails closed."""
+
+    try:
+        rows = await account.read_order_detail(order_date=order_date)
+    except Exception as exc:  # noqa: BLE001 — no readback is no lifecycle proof
+        raise BrokerOrderReadbackUnavailable(
+            f"kt00007 readback failed for {order_no} ({type(exc).__name__})"
+        ) from exc
+    row = next(
+        (item for item in rows if str(item.get("order_id") or "") == order_no), None
+    )
+    if row is None:
+        raise BrokerOrderReadbackUnavailable(
+            f"kt00007 readback did not return acknowledged order {order_no}"
+        )
+    return _readback_from_detail_row(row=row, planned=planned, order_no=order_no, at=at)
 
 
 async def submit_day_order(
@@ -1280,7 +1471,7 @@ async def submit_and_cancel(
         result.failure = "cancel_unconfirmed"
         raise RoundTripIncomplete(
             f"order {order_no} ({planned.symbol}) is still reported as resting by "
-            f"kt00009 after kt10003 — remaining="
+            f"kt00007 after kt10003 — remaining="
             f"{still_resting.remaining_quantity if still_resting else '?'}. "
             "Refusing to report a cancellation the broker did not confirm."
         )
@@ -1299,6 +1490,8 @@ __all__ = [
     "OWN_PENDING_SOURCE",
     "BlockedOrder",
     "BrokerEchoMismatch",
+    "BrokerOrderReadback",
+    "BrokerOrderReadbackUnavailable",
     "BrokerPending",
     "DayOrderResult",
     "FreshTruth",
@@ -1319,12 +1512,15 @@ __all__ = [
     "assert_kiwoom_lane_enabled",
     "assert_mock_host",
     "assert_resting_echo",
+    "broker_pending_from_detail_rows",
     "broker_truth_from",
     "client_order_id_for",
     "pending_unreadable",
     "plan_orders",
     "read_broker_pending",
     "read_fresh_truth",
+    "read_order_readback",
+    "resting_orders_from_detail_rows",
     "submit_day_order",
     "submit_and_cancel",
 ]

--- a/scripts/b0x/kr/kiwoom.py
+++ b/scripts/b0x/kr/kiwoom.py
@@ -807,13 +807,23 @@ async def read_broker_pending(
     own_order_ids: frozenset[str],
     order_date: str | None = None,
 ) -> BrokerPending | PendingUnreadable:
-    """자기 미체결 = 브로커 직접 조회 (§39차 ②). Any failure → tri-state."""
+    """자기 미체결 = 당일 브로커 resting 조회 (§39차 ②). Any failure → tri-state.
+
+    `read_resting_orders` owns the current-day default. Keeping the wrapper
+    here (rather than calling `read_order_detail(order_date=None)` directly)
+    preserves the existing ACCEPTANCE_ONLY/readiness contract: an omitted date
+    is a trading-day query, never a broker-default historical query.
+    """
 
     try:
-        rows = await account.read_order_detail(order_date=order_date)
+        resting = (
+            await account.read_resting_orders()
+            if order_date is None
+            else await account.read_resting_orders(order_date=order_date)
+        )
     except Exception as exc:  # noqa: BLE001 — any failure is "unknown"
         return pending_unreadable(type(exc).__name__)
-    return broker_pending_from_detail_rows(rows=rows, own_order_ids=own_order_ids)
+    return BrokerPending(account_orders=resting, own_order_ids=own_order_ids)
 
 
 def broker_truth_from(

--- a/scripts/b0x/kr/kiwoom_attribution.py
+++ b/scripts/b0x/kr/kiwoom_attribution.py
@@ -193,6 +193,82 @@ class OwnOrderJournal:
         return frozenset(record.order_no for record in self.read_all())
 
 
+@dataclass(frozen=True, slots=True)
+class RealizedPnlInput:
+    """The only P&L fact this lane can currently prove without inventing one.
+
+    The Kiwoom mock detail surface provides fills and remaining quantity, but
+    not a dedicated net realized-P&L field (including fees).  A zero is safe
+    only for the bootstrap case where the complete append-only B0-X journal
+    proves that this UTC day has no B0-X order activity at all.  Once activity
+    exists, the correct value is unreadable until a dedicated P&L evidence
+    source is wired; it must never become a fabricated ``Decimal('0')``.
+    """
+
+    value: Decimal | None
+    source: str
+    reason: str | None = None
+
+    @property
+    def readable(self) -> bool:
+        return self.value is not None
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "readable": self.readable,
+            "value": None if self.value is None else format(self.value, "f"),
+            "source": self.source,
+            "reason": self.reason,
+        }
+
+
+def realized_pnl_input_today(
+    *, journal: OwnOrderJournal, now: dt.datetime
+) -> RealizedPnlInput:
+    """Return a provable bootstrap zero or an explicit unreadable input."""
+
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    try:
+        records = journal.read_all()
+    except Exception as exc:  # noqa: BLE001 — corrupt evidence is not a zero
+        return RealizedPnlInput(
+            value=None,
+            source="own_order_journal",
+            reason=f"journal_unreadable:{type(exc).__name__}",
+        )
+
+    current_day = now.astimezone(dt.UTC).date()
+    for record in records:
+        try:
+            timestamp = dt.datetime.fromisoformat(record.at.replace("Z", "+00:00"))
+        except ValueError:
+            return RealizedPnlInput(
+                value=None,
+                source="own_order_journal",
+                reason="journal_timestamp_unreadable",
+            )
+        if timestamp.tzinfo is None:
+            return RealizedPnlInput(
+                value=None,
+                source="own_order_journal",
+                reason="journal_timestamp_timezone_missing",
+            )
+        if timestamp.astimezone(dt.UTC).date() == current_day:
+            return RealizedPnlInput(
+                value=None,
+                source="own_order_journal",
+                reason=(
+                    "own_order_activity_exists_today_without_dedicated_"
+                    "realized_pnl_source"
+                ),
+            )
+    return RealizedPnlInput(
+        value=Decimal("0"),
+        source="own_order_journal_no_b0x_activity_today",
+    )
+
+
 class OrderDetailReader(Protocol):
     """``ReadOnlyKiwoomMockAccount.read_order_detail`` — the injection seam."""
 
@@ -320,7 +396,9 @@ __all__ = [
     "OrderDetailReader",
     "OwnOrderJournal",
     "OwnOrderRecord",
+    "RealizedPnlInput",
     "build_attribution",
     "kst_order_date",
     "read_own_attribution",
+    "realized_pnl_input_today",
 ]

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -10,18 +10,14 @@ that all come from the venue being *stronger*, not weaker:
    v1.6 ① ledger exception is *not* used and must not be — it is scoped to a
    venue with no pending surface. See :mod:`scripts.b0x.kr.kiwoom`.
 2. **Two mutation modes are deliberately separate.** ``ACCEPTANCE_ONLY``
-   remains one submit → cancel → reconcile round trip. ``INTERIM_ORDERING``
-   submits every envelope-derived DAY order and deliberately leaves it at the
+   remains one submit → cancel → reconcile round trip. ``ORDERING`` submits
+   every eligible envelope-derived DAY order and deliberately leaves it at the
    broker; it is never the default and it never inherits the acceptance cancel.
-3. **No account-wide durable lease exists for this account.** The kis lane
-   holds ``KISMockWriterLease``; there is no kiwoom equivalent in this repo and
-   this module does not invent one. What it does instead is check the account's
-   own **same-day order rows** for activity B0-X did not author
-   (:func:`foreign_same_day_orders`) — broker evidence, which is strictly
-   better than the kis lane's ledger shadow, and which is also the empirical
-   form of the "KR-B1 이 지금 주문을 내고 있으면 착수하지 마라" gate. It is a
-   *detection*, not a lock: exclusivity itself remains an operator action
-   (KR-B1 비활성 확인).
+3. **ORDERING has a writer lease and a broker-truth mutation boundary.** The
+   account-keyed lease is checked before every submit/cancel, and one fresh
+   ``kt00007`` answer derives both pending and same-day foreign activity. A
+   read failure, foreign trace, or lost lease closes that boundary before a
+   mutation can leave the process.
 
 §39차 ③ — legacy 불가침
 ------------------------
@@ -46,6 +42,7 @@ before any network call and this lane never offers the choice.
 from __future__ import annotations
 
 import datetime as dt
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
@@ -63,6 +60,7 @@ from scripts.b0x.kill_switch import evaluate as evaluate_kill_switch
 from scripts.b0x.kr import attribution as kr_attribution
 from scripts.b0x.kr import kiwoom as kiwoom_lane
 from scripts.b0x.kr import kiwoom_attribution as kiwoom_attr
+from scripts.b0x.kr import kiwoom_ordering as ordering_support
 from scripts.b0x.labels import account_history_labels, header_labels
 from scripts.b0x.ledger import (
     DEFAULT_OBSERVATION_DIR,
@@ -93,10 +91,10 @@ KR_CONTRACT_CLAUSES: Final[dict[str, str]] = {
     "§39차 ①②③④⑤": (
         "별도 모듈 · 브로커 직접 미체결 · legacy 불가침 귀속 게이트 · "
         "§4 KR 열 수치 불변 + KRX RTH only · ACCEPTANCE_ONLY 제출→조회→취소→"
-        "reconcile 보존 + INTERIM_ORDERING DAY 주문 잔존."
+        "reconcile 보존 + ORDERING DAY lifecycle/readback/lease."
     ),
 }
-KR_ACCOUNT_MAP_COMMIT: Final[str] = "09c3fc16fcacbc47060e8aa1aa3e8beed0a74028"
+KR_ACCOUNT_MAP_COMMIT: Final[str] = "a43e36e9bc50d7a93bba009bea96172e10dc4de8"
 KR_ACCOUNT_MAP_VALUES: Final[dict[str, str]] = {
     "account_lanes.kiwoom_mock": "KR-B1",
     "b0x_adapter_orders_20260808.surfaces": "∋ kiwoom_mock (§39차 한시, KRX RTH only)",
@@ -107,25 +105,14 @@ KR_ACCOUNT_MAP_VALUES: Final[dict[str, str]] = {
     ),
     "surface": "kiwoom_mock",
 }
-type CycleMode = Literal["acceptance", "interim_ordering"]
+type CycleMode = Literal["acceptance", "ordering"]
 
 ACCEPTANCE_MODE: Final[CycleMode] = "acceptance"
-INTERIM_ORDERING_MODE: Final[CycleMode] = "interim_ordering"
+ORDERING_MODE: Final[CycleMode] = "ordering"
 
 PREVIEW_STATUS: Final[str] = "OBSERVATION_DERIVATION_ONLY"
 ACCEPTANCE_ONLY_STATUS: Final[str] = "ACCEPTANCE_ONLY"
-INTERIM_ORDERING_STATUS: Final[str] = "INTERIM_ORDERING"
-
-#: §50차 2항: first INTERIM sessions are deliberately buy-only. This is a
-#: code-level default, not a CLI/environment dial; lifting it needs explicit
-#: operator approval or the B-track's proper sell path.
-INTERIM_BUY_ONLY_SELL_GATE_ENABLED: Final[bool] = True
-INTERIM_BUY_ONLY_SELL_GATE_REASON: Final[str] = "interim_buy_only_sell_gate"
-INTERIM_BUY_ONLY_SELL_GATE_DETAIL: Final[str] = (
-    "INTERIM_ORDERING first sessions are buy-only; sell submission is blocked "
-    "until explicit operator approval or B-track merge"
-)
-INTERIM_BUY_ONLY_CONSTRAINT: Final[str] = "매수 전용(매도 게이트 ON)"
+ORDERING_STATUS: Final[str] = "ORDERING"
 
 PREVIEW_STATUS_LABEL: Final[str] = (
     "OBSERVATION_DERIVATION_ONLY — kiwoom_mock cycle 지위는 유지된다. 이 수동 mock "
@@ -141,26 +128,24 @@ ACCEPTANCE_ONLY_STATUS_LABEL: Final[str] = (
     "기본값은 preview 이며, 이 경로는 DAY 주문 잔존을 만들지 않는다."
 )
 
-#: §49차 A's exact, deliberately non-clean status. Keep all accepted residual
-#: constraints in the visible artifact label, rather than implying a completed
-#: production-quality ordering surface.
-INTERIM_ORDERING_STATUS_LABEL: Final[str] = (
-    "INTERIM_ORDERING — kiwoom_mock 한시 DAY 주문 잔존 모드. 제약: 일손실 kill "
-    "미배선(realized_pnl_today 소스 없음 → −2.5% NAV kill 발화 불가); 공존 계좌 "
-    "TOCTOU 잔존(KR-B1 foreign trace는 착수 preflight 1회); kiwoom 한정; "
-    "KRX RTH only; 매수 전용(매도 게이트 ON)."
+ORDERING_STATUS_LABEL: Final[str] = (
+    "ORDERING — kiwoom_mock 별도 DAY 주문 lifecycle 모드. 정책표 결정 파생만 §4 "
+    "cap 안에서 제출하며, ACCEPTANCE_ONLY 왕복 취소를 상속하지 않는다. 각 mutation "
+    "직전 account writer lease + kt00007 pending/당일 foreign trace를 fresh 재조회한다. "
+    "일손실 입력 unreadable·foreign trace·read failure·lease loss는 주문 0; 매도는 "
+    "자기 귀속 broker fill 수량까지만; kill은 자기 미체결 전부 취소 시도 후 재조회로 "
+    "확인한다. KRX RTH only."
 )
 
-INTERIM_ORDERING_CONSTRAINTS: Final[dict[str, str]] = {
-    "daily_loss_kill": (
-        "일손실 kill 미배선 — realized_pnl_today 소스가 없어 −2.5% NAV kill은 발화 불가"
-    ),
-    "coexisting_account_toctou": (
-        "공존 계좌 TOCTOU 잔존 — KR-B1 foreign trace는 착수 preflight 1회 관측"
-    ),
-    "venue": "kiwoom 한정",
-    "session": "KRX RTH only",
-    "buy_only": INTERIM_BUY_ONLY_CONSTRAINT,
+ORDERING_REQUIREMENTS: Final[dict[str, str]] = {
+    "table_only": "policy_table deterministic derivation within locked §4 envelope",
+    "day": "default TIF is DAY; successful acknowledgement is never auto-cancelled",
+    "lifecycle": "journal immediately after broker acknowledgement plus broker readback",
+    "sell": "sell quantity is bounded by fresh attributed broker fills",
+    "mutation_boundary": "fresh pending + same-day foreign trace before every mutation",
+    "lease": "account-keyed writer lease checked before every mutation",
+    "pnl": "unreadable realized P&L input yields zero new orders",
+    "kill": "kill cancels every own pending order and re-reads broker confirmation",
 }
 
 #: This account is not B0-X's alone, and the artifact must say so every time.
@@ -179,9 +164,8 @@ OUTSIDE_RTH_REASON: ZeroOrderReason = "outside_krx_regular_session"
 #: this bounded interval. A contract requirement, not a CLI parameter.
 PREFLIGHT_MAX_AGE_SECONDS = 5 * 60
 
-#: The legacy acceptance lever stays intentionally bounded. This constant is
-#: never consulted by ``INTERIM_ORDERING``; that mode submits the full,
-#: already-envelope-limited derivation.
+#: The legacy acceptance lever stays intentionally bounded.  ORDERING has its
+#: own submission path and never consults this value.
 ACCEPTANCE_SUBMISSION_LIMIT = 1
 
 #: 🔴 There is no flag that skips the cancel on ACCEPTANCE_ONLY. Its record
@@ -195,26 +179,18 @@ ROUND_TRIP_MANDATORY_NOTE: Final[str] = (
 #: Kill-trip cancellation is *supported* here — the kis lane's
 #: ``KILL_TRIPPED_CANCEL_UNSUPPORTED`` literal must never appear on this lane.
 KILL_CANCEL_SUPPORTED_NOTE: Final[str] = (
-    "신규 주문 중단. 🔴 kiwoom 은 kt00007 미체결조회와 kt10003 취소를 지원하므로 "
-    "kis_mock 의 「구조적 시도 불가」가 여기서는 성립하지 않는다. 다만 이 사이클은 "
-    "kill 발화로 파생 자체가 0 이라 취소 대상이 생기지 않았다. ACCEPTANCE_ONLY 는 "
-    "자기 주문을 같은 사이클 안에서 회수하지만, INTERIM_ORDERING 은 DAY 주문을 "
-    "자동 취소하지 않는다. 재개는 운영자 결정 (계약 §2-4)."
+    "신규 주문 중단. kiwoom ORDERING 은 kt00007로 자기 미체결을 재조회하고 각 "
+    "잔량에 kt10003 취소를 시도한 뒤 broker 재조회로 남은 수량을 확인한다. 취소/"
+    "재조회 실패는 성공으로 기록하지 않으며 재개는 운영자 결정 (계약 §2-4)."
 )
 
 DAY_ORDER_RETAINED_NOTE: Final[str] = (
-    "DAY_ORDER_RETAINED — INTERIM_ORDERING 은 envelope 파생 전건을 broker에 "
-    "제출하고 즉시 취소하지 않는다. submitted는 접수/주문번호 증거만 뜻하며 "
-    "filled를 뜻하지 않는다."
+    "DAY_ORDER_RETAINED — ORDERING 은 envelope 파생 주문을 DAY로 제출하고 "
+    "성공 직후 자동 취소하지 않는다. broker_ack은 접수 증거이고 filled를 뜻하지 "
+    "않으며, 후속 broker readback이 partial/fill/remaining을 보존한다."
 )
 
-#: Realized P&L has no source on this lane either — stated so a reader does not
-#: read a structural absence as a measured zero.
-KR_REALIZED_PNL_UNAVAILABLE: Final[str] = (
-    "realized_pnl_today has no source on this lane — B0-X fills are not "
-    "reconciled into a P&L ledger, so the −2.5% NAV kill cannot fire. "
-    "Not a measured zero."
-)
+REALIZED_PNL_UNAVAILABLE_REASON: Final[str] = "realized_pnl_unavailable"
 
 KR_ATTRIBUTED_NAV_BASIS: Final[str] = (
     "nav = cash + 자기 귀속 평가금액(지분 비례). legacy 평가금액은 제외 — §4 "
@@ -313,6 +289,7 @@ def broker_state(
     attribution: (
         kr_attribution.OwnFillAttribution | kr_attribution.AttributionUnreadable | None
     ) = None,
+    realized_pnl_today: Decimal = Decimal("0"),
 ) -> LaneAccountState:
     """kiwoom_mock account state, derived entirely from this cycle's reads.
 
@@ -339,7 +316,7 @@ def broker_state(
         # cumulative deployment, so derivation refuses additions rather than
         # sizing them against a figure that shrinks on a partial sell.
         cumulative_deployment_readable=False,
-        realized_pnl_today=Decimal("0"),
+        realized_pnl_today=realized_pnl_today,
         nav=fresh.cash + scoped.attributed_evaluation,
     )
 
@@ -539,13 +516,12 @@ def _confirm_preflight_record(
         },
         "writer_lease": {
             "acquired": False,
-            "surface": "b0x_adapter",
+            "surface": "ACCEPTANCE_ONLY",
             "note": (
-                "이 계좌에는 kis_mock 의 KISMockWriterLease 같은 durable lease 가 "
-                "없다. 대신 (a) B0-X 프로세스 간 flock writer_lock, (b) 브로커 "
-                "당일 주문 흔적 기반 외부 writer 탐지를 쓴다. 계좌 배타성 자체는 "
-                "운영 조치(KR-B1 비활성 확인)로만 확보된다 — lease 가 있다고 "
-                "주장하지 않는다."
+                "이 retained acceptance lever는 ORDERING의 account-keyed lease를 "
+                "획득하지 않는다. ORDERING은 별도 host-local fcntl lease와 매 "
+                "mutation kt00007 foreign-trace boundary를 사용한다; 어느 쪽도 "
+                "KR-B1 비활성 확인이라는 운영 조치를 대체하지 않는다."
             ),
         },
         "passed": not reasons,
@@ -587,14 +563,19 @@ def _preflight_truth_unavailable_record(
             "fail_closed": "account truth unavailable before KR-B1 inactive check",
             "residual_toctou": "preflight_once_before_submission",
         },
-        "writer_lease": {"acquired": False, "surface": "b0x_adapter"},
+        "writer_lease": {
+            "acquired": False,
+            "surface": "ACCEPTANCE_ONLY",
+            "note": "the retained acceptance lever does not claim ORDERING's "
+            "account-keyed writer lease",
+        },
         "passed": False,
         "reasons": ["account_truth_unavailable"],
         "error_type": type(error).__name__,
     }
 
 
-async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept flat
+async def _run_prepared_cycle(  # noqa: PLR0915 — retained acceptance path
     *,
     now: dt.datetime,
     table: PolicyTable,
@@ -604,12 +585,16 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
     ledger: ObservationLedger,
     record: dict[str, Any],
     confirm: bool,
-    mode: CycleMode,
     account: kiwoom_lane.ReadOnlyKiwoomMockAccount | None,
     journal: kiwoom_attr.OwnOrderJournal,
     account_identity: dict[str, str] | None,
 ) -> KiwoomCycleOutcome:
-    """Account truth → 귀속 → derive → plan → explicitly selected mutation mode."""
+    """Preserved ``ACCEPTANCE_ONLY`` submit → cancel → reconcile lever.
+
+    This deliberately has no DAY-retention branch.  ORDERING is implemented in
+    :func:`_run_ordering_cycle` below so changing its status literal cannot turn
+    this historical acceptance workflow into a production-ordering workflow.
+    """
 
     if account is None:
         account = kiwoom_lane.ReadOnlyKiwoomMockAccount()
@@ -637,13 +622,10 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
             detail="account_truth_unavailable",
         )
 
-    # 🔴 Journal read failure is not "we authored nothing" — it propagates as
-    # AttributionUnreadable below and as an empty own-id set here, which only
-    # widens the pending superset (more blocking, never less).
     try:
         own_order_ids = journal.own_order_ids()
         journal_readable = True
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001 — unreadable evidence is not empty evidence
         own_order_ids = frozenset()
         journal_readable = False
     record["own_order_journal"] = {
@@ -651,14 +633,9 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
         "readable": journal_readable,
         "recorded_order_count": len(own_order_ids),
     }
-
     pending = await kiwoom_lane.read_broker_pending(
         account, own_order_ids=own_order_ids
     )
-    # 🔴 kt00009 is recorded, never gating — 2026-08-12 measured it answering
-    # ``return_code=0`` with an empty array while B0-X orders were live. Keeping
-    # the count in the artifact is what makes that claim checkable, and what
-    # will show it changing if the mock is ever fixed.
     record["order_status_diagnostic"] = await account.read_order_status_diagnostic()
     record["fresh_truth"] = fresh.status_only(pending)
     record["own_pending_source"] = kiwoom_lane.OWN_PENDING_SOURCE
@@ -673,7 +650,6 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
         "source": kiwoom_attr.ATTRIBUTION_SOURCE,
         "nav_basis": KR_ATTRIBUTED_NAV_BASIS,
     }
-
     halted = halted_suspect_symbols(table)
     record["halted_suspect"] = {
         "source": "policy_table.universe.halted_suspect (ROB-1236)",
@@ -731,14 +707,7 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
             "kill_switch": decision.canonical(),
         }
     )
-
     if decision.tripped:
-        notice = decision.operator_notice(
-            lane=LANE, remaining_orders_note=KILL_CANCEL_SUPPORTED_NOTE
-        )
-        if notice:
-            ledger.record_notice(at=now, text=notice, lane=LANE)
-            record["operator_notice"] = notice
         record["planned"] = []
         record["blocked"] = []
         record["submitted"] = []
@@ -753,9 +722,6 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
     )
     record["planned"] = [order.to_json() for order in planned]
     record["blocked"] = [order.to_json() for order in blocked]
-
-    round_trips: list[dict[str, Any]] = []
-    day_orders: list[dict[str, Any]] = []
     if not confirm:
         record["submission_skipped"] = "confirm=False — preview only"
         record["submitted"] = []
@@ -765,14 +731,11 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
             outcome=outcome, ledger=ledger, record=record, labels=labels
         )
 
-    if mode == ACCEPTANCE_MODE:
-        record["round_trip_policy"] = ROUND_TRIP_MANDATORY_NOTE
-    else:
-        record["day_order_policy"] = DAY_ORDER_RETAINED_NOTE
+    record["round_trip_policy"] = ROUND_TRIP_MANDATORY_NOTE
+    round_trips: list[dict[str, Any]] = []
     incomplete: kiwoom_lane.RoundTripIncomplete | None = None
-
     for index, order in enumerate(planned):
-        if mode == ACCEPTANCE_MODE and index >= ACCEPTANCE_SUBMISSION_LIMIT:
+        if index >= ACCEPTANCE_SUBMISSION_LIMIT:
             record["submission_stopped"] = (
                 f"acceptance_submission_limit={ACCEPTANCE_SUBMISSION_LIMIT}"
             )
@@ -785,65 +748,16 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
         ):
             record["submission_stopped"] = "preflight_expired"
             break
-
-        # 🔴 §39차 ③ at the mutation boundary. A SELL may only ever reach shares
-        # this lane's own fills paid for. Derivation already refused legacy
-        # symbols (they are not in ``state.positions`` at all); this second line
-        # is deliberately redundant, because a one-line regression there becomes
-        # a sale of KR-B1's shares.
         if order.side == "sell":
-            try:
-                kr_attribution.assert_sell_is_own(
-                    scoped,
-                    symbol=order.symbol,
-                    quantity=Decimal(order.quantity),
-                    lane=LANE,
-                )
-            except kr_attribution.LegacyPositionSellBlocked as exc:
-                record.setdefault("submission_blocked", []).append(
-                    {
-                        "symbol": order.symbol,
-                        "correlation_id": order.client_order_id,
-                        "reason": "legacy_position_sell_blocked",
-                        "detail": str(exc),
-                    }
-                )
-                if mode == INTERIM_ORDERING_MODE:
-                    # A foreign/legacy SELL cannot prevent independently safe
-                    # envelope-derived symbols from being considered.
-                    continue
-                record["submission_stopped"] = "legacy_position_sell_blocked"
-                break
-            if mode == ACCEPTANCE_MODE:
-                # 🔴 The acceptance lever is buy-only. Even an attributed sell
-                # is refused here rather than silently executed, because a sell
-                # that fills cannot be taken back by the mandatory cancel.
-                record.setdefault("submission_blocked", []).append(
-                    {
-                        "symbol": order.symbol,
-                        "correlation_id": order.client_order_id,
-                        "reason": "sell_leg_not_wired_on_acceptance_lever",
-                    }
-                )
-                record["submission_stopped"] = "sell_leg_not_wired"
-                break
-            if INTERIM_BUY_ONLY_SELL_GATE_ENABLED:
-                # §50차 2항: preserve the sell wiring and its own-attribution
-                # check above, but keep first INTERIM sessions buy-only at the
-                # final submission boundary. The artifact must name every
-                # suppressed sell; a quiet ``continue`` would be unauditable.
-                record.setdefault("submission_blocked", []).append(
-                    {
-                        "symbol": order.symbol,
-                        "correlation_id": order.client_order_id,
-                        "side": order.side,
-                        "leg": order.leg,
-                        "reason": INTERIM_BUY_ONLY_SELL_GATE_REASON,
-                        "detail": INTERIM_BUY_ONLY_SELL_GATE_DETAIL,
-                    }
-                )
-                continue
-
+            record.setdefault("submission_blocked", []).append(
+                {
+                    "symbol": order.symbol,
+                    "correlation_id": order.client_order_id,
+                    "reason": "sell_leg_not_wired_on_acceptance_lever",
+                }
+            )
+            record["submission_stopped"] = "sell_leg_not_wired"
+            break
         if order.symbol in halted:
             record.setdefault("submission_blocked", []).append(
                 {
@@ -852,15 +766,8 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
                     "reason": "halted_suspect_symbol",
                 }
             )
-            if mode == INTERIM_ORDERING_MODE:
-                # A table-integrity backstop is scoped to this symbol; preserve
-                # the all-eligible-orders property for the remaining plan.
-                continue
             record["submission_stopped"] = "halted_suspect_symbol"
             break
-
-        # Re-read the broker's resting set immediately before the dispatch: the
-        # preflight snapshot is evidence, this is the mutation boundary.
         current_pending = await kiwoom_lane.read_broker_pending(
             account, own_order_ids=own_order_ids
         )
@@ -868,24 +775,14 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
             position_symbols=scoped.cap_position_symbols, pending=current_pending
         )
         try:
-            if mode == ACCEPTANCE_MODE:
-                trip = await kiwoom_lane.submit_and_cancel(
-                    account,
-                    planned=order,
-                    broker_truth=current_truth,
-                    record_order_no=_journal_writer(journal),
-                    now=submitted_at,
-                )
-                round_trips.append(trip.canonical())
-            else:
-                day_order = await kiwoom_lane.submit_day_order(
-                    account,
-                    planned=order,
-                    broker_truth=current_truth,
-                    record_order_no=_journal_writer(journal),
-                    now=submitted_at,
-                )
-                day_orders.append(day_order.canonical())
+            trip = await kiwoom_lane.submit_and_cancel(
+                account,
+                planned=order,
+                broker_truth=current_truth,
+                record_order_no=_journal_writer(journal),
+                now=submitted_at,
+            )
+            round_trips.append(trip.canonical())
         except OwnPendingResubmitBlocked as exc:
             record.setdefault("submission_dedup_blocked", []).append(
                 {
@@ -895,11 +792,6 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
                     "detail": str(exc),
                 }
             )
-            if mode == INTERIM_ORDERING_MODE:
-                # The broker's pending answer blocks this symbol only. Keep
-                # evaluating other envelope-derived symbols in this explicit
-                # all-eligible-orders mode.
-                continue
             record["submission_stopped"] = "dedup_blocked"
             break
         except kiwoom_lane.RoundTripIncomplete as exc:
@@ -907,36 +799,800 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — linear cycle script, kept fl
             record["submission_stopped"] = "round_trip_incomplete"
             record.setdefault("round_trip_failures", []).append(str(exc))
             break
+
+    record["round_trip"] = round_trips
+    record["day_orders"] = []
+    record["submitted"] = [
+        {
+            "correlation_id": trip["correlation_id"],
+            "symbol": trip["symbol"],
+            "order_no": trip["order_no"],
+            "submitted": trip["submitted"],
+        }
+        for trip in round_trips
+    ]
+    if incomplete is not None:
+        outcome.exit_code = 2
+    return _persist_outcome(
+        outcome=outcome, ledger=ledger, record=record, labels=labels
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MutationBoundary:
+    """One coherent, immediately-pre-mutation broker observation.
+
+    ``kt00007`` is queried exactly once for the boundary.  Both the account
+    pending set and foreign same-day trace are derived from that same answer,
+    preventing an accidental split-brain preflight where those facts came from
+    two different broker moments.
+    """
+
+    at: dt.datetime
+    pending: kiwoom_lane.BrokerPending | PendingUnreadable
+    foreign: ForeignSameDayOrders | PendingUnreadable
+    lease_held: bool
+    blocking_reason: str | None = None
+    detail: str | None = None
+
+    @property
+    def clean(self) -> bool:
+        return (
+            self.blocking_reason is None
+            and not isinstance(self.pending, PendingUnreadable)
+            and not isinstance(self.foreign, PendingUnreadable)
+            and self.foreign.count == 0
+        )
+
+    def canonical(self, *, action: str) -> dict[str, Any]:
+        return {
+            "at": self.at.isoformat(),
+            "action": action,
+            "lease_held": self.lease_held,
+            "pending": self.pending.canonical(),
+            "foreign_same_day_orders": self.foreign.canonical(),
+            "clean": self.clean,
+            "blocking_reason": self.blocking_reason,
+            "detail": self.detail,
+        }
+
+
+def _foreign_same_day_orders_from_rows(
+    *, rows: list[dict[str, Any]], own_order_ids: frozenset[str]
+) -> ForeignSameDayOrders:
+    """Pure foreign-trace projection from the same rows used for pending."""
+
+    foreign_ids: list[str] = []
+    foreign_symbols: set[str] = set()
+    for row in rows:
+        order_id = str(row.get("order_id") or "").strip()
+        if not order_id or order_id in own_order_ids:
+            continue
+        foreign_ids.append(order_id)
+        symbol = str(row.get("symbol") or "").strip()
+        if symbol:
+            foreign_symbols.add(symbol)
+    return ForeignSameDayOrders(
+        order_ids=tuple(sorted(foreign_ids)), symbols=tuple(sorted(foreign_symbols))
+    )
+
+
+async def _read_mutation_boundary(
+    *,
+    account: kiwoom_lane.ReadOnlyKiwoomMockAccount,
+    journal: kiwoom_attr.OwnOrderJournal,
+    lease: ordering_support.WriterLease,
+    at: dt.datetime,
+) -> MutationBoundary:
+    """Fresh lease + one same-day ``kt00007`` read; any failure closes it."""
+
+    try:
+        lease.assert_held()
+    except Exception as exc:  # noqa: BLE001 — lost authority cannot be retried open
+        unreadable = kiwoom_lane.pending_unreadable(
+            f"writer_lease:{type(exc).__name__}"
+        )
+        return MutationBoundary(
+            at=at,
+            pending=unreadable,
+            foreign=unreadable,
+            lease_held=False,
+            blocking_reason="writer_lease_lost",
+            detail=type(exc).__name__,
+        )
+
+    try:
+        own_order_ids = journal.own_order_ids()
+    except Exception as exc:  # noqa: BLE001 — corrupt ownership is not empty ownership
+        unreadable = kiwoom_lane.pending_unreadable(
+            f"own_order_journal:{type(exc).__name__}"
+        )
+        return MutationBoundary(
+            at=at,
+            pending=unreadable,
+            foreign=unreadable,
+            lease_held=True,
+            blocking_reason="own_order_journal_unreadable",
+            detail=type(exc).__name__,
+        )
+
+    try:
+        rows = await account.read_order_detail(
+            order_date=kiwoom_attr.kst_order_date(at)
+        )
+    except Exception as exc:  # noqa: BLE001 — failed foreign/pending read is closed
+        unreadable = kiwoom_lane.pending_unreadable(f"kt00007:{type(exc).__name__}")
+        return MutationBoundary(
+            at=at,
+            pending=unreadable,
+            foreign=unreadable,
+            lease_held=True,
+            blocking_reason="mutation_boundary_read_unavailable",
+            detail=type(exc).__name__,
+        )
+
+    pending = kiwoom_lane.broker_pending_from_detail_rows(
+        rows=rows, own_order_ids=own_order_ids
+    )
+    foreign = _foreign_same_day_orders_from_rows(rows=rows, own_order_ids=own_order_ids)
+    return MutationBoundary(
+        at=at,
+        pending=pending,
+        foreign=foreign,
+        lease_held=True,
+        blocking_reason=("foreign_same_day_orders_present" if foreign.count else None),
+        detail=(None if not foreign.count else f"foreign_order_count={foreign.count}"),
+    )
+
+
+def _append_ordering_event(
+    *,
+    journal: ordering_support.OrderingEventJournal,
+    record: dict[str, Any],
+    event: dict[str, Any],
+) -> None:
+    """Append lifecycle evidence before adding its non-authoritative summary."""
+
+    journal.append(event)
+    record.setdefault("fidelity_events", []).append(event)
+
+
+def _finish_ordering_stopped(
+    *,
+    outcome: KiwoomCycleOutcome,
+    ledger: ObservationLedger,
+    record: dict[str, Any],
+    labels: tuple[str, ...],
+    reason: str,
+    detail: str,
+) -> KiwoomCycleOutcome:
+    """Stop further mutations without erasing already broker-acknowledged work."""
+
+    record["submission_stopped"] = reason
+    record["no_further_mutations"] = True
+    record.setdefault("ordering_failures", []).append(
+        {"reason": reason, "detail": detail}
+    )
+    if record.get("submitted"):
+        outcome.exit_code = 2
+        return _persist_outcome(
+            outcome=outcome, ledger=ledger, record=record, labels=labels
+        )
+    return _finish_zero_order(
+        outcome=outcome,
+        ledger=ledger,
+        record=record,
+        labels=labels,
+        reason=reason,
+        detail=detail,
+    )
+
+
+def _record_ordering_boundary(
+    *,
+    boundary: MutationBoundary,
+    action: str,
+    fidelity: ordering_support.OrderingEventJournal,
+    record: dict[str, Any],
+) -> None:
+    evidence = boundary.canonical(action=action)
+    record.setdefault("mutation_boundaries", []).append(evidence)
+    _append_ordering_event(
+        journal=fidelity,
+        record=record,
+        event={"at": boundary.at.isoformat(), "event": "mutation_boundary", **evidence},
+    )
+
+
+async def _cancel_own_pending_on_kill(  # noqa: PLR0915 — linear safety sequence
+    *,
+    account: kiwoom_lane.ReadOnlyKiwoomMockAccount,
+    journal: kiwoom_attr.OwnOrderJournal,
+    fidelity: ordering_support.OrderingEventJournal,
+    lease: ordering_support.WriterLease,
+    now: dt.datetime,
+    outcome: KiwoomCycleOutcome,
+    ledger: ObservationLedger,
+    record: dict[str, Any],
+    labels: tuple[str, ...],
+) -> KiwoomCycleOutcome:
+    """Cancel every currently-own resting order and prove the result by re-read."""
+
+    initial = await _read_mutation_boundary(
+        account=account, journal=journal, lease=lease, at=dt.datetime.now(dt.UTC)
+    )
+    _record_ordering_boundary(
+        boundary=initial,
+        action="kill_initial_cancel_inventory",
+        fidelity=fidelity,
+        record=record,
+    )
+    if not initial.clean:
+        outcome.exit_code = 2
+        return _finish_ordering_stopped(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="kill_cancel_boundary_not_clean",
+            detail=initial.blocking_reason or "unknown_boundary_failure",
+        )
+    assert isinstance(initial.pending, kiwoom_lane.BrokerPending)
+    record["kill_cancellation"] = {
+        "required": True,
+        "initial_own_resting_count": len(initial.pending.own_orders),
+        "attempts": [],
+        "confirmed": False,
+    }
+
+    for initial_order in initial.pending.own_orders:
+        boundary = await _read_mutation_boundary(
+            account=account, journal=journal, lease=lease, at=dt.datetime.now(dt.UTC)
+        )
+        _record_ordering_boundary(
+            boundary=boundary,
+            action=f"kill_cancel:{initial_order.order_id}",
+            fidelity=fidelity,
+            record=record,
+        )
+        if not boundary.clean:
+            outcome.exit_code = 2
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="kill_cancel_boundary_not_clean",
+                detail=boundary.blocking_reason or "unknown_boundary_failure",
+            )
+        assert isinstance(boundary.pending, kiwoom_lane.BrokerPending)
+        current = next(
+            (
+                item
+                for item in boundary.pending.own_orders
+                if item.order_id == initial_order.order_id
+            ),
+            None,
+        )
+        if current is None:
+            continue
+        try:
+            source = next(
+                item for item in journal.read_all() if item.order_no == current.order_id
+            )
+        except Exception as exc:  # noqa: BLE001 — cannot prove cancel ownership
+            outcome.exit_code = 2
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="kill_cancel_ownership_unreadable",
+                detail=type(exc).__name__,
+            )
+        attempt: dict[str, Any] = {
+            "at": dt.datetime.now(dt.UTC).isoformat(),
+            "original_order_no": current.order_id,
+            "symbol": current.symbol,
+            "remaining_quantity": current.remaining_quantity,
+            "cancel_attempted": True,
+        }
+        try:
+            response = await account.cancel(
+                original_order_no=current.order_id,
+                symbol=current.symbol,
+                cancel_quantity=current.remaining_quantity,
+            )
+        except Exception as exc:  # noqa: BLE001 — response failure is not cancellation
+            attempt["cancel_response"] = {"error_type": type(exc).__name__}
+            record["kill_cancellation"]["attempts"].append(attempt)
+            _append_ordering_event(
+                journal=fidelity,
+                record=record,
+                event={"at": attempt["at"], "event": "cancel_failure", **attempt},
+            )
+            outcome.exit_code = 2
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="kill_cancel_failed",
+                detail=type(exc).__name__,
+            )
+        attempt["cancel_response"] = dict(response)
+        raw_cancel_no = str(response.get("ord_no") or "").strip()
+        if raw_cancel_no.isdigit() and raw_cancel_no != current.order_id:
+            journal.append(
+                kiwoom_attr.OwnOrderRecord(
+                    at=attempt["at"],
+                    order_no=raw_cancel_no,
+                    correlation_id=f"{source.correlation_id}:cancel:{raw_cancel_no}",
+                    symbol=current.symbol,
+                    side="cancel",
+                    price=current.ordered_price,
+                    quantity=current.remaining_quantity,
+                    order_date=kiwoom_attr.kst_order_date(now),
+                )
+            )
+            attempt["cancel_order_no"] = raw_cancel_no
+        record["kill_cancellation"]["attempts"].append(attempt)
+        _append_ordering_event(
+            journal=fidelity,
+            record=record,
+            event={"at": attempt["at"], "event": "cancel_ack", **attempt},
+        )
+
+        reconciled = await _read_mutation_boundary(
+            account=account,
+            journal=journal,
+            lease=lease,
+            at=dt.datetime.now(dt.UTC),
+        )
+        _record_ordering_boundary(
+            boundary=reconciled,
+            action=f"kill_cancel_reconcile:{current.order_id}",
+            fidelity=fidelity,
+            record=record,
+        )
+        if not reconciled.clean:
+            outcome.exit_code = 2
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="kill_cancel_reconcile_unreadable",
+                detail=reconciled.blocking_reason or "unknown_boundary_failure",
+            )
+        assert isinstance(reconciled.pending, kiwoom_lane.BrokerPending)
+        if any(
+            item.order_id == current.order_id for item in reconciled.pending.own_orders
+        ):
+            outcome.exit_code = 2
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="kill_cancel_not_confirmed",
+                detail=f"order_no={current.order_id}",
+            )
+
+    final = await _read_mutation_boundary(
+        account=account, journal=journal, lease=lease, at=dt.datetime.now(dt.UTC)
+    )
+    _record_ordering_boundary(
+        boundary=final,
+        action="kill_final_reconcile",
+        fidelity=fidelity,
+        record=record,
+    )
+    if not final.clean or not isinstance(final.pending, kiwoom_lane.BrokerPending):
+        outcome.exit_code = 2
+        return _finish_ordering_stopped(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="kill_final_reconcile_unreadable",
+            detail=final.blocking_reason or "pending_unreadable",
+        )
+    if final.pending.own_orders:
+        outcome.exit_code = 2
+        return _finish_ordering_stopped(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="kill_own_pending_remains",
+            detail=f"remaining_own_orders={len(final.pending.own_orders)}",
+        )
+    record["kill_cancellation"]["confirmed"] = True
+    record["planned"] = []
+    record["blocked"] = []
+    record["submitted"] = []
+    return _persist_outcome(
+        outcome=outcome, ledger=ledger, record=record, labels=labels
+    )
+
+
+async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
+    *,
+    now: dt.datetime,
+    table: PolicyTable,
+    envelope: Envelope,
+    labels: tuple[str, ...],
+    outcome: KiwoomCycleOutcome,
+    ledger: ObservationLedger,
+    record: dict[str, Any],
+    account: kiwoom_lane.ReadOnlyKiwoomMockAccount | None,
+    journal: kiwoom_attr.OwnOrderJournal,
+    lease: ordering_support.WriterLease,
+    realized_pnl_reader: Callable[..., kiwoom_attr.RealizedPnlInput],
+) -> KiwoomCycleOutcome:
+    """Independent ORDERING mode; it cannot fall through to acceptance cancel."""
+
+    if account is None:
+        account = kiwoom_lane.ReadOnlyKiwoomMockAccount()
+    fidelity = ordering_support.OrderingEventJournal.for_lane(
+        root=ledger.root, lane=LANE
+    )
+    record["fidelity_artifact"] = {
+        "path": str(fidelity.path),
+        "append_only": True,
+        "required_path": [
+            "table_price",
+            "intended_limit",
+            "broker_ack",
+            "partial_or_fill_vwap",
+            "cancel_or_reconcile",
+        ],
+    }
+    try:
+        prior_events = fidelity.read_all()
+    except Exception as exc:  # noqa: BLE001 — corrupted lifecycle is no lifecycle
+        return _finish_zero_order(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="ordering_fidelity_journal_unreadable",
+            detail=type(exc).__name__,
+        )
+    record["fidelity_artifact"]["prior_event_count"] = len(prior_events)
+    record["writer_lease"] = lease.canonical()
+    try:
+        fresh = await kiwoom_lane.read_fresh_truth(account)
+    except Exception as exc:  # noqa: BLE001
+        return _finish_zero_order(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="ordering_account_truth_unavailable",
+            detail=type(exc).__name__,
+        )
+    attribution = await kiwoom_attr.read_own_attribution(
+        journal=journal, read_order_detail=account.read_order_detail
+    )
+    scoped = scoped_positions(fresh=fresh, attribution=attribution)
+    boundary = await _read_mutation_boundary(
+        account=account, journal=journal, lease=lease, at=dt.datetime.now(dt.UTC)
+    )
+    _record_ordering_boundary(
+        boundary=boundary,
+        action="ordering_preflight",
+        fidelity=fidelity,
+        record=record,
+    )
+    record["ordering_preflight"] = {
+        "cash_present": bool(fresh.cash > 0),
+        "attribution_readable": scoped.unreadable is None,
+        "attribution": scoped.canonical(),
+        "mutation_boundary": boundary.canonical(action="ordering_preflight"),
+        "passed": bool(fresh.cash > 0 and scoped.unreadable is None and boundary.clean),
+    }
+    record["fresh_truth"] = fresh.status_only(boundary.pending)
+    record["attribution"] = {
+        **scoped.canonical(),
+        "source": kiwoom_attr.ATTRIBUTION_SOURCE,
+        "nav_basis": KR_ATTRIBUTED_NAV_BASIS,
+    }
+    record["own_pending_source"] = kiwoom_lane.OWN_PENDING_SOURCE
+    record["own_pending_basis"] = kiwoom_lane.OWN_PENDING_BASIS
+    if fresh.cash <= 0:
+        return _finish_zero_order(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="ordering_preflight_not_clean",
+            detail="cash_not_positive",
+        )
+    if scoped.unreadable is not None:
+        return _finish_zero_order(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="ordering_preflight_not_clean",
+            detail="attribution_unreadable",
+        )
+    if not boundary.clean:
+        return _finish_zero_order(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason="ordering_preflight_not_clean",
+            detail=boundary.blocking_reason or "mutation_boundary_not_clean",
+        )
+
+    pnl_input = realized_pnl_reader(journal=journal, now=now)
+    record["realized_pnl_input"] = pnl_input.canonical()
+    record["realized_pnl_source"] = pnl_input.source
+    if not pnl_input.readable:
+        return _finish_zero_order(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason=REALIZED_PNL_UNAVAILABLE_REASON,
+            detail=pnl_input.reason or "realized_pnl_input_unreadable",
+        )
+    assert pnl_input.value is not None
+    state = broker_state(
+        fresh=fresh,
+        pending=boundary.pending,
+        attribution=attribution,
+        realized_pnl_today=pnl_input.value,
+    )
+    record["broker_truth"] = state.broker_truth.canonical()
+    decision = evaluate_kill_switch(state=state, envelope=envelope)
+    derivation = derive_orders(
+        table=table,
+        state=state,
+        envelope=envelope,
+        kill_switch=decision,
+        lane_universe=None,
+        apply_envelope=True,
+    )
+    outcome.derivation = derivation
+    record.update(
+        {
+            "cycle_id": derivation.cycle_id,
+            "account_state_hash": derivation.account_state_hash,
+            "derivation_hash": derivation.derivation_hash(),
+            "orders": [order.canonical() for order in derivation.orders],
+            "skipped": [skip.canonical() for skip in derivation.skipped],
+            "kill_switch": decision.canonical(),
+            "day_order_policy": DAY_ORDER_RETAINED_NOTE,
+            "round_trip": [],
+        }
+    )
+    if decision.tripped:
+        notice = decision.operator_notice(
+            lane=LANE, remaining_orders_note=KILL_CANCEL_SUPPORTED_NOTE
+        )
+        if notice:
+            ledger.record_notice(at=now, text=notice, lane=LANE)
+            record["operator_notice"] = notice
+        return await _cancel_own_pending_on_kill(
+            account=account,
+            journal=journal,
+            fidelity=fidelity,
+            lease=lease,
+            now=now,
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+        )
+
+    held = {pos.symbol: pos.quantity for pos in state.positions}
+    planned, blocked = kiwoom_lane.plan_orders(
+        derivation.orders, envelope=envelope, held_quantities=held
+    )
+    record["planned"] = [order.to_json() for order in planned]
+    record["blocked"] = [order.to_json() for order in blocked]
+    record["halted_suspect"] = {
+        "source": "policy_table.universe.halted_suspect (ROB-1236)",
+        "symbols": list(halted_suspect_symbols(table)),
+    }
+    table_prices = {
+        order.order_key: format(order.table_price, "f") for order in derivation.orders
+    }
+    day_orders: list[dict[str, Any]] = []
+    record["submitted"] = day_orders
+    # Keep the acknowledgement collection visible even if a later readback
+    # fails.  A broker-accepted order must not disappear from the summary just
+    # because its lifecycle could not yet be proven complete.
+    record["day_orders"] = day_orders
+    halted = set(halted_suspect_symbols(table))
+    for order in planned:
+        intent_at = dt.datetime.now(dt.UTC)
+        intent = {
+            "at": intent_at.isoformat(),
+            "event": "table_price_to_intended_limit",
+            "order_key": order.order_key,
+            "correlation_id": order.client_order_id,
+            "symbol": order.symbol,
+            "side": order.side,
+            "table_price": table_prices.get(order.order_key),
+            "intended_limit": order.price,
+            "quantity": order.quantity,
+            "time_in_force": "DAY",
+        }
+        _append_ordering_event(journal=fidelity, record=record, event=intent)
+        if order.symbol in halted:
+            record.setdefault("submission_blocked", []).append(
+                {"symbol": order.symbol, "reason": "halted_suspect_symbol"}
+            )
+            continue
+        sell_scope = scoped
+        if order.side == "sell":
+            try:
+                sell_fresh = await kiwoom_lane.read_fresh_truth(account)
+                sell_attribution = await kiwoom_attr.read_own_attribution(
+                    journal=journal, read_order_detail=account.read_order_detail
+                )
+            except Exception as exc:  # noqa: BLE001 — failed fresh truth is closed
+                return _finish_ordering_stopped(
+                    outcome=outcome,
+                    ledger=ledger,
+                    record=record,
+                    labels=labels,
+                    reason="fresh_sell_attribution_unavailable",
+                    detail=type(exc).__name__,
+                )
+            sell_scope = scoped_positions(
+                fresh=sell_fresh, attribution=sell_attribution
+            )
+            if sell_scope.unreadable is not None:
+                return _finish_ordering_stopped(
+                    outcome=outcome,
+                    ledger=ledger,
+                    record=record,
+                    labels=labels,
+                    reason="fresh_sell_attribution_unavailable",
+                    detail="attribution_unreadable",
+                )
+            try:
+                kr_attribution.assert_sell_is_own(
+                    sell_scope,
+                    symbol=order.symbol,
+                    quantity=Decimal(order.quantity),
+                    lane=LANE,
+                )
+            except kr_attribution.LegacyPositionSellBlocked as exc:
+                record.setdefault("submission_blocked", []).append(
+                    {
+                        "symbol": order.symbol,
+                        "correlation_id": order.client_order_id,
+                        "reason": "own_fill_sell_gate_blocked",
+                        "detail": str(exc),
+                    }
+                )
+                continue
+            except Exception as exc:  # noqa: BLE001 — unknown sell proof is closed
+                return _finish_ordering_stopped(
+                    outcome=outcome,
+                    ledger=ledger,
+                    record=record,
+                    labels=labels,
+                    reason="fresh_sell_attribution_unavailable",
+                    detail=type(exc).__name__,
+                )
+        boundary = await _read_mutation_boundary(
+            account=account,
+            journal=journal,
+            lease=lease,
+            at=dt.datetime.now(dt.UTC),
+        )
+        _record_ordering_boundary(
+            boundary=boundary,
+            action=f"submit:{order.order_key}",
+            fidelity=fidelity,
+            record=record,
+        )
+        if not boundary.clean:
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="mutation_boundary_not_clean",
+                detail=boundary.blocking_reason or "unknown_boundary_failure",
+            )
+        current_truth = kiwoom_lane.broker_truth_from(
+            position_symbols=sell_scope.cap_position_symbols,
+            pending=boundary.pending,
+        )
+        try:
+            day_order = await kiwoom_lane.submit_day_order(
+                account,
+                planned=order,
+                broker_truth=current_truth,
+                record_order_no=_journal_writer(journal),
+                now=dt.datetime.now(dt.UTC),
+            )
+        except OwnPendingResubmitBlocked as exc:
+            record.setdefault("submission_dedup_blocked", []).append(
+                {
+                    "symbol": order.symbol,
+                    "correlation_id": order.client_order_id,
+                    "reason": "pending_recheck_blocked",
+                    "detail": str(exc),
+                }
+            )
+            continue
         except (
             kiwoom_lane.BrokerEchoMismatch,
             kiwoom_lane.KiwoomBrokerRejected,
         ) as exc:
-            # A submit response without usable acceptance evidence may have
-            # changed the external account. Stop immediately and preserve an
-            # auditable non-zero outcome instead of guessing about later legs.
-            if mode == ACCEPTANCE_MODE:
-                raise
             outcome.exit_code = 2
-            record["submission_stopped"] = "day_order_submission_unverified"
             record.setdefault("day_order_failures", []).append(str(exc))
-            break
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="day_order_submission_unverified",
+                detail=type(exc).__name__,
+            )
+        assert day_order.order_no is not None
+        ack = {
+            **day_order.canonical(),
+            "table_price": table_prices.get(order.order_key),
+        }
+        day_orders.append(ack)
+        _append_ordering_event(
+            journal=fidelity,
+            record=record,
+            event={
+                "at": dt.datetime.now(dt.UTC).isoformat(),
+                "event": "broker_ack",
+                "order_key": order.order_key,
+                "broker_ack": ack,
+            },
+        )
+        try:
+            readback = await kiwoom_lane.read_order_readback(
+                account,
+                planned=order,
+                order_no=day_order.order_no,
+                order_date=kiwoom_attr.kst_order_date(now),
+                at=dt.datetime.now(dt.UTC),
+            )
+        except (
+            kiwoom_lane.BrokerOrderReadbackUnavailable,
+            kiwoom_lane.BrokerEchoMismatch,
+        ) as exc:
+            outcome.exit_code = 2
+            ack["readback_failure"] = str(exc)
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="broker_readback_unavailable",
+                detail=type(exc).__name__,
+            )
+        readback_evidence = readback.canonical()
+        ack["broker_readback"] = readback_evidence
+        _append_ordering_event(
+            journal=fidelity,
+            record=record,
+            event={
+                "at": readback.at.isoformat(),
+                "event": "broker_readback_reconcile",
+                "order_key": order.order_key,
+                "broker_readback": readback_evidence,
+            },
+        )
 
-    record["round_trip"] = round_trips
-    record["day_orders"] = day_orders
-    if mode == ACCEPTANCE_MODE:
-        record["submitted"] = [
-            {
-                "correlation_id": trip["correlation_id"],
-                "symbol": trip["symbol"],
-                "order_no": trip["order_no"],
-                "submitted": trip["submitted"],
-            }
-            for trip in round_trips
-        ]
-    else:
-        record["submitted"] = list(day_orders)
-    if incomplete is not None:
-        outcome.exit_code = 2
+    record["fidelity_artifact"]["event_count_after_cycle"] = len(fidelity.read_all())
     return _persist_outcome(
         outcome=outcome, ledger=ledger, record=record, labels=labels
     )
@@ -976,7 +1632,7 @@ def _cycle_status(*, confirm: bool, mode: CycleMode) -> tuple[str, str]:
         return PREVIEW_STATUS, PREVIEW_STATUS_LABEL
     if mode == ACCEPTANCE_MODE:
         return ACCEPTANCE_ONLY_STATUS, ACCEPTANCE_ONLY_STATUS_LABEL
-    return INTERIM_ORDERING_STATUS, INTERIM_ORDERING_STATUS_LABEL
+    return ORDERING_STATUS, ORDERING_STATUS_LABEL
 
 
 def _stamp_contract_and_account_map(
@@ -996,15 +1652,8 @@ def _stamp_contract_and_account_map(
     }
     record["cycle_status"] = cycle_status
     record["cycle_status_label"] = status_label
-    if cycle_status == INTERIM_ORDERING_STATUS:
-        record["interim_ordering_constraints"] = dict(INTERIM_ORDERING_CONSTRAINTS)
-        record["interim_buy_only_sell_gate"] = {
-            "enabled": INTERIM_BUY_ONLY_SELL_GATE_ENABLED,
-            "reason_code": INTERIM_BUY_ONLY_SELL_GATE_REASON,
-            "scope": "submission_stage_sell_legs",
-            "cli_disable_available": False,
-            "release": "explicit_operator_approval_or_b_track_merge",
-        }
+    if cycle_status == ORDERING_STATUS:
+        record["ordering_requirements"] = dict(ORDERING_REQUIREMENTS)
 
 
 async def run_kiwoom_cycle(
@@ -1013,24 +1662,27 @@ async def run_kiwoom_cycle(
     table_dir: Path = DEFAULT_TABLE_DIR,
     out_dir: Path = DEFAULT_OBSERVATION_DIR,
     confirm: bool = False,
-    interim_ordering: bool = False,
+    ordering: bool = False,
     account: kiwoom_lane.ReadOnlyKiwoomMockAccount | None = None,
     journal: kiwoom_attr.OwnOrderJournal | None = None,
+    lease_factory: Callable[[Path, str, str], ordering_support.WriterLease]
+    | None = None,
+    realized_pnl_reader: Callable[..., kiwoom_attr.RealizedPnlInput] | None = None,
 ) -> KiwoomCycleOutcome:
     """One manual kiwoom_mock B0-X cycle.
 
     ``confirm=False`` is the ordinary observation/derivation path. A confirmed
     call is default-disabled and requires the B0-X env gate plus a clean NW-B4
-    preflight inside KRX RTH. With ``interim_ordering=False`` (the safe default)
-    it remains the one-order ``ACCEPTANCE_ONLY`` cancel round trip. The caller
-    must additionally set ``interim_ordering=True`` to leave envelope-derived
-    DAY orders at the broker.
+    preflight inside KRX RTH. With ``ordering=False`` (the safe default) it
+    remains the one-order ``ACCEPTANCE_ONLY`` cancel round trip. The caller
+    must additionally set ``ordering=True`` to select the independent DAY
+    lifecycle path; a status string alone can never select that path.
     """
 
     envelope = load_envelope(MARKET)
     assert_envelope_locked(envelope)
     kiwoom_lane.assert_correlation_prefixes_disjoint()
-    mode: CycleMode = INTERIM_ORDERING_MODE if interim_ordering else ACCEPTANCE_MODE
+    mode: CycleMode = ORDERING_MODE if ordering else ACCEPTANCE_MODE
     cycle_status, status_label = _cycle_status(confirm=confirm, mode=mode)
     labels = header_labels(
         lane=LANE,
@@ -1055,19 +1707,23 @@ async def run_kiwoom_cycle(
             record, cycle_status=cycle_status, status_label=status_label
         )
         record["confirm"] = confirm
-        record["interim_ordering"] = interim_ordering
+        record["ordering"] = ordering
         record["execution_mode"] = "preview" if not confirm else mode
-        record["realized_pnl_source"] = KR_REALIZED_PNL_UNAVAILABLE
+        record["realized_pnl_source"] = (
+            "not_evaluated_outside_ordering"
+            if mode == ACCEPTANCE_MODE
+            else "pending_ordering_preflight"
+        )
 
-        if interim_ordering and not confirm:
+        if ordering and not confirm:
             return _finish_zero_order(
                 outcome=outcome,
                 ledger=ledger,
                 record=record,
                 labels=labels,
-                reason="interim_ordering_requires_confirm",
+                reason="ordering_requires_confirm",
                 detail=(
-                    "INTERIM_ORDERING is not armed by its mode flag alone; "
+                    "ORDERING is not armed by its mode flag alone; "
                     "the per-call confirm=True gate is required"
                 ),
             )
@@ -1119,7 +1775,6 @@ async def run_kiwoom_cycle(
                 ledger=ledger,
                 record=record,
                 confirm=False,
-                mode=mode,
                 account=account,
                 journal=lane_journal,
                 account_identity=None,
@@ -1138,20 +1793,63 @@ async def run_kiwoom_cycle(
                 detail=str(exc),
             )
 
-        return await _run_prepared_cycle(
-            now=now,
-            table=table,
-            envelope=envelope,
-            labels=labels,
-            outcome=outcome,
-            ledger=ledger,
-            record=record,
-            confirm=True,
-            mode=mode,
-            account=account,
-            journal=lane_journal,
-            account_identity=account_identity,
+        if mode == ACCEPTANCE_MODE:
+            return await _run_prepared_cycle(
+                now=now,
+                table=table,
+                envelope=envelope,
+                labels=labels,
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                confirm=True,
+                account=account,
+                journal=lane_journal,
+                account_identity=account_identity,
+            )
+
+        make_lease = (
+            ordering_support.AccountWriterLease
+            if lease_factory is None
+            else lease_factory
         )
+        lease = make_lease(root, LANE, account_identity["fingerprint"])
+        try:
+            lease.acquire()
+        except Exception as exc:  # noqa: BLE001 — no writer authority, no order
+            record["writer_lease"] = {
+                "acquired": False,
+                "authority": "account_keyed_ordering_lease",
+                "error_type": type(exc).__name__,
+            }
+            return _finish_zero_order(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="writer_lease_unavailable",
+                detail=type(exc).__name__,
+            )
+        try:
+            return await _run_ordering_cycle(
+                now=now,
+                table=table,
+                envelope=envelope,
+                labels=labels,
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                account=account,
+                journal=lane_journal,
+                lease=lease,
+                realized_pnl_reader=(
+                    kiwoom_attr.realized_pnl_input_today
+                    if realized_pnl_reader is None
+                    else realized_pnl_reader
+                ),
+            )
+        finally:
+            lease.release()
 
 
 __all__ = [
@@ -1159,14 +1857,10 @@ __all__ = [
     "LANE",
     "CycleMode",
     "ACCEPTANCE_MODE",
-    "INTERIM_ORDERING_MODE",
+    "ORDERING_MODE",
     "PREVIEW_STATUS",
     "ACCEPTANCE_ONLY_STATUS",
-    "INTERIM_ORDERING_STATUS",
-    "INTERIM_BUY_ONLY_SELL_GATE_ENABLED",
-    "INTERIM_BUY_ONLY_SELL_GATE_REASON",
-    "INTERIM_BUY_ONLY_SELL_GATE_DETAIL",
-    "INTERIM_BUY_ONLY_CONSTRAINT",
+    "ORDERING_STATUS",
     "OUTSIDE_RTH_REASON",
     "PREFLIGHT_MAX_AGE_SECONDS",
     "ACCEPTANCE_SUBMISSION_LIMIT",
@@ -1179,13 +1873,14 @@ __all__ = [
     "KR_STATUS_LABEL",
     "PREVIEW_STATUS_LABEL",
     "ACCEPTANCE_ONLY_STATUS_LABEL",
-    "INTERIM_ORDERING_STATUS_LABEL",
-    "INTERIM_ORDERING_CONSTRAINTS",
+    "ORDERING_STATUS_LABEL",
+    "ORDERING_REQUIREMENTS",
     "COEXISTENCE_LABEL",
-    "KR_REALIZED_PNL_UNAVAILABLE",
+    "REALIZED_PNL_UNAVAILABLE_REASON",
     "KR_ATTRIBUTED_NAV_BASIS",
     "ATTRIBUTION_NOT_WIRED",
     "ForeignSameDayOrders",
+    "MutationBoundary",
     "KiwoomCycleOutcome",
     "foreign_same_day_orders",
     "broker_state",

--- a/scripts/b0x/kr/kiwoom_ordering.py
+++ b/scripts/b0x/kr/kiwoom_ordering.py
@@ -1,0 +1,198 @@
+"""Kiwoom B0-X ORDERING-only local writer lease and fidelity journal.
+
+This module intentionally does not know how to call a broker.  It supplies two
+small, auditable primitives to :mod:`scripts.b0x.kr.kiwoom_cycle`:
+
+* an account-keyed, non-blocking local writer lease, checked again immediately
+  before every mutation; and
+* an append-only lifecycle event journal.  A cycle record is a useful summary,
+  but it must not be the only place where an acknowledgement, fill readback, or
+  cancellation reconciliation can be observed.
+
+The lease is host-local ``flock`` authority.  The accompanying broker foreign
+trace is still mandatory at every mutation boundary; neither mechanism is
+presented as a substitute for the other.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Protocol
+
+ORDERING_EVENT_JOURNAL_NAME: Final[str] = "ordering-events.jsonl"
+
+
+class AccountWriterLeaseContended(RuntimeError):
+    """Another local process holds this account's ORDERING writer lease."""
+
+
+class AccountWriterLeaseLost(RuntimeError):
+    """A caller reached a mutation boundary without its lease still held."""
+
+
+class OrderingJournalUnreadable(RuntimeError):
+    """A lifecycle journal exists but cannot be parsed as append-only evidence."""
+
+
+class WriterLease(Protocol):
+    """Injection seam used by tests; production uses :class:`AccountWriterLease`."""
+
+    def acquire(self) -> None: ...
+
+    def assert_held(self) -> None: ...
+
+    def release(self) -> None: ...
+
+    def canonical(self) -> dict[str, Any]: ...
+
+
+@dataclass(slots=True)
+class AccountWriterLease:
+    """A non-blocking local lease keyed by the redacted account fingerprint.
+
+    The lock lives beneath the B0-X artifact root rather than an operator repo,
+    so normal runtime activity cannot dirty a PR-only checkout.  The raw
+    account identifier never reaches this class: the public fingerprint from
+    ``account_identity_summary`` is already a one-way digest.
+    """
+
+    root: Path
+    lane: str
+    account_fingerprint: str
+    _handle: int | None = None
+    _token: str | None = None
+
+    @property
+    def lock_path(self) -> Path:
+        digest = hashlib.sha256(self.account_fingerprint.encode()).hexdigest()[:16]
+        return Path(self.root).expanduser() / self.lane / f".{digest}.ordering.lock"
+
+    @property
+    def acquired(self) -> bool:
+        return self._handle is not None and self._token is not None
+
+    def acquire(self) -> None:
+        if self.acquired:
+            raise RuntimeError("account writer lease is already acquired")
+        path = self.lock_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            os.close(handle)
+            raise AccountWriterLeaseContended(
+                "kiwoom_mock ORDERING account writer lease is held by another "
+                f"local process ({path}); refusing all mutations"
+            ) from exc
+
+        token = uuid.uuid4().hex
+        try:
+            os.ftruncate(handle, 0)
+            os.write(
+                handle,
+                (
+                    f"pid={os.getpid()}\n"
+                    f"lane={self.lane}\n"
+                    f"account_fingerprint={self.account_fingerprint}\n"
+                    f"lease_token_sha256={hashlib.sha256(token.encode()).hexdigest()[:16]}\n"
+                ).encode(),
+            )
+        except BaseException:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+            os.close(handle)
+            raise
+        self._handle = handle
+        self._token = token
+
+    def assert_held(self) -> None:
+        if not self.acquired:
+            raise AccountWriterLeaseLost(
+                "kiwoom_mock ORDERING account writer lease is no longer held; "
+                "the mutation boundary is closed"
+            )
+
+    def release(self) -> None:
+        handle = self._handle
+        self._handle = None
+        self._token = None
+        if handle is None:
+            return
+        try:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+        finally:
+            os.close(handle)
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "acquired": self.acquired,
+            "authority": "host_local_fcntl_account_keyed",
+            "lock_path": str(self.lock_path),
+            "account_fingerprint": self.account_fingerprint,
+            "checked_before_each_mutation": True,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class OrderingEventJournal:
+    """Append-only per-event evidence for the ORDERING lifecycle."""
+
+    path: Path
+
+    @classmethod
+    def for_lane(cls, *, root: Path, lane: str) -> OrderingEventJournal:
+        return cls(path=Path(root).expanduser() / lane / ORDERING_EVENT_JOURNAL_NAME)
+
+    def append(self, event: dict[str, Any]) -> None:
+        if not isinstance(event.get("at"), str) or not event["at"].strip():
+            raise ValueError("ordering lifecycle event requires a non-empty timestamp")
+        if not isinstance(event.get("event"), str) or not event["event"].strip():
+            raise ValueError("ordering lifecycle event requires a non-empty event name")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, sort_keys=True, ensure_ascii=False, default=str)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+    def read_all(self) -> tuple[dict[str, Any], ...]:
+        if not self.path.exists():
+            return ()
+        events: list[dict[str, Any]] = []
+        try:
+            for line in self.path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                if not isinstance(payload, dict):
+                    raise TypeError("ordering lifecycle row is not an object")
+                if not isinstance(payload.get("at"), str) or not payload["at"].strip():
+                    raise ValueError("ordering lifecycle row has no timestamp")
+                if (
+                    not isinstance(payload.get("event"), str)
+                    or not payload["event"].strip()
+                ):
+                    raise ValueError("ordering lifecycle row has no event name")
+                events.append(payload)
+        except Exception as exc:  # noqa: BLE001 — corrupt evidence is never empty
+            raise OrderingJournalUnreadable(
+                f"ordering lifecycle journal at {self.path} is unreadable "
+                f"({type(exc).__name__})"
+            ) from exc
+        return tuple(events)
+
+
+__all__ = [
+    "ORDERING_EVENT_JOURNAL_NAME",
+    "AccountWriterLease",
+    "AccountWriterLeaseContended",
+    "AccountWriterLeaseLost",
+    "OrderingEventJournal",
+    "OrderingJournalUnreadable",
+    "WriterLease",
+]

--- a/scripts/run_b0x_kr_kiwoom_cycle.py
+++ b/scripts/run_b0x_kr_kiwoom_cycle.py
@@ -10,21 +10,22 @@
     # bounded to one submission, and it ALWAYS cancels what it sent.
     uv run python -m scripts.run_b0x_kr_kiwoom_cycle --confirm
 
-    # Explicitly selected INTERIM DAY-order path. It is never the default and
+    # Explicitly selected ORDERING DAY-order path. It is never the default and
     # requires the same per-call confirmation gate.
-    uv run python -m scripts.run_b0x_kr_kiwoom_cycle --interim-ordering --confirm
+    uv run python -m scripts.run_b0x_kr_kiwoom_cycle --ordering --confirm
 
 ``--confirm`` alone is ``ACCEPTANCE_ONLY``: one submit followed by broker-proven
-cancel. ``--interim-ordering --confirm`` is ``INTERIM_ORDERING``: it submits
-every eligible envelope-derived **buy** DAY order and deliberately does not
-auto-cancel. Sell wiring remains behind a default-on, non-CLI buy-only gate
-until explicit approval or B-track merge. Both are default-disabled, cannot be
-combined with ``--now``, and expose no envelope override. The §4 caps are
-module constants in ``scripts.b0x.envelope``, re-asserted before every read.
+cancel. ``--ordering --confirm`` is ``ORDERING``: it submits eligible
+envelope-derived DAY orders and deliberately does not auto-cancel them. Its
+separate runtime path re-reads pending and same-day foreign broker trace before
+every mutation, checks its account writer lease, and refuses an unreadable
+realized-P&L input. Both paths are default-disabled, cannot be combined with
+``--now``, and expose no envelope override. The §4 caps are module constants in
+``scripts.b0x.envelope``, re-asserted before every read.
 
 🔴 There is no ``--no-cancel`` for acceptance. The cancellation it requires
 must be broker-proven or exits ``2``; that safe acceptance behavior is not
-silently transformed into the interim mode.
+silently transformed into ORDERING.
 
 No scheduler registration exists for this script — not TaskIQ, not Prefect,
 not launchd. A cycle happens because an operator ran it.
@@ -133,8 +134,8 @@ async def _readiness(args: argparse.Namespace) -> int:
 
 
 async def _run(args: argparse.Namespace) -> int:
-    if args.interim_ordering and not args.confirm:
-        print("--interim-ordering requires --confirm", file=sys.stderr)
+    if args.ordering and not args.confirm:
+        print("--ordering requires --confirm", file=sys.stderr)
         return 2
     if args.confirm and args.now is not None:
         print("--confirm cannot be combined with --now", file=sys.stderr)
@@ -155,7 +156,7 @@ async def _run(args: argparse.Namespace) -> int:
             table_dir=Path(args.table_dir).expanduser(),
             out_dir=Path(args.out_dir).expanduser(),
             confirm=args.confirm,
-            interim_ordering=args.interim_ordering,
+            ordering=args.ordering,
         )
     except WriterLockUnavailable as exc:
         print(f"WRITER_LOCK_UNAVAILABLE — {exc}", file=sys.stderr)
@@ -202,10 +203,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--interim-ordering",
+        "--ordering",
         action="store_true",
         help=(
-            "select INTERIM_ORDERING DAY-order retention; requires --confirm. "
+            "select ORDERING DAY-order retention; requires --confirm. "
             "Without this flag, --confirm remains the one-order acceptance cancel"
         ),
     )

--- a/tests/scripts/b0x/kr/kiwoom/conftest.py
+++ b/tests/scripts/b0x/kr/kiwoom/conftest.py
@@ -119,7 +119,31 @@ class FakeAccount:
         if self._detail_error is not None:
             raise self._detail_error
         self.detail_calls.append({"order_date": order_date, "symbol": symbol})
-        return list(self._order_detail.get(order_date or "", []))
+        if order_date is not None:
+            return list(self._order_detail.get(order_date, []))
+        if self._resting_error is not None:
+            raise self._resting_error
+        # Legacy acceptance tests describe their broker-pending snapshots with
+        # ``resting=``.  The runtime now reads kt00007 directly, so translate
+        # that fixture shorthand into normalized detail rows only for its
+        # order-date-unspecified pending read.  Same-day foreign/readback
+        # vectors must supply explicit ``order_detail`` evidence.
+        index = min(self.resting_calls, len(self._resting) - 1)
+        self.resting_calls += 1
+        return [
+            {
+                "order_id": item.order_id,
+                "symbol": item.symbol,
+                "status": item.status,
+                "ordered_quantity": item.remaining_quantity,
+                "filled_quantity": 0,
+                "remaining_quantity": item.remaining_quantity,
+                "unfilled_quantity": item.remaining_quantity,
+                "ordered_price": item.ordered_price,
+                "average_price": 0,
+            }
+            for item in self._resting[index]
+        ]
 
     async def place_limit_buy(
         self, *, symbol: str, quantity: int, price: int

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cli.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cli.py
@@ -12,41 +12,39 @@ pytestmark = pytest.mark.unit
 def test_cli_defaults_to_preview_and_preserves_acceptance_form() -> None:
     preview = _parse_args([])
     acceptance = _parse_args(["--confirm"])
-    interim = _parse_args(["--interim-ordering", "--confirm"])
+    ordering = _parse_args(["--ordering", "--confirm"])
 
     assert preview.confirm is False
-    assert preview.interim_ordering is False
+    assert preview.ordering is False
     assert acceptance.confirm is True
-    assert acceptance.interim_ordering is False
-    assert interim.confirm is True
-    assert interim.interim_ordering is True
-    # A sell-gate override would necessarily add a parser destination. There
-    # is deliberately no CLI release path for the default-on INTERIM gate.
-    assert set(vars(interim)) == {
+    assert acceptance.ordering is False
+    assert ordering.confirm is True
+    assert ordering.ordering is True
+    assert set(vars(ordering)) == {
         "table_dir",
         "out_dir",
         "readiness",
         "confirm",
-        "interim_ordering",
+        "ordering",
         "now",
         "json",
     }
 
 
 @pytest.mark.asyncio
-async def test_cli_rejects_interim_ordering_without_per_call_confirmation() -> None:
+async def test_cli_rejects_ordering_without_per_call_confirmation() -> None:
     """This returns before any cycle/account work, so it cannot reach a broker."""
 
-    assert await _run(_parse_args(["--interim-ordering"])) == 2
+    assert await _run(_parse_args(["--ordering"])) == 2
 
 
 @pytest.mark.asyncio
-async def test_cli_rejects_interim_replay_clock_before_any_cycle_work() -> None:
+async def test_cli_rejects_ordering_replay_clock_before_any_cycle_work() -> None:
     assert (
         await _run(
             _parse_args(
                 [
-                    "--interim-ordering",
+                    "--ordering",
                     "--confirm",
                     "--now",
                     "2026-08-10T02:00:00+00:00",

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -20,6 +20,7 @@ from scripts.b0x.kr import attribution as kr_attribution
 from scripts.b0x.kr import kiwoom as kiwoom_lane
 from scripts.b0x.kr import kiwoom_attribution as kiwoom_attr
 from scripts.b0x.kr import kiwoom_cycle
+from scripts.b0x.kr import kiwoom_ordering as ordering_support
 from scripts.policy_table.core.schema import compute_policy_table_hash
 from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
 from tests.scripts.b0x.kr.kiwoom.conftest import FakeAccount, position, resting
@@ -126,16 +127,18 @@ async def _run(
     out_dir,
     table_dir,
     confirm=False,
-    interim_ordering=False,
+    ordering=False,
     now=IN_SESSION,  # noqa: ANN001
+    **kwargs,
 ):  # noqa: ANN202
     return await kiwoom_cycle.run_kiwoom_cycle(
         now=now,
         table_dir=table_dir,
         out_dir=out_dir,
         confirm=confirm,
-        interim_ordering=interim_ordering,
+        ordering=ordering,
         account=account,
+        **kwargs,
     )
 
 
@@ -200,7 +203,7 @@ async def test_record_carries_the_account_map_and_status_label(
 
 
 @pytest.mark.asyncio
-async def test_interim_ordering_requires_confirm_and_keeps_preview_safe(
+async def test_ordering_requires_confirm_and_keeps_preview_safe(
     table_dir, out_dir
 ) -> None:  # noqa: ANN001
     account = FakeAccount()
@@ -208,10 +211,10 @@ async def test_interim_ordering_requires_confirm_and_keeps_preview_safe(
         account=account,
         out_dir=out_dir,
         table_dir=table_dir,
-        interim_ordering=True,
+        ordering=True,
     )
 
-    assert outcome.zero_order_reason == "interim_ordering_requires_confirm"
+    assert outcome.zero_order_reason == "ordering_requires_confirm"
     assert outcome.record["cycle_status"] == kiwoom_cycle.PREVIEW_STATUS
     assert account.buy_calls == []
     assert account.sell_calls == []
@@ -416,85 +419,396 @@ async def test_confirm_submits_exactly_one_order_and_cancels_it(
     assert outcome.record["day_orders"] == []
 
 
+class _TestOrderingLease:
+    def __init__(self) -> None:
+        self.held = False
+        self.checks = 0
+
+    def acquire(self) -> None:
+        self.held = True
+
+    def assert_held(self) -> None:
+        self.checks += 1
+        if not self.held:
+            raise RuntimeError("lease lost")
+
+    def release(self) -> None:
+        self.held = False
+
+    def canonical(self) -> dict[str, object]:
+        return {"acquired": self.held, "test_lease": True}
+
+
+class _DynamicOrderingAccount(FakeAccount):
+    """Fake kt00007 whose rows are updated by the fake broker mutations."""
+
+    def __init__(self, *, rows=None, **kwargs) -> None:  # noqa: ANN001
+        super().__init__(**kwargs)
+        self.rows: list[dict[str, object]] = list(rows or [])
+        self._next_order_no = 1
+
+    async def read_order_detail(self, *, order_date=None, symbol=None):  # noqa: ANN001, ANN201, ARG002
+        self.detail_calls.append({"order_date": order_date, "symbol": symbol})
+        return [dict(row) for row in self.rows]
+
+    async def place_limit_buy(self, *, symbol, quantity, price):  # noqa: ANN001, ANN201
+        await super().place_limit_buy(symbol=symbol, quantity=quantity, price=price)
+        return self._append_order(
+            symbol=symbol, side="buy", quantity=quantity, price=price
+        )
+
+    async def place_limit_sell(self, *, symbol, quantity, price):  # noqa: ANN001, ANN201
+        await super().place_limit_sell(symbol=symbol, quantity=quantity, price=price)
+        return self._append_order(
+            symbol=symbol, side="sell", quantity=quantity, price=price
+        )
+
+    def _append_order(self, *, symbol, side, quantity, price):  # noqa: ANN001, ANN202
+        order_no = f"{self._next_order_no:010d}"
+        self._next_order_no += 1
+        partial = len(self.rows) == 0
+        filled = 1 if partial else 0
+        self.rows.append(
+            {
+                "order_id": order_no,
+                "symbol": symbol,
+                "status": "partial" if partial else "open",
+                "ordered_quantity": quantity,
+                "filled_quantity": filled,
+                "remaining_quantity": quantity - filled,
+                "unfilled_quantity": quantity - filled,
+                "ordered_price": price,
+                "average_price": price + 100 if filled else 0,
+            }
+        )
+        return {"return_code": 0, "ord_no": order_no}
+
+
 @pytest.mark.asyncio
-async def test_interim_ordering_submits_every_envelope_derived_day_order_without_cancel(
-    table_dir, out_dir, armed
+async def test_ordering_submits_table_derived_day_orders_with_readback_fidelity(
+    table_dir, out_dir, armed, frozen_cycle_clock
 ) -> None:  # noqa: ANN001, ARG001
-    """DAY retention replaces neither the derivation caps nor acceptance mode."""
+    """ORDERING has a distinct lifecycle, not an acceptance status rename."""
 
     _write_table(
         table_dir,
         generated_at=IN_SESSION - dt.timedelta(hours=4),
         symbols=("005930", "000660", "035420", "051910"),
     )
-
-    class DistinctOrderNumbers(FakeAccount):
-        async def place_limit_buy(self, *, symbol, quantity, price):  # noqa: ANN001, ANN201
-            payload = await super().place_limit_buy(
-                symbol=symbol, quantity=quantity, price=price
-            )
-            payload["ord_no"] = f"{len(self.buy_calls):010d}"
-            return payload
-
-    account = DistinctOrderNumbers()
+    lease = _TestOrderingLease()
+    account = _DynamicOrderingAccount()
     outcome = await _run(
         account=account,
         out_dir=out_dir,
         table_dir=table_dir,
         confirm=True,
-        interim_ordering=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: lease,
     )
 
     assert outcome.exit_code == 0
-    assert outcome.record["cycle_status"] == "INTERIM_ORDERING"
-    assert outcome.record["cycle_status_label"] == (
-        kiwoom_cycle.INTERIM_ORDERING_STATUS_LABEL
-    )
-    assert outcome.record["interim_ordering_constraints"] == (
-        kiwoom_cycle.INTERIM_ORDERING_CONSTRAINTS
-    )
-    assert kiwoom_cycle.INTERIM_ORDERING_STATUS_LABEL in outcome.record["labels"]
-    for constraint in kiwoom_cycle.INTERIM_ORDERING_CONSTRAINTS.values():
-        assert constraint.split(" — ")[0] in kiwoom_cycle.INTERIM_ORDERING_STATUS_LABEL
-
-    # Four candidates reach derivation, but the locked daily-new cap admits
-    # exactly three. INTERIM_ORDERING sends all three, not the old one-order
-    # acceptance limit, and none reaches cancellation.
+    assert outcome.record["cycle_status"] == kiwoom_cycle.ORDERING_STATUS
+    assert outcome.record["cycle_status_label"] == kiwoom_cycle.ORDERING_STATUS_LABEL
+    assert outcome.record["ordering_requirements"] == kiwoom_cycle.ORDERING_REQUIREMENTS
     assert outcome.derivation is not None
     assert len(outcome.derivation.orders) == 3
-    assert any(
-        skipped["reason"] == "daily_new_entry_cap_reached"
-        for skipped in outcome.record["skipped"]
-    )
     assert len(account.buy_calls) == len(outcome.derivation.orders)
     assert account.sell_calls == []
     assert account.cancel_calls == []
     assert outcome.record["round_trip"] == []
     assert len(outcome.record["day_orders"]) == 3
-    assert outcome.record["submitted"] == outcome.record["day_orders"]
     assert all(
         order["time_in_force"] == "DAY" for order in outcome.record["day_orders"]
     )
     assert all(
         order["automatic_cancel"] is False for order in outcome.record["day_orders"]
     )
-    assert all(
-        order["fill_status"] == "unverified" for order in outcome.record["day_orders"]
+    assert all("broker_readback" in order for order in outcome.record["day_orders"])
+    first_readback = outcome.record["day_orders"][0]["broker_readback"]
+    assert first_readback["partial"] is True
+    assert first_readback["complete"] is False
+    assert first_readback["remaining_quantity"] > 0
+    assert first_readback["fill_vwap"] is not None
+    assert first_readback["slippage_krw"] == "100"
+    events = outcome.record["fidelity_events"]
+    assert {event["event"] for event in events} >= {
+        "table_price_to_intended_limit",
+        "broker_ack",
+        "broker_readback_reconcile",
+    }
+    persisted_events = ordering_support.OrderingEventJournal.for_lane(
+        root=out_dir, lane=kiwoom_cycle.LANE
+    ).read_all()
+    assert tuple(event["at"] for event in persisted_events) == tuple(
+        event["at"] for event in events
     )
-    assert all(
-        Decimal(order["notional_krw"])
-        <= Decimal(outcome.record["envelope"]["per_order_notional"])
-        for order in outcome.record["day_orders"]
-    )
-    assert "acceptance_submission_limit" not in outcome.record
-    assert outcome.record["day_order_policy"] == kiwoom_cycle.DAY_ORDER_RETAINED_NOTE
+    assert all(event["at"] and event["event"] for event in persisted_events)
+    assert lease.checks >= len(outcome.record["day_orders"]) + 1
 
 
 @pytest.mark.asyncio
-async def test_interim_buy_only_sell_gate_blocks_derived_sell_with_audit_reason(
-    table_dir, out_dir, armed, monkeypatch
+async def test_ordering_allows_a_sell_only_when_the_broker_fill_is_attributed(
+    table_dir, out_dir, armed, frozen_cycle_clock, tmp_path
 ) -> None:  # noqa: ANN001, ARG001
-    """§50차 2항: a valid derived sell is visible but cannot reach Kiwoom."""
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l1=None,
+        sell_r1="80000.00",
+    )
+    journal = kiwoom_attr.OwnOrderJournal(path=tmp_path / "own-orders.jsonl")
+    journal.append(
+        kiwoom_attr.OwnOrderRecord(
+            at=frozen_cycle_clock.isoformat(),
+            order_no="0000000042",
+            correlation_id="b0xkw-prior-buy",
+            symbol="005930",
+            side="buy",
+            price=70_000,
+            quantity=10,
+            order_date=kiwoom_attr.kst_order_date(frozen_cycle_clock),
+        )
+    )
+    account = _DynamicOrderingAccount(
+        positions=(position("005930", 10, average_price=70_000),),
+        rows=[
+            {
+                "order_id": "0000000042",
+                "symbol": "005930",
+                "status": "filled",
+                "ordered_quantity": 10,
+                "filled_quantity": 10,
+                "remaining_quantity": 0,
+                "unfilled_quantity": 0,
+                "ordered_price": 70_000,
+                "average_price": 70_000,
+            }
+        ],
+    )
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        journal=journal,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=lambda **_kwargs: kiwoom_attr.RealizedPnlInput(
+            value=Decimal("0"), source="test"
+        ),
+    )
+
+    assert outcome.exit_code == 0
+    assert account.buy_calls == []
+    assert len(account.sell_calls) == 1
+    assert outcome.record["day_orders"][0]["side"] == "sell"
+
+
+@pytest.mark.asyncio
+async def test_ordering_blocks_when_realized_pnl_cannot_be_proven(
+    table_dir, out_dir, armed, frozen_cycle_clock, tmp_path
+) -> None:  # noqa: ANN001, ARG001
+    journal = kiwoom_attr.OwnOrderJournal(path=tmp_path / "own-orders.jsonl")
+    journal.append(
+        kiwoom_attr.OwnOrderRecord(
+            at=frozen_cycle_clock.isoformat(),
+            order_no="0000000042",
+            correlation_id="b0xkw-prior-buy",
+            symbol="005930",
+            side="buy",
+            price=70_000,
+            quantity=1,
+            order_date=kiwoom_attr.kst_order_date(frozen_cycle_clock),
+        )
+    )
+    account = _DynamicOrderingAccount(
+        rows=[
+            {
+                "order_id": "0000000042",
+                "symbol": "005930",
+                "status": "filled",
+                "ordered_quantity": 1,
+                "filled_quantity": 1,
+                "remaining_quantity": 0,
+                "unfilled_quantity": 0,
+                "ordered_price": 70_000,
+                "average_price": 70_000,
+            }
+        ]
+    )
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        journal=journal,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.zero_order_reason == kiwoom_cycle.REALIZED_PNL_UNAVAILABLE_REASON
+    assert outcome.record["realized_pnl_input"]["readable"] is False
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+    assert account.cancel_calls == []
+
+
+@pytest.mark.asyncio
+async def test_ordering_rechecks_foreign_trace_at_the_submit_boundary(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    class ForeignAfterPreflight(_DynamicOrderingAccount):
+        def __init__(self) -> None:
+            super().__init__()
+            self.boundary_reads = 0
+
+        async def read_order_detail(self, *, order_date=None, symbol=None):  # noqa: ANN001, ANN201, ARG002
+            self.detail_calls.append({"order_date": order_date, "symbol": symbol})
+            self.boundary_reads += 1
+            if self.boundary_reads == 1:
+                return []
+            return [
+                {
+                    "order_id": "foreign-1",
+                    "symbol": "000660",
+                    "status": "open",
+                    "ordered_quantity": 1,
+                    "filled_quantity": 0,
+                    "remaining_quantity": 1,
+                    "unfilled_quantity": 1,
+                    "ordered_price": 70_000,
+                    "average_price": 0,
+                }
+            ]
+
+    account = ForeignAfterPreflight()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.zero_order_reason == "mutation_boundary_not_clean"
+    assert len(outcome.record["mutation_boundaries"]) >= 2
+    assert (
+        outcome.record["mutation_boundaries"][-1]["foreign_same_day_orders"]["count"]
+        == 1
+    )
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+
+
+@pytest.mark.asyncio
+async def test_ordering_blocks_when_its_writer_lease_is_lost_before_submit(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    class LostBeforeSubmit(_TestOrderingLease):
+        def assert_held(self) -> None:
+            self.checks += 1
+            if self.checks >= 2:
+                raise RuntimeError("lease disappeared")
+
+    account = _DynamicOrderingAccount()
+    lease = LostBeforeSubmit()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: lease,
+    )
+
+    assert outcome.zero_order_reason == "mutation_boundary_not_clean"
+    assert outcome.record["mutation_boundaries"][-1]["blocking_reason"] == (
+        "writer_lease_lost"
+    )
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+
+
+@pytest.mark.asyncio
+async def test_ordering_rechecks_own_fill_quantity_before_a_sell(
+    table_dir, out_dir, armed, frozen_cycle_clock, tmp_path
+) -> None:  # noqa: ANN001, ARG001
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l1=None,
+        sell_r1="80000.00",
+    )
+    journal = kiwoom_attr.OwnOrderJournal(path=tmp_path / "own-orders.jsonl")
+    journal.append(
+        kiwoom_attr.OwnOrderRecord(
+            at=frozen_cycle_clock.isoformat(),
+            order_no="0000000042",
+            correlation_id="b0xkw-prior-buy",
+            symbol="005930",
+            side="buy",
+            price=70_000,
+            quantity=10,
+            order_date=kiwoom_attr.kst_order_date(frozen_cycle_clock),
+        )
+    )
+    full_fill = {
+        "order_id": "0000000042",
+        "symbol": "005930",
+        "status": "filled",
+        "ordered_quantity": 10,
+        "filled_quantity": 10,
+        "remaining_quantity": 0,
+        "unfilled_quantity": 0,
+        "ordered_price": 70_000,
+        "average_price": 70_000,
+    }
+    missing_fill = {**full_fill, "filled_quantity": 0, "average_price": 0}
+
+    class FillDisappearsBeforeSell(_DynamicOrderingAccount):
+        def __init__(self) -> None:
+            super().__init__(positions=(position("005930", 10),))
+            self.answers = [[full_fill], [full_fill], [missing_fill]]
+            self.answer_index = 0
+
+        async def read_order_detail(self, *, order_date=None, symbol=None):  # noqa: ANN001, ANN201, ARG002
+            self.detail_calls.append({"order_date": order_date, "symbol": symbol})
+            answer = self.answers[min(self.answer_index, len(self.answers) - 1)]
+            self.answer_index += 1
+            return [dict(row) for row in answer]
+
+    account = FillDisappearsBeforeSell()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        journal=journal,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=lambda **_kwargs: kiwoom_attr.RealizedPnlInput(
+            value=Decimal("0"), source="test"
+        ),
+    )
+
+    assert account.sell_calls == []
+    assert outcome.record["submission_blocked"][0]["reason"] == (
+        "own_fill_sell_gate_blocked"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ordering_stops_the_cycle_when_fresh_sell_attribution_is_unreadable(
+    table_dir, out_dir, armed, frozen_cycle_clock, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    """A failed sell-side evidence read cannot be bypassed by later buys."""
 
     _write_table(
         table_dir,
@@ -502,57 +816,111 @@ async def test_interim_buy_only_sell_gate_blocks_derived_sell_with_audit_reason(
         buy_l1=None,
         sell_r1="80000.00",
     )
-    own_attribution = kr_attribution.OwnFillAttribution(
-        lots=(
-            kr_attribution.AttributedLot(
-                symbol="005930",
-                quantity=Decimal("10"),
-                average_price=Decimal("70000"),
-                buy_fill_rows=1,
-                sell_rows=0,
-            ),
-        )
-    )
+    calls = 0
 
-    async def _read_own_attribution(**_kwargs):  # noqa: ANN003, ANN202
-        return own_attribution
+    async def _attribution(**_kwargs):  # noqa: ANN003, ANN202
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return kr_attribution.OwnFillAttribution(
+                lots=(
+                    kr_attribution.AttributedLot(
+                        symbol="005930",
+                        quantity=Decimal("10"),
+                        average_price=Decimal("70000"),
+                        buy_fill_rows=1,
+                        sell_rows=0,
+                    ),
+                )
+            )
+        return kr_attribution.attribution_unreadable("OSError")
 
-    monkeypatch.setattr(kiwoom_attr, "read_own_attribution", _read_own_attribution)
-    account = FakeAccount(positions=(position("005930", 10, average_price=70_000),))
+    monkeypatch.setattr(kiwoom_attr, "read_own_attribution", _attribution)
+    account = _DynamicOrderingAccount(positions=(position("005930", 10),))
     outcome = await _run(
         account=account,
         out_dir=out_dir,
         table_dir=table_dir,
         confirm=True,
-        interim_ordering=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=lambda **_kwargs: kiwoom_attr.RealizedPnlInput(
+            value=Decimal("0"), source="test"
+        ),
     )
 
-    assert outcome.exit_code == 0
-    assert outcome.derivation is not None
-    assert [order.side for order in outcome.derivation.orders] == ["sell"]
-    assert [order["side"] for order in outcome.record["planned"]] == ["sell"]
-    # Keep this assertion before the artifact checks: disabling the gate must
-    # prove that the sell reached the fake venue, rather than only changing a
-    # descriptive field.
-    assert account.sell_calls == []
+    assert outcome.zero_order_reason == "fresh_sell_attribution_unavailable"
     assert account.buy_calls == []
-    assert outcome.record["day_orders"] == []
-    assert outcome.record["submitted"] == []
-    assert outcome.record["interim_buy_only_sell_gate"] == {
-        "enabled": True,
-        "reason_code": "interim_buy_only_sell_gate",
-        "scope": "submission_stage_sell_legs",
-        "cli_disable_available": False,
-        "release": "explicit_operator_approval_or_b_track_merge",
-    }
-    blocked = outcome.record["submission_blocked"]
-    assert [(item["side"], item["leg"], item["reason"]) for item in blocked] == [
-        ("sell", "sell_r1", "interim_buy_only_sell_gate")
-    ]
-    assert blocked[0]["detail"] == kiwoom_cycle.INTERIM_BUY_ONLY_SELL_GATE_DETAIL
-    assert kiwoom_cycle.INTERIM_BUY_ONLY_SELL_GATE_ENABLED is True
-    assert outcome.record["interim_ordering_constraints"]["buy_only"] == (
-        "매수 전용(매도 게이트 ON)"
+    assert account.sell_calls == []
+
+
+@pytest.mark.asyncio
+async def test_ordering_kill_cancels_own_pending_and_proves_it_gone(
+    table_dir, out_dir, armed, frozen_cycle_clock, tmp_path
+) -> None:  # noqa: ANN001, ARG001
+    journal = kiwoom_attr.OwnOrderJournal(path=tmp_path / "own-orders.jsonl")
+    journal.append(
+        kiwoom_attr.OwnOrderRecord(
+            at=frozen_cycle_clock.isoformat(),
+            order_no="0000000042",
+            correlation_id="b0xkw-prior-buy",
+            symbol="005930",
+            side="buy",
+            price=70_000,
+            quantity=3,
+            order_date=kiwoom_attr.kst_order_date(frozen_cycle_clock),
+        )
+    )
+
+    class KillAccount(_DynamicOrderingAccount):
+        async def cancel(self, *, original_order_no, symbol, cancel_quantity):  # noqa: ANN001, ANN201
+            await super().cancel(
+                original_order_no=original_order_no,
+                symbol=symbol,
+                cancel_quantity=cancel_quantity,
+            )
+            self.rows = [
+                row for row in self.rows if row["order_id"] != original_order_no
+            ]
+            return {"return_code": 0, "ord_no": "0000000043"}
+
+    account = KillAccount(
+        rows=[
+            {
+                "order_id": "0000000042",
+                "symbol": "005930",
+                "status": "open",
+                "ordered_quantity": 3,
+                "filled_quantity": 0,
+                "remaining_quantity": 3,
+                "unfilled_quantity": 3,
+                "ordered_price": 70_000,
+                "average_price": 0,
+            }
+        ]
+    )
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        journal=journal,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=lambda **_kwargs: kiwoom_attr.RealizedPnlInput(
+            value=Decimal("-300000"), source="test_kill"
+        ),
+    )
+
+    assert outcome.record["kill_switch"]["allow_new_orders"] is False
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+    assert len(account.cancel_calls) == 1
+    assert outcome.record["kill_cancellation"]["confirmed"] is True
+    assert any(
+        event["event"] == "cancel_ack" for event in outcome.record["fidelity_events"]
     )
 
 

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -484,6 +484,37 @@ class _DynamicOrderingAccount(FakeAccount):
         return {"return_code": 0, "ord_no": order_no}
 
 
+def _own_pending_record(
+    *, now: dt.datetime, order_no: str = "0000000042", quantity: int = 3
+) -> kiwoom_attr.OwnOrderRecord:
+    return kiwoom_attr.OwnOrderRecord(
+        at=now.isoformat(),
+        order_no=order_no,
+        correlation_id="b0xkw-prior-buy",
+        symbol="005930",
+        side="buy",
+        price=70_000,
+        quantity=quantity,
+        order_date=kiwoom_attr.kst_order_date(now),
+    )
+
+
+def _own_pending_row(
+    *, order_no: str = "0000000042", quantity: int = 3
+) -> dict[str, object]:
+    return {
+        "order_id": order_no,
+        "symbol": "005930",
+        "status": "open",
+        "ordered_quantity": quantity,
+        "filled_quantity": 0,
+        "remaining_quantity": quantity,
+        "unfilled_quantity": quantity,
+        "ordered_price": 70_000,
+        "average_price": 0,
+    }
+
+
 @pytest.mark.asyncio
 async def test_ordering_submits_table_derived_day_orders_with_readback_fidelity(
     table_dir, out_dir, armed, frozen_cycle_clock
@@ -545,6 +576,71 @@ async def test_ordering_submits_table_derived_day_orders_with_readback_fidelity(
     )
     assert all(event["at"] and event["event"] for event in persisted_events)
     assert lease.checks >= len(outcome.record["day_orders"]) + 1
+
+
+@pytest.mark.asyncio
+async def test_ordering_stops_after_ack_when_its_readback_row_is_absent(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    """E2: one unproved ACK stops the rest of the DAY submission sequence."""
+
+    class AckWithoutReadback(_DynamicOrderingAccount):
+        async def place_limit_buy(self, *, symbol, quantity, price):  # noqa: ANN001, ANN201
+            await FakeAccount.place_limit_buy(
+                self, symbol=symbol, quantity=quantity, price=price
+            )
+            return {"return_code": 0, "ord_no": "0000000001"}
+
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        symbols=("005930", "000660", "035420", "051910"),
+    )
+    account = AckWithoutReadback()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.exit_code == 2
+    assert outcome.record["submission_stopped"] == "broker_readback_unavailable"
+    assert len(account.buy_calls) == 1
+    assert len(outcome.record["day_orders"]) == 1
+    assert "readback_failure" in outcome.record["day_orders"][0]
+
+
+@pytest.mark.asyncio
+async def test_ordering_blocks_when_fidelity_journal_is_unreadable(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    """E9: corrupt lifecycle evidence closes ORDERING before the venue."""
+
+    fidelity = ordering_support.OrderingEventJournal.for_lane(
+        root=out_dir, lane=kiwoom_cycle.LANE
+    )
+    fidelity.path.parent.mkdir(parents=True)
+    fidelity.path.write_text("{not json\n", encoding="utf-8")
+    account = _DynamicOrderingAccount()
+
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.zero_order_reason == "ordering_fidelity_journal_unreadable"
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+    assert fidelity.path.read_text(encoding="utf-8") == "{not json\n"
 
 
 @pytest.mark.asyncio
@@ -922,6 +1018,89 @@ async def test_ordering_kill_cancels_own_pending_and_proves_it_gone(
     assert any(
         event["event"] == "cancel_ack" for event in outcome.record["fidelity_events"]
     )
+
+
+@pytest.mark.asyncio
+async def test_ordering_kill_rejects_cancel_ack_when_own_order_still_rests(
+    table_dir, out_dir, armed, frozen_cycle_clock, tmp_path
+) -> None:  # noqa: ANN001, ARG001
+    """E4: a cancel ACK is not proof until its per-order broker re-read clears."""
+
+    journal = kiwoom_attr.OwnOrderJournal(path=tmp_path / "own-orders.jsonl")
+    journal.append(_own_pending_record(now=frozen_cycle_clock))
+    account = _DynamicOrderingAccount(rows=[_own_pending_row()])
+
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        journal=journal,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=lambda **_kwargs: kiwoom_attr.RealizedPnlInput(
+            value=Decimal("-300000"), source="test_kill"
+        ),
+    )
+
+    assert outcome.exit_code == 2
+    assert outcome.zero_order_reason == "kill_cancel_not_confirmed"
+    assert len(account.cancel_calls) == 1
+    assert outcome.record["kill_cancellation"]["confirmed"] is False
+    assert any(
+        event["action"].startswith("kill_cancel_reconcile:")
+        for event in outcome.record["fidelity_events"]
+        if event["event"] == "mutation_boundary"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ordering_kill_rejects_own_pending_reappearing_at_final_reconcile(
+    table_dir, out_dir, armed, frozen_cycle_clock, monkeypatch, tmp_path
+) -> None:  # noqa: ANN001, ARG001
+    """E1: all per-order rechecks passing is insufficient without final proof."""
+
+    async def empty_attribution(**_kwargs):  # noqa: ANN003, ANN202
+        return kr_attribution.OwnFillAttribution(lots=())
+
+    monkeypatch.setattr(kiwoom_attr, "read_own_attribution", empty_attribution)
+    journal = kiwoom_attr.OwnOrderJournal(path=tmp_path / "own-orders.jsonl")
+    journal.append(_own_pending_record(now=frozen_cycle_clock))
+    row = _own_pending_row()
+
+    class ReappearsOnFinalReconcile(_DynamicOrderingAccount):
+        def __init__(self) -> None:
+            super().__init__(rows=[row])
+            self.boundary_reads = 0
+
+        async def read_order_detail(self, *, order_date=None, symbol=None):  # noqa: ANN001, ANN201, ARG002
+            self.detail_calls.append({"order_date": order_date, "symbol": symbol})
+            self.boundary_reads += 1
+            if self.boundary_reads == 4:
+                return []
+            return [dict(row)]
+
+    account = ReappearsOnFinalReconcile()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        journal=journal,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=lambda **_kwargs: kiwoom_attr.RealizedPnlInput(
+            value=Decimal("-300000"), source="test_kill"
+        ),
+    )
+
+    assert outcome.exit_code == 2
+    assert outcome.zero_order_reason == "kill_own_pending_remains"
+    assert len(account.cancel_calls) == 1
+    assert account.boundary_reads == 5
+    assert outcome.record["kill_cancellation"]["confirmed"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_legacy_and_pending.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_legacy_and_pending.py
@@ -284,6 +284,31 @@ async def test_pending_comes_from_the_broker_and_splits_own_vs_account() -> None
 
 
 @pytest.mark.asyncio
+async def test_pending_default_preserves_current_day_resting_surface() -> None:
+    """ACCEPTANCE_ONLY/readiness must not fall back to broker-default history."""
+
+    class CurrentDayRestingOnly:
+        def __init__(self) -> None:
+            self.resting_calls = 0
+
+        async def read_resting_orders(self):  # noqa: ANN201
+            self.resting_calls += 1
+            return (resting("111", "005930"),)
+
+        async def read_order_detail(self, **_kwargs):  # noqa: ANN003, ANN201
+            raise AssertionError("pending wrapper bypassed current-day resting surface")
+
+    account = CurrentDayRestingOnly()
+    pending = await kiwoom_lane.read_broker_pending(
+        account, own_order_ids=frozenset({"111"})
+    )
+
+    assert isinstance(pending, kiwoom_lane.BrokerPending)
+    assert pending.own_symbols == ("005930",)
+    assert account.resting_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_pending_read_failure_is_tri_state_and_blocks_every_symbol() -> None:
     account = FakeAccount(resting_error=RuntimeError("kt00009 timeout"))
     pending = await kiwoom_lane.read_broker_pending(account, own_order_ids=frozenset())

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_ordering_support.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_ordering_support.py
@@ -1,0 +1,47 @@
+"""ORDERING-local lease and append-only evidence primitives."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.b0x.kr import kiwoom_ordering as ordering_support
+
+pytestmark = pytest.mark.unit
+
+
+def test_account_writer_lease_is_account_keyed_and_nonblocking(tmp_path) -> None:  # noqa: ANN001
+    first = ordering_support.AccountWriterLease(
+        root=tmp_path,
+        lane="kiwoom_mock",
+        account_fingerprint="sha256:account-a",
+    )
+    same_account = ordering_support.AccountWriterLease(
+        root=tmp_path,
+        lane="kiwoom_mock",
+        account_fingerprint="sha256:account-a",
+    )
+    other_account = ordering_support.AccountWriterLease(
+        root=tmp_path,
+        lane="kiwoom_mock",
+        account_fingerprint="sha256:account-b",
+    )
+    first.acquire()
+    try:
+        with pytest.raises(ordering_support.AccountWriterLeaseContended):
+            same_account.acquire()
+        other_account.acquire()
+        other_account.assert_held()
+    finally:
+        other_account.release()
+        first.release()
+
+
+def test_ordering_event_journal_rejects_malformed_prior_evidence(tmp_path) -> None:  # noqa: ANN001
+    journal = ordering_support.OrderingEventJournal.for_lane(
+        root=tmp_path, lane="kiwoom_mock"
+    )
+    journal.path.parent.mkdir(parents=True)
+    journal.path.write_text('{"at":"2026-08-12T03:00:00+00:00"}\n', encoding="utf-8")
+
+    with pytest.raises(ordering_support.OrderingJournalUnreadable):
+        journal.read_all()

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
@@ -51,8 +51,8 @@ def _sink():  # noqa: ANN202
 
 
 @pytest.mark.asyncio
-async def test_interim_day_submission_never_calls_cancel(now) -> None:  # noqa: ANN001
-    """INTERIM_ORDERING records acceptance, not a synthetic fill or cleanup."""
+async def test_ordering_day_submission_never_calls_cancel(now) -> None:  # noqa: ANN001
+    """ORDERING records acceptance, not a synthetic fill or cleanup."""
 
     account = FakeAccount()
     writer = _sink()

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
@@ -18,8 +18,9 @@ from decimal import Decimal
 
 import pytest
 
-from scripts.b0x.broker_truth import BrokerTruth
+from scripts.b0x.broker_truth import BrokerTruth, OwnPendingResubmitBlocked
 from scripts.b0x.kr import kiwoom as kiwoom_lane
+from scripts.b0x.kr import kiwoom_attribution as kiwoom_attr
 from tests.scripts.b0x.kr.kiwoom.conftest import FakeAccount, resting
 
 pytestmark = pytest.mark.unit
@@ -48,6 +49,32 @@ def _sink():  # noqa: ANN202
 
     _record.written = written  # type: ignore[attr-defined]
     return _record
+
+
+def _readback_row(
+    *,
+    order_no: str = "0000123456",
+    symbol: str = "005930",
+    ordered_quantity: int = 3,
+    filled_quantity: int = 1,
+    remaining_quantity: int = 2,
+    unfilled_quantity: int = 2,
+    ordered_price: int = 70_000,
+    average_price: int = 70_100,
+) -> dict[str, object]:
+    """A broker-detail row for one partial DAY fill."""
+
+    return {
+        "order_id": order_no,
+        "symbol": symbol,
+        "status": "partial",
+        "ordered_quantity": ordered_quantity,
+        "filled_quantity": filled_quantity,
+        "remaining_quantity": remaining_quantity,
+        "unfilled_quantity": unfilled_quantity,
+        "ordered_price": ordered_price,
+        "average_price": average_price,
+    }
 
 
 @pytest.mark.asyncio
@@ -86,6 +113,106 @@ async def test_ordering_day_submission_never_calls_cancel(now) -> None:  # noqa:
     assert writer.written == [  # type: ignore[attr-defined]
         {"order_no": "0000123456", "symbol": "005930", "at": now}
     ]
+
+
+@pytest.mark.asyncio
+async def test_ordering_day_submission_blocks_same_symbol_own_pending(now) -> None:  # noqa: ANN001
+    """E7: the DAY path repeats the dedup check at its mutation boundary."""
+
+    account = FakeAccount()
+    blocked_truth = BrokerTruth(position_symbols=(), own_pending=("005930",))
+
+    with pytest.raises(OwnPendingResubmitBlocked):
+        await kiwoom_lane.submit_day_order(
+            account,
+            planned=_planned(symbol="005930"),
+            broker_truth=blocked_truth,
+            record_order_no=_sink(),
+            now=now,
+        )
+
+    assert account.buy_calls == [], "a blocked DAY resubmit must not reach the venue"
+
+
+@pytest.mark.asyncio
+async def test_ordering_readback_missing_acknowledged_row_is_unavailable(
+    now,
+) -> None:  # noqa: ANN001
+    """E2: an ACK without its kt00007 row is not a fabricated fill."""
+
+    account = FakeAccount(
+        order_detail={kiwoom_attr.kst_order_date(now): []},
+    )
+
+    with pytest.raises(
+        kiwoom_lane.BrokerOrderReadbackUnavailable, match="did not return"
+    ):
+        await kiwoom_lane.read_order_readback(
+            account,
+            planned=_planned(quantity=3),
+            order_no="0000123456",
+            order_date=kiwoom_attr.kst_order_date(now),
+            at=now,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    (
+        ("order_id", "0000000999", "order_no"),
+        ("symbol", "000660", "symbol"),
+        ("ordered_quantity", 4, "ordered_quantity"),
+        ("ordered_price", 70_100, "ordered_price"),
+        ("filled_quantity", 4, "filled_quantity"),
+        ("remaining_quantity", 3, "remaining_quantity"),
+    ),
+)
+def test_ordering_readback_rejects_echo_or_quantity_inconsistency(
+    now, field: str, value: str | int, expected: str
+) -> None:  # noqa: ANN001
+    """E5: every broker echo and fill arithmetic mismatch is fail-closed."""
+
+    row = _readback_row()
+    row[field] = value
+
+    with pytest.raises(kiwoom_lane.BrokerEchoMismatch, match=expected):
+        kiwoom_lane._readback_from_detail_row(  # noqa: SLF001 - exact guard vector
+            row=row,
+            planned=_planned(quantity=3),
+            order_no="0000123456",
+            at=now,
+        )
+
+
+def test_ordering_partial_readback_conserves_remaining_vwap_and_slippage(now) -> None:  # noqa: ANN001
+    """The partial-fill artifact is broker-derived, not completion-shaped."""
+
+    readback = kiwoom_lane._readback_from_detail_row(  # noqa: SLF001 - exact guard vector
+        row=_readback_row(),
+        planned=_planned(quantity=3),
+        order_no="0000123456",
+        at=now,
+    )
+
+    assert readback.partial is True
+    assert readback.complete is False
+    assert readback.remaining_quantity == 2
+    assert readback.canonical()["fill_vwap"] == "70100"
+    assert readback.canonical()["slippage_krw"] == "100"
+
+
+def test_ordering_filled_readback_without_broker_vwap_is_unavailable(now) -> None:  # noqa: ANN001
+    """A fill with no positive broker VWAP cannot preserve its artifact."""
+
+    with pytest.raises(
+        kiwoom_lane.BrokerOrderReadbackUnavailable, match="positive broker VWAP"
+    ):
+        kiwoom_lane._readback_from_detail_row(  # noqa: SLF001 - exact guard vector
+            row=_readback_row(average_price=0),
+            planned=_planned(quantity=3),
+            order_no="0000123456",
+            at=now,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_static_guards.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_static_guards.py
@@ -30,6 +30,7 @@ LANE_MODULES = (
     REPO_ROOT / "scripts" / "b0x" / "kr" / "kiwoom.py",
     REPO_ROOT / "scripts" / "b0x" / "kr" / "kiwoom_attribution.py",
     REPO_ROOT / "scripts" / "b0x" / "kr" / "kiwoom_cycle.py",
+    REPO_ROOT / "scripts" / "b0x" / "kr" / "kiwoom_ordering.py",
     REPO_ROOT / "scripts" / "run_b0x_kr_kiwoom_cycle.py",
 )
 


### PR DESCRIPTION
## Summary

- Replace the temporary INTERIM_ORDERING path with a separate, default-disabled ORDERING DAY lifecycle.
- Preserve ACCEPTANCE_ONLY as the existing one-submit → cancel → reconcile lever.
- Add account writer lease, per-mutation kt00007 pending/foreign re-read, own-only sells, realized-P&L fail-closed behavior, kill cancellation/reconciliation, and append-only fidelity evidence.
- Depends on operator account-map drift CI draft PR: https://github.com/mgh3326/auto_trader-operator/pull/39

## Validation

- `uv run pytest -q tests/scripts/b0x/kr/kiwoom tests/scripts/b0x/test_no_forbidden_imports.py`
- `uv run pytest -q tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py`
- `make lint`

No ORDERING cycle, broker/account contact, env arming, deployment, or merge was performed.