### PR TITLE
feat(invest-watch-ui): watch browsing + order detail + deep-link utility (Phase 1)

### DIFF
--- a/app/core/invest_deep_links.py
+++ b/app/core/invest_deep_links.py
@@ -44,15 +44,29 @@ def build_watches_url(
     return f"{base}?{'&'.join(params)}"
 
 
-def build_order_detail_url(*, broker: str | None, ledger_id: int | None) -> str | None:
+def build_order_detail_url(
+    *, broker: str | None, market: str | None, ledger_id: int | None
+) -> str | None:
     """URL to the standalone order/fill detail view for one ledger row.
 
-    Example: https://mgh3326.duckdns.org/invest/orders/kis/482
-    Returns None when either identifier is missing (same fail-open convention
-    as ``build_position_detail_url``) — callers should skip attaching a link
-    rather than send a broken one.
+    Example: https://mgh3326.duckdns.org/invest/orders/kis/us/482
+
+    ``market`` is required alongside ``broker`` — the literal broker value
+    "kis" is written to two different ledger tables with independent id
+    sequences (KR domestic orders vs. US live orders placed via KIS), so
+    broker alone cannot disambiguate which row ``ledger_id`` refers to (see
+    the matching guard in ``app/routers/invest_fills.py::order_detail`` —
+    this builder and that endpoint must agree on the same
+    broker+market+ledger_id key, or a generated link resolves to the wrong
+    order). Returns None when any identifier is missing (same fail-open
+    convention as ``build_position_detail_url``) — callers should skip
+    attaching a link rather than send a broken or ambiguous one.
     """
-    if not broker or not ledger_id:
+    if not broker or not market or not ledger_id:
         return None
     broker_key = quote(broker.strip().lower())
-    return f"{settings.public_base_url.rstrip('/')}/invest/orders/{broker_key}/{ledger_id}"
+    market_key = quote(market.strip().lower())
+    return (
+        f"{settings.public_base_url.rstrip('/')}/invest/orders/"
+        f"{broker_key}/{market_key}/{ledger_id}"
+    )

--- a/app/core/invest_deep_links.py
+++ b/app/core/invest_deep_links.py
@@ -1,0 +1,58 @@
+"""Deep-link URL builders for the /invest web UI (INVEST-WATCH-UI §57차 item ③).
+
+Pure functions only — no telegram/discord/order_proposals imports. This is the
+"separation design" the job brief called for: the notifier/formatter files
+that actually attach links to Telegram/Discord cards (``app/monitoring/
+trade_notifier/{notifier,formatters_discord}.py``) are owned by an in-flight
+PR (#1844) and are out of scope here. Once that PR lands, its formatters can
+import and call these builders instead of constructing paths inline — mirrors
+the existing ``app/core/portfolio_links.py`` pattern (same ``public_base_url``
+source, same "pure builder, caller attaches" split).
+
+No builder here targets the Phase 2 approval page — it does not exist yet
+(§57차 explicitly forbids starting Phase 2 UI in this job), so there is
+nothing to link to for the third deep-link type ("승인 카드 → 승인 페이지").
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from app.core.config import settings
+
+
+def build_watches_url(
+    *,
+    market: str | None = None,
+    status: str | None = None,
+    symbol: str | None = None,
+) -> str:
+    """URL to the /invest/watches browsing page, optionally pre-filtered.
+
+    Example: https://mgh3326.duckdns.org/invest/watches?market=kr&status=active
+    """
+    base = f"{settings.public_base_url.rstrip('/')}/invest/watches"
+    params: list[str] = []
+    if market:
+        params.append(f"market={quote(market.strip().lower())}")
+    if status:
+        params.append(f"status={quote(status.strip().lower())}")
+    if symbol:
+        params.append(f"symbol={quote(symbol.strip())}")
+    if not params:
+        return base
+    return f"{base}?{'&'.join(params)}"
+
+
+def build_order_detail_url(*, broker: str | None, ledger_id: int | None) -> str | None:
+    """URL to the standalone order/fill detail view for one ledger row.
+
+    Example: https://mgh3326.duckdns.org/invest/orders/kis/482
+    Returns None when either identifier is missing (same fail-open convention
+    as ``build_position_detail_url``) — callers should skip attaching a link
+    rather than send a broken one.
+    """
+    if not broker or not ledger_id:
+        return None
+    broker_key = quote(broker.strip().lower())
+    return f"{settings.public_base_url.rstrip('/')}/invest/orders/{broker_key}/{ledger_id}"

--- a/app/routers/invest_fills.py
+++ b/app/routers/invest_fills.py
@@ -76,28 +76,66 @@ async def fills_freshness(
     return await ExecutionLedgerQueryService(db).freshness()
 
 
+# INVEST-WATCH-UI verify-r1 BLOCKER-1: `broker` alone is NOT a unique key.
+# `broker` is a DB column value, not a constant, and the literal "kis" is
+# written to TWO different tables — KISLiveOrderLedger (KR domestic, always
+# broker="kis") AND LiveOrderLedger (US live orders placed via the KIS
+# broker, order_execution.py, broker="kis" market="us"). Both tables have
+# independent id sequences, so (broker="kis", ledger_id=42) is ambiguous
+# between an unrelated KR order and a US order. Verified exhaustively against
+# every write site for these three tables (kis_live_ledger.py — KIS/kr only,
+# no market column; order_execution.py → live_order_ledger.py — kis/us and
+# upbit/crypto; toss_live_order_ledger_service.py — toss/{kr,us}, broker
+# fixed by a DB CHECK constraint):
+#
+#   (broker, market)   -> ledger table
+#   ("kis",   "kr")    -> KISLiveOrderLedger   (KR domestic; ROB-395)
+#   ("kis",   "us")    -> LiveOrderLedger      (US live via KIS; ROB-407)
+#   ("upbit", "crypto")-> LiveOrderLedger      (crypto via Upbit; ROB-407)
+#   ("toss",  "kr")     -> TossLiveOrderLedger  (Toss KR; ROB-529 P6-B)
+#   ("toss",  "us")     -> TossLiveOrderLedger  (Toss US; ROB-529 P6-B)
+#
+# An explicit allowlist (not an if/elif/else fall-through) so an unrecognized
+# combination fails closed with 400 instead of silently querying the wrong
+# table for the "else" branch.
+_ORDER_DETAIL_LEDGER_BY_BROKER_MARKET: dict[tuple[str, str], str] = {
+    ("kis", "kr"): "kis",
+    ("kis", "us"): "live",
+    ("upbit", "crypto"): "live",
+    ("toss", "kr"): "toss",
+    ("toss", "us"): "toss",
+}
+
+
 @router.get("/order-detail")
 async def order_detail(
     _user: Annotated[User, Depends(get_authenticated_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
     broker: Annotated[str, Query(min_length=1)],
+    market: Annotated[str, Query(min_length=1)],
     ledger_id: Annotated[int, Query(ge=1)],
 ) -> LinkedOrderView:
     """Single order-ledger row for the standalone order detail view (§57차 item ②).
 
     Read-only: reuses the ROB-554 projection helpers (``linked_orders.py``) so
     this view can never drift from the stock-detail order-ledger card. The
-    three live ledgers (LiveOrderLedger for US/crypto, KISLiveOrderLedger for
-    KR, TossLiveOrderLedger for Toss KR/US) each have an independent id
-    sequence, so ``broker`` disambiguates which table ``ledger_id`` refers to
-    (mirrors ``linkedOrderKey`` on the frontend, which keys on broker+market+id
-    for the same reason).
+    three live ledgers each have an independent id sequence, so ``ledger_id``
+    alone is ambiguous — ``(broker, market)`` together select the table
+    (mirrors ``linkedOrderKey`` on the frontend, which keys on
+    broker+market+id for the same reason; see
+    ``_ORDER_DETAIL_LEDGER_BY_BROKER_MARKET`` above for why ``broker`` alone
+    is not enough).
     """
-    broker_key = broker.strip().lower()
-    if broker_key == "kis":
+    ledger_kind = _ORDER_DETAIL_LEDGER_BY_BROKER_MARKET.get(
+        (broker.strip().lower(), market.strip().lower())
+    )
+    if ledger_kind is None:
+        raise HTTPException(status_code=400, detail="unknown_ledger_combination")
+
+    if ledger_kind == "kis":
         row = await db.get(KISLiveOrderLedger, ledger_id)
         view = project_kis_live_order(row) if row is not None else None
-    elif broker_key == "toss":
+    elif ledger_kind == "toss":
         row = await db.get(TossLiveOrderLedger, ledger_id)
         view = project_toss_live_order(row) if row is not None else None
     else:

--- a/app/routers/invest_fills.py
+++ b/app/routers/invest_fills.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_db
+from app.models.review import KISLiveOrderLedger, LiveOrderLedger, TossLiveOrderLedger
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
 from app.schemas.execution_ledger import (
@@ -15,7 +16,13 @@ from app.schemas.execution_ledger import (
     ExecutionLedgerListResponse,
     Side,
 )
+from app.schemas.investment_reports import LinkedOrderView
 from app.services.execution_ledger.query_service import ExecutionLedgerQueryService
+from app.services.investment_reports.linked_orders import (
+    project_kis_live_order,
+    project_live_order,
+    project_toss_live_order,
+)
 
 router = APIRouter(prefix="/trading/api/invest/fills", tags=["invest-fills"])
 Market = Literal["kr", "us", "crypto"]
@@ -67,3 +74,36 @@ async def fills_freshness(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ExecutionLedgerFreshnessReport:
     return await ExecutionLedgerQueryService(db).freshness()
+
+
+@router.get("/order-detail")
+async def order_detail(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    broker: Annotated[str, Query(min_length=1)],
+    ledger_id: Annotated[int, Query(ge=1)],
+) -> LinkedOrderView:
+    """Single order-ledger row for the standalone order detail view (§57차 item ②).
+
+    Read-only: reuses the ROB-554 projection helpers (``linked_orders.py``) so
+    this view can never drift from the stock-detail order-ledger card. The
+    three live ledgers (LiveOrderLedger for US/crypto, KISLiveOrderLedger for
+    KR, TossLiveOrderLedger for Toss KR/US) each have an independent id
+    sequence, so ``broker`` disambiguates which table ``ledger_id`` refers to
+    (mirrors ``linkedOrderKey`` on the frontend, which keys on broker+market+id
+    for the same reason).
+    """
+    broker_key = broker.strip().lower()
+    if broker_key == "kis":
+        row = await db.get(KISLiveOrderLedger, ledger_id)
+        view = project_kis_live_order(row) if row is not None else None
+    elif broker_key == "toss":
+        row = await db.get(TossLiveOrderLedger, ledger_id)
+        view = project_toss_live_order(row) if row is not None else None
+    else:
+        row = await db.get(LiveOrderLedger, ledger_id)
+        view = project_live_order(row) if row is not None else None
+
+    if view is None:
+        raise HTTPException(status_code=404, detail="order_not_found")
+    return view

--- a/frontend/invest/src/__tests__/LinkedOrderRow.test.tsx
+++ b/frontend/invest/src/__tests__/LinkedOrderRow.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { LinkedOrderRow, orderDetailPath } from "../components/orders/LinkedOrderRow";
+import type { LinkedOrder } from "../types/investmentReports";
+
+function makeOrder(overrides: Partial<LinkedOrder> = {}): LinkedOrder {
+  return {
+    ledgerId: 42,
+    broker: "kis",
+    accountScope: "kis_live",
+    market: "kr",
+    orderNo: "0001234500",
+    symbol: "005930",
+    side: "buy",
+    status: "filled",
+    filledQty: "10",
+    avgFillPrice: "70000",
+    ...overrides,
+  };
+}
+
+describe("orderDetailPath", () => {
+  it("builds a path from broker + ledgerId", () => {
+    expect(orderDetailPath(makeOrder())).toBe("/orders/kis/42");
+  });
+
+  it("returns null when broker is missing", () => {
+    expect(orderDetailPath(makeOrder({ broker: null }))).toBeNull();
+  });
+
+  it("returns null when ledgerId is 0/falsy", () => {
+    expect(orderDetailPath(makeOrder({ ledgerId: 0 }))).toBeNull();
+  });
+});
+
+describe("LinkedOrderRow deep link (INVEST-WATCH-UI §57차 item ②)", () => {
+  it("renders the row as a link to the order detail page when broker+ledgerId resolve", () => {
+    render(
+      <MemoryRouter>
+        <LinkedOrderRow order={makeOrder()} />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/orders/kis/42");
+  });
+});

--- a/frontend/invest/src/__tests__/LinkedOrderRow.test.tsx
+++ b/frontend/invest/src/__tests__/LinkedOrderRow.test.tsx
@@ -22,27 +22,52 @@ function makeOrder(overrides: Partial<LinkedOrder> = {}): LinkedOrder {
 }
 
 describe("orderDetailPath", () => {
-  it("builds a path from broker + ledgerId", () => {
-    expect(orderDetailPath(makeOrder())).toBe("/orders/kis/42");
+  it("builds a path from broker + market + ledgerId", () => {
+    expect(orderDetailPath(makeOrder())).toBe("/orders/kis/kr/42");
   });
 
   it("returns null when broker is missing", () => {
     expect(orderDetailPath(makeOrder({ broker: null }))).toBeNull();
   });
 
+  // verify-r1 BLOCKER-1 regression: market must be part of the key. Before
+  // the fix this returned "/orders/kis/42" for BOTH a KR order and a US
+  // order placed via the KIS broker — two different ledger tables with
+  // independent id sequences, so the same path collided on ledger_id.
+  it("returns null when market is missing (would otherwise collide across ledgers)", () => {
+    expect(orderDetailPath(makeOrder({ market: null }))).toBeNull();
+  });
+
   it("returns null when ledgerId is 0/falsy", () => {
     expect(orderDetailPath(makeOrder({ ledgerId: 0 }))).toBeNull();
+  });
+
+  it("builds distinct paths for the same broker+ledgerId under different markets", () => {
+    const krOrder = makeOrder({ broker: "kis", market: "kr", ledgerId: 42 });
+    const usOrder = makeOrder({ broker: "kis", market: "us", ledgerId: 42 });
+    expect(orderDetailPath(krOrder)).not.toBe(orderDetailPath(usOrder));
+    expect(orderDetailPath(krOrder)).toBe("/orders/kis/kr/42");
+    expect(orderDetailPath(usOrder)).toBe("/orders/kis/us/42");
   });
 });
 
 describe("LinkedOrderRow deep link (INVEST-WATCH-UI §57차 item ②)", () => {
-  it("renders the row as a link to the order detail page when broker+ledgerId resolve", () => {
+  it("renders the row as a link to the order detail page when broker+market+ledgerId resolve", () => {
     render(
       <MemoryRouter>
         <LinkedOrderRow order={makeOrder()} />
       </MemoryRouter>,
     );
     const link = screen.getByRole("link");
-    expect(link).toHaveAttribute("href", "/orders/kis/42");
+    expect(link).toHaveAttribute("href", "/orders/kis/kr/42");
+  });
+
+  it("renders a plain (non-link) row when market is missing", () => {
+    render(
+      <MemoryRouter>
+        <LinkedOrderRow order={makeOrder({ market: null })} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("link")).toBeNull();
   });
 });

--- a/frontend/invest/src/__tests__/OrderDetailRoute.test.tsx
+++ b/frontend/invest/src/__tests__/OrderDetailRoute.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as orderDetailApi from "../api/orderDetail";
+import { OrderDetailNotFoundError } from "../api/orderDetail";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { OrderDetailRoute } from "../pages/OrderDetailRoute";
+import { mockRightRail } from "../test/mockRightRail";
+import type { LinkedOrder } from "../types/investmentReports";
+
+function setWidth(w: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: w });
+}
+
+function wrap(initialPath: string) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/orders/:broker/:ledgerId" element={<OrderDetailRoute />} />
+        </Routes>
+      </MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
+
+const ORDER: LinkedOrder = {
+  broker: "kis",
+  accountScope: "kis_live",
+  market: "kr",
+  orderNo: "0001234500",
+  ledgerId: 42,
+  symbol: "005930",
+  side: "buy",
+  status: "filled",
+  filledQty: "10",
+  avgFillPrice: "70000",
+  orderTime: "093015",
+  reconciledAt: "2026-05-10T09:05:00Z",
+  exitReason: null,
+  thesis: "실적 발표 전 저점 매수",
+  reportItemUuid: null,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("OrderDetailRoute responsive dispatch", () => {
+  it("renders the desktop shell at >= 900px", async () => {
+    vi.spyOn(orderDetailApi, "fetchOrderDetail").mockResolvedValue(ORDER);
+    setWidth(1280);
+    render(wrap("/invest/orders/kis/42"));
+    expect(screen.getByTestId("desktop-shell")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("order-detail-card")).toBeInTheDocument());
+    expect(screen.getByText("실적 발표 전 저점 매수")).toBeInTheDocument();
+  });
+
+  it("renders the mobile shell below 900px", async () => {
+    vi.spyOn(orderDetailApi, "fetchOrderDetail").mockResolvedValue(ORDER);
+    setWidth(600);
+    render(wrap("/invest/orders/kis/42"));
+    expect(screen.getByTestId("mobile-shell")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("order-detail-card")).toBeInTheDocument());
+  });
+});
+
+describe("OrderDetailRoute not-found handling", () => {
+  it("shows a not-found message on 404 instead of crashing", async () => {
+    vi.spyOn(orderDetailApi, "fetchOrderDetail").mockRejectedValue(
+      new OrderDetailNotFoundError("order not found"),
+    );
+    setWidth(1280);
+    render(wrap("/invest/orders/kis/999"));
+
+    await waitFor(() => expect(screen.getByText("해당 주문을 찾을 수 없습니다.")).toBeInTheDocument());
+    expect(screen.queryByTestId("order-detail-card")).toBeNull();
+  });
+});

--- a/frontend/invest/src/__tests__/OrderDetailRoute.test.tsx
+++ b/frontend/invest/src/__tests__/OrderDetailRoute.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as orderDetailApi from "../api/orderDetail";
-import { OrderDetailNotFoundError } from "../api/orderDetail";
+import { OrderDetailNotFoundError, OrderDetailUnknownLedgerError } from "../api/orderDetail";
 import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import { OrderDetailRoute } from "../pages/OrderDetailRoute";
 import { mockRightRail } from "../test/mockRightRail";
@@ -18,7 +18,7 @@ function wrap(initialPath: string) {
     <AccountPanelProvider>
       <MemoryRouter basename="/invest" initialEntries={[initialPath]}>
         <Routes>
-          <Route path="/orders/:broker/:ledgerId" element={<OrderDetailRoute />} />
+          <Route path="/orders/:broker/:market/:ledgerId" element={<OrderDetailRoute />} />
         </Routes>
       </MemoryRouter>
     </AccountPanelProvider>
@@ -54,7 +54,7 @@ describe("OrderDetailRoute responsive dispatch", () => {
   it("renders the desktop shell at >= 900px", async () => {
     vi.spyOn(orderDetailApi, "fetchOrderDetail").mockResolvedValue(ORDER);
     setWidth(1280);
-    render(wrap("/invest/orders/kis/42"));
+    render(wrap("/invest/orders/kis/kr/42"));
     expect(screen.getByTestId("desktop-shell")).toBeInTheDocument();
     await waitFor(() => expect(screen.getByTestId("order-detail-card")).toBeInTheDocument());
     expect(screen.getByText("실적 발표 전 저점 매수")).toBeInTheDocument();
@@ -63,7 +63,7 @@ describe("OrderDetailRoute responsive dispatch", () => {
   it("renders the mobile shell below 900px", async () => {
     vi.spyOn(orderDetailApi, "fetchOrderDetail").mockResolvedValue(ORDER);
     setWidth(600);
-    render(wrap("/invest/orders/kis/42"));
+    render(wrap("/invest/orders/kis/kr/42"));
     expect(screen.getByTestId("mobile-shell")).toBeInTheDocument();
     await waitFor(() => expect(screen.getByTestId("order-detail-card")).toBeInTheDocument());
   });
@@ -75,7 +75,21 @@ describe("OrderDetailRoute not-found handling", () => {
       new OrderDetailNotFoundError("order not found"),
     );
     setWidth(1280);
-    render(wrap("/invest/orders/kis/999"));
+    render(wrap("/invest/orders/kis/kr/999"));
+
+    await waitFor(() => expect(screen.getByText("해당 주문을 찾을 수 없습니다.")).toBeInTheDocument());
+    expect(screen.queryByTestId("order-detail-card")).toBeNull();
+  });
+
+  // verify-r1 BLOCKER-1 regression: an unrecognized (broker, market) combo
+  // must fail closed (400 -> not-found UI), never silently fall through to
+  // whichever ledger table happens to be the "else" branch.
+  it("shows a not-found message on 400 (unknown broker+market combination)", async () => {
+    vi.spyOn(orderDetailApi, "fetchOrderDetail").mockRejectedValue(
+      new OrderDetailUnknownLedgerError("unknown ledger combination"),
+    );
+    setWidth(1280);
+    render(wrap("/invest/orders/upbit/kr/1"));
 
     await waitFor(() => expect(screen.getByText("해당 주문을 찾을 수 없습니다.")).toBeInTheDocument());
     expect(screen.queryByTestId("order-detail-card")).toBeNull();

--- a/frontend/invest/src/__tests__/OrderLedgerCard.test.tsx
+++ b/frontend/invest/src/__tests__/OrderLedgerCard.test.tsx
@@ -1,10 +1,19 @@
 // ROB-559 — per-symbol order history card on the stock detail page.
 
 import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 
 import { OrderLedgerCard } from "../desktop/stock-detail/OrderLedgerCard";
 import type { LinkedOrder } from "../types/investmentReports";
+
+// INVEST-WATCH-UI §57차 item ②: LinkedOrderRow now links to the standalone
+// order detail page, so it needs a Router in the tree even in this
+// stock-detail-page test.
+function renderWithRouter(ui: ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 function makeOrder(overrides: Partial<LinkedOrder> = {}): LinkedOrder {
   return {
@@ -24,14 +33,14 @@ function makeOrder(overrides: Partial<LinkedOrder> = {}): LinkedOrder {
 
 describe("OrderLedgerCard (ROB-559)", () => {
   it("renders the 주문 기록 card with status badge + order id for an order", () => {
-    render(<OrderLedgerCard orders={[makeOrder()]} />);
+    renderWithRouter(<OrderLedgerCard orders={[makeOrder()]} />);
     expect(screen.getByText("주문 기록")).toBeInTheDocument();
     expect(screen.getByText("체결")).toBeInTheDocument();
     expect(screen.getByText(/order 7aeb17dd/)).toBeInTheDocument();
   });
 
   it("renders a 미체결 badge and no qty line for an unfilled order", () => {
-    render(
+    renderWithRouter(
       <OrderLedgerCard
         orders={[
           makeOrder({ status: "accepted", filledQty: null, avgFillPrice: null }),
@@ -43,7 +52,7 @@ describe("OrderLedgerCard (ROB-559)", () => {
   });
 
   it("formats tiny fill quantities without scientific notation", () => {
-    render(<OrderLedgerCard orders={[makeOrder({ filledQty: "1E-8" })]} />);
+    renderWithRouter(<OrderLedgerCard orders={[makeOrder({ filledQty: "1E-8" })]} />);
     expect(screen.getByText(/0\.00000001/)).toBeInTheDocument();
   });
 

--- a/frontend/invest/src/__tests__/WatchesRoute.test.tsx
+++ b/frontend/invest/src/__tests__/WatchesRoute.test.tsx
@@ -12,10 +12,10 @@ function setWidth(w: number) {
   Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: w });
 }
 
-function wrap(ui: React.ReactElement) {
+function wrap(ui: React.ReactElement, initialPath = "/invest/watches") {
   return (
     <AccountPanelProvider>
-      <MemoryRouter basename="/invest" initialEntries={["/invest/watches"]}>{ui}</MemoryRouter>
+      <MemoryRouter basename="/invest" initialEntries={[initialPath]}>{ui}</MemoryRouter>
     </AccountPanelProvider>
   );
 }
@@ -120,5 +120,38 @@ describe("WatchesRoute ladder grouping", () => {
 
     await waitFor(() => expect(screen.getAllByTestId("watch-ladder-rung")).toHaveLength(2));
     expect(screen.getAllByText("실행플랜")).toHaveLength(1);
+  });
+});
+
+// verify-r1 SHOULD-1: build_watches_url() (app/core/invest_deep_links.py)
+// generates ?market=&status=&symbol=, but the page used to ignore all three
+// — a symbol-scoped "워치 카드 → watches" deep link landed on the unscoped
+// full list instead. These assert the page actually reads them.
+describe("WatchesRoute deep-link query params (verify-r1 SHOULD-1)", () => {
+  it("seeds the market/status filters from the URL and forwards symbol scope to the fetch", async () => {
+    setWidth(1280);
+    render(wrap(<WatchesRoute />, "/invest/watches?market=us&status=all&symbol=AAPL"));
+
+    await waitFor(() => expect(watchesApi.fetchWatches).toHaveBeenCalledWith("us", "all", "AAPL"));
+    // toggle buttons reflect the seeded state, not the component defaults
+    expect(screen.getByRole("button", { name: "미국" })).toHaveStyle({ color: "var(--bg)" });
+    // "AAPL" renders inside a <strong>, splitting the text node — match on
+    // the status region's full textContent instead of a single text node.
+    expect(screen.getByRole("status").textContent).toMatch(/AAPL 종목으로 범위가 좁혀졌습니다/);
+  });
+
+  it("falls back to defaults when the URL carries an unrecognized market/status value", async () => {
+    setWidth(1280);
+    render(wrap(<WatchesRoute />, "/invest/watches?market=bogus&status=nonsense"));
+
+    await waitFor(() => expect(watchesApi.fetchWatches).toHaveBeenCalledWith("all", "active", undefined));
+  });
+
+  it("omits the symbol scope banner and passes undefined when no symbol param is present", async () => {
+    setWidth(1280);
+    render(wrap(<WatchesRoute />));
+
+    await waitFor(() => expect(watchesApi.fetchWatches).toHaveBeenCalledWith("all", "active", undefined));
+    expect(screen.queryByText(/범위가 좁혀졌습니다/)).toBeNull();
   });
 });

--- a/frontend/invest/src/__tests__/WatchesRoute.test.tsx
+++ b/frontend/invest/src/__tests__/WatchesRoute.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WatchesRoute } from "../pages/WatchesRoute";
+import * as watchesApi from "../api/watches";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
+import type { WatchesResponse } from "../types/watches";
+
+function setWidth(w: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: w });
+}
+
+function wrap(ui: React.ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/watches"]}>{ui}</MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
+
+const READY: WatchesResponse = {
+  market: "all",
+  status: "active",
+  count: 2,
+  data_state: "ok",
+  as_of: "2026-08-13T00:00:00Z",
+  items: [
+    {
+      alert_uuid: "a1",
+      source_report_uuid: "r1",
+      market: "kr",
+      symbol: "005930",
+      symbol_name: "삼성전자",
+      target_kind: "asset",
+      metric: "price_below",
+      operator: "below",
+      threshold: "65000",
+      threshold_high: null,
+      status: "active",
+      valid_until: "2026-09-01T00:00:00Z",
+      intent: "buy_review",
+      action_mode: "notify_only",
+      rationale: "저점 매수",
+      trigger_checklist: [],
+      max_action: { side: "buy", quantity: 10 },
+      current_price: "70000",
+      proximity_band: "within_1_pct",
+      last_event: null,
+      near_expiry: false,
+    },
+    {
+      alert_uuid: "a2",
+      source_report_uuid: "r1",
+      market: "kr",
+      symbol: "005930",
+      symbol_name: "삼성전자",
+      target_kind: "asset",
+      metric: "price_below",
+      operator: "below",
+      threshold: "60000",
+      threshold_high: null,
+      status: "active",
+      valid_until: "2026-09-01T00:00:00Z",
+      intent: "buy_review",
+      action_mode: "notify_only",
+      rationale: "2차 저점 매수",
+      trigger_checklist: [],
+      max_action: {},
+      current_price: "70000",
+      proximity_band: "outside",
+      last_event: null,
+      near_expiry: false,
+    },
+  ],
+  warnings: [],
+  empty_reason: null,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
+  vi.spyOn(watchesApi, "fetchWatches").mockResolvedValue(READY);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("WatchesRoute responsive dispatch", () => {
+  it("renders the desktop shell at >= 900px", async () => {
+    setWidth(1280);
+    render(wrap(<WatchesRoute />));
+    expect(screen.getByTestId("desktop-shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("mobile-shell")).toBeNull();
+    await waitFor(() => expect(screen.getByTestId("watch-group-list")).toBeInTheDocument());
+  });
+
+  it("renders the mobile shell below 900px", async () => {
+    setWidth(600);
+    render(wrap(<WatchesRoute />));
+    expect(screen.getByTestId("mobile-shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("desktop-shell")).toBeNull();
+    await waitFor(() => expect(screen.getByTestId("watch-group-list")).toBeInTheDocument());
+  });
+});
+
+describe("WatchesRoute ladder grouping", () => {
+  it("groups two watch rungs for the same symbol into a single card", async () => {
+    setWidth(1280);
+    render(wrap(<WatchesRoute />));
+
+    await waitFor(() => expect(screen.getAllByTestId("watch-group-card")).toHaveLength(1));
+    expect(screen.getAllByTestId("watch-ladder-rung")).toHaveLength(2);
+    expect(screen.getByText(/2단계 래더/)).toBeInTheDocument();
+  });
+
+  it("shows an execution-plan badge only for the rung that carries max_action", async () => {
+    setWidth(1280);
+    render(wrap(<WatchesRoute />));
+
+    await waitFor(() => expect(screen.getAllByTestId("watch-ladder-rung")).toHaveLength(2));
+    expect(screen.getAllByText("실행플랜")).toHaveLength(1);
+  });
+});

--- a/frontend/invest/src/__tests__/orderDetail.api.test.ts
+++ b/frontend/invest/src/__tests__/orderDetail.api.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fetchOrderDetail, OrderDetailNotFoundError } from "../api/orderDetail";
+import {
+  fetchOrderDetail,
+  OrderDetailNotFoundError,
+  OrderDetailUnknownLedgerError,
+} from "../api/orderDetail";
 
 const originalFetch = global.fetch;
 
@@ -9,7 +13,7 @@ afterEach(() => {
 });
 
 describe("fetchOrderDetail", () => {
-  it("calls order-detail with broker + ledger_id and normalizes the response", async () => {
+  it("calls order-detail with broker + market + ledger_id and normalizes the response", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -33,25 +37,60 @@ describe("fetchOrderDetail", () => {
     });
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const order = await fetchOrderDetail("kis", 42);
+    const order = await fetchOrderDetail("kis", "kr", 42);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "/trading/api/invest/fills/order-detail?broker=kis&ledger_id=42",
+      "/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=42",
       { credentials: "include" },
     );
     expect(order.ledgerId).toBe(42);
     expect(order.thesis).toBe("저점 매수");
   });
 
+  // verify-r1 BLOCKER-1 regression: "kis" is written to two different ledger
+  // tables (KR domestic vs. US live via KIS) with independent id sequences —
+  // market must travel alongside broker or the two collide on ledger_id.
+  it("passes market as a distinct query param from broker (US vs KR disambiguation)", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        broker: "kis",
+        market: "us",
+        ledger_id: 42,
+        symbol: "AAPL",
+        side: "sell",
+        status: "filled",
+        thesis: "US 밸류에이션 부담으로 축소",
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const order = await fetchOrderDetail("kis", "us", 42);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("/trading/api/invest/fills/order-detail?broker=kis&market=us&ledger_id=42");
+    expect(order.symbol).toBe("AAPL");
+    expect(order.thesis).toBe("US 밸류에이션 부담으로 축소");
+  });
+
   it("throws OrderDetailNotFoundError on 404", async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 404 }) as unknown as typeof fetch;
 
-    await expect(fetchOrderDetail("kis", 999)).rejects.toBeInstanceOf(OrderDetailNotFoundError);
+    await expect(fetchOrderDetail("kis", "kr", 999)).rejects.toBeInstanceOf(OrderDetailNotFoundError);
+  });
+
+  it("throws OrderDetailUnknownLedgerError on 400 (unrecognized broker+market combo)", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 400 }) as unknown as typeof fetch;
+
+    await expect(fetchOrderDetail("upbit", "kr", 1)).rejects.toBeInstanceOf(
+      OrderDetailUnknownLedgerError,
+    );
   });
 
   it("throws a generic error on other non-ok responses", async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 }) as unknown as typeof fetch;
 
-    await expect(fetchOrderDetail("kis", 1)).rejects.toThrow("order-detail 500");
+    await expect(fetchOrderDetail("kis", "kr", 1)).rejects.toThrow("order-detail 500");
   });
 });

--- a/frontend/invest/src/__tests__/orderDetail.api.test.ts
+++ b/frontend/invest/src/__tests__/orderDetail.api.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchOrderDetail, OrderDetailNotFoundError } from "../api/orderDetail";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("fetchOrderDetail", () => {
+  it("calls order-detail with broker + ledger_id and normalizes the response", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        broker: "kis",
+        account_scope: "kis_live",
+        market: "kr",
+        order_no: "0001234500",
+        ledger_id: 42,
+        symbol: "005930",
+        side: "buy",
+        status: "filled",
+        filled_qty: "10",
+        avg_fill_price: "70000",
+        order_time: "093015",
+        reconciled_at: "2026-05-10T09:05:00Z",
+        exit_reason: null,
+        thesis: "저점 매수",
+        report_item_uuid: null,
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const order = await fetchOrderDetail("kis", 42);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/trading/api/invest/fills/order-detail?broker=kis&ledger_id=42",
+      { credentials: "include" },
+    );
+    expect(order.ledgerId).toBe(42);
+    expect(order.thesis).toBe("저점 매수");
+  });
+
+  it("throws OrderDetailNotFoundError on 404", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 404 }) as unknown as typeof fetch;
+
+    await expect(fetchOrderDetail("kis", 999)).rejects.toBeInstanceOf(OrderDetailNotFoundError);
+  });
+
+  it("throws a generic error on other non-ok responses", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 }) as unknown as typeof fetch;
+
+    await expect(fetchOrderDetail("kis", 1)).rejects.toThrow("order-detail 500");
+  });
+});

--- a/frontend/invest/src/__tests__/watchGrouping.test.ts
+++ b/frontend/invest/src/__tests__/watchGrouping.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeDistancePct,
+  formatDistancePct,
+  groupWatchesBySymbol,
+  hasMaxAction,
+} from "../components/watches/watchGrouping";
+import type { WatchAlertRow } from "../types/watches";
+
+function makeRow(overrides: Partial<WatchAlertRow> = {}): WatchAlertRow {
+  return {
+    alert_uuid: "a1",
+    source_report_uuid: "r1",
+    market: "kr",
+    symbol: "005930",
+    symbol_name: "삼성전자",
+    target_kind: "asset",
+    metric: "price_below",
+    operator: "below",
+    threshold: "70000",
+    threshold_high: null,
+    status: "active",
+    valid_until: "2026-09-01T00:00:00Z",
+    intent: "buy_review",
+    action_mode: "notify_only",
+    rationale: "저점 매수",
+    trigger_checklist: [],
+    max_action: {},
+    current_price: "72000",
+    proximity_band: "within_1_pct",
+    last_event: null,
+    near_expiry: false,
+    ...overrides,
+  };
+}
+
+describe("groupWatchesBySymbol", () => {
+  it("groups multiple rungs for the same symbol into one ladder, sorted by threshold", () => {
+    const rows = [
+      makeRow({ alert_uuid: "a1", threshold: "65000" }),
+      makeRow({ alert_uuid: "a2", threshold: "60000" }),
+      makeRow({ alert_uuid: "a3", threshold: "70000" }),
+    ];
+
+    const groups = groupWatchesBySymbol(rows);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.symbol).toBe("005930");
+    expect(groups[0]!.items.map((i) => i.alert_uuid)).toEqual(["a2", "a1", "a3"]);
+  });
+
+  it("keeps different symbols in separate groups", () => {
+    const rows = [
+      makeRow({ alert_uuid: "a1", symbol: "005930" }),
+      makeRow({ alert_uuid: "a2", symbol: "000660" }),
+    ];
+
+    const groups = groupWatchesBySymbol(rows);
+    expect(groups.map((g) => g.symbol).sort()).toEqual(["000660", "005930"]);
+  });
+
+  it("does not merge the same symbol across markets", () => {
+    const rows = [
+      makeRow({ alert_uuid: "a1", market: "kr", symbol: "BTC" }),
+      makeRow({ alert_uuid: "a2", market: "crypto", symbol: "BTC" }),
+    ];
+    const groups = groupWatchesBySymbol(rows);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("sorts groups with an active rung before groups with none", () => {
+    const rows = [
+      makeRow({ alert_uuid: "a1", symbol: "ZZZZ", status: "expired" }),
+      makeRow({ alert_uuid: "a2", symbol: "AAAA", status: "active" }),
+    ];
+    const groups = groupWatchesBySymbol(rows);
+    expect(groups[0]!.symbol).toBe("AAAA");
+  });
+
+  it("backfills group-level symbolName/currentPrice from the first row that has one", () => {
+    const rows = [
+      makeRow({ alert_uuid: "a1", symbol_name: null, current_price: null }),
+      makeRow({ alert_uuid: "a2", symbol_name: "삼성전자", current_price: "71000" }),
+    ];
+    const groups = groupWatchesBySymbol(rows);
+    expect(groups[0]!.symbolName).toBe("삼성전자");
+    expect(groups[0]!.currentPrice).toBe("71000");
+  });
+});
+
+describe("computeDistancePct / formatDistancePct", () => {
+  it("computes signed distance from current price to threshold", () => {
+    const row = makeRow({ current_price: "100", threshold: "110" });
+    expect(computeDistancePct(row)).toBeCloseTo(10, 5);
+    expect(formatDistancePct(row)).toBe("+10.00%");
+  });
+
+  it("returns a negative distance when the threshold is below current price", () => {
+    const row = makeRow({ current_price: "100", threshold: "90" });
+    expect(formatDistancePct(row)).toBe("-10.00%");
+  });
+
+  it("returns null when current price is missing", () => {
+    const row = makeRow({ current_price: null });
+    expect(computeDistancePct(row)).toBeNull();
+    expect(formatDistancePct(row)).toBeNull();
+  });
+});
+
+describe("hasMaxAction", () => {
+  it("is false for an empty max_action object", () => {
+    expect(hasMaxAction(makeRow({ max_action: {} }))).toBe(false);
+  });
+
+  it("is true when max_action carries keys", () => {
+    expect(hasMaxAction(makeRow({ max_action: { side: "buy", quantity: 10 } }))).toBe(true);
+  });
+});

--- a/frontend/invest/src/api/orderDetail.ts
+++ b/frontend/invest/src/api/orderDetail.ts
@@ -9,11 +9,23 @@ import { normalizeLinkedOrder } from "./investmentReports";
 const BASE = "/trading/api/invest/fills/order-detail";
 
 export class OrderDetailNotFoundError extends Error {}
+export class OrderDetailUnknownLedgerError extends Error {}
 
-export async function fetchOrderDetail(broker: string, ledgerId: number): Promise<LinkedOrder> {
-  const q = new URLSearchParams({ broker, ledger_id: String(ledgerId) });
+// `market` is required alongside `broker` — verify-r1 BLOCKER-1: the literal
+// broker value "kis" is written to two different ledger tables (KR domestic
+// vs. US live via KIS), each with an independent id sequence, so
+// broker+ledgerId alone can resolve to an unrelated order. Must match the
+// backend's (broker, market) -> table allowlist in
+// app/routers/invest_fills.py::order_detail.
+export async function fetchOrderDetail(
+  broker: string,
+  market: string,
+  ledgerId: number,
+): Promise<LinkedOrder> {
+  const q = new URLSearchParams({ broker, market, ledger_id: String(ledgerId) });
   const res = await fetch(`${BASE}?${q}`, { credentials: "include" });
   if (res.status === 404) throw new OrderDetailNotFoundError("order not found");
+  if (res.status === 400) throw new OrderDetailUnknownLedgerError("unknown ledger combination");
   if (!res.ok) throw new Error(`order-detail ${res.status}`);
   return normalizeLinkedOrder(await res.json());
 }

--- a/frontend/invest/src/api/orderDetail.ts
+++ b/frontend/invest/src/api/orderDetail.ts
@@ -1,0 +1,19 @@
+// INVEST-WATCH-UI §57차 item ② — single order-ledger row (ledger + linked
+// report-item thesis + lifecycle) for the standalone /invest/orders detail
+// page. Backend: GET /trading/api/invest/fills/order-detail (ROB-554
+// projection reused server-side so this can never drift from the
+// stock-detail order-ledger card / report-bundle decision log).
+import type { LinkedOrder } from "../types/investmentReports";
+import { normalizeLinkedOrder } from "./investmentReports";
+
+const BASE = "/trading/api/invest/fills/order-detail";
+
+export class OrderDetailNotFoundError extends Error {}
+
+export async function fetchOrderDetail(broker: string, ledgerId: number): Promise<LinkedOrder> {
+  const q = new URLSearchParams({ broker, ledger_id: String(ledgerId) });
+  const res = await fetch(`${BASE}?${q}`, { credentials: "include" });
+  if (res.status === 404) throw new OrderDetailNotFoundError("order not found");
+  if (!res.ok) throw new Error(`order-detail ${res.status}`);
+  return normalizeLinkedOrder(await res.json());
+}

--- a/frontend/invest/src/components/my/WatchAlertsPanel.tsx
+++ b/frontend/invest/src/components/my/WatchAlertsPanel.tsx
@@ -91,6 +91,11 @@ export function WatchAlertsPanel({ compact = false }: { compact?: boolean }) {
                 {dataState === "ok" ? "실시간" : dataState === "degraded" ? "시세 지연" : "확인 불가"}
               </Pill>
             )}
+            {compact && (
+              <Link to="/watches" style={{ fontSize: 11, color: "var(--fg-3)" }}>
+                전체보기 →
+              </Link>
+            )}
           </div>
           <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-3)" }}>
             AI가 포착한 감시 대상과 실시간 조건 및 근접도를 표시합니다.

--- a/frontend/invest/src/components/orders/LinkedOrderRow.tsx
+++ b/frontend/invest/src/components/orders/LinkedOrderRow.tsx
@@ -2,6 +2,7 @@
 // InvestmentReportBundleContent (ROB-554) so the report-bundle decision log and
 // the stock-detail "주문 기록" card render live orders identically.
 
+import { Link } from "react-router-dom";
 import { Pill, type PillTone } from "../../ds";
 import type { LinkedOrder } from "../../types/investmentReports";
 
@@ -44,6 +45,15 @@ export function linkedOrderKey(order: LinkedOrder): string {
   return `${order.broker ?? ""}:${order.market ?? ""}:${order.ledgerId}`;
 }
 
+// Route to the standalone order detail page (INVEST-WATCH-UI §57차 item ②).
+// broker disambiguates which of the three live ledgers ledgerId refers to
+// (mirrors the backend's /fills/order-detail lookup) — without it there's
+// nothing safe to link to.
+export function orderDetailPath(order: LinkedOrder): string | null {
+  if (!order.broker || !order.ledgerId) return null;
+  return `/orders/${encodeURIComponent(order.broker)}/${order.ledgerId}`;
+}
+
 // Pydantic serializes Decimal to a JSON string; sub-1e-6 magnitudes come through
 // as scientific notation (e.g. "1E-8" for tiny BTC fractions). Render a readable
 // fixed-point number instead, falling back to the raw value if it isn't numeric.
@@ -56,20 +66,10 @@ function fmtAmount(value: number | string | null | undefined): string {
 }
 
 export function LinkedOrderRow({ order }: { order: LinkedOrder }) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        gap: 8,
-        alignItems: "baseline",
-        flexWrap: "wrap",
-        fontSize: 12,
-        color: "var(--fg-3)",
-        background: "var(--surface-2)",
-        padding: "6px 10px",
-        borderRadius: 8,
-      }}
-    >
+  const detailPath = orderDetailPath(order);
+
+  const content = (
+    <>
       <Pill tone={LINKED_ORDER_STATUS_TONES[order.status ?? ""] ?? "paper"} size="sm">
         {LINKED_ORDER_STATUS_LABELS[order.status ?? ""] ?? order.status ?? "—"}
       </Pill>
@@ -87,6 +87,28 @@ export function LinkedOrderRow({ order }: { order: LinkedOrder }) {
       {order.exitReason || order.thesis ? (
         <span style={{ width: "100%" }}>{order.exitReason ?? order.thesis}</span>
       ) : null}
-    </div>
+    </>
   );
+
+  const rowStyle = {
+    display: "flex" as const,
+    gap: 8,
+    alignItems: "baseline" as const,
+    flexWrap: "wrap" as const,
+    fontSize: 12,
+    color: "var(--fg-3)",
+    background: "var(--surface-2)",
+    padding: "6px 10px",
+    borderRadius: 8,
+  };
+
+  if (detailPath) {
+    return (
+      <Link to={detailPath} style={{ ...rowStyle, textDecoration: "none" }}>
+        {content}
+      </Link>
+    );
+  }
+
+  return <div style={rowStyle}>{content}</div>;
 }

--- a/frontend/invest/src/components/orders/LinkedOrderRow.tsx
+++ b/frontend/invest/src/components/orders/LinkedOrderRow.tsx
@@ -46,12 +46,17 @@ export function linkedOrderKey(order: LinkedOrder): string {
 }
 
 // Route to the standalone order detail page (INVEST-WATCH-UI §57차 item ②).
-// broker disambiguates which of the three live ledgers ledgerId refers to
-// (mirrors the backend's /fills/order-detail lookup) — without it there's
-// nothing safe to link to.
+// verify-r1 BLOCKER-1: `broker` alone is NOT unique — the literal "kis" is
+// written to two different ledger tables with independent id sequences (KR
+// domestic orders vs. US live orders placed via the KIS broker), so a
+// broker-only link can resolve to a completely different order. `market`
+// must travel with `broker`+`ledgerId` (mirrors `linkedOrderKey` above, and
+// the backend's matching (broker, market) -> table allowlist in
+// invest_fills.py::order_detail — this function and that endpoint must agree
+// on the same key or a generated link opens the wrong order).
 export function orderDetailPath(order: LinkedOrder): string | null {
-  if (!order.broker || !order.ledgerId) return null;
-  return `/orders/${encodeURIComponent(order.broker)}/${order.ledgerId}`;
+  if (!order.broker || !order.market || !order.ledgerId) return null;
+  return `/orders/${encodeURIComponent(order.broker)}/${encodeURIComponent(order.market)}/${order.ledgerId}`;
 }
 
 // Pydantic serializes Decimal to a JSON string; sub-1e-6 magnitudes come through

--- a/frontend/invest/src/components/orders/OrderDetailBody.tsx
+++ b/frontend/invest/src/components/orders/OrderDetailBody.tsx
@@ -1,0 +1,43 @@
+// Shared status-dispatch body for the standalone order detail page
+// (INVEST-WATCH-UI §57차 item ②) — used by both the mobile and desktop shell
+// wrappers.
+import { PageSafetyNote } from "../PageSafetyNote";
+import { OrderDetailCard } from "./OrderDetailCard";
+import { useOrderDetail } from "./useOrderDetail";
+
+export function OrderDetailBody() {
+  const state = useOrderDetail();
+
+  return (
+    <div style={{ display: "grid", gap: 14 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <h1 style={{ margin: 0, fontSize: 22, letterSpacing: "-0.03em" }}>주문 상세</h1>
+        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>
+          체결 원장과 사유(thesis)를 결합한 읽기 전용 상세 화면입니다.
+        </p>
+      </div>
+
+      <PageSafetyNote
+        routeId="order-detail"
+        heading="읽기 전용"
+        tag="Phase 1"
+        items={["주문 정정·취소·재실행 mutation을 호출하지 않습니다."]}
+      />
+
+      {state.status === "loading" && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>
+      )}
+      {state.status === "not_found" && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+          해당 주문을 찾을 수 없습니다.
+        </div>
+      )}
+      {state.status === "error" && (
+        <div role="alert" style={{ padding: 16, color: "var(--danger)", fontSize: 13 }}>
+          주문 상세를 불러오지 못했습니다. {state.message}
+        </div>
+      )}
+      {state.status === "ready" && <OrderDetailCard order={state.order} />}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/orders/OrderDetailCard.tsx
+++ b/frontend/invest/src/components/orders/OrderDetailCard.tsx
@@ -1,0 +1,96 @@
+// Standalone order/fill detail body (INVEST-WATCH-UI §57차 item ②) — ledger
+// row (symbol · qty · price · lifecycle) combined with the send-time thesis.
+// Reuses the same status vocabulary as LinkedOrderRow (the per-symbol list
+// row on the stock-detail page) so the two views never disagree on labels.
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { Card, Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
+import type { LinkedOrder } from "../../types/investmentReports";
+import {
+  LINKED_ORDER_STATUS_LABELS,
+  LINKED_ORDER_STATUS_TONES,
+} from "./LinkedOrderRow";
+
+function fmtAmount(value: number | string | null | undefined): string {
+  if (value == null || value === "") return "—";
+  const n = Number(value);
+  return Number.isFinite(n) ? n.toLocaleString(undefined, { maximumFractionDigits: 8 }) : String(value);
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: "grid", gap: 2 }}>
+      <div style={{ fontSize: 11, color: "var(--fg-3)" }}>{label}</div>
+      <div style={{ fontSize: 14, fontWeight: 600 }}>{children}</div>
+    </div>
+  );
+}
+
+function isStockDetailMarket(market: string | null | undefined): market is "kr" | "us" | "crypto" {
+  return market === "kr" || market === "us" || market === "crypto";
+}
+
+export function OrderDetailCard({ order }: { order: LinkedOrder }) {
+  const href =
+    isStockDetailMarket(order.market) && order.symbol
+      ? stockDetailPath(order.market, order.symbol)
+      : null;
+
+  return (
+    <Card data-testid="order-detail-card">
+      <div style={{ display: "grid", gap: 16 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", flexWrap: "wrap", gap: 8 }}>
+          <div>
+            <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+              <Pill tone={LINKED_ORDER_STATUS_TONES[order.status ?? ""] ?? "paper"}>
+                {LINKED_ORDER_STATUS_LABELS[order.status ?? ""] ?? order.status ?? "—"}
+              </Pill>
+              <span style={{ fontSize: 20, fontWeight: 800 }}>
+                {order.side === "buy" ? "매수" : order.side === "sell" ? "매도" : ""} {order.symbol ?? "—"}
+              </span>
+            </div>
+            {href ? (
+              <Link to={href} style={{ fontSize: 12, color: "var(--fg-3)" }}>
+                종목 상세 보기
+              </Link>
+            ) : null}
+          </div>
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 12 }}>
+          <Field label="체결 수량">{fmtAmount(order.filledQty)}</Field>
+          <Field label="평균 체결가">{fmtAmount(order.avgFillPrice)}</Field>
+          <Field label="브로커">{order.broker ?? "—"}</Field>
+          <Field label="계좌 구분">{order.accountScope ?? "—"}</Field>
+          <Field label="주문번호">{order.orderNo ?? "—"}</Field>
+          <Field label="주문 시각">{order.orderTime ?? "—"}</Field>
+          <Field label="정산(reconcile) 시각">{order.reconciledAt ?? "—"}</Field>
+        </div>
+
+        {(order.thesis || order.exitReason) && (
+          <div style={{ display: "grid", gap: 8 }}>
+            {order.thesis && (
+              <div>
+                <div style={{ fontSize: 11, color: "var(--fg-3)", marginBottom: 2 }}>사유 (thesis)</div>
+                <div style={{ fontSize: 13, lineHeight: 1.6 }}>{order.thesis}</div>
+              </div>
+            )}
+            {order.exitReason && (
+              <div>
+                <div style={{ fontSize: 11, color: "var(--fg-3)", marginBottom: 2 }}>청산 사유</div>
+                <div style={{ fontSize: 13, lineHeight: 1.6 }}>{order.exitReason}</div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {order.reportItemUuid && (
+          <div style={{ fontSize: 11, color: "var(--fg-3)" }}>
+            연결된 리포트 항목: {order.reportItemUuid.slice(0, 8)}…
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/orders/useOrderDetail.ts
+++ b/frontend/invest/src/components/orders/useOrderDetail.ts
@@ -1,8 +1,12 @@
-// Shared fetch hook for the /invest/orders/:broker/:ledgerId detail route
-// (INVEST-WATCH-UI §57차 item ②).
+// Shared fetch hook for the /invest/orders/:broker/:market/:ledgerId detail
+// route (INVEST-WATCH-UI §57차 item ②).
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { fetchOrderDetail, OrderDetailNotFoundError } from "../../api/orderDetail";
+import {
+  fetchOrderDetail,
+  OrderDetailNotFoundError,
+  OrderDetailUnknownLedgerError,
+} from "../../api/orderDetail";
 import type { LinkedOrder } from "../../types/investmentReports";
 
 export type OrderDetailState =
@@ -12,24 +16,31 @@ export type OrderDetailState =
   | { status: "error"; message: string };
 
 export function useOrderDetail(): OrderDetailState {
-  const { broker, ledgerId } = useParams<{ broker: string; ledgerId: string }>();
+  // `market` is required alongside `broker` — verify-r1 BLOCKER-1: broker
+  // alone (e.g. "kis") is ambiguous between the KR domestic ledger and the
+  // US live ledger, which have independent id sequences.
+  const { broker, market, ledgerId } = useParams<{
+    broker: string;
+    market: string;
+    ledgerId: string;
+  }>();
   const [state, setState] = useState<OrderDetailState>({ status: "loading" });
 
   useEffect(() => {
     const numericLedgerId = Number(ledgerId);
-    if (!broker || !Number.isFinite(numericLedgerId)) {
+    if (!broker || !market || !Number.isFinite(numericLedgerId)) {
       setState({ status: "not_found" });
       return;
     }
     let cancelled = false;
     setState({ status: "loading" });
-    fetchOrderDetail(broker, numericLedgerId)
+    fetchOrderDetail(broker, market, numericLedgerId)
       .then((order) => {
         if (!cancelled) setState({ status: "ready", order });
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        if (err instanceof OrderDetailNotFoundError) {
+        if (err instanceof OrderDetailNotFoundError || err instanceof OrderDetailUnknownLedgerError) {
           setState({ status: "not_found" });
         } else {
           setState({ status: "error", message: err instanceof Error ? err.message : String(err) });
@@ -38,7 +49,7 @@ export function useOrderDetail(): OrderDetailState {
     return () => {
       cancelled = true;
     };
-  }, [broker, ledgerId]);
+  }, [broker, market, ledgerId]);
 
   return state;
 }

--- a/frontend/invest/src/components/orders/useOrderDetail.ts
+++ b/frontend/invest/src/components/orders/useOrderDetail.ts
@@ -1,0 +1,44 @@
+// Shared fetch hook for the /invest/orders/:broker/:ledgerId detail route
+// (INVEST-WATCH-UI §57차 item ②).
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { fetchOrderDetail, OrderDetailNotFoundError } from "../../api/orderDetail";
+import type { LinkedOrder } from "../../types/investmentReports";
+
+export type OrderDetailState =
+  | { status: "loading" }
+  | { status: "ready"; order: LinkedOrder }
+  | { status: "not_found" }
+  | { status: "error"; message: string };
+
+export function useOrderDetail(): OrderDetailState {
+  const { broker, ledgerId } = useParams<{ broker: string; ledgerId: string }>();
+  const [state, setState] = useState<OrderDetailState>({ status: "loading" });
+
+  useEffect(() => {
+    const numericLedgerId = Number(ledgerId);
+    if (!broker || !Number.isFinite(numericLedgerId)) {
+      setState({ status: "not_found" });
+      return;
+    }
+    let cancelled = false;
+    setState({ status: "loading" });
+    fetchOrderDetail(broker, numericLedgerId)
+      .then((order) => {
+        if (!cancelled) setState({ status: "ready", order });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof OrderDetailNotFoundError) {
+          setState({ status: "not_found" });
+        } else {
+          setState({ status: "error", message: err instanceof Error ? err.message : String(err) });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [broker, ledgerId]);
+
+  return state;
+}

--- a/frontend/invest/src/components/watches/WatchGroupCard.tsx
+++ b/frontend/invest/src/components/watches/WatchGroupCard.tsx
@@ -1,0 +1,104 @@
+// One symbol's watch-alert ladder — the per-card unit of the /invest/watches
+// browsing page (INVEST-WATCH-UI §57차 item ①). Mobile-first: a single-column
+// card stack rather than the wide table WatchAlertsPanel uses, so it reads
+// cleanly at phone width without horizontal scroll.
+
+import { Link } from "react-router-dom";
+import { Card, Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
+import type { WatchAlertRow } from "../../types/watches";
+import {
+  PROXIMITY_BAND_LABELS,
+  PROXIMITY_BAND_TONES,
+  WATCH_MARKET_LABEL,
+  WATCH_STATUS_LABELS,
+  WATCH_STATUS_TONES,
+  formatWatchCondition,
+  formatWatchDateTime,
+  formatWatchMoney,
+} from "../my/watchPresentation";
+import type { WatchGroup } from "./watchGrouping";
+import { formatDistancePct, hasMaxAction } from "./watchGrouping";
+
+function LadderRung({ row }: { row: WatchAlertRow }) {
+  const distance = formatDistancePct(row);
+  return (
+    <div
+      data-testid="watch-ladder-rung"
+      style={{
+        display: "grid",
+        gap: 4,
+        padding: "10px 12px",
+        borderRadius: 10,
+        background: "var(--surface-2)",
+      }}
+    >
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+        <Pill tone={WATCH_STATUS_TONES[row.status] ?? "paper"} size="sm">
+          {WATCH_STATUS_LABELS[row.status] ?? row.status}
+        </Pill>
+        {row.status === "active" && row.proximity_band && (
+          <Pill tone={PROXIMITY_BAND_TONES[row.proximity_band] ?? "paper"} size="sm">
+            {PROXIMITY_BAND_LABELS[row.proximity_band] ?? row.proximity_band}
+          </Pill>
+        )}
+        {row.near_expiry && <Pill tone="warn" size="sm">임박</Pill>}
+        <Pill tone="paper" size="sm">{row.intent}</Pill>
+        {hasMaxAction(row) && <Pill tone="accent" size="sm">실행플랜</Pill>}
+      </div>
+      <div style={{ fontSize: 13, fontWeight: 600 }}>{formatWatchCondition(row)}</div>
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap", fontSize: 11, color: "var(--fg-3)" }}>
+        {distance != null && <span>목표까지 {distance}</span>}
+        <span>만료: {formatWatchDateTime(row.valid_until)}</span>
+        {row.last_event && <span>발화: {formatWatchDateTime(row.last_event.created_at)} ({row.last_event.outcome})</span>}
+      </div>
+      {row.rationale && (
+        <div style={{ fontSize: 12, color: "var(--fg-2)", lineHeight: 1.5 }}>{row.rationale}</div>
+      )}
+    </div>
+  );
+}
+
+export function WatchGroupCard({ group }: { group: WatchGroup }) {
+  const href = stockDetailPath(group.market, group.symbol);
+  const dispName = group.symbolName && group.symbolName !== group.symbol ? group.symbolName : group.symbol;
+
+  const header = (
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+      <div>
+        <div style={{ fontSize: 15, fontWeight: 800 }}>{dispName}</div>
+        <div style={{ fontSize: 11, color: "var(--fg-3)" }}>
+          {group.symbol} · {WATCH_MARKET_LABEL[group.market]}
+          {group.items.length > 1 ? ` · ${group.items.length}단계 래더` : ""}
+        </div>
+      </div>
+      {group.currentPrice && (
+        <div style={{ textAlign: "right" }}>
+          <div style={{ fontSize: 10, color: "var(--fg-3)" }}>현재가</div>
+          <div style={{ fontSize: 14, fontWeight: 700, fontFeatureSettings: '"tnum"' }}>
+            {formatWatchMoney(group.currentPrice, group.market)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <Card data-testid="watch-group-card">
+      <div style={{ display: "grid", gap: 10 }}>
+        {href ? (
+          <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>
+            {header}
+          </Link>
+        ) : (
+          header
+        )}
+        <div style={{ display: "grid", gap: 6 }}>
+          {group.items.map((row) => (
+            <LadderRung key={row.alert_uuid} row={row} />
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/watches/WatchesPageBody.tsx
+++ b/frontend/invest/src/components/watches/WatchesPageBody.tsx
@@ -1,0 +1,170 @@
+// Shared fetch + filter + grouped-ladder body for the /invest/watches page
+// (INVEST-WATCH-UI §57차 item ①). One body renders inside both
+// MobileWatchesPage (MobileShell) and DesktopWatchesPage (DesktopShell) —
+// the layout difference between viewports is entirely in the shell, not this
+// content, since a single-column card stack already reads fine at desktop
+// width (unlike WatchAlertsPanel's wide table, which needs horizontal room).
+import { useEffect, useMemo, useState } from "react";
+import { fetchWatches } from "../../api/watches";
+import { Pill } from "../../ds";
+import type { WatchesResponse, WatchMarket, WatchStatus } from "../../types/watches";
+import { PageSafetyNote } from "../PageSafetyNote";
+import { WatchGroupCard } from "./WatchGroupCard";
+import { groupWatchesBySymbol } from "./watchGrouping";
+
+const MARKET_OPTIONS: { key: WatchMarket; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr", label: "국내" },
+  { key: "us", label: "미국" },
+  { key: "crypto", label: "코인" },
+];
+
+const STATUS_OPTIONS: { key: WatchStatus; label: string }[] = [
+  { key: "active", label: "감시중" },
+  { key: "all", label: "전체 상태" },
+  { key: "triggered", label: "감시발화" },
+  { key: "expired", label: "만료됨" },
+  { key: "canceled", label: "취소됨" },
+];
+
+function FilterRow<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { key: T; label: string }[];
+  value: T;
+  onChange: (key: T) => void;
+}) {
+  return (
+    <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+      {options.map((option) => {
+        const active = value === option.key;
+        return (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => onChange(option.key)}
+            style={{
+              border: "none",
+              borderRadius: 999,
+              padding: "6px 12px",
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: "pointer",
+              fontFamily: "inherit",
+              background: active ? "var(--fg)" : "var(--surface-2)",
+              color: active ? "var(--bg)" : "var(--fg-2)",
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function WatchesPageBody() {
+  // Default to "active" — this is a live browsing surface for what's being
+  // watched right now, not a history log (that's what status=all is for).
+  const [market, setMarket] = useState<WatchMarket>("all");
+  const [status, setStatus] = useState<WatchStatus>("active");
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; data: WatchesResponse }
+    | { status: "error"; message: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    fetchWatches(market, status)
+      .then((data) => {
+        if (!cancelled) setState({ status: "ready", data });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState({ status: "error", message: err instanceof Error ? err.message : String(err) });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [market, status]);
+
+  const groups = useMemo(
+    () => (state.status === "ready" ? groupWatchesBySymbol(state.data.items) : []),
+    [state],
+  );
+  const dataState = state.status === "ready" ? state.data.data_state : null;
+
+  return (
+    <div style={{ display: "grid", gap: 14 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <h1 style={{ margin: 0, fontSize: 22, letterSpacing: "-0.03em" }}>감시 목록</h1>
+        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>
+          종목별로 묶은 AI 감시 트리거입니다. 하나의 종목에 여러 단계 조건(래더)이 있으면 한 카드에 함께 표시됩니다.
+        </p>
+      </div>
+
+      <PageSafetyNote
+        routeId="watches"
+        heading="읽기 전용"
+        tag="Phase 1"
+        items={["주문·승인·watch 등록/수정 mutation을 호출하지 않습니다.", "감시 조건 변경은 이 화면에서 할 수 없습니다."]}
+      />
+
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 8 }}>
+        <div style={{ display: "grid", gap: 8 }}>
+          <FilterRow options={MARKET_OPTIONS} value={market} onChange={setMarket} />
+          <FilterRow options={STATUS_OPTIONS} value={status} onChange={setStatus} />
+        </div>
+        {dataState && (
+          <Pill tone={dataState === "ok" ? "accent" : dataState === "degraded" ? "warn" : "loss"} size="sm">
+            {dataState === "ok" ? "실시간" : dataState === "degraded" ? "시세 지연" : "확인 불가"}
+          </Pill>
+        )}
+      </div>
+
+      {state.status === "ready" && state.data.warnings.length > 0 && (
+        <div
+          role="alert"
+          style={{
+            padding: "8px 10px",
+            borderRadius: 10,
+            background: "var(--warn-soft)",
+            color: "var(--warn)",
+            fontSize: 12,
+          }}
+        >
+          {state.data.warnings.join(" · ")}
+        </div>
+      )}
+
+      {state.status === "loading" && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>감시 목록을 불러오는 중…</div>
+      )}
+
+      {state.status === "error" && (
+        <div role="alert" style={{ padding: 16, color: "var(--danger)", fontSize: 13 }}>
+          감시 목록을 불러오지 못했습니다. {state.message}
+        </div>
+      )}
+
+      {state.status === "ready" && groups.length === 0 && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+          {state.data.empty_reason ?? "표시할 감시 항목이 없습니다."}
+        </div>
+      )}
+
+      {groups.length > 0 && (
+        <div data-testid="watch-group-list" style={{ display: "grid", gap: 12 }}>
+          {groups.map((group) => (
+            <WatchGroupCard key={`${group.market}:${group.symbol}`} group={group} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/watches/WatchesPageBody.tsx
+++ b/frontend/invest/src/components/watches/WatchesPageBody.tsx
@@ -5,6 +5,7 @@
 // content, since a single-column card stack already reads fine at desktop
 // width (unlike WatchAlertsPanel's wide table, which needs horizontal room).
 import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { fetchWatches } from "../../api/watches";
 import { Pill } from "../../ds";
 import type { WatchesResponse, WatchMarket, WatchStatus } from "../../types/watches";
@@ -26,6 +27,18 @@ const STATUS_OPTIONS: { key: WatchStatus; label: string }[] = [
   { key: "expired", label: "만료됨" },
   { key: "canceled", label: "취소됨" },
 ];
+
+const VALID_MARKETS = MARKET_OPTIONS.map((o) => o.key);
+const VALID_STATUSES = STATUS_OPTIONS.map((o) => o.key);
+
+// verify-r1 SHOULD-1: `build_watches_url` (app/core/invest_deep_links.py)
+// generates ?market=&status=&symbol= but this page used to ignore them
+// entirely — a "워치 카드 → watches" deep link scoped to one symbol landed on
+// the unscoped full list. Read + validate on mount; unrecognized values fall
+// back to the same defaults as an un-scoped visit rather than 애매하게 breaking.
+function paramOrDefault<T extends string>(raw: string | null, valid: readonly T[], fallback: T): T {
+  return raw && (valid as readonly string[]).includes(raw) ? (raw as T) : fallback;
+}
 
 function FilterRow<T extends string>({
   options,
@@ -66,10 +79,21 @@ function FilterRow<T extends string>({
 }
 
 export function WatchesPageBody() {
+  const [searchParams] = useSearchParams();
   // Default to "active" — this is a live browsing surface for what's being
   // watched right now, not a history log (that's what status=all is for).
-  const [market, setMarket] = useState<WatchMarket>("all");
-  const [status, setStatus] = useState<WatchStatus>("active");
+  // Deep-link filters (?market=&status=) seed the initial toggle state; the
+  // toggle buttons still work normally afterward. ?symbol= has no UI toggle
+  // (it's a one-shot scope from a "워치 카드 → watches" link, not a filter a
+  // user picks from this page), so it's read directly rather than mirrored
+  // into component state.
+  const [market, setMarket] = useState<WatchMarket>(() =>
+    paramOrDefault(searchParams.get("market"), VALID_MARKETS, "all"),
+  );
+  const [status, setStatus] = useState<WatchStatus>(() =>
+    paramOrDefault(searchParams.get("status"), VALID_STATUSES, "active"),
+  );
+  const scopedSymbol = searchParams.get("symbol")?.trim() || undefined;
   const [state, setState] = useState<
     | { status: "loading" }
     | { status: "ready"; data: WatchesResponse }
@@ -79,7 +103,7 @@ export function WatchesPageBody() {
   useEffect(() => {
     let cancelled = false;
     setState({ status: "loading" });
-    fetchWatches(market, status)
+    fetchWatches(market, status, scopedSymbol)
       .then((data) => {
         if (!cancelled) setState({ status: "ready", data });
       })
@@ -91,7 +115,7 @@ export function WatchesPageBody() {
     return () => {
       cancelled = true;
     };
-  }, [market, status]);
+  }, [market, status, scopedSymbol]);
 
   const groups = useMemo(
     () => (state.status === "ready" ? groupWatchesBySymbol(state.data.items) : []),
@@ -114,6 +138,28 @@ export function WatchesPageBody() {
         tag="Phase 1"
         items={["주문·승인·watch 등록/수정 mutation을 호출하지 않습니다.", "감시 조건 변경은 이 화면에서 할 수 없습니다."]}
       />
+
+      {scopedSymbol && (
+        <div
+          role="status"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 8,
+            padding: "8px 12px",
+            borderRadius: 10,
+            background: "var(--accent-soft)",
+            color: "var(--fg-1)",
+            fontSize: 12,
+          }}
+        >
+          <span><strong>{scopedSymbol}</strong> 종목으로 범위가 좁혀졌습니다.</span>
+          <Link to="/watches" style={{ color: "var(--accent)", fontWeight: 700 }}>
+            전체 목록 보기
+          </Link>
+        </div>
+      )}
 
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 8 }}>
         <div style={{ display: "grid", gap: 8 }}>

--- a/frontend/invest/src/components/watches/watchGrouping.ts
+++ b/frontend/invest/src/components/watches/watchGrouping.ts
@@ -1,0 +1,88 @@
+// Pure grouping/ladder helpers for the /invest/watches browsing page
+// (INVEST-WATCH-UI §57차 item ①). Symbol-grouped so a symbol with multiple
+// price-ladder watch rungs (e.g. buy-the-dip at three thresholds) renders as
+// one card instead of N disconnected table rows — the existing
+// WatchAlertsPanel (a flat table) intentionally keeps its own layout;
+// this is the dedicated ladder view.
+
+import type { WatchAlertRow } from "../../types/watches";
+
+export interface WatchGroup {
+  market: WatchAlertRow["market"];
+  symbol: string;
+  symbolName: string | null;
+  currentPrice: string | null;
+  items: WatchAlertRow[];
+}
+
+function ladderCompare(a: WatchAlertRow, b: WatchAlertRow): number {
+  const at = Number(a.threshold);
+  const bt = Number(b.threshold);
+  if (Number.isFinite(at) && Number.isFinite(bt) && at !== bt) return at - bt;
+  return a.alert_uuid.localeCompare(b.alert_uuid);
+}
+
+// Active groups first (they're the ones a user is watching right now), then
+// alphabetical by symbol within each bucket for a stable, scannable order.
+function groupCompare(a: WatchGroup, b: WatchGroup): number {
+  const aActive = a.items.some((item) => item.status === "active") ? 0 : 1;
+  const bActive = b.items.some((item) => item.status === "active") ? 0 : 1;
+  if (aActive !== bActive) return aActive - bActive;
+  return a.symbol.localeCompare(b.symbol);
+}
+
+export function groupWatchesBySymbol(items: WatchAlertRow[]): WatchGroup[] {
+  const byKey = new Map<string, WatchGroup>();
+
+  for (const item of items) {
+    const key = `${item.market}:${item.symbol}`;
+    let group = byKey.get(key);
+    if (!group) {
+      group = {
+        market: item.market,
+        symbol: item.symbol,
+        symbolName: item.symbol_name,
+        currentPrice: item.current_price,
+        items: [],
+      };
+      byKey.set(key, group);
+    }
+    group.items.push(item);
+    if (!group.symbolName && item.symbol_name) group.symbolName = item.symbol_name;
+    if (!group.currentPrice && item.current_price) group.currentPrice = item.current_price;
+  }
+
+  const groups = Array.from(byKey.values());
+  for (const group of groups) group.items.sort(ladderCompare);
+  groups.sort(groupCompare);
+  return groups;
+}
+
+// Signed distance from the current price to this rung's threshold, as a
+// percentage of the current price. Positive = threshold is above current
+// price (room to run before triggering an "above" watch); negative = below.
+export function computeDistancePct(row: WatchAlertRow): number | null {
+  const price = row.current_price != null ? Number(row.current_price) : null;
+  const threshold = row.threshold != null ? Number(row.threshold) : null;
+  if (
+    price == null ||
+    threshold == null ||
+    !Number.isFinite(price) ||
+    !Number.isFinite(threshold) ||
+    price === 0
+  ) {
+    return null;
+  }
+  return ((threshold - price) / price) * 100;
+}
+
+export function formatDistancePct(row: WatchAlertRow): string | null {
+  const pct = computeDistancePct(row);
+  if (pct == null) return null;
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct.toFixed(2)}%`;
+}
+
+export function hasMaxAction(row: WatchAlertRow): boolean {
+  return Boolean(row.max_action) && Object.keys(row.max_action).length > 0;
+}

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -5,6 +5,7 @@ import { ThemeToggle } from "../theme/ThemeToggle";
 const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "홈", end: true },
   { to: "/my", label: "MY" },
+  { to: "/watches", label: "감시" },
   { to: "/feed/news", label: "뉴스" },
   { to: "/discover", label: "발견" },
   { to: "/calendar", label: "캘린더" },

--- a/frontend/invest/src/pages/OrderDetailRoute.tsx
+++ b/frontend/invest/src/pages/OrderDetailRoute.tsx
@@ -1,0 +1,10 @@
+// /invest/orders/:broker/:ledgerId — INVEST-WATCH-UI §57차 item ②. Mobile-first
+// viewport dispatch, mirrors WatchesRoute.tsx / InsightsRoute.tsx.
+import { useViewport } from "../hooks/useViewport";
+import { DesktopOrderDetailPage } from "./desktop/DesktopOrderDetailPage";
+import { MobileOrderDetailPage } from "./mobile/MobileOrderDetailPage";
+
+export function OrderDetailRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileOrderDetailPage /> : <DesktopOrderDetailPage />;
+}

--- a/frontend/invest/src/pages/WatchesRoute.tsx
+++ b/frontend/invest/src/pages/WatchesRoute.tsx
@@ -1,0 +1,10 @@
+// /invest/watches — INVEST-WATCH-UI §57차 item ①. Mobile-first viewport
+// dispatch, mirrors InsightsRoute.tsx / InvestHomeRoute.
+import { useViewport } from "../hooks/useViewport";
+import { DesktopWatchesPage } from "./desktop/DesktopWatchesPage";
+import { MobileWatchesPage } from "./mobile/MobileWatchesPage";
+
+export function WatchesRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileWatchesPage /> : <DesktopWatchesPage />;
+}

--- a/frontend/invest/src/pages/desktop/DesktopOrderDetailPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopOrderDetailPage.tsx
@@ -1,0 +1,7 @@
+// /invest/orders/:broker/:ledgerId (desktop) — INVEST-WATCH-UI §57차 item ②.
+import { OrderDetailBody } from "../../components/orders/OrderDetailBody";
+import { DesktopShell } from "../../desktop/DesktopShell";
+
+export function DesktopOrderDetailPage() {
+  return <DesktopShell center={<OrderDetailBody />} />;
+}

--- a/frontend/invest/src/pages/desktop/DesktopWatchesPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopWatchesPage.tsx
@@ -1,0 +1,7 @@
+// /invest/watches (desktop) — INVEST-WATCH-UI §57차 item ①.
+import { WatchesPageBody } from "../../components/watches/WatchesPageBody";
+import { DesktopShell } from "../../desktop/DesktopShell";
+
+export function DesktopWatchesPage() {
+  return <DesktopShell center={<WatchesPageBody />} />;
+}

--- a/frontend/invest/src/pages/mobile/MobileOrderDetailPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileOrderDetailPage.tsx
@@ -1,0 +1,13 @@
+// /invest/orders/:broker/:ledgerId (mobile) — INVEST-WATCH-UI §57차 item ②.
+import { OrderDetailBody } from "../../components/orders/OrderDetailBody";
+import { MobileShell } from "../../mobile/MobileShell";
+
+export function MobileOrderDetailPage() {
+  return (
+    <MobileShell title="주문 상세">
+      <div style={{ padding: "14px 16px 24px" }}>
+        <OrderDetailBody />
+      </div>
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/pages/mobile/MobileWatchesPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileWatchesPage.tsx
@@ -1,0 +1,13 @@
+// /invest/watches (mobile) — INVEST-WATCH-UI §57차 item ①.
+import { WatchesPageBody } from "../../components/watches/WatchesPageBody";
+import { MobileShell } from "../../mobile/MobileShell";
+
+export function MobileWatchesPage() {
+  return (
+    <MobileShell title="감시">
+      <div style={{ padding: "14px 16px 24px" }}>
+        <WatchesPageBody />
+      </div>
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -22,6 +22,12 @@
 // /invest/reports                 — Investment report list (ROB-265).
 // /invest/reports/:reportUuid     — Single investment report bundle.
 // /invest/stocks/:m/:sym    — Stock detail page.
+// /invest/watches           — Watch-alert browsing, grouped by symbol
+//                             (ladder view). Mobile-first (INVEST-WATCH-UI
+//                             §57차 item ①).
+// /invest/orders/:broker/:ledgerId — Standalone order/fill detail (ledger +
+//                             thesis + lifecycle). INVEST-WATCH-UI §57차
+//                             item ②.
 // ─────────────────────────────────────────────────────────────────────────────
 import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom";
 import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
@@ -42,6 +48,8 @@ import {
   InvestmentReportsRoute,
 } from "./pages/desktop/DesktopInvestmentReportsPage";
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
+import { WatchesRoute } from "./pages/WatchesRoute";
+import { OrderDetailRoute } from "./pages/OrderDetailRoute";
 
 // Static legacy /app/* redirect that preserves any ?search and #hash
 // from the source URL so market-scoped or anchor-scoped bookmarks
@@ -92,6 +100,8 @@ export const router = createBrowserRouter(
     { path: "/reports", element: <InvestmentReportsRoute /> },
     { path: "/reports/:reportUuid", element: <InvestmentReportBundleRoute /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
+    { path: "/watches", element: <WatchesRoute /> },
+    { path: "/orders/:broker/:ledgerId", element: <OrderDetailRoute /> },
 
     // Legacy /invest/app/* URLs redirect to their canonical /invest/*
     // siblings. The retired legacy components were removed after the

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -25,9 +25,11 @@
 // /invest/watches           — Watch-alert browsing, grouped by symbol
 //                             (ladder view). Mobile-first (INVEST-WATCH-UI
 //                             §57차 item ①).
-// /invest/orders/:broker/:ledgerId — Standalone order/fill detail (ledger +
-//                             thesis + lifecycle). INVEST-WATCH-UI §57차
-//                             item ②.
+// /invest/orders/:broker/:market/:ledgerId — Standalone order/fill detail
+//                             (ledger + thesis + lifecycle). INVEST-WATCH-UI
+//                             §57차 item ②. `market` is required alongside
+//                             `broker` (verify-r1 BLOCKER-1) — broker alone
+//                             is ambiguous between two ledger tables.
 // ─────────────────────────────────────────────────────────────────────────────
 import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom";
 import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
@@ -101,7 +103,7 @@ export const router = createBrowserRouter(
     { path: "/reports/:reportUuid", element: <InvestmentReportBundleRoute /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
     { path: "/watches", element: <WatchesRoute /> },
-    { path: "/orders/:broker/:ledgerId", element: <OrderDetailRoute /> },
+    { path: "/orders/:broker/:market/:ledgerId", element: <OrderDetailRoute /> },
 
     // Legacy /invest/app/* URLs redirect to their canonical /invest/*
     // siblings. The retired legacy components were removed after the

--- a/tests/core/test_invest_deep_links.py
+++ b/tests/core/test_invest_deep_links.py
@@ -31,17 +31,35 @@ def test_build_watches_url_uses_public_base_url(monkeypatch):
 
 @pytest.mark.unit
 def test_build_order_detail_url():
-    url = build_order_detail_url(broker="kis", ledger_id=42)
+    url = build_order_detail_url(broker="kis", market="kr", ledger_id=42)
     assert url is not None
-    assert url.endswith("/invest/orders/kis/42")
+    assert url.endswith("/invest/orders/kis/kr/42")
+
+
+# verify-r1 BLOCKER-1 regression: broker="kis" alone is ambiguous between the
+# KR domestic ledger and the US live ledger (independent id sequences), so
+# the same broker+ledger_id must produce DIFFERENT urls depending on market.
+@pytest.mark.unit
+def test_build_order_detail_url_market_disambiguates_same_broker_and_ledger_id():
+    kr_url = build_order_detail_url(broker="kis", market="kr", ledger_id=42)
+    us_url = build_order_detail_url(broker="kis", market="us", ledger_id=42)
+    assert kr_url != us_url
+    assert kr_url.endswith("/invest/orders/kis/kr/42")
+    assert us_url.endswith("/invest/orders/kis/us/42")
 
 
 @pytest.mark.unit
 def test_build_order_detail_url_missing_broker_returns_none():
-    assert build_order_detail_url(broker=None, ledger_id=42) is None
-    assert build_order_detail_url(broker="", ledger_id=42) is None
+    assert build_order_detail_url(broker=None, market="kr", ledger_id=42) is None
+    assert build_order_detail_url(broker="", market="kr", ledger_id=42) is None
+
+
+@pytest.mark.unit
+def test_build_order_detail_url_missing_market_returns_none():
+    assert build_order_detail_url(broker="kis", market=None, ledger_id=42) is None
+    assert build_order_detail_url(broker="kis", market="", ledger_id=42) is None
 
 
 @pytest.mark.unit
 def test_build_order_detail_url_missing_ledger_id_returns_none():
-    assert build_order_detail_url(broker="kis", ledger_id=None) is None
+    assert build_order_detail_url(broker="kis", market="kr", ledger_id=None) is None

--- a/tests/core/test_invest_deep_links.py
+++ b/tests/core/test_invest_deep_links.py
@@ -1,0 +1,47 @@
+"""Tests for the pure /invest deep-link builders (INVEST-WATCH-UI §57차 item ③)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.invest_deep_links import build_order_detail_url, build_watches_url
+
+
+@pytest.mark.unit
+def test_build_watches_url_bare():
+    url = build_watches_url()
+    assert url.endswith("/invest/watches")
+    assert "?" not in url
+
+
+@pytest.mark.unit
+def test_build_watches_url_with_filters():
+    url = build_watches_url(market="kr", status="active", symbol="005930")
+    assert url.endswith("/invest/watches?market=kr&status=active&symbol=005930")
+
+
+@pytest.mark.unit
+def test_build_watches_url_uses_public_base_url(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "public_base_url", "https://example.test/")
+    url = build_watches_url()
+    assert url == "https://example.test/invest/watches"
+
+
+@pytest.mark.unit
+def test_build_order_detail_url():
+    url = build_order_detail_url(broker="kis", ledger_id=42)
+    assert url is not None
+    assert url.endswith("/invest/orders/kis/42")
+
+
+@pytest.mark.unit
+def test_build_order_detail_url_missing_broker_returns_none():
+    assert build_order_detail_url(broker=None, ledger_id=42) is None
+    assert build_order_detail_url(broker="", ledger_id=42) is None
+
+
+@pytest.mark.unit
+def test_build_order_detail_url_missing_ledger_id_returns_none():
+    assert build_order_detail_url(broker="kis", ledger_id=None) is None

--- a/tests/routers/test_invest_fills_router.py
+++ b/tests/routers/test_invest_fills_router.py
@@ -625,13 +625,37 @@ def _make_order_detail_app(db):
     return app
 
 
-@pytest.mark.unit
-def test_order_detail_kis_broker_returns_row():
+def _recording_db_get(rows_by_model_and_id: dict) -> AsyncMock:
+    """AsyncSession.get() stub that records which (model, pk) was queried.
+
+    verify-r1 BLOCKER-1 root cause: the original tests mocked ``db.get`` with
+    a flat ``return_value``, so they never asserted *which model class* was
+    queried — the router could look up the wrong table and every assertion
+    would still pass as long as *a* row came back. These tests instead key
+    the stub by ``(model, pk)`` so a wrong-table lookup returns ``None``
+    (surfacing as an unexpected 404) instead of silently returning content.
+    """
+    calls: list[tuple[type, int]] = []
+
+    async def _get(model, pk):
+        calls.append((model, pk))
+        return rows_by_model_and_id.get((model, pk))
+
     db = AsyncMock()
-    db.get = AsyncMock(return_value=_kis_order_row())
+    db.get = AsyncMock(side_effect=_get)
+    db.get.calls = calls  # type: ignore[attr-defined]
+    return db
+
+
+@pytest.mark.unit
+def test_order_detail_kis_kr_returns_row_from_kis_ledger():
+    from app.models.review import KISLiveOrderLedger
+
+    row = _kis_order_row()
+    db = _recording_db_get({(KISLiveOrderLedger, 42): row})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&ledger_id=42")
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=42")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -639,43 +663,127 @@ def test_order_detail_kis_broker_returns_row():
     assert data["symbol"] == "005930"
     assert data["thesis"] == "실적 발표 전 저점 매수"
     assert data["market"] == "kr"
+    assert db.get.calls == [(KISLiveOrderLedger, 42)]
 
 
 @pytest.mark.unit
-def test_order_detail_toss_broker_returns_row():
-    db = AsyncMock()
-    db.get = AsyncMock(return_value=_toss_order_row())
+def test_order_detail_toss_kr_returns_row_from_toss_ledger():
+    from app.models.review import TossLiveOrderLedger
+
+    row = _toss_order_row()
+    db = _recording_db_get({(TossLiveOrderLedger, 3): row})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=toss&ledger_id=3")
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=toss&market=kr&ledger_id=3")
 
     assert resp.status_code == 200
     data = resp.json()
     assert data["order_no"] == "toss-9"
     assert data["thesis"] == "분할매수 1구간"
+    assert db.get.calls == [(TossLiveOrderLedger, 3)]
 
 
 @pytest.mark.unit
-def test_order_detail_defaults_to_live_ledger_for_other_brokers():
-    db = AsyncMock()
-    db.get = AsyncMock(return_value=_live_order_row())
+def test_order_detail_upbit_crypto_returns_row_from_live_ledger():
+    from app.models.review import LiveOrderLedger
+
+    row = _live_order_row()
+    db = _recording_db_get({(LiveOrderLedger, 7): row})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=upbit&ledger_id=7")
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=upbit&market=crypto&ledger_id=7")
 
     assert resp.status_code == 200
     data = resp.json()
     assert data["symbol"] == "KRW-BTC"
     assert data["exit_reason"] == "target_hit"
+    assert db.get.calls == [(LiveOrderLedger, 7)]
+
+
+@pytest.mark.unit
+def test_order_detail_kis_us_returns_row_from_live_ledger():
+    """US live orders placed via the KIS broker (ROB-407) land in
+    LiveOrderLedger, NOT KISLiveOrderLedger — broker="kis" alone does not
+    imply the KR domestic table."""
+    from app.models.review import LiveOrderLedger
+
+    row = _live_order_row(
+        id=99, broker="kis", account_scope="kis_live", market="us", symbol="AAPL", side="sell"
+    )
+    db = _recording_db_get({(LiveOrderLedger, 99): row})
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=us&ledger_id=99")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["symbol"] == "AAPL"
+    assert data["market"] == "us"
+    assert db.get.calls == [(LiveOrderLedger, 99)]
+
+
+@pytest.mark.unit
+def test_order_detail_disambiguates_colliding_ledger_id_across_ledgers_by_market():
+    """verify-r1 BLOCKER-1 collision fixture (acceptance criterion COLLISION_TEST).
+
+    broker="kis" is written to BOTH KISLiveOrderLedger (KR) and LiveOrderLedger
+    (US, via KIS) — two independent id sequences. Seed id=42 in both tables
+    with DIFFERENT content and confirm the KR link and the US link each
+    resolve to their own correct row, never the other's."""
+    from app.models.review import KISLiveOrderLedger, LiveOrderLedger
+
+    kr_row = _kis_order_row(
+        id=42, symbol="005930", side="buy", thesis="KR 실적 발표 전 저점 매수"
+    )
+    us_row = _live_order_row(
+        id=42,
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol="AAPL",
+        side="sell",
+        thesis="US 밸류에이션 부담으로 축소",
+        exit_reason=None,
+    )
+    db = _recording_db_get({(KISLiveOrderLedger, 42): kr_row, (LiveOrderLedger, 42): us_row})
+    client = TestClient(_make_order_detail_app(db))
+
+    kr_resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=42")
+    us_resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=us&ledger_id=42")
+
+    assert kr_resp.status_code == 200
+    assert us_resp.status_code == 200
+    kr_data, us_data = kr_resp.json(), us_resp.json()
+    assert kr_data["symbol"] == "005930"
+    assert kr_data["thesis"] == "KR 실적 발표 전 저점 매수"
+    assert us_data["symbol"] == "AAPL"
+    assert us_data["thesis"] == "US 밸류에이션 부담으로 축소"
+    assert kr_data != us_data
+    assert db.get.calls == [(KISLiveOrderLedger, 42), (LiveOrderLedger, 42)]
+
+
+@pytest.mark.unit
+def test_order_detail_rejects_unrecognized_broker_market_combination():
+    """Fail-closed on an unrecognized (broker, market) pair — e.g. a typo or
+    an unsupported combination — instead of silently falling through to an
+    arbitrary ledger table (the exact bug this rework fixes)."""
+    db = _recording_db_get({})
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=upbit&market=kr&ledger_id=1")
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "unknown_ledger_combination"
+    # never even queries the DB — the allowlist check happens first
+    assert db.get.calls == []
 
 
 @pytest.mark.unit
 def test_order_detail_returns_404_when_missing():
-    db = AsyncMock()
-    db.get = AsyncMock(return_value=None)
+    db = _recording_db_get({})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&ledger_id=999")
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=999")
 
     assert resp.status_code == 404
 
@@ -685,7 +793,16 @@ def test_order_detail_requires_ledger_id():
     db = AsyncMock()
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis")
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr")
+    assert resp.status_code == 422
+
+
+@pytest.mark.unit
+def test_order_detail_requires_market():
+    db = AsyncMock()
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&ledger_id=42")
     assert resp.status_code == 422
 
 
@@ -710,5 +827,5 @@ def test_unauthenticated_returns_401():
     app.dependency_overrides[get_db] = lambda: AsyncMock()
 
     client = TestClient(app, raise_server_exceptions=False)
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&ledger_id=1")
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=1")
     assert resp.status_code == 401

--- a/tests/routers/test_invest_fills_router.py
+++ b/tests/routers/test_invest_fills_router.py
@@ -655,7 +655,9 @@ def test_order_detail_kis_kr_returns_row_from_kis_ledger():
     db = _recording_db_get({(KISLiveOrderLedger, 42): row})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=42")
+    resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=42"
+    )
 
     assert resp.status_code == 200
     data = resp.json()
@@ -674,7 +676,9 @@ def test_order_detail_toss_kr_returns_row_from_toss_ledger():
     db = _recording_db_get({(TossLiveOrderLedger, 3): row})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=toss&market=kr&ledger_id=3")
+    resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=toss&market=kr&ledger_id=3"
+    )
 
     assert resp.status_code == 200
     data = resp.json()
@@ -691,7 +695,9 @@ def test_order_detail_upbit_crypto_returns_row_from_live_ledger():
     db = _recording_db_get({(LiveOrderLedger, 7): row})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=upbit&market=crypto&ledger_id=7")
+    resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=upbit&market=crypto&ledger_id=7"
+    )
 
     assert resp.status_code == 200
     data = resp.json()
@@ -708,12 +714,19 @@ def test_order_detail_kis_us_returns_row_from_live_ledger():
     from app.models.review import LiveOrderLedger
 
     row = _live_order_row(
-        id=99, broker="kis", account_scope="kis_live", market="us", symbol="AAPL", side="sell"
+        id=99,
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol="AAPL",
+        side="sell",
     )
     db = _recording_db_get({(LiveOrderLedger, 99): row})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=us&ledger_id=99")
+    resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=kis&market=us&ledger_id=99"
+    )
 
     assert resp.status_code == 200
     data = resp.json()
@@ -745,11 +758,17 @@ def test_order_detail_disambiguates_colliding_ledger_id_across_ledgers_by_market
         thesis="US 밸류에이션 부담으로 축소",
         exit_reason=None,
     )
-    db = _recording_db_get({(KISLiveOrderLedger, 42): kr_row, (LiveOrderLedger, 42): us_row})
+    db = _recording_db_get(
+        {(KISLiveOrderLedger, 42): kr_row, (LiveOrderLedger, 42): us_row}
+    )
     client = TestClient(_make_order_detail_app(db))
 
-    kr_resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=42")
-    us_resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=us&ledger_id=42")
+    kr_resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=42"
+    )
+    us_resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=kis&market=us&ledger_id=42"
+    )
 
     assert kr_resp.status_code == 200
     assert us_resp.status_code == 200
@@ -770,7 +789,9 @@ def test_order_detail_rejects_unrecognized_broker_market_combination():
     db = _recording_db_get({})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=upbit&market=kr&ledger_id=1")
+    resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=upbit&market=kr&ledger_id=1"
+    )
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "unknown_ledger_combination"
@@ -783,7 +804,9 @@ def test_order_detail_returns_404_when_missing():
     db = _recording_db_get({})
     client = TestClient(_make_order_detail_app(db))
 
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=999")
+    resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=999"
+    )
 
     assert resp.status_code == 404
 
@@ -827,5 +850,7 @@ def test_unauthenticated_returns_401():
     app.dependency_overrides[get_db] = lambda: AsyncMock()
 
     client = TestClient(app, raise_server_exceptions=False)
-    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=1")
+    resp = client.get(
+        "/trading/api/invest/fills/order-detail?broker=kis&market=kr&ledger_id=1"
+    )
     assert resp.status_code == 401

--- a/tests/routers/test_invest_fills_router.py
+++ b/tests/routers/test_invest_fills_router.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------
@@ -541,3 +541,174 @@ def test_sell_history_dedups_before_limit_and_reports_true_total():
     assert len(data["items"]) == 2  # trimmed page
     assert all(item["source"] == "reconciler" for item in data["items"])
     assert data["source_breakdown"]["websocket"] == 0
+
+
+# ---------------------------------------------------------------------------
+# /order-detail (INVEST-WATCH-UI §57차 item ②)
+# ---------------------------------------------------------------------------
+
+
+def _kis_order_row(**overrides):
+    defaults = {
+        "id": 42,
+        "broker": "kis",
+        "account_mode": "kis_live",
+        "order_no": "0001234500",
+        "symbol": "005930",
+        "side": "buy",
+        "status": "filled",
+        "filled_qty": Decimal("10"),
+        "avg_fill_price": Decimal("70000"),
+        "order_time": "093015",
+        "reconciled_at": datetime(2026, 5, 10, 9, 5, tzinfo=UTC),
+        "exit_reason": None,
+        "thesis": "실적 발표 전 저점 매수",
+        "report_item_uuid": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _live_order_row(**overrides):
+    defaults = {
+        "id": 7,
+        "broker": "upbit",
+        "account_scope": "live",
+        "market": "crypto",
+        "order_no": "abc-123",
+        "symbol": "KRW-BTC",
+        "side": "sell",
+        "status": "filled",
+        "filled_qty": Decimal("0.01"),
+        "avg_fill_price": Decimal("110000000"),
+        "order_time": None,
+        "reconciled_at": None,
+        "exit_reason": "target_hit",
+        "thesis": None,
+        "report_item_uuid": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _toss_order_row(**overrides):
+    defaults = {
+        "id": 3,
+        "broker": "toss",
+        "account_mode": "toss_live",
+        "market": "kr",
+        "broker_order_id": "toss-9",
+        "client_order_id": "toss-client-9",
+        "symbol": "005930",
+        "side": "buy",
+        "status": "accepted",
+        "filled_qty": None,
+        "avg_fill_price": None,
+        "reconciled_at": None,
+        "exit_reason": None,
+        "thesis": "분할매수 1구간",
+        "report_item_uuid": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_order_detail_app(db):
+    from app.core.db import get_db
+    from app.routers import invest_fills
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(invest_fills.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+@pytest.mark.unit
+def test_order_detail_kis_broker_returns_row():
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=_kis_order_row())
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&ledger_id=42")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ledger_id"] == 42
+    assert data["symbol"] == "005930"
+    assert data["thesis"] == "실적 발표 전 저점 매수"
+    assert data["market"] == "kr"
+
+
+@pytest.mark.unit
+def test_order_detail_toss_broker_returns_row():
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=_toss_order_row())
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=toss&ledger_id=3")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["order_no"] == "toss-9"
+    assert data["thesis"] == "분할매수 1구간"
+
+
+@pytest.mark.unit
+def test_order_detail_defaults_to_live_ledger_for_other_brokers():
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=_live_order_row())
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=upbit&ledger_id=7")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["symbol"] == "KRW-BTC"
+    assert data["exit_reason"] == "target_hit"
+
+
+@pytest.mark.unit
+def test_order_detail_returns_404_when_missing():
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&ledger_id=999")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+def test_order_detail_requires_ledger_id():
+    db = AsyncMock()
+    client = TestClient(_make_order_detail_app(db))
+
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Auth — unauthenticated requests return 401
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unauthenticated_returns_401():
+    from app.core.db import get_db
+    from app.routers import invest_fills
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(invest_fills.router)
+
+    def _raise_401():
+        raise HTTPException(status_code=401)
+
+    app.dependency_overrides[get_authenticated_user] = _raise_401
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/trading/api/invest/fills/order-detail?broker=kis&ledger_id=1")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Phase 1 of INVEST-WATCH-UI (§57차) — read-only web UI, mutation 0.

- **① `/invest/watches`** — new mobile-first page grouping active watch alerts by symbol into a ladder view (multiple price-rung watches on one symbol render as one card), showing distance-to-current-price, intent, and an "실행플랜" badge when `max_action` is present. Reuses the existing `GET /trading/api/invest/watches` endpoint as-is; no backend change needed for this item.
- **② Order/fill detail view** — new standalone `/invest/orders/:broker/:ledgerId` page combining the live order ledger row with its send-time thesis and lifecycle (status/filled qty/avg price/reconcile time). Backend adds one read-only endpoint, `GET /trading/api/invest/fills/order-detail`, which reuses the existing ROB-554 projection helpers (`project_kis_live_order` / `project_live_order` / `project_toss_live_order`) so it can never drift from the stock-detail order-ledger card. `LinkedOrderRow` (used on the stock-detail page and the report-bundle decision log) now links each row to this page.
- **③ Deep links** — added `app/core/invest_deep_links.py`, a pure URL-builder utility (`build_watches_url`, `build_order_detail_url`), mirroring the existing `app/core/portfolio_links.py` pattern. **Not wired into the Telegram/Discord notifier** — see "Explicitly out of scope" below.

## Explicitly out of scope (stopped, not implemented)

Per the job brief's file-ownership boundary, actual attachment of deep links to notification cards was **not** implemented:

- `app/monitoring/trade_notifier/{notifier,formatters_discord}.py` and `app/services/order_proposals/**` are owned by an in-flight PR (#1844) and were not touched.
- The 4 existing `notify_fill(detail_url=...)` call sites (`app/jobs/kis_trading.py`, `app/services/toss_notification_service.py`, `app/mcp_server/tooling/toss_live_ledger.py`, `websocket_monitor.py`) are outside this job's declared safe surface (`frontend/invest/src/**`, `invest_watches.py`, `invest_fills.py`, `invest_app_spa.py`, matching `tests/`) and were left untouched.
- The third deep-link type ("승인 카드 → 승인 페이지") has no target — the Phase 2 approval page does not exist yet and Phase 2 UI is explicitly out of scope for this job.

Once #1844 lands, its formatters can import `build_watches_url`/`build_order_detail_url` instead of constructing paths inline — this PR does the "separation design" the brief asked for as the alternative to touching forbidden files.

## Safety

- Mutation 0: the new endpoint is a single `db.get()` read; no INSERT/UPDATE/DELETE anywhere in the diff.
- No new public endpoint: `/trading/api/invest/fills/order-detail` matches the existing `/api/` auth-middleware gate (session required, 401 otherwise) — same as every other `/trading/api/invest/*` route. New frontend routes are served by the existing authenticated `/invest` SPA shell.
- No forbidden-file touches: `git diff origin/main...HEAD --stat` shows only `app/routers/invest_fills.py`, `app/core/invest_deep_links.py` (new), `frontend/invest/src/**`, and matching test files — none of `app/monitoring/trade_notifier/*`, `app/core/config.py`, `app/services/order_proposals/**`, `app/mcp_server/tooling/{analysis_registration,analysis_readonly_registration,buy_candidate_fanout}.py`, `scripts/b0x/kr/**`, `config/trading_policy.yaml`, `docs/playbooks/**`, or `app/jobs/investment_watch_scanner.py`.

## Test plan

- [x] `uv run pytest tests/routers/test_invest_fills_router.py tests/core/test_invest_deep_links.py tests/routers/ -q` — 218+35 passed
- [x] `npx tsc --noEmit && npm run build` (frontend/invest) — clean, build succeeds
- [x] `npx vitest run` (frontend/invest) — 113 files / 636 tests passed, including new `watchGrouping.test.ts`, `WatchesRoute.test.tsx`, `orderDetail.api.test.ts`, `OrderDetailRoute.test.tsx`, `LinkedOrderRow.test.tsx`, and a regression fix to `OrderLedgerCard.test.tsx` (needed a `MemoryRouter` wrapper now that `LinkedOrderRow` links out)
- [x] `python -c "import app.main"` — router registration imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added responsive investment watch pages for grouped alerts by market, symbol, status, and threshold.
  - Added filtered watch deep links, desktop navigation, and compact-panel access.
  - Added responsive, read-only order-detail pages for supported broker and market combinations.
  - Linked eligible order rows to detail pages displaying status, execution metadata, thesis, exit reason, and related reports.
- **Bug Fixes**
  - Added clear loading, empty, unavailable, and error states for watch and order-detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->