### PR TITLE
fix(order-proposals): distinguish veto-cancel unconfirmed from failed (ROB-1246)

### DIFF
--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -533,6 +533,35 @@ async def _handle_deny(
     }
 
 
+def _classify_veto_outcome(outcome: Mapping[str, Any]) -> str:
+    """Map one ``cancel_auto_submitted_rungs`` outcome to a display bucket.
+
+    ``result: "cancel_failed"`` covers two evidentially distinct cases (see
+    ``auto_veto.cancel_auto_submitted_rungs``): (1) the fresh broker fetch
+    already reports the target ``cancelled`` but the Toss-only second-stage
+    ledger reconcile hasn't confirmed yet (``broker_status == "cancelled"``),
+    and (2) the fetch itself never produced a status (broker read failure ->
+    ``broker_status is None``). Neither is proof the cancel did NOT take
+    effect -- ROB-1246: the real Acceptance A run hit case (1) and the
+    operator saw a false "취소 실패" for a cancel that had already succeeded
+    at the broker and converged moments later via a follow-up reconcile.
+    Only a fetched, non-cancelled broker status is a confirmed failure.
+    """
+    result = outcome.get("result")
+    if result in {"filled", "cancelled"}:
+        return result
+    if result == "cancel_failed":
+        broker_status = outcome.get("broker_status")
+        if broker_status == "cancelled" or broker_status is None:
+            return "unconfirmed"
+        return "failed"
+    # "not_cancellable": the rung was never in a broker-cancellable state
+    # (already resolved via another path, or missing a broker_order_id) --
+    # there is no pending broker evidence to wait on, so this is a definite
+    # failure bucket rather than "unconfirmed".
+    return "failed"
+
+
 async def _handle_auto_veto(
     *,
     session: AsyncSession,
@@ -582,11 +611,7 @@ async def _handle_auto_veto(
         fetch_fn=fetch_fn,
         toss_reconcile_fn=toss_reconcile_fn,
     )
-    saw_filled = any(outcome["result"] == "filled" for outcome in outcomes)
-    saw_failure = any(
-        outcome["result"] in {"cancel_failed", "not_cancellable"}
-        for outcome in outcomes
-    )
+    outcome_kinds = {_classify_veto_outcome(outcome) for outcome in outcomes}
 
     await service.record_auto_veto(
         proposal_id,
@@ -596,12 +621,23 @@ async def _handle_auto_veto(
     )
     await session.commit()
 
-    if saw_filled:
+    # Priority order: a fill always wins (nothing left to cancel); a confirmed
+    # failure (broker still shows the target open after the cancel attempt,
+    # or nothing was cancellable) must not be masked by an unconfirmed rung
+    # elsewhere in the same batch; "unconfirmed" only wins over the default
+    # success text when no rung is a definite fill/failure.
+    if "filled" in outcome_kinds:
         reason = "auto_veto_filled"
         text = "✅ 체결됨 — 취소 시점에 이미 체결된 주문입니다."
-    elif saw_failure:
+    elif "failed" in outcome_kinds:
         reason = "auto_veto_failed"
         text = "⚠️ 취소 실패 — 브로커 주문 상태를 확인해 주세요."
+    elif "unconfirmed" in outcome_kinds:
+        reason = "auto_veto_unconfirmed"
+        text = (
+            "🔍 취소 확인 중 — 브로커 취소 처리를 아직 확정하지 못했습니다. "
+            "잠시 후 다시 확인해 주세요."
+        )
     else:
         reason = "auto_veto_cancelled"
         text = "🛑 취소됨"

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -925,6 +925,11 @@ async def test_acceptance_a_toss_veto_needs_broker_terminal_and_ledger_reconcile
         "terminal:broker-auto-1",
         "reconcile:broker-auto-1",
     ]
+    # ROB-1246 ACCEPTANCE_A_REPLAY: the real 2026-08-13 run reached this exact
+    # broker-terminal-then-reconciled sequence and the operator must see the
+    # success card, never "실패".
+    assert "취소됨" in notifier.edited[-1][2]
+    assert "실패" not in notifier.edited[-1][2]
     _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
         group.proposal_id
     )
@@ -962,24 +967,117 @@ async def test_toss_auto_veto_never_marks_cancelled_without_reconcile_terminal(
     async def unconfirmed_reconcile(**_kwargs):
         return {"confirmed": False, "error": "original_order_not_terminal_in_ledger"}
 
+    notifier = _FakeNotifier()
     result = await handle_callback_update(
         _make_update(
             data=_proposal_callback_data(group, action="vc", nonce="veto-nonce")
         ),
         now=datetime.now(UTC),
         service_factory=_session_factory(db_session),
-        notifier=_FakeNotifier(),
+        notifier=notifier,
         veto_cancel_fn=cancel_fn,
         veto_fetch_fn=fetch_fn,
         veto_toss_reconcile_fn=unconfirmed_reconcile,
     )
 
-    assert result["reason"] == "auto_veto_failed"
+    # ROB-1246: broker terminal already reports "cancelled" here -- only the
+    # Toss-only second-stage ledger reconcile is unconfirmed. The evidence
+    # filter below (Mutant guard) must still refuse to mark the rung
+    # cancelled without that reconcile, but the operator-facing text must not
+    # claim the cancel "실패" (Acceptance A, 2026-08-13: this exact fixture
+    # shape was the real callback response for a cancel that had already
+    # succeeded and converged moments later via a follow-up reconcile).
+    assert result["reason"] == "auto_veto_unconfirmed"
+    assert "확인 중" in notifier.edited[-1][2]
+    assert "실패" not in notifier.edited[-1][2]
     _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
         group.proposal_id
     )
     assert rungs[0].state == "resting"
     assert result["outcomes"][0]["error"] == "toss_terminal_reconcile_unconfirmed"
+
+
+@pytest.mark.asyncio
+async def test_auto_veto_still_open_after_cancel_attempt_reports_failure(
+    monkeypatch, db_session
+):
+    """실패 분기: fresh broker fetch shows the target still open, not cancelled."""
+    _allow_chat(monkeypatch)
+    group = await _seed_auto_resting(db_session)
+
+    async def cancel_fn(**_kwargs):
+        return {"success": False, "error": "broker_rejected"}
+
+    async def fetch_fn(**kwargs):
+        return TargetOrderSnapshot(
+            broker_order_id="broker-auto-1",
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            limit_price="97000",
+            remaining_quantity="1",
+            status="resting",
+            observed_at=kwargs["now"].isoformat(),
+        )
+
+    notifier = _FakeNotifier()
+    result = await handle_callback_update(
+        _make_update(
+            data=_proposal_callback_data(group, action="vc", nonce="veto-nonce")
+        ),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        veto_cancel_fn=cancel_fn,
+        veto_fetch_fn=fetch_fn,
+    )
+
+    assert result["reason"] == "auto_veto_failed"
+    assert "취소 실패" in notifier.edited[-1][2]
+    _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "resting"
+
+
+@pytest.mark.asyncio
+async def test_auto_veto_status_fetch_failure_reports_unconfirmed_not_failure(
+    monkeypatch, db_session
+):
+    """미확정 분기: the post-cancel status fetch itself errors out.
+
+    A broker read failure proves nothing about whether the cancel took --
+    it must not be shown to the operator as a confirmed "취소 실패" any more
+    than the Toss reconcile-lag case is (ROB-1246).
+    """
+    _allow_chat(monkeypatch)
+    group = await _seed_auto_resting(db_session)
+
+    async def cancel_fn(**_kwargs):
+        return {"success": True}
+
+    async def fetch_fn(**_kwargs):
+        raise RuntimeError("broker_timeout")
+
+    notifier = _FakeNotifier()
+    result = await handle_callback_update(
+        _make_update(
+            data=_proposal_callback_data(group, action="vc", nonce="veto-nonce")
+        ),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        veto_cancel_fn=cancel_fn,
+        veto_fetch_fn=fetch_fn,
+    )
+
+    assert result["reason"] == "auto_veto_unconfirmed"
+    assert "확인 중" in notifier.edited[-1][2]
+    assert "실패" not in notifier.edited[-1][2]
+    _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "resting"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- The auto-veto Telegram callback (`_handle_auto_veto` in `telegram_callback.py`) collapsed two evidentially distinct `cancel_failed` cases into a single "⚠️ 취소 실패" message: (1) broker terminal already confirms `cancelled` but the Toss-only second-stage ledger reconcile hasn't converged yet, and (2) the post-cancel status fetch itself errored (unknown status). Neither is proof the cancel failed.
- Real incident (Acceptance A, 2026-08-13, proposal `f3016600`, symbol 011200 HMM, `toss_live`): broker cancelled the order at 14:26:16, but the callback showed "취소 실패" because the ledger reconcile hadn't caught up yet — a later manual reconcile converged it cleanly. An operator trusting that message could re-cancel or take other action on an already-closed order.
- Added `_classify_veto_outcome` to split the three operator-facing states — success (`cancelled`/`filled`, unchanged text), **unconfirmed** (new: broker says cancelled but ledger reconcile pending, or status fetch failed — "🔍 취소 확인 중"), and failed (broker confirms the order is still open, or nothing was cancellable — unchanged "⚠️ 취소 실패" text, now only for genuine failures).
- `app/services/order_proposals/auto_veto.py` (the evidence filter sealed by #1844) is untouched — this is a display-layer fix only, verified via empty diff.

## Test plan
- [x] `uv run pytest tests/services/order_proposals/test_telegram_callback.py -q` — 61 passed, including the #1844 "Mutant ③ guard" test (now asserting the corrected `auto_veto_unconfirmed` reason + text while its safety assertion `rungs[0].state == "resting"` is unchanged)
- [x] Two new regression tests added: genuine-failure (`auto_veto_failed`, broker still shows the order open) and status-fetch-error (`auto_veto_unconfirmed`)
- [x] Existing Acceptance-A-replay test extended to assert the success text ("취소됨", never "실패")
- [x] False-green check: reverted the `telegram_callback.py` fix and confirmed the two new/updated tests fail against the old code (proving they actually catch the bug), then restored the fix
- [x] `uv run pytest tests/services/order_proposals/ -q` — 732 passed
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — all clean
- [x] `git diff -- app/services/order_proposals/auto_veto.py` — empty (evidence filter untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-veto outcome reporting to distinguish confirmed cancellation failures from unconfirmed broker or reconciliation states.
  * Prioritized fill and confirmed failure messages before unconfirmed cancellation outcomes.
  * Added clearer operator messaging and reasons for unconfirmed cancellation results.
  * Improved handling of broker status-fetch errors, rejected cancellations, and reconciliation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->