### PR TITLE
feat(order-proposals): add atomic watcher scope seam

### DIFF
--- a/app/services/order_proposals/__init__.py
+++ b/app/services/order_proposals/__init__.py
@@ -15,14 +15,26 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from app.services.order_proposals.service import OrderProposalsService
+    from app.services.order_proposals.service import (
+        OrderProposalsService,
+        WatchToOrderScope,
+        WatchToOrderScopeGroup,
+        WatchToOrderScopeInspection,
+        WatchToOrderScopeRung,
+    )
 
-__all__ = ["OrderProposalsService"]
+__all__ = [
+    "OrderProposalsService",
+    "WatchToOrderScope",
+    "WatchToOrderScopeGroup",
+    "WatchToOrderScopeInspection",
+    "WatchToOrderScopeRung",
+]
 
 
 def __getattr__(name: str):
-    if name == "OrderProposalsService":
-        from app.services.order_proposals.service import OrderProposalsService
+    if name in __all__:
+        from app.services.order_proposals import service
 
-        return OrderProposalsService
+        return getattr(service, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -25,6 +25,7 @@ from app.models.order_proposals import (
 )
 from app.services.order_proposals.defensive_ttl import DEFENSIVE_EXIT_INTENTS
 from app.services.order_proposals.dispatch_contract import ApprovalDispatchState
+from app.services.order_proposals.state_machine import PROPOSAL_TERMINAL_STATES
 
 
 class OrderProposalRepository:
@@ -160,6 +161,55 @@ class OrderProposalRepository:
         await self._session.execute(
             select(func.pg_advisory_xact_lock(func.hashtextextended(lock_key, 0)))
         )
+
+    async def try_acquire_watch_to_order_scope_lock(self, lock_key: str) -> bool:
+        """Try to reserve one watch-to-order scope without waiting.
+
+        This is deliberately a transaction-scoped *try* lock.  A watcher that
+        loses the race must fail closed at its proposal boundary instead of
+        waiting and re-running a stale read.
+        """
+        result = await self._session.execute(
+            select(func.pg_try_advisory_xact_lock(func.hashtextextended(lock_key, 0)))
+        )
+        return bool(result.scalar_one())
+
+    async def list_active_watch_to_order_scope_groups(
+        self,
+        *,
+        symbol: str,
+        market: str,
+        account_mode: str,
+        broker_account_id: str | None,
+    ) -> list[OrderProposal]:
+        """Return scope groups with at least one non-terminal rung.
+
+        Group lifecycle is intentionally not the activity predicate: a
+        supersession can leave a broker-resting rung in a group whose rollup
+        lifecycle is already ``superseded``.  The public service seam reads all
+        rungs for every returned group, including its terminal rungs, so a
+        caller can make a fail-closed decision from the precise mixed state.
+        """
+        stmt = (
+            select(OrderProposal)
+            .join(
+                OrderProposalRung,
+                OrderProposalRung.proposal_pk == OrderProposal.id,
+            )
+            .where(
+                OrderProposal.symbol == symbol,
+                OrderProposal.market == market,
+                OrderProposal.account_mode == account_mode,
+                OrderProposalRung.state.not_in(PROPOSAL_TERMINAL_STATES),
+            )
+            .order_by(OrderProposal.id)
+            .distinct()
+        )
+        if broker_account_id is None:
+            stmt = stmt.where(OrderProposal.broker_account_id.is_(None))
+        else:
+            stmt = stmt.where(OrderProposal.broker_account_id == broker_account_id)
+        return list((await self._session.execute(stmt)).scalars().all())
 
     async def find_rung_by_evidence(
         self,

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -7,6 +7,7 @@ and never commits — callers own the transaction (see global-constraints.md).
 from __future__ import annotations
 
 import inspect
+import json
 import logging
 import secrets
 import uuid
@@ -107,6 +108,98 @@ class RungInput:
     quantity: Decimal
     limit_price: Decimal | None
     notional: Decimal | None
+
+
+_WATCH_TO_ORDER_SCOPE_ORIGIN: Literal["order_proposals"] = "order_proposals"
+_WATCH_TO_ORDER_SCOPE_LOCK_UNAVAILABLE = "watch_to_order_scope_lock_unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class WatchToOrderScope:
+    """The four-axis identity protected for one watcher proposal attempt.
+
+    ``action`` is the caller's requested proposal action, not a fifth lookup
+    axis: the inspection always reports every active proposal action in the
+    protected account/symbol scope so an existing replace/cancel lineage cannot
+    be mistaken for absence.
+    """
+
+    symbol: str
+    market: str
+    account_mode: str
+    broker_account_id: str | None
+    action: str
+
+
+@dataclass(frozen=True, slots=True)
+class WatchToOrderScopeRung:
+    """One immutable rung snapshot returned by the watcher scope seam."""
+
+    rung_index: int
+    side: str
+    state: str
+    broker_order_id: str | None
+    correlation_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class WatchToOrderScopeGroup:
+    """One active group and every one of its rung states.
+
+    ``origin_marker`` identifies this as proposal-ledger evidence when callers
+    combine it with their own broker observations.  ``proposer`` and
+    ``strategy`` retain the group-level provenance without leaking repository
+    models outside this service boundary.
+    """
+
+    proposal_id: uuid.UUID
+    root_proposal_id: uuid.UUID
+    lifecycle_state: str
+    action: str
+    proposer: str
+    strategy: str | None
+    rungs: tuple[WatchToOrderScopeRung, ...]
+    origin_marker: Literal["order_proposals"] = _WATCH_TO_ORDER_SCOPE_ORIGIN
+
+    @property
+    def all_rung_states(self) -> tuple[str, ...]:
+        """Ordered state projection for consumers that only need states."""
+        return tuple(rung.state for rung in self.rungs)
+
+
+@dataclass(frozen=True, slots=True)
+class WatchToOrderScopeInspection:
+    """The lock-backed result for a watcher read-then-create transaction.
+
+    A caller may proceed only when ``lock_acquired`` is true, and must keep the
+    same ``OrderProposalsService`` and uncommitted transaction through
+    ``create_proposal_in_watch_to_order_scope``.  A lock failure deliberately
+    returns no snapshot: a stale or best-effort read is not clearance to create.
+    """
+
+    scope: WatchToOrderScope
+    lock_acquired: bool
+    active_groups: tuple[WatchToOrderScopeGroup, ...]
+    lock_failure_code: str | None = None
+    origin_marker: Literal["order_proposals"] = _WATCH_TO_ORDER_SCOPE_ORIGIN
+    _reservation_token: str | None = None
+
+    @property
+    def groups(self) -> tuple[WatchToOrderScopeGroup, ...]:
+        """Alias kept for consumers that name the collection generically."""
+        return self.active_groups
+
+    @property
+    def origin(self) -> Literal["order_proposals"]:
+        """Short provenance alias for evidence envelopes."""
+        return self.origin_marker
+
+
+@dataclass(frozen=True, slots=True)
+class _WatchToOrderScopeReservation:
+    token: str
+    transaction: Any
+    active_group_proposal_ids: frozenset[uuid.UUID]
 
 
 @dataclass(frozen=True)
@@ -406,6 +499,12 @@ class OrderProposalsService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
         self._repo = OrderProposalRepository(session)
+        # A reservation is intentionally service-instance local.  The public
+        # watcher create companion below requires the same service + open DB
+        # transaction that acquired the PostgreSQL xact lock.
+        self._watch_to_order_scope_reservations: dict[
+            str, _WatchToOrderScopeReservation
+        ] = {}
 
     async def acquire_target_mutation_lock(self, group: OrderProposal) -> bool:
         """Serialize replace/cancel transactions for one broker order target.
@@ -446,6 +545,180 @@ class OrderProposalsService:
             text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
             {"lock_key": lock_key},
         )
+
+    @staticmethod
+    def _watch_to_order_scope_lock_key(scope: WatchToOrderScope) -> str:
+        """Build an unambiguous lock key for the exact four-axis scope.
+
+        JSON preserves the distinction between a missing broker account
+        (``None``) and an empty identifier.  The requested action is excluded
+        on purpose: a watcher must not create while any action is reserving the
+        same account/symbol scope.
+        """
+        return json.dumps(
+            {
+                "namespace": "order_proposals.watch_to_order_scope.v1",
+                "symbol": scope.symbol,
+                "market": scope.market,
+                "account_mode": scope.account_mode,
+                "broker_account_id": scope.broker_account_id,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    async def inspect_watch_to_order_scope(
+        self,
+        symbol: str,
+        market: str,
+        account_mode: str,
+        broker_account_id: str | None,
+        action: str = "place",
+    ) -> WatchToOrderScopeInspection:
+        """Atomically reserve and inspect one watcher create scope.
+
+        The nonblocking transaction lock is obtained *before* the read and is
+        retained until the caller commits or rolls back this session.  A second
+        watcher for the same scope receives ``lock_acquired=False`` immediately
+        and no groups; it must create zero proposals.  The successful caller
+        must keep this same service/session transaction through
+        :meth:`create_proposal_in_watch_to_order_scope`.
+
+        ``active_groups`` means at least one non-terminal rung exists.  That is
+        deliberately rung-based instead of lifecycle-based: a superseded group
+        can still carry a broker-resting rung.
+        """
+        normalized_action = check_action_capability(
+            action=action,
+            account_mode=account_mode,
+            market=market,
+        )
+        scope = WatchToOrderScope(
+            symbol=symbol,
+            market=market,
+            account_mode=account_mode,
+            broker_account_id=broker_account_id,
+            action=normalized_action,
+        )
+        lock_key = self._watch_to_order_scope_lock_key(scope)
+        if not await self._repo.try_acquire_watch_to_order_scope_lock(lock_key):
+            return WatchToOrderScopeInspection(
+                scope=scope,
+                lock_acquired=False,
+                active_groups=(),
+                lock_failure_code=_WATCH_TO_ORDER_SCOPE_LOCK_UNAVAILABLE,
+            )
+
+        groups = await self._repo.list_active_watch_to_order_scope_groups(
+            symbol=scope.symbol,
+            market=scope.market,
+            account_mode=scope.account_mode,
+            broker_account_id=scope.broker_account_id,
+        )
+        snapshots: list[WatchToOrderScopeGroup] = []
+        for group in groups:
+            rungs = await self._repo.list_rungs(group.id)
+            snapshots.append(
+                WatchToOrderScopeGroup(
+                    proposal_id=group.proposal_id,
+                    root_proposal_id=group.root_proposal_id,
+                    lifecycle_state=group.lifecycle_state,
+                    action=group.action or "place",
+                    proposer=group.proposer,
+                    strategy=group.strategy,
+                    rungs=tuple(
+                        WatchToOrderScopeRung(
+                            rung_index=rung.rung_index,
+                            side=rung.side,
+                            state=rung.state,
+                            broker_order_id=rung.broker_order_id,
+                            correlation_id=rung.correlation_id,
+                        )
+                        for rung in rungs
+                    ),
+                )
+            )
+
+        transaction = self._session.sync_session.get_transaction()
+        if transaction is None or not transaction.is_active:
+            # A transaction-scoped lock without a live transaction cannot
+            # protect a later create.  This should be unreachable after the
+            # execute above, but returning a closed result keeps this boundary
+            # fail-closed under unusual session configurations.
+            return WatchToOrderScopeInspection(
+                scope=scope,
+                lock_acquired=False,
+                active_groups=(),
+                lock_failure_code=_WATCH_TO_ORDER_SCOPE_LOCK_UNAVAILABLE,
+            )
+        token = uuid.uuid4().hex
+        self._watch_to_order_scope_reservations[lock_key] = (
+            _WatchToOrderScopeReservation(
+                token=token,
+                transaction=transaction,
+                active_group_proposal_ids=frozenset(
+                    group.proposal_id for group in snapshots
+                ),
+            )
+        )
+        return WatchToOrderScopeInspection(
+            scope=scope,
+            lock_acquired=True,
+            active_groups=tuple(snapshots),
+            _reservation_token=token,
+        )
+
+    async def create_proposal_in_watch_to_order_scope(
+        self,
+        inspection: WatchToOrderScopeInspection,
+        **kwargs: Any,
+    ) -> OrderProposal:
+        """Create only from a still-held, empty watcher scope reservation.
+
+        This is additive: ordinary ``create_proposal`` remains unchanged for
+        existing callers.  New watcher consumers use this companion so a lost
+        try-lock, a transaction boundary, a scope mismatch, or any active rung
+        is a fail-closed zero-create result.
+        """
+        scope = inspection.scope
+        lock_key = self._watch_to_order_scope_lock_key(scope)
+        reservation = self._watch_to_order_scope_reservations.get(lock_key)
+        transaction = self._session.sync_session.get_transaction()
+        if (
+            not inspection.lock_acquired
+            or inspection._reservation_token is None
+            or reservation is None
+            or reservation.token != inspection._reservation_token
+            or transaction is None
+            or reservation.transaction is not transaction
+            or not transaction.is_active
+        ):
+            raise OrderProposalError("watch_to_order_scope_reservation_unavailable")
+
+        requested_scope = {
+            "symbol": kwargs.get("symbol"),
+            "market": kwargs.get("market"),
+            "account_mode": kwargs.get("account_mode"),
+            "broker_account_id": kwargs.get("broker_account_id"),
+            "action": kwargs.get("action") or "place",
+        }
+        expected_scope = {
+            "symbol": scope.symbol,
+            "market": scope.market,
+            "account_mode": scope.account_mode,
+            "broker_account_id": scope.broker_account_id,
+            "action": scope.action,
+        }
+        if requested_scope != expected_scope:
+            raise OrderProposalError("watch_to_order_scope_mismatch")
+        if reservation.active_group_proposal_ids:
+            raise OrderProposalError("watch_to_order_scope_active_rungs_present")
+        # One reservation authorizes one proposal group only.  Consume it before
+        # validation/insert so an exception cannot be retried into a second
+        # create from the same stale empty snapshot.
+        self._watch_to_order_scope_reservations.pop(lock_key, None)
+        return await self.create_proposal(**kwargs)
 
     async def create_proposal(
         self,

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -61,6 +61,25 @@ See the full design in
   AST guard test (`tests/services/order_proposals/test_no_repository_imports.py`)
   enforces this. Direct SQL INSERT/UPDATE/DELETE against `review.order_proposals`
   / `review.order_proposal_rungs` is not permitted.
+- **Watcher read/create seam.** A watcher candidate that can create an order
+  proposal must call `inspect_watch_to_order_scope(symbol, market,
+  account_mode, broker_account_id, action="place")` and keep the same service
+  instance plus uncommitted transaction through
+  `create_proposal_in_watch_to_order_scope(inspection, ...)`. The scope is
+  exactly symbol, market, account mode, and broker account; the service takes a
+  nonblocking transaction advisory lock before its rung-level read. A false
+  `lock_acquired`, any returned active group, a changed transaction, a changed
+  scope, or a consumed reservation means zero creates. The returned groups
+  include every rung state, because a group marked `superseded` can still have a
+  `resting` rung. Commit or rollback releases the lock. Existing
+  `create_proposal` callers remain unchanged and are not this seam.
+- **Reserve-net consumer activation condition.**
+  `_ATOMIC_SELF_OPEN_ORDER_READ_SEAM_AVAILABLE` in
+  `support_reserve_net_consumer.py` must remain false until a separately
+  reviewed consumer-wiring change performs the preceding inspect → empty-result
+  → companion-create sequence in one `OrderProposalsService` transaction for
+  every proposed scope. Merely importing this service API, observing an empty
+  best-effort list, or changing that boolean is not readiness to create.
 - **Proposal persistence precedes every broker mutation.**
   `order_proposal_create` first commits the intended order. With
   `ORDER_PROPOSALS_AUTO_APPROVE=false` (default), creation does not submit.

--- a/tests/services/order_proposals/test_watch_to_order_scope.py
+++ b/tests/services/order_proposals/test_watch_to_order_scope.py
@@ -1,0 +1,233 @@
+"""Contract tests for the public watcher proposal-scope seam."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.core.db import AsyncSessionLocal
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.service import RungInput, WatchToOrderScope
+
+
+def _scope(*, suffix: str | None = None) -> WatchToOrderScope:
+    unique = suffix or uuid.uuid4().hex
+    return WatchToOrderScope(
+        symbol=f"SEAM-{unique}",
+        market="equity_us",
+        account_mode="kis_live",
+        broker_account_id=f"account-{unique}",
+        action="place",
+    )
+
+
+def _create_kwargs(scope: WatchToOrderScope, **overrides: object) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "symbol": scope.symbol,
+        "market": scope.market,
+        "account_mode": scope.account_mode,
+        "broker_account_id": scope.broker_account_id,
+        "side": "buy",
+        "order_type": "limit",
+        "proposer": "watch-scope-test",
+        "strategy": "watch_scope_test",
+        "action": scope.action,
+        "rungs": [RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.mark.asyncio
+async def test_inspect_watch_to_order_scope_uses_every_scope_axis(db_session):
+    scope = _scope()
+    service = OrderProposalsService(db_session)
+    matching = await service.create_proposal(**_create_kwargs(scope))
+    await service.create_proposal(
+        **_create_kwargs(scope, symbol=f"other-symbol-{uuid.uuid4().hex}")
+    )
+    await service.create_proposal(
+        **_create_kwargs(scope, broker_account_id=f"other-{uuid.uuid4().hex}")
+    )
+    await service.create_proposal(**_create_kwargs(scope, broker_account_id=None))
+    await service.create_proposal(**_create_kwargs(scope, account_mode="toss_live"))
+    await service.create_proposal(**_create_kwargs(scope, market="equity_kr"))
+
+    inspection = await service.inspect_watch_to_order_scope(
+        symbol=scope.symbol,
+        market=scope.market,
+        account_mode=scope.account_mode,
+        broker_account_id=scope.broker_account_id,
+    )
+
+    assert inspection.lock_acquired is True
+    assert inspection.lock_failure_code is None
+    assert inspection.scope == scope
+    assert inspection.origin_marker == "order_proposals"
+    assert [group.proposal_id for group in inspection.active_groups] == [
+        matching.proposal_id
+    ]
+    snapshot = inspection.active_groups[0]
+    assert snapshot.origin_marker == "order_proposals"
+    assert snapshot.proposer == "watch-scope-test"
+    assert snapshot.strategy == "watch_scope_test"
+    assert [(rung.rung_index, rung.state) for rung in snapshot.rungs] == [
+        (0, "pending_approval")
+    ]
+    assert snapshot.all_rung_states == ("pending_approval",)
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_inspect_reports_mixed_state_group_by_rung_not_rollup(db_session):
+    scope = _scope()
+    service = OrderProposalsService(db_session)
+    original = await service.create_proposal(
+        **_create_kwargs(
+            scope,
+            rungs=[
+                RungInput(0, "buy", Decimal("1"), Decimal("100"), None),
+                RungInput(1, "buy", Decimal("1"), Decimal("99"), None),
+            ],
+        )
+    )
+    for state in ("revalidating", "approved", "submitting", "resting"):
+        await service.transition_rung(original.proposal_id, 0, new_state=state)
+    await service.transition_rung(original.proposal_id, 1, new_state="revalidating")
+    await service.mark_needs_reconfirm(
+        original.proposal_id,
+        1,
+        now=datetime(2026, 8, 13, 6, 0, tzinfo=UTC),
+    )
+
+    replacement = await service.create_proposal(
+        **_create_kwargs(
+            scope,
+            supersedes_proposal_id=original.proposal_id,
+        )
+    )
+    inspection = await service.inspect_watch_to_order_scope(
+        symbol=scope.symbol,
+        market=scope.market,
+        account_mode=scope.account_mode,
+        broker_account_id=scope.broker_account_id,
+    )
+
+    assert inspection.lock_acquired is True
+    assert {group.proposal_id for group in inspection.active_groups} == {
+        original.proposal_id,
+        replacement.proposal_id,
+    }
+    original_snapshot = next(
+        group
+        for group in inspection.active_groups
+        if group.proposal_id == original.proposal_id
+    )
+    assert original_snapshot.lifecycle_state == "superseded"
+    assert [(rung.rung_index, rung.state) for rung in original_snapshot.rungs] == [
+        (0, "resting"),
+        (1, "superseded"),
+    ]
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_scope_companion_rejects_active_rungs_without_creating(db_session):
+    scope = _scope()
+    service = OrderProposalsService(db_session)
+    existing = await service.create_proposal(**_create_kwargs(scope))
+    inspection = await service.inspect_watch_to_order_scope(
+        symbol=scope.symbol,
+        market=scope.market,
+        account_mode=scope.account_mode,
+        broker_account_id=scope.broker_account_id,
+    )
+
+    with pytest.raises(
+        OrderProposalError, match="watch_to_order_scope_active_rungs_present"
+    ):
+        await service.create_proposal_in_watch_to_order_scope(
+            inspection, **_create_kwargs(scope)
+        )
+
+    repeated = await service.inspect_watch_to_order_scope(
+        symbol=scope.symbol,
+        market=scope.market,
+        account_mode=scope.account_mode,
+        broker_account_id=scope.broker_account_id,
+    )
+    assert [group.proposal_id for group in repeated.active_groups] == [
+        existing.proposal_id
+    ]
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_scope_try_lock_is_nonblocking_and_loser_creates_nothing(
+    db_session,
+):
+    scope = _scope()
+    async with (
+        AsyncSessionLocal() as winner_session,
+        AsyncSessionLocal() as loser_session,
+    ):
+        winner = OrderProposalsService(winner_session)
+        loser = OrderProposalsService(loser_session)
+        winner_inspection = await winner.inspect_watch_to_order_scope(
+            symbol=scope.symbol,
+            market=scope.market,
+            account_mode=scope.account_mode,
+            broker_account_id=scope.broker_account_id,
+        )
+        assert winner_inspection.lock_acquired is True
+        assert winner_inspection.active_groups == ()
+
+        loser_inspection = await asyncio.wait_for(
+            loser.inspect_watch_to_order_scope(
+                symbol=scope.symbol,
+                market=scope.market,
+                account_mode=scope.account_mode,
+                broker_account_id=scope.broker_account_id,
+                # The lock still collides across actions; action is not a scope
+                # axis because existing active orders must not be bypassed.
+                action="replace",
+            ),
+            timeout=1,
+        )
+        assert loser_inspection.lock_acquired is False
+        assert loser_inspection.active_groups == ()
+        assert (
+            loser_inspection.lock_failure_code
+            == "watch_to_order_scope_lock_unavailable"
+        )
+        with pytest.raises(
+            OrderProposalError, match="watch_to_order_scope_reservation_unavailable"
+        ):
+            await loser.create_proposal_in_watch_to_order_scope(
+                loser_inspection, **_create_kwargs(scope, action="replace")
+            )
+
+        created = await winner.create_proposal_in_watch_to_order_scope(
+            winner_inspection, **_create_kwargs(scope)
+        )
+        await winner_session.commit()
+        await loser_session.rollback()
+
+    async with AsyncSessionLocal() as verifier_session:
+        verifier = OrderProposalsService(verifier_session)
+        inspection = await verifier.inspect_watch_to_order_scope(
+            symbol=scope.symbol,
+            market=scope.market,
+            account_mode=scope.account_mode,
+            broker_account_id=scope.broker_account_id,
+        )
+        assert inspection.lock_acquired is True
+        assert [group.proposal_id for group in inspection.active_groups] == [
+            created.proposal_id
+        ]
+        await verifier_session.rollback()


### PR DESCRIPTION
## Summary
- add a public four-axis watch-to-order scope inspection with a nonblocking transaction advisory lock
- return service-owned proposal snapshots with every rung state, including mixed superseded/resting groups
- require the locked companion create path for watcher consumers; document reserve-net readiness without wiring either consumer

## Verification
- make lint
- uv run pytest tests/services/order_proposals -q (734 passed)
- scope, rung-state, lock, fail-closed, and repository-boundary mutation checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a watch-to-order workflow for safely inspecting proposal activity and creating new proposals.
  * Added scope-based matching across symbols, markets, account modes, and broker accounts.
  * Added reporting for active proposal groups, rung details, superseded proposals, lock status, and reservation availability.
  * Added safeguards to prevent duplicate creation during concurrent actions.

* **Documentation**
  * Documented the required inspection and creation workflow, including fail-closed safety conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->