### PR TITLE
test(ROB-1245): lock void_not_authorized structured refusal at MCP surface

### DIFF
--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -930,6 +930,42 @@ async def test_void_requires_reason_and_terminalizes_proposal():
 
 
 @pytest.mark.asyncio
+async def test_void_refusal_surfaces_structured_authorization_detail():
+    """ROB-1245: a stranger's void refusal must not be a bare error string.
+
+    Regression for the Acceptance A finding (tossacc-final-0813.md #3) that a
+    ``void_not_authorized`` response looked unactionable. It is not a bug in
+    ``authorize_void`` (the service layer already fails closed by design and
+    is locked by ``test_legacy_row_without_creator_is_not_owned_by_anyone``);
+    this test locks the *MCP surface* contract so a refusal always carries the
+    evidence the caller needs to see why, instead of silently vanishing like
+    ROB-1244's reasonless refusals.
+    """
+    created = await opt.order_proposal_create(**_create_kwargs())
+
+    token = caller_agent_id_var.set("a-different-lane-agent")
+    try:
+        result = await opt.order_proposal_void(created["proposal_id"], "not mine")
+    finally:
+        caller_agent_id_var.reset(token)
+
+    assert result["success"] is False
+    assert result["error"] == "void_not_authorized"
+    assert result["proposal_id"] == created["proposal_id"]
+    assert result["authorization"]["allowed"] is False
+    assert result["authorization"]["authority"] is None
+    assert result["authorization"]["reason_code"] == "void_not_authorized"
+    assert result["authorization"]["detail"]["requester_agent_id"] == (
+        "a-different-lane-agent"
+    )
+    assert result["authorization"]["detail"]["creator_agent_id"] == _TOOL_CALLER_AGENT
+
+    # Untouched: the live proposal survives the refused void attempt.
+    got = await opt.order_proposal_get(created["proposal_id"])
+    assert got["proposal"]["lifecycle_state"] == "proposed"
+
+
+@pytest.mark.asyncio
 async def test_fetch_void_evidence_forwards_group_valid_until(monkeypatch):
     valid_until = datetime(2026, 7, 15, 15, 0, tzinfo=UTC)
     now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)


### PR DESCRIPTION
## Summary

ROB-1245 (§59차/§63차): "proposal void ownership/void-impossible" repair.

**Finding: the void authority code is already correct by design — no bug found, no widening made.**

Investigated the Acceptance A finding (`~/work/herdr-inbox/tossacc-final-0813.md` #3): a self-created proposal returned `void_not_authorized` with `agent_id` unknown on both sides. Traced this to `app/services/order_proposals/void_authorization.py` + `service.void_proposal` (ROB-1238, #1836), which deliberately fail closed when caller identity cannot be resolved — `requester_agent_id`/`creator_agent_id` both being `None` must never match as "self" (that would let any two unidentified sessions void each other's live proposals, exactly the cross-lane hole ROB-1238 closed). This exact scenario is already locked by `test_legacy_row_without_creator_is_not_owned_by_anyone` and `test_unidentified_caller_cannot_void_a_live_proposal` in `tests/services/order_proposals/test_void_authorization.py`, and documented as an accepted tradeoff in `docs/runbooks/order-proposal-void-authorization.md` §8 ("caller identity requires an HTTP header or env fallback; without either only server-confirmed authorities remain").

Root cause of the Acceptance A symptom is operational (that session's MCP transport/env didn't resolve a caller identity), not a code defect — no widening is warranted, and this PR does not implement any.

The one real gap: nothing pinned that a refused `order_proposal_void` call at the **MCP tool surface** returns the structured `authorization` detail (reason_code/authority/detail) rather than a bare string — which is exactly what "looked unactionable" in Acceptance A. Added a regression test for that contract, verified against a mutant (stripped `authorization` field → test fails; reverted).

## Test plan
- [x] `tests/services/order_proposals/test_void_authorization.py` — 25 passed (baseline, unchanged)
- [x] `tests/test_mcp_order_proposal_tools.py` — new `test_void_refusal_surfaces_structured_authorization_detail` passes
- [x] `tests/services/order_proposals/ tests/test_mcp_order_proposal_tools.py tests/test_route_request_lanes.py` — 815 passed
- [x] Mutant check: stripped `authorization` from the MCP refusal response → new test fails with `KeyError: 'authorization'`; reverted, confirmed clean diff
- [x] `ruff check` / `ruff format --check` clean

## Scope guardrails honored
- No authority widening (§59차 3항 / task guardrail) — zero production code changed, test-only
- No approval classification (§40차), no loss-cut automation, no seam API change
- No broker/account/live contact, no real void execution, no DB writes outside tests
- Files touched: `tests/test_mcp_order_proposal_tools.py` only — no overlap with ROB-1244 (rob1244 worktree still at base commit, no changes) or ROB-1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthorized proposal void attempts now provide structured authorization details, including requester and creator agent information.
  * Proposals remain in the proposed state when a void attempt is unauthorized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->