### PR TITLE
fix(order-proposals): retain auto-approve rejection evidence

### DIFF
--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -25,6 +25,9 @@ from app.mcp_server.caller_identity import get_caller_agent_id
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.alerts import send_approval_dispatch_alert
 from app.services.order_proposals.approval_window import ApprovalWindowDecision
+from app.services.order_proposals.auto_approve_audit import (
+    project_auto_approve_rejections,
+)
 from app.services.order_proposals.broker_gateway import (
     fetch_operator_void_evidence,
     fetch_target_order,
@@ -122,6 +125,7 @@ def _group_dict(g: Any) -> dict[str, Any]:
         "approval_dispatch_failure_code": g.approval_dispatch_failure_code,
         "approval_dispatch_payload_chars": g.approval_dispatch_payload_chars,
         "approval_dispatch_alert": (g.source_asof or {}).get("approval_dispatch_alert"),
+        "auto_approve_rejections": project_auto_approve_rejections(g.source_asof),
         "created_at": g.created_at.isoformat() if g.created_at else None,
     }
 

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -37,6 +37,7 @@ Two classifications live here, selected by ``AutoApproveLimits.mode``
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -46,6 +47,9 @@ from app.services.order_proposals.approval_message import (
     _escape_inline_code,
     _escape_markdown,
     build_callback_data,
+)
+from app.services.order_proposals.auto_approve_audit import (
+    AUTO_APPROVE_REJECTIONS_KEY,
 )
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
@@ -240,6 +244,16 @@ def _scan_approval_required_tags(group: Any) -> _ApprovalRequiredTagScan:
             value = getattr(group, field, None)
             if value is None:
                 continue
+            if field == "source_asof" and isinstance(value, Mapping):
+                # This is system-generated audit output, not proposal input.
+                # Re-scanning it on a later dispatch would turn its own tag
+                # evidence into a new match location and eventually crowd out
+                # the original evidence under the match cap.
+                value = {
+                    key: child
+                    for key, child in value.items()
+                    if key != AUTO_APPROVE_REJECTIONS_KEY
+                }
             fields.append(
                 (
                     field,

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -104,6 +104,21 @@ _TAG_SCAN_FIELDS = (
     "exit_reason",
     "void_reason",
 )
+_TAG_PATH_KEY_ALLOWLIST = frozenset(
+    {
+        "context",
+        "decision",
+        "flags",
+        "labels",
+        "metadata",
+        "notes",
+        "reason",
+        "review",
+        "tag",
+        "tags",
+    }
+)
+_MAX_TAG_MATCHES = 24
 
 # Both-leg cost floor in basis points, per market. NOT measured rates: the two
 # veto-capable ledgers (review.kis_live_order_ledger, review.live_order_ledger)
@@ -138,7 +153,7 @@ class AutoApproveLimits:
 class AutoApproveDecision:
     eligible: bool
     reason: str
-    details: dict[str, str]
+    details: dict[str, Any]
 
 
 def _decimal(value: Any) -> Decimal | None:
@@ -152,6 +167,10 @@ def _decimal(value: Any) -> Decimal | None:
 def _text(value: Decimal) -> str:
     normalized = format(value.normalize(), "f")
     return normalized.rstrip("0").rstrip(".") if "." in normalized else normalized
+
+
+def _known_value(value: Any, allowed: frozenset[str]) -> str:
+    return value if isinstance(value, str) and value in allowed else "unrecognized"
 
 
 def auto_veto_thesis_summary(group: Any) -> str | None:
@@ -206,27 +225,191 @@ def limits_for_market(market: str) -> AutoApproveLimits | None:
     )
 
 
+@dataclass(frozen=True)
+class _ApprovalRequiredTagScan:
+    fields: tuple[tuple[str, Any, str], ...]
+    tags: tuple[str, ...]
+    failed: bool
+
+
+def _scan_approval_required_tags(group: Any) -> _ApprovalRequiredTagScan:
+    """Scan once so an audit match cannot alter the classification result."""
+    fields: list[tuple[str, Any, str]] = []
+    try:
+        for field in _TAG_SCAN_FIELDS:
+            value = getattr(group, field, None)
+            if value is None:
+                continue
+            fields.append(
+                (
+                    field,
+                    value,
+                    value
+                    if isinstance(value, str)
+                    else json.dumps(value, default=str, ensure_ascii=False),
+                )
+            )
+    except Exception:  # noqa: BLE001 - unreadable metadata is not a clearance
+        return _ApprovalRequiredTagScan(
+            (), tuple(sorted(_APPROVAL_REQUIRED_TAGS)), True
+        )
+    haystack = "\n".join(rendered for _, _, rendered in fields).lower()
+    return _ApprovalRequiredTagScan(
+        tuple(fields),
+        tuple(sorted(tag for tag in _APPROVAL_REQUIRED_TAGS if tag in haystack)),
+        False,
+    )
+
+
 def find_approval_required_tags(group: Any) -> tuple[str, ...]:
     """Return the §40차 approval-required tags carried anywhere on ``group``.
 
     Fails closed: if any field resists serialization the proposal is treated
     as carrying every tag, which routes it to a human.
     """
-    parts: list[str] = []
-    try:
-        for field in _TAG_SCAN_FIELDS:
-            value = getattr(group, field, None)
-            if value is None:
-                continue
-            parts.append(
-                value
-                if isinstance(value, str)
-                else json.dumps(value, default=str, ensure_ascii=False)
+    return _scan_approval_required_tags(group).tags
+
+
+def _path_for_json_child(path: str, key: Any, index: int) -> str:
+    """Keep evidence locatable without exposing arbitrary JSON keys."""
+    if isinstance(key, str) and key in _TAG_PATH_KEY_ALLOWLIST:
+        return f"{path}.{key}"
+    return f"{path}[{index}]"
+
+
+def _find_text_matches(
+    text: str,
+    *,
+    token: str,
+    field: str,
+    path: str,
+    kind: str,
+) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    haystack = text.lower()
+    start = 0
+    while len(matches) < _MAX_TAG_MATCHES:
+        found = haystack.find(token, start)
+        if found < 0:
+            break
+        matches.append(
+            {
+                "token": token,
+                "field": field,
+                "path": path,
+                "kind": kind,
+                "char_start": found,
+            }
+        )
+        start = found + len(token)
+    return matches
+
+
+def _find_tag_matches_in_value(
+    value: Any,
+    *,
+    token: str,
+    field: str,
+    path: str,
+    nested: bool,
+) -> list[dict[str, Any]]:
+    if isinstance(value, str):
+        return _find_text_matches(
+            value,
+            token=token,
+            field=field,
+            path=path,
+            kind="json_value" if nested else "text",
+        )
+    if isinstance(value, dict):
+        matches: list[dict[str, Any]] = []
+        for index, (key, child) in enumerate(value.items()):
+            child_path = _path_for_json_child(path, key, index)
+            if isinstance(key, str):
+                matches.extend(
+                    _find_text_matches(
+                        key,
+                        token=token,
+                        field=field,
+                        path=child_path,
+                        kind="json_key",
+                    )
+                )
+            matches.extend(
+                _find_tag_matches_in_value(
+                    child,
+                    token=token,
+                    field=field,
+                    path=child_path,
+                    nested=True,
+                )
             )
-    except Exception:  # noqa: BLE001 - unreadable metadata is not a clearance
-        return tuple(sorted(_APPROVAL_REQUIRED_TAGS))
-    haystack = "\n".join(parts).lower()
-    return tuple(sorted(tag for tag in _APPROVAL_REQUIRED_TAGS if tag in haystack))
+            if len(matches) >= _MAX_TAG_MATCHES:
+                return matches[:_MAX_TAG_MATCHES]
+        return matches
+    if isinstance(value, (list, tuple)):
+        matches = []
+        for index, child in enumerate(value):
+            matches.extend(
+                _find_tag_matches_in_value(
+                    child,
+                    token=token,
+                    field=field,
+                    path=f"{path}[{index}]",
+                    nested=True,
+                )
+            )
+            if len(matches) >= _MAX_TAG_MATCHES:
+                return matches[:_MAX_TAG_MATCHES]
+        return matches
+    return []
+
+
+def _scan_unavailable_matches(tags: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "token": token,
+            "field": "source_asof",
+            "path": "$",
+            "kind": "scan_unavailable",
+            "char_start": 0,
+        }
+        for token in tags
+    ]
+
+
+def _tag_matches_from_scan(scan: _ApprovalRequiredTagScan) -> list[dict[str, Any]]:
+    if not scan.tags:
+        return []
+    if scan.failed:
+        return _scan_unavailable_matches(scan.tags)
+
+    try:
+        matches: list[dict[str, Any]] = []
+        for token in scan.tags:
+            for field, value, rendered in scan.fields:
+                locations = _find_tag_matches_in_value(
+                    value, token=token, field=field, path="$", nested=False
+                )
+                if not locations and token in rendered.lower():
+                    locations = _find_text_matches(
+                        rendered,
+                        token=token,
+                        field=field,
+                        path="$",
+                        kind="serialized",
+                    )
+                matches.extend(locations)
+                if len(matches) >= _MAX_TAG_MATCHES:
+                    return matches[:_MAX_TAG_MATCHES]
+        return matches
+    except Exception:  # noqa: BLE001 - audit evidence must not clear a veto
+        return _scan_unavailable_matches(scan.tags)
+
+
+def find_approval_required_tag_matches(group: Any) -> list[dict[str, Any]]:
+    """Return only token + structural location, never the matched free text."""
+    return _tag_matches_from_scan(_scan_approval_required_tags(group))
 
 
 @dataclass(frozen=True)
@@ -308,51 +491,83 @@ def evaluate_auto_approve_eligibility(
 
     base = {"policy_version": limits.policy_version}
 
-    def reject(reason: str, **details: str) -> AutoApproveDecision:
+    def reject(reason: str, **details: Any) -> AutoApproveDecision:
         return AutoApproveDecision(False, reason, {**base, **details})
 
     mode = limits.mode
     if mode not in ("off", "expanded"):
         # An unrecognised mode is not a licence to submit.
-        return reject("unknown_auto_approve_mode", mode=str(mode))
+        return reject("unknown_auto_approve_mode", mode="unrecognized")
     base["mode"] = mode
 
-    if (getattr(group, "action", None) or "place") != "place":
-        return reject("action_not_place")
-    if getattr(group, "order_type", None) != "limit":
-        return reject("order_type_not_limit")
+    action = getattr(group, "action", None) or "place"
+    if action != "place":
+        return reject(
+            "action_not_place",
+            action=_known_value(action, frozenset({"place", "replace", "cancel"})),
+        )
+    order_type = getattr(group, "order_type", None)
+    if order_type != "limit":
+        return reject(
+            "order_type_not_limit",
+            order_type=_known_value(order_type, frozenset({"limit", "market"})),
+        )
     exit_intent = getattr(group, "exit_intent", None)
     if exit_intent == "loss_cut":
         # §40차: a loss cut is always a human's call. Kept as its own reason so
         # the audit row says why, and so a future exit-intent vocabulary cannot
         # dilute this branch.
-        return reject("loss_cut_intent")
+        return reject("loss_cut_intent", exit_intent_present=True)
     if exit_intent is not None:
-        return reject("exit_intent_present", exit_intent=str(exit_intent))
+        return reject("exit_intent_present", exit_intent_present=True)
+    account_mode = getattr(group, "account_mode", None)
+    market = getattr(group, "market", None)
     if not _is_veto_capable_account_market(
-        getattr(group, "account_mode", None),
-        getattr(group, "market", None),
+        account_mode,
+        market,
     ):
-        return reject("account_not_veto_capable")
+        return reject(
+            "account_not_veto_capable",
+            account_mode=_known_value(
+                account_mode,
+                frozenset(
+                    {"kis_live", "kis_mock", "toss_live", "upbit", "db_simulated"}
+                ),
+            ),
+            market=_known_value(
+                market,
+                frozenset({"equity_kr", "equity_us", "crypto", "forex", "index"}),
+            ),
+        )
     # Applied in both modes: this can only ever reject.
-    tags = find_approval_required_tags(group)
+    tag_scan = _scan_approval_required_tags(group)
+    tags = tag_scan.tags
     if tags:
-        return reject("approval_required_tag", tags=",".join(tags))
+        return reject(
+            "approval_required_tag",
+            tags=",".join(tags),
+            tag_matches=_tag_matches_from_scan(tag_scan),
+        )
     if preview.get("success") is not True:
-        return reject("preview_guard_failed")
+        return reject(
+            "preview_guard_failed",
+            preview_success="false" if preview.get("success") is False else "invalid",
+        )
 
     current_price = _decimal(preview.get("current_price"))
     limit_price = _decimal(getattr(rung, "limit_price", None))
     quantity = _decimal(getattr(rung, "quantity", None))
-    if (
-        current_price is None
-        or current_price <= 0
-        or limit_price is None
-        or limit_price <= 0
-        or quantity is None
-        or quantity <= 0
-    ):
-        return reject("price_or_quantity_missing")
+    missing_inputs = [
+        name
+        for name, value in (
+            ("current_price", current_price),
+            ("limit_price", limit_price),
+            ("quantity", quantity),
+        )
+        if value is None or value <= 0
+    ]
+    if missing_inputs:
+        return reject("price_or_quantity_missing", missing_inputs=missing_inputs)
 
     # Use the executable price × quantity, never proposer-supplied advisory
     # notional, so a stale or understated metadata field cannot bypass caps.
@@ -373,7 +588,10 @@ def evaluate_auto_approve_eligibility(
 
     side = getattr(rung, "side", None)
     if side not in ("buy", "sell"):
-        return reject("side_not_supported")
+        return reject(
+            "side_not_supported",
+            side=_known_value(side, frozenset({"buy", "sell"})),
+        )
 
     # `expanded` drops the min_distance_pct floor but still requires the rung
     # to rest: a buy at or above the market (a sell at or below it) can fill
@@ -391,7 +609,13 @@ def evaluate_auto_approve_eligibility(
         distance_pct = (current_price - limit_price) / current_price * Decimal("100")
         if (limit_price >= threshold) if expanded else (limit_price > threshold):
             return reject(
-                "marketable_not_resting" if expanded else "distance_below_minimum"
+                "marketable_not_resting" if expanded else "distance_below_minimum",
+                current_price=_text(current_price),
+                limit_price=_text(limit_price),
+                quantity=_text(quantity),
+                threshold=_text(threshold),
+                distance_pct=_text(distance_pct),
+                min_distance_pct=_text(limits.min_distance_pct),
             )
         loss_guard = "not_applicable"
     else:
@@ -399,7 +623,13 @@ def evaluate_auto_approve_eligibility(
         distance_pct = (limit_price - current_price) / current_price * Decimal("100")
         if (limit_price <= threshold) if expanded else (limit_price < threshold):
             return reject(
-                "marketable_not_resting" if expanded else "distance_below_minimum"
+                "marketable_not_resting" if expanded else "distance_below_minimum",
+                current_price=_text(current_price),
+                limit_price=_text(limit_price),
+                quantity=_text(quantity),
+                threshold=_text(threshold),
+                distance_pct=_text(distance_pct),
+                min_distance_pct=_text(limits.min_distance_pct),
             )
         # A successful fresh sell preview means the existing avg-cost loss
         # guard ran and passed. We record that provenance instead of
@@ -433,7 +663,7 @@ def evaluate_auto_approve_eligibility(
         # stronger reason (loss-cut, cap, marketability, tag, or unknown
         # classification), while an otherwise eligible order still cannot
         # reach the broker with an unrenderable veto card.
-        return reject("thesis_required_for_veto_card")
+        return reject("thesis_required_for_veto_card", thesis_present=False)
 
     return AutoApproveDecision(
         True,
@@ -509,5 +739,6 @@ __all__ = [
     "classify_sell_profit",
     "evaluate_auto_approve_eligibility",
     "find_approval_required_tags",
+    "find_approval_required_tag_matches",
     "limits_for_market",
 ]

--- a/app/services/order_proposals/auto_approve_audit.py
+++ b/app/services/order_proposals/auto_approve_audit.py
@@ -53,6 +53,7 @@ _NUMERIC_INPUT_KEYS = frozenset(
         "gross_pnl",
         "round_trip_cost",
         "net_pnl",
+        "pending_rung_count",
     }
 )
 _ENUM_INPUT_VALUES = {
@@ -67,11 +68,23 @@ _ENUM_INPUT_VALUES = {
     "side": frozenset({"buy", "sell", "unrecognized"}),
     "preview_success": frozenset({"false", "invalid"}),
 }
-_BOOLEAN_INPUT_KEYS = frozenset({"exit_intent_present", "thesis_present"})
+_BOOLEAN_INPUT_KEYS = frozenset(
+    {
+        "eligibility_error",
+        "exit_intent_present",
+        "thesis_present",
+        "toss_auto_submission_frozen",
+    }
+)
 _MISSING_INPUT_FIELDS = frozenset({"current_price", "limit_price", "quantity"})
 _REASON_CODE_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,79}")
 _DECIMAL_TEXT_PATTERN = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?")
-_LOCATION_PATH_PATTERN = re.compile(r"\$[A-Za-z0-9_$.[\]#:-]{0,191}")
+_POLICY_VERSION_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}(?:\.[0-9]{1,4})?")
+_SAFE_PATH_SEGMENT = (
+    r"(?:\.(?:context|decision|flags|labels|metadata|notes|reason|review|tag|tags)"
+    r"|\[(?:0|[1-9][0-9]{0,3})\])"
+)
+_LOCATION_PATH_PATTERN = re.compile(rf"\$(?:{_SAFE_PATH_SEGMENT}){{0,32}}")
 
 
 def _safe_reason_code(value: Any) -> str:
@@ -87,10 +100,21 @@ def _safe_decimal_text(value: Any) -> str | None:
 
 
 def _safe_policy_version(value: Any) -> str | None:
-    if not isinstance(value, str) or not value or len(value) > 160:
+    if not isinstance(value, str) or not _POLICY_VERSION_PATTERN.fullmatch(value):
         return None
-    # Policy versions are repository-controlled identifiers, not free text.
     return value
+
+
+def _safe_evaluated_at(value: Any) -> str | None:
+    if not isinstance(value, str) or len(value) > 80:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.isoformat()
 
 
 def _safe_mode(value: Any) -> str | None:
@@ -133,7 +157,11 @@ def _safe_tag_matches(value: Any) -> list[dict[str, Any]]:
         char_start = raw.get("char_start")
         if token not in _ALLOWED_TAGS or field not in _ALLOWED_TAG_FIELDS:
             continue
-        if not isinstance(path, str) or not _LOCATION_PATH_PATTERN.fullmatch(path):
+        if (
+            not isinstance(path, str)
+            or len(path) > 192
+            or not _LOCATION_PATH_PATTERN.fullmatch(path)
+        ):
             continue
         if kind not in _ALLOWED_MATCH_KINDS:
             continue
@@ -250,9 +278,9 @@ def build_auto_approve_rejection_attempt(
 def _safe_attempt(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):
         return None
-    evaluated_at = value.get("evaluated_at")
+    evaluated_at = _safe_evaluated_at(value.get("evaluated_at"))
     raw_rungs = value.get("rungs")
-    if not isinstance(evaluated_at, str) or not isinstance(raw_rungs, Sequence):
+    if evaluated_at is None or not isinstance(raw_rungs, Sequence):
         return None
     rungs = [
         safe
@@ -261,7 +289,7 @@ def _safe_attempt(value: Any) -> dict[str, Any] | None:
     ]
     if not rungs:
         return None
-    attempt: dict[str, Any] = {"evaluated_at": evaluated_at[:80], "rungs": rungs}
+    attempt: dict[str, Any] = {"evaluated_at": evaluated_at, "rungs": rungs}
     policy_version = _safe_policy_version(value.get("policy_version"))
     if policy_version is not None:
         attempt["policy_version"] = policy_version

--- a/app/services/order_proposals/auto_approve_audit.py
+++ b/app/services/order_proposals/auto_approve_audit.py
@@ -1,0 +1,327 @@
+"""Safe, durable audit projections for auto-approve demotions.
+
+The auto-approve classifier works with proposal free text so it can fail
+closed.  That text must never become a reason payload: operators need the
+reason code and a reproducible match location, not a copied thesis or other
+unbounded proposal input.  This module owns the narrow JSONB shape shared by
+the writer, Telegram card, and read-only MCP projection.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+AUTO_APPROVE_REJECTIONS_KEY = "auto_approve_rejections"
+
+_MAX_ATTEMPTS = 8
+_MAX_RUNGS_PER_ATTEMPT = 16
+_MAX_TAG_MATCHES_PER_RUNG = 12
+_ALLOWED_TAGS = frozenset({"policy_deviation", "table_disagreement"})
+_ALLOWED_TAG_FIELDS = frozenset(
+    {
+        "rationale",
+        "source_asof",
+        "lot_context",
+        "thesis",
+        "strategy",
+        "exit_reason",
+        "void_reason",
+    }
+)
+_ALLOWED_MATCH_KINDS = frozenset(
+    {"text", "json_key", "json_value", "serialized", "scan_unavailable"}
+)
+_NUMERIC_INPUT_KEYS = frozenset(
+    {
+        "notional",
+        "per_order_cap",
+        "daily_notional_after",
+        "daily_cap",
+        "current_price",
+        "limit_price",
+        "quantity",
+        "threshold",
+        "distance_pct",
+        "min_distance_pct",
+        "avg_buy_price",
+        "breakeven_band_pct",
+        "round_trip_cost_bps",
+        "distance_from_avg",
+        "gross_pnl",
+        "round_trip_cost",
+        "net_pnl",
+    }
+)
+_ENUM_INPUT_VALUES = {
+    "action": frozenset({"place", "replace", "cancel", "unrecognized"}),
+    "order_type": frozenset({"limit", "market", "unrecognized"}),
+    "account_mode": frozenset(
+        {"kis_live", "kis_mock", "toss_live", "upbit", "db_simulated", "unrecognized"}
+    ),
+    "market": frozenset(
+        {"equity_kr", "equity_us", "crypto", "forex", "index", "unrecognized"}
+    ),
+    "side": frozenset({"buy", "sell", "unrecognized"}),
+    "preview_success": frozenset({"false", "invalid"}),
+}
+_BOOLEAN_INPUT_KEYS = frozenset({"exit_intent_present", "thesis_present"})
+_MISSING_INPUT_FIELDS = frozenset({"current_price", "limit_price", "quantity"})
+_REASON_CODE_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,79}")
+_DECIMAL_TEXT_PATTERN = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?")
+_LOCATION_PATH_PATTERN = re.compile(r"\$[A-Za-z0-9_$.[\]#:-]{0,191}")
+
+
+def _safe_reason_code(value: Any) -> str:
+    if isinstance(value, str) and _REASON_CODE_PATTERN.fullmatch(value):
+        return value
+    return "invalid_reason_code"
+
+
+def _safe_decimal_text(value: Any) -> str | None:
+    if not isinstance(value, str) or len(value) > 80:
+        return None
+    return value if _DECIMAL_TEXT_PATTERN.fullmatch(value) else None
+
+
+def _safe_policy_version(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > 160:
+        return None
+    # Policy versions are repository-controlled identifiers, not free text.
+    return value
+
+
+def _safe_mode(value: Any) -> str | None:
+    if value in {"off", "expanded"}:
+        return str(value)
+    if value is not None:
+        return "unrecognized"
+    return None
+
+
+def _safe_rung_index(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if 0 <= value < 10000 else None
+
+
+def _safe_enum_input(key: str, value: Any) -> str | None:
+    return (
+        value if isinstance(value, str) and value in _ENUM_INPUT_VALUES[key] else None
+    )
+
+
+def _safe_missing_inputs(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [field for field in value if field in _MISSING_INPUT_FIELDS]
+
+
+def _safe_tag_matches(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    matches: list[dict[str, Any]] = []
+    for raw in value[:_MAX_TAG_MATCHES_PER_RUNG]:
+        if not isinstance(raw, Mapping):
+            continue
+        token = raw.get("token")
+        field = raw.get("field")
+        path = raw.get("path")
+        kind = raw.get("kind")
+        char_start = raw.get("char_start")
+        if token not in _ALLOWED_TAGS or field not in _ALLOWED_TAG_FIELDS:
+            continue
+        if not isinstance(path, str) or not _LOCATION_PATH_PATTERN.fullmatch(path):
+            continue
+        if kind not in _ALLOWED_MATCH_KINDS:
+            continue
+        if isinstance(char_start, bool) or not isinstance(char_start, int):
+            continue
+        if not 0 <= char_start < 1_000_000:
+            continue
+        matches.append(
+            {
+                "token": token,
+                "field": field,
+                "path": path,
+                "kind": kind,
+                "char_start": char_start,
+            }
+        )
+    return matches
+
+
+def _safe_tags(value: Any, matches: list[dict[str, Any]]) -> list[str]:
+    tags = {match["token"] for match in matches}
+    if isinstance(value, str):
+        tags.update(token for token in value.split(",") if token in _ALLOWED_TAGS)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        tags.update(token for token in value if token in _ALLOWED_TAGS)
+    return sorted(tags)
+
+
+def _safe_inputs_from_decision(decision: Mapping[str, Any]) -> dict[str, Any]:
+    inputs: dict[str, Any] = {}
+    policy_version = _safe_policy_version(decision.get("policy_version"))
+    if policy_version is not None:
+        inputs["policy_version"] = policy_version
+    mode = _safe_mode(decision.get("mode"))
+    if mode is not None:
+        inputs["mode"] = mode
+    for key in sorted(_ENUM_INPUT_VALUES):
+        value = _safe_enum_input(key, decision.get(key))
+        if value is not None:
+            inputs[key] = value
+    for key in sorted(_BOOLEAN_INPUT_KEYS):
+        if decision.get(key) is True or decision.get(key) is False:
+            inputs[key] = decision[key]
+    missing_inputs = _safe_missing_inputs(decision.get("missing_inputs"))
+    if missing_inputs:
+        inputs["missing_inputs"] = missing_inputs
+    for key in sorted(_NUMERIC_INPUT_KEYS):
+        value = _safe_decimal_text(decision.get(key))
+        if value is not None:
+            inputs[key] = value
+    matches = _safe_tag_matches(decision.get("tag_matches"))
+    tags = _safe_tags(decision.get("tags"), matches)
+    if tags:
+        inputs["tags"] = tags
+    if matches:
+        inputs["tag_matches"] = matches
+    return inputs
+
+
+def _safe_inputs_from_stored(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    # Stored attempts use the same safe keys as a freshly flattened decision.
+    return _safe_inputs_from_decision(value)
+
+
+def _safe_rung_from_decision(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping) or value.get("eligible") is not False:
+        return None
+    rung_index = _safe_rung_index(value.get("rung_index"))
+    if rung_index is None:
+        return None
+    return {
+        "rung_index": rung_index,
+        "reason_code": _safe_reason_code(value.get("reason")),
+        "inputs": _safe_inputs_from_decision(value),
+    }
+
+
+def _safe_rung_from_stored(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    rung_index = _safe_rung_index(value.get("rung_index"))
+    if rung_index is None:
+        return None
+    return {
+        "rung_index": rung_index,
+        "reason_code": _safe_reason_code(value.get("reason_code")),
+        "inputs": _safe_inputs_from_stored(value.get("inputs")),
+    }
+
+
+def build_auto_approve_rejection_attempt(
+    *, decisions: Sequence[Mapping[str, Any]], now: datetime
+) -> dict[str, Any] | None:
+    """Project only rejected decisions into a bounded, text-free audit event."""
+    rungs = [
+        safe
+        for decision in decisions[:_MAX_RUNGS_PER_ATTEMPT]
+        if (safe := _safe_rung_from_decision(decision)) is not None
+    ]
+    if not rungs:
+        return None
+    attempt: dict[str, Any] = {
+        "evaluated_at": now.isoformat(),
+        "rungs": rungs,
+    }
+    policy_version = rungs[0]["inputs"].get("policy_version")
+    if policy_version is not None:
+        attempt["policy_version"] = policy_version
+    return attempt
+
+
+def _safe_attempt(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    evaluated_at = value.get("evaluated_at")
+    raw_rungs = value.get("rungs")
+    if not isinstance(evaluated_at, str) or not isinstance(raw_rungs, Sequence):
+        return None
+    rungs = [
+        safe
+        for raw in raw_rungs[:_MAX_RUNGS_PER_ATTEMPT]
+        if (safe := _safe_rung_from_stored(raw)) is not None
+    ]
+    if not rungs:
+        return None
+    attempt: dict[str, Any] = {"evaluated_at": evaluated_at[:80], "rungs": rungs}
+    policy_version = _safe_policy_version(value.get("policy_version"))
+    if policy_version is not None:
+        attempt["policy_version"] = policy_version
+    return attempt
+
+
+def project_auto_approve_rejections(source_asof: Any) -> list[dict[str, Any]]:
+    """Return the safe public projection; never return arbitrary JSONB keys."""
+    if not isinstance(source_asof, Mapping):
+        return []
+    raw_attempts = source_asof.get(AUTO_APPROVE_REJECTIONS_KEY)
+    if not isinstance(raw_attempts, Sequence) or isinstance(raw_attempts, (str, bytes)):
+        return []
+    return [
+        safe
+        for raw in raw_attempts[-_MAX_ATTEMPTS:]
+        if (safe := _safe_attempt(raw)) is not None
+    ]
+
+
+def append_auto_approve_rejection_attempt(
+    source_asof: Any, *, decisions: Sequence[Mapping[str, Any]], now: datetime
+) -> dict[str, Any]:
+    """Append one safe rejection attempt while preserving unrelated provenance."""
+    attempt = build_auto_approve_rejection_attempt(decisions=decisions, now=now)
+    source = dict(source_asof) if isinstance(source_asof, Mapping) else {}
+    if attempt is None:
+        return source
+    source[AUTO_APPROVE_REJECTIONS_KEY] = [
+        *project_auto_approve_rejections(source),
+        attempt,
+    ][-_MAX_ATTEMPTS:]
+    return source
+
+
+def build_auto_approve_rejection_card_block(source_asof: Any) -> str | None:
+    """Render a bounded safe summary for the existing manual approval card."""
+    attempts = project_auto_approve_rejections(source_asof)
+    if not attempts:
+        return None
+    latest = attempts[-1]
+    lines = ["*자동 승인 제외*"]
+    for rung in latest["rungs"][:3]:
+        lines.append(f"- #{rung['rung_index'] + 1}: `{rung['reason_code']}`")
+        matches = rung["inputs"].get("tag_matches", [])
+        for match in matches[:2]:
+            location = match["field"] + match["path"][1:]
+            lines.append(
+                f"  - 태그 `{match['token']}` / 위치 `{location}` "
+                f"(문자 {match['char_start']})"
+            )
+    if len(latest["rungs"]) > 3:
+        lines.append("- 추가 제외 사유는 제안 조회에서 확인")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "AUTO_APPROVE_REJECTIONS_KEY",
+    "append_auto_approve_rejection_attempt",
+    "build_auto_approve_rejection_attempt",
+    "build_auto_approve_rejection_card_block",
+    "project_auto_approve_rejections",
+]

--- a/app/services/order_proposals/auto_approve_audit.py
+++ b/app/services/order_proposals/auto_approve_audit.py
@@ -77,7 +77,32 @@ _BOOLEAN_INPUT_KEYS = frozenset(
     }
 )
 _MISSING_INPUT_FIELDS = frozenset({"current_price", "limit_price", "quantity"})
-_REASON_CODE_PATTERN = re.compile(r"[a-z][a-z0-9_]{0,79}")
+_KNOWN_REASON_CODES = frozenset(
+    {
+        "account_not_veto_capable",
+        "action_not_place",
+        "approval_required_tag",
+        "auto_veto_thesis_missing",
+        "breakeven_band",
+        "daily_cap_exceeded",
+        "distance_below_minimum",
+        "eligibility_error",
+        "exit_intent_present",
+        "expected_pnl_not_positive",
+        "loss_cut_intent",
+        "marketable_not_resting",
+        "multi_rung_requires_approval",
+        "order_type_not_limit",
+        "per_order_cap_exceeded",
+        "preview_guard_failed",
+        "price_or_quantity_missing",
+        "sell_classification_unavailable",
+        "side_not_supported",
+        "thesis_required_for_veto_card",
+        "toss_auto_submission_frozen",
+        "unknown_auto_approve_mode",
+    }
+)
 _DECIMAL_TEXT_PATTERN = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?")
 _POLICY_VERSION_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}(?:\.[0-9]{1,4})?")
 _SAFE_PATH_SEGMENT = (
@@ -88,7 +113,7 @@ _LOCATION_PATH_PATTERN = re.compile(rf"\$(?:{_SAFE_PATH_SEGMENT}){{0,32}}")
 
 
 def _safe_reason_code(value: Any) -> str:
-    if isinstance(value, str) and _REASON_CODE_PATTERN.fullmatch(value):
+    if isinstance(value, str) and value in _KNOWN_REASON_CODES:
         return value
     return "invalid_reason_code"
 

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -48,6 +48,9 @@ from app.services.order_proposals.auto_approve import (
     evaluate_auto_approve_eligibility,
     limits_for_market,
 )
+from app.services.order_proposals.auto_approve_audit import (
+    build_auto_approve_rejection_card_block,
+)
 from app.services.order_proposals.auto_veto import (
     TargetCancelFn,
     TargetFetchFn,
@@ -444,6 +447,16 @@ async def send_proposal_for_approval(
         messages = build_approval_dispatch_messages(
             group=group,
             rungs=rungs,
+            suffix_blocks=(
+                (rejection_block,)
+                if (
+                    rejection_block := build_auto_approve_rejection_card_block(
+                        group.source_asof
+                    )
+                )
+                is not None
+                else ()
+            ),
             binding=binding,
         )
 
@@ -779,6 +792,16 @@ async def dispatch_proposal(
                     payload_chars=messages.payload_chars,
                     context_message_count=0,
                 )
+            else:
+                rejected_decisions = [
+                    decision for decision in decisions if decision["eligible"] is False
+                ]
+                if rejected_decisions:
+                    await service.record_auto_approve_rejections(
+                        proposal_id,
+                        decisions=rejected_decisions,
+                        now=gate_now,
+                    )
         # Persist broker outcomes and the audit/nonce before Telegram I/O.
         await session.commit()
 

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -89,6 +89,91 @@ ServiceFactory = Callable[[], Any]
 RevalidateFn = Callable[..., Any]
 Clock = Callable[[], datetime]
 
+_SOURCE_ASOF_ABSENT = object()
+_AUDITABLE_REVALIDATION_FALLBACK_REASONS = frozenset(
+    {"eligibility_error", "multi_rung_requires_approval"}
+)
+
+
+def _auto_approve_rejection_card_block_for_group(group: Any) -> str | None:
+    """Read optional audit provenance without inventing a missing value.
+
+    ORM groups always expose ``source_asof``.  Some narrow dispatch callers
+    intentionally use shape-only group objects, though, where absence means
+    there is no provenance column at all; that is distinct from an ORM value
+    explicitly stored as ``None``.  Neither case may create a rejection
+    record while rendering a card.  The latter still flows through the safe
+    projector so its ``None`` contract remains exercised.
+    """
+    source_asof = getattr(group, "source_asof", _SOURCE_ASOF_ABSENT)
+    if source_asof is _SOURCE_ASOF_ABSENT:
+        return None
+    return build_auto_approve_rejection_card_block(source_asof)
+
+
+def _manual_fallback_decisions(
+    *,
+    rungs: list[Any],
+    reason: str,
+    policy_version: str,
+    **inputs: Any,
+) -> list[dict[str, Any]]:
+    """Describe a pre-classifier fail-closed fallback using safe primitives."""
+    return [
+        {
+            "rung_index": rung.rung_index,
+            "eligible": False,
+            "reason": reason,
+            "policy_version": policy_version,
+            **inputs,
+        }
+        for rung in rungs
+        if rung.state == "pending_approval"
+    ]
+
+
+def _unrecorded_revalidation_fallbacks(
+    *,
+    outcomes: list[RungOutcome],
+    decisions: list[dict[str, Any]],
+    policy_version: str,
+    pending_count: int,
+) -> list[dict[str, Any]]:
+    """Retain safe revalidation fallbacks that never reached ``reject()``.
+
+    The classifier's decisions are already appended by the eligibility
+    closure.  Multi-rung short-circuiting and a gate exception happen outside
+    that closure, so their typed outcome reasons need a separate audit row.
+    Raw exception detail is deliberately not copied.
+    """
+    recorded = {
+        (decision.get("rung_index"), decision.get("reason"))
+        for decision in decisions
+        if decision.get("eligible") is False
+    }
+    fallbacks: list[dict[str, Any]] = []
+    for outcome in outcomes:
+        detail = outcome.detail if isinstance(outcome.detail, dict) else {}
+        reason = detail.get("reason")
+        key = (outcome.rung_index, reason)
+        if reason not in _AUDITABLE_REVALIDATION_FALLBACK_REASONS or key in recorded:
+            continue
+        inputs: dict[str, Any] = {}
+        if reason == "eligibility_error":
+            inputs["eligibility_error"] = True
+        elif reason == "multi_rung_requires_approval":
+            inputs["pending_rung_count"] = str(pending_count)
+        fallbacks.append(
+            {
+                "rung_index": outcome.rung_index,
+                "eligible": False,
+                "reason": reason,
+                "policy_version": policy_version,
+                **inputs,
+            }
+        )
+    return fallbacks
+
 
 def _mirror_decimal_text(value: Any) -> str:
     """Keep Discord card quantities/prices legible after DB numeric coercion."""
@@ -450,8 +535,8 @@ async def send_proposal_for_approval(
             suffix_blocks=(
                 (rejection_block,)
                 if (
-                    rejection_block := build_auto_approve_rejection_card_block(
-                        group.source_asof
+                    rejection_block := _auto_approve_rejection_card_block_for_group(
+                        group
                     )
                 )
                 is not None
@@ -692,6 +777,7 @@ async def dispatch_proposal(
             )
         limits = limits_for_market(group.market)
         decisions: list[dict[str, Any]] = []
+        fallback_decisions: list[dict[str, Any]] = []
         if limits is not None and group.account_mode == "toss_live":
             toss_freeze = await service.active_toss_auto_submission_freeze(
                 group, now=gate_now
@@ -701,6 +787,14 @@ async def dispatch_proposal(
                 # not even enter revalidation (which can reach a broker) here;
                 # the ordinary approval card is the intentional fail-closed
                 # continuation while the operator considers a cancel proposal.
+                fallback_decisions.extend(
+                    _manual_fallback_decisions(
+                        rungs=initial_rungs,
+                        reason="toss_auto_submission_frozen",
+                        policy_version=limits.policy_version,
+                        toss_auto_submission_frozen=True,
+                    )
+                )
                 limits = None
         if limits is not None and auto_veto_thesis_summary(group) is None:
             # This is deliberately outside the revalidation callback.  The
@@ -708,6 +802,14 @@ async def dispatch_proposal(
             # boundary prevents a future revalidation regression from
             # submitting first and discovering an unrenderable veto card only
             # after the broker accepted it.
+            fallback_decisions.extend(
+                _manual_fallback_decisions(
+                    rungs=initial_rungs,
+                    reason="auto_veto_thesis_missing",
+                    policy_version=limits.policy_version,
+                    thesis_present=False,
+                )
+            )
             limits = None
         if limits is not None:
             daily_notional = await service.auto_approved_daily_notional(group, now=now)
@@ -793,15 +895,25 @@ async def dispatch_proposal(
                     context_message_count=0,
                 )
             else:
-                rejected_decisions = [
-                    decision for decision in decisions if decision["eligible"] is False
-                ]
-                if rejected_decisions:
-                    await service.record_auto_approve_rejections(
-                        proposal_id,
-                        decisions=rejected_decisions,
-                        now=gate_now,
+                fallback_decisions.extend(
+                    _unrecorded_revalidation_fallbacks(
+                        outcomes=outcomes,
+                        decisions=decisions,
+                        policy_version=limits.policy_version,
+                        pending_count=pending_count,
                     )
+                )
+        if not auto_submitted:
+            rejected_decisions = [
+                decision for decision in decisions if decision["eligible"] is False
+            ]
+            rejected_decisions.extend(fallback_decisions)
+            if rejected_decisions:
+                await service.record_auto_approve_rejections(
+                    proposal_id,
+                    decisions=rejected_decisions,
+                    now=gate_now,
+                )
         # Persist broker outcomes and the audit/nonce before Telegram I/O.
         await session.commit()
 

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -30,6 +30,9 @@ from app.models.order_proposals import (
 from app.models.review import TossLiveOrderLedger
 from app.services.order_proposals import state_machine as sm
 from app.services.order_proposals.approval_window_contract import valid_until_block
+from app.services.order_proposals.auto_approve_audit import (
+    append_auto_approve_rejection_attempt,
+)
 from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
 from app.services.order_proposals.defensive_ttl import (
     DEFENSIVE_EXIT_INTENTS,
@@ -2479,6 +2482,30 @@ class OrderProposalsService:
                 "outcomes": outcomes,
             },
         }
+        return await self._repo.update_group(group, source_asof=source_asof)
+
+    async def record_auto_approve_rejections(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        decisions: list[dict[str, Any]],
+        now: datetime,
+    ) -> OrderProposal:
+        """Durably retain safe auto-approve demotion evidence for operators.
+
+        The audit helper permits only reason codes, fixed decision inputs, and
+        tag token/location metadata. Proposal free text and arbitrary preview
+        payloads deliberately cannot reach this JSONB path.
+        """
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        source_asof = append_auto_approve_rejection_attempt(
+            group.source_asof,
+            decisions=decisions,
+            now=now,
+        )
         return await self._repo.update_group(group, source_asof=source_asof)
 
     async def record_auto_veto(

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -567,6 +567,27 @@ uses the same cancel-and-confirm routine and records its result under
 `source_asof.auto_approved.notification_failure`; it never silently leaves a
 resting order without attempting compensating cancellation.
 
+### Manual-fallback evidence (ROB-1244)
+
+Every auto-approve demotion is retained before the ordinary approval card is
+published at `source_asof.auto_approve_rejections[]`. This JSON audit is
+bounded to the latest 8 attempts, 16 rungs per attempt, and 12 tag matches per
+rung. Each rung carries a stable `reason_code` plus a restricted set of
+decision inputs; it never carries a thesis, strategy, preview error, or other
+free-text proposal payload.
+
+The record covers both classifier rejections and the fail-closed paths that
+do not invoke the classifier: a Toss verified-fill freeze, missing auto-veto
+thesis, multi-rung all-or-human fallback, and an eligibility-gate exception.
+For a tag rejection it stores only token, scanned field, structural path, and
+character offset. The manual Telegram card shows the latest reasons (and tag
+locations); `order_proposal_get` and `order_proposal_list` expose the same safe
+projection as `auto_approve_rejections`.
+
+Do not treat the audit object as proposal input. The tag scanner intentionally
+excludes its own `auto_approve_rejections` key, so a second dispatch cannot
+turn prior evidence into a new match or crowd out the original location.
+
 Canary sequence: deploy with the flag off; enable only the smallest checked-in
 caps and confirm one resting order plus veto; verify DB/broker convergence;
 then raise caps in a reviewed policy PR. Never enable by changing both the env

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -12,6 +12,7 @@ from app.services.order_proposals.auto_approve import (
     AutoApproveLimits,
     build_auto_approved_message,
     evaluate_auto_approve_eligibility,
+    find_approval_required_tag_matches,
     find_approval_required_tags,
     limits_for_market,
 )
@@ -394,7 +395,7 @@ def test_expanded_breakeven_band_requires_approval(
     [
         {"rationale": {"tags": ["policy_deviation"]}},
         {"rationale": {"decision": {"flags": ["table_disagreement"]}}},
-        {"thesis": "reviewed under Policy_Deviation waiver"},
+        {"exit_reason": "reviewed under Policy_Deviation waiver"},
         {"source_asof": {"table_disagreement": True}},
         {"lot_context": {"notes": ["table_disagreement"]}},
     ],
@@ -415,6 +416,35 @@ def test_tagged_proposals_require_approval_in_every_mode(mode_limits, group_over
 
 def test_untagged_proposal_is_not_falsely_flagged():
     assert find_approval_required_tags(_group(thesis="ordinary support retest")) == ()
+
+
+def test_tag_match_evidence_records_token_and_structural_location_only():
+    group = _group(
+        rationale={"context": {"tags": ["policy_deviation"]}},
+        thesis="ordinary support retest",
+        strategy="ladder",
+    )
+
+    decision = evaluate_auto_approve_eligibility(
+        group=group,
+        rung=_rung(limit_price=Decimal("97000"), quantity=Decimal("1")),
+        preview={"success": True, "current_price": "100000"},
+        limits=_LIMITS,
+        daily_notional=Decimal("0"),
+    )
+
+    expected = [
+        {
+            "token": "policy_deviation",
+            "field": "rationale",
+            "path": "$.context.tags[0]",
+            "kind": "json_value",
+            "char_start": 0,
+        }
+    ]
+    assert decision.reason == "approval_required_tag"
+    assert decision.details["tag_matches"] == expected
+    assert find_approval_required_tag_matches(group) == expected
 
 
 def test_unserializable_metadata_is_treated_as_tagged():

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -15,6 +16,10 @@ from app.services.order_proposals.auto_approve import (
     find_approval_required_tag_matches,
     find_approval_required_tags,
     limits_for_market,
+)
+from app.services.order_proposals.auto_approve_audit import (
+    append_auto_approve_rejection_attempt,
+    project_auto_approve_rejections,
 )
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
@@ -416,6 +421,94 @@ def test_tagged_proposals_require_approval_in_every_mode(mode_limits, group_over
 
 def test_untagged_proposal_is_not_falsely_flagged():
     assert find_approval_required_tags(_group(thesis="ordinary support retest")) == ()
+
+
+def test_repeated_dispatch_does_not_scan_its_own_rejection_audit():
+    """Prior audit tokens stay evidence, never become new classifier input."""
+    original = _group(
+        rationale={"context": {"tags": ["policy_deviation"]}},
+        thesis="ordinary support retest",
+        strategy="ladder",
+    )
+    original_matches = find_approval_required_tag_matches(original)
+    source_asof = append_auto_approve_rejection_attempt(
+        {},
+        decisions=[
+            {
+                "rung_index": 0,
+                "eligible": False,
+                "reason": "approval_required_tag",
+                "policy_version": "2026-08-12.3",
+                "tag_matches": original_matches,
+            }
+        ],
+        now=datetime(2026, 8, 14, 0, 0, tzinfo=UTC),
+    )
+
+    audit_only = _group(source_asof=source_asof)
+    repeated = _group(
+        rationale=original.rationale,
+        thesis="ordinary support retest",
+        strategy="ladder",
+        source_asof=source_asof,
+    )
+
+    assert find_approval_required_tags(audit_only) == ()
+    assert find_approval_required_tags(repeated) == ("policy_deviation",)
+    assert find_approval_required_tag_matches(repeated) == original_matches
+
+
+def test_rejection_projection_drops_untrusted_metadata_without_losing_reason():
+    raw_input = "private-metadata-must-not-escape"
+    source_asof = {
+        "auto_approve_rejections": [
+            {
+                "evaluated_at": "2026-08-14T00:00:00+00:00",
+                "policy_version": raw_input,
+                "rungs": [
+                    {
+                        "rung_index": 0,
+                        "reason_code": "approval_required_tag",
+                        "inputs": {
+                            "policy_version": raw_input,
+                            "tag_matches": [
+                                {
+                                    "token": "policy_deviation",
+                                    "field": "rationale",
+                                    "path": f"$.{raw_input}",
+                                    "kind": "json_value",
+                                    "char_start": 0,
+                                }
+                            ],
+                            "error": raw_input,
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    projected = project_auto_approve_rejections(source_asof)
+
+    assert projected == [
+        {
+            "evaluated_at": "2026-08-14T00:00:00+00:00",
+            "rungs": [
+                {
+                    "rung_index": 0,
+                    "reason_code": "approval_required_tag",
+                    "inputs": {},
+                }
+            ],
+        }
+    ]
+    assert raw_input not in json.dumps(projected)
+    malformed_time = dict(source_asof["auto_approve_rejections"][0])
+    malformed_time["evaluated_at"] = raw_input
+    assert (
+        project_auto_approve_rejections({"auto_approve_rejections": [malformed_time]})
+        == []
+    )
 
 
 def test_tag_match_evidence_records_token_and_structural_location_only():

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -509,6 +509,16 @@ def test_rejection_projection_drops_untrusted_metadata_without_losing_reason():
         project_auto_approve_rejections({"auto_approve_rejections": [malformed_time]})
         == []
     )
+    untrusted_reason = dict(source_asof["auto_approve_rejections"][0])
+    untrusted_rung = dict(untrusted_reason["rungs"][0])
+    untrusted_rung["reason_code"] = raw_input
+    untrusted_reason["rungs"] = [untrusted_rung]
+    assert (
+        project_auto_approve_rejections(
+            {"auto_approve_rejections": [untrusted_reason]}
+        )[0]["rungs"][0]["reason_code"]
+        == "invalid_reason_code"
+    )
 
 
 def test_tag_match_evidence_records_token_and_structural_location_only():

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -229,6 +229,8 @@ async def _seed_proposal(
     db_session,
     *,
     source_asof=None,
+    market="equity_kr",
+    account_mode="kis_live",
     action=None,
     target_broker_order_id=None,
     target_order_snapshot=None,
@@ -240,8 +242,8 @@ async def _seed_proposal(
     service = OrderProposalsService(db_session)
     group = await service.create_proposal(
         symbol="005930",
-        market="equity_kr",
-        account_mode="kis_live",
+        market=market,
+        account_mode=account_mode,
         side="buy",
         order_type="limit",
         proposer="p",
@@ -1006,6 +1008,158 @@ async def test_missing_auto_veto_thesis_never_revalidates_or_submits(
     assert rungs[0].state == "pending_approval"
     assert "auto_approved" not in (refreshed.source_asof or {})
     assert "주문 제안 승인" in notifier.sent_messages[0][0]
+    evidence = refreshed.source_asof["auto_approve_rejections"][-1]["rungs"]
+    assert evidence == [
+        {
+            "rung_index": 0,
+            "reason_code": "auto_veto_thesis_missing",
+            "inputs": {
+                "policy_version": policy_version_stamp()["version"],
+                "thesis_present": False,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_records_multi_rung_fallback_reason_for_manual_card(
+    monkeypatch, db_session
+):
+    """The revalidation short-circuit is observable without a broker call."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR",
+        f"multi-rung-{uuid.uuid4().hex}",
+    )
+    group = await _seed_proposal(
+        db_session,
+        broker_account_id=f"multi-rung-{uuid.uuid4()}",
+        rungs=[
+            RungInput(0, "buy", Decimal("10"), Decimal("100"), None),
+            RungInput(1, "buy", Decimal("10"), Decimal("99"), None),
+        ],
+    )
+
+    async def multi_rung_fallback(**_kwargs):
+        return [
+            RungOutcome(
+                0, "approval_required", {"reason": "multi_rung_requires_approval"}
+            ),
+            RungOutcome(
+                1, "approval_required", {"reason": "multi_rung_requires_approval"}
+            ),
+        ]
+
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=_FakeNotifier(),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=multi_rung_fallback,
+    )
+
+    refreshed, _rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    evidence = refreshed.source_asof["auto_approve_rejections"][-1]["rungs"]
+    assert [row["reason_code"] for row in evidence] == [
+        "multi_rung_requires_approval",
+        "multi_rung_requires_approval",
+    ]
+    assert all(row["inputs"]["pending_rung_count"] == "2" for row in evidence)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_records_eligibility_error_without_raw_exception_detail(
+    monkeypatch, db_session
+):
+    """A fail-closed gate error retains its typed cause, not exception prose."""
+    from app.core.config import settings
+
+    raw_error = "private-eligibility-error-must-not-escape"
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR",
+        f"eligibility-error-{uuid.uuid4().hex}",
+    )
+    group = await _seed_proposal(
+        db_session, broker_account_id=f"eligibility-error-{uuid.uuid4()}"
+    )
+
+    async def failed_gate(**_kwargs):
+        return [
+            RungOutcome(
+                0,
+                "approval_required",
+                {"reason": "eligibility_error", "error": raw_error},
+            )
+        ]
+
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=_FakeNotifier(),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=failed_gate,
+    )
+
+    refreshed, _rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    evidence = refreshed.source_asof["auto_approve_rejections"][-1]["rungs"][0]
+    assert evidence["reason_code"] == "eligibility_error"
+    assert evidence["inputs"]["eligibility_error"] is True
+    assert raw_error not in json.dumps(evidence)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_records_toss_freeze_without_entering_revalidation(
+    monkeypatch, db_session
+):
+    """A verified-fill freeze is a manual fallback with durable reason input."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR",
+        f"toss-freeze-{uuid.uuid4().hex}",
+    )
+    group = await _seed_proposal(
+        db_session,
+        account_mode="toss_live",
+        broker_account_id=f"toss-freeze-{uuid.uuid4()}",
+    )
+
+    async def frozen_lane(self, group, *, now):
+        return {"state": "frozen"}
+
+    async def must_not_revalidate(**_kwargs):
+        raise AssertionError("freeze must stop revalidation")
+
+    monkeypatch.setattr(
+        OrderProposalsService,
+        "active_toss_auto_submission_freeze",
+        frozen_lane,
+    )
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=_FakeNotifier(),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=must_not_revalidate,
+    )
+
+    refreshed, _rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    evidence = refreshed.source_asof["auto_approve_rejections"][-1]["rungs"][0]
+    assert evidence["reason_code"] == "toss_auto_submission_frozen"
+    assert evidence["inputs"]["toss_auto_submission_frozen"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import json
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -884,6 +885,89 @@ async def test_dispatch_auto_ineligible_degrades_to_human_approval(
     )
     assert rungs[0].state == "pending_approval"
     assert "auto_approved" not in (refreshed.source_asof or {})
+    audit = refreshed.source_asof["auto_approve_rejections"][-1]
+    evidence = audit["rungs"][0]
+    assert evidence["rung_index"] == 0
+    assert evidence["reason_code"] == "distance_below_minimum"
+    expected_inputs = {
+        "mode": "off",
+        "policy_version": policy_version_stamp()["version"],
+        "current_price": "101",
+        "limit_price": "100",
+        "quantity": "10",
+    }
+    assert {key: evidence["inputs"][key] for key in expected_inputs} == expected_inputs
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_tag_rejection_persists_safe_token_evidence_and_card(
+    monkeypatch, db_session
+):
+    """A manual fallback keeps token + location, never the matched prose."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    raw_match_context = "private-context-policy_deviation-marker"
+    group = await _seed_proposal(
+        db_session,
+        broker_account_id="dispatch-auto-tag-evidence",
+        thesis="ordinary support retest",
+        strategy="ladder",
+        source_asof={"context": {"tags": [raw_match_context]}},
+    )
+
+    async def fake_revalidate(*, service, proposal_id, now, eligibility_gate):
+        fresh_group, rungs = await service.get_proposal(proposal_id)
+        decision = await eligibility_gate(
+            group=fresh_group,
+            rung=rungs[0],
+            preview={
+                "success": True,
+                "current_price": "110",
+                "price": "100",
+                "quantity": "10",
+            },
+            now=now,
+        )
+        assert decision.reason == "approval_required_tag"
+        return [RungOutcome(0, "approval_required", {"reason": decision.reason})]
+
+    notifier = _FakeNotifier()
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime(2026, 7, 14, 1, 0, tzinfo=UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=fake_revalidate,
+    )
+
+    refreshed, _rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    audit = refreshed.source_asof["auto_approve_rejections"][-1]
+    evidence = audit["rungs"][0]
+    assert evidence["reason_code"] == "approval_required_tag"
+    assert evidence["inputs"]["tags"] == ["policy_deviation"]
+    assert evidence["inputs"]["tag_matches"] == [
+        {
+            "token": "policy_deviation",
+            "field": "source_asof",
+            "path": "$.context.tags[0]",
+            "kind": "json_value",
+            "char_start": raw_match_context.index("policy_deviation"),
+        }
+    ]
+    assert raw_match_context not in json.dumps(audit)
+
+    card_text = notifier.sent_messages[0][0]
+    assert "자동 승인 제외" in card_text
+    assert "approval_required_tag" in card_text
+    assert "policy_deviation" in card_text
+    assert "source_asof.context.tags[0]" in card_text
+    assert raw_match_context not in card_text
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_dispatch_security_invariants.py
+++ b/tests/services/order_proposals/test_dispatch_security_invariants.py
@@ -1436,20 +1436,26 @@ class _OrchestrationSession:
         (ApprovalDispatchState.SENT_SUPERSEDED, 0),
     ],
 )
+@pytest.mark.parametrize("source_asof_state", ["absent", "none"])
 async def test_send_orchestration_registers_batch_only_for_current_result(
     monkeypatch,
     state: ApprovalDispatchState,
     expected_batch_calls: int,
+    source_asof_state: str,
 ) -> None:
-    group = SimpleNamespace(
-        proposal_id=PROPOSAL_ID,
-        market="equity_kr",
-        account_mode="kis_live",
-        action="place",
-        order_type="limit",
-        valid_until=NOW + timedelta(minutes=5),
-        approval_dispatch_membership_revision=None,
-    )
+    group_fields = {
+        "proposal_id": PROPOSAL_ID,
+        "market": "equity_kr",
+        "account_mode": "kis_live",
+        "action": "place",
+        "order_type": "limit",
+        "valid_until": NOW + timedelta(minutes=5),
+        "approval_dispatch_membership_revision": None,
+    }
+    if source_asof_state == "none":
+        # Explicit ORM-column null still passes through the safe projector.
+        group_fields["source_asof"] = None
+    group = SimpleNamespace(**group_fields)
     first_service = SimpleNamespace(
         set_approval_nonce=AsyncMock(),
         get_proposal=AsyncMock(return_value=(group, [])),
@@ -1497,6 +1503,12 @@ async def test_send_orchestration_registers_batch_only_for_current_result(
             payload_chars=4,
         ),
     )
+    rejection_card = MagicMock(return_value=None)
+    monkeypatch.setattr(
+        dispatch_module,
+        "build_auto_approve_rejection_card_block",
+        rejection_card,
+    )
     monkeypatch.setattr(
         dispatch_module,
         "publish_approval_messages",
@@ -1518,6 +1530,10 @@ async def test_send_orchestration_registers_batch_only_for_current_result(
 
     assert returned is result
     assert register.await_count == expected_batch_calls
+    if source_asof_state == "absent":
+        rejection_card.assert_not_called()
+    else:
+        rejection_card.assert_called_once_with(None)
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -908,7 +908,7 @@ async def test_get_and_list_project_safe_auto_approve_rejection_evidence():
                     "rung_index": 0,
                     "eligible": False,
                     "reason": "approval_required_tag",
-                    "policy_version": "test-policy",
+                    "policy_version": "2026-08-12.3",
                     "mode": "expanded",
                     "tags": "policy_deviation",
                     "tag_matches": [
@@ -932,13 +932,13 @@ async def test_get_and_list_project_safe_auto_approve_rejection_evidence():
     expected = [
         {
             "evaluated_at": now.isoformat(),
-            "policy_version": "test-policy",
+            "policy_version": "2026-08-12.3",
             "rungs": [
                 {
                     "rung_index": 0,
                     "reason_code": "approval_required_tag",
                     "inputs": {
-                        "policy_version": "test-policy",
+                        "policy_version": "2026-08-12.3",
                         "mode": "expanded",
                         "tags": ["policy_deviation"],
                         "tag_matches": [

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import json
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -873,6 +874,96 @@ async def test_create_then_get_then_list():
     listed = await opt.order_proposal_list(limit=10, symbol="000660")
     assert listed["success"] is True
     assert any(p["proposal_id"] == pid for p in listed["proposals"])
+
+
+@pytest.mark.asyncio
+async def test_get_and_list_project_safe_auto_approve_rejection_evidence():
+    created = await opt.order_proposal_create(
+        symbol="AUTO-REJECT-EVIDENCE",
+        market="equity_us",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="operator:sess-evidence",
+        thesis="ordinary support retest",
+        strategy="ladder",
+        rungs=[
+            {
+                "rung_index": 0,
+                "side": "buy",
+                "quantity": "1",
+                "limit_price": "100",
+                "notional": None,
+            }
+        ],
+    )
+    now = datetime(2026, 8, 13, 7, 50, tzinfo=UTC)
+    raw_input = "private-preview-material-must-not-escape"
+    async with AsyncSessionLocal() as session:
+        service = OrderProposalsService(session)
+        await service.record_auto_approve_rejections(
+            uuid.UUID(created["proposal_id"]),
+            decisions=[
+                {
+                    "rung_index": 0,
+                    "eligible": False,
+                    "reason": "approval_required_tag",
+                    "policy_version": "test-policy",
+                    "mode": "expanded",
+                    "tags": "policy_deviation",
+                    "tag_matches": [
+                        {
+                            "token": "policy_deviation",
+                            "field": "rationale",
+                            "path": "$.context.tags[0]",
+                            "kind": "json_value",
+                            "char_start": 0,
+                        }
+                    ],
+                    "error": raw_input,
+                }
+            ],
+            now=now,
+        )
+        await session.commit()
+
+    got = await opt.order_proposal_get(created["proposal_id"])
+    listed = await opt.order_proposal_list(symbol="AUTO-REJECT-EVIDENCE")
+    expected = [
+        {
+            "evaluated_at": now.isoformat(),
+            "policy_version": "test-policy",
+            "rungs": [
+                {
+                    "rung_index": 0,
+                    "reason_code": "approval_required_tag",
+                    "inputs": {
+                        "policy_version": "test-policy",
+                        "mode": "expanded",
+                        "tags": ["policy_deviation"],
+                        "tag_matches": [
+                            {
+                                "token": "policy_deviation",
+                                "field": "rationale",
+                                "path": "$.context.tags[0]",
+                                "kind": "json_value",
+                                "char_start": 0,
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    ]
+    assert got["proposal"]["auto_approve_rejections"] == expected
+    row = next(
+        proposal
+        for proposal in listed["proposals"]
+        if proposal["proposal_id"] == created["proposal_id"]
+    )
+    assert row["auto_approve_rejections"] == expected
+    assert raw_input not in json.dumps(got)
+    assert raw_input not in json.dumps(listed)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist bounded auto-approve rejection evidence in existing proposal JSONB
- record tag token plus structural match location without copying free text
- show the safe demotion summary on the manual approval card and MCP get/list

## Verification
- ........................................................................ [ 32%]
........................................................................ [ 64%]
........................................................................ [ 96%]
.........                                                                [100%]
==================================== PASSES ====================================
_____ test_dispatch_expired_returns_typed_result_without_nonce_or_telegram _____
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
_ test_dispatch_closed_or_unknown_session_is_durably_blocked_without_telegram[True-DEFER_SESSION_CLOSED-DEFER_SESSION_CLOSED/submission_session_closed] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
_ test_dispatch_closed_or_unknown_session_is_durably_blocked_without_telegram[False-CALENDAR_UNKNOWN-CALENDAR_UNKNOWN/nxt_capability_stale] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
___________ test_send_proposal_for_approval_empty_allowlist_is_noop ____________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
_ test_send_proposal_for_approval_send_failure_is_durable_and_invalidates_nonce _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
_ test_4444_thesis_context_failure_withholds_button_and_retry_mints_new_nonce __
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
_____ test_auto_notify_failure_compensates_by_cancelling_live_order[none] ______
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
____ test_auto_notify_failure_compensates_by_cancelling_live_order[raises] _____
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
_____________ test_toss_buying_power_failure_fails_open_to_submit ______________
------------------------------ Captured log call -------------------------------
WARNING  app.services.order_proposals.revalidation:revalidation.py:1197 order proposal buying-power lookup failed; continuing fail-open
Traceback (most recent call last):
  File "/Users/mgh3326/work/auto_trader.rob1244/app/services/order_proposals/revalidation.py", line 1184, in _revalidate_place_rung
    claim = await _maybe_await(
            ^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/Users/mgh3326/work/auto_trader.rob1244/app/services/order_proposals/revalidation.py", line 343, in _maybe_await
    return await value
           ^^^^^^^^^^^
  File "/Users/mgh3326/work/auto_trader.rob1244/tests/services/order_proposals/test_revalidation.py", line 2081, in failed_reader
    raise RuntimeError("buying-power endpoint unavailable")
RuntimeError: buying-power endpoint unavailable
_______ test_create_preflights_manual_target_and_returns_action_evidence _______
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_ test_create_toss_live_target_action_preflights_and_creates_proposal[equity_kr-replace] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_ test_create_toss_live_target_action_preflights_and_creates_proposal[equity_kr-cancel] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_ test_create_toss_live_target_action_preflights_and_creates_proposal[equity_us-replace] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_ test_create_toss_live_target_action_preflights_and_creates_proposal[equity_us-cancel] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
___________________ test_place_create_never_fetches_a_target ___________________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
____ test_toss_create_warns_on_same_account_pending_buying_power_shortfall _____
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_______ test_toss_create_reports_sufficient_buying_power_without_warning _______
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_____ test_toss_create_reader_failure_is_non_blocking_unavailable_advisory _____
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
______________ test_create_advisory_skips_kis_and_sell_proposals _______________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_ test_create_normalizes_market_alias_before_storage_and_payload_hash[kr-equity_kr] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_ test_create_normalizes_market_alias_before_storage_and_payload_hash[us-equity_us] _
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
___________ test_supersede_message_edit_setup_failure_is_best_effort ___________
------------------------------ Captured log call -------------------------------
ERROR    app.mcp_server.tooling.order_proposal_tools:order_proposal_tools.py:463 order_proposal_create: superseded telegram message setup failed for message_id=9998
Traceback (most recent call last):
  File "/Users/mgh3326/work/auto_trader.rob1244/app/mcp_server/tooling/order_proposal_tools.py", line 461, in _edit_superseded_approval_message
    notifier = _get_trade_notifier()
  File "/Users/mgh3326/work/auto_trader.rob1244/tests/test_mcp_order_proposal_tools.py", line 771, in notifier_setup_failure
    raise RuntimeError("notifier setup failed")
RuntimeError: notifier setup failed
_____________ test_create_does_not_dispatch_when_telegram_disabled _____________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
______________ test_create_does_not_dispatch_when_allowlist_empty ______________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
________________ test_create_succeeds_even_when_notifier_raises ________________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
________________________ test_create_then_get_then_list ________________________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
________ test_get_and_list_project_safe_auto_approve_rejection_evidence ________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
__________ test_loss_cut_binding_round_trips_through_create_get_list ___________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_____________ test_void_requires_reason_and_terminalizes_proposal ______________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
___ test_void_unverified_uses_broker_evidence_and_disables_telegram_buttons ____
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
___ test_redispatch_uncertain_send_failure_alerts_without_replacing_attempt ____
------------------------------ Captured log call -------------------------------
ERROR    app.mcp_server.tooling.order_proposal_tools:order_proposal_tools.py:922 order_proposal_redispatch.approval_dispatch_failed
_________ test_expire_sweep_dry_run_lists_candidates_without_mutating __________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_________ test_expire_sweep_confirm_expires_and_edits_telegram_message _________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
___ test_expire_sweep_confirm_skips_non_voidable_and_does_not_edit_telegram ____
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
________ test_list_expired_defensive_returns_expired_loss_cut_proposal _________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
_________ test_list_expired_defensive_excludes_non_defensive_proposal __________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
________________ test_list_expired_defensive_filters_by_market _________________
------------------------------ Captured log call -------------------------------
ERROR    app.services.order_proposals.service:service.py:86 order_proposals.approval_dispatch.finalized
ERROR    app.services.order_proposals.alerts:alerts.py:185 order_proposals.approval_dispatch_alert_failed
test schema bootstrap: databases=1 applied=1 schema_seconds=2.06 database_seconds=0.21
=========================== short test summary info ============================
PASSED tests/services/order_proposals/test_auto_approve.py::test_buy_at_distance_and_daily_cap_boundary_is_eligible
PASSED tests/services/order_proposals/test_auto_approve.py::test_sell_requires_distance_and_previewed_loss_guard
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides0-rung_overrides0-order_type_not_limit]
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides1-rung_overrides1-action_not_place]
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides2-rung_overrides2-action_not_place]
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides3-rung_overrides3-loss_cut_intent]
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides4-rung_overrides4-exit_intent_present]
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides5-rung_overrides5-account_not_veto_capable]
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides6-rung_overrides6-distance_below_minimum]
PASSED tests/services/order_proposals/test_auto_approve.py::test_ineligible_orders_fail_closed[group_overrides7-rung_overrides7-per_order_cap_exceeded]
PASSED tests/services/order_proposals/test_auto_approve.py::test_daily_cap_one_unit_over_boundary_is_ineligible
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_buy_inside_min_distance_is_eligible
PASSED tests/services/order_proposals/test_auto_approve.py::test_off_mode_rejects_what_expanded_would_allow
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_marketable_orders_keep_the_veto_button_meaningful
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_limit_exactly_on_the_market_is_marketable
PASSED tests/services/order_proposals/test_auto_approve.py::test_off_mode_keeps_its_non_strict_distance_boundary
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_take_profit_sell_is_eligible
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_loss_cut_intent_never_auto_submits
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_sell_below_cost_is_not_auto_approved
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_net_pnl_exactly_zero_requires_approval
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_fee_rate_is_charged_before_the_sign_test
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_trusts_the_more_pessimistic_preview_pnl
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_breakeven_band_requires_approval[limit_price0-current_price0-100000]
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_breakeven_band_requires_approval[limit_price1-current_price1-100000]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides0-mode_limits0]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides0-mode_limits1]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides1-mode_limits0]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides1-mode_limits1]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides2-mode_limits0]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides2-mode_limits1]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides3-mode_limits0]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides3-mode_limits1]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides4-mode_limits0]
PASSED tests/services/order_proposals/test_auto_approve.py::test_tagged_proposals_require_approval_in_every_mode[group_overrides4-mode_limits1]
PASSED tests/services/order_proposals/test_auto_approve.py::test_untagged_proposal_is_not_falsely_flagged
PASSED tests/services/order_proposals/test_auto_approve.py::test_tag_match_evidence_records_token_and_structural_location_only
PASSED tests/services/order_proposals/test_auto_approve.py::test_unserializable_metadata_is_treated_as_tagged
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_unclassifiable_sell_fails_closed[preview_overrides0-sell_classification_unavailable]
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_unclassifiable_sell_fails_closed[preview_overrides1-sell_classification_unavailable]
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_unclassifiable_sell_fails_closed[preview_overrides2-sell_classification_unavailable]
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_does_not_widen_the_eligible_account_set
PASSED tests/services/order_proposals/test_auto_approve.py::test_unknown_mode_fails_closed
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_still_honours_the_existing_caps
PASSED tests/services/order_proposals/test_auto_approve.py::test_shipped_default_mode_is_off
PASSED tests/services/order_proposals/test_auto_approve.py::test_toss_live_requires_its_separate_default_off_veto_gate
PASSED tests/services/order_proposals/test_auto_approve.py::test_auto_veto_card_requires_a_thesis_not_a_strategy_fallback
PASSED tests/services/order_proposals/test_auto_approve.py::test_auto_veto_card_has_symbol_quantity_price_and_thesis_fields
PASSED tests/services/order_proposals/test_auto_approve.py::test_auto_veto_card_raises_when_thesis_is_missing
PASSED tests/services/order_proposals/test_auto_approve.py::test_policy_caps_follow_the_declared_upper_bands_and_one_new_entry_limit
PASSED tests/services/order_proposals/test_auto_approve.py::test_policy_cost_rate_cannot_be_edited_below_the_code_floor
PASSED tests/services/order_proposals/test_auto_approve.py::test_expanded_mode_flows_from_settings
PASSED tests/services/order_proposals/test_auto_approve.py::test_daily_notional_uses_auto_approval_time_not_create_time
PASSED tests/services/order_proposals/test_dispatch.py::test_publish_4444_thesis_requires_every_context_before_button
PASSED tests/services/order_proposals/test_dispatch.py::test_send_proposal_for_approval_mints_nonce_and_sends
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_expired_returns_typed_result_without_nonce_or_telegram
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_closed_or_unknown_session_is_durably_blocked_without_telegram[True-DEFER_SESSION_CLOSED-DEFER_SESSION_CLOSED/submission_session_closed]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_closed_or_unknown_session_is_durably_blocked_without_telegram[False-CALENDAR_UNKNOWN-CALENDAR_UNKNOWN/nxt_capability_stale]
PASSED tests/services/order_proposals/test_dispatch.py::test_manual_dispatch_freezes_published_batch_and_starts_next_card
PASSED tests/services/order_proposals/test_dispatch.py::test_batch_summary_is_sent_only_after_membership_commit
PASSED tests/services/order_proposals/test_dispatch.py::test_send_proposal_for_approval_renders_initial_replace_action
PASSED tests/services/order_proposals/test_dispatch.py::test_send_proposal_for_approval_preserves_existing_source_asof
PASSED tests/services/order_proposals/test_dispatch.py::test_send_proposal_for_approval_empty_allowlist_is_noop
PASSED tests/services/order_proposals/test_dispatch.py::test_send_proposal_for_approval_send_failure_is_durable_and_invalidates_nonce
PASSED tests/services/order_proposals/test_dispatch.py::test_4444_thesis_context_failure_withholds_button_and_retry_mints_new_nonce
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_gate_off_preserves_human_approval_flow
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_eligible_buy_or_sell_rests_without_approval[buy]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_eligible_buy_or_sell_rests_without_approval[sell]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_ineligible_degrades_to_human_approval
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_tag_rejection_persists_safe_token_evidence_and_card
PASSED tests/services/order_proposals/test_dispatch.py::test_missing_auto_veto_thesis_never_revalidates_or_submits
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate[cancel-toss_live-equity_kr]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate[cancel-kis_live-equity_kr]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate[cancel-upbit-crypto]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate[replace-toss_live-equity_kr]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate[replace-kis_live-equity_kr]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_approve_cancel_replace_never_mutates_before_gate[replace-upbit-crypto]
PASSED tests/services/order_proposals/test_dispatch.py::test_dispatch_auto_861_reconfirm_degrades_without_losing_state
PASSED tests/services/order_proposals/test_dispatch.py::test_auto_notify_failure_compensates_by_cancelling_live_order[none]
PASSED tests/services/order_proposals/test_dispatch.py::test_auto_notify_failure_compensates_by_cancelling_live_order[raises]
PASSED tests/services/order_proposals/test_revalidation.py::test_unchanged_submits_resting
PASSED tests/services/order_proposals/test_revalidation.py::test_superseded_group_returns_error_before_broker_preview
PASSED tests/services/order_proposals/test_revalidation.py::test_unchanged_submits_acked
PASSED tests/services/order_proposals/test_revalidation.py::test_price_change_needs_reconfirm_no_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_submit_time_eligibility_veto_degrades_to_pending_approval
PASSED tests/services/order_proposals/test_revalidation.py::test_auto_eligibility_multi_rung_degrades_before_any_preview
PASSED tests/services/order_proposals/test_revalidation.py::test_qty_change_needs_reconfirm_no_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_guard_block_fail_closed
PASSED tests/services/order_proposals/test_revalidation.py::test_preview_internal_failure_keeps_error_label
PASSED tests/services/order_proposals/test_revalidation.py::test_preview_insufficient_cash_is_guard_blocked
PASSED tests/services/order_proposals/test_revalidation.py::test_preview_kis_no_sellable_holdings_is_guard_blocked
PASSED tests/services/order_proposals/test_revalidation.py::test_loss_cut_bindings_forwarded_to_preview_and_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_loss_cut_confirmation_preview_is_read_only_and_builds_evidence
PASSED tests/services/order_proposals/test_revalidation.py::test_upbit_loss_cut_default_binding_forwards_identity_and_exit_fields
PASSED tests/services/order_proposals/test_revalidation.py::test_submit_rejected_records_rejected
PASSED tests/services/order_proposals/test_revalidation.py::test_submit_ambiguous_records_unverified
PASSED tests/services/order_proposals/test_revalidation.py::test_submit_exception_records_unverified
PASSED tests/services/order_proposals/test_revalidation.py::test_only_pending_approval_rungs_are_revalidated
PASSED tests/services/order_proposals/test_revalidation.py::test_adapt_live_submit_response_accepted_market_is_acked
PASSED tests/services/order_proposals/test_revalidation.py::test_adapt_live_submit_response_accepted_limit_is_resting
PASSED tests/services/order_proposals/test_revalidation.py::test_adapt_live_submit_response_rejected_flips_success_false
PASSED tests/services/order_proposals/test_revalidation.py::test_adapt_live_submit_response_rejected_falls_back_to_message
PASSED tests/services/order_proposals/test_revalidation.py::test_adapt_live_submit_response_unknown_broker_status_passes_through
PASSED tests/services/order_proposals/test_revalidation.py::test_market_order_unchanged_quantity_submits
PASSED tests/services/order_proposals/test_revalidation.py::test_market_order_qty_change_still_needs_reconfirm
PASSED tests/services/order_proposals/test_revalidation.py::test_preview_exception_returns_to_pending_approval
PASSED tests/services/order_proposals/test_revalidation.py::TestDefaultPlaceOrderFnDecimalCoercion::test_decimal_kwargs_coerced_to_float
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_confirms_cancel_before_new_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_target_drift_is_rejected_without_cancel[broker_order_id-old-2]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_target_drift_is_rejected_without_cancel[symbol-KRW-SOL]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_target_drift_is_rejected_without_cancel[side-buy]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_target_drift_is_rejected_without_cancel[order_type-market]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_target_drift_is_rejected_without_cancel[limit_price-42001]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_target_drift_is_rejected_without_cancel[remaining_quantity-3.4]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_live_cancel_end_to_end_through_broker_gateway
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_live_replace_end_to_end_uses_toss_client_order_id
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_live_replace_opposite_pending_blocks_before_cancel
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_decimal_args_are_exact_and_canonical
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_proposal_client_ids_are_stable_and_rung_scoped
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_adapter_forwards_loss_cut_binding[preview]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_adapter_forwards_loss_cut_binding[submit]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_submit_rejects_invalid_client_order_id_before_broker_call[xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_submit_rejects_invalid_client_order_id_before_broker_call[invalid@client-order-id]
PASSED tests/services/order_proposals/test_revalidation.py::test_upbit_proposal_client_ids_are_stable_and_rung_scoped
PASSED tests/services/order_proposals/test_revalidation.py::test_upbit_revalidation_binds_same_proposal_client_id_to_preview_and_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_upbit_submit_failure_found_evidence_converges_resting
PASSED tests/services/order_proposals/test_revalidation.py::test_upbit_true_rejection_absent_evidence_is_rejected
PASSED tests/services/order_proposals/test_revalidation.py::test_upbit_submit_evidence_unknown_is_unverified
PASSED tests/services/order_proposals/test_revalidation.py::test_upbit_submit_exception_found_evidence_converges_resting
PASSED tests/services/order_proposals/test_revalidation.py::test_default_place_order_forwards_proposal_client_id_to_preview_and_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_kr_routes_preview_and_accepted_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_insufficient_buying_power_prevents_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_sufficient_buying_power_preserves_submit_path
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_sell_rung_skips_buying_power_gate
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_buying_power_failure_fails_open_to_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_deposit_then_same_proposal_reapproval_succeeds
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_successful_rung_reserves_cached_power_for_next_rung
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_explicit_rejection_releases_provisional_power
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_ambiguous_submit_keeps_provisional_power
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_retry_across_dates_reuses_proposal_client_id
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_preview_failure_does_not_cancel[guard_blocked]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_preview_failure_does_not_cancel[normalization_diff]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_cancel_rejection_forbids_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_unconfirmed_cancellation_forbids_submit[cancel_exception-cancel_exception:]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_unconfirmed_cancellation_forbids_submit[confirmation_exception-cancel_confirmation_error:]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_unconfirmed_cancellation_forbids_submit[open_confirmation-cancel_unconfirmed:open]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_unconfirmed_cancellation_forbids_submit[missing_evidence-cancel_confirmation_missing_evidence]
PASSED tests/services/order_proposals/test_revalidation.py::test_cancel_confirms_target_without_preview_or_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_manual_target_uses_fresh_broker_evidence_only
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_unconfirmed_returns_unverified_no_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_confirmation_exception_returns_unverified_no_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_submit_ambiguity_persists_reconcile_lineage[exception]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_submit_ambiguity_persists_reconcile_lineage[ambiguous]
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_submit_failure_found_evidence_converges_resting
PASSED tests/services/order_proposals/test_revalidation.py::test_replace_initial_fetch_returns_pending_approval_on_transient_error
PASSED tests/services/order_proposals/test_revalidation.py::test_cancel_unconfirmed_returns_unverified
PASSED tests/services/order_proposals/test_revalidation.py::test_cancel_confirmation_exception_returns_unverified
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[missing_payload]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[malformed_payload]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[missing_hash]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[missing_client_id]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[missing_quantity]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[missing_limit_price]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[mismatched_client_id]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[missing_success]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[none_success]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_preview_fails_closed[string_success]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_success_false_preview_keeps_guard_blocked_behavior
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_multi_rung_ids_and_correlations_stay_distinct
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_us_preserves_fractional_numeric_precision
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_tick_normalized_preview_needs_reconfirm_without_submit
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_explicit_rejection_records_rejected
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_typed_400_rejection_converges_with_broker_diagnostics
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_post_send_failure_records_unverified[timeout_unknown]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_post_send_failure_records_unverified[server_500_unknown]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_post_send_failure_records_unverified[ledger_failure_preserves_order_id]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_accepted_submit_stays_unverified[missing_order_id]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_incomplete_accepted_submit_stays_unverified[missing_approval_hash_digest]
PASSED tests/services/order_proposals/test_revalidation.py::test_toss_market_order_accepted_is_acked_not_filled
PASSED tests/test_mcp_order_proposal_tools.py::test_create_surfaces_typed_approval_dispatch_block
PASSED tests/test_mcp_order_proposal_tools.py::test_create_preflights_manual_target_and_returns_action_evidence
PASSED tests/test_mcp_order_proposal_tools.py::test_create_lookup_failure_returns_error_without_service_insert
PASSED tests/test_mcp_order_proposal_tools.py::test_create_toss_live_target_action_preflights_and_creates_proposal[equity_kr-replace]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_toss_live_target_action_preflights_and_creates_proposal[equity_kr-cancel]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_toss_live_target_action_preflights_and_creates_proposal[equity_us-replace]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_toss_live_target_action_preflights_and_creates_proposal[equity_us-cancel]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_toss_live_cancel_replace_auto_dispatch_never_mutates_before_gate[replace]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_toss_live_cancel_replace_auto_dispatch_never_mutates_before_gate[cancel]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_rejects_toss_live_crypto_target_action_with_supported_matrix[replace]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_rejects_toss_live_crypto_target_action_with_supported_matrix[cancel]
PASSED tests/test_mcp_order_proposal_tools.py::test_place_create_never_fetches_a_target
PASSED tests/test_mcp_order_proposal_tools.py::test_toss_create_warns_on_same_account_pending_buying_power_shortfall
PASSED tests/test_mcp_order_proposal_tools.py::test_toss_create_reports_sufficient_buying_power_without_warning
PASSED tests/test_mcp_order_proposal_tools.py::test_toss_create_reader_failure_is_non_blocking_unavailable_advisory
PASSED tests/test_mcp_order_proposal_tools.py::test_create_advisory_skips_kis_and_sell_proposals
PASSED tests/test_mcp_order_proposal_tools.py::test_create_normalizes_market_alias_before_storage_and_payload_hash[kr-equity_kr]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_normalizes_market_alias_before_storage_and_payload_hash[us-equity_us]
PASSED tests/test_mcp_order_proposal_tools.py::test_create_rejects_unknown_market_with_allowed_contract_guidance
PASSED tests/test_mcp_order_proposal_tools.py::test_create_docstring_documents_markets_aliases_and_account_modes
PASSED tests/test_mcp_order_proposal_tools.py::test_create_dispatches_telegram_when_enabled_and_allowlisted
PASSED tests/test_mcp_order_proposal_tools.py::test_create_4444_thesis_returns_visible_split_dispatch_result
PASSED tests/test_mcp_order_proposal_tools.py::test_supersede_edits_old_approval_message_and_removes_buttons
PASSED tests/test_mcp_order_proposal_tools.py::test_supersede_message_edit_setup_failure_is_best_effort
PASSED tests/test_mcp_order_proposal_tools.py::test_create_does_not_dispatch_when_telegram_disabled
PASSED tests/test_mcp_order_proposal_tools.py::test_create_does_not_dispatch_when_allowlist_empty
PASSED tests/test_mcp_order_proposal_tools.py::test_create_succeeds_even_when_notifier_raises
PASSED tests/test_mcp_order_proposal_tools.py::test_create_then_get_then_list
PASSED tests/test_mcp_order_proposal_tools.py::test_get_and_list_project_safe_auto_approve_rejection_evidence
PASSED tests/test_mcp_order_proposal_tools.py::test_loss_cut_binding_round_trips_through_create_get_list
PASSED tests/test_mcp_order_proposal_tools.py::test_void_requires_reason_and_terminalizes_proposal
PASSED tests/test_mcp_order_proposal_tools.py::test_fetch_void_evidence_forwards_group_valid_until
PASSED tests/test_mcp_order_proposal_tools.py::test_void_unverified_uses_broker_evidence_and_disables_telegram_buttons
PASSED tests/test_mcp_order_proposal_tools.py::test_create_rejects_empty_rungs
PASSED tests/test_mcp_order_proposal_tools.py::test_tools_registered_and_names_exported
PASSED tests/test_mcp_order_proposal_tools.py::test_redispatch_defaults_to_dry_run_and_never_loads_notifier
PASSED tests/test_mcp_order_proposal_tools.py::test_redispatch_execute_refuses_invalid_proposal_without_telegram
PASSED tests/test_mcp_order_proposal_tools.py::test_redispatch_execute_sends_only_fresh_telegram_card
PASSED tests/test_mcp_order_proposal_tools.py::test_redispatch_uncertain_send_failure_alerts_without_replacing_attempt
PASSED tests/test_mcp_order_proposal_tools.py::test_expire_sweep_dry_run_lists_candidates_without_mutating
PASSED tests/test_mcp_order_proposal_tools.py::test_expire_sweep_confirm_expires_and_edits_telegram_message
PASSED tests/test_mcp_order_proposal_tools.py::test_expire_sweep_confirm_skips_non_voidable_and_does_not_edit_telegram
PASSED tests/test_mcp_order_proposal_tools.py::test_expire_sweep_registered_in_tool_names
PASSED tests/test_mcp_order_proposal_tools.py::test_list_expired_defensive_registered_in_tool_names
PASSED tests/test_mcp_order_proposal_tools.py::test_list_expired_defensive_returns_expired_loss_cut_proposal
PASSED tests/test_mcp_order_proposal_tools.py::test_list_expired_defensive_excludes_non_defensive_proposal
PASSED tests/test_mcp_order_proposal_tools.py::test_list_expired_defensive_filters_by_market
225 passed in 23.10s (225 passed)
- targeted ruff, ty, repository-boundary, and runtime-LLM guards passed
- three requested mutations were injected, failed, and reverted

No migration; no broker path or eligibility decision logic changed.