### PR TITLE
feat(policy): wire reserve-net consumer through scope seam

### DIFF
--- a/app/services/support_reserve_net_consumer.py
+++ b/app/services/support_reserve_net_consumer.py
@@ -1,31 +1,28 @@
 """Fail-closed candidate consumer for ``buy.support_reserve_net``.
 
-This module deliberately owns *selection*, not broker access.  It is an
-operator-policy consumer which turns already-collected evidence into a bounded
-set of proposal-shaped candidates.  It does not read a broker, open a DB
-session, register a scheduler, invoke MCP, or send an order.
+This module owns deterministic selection and proposal persistence only through
+the public watcher-scope seam.  It does not read a broker, open a DB session,
+register a scheduler, invoke MCP, or send an order.  Its caller supplies the
+same ``OrderProposalsService`` instance and uncommitted transaction for every
+inspect/create pair.
 
-ATOMICITY_STANCE = (a): **지금은 원자적이지 않다**.  The public
-``OrderProposalsService`` surface has no transactionally locked read for a
-beneficial owner's same-symbol non-terminal order.  Calling
-``create_proposal`` after a best-effort read could therefore coexist with a
-resting order.  Until the dedicated public seam exists, ``consume`` stops at
-the proposal-creation boundary even when every candidate gate passes.
-
-The dormant call site is intentionally kept small and explicit so the future
-seam job has one integration point to review.  The hard false gate below is
-not an environment setting and is not operator-configurable.
+``consume`` verifies the actual seam capability on that supplied object.  It
+then locks and inspects both the legacy unscoped account representation and the
+canonical concrete account scope before any companion create.  A missing
+capability, lock failure, active group, or account-id representation ambiguity
+is a zero-create result.
 """
 
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal, localcontext
-from typing import Any, Final, Literal, Protocol
+from typing import Any, Final, Literal, Protocol, TypeGuard
 
 from app.core.symbol import to_db_symbol
 from app.schemas.trading_policy import SupportReserveNetDecisionRule
+from app.services.order_proposals.service import RungInput, WatchToOrderScopeInspection
 from app.services.trading_policy_service import (
     load_trading_policy,
     policy_version_stamp,
@@ -36,22 +33,16 @@ CandidateIntent = Literal["new", "add"]
 ReserveNetState = Literal["armed", "open", "filled"]
 
 STRATEGY: Final = "buy.support_reserve_net"
-ATOMICITY_STANCE: Final = "a_candidate_only_before_proposal_creation"
+ATOMICITY_STANCE: Final = "watch_to_order_scope_seam_required"
 ATOMICITY_BLOCK_CODE: Final = "atomic_self_open_order_read_seam_unavailable"
-UNATOMICITY_NOTICE: Final = (
-    "지금은 원자적이지 않다: same-symbol self-open-order read+lock public seam이 없다"
-)
+UNATOMICITY_NOTICE: Final = "watch-to-order scope seam의 실제 inspect/create capability가 없으면 proposal은 생성하지 않는다"
 PROPOSAL_CREATION_CALL_SITE: Final = (
-    "SupportReserveNetConsumer._create_after_atomic_self_open_order_check"
+    "SupportReserveNetConsumer._create_after_atomic_watch_to_order_scope_check"
 )
 
 # §56차 3항 (b).  This is an additional fail-closed deployment boundary,
 # deliberately not a policy-file edit owned by #1840.
 KR_NEW_MIN_AVAILABLE_CASH: Final = Decimal("400000")
-
-# The seam does not exist in this revision.  Do not replace this with an env
-# flag, a best-effort list_recent read, or a direct repository import.
-_ATOMIC_SELF_OPEN_ORDER_READ_SEAM_AVAILABLE: Final = False
 
 _SUPPORTED_ACCOUNT_MODES: Final[dict[str, frozenset[str]]] = {
     "equity_kr": frozenset({"kis_live", "toss_live"}),
@@ -68,18 +59,66 @@ _COUNTED_RESERVE_NET_STATES: Final = frozenset({"armed", "open", "filled"})
 
 
 class ProposalCreator(Protocol):
-    """Future-only public proposal-service port.
+    """Public seam capability required for an automatic proposal create.
 
-    The existing ``OrderProposalsService`` implements this method.  The type is
-    deliberately structural so planning remains free of DB/model imports.
+    The consumer never falls back to ordinary ``create_proposal``.  A caller
+    must supply the same service instance and open transaction for both seam
+    operations.
     """
 
-    async def create_proposal(self, **kwargs: Any) -> Any: ...
+    async def inspect_watch_to_order_scope(
+        self,
+        symbol: str,
+        market: str,
+        account_mode: str,
+        broker_account_id: str | None,
+        action: str = "place",
+    ) -> WatchToOrderScopeInspection: ...
+
+    async def create_proposal_in_watch_to_order_scope(
+        self,
+        inspection: WatchToOrderScopeInspection,
+        **kwargs: Any,
+    ) -> Any: ...
+
+
+def _atomic_self_open_order_read_seam_available(
+    proposal_creator: object | None,
+) -> TypeGuard[ProposalCreator]:
+    """Check the supplied object for both public seam operations at runtime."""
+
+    return proposal_creator is not None and all(
+        callable(getattr(proposal_creator, method, None))
+        for method in (
+            "inspect_watch_to_order_scope",
+            "create_proposal_in_watch_to_order_scope",
+        )
+    )
+
+
+# This preserves the original safety-gate name while making it a runtime
+# predicate over the caller-supplied public seam, never a static ``True``.
+_ATOMIC_SELF_OPEN_ORDER_READ_SEAM_AVAILABLE: Final = (
+    _atomic_self_open_order_read_seam_available
+)
+
+
+def _canonical_broker_account_id(value: object) -> str | None:
+    """Accept only the exact opaque account-id representation from evidence."""
+
+    if not isinstance(value, str) or not value or value != value.strip():
+        return None
+    return value
 
 
 @dataclass(frozen=True, slots=True)
 class CashSnapshot:
-    """Fresh, caller-collected cash evidence for one account/currency."""
+    """Fresh, caller-collected cash evidence for one account/currency.
+
+    ``broker_account_id`` is an opaque canonical identifier.  It must be the
+    exact non-empty representation supplied by the account-evidence source;
+    this consumer does not guess aliases, case, punctuation, or a missing id.
+    """
 
     account_mode: str
     broker_account_id: str
@@ -136,6 +175,10 @@ class ReserveNetCandidate:
     ``deep_loss_pct`` is retained for diagnostics only.  It is deliberately
     absent from ``_rank_key``: a deeper loss must never be a positive ranking
     criterion for an add.
+
+    ``broker_account_id`` follows ``CashSnapshot``'s opaque canonical-id
+    contract.  A non-canonical or unavailable identity rejects the candidate
+    before any seam inspection or proposal create.
     """
 
     normalized_symbol: str
@@ -193,7 +236,7 @@ class CandidateRejection:
 
 @dataclass(frozen=True, slots=True)
 class PreparedReserveNetProposal:
-    """A proposal-shaped candidate, never a persisted proposal in this release."""
+    """A selected payload that may be persisted only through the public seam."""
 
     normalized_symbol: str
     market: Market
@@ -215,14 +258,14 @@ class PreparedReserveNetProposal:
 
 @dataclass(frozen=True, slots=True)
 class ReserveNetPlan:
-    """Deterministic output of the candidate-only phase."""
+    """Deterministic selection output before seam inspection and persistence."""
 
     selected: tuple[PreparedReserveNetProposal, ...]
     rejected: tuple[CandidateRejection, ...]
     atomicity_stance: str = ATOMICITY_STANCE
-    proposal_creation_permitted: Literal[False] = False
-    proposal_creation_block_code: str = ATOMICITY_BLOCK_CODE
-    unatomicity_notice: str = UNATOMICITY_NOTICE
+    proposal_creation_permitted: bool = False
+    proposal_creation_block_code: str | None = ATOMICITY_BLOCK_CODE
+    unatomicity_notice: str | None = UNATOMICITY_NOTICE
 
 
 @dataclass(frozen=True, slots=True)
@@ -238,7 +281,7 @@ class ReserveNetPolicyContractError(ValueError):
 
 
 class SupportReserveNetConsumer:
-    """Policy-driven selector with an intentionally closed proposal boundary."""
+    """Policy-driven selector with a seam-gated proposal boundary."""
 
     def __init__(
         self,
@@ -377,7 +420,7 @@ class SupportReserveNetConsumer:
         *,
         proposal_creator: ProposalCreator | None = None,
     ) -> ReserveNetConsumeResult:
-        """Plan, then stop before proposal creation until the atomic seam lands."""
+        """Plan, then create only through a live atomic seam capability."""
 
         plan = self.plan(request)
         if not plan.selected:
@@ -386,87 +429,126 @@ class SupportReserveNetConsumer:
                 proposal_creation_status="not_attempted_no_selected_candidates",
             )
 
-        # 지금은 원자적이지 않다.  A non-atomic read followed by create is not
-        # a safety check; it is a TOCTOU window that can create a second live
-        # resting buy.  This branch is deliberately unreachable in this job.
-        if not _ATOMIC_SELF_OPEN_ORDER_READ_SEAM_AVAILABLE:
+        if not _ATOMIC_SELF_OPEN_ORDER_READ_SEAM_AVAILABLE(proposal_creator):
             return ReserveNetConsumeResult(
                 plan=plan,
                 proposal_creation_status=ATOMICITY_BLOCK_CODE,
             )
 
-        if proposal_creator is None:
-            # Kept for the future seam integration, where the caller must own
-            # the proposal transaction and post-commit dispatch boundary.
-            return ReserveNetConsumeResult(
-                plan=plan,
-                proposal_creation_status="proposal_creator_unavailable",
-            )
-        created = await self._create_after_atomic_self_open_order_check(
+        plan = replace(
+            plan,
+            proposal_creation_permitted=True,
+            proposal_creation_block_code=None,
+            unatomicity_notice=None,
+        )
+        status, created = await self._create_after_atomic_watch_to_order_scope_check(
             plan, proposal_creator
         )
         return ReserveNetConsumeResult(
             plan=plan,
-            proposal_creation_status="created_after_atomic_seam",
+            proposal_creation_status=status,
             proposals_created=tuple(created),
         )
 
-    async def _create_after_atomic_self_open_order_check(
+    async def _create_after_atomic_watch_to_order_scope_check(
         self,
         plan: ReserveNetPlan,
         proposal_creator: ProposalCreator,
-    ) -> list[Any]:
-        """The sole future call location for ``OrderProposalsService.create_proposal``.
+    ) -> tuple[str, list[Any]]:
+        """Inspect every scope before a companion create in the same transaction."""
 
-        The required public atomic read+lock seam is intentionally not
-        implemented here.  A future seam owner must make the caller prove that
-        it held the lock and observed no same-owner/symbol non-terminal order
-        immediately before this method becomes reachable.
-        """
-
-        # Delayed import keeps candidate planning free of proposal models and
-        # makes this explicit dependency dormant while the hard gate is false.
-        from app.services.order_proposals.service import RungInput
-
-        created: list[Any] = []
+        inspections: list[
+            tuple[PreparedReserveNetProposal, WatchToOrderScopeInspection]
+        ] = []
         for proposal in plan.selected:
+            # The legacy ``None`` account scope is distinct from a concrete
+            # account scope in the seam.  It is inspected and locked first so
+            # an active unscoped proposal blocks this automatic create rather
+            # than being silently skipped by the concrete-scope read.
+            legacy_inspection = await proposal_creator.inspect_watch_to_order_scope(
+                symbol=proposal.normalized_symbol,
+                market=proposal.market,
+                account_mode=proposal.account_mode,
+                broker_account_id=None,
+                action="place",
+            )
+            if not legacy_inspection.lock_acquired:
+                return "watch_to_order_scope_lock_unavailable", []
+            if legacy_inspection.active_groups:
+                return "legacy_unscoped_active_proposal_exists", []
+
+            # Residual race: this serializes callers using the seam, but the
+            # manual MCP ``order_proposal_create`` path does not hold this
+            # lock.  The dedicated runbook records the remaining window and
+            # its operating constraint; this consumer never treats it as a
+            # proof that an out-of-seam manual create cannot intervene.
+            inspection = await proposal_creator.inspect_watch_to_order_scope(
+                symbol=proposal.normalized_symbol,
+                market=proposal.market,
+                account_mode=proposal.account_mode,
+                broker_account_id=proposal.broker_account_id,
+                action="place",
+            )
+            if not inspection.lock_acquired:
+                return "watch_to_order_scope_lock_unavailable", []
+            if inspection.active_groups:
+                return "watch_to_order_scope_active_groups_present", []
+            inspections.append((proposal, inspection))
+
+        # Do not commit or roll back here: every companion create must retain
+        # the same service instance and transaction that acquired its scope
+        # reservation.  A caller owns the later commit/rollback boundary.
+        created: list[Any] = []
+        for proposal, inspection in inspections:
             created.append(
-                await proposal_creator.create_proposal(
-                    symbol=proposal.normalized_symbol,
-                    market=proposal.market,
-                    account_mode=proposal.account_mode,
-                    broker_account_id=proposal.broker_account_id,
-                    side="buy",
-                    order_type=proposal.order_type,
-                    proposer="support_reserve_net_consumer",
-                    strategy=proposal.strategy,
-                    rungs=[
-                        RungInput(
-                            rung_index=0,
-                            side="buy",
-                            quantity=proposal.quantity,
-                            limit_price=proposal.limit_price,
-                            notional=None,
-                        )
-                    ],
-                    thesis=proposal.thesis,
-                    rationale={
-                        "tier": STRATEGY,
-                        "intent": proposal.intent,
-                        "tif": proposal.tif,
-                        "required_cash": str(proposal.required_cash),
-                    },
-                    lot_context={
-                        "beneficial_owner_id": proposal.beneficial_owner_id,
-                        "approval_route": proposal.approval_route,
-                    },
-                    source_asof={
-                        "policy_version": proposal.policy_version,
-                        "policy_content_hash": proposal.policy_content_hash,
-                    },
+                await proposal_creator.create_proposal_in_watch_to_order_scope(
+                    inspection,
+                    **self._proposal_create_kwargs(proposal),
                 )
             )
-        return created
+        return "created_after_atomic_seam", created
+
+    @staticmethod
+    def _proposal_create_kwargs(
+        proposal: PreparedReserveNetProposal,
+    ) -> dict[str, Any]:
+        """Build the buy-only, place-only payload accepted by the seam."""
+
+        return {
+            "symbol": proposal.normalized_symbol,
+            "market": proposal.market,
+            "account_mode": proposal.account_mode,
+            "broker_account_id": proposal.broker_account_id,
+            "side": "buy",
+            "order_type": proposal.order_type,
+            "proposer": "support_reserve_net_consumer",
+            "strategy": proposal.strategy,
+            "action": "place",
+            "rungs": [
+                RungInput(
+                    rung_index=0,
+                    side="buy",
+                    quantity=proposal.quantity,
+                    limit_price=proposal.limit_price,
+                    notional=None,
+                )
+            ],
+            "thesis": proposal.thesis,
+            "rationale": {
+                "tier": STRATEGY,
+                "intent": proposal.intent,
+                "tif": proposal.tif,
+                "required_cash": str(proposal.required_cash),
+            },
+            "lot_context": {
+                "beneficial_owner_id": proposal.beneficial_owner_id,
+                "approval_route": proposal.approval_route,
+            },
+            "source_asof": {
+                "policy_version": proposal.policy_version,
+                "policy_content_hash": proposal.policy_content_hash,
+            },
+        }
 
     def _assert_signed_policy_contract(self) -> None:
         """Reject a malformed policy object rather than silently widening it."""
@@ -524,8 +606,9 @@ class SupportReserveNetConsumer:
         )
         if not candidate.beneficial_owner_id.strip():
             return "beneficial_owner_required"
-        if not candidate.broker_account_id.strip():
-            return "broker_account_id_required"
+        broker_account_id = _canonical_broker_account_id(candidate.broker_account_id)
+        if broker_account_id is None:
+            return "broker_account_id_normalization_unavailable"
         if not normalized or normalized != candidate.normalized_symbol:
             return "normalized_symbol_required"
         if conflict_code := candidate_conflicts.get(candidate_key):
@@ -549,7 +632,7 @@ class SupportReserveNetConsumer:
 
         cash_key = (
             candidate.account_mode,
-            candidate.broker_account_id,
+            broker_account_id,
             self._currency(candidate.market),
         )
         if cash_key in ambiguous_cash_keys:
@@ -710,6 +793,11 @@ class SupportReserveNetConsumer:
         return None
 
     def _prepare(self, candidate: ReserveNetCandidate) -> PreparedReserveNetProposal:
+        broker_account_id = _canonical_broker_account_id(candidate.broker_account_id)
+        if broker_account_id is None:
+            raise ReserveNetPolicyContractError(
+                "broker account id became unavailable after candidate gating"
+            )
         approval_route = (
             "human_approval_required"
             if candidate.account_mode == "toss_live"
@@ -719,7 +807,7 @@ class SupportReserveNetConsumer:
             normalized_symbol=candidate.normalized_symbol,
             market=candidate.market,
             account_mode=candidate.account_mode,
-            broker_account_id=candidate.broker_account_id,
+            broker_account_id=broker_account_id,
             beneficial_owner_id=candidate.beneficial_owner_id,
             intent=candidate.intent,
             quantity=candidate.quantity,
@@ -841,9 +929,12 @@ class SupportReserveNetConsumer:
         index: dict[tuple[str, str, str], CashSnapshot] = {}
         ambiguous: set[tuple[str, str, str]] = set()
         for snapshot in snapshots:
+            broker_account_id = _canonical_broker_account_id(snapshot.broker_account_id)
+            if broker_account_id is None:
+                continue
             key = (
                 snapshot.account_mode,
-                snapshot.broker_account_id,
+                broker_account_id,
                 snapshot.currency,
             )
             if key in index:
@@ -856,7 +947,8 @@ class SupportReserveNetConsumer:
         return (
             cash.is_fresh
             and cash.same_account_currency_pending_accounted
-            and bool(cash.broker_account_id.strip())
+            and _canonical_broker_account_id(cash.broker_account_id)
+            == cash.broker_account_id
             and cash.fresh_broker_orderable_cash > 0
             and cash.net_orderable_cash >= 0
             and cash.net_orderable_cash <= cash.fresh_broker_orderable_cash

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -73,13 +73,17 @@ See the full design in
   include every rung state, because a group marked `superseded` can still have a
   `resting` rung. Commit or rollback releases the lock. Existing
   `create_proposal` callers remain unchanged and are not this seam.
-- **Reserve-net consumer activation condition.**
-  `_ATOMIC_SELF_OPEN_ORDER_READ_SEAM_AVAILABLE` in
-  `support_reserve_net_consumer.py` must remain false until a separately
-  reviewed consumer-wiring change performs the preceding inspect → empty-result
-  → companion-create sequence in one `OrderProposalsService` transaction for
-  every proposed scope. Merely importing this service API, observing an empty
-  best-effort list, or changing that boolean is not readiness to create.
+- **Reserve-net consumer seam readiness.**
+  `SupportReserveNetConsumer.consume` verifies at runtime that its supplied
+  object exposes both public watcher-scope operations. For each selected
+  proposal it inspects the distinct legacy `broker_account_id=None` scope and
+  then the canonical four-axis scope, requires both locks and empty results,
+  and calls the companion create using the still-open same service transaction.
+  A missing method, unavailable lock, active group, or uncanonical account id
+  means zero creates. Merely importing the service API or observing a
+  best-effort list is not readiness to create. The remaining manual-create
+  race and its operating constraint are documented in
+  `support-reserve-net-consumer.md`.
 - **Proposal persistence precedes every broker mutation.**
   `order_proposal_create` first commits the intended order. With
   `ORDER_PROPOSALS_AUTO_APPROVE=false` (default), creation does not submit.

--- a/docs/runbooks/support-reserve-net-consumer.md
+++ b/docs/runbooks/support-reserve-net-consumer.md
@@ -1,41 +1,73 @@
-# Support reserve-net consumer — candidate-only safety boundary
+# Support reserve-net consumer — seam-gated proposal creation
 
 ## Current state
 
 `app.services.support_reserve_net_consumer.SupportReserveNetConsumer` is a
-deterministic, **candidate-only** consumer of
-`decision_rules.buy.support_reserve_net`. It has no scheduler registration,
-MCP tool, broker client, account lookup, DB session, or deployment activation.
-It receives evidence as explicit input and produces proposal-shaped candidates
-only.
+deterministic consumer of `decision_rules.buy.support_reserve_net`. It still has
+no scheduler registration, MCP tool, broker client, account lookup, DB-session
+factory, or deployment activation. It receives all evidence and an already-open
+`OrderProposalsService` transaction from its caller; it creates proposal rows
+only through the public watcher-scope seam.
 
-**ATOMICITY_STANCE = (a): 지금은 원자적이지 않다.** The public
-`OrderProposalsService` API has no transactionally locked read that covers the
-beneficial owner, account, market, symbol, and non-terminal rung state. A
-best-effort list followed by `create_proposal` could race a resting buy and
-produce duplicate live exposure. The consumer therefore stops immediately
-before proposal creation with
-`atomic_self_open_order_read_seam_unavailable`.
+This consumer does not send a broker order. Existing downstream approval,
+classification, veto, and dispatch boundaries remain unchanged.
 
-Do not substitute any of the following for the missing seam:
+## Seam readiness and call order
 
-- `list_recent` (it has no account/rung-state/lock contract);
-- a direct import of the internal proposal repository;
-- `supersedes_proposal_id` (a mixed-state group can retain a resting rung);
-- a cached or manually asserted open-order result.
+Readiness is not an environment switch or a constant set to true. At each
+`consume` call, the consumer checks that the supplied object actually exposes
+both public operations:
 
-The source-visible future call location is
-`SupportReserveNetConsumer._create_after_atomic_self_open_order_check`, but its
-hard non-configurable gate is false in this revision. It does not run.
+- `inspect_watch_to_order_scope`;
+- `create_proposal_in_watch_to_order_scope`.
 
-## Required future seam
+If either operation is unavailable, `consume` returns
+`atomic_self_open_order_read_seam_unavailable` and creates zero proposals.
+It does not fall back to `list_recent`, an internal repository import, a cached
+open-order answer, or ordinary `create_proposal`.
 
-After #1844 is merged, a separately owned seam job must add a public
-order-proposal service operation that, in one transaction, acquires a key scoped
-to the beneficial owner/account/market/symbol, reads both proposal and broker
-non-terminal state with rung-state detail, and permits creation only when it
-observes no same-symbol self buy. That job, not this consumer, owns the lock and
-must be reviewed before the hard candidate-only boundary is removed.
+For every selected proposal, the required sequence is:
+
+```text
+validate canonical broker_account_id
+→ inspect legacy broker_account_id=None scope (lock + empty required)
+→ inspect concrete four-axis scope (lock + empty required)
+→ create_proposal_in_watch_to_order_scope on that concrete inspection
+→ caller-owned commit or rollback
+```
+
+All selected scopes are inspected before the first companion create. The
+consumer does not commit or roll back, so the service instance and transaction
+that acquired each advisory lock remain in force through its create.
+
+## Broker-account representation contract
+
+For automatic reserve-net creation, `broker_account_id` is an opaque canonical
+identifier from the account-evidence source. It must be a non-empty string in
+its exact supplied representation, with no leading or trailing whitespace.
+The consumer does not invent an alias, substitute a default account, or rewrite
+case or punctuation. Candidate and cash evidence must use that same canonical
+value; otherwise the candidate is rejected before a seam inspection and the
+result is zero proposals.
+
+`None` is never a canonical automatic-creation identity. It is a distinct
+legacy ledger scope, not a wildcard. The consumer locks and checks that legacy
+scope first. An active legacy proposal blocks the concrete-id create with
+`legacy_unscoped_active_proposal_exists`; this closes the NULL-ledger probe.
+
+## Residual race with the manual create path
+
+`app/mcp_server/tooling/order_proposal_tools.py::order_proposal_create` remains
+outside the watcher-scope lock. Therefore a manual human/agent create can still
+commit in the interval after this consumer has inspected a scope and before its
+companion create. The seam serializes its own callers, not that manual path.
+
+This is an explicit operating constraint, accepted only while the manual path
+remains separately reviewed and the existing proposal approval/dispatch gates
+remain in place: do not manually create a matching account×market×symbol scope
+while this consumer is running. The consumer never interprets its seam snapshot
+as proof that an out-of-seam manual create cannot intervene. Migrating every
+automatic caller to the seam does not remove this manual-path window.
 
 ## Candidate controls
 
@@ -68,12 +100,13 @@ must be reviewed before the hard candidate-only boundary is removed.
 
 ## Verification and operating rule
 
-Run the dedicated contract suite before changing this consumer:
+Run the consumer and seam contract suites before changing this consumer:
 
 ```bash
-uv run pytest tests/services/test_support_reserve_net_consumer.py -q
+uv run pytest tests/services/test_support_reserve_net_consumer.py \
+  tests/services/order_proposals/test_watch_to_order_scope.py -q
 ```
 
-Passing this suite does **not** authorize a proposal, order, broker probe, or
-environment arm. Until the future atomic seam acceptance is complete, the only
-permitted output is the candidate plan and its explicit atomicity block.
+Passing these suites does not authorize a broker probe, environment arm,
+deployment, or direct broker order. This consumer only persists a proposal via
+the existing service-layer seam; all later execution gates remain independent.

--- a/tests/services/test_support_reserve_net_consumer.py
+++ b/tests/services/test_support_reserve_net_consumer.py
@@ -1,12 +1,15 @@
-"""Adversarial contract tests for the reserve-net candidate-only consumer."""
+"""Adversarial contracts for the seam-gated reserve-net consumer."""
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import replace
 from decimal import Decimal
 
 import pytest
 
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.service import RungInput
 from app.services.support_reserve_net_consumer import (
     ATOMICITY_BLOCK_CODE,
     ATOMICITY_STANCE,
@@ -31,10 +34,11 @@ def _cash(
     net: str | None = None,
     all_pending: str = "0",
     reserve_armed: str = "0",
+    broker_account_id: str = "acct-1",
 ) -> CashSnapshot:
     return CashSnapshot(
         account_mode=account_mode,
-        broker_account_id="acct-1",
+        broker_account_id=broker_account_id,
         currency="USD" if market == "equity_us" else "KRW",
         fresh_broker_orderable_cash=Decimal(fresh),
         net_orderable_cash=Decimal(net if net is not None else fresh),
@@ -57,12 +61,13 @@ def _new(
     honest_upside: str = "45",
     proposed_limit: str = "91.2",
     sector: str = "software",
+    broker_account_id: str = "acct-1",
 ) -> ReserveNetCandidate:
     return ReserveNetCandidate(
         normalized_symbol=symbol,
         market=market,  # type: ignore[arg-type]
         account_mode=account_mode,
-        broker_account_id="acct-1",
+        broker_account_id=broker_account_id,
         beneficial_owner_id="owner-1",
         intent="new",
         current_price=Decimal("100"),
@@ -368,10 +373,10 @@ def test_duplicate_candidate_symbol_is_fail_closed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_atomicity_stance_blocks_proposal_creator_even_for_selected_candidate() -> (
+async def test_missing_seam_capability_blocks_proposal_creator_even_for_selected_candidate() -> (
     None
 ):
-    class SpyProposalCreator:
+    class IncompleteProposalCreator:
         def __init__(self) -> None:
             self.calls: list[dict] = []
 
@@ -379,14 +384,221 @@ async def test_atomicity_stance_blocks_proposal_creator_even_for_selected_candid
             self.calls.append(kwargs)
             return {"unexpected": True}
 
-    spy = SpyProposalCreator()
+    spy = IncompleteProposalCreator()
     result = await _consumer().consume(_request(_new()), proposal_creator=spy)
 
-    assert ATOMICITY_STANCE == "a_candidate_only_before_proposal_creation"
+    assert ATOMICITY_STANCE == "watch_to_order_scope_seam_required"
     assert result.proposal_creation_status == ATOMICITY_BLOCK_CODE
     assert result.plan.proposal_creation_permitted is False
-    assert "지금은 원자적이지 않다" in result.plan.unatomicity_notice
+    assert result.plan.proposal_creation_block_code == ATOMICITY_BLOCK_CODE
+    assert result.plan.unatomicity_notice is not None
     assert spy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_noncanonical_candidate_account_id_stops_before_seam_inspection() -> None:
+    class SeamSpy:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def inspect_watch_to_order_scope(self, **kwargs):
+            self.calls.append("inspect")
+            raise AssertionError("non-canonical account id must not inspect")
+
+        async def create_proposal_in_watch_to_order_scope(self, *args, **kwargs):
+            self.calls.append("create")
+            raise AssertionError("non-canonical account id must not create")
+
+    spy = SeamSpy()
+    result = await _consumer().consume(
+        _request(replace(_new(), broker_account_id=" acct-1 ")),
+        proposal_creator=spy,
+    )
+
+    assert result.plan.selected == ()
+    assert (
+        _rejection_codes(result.plan)["NEW"]
+        == "broker_account_id_normalization_unavailable"
+    )
+    assert result.proposal_creation_status == "not_attempted_no_selected_candidates"
+    assert spy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_noncanonical_cash_account_id_stops_before_seam_inspection() -> None:
+    class SeamSpy:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def inspect_watch_to_order_scope(self, **kwargs):
+            self.calls.append("inspect")
+            raise AssertionError("non-canonical account id must not inspect")
+
+        async def create_proposal_in_watch_to_order_scope(self, *args, **kwargs):
+            self.calls.append("create")
+            raise AssertionError("non-canonical account id must not create")
+
+    spy = SeamSpy()
+    result = await _consumer().consume(
+        _request(_new(), cash=(_cash(broker_account_id="acct-1 "),)),
+        proposal_creator=spy,
+    )
+
+    assert result.plan.selected == ()
+    assert _rejection_codes(result.plan)["NEW"] == "cash_snapshot_unavailable"
+    assert result.proposal_creation_status == "not_attempted_no_selected_candidates"
+    assert spy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_consume_inspects_all_scopes_before_companion_create_and_keeps_loss_cut_blocked(
+    db_session, monkeypatch
+) -> None:
+    suffix = uuid.uuid4().hex.upper()
+    first = _new(
+        f"A-SEAM-{suffix}",
+        required_cash="100000",
+        sector="software",
+    )
+    second = _new(
+        f"B-SEAM-{suffix}",
+        required_cash="100000",
+        sector="hardware",
+    )
+    service = OrderProposalsService(db_session)
+    events: list[tuple[str, str, str | None]] = []
+    original_inspect = service.inspect_watch_to_order_scope
+    original_create = service.create_proposal_in_watch_to_order_scope
+
+    async def record_inspect(**kwargs):
+        events.append(("inspect", kwargs["symbol"], kwargs["broker_account_id"]))
+        return await original_inspect(**kwargs)
+
+    async def record_create(inspection, **kwargs):
+        events.append(("create", kwargs["symbol"], inspection.scope.broker_account_id))
+        return await original_create(inspection, **kwargs)
+
+    monkeypatch.setattr(service, "inspect_watch_to_order_scope", record_inspect)
+    monkeypatch.setattr(
+        service,
+        "create_proposal_in_watch_to_order_scope",
+        record_create,
+    )
+
+    result = await _consumer().consume(
+        _request(first, second), proposal_creator=service
+    )
+
+    assert result.proposal_creation_status == "created_after_atomic_seam"
+    assert result.plan.proposal_creation_permitted is True
+    assert result.plan.proposal_creation_block_code is None
+    assert result.plan.unatomicity_notice is None
+    assert events == [
+        ("inspect", first.normalized_symbol, None),
+        ("inspect", first.normalized_symbol, "acct-1"),
+        ("inspect", second.normalized_symbol, None),
+        ("inspect", second.normalized_symbol, "acct-1"),
+        ("create", first.normalized_symbol, "acct-1"),
+        ("create", second.normalized_symbol, "acct-1"),
+    ]
+    assert len(result.proposals_created) == 2
+    for created in result.proposals_created:
+        group, rungs = await service.get_proposal(created.proposal_id)
+        assert group.side == "buy"
+        assert group.action == "place"
+        assert group.exit_intent is None
+        assert group.exit_reason is None
+        assert [(rung.side, rung.state) for rung in rungs] == [
+            ("buy", "pending_approval")
+        ]
+
+
+@pytest.mark.asyncio
+async def test_concrete_scope_active_group_blocks_companion_create(
+    db_session, monkeypatch
+) -> None:
+    symbol = f"CONCRETE-ACTIVE-{uuid.uuid4().hex.upper()}"
+    service = OrderProposalsService(db_session)
+    await service.create_proposal(
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="kis_live",
+        broker_account_id="acct-1",
+        side="buy",
+        order_type="limit",
+        proposer="concrete-probe",
+        strategy="concrete_scope_probe",
+        action="place",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("91.2"), None)],
+    )
+    companion_calls = 0
+
+    async def forbid_companion_create(*args, **kwargs):
+        nonlocal companion_calls
+        companion_calls += 1
+        raise AssertionError("active concrete scope must block before companion create")
+
+    monkeypatch.setattr(
+        service,
+        "create_proposal_in_watch_to_order_scope",
+        forbid_companion_create,
+    )
+
+    result = await _consumer().consume(_request(_new(symbol)), proposal_creator=service)
+
+    assert (
+        result.proposal_creation_status == "watch_to_order_scope_active_groups_present"
+    )
+    assert result.proposals_created == ()
+    assert companion_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_probe_b_legacy_none_scope_blocks_concrete_create(
+    db_session, monkeypatch
+) -> None:
+    symbol = f"PROBE-B-{uuid.uuid4().hex.upper()}"
+    service = OrderProposalsService(db_session)
+    legacy = await service.create_proposal(
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="kis_live",
+        broker_account_id=None,
+        side="buy",
+        order_type="limit",
+        proposer="legacy-probe",
+        strategy="legacy_scope_probe",
+        action="place",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("91.2"), None)],
+    )
+    companion_calls = 0
+
+    async def forbid_companion_create(*args, **kwargs):
+        nonlocal companion_calls
+        companion_calls += 1
+        raise AssertionError("legacy None scope must block before companion create")
+
+    monkeypatch.setattr(
+        service,
+        "create_proposal_in_watch_to_order_scope",
+        forbid_companion_create,
+    )
+
+    result = await _consumer().consume(_request(_new(symbol)), proposal_creator=service)
+
+    assert result.proposal_creation_status == "legacy_unscoped_active_proposal_exists"
+    assert result.proposals_created == ()
+    assert companion_calls == 0
+    concrete = await service.inspect_watch_to_order_scope(
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="kis_live",
+        broker_account_id="acct-1",
+        action="place",
+    )
+    assert concrete.lock_acquired is True
+    assert concrete.active_groups == ()
+    assert legacy.broker_account_id is None
 
 
 def test_missing_precheck_evidence_fails_closed_before_selection() -> None:


### PR DESCRIPTION
## Stack / merge condition

This PR is intentionally stacked on #1848. It contains the patch-identical rebase of #1848 (`70da67747`, source `276e18e6`) plus the sole wiring commit `d8459e633`.

#1848 remains draft/open. Do not merge this PR before #1848. Once #1848 lands, rebase `rsvwire` onto current `origin/main` and verify that `origin/main..HEAD` contains only the wiring commit before merge review.

## Safety wiring

- Replaces the static consumer block with a runtime predicate over the supplied public seam methods.
- Requires canonical opaque `broker_account_id` evidence; uncertainty produces zero proposals.
- For each selected proposal: inspect/lock legacy `None` scope, then inspect/lock concrete four-axis scope, then companion-create in the still-open transaction.
- Explicitly blocks legacy NULL-ledger active proposals and documents the remaining out-of-seam manual-create race.
- Keeps the existing signed reserve-net caps, US add closure, KR minimum-cash closure, and no-loss-cut automatic payload boundary unchanged.

## Validation

- `make lint` — pass.
- Consumer + seam contracts — 27 passed.
- Final `make test` — 19,371 passed, 3 failed, 13 skipped, 7 deselected. The three failures are `tests/research/test_kr_backfill_build_clients.py` provider-env expectations; all three reproduce unchanged on `origin/main` at `1b0d9a746`.
- Six requested local mutants and one Probe-B assertion reversal were each RED then reverted; evidence is in the job report.

No broker/account/live contact, environment arm, deploy, scheduler registration, seam API change, or policy-file change occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proposal creation now validates watcher-scope capabilities, account IDs, locks, and active groups before proceeding.
  * Plan metadata clearly indicates whether proposal creation is permitted and why it may be blocked.
  * Canonical broker-account validation is applied consistently throughout reserve-net processing.

* **Bug Fixes**
  * Prevented proposal creation when scope checks fail, accounts are invalid, locks are unavailable, or conflicting groups are active.
  * Prevented companion proposals when legacy unscoped proposals are present.

* **Documentation**
  * Updated runbooks to describe the gated creation flow, transaction handling, and remaining race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->