### PR TITLE
policy(auto-approve): raise US per-order/daily cap to $800 (§65차)

### DIFF
--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,7 +2,7 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-08-12.3"
+version: "2026-08-14.1"
 captured_as_of: "2026-08-12"
 source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change)"
 
@@ -46,11 +46,17 @@ order_proposals:
     min_distance_pct: 3
     per_order_cap:
       kr: 400000
-      us: 450
+      # §65차 (2026-08-14): 450 → 800. The US book holds single-share lots of
+      # high-priced ETFs (QQQ/VOO/IVV/BRK.B at $500-750/share), so the band-
+      # derived 450 structurally excluded every single-share profit-take from
+      # auto-approve (25/25 sell proposals carded on 2026-08-13). 800 admits
+      # one-share exits while still capping multi-share notional.
+      us: 800
       crypto: 100000
     daily_cap:
       kr: 400000
-      us: 450
+      # §65차: paired with per_order_cap.us per the KR same-value pattern.
+      us: 800
       crypto: 300000
     # AUTO-APPROVE-EXPAND (§40차) — inputs to the profit-take classification,
     # consumed only when ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded.

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -616,7 +616,9 @@ def test_policy_caps_follow_the_declared_upper_bands_and_one_new_entry_limit():
     # buy.per_symbol_notional_usd_range=[150,450], and one concurrent new
     # entry; see the ownership-minimal derivation comment in the cap block.
     assert (kr.per_order_cap, kr.daily_cap) == (Decimal("400000"), Decimal("400000"))
-    assert (us.per_order_cap, us.daily_cap) == (Decimal("450"), Decimal("450"))
+    # §65차 (2026-08-14): US caps raised 450 -> 800 so single-share exits of
+    # $500-750 ETFs can auto-approve; the sizing band above is unchanged.
+    assert (us.per_order_cap, us.daily_cap) == (Decimal("800"), Decimal("800"))
 
 
 def test_policy_cost_rate_cannot_be_edited_below_the_code_floor(monkeypatch):


### PR DESCRIPTION
Operator-approved (§65차, 2026-08-14): US per_order_cap and daily_cap 450 → 800, policy version 2026-08-12.3 → 2026-08-14.1.

Rationale: the US book holds single-share lots of high-priced ETFs (QQQ/VOO/IVV/BRK.B at $500-750/share). The band-derived $450 cap structurally excluded every single-share profit-take from auto-approve — measured 2026-08-13 US session: 25/25 sell proposals demoted to human approval cards. $800 admits one-share exits while still capping multi-share notional; veto cards, daily accumulation, and dual-account selective-approval warnings unchanged.

Policy schema/service tests: 67 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhWL1VDTYZAZd3Nf3W3GSW