### PR TITLE
feat: add US upside shadow instrumentation

### DIFF
--- a/app/services/us_upside_instrumentation.py
+++ b/app/services/us_upside_instrumentation.py
@@ -55,6 +55,7 @@ class SourceCoverage(StrictModel):
     top_n_cap: int | None = Field(..., ge=1)
     outside_top_n_count: int = Field(ge=0)
     deduped_unique_count: int = Field(ge=0)
+    duplicate_count: int = Field(ge=0)
 
     @model_validator(mode="after")
     def _require_explicit_total_state(self) -> SourceCoverage:
@@ -69,8 +70,11 @@ class SourceCoverage(StrictModel):
             )
         if self.top_n_cap is not None and self.returned_count > self.top_n_cap:
             raise ValueError("returned_count cannot exceed top_n_cap")
-        if self.deduped_unique_count > self.returned_count:
-            raise ValueError("deduped_unique_count cannot exceed returned_count")
+        if self.returned_count != self.deduped_unique_count + self.duplicate_count:
+            raise ValueError(
+                "returned_count must equal deduped_unique_count plus "
+                "duplicate_count; coverage is insufficient"
+            )
         if self.upstream_total_known is not None:
             accounted_count = (
                 self.returned_count
@@ -95,6 +99,7 @@ class CandidateArrayCoverage(StrictModel):
     """Explicit global-dedupe to serialized-candidate-array accounting."""
 
     deduped_unique_count: int = Field(ge=0)
+    cross_source_duplicate_count: int = Field(ge=0)
     recorded_candidate_count: int = Field(ge=0)
     truncated_candidate_count: int = Field(ge=0)
     candidate_array_cap: int | None = Field(..., ge=1)
@@ -251,6 +256,25 @@ class InstrumentationInput(StrictModel):
                 "candidate_array_coverage.recorded_candidate_count must equal the "
                 "serialized candidates array length"
             )
+        per_source_deduped_unique_counts = tuple(
+            source.deduped_unique_count for source in self.sources
+        )
+        per_source_deduped_unique_total = sum(per_source_deduped_unique_counts)
+        global_deduped_unique_count = self.candidate_array_coverage.deduped_unique_count
+        if global_deduped_unique_count < max(per_source_deduped_unique_counts):
+            raise ValueError(
+                "global deduped_unique_count cannot be below the largest "
+                "per-source deduped_unique_count; coverage is insufficient"
+            )
+        if per_source_deduped_unique_total != (
+            global_deduped_unique_count
+            + self.candidate_array_coverage.cross_source_duplicate_count
+        ):
+            raise ValueError(
+                "per-source deduped_unique_count total must equal global "
+                "deduped_unique_count plus cross_source_duplicate_count; "
+                "coverage is insufficient"
+            )
         for candidate in self.candidates:
             for match in candidate.matched_sources:
                 if match.source_id not in known_source_ids:
@@ -330,6 +354,8 @@ class CoverageSummary(StrictModel):
     timeout_or_error_count: int = Field(ge=0)
     unqueried_count: int = Field(ge=0)
     outside_top_n_count: int = Field(ge=0)
+    source_duplicate_count: int = Field(ge=0)
+    cross_source_duplicate_count: int = Field(ge=0)
     candidate_array_truncated_count: int = Field(ge=0)
     candidate_array_cap: int | None
     candidate_truncation_reason: str | None
@@ -392,6 +418,8 @@ class SessionCoverageRollup(StrictModel):
     timeout_or_error_count: int = Field(ge=0)
     unqueried_count: int = Field(ge=0)
     outside_top_n_count: int = Field(ge=0)
+    source_duplicate_count: int = Field(ge=0)
+    cross_source_duplicate_count: int = Field(ge=0)
     candidate_array_truncated_count: int = Field(ge=0)
     candidate_array_cap: int | None
     candidate_truncation_reason: str | None
@@ -535,6 +563,27 @@ def _evaluate_arm(
     )
 
 
+def _coverage_is_complete_from_counts(
+    *,
+    upstream_total_unknown_source_count: int,
+    timeout_or_error_count: int,
+    unqueried_count: int,
+    outside_top_n_count: int,
+    candidate_array_truncated_count: int,
+    candidate_consensus_status_counts: dict[ConsensusState, int],
+) -> bool:
+    """Return the sole coverage predicate used for session and rollup reads."""
+
+    return not (
+        upstream_total_unknown_source_count
+        or candidate_consensus_status_counts["unknown"]
+        or timeout_or_error_count
+        or unqueried_count
+        or outside_top_n_count
+        or candidate_array_truncated_count
+    )
+
+
 def _coverage_summary(snapshot: InstrumentationInput) -> CoverageSummary:
     source_timeout_or_error_count = sum(
         source.timeout_or_error_count for source in snapshot.sources
@@ -548,8 +597,11 @@ def _coverage_summary(snapshot: InstrumentationInput) -> CoverageSummary:
     unknown_source_count = sum(
         source.upstream_total_unknown for source in snapshot.sources
     )
-    candidate_unknown_count = consensus_counts["unknown"]
     outside_top_n_count = sum(source.outside_top_n_count for source in snapshot.sources)
+    source_duplicate_count = sum(source.duplicate_count for source in snapshot.sources)
+    cross_source_duplicate_count = (
+        snapshot.candidate_array_coverage.cross_source_duplicate_count
+    )
     candidate_array_truncated_count = (
         snapshot.candidate_array_coverage.truncated_candidate_count
     )
@@ -558,36 +610,39 @@ def _coverage_summary(snapshot: InstrumentationInput) -> CoverageSummary:
         source_timeout_or_error_count + candidate_timeout_or_error_count
     )
     unqueried_count = source_unqueried_count + candidate_unqueried_count
-    coverage_complete = not (
-        unknown_source_count
-        or candidate_unknown_count
-        or timeout_or_error_count
-        or unqueried_count
-        or outside_top_n_count
-        or candidate_array_truncated_count
+    candidate_consensus_status_counts = {
+        status: consensus_counts[status]
+        for status in (
+            "value",
+            "missing",
+            "stale",
+            "error",
+            "timeout",
+            "unknown",
+            "unqueried",
+        )
+    }
+    coverage_complete = _coverage_is_complete_from_counts(
+        upstream_total_unknown_source_count=unknown_source_count,
+        timeout_or_error_count=timeout_or_error_count,
+        unqueried_count=unqueried_count,
+        outside_top_n_count=outside_top_n_count,
+        candidate_array_truncated_count=candidate_array_truncated_count,
+        candidate_consensus_status_counts=candidate_consensus_status_counts,
     )
     return CoverageSummary(
         upstream_total_unknown_source_count=unknown_source_count,
         timeout_or_error_count=timeout_or_error_count,
         unqueried_count=unqueried_count,
         outside_top_n_count=outside_top_n_count,
+        source_duplicate_count=source_duplicate_count,
+        cross_source_duplicate_count=cross_source_duplicate_count,
         candidate_array_truncated_count=candidate_array_truncated_count,
         candidate_array_cap=snapshot.candidate_array_coverage.candidate_array_cap,
         candidate_truncation_reason=(
             snapshot.candidate_array_coverage.candidate_truncation_reason
         ),
-        candidate_consensus_status_counts={
-            status: consensus_counts[status]
-            for status in (
-                "value",
-                "missing",
-                "stale",
-                "error",
-                "timeout",
-                "unknown",
-                "unqueried",
-            )
-        },
+        candidate_consensus_status_counts=candidate_consensus_status_counts,
         coverage_complete=coverage_complete,
     )
 
@@ -624,8 +679,8 @@ def _interpret_session(
         return SessionInterpretation(
             conclusion="coverage_insufficient_no_threshold_conclusion",
             reason=(
-                "top-N, candidate-array, timeout, unqueried, or unknown coverage "
-                "remains; threshold conclusion is unavailable"
+                "top-N, dedupe census, candidate-array, timeout, unqueried, or "
+                "unknown coverage remains; threshold conclusion is unavailable"
             ),
             passes_all_non_upside_gates=len(survivors),
             survivor_consensus_statuses=survivor_statuses,
@@ -770,6 +825,25 @@ def read_three_completed_sessions(
         raise ValueError("three-session reading requires one policy_sha")
     if len({record.code_sha for record in records}) != 1:
         raise ValueError("three-session reading requires one code_sha")
+    for record in records:
+        recomputed_coverage_complete = _coverage_is_complete_from_counts(
+            upstream_total_unknown_source_count=(
+                record.coverage.upstream_total_unknown_source_count
+            ),
+            timeout_or_error_count=record.coverage.timeout_or_error_count,
+            unqueried_count=record.coverage.unqueried_count,
+            outside_top_n_count=record.coverage.outside_top_n_count,
+            candidate_array_truncated_count=(
+                record.coverage.candidate_array_truncated_count
+            ),
+            candidate_consensus_status_counts=(
+                record.coverage.candidate_consensus_status_counts
+            ),
+        )
+        if record.coverage.coverage_complete != recomputed_coverage_complete:
+            raise ValueError(
+                "stored coverage_complete does not match the recorded coverage counts"
+            )
 
     counts = {
         arm_id: sum(record.arm_shadow_counts[arm_id] for record in records)
@@ -785,6 +859,8 @@ def read_three_completed_sessions(
             timeout_or_error_count=record.coverage.timeout_or_error_count,
             unqueried_count=record.coverage.unqueried_count,
             outside_top_n_count=record.coverage.outside_top_n_count,
+            source_duplicate_count=record.coverage.source_duplicate_count,
+            cross_source_duplicate_count=(record.coverage.cross_source_duplicate_count),
             candidate_array_truncated_count=(
                 record.coverage.candidate_array_truncated_count
             ),

--- a/app/services/us_upside_instrumentation.py
+++ b/app/services/us_upside_instrumentation.py
@@ -67,12 +67,74 @@ class SourceCoverage(StrictModel):
             raise ValueError(
                 "outside_top_n_count must be zero when no top_n_cap is declared"
             )
+        if self.top_n_cap is not None and self.returned_count > self.top_n_cap:
+            raise ValueError("returned_count cannot exceed top_n_cap")
+        if self.deduped_unique_count > self.returned_count:
+            raise ValueError("deduped_unique_count cannot exceed returned_count")
+        if self.upstream_total_known is not None:
+            accounted_count = (
+                self.returned_count
+                + self.timeout_or_error_count
+                + self.unqueried_count
+                + self.outside_top_n_count
+            )
+            if accounted_count != self.upstream_total_known:
+                raise ValueError(
+                    "upstream_total_known must equal returned_count plus every "
+                    "declared non-returned count"
+                )
         return self
 
 
 class MatchedSource(StrictModel):
     source_id: str = Field(min_length=1)
-    rank: int | None = Field(default=None, ge=1)
+    rank: int | None = Field(..., ge=1)
+
+
+class CandidateArrayCoverage(StrictModel):
+    """Explicit global-dedupe to serialized-candidate-array accounting."""
+
+    deduped_unique_count: int = Field(ge=0)
+    recorded_candidate_count: int = Field(ge=0)
+    truncated_candidate_count: int = Field(ge=0)
+    candidate_array_cap: int | None = Field(..., ge=1)
+    candidate_truncation_reason: str | None = Field(...)
+
+    @model_validator(mode="after")
+    def _require_declared_candidate_truncation(self) -> CandidateArrayCoverage:
+        if (
+            self.deduped_unique_count
+            != self.recorded_candidate_count + self.truncated_candidate_count
+        ):
+            raise ValueError(
+                "deduped_unique_count must equal recorded_candidate_count plus "
+                "truncated_candidate_count"
+            )
+        if (
+            self.candidate_array_cap is not None
+            and self.recorded_candidate_count > self.candidate_array_cap
+        ):
+            raise ValueError(
+                "recorded_candidate_count cannot exceed candidate_array_cap"
+            )
+        if self.truncated_candidate_count:
+            if self.candidate_array_cap is None:
+                raise ValueError(
+                    "candidate_array_cap is required when candidates are truncated"
+                )
+            if not self.candidate_truncation_reason or not (
+                self.candidate_truncation_reason.strip()
+            ):
+                raise ValueError(
+                    "candidate_truncation_reason is required when candidates are "
+                    "truncated"
+                )
+        elif self.candidate_truncation_reason is not None:
+            raise ValueError(
+                "candidate_truncation_reason must be null when no candidates are "
+                "truncated"
+            )
+        return self
 
 
 class TickHandling(StrictModel):
@@ -166,6 +228,7 @@ class InstrumentationInput(StrictModel):
     decision_cutoff: str = Field(min_length=1)
     universe_hash: str = Field(min_length=12)
     sources: tuple[SourceCoverage, ...] = Field(min_length=1)
+    candidate_array_coverage: CandidateArrayCoverage
     candidates: tuple[CandidateSnapshot, ...]
 
     @field_validator("contract_sha")
@@ -181,6 +244,13 @@ class InstrumentationInput(StrictModel):
         if len(source_ids) != len(set(source_ids)):
             raise ValueError("sources must have unique source_id values")
         known_source_ids = set(source_ids)
+        if self.candidate_array_coverage.recorded_candidate_count != len(
+            self.candidates
+        ):
+            raise ValueError(
+                "candidate_array_coverage.recorded_candidate_count must equal the "
+                "serialized candidates array length"
+            )
         for candidate in self.candidates:
             for match in candidate.matched_sources:
                 if match.source_id not in known_source_ids:
@@ -260,6 +330,9 @@ class CoverageSummary(StrictModel):
     timeout_or_error_count: int = Field(ge=0)
     unqueried_count: int = Field(ge=0)
     outside_top_n_count: int = Field(ge=0)
+    candidate_array_truncated_count: int = Field(ge=0)
+    candidate_array_cap: int | None
+    candidate_truncation_reason: str | None
     candidate_consensus_status_counts: dict[ConsensusState, int]
     coverage_complete: bool
 
@@ -304,6 +377,7 @@ class SessionRecord(StrictModel):
     input_hash: str
     frozen_arms: tuple[ArmDefinition, ...]
     sources: tuple[SourceCoverage, ...]
+    candidate_array_coverage: CandidateArrayCoverage
     candidates: tuple[CandidateInstrumentationRecord, ...]
     arm_shadow_counts: dict[Literal["A40", "B30", "C25"], int]
     coverage: CoverageSummary
@@ -311,12 +385,35 @@ class SessionRecord(StrictModel):
     read_only_safety: ReadOnlySafety
 
 
+class SessionCoverageRollup(StrictModel):
+    session_id: str
+    coverage_complete: bool
+    upstream_total_unknown_source_count: int = Field(ge=0)
+    timeout_or_error_count: int = Field(ge=0)
+    unqueried_count: int = Field(ge=0)
+    outside_top_n_count: int = Field(ge=0)
+    candidate_array_truncated_count: int = Field(ge=0)
+    candidate_array_cap: int | None
+    candidate_truncation_reason: str | None
+
+
 class ThreeSessionReading(StrictModel):
     session_ids: tuple[str, str, str]
+    all_sessions_coverage_complete: bool
+    session_coverage: tuple[
+        SessionCoverageRollup,
+        SessionCoverageRollup,
+        SessionCoverageRollup,
+    ]
+    conclusion: Literal[
+        "coverage_insufficient_no_threshold_conclusion",
+        "three_session_reading_complete",
+    ]
     a40_shadow_count: int = Field(ge=0)
     b30_shadow_count: int = Field(ge=0)
     c25_shadow_count: int = Field(ge=0)
     next_step: Literal[
+        "coverage_insufficient_no_threshold_conclusion",
         "diagnose_target_coverage_or_support_source_contract",
         "continue_bounded_cohort_reading_without_tuning",
     ]
@@ -452,6 +549,10 @@ def _coverage_summary(snapshot: InstrumentationInput) -> CoverageSummary:
         source.upstream_total_unknown for source in snapshot.sources
     )
     candidate_unknown_count = consensus_counts["unknown"]
+    outside_top_n_count = sum(source.outside_top_n_count for source in snapshot.sources)
+    candidate_array_truncated_count = (
+        snapshot.candidate_array_coverage.truncated_candidate_count
+    )
 
     timeout_or_error_count = (
         source_timeout_or_error_count + candidate_timeout_or_error_count
@@ -462,13 +563,18 @@ def _coverage_summary(snapshot: InstrumentationInput) -> CoverageSummary:
         or candidate_unknown_count
         or timeout_or_error_count
         or unqueried_count
+        or outside_top_n_count
+        or candidate_array_truncated_count
     )
     return CoverageSummary(
         upstream_total_unknown_source_count=unknown_source_count,
         timeout_or_error_count=timeout_or_error_count,
         unqueried_count=unqueried_count,
-        outside_top_n_count=sum(
-            source.outside_top_n_count for source in snapshot.sources
+        outside_top_n_count=outside_top_n_count,
+        candidate_array_truncated_count=candidate_array_truncated_count,
+        candidate_array_cap=snapshot.candidate_array_coverage.candidate_array_cap,
+        candidate_truncation_reason=(
+            snapshot.candidate_array_coverage.candidate_truncation_reason
         ),
         candidate_consensus_status_counts={
             status: consensus_counts[status]
@@ -518,8 +624,8 @@ def _interpret_session(
         return SessionInterpretation(
             conclusion="coverage_insufficient_no_threshold_conclusion",
             reason=(
-                "timeout, unqueried, or unknown coverage remains; threshold "
-                "conclusion is unavailable"
+                "top-N, candidate-array, timeout, unqueried, or unknown coverage "
+                "remains; threshold conclusion is unavailable"
             ),
             passes_all_non_upside_gates=len(survivors),
             survivor_consensus_statuses=survivor_statuses,
@@ -608,6 +714,7 @@ def evaluate_instrumentation(
         input_hash=input_hash,
         frozen_arms=FROZEN_ARMS,
         sources=snapshot.sources,
+        candidate_array_coverage=snapshot.candidate_array_coverage,
         candidates=tuple(candidate_records),
         arm_shadow_counts=arm_shadow_counts,
         coverage=coverage,
@@ -619,6 +726,13 @@ def evaluate_instrumentation(
 def append_session_jsonl(path: Path, record: SessionRecord) -> None:
     """Append one local log record to an explicitly selected output path."""
 
+    if path.exists() and any(
+        prior.session_id == record.session_id for prior in load_session_jsonl(path)
+    ):
+        raise ValueError(
+            "output already contains this session_id; preserve the existing record "
+            "and choose a new artifact for a correction"
+        )
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as artifact:
         artifact.write(
@@ -646,6 +760,10 @@ def read_three_completed_sessions(
 
     if len(records) != 3:
         raise ValueError("exactly three completed session records are required")
+    if len({record.session_id for record in records}) != 3:
+        raise ValueError(
+            "three-session reading requires three unique session_id values"
+        )
     if len({record.contract_sha for record in records}) != 1:
         raise ValueError("three-session reading requires one frozen contract_sha")
     if len({record.policy_sha for record in records}) != 1:
@@ -657,6 +775,42 @@ def read_three_completed_sessions(
         arm_id: sum(record.arm_shadow_counts[arm_id] for record in records)
         for arm_id in ("A40", "B30", "C25")
     }
+    session_coverage = tuple(
+        SessionCoverageRollup(
+            session_id=record.session_id,
+            coverage_complete=record.coverage.coverage_complete,
+            upstream_total_unknown_source_count=(
+                record.coverage.upstream_total_unknown_source_count
+            ),
+            timeout_or_error_count=record.coverage.timeout_or_error_count,
+            unqueried_count=record.coverage.unqueried_count,
+            outside_top_n_count=record.coverage.outside_top_n_count,
+            candidate_array_truncated_count=(
+                record.coverage.candidate_array_truncated_count
+            ),
+            candidate_array_cap=record.coverage.candidate_array_cap,
+            candidate_truncation_reason=(record.coverage.candidate_truncation_reason),
+        )
+        for record in records
+    )
+    all_sessions_coverage_complete = all(
+        coverage.coverage_complete for coverage in session_coverage
+    )
+    if not all_sessions_coverage_complete:
+        return ThreeSessionReading(
+            session_ids=(
+                records[0].session_id,
+                records[1].session_id,
+                records[2].session_id,
+            ),
+            all_sessions_coverage_complete=False,
+            session_coverage=session_coverage,
+            conclusion="coverage_insufficient_no_threshold_conclusion",
+            a40_shadow_count=counts["A40"],
+            b30_shadow_count=counts["B30"],
+            c25_shadow_count=counts["C25"],
+            next_step="coverage_insufficient_no_threshold_conclusion",
+        )
     next_step: Literal[
         "diagnose_target_coverage_or_support_source_contract",
         "continue_bounded_cohort_reading_without_tuning",
@@ -671,6 +825,9 @@ def read_three_completed_sessions(
             records[1].session_id,
             records[2].session_id,
         ),
+        all_sessions_coverage_complete=True,
+        session_coverage=session_coverage,
+        conclusion="three_session_reading_complete",
         a40_shadow_count=counts["A40"],
         b30_shadow_count=counts["B30"],
         c25_shadow_count=counts["C25"],

--- a/app/services/us_upside_instrumentation.py
+++ b/app/services/us_upside_instrumentation.py
@@ -1,0 +1,678 @@
+"""Read-only US upside shadow instrumentation.
+
+This module accepts a previously captured bounded cohort, evaluates only the
+three frozen counterfactual arms, and writes operator-selected local records.
+It has no network, database, broker, eligibility, proposal, or scheduling
+integration.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+CONTRACT_SHA256 = "2b8044a1cc39fbd830f68a3253ebdb20db987f2d9f76763edec8a2e3af3a5fe6"
+SCHEMA_VERSION = "us-upside-shadow-instrumentation-v1"
+
+GateState = Literal["pass", "fail", "unknown"]
+FreshnessState = Literal["fresh", "stale", "unknown"]
+ConsensusState = Literal[
+    "value", "missing", "stale", "error", "timeout", "unknown", "unqueried"
+]
+SupportStrength = Literal["strong", "weak", "none", "unknown"]
+
+_TERMINAL_CONSENSUS_STATES: frozenset[str] = frozenset(
+    {"value", "missing", "stale", "error"}
+)
+_FEASIBILITY_FIELDS = (
+    "sector",
+    "dedupe",
+    "cash",
+    "whole_share",
+)
+
+
+class StrictModel(BaseModel):
+    """Base for the versioned JSON contract; unknown fields are rejected."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class SourceCoverage(StrictModel):
+    """Per-source census, including every bounded-read loss point."""
+
+    source_id: str = Field(min_length=1)
+    upstream_total_known: int | None = Field(..., ge=0)
+    upstream_total_unknown: bool
+    returned_count: int = Field(ge=0)
+    timeout_or_error_count: int = Field(ge=0)
+    unqueried_count: int = Field(ge=0)
+    top_n_cap: int | None = Field(..., ge=1)
+    outside_top_n_count: int = Field(ge=0)
+    deduped_unique_count: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _require_explicit_total_state(self) -> SourceCoverage:
+        if self.upstream_total_unknown == (self.upstream_total_known is not None):
+            raise ValueError(
+                "exactly one of upstream_total_known and upstream_total_unknown "
+                "must be set"
+            )
+        if self.top_n_cap is None and self.outside_top_n_count != 0:
+            raise ValueError(
+                "outside_top_n_count must be zero when no top_n_cap is declared"
+            )
+        return self
+
+
+class MatchedSource(StrictModel):
+    source_id: str = Field(min_length=1)
+    rank: int | None = Field(default=None, ge=1)
+
+
+class TickHandling(StrictModel):
+    rule: str = Field(min_length=1)
+    raw_limit: float | None = Field(..., gt=0)
+    snapped_limit: float | None = Field(..., gt=0)
+    direction: Literal["down", "up", "none", "unknown"]
+
+
+class Feasibility(StrictModel):
+    sector: str | None = Field(...)
+    sector_feasibility: GateState
+    dedupe_feasibility: GateState
+    cash_feasibility: GateState
+    whole_share_feasibility: GateState
+    would_size: float | None = Field(..., gt=0)
+    required_cash: float | None = Field(..., ge=0)
+
+
+class HypotheticalLimitTouch(StrictModel):
+    """Optional next-session high/low observation, not an execution record."""
+
+    next_session_high: float = Field(gt=0)
+    next_session_low: float = Field(gt=0)
+    limit_touched: bool
+
+    @model_validator(mode="after")
+    def _high_is_not_below_low(self) -> HypotheticalLimitTouch:
+        if self.next_session_high < self.next_session_low:
+            raise ValueError("next_session_high must be greater than or equal to low")
+        return self
+
+
+class CandidateSnapshot(StrictModel):
+    """All decision-time facts supplied by the read-only upstream capture."""
+
+    symbol: str = Field(min_length=1)
+    matched_sources: tuple[MatchedSource, ...]
+    freshness: FreshnessState
+    consensus_status: ConsensusState
+    target_honesty: Literal["honest", "not_honest", "unknown"]
+    target_as_of: str | None = Field(...)
+    analyst_count: int | None = Field(..., ge=0)
+    current_price: float | None = Field(..., gt=0)
+    target: float | None = Field(..., gt=0)
+    rsi: float | None = Field(..., ge=0, le=100)
+    support_price: float | None = Field(..., gt=0)
+    support_strength: SupportStrength
+    independent_support_families: tuple[str, ...]
+    non_upside_gate_bits: dict[str, GateState] = Field(min_length=1)
+    proposed_limit: float | None = Field(..., gt=0)
+    tick_handling: TickHandling
+    feasibility: Feasibility
+    hypothetical_limit_touch: HypotheticalLimitTouch | None = Field(...)
+
+    @field_validator("independent_support_families")
+    @classmethod
+    def _require_named_families(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not family.strip() for family in value):
+            raise ValueError("independent_support_families cannot contain blanks")
+        return value
+
+    @field_validator("non_upside_gate_bits")
+    @classmethod
+    def _keep_upside_out_of_base_gates(
+        cls, value: dict[str, GateState]
+    ) -> dict[str, GateState]:
+        if any(not name.strip() for name in value):
+            raise ValueError("non_upside_gate_bits cannot contain blank names")
+        if any("upside" in name.lower() for name in value):
+            raise ValueError("non_upside_gate_bits cannot contain an upside gate")
+        return value
+
+    @model_validator(mode="after")
+    def _keep_tick_record_consistent(self) -> CandidateSnapshot:
+        if self.proposed_limit != self.tick_handling.snapped_limit:
+            raise ValueError(
+                "proposed_limit must exactly equal tick_handling.snapped_limit"
+            )
+        return self
+
+
+class InstrumentationInput(StrictModel):
+    """A single bounded US-session capture supplied to the manual CLI."""
+
+    session_id: str = Field(min_length=1)
+    contract_sha: str
+    policy_sha: str = Field(min_length=12)
+    code_sha: str = Field(min_length=12)
+    source_corpus_as_of: str = Field(min_length=1)
+    decision_cutoff: str = Field(min_length=1)
+    universe_hash: str = Field(min_length=12)
+    sources: tuple[SourceCoverage, ...] = Field(min_length=1)
+    candidates: tuple[CandidateSnapshot, ...]
+
+    @field_validator("contract_sha")
+    @classmethod
+    def _require_frozen_contract(cls, value: str) -> str:
+        if value != CONTRACT_SHA256:
+            raise ValueError("contract_sha does not match the frozen §Q4 contract")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_source_references(self) -> InstrumentationInput:
+        source_ids = [source.source_id for source in self.sources]
+        if len(source_ids) != len(set(source_ids)):
+            raise ValueError("sources must have unique source_id values")
+        known_source_ids = set(source_ids)
+        for candidate in self.candidates:
+            for match in candidate.matched_sources:
+                if match.source_id not in known_source_ids:
+                    raise ValueError(
+                        f"candidate {candidate.symbol} references unknown source "
+                        f"{match.source_id}"
+                    )
+        return self
+
+
+class ArmDefinition(StrictModel):
+    arm_id: Literal["A40", "B30", "C25"]
+    upside_min_pct: int = Field(ge=0)
+    required_support_strength: Literal["strong"] | None = None
+    independent_family_min: int | None = Field(default=None, ge=1)
+    final_discount_min_pct: int | None = Field(default=None, ge=0)
+    final_discount_max_pct: int | None = Field(default=None, ge=0)
+    diagnostic_only: bool
+    shadow_only: Literal[True] = True
+
+    @model_validator(mode="after")
+    def _require_complete_distance_range(self) -> ArmDefinition:
+        values = (self.final_discount_min_pct, self.final_discount_max_pct)
+        if (values[0] is None) != (values[1] is None):
+            raise ValueError("discount range must be fully specified or absent")
+        if values[0] is not None and values[0] > values[1]:
+            raise ValueError("discount range minimum cannot exceed its maximum")
+        return self
+
+
+FROZEN_ARMS: tuple[ArmDefinition, ...] = (
+    ArmDefinition(
+        arm_id="A40",
+        upside_min_pct=40,
+        diagnostic_only=False,
+    ),
+    ArmDefinition(
+        arm_id="B30",
+        upside_min_pct=30,
+        required_support_strength="strong",
+        independent_family_min=3,
+        final_discount_min_pct=12,
+        final_discount_max_pct=15,
+        diagnostic_only=False,
+    ),
+    ArmDefinition(
+        arm_id="C25",
+        upside_min_pct=25,
+        required_support_strength="strong",
+        independent_family_min=3,
+        final_discount_min_pct=11,
+        final_discount_max_pct=15,
+        diagnostic_only=True,
+    ),
+)
+
+
+class ArmGateResult(StrictModel):
+    arm_id: Literal["A40", "B30", "C25"]
+    gate_bits: dict[str, bool]
+    reject_reasons: tuple[str, ...]
+    would_select: bool
+    shadow_only: Literal[True] = True
+
+
+class CandidateInstrumentationRecord(CandidateSnapshot):
+    upside_pct: float | None
+    support_distance_pct: float | None
+    independent_support_family_count: int = Field(ge=0)
+    final_discount_from_current_pct: float | None
+    arithmetic_limit_basis_upside_pct: float | None
+    arm_results: tuple[ArmGateResult, ...]
+
+
+class CoverageSummary(StrictModel):
+    upstream_total_unknown_source_count: int = Field(ge=0)
+    timeout_or_error_count: int = Field(ge=0)
+    unqueried_count: int = Field(ge=0)
+    outside_top_n_count: int = Field(ge=0)
+    candidate_consensus_status_counts: dict[ConsensusState, int]
+    coverage_complete: bool
+
+
+class SessionInterpretation(StrictModel):
+    conclusion: Literal[
+        "upside_dominant_constraint_bounded_cohort",
+        "earlier_source_freshness_or_support_constraint",
+        "coverage_insufficient_no_threshold_conclusion",
+        "no_threshold_conclusion",
+    ]
+    reason: str
+    passes_all_non_upside_gates: int = Field(ge=0)
+    survivor_consensus_statuses: tuple[ConsensusState, ...]
+    upside_band_counts: dict[str, int]
+    fanout_performance_or_alpha_inferred: Literal[False] = False
+    threshold_tuning_permitted: Literal[False] = False
+    if_three_sessions_b30_and_c25_are_zero: Literal[
+        "diagnose_target_coverage_or_support_source_contract"
+    ] = "diagnose_target_coverage_or_support_source_contract"
+
+
+class ReadOnlySafety(StrictModel):
+    eligibility_connections: Literal[0] = 0
+    proposals_created: Literal[0] = 0
+    orders_created: Literal[0] = 0
+    broker_calls: Literal[0] = 0
+    database_writes: Literal[0] = 0
+    scheduler_registrations: Literal[0] = 0
+    threshold_overrides: Literal[0] = 0
+
+
+class SessionRecord(StrictModel):
+    schema_version: Literal["us-upside-shadow-instrumentation-v1"] = SCHEMA_VERSION
+    session_id: str
+    contract_sha: str
+    policy_sha: str
+    code_sha: str
+    source_corpus_as_of: str
+    decision_cutoff: str
+    universe_hash: str
+    input_hash: str
+    frozen_arms: tuple[ArmDefinition, ...]
+    sources: tuple[SourceCoverage, ...]
+    candidates: tuple[CandidateInstrumentationRecord, ...]
+    arm_shadow_counts: dict[Literal["A40", "B30", "C25"], int]
+    coverage: CoverageSummary
+    interpretation: SessionInterpretation
+    read_only_safety: ReadOnlySafety
+
+
+class ThreeSessionReading(StrictModel):
+    session_ids: tuple[str, str, str]
+    a40_shadow_count: int = Field(ge=0)
+    b30_shadow_count: int = Field(ge=0)
+    c25_shadow_count: int = Field(ge=0)
+    next_step: Literal[
+        "diagnose_target_coverage_or_support_source_contract",
+        "continue_bounded_cohort_reading_without_tuning",
+    ]
+    threshold_tuning_permitted: Literal[False] = False
+
+
+def _round(value: float) -> float:
+    return round(value, 6)
+
+
+def _upside_pct(candidate: CandidateSnapshot) -> float | None:
+    if candidate.current_price is None or candidate.target is None:
+        return None
+    return _round((candidate.target / candidate.current_price - 1) * 100)
+
+
+def _support_distance_pct(candidate: CandidateSnapshot) -> float | None:
+    if candidate.current_price is None or candidate.support_price is None:
+        return None
+    return _round(
+        (candidate.current_price - candidate.support_price)
+        / candidate.current_price
+        * 100
+    )
+
+
+def _final_discount_pct(candidate: CandidateSnapshot) -> float | None:
+    if candidate.current_price is None or candidate.proposed_limit is None:
+        return None
+    return _round(
+        (candidate.current_price - candidate.proposed_limit)
+        / candidate.current_price
+        * 100
+    )
+
+
+def _arithmetic_limit_basis_upside_pct(candidate: CandidateSnapshot) -> float | None:
+    if candidate.target is None or candidate.proposed_limit is None:
+        return None
+    return _round((candidate.target / candidate.proposed_limit - 1) * 100)
+
+
+def _family_count(candidate: CandidateSnapshot) -> int:
+    return len({family.strip() for family in candidate.independent_support_families})
+
+
+def _evaluate_arm(
+    candidate: CandidateSnapshot,
+    arm: ArmDefinition,
+    *,
+    upside_pct: float | None,
+    final_discount_pct: float | None,
+) -> ArmGateResult:
+    gate_bits: dict[str, bool] = {}
+    reject_reasons: list[str] = []
+
+    for name, state in sorted(candidate.non_upside_gate_bits.items()):
+        passed = state == "pass"
+        gate_bits[f"non_upside:{name}"] = passed
+        if not passed:
+            reject_reasons.append(f"non_upside_gate_{name}_{state}")
+
+    upside_passed = upside_pct is not None and upside_pct >= arm.upside_min_pct
+    gate_bits["upside_minimum"] = upside_passed
+    if not upside_passed:
+        reason = (
+            "upside_missing"
+            if upside_pct is None
+            else f"upside_below_{arm.upside_min_pct}pct"
+        )
+        reject_reasons.append(reason)
+
+    if arm.required_support_strength is not None:
+        strength_passed = candidate.support_strength == arm.required_support_strength
+        gate_bits["support_strength_strong"] = strength_passed
+        if not strength_passed:
+            reject_reasons.append("support_strength_not_strong")
+
+    if arm.independent_family_min is not None:
+        family_passed = _family_count(candidate) >= arm.independent_family_min
+        gate_bits["independent_support_family_minimum"] = family_passed
+        if not family_passed:
+            reject_reasons.append(
+                f"independent_support_families_below_{arm.independent_family_min}"
+            )
+
+    if arm.final_discount_min_pct is not None:
+        assert arm.final_discount_max_pct is not None
+        distance_passed = (
+            final_discount_pct is not None
+            and arm.final_discount_min_pct
+            <= final_discount_pct
+            <= arm.final_discount_max_pct
+        )
+        gate_bits["final_discount_distance"] = distance_passed
+        if not distance_passed:
+            reason = (
+                "final_discount_missing"
+                if final_discount_pct is None
+                else (
+                    "final_discount_outside_"
+                    f"{arm.final_discount_min_pct}_to_{arm.final_discount_max_pct}_pct"
+                )
+            )
+            reject_reasons.append(reason)
+
+    for name in _FEASIBILITY_FIELDS:
+        state = getattr(candidate.feasibility, f"{name}_feasibility")
+        passed = state == "pass"
+        gate_bits[f"{name}_feasible"] = passed
+        if not passed:
+            reject_reasons.append(f"{name}_feasibility_{state}")
+
+    return ArmGateResult(
+        arm_id=arm.arm_id,
+        gate_bits=gate_bits,
+        reject_reasons=tuple(reject_reasons),
+        would_select=not reject_reasons,
+    )
+
+
+def _coverage_summary(snapshot: InstrumentationInput) -> CoverageSummary:
+    source_timeout_or_error_count = sum(
+        source.timeout_or_error_count for source in snapshot.sources
+    )
+    source_unqueried_count = sum(source.unqueried_count for source in snapshot.sources)
+    consensus_counts = Counter(
+        candidate.consensus_status for candidate in snapshot.candidates
+    )
+    candidate_timeout_or_error_count = consensus_counts["timeout"]
+    candidate_unqueried_count = consensus_counts["unqueried"]
+    unknown_source_count = sum(
+        source.upstream_total_unknown for source in snapshot.sources
+    )
+    candidate_unknown_count = consensus_counts["unknown"]
+
+    timeout_or_error_count = (
+        source_timeout_or_error_count + candidate_timeout_or_error_count
+    )
+    unqueried_count = source_unqueried_count + candidate_unqueried_count
+    coverage_complete = not (
+        unknown_source_count
+        or candidate_unknown_count
+        or timeout_or_error_count
+        or unqueried_count
+    )
+    return CoverageSummary(
+        upstream_total_unknown_source_count=unknown_source_count,
+        timeout_or_error_count=timeout_or_error_count,
+        unqueried_count=unqueried_count,
+        outside_top_n_count=sum(
+            source.outside_top_n_count for source in snapshot.sources
+        ),
+        candidate_consensus_status_counts={
+            status: consensus_counts[status]
+            for status in (
+                "value",
+                "missing",
+                "stale",
+                "error",
+                "timeout",
+                "unknown",
+                "unqueried",
+            )
+        },
+        coverage_complete=coverage_complete,
+    )
+
+
+def _interpret_session(
+    candidate_records: Sequence[CandidateInstrumentationRecord],
+    coverage: CoverageSummary,
+) -> SessionInterpretation:
+    survivors = [
+        candidate
+        for candidate in candidate_records
+        if all(state == "pass" for state in candidate.non_upside_gate_bits.values())
+    ]
+    survivor_statuses = tuple(
+        sorted({candidate.consensus_status for candidate in survivors})
+    )
+    band_counts = {
+        "below_25": 0,
+        "25_to_40": 0,
+        "ge_40": 0,
+        "upside_missing": 0,
+    }
+    for candidate in survivors:
+        if candidate.upside_pct is None:
+            band_counts["upside_missing"] += 1
+        elif candidate.upside_pct >= 40:
+            band_counts["ge_40"] += 1
+        elif candidate.upside_pct >= 25:
+            band_counts["25_to_40"] += 1
+        else:
+            band_counts["below_25"] += 1
+
+    if not coverage.coverage_complete:
+        return SessionInterpretation(
+            conclusion="coverage_insufficient_no_threshold_conclusion",
+            reason=(
+                "timeout, unqueried, or unknown coverage remains; threshold "
+                "conclusion is unavailable"
+            ),
+            passes_all_non_upside_gates=len(survivors),
+            survivor_consensus_statuses=survivor_statuses,
+            upside_band_counts=band_counts,
+        )
+    if not survivors:
+        return SessionInterpretation(
+            conclusion="earlier_source_freshness_or_support_constraint",
+            reason="no candidate survived the declared non-upside gates",
+            passes_all_non_upside_gates=0,
+            survivor_consensus_statuses=survivor_statuses,
+            upside_band_counts=band_counts,
+        )
+    terminal_statuses = all(
+        status in _TERMINAL_CONSENSUS_STATES for status in survivor_statuses
+    )
+    if terminal_statuses and band_counts["ge_40"] == 0 and band_counts["25_to_40"] > 0:
+        return SessionInterpretation(
+            conclusion="upside_dominant_constraint_bounded_cohort",
+            reason=(
+                "all survivor consensus states are terminal, no timeout remains, "
+                "and only the 25-to-40 upside band has candidates"
+            ),
+            passes_all_non_upside_gates=len(survivors),
+            survivor_consensus_statuses=survivor_statuses,
+            upside_band_counts=band_counts,
+        )
+    return SessionInterpretation(
+        conclusion="no_threshold_conclusion",
+        reason="the bounded cohort does not satisfy a fixed dominant-constraint rule",
+        passes_all_non_upside_gates=len(survivors),
+        survivor_consensus_statuses=survivor_statuses,
+        upside_band_counts=band_counts,
+    )
+
+
+def evaluate_instrumentation(
+    snapshot: InstrumentationInput, *, input_hash: str
+) -> SessionRecord:
+    """Evaluate frozen shadow arms without contacting any runtime surface."""
+
+    candidate_records: list[CandidateInstrumentationRecord] = []
+    arm_shadow_counts: dict[Literal["A40", "B30", "C25"], int] = {
+        "A40": 0,
+        "B30": 0,
+        "C25": 0,
+    }
+    for candidate in snapshot.candidates:
+        upside_pct = _upside_pct(candidate)
+        final_discount_pct = _final_discount_pct(candidate)
+        arm_results = tuple(
+            _evaluate_arm(
+                candidate,
+                arm,
+                upside_pct=upside_pct,
+                final_discount_pct=final_discount_pct,
+            )
+            for arm in FROZEN_ARMS
+        )
+        for result in arm_results:
+            if result.would_select:
+                arm_shadow_counts[result.arm_id] += 1
+        candidate_records.append(
+            CandidateInstrumentationRecord(
+                **candidate.model_dump(),
+                upside_pct=upside_pct,
+                support_distance_pct=_support_distance_pct(candidate),
+                independent_support_family_count=_family_count(candidate),
+                final_discount_from_current_pct=final_discount_pct,
+                arithmetic_limit_basis_upside_pct=(
+                    _arithmetic_limit_basis_upside_pct(candidate)
+                ),
+                arm_results=arm_results,
+            )
+        )
+
+    coverage = _coverage_summary(snapshot)
+    return SessionRecord(
+        session_id=snapshot.session_id,
+        contract_sha=snapshot.contract_sha,
+        policy_sha=snapshot.policy_sha,
+        code_sha=snapshot.code_sha,
+        source_corpus_as_of=snapshot.source_corpus_as_of,
+        decision_cutoff=snapshot.decision_cutoff,
+        universe_hash=snapshot.universe_hash,
+        input_hash=input_hash,
+        frozen_arms=FROZEN_ARMS,
+        sources=snapshot.sources,
+        candidates=tuple(candidate_records),
+        arm_shadow_counts=arm_shadow_counts,
+        coverage=coverage,
+        interpretation=_interpret_session(candidate_records, coverage),
+        read_only_safety=ReadOnlySafety(),
+    )
+
+
+def append_session_jsonl(path: Path, record: SessionRecord) -> None:
+    """Append one local log record to an explicitly selected output path."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as artifact:
+        artifact.write(
+            json.dumps(
+                record.model_dump(mode="json"), ensure_ascii=False, sort_keys=True
+            )
+        )
+        artifact.write("\n")
+
+
+def load_session_jsonl(path: Path) -> tuple[SessionRecord, ...]:
+    """Load the local records used for the fixed three-session reading."""
+
+    records: list[SessionRecord] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            records.append(SessionRecord.model_validate_json(line))
+    return tuple(records)
+
+
+def read_three_completed_sessions(
+    records: Sequence[SessionRecord],
+) -> ThreeSessionReading:
+    """Apply the fixed post-three-session guard without exposing a tuning action."""
+
+    if len(records) != 3:
+        raise ValueError("exactly three completed session records are required")
+    if len({record.contract_sha for record in records}) != 1:
+        raise ValueError("three-session reading requires one frozen contract_sha")
+    if len({record.policy_sha for record in records}) != 1:
+        raise ValueError("three-session reading requires one policy_sha")
+    if len({record.code_sha for record in records}) != 1:
+        raise ValueError("three-session reading requires one code_sha")
+
+    counts = {
+        arm_id: sum(record.arm_shadow_counts[arm_id] for record in records)
+        for arm_id in ("A40", "B30", "C25")
+    }
+    next_step: Literal[
+        "diagnose_target_coverage_or_support_source_contract",
+        "continue_bounded_cohort_reading_without_tuning",
+    ]
+    if counts["B30"] == 0 and counts["C25"] == 0:
+        next_step = "diagnose_target_coverage_or_support_source_contract"
+    else:
+        next_step = "continue_bounded_cohort_reading_without_tuning"
+    return ThreeSessionReading(
+        session_ids=(
+            records[0].session_id,
+            records[1].session_id,
+            records[2].session_id,
+        ),
+        a40_shadow_count=counts["A40"],
+        b30_shadow_count=counts["B30"],
+        c25_shadow_count=counts["C25"],
+        next_step=next_step,
+    )

--- a/docs/runbooks/us-upside-shadow-instrumentation.md
+++ b/docs/runbooks/us-upside-shadow-instrumentation.md
@@ -1,0 +1,218 @@
+# US upside shadow instrumentation
+
+This is a manual, read-only logging contract for three consecutive completed
+US regular sessions. It does not collect sources itself and it does not call a
+broker or account, create a proposal, alter eligibility, write a database,
+register a scheduler, deploy anything, or modify a production policy.
+
+The controlling contract is §Q4 of
+`/Users/mgh3326/work/herdr-inbox/answer-codexmock-upside-0814.md`.
+Its frozen SHA-256 is
+`2b8044a1cc39fbd830f68a3253ebdb20db987f2d9f76763edec8a2e3af3a5fe6`.
+
+## Frozen arms
+
+Before the first observation, the implementation freezes exactly these shadow
+arms:
+
+```text
+A40 = current 40% path
+B30 = 30% + strong + 3-family + final distance 12–15%
+C25 = 25% + strong + 3-family + final distance 11–15% (diagnostic only)
+```
+
+`app/services/us_upside_instrumentation.py::FROZEN_ARMS` is the only arm
+definition. The CLI has no arm, threshold, distance, or policy override. Each
+result is a `would_select` counterfactual and contributes only to an
+`arm_shadow_counts` number; `read_only_safety` is fixed at zero for every
+runtime-facing count.
+
+## Input and persisted record
+
+The upstream capture is JSON validated by `InstrumentationInput`. It must
+include the following required decision-time fields. A nullable field is still
+present in the JSON when its value is not known.
+
+| Required §Q4 evidence | Input / log field | Implementation location |
+| --- | --- | --- |
+| Contract, policy, and code SHA | `contract_sha`, `policy_sha`, `code_sha` | `InstrumentationInput`, `SessionRecord` |
+| Corpus as-of, decision cutoff, universe/input hashes | `source_corpus_as_of`, `decision_cutoff`, `universe_hash`, derived `input_hash` | `InstrumentationInput`, CLI `_load_snapshot` |
+| Per-source upstream known/unknown total, returned, timeout/error, outside top-N, deduped unique | `sources[*].upstream_total_known`, `upstream_total_unknown`, `returned_count`, `timeout_or_error_count`, `outside_top_n_count`, `deduped_unique_count` | `SourceCoverage` |
+| Explicit unqueried count | `sources[*].unqueried_count` | `SourceCoverage` / `CoverageSummary` |
+| Matched source IDs and ranks | `candidates[*].matched_sources[*].source_id`, `rank` | `MatchedSource` |
+| Fresh/stale/unknown and target evidence | `freshness`, `consensus_status`, `target_honesty`, `target_as_of`, `analyst_count` | `CandidateSnapshot` |
+| Current price, target, upside, RSI | `current_price`, `target`, derived `upside_pct`, `rsi` | `CandidateSnapshot`, `CandidateInstrumentationRecord` |
+| Support price, strength, independent families, distance | `support_price`, `support_strength`, `independent_support_families`, derived `support_distance_pct` | `CandidateSnapshot`, `CandidateInstrumentationRecord` |
+| Limit, tick treatment, final discount, arithmetic limit-basis upside | `proposed_limit`, `tick_handling`, derived `final_discount_from_current_pct`, `arithmetic_limit_basis_upside_pct` | `TickHandling`, `CandidateInstrumentationRecord` |
+| Exact gate bits and reject reasons per arm | `arm_results[*].gate_bits`, `reject_reasons` | `_evaluate_arm` / `ArmGateResult` |
+| Sector/dedupe/cash/whole-share feasibility, would-size/cash, would-select | `feasibility`, `arm_results[*].would_select` | `Feasibility` / `_evaluate_arm` |
+| Optional following-session high/low touch observation | `hypothetical_limit_touch` | `HypotheticalLimitTouch` |
+
+`SourceCoverage` is intentionally strict: a source must say whether its total
+is known, and it must always provide numeric timeout/error, unqueried, and
+outside-top-N counts. A top-N cap is represented by `top_n_cap`; when absent,
+`outside_top_n_count` must be zero. This makes bounded scope visible instead
+of silently dropping it.
+
+`hypothetical_limit_touch` is an always-present nullable field; its object is
+optional and is an observation only. When present it has `next_session_high`,
+`next_session_low`, and `limit_touched`; it is never a trading or performance
+result.
+
+### Capture JSON shape
+
+The input is one JSON object, not JSONL. This abbreviated valid shape shows
+where an explicit unknown is represented as `null` plus its state flag rather
+than omitted:
+
+```json
+{
+  "session_id": "2026-08-14-rth",
+  "contract_sha": "2b8044a1cc39fbd830f68a3253ebdb20db987f2d9f76763edec8a2e3af3a5fe6",
+  "policy_sha": "<sha256>",
+  "code_sha": "<git-commit-sha>",
+  "source_corpus_as_of": "2026-08-14T22:35:00+09:00",
+  "decision_cutoff": "2026-08-14T22:35:00+09:00",
+  "universe_hash": "<sha256>",
+  "sources": [
+    {
+      "source_id": "upstream-source",
+      "upstream_total_known": 10,
+      "upstream_total_unknown": false,
+      "returned_count": 3,
+      "timeout_or_error_count": 0,
+      "unqueried_count": 0,
+      "top_n_cap": 3,
+      "outside_top_n_count": 7,
+      "deduped_unique_count": 2
+    }
+  ],
+  "candidates": [
+    {
+      "symbol": "EXAMPLE",
+      "matched_sources": [{"source_id": "upstream-source", "rank": 1}],
+      "freshness": "fresh",
+      "consensus_status": "value",
+      "target_honesty": "honest",
+      "target_as_of": "2026-08-14T22:30:00+09:00",
+      "analyst_count": 4,
+      "current_price": 100.0,
+      "target": 130.0,
+      "rsi": 42.0,
+      "support_price": 90.0,
+      "support_strength": "strong",
+      "independent_support_families": ["price", "volume", "trend"],
+      "non_upside_gate_bits": {"source": "pass", "freshness": "pass"},
+      "proposed_limit": 87.0,
+      "tick_handling": {
+        "rule": "upstream tick rule",
+        "raw_limit": 87.004,
+        "snapped_limit": 87.0,
+        "direction": "down"
+      },
+      "feasibility": {
+        "sector": "Example",
+        "sector_feasibility": "pass",
+        "dedupe_feasibility": "pass",
+        "cash_feasibility": "pass",
+        "whole_share_feasibility": "pass",
+        "would_size": 1.0,
+        "required_cash": 87.0
+      },
+      "hypothetical_limit_touch": null
+    }
+  ]
+}
+```
+
+`policy_sha`, `code_sha`, and `universe_hash` above are placeholders only in
+the documentation. A real capture must use their exact decision-time values.
+
+## Fixed reading rules
+
+`_interpret_session` and `read_three_completed_sessions` encode these rules;
+the tests cover their decision branches.
+
+1. If `passes_all_non_upside_gates > 0`, every survivor consensus state is
+   `value`, `missing`, `stale`, or `error`, no timeout remains, `>=40` is zero,
+   and `25~40` is positive, the only conclusion is that upside is the dominant
+   constraint in that bounded cohort.
+2. If there are zero survivors before the upside check, the constraint is an
+   earlier source, freshness, support, or other declared non-upside gate.
+3. Any timeout, unqueried state, or unknown coverage produces
+   `coverage_insufficient_no_threshold_conclusion`; it does not answer a
+   threshold question.
+4. A larger unique-fresh result from source fan-out is not evidence of
+   performance or alpha. The record therefore fixes
+   `fanout_performance_or_alpha_inferred=false`.
+5. Once exactly three sessions are read, zero B30 and C25 counts lead only to
+   `diagnose_target_coverage_or_support_source_contract`; the reader has no
+   below-25 action or threshold-change output.
+
+## Manual three-session procedure
+
+The authorized executor is the US session's upstream read-only
+consumer/operator. This job supplies the validator and logger only; it does
+not perform the collection. Start with the 22:35 KST US session tonight and
+repeat once per next two completed US regular sessions.
+
+1. At the declared decision cutoff, the upstream executor creates one bounded
+   source snapshot under an operator-owned directory, for example
+   `/Users/mgh3326/work/us-upside-captures/20260814-2235.json`. The upstream
+   process must be read-only. It must populate every source census field,
+   every candidate field in the table above, and the three SHA fields.
+2. Before recording, verify the contract and capture provenance without
+   changing anything:
+
+   ```bash
+   shasum -a 256 /Users/mgh3326/work/herdr-inbox/answer-codexmock-upside-0814.md
+   git rev-parse HEAD
+   shasum -a 256 config/trading_policy.yaml
+   ```
+
+   Put the exact values into `contract_sha`, `code_sha`, and `policy_sha` in
+   the snapshot. `contract_sha` must equal the frozen full SHA above.
+3. Record the snapshot after its regular-session capture is complete. No
+   environment variable is required or read by this command; do not arm an
+   execution environment.
+
+   ```bash
+   uv run python -m scripts.run_us_upside_instrumentation record \
+     --input /Users/mgh3326/work/us-upside-captures/20260814-2235.json \
+     --output /Users/mgh3326/work/us-upside-captures/us-upside-shadow.jsonl
+   ```
+
+   The only write is the explicitly named local JSONL output. Save its stdout
+   next to the session evidence.
+4. Stop the collection immediately if a required JSON field, SHA, source
+   count, cap count, or validation result is absent or malformed. If a source
+   genuinely has an unknown total, timeout/error count, or unqueried count,
+   record that state explicitly instead of substituting a value; the log will
+   then be coverage-insufficient and must not be used to infer a threshold.
+5. Do not add following-session high/low data until it exists. If it is later
+   available, it may be captured as `hypothetical_limit_touch` in a subsequent
+   immutable observation record. Do not turn that observation into an
+   execution or performance claim.
+6. After exactly three completed session records exist, run the fixed reader:
+
+   ```bash
+   uv run python -m scripts.run_us_upside_instrumentation read-three \
+     --records /Users/mgh3326/work/us-upside-captures/us-upside-shadow.jsonl
+   ```
+
+   Read each session with Rules 1–4, then use the three-session output only
+   for Rule 5. The reader requires one contract, policy, and code SHA across
+   all three records. Never use candidate counts or touch observations to
+   choose a threshold.
+
+## Stop conditions and scope boundary
+
+- A validation error, contract SHA mismatch, missing cap census, invalid
+  JSONL, source access failure, or any attempted connection to a runtime
+  mutation surface is a stop condition.
+- An explicit unknown/timeout/unqueried state is not silently repaired; it is
+  recorded and makes the threshold conclusion unavailable.
+- The command accepts no credentials and has no broker/account, proposal,
+  eligibility, database, scheduler, deployment, or production-policy path.
+- The US collection must not be implemented by extending the KR-only fan-out
+  surface.

--- a/docs/runbooks/us-upside-shadow-instrumentation.md
+++ b/docs/runbooks/us-upside-shadow-instrumentation.md
@@ -268,6 +268,7 @@ repeat once per next two completed US regular sessions.
    including `cross_source_duplicate_count` and any candidate-array
    cap/loss/reason; every recorded candidate field in the table above; and the
    three SHA fields.
+   `duplicate_count` 는 동일 심볼 반복만 센다. 숫자를 맞추기 위해 잔여를 중복으로 쓰지 마라. 설명 불가면 record 를 쓰지 마라.
 2. Before recording, verify the contract and capture provenance without
    changing anything:
 

--- a/docs/runbooks/us-upside-shadow-instrumentation.md
+++ b/docs/runbooks/us-upside-shadow-instrumentation.md
@@ -37,8 +37,9 @@ present in the JSON when its value is not known.
 | --- | --- | --- |
 | Contract, policy, and code SHA | `contract_sha`, `policy_sha`, `code_sha` | `InstrumentationInput`, `SessionRecord` |
 | Corpus as-of, decision cutoff, universe/input hashes | `source_corpus_as_of`, `decision_cutoff`, `universe_hash`, derived `input_hash` | `InstrumentationInput`, CLI `_load_snapshot` |
-| Per-source upstream known/unknown total, returned, timeout/error, outside top-N, deduped unique | `sources[*].upstream_total_known`, `upstream_total_unknown`, `returned_count`, `timeout_or_error_count`, `outside_top_n_count`, `deduped_unique_count` | `SourceCoverage` |
+| Per-source upstream known/unknown total, returned, timeout/error, top-N cap/outside, deduped unique | `sources[*].upstream_total_known`, `upstream_total_unknown`, `returned_count`, `timeout_or_error_count`, `unqueried_count`, `top_n_cap`, `outside_top_n_count`, `deduped_unique_count` | `SourceCoverage` |
 | Explicit unqueried count | `sources[*].unqueried_count` | `SourceCoverage` / `CoverageSummary` |
+| Global post-dedupe candidate census and candidate-array truncation | `candidate_array_coverage.deduped_unique_count`, `recorded_candidate_count`, `truncated_candidate_count`, `candidate_array_cap`, `candidate_truncation_reason` | `CandidateArrayCoverage`, `CoverageSummary` |
 | Matched source IDs and ranks | `candidates[*].matched_sources[*].source_id`, `rank` | `MatchedSource` |
 | Fresh/stale/unknown and target evidence | `freshness`, `consensus_status`, `target_honesty`, `target_as_of`, `analyst_count` | `CandidateSnapshot` |
 | Current price, target, upside, RSI | `current_price`, `target`, derived `upside_pct`, `rsi` | `CandidateSnapshot`, `CandidateInstrumentationRecord` |
@@ -50,9 +51,20 @@ present in the JSON when its value is not known.
 
 `SourceCoverage` is intentionally strict: a source must say whether its total
 is known, and it must always provide numeric timeout/error, unqueried, and
-outside-top-N counts. A top-N cap is represented by `top_n_cap`; when absent,
-`outside_top_n_count` must be zero. This makes bounded scope visible instead
-of silently dropping it.
+outside-top-N counts. When the upstream total is known, it must equal
+`returned_count + timeout_or_error_count + unqueried_count +
+outside_top_n_count`; those loss categories are therefore disjoint and no
+bounded-read remainder can disappear. A top-N cap is represented by
+`top_n_cap`; when absent, `outside_top_n_count` must be zero.
+
+`CandidateArrayCoverage` performs the same explicit accounting after global
+dedupe: `deduped_unique_count` must equal `recorded_candidate_count +
+truncated_candidate_count`. A positive truncation count requires both the
+candidate-array cap and a non-empty reason. Any nonzero top-N-outside or
+candidate-array-truncated count makes `coverage_complete=false`.
+
+Every matched source object must include `rank`; use `null` when an upstream
+source cannot provide a rank rather than omitting the field.
 
 `hypothetical_limit_touch` is an always-present nullable field; its object is
 optional and is an observation only. When present it has `next_session_high`,
@@ -87,6 +99,13 @@ than omitted:
       "deduped_unique_count": 2
     }
   ],
+  "candidate_array_coverage": {
+    "deduped_unique_count": 2,
+    "recorded_candidate_count": 1,
+    "truncated_candidate_count": 1,
+    "candidate_array_cap": 1,
+    "candidate_truncation_reason": "bounded_candidate_array"
+  },
   "candidates": [
     {
       "symbol": "EXAMPLE",
@@ -128,10 +147,41 @@ than omitted:
 `policy_sha`, `code_sha`, and `universe_hash` above are placeholders only in
 the documentation. A real capture must use their exact decision-time values.
 
+### Capped top-N example: required coverage result
+
+`tests/fixtures/us_upside_instrumentation/runbook_top_n_capped_capture.json`
+is an executable example with `upstream_total_known=10`, `top_n_cap=3`,
+`returned_count=3`, and `outside_top_n_count=7`. Run it from the repository
+root with a disposable local path:
+
+```bash
+uv run python -m scripts.run_us_upside_instrumentation record \
+  --input tests/fixtures/us_upside_instrumentation/runbook_top_n_capped_capture.json \
+  --output /tmp/us-upside-top-n-capped.jsonl
+```
+
+Its stdout must contain `"coverage_complete": false` and
+`coverage_insufficient_no_threshold_conclusion`. The seven records outside
+the top-N bound must never yield a threshold conclusion.
+
 ## Fixed reading rules
 
 `_interpret_session` and `read_three_completed_sessions` encode these rules;
 the tests cover their decision branches.
+
+The frozen §Q4 wording is retained here without a threshold-change action:
+
+```text
+1. `passes_all_non_upside_gates > 0` 이고, 그 집합의 consensus 상태가 모두 value/missing/stale/error
+   로 종결됐고 timeout 이 없는데 `>=40 == 0` 이며 `25~40 > 0` 이면
+   → 해당 bounded cohort 에서 upside 가 지배 제약이다
+2. upside 전에 survivors 가 0 이면 지배 제약은 source·freshness·support 등 앞단이다
+3. 40/99 처럼 timeout·미조회·unknown 이 남으면 coverage 불충분이며 threshold 에 관해 모름이다
+4. FAN-OUT 으로 unique fresh 후보가 늘어도 성과나 alpha 가 개선됐다는 뜻은 아니다
+5. 3세션 뒤 B/C 가 0 이어도 25 아래로 더 내리지 않는다 — target coverage 나 support-source
+   계약을 먼저 진단한다
+3세션 후보 수나 hypothetical touch 로 threshold 를 튜닝하지 마라
+```
 
 1. If `passes_all_non_upside_gates > 0`, every survivor consensus state is
    `value`, `missing`, `stale`, or `error`, no timeout remains, `>=40` is zero,
@@ -139,15 +189,33 @@ the tests cover their decision branches.
    constraint in that bounded cohort.
 2. If there are zero survivors before the upside check, the constraint is an
    earlier source, freshness, support, or other declared non-upside gate.
-3. Any timeout, unqueried state, or unknown coverage produces
+3. Any timeout, unqueried state, unknown coverage, top-N-outside count, or
+   candidate-array truncation produces
    `coverage_insufficient_no_threshold_conclusion`; it does not answer a
-   threshold question.
+   threshold question. In the three-session reader, one incomplete session
+   produces the same result for the aggregate: no upside-dominant or
+   non-dominant conclusion is available.
 4. A larger unique-fresh result from source fan-out is not evidence of
    performance or alpha. The record therefore fixes
    `fanout_performance_or_alpha_inferred=false`.
 5. Once exactly three sessions are read, zero B30 and C25 counts lead only to
    `diagnose_target_coverage_or_support_source_contract`; the reader has no
    below-25 action or threshold-change output.
+
+## Truncation and coverage census
+
+Every bounded-read or aggregation loss point is declared below. A capture or
+reading with any unaccounted point is rejected or remains
+coverage-insufficient; none is treated as a complete cohort.
+
+| Boundary | Required numeric / state record | Enforcement | Coverage effect |
+| --- | --- | --- | --- |
+| Upstream collection outside this repository | `upstream_total_known` or `upstream_total_unknown` for every source | `SourceCoverage` requires exactly one state | Unknown total makes coverage incomplete |
+| Per-source top-N bound | `top_n_cap`, `outside_top_n_count` | Known totals must account for every record; no cap permits no outside count | Any outside count makes coverage incomplete |
+| Post-dedupe candidate array | `deduped_unique_count`, `recorded_candidate_count`, `truncated_candidate_count`, `candidate_array_cap`, `candidate_truncation_reason` | `CandidateArrayCoverage` requires exact accounting, cap, and reason | Any truncation makes coverage incomplete |
+| Timeout or error | `timeout_or_error_count` | Required per source and aggregated in `CoverageSummary` | Any count makes coverage incomplete |
+| Not queried | `unqueried_count` | Required per source and aggregated in `CoverageSummary` | Any count makes coverage incomplete |
+| Three-session aggregate | `session_coverage[*]`, `all_sessions_coverage_complete` | `read_three_completed_sessions` carries every session's coverage state | One incomplete session terminates as coverage-insufficient |
 
 ## Manual three-session procedure
 
@@ -160,7 +228,9 @@ repeat once per next two completed US regular sessions.
    source snapshot under an operator-owned directory, for example
    `/Users/mgh3326/work/us-upside-captures/20260814-2235.json`. The upstream
    process must be read-only. It must populate every source census field,
-   every candidate field in the table above, and the three SHA fields.
+   the global post-dedupe candidate census (including any candidate-array
+   cap/loss/reason), every recorded candidate field in the table above, and
+   the three SHA fields.
 2. Before recording, verify the contract and capture provenance without
    changing anything:
 
@@ -185,10 +255,12 @@ repeat once per next two completed US regular sessions.
    The only write is the explicitly named local JSONL output. Save its stdout
    next to the session evidence.
 4. Stop the collection immediately if a required JSON field, SHA, source
-   count, cap count, or validation result is absent or malformed. If a source
-   genuinely has an unknown total, timeout/error count, or unqueried count,
-   record that state explicitly instead of substituting a value; the log will
-   then be coverage-insufficient and must not be used to infer a threshold.
+   count, top-N count, candidate-array count, cap, truncation reason, or
+   validation result is absent or malformed. If a source genuinely has an
+   unknown total, timeout/error count, unqueried count, top-N-outside count,
+   or candidate-array truncation, record that state explicitly instead of
+   substituting a value; the log will then be coverage-insufficient and must
+   not be used to infer a threshold.
 5. Do not add following-session high/low data until it exists. If it is later
    available, it may be captured as `hypothetical_limit_touch` in a subsequent
    immutable observation record. Do not turn that observation into an
@@ -202,16 +274,24 @@ repeat once per next two completed US regular sessions.
 
    Read each session with Rules 1–4, then use the three-session output only
    for Rule 5. The reader requires one contract, policy, and code SHA across
-   all three records. Never use candidate counts or touch observations to
-   choose a threshold.
+   all three records. If even one session reports incomplete coverage, the
+   aggregate terminates as `coverage_insufficient_no_threshold_conclusion`.
+   Never use candidate counts or touch observations to choose a threshold.
+
+   Keep exactly one line per distinct `session_id` in this artifact. The
+   recorder rejects a duplicate `session_id`; if an input correction is
+   needed, preserve the first artifact and use a new explicitly named output
+   for the corrected observation. `read-three` deliberately rejects any file
+   with a count other than three rather than selecting lines silently.
 
 ## Stop conditions and scope boundary
 
-- A validation error, contract SHA mismatch, missing cap census, invalid
-  JSONL, source access failure, or any attempted connection to a runtime
-  mutation surface is a stop condition.
-- An explicit unknown/timeout/unqueried state is not silently repaired; it is
-  recorded and makes the threshold conclusion unavailable.
+- A validation error, contract SHA mismatch, missing top-N or candidate-array
+  census, invalid JSONL, source access failure, or any attempted connection to
+  a runtime mutation surface is a stop condition.
+- An explicit unknown/timeout/unqueried/top-N-outside/candidate-array-loss
+  state is not silently repaired; it is recorded and makes the threshold
+  conclusion unavailable.
 - The command accepts no credentials and has no broker/account, proposal,
   eligibility, database, scheduler, deployment, or production-policy path.
 - The US collection must not be implemented by extending the KR-only fan-out

--- a/docs/runbooks/us-upside-shadow-instrumentation.md
+++ b/docs/runbooks/us-upside-shadow-instrumentation.md
@@ -37,9 +37,9 @@ present in the JSON when its value is not known.
 | --- | --- | --- |
 | Contract, policy, and code SHA | `contract_sha`, `policy_sha`, `code_sha` | `InstrumentationInput`, `SessionRecord` |
 | Corpus as-of, decision cutoff, universe/input hashes | `source_corpus_as_of`, `decision_cutoff`, `universe_hash`, derived `input_hash` | `InstrumentationInput`, CLI `_load_snapshot` |
-| Per-source upstream known/unknown total, returned, timeout/error, top-N cap/outside, deduped unique | `sources[*].upstream_total_known`, `upstream_total_unknown`, `returned_count`, `timeout_or_error_count`, `unqueried_count`, `top_n_cap`, `outside_top_n_count`, `deduped_unique_count` | `SourceCoverage` |
+| Per-source upstream known/unknown total, returned, timeout/error, top-N cap/outside, deduped unique, declared duplicates | `sources[*].upstream_total_known`, `upstream_total_unknown`, `returned_count`, `timeout_or_error_count`, `unqueried_count`, `top_n_cap`, `outside_top_n_count`, `deduped_unique_count`, `duplicate_count` | `SourceCoverage` |
 | Explicit unqueried count | `sources[*].unqueried_count` | `SourceCoverage` / `CoverageSummary` |
-| Global post-dedupe candidate census and candidate-array truncation | `candidate_array_coverage.deduped_unique_count`, `recorded_candidate_count`, `truncated_candidate_count`, `candidate_array_cap`, `candidate_truncation_reason` | `CandidateArrayCoverage`, `CoverageSummary` |
+| Global post-dedupe candidate census, declared cross-source duplicates, and candidate-array truncation | `candidate_array_coverage.deduped_unique_count`, `cross_source_duplicate_count`, `recorded_candidate_count`, `truncated_candidate_count`, `candidate_array_cap`, `candidate_truncation_reason` | `CandidateArrayCoverage`, `CoverageSummary` |
 | Matched source IDs and ranks | `candidates[*].matched_sources[*].source_id`, `rank` | `MatchedSource` |
 | Fresh/stale/unknown and target evidence | `freshness`, `consensus_status`, `target_honesty`, `target_as_of`, `analyst_count` | `CandidateSnapshot` |
 | Current price, target, upside, RSI | `current_price`, `target`, derived `upside_pct`, `rsi` | `CandidateSnapshot`, `CandidateInstrumentationRecord` |
@@ -57,11 +57,24 @@ outside_top_n_count`; those loss categories are therefore disjoint and no
 bounded-read remainder can disappear. A top-N cap is represented by
 `top_n_cap`; when absent, `outside_top_n_count` must be zero.
 
+The next source boundary is also explicit:
+`returned_count == deduped_unique_count + duplicate_count`. A missing or
+mismatched `duplicate_count` is rejected as coverage-insufficient before a
+session record or threshold conclusion can be emitted. This count represents
+only source rows verified as duplicates; it is not a place to conceal a bound.
+
 `CandidateArrayCoverage` performs the same explicit accounting after global
 dedupe: `deduped_unique_count` must equal `recorded_candidate_count +
 truncated_candidate_count`. A positive truncation count requires both the
 candidate-array cap and a non-empty reason. Any nonzero top-N-outside or
 candidate-array-truncated count makes `coverage_complete=false`.
+
+The global union boundary is explicit as well. Across all sources,
+`sum(deduped_unique_count) == global deduped_unique_count +
+cross_source_duplicate_count`, and the global count must be at least the
+largest one-source unique count. A missing or inconsistent cross-source count
+is rejected as coverage-insufficient before a session record or threshold
+conclusion can be emitted.
 
 Every matched source object must include `rank`; use `null` when an upstream
 source cannot provide a rank rather than omitting the field.
@@ -96,11 +109,13 @@ than omitted:
       "unqueried_count": 0,
       "top_n_cap": 3,
       "outside_top_n_count": 7,
-      "deduped_unique_count": 2
+      "deduped_unique_count": 2,
+      "duplicate_count": 1
     }
   ],
   "candidate_array_coverage": {
     "deduped_unique_count": 2,
+    "cross_source_duplicate_count": 0,
     "recorded_candidate_count": 1,
     "truncated_candidate_count": 1,
     "candidate_array_cap": 1,
@@ -164,6 +179,22 @@ Its stdout must contain `"coverage_complete": false` and
 `coverage_insufficient_no_threshold_conclusion`. The seven records outside
 the top-N bound must never yield a threshold conclusion.
 
+### Coverage-complete example
+
+`tests/fixtures/us_upside_instrumentation/runbook_coverage_complete_capture.json`
+is the separate complete-census example: one returned row, one source unique,
+zero source duplicates, zero cross-source duplicates, and no candidate-array
+truncation. Run it with a separate disposable path:
+
+```bash
+uv run python -m scripts.run_us_upside_instrumentation record \
+  --input tests/fixtures/us_upside_instrumentation/runbook_coverage_complete_capture.json \
+  --output /tmp/us-upside-coverage-complete.jsonl
+```
+
+Its stdout contains `"coverage_complete": true`; its bounded reading is not a
+performance claim and cannot change a threshold.
+
 ## Fixed reading rules
 
 `_interpret_session` and `read_three_completed_sessions` encode these rules;
@@ -189,12 +220,14 @@ The frozen §Q4 wording is retained here without a threshold-change action:
    constraint in that bounded cohort.
 2. If there are zero survivors before the upside check, the constraint is an
    earlier source, freshness, support, or other declared non-upside gate.
-3. Any timeout, unqueried state, unknown coverage, top-N-outside count, or
-   candidate-array truncation produces
+3. Any timeout, unqueried state, unknown coverage, top-N-outside count,
+   source/global dedupe-census mismatch, or candidate-array truncation produces
    `coverage_insufficient_no_threshold_conclusion`; it does not answer a
    threshold question. In the three-session reader, one incomplete session
    produces the same result for the aggregate: no upside-dominant or
-   non-dominant conclusion is available.
+   non-dominant conclusion is available. A dedupe-census mismatch is rejected
+   before it can produce a session verdict, which is the same fail-closed
+   outcome.
 4. A larger unique-fresh result from source fan-out is not evidence of
    performance or alpha. The record therefore fixes
    `fanout_performance_or_alpha_inferred=false`.
@@ -208,14 +241,17 @@ Every bounded-read or aggregation loss point is declared below. A capture or
 reading with any unaccounted point is rejected or remains
 coverage-insufficient; none is treated as a complete cohort.
 
-| Boundary | Required numeric / state record | Enforcement | Coverage effect |
+| Boundary | Required numeric / state record | Arithmetic enforcement | Verdict effect |
 | --- | --- | --- | --- |
 | Upstream collection outside this repository | `upstream_total_known` or `upstream_total_unknown` for every source | `SourceCoverage` requires exactly one state | Unknown total makes coverage incomplete |
-| Per-source top-N bound | `top_n_cap`, `outside_top_n_count` | Known totals must account for every record; no cap permits no outside count | Any outside count makes coverage incomplete |
-| Post-dedupe candidate array | `deduped_unique_count`, `recorded_candidate_count`, `truncated_candidate_count`, `candidate_array_cap`, `candidate_truncation_reason` | `CandidateArrayCoverage` requires exact accounting, cap, and reason | Any truncation makes coverage incomplete |
+| Per-source top-N bound | `top_n_cap`, `outside_top_n_count` | Known total equals returned + timeout/error + unqueried + outside top-N | Any outside count makes coverage incomplete |
+| L1: returned to source unique | `returned_count`, `deduped_unique_count`, `duplicate_count` | `returned == unique + duplicate` | Missing/mismatch is rejected as coverage-insufficient before a verdict |
+| L2: source unique to global unique | per-source `deduped_unique_count`, global `deduped_unique_count`, `cross_source_duplicate_count` | `sum(source unique) == global unique + cross-source duplicate` and `global >= max(source unique)` | Missing/mismatch is rejected as coverage-insufficient before a verdict |
+| L3: global unique to recorded candidates | `deduped_unique_count`, `recorded_candidate_count`, `truncated_candidate_count`, `candidate_array_cap`, `candidate_truncation_reason` | `global unique == recorded + truncated`; positive truncation requires cap and reason | Any truncation makes coverage incomplete |
+| L4: recorded candidates to serialized array | `recorded_candidate_count`, `candidates` | declared recorded count equals array length | Mismatch is rejected before a verdict |
 | Timeout or error | `timeout_or_error_count` | Required per source and aggregated in `CoverageSummary` | Any count makes coverage incomplete |
 | Not queried | `unqueried_count` | Required per source and aggregated in `CoverageSummary` | Any count makes coverage incomplete |
-| Three-session aggregate | `session_coverage[*]`, `all_sessions_coverage_complete` | `read_three_completed_sessions` carries every session's coverage state | One incomplete session terminates as coverage-insufficient |
+| Three-session aggregate | `session_coverage[*]`, `all_sessions_coverage_complete` | reader recomputes each stored coverage flag from its counts | One incomplete session terminates as coverage-insufficient; a stored-flag mismatch is rejected |
 
 ## Manual three-session procedure
 
@@ -228,9 +264,10 @@ repeat once per next two completed US regular sessions.
    source snapshot under an operator-owned directory, for example
    `/Users/mgh3326/work/us-upside-captures/20260814-2235.json`. The upstream
    process must be read-only. It must populate every source census field,
-   the global post-dedupe candidate census (including any candidate-array
-   cap/loss/reason), every recorded candidate field in the table above, and
-   the three SHA fields.
+   including `duplicate_count`; the global post-dedupe candidate census,
+   including `cross_source_duplicate_count` and any candidate-array
+   cap/loss/reason; every recorded candidate field in the table above; and the
+   three SHA fields.
 2. Before recording, verify the contract and capture provenance without
    changing anything:
 
@@ -255,12 +292,13 @@ repeat once per next two completed US regular sessions.
    The only write is the explicitly named local JSONL output. Save its stdout
    next to the session evidence.
 4. Stop the collection immediately if a required JSON field, SHA, source
-   count, top-N count, candidate-array count, cap, truncation reason, or
-   validation result is absent or malformed. If a source genuinely has an
-   unknown total, timeout/error count, unqueried count, top-N-outside count,
-   or candidate-array truncation, record that state explicitly instead of
-   substituting a value; the log will then be coverage-insufficient and must
-   not be used to infer a threshold.
+   count, top-N count, duplicate count, cross-source duplicate count,
+   candidate-array count, cap, truncation reason, or validation result is
+   absent or malformed. Verify both dedupe equations in the census table. If a
+   source genuinely has an unknown total, timeout/error count, unqueried count,
+   top-N-outside count, dedupe-census mismatch, or candidate-array truncation,
+   record or stop on that state explicitly instead of substituting a value; it
+   is coverage-insufficient and must not be used to infer a threshold.
 5. Do not add following-session high/low data until it exists. If it is later
    available, it may be captured as `hypothetical_limit_touch` in a subsequent
    immutable observation record. Do not turn that observation into an
@@ -276,6 +314,8 @@ repeat once per next two completed US regular sessions.
    for Rule 5. The reader requires one contract, policy, and code SHA across
    all three records. If even one session reports incomplete coverage, the
    aggregate terminates as `coverage_insufficient_no_threshold_conclusion`.
+   The reader also rejects a stored `coverage_complete` value that does not
+   recompute from its saved counts. Never hand-edit that boolean.
    Never use candidate counts or touch observations to choose a threshold.
 
    Keep exactly one line per distinct `session_id` in this artifact. The
@@ -286,12 +326,14 @@ repeat once per next two completed US regular sessions.
 
 ## Stop conditions and scope boundary
 
-- A validation error, contract SHA mismatch, missing top-N or candidate-array
-  census, invalid JSONL, source access failure, or any attempted connection to
-  a runtime mutation surface is a stop condition.
-- An explicit unknown/timeout/unqueried/top-N-outside/candidate-array-loss
-  state is not silently repaired; it is recorded and makes the threshold
-  conclusion unavailable.
+- A validation error, contract SHA mismatch, missing top-N, source-duplicate,
+  cross-source-duplicate, or candidate-array census, invalid JSONL, source
+  access failure, or any attempted connection to a runtime mutation surface is
+  a stop condition.
+- An explicit unknown/timeout/unqueried/top-N-outside/dedupe-census-mismatch/
+  candidate-array-loss state is not silently repaired; it is recorded or
+  rejected as coverage-insufficient and makes the threshold conclusion
+  unavailable.
 - The command accepts no credentials and has no broker/account, proposal,
   eligibility, database, scheduler, deployment, or production-policy path.
 - The US collection must not be implemented by extending the KR-only fan-out

--- a/scripts/run_us_upside_instrumentation.py
+++ b/scripts/run_us_upside_instrumentation.py
@@ -1,0 +1,104 @@
+"""Manual CLI for the read-only US upside shadow-instrumentation contract.
+
+The command reads a captured JSON snapshot and appends an operator-selected
+local JSONL record. It has no source collection, broker, account, proposal,
+database, or scheduler behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from app.services.us_upside_instrumentation import (
+    InstrumentationInput,
+    append_session_jsonl,
+    evaluate_instrumentation,
+    load_session_jsonl,
+    read_three_completed_sessions,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Manual US upside shadow-instrumentation recorder"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    record = subparsers.add_parser(
+        "record",
+        help="Validate one captured bounded cohort and append one JSONL record.",
+    )
+    record.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Read-only captured bounded-cohort JSON.",
+    )
+    record.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Operator-selected local JSONL artifact.",
+    )
+
+    read_three = subparsers.add_parser(
+        "read-three",
+        help="Read exactly three completed records without changing any threshold.",
+    )
+    read_three.add_argument(
+        "--records",
+        type=Path,
+        required=True,
+        help="Three-line JSONL artifact produced by the record command.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_snapshot(path: Path) -> tuple[InstrumentationInput, str]:
+    raw = path.read_bytes()
+    return InstrumentationInput.model_validate_json(raw), hashlib.sha256(
+        raw
+    ).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "record":
+        snapshot, input_hash = _load_snapshot(args.input)
+        record = evaluate_instrumentation(snapshot, input_hash=input_hash)
+        append_session_jsonl(args.output, record)
+        print(
+            json.dumps(
+                {
+                    "session_id": record.session_id,
+                    "input_hash": record.input_hash,
+                    "arm_shadow_counts": record.arm_shadow_counts,
+                    "coverage_complete": record.coverage.coverage_complete,
+                    "interpretation": record.interpretation.conclusion,
+                    "read_only_safety": record.read_only_safety.model_dump(),
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    records = load_session_jsonl(args.records)
+    reading = read_three_completed_sessions(records)
+    print(
+        json.dumps(
+            reading.model_dump(mode="json"),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/us_upside_instrumentation/runbook_coverage_complete_capture.json
+++ b/tests/fixtures/us_upside_instrumentation/runbook_coverage_complete_capture.json
@@ -1,5 +1,5 @@
 {
-  "session_id": "2026-08-14-runbook-top-n-cap",
+  "session_id": "2026-08-14-runbook-coverage-complete",
   "contract_sha": "2b8044a1cc39fbd830f68a3253ebdb20db987f2d9f76763edec8a2e3af3a5fe6",
   "policy_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "code_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -9,15 +9,15 @@
   "sources": [
     {
       "source_id": "upstream-source",
-      "upstream_total_known": 10,
+      "upstream_total_known": 1,
       "upstream_total_unknown": false,
-      "returned_count": 3,
+      "returned_count": 1,
       "timeout_or_error_count": 0,
       "unqueried_count": 0,
-      "top_n_cap": 3,
-      "outside_top_n_count": 7,
+      "top_n_cap": null,
+      "outside_top_n_count": 0,
       "deduped_unique_count": 1,
-      "duplicate_count": 2
+      "duplicate_count": 0
     }
   ],
   "candidate_array_coverage": {

--- a/tests/fixtures/us_upside_instrumentation/runbook_top_n_capped_capture.json
+++ b/tests/fixtures/us_upside_instrumentation/runbook_top_n_capped_capture.json
@@ -1,0 +1,76 @@
+{
+  "session_id": "2026-08-14-runbook-top-n-cap",
+  "contract_sha": "2b8044a1cc39fbd830f68a3253ebdb20db987f2d9f76763edec8a2e3af3a5fe6",
+  "policy_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "code_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "source_corpus_as_of": "2026-08-14T22:35:00+09:00",
+  "decision_cutoff": "2026-08-14T22:35:00+09:00",
+  "universe_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "sources": [
+    {
+      "source_id": "upstream-source",
+      "upstream_total_known": 10,
+      "upstream_total_unknown": false,
+      "returned_count": 3,
+      "timeout_or_error_count": 0,
+      "unqueried_count": 0,
+      "top_n_cap": 3,
+      "outside_top_n_count": 7,
+      "deduped_unique_count": 1
+    }
+  ],
+  "candidate_array_coverage": {
+    "deduped_unique_count": 1,
+    "recorded_candidate_count": 1,
+    "truncated_candidate_count": 0,
+    "candidate_array_cap": null,
+    "candidate_truncation_reason": null
+  },
+  "candidates": [
+    {
+      "symbol": "EXAMPLE",
+      "matched_sources": [
+        {
+          "source_id": "upstream-source",
+          "rank": 1
+        }
+      ],
+      "freshness": "fresh",
+      "consensus_status": "value",
+      "target_honesty": "honest",
+      "target_as_of": "2026-08-14T22:30:00+09:00",
+      "analyst_count": 4,
+      "current_price": 100.0,
+      "target": 130.0,
+      "rsi": 42.0,
+      "support_price": 90.0,
+      "support_strength": "strong",
+      "independent_support_families": [
+        "price",
+        "volume",
+        "trend"
+      ],
+      "non_upside_gate_bits": {
+        "source": "pass",
+        "freshness": "pass"
+      },
+      "proposed_limit": 87.0,
+      "tick_handling": {
+        "rule": "upstream tick rule",
+        "raw_limit": 87.004,
+        "snapped_limit": 87.0,
+        "direction": "down"
+      },
+      "feasibility": {
+        "sector": "Example",
+        "sector_feasibility": "pass",
+        "dedupe_feasibility": "pass",
+        "cash_feasibility": "pass",
+        "whole_share_feasibility": "pass",
+        "would_size": 1.0,
+        "required_cash": 87.0
+      },
+      "hypothetical_limit_touch": null
+    }
+  ]
+}

--- a/tests/fixtures/us_upside_instrumentation/verify_r2_l1_reproduction.json
+++ b/tests/fixtures/us_upside_instrumentation/verify_r2_l1_reproduction.json
@@ -1,5 +1,5 @@
 {
-  "session_id": "2026-08-14-runbook-top-n-cap",
+  "session_id": "2026-08-14-verify-r2-l1",
   "contract_sha": "2b8044a1cc39fbd830f68a3253ebdb20db987f2d9f76763edec8a2e3af3a5fe6",
   "policy_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "code_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -9,15 +9,15 @@
   "sources": [
     {
       "source_id": "upstream-source",
-      "upstream_total_known": 10,
+      "upstream_total_known": 500,
       "upstream_total_unknown": false,
-      "returned_count": 3,
+      "returned_count": 500,
       "timeout_or_error_count": 0,
       "unqueried_count": 0,
-      "top_n_cap": 3,
-      "outside_top_n_count": 7,
+      "top_n_cap": 500,
+      "outside_top_n_count": 0,
       "deduped_unique_count": 1,
-      "duplicate_count": 2
+      "duplicate_count": 0
     }
   ],
   "candidate_array_coverage": {

--- a/tests/services/test_us_upside_instrumentation.py
+++ b/tests/services/test_us_upside_instrumentation.py
@@ -38,6 +38,7 @@ def _payload(*, session_id: str = "2026-08-14-rth") -> dict[str, object]:
                 "top_n_cap": None,
                 "outside_top_n_count": 0,
                 "deduped_unique_count": 1,
+                "duplicate_count": 0,
             },
             {
                 "source_id": "support-feed",
@@ -49,10 +50,12 @@ def _payload(*, session_id: str = "2026-08-14-rth") -> dict[str, object]:
                 "top_n_cap": None,
                 "outside_top_n_count": 0,
                 "deduped_unique_count": 1,
+                "duplicate_count": 0,
             },
         ],
         "candidate_array_coverage": {
             "deduped_unique_count": 1,
+            "cross_source_duplicate_count": 1,
             "recorded_candidate_count": 1,
             "truncated_candidate_count": 0,
             "candidate_array_cap": None,
@@ -190,9 +193,11 @@ def test_record_preserves_every_q4_field_and_is_read_only():
         "top_n_cap": None,
         "outside_top_n_count": 0,
         "deduped_unique_count": 1,
+        "duplicate_count": 0,
     }
     assert record.candidate_array_coverage.model_dump() == {
         "deduped_unique_count": 1,
+        "cross_source_duplicate_count": 1,
         "recorded_candidate_count": 1,
         "truncated_candidate_count": 0,
         "candidate_array_cap": None,
@@ -280,16 +285,20 @@ def test_serialized_jsonl_keeps_caps_and_hypothetical_touch_name(tmp_path: Path)
         "top_n_cap",
         "outside_top_n_count",
         "deduped_unique_count",
+        "duplicate_count",
     }
     assert "hypothetical_limit_touch" in payload["candidates"][0]
     assert payload["candidates"][0]["hypothetical_limit_touch"]["limit_touched"]
     assert payload["candidate_array_coverage"] == {
         "deduped_unique_count": 1,
+        "cross_source_duplicate_count": 1,
         "recorded_candidate_count": 1,
         "truncated_candidate_count": 0,
         "candidate_array_cap": None,
         "candidate_truncation_reason": None,
     }
+    assert payload["coverage"]["source_duplicate_count"] == 0
+    assert payload["coverage"]["cross_source_duplicate_count"] == 1
 
 
 def test_dominant_constraint_rule_is_bounded_and_never_a_tuning_signal():
@@ -387,6 +396,8 @@ def test_unknown_timeout_or_unqueried_coverage_has_no_threshold_conclusion():
         "timeout_or_error_count": 1,
         "unqueried_count": 2,
         "outside_top_n_count": 0,
+        "source_duplicate_count": 0,
+        "cross_source_duplicate_count": 1,
         "candidate_array_truncated_count": 0,
         "candidate_array_cap": None,
         "candidate_truncation_reason": None,
@@ -417,6 +428,174 @@ def test_missing_top_n_census_is_rejected_before_recording():
         InstrumentationInput.model_validate(payload)
 
 
+def test_missing_source_duplicate_census_is_rejected_before_recording():
+    payload = _payload()
+    source = payload["sources"][0]
+    assert isinstance(source, dict)
+    source.pop("duplicate_count")
+
+    with pytest.raises(ValidationError, match="duplicate_count"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_missing_cross_source_duplicate_census_is_rejected_before_recording():
+    payload = _payload()
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage.pop("cross_source_duplicate_count")
+
+    with pytest.raises(ValidationError, match="cross_source_duplicate_count"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_verify_r2_l1_reproduction_is_fail_closed_before_a_verdict():
+    payload = _payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    source = sources[0]
+    assert isinstance(source, dict)
+    source.update(
+        {
+            "upstream_total_known": 500,
+            "returned_count": 500,
+            "top_n_cap": 500,
+            "outside_top_n_count": 0,
+            "deduped_unique_count": 1,
+            "duplicate_count": 0,
+        }
+    )
+    payload["sources"] = [source]
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    candidate["matched_sources"] = [{"source_id": "analyst-feed", "rank": 1}]
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage["cross_source_duplicate_count"] = 0
+
+    with pytest.raises(ValidationError, match="coverage is insufficient"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_verify_r2_l1_fixture_cannot_write_the_previously_false_green_record(
+    tmp_path: Path,
+):
+    fixture = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "us_upside_instrumentation"
+        / "verify_r2_l1_reproduction.json"
+    )
+    output = tmp_path / "verify-r2-l1.jsonl"
+
+    with pytest.raises(ValidationError, match="coverage is insufficient"):
+        main(["record", "--input", str(fixture), "--output", str(output)])
+
+    assert not output.exists()
+
+
+def test_l1_declared_duplicate_count_reconciles_a_source_census():
+    payload = _payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    source = sources[0]
+    assert isinstance(source, dict)
+    source.update(
+        {
+            "upstream_total_known": 500,
+            "returned_count": 500,
+            "top_n_cap": 500,
+            "outside_top_n_count": 0,
+            "deduped_unique_count": 1,
+            "duplicate_count": 499,
+        }
+    )
+    payload["sources"] = [source]
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    candidate["matched_sources"] = [{"source_id": "analyst-feed", "rank": 1}]
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage["cross_source_duplicate_count"] = 0
+
+    record = evaluate_instrumentation(
+        InstrumentationInput.model_validate(payload), input_hash="d" * 64
+    )
+
+    assert record.coverage.source_duplicate_count == 499
+    assert record.coverage.coverage_complete is True
+
+
+def test_l2_source_to_global_census_mismatch_is_fail_closed_before_a_verdict():
+    payload = _payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    source = sources[0]
+    assert isinstance(source, dict)
+    source.update(
+        {
+            "upstream_total_known": 500,
+            "returned_count": 500,
+            "top_n_cap": 500,
+            "outside_top_n_count": 0,
+            "deduped_unique_count": 500,
+            "duplicate_count": 0,
+        }
+    )
+    payload["sources"] = [source]
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    candidate["matched_sources"] = [{"source_id": "analyst-feed", "rank": 1}]
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage["cross_source_duplicate_count"] = 499
+
+    with pytest.raises(ValidationError, match="global deduped_unique_count"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_l2_cross_source_duplicate_count_must_reconcile_the_union_total():
+    payload = _payload()
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage["cross_source_duplicate_count"] = 0
+
+    with pytest.raises(ValidationError, match="per-source deduped_unique_count total"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_l2_prevents_an_empty_serialized_cohort_from_claiming_an_earlier_gate():
+    payload = _payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    source = sources[0]
+    assert isinstance(source, dict)
+    source.update(
+        {
+            "upstream_total_known": 500,
+            "returned_count": 500,
+            "top_n_cap": 500,
+            "outside_top_n_count": 0,
+            "deduped_unique_count": 500,
+            "duplicate_count": 0,
+        }
+    )
+    payload["sources"] = [source]
+    payload["candidates"] = []
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage.update(
+        {
+            "deduped_unique_count": 0,
+            "cross_source_duplicate_count": 500,
+            "recorded_candidate_count": 0,
+            "truncated_candidate_count": 0,
+        }
+    )
+
+    with pytest.raises(ValidationError, match="global deduped_unique_count"):
+        InstrumentationInput.model_validate(payload)
+
+
 def test_top_n_capped_runbook_capture_is_coverage_insufficient(tmp_path: Path, capsys):
     fixture = (
         Path(__file__).resolve().parents[1]
@@ -440,6 +619,28 @@ def test_top_n_capped_runbook_capture_is_coverage_insufficient(tmp_path: Path, c
     assert "coverage_insufficient_no_threshold_conclusion" in stdout
 
 
+def test_coverage_complete_runbook_capture_has_a_bounded_dominant_reading(
+    tmp_path: Path, capsys
+):
+    fixture = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "us_upside_instrumentation"
+        / "runbook_coverage_complete_capture.json"
+    )
+    output = tmp_path / "coverage-complete.jsonl"
+
+    assert main(["record", "--input", str(fixture), "--output", str(output)]) == 0
+
+    stdout = capsys.readouterr().out
+    record = load_session_jsonl(output)[0]
+    assert record.coverage.coverage_complete is True
+    assert (
+        record.interpretation.conclusion == "upside_dominant_constraint_bounded_cohort"
+    )
+    assert '"coverage_complete": true' in stdout
+
+
 def test_known_source_total_requires_every_loss_to_be_declared():
     payload = _payload()
     source = payload["sources"][0]
@@ -452,11 +653,34 @@ def test_known_source_total_requires_every_loss_to_be_declared():
 
 def test_candidate_array_truncation_is_recorded_and_blocks_threshold_conclusion():
     payload = _payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    source = sources[0]
+    assert isinstance(source, dict)
+    source.update(
+        {
+            "upstream_total_known": 4,
+            "returned_count": 4,
+            "deduped_unique_count": 4,
+            "duplicate_count": 0,
+        }
+    )
+    other_source = sources[1]
+    assert isinstance(other_source, dict)
+    other_source.update(
+        {
+            "upstream_total_known": 0,
+            "returned_count": 0,
+            "deduped_unique_count": 0,
+            "duplicate_count": 0,
+        }
+    )
     coverage = payload["candidate_array_coverage"]
     assert isinstance(coverage, dict)
     coverage.update(
         {
             "deduped_unique_count": 4,
+            "cross_source_duplicate_count": 0,
             "recorded_candidate_count": 1,
             "truncated_candidate_count": 3,
             "candidate_array_cap": 1,
@@ -567,6 +791,7 @@ def test_three_session_reading_propagates_any_incomplete_coverage_to_unknown():
                     "top_n_cap": 3,
                     "outside_top_n_count": 7,
                     "deduped_unique_count": 1,
+                    "duplicate_count": 2,
                 }
             )
         records.append(
@@ -587,6 +812,36 @@ def test_three_session_reading_propagates_any_incomplete_coverage_to_unknown():
         True,
     ]
     assert reading.session_coverage[1].outside_top_n_count == 7
+
+
+def test_three_session_reader_rejects_a_stored_coverage_flag_mismatch():
+    records = [_record(session_id=f"2026-08-{14 + index}-rth") for index in range(3)]
+    incomplete_payload = _payload(session_id="2026-08-15-rth")
+    source = incomplete_payload["sources"][0]
+    assert isinstance(source, dict)
+    source.update(
+        {
+            "upstream_total_known": 10,
+            "returned_count": 3,
+            "top_n_cap": 3,
+            "outside_top_n_count": 7,
+            "deduped_unique_count": 1,
+            "duplicate_count": 2,
+        }
+    )
+    incomplete = evaluate_instrumentation(
+        InstrumentationInput.model_validate(incomplete_payload), input_hash="e" * 64
+    )
+    tampered = incomplete.model_copy(
+        update={
+            "coverage": incomplete.coverage.model_copy(
+                update={"coverage_complete": True}
+            )
+        }
+    )
+
+    with pytest.raises(ValueError, match="stored coverage_complete"):
+        read_three_completed_sessions((records[0], tampered, records[2]))
 
 
 def test_three_session_read_rejects_a_mid_observation_code_change():

--- a/tests/services/test_us_upside_instrumentation.py
+++ b/tests/services/test_us_upside_instrumentation.py
@@ -30,27 +30,34 @@ def _payload(*, session_id: str = "2026-08-14-rth") -> dict[str, object]:
         "sources": [
             {
                 "source_id": "analyst-feed",
-                "upstream_total_known": 10,
+                "upstream_total_known": 1,
                 "upstream_total_unknown": False,
-                "returned_count": 3,
-                "timeout_or_error_count": 0,
-                "unqueried_count": 0,
-                "top_n_cap": 3,
-                "outside_top_n_count": 7,
-                "deduped_unique_count": 2,
-            },
-            {
-                "source_id": "support-feed",
-                "upstream_total_known": 2,
-                "upstream_total_unknown": False,
-                "returned_count": 2,
+                "returned_count": 1,
                 "timeout_or_error_count": 0,
                 "unqueried_count": 0,
                 "top_n_cap": None,
                 "outside_top_n_count": 0,
-                "deduped_unique_count": 2,
+                "deduped_unique_count": 1,
+            },
+            {
+                "source_id": "support-feed",
+                "upstream_total_known": 1,
+                "upstream_total_unknown": False,
+                "returned_count": 1,
+                "timeout_or_error_count": 0,
+                "unqueried_count": 0,
+                "top_n_cap": None,
+                "outside_top_n_count": 0,
+                "deduped_unique_count": 1,
             },
         ],
+        "candidate_array_coverage": {
+            "deduped_unique_count": 1,
+            "recorded_candidate_count": 1,
+            "truncated_candidate_count": 0,
+            "candidate_array_cap": None,
+            "candidate_truncation_reason": None,
+        },
         "candidates": [
             {
                 "symbol": "ACME",
@@ -175,14 +182,21 @@ def test_record_preserves_every_q4_field_and_is_read_only():
     assert record.input_hash == "d" * 64
     assert source.model_dump() == {
         "source_id": "analyst-feed",
-        "upstream_total_known": 10,
+        "upstream_total_known": 1,
         "upstream_total_unknown": False,
-        "returned_count": 3,
+        "returned_count": 1,
         "timeout_or_error_count": 0,
         "unqueried_count": 0,
-        "top_n_cap": 3,
-        "outside_top_n_count": 7,
-        "deduped_unique_count": 2,
+        "top_n_cap": None,
+        "outside_top_n_count": 0,
+        "deduped_unique_count": 1,
+    }
+    assert record.candidate_array_coverage.model_dump() == {
+        "deduped_unique_count": 1,
+        "recorded_candidate_count": 1,
+        "truncated_candidate_count": 0,
+        "candidate_array_cap": None,
+        "candidate_truncation_reason": None,
     }
     assert candidate.matched_sources[0].model_dump() == {
         "source_id": "analyst-feed",
@@ -269,6 +283,13 @@ def test_serialized_jsonl_keeps_caps_and_hypothetical_touch_name(tmp_path: Path)
     }
     assert "hypothetical_limit_touch" in payload["candidates"][0]
     assert payload["candidates"][0]["hypothetical_limit_touch"]["limit_touched"]
+    assert payload["candidate_array_coverage"] == {
+        "deduped_unique_count": 1,
+        "recorded_candidate_count": 1,
+        "truncated_candidate_count": 0,
+        "candidate_array_cap": None,
+        "candidate_truncation_reason": None,
+    }
 
 
 def test_dominant_constraint_rule_is_bounded_and_never_a_tuning_signal():
@@ -365,7 +386,10 @@ def test_unknown_timeout_or_unqueried_coverage_has_no_threshold_conclusion():
         "upstream_total_unknown_source_count": 1,
         "timeout_or_error_count": 1,
         "unqueried_count": 2,
-        "outside_top_n_count": 7,
+        "outside_top_n_count": 0,
+        "candidate_array_truncated_count": 0,
+        "candidate_array_cap": None,
+        "candidate_truncation_reason": None,
         "candidate_consensus_status_counts": {
             "value": 1,
             "missing": 0,
@@ -383,13 +407,103 @@ def test_unknown_timeout_or_unqueried_coverage_has_no_threshold_conclusion():
     )
 
 
-def test_silent_cap_or_missing_census_is_rejected_before_recording():
+def test_missing_top_n_census_is_rejected_before_recording():
     payload = _payload()
     source = payload["sources"][0]
     assert isinstance(source, dict)
     source.pop("outside_top_n_count")
 
     with pytest.raises(ValidationError, match="outside_top_n_count"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_top_n_capped_runbook_capture_is_coverage_insufficient(tmp_path: Path, capsys):
+    fixture = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "us_upside_instrumentation"
+        / "runbook_top_n_capped_capture.json"
+    )
+    output = tmp_path / "top-n-capped.jsonl"
+
+    assert main(["record", "--input", str(fixture), "--output", str(output)]) == 0
+
+    stdout = capsys.readouterr().out
+    record = load_session_jsonl(output)[0]
+    assert record.coverage.outside_top_n_count == 7
+    assert record.coverage.coverage_complete is False
+    assert (
+        record.interpretation.conclusion
+        == "coverage_insufficient_no_threshold_conclusion"
+    )
+    assert '"coverage_complete": false' in stdout
+    assert "coverage_insufficient_no_threshold_conclusion" in stdout
+
+
+def test_known_source_total_requires_every_loss_to_be_declared():
+    payload = _payload()
+    source = payload["sources"][0]
+    assert isinstance(source, dict)
+    source["upstream_total_known"] = 10
+
+    with pytest.raises(ValidationError, match="declared non-returned count"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_candidate_array_truncation_is_recorded_and_blocks_threshold_conclusion():
+    payload = _payload()
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage.update(
+        {
+            "deduped_unique_count": 4,
+            "recorded_candidate_count": 1,
+            "truncated_candidate_count": 3,
+            "candidate_array_cap": 1,
+            "candidate_truncation_reason": "bounded_candidate_array",
+        }
+    )
+
+    record = evaluate_instrumentation(
+        InstrumentationInput.model_validate(payload), input_hash="d" * 64
+    )
+
+    assert record.candidate_array_coverage.truncated_candidate_count == 3
+    assert record.candidate_array_coverage.candidate_truncation_reason == (
+        "bounded_candidate_array"
+    )
+    assert record.coverage.candidate_array_truncated_count == 3
+    assert record.coverage.coverage_complete is False
+    assert (
+        record.interpretation.conclusion
+        == "coverage_insufficient_no_threshold_conclusion"
+    )
+
+
+def test_candidate_array_unrecorded_loss_is_rejected_before_recording():
+    payload = _payload()
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage["deduped_unique_count"] = 4
+
+    with pytest.raises(ValidationError, match="truncated_candidate_count"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_candidate_array_truncation_requires_cap_and_reason():
+    payload = _payload()
+    coverage = payload["candidate_array_coverage"]
+    assert isinstance(coverage, dict)
+    coverage.update(
+        {
+            "deduped_unique_count": 2,
+            "truncated_candidate_count": 1,
+            "candidate_array_cap": None,
+            "candidate_truncation_reason": None,
+        }
+    )
+
+    with pytest.raises(ValidationError, match="candidate_array_cap"):
         InstrumentationInput.model_validate(payload)
 
 
@@ -400,6 +514,18 @@ def test_missing_candidate_evidence_is_rejected_instead_of_defaulting_to_unknown
     candidate.pop("current_price")
 
     with pytest.raises(ValidationError, match="current_price"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_matched_source_rank_must_be_declared_even_when_unknown():
+    payload = _payload()
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    matches = candidate["matched_sources"]
+    assert isinstance(matches, list)
+    matches[0].pop("rank")
+
+    with pytest.raises(ValidationError, match="rank"):
         InstrumentationInput.model_validate(payload)
 
 
@@ -421,8 +547,46 @@ def test_three_sessions_with_zero_b30_and_c25_only_diagnose_contracts():
     assert reading.a40_shadow_count == 0
     assert reading.b30_shadow_count == 0
     assert reading.c25_shadow_count == 0
+    assert reading.all_sessions_coverage_complete is True
+    assert reading.conclusion == "three_session_reading_complete"
     assert reading.next_step == "diagnose_target_coverage_or_support_source_contract"
     assert reading.threshold_tuning_permitted is False
+
+
+def test_three_session_reading_propagates_any_incomplete_coverage_to_unknown():
+    records = []
+    for index in range(3):
+        payload = _payload(session_id=f"2026-08-{14 + index}-rth")
+        if index == 1:
+            source = payload["sources"][0]
+            assert isinstance(source, dict)
+            source.update(
+                {
+                    "upstream_total_known": 10,
+                    "returned_count": 3,
+                    "top_n_cap": 3,
+                    "outside_top_n_count": 7,
+                    "deduped_unique_count": 1,
+                }
+            )
+        records.append(
+            evaluate_instrumentation(
+                InstrumentationInput.model_validate(payload), input_hash=str(index) * 64
+            )
+        )
+
+    reading = read_three_completed_sessions(records)
+
+    assert reading.all_sessions_coverage_complete is False
+    assert reading.conclusion == "coverage_insufficient_no_threshold_conclusion"
+    assert reading.next_step == "coverage_insufficient_no_threshold_conclusion"
+    assert reading.threshold_tuning_permitted is False
+    assert [coverage.coverage_complete for coverage in reading.session_coverage] == [
+        True,
+        False,
+        True,
+    ]
+    assert reading.session_coverage[1].outside_top_n_count == 7
 
 
 def test_three_session_read_rejects_a_mid_observation_code_change():
@@ -494,6 +658,15 @@ def test_cli_appends_records_and_reads_exactly_three(tmp_path: Path, capsys):
     stdout = capsys.readouterr().out
     assert "continue_bounded_cohort_reading_without_tuning" in stdout
     assert '"threshold_tuning_permitted": false' in stdout
+
+
+def test_record_rejects_duplicate_session_id_in_one_jsonl_artifact(tmp_path: Path):
+    output = tmp_path / "sessions.jsonl"
+
+    append_session_jsonl(output, _record())
+
+    with pytest.raises(ValueError, match="already contains this session_id"):
+        append_session_jsonl(output, _record())
 
 
 def test_input_rejects_unknown_source_reference():

--- a/tests/services/test_us_upside_instrumentation.py
+++ b/tests/services/test_us_upside_instrumentation.py
@@ -1,0 +1,506 @@
+import ast
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.services.us_upside_instrumentation import (
+    CONTRACT_SHA256,
+    FROZEN_ARMS,
+    InstrumentationInput,
+    append_session_jsonl,
+    evaluate_instrumentation,
+    load_session_jsonl,
+    read_three_completed_sessions,
+)
+from scripts.run_us_upside_instrumentation import main, parse_args
+
+
+def _payload(*, session_id: str = "2026-08-14-rth") -> dict[str, object]:
+    return {
+        "session_id": session_id,
+        "contract_sha": CONTRACT_SHA256,
+        "policy_sha": "a" * 64,
+        "code_sha": "b" * 40,
+        "source_corpus_as_of": "2026-08-14T22:35:00+09:00",
+        "decision_cutoff": "2026-08-14T22:35:00+09:00",
+        "universe_hash": "c" * 64,
+        "sources": [
+            {
+                "source_id": "analyst-feed",
+                "upstream_total_known": 10,
+                "upstream_total_unknown": False,
+                "returned_count": 3,
+                "timeout_or_error_count": 0,
+                "unqueried_count": 0,
+                "top_n_cap": 3,
+                "outside_top_n_count": 7,
+                "deduped_unique_count": 2,
+            },
+            {
+                "source_id": "support-feed",
+                "upstream_total_known": 2,
+                "upstream_total_unknown": False,
+                "returned_count": 2,
+                "timeout_or_error_count": 0,
+                "unqueried_count": 0,
+                "top_n_cap": None,
+                "outside_top_n_count": 0,
+                "deduped_unique_count": 2,
+            },
+        ],
+        "candidates": [
+            {
+                "symbol": "ACME",
+                "matched_sources": [
+                    {"source_id": "analyst-feed", "rank": 1},
+                    {"source_id": "support-feed", "rank": 1},
+                ],
+                "freshness": "fresh",
+                "consensus_status": "value",
+                "target_honesty": "honest",
+                "target_as_of": "2026-08-14T22:30:00+09:00",
+                "analyst_count": 4,
+                "current_price": 100.0,
+                "target": 130.0,
+                "rsi": 42.0,
+                "support_price": 90.0,
+                "support_strength": "strong",
+                "independent_support_families": [
+                    "price_structure",
+                    "volume_profile",
+                    "moving_average",
+                ],
+                "non_upside_gate_bits": {
+                    "source": "pass",
+                    "freshness": "pass",
+                    "support": "pass",
+                },
+                "proposed_limit": 87.0,
+                "tick_handling": {
+                    "rule": "US-cent rounding down to the displayed limit",
+                    "raw_limit": 87.004,
+                    "snapped_limit": 87.0,
+                    "direction": "down",
+                },
+                "feasibility": {
+                    "sector": "Industrials",
+                    "sector_feasibility": "pass",
+                    "dedupe_feasibility": "pass",
+                    "cash_feasibility": "pass",
+                    "whole_share_feasibility": "pass",
+                    "would_size": 1.0,
+                    "required_cash": 87.0,
+                },
+                "hypothetical_limit_touch": {
+                    "next_session_high": 94.0,
+                    "next_session_low": 86.0,
+                    "limit_touched": True,
+                },
+            }
+        ],
+    }
+
+
+def _record(*, session_id: str = "2026-08-14-rth"):
+    return evaluate_instrumentation(
+        InstrumentationInput.model_validate(_payload(session_id=session_id)),
+        input_hash="d" * 64,
+    )
+
+
+def test_arms_are_exactly_frozen_and_shadow_only():
+    assert [arm.model_dump() for arm in FROZEN_ARMS] == [
+        {
+            "arm_id": "A40",
+            "upside_min_pct": 40,
+            "required_support_strength": None,
+            "independent_family_min": None,
+            "final_discount_min_pct": None,
+            "final_discount_max_pct": None,
+            "diagnostic_only": False,
+            "shadow_only": True,
+        },
+        {
+            "arm_id": "B30",
+            "upside_min_pct": 30,
+            "required_support_strength": "strong",
+            "independent_family_min": 3,
+            "final_discount_min_pct": 12,
+            "final_discount_max_pct": 15,
+            "diagnostic_only": False,
+            "shadow_only": True,
+        },
+        {
+            "arm_id": "C25",
+            "upside_min_pct": 25,
+            "required_support_strength": "strong",
+            "independent_family_min": 3,
+            "final_discount_min_pct": 11,
+            "final_discount_max_pct": 15,
+            "diagnostic_only": True,
+            "shadow_only": True,
+        },
+    ]
+
+
+def test_cli_has_no_threshold_or_arm_override():
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "record",
+                "--input",
+                "capture.json",
+                "--output",
+                "records.jsonl",
+                "--threshold",
+                "25",
+            ]
+        )
+
+
+def test_record_preserves_every_q4_field_and_is_read_only():
+    record = _record()
+    candidate = record.candidates[0]
+    source = record.sources[0]
+
+    assert record.contract_sha == CONTRACT_SHA256
+    assert record.policy_sha == "a" * 64
+    assert record.code_sha == "b" * 40
+    assert record.source_corpus_as_of == "2026-08-14T22:35:00+09:00"
+    assert record.decision_cutoff == "2026-08-14T22:35:00+09:00"
+    assert record.universe_hash == "c" * 64
+    assert record.input_hash == "d" * 64
+    assert source.model_dump() == {
+        "source_id": "analyst-feed",
+        "upstream_total_known": 10,
+        "upstream_total_unknown": False,
+        "returned_count": 3,
+        "timeout_or_error_count": 0,
+        "unqueried_count": 0,
+        "top_n_cap": 3,
+        "outside_top_n_count": 7,
+        "deduped_unique_count": 2,
+    }
+    assert candidate.matched_sources[0].model_dump() == {
+        "source_id": "analyst-feed",
+        "rank": 1,
+    }
+    assert candidate.freshness == "fresh"
+    assert candidate.target_honesty == "honest"
+    assert candidate.target_as_of == "2026-08-14T22:30:00+09:00"
+    assert candidate.analyst_count == 4
+    assert candidate.upside_pct == 30.0
+    assert candidate.support_distance_pct == 10.0
+    assert candidate.final_discount_from_current_pct == 13.0
+    assert candidate.arithmetic_limit_basis_upside_pct == 49.425287
+    assert candidate.independent_support_families == (
+        "price_structure",
+        "volume_profile",
+        "moving_average",
+    )
+    assert candidate.independent_support_family_count == 3
+    assert candidate.hypothetical_limit_touch is not None
+    assert candidate.hypothetical_limit_touch.limit_touched is True
+    assert record.arm_shadow_counts == {"A40": 0, "B30": 1, "C25": 1}
+    assert record.read_only_safety.model_dump() == {
+        "eligibility_connections": 0,
+        "proposals_created": 0,
+        "orders_created": 0,
+        "broker_calls": 0,
+        "database_writes": 0,
+        "scheduler_registrations": 0,
+        "threshold_overrides": 0,
+    }
+
+
+def test_exact_candidate_log_shape_keeps_hypothetical_touch_separate():
+    payload = _record().model_dump(mode="json")
+    assert set(payload["candidates"][0]) == {
+        "symbol",
+        "matched_sources",
+        "freshness",
+        "consensus_status",
+        "target_honesty",
+        "target_as_of",
+        "analyst_count",
+        "current_price",
+        "target",
+        "rsi",
+        "support_price",
+        "support_strength",
+        "independent_support_families",
+        "non_upside_gate_bits",
+        "proposed_limit",
+        "tick_handling",
+        "feasibility",
+        "hypothetical_limit_touch",
+        "upside_pct",
+        "support_distance_pct",
+        "independent_support_family_count",
+        "final_discount_from_current_pct",
+        "arithmetic_limit_basis_upside_pct",
+        "arm_results",
+    }
+    assert payload["candidates"][0]["hypothetical_limit_touch"] == {
+        "next_session_high": 94.0,
+        "next_session_low": 86.0,
+        "limit_touched": True,
+    }
+
+
+def test_serialized_jsonl_keeps_caps_and_hypothetical_touch_name(tmp_path: Path):
+    output = tmp_path / "session.jsonl"
+    append_session_jsonl(output, _record())
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert set(payload["sources"][0]) == {
+        "source_id",
+        "upstream_total_known",
+        "upstream_total_unknown",
+        "returned_count",
+        "timeout_or_error_count",
+        "unqueried_count",
+        "top_n_cap",
+        "outside_top_n_count",
+        "deduped_unique_count",
+    }
+    assert "hypothetical_limit_touch" in payload["candidates"][0]
+    assert payload["candidates"][0]["hypothetical_limit_touch"]["limit_touched"]
+
+
+def test_dominant_constraint_rule_is_bounded_and_never_a_tuning_signal():
+    interpretation = _record().interpretation
+
+    assert interpretation.conclusion == "upside_dominant_constraint_bounded_cohort"
+    assert interpretation.passes_all_non_upside_gates == 1
+    assert interpretation.survivor_consensus_statuses == ("value",)
+    assert interpretation.upside_band_counts == {
+        "below_25": 0,
+        "25_to_40": 1,
+        "ge_40": 0,
+        "upside_missing": 0,
+    }
+    assert interpretation.fanout_performance_or_alpha_inferred is False
+    assert interpretation.threshold_tuning_permitted is False
+
+
+def test_arm_gate_bits_and_reject_reasons_are_exact_per_counterfactual():
+    payload = _payload()
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    candidate["support_strength"] = "weak"
+    candidate["independent_support_families"] = ["price_structure", "volume"]
+    candidate["proposed_limit"] = 90.0
+    tick_handling = candidate["tick_handling"]
+    assert isinstance(tick_handling, dict)
+    tick_handling["raw_limit"] = 90.0
+    tick_handling["snapped_limit"] = 90.0
+
+    record = evaluate_instrumentation(
+        InstrumentationInput.model_validate(payload), input_hash="d" * 64
+    )
+    a40, b30, c25 = record.candidates[0].arm_results
+
+    assert a40.gate_bits["upside_minimum"] is False
+    assert a40.reject_reasons == ("upside_below_40pct",)
+    assert b30.gate_bits["support_strength_strong"] is False
+    assert b30.gate_bits["independent_support_family_minimum"] is False
+    assert b30.gate_bits["final_discount_distance"] is False
+    assert b30.reject_reasons == (
+        "support_strength_not_strong",
+        "independent_support_families_below_3",
+        "final_discount_outside_12_to_15_pct",
+    )
+    assert c25.reject_reasons == (
+        "support_strength_not_strong",
+        "independent_support_families_below_3",
+        "final_discount_outside_11_to_15_pct",
+    )
+    assert not b30.would_select
+    assert not c25.would_select
+
+
+def test_zero_pre_upside_survivors_is_an_earlier_constraint():
+    payload = _payload()
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    candidate["non_upside_gate_bits"] = {
+        "source": "pass",
+        "freshness": "fail",
+        "support": "pass",
+    }
+
+    record = evaluate_instrumentation(
+        InstrumentationInput.model_validate(payload), input_hash="d" * 64
+    )
+
+    assert (
+        record.interpretation.conclusion
+        == "earlier_source_freshness_or_support_constraint"
+    )
+    assert record.interpretation.passes_all_non_upside_gates == 0
+    assert record.candidates[0].arm_results[0].reject_reasons == (
+        "non_upside_gate_freshness_fail",
+        "upside_below_40pct",
+    )
+
+
+def test_unknown_timeout_or_unqueried_coverage_has_no_threshold_conclusion():
+    payload = _payload()
+    source = payload["sources"][0]
+    assert isinstance(source, dict)
+    source["upstream_total_known"] = None
+    source["upstream_total_unknown"] = True
+    source["timeout_or_error_count"] = 1
+    source["unqueried_count"] = 2
+
+    record = evaluate_instrumentation(
+        InstrumentationInput.model_validate(payload), input_hash="d" * 64
+    )
+
+    assert record.coverage.model_dump() == {
+        "upstream_total_unknown_source_count": 1,
+        "timeout_or_error_count": 1,
+        "unqueried_count": 2,
+        "outside_top_n_count": 7,
+        "candidate_consensus_status_counts": {
+            "value": 1,
+            "missing": 0,
+            "stale": 0,
+            "error": 0,
+            "timeout": 0,
+            "unknown": 0,
+            "unqueried": 0,
+        },
+        "coverage_complete": False,
+    }
+    assert (
+        record.interpretation.conclusion
+        == "coverage_insufficient_no_threshold_conclusion"
+    )
+
+
+def test_silent_cap_or_missing_census_is_rejected_before_recording():
+    payload = _payload()
+    source = payload["sources"][0]
+    assert isinstance(source, dict)
+    source.pop("outside_top_n_count")
+
+    with pytest.raises(ValidationError, match="outside_top_n_count"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_missing_candidate_evidence_is_rejected_instead_of_defaulting_to_unknown():
+    payload = _payload()
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    candidate.pop("current_price")
+
+    with pytest.raises(ValidationError, match="current_price"):
+        InstrumentationInput.model_validate(payload)
+
+
+def test_three_sessions_with_zero_b30_and_c25_only_diagnose_contracts():
+    records = []
+    for index in range(3):
+        payload = _payload(session_id=f"2026-08-{14 + index}-rth")
+        candidate = payload["candidates"][0]
+        assert isinstance(candidate, dict)
+        candidate["target"] = 120.0
+        records.append(
+            evaluate_instrumentation(
+                InstrumentationInput.model_validate(payload), input_hash=str(index) * 64
+            )
+        )
+
+    reading = read_three_completed_sessions(records)
+
+    assert reading.a40_shadow_count == 0
+    assert reading.b30_shadow_count == 0
+    assert reading.c25_shadow_count == 0
+    assert reading.next_step == "diagnose_target_coverage_or_support_source_contract"
+    assert reading.threshold_tuning_permitted is False
+
+
+def test_three_session_read_rejects_a_mid_observation_code_change():
+    records = [_record(session_id=f"2026-08-{14 + index}-rth") for index in range(3)]
+    changed = records[-1].model_copy(update={"code_sha": "e" * 40})
+
+    with pytest.raises(ValueError, match="one code_sha"):
+        read_three_completed_sessions((records[0], records[1], changed))
+
+
+def test_service_source_has_no_runtime_mutation_connection():
+    service_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "services"
+        / "us_upside_instrumentation.py"
+    )
+    source = service_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+    imported_modules.update(
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    )
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    called_attributes = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert not any(
+        module == "app" or module.startswith("app.") for module in imported_modules
+    )
+    assert imported_modules.isdisjoint(
+        {"httpx", "requests", "sqlalchemy", "redis", "taskiq", "subprocess"}
+    )
+    assert ".environ" not in source
+    assert called_names.isdisjoint(
+        {"submit_eligibility", "create_proposal", "place_order"}
+    )
+    assert called_attributes.isdisjoint({"submit", "create_proposal", "place_order"})
+
+
+def test_cli_appends_records_and_reads_exactly_three(tmp_path: Path, capsys):
+    output = tmp_path / "sessions.jsonl"
+    for index in range(3):
+        input_path = tmp_path / f"session-{index}.json"
+        input_path.write_text(
+            json.dumps(_payload(session_id=f"2026-08-{14 + index}-rth")),
+            encoding="utf-8",
+        )
+        assert (
+            main(["record", "--input", str(input_path), "--output", str(output)]) == 0
+        )
+
+    assert len(load_session_jsonl(output)) == 3
+    assert main(["read-three", "--records", str(output)]) == 0
+    stdout = capsys.readouterr().out
+    assert "continue_bounded_cohort_reading_without_tuning" in stdout
+    assert '"threshold_tuning_permitted": false' in stdout
+
+
+def test_input_rejects_unknown_source_reference():
+    payload = copy.deepcopy(_payload())
+    candidate = payload["candidates"][0]
+    assert isinstance(candidate, dict)
+    candidate["matched_sources"] = [{"source_id": "unlisted", "rank": 1}]
+
+    with pytest.raises(ValidationError, match="references unknown source"):
+        InstrumentationInput.model_validate(payload)


### PR DESCRIPTION
## Summary
- Adds an isolated, read-only US bounded-cohort logger with frozen A40/B30/C25 shadow arms.
- Records complete source/candidate/gate/feasibility evidence and fixed three-session reading rules.
- Adds the manual 22:35 KST collection procedure and focused boundary tests.

## Verification
- make lint
- uv run pytest tests/services/test_us_upside_instrumentation.py -vv
- uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -vv
- uv run pytest tests/schemas/test_trading_policy_schema.py -q

## Safety
- No policy, eligibility, proposal, order, broker, database, scheduler, or deployment path is changed.
- The command only reads a supplied JSON snapshot and appends an explicitly selected local JSONL record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added read-only US upside shadow instrumentation for evaluating frozen A40, B30, and C25 scenarios.
  - Added a manual workflow to record validated session snapshots and review results from exactly three completed sessions.
  - Added structured coverage, safety, feasibility, and gate reporting with fail-closed handling for incomplete or inconsistent data.
  - Added local JSONL export and loading with duplicate-session protection and input verification.

- **Documentation**
  - Added an operating runbook with required fields, examples, commands, validation rules, and stop conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->