### PR TITLE
fix(ROB-1247): expose Toss sell cost basis in previews

### DIFF
--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -603,9 +603,10 @@ async def _sell_loss_guard(
 
     floor = avg * Decimal("1.01")
 
+    if evidence_context is not None:
+        evidence_context["avg_buy_price"] = _stringify_decimal(avg)
+
     if loss_cut_ctx is not None:
-        if evidence_context is not None:
-            evidence_context["avg_buy_price"] = _stringify_decimal(avg)
         if price is None:
             return {
                 "success": False,
@@ -965,9 +966,9 @@ async def toss_preview_order(
     if price_context_message is not None:
         order_warnings.append(_PRICE_CONTEXT_UNAVAILABLE)
 
-    loss_cut_evidence: dict[str, Any] = {}
-    if loss_cut_ctx is not None:
-        if current_price_dec is None:
+    sell_evidence: dict[str, Any] = {}
+    if side == "sell":
+        if loss_cut_ctx is not None and current_price_dec is None:
             return {
                 "success": False,
                 "source": "toss",
@@ -979,7 +980,7 @@ async def toss_preview_order(
                 ),
             }
         async with _client_context() as client:
-            loss_cut_guard = await _sell_loss_guard(
+            sell_guard = await _sell_loss_guard(
                 client,
                 symbol,
                 order_type,
@@ -991,10 +992,10 @@ async def toss_preview_order(
                 },
                 loss_cut_ctx=loss_cut_ctx,
                 current_price=current_price_dec,
-                evidence_context=loss_cut_evidence,
+                evidence_context=sell_evidence,
             )
-        if loss_cut_guard is not None:
-            return loss_cut_guard
+        if sell_guard is not None:
+            return sell_guard
 
     fill_warnings, fill_distance = _limit_fill_context(
         market=mkt,
@@ -1069,7 +1070,9 @@ async def toss_preview_order(
         response["loss_cut_slip_band"] = float(current_price_dec) * (
             1.0 - loss_cut_ctx.max_slip
         )
-        response.update(loss_cut_evidence)
+        response.update(sell_evidence)
+    elif side == "sell":
+        response.update(sell_evidence)
     return response
 
 

--- a/tests/mcp_server/tooling/test_toss_loss_cut.py
+++ b/tests/mcp_server/tooling/test_toss_loss_cut.py
@@ -9,8 +9,21 @@ import pytest
 
 from app.mcp_server.tooling import order_validation as ov
 from app.mcp_server.tooling import orders_toss_variants as otv
+from app.services.order_proposals.auto_approve import (
+    AutoApproveLimits,
+    evaluate_auto_approve_eligibility,
+)
 
 _TRADER_AGENT_ID = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
+_AUTO_APPROVE_LIMITS = AutoApproveLimits(
+    min_distance_pct=Decimal("3"),
+    per_order_cap=Decimal("200000"),
+    daily_cap=Decimal("500000"),
+    policy_version="test-policy",
+    mode="expanded",
+    breakeven_band_pct=Decimal("1"),
+    round_trip_cost_bps=Decimal("200"),
+)
 
 
 class _TossClient:
@@ -171,6 +184,24 @@ async def test_toss_loss_cut_preview_applies_slip_band(monkeypatch, price, succe
         assert result["retrospective_id"] == 42
         assert result["loss_cut_slip_band"] == pytest.approx(98.0)
         assert result["avg_buy_price"] == "200"
+        decision = evaluate_auto_approve_eligibility(
+            group=SimpleNamespace(
+                action="place",
+                account_mode="toss_live",
+                market="equity_us",
+                order_type="limit",
+                exit_intent="loss_cut",
+                thesis="confirmed stop loss",
+            ),
+            rung=SimpleNamespace(
+                side="sell", limit_price=Decimal(price), quantity=Decimal("1")
+            ),
+            preview=result,
+            limits=_AUTO_APPROVE_LIMITS,
+            daily_notional=Decimal("0"),
+        )
+        assert decision.eligible is False
+        assert decision.reason == "loss_cut_intent"
     else:
         assert "slip band floor" in result["error"]
 
@@ -189,6 +220,123 @@ async def test_toss_loss_cut_preview_fails_closed_without_current_price(monkeypa
 
     assert result["success"] is False
     assert "current price" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_toss_normal_sell_preview_exposes_valid_cost_basis_for_profit_verdict(
+    monkeypatch,
+):
+    client = _configure_toss(monkeypatch)
+    client.current_price = Decimal("100")
+    client.average_purchase_price = Decimal("90")
+    monkeypatch.setattr(
+        otv.settings, "ORDER_PROPOSALS_TOSS_LIVE_VETO_ENABLED", True, raising=False
+    )
+
+    with otv._bind_order_proposal_context(
+        client_order_id="tosprop-normal-sell", correlation_id=None, rung=0
+    ):
+        result = await otv.toss_preview_order(
+            symbol="AAPL",
+            side="sell",
+            order_type="limit",
+            quantity="1",
+            price="104",
+            market="us",
+            account_mode="toss_live",
+        )
+
+    assert result["success"] is True
+    assert result["avg_buy_price"] == "90"
+    decision = evaluate_auto_approve_eligibility(
+        group=SimpleNamespace(
+            action="place",
+            account_mode="toss_live",
+            market="equity_us",
+            order_type="limit",
+            exit_intent=None,
+            thesis="profit taking at a resting limit",
+        ),
+        rung=SimpleNamespace(
+            side="sell", limit_price=Decimal("104"), quantity=Decimal("1")
+        ),
+        preview=result,
+        limits=_AUTO_APPROVE_LIMITS,
+        daily_notional=Decimal("0"),
+    )
+
+    assert decision.eligible is True
+    assert decision.reason == "eligible"
+    assert decision.details["loss_guard"] == "net_profit_proven"
+
+
+@pytest.mark.asyncio
+async def test_toss_sell_guard_does_not_publish_invalid_cost_basis(monkeypatch):
+    client = _configure_toss(monkeypatch)
+    client.average_purchase_price = Decimal("0")
+    evidence_context: dict[str, object] = {}
+
+    result = await otv._sell_loss_guard(
+        client,
+        "AAPL",
+        "limit",
+        Decimal("104"),
+        {"source": "toss", "preview": True},
+        evidence_context=evidence_context,
+    )
+
+    assert result is not None
+    assert result["success"] is False
+    assert "Invalid holding average purchase price" in result["error"]
+    assert evidence_context == {}
+
+    preview = await otv.toss_preview_order(
+        symbol="AAPL",
+        side="sell",
+        order_type="limit",
+        quantity="1",
+        price="104",
+        market="us",
+        account_mode="toss_live",
+    )
+    assert preview["success"] is False
+    assert "avg_buy_price" not in preview
+
+    missing_evidence_context: dict[str, object] = {}
+    monkeypatch.setattr(otv, "_find_holding", AsyncMock(return_value=None))
+    missing = await otv._sell_loss_guard(
+        client,
+        "AAPL",
+        "limit",
+        Decimal("104"),
+        {"source": "toss", "preview": True},
+        evidence_context=missing_evidence_context,
+    )
+    assert missing is not None
+    assert missing["success"] is False
+    assert "No holding found" in missing["error"]
+    assert missing_evidence_context == {}
+
+
+@pytest.mark.asyncio
+async def test_toss_sell_guard_keeps_the_avg_plus_one_percent_floor(monkeypatch):
+    client = _configure_toss(monkeypatch)
+    client.average_purchase_price = Decimal("100")
+    evidence_context: dict[str, object] = {}
+
+    result = await otv._sell_loss_guard(
+        client,
+        "AAPL",
+        "limit",
+        Decimal("100.5"),
+        {"source": "toss", "preview": True},
+        evidence_context=evidence_context,
+    )
+
+    assert result is not None
+    assert result["success"] is False
+    assert "below average purchase price floor (101.00)" in result["error"]
+    assert evidence_context == {"avg_buy_price": "100"}
 
 
 async def _preview_loss_cut(

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -1084,6 +1084,21 @@ async def test_toss_preview_sell_limit_below_market_returns_marketable_warning(
 ):
     otv = _enable_toss_preview(monkeypatch)
     mock_client = MockTossClient(monkeypatch)
+    mock_client.holdings_list = [
+        {
+            "symbol": "AVGO",
+            "quantity": Decimal("1"),
+            "average_purchase_price": Decimal("300"),
+            "last_price": Decimal("390"),
+            "name": "Broadcom",
+            "market_country": "US",
+            "currency": "USD",
+            "market_value": {},
+            "profit_loss": {},
+            "daily_profit_loss": {},
+            "cost": {},
+        }
+    ]
     mock_client.prices_list = [
         {"symbol": "AVGO", "last_price": Decimal("390"), "currency": "USD"}
     ]

--- a/tests/test_mcp_toss_order_variants_rob561.py
+++ b/tests/test_mcp_toss_order_variants_rob561.py
@@ -50,7 +50,22 @@ async def test_toss_preview_order_snaps_price_kr_sell(monkeypatch):
 
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
-    _ = MockTossClient(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.holdings_list = [
+        {
+            "symbol": "005930",
+            "quantity": Decimal("1"),
+            "average_purchase_price": Decimal("80000"),
+            "last_price": Decimal("87400"),
+            "name": "Samsung",
+            "market_country": "KR",
+            "currency": "KRW",
+            "market_value": {},
+            "profit_loss": {},
+            "daily_profit_loss": {},
+            "cost": {},
+        }
+    ]
 
     # KR 005930, price 87350. Sell should ceil to 87400.
     res = await toss_preview_order(


### PR DESCRIPTION
## Summary
- Expose validated `avg_buy_price` from normal Toss sell previews.
- Keep the `avg * 1.01` loss floor and loss-cut fail-closed sequence unchanged.
- Cover normal and loss-cut previews, invalid cost-basis suppression, and regression guardrails.

## Verification
- `uv run pytest -q tests/mcp_server/tooling/test_toss_loss_cut.py tests/test_mcp_toss_order_variants.py tests/test_mcp_toss_order_variants_rob561.py tests/services/order_proposals/test_revalidation.py::test_toss_adapter_forwards_loss_cut_binding tests/services/order_proposals/test_auto_approve.py::test_expanded_net_pnl_exactly_zero_requires_approval`
- `make lint`
- Four temporary mutants were each rejected by focused tests and reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sell previews now provide purchase-price evidence for both loss-cut and regular sell orders.
  * Profitable normal sell previews can now qualify for automatic approval when holding information is valid.

* **Bug Fixes**
  * Previews fail safely when purchase-cost data is missing or invalid.
  * The minimum average-price protection remains enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->