### PR TITLE
docs(b0x): label KR ladder multi-rung observation limit

### DIFF
--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -137,6 +137,12 @@ ORDERING_STATUS_LABEL: Final[str] = (
     "확인한다. KRX RTH only."
 )
 
+LADDER_MULTI_RUNG_OBSERVATION_LIMIT: Final[str] = (
+    "LADDER_MULTI_RUNG_OBSERVATION_LIMIT — 사다리 2단 이상은 현행 게이트로 "
+    "제출되지 않는다(관측 한계). 사이클 내 일괄 제출 계약이 랜딩하기 전까지의 "
+    "한시 라벨이다."
+)
+
 ORDERING_REQUIREMENTS: Final[dict[str, str]] = {
     "table_only": "policy_table deterministic derivation within locked §4 envelope",
     "day": "default TIF is DAY; successful acknowledgement is never auto-cancelled",
@@ -1686,7 +1692,12 @@ async def run_kiwoom_cycle(
     cycle_status, status_label = _cycle_status(confirm=confirm, mode=mode)
     labels = header_labels(
         lane=LANE,
-        extra=(*account_history_labels(LANE), COEXISTENCE_LABEL, status_label),
+        extra=(
+            *account_history_labels(LANE),
+            COEXISTENCE_LABEL,
+            status_label,
+            LADDER_MULTI_RUNG_OBSERVATION_LIMIT,
+        ),
     )
     outcome = KiwoomCycleOutcome(lane=LANE, at=now)
     root = Path(out_dir).expanduser()

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -200,6 +200,10 @@ async def test_record_carries_the_account_map_and_status_label(
     assert any("COEXISTING_ACCOUNT_LANE" in label for label in record["labels"]), (
         "the coexistence caveat must be on every artifact"
     )
+    assert kiwoom_cycle.LADDER_MULTI_RUNG_OBSERVATION_LIMIT in record["labels"]
+    assert outcome.artifact_path is not None
+    artifact = outcome.artifact_path.read_text(encoding="utf-8")
+    assert "사다리 2단 이상은 현행 게이트로 제출되지 않는다(관측 한계)" in artifact
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add the temporary LADDER_MULTI_RUNG_OBSERVATION_LIMIT label to every kiwoom_mock cycle artifact
- state that ladder rung 2 and above are not submitted by the current gate
- keep submission logic unchanged

## Verification

- uv run pytest tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py -q (32 passed)
- uv run ruff check scripts/b0x/kr/kiwoom_cycle.py tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py

## Landing order

Land this small label PR first. The follow-up batch-submission PR removes the temporary label when the revised contract and KR-only implementation land.

No broker or account contact, armed environment, cycle execution, deployment, or merge was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cycle reports now include an explanatory label for the ladder multi-rung observation limit.
  * Generated artifacts include the corresponding Korean observation-limit notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->