### PR TITLE
feat(b0x): batch same-cycle KR buy ladders

### DIFF
--- a/docs/runbooks/b0x-kr-kiwoom-cycle.md
+++ b/docs/runbooks/b0x-kr-kiwoom-cycle.md
@@ -8,7 +8,8 @@
 `--ordering --confirm` 을 함께 명시한 경우만 독립 모드인 **`ORDERING`** 으로
 전환한다. 정책표가 결정적으로 파생한 주문만 §4 cap 안에서 DAY로 제출하고,
 `ACCEPTANCE_ONLY` 의 즉시취소를 상속하지 않는다. 매도는 fresh broker fill로
-증명된 자기 귀속 수량까지만 가능하다. 위험한 쪽은 기본값이 아니다.
+증명된 자기 귀속 수량까지만 가능하다. 동일 cycle의 동일 symbol BUY 다단은
+v1.8의 KR 전용 일괄 경계를 사용한다. 위험한 쪽은 기본값이 아니다.
 
 ---
 
@@ -54,6 +55,8 @@
 | envelope | §4 KR 열 **그대로 재사용** (`load_envelope("kr")`). 레인 전용 envelope 상수 없음 — 테스트가 강제 |
 | Acceptance 1건 한정 | `ACCEPTANCE_SUBMISSION_LIMIT = 1`, CLI/env override 없음. `--confirm` 단독에만 적용 |
 | ORDERING 별도 모드 | `--ordering --confirm` 에서만 policy-table 결정 파생 주문을 제출. 별도 cap/CLI/env override 없음 — §4 30만·동시 10·일신규 3이 파생 단계에서 계속 강제 |
+| 같은-cycle BUY 묶음 | 동일 결정적 `cycle_id`·동일 symbol·BUY인 2개 이상 계획만 허용. 묶음 직전 공용 재제출 게이트 1회; 다른 cycle/symbol/SELL은 authorization 불가 |
+| 묶음 부분 실패 | 이미 ack된 DAY 주문은 보상 취소하지 않고 보존, 다음 mutation 즉시 중단, `partial_failure` + exit 2 + accepted/remaining key 기록. 성공 상태로 표시 금지 |
 | 매도 귀속 | 매도 직전 fresh broker fill × own-order journal로 자기 수량을 다시 계산해 `assert_sell_is_own`으로 제한. 귀속 불명/부족은 sell 0 |
 | Acceptance 왕복 강제 | `--no-cancel` 같은 플래그가 **존재하지 않는다**. `ACCEPTANCE_ONLY` 취소 미확인 = `RoundTripIncomplete` + exit 2 |
 | DAY 주문 잔존 | `ORDERING` 은 즉시 취소하지 않는다. `broker_ack`은 접수/주문번호 증거일 뿐 filled가 아니며 후속 kt00007 readback이 partial/fill/remaining/VWAP/slippage를 보존 |
@@ -98,6 +101,39 @@ v1.5 ① 이 실격시키는 성질이고, ROB-341 이 KIS 일별체결조회를
 않으려고 **계좌 전체 미체결**을 게이트 입력으로 쓴다 — 계약이 요구하는 자기
 미체결의 상위집합이라 항상 더 많이 막고 덜 막지 않는다. 자기 분은
 `own_symbols` 로 따로 기록한다.
+
+### 4.3 v1.8 — 같은 cycle BUY 사다리의 게이트 1회 + 묶음 제출
+
+**cycle 경계는 호출자가 붙이는 임의 문자열이 아니다.** `derive_orders`가
+`policy_table_hash + 제출 전 account_state_hash + locked envelope_hash + lane`으로
+계산한 결정적 `cycle_id`를 `plan_orders`가 각 `PlannedOrder`에 직접 스탬프한다.
+`authorize_same_cycle_buy_batch`는 2개 이상 주문의 `cycle_id`·symbol·side·order key
+순서가 정확히 같을 때만 authorization을 만들 수 있다. SELL과 단건 주문은 기존
+`submit_day_order`를 계속 사용하며 매 호출마다 공용 게이트를 탄다.
+
+ORDERING은 동일 symbol의 연속 BUY 다단을 하나로 묶고, 묶음 **직전**의 fresh
+`MutationBoundary`에서 만든 broker truth로 `assert_resubmit_allowed`를 정확히 1회
+검사한다. 첫 다리 뒤 생긴 자기 미체결은 같은 authorization의 후속 다리를 막지
+않는다. 대신 후속 다리마다 lease + kt00007 foreign trace를 다시 읽는다. 그 사이
+외부 주문이 끼면 다음 다리 전에 차단된다. 각 broker 답변과 실제 전송 사이의
+원자적 잠금은 venue가 제공하지 않으므로 기존과 같은 짧은 TOCTOU는 남으며,
+artifact의 mutation boundary 시각으로 드러낸다.
+
+**사이클 간 방어는 불변이다.** 다음 broker snapshot이 이전 cycle의 자기 미체결을
+보면 새 `account_state_hash`와 새 `cycle_id`가 만들어지고, 파생 단계의 v1.5 ①
+게이트가 해당 symbol 전체를 `own_pending_order_exists`로 제거한다. 이전 cycle의
+authorization은 cycle/order-key exact + 일회성이므로 재사용할 수 없다.
+
+**부분 실패 방침은 잔존이다.** 다리 N 전송이나 readback이 실패하면 앞서 ack된
+DAY 주문에 보상 cancel을 새로 보내지 않는다. cancel 자체가 추가 broker mutation이고
+원실패 뒤 증거가 불완전한 상태에서 위험을 키울 수 있기 때문이다. 추가 제출을
+즉시 중단하고 exit 2, `PARTIAL_BATCH_FAILURE`, accepted/remaining order key,
+`compensating_cancel_attempted=false`를 cycle JSONL과 Markdown 표 양쪽에 남긴다.
+
+**cap은 묶음 밖에서 이미 전량 소비된다.** derivation은 기존대로 다리마다 주문당
+30만과 종목 총 150만을 소비하고, L1/L2는 일일 신규 symbol 하나로 센다. 일일 신규
+3종목이면 최대 `3 symbols × 2 BUY legs × 300,000 = 1,800,000 KRW/cycle`이며,
+묶음 authorization은 주문을 추가하거나 크기를 다시 계산하지 않는다.
 
 ## 5. 🔴 legacy 불가침 귀속 게이트 (§39차 ③, #1835 패턴)
 
@@ -181,6 +217,10 @@ exit code: `0` 정상 · `2` writer lock 경합, acceptance 왕복 미완(취소
 모든 아티팩트에 `COEXISTING_ACCOUNT_LANE` 라벨이 붙는다: 이 계좌의 보유·체결
 이력 전부를 B0-X 산출로 읽으면 안 된다.
 
+BUY 묶음이 있으면 Markdown에 `Same-cycle BUY batches` 표가 추가된다. `cycle_id`,
+symbol, status, planned 수, accepted/remaining order key, 보상취소 여부와 실패 사유를
+표시한다. `partial_failure`는 헤더에도 `PARTIAL_BATCH_FAILURE`로 중복 표시된다.
+
 ## 9. 알려진 경계 (조용히 넘어가지 않는 것들)
 
 1. **계좌 배타성은 여전히 운영 조치다.** account-keyed local lease는 같은 host의
@@ -191,10 +231,10 @@ exit code: `0` 정상 · `2` writer lock 경합, acceptance 왕복 미완(취소
 2. **legacy 귀속 게이트는 2026-08-12 실환경에서 *증명되지 않았다*.** 그날
    kiwoom_mock 계좌의 보유가 **0종목**이라 legacy 분기에 도달할 입력이 없었다.
    단위 테스트로만 증명된 상태다(보유가 생기는 첫 사이클이 첫 실환경 검증 기회).
-3. **dedup(동일 심볼 재제출 차단)도 실환경 미증명.** `ACCEPTANCE_ONLY` 는 같은
-   사이클 안에서 취소하므로 재제출 시점에 자기 미체결이 남아 있지 않다.
-   `ORDERING` 은 DAY 주문을 남기므로 매 mutation-boundary kt00007 재조회가 같은
-   심볼 재제출을 막아야 한다. 단위 테스트가 코드 경로를 덮는다.
+3. **같은-cycle BUY 묶음과 cycle 간 dedup은 실환경 미증명.** 단위 테스트는 한
+   cycle의 L1/L2가 게이트 1회 뒤 모두 제출되고, 다음 cycle은 이전 DAY 미체결 때문에
+   `own_pending_order_exists`로 0건임을 함께 증명한다. venue는 묶음 원자 API를
+   제공하지 않으므로 다리별 ack/readback과 부분 실패 표면은 계속 필요하다.
 4. **dedicated realized P&L source는 아직 없다.** own-order journal이 current-day
    activity 없음까지 증명하는 bootstrap에서만 0을 쓴다. activity·journal 오류·시간
    정보 오류가 있으면 −2.5% NAV kill을 미발화로 꾸미지 않고 ORDERING 자체가 0이 된다.

--- a/scripts/b0x/kr/kiwoom.py
+++ b/scripts/b0x/kr/kiwoom.py
@@ -234,6 +234,10 @@ class RoundTripIncomplete(RuntimeError):
     """
 
 
+class SameCycleBuyBatchViolation(RuntimeError):
+    """A caller tried to widen the KR-only same-cycle BUY batch boundary."""
+
+
 def _truthy(value: str | None) -> bool:
     return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
@@ -868,6 +872,7 @@ def align_price_kr(price: Decimal, *, side: str) -> int:
 
 @dataclass(frozen=True, slots=True)
 class PlannedOrder:
+    cycle_id: str
     order_key: str
     client_order_id: str
     symbol: str
@@ -879,6 +884,7 @@ class PlannedOrder:
 
     def to_json(self) -> dict[str, Any]:
         return {
+            "cycle_id": self.cycle_id,
             "order_key": self.order_key,
             "client_order_id": self.client_order_id,
             "symbol": self.symbol,
@@ -915,6 +921,7 @@ def client_order_id_for(order_key: str) -> str:
 def plan_orders(
     orders: tuple[DerivedOrder, ...],
     *,
+    cycle_id: str,
     envelope: Envelope,
     held_quantities: dict[str, Decimal],
 ) -> tuple[list[PlannedOrder], list[BlockedOrder]]:
@@ -927,6 +934,8 @@ def plan_orders(
     """
 
     assert_envelope_locked(envelope)
+    if not cycle_id.startswith("b0x-"):
+        raise ValueError(f"invalid deterministic B0-X cycle_id: {cycle_id!r}")
 
     planned: list[PlannedOrder] = []
     blocked: list[BlockedOrder] = []
@@ -1003,6 +1012,7 @@ def plan_orders(
 
         planned.append(
             PlannedOrder(
+                cycle_id=cycle_id,
                 order_key=order.order_key,
                 client_order_id=client_order_id_for(order.order_key),
                 symbol=order.symbol,
@@ -1059,6 +1069,101 @@ class DayOrderResult:
             "automatic_cancel": False,
             "fill_status": "unverified",
         }
+
+
+_SAME_CYCLE_BUY_BATCH_PROOF: Final[object] = object()
+
+
+@dataclass(slots=True)
+class SameCycleBuyBatchAuthorization:
+    """One-shot proof that a KR BUY batch cleared the resubmit gate once.
+
+    The proof is deliberately lane-local and order-key exact. It cannot be
+    used for a different cycle, symbol, side, order, or order sequence, and it
+    cannot be replayed after an attempted dispatch. Single-order and SELL
+    submissions never receive this object and retain their existing gate.
+    """
+
+    cycle_id: str
+    symbol: str
+    order_keys: tuple[str, ...]
+    _proof: object = field(repr=False)
+    _next_index: int = field(default=0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self._proof is not _SAME_CYCLE_BUY_BATCH_PROOF:
+            raise SameCycleBuyBatchViolation(
+                "same-cycle BUY batch authorization was not minted by the gate"
+            )
+
+    @property
+    def attempted_count(self) -> int:
+        return self._next_index
+
+    def claim(self, planned: PlannedOrder) -> None:
+        if planned.cycle_id != self.cycle_id:
+            raise SameCycleBuyBatchViolation(
+                f"batch cycle_id={self.cycle_id!r} cannot submit "
+                f"planned cycle_id={planned.cycle_id!r}"
+            )
+        if planned.symbol != self.symbol or planned.side != "buy":
+            raise SameCycleBuyBatchViolation(
+                "same-cycle BUY batch proof cannot cross symbol or side "
+                f"(batch={self.symbol}/buy, planned={planned.symbol}/{planned.side})"
+            )
+        if self._next_index >= len(self.order_keys):
+            raise SameCycleBuyBatchViolation("same-cycle BUY batch proof is exhausted")
+        expected = self.order_keys[self._next_index]
+        if planned.order_key != expected:
+            raise SameCycleBuyBatchViolation(
+                f"batch expected order_key={expected!r}, got {planned.order_key!r}"
+            )
+        # Consume before the broker call. A failed attempt is not replayable
+        # through the same proof; the cycle stops and records the partial state.
+        self._next_index += 1
+
+
+def authorize_same_cycle_buy_batch(
+    *,
+    cycle_id: str,
+    planned: tuple[PlannedOrder, ...],
+    broker_truth: BrokerTruth,
+) -> SameCycleBuyBatchAuthorization:
+    """Check the unchanged common gate once for one exact KR BUY batch."""
+
+    if not cycle_id.startswith("b0x-"):
+        raise SameCycleBuyBatchViolation(
+            f"invalid deterministic B0-X cycle_id: {cycle_id!r}"
+        )
+    if len(planned) < 2:
+        raise SameCycleBuyBatchViolation(
+            "same-cycle batch authorization requires at least two BUY orders"
+        )
+    if any(order.cycle_id != cycle_id for order in planned):
+        raise SameCycleBuyBatchViolation(
+            "every planned order must carry the exact authorizing cycle_id"
+        )
+    symbols = {order.symbol for order in planned}
+    if len(symbols) != 1:
+        raise SameCycleBuyBatchViolation(
+            f"same-cycle batch cannot cross symbols: {sorted(symbols)}"
+        )
+    if any(order.side != "buy" for order in planned):
+        raise SameCycleBuyBatchViolation(
+            "same-cycle batching is BUY-only; SELL semantics are unchanged"
+        )
+    order_keys = tuple(order.order_key for order in planned)
+    if len(set(order_keys)) != len(order_keys):
+        raise SameCycleBuyBatchViolation("same-cycle batch order keys must be unique")
+
+    symbol = planned[0].symbol
+    assert_resubmit_allowed(broker_truth, symbol=symbol, lane=LANE)
+    return SameCycleBuyBatchAuthorization(
+        cycle_id=cycle_id,
+        symbol=symbol,
+        order_keys=order_keys,
+        _proof=_SAME_CYCLE_BUY_BATCH_PROOF,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1309,13 +1414,49 @@ async def submit_day_order(
 ) -> DayOrderResult:
     """Submit one KRX limit order and deliberately leave its DAY lifecycle open.
 
-    The pre-dispatch resubmit gate and immediate journal append are identical
-    to the acceptance path. What differs is deliberate: no post-submit
-    cancellation, no inferred fill, and no claim that a still-open order is a
-    successful reconciliation.
+    Existing single-order callers retain the pre-dispatch resubmit gate on
+    every call. Same-cycle multi-rung BUYs use
+    :func:`submit_day_order_in_batch`, which requires the exact one-shot proof
+    minted by :func:`authorize_same_cycle_buy_batch` instead.
     """
 
     assert_resubmit_allowed(broker_truth, symbol=planned.symbol, lane=LANE)
+    return await _submit_day_order_after_resubmit_gate(
+        account,
+        planned=planned,
+        record_order_no=record_order_no,
+        now=now,
+    )
+
+
+async def submit_day_order_in_batch(
+    account: ReadOnlyKiwoomMockAccount,
+    *,
+    planned: PlannedOrder,
+    authorization: SameCycleBuyBatchAuthorization,
+    record_order_no: Any,
+    now: dt.datetime,
+) -> DayOrderResult:
+    """Submit one member of an already-authorized same-cycle KR BUY batch."""
+
+    authorization.claim(planned)
+    return await _submit_day_order_after_resubmit_gate(
+        account,
+        planned=planned,
+        record_order_no=record_order_no,
+        now=now,
+    )
+
+
+async def _submit_day_order_after_resubmit_gate(
+    account: ReadOnlyKiwoomMockAccount,
+    *,
+    planned: PlannedOrder,
+    record_order_no: Any,
+    now: dt.datetime,
+) -> DayOrderResult:
+    """Send only after a single-order gate or an exact batch proof was consumed."""
+
     result = DayOrderResult(
         correlation_id=planned.client_order_id,
         symbol=planned.symbol,
@@ -1515,6 +1656,8 @@ __all__ = [
     "RestingOrder",
     "RoundTripIncomplete",
     "RoundTripResult",
+    "SameCycleBuyBatchAuthorization",
+    "SameCycleBuyBatchViolation",
     "align_price_kr",
     "account_identity_summary",
     "assert_broker_ok",
@@ -1522,6 +1665,7 @@ __all__ = [
     "assert_kiwoom_lane_enabled",
     "assert_mock_host",
     "assert_resting_echo",
+    "authorize_same_cycle_buy_batch",
     "broker_pending_from_detail_rows",
     "broker_truth_from",
     "client_order_id_for",
@@ -1532,5 +1676,6 @@ __all__ = [
     "read_order_readback",
     "resting_orders_from_detail_rows",
     "submit_day_order",
+    "submit_day_order_in_batch",
     "submit_and_cancel",
 ]

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -81,8 +81,20 @@ LANE = kiwoom_lane.LANE
 # Provenance is KR-lane-local on purpose (same reasoning as
 # ``scripts.b0x.kr.cycle``): the shared ``scripts.b0x.contract`` stamp still
 # describes the untouched US/crypto lanes.
-KR_CONTRACT_VERSION: Final[str] = "v1.6"
+KR_CONTRACT_VERSION: Final[str] = "v1.8"
+KR_CONTRACT_FILE_SHA256_REFERENCE_ONLY: Final[str] = (
+    "7d2729bc4197dd167d40e3e881b64f30a778b1b1a7158acf81fd0c7d38d008c0"
+)
 KR_CONTRACT_CLAUSES: Final[dict[str, str]] = {
+    "§8 v1.8 (v1.5 ① KR amendment)": (
+        "같은 사이클 = policy table hash + 제출 전 broker account state hash + "
+        "locked envelope hash + lane으로 계산한 결정적 cycle_id. 동일 cycle_id·동일 "
+        "symbol·BUY 다단만 묶음 직전 공용 재제출 게이트를 1회 검사한다. 후속 다리 "
+        "직전 lease + kt00007 foreign trace 재검사는 유지한다. 다음 cycle의 기존 자기 "
+        "미체결 차단, §4/§50 180만 cap, 일일 신규 3종목, SELL, 손실가드, crypto/US와 "
+        "공용 게이트는 불변. 부분 실패는 accepted DAY 주문을 보상 취소하지 않고 "
+        "보존하며 추가 mutation 중단 + partial_failure + exit 2로 기록한다."
+    ),
     "§8 v1.6": (
         "KR 자기 미체결의 kis_mock_order_ledger 예외는 **브로커 표면 부재** 한정. "
         "kiwoom_mock 은 kt00007 미체결조회를 지원하므로 이 예외를 쓰지 않는다 "
@@ -137,10 +149,24 @@ ORDERING_STATUS_LABEL: Final[str] = (
     "확인한다. KRX RTH only."
 )
 
-LADDER_MULTI_RUNG_OBSERVATION_LIMIT: Final[str] = (
-    "LADDER_MULTI_RUNG_OBSERVATION_LIMIT — 사다리 2단 이상은 현행 게이트로 "
-    "제출되지 않는다(관측 한계). 사이클 내 일괄 제출 계약이 랜딩하기 전까지의 "
-    "한시 라벨이다."
+SAME_CYCLE_BUY_BATCH_POLICY: Final[str] = (
+    "SAME_CYCLE_BUY_BATCH — 하나의 결정적 cycle_id에서 파생된 동일 symbol BUY "
+    "다단만 한 묶음이다. 묶음 직전 broker truth로 공용 재제출 게이트를 정확히 "
+    "1회 검사하고, 각 후속 다리 직전에는 writer lease + kt00007 foreign trace를 "
+    "다시 검사한다. 다른 cycle_id·symbol·SELL은 이 경계를 사용할 수 없다."
+)
+
+PARTIAL_BATCH_RETAIN_POLICY: Final[str] = (
+    "PARTIAL_BATCH_RETAIN — 묶음 도중 실패하면 이미 broker-acknowledged 된 DAY "
+    "주문은 취소하지 않고 그대로 보존한다. 보상 취소는 별도 broker mutation이며 "
+    "원실패보다 더 위험할 수 있다. 추가 제출은 즉시 중단하고 exit 2 + 부분 실패 "
+    "라벨과 accepted/remaining order key를 산출물에 기록한다."
+)
+
+PARTIAL_BATCH_FAILURE_LABEL: Final[str] = (
+    "PARTIAL_BATCH_FAILURE — 같은 사이클 BUY 묶음 일부만 broker acknowledgement를 "
+    "받았다. 성공이 아니다. 이미 접수된 DAY 주문은 보상 취소하지 않았고 추가 "
+    "mutation은 중단됐다."
 )
 
 ORDERING_REQUIREMENTS: Final[dict[str, str]] = {
@@ -149,6 +175,8 @@ ORDERING_REQUIREMENTS: Final[dict[str, str]] = {
     "lifecycle": "journal immediately after broker acknowledgement plus broker readback",
     "sell": "sell quantity is bounded by fresh attributed broker fills",
     "mutation_boundary": "fresh pending + same-day foreign trace before every mutation",
+    "buy_batch": SAME_CYCLE_BUY_BATCH_POLICY,
+    "partial_batch": PARTIAL_BATCH_RETAIN_POLICY,
     "lease": "account-keyed writer lease checked before every mutation",
     "pnl": "unreadable realized P&L input yields zero new orders",
     "kill": "kill cancels every own pending order and re-reads broker confirmation",
@@ -236,6 +264,37 @@ class KiwoomCycleOutcome:
     @property
     def order_count(self) -> int:
         return 0 if self.derivation is None else len(self.derivation.orders)
+
+
+def _render_kiwoom_cycle_report(
+    record: dict[str, Any], *, labels: tuple[str, ...]
+) -> str:
+    """Add KR batch lifecycle state to the shared deterministic report."""
+
+    base = render_cycle_report(record, labels=labels)
+    batches = record.get("same_cycle_buy_batches") or []
+    if not batches:
+        return base
+    lines = [
+        base.rstrip(),
+        "",
+        "## Same-cycle BUY batches",
+        "",
+        "| cycle_id | symbol | status | planned | accepted keys | remaining keys | compensating cancel | failure |",
+        "|---|---|---|---:|---|---|---|---|",
+    ]
+    for batch in batches:
+        failure = batch.get("failure") or {}
+        lines.append(
+            f"| {batch.get('cycle_id', '-')} | {batch.get('symbol', '-')} | "
+            f"`{batch.get('status', '-')}` | {batch.get('planned_count', 0)} | "
+            f"{', '.join(batch.get('accepted_order_keys') or []) or '-'} | "
+            f"{', '.join(batch.get('remaining_order_keys') or []) or '-'} | "
+            f"{str(bool(batch.get('compensating_cancel_attempted'))).lower()} | "
+            f"{failure.get('reason', '-')}:{failure.get('detail', '-')} |"
+        )
+    lines += ["", f"retention policy: {PARTIAL_BATCH_RETAIN_POLICY}", ""]
+    return "\n".join(lines)
 
 
 def _table_or_reason(
@@ -334,11 +393,17 @@ def _persist_outcome(
     record: dict[str, Any],
     labels: tuple[str, ...],
 ) -> KiwoomCycleOutcome:
+    artifact_labels = (
+        (*labels, PARTIAL_BATCH_FAILURE_LABEL)
+        if record.get("batch_submission_status") == "partial_failure"
+        else labels
+    )
+    record["labels"] = list(artifact_labels)
     ledger.record_cycle(record)
     outcome.record = record
     outcome.artifact_path = ledger.write_artifact(
         name=f"{outcome.at.strftime('%Y%m%dT%H%M%SZ')}-cycle.md",
-        content=render_cycle_report(record, labels=labels),
+        content=_render_kiwoom_cycle_report(record, labels=artifact_labels),
     )
     return outcome
 
@@ -724,7 +789,10 @@ async def _run_prepared_cycle(  # noqa: PLR0915 — retained acceptance path
 
     held = {pos.symbol: pos.quantity for pos in state.positions}
     planned, blocked = kiwoom_lane.plan_orders(
-        derivation.orders, envelope=envelope, held_quantities=held
+        derivation.orders,
+        cycle_id=derivation.cycle_id,
+        envelope=envelope,
+        held_quantities=held,
     )
     record["planned"] = [order.to_json() for order in planned]
     record["blocked"] = [order.to_json() for order in blocked]
@@ -1008,6 +1076,319 @@ def _record_ordering_boundary(
         record=record,
         event={"at": boundary.at.isoformat(), "event": "mutation_boundary", **evidence},
     )
+
+
+def _ordering_submission_groups(
+    planned: list[kiwoom_lane.PlannedOrder],
+) -> tuple[tuple[kiwoom_lane.PlannedOrder, ...], ...]:
+    """Keep order sequence while grouping only contiguous same-symbol BUY legs."""
+
+    groups: list[tuple[kiwoom_lane.PlannedOrder, ...]] = []
+    index = 0
+    while index < len(planned):
+        first = planned[index]
+        if first.side != "buy":
+            groups.append((first,))
+            index += 1
+            continue
+        end = index + 1
+        while (
+            end < len(planned)
+            and planned[end].side == "buy"
+            and planned[end].symbol == first.symbol
+        ):
+            end += 1
+        groups.append(tuple(planned[index:end]))
+        index = end
+    return tuple(groups)
+
+
+def _append_order_intent(
+    *,
+    order: kiwoom_lane.PlannedOrder,
+    table_prices: dict[str, str],
+    fidelity: ordering_support.OrderingEventJournal,
+    record: dict[str, Any],
+) -> None:
+    intent = {
+        "at": dt.datetime.now(dt.UTC).isoformat(),
+        "event": "table_price_to_intended_limit",
+        "cycle_id": order.cycle_id,
+        "order_key": order.order_key,
+        "correlation_id": order.client_order_id,
+        "symbol": order.symbol,
+        "side": order.side,
+        "table_price": table_prices.get(order.order_key),
+        "intended_limit": order.price,
+        "quantity": order.quantity,
+        "time_in_force": "DAY",
+    }
+    _append_ordering_event(journal=fidelity, record=record, event=intent)
+
+
+async def _record_day_order_lifecycle(
+    *,
+    account: kiwoom_lane.ReadOnlyKiwoomMockAccount,
+    order: kiwoom_lane.PlannedOrder,
+    day_order: kiwoom_lane.DayOrderResult,
+    cycle_now: dt.datetime,
+    table_prices: dict[str, str],
+    day_orders: list[dict[str, Any]],
+    fidelity: ordering_support.OrderingEventJournal,
+    record: dict[str, Any],
+) -> tuple[str, str] | None:
+    """Persist acknowledgement first, then require exact broker readback."""
+
+    assert day_order.order_no is not None
+    ack = {
+        **day_order.canonical(),
+        "cycle_id": order.cycle_id,
+        "order_key": order.order_key,
+        "table_price": table_prices.get(order.order_key),
+    }
+    day_orders.append(ack)
+    _append_ordering_event(
+        journal=fidelity,
+        record=record,
+        event={
+            "at": dt.datetime.now(dt.UTC).isoformat(),
+            "event": "broker_ack",
+            "cycle_id": order.cycle_id,
+            "order_key": order.order_key,
+            "broker_ack": ack,
+        },
+    )
+    try:
+        readback = await kiwoom_lane.read_order_readback(
+            account,
+            planned=order,
+            order_no=day_order.order_no,
+            order_date=kiwoom_attr.kst_order_date(cycle_now),
+            at=dt.datetime.now(dt.UTC),
+        )
+    except (
+        kiwoom_lane.BrokerOrderReadbackUnavailable,
+        kiwoom_lane.BrokerEchoMismatch,
+    ) as exc:
+        ack["readback_failure"] = str(exc)
+        return "broker_readback_unavailable", type(exc).__name__
+
+    readback_evidence = readback.canonical()
+    ack["broker_readback"] = readback_evidence
+    _append_ordering_event(
+        journal=fidelity,
+        record=record,
+        event={
+            "at": readback.at.isoformat(),
+            "event": "broker_readback_reconcile",
+            "cycle_id": order.cycle_id,
+            "order_key": order.order_key,
+            "broker_readback": readback_evidence,
+        },
+    )
+    return None
+
+
+def _mark_buy_batch_failure(
+    *,
+    batch: dict[str, Any],
+    record: dict[str, Any],
+    reason: str,
+    detail: str,
+) -> str:
+    accepted = list(batch["accepted_order_keys"])
+    planned = list(batch["order_keys"])
+    if 0 < len(accepted) < len(planned):
+        status = "partial_failure"
+    elif accepted:
+        status = "incomplete_after_all_acknowledged"
+    else:
+        status = "failed_before_acknowledgement"
+    batch.update(
+        {
+            "status": status,
+            "accepted_count": len(accepted),
+            "remaining_order_keys": [key for key in planned if key not in accepted],
+            "failure": {"reason": reason, "detail": detail},
+            "compensating_cancel_attempted": False,
+            "retention_policy": PARTIAL_BATCH_RETAIN_POLICY,
+        }
+    )
+    record["batch_submission_status"] = status
+    return status
+
+
+async def _submit_same_cycle_buy_batch(  # noqa: PLR0913
+    *,
+    account: kiwoom_lane.ReadOnlyKiwoomMockAccount,
+    batch_orders: tuple[kiwoom_lane.PlannedOrder, ...],
+    cycle_id: str,
+    scoped: kr_attribution.ScopedPositions,
+    halted: set[str],
+    journal: kiwoom_attr.OwnOrderJournal,
+    lease: ordering_support.WriterLease,
+    fidelity: ordering_support.OrderingEventJournal,
+    record: dict[str, Any],
+    day_orders: list[dict[str, Any]],
+    table_prices: dict[str, str],
+    cycle_now: dt.datetime,
+) -> tuple[str, str, bool] | None:
+    """Gate once, then submit one exact same-cycle/symbol BUY group in order."""
+
+    batch = {
+        "cycle_id": cycle_id,
+        "symbol": batch_orders[0].symbol,
+        "side": "buy",
+        "order_keys": [order.order_key for order in batch_orders],
+        "planned_count": len(batch_orders),
+        "accepted_order_keys": [],
+        "accepted_order_nos": [],
+        "gate_checks": 0,
+        "mutation_boundary_checks": 0,
+        "status": "pending",
+        "retention_policy": PARTIAL_BATCH_RETAIN_POLICY,
+    }
+    record.setdefault("same_cycle_buy_batches", []).append(batch)
+    for order in batch_orders:
+        _append_order_intent(
+            order=order,
+            table_prices=table_prices,
+            fidelity=fidelity,
+            record=record,
+        )
+
+    if batch["symbol"] in halted:
+        record.setdefault("submission_blocked", []).append(
+            {"symbol": batch["symbol"], "reason": "halted_suspect_symbol"}
+        )
+        batch["status"] = "blocked_halted_suspect"
+        return None
+
+    boundary = await _read_mutation_boundary(
+        account=account,
+        journal=journal,
+        lease=lease,
+        at=dt.datetime.now(dt.UTC),
+    )
+    batch["mutation_boundary_checks"] += 1
+    _record_ordering_boundary(
+        boundary=boundary,
+        action=f"batch_gate:{cycle_id}:{batch['symbol']}",
+        fidelity=fidelity,
+        record=record,
+    )
+    if not boundary.clean:
+        reason = "mutation_boundary_not_clean"
+        detail = boundary.blocking_reason or "unknown_boundary_failure"
+        _mark_buy_batch_failure(
+            batch=batch, record=record, reason=reason, detail=detail
+        )
+        return reason, detail, False
+
+    current_truth = kiwoom_lane.broker_truth_from(
+        position_symbols=scoped.cap_position_symbols,
+        pending=boundary.pending,
+    )
+    batch["gate_checks"] = 1
+    batch["gate_checked_at"] = boundary.at.isoformat()
+    try:
+        authorization = kiwoom_lane.authorize_same_cycle_buy_batch(
+            cycle_id=cycle_id,
+            planned=batch_orders,
+            broker_truth=current_truth,
+        )
+    except OwnPendingResubmitBlocked as exc:
+        batch["status"] = "blocked_by_preexisting_pending"
+        batch["failure"] = {
+            "reason": "pending_recheck_blocked",
+            "detail": str(exc),
+        }
+        record.setdefault("submission_dedup_blocked", []).append(
+            {
+                "symbol": batch["symbol"],
+                "cycle_id": cycle_id,
+                "reason": "pending_recheck_blocked",
+                "detail": str(exc),
+            }
+        )
+        return None
+    except kiwoom_lane.SameCycleBuyBatchViolation as exc:
+        reason = "same_cycle_batch_invalid"
+        detail = str(exc)
+        _mark_buy_batch_failure(
+            batch=batch, record=record, reason=reason, detail=detail
+        )
+        return reason, detail, True
+
+    for index, order in enumerate(batch_orders):
+        if index:
+            boundary = await _read_mutation_boundary(
+                account=account,
+                journal=journal,
+                lease=lease,
+                at=dt.datetime.now(dt.UTC),
+            )
+            batch["mutation_boundary_checks"] += 1
+            _record_ordering_boundary(
+                boundary=boundary,
+                action=f"batch_continue:{cycle_id}:{order.order_key}",
+                fidelity=fidelity,
+                record=record,
+            )
+            if not boundary.clean:
+                reason = "mutation_boundary_not_clean"
+                detail = boundary.blocking_reason or "unknown_boundary_failure"
+                _mark_buy_batch_failure(
+                    batch=batch, record=record, reason=reason, detail=detail
+                )
+                return reason, detail, False
+        try:
+            day_order = await kiwoom_lane.submit_day_order_in_batch(
+                account,
+                planned=order,
+                authorization=authorization,
+                record_order_no=_journal_writer(journal),
+                now=dt.datetime.now(dt.UTC),
+            )
+        except Exception as exc:  # noqa: BLE001 — every batch failure is material
+            reason = "day_order_submission_unverified"
+            detail = type(exc).__name__
+            record.setdefault("day_order_failures", []).append(str(exc))
+            _mark_buy_batch_failure(
+                batch=batch, record=record, reason=reason, detail=detail
+            )
+            return reason, detail, True
+
+        assert day_order.order_no is not None
+        batch["accepted_order_keys"].append(order.order_key)
+        batch["accepted_order_nos"].append(day_order.order_no)
+        lifecycle_failure = await _record_day_order_lifecycle(
+            account=account,
+            order=order,
+            day_order=day_order,
+            cycle_now=cycle_now,
+            table_prices=table_prices,
+            day_orders=day_orders,
+            fidelity=fidelity,
+            record=record,
+        )
+        if lifecycle_failure is not None:
+            reason, detail = lifecycle_failure
+            _mark_buy_batch_failure(
+                batch=batch, record=record, reason=reason, detail=detail
+            )
+            return reason, detail, True
+
+    batch.update(
+        {
+            "status": "complete",
+            "accepted_count": len(batch["accepted_order_keys"]),
+            "remaining_order_keys": [],
+            "compensating_cancel_attempted": False,
+        }
+    )
+    record["batch_submission_status"] = "complete"
+    return None
 
 
 async def _cancel_own_pending_on_kill(  # noqa: PLR0915 — linear safety sequence
@@ -1398,7 +1779,10 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
 
     held = {pos.symbol: pos.quantity for pos in state.positions}
     planned, blocked = kiwoom_lane.plan_orders(
-        derivation.orders, envelope=envelope, held_quantities=held
+        derivation.orders,
+        cycle_id=derivation.cycle_id,
+        envelope=envelope,
+        held_quantities=held,
     )
     record["planned"] = [order.to_json() for order in planned]
     record["blocked"] = [order.to_json() for order in blocked]
@@ -1415,22 +1799,47 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
     # fails.  A broker-accepted order must not disappear from the summary just
     # because its lifecycle could not yet be proven complete.
     record["day_orders"] = day_orders
+    record["same_cycle_buy_batch_policy"] = SAME_CYCLE_BUY_BATCH_POLICY
+    record["partial_batch_retention_policy"] = PARTIAL_BATCH_RETAIN_POLICY
+    record["same_cycle_buy_batches"] = []
     halted = set(halted_suspect_symbols(table))
-    for order in planned:
-        intent_at = dt.datetime.now(dt.UTC)
-        intent = {
-            "at": intent_at.isoformat(),
-            "event": "table_price_to_intended_limit",
-            "order_key": order.order_key,
-            "correlation_id": order.client_order_id,
-            "symbol": order.symbol,
-            "side": order.side,
-            "table_price": table_prices.get(order.order_key),
-            "intended_limit": order.price,
-            "quantity": order.quantity,
-            "time_in_force": "DAY",
-        }
-        _append_ordering_event(journal=fidelity, record=record, event=intent)
+    for submission_group in _ordering_submission_groups(planned):
+        if len(submission_group) > 1:
+            stop = await _submit_same_cycle_buy_batch(
+                account=account,
+                batch_orders=submission_group,
+                cycle_id=derivation.cycle_id,
+                scoped=scoped,
+                halted=halted,
+                journal=journal,
+                lease=lease,
+                fidelity=fidelity,
+                record=record,
+                day_orders=day_orders,
+                table_prices=table_prices,
+                cycle_now=now,
+            )
+            if stop is not None:
+                reason, detail, force_exit_two = stop
+                if force_exit_two:
+                    outcome.exit_code = 2
+                return _finish_ordering_stopped(
+                    outcome=outcome,
+                    ledger=ledger,
+                    record=record,
+                    labels=labels,
+                    reason=reason,
+                    detail=detail,
+                )
+            continue
+
+        order = submission_group[0]
+        _append_order_intent(
+            order=order,
+            table_prices=table_prices,
+            fidelity=fidelity,
+            record=record,
+        )
         if order.symbol in halted:
             record.setdefault("submission_blocked", []).append(
                 {"symbol": order.symbol, "reason": "halted_suspect_symbol"}
@@ -1547,56 +1956,27 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
                 reason="day_order_submission_unverified",
                 detail=type(exc).__name__,
             )
-        assert day_order.order_no is not None
-        ack = {
-            **day_order.canonical(),
-            "table_price": table_prices.get(order.order_key),
-        }
-        day_orders.append(ack)
-        _append_ordering_event(
-            journal=fidelity,
+        lifecycle_failure = await _record_day_order_lifecycle(
+            account=account,
+            order=order,
+            day_order=day_order,
+            cycle_now=now,
+            table_prices=table_prices,
+            day_orders=day_orders,
+            fidelity=fidelity,
             record=record,
-            event={
-                "at": dt.datetime.now(dt.UTC).isoformat(),
-                "event": "broker_ack",
-                "order_key": order.order_key,
-                "broker_ack": ack,
-            },
         )
-        try:
-            readback = await kiwoom_lane.read_order_readback(
-                account,
-                planned=order,
-                order_no=day_order.order_no,
-                order_date=kiwoom_attr.kst_order_date(now),
-                at=dt.datetime.now(dt.UTC),
-            )
-        except (
-            kiwoom_lane.BrokerOrderReadbackUnavailable,
-            kiwoom_lane.BrokerEchoMismatch,
-        ) as exc:
+        if lifecycle_failure is not None:
+            reason, detail = lifecycle_failure
             outcome.exit_code = 2
-            ack["readback_failure"] = str(exc)
             return _finish_ordering_stopped(
                 outcome=outcome,
                 ledger=ledger,
                 record=record,
                 labels=labels,
-                reason="broker_readback_unavailable",
-                detail=type(exc).__name__,
+                reason=reason,
+                detail=detail,
             )
-        readback_evidence = readback.canonical()
-        ack["broker_readback"] = readback_evidence
-        _append_ordering_event(
-            journal=fidelity,
-            record=record,
-            event={
-                "at": readback.at.isoformat(),
-                "event": "broker_readback_reconcile",
-                "order_key": order.order_key,
-                "broker_readback": readback_evidence,
-            },
-        )
 
     record["fidelity_artifact"]["event_count_after_cycle"] = len(fidelity.read_all())
     return _persist_outcome(
@@ -1648,6 +2028,7 @@ def _stamp_contract_and_account_map(
         "path": "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md",
         "version": KR_CONTRACT_VERSION,
         "clauses": dict(KR_CONTRACT_CLAUSES),
+        "file_sha256_reference_only": KR_CONTRACT_FILE_SHA256_REFERENCE_ONLY,
     }
     record["account_map"] = {
         "repo": "auto_trader-operator",
@@ -1692,12 +2073,7 @@ async def run_kiwoom_cycle(
     cycle_status, status_label = _cycle_status(confirm=confirm, mode=mode)
     labels = header_labels(
         lane=LANE,
-        extra=(
-            *account_history_labels(LANE),
-            COEXISTENCE_LABEL,
-            status_label,
-            LADDER_MULTI_RUNG_OBSERVATION_LIMIT,
-        ),
+        extra=(*account_history_labels(LANE), COEXISTENCE_LABEL, status_label),
     )
     outcome = KiwoomCycleOutcome(lane=LANE, at=now)
     root = Path(out_dir).expanduser()

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -137,6 +137,12 @@ ORDERING_STATUS_LABEL: Final[str] = (
     "확인한다. KRX RTH only."
 )
 
+LADDER_MULTI_RUNG_OBSERVATION_LIMIT: Final[str] = (
+    "LADDER_MULTI_RUNG_OBSERVATION_LIMIT — 사다리 2단 이상은 현행 게이트로 "
+    "제출되지 않는다(관측 한계). 사이클 내 일괄 제출 계약이 랜딩하기 전까지의 "
+    "한시 라벨이다."
+)
+
 ORDERING_REQUIREMENTS: Final[dict[str, str]] = {
     "table_only": "policy_table deterministic derivation within locked §4 envelope",
     "day": "default TIF is DAY; successful acknowledgement is never auto-cancelled",
@@ -1686,7 +1692,12 @@ async def run_kiwoom_cycle(
     cycle_status, status_label = _cycle_status(confirm=confirm, mode=mode)
     labels = header_labels(
         lane=LANE,
-        extra=(*account_history_labels(LANE), COEXISTENCE_LABEL, status_label),
+        extra=(
+            *account_history_labels(LANE),
+            COEXISTENCE_LABEL,
+            status_label,
+            LADDER_MULTI_RUNG_OBSERVATION_LIMIT,
+        ),
     )
     outcome = KiwoomCycleOutcome(lane=LANE, at=now)
     root = Path(out_dir).expanduser()

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -38,6 +38,7 @@ def _write_table(
     symbols: tuple[str, ...] = ("005930",),
     halted: list[str] | None = None,
     buy_l1: str | None = "70000",
+    buy_l2: str | None = None,
     sell_r1: str | None = None,
 ) -> None:
     """Write a real, hash-valid ``policy_table.v1`` for the KR market.
@@ -53,6 +54,7 @@ def _write_table(
                 symbol=symbol,
                 previous_close="72000.00",
                 buy_l1=buy_l1,
+                buy_l2=buy_l2,
                 sell_r1=sell_r1,
             )
             for symbol in symbols
@@ -188,6 +190,15 @@ async def test_record_carries_the_account_map_and_status_label(
     record = outcome.record
 
     assert record["cycle_status"] == "OBSERVATION_DERIVATION_ONLY"
+    assert record["contract"]["version"] == "v1.8"
+    assert record["contract"]["file_sha256_reference_only"] == (
+        "7d2729bc4197dd167d40e3e881b64f30a778b1b1a7158acf81fd0c7d38d008c0"
+    )
+    v18 = record["contract"]["clauses"]["§8 v1.8 (v1.5 ① KR amendment)"]
+    assert "동일 cycle_id·동일 symbol·BUY 다단" in v18
+    assert "다음 cycle의 기존 자기 미체결 차단" in v18
+    assert "crypto/US와 공용 게이트는 불변" in v18
+    assert "partial_failure + exit 2" in v18
     assert record["account_map"]["commit"] == kiwoom_cycle.KR_ACCOUNT_MAP_COMMIT
     assert record["account_map"]["gate_values"]["account_lanes.kiwoom_mock"] == "KR-B1"
     assert (
@@ -200,10 +211,9 @@ async def test_record_carries_the_account_map_and_status_label(
     assert any("COEXISTING_ACCOUNT_LANE" in label for label in record["labels"]), (
         "the coexistence caveat must be on every artifact"
     )
-    assert kiwoom_cycle.LADDER_MULTI_RUNG_OBSERVATION_LIMIT in record["labels"]
     assert outcome.artifact_path is not None
     artifact = outcome.artifact_path.read_text(encoding="utf-8")
-    assert "사다리 2단 이상은 현행 게이트로 제출되지 않는다(관측 한계)" in artifact
+    assert "LADDER_MULTI_RUNG_OBSERVATION_LIMIT" not in artifact
 
 
 @pytest.mark.asyncio
@@ -580,6 +590,265 @@ async def test_ordering_submits_table_derived_day_orders_with_readback_fidelity(
     )
     assert all(event["at"] and event["event"] for event in persisted_events)
     assert lease.checks >= len(outcome.record["day_orders"]) + 1
+
+
+@pytest.mark.asyncio
+async def test_ordering_batches_same_cycle_buy_ladder_under_one_gate(
+    table_dir, out_dir, armed, frozen_cycle_clock, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l2="68000",
+    )
+    gate_symbols: list[str] = []
+    real_assert = kiwoom_lane.assert_resubmit_allowed
+
+    def counted_assert(truth, *, symbol, lane):  # noqa: ANN001, ANN202
+        gate_symbols.append(symbol)
+        return real_assert(truth, symbol=symbol, lane=lane)
+
+    monkeypatch.setattr(kiwoom_lane, "assert_resubmit_allowed", counted_assert)
+    account = _DynamicOrderingAccount()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.exit_code == 0
+    assert gate_symbols == ["005930"]
+    assert len(account.buy_calls) == 2
+    assert {order["cycle_id"] for order in outcome.record["planned"]} == {
+        outcome.record["cycle_id"]
+    }
+    batch = outcome.record["same_cycle_buy_batches"][0]
+    assert batch["cycle_id"] == outcome.record["cycle_id"]
+    assert batch["status"] == "complete"
+    assert batch["gate_checks"] == 1
+    assert batch["mutation_boundary_checks"] == 2
+    assert batch["accepted_count"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "second_error",
+    [
+        kiwoom_lane.KiwoomBrokerRejected(
+            api="kt10000", return_code=1, return_msg="second rung rejected"
+        ),
+        OSError("second rung transport failed"),
+    ],
+    ids=("broker-rejected", "transport-error"),
+)
+async def test_ordering_partial_batch_failure_is_not_success_and_retains_ack(
+    table_dir, out_dir, armed, frozen_cycle_clock, second_error
+) -> None:  # noqa: ANN001, ARG001
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l2="68000",
+    )
+
+    class RejectsSecondRung(_DynamicOrderingAccount):
+        async def place_limit_buy(self, *, symbol, quantity, price):  # noqa: ANN001, ANN201
+            if self.buy_calls:
+                await FakeAccount.place_limit_buy(
+                    self, symbol=symbol, quantity=quantity, price=price
+                )
+                raise second_error
+            return await super().place_limit_buy(
+                symbol=symbol, quantity=quantity, price=price
+            )
+
+    account = RejectsSecondRung()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.exit_code == 2
+    assert outcome.record["batch_submission_status"] == "partial_failure"
+    assert outcome.record["submission_stopped"] == "day_order_submission_unverified"
+    batch = outcome.record["same_cycle_buy_batches"][0]
+    assert batch["status"] == "partial_failure"
+    assert batch["accepted_count"] == 1
+    assert len(batch["remaining_order_keys"]) == 1
+    assert batch["compensating_cancel_attempted"] is False
+    assert len(outcome.record["day_orders"]) == 1
+    assert outcome.record["day_orders"][0]["broker_readback"]["partial"] is True
+    assert len(account.buy_calls) == 2
+    assert account.cancel_calls == []
+    assert outcome.artifact_path is not None
+    artifact = outcome.artifact_path.read_text(encoding="utf-8")
+    assert "PARTIAL_BATCH_FAILURE" in artifact
+    assert "성공이 아니다" in artifact
+    assert batch["accepted_order_keys"][0] in artifact
+    assert batch["remaining_order_keys"][0] in artifact
+    assert "| false | day_order_submission_unverified:" in artifact
+
+
+@pytest.mark.asyncio
+async def test_ordering_rechecks_foreign_trace_between_batch_legs(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l2="68000",
+    )
+
+    class ForeignWriterInterleaves(_DynamicOrderingAccount):
+        async def place_limit_buy(self, *, symbol, quantity, price):  # noqa: ANN001, ANN201
+            result = await super().place_limit_buy(
+                symbol=symbol, quantity=quantity, price=price
+            )
+            if len(self.buy_calls) == 1:
+                self.rows.append(
+                    {
+                        "order_id": "foreign-between-legs",
+                        "symbol": symbol,
+                        "status": "open",
+                        "ordered_quantity": 1,
+                        "filled_quantity": 0,
+                        "remaining_quantity": 1,
+                        "unfilled_quantity": 1,
+                        "ordered_price": price,
+                        "average_price": 0,
+                    }
+                )
+            return result
+
+    account = ForeignWriterInterleaves()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.exit_code == 2
+    assert len(account.buy_calls) == 1
+    assert account.cancel_calls == []
+    batch = outcome.record["same_cycle_buy_batches"][0]
+    assert batch["status"] == "partial_failure"
+    assert batch["failure"]["reason"] == "mutation_boundary_not_clean"
+    assert batch["failure"]["detail"] == "foreign_same_day_orders_present"
+    assert (
+        outcome.record["mutation_boundaries"][-1]["foreign_same_day_orders"]["count"]
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_next_cycle_still_blocks_the_same_symbol_batch(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l2="68000",
+    )
+    account = _DynamicOrderingAccount()
+
+    def readable_zero(**_kwargs):  # noqa: ANN003, ANN202
+        return kiwoom_attr.RealizedPnlInput(value=Decimal("0"), source="test")
+
+    first = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=readable_zero,
+    )
+    second = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock + dt.timedelta(minutes=1),
+        lease_factory=lambda *_: _TestOrderingLease(),
+        realized_pnl_reader=readable_zero,
+    )
+
+    assert len(first.record["day_orders"]) == 2
+    assert len(account.buy_calls) == 2, "cycle 2 must not stack another ladder"
+    assert first.record["cycle_id"] != second.record["cycle_id"]
+    assert second.record["orders"] == []
+    assert second.record["submitted"] == []
+    assert second.record["same_cycle_buy_batches"] == []
+    assert [skip["reason"] for skip in second.record["skipped"]] == [
+        "own_pending_order_exists"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ladder_batches_preserve_the_1800000_cycle_cap_and_daily_symbol_cap(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        symbols=("005930", "000660", "035420", "051910"),
+        buy_l2="68000",
+    )
+    account = _DynamicOrderingAccount()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.exit_code == 0
+    assert len(outcome.record["day_orders"]) == 6
+    assert len({order["symbol"] for order in outcome.record["day_orders"]}) == 3
+    assert all(
+        order["notional_krw"] <= 300_000 for order in outcome.record["day_orders"]
+    )
+    assert (
+        sum(order["notional_krw"] for order in outcome.record["day_orders"])
+        <= 1_800_000
+    )
+    for symbol in {order["symbol"] for order in outcome.record["day_orders"]}:
+        assert (
+            sum(
+                order["notional_krw"]
+                for order in outcome.record["day_orders"]
+                if order["symbol"] == symbol
+            )
+            <= 1_500_000
+        )
+    assert [
+        batch["gate_checks"] for batch in outcome.record["same_cycle_buy_batches"]
+    ] == [
+        1,
+        1,
+        1,
+    ]
+    assert any(
+        skip["symbol"] == "051910" and skip["reason"] == "daily_new_entry_cap_reached"
+        for skip in outcome.record["skipped"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -698,6 +698,71 @@ async def test_ordering_partial_batch_failure_is_not_success_and_retains_ack(
 
 
 @pytest.mark.asyncio
+async def test_ordering_rechecks_foreign_trace_before_first_batch_leg(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    """A foreign order appearing after preflight must stop the batch before L1."""
+
+    _write_table(
+        table_dir,
+        generated_at=IN_SESSION - dt.timedelta(hours=4),
+        buy_l2="68000",
+    )
+
+    class ForeignWriterBeforeBatchGate(_DynamicOrderingAccount):
+        async def read_order_detail(  # noqa: ANN201
+            self,
+            *,
+            order_date=None,
+            symbol=None,  # noqa: ANN001
+        ):
+            rows = await super().read_order_detail(order_date=order_date, symbol=symbol)
+            if len(self.detail_calls) == 1:
+                self.rows.append(
+                    {
+                        "order_id": "foreign-writer-other-symbol",
+                        "symbol": "000660",
+                        "status": "open",
+                        "ordered_quantity": 1,
+                        "filled_quantity": 0,
+                        "remaining_quantity": 1,
+                        "unfilled_quantity": 1,
+                        "ordered_price": 100_000,
+                        "average_price": 0,
+                    }
+                )
+            return rows
+
+    account = ForeignWriterBeforeBatchGate()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+    )
+
+    assert outcome.exit_code == 0
+    assert account.buy_calls == []
+    assert outcome.record["batch_submission_status"] == (
+        "failed_before_acknowledgement"
+    )
+    batch = outcome.record["same_cycle_buy_batches"][0]
+    assert batch["status"] == "failed_before_acknowledgement"
+    assert batch["accepted_order_keys"] == []
+    assert batch["failure"] == {
+        "reason": "mutation_boundary_not_clean",
+        "detail": "foreign_same_day_orders_present",
+    }
+    assert outcome.record["mutation_boundaries"][-1]["action"].startswith("batch_gate:")
+    assert outcome.record["mutation_boundaries"][-1]["foreign_same_day_orders"][
+        "symbols"
+    ] == ["000660"]
+
+
+@pytest.mark.asyncio
 async def test_ordering_rechecks_foreign_trace_between_batch_legs(
     table_dir, out_dir, armed, frozen_cycle_clock
 ) -> None:  # noqa: ANN001, ARG001

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -200,6 +200,10 @@ async def test_record_carries_the_account_map_and_status_label(
     assert any("COEXISTING_ACCOUNT_LANE" in label for label in record["labels"]), (
         "the coexistence caveat must be on every artifact"
     )
+    assert kiwoom_cycle.LADDER_MULTI_RUNG_OBSERVATION_LIMIT in record["labels"]
+    assert outcome.artifact_path is not None
+    artifact = outcome.artifact_path.read_text(encoding="utf-8")
+    assert "사다리 2단 이상은 현행 게이트로 제출되지 않는다(관측 한계)" in artifact
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_envelope_session_and_semantics.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_envelope_session_and_semantics.py
@@ -84,7 +84,10 @@ def test_realized_notional_over_the_cap_is_blocked_after_the_floor() -> None:
         order_key="k",
     )
     planned, blocked = kiwoom_lane.plan_orders(
-        (order,), envelope=KR_MOCK_ENVELOPE, held_quantities={}
+        (order,),
+        cycle_id="b0x-test-cycle",
+        envelope=KR_MOCK_ENVELOPE,
+        held_quantities={},
     )
     # 300,000 / 400,000 floors to 0 shares — blocked, never rounded up.
     assert planned == []

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py
@@ -28,13 +28,22 @@ pytestmark = pytest.mark.unit
 CLEAN_TRUTH = BrokerTruth(position_symbols=(), own_pending=())
 
 
-def _planned(symbol: str = "005930", quantity: int = 1, price: int = 70_000):  # noqa: ANN202
+def _planned(  # noqa: PLR0913
+    symbol: str = "005930",
+    quantity: int = 1,
+    price: int = 70_000,
+    *,
+    cycle_id: str = "b0x-test-cycle",
+    order_key: str = "deadbeefdeadbeef",
+    leg: str = "buy_l1",
+):  # noqa: ANN202
     return kiwoom_lane.PlannedOrder(
-        order_key="deadbeefdeadbeef",
-        client_order_id="b0xkw-deadbeefdeadbeef",
+        cycle_id=cycle_id,
+        order_key=order_key,
+        client_order_id=f"b0xkw-{order_key}",
         symbol=symbol,
         side="buy",
-        leg="buy_l1",
+        leg=leg,
         price=price,
         quantity=quantity,
         notional=Decimal(price * quantity),
@@ -132,6 +141,80 @@ async def test_ordering_day_submission_blocks_same_symbol_own_pending(now) -> No
         )
 
     assert account.buy_calls == [], "a blocked DAY resubmit must not reach the venue"
+
+
+@pytest.mark.asyncio
+async def test_same_cycle_buy_batch_checks_the_common_gate_once(
+    now, monkeypatch
+) -> None:  # noqa: ANN001
+    """The batch proof is exact and the unchanged common gate runs once."""
+
+    calls: list[str] = []
+    real_assert = kiwoom_lane.assert_resubmit_allowed
+
+    def counted_assert(truth, *, symbol, lane):  # noqa: ANN001, ANN202
+        calls.append(symbol)
+        return real_assert(truth, symbol=symbol, lane=lane)
+
+    monkeypatch.setattr(kiwoom_lane, "assert_resubmit_allowed", counted_assert)
+    first = _planned(order_key="l1", leg="buy_l1")
+    second = _planned(order_key="l2", leg="buy_l2", price=68_000)
+    authorization = kiwoom_lane.authorize_same_cycle_buy_batch(
+        cycle_id="b0x-test-cycle",
+        planned=(first, second),
+        broker_truth=CLEAN_TRUTH,
+    )
+    account = FakeAccount()
+
+    await kiwoom_lane.submit_day_order_in_batch(
+        account,
+        planned=first,
+        authorization=authorization,
+        record_order_no=_sink(),
+        now=now,
+    )
+    await kiwoom_lane.submit_day_order_in_batch(
+        account,
+        planned=second,
+        authorization=authorization,
+        record_order_no=_sink(),
+        now=now,
+    )
+
+    assert calls == ["005930"]
+    assert authorization.attempted_count == 2
+    assert [call["price"] for call in account.buy_calls] == [70_000, 68_000]
+
+
+@pytest.mark.parametrize(
+    "second",
+    [
+        _planned(cycle_id="b0x-other-cycle", order_key="l2", leg="buy_l2"),
+        _planned(symbol="000660", order_key="l2", leg="buy_l2"),
+    ],
+    ids=("cross-cycle", "cross-symbol"),
+)
+def test_same_cycle_buy_batch_rejects_boundary_widening(second) -> None:  # noqa: ANN001
+    first = _planned(order_key="l1", leg="buy_l1")
+
+    with pytest.raises(kiwoom_lane.SameCycleBuyBatchViolation):
+        kiwoom_lane.authorize_same_cycle_buy_batch(
+            cycle_id="b0x-test-cycle",
+            planned=(first, second),
+            broker_truth=CLEAN_TRUTH,
+        )
+
+
+def test_same_cycle_buy_batch_proof_cannot_be_forged() -> None:
+    with pytest.raises(
+        kiwoom_lane.SameCycleBuyBatchViolation, match="not minted by the gate"
+    ):
+        kiwoom_lane.SameCycleBuyBatchAuthorization(
+            cycle_id="b0x-test-cycle",
+            symbol="005930",
+            order_keys=("l1", "l2"),
+            _proof=object(),
+        )
 
 
 @pytest.mark.asyncio
@@ -383,6 +466,7 @@ async def test_sell_side_is_refused_by_the_acceptance_lever(now) -> None:  # noq
     """A sell cannot be taken back by the mandatory cancel, so it is not wired."""
 
     sell = kiwoom_lane.PlannedOrder(
+        cycle_id="b0x-test-cycle",
         order_key="k",
         client_order_id="b0xkw-k",
         symbol="005930",

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_static_guards.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_static_guards.py
@@ -280,6 +280,46 @@ def test_kiwoom_broker_imports_are_only_the_three_sanctioned_classes() -> None:
     )
 
 
+def test_same_cycle_batch_api_is_kr_local_and_common_callers_are_unchanged() -> None:
+    """Lane isolation (A): only the kiwoom path can name the batch proof."""
+
+    common = REPO_ROOT / "scripts" / "b0x" / "broker_truth.py"
+    frozen_callers = (
+        REPO_ROOT / "scripts" / "b0x" / "crypto" / "sidecar.py",
+        REPO_ROOT / "scripts" / "b0x" / "us" / "alpaca.py",
+    )
+    batch_names = (
+        "SameCycleBuyBatchAuthorization",
+        "authorize_same_cycle_buy_batch",
+        "submit_day_order_in_batch",
+    )
+
+    for path in (common, *frozen_callers):
+        source = _source(path)
+        assert all(name not in source for name in batch_names), path
+
+    for path in frozen_callers:
+        calls = [
+            node
+            for node in ast.walk(ast.parse(_source(path)))
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "assert_resubmit_allowed"
+        ]
+        assert len(calls) == 1, (
+            f"{path.name} must retain its one existing common-gate call; got "
+            f"{len(calls)}"
+        )
+
+    common_tree = ast.parse(_source(common))
+    definition = next(
+        node
+        for node in common_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "assert_resubmit_allowed"
+    )
+    assert [arg.arg for arg in definition.args.args] == ["truth"]
+    assert [arg.arg for arg in definition.args.kwonlyargs] == ["symbol", "lane"]
+
+
 def test_guard_would_actually_catch_a_bypass() -> None:
     """FALSE-GREEN check: the guards must fail on a planted violation.
 

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -55,14 +55,18 @@ IN_SESSION_NOW = dt.datetime(2026, 8, 10, 2, 0, tzinfo=dt.UTC)
 WEEKEND_NOW = dt.datetime(2026, 8, 8, 2, 0, tzinfo=dt.UTC)
 
 
-def test_kr_contracts_are_v17_and_keep_their_lane_clauses() -> None:
+def test_kr_contracts_keep_their_lane_clauses_at_current_versions() -> None:
     scheduler_clause = common_contract.CONTRACT_CLAUSES["§8 v1.7"]
 
     assert kr_cycle.KR_CONTRACT_VERSION == "v1.7"
     assert kr_cycle.KR_CONTRACT_CLAUSES["§8 v1.7"] == scheduler_clause
     assert "§8 v1.6" in kr_cycle.KR_CONTRACT_CLAUSES
 
-    assert kiwoom_cycle.KR_CONTRACT_VERSION == "v1.7"
+    # v1.8 = the kiwoom-lane ladder batch-submit amendment (§69차); it layers
+    # on top of the v1.7 scheduler clause and the v1.6 lane clauses, so all
+    # three must remain present.
+    assert kiwoom_cycle.KR_CONTRACT_VERSION == "v1.8"
+    assert "§8 v1.8 (v1.5 ① KR amendment)" in kiwoom_cycle.KR_CONTRACT_CLAUSES
     assert kiwoom_cycle.KR_CONTRACT_CLAUSES["§8 v1.7"] == scheduler_clause
     assert "§8 v1.6" in kiwoom_cycle.KR_CONTRACT_CLAUSES
     assert "§39차 ①②③④⑤" in kiwoom_cycle.KR_CONTRACT_CLAUSES


### PR DESCRIPTION
## Dependency

- Draft PR-B, stacked on and landing after PR-A #1859.
- PR-B removes the temporary `LADDER_MULTI_RUNG_OBSERVATION_LIMIT` label once the revised KR contract lands.

## Contract and implementation

- choose lane isolation A: the capability and batch submission path are KR-local; shared broker truth, crypto sidecar, and US Alpaca callers have zero diff
- define one cycle by the deterministic derivation identity: policy table hash + pre-submit account-state hash + locked envelope hash + lane
- authorize only 2+ same-cycle, same-symbol BUY legs, with exact ordered keys; invoke the unchanged common resubmit gate once immediately before the batch
- re-read writer lease and same-day foreign broker trace before every later leg; preserve the existing broker-answer-to-send TOCTOU disclosure
- retain already acknowledged DAY orders on partial failure, attempt no compensating cancel, stop later mutations, emit `partial_failure`, exit 2, and record accepted/remaining keys
- preserve per-order 300k, per-symbol 1.5m, per-cycle 1.8m, and daily-new-symbol 3 caps; SELL and loss-guard paths remain singleton and unchanged
- update the KR runbook and canonical external contract to v1.8; referenced contract SHA-256: `7d2729bc4197dd167d40e3e881b64f30a778b1b1a7158acf81fd0c7d38d008c0`

## Verification

- `make lint` — Ruff check/format and ty all passed
- `uv run pytest tests/scripts/b0x/kr/kiwoom -q` — 169 passed
- common gate + crypto sidecar + US Alpaca + KR isolation suite — 87 passed
- all B0-X tests — 760 passed, 3 skipped
- feature acceptance selection — 10 passed
- two mutants failed as required and were restored: cross-cycle gate removal; partial failure mislabeled complete
- full `uv run pytest tests/ -q -ra -m "not live"` — 19440 passed, 13 skipped, 7 deselected, 3 failed, 35 warnings

The three full-suite failures are all pre-existing local-environment cases in `tests/research/test_kr_backfill_build_clients.py::test_selected_configured_providers_still_fail_closed_without_env`: KIS settings are loaded from the repository-local `.env`, while Toss correctly fails closed as `TossApiDisabled` instead of the stale expected `ValidationError`. The test and implementation files have zero diff from pinned base `26c60abc`; no task-path failure occurred.

## Safety

No broker/account contact, live or mock order, armed environment, cycle execution, deployment, merge, scheduler change, or verifier spawn was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic cycle tracking for planned orders.
  * Added same-cycle, same-symbol BUY batch submission with validation and duplicate prevention.
  * Added detailed batch status reporting and partial-failure handling.

* **Bug Fixes**
  * Prevented new-cycle orders when prior-cycle orders remain unsettled.
  * Preserved successfully acknowledged orders when later submissions fail.

* **Documentation**
  * Updated the Kiwoom KR contract to v1.8 with revised safety rules and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->