### PR TITLE
feat(invest): add B1 loss-cut approval validation

### DIFF
--- a/alembic/versions/20260814_loss_cut_approval_b1.py
+++ b/alembic/versions/20260814_loss_cut_approval_b1.py
@@ -1,0 +1,286 @@
+"""Add channel-neutral loss-cut approval ceremony records.
+
+Revision ID: 20260814_lcapprove_b1
+Revises: 20260805_toss_merge
+Create Date: 2026-08-14
+
+This revision is additive.  It does not backfill approvals or create an order
+submission path; existing dispatch attempts are classified as Telegram rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260814_lcapprove_b1"
+down_revision: str = "20260805_toss_merge"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SCHEMA = "review"
+
+
+def upgrade() -> None:
+    for definition in (
+        "approval_dispatch_channel TEXT",
+        "approval_dispatch_scope_hash TEXT",
+        "approval_dispatch_evidence_hash TEXT",
+        "approved_by_channel TEXT",
+        "approved_by_subject TEXT",
+    ):
+        op.execute(
+            f"ALTER TABLE review.order_proposals ADD COLUMN IF NOT EXISTS {definition}"
+        )
+    op.create_check_constraint(
+        "order_proposals_approval_dispatch_channel",
+        "order_proposals",
+        "approval_dispatch_channel IS NULL OR "
+        "approval_dispatch_channel IN ('telegram','web')",
+        schema=_SCHEMA,
+    )
+    op.create_check_constraint(
+        "order_proposals_approved_by_channel",
+        "order_proposals",
+        "approved_by_channel IS NULL OR approved_by_channel IN ('telegram','web')",
+        schema=_SCHEMA,
+    )
+
+    op.add_column(
+        "order_proposal_approval_dispatch_attempts",
+        sa.Column(
+            "channel",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'telegram'"),
+        ),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        "order_proposal_approval_dispatch_attempts",
+        sa.Column("scope_hash", sa.Text()),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        "order_proposal_approval_dispatch_attempts",
+        sa.Column("evidence_hash", sa.Text()),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        "order_proposal_approval_dispatch_attempts",
+        sa.Column("publication_ref_digest", sa.Text()),
+        schema=_SCHEMA,
+    )
+    op.create_check_constraint(
+        "order_proposal_approval_dispatch_attempt_channel",
+        "order_proposal_approval_dispatch_attempts",
+        "channel IN ('telegram','web')",
+        schema=_SCHEMA,
+    )
+
+    op.create_table(
+        "order_proposal_loss_cut_scopes",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("proposal_pk", sa.BigInteger(), nullable=False),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("account_ref", sa.Text(), nullable=False),
+        sa.Column("account_mode", sa.Text(), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("requested_quantity", sa.Numeric(38, 12), nullable=False),
+        sa.Column("observed_total_quantity", sa.Numeric(38, 12), nullable=False),
+        sa.Column("observed_sellable_quantity", sa.Numeric(38, 12), nullable=False),
+        sa.Column("average_price", sa.Numeric(38, 12), nullable=False),
+        sa.Column("position_scope", postgresql.JSONB(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("observed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("decision_observed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("evidence_valid_until", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("scope_hash", sa.Text(), nullable=False),
+        sa.Column("evidence_hash", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["proposal_pk"],
+            ["review.order_proposals.id"],
+            ondelete="CASCADE",
+            name="fk_order_proposal_loss_cut_scope_proposal",
+        ),
+        sa.UniqueConstraint(
+            "proposal_pk", name="uq_order_proposal_loss_cut_scopes_proposal"
+        ),
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_order_proposal_loss_cut_scopes_scope_hash",
+        "order_proposal_loss_cut_scopes",
+        ["scope_hash"],
+        schema=_SCHEMA,
+    )
+
+    op.create_table(
+        "order_proposal_approval_events",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("proposal_pk", sa.BigInteger(), nullable=False),
+        sa.Column("ceremony_digest", sa.Text(), nullable=False),
+        sa.Column("channel", sa.Text(), nullable=False),
+        sa.Column("step", sa.Text(), nullable=False),
+        sa.Column("outcome", sa.Text(), nullable=False),
+        sa.Column("actor_kind", sa.Text(), nullable=False),
+        sa.Column("actor_subject", sa.Text(), nullable=False),
+        sa.Column("actor_role", sa.Text()),
+        sa.Column("dispatch_attempt_id", postgresql.UUID(as_uuid=True)),
+        sa.Column("membership_revision", sa.Integer()),
+        sa.Column("membership_digest", sa.Text()),
+        sa.Column("nonce_digest", sa.Text()),
+        sa.Column("proposal_payload_hash", sa.Text()),
+        sa.Column("scope_hash", sa.Text()),
+        sa.Column("evidence_hash", sa.Text()),
+        sa.Column("evidence_snapshot", postgresql.JSONB()),
+        sa.Column("reason_code", sa.Text()),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True)),
+        sa.Column("observed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "channel IN ('telegram','web')",
+            name="order_proposal_approval_events_channel",
+        ),
+        sa.CheckConstraint(
+            "step IN ('begin','confirm')",
+            name="order_proposal_approval_events_step",
+        ),
+        sa.CheckConstraint(
+            "outcome IN ('accepted','rejected','needs_reconfirm','expired')",
+            name="order_proposal_approval_events_outcome",
+        ),
+        sa.CheckConstraint(
+            "actor_kind IN ('user','telegram')",
+            name="order_proposal_approval_events_actor_kind",
+        ),
+        sa.ForeignKeyConstraint(
+            ["proposal_pk"],
+            ["review.order_proposals.id"],
+            ondelete="RESTRICT",
+            name="fk_order_proposal_approval_event_proposal",
+        ),
+        sa.UniqueConstraint(
+            "event_id", name="uq_order_proposal_approval_events_event_id"
+        ),
+        sa.UniqueConstraint(
+            "proposal_pk",
+            "ceremony_digest",
+            "step",
+            name="uq_order_proposal_approval_events_ceremony_step",
+        ),
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_order_proposal_approval_events_proposal_observed",
+        "order_proposal_approval_events",
+        ["proposal_pk", "observed_at"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_order_proposal_approval_events_ceremony",
+        "order_proposal_approval_events",
+        ["ceremony_digest"],
+        schema=_SCHEMA,
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION review.reject_order_proposal_approval_event_mutation()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            RAISE EXCEPTION 'order proposal approval events are append-only';
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_order_proposal_approval_events_append_only
+        BEFORE UPDATE OR DELETE ON review.order_proposal_approval_events
+        FOR EACH ROW EXECUTE FUNCTION
+            review.reject_order_proposal_approval_event_mutation()
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_order_proposal_approval_events_truncate_append_only
+        BEFORE TRUNCATE ON review.order_proposal_approval_events
+        FOR EACH STATEMENT EXECUTE FUNCTION
+            review.reject_order_proposal_approval_event_mutation()
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP TRIGGER IF EXISTS "
+        "trg_order_proposal_approval_events_truncate_append_only "
+        "ON review.order_proposal_approval_events"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_order_proposal_approval_events_append_only "
+        "ON review.order_proposal_approval_events"
+    )
+    op.execute(
+        "DROP FUNCTION IF EXISTS review.reject_order_proposal_approval_event_mutation()"
+    )
+    op.drop_table("order_proposal_approval_events", schema=_SCHEMA)
+    op.drop_table("order_proposal_loss_cut_scopes", schema=_SCHEMA)
+    op.drop_constraint(
+        "order_proposal_approval_dispatch_attempt_channel",
+        "order_proposal_approval_dispatch_attempts",
+        schema=_SCHEMA,
+        type_="check",
+    )
+    for column in (
+        "publication_ref_digest",
+        "evidence_hash",
+        "scope_hash",
+        "channel",
+    ):
+        op.drop_column(
+            "order_proposal_approval_dispatch_attempts", column, schema=_SCHEMA
+        )
+    op.drop_constraint(
+        "order_proposals_approved_by_channel",
+        "order_proposals",
+        schema=_SCHEMA,
+        type_="check",
+    )
+    op.drop_constraint(
+        "order_proposals_approval_dispatch_channel",
+        "order_proposals",
+        schema=_SCHEMA,
+        type_="check",
+    )
+    for column in (
+        "approved_by_subject",
+        "approved_by_channel",
+        "approval_dispatch_evidence_hash",
+        "approval_dispatch_scope_hash",
+        "approval_dispatch_channel",
+    ):
+        op.drop_column("order_proposals", column, schema=_SCHEMA)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -865,6 +865,10 @@ class Settings(BaseSettings):
     ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER: str = "X-Telegram-Bot-Api-Secret-Token"
     ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR: str = ""
     ORDER_PROPOSALS_SUBMIT_AGENT_ID: str = ""
+    # B0/B1 loss-cut web surfaces. Both are physically absent from the app
+    # unless an operator enables at least one flag after schema rollout.
+    INVEST_LOSS_CUT_EVIDENCE_ENABLED: bool = False
+    INVEST_LOSS_CUT_APPROVAL_ENABLED: bool = False
 
     # ROB-897: gate for the scheduleless order_proposal valid_until expiry sweep
     # TaskIQ task. Default off -- the sweep runs manually first (dry_run MCP tool

--- a/app/core/invest_deep_links.py
+++ b/app/core/invest_deep_links.py
@@ -9,9 +9,8 @@ import and call these builders instead of constructing paths inline — mirrors
 the existing ``app/core/portfolio_links.py`` pattern (same ``public_base_url``
 source, same "pure builder, caller attaches" split).
 
-No builder here targets the Phase 2 approval page — it does not exist yet
-(§57차 explicitly forbids starting Phase 2 UI in this job), so there is
-nothing to link to for the third deep-link type ("승인 카드 → 승인 페이지").
+The loss-cut builder carries only a proposal UUID. Approval nonce, actor,
+account, quantity, and price never enter the URL.
 """
 
 from __future__ import annotations
@@ -19,6 +18,16 @@ from __future__ import annotations
 from urllib.parse import quote
 
 from app.core.config import settings
+
+
+def build_loss_cut_approval_url(*, proposal_id: object) -> str:
+    """URL to the authenticated evidence and two-step loss-cut page."""
+    proposal = quote(str(proposal_id).strip(), safe="")
+    if not proposal:
+        raise ValueError("proposal_id is required")
+    return (
+        f"{settings.public_base_url.rstrip('/')}/invest/approvals/loss-cut/{proposal}"
+    )
 
 
 def build_watches_url(

--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,7 @@ from app.routers import (
     invest_artifacts,
     invest_fills,
     invest_forecasts,
+    invest_loss_cut_approvals,
     invest_open_orders,
     invest_retrospectives,
     invest_scalping,
@@ -196,6 +197,11 @@ def create_app() -> FastAPI:
     app.include_router(symbol_settings.router)
     app.include_router(deprecated_pages.router)
     app.include_router(invest_api.router)
+    if (
+        settings.INVEST_LOSS_CUT_EVIDENCE_ENABLED
+        or settings.INVEST_LOSS_CUT_APPROVAL_ENABLED
+    ):
+        app.include_router(invest_loss_cut_approvals.router)
     app.include_router(invest_scalping.router)
     app.include_router(invest_fills.router)
     app.include_router(invest_open_orders.router)

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -499,8 +499,10 @@ async def order_proposal_create(
 ) -> dict[str, Any]:
     """Create a place, replace, or cancel proposal without broker mutation.
 
-    ``loss_cut`` keeps retrospective/price/hash guards and is approved only by
-    Telegram's two-click confirmation. ``approval_issue_id`` is an optional
+    ``loss_cut`` keeps retrospective/price/hash guards and requires a single-use
+    two-click confirmation. Telegram remains the submit-capable channel. The
+    authenticated /invest B1 channel shares the nonce but stops at durable
+    validation without submitting an order. ``approval_issue_id`` is an optional
     free-text audit note; no external issue tracker is queried.
 
     Args:

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -750,6 +750,7 @@ async def _get_holdings_for_order(
                     "total_quantity": parsed["total_quantity"],
                     "locked": parsed["locked"],
                     "avg_price": parsed["avg_buy_price"],
+                    "sellable_observed": True,
                 }
         return None
 
@@ -760,9 +761,19 @@ async def _get_holdings_for_order(
             stock_code = str(stock.get("pdno", "")).strip().upper()
             if stock_code != symbol.upper():
                 continue
+            total_quantity = _to_float(stock.get("hldg_qty"), default=0.0)
+            orderable_raw = stock.get("ord_psbl_qty")
+            orderable_quantity = (
+                total_quantity
+                if orderable_raw in {None, ""}
+                else _to_float(orderable_raw, default=0.0)
+            )
             return {
-                "quantity": _to_float(stock.get("hldg_qty"), default=0.0),
+                "quantity": orderable_quantity,
+                "total_quantity": total_quantity,
+                "locked": max(total_quantity - orderable_quantity, 0.0),
                 "avg_price": _to_float(stock.get("pchs_avg_pric"), default=0.0),
+                "sellable_observed": orderable_raw not in {None, ""},
             }
         return None
 
@@ -771,9 +782,21 @@ async def _get_holdings_for_order(
         stock_code = str(stock.get("ovrs_pdno", "")).strip().upper()
         if stock_code != symbol.upper():
             continue
+        total_quantity = _to_float(stock.get("ovrs_cblc_qty"), default=0.0)
+        orderable_raw = stock.get("ord_psbl_qty")
+        if orderable_raw in {None, ""}:
+            orderable_raw = stock.get("ovrs_ord_psbl_qty")
+        orderable_quantity = (
+            total_quantity
+            if orderable_raw in {None, ""}
+            else _to_float(orderable_raw, default=0.0)
+        )
         return {
-            "quantity": _to_float(stock.get("ovrs_cblc_qty"), default=0.0),
+            "quantity": orderable_quantity,
+            "total_quantity": total_quantity,
+            "locked": max(total_quantity - orderable_quantity, 0.0),
             "avg_price": _to_float(stock.get("pchs_avg_pric"), default=0.0),
+            "sellable_observed": orderable_raw not in {None, ""},
         }
     return None
 
@@ -1026,6 +1049,24 @@ async def _preview_sell(
         return result
 
     avg_price = holdings["avg_price"]
+    if loss_cut_ctx is not None and holdings.get("sellable_observed") is not True:
+        result["error"] = "Fresh orderable quantity is required for a loss_cut preview."
+        return result
+    sellable_quantity = _to_float(holdings.get("quantity"), default=0.0)
+    total_quantity = _to_float(
+        holdings.get("total_quantity"), default=sellable_quantity
+    )
+    result["observed_sellable_qty"] = sellable_quantity
+    result["observed_total_qty"] = total_quantity
+    result["observed_locked_qty"] = _to_float(
+        holdings.get("locked"), default=max(total_quantity - sellable_quantity, 0.0)
+    )
+    if quantity is not None and quantity > sellable_quantity:
+        result["error"] = (
+            f"Requested sell quantity {quantity} exceeds orderable balance "
+            f"{sellable_quantity}."
+        )
+        return result
     if order_type == "market":
         # ROB-518 — market sells used to skip the price guards entirely, letting
         # a live sell realize a loss in one call. Same allow_loss_sell scope as
@@ -1048,7 +1089,7 @@ async def _preview_sell(
                 avg_price=avg_price,
                 phase="preview",
             )
-        order_quantity = holdings["quantity"]
+        order_quantity = sellable_quantity
         execution_price = current_price
         result["price"] = execution_price
     else:
@@ -1106,7 +1147,7 @@ async def _preview_sell(
                 avg_price=avg_price,
                 phase="preview",
             )
-        order_quantity = holdings["quantity"] if quantity is None else quantity
+        order_quantity = sellable_quantity if quantity is None else quantity
         execution_price = price
         result["price"] = execution_price
         # ROB-477: informational fill-risk surface. A sell limit above the

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -669,6 +669,55 @@ async def _sell_loss_guard(
     return None
 
 
+async def _loss_cut_position_scope(
+    client: TossReadClient,
+    *,
+    symbol: str,
+    requested_quantity: Decimal | None,
+    base: dict[str, Any],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Read exact Toss position quantities without changing price guards."""
+    try:
+        holding = await _find_holding(client, symbol)
+        sellable = (await client.sellable_quantity(symbol=symbol)).sellable_quantity
+    except Exception as exc:
+        return None, {
+            "success": False,
+            **base,
+            "error": (
+                "Failed to retrieve fresh position scope for loss_cut "
+                f"validation (fail closed): {exc}"
+            ),
+        }
+    if holding is None:
+        return None, {
+            "success": False,
+            **base,
+            "error": f"No holding found for symbol {symbol} (fail closed).",
+        }
+    total = holding.quantity
+    if sellable < Decimal("0") or total < Decimal("0") or sellable > total:
+        return None, {
+            "success": False,
+            **base,
+            "error": "Invalid Toss holding quantity scope (fail closed).",
+        }
+    if requested_quantity is not None and requested_quantity > sellable:
+        return None, {
+            "success": False,
+            **base,
+            "error": (
+                f"Requested sell quantity {requested_quantity} exceeds "
+                f"orderable balance {sellable}."
+            ),
+        }
+    return {
+        "observed_sellable_qty": _stringify_decimal(sellable),
+        "observed_total_qty": _stringify_decimal(total),
+        "observed_locked_qty": _stringify_decimal(total - sellable),
+    }, None
+
+
 async def _opposite_pending_error(
     client: TossReadClient,
     symbol: str,
@@ -979,22 +1028,32 @@ async def toss_preview_order(
                 ),
             }
         async with _client_context() as client:
+            base = {
+                "source": "toss",
+                "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+                "preview": True,
+            }
             loss_cut_guard = await _sell_loss_guard(
                 client,
                 symbol,
                 order_type,
                 price_dec,
-                {
-                    "source": "toss",
-                    "account_mode": ACCOUNT_MODE_TOSS_LIVE,
-                    "preview": True,
-                },
+                base,
                 loss_cut_ctx=loss_cut_ctx,
                 current_price=current_price_dec,
                 evidence_context=loss_cut_evidence,
             )
-        if loss_cut_guard is not None:
-            return loss_cut_guard
+            if loss_cut_guard is not None:
+                return loss_cut_guard
+            position_scope, scope_error = await _loss_cut_position_scope(
+                client,
+                symbol=symbol,
+                requested_quantity=quantity_dec,
+                base=base,
+            )
+        if scope_error is not None:
+            return scope_error
+        loss_cut_evidence.update(position_scope or {})
 
     fill_warnings, fill_distance = _limit_fill_context(
         market=mkt,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -58,6 +58,8 @@ from .order_proposals import (
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
     OrderProposalApprovalDispatchAttempt,
+    OrderProposalApprovalEvent,
+    OrderProposalLossCutScope,
     OrderProposalRung,
 )
 from .paper_cohort import (
@@ -237,6 +239,8 @@ __all__ = [
     "OrderProposalApprovalBatch",
     "OrderProposalApprovalBatchMember",
     "OrderProposalApprovalDispatchAttempt",
+    "OrderProposalApprovalEvent",
+    "OrderProposalLossCutScope",
     "OrderProposalRung",
     "BrokerType",
     "MarketType",

--- a/app/models/order_proposals.py
+++ b/app/models/order_proposals.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from decimal import Decimal
 
 from sqlalchemy import (
     TIMESTAMP,
@@ -69,6 +70,15 @@ class OrderProposal(Base):
             "approval_dispatch_card_kind IN "
             "('manual','reconfirm','auto_veto','loss_cut_confirmation')",
             name="order_proposals_approval_dispatch_card_kind",
+        ),
+        CheckConstraint(
+            "approval_dispatch_channel IS NULL OR "
+            "approval_dispatch_channel IN ('telegram','web')",
+            name="order_proposals_approval_dispatch_channel",
+        ),
+        CheckConstraint(
+            "approved_by_channel IS NULL OR approved_by_channel IN ('telegram','web')",
+            name="order_proposals_approved_by_channel",
         ),
         Index("ix_order_proposals_root", "root_proposal_id"),
         Index("ix_order_proposals_state", "lifecycle_state"),
@@ -133,12 +143,17 @@ class OrderProposal(Base):
     approval_dispatch_failure_code: Mapped[str | None] = mapped_column(Text)
     approval_dispatch_payload_chars: Mapped[int | None] = mapped_column(BigInteger)
     approval_dispatch_card_kind: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_channel: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_scope_hash: Mapped[str | None] = mapped_column(Text)
+    approval_dispatch_evidence_hash: Mapped[str | None] = mapped_column(Text)
     approval_dispatch_membership_revision: Mapped[int | None] = mapped_column(Integer)
     approval_dispatch_membership_digest: Mapped[str | None] = mapped_column(Text)
     approval_dispatch_published_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True)
     )
     approved_by_telegram_user_id: Mapped[str | None] = mapped_column(Text)
+    approved_by_channel: Mapped[str | None] = mapped_column(Text)
+    approved_by_subject: Mapped[str | None] = mapped_column(Text)
     approved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     commit_lease_until: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True)
@@ -219,6 +234,10 @@ class OrderProposalApprovalDispatchAttempt(Base):
             "card_kind IN ('manual','reconfirm','auto_veto','loss_cut_confirmation')",
             name="order_proposal_approval_dispatch_attempt_card_kind",
         ),
+        CheckConstraint(
+            "channel IN ('telegram','web')",
+            name="order_proposal_approval_dispatch_attempt_channel",
+        ),
         Index(
             "ix_order_proposal_approval_dispatch_attempts_proposal",
             "proposal_pk",
@@ -249,6 +268,12 @@ class OrderProposalApprovalDispatchAttempt(Base):
     error_classification: Mapped[str | None] = mapped_column(Text)
     failure_code: Mapped[str | None] = mapped_column(Text)
     card_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    channel: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="telegram"
+    )
+    scope_hash: Mapped[str | None] = mapped_column(Text)
+    evidence_hash: Mapped[str | None] = mapped_column(Text)
+    publication_ref_digest: Mapped[str | None] = mapped_column(Text)
     membership_revision: Mapped[int] = mapped_column(Integer, nullable=False)
     membership_digest: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -259,6 +284,134 @@ class OrderProposalApprovalDispatchAttempt(Base):
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),
+    )
+
+
+class OrderProposalLossCutScope(Base):
+    """Current typed position scope frozen by a web loss-cut ceremony."""
+
+    __tablename__ = "order_proposal_loss_cut_scopes"
+    __table_args__ = (
+        UniqueConstraint(
+            "proposal_pk", name="uq_order_proposal_loss_cut_scopes_proposal"
+        ),
+        Index("ix_order_proposal_loss_cut_scopes_scope_hash", "scope_hash"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    proposal_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposals.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    schema_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1"
+    )
+    account_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    account_mode: Mapped[str] = mapped_column(Text, nullable=False)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    requested_quantity: Mapped[Decimal] = mapped_column(Numeric(38, 12), nullable=False)
+    observed_total_quantity: Mapped[Decimal] = mapped_column(
+        Numeric(38, 12), nullable=False
+    )
+    observed_sellable_quantity: Mapped[Decimal] = mapped_column(
+        Numeric(38, 12), nullable=False
+    )
+    average_price: Mapped[Decimal] = mapped_column(Numeric(38, 12), nullable=False)
+    position_scope: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    observed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    decision_observed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    evidence_valid_until: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    scope_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    evidence_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class OrderProposalApprovalEvent(Base):
+    """Append-only actor/outcome ledger for both approval channels."""
+
+    __tablename__ = "order_proposal_approval_events"
+    __table_args__ = (
+        UniqueConstraint("event_id", name="uq_order_proposal_approval_events_event_id"),
+        UniqueConstraint(
+            "proposal_pk",
+            "ceremony_digest",
+            "step",
+            name="uq_order_proposal_approval_events_ceremony_step",
+        ),
+        CheckConstraint(
+            "channel IN ('telegram','web')",
+            name="order_proposal_approval_events_channel",
+        ),
+        CheckConstraint(
+            "step IN ('begin','confirm')",
+            name="order_proposal_approval_events_step",
+        ),
+        CheckConstraint(
+            "outcome IN ('accepted','rejected','needs_reconfirm','expired')",
+            name="order_proposal_approval_events_outcome",
+        ),
+        CheckConstraint(
+            "actor_kind IN ('user','telegram')",
+            name="order_proposal_approval_events_actor_kind",
+        ),
+        Index(
+            "ix_order_proposal_approval_events_proposal_observed",
+            "proposal_pk",
+            "observed_at",
+        ),
+        Index("ix_order_proposal_approval_events_ceremony", "ceremony_digest"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    proposal_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposals.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    ceremony_digest: Mapped[str] = mapped_column(Text, nullable=False)
+    channel: Mapped[str] = mapped_column(Text, nullable=False)
+    step: Mapped[str] = mapped_column(Text, nullable=False)
+    outcome: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_subject: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_role: Mapped[str | None] = mapped_column(Text)
+    dispatch_attempt_id: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    membership_revision: Mapped[int | None] = mapped_column(Integer)
+    membership_digest: Mapped[str | None] = mapped_column(Text)
+    nonce_digest: Mapped[str | None] = mapped_column(Text)
+    proposal_payload_hash: Mapped[str | None] = mapped_column(Text)
+    scope_hash: Mapped[str | None] = mapped_column(Text)
+    evidence_hash: Mapped[str | None] = mapped_column(Text)
+    evidence_snapshot: Mapped[dict | None] = mapped_column(JSONB)
+    reason_code: Mapped[str | None] = mapped_column(Text)
+    expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    observed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )
 
 

--- a/app/routers/invest_loss_cut_approvals.py
+++ b/app/routers/invest_loss_cut_approvals.py
@@ -1,0 +1,183 @@
+"""Authenticated B0/B1 loss-cut evidence and web confirmation endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.role_hierarchy import has_min_role
+from app.core.config import settings
+from app.core.db import get_db
+from app.models.trading import User, UserRole
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import get_invest_home_service
+from app.schemas.loss_cut_approval import (
+    LossCutBeginRequest,
+    LossCutBeginResponse,
+    LossCutConfirmRequest,
+    LossCutConfirmResponse,
+    LossCutEvidenceResponse,
+)
+from app.services.invest_home_service import InvestHomeService
+from app.services.order_proposals.errors import (
+    OrderProposalError,
+    OrderProposalNotFound,
+)
+from app.services.order_proposals.loss_cut_approval import (
+    LossCutApprovalRejected,
+    LossCutApprovalService,
+)
+
+router = APIRouter(prefix="/invest/api", tags=["invest-loss-cut-approvals"])
+
+
+async def require_loss_cut_operator(
+    user: Annotated[User, Depends(get_authenticated_user)],
+) -> User:
+    """JSON role gate: raise 403 instead of returning an HTML response."""
+    if not has_min_role(user.role, UserRole.trader):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Trader role required",
+        )
+    return user
+
+
+def get_loss_cut_approval_service(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    home_service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
+) -> LossCutApprovalService:
+    return LossCutApprovalService(db, home_service=home_service)
+
+
+def _require_evidence_enabled() -> None:
+    if not settings.INVEST_LOSS_CUT_EVIDENCE_ENABLED:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+
+def _require_approval_enabled() -> None:
+    if not settings.INVEST_LOSS_CUT_APPROVAL_ENABLED:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+
+def _no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+
+
+@router.get(
+    "/loss-cut-evidence/{symbol}",
+    response_model=LossCutEvidenceResponse,
+    dependencies=[Depends(_require_evidence_enabled)],
+)
+async def get_loss_cut_evidence(
+    symbol: str,
+    response: Response,
+    user: Annotated[User, Depends(require_loss_cut_operator)],
+    service: Annotated[LossCutApprovalService, Depends(get_loss_cut_approval_service)],
+) -> LossCutEvidenceResponse:
+    _no_store(response)
+    return await service.get_symbol_evidence(symbol=symbol, user_id=user.id)
+
+
+@router.get(
+    "/loss-cut-approvals/{proposal_id}",
+    response_model=LossCutEvidenceResponse,
+    dependencies=[Depends(_require_approval_enabled)],
+)
+async def get_loss_cut_approval(
+    proposal_id: uuid.UUID,
+    response: Response,
+    _user: Annotated[User, Depends(require_loss_cut_operator)],
+    service: Annotated[LossCutApprovalService, Depends(get_loss_cut_approval_service)],
+) -> LossCutEvidenceResponse:
+    _no_store(response)
+    try:
+        return await service.get_proposal_evidence(proposal_id=proposal_id)
+    except OrderProposalNotFound as exc:
+        raise HTTPException(status_code=404, detail="proposal_not_found") from exc
+    except OrderProposalError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.post(
+    "/loss-cut-approvals/{proposal_id}/begin",
+    response_model=LossCutBeginResponse,
+    dependencies=[Depends(_require_approval_enabled)],
+)
+async def begin_loss_cut_approval(
+    proposal_id: uuid.UUID,
+    _body: LossCutBeginRequest,
+    response: Response,
+    user: Annotated[User, Depends(require_loss_cut_operator)],
+    service: Annotated[LossCutApprovalService, Depends(get_loss_cut_approval_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> LossCutBeginResponse:
+    _no_store(response)
+    try:
+        result = await service.begin(
+            proposal_id=proposal_id,
+            actor_user_id=user.id,
+            actor_role=user.role,
+        )
+        await db.commit()
+        return result
+    except LossCutApprovalRejected as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=exc.code) from exc
+    except OrderProposalNotFound as exc:
+        await db.rollback()
+        raise HTTPException(status_code=404, detail="proposal_not_found") from exc
+    except OrderProposalError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception:
+        await db.rollback()
+        raise
+
+
+@router.post(
+    "/loss-cut-approvals/{proposal_id}/confirm",
+    response_model=LossCutConfirmResponse,
+    dependencies=[Depends(_require_approval_enabled)],
+)
+async def confirm_loss_cut_approval(
+    proposal_id: uuid.UUID,
+    body: LossCutConfirmRequest,
+    response: Response,
+    user: Annotated[User, Depends(require_loss_cut_operator)],
+    service: Annotated[LossCutApprovalService, Depends(get_loss_cut_approval_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> LossCutConfirmResponse:
+    _no_store(response)
+    try:
+        result = await service.confirm(
+            proposal_id=proposal_id,
+            ceremony_id=body.ceremony_id,
+            actor_user_id=user.id,
+            actor_role=user.role,
+        )
+        await db.commit()
+        return result
+    except LossCutApprovalRejected as exc:
+        await db.commit()
+        raise HTTPException(status_code=409, detail=exc.code) from exc
+    except OrderProposalNotFound as exc:
+        await db.rollback()
+        raise HTTPException(status_code=404, detail="proposal_not_found") from exc
+    except OrderProposalError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception:
+        await db.rollback()
+        raise
+
+
+__all__ = [
+    "get_loss_cut_approval_service",
+    "require_loss_cut_operator",
+    "router",
+]

--- a/app/schemas/loss_cut_approval.py
+++ b/app/schemas/loss_cut_approval.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+EvidenceStatus = Literal["filled", "stale", "missing", "unavailable", "source_error"]
+
+
+class LossCutEvidenceField(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: EvidenceStatus
+    label: str
+    value: dict[str, Any] | None = None
+    reason: str | None = None
+    source: str | None = None
+    as_of: str | None = None
+    valid_until: str | None = None
+
+
+class LossCutPositionEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    account_ref: str
+    account_mode: str
+    market: str
+    symbol: str
+    total_quantity: str
+    sellable_quantity: str | None
+    pending_sell_quantity: str | None
+    average_price: str | None
+    current_price: str | None
+    source: str
+    source_status: EvidenceStatus
+    source_reason: str | None = None
+    observed_at: str
+
+
+class LossCutEvidenceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["symbol", "proposal"]
+    symbol: str
+    proposal_id: str | None = None
+    generated_at: str
+    can_begin: bool
+    positions: list[LossCutPositionEvidence] = Field(default_factory=list)
+    loss: LossCutEvidenceField
+    reason: LossCutEvidenceField
+    r931: LossCutEvidenceField
+    consensus: LossCutEvidenceField
+    watch: LossCutEvidenceField
+    fingerprint: dict[str, Any] | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class LossCutBeginRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class LossCutBeginResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str
+    ceremony_id: str
+    expires_at: str
+    evidence: LossCutEvidenceResponse
+    fingerprint: dict[str, Any]
+    next_step: Literal["confirm"] = "confirm"
+
+
+class LossCutConfirmRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ceremony_id: str = Field(min_length=32, max_length=256)
+
+
+class LossCutConfirmResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str
+    status: Literal["validated_no_execution"] = "validated_no_execution"
+    evidence: LossCutEvidenceResponse
+    fingerprint: dict[str, Any]

--- a/app/services/analyst_consensus_snapshots/repository.py
+++ b/app/services/analyst_consensus_snapshots/repository.py
@@ -150,6 +150,25 @@ class AnalystConsensusSnapshotsRepository:
             total_symbols=int(row.total or 0),
         )
 
+    async def latest_for_symbol(
+        self, *, market: str, symbol: str
+    ) -> AnalystConsensusSnapshot | None:
+        """Return the newest durable snapshot for one canonical symbol."""
+        stmt = (
+            select(AnalystConsensusSnapshot)
+            .where(
+                AnalystConsensusSnapshot.market == market.strip().lower(),
+                AnalystConsensusSnapshot.symbol == symbol.strip().upper(),
+            )
+            .order_by(
+                AnalystConsensusSnapshot.snapshot_date.desc(),
+                AnalystConsensusSnapshot.collected_at.desc(),
+                AnalystConsensusSnapshot.id.desc(),
+            )
+            .limit(1)
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
     async def existing_keys(
         self, rows: Iterable[AnalystConsensusSnapshotUpsert]
     ) -> set[tuple[str, str, dt.date, str]]:

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from decimal import ROUND_CEILING, Decimal, InvalidOperation
 from typing import Any
 
+from app.core.invest_deep_links import build_loss_cut_approval_url
 from app.core.timezone import KST
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
@@ -462,12 +463,16 @@ def build_approval_message(
     lines.extend(["", "*근거*", *evidence_lines])
 
     if getattr(group, "exit_intent", None) == "loss_cut":
+        approval_url = build_loss_cut_approval_url(
+            proposal_id=getattr(group, "proposal_id", "")
+        )
         lines.extend(
             [
                 "",
                 "*손절 근거*",
                 f"- 사유: {_escape_markdown(getattr(group, 'exit_reason', None))}",
                 f"- 회고: #{getattr(group, 'retrospective_id', None)}",
+                f"- /invest 증거·확인: {approval_url}",
             ]
         )
 
@@ -522,6 +527,17 @@ def build_approval_message(
             ]
         ]
     }
+    if getattr(group, "exit_intent", None) == "loss_cut":
+        inline_keyboard["inline_keyboard"].append(
+            [
+                {
+                    "text": "🔎 /invest 증거",
+                    "url": build_loss_cut_approval_url(
+                        proposal_id=getattr(group, "proposal_id", "")
+                    ),
+                }
+            ]
+        )
     return text, inline_keyboard
 
 
@@ -657,6 +673,8 @@ def build_loss_cut_confirmation_message(
     if approval_note:
         lines.append(f"- 승인 감사 메모: {_escape_markdown(approval_note)}")
     lines.extend(["", "이 손절 주문을 다시 확인해 주세요."])
+    approval_url = build_loss_cut_approval_url(proposal_id=proposal_id)
+    lines.append(f"/invest 증거·확인: {approval_url}")
     text = "\n".join(lines).replace(str(nonce), "[비공개]")
     keyboard = {
         "inline_keyboard": [
@@ -682,6 +700,9 @@ def build_loss_cut_confirmation_message(
             ]
         ]
     }
+    keyboard["inline_keyboard"].append(
+        [{"text": "🔎 /invest 증거", "url": approval_url}]
+    )
     return text, keyboard
 
 

--- a/app/services/order_proposals/loss_cut_approval.py
+++ b/app/services/order_proposals/loss_cut_approval.py
@@ -1,0 +1,920 @@
+"""B0 evidence and B1 web ceremony for existing loss-cut proposals.
+
+This module never creates proposals and never imports or calls an order-submit
+function.  B1 ends at a durable ``validated_no_execution`` event.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.symbol import to_db_symbol
+from app.mcp_server.caller_identity import caller_agent_id_var
+from app.schemas.loss_cut_approval import (
+    LossCutBeginResponse,
+    LossCutConfirmResponse,
+    LossCutEvidenceField,
+    LossCutEvidenceResponse,
+    LossCutPositionEvidence,
+)
+from app.services.analyst_consensus_snapshots.repository import (
+    AnalystConsensusSnapshotsRepository,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalDispatchState,
+    CallbackEnvelope,
+    build_proposal_dispatch_binding,
+)
+from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.revalidation import preview_loss_cut_confirmation
+
+PreviewFn = Callable[..., Awaitable[dict[str, Any]]]
+Clock = Callable[[], datetime]
+TokenFactory = Callable[[], str]
+
+_CONFIRMATION_TTL_SECONDS = 90
+
+
+class LossCutApprovalRejected(Exception):
+    """A fail-closed result whose audit event is safe to commit."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class _ProposalEvidenceBundle:
+    response: LossCutEvidenceResponse
+    group: Any
+    scope_payload: dict[str, Any]
+    scope_hash: str
+    evidence_hash: str
+    requested_quantity: Decimal
+    total_quantity: Decimal
+    sellable_quantity: Decimal
+    average_price: Decimal
+    account_ref: str
+    observed_at: datetime
+    evidence_valid_until: datetime
+    fingerprint: dict[str, Any]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _secret_digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _decimal_text(value: Any) -> str:
+    decimal = Decimal(str(value))
+    text = format(decimal.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return "0" if text in {"", "-0"} else text
+
+
+def _market_key(market: str) -> str:
+    return {
+        "equity_kr": "kr",
+        "equity_us": "us",
+        "crypto": "crypto",
+    }.get(market, market.strip().lower())
+
+
+def _infer_market(symbol: str) -> str:
+    if symbol.upper().startswith("KRW-"):
+        return "crypto"
+    if len(symbol) == 6 and symbol.isdigit():
+        return "kr"
+    return "us"
+
+
+def _account_mode_for_source(source: str) -> str:
+    return {
+        "kis": "kis_live",
+        "toss_api": "toss_live",
+        "upbit": "upbit",
+    }.get(source, source)
+
+
+def _role_text(role: Any) -> str:
+    return str(getattr(role, "value", role) or "")
+
+
+class LossCutApprovalService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        home_service: Any | None = None,
+        preview_fn: PreviewFn = preview_loss_cut_confirmation,
+        clock: Clock = _utc_now,
+        nonce_factory: TokenFactory = _token,
+        ceremony_factory: TokenFactory = _token,
+    ) -> None:
+        self._session = session
+        self._proposals = OrderProposalsService(session)
+        self._home = home_service
+        self._preview = preview_fn
+        self._clock = clock
+        self._nonce_factory = nonce_factory
+        self._ceremony_factory = ceremony_factory
+
+    async def get_symbol_evidence(
+        self, *, symbol: str, user_id: int
+    ) -> LossCutEvidenceResponse:
+        """B0: assemble evidence without touching proposal approval state."""
+        now = self._clock()
+        canonical_symbol = to_db_symbol(symbol.strip()).upper()
+        if not canonical_symbol:
+            raise OrderProposalError("loss_cut_evidence_symbol_required")
+        if self._home is None:
+            raise OrderProposalError("loss_cut_evidence_home_reader_unavailable")
+        home = await self._home.get_home(user_id=user_id, include_paper=False)
+        positions: list[LossCutPositionEvidence] = []
+        loss_rows: list[dict[str, str]] = []
+        for holding in home.holdings:
+            if to_db_symbol(str(holding.symbol)).upper() != canonical_symbol:
+                continue
+            total = Decimal(str(holding.quantity))
+            average = (
+                Decimal(str(holding.averageCost))
+                if holding.averageCost is not None
+                else None
+            )
+            current = None
+            if holding.valueNative is not None and total > 0:
+                current = Decimal(str(holding.valueNative)) / total
+            sellable_unavailable = holding.source == "toss_api" and not bool(
+                getattr(settings, "toss_live_order_mutations_enabled", False)
+            )
+            sellable = (
+                None
+                if sellable_unavailable or holding.sellableQuantity is None
+                else Decimal(str(holding.sellableQuantity))
+            )
+            source_status = (
+                "unavailable"
+                if sellable_unavailable or not holding.sourceOfTruth
+                else "filled"
+            )
+            source_reason = (
+                "sellable quantity is unavailable while this source is reference-only"
+                if sellable_unavailable
+                else "reference-only holding"
+                if not holding.sourceOfTruth
+                else None
+            )
+            positions.append(
+                LossCutPositionEvidence(
+                    account_ref=str(holding.accountId),
+                    account_mode=_account_mode_for_source(str(holding.source)),
+                    market=str(holding.market),
+                    symbol=canonical_symbol,
+                    total_quantity=_decimal_text(total),
+                    sellable_quantity=(
+                        _decimal_text(sellable) if sellable is not None else None
+                    ),
+                    pending_sell_quantity=_decimal_text(holding.pendingSellQuantity),
+                    average_price=(
+                        _decimal_text(average) if average is not None else None
+                    ),
+                    current_price=(
+                        _decimal_text(current) if current is not None else None
+                    ),
+                    source=str(holding.source),
+                    source_status=source_status,
+                    source_reason=source_reason,
+                    observed_at=now.isoformat(),
+                )
+            )
+            if average is not None and average > 0 and current is not None:
+                loss_rows.append(
+                    {
+                        "account_ref": str(holding.accountId),
+                        "loss_pct": _decimal_text(
+                            (current - average) / average * Decimal("100")
+                        ),
+                    }
+                )
+        market = _infer_market(canonical_symbol)
+        consensus = await self._consensus_field(market=market, symbol=canonical_symbol)
+        watch = await self._watch_field(market=market, symbol=canonical_symbol, now=now)
+        return LossCutEvidenceResponse(
+            mode="symbol",
+            symbol=canonical_symbol,
+            generated_at=now.isoformat(),
+            can_begin=False,
+            positions=positions,
+            loss=LossCutEvidenceField(
+                status="filled" if loss_rows else "missing",
+                label="손실률",
+                value={"positions": loss_rows} if loss_rows else None,
+                reason=None
+                if loss_rows
+                else "fresh price and average cost are required",
+                source="invest_home",
+                as_of=now.isoformat(),
+            ),
+            reason=LossCutEvidenceField(
+                status="missing",
+                label="사유 판정",
+                reason="B0 has no proposal-bound loss-cut reason",
+            ),
+            r931=self._r931_field(),
+            consensus=consensus,
+            watch=watch,
+            warnings=(
+                ["same-symbol positions remain separated by account"]
+                if len(positions) > 1
+                else []
+            ),
+        )
+
+    async def get_proposal_evidence(
+        self, *, proposal_id: uuid.UUID
+    ) -> LossCutEvidenceResponse:
+        return (await self._build_proposal_bundle(proposal_id)).response
+
+    async def begin(
+        self,
+        *,
+        proposal_id: uuid.UUID,
+        actor_user_id: int,
+        actor_role: Any,
+    ) -> LossCutBeginResponse:
+        now = self._clock()
+        callback = await self._proposals.current_callback_envelope(
+            proposal_id, action="op"
+        )
+        await self._proposals.preflight_published_proposal_callback(
+            proposal_id, callback=callback
+        )
+        bundle = await self._build_proposal_bundle(proposal_id, now=now)
+        if not bundle.response.can_begin:
+            raise OrderProposalError("loss_cut_web_begin_not_available")
+
+        ceremony_id = self._ceremony_factory()
+        ceremony_digest = _secret_digest(ceremony_id)
+        confirmation_nonce = self._nonce_factory()
+        actor_subject = str(actor_user_id)
+        try:
+            await self._proposals.consume_published_proposal_callback(
+                proposal_id,
+                callback=callback,
+                now=now,
+            )
+        except OrderProposalError as exc:
+            await self._proposals.append_approval_event(
+                event_id=uuid.uuid4(),
+                proposal_pk=bundle.group.id,
+                ceremony_digest=ceremony_digest,
+                channel="web",
+                step="begin",
+                outcome="rejected",
+                actor_kind="user",
+                actor_subject=actor_subject,
+                actor_role=_role_text(actor_role),
+                dispatch_attempt_id=callback.attempt_id,
+                membership_revision=callback.membership_revision,
+                membership_digest=callback.membership_digest,
+                nonce_digest=_secret_digest(callback.nonce),
+                proposal_payload_hash=bundle.group.payload_hash,
+                scope_hash=bundle.scope_hash,
+                evidence_hash=bundle.evidence_hash,
+                evidence_snapshot=bundle.response.model_dump(mode="json"),
+                reason_code=str(exc),
+                observed_at=now,
+            )
+            raise LossCutApprovalRejected(str(exc)) from exc
+
+        await self._proposals.issue_loss_cut_confirmation(
+            proposal_id,
+            first_nonce=callback.nonce,
+            confirmation_nonce=confirmation_nonce,
+            actor_channel="web",
+            actor_subject=actor_subject,
+            now=now,
+            ttl_seconds=_CONFIRMATION_TTL_SECONDS,
+        )
+        group, _rungs = await self._proposals.get_proposal(proposal_id)
+        attempt_id = uuid.uuid4()
+        binding = build_proposal_dispatch_binding(
+            proposal_id=proposal_id,
+            nonce=confirmation_nonce,
+            attempt_id=attempt_id,
+            card_kind=ApprovalCardKind.LOSS_CUT_CONFIRMATION,
+            current_membership_revision=group.approval_dispatch_membership_revision,
+        )
+        await self._proposals.start_approval_dispatch(
+            proposal_id,
+            attempt_id=attempt_id,
+            binding=binding,
+            now=now,
+            payload_chars=0,
+            context_message_count=0,
+            channel="web",
+            scope_hash=bundle.scope_hash,
+            evidence_hash=bundle.evidence_hash,
+            publication_ref_digest=ceremony_digest,
+        )
+        await self._proposals.finish_web_approval_dispatch(
+            proposal_id, attempt_id=attempt_id, now=now
+        )
+        await self._proposals.upsert_loss_cut_scope(
+            proposal_pk=group.id,
+            schema_version=1,
+            account_ref=bundle.account_ref,
+            account_mode=group.account_mode,
+            market=group.market,
+            symbol=group.symbol,
+            requested_quantity=bundle.requested_quantity,
+            observed_total_quantity=bundle.total_quantity,
+            observed_sellable_quantity=bundle.sellable_quantity,
+            average_price=bundle.average_price,
+            position_scope=bundle.scope_payload,
+            source=f"order_preview:{group.account_mode}",
+            observed_at=bundle.observed_at,
+            decision_observed_at=group.created_at,
+            evidence_valid_until=bundle.evidence_valid_until,
+            scope_hash=bundle.scope_hash,
+            evidence_hash=bundle.evidence_hash,
+        )
+        await self._proposals.append_approval_event(
+            event_id=uuid.uuid4(),
+            proposal_pk=group.id,
+            ceremony_digest=ceremony_digest,
+            channel="web",
+            step="begin",
+            outcome="accepted",
+            actor_kind="user",
+            actor_subject=actor_subject,
+            actor_role=_role_text(actor_role),
+            dispatch_attempt_id=attempt_id,
+            membership_revision=binding.membership_revision,
+            membership_digest=binding.membership_digest,
+            nonce_digest=_secret_digest(confirmation_nonce),
+            proposal_payload_hash=group.payload_hash,
+            scope_hash=bundle.scope_hash,
+            evidence_hash=bundle.evidence_hash,
+            evidence_snapshot=bundle.response.model_dump(mode="json"),
+            expires_at=bundle.evidence_valid_until,
+            observed_at=now,
+        )
+        return LossCutBeginResponse(
+            proposal_id=str(proposal_id),
+            ceremony_id=ceremony_id,
+            expires_at=bundle.evidence_valid_until.isoformat(),
+            evidence=bundle.response,
+            fingerprint=bundle.fingerprint,
+        )
+
+    async def confirm(
+        self,
+        *,
+        proposal_id: uuid.UUID,
+        ceremony_id: str,
+        actor_user_id: int,
+        actor_role: Any,
+    ) -> LossCutConfirmResponse:
+        now = self._clock()
+        group, _rungs = await self._proposals.get_proposal(proposal_id)
+        ceremony_digest = _secret_digest(ceremony_id)
+        begin_event = await self._proposals.get_approval_event(
+            proposal_pk=group.id,
+            ceremony_digest=ceremony_digest,
+            step="begin",
+        )
+        if begin_event is None or begin_event.outcome != "accepted":
+            raise OrderProposalError("loss_cut_web_ceremony_not_found")
+        confirm_event = await self._proposals.get_approval_event(
+            proposal_pk=group.id,
+            ceremony_digest=ceremony_digest,
+            step="confirm",
+        )
+        if confirm_event is not None:
+            raise OrderProposalError("nonce_replay")
+        actor_subject = str(actor_user_id)
+        if (
+            begin_event.channel != "web"
+            or begin_event.actor_kind != "user"
+            or begin_event.actor_subject != actor_subject
+        ):
+            raise OrderProposalError("loss_cut_confirmation_principal_mismatch")
+        if begin_event.expires_at is None or now >= begin_event.expires_at:
+            await self._append_confirm_event(
+                begin_event=begin_event,
+                group=group,
+                actor_subject=actor_subject,
+                actor_role=actor_role,
+                outcome="expired",
+                reason_code="loss_cut_confirmation_expired",
+                observed_at=now,
+            )
+            raise LossCutApprovalRejected("loss_cut_confirmation_expired")
+
+        # This transaction-scoped target lock is deliberately acquired before
+        # the proposal row lock taken by consume_published_proposal_callback.
+        await self._proposals.acquire_target_mutation_lock(group)
+        refreshed_group, _ = await self._proposals.get_proposal(proposal_id)
+        nonce = str(refreshed_group.approval_nonce or "")
+        if (
+            not nonce
+            or begin_event.dispatch_attempt_id is None
+            or begin_event.membership_revision is None
+            or begin_event.membership_digest is None
+            or begin_event.nonce_digest != _secret_digest(nonce)
+        ):
+            raise OrderProposalError("loss_cut_web_binding_mismatch")
+        callback = CallbackEnvelope(
+            action="lc",
+            subject_short=str(proposal_id)[:8],
+            attempt_id=begin_event.dispatch_attempt_id,
+            membership_revision=begin_event.membership_revision,
+            membership_digest=begin_event.membership_digest,
+            nonce=nonce,
+        )
+        await self._proposals.consume_published_proposal_callback(
+            proposal_id,
+            callback=callback,
+            now=now,
+            actor_channel="web",
+            actor_subject=actor_subject,
+        )
+        try:
+            fresh = await self._build_proposal_bundle(proposal_id, now=now)
+        except OrderProposalError as exc:
+            await self._append_confirm_event(
+                begin_event=begin_event,
+                group=group,
+                actor_subject=actor_subject,
+                actor_role=actor_role,
+                outcome="needs_reconfirm",
+                reason_code=(
+                    f"loss_cut_confirmation_revalidation_failed:{str(exc)[:200]}"
+                ),
+                observed_at=now,
+            )
+            raise LossCutApprovalRejected(
+                "loss_cut_confirmation_revalidation_failed"
+            ) from exc
+        scope = await self._proposals.get_loss_cut_scope(group.id)
+        scope_matches = bool(
+            scope is not None
+            and scope.scope_hash == begin_event.scope_hash == fresh.scope_hash
+            and scope.evidence_hash == begin_event.evidence_hash == fresh.evidence_hash
+            and refreshed_group.approval_dispatch_scope_hash == fresh.scope_hash
+            and refreshed_group.approval_dispatch_evidence_hash == fresh.evidence_hash
+        )
+        if not scope_matches:
+            await self._append_confirm_event(
+                begin_event=begin_event,
+                group=group,
+                actor_subject=actor_subject,
+                actor_role=actor_role,
+                outcome="needs_reconfirm",
+                reason_code="loss_cut_confirmation_scope_or_evidence_changed",
+                observed_at=now,
+                fresh=fresh,
+            )
+            raise LossCutApprovalRejected(
+                "loss_cut_confirmation_scope_or_evidence_changed"
+            )
+
+        await self._proposals.record_channel_approval(
+            proposal_id,
+            channel="web",
+            actor_subject=actor_subject,
+            now=now,
+        )
+        await self._append_confirm_event(
+            begin_event=begin_event,
+            group=group,
+            actor_subject=actor_subject,
+            actor_role=actor_role,
+            outcome="accepted",
+            observed_at=now,
+            fresh=fresh,
+        )
+        return LossCutConfirmResponse(
+            proposal_id=str(proposal_id),
+            evidence=fresh.response,
+            fingerprint=fresh.fingerprint,
+        )
+
+    async def _append_confirm_event(
+        self,
+        *,
+        begin_event: Any,
+        group: Any,
+        actor_subject: str,
+        actor_role: Any,
+        outcome: str,
+        observed_at: datetime,
+        reason_code: str | None = None,
+        fresh: _ProposalEvidenceBundle | None = None,
+    ) -> None:
+        await self._proposals.append_approval_event(
+            event_id=uuid.uuid4(),
+            proposal_pk=group.id,
+            ceremony_digest=begin_event.ceremony_digest,
+            channel="web",
+            step="confirm",
+            outcome=outcome,
+            actor_kind="user",
+            actor_subject=actor_subject,
+            actor_role=_role_text(actor_role),
+            dispatch_attempt_id=begin_event.dispatch_attempt_id,
+            membership_revision=begin_event.membership_revision,
+            membership_digest=begin_event.membership_digest,
+            nonce_digest=begin_event.nonce_digest,
+            proposal_payload_hash=group.payload_hash,
+            scope_hash=fresh.scope_hash
+            if fresh is not None
+            else begin_event.scope_hash,
+            evidence_hash=(
+                fresh.evidence_hash if fresh is not None else begin_event.evidence_hash
+            ),
+            evidence_snapshot=(
+                fresh.response.model_dump(mode="json")
+                if fresh is not None
+                else begin_event.evidence_snapshot
+            ),
+            reason_code=reason_code,
+            expires_at=begin_event.expires_at,
+            observed_at=observed_at,
+        )
+
+    async def _build_proposal_bundle(
+        self, proposal_id: uuid.UUID, *, now: datetime | None = None
+    ) -> _ProposalEvidenceBundle:
+        observed_at = now or self._clock()
+        group, rungs = await self._proposals.get_proposal(proposal_id)
+        if group.exit_intent != "loss_cut" or group.retrospective_id is None:
+            raise OrderProposalError("loss_cut_confirmation_requires_loss_cut")
+        if group.side != "sell" or group.order_type != "limit":
+            raise OrderProposalError("loss_cut_confirmation_order_shape_invalid")
+        submit_agent_id = settings.ORDER_PROPOSALS_SUBMIT_AGENT_ID.strip() or None
+        caller_agent_id_token = caller_agent_id_var.set(submit_agent_id)
+        try:
+            preview = await self._preview(
+                service=self._proposals,
+                proposal_id=proposal_id,
+                now=observed_at,
+            )
+        finally:
+            caller_agent_id_var.reset(caller_agent_id_token)
+        preview_rungs = sorted(
+            preview.get("rungs") or [], key=lambda item: int(item["rung_index"])
+        )
+        if not preview_rungs:
+            raise OrderProposalError("loss_cut_confirmation_has_no_eligible_rungs")
+        requested_quantity = sum(
+            (Decimal(str(item["requested_quantity"])) for item in preview_rungs),
+            Decimal("0"),
+        )
+        sellable_values = {
+            Decimal(str(item["observed_sellable_qty"])) for item in preview_rungs
+        }
+        total_values = {
+            Decimal(str(item["observed_total_qty"])) for item in preview_rungs
+        }
+        average_values = {Decimal(str(item["avg_buy_price"])) for item in preview_rungs}
+        if (
+            len(sellable_values) != 1
+            or len(total_values) != 1
+            or len(average_values) != 1
+        ):
+            raise OrderProposalError("loss_cut_confirmation_position_scope_ambiguous")
+        sellable_quantity = sellable_values.pop()
+        total_quantity = total_values.pop()
+        average_price = average_values.pop()
+        if requested_quantity > sellable_quantity:
+            raise OrderProposalError("loss_cut_confirmation_quantity_exceeds_sellable")
+        account_ref = str(group.broker_account_id or "").strip()
+        if not account_ref:
+            raise OrderProposalError("loss_cut_confirmation_account_scope_missing")
+        evidence_valid_until = observed_at + timedelta(
+            seconds=_CONFIRMATION_TTL_SECONDS
+        )
+        if group.valid_until is not None:
+            evidence_valid_until = min(evidence_valid_until, group.valid_until)
+        rung_revisions = {
+            rung.rung_index: int(rung.approval_revision or 0) for rung in rungs
+        }
+        scope_rungs = [
+            {
+                "rung_index": int(item["rung_index"]),
+                "approval_revision": rung_revisions[int(item["rung_index"])],
+                "quantity": _decimal_text(item["requested_quantity"]),
+                "limit_price": _decimal_text(item["limit_price"]),
+            }
+            for item in preview_rungs
+        ]
+        scope_payload = {
+            "schema_version": 1,
+            "proposal_id": str(group.proposal_id),
+            "proposal_revision": group.revision,
+            "proposal_payload_hash": group.payload_hash,
+            "account_ref": account_ref,
+            "account_mode": group.account_mode,
+            "market": group.market,
+            "symbol": group.symbol,
+            "side": group.side,
+            "order_type": group.order_type,
+            "requested_quantity": _decimal_text(requested_quantity),
+            "observed_total_quantity": _decimal_text(total_quantity),
+            "observed_sellable_quantity": _decimal_text(sellable_quantity),
+            "average_price": _decimal_text(average_price),
+            "rungs": scope_rungs,
+        }
+        scope_hash = _digest(scope_payload)
+        market = _market_key(group.market)
+        consensus = await self._consensus_field(market=market, symbol=group.symbol)
+        watch = await self._watch_field(
+            market=market, symbol=group.symbol, now=observed_at
+        )
+        r931 = self._r931_field()
+        loss = LossCutEvidenceField(
+            status="filled",
+            label="손실률",
+            value={"rungs": preview_rungs},
+            source=f"order_preview:{group.account_mode}",
+            as_of=observed_at.isoformat(),
+            valid_until=evidence_valid_until.isoformat(),
+        )
+        reason = LossCutEvidenceField(
+            status="filled",
+            label="사유 판정",
+            value={
+                "exit_reason": group.exit_reason,
+                "retrospective_id": group.retrospective_id,
+                "trigger_type": preview.get("retrospective_trigger_type"),
+                "retrospective_created_at": preview.get("retrospective_created_at"),
+                "lesson_excerpt": preview.get("lesson_excerpt"),
+            },
+            source="review.trade_retrospectives",
+            as_of=preview.get("retrospective_created_at"),
+        )
+        stable_preview_rungs = [
+            {key: value for key, value in item.items() if key != "quote_observed_at"}
+            for item in preview_rungs
+        ]
+        evidence_binding = {
+            "scope_hash": scope_hash,
+            # Observation time advances between clicks by definition. Bind the
+            # fresh values and warnings, while expiry is enforced separately.
+            "loss": {"rungs": stable_preview_rungs},
+            "reason": reason.value,
+            "r931": {"status": r931.status, "value": r931.value},
+            "consensus": {
+                "status": consensus.status,
+                "value": consensus.value,
+                "as_of": consensus.as_of,
+            },
+            "watch": {
+                "status": watch.status,
+                "value": watch.value,
+                "as_of": watch.as_of,
+            },
+        }
+        evidence_hash = _digest(evidence_binding)
+        proposal_age_seconds = max(
+            int((observed_at - group.created_at).total_seconds()), 0
+        )
+        fingerprint = {
+            "proposal_id": str(group.proposal_id),
+            "proposal_revision": group.revision,
+            "proposal_payload_hash": group.payload_hash,
+            "position_scope_hash": scope_hash,
+            "evidence_hash": evidence_hash,
+            "account_ref": account_ref,
+            "account_mode": group.account_mode,
+            "market": group.market,
+            "symbol": group.symbol,
+            "side": group.side,
+            "order_type": group.order_type,
+            "rungs": scope_rungs,
+            "current_prices": [item["current_price"] for item in preview_rungs],
+            "fill_distances": [item.get("fill_distance") for item in preview_rungs],
+            "quote_observed_at": observed_at.isoformat(),
+            "proposal_age_seconds": proposal_age_seconds,
+            "evidence_valid_until": evidence_valid_until.isoformat(),
+            "execution": "disabled_b1",
+        }
+        position = LossCutPositionEvidence(
+            account_ref=account_ref,
+            account_mode=group.account_mode,
+            market=group.market,
+            symbol=group.symbol,
+            total_quantity=_decimal_text(total_quantity),
+            sellable_quantity=_decimal_text(sellable_quantity),
+            pending_sell_quantity=_decimal_text(total_quantity - sellable_quantity),
+            average_price=_decimal_text(average_price),
+            current_price=str(preview_rungs[0]["current_price"]),
+            source=f"order_preview:{group.account_mode}",
+            source_status="filled",
+            observed_at=observed_at.isoformat(),
+        )
+        can_begin = bool(
+            group.approval_dispatch_state == ApprovalDispatchState.SENT_CURRENT.value
+            and group.approval_dispatch_card_kind
+            in {ApprovalCardKind.MANUAL.value, ApprovalCardKind.RECONFIRM.value}
+            and group.approval_nonce
+            and group.approval_nonce_used_at is None
+            and observed_at < evidence_valid_until
+        )
+        response = LossCutEvidenceResponse(
+            mode="proposal",
+            symbol=group.symbol,
+            proposal_id=str(group.proposal_id),
+            generated_at=observed_at.isoformat(),
+            can_begin=can_begin,
+            positions=[position],
+            loss=loss,
+            reason=reason,
+            r931=r931,
+            consensus=consensus,
+            watch=watch,
+            fingerprint=fingerprint,
+        )
+        return _ProposalEvidenceBundle(
+            response=response,
+            group=group,
+            scope_payload=scope_payload,
+            scope_hash=scope_hash,
+            evidence_hash=evidence_hash,
+            requested_quantity=requested_quantity,
+            total_quantity=total_quantity,
+            sellable_quantity=sellable_quantity,
+            average_price=average_price,
+            account_ref=account_ref,
+            observed_at=observed_at,
+            evidence_valid_until=evidence_valid_until,
+            fingerprint=fingerprint,
+        )
+
+    async def _consensus_field(
+        self, *, market: str, symbol: str
+    ) -> LossCutEvidenceField:
+        if market not in {"kr", "us"}:
+            return LossCutEvidenceField(
+                status="unavailable",
+                label="컨센서스",
+                reason="durable consensus snapshots support kr/us equities only",
+                source="analyst_consensus_snapshots",
+            )
+        try:
+            row = await AnalystConsensusSnapshotsRepository(
+                self._session
+            ).latest_for_symbol(market=market, symbol=to_db_symbol(symbol).upper())
+        except Exception as exc:  # noqa: BLE001 - read evidence degrades explicitly
+            return LossCutEvidenceField(
+                status="source_error",
+                label="컨센서스",
+                reason=type(exc).__name__,
+                source="analyst_consensus_snapshots",
+            )
+        if row is None:
+            return LossCutEvidenceField(
+                status="missing",
+                label="컨센서스",
+                reason="no per-symbol durable snapshot",
+                source="analyst_consensus_snapshots",
+            )
+        return LossCutEvidenceField(
+            status="filled",
+            label="컨센서스",
+            value={
+                "buy_count": row.buy_count,
+                "hold_count": row.hold_count,
+                "sell_count": row.sell_count,
+                "total_count": row.total_count,
+                "target_mean": (
+                    _decimal_text(row.target_mean)
+                    if row.target_mean is not None
+                    else None
+                ),
+                "upside_pct": (
+                    _decimal_text(row.upside_pct)
+                    if row.upside_pct is not None
+                    else None
+                ),
+                "analyst_count": row.analyst_count,
+                "newest_opinion_date": (
+                    row.newest_opinion_date.isoformat()
+                    if row.newest_opinion_date is not None
+                    else None
+                ),
+            },
+            source=f"analyst_consensus_snapshots:{row.source}",
+            as_of=row.snapshot_date.isoformat(),
+        )
+
+    async def _watch_field(
+        self, *, market: str, symbol: str, now: datetime
+    ) -> LossCutEvidenceField:
+        if market not in {"kr", "us", "crypto"}:
+            return LossCutEvidenceField(
+                status="unavailable",
+                label="워치 맥락",
+                reason="unsupported market",
+                source="review.investment_watch_alerts",
+            )
+        try:
+            rows = await InvestmentReportsRepository(self._session).list_active_alerts(
+                market=market,
+                symbol=to_db_symbol(symbol).upper(),
+                valid_at=now,
+                limit=20,
+            )
+        except Exception as exc:  # noqa: BLE001 - read evidence degrades explicitly
+            return LossCutEvidenceField(
+                status="source_error",
+                label="워치 맥락",
+                reason=type(exc).__name__,
+                source="review.investment_watch_alerts",
+            )
+        if not rows:
+            return LossCutEvidenceField(
+                status="missing",
+                label="워치 맥락",
+                reason="not-registered",
+                source="review.investment_watch_alerts",
+            )
+        ordered_rows = sorted(
+            rows,
+            key=lambda row: (row.activated_at, row.id),
+            reverse=True,
+        )
+        values = [
+            {
+                "alert_uuid": str(row.alert_uuid),
+                "intent": row.intent,
+                "rationale": row.rationale,
+                "metric": row.metric,
+                "operator": row.operator,
+                "threshold": _decimal_text(row.threshold),
+                "action_mode": row.action_mode,
+                "valid_until": row.valid_until.isoformat(),
+            }
+            for row in ordered_rows
+        ]
+        return LossCutEvidenceField(
+            status="filled",
+            label="워치 맥락",
+            value={"alerts": values},
+            source="review.investment_watch_alerts",
+            as_of=max(row.updated_at for row in rows).isoformat(),
+            valid_until=max(row.valid_until for row in rows).isoformat(),
+        )
+
+    @staticmethod
+    def _r931_field() -> LossCutEvidenceField:
+        return LossCutEvidenceField(
+            status="unavailable",
+            label="R-931",
+            reason="no durable typed producer is registered",
+            source="not-recorded",
+        )
+
+
+__all__ = [
+    "LossCutApprovalRejected",
+    "LossCutApprovalService",
+]

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -21,6 +21,8 @@ from app.models.order_proposals import (
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
     OrderProposalApprovalDispatchAttempt,
+    OrderProposalApprovalEvent,
+    OrderProposalLossCutScope,
     OrderProposalRung,
 )
 from app.services.order_proposals.defensive_ttl import DEFENSIVE_EXIT_INTENTS
@@ -51,6 +53,62 @@ class OrderProposalRepository:
     ) -> OrderProposalApprovalDispatchAttempt:
         row = OrderProposalApprovalDispatchAttempt(**cols)
         self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def insert_approval_event(self, **cols: Any) -> OrderProposalApprovalEvent:
+        row = OrderProposalApprovalEvent(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_approval_event(
+        self,
+        *,
+        proposal_pk: int,
+        ceremony_digest: str,
+        step: str,
+    ) -> OrderProposalApprovalEvent | None:
+        stmt = select(OrderProposalApprovalEvent).where(
+            OrderProposalApprovalEvent.proposal_pk == proposal_pk,
+            OrderProposalApprovalEvent.ceremony_digest == ceremony_digest,
+            OrderProposalApprovalEvent.step == step,
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_approval_events(
+        self, proposal_pk: int
+    ) -> list[OrderProposalApprovalEvent]:
+        stmt = (
+            select(OrderProposalApprovalEvent)
+            .where(OrderProposalApprovalEvent.proposal_pk == proposal_pk)
+            .order_by(
+                OrderProposalApprovalEvent.observed_at, OrderProposalApprovalEvent.id
+            )
+        )
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def get_loss_cut_scope(
+        self, proposal_pk: int, *, for_update: bool = False
+    ) -> OrderProposalLossCutScope | None:
+        stmt = select(OrderProposalLossCutScope).where(
+            OrderProposalLossCutScope.proposal_pk == proposal_pk
+        )
+        if for_update:
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def upsert_loss_cut_scope(self, **cols: Any) -> OrderProposalLossCutScope:
+        proposal_pk = int(cols["proposal_pk"])
+        row = await self.get_loss_cut_scope(proposal_pk, for_update=True)
+        if row is None:
+            row = OrderProposalLossCutScope(**cols)
+            self._session.add(row)
+        else:
+            for key, value in cols.items():
+                setattr(row, key, value)
         await self._session.flush()
         await self._session.refresh(row)
         return row

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -30,7 +30,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal
 
 from app.core.timezone import now_kst
@@ -710,7 +710,7 @@ async def preview_loss_cut_confirmation(
     place_order_fn: PlaceOrderFn = _default_place_order_fn,
     retrospective_lookup_fn: RetrospectiveLookupFn = _default_retrospective_lookup,
 ) -> dict[str, Any]:
-    """Build read-only, fresh evidence for Telegram's loss-cut second step."""
+    """Build read-only, fresh evidence for either loss-cut approval channel."""
     group, rungs = await service.get_proposal(proposal_id)
     if group.exit_intent != "loss_cut" or group.retrospective_id is None:
         raise OrderProposalError("loss_cut_confirmation_requires_loss_cut")
@@ -762,12 +762,24 @@ async def preview_loss_cut_confirmation(
             current_price = Decimal(str(preview["current_price"]))
             avg_buy_price = Decimal(str(preview["avg_buy_price"]))
             slip_band = Decimal(str(preview["loss_cut_slip_band"]))
-        except (KeyError, TypeError, ValueError) as exc:
+            observed_sellable_qty = Decimal(str(preview["observed_sellable_qty"]))
+            observed_total_qty = Decimal(str(preview["observed_total_qty"]))
+        except (InvalidOperation, KeyError, TypeError, ValueError) as exc:
             raise OrderProposalError(
                 "loss_cut_confirmation_preview_missing_price_context"
             ) from exc
         if avg_buy_price <= 0:
             raise OrderProposalError("loss_cut_confirmation_invalid_average_cost")
+        requested_quantity = Decimal(str(rung.quantity))
+        if (
+            requested_quantity <= 0
+            or observed_sellable_qty < 0
+            or observed_total_qty < 0
+            or observed_sellable_qty > observed_total_qty
+        ):
+            raise OrderProposalError("loss_cut_confirmation_position_scope_invalid")
+        if requested_quantity > observed_sellable_qty:
+            raise OrderProposalError("loss_cut_confirmation_quantity_exceeds_sellable")
         loss_pct = ((current_price - avg_buy_price) / avg_buy_price * 100).quantize(
             Decimal("0.01")
         )
@@ -778,6 +790,14 @@ async def preview_loss_cut_confirmation(
                 "avg_buy_price": _norm(avg_buy_price),
                 "loss_pct": format(loss_pct, "f"),
                 "loss_cut_slip_band": _norm(slip_band),
+                "requested_quantity": _norm(requested_quantity),
+                "limit_price": _norm(rung.limit_price),
+                "observed_sellable_qty": _norm(observed_sellable_qty),
+                "observed_total_qty": _norm(observed_total_qty),
+                "observed_locked_qty": _norm(preview.get("observed_locked_qty")),
+                "fill_distance": preview.get("fill_distance"),
+                "warnings": list(preview.get("warnings") or []),
+                "quote_observed_at": now.isoformat(),
             }
         )
     if not evidence_rungs:
@@ -789,6 +809,17 @@ async def preview_loss_cut_confirmation(
         "rungs": evidence_rungs,
         "retrospective_id": group.retrospective_id,
         "lesson_excerpt": lesson,
+        "retrospective_trigger_type": getattr(retrospective, "trigger_type", None),
+        "retrospective_created_at": (
+            value.isoformat()
+            if isinstance(
+                (value := getattr(retrospective, "created_at", None)), datetime
+            )
+            else None
+        ),
+        "exit_reason": group.exit_reason,
+        "proposal_created_at": group.created_at.isoformat(),
+        "observed_at": now.isoformat(),
     }
 
 

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -26,6 +26,8 @@ from app.models.order_proposals import (
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
     OrderProposalApprovalDispatchAttempt,
+    OrderProposalApprovalEvent,
+    OrderProposalLossCutScope,
     OrderProposalRung,
 )
 from app.models.review import TossLiveOrderLedger
@@ -1775,6 +1777,8 @@ class OrderProposalsService:
         callback: CallbackEnvelope,
         now: datetime,
         telegram_user_id: str | None = None,
+        actor_channel: str | None = None,
+        actor_subject: str | None = None,
     ) -> OrderProposal:
         """The single nonce-consumption gate for every proposal card kind."""
         self._require_timezone_aware(now)
@@ -1789,10 +1793,13 @@ class OrderProposalsService:
 
         fields: dict[str, Any] = {"approval_nonce_used_at": now}
         if callback.action == "lc":
+            resolved_channel = actor_channel or "telegram"
+            resolved_subject = actor_subject or telegram_user_id or ""
             fields["source_asof"] = await self._validated_loss_cut_confirmation_source(
                 group,
                 nonce=callback.nonce,
-                telegram_user_id=telegram_user_id or "",
+                actor_channel=resolved_channel,
+                actor_subject=resolved_subject,
                 now=now,
             )
         return await self._repo.update_group(group, **fields)
@@ -1803,7 +1810,9 @@ class OrderProposalsService:
         *,
         first_nonce: str,
         confirmation_nonce: str,
-        telegram_user_id: str,
+        telegram_user_id: str | None = None,
+        actor_channel: str = "telegram",
+        actor_subject: str | None = None,
         now: datetime,
         ttl_seconds: int = 90,
     ) -> OrderProposal:
@@ -1816,6 +1825,9 @@ class OrderProposalsService:
             raise OrderProposalError("loss_cut_confirmation_requires_loss_cut")
         if group.approval_nonce != first_nonce or group.approval_nonce_used_at is None:
             raise OrderProposalError("loss_cut_first_nonce_not_consumed")
+        resolved_subject = actor_subject or telegram_user_id or ""
+        if actor_channel not in {"telegram", "web"} or not resolved_subject:
+            raise OrderProposalError("loss_cut_confirmation_actor_invalid")
         rungs = await self._repo.list_rungs(group.id)
         binding = [
             {
@@ -1834,7 +1846,11 @@ class OrderProposalsService:
             "issued_at": now.isoformat(),
             "expires_at": (now + timedelta(seconds=ttl_seconds)).isoformat(),
             "first_click": {
-                "telegram_user_id": telegram_user_id,
+                "actor_channel": actor_channel,
+                "actor_subject": resolved_subject,
+                "telegram_user_id": (
+                    resolved_subject if actor_channel == "telegram" else None
+                ),
                 "clicked_at": now.isoformat(),
                 "nonce": first_nonce,
             },
@@ -1856,7 +1872,9 @@ class OrderProposalsService:
         proposal_id: uuid.UUID,
         nonce: str,
         *,
-        telegram_user_id: str,
+        telegram_user_id: str | None = None,
+        actor_channel: str = "telegram",
+        actor_subject: str | None = None,
         now: datetime,
     ) -> OrderProposal:
         """Compatibility wrapper for the common published-callback gate."""
@@ -1871,6 +1889,8 @@ class OrderProposalsService:
             proposal_id,
             callback=callback,
             telegram_user_id=telegram_user_id,
+            actor_channel=actor_channel,
+            actor_subject=actor_subject,
             now=now,
         )
 
@@ -1879,7 +1899,8 @@ class OrderProposalsService:
         group: OrderProposal,
         *,
         nonce: str,
-        telegram_user_id: str,
+        actor_channel: str,
+        actor_subject: str,
         now: datetime,
     ) -> dict[str, Any]:
         envelope = (group.source_asof or {}).get(_LOSS_CUT_CONFIRMATION_KEY)
@@ -1892,6 +1913,17 @@ class OrderProposalsService:
         self._require_timezone_aware(expires_at)
         if now >= expires_at:
             raise OrderProposalError("loss_cut_confirmation_expired")
+        first_click = envelope.get("first_click")
+        if not isinstance(first_click, dict):
+            raise OrderProposalError("loss_cut_confirmation_invalid")
+        first_channel = str(first_click.get("actor_channel") or "telegram")
+        first_subject = str(
+            first_click.get("actor_subject")
+            or first_click.get("telegram_user_id")
+            or ""
+        )
+        if first_channel != actor_channel or first_subject != actor_subject:
+            raise OrderProposalError("loss_cut_confirmation_principal_mismatch")
         rungs = await self._repo.list_rungs(group.id)
         current_binding = [
             {
@@ -1910,7 +1942,11 @@ class OrderProposalsService:
         updated_envelope = {
             **envelope,
             "second_click": {
-                "telegram_user_id": telegram_user_id,
+                "actor_channel": actor_channel,
+                "actor_subject": actor_subject,
+                "telegram_user_id": (
+                    actor_subject if actor_channel == "telegram" else None
+                ),
                 "clicked_at": now.isoformat(),
                 "nonce": nonce,
             },
@@ -1933,8 +1969,38 @@ class OrderProposalsService:
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
         return await self._repo.update_group(
-            group, approved_by_telegram_user_id=telegram_user_id, approved_at=now
+            group,
+            approved_by_telegram_user_id=telegram_user_id,
+            approved_by_channel="telegram",
+            approved_by_subject=telegram_user_id,
+            approved_at=now,
         )
+
+    async def record_channel_approval(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        channel: str,
+        actor_subject: str,
+        now: datetime,
+    ) -> OrderProposal:
+        """Record approval validation without transitioning or submitting rungs."""
+        self._require_timezone_aware(now)
+        if channel not in {"telegram", "web"} or not actor_subject:
+            raise OrderProposalError("approval_actor_invalid")
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        fields: dict[str, Any] = {
+            "approved_by_channel": channel,
+            "approved_by_subject": actor_subject,
+            "approved_at": now,
+        }
+        if channel == "telegram":
+            fields["approved_by_telegram_user_id"] = actor_subject
+        else:
+            fields["approved_by_telegram_user_id"] = None
+        return await self._repo.update_group(group, **fields)
 
     async def record_approval_dispatch(
         self,
@@ -1990,13 +2056,19 @@ class OrderProposalsService:
         now: datetime,
         payload_chars: int,
         context_message_count: int,
+        channel: str = "telegram",
+        scope_hash: str | None = None,
+        evidence_hash: str | None = None,
+        publication_ref_digest: str | None = None,
     ) -> OrderProposalApprovalDispatchAttempt:
-        """Commit a pending attempt before any Telegram I/O begins."""
+        """Commit a pending attempt before channel publication begins."""
         self._require_timezone_aware(now)
         if payload_chars < 0:
             raise ValueError("payload_chars must be non-negative")
         if context_message_count < 0:
             raise ValueError("context_message_count must be non-negative")
+        if channel not in {"telegram", "web"}:
+            raise ValueError("approval dispatch channel must be telegram or web")
         if binding.attempt_id != attempt_id:
             raise ValueError("dispatch binding attempt_id mismatch")
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
@@ -2042,6 +2114,10 @@ class OrderProposalsService:
             payload_chars=payload_chars,
             context_message_count=context_message_count,
             card_kind=binding.card_kind.value,
+            channel=channel,
+            scope_hash=scope_hash,
+            evidence_hash=evidence_hash,
+            publication_ref_digest=publication_ref_digest,
             membership_revision=binding.membership_revision,
             membership_digest=binding.membership_digest,
         )
@@ -2054,6 +2130,9 @@ class OrderProposalsService:
             approval_dispatch_failure_code=None,
             approval_dispatch_payload_chars=payload_chars,
             approval_dispatch_card_kind=binding.card_kind.value,
+            approval_dispatch_channel=channel,
+            approval_dispatch_scope_hash=scope_hash,
+            approval_dispatch_evidence_hash=evidence_hash,
             approval_dispatch_membership_revision=binding.membership_revision,
             approval_dispatch_membership_digest=binding.membership_digest,
         )
@@ -2079,6 +2158,8 @@ class OrderProposalsService:
         )
         if attempt is None or attempt.proposal_pk != group.id:
             raise OrderProposalError("approval_dispatch_attempt_not_found")
+        if attempt.channel != "telegram":
+            raise OrderProposalError("approval_dispatch_channel_mismatch")
         if attempt.state != ApprovalDispatchState.PENDING.value:
             raise OrderProposalError("approval_dispatch_attempt_already_finished")
         if publication.card_published and (
@@ -2106,6 +2187,13 @@ class OrderProposalsService:
             group.approval_dispatch_state == ApprovalDispatchState.PENDING.value
             and group.approval_dispatch_attempt_id == attempt_id
             and group.approval_dispatch_card_kind == attempt.card_kind
+            and (
+                group.approval_dispatch_channel == attempt.channel
+                or (
+                    group.approval_dispatch_channel is None
+                    and attempt.channel == "telegram"
+                )
+            )
             and group.approval_dispatch_membership_revision
             == attempt.membership_revision
             and group.approval_dispatch_membership_digest == attempt.membership_digest
@@ -2182,6 +2270,106 @@ class OrderProposalsService:
         await self._repo.update_group(group, **fields)
         _log_dispatch_outcome(result, surface="proposal")
         return result
+
+    async def finish_web_approval_dispatch(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        attempt_id: uuid.UUID,
+        now: datetime,
+    ) -> OrderProposalApprovalDispatchAttempt:
+        """Publish a server-local web binding inside the caller transaction."""
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        attempt = await self._repo.get_approval_dispatch_attempt(
+            attempt_id, for_update=True
+        )
+        if attempt is None or attempt.proposal_pk != group.id:
+            raise OrderProposalError("approval_dispatch_attempt_not_found")
+        if attempt.channel != "web":
+            raise OrderProposalError("approval_dispatch_channel_mismatch")
+        if attempt.state != ApprovalDispatchState.PENDING.value:
+            raise OrderProposalError("approval_dispatch_attempt_already_finished")
+        try:
+            card_kind = ApprovalCardKind(str(attempt.card_kind))
+        except ValueError as exc:
+            raise OrderProposalError("approval_dispatch_card_kind_invalid") from exc
+        expected_digest = build_membership_digest(
+            card_kind=card_kind,
+            membership_revision=attempt.membership_revision,
+            members=[
+                {
+                    "proposal_id": str(group.proposal_id),
+                    "approval_nonce": group.approval_nonce,
+                }
+            ],
+        )
+        is_current_owner = all(
+            (
+                group.approval_dispatch_state == ApprovalDispatchState.PENDING.value,
+                group.approval_dispatch_attempt_id == attempt_id,
+                group.approval_dispatch_card_kind == attempt.card_kind,
+                group.approval_dispatch_channel == "web",
+                group.approval_dispatch_membership_revision
+                == attempt.membership_revision,
+                group.approval_dispatch_membership_digest == attempt.membership_digest,
+                expected_digest == attempt.membership_digest,
+                bool(group.approval_nonce),
+            )
+        )
+        if not is_current_owner:
+            raise OrderProposalError("approval_dispatch_sent_superseded")
+        await self._repo.update_approval_dispatch_attempt(
+            attempt,
+            state=ApprovalDispatchState.SENT_CURRENT.value,
+            completed_at=now,
+        )
+        await self._repo.update_group(
+            group,
+            approval_dispatch_state=ApprovalDispatchState.SENT_CURRENT.value,
+            approval_dispatch_failure_code=None,
+            approval_dispatch_published_at=now,
+        )
+        return attempt
+
+    async def current_callback_envelope(
+        self, proposal_id: uuid.UUID, *, action: str
+    ) -> CallbackEnvelope:
+        """Build callback material from the current server-side binding only."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        nonce = str(group.approval_nonce or "")
+        if not nonce:
+            raise OrderProposalError("approval_nonce_missing")
+        return self._current_callback_envelope(group, action=action, nonce=nonce)
+
+    async def append_approval_event(self, **cols: Any) -> OrderProposalApprovalEvent:
+        return await self._repo.insert_approval_event(**cols)
+
+    async def get_approval_event(
+        self, *, proposal_pk: int, ceremony_digest: str, step: str
+    ) -> OrderProposalApprovalEvent | None:
+        return await self._repo.get_approval_event(
+            proposal_pk=proposal_pk,
+            ceremony_digest=ceremony_digest,
+            step=step,
+        )
+
+    async def list_approval_events(
+        self, proposal_pk: int
+    ) -> list[OrderProposalApprovalEvent]:
+        return await self._repo.list_approval_events(proposal_pk)
+
+    async def upsert_loss_cut_scope(self, **cols: Any) -> OrderProposalLossCutScope:
+        return await self._repo.upsert_loss_cut_scope(**cols)
+
+    async def get_loss_cut_scope(
+        self, proposal_pk: int
+    ) -> OrderProposalLossCutScope | None:
+        return await self._repo.get_loss_cut_scope(proposal_pk)
 
     async def register_approval_batch_member(
         self,

--- a/env.example
+++ b/env.example
@@ -491,6 +491,11 @@ TOSS_APPROVAL_HASH_MODE=optional
 # ROB-653 P6-B — kis_live/crypto preview→place approval-hash 강제 수준 (off|optional|warn|required)
 ORDER_APPROVAL_HASH_MODE=optional
 
+# /invest loss-cut surfaces (B0 evidence / B1 two-step validation).
+# Keep both off until the additive approval schema migration is deployed.
+INVEST_LOSS_CUT_EVIDENCE_ENABLED=false
+INVEST_LOSS_CUT_APPROVAL_ENABLED=false
+
 # ROB-762 — dedicated token for the TradingCodex execution MCP profile.
 # Store the raw value only in operator-managed runtime secrets. TradingCodex
 # should reference the same value as env:AUTO_TRADER_TRADINGCODEX_EXECUTION_TOKEN.
@@ -502,4 +507,3 @@ MCP_TRADINGCODEX_EXECUTION_PORT=8770
 # ========================================
 # watch 트리거 알림 전송 수단 ("hermes_webhook" | "python_direct")
 WATCH_NOTIFY_TRANSPORT=hermes_webhook
-

--- a/env.prod.example
+++ b/env.prod.example
@@ -83,6 +83,10 @@ API_RATE_LIMIT_RETRY_429_BASE_DELAY=0.2
 TELEGRAM_TOKEN=your_telegram_bot_token
 TELEGRAM_CHAT_IDS=[your_chat_id_1,your_chat_id_2]
 
+# /invest loss-cut surfaces. Deploy the additive B1 schema before enabling.
+INVEST_LOSS_CUT_EVIDENCE_ENABLED=false
+INVEST_LOSS_CUT_APPROVAL_ENABLED=false
+
 
 # OpenClaw (Gateway Webhook)
 OPENCLAW_ENABLED=false

--- a/frontend/invest/src/__tests__/LossCutApprovalRoute.test.tsx
+++ b/frontend/invest/src/__tests__/LossCutApprovalRoute.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as approvalApi from "../api/lossCutApproval";
+import { LossCutApprovalRoute } from "../pages/LossCutApprovalRoute";
+import type {
+  LossCutBeginResponse,
+  LossCutConfirmResponse,
+  LossCutEvidenceResponse,
+} from "../types/lossCutApproval";
+
+const PROPOSAL_ID = "11111111-2222-4333-8444-555555555555";
+
+const EVIDENCE: LossCutEvidenceResponse = {
+  mode: "proposal",
+  symbol: "AAPL",
+  proposal_id: PROPOSAL_ID,
+  generated_at: "2026-08-14T06:00:00Z",
+  can_begin: true,
+  positions: [
+    {
+      account_ref: "masked-account",
+      account_mode: "toss_live",
+      market: "equity_us",
+      symbol: "AAPL",
+      total_quantity: "4",
+      sellable_quantity: "3",
+      pending_sell_quantity: "1",
+      average_price: "200",
+      current_price: "100",
+      source: "order_preview:toss_live",
+      source_status: "filled",
+      source_reason: null,
+      observed_at: "2026-08-14T06:00:00Z",
+    },
+  ],
+  loss: {
+    status: "filled",
+    label: "손실률",
+    value: { loss_pct: "-50" },
+    reason: null,
+    source: "order_preview:toss_live",
+    as_of: "2026-08-14T06:00:00Z",
+    valid_until: "2026-08-14T06:01:30Z",
+  },
+  reason: {
+    status: "filled",
+    label: "사유 판정",
+    value: { exit_reason: "stop_loss" },
+    reason: null,
+    source: "review.trade_retrospectives",
+    as_of: "2026-08-14T05:55:00Z",
+    valid_until: null,
+  },
+  r931: {
+    status: "unavailable",
+    label: "R-931",
+    value: null,
+    reason: "no durable typed producer is registered",
+    source: "not-recorded",
+    as_of: null,
+    valid_until: null,
+  },
+  consensus: {
+    status: "missing",
+    label: "컨센서스",
+    value: null,
+    reason: "no per-symbol durable snapshot",
+    source: "analyst_consensus_snapshots",
+    as_of: null,
+    valid_until: null,
+  },
+  watch: {
+    status: "missing",
+    label: "워치 맥락",
+    value: null,
+    reason: "not-registered",
+    source: "review.investment_watch_alerts",
+    as_of: null,
+    valid_until: null,
+  },
+  fingerprint: {
+    proposal_id: PROPOSAL_ID,
+    account_ref: "masked-account",
+    requested_quantity: "1",
+    execution: "disabled_b1",
+  },
+  warnings: [],
+};
+
+const BEGIN: LossCutBeginResponse = {
+  proposal_id: PROPOSAL_ID,
+  ceremony_id: "c".repeat(48),
+  expires_at: "2026-08-14T06:01:30Z",
+  evidence: EVIDENCE,
+  fingerprint: EVIDENCE.fingerprint!,
+  next_step: "confirm",
+};
+
+const CONFIRMED: LossCutConfirmResponse = {
+  proposal_id: PROPOSAL_ID,
+  status: "validated_no_execution",
+  evidence: EVIDENCE,
+  fingerprint: EVIDENCE.fingerprint!,
+};
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={[`/approvals/loss-cut/${PROPOSAL_ID}`]}>
+      <Routes>
+        <Route path="/approvals/loss-cut/:proposalId" element={<LossCutApprovalRoute />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(approvalApi, "fetchLossCutProposalEvidence").mockResolvedValue(EVIDENCE);
+  vi.spyOn(approvalApi, "beginLossCutApproval").mockResolvedValue(BEGIN);
+  vi.spyOn(approvalApi, "confirmLossCutApproval").mockResolvedValue(CONFIRMED);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("LossCutApprovalRoute", () => {
+  it("shows all five evidence fields and the exact account scope", async () => {
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("masked-account")).toBeInTheDocument());
+    for (const label of ["손실률", "사유 판정", "R-931", "컨센서스", "워치 맥락"]) {
+      expect(screen.getByRole("heading", { name: label })).toBeInTheDocument();
+    }
+    expect(screen.getByText("4 / 3")).toBeInTheDocument();
+    expect(screen.getByText("no durable typed producer is registered")).toBeInTheDocument();
+  });
+
+  it("requires two distinct clicks and returns only B1 validation", async () => {
+    const user = userEvent.setup();
+    renderRoute();
+    const first = await screen.findByRole("button", {
+      name: "1단계 · 현재 증거와 대상을 고정",
+    });
+    expect(
+      screen.queryByRole("button", { name: "2단계 · 손절 승인 검증 확정" }),
+    ).toBeNull();
+
+    await user.click(first);
+    await waitFor(() =>
+      expect(approvalApi.beginLossCutApproval).toHaveBeenCalledWith(PROPOSAL_ID),
+    );
+    expect(approvalApi.confirmLossCutApproval).not.toHaveBeenCalled();
+
+    const second = await screen.findByRole("button", {
+      name: "2단계 · 손절 승인 검증 확정",
+    });
+    expect(
+      screen.queryByRole("button", { name: "1단계 · 현재 증거와 대상을 고정" }),
+    ).toBeNull();
+    await user.click(second);
+
+    await waitFor(() =>
+      expect(approvalApi.confirmLossCutApproval).toHaveBeenCalledWith(
+        PROPOSAL_ID,
+        BEGIN.ceremony_id,
+      ),
+    );
+    expect(
+      screen.getByText("승인 검증이 단일 사용으로 기록됐습니다. 주문 제출은 실행되지 않았습니다."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/lossCutApproval.api.test.ts
+++ b/frontend/invest/src/__tests__/lossCutApproval.api.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import {
+  beginLossCutApproval,
+  confirmLossCutApproval,
+  fetchLossCutProposalEvidence,
+} from "../api/lossCutApproval";
+
+const PROPOSAL_ID = "11111111-2222-4333-8444-555555555555";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.cookie = "csrftoken=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+});
+
+test("begin sends an empty body with session and CSRF only", async () => {
+  document.cookie = "csrftoken=csrf-fixture; path=/";
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await beginLossCutApproval(PROPOSAL_ID);
+
+  const [url, init] = fetchMock.mock.calls[0]!;
+  expect(url).toBe(`/invest/api/loss-cut-approvals/${PROPOSAL_ID}/begin`);
+  expect(init).toMatchObject({
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": "csrf-fixture",
+    },
+  });
+  expect(JSON.parse(String(init.body))).toEqual({});
+});
+
+test("confirm sends only the opaque ceremony id", async () => {
+  document.cookie = "csrftoken=csrf-fixture; path=/";
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await confirmLossCutApproval(PROPOSAL_ID, "c".repeat(48));
+
+  const [url, init] = fetchMock.mock.calls[0]!;
+  expect(url).toBe(`/invest/api/loss-cut-approvals/${PROPOSAL_ID}/confirm`);
+  expect(JSON.parse(String(init.body))).toEqual({ ceremony_id: "c".repeat(48) });
+  expect(String(init.body)).not.toContain("nonce");
+  expect(String(init.body)).not.toContain("quantity");
+});
+
+test("evidence GET is session-bound and bypasses browser cache", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await fetchLossCutProposalEvidence(PROPOSAL_ID);
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    `/invest/api/loss-cut-approvals/${PROPOSAL_ID}`,
+    { credentials: "include", signal: undefined, cache: "no-store" },
+  );
+});

--- a/frontend/invest/src/__tests__/routes.test.tsx
+++ b/frontend/invest/src/__tests__/routes.test.tsx
@@ -28,3 +28,9 @@ test("router still exposes /app and /app/paper", () => {
   expect(paths).toContain("/app/paper");
   expect(paths).toContain("/app/paper/:variant");
 });
+
+test("router exposes B0 evidence and B1 loss-cut approval routes", () => {
+  const paths = pathsOf((router as any).routes);
+  expect(paths).toContain("/approvals/loss-cut/evidence/:symbol");
+  expect(paths).toContain("/approvals/loss-cut/:proposalId");
+});

--- a/frontend/invest/src/api/lossCutApproval.ts
+++ b/frontend/invest/src/api/lossCutApproval.ts
@@ -1,0 +1,85 @@
+import type {
+  LossCutBeginResponse,
+  LossCutConfirmResponse,
+  LossCutEvidenceResponse,
+} from "../types/lossCutApproval";
+
+const BASE = "/invest/api";
+
+function readCookie(name: string): string | null {
+  const prefix = `${name}=`;
+  for (const part of document.cookie.split(";")) {
+    const value = part.trim();
+    if (value.startsWith(prefix)) return decodeURIComponent(value.slice(prefix.length));
+  }
+  return null;
+}
+
+async function responseJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(payload?.detail ?? `loss-cut approval ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function mutationHeaders(): HeadersInit {
+  const csrf = readCookie("csrftoken");
+  return {
+    "Content-Type": "application/json",
+    ...(csrf ? { "X-CSRFToken": csrf } : {}),
+  };
+}
+
+export async function fetchLossCutSymbolEvidence(
+  symbol: string,
+  signal?: AbortSignal,
+): Promise<LossCutEvidenceResponse> {
+  const response = await fetch(
+    `${BASE}/loss-cut-evidence/${encodeURIComponent(symbol)}`,
+    { credentials: "include", signal, cache: "no-store" },
+  );
+  return responseJson(response);
+}
+
+export async function fetchLossCutProposalEvidence(
+  proposalId: string,
+  signal?: AbortSignal,
+): Promise<LossCutEvidenceResponse> {
+  const response = await fetch(
+    `${BASE}/loss-cut-approvals/${encodeURIComponent(proposalId)}`,
+    { credentials: "include", signal, cache: "no-store" },
+  );
+  return responseJson(response);
+}
+
+export async function beginLossCutApproval(
+  proposalId: string,
+): Promise<LossCutBeginResponse> {
+  const response = await fetch(
+    `${BASE}/loss-cut-approvals/${encodeURIComponent(proposalId)}/begin`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: mutationHeaders(),
+      body: JSON.stringify({}),
+    },
+  );
+  return responseJson(response);
+}
+
+export async function confirmLossCutApproval(
+  proposalId: string,
+  ceremonyId: string,
+): Promise<LossCutConfirmResponse> {
+  const response = await fetch(
+    `${BASE}/loss-cut-approvals/${encodeURIComponent(proposalId)}/confirm`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: mutationHeaders(),
+      body: JSON.stringify({ ceremony_id: ceremonyId }),
+    },
+  );
+  return responseJson(response);
+}

--- a/frontend/invest/src/pages/LossCutApprovalRoute.tsx
+++ b/frontend/invest/src/pages/LossCutApprovalRoute.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useParams } from "react-router-dom";
+import {
+  beginLossCutApproval,
+  confirmLossCutApproval,
+  fetchLossCutProposalEvidence,
+  fetchLossCutSymbolEvidence,
+} from "../api/lossCutApproval";
+import type {
+  LossCutBeginResponse,
+  LossCutConfirmResponse,
+  LossCutEvidenceField,
+  LossCutEvidenceResponse,
+} from "../types/lossCutApproval";
+
+const STATUS_LABELS = {
+  filled: "채워짐",
+  stale: "오래됨",
+  missing: "없음",
+  unavailable: "기록 불가",
+  source_error: "출처 오류",
+} as const;
+
+function EvidenceCard({ field }: { field: LossCutEvidenceField }) {
+  return (
+    <article className={`loss-cut-evidence-card is-${field.status}`}>
+      <header>
+        <h2>{field.label}</h2>
+        <span>{STATUS_LABELS[field.status]}</span>
+      </header>
+      {field.value ? <pre>{JSON.stringify(field.value, null, 2)}</pre> : null}
+      {field.reason ? <p className="loss-cut-evidence-reason">{field.reason}</p> : null}
+      <dl>
+        <div>
+          <dt>출처</dt>
+          <dd>{field.source ?? "미기록"}</dd>
+        </div>
+        <div>
+          <dt>기준 시각</dt>
+          <dd>{field.as_of ?? "미기록"}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+function EvidencePanel({ evidence }: { evidence: LossCutEvidenceResponse }) {
+  const fields = [
+    evidence.loss,
+    evidence.reason,
+    evidence.r931,
+    evidence.consensus,
+    evidence.watch,
+  ];
+  return (
+    <>
+      <section className="loss-cut-position-panel" aria-label="승인 대상 scope">
+        <h2>승인 대상 계좌·수량</h2>
+        {evidence.positions.length === 0 ? (
+          <p>이 종목의 현재 account position을 확인하지 못했습니다.</p>
+        ) : (
+          evidence.positions.map((position) => (
+            <dl key={`${position.account_ref}:${position.symbol}`}>
+              <div>
+                <dt>계좌</dt>
+                <dd>{position.account_ref}</dd>
+              </div>
+              <div>
+                <dt>종목</dt>
+                <dd>{position.symbol}</dd>
+              </div>
+              <div>
+                <dt>총수량 / 매도가능</dt>
+                <dd>
+                  {position.total_quantity} / {position.sellable_quantity ?? "확인 불가"}
+                </dd>
+              </div>
+              <div>
+                <dt>평단 / 현재가</dt>
+                <dd>
+                  {position.average_price ?? "확인 불가"} /{" "}
+                  {position.current_price ?? "확인 불가"}
+                </dd>
+              </div>
+            </dl>
+          ))
+        )}
+      </section>
+      <section className="loss-cut-evidence-grid" aria-label="손절 승인 증거 5필드">
+        {fields.map((field) => (
+          <EvidenceCard key={field.label} field={field} />
+        ))}
+      </section>
+    </>
+  );
+}
+
+function PageFrame({
+  title,
+  evidence,
+  loading,
+  error,
+  children,
+}: {
+  title: string;
+  evidence: LossCutEvidenceResponse | null;
+  loading: boolean;
+  error: string | null;
+  children?: ReactNode;
+}) {
+  return (
+    <main className="loss-cut-approval-page">
+      <header className="loss-cut-approval-hero">
+        <p className="loss-cut-eyebrow">/invest · 손절 승인</p>
+        <h1>{title}</h1>
+        <p>
+          각 증거의 출처와 빈 상태를 확인하세요. 값이 없으면 빈칸을 숨기지 않습니다.
+        </p>
+      </header>
+      {loading ? <p role="status">최신 증거를 확인하는 중입니다.</p> : null}
+      {error ? <p role="alert" className="loss-cut-error">{error}</p> : null}
+      {evidence ? <EvidencePanel evidence={evidence} /> : null}
+      {children}
+    </main>
+  );
+}
+
+export function LossCutEvidenceRoute() {
+  const { symbol = "" } = useParams();
+  const [evidence, setEvidence] = useState<LossCutEvidenceResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchLossCutSymbolEvidence(symbol, controller.signal)
+      .then(setEvidence)
+      .catch((reason: unknown) => {
+        if (!controller.signal.aborted) setError(String(reason));
+      });
+    return () => controller.abort();
+  }, [symbol]);
+  return (
+    <PageFrame
+      title={`${symbol} 손절 증거`}
+      evidence={evidence}
+      loading={!evidence && !error}
+      error={error}
+    />
+  );
+}
+
+export function LossCutApprovalRoute() {
+  const { proposalId = "" } = useParams();
+  const [evidence, setEvidence] = useState<LossCutEvidenceResponse | null>(null);
+  const [begin, setBegin] = useState<LossCutBeginResponse | null>(null);
+  const [confirmed, setConfirmed] = useState<LossCutConfirmResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchLossCutProposalEvidence(proposalId, controller.signal)
+      .then(setEvidence)
+      .catch((reason: unknown) => {
+        if (!controller.signal.aborted) setError(String(reason));
+      });
+    return () => controller.abort();
+  }, [proposalId]);
+
+  const fingerprint = useMemo(
+    () => begin?.fingerprint ?? confirmed?.fingerprint ?? evidence?.fingerprint,
+    [begin, confirmed, evidence],
+  );
+
+  async function onBegin() {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await beginLossCutApproval(proposalId);
+      setBegin(result);
+      setEvidence(result.evidence);
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onConfirm() {
+    if (!begin) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await confirmLossCutApproval(proposalId, begin.ceremony_id);
+      setConfirmed(result);
+      setEvidence(result.evidence);
+      setBegin(null);
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <PageFrame
+      title={`${evidence?.symbol ?? "손절"} 승인 검증`}
+      evidence={evidence}
+      loading={!evidence && !error}
+      error={error}
+    >
+      {fingerprint ? (
+        <section className="loss-cut-fingerprint" aria-label="승인 대상 fingerprint">
+          <h2>고정된 대상 fingerprint</h2>
+          <pre>{JSON.stringify(fingerprint, null, 2)}</pre>
+        </section>
+      ) : null}
+
+      <section className="loss-cut-two-step" aria-label="2단계 확인">
+        <h2>2단계 확인</h2>
+        <p>
+          B1은 승인 검증 이벤트까지만 기록합니다. 이 화면에서 주문을 제출하지 않습니다.
+        </p>
+        {!begin && !confirmed ? (
+          <button
+            type="button"
+            disabled={busy || !evidence?.can_begin}
+            onClick={onBegin}
+          >
+            1단계 · 현재 증거와 대상을 고정
+          </button>
+        ) : null}
+        {begin ? (
+          <div className="loss-cut-confirm-box">
+            <p>
+              만료: <time>{begin.expires_at}</time>
+            </p>
+            <p>위 계좌·종목·수량·가격 fingerprint가 의도와 같은지 다시 확인하세요.</p>
+            <button type="button" disabled={busy} onClick={onConfirm}>
+              2단계 · 손절 승인 검증 확정
+            </button>
+          </div>
+        ) : null}
+        {confirmed ? (
+          <p role="status" className="loss-cut-success">
+            승인 검증이 단일 사용으로 기록됐습니다. 주문 제출은 실행되지 않았습니다.
+          </p>
+        ) : null}
+      </section>
+    </PageFrame>
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -52,6 +52,10 @@ import {
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
 import { WatchesRoute } from "./pages/WatchesRoute";
 import { OrderDetailRoute } from "./pages/OrderDetailRoute";
+import {
+  LossCutApprovalRoute,
+  LossCutEvidenceRoute,
+} from "./pages/LossCutApprovalRoute";
 
 // Static legacy /app/* redirect that preserves any ?search and #hash
 // from the source URL so market-scoped or anchor-scoped bookmarks
@@ -104,6 +108,14 @@ export const router = createBrowserRouter(
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
     { path: "/watches", element: <WatchesRoute /> },
     { path: "/orders/:broker/:market/:ledgerId", element: <OrderDetailRoute /> },
+    {
+      path: "/approvals/loss-cut/evidence/:symbol",
+      element: <LossCutEvidenceRoute />,
+    },
+    {
+      path: "/approvals/loss-cut/:proposalId",
+      element: <LossCutApprovalRoute />,
+    },
 
     // Legacy /invest/app/* URLs redirect to their canonical /invest/*
     // siblings. The retired legacy components were removed after the

--- a/frontend/invest/src/styles.css
+++ b/frontend/invest/src/styles.css
@@ -12,6 +12,123 @@ body,
   font-family: var(--font-sans);
 }
 
+/* Authenticated loss-cut evidence and two-step approval surface. */
+.loss-cut-approval-page {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 64px;
+  color: var(--text-primary, #172033);
+}
+
+.loss-cut-approval-hero,
+.loss-cut-position-panel,
+.loss-cut-fingerprint,
+.loss-cut-two-step {
+  padding: 24px;
+  border: 1px solid var(--border-subtle, #dce2eb);
+  border-radius: 18px;
+  background: var(--surface-card, #fff);
+  box-shadow: 0 8px 28px rgb(23 32 51 / 6%);
+}
+
+.loss-cut-approval-hero { margin-bottom: 20px; }
+.loss-cut-eyebrow { margin: 0 0 8px; color: #b42318; font-weight: 750; }
+.loss-cut-approval-hero h1 { margin: 0 0 10px; font-size: clamp(28px, 5vw, 44px); }
+.loss-cut-approval-hero p:last-child { margin-bottom: 0; color: #566176; }
+.loss-cut-position-panel { margin-bottom: 20px; }
+.loss-cut-position-panel dl,
+.loss-cut-evidence-card dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.loss-cut-position-panel dl div,
+.loss-cut-evidence-card dl div { min-width: 0; }
+.loss-cut-position-panel dt,
+.loss-cut-evidence-card dt { color: #6b7280; font-size: 12px; }
+.loss-cut-position-panel dd,
+.loss-cut-evidence-card dd { margin: 4px 0 0; overflow-wrap: anywhere; }
+
+.loss-cut-evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.loss-cut-evidence-card {
+  padding: 18px;
+  border: 1px solid #dce2eb;
+  border-left: 5px solid #5f6b7a;
+  border-radius: 14px;
+  background: #fff;
+}
+.loss-cut-evidence-card.is-filled { border-left-color: #067647; }
+.loss-cut-evidence-card.is-stale { border-left-color: #b54708; }
+.loss-cut-evidence-card.is-missing,
+.loss-cut-evidence-card.is-unavailable,
+.loss-cut-evidence-card.is-source_error { border-left-color: #b42318; }
+.loss-cut-evidence-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.loss-cut-evidence-card h2 { margin: 0; font-size: 18px; }
+.loss-cut-evidence-card header span {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #eef2f7;
+  font-size: 12px;
+  font-weight: 700;
+}
+.loss-cut-evidence-card pre,
+.loss-cut-fingerprint pre {
+  max-height: 320px;
+  overflow: auto;
+  padding: 12px;
+  border-radius: 10px;
+  background: #f6f8fb;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+}
+.loss-cut-evidence-reason { color: #b42318; }
+.loss-cut-fingerprint,
+.loss-cut-two-step { margin-top: 20px; }
+.loss-cut-two-step button {
+  width: 100%;
+  min-height: 48px;
+  border: 0;
+  border-radius: 12px;
+  background: #b42318;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 750;
+  cursor: pointer;
+}
+.loss-cut-two-step button:disabled { opacity: 0.45; cursor: not-allowed; }
+.loss-cut-confirm-box {
+  padding: 16px;
+  border: 1px solid #f79009;
+  border-radius: 12px;
+  background: #fffaeb;
+}
+.loss-cut-error,
+.loss-cut-success {
+  padding: 14px 16px;
+  border-radius: 10px;
+}
+.loss-cut-error { background: #fef3f2; color: #b42318; }
+.loss-cut-success { background: #ecfdf3; color: #067647; }
+
+@media (max-width: 600px) {
+  .loss-cut-approval-page { width: min(100% - 20px, 1120px); padding-top: 16px; }
+  .loss-cut-approval-hero,
+  .loss-cut-position-panel,
+  .loss-cut-fingerprint,
+  .loss-cut-two-step { padding: 18px; border-radius: 14px; }
+}
+
 .app-shell {
   max-width: 420px;
   margin: 0 auto;

--- a/frontend/invest/src/types/lossCutApproval.ts
+++ b/frontend/invest/src/types/lossCutApproval.ts
@@ -1,0 +1,64 @@
+export type EvidenceStatus =
+  | "filled"
+  | "stale"
+  | "missing"
+  | "unavailable"
+  | "source_error";
+
+export interface LossCutEvidenceField {
+  status: EvidenceStatus;
+  label: string;
+  value: Record<string, unknown> | null;
+  reason: string | null;
+  source: string | null;
+  as_of: string | null;
+  valid_until: string | null;
+}
+
+export interface LossCutPositionEvidence {
+  account_ref: string;
+  account_mode: string;
+  market: string;
+  symbol: string;
+  total_quantity: string;
+  sellable_quantity: string | null;
+  pending_sell_quantity: string | null;
+  average_price: string | null;
+  current_price: string | null;
+  source: string;
+  source_status: EvidenceStatus;
+  source_reason: string | null;
+  observed_at: string;
+}
+
+export interface LossCutEvidenceResponse {
+  mode: "symbol" | "proposal";
+  symbol: string;
+  proposal_id: string | null;
+  generated_at: string;
+  can_begin: boolean;
+  positions: LossCutPositionEvidence[];
+  loss: LossCutEvidenceField;
+  reason: LossCutEvidenceField;
+  r931: LossCutEvidenceField;
+  consensus: LossCutEvidenceField;
+  watch: LossCutEvidenceField;
+  fingerprint: Record<string, unknown> | null;
+  warnings: string[];
+}
+
+export interface LossCutBeginResponse {
+  proposal_id: string;
+  ceremony_id: string;
+  expires_at: string;
+  evidence: LossCutEvidenceResponse;
+  fingerprint: Record<string, unknown>;
+  next_step: "confirm";
+}
+
+export interface LossCutConfirmResponse {
+  proposal_id: string;
+  status: "validated_no_execution";
+  evidence: LossCutEvidenceResponse;
+  fingerprint: Record<string, unknown>;
+}

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -70,7 +70,9 @@ from sqlalchemy import text
 # v35: review.kis_mock_signal_ledger (new ORM table via create_all). No
 # mirrored ALTER — the table is created wholesale; the bump only forces a
 # persistent local test DB to re-bootstrap once.
-SCHEMA_BOOTSTRAP_VERSION = 35
+# v36: web loss-cut approval events/scopes are new ORM tables. The production
+# migration is deliberately not run by tests; create_all owns the test copy.
+SCHEMA_BOOTSTRAP_VERSION = 36
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -135,6 +137,7 @@ _APPROVAL_PROPOSAL_CARD_KINDS = (
     "auto_veto",
     "loss_cut_confirmation",
 )
+_APPROVAL_CHANNELS = ("telegram", "web")
 _APPROVAL_ATTEMPT_NOT_NULL_COLUMNS = frozenset(
     {
         "attempt_id",
@@ -144,6 +147,7 @@ _APPROVAL_ATTEMPT_NOT_NULL_COLUMNS = frozenset(
         "payload_chars",
         "context_message_count",
         "card_kind",
+        "channel",
         "membership_revision",
         "membership_digest",
         "created_at",
@@ -171,6 +175,18 @@ _APPROVAL_REQUIRED_CHECKS = {
         "order_proposal_approval_dispatch_attempts",
         "order_proposal_approval_dispatch_attempt_card_kind",
     ): ("card_kind", frozenset(_APPROVAL_PROPOSAL_CARD_KINDS), False),
+    (
+        "order_proposals",
+        "order_proposals_approval_dispatch_channel",
+    ): ("approval_dispatch_channel", frozenset(_APPROVAL_CHANNELS), True),
+    (
+        "order_proposals",
+        "order_proposals_approved_by_channel",
+    ): ("approved_by_channel", frozenset(_APPROVAL_CHANNELS), True),
+    (
+        "order_proposal_approval_dispatch_attempts",
+        "order_proposal_approval_dispatch_attempt_channel",
+    ): ("channel", frozenset(_APPROVAL_CHANNELS), False),
     (
         "order_proposal_approval_batches",
         "order_proposal_approval_batches_dispatch_state",
@@ -1065,6 +1081,16 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ADD COLUMN IF NOT EXISTS approval_dispatch_membership_digest TEXT",
     "ALTER TABLE review.order_proposals "
     "ADD COLUMN IF NOT EXISTS approval_dispatch_published_at TIMESTAMPTZ",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_channel TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_scope_hash TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approval_dispatch_evidence_hash TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approved_by_channel TEXT",
+    "ALTER TABLE review.order_proposals "
+    "ADD COLUMN IF NOT EXISTS approved_by_subject TEXT",
     "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
     "ADD COLUMN IF NOT EXISTS error_classification TEXT",
     "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
@@ -1073,6 +1099,14 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ADD COLUMN IF NOT EXISTS membership_revision INTEGER",
     "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
     "ADD COLUMN IF NOT EXISTS membership_digest TEXT",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS channel TEXT NOT NULL DEFAULT 'telegram'",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS scope_hash TEXT",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS evidence_hash TEXT",
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD COLUMN IF NOT EXISTS publication_ref_digest TEXT",
     # Intermediate R1/R2 test schemas may contain attempts without the final
     # immutable binding columns. Those rows cannot truthfully be repaired, so
     # discard only invalid rows in the disposable test ledger before applying
@@ -1099,6 +1133,7 @@ _DDL_STATEMENTS: tuple[str, ...] = (
             "payload_chars",
             "context_message_count",
             "card_kind",
+            "channel",
             "membership_revision",
             "membership_digest",
             "created_at",
@@ -1115,6 +1150,48 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "('pending','sent_current','sent_superseded','failed',"
     "'partial_failed','failed_superseded')); "
     "END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposals_approval_dispatch_channel' "
+    "AND conrelid = 'review.order_proposals'::regclass) THEN "
+    "ALTER TABLE review.order_proposals "
+    "ADD CONSTRAINT order_proposals_approval_dispatch_channel "
+    "CHECK (approval_dispatch_channel IS NULL OR "
+    "approval_dispatch_channel IN ('telegram','web')); "
+    "END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposals_approved_by_channel' "
+    "AND conrelid = 'review.order_proposals'::regclass) THEN "
+    "ALTER TABLE review.order_proposals "
+    "ADD CONSTRAINT order_proposals_approved_by_channel "
+    "CHECK (approved_by_channel IS NULL OR "
+    "approved_by_channel IN ('telegram','web')); "
+    "END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname = 'order_proposal_approval_dispatch_attempt_channel' "
+    "AND conrelid = "
+    "'review.order_proposal_approval_dispatch_attempts'::regclass) THEN "
+    "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+    "ADD CONSTRAINT order_proposal_approval_dispatch_attempt_channel "
+    "CHECK (channel IN ('telegram','web')); "
+    "END IF; END $$",
+    "CREATE OR REPLACE FUNCTION "
+    "review.reject_order_proposal_approval_event_mutation() "
+    "RETURNS trigger AS $$ BEGIN RAISE EXCEPTION "
+    "'order proposal approval events are append-only' "
+    "USING ERRCODE = 'restrict_violation'; END; $$ LANGUAGE plpgsql",
+    "DROP TRIGGER IF EXISTS trg_order_proposal_approval_events_append_only "
+    "ON review.order_proposal_approval_events",
+    "CREATE TRIGGER trg_order_proposal_approval_events_append_only "
+    "BEFORE UPDATE OR DELETE ON review.order_proposal_approval_events "
+    "FOR EACH ROW EXECUTE FUNCTION "
+    "review.reject_order_proposal_approval_event_mutation()",
+    "DROP TRIGGER IF EXISTS "
+    "trg_order_proposal_approval_events_truncate_append_only "
+    "ON review.order_proposal_approval_events",
+    "CREATE TRIGGER trg_order_proposal_approval_events_truncate_append_only "
+    "BEFORE TRUNCATE ON review.order_proposal_approval_events "
+    "FOR EACH STATEMENT EXECUTE FUNCTION "
+    "review.reject_order_proposal_approval_event_mutation()",
     "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
     "WHERE conname = 'order_proposals_approval_dispatch_card_kind' "
     "AND conrelid = 'review.order_proposals'::regclass) THEN "

--- a/tests/core/test_invest_deep_links.py
+++ b/tests/core/test_invest_deep_links.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from app.core.invest_deep_links import build_order_detail_url, build_watches_url
+from app.core.invest_deep_links import (
+    build_loss_cut_approval_url,
+    build_order_detail_url,
+    build_watches_url,
+)
 
 
 @pytest.mark.unit
@@ -27,6 +31,20 @@ def test_build_watches_url_uses_public_base_url(monkeypatch):
     monkeypatch.setattr(settings, "public_base_url", "https://example.test/")
     url = build_watches_url()
     assert url == "https://example.test/invest/watches"
+
+
+@pytest.mark.unit
+def test_build_loss_cut_approval_url_contains_only_proposal_id(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "public_base_url", "https://example.test/")
+    proposal_id = "11111111-2222-4333-8444-555555555555"
+
+    url = build_loss_cut_approval_url(proposal_id=proposal_id)
+
+    assert url == f"https://example.test/invest/approvals/loss-cut/{proposal_id}"
+    assert "nonce" not in url
+    assert "quantity" not in url
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/tooling/test_loss_cut_position_scope.py
+++ b/tests/mcp_server/tooling/test_loss_cut_position_scope.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import LossCutContext
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kis_domestic_zero_orderable_does_not_fall_back_to_total(monkeypatch):
+    client = type(
+        "Client",
+        (),
+        {
+            "fetch_my_stocks": AsyncMock(
+                return_value=[
+                    {
+                        "pdno": "005930",
+                        "hldg_qty": "8",
+                        "ord_psbl_qty": "0",
+                        "pchs_avg_pric": "70000",
+                    }
+                ]
+            )
+        },
+    )()
+    monkeypatch.setattr(
+        order_validation, "_create_kis_client", lambda *, is_mock: client
+    )
+
+    result = await order_validation._get_holdings_for_order(
+        "005930", "equity_kr", is_mock=False
+    )
+
+    assert result == {
+        "quantity": 0.0,
+        "total_quantity": 8.0,
+        "locked": 8.0,
+        "avg_price": 70000.0,
+        "sellable_observed": True,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kis_overseas_uses_common_orderable_field(monkeypatch):
+    client = type(
+        "Client",
+        (),
+        {
+            "fetch_my_us_stocks": AsyncMock(
+                return_value=[
+                    {
+                        "ovrs_pdno": "AAPL",
+                        "ovrs_cblc_qty": "10",
+                        "ord_psbl_qty": "7",
+                        "pchs_avg_pric": "180",
+                    }
+                ]
+            )
+        },
+    )()
+    monkeypatch.setattr(
+        order_validation, "_create_kis_client", lambda *, is_mock: client
+    )
+
+    result = await order_validation._get_holdings_for_order(
+        "AAPL", "equity_us", is_mock=False
+    )
+
+    assert result is not None
+    assert result["quantity"] == 7.0
+    assert result["total_quantity"] == 10.0
+    assert result["locked"] == 3.0
+    assert result["sellable_observed"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_loss_cut_preview_requires_fresh_orderable_quantity(monkeypatch):
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(
+            return_value={
+                "quantity": 8.0,
+                "total_quantity": 8.0,
+                "locked": 0.0,
+                "avg_price": 200.0,
+                "sellable_observed": False,
+            }
+        ),
+    )
+    context = LossCutContext(
+        retrospective_id=42,
+        exit_reason="stop_loss",
+        approval_issue_id=None,
+        requester_agent_id="fixture-agent",
+        max_slip=0.02,
+        approval_verified_at=datetime.now(UTC),
+    )
+
+    result = await order_validation._preview_sell(
+        symbol="005930",
+        order_type="limit",
+        quantity=1.0,
+        price=99.0,
+        current_price=100.0,
+        market_type="equity_kr",
+        loss_cut_ctx=context,
+    )
+
+    assert result["error"] == (
+        "Fresh orderable quantity is required for a loss_cut preview."
+    )

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -847,9 +847,20 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
             holding = type(
                 "Holding",
                 (),
-                {"symbol": symbol or "AAPL", "average_purchase_price": Decimal("200")},
+                {
+                    "symbol": symbol or "AAPL",
+                    "quantity": Decimal("10"),
+                    "average_purchase_price": Decimal("200"),
+                },
             )()
             return type("Holdings", (), {"items": [holding], "raw_overview": {}})()
+
+        async def sellable_quantity(self, *, symbol):
+            return type(
+                "SellableQuantity",
+                (),
+                {"sellable_quantity": Decimal("10")},
+            )()
 
         async def prices(self, symbols):
             price = type(

--- a/tests/mcp_server/tooling/test_toss_loss_cut.py
+++ b/tests/mcp_server/tooling/test_toss_loss_cut.py
@@ -18,6 +18,8 @@ class _TossClient:
         self.placed_payloads: list[dict] = []
         self.current_price = Decimal("100")
         self.average_purchase_price = Decimal("200")
+        self.quantity = Decimal("3")
+        self.sellable = Decimal("2")
 
     async def aclose(self) -> None:
         return None
@@ -31,10 +33,14 @@ class _TossClient:
                 SimpleNamespace(
                     symbol=symbol or "AAPL",
                     average_purchase_price=self.average_purchase_price,
+                    quantity=self.quantity,
                 )
             ],
             raw_overview={},
         )
+
+    async def sellable_quantity(self, *, symbol: str):
+        return SimpleNamespace(sellable_quantity=self.sellable)
 
     async def prices(self, symbols):
         return [
@@ -171,6 +177,9 @@ async def test_toss_loss_cut_preview_applies_slip_band(monkeypatch, price, succe
         assert result["retrospective_id"] == 42
         assert result["loss_cut_slip_band"] == pytest.approx(98.0)
         assert result["avg_buy_price"] == "200"
+        assert result["observed_sellable_qty"] == "2"
+        assert result["observed_total_qty"] == "3"
+        assert result["observed_locked_qty"] == "1"
     else:
         assert "slip band floor" in result["error"]
 
@@ -191,8 +200,24 @@ async def test_toss_loss_cut_preview_fails_closed_without_current_price(monkeypa
     assert "current price" in result["error"]
 
 
+@pytest.mark.asyncio
+async def test_toss_loss_cut_preview_rejects_quantity_above_fresh_sellable(
+    monkeypatch,
+):
+    _configure_toss(monkeypatch)
+    _configure_loss_cut_preconditions(monkeypatch)
+
+    result = await _preview_loss_cut(quantity="2.5")
+
+    assert result["success"] is False
+    assert "exceeds orderable balance 2" in result["error"]
+
+
 async def _preview_loss_cut(
-    *, price: str = "99", approval_issue_id: str | None = "ROB-858"
+    *,
+    price: str = "99",
+    quantity: str = "1",
+    approval_issue_id: str | None = "ROB-858",
 ) -> dict:
     with otv._bind_order_proposal_context(
         client_order_id="tosprop-loss-cut", correlation_id=None, rung=0
@@ -201,7 +226,7 @@ async def _preview_loss_cut(
             symbol="AAPL",
             side="sell",
             order_type="limit",
-            quantity="1",
+            quantity=quantity,
             price=price,
             market="us",
             account_mode="toss_live",

--- a/tests/routers/test_invest_loss_cut_approvals.py
+++ b/tests/routers/test_invest_loss_cut_approvals.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.core.db import get_db
+from app.middleware.auth import AuthMiddleware
+from app.middleware.csrf import TemplateFormCSRFMiddleware
+from app.models.trading import UserRole
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_loss_cut_approvals import (
+    get_loss_cut_approval_service,
+    router,
+)
+from app.schemas.loss_cut_approval import (
+    LossCutBeginResponse,
+    LossCutEvidenceField,
+    LossCutEvidenceResponse,
+)
+
+
+def _evidence(proposal_id: uuid.UUID) -> LossCutEvidenceResponse:
+    return LossCutEvidenceResponse(
+        mode="proposal",
+        symbol="AAPL",
+        proposal_id=str(proposal_id),
+        generated_at="2026-08-14T06:00:00+00:00",
+        can_begin=True,
+        positions=[],
+        loss=LossCutEvidenceField(status="filled", label="손실률", value={}),
+        reason=LossCutEvidenceField(status="filled", label="사유 판정", value={}),
+        r931=LossCutEvidenceField(
+            status="unavailable", label="R-931", reason="not recorded"
+        ),
+        consensus=LossCutEvidenceField(
+            status="missing", label="컨센서스", reason="no snapshot"
+        ),
+        watch=LossCutEvidenceField(
+            status="missing", label="워치 맥락", reason="not-registered"
+        ),
+        fingerprint={"proposal_id": str(proposal_id)},
+    )
+
+
+class _FakeService:
+    def __init__(self, proposal_id: uuid.UUID) -> None:
+        self.proposal_id = proposal_id
+        self.begin_calls: list[dict] = []
+
+    async def get_proposal_evidence(self, *, proposal_id: uuid.UUID):
+        assert proposal_id == self.proposal_id
+        return _evidence(proposal_id)
+
+    async def begin(self, **kwargs):
+        self.begin_calls.append(kwargs)
+        return LossCutBeginResponse(
+            proposal_id=str(self.proposal_id),
+            ceremony_id="c" * 48,
+            expires_at="2026-08-14T06:01:30+00:00",
+            evidence=_evidence(self.proposal_id),
+            fingerprint={"proposal_id": str(self.proposal_id)},
+        )
+
+
+def _build_app(*, user_dependency, service: _FakeService, include_auth=False):
+    app = FastAPI()
+
+    @app.get("/csrf-seed")
+    async def csrf_seed():
+        return {"ok": True}
+
+    app.include_router(router)
+    db = AsyncMock()
+    app.dependency_overrides[get_authenticated_user] = user_dependency
+    app.dependency_overrides[get_loss_cut_approval_service] = lambda: service
+    app.dependency_overrides[get_db] = lambda: db
+    if include_auth:
+        app.add_middleware(AuthMiddleware)
+    app.add_middleware(TemplateFormCSRFMiddleware, secret="router-test-secret")
+    return app, db
+
+
+async def _client(app: FastAPI):
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_get_requires_authenticated_session(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    proposal_id = uuid.uuid4()
+
+    async def unauthenticated():
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    app, _db = _build_app(
+        user_dependency=unauthenticated,
+        service=_FakeService(proposal_id),
+    )
+    async with await _client(app) as client:
+        response = await client.get(f"/invest/api/loss-cut-approvals/{proposal_id}")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_get_rejects_viewer_role(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    proposal_id = uuid.uuid4()
+    app, _db = _build_app(
+        user_dependency=lambda: SimpleNamespace(id=7, role=UserRole.viewer),
+        service=_FakeService(proposal_id),
+    )
+    async with await _client(app) as client:
+        response = await client.get(f"/invest/api/loss-cut-approvals/{proposal_id}")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_get_is_no_store_for_trader(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    proposal_id = uuid.uuid4()
+    app, _db = _build_app(
+        user_dependency=lambda: SimpleNamespace(id=8, role=UserRole.trader),
+        service=_FakeService(proposal_id),
+    )
+    async with await _client(app) as client:
+        response = await client.get(f"/invest/api/loss-cut-approvals/{proposal_id}")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_begin_requires_csrf_before_handler(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    proposal_id = uuid.uuid4()
+    service = _FakeService(proposal_id)
+    app, db = _build_app(
+        user_dependency=lambda: SimpleNamespace(id=9, role=UserRole.trader),
+        service=service,
+    )
+    async with await _client(app) as client:
+        response = await client.post(
+            f"/invest/api/loss-cut-approvals/{proposal_id}/begin",
+            json={},
+        )
+
+    assert response.status_code == 403
+    assert service.begin_calls == []
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_valid_csrf_cannot_bypass_session_auth_middleware(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    monkeypatch.setattr(AuthMiddleware, "_load_user", AsyncMock(return_value=None))
+    proposal_id = uuid.uuid4()
+    service = _FakeService(proposal_id)
+    app, db = _build_app(
+        user_dependency=lambda: SimpleNamespace(id=99, role=UserRole.trader),
+        service=service,
+        include_auth=True,
+    )
+    async with await _client(app) as client:
+        seed = await client.get("/csrf-seed", follow_redirects=False)
+        assert seed.status_code == 303
+        csrf = client.cookies["csrftoken"]
+        response = await client.post(
+            f"/invest/api/loss-cut-approvals/{proposal_id}/begin",
+            json={},
+            headers={"X-CSRFToken": csrf},
+        )
+
+    assert response.status_code == 401
+    assert service.begin_calls == []
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_client_cannot_inject_nonce_or_scope_into_begin(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    proposal_id = uuid.uuid4()
+    service = _FakeService(proposal_id)
+    app, db = _build_app(
+        user_dependency=lambda: SimpleNamespace(id=10, role=UserRole.trader),
+        service=service,
+    )
+    async with await _client(app) as client:
+        await client.get("/csrf-seed")
+        csrf = client.cookies["csrftoken"]
+        response = await client.post(
+            f"/invest/api/loss-cut-approvals/{proposal_id}/begin",
+            json={"approval_nonce": "forged", "quantity": "999"},
+            headers={"X-CSRFToken": csrf},
+        )
+        confirm_response = await client.post(
+            f"/invest/api/loss-cut-approvals/{proposal_id}/confirm",
+            json={"ceremony_id": "c" * 48, "approval_nonce": "forged"},
+            headers={"X-CSRFToken": csrf},
+        )
+
+    assert response.status_code == 422
+    assert confirm_response.status_code == 422
+    assert service.begin_calls == []
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_valid_csrf_begin_uses_only_authenticated_actor(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    proposal_id = uuid.uuid4()
+    service = _FakeService(proposal_id)
+    app, db = _build_app(
+        user_dependency=lambda: SimpleNamespace(id=11, role=UserRole.trader),
+        service=service,
+    )
+    async with await _client(app) as client:
+        await client.get("/csrf-seed")
+        csrf = client.cookies["csrftoken"]
+        response = await client.post(
+            f"/invest/api/loss-cut-approvals/{proposal_id}/begin",
+            json={},
+            headers={"X-CSRFToken": csrf},
+        )
+
+    assert response.status_code == 200
+    assert service.begin_calls == [
+        {
+            "proposal_id": proposal_id,
+            "actor_user_id": 11,
+            "actor_role": UserRole.trader,
+        }
+    ]
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_route_has_no_unwalled_alias(monkeypatch):
+    monkeypatch.setattr(settings, "INVEST_LOSS_CUT_APPROVAL_ENABLED", True)
+    proposal_id = uuid.uuid4()
+    app, _db = _build_app(
+        user_dependency=lambda: SimpleNamespace(id=12, role=UserRole.trader),
+        service=_FakeService(proposal_id),
+    )
+    async with await _client(app) as client:
+        responses = [
+            await client.get(f"/invest/loss-cut-approvals/{proposal_id}"),
+            await client.get(f"/api/loss-cut-approvals/{proposal_id}"),
+            await client.get(f"/loss-cut-approvals/{proposal_id}"),
+        ]
+
+    assert [response.status_code for response in responses] == [404, 404, 404]
+
+
+def test_loss_cut_flags_are_default_off():
+    fields = type(settings).model_fields
+    assert fields["INVEST_LOSS_CUT_EVIDENCE_ENABLED"].default is False
+    assert fields["INVEST_LOSS_CUT_APPROVAL_ENABLED"].default is False

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -266,18 +266,22 @@ def test_batch_result_groups_each_member_outcome():
 
 
 @pytest.mark.unit
-def test_loss_cut_approval_message_shows_reason_and_retrospective():
+def test_loss_cut_approval_message_shows_reason_retrospective_and_invest_link():
     group = _group(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
         approval_issue_id="ROB-800",
     )
-    text, _keyboard = build_approval_message(group=group, rungs=[_rung()])
+    text, keyboard = build_approval_message(group=group, rungs=[_rung()])
     assert "손절 근거" in text
     assert r"stop\_loss" in text
     assert "#42" in text
     assert "ROB-800" not in text
+    approval_url = keyboard["inline_keyboard"][1][0]["url"]
+    assert approval_url.endswith(f"/invest/approvals/loss-cut/{group.proposal_id}")
+    assert approval_url in text
+    assert group.approval_nonce not in approval_url
 
 
 @pytest.mark.unit
@@ -428,6 +432,10 @@ def test_loss_cut_confirmation_callback_and_summary():
         str(group.proposal_id)[:8],
         "secondnonce",
     )
+    approval_url = keyboard["inline_keyboard"][1][0]["url"]
+    assert approval_url.endswith(f"/invest/approvals/loss-cut/{group.proposal_id}")
+    assert approval_url in text
+    assert group.approval_nonce not in approval_url
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_dispatch_security_invariants.py
+++ b/tests/services/order_proposals/test_dispatch_security_invariants.py
@@ -1135,6 +1135,7 @@ async def test_nonce_change_during_inflight_send_supersedes_same_attempt_id() ->
         approval_dispatch_attempt_id=ATTEMPT_ID,
         approval_dispatch_state=ApprovalDispatchState.PENDING.value,
         approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_channel="telegram",
         approval_dispatch_membership_revision=1,
         approval_dispatch_membership_digest=old_digest,
         approval_dispatch_published_at=None,
@@ -1145,6 +1146,7 @@ async def test_nonce_change_during_inflight_send_supersedes_same_attempt_id() ->
     attempt = SimpleNamespace(
         attempt_id=ATTEMPT_ID,
         proposal_pk=1,
+        channel="telegram",
         state=ApprovalDispatchState.PENDING.value,
         card_kind=ApprovalCardKind.MANUAL.value,
         membership_revision=1,
@@ -1199,6 +1201,7 @@ async def test_response_loss_finalizes_failed_and_invalidates_visible_card() -> 
         approval_dispatch_attempt_id=ATTEMPT_ID,
         approval_dispatch_state=ApprovalDispatchState.PENDING.value,
         approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_channel="telegram",
         approval_dispatch_membership_revision=1,
         approval_dispatch_membership_digest=digest,
         approval_nonce="safe-nonce",
@@ -1208,6 +1211,7 @@ async def test_response_loss_finalizes_failed_and_invalidates_visible_card() -> 
     attempt = SimpleNamespace(
         attempt_id=ATTEMPT_ID,
         proposal_pk=1,
+        channel="telegram",
         state=ApprovalDispatchState.PENDING.value,
         card_kind=ApprovalCardKind.MANUAL.value,
         membership_revision=1,
@@ -1279,6 +1283,7 @@ async def test_attempt_completion_order_preserves_current_owner_invariants(
         approval_dispatch_attempt_id=new_id,
         approval_dispatch_state=ApprovalDispatchState.PENDING.value,
         approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_channel="telegram",
         approval_dispatch_membership_revision=2,
         approval_dispatch_membership_digest=new_digest,
         approval_nonce="new-nonce",
@@ -1288,6 +1293,7 @@ async def test_attempt_completion_order_preserves_current_owner_invariants(
         old_id: SimpleNamespace(
             attempt_id=old_id,
             proposal_pk=1,
+            channel="telegram",
             state=ApprovalDispatchState.PENDING.value,
             card_kind=ApprovalCardKind.MANUAL.value,
             membership_revision=1,
@@ -1296,6 +1302,7 @@ async def test_attempt_completion_order_preserves_current_owner_invariants(
         new_id: SimpleNamespace(
             attempt_id=new_id,
             proposal_pk=1,
+            channel="telegram",
             state=ApprovalDispatchState.PENDING.value,
             card_kind=ApprovalCardKind.MANUAL.value,
             membership_revision=2,
@@ -1364,6 +1371,7 @@ async def test_stale_failed_attempt_cannot_trigger_current_failure_compensation(
         approval_dispatch_attempt_id=new_id,
         approval_dispatch_state=ApprovalDispatchState.PENDING.value,
         approval_dispatch_card_kind=ApprovalCardKind.MANUAL.value,
+        approval_dispatch_channel="telegram",
         approval_dispatch_membership_revision=2,
         approval_dispatch_membership_digest=new_digest,
         approval_nonce="new-nonce",
@@ -1372,6 +1380,7 @@ async def test_stale_failed_attempt_cannot_trigger_current_failure_compensation(
     old_attempt = SimpleNamespace(
         attempt_id=old_id,
         proposal_pk=1,
+        channel="telegram",
         state=ApprovalDispatchState.PENDING.value,
         card_kind=ApprovalCardKind.MANUAL.value,
         membership_revision=1,

--- a/tests/services/order_proposals/test_loss_cut_approval.py
+++ b/tests/services/order_proposals/test_loss_cut_approval.py
@@ -1,0 +1,851 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import delete, select, update
+from sqlalchemy.exc import DBAPIError
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.caller_identity import get_caller_agent_id
+from app.models.order_proposals import (
+    OrderProposalApprovalEvent,
+)
+from app.models.trading import UserRole
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalPublication,
+    build_proposal_dispatch_binding,
+)
+from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.loss_cut_approval import (
+    LossCutApprovalRejected,
+    LossCutApprovalService,
+)
+from app.services.order_proposals.service import RungInput
+from app.telegram_contract import TelegramMethodResult
+
+
+class _Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def __call__(self) -> datetime:
+        return self.value
+
+
+def _successful_publication() -> ApprovalPublication:
+    return ApprovalPublication.published(
+        payload_chars=100,
+        method_result=TelegramMethodResult(
+            ok=True,
+            message_id=8181,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=100,
+        ),
+    )
+
+
+async def _seed_loss_cut_proposal(
+    db_session,
+    monkeypatch,
+    *,
+    now: datetime,
+    include_account_scope: bool = True,
+):
+    symbol = f"LC{uuid.uuid4().hex[:8].upper()}"
+    retro = SimpleNamespace(
+        id=8842,
+        symbol=symbol,
+        trigger_type="stop_loss",
+        created_at=now - timedelta(minutes=5),
+        lesson="손절 기준을 늦추지 않는다",
+    )
+
+    async def fake_lookup(session, retrospective_id):
+        assert retrospective_id == retro.id
+        return retro
+
+    monkeypatch.setattr(
+        "app.services.order_proposals.service.get_retrospective_by_id", fake_lookup
+    )
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol=symbol,
+        market="equity_us",
+        account_mode="toss_live",
+        broker_account_id=(
+            f"fixture-{uuid.uuid4().hex[:10]}" if include_account_scope else None
+        ),
+        side="sell",
+        order_type="limit",
+        proposer="b1-test",
+        rungs=[RungInput(0, "sell", Decimal("1"), Decimal("99"), None)],
+        exit_intent="loss_cut",
+        exit_reason="stop_loss",
+        retrospective_id=retro.id,
+        now=now,
+        valid_until=now + timedelta(minutes=15),
+    )
+    first_nonce = "initial-b1"
+    await service.set_approval_nonce(group.proposal_id, first_nonce)
+    group, _ = await service.get_proposal(group.proposal_id)
+    attempt_id = uuid.uuid4()
+    binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=first_nonce,
+        attempt_id=attempt_id,
+        card_kind=ApprovalCardKind.MANUAL,
+        current_membership_revision=group.approval_dispatch_membership_revision,
+    )
+    await service.start_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        binding=binding,
+        now=now,
+        payload_chars=100,
+        context_message_count=0,
+    )
+    result = await service.finish_approval_dispatch(
+        group.proposal_id,
+        attempt_id=attempt_id,
+        publication=_successful_publication(),
+        chat_id="fixture-chat",
+        now=now,
+    )
+    assert result.ok
+    await db_session.commit()
+    return group, retro
+
+
+def _preview(state: dict[str, str], retro: SimpleNamespace):
+    async def fake_preview(**kwargs):
+        observed_at = kwargs["now"]
+        return {
+            "rungs": [
+                {
+                    "rung_index": 0,
+                    "current_price": state["current_price"],
+                    "avg_buy_price": "200",
+                    "loss_pct": "-50.00",
+                    "loss_cut_slip_band": "98",
+                    "requested_quantity": "1",
+                    "limit_price": "99",
+                    "observed_sellable_qty": state["sellable_quantity"],
+                    "observed_total_qty": state["total_quantity"],
+                    "observed_locked_qty": state["locked_quantity"],
+                    "fill_distance": {"pct": state["fill_distance"]},
+                    "warnings": [],
+                    "quote_observed_at": observed_at.isoformat(),
+                }
+            ],
+            "retrospective_id": retro.id,
+            "lesson_excerpt": retro.lesson,
+            "retrospective_trigger_type": retro.trigger_type,
+            "retrospective_created_at": retro.created_at.isoformat(),
+            "exit_reason": "stop_loss",
+            "observed_at": observed_at.isoformat(),
+        }
+
+    return fake_preview
+
+
+def _state() -> dict[str, str]:
+    return {
+        "current_price": "100",
+        "sellable_quantity": "3",
+        "total_quantity": "4",
+        "locked_quantity": "1",
+        "fill_distance": "-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_web_two_step_revalidates_records_actor_and_never_transitions_rung(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(_state(), retro),
+        clock=clock,
+        nonce_factory=lambda: "web-confirmation-nonce",
+        ceremony_factory=lambda: "c" * 48,
+    )
+
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=701,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+    assert begin.next_step == "confirm"
+    assert begin.evidence.can_begin is True
+    browser_payload = json.dumps(begin.model_dump(mode="json"), sort_keys=True)
+    assert "initial-b1" not in browser_payload
+    assert "web-confirmation-nonce" not in browser_payload
+
+    clock.value += timedelta(seconds=1)
+    confirmed = await service.confirm(
+        proposal_id=group.proposal_id,
+        ceremony_id=begin.ceremony_id,
+        actor_user_id=701,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+
+    assert confirmed.status == "validated_no_execution"
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approved_by_channel == "web"
+    assert refreshed.approved_by_subject == "701"
+    assert refreshed.approval_nonce_used_at == clock.value
+    assert [rung.state for rung in rungs] == ["pending_approval"]
+    events = list(
+        (
+            await db_session.execute(
+                select(OrderProposalApprovalEvent)
+                .where(OrderProposalApprovalEvent.proposal_pk == group.id)
+                .order_by(OrderProposalApprovalEvent.observed_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [(event.step, event.outcome) for event in events] == [
+        ("begin", "accepted"),
+        ("confirm", "accepted"),
+    ]
+    assert all(event.nonce_digest for event in events)
+    audit_payload = json.dumps(
+        [event.evidence_snapshot for event in events], sort_keys=True
+    )
+    assert "initial-b1" not in audit_payload
+    assert "web-confirmation-nonce" not in audit_payload
+
+
+@pytest.mark.asyncio
+async def test_web_confirm_rejects_different_principal_without_consuming_nonce(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(_state(), retro),
+        clock=clock,
+        nonce_factory=lambda: "principal-confirmation-nonce",
+        ceremony_factory=lambda: "p" * 48,
+    )
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=801,
+        actor_role=UserRole.trader,
+    )
+    proposal_id = group.proposal_id
+    await db_session.commit()
+
+    with pytest.raises(
+        OrderProposalError, match="^loss_cut_confirmation_principal_mismatch$"
+    ):
+        await service.confirm(
+            proposal_id=group.proposal_id,
+            ceremony_id=begin.ceremony_id,
+            actor_user_id=802,
+            actor_role=UserRole.trader,
+        )
+    await db_session.rollback()
+
+    refreshed, _ = await OrderProposalsService(db_session).get_proposal(proposal_id)
+    assert refreshed.approval_nonce_used_at is None
+    assert refreshed.approved_by_channel is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_price_change_consumes_nonce_and_requires_new_ceremony(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    state = _state()
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(state, retro),
+        clock=clock,
+        nonce_factory=lambda: "changed-evidence-nonce",
+        ceremony_factory=lambda: "e" * 48,
+    )
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=901,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+    state["current_price"] = "101"
+    clock.value += timedelta(seconds=1)
+
+    with pytest.raises(
+        LossCutApprovalRejected,
+        match="^loss_cut_confirmation_scope_or_evidence_changed$",
+    ):
+        await service.confirm(
+            proposal_id=group.proposal_id,
+            ceremony_id=begin.ceremony_id,
+            actor_user_id=901,
+            actor_role=UserRole.trader,
+        )
+    await db_session.commit()
+
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approval_nonce_used_at == clock.value
+    assert refreshed.approved_by_channel is None
+    assert [rung.state for rung in rungs] == ["pending_approval"]
+    confirm_event = (
+        await db_session.execute(
+            select(OrderProposalApprovalEvent).where(
+                OrderProposalApprovalEvent.proposal_pk == group.id,
+                OrderProposalApprovalEvent.step == "confirm",
+            )
+        )
+    ).scalar_one()
+    assert confirm_event.outcome == "needs_reconfirm"
+
+
+@pytest.mark.asyncio
+async def test_confirm_partial_fill_scope_change_consumes_nonce_and_fails_closed(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    state = _state()
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(state, retro),
+        clock=clock,
+        nonce_factory=lambda: "partial-fill-confirmation",
+        ceremony_factory=lambda: "f" * 48,
+    )
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=925,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+    state.update(
+        {
+            "sellable_quantity": "2.5",
+            "total_quantity": "3.5",
+            "locked_quantity": "1",
+        }
+    )
+    clock.value += timedelta(seconds=1)
+
+    with pytest.raises(
+        LossCutApprovalRejected,
+        match="^loss_cut_confirmation_scope_or_evidence_changed$",
+    ):
+        await service.confirm(
+            proposal_id=group.proposal_id,
+            ceremony_id=begin.ceremony_id,
+            actor_user_id=925,
+            actor_role=UserRole.trader,
+        )
+    await db_session.commit()
+
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approval_nonce_used_at == clock.value
+    assert refreshed.approved_by_channel is None
+    assert [rung.state for rung in rungs] == ["pending_approval"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_guard_failure_consumes_nonce_and_requires_reconfirm(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    calls = 0
+    normal_preview = _preview(_state(), retro)
+
+    async def preview_then_block(**kwargs):
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise OrderProposalError("loss_cut_confirmation_quantity_exceeds_sellable")
+        return await normal_preview(**kwargs)
+
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=preview_then_block,
+        clock=clock,
+        nonce_factory=lambda: "guard-failure-confirmation",
+        ceremony_factory=lambda: "g" * 48,
+    )
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=951,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+    clock.value += timedelta(seconds=1)
+
+    with pytest.raises(
+        LossCutApprovalRejected,
+        match="^loss_cut_confirmation_revalidation_failed$",
+    ):
+        await service.confirm(
+            proposal_id=group.proposal_id,
+            ceremony_id=begin.ceremony_id,
+            actor_user_id=951,
+            actor_role=UserRole.trader,
+        )
+    await db_session.commit()
+
+    refreshed, _ = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approval_nonce_used_at == clock.value
+    assert refreshed.approved_by_channel is None
+    event = (
+        await db_session.execute(
+            select(OrderProposalApprovalEvent).where(
+                OrderProposalApprovalEvent.proposal_pk == group.id,
+                OrderProposalApprovalEvent.step == "confirm",
+            )
+        )
+    ).scalar_one()
+    assert event.outcome == "needs_reconfirm"
+    assert event.reason_code == (
+        "loss_cut_confirmation_revalidation_failed:"
+        "loss_cut_confirmation_quantity_exceeds_sellable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_expired_web_ceremony_is_audited_and_does_not_approve(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(_state(), retro),
+        clock=clock,
+        nonce_factory=lambda: "expiry-confirmation-nonce",
+        ceremony_factory=lambda: "x" * 48,
+    )
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=1001,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+    clock.value += timedelta(seconds=91)
+
+    with pytest.raises(
+        LossCutApprovalRejected, match="^loss_cut_confirmation_expired$"
+    ):
+        await service.confirm(
+            proposal_id=group.proposal_id,
+            ceremony_id=begin.ceremony_id,
+            actor_user_id=1001,
+            actor_role=UserRole.trader,
+        )
+    await db_session.commit()
+
+    refreshed, _ = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert refreshed.approved_by_channel is None
+    event = (
+        await db_session.execute(
+            select(OrderProposalApprovalEvent).where(
+                OrderProposalApprovalEvent.proposal_pk == group.id,
+                OrderProposalApprovalEvent.step == "confirm",
+            )
+        )
+    ).scalar_one()
+    assert event.outcome == "expired"
+
+
+@pytest.mark.asyncio
+async def test_cross_channel_first_nonce_has_one_database_winner(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    web_ready = asyncio.Event()
+    telegram_ready = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_preview(**kwargs):
+        web_ready.set()
+        await release.wait()
+        return await _preview(_state(), retro)(**kwargs)
+
+    async def web_click() -> str:
+        async with AsyncSessionLocal() as session:
+            service = LossCutApprovalService(
+                session,
+                preview_fn=blocked_preview,
+                clock=lambda: now + timedelta(seconds=1),
+                nonce_factory=lambda: "web-race-confirmation",
+                ceremony_factory=lambda: "w" * 48,
+            )
+            try:
+                await service.begin(
+                    proposal_id=group.proposal_id,
+                    actor_user_id=1101,
+                    actor_role=UserRole.trader,
+                )
+                await session.commit()
+                return "web"
+            except LossCutApprovalRejected:
+                await session.commit()
+                return "web-rejected"
+
+    async def telegram_click() -> str:
+        async with AsyncSessionLocal() as session:
+            service = OrderProposalsService(session)
+            callback = await service.current_callback_envelope(
+                group.proposal_id, action="op"
+            )
+            telegram_ready.set()
+            await release.wait()
+            try:
+                await service.consume_published_proposal_callback(
+                    group.proposal_id,
+                    callback=callback,
+                    now=now + timedelta(seconds=1),
+                )
+                await session.commit()
+                return "telegram"
+            except OrderProposalError:
+                await session.rollback()
+                return "telegram-rejected"
+
+    web_task = asyncio.create_task(web_click())
+    telegram_task = asyncio.create_task(telegram_click())
+    await asyncio.wait_for(web_ready.wait(), timeout=5)
+    await asyncio.wait_for(telegram_ready.wait(), timeout=5)
+    release.set()
+    outcomes = await asyncio.wait_for(
+        asyncio.gather(web_task, telegram_task), timeout=10
+    )
+
+    assert sorted(outcomes) in [
+        ["telegram", "web-rejected"],
+        ["telegram-rejected", "web"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_confirm_calls_target_lock_before_shared_nonce_consumer(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(_state(), retro),
+        clock=clock,
+        nonce_factory=lambda: "lock-order-confirmation",
+        ceremony_factory=lambda: "l" * 48,
+    )
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=1201,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+    calls: list[str] = []
+    original_lock = service._proposals.acquire_target_mutation_lock
+    original_consume = service._proposals.consume_published_proposal_callback
+
+    async def logged_lock(*args, **kwargs):
+        calls.append("target_lock")
+        return await original_lock(*args, **kwargs)
+
+    async def logged_consume(*args, **kwargs):
+        calls.append("nonce_consume")
+        return await original_consume(*args, **kwargs)
+
+    monkeypatch.setattr(service._proposals, "acquire_target_mutation_lock", logged_lock)
+    monkeypatch.setattr(
+        service._proposals, "consume_published_proposal_callback", logged_consume
+    )
+    clock.value += timedelta(seconds=1)
+    await service.confirm(
+        proposal_id=group.proposal_id,
+        ceremony_id=begin.ceremony_id,
+        actor_user_id=1201,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+
+    assert calls == ["target_lock", "nonce_consume"]
+
+
+@pytest.mark.asyncio
+async def test_total_requested_quantity_cannot_exceed_fresh_sellable_quantity(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    state = _state()
+    state["sellable_quantity"] = "0.5"
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(state, retro),
+        clock=lambda: now + timedelta(seconds=1),
+    )
+
+    with pytest.raises(
+        OrderProposalError, match="^loss_cut_confirmation_quantity_exceeds_sellable$"
+    ):
+        await service.get_proposal_evidence(proposal_id=group.proposal_id)
+
+
+@pytest.mark.asyncio
+async def test_proposal_without_exact_broker_account_scope_fails_closed(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(
+        db_session,
+        monkeypatch,
+        now=now,
+        include_account_scope=False,
+    )
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(_state(), retro),
+        clock=lambda: now + timedelta(seconds=1),
+    )
+
+    with pytest.raises(
+        OrderProposalError, match="^loss_cut_confirmation_account_scope_missing$"
+    ):
+        await service.get_proposal_evidence(proposal_id=group.proposal_id)
+
+
+@pytest.mark.asyncio
+async def test_preview_uses_server_configured_proposal_agent_identity(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_SUBMIT_AGENT_ID", "server-b1-agent")
+    normal_preview = _preview(_state(), retro)
+
+    async def identity_checked_preview(**kwargs):
+        assert get_caller_agent_id() == "server-b1-agent"
+        return await normal_preview(**kwargs)
+
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=identity_checked_preview,
+        clock=lambda: now + timedelta(seconds=1),
+    )
+
+    evidence = await service.get_proposal_evidence(proposal_id=group.proposal_id)
+
+    assert evidence.can_begin is True
+    assert get_caller_agent_id() is None
+
+
+@pytest.mark.asyncio
+async def test_confirmation_replay_is_single_use(db_session, monkeypatch):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    clock = _Clock(now + timedelta(seconds=1))
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(_state(), retro),
+        clock=clock,
+        nonce_factory=lambda: "single-use-confirmation",
+        ceremony_factory=lambda: "s" * 48,
+    )
+    begin = await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=1301,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+    clock.value += timedelta(seconds=1)
+    await service.confirm(
+        proposal_id=group.proposal_id,
+        ceremony_id=begin.ceremony_id,
+        actor_user_id=1301,
+        actor_role=UserRole.trader,
+    )
+    await db_session.commit()
+
+    with pytest.raises(OrderProposalError, match="^nonce_replay$"):
+        await service.confirm(
+            proposal_id=group.proposal_id,
+            ceremony_id=begin.ceremony_id,
+            actor_user_id=1301,
+            actor_role=UserRole.trader,
+        )
+
+
+@pytest.mark.asyncio
+async def test_approval_events_reject_update_and_delete(db_session, monkeypatch):
+    now = datetime.now(UTC)
+    group, retro = await _seed_loss_cut_proposal(db_session, monkeypatch, now=now)
+    service = LossCutApprovalService(
+        db_session,
+        preview_fn=_preview(_state(), retro),
+        clock=lambda: now + timedelta(seconds=1),
+        nonce_factory=lambda: "append-only-confirmation",
+        ceremony_factory=lambda: "a" * 48,
+    )
+    await service.begin(
+        proposal_id=group.proposal_id,
+        actor_user_id=1351,
+        actor_role=UserRole.trader,
+    )
+    group_pk = group.id
+    await db_session.commit()
+
+    async with AsyncSessionLocal() as session:
+        with pytest.raises(DBAPIError):
+            await session.execute(
+                update(OrderProposalApprovalEvent)
+                .where(OrderProposalApprovalEvent.proposal_pk == group_pk)
+                .values(outcome="rejected")
+            )
+        await session.rollback()
+        with pytest.raises(DBAPIError):
+            await session.execute(
+                delete(OrderProposalApprovalEvent).where(
+                    OrderProposalApprovalEvent.proposal_pk == group_pk
+                )
+            )
+        await session.rollback()
+
+
+def _assert_b1_has_no_execution_call(tree: ast.AST) -> None:
+    forbidden = {"revalidate_and_submit", "place_order", "submit_order"}
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    assert not (forbidden & (called | imported))
+
+
+def test_b1_execution_absence_assertion_fails_on_inverted_fixture():
+    source = Path("app/services/order_proposals/loss_cut_approval.py").read_text()
+    _assert_b1_has_no_execution_call(ast.parse(source))
+
+    with pytest.raises(AssertionError):
+        _assert_b1_has_no_execution_call(ast.parse("revalidate_and_submit()"))
+
+
+def test_single_use_assertion_fails_on_double_accept_fixture():
+    def assert_one_accept(outcomes: list[str]) -> None:
+        assert outcomes.count("accepted") == 1
+
+    assert_one_accept(["accepted", "rejected"])
+    with pytest.raises(AssertionError):
+        assert_one_accept(["accepted", "accepted"])
+
+
+@pytest.mark.asyncio
+async def test_b0_evidence_is_read_only_and_keeps_accounts_separate(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    before = len(
+        list((await db_session.execute(select(OrderProposalApprovalEvent))).scalars())
+    )
+    holdings = [
+        SimpleNamespace(
+            symbol="AAPL",
+            quantity=2.0,
+            averageCost=200.0,
+            valueNative=200.0,
+            sellableQuantity=1.0,
+            pendingSellQuantity=1.0,
+            source="kis",
+            sourceOfTruth=True,
+            accountId="kis-one",
+            market="us",
+        ),
+        SimpleNamespace(
+            symbol="AAPL",
+            quantity=3.0,
+            averageCost=150.0,
+            valueNative=300.0,
+            sellableQuantity=None,
+            pendingSellQuantity=0.0,
+            source="toss_api",
+            sourceOfTruth=False,
+            accountId="toss-two",
+            market="us",
+        ),
+    ]
+
+    class FakeHome:
+        async def get_home(self, *, user_id, include_paper):
+            assert user_id == 1401
+            assert include_paper is False
+            return SimpleNamespace(holdings=holdings)
+
+    service = LossCutApprovalService(
+        db_session,
+        home_service=FakeHome(),
+        clock=lambda: now,
+    )
+    evidence = await service.get_symbol_evidence(symbol="AAPL", user_id=1401)
+
+    assert evidence.can_begin is False
+    assert [position.account_ref for position in evidence.positions] == [
+        "kis-one",
+        "toss-two",
+    ]
+    assert [
+        evidence.loss.label,
+        evidence.reason.label,
+        evidence.r931.label,
+        evidence.consensus.label,
+        evidence.watch.label,
+    ] == ["손실률", "사유 판정", "R-931", "컨센서스", "워치 맥락"]
+    assert evidence.reason.status == "missing"
+    assert evidence.r931.status == "unavailable"
+    after = len(
+        list((await db_session.execute(select(OrderProposalApprovalEvent))).scalars())
+    )
+    assert after == before

--- a/tests/services/order_proposals/test_loss_cut_approval_migration.py
+++ b/tests/services/order_proposals/test_loss_cut_approval_migration.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from app.models.order_proposals import (
+    OrderProposal,
+    OrderProposalApprovalDispatchAttempt,
+    OrderProposalApprovalEvent,
+    OrderProposalLossCutScope,
+)
+
+_REPO = Path(__file__).resolve().parents[3]
+_MIGRATION = _REPO / "alembic/versions/20260814_loss_cut_approval_b1.py"
+
+
+@pytest.mark.unit
+def test_loss_cut_approval_schema_is_typed_and_channel_neutral():
+    proposal = OrderProposal.__table__
+    attempt = OrderProposalApprovalDispatchAttempt.__table__
+    scope = OrderProposalLossCutScope.__table__
+    event = OrderProposalApprovalEvent.__table__
+
+    assert {
+        "approval_dispatch_channel",
+        "approval_dispatch_scope_hash",
+        "approval_dispatch_evidence_hash",
+        "approved_by_channel",
+        "approved_by_subject",
+    } <= set(proposal.columns.keys())
+    assert {"channel", "scope_hash", "evidence_hash", "publication_ref_digest"} <= set(
+        attempt.columns.keys()
+    )
+    assert attempt.columns["channel"].nullable is False
+    assert scope.schema == "review"
+    assert scope.columns["proposal_pk"].nullable is False
+    assert event.schema == "review"
+    assert {
+        "event_id",
+        "ceremony_digest",
+        "actor_subject",
+        "scope_hash",
+        "evidence_hash",
+        "evidence_snapshot",
+        "observed_at",
+    } <= set(event.columns.keys())
+
+
+@pytest.mark.unit
+def test_loss_cut_approval_migration_is_single_head_and_has_no_row_dml():
+    source = _MIGRATION.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    assignments: dict[str, object] = {}
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign):
+            target = node.target
+            value = node.value
+        elif isinstance(node, ast.Assign):
+            target = node.targets[0]
+            value = node.value
+        else:
+            continue
+        if isinstance(target, ast.Name) and target.id in {"revision", "down_revision"}:
+            assignments[target.id] = ast.literal_eval(value)
+    assert assignments == {
+        "revision": "20260814_lcapprove_b1",
+        "down_revision": "20260805_toss_merge",
+    }
+    executed_literals = [
+        ast.literal_eval(node.args[0])
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "execute"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+    ]
+    assert not [
+        statement
+        for statement in executed_literals
+        if re.match(r"^\s*(insert\s+into|update\s+|delete\s+from)", statement, re.I)
+    ]
+    assert "trg_order_proposal_approval_events_append_only" in source
+    assert "trg_order_proposal_approval_events_truncate_append_only" in source
+
+    config = Config(str(_REPO / "alembic.ini"))
+    config.set_main_option("script_location", str(_REPO / "alembic"))
+    scripts = ScriptDirectory.from_config(config)
+    assert scripts.get_heads() == ["20260814_lcapprove_b1"]

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -11,6 +11,7 @@ import pytest
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals import revalidation as revalidation_module
 from app.services.order_proposals.broker_gateway import SubmitEvidence
+from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.revalidation import (
     _adapt_live_submit_response,
     preview_loss_cut_confirmation,
@@ -512,16 +513,22 @@ async def test_loss_cut_confirmation_preview_is_read_only_and_builds_evidence(
             "current_price": "100",
             "avg_buy_price": "200",
             "loss_cut_slip_band": "98",
+            "observed_sellable_qty": "3",
+            "observed_total_qty": "4",
+            "observed_locked_qty": "1",
+            "fill_distance": {"pct": "-1"},
+            "warnings": ["fixture-warning"],
         }
 
     async def fake_retro_lookup(retrospective_id):
         assert retrospective_id == 42
         return retro
 
+    now = datetime.now(UTC)
     evidence = await preview_loss_cut_confirmation(
         service=service,
         proposal_id=group.proposal_id,
-        now=datetime.now(UTC),
+        now=now,
         place_order_fn=fake_preview,
         retrospective_lookup_fn=fake_retro_lookup,
     )
@@ -535,13 +542,80 @@ async def test_loss_cut_confirmation_preview_is_read_only_and_builds_evidence(
                 "avg_buy_price": "200",
                 "loss_pct": "-50.00",
                 "loss_cut_slip_band": "98",
+                "requested_quantity": "2",
+                "limit_price": "99",
+                "observed_sellable_qty": "3",
+                "observed_total_qty": "4",
+                "observed_locked_qty": "1",
+                "fill_distance": {"pct": "-1"},
+                "warnings": ["fixture-warning"],
+                "quote_observed_at": now.isoformat(),
             }
         ],
         "retrospective_id": 42,
         "lesson_excerpt": "손절 기준을 늦추지 않는다",
+        "retrospective_trigger_type": "stop_loss",
+        "retrospective_created_at": retro.created_at.isoformat(),
+        "exit_reason": "stop_loss",
+        "proposal_created_at": group.created_at.isoformat(),
+        "observed_at": now.isoformat(),
     }
     _group, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "pending_approval"
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_confirmation_preview_rejects_quantity_above_sellable(
+    db_session, monkeypatch
+):
+    retro = SimpleNamespace(
+        id=43,
+        symbol="005930",
+        trigger_type="stop_loss",
+        created_at=datetime.now(UTC),
+        lesson="fixture",
+    )
+
+    async def fake_lookup(session, retrospective_id):
+        return retro
+
+    monkeypatch.setattr(
+        "app.services.order_proposals.service.get_retrospective_by_id", fake_lookup
+    )
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "sell", Decimal("2"), Decimal("99"), None)],
+        exit_intent="loss_cut",
+        exit_reason="stop_loss",
+        retrospective_id=43,
+    )
+
+    async def fake_preview(**kwargs):
+        return {
+            "success": True,
+            "current_price": "100",
+            "avg_buy_price": "200",
+            "loss_cut_slip_band": "98",
+            "observed_sellable_qty": "1",
+            "observed_total_qty": "2",
+        }
+
+    with pytest.raises(
+        OrderProposalError, match="^loss_cut_confirmation_quantity_exceeds_sellable$"
+    ):
+        await preview_loss_cut_confirmation(
+            service=service,
+            proposal_id=group.proposal_id,
+            now=datetime.now(UTC),
+            place_order_fn=fake_preview,
+            retrospective_lookup_fn=lambda retrospective_id: retro,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -1871,6 +1871,42 @@ async def test_loss_cut_second_nonce_replay_is_rejected(monkeypatch, db_session)
 
 
 @pytest.mark.asyncio
+async def test_loss_cut_second_click_requires_same_telegram_principal(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_loss_cut_proposal(db_session, monkeypatch)
+    notifier = _FakeNotifier()
+    issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
+    await handle_callback_update(
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="loss-cut-first")
+        ),
+        now=issued,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+    callback_data = notifier.edited[-1][3]["inline_keyboard"][0][0]["callback_data"]
+
+    result = await handle_callback_update(
+        _make_update(
+            data=callback_data,
+            callback_id="cbq-other-principal",
+            user_id=USER_ID + 1,
+        ),
+        now=issued + timedelta(seconds=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+
+    assert result["reason"] == "loss_cut_confirmation_principal_mismatch"
+
+
+@pytest.mark.asyncio
 async def test_loss_cut_second_nonce_expires_after_90_seconds(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_loss_cut_proposal(db_session, monkeypatch)

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -158,6 +158,38 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             # Same for the kis_mock pre-submit signal ledger, added after this
             # boundary and already present in Base.metadata.
             await connection.execute(text("DROP TABLE review.kis_mock_signal_ledger"))
+            # B1 loss-cut approval is later than this reconstructed boundary.
+            # Remove its current-head tables and additive columns so the head
+            # upgrade exercises the migration instead of colliding with
+            # objects materialized by Base.metadata.create_all.
+            await connection.execute(
+                text("DROP TABLE review.order_proposal_approval_events")
+            )
+            await connection.execute(
+                text("DROP TABLE review.order_proposal_loss_cut_scopes")
+            )
+            for column in (
+                "publication_ref_digest",
+                "evidence_hash",
+                "scope_hash",
+                "channel",
+            ):
+                await connection.execute(
+                    text(
+                        "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+                        f"DROP COLUMN {column}"
+                    )
+                )
+            for column in (
+                "approved_by_subject",
+                "approved_by_channel",
+                "approval_dispatch_evidence_hash",
+                "approval_dispatch_scope_hash",
+                "approval_dispatch_channel",
+            ):
+                await connection.execute(
+                    text(f"ALTER TABLE review.order_proposals DROP COLUMN {column}")
+                )
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -146,6 +146,38 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             # Same for the kis_mock pre-submit signal ledger, added after this
             # boundary and already present in Base.metadata.
             await connection.execute(text("DROP TABLE review.kis_mock_signal_ledger"))
+            # B1 loss-cut approval is later than this reconstructed boundary.
+            # Remove its current-head tables and additive columns so the head
+            # upgrade exercises the migration instead of colliding with
+            # objects materialized by Base.metadata.create_all.
+            await connection.execute(
+                text("DROP TABLE review.order_proposal_approval_events")
+            )
+            await connection.execute(
+                text("DROP TABLE review.order_proposal_loss_cut_scopes")
+            )
+            for column in (
+                "publication_ref_digest",
+                "evidence_hash",
+                "scope_hash",
+                "channel",
+            ):
+                await connection.execute(
+                    text(
+                        "ALTER TABLE review.order_proposal_approval_dispatch_attempts "
+                        f"DROP COLUMN {column}"
+                    )
+                )
+            for column in (
+                "approved_by_subject",
+                "approved_by_channel",
+                "approval_dispatch_evidence_hash",
+                "approval_dispatch_scope_hash",
+                "approval_dispatch_channel",
+            ):
+                await connection.execute(
+                    text(f"ALTER TABLE review.order_proposals DROP COLUMN {column}")
+                )
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/test_analyst_consensus_snapshot_service.py
+++ b/tests/services/test_analyst_consensus_snapshot_service.py
@@ -196,6 +196,30 @@ async def test_existing_keys_pre_flight(db_session) -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_latest_for_symbol_is_exactly_scoped_and_newest(db_session) -> None:
+    symbol = _unique_symbol()
+    other = _unique_symbol()
+    await _cleanup(db_session, [symbol, other])
+    repo = AnalystConsensusSnapshotsRepository(db_session)
+    await repo.upsert(
+        [
+            _row(symbol=symbol, snapshot_date=dt.date(2026, 7, 1), buy_count=1),
+            _row(symbol=symbol, snapshot_date=dt.date(2026, 7, 3), buy_count=3),
+            _row(symbol=other, snapshot_date=dt.date(2026, 7, 4), buy_count=99),
+        ]
+    )
+    await db_session.commit()
+
+    latest = await repo.latest_for_symbol(market="kr", symbol=symbol.lower())
+
+    assert latest is not None
+    assert latest.symbol == symbol
+    assert latest.snapshot_date == dt.date(2026, 7, 3)
+    assert latest.buy_count == 3
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_different_sources_coexist(db_session) -> None:
     symbol = _unique_symbol()
     await _cleanup(db_session, [symbol])


### PR DESCRIPTION
## Summary

- add authenticated `/invest` B0 evidence and B1 two-step loss-cut validation
- share the existing proposal nonce and dispatch binding across Telegram and web
- bind fresh account, quantity, price, retrospective, consensus, and watch evidence
- add append-only approval audit events and a typed position-scope record

## Scope boundary

- B1 ends at `validated_no_execution`
- no proposal creation, order submission, broker mutation, deployment, or feature arming
- B2 remains a separate approval

## Safety

- database-row-lock single-use race across Telegram and web
- same-principal second step, 90-second expiry, server-only ceremony material
- full fresh preview on confirm; price, quantity, partial-fill, or evidence drift fails closed
- trader/admin session wall, CSRF, no-store, and default-off feature flags
- existing loss guards and policy thresholds are unchanged

## Schema

- additive migration `20260814_lcapprove_b1` included
- migration was not applied to an operational database; only disposable migration-test databases exercised round trips

## Validation

- `make lint`: passed
- B1/auth/schema/position focused suite: 30 passed
- Telegram/service caller suite: 367 passed
- frontend: 115 files / 651 tests passed; typecheck and build passed
- full backend: 19,463 passed, 13 skipped, 7 deselected; 3 local-only research subprocess failures caused by the ignored worktree `.env` being reloaded after the test strips process env. An isolated empty-config probe returns the expected `ValidationError` and exit 17.
