### PR TITLE
policy(auto-approve): raise US daily cap to $5,000 (§71차)

### DIFF
--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,7 +2,7 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-08-14.1"
+version: "2026-08-14.2"
 captured_as_of: "2026-08-12"
 source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits)"
 
@@ -55,8 +55,14 @@ order_proposals:
       crypto: 100000
     daily_cap:
       kr: 400000
-      # §65차: paired with per_order_cap.us per the KR same-value pattern.
-      us: 800
+      # §71차 (2026-08-14): 800 -> 5000. The §65차 same-value pairing was wrong
+      # for US session scale: a 25-proposal trim day totals $4.4-4.8k per
+      # account, so the first auto-approved single share (QQQ $741) consumed
+      # 92.7% of the cap and demoted every later rung to a human card
+      # (measured 2026-08-14 22:35, all rejections daily_cap_exceeded).
+      # 5000 covers an observed full trim session (~10% of book/day/account);
+      # the $800 per-order cap and per-rung veto cards remain the guardrails.
+      us: 5000
       crypto: 300000
     # AUTO-APPROVE-EXPAND (§40차) — inputs to the profit-take classification,
     # consumed only when ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded.

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -749,9 +749,10 @@ def test_policy_caps_follow_the_declared_upper_bands_and_one_new_entry_limit():
     # buy.per_symbol_notional_usd_range=[150,450], and one concurrent new
     # entry; see the ownership-minimal derivation comment in the cap block.
     assert (kr.per_order_cap, kr.daily_cap) == (Decimal("400000"), Decimal("400000"))
-    # §65차 (2026-08-14): US caps raised 450 -> 800 so single-share exits of
-    # $500-750 ETFs can auto-approve; the sizing band above is unchanged.
-    assert (us.per_order_cap, us.daily_cap) == (Decimal("800"), Decimal("800"))
+    # §65차/§71차 (2026-08-14): per-order 800 admits single-share exits of
+    # $500-750 ETFs; daily 5000 covers a full observed trim session instead of
+    # being consumed by its first rung. The sizing band above is unchanged.
+    assert (us.per_order_cap, us.daily_cap) == (Decimal("800"), Decimal("5000"))
 
 
 def test_policy_cost_rate_cannot_be_edited_below_the_code_floor(monkeypatch):


### PR DESCRIPTION
Operator-approved §71차. daily_cap.us 800 → 5000, version 2026-08-14.2. Per-order cap $800 and per-rung veto cards unchanged. Measured basis: 2026-08-14 22:35 session — 23/25 US sell rungs demoted with reason_code daily_cap_exceeded after the first $741 single-share consumed 92.7% of the cap (first production payoff of the ROB-1244 rejection audit trail). Tests: 105 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhWL1VDTYZAZd3Nf3W3GSW