### PR TITLE
fix(b0x): bind US account-map provenance

### DIFF
--- a/scripts/b0x/kr/cycle.py
+++ b/scripts/b0x/kr/cycle.py
@@ -112,16 +112,23 @@ LANE = kr_mock.LANE
 # These provenance blocks are intentionally local to KR.  The shared
 # ``scripts.b0x.contract`` stamp is still v1.4 / the older account-map commit
 # for the untouched US and crypto lanes; letting it leak into a KR artifact
-# would make this v1.6 execution surface report the wrong governing facts.
+# would make this v1.7 execution surface report the wrong governing facts.
 # Do not update the shared stamp as part of this KR-only job.
-KR_CONTRACT_VERSION: Final[str] = "v1.6"
+KR_CONTRACT_VERSION: Final[str] = "v1.7"
 KR_CONTRACT_FILE_SHA256_REFERENCE_ONLY: Final[str] = (
-    "a3922894dcb91c2888daa2b33a9bfb9fab48a1c660ffc16deead09c530faea14"
+    "0d09e1ce4d175da75de17958880491965ea6cae8d13764853f23fbc0348f596a"
 )
 KR_CONTRACT_CLAUSES: Final[dict[str, str]] = {
     "§8 v1.6": (
         "KR 자기 미체결은 kis_mock_order_ledger 조건부 예외이며, "
         "미체결 dedup/캡 입력에만 쓴다. 포지션 진실은 계속 브로커 조회다."
+    ),
+    "§8 v1.7": (
+        "「스케줄러 등록 없음」 개정 — **스케줄러 (Prefect)는 시각만 소유한다**: "
+        "표 빌드 실행(KR 07:45·US 22:00)과 orch 기상 nudge(사이클 슬롯)에 한정. "
+        "전략 판단·주문 파생·dispatch·워커 실행은 불변(orch/워커 소유, "
+        "harvest-before-dispatch 유지). 근거 = 수동 원샷 장전 누락 4회 실측. "
+        "실행 표면·envelope·승격 절차 무변경."
     ),
 }
 KR_ACCOUNT_MAP_COMMIT: Final[str] = "e93349e7ab9b1db414b1fba619e462cf84da1fa7"

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -81,12 +81,19 @@ LANE = kiwoom_lane.LANE
 # Provenance is KR-lane-local on purpose (same reasoning as
 # ``scripts.b0x.kr.cycle``): the shared ``scripts.b0x.contract`` stamp still
 # describes the untouched US/crypto lanes.
-KR_CONTRACT_VERSION: Final[str] = "v1.6"
+KR_CONTRACT_VERSION: Final[str] = "v1.7"
 KR_CONTRACT_CLAUSES: Final[dict[str, str]] = {
     "§8 v1.6": (
         "KR 자기 미체결의 kis_mock_order_ledger 예외는 **브로커 표면 부재** 한정. "
         "kiwoom_mock 은 kt00007 미체결조회를 지원하므로 이 예외를 쓰지 않는다 "
         "(§39차 2항)."
+    ),
+    "§8 v1.7": (
+        "「스케줄러 등록 없음」 개정 — **스케줄러 (Prefect)는 시각만 소유한다**: "
+        "표 빌드 실행(KR 07:45·US 22:00)과 orch 기상 nudge(사이클 슬롯)에 한정. "
+        "전략 판단·주문 파생·dispatch·워커 실행은 불변(orch/워커 소유, "
+        "harvest-before-dispatch 유지). 근거 = 수동 원샷 장전 누락 4회 실측. "
+        "실행 표면·envelope·승격 절차 무변경."
     ),
     "§39차 ①②③④⑤": (
         "별도 모듈 · 브로커 직접 미체결 · legacy 불가침 귀속 게이트 · "

--- a/scripts/b0x/us/contract.py
+++ b/scripts/b0x/us/contract.py
@@ -1,21 +1,24 @@
-"""US-lane contract stamp: v1.6 plus the clauses this adapter implements.
+"""US-lane contract stamp: v1.7 plus the clauses this adapter implements.
 
 The shared B0-X package still carries older sidecar-oriented provenance.  The
 US adapter must not restamp that as its binding contract, so its record replaces
-the generic stamp with this lane-local v1.6 identity.  The whole-file digest is
+the generic stamp with this lane-local v1.7 identity.  The whole-file digest is
 recorded for reference only: the signed binding is version + quoted clauses.
 """
 
 from __future__ import annotations
 
+import re
+import subprocess
+from pathlib import Path
 from typing import Any, Final
 
 CONTRACT_PATH: Final[str] = "~/work/herdr-inbox/b0x-experiment-contract-v1-20260808.md"
-CONTRACT_VERSION: Final[str] = "v1.6"
+CONTRACT_VERSION: Final[str] = "v1.7"
 # Recorded for traceability only.  The binding is version + cited clauses;
 # this digest is deliberately not a substitute for checking those clauses.
 CONTRACT_FILE_SHA256_REFERENCE: Final[str] = (
-    "a3922894dcb91c2888daa2b33a9bfb9fab48a1c660ffc16deead09c530faea14"
+    "0d09e1ce4d175da75de17958880491965ea6cae8d13764853f23fbc0348f596a"
 )
 
 CONTRACT_CLAUSES: Final[dict[str, str]] = {
@@ -35,7 +38,20 @@ CONTRACT_CLAUSES: Final[dict[str, str]] = {
         "브로커의 같은 사이클 응답에서 파생한다."
     ),
     "§8 v1.6": ("kis_mock 한정 원장 미체결 예외; 일반 원칙은 브로커 진실 유지."),
+    "§8 v1.7": (
+        "「스케줄러 등록 없음」 개정 — **스케줄러 (Prefect)는 시각만 소유한다**: "
+        "표 빌드 실행(KR 07:45·US 22:00)과 orch 기상 nudge(사이클 슬롯)에 한정. "
+        "전략 판단·주문 파생·dispatch·워커 실행은 불변(orch/워커 소유, "
+        "harvest-before-dispatch 유지). 근거 = 수동 원샷 장전 누락 4회 실측. "
+        "실행 표면·envelope·승격 절차 무변경."
+    ),
 }
+
+ACCOUNT_MAP_REPO: Final[str] = "auto_trader-operator"
+ACCOUNT_MAP_COMMIT_UNAVAILABLE: Final[str] = "UNAVAILABLE"
+ACCOUNT_MAP_CANONICAL_SURFACE: Final[str] = "operator_contract.yaml"
+ACCOUNT_MAP_REFERENCE_SURFACE: Final[str] = "mock/CLAUDE.md"
+_GIT_COMMIT_RE: Final[re.Pattern[str]] = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 ACCOUNT_MAP_FACTS: Final[dict[str, str]] = {
     "canonical_surface": "operator_contract.yaml",
@@ -58,7 +74,7 @@ ACCOUNT_MAP_FACTS: Final[dict[str, str]] = {
 
 
 def contract_stamp() -> dict[str, Any]:
-    """Return the v1.6/version-plus-clauses binding recorded by US cycles."""
+    """Return the v1.7/version-plus-clauses binding recorded by US cycles."""
 
     return {
         "path": CONTRACT_PATH,
@@ -68,14 +84,160 @@ def contract_stamp() -> dict[str, Any]:
     }
 
 
-def account_map_stamp() -> dict[str, Any]:
-    """Record the machine-readable account-map facts, not a guessed narrative."""
+def _run_git(
+    command: list[str], *, cwd: Path
+) -> subprocess.CompletedProcess[str] | None:
+    """Run a bounded, read-only Git query without raising into a cycle."""
 
-    return dict(ACCOUNT_MAP_FACTS)
+    try:
+        return subprocess.run(
+            ["git", *command],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except OSError:
+        return None
+    except subprocess.SubprocessError:
+        return None
+
+
+def _with_us_account_map_facts(stamp: dict[str, Any]) -> dict[str, Any]:
+    """Add US-lane facts without replacing the worktree provenance binding."""
+
+    return {**stamp, **ACCOUNT_MAP_FACTS}
+
+
+def _unavailable_account_map_stamp(
+    *,
+    source_path: Path | None,
+    reason: str,
+    repository_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return an explicit unknown rather than inventing a historic commit."""
+
+    return _with_us_account_map_facts(
+        {
+            "repo": ACCOUNT_MAP_REPO,
+            "commit": ACCOUNT_MAP_COMMIT_UNAVAILABLE,
+            "commit_status": "unavailable",
+            "commit_reason": reason,
+            "source_path": None if source_path is None else str(source_path),
+            "repository_path": (
+                None if repository_path is None else str(repository_path)
+            ),
+            "branch": ACCOUNT_MAP_COMMIT_UNAVAILABLE,
+            "branch_reason": reason,
+            "reachable_from_origin_main": None,
+            "canonical_surface": ACCOUNT_MAP_CANONICAL_SURFACE,
+            "reference_surface": ACCOUNT_MAP_REFERENCE_SURFACE,
+        }
+    )
+
+
+def account_map_stamp(*, account_map_path: Path | None) -> dict[str, Any]:
+    """Stamp the account-map worktree that supplied this cycle's table path.
+
+    ``account_map_path`` is injected by the cycle from its actual
+    ``--table-dir`` value. The resolver never consults a separate shared
+    checkout: using one would let a later branch switch rewrite provenance for
+    a table the cycle did not consume.
+    """
+
+    if account_map_path is None:
+        return _unavailable_account_map_stamp(
+            source_path=None, reason="account_map_source_not_supplied"
+        )
+
+    source_path = Path(account_map_path).expanduser()
+    root_result = _run_git(["rev-parse", "--show-toplevel"], cwd=source_path)
+    if root_result is None:
+        return _unavailable_account_map_stamp(
+            source_path=source_path, reason="account_map_source_query_unavailable"
+        )
+    if root_result.returncode != 0:
+        return _unavailable_account_map_stamp(
+            source_path=source_path, reason="account_map_source_not_git_repository"
+        )
+
+    root_text = root_result.stdout.strip()
+    if not root_text:
+        return _unavailable_account_map_stamp(
+            source_path=source_path, reason="account_map_repository_path_invalid"
+        )
+    repository_path = Path(root_text)
+    if not (repository_path / ACCOUNT_MAP_CANONICAL_SURFACE).is_file():
+        return _unavailable_account_map_stamp(
+            source_path=source_path,
+            repository_path=repository_path,
+            reason="account_map_canonical_surface_missing",
+        )
+
+    head_result = _run_git(["rev-parse", "HEAD"], cwd=repository_path)
+    if head_result is None or head_result.returncode != 0:
+        return _unavailable_account_map_stamp(
+            source_path=source_path,
+            repository_path=repository_path,
+            reason="account_map_head_query_failed",
+        )
+    commit = head_result.stdout.strip()
+    if not _GIT_COMMIT_RE.fullmatch(commit):
+        return _unavailable_account_map_stamp(
+            source_path=source_path,
+            repository_path=repository_path,
+            reason="account_map_head_invalid",
+        )
+
+    branch_result = _run_git(["branch", "--show-current"], cwd=repository_path)
+    if branch_result is None or branch_result.returncode != 0:
+        branch = ACCOUNT_MAP_COMMIT_UNAVAILABLE
+        branch_reason: str | None = "account_map_branch_query_failed"
+    else:
+        branch = branch_result.stdout.strip() or "detached"
+        branch_reason = None
+
+    reachability_result = _run_git(
+        ["merge-base", "--is-ancestor", commit, "origin/main"],
+        cwd=repository_path,
+    )
+    if reachability_result is not None and reachability_result.returncode == 0:
+        reachable_from_origin_main: bool | None = True
+        commit_status = "available"
+        commit_reason: str | None = None
+    elif reachability_result is not None and reachability_result.returncode == 1:
+        reachable_from_origin_main = False
+        commit_status = "unpublished"
+        commit_reason = "account_map_head_not_reachable_from_origin_main"
+    else:
+        reachable_from_origin_main = None
+        commit_status = "reachability_unavailable"
+        commit_reason = "account_map_origin_main_query_failed"
+
+    return _with_us_account_map_facts(
+        {
+            "repo": ACCOUNT_MAP_REPO,
+            "commit": commit,
+            "commit_status": commit_status,
+            "commit_reason": commit_reason,
+            "source_path": str(source_path),
+            "repository_path": str(repository_path),
+            "branch": branch,
+            "branch_reason": branch_reason,
+            "reachable_from_origin_main": reachable_from_origin_main,
+            "canonical_surface": ACCOUNT_MAP_CANONICAL_SURFACE,
+            "reference_surface": ACCOUNT_MAP_REFERENCE_SURFACE,
+        }
+    )
 
 
 __all__ = [
+    "ACCOUNT_MAP_CANONICAL_SURFACE",
+    "ACCOUNT_MAP_COMMIT_UNAVAILABLE",
     "ACCOUNT_MAP_FACTS",
+    "ACCOUNT_MAP_REFERENCE_SURFACE",
+    "ACCOUNT_MAP_REPO",
     "CONTRACT_FILE_SHA256_REFERENCE",
     "CONTRACT_CLAUSES",
     "CONTRACT_PATH",

--- a/scripts/b0x/us/cycle.py
+++ b/scripts/b0x/us/cycle.py
@@ -168,9 +168,11 @@ async def run_us_cycle(
             envelope=envelope,
             labels=labels,
         )
-        # US binding is v1.6 + clauses, not the older generic sidecar stamp.
+        # US binding is v1.7 + clauses, not the older generic sidecar stamp.
         record["contract"] = contract_stamp()
-        record["account_map"] = account_map_stamp()
+        record["account_map"] = account_map_stamp(
+            account_map_path=Path(table_dir).expanduser()
+        )
         record["confirm"] = confirm
 
         def finish_zero(reason: str, detail: str) -> UsCycleOutcome:

--- a/tests/scripts/b0x/kr/test_cycle.py
+++ b/tests/scripts/b0x/kr/test_cycle.py
@@ -15,6 +15,9 @@ from typing import Any
 
 import pytest
 
+from scripts.b0x import contract as common_contract
+from scripts.b0x.kr import cycle as kr_cycle
+from scripts.b0x.kr import kiwoom_cycle
 from scripts.b0x.kr.cycle import (
     KILL_TRIPPED_CANCEL_UNSUPPORTED,
     KR_ACCOUNT_MAP_COMMIT,
@@ -50,6 +53,19 @@ pytestmark = pytest.mark.unit
 IN_SESSION_NOW = dt.datetime(2026, 8, 10, 2, 0, tzinfo=dt.UTC)
 # 2026-08-08 is a Saturday — outside any session, regardless of time of day.
 WEEKEND_NOW = dt.datetime(2026, 8, 8, 2, 0, tzinfo=dt.UTC)
+
+
+def test_kr_contracts_are_v17_and_keep_their_lane_clauses() -> None:
+    scheduler_clause = common_contract.CONTRACT_CLAUSES["§8 v1.7"]
+
+    assert kr_cycle.KR_CONTRACT_VERSION == "v1.7"
+    assert kr_cycle.KR_CONTRACT_CLAUSES["§8 v1.7"] == scheduler_clause
+    assert "§8 v1.6" in kr_cycle.KR_CONTRACT_CLAUSES
+
+    assert kiwoom_cycle.KR_CONTRACT_VERSION == "v1.7"
+    assert kiwoom_cycle.KR_CONTRACT_CLAUSES["§8 v1.7"] == scheduler_clause
+    assert "§8 v1.6" in kiwoom_cycle.KR_CONTRACT_CLAUSES
+    assert "§39차 ①②③④⑤" in kiwoom_cycle.KR_CONTRACT_CLAUSES
 
 
 @pytest.fixture

--- a/tests/scripts/b0x/us/test_cycle.py
+++ b/tests/scripts/b0x/us/test_cycle.py
@@ -170,7 +170,7 @@ async def test_lab_dry_run_plans_without_preview_submit_or_cancel(
 
     assert read_calls == ["account", "positions", "orders", "ledger"]
     assert outcome.zero_order_reason is None
-    assert outcome.record["contract"]["version"] == "v1.6"
+    assert outcome.record["contract"]["version"] == "v1.7"
     assert outcome.record["submitted"] == []
     assert outcome.record["submission_skipped"].startswith("confirm=False")
     assert submit_calls == []

--- a/tests/scripts/b0x/us/test_guards.py
+++ b/tests/scripts/b0x/us/test_guards.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import datetime as dt
+import subprocess
 from dataclasses import replace
 from decimal import Decimal
 from pathlib import Path
@@ -23,6 +24,8 @@ from scripts.b0x.state import LaneAccountState
 from scripts.b0x.table_source import PolicyTable
 from scripts.b0x.us import alpaca
 from scripts.b0x.us.contract import (
+    ACCOUNT_MAP_COMMIT_UNAVAILABLE,
+    ACCOUNT_MAP_FACTS,
     CONTRACT_FILE_SHA256_REFERENCE,
     CONTRACT_VERSION,
     account_map_stamp,
@@ -39,6 +42,40 @@ NOW = dt.datetime(2026, 8, 10, 15, 0, tzinfo=dt.UTC)
 ROOT = Path(__file__).resolve().parents[4]
 US_PACKAGE = ROOT / "scripts" / "b0x" / "us"
 RUNNER = ROOT / "scripts" / "run_b0x_us_cycle.py"
+V17_SCHEDULER_CLAUSE = (
+    "「스케줄러 등록 없음」 개정 — **스케줄러 (Prefect)는 시각만 소유한다**: "
+    "표 빌드 실행(KR 07:45·US 22:00)과 orch 기상 nudge(사이클 슬롯)에 한정. "
+    "전략 판단·주문 파생·dispatch·워커 실행은 불변(orch/워커 소유, "
+    "harvest-before-dispatch 유지). 근거 = 수동 원샷 장전 누락 4회 실측. "
+    "실행 표면·envelope·승격 절차 무변경."
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_operator_table_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repository_path = tmp_path / "operator.tbl"
+    repository_path.mkdir()
+    _git(repository_path, "init", "-q")
+    _git(repository_path, "config", "user.email", "test@example.invalid")
+    _git(repository_path, "config", "user.name", "B0-X test")
+    (repository_path / "operator_contract.yaml").write_text("contract: test\n")
+    _git(repository_path, "add", "operator_contract.yaml")
+    _git(repository_path, "commit", "-q", "-m", "operator contract")
+    _git(repository_path, "branch", "-M", "main")
+    _git(repository_path, "update-ref", "refs/remotes/origin/main", "HEAD")
+    table_dir = repository_path / "policy-tables"
+    table_dir.mkdir()
+    return repository_path, table_dir
 
 
 def _state(*, pnl: Decimal, nav: Decimal | None) -> LaneAccountState:
@@ -67,17 +104,55 @@ def test_us_envelope_matches_section_4_and_is_locked() -> None:
         assert_envelope_locked(replace(envelope, per_order_notional=Decimal("451")))
 
 
-def test_us_contract_stamp_is_v16_plus_quoted_clauses_with_reference_digest() -> None:
+def test_us_contract_stamp_is_v17_plus_quoted_clauses_with_reference_digest() -> None:
     stamp = contract_stamp()
-    assert stamp["version"] == CONTRACT_VERSION == "v1.6"
+    assert stamp["version"] == CONTRACT_VERSION == "v1.7"
     assert stamp["file_sha256_reference_only"] == CONTRACT_FILE_SHA256_REFERENCE
-    assert {"§1", "§2-2 v1.1", "§4 US", "§8 v1.5 ①", "§8 v1.6"} <= set(stamp["clauses"])
-    assert account_map_stamp()["account_lane"] == (
-        "account_lanes.alpaca_paper_lab=B0-X-US"
-    )
-    assert (
-        "reuse_after_execution" in account_map_stamp()["legacy_lab_cleanup_constraint"]
-    )
+    assert {
+        "§1",
+        "§2-2 v1.1",
+        "§4 US",
+        "§8 v1.5 ①",
+        "§8 v1.6",
+        "§8 v1.7",
+    } <= set(stamp["clauses"])
+    assert stamp["clauses"]["§8 v1.7"] == V17_SCHEDULER_CLAUSE
+
+
+def test_us_account_map_stamp_binds_the_injected_table_worktree(
+    tmp_path: Path,
+) -> None:
+    repository_path, table_dir = _make_operator_table_repo(tmp_path)
+    expected_head = _git(repository_path, "rev-parse", "HEAD")
+
+    stamp = account_map_stamp(account_map_path=table_dir)
+
+    assert stamp["repo"] == "auto_trader-operator"
+    assert stamp["commit"] == expected_head
+    assert stamp["branch"] == "main"
+    assert stamp["reachable_from_origin_main"] is True
+    assert stamp["commit_status"] == "available"
+    assert stamp["commit_reason"] is None
+    assert stamp["canonical_surface"] == "operator_contract.yaml"
+    assert stamp["source_path"] == str(table_dir)
+    for key, value in ACCOUNT_MAP_FACTS.items():
+        assert stamp[key] == value
+
+
+def test_us_account_map_stamp_fails_closed_but_keeps_us_facts(tmp_path: Path) -> None:
+    source_path = tmp_path / "not-an-operator-worktree"
+    source_path.mkdir()
+
+    stamp = account_map_stamp(account_map_path=source_path)
+
+    assert ACCOUNT_MAP_COMMIT_UNAVAILABLE == "UNAVAILABLE"
+    assert stamp["commit"] == "UNAVAILABLE"
+    assert stamp["branch"] == "UNAVAILABLE"
+    assert stamp["commit_status"] == "unavailable"
+    assert stamp["commit_reason"] == "account_map_source_not_git_repository"
+    assert stamp["reachable_from_origin_main"] is None
+    for key, value in ACCOUNT_MAP_FACTS.items():
+        assert stamp[key] == value
 
 
 def test_us_ratio_kill_uses_nav_and_missing_nav_fails_closed() -> None:


### PR DESCRIPTION
## Summary
- Bind US account-map stamps to the actual policy-table worktree commit, branch, and origin/main reachability.
- Preserve the US account-map facts and add the v1.7 scheduler clause to US and KR lane contracts.
- Add unit coverage for available and unavailable bindings, retained facts, and lane clause retention.

## Validation
- uv run pytest tests/scripts/b0x -q: 752 passed, 3 skipped
- make test: 19,475 passed, 3 failed, 13 skipped, 7 deselected
- The 3 full-suite failures are all in tests/research/test_kr_backfill_build_clients.py and do not overlap this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated KR and US contract definitions to version 1.7.
  - Added clearer scheduling ownership terms while preserving orchestration, dispatch, worker execution, and promotion responsibilities.
  - Added account-map provenance tracking, including repository, commit, branch, and availability status.

- **Bug Fixes**
  - Account-map metadata now reports explicit unavailable states when provenance cannot be verified, while retaining available US contract facts.

- **Tests**
  - Added coverage validating version 1.7 clauses, scheduler boundaries, provenance tracking, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->